### PR TITLE
UserAuth: Allow public access to catalog page

### DIFF
--- a/test/zoonk_web/permissions/public_pages_test.exs
+++ b/test/zoonk_web/permissions/public_pages_test.exs
@@ -1,0 +1,25 @@
+defmodule ZoonkWeb.PublicPagesPermissionTest do
+  use ZoonkWeb.ConnCase,
+    async: true,
+    parameterize:
+      for(
+        kind <- [:app, :creator],
+        page <- [
+          %{link: "/catalog", title: "Catalog"}
+        ],
+        do: %{kind: kind, page: page}
+      )
+
+  import Zoonk.OrgFixtures
+
+  describe "Public pages permissions" do
+    test "allows unauthenticated users to access public pages", %{conn: conn, page: page, kind: kind} do
+      org = org_fixture(%{kind: kind})
+
+      conn
+      |> Map.put(:host, org.custom_domain)
+      |> visit(page.link)
+      |> assert_has("li[aria-current='page']", text: page.title)
+    end
+  end
+end

--- a/test/zoonk_web/permissions/require_org_member_test.exs
+++ b/test/zoonk_web/permissions/require_org_member_test.exs
@@ -7,7 +7,6 @@ defmodule ZoonkWeb.RequireOrgMemberPermissionTest do
         page <- [
           %{link: "/", title: "Summary"},
           %{link: "/goals", title: "Goals"},
-          %{link: "/catalog", title: "Catalog"},
           %{link: "/library", title: "Library"},
           %{link: "/user/email", title: "Email"},
           %{link: "/user/billing", title: "Billing"},


### PR DESCRIPTION
Enable unauthenticated users to access the catalog page and add tests to verify this functionality.