### PR TITLE
fix(main): hide performance section for users without progress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,17 @@ Zoonk is a web app where users can learn anything using AI. This app uses AI to 
 - Use meaningful variable names and avoid abbreviations
 - Never guess at imports, table names, or conventions—always search for existing patterns first
 
+Important: Before completing a task, make sure to run the following commands:
+
+- `pnpm format`
+- `pnpm lint --write --unsafe`
+- `pnpm typecheck`
+- `pnpm knip`
+- `pnpm test`
+- `pnpm --filter {app} build`
+- `pnpm --filter {app} build:e2e`
+- `pnpm --filter {app} e2e`
+
 ## Design Style
 
 Whenever you're designing something, follow this design style:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,17 @@ Zoonk is a web app where users can learn anything using AI. This app uses AI to 
 - Use meaningful variable names and avoid abbreviations
 - Never guess at imports, table names, or conventions—always search for existing patterns first
 
+Important: Before completing a task, make sure to run the following commands:
+
+- `pnpm format`
+- `pnpm lint --write --unsafe`
+- `pnpm typecheck`
+- `pnpm knip`
+- `pnpm test`
+- `pnpm --filter {app} build`
+- `pnpm --filter {app} build:e2e`
+- `pnpm --filter {app} e2e`
+
 ## Design Style
 
 Whenever you're designing something, follow this design style:

--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -77,14 +77,13 @@ test.describe("Home Page - Performance Section", () => {
     ).toBeVisible();
   });
 
-  test("user without progress sees energy level at 0%", async ({
+  test("user without progress does not see performance section", async ({
     userWithoutProgress,
   }) => {
     await userWithoutProgress.goto("/");
 
-    await expect(userWithoutProgress.getByText(/^performance$/i)).toBeVisible();
     await expect(
-      userWithoutProgress.getByText("Your energy level is 0%"),
-    ).toBeVisible();
+      userWithoutProgress.getByText(/^performance$/i),
+    ).not.toBeVisible();
   });
 });

--- a/apps/main/src/data/progress/get-energy-level.test.ts
+++ b/apps/main/src/data/progress/get-energy-level.test.ts
@@ -12,12 +12,12 @@ describe("unauthenticated users", () => {
 });
 
 describe("authenticated users", () => {
-  test("returns 0 when user has no progress record", async () => {
+  test("returns null when user has no progress record", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);
 
     const result = await getEnergyLevel({ headers });
-    expect(result).toEqual({ currentEnergy: 0 });
+    expect(result).toBeNull();
   });
 
   test("returns energy level when user has progress record", async () => {

--- a/apps/main/src/data/progress/get-energy-level.ts
+++ b/apps/main/src/data/progress/get-energy-level.ts
@@ -26,12 +26,12 @@ export const getEnergyLevel = cache(
       }),
     );
 
-    if (error) {
+    if (error || !progress) {
       return null;
     }
 
     return {
-      currentEnergy: progress?.currentEnergy ?? 0,
+      currentEnergy: progress.currentEnergy,
     };
   },
 );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hide the Home Performance section for users without progress so we don’t show a misleading 0% energy.

- **Bug Fixes**
  - getEnergyLevel now returns null when no progress record exists.
  - Updated unit and e2e tests to cover the hidden section behavior.

<sup>Written for commit 92149817bf295a7b331da6d034a3725acc834d88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

