### PR TITLE
test(editor): add e2e tests for chapter list

### DIFF
--- a/apps/editor/e2e/chapter-list.test.ts
+++ b/apps/editor/e2e/chapter-list.test.ts
@@ -1,0 +1,412 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import { prisma } from "@zoonk/db";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import tmp from "tmp";
+import { expect, type Page, test } from "./fixtures";
+import { getMoreOptionsButton, importFlow } from "./helpers/import-dialog";
+
+function createImportFile(
+  chapters: { title: string; description: string }[],
+): string {
+  const content = JSON.stringify({ chapters }, null, 2);
+  const tmpFile = tmp.fileSync({ postfix: ".json", prefix: "chapters-" });
+  fs.writeFileSync(tmpFile.name, content);
+  return tmpFile.name;
+}
+
+async function createTestCourse(chapterCount = 0) {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const course = await courseFixture({
+    organizationId: org.id,
+    slug: `e2e-ch-${randomUUID().slice(0, 8)}`,
+  });
+
+  const chapters =
+    chapterCount > 0
+      ? await Promise.all(
+          Array.from({ length: chapterCount }, (_, i) =>
+            chapterFixture({
+              courseId: course.id,
+              language: "en",
+              organizationId: org.id,
+              position: i,
+              title: `Chapter ${i + 1}`,
+            }),
+          ),
+        )
+      : [];
+
+  return { chapters, course, org };
+}
+
+async function navigateToCoursePage(page: Page, slug: string) {
+  await page.goto(`/ai/c/en/${slug}`);
+
+  await expect(
+    page.getByRole("textbox", { name: /edit course title/i }),
+  ).toBeVisible();
+}
+
+async function expectChaptersVisible(
+  page: Page,
+  chapters: { position: number; title: string }[],
+) {
+  await Promise.all(
+    chapters.map(({ position, title }) =>
+      expect(
+        page.getByRole("link", {
+          name: new RegExp(
+            `^${String(position).padStart(2, "0")}.*${title}`,
+            "i",
+          ),
+        }),
+      ).toBeVisible(),
+    ),
+  );
+}
+
+async function expectChapterNotVisible(page: Page, title: string) {
+  await expect(
+    page.getByRole("link", { name: new RegExp(title, "i") }),
+  ).not.toBeVisible();
+}
+
+test.describe("Chapter List", () => {
+  test.describe("Display", () => {
+    test("displays existing chapters with position and title", async ({
+      authenticatedPage,
+    }) => {
+      const { course } = await createTestCourse(3);
+
+      await navigateToCoursePage(authenticatedPage, course.slug);
+
+      await expectChaptersVisible(authenticatedPage, [
+        { position: 1, title: "Chapter 1" },
+        { position: 2, title: "Chapter 2" },
+        { position: 3, title: "Chapter 3" },
+      ]);
+    });
+
+    test("displays chapter description when available", async ({
+      authenticatedPage,
+    }) => {
+      const { course, org } = await createTestCourse();
+      const uniqueDesc = `Description ${randomUUID().slice(0, 8)}`;
+
+      await chapterFixture({
+        courseId: course.id,
+        description: uniqueDesc,
+        language: "en",
+        organizationId: org.id,
+        position: 0,
+        title: "Chapter with description",
+      });
+
+      await navigateToCoursePage(authenticatedPage, course.slug);
+
+      await expect(authenticatedPage.getByText(uniqueDesc)).toBeVisible();
+    });
+  });
+
+  test.describe("Add Chapter", () => {
+    test("adds a chapter and shows chapter edit page", async ({
+      authenticatedPage,
+    }) => {
+      const { course } = await createTestCourse();
+
+      await navigateToCoursePage(authenticatedPage, course.slug);
+
+      await authenticatedPage
+        .getByRole("button", { name: /add chapter/i })
+        .click();
+
+      // Verify destination page content (not just URL)
+      await expect(
+        authenticatedPage.getByRole("textbox", { name: /edit chapter title/i }),
+      ).toBeVisible();
+
+      // Verify the default title is set
+      await expect(
+        authenticatedPage.getByRole("textbox", { name: /edit chapter title/i }),
+      ).toHaveValue(/untitled chapter/i);
+    });
+
+    test("inserts chapter at middle position", async ({
+      authenticatedPage,
+    }) => {
+      const { course } = await createTestCourse(4);
+
+      await navigateToCoursePage(authenticatedPage, course.slug);
+
+      await expectChaptersVisible(authenticatedPage, [
+        { position: 1, title: "Chapter 1" },
+        { position: 2, title: "Chapter 2" },
+        { position: 3, title: "Chapter 3" },
+        { position: 4, title: "Chapter 4" },
+      ]);
+
+      // Hover over the third chapter to reveal the insert button between 2 and 3
+      const thirdChapterItem = authenticatedPage.getByRole("link", {
+        name: /^03.*Chapter 3/i,
+      });
+
+      await thirdChapterItem.hover();
+
+      // Click the insert button that appears before chapter 3 (position 2)
+      const insertButtons = authenticatedPage.getByRole("button", {
+        name: /insert chapter/i,
+      });
+
+      await insertButtons.nth(2).click();
+
+      // After clicking insert, we're redirected to the chapter edit page
+      await expect(
+        authenticatedPage.getByRole("textbox", { name: /edit chapter title/i }),
+      ).toBeVisible();
+
+      // Navigate back to course page to verify insertion
+      await authenticatedPage.goto(`/ai/c/en/${course.slug}`);
+
+      await expect(
+        authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
+      ).toBeVisible();
+
+      // New chapter should be at position 3, shifting chapters 3 and 4 down
+      await expectChaptersVisible(authenticatedPage, [
+        { position: 1, title: "Chapter 1" },
+        { position: 2, title: "Chapter 2" },
+        { position: 3, title: "Untitled chapter" },
+        { position: 4, title: "Chapter 3" },
+        { position: 5, title: "Chapter 4" },
+      ]);
+    });
+  });
+
+  test.describe("Reorder", () => {
+    test("reorders chapters and persists after reload", async ({
+      authenticatedPage,
+    }) => {
+      const { course } = await createTestCourse(3);
+
+      await navigateToCoursePage(authenticatedPage, course.slug);
+
+      await expectChaptersVisible(authenticatedPage, [
+        { position: 1, title: "Chapter 1" },
+        { position: 2, title: "Chapter 2" },
+        { position: 3, title: "Chapter 3" },
+      ]);
+
+      // Get the inner drag handle buttons (exact name match to avoid outer container buttons)
+      const firstHandle = authenticatedPage
+        .getByRole("button", { exact: true, name: "Drag to reorder" })
+        .first();
+
+      const secondHandle = authenticatedPage
+        .getByRole("button", { exact: true, name: "Drag to reorder" })
+        .nth(1);
+
+      const firstBox = await firstHandle.boundingBox();
+      const secondBox = await secondHandle.boundingBox();
+
+      if (!(firstBox && secondBox)) {
+        throw new Error("Drag handle bounding boxes should exist");
+      }
+
+      // Perform drag past 8px activation threshold
+      await firstHandle.hover();
+      await authenticatedPage.mouse.down();
+
+      const targetY = secondBox.y + secondBox.height / 2 + 5;
+
+      await authenticatedPage.mouse.move(
+        firstBox.x + firstBox.width / 2,
+        firstBox.y + 20,
+        { steps: 5 },
+      );
+
+      await authenticatedPage.mouse.move(
+        firstBox.x + firstBox.width / 2,
+        targetY,
+        { steps: 10 },
+      );
+
+      await authenticatedPage.mouse.up();
+
+      // After reorder: Chapter 1 moves from first to last position
+      const reorderedChapters = [
+        { position: 1, title: "Chapter 2" },
+        { position: 2, title: "Chapter 3" },
+        { position: 3, title: "Chapter 1" },
+      ];
+
+      await expectChaptersVisible(authenticatedPage, reorderedChapters);
+
+      // Reload and verify persistence
+      await authenticatedPage.reload();
+
+      await expect(
+        authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
+      ).toBeVisible();
+
+      await expectChaptersVisible(authenticatedPage, reorderedChapters);
+    });
+  });
+
+  test.describe("Import/Export", () => {
+    test("exports chapters as JSON file", async ({ authenticatedPage }) => {
+      const { course, chapters } = await createTestCourse(2);
+
+      await navigateToCoursePage(authenticatedPage, course.slug);
+
+      await getMoreOptionsButton(authenticatedPage).click();
+
+      const downloadPromise = authenticatedPage.waitForEvent("download");
+
+      await authenticatedPage
+        .getByRole("menuitem", { name: /export/i })
+        .click();
+
+      const download = await downloadPromise;
+
+      expect(download.suggestedFilename()).toBe("chapters.json");
+
+      const downloadPath = await download.path();
+
+      if (!downloadPath) {
+        throw new Error("Download path should exist");
+      }
+
+      const json = JSON.parse(fs.readFileSync(downloadPath, "utf-8"));
+      expect(json.chapters).toHaveLength(chapters.length);
+
+      // Verify actual content, not just count
+      const exportedTitles = json.chapters.map(
+        (c: { title: string }) => c.title,
+      );
+      expect(exportedTitles).toContain("Chapter 1");
+      expect(exportedTitles).toContain("Chapter 2");
+    });
+
+    test("imports chapters in merge mode", async ({ authenticatedPage }) => {
+      const { course, chapters } = await createTestCourse(1);
+      const existingTitle = chapters[0]?.title ?? "";
+
+      const prefix = randomUUID().slice(0, 8);
+      const importedTitle1 = `Imported ${prefix} 1`;
+      const importedTitle2 = `Imported ${prefix} 2`;
+
+      const importFile = createImportFile([
+        { description: "First imported", title: importedTitle1 },
+        { description: "Second imported", title: importedTitle2 },
+      ]);
+
+      try {
+        await navigateToCoursePage(authenticatedPage, course.slug);
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: existingTitle }),
+        ).toBeVisible();
+
+        await importFlow(authenticatedPage, importFile, "merge");
+
+        // Verify all chapters are visible (existing + imported)
+        await expect(
+          authenticatedPage.getByRole("link", { name: existingTitle }),
+        ).toBeVisible();
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: importedTitle1 }),
+        ).toBeVisible();
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: importedTitle2 }),
+        ).toBeVisible();
+
+        // Verify persistence after reload
+        await authenticatedPage.reload();
+
+        await expect(
+          authenticatedPage.getByRole("textbox", {
+            name: /edit course title/i,
+          }),
+        ).toBeVisible();
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: existingTitle }),
+        ).toBeVisible();
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: importedTitle1 }),
+        ).toBeVisible();
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: importedTitle2 }),
+        ).toBeVisible();
+      } finally {
+        fs.unlinkSync(importFile);
+      }
+    });
+
+    test("imports chapters in replace mode", async ({ authenticatedPage }) => {
+      const { course, chapters } = await createTestCourse(1);
+      const existingTitle = chapters[0]?.title ?? "";
+
+      const prefix = randomUUID().slice(0, 8);
+      const importedTitle1 = `Replaced ${prefix} 1`;
+      const importedTitle2 = `Replaced ${prefix} 2`;
+
+      const importFile = createImportFile([
+        { description: "First replaced", title: importedTitle1 },
+        { description: "Second replaced", title: importedTitle2 },
+      ]);
+
+      try {
+        await navigateToCoursePage(authenticatedPage, course.slug);
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: existingTitle }),
+        ).toBeVisible();
+
+        await importFlow(authenticatedPage, importFile, "replace");
+
+        // Existing chapter should be removed
+        await expectChapterNotVisible(authenticatedPage, existingTitle);
+
+        // Only imported chapters should be visible
+        await expect(
+          authenticatedPage.getByRole("link", { name: importedTitle1 }),
+        ).toBeVisible();
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: importedTitle2 }),
+        ).toBeVisible();
+
+        // Verify persistence after reload
+        await authenticatedPage.reload();
+
+        await expect(
+          authenticatedPage.getByRole("textbox", {
+            name: /edit course title/i,
+          }),
+        ).toBeVisible();
+
+        await expectChapterNotVisible(authenticatedPage, existingTitle);
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: importedTitle1 }),
+        ).toBeVisible();
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: importedTitle2 }),
+        ).toBeVisible();
+      } finally {
+        fs.unlinkSync(importFile);
+      }
+    });
+  });
+});

--- a/apps/editor/e2e/helpers/import-dialog.ts
+++ b/apps/editor/e2e/helpers/import-dialog.ts
@@ -1,0 +1,33 @@
+import { expect, type Page } from "../fixtures";
+
+export function getMoreOptionsButton(page: Page) {
+  return page.getByRole("button", { name: /more options/i }).first();
+}
+
+export async function importFlow(
+  page: Page,
+  importFile: string,
+  mode: "merge" | "replace",
+) {
+  await getMoreOptionsButton(page).click();
+  await page.getByRole("menuitem", { name: /import/i }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+
+  const [fileChooser] = await Promise.all([
+    page.waitForEvent("filechooser"),
+    dialog.getByText(/drop file or click to select/i).click(),
+  ]);
+
+  await fileChooser.setFiles(importFile);
+
+  if (mode === "merge") {
+    await expect(dialog.getByLabel(/merge/i)).toBeChecked();
+  } else {
+    await dialog.getByText(/replace \(remove existing first\)/i).click();
+  }
+
+  await dialog.getByRole("button", { name: /^import$/i }).click();
+  await expect(dialog).not.toBeVisible();
+}

--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -155,10 +155,20 @@ msgctxt "RWzfUY"
 msgid "Add lesson"
 msgstr "Add lesson"
 
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+msgctxt "ZRJz2g"
+msgid "Insert lesson"
+msgstr "Insert lesson"
+
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "dlQpGl"
 msgid "Add chapter"
 msgstr "Add chapter"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "niU+md"
+msgid "Insert chapter"
+msgstr "Insert chapter"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "sHQNSR"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -155,10 +155,20 @@ msgctxt "RWzfUY"
 msgid "Add lesson"
 msgstr "Agregar lección"
 
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+msgctxt "ZRJz2g"
+msgid "Insert lesson"
+msgstr "Insertar lección"
+
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "dlQpGl"
 msgid "Add chapter"
 msgstr "Agregar capítulo"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "niU+md"
+msgid "Insert chapter"
+msgstr "Insertar capítulo"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "sHQNSR"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -155,10 +155,20 @@ msgctxt "RWzfUY"
 msgid "Add lesson"
 msgstr "Adicionar aula"
 
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+msgctxt "ZRJz2g"
+msgid "Insert lesson"
+msgstr "Inserir aula"
+
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "dlQpGl"
 msgid "Add chapter"
 msgstr "Adicionar capítulo"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "niU+md"
+msgid "Insert chapter"
+msgstr "Inserir capítulo"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "sHQNSR"

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -88,7 +88,10 @@ export async function LessonList({
           onReorder={reorderLessonsAction.bind(null, routeParams)}
         >
           <EditorListContent>
-            <EditorListInsertLine position={0} />
+            <EditorListInsertLine
+              aria-label={t("Insert lesson")}
+              position={0}
+            />
 
             {lessons.map((lesson, index) => (
               <Fragment key={lesson.slug}>
@@ -124,7 +127,10 @@ export async function LessonList({
                   </EditorListItem>
                 </EditorSortableItem>
 
-                <EditorListInsertLine position={index + 1} />
+                <EditorListInsertLine
+                  aria-label={t("Insert lesson")}
+                  position={index + 1}
+                />
               </Fragment>
             ))}
           </EditorListContent>

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
@@ -85,7 +85,10 @@ export async function ChapterList({
           onReorder={reorderChaptersAction.bind(null, routeParams)}
         >
           <EditorListContent>
-            <EditorListInsertLine position={0} />
+            <EditorListInsertLine
+              aria-label={t("Insert chapter")}
+              position={0}
+            />
 
             {chapters.map((chapter, index) => (
               <Fragment key={chapter.slug}>
@@ -121,7 +124,10 @@ export async function ChapterList({
                   </EditorListItem>
                 </EditorSortableItem>
 
-                <EditorListInsertLine position={index + 1} />
+                <EditorListInsertLine
+                  aria-label={t("Insert chapter")}
+                  position={index + 1}
+                />
               </Fragment>
             ))}
           </EditorListContent>

--- a/apps/editor/src/components/editor-list.tsx
+++ b/apps/editor/src/components/editor-list.tsx
@@ -175,10 +175,12 @@ function EditorListContent({
 }
 
 function EditorListInsertLine({
+  "aria-label": ariaLabel,
   position,
   className,
   ...props
 }: Omit<React.ComponentProps<"div">, "onClick"> & {
+  "aria-label"?: string;
   position: number;
 }) {
   const { pending, handleInsert } = useEditorList();
@@ -193,6 +195,7 @@ function EditorListInsertLine({
         <div className="h-px flex-1 bg-primary/30" />
 
         <button
+          aria-label={ariaLabel}
           className="flex size-5 items-center justify-center rounded-full bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
           disabled={pending}
           onClick={() => handleInsert(position)}

--- a/biome.json
+++ b/biome.json
@@ -217,7 +217,7 @@
   },
   "overrides": [
     {
-      "includes": ["**/*.test.ts", "**/*.test.tsx"],
+      "includes": ["**/*.test.ts", "**/*.test.tsx", "**/e2e/**"],
       "linter": {
         "rules": {
           "performance": {

--- a/i18n.lock
+++ b/i18n.lock
@@ -30,7 +30,9 @@ checksums:
     Drag%20to%20reorder/singular: 42c84478eb582f41d72d5bd7b27bb028
     Try%20again/singular: 33dd8820e743e35a66e6977f69e9d3b5
     Add%20lesson/singular: 101a1880b35c68eed6f80e7574f4ff2d
+    Insert%20lesson/singular: 0d943237877e356d1c8aaca8b5360e67
     Add%20chapter/singular: af2ea03f1678fcea1fb005f66f28bfa5
+    Insert%20chapter/singular: cbd41a4782e1254a5c450577cbd7e95d
     We%20couldn't%20load%20the%20chapters.%20Please%20try%20again./singular: 2bfbac73debefc0d7a4ec5c41af9c415
     Failed%20to%20load%20chapters/singular: a462d90fffa946fe5c2aedb6e6fff9b4
     Course%20title%E2%80%A6/singular: 4429de50f5f2d426271e76328c543daf
@@ -98,7 +100,6 @@ checksums:
     Failed%20to%20export/singular: e1ed0bd77fc4509b338f2ed32565012a
     Upload%20a%20JSON%20file%20containing%20alternative%20titles%20to%20import./singular: 7dd18059ccf7955ba864342fdc0d6629
     Alternative%20titles%20imported%20successfully/singular: ca67e17d28382d5ef29bd27219a4104e
-    Available%20categories/singular: bcd678590ae6b4f047a6641bb3c15d6d
     Add%20category/singular: f1ef62efcd0e61cff264dd18047ebd6f
     Category%20options/singular: c968d0f8e27f746f50efeda29834ad74
     Categories/singular: fd4e44f3b1b2bba9ca45f3aef963d042


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds end-to-end tests for the chapter list covering display, insertion, reordering, and import/export. Introduces a shared import dialog helper and small a11y/i18n tweaks to support testing.

- **New Features**
  - Chapter list e2e coverage: renders positions/titles/descriptions, add chapter, insert in middle, drag-to-reorder with persistence, and JSON import/export (merge/replace) with file content checks.

- **Refactors**
  - Extracted reusable import dialog helper and updated alternative titles e2e to use it with safe file cleanup.
  - Added aria-label support to EditorListInsertLine and localized “Insert chapter/lesson” (en/es/pt).
  - Included e2e directory in Biome overrides.

<sup>Written for commit 2430c845135b72373dbe3617cedebe5b415d2623. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

