### PR TITLE
feat(editor): upload course image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,7 +254,7 @@ See these existing patterns in the codebase:
 - For apps using `next-intl`, use `getExtracted` or `useExtracted`. This will extract the translations to PO files when we run `pnpm build`
 - You can't pass the `t` function from `getExtracted` or `useExtracted` to other functions or components. Instead, call it directly in the component or function
 - Whenever using `getExtracted` or `useExtracted`, run `pnpm build` to update PO files
-- Run `pnpm i18n:check` to check for any missing translations and translate empty strings in PO files
+- Run `pnpm i18n:check` to check for any missing translations and translate empty strings in PO files, making sure translations are consistent across the codebase
 
 ## CSS
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ All apps should follow a consistent folder structure:
 **Component Organization:**
 
 1. **Route-specific components**: Colocate directly with the route's `page.tsx`
-2. **Route group shared components**: Use `_components/` or `_hooks/` folders within the route group (e.g., `app/(private)/_components/`)
+2. **Route group shared components**: Use `_components/` or `_hooks/` folders within the route group (e.g., `app/(private)/_components/`), except for the root route group (eg `/[locale]` for `main` app and `/[orgSlug]/c/[lang]/[courseSlug]` for `editor` app) where you should use `src/components/{domain}/` since all components are shared across the app.
 3. **Cross-route-group components**: Place in `src/components/{domain}/`
 4. **Shared utilities**: Place in `src/lib/`
 
@@ -254,7 +254,7 @@ See these existing patterns in the codebase:
 - For apps using `next-intl`, use `getExtracted` or `useExtracted`. This will extract the translations to PO files when we run `pnpm build`
 - You can't pass the `t` function from `getExtracted` or `useExtracted` to other functions or components. Instead, call it directly in the component or function
 - Whenever using `getExtracted` or `useExtracted`, run `pnpm build` to update PO files
-- Run `pnpm i18n:check` to check for any missing translations and translate empty strings in PO files
+- Run `pnpm i18n:check` to check for any missing translations and translate empty strings in PO files, making sure translations are consistent across the codebase
 
 ## CSS
 

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -4,7 +4,7 @@
     "@zoonk/db": "workspace:*",
     "@zoonk/ui": "workspace:*",
     "@zoonk/utils": "workspace:*",
-    "lucide-react": "0.556.0",
+    "lucide-react": "0.562.0",
     "next": "16.1.0",
     "nuqs": "2.7.3",
     "react": "19.2.3",

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -5,7 +5,7 @@
     "@zoonk/next": "workspace:*",
     "@zoonk/ui": "workspace:*",
     "@zoonk/utils": "workspace:*",
-    "lucide-react": "0.556.0",
+    "lucide-react": "0.562.0",
     "next": "16.1.0",
     "next-intl": "4.6.1",
     "react": "19.2.3",

--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -191,6 +191,16 @@ msgid "Change course image"
 msgstr "Change course image"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "09WQsL"
+msgid "Invalid file type. Please upload a {formats} image."
+msgstr "Invalid file type. Please upload a {formats} image."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "4pIjq5"
+msgid "File is too large. Maximum size is {max}MB."
+msgstr "File is too large. Maximum size is {max}MB."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
 msgctxt "7vM5rK"
 msgid "Remove image"
 msgstr "Remove image"
@@ -199,6 +209,16 @@ msgstr "Remove image"
 msgctxt "N8c7X3"
 msgid "Upload course image"
 msgstr "Upload course image"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "P4DaWb"
+msgid "Image removed"
+msgstr "Image removed"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "TcTp+J"
+msgid "Image uploaded"
+msgstr "Image uploaded"
 
 #: src/app/[orgSlug]/course-list.tsx
 msgctxt "c0YWuA"

--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -41,10 +41,30 @@ msgid "Untitled chapter"
 msgstr "Untitled chapter"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "E+/68R"
+msgid "Invalid file type. Please upload a JPEG, PNG, WebP, or GIF image."
+msgstr "Invalid file type. Please upload a JPEG, PNG, WebP, or GIF image."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "in2TjU"
+msgid "File is too large. Maximum size is 5MB."
+msgstr "File is too large. Maximum size is 5MB."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "JkrKUt"
+msgid "Failed to upload image. Please try again."
+msgstr "Failed to upload image. Please try again."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
 msgctxt "lgvvCe"
 msgid "No file provided"
 msgstr "No file provided"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "Q1jVC0"
+msgid "Failed to process image. Please try again."
+msgstr "Failed to process image. Please try again."
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
@@ -164,6 +184,21 @@ msgstr "Edit course title"
 msgctxt "RX7tLA"
 msgid "Course description…"
 msgstr "Course description…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "+MD59T"
+msgid "Change course image"
+msgstr "Change course image"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "7vM5rK"
+msgid "Remove image"
+msgstr "Remove image"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "N8c7X3"
+msgid "Upload course image"
+msgstr "Upload course image"
 
 #: src/app/[orgSlug]/course-list.tsx
 msgctxt "c0YWuA"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -41,10 +41,30 @@ msgid "Untitled chapter"
 msgstr "Capítulo sin título"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "E+/68R"
+msgid "Invalid file type. Please upload a JPEG, PNG, WebP, or GIF image."
+msgstr "Tipo de archivo inválido. Por favor sube una imagen JPEG, PNG, WebP o GIF."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "in2TjU"
+msgid "File is too large. Maximum size is 5MB."
+msgstr "El archivo es demasiado grande. El tamaño máximo es 5MB."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "JkrKUt"
+msgid "Failed to upload image. Please try again."
+msgstr "Error al subir la imagen. Por favor intenta de nuevo."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
 msgctxt "lgvvCe"
 msgid "No file provided"
 msgstr "No se proporcionó ningún archivo"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "Q1jVC0"
+msgid "Failed to process image. Please try again."
+msgstr "Error al procesar la imagen. Por favor intenta de nuevo."
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
@@ -164,6 +184,21 @@ msgstr "Editar título del curso"
 msgctxt "RX7tLA"
 msgid "Course description…"
 msgstr "Descripción del curso…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "+MD59T"
+msgid "Change course image"
+msgstr "Cambiar imagen del curso"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "7vM5rK"
+msgid "Remove image"
+msgstr "Eliminar imagen"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "N8c7X3"
+msgid "Upload course image"
+msgstr "Subir imagen del curso"
 
 #: src/app/[orgSlug]/course-list.tsx
 msgctxt "c0YWuA"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -191,6 +191,16 @@ msgid "Change course image"
 msgstr "Cambiar imagen del curso"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "09WQsL"
+msgid "Invalid file type. Please upload a {formats} image."
+msgstr "Tipo de archivo inválido. Por favor sube una imagen {formats}."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "4pIjq5"
+msgid "File is too large. Maximum size is {max}MB."
+msgstr "El archivo es demasiado grande. El tamaño máximo es {max}MB."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
 msgctxt "7vM5rK"
 msgid "Remove image"
 msgstr "Eliminar imagen"
@@ -199,6 +209,16 @@ msgstr "Eliminar imagen"
 msgctxt "N8c7X3"
 msgid "Upload course image"
 msgstr "Subir imagen del curso"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "P4DaWb"
+msgid "Image removed"
+msgstr "Imagen eliminada"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "TcTp+J"
+msgid "Image uploaded"
+msgstr "Imagen subida"
 
 #: src/app/[orgSlug]/course-list.tsx
 msgctxt "c0YWuA"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -41,10 +41,30 @@ msgid "Untitled chapter"
 msgstr "Capítulo sem título"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "E+/68R"
+msgid "Invalid file type. Please upload a JPEG, PNG, WebP, or GIF image."
+msgstr "Tipo de arquivo inválido. Por favor, envie uma imagem JPEG, PNG, WebP ou GIF."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "in2TjU"
+msgid "File is too large. Maximum size is 5MB."
+msgstr "O arquivo é muito grande. O tamanho máximo é 5MB."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "JkrKUt"
+msgid "Failed to upload image. Please try again."
+msgstr "Falha ao enviar a imagem. Por favor, tente novamente."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
 msgctxt "lgvvCe"
 msgid "No file provided"
 msgstr "Nenhum arquivo fornecido"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "Q1jVC0"
+msgid "Failed to process image. Please try again."
+msgstr "Falha ao processar a imagem. Por favor, tente novamente."
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
@@ -164,6 +184,21 @@ msgstr "Editar título do curso"
 msgctxt "RX7tLA"
 msgid "Course description…"
 msgstr "Descrição do curso…"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "+MD59T"
+msgid "Change course image"
+msgstr "Alterar imagem do curso"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "7vM5rK"
+msgid "Remove image"
+msgstr "Remover imagem"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "N8c7X3"
+msgid "Upload course image"
+msgstr "Enviar imagem do curso"
 
 #: src/app/[orgSlug]/course-list.tsx
 msgctxt "c0YWuA"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -191,6 +191,16 @@ msgid "Change course image"
 msgstr "Alterar imagem do curso"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "09WQsL"
+msgid "Invalid file type. Please upload a {formats} image."
+msgstr "Tipo de arquivo inválido. Por favor, envie uma imagem {formats}."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "4pIjq5"
+msgid "File is too large. Maximum size is {max}MB."
+msgstr "O arquivo é muito grande. O tamanho máximo é {max}MB."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
 msgctxt "7vM5rK"
 msgid "Remove image"
 msgstr "Remover imagem"
@@ -199,6 +209,16 @@ msgstr "Remover imagem"
 msgctxt "N8c7X3"
 msgid "Upload course image"
 msgstr "Enviar imagem do curso"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "P4DaWb"
+msgid "Image removed"
+msgstr "Imagem removida"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+msgctxt "TcTp+J"
+msgid "Image uploaded"
+msgstr "Imagem enviada"
 
 #: src/app/[orgSlug]/course-list.tsx
 msgctxt "c0YWuA"

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -7,6 +7,9 @@ const nextConfig: NextConfig = {
   devIndicators: false,
   experimental: {
     authInterrupts: true,
+    serverActions: {
+      bodySizeLimit: "10mb",
+    },
     staleTimes: {
       dynamic: 300,
     },

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -10,7 +10,7 @@
     "@zoonk/ui": "workspace:*",
     "@zoonk/utils": "workspace:*",
     "js-cookie": "3.0.5",
-    "lucide-react": "0.556.0",
+    "lucide-react": "0.562.0",
     "negotiator": "1.0.0",
     "next": "16.1.0",
     "next-intl": "4.6.1",

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidateMainApp } from "@zoonk/core/cache/revalidate";
+import { processAndUploadImage } from "@zoonk/core/images/process-and-upload";
 import { cacheTagCourse } from "@zoonk/utils/cache";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
@@ -212,6 +213,74 @@ export async function reorderChaptersAction(
   const { error } = await reorderChapters({
     chapters: chapters.map((c) => ({ chapterId: c.id, position: c.position })),
     courseId,
+  });
+
+  if (error) {
+    return { error: await getErrorMessage(error) };
+  }
+
+  after(async () => {
+    await revalidateMainApp([cacheTagCourse({ courseSlug })]);
+  });
+
+  revalidatePath(`/${orgSlug}/c/${lang}/${courseSlug}`);
+  return { error: null };
+}
+
+export async function uploadCourseImageAction(
+  params: ChapterRouteParams,
+  formData: FormData,
+): Promise<{ error: string | null }> {
+  const { courseId, courseSlug, lang, orgSlug } = params;
+  const file = formData.get("file");
+  const t = await getExtracted();
+
+  if (!(file && file instanceof File)) {
+    return { error: t("No file provided") };
+  }
+
+  const { data: imageUrl, error: uploadError } = await processAndUploadImage({
+    file,
+    fileName: `courses/${courseId}/cover.webp`,
+  });
+
+  if (uploadError) {
+    const errorMessages: Record<typeof uploadError, string> = {
+      invalidType: t(
+        "Invalid file type. Please upload a JPEG, PNG, WebP, or GIF image.",
+      ),
+      optimizeFailed: t("Failed to process image. Please try again."),
+      tooLarge: t("File is too large. Maximum size is 5MB."),
+      uploadFailed: t("Failed to upload image. Please try again."),
+    };
+
+    return { error: errorMessages[uploadError] };
+  }
+
+  const { error: updateError } = await updateCourse({
+    courseId,
+    imageUrl,
+  });
+
+  if (updateError) {
+    return { error: await getErrorMessage(updateError) };
+  }
+
+  after(async () => {
+    await revalidateMainApp([cacheTagCourse({ courseSlug })]);
+  });
+
+  revalidatePath(`/${orgSlug}/c/${lang}/${courseSlug}`);
+  return { error: null };
+}
+
+export async function removeCourseImageAction(
+  params: ChapterRouteParams,
+): Promise<{ error: string | null }> {
+  const { courseId, courseSlug, lang, orgSlug } = params;
+  const { error } = await updateCourse({
+    courseId,
+    imageUrl: null,
   });
 
   if (error) {

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
@@ -1,0 +1,81 @@
+import { ContainerHeader } from "@zoonk/ui/components/container";
+import {
+  ImageUploadActionButton,
+  ImageUploadLoading,
+  ImageUploadOverlay,
+  ImageUploadPlaceholder,
+  ImageUploadProvider,
+  ImageUploadRemoveButton,
+  ImageUploadTrigger,
+} from "@zoonk/ui/components/image-upload";
+import { ImageIcon, Trash2Icon, UploadIcon } from "lucide-react";
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import { getExtracted } from "next-intl/server";
+import { getCourse } from "@/data/courses/get-course";
+import { removeCourseImageAction, uploadCourseImageAction } from "./actions";
+
+export async function CourseImage({
+  params,
+}: {
+  params: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]">["params"];
+}) {
+  const { courseSlug, lang, orgSlug } = await params;
+  const t = await getExtracted();
+
+  const { data: course, error } = await getCourse({
+    courseSlug,
+    language: lang,
+    orgSlug,
+  });
+
+  if (error || !course) {
+    return notFound();
+  }
+
+  const routeParams = { courseId: course.id, courseSlug, lang, orgSlug };
+
+  return (
+    <ContainerHeader>
+      <ImageUploadProvider
+        currentImageUrl={course.imageUrl}
+        onRemove={removeCourseImageAction.bind(null, routeParams)}
+        onUpload={uploadCourseImageAction.bind(null, routeParams)}
+      >
+        <ImageUploadTrigger
+          aria-label={
+            course.imageUrl
+              ? t("Change course image")
+              : t("Upload course image")
+          }
+        >
+          {course.imageUrl ? (
+            <Image
+              alt=""
+              className="object-cover transition-opacity group-hover:opacity-80"
+              fill
+              sizes="96px"
+              src={course.imageUrl}
+            />
+          ) : (
+            <ImageUploadPlaceholder>
+              <ImageIcon />
+            </ImageUploadPlaceholder>
+          )}
+
+          <ImageUploadOverlay>
+            <ImageUploadActionButton>
+              <UploadIcon />
+            </ImageUploadActionButton>
+
+            <ImageUploadRemoveButton aria-label={t("Remove image")}>
+              <Trash2Icon />
+            </ImageUploadRemoveButton>
+          </ImageUploadOverlay>
+
+          <ImageUploadLoading />
+        </ImageUploadTrigger>
+      </ImageUploadProvider>
+    </ContainerHeader>
+  );
+}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/course-image.tsx
@@ -8,6 +8,11 @@ import {
   ImageUploadRemoveButton,
   ImageUploadTrigger,
 } from "@zoonk/ui/components/image-upload";
+import {
+  BYTES_PER_MB,
+  DEFAULT_IMAGE_ACCEPTED_TYPES,
+  DEFAULT_IMAGE_MAX_SIZE,
+} from "@zoonk/utils/constants";
 import { ImageIcon, Trash2Icon, UploadIcon } from "lucide-react";
 import Image from "next/image";
 import { notFound } from "next/navigation";
@@ -34,11 +39,26 @@ export async function CourseImage({
   }
 
   const routeParams = { courseId: course.id, courseSlug, lang, orgSlug };
+  const maxSizeMB = DEFAULT_IMAGE_MAX_SIZE / BYTES_PER_MB;
+  const acceptedFormats = DEFAULT_IMAGE_ACCEPTED_TYPES.map((type) =>
+    type.replace("image/", "").toUpperCase(),
+  ).join(", ");
 
   return (
     <ContainerHeader>
       <ImageUploadProvider
         currentImageUrl={course.imageUrl}
+        messages={{
+          invalidType: t(
+            "Invalid file type. Please upload a {formats} image.",
+            { formats: acceptedFormats },
+          ),
+          removeSuccess: t("Image removed"),
+          tooLarge: t("File is too large. Maximum size is {max}MB.", {
+            max: String(maxSizeMB),
+          }),
+          uploadSuccess: t("Image uploaded"),
+        }}
         onRemove={removeCourseImageAction.bind(null, routeParams)}
         onUpload={uploadCourseImageAction.bind(null, routeParams)}
       >

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
@@ -1,4 +1,5 @@
 import { Container } from "@zoonk/ui/components/container";
+import { ImageUploadSkeleton } from "@zoonk/ui/components/image-upload";
 import { Suspense } from "react";
 import { ContentEditorSkeleton } from "@/components/content-editor";
 import { ItemListSkeleton } from "@/components/item-list";
@@ -7,6 +8,7 @@ import { listCourseChapters } from "@/data/chapters/list-course-chapters";
 import { getCourse } from "@/data/courses/get-course";
 import { ChapterList } from "./chapter-list";
 import { CourseContent } from "./course-content";
+import { CourseImage } from "./course-image";
 import { CourseSlug } from "./course-slug";
 
 export default async function CoursePage(
@@ -22,6 +24,10 @@ export default async function CoursePage(
 
   return (
     <Container variant="narrow">
+      <Suspense fallback={<ImageUploadSkeleton />}>
+        <CourseImage params={props.params} />
+      </Suspense>
+
       <Suspense fallback={<ContentEditorSkeleton />}>
         <CourseContent params={props.params} />
       </Suspense>

--- a/apps/editor/src/data/courses/update-course.test.ts
+++ b/apps/editor/src/data/courses/update-course.test.ts
@@ -123,6 +123,28 @@ describe("admins", () => {
     expect(result.data?.slug).toBe("new-slug-multi");
   });
 
+  test("updates imageUrl successfully", async () => {
+    const result = await updateCourse({
+      courseId: course.id,
+      headers,
+      imageUrl: "https://example.com/image.webp",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.imageUrl).toBe("https://example.com/image.webp");
+  });
+
+  test("removes imageUrl by setting it to null", async () => {
+    const result = await updateCourse({
+      courseId: course.id,
+      headers,
+      imageUrl: null,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.imageUrl).toBeNull();
+  });
+
   test("returns Course not found", async () => {
     const result = await updateCourse({
       courseId: 999_999,

--- a/apps/editor/src/data/courses/update-course.ts
+++ b/apps/editor/src/data/courses/update-course.ts
@@ -10,6 +10,7 @@ export async function updateCourse(params: {
   courseId: number;
   description?: string;
   headers?: Headers;
+  imageUrl?: string | null;
   slug?: string;
   title?: string;
 }): Promise<SafeReturn<Course>> {
@@ -43,6 +44,7 @@ export async function updateCourse(params: {
         ...(params.description !== undefined && {
           description: params.description,
         }),
+        ...(params.imageUrl !== undefined && { imageUrl: params.imageUrl }),
         ...(params.slug !== undefined && { slug: toSlug(params.slug) }),
         ...(params.title !== undefined && {
           normalizedTitle: normalizeString(params.title),

--- a/apps/evals/package.json
+++ b/apps/evals/package.json
@@ -5,7 +5,7 @@
     "@zoonk/ui": "workspace:*",
     "@zoonk/utils": "workspace:*",
     "ai": "6.0.3",
-    "lucide-react": "0.556.0",
+    "lucide-react": "0.562.0",
     "next": "16.1.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -9,7 +9,7 @@
     "@zoonk/ui": "workspace:*",
     "@zoonk/utils": "workspace:*",
     "botid": "1.5.10",
-    "lucide-react": "0.556.0",
+    "lucide-react": "0.562.0",
     "next": "16.1.0",
     "next-intl": "4.6.1",
     "react": "19.2.3",

--- a/biome.json
+++ b/biome.json
@@ -116,7 +116,7 @@
         "noEnum": "error",
         "noExportedImports": "error",
         "noInferrableTypes": "error",
-        "noMagicNumbers": "error",
+        "noMagicNumbers": "off",
         "noNamespace": "error",
         "noNegationElse": "error",
         "noNestedTernary": "error",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,7 @@
     "./cache/revalidate": "./src/cache/revalidate-main-app.ts",
     "./courses/image": "./src/courses/course-image.ts",
     "./images/optimize": "./src/images/optimize-image.ts",
+    "./images/process-and-upload": "./src/images/process-and-upload-image.ts",
     "./images/upload": "./src/images/upload-image.ts",
     "./mailer/send": "./src/mailer/send-email.ts",
     "./orgs/find": "./src/orgs/find-org.ts",

--- a/packages/core/src/images/process-and-upload-image.ts
+++ b/packages/core/src/images/process-and-upload-image.ts
@@ -1,0 +1,83 @@
+import "server-only";
+
+import { safeAsync } from "@zoonk/utils/error";
+import { optimizeImage } from "./optimize-image";
+import { uploadImage } from "./upload-image";
+
+const BYTES_PER_MB = 1024 * 1024;
+const DEFAULT_MAX_SIZE = 5 * BYTES_PER_MB;
+
+const DEFAULT_ACCEPTED_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+];
+
+export type ProcessAndUploadImageParams = {
+  file: File;
+  fileName: string;
+  acceptedTypes?: string[];
+  addRandomSuffix?: boolean;
+  format?: "webp" | "jpeg" | "png";
+  maxSize?: number;
+  quality?: number;
+};
+
+export type ProcessAndUploadImageError =
+  | "invalidType"
+  | "tooLarge"
+  | "optimizeFailed"
+  | "uploadFailed";
+
+export type ProcessAndUploadImageResult =
+  | { data: string; error: null }
+  | { data: null; error: ProcessAndUploadImageError };
+
+export async function processAndUploadImage({
+  file,
+  fileName,
+  acceptedTypes = DEFAULT_ACCEPTED_TYPES,
+  addRandomSuffix = true,
+  format = "webp",
+  maxSize = DEFAULT_MAX_SIZE,
+  quality = 80,
+}: ProcessAndUploadImageParams): Promise<ProcessAndUploadImageResult> {
+  if (!acceptedTypes.includes(file.type)) {
+    return { data: null, error: "invalidType" };
+  }
+
+  if (file.size > maxSize) {
+    return { data: null, error: "tooLarge" };
+  }
+
+  const { data: buffer, error: bufferError } = await safeAsync(() =>
+    file.arrayBuffer().then((ab) => Buffer.from(ab)),
+  );
+
+  if (bufferError) {
+    return { data: null, error: "optimizeFailed" };
+  }
+
+  const { data: optimizedImage, error: optimizeError } = await optimizeImage({
+    format,
+    image: buffer,
+    quality,
+  });
+
+  if (optimizeError) {
+    return { data: null, error: "optimizeFailed" };
+  }
+
+  const { data: imageUrl, error: uploadError } = await uploadImage({
+    addRandomSuffix,
+    fileName,
+    image: optimizedImage,
+  });
+
+  if (uploadError) {
+    return { data: null, error: "uploadFailed" };
+  }
+
+  return { data: imageUrl, error: null };
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,7 +47,7 @@
   "name": "@zoonk/ui",
   "peerDependencies": {
     "@tabler/icons-react": ">=3",
-    "lucide-react": ">=0.556.0",
+    "lucide-react": ">=0.562.0",
     "react": ">=19",
     "react-dom": ">=19"
   },

--- a/packages/ui/src/components/image-upload.tsx
+++ b/packages/ui/src/components/image-upload.tsx
@@ -1,0 +1,402 @@
+"use client";
+
+import { LoaderCircleIcon } from "lucide-react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useTransition,
+} from "react";
+import { cn } from "../lib/utils";
+import { Skeleton } from "./skeleton";
+import { toast } from "./sonner";
+
+const BYTES_PER_MB = 1024 * 1024;
+const DEFAULT_MAX_SIZE = 5 * BYTES_PER_MB;
+const DEFAULT_ACCEPTED_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+];
+
+type ImageUploadContextValue = {
+  currentImageUrl: string | null;
+  uploading: boolean;
+  removing: boolean;
+  hasImage: boolean;
+  pending: boolean;
+  openFilePicker: () => void;
+  handleRemove: () => void;
+};
+
+const ImageUploadContext = createContext<ImageUploadContextValue | undefined>(
+  undefined,
+);
+
+function useImageUpload() {
+  const context = useContext(ImageUploadContext);
+  if (!context) {
+    throw new Error(
+      "ImageUpload components must be used within an ImageUploadProvider.",
+    );
+  }
+  return context;
+}
+
+function isValidImage(params: {
+  file: File;
+  acceptedTypes: string[];
+  maxSize: number;
+  onInvalidType?: () => void;
+  onTooLarge?: () => void;
+}): boolean {
+  const { file, acceptedTypes, maxSize, onInvalidType, onTooLarge } = params;
+
+  if (!acceptedTypes.includes(file.type)) {
+    onInvalidType?.();
+    return false;
+  }
+
+  if (file.size > maxSize) {
+    onTooLarge?.();
+    return false;
+  }
+
+  return true;
+}
+
+function ImageUploadProvider({
+  children,
+  currentImageUrl,
+  onUpload,
+  onRemove,
+  onSuccess,
+  onInvalidType,
+  onTooLarge,
+  acceptedTypes = DEFAULT_ACCEPTED_TYPES,
+  maxSize = DEFAULT_MAX_SIZE,
+}: {
+  children: React.ReactNode;
+  currentImageUrl: string | null;
+  onUpload: (formData: FormData) => Promise<{ error: string | null }>;
+  onRemove: () => Promise<{ error: string | null }>;
+  onSuccess?: () => void;
+  onInvalidType?: () => void;
+  onTooLarge?: () => void;
+  acceptedTypes?: string[];
+  maxSize?: number;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [uploading, startUploadTransition] = useTransition();
+  const [removing, startRemoveTransition] = useTransition();
+
+  const defaultInvalidType = useCallback(() => {
+    toast.error(
+      "Invalid file type. Please upload a JPEG, PNG, WebP, or GIF image.",
+    );
+  }, []);
+
+  const defaultTooLarge = useCallback(() => {
+    toast.error("File is too large. Maximum size is 5MB.");
+  }, []);
+
+  const handleFileSelect = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (
+        !(
+          file &&
+          isValidImage({
+            acceptedTypes,
+            file,
+            maxSize,
+            onInvalidType: onInvalidType ?? defaultInvalidType,
+            onTooLarge: onTooLarge ?? defaultTooLarge,
+          })
+        )
+      ) {
+        return;
+      }
+
+      startUploadTransition(async () => {
+        const formData = new FormData();
+        formData.append("file", file);
+
+        const { error } = await onUpload(formData);
+
+        if (error) {
+          toast.error(error);
+        } else {
+          toast.success("Image uploaded");
+          onSuccess?.();
+        }
+      });
+
+      if (inputRef.current) {
+        inputRef.current.value = "";
+      }
+    },
+    [
+      acceptedTypes,
+      maxSize,
+      onUpload,
+      onSuccess,
+      onInvalidType,
+      onTooLarge,
+      defaultInvalidType,
+      defaultTooLarge,
+    ],
+  );
+
+  const openFilePicker = useCallback(() => {
+    inputRef.current?.click();
+  }, []);
+
+  const handleRemove = useCallback(() => {
+    startRemoveTransition(async () => {
+      const { error } = await onRemove();
+
+      if (error) {
+        toast.error(error);
+      } else {
+        toast.success("Image removed");
+        onSuccess?.();
+      }
+    });
+  }, [onRemove, onSuccess]);
+
+  const hasImage = Boolean(currentImageUrl);
+  const pending = uploading || removing;
+
+  const value = useMemo<ImageUploadContextValue>(
+    () => ({
+      currentImageUrl,
+      handleRemove,
+      hasImage,
+      openFilePicker,
+      pending,
+      removing,
+      uploading,
+    }),
+    [
+      currentImageUrl,
+      handleRemove,
+      hasImage,
+      openFilePicker,
+      pending,
+      removing,
+      uploading,
+    ],
+  );
+
+  return (
+    <ImageUploadContext.Provider value={value}>
+      {children}
+      <input
+        accept={acceptedTypes.join(",")}
+        className="hidden"
+        disabled={pending}
+        onChange={handleFileSelect}
+        ref={inputRef}
+        type="file"
+      />
+    </ImageUploadContext.Provider>
+  );
+}
+
+function ImageUploadTrigger({
+  children,
+  className,
+  size = 96,
+  ...props
+}: Omit<React.ComponentProps<"div">, "onClick"> & {
+  size?: number;
+}) {
+  const { hasImage, pending, openFilePicker, handleRemove } = useImageUpload();
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      openFilePicker();
+    } else if (
+      (e.key === "Delete" || e.key === "Backspace") &&
+      hasImage &&
+      !pending
+    ) {
+      e.preventDefault();
+      handleRemove();
+    }
+  }
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: Using div with role="button" because we need to nest a button (delete) inside
+    <div
+      aria-disabled={pending}
+      className={cn(
+        "group relative flex shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-xl bg-muted transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        pending && "pointer-events-none",
+        className,
+      )}
+      data-slot="image-upload-trigger"
+      onClick={openFilePicker}
+      onKeyDown={handleKeyDown}
+      role="button"
+      style={{ height: size, width: size }}
+      tabIndex={pending ? -1 : 0}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ImageUploadOverlay({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  const { pending } = useImageUpload();
+
+  if (pending) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "absolute inset-0 flex items-center justify-center gap-2 bg-background/80 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100",
+        className,
+      )}
+      data-slot="image-upload-overlay"
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ImageUploadLoading({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  const { pending } = useImageUpload();
+
+  if (!pending) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "absolute inset-0 flex items-center justify-center bg-background/80",
+        className,
+      )}
+      data-slot="image-upload-loading"
+      {...props}
+    >
+      <LoaderCircleIcon className="size-6 animate-spin text-muted-foreground" />
+      {children}
+    </div>
+  );
+}
+
+function ImageUploadRemoveButton({
+  children,
+  className,
+  ...props
+}: Omit<React.ComponentProps<"button">, "onClick" | "type">) {
+  const { hasImage, handleRemove } = useImageUpload();
+
+  if (!hasImage) {
+    return null;
+  }
+
+  return (
+    <button
+      className={cn(
+        "flex size-8 items-center justify-center rounded-full bg-background shadow-sm ring-1 ring-border hover:bg-destructive hover:text-destructive-foreground hover:ring-destructive [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      data-slot="image-upload-remove-button"
+      onClick={(e) => {
+        e.stopPropagation();
+        handleRemove();
+      }}
+      type="button"
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ImageUploadPlaceholder({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "size-8 text-muted-foreground transition-colors group-hover:text-foreground [&>svg]:size-full",
+        className,
+      )}
+      data-slot="image-upload-placeholder"
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}
+
+function ImageUploadActionButton({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "flex size-8 items-center justify-center rounded-full bg-background shadow-sm ring-1 ring-border [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      data-slot="image-upload-action-button"
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}
+
+function ImageUploadSkeleton({
+  className,
+  size = 96,
+  ...props
+}: React.ComponentProps<"div"> & {
+  size?: number;
+}) {
+  return (
+    <Skeleton
+      className={cn("rounded-xl", className)}
+      data-slot="image-upload-skeleton"
+      style={{ height: size, width: size }}
+      {...props}
+    />
+  );
+}
+
+export {
+  ImageUploadProvider,
+  ImageUploadTrigger,
+  ImageUploadOverlay,
+  ImageUploadLoading,
+  ImageUploadRemoveButton,
+  ImageUploadPlaceholder,
+  ImageUploadActionButton,
+  ImageUploadSkeleton,
+  useImageUpload,
+};

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -1,2 +1,12 @@
 export const AI_ORG_SLUG = "ai";
 export const SUPPORT_URL = "https://www.zoonk.com/help";
+
+export const BYTES_PER_MB = 1024 * 1024;
+export const DEFAULT_IMAGE_MAX_SIZE = 5 * BYTES_PER_MB;
+
+export const DEFAULT_IMAGE_ACCEPTED_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/utils
       lucide-react:
-        specifier: 0.556.0
-        version: 0.556.0(react@19.2.3)
+        specifier: 0.562.0
+        version: 0.562.0(react@19.2.3)
       next:
         specifier: 16.1.0
         version: 16.1.0(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -85,8 +85,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/utils
       lucide-react:
-        specifier: 0.556.0
-        version: 0.556.0(react@19.2.3)
+        specifier: 0.562.0
+        version: 0.562.0(react@19.2.3)
       next:
         specifier: 16.1.0
         version: 16.1.0(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -155,8 +155,8 @@ importers:
         specifier: 3.0.5
         version: 3.0.5
       lucide-react:
-        specifier: 0.556.0
-        version: 0.556.0(react@19.2.3)
+        specifier: 0.562.0
+        version: 0.562.0(react@19.2.3)
       negotiator:
         specifier: 1.0.0
         version: 1.0.0
@@ -231,8 +231,8 @@ importers:
         specifier: 6.0.3
         version: 6.0.3(zod@4.2.1)
       lucide-react:
-        specifier: 0.556.0
-        version: 0.556.0(react@19.2.3)
+        specifier: 0.562.0
+        version: 0.562.0(react@19.2.3)
       next:
         specifier: 16.1.0
         version: 16.1.0(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -298,8 +298,8 @@ importers:
         specifier: 1.5.10
         version: 1.5.10(next@16.1.0(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       lucide-react:
-        specifier: 0.556.0
-        version: 0.556.0(react@19.2.3)
+        specifier: 0.562.0
+        version: 0.562.0(react@19.2.3)
       next:
         specifier: 16.1.0
         version: 16.1.0(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -650,8 +650,8 @@ importers:
         specifier: 1.4.2
         version: 1.4.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       lucide-react:
-        specifier: '>=0.556.0'
-        version: 0.556.0(react@19.2.3)
+        specifier: '>=0.562.0'
+        version: 0.562.0(react@19.2.3)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -3402,8 +3402,8 @@ packages:
     resolution: {integrity: sha512-Lkk/vx6ak3rYkRR0Nhu4lFUT2VDnQSxBe8Hbl7f36358p6ow8Bnvr8lrLt98H8J1aGxfhbX4Fs5tYg2+FTwr5Q==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
 
-  lucide-react@0.556.0:
-    resolution: {integrity: sha512-iOb8dRk7kLaYBZhR2VlV1CeJGxChBgUthpSP8wom9jfj79qovgG6qcSdiy6vkoREKPnbUYzJsCn4o4PtG3Iy+A==}
+  lucide-react@0.562.0:
+    resolution: {integrity: sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -6941,7 +6941,7 @@ snapshots:
 
   lru.min@1.1.3: {}
 
-  lucide-react@0.556.0(react@19.2.3):
+  lucide-react@0.562.0(react@19.2.3):
     dependencies:
       react: 19.2.3
 


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add course cover image upload to the Editor, with a reusable ImageUpload UI and server-side processing that validates, optimizes to WebP, uploads, and updates the course.

- **New Features**
  - CourseImage on the course page with upload/change/remove and a loading skeleton.
  - New @zoonk/ui ImageUpload components with client-side type/size checks (JPEG/PNG/WebP/GIF, max 5MB) and toasts.
  - Server actions (upload/remove) using @zoonk/core processAndUploadImage to optimize to WebP, upload, save imageUrl, and revalidate caches/paths.
  - Added i18n strings (en/es/pt) for labels and errors; increased serverActions bodySizeLimit to 10mb; tests for imageUrl update/removal.

- **Dependencies**
  - Bumped lucide-react to 0.562.0 across apps and updated @zoonk/ui peer dependency.

<sup>Written for commit 1a7b8b4f5b042961be00f1fa79bca223b0466369. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



