### PR TITLE
refactor(db): rename `locale` field as `language` for consistency

### DIFF
--- a/apps/editor/e2e/alternative-titles.test.ts
+++ b/apps/editor/e2e/alternative-titles.test.ts
@@ -42,7 +42,7 @@ async function createAlternativeTitleFixture(
 ) {
   const slug = `${baseSlug}-${randomUUID().slice(0, 8)}`;
   await prisma.courseAlternativeTitle.create({
-    data: { courseId, locale: "en", slug },
+    data: { courseId, language: "en", slug },
   });
   return slug;
 }
@@ -58,7 +58,7 @@ async function createManyAlternativeTitleFixtures(
   );
 
   await prisma.courseAlternativeTitle.createMany({
-    data: slugs.map((slug) => ({ courseId, locale: "en", slug })),
+    data: slugs.map((slug) => ({ courseId, language: "en", slug })),
   });
 
   return slugs;
@@ -307,7 +307,7 @@ test.describe("Alternative Titles Editor", () => {
     const slug = `dup-test-${uniqueId}`;
 
     await prisma.courseAlternativeTitle.create({
-      data: { courseId: course.id, locale: "en", slug },
+      data: { courseId: course.id, language: "en", slug },
     });
 
     await navigateToCoursePage(authenticatedPage, course.slug);

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
@@ -314,7 +314,7 @@ export async function addAlternativeTitleAction(
 
   await addAlternativeTitles({
     courseId,
-    locale: lang,
+    language: lang,
     titles: [title],
   });
 
@@ -353,7 +353,7 @@ export async function importAlternativeTitlesAction(
   const { error } = await importAlternativeTitles({
     courseId,
     file,
-    locale: lang,
+    language: lang,
     mode,
   });
 

--- a/apps/editor/src/data/alternative-titles/delete-alternative-titles.test.ts
+++ b/apps/editor/src/data/alternative-titles/delete-alternative-titles.test.ts
@@ -18,7 +18,7 @@ describe("deleteAlternativeTitles", () => {
 
     await addAlternativeTitles({
       courseId: course.id,
-      locale: "en",
+      language: "en",
       titles: [title1, title2, title3],
     });
 
@@ -44,7 +44,7 @@ describe("deleteAlternativeTitles", () => {
 
     await addAlternativeTitles({
       courseId: course.id,
-      locale: "en",
+      language: "en",
       titles: [`react-${suffix}`, `vue-${suffix}`, `angular-${suffix}`],
     });
 
@@ -69,7 +69,7 @@ describe("deleteAlternativeTitles", () => {
 
     await addAlternativeTitles({
       courseId: course.id,
-      locale: "en",
+      language: "en",
       titles: [`python-${suffix}`],
     });
 
@@ -94,7 +94,7 @@ describe("deleteAlternativeTitles", () => {
 
     await addAlternativeTitles({
       courseId: course.id,
-      locale: "en",
+      language: "en",
       titles: [`javascript-${suffix}`],
     });
 
@@ -120,13 +120,13 @@ describe("deleteAlternativeTitles", () => {
 
     await addAlternativeTitles({
       courseId: course1.id,
-      locale: "en",
+      language: "en",
       titles: [`typescript-${suffix}`],
     });
 
     await addAlternativeTitles({
       courseId: course2.id,
-      locale: "en",
+      language: "en",
       titles: [`go-programming-${suffix}`],
     });
 

--- a/apps/editor/src/data/alternative-titles/export-alternative-titles.test.ts
+++ b/apps/editor/src/data/alternative-titles/export-alternative-titles.test.ts
@@ -25,10 +25,10 @@ describe("exportAlternativeTitles", () => {
       data: [
         {
           courseId: course.id,
-          locale: "en",
+          language: "en",
           slug: `machine-learning-${suffix}`,
         },
-        { courseId: course.id, locale: "en", slug: `ml-basics-${suffix}` },
+        { courseId: course.id, language: "en", slug: `ml-basics-${suffix}` },
       ],
     });
 
@@ -62,9 +62,17 @@ describe("exportAlternativeTitles", () => {
 
     await prisma.courseAlternativeTitle.createMany({
       data: [
-        { courseId: course.id, locale: "en", slug: `zebra-learning-${suffix}` },
-        { courseId: course.id, locale: "en", slug: `alpha-course-${suffix}` },
-        { courseId: course.id, locale: "en", slug: `beta-training-${suffix}` },
+        {
+          courseId: course.id,
+          language: "en",
+          slug: `zebra-learning-${suffix}`,
+        },
+        { courseId: course.id, language: "en", slug: `alpha-course-${suffix}` },
+        {
+          courseId: course.id,
+          language: "en",
+          slug: `beta-training-${suffix}`,
+        },
       ],
     });
 

--- a/apps/editor/src/data/alternative-titles/import-alternative-titles.test.ts
+++ b/apps/editor/src/data/alternative-titles/import-alternative-titles.test.ts
@@ -32,7 +32,7 @@ describe("importAlternativeTitles", () => {
     const result = await importAlternativeTitles({
       courseId: course.id,
       file,
-      locale: "en",
+      language: "en",
     });
 
     expect(result.error).toBeNull();
@@ -56,7 +56,7 @@ describe("importAlternativeTitles", () => {
     const result = await importAlternativeTitles({
       courseId: 999_999,
       file,
-      locale: "en",
+      language: "en",
     });
 
     expect(result.error?.message).toBe(ErrorCode.courseNotFound);
@@ -71,7 +71,7 @@ describe("importAlternativeTitles", () => {
     await prisma.courseAlternativeTitle.create({
       data: {
         courseId: course.id,
-        locale: "en",
+        language: "en",
         slug: `existing-title-${suffix}`,
       },
     });
@@ -84,7 +84,7 @@ describe("importAlternativeTitles", () => {
     const result = await importAlternativeTitles({
       courseId: course.id,
       file,
-      locale: "en",
+      language: "en",
     });
 
     expect(result.error).toBeNull();
@@ -108,7 +108,7 @@ describe("importAlternativeTitles", () => {
     await prisma.courseAlternativeTitle.create({
       data: {
         courseId: course.id,
-        locale: "en",
+        language: "en",
         slug: `old-title-${suffix}`,
       },
     });
@@ -118,7 +118,7 @@ describe("importAlternativeTitles", () => {
     const result = await importAlternativeTitles({
       courseId: course.id,
       file,
-      locale: "en",
+      language: "en",
       mode: "replace",
     });
 
@@ -133,17 +133,21 @@ describe("importAlternativeTitles", () => {
     expect(titles[0]?.slug).toBe(`new-title-${suffix}`);
   });
 
-  test("replace mode only removes titles for the specified locale", async () => {
+  test("replace mode only removes titles for the specified language", async () => {
     const suffix = randomUUID().slice(0, 8);
     const organization = await organizationFixture();
     const course = await courseFixture({ organizationId: organization.id });
 
     await prisma.courseAlternativeTitle.createMany({
       data: [
-        { courseId: course.id, locale: "en", slug: `english-title-${suffix}` },
         {
           courseId: course.id,
-          locale: "pt",
+          language: "en",
+          slug: `english-title-${suffix}`,
+        },
+        {
+          courseId: course.id,
+          language: "pt",
           slug: `portuguese-title-${suffix}`,
         },
       ],
@@ -154,27 +158,27 @@ describe("importAlternativeTitles", () => {
     const result = await importAlternativeTitles({
       courseId: course.id,
       file,
-      locale: "en",
+      language: "en",
       mode: "replace",
     });
 
     expect(result.error).toBeNull();
 
     const allTitles = await prisma.courseAlternativeTitle.findMany({
-      orderBy: { locale: "asc" },
-      select: { locale: true, slug: true },
+      orderBy: { language: "asc" },
+      select: { language: true, slug: true },
       where: { courseId: course.id },
     });
 
     expect(allTitles).toHaveLength(2);
 
     expect(allTitles).toContainEqual({
-      locale: "en",
+      language: "en",
       slug: `new-english-title-${suffix}`,
     });
 
     expect(allTitles).toContainEqual({
-      locale: "pt",
+      language: "pt",
       slug: `portuguese-title-${suffix}`,
     });
   });
@@ -194,7 +198,7 @@ describe("importAlternativeTitles", () => {
     const result = await importAlternativeTitles({
       courseId: course.id,
       file,
-      locale: "en",
+      language: "en",
     });
 
     expect(result.error).toBeNull();
@@ -217,7 +221,7 @@ describe("importAlternativeTitles", () => {
     const result = await importAlternativeTitles({
       courseId: course.id,
       file,
-      locale: "en",
+      language: "en",
     });
 
     expect(result.error).toBeNull();
@@ -235,7 +239,7 @@ describe("importAlternativeTitles", () => {
       const result = await importAlternativeTitles({
         courseId: course.id,
         file,
-        locale: "en",
+        language: "en",
       });
 
       expect(result.error?.message).toBe(ErrorCode.fileTooLarge);
@@ -252,7 +256,7 @@ describe("importAlternativeTitles", () => {
       const result = await importAlternativeTitles({
         courseId: course.id,
         file,
-        locale: "en",
+        language: "en",
       });
 
       expect(result.error?.message).toBe(ErrorCode.invalidFileType);
@@ -267,7 +271,7 @@ describe("importAlternativeTitles", () => {
       const result = await importAlternativeTitles({
         courseId: course.id,
         file,
-        locale: "en",
+        language: "en",
       });
 
       expect(result.error?.message).toBe(ErrorCode.invalidJsonFormat);
@@ -282,7 +286,7 @@ describe("importAlternativeTitles", () => {
       const result = await importAlternativeTitles({
         courseId: course.id,
         file,
-        locale: "en",
+        language: "en",
       });
 
       expect(result.error?.message).toBe(
@@ -303,7 +307,7 @@ describe("importAlternativeTitles", () => {
       const result = await importAlternativeTitles({
         courseId: course.id,
         file,
-        locale: "en",
+        language: "en",
       });
 
       expect(result.error?.message).toBe(
@@ -324,7 +328,7 @@ describe("importAlternativeTitles", () => {
       const result = await importAlternativeTitles({
         courseId: course.id,
         file,
-        locale: "en",
+        language: "en",
       });
 
       expect(result.error?.message).toBe(
@@ -345,7 +349,7 @@ describe("importAlternativeTitles", () => {
       const result = await importAlternativeTitles({
         courseId: course.id,
         file,
-        locale: "en",
+        language: "en",
       });
 
       expect(result.error?.message).toBe(
@@ -367,7 +371,7 @@ describe("importAlternativeTitles", () => {
       const result = await importAlternativeTitles({
         courseId: course.id,
         file,
-        locale: "en",
+        language: "en",
       });
 
       expect(result.error).toBeNull();

--- a/apps/editor/src/data/alternative-titles/import-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/import-alternative-titles.ts
@@ -33,7 +33,7 @@ function validateImportData(data: unknown): data is AlternativeTitlesImport {
 export async function importAlternativeTitles(params: {
   courseId: number;
   file: File;
-  locale: string;
+  language: string;
   mode?: ImportMode;
 }): Promise<SafeReturn<string[]>> {
   const mode = params.mode ?? "merge";
@@ -73,14 +73,14 @@ export async function importAlternativeTitles(params: {
     prisma.$transaction(async (tx) => {
       if (mode === "replace") {
         await tx.courseAlternativeTitle.deleteMany({
-          where: { courseId: params.courseId, locale: params.locale },
+          where: { courseId: params.courseId, language: params.language },
         });
       }
 
       await tx.courseAlternativeTitle.createMany({
         data: uniqueSlugs.map((slug) => ({
           courseId: params.courseId,
-          locale: params.locale,
+          language: params.language,
           slug,
         })),
         skipDuplicates: true,

--- a/apps/editor/src/data/alternative-titles/list-alternative-titles.test.ts
+++ b/apps/editor/src/data/alternative-titles/list-alternative-titles.test.ts
@@ -14,7 +14,7 @@ describe("listAlternativeTitles", () => {
 
     await addAlternativeTitles({
       courseId: course.id,
-      locale: "en",
+      language: "en",
       titles: [`aaa-${suffix}`, `bbb-${suffix}`, `ccc-${suffix}`],
     });
 
@@ -40,7 +40,7 @@ describe("listAlternativeTitles", () => {
 
     await addAlternativeTitles({
       courseId: course.id,
-      locale: "en",
+      language: "en",
       titles: [`zebra-${suffix}`, `apple-${suffix}`, `mango-${suffix}`],
     });
 
@@ -61,7 +61,7 @@ describe("listAlternativeTitles", () => {
 
     await addAlternativeTitles({
       courseId: course.id,
-      locale: "en",
+      language: "en",
       titles: [`foo-${suffix}`, `bar-${suffix}`],
     });
 

--- a/apps/evals/README.md
+++ b/apps/evals/README.md
@@ -31,7 +31,7 @@ export const TEST_CASES = [
   {
     id: "unique-test-case-id",
     userInput: {
-      locale: "en",
+      language: "en",
       prompt: "your test input",
     },
     expectations: `

--- a/apps/evals/src/tasks/alternative-titles/test-cases.ts
+++ b/apps/evals/src/tasks/alternative-titles/test-cases.ts
@@ -38,7 +38,7 @@ export const TEST_CASES = [
     `,
     id: "en-frontend-development",
     userInput: {
-      locale: "en",
+      language: "en",
       title: "Frontend Development",
     },
   },
@@ -54,7 +54,7 @@ export const TEST_CASES = [
     `,
     id: "en-formula-1",
     userInput: {
-      locale: "en",
+      language: "en",
       title: "Formula 1",
     },
   },
@@ -70,7 +70,7 @@ export const TEST_CASES = [
     `,
     id: "en-ux-design",
     userInput: {
-      locale: "en",
+      language: "en",
       title: "UX Design",
     },
   },
@@ -88,7 +88,7 @@ export const TEST_CASES = [
     `,
     id: "pt-ingles",
     userInput: {
-      locale: "pt",
+      language: "pt",
       title: "Inglês",
     },
   },
@@ -104,7 +104,7 @@ export const TEST_CASES = [
     `,
     id: "pt-inteligencia-artificial",
     userInput: {
-      locale: "pt",
+      language: "pt",
       title: "Inteligência Artificial",
     },
   },
@@ -118,7 +118,7 @@ export const TEST_CASES = [
     `,
     id: "en-machine-learning",
     userInput: {
-      locale: "en",
+      language: "en",
       title: "Machine Learning",
     },
   },
@@ -132,7 +132,7 @@ export const TEST_CASES = [
     `,
     id: "en-javascript",
     userInput: {
-      locale: "en",
+      language: "en",
       title: "JavaScript",
     },
   },
@@ -146,7 +146,7 @@ export const TEST_CASES = [
     `,
     id: "en-python",
     userInput: {
-      locale: "en",
+      language: "en",
       title: "Python",
     },
   },
@@ -159,7 +159,7 @@ export const TEST_CASES = [
     `,
     id: "es-desarrollo-web",
     userInput: {
-      locale: "es",
+      language: "es",
       title: "Desarrollo Web",
     },
   },
@@ -172,7 +172,7 @@ export const TEST_CASES = [
     `,
     id: "en-data-science",
     userInput: {
-      locale: "en",
+      language: "en",
       title: "Data Science",
     },
   },
@@ -188,7 +188,7 @@ export const TEST_CASES = [
     `,
     id: "en-the-matrix",
     userInput: {
-      locale: "en",
+      language: "en",
       title: "The Matrix",
     },
   },
@@ -202,7 +202,7 @@ export const TEST_CASES = [
     `,
     id: "en-calculus",
     userInput: {
-      locale: "en",
+      language: "en",
       title: "Calculus",
     },
   },
@@ -216,7 +216,7 @@ export const TEST_CASES = [
     `,
     id: "en-world-war-2",
     userInput: {
-      locale: "en",
+      language: "en",
       title: "World War II",
     },
   },

--- a/apps/evals/src/tasks/chapter-lessons/test-cases.ts
+++ b/apps/evals/src/tasks/chapter-lessons/test-cases.ts
@@ -12,7 +12,7 @@ const SHARED_EXPECTATIONS = `
   - Don't include summary or review lessons. For example, do NOT create a lesson title "Summary of Key Concepts" or "Review of Chapter"
   - Don't include assessment or quiz lessons
   - Don't include final project or capstone lessons
-  - Should follow the language specified by locale parameter
+  - Should follow the language specified by language parameter
   - Should follow title and description guidelines: no fluff, be concise, straight to the point
   - Descriptions should be concise and straight to the point, no fluff/filler words (avoid "learn", "understand", "explore", "introduction to", etc.)
   - You don't need to evaluate the output format here, just focus on the lesson content quality
@@ -41,7 +41,7 @@ export const TEST_CASES = [
         "Structure and semantics of web content using HTML: Elements, attributes, forms, multimedia, and accessibility.",
       chapterTitle: "HTML",
       courseTitle: "Web Development",
-      locale: "en",
+      language: "en",
     },
   },
   {
@@ -59,7 +59,7 @@ export const TEST_CASES = [
         "Iónico, covalente y metálico; VSEPR, enlace de valencia, orbitales moleculares, hibridación y polaridad.",
       chapterTitle: "Enlace químico y estructura molecular",
       courseTitle: "Química",
-      locale: "es",
+      language: "es",
     },
   },
   {
@@ -79,7 +79,7 @@ export const TEST_CASES = [
         "OLS geometry, assumptions, identification, Gauss–Markov, hypothesis testing, and model diagnostics.",
       chapterTitle: "Econometric Theory I: Linear Models",
       courseTitle: "Economics",
-      locale: "en",
+      language: "en",
     },
   },
   {
@@ -97,7 +97,7 @@ export const TEST_CASES = [
         "Papéis, eventos e artefatos; Definition of Done/Ready, refinamento eficaz e anti‑padrões comuns.",
       chapterTitle: "Scrum na Prática",
       courseTitle: "Metodologias Ágeis",
-      locale: "pt",
+      language: "pt",
     },
   },
   {
@@ -115,7 +115,7 @@ export const TEST_CASES = [
         "Influence, doubt, emotion, denial, volition, and impersonal expressions with triggers.",
       chapterTitle: "Subjunctive: Noun Clauses",
       courseTitle: "Spanish",
-      locale: "en",
+      language: "en",
     },
   },
   {
@@ -134,7 +134,7 @@ export const TEST_CASES = [
         "Fundamental principles, fundamental rights and guarantees, State organization, Union powers, constitutionality control.",
       chapterTitle: "Constitutional Law",
       courseTitle: "Brazilian Law",
-      locale: "en",
+      language: "en",
     },
   },
   {
@@ -153,7 +153,7 @@ export const TEST_CASES = [
         "Types of magic, wand lore, spell categories, nonverbal magic, wandless magic, and the limits of magic.",
       chapterTitle: "The Magic System",
       courseTitle: "Harry Potter",
-      locale: "en",
+      language: "en",
     },
   },
   {
@@ -168,7 +168,7 @@ export const TEST_CASES = [
         "Competências nucleares, portfólio de projetos e branding profissional. Estratégias de estágio, bolsas e entrevistas.",
       chapterTitle: "Mapeando uma trajetória de carreira",
       courseTitle: "Neurociência",
-      locale: "pt",
+      language: "pt",
     },
   },
   {
@@ -183,7 +183,7 @@ export const TEST_CASES = [
         "Project selection, case studies, technical writing, talks, and community presence.",
       chapterTitle: "Portfolio & personal branding",
       courseTitle: "Web Development",
-      locale: "en",
+      language: "en",
     },
   },
 ];

--- a/apps/evals/src/tasks/course-chapters/test-cases.ts
+++ b/apps/evals/src/tasks/course-chapters/test-cases.ts
@@ -4,7 +4,7 @@ const SHARED_EXPECTATIONS = `
   - By the end of this course, they should be able to lead very complex projects and tasks in this field
   - They should be prepared for certifications or advanced studies in this subject like a master's degree or PhD
   - Should include **EVERYTHING** a student needs to be at the top 1% of the field
-  - Should follow the language specified by locale parameter
+  - Should follow the language specified by language parameter
   - Should follow title and description guidelines: no fluff, be concise, straight to the point
   - Should cover latest trends in the field
   - Don't use vendors in chapter titles or descriptions (e.g. "npm", "yarn", "Redux", etc.)
@@ -34,7 +34,7 @@ export const TEST_CASES = [
       ${SHARED_EXPECTATIONS}
     `,
     id: "pt-python",
-    userInput: { courseTitle: "Python", locale: "pt" },
+    userInput: { courseTitle: "Python", language: "pt" },
   },
   {
     expectations: `
@@ -44,7 +44,7 @@ export const TEST_CASES = [
       ${SHARED_EXPECTATIONS}
     `,
     id: "en-web-development",
-    userInput: { courseTitle: "Web Development", locale: "en" },
+    userInput: { courseTitle: "Web Development", language: "en" },
   },
   {
     expectations: `
@@ -54,7 +54,7 @@ export const TEST_CASES = [
       ${SHARED_EXPECTATIONS}
     `,
     id: "pt-metodologias-ageis",
-    userInput: { courseTitle: "Metodologias Ágeis", locale: "pt" },
+    userInput: { courseTitle: "Metodologias Ágeis", language: "pt" },
   },
   {
     expectations: `
@@ -63,7 +63,7 @@ export const TEST_CASES = [
       ${SHARED_EXPECTATIONS}
     `,
     id: "es-quimica",
-    userInput: { courseTitle: "Química", locale: "es" },
+    userInput: { courseTitle: "Química", language: "es" },
   },
   {
     expectations: `
@@ -72,7 +72,7 @@ export const TEST_CASES = [
       ${SHARED_EXPECTATIONS}
     `,
     id: "en-economics",
-    userInput: { courseTitle: "Economics", locale: "en" },
+    userInput: { courseTitle: "Economics", language: "en" },
   },
   {
     expectations: `
@@ -81,7 +81,7 @@ export const TEST_CASES = [
       ${SHARED_EXPECTATIONS}
     `,
     id: "pt-neurociencia",
-    userInput: { courseTitle: "Neurociência", locale: "pt" },
+    userInput: { courseTitle: "Neurociência", language: "pt" },
   },
   {
     expectations: `
@@ -95,7 +95,7 @@ export const TEST_CASES = [
       ${SHARED_EXPECTATIONS}
     `,
     id: "en-spanish",
-    userInput: { courseTitle: "Spanish", locale: "en" },
+    userInput: { courseTitle: "Spanish", language: "en" },
   },
   {
     expectations: `
@@ -105,7 +105,7 @@ export const TEST_CASES = [
       ${SHARED_EXPECTATIONS}
     `,
     id: "pt-direito",
-    userInput: { courseTitle: "Direito", locale: "pt" },
+    userInput: { courseTitle: "Direito", language: "pt" },
   },
   {
     expectations: `
@@ -115,7 +115,7 @@ export const TEST_CASES = [
       ${SHARED_EXPECTATIONS}
     `,
     id: "en-google-cloud",
-    userInput: { courseTitle: "Google Cloud", locale: "en" },
+    userInput: { courseTitle: "Google Cloud", language: "en" },
   },
   {
     expectations: `
@@ -125,7 +125,7 @@ export const TEST_CASES = [
       ${SHARED_EXPECTATIONS}
     `,
     id: "en-uk-law",
-    userInput: { courseTitle: "UK Law", locale: "en" },
+    userInput: { courseTitle: "UK Law", language: "en" },
   },
   {
     expectations: `
@@ -134,7 +134,7 @@ export const TEST_CASES = [
       ${SHARED_EXPECTATIONS}
     `,
     id: "en-brazilian-history",
-    userInput: { courseTitle: "Brazilian History", locale: "en" },
+    userInput: { courseTitle: "Brazilian History", language: "en" },
   },
   {
     expectations: `
@@ -144,6 +144,6 @@ export const TEST_CASES = [
         ${SHARED_EXPECTATIONS}
       `,
     id: "en-harry-potter",
-    userInput: { courseTitle: "Harry Potter", locale: "en" },
+    userInput: { courseTitle: "Harry Potter", language: "en" },
   },
 ];

--- a/apps/evals/src/tasks/course-description/test-cases.ts
+++ b/apps/evals/src/tasks/course-description/test-cases.ts
@@ -26,7 +26,7 @@ export const TEST_CASES = [
     `,
     id: "en-frontend-development",
     userInput: {
-      locale: "en",
+      language: "en",
       title: "Frontend Development",
     },
   },
@@ -41,7 +41,7 @@ export const TEST_CASES = [
     `,
     id: "en-french",
     userInput: {
-      locale: "en",
+      language: "en",
       title: "French",
     },
   },
@@ -56,7 +56,7 @@ export const TEST_CASES = [
     `,
     id: "pt-inteligencia-artificial",
     userInput: {
-      locale: "pt",
+      language: "pt",
       title: "Inteligência Artificial",
     },
   },
@@ -71,7 +71,7 @@ export const TEST_CASES = [
     `,
     id: "es-desarrollo-web",
     userInput: {
-      locale: "es",
+      language: "es",
       title: "Desarrollo Web",
     },
   },
@@ -86,7 +86,7 @@ export const TEST_CASES = [
     `,
     id: "en-the-matrix",
     userInput: {
-      locale: "en",
+      language: "en",
       title: "The Matrix",
     },
   },

--- a/apps/evals/src/tasks/course-suggestions/test-cases.ts
+++ b/apps/evals/src/tasks/course-suggestions/test-cases.ts
@@ -19,7 +19,7 @@ export const TEST_CASES = [
     `,
     id: "pt-want-to-code",
     userInput: {
-      locale: "pt",
+      language: "pt",
       prompt: "I want to code",
     },
   },
@@ -33,7 +33,7 @@ export const TEST_CASES = [
     `,
     id: "en-black-holes",
     userInput: {
-      locale: "en",
+      language: "en",
       prompt: "quero aprender sobre buracos negros",
     },
   },
@@ -47,7 +47,7 @@ export const TEST_CASES = [
     `,
     id: "es-derecho-penal",
     userInput: {
-      locale: "es",
+      language: "es",
       prompt: "derecho penal",
     },
   },
@@ -61,7 +61,7 @@ export const TEST_CASES = [
     `,
     id: "es-derecho-chileno",
     userInput: {
-      locale: "es",
+      language: "es",
       prompt: "derecho chileno",
     },
   },
@@ -75,7 +75,7 @@ export const TEST_CASES = [
     `,
     id: "pt-toefl",
     userInput: {
-      locale: "pt",
+      language: "pt",
       prompt: "quero passar no TOEFL",
     },
   },
@@ -90,7 +90,7 @@ export const TEST_CASES = [
     `,
     id: "pt-physics-and-chemistry",
     userInput: {
-      locale: "pt",
+      language: "pt",
       prompt: "physics and chemistry",
     },
   },
@@ -105,7 +105,7 @@ export const TEST_CASES = [
     `,
     id: "en-intro-to-chemistry",
     userInput: {
-      locale: "en",
+      language: "en",
       prompt: "i want an intro to chemistry",
     },
   },
@@ -119,7 +119,7 @@ export const TEST_CASES = [
     `,
     id: "pt-dragon-ball",
     userInput: {
-      locale: "pt",
+      language: "pt",
       prompt: "dragon bals",
     },
   },
@@ -133,7 +133,7 @@ export const TEST_CASES = [
     `,
     id: "en-beatles",
     userInput: {
-      locale: "en",
+      language: "en",
       prompt: "beatles",
     },
   },
@@ -147,7 +147,7 @@ export const TEST_CASES = [
     `,
     id: "fr-f1",
     userInput: {
-      locale: "fr",
+      language: "fr",
       prompt: "f1",
     },
   },
@@ -163,7 +163,7 @@ export const TEST_CASES = [
     `,
     id: "en-jlpt-n2",
     userInput: {
-      locale: "en",
+      language: "en",
       prompt: "i want to pass the JLPT N2",
     },
   },
@@ -178,7 +178,7 @@ export const TEST_CASES = [
     `,
     id: "pt-ielts-academic",
     userInput: {
-      locale: "pt",
+      language: "pt",
       prompt: "quero passar no IELTS Academic",
     },
   },
@@ -192,7 +192,7 @@ export const TEST_CASES = [
     `,
     id: "en-how-computers-work",
     userInput: {
-      locale: "en",
+      language: "en",
       prompt: "how do computers work",
     },
   },
@@ -207,7 +207,7 @@ export const TEST_CASES = [
     `,
     id: "pt-periodic-table",
     userInput: {
-      locale: "pt",
+      language: "pt",
       prompt: "tabela periódica",
     },
   },
@@ -222,7 +222,7 @@ export const TEST_CASES = [
     `,
     id: "en-matrix-movie",
     userInput: {
-      locale: "en",
+      language: "en",
       prompt: "matrix movie",
     },
   },
@@ -236,7 +236,7 @@ export const TEST_CASES = [
     `,
     id: "en-ai",
     userInput: {
-      locale: "en",
+      language: "en",
       prompt: "ai",
     },
   },
@@ -250,7 +250,7 @@ export const TEST_CASES = [
     `,
     id: "en-wealth-of-nations",
     userInput: {
-      locale: "en",
+      language: "en",
       prompt: "wealth of nations",
     },
   },

--- a/apps/main/src/app/[locale]/(catalog)/learn/[prompt]/course-suggestions.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/learn/[prompt]/course-suggestions.tsx
@@ -34,7 +34,7 @@ export async function CourseSuggestions({
 }: CourseSuggestionsProps) {
   const t = await getExtracted();
   const { id, suggestions } = await generateCourseSuggestions({
-    locale,
+    language: locale,
     prompt,
   });
 

--- a/apps/main/src/data/courses/course-suggestions.test.ts
+++ b/apps/main/src/data/courses/course-suggestions.test.ts
@@ -10,7 +10,7 @@ import {
 test("get an existing item", async () => {
   const spy = vi.spyOn(courseSuggestions, "generateCourseSuggestions");
 
-  const locale = "en";
+  const language = "en";
   const prompt = `typescript-${randomUUID()}`;
 
   const suggestions = [
@@ -18,12 +18,12 @@ test("get an existing item", async () => {
   ];
 
   await prisma.courseSuggestion.upsert({
-    create: { locale, prompt, suggestions },
+    create: { language, prompt, suggestions },
     update: { suggestions },
-    where: { localePrompt: { locale, prompt } },
+    where: { languagePrompt: { language, prompt } },
   });
 
-  const result = await generateCourseSuggestions({ locale, prompt });
+  const result = await generateCourseSuggestions({ language, prompt });
 
   expect(result.suggestions).toEqual(suggestions);
   expect(result.id).toBeTypeOf("number");
@@ -33,7 +33,7 @@ test("get an existing item", async () => {
 test("generates a new item", async () => {
   const spy = vi.spyOn(courseSuggestions, "generateCourseSuggestions");
 
-  const locale = "en";
+  const language = "en";
   const prompt = `vitest-${randomUUID()}`;
 
   const generatedSuggestions = [
@@ -42,14 +42,14 @@ test("generates a new item", async () => {
 
   spy.mockResolvedValueOnce({ data: generatedSuggestions } as never);
 
-  const result = await generateCourseSuggestions({ locale, prompt });
+  const result = await generateCourseSuggestions({ language, prompt });
 
   expect(result.suggestions).toEqual(generatedSuggestions);
   expect(result.id).toBeTypeOf("number");
   expect(spy).toHaveBeenCalledOnce();
 
   // check if the record was added to the database
-  const record = await generateCourseSuggestions({ locale, prompt });
+  const record = await generateCourseSuggestions({ language, prompt });
   expect(record.suggestions).toEqual(generatedSuggestions);
   expect(record.id).toBe(result.id);
   expect(spy).toHaveBeenCalledOnce();
@@ -61,20 +61,20 @@ test("getCourseSuggestionById returns null for non-existent id", async () => {
 });
 
 test("getCourseSuggestionById returns suggestion by id", async () => {
-  const locale = "en";
+  const language = "en";
   const prompt = `by-id-${randomUUID()}`;
   const suggestions = [
     { description: "Test description", title: "Test Course" },
   ];
 
   const record = await prisma.courseSuggestion.create({
-    data: { locale, prompt, suggestions },
+    data: { language, prompt, suggestions },
   });
 
   const result = await getCourseSuggestionById(record.id);
 
   expect(result).toEqual({
-    locale,
+    language,
     prompt,
     suggestions,
   });

--- a/apps/main/src/data/courses/course-suggestions.ts
+++ b/apps/main/src/data/courses/course-suggestions.ts
@@ -10,46 +10,46 @@ type Suggestion = {
 };
 
 async function findCourseSuggestion(params: {
-  locale: string;
+  language: string;
   prompt: string;
 }) {
-  const { locale, prompt: rawPrompt } = params;
+  const { language, prompt: rawPrompt } = params;
   const prompt = normalizeString(rawPrompt);
 
   return prisma.courseSuggestion.findUnique({
-    where: { localePrompt: { locale, prompt } },
+    where: { languagePrompt: { language, prompt } },
   });
 }
 
 async function upsertCourseSuggestion(input: {
-  locale: string;
+  language: string;
   prompt: string;
   suggestions: Suggestion[];
 }) {
-  const { locale, prompt: rawPrompt, suggestions } = input;
+  const { language, prompt: rawPrompt, suggestions } = input;
   const prompt = normalizeString(rawPrompt);
 
   return prisma.courseSuggestion.upsert({
-    create: { locale, prompt, suggestions },
+    create: { language, prompt, suggestions },
     update: { suggestions },
-    where: { localePrompt: { locale, prompt } },
+    where: { languagePrompt: { language, prompt } },
   });
 }
 
 export async function generateCourseSuggestions({
-  locale,
+  language,
   prompt,
 }: {
-  locale: string;
+  language: string;
   prompt: string;
 }): Promise<{ id: number; suggestions: Suggestion[] }> {
-  const record = await findCourseSuggestion({ locale, prompt });
+  const record = await findCourseSuggestion({ language, prompt });
 
   if (!record) {
-    const { data } = await generateTask({ locale, prompt });
+    const { data } = await generateTask({ language, prompt });
 
     const newRecord = await upsertCourseSuggestion({
-      locale,
+      language,
       prompt,
       suggestions: data,
     });
@@ -61,12 +61,12 @@ export async function generateCourseSuggestions({
 }
 
 export async function getCourseSuggestionById(id: number): Promise<{
-  locale: string;
+  language: string;
   prompt: string;
   suggestions: Suggestion[];
 } | null> {
   const record = await prisma.courseSuggestion.findUnique({
-    select: { locale: true, prompt: true, suggestions: true },
+    select: { language: true, prompt: true, suggestions: true },
     where: { id },
   });
 
@@ -75,7 +75,7 @@ export async function getCourseSuggestionById(id: number): Promise<{
   }
 
   return {
-    locale: record.locale,
+    language: record.language,
     prompt: record.prompt,
     suggestions: record.suggestions as Suggestion[],
   };

--- a/packages/ai/src/alternative-titles/generate-alternative-titles.ts
+++ b/packages/ai/src/alternative-titles/generate-alternative-titles.ts
@@ -22,20 +22,20 @@ export type AlternativeTitlesSchema = z.infer<typeof schema>;
 
 export type AlternativeTitlesParams = {
   title: string;
-  locale: string;
+  language: string;
   model?: string;
   useFallback?: boolean;
 };
 
 export async function generateAlternativeTitles({
   title,
-  locale,
+  language,
   model = DEFAULT_MODEL,
   useFallback = true,
 }: AlternativeTitlesParams) {
   const userPrompt = `
     TITLE: ${title}
-    LANGUAGE: ${locale}
+    LANGUAGE: ${language}
   `;
 
   const { output, usage } = await generateText({

--- a/packages/ai/src/chapter-lessons/generate-chapter-lessons.ts
+++ b/packages/ai/src/chapter-lessons/generate-chapter-lessons.ts
@@ -28,7 +28,7 @@ export type ChapterLessonsParams = {
   chapterDescription: string;
   chapterTitle: string;
   courseTitle: string;
-  locale: string;
+  language: string;
   model?: string;
   useFallback?: boolean;
 };
@@ -37,12 +37,12 @@ export async function generateChapterLessons({
   chapterDescription,
   chapterTitle,
   courseTitle,
-  locale,
+  language,
   model = DEFAULT_MODEL,
   useFallback = true,
 }: ChapterLessonsParams) {
   const userPrompt = `
-    LANGUAGE: ${locale}
+    LANGUAGE: ${language}
     COURSE_TITLE: ${courseTitle}
     CHAPTER_TITLE: ${chapterTitle}
     CHAPTER_DESCRIPTION: ${chapterDescription}

--- a/packages/ai/src/course-chapters/generate-course-chapters.ts
+++ b/packages/ai/src/course-chapters/generate-course-chapters.ts
@@ -28,20 +28,20 @@ const schema = z.object({
 export type CourseChaptersSchema = z.infer<typeof schema>;
 
 export type CourseChaptersParams = {
-  locale: string;
+  language: string;
   courseTitle: string;
   model?: string;
   useFallback?: boolean;
 };
 
 export async function generateCourseChapters({
-  locale,
+  language,
   courseTitle,
   model = DEFAULT_MODEL,
   useFallback = true,
 }: CourseChaptersParams) {
   const userPrompt = `
-    LANGUAGE: ${locale}
+    LANGUAGE: ${language}
     COURSE_TITLE: ${courseTitle}
   `;
 

--- a/packages/ai/src/course-description/generate-course-description.ts
+++ b/packages/ai/src/course-description/generate-course-description.ts
@@ -23,20 +23,20 @@ export type CourseDescriptionSchema = z.infer<typeof schema>;
 
 export type CourseDescriptionParams = {
   title: string;
-  locale: string;
+  language: string;
   model?: string;
   useFallback?: boolean;
 };
 
 export async function generateCourseDescription({
   title,
-  locale,
+  language,
   model = DEFAULT_MODEL,
   useFallback = true,
 }: CourseDescriptionParams) {
   const userPrompt = `
     COURSE_TITLE: ${title}
-    LANGUAGE: ${locale}
+    LANGUAGE: ${language}
   `;
 
   const { output, usage } = await generateText({

--- a/packages/ai/src/course-suggestions/course-suggestions.prompt.md
+++ b/packages/ai/src/course-suggestions/course-suggestions.prompt.md
@@ -6,7 +6,7 @@ You generate course suggestions from a user input.
 
 ### Language
 
-- Use the `APP_LANGUAGE` value set by the user for both `title` and `description`, no matter what's the language used in `USER_INPUT`
+- Use the `LANGUAGE` value set by the user for both `title` and `description`, no matter what's the language used in `USER_INPUT`
 - For `en`, default to US English unless the content is about a different region
 - For `pt`, default to Brazilian Portuguese unless the content is about a different region
 - For `es`, default to Latin American Spanish unless the content is about a different region

--- a/packages/ai/src/course-suggestions/generate-course-suggestions.ts
+++ b/packages/ai/src/course-suggestions/generate-course-suggestions.ts
@@ -27,20 +27,20 @@ const schema = z.object({
 export type CourseSuggestionSchema = z.infer<typeof schema>;
 
 export type CourseSuggestionsParams = {
-  locale: string;
+  language: string;
   prompt: string;
   model?: string;
   useFallback?: boolean;
 };
 
 export async function generateCourseSuggestions({
-  locale,
+  language,
   prompt,
   model = DEFAULT_MODEL,
   useFallback = true,
 }: CourseSuggestionsParams) {
   const userPrompt = `
-    APP_LANGUAGE: ${locale}
+    LANGUAGE: ${language}
     USER_INPUT: ${prompt}
   `;
 

--- a/packages/core/src/alternative-titles/add-alternative-titles.test.ts
+++ b/packages/core/src/alternative-titles/add-alternative-titles.test.ts
@@ -14,7 +14,7 @@ describe("addAlternativeTitles", () => {
 
     await addAlternativeTitles({
       courseId: course.id,
-      locale: "en",
+      language: "en",
       titles: [
         `Frontend Development ${suffix}`,
         `Frontend Engineering ${suffix}`,
@@ -41,7 +41,7 @@ describe("addAlternativeTitles", () => {
 
     await addAlternativeTitles({
       courseId: course.id,
-      locale: "en",
+      language: "en",
       titles: [`Machine Learning Basics! ${suffix}`],
     });
 
@@ -62,7 +62,7 @@ describe("addAlternativeTitles", () => {
 
     await addAlternativeTitles({
       courseId: course.id,
-      locale: "en",
+      language: "en",
       titles: [title, title, title.toLowerCase()],
     });
 
@@ -85,13 +85,13 @@ describe("addAlternativeTitles", () => {
 
     await addAlternativeTitles({
       courseId: course1.id,
-      locale: "en",
+      language: "en",
       titles: [sharedTitle],
     });
 
     await addAlternativeTitles({
       courseId: course2.id,
-      locale: "en",
+      language: "en",
       titles: [sharedTitle, uniqueTitle],
     });
 
@@ -109,7 +109,7 @@ describe("addAlternativeTitles", () => {
 
     await addAlternativeTitles({
       courseId: course.id,
-      locale: "en",
+      language: "en",
       titles: [],
     });
 
@@ -128,7 +128,7 @@ describe("addAlternativeTitles", () => {
 
     await addAlternativeTitles({
       courseId: course.id,
-      locale: "en",
+      language: "en",
       titles: ["", "   ", `Valid Title ${suffix}`],
     });
 

--- a/packages/core/src/alternative-titles/add-alternative-titles.ts
+++ b/packages/core/src/alternative-titles/add-alternative-titles.ts
@@ -6,7 +6,7 @@ import { toSlug } from "@zoonk/utils/string";
 export async function addAlternativeTitles(params: {
   courseId: number;
   titles: string[];
-  locale: string;
+  language: string;
 }): Promise<void> {
   const slugs = params.titles.map((title) => toSlug(title));
   const uniqueSlugs = [...new Set(slugs)].filter(Boolean);
@@ -18,7 +18,7 @@ export async function addAlternativeTitles(params: {
   await prisma.courseAlternativeTitle.createMany({
     data: uniqueSlugs.map((slug) => ({
       courseId: params.courseId,
-      locale: params.locale,
+      language: params.language,
       slug,
     })),
     skipDuplicates: true,

--- a/packages/core/src/alternative-titles/find-alternative-title.test.ts
+++ b/packages/core/src/alternative-titles/find-alternative-title.test.ts
@@ -27,12 +27,12 @@ describe("findAlternativeTitle", () => {
 
     await addAlternativeTitles({
       courseId: course.id,
-      locale: "en",
+      language: "en",
       titles: [uniqueTitle],
     });
 
     const result = await findAlternativeTitle({
-      locale: "en",
+      language: "en",
       title: uniqueTitle,
     });
 
@@ -50,12 +50,12 @@ describe("findAlternativeTitle", () => {
 
     await addAlternativeTitles({
       courseId: course.id,
-      locale: "en",
+      language: "en",
       titles: [uniqueTitle],
     });
 
     const result = await findAlternativeTitle({
-      locale: "en",
+      language: "en",
       title: uniqueTitle.toLowerCase(),
     });
 
@@ -64,7 +64,7 @@ describe("findAlternativeTitle", () => {
 
   test("returns null when title does not match", async () => {
     const result = await findAlternativeTitle({
-      locale: "en",
+      language: "en",
       title: `Nonexistent Course ${randomUUID()}`,
     });
 
@@ -82,12 +82,12 @@ describe("findAlternativeTitle", () => {
 
     await addAlternativeTitles({
       courseId: course.id,
-      locale: "en",
+      language: "en",
       titles: [uniqueTitle],
     });
 
     const result = await findAlternativeTitle({
-      locale: "en",
+      language: "en",
       title: uniqueTitle,
     });
 
@@ -105,12 +105,12 @@ describe("findAlternativeTitle", () => {
 
     await addAlternativeTitles({
       courseId: course.id,
-      locale: "en",
+      language: "en",
       titles: [uniqueTitle],
     });
 
     const result = await findAlternativeTitle({
-      locale: "pt",
+      language: "pt",
       title: uniqueTitle,
     });
 

--- a/packages/core/src/alternative-titles/find-alternative-title.ts
+++ b/packages/core/src/alternative-titles/find-alternative-title.ts
@@ -8,7 +8,7 @@ import { cache } from "react";
 export const findAlternativeTitle = cache(
   async (params: {
     title: string;
-    locale: string;
+    language: string;
   }): Promise<{ slug: string; language: string } | null> => {
     const slug = toSlug(params.title);
 
@@ -22,7 +22,7 @@ export const findAlternativeTitle = cache(
           },
         },
       },
-      where: { localeSlug: { locale: params.locale, slug } },
+      where: { languageSlug: { language: params.language, slug } },
     });
 
     if (!result || result.course.organization.slug !== AI_ORG_SLUG) {

--- a/packages/db/src/prisma/migrations/20260112180000_rename_locale_to_language/migration.sql
+++ b/packages/db/src/prisma/migrations/20260112180000_rename_locale_to_language/migration.sql
@@ -1,0 +1,9 @@
+-- CourseSuggestion: rename column and index
+ALTER TABLE "course_suggestions" RENAME COLUMN "locale" TO "language";
+DROP INDEX "course_suggestions_locale_prompt_key";
+CREATE UNIQUE INDEX "course_suggestions_language_prompt_key" ON "course_suggestions"("language", "prompt");
+
+-- CourseAlternativeTitle: rename column and index
+ALTER TABLE "course_alternative_titles" RENAME COLUMN "locale" TO "language";
+DROP INDEX "course_alternative_titles_locale_slug_key";
+CREATE UNIQUE INDEX "course_alternative_titles_language_slug_key" ON "course_alternative_titles"("language", "slug");

--- a/packages/db/src/prisma/models/courses.prisma
+++ b/packages/db/src/prisma/models/courses.prisma
@@ -1,12 +1,12 @@
 model CourseSuggestion {
   id          Int      @id @default(autoincrement())
-  locale      String   @db.VarChar(10)
+  language    String   @db.VarChar(10)
   prompt      String
   suggestions Json
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @default(now()) @updatedAt @map("updated_at")
 
-  @@unique([locale, prompt], name: "localePrompt")
+  @@unique([language, prompt], name: "languagePrompt")
   @@map("course_suggestions")
 }
 
@@ -40,10 +40,10 @@ model CourseAlternativeTitle {
   courseId  Int      @map("course_id")
   course    Course   @relation(fields: [courseId], references: [id], onDelete: Cascade)
   slug      String
-  locale    String   @db.VarChar(10)
+  language  String   @db.VarChar(10)
   createdAt DateTime @default(now()) @map("created_at")
 
-  @@unique([locale, slug], name: "localeSlug")
+  @@unique([language, slug], name: "languageSlug")
   @@index([courseId])
   @@map("course_alternative_titles")
 }

--- a/packages/db/src/prisma/seed/alternative-titles.ts
+++ b/packages/db/src/prisma/seed/alternative-titles.ts
@@ -6,7 +6,6 @@ const alternativeTitlesData = [
   {
     courseSlug: "machine-learning",
     language: "en",
-    locale: "en",
     titles: [
       "ML",
       "Machine Learning Fundamentals",
@@ -17,7 +16,6 @@ const alternativeTitlesData = [
   {
     courseSlug: "machine-learning",
     language: "pt",
-    locale: "pt",
     titles: ["ML", "Aprendizado de Máquina", "Introdução ao Machine Learning"],
   },
 ];
@@ -48,7 +46,7 @@ export async function seedAlternativeTitles(
       await prisma.courseAlternativeTitle.createMany({
         data: slugs.map((slug) => ({
           courseId: course.id,
-          locale: item.locale,
+          language: item.language,
           slug,
         })),
         skipDuplicates: true,

--- a/packages/db/src/prisma/seed/course-suggestions.ts
+++ b/packages/db/src/prisma/seed/course-suggestions.ts
@@ -7,7 +7,7 @@ export async function seedCourseSuggestions(
   // Seed course suggestions for predictable E2E tests
   await prisma.courseSuggestion.upsert({
     create: {
-      locale: "en",
+      language: "en",
       prompt: normalizeString("test prompt"),
       suggestions: [
         {
@@ -22,13 +22,16 @@ export async function seedCourseSuggestions(
     },
     update: {},
     where: {
-      localePrompt: { locale: "en", prompt: normalizeString("test prompt") },
+      languagePrompt: {
+        language: "en",
+        prompt: normalizeString("test prompt"),
+      },
     },
   });
 
   await prisma.courseSuggestion.upsert({
     create: {
-      locale: "pt",
+      language: "pt",
       prompt: normalizeString("test prompt"),
       suggestions: [
         {
@@ -43,7 +46,10 @@ export async function seedCourseSuggestions(
     },
     update: {},
     where: {
-      localePrompt: { locale: "pt", prompt: normalizeString("test prompt") },
+      languagePrompt: {
+        language: "pt",
+        prompt: normalizeString("test prompt"),
+      },
     },
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the locale field to language across the database, Prisma models, and app code for consistency. Adds a migration and updates all usages in editor, main, core, ai, and evals.

- **Refactors**
  - DB: course_suggestions and course_alternative_titles columns and unique indexes renamed to language (languagePrompt, languageSlug).
  - Prisma models and seeds updated to use language.
  - App code: replaced locale with language in params, queries, and selects; updated tests and E2E.
  - AI prompts: switched APP_LANGUAGE/locale references to LANGUAGE.

- **Migration**
  - Run prisma migrate deploy (or generate the client after applying the SQL migration).
  - Replace any remaining locale references in downstream code with language (params, where clauses, indexes).

<sup>Written for commit 4dbd9cb3c5fc196b451f3e659dbec8fb49ccec86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

