### PR TITLE
fix(main): always use locale for all routes

### DIFF
--- a/apps/main/e2e/auth-callback.test.ts
+++ b/apps/main/e2e/auth-callback.test.ts
@@ -19,7 +19,7 @@ test.describe("Auth Callback - Invalid Token", () => {
       }
     });
 
-    await page.goto("/auth/callback/invalid-token");
+    await page.goto("/en/auth/callback/invalid-token");
 
     await expect(page.getByText(/authentication error/i)).toBeVisible();
     await expect(page.getByText(/invalid|expired/i)).toBeVisible();
@@ -66,7 +66,7 @@ test.describe("Auth Callback - Valid Token", () => {
       }
     });
 
-    await page.goto("/auth/callback/valid-token");
+    await page.goto("/en/auth/callback/valid-token");
     await page.waitForURL(/^(?!.*\/auth\/callback)/);
   });
 });

--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -230,7 +230,7 @@ test.describe("Command Palette - Authenticated", () => {
 
     // Click logout - this triggers a hard navigation
     await Promise.all([
-      logoutPage.waitForURL(/^[^?]*\/$/),
+      logoutPage.waitForURL(/^\/(en|pt)\/?$/),
       logoutPage.waitForResponse(
         (response) =>
           response.url().includes("/api/auth/get-session") &&

--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -13,7 +13,7 @@ function getModifierKey(): "Meta" | "Control" {
 
 test.describe("Command Palette - Unauthenticated", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/en/");
     // Wait for the page to be fully interactive before testing keyboard shortcuts
     await expect(page.getByRole("button", { name: /search/i })).toBeVisible();
   });
@@ -93,7 +93,7 @@ test.describe("Command Palette - Unauthenticated", () => {
   });
 
   test("selecting Home shows home content", async ({ page }) => {
-    await page.goto("/courses"); // Start from different page
+    await page.goto("/en/courses"); // Start from different page
     await openCommandPalette(page);
 
     await page
@@ -140,7 +140,7 @@ test.describe("Command Palette - Authenticated", () => {
   test("shows My account group with authenticated options", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto("/");
+    await authenticatedPage.goto("/en/");
     await authenticatedPage.getByRole("button", { name: /search/i }).click();
 
     const dialog = authenticatedPage.getByRole("dialog");
@@ -155,7 +155,7 @@ test.describe("Command Palette - Authenticated", () => {
   test("does NOT show Login option when authenticated", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto("/");
+    await authenticatedPage.goto("/en/");
     await authenticatedPage.getByRole("button", { name: /search/i }).click();
 
     const dialog = authenticatedPage.getByRole("dialog");
@@ -165,7 +165,7 @@ test.describe("Command Palette - Authenticated", () => {
   test("selecting My courses shows user's enrolled courses", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto("/");
+    await authenticatedPage.goto("/en/");
     await authenticatedPage.getByRole("button", { name: /search/i }).click();
 
     await authenticatedPage
@@ -182,7 +182,7 @@ test.describe("Command Palette - Authenticated", () => {
   test("selecting Subscription shows subscription content", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto("/");
+    await authenticatedPage.goto("/en/");
     await authenticatedPage.getByRole("button", { name: /search/i }).click();
 
     await authenticatedPage
@@ -202,7 +202,7 @@ test.describe("Command Palette - Authenticated", () => {
   test("selecting Settings shows settings content", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto("/");
+    await authenticatedPage.goto("/en/");
     await authenticatedPage.getByRole("button", { name: /search/i }).click();
 
     await authenticatedPage
@@ -220,7 +220,7 @@ test.describe("Command Palette - Authenticated", () => {
   test("selecting Logout logs user out and redirects to home", async ({
     logoutPage,
   }) => {
-    await logoutPage.goto("/");
+    await logoutPage.goto("/en/");
 
     // Verify authenticated state by checking command palette shows Logout option
     await logoutPage.getByRole("button", { name: /search/i }).click();
@@ -252,7 +252,7 @@ test.describe("Command Palette - Authenticated", () => {
 
 test.describe("Command Palette - Course Search", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/en/");
     await page.getByRole("button", { name: /search/i }).click();
   });
 
@@ -309,7 +309,7 @@ test.describe("Command Palette - Course Search", () => {
 
 test.describe("Command Palette - Keyboard Navigation", () => {
   test("focuses input on open", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/en/");
     await page.getByRole("button", { name: /search/i }).click();
 
     const input = page.getByPlaceholder(/search/i);
@@ -317,7 +317,7 @@ test.describe("Command Palette - Keyboard Navigation", () => {
   });
 
   test("arrow key navigation selects items", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/en/");
     await page.getByRole("button", { name: /search/i }).click();
 
     const dialog = page.getByRole("dialog");
@@ -360,7 +360,7 @@ test.describe("Command Palette - Keyboard Navigation", () => {
   });
 
   test("Enter to select navigates correctly", async ({ page }) => {
-    await page.goto("/courses"); // Start from courses page so Home navigation is verifiable
+    await page.goto("/en/courses"); // Start from courses page so Home navigation is verifiable
     await page.getByRole("button", { name: /search/i }).click();
     await expect(page.getByRole("dialog")).toBeVisible();
 
@@ -376,7 +376,7 @@ test.describe("Command Palette - Keyboard Navigation", () => {
   });
 
   test("focus trap within dialog", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/en/");
     await page.getByRole("button", { name: /search/i }).click();
     await expect(page.getByRole("dialog")).toBeVisible();
 
@@ -394,7 +394,7 @@ test.describe("Command Palette - Mobile Viewport", () => {
   test.use({ viewport: { height: 667, width: 375 } });
 
   test("command palette opens and functions on mobile", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/en/");
     await page.getByRole("button", { name: /search/i }).click();
 
     const dialog = page.getByRole("dialog");
@@ -407,7 +407,7 @@ test.describe("Command Palette - Mobile Viewport", () => {
 
 test.describe("Command Palette - Accessibility", () => {
   test("has dialog role", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/en/");
     await page.getByRole("button", { name: /search/i }).click();
 
     const dialog = page.getByRole("dialog");
@@ -415,7 +415,7 @@ test.describe("Command Palette - Accessibility", () => {
   });
 
   test("has accessible title", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/en/");
     await page.getByRole("button", { name: /search/i }).click();
 
     const dialog = page.getByRole("dialog");
@@ -427,7 +427,7 @@ test.describe("Command Palette - Accessibility", () => {
   });
 
   test("search button indicates keyboard shortcut", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/en/");
 
     const searchButton = page.getByRole("button", { name: /search/i });
     await expect(searchButton).toHaveAttribute("aria-keyshortcuts", /k/i);
@@ -447,7 +447,7 @@ test.describe("Command Palette - Accessibility", () => {
 
     const page = await context.newPage();
 
-    await page.goto("/");
+    await page.goto("/en/");
     await openCommandPalette(page);
 
     const input = page.getByPlaceholder(/search/i);

--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -244,6 +244,7 @@ test.describe("Command Palette - Authenticated", () => {
 
     // Verify user is logged out - command palette should show Login option
     await logoutPage.getByRole("button", { name: /search/i }).click();
+    await expect(logoutPage.getByRole("dialog")).toBeVisible();
     await expect(
       logoutPage.getByRole("dialog").getByText(/^login$/i),
     ).toBeVisible();

--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -228,19 +228,19 @@ test.describe("Command Palette - Authenticated", () => {
       logoutPage.getByRole("dialog").getByText(/^logout$/i),
     ).toBeVisible();
 
-    // Click logout - this triggers a hard navigation
-    await Promise.all([
-      logoutPage.waitForURL(/^\/(en|pt)\/?$/),
-      logoutPage.waitForResponse(
-        (response) =>
-          response.url().includes("/api/auth/get-session") &&
-          response.status() === 200,
-      ),
-      logoutPage
-        .getByRole("dialog")
-        .getByText(/^logout$/i)
-        .click(),
-    ]);
+    // Click logout - this triggers a hard navigation via window.location.href
+    await logoutPage
+      .getByRole("dialog")
+      .getByText(/^logout$/i)
+      .click();
+
+    // Wait for navigation to complete (home page with locale)
+    await logoutPage.waitForURL(/\/(en|pt)\/?$/);
+
+    // Wait for page to be interactive after hard navigation
+    await expect(
+      logoutPage.getByRole("button", { name: /search/i }),
+    ).toBeVisible();
 
     // Verify user is logged out - command palette should show Login option
     await logoutPage.getByRole("button", { name: /search/i }).click();

--- a/apps/main/e2e/content-feedback.test.ts
+++ b/apps/main/e2e/content-feedback.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "./fixtures";
 // Content feedback is tested on the course suggestions page where it's used
 test.describe("Content Feedback", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/learn/test%20prompt");
+    await page.goto("/en/learn/test%20prompt");
 
     // Wait for content to load
     await expect(page.getByText("Introduction to Testing")).toBeVisible();
@@ -114,7 +114,7 @@ test.describe("Content Feedback - Authenticated", () => {
   test("email field shows authenticated user's email", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto("/learn/test%20prompt");
+    await authenticatedPage.goto("/en/learn/test%20prompt");
     // Wait for content to load
     await expect(
       authenticatedPage.getByText("Introduction to Testing"),

--- a/apps/main/e2e/course-chapters.test.ts
+++ b/apps/main/e2e/course-chapters.test.ts
@@ -4,7 +4,7 @@ test.describe("Course Chapters Accordion", () => {
   test("displays chapters with position numbers and expands to show lessons", async ({
     page,
   }) => {
-    await page.goto("/b/ai/c/machine-learning");
+    await page.goto("/en/b/ai/c/machine-learning");
 
     // Verify chapters are displayed with position numbers
     // Position numbers should be visible (01, 02, 03 for the 3 published chapters)
@@ -43,7 +43,7 @@ test.describe("Course Chapters Accordion", () => {
   });
 
   test("closes current chapter when another is opened", async ({ page }) => {
-    await page.goto("/b/ai/c/machine-learning");
+    await page.goto("/en/b/ai/c/machine-learning");
 
     // Expand first chapter
     await page
@@ -73,7 +73,7 @@ test.describe("Course Chapters Accordion", () => {
   });
 
   test("lesson link navigates to the correct URL", async ({ page }) => {
-    await page.goto("/b/ai/c/machine-learning");
+    await page.goto("/en/b/ai/c/machine-learning");
 
     // Expand first chapter
     await page
@@ -96,7 +96,7 @@ test.describe("Course Chapters Accordion", () => {
   });
 
   test("excludes unpublished chapters from the list", async ({ page }) => {
-    await page.goto("/b/ai/c/machine-learning");
+    await page.goto("/en/b/ai/c/machine-learning");
 
     // Published chapters should be visible
     await expect(
@@ -119,7 +119,7 @@ test.describe("Course Chapters - Empty State", () => {
   test("renders course page without chapters gracefully", async ({ page }) => {
     // This course has chapters but we're testing the page renders
     // A course that never had chapters would also work
-    await page.goto("/b/ai/c/python-programming");
+    await page.goto("/en/b/ai/c/python-programming");
 
     // Course header should still show
     await expect(

--- a/apps/main/e2e/course-detail.test.ts
+++ b/apps/main/e2e/course-detail.test.ts
@@ -4,7 +4,7 @@ test.describe("Course Detail Page", () => {
   test("shows course content with title, description, and image", async ({
     page,
   }) => {
-    await page.goto("/b/ai/c/machine-learning");
+    await page.goto("/en/b/ai/c/machine-learning");
 
     await expect(
       page.getByRole("heading", { level: 1, name: /machine learning/i }),
@@ -20,13 +20,13 @@ test.describe("Course Detail Page", () => {
   });
 
   test("non-existent course shows 404 page", async ({ page }) => {
-    await page.goto("/b/ai/c/nonexistent-course");
+    await page.goto("/en/b/ai/c/nonexistent-course");
 
     await expect(page.getByText(/not found|404/i)).toBeVisible();
   });
 
   test("shows fallback icon when course has no image", async ({ page }) => {
-    await page.goto("/b/ai/c/python-programming");
+    await page.goto("/en/b/ai/c/python-programming");
 
     await expect(
       page.getByRole("heading", { name: /python programming/i }),

--- a/apps/main/e2e/courses.test.ts
+++ b/apps/main/e2e/courses.test.ts
@@ -19,7 +19,7 @@ async function createUnpublishedCourse() {
 
 test.describe("Courses Page - Basic", () => {
   test("shows page content with course cards", async ({ page }) => {
-    await page.goto("/courses");
+    await page.goto("/en/courses");
 
     // Page title and description
     await expect(
@@ -34,7 +34,7 @@ test.describe("Courses Page - Basic", () => {
   });
 
   test("clicking course card navigates to course detail", async ({ page }) => {
-    await page.goto("/courses");
+    await page.goto("/en/courses");
 
     await page.getByText("Machine Learning").first().click();
 

--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -4,7 +4,7 @@ test.describe("Home Page - Unauthenticated", () => {
   test("shows hero with CTAs that navigate to correct pages", async ({
     page,
   }) => {
-    await page.goto("/");
+    await page.goto("/en/");
 
     await expect(page.getByText(/continue learning/i)).not.toBeVisible();
 
@@ -25,7 +25,7 @@ test.describe("Home Page - Unauthenticated", () => {
   });
 
   test("does not show performance section", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/en/");
 
     await expect(page.getByText(/^performance$/i)).not.toBeVisible();
   });
@@ -35,7 +35,7 @@ test.describe("Home Page - Authenticated", () => {
   test("user with progress sees continue learning instead of hero", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto("/");
+    await authenticatedPage.goto("/en/");
 
     await expect(
       authenticatedPage.getByText(/continue learning/i),
@@ -51,7 +51,7 @@ test.describe("Home Page - Authenticated", () => {
   test("user without progress sees hero section", async ({
     userWithoutProgress,
   }) => {
-    await userWithoutProgress.goto("/");
+    await userWithoutProgress.goto("/en/");
 
     await expect(
       userWithoutProgress.getByText(/continue learning/i),
@@ -69,7 +69,7 @@ test.describe("Home Page - Performance Section", () => {
   test("authenticated user with progress sees energy level", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto("/");
+    await authenticatedPage.goto("/en/");
 
     await expect(authenticatedPage.getByText(/^performance$/i)).toBeVisible();
     await expect(
@@ -80,7 +80,7 @@ test.describe("Home Page - Performance Section", () => {
   test("authenticated user with progress sees belt level", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto("/");
+    await authenticatedPage.goto("/en/");
 
     await expect(authenticatedPage.getByText(/^performance$/i)).toBeVisible();
     await expect(
@@ -94,7 +94,7 @@ test.describe("Home Page - Performance Section", () => {
   test("user without progress does not see performance section", async ({
     userWithoutProgress,
   }) => {
-    await userWithoutProgress.goto("/");
+    await userWithoutProgress.goto("/en/");
 
     await expect(
       userWithoutProgress.getByText(/^performance$/i),

--- a/apps/main/e2e/language.test.ts
+++ b/apps/main/e2e/language.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "./fixtures";
 
 test.describe("Language settings page", () => {
   test("displays language selector with current locale", async ({ page }) => {
-    await page.goto("/language");
+    await page.goto("/en/language");
 
     await expect(
       page.getByRole("heading", { level: 1, name: /^language$/i }),
@@ -14,7 +14,7 @@ test.describe("Language settings page", () => {
   });
 
   test("switches UI to Spanish when selected", async ({ page }) => {
-    await page.goto("/language");
+    await page.goto("/en/language");
 
     const selector = page.getByRole("combobox", { name: /update language/i });
     await selector.selectOption("es");
@@ -27,7 +27,7 @@ test.describe("Language settings page", () => {
   });
 
   test("switches UI to Portuguese when selected", async ({ page }) => {
-    await page.goto("/language");
+    await page.goto("/en/language");
 
     const selector = page.getByRole("combobox", { name: /update language/i });
     await selector.selectOption("pt");

--- a/apps/main/e2e/learn.test.ts
+++ b/apps/main/e2e/learn.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "./fixtures";
 
 test.describe("Learn Form", () => {
   test("shows form with auto-focused input", async ({ page }) => {
-    await page.goto("/learn");
+    await page.goto("/en/learn");
 
     await expect(
       page.getByRole("heading", { name: /what do you want to learn/i }),
@@ -14,7 +14,7 @@ test.describe("Learn Form", () => {
   });
 
   test("submitting prompt navigates to suggestions page", async ({ page }) => {
-    await page.goto("/learn");
+    await page.goto("/en/learn");
 
     await page.getByRole("textbox").fill("test prompt");
     await page.getByRole("button", { name: /start/i }).click();
@@ -29,7 +29,7 @@ test.describe("Course Suggestions", () => {
   test("shows suggestions with title, description, and create button", async ({
     page,
   }) => {
-    await page.goto("/learn/test%20prompt");
+    await page.goto("/en/learn/test%20prompt");
 
     await expect(
       page.getByRole("heading", { name: /course ideas for test prompt/i }),
@@ -45,7 +45,7 @@ test.describe("Course Suggestions", () => {
   });
 
   test("Change subject navigates back to learn form", async ({ page }) => {
-    await page.goto("/learn/test%20prompt");
+    await page.goto("/en/learn/test%20prompt");
 
     await expect(
       page.getByRole("heading", { name: /course ideas for/i }),
@@ -59,7 +59,7 @@ test.describe("Course Suggestions", () => {
   });
 
   test("submits form using Enter key", async ({ page }) => {
-    await page.goto("/learn");
+    await page.goto("/en/learn");
 
     const input = page.getByRole("textbox");
     await input.fill("test prompt");

--- a/apps/main/e2e/locale.test.ts
+++ b/apps/main/e2e/locale.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "./fixtures";
 
 test.describe("Locale Behavior - English", () => {
   test("home page shows English content", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/en/");
 
     // Navbar should be in English
     await expect(

--- a/apps/main/e2e/name.test.ts
+++ b/apps/main/e2e/name.test.ts
@@ -2,14 +2,14 @@ import { expect, test } from "./fixtures";
 
 test.describe("Display name settings page", () => {
   test("shows login prompt for unauthenticated users", async ({ page }) => {
-    await page.goto("/name");
+    await page.goto("/en/name");
 
     await expect(page.getByText(/you need to be logged in/i)).toBeVisible();
     await expect(page.getByRole("link", { name: /login/i })).toBeVisible();
   });
 
   test("updates display name successfully", async ({ authenticatedPage }) => {
-    await authenticatedPage.goto("/name");
+    await authenticatedPage.goto("/en/name");
 
     const nameInput = authenticatedPage.getByLabel(/name/i);
     await nameInput.clear();
@@ -34,7 +34,7 @@ test.describe("Display name settings page", () => {
   test("shows error for whitespace-only name", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto("/name");
+    await authenticatedPage.goto("/en/name");
 
     const nameInput = authenticatedPage.getByLabel(/name/i);
     const originalName = await nameInput.inputValue();

--- a/apps/main/e2e/navbar.test.ts
+++ b/apps/main/e2e/navbar.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "./fixtures";
 
 test.describe("Navbar - Unauthenticated", () => {
   test("Home link navigates to home page", async ({ page }) => {
-    await page.goto("/courses");
+    await page.goto("/en/courses");
 
     await page.getByRole("link", { name: /home/i }).click();
 
@@ -12,7 +12,7 @@ test.describe("Navbar - Unauthenticated", () => {
   });
 
   test("Courses link navigates to courses page", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/en/");
 
     await page.getByRole("link", { exact: true, name: "Courses" }).click();
 
@@ -22,7 +22,7 @@ test.describe("Navbar - Unauthenticated", () => {
   });
 
   test("Learn link navigates to learn page", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/en/");
 
     await page.getByRole("link", { exact: true, name: "Learn" }).click();
 
@@ -32,7 +32,7 @@ test.describe("Navbar - Unauthenticated", () => {
   });
 
   test("Home link is active on home page", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/en/");
 
     const homeLink = page.getByRole("link", { name: /home/i });
 
@@ -40,7 +40,7 @@ test.describe("Navbar - Unauthenticated", () => {
   });
 
   test("Courses link is active on courses page", async ({ page }) => {
-    await page.goto("/courses");
+    await page.goto("/en/courses");
 
     const coursesLink = page.getByRole("link", {
       exact: true,
@@ -51,7 +51,7 @@ test.describe("Navbar - Unauthenticated", () => {
   });
 
   test("Learn link is active on learn page", async ({ page }) => {
-    await page.goto("/learn");
+    await page.goto("/en/learn");
 
     const learnLink = page.getByRole("link", { exact: true, name: "Learn" });
 
@@ -63,7 +63,7 @@ test.describe("Navbar - Authenticated", () => {
   test("My courses menu item navigates to my courses page", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto("/");
+    await authenticatedPage.goto("/en/");
 
     await authenticatedPage.getByRole("button", { name: /user menu/i }).click();
 
@@ -79,7 +79,7 @@ test.describe("Navbar - Authenticated", () => {
   test("Settings menu item navigates to settings page", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto("/");
+    await authenticatedPage.goto("/en/");
 
     await authenticatedPage.getByRole("button", { name: /user menu/i }).click();
 

--- a/apps/main/e2e/settings-navbar.test.ts
+++ b/apps/main/e2e/settings-navbar.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "./fixtures";
 
 test.describe("Settings Navbar", () => {
   test("home link navigates to home page", async ({ page }) => {
-    await page.goto("/settings");
+    await page.goto("/en/settings");
     await page.getByRole("link", { name: /home page/i }).click();
 
     await expect(
@@ -13,7 +13,7 @@ test.describe("Settings Navbar", () => {
   test("dropdown Settings item navigates to settings page", async ({
     page,
   }) => {
-    await page.goto("/subscription");
+    await page.goto("/en/subscription");
     await page.getByRole("button", { name: /subscription/i }).click();
     await page.getByRole("menuitem", { name: /^settings$/i }).click();
 
@@ -25,7 +25,7 @@ test.describe("Settings Navbar", () => {
   test("dropdown Subscription item navigates to subscription page", async ({
     page,
   }) => {
-    await page.goto("/settings");
+    await page.goto("/en/settings");
     await page.getByRole("button", { name: /settings/i }).click();
     await page.getByRole("menuitem", { name: /subscription/i }).click();
 
@@ -37,7 +37,7 @@ test.describe("Settings Navbar", () => {
   test("dropdown Language item navigates to language page", async ({
     page,
   }) => {
-    await page.goto("/settings");
+    await page.goto("/en/settings");
     await page.getByRole("button", { name: /settings/i }).click();
     await page.getByRole("menuitem", { name: /language/i }).click();
 
@@ -49,7 +49,7 @@ test.describe("Settings Navbar", () => {
   test("dropdown Display name item navigates to name page", async ({
     page,
   }) => {
-    await page.goto("/settings");
+    await page.goto("/en/settings");
     await page.getByRole("button", { name: /settings/i }).click();
     await page.getByRole("menuitem", { name: /display name/i }).click();
 
@@ -59,7 +59,7 @@ test.describe("Settings Navbar", () => {
   });
 
   test("dropdown Support item navigates to support page", async ({ page }) => {
-    await page.goto("/settings");
+    await page.goto("/en/settings");
     await page.getByRole("button", { name: /settings/i }).click();
     await page.getByRole("menuitem", { name: /support/i }).click();
 
@@ -69,7 +69,7 @@ test.describe("Settings Navbar", () => {
   });
 
   test("logout button logs user out", async ({ logoutPage }) => {
-    await logoutPage.goto("/settings");
+    await logoutPage.goto("/en/settings");
 
     await expect(
       logoutPage.getByRole("link", { name: /logout/i }),

--- a/apps/main/e2e/settings-navbar.test.ts
+++ b/apps/main/e2e/settings-navbar.test.ts
@@ -75,15 +75,11 @@ test.describe("Settings Navbar", () => {
       logoutPage.getByRole("link", { name: /logout/i }),
     ).toBeVisible();
 
-    await Promise.all([
-      logoutPage.waitForURL(/^\/(en|pt)\/?$/),
-      logoutPage.waitForResponse(
-        (response) =>
-          response.url().includes("/api/auth/get-session") &&
-          response.status() === 200,
-      ),
-      logoutPage.getByRole("link", { name: /logout/i }).click(),
-    ]);
+    // Click logout - this triggers a hard navigation via window.location.href
+    await logoutPage.getByRole("link", { name: /logout/i }).click();
+
+    // Wait for navigation to complete (home page with locale)
+    await logoutPage.waitForURL(/\/(en|pt)\/?$/);
 
     await logoutPage.getByRole("button", { name: /search/i }).click();
 

--- a/apps/main/e2e/settings-navbar.test.ts
+++ b/apps/main/e2e/settings-navbar.test.ts
@@ -76,7 +76,7 @@ test.describe("Settings Navbar", () => {
     ).toBeVisible();
 
     await Promise.all([
-      logoutPage.waitForURL(/^[^?]*\/$/),
+      logoutPage.waitForURL(/^\/(en|pt)\/?$/),
       logoutPage.waitForResponse(
         (response) =>
           response.url().includes("/api/auth/get-session") &&

--- a/apps/main/e2e/settings.test.ts
+++ b/apps/main/e2e/settings.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "./fixtures";
 
 test.describe("Settings page", () => {
   test("displays correct heading and description", async ({ page }) => {
-    await page.goto("/settings");
+    await page.goto("/en/settings");
 
     await expect(
       page.getByRole("heading", { level: 1, name: /settings/i }),
@@ -14,7 +14,7 @@ test.describe("Settings page", () => {
   test("settings list items match dropdown items except Settings link", async ({
     page,
   }) => {
-    await page.goto("/settings");
+    await page.goto("/en/settings");
 
     // Open dropdown to get all menu items dynamically (source of truth)
     await page.getByRole("button", { name: /settings/i }).click();
@@ -64,7 +64,7 @@ test.describe("Settings page", () => {
   test("Settings item is active in dropdown when on settings page", async ({
     page,
   }) => {
-    await page.goto("/settings");
+    await page.goto("/en/settings");
     await page.getByRole("button", { name: /settings/i }).click();
 
     // The Settings menu item should be highlighted/active
@@ -73,7 +73,7 @@ test.describe("Settings page", () => {
   });
 
   test("Subscription link navigates to subscription page", async ({ page }) => {
-    await page.goto("/settings");
+    await page.goto("/en/settings");
     await page.getByRole("link", { name: /subscription/i }).click();
 
     await expect(
@@ -82,7 +82,7 @@ test.describe("Settings page", () => {
   });
 
   test("Language link navigates to language page", async ({ page }) => {
-    await page.goto("/settings");
+    await page.goto("/en/settings");
     await page.getByRole("link", { name: /language/i }).click();
 
     await expect(
@@ -91,7 +91,7 @@ test.describe("Settings page", () => {
   });
 
   test("Display name link navigates to name page", async ({ page }) => {
-    await page.goto("/settings");
+    await page.goto("/en/settings");
     await page.getByRole("link", { name: /display name/i }).click();
 
     await expect(
@@ -100,7 +100,7 @@ test.describe("Settings page", () => {
   });
 
   test("Support link navigates to support page", async ({ page }) => {
-    await page.goto("/settings");
+    await page.goto("/en/settings");
     await page.getByRole("link", { name: /support/i }).click();
 
     await expect(

--- a/apps/main/e2e/subscription.test.ts
+++ b/apps/main/e2e/subscription.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from "./fixtures";
 
 test.describe("Subscription Page - Unauthenticated", () => {
   test("shows login prompt with link to login page", async ({ page }) => {
-    await page.goto("/subscription");
+    await page.goto("/en/subscription");
     await expect(
       page.getByRole("alert").filter({ hasText: /logged in/i }),
     ).toBeVisible();
@@ -17,7 +17,7 @@ test.describe("Subscription Page - Unauthenticated", () => {
 
 test.describe("Subscription Page - No Subscription", () => {
   test("shows upgrade content", async ({ authenticatedPage }) => {
-    await authenticatedPage.goto("/subscription");
+    await authenticatedPage.goto("/en/subscription");
 
     await expect(
       authenticatedPage.getByRole("heading", {
@@ -35,7 +35,7 @@ test.describe("Subscription Page - No Subscription", () => {
   test("upgrade button shows loading state when clicked", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto("/subscription");
+    await authenticatedPage.goto("/en/subscription");
 
     const upgradeButton = authenticatedPage.getByRole("button", {
       name: /upgrade/i,
@@ -76,7 +76,7 @@ test.describe("Subscription Page - With Subscription", () => {
     const subscription = await createTestSubscription();
 
     try {
-      await userWithoutProgress.goto("/subscription");
+      await userWithoutProgress.goto("/en/subscription");
 
       await expect(
         userWithoutProgress.getByText(/your subscription is active/i),

--- a/apps/main/e2e/subscription.test.ts
+++ b/apps/main/e2e/subscription.test.ts
@@ -11,7 +11,7 @@ test.describe("Subscription Page - Unauthenticated", () => {
 
     const loginLink = page.getByRole("link", { name: /login/i });
     await expect(loginLink).toBeVisible();
-    await expect(loginLink).toHaveAttribute("href", "/login");
+    await expect(loginLink).toHaveAttribute("href", "/en/login");
   });
 });
 

--- a/apps/main/e2e/support.test.ts
+++ b/apps/main/e2e/support.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "./fixtures";
 
 test.describe("Support page", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/support");
+    await page.goto("/en/support");
 
     await expect(
       page.getByRole("heading", { name: /help & support/i }),
@@ -96,7 +96,7 @@ test.describe("Support page - Authenticated", () => {
   test("email field shows authenticated user's email", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.goto("/support");
+    await authenticatedPage.goto("/en/support");
 
     await authenticatedPage
       .getByRole("button", { name: /contact support/i })

--- a/apps/main/src/app/[locale]/(catalog)/continue-learning.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/continue-learning.tsx
@@ -20,15 +20,16 @@ import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { PlayCircleIcon } from "lucide-react";
 import { cacheLife } from "next/cache";
 import Image from "next/image";
-import { getExtracted } from "next-intl/server";
+import { getExtracted, setRequestLocale } from "next-intl/server";
 import { getContinueLearning } from "@/data/courses/get-continue-learning";
 import { Link } from "@/i18n/navigation";
 import { getActivityKinds } from "@/lib/activities";
 import { Hero } from "./hero";
 
-export async function ContinueLearning() {
+export async function ContinueLearning({ locale }: { locale: string }) {
   "use cache: private";
   cacheLife("minutes");
+  setRequestLocale(locale);
 
   const t = await getExtracted();
   const activityKinds = await getActivityKinds();

--- a/apps/main/src/app/[locale]/(catalog)/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/page.tsx
@@ -33,11 +33,11 @@ export default async function Home({ params }: PageProps<"/[locale]">) {
   return (
     <>
       <Suspense fallback={<ContinueLearningSkeleton />}>
-        <ContinueLearning />
+        <ContinueLearning locale={locale} />
       </Suspense>
 
       <Suspense fallback={<PerformanceSkeleton />}>
-        <Performance />
+        <Performance locale={locale} />
       </Suspense>
     </>
   );

--- a/apps/main/src/app/[locale]/(catalog)/performance.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/performance.tsx
@@ -1,17 +1,19 @@
 import { FeatureCardSectionTitle } from "@zoonk/ui/components/feature";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { cacheLife } from "next/cache";
-import { getExtracted } from "next-intl/server";
+import { getExtracted, setRequestLocale } from "next-intl/server";
 import { getBeltLevel } from "@/data/progress/get-belt-level";
 import { getEnergyLevel } from "@/data/progress/get-energy-level";
 import { BeltLevel, BeltLevelSkeleton } from "./belt-level";
 import { EnergyLevel, EnergyLevelSkeleton } from "./energy-level";
 
-export async function Performance() {
+export async function Performance({ locale }: { locale: string }) {
   "use cache: private";
   cacheLife("minutes");
+  setRequestLocale(locale);
 
   const t = await getExtracted();
+
   const [energyData, beltData] = await Promise.all([
     getEnergyLevel(),
     getBeltLevel(),

--- a/apps/main/src/app/[locale]/logout/page.tsx
+++ b/apps/main/src/app/[locale]/logout/page.tsx
@@ -2,12 +2,15 @@
 
 import { authClient } from "@zoonk/core/auth/client";
 import { FullPageLoading } from "@zoonk/ui/components/loading";
+import { useLocale } from "next-intl";
 import { useEffect, useEffectEvent } from "react";
 
 export default function LogoutPage() {
+  const locale = useLocale();
+
   const handleSuccess = useEffectEvent(() => {
     // Use hard navigation to ensure all client-side state (including useSession) is reset
-    window.location.href = "/";
+    window.location.href = `/${locale}`;
   });
 
   useEffect(() => {

--- a/apps/main/src/i18n/routing.ts
+++ b/apps/main/src/i18n/routing.ts
@@ -3,6 +3,6 @@ import { defineRouting } from "next-intl/routing";
 
 export const routing = defineRouting({
   defaultLocale: DEFAULT_LOCALE,
-  localePrefix: "as-needed",
+  localePrefix: "always",
   locales: SUPPORTED_LOCALES,
 });

--- a/apps/main/src/proxy.ts
+++ b/apps/main/src/proxy.ts
@@ -10,12 +10,6 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: [
-    /*
-     * Match all paths except for:
-     * - if they start with `/api`, `/_next` or `/_vercel`
-     * - the ones containing a dot (e.g. `favicon.ico`)
-     */
-    "/((?!api|_next|_vercel|149e|.*\\..*).*)",
-  ],
+  // We use the locale on all routes, so we only need to match the home page
+  matcher: ["/"],
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Always prefix routes with a locale and redirect the home page to the user’s locale based on cookie or Accept-Language. Home page content now translates correctly by setting the request locale in server components.

- **Refactors**
  - Set next-intl routing to localePrefix "always".
  - Middleware now only matches "/" and skips paths that already include a locale.
  - Root path redirects to /{locale}; removed default-locale stripping and nested-route redirects.
  - Set request locale in home components and made logout redirect to /{locale} to keep URLs consistent.
  - Updated tests for cookie and Accept-Language driven redirects.

<sup>Written for commit 703dfe73aaa113e7a9d6edc3b5d1417651bbd0cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

