### PR TITLE
fix(main): adjust chapter list alignment

### DIFF
--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -51,7 +51,7 @@ export function ChapterList({
         {chapters.map((chapter, index) => (
           <AccordionItem key={chapter.id} value={chapter.slug} variant="ghost">
             <AccordionTrigger className="px-0 py-3 hover:no-underline">
-              <div className="flex items-start gap-3 sm:gap-4">
+              <div className="flex items-baseline gap-1">
                 <span className="w-5 shrink-0 font-mono text-muted-foreground/40 tabular-nums leading-snug sm:w-6">
                   {String(index + 1).padStart(2, "0")}
                 </span>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligned chapter numbers and titles on the same baseline with tighter spacing to fix a visual misalignment in the chapter list. Improves readability and consistency across screen sizes.

<sup>Written for commit 551568f7cb66304fb659e861965ffc127d0addca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

