### PR TITLE
chore: update terms of service

### DIFF
--- a/apps/main/src/app/[locale]/terms/en.mdx
+++ b/apps/main/src/app/[locale]/terms/en.mdx
@@ -26,6 +26,7 @@ By using Zoonk, you agree to these Terms of Service. If you don’t agree, pleas
 - Subscriptions renew automatically until canceled.
 - You can cancel at any time through our website, the App Store, or the Play Store.
 - We may provide refunds at our discretion.
+- "Unlimited" plans are subject to a fair-usage policy. This means unlimited personal, human use—not automated access, bots, or any means to bypass rate limits.
 
 ---
 
@@ -64,6 +65,12 @@ You may not use Zoonk to:
 - Spam, abuse, or disrupt the service.
 - Harm others or violate laws.
 - Misuse payments (for example, disputing charges instead of asking for a refund).
+- Use bots, scripts, automation tools, or any non-human means to access the service or generate content.
+- Circumvent, disable, or interfere with usage limits, rate limiting, or other technical restrictions.
+- Access the service through unauthorized third-party applications or tools.
+- Scrape, crawl, or collect data from Zoonk through automated means.
+- Share account credentials or access tokens with others or automated systems.
+- Exploit free trials, promotional offers, or subscription tiers through automated account creation.
 
 We may suspend or delete your account at our discretion if you break these rules.
 

--- a/apps/main/src/app/[locale]/terms/es.mdx
+++ b/apps/main/src/app/[locale]/terms/es.mdx
@@ -26,6 +26,7 @@ Al usar Zoonk, aceptas estos Términos de Servicio. Si no estás de acuerdo, por
 - Las suscripciones se renuevan automáticamente hasta que se cancelen.
 - Puedes cancelar en cualquier momento a través de nuestro sitio web, App Store o Play Store.
 - Podemos proporcionar reembolsos a nuestra discreción.
+- Los planes "ilimitados" están sujetos a una política de uso justo. Esto significa uso personal y humano ilimitado—no acceso automatizado, bots ni ningún medio para eludir límites de velocidad.
 
 ---
 
@@ -62,6 +63,12 @@ No puedes usar Zoonk para:
 - Enviar spam, abusar o interrumpir el servicio.
 - Dañar a otros o violar leyes.
 - Hacer uso indebido de pagos (por ejemplo, disputar cargos en lugar de solicitar un reembolso).
+- Usar bots, scripts, herramientas de automatización o cualquier medio no humano para acceder al servicio o generar contenido.
+- Eludir, deshabilitar o interferir con límites de uso, limitación de velocidad u otras restricciones técnicas.
+- Acceder al servicio a través de aplicaciones o herramientas de terceros no autorizadas.
+- Hacer scraping, rastreo o recopilación de datos de Zoonk por medios automatizados.
+- Compartir credenciales de cuenta o tokens de acceso con otros o sistemas automatizados.
+- Explotar pruebas gratuitas, ofertas promocionales o niveles de suscripción mediante la creación automatizada de cuentas.
 
 Podemos suspender o eliminar tu cuenta a nuestra discreción si infringes estas reglas.
 

--- a/apps/main/src/app/[locale]/terms/pt.mdx
+++ b/apps/main/src/app/[locale]/terms/pt.mdx
@@ -26,6 +26,7 @@ Ao usar o Zoonk, você concorda com estes Termos de Serviço. Se não concordar,
 - As assinaturas renovam automaticamente até serem canceladas.
 - Você pode cancelar a qualquer momento pelo nosso site, App Store ou Play Store.
 - Podemos fornecer reembolsos a nosso critério.
+- Planos "ilimitados" estão sujeitos a uma política de uso justo. Isso significa uso pessoal e humano ilimitado—não acesso automatizado, bots ou qualquer meio para contornar limites de taxa.
 
 ---
 
@@ -62,6 +63,12 @@ Você não pode usar o Zoonk para:
 - Enviar spam, abusar ou prejudicar o serviço.
 - Prejudicar outros ou violar leis.
 - Fazer uso indevido de pagamentos (por exemplo, contestar cobranças em vez de solicitar reembolso).
+- Usar bots, scripts, ferramentas de automação ou qualquer meio não humano para acessar o serviço ou gerar conteúdo.
+- Contornar, desativar ou interferir em limites de uso, limitação de taxa ou outras restrições técnicas.
+- Acessar o serviço por meio de aplicativos ou ferramentas de terceiros não autorizados.
+- Fazer scraping, rastreamento ou coleta de dados do Zoonk por meios automatizados.
+- Compartilhar credenciais de conta ou tokens de acesso com outras pessoas ou sistemas automatizados.
+- Explorar períodos de teste gratuito, ofertas promocionais ou planos de assinatura por meio de criação automatizada de contas.
 
 Podemos suspender ou excluir sua conta a nosso critério se você violar estas regras.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated Terms of Service in English, Spanish, and Portuguese to add a fair-usage policy for “Unlimited” plans and explicitly ban automated/bot access, rate-limit circumvention, unauthorized tools, scraping, credential sharing, and abuse of trials/promos. Clarifies that access is for personal, human use and strengthens enforcement guidelines.

<sup>Written for commit 56186c136019189015b26ded0168b67a9ceab4f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

