### PR TITLE
refactor(ui): remove zoom on feature card

### DIFF
--- a/packages/ui/src/components/feature.tsx
+++ b/packages/ui/src/components/feature.tsx
@@ -28,7 +28,7 @@ function FeatureCard({
 }: React.ComponentProps<"article">) {
   return (
     <article
-      className={cn("group/feature-card flex flex-col gap-2", className)}
+      className={cn("flex flex-col gap-2", className)}
       data-slot="feature-card"
       {...props}
     >
@@ -182,7 +182,7 @@ function FeatureCardThumbnailImage({
   return (
     <div
       className={cn(
-        "size-full transition-transform duration-300 ease-out group-hover/feature-card:scale-110 [&>img]:size-full [&>img]:object-cover",
+        "size-full transition-transform duration-300 ease-out [&>img]:size-full [&>img]:object-cover",
         className,
       )}
       data-slot="feature-card-thumbnail-image"
@@ -201,7 +201,7 @@ function FeatureCardThumbnailPlaceholder({
   return (
     <div
       className={cn(
-        "flex size-full items-center justify-center bg-muted transition-transform duration-300 ease-out group-hover/feature-card:scale-110 [&>svg]:size-6 [&>svg]:text-muted-foreground/60",
+        "flex size-full items-center justify-center bg-muted transition-transform duration-300 ease-out [&>svg]:size-6 [&>svg]:text-muted-foreground/60",
         className,
       )}
       data-slot="feature-card-thumbnail-placeholder"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the hover zoom effect on FeatureCard to reduce motion and simplify the UI. Removed the group/feature-card class and scale transforms from the thumbnail and placeholder; layout and transitions remain unchanged.

<sup>Written for commit 632a8b2529c10cad9d087ceb6643f4c210120c96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

