### PR TITLE
feat(main): add ui for chapter generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,7 @@ For detailed testing patterns, fixtures, and best practices, see `.claude/skills
 - Use `getExtracted` (server) or `useExtracted` (client) for translations
 - **IMPORTANT**: The `t` function does NOT support dynamic keys. Use string literals: `t("Arts courses")`, not `t(someVariable)`
 - **CRITICAL: NEVER pass `t` as a function argument**. This is a common mistake that breaks i18n extraction. Instead of passing `t` to a function, create an async function that calls `getExtracted()` internally (see `@apps/main/src/lib/categories.ts` and `@apps/main/src/lib/belt-colors.ts` for examples)
+- **CRITICAL: NEVER call `getExtracted()` inside `Promise.all()`**
 - Always read the [translations skill](.claude/skills/translations/SKILL.md) when using `next-intl`.
 
 ## CSS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ For detailed testing patterns, fixtures, and best practices, see `.claude/skills
 - Use `getExtracted` (server) or `useExtracted` (client) for translations
 - **IMPORTANT**: The `t` function does NOT support dynamic keys. Use string literals: `t("Arts courses")`, not `t(someVariable)`
 - **CRITICAL: NEVER pass `t` as a function argument**. This is a common mistake that breaks i18n extraction. Instead of passing `t` to a function, create an async function that calls `getExtracted()` internally (see `@apps/main/src/lib/categories.ts` and `@apps/main/src/lib/belt-colors.ts` for examples)
+- **CRITICAL: NEVER call `getExtracted()` inside `Promise.all()`**
 - Always read the [translations skill](.claude/skills/translations/SKILL.md) when using `next-intl`.
 
 ## CSS

--- a/apps/main/e2e/course-chapters.test.ts
+++ b/apps/main/e2e/course-chapters.test.ts
@@ -161,7 +161,6 @@ test.describe("Course Chapters - No Lessons", () => {
     await expect(
       page.getByRole("heading", { name: /generate chapter/i }),
     ).toBeVisible();
-    await expect(page.getByText(/coming soon/i)).toBeVisible();
   });
 });
 

--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -1,0 +1,271 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import type { Page, Route } from "@zoonk/e2e/fixtures";
+import { expect, test } from "./fixtures";
+
+/**
+ * Test Architecture for Chapter Generation Page
+ *
+ * The generation page has 3 access states:
+ * 1. Unauthenticated - Shows login prompt
+ * 2. Authenticated without subscription - Shows upgrade CTA
+ * 3. Authenticated with subscription - Shows generation UI
+ *
+ * The generation flow interacts with 2 APIs:
+ * 1. POST /api/workflows/chapter-generation/trigger - Starts the workflow, returns { runId: string }
+ * 2. GET /api/workflows/status?runId=X&startIndex=N - Returns SSE stream of step updates
+ */
+
+const TEST_RUN_ID = "test-run-id-chapter-12345";
+const TEST_USER_EMAIL = "e2e-new@zoonk.test";
+
+type MockApiOptions = {
+  triggerResponse?: { runId?: string; error?: string; status?: number };
+  streamMessages?: Array<{ step: string; status: string }>;
+  streamError?: boolean;
+};
+
+/**
+ * Creates a mock SSE stream response from an array of messages.
+ */
+function createSSEStream(
+  messages: Array<{ step: string; status: string }>,
+): string {
+  return messages.map((msg) => `data: ${JSON.stringify(msg)}\n\n`).join("");
+}
+
+/**
+ * Creates the route handler function for mocking APIs.
+ */
+function createRouteHandler(options: MockApiOptions) {
+  const {
+    triggerResponse = { runId: TEST_RUN_ID },
+    streamMessages = [],
+    streamError = false,
+  } = options;
+
+  return async (route: Route) => {
+    const url = route.request().url();
+    const method = route.request().method();
+
+    // Mock trigger API
+    if (
+      url.includes("/api/workflows/chapter-generation/trigger") &&
+      method === "POST"
+    ) {
+      if (triggerResponse.error) {
+        await route.fulfill({
+          body: JSON.stringify({ error: triggerResponse.error }),
+          contentType: "application/json",
+          status: triggerResponse.status ?? 500,
+        });
+        return;
+      }
+      await route.fulfill({
+        body: JSON.stringify({
+          message: "Workflow started",
+          runId: triggerResponse.runId,
+        }),
+        contentType: "application/json",
+        status: 200,
+      });
+      return;
+    }
+
+    // Mock status stream API
+    if (url.includes("/api/workflows/status")) {
+      if (streamError) {
+        await route.abort("failed");
+        return;
+      }
+      await route.fulfill({
+        body: createSSEStream(streamMessages),
+        contentType: "text/event-stream",
+        status: 200,
+      });
+      return;
+    }
+
+    // Continue with all other requests
+    await route.continue();
+  };
+}
+
+/**
+ * Sets up route interception for chapter generation APIs.
+ */
+async function setupMockApis(
+  page: Page,
+  options: MockApiOptions = {},
+): Promise<void> {
+  const handler = createRouteHandler(options);
+  await page.route("**/api/workflows/**", handler);
+}
+
+/**
+ * Gets a chapter ID with pending generation status for testing.
+ */
+async function getPendingChapterId(): Promise<number> {
+  const chapter = await prisma.chapter.findFirst({
+    select: { id: true },
+    where: {
+      generationStatus: "pending",
+      slug: "e2e-no-lessons-chapter",
+    },
+  });
+
+  if (!chapter) {
+    throw new Error("No pending chapter found for E2E testing");
+  }
+
+  return chapter.id;
+}
+
+/**
+ * Creates a test subscription for the test user.
+ */
+async function createTestSubscription() {
+  const uniqueId = randomUUID();
+
+  const user = await prisma.user.findUniqueOrThrow({
+    where: { email: TEST_USER_EMAIL },
+  });
+
+  const subscription = await prisma.subscription.create({
+    data: {
+      plan: "hobby",
+      referenceId: String(user.id),
+      status: "active",
+      stripeCustomerId: `cus_test_e2e_${uniqueId}`,
+      stripeSubscriptionId: `sub_test_e2e_${uniqueId}`,
+    },
+  });
+
+  return subscription;
+}
+
+test.describe("Generate Chapter Page - Unauthenticated", () => {
+  test("shows login prompt with link to login page", async ({ page }) => {
+    const chapterId = await getPendingChapterId();
+    await page.goto(`/generate/ch/${chapterId}`);
+
+    await expect(
+      page.getByRole("alert").filter({ hasText: /logged in/i }),
+    ).toBeVisible();
+
+    const loginLink = page.getByRole("link", { name: /login/i });
+    await expect(loginLink).toBeVisible();
+    await expect(loginLink).toHaveAttribute("href", "/login");
+  });
+});
+
+test.describe("Generate Chapter Page - No Subscription", () => {
+  test("shows upgrade CTA when authenticated without subscription", async ({
+    authenticatedPage,
+  }) => {
+    const chapterId = await getPendingChapterId();
+    await authenticatedPage.goto(`/generate/ch/${chapterId}`);
+
+    await expect(
+      authenticatedPage.getByText(/upgrade to generate/i),
+    ).toBeVisible();
+
+    await expect(
+      authenticatedPage.getByRole("button", { name: /upgrade/i }),
+    ).toBeVisible();
+  });
+
+  test("upgrade button shows loading state when clicked", async ({
+    authenticatedPage,
+  }) => {
+    const chapterId = await getPendingChapterId();
+    await authenticatedPage.goto(`/generate/ch/${chapterId}`);
+
+    const upgradeButton = authenticatedPage.getByRole("button", {
+      name: /upgrade/i,
+    });
+
+    await upgradeButton.click();
+    await expect(upgradeButton).toBeDisabled();
+  });
+});
+
+test.describe("Generate Chapter Page - With Subscription", () => {
+  test("shows generation UI and completes workflow", async ({
+    userWithoutProgress,
+  }) => {
+    const subscription = await createTestSubscription();
+
+    try {
+      const chapterId = await getPendingChapterId();
+
+      await setupMockApis(userWithoutProgress, {
+        streamMessages: [
+          { status: "started", step: "getChapter" },
+          { status: "completed", step: "getChapter" },
+          { status: "started", step: "setChapterAsRunning" },
+          { status: "completed", step: "setChapterAsRunning" },
+          { status: "started", step: "generateLessons" },
+          { status: "completed", step: "generateLessons" },
+          { status: "started", step: "addLessons" },
+          { status: "completed", step: "addLessons" },
+          { status: "started", step: "setChapterAsCompleted" },
+          { status: "completed", step: "setChapterAsCompleted" },
+        ],
+      });
+
+      await userWithoutProgress.goto(`/generate/ch/${chapterId}`);
+
+      // Should show completion message
+      await expect(
+        userWithoutProgress.getByText(/lessons generated/i),
+      ).toBeVisible({ timeout: 10_000 });
+
+      await expect(
+        userWithoutProgress.getByText(/redirecting to your course/i),
+      ).toBeVisible();
+
+      // Should redirect to course page
+      await userWithoutProgress.waitForURL(/\/b\/ai\/c\//, { timeout: 10_000 });
+    } finally {
+      await prisma.subscription.delete({ where: { id: subscription.id } });
+    }
+  });
+
+  test("shows error when stream returns error status", async ({
+    userWithoutProgress,
+  }) => {
+    const subscription = await createTestSubscription();
+
+    try {
+      const chapterId = await getPendingChapterId();
+
+      await setupMockApis(userWithoutProgress, {
+        streamMessages: [
+          { status: "started", step: "getChapter" },
+          { status: "error", step: "getChapter" },
+        ],
+      });
+
+      await userWithoutProgress.goto(`/generate/ch/${chapterId}`);
+
+      await expect(
+        userWithoutProgress.getByText(/generation failed/i),
+      ).toBeVisible({ timeout: 10_000 });
+    } finally {
+      await prisma.subscription.delete({ where: { id: subscription.id } });
+    }
+  });
+});
+
+test.describe("Generate Chapter Page - Not Found", () => {
+  test("invalid chapter ID shows 404 page", async ({ page }) => {
+    await page.goto("/generate/ch/999999");
+    await expect(page.getByText(/not found|404/i)).toBeVisible();
+  });
+
+  test("non-numeric chapter ID shows 404 page", async ({ page }) => {
+    await page.goto("/generate/ch/invalid-id");
+    await expect(page.getByText(/not found|404/i)).toBeVisible();
+  });
+});

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -9,6 +9,7 @@ msgstr ""
 #: src/app/[locale]/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/[locale]/(performance)/_components/performance-empty-state.tsx
 #: src/app/[locale]/(settings)/_components/protected-section.tsx
+#: src/components/auth/login-required.tsx
 msgctxt "AyGauy"
 msgid "Login"
 msgstr "Login"
@@ -735,6 +736,7 @@ msgid "Checking if you're logged in..."
 msgstr "Checking if you're logged in..."
 
 #: src/app/[locale]/(settings)/_components/protected-section.tsx
+#: src/components/auth/login-required.tsx
 msgctxt "yOFm9C"
 msgid "You need to be logged in to access this page."
 msgstr "You need to be logged in to access this page."
@@ -821,6 +823,7 @@ msgid "Check your plan details and manage your subscription."
 msgstr "Check your plan details and manage your subscription."
 
 #: src/app/[locale]/(settings)/subscription/subscription-page.tsx
+#: src/components/subscription/upgrade-cta.tsx
 msgctxt "0h/lPM"
 msgid "Upgrade"
 msgstr "Upgrade"
@@ -836,6 +839,7 @@ msgid "Remove ads, unlock unlimited lessons, and track your progress."
 msgstr "Remove ads, unlock unlimited lessons, and track your progress."
 
 #: src/app/[locale]/(settings)/subscription/subscription-page.tsx
+#: src/components/subscription/upgrade-cta.tsx
 msgctxt "s1ZXI0"
 msgid "Unable to update your subscription. Contact us at hello@zoonk.com"
 msgstr "Unable to update your subscription. Contact us at hello@zoonk.com"
@@ -917,10 +921,66 @@ msgctxt "PJivSX"
 msgid "Lesson"
 msgstr "Lesson"
 
+#: src/app/[locale]/generate/ch/[id]/generate-chapter-content.tsx
+msgctxt "9GwOlW"
+msgid "Generate Chapter"
+msgstr "Generate Chapter"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 msgctxt "/Nrb/0"
 msgid "Generation progress"
 msgstr "Generation progress"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+msgctxt "FazwRl"
+msgid "Try again"
+msgstr "Try again"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+msgctxt "IEv8EV"
+msgid "Redirecting to your course..."
+msgstr "Redirecting to your course..."
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+msgctxt "ssRq8D"
+msgid "Generation failed"
+msgstr "Generation failed"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+msgctxt "TFEFX2"
+msgid "Lessons generated"
+msgstr "Lessons generated"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+msgctxt "ViO6Dt"
+msgid "Creating your lessons"
+msgstr "Creating your lessons"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+msgctxt "W/5hwr"
+msgid "Something went wrong. Please try again."
+msgstr "Something went wrong. Please try again."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "1QgqKE"
+msgid "Generating lessons"
+msgstr "Generating lessons"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+msgctxt "V4F+/7"
+msgid "Finishing up"
+msgstr "Finishing up"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+msgctxt "Z2/Dlq"
+msgid "Loading chapter information"
+msgstr "Loading chapter information"
 
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 msgctxt "DFlapX"
@@ -928,34 +988,9 @@ msgid "Creating your course"
 msgstr "Creating your course"
 
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
-msgctxt "FazwRl"
-msgid "Try again"
-msgstr "Try again"
-
-#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
-msgctxt "IEv8EV"
-msgid "Redirecting to your course..."
-msgstr "Redirecting to your course..."
-
-#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
-msgctxt "ssRq8D"
-msgid "Generation failed"
-msgstr "Generation failed"
-
-#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 msgctxt "TKVQj2"
 msgid "Course generated"
 msgstr "Course generated"
-
-#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
-msgctxt "W/5hwr"
-msgid "Something went wrong. Please try again."
-msgstr "Something went wrong. Please try again."
-
-#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
-msgctxt "1QgqKE"
-msgid "Generating lessons"
-msgstr "Generating lessons"
 
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 msgctxt "4AKS22"
@@ -1061,6 +1096,16 @@ msgstr "Feedback"
 msgctxt "eUzs3M"
 msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
+
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "L90YUq"
+msgid "Upgrade to generate"
+msgstr "Upgrade to generate"
+
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "rNPMU8"
+msgid "Generating content with AI requires an active subscription."
+msgstr "Generating content with AI requires an active subscription."
 
 #: src/lib/activities.ts
 msgctxt "1TOMnj"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -9,6 +9,7 @@ msgstr ""
 #: src/app/[locale]/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/[locale]/(performance)/_components/performance-empty-state.tsx
 #: src/app/[locale]/(settings)/_components/protected-section.tsx
+#: src/components/auth/login-required.tsx
 msgctxt "AyGauy"
 msgid "Login"
 msgstr "Iniciar sesión"
@@ -735,6 +736,7 @@ msgid "Checking if you're logged in..."
 msgstr "Comprobando si has iniciado sesión..."
 
 #: src/app/[locale]/(settings)/_components/protected-section.tsx
+#: src/components/auth/login-required.tsx
 msgctxt "yOFm9C"
 msgid "You need to be logged in to access this page."
 msgstr "Necesitas iniciar sesión para acceder a esta página."
@@ -821,6 +823,7 @@ msgid "Check your plan details and manage your subscription."
 msgstr "Consulta los detalles de tu plan y gestiona tu suscripción."
 
 #: src/app/[locale]/(settings)/subscription/subscription-page.tsx
+#: src/components/subscription/upgrade-cta.tsx
 msgctxt "0h/lPM"
 msgid "Upgrade"
 msgstr "Mejorar"
@@ -836,6 +839,7 @@ msgid "Remove ads, unlock unlimited lessons, and track your progress."
 msgstr "Elimina los anuncios, desbloquea lecciones ilimitadas y haz seguimiento de tu progreso."
 
 #: src/app/[locale]/(settings)/subscription/subscription-page.tsx
+#: src/components/subscription/upgrade-cta.tsx
 msgctxt "s1ZXI0"
 msgid "Unable to update your subscription. Contact us at hello@zoonk.com"
 msgstr "No se pudo actualizar tu suscripción. Contacta con nosotros en contacto@zoonk.com"
@@ -917,10 +921,66 @@ msgctxt "PJivSX"
 msgid "Lesson"
 msgstr "Lección"
 
+#: src/app/[locale]/generate/ch/[id]/generate-chapter-content.tsx
+msgctxt "9GwOlW"
+msgid "Generate Chapter"
+msgstr "Generar capítulo"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 msgctxt "/Nrb/0"
 msgid "Generation progress"
 msgstr "Progreso de generación"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+msgctxt "FazwRl"
+msgid "Try again"
+msgstr "Intentar de nuevo"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+msgctxt "IEv8EV"
+msgid "Redirecting to your course..."
+msgstr "Redirigiendo a tu curso..."
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+msgctxt "ssRq8D"
+msgid "Generation failed"
+msgstr "La generación falló"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+msgctxt "TFEFX2"
+msgid "Lessons generated"
+msgstr "Lecciones generadas"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+msgctxt "ViO6Dt"
+msgid "Creating your lessons"
+msgstr "Creando tus lecciones"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+msgctxt "W/5hwr"
+msgid "Something went wrong. Please try again."
+msgstr "Algo salió mal. Por favor, intenta de nuevo."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "1QgqKE"
+msgid "Generating lessons"
+msgstr "Generando lecciones"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+msgctxt "V4F+/7"
+msgid "Finishing up"
+msgstr "Finalizando"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+msgctxt "Z2/Dlq"
+msgid "Loading chapter information"
+msgstr "Cargando información del capítulo"
 
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 msgctxt "DFlapX"
@@ -928,34 +988,9 @@ msgid "Creating your course"
 msgstr "Creando tu curso"
 
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
-msgctxt "FazwRl"
-msgid "Try again"
-msgstr "Intentar de nuevo"
-
-#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
-msgctxt "IEv8EV"
-msgid "Redirecting to your course..."
-msgstr "Redirigiendo a tu curso..."
-
-#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
-msgctxt "ssRq8D"
-msgid "Generation failed"
-msgstr "La generación falló"
-
-#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 msgctxt "TKVQj2"
 msgid "Course generated"
 msgstr "Curso generado"
-
-#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
-msgctxt "W/5hwr"
-msgid "Something went wrong. Please try again."
-msgstr "Algo salió mal. Por favor, intenta de nuevo."
-
-#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
-msgctxt "1QgqKE"
-msgid "Generating lessons"
-msgstr "Generando lecciones"
 
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 msgctxt "4AKS22"
@@ -1061,6 +1096,16 @@ msgstr "Comentarios"
 msgctxt "eUzs3M"
 msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Envíanos comentarios, preguntas o sugerencias. Completa el formulario a continuación o escríbenos directamente a contacto@zoonk.com."
+
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "L90YUq"
+msgid "Upgrade to generate"
+msgstr "Suscríbete para generar"
+
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "rNPMU8"
+msgid "Generating content with AI requires an active subscription."
+msgstr "Generar contenido con IA requiere una suscripción activa."
 
 #: src/lib/activities.ts
 msgctxt "1TOMnj"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -9,6 +9,7 @@ msgstr ""
 #: src/app/[locale]/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/[locale]/(performance)/_components/performance-empty-state.tsx
 #: src/app/[locale]/(settings)/_components/protected-section.tsx
+#: src/components/auth/login-required.tsx
 msgctxt "AyGauy"
 msgid "Login"
 msgstr "Entrar"
@@ -735,6 +736,7 @@ msgid "Checking if you're logged in..."
 msgstr "Verificando se você está conectado..."
 
 #: src/app/[locale]/(settings)/_components/protected-section.tsx
+#: src/components/auth/login-required.tsx
 msgctxt "yOFm9C"
 msgid "You need to be logged in to access this page."
 msgstr "Você precisa estar conectado para acessar esta página."
@@ -821,6 +823,7 @@ msgid "Check your plan details and manage your subscription."
 msgstr "Verifique os detalhes do seu plano e gerencie sua assinatura."
 
 #: src/app/[locale]/(settings)/subscription/subscription-page.tsx
+#: src/components/subscription/upgrade-cta.tsx
 msgctxt "0h/lPM"
 msgid "Upgrade"
 msgstr "Upgrade"
@@ -836,6 +839,7 @@ msgid "Remove ads, unlock unlimited lessons, and track your progress."
 msgstr "Remova anúncios, desbloqueie aulas ilimitadas e acompanhe seu progresso."
 
 #: src/app/[locale]/(settings)/subscription/subscription-page.tsx
+#: src/components/subscription/upgrade-cta.tsx
 msgctxt "s1ZXI0"
 msgid "Unable to update your subscription. Contact us at hello@zoonk.com"
 msgstr "Não foi possível atualizar sua assinatura. Entre em contato pelo email contato@zoonk.com"
@@ -917,10 +921,66 @@ msgctxt "PJivSX"
 msgid "Lesson"
 msgstr "Aula"
 
+#: src/app/[locale]/generate/ch/[id]/generate-chapter-content.tsx
+msgctxt "9GwOlW"
+msgid "Generate Chapter"
+msgstr "Gerar capítulo"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 msgctxt "/Nrb/0"
 msgid "Generation progress"
 msgstr "Progresso da geração"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+msgctxt "FazwRl"
+msgid "Try again"
+msgstr "Tentar novamente"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+msgctxt "IEv8EV"
+msgid "Redirecting to your course..."
+msgstr "Redirecionando para o seu curso..."
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+msgctxt "ssRq8D"
+msgid "Generation failed"
+msgstr "Geração falhou"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+msgctxt "TFEFX2"
+msgid "Lessons generated"
+msgstr "Aulas geradas"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+msgctxt "ViO6Dt"
+msgid "Creating your lessons"
+msgstr "Criando suas aulas"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+msgctxt "W/5hwr"
+msgid "Something went wrong. Please try again."
+msgstr "Algo deu errado. Por favor, tente novamente."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "1QgqKE"
+msgid "Generating lessons"
+msgstr "Gerando aulas"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+msgctxt "V4F+/7"
+msgid "Finishing up"
+msgstr "Finalizando"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+msgctxt "Z2/Dlq"
+msgid "Loading chapter information"
+msgstr "Carregando informações do capítulo"
 
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 msgctxt "DFlapX"
@@ -928,34 +988,9 @@ msgid "Creating your course"
 msgstr "Criando seu curso"
 
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
-msgctxt "FazwRl"
-msgid "Try again"
-msgstr "Tentar novamente"
-
-#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
-msgctxt "IEv8EV"
-msgid "Redirecting to your course..."
-msgstr "Redirecionando para o seu curso..."
-
-#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
-msgctxt "ssRq8D"
-msgid "Generation failed"
-msgstr "Geração falhou"
-
-#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 msgctxt "TKVQj2"
 msgid "Course generated"
 msgstr "Curso gerado"
-
-#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
-msgctxt "W/5hwr"
-msgid "Something went wrong. Please try again."
-msgstr "Algo deu errado. Por favor, tente novamente."
-
-#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
-msgctxt "1QgqKE"
-msgid "Generating lessons"
-msgstr "Gerando aulas"
 
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 msgctxt "4AKS22"
@@ -1061,6 +1096,16 @@ msgstr "Feedback"
 msgctxt "eUzs3M"
 msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Envie feedback, perguntas ou sugestões para a gente. Preencha o formulário abaixo ou envie um email diretamente para contato@zoonk.com."
+
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "L90YUq"
+msgid "Upgrade to generate"
+msgstr "Assine para gerar"
+
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "rNPMU8"
+msgid "Generating content with AI requires an active subscription."
+msgstr "Gerar conteúdo com IA requer uma assinatura ativa."
 
 #: src/lib/activities.ts
 msgctxt "1TOMnj"

--- a/apps/main/src/app/[locale]/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/generate-chapter-content.tsx
@@ -1,27 +1,78 @@
+import { getSession } from "@zoonk/core/users/session/get";
 import {
   Container,
   ContainerBody,
+  ContainerDescription,
   ContainerHeader,
   ContainerHeaderGroup,
   ContainerTitle,
 } from "@zoonk/ui/components/container";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { parseNumericId } from "@zoonk/utils/string";
+import { notFound, redirect } from "next/navigation";
+import { getExtracted } from "next-intl/server";
+import { LoginRequired } from "@/components/auth/login-required";
+import { SubscriptionGate } from "@/components/subscription/subscription-gate";
+import { getChapterForGeneration } from "@/data/chapters/get-chapter-for-generation";
+import { GenerationClient } from "./generation-client";
 
-export async function GenerateChapterContent() {
+type GenerateChapterContentProps = {
+  params: Promise<{ id: string; locale: string }>;
+};
+
+export async function GenerateChapterContent({
+  params,
+}: GenerateChapterContentProps) {
+  const { id, locale } = await params;
+  const chapterId = parseNumericId(id);
+
+  if (chapterId === null) {
+    notFound();
+  }
+
+  const [session, chapter] = await Promise.all([
+    getSession(),
+    getChapterForGeneration(chapterId),
+  ]);
+
+  if (!chapter) {
+    notFound();
+  }
+
+  const t = await getExtracted();
+
+  if (!session) {
+    return <LoginRequired title={t("Generate Chapter")} />;
+  }
+
+  if (chapter.generationStatus === "completed") {
+    redirect(`/${locale}/b/${AI_ORG_SLUG}/c/${chapter.course.slug}`);
+  }
+
+  const returnUrl = `/generate/ch/${chapterId}`;
+
   return (
     <Container variant="narrow">
       <ContainerHeader>
         <ContainerHeaderGroup>
-          {/* biome-ignore lint/nursery/noJsxLiterals: placeholder page */}
-          <ContainerTitle>Generate Chapter</ContainerTitle>
+          <ContainerTitle>{chapter.title}</ContainerTitle>
+          {chapter.description && (
+            <ContainerDescription>{chapter.description}</ContainerDescription>
+          )}
         </ContainerHeaderGroup>
       </ContainerHeader>
 
       <ContainerBody>
-        <div className="flex h-64 items-center justify-center rounded-xl border border-dashed text-muted-foreground">
-          {/* biome-ignore lint/nursery/noJsxLiterals: placeholder page */}
-          Coming soon
-        </div>
+        <SubscriptionGate returnUrl={returnUrl}>
+          <GenerationClient
+            chapterId={chapterId}
+            courseSlug={chapter.course.slug}
+            generationRunId={chapter.generationRunId}
+            generationStatus={chapter.generationStatus}
+            locale={locale}
+          />
+        </SubscriptionGate>
       </ContainerBody>
     </Container>
   );
@@ -33,6 +84,7 @@ export function GenerateChapterFallback() {
       <ContainerHeader>
         <ContainerHeaderGroup>
           <Skeleton className="h-8 w-48" />
+          <Skeleton className="mt-1 h-4 w-72" />
         </ContainerHeaderGroup>
       </ContainerHeader>
 

--- a/apps/main/src/app/[locale]/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/generation-client.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import type { GenerationStatus } from "@zoonk/db";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { useExtracted } from "next-intl";
+import {
+  GenerationProgressCompleted,
+  GenerationProgressError,
+  GenerationTimeline,
+  GenerationTimelineHeader,
+  GenerationTimelineProgress,
+  GenerationTimelineStep,
+  GenerationTimelineSteps,
+  GenerationTimelineTitle,
+} from "@/components/generation/generation-progress";
+import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
+import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
+import type { StepName } from "@/workflows/chapter-generation/types";
+import { useGenerationPhases } from "./use-generation-phases";
+
+export function GenerationClient({
+  chapterId,
+  courseSlug,
+  generationRunId,
+  generationStatus,
+  locale,
+}: {
+  chapterId: number;
+  courseSlug: string;
+  generationRunId: string | null;
+  generationStatus: GenerationStatus;
+  locale: string;
+}) {
+  const t = useExtracted();
+
+  const generation = useWorkflowGeneration<StepName>({
+    completionStep: "setChapterAsCompleted",
+    initialRunId: generationRunId,
+    initialStatus: generationStatus === "running" ? "streaming" : "idle",
+    statusUrl: "/api/workflows/status",
+    triggerBody: { chapterId },
+    triggerUrl: "/api/workflows/chapter-generation/trigger",
+  });
+
+  const { phases, progress } = useGenerationPhases(
+    generation.completedSteps,
+    generation.currentStep,
+  );
+
+  useCompletionRedirect({
+    status: generation.status,
+    url: `/${locale}/b/${AI_ORG_SLUG}/c/${courseSlug}`,
+  });
+
+  if (generation.status === "triggering" || generation.status === "streaming") {
+    return (
+      <GenerationTimeline>
+        <GenerationTimelineHeader>
+          <GenerationTimelineTitle>
+            {t("Creating your lessons")}
+          </GenerationTimelineTitle>
+          <GenerationTimelineProgress
+            label={t("Generation progress")}
+            value={progress}
+          />
+        </GenerationTimelineHeader>
+
+        <GenerationTimelineSteps>
+          {phases.map((phase, index) => (
+            <GenerationTimelineStep
+              icon={phase.icon}
+              isLast={index === phases.length - 1}
+              key={phase.name}
+              status={phase.status}
+            >
+              {phase.label}
+            </GenerationTimelineStep>
+          ))}
+        </GenerationTimelineSteps>
+      </GenerationTimeline>
+    );
+  }
+
+  if (generation.status === "completed") {
+    return (
+      <GenerationProgressCompleted
+        subtitle={t("Redirecting to your course...")}
+      >
+        {t("Lessons generated")}
+      </GenerationProgressCompleted>
+    );
+  }
+
+  if (generation.status === "error") {
+    return (
+      <GenerationProgressError
+        description={
+          generation.error || t("Something went wrong. Please try again.")
+        }
+        onRetry={generation.retry}
+        retryLabel={t("Try again")}
+      >
+        {t("Generation failed")}
+      </GenerationProgressError>
+    );
+  }
+
+  return null;
+}

--- a/apps/main/src/app/[locale]/generate/ch/[id]/generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/generation-phases.ts
@@ -1,0 +1,53 @@
+import type { LucideIcon } from "lucide-react";
+import { BookOpenIcon, CheckCircleIcon, GraduationCapIcon } from "lucide-react";
+import {
+  calculateWeightedProgress as calculateProgress,
+  getPhaseStatus as getStatus,
+  type PhaseStatus,
+} from "@/lib/generation-phases";
+import type { StepName } from "@/workflows/chapter-generation/types";
+
+export type PhaseName = "loadingInfo" | "generatingLessons" | "completing";
+
+const PHASE_STEPS: Record<PhaseName, StepName[]> = {
+  completing: ["setChapterAsCompleted"],
+  generatingLessons: ["generateLessons", "addLessons"],
+  loadingInfo: ["getChapter", "setChapterAsRunning"],
+};
+
+export const PHASE_ORDER: PhaseName[] = [
+  "loadingInfo",
+  "generatingLessons",
+  "completing",
+];
+
+export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
+  completing: CheckCircleIcon,
+  generatingLessons: GraduationCapIcon,
+  loadingInfo: BookOpenIcon,
+};
+
+const PHASE_WEIGHTS: Record<PhaseName, number> = {
+  completing: 5,
+  generatingLessons: 90,
+  loadingInfo: 5,
+};
+
+export function getPhaseStatus(
+  phase: PhaseName,
+  completedSteps: StepName[],
+  currentStep: StepName | null,
+): PhaseStatus {
+  return getStatus(phase, completedSteps, currentStep, PHASE_STEPS);
+}
+
+export function calculateWeightedProgress(
+  completedSteps: StepName[],
+  currentStep: StepName | null,
+): number {
+  return calculateProgress(completedSteps, currentStep, {
+    phaseOrder: PHASE_ORDER,
+    phaseSteps: PHASE_STEPS,
+    phaseWeights: PHASE_WEIGHTS,
+  });
+}

--- a/apps/main/src/app/[locale]/generate/ch/[id]/page.tsx
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/page.tsx
@@ -5,11 +5,11 @@ import {
 } from "./generate-chapter-content";
 
 export default function GenerateChapterPage(
-  _props: PageProps<"/[locale]/generate/ch/[id]">,
+  props: PageProps<"/[locale]/generate/ch/[id]">,
 ) {
   return (
     <Suspense fallback={<GenerateChapterFallback />}>
-      <GenerateChapterContent />
+      <GenerateChapterContent params={props.params} />
     </Suspense>
   );
 }

--- a/apps/main/src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
@@ -2,7 +2,7 @@
 
 import { useExtracted } from "next-intl";
 import type { PhaseStatus } from "@/lib/generation-phases";
-import type { StepName } from "@/workflows/course-generation/types";
+import type { StepName } from "@/workflows/chapter-generation/types";
 import {
   calculateWeightedProgress,
   getPhaseStatus,
@@ -27,13 +27,9 @@ export function useGenerationPhases(
   const t = useExtracted();
 
   const labels: PhaseLabels = {
-    checkingExisting: t("Checking for existing course"),
-    generatingDetails: t("Generating course details"),
+    completing: t("Finishing up"),
     generatingLessons: t("Generating lessons"),
-    loadingInfo: t("Loading course information"),
-    planningChapters: t("Planning chapters"),
-    savingMetadata: t("Saving course metadata"),
-    settingUp: t("Setting up course"),
+    loadingInfo: t("Loading chapter information"),
   };
 
   const phases: PhaseInfo[] = PHASE_ORDER.map((phase) => ({

--- a/apps/main/src/components/auth/login-required.tsx
+++ b/apps/main/src/components/auth/login-required.tsx
@@ -1,0 +1,43 @@
+import { buttonVariants } from "@zoonk/ui/components/button";
+import {
+  Container,
+  ContainerBody,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
+import { cn } from "@zoonk/ui/lib/utils";
+import { ProtectedSection } from "@zoonk/ui/patterns/auth/protected";
+import { getExtracted } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+
+type LoginRequiredProps = {
+  title: string;
+};
+
+export async function LoginRequired({ title }: LoginRequiredProps) {
+  const t = await getExtracted();
+
+  return (
+    <Container variant="narrow">
+      <ContainerHeader>
+        <ContainerHeaderGroup>
+          <ContainerTitle>{title}</ContainerTitle>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <ProtectedSection
+          actions={
+            <Link className={cn(buttonVariants(), "w-max")} href="/login">
+              {t("Login")}
+            </Link>
+          }
+          alertTitle={t("You need to be logged in to access this page.")}
+          centered
+          state="unauthenticated"
+        />
+      </ContainerBody>
+    </Container>
+  );
+}

--- a/apps/main/src/components/subscription/subscription-gate.tsx
+++ b/apps/main/src/components/subscription/subscription-gate.tsx
@@ -1,0 +1,24 @@
+import "server-only";
+
+import { auth } from "@zoonk/core/auth";
+import { findActiveSubscription } from "@zoonk/core/auth/subscription";
+import { headers } from "next/headers";
+import { UpgradeCTA } from "./upgrade-cta";
+
+export async function SubscriptionGate({
+  children,
+  returnUrl,
+}: {
+  children: React.ReactNode;
+  returnUrl: string;
+}) {
+  const subscriptions = await auth.api.listActiveSubscriptions({
+    headers: await headers(),
+  });
+
+  if (!findActiveSubscription(subscriptions)) {
+    return <UpgradeCTA returnUrl={returnUrl} />;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/main/src/components/subscription/upgrade-cta.tsx
+++ b/apps/main/src/components/subscription/upgrade-cta.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { authClient } from "@zoonk/core/auth/client";
+import { Button } from "@zoonk/ui/components/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@zoonk/ui/components/empty";
+import { Loader2Icon, SparklesIcon } from "lucide-react";
+import { useExtracted } from "next-intl";
+import { useState } from "react";
+
+export function UpgradeCTA({ returnUrl }: { returnUrl: string }) {
+  const [state, setState] = useState<"idle" | "loading" | "error">("idle");
+  const t = useExtracted();
+  const isLoading = state === "loading";
+
+  const subscribe = async () => {
+    setState("loading");
+
+    const { error } = await authClient.subscription.upgrade({
+      cancelUrl: returnUrl,
+      plan: "hobby",
+      successUrl: returnUrl,
+    });
+
+    if (error) {
+      console.error("Error upgrading subscription:", error);
+      setState("error");
+    }
+  };
+
+  return (
+    <Empty className="border-0">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <SparklesIcon />
+        </EmptyMedia>
+
+        <EmptyTitle>{t("Upgrade to generate")}</EmptyTitle>
+
+        <EmptyDescription>
+          {t("Generating content with AI requires an active subscription.")}
+        </EmptyDescription>
+      </EmptyHeader>
+
+      <EmptyContent>
+        <Button disabled={isLoading} onClick={subscribe}>
+          {isLoading && <Loader2Icon className="animate-spin" />}
+          {t("Upgrade")}
+        </Button>
+
+        {state === "error" && (
+          <p className="text-destructive text-sm">
+            {t(
+              "Unable to update your subscription. Contact us at hello@zoonk.com",
+            )}
+          </p>
+        )}
+      </EmptyContent>
+    </Empty>
+  );
+}

--- a/apps/main/src/lib/generation-phases.ts
+++ b/apps/main/src/lib/generation-phases.ts
@@ -1,0 +1,65 @@
+export type PhaseStatus = "pending" | "active" | "completed";
+
+export type PhaseConfig<TPhase extends string, TStep extends string> = {
+  phaseSteps: Record<TPhase, TStep[]>;
+  phaseOrder: TPhase[];
+  phaseWeights: Record<TPhase, number>;
+};
+
+export function getPhaseStatus<TPhase extends string, TStep extends string>(
+  phase: TPhase,
+  completedSteps: TStep[],
+  currentStep: TStep | null,
+  phaseSteps: Record<TPhase, TStep[]>,
+): PhaseStatus {
+  const steps = phaseSteps[phase];
+  const completedCount = steps.filter((s) => completedSteps.includes(s)).length;
+
+  if (completedCount === steps.length) {
+    return "completed";
+  }
+
+  if (currentStep && steps.includes(currentStep)) {
+    return "active";
+  }
+
+  if (completedCount > 0) {
+    return "active";
+  }
+
+  return "pending";
+}
+
+export function calculateWeightedProgress<
+  TPhase extends string,
+  TStep extends string,
+>(
+  completedSteps: TStep[],
+  currentStep: TStep | null,
+  config: PhaseConfig<TPhase, TStep>,
+): number {
+  let totalProgress = 0;
+
+  for (const phase of config.phaseOrder) {
+    const status = getPhaseStatus(
+      phase,
+      completedSteps,
+      currentStep,
+      config.phaseSteps,
+    );
+    const weight = config.phaseWeights[phase];
+
+    if (status === "completed") {
+      totalProgress += weight;
+    } else if (status === "active") {
+      const steps = config.phaseSteps[phase];
+      const completedCount = steps.filter((s) =>
+        completedSteps.includes(s),
+      ).length;
+      const partialProgress = (completedCount / steps.length) * weight;
+      totalProgress += partialProgress;
+    }
+  }
+
+  return Math.round(totalProgress);
+}

--- a/i18n.lock
+++ b/i18n.lock
@@ -352,14 +352,19 @@ checksums:
     Complete%20this%20activity%20to%20reinforce%20your%20learning%20and%20track%20your%20progress./singular: ae9411230fe031bbbd7471a8fde4b17d
     Interactive%20lesson%20with%20exercises%20and%20activities%20to%20help%20you%20learn%20effectively./singular: f74de010a6977351bee6b20c81d90d31
     Lesson/singular: 0369d21b141f7f54c4586224e7e7ae65
+    Generate%20Chapter/singular: 12160bab066da65413de4b511e402446
     Generation%20progress/singular: 4940d589badd32bb89f93989945f68bb
-    Creating%20your%20course/singular: 02c33db1106e7478e5cbd00fa5f20532
     Try%20again/singular: 33dd8820e743e35a66e6977f69e9d3b5
     Redirecting%20to%20your%20course.../singular: 9f268e497368578b98d0125f5ac95902
     Generation%20failed/singular: 70cc0b7e6093afa33e32e6ac474d1fc7
-    Course%20generated/singular: fc6cbef2e4b3ac26d4125c8f67bbb99d
+    Lessons%20generated/singular: 7c32079f95da198e0d7f5351e47eb64f
+    Creating%20your%20lessons/singular: 93571965dc04dcef0bf92f212b3b34d3
     Something%20went%20wrong.%20Please%20try%20again./singular: c62a7718d9a1e9c4ffb707807550f836
     Generating%20lessons/singular: c4cd98341fd568b3cc5ab0daff85f483
+    Finishing%20up/singular: 5db7ffd9f1807c8e5936ddca2fe8d1b7
+    Loading%20chapter%20information/singular: 7a310c88460ccc1d8eb14885361dcfa6
+    Creating%20your%20course/singular: 02c33db1106e7478e5cbd00fa5f20532
+    Course%20generated/singular: fc6cbef2e4b3ac26d4125c8f67bbb99d
     Loading%20course%20information/singular: f2873300c0715a6fc4b3e050d7176037
     Setting%20up%20course/singular: 03144d8ba4e9c555d82e95014047a203
     Generating%20course%20details/singular: 49c28d908a8cb876f14406452c59f05b
@@ -381,21 +386,8 @@ checksums:
     Send%20message/singular: 19e7006870c6e407dece25ee8c9d5333
     Feedback/singular: 6fac88806e0c269a30777b283988c61c
     Send%20feedback%2C%20questions%2C%20or%20suggestions%20to%20us.%20Fill%20in%20the%20form%20below%20or%20email%20us%20directly%20at%20hello%40zoonk.com./singular: 6ce5e55ddeeb7de9480b806358aa5b95
-    History/singular: b0578d6d225f512e42f823fbca2e3c32
-    Math/singular: 0a604ffa5ef57408918fe98ef05eb05a
-    Arts/singular: 9b1845cec1210e57ea990b1a90823228
-    Languages/singular: 2d2a54a7cbbf640ba2aff643a8a3c7c1
-    Health/singular: db2f8a6e827b5436d1eedaf453eaae8a
-    Engineering/singular: 76e841ae8ec3340d7d0a5c2191abbea4
-    Technology/singular: 694755ad06c9b0d9bfcd78e1610670b8
-    Economics/singular: 3931d28200c67977f6ecdf9b2aa61014
-    Culture/singular: 598e8cf9fdd3ed940090e97eac0674b1
-    Communication/singular: 478f3ecaf6419fa9f11f2a83639188c6
-    Society/singular: fc07530371cde440aac96dae7a33aad4
-    Science/singular: 7b1aa37d3f038f226223f85531c688d8
-    Law/singular: 3f04c791596043e899781f74003b9324
-    Business/singular: 7682c7966c6e718836388561e7e68cab
-    Geography/singular: fd93fe516c40f1f2dd96f53a507ce95d
+    Upgrade%20to%20generate/singular: 9c4baffb6ff3a12a322dfe02735ac35c
+    Generating%20content%20with%20AI%20requires%20an%20active%20subscription./singular: ee3e62a18f3437b719f6793dd01d66f8
     Listening/singular: 9e680c44cd88a178b953349ed8881ef2
     Examples/singular: 9dacb7c56bc894e4bcad39f41265e3a0
     Challenge/singular: 7f333a59ee7a3596e27a2f8c3401b764
@@ -420,6 +412,21 @@ checksums:
     Purple/singular: 547ba93b6f68317e2dfbafb16cabc30f
     Black/singular: 0a78282fb00e09a335608b154ffa01de
     Gray/singular: 54ec745c22b59509822468ba82070d74
+    History/singular: b0578d6d225f512e42f823fbca2e3c32
+    Math/singular: 0a604ffa5ef57408918fe98ef05eb05a
+    Arts/singular: 9b1845cec1210e57ea990b1a90823228
+    Languages/singular: 2d2a54a7cbbf640ba2aff643a8a3c7c1
+    Health/singular: db2f8a6e827b5436d1eedaf453eaae8a
+    Engineering/singular: 76e841ae8ec3340d7d0a5c2191abbea4
+    Technology/singular: 694755ad06c9b0d9bfcd78e1610670b8
+    Economics/singular: 3931d28200c67977f6ecdf9b2aa61014
+    Culture/singular: 598e8cf9fdd3ed940090e97eac0674b1
+    Communication/singular: 478f3ecaf6419fa9f11f2a83639188c6
+    Society/singular: fc07530371cde440aac96dae7a33aad4
+    Science/singular: 7b1aa37d3f038f226223f85531c688d8
+    Law/singular: 3f04c791596043e899781f74003b9324
+    Business/singular: 7682c7966c6e718836388561e7e68cab
+    Geography/singular: fd93fe516c40f1f2dd96f53a507ce95d
     "%7Bcategory%7D%20Courses/singular": f82680a650c487992e1025b66f324d4c
     Explore%20all%20%7Bcategory%7D%20courses/singular: b1f2775c67b4a61b3d92b4345b8b852e
     "%7Bcategory%7D%20courses/singular": eafd6f9b1fa97400abe1bfe0c8ee5f19

--- a/packages/db/src/prisma/seed/activities.ts
+++ b/packages/db/src/prisma/seed/activities.ts
@@ -30,7 +30,7 @@ const activitiesData: LessonActivities[] = [
         kind: "background",
       },
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "explanation",
       },
@@ -40,17 +40,17 @@ const activitiesData: LessonActivities[] = [
         kind: "quiz",
       },
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "examples",
       },
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "story",
       },
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "quiz",
       },
@@ -72,7 +72,7 @@ const activitiesData: LessonActivities[] = [
         },
       },
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "quiz",
       },
@@ -83,17 +83,17 @@ const activitiesData: LessonActivities[] = [
   {
     activities: [
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "background",
       },
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "explanation",
       },
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: false,
         kind: "mechanics",
       },
@@ -106,7 +106,7 @@ const activitiesData: LessonActivities[] = [
       {
         description:
           "A custom activity exploring the differences between supervised and unsupervised learning approaches.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: false,
         kind: "custom",
         title: "Supervised vs Unsupervised Learning",
@@ -118,12 +118,12 @@ const activitiesData: LessonActivities[] = [
   {
     activities: [
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "background",
       },
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "explanation",
       },
@@ -134,12 +134,12 @@ const activitiesData: LessonActivities[] = [
   {
     activities: [
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "background",
       },
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "explanation",
       },
@@ -150,12 +150,12 @@ const activitiesData: LessonActivities[] = [
   {
     activities: [
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "background",
       },
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "explanation",
       },
@@ -166,12 +166,12 @@ const activitiesData: LessonActivities[] = [
   {
     activities: [
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "background",
       },
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "explanation",
       },
@@ -182,12 +182,12 @@ const activitiesData: LessonActivities[] = [
   {
     activities: [
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "background",
       },
       {
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         kind: "explanation",
       },

--- a/packages/db/src/prisma/seed/chapters.ts
+++ b/packages/db/src/prisma/seed/chapters.ts
@@ -41,7 +41,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Explore linear regression, logistic regression, and gradient descent algorithms for predictive modeling.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         slug: "regression-algorithms",
         title: "Regression Algorithms",
@@ -49,7 +49,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Understand decision trees, random forests, and ensemble methods for classification and regression tasks.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: false,
         slug: "tree-based-models",
         title: "Tree-Based Models",
@@ -57,7 +57,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Learn the fundamentals of neural networks, activation functions, backpropagation, and deep learning architectures.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: false,
         slug: "neural-networks",
         title: "Neural Networks",
@@ -71,7 +71,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Entenda o que é machine learning, sua história e os diferentes tipos de aprendizado: supervisionado, não supervisionado e por reforço.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         slug: "introducao-ao-machine-learning",
         title: "Introdução ao Machine Learning",
@@ -79,7 +79,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Aprenda sobre datasets, pré-processamento de dados, engenharia de features e como preparar seus dados para treinar modelos.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         slug: "preparacao-de-dados",
         title: "Preparação de Dados",
@@ -87,7 +87,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Explore regressão linear, regressão logística e algoritmos de gradiente descendente para modelagem preditiva.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         slug: "algoritmos-de-regressao",
         title: "Algoritmos de Regressão",
@@ -95,7 +95,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Entenda árvores de decisão, florestas aleatórias e métodos de ensemble para tarefas de classificação e regressão.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: false,
         slug: "modelos-baseados-em-arvores",
         title: "Modelos Baseados em Árvores",
@@ -103,7 +103,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Aprenda os fundamentos de redes neurais, funções de ativação, backpropagation e arquiteturas de deep learning.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: false,
         slug: "redes-neurais",
         title: "Redes Neurais",
@@ -125,7 +125,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Build essential vocabulary for travel, food, family, and daily activities.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         slug: "essential-vocabulary",
         title: "Essential Vocabulary",
@@ -147,7 +147,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Learn about stars, their life cycles, and how they form the building blocks of galaxies.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         slug: "stars-and-galaxies",
         title: "Stars and Galaxies",
@@ -169,7 +169,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Master lists, dictionaries, sets, and tuples for organizing and manipulating data.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         slug: "data-structures",
         title: "Data Structures",
@@ -199,7 +199,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Style your web pages with CSS, including layouts, colors, typography, and responsive design.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         slug: "css-styling",
         title: "CSS Styling",
@@ -221,7 +221,7 @@ const chaptersData: CourseChapters[] = [
       {
         description:
           "Learn techniques for cleaning, transforming, and preparing data for analysis.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         slug: "data-wrangling",
         title: "Data Wrangling",

--- a/packages/db/src/prisma/seed/lessons.ts
+++ b/packages/db/src/prisma/seed/lessons.ts
@@ -60,7 +60,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Learn about different types of datasets and where to find quality data for your projects.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         slug: "understanding-datasets",
         title: "Understanding Datasets",
@@ -68,7 +68,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Master techniques for cleaning and preprocessing raw data before training.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         slug: "data-cleaning",
         title: "Data Cleaning",
@@ -90,7 +90,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Master common greetings and introductions for everyday conversations.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         slug: "greetings-introductions",
         title: "Greetings and Introductions",
@@ -112,7 +112,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Explore the inner planets: Mercury, Venus, Earth, and Mars.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         slug: "inner-planets",
         title: "The Inner Planets",
@@ -134,7 +134,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Understand variables, data types, and basic operations in Python.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         slug: "variables-data-types",
         title: "Variables and Data Types",
@@ -156,7 +156,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Learn about semantic HTML elements and how to structure content meaningfully.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         slug: "semantic-html",
         title: "Semantic HTML",
@@ -178,7 +178,7 @@ const lessonsData: ChapterLessons[] = [
       {
         description:
           "Learn about different types of data, data sources, and how to collect data for analysis.",
-        generationStatus: "completed",
+        generationStatus: "pending",
         isPublished: true,
         slug: "types-of-data",
         title: "Types of Data",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Build the chapter generation page with auth and subscription gates, streaming progress, and redirect on completion. Adds shared generation phase logic and localized copy.

- **New Features**
  - New /generate/ch/[id] UI: shows chapter info, triggers the workflow, streams status via SSE, shows phased progress, redirects when done, and handles errors with retry.
  - Access control: login prompt for unauthenticated users; subscription gate with an Upgrade CTA; 404 for invalid IDs.
  - Shared generation-phases utility used by chapter and course generation; i18n strings added for en/es/pt; docs updated to prevent calling getExtracted inside Promise.all.
  - Seeds updated to set generationStatus to pending for chapters, lessons, and activities so generation can run.

- **Tests**
  - Added e2e coverage for unauthenticated, no subscription, active subscription (success and error), and not-found cases.
  - Mocks trigger and status endpoints, including SSE streams, and verifies redirect to the course on completion.

<sup>Written for commit 5f3934630ce1e90a3b52fe2b8268498f247d7b88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

