### PR TITLE
test(editor): add e2e tests for categories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,11 +159,35 @@ For detailed examples and patterns, see `.claude/skills/compound-components/SKIL
 
 ## Testing
 
+**CRITICAL**: Before writing ANY test, you MUST:
+
+1. **Read `.claude/skills/testing/SKILL.md`** - Contains mandatory patterns and anti-patterns
+2. **Use the `e2e-test-architect` agent** if available - It knows the testing patterns
+3. **Invoke the `/testing` skill** - Use `Skill(testing)` to get guidance
+
 **Always follow TDD (Test-Driven Development)**: Write a failing test first, then write the code to make it pass.
 
 - **E2E tests**: For app/UI features, use Playwright (`apps/{app}/e2e/`)
 - **Integration tests**: For data functions with Prisma (`apps/{app}/src/data/`)
 - **Unit tests**: For utils, helpers, and UI component edge cases
+
+**E2E Query Rules (MANDATORY)**:
+
+- **ALWAYS use semantic queries**: `getByRole`, `getByLabel`, `getByText`, `getByPlaceholder`
+- **NEVER use implementation details**: `data-slot`, `data-testid`, CSS classes, or `.locator()` with selectors
+- **If semantic queries don't work**: Fix the component's accessibility first (add `aria-label`, proper roles, etc.)
+
+```typescript
+// BAD - Implementation details
+page.locator("[data-slot='badge']");
+page.locator("[data-testid='submit']");
+page.locator(".btn-primary");
+
+// GOOD - Semantic queries
+page.getByRole("button", { name: /submit/i });
+page.getByRole("heading", { name: /welcome/i });
+page.getByLabel(/email/i);
+```
 
 **Exclude** `admin` and `evals` apps from testing requirements (internal tools).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,11 +159,35 @@ For detailed examples and patterns, see `.claude/skills/compound-components/SKIL
 
 ## Testing
 
+**CRITICAL**: Before writing ANY test, you MUST:
+
+1. **Read `.claude/skills/testing/SKILL.md`** - Contains mandatory patterns and anti-patterns
+2. **Use the `e2e-test-architect` agent** if available - It knows the testing patterns
+3. **Invoke the `/testing` skill** - Use `Skill(testing)` to get guidance
+
 **Always follow TDD (Test-Driven Development)**: Write a failing test first, then write the code to make it pass.
 
 - **E2E tests**: For app/UI features, use Playwright (`apps/{app}/e2e/`)
 - **Integration tests**: For data functions with Prisma (`apps/{app}/src/data/`)
 - **Unit tests**: For utils, helpers, and UI component edge cases
+
+**E2E Query Rules (MANDATORY)**:
+
+- **ALWAYS use semantic queries**: `getByRole`, `getByLabel`, `getByText`, `getByPlaceholder`
+- **NEVER use implementation details**: `data-slot`, `data-testid`, CSS classes, or `.locator()` with selectors
+- **If semantic queries don't work**: Fix the component's accessibility first (add `aria-label`, proper roles, etc.)
+
+```typescript
+// BAD - Implementation details
+page.locator("[data-slot='badge']");
+page.locator("[data-testid='submit']");
+page.locator(".btn-primary");
+
+// GOOD - Semantic queries
+page.getByRole("button", { name: /submit/i });
+page.getByRole("heading", { name: /welcome/i });
+page.getByLabel(/email/i);
+```
 
 **Exclude** `admin` and `evals` apps from testing requirements (internal tools).
 

--- a/apps/editor/e2e/course-categories.test.ts
+++ b/apps/editor/e2e/course-categories.test.ts
@@ -1,0 +1,236 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import {
+  courseCategoryFixture,
+  courseFixture,
+} from "@zoonk/testing/fixtures/courses";
+import { expect, type Page, test } from "./fixtures";
+
+async function createTestCourse() {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  return courseFixture({
+    organizationId: org.id,
+    slug: `e2e-cat-${randomUUID().slice(0, 8)}`,
+  });
+}
+
+async function navigateToCoursePage(page: Page, slug: string) {
+  await page.goto(`/ai/c/en/${slug}`);
+
+  await expect(
+    page.getByRole("textbox", { name: /edit course title/i }),
+  ).toBeVisible();
+}
+
+async function openCategoryPopover(page: Page) {
+  await page.getByRole("button", { name: /add category/i }).click();
+}
+
+function getCategoryOption(page: Page, name: RegExp) {
+  const dialog = page.getByRole("dialog");
+  return dialog.getByText(name);
+}
+
+test.describe("Course Categories Editor", () => {
+  test("displays existing categories as badges", async ({
+    authenticatedPage,
+  }) => {
+    const course = await createTestCourse();
+
+    await Promise.all([
+      courseCategoryFixture({ category: "tech", courseId: course.id }),
+      courseCategoryFixture({ category: "science", courseId: course.id }),
+    ]);
+
+    await navigateToCoursePage(authenticatedPage, course.slug);
+
+    await expect(authenticatedPage.getByText("Technology")).toBeVisible();
+    await expect(authenticatedPage.getByText("Science")).toBeVisible();
+  });
+
+  test("adds a category and persists after reload", async ({
+    authenticatedPage,
+  }) => {
+    const course = await createTestCourse();
+    await navigateToCoursePage(authenticatedPage, course.slug);
+
+    await openCategoryPopover(authenticatedPage);
+    await getCategoryOption(authenticatedPage, /technology/i).click();
+
+    const addButton = authenticatedPage.getByRole("button", {
+      name: /add category/i,
+    });
+
+    await expect(addButton).toBeEnabled();
+
+    await authenticatedPage.keyboard.press("Escape");
+    await expect(authenticatedPage.getByRole("dialog")).not.toBeVisible();
+
+    const main = authenticatedPage.getByRole("main");
+    await expect(main.getByText("Technology")).toBeVisible();
+
+    await authenticatedPage.reload();
+
+    await expect(
+      authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
+    ).toBeVisible();
+
+    await expect(main.getByText("Technology")).toBeVisible();
+  });
+
+  test("removes a category and persists after reload", async ({
+    authenticatedPage,
+  }) => {
+    const course = await createTestCourse();
+    await courseCategoryFixture({ category: "tech", courseId: course.id });
+
+    await navigateToCoursePage(authenticatedPage, course.slug);
+
+    await expect(authenticatedPage.getByText("Technology")).toBeVisible();
+
+    await openCategoryPopover(authenticatedPage);
+    await getCategoryOption(authenticatedPage, /technology/i).click();
+
+    const addButton = authenticatedPage.getByRole("button", {
+      name: /add category/i,
+    });
+    await expect(addButton).toBeEnabled();
+
+    await authenticatedPage.keyboard.press("Escape");
+
+    await expect(authenticatedPage.getByText("Technology")).not.toBeVisible();
+
+    await authenticatedPage.reload();
+
+    await expect(
+      authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
+    ).toBeVisible();
+
+    await expect(authenticatedPage.getByText("Technology")).not.toBeVisible();
+  });
+
+  test("filters categories by search", async ({ authenticatedPage }) => {
+    const course = await createTestCourse();
+    await navigateToCoursePage(authenticatedPage, course.slug);
+
+    await openCategoryPopover(authenticatedPage);
+
+    await expect(
+      getCategoryOption(authenticatedPage, /technology/i),
+    ).toBeVisible();
+
+    await expect(
+      getCategoryOption(authenticatedPage, /science/i),
+    ).toBeVisible();
+
+    await expect(getCategoryOption(authenticatedPage, /arts/i)).toBeVisible();
+
+    await authenticatedPage.getByPlaceholder(/search/i).fill("tech");
+
+    await expect(
+      getCategoryOption(authenticatedPage, /technology/i),
+    ).toBeVisible();
+
+    await expect(
+      getCategoryOption(authenticatedPage, /science/i),
+    ).not.toBeVisible();
+
+    await expect(
+      getCategoryOption(authenticatedPage, /arts/i),
+    ).not.toBeVisible();
+  });
+
+  test("displays multiple categories in alphabetical order for non-English locale", async ({
+    authenticatedPage,
+  }) => {
+    const course = await createTestCourse();
+    // Use categories with different alphabetical order in English vs Spanish:
+    // English: Arts < Business < Science
+    // Spanish: Artes < Ciencia < Negocios
+    await courseCategoryFixture({ category: "business", courseId: course.id });
+    await courseCategoryFixture({ category: "arts", courseId: course.id });
+    await courseCategoryFixture({ category: "science", courseId: course.id });
+
+    // Set Spanish locale via cookie to test UI translation ordering
+    await authenticatedPage
+      .context()
+      .addCookies([
+        { domain: "localhost", name: "locale", path: "/", value: "es" },
+      ]);
+
+    await authenticatedPage.goto(`/ai/c/en/${course.slug}`);
+
+    await expect(
+      authenticatedPage.getByRole("textbox", {
+        name: /editar título del curso/i,
+      }),
+    ).toBeVisible();
+
+    const main = authenticatedPage.getByRole("main");
+
+    // Spanish alphabetical order: Artes < Ciencia < Negocios
+    const artsBadge = main.getByText("Artes");
+    const scienceBadge = main.getByText("Ciencia");
+    const businessBadge = main.getByText("Negocios");
+
+    await expect(artsBadge).toBeVisible();
+    await expect(scienceBadge).toBeVisible();
+    await expect(businessBadge).toBeVisible();
+
+    const artsBox = await artsBadge.boundingBox();
+    const scienceBox = await scienceBadge.boundingBox();
+    const businessBox = await businessBadge.boundingBox();
+
+    expect(artsBox).toBeTruthy();
+    expect(scienceBox).toBeTruthy();
+    expect(businessBox).toBeTruthy();
+
+    if (!(artsBox && scienceBox && businessBox)) {
+      throw new Error("Could not get bounding boxes for category badges");
+    }
+
+    // Verify Spanish alphabetical order: Artes < Ciencia < Negocios
+    expect(artsBox.x).toBeLessThan(scienceBox.x);
+    expect(scienceBox.x).toBeLessThan(businessBox.x);
+  });
+
+  test("handles multiple add/remove operations in one session", async ({
+    authenticatedPage,
+  }) => {
+    const course = await createTestCourse();
+    await courseCategoryFixture({ category: "tech", courseId: course.id });
+    await courseCategoryFixture({ category: "arts", courseId: course.id });
+
+    await navigateToCoursePage(authenticatedPage, course.slug);
+
+    await expect(authenticatedPage.getByText("Technology")).toBeVisible();
+    await expect(authenticatedPage.getByText("Arts")).toBeVisible();
+
+    await openCategoryPopover(authenticatedPage);
+
+    await getCategoryOption(authenticatedPage, /technology/i).click();
+    await getCategoryOption(authenticatedPage, /science/i).click();
+    await getCategoryOption(authenticatedPage, /math/i).click();
+
+    await authenticatedPage.keyboard.press("Escape");
+
+    await expect(authenticatedPage.getByText("Technology")).not.toBeVisible();
+    await expect(authenticatedPage.getByText("Arts")).toBeVisible();
+    await expect(authenticatedPage.getByText("Science")).toBeVisible();
+    await expect(authenticatedPage.getByText("Math")).toBeVisible();
+
+    await authenticatedPage.reload();
+
+    await expect(
+      authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
+    ).toBeVisible();
+
+    await expect(authenticatedPage.getByText("Technology")).not.toBeVisible();
+    await expect(authenticatedPage.getByText("Arts")).toBeVisible();
+    await expect(authenticatedPage.getByText("Science")).toBeVisible();
+    await expect(authenticatedPage.getByText("Math")).toBeVisible();
+  });
+});

--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -512,9 +512,19 @@ msgid "Alternative titles imported successfully"
 msgstr "Alternative titles imported successfully"
 
 #: src/components/category-editor.tsx
+msgctxt "1O4/kv"
+msgid "Available categories"
+msgstr "Available categories"
+
+#: src/components/category-editor.tsx
 msgctxt "HzJbix"
 msgid "Add category"
 msgstr "Add category"
+
+#: src/components/category-editor.tsx
+msgctxt "P7elzR"
+msgid "Category options"
+msgstr "Category options"
 
 #: src/components/category-editor.tsx
 msgctxt "VKb1MS"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -512,9 +512,19 @@ msgid "Alternative titles imported successfully"
 msgstr "Títulos alternativos importados exitosamente"
 
 #: src/components/category-editor.tsx
+msgctxt "1O4/kv"
+msgid "Available categories"
+msgstr "Categorías disponibles"
+
+#: src/components/category-editor.tsx
 msgctxt "HzJbix"
 msgid "Add category"
 msgstr "Agregar categoría"
+
+#: src/components/category-editor.tsx
+msgctxt "P7elzR"
+msgid "Category options"
+msgstr "Opciones de categoría"
 
 #: src/components/category-editor.tsx
 msgctxt "VKb1MS"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -512,9 +512,19 @@ msgid "Alternative titles imported successfully"
 msgstr "Títulos alternativos importados com sucesso"
 
 #: src/components/category-editor.tsx
+msgctxt "1O4/kv"
+msgid "Available categories"
+msgstr "Categorias disponíveis"
+
+#: src/components/category-editor.tsx
 msgctxt "HzJbix"
 msgid "Add category"
 msgstr "Adicionar categoria"
+
+#: src/components/category-editor.tsx
+msgctxt "P7elzR"
+msgid "Category options"
+msgstr "Opções de categoria"
 
 #: src/components/category-editor.tsx
 msgctxt "VKb1MS"

--- a/apps/editor/src/components/category-editor.tsx
+++ b/apps/editor/src/components/category-editor.tsx
@@ -140,7 +140,11 @@ export function CategoryEditor({
             <PlusIcon />
           </PopoverTrigger>
 
-          <PopoverContent align="start" className="w-56 p-2">
+          <PopoverContent
+            align="start"
+            aria-label={t("Category options")}
+            className="w-56 p-2"
+          >
             <Input
               className="mb-2"
               onChange={(e) => setSearch(e.target.value)}
@@ -152,6 +156,7 @@ export function CategoryEditor({
             <div className="flex max-h-64 flex-col gap-1 overflow-y-auto overscroll-contain">
               {filteredCategories.map((category) => {
                 const isSelected = optimisticCategories.includes(category);
+                const label = categoryLabels[category];
 
                 return (
                   <Label
@@ -162,7 +167,7 @@ export function CategoryEditor({
                       checked={isSelected}
                       onCheckedChange={() => handleToggle(category, isSelected)}
                     />
-                    {categoryLabels[category]}
+                    {label}
                   </Label>
                 );
               })}

--- a/apps/main/AGENTS.md
+++ b/apps/main/AGENTS.md
@@ -1,8 +1,0 @@
-# Guidelines for AI Agents
-
-See the main instructions in [AGENTS.md](../../AGENTS.md). The instructions below are specific to this app.
-
-## Conventions
-
-- Import `Link`, `redirect`, `usePathname`, `useRouter`, and `getPathname` from `@/i18n/navigation` since it handles localization
-- Never hard-code strings. Use `next-intl` instead

--- a/biome.json
+++ b/biome.json
@@ -21,9 +21,11 @@
       "**",
       "!!node_modules",
       "!!.next",
+      "!!.next-e2e",
       "!!dist",
       "!!build",
       "!!generated",
+      "!!messages",
       "!!.turbo"
     ]
   },

--- a/i18n.lock
+++ b/i18n.lock
@@ -98,7 +98,9 @@ checksums:
     Failed%20to%20export/singular: e1ed0bd77fc4509b338f2ed32565012a
     Upload%20a%20JSON%20file%20containing%20alternative%20titles%20to%20import./singular: 7dd18059ccf7955ba864342fdc0d6629
     Alternative%20titles%20imported%20successfully/singular: ca67e17d28382d5ef29bd27219a4104e
+    Available%20categories/singular: bcd678590ae6b4f047a6641bb3c15d6d
     Add%20category/singular: f1ef62efcd0e61cff264dd18047ebd6f
+    Category%20options/singular: c968d0f8e27f746f50efeda29834ad74
     Categories/singular: fd4e44f3b1b2bba9ca45f3aef963d042
     Search/singular: 49dd6c21604b5e8d4153ff1aff2177e1
     Unsaved/singular: ddc9094aecf93ceabe363846756a9925


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Playwright E2E tests for course categories in the editor and improves the category popover’s accessibility and translations. Tests cover display, add/remove persistence, search filtering, and locale-based ordering.

- **New Features**
  - E2E coverage for categories: badges display, add/remove persists after reload, search filter, Spanish alphabetical ordering, and multiple operations in one session.
  - Accessibility and i18n: aria-label on the category popover and new strings/translations (en, es, pt).

- **Refactors**
  - Testing guidelines: added semantic query rules in AGENTS.md and CLAUDE.md; removed apps/main/AGENTS.md.
  - Tooling: biome ignores .next-e2e and messages; updated i18n.lock.

<sup>Written for commit ab59725c4513e2f08307d84d511d8b2df37d3c58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

