### PR TITLE
feat(db): keep track of generation status

### DIFF
--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/course-content.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/course-content.tsx
@@ -30,7 +30,7 @@ export async function CourseContent({
       descriptionLabel={t("Edit course description")}
       descriptionPlaceholder={t("Course description…")}
       entityId={course.id}
-      initialDescription={course.description}
+      initialDescription={course.description ?? ""}
       initialTitle={course.title}
       onSaveDescription={updateCourseDescriptionAction.bind(null, courseSlug)}
       onSaveTitle={updateCourseTitleAction.bind(null, courseSlug)}

--- a/apps/editor/src/data/lessons/import-lessons.test.ts
+++ b/apps/editor/src/data/lessons/import-lessons.test.ts
@@ -659,4 +659,35 @@ describe("admins", () => {
       expect(updatedLesson?.isPublished).toBe(true);
     });
   });
+
+  describe("generationStatus behavior", () => {
+    test("sets chapter generationStatus to completed after importing", async () => {
+      const course = await courseFixture({ organizationId: organization.id });
+
+      const newChapter = await chapterFixture({
+        courseId: course.id,
+        generationStatus: "pending",
+        language: course.language,
+        organizationId: organization.id,
+      });
+
+      const file = createImportFile([
+        { description: "Desc", title: "Test Lesson" },
+      ]);
+
+      const result = await importLessons({
+        chapterId: newChapter.id,
+        file,
+        headers,
+      });
+
+      expect(result.error).toBeNull();
+
+      const updatedChapter = await prisma.chapter.findUnique({
+        where: { id: newChapter.id },
+      });
+
+      expect(updatedChapter?.generationStatus).toBe("completed");
+    });
+  });
 });

--- a/apps/editor/src/data/lessons/import-lessons.ts
+++ b/apps/editor/src/data/lessons/import-lessons.ts
@@ -209,6 +209,11 @@ export async function importLessons(params: {
         imported.push(lessonResult.lesson);
       }
 
+      await tx.chapter.update({
+        data: { generationStatus: "completed" },
+        where: { id: params.chapterId },
+      });
+
       return imported;
     }),
   );

--- a/apps/main/src/app/[locale]/(catalog)/_components/search-courses-action.ts
+++ b/apps/main/src/app/[locale]/(catalog)/_components/search-courses-action.ts
@@ -5,7 +5,7 @@ import { searchCourses } from "@/data/courses/search-courses";
 export type CourseSearchResult = {
   id: number;
   title: string;
-  description: string;
+  description: string | null;
   slug: string;
   imageUrl: string | null;
   brandSlug: string;

--- a/apps/main/src/data/courses/get-course.ts
+++ b/apps/main/src/data/courses/get-course.ts
@@ -7,7 +7,7 @@ export type CourseWithDetails = {
   id: number;
   slug: string;
   title: string;
-  description: string;
+  description: string | null;
   imageUrl: string | null;
   organization: {
     name: string;

--- a/packages/db/src/prisma/migrations/20260111000505_add_generation_status/migration.sql
+++ b/packages/db/src/prisma/migrations/20260111000505_add_generation_status/migration.sql
@@ -1,0 +1,12 @@
+-- AlterTable
+ALTER TABLE "activities" ADD COLUMN     "generation_status" VARCHAR(20) NOT NULL DEFAULT 'pending';
+
+-- AlterTable
+ALTER TABLE "chapters" ADD COLUMN     "generation_status" VARCHAR(20) NOT NULL DEFAULT 'pending';
+
+-- AlterTable
+ALTER TABLE "courses" ADD COLUMN     "generation_status" VARCHAR(20) NOT NULL DEFAULT 'completed',
+ALTER COLUMN "description" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "lessons" ADD COLUMN     "generation_status" VARCHAR(20) NOT NULL DEFAULT 'pending';

--- a/packages/db/src/prisma/models/activities.prisma
+++ b/packages/db/src/prisma/models/activities.prisma
@@ -8,8 +8,9 @@ model Activity {
   language       String             @db.VarChar(10)
   kind           String             @db.VarChar(30)
   title          String?
-  description    String?
-  position       Int
+  description      String?
+  generationStatus String             @default("pending") @map("generation_status") @db.VarChar(20)
+  position         Int
   inventory      Json?
   winCriteria    Json?              @map("win_criteria")
   createdAt      DateTime           @default(now()) @map("created_at")

--- a/packages/db/src/prisma/models/chapters.prisma
+++ b/packages/db/src/prisma/models/chapters.prisma
@@ -9,8 +9,9 @@ model Chapter {
   slug            String
   title           String
   normalizedTitle String   @map("normalized_title")
-  description     String
-  position        Int
+  description      String
+  generationStatus String   @default("pending") @map("generation_status") @db.VarChar(20)
+  position         Int
   createdAt       DateTime @default(now()) @map("created_at")
   updatedAt       DateTime @default(now()) @updatedAt @map("updated_at")
   lessons         Lesson[]

--- a/packages/db/src/prisma/models/courses.prisma
+++ b/packages/db/src/prisma/models/courses.prisma
@@ -19,7 +19,8 @@ model Course {
   slug              String
   title             String
   normalizedTitle   String                   @map("normalized_title")
-  description       String
+  description       String?
+  generationStatus  String                   @default("completed") @map("generation_status") @db.VarChar(20)
   imageUrl          String?                  @map("image_url")
   createdAt         DateTime                 @default(now()) @map("created_at")
   updatedAt         DateTime                 @default(now()) @updatedAt @map("updated_at")

--- a/packages/db/src/prisma/models/lessons.prisma
+++ b/packages/db/src/prisma/models/lessons.prisma
@@ -10,8 +10,9 @@ model Lesson {
   slug            String
   title           String
   normalizedTitle String       @map("normalized_title")
-  description     String
-  position        Int
+  description      String
+  generationStatus String       @default("pending") @map("generation_status") @db.VarChar(20)
+  position         Int
   createdAt       DateTime     @default(now()) @map("created_at")
   updatedAt       DateTime     @default(now()) @updatedAt @map("updated_at")
   activities      Activity[]

--- a/packages/db/src/prisma/seed/activities.ts
+++ b/packages/db/src/prisma/seed/activities.ts
@@ -1,6 +1,7 @@
 import type { Organization, PrismaClient } from "../../generated/prisma/client";
 
 type ActivitySeedData = {
+  generationStatus: string;
   isPublished: boolean;
   kind: string;
   title?: string;
@@ -19,30 +20,37 @@ const activitiesData: LessonActivities[] = [
   {
     activities: [
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "background",
       },
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "explanation",
       },
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "explanation_quiz",
       },
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "examples",
       },
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "story",
       },
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "logic",
       },
       {
+        generationStatus: "completed",
         inventory: {
           computeResources: 70,
           dataQuality: 50,
@@ -59,6 +67,7 @@ const activitiesData: LessonActivities[] = [
         },
       },
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "lesson_quiz",
       },
@@ -69,14 +78,17 @@ const activitiesData: LessonActivities[] = [
   {
     activities: [
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "background",
       },
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "explanation",
       },
       {
+        generationStatus: "completed",
         isPublished: false,
         kind: "mechanics",
       },
@@ -89,6 +101,7 @@ const activitiesData: LessonActivities[] = [
       {
         description:
           "A custom activity exploring the differences between supervised and unsupervised learning approaches.",
+        generationStatus: "completed",
         isPublished: false,
         kind: "custom",
         title: "Supervised vs Unsupervised Learning",
@@ -100,10 +113,12 @@ const activitiesData: LessonActivities[] = [
   {
     activities: [
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "background",
       },
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "explanation",
       },
@@ -114,10 +129,12 @@ const activitiesData: LessonActivities[] = [
   {
     activities: [
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "background",
       },
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "explanation",
       },
@@ -128,10 +145,12 @@ const activitiesData: LessonActivities[] = [
   {
     activities: [
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "background",
       },
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "explanation",
       },
@@ -142,10 +161,12 @@ const activitiesData: LessonActivities[] = [
   {
     activities: [
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "background",
       },
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "explanation",
       },
@@ -156,10 +177,12 @@ const activitiesData: LessonActivities[] = [
   {
     activities: [
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "background",
       },
       {
+        generationStatus: "completed",
         isPublished: true,
         kind: "explanation",
       },
@@ -192,6 +215,7 @@ export async function seedActivities(
             prisma.activity.upsert({
               create: {
                 description: activityData.description,
+                generationStatus: activityData.generationStatus,
                 inventory: activityData.inventory,
                 isPublished: activityData.isPublished,
                 kind: activityData.kind,

--- a/packages/db/src/prisma/seed/chapters.ts
+++ b/packages/db/src/prisma/seed/chapters.ts
@@ -3,6 +3,7 @@ import type { Organization, PrismaClient } from "../../generated/prisma/client";
 
 type ChapterSeedData = {
   description: string;
+  generationStatus: string;
   isPublished: boolean;
   slug: string;
   title: string;
@@ -20,6 +21,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Understand what machine learning is, its history, and the different types of learning: supervised, unsupervised, and reinforcement learning.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "introduction-to-machine-learning",
         title: "Introduction to Machine Learning",
@@ -27,6 +29,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Learn about datasets, data preprocessing, feature engineering, and how to prepare your data for training models.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "data-preparation",
         title: "Data Preparation",
@@ -34,6 +37,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Explore linear regression, logistic regression, and gradient descent algorithms for predictive modeling.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "regression-algorithms",
         title: "Regression Algorithms",
@@ -41,6 +45,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Understand decision trees, random forests, and ensemble methods for classification and regression tasks.",
+        generationStatus: "completed",
         isPublished: false,
         slug: "tree-based-models",
         title: "Tree-Based Models",
@@ -48,6 +53,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Learn the fundamentals of neural networks, activation functions, backpropagation, and deep learning architectures.",
+        generationStatus: "completed",
         isPublished: false,
         slug: "neural-networks",
         title: "Neural Networks",
@@ -61,6 +67,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Entenda o que é machine learning, sua história e os diferentes tipos de aprendizado: supervisionado, não supervisionado e por reforço.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "introducao-ao-machine-learning",
         title: "Introdução ao Machine Learning",
@@ -68,6 +75,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Aprenda sobre datasets, pré-processamento de dados, engenharia de features e como preparar seus dados para treinar modelos.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "preparacao-de-dados",
         title: "Preparação de Dados",
@@ -75,6 +83,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Explore regressão linear, regressão logística e algoritmos de gradiente descendente para modelagem preditiva.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "algoritmos-de-regressao",
         title: "Algoritmos de Regressão",
@@ -82,6 +91,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Entenda árvores de decisão, florestas aleatórias e métodos de ensemble para tarefas de classificação e regressão.",
+        generationStatus: "completed",
         isPublished: false,
         slug: "modelos-baseados-em-arvores",
         title: "Modelos Baseados em Árvores",
@@ -89,6 +99,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Aprenda os fundamentos de redes neurais, funções de ativação, backpropagation e arquiteturas de deep learning.",
+        generationStatus: "completed",
         isPublished: false,
         slug: "redes-neurais",
         title: "Redes Neurais",
@@ -102,6 +113,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Learn the Spanish alphabet, basic pronunciation rules, and common greetings for everyday conversations.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "spanish-basics",
         title: "Spanish Basics",
@@ -109,6 +121,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Build essential vocabulary for travel, food, family, and daily activities.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "essential-vocabulary",
         title: "Essential Vocabulary",
@@ -122,6 +135,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Explore our solar system, including the Sun, planets, moons, and other celestial bodies.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "solar-system",
         title: "The Solar System",
@@ -129,6 +143,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Learn about stars, their life cycles, and how they form the building blocks of galaxies.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "stars-and-galaxies",
         title: "Stars and Galaxies",
@@ -142,6 +157,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Learn Python syntax, variables, data types, and write your first programs.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "python-fundamentals",
         title: "Python Fundamentals",
@@ -149,6 +165,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Master lists, dictionaries, sets, and tuples for organizing and manipulating data.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "data-structures",
         title: "Data Structures",
@@ -162,6 +179,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Learn HTML structure, semantic elements, and how to create well-organized web pages.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "html-foundations",
         title: "HTML Foundations",
@@ -169,6 +187,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Style your web pages with CSS, including layouts, colors, typography, and responsive design.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "css-styling",
         title: "CSS Styling",
@@ -182,6 +201,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Understand data types, data sources, and the fundamentals of data analysis workflows.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "intro-to-data-science",
         title: "Introduction to Data Science",
@@ -189,6 +209,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Learn techniques for cleaning, transforming, and preparing data for analysis.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "data-wrangling",
         title: "Data Wrangling",
@@ -221,6 +242,7 @@ async function seedChaptersForCourse(
       create: {
         courseId: course.id,
         description: chapterData.description,
+        generationStatus: chapterData.generationStatus,
         isPublished: chapterData.isPublished,
         language: data.language,
         normalizedTitle: normalizeString(chapterData.title),

--- a/packages/db/src/prisma/seed/lessons.ts
+++ b/packages/db/src/prisma/seed/lessons.ts
@@ -3,6 +3,7 @@ import type { Organization, PrismaClient } from "../../generated/prisma/client";
 
 type LessonSeedData = {
   description: string;
+  generationStatus: string;
   isPublished: boolean;
   kind?: string;
   slug: string;
@@ -23,6 +24,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Learn what machine learning is and how it differs from traditional programming.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "what-is-machine-learning",
         title: "What is Machine Learning?",
@@ -30,6 +32,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Explore the history of machine learning from its origins to modern developments.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "history-of-ml",
         title: "History of Machine Learning",
@@ -37,6 +40,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Understand supervised, unsupervised, and reinforcement learning approaches.",
+        generationStatus: "completed",
         isPublished: false,
         kind: "custom",
         slug: "types-of-learning",
@@ -51,6 +55,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Learn about different types of datasets and where to find quality data for your projects.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "understanding-datasets",
         title: "Understanding Datasets",
@@ -58,6 +63,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Master techniques for cleaning and preprocessing raw data before training.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "data-cleaning",
         title: "Data Cleaning",
@@ -71,6 +77,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Learn the Spanish alphabet, vowel sounds, and basic pronunciation rules.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "spanish-alphabet",
         title: "The Spanish Alphabet",
@@ -78,6 +85,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Master common greetings and introductions for everyday conversations.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "greetings-introductions",
         title: "Greetings and Introductions",
@@ -91,6 +99,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Learn about the Sun, its structure, and its importance to our solar system.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "the-sun",
         title: "The Sun",
@@ -98,6 +107,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Explore the inner planets: Mercury, Venus, Earth, and Mars.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "inner-planets",
         title: "The Inner Planets",
@@ -111,6 +121,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Set up Python on your computer and write your first Hello World program.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "getting-started-python",
         title: "Getting Started with Python",
@@ -118,6 +129,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Understand variables, data types, and basic operations in Python.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "variables-data-types",
         title: "Variables and Data Types",
@@ -131,6 +143,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Understand HTML document structure, elements, and create your first web page.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "intro-to-html",
         title: "Introduction to HTML",
@@ -138,6 +151,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Learn about semantic HTML elements and how to structure content meaningfully.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "semantic-html",
         title: "Semantic HTML",
@@ -151,6 +165,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Understand what data science is and the role of a data scientist in modern organizations.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "what-is-data-science",
         title: "What is Data Science?",
@@ -158,6 +173,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Learn about different types of data, data sources, and how to collect data for analysis.",
+        generationStatus: "completed",
         isPublished: true,
         slug: "types-of-data",
         title: "Types of Data",
@@ -190,6 +206,7 @@ export async function seedLessons(
               create: {
                 chapterId: chapter.id,
                 description: lessonData.description,
+                generationStatus: lessonData.generationStatus,
                 isPublished: lessonData.isPublished,
                 kind: lessonData.kind ?? "core",
                 language: data.language,

--- a/packages/testing/src/fixtures/activities.ts
+++ b/packages/testing/src/fixtures/activities.ts
@@ -8,6 +8,7 @@ export function activityAttrs(
 > {
   return {
     description: "Test activity description",
+    generationStatus: "completed",
     isPublished: false,
     kind: "background",
     language: "en",

--- a/packages/testing/src/fixtures/chapters.ts
+++ b/packages/testing/src/fixtures/chapters.ts
@@ -11,6 +11,7 @@ export function chapterAttrs(
   return {
     courseId: 0,
     description: "Test chapter description",
+    generationStatus: "completed",
     isPublished: false,
     language: "en",
     normalizedTitle,

--- a/packages/testing/src/fixtures/courses.ts
+++ b/packages/testing/src/fixtures/courses.ts
@@ -11,6 +11,7 @@ export function courseAttrs(
 ): Omit<Course, "id" | "createdAt" | "updatedAt"> {
   return {
     description: "Test course description",
+    generationStatus: "completed",
     imageUrl: null,
     isPublished: false,
     language: "en",

--- a/packages/testing/src/fixtures/courses.ts
+++ b/packages/testing/src/fixtures/courses.ts
@@ -6,11 +6,15 @@ import {
   prisma,
 } from "@zoonk/db";
 
-export function courseAttrs(
-  attrs?: Partial<Course>,
-): Omit<Course, "id" | "createdAt" | "updatedAt"> {
+type CourseAttrs = Omit<Course, "id" | "createdAt" | "updatedAt"> & {
+  description: string;
+};
+
+export function courseAttrs(attrs?: Partial<Course>): CourseAttrs {
+  const { description, ...rest } = attrs ?? {};
+
   return {
-    description: "Test course description",
+    description: description ?? "Test course description",
     generationStatus: "completed",
     imageUrl: null,
     isPublished: false,
@@ -19,7 +23,7 @@ export function courseAttrs(
     organizationId: 0,
     slug: `test-course-${randomUUID()}`,
     title: "Test Course",
-    ...attrs,
+    ...rest,
   };
 }
 

--- a/packages/testing/src/fixtures/lessons.ts
+++ b/packages/testing/src/fixtures/lessons.ts
@@ -11,6 +11,7 @@ export function lessonAttrs(
   return {
     chapterId: 0,
     description: "Test lesson description",
+    generationStatus: "completed",
     isPublished: false,
     kind: "core",
     language: "en",

--- a/packages/ui/src/patterns/courses/course-list.tsx
+++ b/packages/ui/src/patterns/courses/course-list.tsx
@@ -14,7 +14,7 @@ import { ChevronRightIcon, NotebookPenIcon } from "lucide-react";
 
 export type CourseListItem = {
   id: number;
-  description: string;
+  description: string | null;
   imageUrl: string | null;
   slug: string;
   title: string;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add generation status tracking across courses, chapters, lessons, and activities, and mark chapters as completed after lesson import. Course descriptions are now nullable; types and UI updated to handle nulls.

- **New Features**
  - Add generationStatus to activities, chapters, lessons (default pending) and courses (default completed).
  - Set chapter generationStatus to completed after importing lessons.

- **Migration**
  - Run Prisma migration 20260111000505_add_generation_status.
  - Reseed dev data to populate generationStatus.
  - Ensure code handles course.description as null.

<sup>Written for commit 7959fb3ea4b59fc56ffa82ccffd88e71778dcffe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

