### PR TITLE
test(editor): improve locale switcher flaky tests

### DIFF
--- a/apps/editor/e2e/locale-switcher.test.ts
+++ b/apps/editor/e2e/locale-switcher.test.ts
@@ -7,6 +7,8 @@ async function openOrgDropdown(page: Page) {
 async function openLanguageSubmenu(page: Page) {
   await openOrgDropdown(page);
   await page.getByRole("menuitem", { name: /language/i }).click();
+  // Wait for submenu animation to complete (items are visible and stable)
+  await expect(page.getByRole("menuitem", { name: "English" })).toBeVisible();
 }
 
 test.describe("Locale Switcher", () => {
@@ -19,10 +21,13 @@ test.describe("Locale Switcher", () => {
   }) => {
     await openLanguageSubmenu(authenticatedPage);
 
-    // Switch to Portuguese
-    await authenticatedPage
-      .getByRole("menuitem", { name: "Português" })
-      .click();
+    // Switch to Portuguese - force click since submenu animations may cause instability
+    const portugueseItem = authenticatedPage.getByRole("menuitem", {
+      name: "Português",
+    });
+
+    await portugueseItem.click({ force: true });
+    await authenticatedPage.waitForLoadState("domcontentloaded");
 
     // Reopen to verify the Language menu item text changed
     await openOrgDropdown(authenticatedPage);
@@ -55,8 +60,13 @@ test.describe("Locale Switcher", () => {
   }) => {
     await openLanguageSubmenu(authenticatedPage);
 
-    // Switch to Spanish
-    await authenticatedPage.getByRole("menuitem", { name: "Español" }).click();
+    // Switch to Spanish - force click since submenu animations may cause instability
+    const spanishItem = authenticatedPage.getByRole("menuitem", {
+      name: "Español",
+    });
+
+    await spanishItem.click({ force: true });
+    await authenticatedPage.waitForLoadState("domcontentloaded");
 
     // Refresh the page
     await authenticatedPage.reload();


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes the editor locale switcher E2E by waiting for submenu visibility, force-clicking locale items after animations, and waiting for DOM load after switching. Adds concise anti-flake testing guidance to SKILL.md for animated menus, navigation waits, and safe use of force: true.

<sup>Written for commit 598d493384f01a1dce4b7a0814d154b5ca645071. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

