### PR TITLE
feat(ai): add task for generating visual step image

### DIFF
--- a/apps/evals/src/app/page.tsx
+++ b/apps/evals/src/app/page.tsx
@@ -71,6 +71,24 @@ export default function Home() {
           </ItemActions>
         </Item>
 
+        <Item variant="outline">
+          <ItemContent>
+            <ItemTitle>Visual Image Test</ItemTitle>
+            <ItemDescription>
+              Test AI-generated images for step visual resources
+            </ItemDescription>
+          </ItemContent>
+
+          <ItemActions>
+            <Link
+              className={buttonVariants({ variant: "outline" })}
+              href="/visual-image-test"
+            >
+              Test Images
+            </Link>
+          </ItemActions>
+        </Item>
+
         {TASKS.map((task) => (
           <Item key={task.id} variant="outline">
             <ItemContent>

--- a/apps/evals/src/app/visual-image-test/actions.ts
+++ b/apps/evals/src/app/visual-image-test/actions.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { generateVisualStepImage } from "@zoonk/core/steps/visual-image";
+import { parseFormField } from "@zoonk/utils/form";
+
+export async function generateVisualImageAction(formData: FormData) {
+  const prompt = parseFormField(formData, "prompt");
+
+  if (!prompt) {
+    return { error: "Prompt is required." };
+  }
+
+  const { data: imageUrl, error } = await generateVisualStepImage({
+    orgSlug: "evals",
+    prompt,
+  });
+
+  if (error) {
+    console.error("Error generating visual image:", error);
+    return { error: error.message };
+  }
+
+  return { imageUrl, success: true };
+}

--- a/apps/evals/src/app/visual-image-test/form.tsx
+++ b/apps/evals/src/app/visual-image-test/form.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Button } from "@zoonk/ui/components/button";
+import { Input } from "@zoonk/ui/components/input";
+import { Label } from "@zoonk/ui/components/label";
+import { Loader2 } from "lucide-react";
+import Image from "next/image";
+import { useState, useTransition } from "react";
+import { generateVisualImageAction } from "./actions";
+
+export function VisualImageTestForm() {
+  const [isPending, startTransition] = useTransition();
+  const [result, setResult] = useState<{
+    imageUrl?: string;
+    error?: string;
+  } | null>(null);
+
+  async function handleSubmit(formData: FormData) {
+    startTransition(async () => {
+      setResult(null);
+      const response = await generateVisualImageAction(formData);
+
+      if ("error" in response) {
+        setResult({ error: response.error });
+      } else if (response.success && response.imageUrl) {
+        setResult({ imageUrl: response.imageUrl });
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <form action={handleSubmit} className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="prompt">Image Content Prompt</Label>
+          <Input
+            disabled={isPending}
+            id="prompt"
+            name="prompt"
+            placeholder="e.g., A diagram showing the water cycle with evaporation, condensation, and precipitation"
+            required
+            type="text"
+          />
+        </div>
+
+        <Button className="self-start" disabled={isPending} type="submit">
+          {isPending && <Loader2 className="animate-spin" />}
+          Generate Image
+        </Button>
+      </form>
+
+      {result?.error && (
+        <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-4 text-red-500">
+          <p className="font-medium">Error</p>
+          <p className="text-sm">{result.error}</p>
+        </div>
+      )}
+
+      {result?.imageUrl && (
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <p className="font-medium">Generated Image</p>
+            <Image
+              alt="Generated step visual image"
+              className="max-w-md rounded-lg border"
+              height={1024}
+              src={result.imageUrl}
+              width={1024}
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="imageUrl">Image URL</Label>
+            <Input
+              className="font-mono text-sm"
+              id="imageUrl"
+              readOnly
+              value={result.imageUrl}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/evals/src/app/visual-image-test/page.tsx
+++ b/apps/evals/src/app/visual-image-test/page.tsx
@@ -1,0 +1,40 @@
+import {
+  BreadcrumbItem,
+  BreadcrumbPage,
+} from "@zoonk/ui/components/breadcrumb";
+import {
+  Container,
+  ContainerBody,
+  ContainerDescription,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
+import { AppBreadcrumb, HomeLinkBreadcrumb } from "@/components/breadcrumb";
+import { VisualImageTestForm } from "./form";
+
+export default function VisualImageTestPage() {
+  return (
+    <Container>
+      <AppBreadcrumb>
+        <HomeLinkBreadcrumb />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Visual Image Test</BreadcrumbPage>
+        </BreadcrumbItem>
+      </AppBreadcrumb>
+
+      <ContainerHeader>
+        <ContainerHeaderGroup>
+          <ContainerTitle>Step Visual Image Generator</ContainerTitle>
+          <ContainerDescription>
+            Test AI-generated images for step visual resources
+          </ContainerDescription>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <VisualImageTestForm />
+      </ContainerBody>
+    </Container>
+  );
+}

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -26,6 +26,7 @@
     "./tasks/lessons/kind": "./src/tasks/lessons/lesson-kind.ts",
     "./tasks/steps/select-image": "./src/tasks/steps/select-image-step.ts",
     "./tasks/steps/visual": "./src/tasks/steps/step-visual.ts",
+    "./tasks/steps/visual-image": "./src/tasks/steps/step-visual-image.ts",
     "./types": "./src/types.ts"
   },
   "name": "@zoonk/ai",

--- a/packages/ai/src/tasks/steps/step-visual-image.prompt.md
+++ b/packages/ai/src/tasks/steps/step-visual-image.prompt.md
@@ -1,0 +1,7 @@
+Generate an educational illustration for a learning step.
+
+Style: Modern flat illustration with clean geometric shapes, a refined limited color palette (2-4 harmonious colors with subtle tints and shades), generous white space, crisp edges without heavy outlines, subtle ambient shadows for depth, clean sans-serif typography when text is needed, balanced composition with clear visual hierarchy, educational and professional aesthetic, square format (1:1).
+
+The illustration should clearly communicate the educational concept while being visually engaging and easy to understand.
+
+CONTENT TO ILLUSTRATE: **{{PROMPT}}**

--- a/packages/ai/src/tasks/steps/step-visual-image.ts
+++ b/packages/ai/src/tasks/steps/step-visual-image.ts
@@ -1,0 +1,42 @@
+import { openai } from "@ai-sdk/openai";
+import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { type GeneratedFile, type ImageModel, generateImage } from "ai";
+import promptTemplate from "./step-visual-image.prompt.md";
+
+const DEFAULT_MODEL = openai.image("gpt-image-1.5");
+const DEFAULT_QUALITY = "low";
+
+export function getStepVisualImagePrompt(prompt: string) {
+  return promptTemplate.replace("{{PROMPT}}", () => prompt);
+}
+
+export type StepVisualImageParams = {
+  prompt: string;
+  model?: ImageModel;
+  quality?: "auto" | "low" | "medium" | "high";
+};
+
+export async function generateStepVisualImage({
+  prompt,
+  model = DEFAULT_MODEL,
+  quality = DEFAULT_QUALITY,
+}: StepVisualImageParams): Promise<SafeReturn<GeneratedFile>> {
+  const { data, error } = await safeAsync(() =>
+    generateImage({
+      maxImagesPerCall: 1,
+      model,
+      prompt: getStepVisualImagePrompt(prompt),
+      providerOptions: {
+        openai: { output_format: "webp", quality },
+      },
+      size: "1024x1024",
+    }),
+  );
+
+  if (error) {
+    console.error("Error generating step visual image:", error);
+    return { data: null, error };
+  }
+
+  return { data: data.image, error: null };
+}

--- a/packages/ai/src/tasks/steps/step-visual-image.ts
+++ b/packages/ai/src/tasks/steps/step-visual-image.ts
@@ -1,6 +1,6 @@
 import { openai } from "@ai-sdk/openai";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
-import { type GeneratedFile, type ImageModel, generateImage } from "ai";
+import { type GeneratedFile, generateImage, type ImageModel } from "ai";
 import promptTemplate from "./step-visual-image.prompt.md";
 
 const DEFAULT_MODEL = openai.image("gpt-image-1.5");

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "./orgs/get": "./src/orgs/get-org.ts",
     "./orgs/permissions": "./src/orgs/org-permissions.ts",
     "./steps/image": "./src/steps/step-image.ts",
+    "./steps/visual-image": "./src/steps/step-visual-image.ts",
     "./types": "./src/types.ts",
     "./users/orgs/list": "./src/users/list-user-orgs.ts",
     "./users/otp/send": "./src/users/send-otp.ts",

--- a/packages/core/src/steps/step-visual-image.ts
+++ b/packages/core/src/steps/step-visual-image.ts
@@ -1,0 +1,49 @@
+import {
+  generateStepVisualImage,
+  type StepVisualImageParams,
+} from "@zoonk/ai/tasks/steps/visual-image";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import type { SafeReturn } from "@zoonk/utils/error";
+import { toSlug } from "@zoonk/utils/string";
+import { optimizeImage } from "../images/optimize-image";
+import { uploadImage } from "../images/upload-image";
+
+export type GenerateVisualStepImageParams = StepVisualImageParams & {
+  orgSlug?: string;
+};
+
+export async function generateVisualStepImage({
+  orgSlug,
+  prompt,
+  ...rest
+}: GenerateVisualStepImageParams): Promise<SafeReturn<string>> {
+  const { data: image, error: imageGenerationError } =
+    await generateStepVisualImage({ prompt, ...rest });
+
+  if (imageGenerationError) {
+    return { data: null, error: imageGenerationError };
+  }
+
+  const { data: optimized, error: optimizeError } = await optimizeImage({
+    image: Buffer.from(image.uint8Array),
+  });
+
+  if (optimizeError) {
+    return { data: null, error: optimizeError };
+  }
+
+  const slug = toSlug(prompt.substring(0, 50));
+  const org = orgSlug ?? AI_ORG_SLUG;
+  const fileName = `steps/${org}/visual-${slug}.webp`;
+
+  const { data: url, error: uploadError } = await uploadImage({
+    fileName,
+    image: optimized,
+  });
+
+  if (uploadError) {
+    return { data: null, error: uploadError };
+  }
+
+  return { data: url, error: null };
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds visual image generation for step resources and a simple test page to try prompts and get a hosted image URL. This produces consistent square illustrations from a prompt and uploads the result.

- **New Features**
  - Generate an educational illustration from a prompt using a predefined style; outputs 1024x1024 webp.
  - Optimize and upload the image with a predictable filename based on org and prompt slug; returns public URL.
  - New test page at /visual-image-test with a form and server action to submit prompts and preview the image.
  - Added link on the evals home page to access the test page.

<sup>Written for commit b65db65e8a455bad85ac08525a9be80a0514f5e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

