### PR TITLE
test(auth): add ci workflow

### DIFF
--- a/.github/workflows/e2e-auth.yml
+++ b/.github/workflows/e2e-auth.yml
@@ -1,0 +1,90 @@
+name: E2E Tests (Auth App)
+
+on: push
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: 24
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      BETTER_AUTH_SECRET: test-secret-for-ci
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/zoonk_e2e
+      DATABASE_URL_UNPOOLED: postgres://postgres:postgres@localhost:5432/zoonk_e2e
+      E2E_TESTING: "true"
+      NEXT_PUBLIC_APP_DOMAIN: localhost:3004
+      NEXT_PUBLIC_AUTH_APP_URL: http://localhost:3004
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
+    services:
+      db:
+        image: postgres:17-alpine
+        ports: ["5432:5432"]
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: zoonk_e2e
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 1s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-turbo-
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: apps/auth/.next-e2e/cache
+          key: ${{ runner.os }}-nextjs-auth-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('apps/auth/**/*.ts', 'apps/auth/**/*.tsx', 'packages/**/*.ts', 'packages/**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-auth-${{ hashFiles('**/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-auth-
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+        with:
+          version: 10.27.0
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Setup database
+        run: pnpm --filter @zoonk/db db:setup:e2e
+
+      - name: Generate Prisma client
+        run: pnpm --filter @zoonk/db db:generate:e2e
+
+      - name: Seed database
+        run: pnpm --filter @zoonk/db db:seed:e2e
+
+      - name: Build app
+        run: pnpm build:e2e --filter auth
+
+      - name: Run E2E tests
+        run: pnpm e2e --filter auth


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a GitHub Actions workflow to run Auth app E2E tests on every push. Spins up Postgres, prepares the E2E DB, builds the app, and runs Playwright tests with caching to speed up CI.

- **New Features**
  - Triggers on push with a 30-minute timeout.
  - Node 24 + pnpm; installs Playwright Chromium.
  - Starts Postgres 17-alpine and sets E2E env vars.
  - Runs DB setup/generate/seed via @zoonk/db.
  - Caches Turbo and Next.js build output.
  - Builds and tests only the auth app via pnpm filters.

<sup>Written for commit 168003248d2eb6e91f26c556c00f8706950186ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

