### PR TITLE
refactor(main): allow to get course suggestion by id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ i18n.cache
 # Cursor
 .cursor
 debug.log
+
+# AI tasks
+tasks/

--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ i18n.cache
 debug.log
 
 # AI tasks
-tasks/
+/tasks/

--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,5 @@ i18n.cache
 .cursor
 debug.log
 
-# AI tasks
+# Tasks for AI agents
 /tasks/

--- a/apps/main/e2e/learn.test.ts
+++ b/apps/main/e2e/learn.test.ts
@@ -26,7 +26,7 @@ test.describe("Learn Form", () => {
 });
 
 test.describe("Course Suggestions", () => {
-  test("shows suggestions with title, description, and create button", async ({
+  test("shows suggestions with title, description, and generate link", async ({
     page,
   }) => {
     await page.goto("/learn/test%20prompt");
@@ -40,8 +40,22 @@ test.describe("Course Suggestions", () => {
       page.getByText(/fundamentals of software testing/i),
     ).toBeVisible();
 
-    const createButtons = page.getByRole("button", { name: /create course/i });
-    await expect(createButtons.first()).toBeVisible();
+    const generateLinks = page.getByRole("link", { name: /generate/i });
+    await expect(generateLinks.first()).toBeVisible();
+  });
+
+  test("Generate link navigates to generate page", async ({ page }) => {
+    await page.goto("/learn/test%20prompt");
+
+    await expect(
+      page.getByRole("heading", { name: /course ideas for/i }),
+    ).toBeVisible();
+
+    const generateLink = page.getByRole("link", { name: /generate/i }).first();
+    await generateLink.click();
+
+    await expect(page).toHaveURL(/\/generate\/cs\/\d+/);
+    await expect(page.getByText(/coming soon/i)).toBeVisible();
   });
 
   test("Change subject navigates back to learn form", async ({ page }) => {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -358,9 +358,9 @@ msgid "Course ideas for {prompt}"
 msgstr "Course ideas for {prompt}"
 
 #: src/app/[locale]/(catalog)/learn/[prompt]/course-suggestions.tsx
-msgctxt "dCKXDB"
-msgid "Create course"
-msgstr "Create course"
+msgctxt "Pc+tM3"
+msgid "Generate"
+msgstr "Generate"
 
 #: src/app/[locale]/(catalog)/learn/[prompt]/course-suggestions.tsx
 msgctxt "RbslnC"
@@ -555,6 +555,8 @@ msgid "Month"
 msgstr "Month"
 
 #: src/app/[locale]/(performance)/accuracy/page.tsx
+#: src/app/[locale]/(performance)/belt/page.tsx
+#: src/app/[locale]/generate/cs/[id]/generate-course-suggestion-content.tsx
 msgctxt "e61Jf3"
 msgid "Coming soon"
 msgstr "Coming soon"
@@ -886,6 +888,11 @@ msgstr "Interactive lesson with exercises and activities to help you learn effec
 msgctxt "PJivSX"
 msgid "Lesson"
 msgstr "Lesson"
+
+#: src/app/[locale]/generate/cs/[id]/generate-course-suggestion-content.tsx
+msgctxt "9IJjWu"
+msgid "Generate Course"
+msgstr "Generate Course"
 
 #: src/app/[locale]/privacy/page.tsx
 msgctxt "iql85X"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -555,7 +555,6 @@ msgid "Month"
 msgstr "Month"
 
 #: src/app/[locale]/(performance)/accuracy/page.tsx
-#: src/app/[locale]/(performance)/belt/page.tsx
 #: src/app/[locale]/generate/cs/[id]/generate-course-suggestion-content.tsx
 msgctxt "e61Jf3"
 msgid "Coming soon"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -358,9 +358,9 @@ msgid "Course ideas for {prompt}"
 msgstr "Ideas de cursos para {prompt}"
 
 #: src/app/[locale]/(catalog)/learn/[prompt]/course-suggestions.tsx
-msgctxt "dCKXDB"
-msgid "Create course"
-msgstr "Crear curso"
+msgctxt "Pc+tM3"
+msgid "Generate"
+msgstr "Generar"
 
 #: src/app/[locale]/(catalog)/learn/[prompt]/course-suggestions.tsx
 msgctxt "RbslnC"
@@ -555,6 +555,8 @@ msgid "Month"
 msgstr "Mes"
 
 #: src/app/[locale]/(performance)/accuracy/page.tsx
+#: src/app/[locale]/(performance)/belt/page.tsx
+#: src/app/[locale]/generate/cs/[id]/generate-course-suggestion-content.tsx
 msgctxt "e61Jf3"
 msgid "Coming soon"
 msgstr "Próximamente"
@@ -886,6 +888,11 @@ msgstr "Lección interactiva con ejercicios y actividades para ayudarte a aprend
 msgctxt "PJivSX"
 msgid "Lesson"
 msgstr "Lección"
+
+#: src/app/[locale]/generate/cs/[id]/generate-course-suggestion-content.tsx
+msgctxt "9IJjWu"
+msgid "Generate Course"
+msgstr "Generar curso"
 
 #: src/app/[locale]/privacy/page.tsx
 msgctxt "iql85X"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -555,7 +555,6 @@ msgid "Month"
 msgstr "Mes"
 
 #: src/app/[locale]/(performance)/accuracy/page.tsx
-#: src/app/[locale]/(performance)/belt/page.tsx
 #: src/app/[locale]/generate/cs/[id]/generate-course-suggestion-content.tsx
 msgctxt "e61Jf3"
 msgid "Coming soon"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -555,7 +555,6 @@ msgid "Month"
 msgstr "Mês"
 
 #: src/app/[locale]/(performance)/accuracy/page.tsx
-#: src/app/[locale]/(performance)/belt/page.tsx
 #: src/app/[locale]/generate/cs/[id]/generate-course-suggestion-content.tsx
 msgctxt "e61Jf3"
 msgid "Coming soon"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -358,9 +358,9 @@ msgid "Course ideas for {prompt}"
 msgstr "Ideias de cursos para {prompt}"
 
 #: src/app/[locale]/(catalog)/learn/[prompt]/course-suggestions.tsx
-msgctxt "dCKXDB"
-msgid "Create course"
-msgstr "Criar curso"
+msgctxt "Pc+tM3"
+msgid "Generate"
+msgstr "Gerar"
 
 #: src/app/[locale]/(catalog)/learn/[prompt]/course-suggestions.tsx
 msgctxt "RbslnC"
@@ -555,6 +555,8 @@ msgid "Month"
 msgstr "Mês"
 
 #: src/app/[locale]/(performance)/accuracy/page.tsx
+#: src/app/[locale]/(performance)/belt/page.tsx
+#: src/app/[locale]/generate/cs/[id]/generate-course-suggestion-content.tsx
 msgctxt "e61Jf3"
 msgid "Coming soon"
 msgstr "Em breve"
@@ -886,6 +888,11 @@ msgstr "Aula interativa com exercícios e atividades para ajudá-lo a aprender e
 msgctxt "PJivSX"
 msgid "Lesson"
 msgstr "Aula"
+
+#: src/app/[locale]/generate/cs/[id]/generate-course-suggestion-content.tsx
+msgctxt "9IJjWu"
+msgid "Generate Course"
+msgstr "Gerar curso"
 
 #: src/app/[locale]/privacy/page.tsx
 msgctxt "iql85X"

--- a/apps/main/src/app/[locale]/(catalog)/learn/[prompt]/course-suggestions.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/learn/[prompt]/course-suggestions.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@zoonk/ui/components/button";
+import { buttonVariants } from "@zoonk/ui/components/button";
 import {
   Container,
   ContainerBody,
@@ -16,6 +16,7 @@ import {
   ItemSeparator,
   ItemTitle,
 } from "@zoonk/ui/components/item";
+import { SparklesIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
 import { Fragment } from "react/jsx-runtime";
 import { generateCourseSuggestions } from "@/data/courses/course-suggestions";
@@ -32,7 +33,10 @@ export async function CourseSuggestions({
   prompt,
 }: CourseSuggestionsProps) {
   const t = await getExtracted();
-  const suggestions = await generateCourseSuggestions({ locale, prompt });
+  const { id, suggestions } = await generateCourseSuggestions({
+    locale,
+    prompt,
+  });
 
   return (
     <Container variant="narrow">
@@ -61,9 +65,17 @@ export async function CourseSuggestions({
                 </ItemContent>
 
                 <ItemActions>
-                  <Button size="sm" variant="outline">
-                    {t("Create course")}
-                  </Button>
+                  <Link
+                    className={buttonVariants({
+                      className: "gap-1.5",
+                      size: "sm",
+                      variant: "outline",
+                    })}
+                    href={`/generate/cs/${id}`}
+                  >
+                    <SparklesIcon aria-hidden="true" className="size-4" />
+                    {t("Generate")}
+                  </Link>
                 </ItemActions>
               </Item>
 

--- a/apps/main/src/app/[locale]/generate/cs/[id]/generate-course-suggestion-content.tsx
+++ b/apps/main/src/app/[locale]/generate/cs/[id]/generate-course-suggestion-content.tsx
@@ -1,0 +1,45 @@
+import {
+  Container,
+  ContainerBody,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { getExtracted } from "next-intl/server";
+
+export async function GenerateCourseSuggestionContent() {
+  const t = await getExtracted();
+
+  return (
+    <Container variant="narrow">
+      <ContainerHeader>
+        <ContainerHeaderGroup>
+          <ContainerTitle>{t("Generate Course")}</ContainerTitle>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <div className="flex h-64 items-center justify-center rounded-xl border border-dashed text-muted-foreground">
+          {t("Coming soon")}
+        </div>
+      </ContainerBody>
+    </Container>
+  );
+}
+
+export function GenerateCourseSuggestionFallback() {
+  return (
+    <Container variant="narrow">
+      <ContainerHeader>
+        <ContainerHeaderGroup>
+          <Skeleton className="h-8 w-48" />
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <Skeleton className="h-64 w-full rounded-xl" />
+      </ContainerBody>
+    </Container>
+  );
+}

--- a/apps/main/src/app/[locale]/generate/cs/[id]/page.tsx
+++ b/apps/main/src/app/[locale]/generate/cs/[id]/page.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from "react";
+import {
+  GenerateCourseSuggestionContent,
+  GenerateCourseSuggestionFallback,
+} from "./generate-course-suggestion-content";
+
+export default function GenerateCoursePage(
+  _props: PageProps<"/[locale]/generate/cs/[id]">,
+) {
+  return (
+    <Suspense fallback={<GenerateCourseSuggestionFallback />}>
+      <GenerateCourseSuggestionContent />
+    </Suspense>
+  );
+}

--- a/apps/main/src/data/courses/course-suggestions.ts
+++ b/apps/main/src/data/courses/course-suggestions.ts
@@ -42,16 +42,41 @@ export async function generateCourseSuggestions({
 }: {
   locale: string;
   prompt: string;
-}): Promise<Suggestion[]> {
+}): Promise<{ id: number; suggestions: Suggestion[] }> {
   const record = await findCourseSuggestion({ locale, prompt });
 
   if (!record) {
     const { data } = await generateTask({ locale, prompt });
 
-    await upsertCourseSuggestion({ locale, prompt, suggestions: data });
+    const newRecord = await upsertCourseSuggestion({
+      locale,
+      prompt,
+      suggestions: data,
+    });
 
-    return data;
+    return { id: newRecord.id, suggestions: data };
   }
 
-  return record.suggestions as Suggestion[];
+  return { id: record.id, suggestions: record.suggestions as Suggestion[] };
+}
+
+export async function getCourseSuggestionById(id: number): Promise<{
+  locale: string;
+  prompt: string;
+  suggestions: Suggestion[];
+} | null> {
+  const record = await prisma.courseSuggestion.findUnique({
+    select: { locale: true, prompt: true, suggestions: true },
+    where: { id },
+  });
+
+  if (!record) {
+    return null;
+  }
+
+  return {
+    locale: record.locale,
+    prompt: record.prompt,
+    suggestions: record.suggestions as Suggestion[],
+  };
 }

--- a/i18n.lock
+++ b/i18n.lock
@@ -244,7 +244,7 @@ checksums:
     Cooking%20up%20some%20course%20ideas/singular: a42520f96dbac3580a2ccae4bd6ceb31
     We're%20putting%20together%20a%20few%20course%20suggestions%20for%20you.%20This%20may%20take%20a%20few%20seconds./singular: 8467af30434eb8bfb2f13e109b1d9334
     Course%20ideas%20for%20%7Bprompt%7D/singular: 23f94da8ce9272d654ff40bb80e6a352
-    Create%20course/singular: 41f52f80def95a611c9cc3a5e1a11dde
+    Generate/singular: 0345bf322c191e70d01fd6607ec5c2f8
     Change%20subject/singular: 8585bb703ba2d857dd9a7b36f97be507
     Discover%20personalized%20courses%20and%20resources%20to%20learn%20%7Bprompt%7D.%20Zoonk%20uses%20AI%20to%20generate%20interactive%20lessons%20and%20activities%20tailored%20to%20you./singular: 7d54c62a9c8d49b713626fa25edff820
     Learn%20%7Bprompt%7D%20with%20AI/singular: 5a8a8ee7f52faf0cb790e0f0cfbcce7d
@@ -349,6 +349,7 @@ checksums:
     Complete%20this%20activity%20to%20reinforce%20your%20learning%20and%20track%20your%20progress./singular: ae9411230fe031bbbd7471a8fde4b17d
     Interactive%20lesson%20with%20exercises%20and%20activities%20to%20help%20you%20learn%20effectively./singular: f74de010a6977351bee6b20c81d90d31
     Lesson/singular: 0369d21b141f7f54c4586224e7e7ae65
+    Generate%20Course/singular: f9286dd24f884cca823c70524b6562d8
     Read%20Zoonk's%20privacy%20policy%20to%20understand%20how%20we%20collect%2C%20use%2C%20and%20protect%20your%20personal%20information./singular: 044f3586abe7d9915820a6629cef08e4
     Privacy%20Policy/singular: 7459744a63ef8af4e517a09024bd7c08
     Read%20Zoonk's%20terms%20of%20use%20to%20understand%20the%20rules%20and%20conditions%20for%20using%20our%20platform%20and%20services/singular: 4b82898d60691839a1999e4a17199895


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support to fetch course suggestions by id and links Learn suggestions to a new generate page. Updates the UI to use a “Generate” link and adds tests and translations.

- New Features
  - getCourseSuggestionById(id): returns locale, prompt, and suggestions.
  - generateCourseSuggestions now returns { id, suggestions }.
  - New route /[locale]/generate/cs/[id] with a “Generate Course” placeholder and suspense fallback.

- Refactors
  - Learn suggestions: replace “Create course” button with a “Generate” link to /generate/cs/{id}.
  - E2E: assert presence of the link and navigation to the generate page.
  - i18n: add “Generate” and “Generate Course”; reuse “Coming soon”.
  - .gitignore: ignore /tasks/.

<sup>Written for commit 1f83e738745ef8244661f37b4674b70693e6eb2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

