### PR TITLE
test(editor): add e2e tests for chapter/lesson deletion

### DIFF
--- a/apps/editor/e2e/chapter-delete.test.ts
+++ b/apps/editor/e2e/chapter-delete.test.ts
@@ -1,0 +1,154 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { expect, type Page, test } from "./fixtures";
+
+async function createTestChapter(isPublished: boolean) {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-course-${randomUUID().slice(0, 8)}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished,
+    language: course.language,
+    organizationId: org.id,
+    slug: `e2e-chapter-${randomUUID().slice(0, 8)}`,
+  });
+
+  return { chapter, course };
+}
+
+async function navigateToChapterPage(
+  page: Page,
+  courseSlug: string,
+  chapterSlug: string,
+) {
+  await page.goto(`/ai/c/en/${courseSlug}/ch/${chapterSlug}`);
+
+  await expect(
+    page.getByRole("textbox", { name: /edit chapter title/i }),
+  ).toBeVisible();
+}
+
+function getDeleteButton(page: Page) {
+  return page.getByRole("button", { name: /delete chapter/i });
+}
+
+function getDeleteDialog(page: Page) {
+  return page.getByRole("alertdialog");
+}
+
+function getCancelButton(page: Page) {
+  return page.getByRole("button", { name: /cancel/i });
+}
+
+function getConfirmDeleteButton(page: Page) {
+  return page.getByRole("button", { name: /^delete$/i });
+}
+
+async function openDeleteDialog(page: Page) {
+  await getDeleteButton(page).click();
+  await expect(getDeleteDialog(page)).toBeVisible();
+}
+
+async function confirmDelete(page: Page) {
+  await getConfirmDeleteButton(page).click();
+}
+
+async function verifyChapterDeleted(chapterId: number) {
+  const chapter = await prisma.chapter.findUnique({ where: { id: chapterId } });
+  expect(chapter).toBeNull();
+}
+
+async function verifyChapterExists(chapterId: number) {
+  const chapter = await prisma.chapter.findUnique({ where: { id: chapterId } });
+  expect(chapter).not.toBeNull();
+}
+
+test.describe("Chapter Delete", () => {
+  test.describe("Happy Path", () => {
+    test("admin deletes unpublished chapter", async ({ authenticatedPage }) => {
+      const { course, chapter } = await createTestChapter(false);
+      await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
+
+      await expect(getDeleteButton(authenticatedPage)).toBeVisible();
+      await openDeleteDialog(authenticatedPage);
+      await confirmDelete(authenticatedPage);
+
+      await expect(authenticatedPage).toHaveURL(
+        new RegExp(`/ai/c/en/${course.slug}$`),
+      );
+      await verifyChapterDeleted(chapter.id);
+    });
+
+    test("owner deletes unpublished chapter", async ({ ownerPage }) => {
+      const { course, chapter } = await createTestChapter(false);
+      await navigateToChapterPage(ownerPage, course.slug, chapter.slug);
+
+      await openDeleteDialog(ownerPage);
+      await confirmDelete(ownerPage);
+
+      await expect(ownerPage).toHaveURL(new RegExp(`/ai/c/en/${course.slug}$`));
+      await verifyChapterDeleted(chapter.id);
+    });
+
+    test("owner deletes published chapter", async ({ ownerPage }) => {
+      const { course, chapter } = await createTestChapter(true);
+      await navigateToChapterPage(ownerPage, course.slug, chapter.slug);
+
+      await openDeleteDialog(ownerPage);
+      await confirmDelete(ownerPage);
+
+      await expect(ownerPage).toHaveURL(new RegExp(`/ai/c/en/${course.slug}$`));
+      await verifyChapterDeleted(chapter.id);
+    });
+  });
+
+  test.describe("Permissions", () => {
+    test("admin cannot see delete button for published chapter", async ({
+      authenticatedPage,
+    }) => {
+      const { course, chapter } = await createTestChapter(true);
+      await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
+
+      await expect(getDeleteButton(authenticatedPage)).not.toBeVisible();
+      await verifyChapterExists(chapter.id);
+    });
+  });
+
+  test.describe("Dialog Interaction", () => {
+    test("cancel button closes dialog without deleting", async ({
+      authenticatedPage,
+    }) => {
+      const { course, chapter } = await createTestChapter(false);
+      await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
+
+      await openDeleteDialog(authenticatedPage);
+      await getCancelButton(authenticatedPage).click();
+
+      await expect(getDeleteDialog(authenticatedPage)).not.toBeVisible();
+      await verifyChapterExists(chapter.id);
+    });
+
+    test("escape key closes dialog without deleting", async ({
+      authenticatedPage,
+    }) => {
+      const { course, chapter } = await createTestChapter(false);
+      await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
+
+      await openDeleteDialog(authenticatedPage);
+      await authenticatedPage.keyboard.press("Escape");
+
+      await expect(getDeleteDialog(authenticatedPage)).not.toBeVisible();
+      await verifyChapterExists(chapter.id);
+    });
+  });
+});

--- a/apps/editor/e2e/lesson-delete.test.ts
+++ b/apps/editor/e2e/lesson-delete.test.ts
@@ -1,0 +1,198 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { expect, type Page, test } from "./fixtures";
+
+async function createTestLesson(isPublished: boolean) {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-course-${randomUUID().slice(0, 8)}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    language: course.language,
+    organizationId: org.id,
+    slug: `e2e-chapter-${randomUUID().slice(0, 8)}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    isPublished,
+    language: course.language,
+    organizationId: org.id,
+    slug: `e2e-lesson-${randomUUID().slice(0, 8)}`,
+  });
+
+  return { chapter, course, lesson };
+}
+
+async function navigateToLessonPage(
+  page: Page,
+  courseSlug: string,
+  chapterSlug: string,
+  lessonSlug: string,
+) {
+  await page.goto(`/ai/c/en/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`);
+
+  await expect(
+    page.getByRole("textbox", { name: /edit lesson title/i }),
+  ).toBeVisible();
+}
+
+function getDeleteButton(page: Page) {
+  return page.getByRole("button", { name: /delete lesson/i });
+}
+
+function getDeleteDialog(page: Page) {
+  return page.getByRole("alertdialog");
+}
+
+function getCancelButton(page: Page) {
+  return page.getByRole("button", { name: /cancel/i });
+}
+
+function getConfirmDeleteButton(page: Page) {
+  return page.getByRole("button", { name: /^delete$/i });
+}
+
+async function openDeleteDialog(page: Page) {
+  await getDeleteButton(page).click();
+  await expect(getDeleteDialog(page)).toBeVisible();
+}
+
+async function confirmDelete(page: Page) {
+  await getConfirmDeleteButton(page).click();
+}
+
+async function verifyLessonDeleted(lessonId: number) {
+  const lesson = await prisma.lesson.findUnique({ where: { id: lessonId } });
+  expect(lesson).toBeNull();
+}
+
+async function verifyLessonExists(lessonId: number) {
+  const lesson = await prisma.lesson.findUnique({ where: { id: lessonId } });
+  expect(lesson).not.toBeNull();
+}
+
+test.describe("Lesson Delete", () => {
+  test.describe("Happy Path", () => {
+    test("admin deletes unpublished lesson", async ({ authenticatedPage }) => {
+      const { course, chapter, lesson } = await createTestLesson(false);
+      await navigateToLessonPage(
+        authenticatedPage,
+        course.slug,
+        chapter.slug,
+        lesson.slug,
+      );
+
+      await expect(getDeleteButton(authenticatedPage)).toBeVisible();
+      await openDeleteDialog(authenticatedPage);
+      await confirmDelete(authenticatedPage);
+
+      await expect(authenticatedPage).toHaveURL(
+        new RegExp(`/ai/c/en/${course.slug}/ch/${chapter.slug}$`),
+      );
+      await verifyLessonDeleted(lesson.id);
+    });
+
+    test("owner deletes unpublished lesson", async ({ ownerPage }) => {
+      const { course, chapter, lesson } = await createTestLesson(false);
+      await navigateToLessonPage(
+        ownerPage,
+        course.slug,
+        chapter.slug,
+        lesson.slug,
+      );
+
+      await openDeleteDialog(ownerPage);
+      await confirmDelete(ownerPage);
+
+      await expect(ownerPage).toHaveURL(
+        new RegExp(`/ai/c/en/${course.slug}/ch/${chapter.slug}$`),
+      );
+      await verifyLessonDeleted(lesson.id);
+    });
+
+    test("owner deletes published lesson", async ({ ownerPage }) => {
+      const { course, chapter, lesson } = await createTestLesson(true);
+      await navigateToLessonPage(
+        ownerPage,
+        course.slug,
+        chapter.slug,
+        lesson.slug,
+      );
+
+      await openDeleteDialog(ownerPage);
+      await confirmDelete(ownerPage);
+
+      await expect(ownerPage).toHaveURL(
+        new RegExp(`/ai/c/en/${course.slug}/ch/${chapter.slug}$`),
+      );
+      await verifyLessonDeleted(lesson.id);
+    });
+  });
+
+  test.describe("Permissions", () => {
+    test("admin cannot see delete button for published lesson", async ({
+      authenticatedPage,
+    }) => {
+      const { course, chapter, lesson } = await createTestLesson(true);
+      await navigateToLessonPage(
+        authenticatedPage,
+        course.slug,
+        chapter.slug,
+        lesson.slug,
+      );
+
+      await expect(getDeleteButton(authenticatedPage)).not.toBeVisible();
+      await verifyLessonExists(lesson.id);
+    });
+  });
+
+  test.describe("Dialog Interaction", () => {
+    test("cancel button closes dialog without deleting", async ({
+      authenticatedPage,
+    }) => {
+      const { course, chapter, lesson } = await createTestLesson(false);
+      await navigateToLessonPage(
+        authenticatedPage,
+        course.slug,
+        chapter.slug,
+        lesson.slug,
+      );
+
+      await openDeleteDialog(authenticatedPage);
+      await getCancelButton(authenticatedPage).click();
+
+      await expect(getDeleteDialog(authenticatedPage)).not.toBeVisible();
+      await verifyLessonExists(lesson.id);
+    });
+
+    test("escape key closes dialog without deleting", async ({
+      authenticatedPage,
+    }) => {
+      const { course, chapter, lesson } = await createTestLesson(false);
+      await navigateToLessonPage(
+        authenticatedPage,
+        course.slug,
+        chapter.slug,
+        lesson.slug,
+      );
+
+      await openDeleteDialog(authenticatedPage);
+      await authenticatedPage.keyboard.press("Escape");
+
+      await expect(getDeleteDialog(authenticatedPage)).not.toBeVisible();
+      await verifyLessonExists(lesson.id);
+    });
+  });
+});

--- a/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/chapter-actions.tsx
+++ b/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/chapter-actions.tsx
@@ -1,4 +1,6 @@
+import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
 import type { Route } from "next";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { getExtracted } from "next-intl/server";
 import { DeleteItemButton } from "@/components/navbar/delete-item-button";
@@ -28,6 +30,12 @@ export async function ChapterActions({
     return notFound();
   }
 
+  const canDelete = await hasCoursePermission({
+    headers: await headers(),
+    orgId: chapter.organizationId,
+    permission: chapter.isPublished ? "delete" : "update",
+  });
+
   const courseUrl = `/${orgSlug}/c/${lang}/${courseSlug}` as Route;
 
   return (
@@ -42,17 +50,19 @@ export async function ChapterActions({
         )}
       />
 
-      <DeleteItemButton
-        onDelete={deleteChapterAction.bind(
-          null,
-          chapterSlug,
-          courseSlug,
-          chapter.id,
-          courseUrl,
-        )}
-        srLabel={t("Delete chapter")}
-        title={t("Delete chapter?")}
-      />
+      {canDelete && (
+        <DeleteItemButton
+          onDelete={deleteChapterAction.bind(
+            null,
+            chapterSlug,
+            courseSlug,
+            chapter.id,
+            courseUrl,
+          )}
+          srLabel={t("Delete chapter")}
+          title={t("Delete chapter?")}
+        />
+      )}
     </ChapterActionsContainer>
   );
 }

--- a/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-actions.tsx
+++ b/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-actions.tsx
@@ -1,4 +1,6 @@
+import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
 import type { Route } from "next";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { getExtracted } from "next-intl/server";
 import { DeleteItemButton } from "@/components/navbar/delete-item-button";
@@ -28,6 +30,12 @@ export async function LessonActions({
     return notFound();
   }
 
+  const canDelete = await hasCoursePermission({
+    headers: await headers(),
+    orgId: lesson.organizationId,
+    permission: lesson.isPublished ? "delete" : "update",
+  });
+
   const chapterUrl =
     `/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}` as Route;
 
@@ -40,11 +48,13 @@ export async function LessonActions({
         onToggle={togglePublishAction.bind(null, slugs, lesson.id)}
       />
 
-      <DeleteItemButton
-        onDelete={deleteLessonAction.bind(null, slugs, lesson.id, chapterUrl)}
-        srLabel={t("Delete lesson")}
-        title={t("Delete lesson?")}
-      />
+      {canDelete && (
+        <DeleteItemButton
+          onDelete={deleteLessonAction.bind(null, slugs, lesson.id, chapterUrl)}
+          srLabel={t("Delete lesson")}
+          title={t("Delete lesson?")}
+        />
+      )}
     </LessonActionsContainer>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add end-to-end tests for deleting chapters and lessons, and gate the Delete button behind course permissions. This improves confidence in delete flows and ensures the button only shows when the user can delete.

- **New Features**
  - Added e2e tests for chapter/lesson deletion covering admin/owner roles, published/unpublished states, and dialog Cancel/Escape behavior.
  - Show Delete button only when hasCoursePermission allows it: "delete" for published items, "update" for drafts (via next/headers).

<sup>Written for commit 3b8e88f5389371da9bc84e063aef1e0a26a46324. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

