### PR TITLE
Workaround for handling Next.js 16 router caching

### DIFF
--- a/apps/main/src/app/[locale]/(catalog)/learn/start-course-form.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/learn/start-course-form.tsx
@@ -29,7 +29,9 @@ export function StartCourseForm() {
 
     if (query) {
       const encodedQuery = encodeURIComponent(query);
+      setIsLoading(false);
       push(`/learn/${encodedQuery}`);
+      form.reset();
     }
   };
 

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -10,6 +10,7 @@ import {
   Title,
   Trigger,
 } from "@radix-ui/react-dialog";
+import { useRemovePortal } from "@zoonk/ui/hooks/use-remove-portal";
 import { cn } from "@zoonk/ui/lib/utils";
 import { XIcon } from "lucide-react";
 import type * as React from "react";
@@ -23,6 +24,8 @@ function DialogTrigger({ ...props }: React.ComponentProps<typeof Trigger>) {
 }
 
 function DialogPortal({ ...props }: React.ComponentProps<typeof Portal>) {
+  useRemovePortal();
+  useRemovePortal("[data-slot='dialog-overlay']");
   return <Portal data-slot="dialog-portal" {...props} />;
 }
 

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -17,6 +17,7 @@ import {
   SubTrigger,
   Trigger,
 } from "@radix-ui/react-dropdown-menu";
+import { useRemovePortal } from "@zoonk/ui/hooks/use-remove-portal";
 import { cn } from "@zoonk/ui/lib/utils";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 import type * as React from "react";
@@ -26,6 +27,7 @@ function DropdownMenu({ ...props }: React.ComponentProps<typeof Root>) {
 }
 
 function DropdownMenuPortal({ ...props }: React.ComponentProps<typeof Portal>) {
+  useRemovePortal("[data-radix-popper-content-wrapper]");
   return <Portal data-slot="dropdown-menu-portal" {...props} />;
 }
 
@@ -41,7 +43,7 @@ function DropdownMenuContent({
   ...props
 }: React.ComponentProps<typeof Content>) {
   return (
-    <Portal>
+    <DropdownMenuPortal>
       <Content
         className={cn(
           "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in",
@@ -51,7 +53,7 @@ function DropdownMenuContent({
         sideOffset={sideOffset}
         {...props}
       />
-    </Portal>
+    </DropdownMenuPortal>
   );
 }
 

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -17,6 +17,7 @@ import {
   Value,
   Viewport,
 } from "@radix-ui/react-select";
+import { useRemovePortal } from "@zoonk/ui/hooks/use-remove-portal";
 import { cn } from "@zoonk/ui/lib/utils";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import type * as React from "react";
@@ -65,6 +66,8 @@ function SelectContent({
   position = "popper",
   ...props
 }: React.ComponentProps<typeof Content>) {
+  useRemovePortal("[data-radix-select-viewport]");
+
   return (
     <Portal>
       <Content

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -13,6 +13,7 @@ import {
 import { cn } from "@zoonk/ui/lib/utils";
 import { XIcon } from "lucide-react";
 import type * as React from "react";
+import { useRemovePortal } from "../hooks/use-remove-portal";
 
 function Sheet({ ...props }: React.ComponentProps<typeof Root>) {
   return <Root data-slot="sheet" {...props} />;
@@ -27,6 +28,8 @@ function SheetClose({ ...props }: React.ComponentProps<typeof Close>) {
 }
 
 function SheetPortal({ ...props }: React.ComponentProps<typeof Portal>) {
+  useRemovePortal();
+  useRemovePortal("[data-slot='sheet-overlay']");
   return <Portal data-slot="sheet-portal" {...props} />;
 }
 

--- a/packages/ui/src/hooks/use-remove-portal.ts
+++ b/packages/ui/src/hooks/use-remove-portal.ts
@@ -1,0 +1,14 @@
+import { useLayoutEffect } from "react";
+
+export function useRemovePortal(selector = "[role='dialog']") {
+  useLayoutEffect(
+    () => () => {
+      const el = document.querySelector(selector);
+
+      if (el) {
+        el.classList.add("hidden");
+      }
+    },
+    [selector],
+  );
+}

--- a/packages/ui/src/hooks/use-remove-portal.ts
+++ b/packages/ui/src/hooks/use-remove-portal.ts
@@ -1,5 +1,21 @@
 import { useLayoutEffect } from "react";
 
+/**
+ * This is a workaround for this issue:
+ * https://github.com/facebook/react/issues/35000
+ *
+ * On Next.js 16, they're using `Activity` to cache routes.
+ * However, `Activity` doesn't hide portals, making them visible on the new route.
+ *
+ * See these links for more context:
+ *
+ * - https://github.com/vercel/next.js/issues/85390
+ * - https://github.com/vercel/next.js/pull/84923
+ *
+ * We can remove this hook once this is fixed on React or Next.js adds a separate
+ * flag for routing caching. Right now, we can't disable it without also disabling
+ * `cacheComponents`.
+ */
 export function useRemovePortal(selector = "[role='dialog']") {
   useLayoutEffect(
     () => () => {


### PR DESCRIPTION
Next.js 16 merged the `routerBfCache` flag with `cacheComponents` on https://github.com/vercel/next.js/pull/84923

This means we can no longer use `cacheComponents` without also using `routerBfCache`, which broke our components using Radix Portal and our form. We need to double-check other pages as well because this can cause more unexpected behavior since Next.js now preserves the state when navigating back/forward.

We never want this behavior but there isn't a way to disable it right now. So, we need to also test all pages to spot more broken behavior caused by this.

We can partially revert this if https://github.com/facebook/react/issues/35000 is fixed since `Activity` doesn't hide portals. However, this will cause other issues. Basically, we need to make sure we're always resetting a page's state before navigation.

## References

- https://github.com/facebook/react/issues/35000
- https://github.com/vercel/next.js/issues/85390
- https://github.com/vercel/next.js/pull/84923
- https://github.com/vercel/next.js/pull/85309