### PR TITLE
feat(main): add course search to command palette

### DIFF
--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -354,11 +354,6 @@ msgid "Lessons"
 msgstr "Lessons"
 
 #: src/components/navbar/command-palette.tsx
-msgctxt "NNQzoi"
-msgid "Searching..."
-msgstr "Searching..."
-
-#: src/components/navbar/command-palette.tsx
 msgctxt "qlTe+e"
 msgid "new"
 msgstr "new"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -354,11 +354,6 @@ msgid "Lessons"
 msgstr "Lecciones"
 
 #: src/components/navbar/command-palette.tsx
-msgctxt "NNQzoi"
-msgid "Searching..."
-msgstr "Buscando..."
-
-#: src/components/navbar/command-palette.tsx
 msgctxt "qlTe+e"
 msgid "new"
 msgstr "nuevo"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -354,11 +354,6 @@ msgid "Lessons"
 msgstr "Aulas"
 
 #: src/components/navbar/command-palette.tsx
-msgctxt "NNQzoi"
-msgid "Searching..."
-msgstr "Buscando..."
-
-#: src/components/navbar/command-palette.tsx
 msgctxt "qlTe+e"
 msgid "new"
 msgstr "novo"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -6,11 +6,6 @@ msgstr ""
 "X-Generator: next-intl\n"
 
 #: src/app/[locale]/(catalog)/_components/command-palette.tsx
-msgctxt "/aBLH2"
-msgid "Get started"
-msgstr "Get started"
-
-#: src/app/[locale]/(catalog)/_components/command-palette.tsx
 #: src/app/[locale]/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/[locale]/(settings)/_components/protected-section.tsx
 msgctxt "AyGauy"
@@ -23,6 +18,11 @@ msgstr "Login"
 msgctxt "C81/uG"
 msgid "Logout"
 msgstr "Logout"
+
+#: src/app/[locale]/(catalog)/_components/command-palette.tsx
+msgctxt "CxfKLC"
+msgid "Pages"
+msgstr "Pages"
 
 #: src/app/[locale]/(catalog)/_components/command-palette.tsx
 msgctxt "dXSivY"
@@ -411,6 +411,16 @@ msgstr "Follow us"
 msgctxt "YdQxfw"
 msgid "Contact Support"
 msgstr "Contact Support"
+
+#: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/page.tsx
+msgctxt "oCQePC"
+msgid "Learn with interactive lessons and activities. Explore this course and start your learning journey."
+msgstr "Learn with interactive lessons and activities. Explore this course and start your learning journey."
+
+#: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/page.tsx
+msgctxt "onDfe/"
+msgid "Course"
+msgstr "Course"
 
 #: src/app/[locale]/privacy/page.tsx
 msgctxt "iql85X"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -6,11 +6,6 @@ msgstr ""
 "X-Generator: next-intl\n"
 
 #: src/app/[locale]/(catalog)/_components/command-palette.tsx
-msgctxt "/aBLH2"
-msgid "Get started"
-msgstr "Comenzar"
-
-#: src/app/[locale]/(catalog)/_components/command-palette.tsx
 #: src/app/[locale]/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/[locale]/(settings)/_components/protected-section.tsx
 msgctxt "AyGauy"
@@ -23,6 +18,11 @@ msgstr "Iniciar sesión"
 msgctxt "C81/uG"
 msgid "Logout"
 msgstr "Cerrar sesión"
+
+#: src/app/[locale]/(catalog)/_components/command-palette.tsx
+msgctxt "CxfKLC"
+msgid "Pages"
+msgstr "Páginas"
 
 #: src/app/[locale]/(catalog)/_components/command-palette.tsx
 msgctxt "dXSivY"
@@ -411,6 +411,16 @@ msgstr "Síguenos"
 msgctxt "YdQxfw"
 msgid "Contact Support"
 msgstr "Contactar soporte"
+
+#: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/page.tsx
+msgctxt "oCQePC"
+msgid "Learn with interactive lessons and activities. Explore this course and start your learning journey."
+msgstr "Aprende con lecciones y actividades interactivas. Explora este curso y comienza tu viaje de aprendizaje."
+
+#: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/page.tsx
+msgctxt "onDfe/"
+msgid "Course"
+msgstr "Curso"
 
 #: src/app/[locale]/privacy/page.tsx
 msgctxt "iql85X"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -6,11 +6,6 @@ msgstr ""
 "X-Generator: next-intl\n"
 
 #: src/app/[locale]/(catalog)/_components/command-palette.tsx
-msgctxt "/aBLH2"
-msgid "Get started"
-msgstr "Começar"
-
-#: src/app/[locale]/(catalog)/_components/command-palette.tsx
 #: src/app/[locale]/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/[locale]/(settings)/_components/protected-section.tsx
 msgctxt "AyGauy"
@@ -23,6 +18,11 @@ msgstr "Entrar"
 msgctxt "C81/uG"
 msgid "Logout"
 msgstr "Sair"
+
+#: src/app/[locale]/(catalog)/_components/command-palette.tsx
+msgctxt "CxfKLC"
+msgid "Pages"
+msgstr "Páginas"
 
 #: src/app/[locale]/(catalog)/_components/command-palette.tsx
 msgctxt "dXSivY"
@@ -411,6 +411,16 @@ msgstr "Siga-nos"
 msgctxt "YdQxfw"
 msgid "Contact Support"
 msgstr "Contatar suporte"
+
+#: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/page.tsx
+msgctxt "oCQePC"
+msgid "Learn with interactive lessons and activities. Explore this course and start your learning journey."
+msgstr "Aprenda com aulas e atividades interativas. Explore este curso e comece sua jornada de aprendizado."
+
+#: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/page.tsx
+msgctxt "onDfe/"
+msgid "Course"
+msgstr "Curso"
 
 #: src/app/[locale]/privacy/page.tsx
 msgctxt "iql85X"

--- a/apps/main/src/app/[locale]/(catalog)/_components/search-courses-action.ts
+++ b/apps/main/src/app/[locale]/(catalog)/_components/search-courses-action.ts
@@ -1,0 +1,28 @@
+"use server";
+
+import { searchCourses } from "@/data/courses/search-courses";
+
+export type CourseSearchResult = {
+  id: number;
+  title: string;
+  description: string;
+  slug: string;
+  imageUrl: string | null;
+  brandSlug: string;
+};
+
+export async function searchCoursesAction(params: {
+  query: string;
+  language: string;
+}): Promise<CourseSearchResult[]> {
+  const courses = await searchCourses(params);
+
+  return courses.map((course) => ({
+    brandSlug: course.organization.slug,
+    description: course.description,
+    id: course.id,
+    imageUrl: course.imageUrl,
+    slug: course.slug,
+    title: course.title,
+  }));
+}

--- a/apps/main/src/app/[locale]/b/[brandSlug]/c/[courseSlug]/page.tsx
+++ b/apps/main/src/app/[locale]/b/[brandSlug]/c/[courseSlug]/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { getExtracted } from "next-intl/server";
+
+type CoursePageParams = {
+  params: Promise<{
+    locale: string;
+    brandSlug: string;
+    courseSlug: string;
+  }>;
+};
+
+export async function generateMetadata({
+  params,
+}: CoursePageParams): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getExtracted({ locale });
+
+  return {
+    description: t(
+      "Learn with interactive lessons and activities. Explore this course and start your learning journey.",
+    ),
+    title: t("Course"),
+  };
+}
+
+export default async function CoursePage() {
+  return <main>{}</main>;
+}

--- a/apps/main/src/data/courses/search-courses.ts
+++ b/apps/main/src/data/courses/search-courses.ts
@@ -1,13 +1,20 @@
 import "server-only";
 
-import { type Course, prisma } from "@zoonk/db";
+import { type Course, type Organization, prisma } from "@zoonk/db";
 import { normalizeString } from "@zoonk/utils/string";
 import { cache } from "react";
 
 const SEARCH_COURSES_LIMIT = 50;
 
+export type CourseWithOrganization = Course & {
+  organization: Organization;
+};
+
 export const searchCourses = cache(
-  async (params: { query: string; language: string }): Promise<Course[]> => {
+  async (params: {
+    query: string;
+    language: string;
+  }): Promise<CourseWithOrganization[]> => {
     const normalizedSearch = normalizeString(params.query);
 
     if (!normalizedSearch) {
@@ -15,6 +22,7 @@ export const searchCourses = cache(
     }
 
     const courses = await prisma.course.findMany({
+      include: { organization: true },
       orderBy: { createdAt: "desc" },
       take: SEARCH_COURSES_LIMIT,
       where: {

--- a/i18n.lock
+++ b/i18n.lock
@@ -119,9 +119,9 @@ checksums:
     Invalid%20JSON%20format.%20Please%20check%20your%20file/singular: 2a890d833f49aa36f02433476ca33468
     Organization%20not%20found/singular: 4cb8c07ec2c599b6f48750e06ffa182b
   9270df1bc9e10fdb8026bb4ab67061d4:
-    Get%20started/singular: 5c783951b0100a168bdd2161ff294833
     Login/singular: f4f219abeb5a465ecb1c7efaf50246de
     Logout/singular: 07948fdf20705e04a7bf68ab197512bf
+    Pages/singular: 75088c94fb3c374efd452624d4b74be8
     My%20account/singular: 4791806fd9fadc33912e3df7e4e3911c
     Update%20display%20name/singular: eb9878176a51d19451553ed035114e88
     Help%20and%20support/singular: 19383599a92f1b191066d7f29588d72f
@@ -196,6 +196,8 @@ checksums:
     Email%20us%20at%20hello%40zoonk.com/singular: f30da451e0bc14b7463bde402c876af9
     Follow%20us/singular: 778f7a4744f77dbcbd31a8c778cb5209
     Contact%20Support/singular: fcbd9e317c7286b3e08752eb73eb1a81
+    Learn%20with%20interactive%20lessons%20and%20activities.%20Explore%20this%20course%20and%20start%20your%20learning%20journey./singular: 7a3e7eaf93f01f45aa4e11cec5b89cce
+    Course/singular: e85604e8dd47d3ce09440554127079fe
     Read%20Zoonk's%20privacy%20policy%20to%20understand%20how%20we%20collect%2C%20use%2C%20and%20protect%20your%20personal%20information./singular: 044f3586abe7d9915820a6629cef08e4
     Privacy%20Policy/singular: 7459744a63ef8af4e517a09024bd7c08
     Read%20Zoonk's%20terms%20of%20use%20to%20understand%20the%20rules%20and%20conditions%20for%20using%20our%20platform%20and%20services/singular: 4b82898d60691839a1999e4a17199895

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,6 +33,7 @@
     "./globals.css": "./src/styles/globals.css",
     "./hooks/auto-save": "./src/hooks/use-auto-save.ts",
     "./hooks/clipboard": "./src/hooks/use-clipboard.ts",
+    "./hooks/command-palette-search": "./src/hooks/use-command-palette-search.ts",
     "./hooks/debounce": "./src/hooks/use-debounce.ts",
     "./hooks/keyboard": "./src/hooks/use-keyboard.ts",
     "./hooks/mobile": "./src/hooks/use-mobile.ts",

--- a/packages/ui/src/hooks/use-command-palette-search.ts
+++ b/packages/ui/src/hooks/use-command-palette-search.ts
@@ -1,0 +1,101 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { useKeyboardCallback } from "./use-keyboard";
+
+type UseCommandPaletteSearchOptions<TResults> = {
+  emptyResults: TResults;
+  minQueryLength?: number;
+  onSearch: (query: string) => Promise<TResults>;
+};
+
+type UseCommandPaletteSearchReturn<TResults> = {
+  closePalette: () => void;
+  isOpen: boolean;
+  isPending: boolean;
+  onSelectItem: () => void;
+  open: () => void;
+  query: string;
+  results: TResults;
+  setQuery: (query: string) => void;
+  toggle: () => void;
+};
+
+/**
+ * A hook that handles common command palette search logic:
+ * - Open/close state with Cmd+K keyboard shortcut
+ * - Query state with controlled input
+ * - Search with useTransition and race condition handling
+ * - Minimum query length before searching
+ * - Reset on close
+ */
+export function useCommandPaletteSearch<TResults>(
+  options: UseCommandPaletteSearchOptions<TResults>,
+): UseCommandPaletteSearchReturn<TResults> {
+  const { emptyResults, minQueryLength = 2, onSearch } = options;
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<TResults>(emptyResults);
+  const [isPending, startTransition] = useTransition();
+  const requestIdRef = useRef(0);
+
+  useKeyboardCallback("k", () => setIsOpen((prev) => !prev), {
+    mode: "any",
+    modifiers: { ctrlKey: true, metaKey: true },
+  });
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const toggle = useCallback(() => setIsOpen((prev) => !prev), []);
+
+  const closePalette = useCallback(() => {
+    setIsOpen(false);
+    setQuery("");
+    setResults(emptyResults);
+  }, [emptyResults]);
+
+  const onSelectItem = useCallback(() => {
+    closePalette();
+  }, [closePalette]);
+
+  // Search effect with race condition handling
+  useEffect(() => {
+    const trimmedQuery = query.trim();
+
+    // Clear results if query is too short
+    if (trimmedQuery.length < minQueryLength) {
+      setResults(emptyResults);
+      return;
+    }
+
+    // Increment request ID to handle race conditions
+    const currentRequestId = ++requestIdRef.current;
+
+    startTransition(async () => {
+      try {
+        const data = await onSearch(trimmedQuery);
+
+        // Only update if this is still the latest request
+        if (currentRequestId === requestIdRef.current) {
+          setResults(data);
+        }
+      } catch {
+        if (currentRequestId === requestIdRef.current) {
+          setResults(emptyResults);
+        }
+      }
+    });
+  }, [query, minQueryLength, onSearch, emptyResults]);
+
+  return {
+    closePalette,
+    isOpen,
+    isPending,
+    onSelectItem,
+    open,
+    query,
+    results,
+    setQuery,
+    toggle,
+  };
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds course search to the main command palette so users can find and open courses directly. Introduces a shared search hook and updates routing and i18n to support course results.

- **New Features**
  - Search courses in the command palette.
  - Shows results with image, title, and description; opens the course page.
  - Added /b/[brandSlug]/c/[courseSlug] route for course targets.

- **Refactors**
  - New useCommandPaletteSearch hook (Cmd+K toggle, async search, race-safe, min query length).
  - Main and Editor palettes now use the hook; removed loading spinners/skeletons.
  - Updated i18n (renamed section to “Pages”; removed “Searching...” strings).

<sup>Written for commit 57fa9bad27e8e9bcaf11c39353adf282dfbbf41d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

