### PR TITLE
fix(editor): improve category selector with sorting, scroll, and search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Zoonk is a web app where users can learn anything using AI. This app uses AI to 
 - [CSS](#css)
 - [Icons](#icons)
 - [Cache Components](#cache-components)
+- [React Compiler](#react-compiler)
 - [Links](#links)
 - [Params](#params)
 - [Interactions](#interactions)
@@ -428,6 +429,10 @@ import { buttonVariants } from "@zoonk/ui/components/button";
 
 <Link className={buttonVariants({ variant: "outline" })}>Click here</Link>;
 ```
+
+## React Compiler
+
+We're using the new [React Compiler](https://react.dev/learn/react-compiler/introduction). By default, React Compiler will memoize your code based on its analysis and heuristics. In most cases, this memoization will be as precise, or moreso, than what you may have written. This means you don't need to `useMemo` or `useCallback` as much. The useMemo and useCallback hooks can continue to be used with React Compiler as an escape hatch to provide control over which values are memoized. A common use-case for this is if a memoized value is used as an effect dependency, in order to ensure that an effect does not fire repeatedly even when its dependencies do not meaningfully change. However, this should be used sparingly and only when necessary. Don't default to using `useMemo` or `useCallback` with React Compiler, use them only when necessary.
 
 ## Params
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Zoonk is a web app where users can learn anything using AI. This app uses AI to 
 - [CSS](#css)
 - [Icons](#icons)
 - [Cache Components](#cache-components)
+- [React Compiler](#react-compiler)
 - [Links](#links)
 - [Params](#params)
 - [Interactions](#interactions)
@@ -428,6 +429,10 @@ import { buttonVariants } from "@zoonk/ui/components/button";
 
 <Link className={buttonVariants({ variant: "outline" })}>Click here</Link>;
 ```
+
+## React Compiler
+
+We're using the new [React Compiler](https://react.dev/learn/react-compiler/introduction). By default, React Compiler will memoize your code based on its analysis and heuristics. In most cases, this memoization will be as precise, or moreso, than what you may have written. This means you don't need to `useMemo` or `useCallback` as much. The useMemo and useCallback hooks can continue to be used with React Compiler as an escape hatch to provide control over which values are memoized. A common use-case for this is if a memoized value is used as an effect dependency, in order to ensure that an effect does not fire repeatedly even when its dependencies do not meaningfully change. However, this should be used sparingly and only when necessary. Don't default to using `useMemo` or `useCallback` with React Compiler, use them only when necessary.
 
 ## Params
 

--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -497,6 +497,12 @@ msgctxt "VKb1MS"
 msgid "Categories"
 msgstr "Categories"
 
+#: src/components/category-editor.tsx
+#: src/components/navbar/command-palette.tsx
+msgctxt "xmcVZ0"
+msgid "Search"
+msgstr "Search"
+
 #: src/components/content-editor.tsx
 msgctxt "BfrgHC"
 msgid "Unsaved"
@@ -627,11 +633,6 @@ msgstr "sign out"
 msgctxt "wmNq1X"
 msgid "exit"
 msgstr "exit"
-
-#: src/components/navbar/command-palette.tsx
-msgctxt "xmcVZ0"
-msgid "Search"
-msgstr "Search"
 
 #: src/components/navbar/command-palette.tsx
 msgctxt "zTylMM"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -497,6 +497,12 @@ msgctxt "VKb1MS"
 msgid "Categories"
 msgstr "Categorías"
 
+#: src/components/category-editor.tsx
+#: src/components/navbar/command-palette.tsx
+msgctxt "xmcVZ0"
+msgid "Search"
+msgstr "Buscar"
+
 #: src/components/content-editor.tsx
 msgctxt "BfrgHC"
 msgid "Unsaved"
@@ -627,11 +633,6 @@ msgstr "cerrar sesión"
 msgctxt "wmNq1X"
 msgid "exit"
 msgstr "salir"
-
-#: src/components/navbar/command-palette.tsx
-msgctxt "xmcVZ0"
-msgid "Search"
-msgstr "Buscar"
 
 #: src/components/navbar/command-palette.tsx
 msgctxt "zTylMM"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -497,6 +497,12 @@ msgctxt "VKb1MS"
 msgid "Categories"
 msgstr "Categorias"
 
+#: src/components/category-editor.tsx
+#: src/components/navbar/command-palette.tsx
+msgctxt "xmcVZ0"
+msgid "Search"
+msgstr "Buscar"
+
 #: src/components/content-editor.tsx
 msgctxt "BfrgHC"
 msgid "Unsaved"
@@ -627,11 +633,6 @@ msgstr "sair"
 msgctxt "wmNq1X"
 msgid "exit"
 msgstr "sair"
-
-#: src/components/navbar/command-palette.tsx
-msgctxt "xmcVZ0"
-msgid "Search"
-msgstr "Buscar"
 
 #: src/components/navbar/command-palette.tsx
 msgctxt "zTylMM"

--- a/apps/editor/src/components/category-editor.tsx
+++ b/apps/editor/src/components/category-editor.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@zoonk/ui/components/badge";
 import { Button } from "@zoonk/ui/components/button";
 import { Checkbox } from "@zoonk/ui/components/checkbox";
 import { EditableLabel } from "@zoonk/ui/components/editable-text";
+import { Input } from "@zoonk/ui/components/input";
 import { Label } from "@zoonk/ui/components/label";
 import {
   Popover,
@@ -12,10 +13,9 @@ import {
 } from "@zoonk/ui/components/popover";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { toast } from "@zoonk/ui/components/sonner";
-import { COURSE_CATEGORIES } from "@zoonk/utils/categories";
 import { PlusIcon, TagsIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
-import { useOptimistic, useTransition } from "react";
+import { useMemo, useOptimistic, useState, useTransition } from "react";
 import { useCategoryLabels } from "@/hooks/use-category-labels";
 
 export function CategoryEditorSkeleton() {
@@ -47,19 +47,44 @@ export function CategoryEditor({
   onRemove,
 }: CategoryEditorProps) {
   const t = useExtracted();
-  const { labels: categoryLabels, getLabel } = useCategoryLabels();
+  const {
+    labels: categoryLabels,
+    sortedCategories,
+    getLabel,
+  } = useCategoryLabels();
   const [isPending, startTransition] = useTransition();
+  const [search, setSearch] = useState("");
 
   const [optimisticCategories, updateOptimistic] = useOptimistic(
     categories,
     (state, action: OptimisticAction) => {
       if (action.type === "add") {
-        return [...state, action.category].sort();
+        return [...state, action.category];
       }
 
       return state.filter((c) => c !== action.category);
     },
   );
+
+  const sortedOptimisticCategories = useMemo(
+    () =>
+      [...optimisticCategories].sort((a, b) => {
+        const labelA = getLabel(a) ?? a;
+        const labelB = getLabel(b) ?? b;
+        return labelA.localeCompare(labelB);
+      }),
+    [optimisticCategories, getLabel],
+  );
+
+  const filteredCategories = useMemo(() => {
+    if (!search.trim()) {
+      return sortedCategories;
+    }
+    const searchLower = search.toLowerCase();
+    return sortedCategories.filter((category) =>
+      categoryLabels[category].toLowerCase().includes(searchLower),
+    );
+  }, [sortedCategories, categoryLabels, search]);
 
   function handleToggle(category: string, isSelected: boolean) {
     startTransition(async () => {
@@ -86,7 +111,7 @@ export function CategoryEditor({
       <EditableLabel icon={TagsIcon}>{t("Categories")}</EditableLabel>
 
       <div className="flex flex-wrap items-center gap-2">
-        {optimisticCategories.map((category) => {
+        {sortedOptimisticCategories.map((category) => {
           const label = getLabel(category);
 
           if (!label) {
@@ -115,8 +140,16 @@ export function CategoryEditor({
           </PopoverTrigger>
 
           <PopoverContent align="start" className="w-56 p-2">
-            <div className="flex max-h-64 flex-col gap-1 overflow-y-auto">
-              {COURSE_CATEGORIES.map((category) => {
+            <Input
+              className="mb-2"
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder={`${t("Search")}…`}
+              type="search"
+              value={search}
+            />
+
+            <div className="flex max-h-64 flex-col gap-1 overflow-y-auto overscroll-contain">
+              {filteredCategories.map((category) => {
                 const isSelected = optimisticCategories.includes(category);
 
                 return (

--- a/apps/editor/src/components/category-editor.tsx
+++ b/apps/editor/src/components/category-editor.tsx
@@ -52,6 +52,7 @@ export function CategoryEditor({
     sortedCategories,
     getLabel,
   } = useCategoryLabels();
+
   const [isPending, startTransition] = useTransition();
   const [search, setSearch] = useState("");
 
@@ -66,21 +67,19 @@ export function CategoryEditor({
     },
   );
 
-  const sortedOptimisticCategories = useMemo(
-    () =>
-      [...optimisticCategories].sort((a, b) => {
-        const labelA = getLabel(a) ?? a;
-        const labelB = getLabel(b) ?? b;
-        return labelA.localeCompare(labelB);
-      }),
-    [optimisticCategories, getLabel],
-  );
+  const sortedOptimisticCategories = [...optimisticCategories].sort((a, b) => {
+    const labelA = getLabel(a) ?? a;
+    const labelB = getLabel(b) ?? b;
+    return labelA.localeCompare(labelB);
+  });
 
   const filteredCategories = useMemo(() => {
     if (!search.trim()) {
       return sortedCategories;
     }
+
     const searchLower = search.toLowerCase();
+
     return sortedCategories.filter((category) =>
       categoryLabels[category].toLowerCase().includes(searchLower),
     );
@@ -90,6 +89,7 @@ export function CategoryEditor({
     startTransition(async () => {
       if (isSelected) {
         updateOptimistic({ category, type: "remove" });
+
         const { error } = await onRemove(category);
 
         if (error) {
@@ -97,6 +97,7 @@ export function CategoryEditor({
         }
       } else {
         updateOptimistic({ category, type: "add" });
+
         const { error } = await onAdd(category);
 
         if (error) {

--- a/apps/editor/src/hooks/use-category-labels.ts
+++ b/apps/editor/src/hooks/use-category-labels.ts
@@ -5,34 +5,45 @@ import {
   type CourseCategory,
 } from "@zoonk/utils/categories";
 import { useExtracted } from "next-intl";
+import { useMemo } from "react";
 
 type CategoryLabels = Record<CourseCategory, string>;
 
 type UseCategoryLabelsResult = {
   labels: CategoryLabels;
+  sortedCategories: CourseCategory[];
   getLabel: (category: string) => string | null;
 };
 
 export function useCategoryLabels(): UseCategoryLabelsResult {
   const t = useExtracted();
 
-  const labels: CategoryLabels = {
-    arts: t("Arts"),
-    business: t("Business"),
-    communication: t("Communication"),
-    culture: t("Culture"),
-    economics: t("Economics"),
-    engineering: t("Engineering"),
-    geography: t("Geography"),
-    health: t("Health"),
-    history: t("History"),
-    languages: t("Languages"),
-    law: t("Law"),
-    math: t("Math"),
-    science: t("Science"),
-    society: t("Society"),
-    tech: t("Technology"),
-  };
+  const labels = useMemo<CategoryLabels>(
+    () => ({
+      arts: t("Arts"),
+      business: t("Business"),
+      communication: t("Communication"),
+      culture: t("Culture"),
+      economics: t("Economics"),
+      engineering: t("Engineering"),
+      geography: t("Geography"),
+      health: t("Health"),
+      history: t("History"),
+      languages: t("Languages"),
+      law: t("Law"),
+      math: t("Math"),
+      science: t("Science"),
+      society: t("Society"),
+      tech: t("Technology"),
+    }),
+    [t],
+  );
+
+  const sortedCategories = useMemo(
+    () =>
+      [...COURSE_CATEGORIES].sort((a, b) => labels[a].localeCompare(labels[b])),
+    [labels],
+  );
 
   function getLabel(category: string): string | null {
     if (!COURSE_CATEGORIES.includes(category as CourseCategory)) {
@@ -41,5 +52,5 @@ export function useCategoryLabels(): UseCategoryLabelsResult {
     return labels[category as CourseCategory];
   }
 
-  return { getLabel, labels };
+  return { getLabel, labels, sortedCategories };
 }

--- a/apps/editor/src/hooks/use-category-labels.ts
+++ b/apps/editor/src/hooks/use-category-labels.ts
@@ -5,7 +5,6 @@ import {
   type CourseCategory,
 } from "@zoonk/utils/categories";
 import { useExtracted } from "next-intl";
-import { useMemo } from "react";
 
 type CategoryLabels = Record<CourseCategory, string>;
 
@@ -18,31 +17,26 @@ type UseCategoryLabelsResult = {
 export function useCategoryLabels(): UseCategoryLabelsResult {
   const t = useExtracted();
 
-  const labels = useMemo<CategoryLabels>(
-    () => ({
-      arts: t("Arts"),
-      business: t("Business"),
-      communication: t("Communication"),
-      culture: t("Culture"),
-      economics: t("Economics"),
-      engineering: t("Engineering"),
-      geography: t("Geography"),
-      health: t("Health"),
-      history: t("History"),
-      languages: t("Languages"),
-      law: t("Law"),
-      math: t("Math"),
-      science: t("Science"),
-      society: t("Society"),
-      tech: t("Technology"),
-    }),
-    [t],
-  );
+  const labels = {
+    arts: t("Arts"),
+    business: t("Business"),
+    communication: t("Communication"),
+    culture: t("Culture"),
+    economics: t("Economics"),
+    engineering: t("Engineering"),
+    geography: t("Geography"),
+    health: t("Health"),
+    history: t("History"),
+    languages: t("Languages"),
+    law: t("Law"),
+    math: t("Math"),
+    science: t("Science"),
+    society: t("Society"),
+    tech: t("Technology"),
+  };
 
-  const sortedCategories = useMemo(
-    () =>
-      [...COURSE_CATEGORIES].sort((a, b) => labels[a].localeCompare(labels[b])),
-    [labels],
+  const sortedCategories = [...COURSE_CATEGORIES].sort((a, b) =>
+    labels[a].localeCompare(labels[b]),
   );
 
   function getLabel(category: string): string | null {


### PR DESCRIPTION
Sort categories alphabetically by translated label (not English key),
prevent page scrolling when scrolling the popover via overscroll-contain,
and add a search input for filtering categories.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved the category selector with localized alphabetical sorting, search, and better scroll behavior. This makes categories easier to find and stops the page from scrolling when the popover scrolls.

- **New Features**
  - Sort categories by translated label, including selected chips.
  - Add search to filter categories by their translated label.

- **Bug Fixes**
  - Prevent page scrolling while scrolling the popover (overscroll-contain).

<sup>Written for commit 5ecadefce84f1ff2922557e357ed8a1b839bd001. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

