### PR TITLE
API: Add x-org-domain header

### DIFF
--- a/.github/copilot/commit.md
+++ b/.github/copilot/commit.md
@@ -6,7 +6,7 @@
   - For LiveView or frontend changes in `lib/zoonk_web/live/`, use the feature folder name as the prefix. For example:
     - Catalog: for changes in `lib/zoonk_web/live/catalog/`
     - Library: for changes in `lib/zoonk_web/live/library/`
-  - For API changes use `API: {Context}` as the prefix. For example: `API: Accounts`.
+  - For API changes use `API: {Context}:` as the prefix. For example: `API: Accounts:`.
   - For asset changes in `assets/`, use Assets.
   - For changes in the `guides` folder, use Docs.
   - When adding a component, use `Components: Add {component_name}`. Don't do `Components: Add {component_name} component` or `Components: Add {component_name} and preview`. It's implicit that it's a component and we're adding a preview.

--- a/lib/zoonk_web/api/v1/accounts/otp_controller.ex
+++ b/lib/zoonk_web/api/v1/accounts/otp_controller.ex
@@ -71,6 +71,7 @@ defmodule ZoonkWeb.API.V1.Accounts.OTPController do
   ## Request body fields
 
   - `code` - The OTP code to verify (required)
+  - `email` - User's email address (required)
 
   ## Response
 

--- a/lib/zoonk_web/user_auth.ex
+++ b/lib/zoonk_web/user_auth.ex
@@ -326,7 +326,7 @@ defmodule ZoonkWeb.UserAuth do
   end
 
   defp build_scope(user, []), do: build_scope(user, nil)
-  defp build_scope(user, [domain_header]), do: build_scope(user, domain_header)
+  defp build_scope(user, [domain_header | _rest]), do: build_scope(user, domain_header)
 
   # It's a public context only if the LiveView module is from a public page AND the org is public.
   defp public_context?(context, %Scope{org: org}) when is_atom(context) and org.kind in [:app, :creator] do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -73,6 +73,19 @@ defmodule ZoonkWeb.ConnCase do
   end
 
   @doc """
+  Setup basic app for the API.
+
+      setup :setup_api_app
+  """
+  def setup_api_app(%{conn: conn}) do
+    app_org = Zoonk.OrgFixtures.app_org_fixture()
+
+    conn = Plug.Conn.put_req_header(conn, "x-org-domain", app_org.custom_domain)
+
+    %{conn: conn}
+  end
+
+  @doc """
   Logs the given `user` into the `conn`.
 
   It returns an updated `conn`.

--- a/test/zoonk_web/api/v1/accounts/otp_controller_test.exs
+++ b/test/zoonk_web/api/v1/accounts/otp_controller_test.exs
@@ -8,7 +8,7 @@ defmodule ZoonkWeb.API.V1.Accounts.OTPControllerTest do
   alias Zoonk.Accounts.User
 
   describe "signup/2" do
-    setup :setup_app
+    setup :setup_api_app
 
     test "creates a user and delivers login instructions when data is valid", %{conn: conn} do
       email = unique_user_email()
@@ -44,7 +44,7 @@ defmodule ZoonkWeb.API.V1.Accounts.OTPControllerTest do
   end
 
   describe "request_code/2" do
-    setup :setup_app
+    setup :setup_api_app
 
     test "delivers login instructions when email exists", %{conn: conn} do
       email = user_fixture().email
@@ -67,7 +67,7 @@ defmodule ZoonkWeb.API.V1.Accounts.OTPControllerTest do
   end
 
   describe "verify_code/2" do
-    setup :setup_app
+    setup :setup_api_app
 
     test "returns a session token when the code is valid", %{conn: conn} do
       user = user_fixture()

--- a/test/zoonk_web/user_auth_test.exs
+++ b/test/zoonk_web/user_auth_test.exs
@@ -334,12 +334,28 @@ defmodule ZoonkWeb.UserAuthTest do
   end
 
   describe "fetch_api_scope/2" do
-    test "authenticates user with valid bearer token", %{conn: conn, user: user, org: org} do
+    test "authenticates user with valid bearer token", %{conn: conn, user: user} do
+      org = app_org_fixture()
       user_token = Accounts.generate_user_session_token(user, decoded: false)
 
       conn =
         conn
         |> put_req_header("authorization", "Bearer #{user_token}")
+        |> put_req_header("x-org-domain", org.custom_domain)
+        |> UserAuth.fetch_api_scope([])
+
+      assert conn.assigns.scope.user.id == user.id
+      assert conn.assigns.scope.org.id == org.id
+    end
+
+    test "adds the correct org to the scope", %{conn: conn, user: user} do
+      org = org_fixture()
+      user_token = Accounts.generate_user_session_token(user, decoded: false)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{user_token}")
+        |> put_req_header("x-org-domain", org.custom_domain)
         |> UserAuth.fetch_api_scope([])
 
       assert conn.assigns.scope.user.id == user.id


### PR DESCRIPTION
Use the `x-org-domain` to allow us to properly build the scope for the correct organization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated commit message guidelines for API changes to require a colon after the context name.
  - Clarified API documentation to specify that both email and code are required for OTP verification.
  - Added usage instructions for a new API test setup helper.

- **New Features**
  - Introduced a test helper to streamline API test setup with organization domain headers.

- **Bug Fixes**
  - Improved API scope handling to correctly process organization domain headers from requests.

- **Tests**
  - Enhanced tests to explicitly verify organization assignment via headers in authentication logic.
  - Updated test setups to use the new API app setup helper for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->