### PR TITLE
Authorization: Fix permissions

### DIFF
--- a/lib/zoonk/helpers.ex
+++ b/lib/zoonk/helpers.ex
@@ -4,6 +4,54 @@ defmodule Zoonk.Helpers do
   """
 
   @doc """
+  Gets the context from a module name.
+
+  The context is the module name that comes after `Zoonk` or `ZoonkWeb`.
+
+  This is useful for some permission checks we make based on module names.
+  For example, `:org` and `:editor` contexts require admin permissions,
+  while a `:catalog` requires `:member` permissions for private organizations
+  but they are not required for public organizations.
+
+  ## Examples
+
+      iex> get_context_from_module(ZoonkWeb.Catalog.CatalogHomeLive)
+      :catalog
+
+      iex> get_context_from_module(ZoonkWeb.Org.OrgHomeLive)
+      :org
+
+      iex> get_context_from_module(Zoonk.Accounts.User)
+      :accounts
+
+      iex> get_context_from_module("ZoonkWeb.Catalog.CatalogHomeLive")
+      :catalog
+  """
+  def get_context_from_module(module) when is_atom(module) do
+    module
+    |> Module.split()
+    |> get_context_from_module()
+  end
+
+  def get_context_from_module(module) when is_binary(module) do
+    module
+    |> String.split(".")
+    |> get_context_from_module()
+  end
+
+  def get_context_from_module(["Zoonk", scope | _]), do: scope_to_atom(scope)
+  def get_context_from_module(["ZoonkWeb", scope | _]), do: scope_to_atom(scope)
+  def get_context_from_module(_), do: nil
+
+  defp scope_to_atom(scope) do
+    scope
+    |> String.downcase()
+    |> String.to_existing_atom()
+  rescue
+    ArgumentError -> nil
+  end
+
+  @doc """
   Converts a string into snake case.
 
   ## Examples

--- a/lib/zoonk/helpers.ex
+++ b/lib/zoonk/helpers.ex
@@ -39,9 +39,9 @@ defmodule Zoonk.Helpers do
     |> get_context_from_module()
   end
 
-  def get_context_from_module(["Zoonk", scope | _]), do: scope_to_atom(scope)
-  def get_context_from_module(["ZoonkWeb", scope | _]), do: scope_to_atom(scope)
-  def get_context_from_module(_), do: nil
+  def get_context_from_module(["Zoonk", scope | _rest]), do: scope_to_atom(scope)
+  def get_context_from_module(["ZoonkWeb", scope | _rest]), do: scope_to_atom(scope)
+  def get_context_from_module(_module), do: nil
 
   defp scope_to_atom(scope) do
     scope

--- a/lib/zoonk_web/user_authorization.ex
+++ b/lib/zoonk_web/user_authorization.ex
@@ -9,10 +9,12 @@ defmodule ZoonkWeb.UserAuthorization do
   use Gettext, backend: Zoonk.Gettext
 
   alias Zoonk.Accounts.User
+  alias Zoonk.Helpers
   alias Zoonk.Scope
   alias ZoonkWeb.PermissionError
 
   @admin_paths ["/editor", "/org"]
+  @admin_contexts [:editor, :org]
 
   @doc """
   Checks if the user is a confirmed member of the current organization.
@@ -95,8 +97,8 @@ defmodule ZoonkWeb.UserAuthorization do
   end
 
   def on_mount(:ensure_org_admin, _params, _session, socket) do
-    path = Phoenix.LiveView.get_connect_info(socket, :uri).path
-    on_mount_admin(socket, admin_path?: admin_path?(path), org_admin?: org_admin?(socket.assigns.scope))
+    context = Helpers.get_context_from_module(socket.view)
+    on_mount_admin(socket, admin_path?: admin_context?(context), org_admin?: org_admin?(socket.assigns.scope))
   end
 
   defp on_mount_admin(socket, admin_path?: true, org_admin?: true), do: {:cont, socket}
@@ -118,5 +120,11 @@ defmodule ZoonkWeb.UserAuthorization do
 
   defp admin_path?(path) do
     Enum.any?(@admin_paths, &String.starts_with?(path, &1))
+  end
+
+  defp admin_context?(nil), do: false
+
+  defp admin_context?(context) do
+    Enum.member?(@admin_contexts, context)
   end
 end

--- a/test/zoonk/helpers_test.exs
+++ b/test/zoonk/helpers_test.exs
@@ -3,6 +3,35 @@ defmodule Zoonk.HelpersTest do
 
   import Zoonk.Helpers
 
+  describe "get_context_from_module/1" do
+    test "returns the scope for ZoonkWeb modules" do
+      assert :catalog = get_context_from_module(ZoonkWeb.Catalog.CatalogHomeLive)
+      assert :org = get_context_from_module(ZoonkWeb.Org.OrgHomeLive)
+      assert :library = get_context_from_module(ZoonkWeb.Library)
+    end
+
+    test "returns the scope for Zoonk modules" do
+      assert :accounts = get_context_from_module(Zoonk.Accounts.User)
+      assert :locations = get_context_from_module(Zoonk.Locations.Country)
+      assert :library = get_context_from_module(Zoonk.Library)
+    end
+
+    test "returns the scope for string module names" do
+      assert :catalog = get_context_from_module("ZoonkWeb.Catalog.CatalogHomeLive")
+      assert :accounts = get_context_from_module("Zoonk.Accounts.User")
+      assert :locations = get_context_from_module("Zoonk.Locations")
+    end
+
+    test "returns nil for invalid modules" do
+      refute get_context_from_module(InvalidModule)
+      refute get_context_from_module("InvalidModule")
+    end
+
+    test "returns nil for inexisting atoms" do
+      refute get_context_from_module(Zoonk.ThisModuleDoesNotExist.Test)
+    end
+  end
+
   describe "to_snake_case/1" do
     test "converts a string with spaces to snake case" do
       assert to_snake_case("Hello World") == "hello_world"

--- a/test/zoonk_web/user_auth_test.exs
+++ b/test/zoonk_web/user_auth_test.exs
@@ -221,7 +221,10 @@ defmodule ZoonkWeb.UserAuthTest do
         |> get_session()
 
       {:cont, updated_socket} =
-        UserAuth.on_mount(:ensure_authenticated, %{}, session, %LiveView.Socket{private: %{connect_info: conn}})
+        UserAuth.on_mount(:ensure_authenticated, %{}, session, %LiveView.Socket{
+          view: ZoonkWeb.ValidUserToken,
+          private: %{connect_info: conn}
+        })
 
       assert updated_socket.assigns.scope.user.id == user.id
     end
@@ -235,6 +238,7 @@ defmodule ZoonkWeb.UserAuthTest do
         |> get_session()
 
       socket = %LiveView.Socket{
+        view: ZoonkWeb.NoValidUserTokenLive,
         endpoint: ZoonkWeb.Endpoint,
         assigns: %{__changed__: %{}, flash: %{}},
         private: %{connect_info: conn, live_temp: %{}}
@@ -248,6 +252,7 @@ defmodule ZoonkWeb.UserAuthTest do
       session = get_session(conn)
 
       socket = %LiveView.Socket{
+        view: ZoonkWeb.NoUserTokenLive,
         endpoint: ZoonkWeb.Endpoint,
         assigns: %{__changed__: %{}, flash: %{}},
         private: %{connect_info: conn, live_temp: %{}}

--- a/test/zoonk_web/user_authorization_test.exs
+++ b/test/zoonk_web/user_authorization_test.exs
@@ -316,9 +316,9 @@ defmodule ZoonkWeb.UserAuthorizationTest do
       scope = scope_fixture(%{user: user, org: org, org_member: org_member})
 
       socket = %LiveView.Socket{
+        view: ZoonkWeb.AppHomeLive,
         endpoint: ZoonkWeb.Endpoint,
-        assigns: %{__changed__: %{}, flash: %{}, scope: scope},
-        private: %{connect_info: %{uri: %URI{path: "/dashboard"}}}
+        assigns: %{__changed__: %{}, flash: %{}, scope: scope}
       }
 
       assert {:cont, _socket} = UserAuthorization.on_mount(:ensure_org_admin, %{}, %{}, socket)
@@ -331,9 +331,9 @@ defmodule ZoonkWeb.UserAuthorizationTest do
       scope = scope_fixture(%{user: user, org: org, org_member: org_member})
 
       socket = %LiveView.Socket{
+        view: DocumentsLive,
         endpoint: ZoonkWeb.Endpoint,
-        assigns: %{__changed__: %{}, flash: %{}, scope: scope},
-        private: %{connect_info: %{uri: %URI{path: "/editor/documents"}}}
+        assigns: %{__changed__: %{}, flash: %{}, scope: scope}
       }
 
       assert {:cont, _socket} = UserAuthorization.on_mount(:ensure_org_admin, %{}, %{}, socket)
@@ -346,9 +346,9 @@ defmodule ZoonkWeb.UserAuthorizationTest do
       scope = scope_fixture(%{user: user, org: org, org_member: org_member})
 
       socket = %LiveView.Socket{
+        view: ZoonkWeb.Org.OrgSettingsLive,
         endpoint: ZoonkWeb.Endpoint,
-        assigns: %{__changed__: %{}, flash: %{}, scope: scope},
-        private: %{connect_info: %{uri: %URI{path: "/org/settings"}}}
+        assigns: %{__changed__: %{}, flash: %{}, scope: scope}
       }
 
       assert {:cont, _socket} = UserAuthorization.on_mount(:ensure_org_admin, %{}, %{}, socket)
@@ -361,9 +361,9 @@ defmodule ZoonkWeb.UserAuthorizationTest do
       scope = scope_fixture(%{user: user, org: org, org_member: org_member})
 
       socket = %LiveView.Socket{
+        view: ZoonkWeb.Editor.NotAdminLive,
         endpoint: ZoonkWeb.Endpoint,
-        assigns: %{__changed__: %{}, flash: %{}, scope: scope},
-        private: %{connect_info: %{uri: %URI{path: "/editor/documents"}}}
+        assigns: %{__changed__: %{}, flash: %{}, scope: scope}
       }
 
       assert_raise ZoonkWeb.PermissionError, fn ->
@@ -378,9 +378,9 @@ defmodule ZoonkWeb.UserAuthorizationTest do
       scope = scope_fixture(%{user: user, org: org, org_member: org_member})
 
       socket = %LiveView.Socket{
+        view: ZoonkWeb.Org.OrgHomeLive,
         endpoint: ZoonkWeb.Endpoint,
-        assigns: %{__changed__: %{}, flash: %{}, scope: scope},
-        private: %{connect_info: %{uri: %URI{path: "/org/settings"}}}
+        assigns: %{__changed__: %{}, flash: %{}, scope: scope}
       }
 
       assert_raise ZoonkWeb.PermissionError, fn ->
@@ -395,9 +395,9 @@ defmodule ZoonkWeb.UserAuthorizationTest do
       scope = %Scope{user: user, org: org, org_member: org_member}
 
       socket = %LiveView.Socket{
+        view: ZoonkWeb.Org.NotConfirmedUserLive,
         endpoint: ZoonkWeb.Endpoint,
-        assigns: %{__changed__: %{}, flash: %{}, scope: scope},
-        private: %{connect_info: %{uri: %URI{path: "/editor/documents"}}}
+        assigns: %{__changed__: %{}, flash: %{}, scope: scope}
       }
 
       assert_raise ZoonkWeb.PermissionError, fn ->
@@ -411,9 +411,9 @@ defmodule ZoonkWeb.UserAuthorizationTest do
       scope = %Scope{user: user, org: org, org_member: nil}
 
       socket = %LiveView.Socket{
+        view: ZoonkWeb.Org.NotMemberLive,
         endpoint: ZoonkWeb.Endpoint,
-        assigns: %{__changed__: %{}, flash: %{}, scope: scope},
-        private: %{connect_info: %{uri: %URI{path: "/editor/documents"}}}
+        assigns: %{__changed__: %{}, flash: %{}, scope: scope}
       }
 
       assert_raise ZoonkWeb.PermissionError, fn ->
@@ -428,9 +428,9 @@ defmodule ZoonkWeb.UserAuthorizationTest do
       scope = scope_fixture(%{user: user, org: org, org_member: org_member})
 
       socket = %LiveView.Socket{
+        view: ZoonkWeb.Org.NotAdminLive,
         endpoint: ZoonkWeb.Endpoint,
-        assigns: %{__changed__: %{}, flash: %{}, scope: scope},
-        private: %{connect_info: %{uri: %URI{path: "/editor/documents"}}}
+        assigns: %{__changed__: %{}, flash: %{}, scope: scope}
       }
 
       assert_raise ZoonkWeb.PermissionError, fn ->


### PR DESCRIPTION
We can't use LiveView's path to check specific permissions for a route, so we're using a module's context instead.