### PR TITLE
feat(editor): import/export alternative titles

### DIFF
--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -366,6 +366,48 @@ msgid "Add"
 msgstr "Add"
 
 #: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+#: src/components/navbar/delete-item-button.tsx
+#: src/components/slug-editor.tsx
+msgctxt "47FYwb"
+msgid "Cancel"
+msgstr "Cancel"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "5kTT3Y"
+msgid "Drop file or click to select"
+msgstr "Drop file or click to select"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "6MeYja"
+msgid "Alternative titles exported successfully"
+msgstr "Alternative titles exported successfully"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "70OZD0"
+msgid "Replace (remove existing first)"
+msgstr "Replace (remove existing first)"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "95TwrO"
+msgid "Import mode"
+msgstr "Import mode"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "9XUYQt"
+msgid "Import"
+msgstr "Import"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "AICU1d"
+msgid "Import alternative titles"
+msgstr "Import alternative titles"
+
+#: src/components/alternative-titles-editor.tsx
 msgctxt "cvL4Xs"
 msgid "Search titles…"
 msgstr "Search titles…"
@@ -376,9 +418,27 @@ msgid "Remove {title}"
 msgstr "Remove {title}"
 
 #: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "GAHXbk"
+msgid "Show expected format"
+msgstr "Show expected format"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "HNBlXY"
+msgid "Merge (add to existing)"
+msgstr "Merge (add to existing)"
+
+#: src/components/alternative-titles-editor.tsx
 msgctxt "iQDWe6"
 msgid "Alternative titles"
 msgstr "Alternative titles"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "IzCVhG"
+msgid "More options"
+msgstr "More options"
 
 #: src/components/alternative-titles-editor.tsx
 msgctxt "jQY6mT"
@@ -400,6 +460,28 @@ msgctxt "R6KURz"
 msgid "({count})"
 msgstr "({count})"
 
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr "Export"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "w6G8oe"
+msgid "Failed to export"
+msgstr "Failed to export"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "Ws/LkY"
+msgid "Upload a JSON file containing alternative titles to import."
+msgstr "Upload a JSON file containing alternative titles to import."
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "xl9KyD"
+msgid "Alternative titles imported successfully"
+msgstr "Alternative titles imported successfully"
+
 #: src/components/content-editor.tsx
 msgctxt "BfrgHC"
 msgid "Unsaved"
@@ -416,36 +498,9 @@ msgid "Saving…"
 msgstr "Saving…"
 
 #: src/components/entity-list-actions.tsx
-#: src/components/navbar/delete-item-button.tsx
-#: src/components/slug-editor.tsx
-msgctxt "47FYwb"
-msgid "Cancel"
-msgstr "Cancel"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "5kTT3Y"
-msgid "Drop file or click to select"
-msgstr "Drop file or click to select"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "70OZD0"
-msgid "Replace (remove existing first)"
-msgstr "Replace (remove existing first)"
-
-#: src/components/entity-list-actions.tsx
 msgctxt "8n7YmS"
 msgid "Lessons imported successfully"
 msgstr "Lessons imported successfully"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "95TwrO"
-msgid "Import mode"
-msgstr "Import mode"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "9XUYQt"
-msgid "Import"
-msgstr "Import"
 
 #: src/components/entity-list-actions.tsx
 msgctxt "bc4z39"
@@ -453,24 +508,9 @@ msgid "Chapters exported successfully"
 msgstr "Chapters exported successfully"
 
 #: src/components/entity-list-actions.tsx
-msgctxt "GAHXbk"
-msgid "Show expected format"
-msgstr "Show expected format"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "HNBlXY"
-msgid "Merge (add to existing)"
-msgstr "Merge (add to existing)"
-
-#: src/components/entity-list-actions.tsx
 msgctxt "itDWRC"
 msgid "Lessons exported successfully"
 msgstr "Lessons exported successfully"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "IzCVhG"
-msgid "More options"
-msgstr "More options"
 
 #: src/components/entity-list-actions.tsx
 msgctxt "lwIuOL"
@@ -478,19 +518,9 @@ msgid "Upload a JSON file containing chapters to import."
 msgstr "Upload a JSON file containing chapters to import."
 
 #: src/components/entity-list-actions.tsx
-msgctxt "SVwJTM"
-msgid "Export"
-msgstr "Export"
-
-#: src/components/entity-list-actions.tsx
 msgctxt "TQmijK"
 msgid "Import chapters"
 msgstr "Import chapters"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "w6G8oe"
-msgid "Failed to export"
-msgstr "Failed to export"
 
 #: src/components/entity-list-actions.tsx
 msgctxt "WDo1Sx"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -366,6 +366,48 @@ msgid "Add"
 msgstr "Agregar"
 
 #: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+#: src/components/navbar/delete-item-button.tsx
+#: src/components/slug-editor.tsx
+msgctxt "47FYwb"
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "5kTT3Y"
+msgid "Drop file or click to select"
+msgstr "Suelta el archivo o haz clic para seleccionar"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "6MeYja"
+msgid "Alternative titles exported successfully"
+msgstr "Títulos alternativos exportados exitosamente"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "70OZD0"
+msgid "Replace (remove existing first)"
+msgstr "Reemplazar (eliminar existente primero)"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "95TwrO"
+msgid "Import mode"
+msgstr "Modo de importación"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "9XUYQt"
+msgid "Import"
+msgstr "Importar"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "AICU1d"
+msgid "Import alternative titles"
+msgstr "Importar títulos alternativos"
+
+#: src/components/alternative-titles-editor.tsx
 msgctxt "cvL4Xs"
 msgid "Search titles…"
 msgstr "Buscar títulos…"
@@ -376,9 +418,27 @@ msgid "Remove {title}"
 msgstr "Eliminar {title}"
 
 #: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "GAHXbk"
+msgid "Show expected format"
+msgstr "Mostrar formato esperado"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "HNBlXY"
+msgid "Merge (add to existing)"
+msgstr "Combinar (agregar a existente)"
+
+#: src/components/alternative-titles-editor.tsx
 msgctxt "iQDWe6"
 msgid "Alternative titles"
 msgstr "Títulos alternativos"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "IzCVhG"
+msgid "More options"
+msgstr "Más opciones"
 
 #: src/components/alternative-titles-editor.tsx
 msgctxt "jQY6mT"
@@ -400,6 +460,28 @@ msgctxt "R6KURz"
 msgid "({count})"
 msgstr "({count})"
 
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr "Exportar"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "w6G8oe"
+msgid "Failed to export"
+msgstr "Error al exportar"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "Ws/LkY"
+msgid "Upload a JSON file containing alternative titles to import."
+msgstr "Sube un archivo JSON que contenga los títulos alternativos para importar."
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "xl9KyD"
+msgid "Alternative titles imported successfully"
+msgstr "Títulos alternativos importados exitosamente"
+
 #: src/components/content-editor.tsx
 msgctxt "BfrgHC"
 msgid "Unsaved"
@@ -416,36 +498,9 @@ msgid "Saving…"
 msgstr "Guardando…"
 
 #: src/components/entity-list-actions.tsx
-#: src/components/navbar/delete-item-button.tsx
-#: src/components/slug-editor.tsx
-msgctxt "47FYwb"
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "5kTT3Y"
-msgid "Drop file or click to select"
-msgstr "Suelta el archivo o haz clic para seleccionar"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "70OZD0"
-msgid "Replace (remove existing first)"
-msgstr "Reemplazar (eliminar existente primero)"
-
-#: src/components/entity-list-actions.tsx
 msgctxt "8n7YmS"
 msgid "Lessons imported successfully"
 msgstr "Lecciones importadas exitosamente"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "95TwrO"
-msgid "Import mode"
-msgstr "Modo de importación"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "9XUYQt"
-msgid "Import"
-msgstr "Importar"
 
 #: src/components/entity-list-actions.tsx
 msgctxt "bc4z39"
@@ -453,24 +508,9 @@ msgid "Chapters exported successfully"
 msgstr "Capítulos exportados exitosamente"
 
 #: src/components/entity-list-actions.tsx
-msgctxt "GAHXbk"
-msgid "Show expected format"
-msgstr "Mostrar formato esperado"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "HNBlXY"
-msgid "Merge (add to existing)"
-msgstr "Combinar (agregar a existente)"
-
-#: src/components/entity-list-actions.tsx
 msgctxt "itDWRC"
 msgid "Lessons exported successfully"
 msgstr "Lecciones exportadas exitosamente"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "IzCVhG"
-msgid "More options"
-msgstr "Más opciones"
 
 #: src/components/entity-list-actions.tsx
 msgctxt "lwIuOL"
@@ -478,19 +518,9 @@ msgid "Upload a JSON file containing chapters to import."
 msgstr "Sube un archivo JSON que contenga los capítulos a importar."
 
 #: src/components/entity-list-actions.tsx
-msgctxt "SVwJTM"
-msgid "Export"
-msgstr "Exportar"
-
-#: src/components/entity-list-actions.tsx
 msgctxt "TQmijK"
 msgid "Import chapters"
 msgstr "Importar capítulos"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "w6G8oe"
-msgid "Failed to export"
-msgstr "Error al exportar"
 
 #: src/components/entity-list-actions.tsx
 msgctxt "WDo1Sx"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -366,6 +366,48 @@ msgid "Add"
 msgstr "Adicionar"
 
 #: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+#: src/components/navbar/delete-item-button.tsx
+#: src/components/slug-editor.tsx
+msgctxt "47FYwb"
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "5kTT3Y"
+msgid "Drop file or click to select"
+msgstr "Solte o arquivo ou clique para selecionar"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "6MeYja"
+msgid "Alternative titles exported successfully"
+msgstr "Títulos alternativos exportados com sucesso"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "70OZD0"
+msgid "Replace (remove existing first)"
+msgstr "Substituir (remover existentes primeiro)"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "95TwrO"
+msgid "Import mode"
+msgstr "Modo de importação"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "9XUYQt"
+msgid "Import"
+msgstr "Importar"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "AICU1d"
+msgid "Import alternative titles"
+msgstr "Importar títulos alternativos"
+
+#: src/components/alternative-titles-editor.tsx
 msgctxt "cvL4Xs"
 msgid "Search titles…"
 msgstr "Buscar títulos…"
@@ -376,9 +418,27 @@ msgid "Remove {title}"
 msgstr "Remover {title}"
 
 #: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "GAHXbk"
+msgid "Show expected format"
+msgstr "Mostrar formato esperado"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "HNBlXY"
+msgid "Merge (add to existing)"
+msgstr "Mesclar (adicionar aos existentes)"
+
+#: src/components/alternative-titles-editor.tsx
 msgctxt "iQDWe6"
 msgid "Alternative titles"
 msgstr "Títulos alternativos"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "IzCVhG"
+msgid "More options"
+msgstr "Mais opções"
 
 #: src/components/alternative-titles-editor.tsx
 msgctxt "jQY6mT"
@@ -400,6 +460,28 @@ msgctxt "R6KURz"
 msgid "({count})"
 msgstr "({count})"
 
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr "Exportar"
+
+#: src/components/alternative-titles-editor.tsx
+#: src/components/entity-list-actions.tsx
+msgctxt "w6G8oe"
+msgid "Failed to export"
+msgstr "Falha ao exportar"
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "Ws/LkY"
+msgid "Upload a JSON file containing alternative titles to import."
+msgstr "Envie um arquivo JSON contendo os títulos alternativos para importar."
+
+#: src/components/alternative-titles-editor.tsx
+msgctxt "xl9KyD"
+msgid "Alternative titles imported successfully"
+msgstr "Títulos alternativos importados com sucesso"
+
 #: src/components/content-editor.tsx
 msgctxt "BfrgHC"
 msgid "Unsaved"
@@ -416,36 +498,9 @@ msgid "Saving…"
 msgstr "Salvando…"
 
 #: src/components/entity-list-actions.tsx
-#: src/components/navbar/delete-item-button.tsx
-#: src/components/slug-editor.tsx
-msgctxt "47FYwb"
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "5kTT3Y"
-msgid "Drop file or click to select"
-msgstr "Solte o arquivo ou clique para selecionar"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "70OZD0"
-msgid "Replace (remove existing first)"
-msgstr "Substituir (remover existentes primeiro)"
-
-#: src/components/entity-list-actions.tsx
 msgctxt "8n7YmS"
 msgid "Lessons imported successfully"
 msgstr "Aulas importadas com sucesso"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "95TwrO"
-msgid "Import mode"
-msgstr "Modo de importação"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "9XUYQt"
-msgid "Import"
-msgstr "Importar"
 
 #: src/components/entity-list-actions.tsx
 msgctxt "bc4z39"
@@ -453,24 +508,9 @@ msgid "Chapters exported successfully"
 msgstr "Capítulos exportados com sucesso"
 
 #: src/components/entity-list-actions.tsx
-msgctxt "GAHXbk"
-msgid "Show expected format"
-msgstr "Mostrar formato esperado"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "HNBlXY"
-msgid "Merge (add to existing)"
-msgstr "Mesclar (adicionar aos existentes)"
-
-#: src/components/entity-list-actions.tsx
 msgctxt "itDWRC"
 msgid "Lessons exported successfully"
 msgstr "Aulas exportadas com sucesso"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "IzCVhG"
-msgid "More options"
-msgstr "Mais opções"
 
 #: src/components/entity-list-actions.tsx
 msgctxt "lwIuOL"
@@ -478,19 +518,9 @@ msgid "Upload a JSON file containing chapters to import."
 msgstr "Envie um arquivo JSON contendo os capítulos para importar."
 
 #: src/components/entity-list-actions.tsx
-msgctxt "SVwJTM"
-msgid "Export"
-msgstr "Exportar"
-
-#: src/components/entity-list-actions.tsx
 msgctxt "TQmijK"
 msgid "Import chapters"
 msgstr "Importar capítulos"
-
-#: src/components/entity-list-actions.tsx
-msgctxt "w6G8oe"
-msgid "Failed to export"
-msgstr "Falha ao exportar"
 
 #: src/components/entity-list-actions.tsx
 msgctxt "WDo1Sx"

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/course-alternative-titles.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/course-alternative-titles.tsx
@@ -5,6 +5,8 @@ import { getCourse } from "@/data/courses/get-course";
 import {
   addAlternativeTitleAction,
   deleteAlternativeTitleAction,
+  exportAlternativeTitlesAction,
+  importAlternativeTitlesAction,
 } from "./actions";
 
 export async function CourseAlternativeTitles({
@@ -41,6 +43,8 @@ export async function CourseAlternativeTitles({
     <AlternativeTitlesEditor
       onAdd={addAlternativeTitleAction.bind(null, routeParams)}
       onDelete={deleteAlternativeTitleAction.bind(null, routeParams)}
+      onExport={exportAlternativeTitlesAction.bind(null, course.id)}
+      onImport={importAlternativeTitlesAction.bind(null, routeParams)}
       titles={titles}
     />
   );

--- a/apps/editor/src/components/alternative-titles-editor.tsx
+++ b/apps/editor/src/components/alternative-titles-editor.tsx
@@ -7,13 +7,31 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@zoonk/ui/components/collapsible";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@zoonk/ui/components/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@zoonk/ui/components/dropdown-menu";
 import { Input } from "@zoonk/ui/components/input";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { toast } from "@zoonk/ui/components/sonner";
 import { toSlug } from "@zoonk/utils/string";
 import {
   ChevronDownIcon,
   ChevronRightIcon,
+  DownloadIcon,
+  EllipsisVerticalIcon,
   SearchIcon,
+  UploadIcon,
   XIcon,
 } from "lucide-react";
 import { useExtracted } from "next-intl";
@@ -23,23 +41,73 @@ import {
   useMemo,
   useOptimistic,
   useState,
+  useTransition,
 } from "react";
+import {
+  ImportCancel,
+  ImportDropzone,
+  ImportFormatPreview,
+  ImportModeOption,
+  ImportModeSelector,
+  ImportProvider,
+  ImportSubmit,
+} from "./import";
 
 const MAX_VISIBLE_ITEMS = 10;
+
+const IMPORT_FORMAT = {
+  alternativeTitles: ["title-slug-1", "title-slug-2"],
+};
 
 export function AlternativeTitlesEditor({
   titles,
   onAdd,
   onDelete,
+  onExport,
+  onImport,
 }: {
   titles: string[];
   onAdd: (title: string) => Promise<{ error: string | null }>;
   onDelete: (slug: string) => Promise<{ error: string | null }>;
+  onExport: () => Promise<{ data: object | null; error: Error | null }>;
+  onImport: (formData: FormData) => Promise<{ error: string | null }>;
 }) {
   const t = useExtracted();
   const [isOpen, setIsOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const [importOpen, setImportOpen] = useState(false);
+  const [exportPending, startExportTransition] = useTransition();
   const [optimisticTitles, updateOptimisticTitles] = useOptimistic(titles);
+
+  function handleExport() {
+    startExportTransition(async () => {
+      const { data, error } = await onExport();
+
+      if (error || !data) {
+        toast.error(error?.message ?? t("Failed to export"));
+        return;
+      }
+
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "alternative-titles.json";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+
+      toast.success(t("Alternative titles exported successfully"));
+    });
+  }
+
+  function handleImportSuccess() {
+    toast.success(t("Alternative titles imported successfully"));
+    setImportOpen(false);
+  }
 
   const filteredTitles = useMemo(() => {
     if (!search.trim()) {
@@ -92,92 +160,158 @@ export function AlternativeTitlesEditor({
   });
 
   return (
-    <Collapsible onOpenChange={setIsOpen} open={isOpen}>
-      <CollapsibleTrigger className="group flex w-full items-center gap-2 py-2 text-muted-foreground text-sm hover:text-foreground">
-        {isOpen ? (
-          <ChevronDownIcon className="size-4" />
-        ) : (
-          <ChevronRightIcon className="size-4" />
-        )}
-        <span>{t("Alternative titles")}</span>
-        {optimisticTitles.length > 0 && (
-          <span className="text-muted-foreground/60">
-            {t("({count})", { count: String(optimisticTitles.length) })}
-          </span>
-        )}
-      </CollapsibleTrigger>
+    <>
+      <Collapsible className="px-4" onOpenChange={setIsOpen} open={isOpen}>
+        <CollapsibleTrigger className="group flex w-full items-center gap-2 py-2 text-muted-foreground text-sm hover:text-foreground">
+          {isOpen ? (
+            <ChevronDownIcon className="size-4" />
+          ) : (
+            <ChevronRightIcon className="size-4" />
+          )}
+          <span>{t("Alternative titles")}</span>
+          {optimisticTitles.length > 0 && (
+            <span className="text-muted-foreground/60">
+              {t("({count})", { count: String(optimisticTitles.length) })}
+            </span>
+          )}
+        </CollapsibleTrigger>
 
-      <CollapsibleContent className="space-y-3 pb-4">
-        <form action={addAction} className="flex gap-2">
-          <Input
-            className="h-8 text-sm"
-            disabled={isAdding}
-            key={isAdding ? "adding" : "idle"}
-            name="title"
-            placeholder={t("Add alternative title…")}
-          />
-          <Button disabled={isAdding} size="sm" type="submit">
-            {t("Add")}
-          </Button>
-        </form>
+        <CollapsibleContent className="space-y-3 pb-4">
+          <form action={addAction} className="flex gap-2">
+            <Input
+              className="h-8 text-sm"
+              disabled={isAdding}
+              key={isAdding ? "adding" : "idle"}
+              name="title"
+              placeholder={t("Add alternative title…")}
+            />
+            <Button disabled={isAdding} size="sm" type="submit">
+              {t("Add")}
+            </Button>
 
-        {addState.error && (
-          <p className="text-destructive text-sm">{addState.error}</p>
-        )}
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                disabled={exportPending}
+                render={<Button size="icon-sm" variant="ghost" />}
+              >
+                <EllipsisVerticalIcon />
+                <span className="sr-only">{t("More options")}</span>
+              </DropdownMenuTrigger>
 
-        {optimisticTitles.length > 0 && (
-          <>
-            <div className="relative">
-              <SearchIcon className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                className="h-8 pl-9 text-sm"
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder={t("Search titles…")}
-                value={search}
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => setImportOpen(true)}>
+                  <UploadIcon />
+                  {t("Import")}
+                </DropdownMenuItem>
+
+                <DropdownMenuItem onClick={handleExport}>
+                  <DownloadIcon />
+                  {t("Export")}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </form>
+
+          {addState.error && (
+            <p className="text-destructive text-sm">{addState.error}</p>
+          )}
+
+          {optimisticTitles.length > 0 && (
+            <>
+              <div className="relative">
+                <SearchIcon className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  className="h-8 pl-9 text-sm"
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder={t("Search titles…")}
+                  value={search}
+                />
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {filteredTitles.map((slug) => (
+                  <Badge
+                    className="gap-1 pr-1 font-normal"
+                    key={slug}
+                    variant="outline"
+                  >
+                    {slug}
+                    <button
+                      aria-label={t("Remove {title}", { title: slug })}
+                      className="rounded-full p-0.5 hover:bg-muted"
+                      onClick={() => handleDelete(slug)}
+                      type="button"
+                    >
+                      <XIcon className="size-3" />
+                    </button>
+                  </Badge>
+                ))}
+              </div>
+
+              {hasMore && (
+                <p className="text-muted-foreground text-xs">
+                  {t("and {count} more", { count: String(hiddenCount) })}
+                </p>
+              )}
+
+              {search && filteredTitles.length === 0 && (
+                <p className="text-muted-foreground text-sm">
+                  {t("No titles match your search")}
+                </p>
+              )}
+            </>
+          )}
+        </CollapsibleContent>
+      </Collapsible>
+
+      <ImportProvider onImport={onImport} onSuccess={handleImportSuccess}>
+        <Dialog onOpenChange={setImportOpen} open={importOpen}>
+          <DialogContent className="max-h-[calc(100vh-4rem)] overflow-y-auto sm:max-w-lg">
+            <DialogHeader>
+              <DialogTitle>{t("Import alternative titles")}</DialogTitle>
+              <DialogDescription>
+                {t(
+                  "Upload a JSON file containing alternative titles to import.",
+                )}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="grid min-w-0 gap-6">
+              <ImportDropzone>
+                {t("Drop file or click to select")}
+              </ImportDropzone>
+
+              <ImportModeSelector label={t("Import mode")}>
+                <ImportModeOption value="merge">
+                  {t("Merge (add to existing)")}
+                </ImportModeOption>
+                <ImportModeOption value="replace">
+                  {t("Replace (remove existing first)")}
+                </ImportModeOption>
+              </ImportModeSelector>
+
+              <ImportFormatPreview
+                format={IMPORT_FORMAT}
+                label={t("Show expected format")}
               />
             </div>
 
-            <div className="flex flex-wrap gap-2">
-              {filteredTitles.map((slug) => (
-                <Badge
-                  className="gap-1 pr-1 font-normal"
-                  key={slug}
-                  variant="outline"
-                >
-                  {slug}
-                  <button
-                    aria-label={t("Remove {title}", { title: slug })}
-                    className="rounded-full p-0.5 hover:bg-muted"
-                    onClick={() => handleDelete(slug)}
-                    type="button"
-                  >
-                    <XIcon className="size-3" />
-                  </button>
-                </Badge>
-              ))}
-            </div>
-
-            {hasMore && (
-              <p className="text-muted-foreground text-xs">
-                {t("and {count} more", { count: String(hiddenCount) })}
-              </p>
-            )}
-
-            {search && filteredTitles.length === 0 && (
-              <p className="text-muted-foreground text-sm">
-                {t("No titles match your search")}
-              </p>
-            )}
-          </>
-        )}
-      </CollapsibleContent>
-    </Collapsible>
+            <DialogFooter>
+              <ImportCancel onClick={() => setImportOpen(false)}>
+                {t("Cancel")}
+              </ImportCancel>
+              <ImportSubmit>{t("Import")}</ImportSubmit>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </ImportProvider>
+    </>
   );
 }
 
 export function AlternativeTitlesSkeleton() {
   return (
-    <div className="flex items-center gap-2 py-2">
+    <div className="flex items-center gap-2 px-4 py-2">
       <Skeleton className="size-4" />
       <Skeleton className="h-4 w-32" />
     </div>

--- a/i18n.lock
+++ b/i18n.lock
@@ -71,31 +71,35 @@ checksums:
     Logout/singular: 07948fdf20705e04a7bf68ab197512bf
     401%20-%20Unauthorized/singular: 0612c3a47aaacaa9fd8aa3d5f0fbc0b8
     Add/singular: 87c4a663507f2bcbbf79934af8164e13
+    Cancel/singular: 2e2a849c2223911717de8caa2c71bade
+    Drop%20file%20or%20click%20to%20select/singular: e18ab4b554f4a2ab70350d565634021e
+    Alternative%20titles%20exported%20successfully/singular: 533d342c9b0ff576b40b1098d8e6d03c
+    Replace%20(remove%20existing%20first)/singular: 0c375e65816d893151b927f8928c647b
+    Import%20mode/singular: 99a121a79e9385892a65b17c2be56bfa
+    Import/singular: 348b8ab981de5b7f1fca6d7302263bbd
+    Import%20alternative%20titles/singular: 6184f68131e1b31ce82b27e682c32473
     Search%20titles%E2%80%A6/singular: 17c8f6ebb441b65bcd71751d895b083c
     Remove%20%7Btitle%7D/singular: 7ea5f663311db30da2ee678435d6c019
+    Show%20expected%20format/singular: 923bfe5861a5c67c5816dcbc1c6efa29
+    Merge%20(add%20to%20existing)/singular: cb7e20a5abf4b5d9ef49cdb09e037d6a
     Alternative%20titles/singular: 46f935d0da3101e12be5dda4fb12e520
+    More%20options/singular: 53d90eae6a9b0243b5bc043b3d9de169
     Add%20alternative%20title%E2%80%A6/singular: cd5bd023fe1686324a3a146a072c968a
     No%20titles%20match%20your%20search/singular: e35f274fe8b17b3db9b59116ac5b1d5e
     and%20%7Bcount%7D%20more/singular: 1caeff4ca948a7db83103b95323a62b6
     (%7Bcount%7D)/singular: 61cc7515856066d5ddb9c5f2087563d8
+    Export/singular: 709afbc86c5fdca279a111ea8e49d1c9
+    Failed%20to%20export/singular: e1ed0bd77fc4509b338f2ed32565012a
+    Upload%20a%20JSON%20file%20containing%20alternative%20titles%20to%20import./singular: 7dd18059ccf7955ba864342fdc0d6629
+    Alternative%20titles%20imported%20successfully/singular: ca67e17d28382d5ef29bd27219a4104e
     Unsaved/singular: ddc9094aecf93ceabe363846756a9925
     Saved/singular: 6554b923011266821d74e06e013a40e6
     Saving%E2%80%A6/singular: ee98ff32f9a585a9108c8cd961d6077e
-    Cancel/singular: 2e2a849c2223911717de8caa2c71bade
-    Drop%20file%20or%20click%20to%20select/singular: e18ab4b554f4a2ab70350d565634021e
-    Replace%20(remove%20existing%20first)/singular: 0c375e65816d893151b927f8928c647b
     Lessons%20imported%20successfully/singular: 117dcb8f25eb05362ffab7974ecdb5de
-    Import%20mode/singular: 99a121a79e9385892a65b17c2be56bfa
-    Import/singular: 348b8ab981de5b7f1fca6d7302263bbd
     Chapters%20exported%20successfully/singular: c619d46cc34322ce5777a87ec3cc6131
-    Show%20expected%20format/singular: 923bfe5861a5c67c5816dcbc1c6efa29
-    Merge%20(add%20to%20existing)/singular: cb7e20a5abf4b5d9ef49cdb09e037d6a
     Lessons%20exported%20successfully/singular: f896c30aab64bfcc43725f8bd3fc02f7
-    More%20options/singular: 53d90eae6a9b0243b5bc043b3d9de169
     Upload%20a%20JSON%20file%20containing%20chapters%20to%20import./singular: 7bd7e36f80ba8cdcd19c18f53962f747
-    Export/singular: 709afbc86c5fdca279a111ea8e49d1c9
     Import%20chapters/singular: 0bf66ec2862c199b95f19512d832ba9b
-    Failed%20to%20export/singular: e1ed0bd77fc4509b338f2ed32565012a
     Import%20lessons/singular: 8d1fae531b7e8156042321586d18b522
     Chapters%20imported%20successfully/singular: 2a3fda7021d4d81b1cdc6e869f94664f
     Upload%20a%20JSON%20file%20containing%20lessons%20to%20import./singular: a6aec991263d7f81fe5f06e48c4aaa68


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add import/export for course alternative titles in the editor to enable easy bulk management. Supports JSON import (merge or replace) and JSON export with success/error toasts.

- **New Features**
  - Added server actions: importAlternativeTitlesAction and exportAlternativeTitlesAction (with revalidation and error handling).
  - Updated AlternativeTitlesEditor: “More options” menu with Import/Export, import dialog with dropzone, mode selector (merge/replace), and format preview; success/failure toasts.
  - Wired actions in CourseAlternativeTitles via onExport/onImport bindings.
  - Added/enabled i18n strings for EN/ES/PT and updated i18n.lock.

<sup>Written for commit 6053ebe54f969ed3eb55069a7825eec719212ebd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

