### PR TITLE
test(editor): wait for networkidle on content tests

### DIFF
--- a/apps/editor/e2e/chapter-content.test.ts
+++ b/apps/editor/e2e/chapter-content.test.ts
@@ -47,8 +47,14 @@ test.describe("Chapter Content Page", () => {
     });
     const uniqueTitle = `Test Title ${randomUUID().slice(0, 8)}`;
 
+    // Clear first to ensure we're replacing, not appending
+    await titleInput.clear();
     await titleInput.fill(uniqueTitle);
+    // Verify the value is correct before save triggers
+    await expect(titleInput).toHaveValue(uniqueTitle);
+    // Wait for save to complete and indicator to disappear (ensures full save lifecycle)
     await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+    await expect(authenticatedPage.getByText(/^saved$/i)).not.toBeVisible();
     await authenticatedPage.waitForLoadState("networkidle");
 
     await authenticatedPage.reload();
@@ -65,8 +71,14 @@ test.describe("Chapter Content Page", () => {
     });
     const uniqueDescription = `Test Description ${randomUUID().slice(0, 8)}`;
 
+    // Clear first to ensure we're replacing, not appending
+    await descriptionInput.clear();
     await descriptionInput.fill(uniqueDescription);
+    // Verify the value is correct before save triggers
+    await expect(descriptionInput).toHaveValue(uniqueDescription);
+    // Wait for save to complete and indicator to disappear (ensures full save lifecycle)
     await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+    await expect(authenticatedPage.getByText(/^saved$/i)).not.toBeVisible();
     await authenticatedPage.waitForLoadState("networkidle");
 
     await authenticatedPage.reload();

--- a/apps/editor/e2e/chapter-content.test.ts
+++ b/apps/editor/e2e/chapter-content.test.ts
@@ -49,6 +49,7 @@ test.describe("Chapter Content Page", () => {
 
     await titleInput.fill(uniqueTitle);
     await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+    await authenticatedPage.waitForLoadState("networkidle");
 
     await authenticatedPage.reload();
     await expect(titleInput).toBeVisible();
@@ -66,6 +67,7 @@ test.describe("Chapter Content Page", () => {
 
     await descriptionInput.fill(uniqueDescription);
     await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+    await authenticatedPage.waitForLoadState("networkidle");
 
     await authenticatedPage.reload();
     await expect(descriptionInput).toBeVisible();

--- a/apps/editor/e2e/course-content.test.ts
+++ b/apps/editor/e2e/course-content.test.ts
@@ -33,8 +33,14 @@ test.describe("Course Content Page", () => {
     });
     const uniqueTitle = `Test Title ${randomUUID().slice(0, 8)}`;
 
+    // Clear first to ensure we're replacing, not appending
+    await titleInput.clear();
     await titleInput.fill(uniqueTitle);
+    // Verify the value is correct before save triggers
+    await expect(titleInput).toHaveValue(uniqueTitle);
+    // Wait for save to complete and indicator to disappear (ensures full save lifecycle)
     await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+    await expect(authenticatedPage.getByText(/^saved$/i)).not.toBeVisible();
     await authenticatedPage.waitForLoadState("networkidle");
 
     await authenticatedPage.reload();
@@ -51,8 +57,14 @@ test.describe("Course Content Page", () => {
     });
     const uniqueDescription = `Test Description ${randomUUID().slice(0, 8)}`;
 
+    // Clear first to ensure we're replacing, not appending
+    await descriptionInput.clear();
     await descriptionInput.fill(uniqueDescription);
+    // Verify the value is correct before save triggers
+    await expect(descriptionInput).toHaveValue(uniqueDescription);
+    // Wait for save to complete and indicator to disappear (ensures full save lifecycle)
     await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+    await expect(authenticatedPage.getByText(/^saved$/i)).not.toBeVisible();
     await authenticatedPage.waitForLoadState("networkidle");
 
     await authenticatedPage.reload();

--- a/apps/editor/e2e/course-content.test.ts
+++ b/apps/editor/e2e/course-content.test.ts
@@ -35,6 +35,7 @@ test.describe("Course Content Page", () => {
 
     await titleInput.fill(uniqueTitle);
     await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+    await authenticatedPage.waitForLoadState("networkidle");
 
     await authenticatedPage.reload();
     await expect(titleInput).toBeVisible();
@@ -52,6 +53,7 @@ test.describe("Course Content Page", () => {
 
     await descriptionInput.fill(uniqueDescription);
     await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+    await authenticatedPage.waitForLoadState("networkidle");
 
     await authenticatedPage.reload();
     await expect(descriptionInput).toBeVisible();

--- a/apps/editor/e2e/lesson-content.test.ts
+++ b/apps/editor/e2e/lesson-content.test.ts
@@ -63,6 +63,7 @@ test.describe("Lesson Content Page", () => {
 
     await titleInput.fill(uniqueTitle);
     await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+    await authenticatedPage.waitForLoadState("networkidle");
 
     await authenticatedPage.reload();
     await expect(titleInput).toBeVisible();
@@ -85,6 +86,7 @@ test.describe("Lesson Content Page", () => {
 
     await descriptionInput.fill(uniqueDescription);
     await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+    await authenticatedPage.waitForLoadState("networkidle");
 
     await authenticatedPage.reload();
     await expect(descriptionInput).toBeVisible();

--- a/apps/editor/e2e/lesson-content.test.ts
+++ b/apps/editor/e2e/lesson-content.test.ts
@@ -61,8 +61,14 @@ test.describe("Lesson Content Page", () => {
     });
     const uniqueTitle = `Test Title ${randomUUID().slice(0, 8)}`;
 
+    // Clear first to ensure we're replacing, not appending
+    await titleInput.clear();
     await titleInput.fill(uniqueTitle);
+    // Verify the value is correct before save triggers
+    await expect(titleInput).toHaveValue(uniqueTitle);
+    // Wait for save to complete and indicator to disappear (ensures full save lifecycle)
     await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+    await expect(authenticatedPage.getByText(/^saved$/i)).not.toBeVisible();
     await authenticatedPage.waitForLoadState("networkidle");
 
     await authenticatedPage.reload();
@@ -84,8 +90,14 @@ test.describe("Lesson Content Page", () => {
     });
     const uniqueDescription = `Test Description ${randomUUID().slice(0, 8)}`;
 
+    // Clear first to ensure we're replacing, not appending
+    await descriptionInput.clear();
     await descriptionInput.fill(uniqueDescription);
+    // Verify the value is correct before save triggers
+    await expect(descriptionInput).toHaveValue(uniqueDescription);
+    // Wait for save to complete and indicator to disappear (ensures full save lifecycle)
     await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+    await expect(authenticatedPage.getByText(/^saved$/i)).not.toBeVisible();
     await authenticatedPage.waitForLoadState("networkidle");
 
     await authenticatedPage.reload();


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Wait for network idle after “Saved” in editor content E2E tests to ensure autosave completes before reload. Also clear inputs, assert field values, and wait for the “Saved” indicator to disappear to further reduce flakiness in chapter, course, and lesson content tests.

<sup>Written for commit c03b4795e5db181dca3cca5dcc98c771d15e724f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

