### PR TITLE
feat(editor): add chapter and lessons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,7 @@ All packages should follow a consistent structure:
 
 ## Conventions
 
+- **Never pass functions to Client Components** unless they are Server Actions (marked with `"use server"`). Regular functions like `getHref` or callbacks cannot be serialized. Instead, pass serializable data (strings, numbers, objects) and construct values in the client component. For example, pass `hrefPrefix: string` instead of `getHref: (item) => string`
 - When there are **formatting issues**, run `pnpm format` to auto-fix them
 - When there are **linting issues**, run `pnpm lint --write --unsafe` to auto-fix them
 - Run `pnpm typecheck` to check for TypeScript errors
@@ -190,6 +191,21 @@ For example:
 ```
 
 Avoid using `use cache` by default unless we know the page can be static. Plus, you can't use `use cache` with `searchParams`, `cookies()`, or `headers()`.
+
+### Invalidating Client Router Cache with staleTimes
+
+When using `staleTimes` (experimental feature for client-side route caching), mutations that create/update/delete data need to call `revalidatePath()` before redirecting. Otherwise, navigating back to the parent page will show stale cached data.
+
+```tsx
+async function handleCreate() {
+  "use server";
+  const { slug } = await createItem(...);
+
+  // Invalidate the parent page's client cache before redirecting
+  revalidatePath(`/${orgSlug}/items`);
+  redirect(`/${orgSlug}/items/${slug}`);
+}
+```
 
 ### Preloading Data in Parallel
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ All packages should follow a consistent structure:
 
 ## Conventions
 
+- **Never pass functions to Client Components** unless they are Server Actions (marked with `"use server"`). Regular functions like `getHref` or callbacks cannot be serialized. Instead, pass serializable data (strings, numbers, objects) and construct values in the client component. For example, pass `hrefPrefix: string` instead of `getHref: (item) => string`
 - When there are **formatting issues**, run `pnpm format` to auto-fix them
 - When there are **linting issues**, run `pnpm lint --write --unsafe` to auto-fix them
 - Run `pnpm typecheck` to check for TypeScript errors
@@ -190,6 +191,21 @@ For example:
 ```
 
 Avoid using `use cache` by default unless we know the page can be static. Plus, you can't use `use cache` with `searchParams`, `cookies()`, or `headers()`.
+
+### Invalidating Client Router Cache with staleTimes
+
+When using `staleTimes` (experimental feature for client-side route caching), mutations that create/update/delete data need to call `revalidatePath()` before redirecting. Otherwise, navigating back to the parent page will show stale cached data.
+
+```tsx
+async function handleCreate() {
+  "use server";
+  const { slug } = await createItem(...);
+
+  // Invalidate the parent page's client cache before redirecting
+  revalidatePath(`/${orgSlug}/items`);
+  redirect(`/${orgSlug}/items/${slug}`);
+}
+```
 
 ### Preloading Data in Parallel
 

--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -76,6 +76,22 @@ msgctxt "ZFXb/x"
 msgid "Delete course?"
 msgstr "Delete course?"
 
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "BAkmPD"
+msgid "Untitled chapter"
+msgstr "Untitled chapter"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
+msgctxt "sGJpuF"
+msgid "Add a description…"
+msgstr "Add a description…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
+msgctxt "oUJv8w"
+msgid "Untitled lesson"
+msgstr "Untitled lesson"
+
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgctxt "AHvdBa"
 msgid "Edit lesson description"
@@ -134,6 +150,11 @@ msgid "Chapter description…"
 msgstr "Chapter description…"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
+msgctxt "RWzfUY"
+msgid "Add lesson"
+msgstr "Add lesson"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
 msgctxt "yNvug5"
 msgid "Chapter title…"
 msgstr "Chapter title…"
@@ -142,6 +163,11 @@ msgstr "Chapter title…"
 msgctxt "2Pphvx"
 msgid "Course title…"
 msgstr "Course title…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
+msgctxt "dlQpGl"
+msgid "Add chapter"
+msgstr "Add chapter"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
 msgctxt "Ek5KLE"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -76,6 +76,22 @@ msgctxt "ZFXb/x"
 msgid "Delete course?"
 msgstr "¿Eliminar curso?"
 
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "BAkmPD"
+msgid "Untitled chapter"
+msgstr "Capítulo sin título"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
+msgctxt "sGJpuF"
+msgid "Add a description…"
+msgstr "Agrega una descripción…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
+msgctxt "oUJv8w"
+msgid "Untitled lesson"
+msgstr "Lección sin título"
+
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgctxt "AHvdBa"
 msgid "Edit lesson description"
@@ -134,6 +150,11 @@ msgid "Chapter description…"
 msgstr "Descripción del capítulo…"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
+msgctxt "RWzfUY"
+msgid "Add lesson"
+msgstr "Agregar lección"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
 msgctxt "yNvug5"
 msgid "Chapter title…"
 msgstr "Título del capítulo…"
@@ -142,6 +163,11 @@ msgstr "Título del capítulo…"
 msgctxt "2Pphvx"
 msgid "Course title…"
 msgstr "Título del curso…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
+msgctxt "dlQpGl"
+msgid "Add chapter"
+msgstr "Agregar capítulo"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
 msgctxt "Ek5KLE"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -76,6 +76,22 @@ msgctxt "ZFXb/x"
 msgid "Delete course?"
 msgstr "Excluir curso?"
 
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "BAkmPD"
+msgid "Untitled chapter"
+msgstr "Capítulo sem título"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
+msgctxt "sGJpuF"
+msgid "Add a description…"
+msgstr "Adicione uma descrição…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
+msgctxt "oUJv8w"
+msgid "Untitled lesson"
+msgstr "Aula sem título"
+
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgctxt "AHvdBa"
 msgid "Edit lesson description"
@@ -134,6 +150,11 @@ msgid "Chapter description…"
 msgstr "Descrição do capítulo…"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
+msgctxt "RWzfUY"
+msgid "Add lesson"
+msgstr "Adicionar aula"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
 msgctxt "yNvug5"
 msgid "Chapter title…"
 msgstr "Título do capítulo…"
@@ -142,6 +163,11 @@ msgstr "Título do capítulo…"
 msgctxt "2Pphvx"
 msgid "Course title…"
 msgstr "Título do curso…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
+msgctxt "dlQpGl"
+msgid "Add chapter"
+msgstr "Adicionar capítulo"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
 msgctxt "Ek5KLE"

--- a/apps/editor/src/app/[orgSlug]/_components/insert-line.tsx
+++ b/apps/editor/src/app/[orgSlug]/_components/insert-line.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { PlusIcon } from "lucide-react";
+
+export function InsertLine({
+  onInsert,
+  pending,
+}: {
+  onInsert: () => void;
+  pending?: boolean;
+}) {
+  return (
+    <div className="group relative h-0">
+      <div className="absolute inset-x-4 -top-px z-10 flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100">
+        <div className="h-px flex-1 bg-primary/30" />
+
+        <button
+          className="flex size-5 items-center justify-center rounded-full bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          disabled={pending}
+          onClick={onInsert}
+          type="button"
+        >
+          <PlusIcon className="size-3" />
+        </button>
+
+        <div className="h-px flex-1 bg-primary/30" />
+      </div>
+    </div>
+  );
+}

--- a/apps/editor/src/app/[orgSlug]/_components/item-list-editable.tsx
+++ b/apps/editor/src/app/[orgSlug]/_components/item-list-editable.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Button } from "@zoonk/ui/components/button";
+import { LoaderCircleIcon, PlusIcon } from "lucide-react";
+import type { Route } from "next";
+import Link from "next/link";
+import { useTransition } from "react";
+import { InsertLine } from "./insert-line";
+
+type ItemListItem = {
+  slug: string;
+  title: string;
+  description: string;
+  position: number;
+};
+
+type ItemListEditableProps = {
+  addLabel: string;
+  hrefPrefix: string;
+  items: ItemListItem[];
+  onInsert: (position: number) => Promise<void>;
+};
+
+export function ItemListEditable({
+  addLabel,
+  hrefPrefix,
+  items,
+  onInsert,
+}: ItemListEditableProps) {
+  const [pending, startTransition] = useTransition();
+
+  function handleInsert(position: number) {
+    startTransition(async () => {
+      await onInsert(position);
+    });
+  }
+
+  const lastItem = items.at(-1);
+  const endPosition = lastItem ? lastItem.position + 1 : 0;
+
+  return (
+    <div className="relative">
+      {pending && (
+        <div className="absolute inset-0 z-20 flex items-center justify-center bg-background/60">
+          <LoaderCircleIcon className="size-5 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      <div className="flex items-center justify-end px-4 pb-2">
+        <Button
+          disabled={pending}
+          onClick={() => handleInsert(endPosition)}
+          size="sm"
+          variant="outline"
+        >
+          <PlusIcon />
+          {addLabel}
+        </Button>
+      </div>
+
+      {items.length > 0 && (
+        <ul>
+          <InsertLine onInsert={() => handleInsert(0)} pending={pending} />
+
+          {items.map((item) => (
+            <li key={item.slug}>
+              <Link
+                className="flex items-start gap-4 px-4 py-3 transition-colors hover:bg-muted/50"
+                href={`${hrefPrefix}${item.slug}` as Route}
+              >
+                <span className="mt-0.5 font-mono text-muted-foreground text-sm tabular-nums">
+                  {String(item.position).padStart(2, "0")}
+                </span>
+
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-medium">{item.title}</p>
+
+                  {item.description && (
+                    <p className="mt-0.5 line-clamp-2 text-muted-foreground text-sm">
+                      {item.description}
+                    </p>
+                  )}
+                </div>
+              </Link>
+
+              <InsertLine
+                onInsert={() => handleInsert(item.position + 1)}
+                pending={pending}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/editor/src/app/[orgSlug]/_components/item-list-editable.tsx
+++ b/apps/editor/src/app/[orgSlug]/_components/item-list-editable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@zoonk/ui/components/button";
+import { toast } from "@zoonk/ui/components/sonner";
 import { LoaderCircleIcon, PlusIcon } from "lucide-react";
 import type { Route } from "next";
 import Link from "next/link";
@@ -31,7 +32,12 @@ export function ItemListEditable({
 
   function handleInsert(position: number) {
     startTransition(async () => {
-      await onInsert(position);
+      try {
+        await onInsert(position);
+      } catch (error) {
+        console.error(`Failed to insert item at position ${position}:`, error);
+        toast.error(error instanceof Error ? error.message : String(error));
+      }
     });
   }
 

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -121,7 +121,11 @@ async function LessonList({ params }: { params: ChapterPageProps["params"] }) {
       position,
     );
 
-    if (!createError && slug) {
+    if (createError) {
+      throw new Error(createError);
+    }
+
+    if (slug) {
       revalidatePath(`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}`);
       redirect(
         `/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/${slug}`,

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -1,7 +1,8 @@
 import { Container } from "@zoonk/ui/components/container";
 import { ErrorView } from "@zoonk/ui/patterns/error";
 import { SUPPORT_URL } from "@zoonk/utils/constants";
-import { notFound } from "next/navigation";
+import { revalidatePath } from "next/cache";
+import { notFound, redirect } from "next/navigation";
 import { getExtracted } from "next-intl/server";
 import { Suspense } from "react";
 import {
@@ -10,7 +11,7 @@ import {
 } from "@/app/[orgSlug]/_components/back-link";
 import { ContentEditor } from "@/app/[orgSlug]/_components/content-editor";
 import { ContentEditorSkeleton } from "@/app/[orgSlug]/_components/content-editor-skeleton";
-import { ItemList } from "@/app/[orgSlug]/_components/item-list";
+import { ItemListEditable } from "@/app/[orgSlug]/_components/item-list-editable";
 import { ItemListSkeleton } from "@/app/[orgSlug]/_components/item-list-skeleton";
 import { SlugEditor } from "@/app/[orgSlug]/_components/slug-editor";
 import { SlugEditorSkeleton } from "@/app/[orgSlug]/_components/slug-editor-skeleton";
@@ -19,6 +20,7 @@ import { getCourse } from "@/data/courses/get-course";
 import { listChapterLessons } from "@/data/lessons/list-chapter-lessons";
 import {
   checkChapterSlugExists,
+  createLessonAction,
   updateChapterDescriptionAction,
   updateChapterSlugAction,
   updateChapterTitleAction,
@@ -91,12 +93,12 @@ async function LessonList({ params }: { params: ChapterPageProps["params"] }) {
   const { chapterSlug, courseSlug, lang, orgSlug } = await params;
   const t = await getExtracted();
 
-  const { data: lessons, error } = await listChapterLessons({
-    chapterSlug,
-    orgSlug,
-  });
+  const [{ data: lessons, error }, { data: chapter }] = await Promise.all([
+    listChapterLessons({ chapterSlug, orgSlug }),
+    getChapter({ chapterSlug, language: lang, orgSlug }),
+  ]);
 
-  if (error) {
+  if (error || !chapter) {
     return (
       <ErrorView
         description={t("We couldn't load the lessons. Please try again.")}
@@ -108,12 +110,31 @@ async function LessonList({ params }: { params: ChapterPageProps["params"] }) {
     );
   }
 
+  const chapterId = chapter.id;
+
+  async function handleInsert(position: number) {
+    "use server";
+    const { slug, error: createError } = await createLessonAction(
+      chapterSlug,
+      courseSlug,
+      chapterId,
+      position,
+    );
+
+    if (!createError && slug) {
+      revalidatePath(`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}`);
+      redirect(
+        `/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/${slug}`,
+      );
+    }
+  }
+
   return (
-    <ItemList
-      getHref={(item) =>
-        `/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/${item.slug}`
-      }
+    <ItemListEditable
+      addLabel={t("Add lesson")}
+      hrefPrefix={`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/`}
       items={lessons}
+      onInsert={handleInsert}
     />
   );
 }

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
@@ -89,7 +89,11 @@ async function ChapterList({
       position,
     );
 
-    if (!createError && slug) {
+    if (createError) {
+      throw new Error(createError);
+    }
+
+    if (slug) {
       revalidatePath(`/${orgSlug}/c/${lang}/${courseSlug}`);
       redirect(`/${orgSlug}/c/${lang}/${courseSlug}/ch/${slug}`);
     }

--- a/i18n.lock
+++ b/i18n.lock
@@ -15,6 +15,9 @@ checksums:
     Delete%20chapter%3F/singular: 5dfc389e36ee2f05e01896b81bd59493
     Delete%20course/singular: 86bac6527eb0b380a3f0a5e38b6938ff
     Delete%20course%3F/singular: c83369b40aec2a0eb3cafd146d70020e
+    Untitled%20chapter/singular: 28963b46f393d2828ea31c00345d2a2e
+    Add%20a%20description%E2%80%A6/singular: 6737ac865733a3e459ddfeb5b6134ce5
+    Untitled%20lesson/singular: 252aefbc39883b5a3aae879535b0c6d2
     Edit%20lesson%20description/singular: b959f1e2fc7f00f593ae2c1a12fd330d
     Lesson%20description%E2%80%A6/singular: 77ad5a9829eda8182865a46455d5a842
     Lesson%20title%E2%80%A6/singular: d7b981d2734c11f2ee5d58f21c93bd3e
@@ -26,8 +29,10 @@ checksums:
     Try%20again/singular: 33dd8820e743e35a66e6977f69e9d3b5
     Edit%20chapter%20title/singular: 21c04bd3ed6335df5195d1f2857131bf
     Chapter%20description%E2%80%A6/singular: d394513f90a5c9ad1880d364e8fc5cb8
+    Add%20lesson/singular: 101a1880b35c68eed6f80e7574f4ff2d
     Chapter%20title%E2%80%A6/singular: 3ed70a2e64aefe189999ff5899e8a7a2
     Course%20title%E2%80%A6/singular: 4429de50f5f2d426271e76328c543daf
+    Add%20chapter/singular: af2ea03f1678fcea1fb005f66f28bfa5
     Edit%20course%20description/singular: 2304f3ceeea1faaa3a4451c8863ded3b
     Edit%20course%20title/singular: 75b050a3ce516d55c480d633f5da502f
     Course%20description%E2%80%A6/singular: a548f00ce745044f2a2dfbe02b9a0130


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add inline creation of chapters and lessons in the editor lists. You can insert at any position and get redirected to the new item, with client cache revalidated to prevent stale data.

- **New Features**
  - Editable list UI (ItemListEditable) with InsertLine and “Add chapter/lesson” buttons.
  - Server actions to create chapters/lessons; uses revalidatePath and redirect to keep lists fresh.
  - i18n: added “Untitled chapter/lesson”, “Add a description…”, and “Add chapter/lesson” in en/es/pt.

- **Refactors**
  - Replaced ItemList with ItemListEditable on course and chapter pages; pass hrefPrefix instead of functions to client components.
  - Fetch parent entity and items in parallel for IDs; improved error handling.
  - Docs: guidance on not passing functions to client components and on invalidating client router cache when using staleTimes.

<sup>Written for commit e33881850d04b4ff1d6ee9d6456c6080668d9f83. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



