### PR TITLE
test(editor): improve slug checks and flaky tests

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -48,13 +48,14 @@ for i in {1..5}; do pnpm e2e -- -g "test name" --reporter=line; done
 
 **High-risk scenarios that commonly cause flakiness:**
 
-| Scenario                        | Risk                          | Prevention                                         |
-| ------------------------------- | ----------------------------- | -------------------------------------------------- |
-| Clicking dropdown/menu items    | Animations cause instability  | Wait for item visibility, use `force: true`        |
-| Actions that trigger navigation | Page reload detaches elements | Use `waitForLoadState` or `waitForURL` after click |
-| Form submissions                | Async save operations         | Wait for success indicator before next action      |
-| Clicking items in lists         | List may still be loading     | Wait for specific item with `toBeVisible()` first  |
-| Keyboard navigation             | Focus state transitions       | Wait for focused element before next key press     |
+| Scenario                         | Risk                          | Prevention                                         |
+| -------------------------------- | ----------------------------- | -------------------------------------------------- |
+| Clicking dropdown/menu items     | Animations cause instability  | Wait for item visibility, use `force: true`        |
+| Actions that trigger navigation  | Page reload detaches elements | Use `waitForLoadState` or `waitForURL` after click |
+| Form submissions                 | Async save operations         | Wait for success indicator before next action      |
+| Clicking items in lists          | List may still be loading     | Wait for specific item with `toBeVisible()` first  |
+| Keyboard navigation              | Focus state transitions       | Wait for focused element before next key press     |
+| Inputs with debounced validation | State changes between actions | Use `waitForLoadState("networkidle")` after fill   |
 
 **Defensive patterns for common interactions:**
 

--- a/apps/editor/e2e/chapter-content.test.ts
+++ b/apps/editor/e2e/chapter-content.test.ts
@@ -106,7 +106,7 @@ test.describe("Chapter Content Page", () => {
 
     await expect(
       authenticatedPage.getByRole("button", { name: /^save$/i }),
-    ).not.toBeVisible();
+    ).toBeDisabled();
   });
 
   test("saves valid slug and redirects", async ({ authenticatedPage }) => {

--- a/apps/editor/e2e/chapter-content.test.ts
+++ b/apps/editor/e2e/chapter-content.test.ts
@@ -152,10 +152,12 @@ test.describe("Chapter Content Page", () => {
     const uniqueSlug = `enter-test-${randomUUID().slice(0, 8)}`;
 
     await slugInput.fill(uniqueSlug);
+    await authenticatedPage.waitForLoadState("networkidle");
 
-    await expect(
-      authenticatedPage.getByRole("button", { name: /^save$/i }),
-    ).toBeEnabled();
+    const saveButton = authenticatedPage.getByRole("button", {
+      name: /^save$/i,
+    });
+    await expect(saveButton).toBeEnabled();
     await slugInput.press("Enter");
 
     await expect(authenticatedPage).toHaveURL(

--- a/apps/editor/e2e/course-content.test.ts
+++ b/apps/editor/e2e/course-content.test.ts
@@ -126,10 +126,12 @@ test.describe("Course Content Page", () => {
     const uniqueSlug = `enter-test-${randomUUID().slice(0, 8)}`;
 
     await slugInput.fill(uniqueSlug);
+    await authenticatedPage.waitForLoadState("networkidle");
 
-    await expect(
-      authenticatedPage.getByRole("button", { name: /^save$/i }),
-    ).toBeEnabled();
+    const saveButton = authenticatedPage.getByRole("button", {
+      name: /^save$/i,
+    });
+    await expect(saveButton).toBeEnabled();
     await slugInput.press("Enter");
 
     await expect(authenticatedPage).toHaveURL(

--- a/apps/editor/e2e/course-content.test.ts
+++ b/apps/editor/e2e/course-content.test.ts
@@ -84,7 +84,7 @@ test.describe("Course Content Page", () => {
 
     await expect(
       authenticatedPage.getByRole("button", { name: /^save$/i }),
-    ).not.toBeVisible();
+    ).toBeDisabled();
   });
 
   test("saves valid slug and redirects", async ({ authenticatedPage }) => {

--- a/apps/editor/e2e/lesson-content.test.ts
+++ b/apps/editor/e2e/lesson-content.test.ts
@@ -127,7 +127,7 @@ test.describe("Lesson Content Page", () => {
 
     await expect(
       authenticatedPage.getByRole("button", { name: /^save$/i }),
-    ).not.toBeVisible();
+    ).toBeDisabled();
   });
 
   test("saves valid slug and redirects", async ({ authenticatedPage }) => {

--- a/apps/editor/e2e/lesson-content.test.ts
+++ b/apps/editor/e2e/lesson-content.test.ts
@@ -184,10 +184,12 @@ test.describe("Lesson Content Page", () => {
     const uniqueSlug = `enter-test-${randomUUID().slice(0, 8)}`;
 
     await slugInput.fill(uniqueSlug);
+    await authenticatedPage.waitForLoadState("networkidle");
 
-    await expect(
-      authenticatedPage.getByRole("button", { name: /^save$/i }),
-    ).toBeEnabled();
+    const saveButton = authenticatedPage.getByRole("button", {
+      name: /^save$/i,
+    });
+    await expect(saveButton).toBeEnabled();
     await slugInput.press("Enter");
 
     await expect(authenticatedPage).toHaveURL(

--- a/apps/editor/src/app/[orgSlug]/new-course/use-course-form.ts
+++ b/apps/editor/src/app/[orgSlug]/new-course/use-course-form.ts
@@ -28,6 +28,7 @@ export function useCourseForm({ orgSlug }: { orgSlug: string }) {
 
   const slugExists = useSlugCheck({
     checkFn: checkSlugExists,
+    initialSlug: "",
     language: formData.language,
     orgSlug,
     slug: formData.slug,

--- a/apps/editor/src/components/slug-editor.tsx
+++ b/apps/editor/src/components/slug-editor.tsx
@@ -54,6 +54,7 @@ export function SlugEditor({
 
   const slugExists = useSlugCheck({
     checkFn,
+    initialSlug,
     language,
     orgSlug,
     slug,

--- a/apps/editor/src/hooks/use-slug-check.ts
+++ b/apps/editor/src/hooks/use-slug-check.ts
@@ -17,10 +17,11 @@ type SlugCheckFn = (params: SlugCheckParams) => Promise<boolean>;
  */
 export function useSlugCheck({
   checkFn,
+  initialSlug,
   language,
   orgSlug,
   slug,
-}: SlugCheckParams & { checkFn: SlugCheckFn }) {
+}: SlugCheckParams & { checkFn: SlugCheckFn; initialSlug: string }) {
   const [_isPending, startTransition] = useTransition();
   const [slugExists, setSlugExists] = useState(false);
 
@@ -36,7 +37,8 @@ export function useSlugCheck({
   );
 
   useEffect(() => {
-    if (!debouncedSlug.trim()) {
+    // Skip check if empty or if it matches the current entity's slug
+    if (!debouncedSlug.trim() || debouncedSlug.trim() === initialSlug.trim()) {
       setSlugExists(false);
       return;
     }
@@ -50,7 +52,7 @@ export function useSlugCheck({
 
       handleSlugCheck(debouncedSlug, exists);
     });
-  }, [checkFn, debouncedSlug, language, orgSlug]);
+  }, [checkFn, debouncedSlug, initialSlug, language, orgSlug]);
 
   return slugExists;
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved slug validation to ignore unchanged slugs and stabilized Save-on-Enter tests by waiting for network idle and checking the Save button’s disabled state. This reduces flaky tests and avoids unnecessary slug checks.

- **Bug Fixes**
  - Added initialSlug to useSlugCheck and skip checks when the slug is empty or unchanged.
  - Passed initialSlug through SlugEditor and the new course form (empty for new courses).
  - Stabilized e2e flows by waiting for network idle and asserting Save is disabled/enabled before pressing Enter.

<sup>Written for commit 7e5c3de70e873df8148c261667a2e42584b3c7de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

