### PR TITLE
fix(main): use belt indicator color

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -165,6 +165,11 @@ msgid "Green"
 msgstr "Green"
 
 #: src/app/[locale]/(catalog)/belt-level.tsx
+msgctxt "3UK8wh"
+msgid "{color} belt"
+msgstr "{color} belt"
+
+#: src/app/[locale]/(catalog)/belt-level.tsx
 msgctxt "5Tw3Ta"
 msgid "Yellow"
 msgstr "Yellow"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -167,7 +167,7 @@ msgstr "Verde"
 #: src/app/[locale]/(catalog)/belt-level.tsx
 msgctxt "3UK8wh"
 msgid "{color} belt"
-msgstr ""
+msgstr "Cinturón {color}"
 
 #: src/app/[locale]/(catalog)/belt-level.tsx
 msgctxt "5Tw3Ta"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -165,6 +165,11 @@ msgid "Green"
 msgstr "Verde"
 
 #: src/app/[locale]/(catalog)/belt-level.tsx
+msgctxt "3UK8wh"
+msgid "{color} belt"
+msgstr ""
+
+#: src/app/[locale]/(catalog)/belt-level.tsx
 msgctxt "5Tw3Ta"
 msgid "Yellow"
 msgstr "Amarillo"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -167,7 +167,7 @@ msgstr "Verde"
 #: src/app/[locale]/(catalog)/belt-level.tsx
 msgctxt "3UK8wh"
 msgid "{color} belt"
-msgstr ""
+msgstr "faixa {color}"
 
 #: src/app/[locale]/(catalog)/belt-level.tsx
 msgctxt "5Tw3Ta"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -165,6 +165,11 @@ msgid "Green"
 msgstr "Verde"
 
 #: src/app/[locale]/(catalog)/belt-level.tsx
+msgctxt "3UK8wh"
+msgid "{color} belt"
+msgstr ""
+
+#: src/app/[locale]/(catalog)/belt-level.tsx
 msgctxt "5Tw3Ta"
 msgid "Yellow"
 msgstr "Amarela"

--- a/apps/main/src/app/[locale]/(catalog)/belt-level.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/belt-level.tsx
@@ -1,9 +1,9 @@
+import { BeltIndicator } from "@zoonk/ui/components/belt-indicator";
 import {
   FeatureCard,
   FeatureCardBody,
   FeatureCardHeader,
   FeatureCardHeaderContent,
-  FeatureCardIcon,
   FeatureCardIndicator,
   FeatureCardLabel,
   FeatureCardSubtitle,
@@ -11,7 +11,6 @@ import {
 } from "@zoonk/ui/components/feature";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import type { BeltColor } from "@zoonk/utils/belt-level";
-import { AwardIcon } from "lucide-react";
 import { getExtracted, getLocale } from "next-intl/server";
 
 type BeltLevelProps = {
@@ -71,13 +70,13 @@ export async function BeltLevel({
     ? t("Max level reached")
     : t("{value} BP to next level", { value: formattedBp });
 
+  const beltLabel = t("{color} belt", { color: colorName });
+
   return (
     <FeatureCard className="w-full">
-      <FeatureCardHeader className="text-belt">
+      <FeatureCardHeader>
         <FeatureCardHeaderContent>
-          <FeatureCardIcon>
-            <AwardIcon />
-          </FeatureCardIcon>
+          <BeltIndicator color={color} label={beltLabel} size="sm" />
           <FeatureCardLabel>{t("Belt level")}</FeatureCardLabel>
         </FeatureCardHeaderContent>
         <FeatureCardIndicator />

--- a/i18n.lock
+++ b/i18n.lock
@@ -208,6 +208,7 @@ checksums:
     Accuracy/singular: d6022b38e0960d1a7bea84586e4986eb
     This%20content%20was%20generated%20by%20AI.%20It%20may%20contain%20errors%20or%20inaccuracies%20and%20should%20not%20be%20considered%20professional%20advice./singular: 269e7c16a722903b9b434f28aa6cf617
     Green/singular: 482ff383a4258357ba404f283682471d
+    "%7Bcolor%7D%20belt/singular": 5949446c9b4a223c04cc500fa17a1fe0
     Yellow/singular: 15d533755d35af887dfa584975549fda
     "%7Bvalue%7D%20BP%20to%20next%20level/singular": dc80ce93407f21e5e909760ec2c9aaef
     Red/singular: bace0083b78cdb188523bc4abc7b55c6

--- a/packages/ui/src/components/belt-indicator.tsx
+++ b/packages/ui/src/components/belt-indicator.tsx
@@ -1,0 +1,50 @@
+import { cn } from "@zoonk/ui/lib/utils";
+import type { BeltColor } from "@zoonk/utils/belt-level";
+
+const beltColorClasses: Record<BeltColor, string> = {
+  black: "bg-belt-black",
+  blue: "bg-belt-blue",
+  brown: "bg-belt-brown",
+  gray: "bg-belt-gray",
+  green: "bg-belt-green",
+  orange: "bg-belt-orange",
+  purple: "bg-belt-purple",
+  red: "bg-belt-red",
+  white: "bg-belt-white",
+  yellow: "bg-belt-yellow",
+};
+
+function BeltIndicator({
+  className,
+  color,
+  label,
+  size = "md",
+  ...props
+}: Omit<React.ComponentProps<"span">, "color"> & {
+  color: BeltColor;
+  label: string;
+  size?: "sm" | "md" | "lg";
+}) {
+  const sizeClasses: Record<typeof size, string> = {
+    lg: "size-6",
+    md: "size-4",
+    sm: "size-3",
+  };
+
+  return (
+    <span
+      aria-label={label}
+      className={cn(
+        "inline-block shrink-0 rounded-full",
+        "ring-1 ring-black/10 ring-inset dark:ring-white/10",
+        beltColorClasses[color],
+        sizeClasses[size],
+        className,
+      )}
+      role="img"
+      {...props}
+    />
+  );
+}
+
+export { BeltIndicator };

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -48,8 +48,17 @@
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-energy: var(--energy);
-  --color-belt: var(--belt);
   --color-accuracy: var(--accuracy);
+  --color-belt-white: var(--belt-white);
+  --color-belt-yellow: var(--belt-yellow);
+  --color-belt-orange: var(--belt-orange);
+  --color-belt-green: var(--belt-green);
+  --color-belt-blue: var(--belt-blue);
+  --color-belt-purple: var(--belt-purple);
+  --color-belt-brown: var(--belt-brown);
+  --color-belt-red: var(--belt-red);
+  --color-belt-gray: var(--belt-gray);
+  --color-belt-black: var(--belt-black);
 }
 
 :root {
@@ -88,8 +97,17 @@
   --sidebar-border: var(--color-neutral-200);
   --sidebar-ring: var(--color-primary);
   --energy: var(--color-orange-500);
-  --belt: var(--color-purple-500);
   --accuracy: var(--color-green-500);
+  --belt-white: var(--color-white);
+  --belt-yellow: var(--color-yellow-400);
+  --belt-orange: var(--color-orange-400);
+  --belt-green: var(--color-green-500);
+  --belt-blue: var(--color-blue-500);
+  --belt-purple: var(--color-purple-500);
+  --belt-brown: var(--color-amber-800);
+  --belt-red: var(--color-red-500);
+  --belt-gray: var(--color-gray-500);
+  --belt-black: var(--color-black);
 }
 
 @media (prefers-color-scheme: light) and (prefers-contrast: more) {
@@ -129,7 +147,6 @@
     --sidebar-border: var(--color-neutral-950);
     --sidebar-ring: var(--color-primary);
     --energy: var(--color-orange-700);
-    --belt: var(--color-purple-700);
     --accuracy: var(--color-green-700);
   }
 }
@@ -170,8 +187,8 @@
     --sidebar-border: var(--color-neutral-700);
     --sidebar-ring: var(--color-primary);
     --energy: var(--color-orange-400);
-    --belt: var(--color-purple-400);
     --accuracy: var(--color-green-400);
+    --belt-black: var(--color-neutral-700);
   }
 }
 
@@ -211,8 +228,8 @@
     --sidebar-border: var(--color-neutral-50);
     --sidebar-ring: var(--color-primary);
     --energy: var(--color-orange-200);
-    --belt: var(--color-purple-200);
     --accuracy: var(--color-green-200);
+    --belt-black: var(--color-neutral-500);
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced the Belt level icon with a color-coded BeltIndicator so the belt color is shown accurately across themes. Added en/es/pt translations for "{color} belt" to provide accessible labels.

<sup>Written for commit 2ba626bbd0d7019152207c86996ba13cea95c4b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

