### PR TITLE
fix(editor): revalidate paths on deletion

### DIFF
--- a/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidateMainApp } from "@zoonk/core/cache/revalidate";
 import { cacheTagCourse, cacheTagOrgCourses } from "@zoonk/utils/cache";
+import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { after } from "next/server";
 import { deleteCourse } from "@/data/courses/delete-course";
@@ -47,5 +48,6 @@ export async function deleteCourseAction(
     await revalidateMainApp([courseTag, orgCoursesTag]);
   });
 
+  revalidatePath(`/${orgSlug}`);
   redirect(`/${orgSlug}`);
 }

--- a/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
@@ -3,6 +3,7 @@
 import { revalidateMainApp } from "@zoonk/core/cache/revalidate";
 import { cacheTagChapter, cacheTagCourse } from "@zoonk/utils/cache";
 import type { Route } from "next";
+import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { after } from "next/server";
 import { deleteChapter } from "@/data/chapters/delete-chapter";
@@ -53,5 +54,6 @@ export async function deleteChapterAction(
     ]);
   });
 
+  revalidatePath(courseUrl);
   redirect(courseUrl);
 }

--- a/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/actions.ts
@@ -7,6 +7,7 @@ import {
   cacheTagLesson,
 } from "@zoonk/utils/cache";
 import type { Route } from "next";
+import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { after } from "next/server";
 import { deleteLesson } from "@/data/lessons/delete-lesson";
@@ -57,5 +58,6 @@ export async function deleteLessonAction(
     ]);
   });
 
+  revalidatePath(chapterUrl);
   redirect(chapterUrl);
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Revalidates pages after deleting a course, chapter, or lesson so users don’t see stale content when redirected. Adds revalidatePath calls for org, course, and chapter pages.

- **Bug Fixes**
  - Course deletion: revalidatePath(`/${orgSlug}`) before redirect.
  - Chapter deletion: revalidatePath(courseUrl) before redirect.
  - Lesson deletion: revalidatePath(chapterUrl) before redirect.

<sup>Written for commit fed4de837e8d5e35794f60dc1bcbd24ea444e9b1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

