### PR TITLE
feat(main): list courses

### DIFF
--- a/apps/editor/src/app/[orgSlug]/course-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/course-list.tsx
@@ -1,44 +1,13 @@
 import type { Course } from "@zoonk/core/types";
 import {
-  Item,
-  ItemContent,
-  ItemDescription,
-  ItemGroup,
-  ItemMedia,
-  ItemTitle,
-} from "@zoonk/ui/components/item";
-import { Skeleton } from "@zoonk/ui/components/skeleton";
+  CourseListGroup,
+  CourseListItemView,
+} from "@zoonk/ui/patterns/courses/list";
 import { EmptyView } from "@zoonk/ui/patterns/empty";
-import { ChevronRightIcon, NotebookPenIcon } from "lucide-react";
+import { NotebookPenIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { getExtracted } from "next-intl/server";
-
-export function CourseListSkeleton() {
-  return (
-    <ItemGroup>
-      {Array.from({ length: 10 }).map((_, index) => (
-        <Item key={index}>
-          <ItemMedia variant="image">
-            <Skeleton className="size-10" />
-          </ItemMedia>
-
-          <ItemContent>
-            <Skeleton className="h-4 w-48" />
-            <Skeleton className="h-4 w-72" />
-          </ItemContent>
-
-          <Skeleton className="h-5 w-10 rounded-full" />
-
-          <ChevronRightIcon
-            aria-hidden="true"
-            className="size-4 text-muted-foreground"
-          />
-        </Item>
-      ))}
-    </ItemGroup>
-  );
-}
 
 export async function CourseList({
   orgSlug,
@@ -60,43 +29,29 @@ export async function CourseList({
   }
 
   return (
-    <ItemGroup>
+    <CourseListGroup>
       {courses.map((course) => (
-        <Item
-          key={course.id}
-          render={
-            <Link
-              href={`/${orgSlug}/c/${course.language}/${course.slug}`}
-              prefetch={true}
-            />
-          }
-        >
-          {course.imageUrl ? (
-            <ItemMedia className="size-16" variant="image">
+        <CourseListItemView
+          course={course}
+          image={
+            course.imageUrl ? (
               <Image
                 alt={course.title}
                 height={64}
                 src={course.imageUrl}
                 width={64}
               />
-            </ItemMedia>
-          ) : (
-            <ItemMedia className="size-16" variant="icon">
-              <NotebookPenIcon className="size-6 text-muted-foreground/80" />
-            </ItemMedia>
-          )}
-
-          <ItemContent>
-            <ItemTitle>{course.title}</ItemTitle>
-            <ItemDescription>{course.description}</ItemDescription>
-          </ItemContent>
-
-          <ChevronRightIcon
-            aria-hidden="true"
-            className="size-4 text-muted-foreground"
-          />
-        </Item>
+            ) : undefined
+          }
+          key={course.id}
+          linkComponent={
+            <Link
+              href={`/${orgSlug}/c/${course.language}/${course.slug}`}
+              prefetch={true}
+            />
+          }
+        />
       ))}
-    </ItemGroup>
+    </CourseListGroup>
   );
 }

--- a/apps/editor/src/app/[orgSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/page.tsx
@@ -1,8 +1,8 @@
 import { getOrganization } from "@zoonk/core/orgs/get";
 import { Container } from "@zoonk/ui/components/container";
+import { CourseListSkeleton } from "@zoonk/ui/patterns/courses/list";
 import type { Metadata } from "next";
 import { Suspense } from "react";
-import { CourseListSkeleton } from "./course-list";
 import { HomeContainerHeader } from "./home-container-header";
 import { ListCourses } from "./list-courses";
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -134,10 +134,35 @@ msgctxt "R/6nsx"
 msgid "Subscription"
 msgstr "Subscription"
 
+#: src/app/[locale]/(catalog)/courses/course-list-client.tsx
+msgctxt "T0mfNV"
+msgid "Loading more courses…"
+msgstr "Loading more courses…"
+
+#: src/app/[locale]/(catalog)/courses/course-list-client.tsx
+msgctxt "Wc7aau"
+msgid "No courses available yet."
+msgstr "No courses available yet."
+
+#: src/app/[locale]/(catalog)/courses/course-list-client.tsx
+msgctxt "zJxO2f"
+msgid "No courses"
+msgstr "No courses"
+
+#: src/app/[locale]/(catalog)/courses/page.tsx
+msgctxt "hUF3bo"
+msgid "Start learning something new today"
+msgstr "Start learning something new today"
+
 #: src/app/[locale]/(catalog)/courses/page.tsx
 msgctxt "P5jxUC"
 msgid "Online Courses using AI"
 msgstr "Online Courses using AI"
+
+#: src/app/[locale]/(catalog)/courses/page.tsx
+msgctxt "s+Ncqj"
+msgid "Explore courses"
+msgstr "Explore courses"
 
 #: src/app/[locale]/(catalog)/courses/page.tsx
 msgctxt "z6saPZ"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -134,10 +134,35 @@ msgctxt "R/6nsx"
 msgid "Subscription"
 msgstr "Suscripción"
 
+#: src/app/[locale]/(catalog)/courses/course-list-client.tsx
+msgctxt "T0mfNV"
+msgid "Loading more courses…"
+msgstr "Cargando más cursos…"
+
+#: src/app/[locale]/(catalog)/courses/course-list-client.tsx
+msgctxt "Wc7aau"
+msgid "No courses available yet."
+msgstr "Aún no hay cursos disponibles."
+
+#: src/app/[locale]/(catalog)/courses/course-list-client.tsx
+msgctxt "zJxO2f"
+msgid "No courses"
+msgstr "No hay cursos"
+
+#: src/app/[locale]/(catalog)/courses/page.tsx
+msgctxt "hUF3bo"
+msgid "Start learning something new today"
+msgstr "Comienza a aprender algo nuevo hoy"
+
 #: src/app/[locale]/(catalog)/courses/page.tsx
 msgctxt "P5jxUC"
 msgid "Online Courses using AI"
 msgstr "Cursos en línea con IA"
+
+#: src/app/[locale]/(catalog)/courses/page.tsx
+msgctxt "s+Ncqj"
+msgid "Explore courses"
+msgstr "Explorar cursos"
 
 #: src/app/[locale]/(catalog)/courses/page.tsx
 msgctxt "z6saPZ"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -134,10 +134,35 @@ msgctxt "R/6nsx"
 msgid "Subscription"
 msgstr "Assinatura"
 
+#: src/app/[locale]/(catalog)/courses/course-list-client.tsx
+msgctxt "T0mfNV"
+msgid "Loading more courses…"
+msgstr "Carregando mais cursos…"
+
+#: src/app/[locale]/(catalog)/courses/course-list-client.tsx
+msgctxt "Wc7aau"
+msgid "No courses available yet."
+msgstr "Ainda não há cursos disponíveis."
+
+#: src/app/[locale]/(catalog)/courses/course-list-client.tsx
+msgctxt "zJxO2f"
+msgid "No courses"
+msgstr "Nenhum curso"
+
+#: src/app/[locale]/(catalog)/courses/page.tsx
+msgctxt "hUF3bo"
+msgid "Start learning something new today"
+msgstr "Comece a aprender algo novo hoje"
+
 #: src/app/[locale]/(catalog)/courses/page.tsx
 msgctxt "P5jxUC"
 msgid "Online Courses using AI"
 msgstr "Cursos online usando IA"
+
+#: src/app/[locale]/(catalog)/courses/page.tsx
+msgctxt "s+Ncqj"
+msgid "Explore courses"
+msgstr "Explorar cursos"
 
 #: src/app/[locale]/(catalog)/courses/page.tsx
 msgctxt "z6saPZ"

--- a/apps/main/src/app/[locale]/(catalog)/courses/actions.ts
+++ b/apps/main/src/app/[locale]/(catalog)/courses/actions.ts
@@ -1,0 +1,15 @@
+"use server";
+
+import { listCourses } from "@/data/courses/list-courses";
+
+export async function loadMoreCourses(params: {
+  cursor: number;
+  language: string;
+}) {
+  const courses = await listCourses({
+    cursor: params.cursor,
+    language: params.language,
+  });
+
+  return courses;
+}

--- a/apps/main/src/app/[locale]/(catalog)/courses/course-list-client.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/courses/course-list-client.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import type { Course } from "@zoonk/db";
+import { useInfiniteList } from "@zoonk/ui/hooks/infinite-list";
+import {
+  CourseListGroup,
+  type CourseListItem,
+  CourseListItemView,
+} from "@zoonk/ui/patterns/courses/list";
+import { EmptyView } from "@zoonk/ui/patterns/empty";
+import { Loader2Icon, NotebookPenIcon } from "lucide-react";
+import Image from "next/image";
+import { useExtracted } from "next-intl";
+import { ClientLink } from "@/i18n/client-link";
+import { loadMoreCourses } from "./actions";
+
+function toCourseListItem(course: Course): CourseListItem {
+  return {
+    description: course.description,
+    id: course.id,
+    imageUrl: course.imageUrl,
+    slug: course.slug,
+    title: course.title,
+  };
+}
+
+export function CourseListClient({
+  initialCourses,
+  language,
+  limit,
+}: {
+  initialCourses: Course[];
+  language: string;
+  limit: number;
+}) {
+  const t = useExtracted();
+
+  const {
+    items: courses,
+    isLoading,
+    sentryRef,
+  } = useInfiniteList<Course, number>({
+    fetchMore: (cursor) => loadMoreCourses({ cursor, language }),
+    getCursor: (course) => course.id,
+    getKey: (course) => course.id,
+    initialItems: initialCourses,
+    limit,
+  });
+
+  if (courses.length === 0) {
+    return (
+      <EmptyView
+        description={t("No courses available yet.")}
+        icon={NotebookPenIcon}
+        title={t("No courses")}
+      />
+    );
+  }
+
+  return (
+    <>
+      <CourseListGroup>
+        {courses.map((course) => (
+          <CourseListItemView
+            course={toCourseListItem(course)}
+            image={
+              course.imageUrl ? (
+                <Image
+                  alt={course.title}
+                  height={64}
+                  src={course.imageUrl}
+                  width={64}
+                />
+              ) : undefined
+            }
+            key={course.id}
+            linkComponent={
+              <ClientLink href={`/b/zoonk/c/${course.slug}`} prefetch={false} />
+            }
+          />
+        ))}
+      </CourseListGroup>
+
+      <div className="flex justify-center py-4" ref={sentryRef}>
+        {isLoading && (
+          <Loader2Icon
+            aria-label={t("Loading more courses…")}
+            className="size-5 animate-spin text-muted-foreground"
+          />
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/main/src/app/[locale]/(catalog)/courses/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/courses/page.tsx
@@ -1,7 +1,18 @@
 "use cache";
 
+import {
+  Container,
+  ContainerDescription,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
+import { cacheTagCoursesList } from "@zoonk/utils/cache";
 import type { Metadata } from "next";
-import { getExtracted } from "next-intl/server";
+import { cacheTag } from "next/cache";
+import { getExtracted, setRequestLocale } from "next-intl/server";
+import { LIST_COURSES_LIMIT, listCourses } from "@/data/courses/list-courses";
+import { CourseListClient } from "./course-list-client";
 
 export async function generateMetadata({
   params,
@@ -17,6 +28,32 @@ export async function generateMetadata({
   };
 }
 
-export default async function Courses() {
-  return <main>{}</main>;
+export default async function Courses({
+  params,
+}: PageProps<"/[locale]/courses">) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  cacheTag(cacheTagCoursesList({ language: locale }));
+
+  const t = await getExtracted();
+  const courses = await listCourses({ language: locale });
+
+  return (
+    <Container variant="list">
+      <ContainerHeader>
+        <ContainerHeaderGroup>
+          <ContainerTitle>{t("Explore courses")}</ContainerTitle>
+          <ContainerDescription>
+            {t("Start learning something new today")}
+          </ContainerDescription>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <CourseListClient
+        initialCourses={courses}
+        language={locale}
+        limit={LIST_COURSES_LIMIT}
+      />
+    </Container>
+  );
 }

--- a/apps/main/src/data/courses/list-courses.ts
+++ b/apps/main/src/data/courses/list-courses.ts
@@ -5,18 +5,25 @@ import { clampQueryItems } from "@zoonk/db/utils";
 import type { CourseCategory } from "@zoonk/utils/categories";
 import { cache } from "react";
 
-const LIST_COURSES_LIMIT = 20;
+export const LIST_COURSES_LIMIT = 20;
 
 export const listCourses = cache(
   async (params: {
     category?: CourseCategory;
+    cursor?: number;
     language: string;
     limit?: number;
   }): Promise<Course[]> => {
+    const limit = clampQueryItems(params.limit ?? LIST_COURSES_LIMIT);
+
     const courses = await prisma.course.findMany({
       // biome-ignore lint/style/useNamingConvention: _count is Prisma's syntax for counting relations
       orderBy: [{ users: { _count: "desc" } }, { createdAt: "desc" }],
-      take: clampQueryItems(params.limit ?? LIST_COURSES_LIMIT),
+      take: limit,
+      ...(params.cursor && {
+        cursor: { id: params.cursor },
+        skip: 1,
+      }),
       where: {
         isPublished: true,
         language: params.language,

--- a/biome.json
+++ b/biome.json
@@ -215,7 +215,7 @@
   },
   "overrides": [
     {
-      "includes": ["**/*.test.ts"],
+      "includes": ["**/*.test.ts", "**/*.test.tsx"],
       "linter": {
         "rules": {
           "performance": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,6 +7,7 @@
     "cmdk": "1.1.1",
     "input-otp": "1.4.2",
     "next-themes": "0.4.6",
+    "react-infinite-scroll-hook": "6.0.1",
     "react-resizable-panels": "3.0.6",
     "sonner": "2.0.7",
     "tailwind-merge": "3.3.1"
@@ -35,11 +36,13 @@
     "./hooks/clipboard": "./src/hooks/use-clipboard.ts",
     "./hooks/command-palette-search": "./src/hooks/use-command-palette-search.ts",
     "./hooks/debounce": "./src/hooks/use-debounce.ts",
+    "./hooks/infinite-list": "./src/hooks/use-infinite-list.ts",
     "./hooks/keyboard": "./src/hooks/use-keyboard.ts",
     "./hooks/mobile": "./src/hooks/use-mobile.ts",
     "./lib/*": "./src/lib/*.ts",
     "./patterns/auth/protected": "./src/patterns/auth/protected-section.tsx",
     "./patterns/buttons/submit": "./src/patterns/buttons/submit-button.tsx",
+    "./patterns/courses/list": "./src/patterns/courses/course-list.tsx",
     "./patterns/empty": "./src/patterns/empty.tsx",
     "./patterns/error": "./src/patterns/error-view.tsx",
     "./postcss.config": "./postcss.config.mjs"

--- a/packages/ui/src/hooks/use-infinite-list.ts
+++ b/packages/ui/src/hooks/use-infinite-list.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import useInfiniteScroll from "react-infinite-scroll-hook";
+
+type UseInfiniteListOptions<T, C> = {
+  /** Initial items from the server */
+  initialItems: T[];
+  /** Number of items per page */
+  limit: number;
+  /** Function to get the cursor from an item */
+  getCursor: (item: T) => C;
+  /** Function to fetch more items */
+  fetchMore: (cursor: C) => Promise<T[]>;
+  /** Function to get the unique key from an item (for deduplication) */
+  getKey: (item: T) => string | number;
+  /** Root margin for IntersectionObserver */
+  rootMargin?: string;
+};
+
+type UseInfiniteListReturn<T> = {
+  hasNextPage: boolean;
+  isLoading: boolean;
+  items: T[];
+  sentryRef: (node: Element | null) => void;
+};
+
+export function useInfiniteList<T, C>({
+  fetchMore,
+  getCursor,
+  getKey,
+  initialItems,
+  limit,
+  rootMargin = "0px 0px 200px 0px",
+}: UseInfiniteListOptions<T, C>): UseInfiniteListReturn<T> {
+  const [items, setItems] = useState(initialItems);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasNextPage, setHasNextPage] = useState(initialItems.length >= limit);
+
+  // Use ref to track the latest cursor to avoid stale closures
+  const lastItem = initialItems.at(-1);
+  const cursorRef = useRef<C | undefined>(
+    lastItem ? getCursor(lastItem) : undefined,
+  );
+
+  const loadMore = useCallback(async () => {
+    if (cursorRef.current === undefined) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    const newItems = await fetchMore(cursorRef.current);
+
+    if (newItems.length < limit) {
+      setHasNextPage(false);
+    }
+
+    // Update cursor ref to the last new item
+    const lastNewItem = newItems.at(-1);
+    if (lastNewItem) {
+      cursorRef.current = getCursor(lastNewItem);
+    }
+
+    setItems((prev) => {
+      // Dedupe by key to prevent duplicates from race conditions
+      const existingKeys = new Set(prev.map(getKey));
+      const uniqueNewItems = newItems.filter(
+        (item) => !existingKeys.has(getKey(item)),
+      );
+      return [...prev, ...uniqueNewItems];
+    });
+
+    setIsLoading(false);
+  }, [fetchMore, getCursor, getKey, limit]);
+
+  const [sentryRef] = useInfiniteScroll({
+    hasNextPage,
+    loading: isLoading,
+    onLoadMore: loadMore,
+    rootMargin,
+  });
+
+  return {
+    hasNextPage,
+    isLoading,
+    items,
+    sentryRef,
+  };
+}

--- a/packages/ui/src/hooks/use-infinite-list.ts
+++ b/packages/ui/src/hooks/use-infinite-list.ts
@@ -4,17 +4,11 @@ import { useCallback, useRef, useState } from "react";
 import useInfiniteScroll from "react-infinite-scroll-hook";
 
 type UseInfiniteListOptions<T, C> = {
-  /** Initial items from the server */
   initialItems: T[];
-  /** Number of items per page */
   limit: number;
-  /** Function to get the cursor from an item */
   getCursor: (item: T) => C;
-  /** Function to fetch more items */
   fetchMore: (cursor: C) => Promise<T[]>;
-  /** Function to get the unique key from an item (for deduplication) */
   getKey: (item: T) => string | number;
-  /** Root margin for IntersectionObserver */
   rootMargin?: string;
 };
 
@@ -50,28 +44,31 @@ export function useInfiniteList<T, C>({
 
     setIsLoading(true);
 
-    const newItems = await fetchMore(cursorRef.current);
+    try {
+      const newItems = await fetchMore(cursorRef.current);
 
-    if (newItems.length < limit) {
-      setHasNextPage(false);
+      if (newItems.length < limit) {
+        setHasNextPage(false);
+      }
+
+      // Update cursor ref to the last new item
+      const lastNewItem = newItems.at(-1);
+      if (lastNewItem) {
+        cursorRef.current = getCursor(lastNewItem);
+      }
+
+      setItems((prev) => {
+        // Dedupe by key to prevent duplicates from race conditions
+        const existingKeys = new Set(prev.map(getKey));
+        const uniqueNewItems = newItems.filter(
+          (item) => !existingKeys.has(getKey(item)),
+        );
+
+        return [...prev, ...uniqueNewItems];
+      });
+    } finally {
+      setIsLoading(false);
     }
-
-    // Update cursor ref to the last new item
-    const lastNewItem = newItems.at(-1);
-    if (lastNewItem) {
-      cursorRef.current = getCursor(lastNewItem);
-    }
-
-    setItems((prev) => {
-      // Dedupe by key to prevent duplicates from race conditions
-      const existingKeys = new Set(prev.map(getKey));
-      const uniqueNewItems = newItems.filter(
-        (item) => !existingKeys.has(getKey(item)),
-      );
-      return [...prev, ...uniqueNewItems];
-    });
-
-    setIsLoading(false);
   }, [fetchMore, getCursor, getKey, limit]);
 
   const [sentryRef] = useInfiniteScroll({

--- a/packages/ui/src/patterns/courses/course-list.tsx
+++ b/packages/ui/src/patterns/courses/course-list.tsx
@@ -1,0 +1,85 @@
+import {
+  Item,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemMedia,
+  type ItemProps,
+  ItemTitle,
+} from "@zoonk/ui/components/item";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { ChevronRightIcon, NotebookPenIcon } from "lucide-react";
+
+export type CourseListItem = {
+  id: number;
+  description: string;
+  imageUrl: string | null;
+  slug: string;
+  title: string;
+};
+
+type CourseListItemProps = {
+  course: CourseListItem;
+  image?: React.ReactNode;
+  linkComponent: ItemProps["render"];
+};
+
+export function CourseListItemView({
+  course,
+  image,
+  linkComponent,
+}: CourseListItemProps) {
+  return (
+    <Item render={linkComponent}>
+      {image ? (
+        <ItemMedia className="size-16" variant="image">
+          {image}
+        </ItemMedia>
+      ) : (
+        <ItemMedia className="size-16" variant="icon">
+          <NotebookPenIcon className="size-6 text-muted-foreground/80" />
+        </ItemMedia>
+      )}
+
+      <ItemContent>
+        <ItemTitle>{course.title}</ItemTitle>
+        <ItemDescription>{course.description}</ItemDescription>
+      </ItemContent>
+
+      <ChevronRightIcon
+        aria-hidden="true"
+        className="size-4 text-muted-foreground"
+      />
+    </Item>
+  );
+}
+
+export function CourseListGroup(props: React.ComponentProps<typeof ItemGroup>) {
+  return <ItemGroup {...props} />;
+}
+
+export function CourseListSkeleton({ count = 10 }: { count?: number }) {
+  return (
+    <ItemGroup>
+      {Array.from({ length: count }).map((_, index) => (
+        <Item key={index}>
+          <ItemMedia variant="image">
+            <Skeleton className="size-16" />
+          </ItemMedia>
+
+          <ItemContent>
+            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-4 w-72" />
+          </ItemContent>
+
+          <Skeleton className="h-5 w-10 rounded-full" />
+
+          <ChevronRightIcon
+            aria-hidden="true"
+            className="size-4 text-muted-foreground"
+          />
+        </Item>
+      ))}
+    </ItemGroup>
+  );
+}

--- a/packages/ui/src/patterns/courses/course-list.tsx
+++ b/packages/ui/src/patterns/courses/course-list.tsx
@@ -72,8 +72,6 @@ export function CourseListSkeleton({ count = 10 }: { count?: number }) {
             <Skeleton className="h-4 w-72" />
           </ItemContent>
 
-          <Skeleton className="h-5 w-10 rounded-full" />
-
           <ChevronRightIcon
             aria-hidden="true"
             className="size-4 text-muted-foreground"

--- a/packages/utils/src/cache.ts
+++ b/packages/utils/src/cache.ts
@@ -15,3 +15,7 @@ export function cacheTagLesson({ lessonSlug }: { lessonSlug: string }) {
 export function cacheTagOrgCourses({ orgSlug }: { orgSlug: string }) {
   return `org-courses:${orgSlug}`.slice(0, CACHE_TAG_LIMIT);
 }
+
+export function cacheTagCoursesList({ language }: { language: string }) {
+  return `courses-list:${language}`.slice(0, CACHE_TAG_LIMIT);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -661,6 +661,9 @@ importers:
       react-dom:
         specifier: '>=19'
         version: 19.2.3(react@19.2.3)
+      react-infinite-scroll-hook:
+        specifier: 6.0.1
+        version: 6.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-resizable-panels:
         specifier: 3.0.6
         version: 3.0.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -3855,6 +3858,18 @@ packages:
     peerDependencies:
       react: ^19.2.3
 
+  react-infinite-scroll-hook@6.0.1:
+    resolution: {integrity: sha512-5FtJnor4Zyd3uafHCzOlXFCuhFJ2ZzLm3d9XTKbvAN6A/SH+XNFo5IOFk/T1hV5AYy+vOZYoXeH4jkufFB2JVA==}
+    peerDependencies:
+      react: '>=19'
+      react-dom: '>=19'
+
+  react-intersection-observer-hook@4.0.1:
+    resolution: {integrity: sha512-iAic1y/ne0hHjtll6XFFGaq0CWNtukYOA3NXef5yT8TdsA8KdQJ8Ey5CcVWzXKIE9IOU+K9Z40+LXDqBPBdCqw==}
+    peerDependencies:
+      react: '>=19'
+      react-dom: '>=19'
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
@@ -4488,6 +4503,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -7579,6 +7595,17 @@ snapshots:
     dependencies:
       react: 19.2.3
       scheduler: 0.27.0
+
+  react-infinite-scroll-hook@6.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-intersection-observer-hook: 4.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+
+  react-intersection-observer-hook@4.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   react-is@17.0.2: {}
 


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a courses catalog page with infinite scroll and shared course list UI to improve browsing and localization across locales.

- **New Features**
  - New page at /[locale]/courses with title and description.
  - Infinite scrolling via useInfiniteList and loadMoreCourses server action.
  - Empty and loading states with localized messages (EN/ES/PT).
  - Shared CourseList components and skeleton in UI; editor now uses them.

- **Refactors**
  - listCourses now supports cursor-based pagination and exports LIST_COURSES_LIMIT.
  - Added cache tags for courses list and applied revalidation on the page.
  - Added react-infinite-scroll-hook to UI package.
  - Updated test file override in biome.json to include .test.tsx.

<sup>Written for commit a571dc1e01b86b74f810023a4583815e5f4576bf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



