### PR TITLE
test(auth): add e2e tests for otp flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Zoonk is a web app where users can learn anything using AI. This app uses AI to 
 - Prefer short and composable functions
 - Prefer functional programming over OOP
 - Use meaningful variable names and avoid abbreviations
+- Never guess at imports, table names, or conventions—always search for existing patterns first
 
 ## Design Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Zoonk is a web app where users can learn anything using AI. This app uses AI to 
 - Prefer short and composable functions
 - Prefer functional programming over OOP
 - Use meaningful variable names and avoid abbreviations
+- Never guess at imports, table names, or conventions—always search for existing patterns first
 
 ## Design Style
 

--- a/apps/auth/.env.e2e
+++ b/apps/auth/.env.e2e
@@ -1,0 +1,2 @@
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/zoonk_e2e
+DATABASE_URL_UNPOOLED=postgres://postgres:postgres@localhost:5432/zoonk_e2e

--- a/apps/auth/.gitignore
+++ b/apps/auth/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
+!.env.e2e
 
 # vercel
 .vercel

--- a/apps/auth/e2e/helpers/db.ts
+++ b/apps/auth/e2e/helpers/db.ts
@@ -1,0 +1,55 @@
+import { setTimeout } from "node:timers/promises";
+import { prisma } from "@zoonk/db";
+
+/**
+ * Get the latest OTP for an email from the Verification table.
+ * Only works when emailOTP plugin is configured with `storeOTP: "plain"`.
+ * Retries a few times to handle timing issues.
+ *
+ * Note: Better Auth stores the identifier as `sign-in-otp-{email}` and
+ * the value as `{otp}:{attemptCount}`.
+ */
+export async function getOTPForEmail(
+  email: string,
+  maxRetries = 10,
+): Promise<string | null> {
+  const identifier = `sign-in-otp-${email}`;
+
+  for (let i = 0; i < maxRetries; i++) {
+    // biome-ignore lint/performance/noAwaitInLoops: Sequential retry with delay is intentional
+    const verification = await prisma.verification.findFirst({
+      orderBy: { createdAt: "desc" },
+      where: { identifier },
+    });
+
+    if (verification?.value) {
+      // Value format is "123456:0" - extract just the OTP code
+      const otp = verification.value.split(":")[0];
+
+      if (otp) {
+        return otp;
+      }
+    }
+
+    await setTimeout(500);
+  }
+
+  return null;
+}
+
+/**
+ * Clean up verifications for an email (useful for test cleanup).
+ */
+export async function cleanupVerifications(email: string): Promise<void> {
+  const identifier = `sign-in-otp-${email}`;
+  await prisma.verification.deleteMany({
+    where: { identifier },
+  });
+}
+
+/**
+ * Disconnect the Prisma client (call after tests).
+ */
+export async function disconnectDb(): Promise<void> {
+  await prisma.$disconnect();
+}

--- a/apps/auth/e2e/otp.test.ts
+++ b/apps/auth/e2e/otp.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "./fixtures";
+import {
+  cleanupVerifications,
+  disconnectDb,
+  getOTPForEmail,
+} from "./helpers/db";
+
+const TEST_EMAIL = `e2e-otp-${Date.now()}@zoonk.test`;
+const REDIRECT_URL = "http://localhost:3000/test";
+
+test.describe("OTP Login Flow", () => {
+  test.afterAll(async () => {
+    await cleanupVerifications(TEST_EMAIL);
+    await disconnectDb();
+  });
+
+  test("completes email submission and shows OTP page", async ({ page }) => {
+    await page.goto(`/en/login?redirectTo=${encodeURIComponent(REDIRECT_URL)}`);
+    await page.getByLabel(/email/i).fill(TEST_EMAIL);
+    await page.getByRole("button", { name: /^continue$/i }).click();
+    await page.waitForURL(/\/otp/);
+
+    await expect(
+      page.getByRole("heading", { name: /check your email/i }),
+    ).toBeVisible();
+
+    await expect(page.getByText(TEST_EMAIL)).toBeVisible();
+  });
+
+  test("validates OTP and redirects with token", async ({ page }) => {
+    await page.goto(`/en/login?redirectTo=${encodeURIComponent(REDIRECT_URL)}`);
+    await page.getByLabel(/email/i).fill(TEST_EMAIL);
+    await page.getByRole("button", { name: /^continue$/i }).click();
+    await page.waitForURL(/\/otp/);
+
+    const otp = await getOTPForEmail(TEST_EMAIL);
+
+    if (!otp) {
+      throw new Error("OTP not found in database");
+    }
+
+    const redirectPromise = page.waitForRequest((request) => {
+      const url = request.url();
+      return url.startsWith(REDIRECT_URL) && url.includes("token=");
+    });
+
+    await page.getByRole("textbox").click();
+    await page.keyboard.type(otp);
+    await page.getByRole("button", { name: /^continue$/i }).click();
+
+    const redirectRequest = await redirectPromise;
+    const redirectUrl = new URL(redirectRequest.url());
+
+    expect(redirectUrl.origin + redirectUrl.pathname).toBe(REDIRECT_URL);
+    expect(redirectUrl.searchParams.get("token")).toBeTruthy();
+  });
+
+  test("shows error for invalid OTP", async ({ page }) => {
+    await page.goto(`/en/login?redirectTo=${encodeURIComponent(REDIRECT_URL)}`);
+    await page.getByLabel(/email/i).fill(TEST_EMAIL);
+    await page.getByRole("button", { name: /^continue$/i }).click();
+    await page.waitForURL(/\/otp/);
+
+    await page.getByRole("textbox").click();
+    await page.keyboard.type("000000");
+    await page.getByRole("button", { name: /^continue$/i }).click();
+
+    await expect(page.getByText(/incorrect/i)).toBeVisible();
+  });
+
+  test("allows changing email (back to login)", async ({ page }) => {
+    await page.goto(
+      `/en/otp?email=${encodeURIComponent(TEST_EMAIL)}&redirectTo=${encodeURIComponent(REDIRECT_URL)}`,
+    );
+    await page.getByRole("link", { name: /change email/i }).click();
+    await page.waitForURL(/\/login/);
+
+    await expect(
+      page.getByRole("heading", { name: /sign in or create an account/i }),
+    ).toBeVisible();
+  });
+});

--- a/apps/auth/next.config.ts
+++ b/apps/auth/next.config.ts
@@ -24,7 +24,7 @@ const nextConfig: NextConfig = {
     resolveAlias: {
       ...e2eAliases,
     },
-    root: path.resolve(__dirname, "../.."),
+    root: path.resolve(import.meta.dirname, "../.."),
   },
 };
 

--- a/apps/auth/next.config.ts
+++ b/apps/auth/next.config.ts
@@ -1,15 +1,31 @@
+import path from "node:path";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
+
+const isE2E = process.env.E2E_TESTING === "true";
+
+// Swap @zoonk/auth for E2E-specific config during E2E builds
+const e2eAliases: Record<string, string> = isE2E
+  ? { "@zoonk/auth": "../../packages/auth/src/e2e.ts" }
+  : {};
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
   devIndicators: false,
+  // Use separate build directories so E2E and production builds don't conflict
+  distDir: isE2E ? ".next-e2e" : ".next",
   experimental: {
     authInterrupts: true,
     turbopackFileSystemCacheForBuild: true,
     typedEnv: true,
   },
   reactCompiler: true,
+  turbopack: {
+    resolveAlias: {
+      ...e2eAliases,
+    },
+    root: path.resolve(__dirname, "../.."),
+  },
 };
 
 const withNextIntl = createNextIntlPlugin({

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -16,6 +16,7 @@
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@zoonk/db": "workspace:*",
     "@zoonk/e2e": "workspace:*",
     "@zoonk/tsconfig": "workspace:*",
     "babel-plugin-react-compiler": "1.0.0",

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -42,7 +42,7 @@ const nextConfig: NextConfig = {
     resolveAlias: {
       ...e2eAliases,
     },
-    root: path.resolve(__dirname, "../.."),
+    root: path.resolve(import.meta.dirname, "../.."),
   },
   typedRoutes: true,
 };

--- a/apps/evals/next.config.ts
+++ b/apps/evals/next.config.ts
@@ -16,7 +16,7 @@ const nextConfig: NextConfig = {
   pageExtensions: ["ts", "tsx"],
   reactCompiler: true,
   turbopack: {
-    root: path.resolve(__dirname, "../.."),
+    root: path.resolve(import.meta.dirname, "../.."),
     rules: {
       // Allow to import MDX files used for AI prompts
       "*.md": {

--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -50,7 +50,7 @@ const nextConfig: NextConfig = {
     resolveAlias: {
       ...e2eAliases,
     },
-    root: path.resolve(__dirname, "../.."),
+    root: path.resolve(import.meta.dirname, "../.."),
     rules: {
       // Allow to import MDX files used for AI prompts
       "*.md": {

--- a/packages/e2e/src/base.config.ts
+++ b/packages/e2e/src/base.config.ts
@@ -38,7 +38,6 @@ export function createBaseConfig(options: BaseConfigOptions) {
         E2E_TESTING: "true",
         ...options.webServerEnv,
       },
-      reuseExistingServer: !process.env.CI,
       timeout: 120_000,
       // Capture port from Next.js stdout: "- Local: http://localhost:12345"
       wait: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.7)
+      '@zoonk/db':
+        specifier: workspace:*
+        version: link:../../packages/db
       '@zoonk/e2e':
         specifier: workspace:*
         version: link:../../packages/e2e


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add end-to-end tests for the email OTP login flow, covering submit, verify, error states, and changing email. Uses an e2e auth config that stores OTPs in plain text and isolates e2e builds.

- **New Features**
  - Tests the flow: email submission → OTP screen → valid OTP redirects with token.
  - Validates error handling for invalid OTP.
  - Supports returning to login via “change email.”
  - DB helpers to fetch latest OTP from prisma.verification, clean up records, and disconnect.

- **Refactors**
  - E2E auth config: overrides emailOTP to store OTP as plain text, custom sendVerificationOTP, disables rate limiting, uses plain password match.
  - Next.js: E2E_TESTING toggles distDir to .next-e2e and aliases @zoonk/auth to e2e.ts; sets Turbopack resolve alias and root.
  - E2E base config: removes server reuse to avoid flaky runs.
  - Adds @zoonk/db to apps/auth for Prisma access; commits .env.e2e for test DB setup.

<sup>Written for commit c160f8dc0696c119d2f70621dc983d9666a7c554. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

