### PR TITLE
test(auth): add e2e tests for auth callback across apps

### DIFF
--- a/apps/admin/src/app/auth/callback/page.tsx
+++ b/apps/admin/src/app/auth/callback/page.tsx
@@ -1,24 +1,69 @@
 "use client";
 
 import { authClient } from "@zoonk/core/auth/client";
+import { buttonVariants } from "@zoonk/ui/components/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@zoonk/ui/components/empty";
 import { FullPageLoading } from "@zoonk/ui/components/loading";
+import { AlertCircleIcon } from "lucide-react";
+import Link from "next/link";
 import { redirect, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useEffectEvent } from "react";
+import { Suspense, useEffect, useEffectEvent, useState } from "react";
+
+type CallbackErrorType = "missing" | "invalid";
+
+function CallbackError({ type }: { type: CallbackErrorType }) {
+  return (
+    <div className="flex min-h-dvh items-center justify-center p-4">
+      <Empty className="border-none">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <AlertCircleIcon aria-hidden="true" />
+          </EmptyMedia>
+          <EmptyTitle>Authentication Error</EmptyTitle>
+          <EmptyDescription>
+            {type === "missing"
+              ? "The authentication token is missing. Please try logging in again."
+              : "The authentication token is invalid or expired. Please try logging in again."}
+          </EmptyDescription>
+        </EmptyHeader>
+
+        <EmptyContent>
+          <Link
+            className={buttonVariants({ variant: "outline" })}
+            href="/login"
+          >
+            Return to login
+          </Link>
+          <p className="text-muted-foreground text-sm">
+            Need help? Contact us at hello@zoonk.com
+          </p>
+        </EmptyContent>
+      </Empty>
+    </div>
+  );
+}
 
 function CallbackHandler() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token");
+  const [error, setError] = useState<CallbackErrorType | null>(null);
 
   const handleVerify = useEffectEvent(async (userToken: string) => {
-    // we're using a client component to properly set session cookies after token verification
-    // on server-side, the session cookies aren't set
-    const { error } = await authClient.oneTimeToken.verify({
+    const { error: verifyError } = await authClient.oneTimeToken.verify({
       token: userToken,
     });
 
-    if (error) {
-      console.error("Failed to verify one-time token:", error);
-      return redirect("/login");
+    if (verifyError) {
+      console.info("Failed to verify one-time token:", verifyError);
+      setError("invalid");
+      return;
     }
 
     redirect("/");
@@ -27,8 +72,15 @@ function CallbackHandler() {
   useEffect(() => {
     if (token) {
       void handleVerify(token);
+    } else {
+      console.info("Auth callback: missing token");
+      setError("missing");
     }
   }, [token]);
+
+  if (error) {
+    return <CallbackError type={error} />;
+  }
 
   return <FullPageLoading />;
 }

--- a/apps/editor/e2e/auth-callback.test.ts
+++ b/apps/editor/e2e/auth-callback.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "./fixtures";
+
+test.describe("Auth Callback - Missing Token", () => {
+  test("shows error page when token is missing", async ({ page }) => {
+    await page.goto("/auth/callback");
+
+    await expect(page.getByText(/authentication error/i)).toBeVisible();
+    await expect(page.getByText(/token.*missing/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: /login/i })).toBeVisible();
+    await expect(page.getByText(/hello@zoonk\.com/i)).toBeVisible();
+  });
+});
+
+test.describe("Auth Callback - Invalid Token", () => {
+  test("shows error page when verification fails", async ({ page }) => {
+    // Mock API to return 401 error (how Better Auth returns errors)
+    await page.route("**/*", async (route) => {
+      const url = route.request().url();
+      if (url.includes("one-time-token")) {
+        await route.fulfill({
+          body: JSON.stringify({
+            code: "INVALID_TOKEN",
+            message: "Invalid or expired one-time token",
+          }),
+          contentType: "application/json",
+          status: 401,
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto("/auth/callback?token=invalid-token");
+
+    await expect(page.getByText(/authentication error/i)).toBeVisible();
+    await expect(page.getByText(/invalid|expired/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: /login/i })).toBeVisible();
+    await expect(page.getByText(/hello@zoonk\.com/i)).toBeVisible();
+  });
+});
+
+test.describe("Auth Callback - Valid Token", () => {
+  test("redirects to home on successful verification", async ({ page }) => {
+    await page.route("**/*", async (route) => {
+      const url = route.request().url();
+      if (url.includes("one-time-token")) {
+        await route.fulfill({
+          body: JSON.stringify({ session: { id: "test", userId: "test" } }),
+          contentType: "application/json",
+          status: 200,
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto("/auth/callback?token=valid-token");
+    await page.waitForURL(/^(?!.*\/auth\/callback)/);
+  });
+});

--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -337,6 +337,31 @@ msgctxt "lP29gk"
 msgid "A course with this URL already exists"
 msgstr "A course with this URL already exists"
 
+#: src/app/auth/callback/callback-handler.tsx
+msgctxt "57VhQb"
+msgid "Authentication Error"
+msgstr "Authentication Error"
+
+#: src/app/auth/callback/callback-handler.tsx
+msgctxt "ARSMi2"
+msgid "The authentication token is missing. Please try logging in again."
+msgstr "The authentication token is missing. Please try logging in again."
+
+#: src/app/auth/callback/callback-handler.tsx
+msgctxt "Le3MTe"
+msgid "Return to login"
+msgstr "Return to login"
+
+#: src/app/auth/callback/callback-handler.tsx
+msgctxt "mffe4M"
+msgid "The authentication token is invalid or expired. Please try logging in again."
+msgstr "The authentication token is invalid or expired. Please try logging in again."
+
+#: src/app/auth/callback/callback-handler.tsx
+msgctxt "vQjckV"
+msgid "Need help? Contact us at hello@zoonk.com"
+msgstr "Need help? Contact us at hello@zoonk.com"
+
 #: src/app/unauthorized.tsx
 msgctxt "Ajg4UO"
 msgid "You can't edit courses for this organization. Log in with another account or switch to a different organization."

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -337,6 +337,31 @@ msgctxt "lP29gk"
 msgid "A course with this URL already exists"
 msgstr "Ya existe un curso con esta dirección"
 
+#: src/app/auth/callback/callback-handler.tsx
+msgctxt "57VhQb"
+msgid "Authentication Error"
+msgstr "Error de autenticación"
+
+#: src/app/auth/callback/callback-handler.tsx
+msgctxt "ARSMi2"
+msgid "The authentication token is missing. Please try logging in again."
+msgstr "Falta el token de autenticación. Por favor, intenta iniciar sesión nuevamente."
+
+#: src/app/auth/callback/callback-handler.tsx
+msgctxt "Le3MTe"
+msgid "Return to login"
+msgstr "Volver al inicio de sesión"
+
+#: src/app/auth/callback/callback-handler.tsx
+msgctxt "mffe4M"
+msgid "The authentication token is invalid or expired. Please try logging in again."
+msgstr "El token de autenticación es inválido o ha expirado. Por favor, intenta iniciar sesión nuevamente."
+
+#: src/app/auth/callback/callback-handler.tsx
+msgctxt "vQjckV"
+msgid "Need help? Contact us at hello@zoonk.com"
+msgstr "¿Necesitas ayuda? Contáctanos en contacto@zoonk.com"
+
 #: src/app/unauthorized.tsx
 msgctxt "Ajg4UO"
 msgid "You can't edit courses for this organization. Log in with another account or switch to a different organization."

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -337,6 +337,31 @@ msgctxt "lP29gk"
 msgid "A course with this URL already exists"
 msgstr "Já existe um curso com este endereço"
 
+#: src/app/auth/callback/callback-handler.tsx
+msgctxt "57VhQb"
+msgid "Authentication Error"
+msgstr "Erro de autenticação"
+
+#: src/app/auth/callback/callback-handler.tsx
+msgctxt "ARSMi2"
+msgid "The authentication token is missing. Please try logging in again."
+msgstr "O token de autenticação está faltando. Por favor, tente fazer login novamente."
+
+#: src/app/auth/callback/callback-handler.tsx
+msgctxt "Le3MTe"
+msgid "Return to login"
+msgstr "Voltar para o login"
+
+#: src/app/auth/callback/callback-handler.tsx
+msgctxt "mffe4M"
+msgid "The authentication token is invalid or expired. Please try logging in again."
+msgstr "O token de autenticação é inválido ou expirou. Por favor, tente fazer login novamente."
+
+#: src/app/auth/callback/callback-handler.tsx
+msgctxt "vQjckV"
+msgid "Need help? Contact us at hello@zoonk.com"
+msgstr "Precisa de ajuda? Entre em contato com a gente em contato@zoonk.com"
+
 #: src/app/unauthorized.tsx
 msgctxt "Ajg4UO"
 msgid "You can't edit courses for this organization. Log in with another account or switch to a different organization."

--- a/apps/main/e2e/auth-callback.test.ts
+++ b/apps/main/e2e/auth-callback.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "./fixtures";
+
+test.describe("Auth Callback - Missing Token", () => {
+  test("shows error page when token is missing", async ({ page }) => {
+    await page.goto("/auth/callback");
+
+    await expect(page.getByText(/authentication error/i)).toBeVisible();
+    await expect(page.getByText(/token.*missing/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: /login/i })).toBeVisible();
+    await expect(page.getByText(/hello@zoonk\.com/i)).toBeVisible();
+  });
+
+  test("shows Portuguese error page when locale is Portuguese", async ({
+    page,
+  }) => {
+    await page.goto("/pt/auth/callback");
+
+    // Check for link to Portuguese login page
+    await expect(page.locator('a[href="/pt/login"]')).toBeVisible();
+  });
+});
+
+test.describe("Auth Callback - Invalid Token", () => {
+  test("shows error page when verification fails", async ({ page }) => {
+    // Mock API to return 401 error (how Better Auth returns errors)
+    await page.route("**/*", async (route) => {
+      const url = route.request().url();
+      if (url.includes("one-time-token")) {
+        await route.fulfill({
+          body: JSON.stringify({
+            code: "INVALID_TOKEN",
+            message: "Invalid or expired one-time token",
+          }),
+          contentType: "application/json",
+          status: 401,
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto("/auth/callback?token=invalid-token");
+
+    await expect(page.getByText(/authentication error/i)).toBeVisible();
+    await expect(page.getByText(/invalid|expired/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: /login/i })).toBeVisible();
+    await expect(page.getByText(/hello@zoonk\.com/i)).toBeVisible();
+  });
+
+  test("shows Portuguese error page on invalid token", async ({ page }) => {
+    await page.route("**/*", async (route) => {
+      const url = route.request().url();
+      if (url.includes("one-time-token")) {
+        await route.fulfill({
+          body: JSON.stringify({
+            code: "INVALID_TOKEN",
+            message: "Invalid or expired one-time token",
+          }),
+          contentType: "application/json",
+          status: 401,
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto("/pt/auth/callback?token=invalid-token");
+
+    // Check for link to Portuguese login page
+    await expect(page.locator('a[href="/pt/login"]')).toBeVisible();
+  });
+});
+
+test.describe("Auth Callback - Valid Token", () => {
+  test("redirects to home on successful verification", async ({ page }) => {
+    await page.route("**/*", async (route) => {
+      const url = route.request().url();
+      if (url.includes("one-time-token")) {
+        await route.fulfill({
+          body: JSON.stringify({ session: { id: "test", userId: "test" } }),
+          contentType: "application/json",
+          status: 200,
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto("/auth/callback?token=valid-token");
+    await page.waitForURL(/^(?!.*\/auth\/callback)/);
+  });
+});

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -505,6 +505,31 @@ msgctxt "YdQxfw"
 msgid "Contact Support"
 msgstr "Contact Support"
 
+#: src/app/[locale]/auth/callback/page.tsx
+msgctxt "57VhQb"
+msgid "Authentication Error"
+msgstr "Authentication Error"
+
+#: src/app/[locale]/auth/callback/page.tsx
+msgctxt "ARSMi2"
+msgid "The authentication token is missing. Please try logging in again."
+msgstr "The authentication token is missing. Please try logging in again."
+
+#: src/app/[locale]/auth/callback/page.tsx
+msgctxt "Le3MTe"
+msgid "Return to login"
+msgstr "Return to login"
+
+#: src/app/[locale]/auth/callback/page.tsx
+msgctxt "mffe4M"
+msgid "The authentication token is invalid or expired. Please try logging in again."
+msgstr "The authentication token is invalid or expired. Please try logging in again."
+
+#: src/app/[locale]/auth/callback/page.tsx
+msgctxt "vQjckV"
+msgid "Need help? Contact us at hello@zoonk.com"
+msgstr "Need help? Contact us at hello@zoonk.com"
+
 #: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/c/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
 msgctxt "qtQJTV"
 msgid "Complete this activity to reinforce your learning and track your progress."

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -505,6 +505,31 @@ msgctxt "YdQxfw"
 msgid "Contact Support"
 msgstr "Contactar soporte"
 
+#: src/app/[locale]/auth/callback/page.tsx
+msgctxt "57VhQb"
+msgid "Authentication Error"
+msgstr "Error de autenticación"
+
+#: src/app/[locale]/auth/callback/page.tsx
+msgctxt "ARSMi2"
+msgid "The authentication token is missing. Please try logging in again."
+msgstr "Falta el token de autenticación. Por favor, intenta iniciar sesión nuevamente."
+
+#: src/app/[locale]/auth/callback/page.tsx
+msgctxt "Le3MTe"
+msgid "Return to login"
+msgstr "Volver al inicio de sesión"
+
+#: src/app/[locale]/auth/callback/page.tsx
+msgctxt "mffe4M"
+msgid "The authentication token is invalid or expired. Please try logging in again."
+msgstr "El token de autenticación es inválido o ha expirado. Por favor, intenta iniciar sesión nuevamente."
+
+#: src/app/[locale]/auth/callback/page.tsx
+msgctxt "vQjckV"
+msgid "Need help? Contact us at hello@zoonk.com"
+msgstr "¿Necesitas ayuda? Contáctanos en contacto@zoonk.com"
+
 #: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/c/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
 msgctxt "qtQJTV"
 msgid "Complete this activity to reinforce your learning and track your progress."

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -505,6 +505,31 @@ msgctxt "YdQxfw"
 msgid "Contact Support"
 msgstr "Contatar suporte"
 
+#: src/app/[locale]/auth/callback/page.tsx
+msgctxt "57VhQb"
+msgid "Authentication Error"
+msgstr "Erro de autenticação"
+
+#: src/app/[locale]/auth/callback/page.tsx
+msgctxt "ARSMi2"
+msgid "The authentication token is missing. Please try logging in again."
+msgstr "O token de autenticação está faltando. Por favor, tente fazer login novamente."
+
+#: src/app/[locale]/auth/callback/page.tsx
+msgctxt "Le3MTe"
+msgid "Return to login"
+msgstr "Voltar para o login"
+
+#: src/app/[locale]/auth/callback/page.tsx
+msgctxt "mffe4M"
+msgid "The authentication token is invalid or expired. Please try logging in again."
+msgstr "O token de autenticação é inválido ou expirou. Por favor, tente fazer login novamente."
+
+#: src/app/[locale]/auth/callback/page.tsx
+msgctxt "vQjckV"
+msgid "Need help? Contact us at hello@zoonk.com"
+msgstr "Precisa de ajuda? Entre em contato com a gente em contato@zoonk.com"
+
 #: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/c/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
 msgctxt "qtQJTV"
 msgid "Complete this activity to reinforce your learning and track your progress."

--- a/apps/main/src/app/[locale]/auth/callback/page.tsx
+++ b/apps/main/src/app/[locale]/auth/callback/page.tsx
@@ -1,27 +1,79 @@
 "use client";
 
 import { authClient } from "@zoonk/core/auth/client";
+import { buttonVariants } from "@zoonk/ui/components/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@zoonk/ui/components/empty";
 import { FullPageLoading } from "@zoonk/ui/components/loading";
+import { AlertCircleIcon } from "lucide-react";
 import { useSearchParams } from "next/navigation";
-import { useLocale } from "next-intl";
-import { Suspense, useEffect, useEffectEvent } from "react";
-import { redirect } from "@/i18n/navigation";
+import { useExtracted, useLocale } from "next-intl";
+import { Suspense, useEffect, useEffectEvent, useState } from "react";
+import { Link, redirect } from "@/i18n/navigation";
+
+type CallbackErrorType = "missing" | "invalid";
+
+function CallbackError({ type }: { type: CallbackErrorType }) {
+  const t = useExtracted();
+
+  return (
+    <div className="flex min-h-dvh items-center justify-center p-4">
+      <Empty className="border-none">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <AlertCircleIcon aria-hidden="true" />
+          </EmptyMedia>
+          <EmptyTitle>{t("Authentication Error")}</EmptyTitle>
+          <EmptyDescription>
+            {type === "missing"
+              ? t(
+                  "The authentication token is missing. Please try logging in again.",
+                )
+              : t(
+                  "The authentication token is invalid or expired. Please try logging in again.",
+                )}
+          </EmptyDescription>
+        </EmptyHeader>
+
+        <EmptyContent>
+          <Link
+            className={buttonVariants({ variant: "outline" })}
+            href="/login"
+          >
+            {t("Return to login")}
+          </Link>
+          <p className="text-muted-foreground text-sm">
+            {t("Need help? Contact us at hello@zoonk.com")}
+          </p>
+        </EmptyContent>
+      </Empty>
+    </div>
+  );
+}
 
 function CallbackHandler() {
   const searchParams = useSearchParams();
   const locale = useLocale();
   const token = searchParams.get("token");
+  const [error, setError] = useState<CallbackErrorType | null>(null);
 
   const handleVerify = useEffectEvent(async (userToken: string) => {
     // we're using a client component to properly set session cookies after token verification
     // on server-side, the session cookies aren't set
-    const { error } = await authClient.oneTimeToken.verify({
+    const { error: verifyError } = await authClient.oneTimeToken.verify({
       token: userToken,
     });
 
-    if (error) {
-      console.error("Failed to verify one-time token:", error);
-      return redirect({ href: "/login", locale });
+    if (verifyError) {
+      console.info("Failed to verify one-time token:", verifyError);
+      setError("invalid");
+      return;
     }
 
     redirect({ href: "/", locale });
@@ -30,8 +82,15 @@ function CallbackHandler() {
   useEffect(() => {
     if (token) {
       void handleVerify(token);
+    } else {
+      console.info("Auth callback: missing token");
+      setError("missing");
     }
   }, [token]);
+
+  if (error) {
+    return <CallbackError type={error} />;
+  }
 
   return <FullPageLoading />;
 }

--- a/i18n.lock
+++ b/i18n.lock
@@ -66,6 +66,11 @@ checksums:
     The%20main%20title%20that%20learners%20will%20see%20for%20your%20course/singular: 5e0707d1ace160525f64c1ff51474569
     Course%20title/singular: 40d5c412b95b9a452643c69e48465350
     A%20course%20with%20this%20URL%20already%20exists/singular: 36f9d2ffb6817af1ae69ec6dd37cf5d6
+    Authentication%20Error/singular: f8db504523897fad229a0cfdcc34652c
+    The%20authentication%20token%20is%20missing.%20Please%20try%20logging%20in%20again./singular: 74e0970a1f77afba28fe761910aa4604
+    Return%20to%20login/singular: a73bc2aa109b100645c49a3eab040dbf
+    The%20authentication%20token%20is%20invalid%20or%20expired.%20Please%20try%20logging%20in%20again./singular: 9e23335b29f210d8ae14c265aeb6ab1a
+    Need%20help%3F%20Contact%20us%20at%20hello%40zoonk.com/singular: 0053665fad1f58782cc3a6f442b36726
     You%20can't%20edit%20courses%20for%20this%20organization.%20Log%20in%20with%20another%20account%20or%20switch%20to%20a%20different%20organization./singular: f4c2f472730fa69b3602af2d9cfa56c5
     Login/singular: f4f219abeb5a465ecb1c7efaf50246de
     Logout/singular: 07948fdf20705e04a7bf68ab197512bf
@@ -95,6 +100,7 @@ checksums:
     Alternative%20titles%20imported%20successfully/singular: ca67e17d28382d5ef29bd27219a4104e
     Add%20category/singular: f1ef62efcd0e61cff264dd18047ebd6f
     Categories/singular: fd4e44f3b1b2bba9ca45f3aef963d042
+    Search/singular: 49dd6c21604b5e8d4153ff1aff2177e1
     Unsaved/singular: ddc9094aecf93ceabe363846756a9925
     Saved/singular: 6554b923011266821d74e06e013a40e6
     Saving%E2%80%A6/singular: ee98ff32f9a585a9108c8cd961d6077e
@@ -122,7 +128,6 @@ checksums:
     Home%20page/singular: aa72464a366b091aa6f2037ca869c09c
     sign%20out/singular: a917e8428004b4108a66fa0ba9c0c15c
     exit/singular: 8eff58f44e53377753566cba50541cf9
-    Search/singular: 49dd6c21604b5e8d4153ff1aff2177e1
     start/singular: e19dc5c089daea13eeb2efffb890057d
     Delete%20item/singular: b9b5755b0ed185436b52860bde313b9f
     This%20action%20cannot%20be%20undone./singular: 3d8b13374ffd3cefc0f3f7ce077bd9c9
@@ -265,6 +270,11 @@ checksums:
     Email%20us%20at%20hello%40zoonk.com/singular: f30da451e0bc14b7463bde402c876af9
     Follow%20us/singular: 778f7a4744f77dbcbd31a8c778cb5209
     Contact%20Support/singular: fcbd9e317c7286b3e08752eb73eb1a81
+    Authentication%20Error/singular: f8db504523897fad229a0cfdcc34652c
+    The%20authentication%20token%20is%20missing.%20Please%20try%20logging%20in%20again./singular: 74e0970a1f77afba28fe761910aa4604
+    Return%20to%20login/singular: a73bc2aa109b100645c49a3eab040dbf
+    The%20authentication%20token%20is%20invalid%20or%20expired.%20Please%20try%20logging%20in%20again./singular: 9e23335b29f210d8ae14c265aeb6ab1a
+    Need%20help%3F%20Contact%20us%20at%20hello%40zoonk.com/singular: 0053665fad1f58782cc3a6f442b36726
     Complete%20this%20activity%20to%20reinforce%20your%20learning%20and%20track%20your%20progress./singular: ae9411230fe031bbbd7471a8fde4b17d
     Interactive%20lesson%20with%20exercises%20and%20activities%20to%20help%20you%20learn%20effectively./singular: f74de010a6977351bee6b20c81d90d31
     Lesson/singular: 0369d21b141f7f54c4586224e7e7ae65
@@ -317,8 +327,6 @@ checksums:
     Explore%20all%20%7Bcategory%7D%20courses/singular: b1f2775c67b4a61b3d92b4345b8b852e
     "%7Bcategory%7D%20courses/singular": eafd6f9b1fa97400abe1bfe0c8ee5f19
     "%7Bcategory%7D%20courses.%20The%20best%20%7Bcategory%7D%20online%20courses%2C%20interactive%20lessons%20to%20learn./singular": 2ec8d2bc2e44d9def010ec678286dc88
-    An%20unexpected%20error%20occurred/singular: fe07b9cdb1fc3f7397f6d89c102c60af
-    Please%20sign%20in%20to%20continue/singular: 051e59dd3d3b0bfad95982f982fd6b9d
   61a308caf583f5835f54302028bdae73:
     You're%20signed%20in!/singular: 7f23ad13626e60f22e13b8777458750d
     You%20can%20close%20this%20window%20and%20return%20to%20your%20app./singular: 06f96197fc40b30e288b1a9603d15825


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add end-to-end coverage for the auth callback and standardize its error handling across apps. Users now see a clear, localized error page for missing or invalid tokens, and valid tokens redirect to home.

- **New Features**
  - Added Playwright e2e tests in editor and main for missing, invalid, and valid token flows (includes Portuguese locale routing checks).
  - Unified auth callback UX in admin, editor, and main: show an error page (instead of redirect) on missing/invalid tokens with a login link and help email; localized in editor/main (en/es/pt) with locale-aware login links.

<sup>Written for commit 73eb01ddb6fe77ad7f8f1461ab5fef1740bb259a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

