### PR TITLE
feat(main): add animation to generation status

### DIFF
--- a/apps/main/src/components/generation/generation-progress.tsx
+++ b/apps/main/src/components/generation/generation-progress.tsx
@@ -91,7 +91,7 @@ function GenerationTimelineStepIndicator({
   if (status === "active") {
     return (
       <div className="relative flex size-6 shrink-0 items-center justify-center">
-        <div className="absolute inset-0 animate-pulse rounded-full border-2 border-foreground/30" />
+        <div className="absolute inset-0 animate-breathe rounded-full border-2 border-foreground/30 motion-reduce:animate-none motion-reduce:opacity-50" />
         <div className="flex size-6 items-center justify-center rounded-full border-2 border-foreground">
           <Icon aria-hidden="true" className="size-3 text-foreground" />
         </div>
@@ -140,7 +140,8 @@ function GenerationTimelineStep({
         className={cn(
           "pt-0.5 text-sm",
           status === "completed" && "text-muted-foreground",
-          status === "active" && "font-medium text-foreground",
+          status === "active" &&
+            "animate-shimmer-text bg-[linear-gradient(90deg,var(--foreground)_0%,var(--foreground)_40%,var(--muted-foreground)_50%,var(--foreground)_60%,var(--foreground)_100%)] bg-size-[200%_100%] bg-clip-text font-medium text-transparent motion-reduce:animate-none motion-reduce:bg-none motion-reduce:text-foreground",
           status === "pending" && "text-muted-foreground/60",
         )}
       >

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -59,6 +59,8 @@
   --color-belt-red: var(--belt-red);
   --color-belt-gray: var(--belt-gray);
   --color-belt-black: var(--belt-black);
+  --animate-breathe: breathe 2s ease-in-out infinite;
+  --animate-shimmer-text: shimmer-text 3s ease-in-out infinite;
 }
 
 :root {
@@ -252,6 +254,15 @@
   50% {
     transform: scale(1.3);
     opacity: 0.3;
+  }
+}
+
+@keyframes shimmer-text {
+  0% {
+    background-position: 200% center;
+  }
+  100% {
+    background-position: -200% center;
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds subtle animations to the generation progress UI so active steps are easier to follow. Replaces the pulse with a gentle breathe effect and adds shimmering active labels, with reduced-motion fallbacks.

- **New Features**
  - Active step ring now uses a gentle breathe animation.
  - Active step label gets a shimmer text effect.
  - Animations respect reduced motion; added CSS vars and shimmer-text keyframes.

<sup>Written for commit fb83232b58afb45b3f50fdcb6d8e1c243a17837f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

