### PR TITLE
test(editor): add e2e tests for publishing chapters and lessons

### DIFF
--- a/apps/editor/e2e/chapter-publish.test.ts
+++ b/apps/editor/e2e/chapter-publish.test.ts
@@ -1,0 +1,118 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { expect, type Page, test } from "./fixtures";
+
+async function createTestChapter(isPublished: boolean) {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-${randomUUID().slice(0, 8)}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished,
+    organizationId: org.id,
+    slug: `e2e-${randomUUID().slice(0, 8)}`,
+  });
+
+  return { chapter, course };
+}
+
+async function navigateToChapterPage(
+  page: Page,
+  courseSlug: string,
+  chapterSlug: string,
+) {
+  await page.goto(`/ai/c/en/${courseSlug}/ch/${chapterSlug}`);
+
+  await expect(
+    page.getByRole("textbox", { name: /edit chapter title/i }),
+  ).toBeVisible();
+}
+
+test.describe("Chapter Publish Toggle", () => {
+  test("displays Draft for unpublished chapter", async ({
+    authenticatedPage,
+  }) => {
+    const { course, chapter } = await createTestChapter(false);
+    await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
+
+    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
+    await expect(authenticatedPage.getByRole("switch")).not.toBeChecked();
+  });
+
+  test("displays Published for published chapter", async ({
+    authenticatedPage,
+  }) => {
+    const { course, chapter } = await createTestChapter(true);
+    await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
+
+    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
+    await expect(authenticatedPage.getByRole("switch")).toBeChecked();
+  });
+
+  test("publishes a draft chapter and persists", async ({
+    authenticatedPage,
+  }) => {
+    const { course, chapter } = await createTestChapter(false);
+    await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
+
+    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
+
+    const toggle = authenticatedPage.getByRole("switch");
+    await expect(toggle).toBeEnabled();
+    await expect(toggle).not.toBeChecked();
+
+    await toggle.click();
+
+    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
+    await expect(toggle).toBeChecked();
+
+    // Wait for the server action to complete (switch re-enables after transition)
+    await expect(toggle).toBeEnabled();
+
+    await authenticatedPage.reload();
+
+    await expect(
+      authenticatedPage.getByRole("textbox", { name: /edit chapter title/i }),
+    ).toBeVisible();
+    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
+    await expect(authenticatedPage.getByRole("switch")).toBeChecked();
+  });
+
+  test("unpublishes a published chapter and persists", async ({
+    authenticatedPage,
+  }) => {
+    const { course, chapter } = await createTestChapter(true);
+    await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
+
+    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
+
+    const toggle = authenticatedPage.getByRole("switch");
+    await expect(toggle).toBeEnabled();
+    await expect(toggle).toBeChecked();
+
+    await toggle.click();
+
+    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
+    await expect(toggle).not.toBeChecked();
+
+    // Wait for the server action to complete (switch re-enables after transition)
+    await expect(toggle).toBeEnabled();
+
+    await authenticatedPage.reload();
+
+    await expect(
+      authenticatedPage.getByRole("textbox", { name: /edit chapter title/i }),
+    ).toBeVisible();
+    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
+    await expect(authenticatedPage.getByRole("switch")).not.toBeChecked();
+  });
+});

--- a/apps/editor/e2e/lesson-publish.test.ts
+++ b/apps/editor/e2e/lesson-publish.test.ts
@@ -1,0 +1,147 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { expect, type Page, test } from "./fixtures";
+
+async function createTestLesson(isPublished: boolean) {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-${randomUUID().slice(0, 8)}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-${randomUUID().slice(0, 8)}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    isPublished,
+    organizationId: org.id,
+    slug: `e2e-${randomUUID().slice(0, 8)}`,
+  });
+
+  return { chapter, course, lesson };
+}
+
+async function navigateToLessonPage(
+  page: Page,
+  courseSlug: string,
+  chapterSlug: string,
+  lessonSlug: string,
+) {
+  await page.goto(`/ai/c/en/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`);
+
+  await expect(
+    page.getByRole("textbox", { name: /edit lesson title/i }),
+  ).toBeVisible();
+}
+
+test.describe("Lesson Publish Toggle", () => {
+  test("displays Draft for unpublished lesson", async ({
+    authenticatedPage,
+  }) => {
+    const { course, chapter, lesson } = await createTestLesson(false);
+    await navigateToLessonPage(
+      authenticatedPage,
+      course.slug,
+      chapter.slug,
+      lesson.slug,
+    );
+
+    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
+    await expect(authenticatedPage.getByRole("switch")).not.toBeChecked();
+  });
+
+  test("displays Published for published lesson", async ({
+    authenticatedPage,
+  }) => {
+    const { course, chapter, lesson } = await createTestLesson(true);
+    await navigateToLessonPage(
+      authenticatedPage,
+      course.slug,
+      chapter.slug,
+      lesson.slug,
+    );
+
+    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
+    await expect(authenticatedPage.getByRole("switch")).toBeChecked();
+  });
+
+  test("publishes a draft lesson and persists", async ({
+    authenticatedPage,
+  }) => {
+    const { course, chapter, lesson } = await createTestLesson(false);
+    await navigateToLessonPage(
+      authenticatedPage,
+      course.slug,
+      chapter.slug,
+      lesson.slug,
+    );
+
+    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
+
+    const toggle = authenticatedPage.getByRole("switch");
+    await expect(toggle).toBeEnabled();
+    await expect(toggle).not.toBeChecked();
+
+    await toggle.click();
+
+    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
+    await expect(toggle).toBeChecked();
+
+    // Wait for the server action to complete (switch re-enables after transition)
+    await expect(toggle).toBeEnabled();
+
+    await authenticatedPage.reload();
+
+    await expect(
+      authenticatedPage.getByRole("textbox", { name: /edit lesson title/i }),
+    ).toBeVisible();
+    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
+    await expect(authenticatedPage.getByRole("switch")).toBeChecked();
+  });
+
+  test("unpublishes a published lesson and persists", async ({
+    authenticatedPage,
+  }) => {
+    const { course, chapter, lesson } = await createTestLesson(true);
+    await navigateToLessonPage(
+      authenticatedPage,
+      course.slug,
+      chapter.slug,
+      lesson.slug,
+    );
+
+    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
+
+    const toggle = authenticatedPage.getByRole("switch");
+    await expect(toggle).toBeEnabled();
+    await expect(toggle).toBeChecked();
+
+    await toggle.click();
+
+    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
+    await expect(toggle).not.toBeChecked();
+
+    // Wait for the server action to complete (switch re-enables after transition)
+    await expect(toggle).toBeEnabled();
+
+    await authenticatedPage.reload();
+
+    await expect(
+      authenticatedPage.getByRole("textbox", { name: /edit lesson title/i }),
+    ).toBeVisible();
+    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
+    await expect(authenticatedPage.getByRole("switch")).not.toBeChecked();
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added end-to-end tests for the chapter and lesson publish toggles in the editor. They verify Draft/Published labels, switch state and re-enabling after server actions, and persistence after reload.

<sup>Written for commit 6344839f143cb164ede02e3f7f65dce75aead90e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

