### PR TITLE
feat(editor): add APIs for managing categories

### DIFF
--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -202,10 +202,95 @@ msgctxt "w7tf2z"
 msgid "Published"
 msgstr "Published"
 
+#: src/lib/categories.ts
+msgctxt "djJp6c"
+msgid "History"
+msgstr "History"
+
+#: src/lib/categories.ts
+msgctxt "dPgwrL"
+msgid "Math"
+msgstr "Math"
+
+#: src/lib/categories.ts
+msgctxt "fFt3il"
+msgid "Arts"
+msgstr "Arts"
+
+#: src/lib/categories.ts
+msgctxt "GsBRWL"
+msgid "Languages"
+msgstr "Languages"
+
+#: src/lib/categories.ts
+msgctxt "hlmkcL"
+msgid "Health"
+msgstr "Health"
+
+#: src/lib/categories.ts
+msgctxt "hwL7a0"
+msgid "Engineering"
+msgstr "Engineering"
+
+#: src/lib/categories.ts
+msgctxt "I1ZCPK"
+msgid "Technology"
+msgstr "Technology"
+
+#: src/lib/categories.ts
+msgctxt "KOuDOE"
+msgid "Economics"
+msgstr "Economics"
+
+#: src/lib/categories.ts
+msgctxt "mn6pIm"
+msgid "Culture"
+msgstr "Culture"
+
+#: src/lib/categories.ts
+msgctxt "n5D/Ku"
+msgid "Communication"
+msgstr "Communication"
+
+#: src/lib/categories.ts
+msgctxt "OV/2+4"
+msgid "Society"
+msgstr "Society"
+
+#: src/lib/categories.ts
+msgctxt "qydxOd"
+msgid "Science"
+msgstr "Science"
+
+#: src/lib/categories.ts
+msgctxt "u3ovjm"
+msgid "Law"
+msgstr "Law"
+
+#: src/lib/categories.ts
+msgctxt "w1Fanr"
+msgid "Business"
+msgstr "Business"
+
+#: src/lib/categories.ts
+msgctxt "YMDBNH"
+msgid "Geography"
+msgstr "Geography"
+
+#: src/lib/error-messages.ts
+msgctxt "12q6p9"
+msgid "Category not found in this course"
+msgstr "Category not found in this course"
+
 #: src/lib/error-messages.ts
 msgctxt "3IKub9"
 msgid "An unexpected error occurred"
 msgstr "An unexpected error occurred"
+
+#: src/lib/error-messages.ts
+msgctxt "4ec6+l"
+msgid "Invalid category"
+msgstr "Invalid category"
 
 #: src/lib/error-messages.ts
 msgctxt "5hjDIG"
@@ -241,6 +326,11 @@ msgstr "Course not found"
 msgctxt "D8iYTy"
 msgid "Invalid file type. Please upload a JSON file"
 msgstr "Invalid file type. Please upload a JSON file"
+
+#: src/lib/error-messages.ts
+msgctxt "EDiolw"
+msgid "This category has already been added to the course"
+msgstr "This category has already been added to the course"
 
 #: src/lib/error-messages.ts
 msgctxt "foSzTN"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -202,10 +202,95 @@ msgctxt "w7tf2z"
 msgid "Published"
 msgstr "Publicado"
 
+#: src/lib/categories.ts
+msgctxt "djJp6c"
+msgid "History"
+msgstr "Historia"
+
+#: src/lib/categories.ts
+msgctxt "dPgwrL"
+msgid "Math"
+msgstr "Matemáticas"
+
+#: src/lib/categories.ts
+msgctxt "fFt3il"
+msgid "Arts"
+msgstr "Artes"
+
+#: src/lib/categories.ts
+msgctxt "GsBRWL"
+msgid "Languages"
+msgstr "Idiomas"
+
+#: src/lib/categories.ts
+msgctxt "hlmkcL"
+msgid "Health"
+msgstr "Salud"
+
+#: src/lib/categories.ts
+msgctxt "hwL7a0"
+msgid "Engineering"
+msgstr "Ingeniería"
+
+#: src/lib/categories.ts
+msgctxt "I1ZCPK"
+msgid "Technology"
+msgstr "Tecnología"
+
+#: src/lib/categories.ts
+msgctxt "KOuDOE"
+msgid "Economics"
+msgstr "Economía"
+
+#: src/lib/categories.ts
+msgctxt "mn6pIm"
+msgid "Culture"
+msgstr "Cultura"
+
+#: src/lib/categories.ts
+msgctxt "n5D/Ku"
+msgid "Communication"
+msgstr "Comunicación"
+
+#: src/lib/categories.ts
+msgctxt "OV/2+4"
+msgid "Society"
+msgstr "Sociedad"
+
+#: src/lib/categories.ts
+msgctxt "qydxOd"
+msgid "Science"
+msgstr "Ciencia"
+
+#: src/lib/categories.ts
+msgctxt "u3ovjm"
+msgid "Law"
+msgstr "Derecho"
+
+#: src/lib/categories.ts
+msgctxt "w1Fanr"
+msgid "Business"
+msgstr "Negocios"
+
+#: src/lib/categories.ts
+msgctxt "YMDBNH"
+msgid "Geography"
+msgstr "Geografía"
+
+#: src/lib/error-messages.ts
+msgctxt "12q6p9"
+msgid "Category not found in this course"
+msgstr "Categoría no encontrada en este curso"
+
 #: src/lib/error-messages.ts
 msgctxt "3IKub9"
 msgid "An unexpected error occurred"
 msgstr "Ocurrió un error inesperado"
+
+#: src/lib/error-messages.ts
+msgctxt "4ec6+l"
+msgid "Invalid category"
+msgstr "Categoría inválida"
 
 #: src/lib/error-messages.ts
 msgctxt "5hjDIG"
@@ -241,6 +326,11 @@ msgstr "Curso no encontrado"
 msgctxt "D8iYTy"
 msgid "Invalid file type. Please upload a JSON file"
 msgstr "Tipo de archivo inválido. Por favor sube un archivo JSON"
+
+#: src/lib/error-messages.ts
+msgctxt "EDiolw"
+msgid "This category has already been added to the course"
+msgstr "Esta categoría ya ha sido agregada al curso"
 
 #: src/lib/error-messages.ts
 msgctxt "foSzTN"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -202,10 +202,95 @@ msgctxt "w7tf2z"
 msgid "Published"
 msgstr "Publicado"
 
+#: src/lib/categories.ts
+msgctxt "djJp6c"
+msgid "History"
+msgstr "História"
+
+#: src/lib/categories.ts
+msgctxt "dPgwrL"
+msgid "Math"
+msgstr "Matemática"
+
+#: src/lib/categories.ts
+msgctxt "fFt3il"
+msgid "Arts"
+msgstr "Artes"
+
+#: src/lib/categories.ts
+msgctxt "GsBRWL"
+msgid "Languages"
+msgstr "Idiomas"
+
+#: src/lib/categories.ts
+msgctxt "hlmkcL"
+msgid "Health"
+msgstr "Saúde"
+
+#: src/lib/categories.ts
+msgctxt "hwL7a0"
+msgid "Engineering"
+msgstr "Engenharia"
+
+#: src/lib/categories.ts
+msgctxt "I1ZCPK"
+msgid "Technology"
+msgstr "Tecnologia"
+
+#: src/lib/categories.ts
+msgctxt "KOuDOE"
+msgid "Economics"
+msgstr "Economia"
+
+#: src/lib/categories.ts
+msgctxt "mn6pIm"
+msgid "Culture"
+msgstr "Cultura"
+
+#: src/lib/categories.ts
+msgctxt "n5D/Ku"
+msgid "Communication"
+msgstr "Comunicação"
+
+#: src/lib/categories.ts
+msgctxt "OV/2+4"
+msgid "Society"
+msgstr "Sociedade"
+
+#: src/lib/categories.ts
+msgctxt "qydxOd"
+msgid "Science"
+msgstr "Ciência"
+
+#: src/lib/categories.ts
+msgctxt "u3ovjm"
+msgid "Law"
+msgstr "Direito"
+
+#: src/lib/categories.ts
+msgctxt "w1Fanr"
+msgid "Business"
+msgstr "Negócios"
+
+#: src/lib/categories.ts
+msgctxt "YMDBNH"
+msgid "Geography"
+msgstr "Geografia"
+
+#: src/lib/error-messages.ts
+msgctxt "12q6p9"
+msgid "Category not found in this course"
+msgstr "Categoria não encontrada neste curso"
+
 #: src/lib/error-messages.ts
 msgctxt "3IKub9"
 msgid "An unexpected error occurred"
 msgstr "Ocorreu um erro inesperado"
+
+#: src/lib/error-messages.ts
+msgctxt "4ec6+l"
+msgid "Invalid category"
+msgstr "Categoria inválida"
 
 #: src/lib/error-messages.ts
 msgctxt "5hjDIG"
@@ -241,6 +326,11 @@ msgstr "Curso não encontrado"
 msgctxt "D8iYTy"
 msgid "Invalid file type. Please upload a JSON file"
 msgstr "Tipo de arquivo inválido. Por favor, envie um arquivo JSON"
+
+#: src/lib/error-messages.ts
+msgctxt "EDiolw"
+msgid "This category has already been added to the course"
+msgstr "Esta categoria já foi adicionada ao curso"
 
 #: src/lib/error-messages.ts
 msgctxt "foSzTN"

--- a/apps/editor/src/data/categories/add-category-to-course.test.ts
+++ b/apps/editor/src/data/categories/add-category-to-course.test.ts
@@ -1,0 +1,156 @@
+import { prisma } from "@zoonk/db";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import {
+  courseCategoryFixture,
+  courseFixture,
+} from "@zoonk/testing/fixtures/courses";
+import {
+  memberFixture,
+  organizationFixture,
+} from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, describe, expect, test } from "vitest";
+import { ErrorCode } from "@/lib/app-error";
+import { addCategoryToCourse } from "./add-category-to-course";
+
+describe("unauthenticated users", () => {
+  test("returns Forbidden", async () => {
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    const result = await addCategoryToCourse({
+      category: "tech",
+      courseId: course.id,
+      headers: new Headers(),
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("members", () => {
+  test("returns Forbidden", async () => {
+    const { organization, user } = await memberFixture({ role: "member" });
+
+    const [headers, course] = await Promise.all([
+      signInAs(user.email, user.password),
+      courseFixture({ organizationId: organization.id }),
+    ]);
+
+    const result = await addCategoryToCourse({
+      category: "tech",
+      courseId: course.id,
+      headers,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("admins", () => {
+  let organization: Awaited<ReturnType<typeof memberFixture>>["organization"];
+  let headers: Headers;
+
+  beforeAll(async () => {
+    const fixture = await memberFixture({ role: "admin" });
+    organization = fixture.organization;
+    headers = await signInAs(fixture.user.email, fixture.user.password);
+  });
+
+  test("adds category to course successfully", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+
+    const result = await addCategoryToCourse({
+      category: "tech",
+      courseId: course.id,
+      headers,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.category).toBe("tech");
+    expect(result.data?.courseId).toBe(course.id);
+  });
+
+  test("adds multiple categories to same course", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+
+    const [result1, result2] = await Promise.all([
+      addCategoryToCourse({
+        category: "tech",
+        courseId: course.id,
+        headers,
+      }),
+      addCategoryToCourse({
+        category: "science",
+        courseId: course.id,
+        headers,
+      }),
+    ]);
+
+    expect(result1.error).toBeNull();
+    expect(result2.error).toBeNull();
+
+    const categories = await prisma.courseCategory.findMany({
+      where: { courseId: course.id },
+    });
+
+    expect(categories.length).toBe(2);
+  });
+
+  test("returns error when category already added", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+
+    await courseCategoryFixture({
+      category: "tech",
+      courseId: course.id,
+    });
+
+    const result = await addCategoryToCourse({
+      category: "tech",
+      courseId: course.id,
+      headers,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.categoryAlreadyAdded);
+    expect(result.data).toBeNull();
+  });
+
+  test("returns Course not found", async () => {
+    const result = await addCategoryToCourse({
+      category: "tech",
+      courseId: 999_999,
+      headers,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.courseNotFound);
+    expect(result.data).toBeNull();
+  });
+
+  test("returns Invalid category for unknown category", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+
+    const result = await addCategoryToCourse({
+      category: "invalid-category",
+      courseId: course.id,
+      headers,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.invalidCategory);
+    expect(result.data).toBeNull();
+  });
+
+  test("returns Forbidden for course in different organization", async () => {
+    const otherOrg = await organizationFixture();
+    const course = await courseFixture({ organizationId: otherOrg.id });
+
+    const result = await addCategoryToCourse({
+      category: "tech",
+      courseId: course.id,
+      headers,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});

--- a/apps/editor/src/data/categories/add-category-to-course.ts
+++ b/apps/editor/src/data/categories/add-category-to-course.ts
@@ -1,0 +1,62 @@
+import "server-only";
+
+import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
+import { type CourseCategory, prisma } from "@zoonk/db";
+import { COURSE_CATEGORIES } from "@zoonk/utils/categories";
+import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { ErrorCode } from "@/lib/app-error";
+
+export async function addCategoryToCourse(params: {
+  category: string;
+  courseId: number;
+  headers?: Headers;
+}): Promise<SafeReturn<CourseCategory>> {
+  if (!COURSE_CATEGORIES.includes(params.category as never)) {
+    return { data: null, error: new AppError(ErrorCode.invalidCategory) };
+  }
+
+  const { data: course, error: findError } = await safeAsync(() =>
+    prisma.course.findUnique({
+      where: { id: params.courseId },
+    }),
+  );
+
+  if (findError) {
+    return { data: null, error: findError };
+  }
+
+  if (!course) {
+    return { data: null, error: new AppError(ErrorCode.courseNotFound) };
+  }
+
+  const hasPermission = await hasCoursePermission({
+    headers: params.headers,
+    orgId: course.organizationId,
+    permission: "update",
+  });
+
+  if (!hasPermission) {
+    return { data: null, error: new AppError(ErrorCode.forbidden) };
+  }
+
+  const { data: courseCategory, error } = await safeAsync(() =>
+    prisma.courseCategory.create({
+      data: {
+        category: params.category,
+        courseId: params.courseId,
+      },
+    }),
+  );
+
+  if (error) {
+    if (error.message.includes("Unique constraint")) {
+      return {
+        data: null,
+        error: new AppError(ErrorCode.categoryAlreadyAdded),
+      };
+    }
+    return { data: null, error };
+  }
+
+  return { data: courseCategory, error: null };
+}

--- a/apps/editor/src/data/categories/add-category-to-course.ts
+++ b/apps/editor/src/data/categories/add-category-to-course.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
 import { type CourseCategory, prisma } from "@zoonk/db";
+import { isUniqueConstraintError } from "@zoonk/db/utils";
 import { COURSE_CATEGORIES } from "@zoonk/utils/categories";
 import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { ErrorCode } from "@/lib/app-error";
@@ -49,7 +50,7 @@ export async function addCategoryToCourse(params: {
   );
 
   if (error) {
-    if (error.message.includes("Unique constraint")) {
+    if (isUniqueConstraintError(error)) {
       return {
         data: null,
         error: new AppError(ErrorCode.categoryAlreadyAdded),

--- a/apps/editor/src/data/categories/list-course-categories.test.ts
+++ b/apps/editor/src/data/categories/list-course-categories.test.ts
@@ -1,0 +1,81 @@
+import {
+  courseCategoryFixture,
+  courseFixture,
+} from "@zoonk/testing/fixtures/courses";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { describe, expect, test } from "vitest";
+import { listCourseCategories } from "./list-course-categories";
+
+describe("listCourseCategories", () => {
+  test("returns empty array when course has no categories", async () => {
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    const result = await listCourseCategories({ courseId: course.id });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual([]);
+  });
+
+  test("returns all categories for a course", async () => {
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    await Promise.all([
+      courseCategoryFixture({ category: "tech", courseId: course.id }),
+      courseCategoryFixture({ category: "science", courseId: course.id }),
+      courseCategoryFixture({ category: "math", courseId: course.id }),
+    ]);
+
+    const result = await listCourseCategories({ courseId: course.id });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.length).toBe(3);
+  });
+
+  test("returns categories sorted alphabetically", async () => {
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    await Promise.all([
+      courseCategoryFixture({ category: "tech", courseId: course.id }),
+      courseCategoryFixture({ category: "arts", courseId: course.id }),
+      courseCategoryFixture({ category: "math", courseId: course.id }),
+    ]);
+
+    const result = await listCourseCategories({ courseId: course.id });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.[0]?.category).toBe("arts");
+    expect(result.data?.[1]?.category).toBe("math");
+    expect(result.data?.[2]?.category).toBe("tech");
+  });
+
+  test("returns only categories for the specified course", async () => {
+    const organization = await organizationFixture();
+
+    const [course1, course2] = await Promise.all([
+      courseFixture({ organizationId: organization.id }),
+      courseFixture({ organizationId: organization.id }),
+    ]);
+
+    await Promise.all([
+      courseCategoryFixture({ category: "tech", courseId: course1.id }),
+      courseCategoryFixture({ category: "science", courseId: course1.id }),
+      courseCategoryFixture({ category: "arts", courseId: course2.id }),
+    ]);
+
+    const result = await listCourseCategories({ courseId: course1.id });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.length).toBe(2);
+    expect(result.data?.every((c) => c.courseId === course1.id)).toBe(true);
+  });
+
+  test("returns empty array for non-existent course", async () => {
+    const result = await listCourseCategories({ courseId: 999_999 });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual([]);
+  });
+});

--- a/apps/editor/src/data/categories/list-course-categories.ts
+++ b/apps/editor/src/data/categories/list-course-categories.ts
@@ -1,0 +1,21 @@
+import "server-only";
+
+import { type CourseCategory, prisma } from "@zoonk/db";
+import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+
+export async function listCourseCategories(params: {
+  courseId: number;
+}): Promise<SafeReturn<CourseCategory[]>> {
+  const { data, error } = await safeAsync(() =>
+    prisma.courseCategory.findMany({
+      orderBy: { category: "asc" },
+      where: { courseId: params.courseId },
+    }),
+  );
+
+  if (error) {
+    return { data: null, error };
+  }
+
+  return { data, error: null };
+}

--- a/apps/editor/src/data/categories/remove-category-from-course.test.ts
+++ b/apps/editor/src/data/categories/remove-category-from-course.test.ts
@@ -1,0 +1,155 @@
+import { prisma } from "@zoonk/db";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import {
+  courseCategoryFixture,
+  courseFixture,
+} from "@zoonk/testing/fixtures/courses";
+import {
+  memberFixture,
+  organizationFixture,
+} from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, describe, expect, test } from "vitest";
+import { ErrorCode } from "@/lib/app-error";
+import { removeCategoryFromCourse } from "./remove-category-from-course";
+
+describe("unauthenticated users", () => {
+  test("returns Forbidden", async () => {
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    await courseCategoryFixture({
+      category: "tech",
+      courseId: course.id,
+    });
+
+    const result = await removeCategoryFromCourse({
+      category: "tech",
+      courseId: course.id,
+      headers: new Headers(),
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("members", () => {
+  test("returns Forbidden", async () => {
+    const { organization, user } = await memberFixture({ role: "member" });
+
+    const [headers, course] = await Promise.all([
+      signInAs(user.email, user.password),
+      courseFixture({ organizationId: organization.id }),
+    ]);
+
+    await courseCategoryFixture({
+      category: "tech",
+      courseId: course.id,
+    });
+
+    const result = await removeCategoryFromCourse({
+      category: "tech",
+      courseId: course.id,
+      headers,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("admins", () => {
+  let organization: Awaited<ReturnType<typeof memberFixture>>["organization"];
+  let headers: Headers;
+
+  beforeAll(async () => {
+    const fixture = await memberFixture({ role: "admin" });
+    organization = fixture.organization;
+    headers = await signInAs(fixture.user.email, fixture.user.password);
+  });
+
+  test("removes category from course successfully", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+
+    await courseCategoryFixture({
+      category: "tech",
+      courseId: course.id,
+    });
+
+    const result = await removeCategoryFromCourse({
+      category: "tech",
+      courseId: course.id,
+      headers,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.category).toBe("tech");
+    expect(result.data?.courseId).toBe(course.id);
+
+    const remaining = await prisma.courseCategory.findMany({
+      where: { courseId: course.id },
+    });
+
+    expect(remaining.length).toBe(0);
+  });
+
+  test("removes only the specified category", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+
+    await Promise.all([
+      courseCategoryFixture({ category: "tech", courseId: course.id }),
+      courseCategoryFixture({ category: "science", courseId: course.id }),
+      courseCategoryFixture({ category: "math", courseId: course.id }),
+    ]);
+
+    const result = await removeCategoryFromCourse({
+      category: "science",
+      courseId: course.id,
+      headers,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.category).toBe("science");
+
+    const remaining = await prisma.courseCategory.findMany({
+      orderBy: { category: "asc" },
+      where: { courseId: course.id },
+    });
+
+    expect(remaining.length).toBe(2);
+    expect(remaining[0]?.category).toBe("math");
+    expect(remaining[1]?.category).toBe("tech");
+  });
+
+  test("returns Category not in course", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+
+    const result = await removeCategoryFromCourse({
+      category: "tech",
+      courseId: course.id,
+      headers,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.categoryNotInCourse);
+    expect(result.data).toBeNull();
+  });
+
+  test("returns Forbidden for course in different organization", async () => {
+    const otherOrg = await organizationFixture();
+    const course = await courseFixture({ organizationId: otherOrg.id });
+
+    await courseCategoryFixture({
+      category: "tech",
+      courseId: course.id,
+    });
+
+    const result = await removeCategoryFromCourse({
+      category: "tech",
+      courseId: course.id,
+      headers,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});

--- a/apps/editor/src/data/categories/remove-category-from-course.ts
+++ b/apps/editor/src/data/categories/remove-category-from-course.ts
@@ -1,0 +1,54 @@
+import "server-only";
+
+import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
+import { type CourseCategory, prisma } from "@zoonk/db";
+import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { ErrorCode } from "@/lib/app-error";
+
+export async function removeCategoryFromCourse(params: {
+  category: string;
+  courseId: number;
+  headers?: Headers;
+}): Promise<SafeReturn<CourseCategory>> {
+  const { data: courseCategory, error: findError } = await safeAsync(() =>
+    prisma.courseCategory.findUnique({
+      include: { course: true },
+      where: {
+        courseCategory: {
+          category: params.category,
+          courseId: params.courseId,
+        },
+      },
+    }),
+  );
+
+  if (findError) {
+    return { data: null, error: findError };
+  }
+
+  if (!courseCategory) {
+    return { data: null, error: new AppError(ErrorCode.categoryNotInCourse) };
+  }
+
+  const hasPermission = await hasCoursePermission({
+    headers: params.headers,
+    orgId: courseCategory.course.organizationId,
+    permission: "update",
+  });
+
+  if (!hasPermission) {
+    return { data: null, error: new AppError(ErrorCode.forbidden) };
+  }
+
+  const { error } = await safeAsync(() =>
+    prisma.courseCategory.delete({
+      where: { id: courseCategory.id },
+    }),
+  );
+
+  if (error) {
+    return { data: null, error };
+  }
+
+  return { data: courseCategory, error: null };
+}

--- a/apps/editor/src/lib/app-error.ts
+++ b/apps/editor/src/lib/app-error.ts
@@ -1,4 +1,6 @@
 export const ErrorCode = {
+  categoryAlreadyAdded: "categoryAlreadyAdded",
+  categoryNotInCourse: "categoryNotInCourse",
   chapterAlreadyRemoved: "chapterAlreadyRemoved",
   chapterNotFound: "chapterNotFound",
   chapterNotInCourse: "chapterNotInCourse",
@@ -6,6 +8,7 @@ export const ErrorCode = {
   fileTooLarge: "fileTooLarge",
   forbidden: "forbidden",
   invalidAlternativeTitleFormat: "invalidAlternativeTitleFormat",
+  invalidCategory: "invalidCategory",
   invalidChapterFormat: "invalidChapterFormat",
   invalidFileType: "invalidFileType",
   invalidJsonFormat: "invalidJsonFormat",

--- a/apps/editor/src/lib/categories.ts
+++ b/apps/editor/src/lib/categories.ts
@@ -1,0 +1,26 @@
+import type { CourseCategory } from "@zoonk/utils/categories";
+import { getExtracted } from "next-intl/server";
+
+export async function getCategoryLabel(category: CourseCategory) {
+  const t = await getExtracted();
+
+  const labels: Record<CourseCategory, string> = {
+    arts: t("Arts"),
+    business: t("Business"),
+    communication: t("Communication"),
+    culture: t("Culture"),
+    economics: t("Economics"),
+    engineering: t("Engineering"),
+    geography: t("Geography"),
+    health: t("Health"),
+    history: t("History"),
+    languages: t("Languages"),
+    law: t("Law"),
+    math: t("Math"),
+    science: t("Science"),
+    society: t("Society"),
+    tech: t("Technology"),
+  };
+
+  return labels[category];
+}

--- a/apps/editor/src/lib/error-messages.ts
+++ b/apps/editor/src/lib/error-messages.ts
@@ -20,6 +20,10 @@ export async function getErrorMessage(error: Error): Promise<string> {
 
   if (isEditorError(error)) {
     switch (error.code) {
+      case ErrorCode.categoryAlreadyAdded:
+        return t("This category has already been added to the course");
+      case ErrorCode.categoryNotInCourse:
+        return t("Category not found in this course");
       case ErrorCode.forbidden:
         return t("You don't have permission to perform this action");
       case ErrorCode.unauthorized:
@@ -42,6 +46,8 @@ export async function getErrorMessage(error: Error): Promise<string> {
         return t("Invalid file type. Please upload a JSON file");
       case ErrorCode.invalidJsonFormat:
         return t("Invalid JSON format. Please check your file");
+      case ErrorCode.invalidCategory:
+        return t("Invalid category");
       case ErrorCode.invalidChapterFormat:
         return t(
           "Invalid chapter format. Each chapter must have a title and description",

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -498,3 +498,78 @@ msgstr "We'll use this email to contact you."
 msgctxt "Xx0WZV"
 msgid "Send message"
 msgstr "Send message"
+
+#: src/lib/categories.ts
+msgctxt "djJp6c"
+msgid "History"
+msgstr "History"
+
+#: src/lib/categories.ts
+msgctxt "dPgwrL"
+msgid "Math"
+msgstr "Math"
+
+#: src/lib/categories.ts
+msgctxt "fFt3il"
+msgid "Arts"
+msgstr "Arts"
+
+#: src/lib/categories.ts
+msgctxt "GsBRWL"
+msgid "Languages"
+msgstr "Languages"
+
+#: src/lib/categories.ts
+msgctxt "hlmkcL"
+msgid "Health"
+msgstr "Health"
+
+#: src/lib/categories.ts
+msgctxt "hwL7a0"
+msgid "Engineering"
+msgstr "Engineering"
+
+#: src/lib/categories.ts
+msgctxt "I1ZCPK"
+msgid "Technology"
+msgstr "Technology"
+
+#: src/lib/categories.ts
+msgctxt "KOuDOE"
+msgid "Economics"
+msgstr "Economics"
+
+#: src/lib/categories.ts
+msgctxt "mn6pIm"
+msgid "Culture"
+msgstr "Culture"
+
+#: src/lib/categories.ts
+msgctxt "n5D/Ku"
+msgid "Communication"
+msgstr "Communication"
+
+#: src/lib/categories.ts
+msgctxt "OV/2+4"
+msgid "Society"
+msgstr "Society"
+
+#: src/lib/categories.ts
+msgctxt "qydxOd"
+msgid "Science"
+msgstr "Science"
+
+#: src/lib/categories.ts
+msgctxt "u3ovjm"
+msgid "Law"
+msgstr "Law"
+
+#: src/lib/categories.ts
+msgctxt "w1Fanr"
+msgid "Business"
+msgstr "Business"
+
+#: src/lib/categories.ts
+msgctxt "YMDBNH"
+msgid "Geography"
+msgstr "Geography"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -498,3 +498,78 @@ msgstr "Usaremos este correo electrónico para contactarte."
 msgctxt "Xx0WZV"
 msgid "Send message"
 msgstr "Enviar mensaje"
+
+#: src/lib/categories.ts
+msgctxt "djJp6c"
+msgid "History"
+msgstr "Historia"
+
+#: src/lib/categories.ts
+msgctxt "dPgwrL"
+msgid "Math"
+msgstr "Matemáticas"
+
+#: src/lib/categories.ts
+msgctxt "fFt3il"
+msgid "Arts"
+msgstr "Artes"
+
+#: src/lib/categories.ts
+msgctxt "GsBRWL"
+msgid "Languages"
+msgstr "Idiomas"
+
+#: src/lib/categories.ts
+msgctxt "hlmkcL"
+msgid "Health"
+msgstr "Salud"
+
+#: src/lib/categories.ts
+msgctxt "hwL7a0"
+msgid "Engineering"
+msgstr "Ingeniería"
+
+#: src/lib/categories.ts
+msgctxt "I1ZCPK"
+msgid "Technology"
+msgstr "Tecnología"
+
+#: src/lib/categories.ts
+msgctxt "KOuDOE"
+msgid "Economics"
+msgstr "Economía"
+
+#: src/lib/categories.ts
+msgctxt "mn6pIm"
+msgid "Culture"
+msgstr "Cultura"
+
+#: src/lib/categories.ts
+msgctxt "n5D/Ku"
+msgid "Communication"
+msgstr "Comunicación"
+
+#: src/lib/categories.ts
+msgctxt "OV/2+4"
+msgid "Society"
+msgstr "Sociedad"
+
+#: src/lib/categories.ts
+msgctxt "qydxOd"
+msgid "Science"
+msgstr "Ciencia"
+
+#: src/lib/categories.ts
+msgctxt "u3ovjm"
+msgid "Law"
+msgstr "Derecho"
+
+#: src/lib/categories.ts
+msgctxt "w1Fanr"
+msgid "Business"
+msgstr "Negocios"
+
+#: src/lib/categories.ts
+msgctxt "YMDBNH"
+msgid "Geography"
+msgstr "Geografía"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -498,3 +498,78 @@ msgstr "Usaremos este email para entrar em contato com você."
 msgctxt "Xx0WZV"
 msgid "Send message"
 msgstr "Enviar mensagem"
+
+#: src/lib/categories.ts
+msgctxt "djJp6c"
+msgid "History"
+msgstr "História"
+
+#: src/lib/categories.ts
+msgctxt "dPgwrL"
+msgid "Math"
+msgstr "Matemática"
+
+#: src/lib/categories.ts
+msgctxt "fFt3il"
+msgid "Arts"
+msgstr "Artes"
+
+#: src/lib/categories.ts
+msgctxt "GsBRWL"
+msgid "Languages"
+msgstr "Idiomas"
+
+#: src/lib/categories.ts
+msgctxt "hlmkcL"
+msgid "Health"
+msgstr "Saúde"
+
+#: src/lib/categories.ts
+msgctxt "hwL7a0"
+msgid "Engineering"
+msgstr "Engenharia"
+
+#: src/lib/categories.ts
+msgctxt "I1ZCPK"
+msgid "Technology"
+msgstr "Tecnologia"
+
+#: src/lib/categories.ts
+msgctxt "KOuDOE"
+msgid "Economics"
+msgstr "Economia"
+
+#: src/lib/categories.ts
+msgctxt "mn6pIm"
+msgid "Culture"
+msgstr "Cultura"
+
+#: src/lib/categories.ts
+msgctxt "n5D/Ku"
+msgid "Communication"
+msgstr "Comunicação"
+
+#: src/lib/categories.ts
+msgctxt "OV/2+4"
+msgid "Society"
+msgstr "Sociedade"
+
+#: src/lib/categories.ts
+msgctxt "qydxOd"
+msgid "Science"
+msgstr "Ciência"
+
+#: src/lib/categories.ts
+msgctxt "u3ovjm"
+msgid "Law"
+msgstr "Direito"
+
+#: src/lib/categories.ts
+msgctxt "w1Fanr"
+msgid "Business"
+msgstr "Negócios"
+
+#: src/lib/categories.ts
+msgctxt "YMDBNH"
+msgid "Geography"
+msgstr "Geografia"

--- a/apps/main/src/lib/categories.ts
+++ b/apps/main/src/lib/categories.ts
@@ -1,0 +1,43 @@
+import type { CourseCategory } from "@zoonk/utils/categories";
+import {
+  Briefcase,
+  Calculator,
+  Clock,
+  Cpu,
+  FlaskConical,
+  Globe,
+  Heart,
+  Languages,
+  Map as MapIcon,
+  MessageCircle,
+  Palette,
+  Scale,
+  TrendingUp,
+  Users,
+  Wrench,
+} from "lucide-react";
+import { getExtracted } from "next-intl/server";
+
+export async function getCategoryData(category: CourseCategory) {
+  const t = await getExtracted();
+
+  const data = {
+    arts: { icon: Palette, label: t("Arts") },
+    business: { icon: Briefcase, label: t("Business") },
+    communication: { icon: MessageCircle, label: t("Communication") },
+    culture: { icon: Globe, label: t("Culture") },
+    economics: { icon: TrendingUp, label: t("Economics") },
+    engineering: { icon: Wrench, label: t("Engineering") },
+    geography: { icon: MapIcon, label: t("Geography") },
+    health: { icon: Heart, label: t("Health") },
+    history: { icon: Clock, label: t("History") },
+    languages: { icon: Languages, label: t("Languages") },
+    law: { icon: Scale, label: t("Law") },
+    math: { icon: Calculator, label: t("Math") },
+    science: { icon: FlaskConical, label: t("Science") },
+    society: { icon: Users, label: t("Society") },
+    tech: { icon: Cpu, label: t("Technology") },
+  };
+
+  return data[category];
+}

--- a/i18n.lock
+++ b/i18n.lock
@@ -40,7 +40,24 @@ checksums:
     No%20other%20organizations/singular: e9de48fc34aa9de5d30e3eb8eed79ed1
     Draft/singular: e8a92958ad300aacfe46c2bf6644927e
     Published/singular: ad5e035c44f71ed32d41e47c7643f32f
+    History/singular: b0578d6d225f512e42f823fbca2e3c32
+    Math/singular: 0a604ffa5ef57408918fe98ef05eb05a
+    Arts/singular: 9b1845cec1210e57ea990b1a90823228
+    Languages/singular: 2d2a54a7cbbf640ba2aff643a8a3c7c1
+    Health/singular: db2f8a6e827b5436d1eedaf453eaae8a
+    Engineering/singular: 76e841ae8ec3340d7d0a5c2191abbea4
+    Technology/singular: 694755ad06c9b0d9bfcd78e1610670b8
+    Economics/singular: 3931d28200c67977f6ecdf9b2aa61014
+    Culture/singular: 598e8cf9fdd3ed940090e97eac0674b1
+    Communication/singular: 478f3ecaf6419fa9f11f2a83639188c6
+    Society/singular: fc07530371cde440aac96dae7a33aad4
+    Science/singular: 7b1aa37d3f038f226223f85531c688d8
+    Law/singular: 3f04c791596043e899781f74003b9324
+    Business/singular: 7682c7966c6e718836388561e7e68cab
+    Geography/singular: fd93fe516c40f1f2dd96f53a507ce95d
+    Category%20not%20found%20in%20this%20course/singular: 32ae23f7913223e56ab7207abfe032bb
     An%20unexpected%20error%20occurred/singular: fe07b9cdb1fc3f7397f6d89c102c60af
+    Invalid%20category/singular: 5f9195d3e0d1d819cc9d812b712eaca1
     Chapter%20not%20found/singular: 72d4a8758136678acbae0ec942227f7e
     Chapter%20not%20found%20in%20this%20course/singular: d81e3e6176f913514f413784a8e881e3
     Invalid%20chapter%20format.%20Each%20chapter%20must%20have%20a%20title%20and%20description/singular: 6c9dc938c75674b73b61177b55cce86d
@@ -48,6 +65,7 @@ checksums:
     Invalid%20format.%20Please%20provide%20an%20array%20of%20non-empty%20strings/singular: c9dbc954cf099eedbb573d647356f52e
     Course%20not%20found/singular: 679d024095e9e605246a1928a7e1d87b
     Invalid%20file%20type.%20Please%20upload%20a%20JSON%20file/singular: 9164c5c1930e61a6037fab99386c02f6
+    This%20category%20has%20already%20been%20added%20to%20the%20course/singular: 5b220e40c0bfc7b3700d1f402697c522
     Lesson%20not%20found%20in%20this%20chapter/singular: 2697f3d918027ce266c25004b71a51d9
     Please%20sign%20in%20to%20continue/singular: 051e59dd3d3b0bfad95982f982fd6b9d
     Chapter%20and%20course%20must%20belong%20to%20the%20same%20organization/singular: f3c132074516ccc5cad52c88c86d440d
@@ -59,25 +77,36 @@ checksums:
     Invalid%20JSON%20format.%20Please%20check%20your%20file/singular: 2a890d833f49aa36f02433476ca33468
     Organization%20not%20found/singular: 4cb8c07ec2c599b6f48750e06ffa182b
   9270df1bc9e10fdb8026bb4ab67061d4:
+    Get%20started/singular: 5c783951b0100a168bdd2161ff294833
+    Login/singular: f4f219abeb5a465ecb1c7efaf50246de
+    Logout/singular: 07948fdf20705e04a7bf68ab197512bf
+    My%20account/singular: 4791806fd9fadc33912e3df7e4e3911c
+    Send%20feedback/singular: 9631cc08d49da04475b30a0d320ce97c
+    Update%20display%20name/singular: eb9878176a51d19451553ed035114e88
+    Help%20and%20support/singular: 19383599a92f1b191066d7f29588d72f
+    Search%20courses%20or%20pages.../singular: d059e326784d4e9b074d82e7957a3eef
+    No%20results%20found/singular: 5518f2865757dc73900aa03ef8be6934
+    My%20courses/singular: d97cf4146d15d6ff06df054f89cf2bbd
+    Manage%20settings/singular: 72d60ef4e53cd4eb8c041576b9382b51
+    Learn%20something/singular: 2b9c846ff3fe4df7416deac9aa405e30
+    Update%20language/singular: 578f6d1e35422e5fdc38bf8c85126585
+    Manage%20subscription/singular: b83a75127b8eabc21dfa1e0f7104db56
+    Courses/singular: e6d00f3285e8fc48b949af0c4aad3da5
     Home%20page/singular: aa72464a366b091aa6f2037ca869c09c
-    Or/singular: 98639bcbc7b4889bae62ad0ebde740e1
-    Continue/singular: 3cfba90b4600131e82fc4260c568d044
-    Login%20to%20your%20account%20or%20create%20a%20new%20one%20to%20start%20using%20Zoonk./singular: 19158f1a61c7514a587a7adb58dbbd07
-    Continue%20with%20your%20email%20or%20a%20social%20account/singular: 1f2b79de8d5cb3a40df757ab1b50db55
-    Sign%20in%20or%20create%20an%20account/singular: b29f31bce3d279137572901bf10d6e5f
-    By%20clicking%20on%20Continue%2C%20you%20agree%20to%20our%20%3Cterms%3ETerms%20of%20Service%3C%2Fterms%3E%20and%20%3Cprivacy%3EPrivacy%20Policy%3C%2Fprivacy%3E./singular: 5056e412e67c45780a80009328ad062d
-    Login%20or%20Sign%20Up/singular: 62f0c46df2ef1c62965147ab41b3b715
-    myemail%40gmail.com/singular: cc0e6fe2486416d0d35b100ea3830496
-    Email/singular: e7f34943a0c2fb849db1839ff6ef5cb5
-    Continue%20with%20Apple/singular: 8b13538d47736d8b7b0b0edbbeb9c741
-    Continue%20with%20Google/singular: 296841ac969a7f5d0fffc144f2488bbb
-    There%20was%20an%20error%20signing%20you%20in.%20Please%20try%20again%20or%20contact%20hello%40zoonk.com/singular: abb16bd44edbd2ace037414c5ab9567b
-    The%20code%20you%20entered%20is%20incorrect.%20Please%20try%20again%20or%20contact%20hello%40zoonk.com/singular: b437ceb9d111fd91320f586ee73f7024
-    Change%20email/singular: de3d14d915838e1eb5b04e620de35114
-    Enter%20the%20code%20we%20sent%20to%20%7Bemail%7D%3A/singular: 939208aaf736312126ef0fe08cb1faa3
-    Check%20your%20email/singular: c51aa8640fe15af146f3e2dd4602e0c1
+    Follow%20us%20on%20social%20media/singular: d799b702a7881c797d6a1e9668713590
+    Contact%20us/singular: 694a45bc5c96f6f3a27873c1cf5a7707
+    Search/singular: 49dd6c21604b5e8d4153ff1aff2177e1
+    Language/singular: 277fd1a41cc237a437cd1d5e4a80463b
+    Learn/singular: 6559e2075ab6947a1d4fa43e19a5d66b
+    Settings/singular: 8df6777277469c1fd88cc18dde2f1cc3
+    Feedback/singular: 6fac88806e0c269a30777b283988c61c
+    Subscription/singular: ba9f3675e18987d067d48533c8897343
+    Help/singular: 62712a1f2fcef75e399e9a9a9ddbd495
     Online%20Courses%20using%20AI/singular: 4e3c619f363cc66f3f2e604e372ca038
     Explore%20all%20Zoonk%20courses%20to%20learn%20anything%20using%20AI.%20Find%20interactive%20lessons%2C%20challenges%2C%20and%20activities%20to%20learn%20subjects%20like%20science%2C%20math%2C%20technology%2C%20and%20more./singular: c3f4a7dfd17b4523b5535f40170c7731
+    Did%20you%20like%20this%20content%3F/singular: 23b97024cf20ceee3ee4a1ddc65d251c
+    I%20didn't%20like%20it/singular: 9761a96b22323e7db7d7176b77cf7caa
+    I%20liked%20it/singular: ed20592186f53abcc526360869bd0f55
     Cancel/singular: 2e2a849c2223911717de8caa2c71bade
     Cooking%20up%20some%20course%20ideas/singular: a42520f96dbac3580a2ccae4bd6ceb31
     We're%20putting%20together%20a%20few%20course%20suggestions%20for%20you.%20This%20may%20take%20a%20few%20seconds./singular: 8467af30434eb8bfb2f13e109b1d9334
@@ -96,22 +125,19 @@ checksums:
     View%20all%20the%20courses%20you%20started%20on%20Zoonk.%20Continue%20where%20you%20left%20off%20and%20track%20your%20progress%20across%20interactive%20lessons%20and%20activities./singular: eee1ce9f3b0be49ddc9bb3ce21270796
     Zoonk%3A%20AI%20Learning%20Platform/singular: 4a2d25490f4a5e5cd4543f48fcec968d
     Zoonk%20is%20an%20AI-powered%20learning%20platform%20where%20you%20can%20learn%20anything%20through%20interactive%20courses%2C%20lessons%2C%20and%20activities./singular: e836899ce8100db55d5fa54fe6375970
-    Feedback/singular: 6fac88806e0c269a30777b283988c61c
-    Send%20feedback%2C%20questions%2C%20or%20suggestions%20to%20us.%20Fill%20in%20the%20form%20below%20or%20email%20us%20directly%20at%20hello%40zoonk.com./singular: 6ce5e55ddeeb7de9480b806358aa5b95
-    Send%20feedback/singular: 9631cc08d49da04475b30a0d320ce97c
-    Share%20your%20thoughts%20and%20help%20improve%20Zoonk.%20Use%20the%20feedback%20page%20to%20contact%20us%20with%20suggestions%2C%20questions%2C%20or%20issues%20about%20our%20learning%20platform./singular: 6b06a1c72037c5a874506c495070db64
+    Checking%20if%20you're%20logged%20in.../singular: b50f05bfcb51cad6913150273e551291
+    You%20need%20to%20be%20logged%20in%20to%20access%20this%20page./singular: 759ca522663d8f628718332f756dd6c4
+    Display%20name/singular: 725f331065e9d594d720d07b1ae51a90
     Follow%20us/singular: 778f7a4744f77dbcbd31a8c778cb5209
+    Send%20feedback%2C%20questions%2C%20or%20suggestions%20to%20us.%20Fill%20in%20the%20form%20below%20or%20email%20us%20directly%20at%20hello%40zoonk.com./singular: 6ce5e55ddeeb7de9480b806358aa5b95
+    Share%20your%20thoughts%20and%20help%20improve%20Zoonk.%20Use%20the%20feedback%20page%20to%20contact%20us%20with%20suggestions%2C%20questions%2C%20or%20issues%20about%20our%20learning%20platform./singular: 6b06a1c72037c5a874506c495070db64
     Find%20all%20our%20social%20media%20links%20and%20keep%20in%20touch%20with%20us./singular: 622a8496ae558c2347113749ac3c4ab8
-    Follow%20us%20on%20social%20media/singular: d799b702a7881c797d6a1e9668713590
     Connect%20with%20Zoonk%20across%20social%20media.%20Follow%20us%20on%20X%2C%20LinkedIn%2C%20YouTube%2C%20and%20more%20to%20stay%20updated%20on%20new%20features%2C%20tips%2C%20and%20learning%20content./singular: fc9668fa1d3d825afa62bbebf4655fcd
     Get%20support%20and%20answers.%20Fill%20in%20the%20form%20below%20or%20email%20us%20directly%20at%20hello%40zoonk.com./singular: 08e65ee4ac29acae31f47a08f7381365
-    Help/singular: 62712a1f2fcef75e399e9a9a9ddbd495
     Help%20%26%20Support/singular: 662d807b3768c9753238bd5f1c86d2f6
     Need%20help%20with%20Zoonk%3F%20Contact%20our%20support%20or%20browse%20the%20FAQ%20to%20quickly%20find%20answers%20to%20common%20questions./singular: 688f26b3492222993d84ba21fd74a1a3
-    Change%20Language/singular: c798f65b78e23b2cf8fc29a1a24a182f
     Choose%20the%20app%20language%20you%20prefer%20for%20this%20device./singular: 4e22090be4b9fda9945e41822872c030
     Update%20your%20Zoonk%20app%20language%20to%20learn%20in%20English%2C%20Portuguese%2C%20Spanish%2C%20French%2C%20or%20other%20supported%20languages./singular: 1c0ee0edf658ce641954e5e20a447905
-    Language/singular: 277fd1a41cc237a437cd1d5e4a80463b
     Your%20name%20has%20been%20updated%20successfully!/singular: 57bbf14c5b2eb3cefb1bf1dcba56cfa0
     Update%20name/singular: ad5a6fc8a83d09e6e959e21fc1034956
     Failed%20to%20update%20your%20name.%20Please%20try%20again%20or%20contact%20hello%40zoonk.com/singular: 5c23accc74863614c754e0af7d49ab1f
@@ -119,60 +145,46 @@ checksums:
     This%20name%20will%20be%20visible%20to%20other%20users./singular: f09fcb0452297983c7b73c689206fa08
     Set%20or%20update%20your%20Zoonk%20display%20name.%20This%20name%20may%20be%20visible%20to%20others%20and%20will%20be%20used%20when%20referring%20to%20you%20in%20lessons%20and%20activities./singular: 27a489da570cb0d40c7b47d81d271213
     Update%20Display%20Name/singular: 6583c6a89e7dfe4373ba2e6033547b69
-    Display%20name/singular: 725f331065e9d594d720d07b1ae51a90
     This%20is%20the%20name%20others%20may%20see%20and%20the%20one%20we'll%20use%20to%20refer%20to%20you%20in%20activities./singular: 84084520f32cbe01700e2f32c43558aa
-    Logout/singular: 07948fdf20705e04a7bf68ab197512bf
-    Settings/singular: 8df6777277469c1fd88cc18dde2f1cc3
-    Navigate%20settings/singular: 3a3a2a7811fc04b3e7faa316cee3c532
     Customize%20your%20Zoonk%20learning%20experience.%20Manage%20account%20settings%2C%20profile%2C%20and%20preferences%20to%20get%20the%20most%20out%20of%20our%20education%20platform./singular: 36a3ad216744e032858a6279929bd37b
     Manage%20your%20account%20settings%2C%20profile%2C%20and%20preferences./singular: fb026dbc30e3549c3d15e6c254e7d70e
     Manage%20Subscription/singular: 31cafd367fc70d656d8dd979d537dc96
     Manage%20your%20Zoonk%20subscription.%20View%20your%20current%20plan%2C%20upgrade%20or%20downgrade%2C%20and%20see%20available%20benefits./singular: 47f6b6e7b8217ffc7b8135863f626906
     Check%20your%20plan%20details%20and%20manage%20your%20subscription./singular: b9c54ab5f7759daa9fde43d201b05a3d
-    Subscription/singular: ba9f3675e18987d067d48533c8897343
     Upgrade/singular: 63c3b52882e0d779859307d672c178c2
     No%20ads%2C%20unlimited%20lessons%2C%20and%20full%20progress%20tracking./singular: 8f01b698721c3c79191463236f039529
     Remove%20ads%2C%20unlock%20unlimited%20lessons%2C%20and%20track%20your%20progress./singular: d935ae55f9b7faf08bf520b7457972ac
     Upgrade%20to%20Plus/singular: 5ffe2178c10543c0be3b54a15c82da54
     You%E2%80%99re%20on%20Zoonk%20Plus/singular: 5ca1a2563220c91f7eb44a60d2701a79
-    Unable%20to%20change%20your%20subscription.%20Contact%20us%20at%20hello%40zoonk.com/singular: ea42a3331f02e49fabc79ba9e55eb57b
-    Manage%20subscription/singular: b83a75127b8eabc21dfa1e0f7104db56
+    Unable%20to%20update%20your%20subscription.%20Contact%20us%20at%20hello%40zoonk.com/singular: 07449ee5fe347be88856524cec7f06ef
     Read%20Zoonk's%20privacy%20policy%20to%20understand%20how%20we%20collect%2C%20use%2C%20and%20protect%20your%20personal%20information./singular: 044f3586abe7d9915820a6629cef08e4
     Privacy%20Policy/singular: 7459744a63ef8af4e517a09024bd7c08
     Read%20Zoonk's%20terms%20of%20use%20to%20understand%20the%20rules%20and%20conditions%20for%20using%20our%20platform%20and%20services/singular: 4b82898d60691839a1999e4a17199895
     Terms%20of%20Use/singular: 9ac262b2eda552beeecd904c0b9f8fa2
-    Get%20started/singular: 5c783951b0100a168bdd2161ff294833
-    Login/singular: f4f219abeb5a465ecb1c7efaf50246de
-    My%20account/singular: 4791806fd9fadc33912e3df7e4e3911c
-    Update%20display%20name/singular: eb9878176a51d19451553ed035114e88
-    Help%20and%20support/singular: 19383599a92f1b191066d7f29588d72f
-    Search%20courses%20or%20pages.../singular: d059e326784d4e9b074d82e7957a3eef
-    No%20results%20found/singular: 5518f2865757dc73900aa03ef8be6934
-    My%20courses/singular: d97cf4146d15d6ff06df054f89cf2bbd
-    Manage%20settings/singular: 72d60ef4e53cd4eb8c041576b9382b51
-    Learn%20something/singular: 2b9c846ff3fe4df7416deac9aa405e30
-    Close%20search/singular: c992eebc22df6ad1b642e5257d800974
-    Update%20language/singular: 578f6d1e35422e5fdc38bf8c85126585
-    Courses/singular: e6d00f3285e8fc48b949af0c4aad3da5
-    Contact%20us/singular: 694a45bc5c96f6f3a27873c1cf5a7707
-    Search/singular: 49dd6c21604b5e8d4153ff1aff2177e1
     Please%20provide%20as%20much%20detail%20as%20possible./singular: 3c8b231283c751d4beae059a6ffc3643
     Failed%20to%20send%20message.%20Please%20try%20again%20or%20email%20us%20directly%20at%20hello%40zoonk.com/singular: 7f36bcd5ba5dad4b9981f85488ff794c
     Email%20address/singular: 3ba3f099b1b9be6c35ad797da660cb9f
     How%20can%20we%20help%20you%3F/singular: 4571603146ce34160e23dfc95ca53ebf
+    myemail%40gmail.com/singular: cc0e6fe2486416d0d35b100ea3830496
     Message/singular: f2f72126bd244cfc534eab395e054362
     Message%20sent%20successfully!%20We'll%20get%20back%20to%20you%20soon./singular: c34a09294fd597649e9bd42401477697
     We'll%20use%20this%20email%20to%20contact%20you./singular: a09d71670ae76167b7faa718e794086b
     Send%20message/singular: 19e7006870c6e407dece25ee8c9d5333
-    Did%20you%20like%20this%20content%3F/singular: 23b97024cf20ceee3ee4a1ddc65d251c
-    I%20didn't%20like%20it/singular: 9761a96b22323e7db7d7176b77cf7caa
-    I%20liked%20it/singular: ed20592186f53abcc526360869bd0f55
-    Close/singular: 2c2e22f8424a1031de89063bd0022e16
-    "%7Blocale%2C%20select%2C%20pt%20%7B%F0%9F%87%A7%F0%9F%87%B7%20Portugu%C3%AAs%7D%20en%20%7B%F0%9F%87%BA%F0%9F%87%B8%20English%7D%20es%20%7B%F0%9F%87%AA%F0%9F%87%B8%20Espa%C3%B1ol%7D%20other%20%7BUnknown%7D%7D/singular": c88ed734f3b526cd123c7b8f14cf1035
-    Change%20language/singular: 53bea3a813015ca3bf2e4cc6a269fb74
-    Learn/singular: 6559e2075ab6947a1d4fa43e19a5d66b
-    Checking%20if%20you're%20logged%20in.../singular: b50f05bfcb51cad6913150273e551291
-    You%20need%20to%20be%20logged%20in%20to%20access%20this%20page./singular: 759ca522663d8f628718332f756dd6c4
+    History/singular: b0578d6d225f512e42f823fbca2e3c32
+    Math/singular: 0a604ffa5ef57408918fe98ef05eb05a
+    Arts/singular: 9b1845cec1210e57ea990b1a90823228
+    Languages/singular: 2d2a54a7cbbf640ba2aff643a8a3c7c1
+    Health/singular: db2f8a6e827b5436d1eedaf453eaae8a
+    Engineering/singular: 76e841ae8ec3340d7d0a5c2191abbea4
+    Technology/singular: 694755ad06c9b0d9bfcd78e1610670b8
+    Economics/singular: 3931d28200c67977f6ecdf9b2aa61014
+    Culture/singular: 598e8cf9fdd3ed940090e97eac0674b1
+    Communication/singular: 478f3ecaf6419fa9f11f2a83639188c6
+    Society/singular: fc07530371cde440aac96dae7a33aad4
+    Science/singular: 7b1aa37d3f038f226223f85531c688d8
+    Law/singular: 3f04c791596043e899781f74003b9324
+    Business/singular: 7682c7966c6e718836388561e7e68cab
+    Geography/singular: fd93fe516c40f1f2dd96f53a507ce95d
   61a308caf583f5835f54302028bdae73:
     You're%20signed%20in!/singular: 7f23ad13626e60f22e13b8777458750d
     You%20can%20close%20this%20window%20and%20return%20to%20your%20app./singular: 06f96197fc40b30e288b1a9603d15825

--- a/packages/ai/src/course-categories/generate-course-categories.ts
+++ b/packages/ai/src/course-categories/generate-course-categories.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { COURSE_CATEGORIES } from "@zoonk/utils/categories";
 import { generateText, Output } from "ai";
 import { z } from "zod";
 import systemPrompt from "./course-categories.prompt.md";
@@ -15,26 +16,8 @@ const FALLBACK_MODELS = [
   "openai/gpt-4.1-mini",
 ];
 
-const ALLOWED_CATEGORIES = [
-  "arts",
-  "business",
-  "communication",
-  "culture",
-  "economics",
-  "engineering",
-  "geography",
-  "health",
-  "history",
-  "languages",
-  "law",
-  "math",
-  "science",
-  "society",
-  "tech",
-] as const;
-
 const schema = z.object({
-  categories: z.array(z.enum(ALLOWED_CATEGORIES)),
+  categories: z.array(z.enum(COURSE_CATEGORIES)),
 });
 
 export type CourseCategoriesSchema = z.infer<typeof schema>;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21,6 +21,7 @@ export type {
   ChapterLesson,
   Course,
   CourseAlternativeTitle,
+  CourseCategory,
   CourseChapter,
   CourseSuggestion,
   Invitation,

--- a/packages/db/src/prisma/migrations/20251227193851_add_course_categories/migration.sql
+++ b/packages/db/src/prisma/migrations/20251227193851_add_course_categories/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "course_categories" (
+    "id" SERIAL NOT NULL,
+    "course_id" INTEGER NOT NULL,
+    "category" VARCHAR(50) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "course_categories_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "course_categories_category_idx" ON "course_categories"("category");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "course_categories_course_id_category_key" ON "course_categories"("course_id", "category");
+
+-- AddForeignKey
+ALTER TABLE "course_categories" ADD CONSTRAINT "course_categories_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "courses"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/src/prisma/models/courses.prisma
+++ b/packages/db/src/prisma/models/courses.prisma
@@ -23,8 +23,9 @@ model Course {
   imageUrl          String?                  @map("image_url")
   createdAt         DateTime                 @default(now()) @map("created_at")
   updatedAt         DateTime                 @default(now()) @updatedAt @map("updated_at")
-  courseChapters    CourseChapter[]
   alternativeTitles CourseAlternativeTitle[]
+  categories        CourseCategory[]
+  courseChapters    CourseChapter[]
 
   @@unique([organizationId, language, slug], name: "orgSlug")
   @@index([organizationId, language, isPublished])
@@ -43,4 +44,16 @@ model CourseAlternativeTitle {
   @@unique([locale, slug], name: "localeSlug")
   @@index([courseId])
   @@map("course_alternative_titles")
+}
+
+model CourseCategory {
+  id        Int      @id @default(autoincrement())
+  courseId  Int      @map("course_id")
+  course    Course   @relation(fields: [courseId], references: [id], onDelete: Cascade)
+  category  String   @db.VarChar(50)
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@unique([courseId, category], name: "courseCategory")
+  @@index([category])
+  @@map("course_categories")
 }

--- a/packages/db/src/prisma/seed.ts
+++ b/packages/db/src/prisma/seed.ts
@@ -1,5 +1,6 @@
 import { prisma } from "../index";
 import { seedAlternativeTitles } from "./seed/alternative-titles";
+import { seedCategories } from "./seed/categories";
 import { seedChapters } from "./seed/chapters";
 import { seedCourses } from "./seed/courses";
 import { seedLessons } from "./seed/lessons";
@@ -10,6 +11,7 @@ async function main() {
   const users = await seedUsers(prisma);
   const org = await seedOrganizations(prisma, users);
   await seedCourses(prisma, org);
+  await seedCategories(prisma, org);
   await seedChapters(prisma, org);
   await seedLessons(prisma, org);
   await seedAlternativeTitles(prisma, org);

--- a/packages/db/src/prisma/seed/categories.ts
+++ b/packages/db/src/prisma/seed/categories.ts
@@ -1,0 +1,84 @@
+import type { Organization, PrismaClient } from "../../generated/prisma/client";
+import { coursesData } from "./courses";
+
+type CourseCategoryData = {
+  courseSlug: string;
+  language: string;
+  categories: string[];
+};
+
+const categoriesData: CourseCategoryData[] = [
+  {
+    categories: ["tech", "math", "science"],
+    courseSlug: "machine-learning",
+    language: "en",
+  },
+  {
+    categories: ["languages", "culture", "communication"],
+    courseSlug: "spanish",
+    language: "en",
+  },
+  {
+    categories: ["science", "geography"],
+    courseSlug: "astronomy",
+    language: "en",
+  },
+  {
+    categories: ["tech", "math", "science"],
+    courseSlug: "machine-learning",
+    language: "pt",
+  },
+  {
+    categories: ["languages", "culture", "communication"],
+    courseSlug: "espanhol",
+    language: "pt",
+  },
+  {
+    categories: ["science", "geography"],
+    courseSlug: "astronomia",
+    language: "pt",
+  },
+];
+
+export async function seedCategories(
+  prisma: PrismaClient,
+  org: Organization,
+): Promise<void> {
+  const courses = await prisma.course.findMany({
+    select: { id: true, language: true, slug: true },
+    where: {
+      organizationId: org.id,
+      slug: { in: coursesData.map((c) => c.slug) },
+    },
+  });
+
+  const categoryRecords = categoriesData.flatMap((data) => {
+    const course = courses.find(
+      (c) => c.slug === data.courseSlug && c.language === data.language,
+    );
+
+    if (!course) {
+      return [];
+    }
+
+    return data.categories.map((category) => ({
+      category,
+      courseId: course.id,
+    }));
+  });
+
+  await Promise.all(
+    categoryRecords.map((record) =>
+      prisma.courseCategory.upsert({
+        create: record,
+        update: {},
+        where: {
+          courseCategory: {
+            category: record.category,
+            courseId: record.courseId,
+          },
+        },
+      }),
+    ),
+  );
+}

--- a/packages/db/src/utils.ts
+++ b/packages/db/src/utils.ts
@@ -1,5 +1,17 @@
+import { Prisma } from "./generated/prisma/client";
+
 const MAX_QUERY_ITEMS = 100;
 
 export function clampQueryItems(count: number): number {
   return Math.min(Math.max(count, 1), MAX_QUERY_ITEMS);
+}
+
+/**
+ * Check if an error is a Prisma unique constraint violation (P2002).
+ */
+export function isUniqueConstraintError(error: unknown): boolean {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    error.code === "P2002"
+  );
 }

--- a/packages/testing/src/fixtures/courses.ts
+++ b/packages/testing/src/fixtures/courses.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { type Course, prisma } from "@zoonk/db";
+import { type Course, type CourseCategory, prisma } from "@zoonk/db";
 
 export function courseAttrs(
   attrs?: Partial<Course>,
@@ -20,4 +20,16 @@ export function courseAttrs(
 export async function courseFixture(attrs?: Partial<Course>) {
   const course = await prisma.course.create({ data: courseAttrs(attrs) });
   return course;
+}
+
+export async function courseCategoryFixture(
+  attrs: Omit<CourseCategory, "id" | "createdAt">,
+) {
+  const courseCategory = await prisma.courseCategory.create({
+    data: {
+      category: attrs.category,
+      courseId: attrs.courseId,
+    },
+  });
+  return courseCategory;
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,6 +10,7 @@
   },
   "exports": {
     "./cache": "./src/cache.ts",
+    "./categories": "./src/categories.ts",
     "./constants": "./src/constants.ts",
     "./error": "./src/error.ts",
     "./form": "./src/form.ts",

--- a/packages/utils/src/categories.ts
+++ b/packages/utils/src/categories.ts
@@ -1,0 +1,19 @@
+export const COURSE_CATEGORIES = [
+  "arts",
+  "business",
+  "communication",
+  "culture",
+  "economics",
+  "engineering",
+  "geography",
+  "health",
+  "history",
+  "languages",
+  "law",
+  "math",
+  "science",
+  "society",
+  "tech",
+] as const;
+
+export type CourseCategory = (typeof COURSE_CATEGORIES)[number];


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds server APIs to add, list, and remove course categories with validation and org permission checks. Also introduces a CourseCategory DB model, shared category constants, and localized labels/icons.

- **New Features**
  - APIs: addCategoryToCourse, removeCategoryFromCourse, listCourseCategories.
  - Permission checks (org admin) and clear errors: forbidden, invalidCategory, categoryAlreadyAdded, categoryNotInCourse, courseNotFound.
  - Shared COURSE_CATEGORIES constant/type; AI generator updated to use it.
  - Localized category labels and icons for editor and main apps; tests cover permissions and edge cases.

- **Migration**
  - Run Prisma migrate to create course_categories.
  - Run seed to populate sample categories.
  - Update imports to use @zoonk/utils/categories for valid categories.

<sup>Written for commit 0b3e62f9063ba08e58299685e8610353e3f89e1c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



