### PR TITLE
refactor(main): add parent-children relationship to course suggestions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ For detailed UX guidelines (interactions, animation, layout, accessibility), see
 - When adding a new Prisma model, always add a seed for it in `packages/db/src/prisma/seed/`
 - Never run `pnpm dev` as there's already a dev server running
 - When writing a plan, don't include "manual verification" steps. We always do manual verification, you don't need to do it. Just ensure you add the necessary e2e tests for the task
+- Don't create migration files manually. Run `pnpm --filter @zoonk/db db:migrate --name <migration-name>` to generate migration
 
 ## Component Organization
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ For detailed UX guidelines (interactions, animation, layout, accessibility), see
 - When adding a new Prisma model, always add a seed for it in `packages/db/src/prisma/seed/`
 - Never run `pnpm dev` as there's already a dev server running
 - When writing a plan, don't include "manual verification" steps. We always do manual verification, you don't need to do it. Just ensure you add the necessary e2e tests for the task
+- Don't create migration files manually. Run `pnpm --filter @zoonk/db db:migrate --name <migration-name>` to generate migration
 
 ## Component Organization
 

--- a/apps/main/src/app/[locale]/(catalog)/learn/[prompt]/course-suggestions.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/learn/[prompt]/course-suggestions.tsx
@@ -33,7 +33,7 @@ export async function CourseSuggestions({
   prompt,
 }: CourseSuggestionsProps) {
   const t = await getExtracted();
-  const { id, suggestions } = await generateCourseSuggestions({
+  const { suggestions } = await generateCourseSuggestions({
     language: locale,
     prompt,
   });
@@ -57,7 +57,7 @@ export async function CourseSuggestions({
       <ContainerBody>
         <ItemGroup>
           {suggestions.map((course, index) => (
-            <Fragment key={course.title}>
+            <Fragment key={course.id}>
               <Item className="px-0 py-2">
                 <ItemContent className="gap-0.5">
                   <ItemTitle>{course.title}</ItemTitle>
@@ -71,7 +71,7 @@ export async function CourseSuggestions({
                       size: "sm",
                       variant: "outline",
                     })}
-                    href={`/generate/cs/${id}`}
+                    href={`/generate/cs/${course.id}`}
                     prefetch={false}
                   >
                     <SparklesIcon aria-hidden="true" className="size-4" />

--- a/apps/main/src/data/courses/course-suggestions.test.ts
+++ b/apps/main/src/data/courses/course-suggestions.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import * as courseSuggestions from "@zoonk/ai/course-suggestions/generate";
 import { prisma } from "@zoonk/db";
+import { toSlug } from "@zoonk/utils/string";
 import { expect, test, vi } from "vitest";
 import {
   generateCourseSuggestions,
@@ -11,22 +12,40 @@ test("get an existing item", async () => {
   const spy = vi.spyOn(courseSuggestions, "generateCourseSuggestions");
 
   const language = "en";
-  const prompt = `typescript-${randomUUID()}`;
+  const uniqueId = randomUUID();
+  const prompt = `typescript-${uniqueId}`;
 
-  const suggestions = [
-    { description: "A course on TypeScript basics.", title: "TypeScript" },
-  ];
+  const suggestion = {
+    description: "A course on TypeScript basics.",
+    title: `TypeScript ${uniqueId}`,
+  };
 
-  await prisma.courseSuggestion.upsert({
-    create: { language, prompt, suggestions },
-    update: { suggestions },
-    where: { languagePrompt: { language, prompt } },
+  const searchPrompt = await prisma.searchPrompt.create({
+    data: { language, prompt },
+  });
+
+  const courseSuggestion = await prisma.courseSuggestion.create({
+    data: {
+      description: suggestion.description,
+      language,
+      slug: toSlug(suggestion.title),
+      title: suggestion.title,
+    },
+  });
+
+  await prisma.searchPromptSuggestion.create({
+    data: {
+      courseSuggestionId: courseSuggestion.id,
+      position: 0,
+      searchPromptId: searchPrompt.id,
+    },
   });
 
   const result = await generateCourseSuggestions({ language, prompt });
 
-  expect(result.suggestions).toEqual(suggestions);
-  expect(result.id).toBeTypeOf("number");
+  expect(result.suggestions).toHaveLength(1);
+  expect(result.suggestions[0]?.title).toBe(suggestion.title);
+  expect(result.suggestions[0]?.id).toBe(courseSuggestion.id);
   expect(spy).not.toHaveBeenCalled();
 });
 
@@ -44,15 +63,52 @@ test("generates a new item", async () => {
 
   const result = await generateCourseSuggestions({ language, prompt });
 
-  expect(result.suggestions).toEqual(generatedSuggestions);
-  expect(result.id).toBeTypeOf("number");
+  expect(result.suggestions).toHaveLength(1);
+  expect(result.suggestions[0]?.title).toBe("Vitest");
+  expect(result.suggestions[0]?.id).toBeTypeOf("number");
   expect(spy).toHaveBeenCalledOnce();
 
-  // check if the record was added to the database
-  const record = await generateCourseSuggestions({ language, prompt });
-  expect(record.suggestions).toEqual(generatedSuggestions);
-  expect(record.id).toBe(result.id);
+  // Verify item was created in database
+  const dbItem = await prisma.courseSuggestion.findUnique({
+    where: { languageSlug: { language, slug: toSlug("Vitest") } },
+  });
+  expect(dbItem).not.toBeNull();
+  expect(dbItem?.title).toBe("Vitest");
+
+  // Verify calling again returns cached result
+  const cachedResult = await generateCourseSuggestions({ language, prompt });
+  expect(cachedResult.suggestions[0]?.id).toBe(result.suggestions[0]?.id);
   expect(spy).toHaveBeenCalledOnce();
+});
+
+test("deduplicates suggestions across prompts", async () => {
+  const spy = vi.spyOn(courseSuggestions, "generateCourseSuggestions");
+
+  const language = "en";
+  const prompt1 = `dedupe-test-1-${randomUUID()}`;
+  const prompt2 = `dedupe-test-2-${randomUUID()}`;
+
+  const suggestions = [{ description: "Learn basics", title: "Common Course" }];
+
+  spy.mockResolvedValue({ data: suggestions } as never);
+
+  const result1 = await generateCourseSuggestions({
+    language,
+    prompt: prompt1,
+  });
+  const result2 = await generateCourseSuggestions({
+    language,
+    prompt: prompt2,
+  });
+
+  // Both should reference the same suggestion ID
+  expect(result1.suggestions[0]?.id).toBe(result2.suggestions[0]?.id);
+
+  // Only one suggestion should exist in database for this slug
+  const items = await prisma.courseSuggestion.findMany({
+    where: { language, slug: toSlug("Common Course") },
+  });
+  expect(items).toHaveLength(1);
 });
 
 test("getCourseSuggestionById returns null for non-existent id", async () => {
@@ -62,20 +118,22 @@ test("getCourseSuggestionById returns null for non-existent id", async () => {
 
 test("getCourseSuggestionById returns suggestion by id", async () => {
   const language = "en";
-  const prompt = `by-id-${randomUUID()}`;
-  const suggestions = [
-    { description: "Test description", title: "Test Course" },
-  ];
+  const title = `by-id-${randomUUID()}`;
 
-  const record = await prisma.courseSuggestion.create({
-    data: { language, prompt, suggestions },
+  const item = await prisma.courseSuggestion.create({
+    data: {
+      description: "Test description",
+      language,
+      slug: toSlug(title),
+      title,
+    },
   });
 
-  const result = await getCourseSuggestionById(record.id);
+  const result = await getCourseSuggestionById(item.id);
 
   expect(result).toEqual({
+    description: "Test description",
     language,
-    prompt,
-    suggestions,
+    title,
   });
 });

--- a/apps/main/src/data/courses/course-suggestions.ts
+++ b/apps/main/src/data/courses/course-suggestions.ts
@@ -1,38 +1,80 @@
 import "server-only";
 
 import { generateCourseSuggestions as generateTask } from "@zoonk/ai/course-suggestions/generate";
-import { prisma } from "@zoonk/db";
-import { normalizeString } from "@zoonk/utils/string";
+import { type CourseSuggestion, prisma } from "@zoonk/db";
+import { normalizeString, toSlug } from "@zoonk/utils/string";
 
-type Suggestion = {
-  title: string;
-  description: string;
-};
+type SuggestionResult = Pick<CourseSuggestion, "id" | "title" | "description">;
 
-async function findCourseSuggestion(params: {
-  language: string;
-  prompt: string;
-}) {
+async function findSearchPrompt(params: { language: string; prompt: string }) {
   const { language, prompt: rawPrompt } = params;
   const prompt = normalizeString(rawPrompt);
 
-  return prisma.courseSuggestion.findUnique({
+  return prisma.searchPrompt.findUnique({
+    include: {
+      suggestions: {
+        include: { courseSuggestion: true },
+        orderBy: { position: "asc" },
+      },
+    },
     where: { languagePrompt: { language, prompt } },
   });
 }
 
-async function upsertCourseSuggestion(input: {
+async function upsertSearchPromptWithSuggestions(input: {
   language: string;
   prompt: string;
-  suggestions: Suggestion[];
-}) {
+  suggestions: Array<{ title: string; description: string }>;
+}): Promise<{ id: number; suggestions: SuggestionResult[] }> {
   const { language, prompt: rawPrompt, suggestions } = input;
   const prompt = normalizeString(rawPrompt);
 
-  return prisma.courseSuggestion.upsert({
-    create: { language, prompt, suggestions },
-    update: { suggestions },
-    where: { languagePrompt: { language, prompt } },
+  return prisma.$transaction(async (tx) => {
+    const searchPrompt = await tx.searchPrompt.upsert({
+      create: { language, prompt },
+      update: {},
+      where: { languagePrompt: { language, prompt } },
+    });
+
+    const results = await Promise.all(
+      suggestions.map(async (suggestion, i) => {
+        const slug = toSlug(suggestion.title);
+
+        const courseSuggestion = await tx.courseSuggestion.upsert({
+          create: {
+            description: suggestion.description,
+            language,
+            slug,
+            title: suggestion.title,
+          },
+          update: {},
+          where: { languageSlug: { language, slug } },
+        });
+
+        await tx.searchPromptSuggestion.upsert({
+          create: {
+            courseSuggestionId: courseSuggestion.id,
+            position: i,
+            searchPromptId: searchPrompt.id,
+          },
+          update: { position: i },
+          where: {
+            promptSuggestion: {
+              courseSuggestionId: courseSuggestion.id,
+              searchPromptId: searchPrompt.id,
+            },
+          },
+        });
+
+        return {
+          description: courseSuggestion.description,
+          id: courseSuggestion.id,
+          title: courseSuggestion.title,
+        };
+      }),
+    );
+
+    return { id: searchPrompt.id, suggestions: results };
   });
 }
 
@@ -42,41 +84,37 @@ export async function generateCourseSuggestions({
 }: {
   language: string;
   prompt: string;
-}): Promise<{ id: number; suggestions: Suggestion[] }> {
-  const record = await findCourseSuggestion({ language, prompt });
+}): Promise<{ id: number; suggestions: SuggestionResult[] }> {
+  const record = await findSearchPrompt({ language, prompt });
 
-  if (!record) {
-    const { data } = await generateTask({ language, prompt });
-
-    const newRecord = await upsertCourseSuggestion({
-      language,
-      prompt,
-      suggestions: data,
-    });
-
-    return { id: newRecord.id, suggestions: data };
+  if (record && record.suggestions.length > 0) {
+    return {
+      id: record.id,
+      suggestions: record.suggestions.map((link) => ({
+        description: link.courseSuggestion.description,
+        id: link.courseSuggestion.id,
+        title: link.courseSuggestion.title,
+      })),
+    };
   }
 
-  return { id: record.id, suggestions: record.suggestions as Suggestion[] };
+  const { data } = await generateTask({ language, prompt });
+
+  return upsertSearchPromptWithSuggestions({
+    language,
+    prompt,
+    suggestions: data,
+  });
 }
 
-export async function getCourseSuggestionById(id: number): Promise<{
-  language: string;
-  prompt: string;
-  suggestions: Suggestion[];
-} | null> {
-  const record = await prisma.courseSuggestion.findUnique({
-    select: { language: true, prompt: true, suggestions: true },
+export async function getCourseSuggestionById(
+  id: number,
+): Promise<Pick<
+  CourseSuggestion,
+  "language" | "title" | "description"
+> | null> {
+  return prisma.courseSuggestion.findUnique({
+    select: { description: true, language: true, title: true },
     where: { id },
   });
-
-  if (!record) {
-    return null;
-  }
-
-  return {
-    language: record.language,
-    prompt: record.prompt,
-    suggestions: record.suggestions as Suggestion[],
-  };
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -31,6 +31,8 @@ export type {
   Member,
   Organization,
   RateLimit,
+  SearchPrompt,
+  SearchPromptSuggestion,
   Session,
   Step,
   StepAttempt,

--- a/packages/db/src/prisma/migrations/20260112212254_refactor_course_suggestions/migration.sql
+++ b/packages/db/src/prisma/migrations/20260112212254_refactor_course_suggestions/migration.sql
@@ -1,0 +1,63 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `prompt` on the `course_suggestions` table. All the data in the column will be lost.
+  - You are about to drop the column `suggestions` on the `course_suggestions` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[language,slug]` on the table `course_suggestions` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `description` to the `course_suggestions` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `slug` to the `course_suggestions` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `title` to the `course_suggestions` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropIndex
+DROP INDEX "course_suggestions_language_prompt_key";
+
+-- AlterTable
+ALTER TABLE "course_suggestions" DROP COLUMN "prompt",
+DROP COLUMN "suggestions",
+ADD COLUMN     "description" TEXT NOT NULL,
+ADD COLUMN     "slug" TEXT NOT NULL,
+ADD COLUMN     "title" TEXT NOT NULL;
+
+-- CreateTable
+CREATE TABLE "search_prompts" (
+    "id" SERIAL NOT NULL,
+    "language" VARCHAR(10) NOT NULL,
+    "prompt" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "search_prompts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "search_prompt_suggestions" (
+    "id" SERIAL NOT NULL,
+    "search_prompt_id" INTEGER NOT NULL,
+    "course_suggestion_id" INTEGER NOT NULL,
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "search_prompt_suggestions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "search_prompts_language_prompt_key" ON "search_prompts"("language", "prompt");
+
+-- CreateIndex
+CREATE INDEX "search_prompt_suggestions_search_prompt_id_idx" ON "search_prompt_suggestions"("search_prompt_id");
+
+-- CreateIndex
+CREATE INDEX "search_prompt_suggestions_course_suggestion_id_idx" ON "search_prompt_suggestions"("course_suggestion_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "search_prompt_suggestions_search_prompt_id_course_suggestio_key" ON "search_prompt_suggestions"("search_prompt_id", "course_suggestion_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "course_suggestions_language_slug_key" ON "course_suggestions"("language", "slug");
+
+-- AddForeignKey
+ALTER TABLE "search_prompt_suggestions" ADD CONSTRAINT "search_prompt_suggestions_search_prompt_id_fkey" FOREIGN KEY ("search_prompt_id") REFERENCES "search_prompts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "search_prompt_suggestions" ADD CONSTRAINT "search_prompt_suggestions_course_suggestion_id_fkey" FOREIGN KEY ("course_suggestion_id") REFERENCES "course_suggestions"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/src/prisma/models/courses.prisma
+++ b/packages/db/src/prisma/models/courses.prisma
@@ -1,13 +1,42 @@
-model CourseSuggestion {
-  id          Int      @id @default(autoincrement())
-  language    String   @db.VarChar(10)
+model SearchPrompt {
+  id          Int                      @id @default(autoincrement())
+  language    String                   @db.VarChar(10)
   prompt      String
-  suggestions Json
-  createdAt   DateTime @default(now()) @map("created_at")
-  updatedAt   DateTime @default(now()) @updatedAt @map("updated_at")
+  suggestions SearchPromptSuggestion[]
+  createdAt   DateTime                 @default(now()) @map("created_at")
+  updatedAt   DateTime                 @default(now()) @updatedAt @map("updated_at")
 
   @@unique([language, prompt], name: "languagePrompt")
+  @@map("search_prompts")
+}
+
+model CourseSuggestion {
+  id          Int                      @id @default(autoincrement())
+  language    String                   @db.VarChar(10)
+  slug        String
+  title       String
+  description String
+  prompts     SearchPromptSuggestion[]
+  createdAt   DateTime                 @default(now()) @map("created_at")
+  updatedAt   DateTime                 @default(now()) @updatedAt @map("updated_at")
+
+  @@unique([language, slug], name: "languageSlug")
   @@map("course_suggestions")
+}
+
+model SearchPromptSuggestion {
+  id                 Int              @id @default(autoincrement())
+  searchPromptId     Int              @map("search_prompt_id")
+  searchPrompt       SearchPrompt     @relation(fields: [searchPromptId], references: [id], onDelete: Cascade)
+  courseSuggestionId Int              @map("course_suggestion_id")
+  courseSuggestion   CourseSuggestion @relation(fields: [courseSuggestionId], references: [id], onDelete: Cascade)
+  position           Int              @default(0)
+  createdAt          DateTime         @default(now()) @map("created_at")
+
+  @@unique([searchPromptId, courseSuggestionId], name: "promptSuggestion")
+  @@index([searchPromptId])
+  @@index([courseSuggestionId])
+  @@map("search_prompt_suggestions")
 }
 
 model Course {

--- a/packages/db/src/prisma/seed/course-suggestions.ts
+++ b/packages/db/src/prisma/seed/course-suggestions.ts
@@ -1,25 +1,23 @@
-import { normalizeString } from "@zoonk/utils/string";
+import { normalizeString, toSlug } from "@zoonk/utils/string";
 import type { PrismaClient } from "../../generated/prisma/client";
 
 export async function seedCourseSuggestions(
   prisma: PrismaClient,
 ): Promise<void> {
-  // Seed course suggestions for predictable E2E tests
-  await prisma.courseSuggestion.upsert({
-    create: {
-      language: "en",
-      prompt: normalizeString("test prompt"),
-      suggestions: [
-        {
-          description: "Learn the fundamentals of software testing",
-          title: "Introduction to Testing",
-        },
-        {
-          description: "Master complex testing patterns and methodologies",
-          title: "Advanced Test Strategies",
-        },
-      ],
+  // English suggestions
+  const enSuggestions = [
+    {
+      description: "Learn the fundamentals of software testing",
+      title: "Introduction to Testing",
     },
+    {
+      description: "Master complex testing patterns and methodologies",
+      title: "Advanced Test Strategies",
+    },
+  ];
+
+  const enSearchPrompt = await prisma.searchPrompt.upsert({
+    create: { language: "en", prompt: normalizeString("test prompt") },
     update: {},
     where: {
       languagePrompt: {
@@ -29,21 +27,52 @@ export async function seedCourseSuggestions(
     },
   });
 
-  await prisma.courseSuggestion.upsert({
-    create: {
-      language: "pt",
-      prompt: normalizeString("test prompt"),
-      suggestions: [
-        {
-          description: "Aprenda os fundamentos de testes de software",
-          title: "Introdução a Testes",
+  await Promise.all(
+    enSuggestions.map(async (suggestion, i) => {
+      const slug = toSlug(suggestion.title);
+
+      const courseSuggestion = await prisma.courseSuggestion.upsert({
+        create: {
+          description: suggestion.description,
+          language: "en",
+          slug,
+          title: suggestion.title,
         },
-        {
-          description: "Domine padrões e metodologias complexas de testes",
-          title: "Estratégias Avançadas de Testes",
+        update: {},
+        where: { languageSlug: { language: "en", slug } },
+      });
+
+      await prisma.searchPromptSuggestion.upsert({
+        create: {
+          courseSuggestionId: courseSuggestion.id,
+          position: i,
+          searchPromptId: enSearchPrompt.id,
         },
-      ],
+        update: { position: i },
+        where: {
+          promptSuggestion: {
+            courseSuggestionId: courseSuggestion.id,
+            searchPromptId: enSearchPrompt.id,
+          },
+        },
+      });
+    }),
+  );
+
+  // Portuguese suggestions
+  const ptSuggestions = [
+    {
+      description: "Aprenda os fundamentos de testes de software",
+      title: "Introdução a Testes",
     },
+    {
+      description: "Domine padrões e metodologias complexas de testes",
+      title: "Estratégias Avançadas de Testes",
+    },
+  ];
+
+  const ptSearchPrompt = await prisma.searchPrompt.upsert({
+    create: { language: "pt", prompt: normalizeString("test prompt") },
     update: {},
     where: {
       languagePrompt: {
@@ -52,4 +81,36 @@ export async function seedCourseSuggestions(
       },
     },
   });
+
+  await Promise.all(
+    ptSuggestions.map(async (suggestion, i) => {
+      const slug = toSlug(suggestion.title);
+
+      const courseSuggestion = await prisma.courseSuggestion.upsert({
+        create: {
+          description: suggestion.description,
+          language: "pt",
+          slug,
+          title: suggestion.title,
+        },
+        update: {},
+        where: { languageSlug: { language: "pt", slug } },
+      });
+
+      await prisma.searchPromptSuggestion.upsert({
+        create: {
+          courseSuggestionId: courseSuggestion.id,
+          position: i,
+          searchPromptId: ptSearchPrompt.id,
+        },
+        update: { position: i },
+        where: {
+          promptSuggestion: {
+            courseSuggestionId: courseSuggestion.id,
+            searchPromptId: ptSearchPrompt.id,
+          },
+        },
+      });
+    }),
+  );
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Normalize course suggestions by introducing SearchPrompt ↔ CourseSuggestion relationships, replacing prompt-scoped JSON. This dedupes suggestions across prompts, provides stable suggestion IDs, and updates UI links.

- **Refactors**
  - Database: add search_prompts and search_prompt_suggestions; course_suggestions now stores title/description/slug with unique (language, slug).
  - Data layer: generateCourseSuggestions returns searchPrompt.id and [{ id, title, description }]; dedup by slug; getCourseSuggestionById now returns a single suggestion’s fields.
  - UI: use course.id for keys and link to /generate/cs/:id.
  - Seeds/tests: updated seeds for EN/PT; added tests including cross-prompt dedupe.

- **Migration**
  - Run: pnpm --filter @zoonk/db db:migrate.
  - If course_suggestions has data, backfill or truncate before migrating (new NOT NULL columns); then re-seed or let the app regenerate.
  - Update any code relying on prompt-level suggestions or the old getCourseSuggestionById shape.

<sup>Written for commit dade11bfaa26e3e815732b77dff73169b8d79b33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

