### PR TITLE
fix(main): remove loading from course page

### DIFF
--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/loading.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/loading.tsx
@@ -1,5 +1,0 @@
-import { FullPageLoading } from "@zoonk/ui/components/loading";
-
-export default function Loading() {
-  return <FullPageLoading />;
-}


### PR DESCRIPTION
this was causing a bug where ISR wouldn't work for English pages. it was always generating a new page instead of using the cached ones.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the loading.tsx from the course page so ISR works again for English pages. This stops Next.js from regenerating pages and uses the cached version.

<sup>Written for commit ad3029662e2f58a011b7009e2cc1d4ae042c4eba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

