### PR TITLE
test(editor): remove redundant flaky test

### DIFF
--- a/apps/editor/e2e/course-image.test.ts
+++ b/apps/editor/e2e/course-image.test.ts
@@ -176,20 +176,3 @@ test.describe("Course Image - Validation", () => {
     await expect(getUploadButton(authenticatedPage)).toBeVisible();
   });
 });
-
-test.describe("Course Image - Keyboard Accessibility", () => {
-  test("opens file picker with Enter key", async ({ authenticatedPage }) => {
-    const course = await createTestCourse(null);
-    await navigateToCoursePage(authenticatedPage, course.slug);
-
-    await getUploadButton(authenticatedPage).focus();
-
-    const [fileChooser] = await Promise.all([
-      authenticatedPage.waitForEvent("filechooser"),
-      authenticatedPage.keyboard.press("Enter"),
-    ]);
-
-    expect(fileChooser).toBeTruthy();
-    await fileChooser.setFiles([]);
-  });
-});

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@prisma/adapter-pg": "7.2.0",
-    "@vercel/functions": "3.1.0",
+    "@vercel/functions": "3.3.5",
     "@zoonk/utils": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -539,8 +539,8 @@ importers:
         specifier: '>=7.1'
         version: 7.2.0(prisma@7.2.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
       '@vercel/functions':
-        specifier: 3.1.0
-        version: 3.1.0
+        specifier: 3.3.5
+        version: 3.3.5
       '@zoonk/utils':
         specifier: workspace:*
         version: link:../utils
@@ -2507,8 +2507,8 @@ packages:
     resolution: {integrity: sha512-oAj7Pdy83YKSwIaMFoM7zFeLYWRc+qUpW3PiDSblxQMnGFb43qs4bmfq7dr/+JIfwhs6PTwe1o2YBwKhyjWxXw==}
     engines: {node: '>=20.0.0'}
 
-  '@vercel/functions@3.1.0':
-    resolution: {integrity: sha512-V+p8dO+sg1VjiJJUO5rYPp1KG17SzDcR74OWwW7Euyde6L8U5wuTMe9QfEOfLTiWPUPzN1MXZvLcYxqSYhKc4Q==}
+  '@vercel/functions@3.3.5':
+    resolution: {integrity: sha512-GKgC1sAbc0hL8bmzStkbM1FQRdzzYl2vm7L8SqUSnILoEcsAEJFY2prrEHvuhlKXtKqHo3P9WbHlg0QxuazDPA==}
     engines: {node: '>= 20'}
     peerDependencies:
       '@aws-sdk/credential-provider-web-identity': '*'
@@ -2516,12 +2516,12 @@ packages:
       '@aws-sdk/credential-provider-web-identity':
         optional: true
 
-  '@vercel/oidc@3.0.0':
-    resolution: {integrity: sha512-XOoUcf/1VfGArUAfq0ELxk6TD7l4jGcrOsWjQibj4wYM74uNihzZ9gA46ywWegoqKWWdph4y5CKxGI9823deoA==}
-    engines: {node: '>= 20'}
-
   '@vercel/oidc@3.0.5':
     resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
+    engines: {node: '>= 20'}
+
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
   '@vitest/expect@4.0.16':
@@ -6062,16 +6062,13 @@ snapshots:
       throttleit: 2.1.0
       undici: 5.29.0
 
-  '@vercel/functions@3.1.0':
+  '@vercel/functions@3.3.5':
     dependencies:
-      '@vercel/oidc': 3.0.0
-
-  '@vercel/oidc@3.0.0':
-    dependencies:
-      '@types/ms': 2.1.0
-      ms: 2.1.3
+      '@vercel/oidc': 3.1.0
 
   '@vercel/oidc@3.0.5': {}
+
+  '@vercel/oidc@3.1.0': {}
 
   '@vitest/expect@4.0.16':
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removes a flaky, redundant E2E test in the editor to stabilize CI, and updates @vercel/functions to 3.3.5. No app behavior changes.

- **Bug Fixes**
  - Deleted the "Course Image - Keyboard Accessibility" test that intermittently failed due to filechooser event timing.

- **Dependencies**
  - Bumped @vercel/functions from 3.1.0 to 3.3.5 in packages/db and updated the lockfile (transitive @vercel/oidc updated).

<sup>Written for commit 1aa15eb2e73920e8d51d000271588fc6441c7192. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

