### PR TITLE
refactor(main): remove borders from chapter list

### DIFF
--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -38,30 +38,28 @@ export function ChapterList({
   return (
     <section>
       <Accordion
-        className="rounded-none border-0 leading-snug"
         onValueChange={(values) => onExpandedChange?.(values as string[])}
         value={expandedValues}
+        variant="ghost"
       >
         {chapters.map((chapter, index) => (
-          <AccordionItem
-            className="border-border/30 border-b last:border-b-0 data-open:bg-transparent"
-            key={chapter.id}
-            value={chapter.slug}
-          >
-            <AccordionTrigger className="px-0 py-4 hover:no-underline">
-              <div className="flex items-start gap-4">
-                <span className="w-6 shrink-0 font-mono text-muted-foreground/60 text-sm tabular-nums">
+          <AccordionItem key={chapter.id} value={chapter.slug} variant="ghost">
+            <AccordionTrigger className="px-0 py-3 hover:no-underline">
+              <div className="flex items-start gap-3 sm:gap-4">
+                <span className="w-5 shrink-0 font-mono text-muted-foreground/40 tabular-nums leading-snug sm:w-6">
                   {String(index + 1).padStart(2, "0")}
                 </span>
 
-                <span className="text-left font-medium">{chapter.title}</span>
+                <span className="text-left font-medium leading-snug">
+                  {chapter.title}
+                </span>
               </div>
             </AccordionTrigger>
 
-            <AccordionContent className="[&_a]:no-underline">
-              <div className="ml-10 flex flex-col">
+            <AccordionContent className="pb-2 [&_a]:no-underline">
+              <div className="ml-4 flex flex-col gap-3 sm:ml-6">
                 {chapter.description && (
-                  <p className="mb-4 text-muted-foreground text-sm leading-relaxed">
+                  <p className="max-w-prose text-muted-foreground text-sm leading-relaxed">
                     {chapter.description}
                   </p>
                 )}
@@ -70,7 +68,7 @@ export function ChapterList({
                   {chapter.lessons.map((lesson) => (
                     <li key={lesson.id}>
                       <ClientLink
-                        className="-ml-2 block rounded-md px-2 py-2 font-medium text-sm transition-colors hover:bg-muted/50"
+                        className="-mx-2 block rounded-md px-2 py-2.5 text-foreground/80 text-sm transition-colors hover:bg-muted/40 hover:text-foreground"
                         href={`/b/${brandSlug}/c/${courseSlug}/c/${chapter.slug}/l/${lesson.slug}`}
                       >
                         {lesson.title}

--- a/packages/ui/src/components/accordion.tsx
+++ b/packages/ui/src/components/accordion.tsx
@@ -2,25 +2,55 @@
 
 import { Accordion as AccordionPrimitive } from "@base-ui/react/accordion";
 import { cn } from "@zoonk/ui/lib/utils";
+import { cva, type VariantProps } from "class-variance-authority";
 import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 
-function Accordion({ className, ...props }: AccordionPrimitive.Root.Props) {
+const accordionVariants = cva("flex w-full flex-col overflow-hidden", {
+  defaultVariants: {
+    variant: "default",
+  },
+  variants: {
+    variant: {
+      default: "rounded-2xl border",
+      ghost: "rounded-none border-0",
+    },
+  },
+});
+
+const accordionItemVariants = cva("data-open:bg-muted/50", {
+  defaultVariants: {
+    variant: "default",
+  },
+  variants: {
+    variant: {
+      default: "not-last:border-b",
+      ghost: "border-b-0 data-open:bg-transparent",
+    },
+  },
+});
+
+function Accordion({
+  className,
+  variant,
+  ...props
+}: AccordionPrimitive.Root.Props & VariantProps<typeof accordionVariants>) {
   return (
     <AccordionPrimitive.Root
-      className={cn(
-        "flex w-full flex-col overflow-hidden rounded-2xl border",
-        className,
-      )}
+      className={cn(accordionVariants({ className, variant }))}
       data-slot="accordion"
       {...props}
     />
   );
 }
 
-function AccordionItem({ className, ...props }: AccordionPrimitive.Item.Props) {
+function AccordionItem({
+  className,
+  variant,
+  ...props
+}: AccordionPrimitive.Item.Props & VariantProps<typeof accordionItemVariants>) {
   return (
     <AccordionPrimitive.Item
-      className={cn("not-last:border-b data-open:bg-muted/50", className)}
+      className={cn(accordionItemVariants({ className, variant }))}
       data-slot="accordion-item"
       {...props}
     />
@@ -79,4 +109,11 @@ function AccordionContent({
   );
 }
 
-export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };
+export {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  accordionItemVariants,
+  accordionVariants,
+};


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed borders from the Chapter List and switched to a new ghost accordion variant for a cleaner, lighter UI. Also introduced reusable accordion variants for future styling consistency.

- **Refactors**
  - Added cva-based variants to Accordion and AccordionItem (default, ghost).
  - Updated ChapterList to use variant="ghost" and adjusted spacing/typography.
  - Exported accordionVariants and accordionItemVariants for reuse.

<sup>Written for commit e44f29d47933f3254c5ae5c4e5c254ff41a70453. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

