### PR TITLE
fix(editor): revalidate data after update

### DIFF
--- a/apps/editor/e2e/chapter-content.test.ts
+++ b/apps/editor/e2e/chapter-content.test.ts
@@ -216,4 +216,66 @@ test.describe("Chapter Content Page", () => {
       authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
     ).toBeVisible();
   });
+
+  test("updated title shows in course chapter list after navigating back", async ({
+    authenticatedPage,
+  }) => {
+    const { chapter, course } = await createTestChapter();
+    await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
+
+    const titleInput = authenticatedPage.getByRole("textbox", {
+      name: /edit chapter title/i,
+    });
+    const uniqueTitle = `Updated Chapter ${randomUUID().slice(0, 8)}`;
+
+    await titleInput.clear();
+    await titleInput.fill(uniqueTitle);
+    await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+    await expect(authenticatedPage.getByText(/^saved$/i)).not.toBeVisible();
+    await authenticatedPage.waitForLoadState("networkidle");
+
+    // Navigate back to course page via back link
+    const backLink = authenticatedPage.getByRole("link", {
+      name: course.title,
+    });
+    await backLink.click();
+
+    await expect(authenticatedPage).toHaveURL(
+      new RegExp(`/ai/c/en/${course.slug}$`),
+    );
+
+    // Verify the updated title shows in the chapter list
+    await expect(authenticatedPage.getByText(uniqueTitle)).toBeVisible();
+  });
+
+  test("updated description shows in course chapter list after navigating back", async ({
+    authenticatedPage,
+  }) => {
+    const { chapter, course } = await createTestChapter();
+    await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
+
+    const descriptionInput = authenticatedPage.getByRole("textbox", {
+      name: /edit chapter description/i,
+    });
+    const uniqueDescription = `Updated Description ${randomUUID().slice(0, 8)}`;
+
+    await descriptionInput.clear();
+    await descriptionInput.fill(uniqueDescription);
+    await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+    await expect(authenticatedPage.getByText(/^saved$/i)).not.toBeVisible();
+    await authenticatedPage.waitForLoadState("networkidle");
+
+    // Navigate back to course page via back link
+    const backLink = authenticatedPage.getByRole("link", {
+      name: course.title,
+    });
+    await backLink.click();
+
+    await expect(authenticatedPage).toHaveURL(
+      new RegExp(`/ai/c/en/${course.slug}$`),
+    );
+
+    // Verify the updated description shows in the chapter list
+    await expect(authenticatedPage.getByText(uniqueDescription)).toBeVisible();
+  });
 });

--- a/apps/editor/e2e/lesson-content.test.ts
+++ b/apps/editor/e2e/lesson-content.test.ts
@@ -249,4 +249,76 @@ test.describe("Lesson Content Page", () => {
       authenticatedPage.getByRole("textbox", { name: /edit chapter title/i }),
     ).toBeVisible();
   });
+
+  test("updated title shows in chapter lesson list after navigating back", async ({
+    authenticatedPage,
+  }) => {
+    const { chapter, course, lesson } = await createTestLesson();
+    await navigateToLessonPage(
+      authenticatedPage,
+      course.slug,
+      chapter.slug,
+      lesson.slug,
+    );
+
+    const titleInput = authenticatedPage.getByRole("textbox", {
+      name: /edit lesson title/i,
+    });
+    const uniqueTitle = `Updated Lesson ${randomUUID().slice(0, 8)}`;
+
+    await titleInput.clear();
+    await titleInput.fill(uniqueTitle);
+    await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+    await expect(authenticatedPage.getByText(/^saved$/i)).not.toBeVisible();
+    await authenticatedPage.waitForLoadState("networkidle");
+
+    // Navigate back to chapter page via back link
+    const backLink = authenticatedPage.getByRole("link", {
+      name: chapter.title,
+    });
+    await backLink.click();
+
+    await expect(authenticatedPage).toHaveURL(
+      new RegExp(`/ai/c/en/${course.slug}/ch/${chapter.slug}$`),
+    );
+
+    // Verify the updated title shows in the lesson list
+    await expect(authenticatedPage.getByText(uniqueTitle)).toBeVisible();
+  });
+
+  test("updated description shows in chapter lesson list after navigating back", async ({
+    authenticatedPage,
+  }) => {
+    const { chapter, course, lesson } = await createTestLesson();
+    await navigateToLessonPage(
+      authenticatedPage,
+      course.slug,
+      chapter.slug,
+      lesson.slug,
+    );
+
+    const descriptionInput = authenticatedPage.getByRole("textbox", {
+      name: /edit lesson description/i,
+    });
+    const uniqueDescription = `Updated Description ${randomUUID().slice(0, 8)}`;
+
+    await descriptionInput.clear();
+    await descriptionInput.fill(uniqueDescription);
+    await expect(authenticatedPage.getByText(/^saved$/i)).toBeVisible();
+    await expect(authenticatedPage.getByText(/^saved$/i)).not.toBeVisible();
+    await authenticatedPage.waitForLoadState("networkidle");
+
+    // Navigate back to chapter page via back link
+    const backLink = authenticatedPage.getByRole("link", {
+      name: chapter.title,
+    });
+    await backLink.click();
+
+    await expect(authenticatedPage).toHaveURL(
+      new RegExp(`/ai/c/en/${course.slug}/ch/${chapter.slug}$`),
+    );
+
+    // Verify the updated description shows in the lesson list
+    await expect(authenticatedPage.getByText(uniqueDescription)).toBeVisible();
+  });
 });

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
@@ -23,11 +23,17 @@ export async function checkChapterSlugExists(params: {
 }
 
 export async function updateChapterTitleAction(
-  chapterSlug: string,
-  courseSlug: string,
+  slugs: {
+    chapterSlug: string;
+    courseSlug: string;
+    lang: string;
+    orgSlug: string;
+  },
   chapterId: number,
   data: { title: string },
 ): Promise<{ error: string | null }> {
+  const { chapterSlug, courseSlug, lang, orgSlug } = slugs;
+
   const { error } = await updateChapter({
     chapterId,
     title: data.title,
@@ -44,15 +50,22 @@ export async function updateChapterTitleAction(
     ]);
   });
 
+  revalidatePath(`/${orgSlug}/c/${lang}/${courseSlug}`);
   return { error: null };
 }
 
 export async function updateChapterDescriptionAction(
-  chapterSlug: string,
-  courseSlug: string,
+  slugs: {
+    chapterSlug: string;
+    courseSlug: string;
+    lang: string;
+    orgSlug: string;
+  },
   chapterId: number,
   data: { description: string },
 ): Promise<{ error: string | null }> {
+  const { chapterSlug, courseSlug, lang, orgSlug } = slugs;
+
   const { error } = await updateChapter({
     chapterId,
     description: data.description,
@@ -69,6 +82,7 @@ export async function updateChapterDescriptionAction(
     ]);
   });
 
+  revalidatePath(`/${orgSlug}/c/${lang}/${courseSlug}`);
   return { error: null };
 }
 

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/chapter-content.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/chapter-content.tsx
@@ -28,6 +28,8 @@ export async function ChapterContent({
     return notFound();
   }
 
+  const slugs = { chapterSlug, courseSlug, lang, orgSlug };
+
   return (
     <ContentEditor
       descriptionLabel={t("Edit chapter description")}
@@ -35,12 +37,8 @@ export async function ChapterContent({
       entityId={chapter.id}
       initialDescription={chapter.description}
       initialTitle={chapter.title}
-      onSaveDescription={updateChapterDescriptionAction.bind(
-        null,
-        chapterSlug,
-        courseSlug,
-      )}
-      onSaveTitle={updateChapterTitleAction.bind(null, chapterSlug, courseSlug)}
+      onSaveDescription={updateChapterDescriptionAction.bind(null, slugs)}
+      onSaveTitle={updateChapterTitleAction.bind(null, slugs)}
       titleLabel={t("Edit chapter title")}
       titlePlaceholder={t("Chapter title…")}
     />

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/actions.ts
@@ -6,6 +6,7 @@ import {
   cacheTagCourse,
   cacheTagLesson,
 } from "@zoonk/utils/cache";
+import { revalidatePath } from "next/cache";
 import { after } from "next/server";
 import { lessonSlugExists } from "@/data/lessons/lesson-slug";
 import { updateLesson } from "@/data/lessons/update-lesson";
@@ -20,10 +21,18 @@ export async function checkLessonSlugExists(params: {
 }
 
 export async function updateLessonTitleAction(
-  slugs: { lessonSlug: string; chapterSlug: string; courseSlug: string },
+  slugs: {
+    chapterSlug: string;
+    courseSlug: string;
+    lang: string;
+    lessonSlug: string;
+    orgSlug: string;
+  },
   lessonId: number,
   data: { title: string },
 ): Promise<{ error: string | null }> {
+  const { chapterSlug, courseSlug, lang, lessonSlug, orgSlug } = slugs;
+
   const { error } = await updateLesson({
     lessonId,
     title: data.title,
@@ -35,20 +44,29 @@ export async function updateLessonTitleAction(
 
   after(async () => {
     await revalidateMainApp([
-      cacheTagLesson({ lessonSlug: slugs.lessonSlug }),
-      cacheTagChapter({ chapterSlug: slugs.chapterSlug }),
-      cacheTagCourse({ courseSlug: slugs.courseSlug }),
+      cacheTagLesson({ lessonSlug }),
+      cacheTagChapter({ chapterSlug }),
+      cacheTagCourse({ courseSlug }),
     ]);
   });
 
+  revalidatePath(`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}`);
   return { error: null };
 }
 
 export async function updateLessonDescriptionAction(
-  slugs: { lessonSlug: string; chapterSlug: string; courseSlug: string },
+  slugs: {
+    chapterSlug: string;
+    courseSlug: string;
+    lang: string;
+    lessonSlug: string;
+    orgSlug: string;
+  },
   lessonId: number,
   data: { description: string },
 ): Promise<{ error: string | null }> {
+  const { chapterSlug, courseSlug, lang, lessonSlug, orgSlug } = slugs;
+
   const { error } = await updateLesson({
     description: data.description,
     lessonId,
@@ -60,12 +78,13 @@ export async function updateLessonDescriptionAction(
 
   after(async () => {
     await revalidateMainApp([
-      cacheTagLesson({ lessonSlug: slugs.lessonSlug }),
-      cacheTagChapter({ chapterSlug: slugs.chapterSlug }),
-      cacheTagCourse({ courseSlug: slugs.courseSlug }),
+      cacheTagLesson({ lessonSlug }),
+      cacheTagChapter({ chapterSlug }),
+      cacheTagCourse({ courseSlug }),
     ]);
   });
 
+  revalidatePath(`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}`);
   return { error: null };
 }
 

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-content.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-content.tsx
@@ -28,7 +28,7 @@ export async function LessonContent({
     return notFound();
   }
 
-  const slugs = { chapterSlug, courseSlug, lessonSlug };
+  const slugs = { chapterSlug, courseSlug, lang, lessonSlug, orgSlug };
 
   return (
     <ContentEditor


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure chapter and lesson edits revalidate the parent pages so updated titles and descriptions show immediately after navigating back. Added e2e tests to verify the behavior.

- **Bug Fixes**
  - Revalidate course and chapter routes with revalidatePath after updating chapter or lesson content.
  - Pass orgSlug and lang to actions to build correct revalidation paths.
  - Update ChapterContent and LessonContent to bind actions with the full slugs object.
  - Add e2e tests confirming updated titles/descriptions appear in the chapter/lesson lists after returning to the parent page.

<sup>Written for commit a53ae2573721b5f832f8950fb501e1a452f0f196. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

