### PR TITLE
test(main): fix flaky tests for courses and contact form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Zoonk is a web app where users can learn anything using AI. This app uses AI to 
 - [CSS](#css)
 - [Icons](#icons)
 - [React Compiler](#react-compiler)
+- [Next.js](#nextjs)
 - [Specialized Skills](#specialized-skills)
 - [Updating this document](#updating-this-document)
 
@@ -156,6 +157,10 @@ For detailed testing patterns, fixtures, and best practices, see `.claude/skills
 ## React Compiler
 
 We're using the new [React Compiler](https://react.dev/learn/react-compiler/introduction). By default, React Compiler will memoize your code based on its analysis and heuristics. In most cases, this memoization will be as precise, or moreso, than what you may have written. This means you don't need to `useMemo` or `useCallback` as much. The useMemo and useCallback hooks can continue to be used with React Compiler as an escape hatch to provide control over which values are memoized. A common use-case for this is if a memoized value is used as an effect dependency, in order to ensure that an effect does not fire repeatedly even when its dependencies do not meaningfully change. However, this should be used sparingly and only when necessary. Don't default to using `useMemo` or `useCallback` with React Compiler, use them only when necessary.
+
+## Next.js
+
+- You can't use `export const dynamic = "force-dynamic";` with cache components. Instead, wrap async code in a `Suspense` boundary. grep `Suspense` for examples and search the latest Next.js docs for more information.
 
 ## Specialized Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Zoonk is a web app where users can learn anything using AI. This app uses AI to 
 - [CSS](#css)
 - [Icons](#icons)
 - [React Compiler](#react-compiler)
+- [Next.js](#nextjs)
 - [Specialized Skills](#specialized-skills)
 - [Updating this document](#updating-this-document)
 
@@ -156,6 +157,10 @@ For detailed testing patterns, fixtures, and best practices, see `.claude/skills
 ## React Compiler
 
 We're using the new [React Compiler](https://react.dev/learn/react-compiler/introduction). By default, React Compiler will memoize your code based on its analysis and heuristics. In most cases, this memoization will be as precise, or moreso, than what you may have written. This means you don't need to `useMemo` or `useCallback` as much. The useMemo and useCallback hooks can continue to be used with React Compiler as an escape hatch to provide control over which values are memoized. A common use-case for this is if a memoized value is used as an effect dependency, in order to ensure that an effect does not fire repeatedly even when its dependencies do not meaningfully change. However, this should be used sparingly and only when necessary. Don't default to using `useMemo` or `useCallback` with React Compiler, use them only when necessary.
+
+## Next.js
+
+- You can't use `export const dynamic = "force-dynamic";` with cache components. Instead, wrap async code in a `Suspense` boundary. grep `Suspense` for examples and search the latest Next.js docs for more information.
 
 ## Specialized Skills
 

--- a/apps/main/e2e/content-feedback.test.ts
+++ b/apps/main/e2e/content-feedback.test.ts
@@ -66,34 +66,6 @@ test.describe("Content Feedback", () => {
   });
 
   test("submit failure shows error message", async ({ page }) => {
-    // Intercept server action requests and modify response to return error
-    await page.route("**/*", async (route) => {
-      const request = route.request();
-
-      // Server actions use POST with Next-Action header
-      if (
-        request.method() === "POST" &&
-        request.headers()["next-action"] !== undefined
-      ) {
-        // Fetch the real response first to get the correct format
-        const response = await route.fetch();
-        const body = await response.text();
-
-        // Replace status:"success" with status:"error" in the RSC response
-        const errorBody = body.replace(
-          '"status":"success"',
-          '"status":"error"',
-        );
-
-        await route.fulfill({
-          body: errorBody,
-          response,
-        });
-      } else {
-        await route.continue();
-      }
-    });
-
     await page.getByRole("button", { name: /send feedback/i }).click();
 
     const dialog = page.getByRole("dialog");
@@ -103,7 +75,9 @@ test.describe("Content Feedback", () => {
     await expect(emailInput).toBeEnabled();
 
     await emailInput.fill("test@example.com");
-    await dialog.getByLabel(/message/i).fill("This is test feedback");
+
+    // Whitespace passes HTML5 "required" but fails server-side when trimmed
+    await dialog.getByLabel(/message/i).fill("   ");
     await dialog.getByRole("button", { name: /send message/i }).click();
 
     await expect(dialog.getByText(/failed to send message/i)).toBeVisible();

--- a/apps/main/e2e/courses.test.ts
+++ b/apps/main/e2e/courses.test.ts
@@ -36,16 +36,19 @@ test.describe("Courses Page - Basic", () => {
   test("clicking course card navigates to course detail", async ({ page }) => {
     await page.goto("/courses");
 
+    await expect(
+      page.getByRole("heading", { name: /explore courses/i }),
+    ).toBeVisible();
+
     const courseLink = page
-      .getByRole("link", { name: /^Machine Learning/ })
+      .getByRole("link", { name: /machine Learning/i })
       .first();
 
     await expect(courseLink).toBeVisible();
     await courseLink.click();
 
-    await expect(page).toHaveURL(/\/b\/ai\/c\/machine-learning/);
+    await page.waitForURL(/\/b\/ai\/c\/machine-learning/);
 
-    // Verify user sees course detail page (level: 1 for main title, not chapter headings)
     await expect(
       page.getByRole("heading", { level: 1, name: /machine learning/i }),
     ).toBeVisible();

--- a/apps/main/e2e/support.test.ts
+++ b/apps/main/e2e/support.test.ts
@@ -51,41 +51,15 @@ test.describe("Support page", () => {
   });
 
   test("submit failure shows error message", async ({ page }) => {
-    // Intercept server action requests and modify response to return error
-    await page.route("**/*", async (route) => {
-      const request = route.request();
-
-      // Server actions use POST with Next-Action header
-      if (
-        request.method() === "POST" &&
-        request.headers()["next-action"] !== undefined
-      ) {
-        // Fetch the real response first to get the correct format
-        const response = await route.fetch();
-        const body = await response.text();
-
-        // Replace status:"success" with status:"error" in the RSC response
-        const errorBody = body.replace(
-          '"status":"success"',
-          '"status":"error"',
-        );
-
-        await route.fulfill({
-          body: errorBody,
-          response,
-        });
-      } else {
-        await route.continue();
-      }
-    });
-
     await page.getByRole("button", { name: /contact support/i }).click();
 
     const dialog = page.getByRole("dialog");
     const emailInput = dialog.getByLabel(/email/i);
     await expect(emailInput).toBeEnabled();
     await emailInput.fill("test@example.com");
-    await dialog.getByLabel(/message/i).fill("Test message");
+
+    // Whitespace passes HTML5 "required" but fails server-side when trimmed
+    await dialog.getByLabel(/message/i).fill("   ");
     await dialog.getByRole("button", { name: /send message/i }).click();
 
     await expect(dialog.getByText(/failed to send message/i)).toBeVisible();


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilized flaky tests for Courses and contact forms by removing network interception and improving selectors/timing. Also fixed a date-based unit test that broke across weeks, and added a Next.js note to docs.

- **Bug Fixes**
  - E2E: Content Feedback and Support tests now trigger server-side validation by sending whitespace, removing page.route interception and reducing flakiness.
  - E2E: Courses test waits for the page heading, uses a case-insensitive course link, and switches to waitForURL to avoid timing issues.
  - Unit: Energy history test anchors dates to Tuesday noon of the current week to keep all entries in the same week and stable across timezones.

- **Docs**
  - Added Next.js guidance: dynamic="force-dynamic" is not compatible with cache components; use Suspense around async code.

<sup>Written for commit cc4e2142e8b8c7a9208283a0588d18ba4985b265. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

