### PR TITLE
refactor(main): use list layout for courses

### DIFF
--- a/apps/main/e2e/course-detail.test.ts
+++ b/apps/main/e2e/course-detail.test.ts
@@ -45,10 +45,7 @@ test.describe("Course Detail Page - Locale", () => {
   }) => {
     await page.goto("/pt/courses");
 
-    await page
-      .getByRole("link", { name: /machine learning/i })
-      .first()
-      .click();
+    await page.getByRole("link", { name: /^Machine Learning/ }).click();
 
     await expect(page).toHaveURL(/\/pt\/b\/ai\/c\/machine-learning/);
 

--- a/apps/main/e2e/courses.test.ts
+++ b/apps/main/e2e/courses.test.ts
@@ -30,9 +30,7 @@ test.describe("Courses Page - Basic", () => {
       page.getByText(/start learning something new today/i),
     ).toBeVisible();
 
-    // Multiple courses should be visible from seed data
     await expect(page.getByText("Machine Learning").first()).toBeVisible();
-    await expect(page.getByText("Spanish").first()).toBeVisible();
   });
 
   test("clicking course card navigates to course detail", async ({ page }) => {
@@ -56,9 +54,7 @@ test.describe("Courses Page - Locale", () => {
       page.getByRole("heading", { name: /explorar cursos/i }),
     ).toBeVisible();
 
-    // Portuguese courses should be visible
     await expect(page.getByText("Machine Learning").first()).toBeVisible();
-    await expect(page.getByText("Espanhol").first()).toBeVisible();
   });
 
   test("unpublished courses are hidden", async ({ page }) => {

--- a/apps/main/src/app/[locale]/(catalog)/courses/[category]/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/courses/[category]/page.tsx
@@ -49,7 +49,7 @@ export default async function CategoryCourses({
   const courses = await listCourses({ category, language: locale });
 
   return (
-    <Container>
+    <Container variant="list">
       <ContainerHeader>
         <ContainerHeaderGroup>
           <ContainerTitle>{header.title}</ContainerTitle>

--- a/apps/main/src/app/[locale]/(catalog)/courses/course-list-client.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/courses/course-list-client.tsx
@@ -62,7 +62,7 @@ export function CourseListClient({
 
   return (
     <>
-      <CourseListGroup>
+      <CourseListGroup layout="list">
         {courses.map((course) => (
           <CourseListItemView
             course={toCourseListItem(course)}

--- a/apps/main/src/app/[locale]/(catalog)/courses/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/courses/page.tsx
@@ -39,7 +39,7 @@ export default async function Courses({
   const courses = await listCourses({ language: locale });
 
   return (
-    <Container>
+    <Container variant="list">
       <ContainerHeader>
         <ContainerHeaderGroup>
           <ContainerTitle>{t("Explore courses")}</ContainerTitle>

--- a/apps/main/src/app/[locale]/(catalog)/my/user-course-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/my/user-course-list.tsx
@@ -61,7 +61,7 @@ export async function UserCourseList() {
   }
 
   return (
-    <CourseListGroup>
+    <CourseListGroup layout="list">
       {courses.map((course) => (
         <CourseListItemView
           course={toCourseListItem(course)}
@@ -89,5 +89,5 @@ export async function UserCourseList() {
 }
 
 export function UserCourseListSkeleton() {
-  return <CourseListSkeleton count={5} />;
+  return <CourseListSkeleton />;
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -30,6 +30,7 @@
     "db:generate:e2e": "env $(cat .env.e2e | xargs) prisma generate --sql",
     "db:migrate": "prisma migrate dev",
     "db:reset": "prisma migrate reset",
+    "db:reset:e2e": "env $(cat .env.e2e | xargs) prisma migrate reset",
     "db:seed": "prisma db seed",
     "db:seed:e2e": "env $(cat .env.e2e | xargs) prisma db seed",
     "db:setup:e2e": "env $(cat .env.e2e | xargs) prisma migrate deploy",

--- a/packages/db/src/prisma/seed/courses.ts
+++ b/packages/db/src/prisma/seed/courses.ts
@@ -77,6 +77,156 @@ export const coursesData = [
     slug: "data-science",
     title: "Data Science",
   },
+  {
+    description:
+      "Learn the fundamentals of economics including microeconomics, macroeconomics, market structures, and economic policy. Understand how economies function and make informed financial decisions.",
+    imageUrl: null,
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString("Introduction to Economics"),
+    slug: "introduction-to-economics",
+    title: "Introduction to Economics",
+  },
+  {
+    description:
+      "Master digital photography from camera basics to advanced composition techniques. Learn lighting, post-processing, and develop your artistic vision.",
+    imageUrl: null,
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString("Digital Photography"),
+    slug: "digital-photography",
+    title: "Digital Photography",
+  },
+  {
+    description:
+      "Understand the principles of nutrition and how food affects your health. Learn about macronutrients, micronutrients, meal planning, and evidence-based dietary guidelines.",
+    imageUrl: null,
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString("Nutrition Fundamentals"),
+    slug: "nutrition-fundamentals",
+    title: "Nutrition Fundamentals",
+  },
+  {
+    description:
+      "Explore the history and techniques of Western philosophy. From ancient Greek thinkers to modern existentialism, develop critical thinking and analytical skills.",
+    imageUrl: null,
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString("Philosophy"),
+    slug: "philosophy",
+    title: "Philosophy",
+  },
+  {
+    description:
+      "Learn to play guitar from scratch. Covers chords, strumming patterns, fingerpicking, music theory, and popular songs across various genres.",
+    imageUrl: null,
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString("Guitar for Beginners"),
+    slug: "guitar-for-beginners",
+    title: "Guitar for Beginners",
+  },
+  {
+    description:
+      "Develop essential public speaking skills. Learn to structure presentations, engage audiences, overcome stage fright, and communicate with confidence.",
+    imageUrl: null,
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString("Public Speaking"),
+    slug: "public-speaking",
+    title: "Public Speaking",
+  },
+  {
+    description:
+      "Introduction to psychology covering cognition, behavior, development, social interactions, and mental health. Understand how the human mind works.",
+    imageUrl: null,
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString("Psychology 101"),
+    slug: "psychology-101",
+    title: "Psychology 101",
+  },
+  {
+    description:
+      "Learn calculus from limits and derivatives to integrals and series. Build a strong mathematical foundation for science and engineering fields.",
+    imageUrl: null,
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString("Calculus"),
+    slug: "calculus",
+    title: "Calculus",
+  },
+  {
+    description:
+      "Master the art of creative writing. Learn storytelling techniques, character development, dialogue, and how to craft compelling narratives.",
+    imageUrl: null,
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString("Creative Writing"),
+    slug: "creative-writing",
+    title: "Creative Writing",
+  },
+  {
+    description:
+      "Understand climate science and environmental challenges. Learn about ecosystems, sustainability, renewable energy, and how to address climate change.",
+    imageUrl: null,
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString("Environmental Science"),
+    slug: "environmental-science",
+    title: "Environmental Science",
+  },
+  {
+    description:
+      "Learn UI/UX design principles and modern design tools. Create user-centered interfaces, wireframes, prototypes, and conduct usability testing.",
+    imageUrl: null,
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString("UI/UX Design"),
+    slug: "ui-ux-design",
+    title: "UI/UX Design",
+  },
+  {
+    description:
+      "Explore world history from ancient civilizations to modern times. Understand key events, movements, and figures that shaped our world.",
+    imageUrl: null,
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString("World History"),
+    slug: "world-history",
+    title: "World History",
+  },
+  {
+    description:
+      "Master personal finance including budgeting, investing, retirement planning, and debt management. Build wealth and achieve financial independence.",
+    imageUrl: null,
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString("Personal Finance"),
+    slug: "personal-finance",
+    title: "Personal Finance",
+  },
+  {
+    description:
+      "Learn Japanese from basic hiragana and katakana to conversational fluency. Covers grammar, vocabulary, kanji, and cultural context.",
+    imageUrl: null,
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString("Japanese Language"),
+    slug: "japanese-language",
+    title: "Japanese Language",
+  },
+  {
+    description:
+      "Introduction to biology covering cells, genetics, evolution, ecology, and human anatomy. Understand the fundamental principles of life.",
+    imageUrl: null,
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString("Biology Essentials"),
+    slug: "biology-essentials",
+    title: "Biology Essentials",
+  },
 
   // Portuguese courses
   {
@@ -111,6 +261,186 @@ export const coursesData = [
     normalizedTitle: normalizeString("Astronomia"),
     slug: "astronomia",
     title: "Astronomia",
+  },
+  {
+    description:
+      "Domine a programação Python desde os fundamentos até conceitos avançados. Aprenda sintaxe, estruturas de dados, funções, programação orientada a objetos e construa aplicações reais.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Programação Python"),
+    slug: "programacao-python",
+    title: "Programação Python",
+  },
+  {
+    description:
+      "Construa aplicações web modernas com HTML, CSS, JavaScript e frameworks populares. Aprenda desenvolvimento frontend e backend, APIs e estratégias de deploy.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Desenvolvimento Web"),
+    slug: "desenvolvimento-web",
+    title: "Desenvolvimento Web",
+  },
+  {
+    description:
+      "Analise e interprete dados complexos usando métodos estatísticos e ferramentas de visualização. Aprenda manipulação de dados, análise exploratória e aplicações de machine learning.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Ciência de Dados"),
+    slug: "ciencia-de-dados",
+    title: "Ciência de Dados",
+  },
+  {
+    description:
+      "Aprenda os fundamentos da economia incluindo microeconomia, macroeconomia, estruturas de mercado e política econômica. Entenda como as economias funcionam e tome decisões financeiras informadas.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Introdução à Economia"),
+    slug: "introducao-a-economia",
+    title: "Introdução à Economia",
+  },
+  {
+    description:
+      "Domine a fotografia digital desde o básico da câmera até técnicas avançadas de composição. Aprenda iluminação, pós-processamento e desenvolva sua visão artística.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Fotografia Digital"),
+    slug: "fotografia-digital",
+    title: "Fotografia Digital",
+  },
+  {
+    description:
+      "Entenda os princípios da nutrição e como a alimentação afeta sua saúde. Aprenda sobre macronutrientes, micronutrientes, planejamento de refeições e diretrizes alimentares baseadas em evidências.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Fundamentos de Nutrição"),
+    slug: "fundamentos-de-nutricao",
+    title: "Fundamentos de Nutrição",
+  },
+  {
+    description:
+      "Explore a história e técnicas da filosofia ocidental. Dos pensadores gregos antigos ao existencialismo moderno, desenvolva pensamento crítico e habilidades analíticas.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Filosofia"),
+    slug: "filosofia",
+    title: "Filosofia",
+  },
+  {
+    description:
+      "Aprenda a tocar violão do zero. Cobre acordes, padrões de batida, dedilhado, teoria musical e músicas populares de vários gêneros.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Violão para Iniciantes"),
+    slug: "violao-para-iniciantes",
+    title: "Violão para Iniciantes",
+  },
+  {
+    description:
+      "Desenvolva habilidades essenciais de oratória. Aprenda a estruturar apresentações, engajar audiências, superar o medo de palco e comunicar-se com confiança.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Oratória"),
+    slug: "oratoria",
+    title: "Oratória",
+  },
+  {
+    description:
+      "Introdução à psicologia cobrindo cognição, comportamento, desenvolvimento, interações sociais e saúde mental. Entenda como a mente humana funciona.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Psicologia"),
+    slug: "psicologia",
+    title: "Psicologia",
+  },
+  {
+    description:
+      "Aprenda cálculo desde limites e derivadas até integrais e séries. Construa uma base matemática sólida para áreas de ciência e engenharia.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Cálculo"),
+    slug: "calculo",
+    title: "Cálculo",
+  },
+  {
+    description:
+      "Domine a arte da escrita criativa. Aprenda técnicas de narrativa, desenvolvimento de personagens, diálogos e como criar histórias envolventes.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Escrita Criativa"),
+    slug: "escrita-criativa",
+    title: "Escrita Criativa",
+  },
+  {
+    description:
+      "Entenda a ciência do clima e os desafios ambientais. Aprenda sobre ecossistemas, sustentabilidade, energia renovável e como enfrentar as mudanças climáticas.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Ciências Ambientais"),
+    slug: "ciencias-ambientais",
+    title: "Ciências Ambientais",
+  },
+  {
+    description:
+      "Aprenda princípios de design UI/UX e ferramentas modernas de design. Crie interfaces centradas no usuário, wireframes, protótipos e conduza testes de usabilidade.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Design UI/UX"),
+    slug: "design-ui-ux",
+    title: "Design UI/UX",
+  },
+  {
+    description:
+      "Explore a história mundial das civilizações antigas até os tempos modernos. Entenda eventos-chave, movimentos e figuras que moldaram nosso mundo.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("História Mundial"),
+    slug: "historia-mundial",
+    title: "História Mundial",
+  },
+  {
+    description:
+      "Domine finanças pessoais incluindo orçamento, investimentos, planejamento de aposentadoria e gestão de dívidas. Construa riqueza e alcance independência financeira.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Finanças Pessoais"),
+    slug: "financas-pessoais",
+    title: "Finanças Pessoais",
+  },
+  {
+    description:
+      "Aprenda inglês do básico à fluência conversacional. Cobre gramática, vocabulário, pronúncia e contexto cultural para comunicação eficaz.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Inglês"),
+    slug: "ingles",
+    title: "Inglês",
+  },
+  {
+    description:
+      "Introdução à biologia cobrindo células, genética, evolução, ecologia e anatomia humana. Entenda os princípios fundamentais da vida.",
+    imageUrl: null,
+    isPublished: true,
+    language: "pt",
+    normalizedTitle: normalizeString("Biologia"),
+    slug: "biologia",
+    title: "Biologia",
   },
 ];
 

--- a/packages/ui/src/patterns/courses/course-list.tsx
+++ b/packages/ui/src/patterns/courses/course-list.tsx
@@ -70,10 +70,18 @@ export function CourseListGroup({
   );
 }
 
-export function CourseListSkeleton({ count = 12 }: { count?: number }) {
+export function CourseListSkeleton({
+  count,
+  layout = "list",
+}: {
+  count?: number;
+  layout?: ItemGroupProps["layout"];
+}) {
+  const defaultCount = layout === "list" ? 5 : 12;
+
   return (
-    <ItemGroup layout="grid">
-      {Array.from({ length: count }).map((_, index) => (
+    <ItemGroup layout={layout}>
+      {Array.from({ length: count ?? defaultCount }).map((_, index) => (
         <Item key={index}>
           <ItemMedia
             className="size-16 translate-y-0.5 self-start"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the courses catalog and “My Courses” to a list layout for clearer browsing. Also adds a layout-aware skeleton, expands seed data, and updates an e2e selector.

- **Refactors**
  - Use Container variant="list" in /courses and /courses/[category].
  - Render CourseListGroup with layout="list" in catalog and user course list.
  - Make CourseListSkeleton layout-aware with default count (list=5, grid=12).
  - Update e2e test to click the "Machine Learning" link using an anchored name.

- **Migration**
  - Seed the new courses data (db:seed or db:seed:e2e).
  - Use the new db:reset:e2e script when resetting the test database.

<sup>Written for commit 4b524892f962438734a2fe1e55efbbc266a9f68b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

