### PR TITLE
feat(editor): add command palette

### DIFF
--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -333,24 +333,9 @@ msgid "Searching..."
 msgstr "Searching..."
 
 #: src/components/navbar/command-palette.tsx
-msgctxt "oFJ8He"
-msgid "settings"
-msgstr "settings"
-
-#: src/components/navbar/command-palette.tsx
-msgctxt "PlQvK/"
-msgid "locale"
-msgstr "locale"
-
-#: src/components/navbar/command-palette.tsx
 msgctxt "qlTe+e"
 msgid "new"
 msgstr "new"
-
-#: src/components/navbar/command-palette.tsx
-msgctxt "Rbe+bp"
-msgid "language"
-msgstr "language"
 
 #: src/components/navbar/command-palette.tsx
 msgctxt "RSFKID"
@@ -377,17 +362,6 @@ msgstr "exit"
 msgctxt "xmcVZ0"
 msgid "Search"
 msgstr "Search"
-
-#: src/components/navbar/command-palette.tsx
-#: src/components/navbar/locale-switcher.tsx
-msgctxt "y1Z3or"
-msgid "Language"
-msgstr "Language"
-
-#: src/components/navbar/command-palette.tsx
-msgctxt "Zr33al"
-msgid "translate"
-msgstr "translate"
 
 #: src/components/navbar/command-palette.tsx
 msgctxt "zTylMM"
@@ -418,6 +392,11 @@ msgstr "Delete"
 msgctxt "W5ajIY"
 msgid "Delete item?"
 msgstr "Delete item?"
+
+#: src/components/navbar/locale-switcher.tsx
+msgctxt "y1Z3or"
+msgid "Language"
+msgstr "Language"
 
 #: src/components/navbar/org-switcher.tsx
 msgctxt "JD2pwH"

--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -179,6 +179,7 @@ msgstr "Create"
 
 #: src/app/[orgSlug]/new-course/page.tsx
 #: src/app/[orgSlug]/page.tsx
+#: src/components/navbar/command-palette.tsx
 msgctxt "dCKXDB"
 msgid "Create course"
 msgstr "Create course"
@@ -249,6 +250,7 @@ msgid "Select a course to edit its content"
 msgstr "Select a course to edit its content"
 
 #: src/app/[orgSlug]/page.tsx
+#: src/components/navbar/command-palette.tsx
 msgctxt "R85gsW"
 msgid "Courses"
 msgstr "Courses"
@@ -264,6 +266,7 @@ msgid "Login"
 msgstr "Login"
 
 #: src/app/unauthorized.tsx
+#: src/components/navbar/command-palette.tsx
 #: src/components/navbar/logout-menu-item.tsx
 msgctxt "C81/uG"
 msgid "Logout"
@@ -273,6 +276,123 @@ msgstr "Logout"
 msgctxt "gNtXZ8"
 msgid "401 - Unauthorized"
 msgstr "401 - Unauthorized"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "6BySgv"
+msgid "logout"
+msgstr "logout"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "7XTPKO"
+msgid "home"
+msgstr "home"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "C6QAK4"
+msgid "create"
+msgstr "create"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "CxfKLC"
+msgid "Pages"
+msgstr "Pages"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "Do1Pfd"
+msgid "Chapters"
+msgstr "Chapters"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "GH0hAP"
+msgid "add"
+msgstr "add"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "gxt0jA"
+msgid "Search courses, chapters, lessons, or pages..."
+msgstr "Search courses, chapters, lessons, or pages..."
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "hX5PAb"
+msgid "No results found"
+msgstr "No results found"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "i2cX1K"
+msgid "dashboard"
+msgstr "dashboard"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "iqLF8D"
+msgid "Lessons"
+msgstr "Lessons"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "NNQzoi"
+msgid "Searching..."
+msgstr "Searching..."
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "oFJ8He"
+msgid "settings"
+msgstr "settings"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "PlQvK/"
+msgid "locale"
+msgstr "locale"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "qlTe+e"
+msgid "new"
+msgstr "new"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "Rbe+bp"
+msgid "language"
+msgstr "language"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "RSFKID"
+msgid "course"
+msgstr "course"
+
+#: src/components/navbar/command-palette.tsx
+#: src/components/navbar/index.tsx
+msgctxt "U3l+Q9"
+msgid "Home page"
+msgstr "Home page"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "UExMYV"
+msgid "sign out"
+msgstr "sign out"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "wmNq1X"
+msgid "exit"
+msgstr "exit"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "xmcVZ0"
+msgid "Search"
+msgstr "Search"
+
+#: src/components/navbar/command-palette.tsx
+#: src/components/navbar/locale-switcher.tsx
+msgctxt "y1Z3or"
+msgid "Language"
+msgstr "Language"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "Zr33al"
+msgid "translate"
+msgstr "translate"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "zTylMM"
+msgid "start"
+msgstr "start"
 
 #: src/components/navbar/delete-item-button.tsx
 msgctxt "47FYwb"
@@ -298,16 +418,6 @@ msgstr "Delete"
 msgctxt "W5ajIY"
 msgid "Delete item?"
 msgstr "Delete item?"
-
-#: src/components/navbar/index.tsx
-msgctxt "U3l+Q9"
-msgid "Home page"
-msgstr "Home page"
-
-#: src/components/navbar/locale-switcher.tsx
-msgctxt "y1Z3or"
-msgid "Language"
-msgstr "Language"
 
 #: src/components/navbar/org-switcher.tsx
 msgctxt "JD2pwH"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -179,6 +179,7 @@ msgstr "Crear"
 
 #: src/app/[orgSlug]/new-course/page.tsx
 #: src/app/[orgSlug]/page.tsx
+#: src/components/navbar/command-palette.tsx
 msgctxt "dCKXDB"
 msgid "Create course"
 msgstr "Crear curso"
@@ -249,6 +250,7 @@ msgid "Select a course to edit its content"
 msgstr "Selecciona un curso para editar su contenido"
 
 #: src/app/[orgSlug]/page.tsx
+#: src/components/navbar/command-palette.tsx
 msgctxt "R85gsW"
 msgid "Courses"
 msgstr "Cursos"
@@ -264,6 +266,7 @@ msgid "Login"
 msgstr "Iniciar sesión"
 
 #: src/app/unauthorized.tsx
+#: src/components/navbar/command-palette.tsx
 #: src/components/navbar/logout-menu-item.tsx
 msgctxt "C81/uG"
 msgid "Logout"
@@ -273,6 +276,123 @@ msgstr "Cerrar sesión"
 msgctxt "gNtXZ8"
 msgid "401 - Unauthorized"
 msgstr "401 - No autorizado"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "6BySgv"
+msgid "logout"
+msgstr "cerrar sesión"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "7XTPKO"
+msgid "home"
+msgstr "inicio"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "C6QAK4"
+msgid "create"
+msgstr "crear"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "CxfKLC"
+msgid "Pages"
+msgstr "Páginas"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "Do1Pfd"
+msgid "Chapters"
+msgstr "Capítulos"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "GH0hAP"
+msgid "add"
+msgstr "agregar"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "gxt0jA"
+msgid "Search courses, chapters, lessons, or pages..."
+msgstr "Busca cursos, capítulos, lecciones o páginas..."
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "hX5PAb"
+msgid "No results found"
+msgstr "No se encontraron resultados"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "i2cX1K"
+msgid "dashboard"
+msgstr "panel"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "iqLF8D"
+msgid "Lessons"
+msgstr "Lecciones"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "NNQzoi"
+msgid "Searching..."
+msgstr "Buscando..."
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "oFJ8He"
+msgid "settings"
+msgstr "configuración"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "PlQvK/"
+msgid "locale"
+msgstr "idioma"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "qlTe+e"
+msgid "new"
+msgstr "nuevo"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "Rbe+bp"
+msgid "language"
+msgstr "idioma"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "RSFKID"
+msgid "course"
+msgstr "curso"
+
+#: src/components/navbar/command-palette.tsx
+#: src/components/navbar/index.tsx
+msgctxt "U3l+Q9"
+msgid "Home page"
+msgstr "Página de inicio"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "UExMYV"
+msgid "sign out"
+msgstr "cerrar sesión"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "wmNq1X"
+msgid "exit"
+msgstr "salir"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "xmcVZ0"
+msgid "Search"
+msgstr "Buscar"
+
+#: src/components/navbar/command-palette.tsx
+#: src/components/navbar/locale-switcher.tsx
+msgctxt "y1Z3or"
+msgid "Language"
+msgstr "Idioma"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "Zr33al"
+msgid "translate"
+msgstr "traducir"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "zTylMM"
+msgid "start"
+msgstr "comenzar"
 
 #: src/components/navbar/delete-item-button.tsx
 msgctxt "47FYwb"
@@ -298,16 +418,6 @@ msgstr "Eliminar"
 msgctxt "W5ajIY"
 msgid "Delete item?"
 msgstr "¿Eliminar elemento?"
-
-#: src/components/navbar/index.tsx
-msgctxt "U3l+Q9"
-msgid "Home page"
-msgstr "Página de inicio"
-
-#: src/components/navbar/locale-switcher.tsx
-msgctxt "y1Z3or"
-msgid "Language"
-msgstr "Idioma"
 
 #: src/components/navbar/org-switcher.tsx
 msgctxt "JD2pwH"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -333,24 +333,9 @@ msgid "Searching..."
 msgstr "Buscando..."
 
 #: src/components/navbar/command-palette.tsx
-msgctxt "oFJ8He"
-msgid "settings"
-msgstr "configuración"
-
-#: src/components/navbar/command-palette.tsx
-msgctxt "PlQvK/"
-msgid "locale"
-msgstr "idioma"
-
-#: src/components/navbar/command-palette.tsx
 msgctxt "qlTe+e"
 msgid "new"
 msgstr "nuevo"
-
-#: src/components/navbar/command-palette.tsx
-msgctxt "Rbe+bp"
-msgid "language"
-msgstr "idioma"
 
 #: src/components/navbar/command-palette.tsx
 msgctxt "RSFKID"
@@ -377,17 +362,6 @@ msgstr "salir"
 msgctxt "xmcVZ0"
 msgid "Search"
 msgstr "Buscar"
-
-#: src/components/navbar/command-palette.tsx
-#: src/components/navbar/locale-switcher.tsx
-msgctxt "y1Z3or"
-msgid "Language"
-msgstr "Idioma"
-
-#: src/components/navbar/command-palette.tsx
-msgctxt "Zr33al"
-msgid "translate"
-msgstr "traducir"
 
 #: src/components/navbar/command-palette.tsx
 msgctxt "zTylMM"
@@ -418,6 +392,11 @@ msgstr "Eliminar"
 msgctxt "W5ajIY"
 msgid "Delete item?"
 msgstr "¿Eliminar elemento?"
+
+#: src/components/navbar/locale-switcher.tsx
+msgctxt "y1Z3or"
+msgid "Language"
+msgstr "Idioma"
 
 #: src/components/navbar/org-switcher.tsx
 msgctxt "JD2pwH"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -179,6 +179,7 @@ msgstr "Criar"
 
 #: src/app/[orgSlug]/new-course/page.tsx
 #: src/app/[orgSlug]/page.tsx
+#: src/components/navbar/command-palette.tsx
 msgctxt "dCKXDB"
 msgid "Create course"
 msgstr "Criar curso"
@@ -249,6 +250,7 @@ msgid "Select a course to edit its content"
 msgstr "Selecione um curso para editar seu conteúdo"
 
 #: src/app/[orgSlug]/page.tsx
+#: src/components/navbar/command-palette.tsx
 msgctxt "R85gsW"
 msgid "Courses"
 msgstr "Cursos"
@@ -264,6 +266,7 @@ msgid "Login"
 msgstr "Entrar"
 
 #: src/app/unauthorized.tsx
+#: src/components/navbar/command-palette.tsx
 #: src/components/navbar/logout-menu-item.tsx
 msgctxt "C81/uG"
 msgid "Logout"
@@ -273,6 +276,123 @@ msgstr "Sair"
 msgctxt "gNtXZ8"
 msgid "401 - Unauthorized"
 msgstr "401 - Não autorizado"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "6BySgv"
+msgid "logout"
+msgstr "sair"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "7XTPKO"
+msgid "home"
+msgstr "início"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "C6QAK4"
+msgid "create"
+msgstr "criar"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "CxfKLC"
+msgid "Pages"
+msgstr "Páginas"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "Do1Pfd"
+msgid "Chapters"
+msgstr "Capítulos"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "GH0hAP"
+msgid "add"
+msgstr "adicionar"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "gxt0jA"
+msgid "Search courses, chapters, lessons, or pages..."
+msgstr "Buscar cursos, capítulos, aulas ou páginas..."
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "hX5PAb"
+msgid "No results found"
+msgstr "Nenhum resultado encontrado"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "i2cX1K"
+msgid "dashboard"
+msgstr "painel"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "iqLF8D"
+msgid "Lessons"
+msgstr "Aulas"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "NNQzoi"
+msgid "Searching..."
+msgstr "Buscando..."
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "oFJ8He"
+msgid "settings"
+msgstr "configurações"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "PlQvK/"
+msgid "locale"
+msgstr "idioma"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "qlTe+e"
+msgid "new"
+msgstr "novo"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "Rbe+bp"
+msgid "language"
+msgstr "idioma"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "RSFKID"
+msgid "course"
+msgstr "curso"
+
+#: src/components/navbar/command-palette.tsx
+#: src/components/navbar/index.tsx
+msgctxt "U3l+Q9"
+msgid "Home page"
+msgstr "Página inicial"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "UExMYV"
+msgid "sign out"
+msgstr "sair"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "wmNq1X"
+msgid "exit"
+msgstr "sair"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "xmcVZ0"
+msgid "Search"
+msgstr "Buscar"
+
+#: src/components/navbar/command-palette.tsx
+#: src/components/navbar/locale-switcher.tsx
+msgctxt "y1Z3or"
+msgid "Language"
+msgstr "Idioma"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "Zr33al"
+msgid "translate"
+msgstr "traduzir"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "zTylMM"
+msgid "start"
+msgstr "começar"
 
 #: src/components/navbar/delete-item-button.tsx
 msgctxt "47FYwb"
@@ -298,16 +418,6 @@ msgstr "Excluir"
 msgctxt "W5ajIY"
 msgid "Delete item?"
 msgstr "Excluir item?"
-
-#: src/components/navbar/index.tsx
-msgctxt "U3l+Q9"
-msgid "Home page"
-msgstr "Página inicial"
-
-#: src/components/navbar/locale-switcher.tsx
-msgctxt "y1Z3or"
-msgid "Language"
-msgstr "Idioma"
 
 #: src/components/navbar/org-switcher.tsx
 msgctxt "JD2pwH"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -333,24 +333,9 @@ msgid "Searching..."
 msgstr "Buscando..."
 
 #: src/components/navbar/command-palette.tsx
-msgctxt "oFJ8He"
-msgid "settings"
-msgstr "configurações"
-
-#: src/components/navbar/command-palette.tsx
-msgctxt "PlQvK/"
-msgid "locale"
-msgstr "idioma"
-
-#: src/components/navbar/command-palette.tsx
 msgctxt "qlTe+e"
 msgid "new"
 msgstr "novo"
-
-#: src/components/navbar/command-palette.tsx
-msgctxt "Rbe+bp"
-msgid "language"
-msgstr "idioma"
 
 #: src/components/navbar/command-palette.tsx
 msgctxt "RSFKID"
@@ -377,17 +362,6 @@ msgstr "sair"
 msgctxt "xmcVZ0"
 msgid "Search"
 msgstr "Buscar"
-
-#: src/components/navbar/command-palette.tsx
-#: src/components/navbar/locale-switcher.tsx
-msgctxt "y1Z3or"
-msgid "Language"
-msgstr "Idioma"
-
-#: src/components/navbar/command-palette.tsx
-msgctxt "Zr33al"
-msgid "translate"
-msgstr "traduzir"
 
 #: src/components/navbar/command-palette.tsx
 msgctxt "zTylMM"
@@ -418,6 +392,11 @@ msgstr "Excluir"
 msgctxt "W5ajIY"
 msgid "Delete item?"
 msgstr "Excluir item?"
+
+#: src/components/navbar/locale-switcher.tsx
+msgctxt "y1Z3or"
+msgid "Language"
+msgstr "Idioma"
 
 #: src/components/navbar/org-switcher.tsx
 msgctxt "JD2pwH"

--- a/apps/editor/src/components/navbar/command-palette.tsx
+++ b/apps/editor/src/components/navbar/command-palette.tsx
@@ -17,7 +17,6 @@ import {
   FileTextIcon,
   FolderIcon,
   HomeIcon,
-  LanguagesIcon,
   LogOutIcon,
   type LucideIcon,
   PlusIcon,

--- a/apps/editor/src/components/navbar/command-palette.tsx
+++ b/apps/editor/src/components/navbar/command-palette.tsx
@@ -49,6 +49,7 @@ export function CommandPalette() {
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+
   const [results, setResults] = useState<SearchResults>({
     chapters: [],
     courses: [],
@@ -57,7 +58,6 @@ export function CommandPalette() {
 
   const deferredQuery = useDeferredValue(query);
 
-  // Keyboard shortcut: Ctrl+K / Cmd+K
   useKeyboardCallback("k", () => setIsOpen((prev) => !prev), {
     mode: "any",
     modifiers: { ctrlKey: true, metaKey: true },
@@ -88,6 +88,9 @@ export function CommandPalette() {
     startTransition(() => {
       searchContent({ orgSlug, title: deferredQuery })
         .then(setResults)
+        .catch(() => {
+          setResults({ chapters: [], courses: [], lessons: [] });
+        })
         .finally(() => setIsLoading(false));
     });
   }, [deferredQuery, orgSlug]);

--- a/apps/editor/src/components/navbar/command-palette.tsx
+++ b/apps/editor/src/components/navbar/command-palette.tsx
@@ -10,6 +10,7 @@ import {
   CommandList,
 } from "@zoonk/ui/components/command";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { Spinner } from "@zoonk/ui/components/spinner";
 import { useKeyboardCallback } from "@zoonk/ui/hooks/keyboard";
 import {
   BookOpenIcon,
@@ -17,7 +18,6 @@ import {
   FolderIcon,
   HomeIcon,
   LanguagesIcon,
-  LoaderCircleIcon,
   LogOutIcon,
   type LucideIcon,
   PlusIcon,
@@ -92,7 +92,6 @@ export function CommandPalette() {
     });
   }, [deferredQuery, orgSlug]);
 
-  // Static menu items with literal translation keys
   const staticItems: StaticMenuItem[] = [
     {
       icon: HomeIcon,
@@ -158,10 +157,7 @@ export function CommandPalette() {
           <CommandEmpty>
             {isLoading ? (
               <div className="flex items-center justify-center gap-2">
-                <LoaderCircleIcon
-                  aria-hidden="true"
-                  className="size-4 animate-spin"
-                />
+                <Spinner />
                 <span>{t("Searching...")}</span>
               </div>
             ) : (
@@ -256,7 +252,7 @@ function CourseItem({
     >
       {course.imageUrl ? (
         <Image
-          alt=""
+          alt={course.title}
           className="size-8 shrink-0 rounded-md object-cover"
           height={32}
           src={course.imageUrl}
@@ -307,11 +303,13 @@ function PositionedItem({
       <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted font-medium text-sm">
         {position}
       </div>
+
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <Icon aria-hidden="true" className="size-3.5 shrink-0" />
           <p className="truncate font-medium">{title}</p>
         </div>
+
         {description && (
           <p className="truncate text-muted-foreground text-xs">
             {description}

--- a/apps/editor/src/components/navbar/command-palette.tsx
+++ b/apps/editor/src/components/navbar/command-palette.tsx
@@ -111,13 +111,6 @@ export function CommandPalette() {
       url: `/${orgSlug}/new-course`,
     },
     {
-      icon: LanguagesIcon,
-      id: "language",
-      keywords: [t("language"), t("translate"), t("locale"), t("settings")],
-      label: t("Language"),
-      url: "/language",
-    },
-    {
       icon: LogOutIcon,
       id: "logout",
       keywords: [t("logout"), t("sign out"), t("exit")],

--- a/apps/editor/src/components/navbar/command-palette.tsx
+++ b/apps/editor/src/components/navbar/command-palette.tsx
@@ -27,7 +27,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useExtracted } from "next-intl";
 import { startTransition, useDeferredValue, useEffect, useState } from "react";
 import {
-  type SearchResultCourse,
+  type ResultWithImage,
   type SearchResults,
   searchContent,
 } from "@/data/search-content";
@@ -236,7 +236,7 @@ function CourseItem({
   course,
   onSelect,
 }: {
-  course: SearchResultCourse;
+  course: ResultWithImage;
   onSelect: (url: string) => void;
 }) {
   return (

--- a/apps/editor/src/components/navbar/command-palette.tsx
+++ b/apps/editor/src/components/navbar/command-palette.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { Button } from "@zoonk/ui/components/button";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@zoonk/ui/components/command";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { useKeyboardCallback } from "@zoonk/ui/hooks/keyboard";
+import {
+  BookOpenIcon,
+  FileTextIcon,
+  FolderIcon,
+  HomeIcon,
+  LanguagesIcon,
+  LoaderCircleIcon,
+  LogOutIcon,
+  type LucideIcon,
+  PlusIcon,
+  SearchIcon,
+} from "lucide-react";
+import Image from "next/image";
+import { useParams, useRouter } from "next/navigation";
+import { useExtracted } from "next-intl";
+import { startTransition, useDeferredValue, useEffect, useState } from "react";
+import {
+  type SearchResultCourse,
+  type SearchResults,
+  searchContent,
+} from "@/data/search-content";
+
+type StaticMenuItem = {
+  icon: LucideIcon;
+  id: string;
+  keywords: string[];
+  label: string;
+  url: string;
+};
+
+export function CommandPalette() {
+  const t = useExtracted();
+  const router = useRouter();
+  const { orgSlug } = useParams<{ orgSlug: string }>();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [results, setResults] = useState<SearchResults>({
+    chapters: [],
+    courses: [],
+    lessons: [],
+  });
+
+  const deferredQuery = useDeferredValue(query);
+
+  // Keyboard shortcut: Ctrl+K / Cmd+K
+  useKeyboardCallback("k", () => setIsOpen((prev) => !prev), {
+    mode: "any",
+    modifiers: { ctrlKey: true, metaKey: true },
+  });
+
+  const open = () => setIsOpen(true);
+
+  const closePalette = () => {
+    setIsOpen(false);
+    setQuery("");
+    setResults({ chapters: [], courses: [], lessons: [] });
+  };
+
+  const onSelectItem = (url: string) => {
+    closePalette();
+    router.push(url as Parameters<typeof router.push>[0]);
+  };
+
+  // Fetch search results when query changes
+  useEffect(() => {
+    if (!(deferredQuery.trim() && orgSlug)) {
+      setResults({ chapters: [], courses: [], lessons: [] });
+      return;
+    }
+
+    setIsLoading(true);
+
+    startTransition(() => {
+      searchContent({ orgSlug, title: deferredQuery })
+        .then(setResults)
+        .finally(() => setIsLoading(false));
+    });
+  }, [deferredQuery, orgSlug]);
+
+  // Static menu items with literal translation keys
+  const staticItems: StaticMenuItem[] = [
+    {
+      icon: HomeIcon,
+      id: "home",
+      keywords: [t("home"), t("dashboard"), t("start")],
+      label: t("Home page"),
+      url: `/${orgSlug}`,
+    },
+    {
+      icon: PlusIcon,
+      id: "create-course",
+      keywords: [t("new"), t("add"), t("create"), t("course")],
+      label: t("Create course"),
+      url: `/${orgSlug}/new-course`,
+    },
+    {
+      icon: LanguagesIcon,
+      id: "language",
+      keywords: [t("language"), t("translate"), t("locale"), t("settings")],
+      label: t("Language"),
+      url: "/language",
+    },
+    {
+      icon: LogOutIcon,
+      id: "logout",
+      keywords: [t("logout"), t("sign out"), t("exit")],
+      label: t("Logout"),
+      url: "/logout",
+    },
+  ];
+
+  const hasCourses = results.courses.length > 0;
+  const hasChapters = results.chapters.length > 0;
+  const hasLessons = results.lessons.length > 0;
+  const hasDynamicResults = hasCourses || hasChapters || hasLessons;
+
+  return (
+    <>
+      <Button
+        aria-keyshortcuts="Meta+K Control+K"
+        onClick={open}
+        size="icon"
+        variant="outline"
+      >
+        <SearchIcon aria-hidden="true" />
+        <span className="sr-only">{t("Search")}</span>
+      </Button>
+
+      <CommandDialog
+        className="top-4 translate-y-0 lg:top-1/2 lg:translate-y-[-50%]"
+        description={t("Search courses, chapters, lessons, or pages...")}
+        onOpenChange={closePalette}
+        open={isOpen}
+        title={t("Search")}
+      >
+        <CommandInput
+          onValueChange={setQuery}
+          placeholder={t("Search courses, chapters, lessons, or pages...")}
+          value={query}
+        />
+
+        <CommandList>
+          <CommandEmpty>
+            {isLoading ? (
+              <div className="flex items-center justify-center gap-2">
+                <LoaderCircleIcon
+                  aria-hidden="true"
+                  className="size-4 animate-spin"
+                />
+                <span>{t("Searching...")}</span>
+              </div>
+            ) : (
+              <p>{t("No results found")}</p>
+            )}
+          </CommandEmpty>
+
+          {/* Static pages - always shown, filtered by cmdk */}
+          <CommandGroup heading={t("Pages")}>
+            {staticItems.map((item) => (
+              <CommandItem
+                key={item.id}
+                keywords={item.keywords}
+                onSelect={() => onSelectItem(item.url)}
+                value={`${item.label}-${item.id}`}
+              >
+                <item.icon aria-hidden="true" />
+                {item.label}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+
+          {/* Dynamic results - only shown when there are search results */}
+          {hasCourses && (
+            <CommandGroup heading={t("Courses")}>
+              {results.courses.map((course) => (
+                <CourseItem
+                  course={course}
+                  key={course.id}
+                  onSelect={onSelectItem}
+                />
+              ))}
+            </CommandGroup>
+          )}
+
+          {hasChapters && (
+            <CommandGroup heading={t("Chapters")}>
+              {results.chapters.map((chapter) => (
+                <PositionedItem
+                  description={chapter.description}
+                  icon={FolderIcon}
+                  id={chapter.id}
+                  key={chapter.id}
+                  onSelect={() => onSelectItem(chapter.url)}
+                  position={chapter.position}
+                  title={chapter.title}
+                />
+              ))}
+            </CommandGroup>
+          )}
+
+          {hasLessons && (
+            <CommandGroup heading={t("Lessons")}>
+              {results.lessons.map((lesson) => (
+                <PositionedItem
+                  description={lesson.description}
+                  icon={FileTextIcon}
+                  id={lesson.id}
+                  key={lesson.id}
+                  onSelect={() => onSelectItem(lesson.url)}
+                  position={lesson.position}
+                  title={lesson.title}
+                />
+              ))}
+            </CommandGroup>
+          )}
+
+          {/* Loading indicator for dynamic results */}
+          {isLoading && query.trim() && !hasDynamicResults && (
+            <div className="p-4">
+              <Skeleton className="h-8 w-full rounded-lg" />
+            </div>
+          )}
+        </CommandList>
+      </CommandDialog>
+    </>
+  );
+}
+
+function CourseItem({
+  course,
+  onSelect,
+}: {
+  course: SearchResultCourse;
+  onSelect: (url: string) => void;
+}) {
+  return (
+    <CommandItem
+      className="flex items-start gap-3"
+      onSelect={() => onSelect(course.url)}
+      value={`${course.title}-${course.id}`}
+    >
+      {course.imageUrl ? (
+        <Image
+          alt=""
+          className="size-8 shrink-0 rounded-md object-cover"
+          height={32}
+          src={course.imageUrl}
+          width={32}
+        />
+      ) : (
+        <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted">
+          <BookOpenIcon aria-hidden="true" className="size-4" />
+        </div>
+      )}
+      <div className="min-w-0 flex-1">
+        <p className="truncate font-medium">{course.title}</p>
+        {course.description && (
+          <p className="truncate text-muted-foreground text-xs">
+            {course.description}
+          </p>
+        )}
+      </div>
+    </CommandItem>
+  );
+}
+
+/**
+ * Generic item component for chapters and lessons.
+ * Shows a position number badge with an icon and title/description.
+ */
+function PositionedItem({
+  description,
+  icon: Icon,
+  id,
+  onSelect,
+  position,
+  title,
+}: {
+  description: string | null;
+  icon: LucideIcon;
+  id: number;
+  onSelect: () => void;
+  position: number;
+  title: string;
+}) {
+  return (
+    <CommandItem
+      className="flex items-start gap-3"
+      onSelect={onSelect}
+      value={`${title}-${id}`}
+    >
+      <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted font-medium text-sm">
+        {position}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <Icon aria-hidden="true" className="size-3.5 shrink-0" />
+          <p className="truncate font-medium">{title}</p>
+        </div>
+        {description && (
+          <p className="truncate text-muted-foreground text-xs">
+            {description}
+          </p>
+        )}
+      </div>
+    </CommandItem>
+  );
+}

--- a/apps/editor/src/components/navbar/index.tsx
+++ b/apps/editor/src/components/navbar/index.tsx
@@ -8,6 +8,7 @@ import { HomeIcon } from "lucide-react";
 import Link from "next/link";
 import { useParams, useSelectedLayoutSegments } from "next/navigation";
 import { useExtracted } from "next-intl";
+import { CommandPalette } from "./command-palette";
 
 export function NavbarSkeleton() {
   return (
@@ -46,6 +47,8 @@ export function EditorNavbar({ children }: React.PropsWithChildren) {
           <HomeIcon aria-hidden="true" />
           <span className="sr-only">{t("Home page")}</span>
         </Link>
+
+        <CommandPalette />
       </div>
 
       {children}

--- a/apps/editor/src/data/search-content.ts
+++ b/apps/editor/src/data/search-content.ts
@@ -1,0 +1,106 @@
+"use server";
+
+import { headers } from "next/headers";
+import { cache } from "react";
+import { searchOrgChapters } from "@/data/chapters/search-org-chapters";
+import { searchCourses } from "@/data/courses/search-courses";
+import { searchOrgLessons } from "@/data/lessons/search-org-lessons";
+
+export type SearchResultCourse = {
+  id: number;
+  type: "course";
+  title: string;
+  description: string | null;
+  url: string;
+  imageUrl: string | null;
+};
+
+export type SearchResultChapter = {
+  id: number;
+  type: "chapter";
+  title: string;
+  description: string | null;
+  url: string;
+  position: number;
+};
+
+export type SearchResultLesson = {
+  id: number;
+  type: "lesson";
+  title: string;
+  description: string | null;
+  url: string;
+  position: number;
+};
+
+export type SearchResult =
+  | SearchResultCourse
+  | SearchResultChapter
+  | SearchResultLesson;
+
+export type SearchResults = {
+  courses: SearchResultCourse[];
+  chapters: SearchResultChapter[];
+  lessons: SearchResultLesson[];
+};
+
+/**
+ * Search courses, chapters, and lessons in parallel.
+ * Returns grouped results for display in the command palette.
+ */
+export const searchContent = cache(
+  async (params: {
+    title: string;
+    orgSlug: string;
+  }): Promise<SearchResults> => {
+    const { title, orgSlug } = params;
+
+    // Don't search if no query
+    if (!title.trim()) {
+      return { chapters: [], courses: [], lessons: [] };
+    }
+
+    const requestHeaders = await headers();
+
+    // Run all searches in parallel for better performance
+    const [coursesResult, chaptersResult, lessonsResult] = await Promise.all([
+      searchCourses({ headers: requestHeaders, orgSlug, title }),
+      searchOrgChapters({ headers: requestHeaders, orgSlug, title }),
+      searchOrgLessons({ headers: requestHeaders, orgSlug, title }),
+    ]);
+
+    // Transform courses
+    const courses: SearchResultCourse[] = coursesResult.data.map((course) => ({
+      description: course.description,
+      id: course.id,
+      imageUrl: course.imageUrl,
+      title: course.title,
+      type: "course",
+      url: `/${orgSlug}/c/${course.language}/${course.slug}`,
+    }));
+
+    // Transform chapters with position
+    const chapters: SearchResultChapter[] = chaptersResult.data.map(
+      (chapter) => ({
+        description: chapter.description,
+        id: chapter.id,
+        position: chapter.position,
+        title: chapter.title,
+        type: "chapter",
+        url: `/${orgSlug}/c/${chapter.course.language}/${chapter.course.slug}/ch/${chapter.slug}`,
+      }),
+    );
+
+    // Transform lessons with position
+    const lessons: SearchResultLesson[] = lessonsResult.data.map((lesson) => ({
+      description: lesson.description,
+      id: lesson.id,
+      position: lesson.position,
+      title: lesson.title,
+      type: "lesson",
+      url: `/${orgSlug}/c/${lesson.chapter.course.language}/${lesson.chapter.course.slug}/ch/${lesson.chapter.slug}/l/${lesson.slug}`,
+    }));
+
+    return { chapters, courses, lessons };
+  },
+);

--- a/i18n.lock
+++ b/i18n.lock
@@ -4,32 +4,32 @@ checksums:
     Unsaved/singular: ddc9094aecf93ceabe363846756a9925
     Saved/singular: 6554b923011266821d74e06e013a40e6
     Saving%E2%80%A6/singular: ee98ff32f9a585a9108c8cd961d6077e
-    Delete%20course/singular: 86bac6527eb0b380a3f0a5e38b6938ff
-    Delete%20course%3F/singular: c83369b40aec2a0eb3cafd146d70020e
-    Delete%20chapter/singular: 17a0d21cc5650c1a8de6e918fd754a63
-    Delete%20chapter%3F/singular: 5dfc389e36ee2f05e01896b81bd59493
     Delete%20lesson%3F/singular: 7f0eb69c2ada091c8504e0197eae59ab
     Delete%20lesson/singular: 18309d2fe705fd2c4301224dee3be224
-    Course%20title%E2%80%A6/singular: 4429de50f5f2d426271e76328c543daf
-    Contact%20support/singular: 32a4dee2033635e334a5f4d34724e3e0
-    Edit%20course%20description/singular: 2304f3ceeea1faaa3a4451c8863ded3b
-    Try%20again/singular: 33dd8820e743e35a66e6977f69e9d3b5
-    Edit%20course%20title/singular: 75b050a3ce516d55c480d633f5da502f
-    Course%20description%E2%80%A6/singular: a548f00ce745044f2a2dfbe02b9a0130
-    We%20couldn't%20load%20the%20chapters.%20Please%20try%20again./singular: 2bfbac73debefc0d7a4ec5c41af9c415
-    Failed%20to%20load%20chapters/singular: a462d90fffa946fe5c2aedb6e6fff9b4
-    We%20couldn't%20load%20the%20lessons.%20Please%20try%20again./singular: f2e68b6dd4d7f2eb0c91f20ade06957d
-    Failed%20to%20load%20lessons/singular: 427523eb64ddb239d642ca975d6e1dbb
-    Edit%20chapter%20description/singular: e27c305ac8ad54675309e239bccdd648
-    Edit%20chapter%20title/singular: 21c04bd3ed6335df5195d1f2857131bf
-    Chapter%20description%E2%80%A6/singular: d394513f90a5c9ad1880d364e8fc5cb8
-    Chapter%20title%E2%80%A6/singular: 3ed70a2e64aefe189999ff5899e8a7a2
-    Your%20organization%20hasn't%20created%20any%20courses%20yet./singular: 4c09c8406dbf7bfe159f850fc1f22b99
-    No%20courses/singular: 72fc2629e79529e927834070a26d2a07
+    Delete%20chapter/singular: 17a0d21cc5650c1a8de6e918fd754a63
+    Delete%20chapter%3F/singular: 5dfc389e36ee2f05e01896b81bd59493
+    Delete%20course/singular: 86bac6527eb0b380a3f0a5e38b6938ff
+    Delete%20course%3F/singular: c83369b40aec2a0eb3cafd146d70020e
     Edit%20lesson%20description/singular: b959f1e2fc7f00f593ae2c1a12fd330d
     Lesson%20description%E2%80%A6/singular: 77ad5a9829eda8182865a46455d5a842
     Lesson%20title%E2%80%A6/singular: d7b981d2734c11f2ee5d58f21c93bd3e
     Edit%20lesson%20title/singular: 15b5a30f4a0365bae4da264383dae889
+    We%20couldn't%20load%20the%20lessons.%20Please%20try%20again./singular: f2e68b6dd4d7f2eb0c91f20ade06957d
+    Contact%20support/singular: 32a4dee2033635e334a5f4d34724e3e0
+    Failed%20to%20load%20lessons/singular: 427523eb64ddb239d642ca975d6e1dbb
+    Edit%20chapter%20description/singular: e27c305ac8ad54675309e239bccdd648
+    Try%20again/singular: 33dd8820e743e35a66e6977f69e9d3b5
+    Edit%20chapter%20title/singular: 21c04bd3ed6335df5195d1f2857131bf
+    Chapter%20description%E2%80%A6/singular: d394513f90a5c9ad1880d364e8fc5cb8
+    Chapter%20title%E2%80%A6/singular: 3ed70a2e64aefe189999ff5899e8a7a2
+    Course%20title%E2%80%A6/singular: 4429de50f5f2d426271e76328c543daf
+    Edit%20course%20description/singular: 2304f3ceeea1faaa3a4451c8863ded3b
+    Edit%20course%20title/singular: 75b050a3ce516d55c480d633f5da502f
+    Course%20description%E2%80%A6/singular: a548f00ce745044f2a2dfbe02b9a0130
+    We%20couldn't%20load%20the%20chapters.%20Please%20try%20again./singular: 2bfbac73debefc0d7a4ec5c41af9c415
+    Failed%20to%20load%20chapters/singular: a462d90fffa946fe5c2aedb6e6fff9b4
+    Your%20organization%20hasn't%20created%20any%20courses%20yet./singular: 4c09c8406dbf7bfe159f850fc1f22b99
+    No%20courses/singular: 72fc2629e79529e927834070a26d2a07
     All%20fields%20are%20required/singular: 01fe4fe061a783c06c001dd39c78053a
     Next/singular: 89ddbcf710eba274963494f312bdc8a9
     Back/singular: f541015a827e37cb3b1234e56bc2aa3c
@@ -54,13 +54,34 @@ checksums:
     Login/singular: f4f219abeb5a465ecb1c7efaf50246de
     Logout/singular: 07948fdf20705e04a7bf68ab197512bf
     401%20-%20Unauthorized/singular: 0612c3a47aaacaa9fd8aa3d5f0fbc0b8
+    logout/singular: 77ca3565971e69e420e8eec6f752be84
+    home/singular: c227d2c8e5d86a375988bd63ebeececc
+    create/singular: 1323e3c278824cce3b4975f937fed459
+    Pages/singular: 75088c94fb3c374efd452624d4b74be8
+    Chapters/singular: 8528514cebd8dbe0e3a3c84989243d3b
+    add/singular: ba087d9ce25cf6e71df29e8c75706fb8
+    Search%20courses%2C%20chapters%2C%20lessons%2C%20or%20pages.../singular: b89375cf6aa859f0ee3b021222a10705
+    No%20results%20found/singular: 5518f2865757dc73900aa03ef8be6934
+    dashboard/singular: 3e3998114a2eab7daa3c9a23dbeb16b9
+    Lessons/singular: 52fdbe5a3a6ee1cc1e166546516f9111
+    Searching.../singular: 56cf28d6712bf3f7f73af2a81974ac45
+    settings/singular: 2313357d3b991dbd48a264c559ea9b35
+    locale/singular: 1baedd0f3a7e1e835804c3ab7066d364
+    new/singular: 59c16092bc6a4b9de0debe084e4b5f49
+    language/singular: f0106a9b4354555a31e54c05c9b1e1f6
+    course/singular: a8f5f6a15055aa74f1b98d4821329d19
+    Home%20page/singular: aa72464a366b091aa6f2037ca869c09c
+    sign%20out/singular: a917e8428004b4108a66fa0ba9c0c15c
+    exit/singular: 8eff58f44e53377753566cba50541cf9
+    Search/singular: 49dd6c21604b5e8d4153ff1aff2177e1
+    Language/singular: 277fd1a41cc237a437cd1d5e4a80463b
+    translate/singular: a9ff69701924ae84bd571f09df986e00
+    start/singular: e19dc5c089daea13eeb2efffb890057d
     Cancel/singular: 2e2a849c2223911717de8caa2c71bade
     Delete%20item/singular: b9b5755b0ed185436b52860bde313b9f
     This%20action%20cannot%20be%20undone./singular: 3d8b13374ffd3cefc0f3f7ce077bd9c9
     Delete/singular: 8bcf303dd10a645b5baacb02b47d72c9
     Delete%20item%3F/singular: d847684112faebe6e59a16ba2ccaac05
-    Home%20page/singular: aa72464a366b091aa6f2037ca869c09c
-    Language/singular: 277fd1a41cc237a437cd1d5e4a80463b
     Organizations/singular: bd50dd0b17bd74a72b728a8385b5ee28
     No%20other%20organizations/singular: e9de48fc34aa9de5d30e3eb8eed79ed1
     Draft/singular: e8a92958ad300aacfe46c2bf6644927e
@@ -84,20 +105,16 @@ checksums:
     An%20unexpected%20error%20occurred/singular: fe07b9cdb1fc3f7397f6d89c102c60af
     Invalid%20category/singular: 5f9195d3e0d1d819cc9d812b712eaca1
     Chapter%20not%20found/singular: 72d4a8758136678acbae0ec942227f7e
-    Chapter%20not%20found%20in%20this%20course/singular: d81e3e6176f913514f413784a8e881e3
     Invalid%20chapter%20format.%20Each%20chapter%20must%20have%20a%20title%20and%20description/singular: 6c9dc938c75674b73b61177b55cce86d
     Lesson%20not%20found/singular: 41c0c0e96242a28b4d90a84b3bf80e94
     Invalid%20format.%20Please%20provide%20an%20array%20of%20non-empty%20strings/singular: c9dbc954cf099eedbb573d647356f52e
     Course%20not%20found/singular: 679d024095e9e605246a1928a7e1d87b
     Invalid%20file%20type.%20Please%20upload%20a%20JSON%20file/singular: 9164c5c1930e61a6037fab99386c02f6
     This%20category%20has%20already%20been%20added%20to%20the%20course/singular: 5b220e40c0bfc7b3700d1f402697c522
-    Lesson%20not%20found%20in%20this%20chapter/singular: 2697f3d918027ce266c25004b71a51d9
     Please%20sign%20in%20to%20continue/singular: 051e59dd3d3b0bfad95982f982fd6b9d
     Chapter%20and%20course%20must%20belong%20to%20the%20same%20organization/singular: f3c132074516ccc5cad52c88c86d440d
     Invalid%20lesson%20format.%20Each%20lesson%20must%20have%20a%20title%20and%20description/singular: e449a82367ccec6680313c4711549e2e
     You%20don't%20have%20permission%20to%20perform%20this%20action/singular: b99aa4dbc03b5e9b7bf6c64b245a9ab8
-    This%20lesson%20has%20already%20been%20removed/singular: f2630463c13ad524f0cd9378a9c39b06
-    This%20chapter%20has%20already%20been%20removed/singular: b5afad30e3174c18d5aa887a3143397f
     File%20is%20too%20large.%20Maximum%20size%20is%205MB/singular: 6ee737426f04528c60f84ba1004542b3
     Invalid%20JSON%20format.%20Please%20check%20your%20file/singular: 2a890d833f49aa36f02433476ca33468
     Organization%20not%20found/singular: 4cb8c07ec2c599b6f48750e06ffa182b


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a command palette to the editor for fast navigation and search. Opens with Cmd/Ctrl+K and includes a search button in the navbar.

- **New Features**
  - Global search across courses, chapters, and lessons with grouped results, icons, and positions.
  - Quick actions: Home, Create course, Logout.
  - Keyboard shortcut: Cmd/Ctrl+K, with loading and empty states.
  - New server action (search-content) runs course/chapter/lesson searches in parallel and builds target URLs.
  - Uses deferred input and startTransition for responsive UX.
  - Added i18n strings for en, es, and pt.

<sup>Written for commit 7e5cb0fd76c05741200164652def96a5df7defe3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



