### PR TITLE
feat(editor): manage alternative titles

### DIFF
--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -62,6 +62,11 @@ msgid "No file provided"
 msgstr "No file provided"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "Lp3DO2"
+msgid "Title is required"
+msgstr "Title is required"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
 msgctxt "Q1jVC0"
 msgid "Failed to process image. Please try again."
 msgstr "Failed to process image. Please try again."
@@ -354,6 +359,46 @@ msgstr "Logout"
 msgctxt "gNtXZ8"
 msgid "401 - Unauthorized"
 msgstr "401 - Unauthorized"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "2/2yg+"
+msgid "Add"
+msgstr "Add"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "cvL4Xs"
+msgid "Search titles…"
+msgstr "Search titles…"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "G5e8UX"
+msgid "Remove {title}"
+msgstr "Remove {title}"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "iQDWe6"
+msgid "Alternative titles"
+msgstr "Alternative titles"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "jQY6mT"
+msgid "Add alternative title…"
+msgstr "Add alternative title…"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "n2FbaN"
+msgid "No titles match your search"
+msgstr "No titles match your search"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "oDI/Rp"
+msgid "and {count} more"
+msgstr "and {count} more"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "R6KURz"
+msgid "({count})"
+msgstr "({count})"
 
 #: src/components/content-editor.tsx
 msgctxt "BfrgHC"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -62,6 +62,11 @@ msgid "No file provided"
 msgstr "No se proporcionó ningún archivo"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "Lp3DO2"
+msgid "Title is required"
+msgstr "El título es obligatorio"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
 msgctxt "Q1jVC0"
 msgid "Failed to process image. Please try again."
 msgstr "Error al procesar la imagen. Por favor intenta de nuevo."
@@ -354,6 +359,46 @@ msgstr "Cerrar sesión"
 msgctxt "gNtXZ8"
 msgid "401 - Unauthorized"
 msgstr "401 - No autorizado"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "2/2yg+"
+msgid "Add"
+msgstr "Agregar"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "cvL4Xs"
+msgid "Search titles…"
+msgstr "Buscar títulos…"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "G5e8UX"
+msgid "Remove {title}"
+msgstr "Eliminar {title}"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "iQDWe6"
+msgid "Alternative titles"
+msgstr "Títulos alternativos"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "jQY6mT"
+msgid "Add alternative title…"
+msgstr "Agregar título alternativo…"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "n2FbaN"
+msgid "No titles match your search"
+msgstr "No hay títulos que coincidan con tu búsqueda"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "oDI/Rp"
+msgid "and {count} more"
+msgstr "y {count} más"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "R6KURz"
+msgid "({count})"
+msgstr "({count})"
 
 #: src/components/content-editor.tsx
 msgctxt "BfrgHC"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -62,6 +62,11 @@ msgid "No file provided"
 msgstr "Nenhum arquivo fornecido"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+msgctxt "Lp3DO2"
+msgid "Title is required"
+msgstr "Título é obrigatório"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
 msgctxt "Q1jVC0"
 msgid "Failed to process image. Please try again."
 msgstr "Falha ao processar a imagem. Por favor, tente novamente."
@@ -354,6 +359,46 @@ msgstr "Sair"
 msgctxt "gNtXZ8"
 msgid "401 - Unauthorized"
 msgstr "401 - Não autorizado"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "2/2yg+"
+msgid "Add"
+msgstr "Adicionar"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "cvL4Xs"
+msgid "Search titles…"
+msgstr "Buscar títulos…"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "G5e8UX"
+msgid "Remove {title}"
+msgstr "Remover {title}"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "iQDWe6"
+msgid "Alternative titles"
+msgstr "Títulos alternativos"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "jQY6mT"
+msgid "Add alternative title…"
+msgstr "Adicionar título alternativo…"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "n2FbaN"
+msgid "No titles match your search"
+msgstr "Nenhum título corresponde à sua busca"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "oDI/Rp"
+msgid "and {count} more"
+msgstr "e mais {count}"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "R6KURz"
+msgid "({count})"
+msgstr "({count})"
 
 #: src/components/content-editor.tsx
 msgctxt "BfrgHC"

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { addAlternativeTitles } from "@zoonk/core/alternative-titles/add";
 import { revalidateMainApp } from "@zoonk/core/cache/revalidate";
 import { processAndUploadImage } from "@zoonk/core/images/process-and-upload";
 import { cacheTagCourse } from "@zoonk/utils/cache";
@@ -7,6 +8,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { after } from "next/server";
 import { getExtracted } from "next-intl/server";
+import { deleteAlternativeTitles } from "@/data/alternative-titles/delete-alternative-titles";
 import { createChapter } from "@/data/chapters/create-chapter";
 import { exportChapters } from "@/data/chapters/export-chapters";
 import { importChapters } from "@/data/chapters/import-chapters";
@@ -289,6 +291,42 @@ export async function removeCourseImageAction(
 
   after(async () => {
     await revalidateMainApp([cacheTagCourse({ courseSlug })]);
+  });
+
+  revalidatePath(`/${orgSlug}/c/${lang}/${courseSlug}`);
+  return { error: null };
+}
+
+export async function addAlternativeTitleAction(
+  params: ChapterRouteParams,
+  title: string,
+): Promise<{ error: string | null }> {
+  const { courseId, courseSlug, lang, orgSlug } = params;
+  const t = await getExtracted();
+
+  if (!title.trim()) {
+    return { error: t("Title is required") };
+  }
+
+  await addAlternativeTitles({
+    courseId,
+    locale: lang,
+    titles: [title],
+  });
+
+  revalidatePath(`/${orgSlug}/c/${lang}/${courseSlug}`);
+  return { error: null };
+}
+
+export async function deleteAlternativeTitleAction(
+  params: ChapterRouteParams,
+  slug: string,
+): Promise<{ error: string | null }> {
+  const { courseId, courseSlug, lang, orgSlug } = params;
+
+  await deleteAlternativeTitles({
+    courseId,
+    titles: [slug],
   });
 
   revalidatePath(`/${orgSlug}/c/${lang}/${courseSlug}`);

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/course-alternative-titles.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/course-alternative-titles.tsx
@@ -1,0 +1,47 @@
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { AlternativeTitlesEditor } from "@/components/alternative-titles-editor";
+import { listAlternativeTitles } from "@/data/alternative-titles/list-alternative-titles";
+import { getCourse } from "@/data/courses/get-course";
+import {
+  addAlternativeTitleAction,
+  deleteAlternativeTitleAction,
+} from "./actions";
+
+export async function CourseAlternativeTitles({
+  params,
+}: {
+  params: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]">["params"];
+}) {
+  const { courseSlug, lang, orgSlug } = await params;
+
+  if (orgSlug !== AI_ORG_SLUG) {
+    return null;
+  }
+
+  const { data: course } = await getCourse({
+    courseSlug,
+    language: lang,
+    orgSlug,
+  });
+
+  if (!course) {
+    return null;
+  }
+
+  const titles = await listAlternativeTitles({ courseId: course.id });
+
+  const routeParams = {
+    courseId: course.id,
+    courseSlug,
+    lang,
+    orgSlug,
+  };
+
+  return (
+    <AlternativeTitlesEditor
+      onAdd={addAlternativeTitleAction.bind(null, routeParams)}
+      onDelete={deleteAlternativeTitleAction.bind(null, routeParams)}
+      titles={titles}
+    />
+  );
+}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
@@ -1,12 +1,14 @@
 import { Container } from "@zoonk/ui/components/container";
 import { ImageUploadSkeleton } from "@zoonk/ui/components/image-upload";
 import { Suspense } from "react";
+import { AlternativeTitlesSkeleton } from "@/components/alternative-titles-editor";
 import { ContentEditorSkeleton } from "@/components/content-editor";
 import { ItemListSkeleton } from "@/components/item-list";
 import { SlugEditorSkeleton } from "@/components/slug-editor";
 import { listCourseChapters } from "@/data/chapters/list-course-chapters";
 import { getCourse } from "@/data/courses/get-course";
 import { ChapterList } from "./chapter-list";
+import { CourseAlternativeTitles } from "./course-alternative-titles";
 import { CourseContent } from "./course-content";
 import { CourseImage } from "./course-image";
 import { CourseSlug } from "./course-slug";
@@ -34,6 +36,10 @@ export default async function CoursePage(
 
       <Suspense fallback={<SlugEditorSkeleton />}>
         <CourseSlug params={props.params} />
+      </Suspense>
+
+      <Suspense fallback={<AlternativeTitlesSkeleton />}>
+        <CourseAlternativeTitles params={props.params} />
       </Suspense>
 
       <Suspense fallback={<ItemListSkeleton />}>

--- a/apps/editor/src/components/alternative-titles-editor.tsx
+++ b/apps/editor/src/components/alternative-titles-editor.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { Badge } from "@zoonk/ui/components/badge";
+import { Button } from "@zoonk/ui/components/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@zoonk/ui/components/collapsible";
+import { Input } from "@zoonk/ui/components/input";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { toSlug } from "@zoonk/utils/string";
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  SearchIcon,
+  XIcon,
+} from "lucide-react";
+import { useExtracted } from "next-intl";
+import {
+  startTransition,
+  useActionState,
+  useMemo,
+  useOptimistic,
+  useState,
+} from "react";
+
+const MAX_VISIBLE_ITEMS = 10;
+
+export function AlternativeTitlesEditor({
+  titles,
+  onAdd,
+  onDelete,
+}: {
+  titles: string[];
+  onAdd: (title: string) => Promise<{ error: string | null }>;
+  onDelete: (slug: string) => Promise<{ error: string | null }>;
+}) {
+  const t = useExtracted();
+  const [isOpen, setIsOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [optimisticTitles, updateOptimisticTitles] = useOptimistic(titles);
+
+  const filteredTitles = useMemo(() => {
+    if (!search.trim()) {
+      return optimisticTitles.slice(0, MAX_VISIBLE_ITEMS);
+    }
+
+    const searchLower = search.toLowerCase();
+
+    return optimisticTitles.filter((title) =>
+      title.toLowerCase().includes(searchLower),
+    );
+  }, [optimisticTitles, search]);
+
+  const hasMore = !search.trim() && optimisticTitles.length > MAX_VISIBLE_ITEMS;
+  const hiddenCount = optimisticTitles.length - MAX_VISIBLE_ITEMS;
+
+  async function handleAdd(
+    _state: { error: string | null },
+    formData: FormData,
+  ) {
+    const title = formData.get("title") as string;
+
+    if (!title?.trim()) {
+      return { error: null };
+    }
+
+    const slug = toSlug(title);
+
+    startTransition(() => {
+      updateOptimisticTitles((prev) =>
+        prev.includes(slug) ? prev : [...prev, slug].sort(),
+      );
+    });
+
+    const result = await onAdd(title);
+
+    return result;
+  }
+
+  async function handleDelete(slug: string) {
+    startTransition(() => {
+      updateOptimisticTitles((prev) => prev.filter((item) => item !== slug));
+    });
+
+    await onDelete(slug);
+  }
+
+  const [addState, addAction, isAdding] = useActionState(handleAdd, {
+    error: null,
+  });
+
+  return (
+    <Collapsible onOpenChange={setIsOpen} open={isOpen}>
+      <CollapsibleTrigger className="group flex w-full items-center gap-2 py-2 text-muted-foreground text-sm hover:text-foreground">
+        {isOpen ? (
+          <ChevronDownIcon className="size-4" />
+        ) : (
+          <ChevronRightIcon className="size-4" />
+        )}
+        <span>{t("Alternative titles")}</span>
+        {optimisticTitles.length > 0 && (
+          <span className="text-muted-foreground/60">
+            {t("({count})", { count: String(optimisticTitles.length) })}
+          </span>
+        )}
+      </CollapsibleTrigger>
+
+      <CollapsibleContent className="space-y-3 pb-4">
+        <form action={addAction} className="flex gap-2">
+          <Input
+            className="h-8 text-sm"
+            disabled={isAdding}
+            key={isAdding ? "adding" : "idle"}
+            name="title"
+            placeholder={t("Add alternative title…")}
+          />
+          <Button disabled={isAdding} size="sm" type="submit">
+            {t("Add")}
+          </Button>
+        </form>
+
+        {addState.error && (
+          <p className="text-destructive text-sm">{addState.error}</p>
+        )}
+
+        {optimisticTitles.length > 0 && (
+          <>
+            <div className="relative">
+              <SearchIcon className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                className="h-8 pl-9 text-sm"
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={t("Search titles…")}
+                value={search}
+              />
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {filteredTitles.map((slug) => (
+                <Badge
+                  className="gap-1 pr-1 font-normal"
+                  key={slug}
+                  variant="outline"
+                >
+                  {slug}
+                  <button
+                    aria-label={t("Remove {title}", { title: slug })}
+                    className="rounded-full p-0.5 hover:bg-muted"
+                    onClick={() => handleDelete(slug)}
+                    type="button"
+                  >
+                    <XIcon className="size-3" />
+                  </button>
+                </Badge>
+              ))}
+            </div>
+
+            {hasMore && (
+              <p className="text-muted-foreground text-xs">
+                {t("and {count} more", { count: String(hiddenCount) })}
+              </p>
+            )}
+
+            {search && filteredTitles.length === 0 && (
+              <p className="text-muted-foreground text-sm">
+                {t("No titles match your search")}
+              </p>
+            )}
+          </>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export function AlternativeTitlesSkeleton() {
+  return (
+    <div className="flex items-center gap-2 py-2">
+      <Skeleton className="size-4" />
+      <Skeleton className="h-4 w-32" />
+    </div>
+  );
+}

--- a/i18n.lock
+++ b/i18n.lock
@@ -1,70 +1,59 @@
 version: 1
 checksums:
   15ecf73e0c158929f058900aaa9b24c8:
-    Unsaved/singular: ddc9094aecf93ceabe363846756a9925
-    Saved/singular: 6554b923011266821d74e06e013a40e6
-    Saving%E2%80%A6/singular: ee98ff32f9a585a9108c8cd961d6077e
-    Cancel/singular: 2e2a849c2223911717de8caa2c71bade
-    your-custom-url/singular: 762da425a11b62bd253ca0a1dc48f47d
-    Save/singular: f7a2929f33bc420195e59ac5a8bcd454
-    This%20URL%20is%20already%20in%20use/singular: dfc6df86970a8fa27f4f4b4c3f2716b1
-    URL%20address/singular: e752a4cebaefb0cf38c129ec8edd6b65
-    Delete%20lesson%3F/singular: 7f0eb69c2ada091c8504e0197eae59ab
-    Delete%20lesson/singular: 18309d2fe705fd2c4301224dee3be224
     Delete%20chapter/singular: 17a0d21cc5650c1a8de6e918fd754a63
     Delete%20chapter%3F/singular: 5dfc389e36ee2f05e01896b81bd59493
+    Delete%20lesson%3F/singular: 7f0eb69c2ada091c8504e0197eae59ab
+    Delete%20lesson/singular: 18309d2fe705fd2c4301224dee3be224
     Delete%20course/singular: 86bac6527eb0b380a3f0a5e38b6938ff
     Delete%20course%3F/singular: c83369b40aec2a0eb3cafd146d70020e
     Untitled%20chapter/singular: 28963b46f393d2828ea31c00345d2a2e
+    Invalid%20file%20type.%20Please%20upload%20a%20JPEG%2C%20PNG%2C%20WebP%2C%20or%20GIF%20image./singular: 40eeddb92c25b31b4501d3d3a9df9bb4
+    File%20is%20too%20large.%20Maximum%20size%20is%205MB./singular: cc3c4b1ec696f2d8785996097bd4dfc1
+    Failed%20to%20upload%20image.%20Please%20try%20again./singular: 2fe14e681cc529b661785fdc2abac145
     No%20file%20provided/singular: 04285abfc9d18ce401da2f6f570523a5
+    Title%20is%20required/singular: a8541a9d81ad1f2d007e52328d8b4074
+    Failed%20to%20process%20image.%20Please%20try%20again./singular: 7dd397d230e66c4cc464d501e93caa05
     Add%20a%20description%E2%80%A6/singular: 6737ac865733a3e459ddfeb5b6134ce5
     Untitled%20lesson/singular: 252aefbc39883b5a3aae879535b0c6d2
+    Edit%20chapter%20description/singular: e27c305ac8ad54675309e239bccdd648
+    Edit%20chapter%20title/singular: 21c04bd3ed6335df5195d1f2857131bf
+    Chapter%20description%E2%80%A6/singular: d394513f90a5c9ad1880d364e8fc5cb8
+    Chapter%20title%E2%80%A6/singular: 3ed70a2e64aefe189999ff5899e8a7a2
     Edit%20lesson%20description/singular: b959f1e2fc7f00f593ae2c1a12fd330d
     Lesson%20description%E2%80%A6/singular: 77ad5a9829eda8182865a46455d5a842
     Lesson%20title%E2%80%A6/singular: d7b981d2734c11f2ee5d58f21c93bd3e
     Edit%20lesson%20title/singular: 15b5a30f4a0365bae4da264383dae889
     We%20couldn't%20load%20the%20lessons.%20Please%20try%20again./singular: f2e68b6dd4d7f2eb0c91f20ade06957d
     Contact%20support/singular: 32a4dee2033635e334a5f4d34724e3e0
-    Drop%20file%20or%20click%20to%20select/singular: e18ab4b554f4a2ab70350d565634021e
     Failed%20to%20load%20lessons/singular: 427523eb64ddb239d642ca975d6e1dbb
-    Replace%20(remove%20existing%20first)/singular: 0c375e65816d893151b927f8928c647b
-    Lessons%20imported%20successfully/singular: 117dcb8f25eb05362ffab7974ecdb5de
-    Import%20mode/singular: 99a121a79e9385892a65b17c2be56bfa
-    Import/singular: 348b8ab981de5b7f1fca6d7302263bbd
-    Edit%20chapter%20description/singular: e27c305ac8ad54675309e239bccdd648
+    Drag%20to%20reorder/singular: 42c84478eb582f41d72d5bd7b27bb028
     Try%20again/singular: 33dd8820e743e35a66e6977f69e9d3b5
-    Edit%20chapter%20title/singular: 21c04bd3ed6335df5195d1f2857131bf
-    Show%20expected%20format/singular: 923bfe5861a5c67c5816dcbc1c6efa29
-    Merge%20(add%20to%20existing)/singular: cb7e20a5abf4b5d9ef49cdb09e037d6a
-    Lessons%20exported%20successfully/singular: f896c30aab64bfcc43725f8bd3fc02f7
-    More%20options/singular: 53d90eae6a9b0243b5bc043b3d9de169
-    Chapter%20description%E2%80%A6/singular: d394513f90a5c9ad1880d364e8fc5cb8
     Add%20lesson/singular: 101a1880b35c68eed6f80e7574f4ff2d
-    Export/singular: 709afbc86c5fdca279a111ea8e49d1c9
-    KB/singular: 476c6cddd277e93a1bb7af4a763e95dc
-    Failed%20to%20export/singular: e1ed0bd77fc4509b338f2ed32565012a
-    Import%20lessons/singular: 8d1fae531b7e8156042321586d18b522
-    Chapter%20title%E2%80%A6/singular: 3ed70a2e64aefe189999ff5899e8a7a2
-    Upload%20a%20JSON%20file%20containing%20lessons%20to%20import./singular: a6aec991263d7f81fe5f06e48c4aaa68
-    Course%20title%E2%80%A6/singular: 4429de50f5f2d426271e76328c543daf
-    Chapters%20exported%20successfully/singular: c619d46cc34322ce5777a87ec3cc6131
     Add%20chapter/singular: af2ea03f1678fcea1fb005f66f28bfa5
+    We%20couldn't%20load%20the%20chapters.%20Please%20try%20again./singular: 2bfbac73debefc0d7a4ec5c41af9c415
+    Failed%20to%20load%20chapters/singular: a462d90fffa946fe5c2aedb6e6fff9b4
+    Course%20title%E2%80%A6/singular: 4429de50f5f2d426271e76328c543daf
     Edit%20course%20description/singular: 2304f3ceeea1faaa3a4451c8863ded3b
     Edit%20course%20title/singular: 75b050a3ce516d55c480d633f5da502f
-    Upload%20a%20JSON%20file%20containing%20chapters%20to%20import./singular: 7bd7e36f80ba8cdcd19c18f53962f747
     Course%20description%E2%80%A6/singular: a548f00ce745044f2a2dfbe02b9a0130
-    We%20couldn't%20load%20the%20chapters.%20Please%20try%20again./singular: 2bfbac73debefc0d7a4ec5c41af9c415
-    Import%20chapters/singular: 0bf66ec2862c199b95f19512d832ba9b
-    Failed%20to%20load%20chapters/singular: a462d90fffa946fe5c2aedb6e6fff9b4
-    Chapters%20imported%20successfully/singular: 2a3fda7021d4d81b1cdc6e869f94664f
+    Change%20course%20image/singular: 51e27234e38643678b64ccea088c5d95
+    Invalid%20file%20type.%20Please%20upload%20a%20%7Bformats%7D%20image./singular: 73e35f808f53de532953c8ebc5fc6a61
+    File%20is%20too%20large.%20Maximum%20size%20is%20%7Bmax%7DMB./singular: ebc250a9852fc2e88100ece0bfa02aea
+    Remove%20image/singular: 267ff116441d32ab913c467a8945d534
+    Upload%20course%20image/singular: 3d06104ec6418b93ee038445418c9599
+    Image%20removed/singular: b0eb0cb47f8f6c1a2919713e8d1180e7
+    Image%20uploaded/singular: 4161c70f9863af81286081a2f6bab12f
     Your%20organization%20hasn't%20created%20any%20courses%20yet./singular: 4c09c8406dbf7bfe159f850fc1f22b99
     No%20courses/singular: 72fc2629e79529e927834070a26d2a07
+    Select%20a%20course%20to%20edit%20its%20content/singular: 2f17c5f381acd6ffb1c1109a87e341b5
+    Create%20course/singular: 41f52f80def95a611c9cc3a5e1a11dde
+    Courses/singular: e6d00f3285e8fc48b949af0c4aad3da5
     All%20fields%20are%20required/singular: 01fe4fe061a783c06c001dd39c78053a
     Next/singular: 89ddbcf710eba274963494f312bdc8a9
     Back/singular: f541015a827e37cb3b1234e56bc2aa3c
     Close/singular: 2c2e22f8424a1031de89063bd0022e16
     Create/singular: 757ccd28dd533ff3a933355273c1e32a
-    Create%20course/singular: 41f52f80def95a611c9cc3a5e1a11dde
     A%20brief%20description%20of%20your%20course%E2%80%A6/singular: 26ac2beaaae4ce3f3cccb399935c8b9a
     Course%20description/singular: 19e0252f9b2da688a9b029817995c3b2
     A%20short%20summary%20that%20helps%20learners%20understand%20what%20they'll%20learn/singular: 68a3b304d5ce93306c7059f1af9546f2
@@ -77,12 +66,39 @@ checksums:
     The%20main%20title%20that%20learners%20will%20see%20for%20your%20course/singular: 5e0707d1ace160525f64c1ff51474569
     Course%20title/singular: 40d5c412b95b9a452643c69e48465350
     A%20course%20with%20this%20URL%20already%20exists/singular: 36f9d2ffb6817af1ae69ec6dd37cf5d6
-    Select%20a%20course%20to%20edit%20its%20content/singular: 2f17c5f381acd6ffb1c1109a87e341b5
-    Courses/singular: e6d00f3285e8fc48b949af0c4aad3da5
     You%20can't%20edit%20courses%20for%20this%20organization.%20Log%20in%20with%20another%20account%20or%20switch%20to%20a%20different%20organization./singular: f4c2f472730fa69b3602af2d9cfa56c5
     Login/singular: f4f219abeb5a465ecb1c7efaf50246de
     Logout/singular: 07948fdf20705e04a7bf68ab197512bf
     401%20-%20Unauthorized/singular: 0612c3a47aaacaa9fd8aa3d5f0fbc0b8
+    Add/singular: 87c4a663507f2bcbbf79934af8164e13
+    Search%20titles%E2%80%A6/singular: 17c8f6ebb441b65bcd71751d895b083c
+    Remove%20%7Btitle%7D/singular: 7ea5f663311db30da2ee678435d6c019
+    Alternative%20titles/singular: 46f935d0da3101e12be5dda4fb12e520
+    Add%20alternative%20title%E2%80%A6/singular: cd5bd023fe1686324a3a146a072c968a
+    No%20titles%20match%20your%20search/singular: e35f274fe8b17b3db9b59116ac5b1d5e
+    and%20%7Bcount%7D%20more/singular: 1caeff4ca948a7db83103b95323a62b6
+    (%7Bcount%7D)/singular: 61cc7515856066d5ddb9c5f2087563d8
+    Unsaved/singular: ddc9094aecf93ceabe363846756a9925
+    Saved/singular: 6554b923011266821d74e06e013a40e6
+    Saving%E2%80%A6/singular: ee98ff32f9a585a9108c8cd961d6077e
+    Cancel/singular: 2e2a849c2223911717de8caa2c71bade
+    Drop%20file%20or%20click%20to%20select/singular: e18ab4b554f4a2ab70350d565634021e
+    Replace%20(remove%20existing%20first)/singular: 0c375e65816d893151b927f8928c647b
+    Lessons%20imported%20successfully/singular: 117dcb8f25eb05362ffab7974ecdb5de
+    Import%20mode/singular: 99a121a79e9385892a65b17c2be56bfa
+    Import/singular: 348b8ab981de5b7f1fca6d7302263bbd
+    Chapters%20exported%20successfully/singular: c619d46cc34322ce5777a87ec3cc6131
+    Show%20expected%20format/singular: 923bfe5861a5c67c5816dcbc1c6efa29
+    Merge%20(add%20to%20existing)/singular: cb7e20a5abf4b5d9ef49cdb09e037d6a
+    Lessons%20exported%20successfully/singular: f896c30aab64bfcc43725f8bd3fc02f7
+    More%20options/singular: 53d90eae6a9b0243b5bc043b3d9de169
+    Upload%20a%20JSON%20file%20containing%20chapters%20to%20import./singular: 7bd7e36f80ba8cdcd19c18f53962f747
+    Export/singular: 709afbc86c5fdca279a111ea8e49d1c9
+    Import%20chapters/singular: 0bf66ec2862c199b95f19512d832ba9b
+    Failed%20to%20export/singular: e1ed0bd77fc4509b338f2ed32565012a
+    Import%20lessons/singular: 8d1fae531b7e8156042321586d18b522
+    Chapters%20imported%20successfully/singular: 2a3fda7021d4d81b1cdc6e869f94664f
+    Upload%20a%20JSON%20file%20containing%20lessons%20to%20import./singular: a6aec991263d7f81fe5f06e48c4aaa68
     logout/singular: 77ca3565971e69e420e8eec6f752be84
     home/singular: c227d2c8e5d86a375988bd63ebeececc
     create/singular: 1323e3c278824cce3b4975f937fed459
@@ -93,7 +109,6 @@ checksums:
     No%20results%20found/singular: 5518f2865757dc73900aa03ef8be6934
     dashboard/singular: 3e3998114a2eab7daa3c9a23dbeb16b9
     Lessons/singular: 52fdbe5a3a6ee1cc1e166546516f9111
-    Searching.../singular: 56cf28d6712bf3f7f73af2a81974ac45
     new/singular: 59c16092bc6a4b9de0debe084e4b5f49
     course/singular: a8f5f6a15055aa74f1b98d4821329d19
     Home%20page/singular: aa72464a366b091aa6f2037ca869c09c
@@ -110,6 +125,10 @@ checksums:
     No%20other%20organizations/singular: e9de48fc34aa9de5d30e3eb8eed79ed1
     Draft/singular: e8a92958ad300aacfe46c2bf6644927e
     Published/singular: ad5e035c44f71ed32d41e47c7643f32f
+    your-custom-url/singular: 762da425a11b62bd253ca0a1dc48f47d
+    Save/singular: f7a2929f33bc420195e59ac5a8bcd454
+    This%20URL%20is%20already%20in%20use/singular: dfc6df86970a8fa27f4f4b4c3f2716b1
+    URL%20address/singular: e752a4cebaefb0cf38c129ec8edd6b65
     History/singular: b0578d6d225f512e42f823fbca2e3c32
     Math/singular: 0a604ffa5ef57408918fe98ef05eb05a
     Arts/singular: 9b1845cec1210e57ea990b1a90823228


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an Alternative Titles editor to the course page so admins can add, search, and remove alternative course titles. This is gated to the AI organization and includes optimistic updates and validation.

- **New Features**
  - Collapsible “Alternative titles” section on the course page with a loading skeleton.
  - Add and delete actions with optimistic UI, “Title is required” validation, and page revalidation.
  - Search, show up to 10 items, and display “and {count} more” when there are additional titles.
  - New translations for en/es/pt and updated i18n lock.

<sup>Written for commit 9d295cf506554ed88adb330beecd841d6946a056. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

