### PR TITLE
feat(editor): allow to edit course title and description

### DIFF
--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -15,6 +15,41 @@ msgctxt "ZFXb/x"
 msgid "Delete course?"
 msgstr "Delete course?"
 
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "2Pphvx"
+msgid "Course title…"
+msgstr "Course title…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "BfrgHC"
+msgid "Unsaved"
+msgstr "Unsaved"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "Ek5KLE"
+msgid "Edit course description"
+msgstr "Edit course description"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "FKa6ED"
+msgid "Edit course title"
+msgstr "Edit course title"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "fsB/4p"
+msgid "Saved"
+msgstr "Saved"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "RX7tLA"
+msgid "Course description…"
+msgstr "Course description…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "WUV28A"
+msgid "Saving…"
+msgstr "Saving…"
+
 #: src/app/[orgSlug]/course-list.tsx
 msgctxt "c0YWuA"
 msgid "Your organization hasn't created any courses yet."

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -15,6 +15,41 @@ msgctxt "ZFXb/x"
 msgid "Delete course?"
 msgstr "¿Eliminar curso?"
 
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "2Pphvx"
+msgid "Course title…"
+msgstr "Título del curso…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "BfrgHC"
+msgid "Unsaved"
+msgstr "Sin guardar"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "Ek5KLE"
+msgid "Edit course description"
+msgstr "Editar descripción del curso"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "FKa6ED"
+msgid "Edit course title"
+msgstr "Editar título del curso"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "fsB/4p"
+msgid "Saved"
+msgstr "Guardado"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "RX7tLA"
+msgid "Course description…"
+msgstr "Descripción del curso…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "WUV28A"
+msgid "Saving…"
+msgstr "Guardando…"
+
 #: src/app/[orgSlug]/course-list.tsx
 msgctxt "c0YWuA"
 msgid "Your organization hasn't created any courses yet."

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -15,6 +15,41 @@ msgctxt "ZFXb/x"
 msgid "Delete course?"
 msgstr "Excluir curso?"
 
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "2Pphvx"
+msgid "Course title…"
+msgstr "Título do curso…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "BfrgHC"
+msgid "Unsaved"
+msgstr "Não salvo"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "Ek5KLE"
+msgid "Edit course description"
+msgstr "Editar descrição do curso"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "FKa6ED"
+msgid "Edit course title"
+msgstr "Editar título do curso"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "fsB/4p"
+msgid "Saved"
+msgstr "Salvo"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "RX7tLA"
+msgid "Course description…"
+msgstr "Descrição do curso…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+msgctxt "WUV28A"
+msgid "Saving…"
+msgstr "Salvando…"
+
 #: src/app/[orgSlug]/course-list.tsx
 msgctxt "c0YWuA"
 msgid "Your organization hasn't created any courses yet."

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { revalidateMainApp } from "@zoonk/core/cache/revalidate";
+import { cacheTagCourse } from "@zoonk/utils/cache";
+import { after } from "next/server";
+import { updateCourse } from "@/data/courses/update-course";
+import { getErrorMessage } from "@/lib/error-messages";
+
+export async function updateCourseAction(
+  courseId: number,
+  data: { title?: string; description?: string },
+): Promise<{ error: string | null }> {
+  const { error } = await updateCourse({
+    courseId,
+    ...data,
+  });
+
+  if (error) {
+    return { error: await getErrorMessage(error) };
+  }
+
+  after(async () => {
+    await revalidateMainApp([cacheTagCourse({ courseId })]);
+  });
+
+  return { error: null };
+}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor-skeleton.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor-skeleton.tsx
@@ -1,0 +1,17 @@
+import {
+  ContainerHeader,
+  ContainerHeaderGroup,
+} from "@zoonk/ui/components/container";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+
+export function CourseEditorSkeleton() {
+  return (
+    <ContainerHeader>
+      <ContainerHeaderGroup className="flex-1 gap-2">
+        <Skeleton className="h-6 w-3/4" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-2/3" />
+      </ContainerHeaderGroup>
+    </ContainerHeader>
+  );
+}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/course-editor.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import {
+  ContainerHeader,
+  ContainerHeaderGroup,
+} from "@zoonk/ui/components/container";
+import {
+  EditableText,
+  EditableTextarea,
+} from "@zoonk/ui/components/editable-text";
+import {
+  combineSaveStatuses,
+  SaveStatus,
+} from "@zoonk/ui/components/save-status";
+import { useExtracted } from "next-intl";
+import { updateCourseAction } from "./actions";
+import { useAutoSave } from "./use-auto-save";
+
+export function CourseEditor({
+  courseId,
+  initialTitle,
+  initialDescription,
+}: {
+  courseId: number;
+  initialTitle: string;
+  initialDescription: string;
+}) {
+  const t = useExtracted();
+
+  const {
+    status: titleStatus,
+    value: title,
+    setValue: setTitle,
+  } = useAutoSave({
+    initialValue: initialTitle,
+    onSave: (value) => updateCourseAction(courseId, { title: value }),
+  });
+
+  const {
+    status: descriptionStatus,
+    value: description,
+    setValue: setDescription,
+  } = useAutoSave({
+    initialValue: initialDescription,
+    onSave: (value) => updateCourseAction(courseId, { description: value }),
+  });
+
+  const overallStatus = combineSaveStatuses(titleStatus, descriptionStatus);
+
+  return (
+    <ContainerHeader className="relative">
+      <ContainerHeaderGroup className="flex-1">
+        <EditableText
+          aria-label={t("Edit course title")}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder={t("Course title…")}
+          value={title}
+          variant="title"
+        />
+
+        <EditableTextarea
+          aria-label={t("Edit course description")}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder={t("Course description…")}
+          value={description}
+          variant="description"
+        />
+      </ContainerHeaderGroup>
+
+      <SaveStatus
+        className="absolute top-0 right-4"
+        labels={{
+          saved: t("Saved"),
+          saving: t("Saving…"),
+          unsaved: t("Unsaved"),
+        }}
+        status={overallStatus}
+      />
+    </ContainerHeader>
+  );
+}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
@@ -1,36 +1,44 @@
-import {
-  Container,
-  ContainerHeader,
-  ContainerHeaderGroup,
-  ContainerTitle,
-} from "@zoonk/ui/components/container";
+import { Container } from "@zoonk/ui/components/container";
+import { notFound } from "next/navigation";
 import { Suspense } from "react";
+import { getCourse } from "@/data/courses/get-course";
+import { CourseEditor } from "./course-editor";
+import { CourseEditorSkeleton } from "./course-editor-skeleton";
 
-async function CourseHeaderGroup({
+async function CourseContent({
   params,
 }: {
   params: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]">["params"];
 }) {
-  const { courseSlug } = await params;
+  const { courseSlug, lang, orgSlug } = await params;
+
+  const { data: course, error } = await getCourse({
+    courseSlug,
+    language: lang,
+    orgSlug,
+  });
+
+  if (error || !course) {
+    return notFound();
+  }
 
   return (
-    <ContainerHeaderGroup>
-      <ContainerTitle>{courseSlug}</ContainerTitle>
-    </ContainerHeaderGroup>
+    <CourseEditor
+      courseId={course.id}
+      initialDescription={course.description}
+      initialTitle={course.title}
+    />
   );
 }
 
-// this page is just a placeholder for now
-export default async function CoursePage({
-  params,
-}: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]">) {
+export default async function CoursePage(
+  props: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]">,
+) {
   return (
     <Container variant="narrow">
-      <ContainerHeader>
-        <Suspense>
-          <CourseHeaderGroup params={params} />
-        </Suspense>
-      </ContainerHeader>
+      <Suspense fallback={<CourseEditorSkeleton />}>
+        <CourseContent params={props.params} />
+      </Suspense>
     </Container>
   );
 }

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/use-auto-save.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/use-auto-save.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import type { SaveStatusType } from "@zoonk/ui/components/save-status";
+import { toast } from "@zoonk/ui/components/sonner";
+import { useDebounce } from "@zoonk/ui/hooks/debounce";
+import { useEffect, useRef, useState, useTransition } from "react";
+
+const AUTO_SAVE_DEBOUNCE_MS = 500;
+const SAVED_STATUS_DURATION_MS = 2000;
+
+export function useAutoSave({
+  initialValue,
+  onSave,
+  debounceMs = AUTO_SAVE_DEBOUNCE_MS,
+}: {
+  initialValue: string;
+  onSave: (value: string) => Promise<{ error: string | null }>;
+  debounceMs?: number;
+}): {
+  status: SaveStatusType;
+  value: string;
+  setValue: (value: string) => void;
+} {
+  const [value, setValue] = useState(initialValue);
+  const [status, setStatus] = useState<SaveStatusType>("idle");
+  const [isPending, startTransition] = useTransition();
+
+  const debouncedValue = useDebounce(value, debounceMs);
+  const lastSavedValue = useRef(initialValue);
+  const savedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (debouncedValue === lastSavedValue.current) {
+      return;
+    }
+
+    if (savedTimeoutRef.current) {
+      clearTimeout(savedTimeoutRef.current);
+      savedTimeoutRef.current = null;
+    }
+
+    startTransition(async () => {
+      setStatus("saving");
+      const result = await onSave(debouncedValue);
+
+      if (result.error) {
+        toast.error(result.error);
+        setStatus("unsaved");
+      } else {
+        lastSavedValue.current = debouncedValue;
+        setStatus("saved");
+
+        savedTimeoutRef.current = setTimeout(() => {
+          setStatus("idle");
+          savedTimeoutRef.current = null;
+        }, SAVED_STATUS_DURATION_MS);
+      }
+    });
+  }, [debouncedValue, onSave]);
+
+  useEffect(
+    () => () => {
+      if (savedTimeoutRef.current) {
+        clearTimeout(savedTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  function handleSetValue(newValue: string) {
+    setValue(newValue);
+    if (newValue !== lastSavedValue.current && status !== "unsaved") {
+      setStatus("unsaved");
+    }
+  }
+
+  return {
+    setValue: handleSetValue,
+    status: isPending ? "saving" : status,
+    value,
+  };
+}

--- a/i18n.lock
+++ b/i18n.lock
@@ -3,6 +3,13 @@ checksums:
   15ecf73e0c158929f058900aaa9b24c8:
     Delete%20course/singular: 86bac6527eb0b380a3f0a5e38b6938ff
     Delete%20course%3F/singular: c83369b40aec2a0eb3cafd146d70020e
+    Course%20title%E2%80%A6/singular: 4429de50f5f2d426271e76328c543daf
+    Unsaved/singular: ddc9094aecf93ceabe363846756a9925
+    Edit%20course%20description/singular: 2304f3ceeea1faaa3a4451c8863ded3b
+    Edit%20course%20title/singular: 75b050a3ce516d55c480d633f5da502f
+    Saved/singular: 6554b923011266821d74e06e013a40e6
+    Course%20description%E2%80%A6/singular: a548f00ce745044f2a2dfbe02b9a0130
+    Saving%E2%80%A6/singular: ee98ff32f9a585a9108c8cd961d6077e
     Your%20organization%20hasn't%20created%20any%20courses%20yet./singular: 4c09c8406dbf7bfe159f850fc1f22b99
     No%20courses/singular: 72fc2629e79529e927834070a26d2a07
     All%20fields%20are%20required/singular: 01fe4fe061a783c06c001dd39c78053a

--- a/packages/ui/src/components/editable-text.tsx
+++ b/packages/ui/src/components/editable-text.tsx
@@ -1,0 +1,89 @@
+import { cn } from "@zoonk/ui/lib/utils";
+import { cva, type VariantProps } from "class-variance-authority";
+
+const editableTextVariants = cva(
+  [
+    "w-full border-none bg-transparent px-0 outline-none",
+    "cursor-text placeholder:text-muted-foreground/50",
+    "focus-visible:ring-0",
+    "transition-colors duration-150",
+  ],
+  {
+    defaultVariants: {
+      variant: "default",
+    },
+    variants: {
+      variant: {
+        default: "text-foreground",
+        description:
+          "text-pretty text-muted-foreground leading-tight tracking-tight",
+        muted: "text-muted-foreground",
+        title:
+          "scroll-m-20 text-balance font-semibold text-foreground/90 text-lg leading-none tracking-tight",
+      },
+    },
+  },
+);
+
+export type EditableTextProps = Omit<React.ComponentProps<"input">, "type"> &
+  VariantProps<typeof editableTextVariants>;
+
+function EditableText({ className, variant, ...props }: EditableTextProps) {
+  return (
+    <input
+      className={cn(editableTextVariants({ variant }), className)}
+      data-slot="editable-text"
+      type="text"
+      {...props}
+    />
+  );
+}
+
+const editableTextareaVariants = cva(
+  [
+    "w-full border-none bg-transparent px-0 outline-none",
+    "field-sizing-content min-h-6 resize-none",
+    "cursor-text placeholder:text-muted-foreground/50",
+    "focus-visible:ring-0",
+    "transition-colors duration-150",
+  ],
+  {
+    defaultVariants: {
+      variant: "default",
+    },
+    variants: {
+      variant: {
+        default: "text-foreground",
+        description:
+          "text-pretty text-muted-foreground leading-tight tracking-tight",
+        muted: "text-muted-foreground",
+      },
+    },
+  },
+);
+
+export type EditableTextareaProps = React.ComponentProps<"textarea"> &
+  VariantProps<typeof editableTextareaVariants>;
+
+function EditableTextarea({
+  className,
+  variant,
+  rows = 1,
+  ...props
+}: EditableTextareaProps) {
+  return (
+    <textarea
+      className={cn(editableTextareaVariants({ variant }), className)}
+      data-slot="editable-textarea"
+      rows={rows}
+      {...props}
+    />
+  );
+}
+
+export {
+  EditableText,
+  editableTextVariants,
+  EditableTextarea,
+  editableTextareaVariants,
+};

--- a/packages/ui/src/components/save-status.tsx
+++ b/packages/ui/src/components/save-status.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@zoonk/ui/lib/utils";
 import type * as React from "react";
 
-export type SaveStatusType = "idle" | "unsaved" | "saving" | "saved";
+export type SaveStatusType = "idle" | "unsaved" | "saving" | "saved" | "fading";
 
 export type SaveStatusLabels = {
   unsaved: React.ReactNode;
@@ -24,8 +24,8 @@ function SaveStatus({ status, labels, className, ...props }: SaveStatusProps) {
       aria-live="polite"
       className={cn(
         "text-muted-foreground/60 text-xs",
-        "transition-opacity duration-2000",
-        status === "saved" && "opacity-0",
+        "transition-opacity duration-500",
+        status === "fading" && "opacity-0",
         className,
       )}
       data-slot="save-status"
@@ -34,7 +34,7 @@ function SaveStatus({ status, labels, className, ...props }: SaveStatusProps) {
     >
       {status === "unsaved" && labels.unsaved}
       {status === "saving" && labels.saving}
-      {status === "saved" && labels.saved}
+      {(status === "saved" || status === "fading") && labels.saved}
     </span>
   );
 }
@@ -50,6 +50,10 @@ function combineSaveStatuses(...statuses: SaveStatusType[]): SaveStatusType {
 
   if (statuses.some((s) => s === "saved")) {
     return "saved";
+  }
+
+  if (statuses.some((s) => s === "fading")) {
+    return "fading";
   }
 
   return "idle";

--- a/packages/ui/src/components/save-status.tsx
+++ b/packages/ui/src/components/save-status.tsx
@@ -1,0 +1,58 @@
+import { cn } from "@zoonk/ui/lib/utils";
+import type * as React from "react";
+
+export type SaveStatusType = "idle" | "unsaved" | "saving" | "saved";
+
+export type SaveStatusLabels = {
+  unsaved: React.ReactNode;
+  saving: React.ReactNode;
+  saved: React.ReactNode;
+};
+
+export type SaveStatusProps = React.ComponentProps<"span"> & {
+  status: SaveStatusType;
+  labels: SaveStatusLabels;
+};
+
+function SaveStatus({ status, labels, className, ...props }: SaveStatusProps) {
+  if (status === "idle") {
+    return null;
+  }
+
+  return (
+    <span
+      aria-live="polite"
+      className={cn(
+        "text-muted-foreground/60 text-xs",
+        "transition-opacity duration-2000",
+        status === "saved" && "opacity-0",
+        className,
+      )}
+      data-slot="save-status"
+      data-status={status}
+      {...props}
+    >
+      {status === "unsaved" && labels.unsaved}
+      {status === "saving" && labels.saving}
+      {status === "saved" && labels.saved}
+    </span>
+  );
+}
+
+function combineSaveStatuses(...statuses: SaveStatusType[]): SaveStatusType {
+  if (statuses.some((s) => s === "saving")) {
+    return "saving";
+  }
+
+  if (statuses.some((s) => s === "unsaved")) {
+    return "unsaved";
+  }
+
+  if (statuses.some((s) => s === "saved")) {
+    return "saved";
+  }
+
+  return "idle";
+}
+
+export { combineSaveStatuses, SaveStatus };


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable inline editing of a course’s title and description with debounced auto-save and a clear save status. Updates persist via a server action and trigger cache revalidation in the main app.

- **New Features**
  - Inline editing for title and description with accessible labels and placeholders.
  - Auto-save with 500ms debounce, showing Unsaved/Saving/Saved, and error toast on failures.
  - Server action to update courses and revalidate main app cache.
  - Page now fetches course data, handles not-found, and renders an editor with a Suspense skeleton.
  - Added reusable EditableText/EditableTextarea and SaveStatus components, plus en/es/pt translations.

<sup>Written for commit df050866ea967ed2ba33b1e43beb7920f164d73c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





