### PR TITLE
test(auth): set up e2e tests for auth app

### DIFF
--- a/apps/auth/.gitignore
+++ b/apps/auth/.gitignore
@@ -12,6 +12,7 @@
 
 # testing
 /coverage
+e2e/.auth/
 
 # next.js
 /.next/

--- a/apps/auth/e2e/fixtures.ts
+++ b/apps/auth/e2e/fixtures.ts
@@ -1,0 +1,1 @@
+export { expect, type Page, test } from "@zoonk/e2e/fixtures";

--- a/apps/auth/e2e/global-setup.ts
+++ b/apps/auth/e2e/global-setup.ts
@@ -1,0 +1,5 @@
+import { mkdir } from "node:fs/promises";
+
+export default async function globalSetup(): Promise<void> {
+  await mkdir("e2e/.auth", { recursive: true });
+}

--- a/apps/auth/e2e/login.test.ts
+++ b/apps/auth/e2e/login.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "./fixtures";
+
+test.describe("Login Page", () => {
+  test("displays login form with email input and social buttons", async ({
+    page,
+  }) => {
+    await page.goto("/en/login");
+
+    // Verify heading
+    await expect(
+      page.getByRole("heading", { name: /sign in or create an account/i }),
+    ).toBeVisible();
+
+    // Verify email form elements
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+
+    await expect(
+      page.getByRole("button", { name: /^continue$/i }),
+    ).toBeVisible();
+
+    // Verify social login buttons
+    await expect(
+      page.getByRole("button", { name: /continue with google/i }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole("button", { name: /continue with apple/i }),
+    ).toBeVisible();
+  });
+});

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -16,6 +16,7 @@
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@zoonk/e2e": "workspace:*",
     "@zoonk/tsconfig": "workspace:*",
     "babel-plugin-react-compiler": "1.0.0",
     "typescript": "^5"
@@ -25,7 +26,10 @@
   "scripts": {
     "analyze": "next experimental-analyze",
     "build": "next build",
+    "build:e2e": "E2E_TESTING=true next build",
     "dev": "next dev -p 3004",
+    "e2e": "env $(cat .env.e2e | xargs) playwright test",
+    "e2e:ui": "env $(cat .env.e2e | xargs) playwright test --ui",
     "start": "next start -p 3004",
     "typecheck": "next typegen && tsc --noEmit"
   },

--- a/apps/auth/playwright.config.ts
+++ b/apps/auth/playwright.config.ts
@@ -1,0 +1,6 @@
+import { createBaseConfig } from "@zoonk/e2e/base.config";
+
+export default createBaseConfig({
+  globalSetup: "./e2e/global-setup.ts",
+  testDir: "./e2e",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.7)
+      '@zoonk/e2e':
+        specifier: workspace:*
+        version: link:../../packages/e2e
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set up Playwright e2e tests for the auth app using shared @zoonk/e2e fixtures. Added a login page UI test and scripts to build and run the suite.

- **New Features**
  - Playwright config with global setup to create e2e/.auth.
  - Shared fixtures re-export for tests.
  - Login test checks heading, email field, Continue, Google, and Apple buttons.
  - New scripts: build:e2e, e2e, e2e:ui (loads env from .env.e2e).
  - .gitignore updated to ignore e2e/.auth.

- **Dependencies**
  - Added @zoonk/e2e (workspace).

<sup>Written for commit 36cea5b4f0ce4b5428411ffaebed1382d90a49ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

