### PR TITLE
feat(editor): automatically publish chapters/lessons when added to unpublished items

### DIFF
--- a/apps/editor/src/data/chapters/add-chapter-to-course.test.ts
+++ b/apps/editor/src/data/chapters/add-chapter-to-course.test.ts
@@ -397,4 +397,60 @@ describe("admins", () => {
     const sortedPositions = [...positions].sort((a, b) => a - b);
     expect(sortedPositions).toEqual([0, 1, 2, 3, 4]);
   });
+
+  describe("isPublished behavior", () => {
+    test("chapter becomes published when added to unpublished course", async () => {
+      const unpublishedCourse = await courseFixture({
+        isPublished: false,
+        organizationId: organization.id,
+      });
+
+      const unpublishedChapter = await chapterFixture({
+        isPublished: false,
+        organizationId: organization.id,
+      });
+
+      const result = await addChapterToCourse({
+        chapterId: unpublishedChapter.id,
+        courseId: unpublishedCourse.id,
+        headers,
+        position: 0,
+      });
+
+      expect(result.error).toBeNull();
+
+      const updatedChapter = await prisma.chapter.findUnique({
+        where: { id: unpublishedChapter.id },
+      });
+
+      expect(updatedChapter?.isPublished).toBe(true);
+    });
+
+    test("chapter remains unpublished when added to published course", async () => {
+      const publishedCourse = await courseFixture({
+        isPublished: true,
+        organizationId: organization.id,
+      });
+
+      const unpublishedChapter = await chapterFixture({
+        isPublished: false,
+        organizationId: organization.id,
+      });
+
+      const result = await addChapterToCourse({
+        chapterId: unpublishedChapter.id,
+        courseId: publishedCourse.id,
+        headers,
+        position: 0,
+      });
+
+      expect(result.error).toBeNull();
+
+      const updatedChapter = await prisma.chapter.findUnique({
+        where: { id: unpublishedChapter.id },
+      });
+
+      expect(updatedChapter?.isPublished).toBe(false);
+    });
+  });
 });

--- a/apps/editor/src/data/chapters/add-chapter-to-course.ts
+++ b/apps/editor/src/data/chapters/add-chapter-to-course.ts
@@ -66,6 +66,13 @@ export async function addChapterToCourse(params: {
         },
       });
 
+      if (!course.isPublished) {
+        await tx.chapter.update({
+          data: { isPublished: true },
+          where: { id: params.chapterId },
+        });
+      }
+
       return tx.courseChapter.create({
         data: {
           chapterId: params.chapterId,

--- a/apps/editor/src/data/chapters/create-chapter.test.ts
+++ b/apps/editor/src/data/chapters/create-chapter.test.ts
@@ -354,4 +354,40 @@ describe("admins", () => {
     const sortedPositions = [...positions].sort((a, b) => a - b);
     expect(sortedPositions).toEqual([0, 1, 2, 3, 4]);
   });
+
+  describe("isPublished behavior", () => {
+    test("chapter is published when course is unpublished", async () => {
+      const unpublishedCourse = await courseFixture({
+        isPublished: false,
+        organizationId: organization.id,
+      });
+
+      const result = await createChapter({
+        ...chapterAttrs(),
+        courseId: unpublishedCourse.id,
+        headers,
+        position: 0,
+      });
+
+      expect(result.error).toBeNull();
+      expect(result.data?.chapter.isPublished).toBe(true);
+    });
+
+    test("chapter is unpublished when course is published", async () => {
+      const publishedCourse = await courseFixture({
+        isPublished: true,
+        organizationId: organization.id,
+      });
+
+      const result = await createChapter({
+        ...chapterAttrs(),
+        courseId: publishedCourse.id,
+        headers,
+        position: 0,
+      });
+
+      expect(result.error).toBeNull();
+      expect(result.data?.chapter.isPublished).toBe(false);
+    });
+  });
 });

--- a/apps/editor/src/data/chapters/create-chapter.ts
+++ b/apps/editor/src/data/chapters/create-chapter.ts
@@ -54,6 +54,7 @@ export async function createChapter(params: {
       const chapter = await tx.chapter.create({
         data: {
           description: params.description,
+          isPublished: !course.isPublished,
           normalizedTitle,
           organizationId: course.organizationId,
           slug: chapterSlug,

--- a/apps/editor/src/data/chapters/import-chapters.ts
+++ b/apps/editor/src/data/chapters/import-chapters.ts
@@ -203,7 +203,14 @@ export async function importChapters(params: {
         let chapter: Chapter;
 
         if (item.hasExplicitSlug && existingChapter) {
-          chapter = existingChapter;
+          if (course.isPublished || existingChapter.isPublished) {
+            chapter = existingChapter;
+          } else {
+            chapter = await tx.chapter.update({
+              data: { isPublished: true },
+              where: { id: existingChapter.id },
+            });
+          }
         } else {
           const uniqueSlug =
             !item.hasExplicitSlug && existingChapter
@@ -213,6 +220,7 @@ export async function importChapters(params: {
           chapter = await tx.chapter.create({
             data: {
               description: item.chapterData.description,
+              isPublished: !course.isPublished,
               normalizedTitle: item.normalizedTitle,
               organizationId: course.organizationId,
               slug: uniqueSlug,

--- a/apps/editor/src/data/lessons/add-lesson-to-chapter.test.ts
+++ b/apps/editor/src/data/lessons/add-lesson-to-chapter.test.ts
@@ -297,4 +297,60 @@ describe("admins", () => {
     const sortedPositions = [...positions].sort((a, b) => a - b);
     expect(sortedPositions).toEqual([0, 1, 2, 3, 4]);
   });
+
+  describe("isPublished behavior", () => {
+    test("lesson becomes published when added to unpublished chapter", async () => {
+      const unpublishedChapter = await chapterFixture({
+        isPublished: false,
+        organizationId: organization.id,
+      });
+
+      const unpublishedLesson = await lessonFixture({
+        isPublished: false,
+        organizationId: organization.id,
+      });
+
+      const result = await addLessonToChapter({
+        chapterId: unpublishedChapter.id,
+        headers,
+        lessonId: unpublishedLesson.id,
+        position: 0,
+      });
+
+      expect(result.error).toBeNull();
+
+      const updatedLesson = await prisma.lesson.findUnique({
+        where: { id: unpublishedLesson.id },
+      });
+
+      expect(updatedLesson?.isPublished).toBe(true);
+    });
+
+    test("lesson remains unpublished when added to published chapter", async () => {
+      const publishedChapter = await chapterFixture({
+        isPublished: true,
+        organizationId: organization.id,
+      });
+
+      const unpublishedLesson = await lessonFixture({
+        isPublished: false,
+        organizationId: organization.id,
+      });
+
+      const result = await addLessonToChapter({
+        chapterId: publishedChapter.id,
+        headers,
+        lessonId: unpublishedLesson.id,
+        position: 0,
+      });
+
+      expect(result.error).toBeNull();
+
+      const updatedLesson = await prisma.lesson.findUnique({
+        where: { id: unpublishedLesson.id },
+      });
+
+      expect(updatedLesson?.isPublished).toBe(false);
+    });
+  });
 });

--- a/apps/editor/src/data/lessons/add-lesson-to-chapter.ts
+++ b/apps/editor/src/data/lessons/add-lesson-to-chapter.ts
@@ -66,6 +66,13 @@ export async function addLessonToChapter(params: {
         },
       });
 
+      if (!chapter.isPublished) {
+        await tx.lesson.update({
+          data: { isPublished: true },
+          where: { id: params.lessonId },
+        });
+      }
+
       return tx.chapterLesson.create({
         data: {
           chapterId: params.chapterId,

--- a/apps/editor/src/data/lessons/create-lesson.test.ts
+++ b/apps/editor/src/data/lessons/create-lesson.test.ts
@@ -364,4 +364,40 @@ describe("admins", () => {
     const sortedPositions = [...positions].sort((a, b) => a - b);
     expect(sortedPositions).toEqual([0, 1, 2, 3, 4]);
   });
+
+  describe("isPublished behavior", () => {
+    test("lesson is published when chapter is unpublished", async () => {
+      const unpublishedChapter = await chapterFixture({
+        isPublished: false,
+        organizationId: organization.id,
+      });
+
+      const result = await createLesson({
+        ...lessonAttrs(),
+        chapterId: unpublishedChapter.id,
+        headers,
+        position: 0,
+      });
+
+      expect(result.error).toBeNull();
+      expect(result.data?.lesson.isPublished).toBe(true);
+    });
+
+    test("lesson is unpublished when chapter is published", async () => {
+      const publishedChapter = await chapterFixture({
+        isPublished: true,
+        organizationId: organization.id,
+      });
+
+      const result = await createLesson({
+        ...lessonAttrs(),
+        chapterId: publishedChapter.id,
+        headers,
+        position: 0,
+      });
+
+      expect(result.error).toBeNull();
+      expect(result.data?.lesson.isPublished).toBe(false);
+    });
+  });
 });

--- a/apps/editor/src/data/lessons/create-lesson.ts
+++ b/apps/editor/src/data/lessons/create-lesson.ts
@@ -54,6 +54,7 @@ export async function createLesson(params: {
       const lesson = await tx.lesson.create({
         data: {
           description: params.description,
+          isPublished: !chapter.isPublished,
           normalizedTitle,
           organizationId: chapter.organizationId,
           slug: lessonSlug,

--- a/apps/editor/src/data/lessons/import-lessons.ts
+++ b/apps/editor/src/data/lessons/import-lessons.ts
@@ -203,7 +203,14 @@ export async function importLessons(params: {
         let lesson: Lesson;
 
         if (item.hasExplicitSlug && existingLesson) {
-          lesson = existingLesson;
+          if (chapter.isPublished || existingLesson.isPublished) {
+            lesson = existingLesson;
+          } else {
+            lesson = await tx.lesson.update({
+              data: { isPublished: true },
+              where: { id: existingLesson.id },
+            });
+          }
         } else {
           const uniqueSlug =
             !item.hasExplicitSlug && existingLesson
@@ -213,6 +220,7 @@ export async function importLessons(params: {
           lesson = await tx.lesson.create({
             data: {
               description: item.lessonData.description,
+              isPublished: !chapter.isPublished,
               normalizedTitle: item.normalizedTitle,
               organizationId: chapter.organizationId,
               slug: uniqueSlug,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automatically sets publish state when adding, creating, or importing chapters and lessons. Children are published if the parent is unpublished; they stay unpublished if the parent is published.

- New Features
  - Chapters: Added/created/imported under an unpublished course are published; under a published course they are unpublished. Existing imported chapters with an explicit slug are published when imported into an unpublished course (no change if already published).
  - Lessons: Added/created/imported under an unpublished chapter are published; under a published chapter they are unpublished. Existing imported lessons with an explicit slug are published when imported into an unpublished chapter (no change if already published).

<sup>Written for commit 102045f5c246fbb73729fd69e4f8d704fd274250. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

