### PR TITLE
chore(editor): setup e2e tests

### DIFF
--- a/.github/workflows/e2e-editor.yml
+++ b/.github/workflows/e2e-editor.yml
@@ -1,0 +1,78 @@
+name: E2E Tests (Editor App)
+
+on: push
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: 24
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      BETTER_AUTH_SECRET: test-secret-for-ci
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/zoonk_e2e
+      DATABASE_URL_UNPOOLED: postgres://postgres:postgres@localhost:5432/zoonk_e2e
+      E2E_TESTING: "true"
+      NEXT_PUBLIC_APP_DOMAIN: localhost:3003
+      NEXT_PUBLIC_AUTH_APP_URL: http://localhost:3001
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
+    services:
+      db:
+        image: postgres:17-alpine
+        ports: ["5432:5432"]
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: zoonk_e2e
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 1s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-turbo-
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: apps/editor/.next-e2e/cache
+          key: ${{ runner.os }}-nextjs-editor-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('apps/editor/**/*.ts', 'apps/editor/**/*.tsx', 'packages/**/*.ts', 'packages/**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-editor-${{ hashFiles('**/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-editor-
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+        with:
+          version: 10.27.0
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: pnpm e2e --filter=editor

--- a/apps/editor/e2e/fixtures.ts
+++ b/apps/editor/e2e/fixtures.ts
@@ -1,0 +1,28 @@
+import type { Page } from "@zoonk/e2e/fixtures";
+import { test as base } from "@zoonk/e2e/fixtures";
+
+export type EditorAuthFixtures = {
+  authenticatedPage: Page;
+  userWithoutOrg: Page;
+};
+
+export const test = base.extend<EditorAuthFixtures>({
+  authenticatedPage: async ({ browser }, use) => {
+    const context = await browser.newContext({
+      storageState: "e2e/.auth/admin.json",
+    });
+    const page = await context.newPage();
+    await use(page);
+    await context.close();
+  },
+  userWithoutOrg: async ({ browser }, use) => {
+    const context = await browser.newContext({
+      storageState: "e2e/.auth/noOrg.json",
+    });
+    const page = await context.newPage();
+    await use(page);
+    await context.close();
+  },
+});
+
+export { expect, type Page } from "@zoonk/e2e/fixtures";

--- a/apps/editor/e2e/global-setup.ts
+++ b/apps/editor/e2e/global-setup.ts
@@ -1,0 +1,49 @@
+import { mkdir } from "node:fs/promises";
+import { request } from "@zoonk/e2e/fixtures";
+
+const BASE_URL = "http://localhost:3003";
+
+export const E2E_USERS = {
+  admin: {
+    email: "admin@zoonk.test",
+    password: "password123",
+  },
+  noOrg: {
+    email: "e2e-logout@zoonk.test",
+    password: "password123",
+  },
+} as const;
+
+async function authenticateUser(
+  name: string,
+  user: { email: string; password: string },
+): Promise<void> {
+  const context = await request.newContext({ baseURL: BASE_URL });
+
+  const response = await context.post("/api/auth/sign-in/email", {
+    data: {
+      email: user.email,
+      password: user.password,
+    },
+  });
+
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(
+      `Failed to authenticate ${name} (${user.email}): ${response.status()} - ${body}`,
+    );
+  }
+
+  await context.storageState({ path: `e2e/.auth/${name}.json` });
+  await context.dispose();
+}
+
+export default async function globalSetup(): Promise<void> {
+  await mkdir("e2e/.auth", { recursive: true });
+
+  await Promise.all(
+    Object.entries(E2E_USERS).map(([name, user]) =>
+      authenticateUser(name, user),
+    ),
+  );
+}

--- a/apps/editor/e2e/home.test.ts
+++ b/apps/editor/e2e/home.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "./fixtures";
+
+test.describe("Home Page - Unauthenticated", () => {
+  test("shows unauthorized page with login link", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("heading", { name: /401 - unauthorized/i }),
+    ).toBeVisible();
+
+    await expect(page.getByRole("link", { name: /login/i })).toBeVisible();
+  });
+});
+
+test.describe("Home Page - Authenticated without org", () => {
+  test("shows unauthorized page with logout link", async ({
+    userWithoutOrg,
+  }) => {
+    await userWithoutOrg.goto("/");
+
+    await expect(
+      userWithoutOrg.getByRole("heading", { name: /401 - unauthorized/i }),
+    ).toBeVisible();
+
+    await expect(
+      userWithoutOrg.getByRole("link", { name: /logout/i }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("Home Page - Authenticated with org", () => {
+  test("redirects to active organization page", async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto("/");
+
+    await authenticatedPage.waitForURL(/\/ai/);
+
+    await expect(authenticatedPage).toHaveURL(/\/ai/);
+  });
+});

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -1,10 +1,20 @@
+import path from "node:path";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
 const CACHE_IMAGE_DAYS = 30;
 
+const isE2E = process.env.E2E_TESTING === "true";
+
+// Swap @zoonk/auth for E2E-specific config during E2E builds
+const e2eAliases: Record<string, string> = isE2E
+  ? { "@zoonk/auth": "../../packages/auth/src/e2e.ts" }
+  : {};
+
 const nextConfig: NextConfig = {
   devIndicators: false,
+  // Use separate build directories so E2E and production builds don't conflict
+  distDir: isE2E ? ".next-e2e" : ".next",
   experimental: {
     authInterrupts: true,
     serverActions: {
@@ -25,6 +35,12 @@ const nextConfig: NextConfig = {
     ],
   },
   reactCompiler: true,
+  turbopack: {
+    resolveAlias: {
+      ...e2eAliases,
+    },
+    root: path.resolve(__dirname, "../.."),
+  },
   typedRoutes: true,
 };
 

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -24,6 +24,7 @@
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@zoonk/e2e": "workspace:*",
     "@zoonk/testing": "workspace:*",
     "@zoonk/tsconfig": "workspace:*",
     "babel-plugin-react-compiler": "1.0.0",
@@ -36,7 +37,10 @@
   "scripts": {
     "analyze": "next experimental-analyze",
     "build": "next build",
+    "build:e2e": "E2E_TESTING=true next build",
     "dev": "next dev -p 3003",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
     "start": "next start -p 3003",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/apps/editor/playwright.config.ts
+++ b/apps/editor/playwright.config.ts
@@ -1,0 +1,15 @@
+import { createBaseConfig } from "@zoonk/e2e/base.config";
+
+const E2E_DATABASE_URL =
+  "postgres://postgres:postgres@localhost:5432/zoonk_e2e";
+
+export default createBaseConfig({
+  baseURL: "http://localhost:3003",
+  globalSetup: "./e2e/global-setup.ts",
+  port: 3003,
+  testDir: "./e2e",
+  webServerEnv: {
+    DATABASE_URL: E2E_DATABASE_URL,
+    DATABASE_URL_UNPOOLED: E2E_DATABASE_URL,
+  },
+});

--- a/apps/editor/vitest.config.mts
+++ b/apps/editor/vitest.config.mts
@@ -20,6 +20,7 @@ export default defineConfig({
         "postgres://postgres:postgres@localhost:5432/zoonk_test",
     },
     environment: "node",
+    exclude: ["**/node_modules/**", "**/e2e/**"],
     setupFiles: ["./setup-tests.ts"],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.7)
+      '@zoonk/e2e':
+        specifier: workspace:*
+        version: link:../../packages/e2e
       '@zoonk/testing':
         specifier: workspace:*
         version: link:../../packages/testing


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set up Playwright E2E tests for the Editor app with a dedicated CI workflow and an E2E build mode. Covers unauthenticated, no-org, and org-authenticated home page flows.

- New Features
  - Playwright config for Editor (baseURL 3003, global setup seeds auth storage for admin/noOrg, fixtures for authenticatedPage and userWithoutOrg).
  - Next.js E2E mode: E2E_TESTING=true uses .next-e2e and aliases @zoonk/auth to e2e.ts.
  - GitHub Actions workflow runs E2E with Postgres 17, build caches, and Chromium install.
  - New scripts: build:e2e, e2e, e2e:ui; adds @zoonk/e2e workspace dep.

- Migration
  - Ensure a local Postgres with DB zoonk_e2e (or update DATABASE_URL).
  - Run: pnpm --filter=editor build:e2e && pnpm --filter=editor e2e.

<sup>Written for commit f88f7ba0d993a3d36a829503b32643678ee28ba0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

