### PR TITLE
test(main): scope navigation elements to avoid conflicts

### DIFF
--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -1,8 +1,12 @@
 import { expect, type Page, test } from "./fixtures";
 
 // Helper to open command palette via click (reliable for tests that don't test keyboard shortcuts)
+// Scoped to navigation to avoid strict mode violation when multiple search buttons exist during streaming
 async function openCommandPalette(page: Page) {
-  await page.getByRole("button", { name: /search/i }).click();
+  await page
+    .getByRole("navigation")
+    .getByRole("button", { name: /search/i })
+    .click();
 }
 
 // Helper to get the correct modifier key for the platform
@@ -15,7 +19,10 @@ test.describe("Command Palette - Unauthenticated", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
     // Wait for the page to be fully interactive before testing keyboard shortcuts
-    await expect(page.getByRole("button", { name: /search/i })).toBeVisible();
+    // Scoped to navigation to avoid strict mode violation
+    await expect(
+      page.getByRole("navigation").getByRole("button", { name: /search/i }),
+    ).toBeVisible();
   });
 
   test("toggles closed with Ctrl+K / Cmd+K when already open", async ({
@@ -36,7 +43,7 @@ test.describe("Command Palette - Unauthenticated", () => {
 
   test("opens when clicking search button", async ({ page }) => {
     await expect(page.getByRole("dialog")).not.toBeVisible();
-    await page.getByRole("button", { name: /search/i }).click();
+    await openCommandPalette(page);
     await expect(page.getByRole("dialog")).toBeVisible();
   });
 
@@ -141,7 +148,7 @@ test.describe("Command Palette - Authenticated", () => {
     authenticatedPage,
   }) => {
     await authenticatedPage.goto("/");
-    await authenticatedPage.getByRole("button", { name: /search/i }).click();
+    await openCommandPalette(authenticatedPage);
 
     const dialog = authenticatedPage.getByRole("dialog");
     await expect(dialog.getByText(/^my courses$/i)).toBeVisible();
@@ -156,7 +163,7 @@ test.describe("Command Palette - Authenticated", () => {
     authenticatedPage,
   }) => {
     await authenticatedPage.goto("/");
-    await authenticatedPage.getByRole("button", { name: /search/i }).click();
+    await openCommandPalette(authenticatedPage);
 
     const dialog = authenticatedPage.getByRole("dialog");
     await expect(dialog.getByText(/^login$/i)).not.toBeVisible();
@@ -166,7 +173,7 @@ test.describe("Command Palette - Authenticated", () => {
     authenticatedPage,
   }) => {
     await authenticatedPage.goto("/");
-    await authenticatedPage.getByRole("button", { name: /search/i }).click();
+    await openCommandPalette(authenticatedPage);
 
     await authenticatedPage
       .getByRole("dialog")
@@ -183,7 +190,7 @@ test.describe("Command Palette - Authenticated", () => {
     authenticatedPage,
   }) => {
     await authenticatedPage.goto("/");
-    await authenticatedPage.getByRole("button", { name: /search/i }).click();
+    await openCommandPalette(authenticatedPage);
 
     await authenticatedPage
       .getByRole("dialog")
@@ -203,7 +210,7 @@ test.describe("Command Palette - Authenticated", () => {
     authenticatedPage,
   }) => {
     await authenticatedPage.goto("/");
-    await authenticatedPage.getByRole("button", { name: /search/i }).click();
+    await openCommandPalette(authenticatedPage);
 
     await authenticatedPage
       .getByRole("dialog")
@@ -223,7 +230,7 @@ test.describe("Command Palette - Authenticated", () => {
     await logoutPage.goto("/");
 
     // Verify authenticated state by checking command palette shows Logout option
-    await logoutPage.getByRole("button", { name: /search/i }).click();
+    await openCommandPalette(logoutPage);
     await expect(
       logoutPage.getByRole("dialog").getByText(/^logout$/i),
     ).toBeVisible();
@@ -243,7 +250,7 @@ test.describe("Command Palette - Authenticated", () => {
     ]);
 
     // Verify user is logged out - command palette should show Login option
-    await logoutPage.getByRole("button", { name: /search/i }).click();
+    await openCommandPalette(logoutPage);
     await expect(
       logoutPage.getByRole("dialog").getByText(/^login$/i),
     ).toBeVisible();
@@ -253,7 +260,7 @@ test.describe("Command Palette - Authenticated", () => {
 test.describe("Command Palette - Course Search", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
-    await page.getByRole("button", { name: /search/i }).click();
+    await openCommandPalette(page);
   });
 
   test("does not search with fewer than 2 characters", async ({ page }) => {
@@ -310,7 +317,7 @@ test.describe("Command Palette - Course Search", () => {
 test.describe("Command Palette - Keyboard Navigation", () => {
   test("focuses input on open", async ({ page }) => {
     await page.goto("/");
-    await page.getByRole("button", { name: /search/i }).click();
+    await openCommandPalette(page);
 
     const input = page.getByPlaceholder(/search/i);
     await expect(input).toBeFocused();
@@ -318,7 +325,7 @@ test.describe("Command Palette - Keyboard Navigation", () => {
 
   test("arrow key navigation selects items", async ({ page }) => {
     await page.goto("/");
-    await page.getByRole("button", { name: /search/i }).click();
+    await openCommandPalette(page);
 
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
@@ -361,7 +368,7 @@ test.describe("Command Palette - Keyboard Navigation", () => {
 
   test("Enter to select navigates correctly", async ({ page }) => {
     await page.goto("/courses"); // Start from courses page so Home navigation is verifiable
-    await page.getByRole("button", { name: /search/i }).click();
+    await openCommandPalette(page);
     await expect(page.getByRole("dialog")).toBeVisible();
 
     // Type to filter to Home option, then press Enter to select it
@@ -377,7 +384,7 @@ test.describe("Command Palette - Keyboard Navigation", () => {
 
   test("focus trap within dialog", async ({ page }) => {
     await page.goto("/");
-    await page.getByRole("button", { name: /search/i }).click();
+    await openCommandPalette(page);
     await expect(page.getByRole("dialog")).toBeVisible();
 
     // Tab multiple times to cycle through focusable elements
@@ -395,7 +402,7 @@ test.describe("Command Palette - Mobile Viewport", () => {
 
   test("command palette opens and functions on mobile", async ({ page }) => {
     await page.goto("/");
-    await page.getByRole("button", { name: /search/i }).click();
+    await openCommandPalette(page);
 
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
@@ -408,7 +415,7 @@ test.describe("Command Palette - Mobile Viewport", () => {
 test.describe("Command Palette - Accessibility", () => {
   test("has dialog role", async ({ page }) => {
     await page.goto("/");
-    await page.getByRole("button", { name: /search/i }).click();
+    await openCommandPalette(page);
 
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
@@ -416,7 +423,7 @@ test.describe("Command Palette - Accessibility", () => {
 
   test("has accessible title", async ({ page }) => {
     await page.goto("/");
-    await page.getByRole("button", { name: /search/i }).click();
+    await openCommandPalette(page);
 
     const dialog = page.getByRole("dialog");
     const hasLabel = await dialog.evaluate(
@@ -429,7 +436,10 @@ test.describe("Command Palette - Accessibility", () => {
   test("search button indicates keyboard shortcut", async ({ page }) => {
     await page.goto("/");
 
-    const searchButton = page.getByRole("button", { name: /search/i });
+    // Scoped to navigation to avoid strict mode violation
+    const searchButton = page
+      .getByRole("navigation")
+      .getByRole("button", { name: /search/i });
     await expect(searchButton).toHaveAttribute("aria-keyshortcuts", /k/i);
   });
 

--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -37,8 +37,11 @@ test.describe("Home Page - Authenticated", () => {
   }) => {
     await authenticatedPage.goto("/");
 
+    // Use .first() to handle potential duplicates during streaming/hydration
     await expect(
-      authenticatedPage.getByText(/continue learning/i),
+      authenticatedPage
+        .getByRole("heading", { name: /continue learning/i })
+        .first(),
     ).toBeVisible();
 
     await expect(

--- a/apps/main/e2e/locale.test.ts
+++ b/apps/main/e2e/locale.test.ts
@@ -4,13 +4,15 @@ test.describe("Locale Behavior - English", () => {
   test("home page shows English content", async ({ page }) => {
     await page.goto("/");
 
-    // Navbar should be in English
+    const nav = page.getByRole("navigation");
+
+    // Navbar should be in English (scoped to navigation to avoid hero links)
     await expect(
-      page.getByRole("link", { exact: true, name: "Courses" }),
+      nav.getByRole("link", { exact: true, name: "Courses" }),
     ).toBeVisible();
 
     await expect(
-      page.getByRole("link", { exact: true, name: "Learn" }),
+      nav.getByRole("link", { exact: true, name: "Learn" }),
     ).toBeVisible();
 
     // Hero heading should be in English
@@ -24,18 +26,20 @@ test.describe("Locale Behavior - Portuguese", () => {
   test("Portuguese home shows Portuguese content", async ({ page }) => {
     await page.goto("/pt");
 
+    const nav = page.getByRole("navigation");
+
     // Wait for Portuguese hero heading to confirm locale is loaded
     await expect(
       page.getByRole("heading", { name: /aprenda qualquer coisa com ia/i }),
     ).toBeVisible();
 
-    // Navbar should be in Portuguese (use exact match to avoid hero links)
+    // Navbar should be in Portuguese (scoped to navigation to avoid hero links)
     await expect(
-      page.getByRole("link", { exact: true, name: "Cursos" }),
+      nav.getByRole("link", { exact: true, name: "Cursos" }),
     ).toBeVisible();
 
     await expect(
-      page.getByRole("link", { exact: true, name: "Aprender" }),
+      nav.getByRole("link", { exact: true, name: "Aprender" }),
     ).toBeVisible();
   });
 });
@@ -46,8 +50,11 @@ test.describe("Locale Navigation", () => {
   }) => {
     await page.goto("/pt");
 
-    // Click Courses link (in Portuguese: "Cursos")
-    await page.getByRole("link", { exact: true, name: "Cursos" }).click();
+    // Click Courses link in navbar (scoped to navigation to avoid hero links)
+    await page
+      .getByRole("navigation")
+      .getByRole("link", { exact: true, name: "Cursos" })
+      .click();
 
     // Should be on Portuguese courses page
     await expect(page).toHaveURL(/\/pt\/courses/);

--- a/apps/main/e2e/navbar.test.ts
+++ b/apps/main/e2e/navbar.test.ts
@@ -4,7 +4,11 @@ test.describe("Navbar - Unauthenticated", () => {
   test("Home link navigates to home page", async ({ page }) => {
     await page.goto("/courses");
 
-    await page.getByRole("link", { name: /home/i }).click();
+    // Scope to navigation to avoid conflicts with links in main content
+    await page
+      .getByRole("navigation")
+      .getByRole("link", { name: /home/i })
+      .click();
 
     await expect(
       page.getByRole("heading", { name: /learn anything with ai/i }),
@@ -14,7 +18,11 @@ test.describe("Navbar - Unauthenticated", () => {
   test("Courses link navigates to courses page", async ({ page }) => {
     await page.goto("/");
 
-    await page.getByRole("link", { exact: true, name: "Courses" }).click();
+    // Scope to navigation to avoid conflicts with "Explore courses" in hero
+    await page
+      .getByRole("navigation")
+      .getByRole("link", { exact: true, name: "Courses" })
+      .click();
 
     await expect(
       page.getByRole("heading", { name: /explore courses/i }),
@@ -24,7 +32,11 @@ test.describe("Navbar - Unauthenticated", () => {
   test("Learn link navigates to learn page", async ({ page }) => {
     await page.goto("/");
 
-    await page.getByRole("link", { exact: true, name: "Learn" }).click();
+    // Scope to navigation to avoid conflicts with "Learn anything" in hero
+    await page
+      .getByRole("navigation")
+      .getByRole("link", { exact: true, name: "Learn" })
+      .click();
 
     await expect(
       page.getByRole("heading", { name: /what do you want to learn/i }),
@@ -34,7 +46,9 @@ test.describe("Navbar - Unauthenticated", () => {
   test("Home link is active on home page", async ({ page }) => {
     await page.goto("/");
 
-    const homeLink = page.getByRole("link", { name: /home/i });
+    const homeLink = page
+      .getByRole("navigation")
+      .getByRole("link", { name: /home/i });
 
     await expect(homeLink).toHaveAttribute("aria-current", "page");
   });
@@ -42,10 +56,9 @@ test.describe("Navbar - Unauthenticated", () => {
   test("Courses link is active on courses page", async ({ page }) => {
     await page.goto("/courses");
 
-    const coursesLink = page.getByRole("link", {
-      exact: true,
-      name: "Courses",
-    });
+    const coursesLink = page
+      .getByRole("navigation")
+      .getByRole("link", { exact: true, name: "Courses" });
 
     await expect(coursesLink).toHaveAttribute("aria-current", "page");
   });
@@ -53,7 +66,9 @@ test.describe("Navbar - Unauthenticated", () => {
   test("Learn link is active on learn page", async ({ page }) => {
     await page.goto("/learn");
 
-    const learnLink = page.getByRole("link", { exact: true, name: "Learn" });
+    const learnLink = page
+      .getByRole("navigation")
+      .getByRole("link", { exact: true, name: "Learn" });
 
     await expect(learnLink).toHaveAttribute("aria-current", "page");
   });

--- a/apps/main/e2e/settings-navbar.test.ts
+++ b/apps/main/e2e/settings-navbar.test.ts
@@ -85,7 +85,11 @@ test.describe("Settings Navbar", () => {
       logoutPage.getByRole("link", { name: /logout/i }).click(),
     ]);
 
-    await logoutPage.getByRole("button", { name: /search/i }).click();
+    // Scope to navigation to avoid strict mode violation
+    await logoutPage
+      .getByRole("navigation")
+      .getByRole("button", { name: /search/i })
+      .click();
 
     await expect(
       logoutPage.getByRole("dialog").getByText(/^login$/i),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Scoped e2e selectors to the navigation bar to avoid conflicts with hero content and duplicate elements during streaming/hydration. This resolves Playwright strict mode violations and stabilizes command palette, navbar, locale, and settings tests.

- **Bug Fixes**
  - Scope Search button and navbar links with getByRole("navigation").
  - Add openCommandPalette(page) helper to click the nav-scoped Search button.
  - Adjust assertions to avoid duplicates (e.g., use heading .first(), exact link matches).
  - Reduce flakiness caused by streaming/hydration duplicates across affected tests.

<sup>Written for commit 1d76c2d0761d1e2fb03a65e000727dcc29ef7f65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

