### PR TITLE
test(editor): add e2e tests for alternative titles

### DIFF
--- a/apps/editor/e2e/alternative-titles.test.ts
+++ b/apps/editor/e2e/alternative-titles.test.ts
@@ -1,0 +1,373 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import path from "node:path";
+import { prisma } from "@zoonk/db";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { expect, type Page, test } from "./fixtures";
+
+function createImportFile(slugs: string[]): string {
+  const content = JSON.stringify({ alternativeTitles: slugs }, null, 2);
+  const tmpFile = path.join(os.tmpdir(), `alt-titles-${randomUUID()}.json`);
+  fs.writeFileSync(tmpFile, content);
+  return tmpFile;
+}
+
+async function createTestCourse() {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  return courseFixture({
+    organizationId: org.id,
+    slug: `e2e-alt-${randomUUID().slice(0, 8)}`,
+  });
+}
+
+async function navigateToCoursePage(page: Page, slug: string) {
+  await page.goto(`/ai/c/en/${slug}`);
+
+  await expect(
+    page.getByRole("textbox", { name: /edit course title/i }),
+  ).toBeVisible();
+}
+
+async function openAlternativeTitles(page: Page) {
+  await page.getByRole("button", { name: /alternative titles/i }).click();
+}
+
+async function createAlternativeTitleFixture(
+  courseId: number,
+  baseSlug: string,
+) {
+  const slug = `${baseSlug}-${randomUUID().slice(0, 8)}`;
+  await prisma.courseAlternativeTitle.create({
+    data: { courseId, locale: "en", slug },
+  });
+  return slug;
+}
+
+async function createManyAlternativeTitleFixtures(
+  courseId: number,
+  count: number,
+) {
+  const prefix = randomUUID().slice(0, 8);
+  const slugs = Array.from(
+    { length: count },
+    (_, i) => `slug-${prefix}-${String(i + 1).padStart(2, "0")}`,
+  );
+
+  await prisma.courseAlternativeTitle.createMany({
+    data: slugs.map((slug) => ({ courseId, locale: "en", slug })),
+  });
+
+  return slugs;
+}
+
+function getMoreOptionsButton(page: Page) {
+  return page.getByRole("button", { name: /more options/i }).first();
+}
+
+test.describe("Alternative Titles Editor", () => {
+  test("displays existing titles with count badge", async ({
+    authenticatedPage,
+  }) => {
+    const course = await createTestCourse();
+
+    const slug1 = await createAlternativeTitleFixture(course.id, "title-one");
+    const slug2 = await createAlternativeTitleFixture(course.id, "title-two");
+
+    await navigateToCoursePage(authenticatedPage, course.slug);
+
+    const collapsibleButton = authenticatedPage.getByRole("button", {
+      name: /alternative titles/i,
+    });
+
+    await expect(collapsibleButton).toBeVisible();
+    await expect(authenticatedPage.getByText("(2)")).toBeVisible();
+
+    await openAlternativeTitles(authenticatedPage);
+
+    await expect(authenticatedPage.getByText(slug1)).toBeVisible();
+    await expect(authenticatedPage.getByText(slug2)).toBeVisible();
+  });
+
+  test("adds a title and persists after reload", async ({
+    authenticatedPage,
+  }) => {
+    const course = await createTestCourse();
+    const uniqueId = randomUUID().slice(0, 8);
+    const titleInput = `My New Title ${uniqueId}`;
+    const expectedSlug = `my-new-title-${uniqueId}`;
+
+    await navigateToCoursePage(authenticatedPage, course.slug);
+
+    await openAlternativeTitles(authenticatedPage);
+
+    await authenticatedPage
+      .getByPlaceholder(/add alternative title/i)
+      .fill(titleInput);
+
+    await authenticatedPage.getByRole("button", { name: /^add$/i }).click();
+
+    await expect(authenticatedPage.getByText(expectedSlug)).toBeVisible();
+
+    await authenticatedPage.reload();
+
+    await expect(
+      authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
+    ).toBeVisible();
+
+    await openAlternativeTitles(authenticatedPage);
+
+    await expect(authenticatedPage.getByText(expectedSlug)).toBeVisible();
+  });
+
+  test("removes a title and persists after reload", async ({
+    authenticatedPage,
+  }) => {
+    const course = await createTestCourse();
+    const slug = await createAlternativeTitleFixture(course.id, "to-remove");
+
+    await navigateToCoursePage(authenticatedPage, course.slug);
+    await openAlternativeTitles(authenticatedPage);
+
+    await expect(authenticatedPage.getByText(slug)).toBeVisible();
+
+    await authenticatedPage
+      .getByRole("button", { name: new RegExp(`remove ${slug}`, "i") })
+      .click();
+
+    await expect(authenticatedPage.getByText(slug)).not.toBeVisible();
+
+    await authenticatedPage.reload();
+
+    await expect(
+      authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
+    ).toBeVisible();
+
+    await openAlternativeTitles(authenticatedPage);
+
+    await expect(authenticatedPage.getByText(slug)).not.toBeVisible();
+  });
+
+  test("filters titles by search", async ({ authenticatedPage }) => {
+    const course = await createTestCourse();
+    const prefix = randomUUID().slice(0, 8);
+
+    const machineSlug = await createAlternativeTitleFixture(
+      course.id,
+      `machine-${prefix}`,
+    );
+    const deepSlug = await createAlternativeTitleFixture(
+      course.id,
+      `deep-${prefix}`,
+    );
+    const dataSlug = await createAlternativeTitleFixture(
+      course.id,
+      `data-${prefix}`,
+    );
+
+    await navigateToCoursePage(authenticatedPage, course.slug);
+    await openAlternativeTitles(authenticatedPage);
+
+    await expect(authenticatedPage.getByText(machineSlug)).toBeVisible();
+    await expect(authenticatedPage.getByText(deepSlug)).toBeVisible();
+    await expect(authenticatedPage.getByText(dataSlug)).toBeVisible();
+
+    await authenticatedPage.getByPlaceholder(/search titles/i).fill(prefix);
+
+    await expect(authenticatedPage.getByText(machineSlug)).toBeVisible();
+    await expect(authenticatedPage.getByText(deepSlug)).toBeVisible();
+    await expect(authenticatedPage.getByText(dataSlug)).toBeVisible();
+
+    await authenticatedPage.getByPlaceholder(/search titles/i).fill("xyz");
+
+    await expect(
+      authenticatedPage.getByText(/no titles match your search/i),
+    ).toBeVisible();
+
+    await authenticatedPage.getByPlaceholder(/search titles/i).clear();
+
+    await expect(authenticatedPage.getByText(machineSlug)).toBeVisible();
+    await expect(authenticatedPage.getByText(deepSlug)).toBeVisible();
+    await expect(authenticatedPage.getByText(dataSlug)).toBeVisible();
+  });
+
+  test("shows more/less when there are many titles", async ({
+    authenticatedPage,
+  }) => {
+    const course = await createTestCourse();
+    const slugs = await createManyAlternativeTitleFixtures(course.id, 12);
+
+    await navigateToCoursePage(authenticatedPage, course.slug);
+    await openAlternativeTitles(authenticatedPage);
+
+    await Promise.all(
+      slugs
+        .slice(0, 10)
+        .map((slug) => expect(authenticatedPage.getByText(slug)).toBeVisible()),
+    );
+
+    const slug11 = slugs[10] as string;
+    const slug12 = slugs[11] as string;
+
+    await expect(authenticatedPage.getByText(slug11)).not.toBeVisible();
+    await expect(authenticatedPage.getByText(slug12)).not.toBeVisible();
+
+    await expect(authenticatedPage.getByText(/and 2 more/i)).toBeVisible();
+
+    await authenticatedPage.getByText(/and 2 more/i).click();
+
+    await expect(authenticatedPage.getByText(slug11)).toBeVisible();
+    await expect(authenticatedPage.getByText(slug12)).toBeVisible();
+
+    await expect(authenticatedPage.getByText(/show less/i)).toBeVisible();
+
+    await authenticatedPage.getByText(/show less/i).click();
+
+    await expect(authenticatedPage.getByText(slug11)).not.toBeVisible();
+    await expect(authenticatedPage.getByText(slug12)).not.toBeVisible();
+  });
+
+  test("imports titles in merge mode", async ({ authenticatedPage }) => {
+    const course = await createTestCourse();
+    const existingSlug = await createAlternativeTitleFixture(
+      course.id,
+      "existing",
+    );
+    const prefix = randomUUID().slice(0, 8);
+    const importedSlug1 = `imported-${prefix}-1`;
+    const importedSlug2 = `imported-${prefix}-2`;
+    const importFile = createImportFile([importedSlug1, importedSlug2]);
+
+    await navigateToCoursePage(authenticatedPage, course.slug);
+    await openAlternativeTitles(authenticatedPage);
+
+    await expect(authenticatedPage.getByText(existingSlug)).toBeVisible();
+
+    await getMoreOptionsButton(authenticatedPage).click();
+    await authenticatedPage.getByRole("menuitem", { name: /import/i }).click();
+
+    const dialog = authenticatedPage.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    const [fileChooser] = await Promise.all([
+      authenticatedPage.waitForEvent("filechooser"),
+      dialog.getByText(/drop file or click to select/i).click(),
+    ]);
+
+    await fileChooser.setFiles(importFile);
+
+    await expect(dialog.getByLabel(/merge/i)).toBeChecked();
+
+    await dialog.getByRole("button", { name: /^import$/i }).click();
+
+    await expect(dialog).not.toBeVisible();
+
+    await expect(authenticatedPage.getByText(existingSlug)).toBeVisible();
+    await expect(authenticatedPage.getByText(importedSlug1)).toBeVisible();
+    await expect(authenticatedPage.getByText(importedSlug2)).toBeVisible();
+
+    await authenticatedPage.reload();
+
+    await expect(
+      authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
+    ).toBeVisible();
+
+    await openAlternativeTitles(authenticatedPage);
+
+    await expect(authenticatedPage.getByText(existingSlug)).toBeVisible();
+    await expect(authenticatedPage.getByText(importedSlug1)).toBeVisible();
+    await expect(authenticatedPage.getByText(importedSlug2)).toBeVisible();
+
+    fs.unlinkSync(importFile);
+  });
+
+  test("imports titles in replace mode", async ({ authenticatedPage }) => {
+    const course = await createTestCourse();
+    const oldSlug = await createAlternativeTitleFixture(course.id, "old");
+    const prefix = randomUUID().slice(0, 8);
+    const importedSlug1 = `replaced-${prefix}-1`;
+    const importedSlug2 = `replaced-${prefix}-2`;
+    const importFile = createImportFile([importedSlug1, importedSlug2]);
+
+    await navigateToCoursePage(authenticatedPage, course.slug);
+    await openAlternativeTitles(authenticatedPage);
+
+    await expect(authenticatedPage.getByText(oldSlug)).toBeVisible();
+
+    await getMoreOptionsButton(authenticatedPage).click();
+    await authenticatedPage.getByRole("menuitem", { name: /import/i }).click();
+
+    const dialog = authenticatedPage.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    const [fileChooser] = await Promise.all([
+      authenticatedPage.waitForEvent("filechooser"),
+      dialog.getByText(/drop file or click to select/i).click(),
+    ]);
+
+    await fileChooser.setFiles(importFile);
+
+    await dialog.getByText(/replace \(remove existing first\)/i).click();
+
+    await dialog.getByRole("button", { name: /^import$/i }).click();
+
+    await expect(dialog).not.toBeVisible();
+
+    await expect(authenticatedPage.getByText(oldSlug)).not.toBeVisible();
+    await expect(authenticatedPage.getByText(importedSlug1)).toBeVisible();
+    await expect(authenticatedPage.getByText(importedSlug2)).toBeVisible();
+
+    await authenticatedPage.reload();
+
+    await expect(
+      authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
+    ).toBeVisible();
+
+    await openAlternativeTitles(authenticatedPage);
+
+    await expect(authenticatedPage.getByText(oldSlug)).not.toBeVisible();
+    await expect(authenticatedPage.getByText(importedSlug1)).toBeVisible();
+    await expect(authenticatedPage.getByText(importedSlug2)).toBeVisible();
+
+    fs.unlinkSync(importFile);
+  });
+
+  test("does not add duplicate titles", async ({ authenticatedPage }) => {
+    const course = await createTestCourse();
+    const uniqueId = randomUUID().slice(0, 8);
+    const slug = `dup-test-${uniqueId}`;
+
+    await prisma.courseAlternativeTitle.create({
+      data: { courseId: course.id, locale: "en", slug },
+    });
+
+    await navigateToCoursePage(authenticatedPage, course.slug);
+    await openAlternativeTitles(authenticatedPage);
+
+    await expect(authenticatedPage.getByText("(1)")).toBeVisible();
+
+    await authenticatedPage
+      .getByPlaceholder(/add alternative title/i)
+      .fill(`Dup Test ${uniqueId}`);
+
+    await authenticatedPage.getByRole("button", { name: /^add$/i }).click();
+
+    await expect(authenticatedPage.getByText("(1)")).toBeVisible();
+  });
+
+  test("does not submit empty input", async ({ authenticatedPage }) => {
+    const course = await createTestCourse();
+
+    await navigateToCoursePage(authenticatedPage, course.slug);
+    await openAlternativeTitles(authenticatedPage);
+
+    await authenticatedPage.getByRole("button", { name: /^add$/i }).click();
+
+    await expect(
+      authenticatedPage.getByRole("button", { name: /alternative titles/i }),
+    ).not.toContainText("(");
+  });
+});

--- a/apps/editor/e2e/alternative-titles.test.ts
+++ b/apps/editor/e2e/alternative-titles.test.ts
@@ -1,16 +1,15 @@
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
-import * as os from "node:os";
-import path from "node:path";
 import { prisma } from "@zoonk/db";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import tmp from "tmp";
 import { expect, type Page, test } from "./fixtures";
 
 function createImportFile(slugs: string[]): string {
   const content = JSON.stringify({ alternativeTitles: slugs }, null, 2);
-  const tmpFile = path.join(os.tmpdir(), `alt-titles-${randomUUID()}.json`);
-  fs.writeFileSync(tmpFile, content);
-  return tmpFile;
+  const tmpFile = tmp.fileSync({ postfix: ".json", prefix: "alt-titles-" });
+  fs.writeFileSync(tmpFile.name, content);
+  return tmpFile.name;
 }
 
 async function createTestCourse() {

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -24,10 +24,12 @@
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/tmp": "0.2.6",
     "@zoonk/e2e": "workspace:*",
     "@zoonk/testing": "workspace:*",
     "@zoonk/tsconfig": "workspace:*",
     "babel-plugin-react-compiler": "1.0.0",
+    "tmp": "0.2.3",
     "typescript": "^5",
     "vite-tsconfig-paths": "6.0.3",
     "vitest": "4.0.16"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.7)
+      '@types/tmp':
+        specifier: 0.2.6
+        version: 0.2.6
       '@zoonk/e2e':
         specifier: workspace:*
         version: link:../../packages/e2e
@@ -215,6 +218,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: 1.0.0
         version: 1.0.0
+      tmp:
+        specifier: 0.2.3
+        version: 0.2.3
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -2400,6 +2406,9 @@ packages:
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
 
+  '@types/tmp@0.2.6':
+    resolution: {integrity: sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -4157,6 +4166,10 @@ packages:
     resolution: {integrity: sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==}
     hasBin: true
 
+  tmp@0.2.3:
+    resolution: {integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==}
+    engines: {node: '>=14.14'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -5828,6 +5841,8 @@ snapshots:
   '@types/react@19.2.7':
     dependencies:
       csstype: 3.2.3
+
+  '@types/tmp@0.2.6': {}
 
   '@types/unist@2.0.11': {}
 
@@ -7821,6 +7836,8 @@ snapshots:
   tldts@7.0.19:
     dependencies:
       tldts-core: 7.0.19
+
+  tmp@0.2.3: {}
 
   to-regex-range@5.0.1:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds end-to-end tests for the Alternative Titles editor on course pages to prevent regressions in core flows. Verifies add/remove, search, overflow, and import behaviors with persistence after reload.

- **Coverage**
  - Shows existing titles and count badge.
  - Add/remove titles with persistence after reload.
  - Search filter works.
  - Show more/less when there are many titles.
  - Import from JSON in merge or replace mode.
  - Blocks duplicates and empty submissions.

<sup>Written for commit 0ca214d01a4090e2e5c4f9f7a5261ca28a63c409. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

