### PR TITLE
feat(ai): support reasoning effort

### DIFF
--- a/apps/evals/src/lib/models.ts
+++ b/apps/evals/src/lib/models.ts
@@ -122,7 +122,7 @@ export const EVAL_MODELS: ModelConfig[] = [
     reasoningEffort: "auto",
   },
   {
-    id: "openai/gpt-5.2",
+    id: "openai/gpt-5.2:high",
     inputCost: 1.75,
     name: "gpt-5.2",
     outputCost: 14,
@@ -200,4 +200,13 @@ export function getModelDisplayName(model: ModelConfig): string {
 
 export function getModelById(modelId: string): ModelConfig | undefined {
   return EVAL_MODELS.find((model) => model.id === modelId);
+}
+
+/**
+ * Get the base model ID to pass to the AI gateway.
+ * Strips any reasoning effort suffix (e.g., "openai/gpt-5.2:high" -> "openai/gpt-5.2")
+ */
+export function getGatewayModelId(modelId: string): string {
+  const colonIndex = modelId.indexOf(":");
+  return colonIndex === -1 ? modelId : modelId.slice(0, colonIndex);
 }

--- a/apps/evals/src/lib/models.ts
+++ b/apps/evals/src/lib/models.ts
@@ -122,6 +122,13 @@ export const EVAL_MODELS: ModelConfig[] = [
     reasoningEffort: "auto",
   },
   {
+    id: "openai/gpt-5.2",
+    inputCost: 1.75,
+    name: "gpt-5.2",
+    outputCost: 14,
+    reasoningEffort: "high",
+  },
+  {
     id: "openai/gpt-4.1",
     inputCost: 2,
     name: "gpt-4.1",
@@ -156,7 +163,6 @@ export const EVAL_MODELS: ModelConfig[] = [
     inputCost: 0.2,
     name: "grok-4.1-fast-reasoning",
     outputCost: 0.5,
-    reasoningEffort: "auto",
   },
   {
     id: "xai/grok-4.1-fast-non-reasoning",
@@ -175,7 +181,6 @@ export const EVAL_MODELS: ModelConfig[] = [
     inputCost: 0.2,
     name: "grok-4-fast-reasoning",
     outputCost: 0.5,
-    reasoningEffort: "auto",
   },
   {
     id: "xai/grok-4-fast-non-reasoning",

--- a/apps/evals/src/lib/output-generator.ts
+++ b/apps/evals/src/lib/output-generator.ts
@@ -1,4 +1,5 @@
 import { RUNS_PER_TEST_CASE } from "@/tasks";
+import { getGatewayModelId, getModelById } from "./models";
 import { loadModelOutputs, saveModelOutputs } from "./output-loader";
 import type { ModelOutputs, OutputEntry, Task, TestCase } from "./types";
 
@@ -14,10 +15,13 @@ async function generateOutputForTestCase(
 
   console.info(`Generating output for: ${inputSummary} (run ${runNumber})`);
 
+  const model = getModelById(modelId);
+  const gatewayModelId = getGatewayModelId(modelId);
   const startTime = performance.now();
   const result = await task.generate({
     ...testCase.userInput,
-    model: modelId,
+    model: gatewayModelId,
+    reasoningEffort: model?.reasoningEffort,
     useFallback: false,
   });
   const duration = performance.now() - startTime;

--- a/apps/evals/src/lib/types.ts
+++ b/apps/evals/src/lib/types.ts
@@ -1,3 +1,4 @@
+import type { ReasoningEffort } from "@zoonk/ai/types";
 import type { LanguageModelUsage } from "ai";
 import z from "zod";
 
@@ -51,7 +52,11 @@ export type Task<TInput = unknown, TOutput = unknown> = {
   // Using method signature instead of property signature makes this bivariant,
   // allowing Task<SpecificInput> to be assignable to Task<unknown>
   generate(
-    input: TInput & { model: string; useFallback?: boolean },
+    input: TInput & {
+      model: string;
+      useFallback?: boolean;
+      reasoningEffort?: ReasoningEffort;
+    },
   ): Promise<TaskResult<TOutput>>;
 };
 

--- a/packages/ai/src/tasks/activities/core/activity-background.ts
+++ b/packages/ai/src/tasks/activities/core/activity-background.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { generateText, Output } from "ai";
 import { z } from "zod";
+import { buildProviderOptions, type ReasoningEffort } from "../../../types";
 import systemPrompt from "./activity-background.prompt.md";
 
 const DEFAULT_MODEL =
@@ -34,6 +35,7 @@ export type ActivityBackgroundParams = {
   language: string;
   model?: string;
   useFallback?: boolean;
+  reasoningEffort?: ReasoningEffort;
 };
 
 export async function generateActivityBackground({
@@ -44,6 +46,7 @@ export async function generateActivityBackground({
   language,
   model = DEFAULT_MODEL,
   useFallback = true,
+  reasoningEffort,
 }: ActivityBackgroundParams) {
   const userPrompt = `LESSON_TITLE: ${lessonTitle}
 LESSON_DESCRIPTION: ${lessonDescription}
@@ -51,13 +54,17 @@ CHAPTER_TITLE: ${chapterTitle}
 COURSE_TITLE: ${courseTitle}
 LANGUAGE: ${language}`;
 
+  const providerOptions = buildProviderOptions({
+    fallbackModels: FALLBACK_MODELS,
+    reasoningEffort,
+    useFallback,
+  });
+
   const { output, usage } = await generateText({
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
-    providerOptions: {
-      gateway: { models: useFallback ? FALLBACK_MODELS : [] },
-    },
+    providerOptions,
     system: systemPrompt,
   });
 

--- a/packages/ai/src/tasks/activities/core/activity-explanation-quiz.ts
+++ b/packages/ai/src/tasks/activities/core/activity-explanation-quiz.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { generateText, stepCountIs } from "ai";
+import { buildProviderOptions, type ReasoningEffort } from "../../../types";
 
 import { type QuizQuestion, quizTools } from "../_tools/quiz";
 import systemPrompt from "./activity-explanation-quiz.prompt.md";
@@ -29,6 +30,7 @@ export type ActivityExplanationQuizParams = {
   explanationSteps: Array<{ title: string; text: string }>;
   model?: string;
   useFallback?: boolean;
+  reasoningEffort?: ReasoningEffort;
 };
 
 export async function generateActivityExplanationQuiz({
@@ -40,6 +42,7 @@ export async function generateActivityExplanationQuiz({
   explanationSteps,
   model = DEFAULT_MODEL,
   useFallback = true,
+  reasoningEffort,
 }: ActivityExplanationQuizParams) {
   const formattedExplanationSteps = explanationSteps
     .map((step, index) => `${index + 1}. ${step.title}: ${step.text}`)
@@ -55,12 +58,16 @@ ${formattedExplanationSteps}
 
 Generate quiz questions that test understanding of these concepts. Use the available tools to create questions in appropriate formats. Aim for 4-8 questions covering the key concepts.`;
 
+  const providerOptions = buildProviderOptions({
+    fallbackModels: FALLBACK_MODELS,
+    reasoningEffort,
+    useFallback,
+  });
+
   const { steps, usage } = await generateText({
     model,
     prompt: userPrompt,
-    providerOptions: {
-      gateway: { models: useFallback ? FALLBACK_MODELS : [] },
-    },
+    providerOptions,
     stopWhen: stepCountIs(10),
     system: systemPrompt,
     toolChoice: "required",

--- a/packages/ai/src/tasks/activities/core/activity-explanation.ts
+++ b/packages/ai/src/tasks/activities/core/activity-explanation.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { generateText, Output } from "ai";
 import { z } from "zod";
+import { buildProviderOptions, type ReasoningEffort } from "../../../types";
 import systemPrompt from "./activity-explanation.prompt.md";
 
 const DEFAULT_MODEL =
@@ -35,6 +36,7 @@ export type ActivityExplanationParams = {
   backgroundSteps: Array<{ title: string; text: string }>;
   model?: string;
   useFallback?: boolean;
+  reasoningEffort?: ReasoningEffort;
 };
 
 export async function generateActivityExplanation({
@@ -46,6 +48,7 @@ export async function generateActivityExplanation({
   backgroundSteps,
   model = DEFAULT_MODEL,
   useFallback = true,
+  reasoningEffort,
 }: ActivityExplanationParams) {
   const formattedBackgroundSteps = backgroundSteps
     .map((step, index) => `${index + 1}. ${step.title}: ${step.text}`)
@@ -59,13 +62,17 @@ LANGUAGE: ${language}
 BACKGROUND_STEPS:
 ${formattedBackgroundSteps}`;
 
+  const providerOptions = buildProviderOptions({
+    fallbackModels: FALLBACK_MODELS,
+    reasoningEffort,
+    useFallback,
+  });
+
   const { output, usage } = await generateText({
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
-    providerOptions: {
-      gateway: { models: useFallback ? FALLBACK_MODELS : [] },
-    },
+    providerOptions,
     system: systemPrompt,
   });
 

--- a/packages/ai/src/tasks/chapters/chapter-lessons.ts
+++ b/packages/ai/src/tasks/chapters/chapter-lessons.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { generateText, Output } from "ai";
 import { z } from "zod";
+import { buildProviderOptions, type ReasoningEffort } from "../../types";
 import systemPrompt from "./chapter-lessons.prompt.md";
 
 const DEFAULT_MODEL = process.env.AI_MODEL_CHAPTER_LESSONS ?? "openai/gpt-5.2";
@@ -31,6 +32,7 @@ export type ChapterLessonsParams = {
   language: string;
   model?: string;
   useFallback?: boolean;
+  reasoningEffort?: ReasoningEffort;
 };
 
 export async function generateChapterLessons({
@@ -40,6 +42,7 @@ export async function generateChapterLessons({
   language,
   model = DEFAULT_MODEL,
   useFallback = true,
+  reasoningEffort,
 }: ChapterLessonsParams) {
   const userPrompt = `
     LANGUAGE: ${language}
@@ -48,13 +51,17 @@ export async function generateChapterLessons({
     CHAPTER_DESCRIPTION: ${chapterDescription}
   `;
 
+  const providerOptions = buildProviderOptions({
+    fallbackModels: FALLBACK_MODELS,
+    reasoningEffort,
+    useFallback,
+  });
+
   const { output, usage } = await generateText({
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
-    providerOptions: {
-      gateway: { models: useFallback ? FALLBACK_MODELS : [] },
-    },
+    providerOptions,
     system: systemPrompt,
   });
 

--- a/packages/ai/src/tasks/courses/alternative-titles.ts
+++ b/packages/ai/src/tasks/courses/alternative-titles.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { generateText, Output } from "ai";
 import { z } from "zod";
+import { buildProviderOptions, type ReasoningEffort } from "../../types";
 import systemPrompt from "./alternative-titles.prompt.md";
 
 const DEFAULT_MODEL =
@@ -25,6 +26,7 @@ export type AlternativeTitlesParams = {
   language: string;
   model?: string;
   useFallback?: boolean;
+  reasoningEffort?: ReasoningEffort;
 };
 
 export async function generateAlternativeTitles({
@@ -32,19 +34,24 @@ export async function generateAlternativeTitles({
   language,
   model = DEFAULT_MODEL,
   useFallback = true,
+  reasoningEffort,
 }: AlternativeTitlesParams) {
   const userPrompt = `
     TITLE: ${title}
     LANGUAGE: ${language}
   `;
 
+  const providerOptions = buildProviderOptions({
+    fallbackModels: FALLBACK_MODELS,
+    reasoningEffort,
+    useFallback,
+  });
+
   const { output, usage } = await generateText({
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
-    providerOptions: {
-      gateway: { models: useFallback ? FALLBACK_MODELS : [] },
-    },
+    providerOptions,
     system: systemPrompt,
   });
 

--- a/packages/ai/src/tasks/courses/course-categories.ts
+++ b/packages/ai/src/tasks/courses/course-categories.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { COURSE_CATEGORIES } from "@zoonk/utils/categories";
 import { generateText, Output } from "ai";
 import { z } from "zod";
+import { buildProviderOptions, type ReasoningEffort } from "../../types";
 import systemPrompt from "./course-categories.prompt.md";
 
 const DEFAULT_MODEL =
@@ -26,22 +27,28 @@ export type CourseCategoriesParams = {
   courseTitle: string;
   model?: string;
   useFallback?: boolean;
+  reasoningEffort?: ReasoningEffort;
 };
 
 export async function generateCourseCategories({
   courseTitle,
   model = DEFAULT_MODEL,
   useFallback = true,
+  reasoningEffort,
 }: CourseCategoriesParams) {
   const userPrompt = `COURSE_TITLE: ${courseTitle}`;
+
+  const providerOptions = buildProviderOptions({
+    fallbackModels: FALLBACK_MODELS,
+    reasoningEffort,
+    useFallback,
+  });
 
   const { output, usage } = await generateText({
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
-    providerOptions: {
-      gateway: { models: useFallback ? FALLBACK_MODELS : [] },
-    },
+    providerOptions,
     system: systemPrompt,
   });
 

--- a/packages/ai/src/tasks/courses/course-chapters.ts
+++ b/packages/ai/src/tasks/courses/course-chapters.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { generateText, Output } from "ai";
 import { z } from "zod";
+import { buildProviderOptions, type ReasoningEffort } from "../../types";
 import systemPrompt from "./course-chapters.prompt.md";
 
 const DEFAULT_MODEL = process.env.AI_MODEL_COURSE_CHAPTERS ?? "openai/gpt-5";
@@ -30,6 +31,7 @@ export type CourseChaptersParams = {
   courseTitle: string;
   model?: string;
   useFallback?: boolean;
+  reasoningEffort?: ReasoningEffort;
 };
 
 export async function generateCourseChapters({
@@ -37,19 +39,24 @@ export async function generateCourseChapters({
   courseTitle,
   model = DEFAULT_MODEL,
   useFallback = true,
+  reasoningEffort,
 }: CourseChaptersParams) {
   const userPrompt = `
     LANGUAGE: ${language}
     COURSE_TITLE: ${courseTitle}
   `;
 
+  const providerOptions = buildProviderOptions({
+    fallbackModels: FALLBACK_MODELS,
+    reasoningEffort,
+    useFallback,
+  });
+
   const { output, usage } = await generateText({
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
-    providerOptions: {
-      gateway: { models: useFallback ? FALLBACK_MODELS : [] },
-    },
+    providerOptions,
     system: systemPrompt,
   });
 

--- a/packages/ai/src/tasks/courses/course-description.ts
+++ b/packages/ai/src/tasks/courses/course-description.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { generateText, Output } from "ai";
 import { z } from "zod";
+import { buildProviderOptions, type ReasoningEffort } from "../../types";
 import systemPrompt from "./course-description.prompt.md";
 
 const DEFAULT_MODEL =
@@ -26,6 +27,7 @@ export type CourseDescriptionParams = {
   language: string;
   model?: string;
   useFallback?: boolean;
+  reasoningEffort?: ReasoningEffort;
 };
 
 export async function generateCourseDescription({
@@ -33,19 +35,24 @@ export async function generateCourseDescription({
   language,
   model = DEFAULT_MODEL,
   useFallback = true,
+  reasoningEffort,
 }: CourseDescriptionParams) {
   const userPrompt = `
     COURSE_TITLE: ${title}
     LANGUAGE: ${language}
   `;
 
+  const providerOptions = buildProviderOptions({
+    fallbackModels: FALLBACK_MODELS,
+    reasoningEffort,
+    useFallback,
+  });
+
   const { output, usage } = await generateText({
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
-    providerOptions: {
-      gateway: { models: useFallback ? FALLBACK_MODELS : [] },
-    },
+    providerOptions,
     system: systemPrompt,
   });
 

--- a/packages/ai/src/tasks/courses/course-suggestions.ts
+++ b/packages/ai/src/tasks/courses/course-suggestions.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { generateText, Output } from "ai";
 import { z } from "zod";
+import { buildProviderOptions, type ReasoningEffort } from "../../types";
 import systemPrompt from "./course-suggestions.prompt.md";
 
 const DEFAULT_MODEL =
@@ -31,6 +32,7 @@ export type CourseSuggestionsParams = {
   prompt: string;
   model?: string;
   useFallback?: boolean;
+  reasoningEffort?: ReasoningEffort;
 };
 
 export async function generateCourseSuggestions({
@@ -38,19 +40,24 @@ export async function generateCourseSuggestions({
   prompt,
   model = DEFAULT_MODEL,
   useFallback = true,
+  reasoningEffort,
 }: CourseSuggestionsParams) {
   const userPrompt = `
     LANGUAGE: ${language}
     USER_INPUT: ${prompt}
   `;
 
+  const providerOptions = buildProviderOptions({
+    fallbackModels: FALLBACK_MODELS,
+    reasoningEffort,
+    useFallback,
+  });
+
   const { output, usage } = await generateText({
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
-    providerOptions: {
-      gateway: { models: useFallback ? FALLBACK_MODELS : [] },
-    },
+    providerOptions,
     system: systemPrompt,
   });
 

--- a/packages/ai/src/tasks/lessons/lesson-activities.ts
+++ b/packages/ai/src/tasks/lessons/lesson-activities.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { generateText, Output } from "ai";
 import { z } from "zod";
+import { buildProviderOptions, type ReasoningEffort } from "../../types";
 import systemPrompt from "./lesson-activities.prompt.md";
 
 const DEFAULT_MODEL =
@@ -34,6 +35,7 @@ export type LessonActivitiesParams = {
   language: string;
   model?: string;
   useFallback?: boolean;
+  reasoningEffort?: ReasoningEffort;
 };
 
 export async function generateLessonActivities({
@@ -44,6 +46,7 @@ export async function generateLessonActivities({
   language,
   model = DEFAULT_MODEL,
   useFallback = true,
+  reasoningEffort,
 }: LessonActivitiesParams) {
   const userPrompt = `LESSON_TITLE: ${lessonTitle}
 LESSON_DESCRIPTION: ${lessonDescription}
@@ -51,13 +54,17 @@ CHAPTER_TITLE: ${chapterTitle}
 COURSE_TITLE: ${courseTitle}
 LANGUAGE: ${language}`;
 
+  const providerOptions = buildProviderOptions({
+    fallbackModels: FALLBACK_MODELS,
+    reasoningEffort,
+    useFallback,
+  });
+
   const { output, usage } = await generateText({
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
-    providerOptions: {
-      gateway: { models: useFallback ? FALLBACK_MODELS : [] },
-    },
+    providerOptions,
     system: systemPrompt,
   });
 

--- a/packages/ai/src/tasks/lessons/lesson-kind.ts
+++ b/packages/ai/src/tasks/lessons/lesson-kind.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { generateText, Output } from "ai";
 import { z } from "zod";
+import { buildProviderOptions, type ReasoningEffort } from "../../types";
 import systemPrompt from "./lesson-kind.prompt.md";
 
 const DEFAULT_MODEL =
@@ -27,6 +28,7 @@ export type LessonKindParams = {
   language: string;
   model?: string;
   useFallback?: boolean;
+  reasoningEffort?: ReasoningEffort;
 };
 
 export async function generateLessonKind({
@@ -37,6 +39,7 @@ export async function generateLessonKind({
   language,
   model = DEFAULT_MODEL,
   useFallback = true,
+  reasoningEffort,
 }: LessonKindParams) {
   const userPrompt = `LESSON_TITLE: ${lessonTitle}
 LESSON_DESCRIPTION: ${lessonDescription}
@@ -44,13 +47,17 @@ CHAPTER_TITLE: ${chapterTitle}
 COURSE_TITLE: ${courseTitle}
 LANGUAGE: ${language}`;
 
+  const providerOptions = buildProviderOptions({
+    fallbackModels: FALLBACK_MODELS,
+    reasoningEffort,
+    useFallback,
+  });
+
   const { output, usage } = await generateText({
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
-    providerOptions: {
-      gateway: { models: useFallback ? FALLBACK_MODELS : [] },
-    },
+    providerOptions,
     system: systemPrompt,
   });
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -1,1 +1,30 @@
 export type { Experimental_GeneratedImage as GeneratedImage } from "ai";
+
+export type ReasoningEffort = "auto" | "low" | "medium" | "high";
+
+type ProviderOptionsParams = {
+  useFallback: boolean;
+  fallbackModels: string[];
+  reasoningEffort?: ReasoningEffort;
+};
+
+type ProviderOptionsResult = {
+  gateway: { models: string[] };
+  openai?: { reasoningEffort: ReasoningEffort };
+};
+
+export function buildProviderOptions({
+  useFallback,
+  fallbackModels,
+  reasoningEffort,
+}: ProviderOptionsParams): ProviderOptionsResult {
+  const options: ProviderOptionsResult = {
+    gateway: { models: useFallback ? fallbackModels : [] },
+  };
+
+  if (reasoningEffort && reasoningEffort !== "auto") {
+    options.openai = { reasoningEffort };
+  }
+
+  return options;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add reasoning effort control across generation tasks and evals, including a high-effort GPT-5.2 variant. Centralizes provider options and ensures the gateway gets a base model ID while passing effort to the provider.

- **New Features**
  - Add ReasoningEffort ("auto" | "low" | "medium" | "high") and thread it through all tasks and the eval runner.
  - OpenAI calls now include reasoningEffort when not "auto"; fallback models still supported.
  - Add model "openai/gpt-5.2:high"; evals strip the ":high" before calling the gateway and pass effort separately.

- **Refactors**
  - Introduce buildProviderOptions to replace inline providerOptions across tasks.
  - Add getGatewayModelId and use getModelById in eval output generation.
  - Clean up EVAL_MODELS to remove redundant "auto" flags on grok fast reasoning entries.

<sup>Written for commit c49b0ab331d27838daee02d052e8924ba5a6ed3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

