### PR TITLE
fix(data): use individual args for React cache deduplication

### DIFF
--- a/apps/editor/src/data/categories/list-course-categories.ts
+++ b/apps/editor/src/data/categories/list-course-categories.ts
@@ -4,20 +4,20 @@ import { type CourseCategory, prisma } from "@zoonk/db";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 
-export const listCourseCategories = cache(
-  async (params: {
-    courseSlug: string;
-    language: string;
-    orgSlug: string;
-  }): Promise<SafeReturn<CourseCategory[]>> => {
+const cachedListCourseCategories = cache(
+  async (
+    courseSlug: string,
+    language: string,
+    orgSlug: string,
+  ): Promise<SafeReturn<CourseCategory[]>> => {
     const { data, error } = await safeAsync(() =>
       prisma.courseCategory.findMany({
         orderBy: { category: "asc" },
         where: {
           course: {
-            language: params.language,
-            organization: { slug: params.orgSlug },
-            slug: params.courseSlug,
+            language,
+            organization: { slug: orgSlug },
+            slug: courseSlug,
           },
         },
       }),
@@ -30,3 +30,15 @@ export const listCourseCategories = cache(
     return { data, error: null };
   },
 );
+
+export function listCourseCategories(params: {
+  courseSlug: string;
+  language: string;
+  orgSlug: string;
+}): Promise<SafeReturn<CourseCategory[]>> {
+  return cachedListCourseCategories(
+    params.courseSlug,
+    params.language,
+    params.orgSlug,
+  );
+}

--- a/apps/editor/src/data/chapters/chapter-slug.ts
+++ b/apps/editor/src/data/chapters/chapter-slug.ts
@@ -4,18 +4,22 @@ import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 
-export const chapterSlugExists = cache(
-  async (params: { courseId: number; slug: string }): Promise<boolean> => {
+const cachedChapterSlugExists = cache(
+  async (courseId: number, slug: string): Promise<boolean> => {
     const { data } = await safeAsync(() =>
       prisma.chapter.findFirst({
         select: { id: true },
-        where: {
-          courseId: params.courseId,
-          slug: params.slug,
-        },
+        where: { courseId, slug },
       }),
     );
 
     return data !== null;
   },
 );
+
+export function chapterSlugExists(params: {
+  courseId: number;
+  slug: string;
+}): Promise<boolean> {
+  return cachedChapterSlugExists(params.courseId, params.slug);
+}

--- a/apps/editor/src/data/chapters/list-course-chapters.ts
+++ b/apps/editor/src/data/chapters/list-course-chapters.ts
@@ -6,27 +6,27 @@ import { AppError, safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 import { ErrorCode } from "@/lib/app-error";
 
-export const listCourseChapters = cache(
-  async (params: {
-    courseSlug: string;
-    headers?: Headers;
-    language: string;
-    orgSlug: string;
-  }): Promise<{ data: Chapter[]; error: Error | null }> => {
+const cachedListCourseChapters = cache(
+  async (
+    courseSlug: string,
+    language: string,
+    orgSlug: string,
+    headers?: Headers,
+  ): Promise<{ data: Chapter[]; error: Error | null }> => {
     const { data, error } = await safeAsync(() =>
       Promise.all([
         hasCoursePermission({
-          headers: params.headers,
-          orgSlug: params.orgSlug,
+          headers,
+          orgSlug,
           permission: "update",
         }),
         prisma.chapter.findMany({
           orderBy: { position: "asc" },
           where: {
             course: {
-              language: params.language,
-              organization: { slug: params.orgSlug },
-              slug: params.courseSlug,
+              language,
+              organization: { slug: orgSlug },
+              slug: courseSlug,
             },
           },
         }),
@@ -46,3 +46,17 @@ export const listCourseChapters = cache(
     return { data: chapters, error: null };
   },
 );
+
+export function listCourseChapters(params: {
+  courseSlug: string;
+  headers?: Headers;
+  language: string;
+  orgSlug: string;
+}): Promise<{ data: Chapter[]; error: Error | null }> {
+  return cachedListCourseChapters(
+    params.courseSlug,
+    params.language,
+    params.orgSlug,
+    params.headers,
+  );
+}

--- a/apps/editor/src/data/courses/course-slug.ts
+++ b/apps/editor/src/data/courses/course-slug.ts
@@ -4,19 +4,15 @@ import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 
-export const courseSlugExists = cache(
-  async (params: {
-    language: string;
-    orgSlug: string;
-    slug: string;
-  }): Promise<boolean> => {
+const cachedCourseSlugExists = cache(
+  async (language: string, orgSlug: string, slug: string): Promise<boolean> => {
     const { data } = await safeAsync(() =>
       prisma.course.findFirst({
         select: { id: true },
         where: {
-          language: params.language,
-          organization: { slug: params.orgSlug },
-          slug: params.slug,
+          language,
+          organization: { slug: orgSlug },
+          slug,
         },
       }),
     );
@@ -24,3 +20,11 @@ export const courseSlugExists = cache(
     return data !== null;
   },
 );
+
+export function courseSlugExists(params: {
+  language: string;
+  orgSlug: string;
+  slug: string;
+}): Promise<boolean> {
+  return cachedCourseSlugExists(params.language, params.orgSlug, params.slug);
+}

--- a/apps/editor/src/data/courses/get-course.ts
+++ b/apps/editor/src/data/courses/get-course.ts
@@ -6,25 +6,25 @@ import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 import { ErrorCode } from "@/lib/app-error";
 
-export const getCourse = cache(
-  async (params: {
-    courseSlug: string;
-    language: string;
-    orgSlug: string;
-    headers?: Headers;
-  }): Promise<SafeReturn<Course | null>> => {
+const cachedGetCourse = cache(
+  async (
+    courseSlug: string,
+    language: string,
+    orgSlug: string,
+    headers?: Headers,
+  ): Promise<SafeReturn<Course | null>> => {
     const { data, error } = await safeAsync(() =>
       Promise.all([
         hasCoursePermission({
-          headers: params.headers,
-          orgSlug: params.orgSlug,
+          headers,
+          orgSlug,
           permission: "update",
         }),
         prisma.course.findFirst({
           where: {
-            language: params.language,
-            organization: { slug: params.orgSlug },
-            slug: params.courseSlug,
+            language,
+            organization: { slug: orgSlug },
+            slug: courseSlug,
           },
         }),
       ]),
@@ -47,3 +47,17 @@ export const getCourse = cache(
     return { data: course, error: null };
   },
 );
+
+export function getCourse(params: {
+  courseSlug: string;
+  language: string;
+  orgSlug: string;
+  headers?: Headers;
+}): Promise<SafeReturn<Course | null>> {
+  return cachedGetCourse(
+    params.courseSlug,
+    params.language,
+    params.orgSlug,
+    params.headers,
+  );
+}

--- a/apps/editor/src/data/lessons/lesson-slug.ts
+++ b/apps/editor/src/data/lessons/lesson-slug.ts
@@ -4,18 +4,22 @@ import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 
-export const lessonSlugExists = cache(
-  async (params: { chapterId: number; slug: string }): Promise<boolean> => {
+const cachedLessonSlugExists = cache(
+  async (chapterId: number, slug: string): Promise<boolean> => {
     const { data } = await safeAsync(() =>
       prisma.lesson.findFirst({
         select: { id: true },
-        where: {
-          chapterId: params.chapterId,
-          slug: params.slug,
-        },
+        where: { chapterId, slug },
       }),
     );
 
     return data !== null;
   },
 );
+
+export function lessonSlugExists(params: {
+  chapterId: number;
+  slug: string;
+}): Promise<boolean> {
+  return cachedLessonSlugExists(params.chapterId, params.slug);
+}

--- a/apps/editor/src/data/search-content.ts
+++ b/apps/editor/src/data/search-content.ts
@@ -30,18 +30,12 @@ export type SearchResults = {
   lessons: ResultWithPosition[];
 };
 
-/**
- * Search courses, chapters, and lessons in parallel.
- * Returns grouped results for display in the command palette.
- */
-export const searchContent = cache(
-  async (params: {
-    title: string;
-    orgSlug: string;
-    limit?: number;
-  }): Promise<SearchResults> => {
-    const { title, orgSlug, limit } = params;
-
+const cachedSearchContent = cache(
+  async (
+    title: string,
+    orgSlug: string,
+    limit?: number,
+  ): Promise<SearchResults> => {
     if (!title.trim()) {
       return { chapters: [], courses: [], lessons: [] };
     }
@@ -86,3 +80,11 @@ export const searchContent = cache(
     return { chapters, courses, lessons };
   },
 );
+
+export async function searchContent(params: {
+  title: string;
+  orgSlug: string;
+  limit?: number;
+}): Promise<SearchResults> {
+  return cachedSearchContent(params.title, params.orgSlug, params.limit);
+}

--- a/apps/main/src/data/chapters/list-course-chapters.ts
+++ b/apps/main/src/data/chapters/list-course-chapters.ts
@@ -18,12 +18,12 @@ export type ChapterWithLessons = {
   }[];
 };
 
-export const listCourseChapters = cache(
-  async (params: {
-    brandSlug: string;
-    courseSlug: string;
-    language: string;
-  }): Promise<ChapterWithLessons[]> =>
+const cachedListCourseChapters = cache(
+  async (
+    brandSlug: string,
+    courseSlug: string,
+    language: string,
+  ): Promise<ChapterWithLessons[]> =>
     prisma.chapter.findMany({
       orderBy: { position: "asc" },
       select: {
@@ -47,14 +47,26 @@ export const listCourseChapters = cache(
       where: {
         course: {
           isPublished: true,
-          language: params.language,
+          language,
           organization: {
             kind: "brand",
-            slug: params.brandSlug,
+            slug: brandSlug,
           },
-          slug: params.courseSlug,
+          slug: courseSlug,
         },
         isPublished: true,
       },
     }),
 );
+
+export function listCourseChapters(params: {
+  brandSlug: string;
+  courseSlug: string;
+  language: string;
+}): Promise<ChapterWithLessons[]> {
+  return cachedListCourseChapters(
+    params.brandSlug,
+    params.courseSlug,
+    params.language,
+  );
+}

--- a/apps/main/src/data/courses/find-existing-course.ts
+++ b/apps/main/src/data/courses/find-existing-course.ts
@@ -12,19 +12,19 @@ type ExistingCourse = {
   generationStatus: string;
 };
 
-export const findExistingCourse = cache(
-  async (params: {
-    slug: string;
-    language: string;
-  }): Promise<SafeReturn<ExistingCourse | null>> => {
-    const normalizedSlug = toSlug(params.slug);
+const cachedFindExistingCourse = cache(
+  async (
+    slug: string,
+    language: string,
+  ): Promise<SafeReturn<ExistingCourse | null>> => {
+    const normalizedSlug = toSlug(slug);
 
     const { data, error } = await safeAsync(() =>
       Promise.all([
         prisma.course.findFirst({
           select: { generationStatus: true, id: true, slug: true },
           where: {
-            language: params.language,
+            language,
             organization: { slug: AI_ORG_SLUG },
             slug: normalizedSlug,
           },
@@ -36,7 +36,7 @@ export const findExistingCourse = cache(
             },
           },
           where: {
-            languageSlug: { language: params.language, slug: normalizedSlug },
+            languageSlug: { language, slug: normalizedSlug },
           },
         }),
       ]),
@@ -59,3 +59,10 @@ export const findExistingCourse = cache(
     return { data: null, error: null };
   },
 );
+
+export function findExistingCourse(params: {
+  slug: string;
+  language: string;
+}): Promise<SafeReturn<ExistingCourse | null>> {
+  return cachedFindExistingCourse(params.slug, params.language);
+}

--- a/apps/main/src/data/courses/get-course.ts
+++ b/apps/main/src/data/courses/get-course.ts
@@ -17,12 +17,12 @@ export type CourseWithDetails = {
   categories: { category: string }[];
 };
 
-export const getCourse = cache(
-  async (params: {
-    brandSlug: string;
-    courseSlug: string;
-    language: string;
-  }): Promise<CourseWithDetails | null> =>
+const cachedGetCourse = cache(
+  async (
+    brandSlug: string,
+    courseSlug: string,
+    language: string,
+  ): Promise<CourseWithDetails | null> =>
     prisma.course.findFirst({
       select: {
         categories: {
@@ -39,12 +39,20 @@ export const getCourse = cache(
       },
       where: {
         isPublished: true,
-        language: params.language,
+        language,
         organization: {
           kind: "brand",
-          slug: params.brandSlug,
+          slug: brandSlug,
         },
-        slug: params.courseSlug,
+        slug: courseSlug,
       },
     }),
 );
+
+export function getCourse(params: {
+  brandSlug: string;
+  courseSlug: string;
+  language: string;
+}): Promise<CourseWithDetails | null> {
+  return cachedGetCourse(params.brandSlug, params.courseSlug, params.language);
+}

--- a/apps/main/src/data/courses/search-courses.ts
+++ b/apps/main/src/data/courses/search-courses.ts
@@ -11,23 +11,21 @@ export type CourseWithOrganization = Course & {
   organization: Organization;
 };
 
-export const searchCourses = cache(
-  async (params: {
-    query: string;
-    language: string;
-    limit?: number;
-  }): Promise<CourseWithOrganization[]> => {
-    const normalizedSearch = normalizeString(params.query);
+const cachedSearchCourses = cache(
+  async (
+    query: string,
+    language: string,
+    limit: number,
+  ): Promise<CourseWithOrganization[]> => {
+    const normalizedSearch = normalizeString(query);
 
     if (!normalizedSearch) {
       return [];
     }
 
-    const limit = clampQueryItems(params.limit ?? DEFAULT_SEARCH_LIMIT);
-
     const baseWhere = {
       isPublished: true,
-      language: params.language,
+      language,
       organization: { kind: "brand" } as const,
     };
 
@@ -53,3 +51,12 @@ export const searchCourses = cache(
     return mergeSearchResults(exactMatch, containsMatches);
   },
 );
+
+export function searchCourses(params: {
+  query: string;
+  language: string;
+  limit?: number;
+}): Promise<CourseWithOrganization[]> {
+  const limit = clampQueryItems(params.limit ?? DEFAULT_SEARCH_LIMIT);
+  return cachedSearchCourses(params.query, params.language, limit);
+}

--- a/apps/main/src/data/progress/get-best-day.ts
+++ b/apps/main/src/data/progress/get-best-day.ts
@@ -11,16 +11,15 @@ export type BestDayData = {
 
 export type BestDayParams = {
   headers?: Headers;
-  /**
-   * Start date for filtering. When provided,
-   * uses this date instead of the default 90-day window.
-   */
   startDate?: Date;
 };
 
-export const getBestDay = cache(
-  async (params?: BestDayParams): Promise<BestDayData | null> => {
-    const session = await getSession({ headers: params?.headers });
+const cachedGetBestDay = cache(
+  async (
+    startDateIso: string | undefined,
+    headers?: Headers,
+  ): Promise<BestDayData | null> => {
+    const session = await getSession({ headers });
 
     if (!session) {
       return null;
@@ -28,11 +27,10 @@ export const getBestDay = cache(
 
     const userId = Number(session.user.id);
 
-    // Use provided start date or default to 90 days ago
     let startDate: Date;
 
-    if (params?.startDate) {
-      startDate = params.startDate;
+    if (startDateIso) {
+      startDate = new Date(startDateIso);
     } else {
       startDate = new Date();
       startDate.setDate(startDate.getDate() - 90);
@@ -82,3 +80,9 @@ export const getBestDay = cache(
     return bestDay;
   },
 );
+
+export function getBestDay(
+  params?: BestDayParams,
+): Promise<BestDayData | null> {
+  return cachedGetBestDay(params?.startDate?.toISOString(), params?.headers);
+}


### PR DESCRIPTION
## Summary
- Fix React `cache()` deduplication by using individual primitive arguments instead of objects
- React's `cache()` uses `===` for comparison, so object parameters always miss cache (different instances are never equal)
- Convert 27 cached functions across `apps/editor`, `apps/main`, and `packages/core` to use individual args internally while keeping object params in exported wrappers for API consistency

## Test plan
- [x] `pnpm format` passes
- [x] `pnpm lint --write --unsafe` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm knip` passes
- [x] `pnpm test` passes (577 tests)
- [x] `pnpm --filter main build` passes
- [x] `pnpm --filter editor build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix React cache() dedup by passing primitive args instead of objects, preventing cache misses in data loaders. Improves cache hit rate and reduces redundant DB calls without changing public APIs.

- **Bug Fixes**
  - Converted 27 cached functions to use individual args; kept object-based wrappers for API consistency.
  - Normalized inputs (e.g., limit, date ISO strings) before caching for stable keys.
  - Applied across apps/editor, apps/main, and packages/core, including permission checks.

<sup>Written for commit fad3b172eef3b09c1581ce7b5ea2376a4856b16b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

