### PR TITLE
feat(editor): add slug checks for chapters and lessons

### DIFF
--- a/apps/editor/src/app/[orgSlug]/new-course/use-course-form.ts
+++ b/apps/editor/src/app/[orgSlug]/new-course/use-course-form.ts
@@ -2,7 +2,8 @@
 
 import { useExtracted, useLocale } from "next-intl";
 import { useState } from "react";
-import { useSlugCheck } from "./use-slug-check";
+import { useSlugCheck } from "@/hooks/use-slug-check";
+import { checkSlugExists } from "./actions";
 
 export type CourseFormData = {
   title: string;
@@ -26,6 +27,7 @@ export function useCourseForm({ orgSlug }: { orgSlug: string }) {
   });
 
   const slugExists = useSlugCheck({
+    checkFn: checkSlugExists,
     language: formData.language,
     orgSlug,
     slug: formData.slug,

--- a/apps/editor/src/data/chapters/chapter-slug.test.ts
+++ b/apps/editor/src/data/chapters/chapter-slug.test.ts
@@ -1,0 +1,75 @@
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, describe, expect, test } from "vitest";
+import { chapterSlugExists } from "./chapter-slug";
+
+describe("chapterSlugExists()", () => {
+  let organization: Awaited<ReturnType<typeof organizationFixture>>;
+  let course: Awaited<ReturnType<typeof courseFixture>>;
+
+  beforeAll(async () => {
+    organization = await organizationFixture();
+    course = await courseFixture({ organizationId: organization.id });
+  });
+
+  test("returns true when slug exists for same language and org", async () => {
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const exists = await chapterSlugExists({
+      language: chapter.language,
+      orgSlug: organization.slug,
+      slug: chapter.slug,
+    });
+
+    expect(exists).toBe(true);
+  });
+
+  test("returns false when slug does not exist", async () => {
+    const exists = await chapterSlugExists({
+      language: "en",
+      orgSlug: organization.slug,
+      slug: "non-existent-slug",
+    });
+
+    expect(exists).toBe(false);
+  });
+
+  test("returns false when slug exists but language differs", async () => {
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: "en",
+      organizationId: organization.id,
+    });
+
+    const exists = await chapterSlugExists({
+      language: "pt",
+      orgSlug: organization.slug,
+      slug: chapter.slug,
+    });
+
+    expect(exists).toBe(false);
+  });
+
+  test("returns false when slug exists but organization differs", async () => {
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+    const chapter = await chapterFixture({
+      courseId: otherCourse.id,
+      language: otherCourse.language,
+      organizationId: otherOrg.id,
+    });
+
+    const exists = await chapterSlugExists({
+      language: chapter.language,
+      orgSlug: organization.slug,
+      slug: chapter.slug,
+    });
+
+    expect(exists).toBe(false);
+  });
+});

--- a/apps/editor/src/data/chapters/chapter-slug.ts
+++ b/apps/editor/src/data/chapters/chapter-slug.ts
@@ -1,0 +1,26 @@
+import "server-only";
+
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { cache } from "react";
+
+export const chapterSlugExists = cache(
+  async (params: {
+    language: string;
+    orgSlug: string;
+    slug: string;
+  }): Promise<boolean> => {
+    const { data } = await safeAsync(() =>
+      prisma.chapter.findFirst({
+        select: { id: true },
+        where: {
+          language: params.language,
+          organization: { slug: params.orgSlug },
+          slug: params.slug,
+        },
+      }),
+    );
+
+    return data !== null;
+  },
+);

--- a/apps/editor/src/data/lessons/lesson-slug.test.ts
+++ b/apps/editor/src/data/lessons/lesson-slug.test.ts
@@ -1,0 +1,86 @@
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, describe, expect, test } from "vitest";
+import { lessonSlugExists } from "./lesson-slug";
+
+describe("lessonSlugExists()", () => {
+  let organization: Awaited<ReturnType<typeof organizationFixture>>;
+  let chapter: Awaited<ReturnType<typeof chapterFixture>>;
+
+  beforeAll(async () => {
+    organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+    chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+  });
+
+  test("returns true when slug exists for same language and org", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: chapter.language,
+      organizationId: organization.id,
+    });
+
+    const exists = await lessonSlugExists({
+      language: lesson.language,
+      orgSlug: organization.slug,
+      slug: lesson.slug,
+    });
+
+    expect(exists).toBe(true);
+  });
+
+  test("returns false when slug does not exist", async () => {
+    const exists = await lessonSlugExists({
+      language: "en",
+      orgSlug: organization.slug,
+      slug: "non-existent-slug",
+    });
+
+    expect(exists).toBe(false);
+  });
+
+  test("returns false when slug exists but language differs", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: "en",
+      organizationId: organization.id,
+    });
+
+    const exists = await lessonSlugExists({
+      language: "pt",
+      orgSlug: organization.slug,
+      slug: lesson.slug,
+    });
+
+    expect(exists).toBe(false);
+  });
+
+  test("returns false when slug exists but organization differs", async () => {
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+    const otherChapter = await chapterFixture({
+      courseId: otherCourse.id,
+      language: otherCourse.language,
+      organizationId: otherOrg.id,
+    });
+    const lesson = await lessonFixture({
+      chapterId: otherChapter.id,
+      language: otherChapter.language,
+      organizationId: otherOrg.id,
+    });
+
+    const exists = await lessonSlugExists({
+      language: lesson.language,
+      orgSlug: organization.slug,
+      slug: lesson.slug,
+    });
+
+    expect(exists).toBe(false);
+  });
+});

--- a/apps/editor/src/data/lessons/lesson-slug.ts
+++ b/apps/editor/src/data/lessons/lesson-slug.ts
@@ -1,0 +1,26 @@
+import "server-only";
+
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { cache } from "react";
+
+export const lessonSlugExists = cache(
+  async (params: {
+    language: string;
+    orgSlug: string;
+    slug: string;
+  }): Promise<boolean> => {
+    const { data } = await safeAsync(() =>
+      prisma.lesson.findFirst({
+        select: { id: true },
+        where: {
+          language: params.language,
+          organization: { slug: params.orgSlug },
+          slug: params.slug,
+        },
+      }),
+    );
+
+    return data !== null;
+  },
+);

--- a/apps/editor/src/hooks/use-slug-check.ts
+++ b/apps/editor/src/hooks/use-slug-check.ts
@@ -1,19 +1,26 @@
+"use client";
+
 import { useDebounce } from "@zoonk/ui/hooks/debounce";
 import { useEffect, useEffectEvent, useState, useTransition } from "react";
-import { checkSlugExists } from "./actions";
 
-/**
- * Hook to check if a slug already exists with debouncing.
- */
-export function useSlugCheck({
-  language,
-  orgSlug,
-  slug,
-}: {
+type SlugCheckParams = {
   language: string;
   orgSlug: string;
   slug: string;
-}) {
+};
+
+type SlugCheckFn = (params: SlugCheckParams) => Promise<boolean>;
+
+/**
+ * Hook to check if a slug already exists with debouncing.
+ * Works with any entity type (course, chapter, lesson) by accepting a check function.
+ */
+export function useSlugCheck({
+  checkFn,
+  language,
+  orgSlug,
+  slug,
+}: SlugCheckParams & { checkFn: SlugCheckFn }) {
   const [_isPending, startTransition] = useTransition();
   const [slugExists, setSlugExists] = useState(false);
 
@@ -35,7 +42,7 @@ export function useSlugCheck({
     }
 
     startTransition(async () => {
-      const exists = await checkSlugExists({
+      const exists = await checkFn({
         language,
         orgSlug,
         slug: debouncedSlug,
@@ -43,7 +50,7 @@ export function useSlugCheck({
 
       handleSlugCheck(debouncedSlug, exists);
     });
-  }, [debouncedSlug, language, orgSlug]);
+  }, [checkFn, debouncedSlug, language, orgSlug]);
 
   return slugExists;
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add slug existence checks for chapters and lessons, and make the slug-check hook generic to prevent duplicate slugs per org and language. Also update the course form to use the new hook signature.

- New Features
  - chapterSlugExists and lessonSlugExists server checks (scoped by org and language, cached).
  - Tests cover true/false cases across org and language.

- Refactors
  - useSlugCheck now accepts a checkFn and was moved to hooks.
  - Course form imports the hook from hooks and passes checkSlugExists.

<sup>Written for commit e5768ac82baa30196a5cf5390ca6a05e7636b35f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

