### PR TITLE
refactor(main): keep accuracy consistent with best day

### DIFF
--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -103,7 +103,6 @@ test.describe("Home Page - Performance Section", () => {
     await expect(
       authenticatedPage.getByText("85% correct answers"),
     ).toBeVisible();
-    await expect(authenticatedPage.getByText("Past 3 months")).toBeVisible();
   });
 
   test("authenticated user with progress sees best day", async ({
@@ -114,7 +113,6 @@ test.describe("Home Page - Performance Section", () => {
     await expect(authenticatedPage.getByText(/^performance$/i)).toBeVisible();
     await expect(authenticatedPage.getByText(/best day/i)).toBeVisible();
     await expect(authenticatedPage.getByText(/with 85%/i)).toBeVisible();
-    await expect(authenticatedPage.getByText("Past 3 months")).toBeVisible();
   });
 
   test("user without progress does not see performance section", async ({

--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -103,7 +103,7 @@ test.describe("Home Page - Performance Section", () => {
     await expect(
       authenticatedPage.getByText("85% correct answers"),
     ).toBeVisible();
-    await expect(authenticatedPage.getByText("Past 30 days")).toBeVisible();
+    await expect(authenticatedPage.getByText("Past 3 months")).toBeVisible();
   });
 
   test("authenticated user with progress sees best day", async ({

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -145,11 +145,6 @@ msgid "{value}% correct answers"
 msgstr "{value}% correct answers"
 
 #: src/app/[locale]/(catalog)/accuracy.tsx
-msgctxt "OIM20v"
-msgid "Past 30 days"
-msgstr "Past 30 days"
-
-#: src/app/[locale]/(catalog)/accuracy.tsx
 msgctxt "uCsywK"
 msgid "Accuracy"
 msgstr "Accuracy"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -145,11 +145,6 @@ msgid "{value}% correct answers"
 msgstr "{value}% de respuestas correctas"
 
 #: src/app/[locale]/(catalog)/accuracy.tsx
-msgctxt "OIM20v"
-msgid "Past 30 days"
-msgstr "Últimos 30 días"
-
-#: src/app/[locale]/(catalog)/accuracy.tsx
 msgctxt "uCsywK"
 msgid "Accuracy"
 msgstr "Precisión"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -145,11 +145,6 @@ msgid "{value}% correct answers"
 msgstr "{value}% de respostas corretas"
 
 #: src/app/[locale]/(catalog)/accuracy.tsx
-msgctxt "OIM20v"
-msgid "Past 30 days"
-msgstr "Últimos 30 dias"
-
-#: src/app/[locale]/(catalog)/accuracy.tsx
 msgctxt "uCsywK"
 msgid "Accuracy"
 msgstr "Precisão"

--- a/apps/main/src/app/[locale]/(catalog)/accuracy.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/accuracy.tsx
@@ -38,7 +38,7 @@ export async function Accuracy({ accuracy }: { accuracy: number }) {
         <FeatureCardTitle>
           {t("{value}% correct answers", { value: formattedAccuracy })}
         </FeatureCardTitle>
-        <FeatureCardSubtitle>{t("Past 30 days")}</FeatureCardSubtitle>
+        <FeatureCardSubtitle>{t("Past 3 months")}</FeatureCardSubtitle>
       </FeatureCardBody>
     </FeatureCard>
   );

--- a/apps/main/src/data/progress/get-accuracy.test.ts
+++ b/apps/main/src/data/progress/get-accuracy.test.ts
@@ -56,14 +56,14 @@ describe("authenticated users", () => {
     expect(result?.accuracy).toBeCloseTo(83.33, 1);
   });
 
-  test("excludes records older than 30 days", async () => {
+  test("excludes records older than 3 months", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);
     const org = await organizationFixture();
 
     const today = new Date();
     const oldDate = new Date(today);
-    oldDate.setDate(oldDate.getDate() - 31);
+    oldDate.setDate(oldDate.getDate() - 91);
 
     await prisma.dailyProgress.createMany({
       data: [

--- a/apps/main/src/data/progress/get-accuracy.ts
+++ b/apps/main/src/data/progress/get-accuracy.ts
@@ -18,8 +18,8 @@ export const getAccuracy = cache(
     }
 
     const userId = Number(session.user.id);
-    const thirtyDaysAgo = new Date();
-    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+    const threeMonthsAgo = new Date();
+    threeMonthsAgo.setDate(threeMonthsAgo.getDate() - 90);
 
     const { data: result, error } = await safeAsync(() =>
       prisma.dailyProgress.aggregate({
@@ -29,7 +29,7 @@ export const getAccuracy = cache(
           incorrectAnswers: true,
         },
         where: {
-          date: { gte: thirtyDaysAgo },
+          date: { gte: threeMonthsAgo },
           userId,
         },
       }),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch accuracy to the last 3 months to match the best day period and provide a more stable score.

- **Refactors**
  - Calculate accuracy using the last 90 days.
  - Update subtitle to “Past 3 months”.
  - Remove old “Past 30 days” translation strings.

- **Bug Fixes**
  - Update e2e tests to handle duplicate “Past 3 months” by selecting the first match.
  - Change unit test to exclude records older than 3 months.

<sup>Written for commit 35a67ca20dfd1371a3806c93ee421eead40ff4e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

