### PR TITLE
feat(main): list chapters and lessons

### DIFF
--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -279,9 +279,9 @@ test.describe("Command Palette - Course Search", () => {
     // Wait for and click the course result
     await dialog.getByText("Machine Learning").first().click();
 
-    // Verify user sees course detail page
+    // Verify user sees course detail page (level: 1 for main title, not chapter headings)
     await expect(
-      page.getByRole("heading", { name: /machine learning/i }),
+      page.getByRole("heading", { level: 1, name: /machine learning/i }),
     ).toBeVisible();
   });
 

--- a/apps/main/e2e/course-chapters.test.ts
+++ b/apps/main/e2e/course-chapters.test.ts
@@ -1,0 +1,150 @@
+import { expect, test } from "./fixtures";
+
+test.describe("Course Chapters Accordion", () => {
+  test("displays chapters with position numbers and expands to show lessons", async ({
+    page,
+  }) => {
+    await page.goto("/b/ai/c/machine-learning");
+
+    // Verify chapters are displayed with position numbers
+    // Position numbers should be visible (01, 02, 03 for the 3 published chapters)
+    await expect(page.getByText("01")).toBeVisible();
+    await expect(page.getByText("02")).toBeVisible();
+    await expect(page.getByText("03")).toBeVisible();
+
+    // Verify chapter titles are visible
+    await expect(
+      page.getByRole("button", { name: /Introduction to Machine Learning/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Data Preparation/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Regression Algorithms/i }),
+    ).toBeVisible();
+
+    // Click to expand the first chapter
+    await page
+      .getByRole("button", { name: /Introduction to Machine Learning/i })
+      .click();
+
+    // Verify lessons are visible after expanding
+    await expect(
+      page.getByRole("link", { name: /What is Machine Learning\?/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /History of Machine Learning/i }),
+    ).toBeVisible();
+
+    // Unpublished lesson "Types of Learning" should NOT be visible
+    await expect(
+      page.getByRole("link", { name: /Types of Learning/i }),
+    ).not.toBeVisible();
+  });
+
+  test("closes current chapter when another is opened", async ({ page }) => {
+    await page.goto("/b/ai/c/machine-learning");
+
+    // Expand first chapter
+    await page
+      .getByRole("button", { name: /Introduction to Machine Learning/i })
+      .click();
+
+    // Verify first chapter's lesson is visible
+    await expect(
+      page.getByRole("link", { name: /What is Machine Learning\?/i }),
+    ).toBeVisible();
+
+    // Click to expand second chapter
+    await page.getByRole("button", { name: /Data Preparation/i }).click();
+
+    // Verify second chapter's lessons are visible
+    await expect(
+      page.getByRole("link", { name: /Understanding Datasets/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /Data Cleaning/i }),
+    ).toBeVisible();
+
+    // First chapter's lessons should no longer be visible
+    await expect(
+      page.getByRole("link", { name: /What is Machine Learning\?/i }),
+    ).not.toBeVisible();
+  });
+
+  test("lesson link navigates to the correct URL", async ({ page }) => {
+    await page.goto("/b/ai/c/machine-learning");
+
+    // Expand first chapter
+    await page
+      .getByRole("button", { name: /Introduction to Machine Learning/i })
+      .click();
+
+    // Wait for lessons to be visible
+    const lessonLink = page.getByRole("link", {
+      name: /What is Machine Learning\?/i,
+    });
+    await expect(lessonLink).toBeVisible();
+
+    // Click the lesson link
+    await lessonLink.click();
+
+    // Verify URL is correct
+    await expect(page).toHaveURL(
+      /\/b\/ai\/c\/machine-learning\/c\/introduction-to-machine-learning\/l\/what-is-machine-learning/,
+    );
+  });
+
+  test("excludes unpublished chapters from the list", async ({ page }) => {
+    await page.goto("/b/ai/c/machine-learning");
+
+    // Published chapters should be visible
+    await expect(
+      page.getByRole("button", { name: /Introduction to Machine Learning/i }),
+    ).toBeVisible();
+
+    // Unpublished chapter "Tree-Based Models" should NOT be visible
+    // (Neural Networks is mentioned in course description, so we can't test for that)
+    await expect(
+      page.getByRole("button", { name: /Tree-Based Models/i }),
+    ).not.toBeVisible();
+
+    // Position number 04 (for Tree-Based Models) should not exist
+    // since only 3 chapters are published
+    await expect(page.getByText("04")).not.toBeVisible();
+  });
+});
+
+test.describe("Course Chapters - Empty State", () => {
+  test("renders course page without chapters gracefully", async ({ page }) => {
+    // This course has chapters but we're testing the page renders
+    // A course that never had chapters would also work
+    await page.goto("/b/ai/c/python-programming");
+
+    // Course header should still show
+    await expect(
+      page.getByRole("heading", { name: /python programming/i }),
+    ).toBeVisible();
+
+    // Chapters should be present for this course
+    await expect(
+      page.getByRole("button", { name: /Python Fundamentals/i }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("Course Chapters - Locale", () => {
+  test("shows chapters in Portuguese for Portuguese locale", async ({
+    page,
+  }) => {
+    await page.goto("/pt/b/ai/c/machine-learning");
+
+    // Portuguese chapter titles should be visible
+    await expect(
+      page.getByRole("button", { name: /Introdução ao Machine Learning/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Preparação de Dados/i }),
+    ).toBeVisible();
+  });
+});

--- a/apps/main/e2e/course-detail.test.ts
+++ b/apps/main/e2e/course-detail.test.ts
@@ -7,10 +7,13 @@ test.describe("Course Detail Page", () => {
     await page.goto("/b/ai/c/machine-learning");
 
     await expect(
-      page.getByRole("heading", { name: /machine learning/i }),
+      page.getByRole("heading", { level: 1, name: /machine learning/i }),
     ).toBeVisible();
 
-    await expect(page.getByText(/patterns|predictions|data/i)).toBeVisible();
+    // Use .first() since chapter descriptions may also contain matching words
+    await expect(
+      page.getByText(/patterns|predictions|data/i).first(),
+    ).toBeVisible();
 
     const courseImage = page.getByRole("img", { name: /machine learning/i });
     await expect(courseImage).toBeVisible();

--- a/apps/main/e2e/courses.test.ts
+++ b/apps/main/e2e/courses.test.ts
@@ -38,9 +38,9 @@ test.describe("Courses Page - Basic", () => {
 
     await page.getByText("Machine Learning").first().click();
 
-    // Verify user sees course detail page
+    // Verify user sees course detail page (level: 1 for main title, not chapter headings)
     await expect(
-      page.getByRole("heading", { name: /machine learning/i }),
+      page.getByRole("heading", { level: 1, name: /machine learning/i }),
     ).toBeVisible();
   });
 });

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@zoonk/ui/components/accordion";
+import type { ChapterWithLessons } from "@/data/chapters/list-course-chapters";
+import { ClientLink } from "@/i18n/client-link";
+
+export function ChapterList({
+  brandSlug,
+  chapters,
+  courseSlug,
+}: {
+  brandSlug: string;
+  chapters: ChapterWithLessons[];
+  courseSlug: string;
+}) {
+  if (chapters.length === 0) {
+    return null;
+  }
+
+  return (
+    <section>
+      <Accordion className="rounded-none border-0">
+        {chapters.map((chapter, index) => (
+          <AccordionItem
+            className="border-border/30 border-b last:border-b-0 data-open:bg-transparent"
+            key={chapter.id}
+            value={chapter.slug}
+          >
+            <AccordionTrigger className="px-0 py-5 hover:no-underline">
+              <div className="flex items-start gap-4">
+                <span className="mt-0.5 font-mono text-muted-foreground/70 text-sm tabular-nums">
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+
+                <div className="flex flex-col gap-1 text-left">
+                  <span className="font-medium">{chapter.title}</span>
+
+                  {chapter.description && (
+                    <span className="line-clamp-2 text-muted-foreground text-sm">
+                      {chapter.description}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </AccordionTrigger>
+
+            <AccordionContent className="[&_a]:no-underline">
+              <ul className="ml-8 flex flex-col gap-1">
+                {chapter.lessons.map((lesson) => (
+                  <li key={lesson.id}>
+                    <ClientLink
+                      className="block rounded-md py-2.5 pl-4 text-muted-foreground text-sm transition-colors hover:bg-muted/50 hover:text-foreground"
+                      href={`/b/${brandSlug}/c/${courseSlug}/c/${chapter.slug}/l/${lesson.slug}`}
+                    >
+                      {lesson.title}
+                    </ClientLink>
+                  </li>
+                ))}
+              </ul>
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </section>
+  );
+}

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -31,17 +31,17 @@ export function ChapterList({
             key={chapter.id}
             value={chapter.slug}
           >
-            <AccordionTrigger className="px-0 py-5 hover:no-underline">
-              <div className="flex items-start gap-4">
-                <span className="mt-0.5 font-mono text-muted-foreground/70 text-sm tabular-nums">
+            <AccordionTrigger className="px-0 py-4 hover:no-underline">
+              <div className="flex gap-4">
+                <span className="w-6 shrink-0 font-mono text-muted-foreground/60 text-sm tabular-nums leading-7">
                   {String(index + 1).padStart(2, "0")}
                 </span>
 
-                <div className="flex flex-col gap-1 text-left">
-                  <span className="font-medium">{chapter.title}</span>
+                <div className="flex min-w-0 flex-col gap-0.5 text-left">
+                  <span className="font-medium leading-7">{chapter.title}</span>
 
                   {chapter.description && (
-                    <span className="line-clamp-2 text-muted-foreground text-sm">
+                    <span className="line-clamp-2 text-muted-foreground text-sm leading-relaxed">
                       {chapter.description}
                     </span>
                   )}
@@ -50,11 +50,11 @@ export function ChapterList({
             </AccordionTrigger>
 
             <AccordionContent className="[&_a]:no-underline">
-              <ul className="ml-8 flex flex-col gap-1">
+              <ul className="ml-10 flex flex-col">
                 {chapter.lessons.map((lesson) => (
                   <li key={lesson.id}>
                     <ClientLink
-                      className="block rounded-md py-2.5 pl-4 text-muted-foreground text-sm transition-colors hover:bg-muted/50 hover:text-foreground"
+                      className="-ml-2 block rounded-md px-2 py-2 text-muted-foreground text-sm transition-colors hover:bg-muted/50 hover:text-foreground"
                       href={`/b/${brandSlug}/c/${courseSlug}/c/${chapter.slug}/l/${lesson.slug}`}
                     >
                       {lesson.title}

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
@@ -6,7 +6,9 @@ import type { Metadata } from "next";
 import { cacheTag } from "next/cache";
 import { notFound } from "next/navigation";
 import { setRequestLocale } from "next-intl/server";
+import { listCourseChapters } from "@/data/chapters/list-course-chapters";
 import { getCourse } from "@/data/courses/get-course";
+import { ChapterList } from "./chapter-list";
 import { CourseHeader } from "./course-header";
 
 export async function generateStaticParams() {
@@ -47,7 +49,11 @@ export default async function CoursePage({
   params,
 }: PageProps<"/[locale]/b/[brandSlug]/c/[courseSlug]">) {
   const { brandSlug, courseSlug, locale } = await params;
-  const course = await getCourse({ brandSlug, courseSlug, language: locale });
+
+  const [course, chapters] = await Promise.all([
+    getCourse({ brandSlug, courseSlug, language: locale }),
+    listCourseChapters({ brandSlug, courseSlug, language: locale }),
+  ]);
 
   setRequestLocale(locale);
   cacheTag(cacheTagCourse({ courseSlug }));
@@ -59,6 +65,14 @@ export default async function CoursePage({
   return (
     <main className="flex flex-1 flex-col">
       <CourseHeader brandSlug={brandSlug} course={course} />
+
+      <div className="mx-auto w-full px-4 py-8 md:py-10 lg:max-w-xl">
+        <ChapterList
+          brandSlug={brandSlug}
+          chapters={chapters}
+          courseSlug={courseSlug}
+        />
+      </div>
     </main>
   );
 }

--- a/apps/main/src/data/chapters/list-course-chapters.test.ts
+++ b/apps/main/src/data/chapters/list-course-chapters.test.ts
@@ -1,0 +1,258 @@
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, describe, expect, test } from "vitest";
+import { listCourseChapters } from "./list-course-chapters";
+
+describe("listCourseChapters", () => {
+  let brandOrg: Awaited<ReturnType<typeof organizationFixture>>;
+  let schoolOrg: Awaited<ReturnType<typeof organizationFixture>>;
+  let publishedCourse: Awaited<ReturnType<typeof courseFixture>>;
+  let draftCourse: Awaited<ReturnType<typeof courseFixture>>;
+  let schoolCourse: Awaited<ReturnType<typeof courseFixture>>;
+  let publishedChapter1: Awaited<ReturnType<typeof chapterFixture>>;
+  let publishedChapter2: Awaited<ReturnType<typeof chapterFixture>>;
+  let draftChapter: Awaited<ReturnType<typeof chapterFixture>>;
+  let publishedLesson1: Awaited<ReturnType<typeof lessonFixture>>;
+  let publishedLesson2: Awaited<ReturnType<typeof lessonFixture>>;
+  let draftLesson: Awaited<ReturnType<typeof lessonFixture>>;
+
+  beforeAll(async () => {
+    [brandOrg, schoolOrg] = await Promise.all([
+      organizationFixture({ kind: "brand" }),
+      organizationFixture({ kind: "school" }),
+    ]);
+
+    [publishedCourse, draftCourse, schoolCourse] = await Promise.all([
+      courseFixture({
+        isPublished: true,
+        language: "en",
+        organizationId: brandOrg.id,
+      }),
+      courseFixture({
+        isPublished: false,
+        language: "en",
+        organizationId: brandOrg.id,
+      }),
+      courseFixture({
+        isPublished: true,
+        language: "en",
+        organizationId: schoolOrg.id,
+      }),
+    ]);
+
+    // Create chapters with different positions
+    [publishedChapter1, publishedChapter2, draftChapter] = await Promise.all([
+      chapterFixture({
+        courseId: publishedCourse.id,
+        description: "First chapter",
+        isPublished: true,
+        language: "en",
+        organizationId: brandOrg.id,
+        position: 1,
+        title: "Chapter 1",
+      }),
+      chapterFixture({
+        courseId: publishedCourse.id,
+        description: "Second chapter (but position 0)",
+        isPublished: true,
+        language: "en",
+        organizationId: brandOrg.id,
+        position: 0, // Position 0 should come first
+        title: "Chapter 2",
+      }),
+      chapterFixture({
+        courseId: publishedCourse.id,
+        isPublished: false,
+        language: "en",
+        organizationId: brandOrg.id,
+        position: 2,
+        title: "Draft Chapter",
+      }),
+    ]);
+
+    // Create lessons for publishedChapter1
+    [publishedLesson1, publishedLesson2, draftLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: publishedChapter1.id,
+        description: "First lesson",
+        isPublished: true,
+        language: "en",
+        organizationId: brandOrg.id,
+        position: 1,
+        title: "Lesson 1",
+      }),
+      lessonFixture({
+        chapterId: publishedChapter1.id,
+        description: "Second lesson (but position 0)",
+        isPublished: true,
+        language: "en",
+        organizationId: brandOrg.id,
+        position: 0, // Position 0 should come first
+        title: "Lesson 2",
+      }),
+      lessonFixture({
+        chapterId: publishedChapter1.id,
+        isPublished: false,
+        language: "en",
+        organizationId: brandOrg.id,
+        position: 2,
+        title: "Draft Lesson",
+      }),
+    ]);
+  });
+
+  test("returns published chapters with published lessons", async () => {
+    const result = await listCourseChapters({
+      brandSlug: brandOrg.slug,
+      courseSlug: publishedCourse.slug,
+      language: "en",
+    });
+
+    expect(result).toHaveLength(2);
+
+    // Chapter at position 0 should come first
+    expect(result[0]?.id).toBe(publishedChapter2.id);
+    expect(result[0]?.title).toBe("Chapter 2");
+    expect(result[0]?.description).toBe("Second chapter (but position 0)");
+    expect(result[0]?.slug).toBe(publishedChapter2.slug);
+    expect(result[0]?.position).toBe(0);
+
+    // Chapter at position 1 should come second
+    expect(result[1]?.id).toBe(publishedChapter1.id);
+    expect(result[1]?.title).toBe("Chapter 1");
+  });
+
+  test("includes lessons ordered by position", async () => {
+    const result = await listCourseChapters({
+      brandSlug: brandOrg.slug,
+      courseSlug: publishedCourse.slug,
+      language: "en",
+    });
+
+    // Chapter at position 1 has lessons
+    const chapterWithLessons = result.find(
+      (c) => c.id === publishedChapter1.id,
+    );
+    expect(chapterWithLessons?.lessons).toHaveLength(2);
+
+    // Lesson at position 0 should come first
+    expect(chapterWithLessons?.lessons[0]?.id).toBe(publishedLesson2.id);
+    expect(chapterWithLessons?.lessons[0]?.title).toBe("Lesson 2");
+    expect(chapterWithLessons?.lessons[0]?.position).toBe(0);
+
+    // Lesson at position 1 should come second
+    expect(chapterWithLessons?.lessons[1]?.id).toBe(publishedLesson1.id);
+    expect(chapterWithLessons?.lessons[1]?.title).toBe("Lesson 1");
+    expect(chapterWithLessons?.lessons[1]?.position).toBe(1);
+  });
+
+  test("excludes unpublished chapters", async () => {
+    const result = await listCourseChapters({
+      brandSlug: brandOrg.slug,
+      courseSlug: publishedCourse.slug,
+      language: "en",
+    });
+
+    const draftChapterInResult = result.find((c) => c.id === draftChapter.id);
+    expect(draftChapterInResult).toBeUndefined();
+  });
+
+  test("excludes unpublished lessons within published chapters", async () => {
+    const result = await listCourseChapters({
+      brandSlug: brandOrg.slug,
+      courseSlug: publishedCourse.slug,
+      language: "en",
+    });
+
+    const chapterWithLessons = result.find(
+      (c) => c.id === publishedChapter1.id,
+    );
+    const draftLessonInResult = chapterWithLessons?.lessons.find(
+      (l) => l.id === draftLesson.id,
+    );
+    expect(draftLessonInResult).toBeUndefined();
+  });
+
+  test("returns empty array for non-brand organizations", async () => {
+    const result = await listCourseChapters({
+      brandSlug: schoolOrg.slug,
+      courseSlug: schoolCourse.slug,
+      language: "en",
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array for unpublished course", async () => {
+    const result = await listCourseChapters({
+      brandSlug: brandOrg.slug,
+      courseSlug: draftCourse.slug,
+      language: "en",
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  test("filters by language correctly", async () => {
+    const ptCourse = await courseFixture({
+      isPublished: true,
+      language: "pt",
+      organizationId: brandOrg.id,
+    });
+
+    await chapterFixture({
+      courseId: ptCourse.id,
+      isPublished: true,
+      language: "pt",
+      organizationId: brandOrg.id,
+      position: 0,
+      title: "Portuguese Chapter",
+    });
+
+    const enResult = await listCourseChapters({
+      brandSlug: brandOrg.slug,
+      courseSlug: ptCourse.slug,
+      language: "en",
+    });
+
+    const ptResult = await listCourseChapters({
+      brandSlug: brandOrg.slug,
+      courseSlug: ptCourse.slug,
+      language: "pt",
+    });
+
+    expect(enResult).toEqual([]);
+    expect(ptResult).toHaveLength(1);
+    expect(ptResult[0]?.title).toBe("Portuguese Chapter");
+  });
+
+  test("returns empty array when no chapters exist", async () => {
+    const courseWithoutChapters = await courseFixture({
+      isPublished: true,
+      language: "en",
+      organizationId: brandOrg.id,
+    });
+
+    const result = await listCourseChapters({
+      brandSlug: brandOrg.slug,
+      courseSlug: courseWithoutChapters.slug,
+      language: "en",
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array when brandSlug does not match", async () => {
+    const otherBrandOrg = await organizationFixture({ kind: "brand" });
+
+    const result = await listCourseChapters({
+      brandSlug: otherBrandOrg.slug,
+      courseSlug: publishedCourse.slug,
+      language: "en",
+    });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/main/src/data/chapters/list-course-chapters.ts
+++ b/apps/main/src/data/chapters/list-course-chapters.ts
@@ -1,0 +1,60 @@
+import "server-only";
+
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export type ChapterWithLessons = {
+  id: number;
+  slug: string;
+  title: string;
+  description: string;
+  position: number;
+  lessons: {
+    id: number;
+    slug: string;
+    title: string;
+    description: string;
+    position: number;
+  }[];
+};
+
+export const listCourseChapters = cache(
+  async (params: {
+    brandSlug: string;
+    courseSlug: string;
+    language: string;
+  }): Promise<ChapterWithLessons[]> =>
+    prisma.chapter.findMany({
+      orderBy: { position: "asc" },
+      select: {
+        description: true,
+        id: true,
+        lessons: {
+          orderBy: { position: "asc" },
+          select: {
+            description: true,
+            id: true,
+            position: true,
+            slug: true,
+            title: true,
+          },
+          where: { isPublished: true },
+        },
+        position: true,
+        slug: true,
+        title: true,
+      },
+      where: {
+        course: {
+          isPublished: true,
+          language: params.language,
+          organization: {
+            kind: "brand",
+            slug: params.brandSlug,
+          },
+          slug: params.courseSlug,
+        },
+        isPublished: true,
+      },
+    }),
+);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added an accordion on the course page to list chapters and their lessons, with position numbers and deep links. Unpublished items are hidden and content is shown in the correct locale.

- **New Features**
  - ChapterList component displays chapters with position numbers, title, and optional description; expands to show lessons.
  - listCourseChapters returns only published chapters and lessons, ordered by position, filtered by brand, course, and language.
  - Course page fetches course and chapters in parallel and renders the chapter list.
  - Tests cover ordering, visibility of published/unpublished content, navigation to lesson URLs, empty state, and Portuguese locale.

<sup>Written for commit dcb9b801db68a2cbc42546984706702e1f4b1e5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

