### PR TITLE
chore(test): use dynamic ports on e2e tests

### DIFF
--- a/apps/editor/e2e/command-palette.test.ts
+++ b/apps/editor/e2e/command-palette.test.ts
@@ -375,22 +375,15 @@ test.describe("Command Palette - Accessibility", () => {
 
   test("search input has font-size >= 16px on mobile to prevent iOS Safari zoom", async ({
     browser,
+    baseURL,
   }) => {
     const context = await browser.newContext({
+      storageState: "e2e/.auth/owner.json",
       viewport: { height: 667, width: 375 },
     });
 
     const page = await context.newPage();
-
-    // Login as owner for this test
-    await page.goto("http://localhost:3003/api/auth/sign-in/email", {
-      waitUntil: "networkidle",
-    });
-    await page.request.post("http://localhost:3003/api/auth/sign-in/email", {
-      data: { email: "owner@zoonk.test", password: "password123" },
-    });
-
-    await page.goto("http://localhost:3003/ai");
+    await page.goto(`${baseURL}/ai`);
     await openCommandPalette(page);
 
     const input = page.getByPlaceholder(/search/i);

--- a/apps/editor/e2e/fixtures.ts
+++ b/apps/editor/e2e/fixtures.ts
@@ -1,5 +1,5 @@
 import type { Page } from "@zoonk/e2e/fixtures";
-import { test as base } from "@zoonk/e2e/fixtures";
+import { test as base, createAuthFixture } from "@zoonk/e2e/fixtures";
 
 export type EditorAuthFixtures = {
   authenticatedPage: Page;
@@ -10,46 +10,11 @@ export type EditorAuthFixtures = {
 };
 
 export const test = base.extend<EditorAuthFixtures>({
-  authenticatedPage: async ({ browser }, use) => {
-    const context = await browser.newContext({
-      storageState: "e2e/.auth/admin.json",
-    });
-    const page = await context.newPage();
-    await use(page);
-    await context.close();
-  },
-  memberPage: async ({ browser }, use) => {
-    const context = await browser.newContext({
-      storageState: "e2e/.auth/member.json",
-    });
-    const page = await context.newPage();
-    await use(page);
-    await context.close();
-  },
-  multiOrgPage: async ({ browser }, use) => {
-    const context = await browser.newContext({
-      storageState: "e2e/.auth/multiOrg.json",
-    });
-    const page = await context.newPage();
-    await use(page);
-    await context.close();
-  },
-  ownerPage: async ({ browser }, use) => {
-    const context = await browser.newContext({
-      storageState: "e2e/.auth/owner.json",
-    });
-    const page = await context.newPage();
-    await use(page);
-    await context.close();
-  },
-  userWithoutOrg: async ({ browser }, use) => {
-    const context = await browser.newContext({
-      storageState: "e2e/.auth/noOrg.json",
-    });
-    const page = await context.newPage();
-    await use(page);
-    await context.close();
-  },
+  authenticatedPage: createAuthFixture("e2e/.auth/admin.json"),
+  memberPage: createAuthFixture("e2e/.auth/member.json"),
+  multiOrgPage: createAuthFixture("e2e/.auth/multiOrg.json"),
+  ownerPage: createAuthFixture("e2e/.auth/owner.json"),
+  userWithoutOrg: createAuthFixture("e2e/.auth/noOrg.json"),
 });
 
 export { expect, type Page } from "@zoonk/e2e/fixtures";

--- a/apps/editor/e2e/global-setup.ts
+++ b/apps/editor/e2e/global-setup.ts
@@ -1,7 +1,5 @@
 import { mkdir } from "node:fs/promises";
-import { request } from "@zoonk/e2e/fixtures";
-
-const BASE_URL = "http://localhost:3003";
+import { getBaseURL, request } from "@zoonk/e2e/fixtures";
 
 export const E2E_USERS = {
   admin: {
@@ -30,7 +28,7 @@ async function authenticateUser(
   name: string,
   user: { email: string; password: string },
 ): Promise<void> {
-  const context = await request.newContext({ baseURL: BASE_URL });
+  const context = await request.newContext({ baseURL: getBaseURL() });
 
   const response = await context.post("/api/auth/sign-in/email", {
     data: {

--- a/apps/editor/playwright.config.ts
+++ b/apps/editor/playwright.config.ts
@@ -1,15 +1,6 @@
 import { createBaseConfig } from "@zoonk/e2e/base.config";
 
-const E2E_DATABASE_URL =
-  "postgres://postgres:postgres@localhost:5432/zoonk_e2e";
-
 export default createBaseConfig({
-  baseURL: "http://localhost:3003",
   globalSetup: "./e2e/global-setup.ts",
-  port: 3003,
   testDir: "./e2e",
-  webServerEnv: {
-    DATABASE_URL: E2E_DATABASE_URL,
-    DATABASE_URL_UNPOOLED: E2E_DATABASE_URL,
-  },
 });

--- a/apps/main/e2e/global-setup.ts
+++ b/apps/main/e2e/global-setup.ts
@@ -1,7 +1,5 @@
 import { mkdir } from "node:fs/promises";
-import { request } from "@zoonk/e2e/fixtures";
-
-const BASE_URL = "http://localhost:3000";
+import { getBaseURL, request } from "@zoonk/e2e/fixtures";
 
 export const E2E_USERS = {
   logout: {
@@ -22,7 +20,7 @@ async function authenticateUser(
   name: string,
   user: { email: string; password: string },
 ): Promise<void> {
-  const context = await request.newContext({ baseURL: BASE_URL });
+  const context = await request.newContext({ baseURL: getBaseURL() });
 
   const response = await context.post("/api/auth/sign-in/email", {
     data: {

--- a/apps/main/playwright.config.ts
+++ b/apps/main/playwright.config.ts
@@ -1,15 +1,6 @@
 import { createBaseConfig } from "@zoonk/e2e/base.config";
 
-const E2E_DATABASE_URL =
-  "postgres://postgres:postgres@localhost:5432/zoonk_e2e";
-
 export default createBaseConfig({
-  baseURL: "http://localhost:3000",
   globalSetup: "./e2e/global-setup.ts",
-  port: 3000,
   testDir: "./e2e",
-  webServerEnv: {
-    DATABASE_URL: E2E_DATABASE_URL,
-    DATABASE_URL_UNPOOLED: E2E_DATABASE_URL,
-  },
 });

--- a/packages/e2e/src/base.config.ts
+++ b/packages/e2e/src/base.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig, devices } from "@playwright/test";
 
 type BaseConfigOptions = {
-  baseURL: string;
   globalSetup?: string;
-  port: number;
   testDir: string;
   webServerEnv?: Record<string, string>;
 };
+
+const E2E_DATABASE_URL =
+  "postgres://postgres:postgres@localhost:5432/zoonk_e2e";
 
 export function createBaseConfig(options: BaseConfigOptions) {
   return defineConfig({
@@ -25,20 +26,25 @@ export function createBaseConfig(options: BaseConfigOptions) {
     retries: process.env.CI ? 2 : 0,
     testDir: options.testDir,
     use: {
-      baseURL: options.baseURL,
       screenshot: "only-on-failure",
       trace: "on-first-retry",
       video: "retain-on-failure",
     },
     webServer: {
-      command: `pnpm start -p ${options.port}`,
+      command: "pnpm start -p 0",
       env: {
+        DATABASE_URL: E2E_DATABASE_URL,
+        DATABASE_URL_UNPOOLED: E2E_DATABASE_URL,
         E2E_TESTING: "true",
         ...options.webServerEnv,
       },
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
-      url: options.baseURL,
+      // Capture port from Next.js stdout: "- Local: http://localhost:12345"
+      wait: {
+        stdout:
+          /-\s+Local:\s+(?<E2E_BASE_URL>http:\/\/localhost:(?<E2E_PORT>\d+))/,
+      },
     },
   });
 }

--- a/packages/e2e/src/fixtures/index.ts
+++ b/packages/e2e/src/fixtures/index.ts
@@ -1,12 +1,11 @@
 export {
   type AuthFixtures,
-  createAuthContext,
+  createAuthFixture,
   createStorageStateFixtures,
   expect,
+  getBaseURL,
   type Page,
   request,
   type StorageStateConfig,
-  signIn,
-  type TestUser,
   test,
 } from "./auth";

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -15,6 +15,6 @@
     "skipLibCheck": true,
     "strict": true,
     "strictNullChecks": true,
-    "target": "ES2017"
+    "target": "ES2020"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -54,7 +54,7 @@
       "persistent": true
     },
     "e2e": {
-      "passThroughEnv": ["PLAYWRIGHT_*"]
+      "passThroughEnv": ["PLAYWRIGHT_*", "E2E_BASE_URL"]
     },
     "start": {
       "cache": false,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Run e2e tests on dynamic ports and pass the runtime baseURL to tests and fixtures to avoid port conflicts and flaky runs. Also simplified auth fixtures and removed hardcoded localhost URLs.

- **Refactors**
  - Start webServer with -p 0 and capture E2E_BASE_URL from Next.js stdout.
  - Remove baseURL/port from app Playwright configs; move DB env to shared base config.
  - Extend test to provide baseURL; add getBaseURL() helper.
  - Replace hardcoded URLs with baseURL across tests and global setups.
  - Add createAuthFixture and use storage state files for auth pages.
  - Drop signIn/createAuthContext helpers in favor of storage states.
  - Pass E2E_BASE_URL through Turbo; update TS target to ES2020.

- **Migration**
  - Update any tests using localhost URLs to use the baseURL fixture or getBaseURL().
  - Ensure global-setup generates storage states in e2e/.auth.

<sup>Written for commit 5f20b3675dc7ed39579ea7acdc30d00f13dd7fa0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

