### PR TITLE
feat(core): add alternative titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,7 @@ All packages should follow a consistent structure:
 - Always build skeleton components when using `Suspense` for loading states
 - Don't add comments to a component's props
 - Pass types directly to the component declaration instead of using `type` since those types won't be exported/reused
+- When adding a new Prisma model, always add a seed for it in `packages/db/src/prisma/seed/`
 
 ## Testing
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,10 @@
   },
   "exports": {
     "./ai": "./src/ai.ts",
+    "./alternative-titles/add": "./src/alternative-titles/add-alternative-titles.ts",
+    "./alternative-titles/delete": "./src/alternative-titles/delete-alternative-titles.ts",
+    "./alternative-titles/find": "./src/alternative-titles/find-alternative-title.ts",
+    "./alternative-titles/list": "./src/alternative-titles/list-alternative-titles.ts",
     "./auth": "./src/auth/auth.ts",
     "./auth/client": "./src/auth/client.ts",
     "./auth/hooks/auth-state": "./src/auth/hooks/auth-state.ts",

--- a/packages/core/src/alternative-titles/add-alternative-titles.test.ts
+++ b/packages/core/src/alternative-titles/add-alternative-titles.test.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { describe, expect, test } from "vitest";
+import { addAlternativeTitles } from "./add-alternative-titles";
+
+describe("addAlternativeTitles", () => {
+  test("adds alternative titles to a course", async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({ organizationId: org.id });
+
+    const suffix = randomUUID().slice(0, 8);
+
+    await addAlternativeTitles({
+      courseId: course.id,
+      locale: "en",
+      titles: [
+        `Frontend Development ${suffix}`,
+        `Frontend Engineering ${suffix}`,
+      ],
+    });
+
+    const titles = await prisma.courseAlternativeTitle.findMany({
+      orderBy: { slug: "asc" },
+      select: { slug: true },
+      where: { courseId: course.id },
+    });
+
+    expect(titles).toEqual([
+      { slug: `frontend-development-${suffix}` },
+      { slug: `frontend-engineering-${suffix}` },
+    ]);
+  });
+
+  test("converts titles to slugs", async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({ organizationId: org.id });
+
+    const suffix = randomUUID().slice(0, 8);
+
+    await addAlternativeTitles({
+      courseId: course.id,
+      locale: "en",
+      titles: [`Machine Learning Basics! ${suffix}`],
+    });
+
+    const titles = await prisma.courseAlternativeTitle.findMany({
+      select: { slug: true },
+      where: { courseId: course.id },
+    });
+
+    expect(titles).toEqual([{ slug: `machine-learning-basics-${suffix}` }]);
+  });
+
+  test("removes duplicate titles", async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({ organizationId: org.id });
+
+    const suffix = randomUUID().slice(0, 8);
+    const title = `React ${suffix}`;
+
+    await addAlternativeTitles({
+      courseId: course.id,
+      locale: "en",
+      titles: [title, title, title.toLowerCase()],
+    });
+
+    const titles = await prisma.courseAlternativeTitle.findMany({
+      select: { slug: true },
+      where: { courseId: course.id },
+    });
+
+    expect(titles).toEqual([{ slug: `react-${suffix}` }]);
+  });
+
+  test("silently ignores duplicate titles across courses", async () => {
+    const org = await organizationFixture();
+    const course1 = await courseFixture({ organizationId: org.id });
+    const course2 = await courseFixture({ organizationId: org.id });
+
+    const suffix = randomUUID().slice(0, 8);
+    const sharedTitle = `Vue.js ${suffix}`;
+    const uniqueTitle = `Angular ${suffix}`;
+
+    await addAlternativeTitles({
+      courseId: course1.id,
+      locale: "en",
+      titles: [sharedTitle],
+    });
+
+    await addAlternativeTitles({
+      courseId: course2.id,
+      locale: "en",
+      titles: [sharedTitle, uniqueTitle],
+    });
+
+    const course2Titles = await prisma.courseAlternativeTitle.findMany({
+      select: { slug: true },
+      where: { courseId: course2.id },
+    });
+
+    expect(course2Titles).toEqual([{ slug: `angular-${suffix}` }]);
+  });
+
+  test("does nothing when titles array is empty", async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({ organizationId: org.id });
+
+    await addAlternativeTitles({
+      courseId: course.id,
+      locale: "en",
+      titles: [],
+    });
+
+    const titles = await prisma.courseAlternativeTitle.findMany({
+      where: { courseId: course.id },
+    });
+
+    expect(titles).toEqual([]);
+  });
+
+  test("filters out empty slugs", async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({ organizationId: org.id });
+
+    const suffix = randomUUID().slice(0, 8);
+
+    await addAlternativeTitles({
+      courseId: course.id,
+      locale: "en",
+      titles: ["", "   ", `Valid Title ${suffix}`],
+    });
+
+    const titles = await prisma.courseAlternativeTitle.findMany({
+      select: { slug: true },
+      where: { courseId: course.id },
+    });
+
+    expect(titles).toEqual([{ slug: `valid-title-${suffix}` }]);
+  });
+});

--- a/packages/core/src/alternative-titles/add-alternative-titles.ts
+++ b/packages/core/src/alternative-titles/add-alternative-titles.ts
@@ -1,0 +1,26 @@
+import "server-only";
+
+import { prisma } from "@zoonk/db";
+import { toSlug } from "@zoonk/utils/string";
+
+export async function addAlternativeTitles(params: {
+  courseId: number;
+  titles: string[];
+  locale: string;
+}): Promise<void> {
+  const slugs = params.titles.map((title) => toSlug(title));
+  const uniqueSlugs = [...new Set(slugs)].filter(Boolean);
+
+  if (uniqueSlugs.length === 0) {
+    return;
+  }
+
+  await prisma.courseAlternativeTitle.createMany({
+    data: uniqueSlugs.map((slug) => ({
+      courseId: params.courseId,
+      locale: params.locale,
+      slug,
+    })),
+    skipDuplicates: true,
+  });
+}

--- a/packages/core/src/alternative-titles/delete-alternative-titles.test.ts
+++ b/packages/core/src/alternative-titles/delete-alternative-titles.test.ts
@@ -1,0 +1,150 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { describe, expect, test } from "vitest";
+import { addAlternativeTitles } from "./add-alternative-titles";
+import { deleteAlternativeTitles } from "./delete-alternative-titles";
+
+describe("deleteAlternativeTitles", () => {
+  test("deletes specific alternative titles from a course", async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({ organizationId: org.id });
+
+    const suffix = randomUUID().slice(0, 8);
+    const title1 = `frontend-development-${suffix}`;
+    const title2 = `frontend-engineering-${suffix}`;
+    const title3 = `frontend-dev-${suffix}`;
+
+    await addAlternativeTitles({
+      courseId: course.id,
+      locale: "en",
+      titles: [title1, title2, title3],
+    });
+
+    await deleteAlternativeTitles({
+      courseId: course.id,
+      titles: [title1],
+    });
+
+    const remaining = await prisma.courseAlternativeTitle.findMany({
+      orderBy: { slug: "asc" },
+      select: { slug: true },
+      where: { courseId: course.id },
+    });
+
+    expect(remaining).toEqual([{ slug: title3 }, { slug: title2 }]);
+  });
+
+  test("deletes multiple titles at once", async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({ organizationId: org.id });
+
+    const suffix = randomUUID().slice(0, 8);
+
+    await addAlternativeTitles({
+      courseId: course.id,
+      locale: "en",
+      titles: [`react-${suffix}`, `vue-${suffix}`, `angular-${suffix}`],
+    });
+
+    await deleteAlternativeTitles({
+      courseId: course.id,
+      titles: [`react-${suffix}`, `angular-${suffix}`],
+    });
+
+    const remaining = await prisma.courseAlternativeTitle.findMany({
+      select: { slug: true },
+      where: { courseId: course.id },
+    });
+
+    expect(remaining).toEqual([{ slug: `vue-${suffix}` }]);
+  });
+
+  test("handles deleting non-existent titles gracefully", async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({ organizationId: org.id });
+
+    const suffix = randomUUID().slice(0, 8);
+
+    await addAlternativeTitles({
+      courseId: course.id,
+      locale: "en",
+      titles: [`python-${suffix}`],
+    });
+
+    await deleteAlternativeTitles({
+      courseId: course.id,
+      titles: ["nonexistent-title"],
+    });
+
+    const remaining = await prisma.courseAlternativeTitle.findMany({
+      select: { slug: true },
+      where: { courseId: course.id },
+    });
+
+    expect(remaining).toEqual([{ slug: `python-${suffix}` }]);
+  });
+
+  test("does nothing when titles array is empty", async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({ organizationId: org.id });
+
+    const suffix = randomUUID().slice(0, 8);
+
+    await addAlternativeTitles({
+      courseId: course.id,
+      locale: "en",
+      titles: [`javascript-${suffix}`],
+    });
+
+    await deleteAlternativeTitles({
+      courseId: course.id,
+      titles: [],
+    });
+
+    const remaining = await prisma.courseAlternativeTitle.findMany({
+      select: { slug: true },
+      where: { courseId: course.id },
+    });
+
+    expect(remaining).toEqual([{ slug: `javascript-${suffix}` }]);
+  });
+
+  test("only deletes titles from the specified course", async () => {
+    const org = await organizationFixture();
+    const course1 = await courseFixture({ organizationId: org.id });
+    const course2 = await courseFixture({ organizationId: org.id });
+
+    const suffix = randomUUID().slice(0, 8);
+
+    await addAlternativeTitles({
+      courseId: course1.id,
+      locale: "en",
+      titles: [`typescript-${suffix}`],
+    });
+
+    await addAlternativeTitles({
+      courseId: course2.id,
+      locale: "en",
+      titles: [`go-programming-${suffix}`],
+    });
+
+    await deleteAlternativeTitles({
+      courseId: course1.id,
+      titles: [`typescript-${suffix}`, `go-programming-${suffix}`],
+    });
+
+    const course1Titles = await prisma.courseAlternativeTitle.findMany({
+      where: { courseId: course1.id },
+    });
+
+    const course2Titles = await prisma.courseAlternativeTitle.findMany({
+      select: { slug: true },
+      where: { courseId: course2.id },
+    });
+
+    expect(course1Titles).toEqual([]);
+    expect(course2Titles).toEqual([{ slug: `go-programming-${suffix}` }]);
+  });
+});

--- a/packages/core/src/alternative-titles/delete-alternative-titles.ts
+++ b/packages/core/src/alternative-titles/delete-alternative-titles.ts
@@ -1,0 +1,22 @@
+import "server-only";
+
+import { prisma } from "@zoonk/db";
+import { toSlug } from "@zoonk/utils/string";
+
+export async function deleteAlternativeTitles(params: {
+  courseId: number;
+  titles: string[];
+}): Promise<void> {
+  const slugs = params.titles.map((title) => toSlug(title));
+
+  if (slugs.length === 0) {
+    return;
+  }
+
+  await prisma.courseAlternativeTitle.deleteMany({
+    where: {
+      courseId: params.courseId,
+      slug: { in: slugs },
+    },
+  });
+}

--- a/packages/core/src/alternative-titles/find-alternative-title.test.ts
+++ b/packages/core/src/alternative-titles/find-alternative-title.test.ts
@@ -1,0 +1,119 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { describe, expect, test } from "vitest";
+import { addAlternativeTitles } from "./add-alternative-titles";
+import { findAlternativeTitle } from "./find-alternative-title";
+
+async function getOrCreateAIOrg() {
+  return prisma.organization.upsert({
+    create: { name: "AI", slug: AI_ORG_SLUG },
+    update: {},
+    where: { slug: AI_ORG_SLUG },
+  });
+}
+
+describe("findAlternativeTitle", () => {
+  test("returns course when alternative title matches", async () => {
+    const org = await getOrCreateAIOrg();
+    const course = await courseFixture({
+      language: "en",
+      organizationId: org.id,
+    });
+
+    const uniqueTitle = `Frontend Development ${randomUUID()}`;
+
+    await addAlternativeTitles({
+      courseId: course.id,
+      locale: "en",
+      titles: [uniqueTitle],
+    });
+
+    const result = await findAlternativeTitle({
+      locale: "en",
+      title: uniqueTitle,
+    });
+
+    expect(result).toEqual({ language: "en", slug: course.slug });
+  });
+
+  test("returns course when title matches with different casing", async () => {
+    const org = await getOrCreateAIOrg();
+    const course = await courseFixture({
+      language: "en",
+      organizationId: org.id,
+    });
+
+    const uniqueTitle = `Machine Learning ${randomUUID()}`;
+
+    await addAlternativeTitles({
+      courseId: course.id,
+      locale: "en",
+      titles: [uniqueTitle],
+    });
+
+    const result = await findAlternativeTitle({
+      locale: "en",
+      title: uniqueTitle.toLowerCase(),
+    });
+
+    expect(result).toEqual({ language: "en", slug: course.slug });
+  });
+
+  test("returns null when title does not match", async () => {
+    const result = await findAlternativeTitle({
+      locale: "en",
+      title: `Nonexistent Course ${randomUUID()}`,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null when course belongs to non-AI org", async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({
+      language: "en",
+      organizationId: org.id,
+    });
+
+    const uniqueTitle = `React Development ${randomUUID()}`;
+
+    await addAlternativeTitles({
+      courseId: course.id,
+      locale: "en",
+      titles: [uniqueTitle],
+    });
+
+    const result = await findAlternativeTitle({
+      locale: "en",
+      title: uniqueTitle,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null when locale does not match", async () => {
+    const org = await getOrCreateAIOrg();
+    const course = await courseFixture({
+      language: "en",
+      organizationId: org.id,
+    });
+
+    const uniqueTitle = `Python Programming ${randomUUID()}`;
+
+    await addAlternativeTitles({
+      courseId: course.id,
+      locale: "en",
+      titles: [uniqueTitle],
+    });
+
+    const result = await findAlternativeTitle({
+      locale: "pt",
+      title: uniqueTitle,
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/core/src/alternative-titles/find-alternative-title.ts
+++ b/packages/core/src/alternative-titles/find-alternative-title.ts
@@ -5,10 +5,11 @@ import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { toSlug } from "@zoonk/utils/string";
 import { cache } from "react";
 
-type FindResult = { slug: string; language: string } | null;
-
 export const findAlternativeTitle = cache(
-  async (params: { title: string; locale: string }): Promise<FindResult> => {
+  async (params: {
+    title: string;
+    locale: string;
+  }): Promise<{ slug: string; language: string } | null> => {
     const slug = toSlug(params.title);
 
     const result = await prisma.courseAlternativeTitle.findUnique({

--- a/packages/core/src/alternative-titles/find-alternative-title.ts
+++ b/packages/core/src/alternative-titles/find-alternative-title.ts
@@ -1,0 +1,33 @@
+import "server-only";
+
+import { prisma } from "@zoonk/db";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { toSlug } from "@zoonk/utils/string";
+import { cache } from "react";
+
+type FindResult = { slug: string; language: string } | null;
+
+export const findAlternativeTitle = cache(
+  async (params: { title: string; locale: string }): Promise<FindResult> => {
+    const slug = toSlug(params.title);
+
+    const result = await prisma.courseAlternativeTitle.findUnique({
+      select: {
+        course: {
+          select: {
+            language: true,
+            organization: { select: { slug: true } },
+            slug: true,
+          },
+        },
+      },
+      where: { localeSlug: { locale: params.locale, slug } },
+    });
+
+    if (!result || result.course.organization.slug !== AI_ORG_SLUG) {
+      return null;
+    }
+
+    return { language: result.course.language, slug: result.course.slug };
+  },
+);

--- a/packages/core/src/alternative-titles/list-alternative-titles.test.ts
+++ b/packages/core/src/alternative-titles/list-alternative-titles.test.ts
@@ -52,4 +52,21 @@ describe("listAlternativeTitles", () => {
       `zebra-${suffix}`,
     ]);
   });
+
+  test("returns alternative titles by course slug", async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({ organizationId: org.id });
+
+    const suffix = randomUUID().slice(0, 8);
+
+    await addAlternativeTitles({
+      courseId: course.id,
+      locale: "en",
+      titles: [`foo-${suffix}`, `bar-${suffix}`],
+    });
+
+    const result = await listAlternativeTitles({ courseSlug: course.slug });
+
+    expect(result).toEqual([`bar-${suffix}`, `foo-${suffix}`]);
+  });
 });

--- a/packages/core/src/alternative-titles/list-alternative-titles.test.ts
+++ b/packages/core/src/alternative-titles/list-alternative-titles.test.ts
@@ -1,0 +1,55 @@
+import { randomUUID } from "node:crypto";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { describe, expect, test } from "vitest";
+import { addAlternativeTitles } from "./add-alternative-titles";
+import { listAlternativeTitles } from "./list-alternative-titles";
+
+describe("listAlternativeTitles", () => {
+  test("returns all alternative titles for a course", async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({ organizationId: org.id });
+
+    const suffix = randomUUID().slice(0, 8);
+
+    await addAlternativeTitles({
+      courseId: course.id,
+      locale: "en",
+      titles: [`aaa-${suffix}`, `bbb-${suffix}`, `ccc-${suffix}`],
+    });
+
+    const result = await listAlternativeTitles({ courseId: course.id });
+
+    expect(result).toEqual([`aaa-${suffix}`, `bbb-${suffix}`, `ccc-${suffix}`]);
+  });
+
+  test("returns empty array when course has no alternative titles", async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({ organizationId: org.id });
+
+    const result = await listAlternativeTitles({ courseId: course.id });
+
+    expect(result).toEqual([]);
+  });
+
+  test("returns titles sorted alphabetically", async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({ organizationId: org.id });
+
+    const suffix = randomUUID().slice(0, 8);
+
+    await addAlternativeTitles({
+      courseId: course.id,
+      locale: "en",
+      titles: [`zebra-${suffix}`, `apple-${suffix}`, `mango-${suffix}`],
+    });
+
+    const result = await listAlternativeTitles({ courseId: course.id });
+
+    expect(result).toEqual([
+      `apple-${suffix}`,
+      `mango-${suffix}`,
+      `zebra-${suffix}`,
+    ]);
+  });
+});

--- a/packages/core/src/alternative-titles/list-alternative-titles.ts
+++ b/packages/core/src/alternative-titles/list-alternative-titles.ts
@@ -3,12 +3,21 @@ import "server-only";
 import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
+type ListAlternativeTitlesParams =
+  | { courseId: number }
+  | { courseSlug: string };
+
 export const listAlternativeTitles = cache(
-  async (params: { courseId: number }): Promise<string[]> => {
+  async (params: ListAlternativeTitlesParams): Promise<string[]> => {
+    const where =
+      "courseId" in params
+        ? { courseId: params.courseId }
+        : { course: { slug: params.courseSlug } };
+
     const results = await prisma.courseAlternativeTitle.findMany({
       orderBy: { slug: "asc" },
       select: { slug: true },
-      where: { courseId: params.courseId },
+      where,
     });
 
     return results.map((r) => r.slug);

--- a/packages/core/src/alternative-titles/list-alternative-titles.ts
+++ b/packages/core/src/alternative-titles/list-alternative-titles.ts
@@ -1,0 +1,16 @@
+import "server-only";
+
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const listAlternativeTitles = cache(
+  async (params: { courseId: number }): Promise<string[]> => {
+    const results = await prisma.courseAlternativeTitle.findMany({
+      orderBy: { slug: "asc" },
+      select: { slug: true },
+      where: { courseId: params.courseId },
+    });
+
+    return results.map((r) => r.slug);
+  },
+);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,6 +7,7 @@ export type { CoursePermission, UserWithRole } from "@zoonk/auth/types";
 export type {
   Account,
   Course,
+  CourseAlternativeTitle,
   CourseSuggestion,
   Invitation,
   Member,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -19,6 +19,7 @@ export type {
   Account,
   Chapter,
   Course,
+  CourseAlternativeTitle,
   CourseChapter,
   CourseSuggestion,
   Invitation,

--- a/packages/db/src/prisma/migrations/20251227152403_add_alternative_titles/migration.sql
+++ b/packages/db/src/prisma/migrations/20251227152403_add_alternative_titles/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "course_alternative_titles" (
+    "id" SERIAL NOT NULL,
+    "course_id" INTEGER NOT NULL,
+    "slug" TEXT NOT NULL,
+    "locale" VARCHAR(10) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "course_alternative_titles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "course_alternative_titles_course_id_idx" ON "course_alternative_titles"("course_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "course_alternative_titles_locale_slug_key" ON "course_alternative_titles"("locale", "slug");
+
+-- AddForeignKey
+ALTER TABLE "course_alternative_titles" ADD CONSTRAINT "course_alternative_titles_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "courses"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/src/prisma/models/courses.prisma
+++ b/packages/db/src/prisma/models/courses.prisma
@@ -11,22 +11,36 @@ model CourseSuggestion {
 }
 
 model Course {
-  id              Int             @id @default(autoincrement())
-  organizationId  Int             @map("organization_id")
-  organization    Organization    @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  isPublished     Boolean         @default(false) @map("is_published")
-  language        String          @db.VarChar(10)
-  slug            String
-  title           String
-  normalizedTitle String          @map("normalized_title")
-  description     String
-  imageUrl        String?         @map("image_url")
-  createdAt       DateTime        @default(now()) @map("created_at")
-  updatedAt       DateTime        @default(now()) @updatedAt @map("updated_at")
-  courseChapters  CourseChapter[]
+  id                Int                      @id @default(autoincrement())
+  organizationId    Int                      @map("organization_id")
+  organization      Organization             @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  isPublished       Boolean                  @default(false) @map("is_published")
+  language          String                   @db.VarChar(10)
+  slug              String
+  title             String
+  normalizedTitle   String                   @map("normalized_title")
+  description       String
+  imageUrl          String?                  @map("image_url")
+  createdAt         DateTime                 @default(now()) @map("created_at")
+  updatedAt         DateTime                 @default(now()) @updatedAt @map("updated_at")
+  courseChapters    CourseChapter[]
+  alternativeTitles CourseAlternativeTitle[]
 
   @@unique([organizationId, language, slug], name: "orgSlug")
   @@index([organizationId, language, isPublished])
   @@index([organizationId, normalizedTitle])
   @@map("courses")
+}
+
+model CourseAlternativeTitle {
+  id        Int      @id @default(autoincrement())
+  courseId  Int      @map("course_id")
+  course    Course   @relation(fields: [courseId], references: [id], onDelete: Cascade)
+  slug      String
+  locale    String   @db.VarChar(10)
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@unique([locale, slug], name: "localeSlug")
+  @@index([courseId])
+  @@map("course_alternative_titles")
 }

--- a/packages/db/src/prisma/seed.ts
+++ b/packages/db/src/prisma/seed.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../index";
+import { seedAlternativeTitles } from "./seed/alternative-titles";
 import { seedChapters } from "./seed/chapters";
 import { seedCourses } from "./seed/courses";
 import { seedOrganizations } from "./seed/orgs";
@@ -9,6 +10,7 @@ async function main() {
   const org = await seedOrganizations(prisma, users);
   await seedCourses(prisma, org);
   await seedChapters(prisma, org);
+  await seedAlternativeTitles(prisma, org);
 }
 
 main()

--- a/packages/db/src/prisma/seed/alternative-titles.ts
+++ b/packages/db/src/prisma/seed/alternative-titles.ts
@@ -1,0 +1,58 @@
+import { toSlug } from "@zoonk/utils/string";
+import type { Organization, PrismaClient } from "../../generated/prisma/client";
+
+const alternativeTitlesData = [
+  // English - Machine Learning
+  {
+    courseSlug: "machine-learning",
+    language: "en",
+    locale: "en",
+    titles: [
+      "ML",
+      "Machine Learning Fundamentals",
+      "Intro to Machine Learning",
+    ],
+  },
+  // Portuguese - Machine Learning
+  {
+    courseSlug: "machine-learning",
+    language: "pt",
+    locale: "pt",
+    titles: ["ML", "Aprendizado de Máquina", "Introdução ao Machine Learning"],
+  },
+];
+
+export async function seedAlternativeTitles(
+  prisma: PrismaClient,
+  org: Organization,
+): Promise<void> {
+  await Promise.all(
+    alternativeTitlesData.map(async (item) => {
+      const course = await prisma.course.findUnique({
+        select: { id: true },
+        where: {
+          orgSlug: {
+            language: item.language,
+            organizationId: org.id,
+            slug: item.courseSlug,
+          },
+        },
+      });
+
+      if (!course) {
+        return;
+      }
+
+      const slugs = item.titles.map(toSlug);
+
+      await prisma.courseAlternativeTitle.createMany({
+        data: slugs.map((slug) => ({
+          courseId: course.id,
+          locale: item.locale,
+          slug,
+        })),
+        skipDuplicates: true,
+      });
+    }),
+  );
+}

--- a/packages/db/src/prisma/seed/chapters.ts
+++ b/packages/db/src/prisma/seed/chapters.ts
@@ -1,11 +1,5 @@
+import { normalizeString } from "@zoonk/utils/string";
 import type { Organization, PrismaClient } from "../../generated/prisma/client";
-
-function normalizeForSearch(text: string): string {
-  return text
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase();
-}
 
 type ChapterSeedData = {
   description: string;
@@ -125,7 +119,7 @@ async function seedChaptersForLanguage(
       create: {
         description: chapterData.description,
         isPublished: chapterData.isPublished,
-        normalizedTitle: normalizeForSearch(chapterData.title),
+        normalizedTitle: normalizeString(chapterData.title),
         organizationId: org.id,
         slug: chapterData.slug,
         title: chapterData.title,

--- a/packages/db/src/prisma/seed/courses.ts
+++ b/packages/db/src/prisma/seed/courses.ts
@@ -1,15 +1,5 @@
+import { normalizeString } from "@zoonk/utils/string";
 import type { Organization, PrismaClient } from "../../generated/prisma/client";
-
-/**
- * Normalizes text for accent-insensitive search by removing accents
- * and converting to lowercase.
- */
-function normalizeForSearch(text: string): string {
-  return text
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase();
-}
 
 export const coursesData = [
   // English courses
@@ -20,7 +10,7 @@ export const coursesData = [
       "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/courses/machine_learning-jmaDwiS0MptNV2EGCZzYWU7RBJs3Qg.webp",
     isPublished: true,
     language: "en",
-    normalizedTitle: normalizeForSearch("Machine Learning"),
+    normalizedTitle: normalizeString("Machine Learning"),
     slug: "machine-learning",
     title: "Machine Learning",
   },
@@ -31,7 +21,7 @@ export const coursesData = [
       "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/courses/spanish-G8NTOu5F2vUzMSaJ7oa2hgKrzAQtGr.webp",
     isPublished: true,
     language: "en",
-    normalizedTitle: normalizeForSearch("Spanish"),
+    normalizedTitle: normalizeString("Spanish"),
     slug: "spanish",
     title: "Spanish",
   },
@@ -42,7 +32,7 @@ export const coursesData = [
       "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/courses/astronomy-OfBov0VHGQPk98amhfAPg4UVrJH114.webp",
     isPublished: false,
     language: "en",
-    normalizedTitle: normalizeForSearch("Astronomy"),
+    normalizedTitle: normalizeString("Astronomy"),
     slug: "astronomy",
     title: "Astronomy",
   },
@@ -55,7 +45,7 @@ export const coursesData = [
       "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/courses/machine_learning-jmaDwiS0MptNV2EGCZzYWU7RBJs3Qg.webp",
     isPublished: true,
     language: "pt",
-    normalizedTitle: normalizeForSearch("Machine Learning"),
+    normalizedTitle: normalizeString("Machine Learning"),
     slug: "machine-learning",
     title: "Machine Learning",
   },
@@ -66,7 +56,7 @@ export const coursesData = [
       "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/courses/spanish-G8NTOu5F2vUzMSaJ7oa2hgKrzAQtGr.webp",
     isPublished: true,
     language: "pt",
-    normalizedTitle: normalizeForSearch("Espanhol"),
+    normalizedTitle: normalizeString("Espanhol"),
     slug: "espanhol",
     title: "Espanhol",
   },
@@ -77,7 +67,7 @@ export const coursesData = [
       "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/courses/astronomy-OfBov0VHGQPk98amhfAPg4UVrJH114.webp",
     isPublished: false,
     language: "pt",
-    normalizedTitle: normalizeForSearch("Astronomia"),
+    normalizedTitle: normalizeString("Astronomia"),
     slug: "astronomia",
     title: "Astronomia",
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,6 +10,7 @@
   },
   "exports": {
     "./cache": "./src/cache.ts",
+    "./constants": "./src/constants.ts",
     "./error": "./src/error.ts",
     "./form": "./src/form.ts",
     "./locale": "./src/locale.ts",

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -1,0 +1,1 @@
+export const AI_ORG_SLUG = "ai";


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add alternative titles for courses to support alias-based search and management. Includes new core APIs, a backing table, and seeds.

- **New Features**
  - Core APIs: add, delete, list, and find alternative titles (cached where relevant).
  - Titles are normalized to slugs, deduped, and enforced unique per locale.
  - New table course_alternative_titles with foreign key to courses and unique (locale, slug).
  - Exports added in core: ./alternative-titles/{add,delete,find,list}; types exported for CourseAlternativeTitle.
  - Seed data for alternative titles in English and Portuguese.

- **Migration**
  - Run Prisma migrations to create course_alternative_titles.
  - Re-seed the database to populate initial alternative titles.

<sup>Written for commit b786700cfa1b8fe534953511139a1f39c58e90a0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



