### PR TITLE
Helpers: Add to_existing_atom/1

### DIFF
--- a/lib/zoonk/helpers.ex
+++ b/lib/zoonk/helpers.ex
@@ -207,4 +207,28 @@ defmodule Zoonk.Helpers do
 
   def with_decoded_token({:ok, decoded_token}, fun, _error_value), do: fun.(decoded_token)
   def with_decoded_token(_error, _fun, error_value), do: error_value
+
+  @doc """
+  Converts a string to an existing atom.
+
+  Returns `nil` if the atom doesn't exist instead of raising an error.
+
+  ## Examples
+
+      iex> to_existing_atom("catalog")
+      :catalog
+
+      iex> to_existing_atom("non_existent_atom")
+      nil
+
+      iex> to_existing_atom(nil)
+      nil
+  """
+  def to_existing_atom(nil), do: nil
+
+  def to_existing_atom(string) when is_binary(string) do
+    String.to_existing_atom(string)
+  rescue
+    ArgumentError -> nil
+  end
 end

--- a/test/zoonk/helpers_test.exs
+++ b/test/zoonk/helpers_test.exs
@@ -185,4 +185,24 @@ defmodule Zoonk.HelpersTest do
       assert result == {"token", 123}
     end
   end
+
+  describe "to_existing_atom/1" do
+    test "converts a string to an existing atom" do
+      assert to_existing_atom("catalog") == :catalog
+      assert to_existing_atom("accounts") == :accounts
+    end
+
+    test "returns nil for non-existent atoms" do
+      assert to_existing_atom("non_existent_atom") == nil
+    end
+
+    test "returns nil when the input is nil" do
+      assert to_existing_atom(nil) == nil
+    end
+
+    test "does not create new atoms" do
+      random_string = "random_#{System.unique_integer([:positive])}"
+      assert to_existing_atom(random_string) == nil
+    end
+  end
 end


### PR DESCRIPTION
Introduce a new function to convert a string to an existing atom, returning `nil` for non-existent atoms or `nil` input.