### PR TITLE
Accounts: Convert guest user into regular one

### DIFF
--- a/lib/zoonk/accounts.ex
+++ b/lib/zoonk/accounts.ex
@@ -161,9 +161,11 @@ defmodule Zoonk.Accounts do
 
   defp user_email_multi(user, email, context) do
     changeset = User.email_changeset(user, %{email: email})
+    confirm = User.confirm_changeset(user)
 
     Ecto.Multi.new()
     |> Ecto.Multi.update(:user, changeset)
+    |> Ecto.Multi.update(:confirm, confirm)
     |> Ecto.Multi.delete_all(:tokens, UserToken.by_user_and_contexts_query(user, [context]))
   end
 

--- a/lib/zoonk/accounts/user.ex
+++ b/lib/zoonk/accounts/user.ex
@@ -14,7 +14,7 @@ defmodule Zoonk.Accounts.User do
   | Type | Description |
   |------|-------------|
   | `:regular` | Regular users. |
-  | `:agent` | AI bots and agents. |
+  | `:guest` | Users who didn't sign up. |
 
   ## Fields
 
@@ -22,7 +22,7 @@ defmodule Zoonk.Accounts.User do
   |------------|------|-------------|
   | `year_of_birth` | `Integer` | We need the year of birth for legal reasons when a profile is public. |
   | `currency` | `Ecto.Enum` | The currency used for payments. |
-  | `kind` | `Ecto.Enum` | Users can have different types: `regular`, `guest`, `agent` |
+  | `kind` | `Ecto.Enum` | Users can have different types: `regular`, `guest` |
   | `email` | `String` | The user's email address. |
   | `stripe_customer_id` | `String` | Customer ID used for Stripe payments. |
   | `tax_id` | `Zoonk.Vault.Binary` | Tax ID required by some jurisdictions. |
@@ -147,7 +147,7 @@ defmodule Zoonk.Accounts.User do
   """
   def confirm_changeset(user) do
     now = DateTime.utc_now()
-    change(user, confirmed_at: now)
+    change(user, confirmed_at: now, kind: :regular)
   end
 
   @doc """

--- a/lib/zoonk_web/live/user/user_email_live.ex
+++ b/lib/zoonk_web/live/user/user_email_live.ex
@@ -87,7 +87,6 @@ defmodule ZoonkWeb.User.UserEmailLive do
   def handle_event("update_email", params, socket) do
     %{"user" => user_params} = params
     user = socket.assigns.scope.user
-    true = Accounts.sudo_mode?(user)
 
     case Accounts.change_user_email(user, user_params) do
       %{valid?: true} = changeset ->

--- a/test/zoonk_web/live/user/user_email_live_test.exs
+++ b/test/zoonk_web/live/user/user_email_live_test.exs
@@ -2,10 +2,12 @@ defmodule ZoonkWeb.User.UserEmailLiveTest do
   use ZoonkWeb.ConnCase, async: true
 
   import Zoonk.AccountFixtures
+  import Zoonk.OrgFixtures
 
   alias Zoonk.Accounts
+  alias Zoonk.Scope
 
-  describe "update email form" do
+  describe "update email form (regular user)" do
     setup :signup_and_login_user
 
     test "updates the user email", %{conn: conn, user: user} do
@@ -33,6 +35,28 @@ defmodule ZoonkWeb.User.UserEmailLiveTest do
       |> fill_in("Email address", with: user.email)
       |> submit()
       |> assert_has("p", text: "did not change")
+    end
+  end
+
+  describe "update email form (guest user)" do
+    setup do
+      app_org = app_org_fixture()
+      conn = Map.put(build_conn(), :host, app_org.custom_domain)
+      %{conn: conn, org: app_org}
+    end
+
+    test "updates the user email", %{conn: conn, org: org} do
+      {:ok, user} = Accounts.create_guest_user(%{language: "en"}, %Scope{org: org, user: nil})
+      new_email = unique_user_email()
+
+      conn
+      |> login_user(user)
+      |> visit(~p"/user/email")
+      |> fill_in("Email address", with: new_email)
+      |> submit()
+      |> assert_has("div", text: "A link to confirm your email")
+
+      assert Accounts.get_user_by_email(user.email)
     end
   end
 
@@ -78,6 +102,33 @@ defmodule ZoonkWeb.User.UserEmailLiveTest do
       build_conn()
       |> visit(~p"/user/email/confirm/#{token}")
       |> assert_path(~p"/login")
+    end
+  end
+
+  describe "confirm email (guest user)" do
+    setup %{conn: conn} do
+      org = app_org_fixture()
+      conn = Map.put(conn, :host, org.custom_domain)
+      {:ok, user} = Accounts.create_guest_user(%{language: "en"}, %Scope{org: org, user: nil})
+      email = unique_user_email()
+
+      token =
+        extract_user_token(fn url ->
+          Accounts.deliver_user_update_email_instructions(%{user | email: email}, user.email, url)
+        end)
+
+      %{conn: login_user(conn, user), token: token, email: email, user: user}
+    end
+
+    test "converts to a regular user", %{conn: conn, user: user, token: token, email: email} do
+      conn
+      |> visit(~p"/user/email/confirm/#{token}")
+      |> assert_path(~p"/user/email")
+      |> assert_has("div", text: "Email changed successfully.")
+
+      refute Accounts.get_user_by_email(user.email)
+      user = Accounts.get_user_by_email(email)
+      assert user.kind == :regular
     end
   end
 end


### PR DESCRIPTION
When a user updates - and confirms - their email address, we convert them into a regular user.