### PR TITLE
feat(main): skip migrations for Vercel preview deployments

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -43,7 +43,7 @@
   "private": true,
   "scripts": {
     "analyze": "next experimental-analyze",
-    "build": "pnpm --filter @zoonk/db db:deploy && next build",
+    "build": "bash scripts/maybe-migrate.sh && next build",
     "dev": "next dev",
     "start": "next start",
     "stripe:listen": "stripe listen --forward-to http://localhost:3000/api/auth/stripe/webhook",

--- a/apps/main/scripts/maybe-migrate.sh
+++ b/apps/main/scripts/maybe-migrate.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Run migrations conditionally based on environment:
+# - Vercel production: run migrations
+# - Vercel preview: skip migrations (multiple branches may deploy simultaneously)
+# - Non-Vercel (staging, etc.): run migrations
+
+if [ "$VERCEL_ENV" = "preview" ]; then
+  echo "Skipping migrations for Vercel preview deployment"
+  exit 0
+fi
+
+echo "Running database migrations..."
+pnpm --filter @zoonk/db db:deploy


### PR DESCRIPTION
Migrations now only run on Vercel production and custom environments
(like staging). Preview deployments skip migrations to avoid conflicts
when multiple branches deploy simultaneously.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip database migrations on Vercel preview deployments to prevent conflicts when multiple branches deploy. Migrations still run on Vercel production and non-Vercel environments via a new maybe-migrate.sh used by the build script.

<sup>Written for commit a76dd8ac8fba0ef76b64c3d901f10d9d25690635. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

