### PR TITLE
Onboarding: Add login and signup button links

### DIFF
--- a/.github/copilot/components.md
+++ b/.github/copilot/components.md
@@ -17,3 +17,4 @@
 - For components with inner blocks, use `{render_slot(@inner_block)}` to render the inner block. Never use only {@inner_block} or <%= @inner_block %> or <%= render_slot(@inner_block) %>.
 - Make sure your components are accessible.
 - When creating a component inside `lib/zoonk_web/components`, use `use Phoenix.Component` instead of `ZoonkWeb, :html` to avoid circular dependencies. Then, import each individua component you need. For example, `import ZoonkWeb.Components.Text` to use the `<.text>` component. When you need to use a shared component outside of `lib/zoonk_web/components`, then you can use `ZoonkWeb, :html` to import all components.
+- When asking to use a link styled as a button, use the `<.a kind={:button}>` component from `lib/zoonk_web/components/anchor.ex`.

--- a/lib/zoonk_web/live/onboarding/onboarding_start_live.ex
+++ b/lib/zoonk_web/live/onboarding/onboarding_start_live.ex
@@ -8,6 +8,16 @@ defmodule ZoonkWeb.Onboarding.OnboardingStartLive do
   def render(assigns) do
     ~H"""
     <main class="h-dvh flex w-full items-center justify-center p-4">
+      <div class="absolute top-4 right-4">
+        <.a kind={:button} size={:sm} navigate={~p"/login"}>
+          {gettext("Login")}
+        </.a>
+
+        <.a kind={:button} variant={:outline} size={:sm} navigate={~p"/signup"}>
+          {gettext("Sign Up")}
+        </.a>
+      </div>
+
       <div class="flex w-full max-w-lg flex-col items-center gap-4 text-center">
         <.text tag="h1" size={:xxl}>
           {dgettext("onboarding", "What do you want to learn?")}


### PR DESCRIPTION
Introduce button links for login and signup on the onboarding page.

Closes #37