### PR TITLE
fix(db): update lesson unique index

### DIFF
--- a/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-actions.tsx
+++ b/apps/editor/src/app/[orgSlug]/@navbarActions/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-actions.tsx
@@ -21,6 +21,8 @@ export async function LessonActions({
   const t = await getExtracted();
 
   const { data: lesson } = await getLesson({
+    chapterSlug,
+    courseSlug,
     language: lang,
     lessonSlug,
     orgSlug,

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/actions.ts
@@ -13,11 +13,14 @@ import { updateLesson } from "@/data/lessons/update-lesson";
 import { getErrorMessage } from "@/lib/error-messages";
 
 export async function checkLessonSlugExists(params: {
-  language: string;
-  orgSlug: string;
+  chapterId?: number;
   slug: string;
 }): Promise<boolean> {
-  return lessonSlugExists(params);
+  if (!params.chapterId) {
+    return false;
+  }
+
+  return lessonSlugExists({ chapterId: params.chapterId, slug: params.slug });
 }
 
 export async function updateLessonTitleAction(

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-content.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-content.tsx
@@ -19,6 +19,8 @@ export async function LessonContent({
   const t = await getExtracted();
 
   const { data: lesson, error } = await getLesson({
+    chapterSlug,
+    courseSlug,
     language: lang,
     lessonSlug,
     orgSlug,

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-slug.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-slug.tsx
@@ -13,6 +13,8 @@ export async function LessonSlug({
   const { chapterSlug, courseSlug, lang, lessonSlug, orgSlug } = await params;
 
   const { data: lesson } = await getLesson({
+    chapterSlug,
+    courseSlug,
     language: lang,
     lessonSlug,
     orgSlug,
@@ -26,6 +28,7 @@ export async function LessonSlug({
 
   return (
     <SlugEditor
+      chapterId={lesson.chapterId}
       checkFn={checkLessonSlugExists}
       entityId={lesson.id}
       initialSlug={lesson.slug}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -19,7 +19,13 @@ export default async function LessonPage(props: LessonPageProps) {
   // Preload data in parallel (cached, so child components get the same promise)
   void Promise.all([
     getChapter({ chapterSlug, courseSlug, language: lang, orgSlug }),
-    getLesson({ language: lang, lessonSlug, orgSlug }),
+    getLesson({
+      chapterSlug,
+      courseSlug,
+      language: lang,
+      lessonSlug,
+      orgSlug,
+    }),
   ]);
 
   return (

--- a/apps/editor/src/components/slug-editor.tsx
+++ b/apps/editor/src/components/slug-editor.tsx
@@ -18,6 +18,7 @@ export function SlugEditorSkeleton() {
 }
 
 type SlugCheckParams = {
+  chapterId?: number;
   courseId?: number;
   language: string;
   orgSlug: string;
@@ -25,6 +26,7 @@ type SlugCheckParams = {
 };
 
 type SlugEditorProps = {
+  chapterId?: number;
   checkFn: (params: SlugCheckParams) => Promise<boolean>;
   courseId?: number;
   entityId: number;
@@ -40,6 +42,7 @@ type SlugEditorProps = {
 };
 
 export function SlugEditor({
+  chapterId,
   checkFn,
   courseId,
   entityId,
@@ -56,6 +59,7 @@ export function SlugEditor({
   const [slug, setSlug] = useState(initialSlug);
 
   const slugExists = useSlugCheck({
+    chapterId,
     checkFn,
     courseId,
     initialSlug,

--- a/apps/editor/src/data/lessons/create-lesson.test.ts
+++ b/apps/editor/src/data/lessons/create-lesson.test.ts
@@ -183,7 +183,7 @@ describe("admins", () => {
     expect(result.data).toBeNull();
   });
 
-  test("returns error when slug already exists for same org and language", async () => {
+  test("returns error when slug already exists for same chapter", async () => {
     const attrs = lessonAttrs({
       chapterId: chapter.id,
       organizationId: organization.id,
@@ -204,6 +204,46 @@ describe("admins", () => {
     });
 
     expect(result.error).not.toBeNull();
+  });
+
+  test("allows same slug in different chapters", async () => {
+    const newCourse = await courseFixture({ organizationId: organization.id });
+    const [chapter1, chapter2] = await Promise.all([
+      chapterFixture({
+        courseId: newCourse.id,
+        language: newCourse.language,
+        organizationId: organization.id,
+      }),
+      chapterFixture({
+        courseId: newCourse.id,
+        language: newCourse.language,
+        organizationId: organization.id,
+      }),
+    ]);
+
+    const attrs = lessonAttrs({
+      chapterId: chapter1.id,
+      organizationId: organization.id,
+    });
+
+    const [result1, result2] = await Promise.all([
+      createLesson({
+        ...attrs,
+        chapterId: chapter1.id,
+        headers,
+        position: 0,
+      }),
+      createLesson({
+        ...attrs,
+        chapterId: chapter2.id,
+        headers,
+        position: 0,
+      }),
+    ]);
+
+    expect(result1.error).toBeNull();
+    expect(result2.error).toBeNull();
+    expect(result1.data?.slug).toBe(result2.data?.slug);
   });
 
   test("creates lesson at correct position", async () => {

--- a/apps/editor/src/data/lessons/get-lesson.ts
+++ b/apps/editor/src/data/lessons/get-lesson.ts
@@ -8,6 +8,8 @@ import { ErrorCode } from "@/lib/app-error";
 
 export const getLesson = cache(
   async (params: {
+    chapterSlug: string;
+    courseSlug: string;
     headers?: Headers;
     language: string;
     lessonSlug: string;
@@ -16,7 +18,10 @@ export const getLesson = cache(
     const { data: lesson, error: findError } = await safeAsync(() =>
       prisma.lesson.findFirst({
         where: {
-          language: params.language,
+          chapter: {
+            course: { language: params.language, slug: params.courseSlug },
+            slug: params.chapterSlug,
+          },
           organization: { slug: params.orgSlug },
           slug: params.lessonSlug,
         },

--- a/apps/editor/src/data/lessons/import-lessons.ts
+++ b/apps/editor/src/data/lessons/import-lessons.ts
@@ -136,16 +136,15 @@ export async function importLessons(params: {
 
       const allSlugs = lessonsToImport.map((l) => l.slug);
 
-      const existingLessonsInOrg = await tx.lesson.findMany({
+      const existingLessonsInChapter = await tx.lesson.findMany({
         where: {
-          language: chapter.language,
-          organizationId: chapter.organizationId,
+          chapterId: params.chapterId,
           slug: { in: allSlugs },
         },
       });
 
       const existingLessonMap = new Map(
-        existingLessonsInOrg.map((l) => [l.slug, l]),
+        existingLessonsInChapter.map((l) => [l.slug, l]),
       );
 
       // Deduplicate slugs within the batch to prevent unique constraint violations

--- a/apps/editor/src/data/lessons/lesson-slug.test.ts
+++ b/apps/editor/src/data/lessons/lesson-slug.test.ts
@@ -19,7 +19,7 @@ describe("lessonSlugExists()", () => {
     });
   });
 
-  test("returns true when slug exists for same language and org", async () => {
+  test("returns true when slug exists in same chapter", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       language: chapter.language,
@@ -27,8 +27,7 @@ describe("lessonSlugExists()", () => {
     });
 
     const exists = await lessonSlugExists({
-      language: lesson.language,
-      orgSlug: organization.slug,
+      chapterId: chapter.id,
       slug: lesson.slug,
     });
 
@@ -37,47 +36,36 @@ describe("lessonSlugExists()", () => {
 
   test("returns false when slug does not exist", async () => {
     const exists = await lessonSlugExists({
-      language: "en",
-      orgSlug: organization.slug,
+      chapterId: chapter.id,
       slug: "non-existent-slug",
     });
 
     expect(exists).toBe(false);
   });
 
-  test("returns false when slug exists but language differs", async () => {
+  test("returns false when slug exists but chapter differs", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const [chapter1, chapter2] = await Promise.all([
+      chapterFixture({
+        courseId: course.id,
+        language: course.language,
+        organizationId: organization.id,
+      }),
+      chapterFixture({
+        courseId: course.id,
+        language: course.language,
+        organizationId: organization.id,
+      }),
+    ]);
+
     const lesson = await lessonFixture({
-      chapterId: chapter.id,
-      language: "en",
+      chapterId: chapter1.id,
+      language: chapter1.language,
       organizationId: organization.id,
     });
 
     const exists = await lessonSlugExists({
-      language: "pt",
-      orgSlug: organization.slug,
-      slug: lesson.slug,
-    });
-
-    expect(exists).toBe(false);
-  });
-
-  test("returns false when slug exists but organization differs", async () => {
-    const otherOrg = await organizationFixture();
-    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
-    const otherChapter = await chapterFixture({
-      courseId: otherCourse.id,
-      language: otherCourse.language,
-      organizationId: otherOrg.id,
-    });
-    const lesson = await lessonFixture({
-      chapterId: otherChapter.id,
-      language: otherChapter.language,
-      organizationId: otherOrg.id,
-    });
-
-    const exists = await lessonSlugExists({
-      language: lesson.language,
-      orgSlug: organization.slug,
+      chapterId: chapter2.id,
       slug: lesson.slug,
     });
 

--- a/apps/editor/src/data/lessons/lesson-slug.ts
+++ b/apps/editor/src/data/lessons/lesson-slug.ts
@@ -5,17 +5,12 @@ import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 
 export const lessonSlugExists = cache(
-  async (params: {
-    language: string;
-    orgSlug: string;
-    slug: string;
-  }): Promise<boolean> => {
+  async (params: { chapterId: number; slug: string }): Promise<boolean> => {
     const { data } = await safeAsync(() =>
       prisma.lesson.findFirst({
         select: { id: true },
         where: {
-          language: params.language,
-          organization: { slug: params.orgSlug },
+          chapterId: params.chapterId,
           slug: params.slug,
         },
       }),

--- a/apps/editor/src/lib/use-slug-check.ts
+++ b/apps/editor/src/lib/use-slug-check.ts
@@ -4,6 +4,7 @@ import { useDebounce } from "@zoonk/ui/hooks/debounce";
 import { useEffect, useEffectEvent, useState, useTransition } from "react";
 
 type SlugCheckParams = {
+  chapterId?: number;
   courseId?: number;
   language: string;
   orgSlug: string;
@@ -17,6 +18,7 @@ type SlugCheckFn = (params: SlugCheckParams) => Promise<boolean>;
  * Works with any entity type (course, chapter, lesson) by accepting a check function.
  */
 export function useSlugCheck({
+  chapterId,
   checkFn,
   courseId,
   initialSlug,
@@ -47,6 +49,7 @@ export function useSlugCheck({
 
     startTransition(async () => {
       const exists = await checkFn({
+        chapterId,
         courseId,
         language,
         orgSlug,
@@ -55,7 +58,15 @@ export function useSlugCheck({
 
       handleSlugCheck(debouncedSlug, exists);
     });
-  }, [checkFn, courseId, debouncedSlug, initialSlug, language, orgSlug]);
+  }, [
+    chapterId,
+    checkFn,
+    courseId,
+    debouncedSlug,
+    initialSlug,
+    language,
+    orgSlug,
+  ]);
 
   return slugExists;
 }

--- a/packages/db/src/prisma/migrations/20260113234707_change_chapter_lesson_unique_index/migration.sql
+++ b/packages/db/src/prisma/migrations/20260113234707_change_chapter_lesson_unique_index/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[chapter_id,slug]` on the table `lessons` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "lessons_organization_id_language_slug_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "lessons_chapter_id_slug_key" ON "lessons"("chapter_id", "slug");

--- a/packages/db/src/prisma/models/lessons.prisma
+++ b/packages/db/src/prisma/models/lessons.prisma
@@ -18,7 +18,7 @@ model Lesson {
   updatedAt        DateTime         @default(now()) @updatedAt @map("updated_at")
   activities       Activity[]
 
-  @@unique([organizationId, language, slug], name: "orgLanguageLessonSlug")
+  @@unique([chapterId, slug], name: "chapterLessonSlug")
   @@index([organizationId, normalizedTitle])
   @@index([chapterId, position])
   @@index([organizationId, kind])

--- a/packages/db/src/prisma/seed/lessons.ts
+++ b/packages/db/src/prisma/seed/lessons.ts
@@ -223,9 +223,8 @@ export async function seedLessons(
               },
               update: {},
               where: {
-                orgLanguageLessonSlug: {
-                  language: data.language,
-                  organizationId: org.id,
+                chapterLessonSlug: {
+                  chapterId: chapter.id,
                   slug: lessonData.slug,
                 },
               },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Changed lesson slug uniqueness to be per chapter instead of per organization + language. This allows the same lesson slug in different chapters and ensures lookups return the correct lesson when duplicates exist across chapters.

- **Migration**
  - Replace unique index with chapterId + slug.
  - Update getLesson to scope by courseSlug and chapterSlug; editor routes now pass these props.
  - Slug checks use chapterId; import logic checks existing slugs within the chapter; seeds use the new compound key.

<sup>Written for commit fab1be78a30561205df83880f3a3b3d9e696832f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

