### PR TITLE
test(editor): add e2e tests for editing chapters and lessons

### DIFF
--- a/apps/editor/e2e/chapter-content.test.ts
+++ b/apps/editor/e2e/chapter-content.test.ts
@@ -1,0 +1,203 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { expect, type Page, test } from "./fixtures";
+
+async function createTestChapter() {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-${randomUUID().slice(0, 8)}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-${randomUUID().slice(0, 8)}`,
+  });
+
+  return { chapter, course };
+}
+
+async function navigateToChapterPage(
+  page: Page,
+  courseSlug: string,
+  chapterSlug: string,
+) {
+  await page.goto(`/ai/c/en/${courseSlug}/ch/${chapterSlug}`);
+
+  await expect(
+    page.getByRole("textbox", { name: /edit chapter title/i }),
+  ).toBeVisible();
+}
+
+test.describe("Chapter Content Page", () => {
+  test("auto-saves and persists title", async ({ authenticatedPage }) => {
+    const { chapter, course } = await createTestChapter();
+    await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
+
+    const titleInput = authenticatedPage.getByRole("textbox", {
+      name: /edit chapter title/i,
+    });
+    const uniqueTitle = `Test Title ${randomUUID().slice(0, 8)}`;
+
+    await titleInput.fill(uniqueTitle);
+    await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+
+    await authenticatedPage.reload();
+    await expect(titleInput).toBeVisible();
+    await expect(titleInput).toHaveValue(uniqueTitle);
+  });
+
+  test("auto-saves and persists description", async ({ authenticatedPage }) => {
+    const { chapter, course } = await createTestChapter();
+    await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
+
+    const descriptionInput = authenticatedPage.getByRole("textbox", {
+      name: /edit chapter description/i,
+    });
+    const uniqueDescription = `Test Description ${randomUUID().slice(0, 8)}`;
+
+    await descriptionInput.fill(uniqueDescription);
+    await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+
+    await authenticatedPage.reload();
+    await expect(descriptionInput).toBeVisible();
+    await expect(descriptionInput).toHaveValue(uniqueDescription);
+  });
+
+  test("shows validation error for duplicate slug", async ({
+    authenticatedPage,
+  }) => {
+    await navigateToChapterPage(
+      authenticatedPage,
+      "machine-learning",
+      "introduction-to-machine-learning",
+    );
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+
+    await slugInput.fill("data-preparation");
+
+    await expect(
+      authenticatedPage.getByText(/this url is already in use/i),
+    ).toBeVisible();
+    await expect(
+      authenticatedPage.getByRole("img", {
+        name: /this url is already in use/i,
+      }),
+    ).toBeVisible();
+  });
+
+  test("disables save for empty slug", async ({ authenticatedPage }) => {
+    await navigateToChapterPage(
+      authenticatedPage,
+      "machine-learning",
+      "introduction-to-machine-learning",
+    );
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+
+    await slugInput.fill("");
+
+    await expect(
+      authenticatedPage.getByRole("button", { name: /^save$/i }),
+    ).not.toBeVisible();
+  });
+
+  test("saves valid slug and redirects", async ({ authenticatedPage }) => {
+    const { chapter, course } = await createTestChapter();
+    await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
+
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const uniqueSlug = `test-slug-${randomUUID().slice(0, 8)}`;
+
+    await slugInput.fill(uniqueSlug);
+
+    const saveButton = authenticatedPage.getByRole("button", {
+      name: /^save$/i,
+    });
+    await expect(saveButton).toBeEnabled();
+    await saveButton.click();
+
+    await expect(authenticatedPage).toHaveURL(
+      new RegExp(`/ai/c/en/${course.slug}/ch/${uniqueSlug}`),
+    );
+    await expect(slugInput).toHaveValue(uniqueSlug);
+  });
+
+  test("reverts changes on cancel", async ({ authenticatedPage }) => {
+    await navigateToChapterPage(
+      authenticatedPage,
+      "machine-learning",
+      "introduction-to-machine-learning",
+    );
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+
+    await slugInput.fill("some-other-slug");
+    await authenticatedPage.getByRole("button", { name: /cancel/i }).click();
+
+    await expect(slugInput).toHaveValue("introduction-to-machine-learning");
+  });
+
+  test("saves on Enter key", async ({ authenticatedPage }) => {
+    const { chapter, course } = await createTestChapter();
+    await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
+
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const uniqueSlug = `enter-test-${randomUUID().slice(0, 8)}`;
+
+    await slugInput.fill(uniqueSlug);
+
+    await expect(
+      authenticatedPage.getByRole("button", { name: /^save$/i }),
+    ).toBeEnabled();
+    await slugInput.press("Enter");
+
+    await expect(authenticatedPage).toHaveURL(
+      new RegExp(`/ai/c/en/${course.slug}/ch/${uniqueSlug}`),
+    );
+  });
+
+  test("cancels on Escape key", async ({ authenticatedPage }) => {
+    await navigateToChapterPage(
+      authenticatedPage,
+      "machine-learning",
+      "introduction-to-machine-learning",
+    );
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+
+    await slugInput.fill("escape-test-slug");
+    await slugInput.press("Escape");
+
+    await expect(slugInput).toHaveValue("introduction-to-machine-learning");
+  });
+
+  test("back link shows course title and navigates to course", async ({
+    authenticatedPage,
+  }) => {
+    await navigateToChapterPage(
+      authenticatedPage,
+      "machine-learning",
+      "introduction-to-machine-learning",
+    );
+
+    const backLink = authenticatedPage.getByRole("link", {
+      exact: true,
+      name: "Machine Learning",
+    });
+
+    await expect(backLink).toBeVisible();
+    await backLink.click();
+
+    await expect(authenticatedPage).toHaveURL(/\/ai\/c\/en\/machine-learning$/);
+
+    await expect(
+      authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
+    ).toBeVisible();
+  });
+});

--- a/apps/editor/e2e/lesson-content.test.ts
+++ b/apps/editor/e2e/lesson-content.test.ts
@@ -1,0 +1,236 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { expect, type Page, test } from "./fixtures";
+
+async function createTestLesson() {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-${randomUUID().slice(0, 8)}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-${randomUUID().slice(0, 8)}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-${randomUUID().slice(0, 8)}`,
+  });
+
+  return { chapter, course, lesson };
+}
+
+async function navigateToLessonPage(
+  page: Page,
+  courseSlug: string,
+  chapterSlug: string,
+  lessonSlug: string,
+) {
+  await page.goto(`/ai/c/en/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`);
+
+  await expect(
+    page.getByRole("textbox", { name: /edit lesson title/i }),
+  ).toBeVisible();
+}
+
+test.describe("Lesson Content Page", () => {
+  test("auto-saves and persists title", async ({ authenticatedPage }) => {
+    const { chapter, course, lesson } = await createTestLesson();
+    await navigateToLessonPage(
+      authenticatedPage,
+      course.slug,
+      chapter.slug,
+      lesson.slug,
+    );
+
+    const titleInput = authenticatedPage.getByRole("textbox", {
+      name: /edit lesson title/i,
+    });
+    const uniqueTitle = `Test Title ${randomUUID().slice(0, 8)}`;
+
+    await titleInput.fill(uniqueTitle);
+    await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+
+    await authenticatedPage.reload();
+    await expect(titleInput).toBeVisible();
+    await expect(titleInput).toHaveValue(uniqueTitle);
+  });
+
+  test("auto-saves and persists description", async ({ authenticatedPage }) => {
+    const { chapter, course, lesson } = await createTestLesson();
+    await navigateToLessonPage(
+      authenticatedPage,
+      course.slug,
+      chapter.slug,
+      lesson.slug,
+    );
+
+    const descriptionInput = authenticatedPage.getByRole("textbox", {
+      name: /edit lesson description/i,
+    });
+    const uniqueDescription = `Test Description ${randomUUID().slice(0, 8)}`;
+
+    await descriptionInput.fill(uniqueDescription);
+    await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+
+    await authenticatedPage.reload();
+    await expect(descriptionInput).toBeVisible();
+    await expect(descriptionInput).toHaveValue(uniqueDescription);
+  });
+
+  test("shows validation error for duplicate slug", async ({
+    authenticatedPage,
+  }) => {
+    await navigateToLessonPage(
+      authenticatedPage,
+      "machine-learning",
+      "introduction-to-machine-learning",
+      "what-is-machine-learning",
+    );
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+
+    await slugInput.fill("history-of-ml");
+
+    await expect(
+      authenticatedPage.getByText(/this url is already in use/i),
+    ).toBeVisible();
+    await expect(
+      authenticatedPage.getByRole("img", {
+        name: /this url is already in use/i,
+      }),
+    ).toBeVisible();
+  });
+
+  test("disables save for empty slug", async ({ authenticatedPage }) => {
+    await navigateToLessonPage(
+      authenticatedPage,
+      "machine-learning",
+      "introduction-to-machine-learning",
+      "what-is-machine-learning",
+    );
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+
+    await slugInput.fill("");
+
+    await expect(
+      authenticatedPage.getByRole("button", { name: /^save$/i }),
+    ).not.toBeVisible();
+  });
+
+  test("saves valid slug and redirects", async ({ authenticatedPage }) => {
+    const { chapter, course, lesson } = await createTestLesson();
+    await navigateToLessonPage(
+      authenticatedPage,
+      course.slug,
+      chapter.slug,
+      lesson.slug,
+    );
+
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const uniqueSlug = `test-slug-${randomUUID().slice(0, 8)}`;
+
+    await slugInput.fill(uniqueSlug);
+
+    const saveButton = authenticatedPage.getByRole("button", {
+      name: /^save$/i,
+    });
+    await expect(saveButton).toBeEnabled();
+    await saveButton.click();
+
+    await expect(authenticatedPage).toHaveURL(
+      new RegExp(`/ai/c/en/${course.slug}/ch/${chapter.slug}/l/${uniqueSlug}`),
+    );
+    await expect(slugInput).toHaveValue(uniqueSlug);
+  });
+
+  test("reverts changes on cancel", async ({ authenticatedPage }) => {
+    await navigateToLessonPage(
+      authenticatedPage,
+      "machine-learning",
+      "introduction-to-machine-learning",
+      "what-is-machine-learning",
+    );
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+
+    await slugInput.fill("some-other-slug");
+    await authenticatedPage.getByRole("button", { name: /cancel/i }).click();
+
+    await expect(slugInput).toHaveValue("what-is-machine-learning");
+  });
+
+  test("saves on Enter key", async ({ authenticatedPage }) => {
+    const { chapter, course, lesson } = await createTestLesson();
+    await navigateToLessonPage(
+      authenticatedPage,
+      course.slug,
+      chapter.slug,
+      lesson.slug,
+    );
+
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const uniqueSlug = `enter-test-${randomUUID().slice(0, 8)}`;
+
+    await slugInput.fill(uniqueSlug);
+
+    await expect(
+      authenticatedPage.getByRole("button", { name: /^save$/i }),
+    ).toBeEnabled();
+    await slugInput.press("Enter");
+
+    await expect(authenticatedPage).toHaveURL(
+      new RegExp(`/ai/c/en/${course.slug}/ch/${chapter.slug}/l/${uniqueSlug}`),
+    );
+  });
+
+  test("cancels on Escape key", async ({ authenticatedPage }) => {
+    await navigateToLessonPage(
+      authenticatedPage,
+      "machine-learning",
+      "introduction-to-machine-learning",
+      "what-is-machine-learning",
+    );
+    const slugInput = authenticatedPage.getByLabel(/url address/i);
+
+    await slugInput.fill("escape-test-slug");
+    await slugInput.press("Escape");
+
+    await expect(slugInput).toHaveValue("what-is-machine-learning");
+  });
+
+  test("back link shows chapter title and navigates to chapter", async ({
+    authenticatedPage,
+  }) => {
+    await navigateToLessonPage(
+      authenticatedPage,
+      "machine-learning",
+      "introduction-to-machine-learning",
+      "what-is-machine-learning",
+    );
+
+    const backLink = authenticatedPage.getByRole("link", {
+      name: /introduction to machine learning/i,
+    });
+    await expect(backLink).toBeVisible();
+    await backLink.click();
+
+    await expect(authenticatedPage).toHaveURL(
+      /\/ai\/c\/en\/machine-learning\/ch\/introduction-to-machine-learning$/,
+    );
+    await expect(
+      authenticatedPage.getByRole("textbox", { name: /edit chapter title/i }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added e2e tests for chapter and lesson editor pages. They cover autosave for title/description, slug validation (duplicate, empty), save and redirect, cancel revert, Enter/Escape behavior, and back-link navigation.

<sup>Written for commit f7d59a527bc9ec82664039f306d3ab67dbca7e38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

