### PR TITLE
feat(main): add functions for listing courses

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -561,3 +561,13 @@ msgstr "Business"
 msgctxt "YMDBNH"
 msgid "Geography"
 msgstr "Geography"
+
+#: src/lib/error-messages.ts
+msgctxt "3IKub9"
+msgid "An unexpected error occurred"
+msgstr "An unexpected error occurred"
+
+#: src/lib/error-messages.ts
+msgctxt "g5WLcA"
+msgid "Please sign in to continue"
+msgstr "Please sign in to continue"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -561,3 +561,13 @@ msgstr "Negocios"
 msgctxt "YMDBNH"
 msgid "Geography"
 msgstr "Geografía"
+
+#: src/lib/error-messages.ts
+msgctxt "3IKub9"
+msgid "An unexpected error occurred"
+msgstr "Ocurrió un error inesperado"
+
+#: src/lib/error-messages.ts
+msgctxt "g5WLcA"
+msgid "Please sign in to continue"
+msgstr "Inicia sesión para continuar"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -561,3 +561,13 @@ msgstr "Negócios"
 msgctxt "YMDBNH"
 msgid "Geography"
 msgstr "Geografia"
+
+#: src/lib/error-messages.ts
+msgctxt "3IKub9"
+msgid "An unexpected error occurred"
+msgstr "Ocorreu um erro inesperado"
+
+#: src/lib/error-messages.ts
+msgctxt "g5WLcA"
+msgid "Please sign in to continue"
+msgstr "Faça login para continuar"

--- a/apps/main/src/data/courses/add-course-user.test.ts
+++ b/apps/main/src/data/courses/add-course-user.test.ts
@@ -1,0 +1,116 @@
+import { prisma } from "@zoonk/db";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { beforeAll, describe, expect, test } from "vitest";
+import { ErrorCode } from "@/lib/app-error";
+import { addCourseUser } from "./add-course-user";
+
+describe("unauthenticated users", () => {
+  test("returns Unauthorized", async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: org.id,
+    });
+
+    const result = await addCourseUser({
+      courseId: course.id,
+      headers: new Headers(),
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.unauthorized);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("authenticated users", () => {
+  let organization: Awaited<ReturnType<typeof organizationFixture>>;
+  let user: Awaited<ReturnType<typeof userFixture>>;
+  let headers: Headers;
+  let course: Awaited<ReturnType<typeof courseFixture>>;
+
+  beforeAll(async () => {
+    [organization, user] = await Promise.all([
+      organizationFixture(),
+      userFixture(),
+    ]);
+
+    [headers, course] = await Promise.all([
+      signInAs(user.email, user.password),
+      courseFixture({
+        isPublished: true,
+        organizationId: organization.id,
+      }),
+    ]);
+  });
+
+  test("adds a course to user successfully", async () => {
+    const result = await addCourseUser({
+      courseId: course.id,
+      headers,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toBeDefined();
+    expect(result.data?.courseId).toBe(course.id);
+    expect(result.data?.userId).toBe(Number(user.id));
+  });
+
+  test("is idempotent (adding same course twice does not error)", async () => {
+    const newCourse = await courseFixture({
+      isPublished: true,
+      organizationId: organization.id,
+    });
+
+    const firstResult = await addCourseUser({
+      courseId: newCourse.id,
+      headers,
+    });
+
+    const secondResult = await addCourseUser({
+      courseId: newCourse.id,
+      headers,
+    });
+
+    expect(firstResult.error).toBeNull();
+    expect(secondResult.error).toBeNull();
+    expect(firstResult.data?.id).toBe(secondResult.data?.id);
+
+    const count = await prisma.courseUser.count({
+      where: {
+        courseId: newCourse.id,
+        userId: Number(user.id),
+      },
+    });
+
+    expect(count).toBe(1);
+  });
+
+  test("creates a record in the database", async () => {
+    const newCourse = await courseFixture({
+      isPublished: true,
+      organizationId: organization.id,
+    });
+
+    await addCourseUser({
+      courseId: newCourse.id,
+      headers,
+    });
+
+    const record = await prisma.courseUser.findUnique({
+      where: {
+        courseUser: {
+          courseId: newCourse.id,
+          userId: Number(user.id),
+        },
+      },
+    });
+
+    expect(record).not.toBeNull();
+    expect(record?.courseId).toBe(newCourse.id);
+    expect(record?.userId).toBe(Number(user.id));
+    expect(record?.startedAt).toBeInstanceOf(Date);
+  });
+});

--- a/apps/main/src/data/courses/add-course-user.ts
+++ b/apps/main/src/data/courses/add-course-user.ts
@@ -1,0 +1,41 @@
+import "server-only";
+
+import { getSession } from "@zoonk/core/users/session/get";
+import { type CourseUser, prisma } from "@zoonk/db";
+import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { ErrorCode } from "@/lib/app-error";
+
+export async function addCourseUser(params: {
+  courseId: number;
+  headers?: Headers;
+}): Promise<SafeReturn<CourseUser>> {
+  const session = await getSession({ headers: params.headers });
+
+  if (!session) {
+    return { data: null, error: new AppError(ErrorCode.unauthorized) };
+  }
+
+  const userId = Number(session.user.id);
+
+  const { data, error } = await safeAsync(() =>
+    prisma.courseUser.upsert({
+      create: {
+        courseId: params.courseId,
+        userId,
+      },
+      update: {},
+      where: {
+        courseUser: {
+          courseId: params.courseId,
+          userId,
+        },
+      },
+    }),
+  );
+
+  if (error) {
+    return { data: null, error };
+  }
+
+  return { data, error: null };
+}

--- a/apps/main/src/data/courses/list-courses.test.ts
+++ b/apps/main/src/data/courses/list-courses.test.ts
@@ -1,0 +1,233 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import {
+  courseCategoryFixture,
+  courseFixture,
+  courseUserFixture,
+} from "@zoonk/testing/fixtures/courses";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { beforeAll, describe, expect, test } from "vitest";
+import { listCourses } from "./list-courses";
+
+describe("listCourses", () => {
+  let brandOrg: Awaited<ReturnType<typeof organizationFixture>>;
+  let privateOrg: Awaited<ReturnType<typeof organizationFixture>>;
+  let publishedCourse: Awaited<ReturnType<typeof courseFixture>>;
+  let draftCourse: Awaited<ReturnType<typeof courseFixture>>;
+  let privateCourse: Awaited<ReturnType<typeof courseFixture>>;
+
+  beforeAll(async () => {
+    [brandOrg, privateOrg] = await Promise.all([
+      organizationFixture({ kind: "brand" }),
+      organizationFixture({ kind: "school" }),
+    ]);
+
+    [publishedCourse, draftCourse, privateCourse] = await Promise.all([
+      courseFixture({
+        isPublished: true,
+        language: "en",
+        organizationId: brandOrg.id,
+      }),
+      courseFixture({
+        isPublished: false,
+        language: "en",
+        organizationId: brandOrg.id,
+      }),
+      courseFixture({
+        isPublished: true,
+        language: "en",
+        organizationId: privateOrg.id,
+      }),
+    ]);
+  });
+
+  test("returns only published courses from brand orgs", async () => {
+    const result = await listCourses({ language: "en", limit: 100 });
+    const ids = result.map((c) => c.id);
+
+    expect(ids).toContain(publishedCourse.id);
+    expect(ids).not.toContain(draftCourse.id);
+    expect(ids).not.toContain(privateCourse.id);
+  });
+
+  test("filters by language", async () => {
+    const ptCourse = await courseFixture({
+      isPublished: true,
+      language: "pt",
+      organizationId: brandOrg.id,
+    });
+
+    const enResult = await listCourses({ language: "en", limit: 100 });
+    const ptResult = await listCourses({ language: "pt", limit: 100 });
+
+    const enIds = enResult.map((c) => c.id);
+    const ptIds = ptResult.map((c) => c.id);
+
+    expect(enIds).not.toContain(ptCourse.id);
+    expect(ptIds).toContain(ptCourse.id);
+    expect(ptIds).not.toContain(publishedCourse.id);
+  });
+
+  test("filters by category", async () => {
+    const techCourse = await courseFixture({
+      isPublished: true,
+      language: "en",
+      organizationId: brandOrg.id,
+    });
+
+    await courseCategoryFixture({
+      category: "tech",
+      courseId: techCourse.id,
+    });
+
+    const result = await listCourses({ category: "tech", language: "en" });
+
+    const ids = result.map((c) => c.id);
+
+    expect(ids).toContain(techCourse.id);
+    expect(ids).not.toContain(publishedCourse.id);
+  });
+
+  test("limits results to specified amount", async () => {
+    await prisma.course.createMany({
+      data: Array.from({ length: 5 }, (_, i) => ({
+        description: `Course ${i} description`,
+        imageUrl: "https://example.com/image.jpg",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: `test course ${i}`,
+        organizationId: brandOrg.id,
+        slug: `test-course-${randomUUID()}-${i}`,
+        title: `Test Course ${i}`,
+      })),
+    });
+
+    const result = await listCourses({ language: "en", limit: 3 });
+
+    expect(result).toHaveLength(3);
+  });
+
+  test("sorts by popularity (more users first)", async () => {
+    const [user1, user2, user3] = await Promise.all([
+      userFixture(),
+      userFixture(),
+      userFixture(),
+    ]);
+
+    const [popularCourse, lessPopularCourse] = await Promise.all([
+      courseFixture({
+        isPublished: true,
+        language: "en",
+        organizationId: brandOrg.id,
+        slug: `popular-course-${randomUUID()}`,
+      }),
+      courseFixture({
+        isPublished: true,
+        language: "en",
+        organizationId: brandOrg.id,
+        slug: `less-popular-course-${randomUUID()}`,
+      }),
+    ]);
+
+    await Promise.all([
+      courseUserFixture({
+        courseId: popularCourse.id,
+        userId: Number(user1.id),
+      }),
+      courseUserFixture({
+        courseId: popularCourse.id,
+        userId: Number(user2.id),
+      }),
+      courseUserFixture({
+        courseId: popularCourse.id,
+        userId: Number(user3.id),
+      }),
+      courseUserFixture({
+        courseId: lessPopularCourse.id,
+        userId: Number(user1.id),
+      }),
+    ]);
+
+    const result = await listCourses({ language: "en" });
+
+    const popularIndex = result.findIndex((c) => c.id === popularCourse.id);
+
+    const lessPopularIndex = result.findIndex(
+      (c) => c.id === lessPopularCourse.id,
+    );
+
+    expect(popularIndex).toBeLessThan(lessPopularIndex);
+  });
+
+  test("sorts by createdAt as tiebreaker for same popularity", async () => {
+    const [org, user1, user2, user3, user4] = await Promise.all([
+      organizationFixture({ kind: "brand" }),
+      userFixture(),
+      userFixture(),
+      userFixture(),
+      userFixture(),
+    ]);
+
+    const now = new Date();
+    const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+
+    const olderCourse = await courseFixture({
+      createdAt: oneHourAgo,
+      isPublished: true,
+      language: "en",
+      organizationId: org.id,
+    });
+
+    const newerCourse = await courseFixture({
+      createdAt: now,
+      isPublished: true,
+      language: "en",
+      organizationId: org.id,
+    });
+
+    await Promise.all([
+      courseUserFixture({
+        courseId: olderCourse.id,
+        userId: Number(user1.id),
+      }),
+      courseUserFixture({
+        courseId: olderCourse.id,
+        userId: Number(user2.id),
+      }),
+      courseUserFixture({
+        courseId: olderCourse.id,
+        userId: Number(user3.id),
+      }),
+      courseUserFixture({
+        courseId: olderCourse.id,
+        userId: Number(user4.id),
+      }),
+      courseUserFixture({
+        courseId: newerCourse.id,
+        userId: Number(user1.id),
+      }),
+      courseUserFixture({
+        courseId: newerCourse.id,
+        userId: Number(user2.id),
+      }),
+      courseUserFixture({
+        courseId: newerCourse.id,
+        userId: Number(user3.id),
+      }),
+      courseUserFixture({
+        courseId: newerCourse.id,
+        userId: Number(user4.id),
+      }),
+    ]);
+
+    const result = await listCourses({ language: "en" });
+
+    const newerIndex = result.findIndex((c) => c.id === newerCourse.id);
+    const olderIndex = result.findIndex((c) => c.id === olderCourse.id);
+
+    expect(newerIndex).toBeGreaterThanOrEqual(0);
+    expect(olderIndex).toBeGreaterThanOrEqual(0);
+    expect(newerIndex).toBeLessThan(olderIndex);
+  });
+});

--- a/apps/main/src/data/courses/list-courses.ts
+++ b/apps/main/src/data/courses/list-courses.ts
@@ -1,0 +1,32 @@
+import "server-only";
+
+import { type Course, prisma } from "@zoonk/db";
+import { clampQueryItems } from "@zoonk/db/utils";
+import type { CourseCategory } from "@zoonk/utils/categories";
+import { cache } from "react";
+
+const LIST_COURSES_LIMIT = 20;
+
+export const listCourses = cache(
+  async (params: {
+    category?: CourseCategory;
+    language: string;
+    limit?: number;
+  }): Promise<Course[]> => {
+    const courses = await prisma.course.findMany({
+      // biome-ignore lint/style/useNamingConvention: _count is Prisma's syntax for counting relations
+      orderBy: [{ users: { _count: "desc" } }, { createdAt: "desc" }],
+      take: clampQueryItems(params.limit ?? LIST_COURSES_LIMIT),
+      where: {
+        isPublished: true,
+        language: params.language,
+        organization: { kind: "brand" },
+        ...(params.category && {
+          categories: { some: { category: params.category } },
+        }),
+      },
+    });
+
+    return courses;
+  },
+);

--- a/apps/main/src/lib/app-error.ts
+++ b/apps/main/src/lib/app-error.ts
@@ -1,0 +1,5 @@
+export const ErrorCode = {
+  unauthorized: "unauthorized",
+} as const;
+
+export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/apps/main/src/lib/error-messages.ts
+++ b/apps/main/src/lib/error-messages.ts
@@ -1,0 +1,30 @@
+import type { AppError } from "@zoonk/utils/error";
+import { isAppError } from "@zoonk/utils/error";
+import { getExtracted } from "next-intl/server";
+import { ErrorCode, type ErrorCodeType } from "./app-error";
+
+function assertNever(x: never): never {
+  throw new Error(`Unhandled error code: ${x}`);
+}
+
+function isMainAppError(error: Error): error is AppError<ErrorCodeType> {
+  return (
+    isAppError(error) &&
+    Object.values(ErrorCode).includes(error.code as ErrorCodeType)
+  );
+}
+
+export async function getErrorMessage(error: Error): Promise<string> {
+  const t = await getExtracted();
+
+  if (isMainAppError(error)) {
+    switch (error.code) {
+      case ErrorCode.unauthorized:
+        return t("Please sign in to continue");
+      default:
+        return assertNever(error.code);
+    }
+  }
+
+  return t("An unexpected error occurred");
+}

--- a/apps/main/vitest.config.mts
+++ b/apps/main/vitest.config.mts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { loadEnv } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
@@ -6,6 +7,15 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   assetsInclude: ["**/*.md"],
   plugins: [tsconfigPaths(), react()],
+  resolve: {
+    alias: [
+      {
+        // Use @zoonk/auth/testing in tests to avoid nextCookies() which requires Next.js context
+        find: /^@zoonk\/auth$/,
+        replacement: resolve(__dirname, "../../packages/auth/src/testing.ts"),
+      },
+    ],
+  },
   test: {
     deps: {
       optimizer: { ssr: { include: ["next"] } },

--- a/i18n.lock
+++ b/i18n.lock
@@ -226,6 +226,8 @@ checksums:
     Law/singular: 3f04c791596043e899781f74003b9324
     Business/singular: 7682c7966c6e718836388561e7e68cab
     Geography/singular: fd93fe516c40f1f2dd96f53a507ce95d
+    An%20unexpected%20error%20occurred/singular: fe07b9cdb1fc3f7397f6d89c102c60af
+    Please%20sign%20in%20to%20continue/singular: 051e59dd3d3b0bfad95982f982fd6b9d
   61a308caf583f5835f54302028bdae73:
     You're%20signed%20in!/singular: 7f23ad13626e60f22e13b8777458750d
     You%20can%20close%20this%20window%20and%20return%20to%20your%20app./singular: 06f96197fc40b30e288b1a9603d15825

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -22,6 +22,7 @@ export type {
   CourseAlternativeTitle,
   CourseCategory,
   CourseSuggestion,
+  CourseUser,
   Invitation,
   Lesson,
   Member,

--- a/packages/db/src/prisma/migrations/20251229032633_add_course_users/migration.sql
+++ b/packages/db/src/prisma/migrations/20251229032633_add_course_users/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "course_users" (
+    "id" SERIAL NOT NULL,
+    "course_id" INTEGER NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "started_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "course_users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "course_users_course_id_idx" ON "course_users"("course_id");
+
+-- CreateIndex
+CREATE INDEX "course_users_user_id_idx" ON "course_users"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "course_users_course_id_user_id_key" ON "course_users"("course_id", "user_id");
+
+-- AddForeignKey
+ALTER TABLE "course_users" ADD CONSTRAINT "course_users_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "courses"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "course_users" ADD CONSTRAINT "course_users_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/src/prisma/models/accounts.prisma
+++ b/packages/db/src/prisma/models/accounts.prisma
@@ -17,6 +17,7 @@ model User {
   accounts         Account[]
   members          Member[]
   invitations      Invitation[]
+  courses          CourseUser[]
 
   @@unique([email])
   @@map("users")

--- a/packages/db/src/prisma/models/courses.prisma
+++ b/packages/db/src/prisma/models/courses.prisma
@@ -26,6 +26,7 @@ model Course {
   alternativeTitles CourseAlternativeTitle[]
   categories        CourseCategory[]
   chapters          Chapter[]
+  users             CourseUser[]
 
   @@unique([organizationId, language, slug], name: "orgSlug")
   @@index([organizationId, language, isPublished])
@@ -56,4 +57,18 @@ model CourseCategory {
   @@unique([courseId, category], name: "courseCategory")
   @@index([category])
   @@map("course_categories")
+}
+
+model CourseUser {
+  id        Int      @id @default(autoincrement())
+  courseId  Int      @map("course_id")
+  course    Course   @relation(fields: [courseId], references: [id], onDelete: Cascade)
+  userId    Int      @map("user_id")
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  startedAt DateTime @default(now()) @map("started_at")
+
+  @@unique([courseId, userId], name: "courseUser")
+  @@index([courseId])
+  @@index([userId])
+  @@map("course_users")
 }

--- a/packages/db/src/prisma/seed.ts
+++ b/packages/db/src/prisma/seed.ts
@@ -2,6 +2,7 @@ import { prisma } from "../index";
 import { seedAlternativeTitles } from "./seed/alternative-titles";
 import { seedCategories } from "./seed/categories";
 import { seedChapters } from "./seed/chapters";
+import { seedCourseUsers } from "./seed/course-users";
 import { seedCourses } from "./seed/courses";
 import { seedLessons } from "./seed/lessons";
 import { seedOrganizations } from "./seed/orgs";
@@ -15,6 +16,7 @@ async function main() {
   await seedChapters(prisma, org);
   await seedLessons(prisma, org);
   await seedAlternativeTitles(prisma, org);
+  await seedCourseUsers(prisma, org, users);
 }
 
 main()

--- a/packages/db/src/prisma/seed/course-users.ts
+++ b/packages/db/src/prisma/seed/course-users.ts
@@ -1,0 +1,65 @@
+import type { Organization, PrismaClient } from "../../generated/prisma/client";
+import type { SeedUsers } from "./users";
+
+export async function seedCourseUsers(
+  prisma: PrismaClient,
+  org: Organization,
+  users: SeedUsers,
+): Promise<void> {
+  const courses = await prisma.course.findMany({
+    where: { isPublished: true, organizationId: org.id },
+  });
+
+  if (courses.length === 0) {
+    return;
+  }
+
+  const firstCourse = courses[0];
+  const secondCourse = courses[1];
+
+  if (firstCourse) {
+    await prisma.courseUser.upsert({
+      create: {
+        courseId: firstCourse.id,
+        userId: users.owner.id,
+      },
+      update: {},
+      where: {
+        courseUser: {
+          courseId: firstCourse.id,
+          userId: users.owner.id,
+        },
+      },
+    });
+
+    await prisma.courseUser.upsert({
+      create: {
+        courseId: firstCourse.id,
+        userId: users.member.id,
+      },
+      update: {},
+      where: {
+        courseUser: {
+          courseId: firstCourse.id,
+          userId: users.member.id,
+        },
+      },
+    });
+  }
+
+  if (secondCourse) {
+    await prisma.courseUser.upsert({
+      create: {
+        courseId: secondCourse.id,
+        userId: users.owner.id,
+      },
+      update: {},
+      where: {
+        courseUser: {
+          courseId: secondCourse.id,
+          userId: users.owner.id,
+        },
+      },
+    });
+  }
+}

--- a/packages/testing/src/fixtures/courses.ts
+++ b/packages/testing/src/fixtures/courses.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "node:crypto";
-import { type Course, type CourseCategory, prisma } from "@zoonk/db";
+import {
+  type Course,
+  type CourseCategory,
+  type CourseUser,
+  prisma,
+} from "@zoonk/db";
 
 export function courseAttrs(
   attrs?: Partial<Course>,
@@ -32,4 +37,17 @@ export async function courseCategoryFixture(
     },
   });
   return courseCategory;
+}
+
+export async function courseUserFixture(
+  attrs: Omit<CourseUser, "id" | "startedAt">,
+) {
+  const courseUser = await prisma.courseUser.create({
+    data: {
+      courseId: attrs.courseId,
+      userId: attrs.userId,
+    },
+  });
+
+  return courseUser;
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds server functions to list courses and enroll users. Lists published brand courses by language/category, sorted by popularity, and lets signed-in users join a course.

- **New Features**
  - listCourses(params): returns published brand courses for a language, optional category, limited (default 20), ordered by users count then createdAt; cached via react.cache.
  - addCourseUser(courseId): upserts a CourseUser for the signed-in user; idempotent; returns Unauthorized when not signed in.
  - Error handling: getErrorMessage maps Unauthorized to a localized string; added en/es/pt messages.

- **Migration**
  - Add CourseUser relation (course_users table) and export type in db package.
  - Run Prisma migrate and regenerate the client.
  - Optional: re-seed to populate sample course-user data.

<sup>Written for commit 209d2d1901b4349f4dacd283dc93f5a3aee255bf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

