### PR TITLE
refactor(ai): move image prompt to its own file

### DIFF
--- a/packages/ai/src/tasks/courses/course-thumbnail.prompt.md
+++ b/packages/ai/src/tasks/courses/course-thumbnail.prompt.md
@@ -1,0 +1,5 @@
+Generate an icon to visually symbolize a topic using a simple, recognizable object.
+
+Style: 3D rendered with vivid high-contrast colors, smooth matte surfaces, clean sharp edges with slight bevels, realistic lighting and subtle shadows, minimalist and modern design, subtle neutral background, no text, square format (1:1).
+
+TOPIC: **{{TITLE}}**

--- a/packages/ai/src/tasks/courses/course-thumbnail.ts
+++ b/packages/ai/src/tasks/courses/course-thumbnail.ts
@@ -7,7 +7,7 @@ const DEFAULT_MODEL = openai.image("gpt-image-1-mini");
 const DEFAULT_QUALITY = "low";
 
 export function getCourseThumbnailPrompt(title: string) {
-  return promptTemplate.replace("{{TITLE}}", title);
+  return promptTemplate.replace("{{TITLE}}", () => title);
 }
 
 export type CourseThumbnailParams = {

--- a/packages/ai/src/tasks/courses/course-thumbnail.ts
+++ b/packages/ai/src/tasks/courses/course-thumbnail.ts
@@ -1,19 +1,13 @@
 import { openai } from "@ai-sdk/openai";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { type GeneratedFile, generateImage, type ImageModel } from "ai";
+import promptTemplate from "./course-thumbnail.prompt.md";
 
 const DEFAULT_MODEL = openai.image("gpt-image-1-mini");
 const DEFAULT_QUALITY = "low";
 
 export function getCourseThumbnailPrompt(title: string) {
-  return `
-  Generate an icon to visually symbolize a topic using a simple, recognizable object.
-  Style: 3D rendered with vivid high-contrast colors, smooth matte surfaces,
-  clean sharp edges with slight bevels, realistic lighting and subtle shadows,
-  minimalist and modern design, subtle neutral background, no text, square format (1:1).
-
-  TOPIC: **${title}**
-  `;
+  return promptTemplate.replace("{{TITLE}}", title);
 }
 
 export type CourseThumbnailParams = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved the course thumbnail image prompt into a dedicated markdown template to make it easier to edit and reuse. No behavior change to image generation.

- **Refactors**
  - Added course-thumbnail.prompt.md with the image prompt template.
  - Updated getCourseThumbnailPrompt to import the template and replace {{TITLE}} with the course title.

<sup>Written for commit b7e985903aac2de8544143d2d0126fa593feb321. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

