### PR TITLE
feat(main): display energy level

### DIFF
--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -23,6 +23,12 @@ test.describe("Home Page - Unauthenticated", () => {
       page.getByRole("heading", { name: /what do you want to learn/i }),
     ).toBeVisible();
   });
+
+  test("does not show performance section", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByText(/^performance$/i)).not.toBeVisible();
+  });
 });
 
 test.describe("Home Page - Authenticated", () => {
@@ -55,6 +61,30 @@ test.describe("Home Page - Authenticated", () => {
       userWithoutProgress.getByRole("heading", {
         name: /learn anything with ai/i,
       }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("Home Page - Performance Section", () => {
+  test("authenticated user with progress sees energy level", async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto("/");
+
+    await expect(authenticatedPage.getByText(/^performance$/i)).toBeVisible();
+    await expect(
+      authenticatedPage.getByText("Your energy level is 75%"),
+    ).toBeVisible();
+  });
+
+  test("user without progress sees energy level at 0%", async ({
+    userWithoutProgress,
+  }) => {
+    await userWithoutProgress.goto("/");
+
+    await expect(userWithoutProgress.getByText(/^performance$/i)).toBeVisible();
+    await expect(
+      userWithoutProgress.getByText("Your energy level is 0%"),
     ).toBeVisible();
   });
 });

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -207,6 +207,26 @@ msgctxt "z6saPZ"
 msgid "Explore all Zoonk courses to learn anything using AI. Find interactive lessons, challenges, and activities to learn subjects like science, math, technology, and more."
 msgstr "Explore all Zoonk courses to learn anything using AI. Find interactive lessons, challenges, and activities to learn subjects like science, math, technology, and more."
 
+#: src/app/[locale]/(catalog)/energy-level.tsx
+msgctxt "aRv72g"
+msgid "Energy level"
+msgstr "Energy level"
+
+#: src/app/[locale]/(catalog)/energy-level.tsx
+msgctxt "soDmlG"
+msgid "Keep learning to increase it"
+msgstr "Keep learning to increase it"
+
+#: src/app/[locale]/(catalog)/energy-level.tsx
+msgctxt "UW6IeG"
+msgid "Your energy level is {value}%"
+msgstr "Your energy level is {value}%"
+
+#: src/app/[locale]/(catalog)/energy-level.tsx
+msgctxt "WgeB0r"
+msgid "Keep learning to maintain it"
+msgstr "Keep learning to maintain it"
+
 #: src/app/[locale]/(catalog)/hero.tsx
 msgctxt "nlT+zW"
 msgid "Learn anything"
@@ -346,6 +366,11 @@ msgstr "Zoonk: AI Learning Platform"
 msgctxt "ZgSctJ"
 msgid "Zoonk is an AI-powered learning platform where you can learn anything through interactive courses, lessons, and activities."
 msgstr "Zoonk is an AI-powered learning platform where you can learn anything through interactive courses, lessons, and activities."
+
+#: src/app/[locale]/(catalog)/performance.tsx
+msgctxt "AA5h7P"
+msgid "Performance"
+msgstr "Performance"
 
 #: src/app/[locale]/(settings)/_components/protected-section.tsx
 msgctxt "2jC0rX"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -207,6 +207,26 @@ msgctxt "z6saPZ"
 msgid "Explore all Zoonk courses to learn anything using AI. Find interactive lessons, challenges, and activities to learn subjects like science, math, technology, and more."
 msgstr "Explora todos los cursos de Zoonk para aprender cualquier cosa usando IA. Encuentra lecciones interactivas, desafíos y actividades para aprender materias como ciencia, matemáticas, tecnología y más."
 
+#: src/app/[locale]/(catalog)/energy-level.tsx
+msgctxt "aRv72g"
+msgid "Energy level"
+msgstr "Nivel de energía"
+
+#: src/app/[locale]/(catalog)/energy-level.tsx
+msgctxt "soDmlG"
+msgid "Keep learning to increase it"
+msgstr "Sigue aprendiendo para aumentarlo"
+
+#: src/app/[locale]/(catalog)/energy-level.tsx
+msgctxt "UW6IeG"
+msgid "Your energy level is {value}%"
+msgstr "Tu nivel de energía es {value}%"
+
+#: src/app/[locale]/(catalog)/energy-level.tsx
+msgctxt "WgeB0r"
+msgid "Keep learning to maintain it"
+msgstr "Sigue aprendiendo para mantenerlo"
+
 #: src/app/[locale]/(catalog)/hero.tsx
 msgctxt "nlT+zW"
 msgid "Learn anything"
@@ -346,6 +366,11 @@ msgstr "Zoonk: plataforma de aprendizaje con IA"
 msgctxt "ZgSctJ"
 msgid "Zoonk is an AI-powered learning platform where you can learn anything through interactive courses, lessons, and activities."
 msgstr "Zoonk es una plataforma de aprendizaje impulsada por IA donde puedes aprender cualquier cosa a través de cursos interactivos, lecciones y actividades."
+
+#: src/app/[locale]/(catalog)/performance.tsx
+msgctxt "AA5h7P"
+msgid "Performance"
+msgstr "Rendimiento"
 
 #: src/app/[locale]/(settings)/_components/protected-section.tsx
 msgctxt "2jC0rX"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -207,6 +207,26 @@ msgctxt "z6saPZ"
 msgid "Explore all Zoonk courses to learn anything using AI. Find interactive lessons, challenges, and activities to learn subjects like science, math, technology, and more."
 msgstr "Explore todos os cursos do Zoonk para aprender qualquer coisa usando IA. Encontre aulas interativas, desafios e atividades para aprender matérias como ciência, matemática, tecnologia e muito mais."
 
+#: src/app/[locale]/(catalog)/energy-level.tsx
+msgctxt "aRv72g"
+msgid "Energy level"
+msgstr "Nível de energia"
+
+#: src/app/[locale]/(catalog)/energy-level.tsx
+msgctxt "soDmlG"
+msgid "Keep learning to increase it"
+msgstr "Continue aprendendo para aumentá-lo"
+
+#: src/app/[locale]/(catalog)/energy-level.tsx
+msgctxt "UW6IeG"
+msgid "Your energy level is {value}%"
+msgstr "Seu nível de energia é {value}%"
+
+#: src/app/[locale]/(catalog)/energy-level.tsx
+msgctxt "WgeB0r"
+msgid "Keep learning to maintain it"
+msgstr "Continue aprendendo para mantê-lo"
+
 #: src/app/[locale]/(catalog)/hero.tsx
 msgctxt "nlT+zW"
 msgid "Learn anything"
@@ -346,6 +366,11 @@ msgstr "Zoonk: plataforma de aprendizagem com IA"
 msgctxt "ZgSctJ"
 msgid "Zoonk is an AI-powered learning platform where you can learn anything through interactive courses, lessons, and activities."
 msgstr "O Zoonk é uma plataforma de aprendizagem com IA onde você pode aprender qualquer coisa através de cursos interativos, aulas e atividades."
+
+#: src/app/[locale]/(catalog)/performance.tsx
+msgctxt "AA5h7P"
+msgid "Performance"
+msgstr "Desempenho"
 
 #: src/app/[locale]/(settings)/_components/protected-section.tsx
 msgctxt "2jC0rX"

--- a/apps/main/src/app/[locale]/(catalog)/energy-level.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/energy-level.tsx
@@ -11,11 +11,16 @@ import {
 } from "@zoonk/ui/components/feature";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { ZapIcon } from "lucide-react";
-import { getExtracted } from "next-intl/server";
+import { getExtracted, getLocale } from "next-intl/server";
 
 export async function EnergyLevel({ energy }: { energy: number }) {
   const t = await getExtracted();
-  const roundedEnergy = Math.round(energy);
+  const locale = await getLocale();
+
+  const formattedEnergy = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 1,
+    trailingZeroDisplay: "stripIfInteger",
+  }).format(energy);
 
   const description =
     energy < 100
@@ -36,7 +41,7 @@ export async function EnergyLevel({ energy }: { energy: number }) {
 
       <FeatureCardBody>
         <FeatureCardTitle>
-          {t("Your energy level is {value}%", { value: String(roundedEnergy) })}
+          {t("Your energy level is {value}%", { value: formattedEnergy })}
         </FeatureCardTitle>
         <FeatureCardSubtitle>{description}</FeatureCardSubtitle>
       </FeatureCardBody>

--- a/apps/main/src/app/[locale]/(catalog)/energy-level.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/energy-level.tsx
@@ -1,0 +1,58 @@
+import {
+  FeatureCard,
+  FeatureCardBody,
+  FeatureCardHeader,
+  FeatureCardHeaderContent,
+  FeatureCardIcon,
+  FeatureCardIndicator,
+  FeatureCardLabel,
+  FeatureCardSubtitle,
+  FeatureCardTitle,
+} from "@zoonk/ui/components/feature";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { ZapIcon } from "lucide-react";
+import { getExtracted } from "next-intl/server";
+
+export async function EnergyLevel({ energy }: { energy: number }) {
+  const t = await getExtracted();
+  const roundedEnergy = Math.round(energy);
+
+  const description =
+    energy < 100
+      ? t("Keep learning to increase it")
+      : t("Keep learning to maintain it");
+
+  return (
+    <FeatureCard className="w-full max-w-xs">
+      <FeatureCardHeader className="text-orange-500">
+        <FeatureCardHeaderContent>
+          <FeatureCardIcon>
+            <ZapIcon />
+          </FeatureCardIcon>
+          <FeatureCardLabel>{t("Energy level")}</FeatureCardLabel>
+        </FeatureCardHeaderContent>
+        <FeatureCardIndicator />
+      </FeatureCardHeader>
+
+      <FeatureCardBody>
+        <FeatureCardTitle>
+          {t("Your energy level is {value}%", { value: String(roundedEnergy) })}
+        </FeatureCardTitle>
+        <FeatureCardSubtitle>{description}</FeatureCardSubtitle>
+      </FeatureCardBody>
+    </FeatureCard>
+  );
+}
+
+export function EnergyLevelSkeleton() {
+  return (
+    <FeatureCard className="w-full max-w-xs">
+      <Skeleton className="h-5 w-28" />
+
+      <FeatureCardBody className="gap-1">
+        <Skeleton className="h-4 w-full max-w-40" />
+        <Skeleton className="h-3 w-full max-w-28" />
+      </FeatureCardBody>
+    </FeatureCard>
+  );
+}

--- a/apps/main/src/app/[locale]/(catalog)/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/page.tsx
@@ -2,10 +2,12 @@ import type { Metadata } from "next";
 import { getExtracted, setRequestLocale } from "next-intl/server";
 import { Suspense } from "react";
 import { getContinueLearning } from "@/data/courses/get-continue-learning";
+import { getEnergyLevel } from "@/data/progress/get-energy-level";
 import {
   ContinueLearning,
   ContinueLearningSkeleton,
 } from "./continue-learning";
+import { Performance, PerformanceSkeleton } from "./performance";
 
 export async function generateMetadata({
   params,
@@ -26,11 +28,17 @@ export default async function Home({ params }: PageProps<"/[locale]">) {
   setRequestLocale(locale);
 
   // preload data
-  void getContinueLearning();
+  void Promise.all([getContinueLearning(), getEnergyLevel()]);
 
   return (
-    <Suspense fallback={<ContinueLearningSkeleton />}>
-      <ContinueLearning />
-    </Suspense>
+    <>
+      <Suspense fallback={<ContinueLearningSkeleton />}>
+        <ContinueLearning />
+      </Suspense>
+
+      <Suspense fallback={<PerformanceSkeleton />}>
+        <Performance />
+      </Suspense>
+    </>
   );
 }

--- a/apps/main/src/app/[locale]/(catalog)/performance.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/performance.tsx
@@ -1,0 +1,45 @@
+import { FeatureCardSectionTitle } from "@zoonk/ui/components/feature";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { cacheLife } from "next/cache";
+import { getExtracted } from "next-intl/server";
+import { getEnergyLevel } from "@/data/progress/get-energy-level";
+import { EnergyLevel, EnergyLevelSkeleton } from "./energy-level";
+
+export async function Performance() {
+  "use cache: private";
+  cacheLife("minutes");
+
+  const t = await getExtracted();
+  const energyData = await getEnergyLevel();
+
+  if (!energyData) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-labelledby="performance-title"
+      className="flex flex-col gap-3 py-4 md:py-6"
+    >
+      <FeatureCardSectionTitle className="px-4" id="performance-title">
+        {t("Performance")}
+      </FeatureCardSectionTitle>
+
+      <div className="flex flex-wrap gap-4 px-4">
+        <EnergyLevel energy={energyData.currentEnergy} />
+      </div>
+    </section>
+  );
+}
+
+export function PerformanceSkeleton() {
+  return (
+    <section className="flex flex-col gap-3 py-4 md:py-6">
+      <Skeleton className="mx-4 h-5 w-24" />
+
+      <div className="flex flex-wrap gap-4 px-4">
+        <EnergyLevelSkeleton />
+      </div>
+    </section>
+  );
+}

--- a/apps/main/src/data/progress/get-energy-level.test.ts
+++ b/apps/main/src/data/progress/get-energy-level.test.ts
@@ -1,0 +1,37 @@
+import { prisma } from "@zoonk/db";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { describe, expect, test } from "vitest";
+import { getEnergyLevel } from "./get-energy-level";
+
+describe("unauthenticated users", () => {
+  test("returns null", async () => {
+    const result = await getEnergyLevel({ headers: new Headers() });
+    expect(result).toBeNull();
+  });
+});
+
+describe("authenticated users", () => {
+  test("returns 0 when user has no progress record", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+
+    const result = await getEnergyLevel({ headers });
+    expect(result).toEqual({ currentEnergy: 0 });
+  });
+
+  test("returns energy level when user has progress record", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+
+    await prisma.userProgress.create({
+      data: {
+        currentEnergy: 85.5,
+        userId: Number(user.id),
+      },
+    });
+
+    const result = await getEnergyLevel({ headers });
+    expect(result).toEqual({ currentEnergy: 85.5 });
+  });
+});

--- a/apps/main/src/data/progress/get-energy-level.ts
+++ b/apps/main/src/data/progress/get-energy-level.ts
@@ -1,0 +1,37 @@
+import "server-only";
+
+import { getSession } from "@zoonk/core/users/session/get";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { cache } from "react";
+
+export type EnergyLevelData = {
+  currentEnergy: number;
+};
+
+export const getEnergyLevel = cache(
+  async (params?: { headers?: Headers }): Promise<EnergyLevelData | null> => {
+    const session = await getSession({ headers: params?.headers });
+
+    if (!session) {
+      return null;
+    }
+
+    const userId = Number(session.user.id);
+
+    const { data: progress, error } = await safeAsync(() =>
+      prisma.userProgress.findUnique({
+        select: { currentEnergy: true },
+        where: { userId },
+      }),
+    );
+
+    if (error) {
+      return null;
+    }
+
+    return {
+      currentEnergy: progress?.currentEnergy ?? 0,
+    };
+  },
+);

--- a/i18n.lock
+++ b/i18n.lock
@@ -216,6 +216,11 @@ checksums:
     Online%20Courses%20using%20AI/singular: 4e3c619f363cc66f3f2e604e372ca038
     Explore%20courses/singular: 3a60fa1d4a1a6cfffcc0573e3366cd35
     Explore%20all%20Zoonk%20courses%20to%20learn%20anything%20using%20AI.%20Find%20interactive%20lessons%2C%20challenges%2C%20and%20activities%20to%20learn%20subjects%20like%20science%2C%20math%2C%20technology%2C%20and%20more./singular: c3f4a7dfd17b4523b5535f40170c7731
+    Energy%20level/singular: 9c2b27fe5529d52a24e9cff65feda402
+    "%7Bvalue%7D%25/singular": 35cbe4d3fffd3e6b5415eea333f532d7
+    Keep%20learning%20to%20increase%20it/singular: a3c3f15ac29089d9448b0971126cabf7
+    Your%20energy%20level%20is%20%7Bvalue%7D%25/singular: ca18bb24c0e7c81836adda3a098e20f7
+    Keep%20learning%20to%20maintain%20it/singular: 0d21c6a7c014a9e42e97c37d4e8d9674
     Learn%20anything/singular: 1409ee983014ff2deefb61aa0fbc570d
     Learn%20anything%20with%20AI/singular: 0ee713125135f591c75af6e19f94f03a
     Interactive%20courses%20built%20for%20you.%20Just%20tell%20us%20what%20you%20want%20to%20learn./singular: 30ce55333f2080aaf0681647cb26bfbb
@@ -244,6 +249,7 @@ checksums:
     No%20courses%20yet/singular: d5fcc38466fdc83a74eab5032a2f85b6
     Zoonk%3A%20AI%20Learning%20Platform/singular: 4a2d25490f4a5e5cd4543f48fcec968d
     Zoonk%20is%20an%20AI-powered%20learning%20platform%20where%20you%20can%20learn%20anything%20through%20interactive%20courses%2C%20lessons%2C%20and%20activities./singular: e836899ce8100db55d5fa54fe6375970
+    Performance/singular: 28b6d3a3d4a53afa0617a180e318ff4d
     Checking%20if%20you're%20logged%20in.../singular: b50f05bfcb51cad6913150273e551291
     You%20need%20to%20be%20logged%20in%20to%20access%20this%20page./singular: 759ca522663d8f628718332f756dd6c4
     Display%20name/singular: 725f331065e9d594d720d07b1ae51a90

--- a/packages/ui/src/components/feature.tsx
+++ b/packages/ui/src/components/feature.tsx
@@ -10,7 +10,7 @@ function FeatureCardSectionTitle({
   return (
     <h2
       className={cn(
-        "font-medium text-muted-foreground text-sm tracking-tight",
+        "font-medium text-muted-foreground text-xs uppercase tracking-wide",
         className,
       )}
       data-slot="feature-card-section-title"
@@ -45,7 +45,7 @@ function FeatureCardHeader({
   return (
     <div
       className={cn(
-        "flex items-center justify-between text-muted-foreground transition-colors group-hover/feature-card:text-secondary-foreground",
+        "flex items-center justify-between text-muted-foreground",
         className,
       )}
       data-slot="feature-card-header"
@@ -96,7 +96,10 @@ function FeatureCardLabel({
 }: React.ComponentProps<"span">) {
   return (
     <span
-      className={cn("truncate font-light text-sm transition-colors", className)}
+      className={cn(
+        "truncate font-medium text-sm transition-colors",
+        className,
+      )}
       data-slot="feature-card-label"
       {...props}
     >
@@ -252,7 +255,7 @@ function FeatureCardSubtitle({
   return (
     <div
       className={cn(
-        "mb-0.5 truncate text-muted-foreground text-sm [&>a]:underline-offset-2 [&>a]:transition-colors [&>a]:hover:text-muted-foreground/80 [&>a]:hover:underline",
+        "mb-0.5 truncate text-muted-foreground text-sm tracking-tight [&>a]:underline-offset-2 [&>a]:transition-colors [&>a]:hover:text-muted-foreground/80 [&>a]:hover:underline",
         className,
       )}
       data-slot="feature-card-subtitle"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a new Performance section on the home page that shows the user’s energy level to make progress more visible. Authenticated users see their current energy; unauthenticated users don’t see the section.

- **New Features**
  - Performance section displays energy level (formatted to one decimal place); shows 0% when no progress; hidden for unauthenticated.
  - Added getEnergyLevel with session check, caching, and safe error handling.
  - Implemented Suspense and skeletons for Performance and EnergyLevel.
  - Added translations in en, es, and pt.

- **Refactors**
  - Tweaked feature card styles (section title, label weight, subtitle tracking).
  - Preload continue learning and energy data in parallel.
  - Added unit and e2e tests for energy level rendering.

<sup>Written for commit 28e2425bd4c38c80146571b413dcbf16fb281d9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

