### PR TITLE
test(main): wait contact field to be enabled

### DIFF
--- a/apps/main/e2e/content-feedback.test.ts
+++ b/apps/main/e2e/content-feedback.test.ts
@@ -32,7 +32,12 @@ test.describe("Content Feedback", () => {
     await page.getByRole("button", { name: /send feedback/i }).click();
 
     const dialog = page.getByRole("dialog");
-    await dialog.getByLabel(/email/i).fill("test@example.com");
+    const emailInput = dialog.getByLabel(/email/i);
+
+    // Wait for dialog to be fully visible and email input to be enabled
+    await expect(emailInput).toBeEnabled();
+
+    await emailInput.fill("test@example.com");
     await dialog.getByLabel(/message/i).fill("This is test feedback");
     await dialog.getByRole("button", { name: /send message/i }).click();
 
@@ -44,6 +49,10 @@ test.describe("Content Feedback", () => {
 
     const dialog = page.getByRole("dialog");
     const emailInput = dialog.getByLabel(/email/i);
+
+    // Wait for dialog to be fully visible and email input to be enabled
+    await expect(emailInput).toBeEnabled();
+
     await emailInput.fill("invalid-email");
     await dialog.getByLabel(/message/i).fill("This is test feedback");
     await dialog.getByRole("button", { name: /send message/i }).click();
@@ -88,7 +97,12 @@ test.describe("Content Feedback", () => {
     await page.getByRole("button", { name: /send feedback/i }).click();
 
     const dialog = page.getByRole("dialog");
-    await dialog.getByLabel(/email/i).fill("test@example.com");
+    const emailInput = dialog.getByLabel(/email/i);
+
+    // Wait for dialog to be fully visible and email input to be enabled
+    await expect(emailInput).toBeEnabled();
+
+    await emailInput.fill("test@example.com");
     await dialog.getByLabel(/message/i).fill("This is test feedback");
     await dialog.getByRole("button", { name: /send message/i }).click();
 
@@ -111,6 +125,10 @@ test.describe("Content Feedback - Authenticated", () => {
       .click();
 
     const emailInput = authenticatedPage.getByLabel(/email/i);
+
+    // Wait for dialog to be fully visible and email input to be enabled
+    await expect(emailInput).toBeEnabled();
+
     // Should be pre-filled with user's email
     await expect(emailInput).toHaveValue(/e2e-progress@zoonk\.test/);
   });

--- a/apps/main/e2e/support.test.ts
+++ b/apps/main/e2e/support.test.ts
@@ -23,7 +23,9 @@ test.describe("Support page", () => {
     await page.getByRole("button", { name: /contact support/i }).click();
 
     const dialog = page.getByRole("dialog");
-    await dialog.getByLabel(/email/i).fill("test@example.com");
+    const emailInput = dialog.getByLabel(/email/i);
+    await expect(emailInput).toBeEnabled();
+    await emailInput.fill("test@example.com");
     await dialog.getByLabel(/message/i).fill("Test message");
     await dialog.getByRole("button", { name: /send message/i }).click();
 
@@ -35,6 +37,7 @@ test.describe("Support page", () => {
 
     const dialog = page.getByRole("dialog");
     const emailInput = dialog.getByLabel(/email/i);
+    await expect(emailInput).toBeEnabled();
     await emailInput.fill("invalid-email");
     await dialog.getByLabel(/message/i).fill("Test message");
     await dialog.getByRole("button", { name: /send message/i }).click();
@@ -79,7 +82,9 @@ test.describe("Support page", () => {
     await page.getByRole("button", { name: /contact support/i }).click();
 
     const dialog = page.getByRole("dialog");
-    await dialog.getByLabel(/email/i).fill("test@example.com");
+    const emailInput = dialog.getByLabel(/email/i);
+    await expect(emailInput).toBeEnabled();
+    await emailInput.fill("test@example.com");
     await dialog.getByLabel(/message/i).fill("Test message");
     await dialog.getByRole("button", { name: /send message/i }).click();
 
@@ -97,7 +102,12 @@ test.describe("Support page - Authenticated", () => {
       .getByRole("button", { name: /contact support/i })
       .click();
 
-    const emailInput = authenticatedPage.getByLabel(/email/i);
+    const emailInput = authenticatedPage
+      .getByRole("dialog")
+      .getByLabel(/email/i);
+
+    await expect(emailInput).toBeEnabled();
+
     // Should be pre-filled with user's email
     await expect(emailInput).toHaveValue(/e2e-progress@zoonk\.test/);
   });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Wait for the email field to be enabled before filling it in Content Feedback and Support E2E tests. This prevents flaky failures when the dialog opens for both authenticated and guest flows by using expect(emailInput).toBeEnabled() before fill.

<sup>Written for commit dee51437b0bbd6c82f788acf8e558598a10f9a29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

