### PR TITLE
refactor(db):  use bigint for activities and progress ids

### DIFF
--- a/apps/main/src/data/progress/get-best-time.test.ts
+++ b/apps/main/src/data/progress/get-best-time.test.ts
@@ -14,7 +14,7 @@ type StepAttemptParams = {
   hourOfDay: number;
   isCorrect: boolean;
   orgId: number;
-  stepId: number;
+  stepId: bigint;
   userId: number;
 };
 

--- a/packages/db/src/prisma/migrations/20260114010522_use_bigint/migration.sql
+++ b/packages/db/src/prisma/migrations/20260114010522_use_bigint/migration.sql
@@ -1,0 +1,62 @@
+/*
+  Warnings:
+
+  - The primary key for the `activities` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `activity_progress` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `daily_progress` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `step_attempts` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `steps` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- DropForeignKey
+ALTER TABLE "activity_progress" DROP CONSTRAINT "activity_progress_activity_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "step_attempts" DROP CONSTRAINT "step_attempts_step_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "steps" DROP CONSTRAINT "steps_activity_id_fkey";
+
+-- AlterTable
+ALTER TABLE "activities" DROP CONSTRAINT "activities_pkey",
+ALTER COLUMN "id" SET DATA TYPE BIGINT,
+ADD CONSTRAINT "activities_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "activity_progress" DROP CONSTRAINT "activity_progress_pkey",
+ALTER COLUMN "id" SET DATA TYPE BIGINT,
+ALTER COLUMN "activity_id" SET DATA TYPE BIGINT,
+ADD CONSTRAINT "activity_progress_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "daily_progress" DROP CONSTRAINT "daily_progress_pkey",
+ALTER COLUMN "id" SET DATA TYPE BIGINT,
+ADD CONSTRAINT "daily_progress_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "step_attempts" DROP CONSTRAINT "step_attempts_pkey",
+ALTER COLUMN "id" SET DATA TYPE BIGINT,
+ALTER COLUMN "step_id" SET DATA TYPE BIGINT,
+ADD CONSTRAINT "step_attempts_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "steps" DROP CONSTRAINT "steps_pkey",
+ALTER COLUMN "id" SET DATA TYPE BIGINT,
+ALTER COLUMN "activity_id" SET DATA TYPE BIGINT,
+ADD CONSTRAINT "steps_pkey" PRIMARY KEY ("id");
+
+-- AddForeignKey
+ALTER TABLE "activity_progress" ADD CONSTRAINT "activity_progress_activity_id_fkey" FOREIGN KEY ("activity_id") REFERENCES "activities"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "step_attempts" ADD CONSTRAINT "step_attempts_step_id_fkey" FOREIGN KEY ("step_id") REFERENCES "steps"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "steps" ADD CONSTRAINT "steps_activity_id_fkey" FOREIGN KEY ("activity_id") REFERENCES "activities"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AlterSequence - Change sequences to BIGINT to support larger max values
+ALTER SEQUENCE activities_id_seq AS BIGINT;
+ALTER SEQUENCE activity_progress_id_seq AS BIGINT;
+ALTER SEQUENCE daily_progress_id_seq AS BIGINT;
+ALTER SEQUENCE step_attempts_id_seq AS BIGINT;
+ALTER SEQUENCE steps_id_seq AS BIGINT;

--- a/packages/db/src/prisma/models/activities.prisma
+++ b/packages/db/src/prisma/models/activities.prisma
@@ -1,5 +1,5 @@
 model Activity {
-  id               Int                @id @default(autoincrement())
+  id               BigInt             @id @default(autoincrement())
   organizationId   Int                @map("organization_id")
   organization     Organization       @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   lessonId         Int                @map("lesson_id")
@@ -25,10 +25,10 @@ model Activity {
 }
 
 model ActivityProgress {
-  id              Int       @id @default(autoincrement())
+  id              BigInt    @id @default(autoincrement())
   userId          Int       @map("user_id")
   user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  activityId      Int       @map("activity_id")
+  activityId      BigInt    @map("activity_id")
   activity        Activity  @relation(fields: [activityId], references: [id], onDelete: Cascade)
   startedAt       DateTime  @default(now()) @map("started_at")
   completedAt     DateTime? @map("completed_at")

--- a/packages/db/src/prisma/models/progress.prisma
+++ b/packages/db/src/prisma/models/progress.prisma
@@ -1,8 +1,8 @@
 model StepAttempt {
-  id              Int          @id @default(autoincrement())
+  id              BigInt       @id @default(autoincrement())
   userId          Int          @map("user_id")
   user            User         @relation(fields: [userId], references: [id], onDelete: Cascade)
-  stepId          Int          @map("step_id")
+  stepId          BigInt       @map("step_id")
   step            Step         @relation(fields: [stepId], references: [id], onDelete: Cascade)
   organizationId  Int          @map("organization_id")
   organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
@@ -35,7 +35,7 @@ model UserProgress {
 }
 
 model DailyProgress {
-  id                   Int           @id @default(autoincrement())
+  id                   BigInt        @id @default(autoincrement())
   userId               Int           @map("user_id")
   user                 User          @relation(fields: [userId], references: [id], onDelete: Cascade)
   date                 DateTime      @db.Date

--- a/packages/db/src/prisma/models/steps.prisma
+++ b/packages/db/src/prisma/models/steps.prisma
@@ -1,6 +1,6 @@
 model Step {
-  id            Int           @id @default(autoincrement())
-  activityId    Int           @map("activity_id")
+  id            BigInt        @id @default(autoincrement())
+  activityId    BigInt        @map("activity_id")
   activity      Activity      @relation(fields: [activityId], references: [id], onDelete: Cascade)
   kind          String        @db.VarChar(20)
   position      Int

--- a/packages/db/src/prisma/seed/progress.ts
+++ b/packages/db/src/prisma/seed/progress.ts
@@ -13,7 +13,7 @@ type E2eAttemptData = {
   hourOfDay: number;
   isCorrect: boolean;
   organizationId: number;
-  stepId: number;
+  stepId: bigint;
   userId: number;
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched primary keys and related foreign keys for activities, steps, and progress models from Int to BigInt to support larger ID ranges. Added a migration, updated Prisma models/sequences, and adjusted TypeScript types in tests/seed.

- **Migration**
  - Run prisma migrate deploy to apply 20260114010522_use_bigint.
  - Update code to use bigint for IDs/FKs: Activity.id, Step.id, StepAttempt.id, ActivityProgress.id, DailyProgress.id, stepId, activityId.
  - If sending IDs in JSON, convert BigInt to string to avoid serialization errors.

<sup>Written for commit 4b8b761f1460aa4bffe92dde3117f48ac190e022. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

