### PR TITLE
test(main): add e2e tests for the settings navbar

### DIFF
--- a/apps/main/e2e/settings-navbar.test.ts
+++ b/apps/main/e2e/settings-navbar.test.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "./fixtures";
+
+test.describe("Settings Navbar", () => {
+  test("home link navigates to home page", async ({ page }) => {
+    await page.goto("/settings");
+    await page.getByRole("link", { name: /home page/i }).click();
+
+    await expect(
+      page.getByRole("heading", { name: /learn anything with ai/i }),
+    ).toBeVisible();
+  });
+
+  test("dropdown Settings item navigates to settings page", async ({
+    page,
+  }) => {
+    await page.goto("/subscription");
+    await page.getByRole("button", { name: /subscription/i }).click();
+    await page.getByRole("menuitem", { name: /^settings$/i }).click();
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: /settings/i }),
+    ).toBeVisible();
+  });
+
+  test("dropdown Subscription item navigates to subscription page", async ({
+    page,
+  }) => {
+    await page.goto("/settings");
+    await page.getByRole("button", { name: /settings/i }).click();
+    await page.getByRole("menuitem", { name: /subscription/i }).click();
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: /subscription/i }),
+    ).toBeVisible();
+  });
+
+  test("dropdown Language item navigates to language page", async ({
+    page,
+  }) => {
+    await page.goto("/settings");
+    await page.getByRole("button", { name: /settings/i }).click();
+    await page.getByRole("menuitem", { name: /language/i }).click();
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: /language/i }),
+    ).toBeVisible();
+  });
+
+  test("dropdown Display name item navigates to name page", async ({
+    page,
+  }) => {
+    await page.goto("/settings");
+    await page.getByRole("button", { name: /settings/i }).click();
+    await page.getByRole("menuitem", { name: /display name/i }).click();
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: /display name/i }),
+    ).toBeVisible();
+  });
+
+  test("dropdown Support item navigates to support page", async ({ page }) => {
+    await page.goto("/settings");
+    await page.getByRole("button", { name: /settings/i }).click();
+    await page.getByRole("menuitem", { name: /support/i }).click();
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: /help.*support/i }),
+    ).toBeVisible();
+  });
+
+  test("logout button logs user out", async ({ logoutPage }) => {
+    await logoutPage.goto("/settings");
+
+    await expect(
+      logoutPage.getByRole("link", { name: /logout/i }),
+    ).toBeVisible();
+
+    await Promise.all([
+      logoutPage.waitForURL(/^[^?]*\/$/),
+      logoutPage.waitForResponse(
+        (response) =>
+          response.url().includes("/api/auth/get-session") &&
+          response.status() === 200,
+      ),
+      logoutPage.getByRole("link", { name: /logout/i }).click(),
+    ]);
+
+    await logoutPage.getByRole("button", { name: /search/i }).click();
+
+    await expect(
+      logoutPage.getByRole("dialog").getByText(/^login$/i),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add end-to-end tests for the Settings navbar to ensure navigation works and logout behaves correctly. Covers the Home link, dropdown routes (Settings, Subscription, Language, Display Name, Support), and logout redirect with login prompt.

<sup>Written for commit f25e92edca097b02c5a5f81080190de689b1f8b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

