### PR TITLE
test(editor): add e2e tests for editing course content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,8 +169,6 @@ For detailed examples and patterns, see `.claude/skills/compound-components/SKIL
 
 **E2E builds**: Apps use separate build directories for E2E testing (e.g., `.next-e2e` instead of `.next`). When running E2E tests, build with `E2E_TESTING=true pnpm --filter {app} build` to ensure the correct build directory is used.
 
-**E2E database reset**: When updating seed files, reset the E2E database with `dropdb zoonk_e2e && createdb zoonk_e2e`
-
 For detailed testing patterns, fixtures, and best practices, see `.claude/skills/testing/SKILL.md`
 
 ## i18n

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,8 +169,6 @@ For detailed examples and patterns, see `.claude/skills/compound-components/SKIL
 
 **E2E builds**: Apps use separate build directories for E2E testing (e.g., `.next-e2e` instead of `.next`). When running E2E tests, build with `E2E_TESTING=true pnpm --filter {app} build` to ensure the correct build directory is used.
 
-**E2E database reset**: When updating seed files, reset the E2E database with `dropdb zoonk_e2e && createdb zoonk_e2e`
-
 For detailed testing patterns, fixtures, and best practices, see `.claude/skills/testing/SKILL.md`
 
 ## i18n

--- a/apps/editor/.env.e2e
+++ b/apps/editor/.env.e2e
@@ -1,0 +1,2 @@
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/zoonk_e2e
+DATABASE_URL_UNPOOLED=postgres://postgres:postgres@localhost:5432/zoonk_e2e

--- a/apps/editor/.gitignore
+++ b/apps/editor/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 .env*
 !.env.example
 !.env.test
+!.env.e2e
 
 # vercel
 .vercel

--- a/apps/editor/e2e/course-content.test.ts
+++ b/apps/editor/e2e/course-content.test.ts
@@ -1,0 +1,149 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { expect, type Page, test } from "./fixtures";
+
+async function createTestCourse() {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  return courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-${randomUUID().slice(0, 8)}`,
+  });
+}
+
+async function navigateToCoursePage(page: Page, slug: string) {
+  await page.goto(`/ai/c/en/${slug}`);
+
+  await expect(
+    page.getByRole("textbox", { name: /edit course title/i }),
+  ).toBeVisible();
+}
+
+test.describe("Course Content Page", () => {
+  test("auto-saves and persists title", async ({ authenticatedPage }) => {
+    const course = await createTestCourse();
+    await navigateToCoursePage(authenticatedPage, course.slug);
+
+    const titleInput = authenticatedPage.getByRole("textbox", {
+      name: /edit course title/i,
+    });
+    const uniqueTitle = `Test Title ${randomUUID().slice(0, 8)}`;
+
+    await titleInput.fill(uniqueTitle);
+    await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+
+    await authenticatedPage.reload();
+    await expect(titleInput).toBeVisible();
+    await expect(titleInput).toHaveValue(uniqueTitle);
+  });
+
+  test("auto-saves and persists description", async ({ authenticatedPage }) => {
+    const course = await createTestCourse();
+    await navigateToCoursePage(authenticatedPage, course.slug);
+
+    const descriptionInput = authenticatedPage.getByRole("textbox", {
+      name: /edit course description/i,
+    });
+    const uniqueDescription = `Test Description ${randomUUID().slice(0, 8)}`;
+
+    await descriptionInput.fill(uniqueDescription);
+    await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+
+    await authenticatedPage.reload();
+    await expect(descriptionInput).toBeVisible();
+    await expect(descriptionInput).toHaveValue(uniqueDescription);
+  });
+
+  test("shows validation error for duplicate slug", async ({
+    authenticatedPage,
+  }) => {
+    await navigateToCoursePage(authenticatedPage, "machine-learning");
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+
+    await slugInput.fill("spanish");
+
+    await expect(
+      authenticatedPage.getByText(/this url is already in use/i),
+    ).toBeVisible();
+    await expect(
+      authenticatedPage.getByRole("img", {
+        name: /this url is already in use/i,
+      }),
+    ).toBeVisible();
+  });
+
+  test("disables save for empty slug", async ({ authenticatedPage }) => {
+    await navigateToCoursePage(authenticatedPage, "machine-learning");
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+
+    await slugInput.fill("");
+
+    await expect(
+      authenticatedPage.getByRole("button", { name: /^save$/i }),
+    ).not.toBeVisible();
+  });
+
+  test("saves valid slug and redirects", async ({ authenticatedPage }) => {
+    const course = await createTestCourse();
+    await navigateToCoursePage(authenticatedPage, course.slug);
+
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const uniqueSlug = `test-slug-${randomUUID().slice(0, 8)}`;
+
+    await slugInput.fill(uniqueSlug);
+
+    const saveButton = authenticatedPage.getByRole("button", {
+      name: /^save$/i,
+    });
+    await expect(saveButton).toBeEnabled();
+    await saveButton.click();
+
+    await expect(authenticatedPage).toHaveURL(
+      new RegExp(`/ai/c/en/${uniqueSlug}`),
+    );
+    await expect(slugInput).toHaveValue(uniqueSlug);
+  });
+
+  test("reverts changes on cancel", async ({ authenticatedPage }) => {
+    await navigateToCoursePage(authenticatedPage, "machine-learning");
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+
+    await slugInput.fill("some-other-slug");
+    await authenticatedPage.getByRole("button", { name: /cancel/i }).click();
+
+    await expect(slugInput).toHaveValue("machine-learning");
+  });
+
+  test("saves on Enter key", async ({ authenticatedPage }) => {
+    const course = await createTestCourse();
+    await navigateToCoursePage(authenticatedPage, course.slug);
+
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const uniqueSlug = `enter-test-${randomUUID().slice(0, 8)}`;
+
+    await slugInput.fill(uniqueSlug);
+
+    await expect(
+      authenticatedPage.getByRole("button", { name: /^save$/i }),
+    ).toBeEnabled();
+    await slugInput.press("Enter");
+
+    await expect(authenticatedPage).toHaveURL(
+      new RegExp(`/ai/c/en/${uniqueSlug}`),
+    );
+  });
+
+  test("cancels on Escape key", async ({ authenticatedPage }) => {
+    await navigateToCoursePage(authenticatedPage, "machine-learning");
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+
+    await slugInput.fill("escape-test-slug");
+    await slugInput.press("Escape");
+
+    await expect(slugInput).toHaveValue("machine-learning");
+  });
+});

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -40,7 +40,7 @@
     "build:e2e": "E2E_TESTING=true next build",
     "dev": "next dev -p 3003",
     "e2e": "env $(cat .env.e2e | xargs) playwright test",
-    "e2e:ui": "playwright test --ui",
+    "e2e:ui": "env $(cat .env.e2e | xargs) playwright test --ui",
     "start": "next start -p 3003",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -39,7 +39,7 @@
     "build": "next build",
     "build:e2e": "E2E_TESTING=true next build",
     "dev": "next dev -p 3003",
-    "e2e": "playwright test",
+    "e2e": "env $(cat .env.e2e | xargs) playwright test",
     "e2e:ui": "playwright test --ui",
     "start": "next start -p 3003",
     "test": "vitest run",

--- a/packages/db/src/prisma/seed/courses.ts
+++ b/packages/db/src/prisma/seed/courses.ts
@@ -6,6 +6,16 @@ export const coursesData = [
   // English courses
   {
     description:
+      "A draft course for E2E testing. This course should only appear in the draft courses list.",
+    imageUrl: null,
+    isPublished: false,
+    language: "en",
+    normalizedTitle: normalizeString("E2E Draft Course"),
+    slug: "e2e-draft-course",
+    title: "E2E Draft Course",
+  },
+  {
+    description:
       "Machine learning enables computers to identify patterns and make predictions from data. Covers supervised and unsupervised techniques, neural networks, and model evaluation. Prepares you to work as a machine learning engineer at tech companies, research labs, or startups building AI products.",
     imageUrl:
       "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/courses/machine_learning-jmaDwiS0MptNV2EGCZzYWU7RBJs3Qg.webp",

--- a/packages/db/src/prisma/seed/courses.ts
+++ b/packages/db/src/prisma/seed/courses.ts
@@ -6,16 +6,6 @@ export const coursesData = [
   // English courses
   {
     description:
-      "A draft course for E2E testing. This course should only appear in the draft courses list.",
-    imageUrl: null,
-    isPublished: false,
-    language: "en",
-    normalizedTitle: normalizeString("E2E Draft Course"),
-    slug: "e2e-draft-course",
-    title: "E2E Draft Course",
-  },
-  {
-    description:
       "Machine learning enables computers to identify patterns and make predictions from data. Covers supervised and unsupervised techniques, neural networks, and model evaluation. Prepares you to work as a machine learning engineer at tech companies, research labs, or startups building AI products.",
     imageUrl:
       "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/courses/machine_learning-jmaDwiS0MptNV2EGCZzYWU7RBJs3Qg.webp",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added Playwright E2E tests for the editor’s course content page to verify title/description auto-save and persistence, slug validation, save/cancel actions, Enter/Escape shortcuts, and redirect after slug updates. Set up .env.e2e and updated the e2e script to load DB env vars; refined testing docs to avoid redundant tests and clarified E2E data setup (fixtures vs seeds).

<sup>Written for commit 867802cea0ced18769fedaea73e4c05bad612542. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

