### PR TITLE
feat(editor): show only draft courses on org home page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,7 +335,7 @@ function MediaCardTitle({ children, className }) {
 - You CAN use string interpolation in `getExtracted`/`useExtracted` to get the translation for a dynamic value. For example: `t("Explore all {category} courses", { category: "arts" })`
 - Whenever using `getExtracted` or `useExtracted`, run `pnpm build` to update PO files
 - Run `pnpm i18n:check` to check for any missing translations and translate empty strings in PO files, making sure translations are consistent across the codebase
-- When you see a `MISSING_TRANSLATION` error (or similar), it means the PO file hasn't been translated. Just go to the PO file and translate the empty strings
+- When you see a `MISSING_TRANSLATION` error (or similar), it means the PO file hasn't been translated. Just go to the PO file and translate the empty strings. You should never create new translations on PO files manually, just extract them using `pnpm build`. If you're on an environment where you can't run `pnpm build`, just ignore this i18n step.
 - You don't need to pass a locale to `getExtracted` when using RSC, only on `generateMetadata` or server actions. It works without a locale on server components
 
 ## CSS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,7 +335,7 @@ function MediaCardTitle({ children, className }) {
 - You CAN use string interpolation in `getExtracted`/`useExtracted` to get the translation for a dynamic value. For example: `t("Explore all {category} courses", { category: "arts" })`
 - Whenever using `getExtracted` or `useExtracted`, run `pnpm build` to update PO files
 - Run `pnpm i18n:check` to check for any missing translations and translate empty strings in PO files, making sure translations are consistent across the codebase
-- When you see a `MISSING_TRANSLATION` error (or similar), it means the PO file hasn't been translated. Just go to the PO file and translate the empty strings
+- When you see a `MISSING_TRANSLATION` error (or similar), it means the PO file hasn't been translated. Just go to the PO file and translate the empty strings. You should never create new translations on PO files manually, just extract them using `pnpm build`. If you're on an environment where you can't run `pnpm build`, just ignore this i18n step.
 - You don't need to pass a locale to `getExtracted` when using RSC, only on `generateMetadata` or server actions. It works without a locale on server components
 
 ## CSS

--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -227,8 +227,8 @@ msgstr "Image uploaded"
 
 #: src/app/[orgSlug]/home-container-header.tsx
 msgctxt "6gzGoI"
-msgid "Select a course to edit its content"
-msgstr "Select a course to edit its content"
+msgid "Courses that are not published yet"
+msgstr "Courses that are not published yet"
 
 #: src/app/[orgSlug]/home-container-header.tsx
 #: src/app/[orgSlug]/new-course/page.tsx
@@ -238,20 +238,24 @@ msgid "Create course"
 msgstr "Create course"
 
 #: src/app/[orgSlug]/home-container-header.tsx
-#: src/components/navbar/command-palette.tsx
 msgctxt "R85gsW"
+msgid "Draft courses"
+msgstr "Draft courses"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "R85gsX"
 msgid "Courses"
 msgstr "Courses"
 
 #: src/app/[orgSlug]/list-courses.tsx
 msgctxt "c0YWuA"
-msgid "Your organization hasn't created any courses yet."
-msgstr "Your organization hasn't created any courses yet."
+msgid "Your organization doesn't have any draft courses."
+msgstr "Your organization doesn't have any draft courses."
 
 #: src/app/[orgSlug]/list-courses.tsx
 msgctxt "zJxO2f"
-msgid "No courses"
-msgstr "No courses"
+msgid "No draft courses"
+msgstr "No draft courses"
 
 #: src/app/[orgSlug]/new-course/actions.ts
 msgctxt "bLbK+M"

--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -226,9 +226,9 @@ msgid "Image uploaded"
 msgstr "Image uploaded"
 
 #: src/app/[orgSlug]/home-container-header.tsx
-msgctxt "6gzGoI"
-msgid "Courses that are not published yet"
-msgstr "Courses that are not published yet"
+msgctxt "3MA05s"
+msgid "Draft courses"
+msgstr "Draft courses"
 
 #: src/app/[orgSlug]/home-container-header.tsx
 #: src/app/[orgSlug]/new-course/page.tsx
@@ -238,24 +238,19 @@ msgid "Create course"
 msgstr "Create course"
 
 #: src/app/[orgSlug]/home-container-header.tsx
-msgctxt "R85gsW"
-msgid "Draft courses"
-msgstr "Draft courses"
-
-#: src/components/navbar/command-palette.tsx
-msgctxt "R85gsX"
-msgid "Courses"
-msgstr "Courses"
+msgctxt "ugXYXv"
+msgid "Courses that are not published yet"
+msgstr "Courses that are not published yet"
 
 #: src/app/[orgSlug]/list-courses.tsx
-msgctxt "c0YWuA"
-msgid "Your organization doesn't have any draft courses."
-msgstr "Your organization doesn't have any draft courses."
-
-#: src/app/[orgSlug]/list-courses.tsx
-msgctxt "zJxO2f"
+msgctxt "F5+xrT"
 msgid "No draft courses"
 msgstr "No draft courses"
+
+#: src/app/[orgSlug]/list-courses.tsx
+msgctxt "mYCw6F"
+msgid "Your organization doesn't have any draft courses."
+msgstr "Your organization doesn't have any draft courses."
 
 #: src/app/[orgSlug]/new-course/actions.ts
 msgctxt "bLbK+M"
@@ -610,6 +605,11 @@ msgstr "Lessons"
 msgctxt "qlTe+e"
 msgid "new"
 msgstr "new"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "R85gsW"
+msgid "Courses"
+msgstr "Courses"
 
 #: src/components/navbar/command-palette.tsx
 msgctxt "RSFKID"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -226,9 +226,9 @@ msgid "Image uploaded"
 msgstr "Imagen subida"
 
 #: src/app/[orgSlug]/home-container-header.tsx
-msgctxt "6gzGoI"
-msgid "Courses that are not published yet"
-msgstr "Cursos que aún no han sido publicados"
+msgctxt "3MA05s"
+msgid "Draft courses"
+msgstr ""
 
 #: src/app/[orgSlug]/home-container-header.tsx
 #: src/app/[orgSlug]/new-course/page.tsx
@@ -238,24 +238,19 @@ msgid "Create course"
 msgstr "Crear curso"
 
 #: src/app/[orgSlug]/home-container-header.tsx
-msgctxt "R85gsW"
-msgid "Draft courses"
-msgstr "Cursos en borrador"
-
-#: src/components/navbar/command-palette.tsx
-msgctxt "R85gsX"
-msgid "Courses"
-msgstr "Cursos"
+msgctxt "ugXYXv"
+msgid "Courses that are not published yet"
+msgstr ""
 
 #: src/app/[orgSlug]/list-courses.tsx
-msgctxt "c0YWuA"
-msgid "Your organization doesn't have any draft courses."
-msgstr "Tu organización no tiene ningún curso en borrador."
-
-#: src/app/[orgSlug]/list-courses.tsx
-msgctxt "zJxO2f"
+msgctxt "F5+xrT"
 msgid "No draft courses"
-msgstr "Sin cursos en borrador"
+msgstr ""
+
+#: src/app/[orgSlug]/list-courses.tsx
+msgctxt "mYCw6F"
+msgid "Your organization doesn't have any draft courses."
+msgstr ""
 
 #: src/app/[orgSlug]/new-course/actions.ts
 msgctxt "bLbK+M"
@@ -610,6 +605,11 @@ msgstr "Lecciones"
 msgctxt "qlTe+e"
 msgid "new"
 msgstr "nuevo"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "R85gsW"
+msgid "Courses"
+msgstr "Cursos en borrador"
 
 #: src/components/navbar/command-palette.tsx
 msgctxt "RSFKID"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -228,7 +228,7 @@ msgstr "Imagen subida"
 #: src/app/[orgSlug]/home-container-header.tsx
 msgctxt "3MA05s"
 msgid "Draft courses"
-msgstr ""
+msgstr "Cursos en borrador"
 
 #: src/app/[orgSlug]/home-container-header.tsx
 #: src/app/[orgSlug]/new-course/page.tsx
@@ -240,17 +240,17 @@ msgstr "Crear curso"
 #: src/app/[orgSlug]/home-container-header.tsx
 msgctxt "ugXYXv"
 msgid "Courses that are not published yet"
-msgstr ""
+msgstr "Cursos que aún no están publicados"
 
 #: src/app/[orgSlug]/list-courses.tsx
 msgctxt "F5+xrT"
 msgid "No draft courses"
-msgstr ""
+msgstr "No hay cursos en borrador"
 
 #: src/app/[orgSlug]/list-courses.tsx
 msgctxt "mYCw6F"
 msgid "Your organization doesn't have any draft courses."
-msgstr ""
+msgstr "Tu organización no tiene cursos en borrador."
 
 #: src/app/[orgSlug]/new-course/actions.ts
 msgctxt "bLbK+M"
@@ -609,7 +609,7 @@ msgstr "nuevo"
 #: src/components/navbar/command-palette.tsx
 msgctxt "R85gsW"
 msgid "Courses"
-msgstr "Cursos en borrador"
+msgstr "Cursos"
 
 #: src/components/navbar/command-palette.tsx
 msgctxt "RSFKID"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -227,8 +227,8 @@ msgstr "Imagen subida"
 
 #: src/app/[orgSlug]/home-container-header.tsx
 msgctxt "6gzGoI"
-msgid "Select a course to edit its content"
-msgstr "Selecciona un curso para editar su contenido"
+msgid "Courses that are not published yet"
+msgstr "Cursos que aún no han sido publicados"
 
 #: src/app/[orgSlug]/home-container-header.tsx
 #: src/app/[orgSlug]/new-course/page.tsx
@@ -238,20 +238,24 @@ msgid "Create course"
 msgstr "Crear curso"
 
 #: src/app/[orgSlug]/home-container-header.tsx
-#: src/components/navbar/command-palette.tsx
 msgctxt "R85gsW"
+msgid "Draft courses"
+msgstr "Cursos en borrador"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "R85gsX"
 msgid "Courses"
 msgstr "Cursos"
 
 #: src/app/[orgSlug]/list-courses.tsx
 msgctxt "c0YWuA"
-msgid "Your organization hasn't created any courses yet."
-msgstr "Tu organización aún no ha creado ningún curso."
+msgid "Your organization doesn't have any draft courses."
+msgstr "Tu organización no tiene ningún curso en borrador."
 
 #: src/app/[orgSlug]/list-courses.tsx
 msgctxt "zJxO2f"
-msgid "No courses"
-msgstr "Sin cursos"
+msgid "No draft courses"
+msgstr "Sin cursos en borrador"
 
 #: src/app/[orgSlug]/new-course/actions.ts
 msgctxt "bLbK+M"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -228,7 +228,7 @@ msgstr "Imagem enviada"
 #: src/app/[orgSlug]/home-container-header.tsx
 msgctxt "3MA05s"
 msgid "Draft courses"
-msgstr ""
+msgstr "Cursos em rascunho"
 
 #: src/app/[orgSlug]/home-container-header.tsx
 #: src/app/[orgSlug]/new-course/page.tsx
@@ -240,17 +240,17 @@ msgstr "Criar curso"
 #: src/app/[orgSlug]/home-container-header.tsx
 msgctxt "ugXYXv"
 msgid "Courses that are not published yet"
-msgstr ""
+msgstr "Cursos que ainda não foram publicados"
 
 #: src/app/[orgSlug]/list-courses.tsx
 msgctxt "F5+xrT"
 msgid "No draft courses"
-msgstr ""
+msgstr "Nenhum curso em rascunho"
 
 #: src/app/[orgSlug]/list-courses.tsx
 msgctxt "mYCw6F"
 msgid "Your organization doesn't have any draft courses."
-msgstr ""
+msgstr "Sua organização não tem nenhum curso em rascunho."
 
 #: src/app/[orgSlug]/new-course/actions.ts
 msgctxt "bLbK+M"
@@ -609,7 +609,7 @@ msgstr "novo"
 #: src/components/navbar/command-palette.tsx
 msgctxt "R85gsW"
 msgid "Courses"
-msgstr "Cursos em rascunho"
+msgstr "Cursos"
 
 #: src/components/navbar/command-palette.tsx
 msgctxt "RSFKID"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -227,8 +227,8 @@ msgstr "Imagem enviada"
 
 #: src/app/[orgSlug]/home-container-header.tsx
 msgctxt "6gzGoI"
-msgid "Select a course to edit its content"
-msgstr "Selecione um curso para editar seu conteúdo"
+msgid "Courses that are not published yet"
+msgstr "Cursos que ainda não foram publicados"
 
 #: src/app/[orgSlug]/home-container-header.tsx
 #: src/app/[orgSlug]/new-course/page.tsx
@@ -238,20 +238,24 @@ msgid "Create course"
 msgstr "Criar curso"
 
 #: src/app/[orgSlug]/home-container-header.tsx
-#: src/components/navbar/command-palette.tsx
 msgctxt "R85gsW"
+msgid "Draft courses"
+msgstr "Cursos em rascunho"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "R85gsX"
 msgid "Courses"
 msgstr "Cursos"
 
 #: src/app/[orgSlug]/list-courses.tsx
 msgctxt "c0YWuA"
-msgid "Your organization hasn't created any courses yet."
-msgstr "Sua organização ainda não criou nenhum curso."
+msgid "Your organization doesn't have any draft courses."
+msgstr "Sua organização não tem nenhum curso em rascunho."
 
 #: src/app/[orgSlug]/list-courses.tsx
 msgctxt "zJxO2f"
-msgid "No courses"
-msgstr "Sem cursos"
+msgid "No draft courses"
+msgstr "Sem cursos em rascunho"
 
 #: src/app/[orgSlug]/new-course/actions.ts
 msgctxt "bLbK+M"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -226,9 +226,9 @@ msgid "Image uploaded"
 msgstr "Imagem enviada"
 
 #: src/app/[orgSlug]/home-container-header.tsx
-msgctxt "6gzGoI"
-msgid "Courses that are not published yet"
-msgstr "Cursos que ainda não foram publicados"
+msgctxt "3MA05s"
+msgid "Draft courses"
+msgstr ""
 
 #: src/app/[orgSlug]/home-container-header.tsx
 #: src/app/[orgSlug]/new-course/page.tsx
@@ -238,24 +238,19 @@ msgid "Create course"
 msgstr "Criar curso"
 
 #: src/app/[orgSlug]/home-container-header.tsx
-msgctxt "R85gsW"
-msgid "Draft courses"
-msgstr "Cursos em rascunho"
-
-#: src/components/navbar/command-palette.tsx
-msgctxt "R85gsX"
-msgid "Courses"
-msgstr "Cursos"
+msgctxt "ugXYXv"
+msgid "Courses that are not published yet"
+msgstr ""
 
 #: src/app/[orgSlug]/list-courses.tsx
-msgctxt "c0YWuA"
-msgid "Your organization doesn't have any draft courses."
-msgstr "Sua organização não tem nenhum curso em rascunho."
-
-#: src/app/[orgSlug]/list-courses.tsx
-msgctxt "zJxO2f"
+msgctxt "F5+xrT"
 msgid "No draft courses"
-msgstr "Sem cursos em rascunho"
+msgstr ""
+
+#: src/app/[orgSlug]/list-courses.tsx
+msgctxt "mYCw6F"
+msgid "Your organization doesn't have any draft courses."
+msgstr ""
 
 #: src/app/[orgSlug]/new-course/actions.ts
 msgctxt "bLbK+M"
@@ -610,6 +605,11 @@ msgstr "Aulas"
 msgctxt "qlTe+e"
 msgid "new"
 msgstr "novo"
+
+#: src/components/navbar/command-palette.tsx
+msgctxt "R85gsW"
+msgid "Courses"
+msgstr "Cursos em rascunho"
 
 #: src/components/navbar/command-palette.tsx
 msgctxt "RSFKID"

--- a/apps/editor/src/app/[orgSlug]/home-container-header.tsx
+++ b/apps/editor/src/app/[orgSlug]/home-container-header.tsx
@@ -22,9 +22,9 @@ export async function HomeContainerHeader({
   return (
     <ContainerHeader>
       <ContainerHeaderGroup>
-        <ContainerTitle>{t("Courses")}</ContainerTitle>
+        <ContainerTitle>{t("Draft courses")}</ContainerTitle>
         <ContainerDescription>
-          {t("Select a course to edit its content")}
+          {t("Courses that are not published yet")}
         </ContainerDescription>
       </ContainerHeaderGroup>
 

--- a/apps/editor/src/app/[orgSlug]/list-courses.tsx
+++ b/apps/editor/src/app/[orgSlug]/list-courses.tsx
@@ -7,7 +7,7 @@ import { NotebookPenIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { getExtracted } from "next-intl/server";
-import { listCourses } from "@/data/courses/list-courses";
+import { listDraftCourses } from "@/data/courses/list-draft-courses";
 
 export async function ListCourses({
   params,
@@ -15,16 +15,16 @@ export async function ListCourses({
   params: PageProps<"/[orgSlug]">["params"];
 }) {
   const { orgSlug } = await params;
-  const { data: courses } = await listCourses({ orgSlug });
+  const { data: courses } = await listDraftCourses({ orgSlug });
 
   const t = await getExtracted();
 
   if (courses.length === 0) {
     return (
       <EmptyView
-        description={t("Your organization hasn't created any courses yet.")}
+        description={t("Your organization doesn't have any draft courses.")}
         icon={NotebookPenIcon}
-        title={t("No courses")}
+        title={t("No draft courses")}
       />
     );
   }

--- a/apps/editor/src/data/courses/list-draft-courses.test.ts
+++ b/apps/editor/src/data/courses/list-draft-courses.test.ts
@@ -98,7 +98,7 @@ describe("org admins", () => {
 
     expect(result.error).toBeNull();
     expect(result.data).toHaveLength(1);
-    expect(result.data[0].id).toBe(draftCourse.id);
+    expect(result.data[0]?.id).toBe(draftCourse.id);
     expect(result.data.every((c) => c.isPublished === false)).toBe(true);
   });
 
@@ -109,7 +109,9 @@ describe("org admins", () => {
     });
 
     expect(result.error).toBeNull();
-    expect(result.data.find((c) => c.id === publishedCourse.id)).toBeUndefined();
+    expect(
+      result.data.find((c) => c.id === publishedCourse.id),
+    ).toBeUndefined();
   });
 
   test("filters by language", async () => {

--- a/apps/editor/src/data/courses/list-draft-courses.ts
+++ b/apps/editor/src/data/courses/list-draft-courses.ts
@@ -2,19 +2,15 @@ import "server-only";
 
 import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
 import { type Course, prisma } from "@zoonk/db";
-import { clampQueryItems } from "@zoonk/db/utils";
 import { AppError, safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 import { ErrorCode } from "@/lib/app-error";
 
-const LIST_COURSES_LIMIT = 20;
-
-export const listCourses = cache(
+export const listDraftCourses = cache(
   async (params: {
     orgSlug: string;
     headers?: Headers;
     language?: string;
-    limit?: number;
   }): Promise<{ data: Course[]; error: Error | null }> => {
     const { data, error } = await safeAsync(() =>
       Promise.all([
@@ -25,8 +21,8 @@ export const listCourses = cache(
         }),
         prisma.course.findMany({
           orderBy: { createdAt: "desc" },
-          take: clampQueryItems(params.limit ?? LIST_COURSES_LIMIT),
           where: {
+            isPublished: false,
             organization: { slug: params.orgSlug },
             ...(params.language && { language: params.language }),
           },

--- a/i18n.lock
+++ b/i18n.lock
@@ -44,11 +44,11 @@ checksums:
     Upload%20course%20image/singular: 3d06104ec6418b93ee038445418c9599
     Image%20removed/singular: b0eb0cb47f8f6c1a2919713e8d1180e7
     Image%20uploaded/singular: 4161c70f9863af81286081a2f6bab12f
-    Your%20organization%20hasn't%20created%20any%20courses%20yet./singular: 4c09c8406dbf7bfe159f850fc1f22b99
-    No%20courses/singular: 72fc2629e79529e927834070a26d2a07
-    Select%20a%20course%20to%20edit%20its%20content/singular: 2f17c5f381acd6ffb1c1109a87e341b5
+    Draft%20courses/singular: a08a92e1697e25ae3f60e282326d942e
     Create%20course/singular: 41f52f80def95a611c9cc3a5e1a11dde
-    Courses/singular: e6d00f3285e8fc48b949af0c4aad3da5
+    Courses%20that%20are%20not%20published%20yet/singular: e08fd000b4c30ddb0b14ff1d2a875eb0
+    No%20draft%20courses/singular: 0f0801105a49bf8e6486ed3435a120f8
+    Your%20organization%20doesn't%20have%20any%20draft%20courses./singular: 5118aa8f79e5d6508b9fdc49ee13c34c
     All%20fields%20are%20required/singular: 01fe4fe061a783c06c001dd39c78053a
     Next/singular: 89ddbcf710eba274963494f312bdc8a9
     Back/singular: f541015a827e37cb3b1234e56bc2aa3c
@@ -117,6 +117,7 @@ checksums:
     dashboard/singular: 3e3998114a2eab7daa3c9a23dbeb16b9
     Lessons/singular: 52fdbe5a3a6ee1cc1e166546516f9111
     new/singular: 59c16092bc6a4b9de0debe084e4b5f49
+    Courses/singular: e6d00f3285e8fc48b949af0c4aad3da5
     course/singular: a8f5f6a15055aa74f1b98d4821329d19
     Home%20page/singular: aa72464a366b091aa6f2037ca869c09c
     sign%20out/singular: a917e8428004b4108a66fa0ba9c0c15c


### PR DESCRIPTION
Replace listCourses with listDraftCourses to show only unpublished
courses on the editor org home page. Update header title and
description to reflect this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show only draft (unpublished) courses on the editor org home page. Updated UI copy and data query to match.

- **New Features**
  - Switched to listDraftCourses; filters isPublished: false and removes limit.
  - Updated header title/description and empty states to “Draft courses” in en/es/pt.
  - Updated tests to assert draft-only results and language filtering.

<sup>Written for commit 3bbf02219c5ab66276107abddbd5a4abc69d890f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

