### PR TITLE
test(core): skip cache revalidation on e2e tests

### DIFF
--- a/packages/core/src/cache/revalidate-main-app.ts
+++ b/packages/core/src/cache/revalidate-main-app.ts
@@ -3,6 +3,7 @@ import "server-only";
 const vercelEnv = process.env.VERCEL_ENV;
 const isVercelEnv = Boolean(vercelEnv);
 const isVercelPreview = isVercelEnv && vercelEnv !== "production";
+const isE2ETesting = process.env.E2E_TESTING === "true";
 
 /**
  * Revalidates cache tags in the main app.
@@ -13,8 +14,7 @@ export async function revalidateMainApp(tags: string[]) {
   const url = `${process.env.NEXT_PUBLIC_MAIN_APP_URL}/api/revalidate`;
   const secret = process.env.REVALIDATE_SECRET;
 
-  if (isVercelPreview) {
-    console.info("Skipping revalidation in Vercel preview environment");
+  if (isVercelPreview || isE2ETesting) {
     return;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip cache revalidation during end-to-end tests to avoid external calls and test flakiness. revalidateMainApp now returns early when E2E_TESTING=true or in Vercel preview.

<sup>Written for commit b3fa0e2ae82bd4b032cfe81db4d5c18b3739820a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

