### PR TITLE
test: remove e2e vars duplication

### DIFF
--- a/apps/auth/.env.e2e
+++ b/apps/auth/.env.e2e
@@ -1,2 +1,0 @@
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/zoonk_e2e
-DATABASE_URL_UNPOOLED=postgres://postgres:postgres@localhost:5432/zoonk_e2e

--- a/apps/auth/.gitignore
+++ b/apps/auth/.gitignore
@@ -34,7 +34,6 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
-!.env.e2e
 
 # vercel
 .vercel

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -27,10 +27,10 @@
   "scripts": {
     "analyze": "next experimental-analyze",
     "build": "next build",
-    "build:e2e": "E2E_TESTING=true next build",
+    "build:e2e": "env $(cat ../../packages/db/.env.e2e | xargs) next build",
     "dev": "next dev -p 3004",
-    "e2e": "env $(cat .env.e2e | xargs) playwright test",
-    "e2e:ui": "env $(cat .env.e2e | xargs) playwright test --ui",
+    "e2e": "env $(cat ../../packages/db/.env.e2e | xargs) playwright test",
+    "e2e:ui": "env $(cat ../../packages/db/.env.e2e | xargs) playwright test --ui",
     "start": "next start -p 3004",
     "typecheck": "next typegen && tsc --noEmit"
   },

--- a/apps/editor/.env.e2e
+++ b/apps/editor/.env.e2e
@@ -1,2 +1,0 @@
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/zoonk_e2e
-DATABASE_URL_UNPOOLED=postgres://postgres:postgres@localhost:5432/zoonk_e2e

--- a/apps/editor/.gitignore
+++ b/apps/editor/.gitignore
@@ -34,7 +34,6 @@ yarn-error.log*
 .env*
 !.env.example
 !.env.test
-!.env.e2e
 
 # vercel
 .vercel

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -39,10 +39,10 @@
   "scripts": {
     "analyze": "next experimental-analyze",
     "build": "next build",
-    "build:e2e": "E2E_TESTING=true next build",
+    "build:e2e": "env $(cat ../../packages/db/.env.e2e | xargs) next build",
     "dev": "next dev -p 3003",
-    "e2e": "env $(cat .env.e2e | xargs) playwright test",
-    "e2e:ui": "env $(cat .env.e2e | xargs) playwright test --ui",
+    "e2e": "env $(cat ../../packages/db/.env.e2e | xargs) playwright test",
+    "e2e:ui": "env $(cat ../../packages/db/.env.e2e | xargs) playwright test --ui",
     "start": "next start -p 3003",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/apps/main/.env.e2e
+++ b/apps/main/.env.e2e
@@ -1,2 +1,0 @@
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/zoonk_e2e
-DATABASE_URL_UNPOOLED=postgres://postgres:postgres@localhost:5432/zoonk_e2e

--- a/apps/main/.gitignore
+++ b/apps/main/.gitignore
@@ -37,7 +37,6 @@ yarn-error.log*
 .env*
 !.env.example
 !.env.test
-!.env.e2e
 
 # vercel
 .vercel

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -41,10 +41,10 @@
   "scripts": {
     "analyze": "next experimental-analyze",
     "build": "bash scripts/maybe-migrate.sh && next build",
-    "build:e2e": "E2E_TESTING=true next build",
+    "build:e2e": "env $(cat ../../packages/db/.env.e2e | xargs) next build",
     "dev": "next dev",
-    "e2e": "env $(cat .env.e2e | xargs) playwright test",
-    "e2e:ui": "env $(cat .env.e2e | xargs) playwright test --ui",
+    "e2e": "env $(cat ../../packages/db/.env.e2e | xargs) playwright test",
+    "e2e:ui": "env $(cat ../../packages/db/.env.e2e | xargs) playwright test --ui",
     "start": "next start",
     "stripe:listen": "stripe listen --forward-to http://localhost:3000/api/auth/stripe/webhook",
     "test": "vitest run",

--- a/packages/db/.env.e2e
+++ b/packages/db/.env.e2e
@@ -1,2 +1,3 @@
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/zoonk_e2e
 DATABASE_URL_UNPOOLED=postgres://postgres:postgres@localhost:5432/zoonk_e2e
+E2E_TESTING=true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Centralized e2e environment variables into packages/db/.env.e2e and updated app scripts to source it. This removes duplicated env files and keeps E2E_TESTING consistent across apps.

- **Refactors**
  - Removed per-app .env.e2e files (auth, editor, main).
  - Updated build:e2e and e2e scripts to source ../../packages/db/.env.e2e.
  - Added E2E_TESTING=true to the shared env file.
  - Cleaned .gitignore entries that whitelisted app-level .env.e2e.

- **Migration**
  - If you had custom app-level e2e envs, move them to packages/db/.env.e2e.
  - Run e2e commands as usual; they now read from the shared file.

<sup>Written for commit 98ff967cf6bfb62cffdaa40b1cc8d98885684514. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

