### PR TITLE
feat(db):  add models for activities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Zoonk is a web app where users can learn anything using AI. This app uses AI to 
 - [Content & Accessibility](#content--accessibility)
 - [Performance](#performance)
 - [Design](#design)
+- [Content System](#content-system)
 
 ## Principles
 
@@ -511,6 +512,76 @@ You can delay unwrapping the Promise (either with await or React.use) until you 
 - MUST: Increase contrast on `:hover/:active/:focus`
 - SHOULD: Match browser UI to bg
 - SHOULD: Avoid gradient banding (use masks when needed)
+
+## Content System
+
+Zoonk's content is structured hierarchically: **Courses → Chapters → Lessons → Activities → Steps**.
+
+### Lessons
+
+Lessons have a `kind` field that determines their structure:
+
+- **core**: Regular AI-generated lessons with structured activities (background, explanation, explanation_quiz, mechanics, examples, story, logic, challenge, lesson_quiz)
+- **language**: Language learning lessons (vocabulary, grammar, reading, listening, pronunciation, review)
+- **custom**: User-created lessons or lessons that don't fit the standard structure (e.g., tutorials, step-by-step guides)
+
+### Activities
+
+Activities belong to lessons and have a `kind` field that specifies the activity type. Valid activity kinds depend on the parent lesson's kind:
+
+- **Core lessons**: background, explanation, explanation_quiz, mechanics, examples, story, logic, challenge, lesson_quiz
+- **Language lessons**: vocabulary, grammar, reading, listening, pronunciation, review
+- **Custom lessons**: custom (uses title/description for user-defined content)
+
+#### Challenge Mode
+
+Any activity can become a challenge by setting `inventory` and `winCriteria`. Challenges track inventory items (e.g., `codeQuality: 60`) and require meeting win conditions (e.g., `codeQuality >= 70`). Step options have `effects` that modify inventory values.
+
+### Steps
+
+Steps are the atomic learning units within activities. Kinds:
+
+| Kind              | Description                                     |
+| ----------------- | ----------------------------------------------- |
+| `static`          | Title + brief text content (informational)      |
+| `multiple_choice` | Question with selectable options                |
+| `match_columns`   | Pair matching exercise                          |
+| `fill_blank`      | Sentence completion with word bank              |
+| `select_image`    | Image selection question                        |
+| `sort_order`      | Ordering items correctly                        |
+| `arrange_words`   | Word arrangement (useful for language learning) |
+
+Steps can have visual resources (`visualKind`): `code`, `image`, `table`, `chart_bar`, `chart_line`, `chart_pie`, `chart_area`, `diagram`, `timeline`, `quote`, `audio`, `video`.
+
+### User Progress
+
+Progress is tracked at multiple levels:
+
+- **StepAttempt**: Every answer recorded with correctness, duration, time of day
+- **ActivityProgress**: Activity start/completion times, challenge results
+- **UserProgress**: Current energy level (0-100%), total Brain Power
+- **DailyProgress**: Daily aggregates per organization
+
+#### Energy Level
+
+- Starts at 0%, max 100%
+- Correct answers: +0.1%
+- Incorrect answers: -0.05%
+- Daily decay: -1% per inactive day
+
+#### Belt System (Brain Power)
+
+Users earn BP for completing activities:
+
+- Static steps: 10 BP
+- Interactive steps: 25 BP
+- Challenges: 100 BP
+
+Belt levels (10 levels each): White (250 BP/level) → Yellow (500) → Orange (1k) → Green (5k) → Blue (10k) → Purple (20k) → Brown (40k) → Red (60k) → Gray (80k) → Black (100k)
+
+#### Future Extensibility
+
+The `StepAttempt.effects` JSON field is designed to support future skill tracking (e.g., `{ "skills": { "leadership": 5 } }`). When skills are implemented, aggregation tables will be added for fast querying.
 
 ## Updating this document
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17,20 +17,26 @@ if (process.env.NODE_ENV !== "production") {
 
 export type {
   Account,
+  Activity,
+  ActivityProgress,
   Chapter,
   Course,
   CourseAlternativeTitle,
   CourseCategory,
   CourseSuggestion,
   CourseUser,
+  DailyProgress,
   Invitation,
   Lesson,
   Member,
   Organization,
   RateLimit,
   Session,
+  Step,
+  StepAttempt,
   Subscription,
   User,
+  UserProgress,
   Verification,
 } from "./generated/prisma/client";
 

--- a/packages/db/src/prisma/migrations/20251231003222_add_activities_steps_progress/migration.sql
+++ b/packages/db/src/prisma/migrations/20251231003222_add_activities_steps_progress/migration.sql
@@ -1,0 +1,180 @@
+-- AlterTable
+ALTER TABLE "lessons" ADD COLUMN     "kind" VARCHAR(20) NOT NULL DEFAULT 'core';
+
+-- CreateTable
+CREATE TABLE "activities" (
+    "id" SERIAL NOT NULL,
+    "organization_id" INTEGER NOT NULL,
+    "lesson_id" INTEGER NOT NULL,
+    "is_published" BOOLEAN NOT NULL DEFAULT false,
+    "language" VARCHAR(10) NOT NULL,
+    "kind" VARCHAR(30) NOT NULL,
+    "title" TEXT,
+    "description" TEXT,
+    "position" INTEGER NOT NULL,
+    "inventory" JSONB,
+    "win_criteria" JSONB,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "activities_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "activity_progress" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "activity_id" INTEGER NOT NULL,
+    "started_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completed_at" TIMESTAMP(3),
+    "duration_seconds" INTEGER,
+    "inventory_final" JSONB,
+    "passed" BOOLEAN,
+
+    CONSTRAINT "activity_progress_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "step_attempts" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "step_id" INTEGER NOT NULL,
+    "organization_id" INTEGER NOT NULL,
+    "is_correct" BOOLEAN NOT NULL,
+    "answer" JSONB NOT NULL,
+    "effects" JSONB,
+    "duration_seconds" INTEGER NOT NULL,
+    "answered_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "hour_of_day" SMALLINT NOT NULL,
+    "day_of_week" SMALLINT NOT NULL,
+
+    CONSTRAINT "step_attempts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "user_progress" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "current_energy" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "total_brain_power" BIGINT NOT NULL DEFAULT 0,
+    "last_active_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_progress_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "daily_progress" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "date" DATE NOT NULL,
+    "organization_id" INTEGER,
+    "correct_answers" INTEGER NOT NULL DEFAULT 0,
+    "incorrect_answers" INTEGER NOT NULL DEFAULT 0,
+    "static_completed" INTEGER NOT NULL DEFAULT 0,
+    "interactive_completed" INTEGER NOT NULL DEFAULT 0,
+    "challenges_completed" INTEGER NOT NULL DEFAULT 0,
+    "brain_power_earned" INTEGER NOT NULL DEFAULT 0,
+    "time_spent_seconds" INTEGER NOT NULL DEFAULT 0,
+    "energy_at_end" DOUBLE PRECISION NOT NULL DEFAULT 0,
+
+    CONSTRAINT "daily_progress_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "steps" (
+    "id" SERIAL NOT NULL,
+    "activity_id" INTEGER NOT NULL,
+    "kind" VARCHAR(20) NOT NULL,
+    "position" INTEGER NOT NULL,
+    "content" JSONB NOT NULL,
+    "visual_kind" VARCHAR(20),
+    "visual_content" JSONB,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "steps_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "activities_lesson_id_position_idx" ON "activities"("lesson_id", "position");
+
+-- CreateIndex
+CREATE INDEX "activities_organization_id_kind_idx" ON "activities"("organization_id", "kind");
+
+-- CreateIndex
+CREATE INDEX "activity_progress_user_id_idx" ON "activity_progress"("user_id");
+
+-- CreateIndex
+CREATE INDEX "activity_progress_activity_id_idx" ON "activity_progress"("activity_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "activity_progress_user_id_activity_id_key" ON "activity_progress"("user_id", "activity_id");
+
+-- CreateIndex
+CREATE INDEX "step_attempts_user_id_answered_at_idx" ON "step_attempts"("user_id", "answered_at");
+
+-- CreateIndex
+CREATE INDEX "step_attempts_step_id_idx" ON "step_attempts"("step_id");
+
+-- CreateIndex
+CREATE INDEX "step_attempts_organization_id_idx" ON "step_attempts"("organization_id");
+
+-- CreateIndex
+CREATE INDEX "step_attempts_user_id_organization_id_idx" ON "step_attempts"("user_id", "organization_id");
+
+-- CreateIndex
+CREATE INDEX "step_attempts_user_id_day_of_week_idx" ON "step_attempts"("user_id", "day_of_week");
+
+-- CreateIndex
+CREATE INDEX "step_attempts_user_id_hour_of_day_idx" ON "step_attempts"("user_id", "hour_of_day");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_progress_user_id_key" ON "user_progress"("user_id");
+
+-- CreateIndex
+CREATE INDEX "daily_progress_user_id_date_idx" ON "daily_progress"("user_id", "date");
+
+-- CreateIndex
+CREATE INDEX "daily_progress_organization_id_idx" ON "daily_progress"("organization_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "daily_progress_user_id_date_organization_id_key" ON "daily_progress"("user_id", "date", "organization_id");
+
+-- CreateIndex
+CREATE INDEX "steps_activity_id_position_idx" ON "steps"("activity_id", "position");
+
+-- CreateIndex
+CREATE INDEX "lessons_organization_id_kind_idx" ON "lessons"("organization_id", "kind");
+
+-- AddForeignKey
+ALTER TABLE "activities" ADD CONSTRAINT "activities_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activities" ADD CONSTRAINT "activities_lesson_id_fkey" FOREIGN KEY ("lesson_id") REFERENCES "lessons"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_progress" ADD CONSTRAINT "activity_progress_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_progress" ADD CONSTRAINT "activity_progress_activity_id_fkey" FOREIGN KEY ("activity_id") REFERENCES "activities"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "step_attempts" ADD CONSTRAINT "step_attempts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "step_attempts" ADD CONSTRAINT "step_attempts_step_id_fkey" FOREIGN KEY ("step_id") REFERENCES "steps"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "step_attempts" ADD CONSTRAINT "step_attempts_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_progress" ADD CONSTRAINT "user_progress_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "daily_progress" ADD CONSTRAINT "daily_progress_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "daily_progress" ADD CONSTRAINT "daily_progress_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "steps" ADD CONSTRAINT "steps_activity_id_fkey" FOREIGN KEY ("activity_id") REFERENCES "activities"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/src/prisma/models/accounts.prisma
+++ b/packages/db/src/prisma/models/accounts.prisma
@@ -1,23 +1,27 @@
 // Better Auth models for Prisma
 
 model User {
-  id               Int          @id @default(autoincrement())
+  id               Int                @id @default(autoincrement())
   name             String
   email            String
-  emailVerified    Boolean      @default(false) @map("email_verified")
+  emailVerified    Boolean            @default(false) @map("email_verified")
   image            String?
-  createdAt        DateTime     @default(now()) @map("created_at")
-  updatedAt        DateTime     @updatedAt @map("updated_at")
+  createdAt        DateTime           @default(now()) @map("created_at")
+  updatedAt        DateTime           @updatedAt @map("updated_at")
   role             String?
-  banned           Boolean?     @default(false)
-  banReason        String?      @map("ban_reason")
-  banExpires       DateTime?    @map("ban_expires")
-  stripeCustomerId String?      @map("stripe_customer_id")
+  banned           Boolean?           @default(false)
+  banReason        String?            @map("ban_reason")
+  banExpires       DateTime?          @map("ban_expires")
+  stripeCustomerId String?            @map("stripe_customer_id")
   sessions         Session[]
   accounts         Account[]
   members          Member[]
   invitations      Invitation[]
   courses          CourseUser[]
+  activityProgress ActivityProgress[]
+  stepAttempts     StepAttempt[]
+  progress         UserProgress?
+  dailyProgress    DailyProgress[]
 
   @@unique([email])
   @@map("users")
@@ -74,18 +78,21 @@ model Verification {
 }
 
 model Organization {
-  id          Int          @id @default(autoincrement())
-  name        String
-  slug        String
-  logo        String?
-  createdAt   DateTime     @default(now()) @map("created_at")
-  metadata    String?
-  kind        String       @default("brand")
-  members     Member[]
-  invitations Invitation[]
-  courses     Course[]
-  chapters    Chapter[]
-  lessons     Lesson[]
+  id            Int             @id @default(autoincrement())
+  name          String
+  slug          String
+  logo          String?
+  createdAt     DateTime        @default(now()) @map("created_at")
+  metadata      String?
+  kind          String          @default("brand")
+  members       Member[]
+  invitations   Invitation[]
+  courses       Course[]
+  chapters      Chapter[]
+  lessons       Lesson[]
+  activities    Activity[]
+  stepAttempts  StepAttempt[]
+  dailyProgress DailyProgress[]
 
   @@unique([slug])
   @@map("organizations")

--- a/packages/db/src/prisma/models/activities.prisma
+++ b/packages/db/src/prisma/models/activities.prisma
@@ -1,0 +1,41 @@
+model Activity {
+  id             Int                @id @default(autoincrement())
+  organizationId Int                @map("organization_id")
+  organization   Organization       @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  lessonId       Int                @map("lesson_id")
+  lesson         Lesson             @relation(fields: [lessonId], references: [id], onDelete: Cascade)
+  isPublished    Boolean            @default(false) @map("is_published")
+  language       String             @db.VarChar(10)
+  kind           String             @db.VarChar(30)
+  title          String?
+  description    String?
+  position       Int
+  inventory      Json?
+  winCriteria    Json?              @map("win_criteria")
+  createdAt      DateTime           @default(now()) @map("created_at")
+  updatedAt      DateTime           @default(now()) @updatedAt @map("updated_at")
+  steps          Step[]
+  progress       ActivityProgress[]
+
+  @@index([lessonId, position])
+  @@index([organizationId, kind])
+  @@map("activities")
+}
+
+model ActivityProgress {
+  id              Int       @id @default(autoincrement())
+  userId          Int       @map("user_id")
+  user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  activityId      Int       @map("activity_id")
+  activity        Activity  @relation(fields: [activityId], references: [id], onDelete: Cascade)
+  startedAt       DateTime  @default(now()) @map("started_at")
+  completedAt     DateTime? @map("completed_at")
+  durationSeconds Int?      @map("duration_seconds")
+  inventoryFinal  Json?     @map("inventory_final")
+  passed          Boolean?
+
+  @@unique([userId, activityId], name: "userActivity")
+  @@index([userId])
+  @@index([activityId])
+  @@map("activity_progress")
+}

--- a/packages/db/src/prisma/models/lessons.prisma
+++ b/packages/db/src/prisma/models/lessons.prisma
@@ -1,21 +1,24 @@
 model Lesson {
-  id              Int      @id @default(autoincrement())
-  organizationId  Int      @map("organization_id")
+  id              Int          @id @default(autoincrement())
+  organizationId  Int          @map("organization_id")
   organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  chapterId       Int      @map("chapter_id")
-  chapter         Chapter  @relation(fields: [chapterId], references: [id], onDelete: Cascade)
-  isPublished     Boolean  @default(false) @map("is_published")
-  language        String   @db.VarChar(10)
+  chapterId       Int          @map("chapter_id")
+  chapter         Chapter      @relation(fields: [chapterId], references: [id], onDelete: Cascade)
+  isPublished     Boolean      @default(false) @map("is_published")
+  language        String       @db.VarChar(10)
+  kind            String       @default("core") @db.VarChar(20)
   slug            String
   title           String
-  normalizedTitle String   @map("normalized_title")
+  normalizedTitle String       @map("normalized_title")
   description     String
   position        Int
-  createdAt       DateTime @default(now()) @map("created_at")
-  updatedAt       DateTime @default(now()) @updatedAt @map("updated_at")
+  createdAt       DateTime     @default(now()) @map("created_at")
+  updatedAt       DateTime     @default(now()) @updatedAt @map("updated_at")
+  activities      Activity[]
 
   @@unique([organizationId, language, slug], name: "orgLanguageLessonSlug")
   @@index([organizationId, normalizedTitle])
   @@index([chapterId, position])
+  @@index([organizationId, kind])
   @@map("lessons")
 }

--- a/packages/db/src/prisma/models/progress.prisma
+++ b/packages/db/src/prisma/models/progress.prisma
@@ -1,0 +1,57 @@
+model StepAttempt {
+  id              Int          @id @default(autoincrement())
+  userId          Int          @map("user_id")
+  user            User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  stepId          Int          @map("step_id")
+  step            Step         @relation(fields: [stepId], references: [id], onDelete: Cascade)
+  organizationId  Int          @map("organization_id")
+  organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  isCorrect       Boolean      @map("is_correct")
+  answer          Json
+  effects         Json?
+  durationSeconds Int          @map("duration_seconds")
+  answeredAt      DateTime     @default(now()) @map("answered_at")
+  hourOfDay       Int          @map("hour_of_day") @db.SmallInt
+  dayOfWeek       Int          @map("day_of_week") @db.SmallInt
+
+  @@index([userId, answeredAt])
+  @@index([stepId])
+  @@index([organizationId])
+  @@index([userId, organizationId])
+  @@index([userId, dayOfWeek])
+  @@index([userId, hourOfDay])
+  @@map("step_attempts")
+}
+
+model UserProgress {
+  id              Int      @id @default(autoincrement())
+  userId          Int      @unique @map("user_id")
+  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  currentEnergy   Float    @default(0) @map("current_energy")
+  totalBrainPower BigInt   @default(0) @map("total_brain_power")
+  lastActiveAt    DateTime @default(now()) @map("last_active_at")
+
+  @@map("user_progress")
+}
+
+model DailyProgress {
+  id                   Int           @id @default(autoincrement())
+  userId               Int           @map("user_id")
+  user                 User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  date                 DateTime      @db.Date
+  organizationId       Int?          @map("organization_id")
+  organization         Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  correctAnswers       Int           @default(0) @map("correct_answers")
+  incorrectAnswers     Int           @default(0) @map("incorrect_answers")
+  staticCompleted      Int           @default(0) @map("static_completed")
+  interactiveCompleted Int           @default(0) @map("interactive_completed")
+  challengesCompleted  Int           @default(0) @map("challenges_completed")
+  brainPowerEarned     Int           @default(0) @map("brain_power_earned")
+  timeSpentSeconds     Int           @default(0) @map("time_spent_seconds")
+  energyAtEnd          Float         @default(0) @map("energy_at_end")
+
+  @@unique([userId, date, organizationId], name: "userDateOrg")
+  @@index([userId, date])
+  @@index([organizationId])
+  @@map("daily_progress")
+}

--- a/packages/db/src/prisma/models/steps.prisma
+++ b/packages/db/src/prisma/models/steps.prisma
@@ -1,0 +1,16 @@
+model Step {
+  id            Int           @id @default(autoincrement())
+  activityId    Int           @map("activity_id")
+  activity      Activity      @relation(fields: [activityId], references: [id], onDelete: Cascade)
+  kind          String        @db.VarChar(20)
+  position      Int
+  content       Json
+  visualKind    String?       @map("visual_kind") @db.VarChar(20)
+  visualContent Json?         @map("visual_content")
+  createdAt     DateTime      @default(now()) @map("created_at")
+  updatedAt     DateTime      @default(now()) @updatedAt @map("updated_at")
+  attempts      StepAttempt[]
+
+  @@index([activityId, position])
+  @@map("steps")
+}

--- a/packages/db/src/prisma/seed.ts
+++ b/packages/db/src/prisma/seed.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../index";
+import { seedActivities } from "./seed/activities";
 import { seedAlternativeTitles } from "./seed/alternative-titles";
 import { seedCategories } from "./seed/categories";
 import { seedChapters } from "./seed/chapters";
@@ -6,6 +7,8 @@ import { seedCourseUsers } from "./seed/course-users";
 import { seedCourses } from "./seed/courses";
 import { seedLessons } from "./seed/lessons";
 import { seedOrganizations } from "./seed/orgs";
+import { seedProgress } from "./seed/progress";
+import { seedSteps } from "./seed/steps";
 import { seedUsers } from "./seed/users";
 
 async function main() {
@@ -17,6 +20,9 @@ async function main() {
   await seedLessons(prisma, org);
   await seedAlternativeTitles(prisma, org);
   await seedCourseUsers(prisma, org, users);
+  await seedActivities(prisma, org);
+  await seedSteps(prisma, org);
+  await seedProgress(prisma, org, users);
 }
 
 main()

--- a/packages/db/src/prisma/seed/activities.ts
+++ b/packages/db/src/prisma/seed/activities.ts
@@ -1,0 +1,146 @@
+import type { Organization, PrismaClient } from "../../generated/prisma/client";
+
+type ActivitySeedData = {
+  isPublished: boolean;
+  kind: string;
+  title?: string;
+  description?: string;
+  inventory?: Record<string, number>;
+  winCriteria?: Record<string, { operator: string; value: number }>;
+};
+
+type LessonActivities = {
+  lessonSlug: string;
+  language: string;
+  activities: ActivitySeedData[];
+};
+
+const activitiesData: LessonActivities[] = [
+  {
+    activities: [
+      {
+        isPublished: true,
+        kind: "background",
+      },
+      {
+        isPublished: true,
+        kind: "explanation",
+      },
+      {
+        isPublished: true,
+        kind: "explanation_quiz",
+      },
+      {
+        isPublished: true,
+        kind: "examples",
+      },
+      {
+        isPublished: true,
+        kind: "story",
+      },
+      {
+        isPublished: true,
+        kind: "logic",
+      },
+      {
+        inventory: {
+          computeResources: 70,
+          dataQuality: 50,
+          modelAccuracy: 60,
+          teamMorale: 80,
+        },
+        isPublished: true,
+        kind: "challenge",
+        winCriteria: {
+          computeResources: { operator: ">=", value: 50 },
+          dataQuality: { operator: ">=", value: 65 },
+          modelAccuracy: { operator: ">=", value: 75 },
+          teamMorale: { operator: ">=", value: 60 },
+        },
+      },
+      {
+        isPublished: true,
+        kind: "lesson_quiz",
+      },
+    ],
+    language: "en",
+    lessonSlug: "what-is-machine-learning",
+  },
+  {
+    activities: [
+      {
+        isPublished: true,
+        kind: "background",
+      },
+      {
+        isPublished: true,
+        kind: "explanation",
+      },
+      {
+        isPublished: false,
+        kind: "mechanics",
+      },
+    ],
+    language: "en",
+    lessonSlug: "history-of-ml",
+  },
+  {
+    activities: [
+      {
+        description:
+          "A custom activity exploring the differences between supervised and unsupervised learning approaches.",
+        isPublished: false,
+        kind: "custom",
+        title: "Supervised vs Unsupervised Learning",
+      },
+    ],
+    language: "en",
+    lessonSlug: "types-of-learning",
+  },
+];
+
+export async function seedActivities(
+  prisma: PrismaClient,
+  org: Organization,
+): Promise<void> {
+  const allActivityPromises = activitiesData.flatMap((data) =>
+    prisma.lesson
+      .findFirst({
+        where: {
+          language: data.language,
+          organizationId: org.id,
+          slug: data.lessonSlug,
+        },
+      })
+      .then(async (lesson) => {
+        if (!lesson) {
+          return;
+        }
+
+        await Promise.all(
+          data.activities.map((activityData, position) =>
+            prisma.activity.upsert({
+              create: {
+                description: activityData.description,
+                inventory: activityData.inventory,
+                isPublished: activityData.isPublished,
+                kind: activityData.kind,
+                language: data.language,
+                lessonId: lesson.id,
+                organizationId: org.id,
+                position,
+                title: activityData.title,
+                winCriteria: activityData.winCriteria,
+              },
+              update: {},
+              where: {
+                id: -1, // Force create since there's no unique constraint
+              },
+            }),
+          ),
+        );
+      }),
+  );
+
+  await Promise.all(allActivityPromises);
+}

--- a/packages/db/src/prisma/seed/lessons.ts
+++ b/packages/db/src/prisma/seed/lessons.ts
@@ -4,6 +4,7 @@ import type { Organization, PrismaClient } from "../../generated/prisma/client";
 type LessonSeedData = {
   description: string;
   isPublished: boolean;
+  kind?: string;
   slug: string;
   title: string;
 };
@@ -37,6 +38,7 @@ const lessonsData: ChapterLessons[] = [
         description:
           "Understand supervised, unsupervised, and reinforcement learning approaches.",
         isPublished: false,
+        kind: "custom",
         slug: "types-of-learning",
         title: "Types of Learning",
       },
@@ -89,6 +91,7 @@ export async function seedLessons(
                 chapterId: chapter.id,
                 description: lessonData.description,
                 isPublished: lessonData.isPublished,
+                kind: lessonData.kind ?? "core",
                 language: data.language,
                 normalizedTitle: normalizeString(lessonData.title),
                 organizationId: org.id,

--- a/packages/db/src/prisma/seed/progress.ts
+++ b/packages/db/src/prisma/seed/progress.ts
@@ -1,0 +1,170 @@
+import type { Organization, PrismaClient } from "../../generated/prisma/client";
+import type { SeedUsers } from "./users";
+
+export async function seedProgress(
+  prisma: PrismaClient,
+  org: Organization,
+  users: SeedUsers,
+): Promise<void> {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+  // Create UserProgress for each user
+  await Promise.all([
+    prisma.userProgress.upsert({
+      create: {
+        currentEnergy: 72.5,
+        lastActiveAt: now,
+        totalBrainPower: BigInt(15_750),
+        userId: users.owner.id,
+      },
+      update: {},
+      where: { userId: users.owner.id },
+    }),
+    prisma.userProgress.upsert({
+      create: {
+        currentEnergy: 45.2,
+        lastActiveAt: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000), // 2 days ago
+        totalBrainPower: BigInt(8500),
+        userId: users.admin.id,
+      },
+      update: {},
+      where: { userId: users.admin.id },
+    }),
+    prisma.userProgress.upsert({
+      create: {
+        currentEnergy: 15.0,
+        lastActiveAt: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000), // 7 days ago
+        totalBrainPower: BigInt(2100),
+        userId: users.member.id,
+      },
+      update: {},
+      where: { userId: users.member.id },
+    }),
+  ]);
+
+  // Create DailyProgress for the past 7 days for the owner user
+  type DailyProgressInput = {
+    brainPowerEarned: number;
+    challengesCompleted: number;
+    correctAnswers: number;
+    date: Date;
+    energyAtEnd: number;
+    incorrectAnswers: number;
+    interactiveCompleted: number;
+    organizationId: number;
+    staticCompleted: number;
+    timeSpentSeconds: number;
+    userId: number;
+  };
+
+  const dailyProgressData: DailyProgressInput[] = [];
+  for (let i = 6; i >= 0; i--) {
+    const date = new Date(today.getTime() - i * 24 * 60 * 60 * 1000);
+    const isActiveDay = i !== 3 && i !== 5; // Skip days 3 and 5 (inactive days)
+
+    if (isActiveDay) {
+      dailyProgressData.push({
+        brainPowerEarned: 200 + Math.floor(Math.random() * 300),
+        challengesCompleted: i === 0 ? 1 : 0, // Completed a challenge today
+        correctAnswers: 15 + Math.floor(Math.random() * 20),
+        date,
+        energyAtEnd: 65 + Math.random() * 10,
+        incorrectAnswers: 2 + Math.floor(Math.random() * 5),
+        interactiveCompleted: 8 + Math.floor(Math.random() * 10),
+        organizationId: org.id,
+        staticCompleted: 5 + Math.floor(Math.random() * 8),
+        timeSpentSeconds: 1200 + Math.floor(Math.random() * 1800),
+        userId: users.owner.id,
+      });
+    }
+  }
+
+  await Promise.all(
+    dailyProgressData.map((data) =>
+      prisma.dailyProgress.upsert({
+        create: data,
+        update: {},
+        where: {
+          userDateOrg: {
+            date: data.date,
+            organizationId: data.organizationId,
+            userId: data.userId,
+          },
+        },
+      }),
+    ),
+  );
+
+  // Create some sample step attempts
+  const lesson = await prisma.lesson.findFirst({
+    where: {
+      language: "en",
+      organizationId: org.id,
+      slug: "what-is-machine-learning",
+    },
+  });
+
+  if (!lesson) {
+    return;
+  }
+
+  const activity = await prisma.activity.findFirst({
+    where: {
+      lessonId: lesson.id,
+      position: 2, // explanation_quiz
+    },
+  });
+
+  if (!activity) {
+    return;
+  }
+
+  const steps = await prisma.step.findMany({
+    orderBy: { position: "asc" },
+    where: { activityId: activity.id },
+  });
+
+  if (steps.length === 0) {
+    return;
+  }
+
+  // Create attempts for the owner user
+  const attemptData = steps.slice(0, 3).map((step, index) => ({
+    answer: { selectedOption: index === 1 ? 0 : 1 },
+    answeredAt: new Date(now.getTime() - (3 - index) * 60 * 1000),
+    dayOfWeek: now.getDay(),
+    durationSeconds: 15 + Math.floor(Math.random() * 30),
+    hourOfDay: now.getHours(),
+    isCorrect: index !== 1, // Second attempt is wrong
+    organizationId: org.id,
+    stepId: step.id,
+    userId: users.owner.id,
+  }));
+
+  await Promise.all(
+    attemptData.map((data) =>
+      prisma.stepAttempt.create({
+        data,
+      }),
+    ),
+  );
+
+  // Create activity progress
+  await prisma.activityProgress.upsert({
+    create: {
+      activityId: activity.id,
+      completedAt: now,
+      durationSeconds: 180,
+      startedAt: new Date(now.getTime() - 3 * 60 * 1000),
+      userId: users.owner.id,
+    },
+    update: {},
+    where: {
+      userActivity: {
+        activityId: activity.id,
+        userId: users.owner.id,
+      },
+    },
+  });
+}

--- a/packages/db/src/prisma/seed/steps.ts
+++ b/packages/db/src/prisma/seed/steps.ts
@@ -1,0 +1,318 @@
+import type {
+  Organization,
+  Prisma,
+  PrismaClient,
+} from "../../generated/prisma/client";
+
+type StepSeedData = {
+  kind: string;
+  content: Prisma.InputJsonValue;
+  visualKind?: string;
+  visualContent?: Prisma.InputJsonValue;
+};
+
+type ActivitySteps = {
+  lessonSlug: string;
+  language: string;
+  activityPosition: number;
+  steps: StepSeedData[];
+};
+
+const stepsData: ActivitySteps[] = [
+  {
+    activityPosition: 0, // background activity
+    language: "en",
+    lessonSlug: "what-is-machine-learning",
+    steps: [
+      {
+        content: {
+          text: "In 1956, a group of scientists gathered at Dartmouth College with an ambitious goal: create machines that could think like humans.",
+          title: "The Birth of AI",
+        },
+        kind: "static",
+        visualContent: {
+          events: [
+            {
+              date: "1956",
+              description: "The term 'Artificial Intelligence' is coined.",
+              title: "Dartmouth Conference",
+            },
+            {
+              date: "1997",
+              description: "IBM's computer defeats world chess champion.",
+              title: "Deep Blue",
+            },
+            {
+              date: "2012",
+              description:
+                "Neural networks achieve breakthrough in image recognition.",
+              title: "Deep Learning Revolution",
+            },
+          ],
+        },
+        visualKind: "timeline",
+      },
+      {
+        content: {
+          text: "Traditional programming required explicit rules for every scenario. But what if computers could learn patterns from data instead?",
+          title: "The Problem",
+        },
+        kind: "static",
+        visualContent: {
+          edges: [
+            { from: "input", to: "output" },
+            { from: "rules", to: "output" },
+          ],
+          nodes: [
+            { id: "input", label: "Data", x: 0, y: 50 },
+            { id: "rules", label: "Rules", x: 100, y: 0 },
+            { id: "output", label: "Output", x: 200, y: 50 },
+          ],
+        },
+        visualKind: "diagram",
+      },
+      {
+        content: {
+          text: "Machine learning flips the script: instead of programming rules, we provide examples and let the computer discover the patterns.",
+          title: "A New Approach",
+        },
+        kind: "static",
+        visualContent: {
+          author: "Tom Mitchell, 1997",
+          text: "A computer program is said to learn from experience E with respect to some task T and some performance measure P, if its performance on T, as measured by P, improves with experience E.",
+        },
+        visualKind: "quote",
+      },
+    ],
+  },
+  {
+    activityPosition: 2, // explanation_quiz activity
+    language: "en",
+    lessonSlug: "what-is-machine-learning",
+    steps: [
+      {
+        content: {
+          context:
+            "Traditional programming requires explicit rules for every scenario.",
+          options: [
+            {
+              feedback:
+                "Both use electricity. Think about how they solve problems.",
+              isCorrect: false,
+              text: "Traditional programming uses electricity, ML uses batteries",
+            },
+            {
+              feedback:
+                "Exactly! ML discovers patterns from examples rather than following pre-programmed rules.",
+              isCorrect: true,
+              text: "ML learns patterns from data instead of following explicit rules",
+            },
+            {
+              feedback:
+                "Speed isn't the key difference. Consider how each approach solves problems.",
+              isCorrect: false,
+              text: "Traditional programming is faster than ML",
+            },
+          ],
+          question:
+            "What is the main difference between traditional programming and machine learning?",
+        },
+        kind: "multiple_choice",
+      },
+      {
+        content: {
+          pairs: [
+            {
+              left: "Supervised Learning",
+              right: "Learning from labeled examples",
+            },
+            { left: "Unsupervised Learning", right: "Finding hidden patterns" },
+            {
+              left: "Reinforcement Learning",
+              right: "Learning through trial and error",
+            },
+          ],
+        },
+        kind: "match_columns",
+      },
+      {
+        content: {
+          answers: ["supervised", "unsupervised"],
+          feedback:
+            "Great! You understand the difference between these learning types.",
+          template:
+            "In {0} learning, the algorithm learns from labeled data, while in {1} learning, it finds patterns without labels.",
+          wordBank: ["supervised", "unsupervised", "reinforcement", "deep"],
+        },
+        kind: "fill_blank",
+      },
+      {
+        content: {
+          items: [
+            "Collect and prepare data",
+            "Choose a model architecture",
+            "Train the model",
+            "Evaluate performance",
+            "Deploy to production",
+          ],
+          question: "Arrange the ML development process in the correct order:",
+        },
+        kind: "sort_order",
+      },
+      {
+        content: {
+          images: [
+            {
+              alt: "Connected layers of nodes",
+              feedback:
+                "Correct! Neural networks have interconnected layers of nodes.",
+              isCorrect: true,
+              url: "https://example.com/neural-network.png",
+            },
+            {
+              alt: "Simple flowchart",
+              feedback:
+                "This is a flowchart, not a neural network architecture.",
+              isCorrect: false,
+              url: "https://example.com/flowchart.png",
+            },
+          ],
+          question: "Which diagram best represents a neural network?",
+        },
+        kind: "select_image",
+      },
+    ],
+  },
+  {
+    activityPosition: 6, // challenge activity
+    language: "en",
+    lessonSlug: "what-is-machine-learning",
+    steps: [
+      {
+        content: {
+          text: "You're leading a machine learning project at a startup. Your goal is to build a successful model while managing resources and team morale. Make strategic decisions to win!",
+          title: "The ML Project Challenge",
+        },
+        kind: "static",
+      },
+      {
+        content: {
+          options: [
+            {
+              effects: { dataQuality: -10, modelAccuracy: -15, teamMorale: -5 },
+              feedback:
+                "Garbage in, garbage out. Poor data quality leads to poor models.",
+              isCorrect: false,
+              text: "Ignore it and proceed with training",
+            },
+            {
+              effects: {
+                computeResources: -5,
+                dataQuality: 20,
+                modelAccuracy: 10,
+              },
+              feedback:
+                "Good choice! Clean data is the foundation of good ML models.",
+              isCorrect: true,
+              text: "Spend time cleaning and validating the data",
+            },
+            {
+              effects: {
+                computeResources: -25,
+                dataQuality: 15,
+                teamMorale: -10,
+              },
+              feedback: "This wastes resources when cleaning could suffice.",
+              isCorrect: false,
+              text: "Collect entirely new data from scratch",
+            },
+          ],
+          question:
+            "Your team discovers the training data has quality issues. What do you do?",
+        },
+        kind: "multiple_choice",
+      },
+      {
+        content: {
+          options: [
+            {
+              effects: {
+                computeResources: -20,
+                modelAccuracy: 5,
+                teamMorale: 5,
+              },
+              feedback:
+                "Complex models need more compute and may overfit. Start simple!",
+              isCorrect: false,
+              text: "Immediately switch to the complex model",
+            },
+            {
+              effects: { dataQuality: 5, modelAccuracy: 15, teamMorale: 10 },
+              feedback:
+                "Smart! Understanding the problem helps choose the right solution.",
+              isCorrect: true,
+              text: "First analyze why the current model is failing",
+            },
+            {
+              effects: { teamMorale: -20 },
+              feedback:
+                "Ignoring team input hurts morale and misses opportunities.",
+              isCorrect: false,
+              text: "Dismiss the suggestion without discussion",
+            },
+          ],
+          question:
+            "The model is underperforming. A team member suggests using a more complex architecture. What's your decision?",
+        },
+        kind: "multiple_choice",
+      },
+    ],
+  },
+];
+
+export async function seedSteps(
+  prisma: PrismaClient,
+  org: Organization,
+): Promise<void> {
+  const stepCreationPromises = stepsData.map(async (data) => {
+    const lesson = await prisma.lesson.findFirst({
+      where: {
+        language: data.language,
+        organizationId: org.id,
+        slug: data.lessonSlug,
+      },
+    });
+
+    if (!lesson) {
+      return;
+    }
+
+    const activity = await prisma.activity.findFirst({
+      where: {
+        lessonId: lesson.id,
+        position: data.activityPosition,
+      },
+    });
+
+    if (!activity) {
+      return;
+    }
+
+    await Promise.all(
+      data.steps.map((stepData, position) =>
+        prisma.step.create({
+          data: {
+            activityId: activity.id,
+            content: stepData.content,
+            kind: stepData.kind,
+            position,
+            visualContent: stepData.visualContent,
+            visualKind: stepData.visualKind,
+          },
+        }),
+      ),
+    );
+  });
+
+  await Promise.all(stepCreationPromises);
+}

--- a/packages/testing/src/fixtures/lessons.ts
+++ b/packages/testing/src/fixtures/lessons.ts
@@ -12,6 +12,7 @@ export function lessonAttrs(
     chapterId: 0,
     description: "Test lesson description",
     isPublished: false,
+    kind: "core",
     language: "en",
     normalizedTitle,
     organizationId: 0,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Activities, Steps, and Progress to the database to structure lessons and track user learning. Includes challenge support, lesson kinds, seed data, and indexes for faster queries.

- **New Features**
  - Added Prisma models: Activity, Step, ActivityProgress, StepAttempt, UserProgress, DailyProgress.
  - Added lesson kind and new indexes on lessons/activities/steps.
  - Activities support challenges via inventory and winCriteria.
  - Seeded activities, steps, and progress with example ML content.
  - Exported new types and documented the Content System in AGENTS.md.

- **Migration**
  - Run Prisma migrate and regenerate the client.
  - Update any code creating lessons to set the kind field.
  - Optional: run seeds to populate activities, steps, and progress.

<sup>Written for commit 158dd7ad5293a9f2353a05aa2297969561a82eae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

