### PR TITLE
feat: add CSP headers

### DIFF
--- a/apps/auth/next.config.ts
+++ b/apps/auth/next.config.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { createSecurityHeaders } from "@zoonk/next/security-headers";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
@@ -19,6 +20,7 @@ const nextConfig: NextConfig = {
     turbopackFileSystemCacheForBuild: true,
     typedEnv: true,
   },
+  headers: async () => createSecurityHeaders(),
   reactCompiler: true,
   turbopack: {
     resolveAlias: {

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { createSecurityHeaders } from "@zoonk/next/security-headers";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
@@ -29,6 +30,14 @@ const nextConfig: NextConfig = {
     turbopackFileSystemCacheForBuild: true,
     typedEnv: true,
   },
+  headers: async () =>
+    createSecurityHeaders({
+      imgSrc: [
+        "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com",
+        "https://*.googleusercontent.com",
+        "https://*.githubusercontent.com",
+      ],
+    }),
   images: {
     minimumCacheTTL: 60 * 60 * 24 * CACHE_IMAGE_DAYS,
     remotePatterns: [

--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import createMDX from "@next/mdx";
+import { createSecurityHeaders } from "@zoonk/next/security-headers";
 import { withBotId } from "botid/next/config";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
@@ -37,6 +38,16 @@ const nextConfig: NextConfig = {
     turbopackFileSystemCacheForBuild: true,
     typedEnv: true,
   },
+  headers: async () =>
+    createSecurityHeaders({
+      connectSrc: ["https://vitals.vercel-analytics.com"],
+      imgSrc: [
+        "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com",
+        "https://*.googleusercontent.com",
+        "https://*.githubusercontent.com",
+      ],
+      scriptSrc: ["https://va.vercel-scripts.com"],
+    }),
   images: {
     minimumCacheTTL: 60 * 60 * 24 * CACHE_IMAGE_DAYS,
     remotePatterns: [

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -10,7 +10,8 @@
     "typescript": "^5"
   },
   "exports": {
-    "./i18n/codec": "./src/i18n/next-intl-codec.ts"
+    "./i18n/codec": "./src/i18n/next-intl-codec.ts",
+    "./security-headers": "./src/security-headers.ts"
   },
   "name": "@zoonk/next",
   "peerDependencies": {

--- a/packages/next/src/security-headers.ts
+++ b/packages/next/src/security-headers.ts
@@ -1,0 +1,45 @@
+import type { Header } from "next/dist/lib/load-custom-routes";
+
+const isDev = process.env.NODE_ENV === "development";
+
+type CSPOptions = {
+  imgSrc?: string[];
+  scriptSrc?: string[];
+  connectSrc?: string[];
+};
+
+export function createSecurityHeaders(options: CSPOptions = {}): Header[] {
+  const imgSrc = ["'self'", "blob:", "data:", ...(options.imgSrc ?? [])];
+  const scriptSrc = ["'self'", "'unsafe-inline'", ...(options.scriptSrc ?? [])];
+  const connectSrc = ["'self'", ...(options.connectSrc ?? [])];
+
+  if (isDev) {
+    scriptSrc.push("'unsafe-eval'");
+  }
+
+  const csp = [
+    "default-src 'self'",
+    `script-src ${scriptSrc.join(" ")}`,
+    "style-src 'self' 'unsafe-inline'",
+    `img-src ${imgSrc.join(" ")}`,
+    "font-src 'self'",
+    `connect-src ${connectSrc.join(" ")}`,
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    "upgrade-insecure-requests",
+  ].join("; ");
+
+  return [
+    {
+      headers: [
+        { key: "Content-Security-Policy", value: csp },
+        { key: "X-Content-Type-Options", value: "nosniff" },
+        { key: "X-Frame-Options", value: "DENY" },
+        { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+      ],
+      source: "/(.*)",
+    },
+  ];
+}

--- a/packages/next/src/security-headers.ts
+++ b/packages/next/src/security-headers.ts
@@ -1,6 +1,8 @@
-import type { Header } from "next/dist/lib/load-custom-routes";
+import type { NextConfig } from "next";
 
 const isDev = process.env.NODE_ENV === "development";
+
+type Header = Awaited<ReturnType<NonNullable<NextConfig["headers"]>>>[number];
 
 type CSPOptions = {
   imgSrc?: string[];


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add CSP and other security headers to all Next.js apps using a shared helper. This tightens security while allowing required images and Vercel analytics to keep working.

- **New Features**
  - Added @zoonk/next/security-headers with createSecurityHeaders to set CSP, X-Content-Type-Options, X-Frame-Options, and Referrer-Policy (exported in packages/next).
  - Applied headers in apps: Auth uses defaults; Editor allows images from Vercel Storage, Google, and GitHub; Main also allows vitals.vercel-analytics.com (connect) and va.vercel-scripts.com (script).
  - Development adds 'unsafe-eval' to script-src for dev tooling.

<sup>Written for commit 659dea5334b2aaf199176b4616b3c57b51c8a246. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

