### PR TITLE
feat(auth): skip login page when user has existing session

### DIFF
--- a/apps/auth/src/app/[locale]/login/page.tsx
+++ b/apps/auth/src/app/[locale]/login/page.tsx
@@ -1,5 +1,7 @@
+import { getSession } from "@zoonk/core/users/session/get";
 import { FullPageLoading } from "@zoonk/ui/components/loading";
 import { getExtracted } from "next-intl/server";
+import { redirect } from "next/navigation";
 import { Suspense } from "react";
 import {
   Login,
@@ -18,8 +20,15 @@ import { sendVerificationOTPAction } from "./actions";
 import { SocialLogin } from "./social-login";
 
 async function LoginView({ searchParams }: PageProps<"/[locale]/login">) {
-  const t = await getExtracted();
   const { redirectTo } = await searchParams;
+
+  // If user already has a session, skip login and redirect with a one-time token
+  const session = await getSession();
+  if (session && redirectTo) {
+    redirect(`/callback?redirectTo=${encodeURIComponent(String(redirectTo))}`);
+  }
+
+  const t = await getExtracted();
 
   return (
     <>

--- a/apps/auth/src/app/[locale]/login/page.tsx
+++ b/apps/auth/src/app/[locale]/login/page.tsx
@@ -1,7 +1,7 @@
 import { getSession } from "@zoonk/core/users/session/get";
 import { FullPageLoading } from "@zoonk/ui/components/loading";
-import { getExtracted } from "next-intl/server";
 import { redirect } from "next/navigation";
+import { getExtracted } from "next-intl/server";
 import { Suspense } from "react";
 import {
   Login,


### PR DESCRIPTION
When a user visits the login page with an existing session and a
redirectTo parameter, automatically generate a one-time token and
redirect them back to the app without showing the login form.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the login page when a user already has a session and a redirectTo param is present. We now redirect straight to /callback with redirectTo so the app can continue without showing the login form.

<sup>Written for commit c216ff733b4443a6ecbe401fb0d8163da6f95752. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

