### PR TITLE
feat(editor): add drag-and-drop sorting for chapters and lessons

### DIFF
--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -115,6 +115,12 @@ msgstr "Failed to load lessons"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "aJ/bsX"
+msgid "Drag to reorder"
+msgstr "Drag to reorder"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "FazwRl"
 msgid "Try again"
 msgstr "Try again"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -115,6 +115,12 @@ msgstr "Error al cargar lecciones"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "aJ/bsX"
+msgid "Drag to reorder"
+msgstr "Arrastra para reordenar"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "FazwRl"
 msgid "Try again"
 msgstr "Intentar de nuevo"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -115,6 +115,12 @@ msgstr "Falha ao carregar aulas"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "aJ/bsX"
+msgid "Drag to reorder"
+msgstr "Arraste para reordenar"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "FazwRl"
 msgid "Try again"
 msgstr "Tentar novamente"

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
+    "@dnd-kit/core": "6.3.1",
+    "@dnd-kit/sortable": "10.0.0",
+    "@dnd-kit/utilities": "3.2.2",
     "@formatjs/intl-localematcher": "0.7.3",
     "@zoonk/core": "workspace:*",
     "@zoonk/db": "workspace:*",

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { getExtracted } from "next-intl/server";
 import { Fragment } from "react";
 import {
+  EditorDragHandle,
   EditorListAddButton,
   EditorListContent,
   EditorListHeader,
@@ -15,6 +16,9 @@ import {
   EditorListItemTitle,
   EditorListProvider,
   EditorListSpinner,
+  EditorSortableItem,
+  EditorSortableItemRow,
+  EditorSortableList,
 } from "@/components/editor-list";
 import { EntityListActions } from "@/components/entity-list-actions";
 import { getChapter } from "@/data/chapters/get-chapter";
@@ -23,6 +27,7 @@ import {
   exportLessonsAction,
   handleImportLessonsAction,
   insertLessonAction,
+  reorderLessonsAction,
 } from "./actions";
 
 type ChapterPageProps =
@@ -77,36 +82,47 @@ export async function LessonList({
       </EditorListHeader>
 
       {lessons.length > 0 && (
-        <EditorListContent>
-          <EditorListInsertLine position={0} />
+        <EditorSortableList
+          items={lessons}
+          onReorder={reorderLessonsAction.bind(null, routeParams)}
+        >
+          <EditorListContent>
+            <EditorListInsertLine position={0} />
 
-          {lessons.map((lesson) => (
-            <Fragment key={lesson.slug}>
-              <EditorListItem>
-                <Link
-                  className="flex items-start gap-4 px-4 py-3 transition-colors hover:bg-muted/50"
-                  href={`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/${lesson.slug}`}
-                >
-                  <EditorListItemPosition>
-                    {lesson.position}
-                  </EditorListItemPosition>
+            {lessons.map((lesson, index) => (
+              <Fragment key={lesson.slug}>
+                <EditorSortableItem id={lesson.id}>
+                  <EditorListItem>
+                    <EditorSortableItemRow>
+                      <EditorDragHandle />
 
-                  <EditorListItemContent>
-                    <EditorListItemTitle>{lesson.title}</EditorListItemTitle>
+                      <Link
+                        className="flex flex-1 items-start gap-4"
+                        href={`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/${lesson.slug}`}
+                      >
+                        <EditorListItemPosition>{index}</EditorListItemPosition>
 
-                    {lesson.description && (
-                      <EditorListItemDescription>
-                        {lesson.description}
-                      </EditorListItemDescription>
-                    )}
-                  </EditorListItemContent>
-                </Link>
-              </EditorListItem>
+                        <EditorListItemContent>
+                          <EditorListItemTitle>
+                            {lesson.title}
+                          </EditorListItemTitle>
 
-              <EditorListInsertLine position={lesson.position + 1} />
-            </Fragment>
-          ))}
-        </EditorListContent>
+                          {lesson.description && (
+                            <EditorListItemDescription>
+                              {lesson.description}
+                            </EditorListItemDescription>
+                          )}
+                        </EditorListItemContent>
+                      </Link>
+                    </EditorSortableItemRow>
+                  </EditorListItem>
+                </EditorSortableItem>
+
+                <EditorListInsertLine position={index + 1} />
+              </Fragment>
+            ))}
+          </EditorListContent>
+        </EditorSortableList>
       )}
     </EditorListProvider>
   );

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -94,7 +94,7 @@ export async function LessonList({
                 <EditorSortableItem id={lesson.id}>
                   <EditorListItem>
                     <EditorSortableItemRow>
-                      <EditorDragHandle />
+                      <EditorDragHandle aria-label={t("Drag to reorder")} />
 
                       <Link
                         className="flex flex-1 items-start gap-4"

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
@@ -91,7 +91,7 @@ export async function ChapterList({
                 <EditorSortableItem id={chapter.id}>
                   <EditorListItem>
                     <EditorSortableItemRow>
-                      <EditorDragHandle />
+                      <EditorDragHandle aria-label={t("Drag to reorder")} />
 
                       <Link
                         className="flex flex-1 items-start gap-4"

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { getExtracted } from "next-intl/server";
 import { Fragment } from "react";
 import {
+  EditorDragHandle,
   EditorListAddButton,
   EditorListContent,
   EditorListHeader,
@@ -15,6 +16,9 @@ import {
   EditorListItemTitle,
   EditorListProvider,
   EditorListSpinner,
+  EditorSortableItem,
+  EditorSortableItemRow,
+  EditorSortableList,
 } from "@/components/editor-list";
 import { EntityListActions } from "@/components/entity-list-actions";
 import { listCourseChapters } from "@/data/chapters/list-course-chapters";
@@ -23,6 +27,7 @@ import {
   exportChaptersAction,
   handleImportChaptersAction,
   insertChapterAction,
+  reorderChaptersAction,
 } from "./actions";
 
 export async function ChapterList({
@@ -74,36 +79,47 @@ export async function ChapterList({
       </EditorListHeader>
 
       {chapters.length > 0 && (
-        <EditorListContent>
-          <EditorListInsertLine position={0} />
+        <EditorSortableList
+          items={chapters}
+          onReorder={reorderChaptersAction.bind(null, routeParams)}
+        >
+          <EditorListContent>
+            <EditorListInsertLine position={0} />
 
-          {chapters.map((chapter) => (
-            <Fragment key={chapter.slug}>
-              <EditorListItem>
-                <Link
-                  className="flex items-start gap-4 px-4 py-3 transition-colors hover:bg-muted/50"
-                  href={`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapter.slug}`}
-                >
-                  <EditorListItemPosition>
-                    {chapter.position}
-                  </EditorListItemPosition>
+            {chapters.map((chapter, index) => (
+              <Fragment key={chapter.slug}>
+                <EditorSortableItem id={chapter.id}>
+                  <EditorListItem>
+                    <EditorSortableItemRow>
+                      <EditorDragHandle />
 
-                  <EditorListItemContent>
-                    <EditorListItemTitle>{chapter.title}</EditorListItemTitle>
+                      <Link
+                        className="flex flex-1 items-start gap-4"
+                        href={`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapter.slug}`}
+                      >
+                        <EditorListItemPosition>{index}</EditorListItemPosition>
 
-                    {chapter.description && (
-                      <EditorListItemDescription>
-                        {chapter.description}
-                      </EditorListItemDescription>
-                    )}
-                  </EditorListItemContent>
-                </Link>
-              </EditorListItem>
+                        <EditorListItemContent>
+                          <EditorListItemTitle>
+                            {chapter.title}
+                          </EditorListItemTitle>
 
-              <EditorListInsertLine position={chapter.position + 1} />
-            </Fragment>
-          ))}
-        </EditorListContent>
+                          {chapter.description && (
+                            <EditorListItemDescription>
+                              {chapter.description}
+                            </EditorListItemDescription>
+                          )}
+                        </EditorListItemContent>
+                      </Link>
+                    </EditorSortableItemRow>
+                  </EditorListItem>
+                </EditorSortableItem>
+
+                <EditorListInsertLine position={index + 1} />
+              </Fragment>
+            ))}
+          </EditorListContent>
+        </EditorSortableList>
       )}
     </EditorListProvider>
   );

--- a/apps/editor/src/components/editor-list.tsx
+++ b/apps/editor/src/components/editor-list.tsx
@@ -1,14 +1,36 @@
 "use client";
 
+import type { DragEndEvent, DragStartEvent } from "@dnd-kit/core";
+import {
+  closestCenter,
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { Button } from "@zoonk/ui/components/button";
 import { toast } from "@zoonk/ui/components/sonner";
 import { cn } from "@zoonk/ui/lib/utils";
-import { LoaderCircleIcon, PlusIcon } from "lucide-react";
+import { GripVerticalIcon, LoaderCircleIcon, PlusIcon } from "lucide-react";
 import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
+  useId,
   useMemo,
+  useOptimistic,
+  useState,
   useTransition,
 } from "react";
 
@@ -264,18 +286,268 @@ function EditorListItemDescription({
   );
 }
 
+type SortableItem = {
+  id: number;
+  position: number;
+};
+
+type EditorSortableContextValue = {
+  activeId: number | null;
+  isDragging: boolean;
+};
+
+const EditorSortableContext = createContext<
+  EditorSortableContextValue | undefined
+>(undefined);
+
+function useEditorSortable() {
+  const context = useContext(EditorSortableContext);
+  if (!context) {
+    throw new Error(
+      "EditorSortable components must be used within an EditorSortableList.",
+    );
+  }
+  return context;
+}
+
+function EditorSortableList<T extends SortableItem>({
+  children,
+  items: initialItems,
+  onReorder,
+  renderOverlay,
+}: {
+  children: React.ReactNode;
+  items: T[];
+  onReorder: (
+    items: { id: number; position: number }[],
+  ) => Promise<{ error: string | null }>;
+  renderOverlay?: (activeItem: T) => React.ReactNode;
+}) {
+  const dndId = useId();
+  const [mounted, setMounted] = useState(false);
+  const [activeId, setActiveId] = useState<number | null>(null);
+  const [optimisticItems, setOptimisticItems] = useOptimistic(initialItems);
+  const [pending, startTransition] = useTransition();
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveId(event.active.id as number);
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      setActiveId(null);
+
+      if (!over || active.id === over.id) {
+        return;
+      }
+
+      const oldIndex = optimisticItems.findIndex(
+        (item) => item.id === active.id,
+      );
+      const newIndex = optimisticItems.findIndex((item) => item.id === over.id);
+
+      if (oldIndex === -1 || newIndex === -1) {
+        return;
+      }
+
+      const reorderedItems = arrayMove(optimisticItems, oldIndex, newIndex);
+      const newPositions = reorderedItems.map(
+        (item: SortableItem, index: number) => ({
+          id: item.id,
+          position: index,
+        }),
+      );
+
+      startTransition(async () => {
+        setOptimisticItems(reorderedItems);
+
+        const { error } = await onReorder(newPositions);
+
+        if (error) {
+          toast.error(error);
+        }
+      });
+    },
+    [optimisticItems, onReorder, setOptimisticItems],
+  );
+
+  const handleDragCancel = useCallback(() => {
+    setActiveId(null);
+  }, []);
+
+  const activeItem = activeId
+    ? optimisticItems.find((item) => item.id === activeId)
+    : null;
+
+  const contextValue = useMemo<EditorSortableContextValue>(
+    () => ({
+      activeId,
+      isDragging: activeId !== null,
+    }),
+    [activeId],
+  );
+
+  const itemIds = useMemo(
+    () => optimisticItems.map((item) => item.id),
+    [optimisticItems],
+  );
+
+  if (!mounted) {
+    return <div data-slot="editor-sortable-list">{children}</div>;
+  }
+
+  return (
+    <EditorSortableContext.Provider value={contextValue}>
+      <DndContext
+        collisionDetection={closestCenter}
+        id={dndId}
+        onDragCancel={handleDragCancel}
+        onDragEnd={handleDragEnd}
+        onDragStart={handleDragStart}
+        sensors={sensors}
+      >
+        <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+          <div
+            className={cn(pending && "pointer-events-none opacity-60")}
+            data-slot="editor-sortable-list"
+          >
+            {children}
+          </div>
+        </SortableContext>
+
+        <DragOverlay>
+          {activeItem && renderOverlay ? (
+            <div
+              className="rounded-md border bg-background shadow-md"
+              data-slot="editor-drag-overlay"
+            >
+              {renderOverlay(activeItem)}
+            </div>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+    </EditorSortableContext.Provider>
+  );
+}
+
+function EditorSortableItem({
+  children,
+  id,
+}: {
+  children: React.ReactNode;
+  id: number;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      className={cn(isDragging && "opacity-50")}
+      data-dragging={isDragging}
+      data-slot="editor-sortable-item"
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+    >
+      <EditorSortableItemContext.Provider value={listeners}>
+        {children}
+      </EditorSortableItemContext.Provider>
+    </div>
+  );
+}
+
+const EditorSortableItemContext = createContext<
+  ReturnType<typeof useSortable>["listeners"] | undefined
+>(undefined);
+
+function EditorSortableItemRow({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2 px-4 py-3 transition-colors hover:bg-muted/50",
+        className,
+      )}
+      data-slot="editor-sortable-item-row"
+      {...props}
+    />
+  );
+}
+
+function EditorDragHandle({
+  className,
+  ...props
+}: React.ComponentProps<"button">) {
+  const listeners = useContext(EditorSortableItemContext);
+
+  if (!listeners) {
+    throw new Error(
+      "EditorDragHandle must be used within an EditorSortableItem.",
+    );
+  }
+
+  return (
+    <button
+      className={cn(
+        "mt-1 flex shrink-0 cursor-grab touch-none items-center justify-center text-muted-foreground transition-colors hover:text-foreground focus-visible:text-foreground focus-visible:outline-none active:cursor-grabbing",
+        className,
+      )}
+      data-slot="editor-drag-handle"
+      type="button"
+      {...listeners}
+      {...props}
+    >
+      <GripVerticalIcon className="size-4" />
+    </button>
+  );
+}
+
 export {
-  EditorListProvider,
-  EditorListSpinner,
-  EditorListHeader,
+  EditorDragHandle,
   EditorListAddButton,
   EditorListContent,
+  EditorListHeader,
   EditorListInsertLine,
   EditorListItem,
+  EditorListItemContent,
+  EditorListItemDescription,
   EditorListItemLink,
   EditorListItemPosition,
-  EditorListItemContent,
   EditorListItemTitle,
-  EditorListItemDescription,
+  EditorListProvider,
+  EditorListSpinner,
+  EditorSortableItem,
+  EditorSortableItemRow,
+  EditorSortableList,
   useEditorList,
+  useEditorSortable,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,15 @@ importers:
 
   apps/editor:
     dependencies:
+      '@dnd-kit/core':
+        specifier: 6.3.1
+        version: 6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@dnd-kit/sortable':
+        specifier: 10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+      '@dnd-kit/utilities':
+        specifier: 3.2.2
+        version: 3.2.2(react@19.2.3)
       '@formatjs/intl-localematcher':
         specifier: 0.7.3
         version: 0.7.3
@@ -1001,6 +1010,28 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@electric-sql/pglite-socket@0.0.6':
     resolution: {integrity: sha512-6RjmgzphIHIBA4NrMGJsjNWK4pu+bCWJlEWlwcxFTVY3WT86dFpKwbZaGWZV6C5Rd7sCk1Z0CI76QEfukLAUXw==}
@@ -4817,6 +4848,31 @@ snapshots:
       postcss: 8.5.6
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.3)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.3)
+      react: 19.2.3
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      tslib: 2.8.1
 
   '@electric-sql/pglite-socket@0.0.6(@electric-sql/pglite@0.3.2)':
     dependencies:


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added drag-and-drop sorting for chapters and lessons in the editor with optimistic UI updates and server-side persistence. Makes reorganizing course content faster and more intuitive.

- **New Features**
  - Added EditorSortableList, EditorSortableItem, EditorSortableItemRow, and EditorDragHandle using dnd-kit.
  - Integrated sortable lists into chapter-list and lesson-list pages; added localized “Drag to reorder” label.
  - Optimistic reorder with toasts and cache/path revalidation.
  - Added reorderChaptersAction and reorderLessonsAction to save new positions.

- **Dependencies**
  - @dnd-kit/core, @dnd-kit/sortable, @dnd-kit/utilities.

<sup>Written for commit a9fbabea0c442612ca2383feb924923c5811ea59. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



