### PR TITLE
feat(ai): add task for generating step image

### DIFF
--- a/apps/evals/src/app/page.tsx
+++ b/apps/evals/src/app/page.tsx
@@ -53,6 +53,24 @@ export default function Home() {
           </ItemActions>
         </Item>
 
+        <Item variant="outline">
+          <ItemContent>
+            <ItemTitle>Select Image Test</ItemTitle>
+            <ItemDescription>
+              Test AI-generated images for selectImage quiz steps
+            </ItemDescription>
+          </ItemContent>
+
+          <ItemActions>
+            <Link
+              className={buttonVariants({ variant: "outline" })}
+              href="/select-image-test"
+            >
+              Test Images
+            </Link>
+          </ItemActions>
+        </Item>
+
         {TASKS.map((task) => (
           <Item key={task.id} variant="outline">
             <ItemContent>

--- a/apps/evals/src/app/select-image-test/actions.ts
+++ b/apps/evals/src/app/select-image-test/actions.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { generateStepImage } from "@zoonk/core/steps/image";
+import { parseFormField } from "@zoonk/utils/form";
+
+export async function generateSelectImageAction(formData: FormData) {
+  const prompt = parseFormField(formData, "prompt");
+
+  if (!prompt) {
+    return { error: "Prompt is required." };
+  }
+
+  const { data: imageUrl, error } = await generateStepImage({
+    orgSlug: "evals",
+    prompt,
+  });
+
+  if (error) {
+    console.error("Error generating select image:", error);
+    return { error: error.message };
+  }
+
+  return { imageUrl, success: true };
+}

--- a/apps/evals/src/app/select-image-test/form.tsx
+++ b/apps/evals/src/app/select-image-test/form.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Button } from "@zoonk/ui/components/button";
+import { Input } from "@zoonk/ui/components/input";
+import { Label } from "@zoonk/ui/components/label";
+import { Loader2 } from "lucide-react";
+import Image from "next/image";
+import { useState, useTransition } from "react";
+import { generateSelectImageAction } from "./actions";
+
+export function SelectImageTestForm() {
+  const [isPending, startTransition] = useTransition();
+  const [result, setResult] = useState<{
+    imageUrl?: string;
+    error?: string;
+  } | null>(null);
+
+  async function handleSubmit(formData: FormData) {
+    startTransition(async () => {
+      setResult(null);
+      const response = await generateSelectImageAction(formData);
+
+      if ("error" in response) {
+        setResult({ error: response.error });
+      } else if (response.success && response.imageUrl) {
+        setResult({ imageUrl: response.imageUrl });
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <form action={handleSubmit} className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="prompt">Image Content Prompt</Label>
+          <Input
+            disabled={isPending}
+            id="prompt"
+            name="prompt"
+            placeholder="e.g., Connected layers of nodes representing a neural network"
+            required
+            type="text"
+          />
+        </div>
+
+        <Button className="self-start" disabled={isPending} type="submit">
+          {isPending && <Loader2 className="animate-spin" />}
+          Generate Image
+        </Button>
+      </form>
+
+      {result?.error && (
+        <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-4 text-red-500">
+          <p className="font-medium">Error</p>
+          <p className="text-sm">{result.error}</p>
+        </div>
+      )}
+
+      {result?.imageUrl && (
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <p className="font-medium">Generated Image</p>
+            <Image
+              alt="Generated select image step"
+              className="max-w-md rounded-lg border"
+              height={1024}
+              src={result.imageUrl}
+              width={1024}
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="imageUrl">Image URL</Label>
+            <Input
+              className="font-mono text-sm"
+              id="imageUrl"
+              readOnly
+              value={result.imageUrl}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/evals/src/app/select-image-test/page.tsx
+++ b/apps/evals/src/app/select-image-test/page.tsx
@@ -1,0 +1,40 @@
+import {
+  BreadcrumbItem,
+  BreadcrumbPage,
+} from "@zoonk/ui/components/breadcrumb";
+import {
+  Container,
+  ContainerBody,
+  ContainerDescription,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
+import { AppBreadcrumb, HomeLinkBreadcrumb } from "@/components/breadcrumb";
+import { SelectImageTestForm } from "./form";
+
+export default function SelectImageTestPage() {
+  return (
+    <Container>
+      <AppBreadcrumb>
+        <HomeLinkBreadcrumb />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Select Image Test</BreadcrumbPage>
+        </BreadcrumbItem>
+      </AppBreadcrumb>
+
+      <ContainerHeader>
+        <ContainerHeaderGroup>
+          <ContainerTitle>Select Image Step Generator</ContainerTitle>
+          <ContainerDescription>
+            Test AI-generated images for selectImage quiz steps
+          </ContainerDescription>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <SelectImageTestForm />
+      </ContainerBody>
+    </Container>
+  );
+}

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -24,6 +24,7 @@
     "./tasks/courses/thumbnail": "./src/tasks/courses/course-thumbnail.ts",
     "./tasks/lessons/activities": "./src/tasks/lessons/lesson-activities.ts",
     "./tasks/lessons/kind": "./src/tasks/lessons/lesson-kind.ts",
+    "./tasks/steps/select-image": "./src/tasks/steps/select-image-step.ts",
     "./types": "./src/types.ts"
   },
   "name": "@zoonk/ai",

--- a/packages/ai/src/tasks/steps/select-image-step.prompt.md
+++ b/packages/ai/src/tasks/steps/select-image-step.prompt.md
@@ -1,0 +1,7 @@
+Generate an educational illustration for a visual quiz question.
+
+Style: 3D rendered with vivid high-contrast colors, smooth matte surfaces, clean sharp edges with slight bevels, realistic lighting and subtle shadows, minimalist and modern design, subtle neutral background, no text labels or annotations, square format (1:1).
+
+The image should clearly depict the concept while being visually distinct from other options in a quiz context. Focus on clarity and recognizability.
+
+CONTENT TO ILLUSTRATE: **{{PROMPT}}**

--- a/packages/ai/src/tasks/steps/select-image-step.ts
+++ b/packages/ai/src/tasks/steps/select-image-step.ts
@@ -1,0 +1,42 @@
+import { openai } from "@ai-sdk/openai";
+import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { type GeneratedFile, generateImage, type ImageModel } from "ai";
+import promptTemplate from "./select-image-step.prompt.md";
+
+const DEFAULT_MODEL = openai.image("gpt-image-1-mini");
+const DEFAULT_QUALITY = "low";
+
+export function getSelectImageStepPrompt(prompt: string) {
+  return promptTemplate.replace("{{PROMPT}}", () => prompt);
+}
+
+export type SelectImageStepParams = {
+  prompt: string;
+  model?: ImageModel;
+  quality?: "auto" | "low" | "medium" | "high";
+};
+
+export async function generateSelectImageStep({
+  prompt,
+  model = DEFAULT_MODEL,
+  quality = DEFAULT_QUALITY,
+}: SelectImageStepParams): Promise<SafeReturn<GeneratedFile>> {
+  const { data, error } = await safeAsync(() =>
+    generateImage({
+      maxImagesPerCall: 1,
+      model,
+      prompt: getSelectImageStepPrompt(prompt),
+      providerOptions: {
+        openai: { output_format: "webp", quality },
+      },
+      size: "1024x1024",
+    }),
+  );
+
+  if (error) {
+    console.error("Error generating select image step:", error);
+    return { data: null, error };
+  }
+
+  return { data: data.image, error: null };
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,7 @@
     "./orgs/find": "./src/orgs/find-org.ts",
     "./orgs/get": "./src/orgs/get-org.ts",
     "./orgs/permissions": "./src/orgs/org-permissions.ts",
+    "./steps/image": "./src/steps/step-image.ts",
     "./types": "./src/types.ts",
     "./users/orgs/list": "./src/users/list-user-orgs.ts",
     "./users/otp/send": "./src/users/send-otp.ts",

--- a/packages/core/src/steps/step-image.ts
+++ b/packages/core/src/steps/step-image.ts
@@ -1,0 +1,49 @@
+import {
+  generateSelectImageStep,
+  type SelectImageStepParams,
+} from "@zoonk/ai/tasks/steps/select-image";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import type { SafeReturn } from "@zoonk/utils/error";
+import { toSlug } from "@zoonk/utils/string";
+import { optimizeImage } from "../images/optimize-image";
+import { uploadImage } from "../images/upload-image";
+
+export type GenerateStepImageParams = SelectImageStepParams & {
+  orgSlug?: string;
+};
+
+export async function generateStepImage({
+  orgSlug,
+  prompt,
+  ...rest
+}: GenerateStepImageParams): Promise<SafeReturn<string>> {
+  const { data: image, error: imageGenerationError } =
+    await generateSelectImageStep({ prompt, ...rest });
+
+  if (imageGenerationError) {
+    return { data: null, error: imageGenerationError };
+  }
+
+  const { data: optimized, error: optimizeError } = await optimizeImage({
+    image: Buffer.from(image.uint8Array),
+  });
+
+  if (optimizeError) {
+    return { data: null, error: optimizeError };
+  }
+
+  const slug = toSlug(prompt.substring(0, 50));
+  const org = orgSlug ?? AI_ORG_SLUG;
+  const fileName = `steps/${org}/${slug}.webp`;
+
+  const { data: url, error: uploadError } = await uploadImage({
+    fileName,
+    image: optimized,
+  });
+
+  if (uploadError) {
+    return { data: null, error: uploadError };
+  }
+
+  return { data: url, error: null };
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds image generation for select-image quiz steps and a test page to preview results. This enables creating consistent, square illustrations and saving them to storage for reuse.

- **New Features**
  - New task to generate 1024x1024 select-image step illustrations from a prompt template (clean, high-contrast 3D style).
  - Core helper generateStepImage that generates, optimizes to webp, uploads, and returns the image URL; supports org slug-based paths.
  - Test UI at /select-image-test with a prompt form, loading state, error display, and image preview + URL copy.
  - Exposed new entry points: @zoonk/ai/tasks/steps/select-image and @zoonk/core/steps/image.
  - Sensible defaults: low quality, single image, webp output, filename slugged from prompt.

<sup>Written for commit de6c7ca47a3a9f923dd217ccfdadc804236aa9ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

