### PR TITLE
refactor(db): use enum for step kind

### DIFF
--- a/apps/main/src/data/progress/get-best-time.test.ts
+++ b/apps/main/src/data/progress/get-best-time.test.ts
@@ -1,3 +1,4 @@
+import type { StepKind } from "@zoonk/db";
 import { prisma } from "@zoonk/db";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { signInAs } from "@zoonk/testing/fixtures/auth";
@@ -71,7 +72,7 @@ async function createTestStep(orgId: number) {
     data: {
       activityId: activity.id,
       content: {},
-      kind: "multiple_choice",
+      kind: "multipleChoice" as StepKind,
       position: 0,
     },
   });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,7 +1,8 @@
 import { PrismaPg } from "@prisma/adapter-pg";
 import { attachDatabasePool } from "@vercel/functions";
 import { Pool } from "pg";
-import { PrismaClient } from "./generated/prisma/client";
+// biome-ignore lint/style/noExportedImports: StepKind needs to be exported as a value for Prisma enum usage
+import { PrismaClient, StepKind } from "./generated/prisma/client";
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
@@ -47,4 +48,4 @@ export type {
 
 export type { BatchPayload } from "./generated/prisma/internal/prismaNamespace";
 
-export { prisma };
+export { prisma, StepKind };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,8 +1,7 @@
 import { PrismaPg } from "@prisma/adapter-pg";
 import { attachDatabasePool } from "@vercel/functions";
 import { Pool } from "pg";
-// biome-ignore lint/style/noExportedImports: StepKind needs to be exported as a value for Prisma enum usage
-import { PrismaClient, StepKind } from "./generated/prisma/client";
+import { PrismaClient } from "./generated/prisma/client";
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
@@ -40,6 +39,7 @@ export type {
   Session,
   Step,
   StepAttempt,
+  StepKind,
   Subscription,
   User,
   UserProgress,
@@ -48,4 +48,4 @@ export type {
 
 export type { BatchPayload } from "./generated/prisma/internal/prismaNamespace";
 
-export { prisma, StepKind };
+export { prisma };

--- a/packages/db/src/prisma/enums.prisma
+++ b/packages/db/src/prisma/enums.prisma
@@ -28,6 +28,16 @@ enum ActivityKind {
   review
 }
 
+enum StepKind {
+  static
+  fillBlank      @map("fill_blank")
+  matchColumns   @map("match_columns")
+  multipleChoice @map("multiple_choice")
+  selectImage    @map("select_image")
+  sortOrder      @map("sort_order")
+  arrangeWords   @map("arrange_words")
+}
+
 enum StepVisualKind {
   code
   image

--- a/packages/db/src/prisma/migrations/20260116032149_step_kind_enum/migration.sql
+++ b/packages/db/src/prisma/migrations/20260116032149_step_kind_enum/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - Changed the type of `kind` on the `steps` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- CreateEnum
+CREATE TYPE "StepKind" AS ENUM ('static', 'fill_blank', 'match_columns', 'multiple_choice', 'select_image', 'sort_order', 'arrange_words');
+
+-- AlterTable
+ALTER TABLE "steps" DROP COLUMN "kind",
+ADD COLUMN     "kind" "StepKind" NOT NULL;

--- a/packages/db/src/prisma/models/steps.prisma
+++ b/packages/db/src/prisma/models/steps.prisma
@@ -2,7 +2,7 @@ model Step {
   id            BigInt          @id @default(autoincrement())
   activityId    BigInt          @map("activity_id")
   activity      Activity        @relation(fields: [activityId], references: [id], onDelete: Cascade)
-  kind          String          @db.VarChar(20)
+  kind          StepKind
   position      Int
   content       Json
   visualKind    StepVisualKind? @map("visual_kind")

--- a/packages/db/src/prisma/seed/steps.ts
+++ b/packages/db/src/prisma/seed/steps.ts
@@ -2,11 +2,12 @@ import type {
   Organization,
   Prisma,
   PrismaClient,
+  StepKind,
   StepVisualKind,
 } from "../../generated/prisma/client";
 
 type StepSeedData = {
-  kind: string;
+  kind: StepKind;
   content: Prisma.InputJsonValue;
   visualKind?: StepVisualKind;
   visualContent?: Prisma.InputJsonValue;
@@ -118,7 +119,7 @@ const stepsData: ActivitySteps[] = [
           question:
             "What is the main difference between traditional programming and machine learning?",
         },
-        kind: "multiple_choice",
+        kind: "multipleChoice" as StepKind,
       },
       {
         content: {
@@ -134,7 +135,7 @@ const stepsData: ActivitySteps[] = [
             },
           ],
         },
-        kind: "match_columns",
+        kind: "matchColumns" as StepKind,
       },
       {
         content: {
@@ -145,7 +146,7 @@ const stepsData: ActivitySteps[] = [
             "In {0} learning, the algorithm learns from labeled data, while in {1} learning, it finds patterns without labels.",
           wordBank: ["supervised", "unsupervised", "reinforcement", "deep"],
         },
-        kind: "fill_blank",
+        kind: "fillBlank" as StepKind,
       },
       {
         content: {
@@ -158,7 +159,7 @@ const stepsData: ActivitySteps[] = [
           ],
           question: "Arrange the ML development process in the correct order:",
         },
-        kind: "sort_order",
+        kind: "sortOrder" as StepKind,
       },
       {
         content: {
@@ -180,7 +181,7 @@ const stepsData: ActivitySteps[] = [
           ],
           question: "Which diagram best represents a neural network?",
         },
-        kind: "select_image",
+        kind: "selectImage" as StepKind,
       },
     ],
   },
@@ -231,7 +232,7 @@ const stepsData: ActivitySteps[] = [
           question:
             "Your team discovers the training data has quality issues. What do you do?",
         },
-        kind: "multiple_choice",
+        kind: "multipleChoice" as StepKind,
       },
       {
         content: {
@@ -265,7 +266,7 @@ const stepsData: ActivitySteps[] = [
           question:
             "The model is underperforming. A team member suggests using a more complex architecture. What's your decision?",
         },
-        kind: "multiple_choice",
+        kind: "multipleChoice" as StepKind,
       },
     ],
   },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch steps.kind from a string to a Prisma enum (StepKind) and update usages. This enforces valid values and aligns DB snake_case with camelCase in code.

- **Refactors**
  - Added StepKind enum with @map to existing snake_case DB values.
  - Changed steps.kind to StepKind in the Prisma model and added a migration.
  - Exported StepKind from @zoonk/db.
  - Updated seeds and tests to use camelCase literals (e.g., multipleChoice, fillBlank).

- **Migration**
  - Destructive change: steps.kind is dropped and recreated as an enum.
  - If the steps table has data, back up and restore mapped values; otherwise run during empty/seeded envs.
  - Apply with your normal Prisma migration flow.

<sup>Written for commit 6b56f792f01fbeaf54c07789b97265e83f97a4f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

