### PR TITLE
fix(editor): move list item links to client components

### DIFF
--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list-item-link.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list-item-link.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Link from "next/link";
+import {
+  EditorListItemContent,
+  EditorListItemDescription,
+  EditorListItemLink,
+  EditorListItemTitle,
+} from "@/components/editor-list";
+
+export function LessonListItemLink({
+  chapterSlug,
+  courseSlug,
+  description,
+  lang,
+  lessonSlug,
+  orgSlug,
+  title,
+}: {
+  chapterSlug: string;
+  courseSlug: string;
+  description: string | null;
+  lang: string;
+  lessonSlug: string;
+  orgSlug: string;
+  title: string;
+}) {
+  return (
+    <EditorListItemLink
+      render={
+        <Link
+          href={`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`}
+        />
+      }
+    >
+      <EditorListItemContent>
+        <EditorListItemTitle>{title}</EditorListItemTitle>
+
+        {description && (
+          <EditorListItemDescription>{description}</EditorListItemDescription>
+        )}
+      </EditorListItemContent>
+    </EditorListItemLink>
+  );
+}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -1,6 +1,5 @@
 import { ErrorView } from "@zoonk/ui/patterns/error";
 import { SUPPORT_URL } from "@zoonk/utils/constants";
-import Link from "next/link";
 import { getExtracted } from "next-intl/server";
 import {
   EditorDragHandle,
@@ -9,10 +8,6 @@ import {
   EditorListHeader,
   EditorListItem,
   EditorListItemActions,
-  EditorListItemContent,
-  EditorListItemDescription,
-  EditorListItemLink,
-  EditorListItemTitle,
   EditorListProvider,
   EditorListSpinner,
   EditorSortableItem,
@@ -28,6 +23,7 @@ import {
   insertLessonAction,
   reorderLessonsAction,
 } from "./actions";
+import { LessonListItemLink } from "./lesson-list-item-link";
 
 type ChapterPageProps =
   PageProps<"/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]">;
@@ -94,25 +90,15 @@ export async function LessonList({
                       {index + 1}
                     </EditorDragHandle>
 
-                    <EditorListItemLink
-                      render={
-                        <Link
-                          href={`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/${lesson.slug}`}
-                        />
-                      }
-                    >
-                      <EditorListItemContent>
-                        <EditorListItemTitle>
-                          {lesson.title}
-                        </EditorListItemTitle>
-
-                        {lesson.description && (
-                          <EditorListItemDescription>
-                            {lesson.description}
-                          </EditorListItemDescription>
-                        )}
-                      </EditorListItemContent>
-                    </EditorListItemLink>
+                    <LessonListItemLink
+                      chapterSlug={chapterSlug}
+                      courseSlug={courseSlug}
+                      description={lesson.description}
+                      lang={lang}
+                      lessonSlug={lesson.slug}
+                      orgSlug={orgSlug}
+                      title={lesson.title}
+                    />
 
                     <EditorListItemActions
                       aria-label={t("Lesson actions")}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list-item-link.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list-item-link.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Link from "next/link";
+import {
+  EditorListItemContent,
+  EditorListItemDescription,
+  EditorListItemLink,
+  EditorListItemTitle,
+} from "@/components/editor-list";
+
+export function ChapterListItemLink({
+  chapterSlug,
+  courseSlug,
+  description,
+  lang,
+  orgSlug,
+  title,
+}: {
+  chapterSlug: string;
+  courseSlug: string;
+  description: string | null;
+  lang: string;
+  orgSlug: string;
+  title: string;
+}) {
+  return (
+    <EditorListItemLink
+      render={
+        <Link href={`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}`} />
+      }
+    >
+      <EditorListItemContent>
+        <EditorListItemTitle>{title}</EditorListItemTitle>
+
+        {description && (
+          <EditorListItemDescription>{description}</EditorListItemDescription>
+        )}
+      </EditorListItemContent>
+    </EditorListItemLink>
+  );
+}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
@@ -1,6 +1,5 @@
 import { ErrorView } from "@zoonk/ui/patterns/error";
 import { SUPPORT_URL } from "@zoonk/utils/constants";
-import Link from "next/link";
 import { getExtracted } from "next-intl/server";
 import {
   EditorDragHandle,
@@ -9,10 +8,6 @@ import {
   EditorListHeader,
   EditorListItem,
   EditorListItemActions,
-  EditorListItemContent,
-  EditorListItemDescription,
-  EditorListItemLink,
-  EditorListItemTitle,
   EditorListProvider,
   EditorListSpinner,
   EditorSortableItem,
@@ -28,6 +23,7 @@ import {
   insertChapterAction,
   reorderChaptersAction,
 } from "./actions";
+import { ChapterListItemLink } from "./chapter-list-item-link";
 
 export async function ChapterList({
   params,
@@ -91,25 +87,14 @@ export async function ChapterList({
                       {index + 1}
                     </EditorDragHandle>
 
-                    <EditorListItemLink
-                      render={
-                        <Link
-                          href={`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapter.slug}`}
-                        />
-                      }
-                    >
-                      <EditorListItemContent>
-                        <EditorListItemTitle>
-                          {chapter.title}
-                        </EditorListItemTitle>
-
-                        {chapter.description && (
-                          <EditorListItemDescription>
-                            {chapter.description}
-                          </EditorListItemDescription>
-                        )}
-                      </EditorListItemContent>
-                    </EditorListItemLink>
+                    <ChapterListItemLink
+                      chapterSlug={chapter.slug}
+                      courseSlug={courseSlug}
+                      description={chapter.description}
+                      lang={lang}
+                      orgSlug={orgSlug}
+                      title={chapter.title}
+                    />
 
                     <EditorListItemActions
                       aria-label={t("Chapter actions")}


### PR DESCRIPTION
The render prop pattern with useRender from Base UI doesn't serialize correctly during RSC streaming when used many times. This caused the geology course page (with 169 chapters) to crash with React error 130.

The fix creates minimal client component wrappers for the link portions of chapter and lesson lists, keeping the render prop pattern on the client side where it works correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved chapter and lesson list item links into small client components to fix an RSC streaming crash (React error 130) on large course pages. This keeps render-prop link logic on the client and restores stability.

- **Bug Fixes**
  - Added ChapterListItemLink and LessonListItemLink ("use client") wrapping EditorListItemLink + Next.js Link.
  - Updated chapter-list.tsx and lesson-list.tsx to use these wrappers; removed server-side Link render props.
  - Avoids Base UI useRender serialization issues during RSC streaming, preventing crashes on pages with many items (e.g., 169 chapters).

<sup>Written for commit 54a8c93bb3b5e8d98b39f67e60d95db3433eaa38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

