### PR TITLE
refactor(main): move hero out of continue learning

### DIFF
--- a/apps/main/src/app/[locale]/(catalog)/continue-learning.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/continue-learning.tsx
@@ -18,29 +18,24 @@ import {
 import { ScrollArea, ScrollBar } from "@zoonk/ui/components/scroll-area";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { PlayCircleIcon } from "lucide-react";
-import { cacheLife } from "next/cache";
 import Image from "next/image";
 import { getExtracted } from "next-intl/server";
-import { getContinueLearning } from "@/data/courses/get-continue-learning";
+import type { ContinueLearningItem } from "@/data/courses/get-continue-learning";
 import { Link } from "@/i18n/navigation";
 import { getActivityKinds } from "@/lib/activities";
-import { Hero } from "./hero";
 
-export async function ContinueLearning() {
-  "use cache: private";
-  cacheLife("minutes");
-
+export async function ContinueLearningList({
+  items,
+}: {
+  items: ContinueLearningItem[];
+}) {
   const t = await getExtracted();
   const activityKinds = await getActivityKinds();
-  const items = await getContinueLearning();
-
-  if (items.length === 0) {
-    return <Hero />;
-  }
 
   const kindLabels = new Map<string, string>(
     activityKinds.map((k) => [k.key, k.label]),
   );
+
   const defaultLabel = t("Activity");
 
   return (

--- a/apps/main/src/app/[locale]/(catalog)/home-content.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/home-content.tsx
@@ -1,0 +1,37 @@
+import { Suspense } from "react";
+import { getContinueLearning } from "@/data/courses/get-continue-learning";
+import {
+  ContinueLearningList,
+  ContinueLearningSkeleton,
+} from "./continue-learning";
+import { Hero } from "./hero";
+import { Performance, PerformanceSkeleton } from "./performance";
+
+export async function HomeContent() {
+  const items = await getContinueLearning();
+
+  if (items.length === 0) {
+    return <Hero />;
+  }
+
+  return (
+    <>
+      <Suspense fallback={<ContinueLearningSkeleton />}>
+        <ContinueLearningList items={items} />
+      </Suspense>
+
+      <Suspense fallback={<PerformanceSkeleton />}>
+        <Performance />
+      </Suspense>
+    </>
+  );
+}
+
+export function HomeContentSkeleton() {
+  return (
+    <>
+      <ContinueLearningSkeleton />
+      <PerformanceSkeleton />
+    </>
+  );
+}

--- a/apps/main/src/app/[locale]/(catalog)/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/page.tsx
@@ -3,11 +3,7 @@ import { getExtracted, setRequestLocale } from "next-intl/server";
 import { Suspense } from "react";
 import { getContinueLearning } from "@/data/courses/get-continue-learning";
 import { getEnergyLevel } from "@/data/progress/get-energy-level";
-import {
-  ContinueLearning,
-  ContinueLearningSkeleton,
-} from "./continue-learning";
-import { Performance, PerformanceSkeleton } from "./performance";
+import { HomeContent, HomeContentSkeleton } from "./home-content";
 
 export async function generateMetadata({
   params,
@@ -31,14 +27,8 @@ export default async function Home({ params }: PageProps<"/[locale]">) {
   void Promise.all([getContinueLearning(), getEnergyLevel()]);
 
   return (
-    <>
-      <Suspense fallback={<ContinueLearningSkeleton />}>
-        <ContinueLearning />
-      </Suspense>
-
-      <Suspense fallback={<PerformanceSkeleton />}>
-        <Performance />
-      </Suspense>
-    </>
+    <Suspense fallback={<HomeContentSkeleton />}>
+      <HomeContent />
+    </Suspense>
   );
 }

--- a/apps/main/src/app/[locale]/(catalog)/performance.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/performance.tsx
@@ -1,6 +1,5 @@
 import { FeatureCardSectionTitle } from "@zoonk/ui/components/feature";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
-import { cacheLife } from "next/cache";
 import { getExtracted } from "next-intl/server";
 import { getBeltLevel } from "@/data/progress/get-belt-level";
 import { getEnergyLevel } from "@/data/progress/get-energy-level";
@@ -8,10 +7,8 @@ import { BeltLevel, BeltLevelSkeleton } from "./belt-level";
 import { EnergyLevel, EnergyLevelSkeleton } from "./energy-level";
 
 export async function Performance() {
-  "use cache: private";
-  cacheLife("minutes");
-
   const t = await getExtracted();
+
   const [energyData, beltData] = await Promise.all([
     getEnergyLevel(),
     getBeltLevel(),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved the hero out of Continue Learning and introduced a HomeContent wrapper to control the home page flow. This simplifies data fetching, improves empty-state handling, and consolidates Suspense boundaries.

- **Refactors**
  - Added HomeContent to fetch continue learning and show Hero when empty.
  - Replaced ContinueLearning with ContinueLearningList that accepts items.
  - Page now renders HomeContent within a single Suspense with HomeContentSkeleton.
  - Removed cacheLife/private caching from ContinueLearning and Performance.

<sup>Written for commit c9a6906846b72dcba375ab67e718ce033c34f153. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

