### PR TITLE
test(editor): add e2e tests for course deletion

### DIFF
--- a/apps/editor/e2e/course-delete.test.ts
+++ b/apps/editor/e2e/course-delete.test.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { expect, type Page, test } from "./fixtures";
+
+async function createTestCourse(isPublished: boolean) {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  return courseFixture({
+    isPublished,
+    organizationId: org.id,
+    slug: `e2e-${randomUUID().slice(0, 8)}`,
+  });
+}
+
+async function navigateToCoursePage(page: Page, slug: string) {
+  await page.goto(`/ai/c/en/${slug}`);
+
+  await expect(
+    page.getByRole("textbox", { name: /edit course title/i }),
+  ).toBeVisible();
+}
+
+function getDeleteButton(page: Page) {
+  return page.getByRole("button", { name: /delete course/i });
+}
+
+function getDeleteDialog(page: Page) {
+  return page.getByRole("alertdialog");
+}
+
+function getCancelButton(page: Page) {
+  return page.getByRole("button", { name: /cancel/i });
+}
+
+function getConfirmDeleteButton(page: Page) {
+  return page.getByRole("button", { name: /^delete$/i });
+}
+
+async function openDeleteDialog(page: Page) {
+  await getDeleteButton(page).click();
+  await expect(getDeleteDialog(page)).toBeVisible();
+}
+
+async function confirmDelete(page: Page) {
+  await getConfirmDeleteButton(page).click();
+}
+
+async function verifyCourseDeleted(courseId: number) {
+  const course = await prisma.course.findUnique({ where: { id: courseId } });
+  expect(course).toBeNull();
+}
+
+async function verifyCourseExists(courseId: number) {
+  const course = await prisma.course.findUnique({ where: { id: courseId } });
+  expect(course).not.toBeNull();
+}
+
+test.describe("Course Delete", () => {
+  test.describe("Happy Path", () => {
+    test("admin deletes unpublished course", async ({ authenticatedPage }) => {
+      const course = await createTestCourse(false);
+      await navigateToCoursePage(authenticatedPage, course.slug);
+
+      await expect(getDeleteButton(authenticatedPage)).toBeVisible();
+      await openDeleteDialog(authenticatedPage);
+      await confirmDelete(authenticatedPage);
+
+      await expect(authenticatedPage).toHaveURL(/\/ai$/);
+      await verifyCourseDeleted(course.id);
+    });
+
+    test("owner deletes unpublished course", async ({ ownerPage }) => {
+      const course = await createTestCourse(false);
+      await navigateToCoursePage(ownerPage, course.slug);
+
+      await openDeleteDialog(ownerPage);
+      await confirmDelete(ownerPage);
+
+      await expect(ownerPage).toHaveURL(/\/ai$/);
+      await verifyCourseDeleted(course.id);
+    });
+
+    test("owner deletes published course", async ({ ownerPage }) => {
+      const course = await createTestCourse(true);
+      await navigateToCoursePage(ownerPage, course.slug);
+
+      await openDeleteDialog(ownerPage);
+      await confirmDelete(ownerPage);
+
+      await expect(ownerPage).toHaveURL(/\/ai$/);
+      await verifyCourseDeleted(course.id);
+    });
+  });
+
+  test.describe("Permissions", () => {
+    test("admin cannot see delete button for published course", async ({
+      authenticatedPage,
+    }) => {
+      const course = await createTestCourse(true);
+      await navigateToCoursePage(authenticatedPage, course.slug);
+
+      await expect(getDeleteButton(authenticatedPage)).not.toBeVisible();
+      await verifyCourseExists(course.id);
+    });
+  });
+
+  test.describe("Dialog Interaction", () => {
+    test("cancel button closes dialog without deleting", async ({
+      authenticatedPage,
+    }) => {
+      const course = await createTestCourse(false);
+      await navigateToCoursePage(authenticatedPage, course.slug);
+
+      await openDeleteDialog(authenticatedPage);
+      await getCancelButton(authenticatedPage).click();
+
+      await expect(getDeleteDialog(authenticatedPage)).not.toBeVisible();
+      await verifyCourseExists(course.id);
+    });
+
+    test("escape key closes dialog without deleting", async ({
+      authenticatedPage,
+    }) => {
+      const course = await createTestCourse(false);
+      await navigateToCoursePage(authenticatedPage, course.slug);
+
+      await openDeleteDialog(authenticatedPage);
+      await authenticatedPage.keyboard.press("Escape");
+
+      await expect(getDeleteDialog(authenticatedPage)).not.toBeVisible();
+      await verifyCourseExists(course.id);
+    });
+  });
+});

--- a/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/course-actions.tsx
+++ b/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/course-actions.tsx
@@ -1,3 +1,5 @@
+import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { getExtracted } from "next-intl/server";
 import { DeleteItemButton } from "@/components/navbar/delete-item-button";
@@ -23,6 +25,12 @@ export async function CourseActions({
     return notFound();
   }
 
+  const canDelete = await hasCoursePermission({
+    headers: await headers(),
+    orgId: course.organizationId,
+    permission: course.isPublished ? "delete" : "update",
+  });
+
   return (
     <CourseActionsContainer>
       <PublishToggle
@@ -35,11 +43,18 @@ export async function CourseActions({
         })}
       />
 
-      <DeleteItemButton
-        onDelete={deleteCourseAction.bind(null, courseSlug, orgSlug, course.id)}
-        srLabel={t("Delete course")}
-        title={t("Delete course?")}
-      />
+      {canDelete && (
+        <DeleteItemButton
+          onDelete={deleteCourseAction.bind(
+            null,
+            courseSlug,
+            orgSlug,
+            course.id,
+          )}
+          srLabel={t("Delete course")}
+          title={t("Delete course?")}
+        />
+      )}
     </CourseActionsContainer>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add end-to-end tests for course deletion and gate the Delete button behind permission checks. This ensures only authorized users can delete courses and the UI hides the button when not allowed.

- New Features
  - Added Playwright e2e suite for course deletion.
  - Covers owner/admin happy paths, permission-based visibility, and dialog cancel/Escape behavior.
  - Verifies redirect to the org page and database deletion.

- Bug Fixes
  - Delete button now renders only when the user has permission (hasCoursePermission: "delete" for published, "update" for drafts).
  - Hides the delete option from admins on published courses.

<sup>Written for commit 18ff6ed542f33a1d8aab488d46c66357e470ee60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

