### PR TITLE
chore(editor): add e2e tests for org home page

### DIFF
--- a/apps/editor/e2e/fixtures.ts
+++ b/apps/editor/e2e/fixtures.ts
@@ -3,6 +3,8 @@ import { test as base } from "@zoonk/e2e/fixtures";
 
 export type EditorAuthFixtures = {
   authenticatedPage: Page;
+  memberPage: Page;
+  ownerPage: Page;
   userWithoutOrg: Page;
 };
 
@@ -10,6 +12,22 @@ export const test = base.extend<EditorAuthFixtures>({
   authenticatedPage: async ({ browser }, use) => {
     const context = await browser.newContext({
       storageState: "e2e/.auth/admin.json",
+    });
+    const page = await context.newPage();
+    await use(page);
+    await context.close();
+  },
+  memberPage: async ({ browser }, use) => {
+    const context = await browser.newContext({
+      storageState: "e2e/.auth/member.json",
+    });
+    const page = await context.newPage();
+    await use(page);
+    await context.close();
+  },
+  ownerPage: async ({ browser }, use) => {
+    const context = await browser.newContext({
+      storageState: "e2e/.auth/owner.json",
     });
     const page = await context.newPage();
     await use(page);

--- a/apps/editor/e2e/global-setup.ts
+++ b/apps/editor/e2e/global-setup.ts
@@ -8,8 +8,16 @@ export const E2E_USERS = {
     email: "admin@zoonk.test",
     password: "password123",
   },
+  member: {
+    email: "member@zoonk.test",
+    password: "password123",
+  },
   noOrg: {
     email: "e2e-logout@zoonk.test",
+    password: "password123",
+  },
+  owner: {
+    email: "owner@zoonk.test",
     password: "password123",
   },
 } as const;

--- a/apps/editor/e2e/org-home.test.ts
+++ b/apps/editor/e2e/org-home.test.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "./fixtures";
+
+test.describe("Org Home - Permissions", () => {
+  test("returns not found for non-existent org", async ({ ownerPage }) => {
+    await ownerPage.goto("/non-existent-org");
+
+    await expect(
+      ownerPage.getByRole("heading", { name: /404/i }),
+    ).toBeVisible();
+  });
+
+  test("allows owner to view page", async ({ ownerPage }) => {
+    await ownerPage.goto("/ai");
+
+    await expect(
+      ownerPage.getByRole("heading", { name: /draft courses/i }),
+    ).toBeVisible();
+  });
+
+  test("allows admin to view page", async ({ authenticatedPage }) => {
+    await authenticatedPage.goto("/ai");
+
+    await expect(
+      authenticatedPage.getByRole("heading", { name: /draft courses/i }),
+    ).toBeVisible();
+  });
+
+  test("denies member access", async ({ memberPage }) => {
+    await memberPage.goto("/ai");
+
+    await expect(
+      memberPage.getByRole("heading", { name: /401.*unauthorized/i }),
+    ).toBeVisible();
+  });
+
+  test("denies non-org member access", async ({ userWithoutOrg }) => {
+    await userWithoutOrg.goto("/ai");
+
+    await expect(
+      userWithoutOrg.getByRole("heading", { name: /401.*unauthorized/i }),
+    ).toBeVisible();
+  });
+
+  test("denies unauthenticated access", async ({ page }) => {
+    await page.goto("/ai");
+
+    await expect(
+      page.getByRole("heading", { name: /401.*unauthorized/i }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("Org Home - Course Filtering", () => {
+  test("shows only courses from this org", async ({ ownerPage }) => {
+    await ownerPage.goto("/ai");
+
+    // Should see E2E Draft Course from ai org
+    await expect(ownerPage.getByText("E2E Draft Course")).toBeVisible();
+
+    // Should not see Test Org Course from test-org
+    await expect(ownerPage.getByText("Test Org Course")).not.toBeVisible();
+  });
+
+  test("shows only draft courses, not published", async ({ ownerPage }) => {
+    await ownerPage.goto("/ai");
+
+    // Should see E2E Draft Course (draft)
+    await expect(ownerPage.getByText("E2E Draft Course")).toBeVisible();
+
+    // Should not see Machine Learning (published)
+    await expect(ownerPage.getByText("Machine Learning")).not.toBeVisible();
+  });
+});
+
+test.describe("Org Home - Navigation", () => {
+  test("clicking create course navigates to creation page", async ({
+    ownerPage,
+  }) => {
+    await ownerPage.goto("/ai");
+    await ownerPage.getByRole("link", { name: /create course/i }).click();
+
+    await expect(ownerPage).toHaveURL(/\/ai\/new-course/);
+    await expect(ownerPage.getByText(/course title/i)).toBeVisible();
+  });
+});

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -156,7 +156,6 @@ msgstr "Next: {activity}"
 
 #: src/app/[locale]/(catalog)/continue-learning.tsx
 #: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/c/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
-#: src/lib/activities.ts
 msgctxt "ZmlNQ3"
 msgid "Activity"
 msgstr "Activity"
@@ -780,13 +779,3 @@ msgstr "{category} courses"
 msgctxt "XL8IWT"
 msgid "{category} courses. The best {category} online courses, interactive lessons to learn."
 msgstr "{category} courses. The best {category} online courses, interactive lessons to learn."
-
-#: src/lib/error-messages.ts
-msgctxt "3IKub9"
-msgid "An unexpected error occurred"
-msgstr "An unexpected error occurred"
-
-#: src/lib/error-messages.ts
-msgctxt "g5WLcA"
-msgid "Please sign in to continue"
-msgstr "Please sign in to continue"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -156,7 +156,6 @@ msgstr "Siguiente: {activity}"
 
 #: src/app/[locale]/(catalog)/continue-learning.tsx
 #: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/c/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
-#: src/lib/activities.ts
 msgctxt "ZmlNQ3"
 msgid "Activity"
 msgstr "Actividad"
@@ -780,13 +779,3 @@ msgstr "Cursos de {category}"
 msgctxt "XL8IWT"
 msgid "{category} courses. The best {category} online courses, interactive lessons to learn."
 msgstr "Cursos de {category}. Los mejores cursos en línea de {category}, lecciones interactivas para aprender."
-
-#: src/lib/error-messages.ts
-msgctxt "3IKub9"
-msgid "An unexpected error occurred"
-msgstr "Ocurrió un error inesperado"
-
-#: src/lib/error-messages.ts
-msgctxt "g5WLcA"
-msgid "Please sign in to continue"
-msgstr "Inicia sesión para continuar"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -156,7 +156,6 @@ msgstr "Próximo: {activity}"
 
 #: src/app/[locale]/(catalog)/continue-learning.tsx
 #: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/c/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
-#: src/lib/activities.ts
 msgctxt "ZmlNQ3"
 msgid "Activity"
 msgstr "Atividade"
@@ -780,13 +779,3 @@ msgstr "Cursos de {category}"
 msgctxt "XL8IWT"
 msgid "{category} courses. The best {category} online courses, interactive lessons to learn."
 msgstr "Cursos de {category}. Os melhores cursos online de {category}, aulas interativas pra aprender."
-
-#: src/lib/error-messages.ts
-msgctxt "3IKub9"
-msgid "An unexpected error occurred"
-msgstr "Ocorreu um erro inesperado"
-
-#: src/lib/error-messages.ts
-msgctxt "g5WLcA"
-msgid "Please sign in to continue"
-msgstr "Faça login para continuar"

--- a/packages/db/src/prisma/seed.ts
+++ b/packages/db/src/prisma/seed.ts
@@ -16,16 +16,16 @@ import { seedUsers } from "./seed/users";
 async function main() {
   const users = await seedUsers(prisma);
   await seedAccounts(prisma, users);
-  const org = await seedOrganizations(prisma, users);
-  await seedCourses(prisma, org);
-  await seedCategories(prisma, org);
-  await seedChapters(prisma, org);
-  await seedLessons(prisma, org);
-  await seedAlternativeTitles(prisma, org);
-  await seedCourseUsers(prisma, org, users);
-  await seedActivities(prisma, org);
-  await seedSteps(prisma, org);
-  await seedProgress(prisma, org, users);
+  const orgs = await seedOrganizations(prisma, users);
+  await seedCourses(prisma, orgs);
+  await seedCategories(prisma, orgs.ai);
+  await seedChapters(prisma, orgs.ai);
+  await seedLessons(prisma, orgs.ai);
+  await seedAlternativeTitles(prisma, orgs.ai);
+  await seedCourseUsers(prisma, orgs.ai, users);
+  await seedActivities(prisma, orgs.ai);
+  await seedSteps(prisma, orgs.ai);
+  await seedProgress(prisma, orgs.ai, users);
   await seedCourseSuggestions(prisma);
 }
 

--- a/packages/db/src/prisma/seed/courses.ts
+++ b/packages/db/src/prisma/seed/courses.ts
@@ -1,8 +1,19 @@
 import { normalizeString } from "@zoonk/utils/string";
-import type { Organization, PrismaClient } from "../../generated/prisma/client";
+import type { PrismaClient } from "../../generated/prisma/client";
+import type { SeedOrganizations } from "./orgs";
 
 export const coursesData = [
   // English courses
+  {
+    description:
+      "A draft course for E2E testing. This course should only appear in the draft courses list.",
+    imageUrl: null,
+    isPublished: false,
+    language: "en",
+    normalizedTitle: normalizeString("E2E Draft Course"),
+    slug: "e2e-draft-course",
+    title: "E2E Draft Course",
+  },
   {
     description:
       "Machine learning enables computers to identify patterns and make predictions from data. Covers supervised and unsupervised techniques, neural networks, and model evaluation. Prepares you to work as a machine learning engineer at tech companies, research labs, or startups building AI products.",
@@ -103,26 +114,54 @@ export const coursesData = [
   },
 ];
 
+const testOrgCoursesData = [
+  {
+    description: "A course from test-org that should not appear in ai org.",
+    imageUrl: null,
+    isPublished: false,
+    language: "en",
+    normalizedTitle: normalizeString("Test Org Course"),
+    slug: "test-org-course",
+    title: "Test Org Course",
+  },
+];
+
 export async function seedCourses(
   prisma: PrismaClient,
-  org: Organization,
+  orgs: SeedOrganizations,
 ): Promise<void> {
-  await Promise.all(
-    coursesData.map((course) =>
+  await Promise.all([
+    ...coursesData.map((course) =>
       prisma.course.upsert({
         create: {
-          organizationId: org.id,
+          organizationId: orgs.ai.id,
           ...course,
         },
         update: {},
         where: {
           orgSlug: {
             language: course.language,
-            organizationId: org.id,
+            organizationId: orgs.ai.id,
             slug: course.slug,
           },
         },
       }),
     ),
-  );
+    ...testOrgCoursesData.map((course) =>
+      prisma.course.upsert({
+        create: {
+          organizationId: orgs.testOrg.id,
+          ...course,
+        },
+        update: {},
+        where: {
+          orgSlug: {
+            language: course.language,
+            organizationId: orgs.testOrg.id,
+            slug: course.slug,
+          },
+        },
+      }),
+    ),
+  ]);
 }

--- a/packages/db/src/prisma/seed/orgs.ts
+++ b/packages/db/src/prisma/seed/orgs.ts
@@ -1,25 +1,40 @@
 import type { Organization, PrismaClient } from "../../generated/prisma/client";
 import type { SeedUsers } from "./users";
 
+export type SeedOrganizations = {
+  ai: Organization;
+  testOrg: Organization;
+};
+
 export async function seedOrganizations(
   prisma: PrismaClient,
   users: SeedUsers,
-): Promise<Organization> {
-  const org = await prisma.organization.upsert({
-    create: {
-      members: {
-        create: [
-          { role: "owner", userId: users.owner.id },
-          { role: "admin", userId: users.admin.id },
-          { role: "member", userId: users.member.id },
-        ],
+): Promise<SeedOrganizations> {
+  const [ai, testOrg] = await Promise.all([
+    prisma.organization.upsert({
+      create: {
+        members: {
+          create: [
+            { role: "owner", userId: users.owner.id },
+            { role: "admin", userId: users.admin.id },
+            { role: "member", userId: users.member.id },
+          ],
+        },
+        name: "Zoonk AI",
+        slug: "ai",
       },
-      name: "Zoonk AI",
-      slug: "ai",
-    },
-    update: {},
-    where: { slug: "ai" },
-  });
+      update: {},
+      where: { slug: "ai" },
+    }),
+    prisma.organization.upsert({
+      create: {
+        name: "Test Org",
+        slug: "test-org",
+      },
+      update: {},
+      where: { slug: "test-org" },
+    }),
+  ]);
 
-  return org;
+  return { ai, testOrg };
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds end-to-end tests for the org home page, covering permissions, course filtering, and navigation. Updates fixtures and seed data to support owner/admin/member roles and multiple orgs.

- **New Features**
  - Added org-home e2e tests: permissions (owner/admin allowed; member, non-member, and guest denied), course filtering (org-only, draft-only), and navigation to create course.
  - Extended fixtures with ownerPage and memberPage; added E2E users for owner and member.

- **Refactors**
  - Seed now creates two orgs (ai, test-org) and returns both; seeds an "E2E Draft Course" in ai and a "Test Org Course" in test-org to validate filtering.
  - Updated seed flow to use orgs.ai for related entities (categories, chapters, lessons, activities, steps, progress).
  - Removed unused i18n strings from en/es/pt .po files.

<sup>Written for commit 837a6538c90354b92783a221985a262eea1bdbf2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

