### PR TITLE
fix(ui): auto-resize textarea on Safari when field-sizing is unsupported

### DIFF
--- a/packages/ui/src/components/editable-text.tsx
+++ b/packages/ui/src/components/editable-text.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import { cn } from "@zoonk/ui/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 import type { LucideIcon } from "lucide-react";
+import { useAutoResize } from "../hooks/use-auto-resize";
 
 export type EditableLabelProps = React.ComponentProps<"label"> & {
   icon?: LucideIcon;
@@ -95,13 +98,20 @@ function EditableTextarea({
   className,
   variant,
   rows = 1,
+  value,
   ...props
 }: EditableTextareaProps) {
+  const autoResizeRef = useAutoResize({
+    value: typeof value === "string" ? value : undefined,
+  });
+
   return (
     <textarea
       className={cn(editableTextareaVariants({ variant }), className)}
       data-slot="editable-textarea"
+      ref={autoResizeRef}
       rows={rows}
+      value={value}
       {...props}
     />
   );

--- a/packages/ui/src/hooks/use-auto-resize.ts
+++ b/packages/ui/src/hooks/use-auto-resize.ts
@@ -1,0 +1,64 @@
+import { useCallback, useLayoutEffect, useRef } from "react";
+
+/**
+ * Checks if the browser supports CSS `field-sizing: content`.
+ * We cache this check to avoid repeated DOM operations.
+ */
+let fieldSizingSupported: boolean | null = null;
+
+function isFieldSizingSupported(): boolean {
+  if (fieldSizingSupported !== null) return fieldSizingSupported;
+  if (typeof window === "undefined") return true;
+  fieldSizingSupported = CSS.supports("field-sizing", "content");
+  return fieldSizingSupported;
+}
+
+/**
+ * Resizes a textarea to fit its content by setting height to scrollHeight.
+ */
+function resizeTextarea(textarea: HTMLTextAreaElement): void {
+  textarea.style.height = "auto";
+  textarea.style.height = `${textarea.scrollHeight}px`;
+}
+
+type UseAutoResizeOptions = {
+  value?: string;
+};
+
+/**
+ * Auto-resizes a textarea to fit its content when CSS `field-sizing: content`
+ * is not supported (e.g., older Safari versions).
+ *
+ * Returns a ref callback to attach to the textarea element.
+ */
+export function useAutoResize({ value }: UseAutoResizeOptions = {}) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const needsJsResize = !isFieldSizingSupported();
+
+  useLayoutEffect(() => {
+    if (!needsJsResize || !textareaRef.current) return;
+    resizeTextarea(textareaRef.current);
+  }, [needsJsResize, value]);
+
+  useLayoutEffect(() => {
+    if (!needsJsResize || !textareaRef.current) return;
+
+    const textarea = textareaRef.current;
+    const handleInput = () => resizeTextarea(textarea);
+    textarea.addEventListener("input", handleInput);
+
+    return () => textarea.removeEventListener("input", handleInput);
+  }, [needsJsResize]);
+
+  const refCallback = useCallback(
+    (node: HTMLTextAreaElement | null) => {
+      textareaRef.current = node;
+      if (needsJsResize && node) {
+        resizeTextarea(node);
+      }
+    },
+    [needsJsResize],
+  );
+
+  return refCallback;
+}


### PR DESCRIPTION
Safari only recently added support for `field-sizing: content` in
version 26.2. For older Safari versions, the textarea would show only
one line. This adds a JavaScript fallback that auto-resizes the
textarea by measuring its scrollHeight when CSS support is missing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes textarea sizing on older Safari versions by adding a JS fallback when field-sizing: content isn’t supported. Textareas now expand to fit their content across browsers.

- **Bug Fixes**
  - Added useAutoResize hook that sets height to scrollHeight when field-sizing is unsupported.
  - Detects support via CSS.supports and only applies the fallback as needed.
  - Integrated into EditableTextarea with a ref; resizes on mount, input, and controlled value changes.

<sup>Written for commit ef869c3ef697182858d0479ea49e40fb784d5122. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

