### PR TITLE
feat(main):  add findExistingCourse()

### DIFF
--- a/apps/main/src/data/courses/find-existing-course.test.ts
+++ b/apps/main/src/data/courses/find-existing-course.test.ts
@@ -131,7 +131,7 @@ describe("findExistingCourse", () => {
 
     await courseAlternativeTitleFixture({
       courseId: altCourse.id,
-      language: "pt",
+      language: "en",
       slug: uniqueSlug,
     });
 

--- a/apps/main/src/data/courses/find-existing-course.test.ts
+++ b/apps/main/src/data/courses/find-existing-course.test.ts
@@ -1,0 +1,193 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import {
+  courseAlternativeTitleFixture,
+  courseFixture,
+} from "@zoonk/testing/fixtures/courses";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { toSlug } from "@zoonk/utils/string";
+import { beforeAll, describe, expect, test } from "vitest";
+import { findExistingCourse } from "./find-existing-course";
+
+async function getOrCreateAIOrg() {
+  return prisma.organization.upsert({
+    create: { name: "AI", slug: AI_ORG_SLUG },
+    update: {},
+    where: { slug: AI_ORG_SLUG },
+  });
+}
+
+describe("findExistingCourse", () => {
+  let aiOrg: Awaited<ReturnType<typeof getOrCreateAIOrg>>;
+  let nonAiOrg: Awaited<ReturnType<typeof organizationFixture>>;
+
+  beforeAll(async () => {
+    [aiOrg, nonAiOrg] = await Promise.all([
+      getOrCreateAIOrg(),
+      organizationFixture(),
+    ]);
+  });
+
+  test("returns null when no course exists with slug/language", async () => {
+    const result = await findExistingCourse({
+      language: "en",
+      slug: "non-existent-course",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toBeNull();
+  });
+
+  test("returns course when found by slug + language in courses table (AI org)", async () => {
+    const uniqueSlug = `ai-course-slug-${randomUUID()}`;
+
+    const course = await courseFixture({
+      generationStatus: "completed",
+      language: "en",
+      organizationId: aiOrg.id,
+      slug: uniqueSlug,
+    });
+
+    const result = await findExistingCourse({
+      language: "en",
+      slug: uniqueSlug,
+    });
+
+    expect(result.error).toBeNull();
+
+    expect(result.data).toEqual({
+      generationStatus: course.generationStatus,
+      id: course.id,
+      slug: course.slug,
+    });
+  });
+
+  test("returns course when found by slug + language in alternative titles table", async () => {
+    const uniqueSlug = `original-course-slug-${randomUUID()}`;
+    const altSlug = `alternative-slug-${randomUUID()}`;
+
+    const course = await courseFixture({
+      generationStatus: "completed",
+      language: "en",
+      organizationId: aiOrg.id,
+      slug: uniqueSlug,
+    });
+
+    await courseAlternativeTitleFixture({
+      courseId: course.id,
+      language: "en",
+      slug: altSlug,
+    });
+
+    const result = await findExistingCourse({
+      language: "en",
+      slug: altSlug,
+    });
+
+    expect(result.error).toBeNull();
+
+    expect(result.data).toEqual({
+      generationStatus: course.generationStatus,
+      id: course.id,
+      slug: course.slug,
+    });
+  });
+
+  test("returns null for courses from non-AI organizations", async () => {
+    const uniqueSlug = `non-ai-course-${randomUUID()}`;
+
+    await courseFixture({
+      language: "en",
+      organizationId: nonAiOrg.id,
+      slug: uniqueSlug,
+    });
+
+    const result = await findExistingCourse({
+      language: "en",
+      slug: uniqueSlug,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toBeNull();
+  });
+
+  test("prioritizes direct course match over alternative title match", async () => {
+    const uniqueSlug = `priority-test-slug-${randomUUID()}`;
+
+    const directCourse = await courseFixture({
+      generationStatus: "completed",
+      language: "en",
+      organizationId: aiOrg.id,
+      slug: uniqueSlug,
+    });
+
+    const altCourse = await courseFixture({
+      generationStatus: "pending",
+      language: "en",
+      organizationId: aiOrg.id,
+      slug: `alt-course-for-priority-${randomUUID()}`,
+    });
+
+    await courseAlternativeTitleFixture({
+      courseId: altCourse.id,
+      language: "pt",
+      slug: uniqueSlug,
+    });
+
+    const result = await findExistingCourse({
+      language: "en",
+      slug: uniqueSlug,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.id).toBe(directCourse.id);
+    expect(result.data?.generationStatus).toBe("completed");
+  });
+
+  test("handles slug normalization", async () => {
+    const uniqueTitle = `My Course Title ${randomUUID()}`;
+
+    const course = await courseFixture({
+      language: "en",
+      organizationId: aiOrg.id,
+      slug: toSlug(uniqueTitle),
+    });
+
+    const result = await findExistingCourse({
+      language: "en",
+      slug: uniqueTitle,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.id).toBe(course.id);
+  });
+
+  test("handles different languages correctly", async () => {
+    const uniqueSlug = `language-test-course-${randomUUID()}`;
+
+    const [enCourse, ptCourse] = await Promise.all([
+      courseFixture({
+        language: "en",
+        organizationId: aiOrg.id,
+        slug: uniqueSlug,
+      }),
+      courseFixture({
+        language: "pt",
+        organizationId: aiOrg.id,
+        slug: uniqueSlug,
+      }),
+    ]);
+
+    const [enResult, ptResult] = await Promise.all([
+      findExistingCourse({ language: "en", slug: uniqueSlug }),
+      findExistingCourse({ language: "pt", slug: uniqueSlug }),
+    ]);
+
+    expect(enResult.error).toBeNull();
+    expect(enResult.data?.id).toBe(enCourse.id);
+
+    expect(ptResult.error).toBeNull();
+    expect(ptResult.data?.id).toBe(ptCourse.id);
+  });
+});

--- a/apps/main/src/data/courses/find-existing-course.ts
+++ b/apps/main/src/data/courses/find-existing-course.ts
@@ -1,0 +1,61 @@
+import "server-only";
+
+import { prisma } from "@zoonk/db";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { toSlug } from "@zoonk/utils/string";
+import { cache } from "react";
+
+type ExistingCourse = {
+  id: number;
+  slug: string;
+  generationStatus: string;
+};
+
+export const findExistingCourse = cache(
+  async (params: {
+    slug: string;
+    language: string;
+  }): Promise<SafeReturn<ExistingCourse | null>> => {
+    const normalizedSlug = toSlug(params.slug);
+
+    const { data, error } = await safeAsync(() =>
+      Promise.all([
+        prisma.course.findFirst({
+          select: { generationStatus: true, id: true, slug: true },
+          where: {
+            language: params.language,
+            organization: { slug: AI_ORG_SLUG },
+            slug: normalizedSlug,
+          },
+        }),
+        prisma.courseAlternativeTitle.findUnique({
+          select: {
+            course: {
+              select: { generationStatus: true, id: true, slug: true },
+            },
+          },
+          where: {
+            languageSlug: { language: params.language, slug: normalizedSlug },
+          },
+        }),
+      ]),
+    );
+
+    if (error) {
+      return { data: null, error };
+    }
+
+    const [courseMatch, alternativeTitleMatch] = data;
+
+    if (courseMatch) {
+      return { data: courseMatch, error: null };
+    }
+
+    if (alternativeTitleMatch) {
+      return { data: alternativeTitleMatch.course, error: null };
+    }
+
+    return { data: null, error: null };
+  },
+);

--- a/packages/testing/src/fixtures/courses.ts
+++ b/packages/testing/src/fixtures/courses.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import {
   type Course,
+  type CourseAlternativeTitle,
   type CourseCategory,
   type CourseUser,
   prisma,
@@ -55,4 +56,16 @@ export async function courseUserFixture(
   });
 
   return courseUser;
+}
+
+export async function courseAlternativeTitleFixture(
+  attrs: Omit<CourseAlternativeTitle, "id" | "createdAt">,
+) {
+  return prisma.courseAlternativeTitle.create({
+    data: {
+      courseId: attrs.courseId,
+      language: attrs.language,
+      slug: attrs.slug,
+    },
+  });
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add findExistingCourse() to resolve courses by slug and language within the AI org. Prevents duplicates by checking both courses and alternative titles.

- New Features
  - Server-only findExistingCourse(params) returns { id, slug, generationStatus } or null, wrapped in SafeReturn.
  - Normalizes input title to slug; direct course match takes priority over alternative title.
  - Uses React cache to memoize lookups.
  - Comprehensive tests for not found, direct vs. alternative matches, non-AI org rejection, slug normalization, and language-specific results.
  - Adds courseAlternativeTitleFixture for test data.

<sup>Written for commit aabd4f7e0838c913615d874d75eabc6bc7a33afc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

