### PR TITLE
refactor(main): rename subscription plan

### DIFF
--- a/apps/main/e2e/subscription.test.ts
+++ b/apps/main/e2e/subscription.test.ts
@@ -30,8 +30,6 @@ test.describe("Subscription Page - No Subscription", () => {
     await expect(
       authenticatedPage.getByRole("button", { name: /upgrade/i }),
     ).toBeVisible();
-
-    await expect(authenticatedPage.getByText(/upgrade to plus/i)).toBeVisible();
   });
 
   test("upgrade button shows loading state when clicked", async ({
@@ -61,7 +59,7 @@ test.describe("Subscription Page - With Subscription", () => {
 
     const subscription = await prisma.subscription.create({
       data: {
-        plan: "plus",
+        plan: "hobby",
         referenceId: String(user.id),
         status: "active",
         stripeCustomerId: `cus_test_e2e_${uniqueId}`,
@@ -81,7 +79,7 @@ test.describe("Subscription Page - With Subscription", () => {
       await userWithoutProgress.goto("/subscription");
 
       await expect(
-        userWithoutProgress.getByText(/you.re on zoonk plus/i),
+        userWithoutProgress.getByText(/your subscription is active/i),
       ).toBeVisible();
 
       const manageButton = userWithoutProgress.getByRole("button", {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -454,19 +454,14 @@ msgid "Remove ads, unlock unlimited lessons, and track your progress."
 msgstr "Remove ads, unlock unlimited lessons, and track your progress."
 
 #: src/app/[locale]/(settings)/subscription/subscription-page.tsx
-msgctxt "igjTln"
-msgid "Upgrade to Plus"
-msgstr "Upgrade to Plus"
-
-#: src/app/[locale]/(settings)/subscription/subscription-page.tsx
-msgctxt "iMhTwm"
-msgid "You’re on Zoonk Plus"
-msgstr "You’re on Zoonk Plus"
-
-#: src/app/[locale]/(settings)/subscription/subscription-page.tsx
 msgctxt "s1ZXI0"
 msgid "Unable to update your subscription. Contact us at hello@zoonk.com"
 msgstr "Unable to update your subscription. Contact us at hello@zoonk.com"
+
+#: src/app/[locale]/(settings)/subscription/subscription-page.tsx
+msgctxt "YCSaAY"
+msgid "Your subscription is active"
+msgstr "Your subscription is active"
 
 #: src/app/[locale]/(settings)/support/page.tsx
 #: src/app/[locale]/(settings)/support/support-content.tsx

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -454,19 +454,14 @@ msgid "Remove ads, unlock unlimited lessons, and track your progress."
 msgstr "Elimina los anuncios, desbloquea lecciones ilimitadas y haz seguimiento de tu progreso."
 
 #: src/app/[locale]/(settings)/subscription/subscription-page.tsx
-msgctxt "igjTln"
-msgid "Upgrade to Plus"
-msgstr "Mejorar a Plus"
-
-#: src/app/[locale]/(settings)/subscription/subscription-page.tsx
-msgctxt "iMhTwm"
-msgid "You’re on Zoonk Plus"
-msgstr "Estás en Zoonk Plus"
-
-#: src/app/[locale]/(settings)/subscription/subscription-page.tsx
 msgctxt "s1ZXI0"
 msgid "Unable to update your subscription. Contact us at hello@zoonk.com"
 msgstr "No se pudo actualizar tu suscripción. Contacta con nosotros en contacto@zoonk.com"
+
+#: src/app/[locale]/(settings)/subscription/subscription-page.tsx
+msgctxt "YCSaAY"
+msgid "Your subscription is active"
+msgstr "Tu suscripción está activa"
 
 #: src/app/[locale]/(settings)/support/page.tsx
 #: src/app/[locale]/(settings)/support/support-content.tsx

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -454,19 +454,14 @@ msgid "Remove ads, unlock unlimited lessons, and track your progress."
 msgstr "Remova anúncios, desbloqueie aulas ilimitadas e acompanhe seu progresso."
 
 #: src/app/[locale]/(settings)/subscription/subscription-page.tsx
-msgctxt "igjTln"
-msgid "Upgrade to Plus"
-msgstr "Fazer upgrade para Plus"
-
-#: src/app/[locale]/(settings)/subscription/subscription-page.tsx
-msgctxt "iMhTwm"
-msgid "You’re on Zoonk Plus"
-msgstr "Você está no Zoonk Plus"
-
-#: src/app/[locale]/(settings)/subscription/subscription-page.tsx
 msgctxt "s1ZXI0"
 msgid "Unable to update your subscription. Contact us at hello@zoonk.com"
 msgstr "Não foi possível atualizar sua assinatura. Entre em contato pelo email contato@zoonk.com"
+
+#: src/app/[locale]/(settings)/subscription/subscription-page.tsx
+msgctxt "YCSaAY"
+msgid "Your subscription is active"
+msgstr "Sua assinatura está ativa"
 
 #: src/app/[locale]/(settings)/support/page.tsx
 #: src/app/[locale]/(settings)/support/support-content.tsx

--- a/apps/main/src/app/[locale]/(settings)/subscription/subscription-page.tsx
+++ b/apps/main/src/app/[locale]/(settings)/subscription/subscription-page.tsx
@@ -23,8 +23,9 @@ export function SubscriptionPage() {
   const isLoading = state === "loading";
   const hasError = state === "error";
 
-  const title = subscription ? t("You’re on Zoonk Plus") : t("Upgrade to Plus");
+  const title = subscription ? t("Your subscription is active") : t("Upgrade");
   const action = subscription ? t("Manage subscription") : t("Upgrade");
+
   const description = subscription
     ? t("No ads, unlimited lessons, and full progress tracking.")
     : t("Remove ads, unlock unlimited lessons, and track your progress.");
@@ -34,7 +35,7 @@ export function SubscriptionPage() {
 
     const { error } = await authClient.subscription.upgrade({
       cancelUrl: "/subscription",
-      plan: "plus",
+      plan: "hobby",
       successUrl: "/subscription",
     });
 

--- a/i18n.lock
+++ b/i18n.lock
@@ -265,9 +265,8 @@ checksums:
     Upgrade/singular: 63c3b52882e0d779859307d672c178c2
     No%20ads%2C%20unlimited%20lessons%2C%20and%20full%20progress%20tracking./singular: 8f01b698721c3c79191463236f039529
     Remove%20ads%2C%20unlock%20unlimited%20lessons%2C%20and%20track%20your%20progress./singular: d935ae55f9b7faf08bf520b7457972ac
-    Upgrade%20to%20Plus/singular: 5ffe2178c10543c0be3b54a15c82da54
-    You%E2%80%99re%20on%20Zoonk%20Plus/singular: 5ca1a2563220c91f7eb44a60d2701a79
     Unable%20to%20update%20your%20subscription.%20Contact%20us%20at%20hello%40zoonk.com/singular: 07449ee5fe347be88856524cec7f06ef
+    Your%20subscription%20is%20active/singular: 4afa66402844306fde2bccddb4c31adc
     Get%20help%20with%20your%20account%2C%20courses%2C%20or%20any%20technical%20issues.%20Our%20support%20team%20is%20here%20to%20assist%20you./singular: 9de0c5af17bcf14dc8229ac5896db641
     Help%20%26%20Support/singular: 662d807b3768c9753238bd5f1c86d2f6
     Connect%20with%20the%20community%20and%20get%20answers/singular: ddbaaadbe1d98d93c6ceb40231559402
@@ -276,7 +275,6 @@ checksums:
     Follow%20us/singular: 778f7a4744f77dbcbd31a8c778cb5209
     Contact%20Support/singular: fcbd9e317c7286b3e08752eb73eb1a81
     Authentication%20Error/singular: f8db504523897fad229a0cfdcc34652c
-    The%20authentication%20token%20is%20missing.%20Please%20try%20logging%20in%20again./singular: 74e0970a1f77afba28fe761910aa4604
     Return%20to%20login/singular: a73bc2aa109b100645c49a3eab040dbf
     The%20authentication%20token%20is%20invalid%20or%20expired.%20Please%20try%20logging%20in%20again./singular: 9e23335b29f210d8ae14c265aeb6ab1a
     Need%20help%3F%20Contact%20us%20at%20hello%40zoonk.com/singular: 0053665fad1f58782cc3a6f442b36726

--- a/packages/auth/src/plugins/stripe.ts
+++ b/packages/auth/src/plugins/stripe.ts
@@ -22,9 +22,9 @@ export function stripePlugin() {
       }),
       plans: [
         {
-          annualDiscountLookupKey: "plus_yearly",
-          lookupKey: "plus_monthly",
-          name: "plus",
+          annualDiscountLookupKey: "hobby_yearly",
+          lookupKey: "hobby_monthly",
+          name: "hobby",
         },
       ],
     },

--- a/packages/db/src/prisma/migrations/20260108151835_add_cancel_fields_to_subscriptions/migration.sql
+++ b/packages/db/src/prisma/migrations/20260108151835_add_cancel_fields_to_subscriptions/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "subscriptions" ADD COLUMN     "cancel_at" TIMESTAMP(3),
+ADD COLUMN     "canceled_at" TIMESTAMP(3),
+ADD COLUMN     "ended_at" TIMESTAMP(3);

--- a/packages/db/src/prisma/models/accounts.prisma
+++ b/packages/db/src/prisma/models/accounts.prisma
@@ -141,6 +141,9 @@ model Subscription {
   trialStart           DateTime? @map("trial_start")
   trialEnd             DateTime? @map("trial_end")
   cancelAtPeriodEnd    Boolean?  @default(false) @map("cancel_at_period_end")
+  cancelAt             DateTime? @map("cancel_at")
+  canceledAt           DateTime? @map("canceled_at")
+  endedAt              DateTime? @map("ended_at")
   seats                Int?
 
   @@map("subscriptions")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the subscription plan from Plus to Hobby across the app and Stripe, and simplified the subscription page copy. Added new fields to track subscription cancellation.

- **Refactors**
  - Updated Stripe plan to hobby (lookup keys: hobby_monthly, hobby_yearly) and switched upgrade flow to plan: "hobby".
  - Replaced UI texts with "Upgrade" and "Your subscription is active"; updated tests and translations (en/es/pt).

- **Migration**
  - Added cancel_at, canceled_at, ended_at to subscriptions and updated the Prisma model.
  - Run the database migration.

<sup>Written for commit 7501f7c0665fbfc91ab03e520ba1ea572ac1214d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

