### PR TITLE
test(editor): add e2e tests for locale switcher and logout menu

### DIFF
--- a/apps/editor/e2e/locale-switcher.test.ts
+++ b/apps/editor/e2e/locale-switcher.test.ts
@@ -1,0 +1,71 @@
+import { expect, type Page, test } from "./fixtures";
+
+async function openOrgDropdown(page: Page) {
+  await page.getByRole("button", { name: /organizations|ai/i }).click();
+}
+
+async function openLanguageSubmenu(page: Page) {
+  await openOrgDropdown(page);
+  await page.getByRole("menuitem", { name: /language/i }).click();
+}
+
+test.describe("Locale Switcher", () => {
+  test.beforeEach(async ({ authenticatedPage }) => {
+    await authenticatedPage.goto("/ai");
+  });
+
+  test("switching locale updates page content", async ({
+    authenticatedPage,
+  }) => {
+    await openLanguageSubmenu(authenticatedPage);
+
+    // Switch to Portuguese
+    await authenticatedPage
+      .getByRole("menuitem", { name: "Português" })
+      .click();
+
+    // Reopen to verify the Language menu item text changed
+    await openOrgDropdown(authenticatedPage);
+
+    await expect(
+      authenticatedPage.getByRole("menuitem", { name: /idioma/i }),
+    ).toBeVisible();
+  });
+
+  test("marks currently selected locale with aria-current", async ({
+    authenticatedPage,
+  }) => {
+    await openLanguageSubmenu(authenticatedPage);
+
+    // English should be marked as current (default locale)
+    const englishItem = authenticatedPage.getByRole("menuitem", {
+      name: "English",
+    });
+    await expect(englishItem).toHaveAttribute("aria-current", "true");
+
+    // Other locales should not be marked as current
+    const portugueseItem = authenticatedPage.getByRole("menuitem", {
+      name: "Português",
+    });
+    await expect(portugueseItem).not.toHaveAttribute("aria-current", "true");
+  });
+
+  test("persists locale selection after page refresh", async ({
+    authenticatedPage,
+  }) => {
+    await openLanguageSubmenu(authenticatedPage);
+
+    // Switch to Spanish
+    await authenticatedPage.getByRole("menuitem", { name: "Español" }).click();
+
+    // Refresh the page
+    await authenticatedPage.reload();
+
+    // Verify the locale persisted by checking the Language menu text
+    await openOrgDropdown(authenticatedPage);
+
+    await expect(
+      authenticatedPage.getByRole("menuitem", { name: /idioma/i }),
+    ).toBeVisible();
+  });
+});

--- a/apps/editor/e2e/logout-menu-item.test.ts
+++ b/apps/editor/e2e/logout-menu-item.test.ts
@@ -1,0 +1,22 @@
+import { expect, type Page, test } from "./fixtures";
+
+async function openOrgDropdown(page: Page) {
+  await page.getByRole("button", { name: /organizations|ai/i }).click();
+}
+
+test.describe("Logout Menu Item", () => {
+  test("logs out user and shows login button", async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto("/ai");
+
+    await openOrgDropdown(authenticatedPage);
+    await authenticatedPage.getByRole("menuitem", { name: /logout/i }).click();
+
+    // After logout (hard navigation), user should see the login button
+    await authenticatedPage.waitForURL("/");
+    await expect(
+      authenticatedPage.getByRole("link", { name: /login/i }),
+    ).toBeVisible();
+  });
+});

--- a/apps/editor/src/app/logout/page.tsx
+++ b/apps/editor/src/app/logout/page.tsx
@@ -2,14 +2,12 @@
 
 import { authClient } from "@zoonk/core/auth/client";
 import { FullPageLoading } from "@zoonk/ui/components/loading";
-import { useRouter } from "next/navigation";
 import { useEffect, useEffectEvent } from "react";
 
 export default function LogoutPage() {
-  const { push } = useRouter();
-
   const handleSuccess = useEffectEvent(() => {
-    push("/login");
+    // Use hard navigation to ensure all client-side state (including useSession) is reset
+    window.location.href = "/";
   });
 
   useEffect(() => {

--- a/apps/editor/src/components/navbar/locale-switcher.tsx
+++ b/apps/editor/src/components/navbar/locale-switcher.tsx
@@ -37,6 +37,7 @@ export function LocaleSwitcher() {
       <DropdownMenuSubContent>
         {SUPPORTED_LOCALES.map((lang) => (
           <DropdownMenuItem
+            aria-current={lang === locale ? "true" : undefined}
             disabled={isPending}
             key={lang}
             onClick={() => onLocaleChange(lang)}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add e2e tests for the locale switcher and logout menu to validate language changes, persistence after refresh, and the logout flow. Also improve logout reliability and locale selection accessibility.

- **Bug Fixes**
  - Logout now uses hard navigation to “/” to fully reset client state after sign-out.
  - Locale switcher marks the active language with aria-current for better accessibility and clearer state in tests.

<sup>Written for commit 898447d244739c0dc447eb56d71d457824bd257f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

