### PR TITLE
UserAuthorization: Implement organization membership checks

### DIFF
--- a/.github/copilot/project.md
+++ b/.github/copilot/project.md
@@ -10,3 +10,5 @@
 - When using the zoonk domain, always write `zoonk.com`, not `zoonk.org`. For testing, you can use `zoonk.test` instead.
 - Before suggesting any code, check if this code can be simplified even further. Continue doing this until you reach the simplest solution possible.
 - Always add tests to any functionality you add or modify.
+- Use Verified Routes instead of Router helpers. For example, instead of using `Routes.page_path(@conn, :index)`, use `~p"/"` or `~p"/#{@user}"` for dynamic routes.
+- Use the new `Gettext` syntax for importing it: `use Gettext, backend: Zoonk.Gettext` instead of `import ZoonkWeb.Gettext`.

--- a/.github/copilot/pull_request.md
+++ b/.github/copilot/pull_request.md
@@ -1,0 +1,7 @@
+# Pull Request description instructions
+
+- Keep the title short and descriptive.
+- Add a prefix to the title similar to how you would in a commit message - in general, follow commit message conventions for PR titles.
+- Analyze all code changes and write a summary of what they do and what's the reason for them.
+- If necessary, add bullet points to explain the changes in detail.
+- If the pull request is related to an issue, add a reference to it.

--- a/.github/copilot/tests.md
+++ b/.github/copilot/tests.md
@@ -5,3 +5,4 @@
 - When creating a new schema or context, create a fixtures file for it at `test/support/fixtures`.
 - Add fixtures individually to each test instead of adding them to the `setup` block.
 - Use the `PhoenixTest` library for testing.
+- `Phoenix.ConnTest.get_flash/2` is deprecated. Use `Phoenix.Flash.get/2` instead.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,5 +43,13 @@
     {
       "file": ".github/copilot/llm_docs/phoenix_test.md"
     }
+  ],
+  "github.copilot.chat.pullRequestDescriptionGeneration.instructions": [
+    {
+      "file": ".github/copilot/pull_request.md"
+    },
+    {
+      "file": ".github/copilot/commit.md"
+    }
   ]
 }

--- a/lib/zoonk_web/controllers/accounts/oauth_controller.ex
+++ b/lib/zoonk_web/controllers/accounts/oauth_controller.ex
@@ -6,7 +6,7 @@ defmodule ZoonkWeb.Accounts.OAuthController do
 
   alias Zoonk.Accounts
   alias Zoonk.Accounts.User
-  alias ZoonkWeb.Accounts.UserAuth
+  alias ZoonkWeb.UserAuth
 
   @oauth_state_cookie "_zk_oauth_state"
 

--- a/lib/zoonk_web/controllers/accounts/user_session_controller.ex
+++ b/lib/zoonk_web/controllers/accounts/user_session_controller.ex
@@ -8,7 +8,7 @@ defmodule ZoonkWeb.Accounts.UserSessionController do
   use ZoonkWeb, :controller
 
   alias Zoonk.Accounts
-  alias ZoonkWeb.Accounts.UserAuth
+  alias ZoonkWeb.UserAuth
 
   @doc """
   Logs in a user.

--- a/lib/zoonk_web/live/auth/user_signup_live.ex
+++ b/lib/zoonk_web/live/auth/user_signup_live.ex
@@ -7,7 +7,7 @@ defmodule ZoonkWeb.User.UserSignUpLive do
   alias Zoonk.Accounts.User
   alias Zoonk.Config.AuthConfig
   alias Zoonk.Scope
-  alias ZoonkWeb.Accounts.UserAuth
+  alias ZoonkWeb.UserAuth
 
   def render(assigns) do
     ~H"""

--- a/lib/zoonk_web/live/auth/user_signup_with_email_live.ex
+++ b/lib/zoonk_web/live/auth/user_signup_with_email_live.ex
@@ -8,7 +8,7 @@ defmodule ZoonkWeb.User.UserSignUpWithEmailLive do
   alias Zoonk.Accounts.User
   alias Zoonk.Config.LanguageConfig
   alias Zoonk.Scope
-  alias ZoonkWeb.Accounts.UserAuth
+  alias ZoonkWeb.UserAuth
 
   def render(assigns) do
     ~H"""

--- a/lib/zoonk_web/router.ex
+++ b/lib/zoonk_web/router.ex
@@ -3,8 +3,10 @@ defmodule ZoonkWeb.Router do
 
   import ZoonkWeb.Accounts.UserAuth
   import ZoonkWeb.Language
+  import ZoonkWeb.UserAuthorization
 
   alias ZoonkWeb.Accounts.UserAuth
+  alias ZoonkWeb.UserAuthorization
 
   @allowed_images "https://avatars.githubusercontent.com https://github.com https://*.googleusercontent.com"
 
@@ -42,11 +44,12 @@ defmodule ZoonkWeb.Router do
   end
 
   scope "/", ZoonkWeb do
-    pipe_through [:browser, :require_authenticated_user]
+    pipe_through [:browser, :require_authenticated_user, :require_org_member]
 
     live_session :require_authenticated_user,
       on_mount: [
         {UserAuth, :ensure_authenticated},
+        {UserAuthorization, :ensure_org_member},
         {ZoonkWeb.Language, :set_app_language}
       ] do
       live "/", AppHomeLive

--- a/lib/zoonk_web/router.ex
+++ b/lib/zoonk_web/router.ex
@@ -1,11 +1,11 @@
 defmodule ZoonkWeb.Router do
   use ZoonkWeb, :router
 
-  import ZoonkWeb.Accounts.UserAuth
   import ZoonkWeb.Language
+  import ZoonkWeb.UserAuth
   import ZoonkWeb.UserAuthorization
 
-  alias ZoonkWeb.Accounts.UserAuth
+  alias ZoonkWeb.UserAuth
   alias ZoonkWeb.UserAuthorization
 
   @allowed_images "https://avatars.githubusercontent.com https://github.com https://*.googleusercontent.com"

--- a/lib/zoonk_web/user_auth.ex
+++ b/lib/zoonk_web/user_auth.ex
@@ -163,7 +163,10 @@ defmodule ZoonkWeb.UserAuth do
     if socket.assigns.current_scope && socket.assigns.current_scope.user do
       {:cont, socket}
     else
-      socket = Phoenix.LiveView.redirect(socket, to: ~p"/login")
+      socket =
+        socket
+        |> Phoenix.LiveView.put_flash(:error, dgettext("users", "You must log in to access this page."))
+        |> Phoenix.LiveView.redirect(to: ~p"/login")
 
       {:halt, socket}
     end

--- a/lib/zoonk_web/user_auth.ex
+++ b/lib/zoonk_web/user_auth.ex
@@ -163,10 +163,7 @@ defmodule ZoonkWeb.UserAuth do
     if socket.assigns.current_scope && socket.assigns.current_scope.user do
       {:cont, socket}
     else
-      socket =
-        socket
-        |> Phoenix.LiveView.put_flash(:error, dgettext("users", "You must log in to access this page."))
-        |> Phoenix.LiveView.redirect(to: ~p"/login")
+      socket = Phoenix.LiveView.redirect(socket, to: ~p"/login")
 
       {:halt, socket}
     end

--- a/lib/zoonk_web/user_auth.ex
+++ b/lib/zoonk_web/user_auth.ex
@@ -1,4 +1,4 @@
-defmodule ZoonkWeb.Accounts.UserAuth do
+defmodule ZoonkWeb.UserAuth do
   @moduledoc """
   Session management for user authentication.
 
@@ -143,13 +143,13 @@ defmodule ZoonkWeb.Accounts.UserAuth do
       defmodule ZoonkWeb.PageLive do
         use ZoonkWeb, :live_view
 
-        on_mount {ZoonkWeb.Accounts.UserAuth, :mount_current_scope}
+        on_mount {ZoonkWeb.UserAuth, :mount_current_scope}
         ...
       end
 
   Or use the `live_session` of your router to invoke the on_mount callback:
 
-      live_session :authenticated, on_mount: [{ZoonkWeb.Accounts.UserAuth, :ensure_authenticated}] do
+      live_session :authenticated, on_mount: [{ZoonkWeb.UserAuth, :ensure_authenticated}] do
         live "/profile", ProfileLive, :index
       end
   """

--- a/lib/zoonk_web/user_authorization.ex
+++ b/lib/zoonk_web/user_authorization.ex
@@ -1,0 +1,45 @@
+defmodule ZoonkWeb.UserAuthorization do
+  @moduledoc """
+  Authorization plugs for web routes.
+
+  This module contains plugs that check if a user has permission to access
+  certain routes based on their organization membership and status.
+  """
+  use Gettext, backend: Zoonk.Gettext
+
+  import Phoenix.Controller
+  import Plug.Conn
+
+  alias Zoonk.Accounts.User
+  alias Zoonk.Scope
+  alias ZoonkWeb.Accounts.UserAuth
+
+  @doc """
+  Checks if the user is a confirmed member of the current organization.
+
+  This plug verifies that either:
+  1. The user is a confirmed member of the organization
+  2. OR the organization is public (`:app` or `:creator` kind)
+
+  If not, then we log them out.
+
+  ## Examples
+
+      plug :require_org_member
+  """
+  def require_org_member(conn, _opts) when conn.assigns.current_scope.org.kind in [:app, :creator], do: conn
+  def require_org_member(conn, opts), do: require_org_member(conn, opts, org_member?(conn.assigns.current_scope))
+
+  defp require_org_member(conn, _opts, true), do: conn
+
+  defp require_org_member(conn, _opts, false) do
+    conn
+    |> put_flash(:error, dgettext("errors", "You must be a member of this organization."))
+    |> UserAuth.logout_user()
+    |> halt()
+  end
+
+  defp org_member?(%Scope{user: %User{confirmed_at: nil}}), do: false
+  defp org_member?(%Scope{org_member: nil}), do: false
+  defp org_member?(_scope), do: true
+end

--- a/lib/zoonk_web/user_authorization.ex
+++ b/lib/zoonk_web/user_authorization.ex
@@ -65,7 +65,7 @@ defmodule ZoonkWeb.UserAuthorization do
       socket =
         socket
         |> Phoenix.LiveView.put_flash(:error, dgettext("errors", "You must be a member of this organization."))
-        |> Phoenix.LiveView.redirect(to: ~p"/login")
+        |> Phoenix.LiveView.redirect(to: ~p"/login", status: 403)
 
       {:halt, socket}
     end

--- a/lib/zoonk_web/user_authorization.ex
+++ b/lib/zoonk_web/user_authorization.ex
@@ -5,6 +5,7 @@ defmodule ZoonkWeb.UserAuthorization do
   This module contains plugs that check if a user has permission to access
   certain routes based on their organization membership and status.
   """
+  use ZoonkWeb, :verified_routes
   use Gettext, backend: Zoonk.Gettext
 
   import Phoenix.Controller
@@ -37,6 +38,37 @@ defmodule ZoonkWeb.UserAuthorization do
     |> put_flash(:error, dgettext("errors", "You must be a member of this organization."))
     |> UserAuth.logout_user()
     |> halt()
+  end
+
+  @doc """
+  LiveView hook to check if the user is a confirmed member of the current organization.
+
+  This hook verifies that either:
+  1. The user is a confirmed member of the organization
+  2. OR the organization is public (`:app` or `:creator` kind)
+
+  If not, then we log them out and redirect to the home page.
+
+  ## Examples
+
+      on_mount {ZoonkWeb.UserAuthorization, :ensure_org_member}
+  """
+  def on_mount(:ensure_org_member, _params, _session, socket)
+      when socket.assigns.current_scope.org.kind in [:app, :creator] do
+    {:cont, socket}
+  end
+
+  def on_mount(:ensure_org_member, _params, _session, socket) do
+    if org_member?(socket.assigns.current_scope) do
+      {:cont, socket}
+    else
+      socket =
+        socket
+        |> Phoenix.LiveView.put_flash(:error, dgettext("errors", "You must be a member of this organization."))
+        |> Phoenix.LiveView.redirect(to: ~p"/login")
+
+      {:halt, socket}
+    end
   end
 
   defp org_member?(%Scope{user: %User{confirmed_at: nil}}), do: false

--- a/lib/zoonk_web/user_authorization.ex
+++ b/lib/zoonk_web/user_authorization.ex
@@ -13,7 +13,7 @@ defmodule ZoonkWeb.UserAuthorization do
 
   alias Zoonk.Accounts.User
   alias Zoonk.Scope
-  alias ZoonkWeb.Accounts.UserAuth
+  alias ZoonkWeb.UserAuth
 
   @doc """
   Checks if the user is a confirmed member of the current organization.

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -109,16 +109,4 @@ defmodule ZoonkWeb.ConnCase do
 
   defp get_org(kind),
     do: Zoonk.OrgFixtures.org_fixture(%{kind: kind, custom_domain: "zoonk.test-#{System.unique_integer()}"})
-
-  def assert_unconfirmed_member_access_denied(conn, org, page) do
-    user = %{Zoonk.AccountFixtures.user_fixture() | confirmed_at: nil}
-    org_member = Zoonk.OrgFixtures.org_member_fixture(%{user: user, org: org})
-    scope = %Zoonk.Scope{user: user, org: org, org_member: org_member}
-
-    assert_raise ZoonkWeb.PermissionError, fn ->
-      conn
-      |> Plug.Conn.assign(:current_scope, scope)
-      |> PhoenixTest.visit(page)
-    end
-  end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -109,4 +109,16 @@ defmodule ZoonkWeb.ConnCase do
 
   defp get_org(kind),
     do: Zoonk.OrgFixtures.org_fixture(%{kind: kind, custom_domain: "zoonk.test-#{System.unique_integer()}"})
+
+  def assert_unconfirmed_member_access_denied(conn, org, page) do
+    user = %{Zoonk.AccountFixtures.user_fixture() | confirmed_at: nil}
+    org_member = Zoonk.OrgFixtures.org_member_fixture(%{user: user, org: org})
+    scope = %Zoonk.Scope{user: user, org: org, org_member: org_member}
+
+    assert_raise ZoonkWeb.PermissionError, fn ->
+      conn
+      |> Plug.Conn.assign(:current_scope, scope)
+      |> PhoenixTest.visit(page)
+    end
+  end
 end

--- a/test/support/fixtures/org_fixtures.ex
+++ b/test/support/fixtures/org_fixtures.ex
@@ -19,7 +19,12 @@ defmodule Zoonk.OrgFixtures do
 
   def valid_org_attributes(attrs \\ %{}) do
     unique_int = System.unique_integer([:positive])
-    Enum.into(attrs, %{display_name: "Test Org #{unique_int}", subdomain: "org#{unique_int}"})
+
+    Enum.into(attrs, %{
+      display_name: "Test Org #{unique_int}",
+      custom_domain: "zoonk_#{unique_int}.test",
+      subdomain: "org#{unique_int}"
+    })
   end
 
   @doc """

--- a/test/support/helpers/org_member_required.ex
+++ b/test/support/helpers/org_member_required.ex
@@ -26,67 +26,45 @@ defmodule ZoonkWeb.OrgMemberRequiredHelper do
   end
 
   defp allow_access_without_membership(org_kind, page) do
-    conn = Phoenix.ConnTest.build_conn()
-    user = user_fixture()
-    org = org_fixture(%{kind: org_kind})
-
-    conn
-    |> Map.put(:host, org.custom_domain)
-    |> ZoonkWeb.ConnCase.login_user(user)
-    |> visit(page.link)
-    |> assert_has("li[aria-current='page']", text: page.title)
+    test_access(org_kind, page, confirmed?: true, create_member?: false, expect_success?: true)
   end
 
   defp allow_access_for_unconfirmed_user(org_kind, page) do
-    conn = Phoenix.ConnTest.build_conn()
-    user = unconfirmed_user_fixture()
-    org = org_fixture(%{kind: org_kind})
-    org_member_fixture(%{user: user, org: org})
-
-    conn
-    |> Map.put(:host, org.custom_domain)
-    |> ZoonkWeb.ConnCase.login_user(user)
-    |> visit(page.link)
-    |> assert_has("li[aria-current='page']", text: page.title)
+    test_access(org_kind, page, confirmed?: false, create_member?: true, expect_success?: true)
   end
 
   defp allow_access_for_confirmed_member(org_kind, page) do
-    conn = Phoenix.ConnTest.build_conn()
-    user = user_fixture()
-    org = org_fixture(%{kind: org_kind})
-    org_member_fixture(%{user: user, org: org})
-
-    conn
-    |> Map.put(:host, org.custom_domain)
-    |> ZoonkWeb.ConnCase.login_user(user)
-    |> visit(page.link)
-    |> assert_has("li[aria-current='page']", text: page.title)
+    test_access(org_kind, page, confirmed?: true, create_member?: true, expect_success?: true)
   end
 
   defp raises_for_unconfirmed_member(org_kind, page) do
-    conn = Phoenix.ConnTest.build_conn()
-    user = unconfirmed_user_fixture()
-    org = org_fixture(%{kind: org_kind})
-    org_member_fixture(%{user: user, org: org})
-
-    assert_raise(PermissionError, fn ->
-      conn
-      |> Map.put(:host, org.custom_domain)
-      |> ZoonkWeb.ConnCase.login_user(user)
-      |> visit(page.link)
-    end)
+    test_access(org_kind, page, confirmed?: false, create_member?: true, expect_success?: false)
   end
 
   defp raises_without_membership(org_kind, page) do
+    test_access(org_kind, page, confirmed?: true, create_member?: false, expect_success?: false)
+  end
+
+  defp test_access(org_kind, page, opts) do
     conn = Phoenix.ConnTest.build_conn()
-    user = user_fixture()
+    user = if opts[:confirmed?], do: user_fixture(), else: unconfirmed_user_fixture()
     org = org_fixture(%{kind: org_kind})
 
-    assert_raise(PermissionError, fn ->
+    if opts[:create_member?] do
+      org_member_fixture(%{user: user, org: org})
+    end
+
+    conn =
       conn
       |> Map.put(:host, org.custom_domain)
       |> ZoonkWeb.ConnCase.login_user(user)
+
+    if opts[:expect_success?] do
+      conn
       |> visit(page.link)
-    end)
+      |> assert_has("li[aria-current='page']", text: page.title)
+    else
+      assert_raise(PermissionError, fn -> visit(conn, page.link) end)
+    end
   end
 end

--- a/test/support/helpers/org_member_required.ex
+++ b/test/support/helpers/org_member_required.ex
@@ -1,0 +1,24 @@
+defmodule ZoonkWeb.OrgMemberRequiredHelper do
+  @moduledoc false
+
+  import ExUnit.Assertions
+  import PhoenixTest
+  import Plug.Conn
+  import Zoonk.AccountFixtures
+  import Zoonk.OrgFixtures
+
+  alias Zoonk.Scope
+  alias ZoonkWeb.PermissionError
+
+  def assert_unconfirmed_member_access_denied(conn, org, page) do
+    user = %{user_fixture() | confirmed_at: nil}
+    org_member = org_member_fixture(%{user: user, org: org})
+    scope = %Scope{user: user, org: org, org_member: org_member}
+
+    assert_raise(PermissionError, fn ->
+      conn
+      |> assign(:current_scope, scope)
+      |> visit(page)
+    end)
+  end
+end

--- a/test/support/helpers/org_member_required.ex
+++ b/test/support/helpers/org_member_required.ex
@@ -3,22 +3,90 @@ defmodule ZoonkWeb.OrgMemberRequiredHelper do
 
   import ExUnit.Assertions
   import PhoenixTest
-  import Plug.Conn
   import Zoonk.AccountFixtures
   import Zoonk.OrgFixtures
 
-  alias Zoonk.Scope
   alias ZoonkWeb.PermissionError
 
-  def assert_unconfirmed_member_access_denied(conn, org, page) do
-    user = %{user_fixture() | confirmed_at: nil}
-    org_member = org_member_fixture(%{user: user, org: org})
-    scope = %Scope{user: user, org: org, org_member: org_member}
+  def assert_require_org_member(page) do
+    allow_access_without_membership(:app, page)
+    allow_access_without_membership(:creator, page)
+
+    allow_access_for_unconfirmed_user(:app, page)
+    allow_access_for_unconfirmed_user(:creator, page)
+
+    allow_access_for_confirmed_member(:team, page)
+    allow_access_for_confirmed_member(:school, page)
+
+    raises_for_unconfirmed_member(:team, page)
+    raises_for_unconfirmed_member(:school, page)
+
+    raises_without_membership(:team, page)
+    raises_without_membership(:school, page)
+  end
+
+  defp allow_access_without_membership(org_kind, page) do
+    conn = Phoenix.ConnTest.build_conn()
+    user = user_fixture()
+    org = org_fixture(%{kind: org_kind})
+
+    conn
+    |> Map.put(:host, org.custom_domain)
+    |> ZoonkWeb.ConnCase.login_user(user)
+    |> visit(page.link)
+    |> assert_has("li[aria-current='page']", text: page.title)
+  end
+
+  defp allow_access_for_unconfirmed_user(org_kind, page) do
+    conn = Phoenix.ConnTest.build_conn()
+    user = unconfirmed_user_fixture()
+    org = org_fixture(%{kind: org_kind})
+    org_member_fixture(%{user: user, org: org})
+
+    conn
+    |> Map.put(:host, org.custom_domain)
+    |> ZoonkWeb.ConnCase.login_user(user)
+    |> visit(page.link)
+    |> assert_has("li[aria-current='page']", text: page.title)
+  end
+
+  defp allow_access_for_confirmed_member(org_kind, page) do
+    conn = Phoenix.ConnTest.build_conn()
+    user = user_fixture()
+    org = org_fixture(%{kind: org_kind})
+    org_member_fixture(%{user: user, org: org})
+
+    conn
+    |> Map.put(:host, org.custom_domain)
+    |> ZoonkWeb.ConnCase.login_user(user)
+    |> visit(page.link)
+    |> assert_has("li[aria-current='page']", text: page.title)
+  end
+
+  defp raises_for_unconfirmed_member(org_kind, page) do
+    conn = Phoenix.ConnTest.build_conn()
+    user = unconfirmed_user_fixture()
+    org = org_fixture(%{kind: org_kind})
+    org_member_fixture(%{user: user, org: org})
 
     assert_raise(PermissionError, fn ->
       conn
-      |> assign(:current_scope, scope)
-      |> visit(page)
+      |> Map.put(:host, org.custom_domain)
+      |> ZoonkWeb.ConnCase.login_user(user)
+      |> visit(page.link)
+    end)
+  end
+
+  defp raises_without_membership(org_kind, page) do
+    conn = Phoenix.ConnTest.build_conn()
+    user = user_fixture()
+    org = org_fixture(%{kind: org_kind})
+
+    assert_raise(PermissionError, fn ->
+      conn
+      |> Map.put(:host, org.custom_domain)
+      |> ZoonkWeb.ConnCase.login_user(user)
+      |> visit(page.link)
     end)
   end
 end

--- a/test/support/helpers/org_member_required.ex
+++ b/test/support/helpers/org_member_required.ex
@@ -9,6 +9,11 @@ defmodule ZoonkWeb.OrgMemberRequiredHelper do
   alias ZoonkWeb.PermissionError
 
   def assert_require_org_member(page) do
+    redirects_to_login(:app, page)
+    redirects_to_login(:creator, page)
+    redirects_to_login(:team, page)
+    redirects_to_login(:school, page)
+
     allow_access_without_membership(:app, page)
     allow_access_without_membership(:creator, page)
 
@@ -46,7 +51,6 @@ defmodule ZoonkWeb.OrgMemberRequiredHelper do
   end
 
   defp test_access(org_kind, page, opts) do
-    conn = Phoenix.ConnTest.build_conn()
     user = if opts[:confirmed?], do: user_fixture(), else: unconfirmed_user_fixture()
     org = org_fixture(%{kind: org_kind})
 
@@ -55,7 +59,7 @@ defmodule ZoonkWeb.OrgMemberRequiredHelper do
     end
 
     conn =
-      conn
+      Phoenix.ConnTest.build_conn()
       |> Map.put(:host, org.custom_domain)
       |> ZoonkWeb.ConnCase.login_user(user)
 
@@ -66,5 +70,15 @@ defmodule ZoonkWeb.OrgMemberRequiredHelper do
     else
       assert_raise(PermissionError, fn -> visit(conn, page.link) end)
     end
+  end
+
+  defp redirects_to_login(org_kind, page) do
+    conn = Phoenix.ConnTest.build_conn()
+    org = org_fixture(%{kind: org_kind})
+
+    conn
+    |> Map.put(:host, org.custom_domain)
+    |> visit(page.link)
+    |> assert_path("/login")
   end
 end

--- a/test/support/helpers/org_member_required.ex
+++ b/test/support/helpers/org_member_required.ex
@@ -8,7 +8,23 @@ defmodule ZoonkWeb.OrgMemberRequiredHelper do
 
   alias ZoonkWeb.PermissionError
 
-  def assert_require_org_member(page) do
+  @doc """
+  Tests page authorization for different organization kinds and user states.
+
+  This helper function tests multiple authorization scenarios:
+
+  - Redirects to login when user is not authenticated
+  - Allows access without membership for public organizations (:app, :creator)
+  - Allows access for unconfirmed users in public organizations
+  - Allows access for confirmed members in private organizations (:team, :school)
+  - Raises error for unconfirmed members in private organizations
+  - Raises error for non-members in private organizations
+
+  ## Example
+
+      assert_page_authorization(%{link: ~p"/", title: "Summary"})
+  """
+  def assert_page_authorization(page) do
     redirects_to_login(:app, page)
     redirects_to_login(:creator, page)
     redirects_to_login(:team, page)

--- a/test/zoonk_web/live/app_home_live_test.exs
+++ b/test/zoonk_web/live/app_home_live_test.exs
@@ -101,15 +101,7 @@ defmodule ZoonkWeb.AppHomeLiveTest do
     end
 
     test "raises when user is a member but not confirmed", %{conn: conn, org: org} do
-      user = %{user_fixture() | confirmed_at: nil}
-      org_member = org_member_fixture(%{user: user, org: org})
-      scope = %Scope{user: user, org: org, org_member: org_member}
-
-      assert_raise ZoonkWeb.PermissionError, fn ->
-        conn
-        |> assign(:current_scope, scope)
-        |> visit(~p"/")
-      end
+      assert_unconfirmed_member_access_denied(conn, org, ~p"/")
     end
   end
 
@@ -134,6 +126,10 @@ defmodule ZoonkWeb.AppHomeLiveTest do
         |> assign(:current_scope, scope)
         |> visit(~p"/")
       end
+    end
+
+    test "raises when user is a member but not confirmed", %{conn: conn, org: org} do
+      assert_unconfirmed_member_access_denied(conn, org, ~p"/")
     end
   end
 end

--- a/test/zoonk_web/live/app_home_live_test.exs
+++ b/test/zoonk_web/live/app_home_live_test.exs
@@ -4,12 +4,6 @@ defmodule ZoonkWeb.AppHomeLiveTest do
   import ZoonkWeb.OrgMemberRequiredHelper
 
   describe "app home page" do
-    test "redirects to the login page", %{conn: conn} do
-      conn
-      |> visit(~p"/")
-      |> assert_path(~p"/login")
-    end
-
     test "handle org authorization" do
       assert_require_org_member(%{link: ~p"/", title: "Summary"})
     end

--- a/test/zoonk_web/live/app_home_live_test.exs
+++ b/test/zoonk_web/live/app_home_live_test.exs
@@ -1,6 +1,11 @@
 defmodule ZoonkWeb.AppHomeLiveTest do
   use ZoonkWeb.ConnCase, async: true
 
+  import Zoonk.AccountFixtures
+  import Zoonk.OrgFixtures
+
+  alias Zoonk.Scope
+
   describe "app home page (unauthenticated)" do
     test "redirects to the login page", %{conn: conn} do
       conn
@@ -23,6 +28,109 @@ defmodule ZoonkWeb.AppHomeLiveTest do
       |> visit(~p"/")
       |> click_link("Email")
       |> assert_path(~p"/user/email")
+    end
+  end
+
+  describe "app home page (:app org)" do
+    setup [:signup_and_login_user, :setup_app]
+
+    test "allows access for app organization without org membership", %{conn: conn, user: user, org: org} do
+      scope = %Scope{user: user, org: org, org_member: nil}
+
+      conn
+      |> assign(:current_scope, scope)
+      |> visit(~p"/")
+      |> assert_has("li[aria-current='page']", text: "Summary")
+    end
+
+    test "allows access for unconfirmed user with app organization", %{conn: conn, org: org} do
+      user = %{user_fixture() | confirmed_at: nil}
+      scope = %Scope{user: user, org: org, org_member: nil}
+
+      conn
+      |> assign(:current_scope, scope)
+      |> visit(~p"/")
+      |> assert_has("li[aria-current='page']", text: "Summary")
+    end
+  end
+
+  describe "app home page (:creator org)" do
+    setup [:signup_and_login_user, :setup_creator]
+
+    test "allows access for creator organization without org membership", %{conn: conn, user: user, org: org} do
+      scope = %Scope{user: user, org: org, org_member: nil}
+
+      conn
+      |> assign(:current_scope, scope)
+      |> visit(~p"/")
+      |> assert_has("li[aria-current='page']", text: "Summary")
+    end
+
+    test "allows access for unconfirmed user with creator organization", %{conn: conn, org: org} do
+      user = %{user_fixture() | confirmed_at: nil}
+      scope = %Scope{user: user, org: org, org_member: nil}
+
+      conn
+      |> assign(:current_scope, scope)
+      |> visit(~p"/")
+      |> assert_has("li[aria-current='page']", text: "Summary")
+    end
+  end
+
+  describe "app home page (:team org)" do
+    setup [:signup_and_login_user, :setup_team]
+
+    test "allows access when user is a confirmed member of the team organization", %{conn: conn, user: user, org: org} do
+      org_member = org_member_fixture(%{user: user, org: org})
+      scope = %Scope{user: user, org: org, org_member: org_member}
+
+      conn
+      |> assign(:current_scope, scope)
+      |> visit(~p"/")
+      |> assert_has("li[aria-current='page']", text: "Summary")
+    end
+
+    test "redirects when user is not a member of the team organization", %{conn: conn, user: user, org: org} do
+      scope = %Scope{user: user, org: org, org_member: nil}
+
+      conn
+      |> assign(:current_scope, scope)
+      |> visit(~p"/")
+      |> assert_path(~p"/login")
+    end
+
+    test "redirects when user is a member but not confirmed", %{conn: conn, org: org} do
+      user = %{user_fixture() | confirmed_at: nil}
+      org_member = org_member_fixture(%{user: user, org: org})
+      scope = %Scope{user: user, org: org, org_member: org_member}
+
+      conn
+      |> assign(:current_scope, scope)
+      |> visit(~p"/")
+      |> assert_path(~p"/login")
+    end
+  end
+
+  describe "app home page (:school org)" do
+    setup [:signup_and_login_user, :setup_school]
+
+    test "allows access when user is a confirmed member of the school organization", %{conn: conn, user: user, org: org} do
+      org_member = org_member_fixture(%{user: user, org: org})
+      scope = %Scope{user: user, org: org, org_member: org_member}
+
+      conn
+      |> assign(:current_scope, scope)
+      |> visit(~p"/")
+      |> assert_has("li[aria-current='page']", text: "Summary")
+    end
+
+    test "redirects when user is not a member of the school organization", %{conn: conn, user: user, org: org} do
+      scope = %Scope{user: user, org: org, org_member: nil}
+
+      conn
+      |> assign(:current_scope, scope)
+      |> visit(~p"/")
+      |> assert_path(~p"/login")
     end
   end
 end

--- a/test/zoonk_web/live/app_home_live_test.exs
+++ b/test/zoonk_web/live/app_home_live_test.exs
@@ -5,7 +5,7 @@ defmodule ZoonkWeb.AppHomeLiveTest do
 
   describe "app home page" do
     test "handle org authorization" do
-      assert_require_org_member(%{link: ~p"/", title: "Summary"})
+      assert_page_authorization(%{link: ~p"/", title: "Summary"})
     end
   end
 end

--- a/test/zoonk_web/live/app_home_live_test.exs
+++ b/test/zoonk_web/live/app_home_live_test.exs
@@ -3,6 +3,7 @@ defmodule ZoonkWeb.AppHomeLiveTest do
 
   import Zoonk.AccountFixtures
   import Zoonk.OrgFixtures
+  import ZoonkWeb.OrgMemberRequiredHelper
 
   alias Zoonk.Scope
 

--- a/test/zoonk_web/live/app_home_live_test.exs
+++ b/test/zoonk_web/live/app_home_live_test.exs
@@ -1,136 +1,17 @@
 defmodule ZoonkWeb.AppHomeLiveTest do
   use ZoonkWeb.ConnCase, async: true
 
-  import Zoonk.AccountFixtures
-  import Zoonk.OrgFixtures
   import ZoonkWeb.OrgMemberRequiredHelper
 
-  alias Zoonk.Scope
-
-  describe "app home page (unauthenticated)" do
+  describe "app home page" do
     test "redirects to the login page", %{conn: conn} do
       conn
       |> visit(~p"/")
       |> assert_path(~p"/login")
     end
-  end
 
-  describe "app home page" do
-    setup :signup_and_login_user
-
-    test "renders page", %{conn: conn} do
-      conn
-      |> visit(~p"/")
-      |> assert_has("li[aria-current='page']", text: "Summary")
-    end
-
-    test "navigates to the settings page", %{conn: conn} do
-      conn
-      |> visit(~p"/")
-      |> click_link("Email")
-      |> assert_path(~p"/user/email")
-    end
-  end
-
-  describe "app home page (:app org)" do
-    setup [:signup_and_login_user, :setup_app]
-
-    test "allows access for app organization without org membership", %{conn: conn, user: user, org: org} do
-      scope = %Scope{user: user, org: org, org_member: nil}
-
-      conn
-      |> assign(:current_scope, scope)
-      |> visit(~p"/")
-      |> assert_has("li[aria-current='page']", text: "Summary")
-    end
-
-    test "allows access for unconfirmed user with app organization", %{conn: conn, org: org} do
-      user = %{user_fixture() | confirmed_at: nil}
-      scope = %Scope{user: user, org: org, org_member: nil}
-
-      conn
-      |> assign(:current_scope, scope)
-      |> visit(~p"/")
-      |> assert_has("li[aria-current='page']", text: "Summary")
-    end
-  end
-
-  describe "app home page (:creator org)" do
-    setup [:signup_and_login_user, :setup_creator]
-
-    test "allows access for creator organization without org membership", %{conn: conn, user: user, org: org} do
-      scope = %Scope{user: user, org: org, org_member: nil}
-
-      conn
-      |> assign(:current_scope, scope)
-      |> visit(~p"/")
-      |> assert_has("li[aria-current='page']", text: "Summary")
-    end
-
-    test "allows access for unconfirmed user with creator organization", %{conn: conn, org: org} do
-      user = %{user_fixture() | confirmed_at: nil}
-      scope = %Scope{user: user, org: org, org_member: nil}
-
-      conn
-      |> assign(:current_scope, scope)
-      |> visit(~p"/")
-      |> assert_has("li[aria-current='page']", text: "Summary")
-    end
-  end
-
-  describe "app home page (:team org)" do
-    setup [:signup_and_login_user, :setup_team]
-
-    test "allows access when user is a confirmed member of the team organization", %{conn: conn, user: user, org: org} do
-      org_member = org_member_fixture(%{user: user, org: org})
-      scope = %Scope{user: user, org: org, org_member: org_member}
-
-      conn
-      |> assign(:current_scope, scope)
-      |> visit(~p"/")
-      |> assert_has("li[aria-current='page']", text: "Summary")
-    end
-
-    test "raises when user is not a member of the team organization", %{conn: conn, user: user, org: org} do
-      scope = %Scope{user: user, org: org, org_member: nil}
-
-      assert_raise ZoonkWeb.PermissionError, fn ->
-        conn
-        |> assign(:current_scope, scope)
-        |> visit(~p"/")
-      end
-    end
-
-    test "raises when user is a member but not confirmed", %{conn: conn, org: org} do
-      assert_unconfirmed_member_access_denied(conn, org, ~p"/")
-    end
-  end
-
-  describe "app home page (:school org)" do
-    setup [:signup_and_login_user, :setup_school]
-
-    test "allows access when user is a confirmed member of the school organization", %{conn: conn, user: user, org: org} do
-      org_member = org_member_fixture(%{user: user, org: org})
-      scope = %Scope{user: user, org: org, org_member: org_member}
-
-      conn
-      |> assign(:current_scope, scope)
-      |> visit(~p"/")
-      |> assert_has("li[aria-current='page']", text: "Summary")
-    end
-
-    test "raises when user is not a member of the school organization", %{conn: conn, user: user, org: org} do
-      scope = %Scope{user: user, org: org, org_member: nil}
-
-      assert_raise ZoonkWeb.PermissionError, fn ->
-        conn
-        |> assign(:current_scope, scope)
-        |> visit(~p"/")
-      end
-    end
-
-    test "raises when user is a member but not confirmed", %{conn: conn, org: org} do
-      assert_unconfirmed_member_access_denied(conn, org, ~p"/")
+    test "handle org authorization" do
+      assert_require_org_member(%{link: ~p"/", title: "Summary"})
     end
   end
 end

--- a/test/zoonk_web/live/app_home_live_test.exs
+++ b/test/zoonk_web/live/app_home_live_test.exs
@@ -90,24 +90,26 @@ defmodule ZoonkWeb.AppHomeLiveTest do
       |> assert_has("li[aria-current='page']", text: "Summary")
     end
 
-    test "redirects when user is not a member of the team organization", %{conn: conn, user: user, org: org} do
+    test "raises when user is not a member of the team organization", %{conn: conn, user: user, org: org} do
       scope = %Scope{user: user, org: org, org_member: nil}
 
-      conn
-      |> assign(:current_scope, scope)
-      |> visit(~p"/")
-      |> assert_path(~p"/login")
+      assert_raise ZoonkWeb.PermissionError, fn ->
+        conn
+        |> assign(:current_scope, scope)
+        |> visit(~p"/")
+      end
     end
 
-    test "redirects when user is a member but not confirmed", %{conn: conn, org: org} do
+    test "raises when user is a member but not confirmed", %{conn: conn, org: org} do
       user = %{user_fixture() | confirmed_at: nil}
       org_member = org_member_fixture(%{user: user, org: org})
       scope = %Scope{user: user, org: org, org_member: org_member}
 
-      conn
-      |> assign(:current_scope, scope)
-      |> visit(~p"/")
-      |> assert_path(~p"/login")
+      assert_raise ZoonkWeb.PermissionError, fn ->
+        conn
+        |> assign(:current_scope, scope)
+        |> visit(~p"/")
+      end
     end
   end
 
@@ -124,13 +126,14 @@ defmodule ZoonkWeb.AppHomeLiveTest do
       |> assert_has("li[aria-current='page']", text: "Summary")
     end
 
-    test "redirects when user is not a member of the school organization", %{conn: conn, user: user, org: org} do
+    test "raises when user is not a member of the school organization", %{conn: conn, user: user, org: org} do
       scope = %Scope{user: user, org: org, org_member: nil}
 
-      conn
-      |> assign(:current_scope, scope)
-      |> visit(~p"/")
-      |> assert_path(~p"/login")
+      assert_raise ZoonkWeb.PermissionError, fn ->
+        conn
+        |> assign(:current_scope, scope)
+        |> visit(~p"/")
+      end
     end
   end
 end

--- a/test/zoonk_web/live/catalog/catalog_home_live_test.exs
+++ b/test/zoonk_web/live/catalog/catalog_home_live_test.exs
@@ -1,23 +1,11 @@
 defmodule ZoonkWeb.Catalog.CatalogHomeLiveTest do
   use ZoonkWeb.ConnCase, async: true
 
-  describe "catalog home page (unauthenticated)" do
-    test "redirects to the login page", %{conn: conn} do
-      conn
-      |> visit(~p"/catalog")
-      |> assert_path(~p"/login")
-    end
-  end
+  import ZoonkWeb.OrgMemberRequiredHelper
 
   describe "catalog home page" do
-    setup :signup_and_login_user
-
-    test "renders page", %{conn: conn} do
-      conn
-      |> visit(~p"/catalog")
-      |> click_link("aside a", "Catalog")
-      |> assert_path(~p"/catalog")
-      |> assert_has("li[aria-current='page']", text: "Catalog")
+    test "handle org authorization" do
+      assert_page_authorization(%{link: ~p"/catalog", title: "Catalog"})
     end
   end
 end

--- a/test/zoonk_web/live/goals/goals_home_live_test.exs
+++ b/test/zoonk_web/live/goals/goals_home_live_test.exs
@@ -4,12 +4,6 @@ defmodule ZoonkWeb.Goals.GoalsHomeLiveTest do
   import ZoonkWeb.OrgMemberRequiredHelper
 
   describe "goals home page" do
-    test "redirects to the login page", %{conn: conn} do
-      conn
-      |> visit(~p"/goals")
-      |> assert_path(~p"/login")
-    end
-
     test "handle org authorization" do
       assert_require_org_member(%{link: ~p"/goals", title: "Goals"})
     end

--- a/test/zoonk_web/live/goals/goals_home_live_test.exs
+++ b/test/zoonk_web/live/goals/goals_home_live_test.exs
@@ -1,119 +1,17 @@
 defmodule ZoonkWeb.Goals.GoalsHomeLiveTest do
   use ZoonkWeb.ConnCase, async: true
 
-  import Zoonk.AccountFixtures
-  import Zoonk.OrgFixtures
   import ZoonkWeb.OrgMemberRequiredHelper
 
-  alias Zoonk.Scope
-
-  describe "goals home page (unauthenticated)" do
+  describe "goals home page" do
     test "redirects to the login page", %{conn: conn} do
       conn
       |> visit(~p"/goals")
       |> assert_path(~p"/login")
     end
-  end
 
-  describe "goals home page (:app org)" do
-    setup [:signup_and_login_user, :setup_app]
-
-    test "allows access for app organization without org membership", %{conn: conn, user: user, org: org} do
-      scope = %Scope{user: user, org: org, org_member: nil}
-
-      conn
-      |> assign(:current_scope, scope)
-      |> visit(~p"/goals")
-      |> assert_has("li[aria-current='page']", text: "Goals")
-    end
-
-    test "allows access for unconfirmed user with app organization", %{conn: conn, org: org} do
-      user = %{user_fixture() | confirmed_at: nil}
-      scope = %Scope{user: user, org: org, org_member: nil}
-
-      conn
-      |> assign(:current_scope, scope)
-      |> visit(~p"/goals")
-      |> assert_has("li[aria-current='page']", text: "Goals")
-    end
-  end
-
-  describe "goals home page (:creator org)" do
-    setup [:signup_and_login_user, :setup_creator]
-
-    test "allows access for creator organization without org membership", %{conn: conn, user: user, org: org} do
-      scope = %Scope{user: user, org: org, org_member: nil}
-
-      conn
-      |> assign(:current_scope, scope)
-      |> visit(~p"/goals")
-      |> assert_has("li[aria-current='page']", text: "Goals")
-    end
-
-    test "allows access for unconfirmed user with creator organization", %{conn: conn, org: org} do
-      user = %{user_fixture() | confirmed_at: nil}
-      scope = %Scope{user: user, org: org, org_member: nil}
-
-      conn
-      |> assign(:current_scope, scope)
-      |> visit(~p"/goals")
-      |> assert_has("li[aria-current='page']", text: "Goals")
-    end
-  end
-
-  describe "goals home page (:team org)" do
-    setup [:signup_and_login_user, :setup_team]
-
-    test "allows access when user is a confirmed member of the team organization", %{conn: conn, user: user, org: org} do
-      org_member = org_member_fixture(%{user: user, org: org})
-      scope = %Scope{user: user, org: org, org_member: org_member}
-
-      conn
-      |> assign(:current_scope, scope)
-      |> visit(~p"/goals")
-      |> assert_has("li[aria-current='page']", text: "Goals")
-    end
-
-    test "raises when user is not a member of the team organization", %{conn: conn, user: user, org: org} do
-      scope = %Scope{user: user, org: org, org_member: nil}
-
-      assert_raise ZoonkWeb.PermissionError, fn ->
-        conn
-        |> assign(:current_scope, scope)
-        |> visit(~p"/goals")
-      end
-    end
-
-    test "raises when user is a member but not confirmed", %{conn: conn, org: org} do
-      assert_unconfirmed_member_access_denied(conn, org, ~p"/goals")
-    end
-  end
-
-  describe "goals home page (:school org)" do
-    setup [:signup_and_login_user, :setup_school]
-
-    test "allows access when user is a confirmed member of the school organization", %{conn: conn, user: user, org: org} do
-      org_member = org_member_fixture(%{user: user, org: org})
-      scope = %Scope{user: user, org: org, org_member: org_member}
-
-      conn
-      |> assign(:current_scope, scope)
-      |> visit(~p"/goals")
-      |> assert_has("li[aria-current='page']", text: "Goals")
-    end
-
-    test "raises when user is not a member of the school organization", %{conn: conn, user: user, org: org} do
-      scope = %Scope{user: user, org: org, org_member: nil}
-
-      assert_raise ZoonkWeb.PermissionError, fn ->
-        conn
-        |> assign(:current_scope, scope)
-        |> visit(~p"/goals")
-      end
-    end
-
-    test "raises when user is a member but not confirmed", %{conn: conn, org: org} do
-      assert_unconfirmed_member_access_denied(conn, org, ~p"/goals")
+    test "handle org authorization" do
+      assert_require_org_member(%{link: ~p"/goals", title: "Goals"})
     end
   end
 end

--- a/test/zoonk_web/live/goals/goals_home_live_test.exs
+++ b/test/zoonk_web/live/goals/goals_home_live_test.exs
@@ -3,6 +3,7 @@ defmodule ZoonkWeb.Goals.GoalsHomeLiveTest do
 
   import Zoonk.AccountFixtures
   import Zoonk.OrgFixtures
+  import ZoonkWeb.OrgMemberRequiredHelper
 
   alias Zoonk.Scope
 

--- a/test/zoonk_web/live/goals/goals_home_live_test.exs
+++ b/test/zoonk_web/live/goals/goals_home_live_test.exs
@@ -1,6 +1,11 @@
 defmodule ZoonkWeb.Goals.GoalsHomeLiveTest do
   use ZoonkWeb.ConnCase, async: true
 
+  import Zoonk.AccountFixtures
+  import Zoonk.OrgFixtures
+
+  alias Zoonk.Scope
+
   describe "goals home page (unauthenticated)" do
     test "redirects to the login page", %{conn: conn} do
       conn
@@ -9,15 +14,105 @@ defmodule ZoonkWeb.Goals.GoalsHomeLiveTest do
     end
   end
 
-  describe "goals home page" do
-    setup :signup_and_login_user
+  describe "goals home page (:app org)" do
+    setup [:signup_and_login_user, :setup_app]
 
-    test "renders page", %{conn: conn} do
+    test "allows access for app organization without org membership", %{conn: conn, user: user, org: org} do
+      scope = %Scope{user: user, org: org, org_member: nil}
+
       conn
-      |> visit(~p"/")
-      |> click_link("aside a", "Goals")
-      |> assert_path(~p"/goals")
+      |> assign(:current_scope, scope)
+      |> visit(~p"/goals")
       |> assert_has("li[aria-current='page']", text: "Goals")
+    end
+
+    test "allows access for unconfirmed user with app organization", %{conn: conn, org: org} do
+      user = %{user_fixture() | confirmed_at: nil}
+      scope = %Scope{user: user, org: org, org_member: nil}
+
+      conn
+      |> assign(:current_scope, scope)
+      |> visit(~p"/goals")
+      |> assert_has("li[aria-current='page']", text: "Goals")
+    end
+  end
+
+  describe "goals home page (:creator org)" do
+    setup [:signup_and_login_user, :setup_creator]
+
+    test "allows access for creator organization without org membership", %{conn: conn, user: user, org: org} do
+      scope = %Scope{user: user, org: org, org_member: nil}
+
+      conn
+      |> assign(:current_scope, scope)
+      |> visit(~p"/goals")
+      |> assert_has("li[aria-current='page']", text: "Goals")
+    end
+
+    test "allows access for unconfirmed user with creator organization", %{conn: conn, org: org} do
+      user = %{user_fixture() | confirmed_at: nil}
+      scope = %Scope{user: user, org: org, org_member: nil}
+
+      conn
+      |> assign(:current_scope, scope)
+      |> visit(~p"/goals")
+      |> assert_has("li[aria-current='page']", text: "Goals")
+    end
+  end
+
+  describe "goals home page (:team org)" do
+    setup [:signup_and_login_user, :setup_team]
+
+    test "allows access when user is a confirmed member of the team organization", %{conn: conn, user: user, org: org} do
+      org_member = org_member_fixture(%{user: user, org: org})
+      scope = %Scope{user: user, org: org, org_member: org_member}
+
+      conn
+      |> assign(:current_scope, scope)
+      |> visit(~p"/goals")
+      |> assert_has("li[aria-current='page']", text: "Goals")
+    end
+
+    test "raises when user is not a member of the team organization", %{conn: conn, user: user, org: org} do
+      scope = %Scope{user: user, org: org, org_member: nil}
+
+      assert_raise ZoonkWeb.PermissionError, fn ->
+        conn
+        |> assign(:current_scope, scope)
+        |> visit(~p"/goals")
+      end
+    end
+
+    test "raises when user is a member but not confirmed", %{conn: conn, org: org} do
+      assert_unconfirmed_member_access_denied(conn, org, ~p"/goals")
+    end
+  end
+
+  describe "goals home page (:school org)" do
+    setup [:signup_and_login_user, :setup_school]
+
+    test "allows access when user is a confirmed member of the school organization", %{conn: conn, user: user, org: org} do
+      org_member = org_member_fixture(%{user: user, org: org})
+      scope = %Scope{user: user, org: org, org_member: org_member}
+
+      conn
+      |> assign(:current_scope, scope)
+      |> visit(~p"/goals")
+      |> assert_has("li[aria-current='page']", text: "Goals")
+    end
+
+    test "raises when user is not a member of the school organization", %{conn: conn, user: user, org: org} do
+      scope = %Scope{user: user, org: org, org_member: nil}
+
+      assert_raise ZoonkWeb.PermissionError, fn ->
+        conn
+        |> assign(:current_scope, scope)
+        |> visit(~p"/goals")
+      end
+    end
+
+    test "raises when user is a member but not confirmed", %{conn: conn, org: org} do
+      assert_unconfirmed_member_access_denied(conn, org, ~p"/goals")
     end
   end
 end

--- a/test/zoonk_web/live/goals/goals_home_live_test.exs
+++ b/test/zoonk_web/live/goals/goals_home_live_test.exs
@@ -5,7 +5,7 @@ defmodule ZoonkWeb.Goals.GoalsHomeLiveTest do
 
   describe "goals home page" do
     test "handle org authorization" do
-      assert_require_org_member(%{link: ~p"/goals", title: "Goals"})
+      assert_page_authorization(%{link: ~p"/goals", title: "Goals"})
     end
   end
 end

--- a/test/zoonk_web/live/library/library_home_live_test.exs
+++ b/test/zoonk_web/live/library/library_home_live_test.exs
@@ -1,23 +1,11 @@
 defmodule ZoonkWeb.Library.LibraryHomeLiveTest do
   use ZoonkWeb.ConnCase, async: true
 
-  describe "library home page (unauthenticated)" do
-    test "redirects to the login page", %{conn: conn} do
-      conn
-      |> visit(~p"/library")
-      |> assert_path(~p"/login")
-    end
-  end
+  import ZoonkWeb.OrgMemberRequiredHelper
 
   describe "library home page" do
-    setup :signup_and_login_user
-
-    test "renders page", %{conn: conn} do
-      conn
-      |> visit(~p"/")
-      |> click_link("aside a", "Library")
-      |> assert_path(~p"/library")
-      |> assert_has("li[aria-current='page']", text: "Library")
+    test "handle org authorization" do
+      assert_page_authorization(%{link: ~p"/library", title: "Library"})
     end
   end
 end

--- a/test/zoonk_web/live/user/user_email_live_test.exs
+++ b/test/zoonk_web/live/user/user_email_live_test.exs
@@ -2,24 +2,13 @@ defmodule ZoonkWeb.User.UserEmailLiveTest do
   use ZoonkWeb.ConnCase, async: true
 
   import Zoonk.AccountFixtures
+  import ZoonkWeb.OrgMemberRequiredHelper
 
   alias Zoonk.Accounts
 
-  describe "user email page (unauthenticated)" do
-    test "redirects to the login page", %{conn: conn} do
-      conn
-      |> visit(~p"/user/email")
-      |> assert_path(~p"/login")
-    end
-  end
-
   describe "user email page" do
-    setup :signup_and_login_user
-
-    test "renders page", %{conn: conn} do
-      conn
-      |> visit(~p"/user/email")
-      |> assert_has("h3", text: "Change Email")
+    test "handle org authorization" do
+      assert_page_authorization(%{link: ~p"/user/email", title: "Email"})
     end
   end
 

--- a/test/zoonk_web/user_auth_test.exs
+++ b/test/zoonk_web/user_auth_test.exs
@@ -349,11 +349,8 @@ defmodule ZoonkWeb.Accounts.UserAuthTest do
         |> UserAuth.require_authenticated_user([])
 
       assert conn.halted
-
       assert redirected_to(conn) == ~p"/login"
-
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
-               "You must log in to access this page."
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You must log in to access this page."
     end
 
     test "stores the path to redirect to on GET", %{conn: conn} do

--- a/test/zoonk_web/user_auth_test.exs
+++ b/test/zoonk_web/user_auth_test.exs
@@ -1,4 +1,4 @@
-defmodule ZoonkWeb.Accounts.UserAuthTest do
+defmodule ZoonkWeb.UserAuthTest do
   use ZoonkWeb.ConnCase, async: true
 
   import Zoonk.AccountFixtures
@@ -9,7 +9,7 @@ defmodule ZoonkWeb.Accounts.UserAuthTest do
   alias Zoonk.Accounts
   alias Zoonk.Config.AuthConfig
   alias Zoonk.Scope
-  alias ZoonkWeb.Accounts.UserAuth
+  alias ZoonkWeb.UserAuth
 
   @remember_me_cookie AuthConfig.get_cookie_name(:remember_me)
   @max_age AuthConfig.get_max_age(:token, :seconds)

--- a/test/zoonk_web/user_authorization_test.exs
+++ b/test/zoonk_web/user_authorization_test.exs
@@ -64,15 +64,12 @@ defmodule ZoonkWeb.UserAuthorizationTest do
       org_member = org_member_fixture(%{user: user, org: org})
       scope = %Scope{user: user, org: org, org_member: org_member}
 
-      conn =
+      assert_raise ZoonkWeb.PermissionError, fn ->
         conn
         |> assign(:current_scope, scope)
         |> fetch_flash()
         |> UserAuthorization.require_org_member([])
-
-      assert conn.halted
-      assert redirected_to(conn) == ~p"/"
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You must be a member of this organization."
+      end
     end
 
     test "blocks access when org_member is nil", %{conn: conn} do
@@ -80,15 +77,12 @@ defmodule ZoonkWeb.UserAuthorizationTest do
       org = org_fixture(%{kind: :team})
       scope = %Scope{user: user, org: org, org_member: nil}
 
-      conn =
+      assert_raise ZoonkWeb.PermissionError, fn ->
         conn
         |> assign(:current_scope, scope)
         |> fetch_flash()
         |> UserAuthorization.require_org_member([])
-
-      assert conn.halted
-      assert redirected_to(conn) == ~p"/"
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You must be a member of this organization."
+      end
     end
 
     test "blocks access for school organizations when user is not a member", %{conn: conn} do
@@ -96,15 +90,12 @@ defmodule ZoonkWeb.UserAuthorizationTest do
       org = org_fixture(%{kind: :school})
       scope = %Scope{user: user, org: org, org_member: nil}
 
-      conn =
+      assert_raise ZoonkWeb.PermissionError, fn ->
         conn
         |> assign(:current_scope, scope)
         |> fetch_flash()
         |> UserAuthorization.require_org_member([])
-
-      assert conn.halted
-      assert redirected_to(conn) == ~p"/"
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You must be a member of this organization."
+      end
     end
   end
 
@@ -160,9 +151,9 @@ defmodule ZoonkWeb.UserAuthorizationTest do
         assigns: %{__changed__: %{}, flash: %{}, current_scope: scope}
       }
 
-      assert {:halt, redirected_socket} = UserAuthorization.on_mount(:ensure_org_member, %{}, %{}, socket)
-      assert redirected_socket.redirected == {:redirect, %{to: "/login", status: 403}}
-      assert redirected_socket.assigns.flash["error"] == "You must be a member of this organization."
+      assert_raise ZoonkWeb.PermissionError, fn ->
+        UserAuthorization.on_mount(:ensure_org_member, %{}, %{}, socket)
+      end
     end
 
     test "redirects when org_member is nil" do
@@ -175,9 +166,9 @@ defmodule ZoonkWeb.UserAuthorizationTest do
         assigns: %{__changed__: %{}, flash: %{}, current_scope: scope}
       }
 
-      assert {:halt, redirected_socket} = UserAuthorization.on_mount(:ensure_org_member, %{}, %{}, socket)
-      assert redirected_socket.redirected == {:redirect, %{to: "/login", status: 403}}
-      assert redirected_socket.assigns.flash["error"] == "You must be a member of this organization."
+      assert_raise ZoonkWeb.PermissionError, fn ->
+        UserAuthorization.on_mount(:ensure_org_member, %{}, %{}, socket)
+      end
     end
 
     test "redirects for school organizations when user is not a member" do
@@ -190,9 +181,9 @@ defmodule ZoonkWeb.UserAuthorizationTest do
         assigns: %{__changed__: %{}, flash: %{}, current_scope: scope}
       }
 
-      assert {:halt, redirected_socket} = UserAuthorization.on_mount(:ensure_org_member, %{}, %{}, socket)
-      assert redirected_socket.redirected == {:redirect, %{to: "/login", status: 403}}
-      assert redirected_socket.assigns.flash["error"] == "You must be a member of this organization."
+      assert_raise ZoonkWeb.PermissionError, fn ->
+        UserAuthorization.on_mount(:ensure_org_member, %{}, %{}, socket)
+      end
     end
   end
 end

--- a/test/zoonk_web/user_authorization_test.exs
+++ b/test/zoonk_web/user_authorization_test.exs
@@ -1,0 +1,109 @@
+defmodule ZoonkWeb.UserAuthorizationTest do
+  use ZoonkWeb.ConnCase, async: true
+
+  import Zoonk.AccountFixtures
+  import Zoonk.OrgFixtures
+
+  alias Zoonk.Scope
+  alias ZoonkWeb.UserAuthorization
+
+  setup %{conn: conn} do
+    conn =
+      conn
+      |> Map.replace!(:secret_key_base, ZoonkWeb.Endpoint.config(:secret_key_base))
+      |> init_test_session(%{})
+
+    %{conn: conn}
+  end
+
+  describe "require_org_member/2" do
+    test "allows access when organization kind is :app", %{conn: conn} do
+      user = %{user_fixture() | confirmed_at: nil}
+      org = app_org_fixture()
+      scope = scope_fixture(%{user: user, org: org, org_member: nil})
+
+      conn =
+        conn
+        |> assign(:current_scope, scope)
+        |> UserAuthorization.require_org_member([])
+
+      refute conn.halted
+    end
+
+    test "allows access when organization kind is :creator", %{conn: conn} do
+      user = %{user_fixture() | confirmed_at: nil}
+      org = org_fixture(%{kind: :creator})
+      scope = scope_fixture(%{user: user, org: org, org_member: nil})
+
+      conn =
+        conn
+        |> assign(:current_scope, scope)
+        |> UserAuthorization.require_org_member([])
+
+      refute conn.halted
+    end
+
+    test "allows access when user is a confirmed member of the organization", %{conn: conn} do
+      user = user_fixture()
+      org = org_fixture(%{kind: :team})
+      org_member = org_member_fixture(%{user: user, org: org})
+      scope = scope_fixture(%{user: user, org: org, org_member: org_member})
+
+      conn =
+        conn
+        |> assign(:current_scope, scope)
+        |> UserAuthorization.require_org_member([])
+
+      refute conn.halted
+    end
+
+    test "blocks access when user is not confirmed", %{conn: conn} do
+      user = %{user_fixture() | confirmed_at: nil}
+      org = org_fixture(%{kind: :team})
+      org_member = org_member_fixture(%{user: user, org: org})
+      scope = %Scope{user: user, org: org, org_member: org_member}
+
+      conn =
+        conn
+        |> assign(:current_scope, scope)
+        |> fetch_flash()
+        |> UserAuthorization.require_org_member([])
+
+      assert conn.halted
+      assert redirected_to(conn) == ~p"/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You must be a member of this organization."
+    end
+
+    test "blocks access when org_member is nil", %{conn: conn} do
+      user = user_fixture()
+      org = org_fixture(%{kind: :team})
+      scope = %Scope{user: user, org: org, org_member: nil}
+
+      conn =
+        conn
+        |> assign(:current_scope, scope)
+        |> fetch_flash()
+        |> UserAuthorization.require_org_member([])
+
+      assert conn.halted
+      assert redirected_to(conn) == ~p"/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You must be a member of this organization."
+    end
+
+    test "blocks access for school organizations when user is not a member", %{conn: conn} do
+      user = user_fixture()
+      org = org_fixture(%{kind: :school})
+      scope = %Scope{user: user, org: org, org_member: nil}
+
+      conn =
+        conn
+        |> assign(:current_scope, scope)
+        |> fetch_flash()
+        |> UserAuthorization.require_org_member([])
+
+      assert conn.halted
+      assert redirected_to(conn) == ~p"/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You must be a member of this organization."
+    end
+  end
+end

--- a/test/zoonk_web/user_authorization_test.exs
+++ b/test/zoonk_web/user_authorization_test.exs
@@ -4,6 +4,7 @@ defmodule ZoonkWeb.UserAuthorizationTest do
   import Zoonk.AccountFixtures
   import Zoonk.OrgFixtures
 
+  alias Phoenix.LiveView
   alias Zoonk.Scope
   alias ZoonkWeb.UserAuthorization
 
@@ -104,6 +105,94 @@ defmodule ZoonkWeb.UserAuthorizationTest do
       assert conn.halted
       assert redirected_to(conn) == ~p"/"
       assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You must be a member of this organization."
+    end
+  end
+
+  describe "on_mount :ensure_org_member" do
+    test "allows access when organization kind is :app" do
+      user = %{user_fixture() | confirmed_at: nil}
+      org = app_org_fixture()
+      scope = scope_fixture(%{user: user, org: org, org_member: nil})
+
+      socket = %LiveView.Socket{
+        endpoint: ZoonkWeb.Endpoint,
+        assigns: %{__changed__: %{}, flash: %{}, current_scope: scope}
+      }
+
+      assert {:cont, _socket} = UserAuthorization.on_mount(:ensure_org_member, %{}, %{}, socket)
+    end
+
+    test "allows access when organization kind is :creator" do
+      user = %{user_fixture() | confirmed_at: nil}
+      org = org_fixture(%{kind: :creator})
+      scope = scope_fixture(%{user: user, org: org, org_member: nil})
+
+      socket = %LiveView.Socket{
+        endpoint: ZoonkWeb.Endpoint,
+        assigns: %{__changed__: %{}, flash: %{}, current_scope: scope}
+      }
+
+      assert {:cont, _socket} = UserAuthorization.on_mount(:ensure_org_member, %{}, %{}, socket)
+    end
+
+    test "allows access when user is a confirmed member of the organization" do
+      user = user_fixture()
+      org = org_fixture(%{kind: :team})
+      org_member = org_member_fixture(%{user: user, org: org})
+      scope = scope_fixture(%{user: user, org: org, org_member: org_member})
+
+      socket = %LiveView.Socket{
+        endpoint: ZoonkWeb.Endpoint,
+        assigns: %{__changed__: %{}, flash: %{}, current_scope: scope}
+      }
+
+      assert {:cont, _socket} = UserAuthorization.on_mount(:ensure_org_member, %{}, %{}, socket)
+    end
+
+    test "redirects when user is not confirmed" do
+      user = %{user_fixture() | confirmed_at: nil}
+      org = org_fixture(%{kind: :team})
+      org_member = org_member_fixture(%{user: user, org: org})
+      scope = %Scope{user: user, org: org, org_member: org_member}
+
+      socket = %LiveView.Socket{
+        endpoint: ZoonkWeb.Endpoint,
+        assigns: %{__changed__: %{}, flash: %{}, current_scope: scope}
+      }
+
+      assert {:halt, redirected_socket} = UserAuthorization.on_mount(:ensure_org_member, %{}, %{}, socket)
+      assert redirected_socket.redirected == {:redirect, %{to: "/login", status: 403}}
+      assert redirected_socket.assigns.flash["error"] == "You must be a member of this organization."
+    end
+
+    test "redirects when org_member is nil" do
+      user = user_fixture()
+      org = org_fixture(%{kind: :team})
+      scope = %Scope{user: user, org: org, org_member: nil}
+
+      socket = %LiveView.Socket{
+        endpoint: ZoonkWeb.Endpoint,
+        assigns: %{__changed__: %{}, flash: %{}, current_scope: scope}
+      }
+
+      assert {:halt, redirected_socket} = UserAuthorization.on_mount(:ensure_org_member, %{}, %{}, socket)
+      assert redirected_socket.redirected == {:redirect, %{to: "/login", status: 403}}
+      assert redirected_socket.assigns.flash["error"] == "You must be a member of this organization."
+    end
+
+    test "redirects for school organizations when user is not a member" do
+      user = user_fixture()
+      org = org_fixture(%{kind: :school})
+      scope = %Scope{user: user, org: org, org_member: nil}
+
+      socket = %LiveView.Socket{
+        endpoint: ZoonkWeb.Endpoint,
+        assigns: %{__changed__: %{}, flash: %{}, current_scope: scope}
+      }
+
+      assert {:halt, redirected_socket} = UserAuthorization.on_mount(:ensure_org_member, %{}, %{}, socket)
+      assert redirected_socket.redirected == {:redirect, %{to: "/login", status: 403}}
+      assert redirected_socket.assigns.flash["error"] == "You must be a member of this organization."
     end
   end
 end


### PR DESCRIPTION
Add organization membership checks to ensure users have the necessary permissions to access certain routes. 

Refactor user authentication and authorization modules for clarity and maintainability.

Update tests to cover new authorization logic and simplify existing test structures.