### PR TITLE
Accounts: Add org member on signup

### DIFF
--- a/lib/zoonk/accounts.ex
+++ b/lib/zoonk/accounts.ex
@@ -73,13 +73,7 @@ defmodule Zoonk.Accounts do
     Ecto.Multi.new()
     |> Ecto.Multi.insert(:user, changeset)
     |> Ecto.Multi.insert(:profile, &build_initial_user_profile/1)
-    |> Ecto.Multi.insert(:org_member, fn %{user: user} ->
-      OrgMember.changeset(%OrgMember{}, %{
-        org_id: scope.org.id,
-        user_id: user.id,
-        role: :member
-      })
-    end)
+    |> Ecto.Multi.insert(:org_member, &build_org_member_changeset(&1, scope.org))
     |> Repo.transaction()
     |> Helpers.get_changeset_from_transaction(:user)
   end
@@ -316,13 +310,7 @@ defmodule Zoonk.Accounts do
     |> Ecto.Multi.insert(:user, user_changeset)
     |> Ecto.Multi.insert(:profile, &build_initial_user_profile(&1, profile_opts))
     |> Ecto.Multi.insert(:provider, &user_provider_changeset(&1, provider_attrs))
-    |> Ecto.Multi.insert(:org_member, fn %{user: user} ->
-      OrgMember.changeset(%OrgMember{}, %{
-        org_id: scope.org.id,
-        user_id: user.id,
-        role: :member
-      })
-    end)
+    |> Ecto.Multi.insert(:org_member, &build_org_member_changeset(&1, scope.org))
     |> Repo.transaction()
     |> Helpers.get_changeset_from_transaction(:user)
   end
@@ -363,5 +351,13 @@ defmodule Zoonk.Accounts do
     |> where([p], p.username == ^username)
     |> Repo.exists?()
     |> Kernel.not()
+  end
+
+  defp build_org_member_changeset(%{user: user}, org) do
+    OrgMember.changeset(%OrgMember{}, %{
+      org_id: org.id,
+      user_id: user.id,
+      role: :member
+    })
   end
 end

--- a/lib/zoonk/accounts.ex
+++ b/lib/zoonk/accounts.ex
@@ -18,6 +18,7 @@ defmodule Zoonk.Accounts do
   alias Zoonk.Config.AuthConfig
   alias Zoonk.Helpers
   alias Zoonk.Orgs.Org
+  alias Zoonk.Orgs.OrgMember
   alias Zoonk.Orgs.OrgSettings
   alias Zoonk.Repo
   alias Zoonk.Scope
@@ -72,6 +73,13 @@ defmodule Zoonk.Accounts do
     Ecto.Multi.new()
     |> Ecto.Multi.insert(:user, changeset)
     |> Ecto.Multi.insert(:profile, &build_initial_user_profile/1)
+    |> Ecto.Multi.insert(:org_member, fn %{user: user} ->
+      OrgMember.changeset(%OrgMember{}, %{
+        org_id: scope.org.id,
+        user_id: user.id,
+        role: :member
+      })
+    end)
     |> Repo.transaction()
     |> Helpers.get_changeset_from_transaction(:user)
   end
@@ -308,6 +316,13 @@ defmodule Zoonk.Accounts do
     |> Ecto.Multi.insert(:user, user_changeset)
     |> Ecto.Multi.insert(:profile, &build_initial_user_profile(&1, profile_opts))
     |> Ecto.Multi.insert(:provider, &user_provider_changeset(&1, provider_attrs))
+    |> Ecto.Multi.insert(:org_member, fn %{user: user} ->
+      OrgMember.changeset(%OrgMember{}, %{
+        org_id: scope.org.id,
+        user_id: user.id,
+        role: :member
+      })
+    end)
     |> Repo.transaction()
     |> Helpers.get_changeset_from_transaction(:user)
   end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -48,20 +48,15 @@ defmodule ZoonkWeb.ConnCase do
   def signup_and_login_user(%{conn: conn} = context) do
     user = Zoonk.AccountFixtures.user_fixture()
     app_org = Zoonk.OrgFixtures.app_org_fixture()
-    org_member = Zoonk.OrgFixtures.org_member_fixture(%{user: user, org: app_org})
-
-    scope =
-      %Zoonk.Scope{}
-      |> Zoonk.Scope.set(app_org)
-      |> Zoonk.Scope.set(user)
-      |> Zoonk.Scope.set(org_member)
 
     opts =
       context
       |> Map.take([:token_inserted_at])
       |> Enum.to_list()
 
-    %{conn: login_user(conn, user, opts), user: user, org: app_org, org_member: org_member, scope: scope}
+    conn = Map.put(conn, :host, app_org.custom_domain)
+
+    %{conn: login_user(conn, user, opts), user: user}
   end
 
   @doc """
@@ -84,29 +79,4 @@ defmodule ZoonkWeb.ConnCase do
   defp maybe_set_token_inserted_at(token, inserted_at) do
     Zoonk.AccountFixtures.override_token_inserted_at(token, inserted_at)
   end
-
-  @doc """
-  Set up helper that assigns an org to the scope.
-
-      setup :setup_org
-
-  It stores an updated connection using an org's custom
-  domain as the host and adding them to the scope.
-  """
-  def setup_org(%{conn: conn}, opts \\ []) do
-    org = get_org(Keyword.get(opts, :org_kind, :app))
-    scope = Zoonk.Scope.set(%Zoonk.Scope{}, org)
-    conn = Map.put(conn, :host, org.custom_domain)
-    %{conn: conn, org: org, scope: scope}
-  end
-
-  def setup_team(context), do: setup_org(context, org_kind: :team)
-  def setup_school(context), do: setup_org(context, org_kind: :school)
-  def setup_app(context), do: setup_org(context, org_kind: :app)
-  def setup_creator(context), do: setup_org(context, org_kind: :creator)
-
-  defp get_org(:app), do: Zoonk.OrgFixtures.app_org_fixture()
-
-  defp get_org(kind),
-    do: Zoonk.OrgFixtures.org_fixture(%{kind: kind, custom_domain: "zoonk.test-#{System.unique_integer()}"})
 end

--- a/test/support/fixtures/org_fixtures.ex
+++ b/test/support/fixtures/org_fixtures.ex
@@ -128,6 +128,6 @@ defmodule Zoonk.OrgFixtures do
 
     %OrgMember{}
     |> OrgMember.changeset(attrs)
-    |> Repo.insert!()
+    |> Repo.insert!(on_conflict: :replace_all, conflict_target: [:user_id, :org_id])
   end
 end

--- a/test/zoonk/accounts/accounts_test.exs
+++ b/test/zoonk/accounts/accounts_test.exs
@@ -10,6 +10,7 @@ defmodule Zoonk.AccountsTest do
   alias Zoonk.Accounts.UserToken
   alias Zoonk.Config.AuthConfig
   alias Zoonk.Config.SubdomainConfig
+  alias Zoonk.Orgs.OrgMember
   alias Zoonk.Repo
 
   describe "change_user_profile/2" do
@@ -107,6 +108,10 @@ defmodule Zoonk.AccountsTest do
       assert user.email == email
       assert is_nil(user.confirmed_at)
       assert Repo.get_by(UserProfile, user_id: user.id)
+
+      # Verify that an org member is created
+      org_member = Repo.get_by(OrgMember, user_id: user.id, org_id: scope.org.id)
+      assert org_member.role == :member
     end
 
     test "doesn't allow to signup to a team when sign up is not allowed" do
@@ -420,6 +425,10 @@ defmodule Zoonk.AccountsTest do
 
       assert user_profile.user_id == user.id
       assert user_profile.picture_url == picture
+
+      # Verify that an org member is created
+      org_member = Repo.get_by(OrgMember, user_id: user.id, org_id: scope.org.id)
+      assert org_member.role == :member
     end
 
     test "creates a new user for :creator orgs" do

--- a/test/zoonk_web/live/user/user_signup_with_email_live_test.exs
+++ b/test/zoonk_web/live/user/user_signup_with_email_live_test.exs
@@ -2,6 +2,7 @@ defmodule ZoonkWeb.User.SignUpWithEmailLiveTest do
   use ZoonkWeb.ConnCase, async: true
 
   import Zoonk.AccountFixtures
+  import Zoonk.OrgFixtures
 
   describe "Sign up with email page" do
     test "renders signup page", %{conn: conn} do
@@ -26,7 +27,12 @@ defmodule ZoonkWeb.User.SignUpWithEmailLiveTest do
   end
 
   describe "signs up user (:app org)" do
-    setup :setup_app
+    setup do
+      app_org = app_org_fixture()
+      conn = Map.put(build_conn(), :host, app_org.custom_domain)
+
+      %{conn: conn}
+    end
 
     test "use the browser's language", %{conn: conn} do
       conn = put_req_header(conn, "accept-language", "pt-BR")

--- a/test/zoonk_web/user_auth_test.exs
+++ b/test/zoonk_web/user_auth_test.exs
@@ -8,6 +8,7 @@ defmodule ZoonkWeb.UserAuthTest do
   alias Phoenix.Socket.Broadcast
   alias Zoonk.Accounts
   alias Zoonk.Config.AuthConfig
+  alias Zoonk.Orgs
   alias Zoonk.Scope
   alias ZoonkWeb.UserAuth
 
@@ -17,7 +18,7 @@ defmodule ZoonkWeb.UserAuthTest do
   setup %{conn: conn} do
     user = %{user_fixture() | authenticated_at: DateTime.utc_now()}
     org = app_org_fixture()
-    org_member = org_member_fixture(%{user: user, org: org})
+    org_member = Orgs.get_org_member(org, user)
 
     scope =
       %Scope{}


### PR DESCRIPTION
Implement organization member creation during user signup.

This change enhances the signup process by automatically adding new users as members of the organization they are signing up for.