### PR TITLE
feat(main): add best day to home

### DIFF
--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -103,6 +103,17 @@ test.describe("Home Page - Performance Section", () => {
     await expect(authenticatedPage.getByText("Past 30 days")).toBeVisible();
   });
 
+  test("authenticated user with progress sees best day", async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto("/");
+
+    await expect(authenticatedPage.getByText(/^performance$/i)).toBeVisible();
+    await expect(authenticatedPage.getByText(/best day/i)).toBeVisible();
+    await expect(authenticatedPage.getByText(/with 85%/i)).toBeVisible();
+    await expect(authenticatedPage.getByText("Past 3 months")).toBeVisible();
+  });
+
   test("user without progress does not see performance section", async ({
     userWithoutProgress,
   }) => {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -249,6 +249,21 @@ msgctxt "Yp7v0H"
 msgid "Gray"
 msgstr "Gray"
 
+#: src/app/[locale]/(catalog)/best-day.tsx
+msgctxt "bcsugq"
+msgid "{day} with {value}%"
+msgstr "{day} with {value}%"
+
+#: src/app/[locale]/(catalog)/best-day.tsx
+msgctxt "HHFpcy"
+msgid "Best day"
+msgstr "Best day"
+
+#: src/app/[locale]/(catalog)/best-day.tsx
+msgctxt "zml1/y"
+msgid "Past 3 months"
+msgstr "Past 3 months"
+
 #: src/app/[locale]/(catalog)/continue-learning.tsx
 msgctxt "0X+xfW"
 msgid "Continue learning"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -249,6 +249,21 @@ msgctxt "Yp7v0H"
 msgid "Gray"
 msgstr "Gris"
 
+#: src/app/[locale]/(catalog)/best-day.tsx
+msgctxt "bcsugq"
+msgid "{day} with {value}%"
+msgstr "{day} con {value}%"
+
+#: src/app/[locale]/(catalog)/best-day.tsx
+msgctxt "HHFpcy"
+msgid "Best day"
+msgstr "Mejor día"
+
+#: src/app/[locale]/(catalog)/best-day.tsx
+msgctxt "zml1/y"
+msgid "Past 3 months"
+msgstr "Últimos 3 meses"
+
 #: src/app/[locale]/(catalog)/continue-learning.tsx
 msgctxt "0X+xfW"
 msgid "Continue learning"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -249,6 +249,21 @@ msgctxt "Yp7v0H"
 msgid "Gray"
 msgstr "Cinza"
 
+#: src/app/[locale]/(catalog)/best-day.tsx
+msgctxt "bcsugq"
+msgid "{day} with {value}%"
+msgstr "{day} com {value}%"
+
+#: src/app/[locale]/(catalog)/best-day.tsx
+msgctxt "HHFpcy"
+msgid "Best day"
+msgstr "Melhor dia"
+
+#: src/app/[locale]/(catalog)/best-day.tsx
+msgctxt "zml1/y"
+msgid "Past 3 months"
+msgstr "Últimos 3 meses"
+
 #: src/app/[locale]/(catalog)/continue-learning.tsx
 msgctxt "0X+xfW"
 msgid "Continue learning"

--- a/apps/main/src/app/[locale]/(catalog)/best-day.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/best-day.tsx
@@ -1,0 +1,69 @@
+import {
+  FeatureCard,
+  FeatureCardBody,
+  FeatureCardHeader,
+  FeatureCardHeaderContent,
+  FeatureCardIcon,
+  FeatureCardIndicator,
+  FeatureCardLabel,
+  FeatureCardSubtitle,
+  FeatureCardTitle,
+} from "@zoonk/ui/components/feature";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { CalendarDays } from "lucide-react";
+import { getExtracted, getLocale } from "next-intl/server";
+
+type BestDayProps = {
+  accuracy: number;
+  dayOfWeek: number;
+};
+
+export async function BestDay({ accuracy, dayOfWeek }: BestDayProps) {
+  const t = await getExtracted();
+  const locale = await getLocale();
+
+  const referenceDate = new Date(1970, 0, 4 + dayOfWeek);
+
+  const dayName = new Intl.DateTimeFormat(locale, { weekday: "long" }).format(
+    referenceDate,
+  );
+
+  const formattedAccuracy = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 1,
+    trailingZeroDisplay: "stripIfInteger",
+  }).format(accuracy);
+
+  return (
+    <FeatureCard className="w-full">
+      <FeatureCardHeader className="text-accuracy">
+        <FeatureCardHeaderContent>
+          <FeatureCardIcon>
+            <CalendarDays />
+          </FeatureCardIcon>
+          <FeatureCardLabel>{t("Best day")}</FeatureCardLabel>
+        </FeatureCardHeaderContent>
+        <FeatureCardIndicator />
+      </FeatureCardHeader>
+
+      <FeatureCardBody>
+        <FeatureCardTitle className="first-letter:uppercase">
+          {t("{day} with {value}%", { day: dayName, value: formattedAccuracy })}
+        </FeatureCardTitle>
+        <FeatureCardSubtitle>{t("Past 3 months")}</FeatureCardSubtitle>
+      </FeatureCardBody>
+    </FeatureCard>
+  );
+}
+
+export function BestDaySkeleton() {
+  return (
+    <FeatureCard className="w-full">
+      <Skeleton className="h-5 w-24" />
+
+      <FeatureCardBody className="gap-1">
+        <Skeleton className="h-4 w-full max-w-40" />
+        <Skeleton className="h-3 w-full max-w-28" />
+      </FeatureCardBody>
+    </FeatureCard>
+  );
+}

--- a/apps/main/src/app/[locale]/(catalog)/performance.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/performance.tsx
@@ -3,23 +3,22 @@ import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { getExtracted } from "next-intl/server";
 import { getAccuracy } from "@/data/progress/get-accuracy";
 import { getBeltLevel } from "@/data/progress/get-belt-level";
+import { getBestDay } from "@/data/progress/get-best-day";
 import { getEnergyLevel } from "@/data/progress/get-energy-level";
 import { Accuracy, AccuracySkeleton } from "./accuracy";
 import { BeltLevel, BeltLevelSkeleton } from "./belt-level";
+import { BestDay, BestDaySkeleton } from "./best-day";
 import { EnergyLevel, EnergyLevelSkeleton } from "./energy-level";
 
 export async function Performance() {
   const t = await getExtracted();
 
-  const [energyData, beltData, accuracyData] = await Promise.all([
+  const [energyData, beltData, accuracyData, bestDayData] = await Promise.all([
     getEnergyLevel(),
     getBeltLevel(),
     getAccuracy(),
+    getBestDay(),
   ]);
-
-  if (!(energyData && beltData && accuracyData)) {
-    return null;
-  }
 
   return (
     <section
@@ -31,14 +30,25 @@ export async function Performance() {
       </FeatureCardSectionTitle>
 
       <div className="grid grid-cols-1 gap-4 px-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
-        <EnergyLevel energy={energyData.currentEnergy} />
-        <BeltLevel
-          bpToNextLevel={beltData.bpToNextLevel}
-          color={beltData.color}
-          isMaxLevel={beltData.isMaxLevel}
-          level={beltData.level}
-        />
-        <Accuracy accuracy={accuracyData.accuracy} />
+        {energyData && <EnergyLevel energy={energyData.currentEnergy} />}
+
+        {beltData && (
+          <BeltLevel
+            bpToNextLevel={beltData.bpToNextLevel}
+            color={beltData.color}
+            isMaxLevel={beltData.isMaxLevel}
+            level={beltData.level}
+          />
+        )}
+
+        {accuracyData && <Accuracy accuracy={accuracyData.accuracy} />}
+
+        {bestDayData && (
+          <BestDay
+            accuracy={bestDayData.accuracy}
+            dayOfWeek={bestDayData.dayOfWeek}
+          />
+        )}
       </div>
     </section>
   );
@@ -53,6 +63,7 @@ export function PerformanceSkeleton() {
         <EnergyLevelSkeleton />
         <BeltLevelSkeleton />
         <AccuracySkeleton />
+        <BestDaySkeleton />
       </div>
     </section>
   );

--- a/apps/main/src/data/progress/get-best-day.test.ts
+++ b/apps/main/src/data/progress/get-best-day.test.ts
@@ -1,0 +1,166 @@
+import { prisma } from "@zoonk/db";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { describe, expect, test } from "vitest";
+import { getBestDay } from "./get-best-day";
+
+describe("unauthenticated users", () => {
+  test("returns null", async () => {
+    const result = await getBestDay({ headers: new Headers() });
+    expect(result).toBeNull();
+  });
+});
+
+describe("authenticated users", () => {
+  test("returns null when user has no DailyProgress records", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+
+    const result = await getBestDay({ headers });
+    expect(result).toBeNull();
+  });
+
+  test("returns best day when user has data for multiple days", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+    const org = await organizationFixture();
+
+    const today = new Date();
+    const sunday = new Date(today);
+    sunday.setDate(sunday.getDate() - sunday.getDay());
+
+    const monday = new Date(sunday);
+    monday.setDate(monday.getDate() + 1);
+
+    await prisma.dailyProgress.createMany({
+      data: [
+        {
+          correctAnswers: 18,
+          date: sunday,
+          incorrectAnswers: 2,
+          organizationId: org.id,
+          userId: Number(user.id),
+        },
+        {
+          correctAnswers: 15,
+          date: monday,
+          incorrectAnswers: 5,
+          organizationId: org.id,
+          userId: Number(user.id),
+        },
+      ],
+    });
+
+    const result = await getBestDay({ headers });
+
+    expect(result).not.toBeNull();
+    expect(result?.dayOfWeek).toBe(0);
+    expect(result?.accuracy).toBe(90);
+  });
+
+  test("excludes records older than 90 days", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+    const org = await organizationFixture();
+
+    const today = new Date();
+    const oldDate = new Date(today);
+    oldDate.setDate(oldDate.getDate() - 91);
+
+    await prisma.dailyProgress.createMany({
+      data: [
+        {
+          correctAnswers: 8,
+          date: today,
+          incorrectAnswers: 2,
+          organizationId: org.id,
+          userId: Number(user.id),
+        },
+        {
+          correctAnswers: 20,
+          date: oldDate,
+          incorrectAnswers: 0,
+          organizationId: org.id,
+          userId: Number(user.id),
+        },
+      ],
+    });
+
+    const result = await getBestDay({ headers });
+
+    expect(result).not.toBeNull();
+    expect(result?.accuracy).toBe(80);
+  });
+
+  test("uses day with most answers as tiebreaker", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+    const org = await organizationFixture();
+
+    const today = new Date();
+    const sunday = new Date(today);
+    sunday.setDate(sunday.getDate() - sunday.getDay());
+
+    const nextSunday = new Date(sunday);
+    nextSunday.setDate(nextSunday.getDate() + 7);
+
+    const monday = new Date(sunday);
+    monday.setDate(monday.getDate() + 1);
+
+    await prisma.dailyProgress.createMany({
+      data: [
+        {
+          correctAnswers: 9,
+          date: sunday,
+          incorrectAnswers: 1,
+          organizationId: org.id,
+          userId: Number(user.id),
+        },
+        {
+          correctAnswers: 9,
+          date: nextSunday,
+          incorrectAnswers: 1,
+          organizationId: org.id,
+          userId: Number(user.id),
+        },
+        {
+          correctAnswers: 8,
+          date: monday,
+          incorrectAnswers: 2,
+          organizationId: org.id,
+          userId: Number(user.id),
+        },
+      ],
+    });
+
+    const result = await getBestDay({ headers });
+
+    expect(result).not.toBeNull();
+    expect(result?.dayOfWeek).toBe(0);
+    expect(result?.accuracy).toBe(90);
+  });
+
+  test("returns correct accuracy calculation", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+    const org = await organizationFixture();
+
+    const today = new Date();
+
+    await prisma.dailyProgress.create({
+      data: {
+        correctAnswers: 17,
+        date: today,
+        incorrectAnswers: 3,
+        organizationId: org.id,
+        userId: Number(user.id),
+      },
+    });
+
+    const result = await getBestDay({ headers });
+
+    expect(result).not.toBeNull();
+    expect(result?.accuracy).toBe(85);
+  });
+});

--- a/apps/main/src/data/progress/get-best-day.ts
+++ b/apps/main/src/data/progress/get-best-day.ts
@@ -1,0 +1,61 @@
+import "server-only";
+
+import { getSession } from "@zoonk/core/users/session/get";
+import { prisma } from "@zoonk/db";
+import { getBestDay as getBestDayQuery } from "@zoonk/db/best-day";
+import { safeAsync } from "@zoonk/utils/error";
+import { cache } from "react";
+
+export type BestDayData = {
+  accuracy: number;
+  dayOfWeek: number;
+};
+
+export const getBestDay = cache(
+  async (params?: { headers?: Headers }): Promise<BestDayData | null> => {
+    const session = await getSession({ headers: params?.headers });
+
+    if (!session) {
+      return null;
+    }
+
+    const userId = Number(session.user.id);
+    const ninetyDaysAgo = new Date();
+    ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+
+    const { data: results, error } = await safeAsync(() =>
+      prisma.$queryRawTyped(getBestDayQuery(userId, ninetyDaysAgo)),
+    );
+
+    if (error || !results || results.length === 0) {
+      return null;
+    }
+
+    let bestDay: BestDayData | null = null;
+    let bestDayTotal = 0;
+
+    for (const row of results) {
+      const correct = Number(row.correct);
+      const incorrect = Number(row.incorrect);
+      const total = correct + incorrect;
+
+      if (total === 0) {
+        continue;
+      }
+
+      const accuracy = (correct / total) * 100;
+
+      const isBetter =
+        !bestDay ||
+        accuracy > bestDay.accuracy ||
+        (accuracy === bestDay.accuracy && total > bestDayTotal);
+
+      if (isBetter) {
+        bestDay = { accuracy, dayOfWeek: Number(row.dayOfWeek) };
+        bestDayTotal = total;
+      }
+    }
+
+    return bestDay;
+  },
+);

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -14,6 +14,7 @@
   },
   "exports": {
     ".": "./src/index.ts",
+    "./best-day": "./src/generated/prisma/sql/getBestDay.ts",
     "./continue-learning": "./src/generated/prisma/sql/getContinueLearning.ts",
     "./utils": "./src/utils.ts"
   },

--- a/packages/db/src/prisma/sql/getBestDay.sql
+++ b/packages/db/src/prisma/sql/getBestDay.sql
@@ -1,0 +1,10 @@
+-- @param {Int} $1:userId
+-- @param {DateTime} $2:since
+SELECT
+  EXTRACT(DOW FROM date)::int AS "dayOfWeek",
+  SUM(correct_answers)::bigint AS correct,
+  SUM(incorrect_answers)::bigint AS incorrect
+FROM daily_progress
+WHERE user_id = $1 AND date >= $2
+GROUP BY EXTRACT(DOW FROM date)
+HAVING SUM(correct_answers) + SUM(incorrect_answers) > 0;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show “Best day” in the Home Performance section to highlight the weekday with the highest answer accuracy over the past 3 months. Data is aggregated server-side and shown with localized text (e.g., “Monday with 85%”).

- New Features
  - BestDay card and skeleton added to the Performance grid.
  - getBestDay server query: last 90 days, accuracy per weekday, tie-break by total answers.
  - New SQL (getBestDay.sql) and db export path added.
  - i18n strings added for en, es, and pt.
  - Performance section now renders each card only when data is available.

<sup>Written for commit fc5576124ea8ea28215b3ac65b43518bccdfc50b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

