### PR TITLE
feat(editor): add api for importing/exporting alternative titles

### DIFF
--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -223,6 +223,11 @@ msgid "Invalid chapter format. Each chapter must have a title and description"
 msgstr "Invalid chapter format. Each chapter must have a title and description"
 
 #: src/lib/error-messages.ts
+msgctxt "c3FYXv"
+msgid "Invalid format. Please provide an array of non-empty strings"
+msgstr "Invalid format. Please provide an array of non-empty strings"
+
+#: src/lib/error-messages.ts
 msgctxt "cvtZ2C"
 msgid "Course not found"
 msgstr "Course not found"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -223,6 +223,11 @@ msgid "Invalid chapter format. Each chapter must have a title and description"
 msgstr "Formato de capítulo inválido. Cada capítulo debe tener un título y una descripción"
 
 #: src/lib/error-messages.ts
+msgctxt "c3FYXv"
+msgid "Invalid format. Please provide an array of non-empty strings"
+msgstr "Formato inválido. Por favor, proporciona un array de cadenas no vacías"
+
+#: src/lib/error-messages.ts
 msgctxt "cvtZ2C"
 msgid "Course not found"
 msgstr "Curso no encontrado"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -223,6 +223,11 @@ msgid "Invalid chapter format. Each chapter must have a title and description"
 msgstr "Formato de capítulo inválido. Cada capítulo precisa ter um título e uma descrição"
 
 #: src/lib/error-messages.ts
+msgctxt "c3FYXv"
+msgid "Invalid format. Please provide an array of non-empty strings"
+msgstr "Formato inválido. Forneça um array de strings não vazias"
+
+#: src/lib/error-messages.ts
 msgctxt "cvtZ2C"
 msgid "Course not found"
 msgstr "Curso não encontrado"

--- a/apps/editor/src/data/alternative-titles/export-alternative-titles.test.ts
+++ b/apps/editor/src/data/alternative-titles/export-alternative-titles.test.ts
@@ -1,0 +1,82 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { describe, expect, test } from "vitest";
+import { ErrorCode } from "@/lib/app-error";
+import { exportAlternativeTitles } from "./export-alternative-titles";
+
+describe("exportAlternativeTitles", () => {
+  test("returns courseNotFound for non-existent course", async () => {
+    const result = await exportAlternativeTitles({
+      courseId: 999_999,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.courseNotFound);
+    expect(result.data).toBeNull();
+  });
+
+  test("exports titles successfully", async () => {
+    const suffix = randomUUID().slice(0, 8);
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    await prisma.courseAlternativeTitle.createMany({
+      data: [
+        {
+          courseId: course.id,
+          locale: "en",
+          slug: `machine-learning-${suffix}`,
+        },
+        { courseId: course.id, locale: "en", slug: `ml-basics-${suffix}` },
+      ],
+    });
+
+    const result = await exportAlternativeTitles({
+      courseId: course.id,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toBeDefined();
+    expect(result.data?.version).toBe(1);
+    expect(result.data?.exportedAt).toBeDefined();
+    expect(result.data?.alternativeTitles).toHaveLength(2);
+  });
+
+  test("exports empty array when no titles exist", async () => {
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    const result = await exportAlternativeTitles({
+      courseId: course.id,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.alternativeTitles).toEqual([]);
+  });
+
+  test("returns titles sorted alphabetically", async () => {
+    const suffix = randomUUID().slice(0, 8);
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    await prisma.courseAlternativeTitle.createMany({
+      data: [
+        { courseId: course.id, locale: "en", slug: `zebra-learning-${suffix}` },
+        { courseId: course.id, locale: "en", slug: `alpha-course-${suffix}` },
+        { courseId: course.id, locale: "en", slug: `beta-training-${suffix}` },
+      ],
+    });
+
+    const result = await exportAlternativeTitles({
+      courseId: course.id,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.alternativeTitles).toEqual([
+      `alpha-course-${suffix}`,
+      `beta-training-${suffix}`,
+      `zebra-learning-${suffix}`,
+    ]);
+  });
+});

--- a/apps/editor/src/data/alternative-titles/export-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/export-alternative-titles.ts
@@ -1,0 +1,50 @@
+import "server-only";
+
+import { prisma } from "@zoonk/db";
+import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { ErrorCode } from "@/lib/app-error";
+
+export type AlternativeTitlesExport = {
+  alternativeTitles: string[];
+  exportedAt: string;
+  version: number;
+};
+
+export async function exportAlternativeTitles(params: {
+  courseId: number;
+}): Promise<SafeReturn<AlternativeTitlesExport>> {
+  const { data: course, error: findError } = await safeAsync(() =>
+    prisma.course.findUnique({
+      where: { id: params.courseId },
+    }),
+  );
+
+  if (findError) {
+    return { data: null, error: findError };
+  }
+
+  if (!course) {
+    return { data: null, error: new AppError(ErrorCode.courseNotFound) };
+  }
+
+  const { data: titles, error: titlesError } = await safeAsync(() =>
+    prisma.courseAlternativeTitle.findMany({
+      orderBy: { slug: "asc" },
+      select: { slug: true },
+      where: { courseId: params.courseId },
+    }),
+  );
+
+  if (titlesError) {
+    return { data: null, error: titlesError };
+  }
+
+  return {
+    data: {
+      alternativeTitles: titles.map((t) => t.slug),
+      exportedAt: new Date().toISOString(),
+      version: 1,
+    },
+    error: null,
+  };
+}

--- a/apps/editor/src/data/alternative-titles/import-alternative-titles.test.ts
+++ b/apps/editor/src/data/alternative-titles/import-alternative-titles.test.ts
@@ -1,0 +1,331 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { describe, expect, test } from "vitest";
+import { ErrorCode } from "@/lib/app-error";
+import { importAlternativeTitles } from "./import-alternative-titles";
+
+function createMockFile(
+  content: string,
+  name = "alternative-titles.json",
+  type = "application/json",
+): File {
+  return new File([content], name, { type });
+}
+
+function createImportFile(alternativeTitles: string[]): File {
+  return createMockFile(JSON.stringify({ alternativeTitles }));
+}
+
+describe("importAlternativeTitles", () => {
+  test("imports titles successfully", async () => {
+    const suffix = randomUUID().slice(0, 8);
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    const file = createImportFile([
+      `Machine Learning ${suffix}`,
+      `ML Basics ${suffix}`,
+    ]);
+
+    const result = await importAlternativeTitles({
+      courseId: course.id,
+      file,
+      locale: "en",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toHaveLength(2);
+    expect(result.data).toContain(`machine-learning-${suffix}`);
+    expect(result.data).toContain(`ml-basics-${suffix}`);
+
+    const titles = await prisma.courseAlternativeTitle.findMany({
+      orderBy: { slug: "asc" },
+      select: { slug: true },
+      where: { courseId: course.id },
+    });
+
+    expect(titles).toHaveLength(2);
+  });
+
+  test("returns courseNotFound for non-existent course", async () => {
+    const suffix = randomUUID().slice(0, 8);
+    const file = createImportFile([`Test Title ${suffix}`]);
+
+    const result = await importAlternativeTitles({
+      courseId: 999_999,
+      file,
+      locale: "en",
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.courseNotFound);
+    expect(result.data).toBeNull();
+  });
+
+  test("merge mode adds new titles and skips duplicates", async () => {
+    const suffix = randomUUID().slice(0, 8);
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    await prisma.courseAlternativeTitle.create({
+      data: {
+        courseId: course.id,
+        locale: "en",
+        slug: `existing-title-${suffix}`,
+      },
+    });
+
+    const file = createImportFile([
+      `Existing Title ${suffix}`,
+      `New Title ${suffix}`,
+    ]);
+
+    const result = await importAlternativeTitles({
+      courseId: course.id,
+      file,
+      locale: "en",
+    });
+
+    expect(result.error).toBeNull();
+
+    const titles = await prisma.courseAlternativeTitle.findMany({
+      orderBy: { slug: "asc" },
+      select: { slug: true },
+      where: { courseId: course.id },
+    });
+
+    expect(titles).toHaveLength(2);
+    expect(titles).toContainEqual({ slug: `existing-title-${suffix}` });
+    expect(titles).toContainEqual({ slug: `new-title-${suffix}` });
+  });
+
+  test("replace mode removes existing titles", async () => {
+    const suffix = randomUUID().slice(0, 8);
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    await prisma.courseAlternativeTitle.create({
+      data: {
+        courseId: course.id,
+        locale: "en",
+        slug: `old-title-${suffix}`,
+      },
+    });
+
+    const file = createImportFile([`New Title ${suffix}`]);
+
+    const result = await importAlternativeTitles({
+      courseId: course.id,
+      file,
+      locale: "en",
+      mode: "replace",
+    });
+
+    expect(result.error).toBeNull();
+
+    const titles = await prisma.courseAlternativeTitle.findMany({
+      select: { slug: true },
+      where: { courseId: course.id },
+    });
+
+    expect(titles).toHaveLength(1);
+    expect(titles[0]?.slug).toBe(`new-title-${suffix}`);
+  });
+
+  test("handles duplicate titles within import file", async () => {
+    const suffix = randomUUID().slice(0, 8);
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    const file = createImportFile([
+      `Same Title ${suffix}`,
+      `Same Title ${suffix}`,
+      `SAME TITLE ${suffix}`,
+      `Different Title ${suffix}`,
+    ]);
+
+    const result = await importAlternativeTitles({
+      courseId: course.id,
+      file,
+      locale: "en",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toHaveLength(2);
+
+    const titles = await prisma.courseAlternativeTitle.findMany({
+      select: { slug: true },
+      where: { courseId: course.id },
+    });
+
+    expect(titles).toHaveLength(2);
+  });
+
+  test("returns empty array when all titles are empty", async () => {
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    const file = createMockFile(JSON.stringify({ alternativeTitles: [] }));
+
+    const result = await importAlternativeTitles({
+      courseId: course.id,
+      file,
+      locale: "en",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual([]);
+  });
+
+  describe("file validation", () => {
+    test("rejects file larger than 5MB", async () => {
+      const organization = await organizationFixture();
+      const course = await courseFixture({ organizationId: organization.id });
+
+      const largeContent = "x".repeat(6 * 1024 * 1024);
+      const file = createMockFile(largeContent);
+
+      const result = await importAlternativeTitles({
+        courseId: course.id,
+        file,
+        locale: "en",
+      });
+
+      expect(result.error?.message).toBe(ErrorCode.fileTooLarge);
+    });
+
+    test("rejects non-JSON file", async () => {
+      const organization = await organizationFixture();
+      const course = await courseFixture({ organizationId: organization.id });
+
+      const file = new File(["test content"], "titles.txt", {
+        type: "text/plain",
+      });
+
+      const result = await importAlternativeTitles({
+        courseId: course.id,
+        file,
+        locale: "en",
+      });
+
+      expect(result.error?.message).toBe(ErrorCode.invalidFileType);
+    });
+
+    test("rejects invalid JSON", async () => {
+      const organization = await organizationFixture();
+      const course = await courseFixture({ organizationId: organization.id });
+
+      const file = createMockFile("{ invalid json }");
+
+      const result = await importAlternativeTitles({
+        courseId: course.id,
+        file,
+        locale: "en",
+      });
+
+      expect(result.error?.message).toBe(ErrorCode.invalidJsonFormat);
+    });
+
+    test("rejects JSON without alternativeTitles array", async () => {
+      const organization = await organizationFixture();
+      const course = await courseFixture({ organizationId: organization.id });
+
+      const file = createMockFile(JSON.stringify({ foo: "bar" }));
+
+      const result = await importAlternativeTitles({
+        courseId: course.id,
+        file,
+        locale: "en",
+      });
+
+      expect(result.error?.message).toBe(
+        ErrorCode.invalidAlternativeTitleFormat,
+      );
+    });
+
+    test("rejects non-string titles", async () => {
+      const organization = await organizationFixture();
+      const course = await courseFixture({ organizationId: organization.id });
+
+      const file = createMockFile(
+        JSON.stringify({
+          alternativeTitles: [123, "Valid Title"],
+        }),
+      );
+
+      const result = await importAlternativeTitles({
+        courseId: course.id,
+        file,
+        locale: "en",
+      });
+
+      expect(result.error?.message).toBe(
+        ErrorCode.invalidAlternativeTitleFormat,
+      );
+    });
+
+    test("rejects empty string titles", async () => {
+      const organization = await organizationFixture();
+      const course = await courseFixture({ organizationId: organization.id });
+
+      const file = createMockFile(
+        JSON.stringify({
+          alternativeTitles: ["", "Valid Title"],
+        }),
+      );
+
+      const result = await importAlternativeTitles({
+        courseId: course.id,
+        file,
+        locale: "en",
+      });
+
+      expect(result.error?.message).toBe(
+        ErrorCode.invalidAlternativeTitleFormat,
+      );
+    });
+
+    test("rejects whitespace-only titles", async () => {
+      const organization = await organizationFixture();
+      const course = await courseFixture({ organizationId: organization.id });
+
+      const file = createMockFile(
+        JSON.stringify({
+          alternativeTitles: ["   ", "Valid Title"],
+        }),
+      );
+
+      const result = await importAlternativeTitles({
+        courseId: course.id,
+        file,
+        locale: "en",
+      });
+
+      expect(result.error?.message).toBe(
+        ErrorCode.invalidAlternativeTitleFormat,
+      );
+    });
+
+    test("accepts JSON file by name when type is empty", async () => {
+      const suffix = randomUUID().slice(0, 8);
+      const organization = await organizationFixture();
+      const course = await courseFixture({ organizationId: organization.id });
+
+      const file = new File(
+        [JSON.stringify({ alternativeTitles: [`Test Title ${suffix}`] })],
+        "titles.json",
+        { type: "" },
+      );
+
+      const result = await importAlternativeTitles({
+        courseId: course.id,
+        file,
+        locale: "en",
+      });
+
+      expect(result.error).toBeNull();
+      expect(result.data).toHaveLength(1);
+    });
+  });
+});

--- a/apps/editor/src/data/alternative-titles/import-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/import-alternative-titles.ts
@@ -73,7 +73,7 @@ export async function importAlternativeTitles(params: {
     prisma.$transaction(async (tx) => {
       if (mode === "replace") {
         await tx.courseAlternativeTitle.deleteMany({
-          where: { courseId: params.courseId },
+          where: { courseId: params.courseId, locale: params.locale },
         });
       }
 

--- a/apps/editor/src/data/alternative-titles/import-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/import-alternative-titles.ts
@@ -1,0 +1,98 @@
+import "server-only";
+
+import { prisma } from "@zoonk/db";
+import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { toSlug } from "@zoonk/utils/string";
+import { ErrorCode } from "@/lib/app-error";
+import { parseJsonFile } from "@/lib/parse-json-file";
+
+export type AlternativeTitlesImport = {
+  alternativeTitles: string[];
+};
+
+export type ImportMode = "merge" | "replace";
+
+function validateTitleData(title: unknown): title is string {
+  return typeof title === "string" && title.trim().length > 0;
+}
+
+function validateImportData(data: unknown): data is AlternativeTitlesImport {
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+
+  const d = data as Record<string, unknown>;
+
+  if (!Array.isArray(d.alternativeTitles)) {
+    return false;
+  }
+
+  return d.alternativeTitles.every(validateTitleData);
+}
+
+export async function importAlternativeTitles(params: {
+  courseId: number;
+  file: File;
+  locale: string;
+  mode?: ImportMode;
+}): Promise<SafeReturn<string[]>> {
+  const mode = params.mode ?? "merge";
+
+  const { data: importData, error: parseError } = await parseJsonFile({
+    file: params.file,
+    invalidFormatError: ErrorCode.invalidAlternativeTitleFormat,
+    validate: validateImportData,
+  });
+
+  if (parseError) {
+    return { data: null, error: parseError };
+  }
+
+  const { data: course, error: findError } = await safeAsync(() =>
+    prisma.course.findUnique({
+      where: { id: params.courseId },
+    }),
+  );
+
+  if (findError) {
+    return { data: null, error: findError };
+  }
+
+  if (!course) {
+    return { data: null, error: new AppError(ErrorCode.courseNotFound) };
+  }
+
+  const slugs = importData.alternativeTitles.map((title) => toSlug(title));
+  const uniqueSlugs = [...new Set(slugs)].filter(Boolean);
+
+  if (uniqueSlugs.length === 0) {
+    return { data: [], error: null };
+  }
+
+  const { data: result, error: importError } = await safeAsync(() =>
+    prisma.$transaction(async (tx) => {
+      if (mode === "replace") {
+        await tx.courseAlternativeTitle.deleteMany({
+          where: { courseId: params.courseId },
+        });
+      }
+
+      await tx.courseAlternativeTitle.createMany({
+        data: uniqueSlugs.map((slug) => ({
+          courseId: params.courseId,
+          locale: params.locale,
+          slug,
+        })),
+        skipDuplicates: true,
+      });
+
+      return uniqueSlugs;
+    }),
+  );
+
+  if (importError) {
+    return { data: null, error: importError };
+  }
+
+  return { data: result, error: null };
+}

--- a/apps/editor/src/lib/app-error.ts
+++ b/apps/editor/src/lib/app-error.ts
@@ -5,6 +5,7 @@ export const ErrorCode = {
   courseNotFound: "courseNotFound",
   fileTooLarge: "fileTooLarge",
   forbidden: "forbidden",
+  invalidAlternativeTitleFormat: "invalidAlternativeTitleFormat",
   invalidChapterFormat: "invalidChapterFormat",
   invalidFileType: "invalidFileType",
   invalidJsonFormat: "invalidJsonFormat",

--- a/apps/editor/src/lib/error-messages.ts
+++ b/apps/editor/src/lib/error-messages.ts
@@ -46,6 +46,10 @@ export async function getErrorMessage(error: Error): Promise<string> {
         return t(
           "Invalid chapter format. Each chapter must have a title and description",
         );
+      case ErrorCode.invalidAlternativeTitleFormat:
+        return t(
+          "Invalid format. Please provide an array of non-empty strings",
+        );
       default:
         return assertNever(error.code);
     }

--- a/apps/editor/src/lib/parse-json-file.ts
+++ b/apps/editor/src/lib/parse-json-file.ts
@@ -1,0 +1,59 @@
+import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { ErrorCode, type ErrorCodeType } from "./app-error";
+
+const BYTES_PER_KB = 1024;
+const KB_PER_MB = 1024;
+const MAX_FILE_SIZE_MB = 5;
+const MAX_FILE_SIZE = MAX_FILE_SIZE_MB * KB_PER_MB * BYTES_PER_KB;
+
+export async function parseJsonFile<T>(params: {
+  file: File;
+  invalidFormatError: ErrorCodeType;
+  validate: (data: unknown) => data is T;
+}): Promise<SafeReturn<T>> {
+  const { file, invalidFormatError, validate } = params;
+
+  if (file.size > MAX_FILE_SIZE) {
+    return {
+      data: null,
+      error: new AppError(ErrorCode.fileTooLarge),
+    };
+  }
+
+  const isJsonType = file.type.includes("json");
+  const isJsonFile = file.name.endsWith(".json");
+  const isValidJsonFile = isJsonType || isJsonFile;
+
+  if (!isValidJsonFile) {
+    return {
+      data: null,
+      error: new AppError(ErrorCode.invalidFileType),
+    };
+  }
+
+  const { data: text, error: readError } = await safeAsync(() => file.text());
+
+  if (readError) {
+    return { data: null, error: readError };
+  }
+
+  const { data: parsed, error: parseError } = await safeAsync(async () =>
+    JSON.parse(text),
+  );
+
+  if (parseError) {
+    return {
+      data: null,
+      error: new AppError(ErrorCode.invalidJsonFormat),
+    };
+  }
+
+  if (!validate(parsed)) {
+    return {
+      data: null,
+      error: new AppError(invalidFormatError),
+    };
+  }
+
+  return { data: parsed, error: null };
+}

--- a/i18n.lock
+++ b/i18n.lock
@@ -44,6 +44,7 @@ checksums:
     Chapter%20not%20found/singular: 72d4a8758136678acbae0ec942227f7e
     Chapter%20not%20found%20in%20this%20course/singular: d81e3e6176f913514f413784a8e881e3
     Invalid%20chapter%20format.%20Each%20chapter%20must%20have%20a%20title%20and%20description/singular: 6c9dc938c75674b73b61177b55cce86d
+    Invalid%20format.%20Please%20provide%20an%20array%20of%20non-empty%20strings/singular: c9dbc954cf099eedbb573d647356f52e
     Course%20not%20found/singular: 679d024095e9e605246a1928a7e1d87b
     Invalid%20file%20type.%20Please%20upload%20a%20JSON%20file/singular: 9164c5c1930e61a6037fab99386c02f6
     Please%20sign%20in%20to%20continue/singular: 051e59dd3d3b0bfad95982f982fd6b9d


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds APIs to import and export course alternative titles as JSON, with strong validation and clear errors. Also introduces a shared JSON file parser and updates chapter import to use it.

- **New Features**
  - exportAlternativeTitles: returns sorted slugs with version and exportedAt.
  - importAlternativeTitles: validates an array of non-empty strings, slugifies, de-duplicates, and supports merge or replace scoped to the specified locale.
  - New error code and messages for invalid alternative title format; i18n strings added.

- **Refactors**
  - Added parseJsonFile utility for size/type/JSON validation.
  - Updated importChapters to use parseJsonFile and unified error handling.

<sup>Written for commit d4f5da97c693581b24366bcd04fb7c0b52e457d0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



