### PR TITLE
feat(editor): add back navigation

### DIFF
--- a/apps/editor/src/app/[orgSlug]/_components/back-link.tsx
+++ b/apps/editor/src/app/[orgSlug]/_components/back-link.tsx
@@ -1,0 +1,30 @@
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { ChevronLeft } from "lucide-react";
+import type { Route } from "next";
+import Link from "next/link";
+
+export function BackLink<T extends string>({
+  href,
+  children,
+}: {
+  href: Route<T>;
+  children: React.ReactNode;
+}) {
+  return (
+    <Link
+      className="-mt-4 inline-flex items-center gap-1 px-4 text-muted-foreground text-sm transition-colors hover:text-foreground"
+      href={href}
+    >
+      <ChevronLeft aria-hidden="true" className="size-4" />
+      {children}
+    </Link>
+  );
+}
+
+export function BackLinkSkeleton() {
+  return (
+    <div className="px-4">
+      <Skeleton className="h-5 w-32" />
+    </div>
+  );
+}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -4,11 +4,16 @@ import { SUPPORT_URL } from "@zoonk/utils/constants";
 import { notFound } from "next/navigation";
 import { getExtracted } from "next-intl/server";
 import { Suspense } from "react";
+import {
+  BackLink,
+  BackLinkSkeleton,
+} from "@/app/[orgSlug]/_components/back-link";
 import { ContentEditor } from "@/app/[orgSlug]/_components/content-editor";
 import { ContentEditorSkeleton } from "@/app/[orgSlug]/_components/content-editor-skeleton";
 import { ItemList } from "@/app/[orgSlug]/_components/item-list";
 import { ItemListSkeleton } from "@/app/[orgSlug]/_components/item-list-skeleton";
 import { getChapter } from "@/data/chapters/get-chapter";
+import { getCourse } from "@/data/courses/get-course";
 import { listChapterLessons } from "@/data/lessons/list-chapter-lessons";
 import {
   updateChapterDescriptionAction,
@@ -17,6 +22,29 @@ import {
 
 type ChapterPageProps =
   PageProps<"/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]">;
+
+async function ChapterBackLink({
+  params,
+}: {
+  params: ChapterPageProps["params"];
+}) {
+  const { courseSlug, lang, orgSlug } = await params;
+  const { data: course } = await getCourse({
+    courseSlug,
+    language: lang,
+    orgSlug,
+  });
+
+  if (!course) {
+    return null;
+  }
+
+  return (
+    <BackLink href={`/${orgSlug}/c/${lang}/${courseSlug}`}>
+      {course.title}
+    </BackLink>
+  );
+}
 
 async function ChapterContent({
   params,
@@ -87,16 +115,21 @@ async function LessonList({ params }: { params: ChapterPageProps["params"] }) {
 }
 
 export default async function ChapterPage(props: ChapterPageProps) {
-  const { chapterSlug, lang, orgSlug } = await props.params;
+  const { chapterSlug, courseSlug, lang, orgSlug } = await props.params;
 
   // Preload data in parallel (cached, so child components get the same promise)
   void Promise.all([
+    getCourse({ courseSlug, language: lang, orgSlug }),
     getChapter({ chapterSlug, language: lang, orgSlug }),
     listChapterLessons({ chapterSlug, orgSlug }),
   ]);
 
   return (
     <Container variant="narrow">
+      <Suspense fallback={<BackLinkSkeleton />}>
+        <ChapterBackLink params={props.params} />
+      </Suspense>
+
       <Suspense fallback={<ContentEditorSkeleton />}>
         <ChapterContent params={props.params} />
       </Suspense>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Back link to lesson and chapter editor pages so users can return to the parent chapter or course. Includes a skeleton fallback and parallel data preloading to show the parent title quickly.

- New Features
  - New BackLink and BackLinkSkeleton components with a chevron icon.
  - Lesson page: Back to chapter (shows chapter title), uses Suspense + skeleton, preloads chapter and lesson in parallel.
  - Chapter page: Back to course (shows course title), uses Suspense + skeleton, preloads course, chapter, and lessons in parallel.

<sup>Written for commit 12d9cbaa9a36cd666ae6abaeff71eb4ee4e6e45e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

