### PR TITLE
Accounts: Implement OTP

### DIFF
--- a/lib/zoonk/accounts.ex
+++ b/lib/zoonk/accounts.ex
@@ -170,10 +170,10 @@ defmodule Zoonk.Accounts do
   end
 
   @doc """
-  Gets the user with the given magic link token.
+  Gets the user with the given OTP code.
   """
-  def get_user_by_magic_link_token(token) do
-    with {:ok, query} <- UserToken.verify_magic_link_token_query(token),
+  def get_user_by_otp_code(otp_code) do
+    with {:ok, query} <- UserToken.verify_otp_code_query(otp_code),
          {user, _token} <- Repo.one(query) do
       user
     else
@@ -182,20 +182,20 @@ defmodule Zoonk.Accounts do
   end
 
   @doc """
-  Logs the user in by magic link.
+  Logs the user in by OTP code.
 
   There are three cases to consider:
 
   1. The user has already confirmed their email. They are logged in
-     and the magic link is expired.
+     and the OTP code is expired.
 
   2. The user has not confirmed their email.
      In this case, the user gets confirmed, logged in, and all tokens -
      including session ones - are expired. In theory, no other tokens
      exist but we delete all of them for best security practices.
   """
-  def login_user_by_magic_link(token) do
-    {:ok, query} = UserToken.verify_magic_link_token_query(token)
+  def login_user_by_otp(otp_code) do
+    {:ok, query} = UserToken.verify_otp_code_query(otp_code)
 
     case Repo.one(query) do
       {%User{confirmed_at: nil} = user, _token} ->
@@ -221,21 +221,20 @@ defmodule Zoonk.Accounts do
       {:ok, %{to: ..., body: ...}}
 
   """
-  def deliver_user_update_email_instructions(%User{} = user, current_email, update_email_url_fun)
-      when is_function(update_email_url_fun, 1) do
-    {encoded_token, user_token} = UserToken.build_email_token(user, "change:#{current_email}")
+  def deliver_user_update_email_instructions(%User{} = user, current_email) do
+    {otp_code, user_token} = UserToken.build_otp_code(user, "change:#{current_email}")
 
     Repo.insert!(user_token)
-    UserNotifier.deliver_update_email_instructions(user, update_email_url_fun.(encoded_token))
+    UserNotifier.deliver_update_email_instructions(user, otp_code)
   end
 
   @doc ~S"""
-  Delivers the magic link login instructions to the given user.
+  Delivers the OTP code login instructions to the given user.
   """
-  def deliver_login_instructions(%User{} = user, magic_link_url_fun) when is_function(magic_link_url_fun, 1) do
-    {encoded_token, user_token} = UserToken.build_email_token(user, "login")
+  def deliver_login_instructions(%User{} = user) do
+    {otp_code, user_token} = UserToken.build_otp_code(user, "login")
     Repo.insert!(user_token)
-    UserNotifier.deliver_login_instructions(user, magic_link_url_fun.(encoded_token))
+    UserNotifier.deliver_login_instructions(user, otp_code)
   end
 
   @doc """

--- a/lib/zoonk/accounts.ex
+++ b/lib/zoonk/accounts.ex
@@ -116,14 +116,14 @@ defmodule Zoonk.Accounts do
   end
 
   @doc """
-  Updates the user email using the given token.
+  Updates the user email using the given OTP code.
 
-  If the token matches, the user email is updated and the token is deleted.
+  If the code matches, the user email is updated and the code is deleted.
   """
-  def update_user_email(user, token) do
+  def update_user_email(user, otp_code) do
     context = "change:#{user.email}"
 
-    with {:ok, query} <- UserToken.verify_change_email_token_query(token, context),
+    with {:ok, query} <- UserToken.verify_change_email_code_query(otp_code, context),
          %UserToken{sent_to: email} <- Repo.one(query),
          {:ok, _res} <-
            user

--- a/lib/zoonk/accounts/user_token.ex
+++ b/lib/zoonk/accounts/user_token.ex
@@ -2,15 +2,16 @@ defmodule Zoonk.Accounts.UserToken do
   @moduledoc """
   Represents authentication and verification tokens for users.
 
-  We send tokens to users when they try to sign in or sign up
-  using a magic link, or when they change their email address.
+  We send an OTP code to users when they login, sign up, or change their email.
+  They can use this code to verify their identity and
+  generate a session token used for authentication.
 
   ## Fields
 
   | Field Name   | Type      | Description                                       |
   |--------------|-----------|---------------------------------------------------|
   | `token`      | `Binary`  | The token used for authentication or verification.|
-  | `context`    | `String`  | The context in which the token is used (e.g., "email_verification"). |
+  | `context`    | `String`  | The context in which the token is used (e.g., "login"). |
   | `sent_to`    | `String`  | The email address or phone number to which the token was sent. |
   | `user_id`    | `Integer` | The ID from `Zoonk.Accounts.User`.                |
   | `inserted_at`| `DateTime`| Timestamp when the token was created.             |
@@ -84,62 +85,55 @@ defmodule Zoonk.Accounts.UserToken do
   end
 
   @doc """
-  Builds a token and its hash to be delivered to the user's email.
+  Builds an OTP code and its hash to be delivered to the user's email.
 
-  The non-hashed token is sent to the user email while the
-  hashed part is stored in the database. The original token cannot be reconstructed,
+  The non-hashed OTP code is sent to the user email while the
+  hashed part is stored in the database. The original code cannot be reconstructed,
   which means anyone with read-only access to the database cannot directly use
-  the token in the application to gain access. Furthermore, if the user changes
-  their email in the system, the tokens sent to the previous email are no longer
+  the code in the application to gain access. Furthermore, if the user changes
+  their email in the system, the codes sent to the previous email are no longer
   valid.
-
-  Users can easily adapt the existing code to provide other types of delivery methods,
-  for example, by phone numbers.
   """
-  def build_email_token(user, context) do
-    build_hashed_token(user, context, user.email)
-  end
+  def build_otp_code(user, context) do
+    otp_code =
+      100_000..999_999
+      |> Enum.random()
+      |> Integer.to_string()
 
-  defp build_hashed_token(user, context, sent_to) do
-    token = :crypto.strong_rand_bytes(@rand_size)
-    hashed_token = :crypto.hash(AuthConfig.get_hash_algorithm(), token)
+    hashed_token = :crypto.hash(AuthConfig.get_hash_algorithm(), otp_code)
 
-    {Base.url_encode64(token, padding: false),
+    {otp_code,
      %UserToken{
        token: hashed_token,
        context: context,
-       sent_to: sent_to,
+       sent_to: user.email,
        user_id: user.id
      }}
   end
 
   @doc """
-  Checks if the token is valid and returns its underlying lookup query.
+  Checks if the OTP code is valid and returns its underlying lookup query.
 
   If found, the query returns a tuple of the form `{user, token}`.
 
-  The given token is valid if it matches its hashed counterpart in the
-  database. This function also checks if the token is being used within
-  15 minutes. The context of a magic link token is always "login".
+  The given code is valid if it matches its hashed counterpart in the
+  database. This function also checks if the code is being used within
+  15 minutes. The context of an OTP code is always "login".
   """
-  def verify_magic_link_token_query(token) do
-    case Base.url_decode64(token, padding: false) do
-      {:ok, decoded_token} ->
-        hashed_token = :crypto.hash(AuthConfig.get_hash_algorithm(), decoded_token)
+  def verify_otp_code_query(otp_code) do
+    hashed_otp = :crypto.hash(AuthConfig.get_hash_algorithm(), otp_code)
 
-        query =
-          hashed_token
-          |> by_token_and_context_query("login")
-          |> join(:inner, [token], user in assoc(token, :user))
-          |> where([token], token.inserted_at > ago(^AuthConfig.get_max_age(:magic_link, :minutes), "minute"))
-          |> where([token, user], token.sent_to == user.email)
-          |> select([token, user], {user, token})
+    query =
+      hashed_otp
+      |> by_token_and_context_query("login")
+      |> join(:inner, [token], user in assoc(token, :user))
+      |> where([token], token.inserted_at > ago(^AuthConfig.get_max_age(:otp, :minutes), "minute"))
+      |> where([token, user], token.sent_to == user.email)
+      |> select([token, user], {user, token})
 
-        {:ok, query}
-
-      :error ->
-        :error
-    end
+    {:ok, query}
+  rescue
+    _error -> :error
   end
 
   @doc """

--- a/lib/zoonk/accounts/user_token.ex
+++ b/lib/zoonk/accounts/user_token.ex
@@ -7,14 +7,14 @@ defmodule Zoonk.Accounts.UserToken do
 
   ## Fields
 
-  | Field Name | Type | Description |
-  |------------|------|-------------|
-  | `token` | `Binary` | The token used for authentication or verification. |
-  | `context` | `String` | The context in which the token is used (e.g., "email_verification"). |
-  | `sent_to` | `String` | The email address or phone number to which the token was sent. |
-  | `user_id` | `Integer` | The ID from `Zoonk.Accounts.User`. |
-  | `inserted_at` | `DateTime` | Timestamp when the token was created. |
-  | `updated_at` | `DateTime` | Timestamp when the token was last updated. |
+  | Field Name   | Type      | Description                                       |
+  |--------------|-----------|---------------------------------------------------|
+  | `token`      | `Binary`  | The token used for authentication or verification.|
+  | `context`    | `String`  | The context in which the token is used (e.g., "email_verification"). |
+  | `sent_to`    | `String`  | The email address or phone number to which the token was sent. |
+  | `user_id`    | `Integer` | The ID from `Zoonk.Accounts.User`.                |
+  | `inserted_at`| `DateTime`| Timestamp when the token was created.             |
+  | `updated_at` | `DateTime`| Timestamp when the token was last updated.        |
   """
   use Ecto.Schema
 

--- a/lib/zoonk/accounts/user_token.ex
+++ b/lib/zoonk/accounts/user_token.ex
@@ -137,31 +137,24 @@ defmodule Zoonk.Accounts.UserToken do
   end
 
   @doc """
-  Checks if the token is valid and returns its underlying lookup query.
+  Checks if the OTP code is valid and returns its underlying lookup query.
 
   The query returns the user_token found by the token, if any.
 
-  This is used to validate requests to change the user
-  email.
-  The given token is valid if it matches its hashed counterpart in the
+  This is used to validate requests to change the user email.
+  The given OTP code is valid if it matches its hashed counterpart in the
   database and if it has not expired.
   The context must always start with "change:".
   """
-  def verify_change_email_token_query(token, "change:" <> _rest = context) do
-    case Base.url_decode64(token, padding: false) do
-      {:ok, decoded_token} ->
-        hashed_token = :crypto.hash(AuthConfig.get_hash_algorithm(), decoded_token)
+  def verify_change_email_code_query(otp_code, "change:" <> _rest = context) do
+    hashed_otp = :crypto.hash(AuthConfig.get_hash_algorithm(), otp_code)
 
-        query =
-          hashed_token
-          |> by_token_and_context_query(context)
-          |> where([token], token.inserted_at > ago(^AuthConfig.get_max_age(:change_email, :days), "day"))
+    query =
+      hashed_otp
+      |> by_token_and_context_query(context)
+      |> where([token], token.inserted_at > ago(^AuthConfig.get_max_age(:change_email, :days), "day"))
 
-        {:ok, query}
-
-      :error ->
-        :error
-    end
+    {:ok, query}
   end
 
   @doc """

--- a/lib/zoonk/config/auth_config.ex
+++ b/lib/zoonk/config/auth_config.ex
@@ -19,7 +19,7 @@ defmodule Zoonk.Config.AuthConfig do
   @doc """
   Returns the maximum age or validity of an item.
 
-  For magic link tokens, it is very important to keep their expiry short,
+  For OTP codes, it is very important to keep their expiry short,
   since someone with access to the email may take over the account.
 
   ## Example
@@ -30,7 +30,7 @@ defmodule Zoonk.Config.AuthConfig do
       iex> get_max_age(:token, :seconds)
       31536000
 
-      iex> get_max_age(:magic_link, :minutes)
+      iex> get_max_age(:otp, :minutes)
       15
 
       iex> get_max_age(:change_email, :days)
@@ -41,7 +41,7 @@ defmodule Zoonk.Config.AuthConfig do
   """
   def get_max_age(:token, :days), do: 365
   def get_max_age(:token, :seconds), do: get_max_age(:token, :days) * 24 * 60 * 60
-  def get_max_age(:magic_link, :minutes), do: 15
+  def get_max_age(:otp, :minutes), do: 15
   def get_max_age(:change_email, :days), do: 7
   def get_max_age(:sudo_mode, :minutes), do: -10
 

--- a/lib/zoonk/config/auth_config.ex
+++ b/lib/zoonk/config/auth_config.ex
@@ -73,4 +73,17 @@ defmodule Zoonk.Config.AuthConfig do
       [:apple, :github, :google]
   """
   def list_providers, do: [:apple, :github, :google]
+
+  @doc """
+  Returns the maximum number of OTP codes that can be issued per hour.
+
+  The purpose of this rate limit is to prevent brute force attacks
+  and protect users from excessive OTP code attempts.
+
+  ## Example
+
+      iex> get_max_otp_codes_per_hour()
+      5
+  """
+  def get_max_otp_codes_per_hour, do: 5
 end

--- a/lib/zoonk_web/controllers/accounts/user_session_controller.ex
+++ b/lib/zoonk_web/controllers/accounts/user_session_controller.ex
@@ -18,24 +18,19 @@ defmodule ZoonkWeb.Accounts.UserSessionController do
 
   This controller is also used for confirming a user.
   """
-  def create(conn, params) do
-    create(conn, params, nil)
-  end
-
-  # OTP login
-  defp create(conn, %{"user" => %{"code" => otp}}, info) do
+  def create(conn, %{"user" => %{"code" => otp}, "_action" => action}) do
     case Accounts.login_user_by_otp(otp) do
       {:ok, user, tokens_to_disconnect} ->
         UserAuth.disconnect_sessions(tokens_to_disconnect)
 
         conn
-        |> put_flash(:info, info)
+        |> put_flash(:info, confirmation_msg(action))
         |> UserAuth.login_user(user)
 
       _error ->
         conn
-        |> put_flash(:error, expired_code())
-        |> redirect(to: ~p"/login/email")
+        |> put_flash(:error, dgettext("users", "Invalid code or account not found."))
+        |> redirect(to: error_redirect(action))
     end
   end
 
@@ -48,28 +43,9 @@ defmodule ZoonkWeb.Accounts.UserSessionController do
     |> UserAuth.logout_user()
   end
 
-  @doc """
-  Confirms a user account.
-  """
-  def confirm(conn, %{"code" => otp}), do: login_user(conn, otp, :confirm)
+  defp confirmation_msg("signup"), do: dgettext("users", "Your account is confirmed!")
+  defp confirmation_msg(_action), do: nil
 
-  @doc """
-  Signs in a user via an OTP code sent to their email.
-  """
-  def login(conn, %{"code" => otp}), do: login_user(conn, otp, :login)
-
-  defp login_user(conn, otp_code, action) do
-    if Accounts.get_user_by_otp_code(otp_code) do
-      create(conn, %{"user" => %{"code" => otp_code}}, login_flash(action))
-    else
-      conn
-      |> put_flash(:error, expired_code())
-      |> redirect(to: ~p"/login/email")
-    end
-  end
-
-  defp login_flash(:confirm), do: dgettext("users", "User confirmed successfully.")
-  defp login_flash(:login), do: nil
-
-  defp expired_code, do: dgettext("users", "Code is invalid or it has expired.")
+  defp error_redirect("login"), do: ~p"/login/code"
+  defp error_redirect("signup"), do: ~p"/signup/code"
 end

--- a/lib/zoonk_web/live/auth/user_code_live.ex
+++ b/lib/zoonk_web/live/auth/user_code_live.ex
@@ -23,15 +23,17 @@ defmodule ZoonkWeb.User.UserCodeLive do
           field={f[:code]}
           label={dgettext("users", "One-time code")}
           hide_label
-          type="text"
           placeholder={dgettext("users", "Enter your code")}
           autocomplete="one-time-code"
+          inputmode="numeric"
+          pattern="[0-9]*"
+          maxlength="6"
           required
           class="w-full"
         />
 
-        <.button type="submit" class="w-full" size={:md} icon_align={:left} icon="tabler-mail-filled">
-          {dgettext("users", "Login")}
+        <.button type="submit" class="w-full" size={:md} icon_align={:left} icon="tabler-check">
+          {dgettext("users", "Verify")}
         </.button>
       </.form>
     </.main_container>

--- a/lib/zoonk_web/live/auth/user_code_live.ex
+++ b/lib/zoonk_web/live/auth/user_code_live.ex
@@ -1,0 +1,55 @@
+defmodule ZoonkWeb.User.UserCodeLive do
+  @moduledoc false
+  use ZoonkWeb, :live_view
+
+  import ZoonkWeb.User.UserComponents
+
+  alias Zoonk.Accounts.User
+  alias Zoonk.Scope
+  alias ZoonkWeb.UserAuth
+
+  def render(assigns) do
+    ~H"""
+    <.main_container action={:login} flash={@flash} show_options>
+      <.form
+        :let={f}
+        for={@form}
+        id="otp_form"
+        action={~p"/login?_action=#{@live_action}"}
+        aria-label={dgettext("users", "Enter your code")}
+        class="flex w-full flex-col gap-4"
+      >
+        <.input
+          field={f[:code]}
+          label={dgettext("users", "One-time code")}
+          hide_label
+          type="text"
+          placeholder={dgettext("users", "Enter your code")}
+          autocomplete="one-time-code"
+          required
+          class="w-full"
+        />
+
+        <.button type="submit" class="w-full" size={:md} icon_align={:left} icon="tabler-mail-filled">
+          {dgettext("users", "Login")}
+        </.button>
+      </.form>
+    </.main_container>
+    """
+  end
+
+  def mount(_params, _session, %{assigns: %{scope: %Scope{user: %User{}}}} = socket) do
+    {:ok, redirect(socket, to: UserAuth.signed_in_path(socket))}
+  end
+
+  def mount(_params, _session, socket) do
+    form = to_form(%{"code" => ""}, as: :user)
+
+    socket =
+      socket
+      |> assign(form: form)
+      |> assign(page_title: dgettext("users", "Confirmation code"))
+
+    {:ok, socket}
+  end
+end

--- a/lib/zoonk_web/live/auth/user_components.ex
+++ b/lib/zoonk_web/live/auth/user_components.ex
@@ -4,7 +4,7 @@ defmodule ZoonkWeb.User.UserComponents do
 
   alias Zoonk.Config.AuthConfig
 
-  @actions [:login, :signup]
+  @actions [:login, :signup, :confirm]
 
   @doc """
   Generates a link to the authentication provider.
@@ -103,14 +103,15 @@ defmodule ZoonkWeb.User.UserComponents do
         </.text>
       </section>
 
-      <.footer_link action={get_footer_action(@action)} />
+      <.footer_link :if={@action != :confirm} action={get_footer_action(@action)} />
       <.flash_group flash={@flash} />
     </main>
     """
   end
 
-  defp get_auth_header(:login), do: dgettext("users", "Access your Zoonk account.")
-  defp get_auth_header(:signup), do: dgettext("users", "Start learning the skills to build amazing things.")
+  defp get_auth_header(:login), do: dgettext("users", "Access your Zoonk account")
+  defp get_auth_header(:signup), do: dgettext("users", "Start learning the skills to build amazing things")
+  defp get_auth_header(:confirm), do: dgettext("users", "Validate your email address")
 
   defp get_auth_link(:login), do: ~p"/login"
   defp get_auth_link(:signup), do: ~p"/signup"

--- a/lib/zoonk_web/live/auth/user_confirm_code_live.ex
+++ b/lib/zoonk_web/live/auth/user_confirm_code_live.ex
@@ -49,7 +49,7 @@ defmodule ZoonkWeb.User.UserConfirmCodeLive do
   end
 
   def mount(_params, _session, %{assigns: %{scope: %Scope{user: %User{}}} = assigns} = socket)
-      when assigns.live_action != :email do
+      when assigns.live_action == :signup do
     {:ok, redirect(socket, to: UserAuth.signed_in_path(socket))}
   end
 

--- a/lib/zoonk_web/live/auth/user_confirm_code_live.ex
+++ b/lib/zoonk_web/live/auth/user_confirm_code_live.ex
@@ -1,4 +1,4 @@
-defmodule ZoonkWeb.User.UserCodeLive do
+defmodule ZoonkWeb.User.UserConfirmCodeLive do
   @moduledoc false
   use ZoonkWeb, :live_view
 
@@ -40,7 +40,8 @@ defmodule ZoonkWeb.User.UserCodeLive do
     """
   end
 
-  def mount(_params, _session, %{assigns: %{scope: %Scope{user: %User{}}}} = socket) do
+  def mount(_params, _session, %{assigns: %{scope: %Scope{user: %User{}}} = assigns} = socket)
+      when assigns.live_action != :email do
     {:ok, redirect(socket, to: UserAuth.signed_in_path(socket))}
   end
 

--- a/lib/zoonk_web/live/auth/user_confirm_code_live.ex
+++ b/lib/zoonk_web/live/auth/user_confirm_code_live.ex
@@ -11,13 +11,17 @@ defmodule ZoonkWeb.User.UserConfirmCodeLive do
   def render(assigns) do
     ~H"""
     <.main_container action={:confirm} flash={@flash}>
+      <.text tag="h2" variant={:secondary}>
+        {dgettext("users", "We sent a code to your email address. Please enter it below to proceed.")}
+      </.text>
+
       <.form
         :let={f}
         for={@form}
         id="otp_form"
         action={~p"/confirm?_action=#{@live_action}"}
         aria-label={dgettext("users", "Enter your code")}
-        class="flex w-full flex-col gap-4"
+        class="mt-4 flex w-full flex-col gap-4"
       >
         <.input
           field={f[:code]}

--- a/lib/zoonk_web/live/auth/user_confirm_code_live.ex
+++ b/lib/zoonk_web/live/auth/user_confirm_code_live.ex
@@ -10,7 +10,7 @@ defmodule ZoonkWeb.User.UserConfirmCodeLive do
 
   def render(assigns) do
     ~H"""
-    <.main_container action={:login} flash={@flash} show_options>
+    <.main_container action={:confirm} flash={@flash}>
       <.form
         :let={f}
         for={@form}
@@ -36,6 +36,10 @@ defmodule ZoonkWeb.User.UserConfirmCodeLive do
           {dgettext("users", "Verify")}
         </.button>
       </.form>
+
+      <.a navigate={get_back_link(@live_action)} class="mt-4 text-sm">
+        {gettext("Back")}
+      </.a>
     </.main_container>
     """
   end
@@ -55,4 +59,8 @@ defmodule ZoonkWeb.User.UserConfirmCodeLive do
 
     {:ok, socket}
   end
+
+  defp get_back_link(:email), do: ~p"/settings"
+  defp get_back_link(:login), do: ~p"/login"
+  defp get_back_link(:signup), do: ~p"/signup"
 end

--- a/lib/zoonk_web/live/auth/user_confirm_code_live.ex
+++ b/lib/zoonk_web/live/auth/user_confirm_code_live.ex
@@ -15,7 +15,7 @@ defmodule ZoonkWeb.User.UserConfirmCodeLive do
         :let={f}
         for={@form}
         id="otp_form"
-        action={~p"/login?_action=#{@live_action}"}
+        action={~p"/confirm?_action=#{@live_action}"}
         aria-label={dgettext("users", "Enter your code")}
         class="flex w-full flex-col gap-4"
       >

--- a/lib/zoonk_web/live/auth/user_login_with_email_live.ex
+++ b/lib/zoonk_web/live/auth/user_login_with_email_live.ex
@@ -13,9 +13,9 @@ defmodule ZoonkWeb.User.UserLoginWithEmailLive do
         :let={f}
         :if={!@link_sent}
         for={@form}
-        id="login_form_magic"
+        id="login_form"
         action={~p"/login"}
-        phx-submit="submit_magic"
+        phx-submit="submit"
         aria-label={dgettext("users", "Sign in form")}
         class="flex w-full flex-col gap-4"
       >
@@ -66,12 +66,9 @@ defmodule ZoonkWeb.User.UserLoginWithEmailLive do
     {:ok, socket}
   end
 
-  def handle_event("submit_magic", %{"email" => email}, socket) do
+  def handle_event("submit", %{"email" => email}, socket) do
     if user = Accounts.get_user_by_email(email) do
-      Accounts.deliver_login_instructions(
-        user,
-        &url(socket.assigns.uri, ~p"/login/t/#{&1}")
-      )
+      Accounts.deliver_login_instructions(user)
     end
 
     {:noreply, assign(socket, link_sent: true)}

--- a/lib/zoonk_web/live/auth/user_login_with_email_live.ex
+++ b/lib/zoonk_web/live/auth/user_login_with_email_live.ex
@@ -11,7 +11,6 @@ defmodule ZoonkWeb.User.UserLoginWithEmailLive do
     <.main_container action={:login} flash={@flash} show_options>
       <.form
         :let={f}
-        :if={!@link_sent}
         for={@form}
         id="login_form"
         action={~p"/login"}
@@ -34,18 +33,6 @@ defmodule ZoonkWeb.User.UserLoginWithEmailLive do
           {dgettext("users", "Login")}
         </.button>
       </.form>
-
-      <.card :if={@link_sent} size={:auto}>
-        <.card_content class="flex flex-col gap-4">
-          <.text>
-            {dgettext("users", "If your email is in our system, you will receive a link to login.")}
-          </.text>
-
-          <.button phx-click="try_again" variant={:outline} size={:md} class="w-full">
-            {dgettext("users", "Try again")}
-          </.button>
-        </.card_content>
-      </.card>
     </.main_container>
     """
   end
@@ -60,7 +47,6 @@ defmodule ZoonkWeb.User.UserLoginWithEmailLive do
     socket =
       socket
       |> assign(form: form)
-      |> assign(link_sent: false)
       |> assign(page_title: dgettext("users", "Sign in with email"))
 
     {:ok, socket}
@@ -71,10 +57,6 @@ defmodule ZoonkWeb.User.UserLoginWithEmailLive do
       Accounts.deliver_login_instructions(user)
     end
 
-    {:noreply, assign(socket, link_sent: true)}
-  end
-
-  def handle_event("try_again", _params, socket) do
-    {:noreply, assign(socket, link_sent: false)}
+    {:noreply, push_navigate(socket, to: ~p"/login/code")}
   end
 end

--- a/lib/zoonk_web/live/auth/user_login_with_email_live.ex
+++ b/lib/zoonk_web/live/auth/user_login_with_email_live.ex
@@ -57,6 +57,6 @@ defmodule ZoonkWeb.User.UserLoginWithEmailLive do
       Accounts.deliver_login_instructions(user)
     end
 
-    {:noreply, push_navigate(socket, to: ~p"/login/code")}
+    {:noreply, push_navigate(socket, to: ~p"/confirm/login")}
   end
 end

--- a/lib/zoonk_web/live/auth/user_signup_with_email_live.ex
+++ b/lib/zoonk_web/live/auth/user_signup_with_email_live.ex
@@ -81,7 +81,7 @@ defmodule ZoonkWeb.User.UserSignUpWithEmailLive do
       {:ok, user} ->
         {:ok, _url_fn} = Accounts.deliver_login_instructions(user)
 
-        {:noreply, push_navigate(socket, to: ~p"/signup/code")}
+        {:noreply, push_navigate(socket, to: ~p"/confirm/signup")}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply,

--- a/lib/zoonk_web/live/auth/user_signup_with_email_live.ex
+++ b/lib/zoonk_web/live/auth/user_signup_with_email_live.ex
@@ -93,11 +93,7 @@ defmodule ZoonkWeb.User.UserSignUpWithEmailLive do
   def handle_event("save", %{"user" => user_params}, socket) do
     case Accounts.signup_user(user_params, socket.assigns.scope) do
       {:ok, user} ->
-        {:ok, _url_fn} =
-          Accounts.deliver_login_instructions(
-            user,
-            &url(socket.assigns.uri, ~p"/confirm/#{&1}")
-          )
+        {:ok, _url_fn} = Accounts.deliver_login_instructions(user)
 
         {:noreply, assign(socket, user_email: user.email)}
 

--- a/lib/zoonk_web/live/auth/user_signup_with_email_live.ex
+++ b/lib/zoonk_web/live/auth/user_signup_with_email_live.ex
@@ -14,7 +14,6 @@ defmodule ZoonkWeb.User.UserSignUpWithEmailLive do
     ~H"""
     <.main_container action={:signup} show_options flash={@flash}>
       <.form
-        :if={is_nil(@user_email)}
         for={@form}
         id="signup_form"
         phx-submit="save"
@@ -56,18 +55,6 @@ defmodule ZoonkWeb.User.UserSignUpWithEmailLive do
           {dgettext("users", "Create an account")}
         </.button>
       </.form>
-
-      <.card :if={is_binary(@user_email)} size={:auto}>
-        <.card_content class="flex flex-col gap-4">
-          <.text>
-            {dgettext(
-              "users",
-              "An email was sent to %{email}, please click on the confirmation link to access your account.",
-              email: @user_email
-            )}
-          </.text>
-        </.card_content>
-      </.card>
     </.main_container>
     """
   end
@@ -83,7 +70,6 @@ defmodule ZoonkWeb.User.UserSignUpWithEmailLive do
     socket =
       socket
       |> assign(check_errors: false)
-      |> assign(user_email: nil)
       |> assign_form(changeset)
       |> assign(page_title: dgettext("users", "Create an account"))
 
@@ -95,7 +81,7 @@ defmodule ZoonkWeb.User.UserSignUpWithEmailLive do
       {:ok, user} ->
         {:ok, _url_fn} = Accounts.deliver_login_instructions(user)
 
-        {:noreply, assign(socket, user_email: user.email)}
+        {:noreply, push_navigate(socket, to: ~p"/signup/code")}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply,

--- a/lib/zoonk_web/live/user/user_settings_live.ex
+++ b/lib/zoonk_web/live/user/user_settings_live.ex
@@ -4,6 +4,8 @@ defmodule ZoonkWeb.User.UserSettingsLive do
 
   alias Zoonk.Accounts
 
+  on_mount {ZoonkWeb.UserAuth, :ensure_sudo_mode}
+
   def render(assigns) do
     ~H"""
     <main class="min-h-dvh flex flex-col gap-8 p-4">

--- a/lib/zoonk_web/live/user/user_settings_live.ex
+++ b/lib/zoonk_web/live/user/user_settings_live.ex
@@ -58,9 +58,9 @@ defmodule ZoonkWeb.User.UserSettingsLive do
     """
   end
 
-  def mount(%{"token" => token}, _session, socket) do
+  def mount(%{"code" => otp_code}, _session, socket) do
     socket =
-      case Accounts.update_user_email(socket.assigns.scope.user, token) do
+      case Accounts.update_user_email(socket.assigns.scope.user, otp_code) do
         :ok ->
           put_flash(socket, :info, dgettext("users", "Email changed successfully."))
 
@@ -105,11 +105,7 @@ defmodule ZoonkWeb.User.UserSettingsLive do
       %{valid?: true} = changeset ->
         user_changeset = Ecto.Changeset.apply_action!(changeset, :insert)
 
-        Accounts.deliver_user_update_email_instructions(
-          user_changeset,
-          user.email,
-          &url(socket.assigns.uri, ~p"/settings/confirm/#{&1}")
-        )
+        Accounts.deliver_user_update_email_instructions(user_changeset, user.email)
 
         info = dgettext("users", "A link to confirm your email change has been sent to the new address.")
         {:noreply, put_flash(socket, :info, info)}

--- a/lib/zoonk_web/router.ex
+++ b/lib/zoonk_web/router.ex
@@ -61,7 +61,7 @@ defmodule ZoonkWeb.Router do
       live "/learn/:input", Learning.LearningRecommendationsLive
 
       live "/settings", User.UserSettingsLive
-      live "/settings/confirm/:token", User.UserSettingsLive
+      live "/settings/confirm/:code", User.UserSettingsLive
     end
   end
 

--- a/lib/zoonk_web/router.ex
+++ b/lib/zoonk_web/router.ex
@@ -61,7 +61,6 @@ defmodule ZoonkWeb.Router do
       live "/learn/:input", Learning.LearningRecommendationsLive
 
       live "/settings", User.UserSettingsLive
-      live "/settings/confirm/:code", User.UserSettingsLive
     end
   end
 
@@ -77,6 +76,9 @@ defmodule ZoonkWeb.Router do
       live "/signup/email", User.UserSignUpWithEmailLive
       live "/login", User.UserLoginLive
       live "/login/email", User.UserLoginWithEmailLive
+
+      live "/login/code", User.UserCodeLive, :login
+      live "/signup/code", User.UserCodeLive, :signup
     end
   end
 
@@ -85,8 +87,6 @@ defmodule ZoonkWeb.Router do
 
     post "/login", Accounts.UserSessionController, :create
     delete "/logout", Accounts.UserSessionController, :delete
-    get "/login/t/:token", Accounts.UserSessionController, :login
-    get "/confirm/:token", Accounts.UserSessionController, :confirm
 
     get "/auth/:provider", Accounts.OAuthController, :request
     get "/auth/:provider/callback", Accounts.OAuthController, :callback

--- a/lib/zoonk_web/router.ex
+++ b/lib/zoonk_web/router.ex
@@ -86,7 +86,7 @@ defmodule ZoonkWeb.Router do
   scope "/", ZoonkWeb do
     pipe_through [:browser]
 
-    post "/login", Accounts.UserSessionController, :create
+    post "/confirm", Accounts.UserSessionController, :create
     delete "/logout", Accounts.UserSessionController, :delete
 
     get "/auth/:provider", Accounts.OAuthController, :request

--- a/lib/zoonk_web/router.ex
+++ b/lib/zoonk_web/router.ex
@@ -61,6 +61,7 @@ defmodule ZoonkWeb.Router do
       live "/learn/:input", Learning.LearningRecommendationsLive
 
       live "/settings", User.UserSettingsLive
+      live "/confirm/email", User.UserConfirmCodeLive, :email
     end
   end
 
@@ -77,8 +78,8 @@ defmodule ZoonkWeb.Router do
       live "/login", User.UserLoginLive
       live "/login/email", User.UserLoginWithEmailLive
 
-      live "/login/code", User.UserCodeLive, :login
-      live "/signup/code", User.UserCodeLive, :signup
+      live "/confirm/login", User.UserConfirmCodeLive, :login
+      live "/confirm/signup", User.UserConfirmCodeLive, :signup
     end
   end
 

--- a/lib/zoonk_web/user_auth.ex
+++ b/lib/zoonk_web/user_auth.ex
@@ -224,11 +224,9 @@ defmodule ZoonkWeb.UserAuth do
   end
 
   defp mount_scope(socket, session) do
-    %URI{host: host} = uri = Phoenix.LiveView.get_connect_info(socket, :uri)
+    %URI{host: host} = Phoenix.LiveView.get_connect_info(socket, :uri)
 
-    socket
-    |> Phoenix.Component.assign(uri: get_uri(uri))
-    |> Phoenix.Component.assign_new(:scope, fn ->
+    Phoenix.Component.assign_new(socket, :scope, fn ->
       user = get_user_by_session_token(session["user_token"])
       build_scope(user, host)
     end)
@@ -326,21 +324,4 @@ defmodule ZoonkWeb.UserAuth do
   end
 
   defp public_path?(_path, _scope), do: false
-
-  # We’re assigning the current URI to the socket to
-  # build verification links accurately. This ensures
-  # we’re using the right URI when sending magic links,
-  # especially since we support subdomains and custom domains,
-  # making the endpoint’s host value unreliable.
-  defp get_uri(%URI{host: host, port: port, scheme: scheme}) do
-    %URI{
-      host: host,
-      port: get_port(port, Application.get_env(:zoonk, :dev_routes)),
-      scheme: scheme
-    }
-  end
-
-  # only add port for dev routes
-  defp get_port(port, true), do: port
-  defp get_port(_port, _dev_route?), do: nil
 end

--- a/test/support/fixtures/account_fixtures.ex
+++ b/test/support/fixtures/account_fixtures.ex
@@ -79,9 +79,8 @@ defmodule Zoonk.AccountFixtures do
   end
 
   def generate_user_otp_code(user) do
-    {otp_code, user_token} = UserToken.build_otp_code(user, "login")
-    Zoonk.Repo.insert!(user_token)
-    {otp_code, user_token.token}
+    {:ok, otp_code} = UserToken.build_otp_code(user, "login")
+    otp_code
   end
 
   def offset_user_token(token, amount_to_add, unit) do

--- a/test/support/fixtures/account_fixtures.ex
+++ b/test/support/fixtures/account_fixtures.ex
@@ -43,18 +43,14 @@ defmodule Zoonk.AccountFixtures do
   def user_fixture(attrs \\ %{}) do
     preload = Map.get(attrs, :preload, [])
     fixture = unconfirmed_user_fixture(attrs)
-
-    token =
-      extract_user_token(fn url ->
-        Accounts.deliver_login_instructions(fixture, url)
-      end)
+    otp_code = extract_otp_code(Accounts.deliver_login_instructions(fixture))
 
     UserProfile
     |> Repo.get_by!(user_id: fixture.id)
     |> UserProfile.changeset(%{picture_url: "https://zoonk.test/image.png"})
     |> Repo.update!()
 
-    {:ok, user, _expired_tokens} = Accounts.login_user_by_magic_link(token)
+    {:ok, user, _expired_tokens} = Accounts.login_user_by_otp(otp_code)
 
     Repo.preload(user, preload)
   end
@@ -70,10 +66,10 @@ defmodule Zoonk.AccountFixtures do
     Scope.set(%Scope{org: org, user: user, org_member: org_member})
   end
 
-  def extract_user_token(fun) do
-    {:ok, captured_email} = fun.(&"[TOKEN]#{&1}[TOKEN]")
-    [_str, token | _opts] = String.split(captured_email.text_body, "[TOKEN]")
-    token
+  def extract_otp_code({:ok, email}) do
+    ~r/\n\s*(?<otp>\d{6})\s*\n/
+    |> Regex.named_captures(email.text_body)
+    |> Map.fetch!("otp")
   end
 
   def override_token_authenticated_at(token, authenticated_at) when is_binary(token) do
@@ -82,10 +78,10 @@ defmodule Zoonk.AccountFixtures do
     |> Zoonk.Repo.update_all(set: [authenticated_at: authenticated_at])
   end
 
-  def generate_user_magic_link_token(user) do
-    {encoded_token, user_token} = UserToken.build_email_token(user, "login")
+  def generate_user_otp_code(user) do
+    {otp_code, user_token} = UserToken.build_otp_code(user, "login")
     Zoonk.Repo.insert!(user_token)
-    {encoded_token, user_token.token}
+    {otp_code, user_token.token}
   end
 
   def offset_user_token(token, amount_to_add, unit) do

--- a/test/zoonk_web/controllers/accounts/user_session_controller_test.exs
+++ b/test/zoonk_web/controllers/accounts/user_session_controller_test.exs
@@ -13,7 +13,7 @@ defmodule ZoonkWeb.Accounts.UserSessionControllerTest do
     end
 
     test "logs the user in", %{conn: conn, user: user} do
-      {otp_code, _hashed_token} = generate_user_otp_code(user)
+      otp_code = generate_user_otp_code(user)
 
       params = %{"_action" => "login", "user" => %{"code" => otp_code}}
       post_conn = post(conn, ~p"/confirm", params)

--- a/test/zoonk_web/controllers/accounts/user_session_controller_test.exs
+++ b/test/zoonk_web/controllers/accounts/user_session_controller_test.exs
@@ -51,12 +51,12 @@ defmodule ZoonkWeb.Accounts.UserSessionControllerTest do
       assert Phoenix.Flash.get(post_conn.assigns.flash, :info) =~ "Your account is confirmed!"
 
       # we are logged in now
-      assert redirected_to(conn) == ~p"/"
-      assert get_session(conn, :user_token)
+      assert redirected_to(post_conn) == ~p"/"
+      assert get_session(post_conn, :user_token)
 
       # logs out when trying to confirm again
       logout_conn = post(build_conn(), ~p"/login", params)
-      assert redirected_to(logout_conn) == ~p"/login/code"
+      assert redirected_to(logout_conn) == ~p"/signup/code"
       assert Phoenix.Flash.get(logout_conn.assigns.flash, :error) =~ "Invalid code or account not found."
       refute get_session(logout_conn, :user_token)
     end

--- a/test/zoonk_web/controllers/accounts/user_session_controller_test.exs
+++ b/test/zoonk_web/controllers/accounts/user_session_controller_test.exs
@@ -7,65 +7,65 @@ defmodule ZoonkWeb.Accounts.UserSessionControllerTest do
   alias Zoonk.Accounts.User
   alias Zoonk.Repo
 
-  setup do
-    %{unconfirmed_user: unconfirmed_user_fixture(), user: user_fixture()}
-  end
+  describe "POST /login?_action=login" do
+    setup do
+      %{user: user_fixture()}
+    end
 
-  describe "POST /login - OTP code" do
     test "logs the user in", %{conn: conn, user: user} do
       {otp_code, _hashed_token} = generate_user_otp_code(user)
 
-      post_conn = post(conn, ~p"/login", %{"user" => %{"code" => otp_code}})
+      params = %{"_action" => "login", "user" => %{"code" => otp_code}}
+      post_conn = post(conn, ~p"/login", params)
 
       assert get_session(post_conn, :user_token)
+      assert Repo.get!(User, user.id).confirmed_at == user.confirmed_at
       assert redirected_to(post_conn) == ~p"/"
+      assert is_nil(Phoenix.Flash.get(post_conn.assigns.flash, :info))
 
       # Now do a logged in request and assert on the menu
       loggedin_conn = get(post_conn, ~p"/")
       html_response(loggedin_conn, 200)
     end
 
-    test "redirects to login page when OTP code is invalid", %{conn: conn} do
-      conn = post(conn, ~p"/login", %{"user" => %{"code" => "invalid"}})
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "Code is invalid or it has expired."
-      assert redirected_to(conn) == ~p"/login/email"
+    test "redirects back to the code page when OTP code is invalid", %{conn: conn} do
+      params = %{"_action" => "login", "user" => %{"code" => "invalid_code"}}
+      conn = post(conn, ~p"/login", params)
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "Invalid code or account not found."
+      assert redirected_to(conn) == ~p"/login/code"
     end
   end
 
-  describe "GET /confirm/:code" do
+  describe "POST /login?_action=signup" do
+    setup do
+      %{unconfirmed_user: unconfirmed_user_fixture(), user: user_fixture()}
+    end
+
     test "confirms the given code once", %{conn: conn, unconfirmed_user: user} do
       code = extract_user_otp_code(fn url -> Accounts.deliver_login_instructions(user, url) end)
 
-      conn = get(conn, ~p"/confirm/#{code}")
+      params = %{"_action" => "signup", "user" => %{"code" => code}}
+      post_conn = post(conn, ~p"/login", params)
 
       assert Repo.get!(User, user.id).confirmed_at
-      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "User confirmed successfully."
+      assert Phoenix.Flash.get(post_conn.assigns.flash, :info) =~ "Your account is confirmed!"
 
       # we are logged in now
       assert redirected_to(conn) == ~p"/"
       assert get_session(conn, :user_token)
 
-      # log out, new conn
-      logout_conn = get(build_conn(), ~p"/confirm/#{code}")
-      assert redirected_to(logout_conn) == ~p"/login/email"
-      assert Phoenix.Flash.get(logout_conn.assigns.flash, :error) =~ "Code is invalid or it has expired."
+      # logs out when trying to confirm again
+      logout_conn = post(build_conn(), ~p"/login", params)
+      assert redirected_to(logout_conn) == ~p"/login/signup"
+      assert Phoenix.Flash.get(logout_conn.assigns.flash, :error) =~ "Invalid code or account not found."
       refute get_session(logout_conn, :user_token)
     end
 
-    test "logs confirmed user in without changing confirmed_at", %{conn: conn, user: user} do
-      code = extract_user_otp_code(fn url -> Accounts.deliver_login_instructions(user, url) end)
-      conn = get(conn, ~p"/login/t/#{code}")
-
-      assert get_session(conn, :user_token)
-      assert Repo.get!(User, user.id).confirmed_at == user.confirmed_at
-      assert redirected_to(conn) == ~p"/"
-      assert is_nil(Phoenix.Flash.get(conn.assigns.flash, :info))
-    end
-
-    test "redirects to the login page if the code is invalid", %{conn: conn} do
-      conn = get(conn, ~p"/confirm/invalid_code")
-      assert redirected_to(conn) == ~p"/login/email"
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "Code is invalid or it has expired."
+    test "redirects back to the code page if the code is invalid", %{conn: conn} do
+      params = %{"_action" => "signup", "user" => %{"code" => "invalid_code"}}
+      conn = post(conn, ~p"/login", params)
+      assert redirected_to(conn) == ~p"/signup/code"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "Invalid code or account not found."
     end
   end
 

--- a/test/zoonk_web/controllers/accounts/user_session_controller_test.exs
+++ b/test/zoonk_web/controllers/accounts/user_session_controller_test.exs
@@ -87,7 +87,7 @@ defmodule ZoonkWeb.Accounts.UserSessionControllerTest do
       assert Phoenix.Flash.get(post_conn.assigns.flash, :info) =~ "Email changed successfully."
 
       refute Accounts.get_user_by_email(user.email)
-      assert Accounts.get_user_by_email(email)
+      assert Accounts.get_user_by_email(email).confirmed_at
 
       # don't allow to use the same OTP code again
       updated_conn = post(conn, ~p"/confirm", params)

--- a/test/zoonk_web/controllers/accounts/user_session_controller_test.exs
+++ b/test/zoonk_web/controllers/accounts/user_session_controller_test.exs
@@ -90,9 +90,9 @@ defmodule ZoonkWeb.Accounts.UserSessionControllerTest do
       assert Accounts.get_user_by_email(email)
 
       # don't allow to use the same OTP code again
-      post_conn = post(conn, ~p"/confirm", params)
-      assert redirected_to(post_conn) == ~p"/settings"
-      assert Phoenix.Flash.get(post_conn.assigns.flash, :error) =~ "Code is invalid or it has expired."
+      updated_conn = post(conn, ~p"/confirm", params)
+      assert redirected_to(updated_conn) == ~p"/settings"
+      assert Phoenix.Flash.get(updated_conn.assigns.flash, :error) =~ "Code is invalid or it has expired."
     end
 
     test "doesn't update email with invalid code", %{conn: conn, user: user} do

--- a/test/zoonk_web/controllers/accounts/user_session_controller_test.exs
+++ b/test/zoonk_web/controllers/accounts/user_session_controller_test.exs
@@ -42,7 +42,7 @@ defmodule ZoonkWeb.Accounts.UserSessionControllerTest do
     end
 
     test "confirms the given code once", %{conn: conn, unconfirmed_user: user} do
-      code = extract_user_otp_code(fn url -> Accounts.deliver_login_instructions(user, url) end)
+      code = extract_otp_code(Accounts.deliver_login_instructions(user))
 
       params = %{"_action" => "signup", "user" => %{"code" => code}}
       post_conn = post(conn, ~p"/login", params)
@@ -56,7 +56,7 @@ defmodule ZoonkWeb.Accounts.UserSessionControllerTest do
 
       # logs out when trying to confirm again
       logout_conn = post(build_conn(), ~p"/login", params)
-      assert redirected_to(logout_conn) == ~p"/login/signup"
+      assert redirected_to(logout_conn) == ~p"/login/code"
       assert Phoenix.Flash.get(logout_conn.assigns.flash, :error) =~ "Invalid code or account not found."
       refute get_session(logout_conn, :user_token)
     end
@@ -70,6 +70,10 @@ defmodule ZoonkWeb.Accounts.UserSessionControllerTest do
   end
 
   describe "DELETE /logout" do
+    setup do
+      %{user: user_fixture()}
+    end
+
     test "logs the user out", %{conn: conn, user: user} do
       conn =
         conn

--- a/test/zoonk_web/live/user/user_confirm_code_live_test.exs
+++ b/test/zoonk_web/live/user/user_confirm_code_live_test.exs
@@ -6,13 +6,15 @@ defmodule ZoonkWeb.User.UserConfirmCodeLiveTest do
   alias Zoonk.Accounts
 
   describe "/confirm/login" do
-    test "redirects when user is logged in", %{conn: conn} do
+    test "doesn't redirect when user is logged in", %{conn: conn} do
       user = user_fixture()
 
+      # when in sudo mode, users need to confirm their login
+      # so, they need to have access to the confirm page
       conn
       |> login_user(user)
       |> visit(~p"/confirm/login")
-      |> assert_path(~p"/")
+      |> assert_path(~p"/confirm/login")
     end
 
     test "logs the user in with a valid code", %{conn: conn} do

--- a/test/zoonk_web/live/user/user_confirm_code_live_test.exs
+++ b/test/zoonk_web/live/user/user_confirm_code_live_test.exs
@@ -1,0 +1,97 @@
+defmodule ZoonkWeb.User.UserConfirmCodeLiveTest do
+  use ZoonkWeb.ConnCase, async: true
+
+  import Zoonk.AccountFixtures
+
+  alias Zoonk.Accounts
+
+  describe "/confirm/login" do
+    test "redirects when user is logged in", %{conn: conn} do
+      user = user_fixture()
+
+      conn
+      |> login_user(user)
+      |> visit(~p"/confirm/login")
+      |> assert_path(~p"/")
+    end
+
+    test "logs the user in with a valid code", %{conn: conn} do
+      user = user_fixture()
+      otp_code = generate_user_otp_code(user)
+
+      conn
+      |> visit(~p"/confirm/login")
+      |> fill_in("One-time code", with: otp_code)
+      |> submit()
+      |> assert_path(~p"/")
+    end
+
+    test "shows error with an invalid code", %{conn: conn} do
+      conn
+      |> visit(~p"/confirm/login")
+      |> fill_in("One-time code", with: "invalid_code")
+      |> submit()
+      |> assert_has("div", text: "Invalid code or account not found.")
+      |> assert_path(~p"/confirm/login")
+    end
+  end
+
+  describe "/confirm/signup" do
+    test "redirects when user is logged in", %{conn: conn} do
+      user = user_fixture()
+
+      conn
+      |> login_user(user)
+      |> visit(~p"/confirm/signup")
+      |> assert_path(~p"/")
+    end
+
+    test "logs the user in with a valid code", %{conn: conn} do
+      user = user_fixture()
+      otp_code = generate_user_otp_code(user)
+
+      conn
+      |> visit(~p"/confirm/signup")
+      |> fill_in("One-time code", with: otp_code)
+      |> submit()
+      |> assert_path(~p"/")
+    end
+
+    test "shows error with an invalid code", %{conn: conn} do
+      conn
+      |> visit(~p"/confirm/signup")
+      |> fill_in("One-time code", with: "invalid_code")
+      |> submit()
+      |> assert_has("div", text: "Invalid code or account not found.")
+      |> assert_path(~p"/confirm/signup")
+    end
+  end
+
+  describe "/confirm/email" do
+    setup %{conn: conn} do
+      user = user_fixture()
+      email = unique_user_email()
+
+      otp_code = extract_otp_code(Accounts.deliver_user_update_email_instructions(%{user | email: email}, user.email))
+
+      %{conn: login_user(conn, user), otp_code: otp_code, email: email, user: user}
+    end
+
+    test "updates the user email", %{conn: conn, otp_code: otp_code, email: email, user: user} do
+      # user still has the current email address
+      assert Accounts.get_user_by_email(user.email)
+      refute Accounts.get_user_by_email(email)
+
+      conn
+      |> visit(~p"/confirm/email")
+      |> fill_in("One-time code", with: otp_code)
+      |> submit()
+      |> assert_path(~p"/settings")
+      |> assert_has("div", text: "Email changed successfully.")
+
+      # user now has the new email address
+      refute Accounts.get_user_by_email(user.email)
+      assert Accounts.get_user_by_email(email).confirmed_at
+    end
+  end
+end

--- a/test/zoonk_web/live/user/user_login_with_email_live_test.exs
+++ b/test/zoonk_web/live/user/user_login_with_email_live_test.exs
@@ -19,27 +19,9 @@ defmodule ZoonkWeb.User.UserLoginWithEmailLiveTest do
       |> visit(~p"/login/email")
       |> fill_in("Email address", with: user.email)
       |> submit()
-      |> assert_has("p", text: "If your email is in our system")
+      |> assert_path(~p"/login/code")
 
       assert Zoonk.Repo.get_by!(Zoonk.Accounts.UserToken, user_id: user.id).context == "login"
-    end
-
-    test "does not disclose if user is signed up", %{conn: conn} do
-      conn
-      |> visit(~p"/login/email")
-      |> fill_in("Email address", with: "idonotexist@example.com")
-      |> submit()
-      |> assert_has("p", text: "If your email is in our system")
-    end
-
-    test "displays the login form when the user clicks 'Try again'", %{conn: conn} do
-      conn
-      |> visit(~p"/login/email")
-      |> fill_in("Email address", with: "user@example.com")
-      |> submit()
-      |> refute_has("form")
-      |> click_button("Try again")
-      |> assert_has("form")
     end
   end
 

--- a/test/zoonk_web/live/user/user_login_with_email_live_test.exs
+++ b/test/zoonk_web/live/user/user_login_with_email_live_test.exs
@@ -19,7 +19,7 @@ defmodule ZoonkWeb.User.UserLoginWithEmailLiveTest do
       |> visit(~p"/login/email")
       |> fill_in("Email address", with: user.email)
       |> submit()
-      |> assert_path(~p"/login/code")
+      |> assert_path(~p"/confirm/login")
 
       assert Zoonk.Repo.get_by!(Zoonk.Accounts.UserToken, user_id: user.id).context == "login"
     end

--- a/test/zoonk_web/live/user/user_login_with_email_live_test.exs
+++ b/test/zoonk_web/live/user/user_login_with_email_live_test.exs
@@ -11,8 +11,8 @@ defmodule ZoonkWeb.User.UserLoginWithEmailLiveTest do
     end
   end
 
-  describe "user login - magic link" do
-    test "sends magic link email when user exists", %{conn: conn} do
+  describe "user login - OTP code" do
+    test "sends OTP code email when user exists", %{conn: conn} do
       user = user_fixture()
 
       conn

--- a/test/zoonk_web/live/user/user_settings_live_test.exs
+++ b/test/zoonk_web/live/user/user_settings_live_test.exs
@@ -5,19 +5,20 @@ defmodule ZoonkWeb.User.UserSettingsLiveTest do
 
   alias Zoonk.Accounts
 
-  describe "update email form (regular user)" do
+  describe "update email form" do
     setup :signup_and_login_user
 
-    test "updates the user email", %{conn: conn, user: user} do
+    test "redirects to the confirmation page", %{conn: conn, user: user} do
       new_email = unique_user_email()
 
       conn
       |> visit(~p"/settings")
       |> fill_in("Email address", with: new_email)
       |> submit()
-      |> assert_has("div", text: "A code to confirm your email")
+      |> assert_path(~p"/confirm/email")
 
       assert Accounts.get_user_by_email(user.email)
+      refute Accounts.get_user_by_email(new_email)
     end
 
     test "renders errors with invalid data (phx-change)", %{conn: conn} do
@@ -33,48 +34,6 @@ defmodule ZoonkWeb.User.UserSettingsLiveTest do
       |> fill_in("Email address", with: user.email)
       |> submit()
       |> assert_has("p", text: "did not change")
-    end
-  end
-
-  describe "confirm email" do
-    setup %{conn: conn} do
-      user = user_fixture()
-      email = unique_user_email()
-
-      otp_code = extract_otp_code(Accounts.deliver_user_update_email_instructions(%{user | email: email}, user.email))
-
-      %{conn: login_user(conn, user), otp_code: otp_code, email: email, user: user}
-    end
-
-    test "updates the user email once", %{conn: conn, user: user, otp_code: otp_code, email: email} do
-      conn
-      |> visit(~p"/settings/confirm/#{otp_code}")
-      |> assert_path(~p"/settings")
-      |> assert_has("div", text: "Email changed successfully.")
-
-      refute Accounts.get_user_by_email(user.email)
-      assert Accounts.get_user_by_email(email)
-
-      # use confirm otp code again
-      conn
-      |> visit(~p"/settings/confirm/#{otp_code}")
-      |> assert_path(~p"/settings")
-      |> assert_has("div", text: "Email change link is invalid or it has expired.")
-    end
-
-    test "does not update email with invalid otp code", %{conn: conn, user: user} do
-      conn
-      |> visit(~p"/settings/confirm/oops")
-      |> assert_path(~p"/settings")
-      |> assert_has("div", text: "Email change link is invalid or it has expired.")
-
-      assert Accounts.get_user_by_email(user.email)
-    end
-
-    test "redirects if user is not logged in", %{otp_code: otp_code} do
-      build_conn()
-      |> visit(~p"/settings/confirm/#{otp_code}")
-      |> assert_path(~p"/login")
     end
   end
 end

--- a/test/zoonk_web/live/user/user_settings_live_test.exs
+++ b/test/zoonk_web/live/user/user_settings_live_test.exs
@@ -4,6 +4,7 @@ defmodule ZoonkWeb.User.UserSettingsLiveTest do
   import Zoonk.AccountFixtures
 
   alias Zoonk.Accounts
+  alias Zoonk.Config.AuthConfig
 
   describe "update email form" do
     setup :signup_and_login_user
@@ -34,6 +35,17 @@ defmodule ZoonkWeb.User.UserSettingsLiveTest do
       |> fill_in("Email address", with: user.email)
       |> submit()
       |> assert_has("p", text: "did not change")
+    end
+
+    test "redirects if user is not in sudo mode", %{conn: conn} do
+      sudo_minutes = AuthConfig.get_max_age(:sudo_mode, :minutes) - 1
+
+      conn
+      |> login_user(user_fixture(),
+        token_authenticated_at: DateTime.add(DateTime.utc_now(), sudo_minutes, :minute)
+      )
+      |> visit(~p"/settings")
+      |> assert_path(~p"/login")
     end
   end
 end

--- a/test/zoonk_web/live/user/user_signup_with_email_live_test.exs
+++ b/test/zoonk_web/live/user/user_signup_with_email_live_test.exs
@@ -66,7 +66,7 @@ defmodule ZoonkWeb.User.SignUpWithEmailLiveTest do
       |> visit(~p"/signup/email")
       |> fill_in("Email address", with: email)
       |> submit()
-      |> assert_path(~p"/signup/code")
+      |> assert_path(~p"/confirm/signup")
 
       user = Zoonk.Accounts.get_user_by_email(email)
       assert user.confirmed_at == nil

--- a/test/zoonk_web/live/user/user_signup_with_email_live_test.exs
+++ b/test/zoonk_web/live/user/user_signup_with_email_live_test.exs
@@ -66,7 +66,7 @@ defmodule ZoonkWeb.User.SignUpWithEmailLiveTest do
       |> visit(~p"/signup/email")
       |> fill_in("Email address", with: email)
       |> submit()
-      |> assert_has("p", text: "An email was sent to #{email}")
+      |> assert_path(~p"/signup/code")
 
       user = Zoonk.Accounts.get_user_by_email(email)
       assert user.confirmed_at == nil


### PR DESCRIPTION
Introduce a new OTP-based authentication mechanism for user login and signup.

This replaces the previous magic link solution.

Closes #202