### PR TITLE
feat(editor):  support drag and drop on mobile

### DIFF
--- a/apps/editor/e2e/chapter-list.test.ts
+++ b/apps/editor/e2e/chapter-list.test.ts
@@ -57,16 +57,19 @@ async function expectChaptersVisible(
   chapters: { position: number; title: string }[],
 ) {
   await Promise.all(
-    chapters.map(({ position, title }) =>
-      expect(
-        page.getByRole("link", {
-          name: new RegExp(
-            `^${String(position).padStart(2, "0")}.*${title}`,
-            "i",
-          ),
-        }),
-      ).toBeVisible(),
-    ),
+    chapters.map(async ({ position, title }) => {
+      // Position is now in the drag handle button
+      await expect(
+        page
+          .getByRole("button", { name: "Drag to reorder" })
+          .filter({ hasText: String(position).padStart(2, "0") }),
+      ).toBeVisible();
+
+      // Title is in the link
+      await expect(
+        page.getByRole("link", { name: new RegExp(title, "i") }),
+      ).toBeVisible();
+    }),
   );
 }
 

--- a/apps/editor/e2e/chapter-list.test.ts
+++ b/apps/editor/e2e/chapter-list.test.ts
@@ -58,16 +58,14 @@ async function expectChaptersVisible(
 ) {
   await Promise.all(
     chapters.map(async ({ position, title }) => {
-      // Position is now in the drag handle button
-      await expect(
-        page
-          .getByRole("button", { name: "Drag to reorder" })
-          .filter({ hasText: String(position).padStart(2, "0") }),
-      ).toBeVisible();
+      // Find the listitem containing both the position number and title link
+      // This verifies they are in the same row
+      const listItem = page.getByRole("listitem").filter({
+        hasText: new RegExp(String(position).padStart(2, "0")),
+      });
 
-      // Title is in the link
       await expect(
-        page.getByRole("link", { name: new RegExp(title, "i") }),
+        listItem.getByRole("link", { name: new RegExp(title, "i") }),
       ).toBeVisible();
     }),
   );
@@ -207,7 +205,7 @@ test.describe("Chapter List", () => {
         { position: 3, title: "Chapter 3" },
       ]);
 
-      // Get the inner drag handle buttons (exact name match to avoid outer container buttons)
+      // Get the drag handle buttons
       const firstHandle = authenticatedPage
         .getByRole("button", { exact: true, name: "Drag to reorder" })
         .first();
@@ -234,7 +232,7 @@ test.describe("Chapter List", () => {
         throw new Error("Drag handle bounding boxes should exist");
       }
 
-      // Perform drag past 8px activation threshold
+      // Perform drag past 8px activation threshold (PointerSensor uses distance)
       await firstHandle.hover();
       await authenticatedPage.mouse.down();
 

--- a/apps/editor/e2e/lesson-list.test.ts
+++ b/apps/editor/e2e/lesson-list.test.ts
@@ -72,16 +72,14 @@ async function expectLessonsVisible(
 ) {
   await Promise.all(
     lessons.map(async ({ position, title }) => {
-      // Position is now in the drag handle button
-      await expect(
-        page
-          .getByRole("button", { name: "Drag to reorder" })
-          .filter({ hasText: String(position).padStart(2, "0") }),
-      ).toBeVisible();
+      // Find the listitem containing both the position number and title link
+      // This verifies they are in the same row
+      const listItem = page.getByRole("listitem").filter({
+        hasText: new RegExp(String(position).padStart(2, "0")),
+      });
 
-      // Title is in the link
       await expect(
-        page.getByRole("link", { name: new RegExp(title, "i") }),
+        listItem.getByRole("link", { name: new RegExp(title, "i") }),
       ).toBeVisible();
     }),
   );
@@ -221,7 +219,7 @@ test.describe("Lesson List", () => {
         { position: 3, title: "Lesson 3" },
       ]);
 
-      // Get the inner drag handle buttons (exact name match to avoid outer container buttons)
+      // Get the drag handle buttons
       const firstHandle = authenticatedPage
         .getByRole("button", { exact: true, name: "Drag to reorder" })
         .first();
@@ -248,7 +246,7 @@ test.describe("Lesson List", () => {
         throw new Error("Drag handle bounding boxes should exist");
       }
 
-      // Perform drag past 8px activation threshold
+      // Perform drag past 8px activation threshold (PointerSensor uses distance)
       await firstHandle.hover();
       await authenticatedPage.mouse.down();
 

--- a/apps/editor/e2e/lesson-list.test.ts
+++ b/apps/editor/e2e/lesson-list.test.ts
@@ -71,16 +71,19 @@ async function expectLessonsVisible(
   lessons: { position: number; title: string }[],
 ) {
   await Promise.all(
-    lessons.map(({ position, title }) =>
-      expect(
-        page.getByRole("link", {
-          name: new RegExp(
-            `^${String(position).padStart(2, "0")}.*${title}`,
-            "i",
-          ),
-        }),
-      ).toBeVisible(),
-    ),
+    lessons.map(async ({ position, title }) => {
+      // Position is now in the drag handle button
+      await expect(
+        page
+          .getByRole("button", { name: "Drag to reorder" })
+          .filter({ hasText: String(position).padStart(2, "0") }),
+      ).toBeVisible();
+
+      // Title is in the link
+      await expect(
+        page.getByRole("link", { name: new RegExp(title, "i") }),
+      ).toBeVisible();
+    }),
   );
 }
 

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -12,7 +12,6 @@ import {
   EditorListItemContent,
   EditorListItemDescription,
   EditorListItemLink,
-  EditorListItemPosition,
   EditorListItemTitle,
   EditorListProvider,
   EditorListSpinner,
@@ -91,7 +90,9 @@ export async function LessonList({
               <EditorSortableItem id={lesson.id} key={lesson.slug}>
                 <EditorListItem>
                   <EditorSortableItemRow>
-                    <EditorDragHandle aria-label={t("Drag to reorder")} />
+                    <EditorDragHandle aria-label={t("Drag to reorder")}>
+                      {index + 1}
+                    </EditorDragHandle>
 
                     <EditorListItemLink
                       render={
@@ -100,10 +101,6 @@ export async function LessonList({
                         />
                       }
                     >
-                      <EditorListItemPosition>
-                        {index + 1}
-                      </EditorListItemPosition>
-
                       <EditorListItemContent>
                         <EditorListItemTitle>
                           {lesson.title}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
@@ -12,7 +12,6 @@ import {
   EditorListItemContent,
   EditorListItemDescription,
   EditorListItemLink,
-  EditorListItemPosition,
   EditorListItemTitle,
   EditorListProvider,
   EditorListSpinner,
@@ -88,7 +87,9 @@ export async function ChapterList({
               <EditorSortableItem id={chapter.id} key={chapter.slug}>
                 <EditorListItem>
                   <EditorSortableItemRow>
-                    <EditorDragHandle aria-label={t("Drag to reorder")} />
+                    <EditorDragHandle aria-label={t("Drag to reorder")}>
+                      {index + 1}
+                    </EditorDragHandle>
 
                     <EditorListItemLink
                       render={
@@ -97,10 +98,6 @@ export async function ChapterList({
                         />
                       }
                     >
-                      <EditorListItemPosition>
-                        {index + 1}
-                      </EditorListItemPosition>
-
                       <EditorListItemContent>
                         <EditorListItemTitle>
                           {chapter.title}

--- a/apps/editor/src/components/editor-list.tsx
+++ b/apps/editor/src/components/editor-list.tsx
@@ -190,6 +190,7 @@ function EditorListItem({ className, ...props }: React.ComponentProps<"li">) {
 function EditorListItemLink({
   className,
   render,
+  style,
   ...props
 }: useRender.ComponentProps<"a">) {
   return useRender({
@@ -197,6 +198,11 @@ function EditorListItemLink({
     props: mergeProps<"a">(
       {
         className: cn("flex min-w-0 flex-1 items-start gap-4", className),
+        style: {
+          // Prevent iOS context menu on long-press (allows row drag to work)
+          WebkitTouchCallout: "none",
+          ...style,
+        },
       },
       props,
     ),
@@ -461,6 +467,7 @@ function EditorSortableItem({
 
 function EditorSortableItemRow({
   className,
+  style,
   ...props
 }: React.ComponentProps<"div">) {
   const context = useContext(EditorSortableItemContext);
@@ -472,6 +479,12 @@ function EditorSortableItemRow({
         className,
       )}
       data-slot="editor-sortable-item-row"
+      style={{
+        // Prevent iOS context menu on long-press
+        WebkitTouchCallout: "none",
+        WebkitUserSelect: "none",
+        ...style,
+      }}
       {...context?.listeners}
       {...props}
     />

--- a/apps/editor/src/components/editor-list.tsx
+++ b/apps/editor/src/components/editor-list.tsx
@@ -190,7 +190,6 @@ function EditorListItem({ className, ...props }: React.ComponentProps<"li">) {
 function EditorListItemLink({
   className,
   render,
-  style,
   ...props
 }: useRender.ComponentProps<"a">) {
   return useRender({
@@ -198,11 +197,6 @@ function EditorListItemLink({
     props: mergeProps<"a">(
       {
         className: cn("flex min-w-0 flex-1 items-start gap-4", className),
-        style: {
-          // Prevent iOS context menu on long-press (allows row drag to work)
-          WebkitTouchCallout: "none",
-          ...style,
-        },
       },
       props,
     ),
@@ -300,8 +294,9 @@ function EditorSortableList<T extends SortableItem>({
     }),
     useSensor(TouchSensor, {
       activationConstraint: {
-        delay: 450,
-        tolerance: 5,
+        // Short delay to distinguish tap from drag, with tolerance for slight movement
+        delay: 150,
+        tolerance: 8,
       },
     }),
     useSensor(KeyboardSensor, {
@@ -467,11 +462,8 @@ function EditorSortableItem({
 
 function EditorSortableItemRow({
   className,
-  style,
   ...props
 }: React.ComponentProps<"div">) {
-  const context = useContext(EditorSortableItemContext);
-
   return (
     <div
       className={cn(
@@ -479,13 +471,6 @@ function EditorSortableItemRow({
         className,
       )}
       data-slot="editor-sortable-item-row"
-      style={{
-        // Prevent iOS context menu on long-press
-        WebkitTouchCallout: "none",
-        WebkitUserSelect: "none",
-        ...style,
-      }}
-      {...context?.listeners}
       {...props}
     />
   );
@@ -507,7 +492,7 @@ function EditorDragHandle({
   return (
     <button
       className={cn(
-        "relative flex min-h-11 min-w-11 shrink-0 cursor-grab select-none items-center justify-center rounded-md font-mono text-muted-foreground text-sm tabular-nums transition-colors before:absolute before:top-1/2 before:left-1/2 before:size-full before:min-h-11 before:min-w-11 before:-translate-x-1/2 before:-translate-y-1/2 hover:bg-muted hover:text-foreground focus-visible:bg-muted focus-visible:text-foreground focus-visible:outline-none active:cursor-grabbing active:bg-muted",
+        "relative flex min-h-11 min-w-11 shrink-0 cursor-grab touch-none select-none items-center justify-center rounded-md font-mono text-muted-foreground text-sm tabular-nums transition-colors before:absolute before:top-1/2 before:left-1/2 before:size-full before:min-h-11 before:min-w-11 before:-translate-x-1/2 before:-translate-y-1/2 hover:bg-muted hover:text-foreground focus-visible:bg-muted focus-visible:text-foreground focus-visible:outline-none active:cursor-grabbing active:bg-muted",
         className,
       )}
       data-slot="editor-drag-handle"

--- a/apps/editor/src/components/editor-list.tsx
+++ b/apps/editor/src/components/editor-list.tsx
@@ -479,7 +479,7 @@ function EditorSortableItemRow({
   return (
     <div
       className={cn(
-        "group/row flex items-start gap-2 px-4 py-3 transition-colors hover:bg-muted/50",
+        "group/row flex select-none items-start gap-2 px-4 py-3 transition-colors hover:bg-muted/50",
         className,
       )}
       data-slot="editor-sortable-item-row"

--- a/apps/editor/src/components/editor-list.tsx
+++ b/apps/editor/src/components/editor-list.tsx
@@ -31,12 +31,7 @@ import { toast } from "@zoonk/ui/components/sonner";
 import { mergeProps, useRender } from "@zoonk/ui/lib/render";
 import { cn } from "@zoonk/ui/lib/utils";
 import { isNextRedirectError } from "@zoonk/utils/error";
-import {
-  EllipsisIcon,
-  GripVerticalIcon,
-  LoaderCircleIcon,
-  PlusIcon,
-} from "lucide-react";
+import { EllipsisIcon, LoaderCircleIcon, PlusIcon } from "lucide-react";
 import {
   createContext,
   useCallback,
@@ -212,27 +207,6 @@ function EditorListItemLink({
   });
 }
 
-function EditorListItemPosition({
-  children,
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
-  return (
-    <span
-      className={cn(
-        "mt-0.5 font-mono text-muted-foreground text-sm tabular-nums",
-        className,
-      )}
-      data-slot="editor-list-item-position"
-      {...props}
-    >
-      {typeof children === "number"
-        ? String(children).padStart(2, "0")
-        : children}
-    </span>
-  );
-}
-
 function EditorListItemContent({
   className,
   ...props
@@ -320,8 +294,7 @@ function EditorSortableList<T extends SortableItem>({
     }),
     useSensor(TouchSensor, {
       activationConstraint: {
-        delay: 200,
-        tolerance: 5,
+        distance: 10,
       },
     }),
     useSensor(KeyboardSensor, {
@@ -479,7 +452,7 @@ function EditorSortableItemRow({
   return (
     <div
       className={cn(
-        "group/row flex select-none items-start gap-2 px-4 py-3 transition-colors hover:bg-muted/50",
+        "group/row flex items-start gap-2 px-4 py-3 transition-colors hover:bg-muted/50",
         className,
       )}
       data-slot="editor-sortable-item-row"
@@ -489,6 +462,7 @@ function EditorSortableItemRow({
 }
 
 function EditorDragHandle({
+  children,
   className,
   ...props
 }: React.ComponentProps<"button">) {
@@ -503,7 +477,7 @@ function EditorDragHandle({
   return (
     <button
       className={cn(
-        "relative mt-1 flex shrink-0 cursor-grab items-center justify-center text-muted-foreground transition-colors before:absolute before:top-1/2 before:left-1/2 before:size-full before:min-h-11 before:min-w-11 before:-translate-x-1/2 before:-translate-y-1/2 hover:text-foreground focus-visible:text-foreground focus-visible:outline-none active:cursor-grabbing",
+        "relative flex min-h-11 min-w-8 shrink-0 cursor-grab select-none items-center justify-center rounded-md font-mono text-muted-foreground text-sm tabular-nums transition-colors hover:bg-muted hover:text-foreground focus-visible:bg-muted focus-visible:text-foreground focus-visible:outline-none active:cursor-grabbing active:bg-muted",
         className,
       )}
       data-slot="editor-drag-handle"
@@ -511,7 +485,9 @@ function EditorDragHandle({
       {...listeners}
       {...props}
     >
-      <GripVerticalIcon className="size-4" />
+      {typeof children === "number"
+        ? String(children).padStart(2, "0")
+        : children}
     </button>
   );
 }
@@ -594,7 +570,6 @@ export {
   EditorListItemContent,
   EditorListItemDescription,
   EditorListItemLink,
-  EditorListItemPosition,
   EditorListItemTitle,
   EditorListProvider,
   EditorListSkeleton,

--- a/apps/editor/src/components/editor-list.tsx
+++ b/apps/editor/src/components/editor-list.tsx
@@ -7,6 +7,7 @@ import {
   DragOverlay,
   KeyboardSensor,
   PointerSensor,
+  TouchSensor,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
@@ -317,6 +318,12 @@ function EditorSortableList<T extends SortableItem>({
         distance: 8,
       },
     }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 200,
+        tolerance: 5,
+      },
+    }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     }),
@@ -496,7 +503,7 @@ function EditorDragHandle({
   return (
     <button
       className={cn(
-        "mt-1 flex shrink-0 cursor-grab touch-none items-center justify-center text-muted-foreground transition-colors hover:text-foreground focus-visible:text-foreground focus-visible:outline-none active:cursor-grabbing",
+        "relative mt-1 flex shrink-0 cursor-grab items-center justify-center text-muted-foreground transition-colors before:absolute before:top-1/2 before:left-1/2 before:size-full before:min-h-11 before:min-w-11 before:-translate-x-1/2 before:-translate-y-1/2 hover:text-foreground focus-visible:text-foreground focus-visible:outline-none active:cursor-grabbing",
         className,
       )}
       data-slot="editor-drag-handle"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable drag-and-drop on mobile with touch support, haptic feedback, and a larger numbered drag handle. Dragging is triggered from the handle; positions moved into it and links now only show titles.

- **New Features**
  - Added dnd-kit TouchSensor with a 150ms delay and 8px tolerance; PointerSensor uses an 8px activation distance to prevent accidental drags.
  - Moved the position into the drag handle and expanded its tap target; disabled text selection for smoother touch interactions.

<sup>Written for commit 427efd2793b83ca1451af8fbdf48f28d06ac58f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

