### PR TITLE
fix(editor): reload page when switching locale

### DIFF
--- a/apps/editor/src/components/navbar/locale-switcher.tsx
+++ b/apps/editor/src/components/navbar/locale-switcher.tsx
@@ -9,27 +9,20 @@ import {
 import { LOCALE_LABELS, SUPPORTED_LOCALES } from "@zoonk/utils/locale";
 import Cookies from "js-cookie";
 import { CheckIcon, LanguagesIcon } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useExtracted, useLocale } from "next-intl";
-import { useTransition } from "react";
 
 export function LocaleSwitcher() {
   const t = useExtracted();
   const locale = useLocale();
-  const router = useRouter();
-  const [isPending, startTransition] = useTransition();
 
   function onLocaleChange(nextLocale: string) {
     Cookies.set("locale", nextLocale, { expires: 365, sameSite: "lax" });
-
-    startTransition(() => {
-      router.refresh();
-    });
+    window.location.reload();
   }
 
   return (
     <DropdownMenuSub>
-      <DropdownMenuSubTrigger className="gap-2" disabled={isPending}>
+      <DropdownMenuSubTrigger className="gap-2">
         <LanguagesIcon aria-hidden="true" />
         {t("Language")}
       </DropdownMenuSubTrigger>
@@ -38,7 +31,6 @@ export function LocaleSwitcher() {
         {SUPPORTED_LOCALES.map((lang) => (
           <DropdownMenuItem
             aria-current={lang === locale ? "true" : undefined}
-            disabled={isPending}
             key={lang}
             onClick={() => onLocaleChange(lang)}
           >


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reloads the editor after changing the language so the locale cookie is applied and translations update immediately.

- **Bug Fixes**
  - Replaced router.refresh() with window.location.reload() in LocaleSwitcher.
  - Removed useTransition and related disabled states.

<sup>Written for commit e83fff163223d341c316121c379efc337a1a37a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

