### PR TITLE
 Increase :connect_timeout to Handle Longer Cold Starts on Neon

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -129,7 +129,8 @@ if config_env() == :prod do
     url: database_url,
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
     socket_options: maybe_ipv6,
-    ssl: [cacerts: :public_key.cacerts_get()]
+    ssl: [cacerts: :public_key.cacerts_get()],
+    connect_timeout: 30_000
 
   config :zoonk, ZoonkWeb.Endpoint,
     url: [host: host, port: 443, scheme: "https"],


### PR DESCRIPTION
### Description

This PR addresses the issue of database timeouts occurring due to cold starts on Neon, as observed in our demo app. Sentry logged 6 timeout errors in the past 2 months, indicating that the cold start time for the database is occasionally exceeding the default 5-second connection timeout provided by the Postgres adapter.

To mitigate this issue, I've increased the :connect_timeout in the runtime.exs file to ensure that the application can handle longer cold starts from the database.

#### Change: 
Increased the :connect_timeout setting for the Postgres adapter.

#### Changes Made
Modified runtime.exs to increase the :connect_timeout to 30 seconds (30,000 ms).

#### How to Test
This change is related to the application's configuration and is not directly testable via unit tests. However, we can validate the effectiveness of the change by:

1. Deploying the changes to a staging or production-like environment.
2. Allowing the Neon database to auto-suspend.
3. Triggering a database connection from the application to observe if the increased timeout resolves the issue.

#### Additional Context
This change should help prevent timeout errors during cold starts of the Neon database. If the issue persists, further adjustments to the :connect_timeout or additional optimizations may be necessary.

Fixes #197 