### PR TITLE
feat(editor): add slug editor

### DIFF
--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -20,6 +20,37 @@ msgctxt "WUV28A"
 msgid "Saving…"
 msgstr "Saving…"
 
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+#: src/components/navbar/delete-item-button.tsx
+msgctxt "47FYwb"
+msgid "Cancel"
+msgstr "Cancel"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "fZThA8"
+msgid "Slug already exists"
+msgstr "Slug already exists"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "J9+DwE"
+msgid "slug…"
+msgstr "slug…"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "QGLi0O"
+msgid "URL address"
+msgstr "URL address"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "Rr6+VH"
+msgid "This slug is already in use"
+msgstr "This slug is already in use"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "Tk3zpi"
+msgid "Save slug"
+msgstr "Save slug"
+
 #: src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgctxt "52DE8l"
 msgid "Delete lesson?"
@@ -59,6 +90,11 @@ msgstr "Edit lesson description"
 msgctxt "AmPWks"
 msgid "Lesson description…"
 msgstr "Lesson description…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+msgctxt "jE/NFn"
+msgid "Edit lesson slug"
+msgstr "Edit lesson slug"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgctxt "jrinBZ"
@@ -108,6 +144,11 @@ msgid "Chapter description…"
 msgstr "Chapter description…"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
+msgctxt "lU8tx5"
+msgid "Edit chapter slug"
+msgstr "Edit chapter slug"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
 msgctxt "yNvug5"
 msgid "Chapter title…"
 msgstr "Chapter title…"
@@ -136,6 +177,11 @@ msgstr "Course description…"
 msgctxt "sHQNSR"
 msgid "We couldn't load the chapters. Please try again."
 msgstr "We couldn't load the chapters. Please try again."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
+msgctxt "v2PuXy"
+msgid "Edit course slug"
+msgstr "Edit course slug"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
 msgctxt "xA68iL"
@@ -367,11 +413,6 @@ msgstr "Search"
 msgctxt "zTylMM"
 msgid "start"
 msgstr "start"
-
-#: src/components/navbar/delete-item-button.tsx
-msgctxt "47FYwb"
-msgid "Cancel"
-msgstr "Cancel"
 
 #: src/components/navbar/delete-item-button.tsx
 msgctxt "hHa3Ql"

--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -92,11 +92,6 @@ msgid "Lesson description…"
 msgstr "Lesson description…"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgctxt "jE/NFn"
-msgid "Edit lesson slug"
-msgstr "Edit lesson slug"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgctxt "jrinBZ"
 msgid "Lesson title…"
 msgstr "Lesson title…"
@@ -144,11 +139,6 @@ msgid "Chapter description…"
 msgstr "Chapter description…"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
-msgctxt "lU8tx5"
-msgid "Edit chapter slug"
-msgstr "Edit chapter slug"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
 msgctxt "yNvug5"
 msgid "Chapter title…"
 msgstr "Chapter title…"
@@ -177,11 +167,6 @@ msgstr "Course description…"
 msgctxt "sHQNSR"
 msgid "We couldn't load the chapters. Please try again."
 msgstr "We couldn't load the chapters. Please try again."
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
-msgctxt "v2PuXy"
-msgid "Edit course slug"
-msgstr "Edit course slug"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
 msgctxt "xA68iL"

--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -27,29 +27,24 @@ msgid "Cancel"
 msgstr "Cancel"
 
 #: src/app/[orgSlug]/_components/slug-editor.tsx
-msgctxt "fZThA8"
-msgid "Slug already exists"
-msgstr "Slug already exists"
+msgctxt "8mWdw8"
+msgid "your-custom-url"
+msgstr "your-custom-url"
 
 #: src/app/[orgSlug]/_components/slug-editor.tsx
-msgctxt "J9+DwE"
-msgid "slug…"
-msgstr "slug…"
+msgctxt "jvo0vs"
+msgid "Save"
+msgstr "Save"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "NJUZ2D"
+msgid "This URL is already in use"
+msgstr "This URL is already in use"
 
 #: src/app/[orgSlug]/_components/slug-editor.tsx
 msgctxt "QGLi0O"
 msgid "URL address"
 msgstr "URL address"
-
-#: src/app/[orgSlug]/_components/slug-editor.tsx
-msgctxt "Rr6+VH"
-msgid "This slug is already in use"
-msgstr "This slug is already in use"
-
-#: src/app/[orgSlug]/_components/slug-editor.tsx
-msgctxt "Tk3zpi"
-msgid "Save slug"
-msgstr "Save slug"
 
 #: src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgctxt "52DE8l"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -92,11 +92,6 @@ msgid "Lesson description…"
 msgstr "Descripción de la lección…"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgctxt "jE/NFn"
-msgid "Edit lesson slug"
-msgstr "Editar slug de la lección"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgctxt "jrinBZ"
 msgid "Lesson title…"
 msgstr "Título de la lección…"
@@ -144,11 +139,6 @@ msgid "Chapter description…"
 msgstr "Descripción del capítulo…"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
-msgctxt "lU8tx5"
-msgid "Edit chapter slug"
-msgstr "Editar slug del capítulo"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
 msgctxt "yNvug5"
 msgid "Chapter title…"
 msgstr "Título del capítulo…"
@@ -177,11 +167,6 @@ msgstr "Descripción del curso…"
 msgctxt "sHQNSR"
 msgid "We couldn't load the chapters. Please try again."
 msgstr "No pudimos cargar los capítulos. Por favor, intenta de nuevo."
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
-msgctxt "v2PuXy"
-msgid "Edit course slug"
-msgstr "Editar slug del curso"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
 msgctxt "xA68iL"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -27,29 +27,24 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: src/app/[orgSlug]/_components/slug-editor.tsx
-msgctxt "fZThA8"
-msgid "Slug already exists"
-msgstr "El slug ya existe"
+msgctxt "8mWdw8"
+msgid "your-custom-url"
+msgstr "tu-url-personalizada"
 
 #: src/app/[orgSlug]/_components/slug-editor.tsx
-msgctxt "J9+DwE"
-msgid "slug…"
-msgstr "slug…"
+msgctxt "jvo0vs"
+msgid "Save"
+msgstr "Guardar"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "NJUZ2D"
+msgid "This URL is already in use"
+msgstr "Esta URL ya está en uso"
 
 #: src/app/[orgSlug]/_components/slug-editor.tsx
 msgctxt "QGLi0O"
 msgid "URL address"
 msgstr "Dirección URL"
-
-#: src/app/[orgSlug]/_components/slug-editor.tsx
-msgctxt "Rr6+VH"
-msgid "This slug is already in use"
-msgstr "Este slug ya está en uso"
-
-#: src/app/[orgSlug]/_components/slug-editor.tsx
-msgctxt "Tk3zpi"
-msgid "Save slug"
-msgstr "Guardar slug"
 
 #: src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgctxt "52DE8l"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -20,6 +20,37 @@ msgctxt "WUV28A"
 msgid "Saving…"
 msgstr "Guardando…"
 
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+#: src/components/navbar/delete-item-button.tsx
+msgctxt "47FYwb"
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "fZThA8"
+msgid "Slug already exists"
+msgstr "El slug ya existe"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "J9+DwE"
+msgid "slug…"
+msgstr "slug…"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "QGLi0O"
+msgid "URL address"
+msgstr "Dirección URL"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "Rr6+VH"
+msgid "This slug is already in use"
+msgstr "Este slug ya está en uso"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "Tk3zpi"
+msgid "Save slug"
+msgstr "Guardar slug"
+
 #: src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgctxt "52DE8l"
 msgid "Delete lesson?"
@@ -59,6 +90,11 @@ msgstr "Editar descripción de la lección"
 msgctxt "AmPWks"
 msgid "Lesson description…"
 msgstr "Descripción de la lección…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+msgctxt "jE/NFn"
+msgid "Edit lesson slug"
+msgstr "Editar slug de la lección"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgctxt "jrinBZ"
@@ -108,6 +144,11 @@ msgid "Chapter description…"
 msgstr "Descripción del capítulo…"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
+msgctxt "lU8tx5"
+msgid "Edit chapter slug"
+msgstr "Editar slug del capítulo"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
 msgctxt "yNvug5"
 msgid "Chapter title…"
 msgstr "Título del capítulo…"
@@ -136,6 +177,11 @@ msgstr "Descripción del curso…"
 msgctxt "sHQNSR"
 msgid "We couldn't load the chapters. Please try again."
 msgstr "No pudimos cargar los capítulos. Por favor, intenta de nuevo."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
+msgctxt "v2PuXy"
+msgid "Edit course slug"
+msgstr "Editar slug del curso"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
 msgctxt "xA68iL"
@@ -367,11 +413,6 @@ msgstr "Buscar"
 msgctxt "zTylMM"
 msgid "start"
 msgstr "comenzar"
-
-#: src/components/navbar/delete-item-button.tsx
-msgctxt "47FYwb"
-msgid "Cancel"
-msgstr "Cancelar"
 
 #: src/components/navbar/delete-item-button.tsx
 msgctxt "hHa3Ql"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -20,6 +20,37 @@ msgctxt "WUV28A"
 msgid "Saving…"
 msgstr "Salvando…"
 
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+#: src/components/navbar/delete-item-button.tsx
+msgctxt "47FYwb"
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "fZThA8"
+msgid "Slug already exists"
+msgstr "Slug já existe"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "J9+DwE"
+msgid "slug…"
+msgstr "slug…"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "QGLi0O"
+msgid "URL address"
+msgstr "Endereço URL"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "Rr6+VH"
+msgid "This slug is already in use"
+msgstr "Este slug já está em uso"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "Tk3zpi"
+msgid "Save slug"
+msgstr "Salvar slug"
+
 #: src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgctxt "52DE8l"
 msgid "Delete lesson?"
@@ -59,6 +90,11 @@ msgstr "Editar descrição da aula"
 msgctxt "AmPWks"
 msgid "Lesson description…"
 msgstr "Descrição da aula…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+msgctxt "jE/NFn"
+msgid "Edit lesson slug"
+msgstr "Editar slug da aula"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgctxt "jrinBZ"
@@ -108,6 +144,11 @@ msgid "Chapter description…"
 msgstr "Descrição do capítulo…"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
+msgctxt "lU8tx5"
+msgid "Edit chapter slug"
+msgstr "Editar slug do capítulo"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
 msgctxt "yNvug5"
 msgid "Chapter title…"
 msgstr "Título do capítulo…"
@@ -136,6 +177,11 @@ msgstr "Descrição do curso…"
 msgctxt "sHQNSR"
 msgid "We couldn't load the chapters. Please try again."
 msgstr "Não conseguimos carregar os capítulos. Por favor, tente novamente."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
+msgctxt "v2PuXy"
+msgid "Edit course slug"
+msgstr "Editar slug do curso"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
 msgctxt "xA68iL"
@@ -367,11 +413,6 @@ msgstr "Buscar"
 msgctxt "zTylMM"
 msgid "start"
 msgstr "começar"
-
-#: src/components/navbar/delete-item-button.tsx
-msgctxt "47FYwb"
-msgid "Cancel"
-msgstr "Cancelar"
 
 #: src/components/navbar/delete-item-button.tsx
 msgctxt "hHa3Ql"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -92,11 +92,6 @@ msgid "Lesson description…"
 msgstr "Descrição da aula…"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgctxt "jE/NFn"
-msgid "Edit lesson slug"
-msgstr "Editar slug da aula"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgctxt "jrinBZ"
 msgid "Lesson title…"
 msgstr "Título da aula…"
@@ -144,11 +139,6 @@ msgid "Chapter description…"
 msgstr "Descrição do capítulo…"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
-msgctxt "lU8tx5"
-msgid "Edit chapter slug"
-msgstr "Editar slug do capítulo"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
 msgctxt "yNvug5"
 msgid "Chapter title…"
 msgstr "Título do capítulo…"
@@ -177,11 +167,6 @@ msgstr "Descrição do curso…"
 msgctxt "sHQNSR"
 msgid "We couldn't load the chapters. Please try again."
 msgstr "Não conseguimos carregar os capítulos. Por favor, tente novamente."
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
-msgctxt "v2PuXy"
-msgid "Edit course slug"
-msgstr "Editar slug do curso"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
 msgctxt "xA68iL"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -27,29 +27,24 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: src/app/[orgSlug]/_components/slug-editor.tsx
-msgctxt "fZThA8"
-msgid "Slug already exists"
-msgstr "Slug já existe"
+msgctxt "8mWdw8"
+msgid "your-custom-url"
+msgstr "sua-url-personalizada"
 
 #: src/app/[orgSlug]/_components/slug-editor.tsx
-msgctxt "J9+DwE"
-msgid "slug…"
-msgstr "slug…"
+msgctxt "jvo0vs"
+msgid "Save"
+msgstr "Salvar"
+
+#: src/app/[orgSlug]/_components/slug-editor.tsx
+msgctxt "NJUZ2D"
+msgid "This URL is already in use"
+msgstr "Esta URL já está em uso"
 
 #: src/app/[orgSlug]/_components/slug-editor.tsx
 msgctxt "QGLi0O"
 msgid "URL address"
 msgstr "Endereço URL"
-
-#: src/app/[orgSlug]/_components/slug-editor.tsx
-msgctxt "Rr6+VH"
-msgid "This slug is already in use"
-msgstr "Este slug já está em uso"
-
-#: src/app/[orgSlug]/_components/slug-editor.tsx
-msgctxt "Tk3zpi"
-msgid "Save slug"
-msgstr "Salvar slug"
 
 #: src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgctxt "52DE8l"

--- a/apps/editor/src/app/[orgSlug]/_components/slug-editor-skeleton.tsx
+++ b/apps/editor/src/app/[orgSlug]/_components/slug-editor-skeleton.tsx
@@ -1,0 +1,5 @@
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+
+export function SlugEditorSkeleton() {
+  return <Skeleton className="mx-4 h-5 w-32" />;
+}

--- a/apps/editor/src/app/[orgSlug]/_components/slug-editor.tsx
+++ b/apps/editor/src/app/[orgSlug]/_components/slug-editor.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { Button } from "@zoonk/ui/components/button";
+import { EditableText } from "@zoonk/ui/components/editable-text";
+import { toast } from "@zoonk/ui/components/sonner";
+import { Check, CircleAlert, Link, X } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useExtracted } from "next-intl";
+import { useState, useTransition } from "react";
+import { useSlugCheck } from "@/hooks/use-slug-check";
+
+type SlugCheckParams = {
+  language: string;
+  orgSlug: string;
+  slug: string;
+};
+
+type SlugEditorProps = {
+  checkFn: (params: SlugCheckParams) => Promise<boolean>;
+  entityId: number;
+  initialSlug: string;
+  label: string;
+  language: string;
+  onSave: (
+    id: number,
+    data: { slug: string },
+  ) => Promise<{ error: string | null; newSlug?: string }>;
+  orgSlug: string;
+  redirectPrefix: string;
+  redirectSuffix?: string;
+};
+
+export function SlugEditor({
+  checkFn,
+  entityId,
+  initialSlug,
+  label,
+  language,
+  onSave,
+  orgSlug,
+  redirectPrefix,
+  redirectSuffix = "",
+}: SlugEditorProps) {
+  const t = useExtracted();
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [slug, setSlug] = useState(initialSlug);
+
+  const slugExists = useSlugCheck({
+    checkFn,
+    language,
+    orgSlug,
+    slug,
+  });
+
+  const hasChanged = slug.trim() !== initialSlug;
+  const isEmpty = slug.trim().length === 0;
+  const showError = hasChanged && slugExists;
+  const canSave = hasChanged && !isEmpty && !slugExists && !isPending;
+
+  function handleCancel() {
+    setSlug(initialSlug);
+  }
+
+  function handleSave() {
+    startTransition(async () => {
+      const result = await onSave(entityId, { slug: slug.trim() });
+
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
+
+      if (result.newSlug) {
+        const url = `${redirectPrefix}${result.newSlug}${redirectSuffix}`;
+        router.push(url as Parameters<typeof router.push>[0]);
+      }
+    });
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter" && canSave) {
+      e.preventDefault();
+      handleSave();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      handleCancel();
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1 px-4">
+      <label className="flex items-center gap-1.5 text-muted-foreground text-xs">
+        <Link aria-hidden="true" className="size-3" />
+        <span>{t("URL address")}</span>
+      </label>
+
+      <div className="flex h-5 items-center gap-2">
+        <EditableText
+          aria-label={label}
+          className="max-w-48 text-sm"
+          disabled={isPending}
+          onChange={(e) => setSlug(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={t("slug…")}
+          value={slug}
+          variant="muted"
+        />
+
+        <div
+          className={`flex items-center gap-1 transition-opacity ${hasChanged ? "opacity-100" : "pointer-events-none opacity-0"}`}
+        >
+          {showError ? (
+            <span
+              aria-label={t("Slug already exists")}
+              className="flex size-5 items-center justify-center"
+              role="img"
+            >
+              <CircleAlert className="size-4 text-destructive" />
+            </span>
+          ) : (
+            <Button
+              aria-label={t("Save slug")}
+              disabled={!canSave}
+              onClick={handleSave}
+              size="icon-sm"
+              variant="ghost"
+            >
+              <Check className="size-4" />
+            </Button>
+          )}
+
+          <Button
+            aria-label={t("Cancel")}
+            disabled={isPending}
+            onClick={handleCancel}
+            size="icon-sm"
+            variant="ghost"
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
+      </div>
+
+      {showError && (
+        <p className="text-destructive text-xs">
+          {t("This slug is already in use")}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/editor/src/app/[orgSlug]/_components/slug-editor.tsx
+++ b/apps/editor/src/app/[orgSlug]/_components/slug-editor.tsx
@@ -19,7 +19,6 @@ type SlugEditorProps = {
   checkFn: (params: SlugCheckParams) => Promise<boolean>;
   entityId: number;
   initialSlug: string;
-  label: string;
   language: string;
   onSave: (
     id: number,
@@ -34,7 +33,6 @@ export function SlugEditor({
   checkFn,
   entityId,
   initialSlug,
-  label,
   language,
   onSave,
   orgSlug,
@@ -90,16 +88,19 @@ export function SlugEditor({
 
   return (
     <div className="flex flex-col gap-1 px-4">
-      <label className="flex items-center gap-1.5 text-muted-foreground text-xs">
+      <label
+        className="flex items-center gap-1.5 text-muted-foreground text-xs"
+        htmlFor="slug-editor"
+      >
         <Link aria-hidden="true" className="size-3" />
-        <span>{t("URL address")}</span>
+        {t("URL address")}
       </label>
 
       <div className="flex h-5 items-center gap-2">
         <EditableText
-          aria-label={label}
           className="max-w-48 text-sm"
           disabled={isPending}
+          id="slug-editor"
           onChange={(e) => setSlug(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder={t("slug…")}

--- a/apps/editor/src/app/[orgSlug]/_components/slug-editor.tsx
+++ b/apps/editor/src/app/[orgSlug]/_components/slug-editor.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { Button } from "@zoonk/ui/components/button";
-import { EditableText } from "@zoonk/ui/components/editable-text";
+import {
+  EditableLabel,
+  EditableText,
+} from "@zoonk/ui/components/editable-text";
 import { toast } from "@zoonk/ui/components/sonner";
-import { Check, CircleAlert, Link, X } from "lucide-react";
+import { Check, CircleAlert, Link as LinkIcon, X } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useExtracted } from "next-intl";
 import { useState, useTransition } from "react";
@@ -88,13 +91,9 @@ export function SlugEditor({
 
   return (
     <div className="flex flex-col gap-1 px-4">
-      <label
-        className="flex items-center gap-1.5 text-muted-foreground text-xs"
-        htmlFor="slug-editor"
-      >
-        <Link aria-hidden="true" className="size-3" />
+      <EditableLabel htmlFor="slug-editor" icon={LinkIcon}>
         {t("URL address")}
-      </label>
+      </EditableLabel>
 
       <div className="flex h-5 items-center gap-2">
         <EditableText

--- a/apps/editor/src/app/[orgSlug]/_components/slug-editor.tsx
+++ b/apps/editor/src/app/[orgSlug]/_components/slug-editor.tsx
@@ -103,7 +103,7 @@ export function SlugEditor({
           id="slug-editor"
           onChange={(e) => setSlug(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder={t("slug…")}
+          placeholder={t("your-custom-url")}
           value={slug}
           variant="muted"
         />
@@ -113,7 +113,7 @@ export function SlugEditor({
         >
           {showError ? (
             <span
-              aria-label={t("Slug already exists")}
+              aria-label={t("This URL is already in use")}
               className="flex size-5 items-center justify-center"
               role="img"
             >
@@ -121,7 +121,7 @@ export function SlugEditor({
             </span>
           ) : (
             <Button
-              aria-label={t("Save slug")}
+              aria-label={t("Save")}
               disabled={!canSave}
               onClick={handleSave}
               size="icon-sm"
@@ -145,7 +145,7 @@ export function SlugEditor({
 
       {showError && (
         <p className="text-destructive text-xs">
-          {t("This slug is already in use")}
+          {t("This URL is already in use")}
         </p>
       )}
     </div>

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
@@ -3,8 +3,17 @@
 import { revalidateMainApp } from "@zoonk/core/cache/revalidate";
 import { cacheTagCourse } from "@zoonk/utils/cache";
 import { after } from "next/server";
+import { courseSlugExists } from "@/data/courses/course-slug";
 import { updateCourse } from "@/data/courses/update-course";
 import { getErrorMessage } from "@/lib/error-messages";
+
+export async function checkCourseSlugExists(params: {
+  language: string;
+  orgSlug: string;
+  slug: string;
+}): Promise<boolean> {
+  return courseSlugExists(params);
+}
 
 export async function updateCourseTitleAction(
   courseSlug: string,
@@ -46,4 +55,28 @@ export async function updateCourseDescriptionAction(
   });
 
   return { error: null };
+}
+
+export async function updateCourseSlugAction(
+  currentSlug: string,
+  courseId: number,
+  data: { slug: string },
+): Promise<{ error: string | null; newSlug?: string }> {
+  const { data: course, error } = await updateCourse({
+    courseId,
+    slug: data.slug,
+  });
+
+  if (error) {
+    return { error: await getErrorMessage(error) };
+  }
+
+  after(async () => {
+    await revalidateMainApp([
+      cacheTagCourse({ courseSlug: currentSlug }),
+      cacheTagCourse({ courseSlug: course.slug }),
+    ]);
+  });
+
+  return { error: null, newSlug: course.slug };
 }

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
@@ -3,8 +3,17 @@
 import { revalidateMainApp } from "@zoonk/core/cache/revalidate";
 import { cacheTagChapter, cacheTagCourse } from "@zoonk/utils/cache";
 import { after } from "next/server";
+import { chapterSlugExists } from "@/data/chapters/chapter-slug";
 import { updateChapter } from "@/data/chapters/update-chapter";
 import { getErrorMessage } from "@/lib/error-messages";
+
+export async function checkChapterSlugExists(params: {
+  language: string;
+  orgSlug: string;
+  slug: string;
+}): Promise<boolean> {
+  return chapterSlugExists(params);
+}
 
 export async function updateChapterTitleAction(
   chapterSlug: string,
@@ -54,4 +63,30 @@ export async function updateChapterDescriptionAction(
   });
 
   return { error: null };
+}
+
+export async function updateChapterSlugAction(
+  currentSlug: string,
+  courseSlug: string,
+  chapterId: number,
+  data: { slug: string },
+): Promise<{ error: string | null; newSlug?: string }> {
+  const { data: chapter, error } = await updateChapter({
+    chapterId,
+    slug: data.slug,
+  });
+
+  if (error) {
+    return { error: await getErrorMessage(error) };
+  }
+
+  after(async () => {
+    await revalidateMainApp([
+      cacheTagChapter({ chapterSlug: currentSlug }),
+      cacheTagChapter({ chapterSlug: chapter.slug }),
+      cacheTagCourse({ courseSlug }),
+    ]);
+  });
+
+  return { error: null, newSlug: chapter.slug };
 }

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/actions.ts
@@ -7,8 +7,17 @@ import {
   cacheTagLesson,
 } from "@zoonk/utils/cache";
 import { after } from "next/server";
+import { lessonSlugExists } from "@/data/lessons/lesson-slug";
 import { updateLesson } from "@/data/lessons/update-lesson";
 import { getErrorMessage } from "@/lib/error-messages";
+
+export async function checkLessonSlugExists(params: {
+  language: string;
+  orgSlug: string;
+  slug: string;
+}): Promise<boolean> {
+  return lessonSlugExists(params);
+}
 
 export async function updateLessonTitleAction(
   slugs: { lessonSlug: string; chapterSlug: string; courseSlug: string },
@@ -58,4 +67,30 @@ export async function updateLessonDescriptionAction(
   });
 
   return { error: null };
+}
+
+export async function updateLessonSlugAction(
+  slugs: { lessonSlug: string; chapterSlug: string; courseSlug: string },
+  lessonId: number,
+  data: { slug: string },
+): Promise<{ error: string | null; newSlug?: string }> {
+  const { data: lesson, error } = await updateLesson({
+    lessonId,
+    slug: data.slug,
+  });
+
+  if (error) {
+    return { error: await getErrorMessage(error) };
+  }
+
+  after(async () => {
+    await revalidateMainApp([
+      cacheTagLesson({ lessonSlug: slugs.lessonSlug }),
+      cacheTagLesson({ lessonSlug: lesson.slug }),
+      cacheTagChapter({ chapterSlug: slugs.chapterSlug }),
+      cacheTagCourse({ courseSlug: slugs.courseSlug }),
+    ]);
+  });
+
+  return { error: null, newSlug: lesson.slug };
 }

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -8,10 +8,14 @@ import {
 } from "@/app/[orgSlug]/_components/back-link";
 import { ContentEditor } from "@/app/[orgSlug]/_components/content-editor";
 import { ContentEditorSkeleton } from "@/app/[orgSlug]/_components/content-editor-skeleton";
+import { SlugEditor } from "@/app/[orgSlug]/_components/slug-editor";
+import { SlugEditorSkeleton } from "@/app/[orgSlug]/_components/slug-editor-skeleton";
 import { getChapter } from "@/data/chapters/get-chapter";
 import { getLesson } from "@/data/lessons/get-lesson";
 import {
+  checkLessonSlugExists,
   updateLessonDescriptionAction,
+  updateLessonSlugAction,
   updateLessonTitleAction,
 } from "./actions";
 
@@ -77,6 +81,36 @@ async function LessonContent({
   );
 }
 
+async function LessonSlug({ params }: { params: LessonPageProps["params"] }) {
+  const { chapterSlug, courseSlug, lang, lessonSlug, orgSlug } = await params;
+  const t = await getExtracted();
+
+  const { data: lesson } = await getLesson({
+    language: lang,
+    lessonSlug,
+    orgSlug,
+  });
+
+  if (!lesson) {
+    return null;
+  }
+
+  const slugs = { chapterSlug, courseSlug, lessonSlug };
+
+  return (
+    <SlugEditor
+      checkFn={checkLessonSlugExists}
+      entityId={lesson.id}
+      initialSlug={lesson.slug}
+      label={t("Edit lesson slug")}
+      language={lang}
+      onSave={updateLessonSlugAction.bind(null, slugs)}
+      orgSlug={orgSlug}
+      redirectPrefix={`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/`}
+    />
+  );
+}
+
 export default async function LessonPage(props: LessonPageProps) {
   const { chapterSlug, lang, lessonSlug, orgSlug } = await props.params;
 
@@ -94,6 +128,10 @@ export default async function LessonPage(props: LessonPageProps) {
 
       <Suspense fallback={<ContentEditorSkeleton />}>
         <LessonContent params={props.params} />
+      </Suspense>
+
+      <Suspense fallback={<SlugEditorSkeleton />}>
+        <LessonSlug params={props.params} />
       </Suspense>
     </Container>
   );

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -83,7 +83,6 @@ async function LessonContent({
 
 async function LessonSlug({ params }: { params: LessonPageProps["params"] }) {
   const { chapterSlug, courseSlug, lang, lessonSlug, orgSlug } = await params;
-  const t = await getExtracted();
 
   const { data: lesson } = await getLesson({
     language: lang,
@@ -102,7 +101,6 @@ async function LessonSlug({ params }: { params: LessonPageProps["params"] }) {
       checkFn={checkLessonSlugExists}
       entityId={lesson.id}
       initialSlug={lesson.slug}
-      label={t("Edit lesson slug")}
       language={lang}
       onSave={updateLessonSlugAction.bind(null, slugs)}
       orgSlug={orgSlug}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -12,11 +12,15 @@ import { ContentEditor } from "@/app/[orgSlug]/_components/content-editor";
 import { ContentEditorSkeleton } from "@/app/[orgSlug]/_components/content-editor-skeleton";
 import { ItemList } from "@/app/[orgSlug]/_components/item-list";
 import { ItemListSkeleton } from "@/app/[orgSlug]/_components/item-list-skeleton";
+import { SlugEditor } from "@/app/[orgSlug]/_components/slug-editor";
+import { SlugEditorSkeleton } from "@/app/[orgSlug]/_components/slug-editor-skeleton";
 import { getChapter } from "@/data/chapters/get-chapter";
 import { getCourse } from "@/data/courses/get-course";
 import { listChapterLessons } from "@/data/lessons/list-chapter-lessons";
 import {
+  checkChapterSlugExists,
   updateChapterDescriptionAction,
+  updateChapterSlugAction,
   updateChapterTitleAction,
 } from "./actions";
 
@@ -114,6 +118,34 @@ async function LessonList({ params }: { params: ChapterPageProps["params"] }) {
   );
 }
 
+async function ChapterSlug({ params }: { params: ChapterPageProps["params"] }) {
+  const { chapterSlug, courseSlug, lang, orgSlug } = await params;
+  const t = await getExtracted();
+
+  const { data: chapter } = await getChapter({
+    chapterSlug,
+    language: lang,
+    orgSlug,
+  });
+
+  if (!chapter) {
+    return null;
+  }
+
+  return (
+    <SlugEditor
+      checkFn={checkChapterSlugExists}
+      entityId={chapter.id}
+      initialSlug={chapter.slug}
+      label={t("Edit chapter slug")}
+      language={lang}
+      onSave={updateChapterSlugAction.bind(null, chapterSlug, courseSlug)}
+      orgSlug={orgSlug}
+      redirectPrefix={`/${orgSlug}/c/${lang}/${courseSlug}/ch/`}
+    />
+  );
+}
+
 export default async function ChapterPage(props: ChapterPageProps) {
   const { chapterSlug, courseSlug, lang, orgSlug } = await props.params;
 
@@ -132,6 +164,10 @@ export default async function ChapterPage(props: ChapterPageProps) {
 
       <Suspense fallback={<ContentEditorSkeleton />}>
         <ChapterContent params={props.params} />
+      </Suspense>
+
+      <Suspense fallback={<SlugEditorSkeleton />}>
+        <ChapterSlug params={props.params} />
       </Suspense>
 
       <Suspense fallback={<ItemListSkeleton />}>

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -120,7 +120,6 @@ async function LessonList({ params }: { params: ChapterPageProps["params"] }) {
 
 async function ChapterSlug({ params }: { params: ChapterPageProps["params"] }) {
   const { chapterSlug, courseSlug, lang, orgSlug } = await params;
-  const t = await getExtracted();
 
   const { data: chapter } = await getChapter({
     chapterSlug,
@@ -137,7 +136,6 @@ async function ChapterSlug({ params }: { params: ChapterPageProps["params"] }) {
       checkFn={checkChapterSlugExists}
       entityId={chapter.id}
       initialSlug={chapter.slug}
-      label={t("Edit chapter slug")}
       language={lang}
       onSave={updateChapterSlugAction.bind(null, chapterSlug, courseSlug)}
       orgSlug={orgSlug}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
@@ -8,10 +8,14 @@ import { ContentEditor } from "@/app/[orgSlug]/_components/content-editor";
 import { ContentEditorSkeleton } from "@/app/[orgSlug]/_components/content-editor-skeleton";
 import { ItemList } from "@/app/[orgSlug]/_components/item-list";
 import { ItemListSkeleton } from "@/app/[orgSlug]/_components/item-list-skeleton";
+import { SlugEditor } from "@/app/[orgSlug]/_components/slug-editor";
+import { SlugEditorSkeleton } from "@/app/[orgSlug]/_components/slug-editor-skeleton";
 import { listCourseChapters } from "@/data/chapters/list-course-chapters";
 import { getCourse } from "@/data/courses/get-course";
 import {
+  checkCourseSlugExists,
   updateCourseDescriptionAction,
+  updateCourseSlugAction,
   updateCourseTitleAction,
 } from "./actions";
 
@@ -82,6 +86,38 @@ async function ChapterList({
   );
 }
 
+async function CourseSlug({
+  params,
+}: {
+  params: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]">["params"];
+}) {
+  const { courseSlug, lang, orgSlug } = await params;
+  const t = await getExtracted();
+
+  const { data: course } = await getCourse({
+    courseSlug,
+    language: lang,
+    orgSlug,
+  });
+
+  if (!course) {
+    return null;
+  }
+
+  return (
+    <SlugEditor
+      checkFn={checkCourseSlugExists}
+      entityId={course.id}
+      initialSlug={course.slug}
+      label={t("Edit course slug")}
+      language={lang}
+      onSave={updateCourseSlugAction.bind(null, courseSlug)}
+      orgSlug={orgSlug}
+      redirectPrefix={`/${orgSlug}/c/${lang}/`}
+    />
+  );
+}
+
 export default async function CoursePage(
   props: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]">,
 ) {
@@ -97,6 +133,10 @@ export default async function CoursePage(
     <Container variant="narrow">
       <Suspense fallback={<ContentEditorSkeleton />}>
         <CourseContent params={props.params} />
+      </Suspense>
+
+      <Suspense fallback={<SlugEditorSkeleton />}>
+        <CourseSlug params={props.params} />
       </Suspense>
 
       <Suspense fallback={<ItemListSkeleton />}>

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
@@ -92,7 +92,6 @@ async function CourseSlug({
   params: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]">["params"];
 }) {
   const { courseSlug, lang, orgSlug } = await params;
-  const t = await getExtracted();
 
   const { data: course } = await getCourse({
     courseSlug,
@@ -109,7 +108,6 @@ async function CourseSlug({
       checkFn={checkCourseSlugExists}
       entityId={course.id}
       initialSlug={course.slug}
-      label={t("Edit course slug")}
       language={lang}
       onSave={updateCourseSlugAction.bind(null, courseSlug)}
       orgSlug={orgSlug}

--- a/i18n.lock
+++ b/i18n.lock
@@ -4,6 +4,12 @@ checksums:
     Unsaved/singular: ddc9094aecf93ceabe363846756a9925
     Saved/singular: 6554b923011266821d74e06e013a40e6
     Saving%E2%80%A6/singular: ee98ff32f9a585a9108c8cd961d6077e
+    Cancel/singular: 2e2a849c2223911717de8caa2c71bade
+    Slug%20already%20exists/singular: cc53fffad738a971d2de23cd2c36f279
+    slug%E2%80%A6/singular: a8347cbf3f44d5281d5f45ddcc596af8
+    URL%20address/singular: e752a4cebaefb0cf38c129ec8edd6b65
+    This%20slug%20is%20already%20in%20use/singular: 956287592b5ee327cfbb73a85a052248
+    Save%20slug/singular: b42b7839c331683a7593fdbc1a443c54
     Delete%20lesson%3F/singular: 7f0eb69c2ada091c8504e0197eae59ab
     Delete%20lesson/singular: 18309d2fe705fd2c4301224dee3be224
     Delete%20chapter/singular: 17a0d21cc5650c1a8de6e918fd754a63
@@ -12,6 +18,7 @@ checksums:
     Delete%20course%3F/singular: c83369b40aec2a0eb3cafd146d70020e
     Edit%20lesson%20description/singular: b959f1e2fc7f00f593ae2c1a12fd330d
     Lesson%20description%E2%80%A6/singular: 77ad5a9829eda8182865a46455d5a842
+    Edit%20lesson%20slug/singular: 2df251294158867c665f4338631b752f
     Lesson%20title%E2%80%A6/singular: d7b981d2734c11f2ee5d58f21c93bd3e
     Edit%20lesson%20title/singular: 15b5a30f4a0365bae4da264383dae889
     We%20couldn't%20load%20the%20lessons.%20Please%20try%20again./singular: f2e68b6dd4d7f2eb0c91f20ade06957d
@@ -21,12 +28,14 @@ checksums:
     Try%20again/singular: 33dd8820e743e35a66e6977f69e9d3b5
     Edit%20chapter%20title/singular: 21c04bd3ed6335df5195d1f2857131bf
     Chapter%20description%E2%80%A6/singular: d394513f90a5c9ad1880d364e8fc5cb8
+    Edit%20chapter%20slug/singular: e958f7e0a550d5d19c655e0bb8bf6027
     Chapter%20title%E2%80%A6/singular: 3ed70a2e64aefe189999ff5899e8a7a2
     Course%20title%E2%80%A6/singular: 4429de50f5f2d426271e76328c543daf
     Edit%20course%20description/singular: 2304f3ceeea1faaa3a4451c8863ded3b
     Edit%20course%20title/singular: 75b050a3ce516d55c480d633f5da502f
     Course%20description%E2%80%A6/singular: a548f00ce745044f2a2dfbe02b9a0130
     We%20couldn't%20load%20the%20chapters.%20Please%20try%20again./singular: 2bfbac73debefc0d7a4ec5c41af9c415
+    Edit%20course%20slug/singular: 6233d3df1de270c5ceae189aa05f039b
     Failed%20to%20load%20chapters/singular: a462d90fffa946fe5c2aedb6e6fff9b4
     Your%20organization%20hasn't%20created%20any%20courses%20yet./singular: 4c09c8406dbf7bfe159f850fc1f22b99
     No%20courses/singular: 72fc2629e79529e927834070a26d2a07
@@ -65,23 +74,18 @@ checksums:
     dashboard/singular: 3e3998114a2eab7daa3c9a23dbeb16b9
     Lessons/singular: 52fdbe5a3a6ee1cc1e166546516f9111
     Searching.../singular: 56cf28d6712bf3f7f73af2a81974ac45
-    settings/singular: 2313357d3b991dbd48a264c559ea9b35
-    locale/singular: 1baedd0f3a7e1e835804c3ab7066d364
     new/singular: 59c16092bc6a4b9de0debe084e4b5f49
-    language/singular: f0106a9b4354555a31e54c05c9b1e1f6
     course/singular: a8f5f6a15055aa74f1b98d4821329d19
     Home%20page/singular: aa72464a366b091aa6f2037ca869c09c
     sign%20out/singular: a917e8428004b4108a66fa0ba9c0c15c
     exit/singular: 8eff58f44e53377753566cba50541cf9
     Search/singular: 49dd6c21604b5e8d4153ff1aff2177e1
-    Language/singular: 277fd1a41cc237a437cd1d5e4a80463b
-    translate/singular: a9ff69701924ae84bd571f09df986e00
     start/singular: e19dc5c089daea13eeb2efffb890057d
-    Cancel/singular: 2e2a849c2223911717de8caa2c71bade
     Delete%20item/singular: b9b5755b0ed185436b52860bde313b9f
     This%20action%20cannot%20be%20undone./singular: 3d8b13374ffd3cefc0f3f7ce077bd9c9
     Delete/singular: 8bcf303dd10a645b5baacb02b47d72c9
     Delete%20item%3F/singular: d847684112faebe6e59a16ba2ccaac05
+    Language/singular: 277fd1a41cc237a437cd1d5e4a80463b
     Organizations/singular: bd50dd0b17bd74a72b728a8385b5ee28
     No%20other%20organizations/singular: e9de48fc34aa9de5d30e3eb8eed79ed1
     Draft/singular: e8a92958ad300aacfe46c2bf6644927e

--- a/i18n.lock
+++ b/i18n.lock
@@ -5,11 +5,10 @@ checksums:
     Saved/singular: 6554b923011266821d74e06e013a40e6
     Saving%E2%80%A6/singular: ee98ff32f9a585a9108c8cd961d6077e
     Cancel/singular: 2e2a849c2223911717de8caa2c71bade
-    Slug%20already%20exists/singular: cc53fffad738a971d2de23cd2c36f279
-    slug%E2%80%A6/singular: a8347cbf3f44d5281d5f45ddcc596af8
+    your-custom-url/singular: 762da425a11b62bd253ca0a1dc48f47d
+    Save/singular: f7a2929f33bc420195e59ac5a8bcd454
+    This%20URL%20is%20already%20in%20use/singular: dfc6df86970a8fa27f4f4b4c3f2716b1
     URL%20address/singular: e752a4cebaefb0cf38c129ec8edd6b65
-    This%20slug%20is%20already%20in%20use/singular: 956287592b5ee327cfbb73a85a052248
-    Save%20slug/singular: b42b7839c331683a7593fdbc1a443c54
     Delete%20lesson%3F/singular: 7f0eb69c2ada091c8504e0197eae59ab
     Delete%20lesson/singular: 18309d2fe705fd2c4301224dee3be224
     Delete%20chapter/singular: 17a0d21cc5650c1a8de6e918fd754a63
@@ -18,7 +17,6 @@ checksums:
     Delete%20course%3F/singular: c83369b40aec2a0eb3cafd146d70020e
     Edit%20lesson%20description/singular: b959f1e2fc7f00f593ae2c1a12fd330d
     Lesson%20description%E2%80%A6/singular: 77ad5a9829eda8182865a46455d5a842
-    Edit%20lesson%20slug/singular: 2df251294158867c665f4338631b752f
     Lesson%20title%E2%80%A6/singular: d7b981d2734c11f2ee5d58f21c93bd3e
     Edit%20lesson%20title/singular: 15b5a30f4a0365bae4da264383dae889
     We%20couldn't%20load%20the%20lessons.%20Please%20try%20again./singular: f2e68b6dd4d7f2eb0c91f20ade06957d
@@ -28,14 +26,12 @@ checksums:
     Try%20again/singular: 33dd8820e743e35a66e6977f69e9d3b5
     Edit%20chapter%20title/singular: 21c04bd3ed6335df5195d1f2857131bf
     Chapter%20description%E2%80%A6/singular: d394513f90a5c9ad1880d364e8fc5cb8
-    Edit%20chapter%20slug/singular: e958f7e0a550d5d19c655e0bb8bf6027
     Chapter%20title%E2%80%A6/singular: 3ed70a2e64aefe189999ff5899e8a7a2
     Course%20title%E2%80%A6/singular: 4429de50f5f2d426271e76328c543daf
     Edit%20course%20description/singular: 2304f3ceeea1faaa3a4451c8863ded3b
     Edit%20course%20title/singular: 75b050a3ce516d55c480d633f5da502f
     Course%20description%E2%80%A6/singular: a548f00ce745044f2a2dfbe02b9a0130
     We%20couldn't%20load%20the%20chapters.%20Please%20try%20again./singular: 2bfbac73debefc0d7a4ec5c41af9c415
-    Edit%20course%20slug/singular: 6233d3df1de270c5ceae189aa05f039b
     Failed%20to%20load%20chapters/singular: a462d90fffa946fe5c2aedb6e6fff9b4
     Your%20organization%20hasn't%20created%20any%20courses%20yet./singular: 4c09c8406dbf7bfe159f850fc1f22b99
     No%20courses/singular: 72fc2629e79529e927834070a26d2a07

--- a/packages/ui/src/components/editable-text.tsx
+++ b/packages/ui/src/components/editable-text.tsx
@@ -1,5 +1,31 @@
 import { cn } from "@zoonk/ui/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
+import type { LucideIcon } from "lucide-react";
+
+export type EditableLabelProps = React.ComponentProps<"label"> & {
+  icon?: LucideIcon;
+};
+
+function EditableLabel({
+  children,
+  className,
+  icon: Icon,
+  ...props
+}: EditableLabelProps) {
+  return (
+    // biome-ignore lint/a11y/noLabelWithoutControl: htmlFor is passed via props
+    <label
+      className={cn(
+        "flex items-center gap-1.5 text-muted-foreground text-xs",
+        className,
+      )}
+      {...props}
+    >
+      {Icon && <Icon aria-hidden="true" className="size-3" />}
+      {children}
+    </label>
+  );
+}
 
 const editableTextVariants = cva(
   [
@@ -82,6 +108,7 @@ function EditableTextarea({
 }
 
 export {
+  EditableLabel,
   EditableText,
   editableTextVariants,
   EditableTextarea,


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an inline slug editor to the course, chapter, and lesson pages. Editors can rename slugs with live validation and auto-redirect to the new URL.

- **New Features**
  - SlugEditor + skeleton added and wired into course/chapter/lesson pages with localized labels.
  - Live slug availability checks (course/chapter/lesson) with clear error state and Enter/Esc shortcuts.
  - Saving updates the entity, revalidates cache tags, and navigates to the new route.
  - New i18n strings added for en, es, and pt.

<sup>Written for commit f45af3d4526acaf15aad2c108559b16d37add46d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





