### PR TITLE
feat(editor): allow admins to delete unpublished content

### DIFF
--- a/apps/editor/src/data/chapters/delete-chapter.ts
+++ b/apps/editor/src/data/chapters/delete-chapter.ts
@@ -26,7 +26,7 @@ export async function deleteChapter(params: {
   const hasPermission = await hasCoursePermission({
     headers: params.headers,
     orgId: chapter.organizationId,
-    permission: "delete",
+    permission: chapter.isPublished ? "delete" : "update",
   });
 
   if (!hasPermission) {

--- a/apps/editor/src/data/courses/delete-course.ts
+++ b/apps/editor/src/data/courses/delete-course.ts
@@ -26,7 +26,7 @@ export async function deleteCourse(params: {
   const hasPermission = await hasCoursePermission({
     headers: params.headers,
     orgId: course.organizationId,
-    permission: "delete",
+    permission: course.isPublished ? "delete" : "update",
   });
 
   if (!hasPermission) {

--- a/apps/editor/src/data/lessons/delete-lesson.ts
+++ b/apps/editor/src/data/lessons/delete-lesson.ts
@@ -26,7 +26,7 @@ export async function deleteLesson(params: {
   const hasPermission = await hasCoursePermission({
     headers: params.headers,
     orgId: lesson.organizationId,
-    permission: "delete",
+    permission: lesson.isPublished ? "delete" : "update",
   });
 
   if (!hasPermission) {


### PR DESCRIPTION
Update delete functions for courses, chapters, and lessons to check
'update' permission instead of 'delete' when content is unpublished.
This allows admins (who have update but not delete permission) to
delete draft content while still requiring owner permission for
published content.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow admins to delete unpublished courses, chapters, and lessons by checking update permission for drafts, while still requiring delete permission for published content. This lets admins clean up drafts without owner access and keeps published content protected.

- **New Features**
  - Use update permission for deleting unpublished items; keep delete permission for published.
  - Added admin tests for courses, chapters, and lessons (success for drafts, forbidden for published).

<sup>Written for commit b9daa8afb9e5176c66b3d9b72ac27a245e8222b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

