### PR TITLE
fix(ui): remove automatic vertical scrollbar from ScrollArea

### DIFF
--- a/apps/main/src/app/[locale]/(catalog)/courses/category-pills.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/courses/category-pills.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { buttonVariants } from "@zoonk/ui/components/button";
-import { ScrollArea, ScrollBar } from "@zoonk/ui/components/scroll-area";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { useSelectedLayoutSegment } from "next/navigation";
 import { useExtracted } from "next-intl";
@@ -29,36 +28,35 @@ export function CategoryPills() {
   const t = useExtracted();
 
   return (
-    <ScrollArea className="w-full px-4 pb-4">
-      <nav aria-label={t("Course categories")} className="flex gap-2">
-        <Link
-          className={buttonVariants({
-            size: "sm",
-            variant: segment === null ? "default" : "outline",
-          })}
-          href="/courses"
-        >
-          {t("All")}
-        </Link>
+    <nav
+      aria-label={t("Course categories")}
+      className="flex w-full gap-2 overflow-x-auto overflow-y-hidden px-4 pb-4 [-webkit-overflow-scrolling:touch] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+    >
+      <Link
+        className={buttonVariants({
+          size: "sm",
+          variant: segment === null ? "default" : "outline",
+        })}
+        href="/courses"
+      >
+        {t("All")}
+      </Link>
 
-        {categories
-          .sort((a, b) => a.label.localeCompare(b.label))
-          .map((category) => (
-            <Link
-              className={buttonVariants({
-                size: "sm",
-                variant: segment === category.key ? "default" : "outline",
-              })}
-              href={`/courses/${category.key}`}
-              key={category.key}
-            >
-              <category.icon aria-hidden className="size-4" />
-              {category.label}
-            </Link>
-          ))}
-      </nav>
-
-      <ScrollBar orientation="horizontal" />
-    </ScrollArea>
+      {categories
+        .sort((a, b) => a.label.localeCompare(b.label))
+        .map((category) => (
+          <Link
+            className={buttonVariants({
+              size: "sm",
+              variant: segment === category.key ? "default" : "outline",
+            })}
+            href={`/courses/${category.key}`}
+            key={category.key}
+          >
+            <category.icon aria-hidden className="size-4" />
+            {category.label}
+          </Link>
+        ))}
+    </nav>
   );
 }

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -20,7 +20,6 @@ function ScrollArea({
       >
         {children}
       </ScrollAreaPrimitive.Viewport>
-      <ScrollBar />
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
   );


### PR DESCRIPTION
The ScrollArea component was rendering a default vertical ScrollBar,
causing horizontal-only scroll areas (like category filters) to also
scroll vertically. This was especially noticeable on mobile devices.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed unwanted vertical scrolling in horizontal category filters on mobile. Addresses Linear PZUTB.

- **Bug Fixes**
  - ScrollArea no longer auto-renders a vertical ScrollBar.
  - CategoryPills now use native horizontal scroll (overflow-x-auto, overflow-y-hidden, hidden scrollbar, -webkit-overflow-scrolling: touch).

<sup>Written for commit 70828266462539d7d19ef890ebb3cea2c87b00c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

