### PR TITLE
feat(main): add category page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,7 @@ All packages should follow a consistent structure:
 - Use `safeAsync` when using `await` to better handle errors
 - When creating a skeleton, use the `Skeleton` component from `@zoonk/ui/components/skeleton`
 - Always build skeleton components when using `Suspense` for loading states
+- Always place skeletons in the same file as the component they're loading for, not in a separate file
 - Don't add comments to a component's props
 - Pass types directly to the component declaration instead of using `type` since those types won't be exported/reused
 - When adding a new Prisma model, always add a seed for it in `packages/db/src/prisma/seed/`
@@ -252,9 +253,13 @@ See these existing patterns in the codebase:
 
 - When updating `app-error.ts` files also update `error-messages.ts` to include the new error code and run `pnpm build` to update PO files
 - For apps using `next-intl`, use `getExtracted` or `useExtracted`. This will extract the translations to PO files when we run `pnpm build`
-- You can't pass the `t` function from `getExtracted` or `useExtracted` to other functions or components. Instead, call it directly in the component or function
+- You can't pass the `t` function from `getExtracted` or `useExtracted` to other functions or components. Instead, call it directly in the component or function. Eg. don't do this: `myFunction(t, label)` instead do this: `myFunction(t("label"))`
+- **IMPORTANT: The `t` function from `getExtracted`/`useExtracted` does NOT support dynamic values**. You cannot use `t(getLabel(value))`. Instead, you need to use string literals: `t("Arts courses")`, `t("Business courses")`, etc
+- You CAN use string interpolation in `getExtracted`/`useExtracted` to get the translation for a dynamic value. For example: `t("Explore all {category} courses", { category: "arts" })`
 - Whenever using `getExtracted` or `useExtracted`, run `pnpm build` to update PO files
 - Run `pnpm i18n:check` to check for any missing translations and translate empty strings in PO files, making sure translations are consistent across the codebase
+- When you see a `MISSING_TRANSLATION` error (or similar), it means the PO file hasn't been translated. Just go to the PO file and translate the empty strings
+- You don't need to pass a locale to `getExtracted` when using RSC, only on `generateMetadata` or server actions. It works without a locale on server components
 
 ## CSS
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ All packages should follow a consistent structure:
 - Use `safeAsync` when using `await` to better handle errors
 - When creating a skeleton, use the `Skeleton` component from `@zoonk/ui/components/skeleton`
 - Always build skeleton components when using `Suspense` for loading states
+- Always place skeletons in the same file as the component they're loading for, not in a separate file
 - Don't add comments to a component's props
 - Pass types directly to the component declaration instead of using `type` since those types won't be exported/reused
 - When adding a new Prisma model, always add a seed for it in `packages/db/src/prisma/seed/`
@@ -252,9 +253,13 @@ See these existing patterns in the codebase:
 
 - When updating `app-error.ts` files also update `error-messages.ts` to include the new error code and run `pnpm build` to update PO files
 - For apps using `next-intl`, use `getExtracted` or `useExtracted`. This will extract the translations to PO files when we run `pnpm build`
-- You can't pass the `t` function from `getExtracted` or `useExtracted` to other functions or components. Instead, call it directly in the component or function
+- You can't pass the `t` function from `getExtracted` or `useExtracted` to other functions or components. Instead, call it directly in the component or function. Eg. don't do this: `myFunction(t, label)` instead do this: `myFunction(t("label"))`
+- **IMPORTANT: The `t` function from `getExtracted`/`useExtracted` does NOT support dynamic values**. You cannot use `t(getLabel(value))`. Instead, you need to use string literals: `t("Arts courses")`, `t("Business courses")`, etc
+- You CAN use string interpolation in `getExtracted`/`useExtracted` to get the translation for a dynamic value. For example: `t("Explore all {category} courses", { category: "arts" })`
 - Whenever using `getExtracted` or `useExtracted`, run `pnpm build` to update PO files
 - Run `pnpm i18n:check` to check for any missing translations and translate empty strings in PO files, making sure translations are consistent across the codebase
+- When you see a `MISSING_TRANSLATION` error (or similar), it means the PO file hasn't been translated. Just go to the PO file and translate the empty strings
+- You don't need to pass a locale to `getExtracted` when using RSC, only on `generateMetadata` or server actions. It works without a locale on server components
 
 ## CSS
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -134,6 +134,16 @@ msgctxt "R/6nsx"
 msgid "Subscription"
 msgstr "Subscription"
 
+#: src/app/[locale]/(catalog)/courses/category-pills.tsx
+msgctxt "tuZsq+"
+msgid "Course categories"
+msgstr "Course categories"
+
+#: src/app/[locale]/(catalog)/courses/category-pills.tsx
+msgctxt "zQvVDJ"
+msgid "All"
+msgstr "All"
+
 #: src/app/[locale]/(catalog)/courses/course-list-client.tsx
 msgctxt "T0mfNV"
 msgid "Loading more courses…"
@@ -538,80 +548,115 @@ msgctxt "eUzs3M"
 msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "djJp6c"
 msgid "History"
 msgstr "History"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "dPgwrL"
 msgid "Math"
 msgstr "Math"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "fFt3il"
 msgid "Arts"
 msgstr "Arts"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "GsBRWL"
 msgid "Languages"
 msgstr "Languages"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "hlmkcL"
 msgid "Health"
 msgstr "Health"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "hwL7a0"
 msgid "Engineering"
 msgstr "Engineering"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "I1ZCPK"
 msgid "Technology"
 msgstr "Technology"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "KOuDOE"
 msgid "Economics"
 msgstr "Economics"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "mn6pIm"
 msgid "Culture"
 msgstr "Culture"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "n5D/Ku"
 msgid "Communication"
 msgstr "Communication"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "OV/2+4"
 msgid "Society"
 msgstr "Society"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "qydxOd"
 msgid "Science"
 msgstr "Science"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "u3ovjm"
 msgid "Law"
 msgstr "Law"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "w1Fanr"
 msgid "Business"
 msgstr "Business"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "YMDBNH"
 msgid "Geography"
 msgstr "Geography"
+
+#: src/lib/categories.ts
+msgctxt "4HKnmB"
+msgid "{category} Courses"
+msgstr "{category} Courses"
+
+#: src/lib/categories.ts
+msgctxt "EMi23I"
+msgid "Explore all {category} courses"
+msgstr "Explore all {category} courses"
+
+#: src/lib/categories.ts
+msgctxt "Rz9oL+"
+msgid "{category} courses"
+msgstr "{category} courses"
+
+#: src/lib/categories.ts
+msgctxt "XL8IWT"
+msgid "{category} courses. The best {category} online courses, interactive lessons to learn."
+msgstr "{category} courses. The best {category} online courses, interactive lessons to learn."
 
 #: src/lib/error-messages.ts
 msgctxt "3IKub9"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -134,6 +134,16 @@ msgctxt "R/6nsx"
 msgid "Subscription"
 msgstr "Suscripción"
 
+#: src/app/[locale]/(catalog)/courses/category-pills.tsx
+msgctxt "tuZsq+"
+msgid "Course categories"
+msgstr "Categorías de cursos"
+
+#: src/app/[locale]/(catalog)/courses/category-pills.tsx
+msgctxt "zQvVDJ"
+msgid "All"
+msgstr "Todos"
+
 #: src/app/[locale]/(catalog)/courses/course-list-client.tsx
 msgctxt "T0mfNV"
 msgid "Loading more courses…"
@@ -538,80 +548,115 @@ msgctxt "eUzs3M"
 msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Envíanos comentarios, preguntas o sugerencias. Completa el formulario a continuación o escríbenos directamente a contacto@zoonk.com."
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "djJp6c"
 msgid "History"
 msgstr "Historia"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "dPgwrL"
 msgid "Math"
 msgstr "Matemáticas"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "fFt3il"
 msgid "Arts"
 msgstr "Artes"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "GsBRWL"
 msgid "Languages"
 msgstr "Idiomas"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "hlmkcL"
 msgid "Health"
 msgstr "Salud"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "hwL7a0"
 msgid "Engineering"
 msgstr "Ingeniería"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "I1ZCPK"
 msgid "Technology"
 msgstr "Tecnología"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "KOuDOE"
 msgid "Economics"
 msgstr "Economía"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "mn6pIm"
 msgid "Culture"
 msgstr "Cultura"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "n5D/Ku"
 msgid "Communication"
 msgstr "Comunicación"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "OV/2+4"
 msgid "Society"
 msgstr "Sociedad"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "qydxOd"
 msgid "Science"
 msgstr "Ciencia"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "u3ovjm"
 msgid "Law"
 msgstr "Derecho"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "w1Fanr"
 msgid "Business"
 msgstr "Negocios"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "YMDBNH"
 msgid "Geography"
 msgstr "Geografía"
+
+#: src/lib/categories.ts
+msgctxt "4HKnmB"
+msgid "{category} Courses"
+msgstr "Cursos de {category}"
+
+#: src/lib/categories.ts
+msgctxt "EMi23I"
+msgid "Explore all {category} courses"
+msgstr "Explorar todos los cursos de {category}"
+
+#: src/lib/categories.ts
+msgctxt "Rz9oL+"
+msgid "{category} courses"
+msgstr "Cursos de {category}"
+
+#: src/lib/categories.ts
+msgctxt "XL8IWT"
+msgid "{category} courses. The best {category} online courses, interactive lessons to learn."
+msgstr "Cursos de {category}. Los mejores cursos en línea de {category}, lecciones interactivas para aprender."
 
 #: src/lib/error-messages.ts
 msgctxt "3IKub9"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -134,6 +134,16 @@ msgctxt "R/6nsx"
 msgid "Subscription"
 msgstr "Assinatura"
 
+#: src/app/[locale]/(catalog)/courses/category-pills.tsx
+msgctxt "tuZsq+"
+msgid "Course categories"
+msgstr "Categorias de cursos"
+
+#: src/app/[locale]/(catalog)/courses/category-pills.tsx
+msgctxt "zQvVDJ"
+msgid "All"
+msgstr "Todos"
+
 #: src/app/[locale]/(catalog)/courses/course-list-client.tsx
 msgctxt "T0mfNV"
 msgid "Loading more courses…"
@@ -538,80 +548,115 @@ msgctxt "eUzs3M"
 msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Envie feedback, perguntas ou sugestões para a gente. Preencha o formulário abaixo ou envie um email diretamente para contato@zoonk.com."
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "djJp6c"
 msgid "History"
 msgstr "História"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "dPgwrL"
 msgid "Math"
 msgstr "Matemática"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "fFt3il"
 msgid "Arts"
 msgstr "Artes"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "GsBRWL"
 msgid "Languages"
 msgstr "Idiomas"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "hlmkcL"
 msgid "Health"
 msgstr "Saúde"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "hwL7a0"
 msgid "Engineering"
 msgstr "Engenharia"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "I1ZCPK"
 msgid "Technology"
 msgstr "Tecnologia"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "KOuDOE"
 msgid "Economics"
 msgstr "Economia"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "mn6pIm"
 msgid "Culture"
 msgstr "Cultura"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "n5D/Ku"
 msgid "Communication"
 msgstr "Comunicação"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "OV/2+4"
 msgid "Society"
 msgstr "Sociedade"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "qydxOd"
 msgid "Science"
-msgstr "Ciência"
+msgstr "Ciências"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "u3ovjm"
 msgid "Law"
 msgstr "Direito"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "w1Fanr"
 msgid "Business"
 msgstr "Negócios"
 
+#: src/hooks/use-categories.ts
 #: src/lib/categories.ts
 msgctxt "YMDBNH"
 msgid "Geography"
 msgstr "Geografia"
+
+#: src/lib/categories.ts
+msgctxt "4HKnmB"
+msgid "{category} Courses"
+msgstr "Cursos de {category}"
+
+#: src/lib/categories.ts
+msgctxt "EMi23I"
+msgid "Explore all {category} courses"
+msgstr "Explorar todos os cursos de {category}"
+
+#: src/lib/categories.ts
+msgctxt "Rz9oL+"
+msgid "{category} courses"
+msgstr "Cursos de {category}"
+
+#: src/lib/categories.ts
+msgctxt "XL8IWT"
+msgid "{category} courses. The best {category} online courses, interactive lessons to learn."
+msgstr "Cursos de {category}. Os melhores cursos online de {category}, aulas interativas pra aprender."
 
 #: src/lib/error-messages.ts
 msgctxt "3IKub9"

--- a/apps/main/src/app/[locale]/(catalog)/courses/[category]/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/courses/[category]/page.tsx
@@ -1,0 +1,68 @@
+"use cache";
+
+import {
+  Container,
+  ContainerDescription,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
+import { cacheTagCoursesListByCategory } from "@zoonk/utils/cache";
+import { COURSE_CATEGORIES, isValidCategory } from "@zoonk/utils/categories";
+import type { Metadata } from "next";
+import { cacheTag } from "next/cache";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { LIST_COURSES_LIMIT, listCourses } from "@/data/courses/list-courses";
+import { getCategoryHeader, getCategoryMeta } from "@/lib/categories";
+import { CourseListClient } from "../course-list-client";
+
+export async function generateStaticParams() {
+  return COURSE_CATEGORIES.map((category) => ({ category }));
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps<"/[locale]/courses/[category]">): Promise<Metadata> {
+  const { category, locale } = await params;
+
+  if (!isValidCategory(category)) {
+    return {};
+  }
+
+  return getCategoryMeta({ category, locale });
+}
+
+export default async function CategoryCourses({
+  params,
+}: PageProps<"/[locale]/courses/[category]">) {
+  const { category, locale } = await params;
+
+  if (!isValidCategory(category)) {
+    notFound();
+  }
+
+  setRequestLocale(locale);
+  cacheTag(cacheTagCoursesListByCategory({ category, language: locale }));
+
+  const header = await getCategoryHeader(category);
+  const courses = await listCourses({ category, language: locale });
+
+  return (
+    <Container variant="list">
+      <ContainerHeader>
+        <ContainerHeaderGroup>
+          <ContainerTitle>{header.title}</ContainerTitle>
+          <ContainerDescription>{header.description}</ContainerDescription>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <CourseListClient
+        category={category}
+        initialCourses={courses}
+        language={locale}
+        limit={LIST_COURSES_LIMIT}
+      />
+    </Container>
+  );
+}

--- a/apps/main/src/app/[locale]/(catalog)/courses/actions.ts
+++ b/apps/main/src/app/[locale]/(catalog)/courses/actions.ts
@@ -1,12 +1,15 @@
 "use server";
 
+import type { CourseCategory } from "@zoonk/utils/categories";
 import { listCourses } from "@/data/courses/list-courses";
 
 export async function loadMoreCourses(params: {
+  category?: CourseCategory;
   cursor: number;
   language: string;
 }) {
   const courses = await listCourses({
+    category: params.category,
     cursor: params.cursor,
     language: params.language,
   });

--- a/apps/main/src/app/[locale]/(catalog)/courses/category-pills.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/courses/category-pills.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { buttonVariants } from "@zoonk/ui/components/button";
+import { ScrollArea, ScrollBar } from "@zoonk/ui/components/scroll-area";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { useSelectedLayoutSegment } from "next/navigation";
+import { useExtracted } from "next-intl";
+import { useCategories } from "@/hooks/use-categories";
+import { Link } from "@/i18n/navigation";
+
+export function CategoryPillsSkeleton() {
+  return (
+    <div className="mx-auto w-full lg:max-w-xl">
+      <div className="flex gap-2 px-4 pt-4 pb-2 lg:pt-0">
+        <Skeleton className="h-8 w-12 rounded-4xl" />
+        <Skeleton className="h-8 w-16 rounded-4xl" />
+        <Skeleton className="h-8 w-24 rounded-4xl" />
+        <Skeleton className="h-8 w-20 rounded-4xl" />
+        <Skeleton className="h-8 w-20 rounded-4xl" />
+        <Skeleton className="h-8 w-16 rounded-4xl" />
+      </div>
+    </div>
+  );
+}
+
+export function CategoryPills() {
+  const segment = useSelectedLayoutSegment();
+  const categories = useCategories();
+  const t = useExtracted();
+
+  return (
+    <ScrollArea className="w-full px-4 pb-4">
+      <nav aria-label={t("Course categories")} className="flex gap-2">
+        <Link
+          className={buttonVariants({
+            size: "sm",
+            variant: segment === null ? "default" : "outline",
+          })}
+          href="/courses"
+        >
+          {t("All")}
+        </Link>
+
+        {categories
+          .sort((a, b) => a.label.localeCompare(b.label))
+          .map((category) => (
+            <Link
+              className={buttonVariants({
+                size: "sm",
+                variant: segment === category.key ? "default" : "outline",
+              })}
+              href={`/courses/${category.key}`}
+              key={category.key}
+            >
+              <category.icon aria-hidden className="size-4" />
+              {category.label}
+            </Link>
+          ))}
+      </nav>
+
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+  );
+}

--- a/apps/main/src/app/[locale]/(catalog)/courses/course-list-client.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/courses/course-list-client.tsx
@@ -8,6 +8,7 @@ import {
   CourseListItemView,
 } from "@zoonk/ui/patterns/courses/list";
 import { EmptyView } from "@zoonk/ui/patterns/empty";
+import type { CourseCategory } from "@zoonk/utils/categories";
 import { Loader2Icon, NotebookPenIcon } from "lucide-react";
 import Image from "next/image";
 import { useExtracted } from "next-intl";
@@ -25,10 +26,12 @@ function toCourseListItem(course: Course): CourseListItem {
 }
 
 export function CourseListClient({
+  category,
   initialCourses,
   language,
   limit,
 }: {
+  category?: CourseCategory;
   initialCourses: Course[];
   language: string;
   limit: number;
@@ -40,7 +43,7 @@ export function CourseListClient({
     isLoading,
     sentryRef,
   } = useInfiniteList<Course, number>({
-    fetchMore: (cursor) => loadMoreCourses({ cursor, language }),
+    fetchMore: (cursor) => loadMoreCourses({ category, cursor, language }),
     getCursor: (course) => course.id,
     getKey: (course) => course.id,
     initialItems: initialCourses,

--- a/apps/main/src/app/[locale]/(catalog)/courses/layout.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/courses/layout.tsx
@@ -1,0 +1,20 @@
+"use cache";
+
+import { Suspense } from "react";
+import { CategoryPills, CategoryPillsSkeleton } from "./category-pills";
+
+export default async function CoursesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Suspense fallback={<CategoryPillsSkeleton />}>
+        <CategoryPills />
+      </Suspense>
+
+      {children}
+    </>
+  );
+}

--- a/apps/main/src/hooks/use-categories.ts
+++ b/apps/main/src/hooks/use-categories.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useExtracted } from "next-intl";
+import type { CategoryInfo } from "@/lib/categories";
+import { CATEGORY_ICONS } from "@/lib/categories";
+
+export function useCategories(): CategoryInfo[] {
+  const t = useExtracted();
+
+  return [
+    { icon: CATEGORY_ICONS.arts, key: "arts", label: t("Arts") },
+    { icon: CATEGORY_ICONS.business, key: "business", label: t("Business") },
+    {
+      icon: CATEGORY_ICONS.communication,
+      key: "communication",
+      label: t("Communication"),
+    },
+    { icon: CATEGORY_ICONS.culture, key: "culture", label: t("Culture") },
+    {
+      icon: CATEGORY_ICONS.economics,
+      key: "economics",
+      label: t("Economics"),
+    },
+    {
+      icon: CATEGORY_ICONS.engineering,
+      key: "engineering",
+      label: t("Engineering"),
+    },
+    {
+      icon: CATEGORY_ICONS.geography,
+      key: "geography",
+      label: t("Geography"),
+    },
+    { icon: CATEGORY_ICONS.health, key: "health", label: t("Health") },
+    { icon: CATEGORY_ICONS.history, key: "history", label: t("History") },
+    {
+      icon: CATEGORY_ICONS.languages,
+      key: "languages",
+      label: t("Languages"),
+    },
+    { icon: CATEGORY_ICONS.law, key: "law", label: t("Law") },
+    { icon: CATEGORY_ICONS.math, key: "math", label: t("Math") },
+    { icon: CATEGORY_ICONS.science, key: "science", label: t("Science") },
+    { icon: CATEGORY_ICONS.society, key: "society", label: t("Society") },
+    { icon: CATEGORY_ICONS.tech, key: "tech", label: t("Technology") },
+  ];
+}

--- a/apps/main/src/lib/categories.ts
+++ b/apps/main/src/lib/categories.ts
@@ -1,4 +1,5 @@
 import type { CourseCategory } from "@zoonk/utils/categories";
+import type { LucideIcon } from "lucide-react";
 import {
   Briefcase,
   Calculator,
@@ -18,26 +19,109 @@ import {
 } from "lucide-react";
 import { getExtracted } from "next-intl/server";
 
-export async function getCategoryData(category: CourseCategory) {
-  const t = await getExtracted();
+export type CategoryInfo = {
+  icon: LucideIcon;
+  key: CourseCategory;
+  label: string;
+};
 
-  const data = {
-    arts: { icon: Palette, label: t("Arts") },
-    business: { icon: Briefcase, label: t("Business") },
-    communication: { icon: MessageCircle, label: t("Communication") },
-    culture: { icon: Globe, label: t("Culture") },
-    economics: { icon: TrendingUp, label: t("Economics") },
-    engineering: { icon: Wrench, label: t("Engineering") },
-    geography: { icon: MapIcon, label: t("Geography") },
-    health: { icon: Heart, label: t("Health") },
-    history: { icon: Clock, label: t("History") },
-    languages: { icon: Languages, label: t("Languages") },
-    law: { icon: Scale, label: t("Law") },
-    math: { icon: Calculator, label: t("Math") },
-    science: { icon: FlaskConical, label: t("Science") },
-    society: { icon: Users, label: t("Society") },
-    tech: { icon: Cpu, label: t("Technology") },
+export const CATEGORY_ICONS: Record<CourseCategory, LucideIcon> = {
+  arts: Palette,
+  business: Briefcase,
+  communication: MessageCircle,
+  culture: Globe,
+  economics: TrendingUp,
+  engineering: Wrench,
+  geography: MapIcon,
+  health: Heart,
+  history: Clock,
+  languages: Languages,
+  law: Scale,
+  math: Calculator,
+  science: FlaskConical,
+  society: Users,
+  tech: Cpu,
+};
+
+export async function getCategories(params?: {
+  locale: string;
+}): Promise<CategoryInfo[]> {
+  const t = await getExtracted(params);
+
+  return [
+    { icon: CATEGORY_ICONS.arts, key: "arts", label: t("Arts") },
+    { icon: CATEGORY_ICONS.business, key: "business", label: t("Business") },
+    {
+      icon: CATEGORY_ICONS.communication,
+      key: "communication",
+      label: t("Communication"),
+    },
+    { icon: CATEGORY_ICONS.culture, key: "culture", label: t("Culture") },
+    {
+      icon: CATEGORY_ICONS.economics,
+      key: "economics",
+      label: t("Economics"),
+    },
+    {
+      icon: CATEGORY_ICONS.engineering,
+      key: "engineering",
+      label: t("Engineering"),
+    },
+    {
+      icon: CATEGORY_ICONS.geography,
+      key: "geography",
+      label: t("Geography"),
+    },
+    { icon: CATEGORY_ICONS.health, key: "health", label: t("Health") },
+    { icon: CATEGORY_ICONS.history, key: "history", label: t("History") },
+    {
+      icon: CATEGORY_ICONS.languages,
+      key: "languages",
+      label: t("Languages"),
+    },
+    { icon: CATEGORY_ICONS.law, key: "law", label: t("Law") },
+    { icon: CATEGORY_ICONS.math, key: "math", label: t("Math") },
+    { icon: CATEGORY_ICONS.science, key: "science", label: t("Science") },
+    { icon: CATEGORY_ICONS.society, key: "society", label: t("Society") },
+    { icon: CATEGORY_ICONS.tech, key: "tech", label: t("Technology") },
+  ];
+}
+
+async function getCategoryLabel(
+  category: CourseCategory,
+  opts?: {
+    locale: string;
+  },
+): Promise<string> {
+  const categories = await getCategories(opts);
+
+  return categories.find((cat) => cat.key === category)?.label ?? "";
+}
+
+export async function getCategoryMeta(params: {
+  locale: string;
+  category: CourseCategory;
+}) {
+  const t = await getExtracted(params);
+  const label = await getCategoryLabel(params.category, params);
+
+  return {
+    description: t(
+      "{category} courses. The best {category} online courses, interactive lessons to learn.",
+      {
+        category: label,
+      },
+    ),
+    title: t("{category} Courses", { category: label }),
   };
+}
 
-  return data[category];
+export async function getCategoryHeader(category: CourseCategory) {
+  const t = await getExtracted();
+  const label = await getCategoryLabel(category);
+
+  return {
+    description: t("Explore all {category} courses", { category: label }),
+    title: t("{category} courses", { category: label }),
+  };
 }

--- a/i18n.lock
+++ b/i18n.lock
@@ -191,6 +191,8 @@ checksums:
     Settings/singular: 8df6777277469c1fd88cc18dde2f1cc3
     Support/singular: 55aab5fd0f31a9cb055a2edeeedfaf63
     Subscription/singular: ba9f3675e18987d067d48533c8897343
+    Course%20categories/singular: 3c86af7c305be0c0f5b65077fb06708d
+    All/singular: 5e2e93f8e2a5f315b6fecdd0a0e6f55f
     Loading%20more%20courses%E2%80%A6/singular: 290733f8b53c88f64b385ba9dd320acf
     No%20courses%20available%20yet./singular: 1a6b72175b8ad0ce36f9cb0bcaab4c84
     No%20courses/singular: 72fc2629e79529e927834070a26d2a07
@@ -286,6 +288,10 @@ checksums:
     Law/singular: 3f04c791596043e899781f74003b9324
     Business/singular: 7682c7966c6e718836388561e7e68cab
     Geography/singular: fd93fe516c40f1f2dd96f53a507ce95d
+    "%7Bcategory%7D%20Courses/singular": f82680a650c487992e1025b66f324d4c
+    Explore%20all%20%7Bcategory%7D%20courses/singular: b1f2775c67b4a61b3d92b4345b8b852e
+    "%7Bcategory%7D%20courses/singular": eafd6f9b1fa97400abe1bfe0c8ee5f19
+    "%7Bcategory%7D%20courses.%20The%20best%20%7Bcategory%7D%20online%20courses%2C%20interactive%20lessons%20to%20learn./singular": 2ec8d2bc2e44d9def010ec678286dc88
     An%20unexpected%20error%20occurred/singular: fe07b9cdb1fc3f7397f6d89c102c60af
     Please%20sign%20in%20to%20continue/singular: 051e59dd3d3b0bfad95982f982fd6b9d
   61a308caf583f5835f54302028bdae73:

--- a/packages/utils/src/cache.ts
+++ b/packages/utils/src/cache.ts
@@ -19,3 +19,13 @@ export function cacheTagOrgCourses({ orgSlug }: { orgSlug: string }) {
 export function cacheTagCoursesList({ language }: { language: string }) {
   return `courses-list:${language}`.slice(0, CACHE_TAG_LIMIT);
 }
+
+export function cacheTagCoursesListByCategory({
+  language,
+  category,
+}: {
+  language: string;
+  category: string;
+}) {
+  return `courses-list:${language}:${category}`.slice(0, CACHE_TAG_LIMIT);
+}

--- a/packages/utils/src/categories.ts
+++ b/packages/utils/src/categories.ts
@@ -16,4 +16,10 @@ export const COURSE_CATEGORIES = [
   "tech",
 ] as const;
 
+const COURSE_CATEGORY_SET: ReadonlySet<string> = new Set(COURSE_CATEGORIES);
+
 export type CourseCategory = (typeof COURSE_CATEGORIES)[number];
+
+export function isValidCategory(category: unknown): category is CourseCategory {
+  return typeof category === "string" && COURSE_CATEGORY_SET.has(category);
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added category-specific course pages with localized titles and descriptions, plus a pill-style navigator to switch categories. Infinite loading and caching now respect the selected category.

- **New Features**
  - New route /[locale]/courses/[category] with static params, validation, and notFound handling.
  - Category pills navigation with a skeleton, rendered via the courses layout.
  - Localized metadata and headers per category (en, es, pt).

- **Refactors**
  - Infinite list and server action accept a category; caching tagged by language+category.
  - Shared category icons/labels via helpers (useCategories, CATEGORY_ICONS); added isValidCategory.
  - Added i18n strings for categories and dynamic meta; updated docs on next-intl usage and skeleton placement.

<sup>Written for commit c5395ec924a0039b5c8bcd75f4425795c131bc36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

