### PR TITLE
feat(editor): list/add/reorder activities

### DIFF
--- a/apps/editor/e2e/activity-list.test.ts
+++ b/apps/editor/e2e/activity-list.test.ts
@@ -1,0 +1,470 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import tmp from "tmp";
+import { expect, type Page, test } from "./fixtures";
+import { getMoreOptionsButton, importFlow } from "./helpers/import-dialog";
+
+function createImportFile(
+  activities: { description?: string; kind: string; title?: string }[],
+): string {
+  const content = JSON.stringify({ activities }, null, 2);
+  const tmpFile = tmp.fileSync({ postfix: ".json", prefix: "activities-" });
+  fs.writeFileSync(tmpFile.name, content);
+  return tmpFile.name;
+}
+
+async function createTestLesson(activityCount = 0) {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const course = await courseFixture({
+    organizationId: org.id,
+    slug: `e2e-ac-${randomUUID().slice(0, 8)}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    language: "en",
+    organizationId: org.id,
+    position: 0,
+    slug: `e2e-ch-${randomUUID().slice(0, 8)}`,
+    title: "Test Chapter",
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    language: "en",
+    organizationId: org.id,
+    position: 0,
+    slug: `e2e-ls-${randomUUID().slice(0, 8)}`,
+    title: "Test Lesson",
+  });
+
+  const activities =
+    activityCount > 0
+      ? await Promise.all(
+          Array.from({ length: activityCount }, (_, i) =>
+            activityFixture({
+              language: "en",
+              lessonId: lesson.id,
+              organizationId: org.id,
+              position: i,
+              title: `Activity ${i + 1}`,
+            }),
+          ),
+        )
+      : [];
+
+  return { activities, chapter, course, lesson, org };
+}
+
+async function navigateToLessonPage(
+  page: Page,
+  courseSlug: string,
+  chapterSlug: string,
+  lessonSlug: string,
+) {
+  await page.goto(`/ai/c/en/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`);
+
+  await expect(
+    page.getByRole("textbox", { name: /edit lesson title/i }),
+  ).toBeVisible();
+}
+
+async function expectActivitiesVisible(
+  page: Page,
+  activities: { position: number; title: string }[],
+) {
+  await Promise.all(
+    activities.map(async ({ position, title }) => {
+      const listItem = page.getByRole("listitem").filter({
+        hasText: new RegExp(String(position).padStart(2, "0")),
+      });
+
+      await expect(
+        listItem.getByRole("link", { name: new RegExp(title, "i") }),
+      ).toBeVisible();
+    }),
+  );
+}
+
+async function expectActivityNotVisible(page: Page, title: string) {
+  await expect(
+    page.getByRole("link", { name: new RegExp(title, "i") }),
+  ).not.toBeVisible();
+}
+
+test.describe("Activity List", () => {
+  test.describe("Display", () => {
+    test("displays existing activities with position and title", async ({
+      authenticatedPage,
+    }) => {
+      const { chapter, course, lesson } = await createTestLesson(3);
+
+      await navigateToLessonPage(
+        authenticatedPage,
+        course.slug,
+        chapter.slug,
+        lesson.slug,
+      );
+
+      await expectActivitiesVisible(authenticatedPage, [
+        { position: 1, title: "Activity 1" },
+        { position: 2, title: "Activity 2" },
+        { position: 3, title: "Activity 3" },
+      ]);
+    });
+
+    test("displays activity description when available", async ({
+      authenticatedPage,
+    }) => {
+      const { chapter, course, lesson, org } = await createTestLesson();
+      const uniqueDesc = `Description ${randomUUID().slice(0, 8)}`;
+
+      await activityFixture({
+        description: uniqueDesc,
+        language: "en",
+        lessonId: lesson.id,
+        organizationId: org.id,
+        position: 0,
+        title: "Activity with description",
+      });
+
+      await navigateToLessonPage(
+        authenticatedPage,
+        course.slug,
+        chapter.slug,
+        lesson.slug,
+      );
+
+      await expect(authenticatedPage.getByText(uniqueDesc)).toBeVisible();
+    });
+  });
+
+  test.describe("Add Activity", () => {
+    test("adds an activity and shows activity edit page", async ({
+      authenticatedPage,
+    }) => {
+      const { chapter, course, lesson } = await createTestLesson();
+
+      await navigateToLessonPage(
+        authenticatedPage,
+        course.slug,
+        chapter.slug,
+        lesson.slug,
+      );
+
+      await authenticatedPage
+        .getByRole("button", { name: /add activity/i })
+        .click();
+
+      await expect(
+        authenticatedPage.getByText(/activity editor coming soon/i),
+      ).toBeVisible();
+    });
+
+    test("inserts activity at middle position", async ({
+      authenticatedPage,
+    }) => {
+      const { chapter, course, lesson } = await createTestLesson(4);
+
+      await navigateToLessonPage(
+        authenticatedPage,
+        course.slug,
+        chapter.slug,
+        lesson.slug,
+      );
+
+      await expectActivitiesVisible(authenticatedPage, [
+        { position: 1, title: "Activity 1" },
+        { position: 2, title: "Activity 2" },
+        { position: 3, title: "Activity 3" },
+        { position: 4, title: "Activity 4" },
+      ]);
+
+      const actionsButtons = authenticatedPage.getByRole("button", {
+        exact: true,
+        name: "Activity actions",
+      });
+
+      await actionsButtons.nth(1).click();
+
+      const insertBelowItem = authenticatedPage.getByRole("menuitem", {
+        name: /insert below/i,
+      });
+      await insertBelowItem.waitFor({ state: "visible" });
+      await insertBelowItem.click();
+
+      await expect(
+        authenticatedPage.getByText(/activity editor coming soon/i),
+      ).toBeVisible();
+
+      await authenticatedPage.goto(
+        `/ai/c/en/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`,
+      );
+
+      await expect(
+        authenticatedPage.getByRole("textbox", { name: /edit lesson title/i }),
+      ).toBeVisible();
+
+      await expectActivitiesVisible(authenticatedPage, [
+        { position: 1, title: "Activity 1" },
+        { position: 2, title: "Activity 2" },
+        { position: 3, title: "Untitled activity" },
+        { position: 4, title: "Activity 3" },
+        { position: 5, title: "Activity 4" },
+      ]);
+    });
+  });
+
+  test.describe("Reorder", () => {
+    test("reorders activities and persists after reload", async ({
+      authenticatedPage,
+    }) => {
+      const { chapter, course, lesson } = await createTestLesson(3);
+
+      await navigateToLessonPage(
+        authenticatedPage,
+        course.slug,
+        chapter.slug,
+        lesson.slug,
+      );
+
+      await expectActivitiesVisible(authenticatedPage, [
+        { position: 1, title: "Activity 1" },
+        { position: 2, title: "Activity 2" },
+        { position: 3, title: "Activity 3" },
+      ]);
+
+      const firstHandle = authenticatedPage
+        .getByRole("button", { exact: true, name: "Drag to reorder" })
+        .first();
+
+      const secondHandle = authenticatedPage
+        .getByRole("button", { exact: true, name: "Drag to reorder" })
+        .nth(1);
+
+      type BoundingBox = Awaited<ReturnType<typeof firstHandle.boundingBox>>;
+      const boxes: { first: BoundingBox; second: BoundingBox } = {
+        first: null,
+        second: null,
+      };
+
+      await expect(async () => {
+        boxes.first = await firstHandle.boundingBox();
+        boxes.second = await secondHandle.boundingBox();
+        expect(boxes.first).toBeTruthy();
+        expect(boxes.second).toBeTruthy();
+      }).toPass({ timeout: 10_000 });
+
+      if (!(boxes.first && boxes.second)) {
+        throw new Error("Drag handle bounding boxes should exist");
+      }
+
+      await firstHandle.hover();
+      await authenticatedPage.mouse.down();
+
+      const targetY = boxes.second.y + boxes.second.height / 2 + 5;
+
+      await authenticatedPage.mouse.move(
+        boxes.first.x + boxes.first.width / 2,
+        boxes.first.y + 20,
+        { steps: 5 },
+      );
+
+      await authenticatedPage.mouse.move(
+        boxes.first.x + boxes.first.width / 2,
+        targetY,
+        { steps: 10 },
+      );
+
+      await authenticatedPage.mouse.up();
+
+      const reorderedActivities = [
+        { position: 1, title: "Activity 2" },
+        { position: 2, title: "Activity 1" },
+        { position: 3, title: "Activity 3" },
+      ];
+
+      await expectActivitiesVisible(authenticatedPage, reorderedActivities);
+
+      await authenticatedPage.reload();
+
+      await expect(
+        authenticatedPage.getByRole("textbox", { name: /edit lesson title/i }),
+      ).toBeVisible();
+
+      await expectActivitiesVisible(authenticatedPage, reorderedActivities);
+    });
+  });
+
+  test.describe("Import/Export", () => {
+    test("exports activities as JSON file", async ({ authenticatedPage }) => {
+      const { activities, chapter, course, lesson } = await createTestLesson(2);
+
+      await navigateToLessonPage(
+        authenticatedPage,
+        course.slug,
+        chapter.slug,
+        lesson.slug,
+      );
+
+      await getMoreOptionsButton(authenticatedPage).click();
+
+      const downloadPromise = authenticatedPage.waitForEvent("download");
+
+      await authenticatedPage
+        .getByRole("menuitem", { name: /export/i })
+        .click();
+
+      const download = await downloadPromise;
+
+      expect(download.suggestedFilename()).toBe("activities.json");
+
+      const downloadPath = await download.path();
+
+      if (!downloadPath) {
+        throw new Error("Download path should exist");
+      }
+
+      const json = JSON.parse(fs.readFileSync(downloadPath, "utf-8"));
+      expect(json.activities).toHaveLength(activities.length);
+
+      const exportedTitles = json.activities.map(
+        (a: { title: string }) => a.title,
+      );
+      expect(exportedTitles).toContain("Activity 1");
+      expect(exportedTitles).toContain("Activity 2");
+    });
+
+    test("imports activities in merge mode", async ({ authenticatedPage }) => {
+      const { activities, chapter, course, lesson } = await createTestLesson(1);
+      const existingTitle = activities[0]?.title ?? "";
+
+      const prefix = randomUUID().slice(0, 8);
+      const importedTitle1 = `Imported ${prefix} 1`;
+      const importedTitle2 = `Imported ${prefix} 2`;
+
+      const importFile = createImportFile([
+        { kind: "background", title: importedTitle1 },
+        { kind: "quiz", title: importedTitle2 },
+      ]);
+
+      try {
+        await navigateToLessonPage(
+          authenticatedPage,
+          course.slug,
+          chapter.slug,
+          lesson.slug,
+        );
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: existingTitle }),
+        ).toBeVisible();
+
+        await importFlow(authenticatedPage, importFile, "merge");
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: existingTitle }),
+        ).toBeVisible();
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: importedTitle1 }),
+        ).toBeVisible();
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: importedTitle2 }),
+        ).toBeVisible();
+
+        await authenticatedPage.reload();
+
+        await expect(
+          authenticatedPage.getByRole("textbox", {
+            name: /edit lesson title/i,
+          }),
+        ).toBeVisible();
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: existingTitle }),
+        ).toBeVisible();
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: importedTitle1 }),
+        ).toBeVisible();
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: importedTitle2 }),
+        ).toBeVisible();
+      } finally {
+        fs.unlinkSync(importFile);
+      }
+    });
+
+    test("imports activities in replace mode", async ({
+      authenticatedPage,
+    }) => {
+      const { activities, chapter, course, lesson } = await createTestLesson(1);
+      const existingTitle = activities[0]?.title ?? "";
+
+      const prefix = randomUUID().slice(0, 8);
+      const importedTitle1 = `Replaced ${prefix} 1`;
+      const importedTitle2 = `Replaced ${prefix} 2`;
+
+      const importFile = createImportFile([
+        { kind: "background", title: importedTitle1 },
+        { kind: "quiz", title: importedTitle2 },
+      ]);
+
+      try {
+        await navigateToLessonPage(
+          authenticatedPage,
+          course.slug,
+          chapter.slug,
+          lesson.slug,
+        );
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: existingTitle }),
+        ).toBeVisible();
+
+        await importFlow(authenticatedPage, importFile, "replace");
+
+        await expectActivityNotVisible(authenticatedPage, existingTitle);
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: importedTitle1 }),
+        ).toBeVisible();
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: importedTitle2 }),
+        ).toBeVisible();
+
+        await authenticatedPage.reload();
+
+        await expect(
+          authenticatedPage.getByRole("textbox", {
+            name: /edit lesson title/i,
+          }),
+        ).toBeVisible();
+
+        await expectActivityNotVisible(authenticatedPage, existingTitle);
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: importedTitle1 }),
+        ).toBeVisible();
+
+        await expect(
+          authenticatedPage.getByRole("link", { name: importedTitle2 }),
+        ).toBeVisible();
+      } finally {
+        fs.unlinkSync(importFile);
+      }
+    });
+  });
+});

--- a/apps/editor/e2e/chapter-publish.test.ts
+++ b/apps/editor/e2e/chapter-publish.test.ts
@@ -44,8 +44,12 @@ test.describe("Chapter Publish Toggle", () => {
     const { course, chapter } = await createTestChapter(false);
     await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
 
-    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
-    await expect(authenticatedPage.getByRole("switch")).not.toBeChecked();
+    const publishToggle = authenticatedPage.getByRole("switch");
+    const publishLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: publishToggle });
+    await expect(publishLabel.getByText(/^draft$/i)).toBeVisible();
+    await expect(publishToggle).not.toBeChecked();
   });
 
   test("displays Published for published chapter", async ({
@@ -54,8 +58,12 @@ test.describe("Chapter Publish Toggle", () => {
     const { course, chapter } = await createTestChapter(true);
     await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
 
-    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
-    await expect(authenticatedPage.getByRole("switch")).toBeChecked();
+    const publishToggle = authenticatedPage.getByRole("switch");
+    const publishLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: publishToggle });
+    await expect(publishLabel.getByText(/^published$/i)).toBeVisible();
+    await expect(publishToggle).toBeChecked();
   });
 
   test("publishes a draft chapter and persists", async ({
@@ -64,15 +72,18 @@ test.describe("Chapter Publish Toggle", () => {
     const { course, chapter } = await createTestChapter(false);
     await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
 
-    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
-
     const toggle = authenticatedPage.getByRole("switch");
+    const publishLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: toggle });
+
+    await expect(publishLabel.getByText(/^draft$/i)).toBeVisible();
     await expect(toggle).toBeEnabled();
     await expect(toggle).not.toBeChecked();
 
     await toggle.click();
 
-    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
+    await expect(publishLabel.getByText(/^published$/i)).toBeVisible();
     await expect(toggle).toBeChecked();
 
     // Wait for the server action to complete (switch re-enables after transition)
@@ -83,8 +94,12 @@ test.describe("Chapter Publish Toggle", () => {
     await expect(
       authenticatedPage.getByRole("textbox", { name: /edit chapter title/i }),
     ).toBeVisible();
-    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
-    await expect(authenticatedPage.getByRole("switch")).toBeChecked();
+    const reloadedToggle = authenticatedPage.getByRole("switch");
+    const reloadedLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: reloadedToggle });
+    await expect(reloadedLabel.getByText(/^published$/i)).toBeVisible();
+    await expect(reloadedToggle).toBeChecked();
   });
 
   test("unpublishes a published chapter and persists", async ({
@@ -93,15 +108,18 @@ test.describe("Chapter Publish Toggle", () => {
     const { course, chapter } = await createTestChapter(true);
     await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
 
-    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
-
     const toggle = authenticatedPage.getByRole("switch");
+    const publishLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: toggle });
+
+    await expect(publishLabel.getByText(/^published$/i)).toBeVisible();
     await expect(toggle).toBeEnabled();
     await expect(toggle).toBeChecked();
 
     await toggle.click();
 
-    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
+    await expect(publishLabel.getByText(/^draft$/i)).toBeVisible();
     await expect(toggle).not.toBeChecked();
 
     // Wait for the server action to complete (switch re-enables after transition)
@@ -112,7 +130,11 @@ test.describe("Chapter Publish Toggle", () => {
     await expect(
       authenticatedPage.getByRole("textbox", { name: /edit chapter title/i }),
     ).toBeVisible();
-    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
-    await expect(authenticatedPage.getByRole("switch")).not.toBeChecked();
+    const reloadedToggle = authenticatedPage.getByRole("switch");
+    const reloadedLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: reloadedToggle });
+    await expect(reloadedLabel.getByText(/^draft$/i)).toBeVisible();
+    await expect(reloadedToggle).not.toBeChecked();
   });
 });

--- a/apps/editor/e2e/course-publish.test.ts
+++ b/apps/editor/e2e/course-publish.test.ts
@@ -30,8 +30,12 @@ test.describe("Course Publish Toggle", () => {
     const course = await createTestCourse(false);
     await navigateToCoursePage(authenticatedPage, course.slug);
 
-    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
-    await expect(authenticatedPage.getByRole("switch")).not.toBeChecked();
+    const publishToggle = authenticatedPage.getByRole("switch");
+    const publishLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: publishToggle });
+    await expect(publishLabel.getByText(/^draft$/i)).toBeVisible();
+    await expect(publishToggle).not.toBeChecked();
   });
 
   test("displays Published for published course", async ({
@@ -40,8 +44,12 @@ test.describe("Course Publish Toggle", () => {
     const course = await createTestCourse(true);
     await navigateToCoursePage(authenticatedPage, course.slug);
 
-    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
-    await expect(authenticatedPage.getByRole("switch")).toBeChecked();
+    const publishToggle = authenticatedPage.getByRole("switch");
+    const publishLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: publishToggle });
+    await expect(publishLabel.getByText(/^published$/i)).toBeVisible();
+    await expect(publishToggle).toBeChecked();
   });
 
   test("publishes a draft course and persists", async ({
@@ -50,15 +58,18 @@ test.describe("Course Publish Toggle", () => {
     const course = await createTestCourse(false);
     await navigateToCoursePage(authenticatedPage, course.slug);
 
-    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
-
     const toggle = authenticatedPage.getByRole("switch");
+    const publishLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: toggle });
+
+    await expect(publishLabel.getByText(/^draft$/i)).toBeVisible();
     await expect(toggle).toBeEnabled();
     await expect(toggle).not.toBeChecked();
 
     await toggle.click();
 
-    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
+    await expect(publishLabel.getByText(/^published$/i)).toBeVisible();
     await expect(toggle).toBeChecked();
 
     // Wait for the server action to complete (switch re-enables after transition)
@@ -69,8 +80,12 @@ test.describe("Course Publish Toggle", () => {
     await expect(
       authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
     ).toBeVisible();
-    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
-    await expect(authenticatedPage.getByRole("switch")).toBeChecked();
+    const reloadedToggle = authenticatedPage.getByRole("switch");
+    const reloadedLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: reloadedToggle });
+    await expect(reloadedLabel.getByText(/^published$/i)).toBeVisible();
+    await expect(reloadedToggle).toBeChecked();
   });
 
   test("unpublishes a published course and persists", async ({
@@ -79,15 +94,18 @@ test.describe("Course Publish Toggle", () => {
     const course = await createTestCourse(true);
     await navigateToCoursePage(authenticatedPage, course.slug);
 
-    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
-
     const toggle = authenticatedPage.getByRole("switch");
+    const publishLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: toggle });
+
+    await expect(publishLabel.getByText(/^published$/i)).toBeVisible();
     await expect(toggle).toBeEnabled();
     await expect(toggle).toBeChecked();
 
     await toggle.click();
 
-    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
+    await expect(publishLabel.getByText(/^draft$/i)).toBeVisible();
     await expect(toggle).not.toBeChecked();
 
     // Wait for the server action to complete (switch re-enables after transition)
@@ -98,7 +116,11 @@ test.describe("Course Publish Toggle", () => {
     await expect(
       authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
     ).toBeVisible();
-    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
-    await expect(authenticatedPage.getByRole("switch")).not.toBeChecked();
+    const reloadedToggle = authenticatedPage.getByRole("switch");
+    const reloadedLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: reloadedToggle });
+    await expect(reloadedLabel.getByText(/^draft$/i)).toBeVisible();
+    await expect(reloadedToggle).not.toBeChecked();
   });
 });

--- a/apps/editor/e2e/lesson-publish.test.ts
+++ b/apps/editor/e2e/lesson-publish.test.ts
@@ -58,8 +58,12 @@ test.describe("Lesson Publish Toggle", () => {
       lesson.slug,
     );
 
-    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
-    await expect(authenticatedPage.getByRole("switch")).not.toBeChecked();
+    const publishToggle = authenticatedPage.getByRole("switch");
+    const publishLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: publishToggle });
+    await expect(publishLabel.getByText(/^draft$/i)).toBeVisible();
+    await expect(publishToggle).not.toBeChecked();
   });
 
   test("displays Published for published lesson", async ({
@@ -73,8 +77,12 @@ test.describe("Lesson Publish Toggle", () => {
       lesson.slug,
     );
 
-    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
-    await expect(authenticatedPage.getByRole("switch")).toBeChecked();
+    const publishToggle = authenticatedPage.getByRole("switch");
+    const publishLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: publishToggle });
+    await expect(publishLabel.getByText(/^published$/i)).toBeVisible();
+    await expect(publishToggle).toBeChecked();
   });
 
   test("publishes a draft lesson and persists", async ({
@@ -88,15 +96,18 @@ test.describe("Lesson Publish Toggle", () => {
       lesson.slug,
     );
 
-    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
-
     const toggle = authenticatedPage.getByRole("switch");
+    const publishLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: toggle });
+
+    await expect(publishLabel.getByText(/^draft$/i)).toBeVisible();
     await expect(toggle).toBeEnabled();
     await expect(toggle).not.toBeChecked();
 
     await toggle.click();
 
-    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
+    await expect(publishLabel.getByText(/^published$/i)).toBeVisible();
     await expect(toggle).toBeChecked();
 
     // Wait for the server action to complete (switch re-enables after transition)
@@ -107,8 +118,12 @@ test.describe("Lesson Publish Toggle", () => {
     await expect(
       authenticatedPage.getByRole("textbox", { name: /edit lesson title/i }),
     ).toBeVisible();
-    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
-    await expect(authenticatedPage.getByRole("switch")).toBeChecked();
+    const reloadedToggle = authenticatedPage.getByRole("switch");
+    const reloadedLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: reloadedToggle });
+    await expect(reloadedLabel.getByText(/^published$/i)).toBeVisible();
+    await expect(reloadedToggle).toBeChecked();
   });
 
   test("unpublishes a published lesson and persists", async ({
@@ -122,15 +137,18 @@ test.describe("Lesson Publish Toggle", () => {
       lesson.slug,
     );
 
-    await expect(authenticatedPage.getByText(/^published$/i)).toBeVisible();
-
     const toggle = authenticatedPage.getByRole("switch");
+    const publishLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: toggle });
+
+    await expect(publishLabel.getByText(/^published$/i)).toBeVisible();
     await expect(toggle).toBeEnabled();
     await expect(toggle).toBeChecked();
 
     await toggle.click();
 
-    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
+    await expect(publishLabel.getByText(/^draft$/i)).toBeVisible();
     await expect(toggle).not.toBeChecked();
 
     // Wait for the server action to complete (switch re-enables after transition)
@@ -141,7 +159,11 @@ test.describe("Lesson Publish Toggle", () => {
     await expect(
       authenticatedPage.getByRole("textbox", { name: /edit lesson title/i }),
     ).toBeVisible();
-    await expect(authenticatedPage.getByText(/^draft$/i)).toBeVisible();
-    await expect(authenticatedPage.getByRole("switch")).not.toBeChecked();
+    const reloadedToggle = authenticatedPage.getByRole("switch");
+    const reloadedLabel = authenticatedPage
+      .locator("label")
+      .filter({ has: reloadedToggle });
+    await expect(reloadedLabel.getByText(/^draft$/i)).toBeVisible();
+    await expect(reloadedToggle).not.toBeChecked();
   });
 });

--- a/apps/editor/messages/en.po
+++ b/apps/editor/messages/en.po
@@ -57,6 +57,7 @@ msgstr "Failed to upload image. Please try again."
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-actions.ts
 msgctxt "lgvvCe"
 msgid "No file provided"
 msgstr "No file provided"
@@ -78,6 +79,7 @@ msgstr "Failed to process image. Please try again."
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-actions.ts
 msgctxt "sGJpuF"
 msgid "Add a description…"
 msgstr "Add a description…"
@@ -107,6 +109,76 @@ msgctxt "yNvug5"
 msgid "Chapter title…"
 msgstr "Chapter title…"
 
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[activityId]/page.tsx
+msgctxt "PJivSX"
+msgid "Lesson"
+msgstr "Lesson"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[activityId]/page.tsx
+msgctxt "Y7nk1I"
+msgid "Activity editor coming soon"
+msgstr "Activity editor coming soon"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-actions.ts
+msgctxt "BhBMMj"
+msgid "Untitled activity"
+msgstr "Untitled activity"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+msgctxt "30g9Ie"
+msgid "We couldn't load the activities. Please try again."
+msgstr "We couldn't load the activities. Please try again."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "5CI3KH"
+msgid "Contact support"
+msgstr "Contact support"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+msgctxt "9IwZ+U"
+msgid "Add activity"
+msgstr "Add activity"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "aJ/bsX"
+msgid "Drag to reorder"
+msgstr "Drag to reorder"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "FazwRl"
+msgid "Try again"
+msgstr "Try again"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "geXvrp"
+msgid "Insert below"
+msgstr "Insert below"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+msgctxt "ivVUmr"
+msgid "Failed to load activities"
+msgstr "Failed to load activities"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+msgctxt "Lhaog4"
+msgid "Activity actions"
+msgstr "Activity actions"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "vTz4RU"
+msgid "Insert above"
+msgstr "Insert above"
+
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-content.tsx
 msgctxt "AHvdBa"
 msgid "Edit lesson description"
@@ -133,21 +205,9 @@ msgid "We couldn't load the lessons. Please try again."
 msgstr "We couldn't load the lessons. Please try again."
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "5CI3KH"
-msgid "Contact support"
-msgstr "Contact support"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgctxt "6ssHZM"
 msgid "Failed to load lessons"
 msgstr "Failed to load lessons"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "aJ/bsX"
-msgid "Drag to reorder"
-msgstr "Drag to reorder"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgctxt "drUbPJ"
@@ -155,27 +215,9 @@ msgid "Lesson actions"
 msgstr "Lesson actions"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "FazwRl"
-msgid "Try again"
-msgstr "Try again"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "geXvrp"
-msgid "Insert below"
-msgstr "Insert below"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgctxt "RWzfUY"
 msgid "Add lesson"
 msgstr "Add lesson"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "vTz4RU"
-msgid "Insert above"
-msgstr "Insert above"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "BxygZD"
@@ -570,6 +612,11 @@ msgid "Saving…"
 msgstr "Saving…"
 
 #: src/components/entity-list-actions.tsx
+msgctxt "6P4woA"
+msgid "Upload a JSON file containing activities to import."
+msgstr "Upload a JSON file containing activities to import."
+
+#: src/components/entity-list-actions.tsx
 msgctxt "8n7YmS"
 msgid "Lessons imported successfully"
 msgstr "Lessons imported successfully"
@@ -585,9 +632,24 @@ msgid "Lessons exported successfully"
 msgstr "Lessons exported successfully"
 
 #: src/components/entity-list-actions.tsx
+msgctxt "JneX6x"
+msgid "Activities imported successfully"
+msgstr "Activities imported successfully"
+
+#: src/components/entity-list-actions.tsx
+msgctxt "Jva2tZ"
+msgid "Activities exported successfully"
+msgstr "Activities exported successfully"
+
+#: src/components/entity-list-actions.tsx
 msgctxt "lwIuOL"
 msgid "Upload a JSON file containing chapters to import."
 msgstr "Upload a JSON file containing chapters to import."
+
+#: src/components/entity-list-actions.tsx
+msgctxt "m6heoi"
+msgid "Import activities"
+msgstr "Import activities"
 
 #: src/components/entity-list-actions.tsx
 msgctxt "TQmijK"
@@ -811,6 +873,11 @@ msgid "This category has already been added to the course"
 msgstr "This category has already been added to the course"
 
 #: src/lib/error-messages.ts
+msgctxt "eyPdgP"
+msgid "Invalid activity format. Each activity must have a kind and position"
+msgstr "Invalid activity format. Each activity must have a kind and position"
+
+#: src/lib/error-messages.ts
 msgctxt "g5WLcA"
 msgid "Please sign in to continue"
 msgstr "Please sign in to continue"
@@ -819,6 +886,11 @@ msgstr "Please sign in to continue"
 msgctxt "gYaLKN"
 msgid "Chapter and course must belong to the same organization"
 msgstr "Chapter and course must belong to the same organization"
+
+#: src/lib/error-messages.ts
+msgctxt "lnW7BB"
+msgid "Activity not found"
+msgstr "Activity not found"
 
 #: src/lib/error-messages.ts
 msgctxt "MqOLCG"

--- a/apps/editor/messages/es.po
+++ b/apps/editor/messages/es.po
@@ -57,6 +57,7 @@ msgstr "Error al subir la imagen. Por favor intenta de nuevo."
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-actions.ts
 msgctxt "lgvvCe"
 msgid "No file provided"
 msgstr "No se proporcionó ningún archivo"
@@ -78,6 +79,7 @@ msgstr "Error al procesar la imagen. Por favor intenta de nuevo."
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-actions.ts
 msgctxt "sGJpuF"
 msgid "Add a description…"
 msgstr "Agrega una descripción…"
@@ -107,6 +109,76 @@ msgctxt "yNvug5"
 msgid "Chapter title…"
 msgstr "Título del capítulo…"
 
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[activityId]/page.tsx
+msgctxt "PJivSX"
+msgid "Lesson"
+msgstr "Lección"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[activityId]/page.tsx
+msgctxt "Y7nk1I"
+msgid "Activity editor coming soon"
+msgstr "Editor de actividades próximamente"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-actions.ts
+msgctxt "BhBMMj"
+msgid "Untitled activity"
+msgstr "Actividad sin título"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+msgctxt "30g9Ie"
+msgid "We couldn't load the activities. Please try again."
+msgstr "No pudimos cargar las actividades. Por favor, intenta de nuevo."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "5CI3KH"
+msgid "Contact support"
+msgstr "Contactar soporte"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+msgctxt "9IwZ+U"
+msgid "Add activity"
+msgstr "Agregar actividad"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "aJ/bsX"
+msgid "Drag to reorder"
+msgstr "Arrastra para reordenar"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "FazwRl"
+msgid "Try again"
+msgstr "Intentar de nuevo"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "geXvrp"
+msgid "Insert below"
+msgstr "Insertar debajo"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+msgctxt "ivVUmr"
+msgid "Failed to load activities"
+msgstr "Error al cargar actividades"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+msgctxt "Lhaog4"
+msgid "Activity actions"
+msgstr "Acciones de actividad"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "vTz4RU"
+msgid "Insert above"
+msgstr "Insertar arriba"
+
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-content.tsx
 msgctxt "AHvdBa"
 msgid "Edit lesson description"
@@ -133,21 +205,9 @@ msgid "We couldn't load the lessons. Please try again."
 msgstr "No pudimos cargar las lecciones. Por favor, intenta de nuevo."
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "5CI3KH"
-msgid "Contact support"
-msgstr "Contactar soporte"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgctxt "6ssHZM"
 msgid "Failed to load lessons"
 msgstr "Error al cargar lecciones"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "aJ/bsX"
-msgid "Drag to reorder"
-msgstr "Arrastra para reordenar"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgctxt "drUbPJ"
@@ -155,27 +215,9 @@ msgid "Lesson actions"
 msgstr "Acciones de la lección"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "FazwRl"
-msgid "Try again"
-msgstr "Intentar de nuevo"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "geXvrp"
-msgid "Insert below"
-msgstr "Insertar debajo"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgctxt "RWzfUY"
 msgid "Add lesson"
 msgstr "Agregar lección"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "vTz4RU"
-msgid "Insert above"
-msgstr "Insertar arriba"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "BxygZD"
@@ -570,6 +612,11 @@ msgid "Saving…"
 msgstr "Guardando…"
 
 #: src/components/entity-list-actions.tsx
+msgctxt "6P4woA"
+msgid "Upload a JSON file containing activities to import."
+msgstr "Sube un archivo JSON que contenga las actividades a importar."
+
+#: src/components/entity-list-actions.tsx
 msgctxt "8n7YmS"
 msgid "Lessons imported successfully"
 msgstr "Lecciones importadas exitosamente"
@@ -585,9 +632,24 @@ msgid "Lessons exported successfully"
 msgstr "Lecciones exportadas exitosamente"
 
 #: src/components/entity-list-actions.tsx
+msgctxt "JneX6x"
+msgid "Activities imported successfully"
+msgstr "Actividades importadas exitosamente"
+
+#: src/components/entity-list-actions.tsx
+msgctxt "Jva2tZ"
+msgid "Activities exported successfully"
+msgstr "Actividades exportadas exitosamente"
+
+#: src/components/entity-list-actions.tsx
 msgctxt "lwIuOL"
 msgid "Upload a JSON file containing chapters to import."
 msgstr "Sube un archivo JSON que contenga los capítulos a importar."
+
+#: src/components/entity-list-actions.tsx
+msgctxt "m6heoi"
+msgid "Import activities"
+msgstr "Importar actividades"
 
 #: src/components/entity-list-actions.tsx
 msgctxt "TQmijK"
@@ -811,6 +873,11 @@ msgid "This category has already been added to the course"
 msgstr "Esta categoría ya ha sido agregada al curso"
 
 #: src/lib/error-messages.ts
+msgctxt "eyPdgP"
+msgid "Invalid activity format. Each activity must have a kind and position"
+msgstr "Formato de actividad inválido. Cada actividad debe tener un tipo y posición"
+
+#: src/lib/error-messages.ts
 msgctxt "g5WLcA"
 msgid "Please sign in to continue"
 msgstr "Por favor inicia sesión para continuar"
@@ -819,6 +886,11 @@ msgstr "Por favor inicia sesión para continuar"
 msgctxt "gYaLKN"
 msgid "Chapter and course must belong to the same organization"
 msgstr "El capítulo y el curso deben pertenecer a la misma organización"
+
+#: src/lib/error-messages.ts
+msgctxt "lnW7BB"
+msgid "Activity not found"
+msgstr "Actividad no encontrada"
 
 #: src/lib/error-messages.ts
 msgctxt "MqOLCG"

--- a/apps/editor/messages/pt.po
+++ b/apps/editor/messages/pt.po
@@ -57,6 +57,7 @@ msgstr "Falha ao enviar a imagem. Por favor, tente novamente."
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-actions.ts
 msgctxt "lgvvCe"
 msgid "No file provided"
 msgstr "Nenhum arquivo fornecido"
@@ -78,6 +79,7 @@ msgstr "Falha ao processar a imagem. Por favor, tente novamente."
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/actions.ts
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/actions.ts
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-actions.ts
 msgctxt "sGJpuF"
 msgid "Add a description…"
 msgstr "Adicione uma descrição…"
@@ -107,6 +109,76 @@ msgctxt "yNvug5"
 msgid "Chapter title…"
 msgstr "Título do capítulo…"
 
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[activityId]/page.tsx
+msgctxt "PJivSX"
+msgid "Lesson"
+msgstr "Aula"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[activityId]/page.tsx
+msgctxt "Y7nk1I"
+msgid "Activity editor coming soon"
+msgstr "Editor de atividades em breve"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-actions.ts
+msgctxt "BhBMMj"
+msgid "Untitled activity"
+msgstr "Atividade sem título"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+msgctxt "30g9Ie"
+msgid "We couldn't load the activities. Please try again."
+msgstr "Não conseguimos carregar as atividades. Tente novamente."
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "5CI3KH"
+msgid "Contact support"
+msgstr "Falar com o suporte"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+msgctxt "9IwZ+U"
+msgid "Add activity"
+msgstr "Adicionar atividade"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "aJ/bsX"
+msgid "Drag to reorder"
+msgstr "Arraste para reordenar"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "FazwRl"
+msgid "Try again"
+msgstr "Tentar novamente"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "geXvrp"
+msgid "Insert below"
+msgstr "Inserir abaixo"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+msgctxt "ivVUmr"
+msgid "Failed to load activities"
+msgstr "Falha ao carregar atividades"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+msgctxt "Lhaog4"
+msgid "Activity actions"
+msgstr "Ações da atividade"
+
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
+msgctxt "vTz4RU"
+msgid "Insert above"
+msgstr "Inserir acima"
+
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-content.tsx
 msgctxt "AHvdBa"
 msgid "Edit lesson description"
@@ -133,21 +205,9 @@ msgid "We couldn't load the lessons. Please try again."
 msgstr "Não conseguimos carregar as aulas. Por favor, tente novamente."
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "5CI3KH"
-msgid "Contact support"
-msgstr "Falar com o suporte"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgctxt "6ssHZM"
 msgid "Failed to load lessons"
 msgstr "Falha ao carregar aulas"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "aJ/bsX"
-msgid "Drag to reorder"
-msgstr "Arraste para reordenar"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgctxt "drUbPJ"
@@ -155,27 +215,9 @@ msgid "Lesson actions"
 msgstr "Ações da aula"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "FazwRl"
-msgid "Try again"
-msgstr "Tentar novamente"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "geXvrp"
-msgid "Insert below"
-msgstr "Inserir abaixo"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgctxt "RWzfUY"
 msgid "Add lesson"
 msgstr "Adicionar aula"
-
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-#: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
-msgctxt "vTz4RU"
-msgid "Insert above"
-msgstr "Inserir acima"
 
 #: src/app/[orgSlug]/c/[lang]/[courseSlug]/chapter-list.tsx
 msgctxt "BxygZD"
@@ -570,6 +612,11 @@ msgid "Saving…"
 msgstr "Salvando…"
 
 #: src/components/entity-list-actions.tsx
+msgctxt "6P4woA"
+msgid "Upload a JSON file containing activities to import."
+msgstr "Envie um arquivo JSON contendo as atividades para importar."
+
+#: src/components/entity-list-actions.tsx
 msgctxt "8n7YmS"
 msgid "Lessons imported successfully"
 msgstr "Aulas importadas com sucesso"
@@ -585,9 +632,24 @@ msgid "Lessons exported successfully"
 msgstr "Aulas exportadas com sucesso"
 
 #: src/components/entity-list-actions.tsx
+msgctxt "JneX6x"
+msgid "Activities imported successfully"
+msgstr "Atividades importadas com sucesso"
+
+#: src/components/entity-list-actions.tsx
+msgctxt "Jva2tZ"
+msgid "Activities exported successfully"
+msgstr "Atividades exportadas com sucesso"
+
+#: src/components/entity-list-actions.tsx
 msgctxt "lwIuOL"
 msgid "Upload a JSON file containing chapters to import."
 msgstr "Envie um arquivo JSON contendo os capítulos para importar."
+
+#: src/components/entity-list-actions.tsx
+msgctxt "m6heoi"
+msgid "Import activities"
+msgstr "Importar atividades"
 
 #: src/components/entity-list-actions.tsx
 msgctxt "TQmijK"
@@ -811,6 +873,11 @@ msgid "This category has already been added to the course"
 msgstr "Esta categoria já foi adicionada ao curso"
 
 #: src/lib/error-messages.ts
+msgctxt "eyPdgP"
+msgid "Invalid activity format. Each activity must have a kind and position"
+msgstr "Formato de atividade inválido. Cada atividade deve ter um tipo e uma posição"
+
+#: src/lib/error-messages.ts
 msgctxt "g5WLcA"
 msgid "Please sign in to continue"
 msgstr "Faça login para continuar"
@@ -819,6 +886,11 @@ msgstr "Faça login para continuar"
 msgctxt "gYaLKN"
 msgid "Chapter and course must belong to the same organization"
 msgstr "Capítulo e curso devem pertencer à mesma organização"
+
+#: src/lib/error-messages.ts
+msgctxt "lnW7BB"
+msgid "Activity not found"
+msgstr "Atividade não encontrada"
 
 #: src/lib/error-messages.ts
 msgctxt "MqOLCG"

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[activityId]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[activityId]/page.tsx
@@ -1,0 +1,69 @@
+import { Container, ContainerBody } from "@zoonk/ui/components/container";
+import { getExtracted } from "next-intl/server";
+import { Suspense } from "react";
+import { BackLink, BackLinkSkeleton } from "@/components/back-link";
+import { getLesson } from "@/data/lessons/get-lesson";
+
+type ActivityPageProps =
+  PageProps<"/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[activityId]">;
+
+async function ActivityBackLink({
+  params,
+}: {
+  params: ActivityPageProps["params"];
+}) {
+  const { chapterSlug, courseSlug, lang, lessonSlug, orgSlug } = await params;
+  const t = await getExtracted();
+  const { data: lesson } = await getLesson({
+    chapterSlug,
+    courseSlug,
+    language: lang,
+    lessonSlug,
+    orgSlug,
+  });
+
+  const lessonTitle = lesson?.title ?? t("Lesson");
+
+  return (
+    <BackLink
+      href={`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`}
+    >
+      {lessonTitle}
+    </BackLink>
+  );
+}
+
+async function ActivityPlaceholder() {
+  const t = await getExtracted();
+
+  return (
+    <div className="py-12 text-center text-muted-foreground">
+      {t("Activity editor coming soon")}
+    </div>
+  );
+}
+
+export default async function ActivityPage(props: ActivityPageProps) {
+  const { chapterSlug, courseSlug, lang, lessonSlug, orgSlug } =
+    await props.params;
+
+  void getLesson({
+    chapterSlug,
+    courseSlug,
+    language: lang,
+    lessonSlug,
+    orgSlug,
+  });
+
+  return (
+    <Container variant="narrow">
+      <Suspense fallback={<BackLinkSkeleton />}>
+        <ActivityBackLink params={props.params} />
+      </Suspense>
+
+      <ContainerBody>
+        <ActivityPlaceholder />
+      </ContainerBody>
+    </Container>
+  );
+}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-actions.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-actions.ts
@@ -1,0 +1,170 @@
+"use server";
+
+import { revalidateMainApp } from "@zoonk/core/cache/revalidate";
+import { cacheTagLesson } from "@zoonk/utils/cache";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { after } from "next/server";
+import { getExtracted } from "next-intl/server";
+import { createActivity } from "@/data/activities/create-activity";
+import { exportActivities } from "@/data/activities/export-activities";
+import { importActivities } from "@/data/activities/import-activities";
+import { reorderActivities } from "@/data/activities/reorder-activities";
+import { getErrorMessage } from "@/lib/error-messages";
+
+async function createActivityAction(
+  lessonSlug: string,
+  lessonId: number,
+  position: number,
+): Promise<{ activityId: bigint | null; error: string | null }> {
+  const t = await getExtracted();
+  const title = t("Untitled activity");
+  const description = t("Add a description…");
+
+  const { data, error } = await createActivity({
+    description,
+    kind: "custom",
+    lessonId,
+    position,
+    title,
+  });
+
+  if (error) {
+    return { activityId: null, error: await getErrorMessage(error) };
+  }
+
+  after(async () => {
+    await revalidateMainApp([cacheTagLesson({ lessonSlug })]);
+  });
+
+  return { activityId: data.id, error: null };
+}
+
+async function importActivitiesAction(
+  lessonSlug: string,
+  lessonId: number,
+  formData: FormData,
+): Promise<{ error: string | null }> {
+  const file = formData.get("file");
+  const mode = formData.get("mode") as "merge" | "replace";
+
+  if (!(file && file instanceof File)) {
+    const t = await getExtracted();
+    return { error: t("No file provided") };
+  }
+
+  const { error } = await importActivities({
+    file,
+    lessonId,
+    mode,
+  });
+
+  if (error) {
+    return { error: await getErrorMessage(error) };
+  }
+
+  after(async () => {
+    await revalidateMainApp([cacheTagLesson({ lessonSlug })]);
+  });
+
+  return { error: null };
+}
+
+export async function exportActivitiesAction(lessonId: number): Promise<{
+  data: object | null;
+  error: Error | null;
+}> {
+  const { data, error } = await exportActivities({ lessonId });
+
+  if (error) {
+    return { data: null, error };
+  }
+
+  return { data, error: null };
+}
+
+type ActivityRouteParams = {
+  chapterSlug: string;
+  courseSlug: string;
+  lang: string;
+  lessonId: number;
+  lessonSlug: string;
+  orgSlug: string;
+};
+
+export async function insertActivityAction(
+  params: ActivityRouteParams,
+  position: number,
+): Promise<void> {
+  const { chapterSlug, courseSlug, lang, lessonId, lessonSlug, orgSlug } =
+    params;
+  const { activityId, error } = await createActivityAction(
+    lessonSlug,
+    lessonId,
+    position,
+  );
+
+  if (error) {
+    throw new Error(error);
+  }
+
+  if (activityId) {
+    revalidatePath(
+      `/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`,
+    );
+    redirect(
+      `/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}/a/${activityId}`,
+    );
+  }
+}
+
+export async function handleImportActivitiesAction(
+  params: ActivityRouteParams,
+  formData: FormData,
+): Promise<{ error: string | null }> {
+  const { chapterSlug, courseSlug, lang, lessonId, lessonSlug, orgSlug } =
+    params;
+  const { error } = await importActivitiesAction(
+    lessonSlug,
+    lessonId,
+    formData,
+  );
+
+  if (error) {
+    return { error };
+  }
+
+  revalidatePath(
+    `/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`,
+  );
+  return { error: null };
+}
+
+export async function reorderActivitiesAction(
+  params: ActivityRouteParams,
+  activities: { id: number; position: number }[],
+): Promise<{ error: string | null }> {
+  const { chapterSlug, courseSlug, lang, lessonId, lessonSlug, orgSlug } =
+    params;
+
+  const { error } = await reorderActivities({
+    activities: activities.map((a) => ({
+      activityId: BigInt(a.id),
+      position: a.position,
+    })),
+    lessonId,
+  });
+
+  if (error) {
+    return { error: await getErrorMessage(error) };
+  }
+
+  after(async () => {
+    await revalidateMainApp([cacheTagLesson({ lessonSlug })]);
+  });
+
+  revalidatePath(
+    `/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`,
+  );
+  return { error: null };
+}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list-item-link.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list-item-link.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import Link from "next/link";
+import {
+  EditorListItemContent,
+  EditorListItemDescription,
+  EditorListItemLink,
+  EditorListItemTitle,
+} from "@/components/editor-list";
+
+export function ActivityListItemLink({
+  activityId,
+  chapterSlug,
+  courseSlug,
+  description,
+  kind,
+  lang,
+  lessonSlug,
+  orgSlug,
+  title,
+}: {
+  activityId: bigint;
+  chapterSlug: string;
+  courseSlug: string;
+  description: string | null;
+  kind: string;
+  lang: string;
+  lessonSlug: string;
+  orgSlug: string;
+  title: string | null;
+}) {
+  const displayTitle = title ?? kind;
+
+  return (
+    <EditorListItemLink
+      render={
+        <Link
+          href={`/${orgSlug}/c/${lang}/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}/a/${activityId}`}
+        />
+      }
+    >
+      <EditorListItemContent>
+        <EditorListItemTitle>{displayTitle}</EditorListItemTitle>
+
+        {description && (
+          <EditorListItemDescription>{description}</EditorListItemDescription>
+        )}
+      </EditorListItemContent>
+    </EditorListItemLink>
+  );
+}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
@@ -1,0 +1,130 @@
+import { ErrorView } from "@zoonk/ui/patterns/error";
+import { SUPPORT_URL } from "@zoonk/utils/constants";
+import { getExtracted } from "next-intl/server";
+import {
+  EditorDragHandle,
+  EditorListAddButton,
+  EditorListContent,
+  EditorListHeader,
+  EditorListItem,
+  EditorListItemActions,
+  EditorListProvider,
+  EditorListSpinner,
+  EditorSortableItem,
+  EditorSortableItemRow,
+  EditorSortableList,
+} from "@/components/editor-list";
+import { EntityListActions } from "@/components/entity-list-actions";
+import { listLessonActivities } from "@/data/activities/list-lesson-activities";
+import { getLesson } from "@/data/lessons/get-lesson";
+import {
+  exportActivitiesAction,
+  handleImportActivitiesAction,
+  insertActivityAction,
+  reorderActivitiesAction,
+} from "./activity-actions";
+import { ActivityListItemLink } from "./activity-list-item-link";
+
+type LessonPageProps =
+  PageProps<"/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]">;
+
+export async function ActivityList({
+  params,
+}: {
+  params: LessonPageProps["params"];
+}) {
+  const { chapterSlug, courseSlug, lang, lessonSlug, orgSlug } = await params;
+  const t = await getExtracted();
+
+  const [{ data: activities, error }, { data: lesson }] = await Promise.all([
+    listLessonActivities({ lessonSlug, orgSlug }),
+    getLesson({ chapterSlug, courseSlug, language: lang, lessonSlug, orgSlug }),
+  ]);
+
+  if (error || !lesson) {
+    return (
+      <ErrorView
+        description={t("We couldn't load the activities. Please try again.")}
+        retryLabel={t("Try again")}
+        supportHref={SUPPORT_URL}
+        supportLabel={t("Contact support")}
+        title={t("Failed to load activities")}
+      />
+    );
+  }
+
+  const lessonId = lesson.id;
+
+  const routeParams = {
+    chapterSlug,
+    courseSlug,
+    lang,
+    lessonId,
+    lessonSlug,
+    orgSlug,
+  };
+
+  const lastActivity = activities.at(-1);
+  const endPosition = lastActivity ? lastActivity.position + 1 : 0;
+
+  return (
+    <EditorListProvider onInsert={insertActivityAction.bind(null, routeParams)}>
+      <EditorListSpinner />
+
+      <EditorListHeader>
+        <EditorListAddButton position={endPosition}>
+          {t("Add activity")}
+        </EditorListAddButton>
+
+        <EntityListActions
+          entityType="activities"
+          onExport={exportActivitiesAction.bind(null, lessonId)}
+          onImport={handleImportActivitiesAction.bind(null, routeParams)}
+        />
+      </EditorListHeader>
+
+      {activities.length > 0 && (
+        <EditorSortableList
+          items={activities.map((a) => ({ ...a, id: Number(a.id) }))}
+          onReorder={reorderActivitiesAction.bind(null, routeParams)}
+        >
+          <EditorListContent>
+            {activities.map((activity, index) => (
+              <EditorSortableItem
+                id={Number(activity.id)}
+                key={String(activity.id)}
+              >
+                <EditorListItem>
+                  <EditorSortableItemRow>
+                    <EditorDragHandle aria-label={t("Drag to reorder")}>
+                      {index + 1}
+                    </EditorDragHandle>
+
+                    <ActivityListItemLink
+                      activityId={activity.id}
+                      chapterSlug={chapterSlug}
+                      courseSlug={courseSlug}
+                      description={activity.description}
+                      kind={activity.kind}
+                      lang={lang}
+                      lessonSlug={lessonSlug}
+                      orgSlug={orgSlug}
+                      title={activity.title}
+                    />
+
+                    <EditorListItemActions
+                      aria-label={t("Activity actions")}
+                      insertAboveLabel={t("Insert above")}
+                      insertBelowLabel={t("Insert below")}
+                      position={index}
+                    />
+                  </EditorSortableItemRow>
+                </EditorListItem>
+              </EditorSortableItem>
+            ))}
+          </EditorListContent>
+        </EditorSortableList>
+      )}
+    </EditorListProvider>
+  );
+}

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
@@ -36,12 +36,15 @@ export async function ActivityList({
   const { chapterSlug, courseSlug, lang, lessonSlug, orgSlug } = await params;
   const t = await getExtracted();
 
-  const [{ data: activities, error }, { data: lesson }] = await Promise.all([
-    listLessonActivities({ lessonSlug, orgSlug }),
-    getLesson({ chapterSlug, courseSlug, language: lang, lessonSlug, orgSlug }),
-  ]);
+  const { data: lesson } = await getLesson({
+    chapterSlug,
+    courseSlug,
+    language: lang,
+    lessonSlug,
+    orgSlug,
+  });
 
-  if (error || !lesson) {
+  if (!lesson) {
     return (
       <ErrorView
         description={t("We couldn't load the activities. Please try again.")}
@@ -54,6 +57,23 @@ export async function ActivityList({
   }
 
   const lessonId = lesson.id;
+
+  const { data: activities, error } = await listLessonActivities({
+    lessonId,
+    orgId: lesson.organizationId,
+  });
+
+  if (error) {
+    return (
+      <ErrorView
+        description={t("We couldn't load the activities. Please try again.")}
+        retryLabel={t("Try again")}
+        supportHref={SUPPORT_URL}
+        supportLabel={t("Contact support")}
+        title={t("Failed to load activities")}
+      />
+    );
+  }
 
   const routeParams = {
     chapterSlug,

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -4,7 +4,6 @@ import { BackLinkSkeleton } from "@/components/back-link";
 import { ContentEditorSkeleton } from "@/components/content-editor";
 import { EditorListSkeleton } from "@/components/editor-list";
 import { SlugEditorSkeleton } from "@/components/slug-editor";
-import { listLessonActivities } from "@/data/activities/list-lesson-activities";
 import { getChapter } from "@/data/chapters/get-chapter";
 import { getLesson } from "@/data/lessons/get-lesson";
 import { ActivityList } from "./activity-list";
@@ -29,7 +28,6 @@ export default async function LessonPage(props: LessonPageProps) {
       lessonSlug,
       orgSlug,
     }),
-    listLessonActivities({ lessonSlug, orgSlug }),
   ]);
 
   return (

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -2,9 +2,12 @@ import { Container, ContainerBody } from "@zoonk/ui/components/container";
 import { Suspense } from "react";
 import { BackLinkSkeleton } from "@/components/back-link";
 import { ContentEditorSkeleton } from "@/components/content-editor";
+import { EditorListSkeleton } from "@/components/editor-list";
 import { SlugEditorSkeleton } from "@/components/slug-editor";
+import { listLessonActivities } from "@/data/activities/list-lesson-activities";
 import { getChapter } from "@/data/chapters/get-chapter";
 import { getLesson } from "@/data/lessons/get-lesson";
+import { ActivityList } from "./activity-list";
 import { LessonBackLink } from "./lesson-back-link";
 import { LessonContent } from "./lesson-content";
 import { LessonSlug } from "./lesson-slug";
@@ -26,6 +29,7 @@ export default async function LessonPage(props: LessonPageProps) {
       lessonSlug,
       orgSlug,
     }),
+    listLessonActivities({ lessonSlug, orgSlug }),
   ]);
 
   return (
@@ -43,6 +47,10 @@ export default async function LessonPage(props: LessonPageProps) {
           <LessonSlug params={props.params} />
         </Suspense>
       </ContainerBody>
+
+      <Suspense fallback={<EditorListSkeleton />}>
+        <ActivityList params={props.params} />
+      </Suspense>
     </Container>
   );
 }

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -36,12 +36,14 @@ export async function LessonList({
   const { chapterSlug, courseSlug, lang, orgSlug } = await params;
   const t = await getExtracted();
 
-  const [{ data: lessons, error }, { data: chapter }] = await Promise.all([
-    listChapterLessons({ chapterSlug, orgSlug }),
-    getChapter({ chapterSlug, courseSlug, language: lang, orgSlug }),
-  ]);
+  const { data: chapter } = await getChapter({
+    chapterSlug,
+    courseSlug,
+    language: lang,
+    orgSlug,
+  });
 
-  if (error || !chapter) {
+  if (!chapter) {
     return (
       <ErrorView
         description={t("We couldn't load the lessons. Please try again.")}
@@ -54,6 +56,23 @@ export async function LessonList({
   }
 
   const chapterId = chapter.id;
+
+  const { data: lessons, error } = await listChapterLessons({
+    chapterId,
+    orgId: chapter.organizationId,
+  });
+
+  if (error) {
+    return (
+      <ErrorView
+        description={t("We couldn't load the lessons. Please try again.")}
+        retryLabel={t("Try again")}
+        supportHref={SUPPORT_URL}
+        supportLabel={t("Contact support")}
+        title={t("Failed to load lessons")}
+      />
+    );
+  }
 
   const routeParams = { chapterId, chapterSlug, courseSlug, lang, orgSlug };
 

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -6,7 +6,6 @@ import { EditorListSkeleton } from "@/components/editor-list";
 import { SlugEditorSkeleton } from "@/components/slug-editor";
 import { getChapter } from "@/data/chapters/get-chapter";
 import { getCourse } from "@/data/courses/get-course";
-import { listChapterLessons } from "@/data/lessons/list-chapter-lessons";
 import { ChapterBackLink } from "./chapter-back-link";
 import { ChapterContent } from "./chapter-content";
 import { ChapterSlug } from "./chapter-slug";
@@ -22,7 +21,6 @@ export default async function ChapterPage(props: ChapterPageProps) {
   void Promise.all([
     getCourse({ courseSlug, language: lang, orgSlug }),
     getChapter({ chapterSlug, courseSlug, language: lang, orgSlug }),
-    listChapterLessons({ chapterSlug, orgSlug }),
   ]);
 
   return (

--- a/apps/editor/src/components/entity-list-actions.tsx
+++ b/apps/editor/src/components/entity-list-actions.tsx
@@ -29,9 +29,18 @@ import {
   ImportSubmit,
 } from "./import";
 
-type EntityType = "chapters" | "lessons";
+type EntityType = "activities" | "chapters" | "lessons";
 
 const FORMATS: Record<EntityType, object> = {
+  activities: {
+    activities: [
+      {
+        description: "Activity description",
+        kind: "background",
+        title: "Activity title",
+      },
+    ],
+  },
   chapters: {
     chapters: [
       {
@@ -66,6 +75,14 @@ export function EntityListActions({
   const [pending, startTransition] = useTransition();
 
   const labels = {
+    activities: {
+      exportSuccess: t("Activities exported successfully"),
+      importDescription: t(
+        "Upload a JSON file containing activities to import.",
+      ),
+      importSuccess: t("Activities imported successfully"),
+      importTitle: t("Import activities"),
+    },
     chapters: {
       exportSuccess: t("Chapters exported successfully"),
       importDescription: t("Upload a JSON file containing chapters to import."),

--- a/apps/editor/src/data/activities/create-activity.test.ts
+++ b/apps/editor/src/data/activities/create-activity.test.ts
@@ -1,0 +1,449 @@
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import {
+  memberFixture,
+  organizationFixture,
+} from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, describe, expect, test } from "vitest";
+import { ErrorCode } from "@/lib/app-error";
+import { createActivity } from "./create-activity";
+
+describe("unauthenticated users", () => {
+  test("returns Forbidden", async () => {
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const result = await createActivity({
+      headers: new Headers(),
+      kind: "custom",
+      lessonId: lesson.id,
+      position: 0,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("members", () => {
+  test("returns Forbidden", async () => {
+    const { organization, user } = await memberFixture({ role: "member" });
+
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const [headers, lesson] = await Promise.all([
+      signInAs(user.email, user.password),
+      lessonFixture({
+        chapterId: chapter.id,
+        language: course.language,
+        organizationId: organization.id,
+      }),
+    ]);
+
+    const result = await createActivity({
+      headers,
+      kind: "custom",
+      lessonId: lesson.id,
+      position: 0,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("admins", () => {
+  let organization: Awaited<ReturnType<typeof memberFixture>>["organization"];
+  let headers: Headers;
+  let lesson: Awaited<ReturnType<typeof lessonFixture>>;
+
+  beforeAll(async () => {
+    const fixture = await memberFixture({ role: "admin" });
+    organization = fixture.organization;
+
+    const course = await courseFixture({
+      organizationId: fixture.organization.id,
+    });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: fixture.organization.id,
+    });
+    [headers, lesson] = await Promise.all([
+      signInAs(fixture.user.email, fixture.user.password),
+      lessonFixture({
+        chapterId: chapter.id,
+        language: course.language,
+        organizationId: fixture.organization.id,
+      }),
+    ]);
+  });
+
+  test("creates activity successfully", async () => {
+    const result = await createActivity({
+      description: "Test description",
+      headers,
+      kind: "background",
+      lessonId: lesson.id,
+      position: 0,
+      title: "Test Activity",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toBeDefined();
+    expect(result.data?.title).toBe("Test Activity");
+    expect(result.data?.description).toBe("Test description");
+    expect(result.data?.organizationId).toBe(organization.id);
+    expect(result.data?.lessonId).toBe(lesson.id);
+    expect(result.data?.language).toBe(lesson.language);
+    expect(result.data?.kind).toBe("background");
+  });
+
+  test("creates activity with custom kind", async () => {
+    const result = await createActivity({
+      headers,
+      kind: "custom",
+      lessonId: lesson.id,
+      position: 0,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.kind).toBe("custom");
+  });
+
+  test("returns Lesson not found", async () => {
+    const result = await createActivity({
+      headers,
+      kind: "custom",
+      lessonId: 999_999,
+      position: 0,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.lessonNotFound);
+    expect(result.data).toBeNull();
+  });
+
+  test("don't allow to create activity for a different organization", async () => {
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+    const otherChapter = await chapterFixture({
+      courseId: otherCourse.id,
+      language: otherCourse.language,
+      organizationId: otherOrg.id,
+    });
+    const otherLesson = await lessonFixture({
+      chapterId: otherChapter.id,
+      language: otherCourse.language,
+      organizationId: otherOrg.id,
+    });
+
+    const result = await createActivity({
+      headers,
+      kind: "custom",
+      lessonId: otherLesson.id,
+      position: 0,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+
+  test("creates activity at correct position", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const newLesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const expectedPosition = 5;
+
+    const result = await createActivity({
+      headers,
+      kind: "custom",
+      lessonId: newLesson.id,
+      position: expectedPosition,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.position).toBe(expectedPosition);
+  });
+
+  test("shifts existing activities when creating at position 0", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const newLesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const [activity1, activity2] = await Promise.all([
+      activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    const result = await createActivity({
+      headers,
+      kind: "custom",
+      lessonId: newLesson.id,
+      position: 0,
+    });
+
+    expect(result.error).toBeNull();
+
+    const activities = await prisma.activity.findMany({
+      orderBy: { position: "asc" },
+      where: { lessonId: newLesson.id },
+    });
+
+    expect(activities.length).toBe(3);
+    expect(activities[0]?.id).toBe(result.data?.id);
+    expect(activities[0]?.position).toBe(0);
+    expect(activities[1]?.id).toBe(activity1.id);
+    expect(activities[1]?.position).toBe(1);
+    expect(activities[2]?.id).toBe(activity2.id);
+    expect(activities[2]?.position).toBe(2);
+  });
+
+  test("shifts only activities after insertion point", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const newLesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const [activity1, activity2, activity3] = await Promise.all([
+      activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 1,
+      }),
+      activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 2,
+      }),
+    ]);
+
+    const result = await createActivity({
+      headers,
+      kind: "custom",
+      lessonId: newLesson.id,
+      position: 1,
+    });
+
+    expect(result.error).toBeNull();
+
+    const activities = await prisma.activity.findMany({
+      orderBy: { position: "asc" },
+      where: { lessonId: newLesson.id },
+    });
+
+    expect(activities.length).toBe(4);
+    expect(activities[0]?.id).toBe(activity1.id);
+    expect(activities[0]?.position).toBe(0);
+    expect(activities[1]?.id).toBe(result.data?.id);
+    expect(activities[1]?.position).toBe(1);
+    expect(activities[2]?.id).toBe(activity2.id);
+    expect(activities[2]?.position).toBe(2);
+    expect(activities[3]?.id).toBe(activity3.id);
+    expect(activities[3]?.position).toBe(3);
+  });
+
+  test("does not shift activities when creating at end", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const newLesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const [activity1, activity2] = await Promise.all([
+      activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    const result = await createActivity({
+      headers,
+      kind: "custom",
+      lessonId: newLesson.id,
+      position: 2,
+    });
+
+    expect(result.error).toBeNull();
+
+    const activities = await prisma.activity.findMany({
+      orderBy: { position: "asc" },
+      where: { lessonId: newLesson.id },
+    });
+
+    expect(activities.length).toBe(3);
+    expect(activities[0]?.id).toBe(activity1.id);
+    expect(activities[0]?.position).toBe(0);
+    expect(activities[1]?.id).toBe(activity2.id);
+    expect(activities[1]?.position).toBe(1);
+    expect(activities[2]?.id).toBe(result.data?.id);
+    expect(activities[2]?.position).toBe(2);
+  });
+
+  test("handles concurrent creations at same position without duplicate positions", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const newLesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        createActivity({
+          headers,
+          kind: "custom",
+          lessonId: newLesson.id,
+          position: 0,
+        }),
+      ),
+    );
+
+    for (const result of results) {
+      expect(result.error).toBeNull();
+    }
+
+    const activities = await prisma.activity.findMany({
+      orderBy: { position: "asc" },
+      where: { lessonId: newLesson.id },
+    });
+
+    expect(activities.length).toBe(5);
+
+    const positions = activities.map((a) => a.position);
+    const uniquePositions = new Set(positions);
+    expect(uniquePositions.size).toBe(5);
+
+    const sortedPositions = [...positions].sort((a, b) => a - b);
+    expect(sortedPositions).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  describe("isPublished behavior", () => {
+    test("activity is published when lesson is unpublished", async () => {
+      const course = await courseFixture({ organizationId: organization.id });
+      const chapter = await chapterFixture({
+        courseId: course.id,
+        language: course.language,
+        organizationId: organization.id,
+      });
+      const unpublishedLesson = await lessonFixture({
+        chapterId: chapter.id,
+        isPublished: false,
+        language: course.language,
+        organizationId: organization.id,
+      });
+
+      const result = await createActivity({
+        headers,
+        kind: "custom",
+        lessonId: unpublishedLesson.id,
+        position: 0,
+      });
+
+      expect(result.error).toBeNull();
+      expect(result.data?.isPublished).toBe(true);
+    });
+
+    test("activity is unpublished when lesson is published", async () => {
+      const course = await courseFixture({ organizationId: organization.id });
+      const chapter = await chapterFixture({
+        courseId: course.id,
+        language: course.language,
+        organizationId: organization.id,
+      });
+      const publishedLesson = await lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        language: course.language,
+        organizationId: organization.id,
+      });
+
+      const result = await createActivity({
+        headers,
+        kind: "custom",
+        lessonId: publishedLesson.id,
+        position: 0,
+      });
+
+      expect(result.error).toBeNull();
+      expect(result.data?.isPublished).toBe(false);
+    });
+  });
+});

--- a/apps/editor/src/data/activities/create-activity.ts
+++ b/apps/editor/src/data/activities/create-activity.ts
@@ -1,0 +1,72 @@
+import "server-only";
+
+import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
+import { type Activity, type ActivityKind, prisma } from "@zoonk/db";
+import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { ErrorCode } from "@/lib/app-error";
+
+export async function createActivity(params: {
+  description?: string;
+  headers?: Headers;
+  kind: ActivityKind;
+  lessonId: number;
+  position: number;
+  title?: string;
+}): Promise<SafeReturn<Activity>> {
+  const { data: lesson, error: findError } = await safeAsync(() =>
+    prisma.lesson.findUnique({
+      where: { id: params.lessonId },
+    }),
+  );
+
+  if (findError) {
+    return { data: null, error: findError };
+  }
+
+  if (!lesson) {
+    return { data: null, error: new AppError(ErrorCode.lessonNotFound) };
+  }
+
+  const hasPermission = await hasCoursePermission({
+    headers: params.headers,
+    orgId: lesson.organizationId,
+    permission: "update",
+  });
+
+  if (!hasPermission) {
+    return { data: null, error: new AppError(ErrorCode.forbidden) };
+  }
+
+  const { data: activity, error } = await safeAsync(() =>
+    prisma.$transaction(async (tx) => {
+      await tx.$queryRaw`SELECT id FROM lessons WHERE id = ${params.lessonId} FOR UPDATE`;
+
+      await tx.activity.updateMany({
+        data: { position: { increment: 1 } },
+        where: {
+          lessonId: params.lessonId,
+          position: { gte: params.position },
+        },
+      });
+
+      return tx.activity.create({
+        data: {
+          description: params.description,
+          isPublished: !lesson.isPublished,
+          kind: params.kind,
+          language: lesson.language,
+          lessonId: params.lessonId,
+          organizationId: lesson.organizationId,
+          position: params.position,
+          title: params.title,
+        },
+      });
+    }),
+  );
+
+  if (error) {
+    return { data: null, error };
+  }
+
+  return { data: activity, error: null };
+}

--- a/apps/editor/src/data/activities/export-activities.test.ts
+++ b/apps/editor/src/data/activities/export-activities.test.ts
@@ -1,0 +1,277 @@
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import {
+  memberFixture,
+  organizationFixture,
+} from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, describe, expect, test } from "vitest";
+import { ErrorCode } from "@/lib/app-error";
+import { exportActivities } from "./export-activities";
+
+describe("unauthenticated users", () => {
+  test("returns Forbidden", async () => {
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const result = await exportActivities({
+      headers: new Headers(),
+      lessonId: lesson.id,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("members", () => {
+  test("returns Forbidden", async () => {
+    const { organization, user } = await memberFixture({ role: "member" });
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const [headers, lesson] = await Promise.all([
+      signInAs(user.email, user.password),
+      lessonFixture({
+        chapterId: chapter.id,
+        language: course.language,
+        organizationId: organization.id,
+      }),
+    ]);
+
+    const result = await exportActivities({
+      headers,
+      lessonId: lesson.id,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("admins", () => {
+  let organization: Awaited<ReturnType<typeof memberFixture>>["organization"];
+  let headers: Headers;
+  let lesson: Awaited<ReturnType<typeof lessonFixture>>;
+
+  beforeAll(async () => {
+    const fixture = await memberFixture({ role: "admin" });
+    organization = fixture.organization;
+    const course = await courseFixture({
+      organizationId: fixture.organization.id,
+    });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: fixture.organization.id,
+    });
+
+    [headers, lesson] = await Promise.all([
+      signInAs(fixture.user.email, fixture.user.password),
+      lessonFixture({
+        chapterId: chapter.id,
+        language: course.language,
+        organizationId: fixture.organization.id,
+      }),
+    ]);
+  });
+
+  test("exports activities successfully", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const newLesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    await Promise.all([
+      activityFixture({
+        kind: "background",
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 0,
+        title: "Activity 1",
+      }),
+      activityFixture({
+        kind: "quiz",
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 1,
+        title: "Activity 2",
+      }),
+    ]);
+
+    const result = await exportActivities({
+      headers,
+      lessonId: newLesson.id,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toBeDefined();
+    expect(result.data?.version).toBe(1);
+    expect(result.data?.exportedAt).toBeDefined();
+    expect(result.data?.activities).toHaveLength(2);
+    expect(result.data?.activities[0]?.title).toBe("Activity 1");
+    expect(result.data?.activities[0]?.position).toBe(0);
+    expect(result.data?.activities[0]?.kind).toBe("background");
+    expect(result.data?.activities[1]?.title).toBe("Activity 2");
+    expect(result.data?.activities[1]?.position).toBe(1);
+    expect(result.data?.activities[1]?.kind).toBe("quiz");
+  });
+
+  test("exports empty activities array when lesson has no activities", async () => {
+    const result = await exportActivities({
+      headers,
+      lessonId: lesson.id,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.activities).toEqual([]);
+  });
+
+  test("returns Lesson not found for non-existent lesson", async () => {
+    const result = await exportActivities({
+      headers,
+      lessonId: 999_999,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.lessonNotFound);
+    expect(result.data).toBeNull();
+  });
+
+  test("don't allow exporting activities from a different organization", async () => {
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+    const otherChapter = await chapterFixture({
+      courseId: otherCourse.id,
+      language: otherCourse.language,
+      organizationId: otherOrg.id,
+    });
+    const otherLesson = await lessonFixture({
+      chapterId: otherChapter.id,
+      language: otherCourse.language,
+      organizationId: otherOrg.id,
+    });
+
+    const result = await exportActivities({
+      headers,
+      lessonId: otherLesson.id,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+
+  test("exports activities in correct order", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const newLesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    await Promise.all([
+      activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 2,
+        title: "Third",
+      }),
+      activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 0,
+        title: "First",
+      }),
+      activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 1,
+        title: "Second",
+      }),
+    ]);
+
+    const result = await exportActivities({
+      headers,
+      lessonId: newLesson.id,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.activities).toHaveLength(3);
+    expect(result.data?.activities[0]?.title).toBe("First");
+    expect(result.data?.activities[0]?.position).toBe(0);
+    expect(result.data?.activities[1]?.title).toBe("Second");
+    expect(result.data?.activities[1]?.position).toBe(1);
+    expect(result.data?.activities[2]?.title).toBe("Third");
+    expect(result.data?.activities[2]?.position).toBe(2);
+  });
+
+  test("includes all activity fields in export", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const newLesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    await activityFixture({
+      description: "Test Description",
+      kind: "explanation",
+      language: course.language,
+      lessonId: newLesson.id,
+      organizationId: organization.id,
+      position: 0,
+      title: "Test Title",
+    });
+
+    const result = await exportActivities({
+      headers,
+      lessonId: newLesson.id,
+    });
+
+    expect(result.error).toBeNull();
+
+    expect(result.data?.activities[0]).toEqual({
+      description: "Test Description",
+      kind: "explanation",
+      position: 0,
+      title: "Test Title",
+    });
+  });
+});

--- a/apps/editor/src/data/activities/export-activities.ts
+++ b/apps/editor/src/data/activities/export-activities.ts
@@ -1,0 +1,75 @@
+import "server-only";
+
+import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
+import { type ActivityKind, prisma } from "@zoonk/db";
+import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { ErrorCode } from "@/lib/app-error";
+
+export type ExportedActivity = {
+  description: string | null;
+  kind: ActivityKind;
+  position: number;
+  title: string | null;
+};
+
+export type ActivitiesExport = {
+  activities: ExportedActivity[];
+  exportedAt: string;
+  version: number;
+};
+
+export async function exportActivities(params: {
+  lessonId: number;
+  headers?: Headers;
+}): Promise<SafeReturn<ActivitiesExport>> {
+  const { data: lesson, error: findError } = await safeAsync(() =>
+    prisma.lesson.findUnique({
+      where: { id: params.lessonId },
+    }),
+  );
+
+  if (findError) {
+    return { data: null, error: findError };
+  }
+
+  if (!lesson) {
+    return { data: null, error: new AppError(ErrorCode.lessonNotFound) };
+  }
+
+  const hasPermission = await hasCoursePermission({
+    headers: params.headers,
+    orgId: lesson.organizationId,
+    permission: "update",
+  });
+
+  if (!hasPermission) {
+    return { data: null, error: new AppError(ErrorCode.forbidden) };
+  }
+
+  const { data: activities, error: activitiesError } = await safeAsync(() =>
+    prisma.activity.findMany({
+      orderBy: { position: "asc" },
+      where: { lessonId: params.lessonId },
+    }),
+  );
+
+  if (activitiesError) {
+    return { data: null, error: activitiesError };
+  }
+
+  const exportedActivities: ExportedActivity[] = activities.map((activity) => ({
+    description: activity.description,
+    kind: activity.kind,
+    position: activity.position,
+    title: activity.title,
+  }));
+
+  return {
+    data: {
+      activities: exportedActivities,
+      exportedAt: new Date().toISOString(),
+      version: 1,
+    },
+    error: null,
+  };
+}

--- a/apps/editor/src/data/activities/get-activity.test.ts
+++ b/apps/editor/src/data/activities/get-activity.test.ts
@@ -1,0 +1,160 @@
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import {
+  memberFixture,
+  organizationFixture,
+} from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, describe, expect, test } from "vitest";
+import { ErrorCode } from "@/lib/app-error";
+import { getActivity } from "./get-activity";
+
+describe("unauthenticated users", () => {
+  test("returns Forbidden", async () => {
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const activity = await activityFixture({
+      language: course.language,
+      lessonId: lesson.id,
+      organizationId: organization.id,
+    });
+
+    const result = await getActivity({
+      activityId: activity.id,
+      headers: new Headers(),
+      orgSlug: organization.slug,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("members", () => {
+  test("returns Forbidden", async () => {
+    const { organization, user } = await memberFixture({ role: "member" });
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const [headers, activity] = await Promise.all([
+      signInAs(user.email, user.password),
+      activityFixture({
+        language: course.language,
+        lessonId: lesson.id,
+        organizationId: organization.id,
+      }),
+    ]);
+
+    const result = await getActivity({
+      activityId: activity.id,
+      headers,
+      orgSlug: organization.slug,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("admins", () => {
+  let organization: Awaited<ReturnType<typeof memberFixture>>["organization"];
+  let headers: Headers;
+
+  beforeAll(async () => {
+    const fixture = await memberFixture({ role: "admin" });
+    organization = fixture.organization;
+
+    headers = await signInAs(fixture.user.email, fixture.user.password);
+  });
+
+  test("returns activity by id", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const activity = await activityFixture({
+      language: course.language,
+      lessonId: lesson.id,
+      organizationId: organization.id,
+      title: "Test Activity",
+    });
+
+    const result = await getActivity({
+      activityId: activity.id,
+      headers,
+      orgSlug: organization.slug,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.id).toBe(activity.id);
+    expect(result.data?.title).toBe("Test Activity");
+  });
+
+  test("returns null when activity not found", async () => {
+    const result = await getActivity({
+      activityId: BigInt(999_999_999),
+      headers,
+      orgSlug: organization.slug,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toBeNull();
+  });
+
+  test("returns Forbidden for activity in different organization", async () => {
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+    const otherChapter = await chapterFixture({
+      courseId: otherCourse.id,
+      language: otherCourse.language,
+      organizationId: otherOrg.id,
+    });
+    const otherLesson = await lessonFixture({
+      chapterId: otherChapter.id,
+      language: otherCourse.language,
+      organizationId: otherOrg.id,
+    });
+    const otherActivity = await activityFixture({
+      language: otherCourse.language,
+      lessonId: otherLesson.id,
+      organizationId: otherOrg.id,
+    });
+
+    const result = await getActivity({
+      activityId: otherActivity.id,
+      headers,
+      orgSlug: otherOrg.slug,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});

--- a/apps/editor/src/data/activities/get-activity.ts
+++ b/apps/editor/src/data/activities/get-activity.ts
@@ -1,0 +1,52 @@
+import "server-only";
+
+import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
+import { type Activity, prisma } from "@zoonk/db";
+import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { cache } from "react";
+import { ErrorCode } from "@/lib/app-error";
+
+const cachedGetActivity = cache(
+  async (
+    activityId: bigint,
+    orgSlug: string,
+    headers?: Headers,
+  ): Promise<SafeReturn<Activity | null>> => {
+    const { data: activity, error: findError } = await safeAsync(() =>
+      prisma.activity.findFirst({
+        where: {
+          id: activityId,
+          organization: { slug: orgSlug },
+        },
+      }),
+    );
+
+    if (findError) {
+      return { data: null, error: findError };
+    }
+
+    if (!activity) {
+      return { data: null, error: null };
+    }
+
+    const hasPermission = await hasCoursePermission({
+      headers,
+      orgId: activity.organizationId,
+      permission: "update",
+    });
+
+    if (!hasPermission) {
+      return { data: null, error: new AppError(ErrorCode.forbidden) };
+    }
+
+    return { data: activity, error: null };
+  },
+);
+
+export function getActivity(params: {
+  activityId: bigint;
+  headers?: Headers;
+  orgSlug: string;
+}): Promise<SafeReturn<Activity | null>> {
+  return cachedGetActivity(params.activityId, params.orgSlug, params.headers);
+}

--- a/apps/editor/src/data/activities/import-activities.test.ts
+++ b/apps/editor/src/data/activities/import-activities.test.ts
@@ -1,0 +1,615 @@
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import {
+  memberFixture,
+  organizationFixture,
+} from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, describe, expect, test } from "vitest";
+import { ErrorCode } from "@/lib/app-error";
+import { importActivities } from "./import-activities";
+
+function createMockFile(
+  content: string,
+  name = "activities.json",
+  type = "application/json",
+): File {
+  return new File([content], name, { type });
+}
+
+function createImportFile(
+  activities: Array<{ description?: string; kind: string; title?: string }>,
+): File {
+  return createMockFile(JSON.stringify({ activities }));
+}
+
+describe("unauthenticated users", () => {
+  test("returns Forbidden", async () => {
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const file = createImportFile([{ kind: "background", title: "Test" }]);
+
+    const result = await importActivities({
+      file,
+      headers: new Headers(),
+      lessonId: lesson.id,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("members", () => {
+  test("returns Forbidden", async () => {
+    const { organization, user } = await memberFixture({ role: "member" });
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const [headers, lesson] = await Promise.all([
+      signInAs(user.email, user.password),
+      lessonFixture({
+        chapterId: chapter.id,
+        language: course.language,
+        organizationId: organization.id,
+      }),
+    ]);
+
+    const file = createImportFile([{ kind: "background", title: "Test" }]);
+
+    const result = await importActivities({
+      file,
+      headers,
+      lessonId: lesson.id,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("admins", () => {
+  let organization: Awaited<ReturnType<typeof memberFixture>>["organization"];
+  let headers: Headers;
+  let lesson: Awaited<ReturnType<typeof lessonFixture>>;
+
+  beforeAll(async () => {
+    const fixture = await memberFixture({ role: "admin" });
+    organization = fixture.organization;
+    const course = await courseFixture({
+      organizationId: fixture.organization.id,
+    });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: fixture.organization.id,
+    });
+
+    [headers, lesson] = await Promise.all([
+      signInAs(fixture.user.email, fixture.user.password),
+      lessonFixture({
+        chapterId: chapter.id,
+        language: course.language,
+        organizationId: fixture.organization.id,
+      }),
+    ]);
+  });
+
+  test("imports activities successfully", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const newLesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const file = createImportFile([
+      {
+        description: "First Description",
+        kind: "background",
+        title: "First Activity",
+      },
+      {
+        description: "Second Description",
+        kind: "quiz",
+        title: "Second Activity",
+      },
+    ]);
+
+    const result = await importActivities({
+      file,
+      headers,
+      lessonId: newLesson.id,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toHaveLength(2);
+    expect(result.data?.[0]?.title).toBe("First Activity");
+    expect(result.data?.[0]?.kind).toBe("background");
+    expect(result.data?.[1]?.title).toBe("Second Activity");
+    expect(result.data?.[1]?.kind).toBe("quiz");
+
+    const activities = await prisma.activity.findMany({
+      orderBy: { position: "asc" },
+      where: { lessonId: newLesson.id },
+    });
+
+    expect(activities).toHaveLength(2);
+    expect(activities[0]?.id).toBe(result.data?.[0]?.id);
+    expect(activities[0]?.position).toBe(0);
+    expect(activities[1]?.position).toBe(1);
+  });
+
+  test("returns Lesson not found for non-existent lesson", async () => {
+    const file = createImportFile([{ kind: "background", title: "Test" }]);
+
+    const result = await importActivities({
+      file,
+      headers,
+      lessonId: 999_999,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.lessonNotFound);
+    expect(result.data).toBeNull();
+  });
+
+  test("don't allow importing activities to a different organization", async () => {
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+    const otherChapter = await chapterFixture({
+      courseId: otherCourse.id,
+      language: otherCourse.language,
+      organizationId: otherOrg.id,
+    });
+    const otherLesson = await lessonFixture({
+      chapterId: otherChapter.id,
+      language: otherCourse.language,
+      organizationId: otherOrg.id,
+    });
+
+    const file = createImportFile([{ kind: "background", title: "Test" }]);
+
+    const result = await importActivities({
+      file,
+      headers,
+      lessonId: otherLesson.id,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+
+  test("appends to existing activities", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const newLesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    await activityFixture({
+      language: course.language,
+      lessonId: newLesson.id,
+      organizationId: organization.id,
+      position: 0,
+      title: "Existing",
+    });
+
+    const file = createImportFile([{ kind: "background", title: "Imported" }]);
+
+    const result = await importActivities({
+      file,
+      headers,
+      lessonId: newLesson.id,
+    });
+
+    expect(result.error).toBeNull();
+
+    const activities = await prisma.activity.findMany({
+      orderBy: { position: "asc" },
+      where: { lessonId: newLesson.id },
+    });
+
+    expect(activities).toHaveLength(2);
+    expect(activities[0]?.title).toBe("Existing");
+    expect(activities[1]?.title).toBe("Imported");
+  });
+
+  test("assigns positions in order", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const newLesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const file = createImportFile([
+      { kind: "background", title: "First" },
+      { kind: "explanation", title: "Second" },
+      { kind: "quiz", title: "Third" },
+    ]);
+
+    const result = await importActivities({
+      file,
+      headers,
+      lessonId: newLesson.id,
+    });
+
+    expect(result.error).toBeNull();
+
+    const activities = await prisma.activity.findMany({
+      orderBy: { position: "asc" },
+      where: { lessonId: newLesson.id },
+    });
+
+    expect(activities).toHaveLength(3);
+    expect(activities[0]?.position).toBe(0);
+    expect(activities[0]?.title).toBe("First");
+    expect(activities[1]?.position).toBe(1);
+    expect(activities[1]?.title).toBe("Second");
+    expect(activities[2]?.position).toBe(2);
+    expect(activities[2]?.title).toBe("Third");
+  });
+
+  describe("replace mode", () => {
+    test("removes existing activities and adds new ones", async () => {
+      const course = await courseFixture({ organizationId: organization.id });
+      const chapter = await chapterFixture({
+        courseId: course.id,
+        language: course.language,
+        organizationId: organization.id,
+      });
+      const newLesson = await lessonFixture({
+        chapterId: chapter.id,
+        language: course.language,
+        organizationId: organization.id,
+      });
+
+      await activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 0,
+        title: "Existing",
+      });
+
+      const file = createImportFile([
+        { kind: "background", title: "New Activity" },
+      ]);
+
+      const result = await importActivities({
+        file,
+        headers,
+        lessonId: newLesson.id,
+        mode: "replace",
+      });
+
+      expect(result.error).toBeNull();
+      expect(result.data).toHaveLength(1);
+      expect(result.data?.[0]?.title).toBe("New Activity");
+
+      const activities = await prisma.activity.findMany({
+        where: { lessonId: newLesson.id },
+      });
+
+      expect(activities).toHaveLength(1);
+      expect(activities[0]?.title).toBe("New Activity");
+    });
+
+    test("starts positions from 0 after replace", async () => {
+      const course = await courseFixture({ organizationId: organization.id });
+      const chapter = await chapterFixture({
+        courseId: course.id,
+        language: course.language,
+        organizationId: organization.id,
+      });
+      const newLesson = await lessonFixture({
+        chapterId: chapter.id,
+        language: course.language,
+        organizationId: organization.id,
+      });
+
+      await activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 5,
+      });
+
+      const file = createImportFile([
+        { kind: "background", title: "First" },
+        { kind: "quiz", title: "Second" },
+      ]);
+
+      const result = await importActivities({
+        file,
+        headers,
+        lessonId: newLesson.id,
+        mode: "replace",
+      });
+
+      expect(result.error).toBeNull();
+
+      const activities = await prisma.activity.findMany({
+        orderBy: { position: "asc" },
+        where: { lessonId: newLesson.id },
+      });
+
+      expect(activities).toHaveLength(2);
+      expect(activities[0]?.position).toBe(0);
+      expect(activities[1]?.position).toBe(1);
+    });
+
+    test("works with empty lesson", async () => {
+      const course = await courseFixture({ organizationId: organization.id });
+      const chapter = await chapterFixture({
+        courseId: course.id,
+        language: course.language,
+        organizationId: organization.id,
+      });
+      const newLesson = await lessonFixture({
+        chapterId: chapter.id,
+        language: course.language,
+        organizationId: organization.id,
+      });
+
+      const file = createImportFile([
+        { kind: "background", title: "New Activity" },
+      ]);
+
+      const result = await importActivities({
+        file,
+        headers,
+        lessonId: newLesson.id,
+        mode: "replace",
+      });
+
+      expect(result.error).toBeNull();
+      expect(result.data).toHaveLength(1);
+    });
+  });
+
+  describe("file validation", () => {
+    test("rejects file larger than 5MB", async () => {
+      const largeContent = "x".repeat(6 * 1024 * 1024);
+      const file = createMockFile(largeContent);
+
+      const result = await importActivities({
+        file,
+        headers,
+        lessonId: lesson.id,
+      });
+
+      expect(result.error?.message).toBe(ErrorCode.fileTooLarge);
+    });
+
+    test("rejects non-JSON file", async () => {
+      const file = new File(["test content"], "activities.txt", {
+        type: "text/plain",
+      });
+
+      const result = await importActivities({
+        file,
+        headers,
+        lessonId: lesson.id,
+      });
+
+      expect(result.error?.message).toBe(ErrorCode.invalidFileType);
+    });
+
+    test("rejects invalid JSON", async () => {
+      const file = createMockFile("{ invalid json }");
+
+      const result = await importActivities({
+        file,
+        headers,
+        lessonId: lesson.id,
+      });
+
+      expect(result.error?.message).toBe(ErrorCode.invalidJsonFormat);
+    });
+
+    test("rejects JSON without activities array", async () => {
+      const file = createMockFile(JSON.stringify({ foo: "bar" }));
+
+      const result = await importActivities({
+        file,
+        headers,
+        lessonId: lesson.id,
+      });
+
+      expect(result.error?.message).toBe(ErrorCode.invalidActivityFormat);
+    });
+
+    test("rejects activity without kind", async () => {
+      const file = createMockFile(
+        JSON.stringify({
+          activities: [{ title: "Test" }],
+        }),
+      );
+
+      const result = await importActivities({
+        file,
+        headers,
+        lessonId: lesson.id,
+      });
+
+      expect(result.error?.message).toBe(ErrorCode.invalidActivityFormat);
+    });
+
+    test("rejects activity with invalid kind", async () => {
+      const file = createMockFile(
+        JSON.stringify({
+          activities: [{ kind: "invalid_kind" }],
+        }),
+      );
+
+      const result = await importActivities({
+        file,
+        headers,
+        lessonId: lesson.id,
+      });
+
+      expect(result.error?.message).toBe(ErrorCode.invalidActivityFormat);
+    });
+
+    test("accepts JSON file by name when type is empty", async () => {
+      const course = await courseFixture({ organizationId: organization.id });
+      const chapter = await chapterFixture({
+        courseId: course.id,
+        language: course.language,
+        organizationId: organization.id,
+      });
+      const newLesson = await lessonFixture({
+        chapterId: chapter.id,
+        language: course.language,
+        organizationId: organization.id,
+      });
+
+      const file = new File(
+        [
+          JSON.stringify({
+            activities: [{ kind: "background", title: "Test" }],
+          }),
+        ],
+        "activities.json",
+        { type: "" },
+      );
+
+      const result = await importActivities({
+        file,
+        headers,
+        lessonId: newLesson.id,
+      });
+
+      expect(result.error).toBeNull();
+      expect(result.data).toHaveLength(1);
+    });
+  });
+
+  describe("isPublished behavior", () => {
+    test("imported activities are published when lesson is unpublished", async () => {
+      const course = await courseFixture({ organizationId: organization.id });
+      const chapter = await chapterFixture({
+        courseId: course.id,
+        language: course.language,
+        organizationId: organization.id,
+      });
+      const unpublishedLesson = await lessonFixture({
+        chapterId: chapter.id,
+        isPublished: false,
+        language: course.language,
+        organizationId: organization.id,
+      });
+
+      const file = createImportFile([
+        { kind: "background", title: "Test Activity" },
+      ]);
+
+      const result = await importActivities({
+        file,
+        headers,
+        lessonId: unpublishedLesson.id,
+      });
+
+      expect(result.error).toBeNull();
+      expect(result.data?.[0]?.isPublished).toBe(true);
+    });
+
+    test("imported activities are unpublished when lesson is published", async () => {
+      const course = await courseFixture({ organizationId: organization.id });
+      const chapter = await chapterFixture({
+        courseId: course.id,
+        language: course.language,
+        organizationId: organization.id,
+      });
+      const publishedLesson = await lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        language: course.language,
+        organizationId: organization.id,
+      });
+
+      const file = createImportFile([
+        { kind: "background", title: "Test Activity" },
+      ]);
+
+      const result = await importActivities({
+        file,
+        headers,
+        lessonId: publishedLesson.id,
+      });
+
+      expect(result.error).toBeNull();
+      expect(result.data?.[0]?.isPublished).toBe(false);
+    });
+  });
+
+  describe("generationStatus behavior", () => {
+    test("sets lesson generationStatus to completed after importing", async () => {
+      const course = await courseFixture({ organizationId: organization.id });
+      const chapter = await chapterFixture({
+        courseId: course.id,
+        language: course.language,
+        organizationId: organization.id,
+      });
+
+      const newLesson = await lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "pending",
+        language: course.language,
+        organizationId: organization.id,
+      });
+
+      const file = createImportFile([
+        { kind: "background", title: "Test Activity" },
+      ]);
+
+      const result = await importActivities({
+        file,
+        headers,
+        lessonId: newLesson.id,
+      });
+
+      expect(result.error).toBeNull();
+
+      const updatedLesson = await prisma.lesson.findUnique({
+        where: { id: newLesson.id },
+      });
+
+      expect(updatedLesson?.generationStatus).toBe("completed");
+    });
+  });
+});

--- a/apps/editor/src/data/activities/import-activities.ts
+++ b/apps/editor/src/data/activities/import-activities.ts
@@ -1,0 +1,183 @@
+import "server-only";
+
+import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
+import { type Activity, type ActivityKind, prisma } from "@zoonk/db";
+import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { ErrorCode } from "@/lib/app-error";
+import { parseJsonFile } from "@/lib/parse-json-file";
+
+const validActivityKinds: ActivityKind[] = [
+  "custom",
+  "background",
+  "explanation",
+  "quiz",
+  "mechanics",
+  "examples",
+  "story",
+  "challenge",
+  "vocabulary",
+  "grammar",
+  "reading",
+  "listening",
+  "pronunciation",
+  "review",
+];
+
+export type ActivityImportData = {
+  description?: string;
+  kind: ActivityKind;
+  title?: string;
+};
+
+export type ActivitiesImport = {
+  activities: ActivityImportData[];
+};
+
+export type ImportMode = "merge" | "replace";
+
+type TransactionClient = Parameters<
+  Parameters<typeof prisma.$transaction>[0]
+>[0];
+
+function validateActivityData(
+  activity: unknown,
+): activity is ActivityImportData {
+  if (typeof activity !== "object" || activity === null) {
+    return false;
+  }
+
+  const a = activity as Record<string, unknown>;
+
+  const hasValidKind =
+    typeof a.kind === "string" &&
+    validActivityKinds.includes(a.kind as ActivityKind);
+
+  return hasValidKind;
+}
+
+function validateImportData(data: unknown): data is ActivitiesImport {
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+
+  const d = data as Record<string, unknown>;
+
+  if (!Array.isArray(d.activities)) {
+    return false;
+  }
+
+  return d.activities.every(validateActivityData);
+}
+
+async function removeExistingActivities(
+  tx: TransactionClient,
+  lessonId: number,
+): Promise<void> {
+  await tx.activity.deleteMany({
+    where: { lessonId },
+  });
+}
+
+export async function importActivities(params: {
+  file: File;
+  headers?: Headers;
+  lessonId: number;
+  mode?: ImportMode;
+}): Promise<SafeReturn<Activity[]>> {
+  const mode = params.mode ?? "merge";
+
+  const { data: importData, error: parseError } = await parseJsonFile({
+    file: params.file,
+    invalidFormatError: ErrorCode.invalidActivityFormat,
+    validate: validateImportData,
+  });
+
+  if (parseError) {
+    return { data: null, error: parseError };
+  }
+
+  const { data: lesson, error: findError } = await safeAsync(() =>
+    prisma.lesson.findUnique({
+      where: { id: params.lessonId },
+    }),
+  );
+
+  if (findError) {
+    return { data: null, error: findError };
+  }
+
+  if (!lesson) {
+    return { data: null, error: new AppError(ErrorCode.lessonNotFound) };
+  }
+
+  const hasPermission = await hasCoursePermission({
+    headers: params.headers,
+    orgId: lesson.organizationId,
+    permission: "update",
+  });
+
+  if (!hasPermission) {
+    return { data: null, error: new AppError(ErrorCode.forbidden) };
+  }
+
+  const { data: result, error: importError } = await safeAsync(() =>
+    prisma.$transaction(async (tx) => {
+      let startPosition = 0;
+
+      if (mode === "replace") {
+        await removeExistingActivities(tx, params.lessonId);
+      } else {
+        const existingActivities = await tx.activity.findMany({
+          orderBy: { position: "desc" },
+          select: { position: true },
+          take: 1,
+          where: { lessonId: params.lessonId },
+        });
+
+        startPosition = (existingActivities[0]?.position ?? -1) + 1;
+      }
+
+      const imported: Activity[] = [];
+
+      const activityOperations = importData.activities.map(
+        async (activityData, i) => {
+          const activity = await tx.activity.create({
+            data: {
+              description: activityData.description,
+              isPublished: !lesson.isPublished,
+              kind: activityData.kind,
+              language: lesson.language,
+              lessonId: params.lessonId,
+              organizationId: lesson.organizationId,
+              position: startPosition + i,
+              title: activityData.title,
+            },
+          });
+
+          return { activity, index: i };
+        },
+      );
+
+      const results = await Promise.all(activityOperations);
+
+      results.sort((a, b) => a.index - b.index);
+
+      for (const activityResult of results) {
+        imported.push(activityResult.activity);
+      }
+
+      await tx.lesson.update({
+        data: { generationStatus: "completed" },
+        where: { id: params.lessonId },
+      });
+
+      return imported;
+    }),
+  );
+
+  if (importError) {
+    return { data: null, error: importError };
+  }
+
+  return { data: result, error: null };
+}

--- a/apps/editor/src/data/activities/list-lesson-activities.test.ts
+++ b/apps/editor/src/data/activities/list-lesson-activities.test.ts
@@ -1,0 +1,207 @@
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import {
+  memberFixture,
+  organizationFixture,
+} from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, describe, expect, test } from "vitest";
+import { ErrorCode } from "@/lib/app-error";
+import { listLessonActivities } from "./list-lesson-activities";
+
+describe("unauthenticated users", () => {
+  test("returns Forbidden", async () => {
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const result = await listLessonActivities({
+      headers: new Headers(),
+      lessonSlug: lesson.slug,
+      orgSlug: organization.slug,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toEqual([]);
+  });
+});
+
+describe("members", () => {
+  test("returns Forbidden", async () => {
+    const { organization, user } = await memberFixture({ role: "member" });
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const [headers, lesson] = await Promise.all([
+      signInAs(user.email, user.password),
+      lessonFixture({
+        chapterId: chapter.id,
+        language: course.language,
+        organizationId: organization.id,
+      }),
+    ]);
+
+    const result = await listLessonActivities({
+      headers,
+      lessonSlug: lesson.slug,
+      orgSlug: organization.slug,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toEqual([]);
+  });
+});
+
+describe("admins", () => {
+  let organization: Awaited<ReturnType<typeof memberFixture>>["organization"];
+  let headers: Headers;
+
+  beforeAll(async () => {
+    const fixture = await memberFixture({ role: "admin" });
+    organization = fixture.organization;
+
+    const course = await courseFixture({
+      organizationId: fixture.organization.id,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: fixture.organization.id,
+    });
+
+    [headers] = await Promise.all([
+      signInAs(fixture.user.email, fixture.user.password),
+      lessonFixture({
+        chapterId: chapter.id,
+        language: course.language,
+        organizationId: fixture.organization.id,
+      }),
+    ]);
+  });
+
+  test("lists activities for a lesson ordered by position", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const newLesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const [activity1, activity2, activity3] = await Promise.all([
+      activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 2,
+      }),
+      activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    const result = await listLessonActivities({
+      headers,
+      lessonSlug: newLesson.slug,
+      orgSlug: organization.slug,
+    });
+
+    const expectedActivityCount = 3;
+
+    expect(result.error).toBeNull();
+    expect(result.data.length).toBe(expectedActivityCount);
+    expect(result.data[0]?.id).toBe(activity2.id);
+    expect(result.data[0]?.position).toBe(0);
+    expect(result.data[1]?.id).toBe(activity3.id);
+    expect(result.data[1]?.position).toBe(1);
+    expect(result.data[2]?.id).toBe(activity1.id);
+    expect(result.data[2]?.position).toBe(2);
+  });
+
+  test("returns empty array when lesson has no activities", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const emptyLesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const result = await listLessonActivities({
+      headers,
+      lessonSlug: emptyLesson.slug,
+      orgSlug: organization.slug,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual([]);
+  });
+
+  test("returns empty array when lesson not found", async () => {
+    const result = await listLessonActivities({
+      headers,
+      lessonSlug: "non-existent-lesson",
+      orgSlug: organization.slug,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual([]);
+  });
+
+  test("returns Forbidden for lesson in different organization", async () => {
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+    const otherChapter = await chapterFixture({
+      courseId: otherCourse.id,
+      language: otherCourse.language,
+      organizationId: otherOrg.id,
+    });
+    const otherLesson = await lessonFixture({
+      chapterId: otherChapter.id,
+      language: otherCourse.language,
+      organizationId: otherOrg.id,
+    });
+
+    const result = await listLessonActivities({
+      headers,
+      lessonSlug: otherLesson.slug,
+      orgSlug: otherOrg.slug,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toEqual([]);
+  });
+});

--- a/apps/editor/src/data/activities/list-lesson-activities.ts
+++ b/apps/editor/src/data/activities/list-lesson-activities.ts
@@ -1,0 +1,58 @@
+import "server-only";
+
+import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
+import { type Activity, prisma } from "@zoonk/db";
+import { AppError, safeAsync } from "@zoonk/utils/error";
+import { cache } from "react";
+import { ErrorCode } from "@/lib/app-error";
+
+const cachedListLessonActivities = cache(
+  async (
+    lessonSlug: string,
+    orgSlug: string,
+    headers?: Headers,
+  ): Promise<{ data: Activity[]; error: Error | null }> => {
+    const { data, error } = await safeAsync(() =>
+      Promise.all([
+        hasCoursePermission({
+          headers,
+          orgSlug,
+          permission: "update",
+        }),
+        prisma.activity.findMany({
+          orderBy: { position: "asc" },
+          where: {
+            lesson: {
+              organization: { slug: orgSlug },
+              slug: lessonSlug,
+            },
+          },
+        }),
+      ]),
+    );
+
+    if (error) {
+      return { data: [], error };
+    }
+
+    const [hasPermission, activities] = data;
+
+    if (!hasPermission) {
+      return { data: [], error: new AppError(ErrorCode.forbidden) };
+    }
+
+    return { data: activities, error: null };
+  },
+);
+
+export function listLessonActivities(params: {
+  lessonSlug: string;
+  headers?: Headers;
+  orgSlug: string;
+}): Promise<{ data: Activity[]; error: Error | null }> {
+  return cachedListLessonActivities(
+    params.lessonSlug,
+    params.orgSlug,
+    params.headers,
+  );
+}

--- a/apps/editor/src/data/activities/list-lesson-activities.ts
+++ b/apps/editor/src/data/activities/list-lesson-activities.ts
@@ -8,25 +8,20 @@ import { ErrorCode } from "@/lib/app-error";
 
 const cachedListLessonActivities = cache(
   async (
-    lessonSlug: string,
-    orgSlug: string,
+    lessonId: number,
+    orgId: number,
     headers?: Headers,
   ): Promise<{ data: Activity[]; error: Error | null }> => {
     const { data, error } = await safeAsync(() =>
       Promise.all([
         hasCoursePermission({
           headers,
-          orgSlug,
+          orgId,
           permission: "update",
         }),
         prisma.activity.findMany({
           orderBy: { position: "asc" },
-          where: {
-            lesson: {
-              organization: { slug: orgSlug },
-              slug: lessonSlug,
-            },
-          },
+          where: { lessonId, organizationId: orgId },
         }),
       ]),
     );
@@ -46,13 +41,13 @@ const cachedListLessonActivities = cache(
 );
 
 export function listLessonActivities(params: {
-  lessonSlug: string;
   headers?: Headers;
-  orgSlug: string;
+  lessonId: number;
+  orgId: number;
 }): Promise<{ data: Activity[]; error: Error | null }> {
   return cachedListLessonActivities(
-    params.lessonSlug,
-    params.orgSlug,
+    params.lessonId,
+    params.orgId,
     params.headers,
   );
 }

--- a/apps/editor/src/data/activities/reorder-activities.test.ts
+++ b/apps/editor/src/data/activities/reorder-activities.test.ts
@@ -1,0 +1,245 @@
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import {
+  memberFixture,
+  organizationFixture,
+} from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, describe, expect, test } from "vitest";
+import { ErrorCode } from "@/lib/app-error";
+import { reorderActivities } from "./reorder-activities";
+
+describe("unauthenticated users", () => {
+  test("returns Forbidden", async () => {
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const result = await reorderActivities({
+      activities: [],
+      headers: new Headers(),
+      lessonId: lesson.id,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("members", () => {
+  test("returns Forbidden", async () => {
+    const { organization, user } = await memberFixture({ role: "member" });
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const [headers, lesson] = await Promise.all([
+      signInAs(user.email, user.password),
+      lessonFixture({
+        chapterId: chapter.id,
+        language: course.language,
+        organizationId: organization.id,
+      }),
+    ]);
+
+    const result = await reorderActivities({
+      activities: [],
+      headers,
+      lessonId: lesson.id,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("admins", () => {
+  let organization: Awaited<ReturnType<typeof memberFixture>>["organization"];
+  let headers: Headers;
+  let lesson: Awaited<ReturnType<typeof lessonFixture>>;
+
+  beforeAll(async () => {
+    const fixture = await memberFixture({ role: "admin" });
+    organization = fixture.organization;
+
+    const course = await courseFixture({
+      organizationId: fixture.organization.id,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: fixture.organization.id,
+    });
+
+    [headers, lesson] = await Promise.all([
+      signInAs(fixture.user.email, fixture.user.password),
+      lessonFixture({
+        chapterId: chapter.id,
+        language: course.language,
+        organizationId: fixture.organization.id,
+      }),
+    ]);
+  });
+
+  test("reorders activities successfully", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const newLesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const [activity1, activity2, activity3] = await Promise.all([
+      activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 1,
+      }),
+      activityFixture({
+        language: course.language,
+        lessonId: newLesson.id,
+        organizationId: organization.id,
+        position: 2,
+      }),
+    ]);
+
+    const result = await reorderActivities({
+      activities: [
+        { activityId: activity3.id, position: 0 },
+        { activityId: activity1.id, position: 1 },
+        { activityId: activity2.id, position: 2 },
+      ],
+      headers,
+      lessonId: newLesson.id,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.updated).toBe(3);
+
+    const reorderedActivities = await prisma.activity.findMany({
+      orderBy: { position: "asc" },
+      where: { lessonId: newLesson.id },
+    });
+
+    expect(reorderedActivities[0]?.id).toBe(activity3.id);
+    expect(reorderedActivities[1]?.id).toBe(activity1.id);
+    expect(reorderedActivities[2]?.id).toBe(activity2.id);
+  });
+
+  test("returns Lesson not found", async () => {
+    const result = await reorderActivities({
+      activities: [],
+      headers,
+      lessonId: 999_999,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.lessonNotFound);
+    expect(result.data).toBeNull();
+  });
+
+  test("returns Forbidden for lesson in different organization", async () => {
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+    const otherChapter = await chapterFixture({
+      courseId: otherCourse.id,
+      language: otherCourse.language,
+      organizationId: otherOrg.id,
+    });
+    const otherLesson = await lessonFixture({
+      chapterId: otherChapter.id,
+      language: otherCourse.language,
+      organizationId: otherOrg.id,
+    });
+
+    const result = await reorderActivities({
+      activities: [],
+      headers,
+      lessonId: otherLesson.id,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+
+  test("handles empty activities array", async () => {
+    const result = await reorderActivities({
+      activities: [],
+      headers,
+      lessonId: lesson.id,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.updated).toBe(0);
+  });
+
+  test("only updates activities that exist in the lesson", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+    const newLesson = await lessonFixture({
+      chapterId: chapter.id,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const activity = await activityFixture({
+      language: course.language,
+      lessonId: newLesson.id,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const expectedPosition = 5;
+
+    const result = await reorderActivities({
+      activities: [
+        { activityId: activity.id, position: expectedPosition },
+        { activityId: BigInt(999_999), position: 0 },
+      ],
+      headers,
+      lessonId: newLesson.id,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.updated).toBe(1);
+
+    const updatedActivity = await prisma.activity.findFirst({
+      where: { id: activity.id, lessonId: newLesson.id },
+    });
+
+    expect(updatedActivity?.position).toBe(expectedPosition);
+  });
+});

--- a/apps/editor/src/data/activities/reorder-activities.ts
+++ b/apps/editor/src/data/activities/reorder-activities.ts
@@ -1,0 +1,63 @@
+import "server-only";
+
+import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
+import { prisma } from "@zoonk/db";
+import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { ErrorCode } from "@/lib/app-error";
+
+export type ActivityPosition = {
+  activityId: bigint;
+  position: number;
+};
+
+export async function reorderActivities(params: {
+  activities: ActivityPosition[];
+  lessonId: number;
+  headers?: Headers;
+}): Promise<SafeReturn<{ updated: number }>> {
+  const { data: lesson, error: findError } = await safeAsync(() =>
+    prisma.lesson.findUnique({
+      where: { id: params.lessonId },
+    }),
+  );
+
+  if (findError) {
+    return { data: null, error: findError };
+  }
+
+  if (!lesson) {
+    return { data: null, error: new AppError(ErrorCode.lessonNotFound) };
+  }
+
+  const hasPermission = await hasCoursePermission({
+    headers: params.headers,
+    orgId: lesson.organizationId,
+    permission: "update",
+  });
+
+  if (!hasPermission) {
+    return { data: null, error: new AppError(ErrorCode.forbidden) };
+  }
+
+  const { data, error } = await safeAsync(() =>
+    prisma.$transaction(
+      params.activities.map((activity) =>
+        prisma.activity.updateMany({
+          data: { position: activity.position },
+          where: {
+            id: activity.activityId,
+            lessonId: params.lessonId,
+          },
+        }),
+      ),
+    ),
+  );
+
+  if (error) {
+    return { data: null, error };
+  }
+
+  const totalUpdated = data.reduce((acc, result) => acc + result.count, 0);
+
+  return { data: { updated: totalUpdated }, error: null };
+}

--- a/apps/editor/src/data/lessons/list-chapter-lessons.ts
+++ b/apps/editor/src/data/lessons/list-chapter-lessons.ts
@@ -8,25 +8,20 @@ import { ErrorCode } from "@/lib/app-error";
 
 const cachedListChapterLessons = cache(
   async (
-    chapterSlug: string,
-    orgSlug: string,
+    chapterId: number,
+    orgId: number,
     headers?: Headers,
   ): Promise<{ data: Lesson[]; error: Error | null }> => {
     const { data, error } = await safeAsync(() =>
       Promise.all([
         hasCoursePermission({
           headers,
-          orgSlug,
+          orgId,
           permission: "update",
         }),
         prisma.lesson.findMany({
           orderBy: { position: "asc" },
-          where: {
-            chapter: {
-              organization: { slug: orgSlug },
-              slug: chapterSlug,
-            },
-          },
+          where: { chapterId, organizationId: orgId },
         }),
       ]),
     );
@@ -46,13 +41,13 @@ const cachedListChapterLessons = cache(
 );
 
 export function listChapterLessons(params: {
-  chapterSlug: string;
+  chapterId: number;
   headers?: Headers;
-  orgSlug: string;
+  orgId: number;
 }): Promise<{ data: Lesson[]; error: Error | null }> {
   return cachedListChapterLessons(
-    params.chapterSlug,
-    params.orgSlug,
+    params.chapterId,
+    params.orgId,
     params.headers,
   );
 }

--- a/apps/editor/src/lib/app-error.ts
+++ b/apps/editor/src/lib/app-error.ts
@@ -1,10 +1,12 @@
 export const ErrorCode = {
+  activityNotFound: "activityNotFound",
   categoryAlreadyAdded: "categoryAlreadyAdded",
   categoryNotInCourse: "categoryNotInCourse",
   chapterNotFound: "chapterNotFound",
   courseNotFound: "courseNotFound",
   fileTooLarge: "fileTooLarge",
   forbidden: "forbidden",
+  invalidActivityFormat: "invalidActivityFormat",
   invalidAlternativeTitleFormat: "invalidAlternativeTitleFormat",
   invalidCategory: "invalidCategory",
   invalidChapterFormat: "invalidChapterFormat",

--- a/apps/editor/src/lib/error-messages.ts
+++ b/apps/editor/src/lib/error-messages.ts
@@ -20,6 +20,8 @@ export async function getErrorMessage(error: Error): Promise<string> {
 
   if (isEditorError(error)) {
     switch (error.code) {
+      case ErrorCode.activityNotFound:
+        return t("Activity not found");
       case ErrorCode.categoryAlreadyAdded:
         return t("This category has already been added to the course");
       case ErrorCode.categoryNotInCourse:
@@ -47,6 +49,10 @@ export async function getErrorMessage(error: Error): Promise<string> {
       case ErrorCode.invalidChapterFormat:
         return t(
           "Invalid chapter format. Each chapter must have a title and description",
+        );
+      case ErrorCode.invalidActivityFormat:
+        return t(
+          "Invalid activity format. Each activity must have a kind and position",
         );
       case ErrorCode.invalidAlternativeTitleFormat:
         return t(

--- a/i18n.lock
+++ b/i18n.lock
@@ -21,19 +21,26 @@ checksums:
     Edit%20chapter%20title/singular: 21c04bd3ed6335df5195d1f2857131bf
     Chapter%20description%E2%80%A6/singular: d394513f90a5c9ad1880d364e8fc5cb8
     Chapter%20title%E2%80%A6/singular: 3ed70a2e64aefe189999ff5899e8a7a2
+    Lesson/singular: 0369d21b141f7f54c4586224e7e7ae65
+    Activity%20editor%20coming%20soon/singular: e02fa050fd72d48f0a50cad81149b8fd
+    Untitled%20activity/singular: 92dccd756c491fc1b61f3eced6b4b96a
+    We%20couldn't%20load%20the%20activities.%20Please%20try%20again./singular: 2f8bcd34b6eb7dc4a2ebccf05311b4c2
+    Contact%20support/singular: 32a4dee2033635e334a5f4d34724e3e0
+    Add%20activity/singular: 69eea4d3afd3c3b3fba0975ff6d9a1d1
+    Drag%20to%20reorder/singular: 42c84478eb582f41d72d5bd7b27bb028
+    Try%20again/singular: 33dd8820e743e35a66e6977f69e9d3b5
+    Insert%20below/singular: 13f5339830c81c2c64a513b4f0a77c2d
+    Failed%20to%20load%20activities/singular: 1d7878e3d09bbbbc244fcca4f846fc0a
+    Activity%20actions/singular: c3253e1c7046f25d280fea09a6d17a31
+    Insert%20above/singular: 24d027b3c1e816c98f5571bb637669bf
     Edit%20lesson%20description/singular: b959f1e2fc7f00f593ae2c1a12fd330d
     Lesson%20description%E2%80%A6/singular: 77ad5a9829eda8182865a46455d5a842
     Lesson%20title%E2%80%A6/singular: d7b981d2734c11f2ee5d58f21c93bd3e
     Edit%20lesson%20title/singular: 15b5a30f4a0365bae4da264383dae889
     We%20couldn't%20load%20the%20lessons.%20Please%20try%20again./singular: f2e68b6dd4d7f2eb0c91f20ade06957d
-    Contact%20support/singular: 32a4dee2033635e334a5f4d34724e3e0
     Failed%20to%20load%20lessons/singular: 427523eb64ddb239d642ca975d6e1dbb
-    Drag%20to%20reorder/singular: 42c84478eb582f41d72d5bd7b27bb028
     Lesson%20actions/singular: e014e6d8a3eb4906b17a79ca0ee96867
-    Try%20again/singular: 33dd8820e743e35a66e6977f69e9d3b5
-    Insert%20below/singular: 13f5339830c81c2c64a513b4f0a77c2d
     Add%20lesson/singular: 101a1880b35c68eed6f80e7574f4ff2d
-    Insert%20above/singular: 24d027b3c1e816c98f5571bb637669bf
     Chapter%20actions/singular: 9f8fd63a1c71839fddbb5b57a1c62f73
     Add%20chapter/singular: af2ea03f1678fcea1fb005f66f28bfa5
     We%20couldn't%20load%20the%20chapters.%20Please%20try%20again./singular: 2bfbac73debefc0d7a4ec5c41af9c415
@@ -109,10 +116,14 @@ checksums:
     Unsaved/singular: ddc9094aecf93ceabe363846756a9925
     Saved/singular: 6554b923011266821d74e06e013a40e6
     Saving%E2%80%A6/singular: ee98ff32f9a585a9108c8cd961d6077e
+    Upload%20a%20JSON%20file%20containing%20activities%20to%20import./singular: 43985544e0dd3f095f4c9b332da33958
     Lessons%20imported%20successfully/singular: 117dcb8f25eb05362ffab7974ecdb5de
     Chapters%20exported%20successfully/singular: c619d46cc34322ce5777a87ec3cc6131
     Lessons%20exported%20successfully/singular: f896c30aab64bfcc43725f8bd3fc02f7
+    Activities%20imported%20successfully/singular: a7d9861227d8a620333036159e9fcb0a
+    Activities%20exported%20successfully/singular: 95dfbf175ca0ad27b473e1a6462909d6
     Upload%20a%20JSON%20file%20containing%20chapters%20to%20import./singular: 7bd7e36f80ba8cdcd19c18f53962f747
+    Import%20activities/singular: a53f1dbd54e4d268f062ef223fbeca7e
     Import%20chapters/singular: 0bf66ec2862c199b95f19512d832ba9b
     Import%20lessons/singular: 8d1fae531b7e8156042321586d18b522
     Chapters%20imported%20successfully/singular: 2a3fda7021d4d81b1cdc6e869f94664f
@@ -147,6 +158,25 @@ checksums:
     Save/singular: f7a2929f33bc420195e59ac5a8bcd454
     This%20URL%20is%20already%20in%20use/singular: dfc6df86970a8fa27f4f4b4c3f2716b1
     URL%20address/singular: e752a4cebaefb0cf38c129ec8edd6b65
+    Category%20not%20found%20in%20this%20course/singular: 32ae23f7913223e56ab7207abfe032bb
+    An%20unexpected%20error%20occurred/singular: fe07b9cdb1fc3f7397f6d89c102c60af
+    Invalid%20category/singular: 5f9195d3e0d1d819cc9d812b712eaca1
+    Chapter%20not%20found/singular: 72d4a8758136678acbae0ec942227f7e
+    Invalid%20chapter%20format.%20Each%20chapter%20must%20have%20a%20title%20and%20description/singular: 6c9dc938c75674b73b61177b55cce86d
+    Lesson%20not%20found/singular: 41c0c0e96242a28b4d90a84b3bf80e94
+    Invalid%20format.%20Please%20provide%20an%20array%20of%20non-empty%20strings/singular: c9dbc954cf099eedbb573d647356f52e
+    Course%20not%20found/singular: 679d024095e9e605246a1928a7e1d87b
+    Invalid%20file%20type.%20Please%20upload%20a%20JSON%20file/singular: 9164c5c1930e61a6037fab99386c02f6
+    This%20category%20has%20already%20been%20added%20to%20the%20course/singular: 5b220e40c0bfc7b3700d1f402697c522
+    Invalid%20activity%20format.%20Each%20activity%20must%20have%20a%20kind%20and%20position/singular: 56d8809184a63043c5a7eda1f86a4b66
+    Please%20sign%20in%20to%20continue/singular: 051e59dd3d3b0bfad95982f982fd6b9d
+    Chapter%20and%20course%20must%20belong%20to%20the%20same%20organization/singular: f3c132074516ccc5cad52c88c86d440d
+    Activity%20not%20found/singular: d4c0726446f5d6a7a7697bf63b9fa577
+    Invalid%20lesson%20format.%20Each%20lesson%20must%20have%20a%20title%20and%20description/singular: e449a82367ccec6680313c4711549e2e
+    You%20don't%20have%20permission%20to%20perform%20this%20action/singular: b99aa4dbc03b5e9b7bf6c64b245a9ab8
+    File%20is%20too%20large.%20Maximum%20size%20is%205MB/singular: 6ee737426f04528c60f84ba1004542b3
+    Invalid%20JSON%20format.%20Please%20check%20your%20file/singular: 2a890d833f49aa36f02433476ca33468
+    Organization%20not%20found/singular: 4cb8c07ec2c599b6f48750e06ffa182b
     History/singular: b0578d6d225f512e42f823fbca2e3c32
     Math/singular: 0a604ffa5ef57408918fe98ef05eb05a
     Arts/singular: 9b1845cec1210e57ea990b1a90823228
@@ -162,23 +192,6 @@ checksums:
     Law/singular: 3f04c791596043e899781f74003b9324
     Business/singular: 7682c7966c6e718836388561e7e68cab
     Geography/singular: fd93fe516c40f1f2dd96f53a507ce95d
-    Category%20not%20found%20in%20this%20course/singular: 32ae23f7913223e56ab7207abfe032bb
-    An%20unexpected%20error%20occurred/singular: fe07b9cdb1fc3f7397f6d89c102c60af
-    Invalid%20category/singular: 5f9195d3e0d1d819cc9d812b712eaca1
-    Chapter%20not%20found/singular: 72d4a8758136678acbae0ec942227f7e
-    Invalid%20chapter%20format.%20Each%20chapter%20must%20have%20a%20title%20and%20description/singular: 6c9dc938c75674b73b61177b55cce86d
-    Lesson%20not%20found/singular: 41c0c0e96242a28b4d90a84b3bf80e94
-    Invalid%20format.%20Please%20provide%20an%20array%20of%20non-empty%20strings/singular: c9dbc954cf099eedbb573d647356f52e
-    Course%20not%20found/singular: 679d024095e9e605246a1928a7e1d87b
-    Invalid%20file%20type.%20Please%20upload%20a%20JSON%20file/singular: 9164c5c1930e61a6037fab99386c02f6
-    This%20category%20has%20already%20been%20added%20to%20the%20course/singular: 5b220e40c0bfc7b3700d1f402697c522
-    Please%20sign%20in%20to%20continue/singular: 051e59dd3d3b0bfad95982f982fd6b9d
-    Chapter%20and%20course%20must%20belong%20to%20the%20same%20organization/singular: f3c132074516ccc5cad52c88c86d440d
-    Invalid%20lesson%20format.%20Each%20lesson%20must%20have%20a%20title%20and%20description/singular: e449a82367ccec6680313c4711549e2e
-    You%20don't%20have%20permission%20to%20perform%20this%20action/singular: b99aa4dbc03b5e9b7bf6c64b245a9ab8
-    File%20is%20too%20large.%20Maximum%20size%20is%205MB/singular: 6ee737426f04528c60f84ba1004542b3
-    Invalid%20JSON%20format.%20Please%20check%20your%20file/singular: 2a890d833f49aa36f02433476ca33468
-    Organization%20not%20found/singular: 4cb8c07ec2c599b6f48750e06ffa182b
   9270df1bc9e10fdb8026bb4ab67061d4:
     Login/singular: f4f219abeb5a465ecb1c7efaf50246de
     Logout/singular: 07948fdf20705e04a7bf68ab197512bf


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add activity management to the lesson editor: list, add, import/export, and drag to reorder lesson activities. Includes a basic activity page and server actions with permissions and errors.

- **New Features**
  - Activity list on the lesson page with drag-and-drop reorder (persisted).
  - Add activity at any position with default title/description.
  - Import/export activities as JSON with merge or replace modes.
  - Activity details route with back link (editor coming soon).
  - Data APIs: list/create/get/reorder/export/import with permission checks and new errors (activityNotFound, invalidActivityFormat).
  - UI actions for activities in EntityListActions with i18n strings.

- **Refactors**
  - Stabilized publish toggle e2e tests by scoping the label to the switch.

<sup>Written for commit 544715e03c02bde47a686c1bae238544126b919d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

