### PR TITLE
feat(db): add generationRunId field to content models

### DIFF
--- a/packages/db/src/prisma/migrations/20260112221515_add_run_id/migration.sql
+++ b/packages/db/src/prisma/migrations/20260112221515_add_run_id/migration.sql
@@ -1,0 +1,15 @@
+-- AlterTable
+ALTER TABLE "activities" ADD COLUMN     "generation_run_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "chapters" ADD COLUMN     "generation_run_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "course_suggestions" ADD COLUMN     "generation_run_id" TEXT,
+ADD COLUMN     "generation_status" VARCHAR(20) NOT NULL DEFAULT 'pending';
+
+-- AlterTable
+ALTER TABLE "courses" ADD COLUMN     "generation_run_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "lessons" ADD COLUMN     "generation_run_id" TEXT;

--- a/packages/db/src/prisma/models/activities.prisma
+++ b/packages/db/src/prisma/models/activities.prisma
@@ -1,22 +1,23 @@
 model Activity {
-  id             Int                @id @default(autoincrement())
-  organizationId Int                @map("organization_id")
-  organization   Organization       @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  lessonId       Int                @map("lesson_id")
-  lesson         Lesson             @relation(fields: [lessonId], references: [id], onDelete: Cascade)
-  isPublished    Boolean            @default(false) @map("is_published")
-  language       String             @db.VarChar(10)
-  kind           String             @db.VarChar(30)
-  title          String?
+  id               Int                @id @default(autoincrement())
+  organizationId   Int                @map("organization_id")
+  organization     Organization       @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  lessonId         Int                @map("lesson_id")
+  lesson           Lesson             @relation(fields: [lessonId], references: [id], onDelete: Cascade)
+  isPublished      Boolean            @default(false) @map("is_published")
+  language         String             @db.VarChar(10)
+  kind             String             @db.VarChar(30)
+  title            String?
   description      String?
   generationStatus String             @default("pending") @map("generation_status") @db.VarChar(20)
+  generationRunId  String?            @map("generation_run_id")
   position         Int
-  inventory      Json?
-  winCriteria    Json?              @map("win_criteria")
-  createdAt      DateTime           @default(now()) @map("created_at")
-  updatedAt      DateTime           @default(now()) @updatedAt @map("updated_at")
-  steps          Step[]
-  progress       ActivityProgress[]
+  inventory        Json?
+  winCriteria      Json?              @map("win_criteria")
+  createdAt        DateTime           @default(now()) @map("created_at")
+  updatedAt        DateTime           @default(now()) @updatedAt @map("updated_at")
+  steps            Step[]
+  progress         ActivityProgress[]
 
   @@index([lessonId, position])
   @@index([organizationId, kind])

--- a/packages/db/src/prisma/models/chapters.prisma
+++ b/packages/db/src/prisma/models/chapters.prisma
@@ -1,20 +1,21 @@
 model Chapter {
-  id              Int      @id @default(autoincrement())
-  organizationId  Int      @map("organization_id")
-  organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  courseId        Int      @map("course_id")
-  course          Course   @relation(fields: [courseId], references: [id], onDelete: Cascade)
-  isPublished     Boolean  @default(false) @map("is_published")
-  language        String   @db.VarChar(10)
-  slug            String
-  title           String
-  normalizedTitle String   @map("normalized_title")
+  id               Int          @id @default(autoincrement())
+  organizationId   Int          @map("organization_id")
+  organization     Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  courseId         Int          @map("course_id")
+  course           Course       @relation(fields: [courseId], references: [id], onDelete: Cascade)
+  isPublished      Boolean      @default(false) @map("is_published")
+  language         String       @db.VarChar(10)
+  slug             String
+  title            String
+  normalizedTitle  String       @map("normalized_title")
   description      String
-  generationStatus String   @default("pending") @map("generation_status") @db.VarChar(20)
+  generationStatus String       @default("pending") @map("generation_status") @db.VarChar(20)
+  generationRunId  String?      @map("generation_run_id")
   position         Int
-  createdAt       DateTime @default(now()) @map("created_at")
-  updatedAt       DateTime @default(now()) @updatedAt @map("updated_at")
-  lessons         Lesson[]
+  createdAt        DateTime     @default(now()) @map("created_at")
+  updatedAt        DateTime     @default(now()) @updatedAt @map("updated_at")
+  lessons          Lesson[]
 
   @@unique([courseId, slug], name: "courseChapterSlug")
   @@index([organizationId, normalizedTitle])

--- a/packages/db/src/prisma/models/courses.prisma
+++ b/packages/db/src/prisma/models/courses.prisma
@@ -11,14 +11,16 @@ model SearchPrompt {
 }
 
 model CourseSuggestion {
-  id          Int                      @id @default(autoincrement())
-  language    String                   @db.VarChar(10)
-  slug        String
-  title       String
-  description String
-  prompts     SearchPromptSuggestion[]
-  createdAt   DateTime                 @default(now()) @map("created_at")
-  updatedAt   DateTime                 @default(now()) @updatedAt @map("updated_at")
+  id               Int                      @id @default(autoincrement())
+  language         String                   @db.VarChar(10)
+  slug             String
+  title            String
+  description      String
+  generationStatus String                   @default("pending") @map("generation_status") @db.VarChar(20)
+  generationRunId  String?                  @map("generation_run_id")
+  prompts          SearchPromptSuggestion[]
+  createdAt        DateTime                 @default(now()) @map("created_at")
+  updatedAt        DateTime                 @default(now()) @updatedAt @map("updated_at")
 
   @@unique([language, slug], name: "languageSlug")
   @@map("course_suggestions")
@@ -50,6 +52,7 @@ model Course {
   normalizedTitle   String                   @map("normalized_title")
   description       String?
   generationStatus  String                   @default("completed") @map("generation_status") @db.VarChar(20)
+  generationRunId   String?                  @map("generation_run_id")
   imageUrl          String?                  @map("image_url")
   createdAt         DateTime                 @default(now()) @map("created_at")
   updatedAt         DateTime                 @default(now()) @updatedAt @map("updated_at")

--- a/packages/db/src/prisma/models/lessons.prisma
+++ b/packages/db/src/prisma/models/lessons.prisma
@@ -1,21 +1,22 @@
 model Lesson {
-  id              Int          @id @default(autoincrement())
-  organizationId  Int          @map("organization_id")
-  organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  chapterId       Int          @map("chapter_id")
-  chapter         Chapter      @relation(fields: [chapterId], references: [id], onDelete: Cascade)
-  isPublished     Boolean      @default(false) @map("is_published")
-  language        String       @db.VarChar(10)
-  kind            String       @default("core") @db.VarChar(20)
-  slug            String
-  title           String
-  normalizedTitle String       @map("normalized_title")
+  id               Int          @id @default(autoincrement())
+  organizationId   Int          @map("organization_id")
+  organization     Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  chapterId        Int          @map("chapter_id")
+  chapter          Chapter      @relation(fields: [chapterId], references: [id], onDelete: Cascade)
+  isPublished      Boolean      @default(false) @map("is_published")
+  language         String       @db.VarChar(10)
+  kind             String       @default("core") @db.VarChar(20)
+  slug             String
+  title            String
+  normalizedTitle  String       @map("normalized_title")
   description      String
   generationStatus String       @default("pending") @map("generation_status") @db.VarChar(20)
+  generationRunId  String?      @map("generation_run_id")
   position         Int
-  createdAt       DateTime     @default(now()) @map("created_at")
-  updatedAt       DateTime     @default(now()) @updatedAt @map("updated_at")
-  activities      Activity[]
+  createdAt        DateTime     @default(now()) @map("created_at")
+  updatedAt        DateTime     @default(now()) @updatedAt @map("updated_at")
+  activities       Activity[]
 
   @@unique([organizationId, language, slug], name: "orgLanguageLessonSlug")
   @@index([organizationId, normalizedTitle])

--- a/packages/testing/src/fixtures/activities.ts
+++ b/packages/testing/src/fixtures/activities.ts
@@ -8,6 +8,7 @@ export function activityAttrs(
 > {
   return {
     description: "Test activity description",
+    generationRunId: null,
     generationStatus: "completed",
     isPublished: false,
     kind: "background",

--- a/packages/testing/src/fixtures/chapters.ts
+++ b/packages/testing/src/fixtures/chapters.ts
@@ -11,6 +11,7 @@ export function chapterAttrs(
   return {
     courseId: 0,
     description: "Test chapter description",
+    generationRunId: null,
     generationStatus: "completed",
     isPublished: false,
     language: "en",

--- a/packages/testing/src/fixtures/courses.ts
+++ b/packages/testing/src/fixtures/courses.ts
@@ -16,6 +16,7 @@ export function courseAttrs(attrs?: Partial<Course>): CourseAttrs {
 
   return {
     description: description ?? "Test course description",
+    generationRunId: null,
     generationStatus: "completed",
     imageUrl: null,
     isPublished: false,

--- a/packages/testing/src/fixtures/lessons.ts
+++ b/packages/testing/src/fixtures/lessons.ts
@@ -11,6 +11,7 @@ export function lessonAttrs(
   return {
     chapterId: 0,
     description: "Test lesson description",
+    generationRunId: null,
     generationStatus: "completed",
     isPublished: false,
     kind: "core",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add generationRunId to activities, chapters, lessons, courses, and course suggestions to track which generation run created or updated content. Also add generationStatus to course_suggestions to support run lifecycle.

- **New Features**
  - Added optional generation_run_id to activities, chapters, lessons, courses, and course_suggestions.
  - Added generation_status to course_suggestions with default 'pending'.

- **Migration**
  - Run Prisma migrate and regenerate the Prisma client.
  - Existing rows will have generationRunId = null; no backfill needed.

<sup>Written for commit e1b2dd87d469f8860b0195efb38234270b85e61c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

