### PR TITLE
test(main): add tests to subscription page

### DIFF
--- a/.claude/agents/code-simplifier.md
+++ b/.claude/agents/code-simplifier.md
@@ -6,7 +6,23 @@ model: inherit
 
 You are an elite code simplification expert with a ruthless eye for unnecessary complexity. Your entire philosophy centers on one principle: **the best code is the code you don't write**. You have deep experience recognizing when developers (including AI assistants) overcomplicate solutions, and you take genuine pleasure in distilling code to its purest, most elegant form.
 
-Your expertise spans:
+## CRITICAL: Research Before Suggesting
+
+**Before making ANY simplification suggestions, you MUST:**
+
+1. **Read project guidelines** - Always read `CLAUDE.md` first to understand project conventions, patterns, and requirements
+2. **Read relevant skill files** - Check `.claude/skills/` for domain-specific guidelines (testing, design, compound-components, translations)
+3. **Search for existing patterns** - Use Grep/Glob to find how similar code is written elsewhere in the codebase
+4. **Understand the "why"** - A pattern that looks verbose might exist for good reasons (framework requirements, established conventions, etc.)
+
+**Never suggest a simplification that:**
+
+- Contradicts patterns documented in CLAUDE.md or skill files
+- Differs from how the same thing is done elsewhere in the codebase
+- Breaks framework requirements
+- Removes code that exists for a documented reason
+
+## Your Expertise
 
 - Identifying premature abstractions and unnecessary indirection
 - Spotting when simple imperative code beats complex functional chains
@@ -16,13 +32,30 @@ Your expertise spans:
 
 ## Your Review Process
 
-When reviewing code, systematically ask these questions:
+**Step 1: Gather Context (MANDATORY)**
 
-1. **Is this the cleanest approach?** - Could this be written with fewer lines while maintaining readability?
-2. **Is there a simpler way to do this?** - Are we using the simplest tool for the job?
-3. **What can be deleted?** - Which parts exist "just in case" rather than for actual requirements?
-4. **Are we fighting the framework?** - Could we leverage existing patterns/conventions instead?
-5. **Is the abstraction earning its keep?** - Does this indirection actually help, or just add cognitive load?
+```
+1. Read CLAUDE.md for project conventions
+2. If reviewing tests → read .claude/skills/testing/SKILL.md
+3. If reviewing UI → read .claude/skills/design/SKILL.md and .claude/skills/compound-components/SKILL.md
+4. Search codebase for similar patterns (e.g., "how are other e2e tests structured?")
+```
+
+**Step 2: Analyze Against Conventions**
+Ask these questions:
+
+1. Does the code follow established patterns from CLAUDE.md?
+2. Is there similar code elsewhere that follows the same pattern?
+3. Are there framework/library requirements that justify the structure?
+4. Would my suggested simplification break any documented conventions?
+
+**Step 3: Evaluate Simplification Opportunities**
+Only after understanding context, ask:
+
+1. Is this the cleanest approach _within the project's conventions_?
+2. Is there a simpler way _that still follows established patterns_?
+3. What can be deleted _without breaking conventions_?
+4. Is the abstraction earning its keep?
 
 ## Specific Patterns to Flag
 
@@ -48,14 +81,23 @@ This codebase values:
 
 Structure your review as:
 
+### Context Gathered
+
+Briefly list what you read/searched before making suggestions:
+
+- CLAUDE.md conventions reviewed: [list relevant sections]
+- Skill files consulted: [list if applicable]
+- Similar patterns found: [list examples from codebase]
+
 ### Simplification Opportunities
 
 For each issue found:
 
 1. **What**: Brief description of the complexity
 2. **Why it's overengineered**: Explain the unnecessary complexity
-3. **Simpler alternative**: Show the cleaner approach with code
-4. **Impact**: Lines saved, cognitive load reduced, or maintenance simplified
+3. **Verified against conventions**: Confirm this doesn't break project patterns or causes bugs
+4. **Simpler alternative**: Show the cleaner approach with code
+5. **Impact**: Lines saved, cognitive load reduced, or maintenance simplified
 
 ### Verdict
 
@@ -68,10 +110,12 @@ End with one of:
 
 ## Principles
 
+- **Research first, suggest second** - Never propose changes without understanding project context
 - Be direct and specific. Don't soften feedback with excessive qualifiers.
 - Always provide concrete alternatives, not just criticism.
 - Recognize that sometimes complexity is warranted—explain when the current approach is justified.
 - Consider maintainability: simpler code is easier to debug, test, and modify.
 - Remember: every line of code is a liability. Fewer lines = fewer bugs = less maintenance.
+- **When in doubt, search the codebase** - If you're unsure about a pattern, find how it's done elsewhere
 
-Your goal is to help produce code that future developers will thank you for—code so clean and obvious that it barely needs comments because the intent is crystal clear.
+Your goal is to help produce code that future developers will thank you for—code so clean and obvious that it barely needs comments because the intent is crystal clear. But never sacrifice correctness or convention-compliance for brevity.

--- a/apps/main/e2e/subscription.test.ts
+++ b/apps/main/e2e/subscription.test.ts
@@ -1,0 +1,96 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { expect, test } from "./fixtures";
+
+test.describe("Subscription Page - Unauthenticated", () => {
+  test("login link navigates to login page", async ({ page }) => {
+    await page.goto("/subscription");
+    await expect(
+      page.getByRole("alert").filter({ hasText: /logged in/i }),
+    ).toBeVisible();
+
+    await page.getByRole("link", { name: /login/i }).click();
+    await expect(page).toHaveURL(/\/login/);
+  });
+});
+
+test.describe("Subscription Page - No Subscription", () => {
+  test("shows upgrade content", async ({ authenticatedPage }) => {
+    await authenticatedPage.goto("/subscription");
+
+    await expect(
+      authenticatedPage.getByRole("heading", {
+        level: 1,
+        name: /subscription/i,
+      }),
+    ).toBeVisible();
+
+    // Wait for content to load (skeleton disappears)
+    await expect(
+      authenticatedPage.getByRole("button", { name: /upgrade/i }),
+    ).toBeVisible();
+
+    await expect(authenticatedPage.getByText(/upgrade to plus/i)).toBeVisible();
+  });
+
+  test("upgrade button shows loading state when clicked", async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto("/subscription");
+
+    const upgradeButton = authenticatedPage.getByRole("button", {
+      name: /upgrade/i,
+    });
+
+    await upgradeButton.click();
+
+    await expect(upgradeButton).toBeDisabled();
+  });
+});
+
+test.describe("Subscription Page - With Subscription", () => {
+  const TestUserEmail = "e2e-new@zoonk.test";
+
+  async function createTestSubscription() {
+    const uniqueId = randomUUID();
+
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: TestUserEmail },
+    });
+
+    const subscription = await prisma.subscription.create({
+      data: {
+        plan: "plus",
+        referenceId: String(user.id),
+        status: "active",
+        stripeCustomerId: `cus_test_e2e_${uniqueId}`,
+        stripeSubscriptionId: `sub_test_e2e_${uniqueId}`,
+      },
+    });
+
+    return subscription;
+  }
+
+  test("manage button shows loading state when clicked", async ({
+    userWithoutProgress,
+  }) => {
+    const subscription = await createTestSubscription();
+
+    try {
+      await userWithoutProgress.goto("/subscription");
+
+      await expect(
+        userWithoutProgress.getByText(/you.re on zoonk plus/i),
+      ).toBeVisible();
+
+      const manageButton = userWithoutProgress.getByRole("button", {
+        name: /manage subscription/i,
+      });
+
+      await manageButton.click();
+      await expect(manageButton).toBeDisabled();
+    } finally {
+      await prisma.subscription.delete({ where: { id: subscription.id } });
+    }
+  });
+});

--- a/apps/main/e2e/subscription.test.ts
+++ b/apps/main/e2e/subscription.test.ts
@@ -3,14 +3,15 @@ import { prisma } from "@zoonk/db";
 import { expect, test } from "./fixtures";
 
 test.describe("Subscription Page - Unauthenticated", () => {
-  test("login link navigates to login page", async ({ page }) => {
+  test("shows login prompt with link to login page", async ({ page }) => {
     await page.goto("/subscription");
     await expect(
       page.getByRole("alert").filter({ hasText: /logged in/i }),
     ).toBeVisible();
 
-    await page.getByRole("link", { name: /login/i }).click();
-    await expect(page).toHaveURL(/\/login/);
+    const loginLink = page.getByRole("link", { name: /login/i });
+    await expect(loginLink).toBeVisible();
+    await expect(loginLink).toHaveAttribute("href", "/login");
   });
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds end-to-end tests for the subscription page to verify the login prompt/link, upgrade flow, and manage flow states. Also updates the code-simplifier guidelines to require project-context research and convention checks before suggesting changes.

- **New Features**
  - Unauthenticated: shows login alert and the login link points to /login.
  - No subscription: renders Subscription page content; Upgrade button disables on click.
  - With subscription: creates a temporary Plus subscription via Prisma, confirms Plus status, and disables Manage Subscription on click; cleans up test data.

<sup>Written for commit 5190e8646ff2bbf20350076c85d8b0c7a1d07b28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

