### PR TITLE
Accounts: Include email on OTP verification

### DIFF
--- a/lib/zoonk/accounts.ex
+++ b/lib/zoonk/accounts.ex
@@ -188,18 +188,6 @@ defmodule Zoonk.Accounts do
   end
 
   @doc """
-  Gets the user with the given OTP code.
-  """
-  def get_user_by_otp_code(otp_code) do
-    with {:ok, query} <- UserToken.verify_otp_code_query(otp_code),
-         {user, _token} <- Repo.one(query) do
-      user
-    else
-      _error -> nil
-    end
-  end
-
-  @doc """
   Logs the user in by OTP code.
 
   There are three cases to consider:
@@ -212,8 +200,8 @@ defmodule Zoonk.Accounts do
      including session ones - are expired. In theory, no other tokens
      exist but we delete all of them for best security practices.
   """
-  def login_user_by_otp(otp_code) do
-    {:ok, query} = UserToken.verify_otp_code_query(otp_code)
+  def login_user_by_otp(otp_code, email) do
+    {:ok, query} = UserToken.verify_otp_code_query(otp_code, email)
 
     case Repo.one(query) do
       {%User{confirmed_at: nil} = user, _token} ->

--- a/lib/zoonk/accounts/user_token.ex
+++ b/lib/zoonk/accounts/user_token.ex
@@ -130,7 +130,7 @@ defmodule Zoonk.Accounts.UserToken do
   database. This function also checks if the code is being used within
   15 minutes. The context of an OTP code is always "login".
   """
-  def verify_otp_code_query(otp_code) do
+  def verify_otp_code_query(otp_code, email) do
     hashed_otp = :crypto.hash(AuthConfig.get_hash_algorithm(), otp_code)
 
     query =
@@ -138,6 +138,7 @@ defmodule Zoonk.Accounts.UserToken do
       |> by_token_and_context_query("login")
       |> join(:inner, [token], user in assoc(token, :user))
       |> where([token], token.inserted_at > ago(^AuthConfig.get_max_age(:otp, :minutes), "minute"))
+      |> where([token, user], token.sent_to == ^email)
       |> where([token, user], token.sent_to == user.email)
       |> select([token, user], {user, token})
 

--- a/lib/zoonk_web/api/v1/accounts/otp_controller.ex
+++ b/lib/zoonk_web/api/v1/accounts/otp_controller.ex
@@ -78,8 +78,8 @@ defmodule ZoonkWeb.API.V1.Accounts.OTPController do
   - 400 Bad Request if required parameters are missing
   - 401 Unauthorized if the code is invalid or expired
   """
-  def verify_code(conn, %{"code" => otp_code}) do
-    case Accounts.login_user_by_otp(otp_code) do
+  def verify_code(conn, %{"code" => otp_code, "email" => email}) do
+    case Accounts.login_user_by_otp(otp_code, email) do
       {:ok, user, _tokens_to_disconnect} ->
         token = Accounts.generate_user_session_token(user, decoded: false)
 

--- a/lib/zoonk_web/controllers/accounts/user_session_controller.ex
+++ b/lib/zoonk_web/controllers/accounts/user_session_controller.ex
@@ -32,8 +32,8 @@ defmodule ZoonkWeb.Accounts.UserSessionController do
     end
   end
 
-  def create(conn, %{"_action" => action, "user" => %{"code" => otp}}) do
-    case Accounts.login_user_by_otp(otp) do
+  def create(conn, %{"_action" => action, "user" => %{"code" => otp, "email" => email}}) do
+    case Accounts.login_user_by_otp(otp, email) do
       {:ok, user, tokens_to_disconnect} ->
         UserAuth.disconnect_sessions(tokens_to_disconnect)
 

--- a/lib/zoonk_web/live/auth/user_confirm_code_live.ex
+++ b/lib/zoonk_web/live/auth/user_confirm_code_live.ex
@@ -23,6 +23,8 @@ defmodule ZoonkWeb.User.UserConfirmCodeLive do
         aria-label={dgettext("users", "Enter your code")}
         class="mt-4 flex w-full flex-col gap-4"
       >
+        <.input type="hidden" field={f[:email]} />
+
         <.input
           field={f[:code]}
           label={dgettext("users", "One-time code")}
@@ -53,8 +55,9 @@ defmodule ZoonkWeb.User.UserConfirmCodeLive do
     {:ok, redirect(socket, to: UserAuth.signed_in_path(socket))}
   end
 
-  def mount(_params, _session, socket) do
-    form = to_form(%{"code" => ""}, as: :user)
+  def mount(params, _session, socket) do
+    email = get_user_email(socket.assigns, params)
+    form = to_form(%{"code" => "", "email" => email}, as: :user)
 
     socket =
       socket
@@ -63,6 +66,9 @@ defmodule ZoonkWeb.User.UserConfirmCodeLive do
 
     {:ok, socket}
   end
+
+  defp get_user_email(assigns, params) when is_nil(assigns.scope.user), do: params["email"]
+  defp get_user_email(assigns, _params), do: assigns.scope.user.email
 
   defp get_back_link(:email), do: ~p"/settings"
   defp get_back_link(:login), do: ~p"/login"

--- a/lib/zoonk_web/live/auth/user_login_with_email_live.ex
+++ b/lib/zoonk_web/live/auth/user_login_with_email_live.ex
@@ -57,6 +57,6 @@ defmodule ZoonkWeb.User.UserLoginWithEmailLive do
       Accounts.deliver_login_instructions(user)
     end
 
-    {:noreply, push_navigate(socket, to: ~p"/confirm/login")}
+    {:noreply, push_navigate(socket, to: ~p"/confirm/login?email=#{email}")}
   end
 end

--- a/lib/zoonk_web/live/auth/user_signup_with_email_live.ex
+++ b/lib/zoonk_web/live/auth/user_signup_with_email_live.ex
@@ -84,7 +84,7 @@ defmodule ZoonkWeb.User.UserSignUpWithEmailLive do
       {:ok, user} ->
         {:ok, _url_fn} = Accounts.deliver_login_instructions(user)
 
-        {:noreply, push_navigate(socket, to: ~p"/confirm/signup")}
+        {:noreply, push_navigate(socket, to: ~p"/confirm/signup?email=#{user.email}")}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply,

--- a/test/support/fixtures/account_fixtures.ex
+++ b/test/support/fixtures/account_fixtures.ex
@@ -50,7 +50,7 @@ defmodule Zoonk.AccountFixtures do
     |> UserProfile.changeset(%{picture_url: "https://zoonk.test/image.png"})
     |> Repo.update!()
 
-    {:ok, user, _expired_tokens} = Accounts.login_user_by_otp(otp_code)
+    {:ok, user, _expired_tokens} = Accounts.login_user_by_otp(otp_code, fixture.email)
 
     Repo.preload(user, preload)
   end

--- a/test/zoonk_web/api/v1/accounts/otp_controller_test.exs
+++ b/test/zoonk_web/api/v1/accounts/otp_controller_test.exs
@@ -73,7 +73,7 @@ defmodule ZoonkWeb.API.V1.Accounts.OTPControllerTest do
       user = user_fixture()
       otp_code = extract_otp_code(Accounts.deliver_login_instructions(user))
 
-      conn = post(conn, ~p"/api/v1/auth/verify_code", %{"code" => otp_code})
+      conn = post(conn, ~p"/api/v1/auth/verify_code", %{"code" => otp_code, "email" => user.email})
 
       assert %{"token" => token} = json_response(conn, 200)
       assert {%User{}, _token_inserted_at} = Accounts.get_user_by_session_token(token)
@@ -81,12 +81,12 @@ defmodule ZoonkWeb.API.V1.Accounts.OTPControllerTest do
 
     test "returns error when the code is invalid", %{conn: conn} do
       invalid_code = "invalid_code"
-      conn = post(conn, ~p"/api/v1/auth/verify_code", %{"code" => invalid_code})
+      conn = post(conn, ~p"/api/v1/auth/verify_code", %{"code" => invalid_code, "email" => unique_user_email()})
 
       assert %{"error" => %{"message" => "Invalid code or expired"}} = json_response(conn, 401)
     end
 
-    test "returns error when code is missing", %{conn: conn} do
+    test "returns error when parameters are missing", %{conn: conn} do
       conn = post(conn, ~p"/api/v1/auth/verify_code", %{})
       assert_json_error(conn, 400)
     end

--- a/test/zoonk_web/controllers/accounts/user_session_controller_test.exs
+++ b/test/zoonk_web/controllers/accounts/user_session_controller_test.exs
@@ -15,7 +15,7 @@ defmodule ZoonkWeb.Accounts.UserSessionControllerTest do
     test "logs the user in", %{conn: conn, user: user} do
       otp_code = generate_user_otp_code(user)
 
-      params = %{"_action" => "login", "user" => %{"code" => otp_code}}
+      params = %{"_action" => "login", "user" => %{"code" => otp_code, "email" => user.email}}
       post_conn = post(conn, ~p"/confirm", params)
 
       assert get_session(post_conn, :user_token)
@@ -28,8 +28,8 @@ defmodule ZoonkWeb.Accounts.UserSessionControllerTest do
       html_response(loggedin_conn, 200)
     end
 
-    test "redirects back to the code page when OTP code is invalid", %{conn: conn} do
-      params = %{"_action" => "login", "user" => %{"code" => "invalid_code"}}
+    test "redirects back to the code page when OTP code is invalid", %{conn: conn, user: user} do
+      params = %{"_action" => "login", "user" => %{"code" => "invalid_code", "email" => user.email}}
       conn = post(conn, ~p"/confirm", params)
       assert Phoenix.Flash.get(conn.assigns.flash, :error) == "Invalid code or account not found."
       assert redirected_to(conn) == ~p"/confirm/login"
@@ -44,7 +44,7 @@ defmodule ZoonkWeb.Accounts.UserSessionControllerTest do
     test "confirms the given code once", %{conn: conn, unconfirmed_user: user} do
       code = extract_otp_code(Accounts.deliver_login_instructions(user))
 
-      params = %{"_action" => "signup", "user" => %{"code" => code}}
+      params = %{"_action" => "signup", "user" => %{"code" => code, "email" => user.email}}
       post_conn = post(conn, ~p"/confirm", params)
 
       assert Repo.get!(User, user.id).confirmed_at
@@ -61,8 +61,8 @@ defmodule ZoonkWeb.Accounts.UserSessionControllerTest do
       refute get_session(logout_conn, :user_token)
     end
 
-    test "redirects back to the code page if the code is invalid", %{conn: conn} do
-      params = %{"_action" => "signup", "user" => %{"code" => "invalid_code"}}
+    test "redirects back to the code page if the code is invalid", %{conn: conn, user: user} do
+      params = %{"_action" => "signup", "user" => %{"code" => "invalid_code", "email" => user.email}}
       conn = post(conn, ~p"/confirm", params)
       assert redirected_to(conn) == ~p"/confirm/signup"
       assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "Invalid code or account not found."

--- a/test/zoonk_web/live/user/user_confirm_code_live_test.exs
+++ b/test/zoonk_web/live/user/user_confirm_code_live_test.exs
@@ -22,15 +22,17 @@ defmodule ZoonkWeb.User.UserConfirmCodeLiveTest do
       otp_code = generate_user_otp_code(user)
 
       conn
-      |> visit(~p"/confirm/login")
+      |> visit(~p"/confirm/login?email=#{user.email}")
       |> fill_in("One-time code", with: otp_code)
       |> submit()
       |> assert_path(~p"/")
     end
 
     test "shows error with an invalid code", %{conn: conn} do
+      user = user_fixture()
+
       conn
-      |> visit(~p"/confirm/login")
+      |> visit(~p"/confirm/login?email=#{user.email}")
       |> fill_in("One-time code", with: "invalid_code")
       |> submit()
       |> assert_has("div", text: "Invalid code or account not found.")
@@ -53,15 +55,17 @@ defmodule ZoonkWeb.User.UserConfirmCodeLiveTest do
       otp_code = generate_user_otp_code(user)
 
       conn
-      |> visit(~p"/confirm/signup")
+      |> visit(~p"/confirm/signup?email=#{user.email}")
       |> fill_in("One-time code", with: otp_code)
       |> submit()
       |> assert_path(~p"/")
     end
 
     test "shows error with an invalid code", %{conn: conn} do
+      user = user_fixture()
+
       conn
-      |> visit(~p"/confirm/signup")
+      |> visit(~p"/confirm/signup?email=#{user.email}")
       |> fill_in("One-time code", with: "invalid_code")
       |> submit()
       |> assert_has("div", text: "Invalid code or account not found.")

--- a/test/zoonk_web/live/user/user_login_with_email_live_test.exs
+++ b/test/zoonk_web/live/user/user_login_with_email_live_test.exs
@@ -23,7 +23,7 @@ defmodule ZoonkWeb.User.UserLoginWithEmailLiveTest do
       |> visit(~p"/login/email")
       |> fill_in("Email address", with: user.email)
       |> submit()
-      |> assert_path(~p"/confirm/login")
+      |> assert_path(~p"/confirm/login", query_params: %{email: user.email})
 
       assert Zoonk.Repo.get_by!(Zoonk.Accounts.UserToken, user_id: user.id).context == "login"
     end

--- a/test/zoonk_web/live/user/user_signup_with_email_live_test.exs
+++ b/test/zoonk_web/live/user/user_signup_with_email_live_test.exs
@@ -68,7 +68,7 @@ defmodule ZoonkWeb.User.SignUpWithEmailLiveTest do
       |> visit(~p"/signup/email")
       |> fill_in("Email address", with: email)
       |> submit()
-      |> assert_path(~p"/confirm/signup")
+      |> assert_path(~p"/confirm/signup", query_params: %{email: email})
 
       user = Zoonk.Accounts.get_user_by_email(email)
       assert user.confirmed_at == nil


### PR DESCRIPTION
Fixes a security issue where - even though unlikely - we could have a user being logged in as another user.

To prevent this, we're now passing the user's email address along with the OTP verification request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Email address is now required alongside the one-time code for OTP-based login and verification flows.
  - Confirmation and signup pages now include the user's email in the URL for improved context and usability.

- **Bug Fixes**
  - Improved user authentication accuracy by ensuring OTP codes are validated against both the code and the email address.

- **Tests**
  - Updated and expanded tests to cover new email requirements and ensure correct user identification during OTP login and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->