### PR TITLE
feat(main): list user courses

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -160,6 +160,7 @@ msgid "Online Courses using AI"
 msgstr "Online Courses using AI"
 
 #: src/app/[locale]/(catalog)/courses/page.tsx
+#: src/app/[locale]/(catalog)/my/user-course-list.tsx
 msgctxt "s+Ncqj"
 msgid "Explore courses"
 msgstr "Explore courses"
@@ -260,6 +261,11 @@ msgid "Learn Anything with AI"
 msgstr "Learn Anything with AI"
 
 #: src/app/[locale]/(catalog)/my/page.tsx
+msgctxt "Dr13kE"
+msgid "Continue where you left off"
+msgstr "Continue where you left off"
+
+#: src/app/[locale]/(catalog)/my/page.tsx
 msgctxt "eeNr/Y"
 msgid "My Courses"
 msgstr "My Courses"
@@ -268,6 +274,16 @@ msgstr "My Courses"
 msgctxt "wfuVYZ"
 msgid "View all the courses you started on Zoonk. Continue where you left off and track your progress across interactive lessons and activities."
 msgstr "View all the courses you started on Zoonk. Continue where you left off and track your progress across interactive lessons and activities."
+
+#: src/app/[locale]/(catalog)/my/user-course-list.tsx
+msgctxt "azX41u"
+msgid "Start learning something new today."
+msgstr "Start learning something new today."
+
+#: src/app/[locale]/(catalog)/my/user-course-list.tsx
+msgctxt "BDHWkf"
+msgid "No courses yet"
+msgstr "No courses yet"
 
 #: src/app/[locale]/(catalog)/page.tsx
 msgctxt "qsfeMJ"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -160,6 +160,7 @@ msgid "Online Courses using AI"
 msgstr "Cursos en línea con IA"
 
 #: src/app/[locale]/(catalog)/courses/page.tsx
+#: src/app/[locale]/(catalog)/my/user-course-list.tsx
 msgctxt "s+Ncqj"
 msgid "Explore courses"
 msgstr "Explorar cursos"
@@ -260,6 +261,11 @@ msgid "Learn Anything with AI"
 msgstr "Aprende cualquier cosa con IA"
 
 #: src/app/[locale]/(catalog)/my/page.tsx
+msgctxt "Dr13kE"
+msgid "Continue where you left off"
+msgstr "Continúa donde lo dejaste"
+
+#: src/app/[locale]/(catalog)/my/page.tsx
 msgctxt "eeNr/Y"
 msgid "My Courses"
 msgstr "Mis cursos"
@@ -268,6 +274,16 @@ msgstr "Mis cursos"
 msgctxt "wfuVYZ"
 msgid "View all the courses you started on Zoonk. Continue where you left off and track your progress across interactive lessons and activities."
 msgstr "Ve todos los cursos que has comenzado en Zoonk. Continúa donde lo dejaste y haz seguimiento de tu progreso en lecciones y actividades interactivas."
+
+#: src/app/[locale]/(catalog)/my/user-course-list.tsx
+msgctxt "azX41u"
+msgid "Start learning something new today."
+msgstr "Comienza a aprender algo nuevo hoy."
+
+#: src/app/[locale]/(catalog)/my/user-course-list.tsx
+msgctxt "BDHWkf"
+msgid "No courses yet"
+msgstr "Aún no hay cursos"
 
 #: src/app/[locale]/(catalog)/page.tsx
 msgctxt "qsfeMJ"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -160,6 +160,7 @@ msgid "Online Courses using AI"
 msgstr "Cursos online usando IA"
 
 #: src/app/[locale]/(catalog)/courses/page.tsx
+#: src/app/[locale]/(catalog)/my/user-course-list.tsx
 msgctxt "s+Ncqj"
 msgid "Explore courses"
 msgstr "Explorar cursos"
@@ -260,6 +261,11 @@ msgid "Learn Anything with AI"
 msgstr "Aprenda qualquer coisa com IA"
 
 #: src/app/[locale]/(catalog)/my/page.tsx
+msgctxt "Dr13kE"
+msgid "Continue where you left off"
+msgstr "Continue de onde você parou"
+
+#: src/app/[locale]/(catalog)/my/page.tsx
 msgctxt "eeNr/Y"
 msgid "My Courses"
 msgstr "Meus cursos"
@@ -268,6 +274,16 @@ msgstr "Meus cursos"
 msgctxt "wfuVYZ"
 msgid "View all the courses you started on Zoonk. Continue where you left off and track your progress across interactive lessons and activities."
 msgstr "Veja todos os cursos que você começou no Zoonk. Continue de onde parou e acompanhe seu progresso nas aulas interativas e atividades."
+
+#: src/app/[locale]/(catalog)/my/user-course-list.tsx
+msgctxt "azX41u"
+msgid "Start learning something new today."
+msgstr "Comece a aprender algo novo hoje."
+
+#: src/app/[locale]/(catalog)/my/user-course-list.tsx
+msgctxt "BDHWkf"
+msgid "No courses yet"
+msgstr "Ainda não há cursos"
 
 #: src/app/[locale]/(catalog)/page.tsx
 msgctxt "qsfeMJ"

--- a/apps/main/src/app/[locale]/(catalog)/my/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/my/page.tsx
@@ -1,5 +1,14 @@
+import {
+  Container,
+  ContainerDescription,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
 import type { Metadata } from "next";
-import { getExtracted } from "next-intl/server";
+import { getExtracted, setRequestLocale } from "next-intl/server";
+import { Suspense } from "react";
+import { UserCourseList, UserCourseListSkeleton } from "./user-course-list";
 
 export async function generateMetadata({
   params,
@@ -15,6 +24,26 @@ export async function generateMetadata({
   };
 }
 
-export default async function MyCourses() {
-  return <main>{}</main>;
+export default async function MyCourses({ params }: PageProps<"/[locale]/my">) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const t = await getExtracted();
+
+  return (
+    <Container variant="list">
+      <ContainerHeader>
+        <ContainerHeaderGroup>
+          <ContainerTitle>{t("My Courses")}</ContainerTitle>
+          <ContainerDescription>
+            {t("Continue where you left off")}
+          </ContainerDescription>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <Suspense fallback={<UserCourseListSkeleton />}>
+        <UserCourseList />
+      </Suspense>
+    </Container>
+  );
 }

--- a/apps/main/src/app/[locale]/(catalog)/my/user-course-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/my/user-course-list.tsx
@@ -1,0 +1,93 @@
+import { buttonVariants } from "@zoonk/ui/components/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@zoonk/ui/components/empty";
+import {
+  CourseListGroup,
+  CourseListItemView,
+  CourseListSkeleton,
+} from "@zoonk/ui/patterns/courses/list";
+import { NotebookPenIcon } from "lucide-react";
+import Image from "next/image";
+import { getExtracted } from "next-intl/server";
+import {
+  listUserCourses,
+  type UserCourse,
+} from "@/data/courses/list-user-courses";
+import { Link } from "@/i18n/navigation";
+
+function toCourseListItem(course: UserCourse) {
+  return {
+    description: course.description,
+    id: course.id,
+    imageUrl: course.imageUrl,
+    slug: course.slug,
+    title: course.title,
+  };
+}
+
+export async function UserCourseList() {
+  const t = await getExtracted();
+  const { data: courses } = await listUserCourses();
+
+  if (!courses || courses.length === 0) {
+    return (
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <NotebookPenIcon aria-hidden="true" />
+          </EmptyMedia>
+          <EmptyTitle>{t("No courses yet")}</EmptyTitle>
+          <EmptyDescription>
+            {t("Start learning something new today.")}
+          </EmptyDescription>
+        </EmptyHeader>
+
+        <EmptyContent>
+          <Link
+            className={buttonVariants({ variant: "outline" })}
+            href="/courses"
+          >
+            {t("Explore courses")}
+          </Link>
+        </EmptyContent>
+      </Empty>
+    );
+  }
+
+  return (
+    <CourseListGroup>
+      {courses.map((course) => (
+        <CourseListItemView
+          course={toCourseListItem(course)}
+          image={
+            course.imageUrl ? (
+              <Image
+                alt={course.title}
+                height={64}
+                src={course.imageUrl}
+                width={64}
+              />
+            ) : undefined
+          }
+          key={course.id}
+          linkComponent={
+            <Link
+              href={`/b/${course.organization.slug}/c/${course.slug}`}
+              prefetch={false}
+            />
+          }
+        />
+      ))}
+    </CourseListGroup>
+  );
+}
+
+export function UserCourseListSkeleton() {
+  return <CourseListSkeleton count={5} />;
+}

--- a/i18n.lock
+++ b/i18n.lock
@@ -189,7 +189,12 @@ checksums:
     Settings/singular: 8df6777277469c1fd88cc18dde2f1cc3
     Support/singular: 55aab5fd0f31a9cb055a2edeeedfaf63
     Subscription/singular: ba9f3675e18987d067d48533c8897343
+    Loading%20more%20courses%E2%80%A6/singular: 290733f8b53c88f64b385ba9dd320acf
+    No%20courses%20available%20yet./singular: 1a6b72175b8ad0ce36f9cb0bcaab4c84
+    No%20courses/singular: 72fc2629e79529e927834070a26d2a07
+    Start%20learning%20something%20new%20today/singular: 727ed4b5249a54fc3975f77b91e96757
     Online%20Courses%20using%20AI/singular: 4e3c619f363cc66f3f2e604e372ca038
+    Explore%20courses/singular: 3a60fa1d4a1a6cfffcc0573e3366cd35
     Explore%20all%20Zoonk%20courses%20to%20learn%20anything%20using%20AI.%20Find%20interactive%20lessons%2C%20challenges%2C%20and%20activities%20to%20learn%20subjects%20like%20science%2C%20math%2C%20technology%2C%20and%20more./singular: c3f4a7dfd17b4523b5535f40170c7731
     Did%20you%20like%20this%20content%3F/singular: 23b97024cf20ceee3ee4a1ddc65d251c
     Send%20feedback/singular: 9631cc08d49da04475b30a0d320ce97c
@@ -209,8 +214,11 @@ checksums:
     Tell%20Zoonk%20what%20you%20want%20to%20learn%20and%20get%20a%20course%20generated%20by%20AI.%20Start%20learning%20any%20subject%20with%20interactive%20lessons%20and%20activities./singular: bce6930e3cd7b20455ea7996a65cbe4f
     What%20do%20you%20want%20to%20learn%3F/singular: eae5c853dbe20fa2e1eacb1e8396d3de
     Learn%20Anything%20with%20AI/singular: af8ba68f4986f321a1025e9b0f4ac794
+    Continue%20where%20you%20left%20off/singular: c3ef4fd14e046d53816ede13fc5d27fc
     My%20Courses/singular: 3031c7801404796addff2b7d796fa4c2
     View%20all%20the%20courses%20you%20started%20on%20Zoonk.%20Continue%20where%20you%20left%20off%20and%20track%20your%20progress%20across%20interactive%20lessons%20and%20activities./singular: eee1ce9f3b0be49ddc9bb3ce21270796
+    Start%20learning%20something%20new%20today./singular: 55903bfd6e1f8c3e95c73ec67427ed11
+    No%20courses%20yet/singular: d5fcc38466fdc83a74eab5032a2f85b6
     Zoonk%3A%20AI%20Learning%20Platform/singular: 4a2d25490f4a5e5cd4543f48fcec968d
     Zoonk%20is%20an%20AI-powered%20learning%20platform%20where%20you%20can%20learn%20anything%20through%20interactive%20courses%2C%20lessons%2C%20and%20activities./singular: e836899ce8100db55d5fa54fe6375970
     Checking%20if%20you're%20logged%20in.../singular: b50f05bfcb51cad6913150273e551291


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces a localized My Courses page that lists a user’s courses with loading skeleton and an empty state, making it easy to continue where they left off. Also updates the data layer to include organization info for course links.

- New Features
  - My Courses page with header and description, plus UserCourseList with skeleton and empty state (CTA to Explore courses).
  - Courses link to organization paths using org slug; new strings translated in en/es/pt.

- Refactors
  - listUserCourses now returns courses with organization included and removes the limit parameter; still ordered by most recent. 
  - Tests updated to assert organization fields and drop limit checks.

<sup>Written for commit a71ffc762a22f2c4eb76918e6bcd1849a6d64545. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

