### PR TITLE
feat(main): add listUserCourses function

### DIFF
--- a/apps/main/src/data/courses/list-user-courses.test.ts
+++ b/apps/main/src/data/courses/list-user-courses.test.ts
@@ -1,0 +1,163 @@
+import { prisma } from "@zoonk/db";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import {
+  courseFixture,
+  courseUserFixture,
+} from "@zoonk/testing/fixtures/courses";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { beforeAll, describe, expect, test } from "vitest";
+import { ErrorCode } from "@/lib/app-error";
+import { listUserCourses } from "./list-user-courses";
+
+describe("unauthenticated users", () => {
+  test("returns Unauthorized", async () => {
+    const result = await listUserCourses({ headers: new Headers() });
+
+    expect(result.error?.message).toBe(ErrorCode.unauthorized);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("authenticated users", () => {
+  let organization: Awaited<ReturnType<typeof organizationFixture>>;
+  let user: Awaited<ReturnType<typeof userFixture>>;
+  let headers: Headers;
+
+  beforeAll(async () => {
+    [organization, user] = await Promise.all([
+      organizationFixture(),
+      userFixture(),
+    ]);
+
+    headers = await signInAs(user.email, user.password);
+  });
+
+  test("returns empty array when user has no courses", async () => {
+    const newUser = await userFixture();
+    const newHeaders = await signInAs(newUser.email, newUser.password);
+
+    const result = await listUserCourses({ headers: newHeaders });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual([]);
+  });
+
+  test("returns courses the user has started", async () => {
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: organization.id,
+    });
+
+    await courseUserFixture({
+      courseId: course.id,
+      userId: Number(user.id),
+    });
+
+    const result = await listUserCourses({ headers });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toBeDefined();
+    expect(result.data?.some((c) => c.id === course.id)).toBe(true);
+  });
+
+  test("orders courses by startedAt descending (most recent first)", async () => {
+    const testUser = await userFixture();
+    const testHeaders = await signInAs(testUser.email, testUser.password);
+
+    const [course1, course2, course3] = await Promise.all([
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    // Create course users with specific timestamps
+    const now = new Date();
+    const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+    const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000);
+
+    await prisma.courseUser.createMany({
+      data: [
+        {
+          courseId: course1.id,
+          startedAt: twoHoursAgo,
+          userId: Number(testUser.id),
+        },
+        {
+          courseId: course2.id,
+          startedAt: now,
+          userId: Number(testUser.id),
+        },
+        {
+          courseId: course3.id,
+          startedAt: oneHourAgo,
+          userId: Number(testUser.id),
+        },
+      ],
+    });
+
+    const result = await listUserCourses({ headers: testHeaders });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toHaveLength(3);
+
+    const courseIds = result.data?.map((c) => c.id);
+    expect(courseIds).toEqual([course2.id, course3.id, course1.id]);
+  });
+
+  test("respects the limit parameter", async () => {
+    const testUser = await userFixture();
+    const testHeaders = await signInAs(testUser.email, testUser.password);
+
+    const courses = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        courseFixture({ isPublished: true, organizationId: organization.id }),
+      ),
+    );
+
+    await Promise.all(
+      courses.map((course) =>
+        courseUserFixture({
+          courseId: course.id,
+          userId: Number(testUser.id),
+        }),
+      ),
+    );
+
+    const result = await listUserCourses({ headers: testHeaders, limit: 3 });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toHaveLength(3);
+  });
+
+  test("does not return other users courses", async () => {
+    const [otherUser, testUser] = await Promise.all([
+      userFixture(),
+      userFixture(),
+    ]);
+
+    const testHeaders = await signInAs(testUser.email, testUser.password);
+
+    const [otherUserCourse, testUserCourse] = await Promise.all([
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    await Promise.all([
+      courseUserFixture({
+        courseId: otherUserCourse.id,
+        userId: Number(otherUser.id),
+      }),
+      courseUserFixture({
+        courseId: testUserCourse.id,
+        userId: Number(testUser.id),
+      }),
+    ]);
+
+    const result = await listUserCourses({ headers: testHeaders });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.some((c) => c.id === testUserCourse.id)).toBe(true);
+    expect(result.data?.some((c) => c.id === otherUserCourse.id)).toBe(false);
+  });
+});

--- a/apps/main/src/data/courses/list-user-courses.ts
+++ b/apps/main/src/data/courses/list-user-courses.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { getSession } from "@zoonk/core/users/session/get";
 import { type Course, prisma } from "@zoonk/db";
 import { clampQueryItems } from "@zoonk/db/utils";
-import { AppError, type SafeReturn } from "@zoonk/utils/error";
+import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 import { ErrorCode } from "@/lib/app-error";
 
@@ -22,14 +22,20 @@ export const listUserCourses = cache(
 
     const userId = Number(session.user.id);
 
-    const courseUsers = await prisma.courseUser.findMany({
-      include: { course: true },
-      orderBy: { startedAt: "desc" },
-      take: clampQueryItems(params?.limit ?? LIST_USER_COURSES_LIMIT),
-      where: { userId },
-    });
+    const { data, error } = await safeAsync(() =>
+      prisma.courseUser.findMany({
+        include: { course: true },
+        orderBy: { startedAt: "desc" },
+        take: clampQueryItems(params?.limit ?? LIST_USER_COURSES_LIMIT),
+        where: { userId },
+      }),
+    );
 
-    const courses = courseUsers.map((cu) => cu.course);
+    if (error) {
+      return { data: null, error };
+    }
+
+    const courses = data.map((cu) => cu.course);
 
     return { data: courses, error: null };
   },

--- a/apps/main/src/data/courses/list-user-courses.ts
+++ b/apps/main/src/data/courses/list-user-courses.ts
@@ -1,0 +1,36 @@
+import "server-only";
+
+import { getSession } from "@zoonk/core/users/session/get";
+import { type Course, prisma } from "@zoonk/db";
+import { clampQueryItems } from "@zoonk/db/utils";
+import { AppError, type SafeReturn } from "@zoonk/utils/error";
+import { cache } from "react";
+import { ErrorCode } from "@/lib/app-error";
+
+const LIST_USER_COURSES_LIMIT = 20;
+
+export const listUserCourses = cache(
+  async (params?: {
+    headers?: Headers;
+    limit?: number;
+  }): Promise<SafeReturn<Course[]>> => {
+    const session = await getSession({ headers: params?.headers });
+
+    if (!session) {
+      return { data: null, error: new AppError(ErrorCode.unauthorized) };
+    }
+
+    const userId = Number(session.user.id);
+
+    const courseUsers = await prisma.courseUser.findMany({
+      include: { course: true },
+      orderBy: { startedAt: "desc" },
+      take: clampQueryItems(params?.limit ?? LIST_USER_COURSES_LIMIT),
+      where: { userId },
+    });
+
+    const courses = courseUsers.map((cu) => cu.course);
+
+    return { data: courses, error: null };
+  },
+);


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add listUserCourses to fetch the signed-in user’s started courses with consistent ordering and simple pagination. Returns Unauthorized for anonymous requests and caches results.

- **New Features**
  - Returns only the authenticated user’s courses, ordered by startedAt (most recent first).
  - Supports a limit parameter (default 20, clamped).
  - Cached via React cache and uses session from headers; returns Unauthorized if missing.
  - Tests cover unauthorized, empty state, ordering, limit, and user scoping.

<sup>Written for commit 2f4330c68817eb96e3cd659db4837720e0c0428d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



