### PR TITLE
fix(editor): revalidate chapter/lesson pages after publish action

### DIFF
--- a/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
@@ -10,12 +10,19 @@ import { deleteChapter } from "@/data/chapters/delete-chapter";
 import { toggleChapterPublished } from "@/data/chapters/publish-chapter";
 import { getErrorMessage } from "@/lib/error-messages";
 
+type TogglePublishParams = {
+  chapterId: number;
+  chapterSlug: string;
+  chapterUrl: string;
+  courseSlug: string;
+};
+
 export async function togglePublishAction(
-  chapterSlug: string,
-  courseSlug: string,
-  chapterId: number,
+  params: TogglePublishParams,
   isPublished: boolean,
 ): Promise<{ error: string | null }> {
+  const { chapterId, chapterSlug, chapterUrl, courseSlug } = params;
+
   const { error } = await toggleChapterPublished({
     chapterId,
     isPublished,
@@ -31,6 +38,8 @@ export async function togglePublishAction(
       cacheTagCourse({ courseSlug }),
     ]);
   });
+
+  revalidatePath(chapterUrl);
 
   return { error: null };
 }

--- a/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/chapter-actions.tsx
+++ b/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/chapter-actions.tsx
@@ -37,17 +37,18 @@ export async function ChapterActions({
   });
 
   const courseUrl = `/${orgSlug}/c/${lang}/${courseSlug}` as Route;
+  const chapterUrl = `/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}`;
 
   return (
     <ChapterActionsContainer>
       <PublishToggle
         isPublished={chapter.isPublished}
-        onToggle={togglePublishAction.bind(
-          null,
+        onToggle={togglePublishAction.bind(null, {
+          chapterId: chapter.id,
           chapterSlug,
+          chapterUrl,
           courseSlug,
-          chapter.id,
-        )}
+        })}
       />
 
       {canDelete && (

--- a/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/actions.ts
@@ -16,6 +16,7 @@ import { getErrorMessage } from "@/lib/error-messages";
 
 export async function togglePublishAction(
   slugs: { lessonSlug: string; chapterSlug: string; courseSlug: string },
+  lessonUrl: string,
   lessonId: number,
   isPublished: boolean,
 ): Promise<{ error: string | null }> {
@@ -35,6 +36,8 @@ export async function togglePublishAction(
       cacheTagCourse({ courseSlug: slugs.courseSlug }),
     ]);
   });
+
+  revalidatePath(lessonUrl);
 
   return { error: null };
 }

--- a/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-actions.tsx
+++ b/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-actions.tsx
@@ -38,6 +38,7 @@ export async function LessonActions({
 
   const chapterUrl =
     `/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}` as Route;
+  const lessonUrl = `/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`;
 
   const slugs = { chapterSlug, courseSlug, lessonSlug };
 
@@ -45,7 +46,7 @@ export async function LessonActions({
     <LessonActionsContainer>
       <PublishToggle
         isPublished={lesson.isPublished}
-        onToggle={togglePublishAction.bind(null, slugs, lesson.id)}
+        onToggle={togglePublishAction.bind(null, slugs, lessonUrl, lesson.id)}
       />
 
       {canDelete && (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure chapter and lesson pages update immediately after publish/unpublish. Revalidate the page path to fix stale state in the editor UI.

- **Bug Fixes**
  - Call revalidatePath for chapter and lesson URLs after toggling publish.
  - Fixes stale publish state on chapter/lesson pages and navbar actions.

- **Refactors**
  - Update togglePublishAction to accept a params object and include chapterUrl/lessonUrl from the UI.

<sup>Written for commit 6ed052a5e609f33ed6633544acff9e870361923f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

