### PR TITLE
fix(dev): remove example domain from seed

### DIFF
--- a/packages/db/src/prisma/seed/steps.ts
+++ b/packages/db/src/prisma/seed/steps.ts
@@ -167,14 +167,14 @@ const stepsData: ActivitySteps[] = [
               feedback:
                 "Correct! Neural networks have interconnected layers of nodes.",
               isCorrect: true,
-              url: "https://example.com/neural-network.png",
+              url: "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/courses/machine_learning-jmaDwiS0MptNV2EGCZzYWU7RBJs3Qg.webp",
             },
             {
               alt: "Simple flowchart",
               feedback:
                 "This is a flowchart, not a neural network architecture.",
               isCorrect: false,
-              url: "https://example.com/flowchart.png",
+              url: "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/courses/astronomy-OfBov0VHGQPk98amhfAPg4UVrJH114.webp",
             },
           ],
           question: "Which diagram best represents a neural network?",

--- a/packages/testing/src/fixtures/courses.ts
+++ b/packages/testing/src/fixtures/courses.ts
@@ -11,7 +11,7 @@ export function courseAttrs(
 ): Omit<Course, "id" | "createdAt" | "updatedAt"> {
   return {
     description: "Test course description",
-    imageUrl: "https://example.com/image.jpg",
+    imageUrl: null,
     isPublished: false,
     language: "en",
     normalizedTitle: "test course",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced example.com image URLs in seed steps with real Vercel Blob URLs, and set the testing course fixture imageUrl to null. This fixes broken images and avoids external network calls in dev and tests.

<sup>Written for commit 455d7e9740dbe99e6f11ca0d6a85845033ddd2f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

