### PR TITLE
feat(main): add peak time to home

### DIFF
--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -115,6 +115,18 @@ test.describe("Home Page - Performance Section", () => {
     await expect(authenticatedPage.getByText(/with 85%/i)).toBeVisible();
   });
 
+  test("authenticated user with progress sees peak time", async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto("/");
+
+    await expect(authenticatedPage.getByText(/^performance$/i)).toBeVisible();
+    await expect(authenticatedPage.getByText(/peak time/i)).toBeVisible();
+    await expect(
+      authenticatedPage.getByText(/morning with 90%/i),
+    ).toBeVisible();
+  });
+
   test("user without progress does not see performance section", async ({
     userWithoutProgress,
   }) => {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -149,6 +149,13 @@ msgctxt "uCsywK"
 msgid "Accuracy"
 msgstr "Accuracy"
 
+#: src/app/[locale]/(catalog)/accuracy.tsx
+#: src/app/[locale]/(catalog)/best-day.tsx
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "zml1/y"
+msgid "Past 3 months"
+msgstr "Past 3 months"
+
 #: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-search-container.tsx
 msgctxt "ai9FYU"
 msgid "Search chapters and lessons..."
@@ -253,11 +260,6 @@ msgstr "{day} with {value}%"
 msgctxt "HHFpcy"
 msgid "Best day"
 msgstr "Best day"
-
-#: src/app/[locale]/(catalog)/best-day.tsx
-msgctxt "zml1/y"
-msgid "Past 3 months"
-msgstr "Past 3 months"
 
 #: src/app/[locale]/(catalog)/continue-learning.tsx
 msgctxt "0X+xfW"
@@ -481,6 +483,36 @@ msgstr "Zoonk: AI Learning Platform"
 msgctxt "ZgSctJ"
 msgid "Zoonk is an AI-powered learning platform where you can learn anything through interactive courses, lessons, and activities."
 msgstr "Zoonk is an AI-powered learning platform where you can learn anything through interactive courses, lessons, and activities."
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "/kzk/m"
+msgid "Morning"
+msgstr "Morning"
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "00/IyC"
+msgid "Night"
+msgstr "Night"
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "mF+J9o"
+msgid "Afternoon"
+msgstr "Afternoon"
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "mPEpnN"
+msgid "Evening"
+msgstr "Evening"
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "NtOh+J"
+msgid "Peak time"
+msgstr "Peak time"
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "vG7kPp"
+msgid "{period} with {value}%"
+msgstr "{period} with {value}%"
 
 #: src/app/[locale]/(catalog)/performance.tsx
 msgctxt "AA5h7P"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -149,6 +149,13 @@ msgctxt "uCsywK"
 msgid "Accuracy"
 msgstr "Precisión"
 
+#: src/app/[locale]/(catalog)/accuracy.tsx
+#: src/app/[locale]/(catalog)/best-day.tsx
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "zml1/y"
+msgid "Past 3 months"
+msgstr "Últimos 3 meses"
+
 #: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-search-container.tsx
 msgctxt "ai9FYU"
 msgid "Search chapters and lessons..."
@@ -253,11 +260,6 @@ msgstr "{day} con {value}%"
 msgctxt "HHFpcy"
 msgid "Best day"
 msgstr "Mejor día"
-
-#: src/app/[locale]/(catalog)/best-day.tsx
-msgctxt "zml1/y"
-msgid "Past 3 months"
-msgstr "Últimos 3 meses"
 
 #: src/app/[locale]/(catalog)/continue-learning.tsx
 msgctxt "0X+xfW"
@@ -481,6 +483,36 @@ msgstr "Zoonk: plataforma de aprendizaje con IA"
 msgctxt "ZgSctJ"
 msgid "Zoonk is an AI-powered learning platform where you can learn anything through interactive courses, lessons, and activities."
 msgstr "Zoonk es una plataforma de aprendizaje impulsada por IA donde puedes aprender cualquier cosa a través de cursos interactivos, lecciones y actividades."
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "/kzk/m"
+msgid "Morning"
+msgstr "Mañana"
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "00/IyC"
+msgid "Night"
+msgstr "Madrugada"
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "mF+J9o"
+msgid "Afternoon"
+msgstr "Tarde"
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "mPEpnN"
+msgid "Evening"
+msgstr "Noche"
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "NtOh+J"
+msgid "Peak time"
+msgstr "Hora pico"
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "vG7kPp"
+msgid "{period} with {value}%"
+msgstr "{period} con {value}%"
 
 #: src/app/[locale]/(catalog)/performance.tsx
 msgctxt "AA5h7P"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -149,6 +149,13 @@ msgctxt "uCsywK"
 msgid "Accuracy"
 msgstr "Precisão"
 
+#: src/app/[locale]/(catalog)/accuracy.tsx
+#: src/app/[locale]/(catalog)/best-day.tsx
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "zml1/y"
+msgid "Past 3 months"
+msgstr "Últimos 3 meses"
+
 #: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-search-container.tsx
 msgctxt "ai9FYU"
 msgid "Search chapters and lessons..."
@@ -253,11 +260,6 @@ msgstr "{day} com {value}%"
 msgctxt "HHFpcy"
 msgid "Best day"
 msgstr "Melhor dia"
-
-#: src/app/[locale]/(catalog)/best-day.tsx
-msgctxt "zml1/y"
-msgid "Past 3 months"
-msgstr "Últimos 3 meses"
 
 #: src/app/[locale]/(catalog)/continue-learning.tsx
 msgctxt "0X+xfW"
@@ -481,6 +483,36 @@ msgstr "Zoonk: plataforma de aprendizagem com IA"
 msgctxt "ZgSctJ"
 msgid "Zoonk is an AI-powered learning platform where you can learn anything through interactive courses, lessons, and activities."
 msgstr "O Zoonk é uma plataforma de aprendizagem com IA onde você pode aprender qualquer coisa através de cursos interativos, aulas e atividades."
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "/kzk/m"
+msgid "Morning"
+msgstr "Manhã"
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "00/IyC"
+msgid "Night"
+msgstr "Madrugada"
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "mF+J9o"
+msgid "Afternoon"
+msgstr "Tarde"
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "mPEpnN"
+msgid "Evening"
+msgstr "Noite"
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "NtOh+J"
+msgid "Peak time"
+msgstr "Horário de pico"
+
+#: src/app/[locale]/(catalog)/peak-time.tsx
+msgctxt "vG7kPp"
+msgid "{period} with {value}%"
+msgstr "{period} com {value}%"
 
 #: src/app/[locale]/(catalog)/performance.tsx
 msgctxt "AA5h7P"

--- a/apps/main/src/app/[locale]/(catalog)/peak-time.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/peak-time.tsx
@@ -1,0 +1,75 @@
+import {
+  FeatureCard,
+  FeatureCardBody,
+  FeatureCardHeader,
+  FeatureCardHeaderContent,
+  FeatureCardIcon,
+  FeatureCardIndicator,
+  FeatureCardLabel,
+  FeatureCardSubtitle,
+  FeatureCardTitle,
+} from "@zoonk/ui/components/feature";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { Clock } from "lucide-react";
+import { getExtracted, getLocale } from "next-intl/server";
+
+type PeakTimeProps = {
+  accuracy: number;
+  period: number;
+};
+
+export async function PeakTime({ accuracy, period }: PeakTimeProps) {
+  const t = await getExtracted();
+  const locale = await getLocale();
+
+  const periodNames = [
+    t("Night"),
+    t("Morning"),
+    t("Afternoon"),
+    t("Evening"),
+  ] as const;
+
+  const periodName = periodNames[period] ?? periodNames[1];
+
+  const formattedAccuracy = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 1,
+    trailingZeroDisplay: "stripIfInteger",
+  }).format(accuracy);
+
+  return (
+    <FeatureCard className="w-full">
+      <FeatureCardHeader className="text-accuracy">
+        <FeatureCardHeaderContent>
+          <FeatureCardIcon>
+            <Clock />
+          </FeatureCardIcon>
+          <FeatureCardLabel>{t("Peak time")}</FeatureCardLabel>
+        </FeatureCardHeaderContent>
+        <FeatureCardIndicator />
+      </FeatureCardHeader>
+
+      <FeatureCardBody>
+        <FeatureCardTitle className="first-letter:uppercase">
+          {t("{period} with {value}%", {
+            period: periodName,
+            value: formattedAccuracy,
+          })}
+        </FeatureCardTitle>
+        <FeatureCardSubtitle>{t("Past 3 months")}</FeatureCardSubtitle>
+      </FeatureCardBody>
+    </FeatureCard>
+  );
+}
+
+export function PeakTimeSkeleton() {
+  return (
+    <FeatureCard className="w-full">
+      <Skeleton className="h-5 w-24" />
+
+      <FeatureCardBody className="gap-1">
+        <Skeleton className="h-4 w-full max-w-40" />
+        <Skeleton className="h-3 w-full max-w-28" />
+      </FeatureCardBody>
+    </FeatureCard>
+  );
+}

--- a/apps/main/src/app/[locale]/(catalog)/performance.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/performance.tsx
@@ -5,20 +5,24 @@ import { getAccuracy } from "@/data/progress/get-accuracy";
 import { getBeltLevel } from "@/data/progress/get-belt-level";
 import { getBestDay } from "@/data/progress/get-best-day";
 import { getEnergyLevel } from "@/data/progress/get-energy-level";
+import { getPeakTime } from "@/data/progress/get-peak-time";
 import { Accuracy, AccuracySkeleton } from "./accuracy";
 import { BeltLevel, BeltLevelSkeleton } from "./belt-level";
 import { BestDay, BestDaySkeleton } from "./best-day";
 import { EnergyLevel, EnergyLevelSkeleton } from "./energy-level";
+import { PeakTime, PeakTimeSkeleton } from "./peak-time";
 
 export async function Performance() {
   const t = await getExtracted();
 
-  const [energyData, beltData, accuracyData, bestDayData] = await Promise.all([
-    getEnergyLevel(),
-    getBeltLevel(),
-    getAccuracy(),
-    getBestDay(),
-  ]);
+  const [energyData, beltData, accuracyData, bestDayData, peakTimeData] =
+    await Promise.all([
+      getEnergyLevel(),
+      getBeltLevel(),
+      getAccuracy(),
+      getBestDay(),
+      getPeakTime(),
+    ]);
 
   return (
     <section
@@ -49,6 +53,13 @@ export async function Performance() {
             dayOfWeek={bestDayData.dayOfWeek}
           />
         )}
+
+        {peakTimeData && (
+          <PeakTime
+            accuracy={peakTimeData.accuracy}
+            period={peakTimeData.period}
+          />
+        )}
       </div>
     </section>
   );
@@ -64,6 +75,7 @@ export function PerformanceSkeleton() {
         <BeltLevelSkeleton />
         <AccuracySkeleton />
         <BestDaySkeleton />
+        <PeakTimeSkeleton />
       </div>
     </section>
   );

--- a/apps/main/src/data/progress/get-peak-time.test.ts
+++ b/apps/main/src/data/progress/get-peak-time.test.ts
@@ -1,0 +1,241 @@
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { describe, expect, test } from "vitest";
+import { getPeakTime } from "./get-peak-time";
+
+type StepAttemptParams = {
+  answeredAt?: Date;
+  hourOfDay: number;
+  isCorrect: boolean;
+  orgId: number;
+  stepId: number;
+  userId: number;
+};
+
+function buildStepAttemptData(params: StepAttemptParams) {
+  const answeredAt = params.answeredAt ?? new Date();
+  return {
+    answer: { selectedOption: params.isCorrect ? 1 : 0 },
+    answeredAt,
+    dayOfWeek: answeredAt.getDay(),
+    durationSeconds: 15,
+    hourOfDay: params.hourOfDay,
+    isCorrect: params.isCorrect,
+    organizationId: params.orgId,
+    stepId: params.stepId,
+    userId: params.userId,
+  };
+}
+
+async function createStepAttempts(
+  params: Omit<StepAttemptParams, "isCorrect">,
+  correct: number,
+  incorrect: number,
+) {
+  const correctAttempts = Array.from({ length: correct }, () =>
+    buildStepAttemptData({ ...params, isCorrect: true }),
+  );
+
+  const incorrectAttempts = Array.from({ length: incorrect }, () =>
+    buildStepAttemptData({ ...params, isCorrect: false }),
+  );
+
+  const allAttempts = [...correctAttempts, ...incorrectAttempts];
+
+  await Promise.all(
+    allAttempts.map((data) => prisma.stepAttempt.create({ data })),
+  );
+}
+
+async function createTestStep(orgId: number) {
+  const course = await courseFixture({ organizationId: orgId });
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    organizationId: orgId,
+  });
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    organizationId: orgId,
+  });
+  const activity = await activityFixture({
+    lessonId: lesson.id,
+    organizationId: orgId,
+  });
+  const step = await prisma.step.create({
+    data: {
+      activityId: activity.id,
+      content: {},
+      kind: "multiple_choice",
+      position: 0,
+    },
+  });
+
+  return step;
+}
+
+describe("unauthenticated users", () => {
+  test("returns null", async () => {
+    const result = await getPeakTime({ headers: new Headers() });
+    expect(result).toBeNull();
+  });
+});
+
+describe("authenticated users", () => {
+  test("returns null when user has no StepAttempt records", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+
+    const result = await getPeakTime({ headers });
+    expect(result).toBeNull();
+  });
+
+  test("returns peak time when user has data for multiple periods", async () => {
+    const [user, org] = await Promise.all([
+      userFixture(),
+      organizationFixture(),
+    ]);
+    const [headers, step] = await Promise.all([
+      signInAs(user.email, user.password),
+      createTestStep(org.id),
+    ]);
+
+    const userId = Number(user.id);
+    const orgId = org.id;
+    const stepId = step.id;
+
+    await Promise.all([
+      // Morning (hour 9): 9 correct, 1 incorrect = 90%
+      createStepAttempts({ hourOfDay: 9, orgId, stepId, userId }, 9, 1),
+      // Afternoon (hour 15): 8 correct, 2 incorrect = 80%
+      createStepAttempts({ hourOfDay: 15, orgId, stepId, userId }, 8, 2),
+    ]);
+
+    const result = await getPeakTime({ headers });
+
+    expect(result).not.toBeNull();
+    expect(result?.period).toBe(1); // Morning
+    expect(result?.accuracy).toBe(90);
+  });
+
+  test("excludes records older than 90 days", async () => {
+    const [user, org] = await Promise.all([
+      userFixture(),
+      organizationFixture(),
+    ]);
+    const [headers, step] = await Promise.all([
+      signInAs(user.email, user.password),
+      createTestStep(org.id),
+    ]);
+
+    const now = new Date();
+    const oldDate = new Date(now);
+    oldDate.setDate(oldDate.getDate() - 91);
+
+    const userId = Number(user.id);
+    const orgId = org.id;
+    const stepId = step.id;
+
+    await Promise.all([
+      // Recent Morning attempts: 80%
+      createStepAttempts(
+        { answeredAt: now, hourOfDay: 9, orgId, stepId, userId },
+        8,
+        2,
+      ),
+      // Old Afternoon attempts: 100% (should be excluded)
+      createStepAttempts(
+        { answeredAt: oldDate, hourOfDay: 15, orgId, stepId, userId },
+        10,
+        0,
+      ),
+    ]);
+
+    const result = await getPeakTime({ headers });
+
+    expect(result).not.toBeNull();
+    expect(result?.period).toBe(1); // Morning
+    expect(result?.accuracy).toBe(80);
+  });
+
+  test("uses period with most answers as tiebreaker", async () => {
+    const [user, org] = await Promise.all([
+      userFixture(),
+      organizationFixture(),
+    ]);
+    const [headers, step] = await Promise.all([
+      signInAs(user.email, user.password),
+      createTestStep(org.id),
+    ]);
+
+    const userId = Number(user.id);
+    const orgId = org.id;
+    const stepId = step.id;
+
+    await Promise.all([
+      // Morning (hour 9): 9 correct, 1 incorrect = 90%
+      createStepAttempts({ hourOfDay: 9, orgId, stepId, userId }, 9, 1),
+      // Afternoon (hour 15): 18 correct, 2 incorrect = 90% (more answers)
+      createStepAttempts({ hourOfDay: 15, orgId, stepId, userId }, 18, 2),
+    ]);
+
+    const result = await getPeakTime({ headers });
+
+    expect(result).not.toBeNull();
+    expect(result?.period).toBe(2); // Afternoon (more answers)
+    expect(result?.accuracy).toBe(90);
+  });
+
+  test("returns correct accuracy calculation", async () => {
+    const [user, org] = await Promise.all([
+      userFixture(),
+      organizationFixture(),
+    ]);
+    const [headers, step] = await Promise.all([
+      signInAs(user.email, user.password),
+      createTestStep(org.id),
+    ]);
+
+    const userId = Number(user.id);
+    const orgId = org.id;
+    const stepId = step.id;
+
+    // 17 correct, 3 incorrect = 85%
+    await createStepAttempts({ hourOfDay: 21, orgId, stepId, userId }, 17, 3);
+
+    const result = await getPeakTime({ headers });
+
+    expect(result).not.toBeNull();
+    expect(result?.period).toBe(3); // Evening
+    expect(result?.accuracy).toBe(85);
+  });
+
+  test("correctly maps hours to periods", async () => {
+    const [user, org] = await Promise.all([
+      userFixture(),
+      organizationFixture(),
+    ]);
+    const [headers, step] = await Promise.all([
+      signInAs(user.email, user.password),
+      createTestStep(org.id),
+    ]);
+
+    const userId = Number(user.id);
+    const orgId = org.id;
+    const stepId = step.id;
+
+    // Night (hour 3): 100%
+    await createStepAttempts({ hourOfDay: 3, orgId, stepId, userId }, 1, 0);
+
+    const result = await getPeakTime({ headers });
+
+    expect(result).not.toBeNull();
+    expect(result?.period).toBe(0); // Night
+    expect(result?.accuracy).toBe(100);
+  });
+});

--- a/apps/main/src/data/progress/get-peak-time.ts
+++ b/apps/main/src/data/progress/get-peak-time.ts
@@ -1,0 +1,61 @@
+import "server-only";
+
+import { getSession } from "@zoonk/core/users/session/get";
+import { prisma } from "@zoonk/db";
+import { getPeakTime as getPeakTimeQuery } from "@zoonk/db/peak-time";
+import { safeAsync } from "@zoonk/utils/error";
+import { cache } from "react";
+
+export type PeakTimeData = {
+  accuracy: number;
+  period: number;
+};
+
+export const getPeakTime = cache(
+  async (params?: { headers?: Headers }): Promise<PeakTimeData | null> => {
+    const session = await getSession({ headers: params?.headers });
+
+    if (!session) {
+      return null;
+    }
+
+    const userId = Number(session.user.id);
+    const ninetyDaysAgo = new Date();
+    ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+
+    const { data: results, error } = await safeAsync(() =>
+      prisma.$queryRawTyped(getPeakTimeQuery(userId, ninetyDaysAgo)),
+    );
+
+    if (error || !results || results.length === 0) {
+      return null;
+    }
+
+    let peakTime: PeakTimeData | null = null;
+    let peakTimeTotal = 0;
+
+    for (const row of results) {
+      const correct = Number(row.correct);
+      const incorrect = Number(row.incorrect);
+      const total = correct + incorrect;
+
+      if (total === 0) {
+        continue;
+      }
+
+      const accuracy = (correct / total) * 100;
+
+      const isBetter =
+        !peakTime ||
+        accuracy > peakTime.accuracy ||
+        (accuracy === peakTime.accuracy && total > peakTimeTotal);
+
+      if (isBetter) {
+        peakTime = { accuracy, period: Number(row.period) };
+        peakTimeTotal = total;
+      }
+    }
+
+    return peakTime;
+  },
+);

--- a/i18n.lock
+++ b/i18n.lock
@@ -204,9 +204,10 @@ checksums:
     Support/singular: 55aab5fd0f31a9cb055a2edeeedfaf63
     Subscription/singular: ba9f3675e18987d067d48533c8897343
     "%7Bvalue%7D%25%20correct%20answers/singular": 0a95eedb35d1990c8e8af833ddba628f
-    Past%2030%20days/singular: 6d69a6c6519721c00a9ef320e70099bc
     Accuracy/singular: d6022b38e0960d1a7bea84586e4986eb
+    Past%203%20months/singular: 0784d60565f6812fce36c72252663412
     Search%20chapters%20and%20lessons.../singular: 9efe924871c3c733391ccd1e3c6d044f
+    Search%20chapters%20and%20lessons/singular: 1478233cb8fcb9b66cea6661a11d388c
     No%20chapters%20or%20lessons%20found/singular: 2fe297df8b5d61f27245373ef71d1f10
     This%20content%20was%20generated%20by%20AI.%20It%20may%20contain%20errors%20or%20inaccuracies%20and%20should%20not%20be%20considered%20professional%20advice./singular: 269e7c16a722903b9b434f28aa6cf617
     Green/singular: 482ff383a4258357ba404f283682471d
@@ -224,6 +225,14 @@ checksums:
     "%7Bcolor%7D%20Belt%20-%20Level%20%7Blevel%7D/singular": abb5a7600bd66f523906425beffbaff4
     Black/singular: 0a78282fb00e09a335608b154ffa01de
     Gray/singular: 54ec745c22b59509822468ba82070d74
+    "%7Bday%7D%20with%20%7Bvalue%7D%25/singular": 6e5416262bf719f632e31ed1a8236801
+    Best%20day/singular: c7d1324abc9d2515ec3bbc955b317404
+    Morning/singular: c2f3e2bb2361eebb1576896fcc6c0d69
+    Night/singular: 6fa09c4a1c03187be163148a653056ae
+    Afternoon/singular: b34f73070b6ce5e811f2aeec93798d7d
+    Evening/singular: d401caa89963f8017a148bcdd1749c2d
+    Peak%20time/singular: 00610169ef99ad10cd58469e43f5a056
+    "%7Bperiod%7D%20with%20%7Bvalue%7D%25/singular": 958bc2c65d9a6823edee6f2585fd6501
     Continue%20learning/singular: ff5ff528cbacf657af36fb9b711431d6
     Next%3A%20%7Bactivity%7D/singular: 9208679843466247d2161793249e5eda
     Activity/singular: 1948763de8e531483a798b68195e297e

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -16,6 +16,7 @@
     ".": "./src/index.ts",
     "./best-day": "./src/generated/prisma/sql/getBestDay.ts",
     "./continue-learning": "./src/generated/prisma/sql/getContinueLearning.ts",
+    "./peak-time": "./src/generated/prisma/sql/getPeakTime.ts",
     "./utils": "./src/utils.ts"
   },
   "name": "@zoonk/db",

--- a/packages/db/src/prisma/seed/progress.ts
+++ b/packages/db/src/prisma/seed/progress.ts
@@ -1,5 +1,68 @@
-import type { Organization, PrismaClient } from "../../generated/prisma/client";
+import type {
+  Organization,
+  PrismaClient,
+  Step,
+} from "../../generated/prisma/client";
 import type { SeedUsers } from "./users";
+
+type E2eAttemptData = {
+  answer: { selectedOption: number };
+  answeredAt: Date;
+  dayOfWeek: number;
+  durationSeconds: number;
+  hourOfDay: number;
+  isCorrect: boolean;
+  organizationId: number;
+  stepId: number;
+  userId: number;
+};
+
+function buildE2eStepAttempts(
+  step: Step,
+  org: Organization,
+  userId: number,
+  now: Date,
+): E2eAttemptData[] {
+  const configs = [
+    { correct: 9, hourOfDay: 9, incorrect: 1 }, // Morning: 90%
+    { correct: 8, hourOfDay: 15, incorrect: 2 }, // Afternoon: 80%
+    { correct: 7, hourOfDay: 21, incorrect: 3 }, // Evening: 70%
+  ];
+
+  const attempts: E2eAttemptData[] = [];
+
+  for (const config of configs) {
+    for (let i = 0; i < config.correct; i++) {
+      attempts.push({
+        answer: { selectedOption: 1 },
+        answeredAt: new Date(now.getTime() - i * 60 * 1000),
+        dayOfWeek: now.getDay(),
+        durationSeconds: 15,
+        hourOfDay: config.hourOfDay,
+        isCorrect: true,
+        organizationId: org.id,
+        stepId: step.id,
+        userId,
+      });
+    }
+
+    for (let i = 0; i < config.incorrect; i++) {
+      attempts.push({
+        answer: { selectedOption: 0 },
+        answeredAt: new Date(now.getTime() - (config.correct + i) * 60 * 1000),
+        dayOfWeek: now.getDay(),
+        durationSeconds: 15,
+        hourOfDay: config.hourOfDay,
+        isCorrect: false,
+        organizationId: org.id,
+        stepId: step.id,
+        userId,
+      });
+    }
+  }
+
+  return attempts;
+}
 
 export async function seedProgress(
   prisma: PrismaClient,
@@ -9,7 +72,6 @@ export async function seedProgress(
   const now = new Date();
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 
-  // Create UserProgress for each user
   await Promise.all([
     prisma.userProgress.upsert({
       create: {
@@ -24,7 +86,7 @@ export async function seedProgress(
     prisma.userProgress.upsert({
       create: {
         currentEnergy: 45.2,
-        lastActiveAt: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000), // 2 days ago
+        lastActiveAt: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000),
         totalBrainPower: BigInt(8500),
         userId: users.admin.id,
       },
@@ -34,14 +96,13 @@ export async function seedProgress(
     prisma.userProgress.upsert({
       create: {
         currentEnergy: 15.0,
-        lastActiveAt: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000), // 7 days ago
+        lastActiveAt: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000),
         totalBrainPower: BigInt(2100),
         userId: users.member.id,
       },
       update: {},
       where: { userId: users.member.id },
     }),
-    // E2E user progress (deterministic values for testing)
     prisma.userProgress.upsert({
       create: {
         currentEnergy: 75.0,
@@ -54,7 +115,6 @@ export async function seedProgress(
     }),
   ]);
 
-  // Create DailyProgress for the past 7 days for the owner user
   type DailyProgressInput = {
     brainPowerEarned: number;
     challengesCompleted: number;
@@ -70,14 +130,15 @@ export async function seedProgress(
   };
 
   const dailyProgressData: DailyProgressInput[] = [];
+
   for (let i = 6; i >= 0; i--) {
     const date = new Date(today.getTime() - i * 24 * 60 * 60 * 1000);
-    const isActiveDay = i !== 3 && i !== 5; // Skip days 3 and 5 (inactive days)
+    const isActiveDay = i !== 3 && i !== 5;
 
     if (isActiveDay) {
       dailyProgressData.push({
         brainPowerEarned: 200 + Math.floor(Math.random() * 300),
-        challengesCompleted: i === 0 ? 1 : 0, // Completed a challenge today
+        challengesCompleted: i === 0 ? 1 : 0,
         correctAnswers: 15 + Math.floor(Math.random() * 20),
         date,
         energyAtEnd: 65 + Math.random() * 10,
@@ -89,11 +150,7 @@ export async function seedProgress(
         userId: users.owner.id,
       });
     }
-  }
 
-  // E2E user daily progress (deterministic values for testing: 85% accuracy)
-  for (let i = 6; i >= 0; i--) {
-    const date = new Date(today.getTime() - i * 24 * 60 * 60 * 1000);
     dailyProgressData.push({
       brainPowerEarned: 300,
       challengesCompleted: 0,
@@ -125,7 +182,6 @@ export async function seedProgress(
     ),
   );
 
-  // Create some sample step attempts
   const lesson = await prisma.lesson.findFirst({
     where: {
       language: "en",
@@ -139,10 +195,7 @@ export async function seedProgress(
   }
 
   const activity = await prisma.activity.findFirst({
-    where: {
-      lessonId: lesson.id,
-      position: 2, // explanation_quiz
-    },
+    where: { lessonId: lesson.id, position: 2 },
   });
 
   if (!activity) {
@@ -158,28 +211,36 @@ export async function seedProgress(
     return;
   }
 
-  // Create attempts for the owner user
-  const attemptData = steps.slice(0, 3).map((step, index) => ({
+  const firstStep = steps[0];
+
+  if (!firstStep) {
+    return;
+  }
+
+  const attemptData = steps.slice(0, 3).map((s, index) => ({
     answer: { selectedOption: index === 1 ? 0 : 1 },
     answeredAt: new Date(now.getTime() - (3 - index) * 60 * 1000),
     dayOfWeek: now.getDay(),
     durationSeconds: 15 + Math.floor(Math.random() * 30),
     hourOfDay: now.getHours(),
-    isCorrect: index !== 1, // Second attempt is wrong
+    isCorrect: index !== 1,
     organizationId: org.id,
-    stepId: step.id,
+    stepId: s.id,
     userId: users.owner.id,
   }));
 
-  await Promise.all(
-    attemptData.map((data) =>
-      prisma.stepAttempt.create({
-        data,
-      }),
-    ),
+  const e2eAttemptData = buildE2eStepAttempts(
+    firstStep,
+    org,
+    users.e2eWithProgress.id,
+    now,
   );
 
-  // Create activity progress
+  await Promise.all([
+    ...attemptData.map((data) => prisma.stepAttempt.create({ data })),
+    ...e2eAttemptData.map((data) => prisma.stepAttempt.create({ data })),
+  ]);
+
   await prisma.activityProgress.upsert({
     create: {
       activityId: activity.id,

--- a/packages/db/src/prisma/sql/getPeakTime.sql
+++ b/packages/db/src/prisma/sql/getPeakTime.sql
@@ -1,0 +1,15 @@
+-- @param {Int} $1:userId
+-- @param {DateTime} $2:since
+SELECT
+  CASE
+    WHEN hour_of_day BETWEEN 0 AND 5 THEN 0
+    WHEN hour_of_day BETWEEN 6 AND 11 THEN 1
+    WHEN hour_of_day BETWEEN 12 AND 17 THEN 2
+    ELSE 3
+  END AS "period",
+  COUNT(*) FILTER (WHERE is_correct = true)::bigint AS correct,
+  COUNT(*) FILTER (WHERE is_correct = false)::bigint AS incorrect
+FROM step_attempts
+WHERE user_id = $1 AND answered_at >= $2
+GROUP BY 1
+HAVING COUNT(*) FILTER (WHERE is_correct = true) + COUNT(*) FILTER (WHERE is_correct = false) > 0;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Peak time card to the Home Performance section, showing the time of day when the user performs best with a % accuracy from the past 3 months.

- **New Features**
  - UI: new PeakTime card and skeleton in Performance; displays "{period} with {value}%" and "Past 3 months".
  - Data: getPeakTime queries recent step attempts via new SQL (getPeakTime.sql), picks highest accuracy with tiebreaker by total answers, cached per session.
  - i18n: added period names and strings in en/es/pt; shared "Past 3 months" key.
  - Tests: unit tests for getPeakTime and e2e check on Home (“Morning with 90%”); seed updated for deterministic attempts.
  - DB: exported peak-time query from @zoonk/db.

<sup>Written for commit 32983339b2f04e970ce2a656f56b81d14af2881f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

