### PR TITLE
test(editor): add e2e tests for course publish

### DIFF
--- a/apps/editor/e2e/course-publish.test.ts
+++ b/apps/editor/e2e/course-publish.test.ts
@@ -1,0 +1,104 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { expect, type Page, test } from "./fixtures";
+
+async function createTestCourse(isPublished: boolean) {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  return courseFixture({
+    isPublished,
+    organizationId: org.id,
+    slug: `e2e-${randomUUID().slice(0, 8)}`,
+  });
+}
+
+async function navigateToCoursePage(page: Page, slug: string) {
+  await page.goto(`/ai/c/en/${slug}`);
+
+  await expect(
+    page.getByRole("textbox", { name: /edit course title/i }),
+  ).toBeVisible();
+}
+
+test.describe("Course Publish Toggle", () => {
+  test("displays Draft for unpublished course", async ({
+    authenticatedPage,
+  }) => {
+    const course = await createTestCourse(false);
+    await navigateToCoursePage(authenticatedPage, course.slug);
+
+    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
+    await expect(authenticatedPage.getByRole("switch")).not.toBeChecked();
+  });
+
+  test("displays Published for published course", async ({
+    authenticatedPage,
+  }) => {
+    const course = await createTestCourse(true);
+    await navigateToCoursePage(authenticatedPage, course.slug);
+
+    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
+    await expect(authenticatedPage.getByRole("switch")).toBeChecked();
+  });
+
+  test("publishes a draft course and persists", async ({
+    authenticatedPage,
+  }) => {
+    const course = await createTestCourse(false);
+    await navigateToCoursePage(authenticatedPage, course.slug);
+
+    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
+
+    const toggle = authenticatedPage.getByRole("switch");
+    await expect(toggle).toBeEnabled();
+    await expect(toggle).not.toBeChecked();
+
+    await toggle.click();
+
+    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
+    await expect(toggle).toBeChecked();
+
+    // Wait for the server action to complete (switch re-enables after transition)
+    await expect(toggle).toBeEnabled();
+
+    await authenticatedPage.reload();
+
+    await expect(
+      authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
+    ).toBeVisible();
+    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
+    await expect(authenticatedPage.getByRole("switch")).toBeChecked();
+  });
+
+  test("unpublishes a published course and persists", async ({
+    authenticatedPage,
+  }) => {
+    const course = await createTestCourse(true);
+    await navigateToCoursePage(authenticatedPage, course.slug);
+
+    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
+
+    const toggle = authenticatedPage.getByRole("switch");
+    await expect(toggle).toBeEnabled();
+    await expect(toggle).toBeChecked();
+
+    await toggle.click();
+
+    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
+    await expect(toggle).not.toBeChecked();
+
+    // Wait for the server action to complete (switch re-enables after transition)
+    await expect(toggle).toBeEnabled();
+
+    await authenticatedPage.reload();
+
+    await expect(
+      authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
+    ).toBeVisible();
+    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
+    await expect(authenticatedPage.getByRole("switch")).not.toBeChecked();
+  });
+});

--- a/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/actions.ts
@@ -9,11 +9,19 @@ import { deleteCourse } from "@/data/courses/delete-course";
 import { toggleCoursePublished } from "@/data/courses/publish-course";
 import { getErrorMessage } from "@/lib/error-messages";
 
+type TogglePublishParams = {
+  courseId: number;
+  courseSlug: string;
+  courseUrl: string;
+  orgSlug: string;
+};
+
 export async function togglePublishAction(
-  courseSlug: string,
-  courseId: number,
+  params: TogglePublishParams,
   isPublished: boolean,
 ): Promise<{ error: string | null }> {
+  const { courseId, courseSlug, courseUrl, orgSlug } = params;
+
   const { error } = await toggleCoursePublished({
     courseId,
     isPublished,
@@ -24,8 +32,13 @@ export async function togglePublishAction(
   }
 
   after(async () => {
-    await revalidateMainApp([cacheTagCourse({ courseSlug })]);
+    const courseTag = cacheTagCourse({ courseSlug });
+    const orgCoursesTag = cacheTagOrgCourses({ orgSlug });
+
+    await revalidateMainApp([courseTag, orgCoursesTag]);
   });
+
+  revalidatePath(courseUrl);
 
   return { error: null };
 }

--- a/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/course-actions.tsx
+++ b/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/course-actions.tsx
@@ -11,6 +11,7 @@ export async function CourseActions({
 }: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]">) {
   const { courseSlug, lang, orgSlug } = await params;
   const t = await getExtracted();
+  const courseUrl = `/${orgSlug}/c/${lang}/${courseSlug}`;
 
   const { data: course } = await getCourse({
     courseSlug,
@@ -26,7 +27,12 @@ export async function CourseActions({
     <CourseActionsContainer>
       <PublishToggle
         isPublished={course.isPublished}
-        onToggle={togglePublishAction.bind(null, courseSlug, course.id)}
+        onToggle={togglePublishAction.bind(null, {
+          courseId: course.id,
+          courseSlug,
+          courseUrl,
+          orgSlug,
+        })}
       />
 
       <DeleteItemButton


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added end-to-end tests for the course publish toggle and improved revalidation so changes persist and the UI updates reliably after publish/unpublish.

- **New Features**
  - E2E tests cover Draft/Published labels, switch state, toggling publish/unpublish, and persistence after reload.

- **Refactors**
  - togglePublishAction now accepts a params object (courseId, courseSlug, courseUrl, orgSlug).
  - Revalidates course and org courses cache tags, and the course page path after toggling publish.

<sup>Written for commit d63e50a23d696a032b6470a8fe4f7db13c29880e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

