### PR TITLE
test(main): remove alert assertion

### DIFF
--- a/apps/main/e2e/name.test.ts
+++ b/apps/main/e2e/name.test.ts
@@ -46,8 +46,6 @@ test.describe("Display name settings page", () => {
       .getByRole("button", { name: /update name/i })
       .click();
 
-    await expect(authenticatedPage.getByRole("alert")).toBeVisible();
-
     await expect(
       authenticatedPage.getByText(/failed to update your name/i),
     ).toBeVisible();


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the alert assertion in the Display name settings e2e test to reduce flakiness. The test now only asserts the "failed to update your name" error message.

<sup>Written for commit 2eba3e986c8dc8266db112043491cf796c739b44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

