### PR TITLE
fix(editor): improve ux when inserting items

### DIFF
--- a/apps/editor/e2e/chapter-list.test.ts
+++ b/apps/editor/e2e/chapter-list.test.ts
@@ -150,19 +150,20 @@ test.describe("Chapter List", () => {
         { position: 4, title: "Chapter 4" },
       ]);
 
-      // Hover over the third chapter to reveal the insert button between 2 and 3
-      const thirdChapterItem = authenticatedPage.getByRole("link", {
-        name: /^03.*Chapter 3/i,
+      // Click the actions menu on Chapter 2 to insert below it (at position 2)
+      // Use exact match to avoid matching outer container buttons
+      const actionsButtons = authenticatedPage.getByRole("button", {
+        exact: true,
+        name: "Chapter actions",
       });
 
-      await thirdChapterItem.hover();
+      // Click the second chapter's actions button (index 1)
+      await actionsButtons.nth(1).click();
 
-      // Click the insert button that appears before chapter 3 (position 2)
-      const insertButtons = authenticatedPage.getByRole("button", {
-        name: /insert chapter/i,
-      });
-
-      await insertButtons.nth(2).click();
+      // Click "Insert below" to insert after Chapter 2
+      await authenticatedPage
+        .getByRole("menuitem", { name: /insert below/i })
+        .click();
 
       // After clicking insert, we're redirected to the chapter edit page
       await expect(

--- a/apps/editor/e2e/chapter-list.test.ts
+++ b/apps/editor/e2e/chapter-list.test.ts
@@ -160,10 +160,12 @@ test.describe("Chapter List", () => {
       // Click the second chapter's actions button (index 1)
       await actionsButtons.nth(1).click();
 
-      // Click "Insert below" to insert after Chapter 2
-      await authenticatedPage
-        .getByRole("menuitem", { name: /insert below/i })
-        .click();
+      // Wait for the menu to appear and click "Insert below"
+      const insertBelowItem = authenticatedPage.getByRole("menuitem", {
+        name: /insert below/i,
+      });
+      await insertBelowItem.waitFor({ state: "visible" });
+      await insertBelowItem.click();
 
       // After clicking insert, we're redirected to the chapter edit page
       await expect(

--- a/apps/editor/e2e/lesson-list.test.ts
+++ b/apps/editor/e2e/lesson-list.test.ts
@@ -162,19 +162,22 @@ test.describe("Lesson List", () => {
         { position: 4, title: "Lesson 4" },
       ]);
 
-      // Hover over the third lesson to reveal the insert button between 2 and 3
-      const thirdLessonItem = authenticatedPage.getByRole("link", {
-        name: /^03.*Lesson 3/i,
+      // Click the actions menu on Lesson 2 to insert below it (at position 2)
+      // Use exact match to avoid matching outer container buttons
+      const actionsButtons = authenticatedPage.getByRole("button", {
+        exact: true,
+        name: "Lesson actions",
       });
 
-      await thirdLessonItem.hover();
+      // Click the second lesson's actions button (index 1)
+      await actionsButtons.nth(1).click();
 
-      // Click the insert button that appears before lesson 3 (position 2)
-      const insertButtons = authenticatedPage.getByRole("button", {
-        name: /insert lesson/i,
+      // Wait for the menu to appear and click "Insert below"
+      const insertBelowItem = authenticatedPage.getByRole("menuitem", {
+        name: /insert below/i,
       });
-
-      await insertButtons.nth(2).click();
+      await insertBelowItem.waitFor({ state: "visible" });
+      await insertBelowItem.click();
 
       // After clicking insert, we're redirected to the lesson edit page
       await expect(

--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -145,10 +145,21 @@ msgid "Drag to reorder"
 msgstr "Drag to reorder"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+msgctxt "drUbPJ"
+msgid "Lesson actions"
+msgstr "Lesson actions"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "FazwRl"
 msgid "Try again"
 msgstr "Try again"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "geXvrp"
+msgid "Insert below"
+msgstr "Insert below"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgctxt "RWzfUY"
@@ -156,19 +167,20 @@ msgid "Add lesson"
 msgstr "Add lesson"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgctxt "ZRJz2g"
-msgid "Insert lesson"
-msgstr "Insert lesson"
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "vTz4RU"
+msgid "Insert above"
+msgstr "Insert above"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "BxygZD"
+msgid "Chapter actions"
+msgstr "Chapter actions"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "dlQpGl"
 msgid "Add chapter"
 msgstr "Add chapter"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "niU+md"
-msgid "Insert chapter"
-msgstr "Insert chapter"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "sHQNSR"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -145,10 +145,21 @@ msgid "Drag to reorder"
 msgstr "Arrastra para reordenar"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+msgctxt "drUbPJ"
+msgid "Lesson actions"
+msgstr "Acciones de la lección"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "FazwRl"
 msgid "Try again"
 msgstr "Intentar de nuevo"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "geXvrp"
+msgid "Insert below"
+msgstr "Insertar debajo"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgctxt "RWzfUY"
@@ -156,19 +167,20 @@ msgid "Add lesson"
 msgstr "Agregar lección"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgctxt "ZRJz2g"
-msgid "Insert lesson"
-msgstr "Insertar lección"
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "vTz4RU"
+msgid "Insert above"
+msgstr "Insertar arriba"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "BxygZD"
+msgid "Chapter actions"
+msgstr "Acciones del capítulo"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "dlQpGl"
 msgid "Add chapter"
 msgstr "Agregar capítulo"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "niU+md"
-msgid "Insert chapter"
-msgstr "Insertar capítulo"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "sHQNSR"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -145,10 +145,21 @@ msgid "Drag to reorder"
 msgstr "Arraste para reordenar"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+msgctxt "drUbPJ"
+msgid "Lesson actions"
+msgstr "Ações da aula"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "FazwRl"
 msgid "Try again"
 msgstr "Tentar novamente"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "geXvrp"
+msgid "Insert below"
+msgstr "Inserir abaixo"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgctxt "RWzfUY"
@@ -156,19 +167,20 @@ msgid "Add lesson"
 msgstr "Adicionar aula"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgctxt "ZRJz2g"
-msgid "Insert lesson"
-msgstr "Inserir aula"
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "vTz4RU"
+msgid "Insert above"
+msgstr "Inserir acima"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "BxygZD"
+msgid "Chapter actions"
+msgstr "Ações do capítulo"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "dlQpGl"
 msgid "Add chapter"
 msgstr "Adicionar capítulo"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "niU+md"
-msgid "Insert chapter"
-msgstr "Inserir capítulo"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "sHQNSR"

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -2,14 +2,13 @@ import { ErrorView } from "@zoonk/ui/patterns/error";
 import { SUPPORT_URL } from "@zoonk/utils/constants";
 import Link from "next/link";
 import { getExtracted } from "next-intl/server";
-import { Fragment } from "react";
 import {
   EditorDragHandle,
   EditorListAddButton,
   EditorListContent,
   EditorListHeader,
-  EditorListInsertLine,
   EditorListItem,
+  EditorListItemActions,
   EditorListItemContent,
   EditorListItemDescription,
   EditorListItemLink,
@@ -88,50 +87,45 @@ export async function LessonList({
           onReorder={reorderLessonsAction.bind(null, routeParams)}
         >
           <EditorListContent>
-            <EditorListInsertLine
-              aria-label={t("Insert lesson")}
-              position={0}
-            />
-
             {lessons.map((lesson, index) => (
-              <Fragment key={lesson.slug}>
-                <EditorSortableItem id={lesson.id}>
-                  <EditorListItem>
-                    <EditorSortableItemRow>
-                      <EditorDragHandle aria-label={t("Drag to reorder")} />
+              <EditorSortableItem id={lesson.id} key={lesson.slug}>
+                <EditorListItem>
+                  <EditorSortableItemRow>
+                    <EditorDragHandle aria-label={t("Drag to reorder")} />
 
-                      <EditorListItemLink
-                        render={
-                          <Link
-                            href={`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/${lesson.slug}`}
-                          />
-                        }
-                      >
-                        <EditorListItemPosition>
-                          {index + 1}
-                        </EditorListItemPosition>
+                    <EditorListItemLink
+                      render={
+                        <Link
+                          href={`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/${lesson.slug}`}
+                        />
+                      }
+                    >
+                      <EditorListItemPosition>
+                        {index + 1}
+                      </EditorListItemPosition>
 
-                        <EditorListItemContent>
-                          <EditorListItemTitle>
-                            {lesson.title}
-                          </EditorListItemTitle>
+                      <EditorListItemContent>
+                        <EditorListItemTitle>
+                          {lesson.title}
+                        </EditorListItemTitle>
 
-                          {lesson.description && (
-                            <EditorListItemDescription>
-                              {lesson.description}
-                            </EditorListItemDescription>
-                          )}
-                        </EditorListItemContent>
-                      </EditorListItemLink>
-                    </EditorSortableItemRow>
-                  </EditorListItem>
-                </EditorSortableItem>
+                        {lesson.description && (
+                          <EditorListItemDescription>
+                            {lesson.description}
+                          </EditorListItemDescription>
+                        )}
+                      </EditorListItemContent>
+                    </EditorListItemLink>
 
-                <EditorListInsertLine
-                  aria-label={t("Insert lesson")}
-                  position={index + 1}
-                />
-              </Fragment>
+                    <EditorListItemActions
+                      aria-label={t("Lesson actions")}
+                      insertAboveLabel={t("Insert above")}
+                      insertBelowLabel={t("Insert below")}
+                      position={index}
+                    />
+                  </EditorSortableItemRow>
+                </EditorListItem>
+              </EditorSortableItem>
             ))}
           </EditorListContent>
         </EditorSortableList>

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
@@ -2,14 +2,13 @@ import { ErrorView } from "@zoonk/ui/patterns/error";
 import { SUPPORT_URL } from "@zoonk/utils/constants";
 import Link from "next/link";
 import { getExtracted } from "next-intl/server";
-import { Fragment } from "react";
 import {
   EditorDragHandle,
   EditorListAddButton,
   EditorListContent,
   EditorListHeader,
-  EditorListInsertLine,
   EditorListItem,
+  EditorListItemActions,
   EditorListItemContent,
   EditorListItemDescription,
   EditorListItemLink,
@@ -85,50 +84,45 @@ export async function ChapterList({
           onReorder={reorderChaptersAction.bind(null, routeParams)}
         >
           <EditorListContent>
-            <EditorListInsertLine
-              aria-label={t("Insert chapter")}
-              position={0}
-            />
-
             {chapters.map((chapter, index) => (
-              <Fragment key={chapter.slug}>
-                <EditorSortableItem id={chapter.id}>
-                  <EditorListItem>
-                    <EditorSortableItemRow>
-                      <EditorDragHandle aria-label={t("Drag to reorder")} />
+              <EditorSortableItem id={chapter.id} key={chapter.slug}>
+                <EditorListItem>
+                  <EditorSortableItemRow>
+                    <EditorDragHandle aria-label={t("Drag to reorder")} />
 
-                      <EditorListItemLink
-                        render={
-                          <Link
-                            href={`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapter.slug}`}
-                          />
-                        }
-                      >
-                        <EditorListItemPosition>
-                          {index + 1}
-                        </EditorListItemPosition>
+                    <EditorListItemLink
+                      render={
+                        <Link
+                          href={`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapter.slug}`}
+                        />
+                      }
+                    >
+                      <EditorListItemPosition>
+                        {index + 1}
+                      </EditorListItemPosition>
 
-                        <EditorListItemContent>
-                          <EditorListItemTitle>
-                            {chapter.title}
-                          </EditorListItemTitle>
+                      <EditorListItemContent>
+                        <EditorListItemTitle>
+                          {chapter.title}
+                        </EditorListItemTitle>
 
-                          {chapter.description && (
-                            <EditorListItemDescription>
-                              {chapter.description}
-                            </EditorListItemDescription>
-                          )}
-                        </EditorListItemContent>
-                      </EditorListItemLink>
-                    </EditorSortableItemRow>
-                  </EditorListItem>
-                </EditorSortableItem>
+                        {chapter.description && (
+                          <EditorListItemDescription>
+                            {chapter.description}
+                          </EditorListItemDescription>
+                        )}
+                      </EditorListItemContent>
+                    </EditorListItemLink>
 
-                <EditorListInsertLine
-                  aria-label={t("Insert chapter")}
-                  position={index + 1}
-                />
-              </Fragment>
+                    <EditorListItemActions
+                      aria-label={t("Chapter actions")}
+                      insertAboveLabel={t("Insert above")}
+                      insertBelowLabel={t("Insert below")}
+                      position={index}
+                    />
+                  </EditorSortableItemRow>
+                </EditorListItem>
+              </EditorSortableItem>
             ))}
           </EditorListContent>
         </EditorSortableList>

--- a/apps/editor/src/components/editor-list.tsx
+++ b/apps/editor/src/components/editor-list.tsx
@@ -19,12 +19,23 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Button } from "@zoonk/ui/components/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@zoonk/ui/components/dropdown-menu";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { toast } from "@zoonk/ui/components/sonner";
 import { mergeProps, useRender } from "@zoonk/ui/lib/render";
 import { cn } from "@zoonk/ui/lib/utils";
 import { isNextRedirectError } from "@zoonk/utils/error";
-import { GripVerticalIcon, LoaderCircleIcon, PlusIcon } from "lucide-react";
+import {
+  EllipsisIcon,
+  GripVerticalIcon,
+  LoaderCircleIcon,
+  PlusIcon,
+} from "lucide-react";
 import {
   createContext,
   useCallback,
@@ -171,42 +182,6 @@ function EditorListContent({
 }: React.ComponentProps<"ul">) {
   return (
     <ul className={cn(className)} data-slot="editor-list-content" {...props} />
-  );
-}
-
-function EditorListInsertLine({
-  "aria-label": ariaLabel,
-  position,
-  className,
-  ...props
-}: Omit<React.ComponentProps<"div">, "onClick"> & {
-  "aria-label"?: string;
-  position: number;
-}) {
-  const { pending, handleInsert } = useEditorList();
-
-  return (
-    <div
-      className={cn("group relative h-0", className)}
-      data-slot="editor-list-insert-line"
-      {...props}
-    >
-      <div className="absolute inset-x-4 -top-px z-10 flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100">
-        <div className="h-px flex-1 bg-primary/30" />
-
-        <button
-          aria-label={ariaLabel}
-          className="flex size-5 items-center justify-center rounded-full bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-          disabled={pending}
-          onClick={() => handleInsert(position)}
-          type="button"
-        >
-          <PlusIcon className="size-3" />
-        </button>
-
-        <div className="h-px flex-1 bg-primary/30" />
-      </div>
-    </div>
   );
 }
 
@@ -497,7 +472,7 @@ function EditorSortableItemRow({
   return (
     <div
       className={cn(
-        "flex items-start gap-2 px-4 py-3 transition-colors hover:bg-muted/50",
+        "group/row flex items-start gap-2 px-4 py-3 transition-colors hover:bg-muted/50",
         className,
       )}
       data-slot="editor-sortable-item-row"
@@ -531,6 +506,44 @@ function EditorDragHandle({
     >
       <GripVerticalIcon className="size-4" />
     </button>
+  );
+}
+
+function EditorListItemActions({
+  "aria-label": ariaLabel,
+  insertAboveLabel,
+  insertBelowLabel,
+  position,
+}: {
+  "aria-label": string;
+  insertAboveLabel: string;
+  insertBelowLabel: string;
+  position: number;
+}) {
+  const { pending, handleInsert } = useEditorList();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label={ariaLabel}
+        className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus:opacity-100 group-hover/row:opacity-100 [@media(hover:none)]:opacity-100"
+        disabled={pending}
+      >
+        <EllipsisIcon className="size-4" />
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => handleInsert(position)}>
+          <PlusIcon />
+          {insertAboveLabel}
+        </DropdownMenuItem>
+
+        <DropdownMenuItem onClick={() => handleInsert(position + 1)}>
+          <PlusIcon />
+          {insertBelowLabel}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -569,8 +582,8 @@ export {
   EditorListAddButton,
   EditorListContent,
   EditorListHeader,
-  EditorListInsertLine,
   EditorListItem,
+  EditorListItemActions,
   EditorListItemContent,
   EditorListItemDescription,
   EditorListItemLink,

--- a/i18n.lock
+++ b/i18n.lock
@@ -28,11 +28,13 @@ checksums:
     Contact%20support/singular: 32a4dee2033635e334a5f4d34724e3e0
     Failed%20to%20load%20lessons/singular: 427523eb64ddb239d642ca975d6e1dbb
     Drag%20to%20reorder/singular: 42c84478eb582f41d72d5bd7b27bb028
+    Lesson%20actions/singular: e014e6d8a3eb4906b17a79ca0ee96867
     Try%20again/singular: 33dd8820e743e35a66e6977f69e9d3b5
+    Insert%20below/singular: 13f5339830c81c2c64a513b4f0a77c2d
     Add%20lesson/singular: 101a1880b35c68eed6f80e7574f4ff2d
-    Insert%20lesson/singular: 0d943237877e356d1c8aaca8b5360e67
+    Insert%20above/singular: 24d027b3c1e816c98f5571bb637669bf
+    Chapter%20actions/singular: 9f8fd63a1c71839fddbb5b57a1c62f73
     Add%20chapter/singular: af2ea03f1678fcea1fb005f66f28bfa5
-    Insert%20chapter/singular: cbd41a4782e1254a5c450577cbd7e95d
     We%20couldn't%20load%20the%20chapters.%20Please%20try%20again./singular: 2bfbac73debefc0d7a4ec5c41af9c415
     Failed%20to%20load%20chapters/singular: a462d90fffa946fe5c2aedb6e6fff9b4
     Course%20title%E2%80%A6/singular: 4429de50f5f2d426271e76328c543daf


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched insertion from hover lines to an actions menu on each list item. This makes insert above/below explicit, more accessible, and better on touch devices.

- **Refactors**
  - Added EditorListItemActions dropdown with Insert above/below; removed EditorListInsertLine.
  - Updated chapter and lesson lists to show an actions button per item with proper aria labels.
  - Updated e2e test to use the actions menu and “Insert below”.
  - Added new i18n keys and translations (en/es/pt); removed old insert strings.

<sup>Written for commit 550ba2dffc305843d3be4ffa453d6e1c834cd3a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

