### PR TITLE
Onboarding: Permissions handling

### DIFF
--- a/lib/zoonk_web/live/onboarding/onboarding_permissions.ex
+++ b/lib/zoonk_web/live/onboarding/onboarding_permissions.ex
@@ -1,0 +1,14 @@
+defmodule ZoonkWeb.Onboarding.OnboardingPermissions do
+  @moduledoc false
+  use ZoonkWeb, :verified_routes
+
+  alias Zoonk.Orgs.Org
+  alias Zoonk.Scope
+
+  def on_mount(:onboarding_permissions, _params, _session, socket) do
+    handle_permissions(socket, socket.assigns.scope)
+  end
+
+  defp handle_permissions(socket, %Scope{org: %Org{kind: :app}, user: nil}), do: {:cont, socket}
+  defp handle_permissions(socket, _scope), do: {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/")}
+end

--- a/lib/zoonk_web/live/onboarding/onboarding_start_live.ex
+++ b/lib/zoonk_web/live/onboarding/onboarding_start_live.ex
@@ -2,6 +2,8 @@ defmodule ZoonkWeb.Onboarding.OnboardingStartLive do
   @moduledoc false
   use ZoonkWeb, :live_view
 
+  on_mount {ZoonkWeb.Onboarding.OnboardingPermissions, :onboarding_permissions}
+
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""

--- a/lib/zoonk_web/live/onboarding/onboarding_start_live.ex
+++ b/lib/zoonk_web/live/onboarding/onboarding_start_live.ex
@@ -1,0 +1,20 @@
+defmodule ZoonkWeb.Onboarding.OnboardingStartLive do
+  @moduledoc false
+  use ZoonkWeb, :live_view
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <div>
+      placeholder for onboarding
+      <h1>{dgettext("onboarding", "Get Started")}</h1>
+    </div>
+    """
+  end
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    socket = assign(socket, :page_title, dgettext("onboarding", "Get Started"))
+    {:ok, socket}
+  end
+end

--- a/lib/zoonk_web/router.ex
+++ b/lib/zoonk_web/router.ex
@@ -55,6 +55,8 @@ defmodule ZoonkWeb.Router do
       ] do
       live "/", AppHomeLive
 
+      live "/start", Onboarding.OnboardingStartLive
+
       live "/goals", Goals.GoalsHomeLive
 
       live "/catalog", Catalog.CatalogHomeLive

--- a/lib/zoonk_web/router.ex
+++ b/lib/zoonk_web/router.ex
@@ -55,8 +55,6 @@ defmodule ZoonkWeb.Router do
       ] do
       live "/", AppHomeLive
 
-      live "/start", Onboarding.OnboardingStartLive
-
       live "/goals", Goals.GoalsHomeLive
 
       live "/catalog", Catalog.CatalogHomeLive
@@ -86,6 +84,8 @@ defmodule ZoonkWeb.Router do
         {UserAuth, :mount_scope},
         {ZoonkWeb.Language, :set_app_language}
       ] do
+      live "/start", Onboarding.OnboardingStartLive
+
       live "/signup", User.UserSignUpLive
       live "/signup/email", User.UserSignUpWithEmailLive
       live "/login", User.UserLoginLive

--- a/lib/zoonk_web/user_auth.ex
+++ b/lib/zoonk_web/user_auth.ex
@@ -24,7 +24,7 @@ defmodule ZoonkWeb.UserAuth do
   @remember_me_options [sign: true, max_age: @max_age, same_site: "Lax"]
 
   @public_paths ["/catalog"]
-  @public_contexts [:catalog, :onboarding]
+  @public_contexts [:catalog]
 
   @doc """
   Logs the user in.

--- a/lib/zoonk_web/user_auth.ex
+++ b/lib/zoonk_web/user_auth.ex
@@ -22,8 +22,8 @@ defmodule ZoonkWeb.UserAuth do
   @remember_me_cookie AuthConfig.get_cookie_name(:remember_me)
   @remember_me_options [sign: true, max_age: @max_age, same_site: "Lax"]
 
-  @public_paths ["/catalog"]
-  @public_contexts [:catalog]
+  @public_paths ["/catalog", "/start"]
+  @public_contexts [:catalog, :onboarding]
 
   @doc """
   Logs the user in.

--- a/lib/zoonk_web/user_auth.ex
+++ b/lib/zoonk_web/user_auth.ex
@@ -165,12 +165,12 @@ defmodule ZoonkWeb.UserAuth do
   def on_mount(:ensure_authenticated, _params, session, socket) do
     socket = mount_scope(socket, session)
     context = Helpers.get_context_from_module(socket.view)
-    looged_in? = socket.assigns.scope && socket.assigns.scope.user
+    logged_in? = socket.assigns.scope && socket.assigns.scope.user
 
-    if public_context?(context) or looged_in? do
+    if public_context?(context) or logged_in? do
       {:cont, socket}
     else
-      socket = Phoenix.LiveView.redirect(socket, to: unauthenticated_path(socket.assigns.scope))
+      socket = Phoenix.LiveView.redirect(socket, to: unauthenticated_path(socket.assigns.scope, nil))
 
       {:halt, socket}
     end
@@ -217,7 +217,7 @@ defmodule ZoonkWeb.UserAuth do
     else
       conn
       |> maybe_store_return_to()
-      |> redirect(to: unauthenticated_path(conn.assigns.scope))
+      |> redirect(to: unauthenticated_path(conn.assigns.scope, conn.request_path))
       |> halt()
     end
   end
@@ -258,9 +258,10 @@ defmodule ZoonkWeb.UserAuth do
 
   def signed_in_path(_conn), do: ~p"/"
 
-  defp unauthenticated_path(%Scope{org: %Org{kind: :app}}), do: ~p"/start"
-  defp unauthenticated_path(%Scope{org: %Org{kind: :creator}}), do: ~p"/catalog"
-  defp unauthenticated_path(_scope), do: ~p"/login"
+  defp unauthenticated_path(_scope, "/user" <> _rest), do: ~p"/login"
+  defp unauthenticated_path(%Scope{org: %Org{kind: :app}}, _path), do: ~p"/start"
+  defp unauthenticated_path(%Scope{org: %Org{kind: :creator}}, _path), do: ~p"/catalog"
+  defp unauthenticated_path(_scope, _path), do: ~p"/login"
 
   defp build_scope(user, host) do
     org = Orgs.get_org_by_host(host)

--- a/lib/zoonk_web/user_auth.ex
+++ b/lib/zoonk_web/user_auth.ex
@@ -23,7 +23,7 @@ defmodule ZoonkWeb.UserAuth do
   @remember_me_cookie AuthConfig.get_cookie_name(:remember_me)
   @remember_me_options [sign: true, max_age: @max_age, same_site: "Lax"]
 
-  @public_paths ["/catalog", "/start"]
+  @public_paths ["/catalog"]
   @public_contexts [:catalog, :onboarding]
 
   @doc """

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -79,4 +79,12 @@ defmodule ZoonkWeb.ConnCase do
   defp maybe_set_token_inserted_at(token, inserted_at) do
     Zoonk.AccountFixtures.override_token_inserted_at(token, inserted_at)
   end
+
+  @doc """
+  Returns the path to redirect unauthenticated users.
+  """
+  def redirect_path(_kind, "/user" <> _path), do: "/login"
+  def redirect_path(:app, _path), do: "/start"
+  def redirect_path(:creator, _path), do: "/catalog"
+  def redirect_path(_kind, _path), do: "/login"
 end

--- a/test/zoonk_web/live/app_home_live_test.exs
+++ b/test/zoonk_web/live/app_home_live_test.exs
@@ -1,0 +1,35 @@
+defmodule ZoonkWeb.AppHomeLiveTest do
+  use ZoonkWeb.ConnCase, async: true
+
+  import Zoonk.OrgFixtures
+
+  describe "app home page (unauthenticated)" do
+    test "redirects to onboarding for :app org" do
+      build_conn()
+      |> Map.put(:host, app_org_fixture().custom_domain)
+      |> visit(~p"/")
+      |> assert_path(~p"/start")
+    end
+
+    test "redirects to catalog for :creator org" do
+      build_conn()
+      |> Map.put(:host, org_fixture(%{kind: :creator}).custom_domain)
+      |> visit(~p"/")
+      |> assert_path(~p"/catalog")
+    end
+
+    test "redirects to login for :team org" do
+      build_conn()
+      |> Map.put(:host, org_fixture(%{kind: :team}).custom_domain)
+      |> visit(~p"/")
+      |> assert_path(~p"/login")
+    end
+
+    test "redirects to login for :school org" do
+      build_conn()
+      |> Map.put(:host, org_fixture(%{kind: :school}).custom_domain)
+      |> visit(~p"/")
+      |> assert_path(~p"/login")
+    end
+  end
+end

--- a/test/zoonk_web/live/onboarding/onboarding_start_live_test.exs
+++ b/test/zoonk_web/live/onboarding/onboarding_start_live_test.exs
@@ -1,0 +1,45 @@
+defmodule ZoonkWeb.OnboardingStartLiveTest do
+  use ZoonkWeb.ConnCase, async: true
+
+  import Zoonk.OrgFixtures
+
+  describe "onboarding start page (unauthenticated)" do
+    test "renders page for :app org" do
+      build_conn()
+      |> Map.put(:host, app_org_fixture().custom_domain)
+      |> visit(~p"/start")
+      |> assert_has("h1", text: "Get Started")
+    end
+
+    test "redirects page for :creator org" do
+      build_conn()
+      |> Map.put(:host, org_fixture(%{kind: :creator}).custom_domain)
+      |> visit(~p"/start")
+      |> assert_path(~p"/catalog")
+    end
+
+    test "redirects page for :team org" do
+      build_conn()
+      |> Map.put(:host, org_fixture(%{kind: :team}).custom_domain)
+      |> visit(~p"/start")
+      |> assert_path(~p"/login")
+    end
+
+    test "redirects page for :school org" do
+      build_conn()
+      |> Map.put(:host, org_fixture(%{kind: :school}).custom_domain)
+      |> visit(~p"/start")
+      |> assert_path(~p"/login")
+    end
+  end
+
+  describe "onboarding start page (authenticated)" do
+    setup :signup_and_login_user
+
+    test "redirects to the home page", %{conn: conn} do
+      conn
+      |> visit(~p"/start")
+      |> assert_path(~p"/")
+    end
+  end
+end

--- a/test/zoonk_web/live/user/user_email_live_test.exs
+++ b/test/zoonk_web/live/user/user_email_live_test.exs
@@ -78,7 +78,6 @@ defmodule ZoonkWeb.User.UserEmailLiveTest do
       build_conn()
       |> visit(~p"/user/email/confirm/#{token}")
       |> assert_path(~p"/login")
-      |> assert_has("div", text: "You must log in to access this page.")
     end
   end
 end

--- a/test/zoonk_web/permissions/public_pages_test.exs
+++ b/test/zoonk_web/permissions/public_pages_test.exs
@@ -5,7 +5,6 @@ defmodule ZoonkWeb.PublicPagesPermissionTest do
       for(
         kind <- [:app, :creator],
         page <- [
-          %{link: "/start", title: "Get Started"},
           %{link: "/catalog", menu: "Catalog"}
         ],
         do: %{kind: kind, page: page}

--- a/test/zoonk_web/permissions/public_pages_test.exs
+++ b/test/zoonk_web/permissions/public_pages_test.exs
@@ -5,7 +5,8 @@ defmodule ZoonkWeb.PublicPagesPermissionTest do
       for(
         kind <- [:app, :creator],
         page <- [
-          %{link: "/catalog", title: "Catalog"}
+          %{link: "/start", title: "Get Started"},
+          %{link: "/catalog", menu: "Catalog"}
         ],
         do: %{kind: kind, page: page}
       )
@@ -19,7 +20,15 @@ defmodule ZoonkWeb.PublicPagesPermissionTest do
       conn
       |> Map.put(:host, org.custom_domain)
       |> visit(page.link)
-      |> assert_has("li[aria-current='page']", text: page.title)
+      |> assert_page(page)
     end
+  end
+
+  defp assert_page(session, %{menu: menu}) do
+    assert_has(session, "li[aria-current='page']", text: menu)
+  end
+
+  defp assert_page(session, %{title: title}) do
+    assert_has(session, "h1", text: title)
   end
 end

--- a/test/zoonk_web/permissions/public_pages_test.exs
+++ b/test/zoonk_web/permissions/public_pages_test.exs
@@ -19,15 +19,7 @@ defmodule ZoonkWeb.PublicPagesPermissionTest do
       conn
       |> Map.put(:host, org.custom_domain)
       |> visit(page.link)
-      |> assert_page(page)
+      |> assert_has("li[aria-current='page']", text: page.menu)
     end
-  end
-
-  defp assert_page(session, %{menu: menu}) do
-    assert_has(session, "li[aria-current='page']", text: menu)
-  end
-
-  defp assert_page(session, %{title: title}) do
-    assert_has(session, "h1", text: title)
   end
 end

--- a/test/zoonk_web/permissions/require_org_admin_test.exs
+++ b/test/zoonk_web/permissions/require_org_admin_test.exs
@@ -5,12 +5,12 @@ defmodule ZoonkWeb.RequireOrgAdminPermissionTest do
       for(
         kind <- [:app, :creator, :team, :school],
         page <- [
-          %{link: "/org", title: "Overview"},
-          %{link: "/org/teams", title: "Teams"},
-          %{link: "/org/members", title: "Members"},
-          %{link: "/org/settings", title: "Settings"},
-          %{link: "/editor", title: "Dashboard"},
-          %{link: "/editor/new", title: "Create New"}
+          %{link: "/org", menu: "Overview"},
+          %{link: "/org/teams", menu: "Teams"},
+          %{link: "/org/members", menu: "Members"},
+          %{link: "/org/settings", menu: "Settings"},
+          %{link: "/editor", menu: "Dashboard"},
+          %{link: "/editor/new", menu: "Create New"}
         ],
         do: %{kind: kind, page: page}
       )
@@ -39,7 +39,7 @@ defmodule ZoonkWeb.RequireOrgAdminPermissionTest do
       |> Map.put(:host, org.custom_domain)
       |> login_user(user)
       |> visit(page.link)
-      |> assert_has("li[aria-current='page']", text: page.title)
+      |> assert_has("li[aria-current='page']", text: page.menu)
     end
 
     test "raises error for users with member role", %{conn: conn, page: page, kind: kind} do

--- a/test/zoonk_web/permissions/require_org_admin_test.exs
+++ b/test/zoonk_web/permissions/require_org_admin_test.exs
@@ -27,7 +27,7 @@ defmodule ZoonkWeb.RequireOrgAdminPermissionTest do
       conn
       |> Map.put(:host, org.custom_domain)
       |> visit(page.link)
-      |> assert_path(~p"/login")
+      |> assert_path(redirect_path(kind, page.link))
     end
 
     test "allows access for users with admin role", %{conn: conn, page: page, kind: kind} do

--- a/test/zoonk_web/permissions/require_org_member_test.exs
+++ b/test/zoonk_web/permissions/require_org_member_test.exs
@@ -27,7 +27,7 @@ defmodule ZoonkWeb.RequireOrgMemberPermissionTest do
       conn
       |> Map.put(:host, org.custom_domain)
       |> visit(page.link)
-      |> assert_path(~p"/login")
+      |> assert_path(redirect_path(kind, page.link))
     end
 
     test "allows access without membership for public organizations", %{conn: conn, page: page, kind: kind} do

--- a/test/zoonk_web/permissions/require_org_member_test.exs
+++ b/test/zoonk_web/permissions/require_org_member_test.exs
@@ -5,12 +5,12 @@ defmodule ZoonkWeb.RequireOrgMemberPermissionTest do
       for(
         kind <- [:app, :creator, :team, :school],
         page <- [
-          %{link: "/", title: "Summary"},
-          %{link: "/goals", title: "Goals"},
-          %{link: "/library", title: "Library"},
-          %{link: "/user/email", title: "Email"},
-          %{link: "/user/billing", title: "Billing"},
-          %{link: "/user/interests", title: "Interests"}
+          %{link: "/", menu: "Summary"},
+          %{link: "/goals", menu: "Goals"},
+          %{link: "/library", menu: "Library"},
+          %{link: "/user/email", menu: "Email"},
+          %{link: "/user/billing", menu: "Billing"},
+          %{link: "/user/interests", menu: "Interests"}
         ],
         do: %{kind: kind, page: page}
       )
@@ -39,7 +39,7 @@ defmodule ZoonkWeb.RequireOrgMemberPermissionTest do
         |> Map.put(:host, org.custom_domain)
         |> login_user(user)
         |> visit(page.link)
-        |> assert_has("li[aria-current='page']", text: page.title)
+        |> assert_has("li[aria-current='page']", text: page.menu)
       end
     end
 
@@ -53,7 +53,7 @@ defmodule ZoonkWeb.RequireOrgMemberPermissionTest do
         |> Map.put(:host, org.custom_domain)
         |> login_user(user)
         |> visit(page.link)
-        |> assert_has("li[aria-current='page']", text: page.title)
+        |> assert_has("li[aria-current='page']", text: page.menu)
       end
     end
 
@@ -67,7 +67,7 @@ defmodule ZoonkWeb.RequireOrgMemberPermissionTest do
         |> Map.put(:host, org.custom_domain)
         |> login_user(user)
         |> visit(page.link)
-        |> assert_has("li[aria-current='page']", text: page.title)
+        |> assert_has("li[aria-current='page']", text: page.menu)
       end
     end
 

--- a/test/zoonk_web/user_auth_test.exs
+++ b/test/zoonk_web/user_auth_test.exs
@@ -355,8 +355,7 @@ defmodule ZoonkWeb.UserAuthTest do
         |> UserAuth.require_authenticated_user([])
 
       assert conn.halted
-      assert redirected_to(conn) == ~p"/login"
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You must log in to access this page."
+      assert redirected_to(conn) == redirect_path(:app, nil)
     end
 
     test "stores the path to redirect to on GET", %{conn: conn} do


### PR DESCRIPTION
Introduce an onboarding page with appropriate routing and permissions handling for different organization types. 

This is backend work only. I'm working on the frontend implementation for this closer to v0.1.