### PR TITLE
fix(editor): always use custom lesson kind

### DIFF
--- a/apps/editor/src/data/lessons/create-lesson.test.ts
+++ b/apps/editor/src/data/lessons/create-lesson.test.ts
@@ -107,6 +107,7 @@ describe("admins", () => {
     expect(result.data?.organizationId).toBe(organization.id);
     expect(result.data?.chapterId).toBe(chapter.id);
     expect(result.data?.language).toBe(chapter.language);
+    expect(result.data?.kind).toBe("custom");
   });
 
   test("normalizes slug", async () => {

--- a/apps/editor/src/data/lessons/create-lesson.ts
+++ b/apps/editor/src/data/lessons/create-lesson.ts
@@ -59,6 +59,7 @@ export async function createLesson(params: {
           chapterId: params.chapterId,
           description: params.description,
           isPublished: !chapter.isPublished,
+          kind: "custom",
           language: chapter.language,
           normalizedTitle,
           organizationId: chapter.organizationId,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Always set kind: "custom" when creating lessons in the editor to standardize lesson type and avoid mismatches.
Updated createLesson to set the kind and added a test assertion to verify it.

<sup>Written for commit 4b327b1d6b96c2298dcd472d278a693671747a2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

