### PR TITLE
fix(main): preload all queries on home page

### DIFF
--- a/apps/main/src/app/[locale]/(catalog)/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/page.tsx
@@ -2,7 +2,11 @@ import type { Metadata } from "next";
 import { getExtracted, setRequestLocale } from "next-intl/server";
 import { Suspense } from "react";
 import { getContinueLearning } from "@/data/courses/get-continue-learning";
+import { getBeltLevel } from "@/data/progress/get-belt-level";
+import { getBestDay } from "@/data/progress/get-best-day";
+import { getBestTime } from "@/data/progress/get-best-time";
 import { getEnergyLevel } from "@/data/progress/get-energy-level";
+import { getScore } from "@/data/progress/get-score";
 import { HomeContent, HomeContentSkeleton } from "./home-content";
 
 export async function generateMetadata({
@@ -23,8 +27,15 @@ export default async function Home({ params }: PageProps<"/[locale]">) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  // preload data
-  void Promise.all([getContinueLearning(), getEnergyLevel()]);
+  // preload data for Suspense boundaries
+  void Promise.all([
+    getContinueLearning(),
+    getEnergyLevel(),
+    getBeltLevel(),
+    getScore(),
+    getBestDay(),
+    getBestTime(),
+  ]);
 
   return (
     <Suspense fallback={<HomeContentSkeleton />}>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preload all home page data queries to avoid network waterfalls and reduce Suspense fallbacks. Adds belt level, score, best day, and best time to the Promise.all alongside continue learning and energy level.

<sup>Written for commit 8affe9cfad84f6599fc827226d6b05daf183314f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

