### PR TITLE
test(main): add e2e tests to name form

### DIFF
--- a/apps/main/e2e/name.test.ts
+++ b/apps/main/e2e/name.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "./fixtures";
+
+test.describe("Display name settings page", () => {
+  test("shows login prompt for unauthenticated users", async ({ page }) => {
+    await page.goto("/name");
+
+    await expect(page.getByText(/you need to be logged in/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: /login/i })).toBeVisible();
+  });
+
+  test("updates display name successfully", async ({ authenticatedPage }) => {
+    await authenticatedPage.goto("/name");
+
+    const nameInput = authenticatedPage.getByLabel(/name/i);
+    await nameInput.clear();
+    await nameInput.fill("New Test Name");
+
+    await authenticatedPage
+      .getByRole("button", { name: /update name/i })
+      .click();
+
+    await expect(
+      authenticatedPage.getByText(/your name has been updated successfully/i),
+    ).toBeVisible();
+
+    // Verify name persists after reload
+    await authenticatedPage.reload();
+
+    await expect(authenticatedPage.getByLabel(/name/i)).toHaveValue(
+      "New Test Name",
+    );
+  });
+
+  test("shows error for whitespace-only name", async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto("/name");
+
+    const nameInput = authenticatedPage.getByLabel(/name/i);
+    const originalName = await nameInput.inputValue();
+
+    await nameInput.clear();
+    await nameInput.fill("   "); // Whitespace passes HTML5 required but fails server validation
+
+    await authenticatedPage
+      .getByRole("button", { name: /update name/i })
+      .click();
+
+    await expect(authenticatedPage.getByRole("alert")).toBeVisible();
+
+    await expect(
+      authenticatedPage.getByText(/failed to update your name/i),
+    ).toBeVisible();
+
+    // Verify name wasn't updated after reload
+    await authenticatedPage.reload();
+
+    await expect(authenticatedPage.getByLabel(/name/i)).toHaveValue(
+      originalName,
+    );
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added end-to-end tests for the display name settings page and updated testing docs for Server Actions. This increases coverage and clarifies how to test server-side validations.

- **New Features**
  - Unauthenticated users see a login prompt on /name.
  - Successful name update shows a success message and persists after reload.
  - Whitespace-only input triggers an error alert and does not change the saved name.

<sup>Written for commit 510814da1ec86ab8175767ca45304e0246fedd7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

