### PR TITLE
feat(main): redirect when content hasn't been generated yet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Zoonk is a web app where users can learn anything using AI. This app uses AI to 
 - Use meaningful variable names and avoid abbreviations
 - Never guess at imports, table names, or conventions—always search for existing patterns first
 
-Important: Before completing a task, make sure to run the following commands:
+**IMPORTANT**: Before completing a task, make sure to run the following commands:
 
 - `pnpm format`
 - `pnpm lint --write --unsafe`
@@ -37,7 +37,7 @@ Important: Before completing a task, make sure to run the following commands:
 - `pnpm knip`
 - `pnpm test`
 - `pnpm --filter {app} build`
-- `pnpm --filter {app} build:e2e`
+- `pnpm --filter {app} build:e2e` (always run this before running e2e tests)
 - `pnpm --filter {app} e2e`
 
 ## Design Style
@@ -70,6 +70,7 @@ For detailed UX guidelines (interactions, animation, layout, accessibility), see
 - Pass types directly to the component declaration instead of using `type` since those types won't be exported/reused
 - When adding a new Prisma model, always add a seed for it in `packages/db/src/prisma/seed/`
 - Never run `pnpm dev` as there's already a dev server running
+- When writing a plan, don't include "manual verification" steps. We always do manual verification, you don't need to do it. Just ensure you add the necessary e2e tests for the task
 
 ## Component Organization
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Zoonk is a web app where users can learn anything using AI. This app uses AI to 
 - Use meaningful variable names and avoid abbreviations
 - Never guess at imports, table names, or conventions—always search for existing patterns first
 
-Important: Before completing a task, make sure to run the following commands:
+**IMPORTANT**: Before completing a task, make sure to run the following commands:
 
 - `pnpm format`
 - `pnpm lint --write --unsafe`
@@ -37,7 +37,7 @@ Important: Before completing a task, make sure to run the following commands:
 - `pnpm knip`
 - `pnpm test`
 - `pnpm --filter {app} build`
-- `pnpm --filter {app} build:e2e`
+- `pnpm --filter {app} build:e2e` (always run this before running e2e tests)
 - `pnpm --filter {app} e2e`
 
 ## Design Style
@@ -70,6 +70,7 @@ For detailed UX guidelines (interactions, animation, layout, accessibility), see
 - Pass types directly to the component declaration instead of using `type` since those types won't be exported/reused
 - When adding a new Prisma model, always add a seed for it in `packages/db/src/prisma/seed/`
 - Never run `pnpm dev` as there's already a dev server running
+- When writing a plan, don't include "manual verification" steps. We always do manual verification, you don't need to do it. Just ensure you add the necessary e2e tests for the task
 
 ## Component Organization
 

--- a/apps/main/e2e/course-chapters.test.ts
+++ b/apps/main/e2e/course-chapters.test.ts
@@ -133,6 +133,38 @@ test.describe("Course Chapters - Empty State", () => {
   });
 });
 
+test.describe("Course Chapters - No Lessons", () => {
+  test("shows generate lessons message and navigates to generate page", async ({
+    page,
+  }) => {
+    await page.goto("/b/ai/c/python-programming");
+
+    // Expand the chapter that has no lessons
+    await page.getByRole("button", { name: /e2e no lessons chapter/i }).click();
+
+    // Should see the explanatory message
+    await expect(
+      page.getByText(/lessons haven't been generated for this chapter yet/i),
+    ).toBeVisible();
+
+    // Should see the generate lessons button
+    const generateButton = page.getByRole("link", {
+      name: /generate lessons/i,
+    });
+    await expect(generateButton).toBeVisible();
+
+    // Click the generate lessons button
+    await generateButton.click();
+
+    // Should navigate to generate chapter page
+    await expect(page).toHaveURL(/\/generate\/ch\/\d+/);
+    await expect(
+      page.getByRole("heading", { name: /generate chapter/i }),
+    ).toBeVisible();
+    await expect(page.getByText(/coming soon/i)).toBeVisible();
+  });
+});
+
 test.describe("Course Chapters - Locale", () => {
   test("shows chapters in Portuguese for Portuguese locale", async ({
     page,

--- a/apps/main/e2e/course-detail.test.ts
+++ b/apps/main/e2e/course-detail.test.ts
@@ -25,6 +25,18 @@ test.describe("Course Detail Page", () => {
     await expect(page.getByText(/not found|404/i)).toBeVisible();
   });
 
+  test("redirects to generate page when course has no chapters", async ({
+    page,
+  }) => {
+    await page.goto("/b/ai/c/e2e-no-chapters-course");
+
+    await expect(page).toHaveURL(/\/generate\/c\/\d+/);
+    await expect(
+      page.getByRole("heading", { name: /generate course/i }),
+    ).toBeVisible();
+    await expect(page.getByText(/coming soon/i)).toBeVisible();
+  });
+
   test("shows fallback icon when course has no image", async ({ page }) => {
     await page.goto("/b/ai/c/python-programming");
 

--- a/apps/main/e2e/courses.test.ts
+++ b/apps/main/e2e/courses.test.ts
@@ -36,7 +36,12 @@ test.describe("Courses Page - Basic", () => {
   test("clicking course card navigates to course detail", async ({ page }) => {
     await page.goto("/courses");
 
-    await page.getByText("Machine Learning").first().click();
+    await page
+      .getByRole("link", { name: /^Machine Learning/ })
+      .first()
+      .click();
+
+    await expect(page).toHaveURL(/\/b\/ai\/c\/machine-learning/);
 
     // Verify user sees course detail page (level: 1 for main title, not chapter headings)
     await expect(

--- a/apps/main/instrumentation-client.ts
+++ b/apps/main/instrumentation-client.ts
@@ -14,5 +14,13 @@ initBotId({
       method: "GET",
       path: "/learn/*",
     },
+    {
+      method: "GET",
+      path: "/*/generate/*",
+    },
+    {
+      method: "GET",
+      path: "/generate/*",
+    },
   ],
 });

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -141,6 +141,16 @@ msgctxt "R/6nsx"
 msgid "Subscription"
 msgstr "Subscription"
 
+#: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+msgctxt "8AbgQ7"
+msgid "Lessons haven't been generated for this chapter yet."
+msgstr "Lessons haven't been generated for this chapter yet."
+
+#: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+msgctxt "DG7kYp"
+msgid "Generate lessons"
+msgstr "Generate lessons"
+
 #: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-search-container.tsx
 msgctxt "ai9FYU"
 msgid "Search chapters and lessons..."

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -141,6 +141,16 @@ msgctxt "R/6nsx"
 msgid "Subscription"
 msgstr "Suscripción"
 
+#: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+msgctxt "8AbgQ7"
+msgid "Lessons haven't been generated for this chapter yet."
+msgstr "Las lecciones aún no se han generado para este capítulo."
+
+#: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+msgctxt "DG7kYp"
+msgid "Generate lessons"
+msgstr "Generar lecciones"
+
 #: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-search-container.tsx
 msgctxt "ai9FYU"
 msgid "Search chapters and lessons..."

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -141,6 +141,16 @@ msgctxt "R/6nsx"
 msgid "Subscription"
 msgstr "Assinatura"
 
+#: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+msgctxt "8AbgQ7"
+msgid "Lessons haven't been generated for this chapter yet."
+msgstr "As aulas ainda não foram geradas para este capítulo."
+
+#: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+msgctxt "DG7kYp"
+msgid "Generate lessons"
+msgstr "Gerar aulas"
+
 #: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-search-container.tsx
 msgctxt "ai9FYU"
 msgid "Search chapters and lessons..."

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -6,8 +6,12 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@zoonk/ui/components/accordion";
+import { buttonVariants } from "@zoonk/ui/components/button";
+import { SparklesIcon } from "lucide-react";
+import { useExtracted } from "next-intl";
 import type { ChapterWithLessons } from "@/data/chapters/list-course-chapters";
 import { ClientLink } from "@/i18n/client-link";
+import { Link } from "@/i18n/navigation";
 
 export function ChapterList({
   brandSlug,
@@ -24,6 +28,8 @@ export function ChapterList({
   expandedValues?: string[];
   onExpandedChange?: (values: string[]) => void;
 }) {
+  const t = useExtracted();
+
   if (chapters.length === 0) {
     if (!emptyStateText) {
       return null;
@@ -64,18 +70,40 @@ export function ChapterList({
                   </p>
                 )}
 
-                <ul className="flex flex-col">
-                  {chapter.lessons.map((lesson) => (
-                    <li key={lesson.id}>
-                      <ClientLink
-                        className="-mx-2 block rounded-md px-2 py-2.5 text-foreground/80 text-sm transition-colors hover:bg-muted/40 hover:text-foreground"
-                        href={`/b/${brandSlug}/c/${courseSlug}/c/${chapter.slug}/l/${lesson.slug}`}
-                      >
-                        {lesson.title}
-                      </ClientLink>
-                    </li>
-                  ))}
-                </ul>
+                {chapter.lessons.length === 0 ? (
+                  <div className="flex flex-col gap-3">
+                    <p className="text-muted-foreground text-sm">
+                      {t(
+                        "Lessons haven't been generated for this chapter yet.",
+                      )}
+                    </p>
+                    <Link
+                      className={buttonVariants({
+                        className: "w-fit",
+                        size: "sm",
+                        variant: "outline",
+                      })}
+                      href={`/generate/ch/${chapter.id}`}
+                      prefetch={false}
+                    >
+                      <SparklesIcon className="size-4" />
+                      {t("Generate lessons")}
+                    </Link>
+                  </div>
+                ) : (
+                  <ul className="flex flex-col">
+                    {chapter.lessons.map((lesson) => (
+                      <li key={lesson.id}>
+                        <ClientLink
+                          className="-mx-2 block rounded-md px-2 py-2.5 text-foreground/80 text-sm transition-colors hover:bg-muted/40 hover:text-foreground"
+                          href={`/b/${brandSlug}/c/${courseSlug}/c/${chapter.slug}/l/${lesson.slug}`}
+                        >
+                          {lesson.title}
+                        </ClientLink>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </div>
             </AccordionContent>
           </AccordionItem>

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
@@ -9,6 +9,7 @@ import { setRequestLocale } from "next-intl/server";
 import { Suspense } from "react";
 import { listCourseChapters } from "@/data/chapters/list-course-chapters";
 import { getCourse } from "@/data/courses/get-course";
+import { redirect } from "@/i18n/navigation";
 import { ChapterSearchContainer } from "./chapter-search-container";
 import { CourseHeader } from "./course-header";
 
@@ -61,6 +62,10 @@ export default async function CoursePage({
 
   if (!course) {
     notFound();
+  }
+
+  if (chapters.length === 0) {
+    redirect({ href: `/generate/c/${course.id}`, locale });
   }
 
   return (

--- a/apps/main/src/app/[locale]/(catalog)/learn/[prompt]/course-suggestions.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/learn/[prompt]/course-suggestions.tsx
@@ -72,6 +72,7 @@ export async function CourseSuggestions({
                       variant: "outline",
                     })}
                     href={`/generate/cs/${id}`}
+                    prefetch={false}
                   >
                     <SparklesIcon aria-hidden="true" className="size-4" />
                     {t("Generate")}

--- a/apps/main/src/app/[locale]/generate/c/[id]/generate-course-content.tsx
+++ b/apps/main/src/app/[locale]/generate/c/[id]/generate-course-content.tsx
@@ -1,0 +1,44 @@
+import {
+  Container,
+  ContainerBody,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+
+export async function GenerateCourseContent() {
+  return (
+    <Container variant="narrow">
+      <ContainerHeader>
+        <ContainerHeaderGroup>
+          {/* biome-ignore lint/nursery/noJsxLiterals: placeholder page */}
+          <ContainerTitle>Generate Course</ContainerTitle>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <div className="flex h-64 items-center justify-center rounded-xl border border-dashed text-muted-foreground">
+          {/* biome-ignore lint/nursery/noJsxLiterals: placeholder page */}
+          Coming soon
+        </div>
+      </ContainerBody>
+    </Container>
+  );
+}
+
+export function GenerateCourseFallback() {
+  return (
+    <Container variant="narrow">
+      <ContainerHeader>
+        <ContainerHeaderGroup>
+          <Skeleton className="h-8 w-48" />
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <Skeleton className="h-64 w-full rounded-xl" />
+      </ContainerBody>
+    </Container>
+  );
+}

--- a/apps/main/src/app/[locale]/generate/c/[id]/page.tsx
+++ b/apps/main/src/app/[locale]/generate/c/[id]/page.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from "react";
+import {
+  GenerateCourseContent,
+  GenerateCourseFallback,
+} from "./generate-course-content";
+
+export default function GenerateCoursePage(
+  _props: PageProps<"/[locale]/generate/c/[id]">,
+) {
+  return (
+    <Suspense fallback={<GenerateCourseFallback />}>
+      <GenerateCourseContent />
+    </Suspense>
+  );
+}

--- a/apps/main/src/app/[locale]/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/generate-chapter-content.tsx
@@ -1,0 +1,44 @@
+import {
+  Container,
+  ContainerBody,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+
+export async function GenerateChapterContent() {
+  return (
+    <Container variant="narrow">
+      <ContainerHeader>
+        <ContainerHeaderGroup>
+          {/* biome-ignore lint/nursery/noJsxLiterals: placeholder page */}
+          <ContainerTitle>Generate Chapter</ContainerTitle>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <div className="flex h-64 items-center justify-center rounded-xl border border-dashed text-muted-foreground">
+          {/* biome-ignore lint/nursery/noJsxLiterals: placeholder page */}
+          Coming soon
+        </div>
+      </ContainerBody>
+    </Container>
+  );
+}
+
+export function GenerateChapterFallback() {
+  return (
+    <Container variant="narrow">
+      <ContainerHeader>
+        <ContainerHeaderGroup>
+          <Skeleton className="h-8 w-48" />
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <Skeleton className="h-64 w-full rounded-xl" />
+      </ContainerBody>
+    </Container>
+  );
+}

--- a/apps/main/src/app/[locale]/generate/ch/[id]/page.tsx
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/page.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from "react";
+import {
+  GenerateChapterContent,
+  GenerateChapterFallback,
+} from "./generate-chapter-content";
+
+export default function GenerateChapterPage(
+  _props: PageProps<"/[locale]/generate/ch/[id]">,
+) {
+  return (
+    <Suspense fallback={<GenerateChapterFallback />}>
+      <GenerateChapterContent />
+    </Suspense>
+  );
+}

--- a/i18n.lock
+++ b/i18n.lock
@@ -203,20 +203,21 @@ checksums:
     Settings/singular: 8df6777277469c1fd88cc18dde2f1cc3
     Support/singular: 55aab5fd0f31a9cb055a2edeeedfaf63
     Subscription/singular: ba9f3675e18987d067d48533c8897343
-    "%7Bvalue%7D%25%20correct%20answers/singular": 0a95eedb35d1990c8e8af833ddba628f
-    Accuracy/singular: d6022b38e0960d1a7bea84586e4986eb
-    Past%203%20months/singular: 0784d60565f6812fce36c72252663412
+    Lessons%20haven't%20been%20generated%20for%20this%20chapter%20yet./singular: ab7a5c1b0cf16f1a8b9cf87487800e3f
+    Generate%20lessons/singular: 99814020e2da40d3f3146eaba4e42959
     Search%20chapters%20and%20lessons.../singular: 9efe924871c3c733391ccd1e3c6d044f
     Search%20chapters%20and%20lessons/singular: 1478233cb8fcb9b66cea6661a11d388c
     No%20chapters%20or%20lessons%20found/singular: 2fe297df8b5d61f27245373ef71d1f10
     This%20content%20was%20generated%20by%20AI.%20It%20may%20contain%20errors%20or%20inaccuracies%20and%20should%20not%20be%20considered%20professional%20advice./singular: 269e7c16a722903b9b434f28aa6cf617
-    "%7Bcolor%7D%20belt/singular": 5949446c9b4a223c04cc500fa17a1fe0
-    "%7Bvalue%7D%20BP%20to%20next%20level/singular": dc80ce93407f21e5e909760ec2c9aaef
-    Belt/singular: fa36e8e36732c223d2876c0337d372e9
-    Max%20level%20reached/singular: 5bfdf2d9ba3929b456dcf5c253315e92
-    "%7Bcolor%7D%20Belt%20-%20Level%20%7Blevel%7D/singular": abb5a7600bd66f523906425beffbaff4
     "%7Bday%7D%20with%20%7Bvalue%7D%25/singular": 6e5416262bf719f632e31ed1a8236801
     Best%20day/singular: c7d1324abc9d2515ec3bbc955b317404
+    Past%203%20months/singular: 0784d60565f6812fce36c72252663412
+    Morning/singular: c2f3e2bb2361eebb1576896fcc6c0d69
+    Night/singular: 6fa09c4a1c03187be163148a653056ae
+    Best%20time/singular: 347c8096d59804d21a49e6dcd90c78a2
+    Afternoon/singular: b34f73070b6ce5e811f2aeec93798d7d
+    Evening/singular: d401caa89963f8017a148bcdd1749c2d
+    "%7Bperiod%7D%20with%20%7Bvalue%7D%25/singular": 958bc2c65d9a6823edee6f2585fd6501
     Continue%20learning/singular: ff5ff528cbacf657af36fb9b711431d6
     Next%3A%20%7Bactivity%7D/singular: 9208679843466247d2161793249e5eda
     Activity/singular: 1948763de8e531483a798b68195e297e
@@ -254,6 +255,11 @@ checksums:
     Tell%20Zoonk%20what%20you%20want%20to%20learn%20and%20get%20a%20course%20generated%20by%20AI.%20Start%20learning%20any%20subject%20with%20interactive%20lessons%20and%20activities./singular: bce6930e3cd7b20455ea7996a65cbe4f
     What%20do%20you%20want%20to%20learn%3F/singular: eae5c853dbe20fa2e1eacb1e8396d3de
     Learn%20Anything%20with%20AI/singular: af8ba68f4986f321a1025e9b0f4ac794
+    "%7Bcolor%7D%20belt/singular": 5949446c9b4a223c04cc500fa17a1fe0
+    "%7Bvalue%7D%20BP%20to%20next%20level/singular": dc80ce93407f21e5e909760ec2c9aaef
+    Max%20level%20reached/singular: 5bfdf2d9ba3929b456dcf5c253315e92
+    "%7Bcolor%7D%20Belt%20-%20Level%20%7Blevel%7D/singular": abb5a7600bd66f523906425beffbaff4
+    Level/singular: 1e3bf31d5c6083e898dd3e3359fbb0c2
     Continue%20where%20you%20left%20off/singular: c3ef4fd14e046d53816ede13fc5d27fc
     My%20Courses/singular: 3031c7801404796addff2b7d796fa4c2
     View%20all%20the%20courses%20you%20started%20on%20Zoonk.%20Continue%20where%20you%20left%20off%20and%20track%20your%20progress%20across%20interactive%20lessons%20and%20activities./singular: eee1ce9f3b0be49ddc9bb3ce21270796
@@ -261,13 +267,9 @@ checksums:
     No%20courses%20yet/singular: d5fcc38466fdc83a74eab5032a2f85b6
     Zoonk%3A%20AI%20Learning%20Platform/singular: 4a2d25490f4a5e5cd4543f48fcec968d
     Zoonk%20is%20an%20AI-powered%20learning%20platform%20where%20you%20can%20learn%20anything%20through%20interactive%20courses%2C%20lessons%2C%20and%20activities./singular: e836899ce8100db55d5fa54fe6375970
-    Morning/singular: c2f3e2bb2361eebb1576896fcc6c0d69
-    Night/singular: 6fa09c4a1c03187be163148a653056ae
-    Afternoon/singular: b34f73070b6ce5e811f2aeec93798d7d
-    Evening/singular: d401caa89963f8017a148bcdd1749c2d
-    Peak%20time/singular: 00610169ef99ad10cd58469e43f5a056
-    "%7Bperiod%7D%20with%20%7Bvalue%7D%25/singular": 958bc2c65d9a6823edee6f2585fd6501
     Performance/singular: 28b6d3a3d4a53afa0617a180e318ff4d
+    "%7Bvalue%7D%25%20correct%20answers/singular": 0a95eedb35d1990c8e8af833ddba628f
+    Score/singular: b5e6f7445382f67427b5c48cc9ef33bc
     "%7Bvalue%7D%25/singular": 35cbe4d3fffd3e6b5415eea333f532d7
     vs%20last%20month/singular: 642c3b71173b2adbd876aa05d53d47cf
     vs%20last%206%20months/singular: 82e8ff0c71a42ab0aa345474035d29b4
@@ -281,15 +283,18 @@ checksums:
     6%20Months/singular: 087e8a324c3bcac4f34c23d814f7057a
     Period%20selection/singular: e23c5c435a91f9a8a1ff74d08ac44750
     Month/singular: ae7bef950efc406ff0980affabc1a64c
-    Coming%20soon/singular: ee2b0671e00972773210c5be5a9ccb89
-    Track%20your%20accuracy%20over%20time%20and%20see%20your%20best%20days%20and%20peak%20times./singular: 6cf7fcfdc6aeba2b3663cd106bb9edf8
-    Track%20your%20accuracy%20and%20performance%20trends/singular: 880e1c11776101f3fd7e3ba37f621842
+    Energy%20chart/singular: 79a504a3370c1e606dc714f587012cbe
+    Avg/singular: 2d7f837da968af2579e75135d3787b3d
+    Energy%20reflects%20your%20learning%20consistency.%20It%20increases%20with%20correct%20answers%20(%2B0.1%25)%2C%20decreases%20with%20wrong%20answers%20(-0.03%25)%2C%20and%20drops%201%25%20for%20each%20inactive%20day./singular: 94dd59a838ae089f5aa690db00866501
+    About%20Energy/singular: 18287bbbcf63528fb4d77c47340bac10
+    Track%20your%20energy%20over%20time%20and%20see%20how%20your%20learning%20consistency%20affects%20your%20progress./singular: 2b44dbd8007faa2b33dcbcee0cad6307
+    Track%20your%20learning%20energy%20over%20time/singular: c9ec5b7fab47c0313af0dbb14e83c653
     Brain%20Power%20chart/singular: 07ca213967e88b69e1000a6cda465ad8
     Total%20Brain%20Power%20earned%3A%20%7Btotal%7D/singular: d28228f7edab6482d1a444de33646b1a
     "%7Bvalue%7D%20BP/singular": a2480149a0208509d79feeb1ca1cfa1e
     Brain%20Power%20(BP)%20represents%20your%20knowledge%20growth.%20Unlike%20energy%2C%20BP%20never%20decreases%20-%20it%20only%20grows%20as%20you%20learn%20more./singular: 436619a12f6800283deddf1f429d506a
-    About%20Belts/singular: 3a946fdc1c45cc0e7d944d5f6ac08427
     Belt%20colors%20in%20order%3A%20White%2C%20Yellow%2C%20Orange%2C%20Green%2C%20Blue%2C%20Purple%2C%20Brown%2C%20Red%2C%20Gray%2C%20and%20Black.%20Keep%20learning%20to%20reach%20the%20highest%20level!/singular: 9e74564402564784900f3ba7c0da5f10
+    About%20Levels/singular: c6833a65186160f3a1ded244544ac163
     Every%20time%20you%20complete%20an%20activity%2C%20you%20earn%20Brain%20Power.%20As%20you%20accumulate%20BP%2C%20you%20progress%20through%2010%20belt%20colors%2C%20each%20with%2010%20levels./singular: e83109402715e0504df428c5aa41ac26
     Level%20%7Bcurrent%7D%20of%2010%20in%20%7Bcolor%7D%20belt/singular: 2b6cc01675b41d1269ce8a1050728622
     Done/singular: ffd408fa29d5bc9039ef8ea1b9b699bb
@@ -300,14 +305,11 @@ checksums:
     BP/singular: 842ed01b3a4d0efa6fe96ae8c595726c
     "%7Bvalue%7D%20BP%20earned/singular": 583e121af4a624edef99166b4af272c0
     Total%20Brain%20Power/singular: d20bd99b8345101df62b8fa365c9b2dc
-    Track%20your%20belt%20progress%20and%20see%20how%20you%20advance./singular: bed7b02517fa582692bca05e6aba8cd8
-    Track%20your%20belt%20progress/singular: cde6164b595117241bf3692dae55302d
-    Energy%20chart/singular: 79a504a3370c1e606dc714f587012cbe
-    Avg/singular: 2d7f837da968af2579e75135d3787b3d
-    Energy%20reflects%20your%20learning%20consistency.%20It%20increases%20with%20correct%20answers%20(%2B0.1%25)%2C%20decreases%20with%20wrong%20answers%20(-0.03%25)%2C%20and%20drops%201%25%20for%20each%20inactive%20day./singular: 94dd59a838ae089f5aa690db00866501
-    About%20Energy/singular: 18287bbbcf63528fb4d77c47340bac10
-    Track%20your%20energy%20over%20time%20and%20see%20how%20your%20learning%20consistency%20affects%20your%20progress./singular: 2b44dbd8007faa2b33dcbcee0cad6307
-    Track%20your%20learning%20energy%20over%20time/singular: c9ec5b7fab47c0313af0dbb14e83c653
+    Track%20your%20level%20progress%20and%20see%20how%20you%20advance./singular: 25792319622e431462e5963816d3a1c1
+    Track%20your%20level%20progress/singular: d5aa88156f57e99743b099ada4daecd4
+    Coming%20soon/singular: ee2b0671e00972773210c5be5a9ccb89
+    Track%20your%20score%20and%20performance%20trends/singular: b660687741358d332d8bbc63c58f1368
+    Track%20your%20score%20over%20time%20and%20see%20your%20best%20days%20and%20times./singular: d477bfe0bba94da2985619fccead6fcd
     Checking%20if%20you're%20logged%20in.../singular: b50f05bfcb51cad6913150273e551291
     You%20need%20to%20be%20logged%20in%20to%20access%20this%20page./singular: 759ca522663d8f628718332f756dd6c4
     Display%20name/singular: 725f331065e9d594d720d07b1ae51a90

--- a/packages/db/src/prisma/seed/chapters.ts
+++ b/packages/db/src/prisma/seed/chapters.ts
@@ -170,6 +170,14 @@ const chaptersData: CourseChapters[] = [
         slug: "data-structures",
         title: "Data Structures",
       },
+      {
+        description:
+          "A chapter with no lessons for E2E testing generation status.",
+        generationStatus: "pending",
+        isPublished: true,
+        slug: "e2e-no-lessons-chapter",
+        title: "E2E No Lessons Chapter",
+      },
     ],
     courseSlug: "python-programming",
     language: "en",

--- a/packages/db/src/prisma/seed/courses.ts
+++ b/packages/db/src/prisma/seed/courses.ts
@@ -16,6 +16,16 @@ export const coursesData = [
   },
   {
     description:
+      "A course with no chapters for E2E testing generation status redirect.",
+    imageUrl: null,
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString("E2E No Chapters Course"),
+    slug: "e2e-no-chapters-course",
+    title: "E2E No Chapters Course",
+  },
+  {
+    description:
       "Machine learning enables computers to identify patterns and make predictions from data. Covers supervised and unsupervised techniques, neural networks, and model evaluation. Prepares you to work as a machine learning engineer at tech companies, research labs, or startups building AI products.",
     imageUrl:
       "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/courses/machine_learning-jmaDwiS0MptNV2EGCZzYWU7RBJs3Qg.webp",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Redirect users to a generate flow when a course has no chapters or a chapter has no lessons, and show a clear CTA to start generation. Adds placeholder generate pages, seeds, i18n, botid protection, and E2E coverage.

- **New Features**
  - Redirect courses without chapters to /generate/c/[id].
  - Show “Lessons haven't been generated…” with a “Generate lessons” button linking to /generate/ch/[id].
  - Added /generate/c/[id] and /generate/ch/[id] pages with placeholder UI and Suspense fallbacks.
  - Added E2E tests and seed data for “no chapters” and “no lessons” cases.
  - Added botid protection and disabled prefetch for generate links; added translations.

<sup>Written for commit a2c4a855fadfdb9255c7acace62bf494f8814bc4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

