### PR TITLE
refactor(db): use enum for visualKind

### DIFF
--- a/packages/db/src/prisma/enums.prisma
+++ b/packages/db/src/prisma/enums.prisma
@@ -27,3 +27,15 @@ enum ActivityKind {
   pronunciation
   review
 }
+
+enum StepVisualKind {
+  code
+  image
+  table
+  chart
+  diagram
+  timeline
+  quote
+  audio
+  video
+}

--- a/packages/db/src/prisma/migrations/20260114221443_add_step_visual_kind_enum/migration.sql
+++ b/packages/db/src/prisma/migrations/20260114221443_add_step_visual_kind_enum/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - The `visual_kind` column on the `steps` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- CreateEnum
+CREATE TYPE "StepVisualKind" AS ENUM ('code', 'image', 'table', 'chart', 'diagram', 'timeline', 'quote', 'audio', 'video');
+
+-- AlterTable
+ALTER TABLE "steps" DROP COLUMN "visual_kind",
+ADD COLUMN     "visual_kind" "StepVisualKind";

--- a/packages/db/src/prisma/models/steps.prisma
+++ b/packages/db/src/prisma/models/steps.prisma
@@ -1,14 +1,14 @@
 model Step {
-  id            BigInt        @id @default(autoincrement())
-  activityId    BigInt        @map("activity_id")
-  activity      Activity      @relation(fields: [activityId], references: [id], onDelete: Cascade)
-  kind          String        @db.VarChar(20)
+  id            BigInt          @id @default(autoincrement())
+  activityId    BigInt          @map("activity_id")
+  activity      Activity        @relation(fields: [activityId], references: [id], onDelete: Cascade)
+  kind          String          @db.VarChar(20)
   position      Int
   content       Json
-  visualKind    String?       @map("visual_kind") @db.VarChar(20)
-  visualContent Json?         @map("visual_content")
-  createdAt     DateTime      @default(now()) @map("created_at")
-  updatedAt     DateTime      @default(now()) @updatedAt @map("updated_at")
+  visualKind    StepVisualKind? @map("visual_kind")
+  visualContent Json?           @map("visual_content")
+  createdAt     DateTime        @default(now()) @map("created_at")
+  updatedAt     DateTime        @default(now()) @updatedAt @map("updated_at")
   attempts      StepAttempt[]
 
   @@index([activityId, position])

--- a/packages/db/src/prisma/seed/steps.ts
+++ b/packages/db/src/prisma/seed/steps.ts
@@ -2,12 +2,13 @@ import type {
   Organization,
   Prisma,
   PrismaClient,
+  StepVisualKind,
 } from "../../generated/prisma/client";
 
 type StepSeedData = {
   kind: string;
   content: Prisma.InputJsonValue;
-  visualKind?: string;
+  visualKind?: StepVisualKind;
   visualContent?: Prisma.InputJsonValue;
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched steps.visual_kind from string to a Prisma enum (StepVisualKind) for stricter validation and better type safety. Updated schema and seed types; migration recreates the column.

- **Migration**
  - Run prisma migrate; visual_kind is dropped and recreated as an enum.
  - Confirm existing values match: code, image, table, chart, diagram, timeline, quote, audio, video; map/backfill before migrating.
  - Regenerate Prisma client (prisma generate).

<sup>Written for commit 5425f2718a7b8d4c7bf3aec1c5c4dfb89ab86aaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

