### PR TITLE
feat(main): allow only subscribers to generate chapters

### DIFF
--- a/apps/main/src/app/api/workflows/chapter-generation/trigger/route.ts
+++ b/apps/main/src/app/api/workflows/chapter-generation/trigger/route.ts
@@ -1,4 +1,6 @@
+import { auth } from "@zoonk/core/auth";
 import { parseNumericId } from "@zoonk/utils/string";
+import { headers } from "next/headers";
 import { start } from "workflow/api";
 import { chapterGenerationWorkflow } from "@/workflows/chapter-generation/chapter-generation-workflow";
 
@@ -10,6 +12,21 @@ export async function POST(request: Request) {
     return Response.json(
       { error: "Missing or invalid chapterId" },
       { status: 400 },
+    );
+  }
+
+  const subscriptions = await auth.api.listActiveSubscriptions({
+    headers: await headers(),
+  });
+
+  const activeSubscription = subscriptions.find(
+    (sub) => sub.status === "active" || sub.status === "trialing",
+  );
+
+  if (!activeSubscription) {
+    return Response.json(
+      { error: "Active subscription required" },
+      { status: 402 },
     );
   }
 

--- a/apps/main/src/app/api/workflows/chapter-generation/trigger/route.ts
+++ b/apps/main/src/app/api/workflows/chapter-generation/trigger/route.ts
@@ -1,4 +1,5 @@
 import { auth } from "@zoonk/core/auth";
+import { findActiveSubscription } from "@zoonk/core/auth/subscription";
 import { parseNumericId } from "@zoonk/utils/string";
 import { headers } from "next/headers";
 import { start } from "workflow/api";
@@ -19,11 +20,7 @@ export async function POST(request: Request) {
     headers: await headers(),
   });
 
-  const activeSubscription = subscriptions.find(
-    (sub) => sub.status === "active" || sub.status === "trialing",
-  );
-
-  if (!activeSubscription) {
+  if (!findActiveSubscription(subscriptions)) {
     return Response.json(
       { error: "Active subscription required" },
       { status: 402 },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -22,6 +22,7 @@
     "./hooks/auth-state": "./src/hooks/use-auth-state.ts",
     "./hooks/subscription": "./src/hooks/use-subscription.ts",
     "./next": "./src/next.ts",
+    "./subscription": "./src/subscription.ts",
     "./testing": "./src/testing.ts",
     "./types": "./src/types.ts"
   },

--- a/packages/auth/src/hooks/use-subscription.ts
+++ b/packages/auth/src/hooks/use-subscription.ts
@@ -1,15 +1,11 @@
 import type { Subscription } from "@better-auth/stripe";
 import { useEffect, useState } from "react";
 import { authClient } from "../client";
+import { findActiveSubscription } from "../subscription";
 
 async function getActiveSubscription() {
-  const { data: subscription } = await authClient.subscription.list();
-
-  const activeSubscription = subscription?.find(
-    (sub) => sub.status === "active" || sub.status === "trialing",
-  );
-
-  return activeSubscription || null;
+  const { data: subscriptions } = await authClient.subscription.list();
+  return findActiveSubscription(subscriptions) ?? null;
 }
 
 export function useSubscription() {

--- a/packages/auth/src/subscription.ts
+++ b/packages/auth/src/subscription.ts
@@ -1,0 +1,13 @@
+type SubscriptionStatus = { status?: string | null };
+
+export function isActiveSubscription<T extends SubscriptionStatus>(
+  sub: T,
+): boolean {
+  return sub.status === "active" || sub.status === "trialing";
+}
+
+export function findActiveSubscription<T extends SubscriptionStatus>(
+  subscriptions: T[] | null | undefined,
+): T | undefined {
+  return subscriptions?.find(isActiveSubscription);
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
     "./auth/hooks/auth-state": "./src/auth/hooks/auth-state.ts",
     "./auth/hooks/subscription": "./src/auth/hooks/subscription.ts",
     "./auth/next": "./src/auth/next.ts",
+    "./auth/subscription": "./src/auth/subscription.ts",
     "./cache/revalidate": "./src/cache/revalidate-main-app.ts",
     "./courses/image": "./src/courses/course-image.ts",
     "./images/optimize": "./src/images/optimize-image.ts",

--- a/packages/core/src/auth/subscription.ts
+++ b/packages/core/src/auth/subscription.ts
@@ -1,0 +1,5 @@
+// biome-ignore lint/performance/noBarrelFile: re-exporting for convenience
+export {
+  findActiveSubscription,
+  isActiveSubscription,
+} from "@zoonk/auth/subscription";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Only subscribers can trigger chapter generation. Non-subscribed requests now return 402, and a shared helper detects active subscriptions across packages.

- **New Features**
  - Enforced subscription check in the chapter-generation trigger route using auth and Next headers.
  - Returns 402 with “Active subscription required” when no active subscription is found.

- **Refactors**
  - Added isActiveSubscription and findActiveSubscription helpers; exported in auth and re-exported in core.
  - Simplified use-subscription hook to use the shared helper.

<sup>Written for commit 1efc51ea601432ca8767ae9f5d73bf248eb48558. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

