### PR TITLE
feat(db): add Word and Sentence models for language courses

### DIFF
--- a/apps/editor/src/data/activities/import-activities.ts
+++ b/apps/editor/src/data/activities/import-activities.ts
@@ -19,7 +19,6 @@ const validActivityKinds: ActivityKind[] = [
   "grammar",
   "reading",
   "listening",
-  "pronunciation",
   "review",
 ];
 

--- a/packages/db/src/prisma/enums.prisma
+++ b/packages/db/src/prisma/enums.prisma
@@ -24,7 +24,6 @@ enum ActivityKind {
   grammar
   reading
   listening
-  pronunciation
   review
 }
 

--- a/packages/db/src/prisma/migrations/20260121142124_add_word_sentence_models/migration.sql
+++ b/packages/db/src/prisma/migrations/20260121142124_add_word_sentence_models/migration.sql
@@ -1,0 +1,117 @@
+/*
+  Warnings:
+
+  - The values [pronunciation] on the enum `ActivityKind` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "ActivityKind_new" AS ENUM ('custom', 'background', 'explanation', 'quiz', 'mechanics', 'examples', 'story', 'challenge', 'vocabulary', 'grammar', 'reading', 'listening', 'review');
+ALTER TABLE "public"."activities" ALTER COLUMN "kind" DROP DEFAULT;
+ALTER TABLE "activities" ALTER COLUMN "kind" TYPE "ActivityKind_new" USING ("kind"::text::"ActivityKind_new");
+ALTER TYPE "ActivityKind" RENAME TO "ActivityKind_old";
+ALTER TYPE "ActivityKind_new" RENAME TO "ActivityKind";
+DROP TYPE "public"."ActivityKind_old";
+ALTER TABLE "activities" ALTER COLUMN "kind" SET DEFAULT 'custom';
+COMMIT;
+
+-- CreateTable
+CREATE TABLE "words" (
+    "id" BIGSERIAL NOT NULL,
+    "organization_id" INTEGER NOT NULL,
+    "target_language" VARCHAR(10) NOT NULL,
+    "user_language" VARCHAR(10) NOT NULL,
+    "word" TEXT NOT NULL,
+    "translation" TEXT NOT NULL,
+    "pronunciation" TEXT NOT NULL,
+    "romanization" TEXT,
+    "audio_url" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "words_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "sentences" (
+    "id" BIGSERIAL NOT NULL,
+    "organization_id" INTEGER NOT NULL,
+    "target_language" VARCHAR(10) NOT NULL,
+    "user_language" VARCHAR(10) NOT NULL,
+    "sentence" TEXT NOT NULL,
+    "translation" TEXT NOT NULL,
+    "romanization" TEXT,
+    "audio_url" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "sentences_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "lesson_words" (
+    "id" BIGSERIAL NOT NULL,
+    "lesson_id" INTEGER NOT NULL,
+    "word_id" BIGINT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "lesson_words_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "lesson_sentences" (
+    "id" BIGSERIAL NOT NULL,
+    "lesson_id" INTEGER NOT NULL,
+    "sentence_id" BIGINT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "lesson_sentences_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "words_organization_id_target_language_user_language_idx" ON "words"("organization_id", "target_language", "user_language");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "words_organization_id_target_language_user_language_word_key" ON "words"("organization_id", "target_language", "user_language", "word");
+
+-- CreateIndex
+CREATE INDEX "sentences_organization_id_target_language_user_language_idx" ON "sentences"("organization_id", "target_language", "user_language");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sentences_organization_id_target_language_user_language_sen_key" ON "sentences"("organization_id", "target_language", "user_language", "sentence");
+
+-- CreateIndex
+CREATE INDEX "lesson_words_lesson_id_idx" ON "lesson_words"("lesson_id");
+
+-- CreateIndex
+CREATE INDEX "lesson_words_word_id_idx" ON "lesson_words"("word_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "lesson_words_lesson_id_word_id_key" ON "lesson_words"("lesson_id", "word_id");
+
+-- CreateIndex
+CREATE INDEX "lesson_sentences_lesson_id_idx" ON "lesson_sentences"("lesson_id");
+
+-- CreateIndex
+CREATE INDEX "lesson_sentences_sentence_id_idx" ON "lesson_sentences"("sentence_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "lesson_sentences_lesson_id_sentence_id_key" ON "lesson_sentences"("lesson_id", "sentence_id");
+
+-- AddForeignKey
+ALTER TABLE "words" ADD CONSTRAINT "words_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sentences" ADD CONSTRAINT "sentences_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "lesson_words" ADD CONSTRAINT "lesson_words_lesson_id_fkey" FOREIGN KEY ("lesson_id") REFERENCES "lessons"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "lesson_words" ADD CONSTRAINT "lesson_words_word_id_fkey" FOREIGN KEY ("word_id") REFERENCES "words"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "lesson_sentences" ADD CONSTRAINT "lesson_sentences_lesson_id_fkey" FOREIGN KEY ("lesson_id") REFERENCES "lessons"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "lesson_sentences" ADD CONSTRAINT "lesson_sentences_sentence_id_fkey" FOREIGN KEY ("sentence_id") REFERENCES "sentences"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/src/prisma/models/accounts.prisma
+++ b/packages/db/src/prisma/models/accounts.prisma
@@ -94,6 +94,8 @@ model Organization {
   stepAttempts     StepAttempt[]
   dailyProgress    DailyProgress[]
   stripeCustomerId String?         @map("stripe_customer_id")
+  words            Word[]
+  sentences        Sentence[]
 
   @@unique([slug])
   @@map("organizations")

--- a/packages/db/src/prisma/models/lessons.prisma
+++ b/packages/db/src/prisma/models/lessons.prisma
@@ -17,6 +17,8 @@ model Lesson {
   createdAt        DateTime         @default(now()) @map("created_at")
   updatedAt        DateTime         @default(now()) @updatedAt @map("updated_at")
   activities       Activity[]
+  words            LessonWord[]
+  sentences        LessonSentence[]
 
   @@unique([chapterId, slug], name: "chapterLessonSlug")
   @@index([organizationId, normalizedTitle])

--- a/packages/db/src/prisma/models/vocabulary.prisma
+++ b/packages/db/src/prisma/models/vocabulary.prisma
@@ -1,0 +1,66 @@
+model Word {
+  id             BigInt       @id @default(autoincrement())
+  organizationId Int          @map("organization_id")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  targetLanguage String       @map("target_language") @db.VarChar(10)
+  userLanguage   String       @map("user_language") @db.VarChar(10)
+  word           String
+  translation    String
+  pronunciation  String
+  romanization   String?
+  audioUrl       String?      @map("audio_url")
+  createdAt      DateTime     @default(now()) @map("created_at")
+  updatedAt      DateTime     @default(now()) @updatedAt @map("updated_at")
+  lessons        LessonWord[]
+
+  @@unique([organizationId, targetLanguage, userLanguage, word], name: "orgWord")
+  @@index([organizationId, targetLanguage, userLanguage])
+  @@map("words")
+}
+
+model Sentence {
+  id             BigInt           @id @default(autoincrement())
+  organizationId Int              @map("organization_id")
+  organization   Organization     @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  targetLanguage String           @map("target_language") @db.VarChar(10)
+  userLanguage   String           @map("user_language") @db.VarChar(10)
+  sentence       String
+  translation    String
+  romanization   String?
+  audioUrl       String?          @map("audio_url")
+  createdAt      DateTime         @default(now()) @map("created_at")
+  updatedAt      DateTime         @default(now()) @updatedAt @map("updated_at")
+  lessons        LessonSentence[]
+
+  @@unique([organizationId, targetLanguage, userLanguage, sentence], name: "orgSentence")
+  @@index([organizationId, targetLanguage, userLanguage])
+  @@map("sentences")
+}
+
+model LessonWord {
+  id        BigInt   @id @default(autoincrement())
+  lessonId  Int      @map("lesson_id")
+  lesson    Lesson   @relation(fields: [lessonId], references: [id], onDelete: Cascade)
+  wordId    BigInt   @map("word_id")
+  word      Word     @relation(fields: [wordId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@unique([lessonId, wordId], name: "lessonWord")
+  @@index([lessonId])
+  @@index([wordId])
+  @@map("lesson_words")
+}
+
+model LessonSentence {
+  id         BigInt   @id @default(autoincrement())
+  lessonId   Int      @map("lesson_id")
+  lesson     Lesson   @relation(fields: [lessonId], references: [id], onDelete: Cascade)
+  sentenceId BigInt   @map("sentence_id")
+  sentence   Sentence @relation(fields: [sentenceId], references: [id], onDelete: Cascade)
+  createdAt  DateTime @default(now()) @map("created_at")
+
+  @@unique([lessonId, sentenceId], name: "lessonSentence")
+  @@index([lessonId])
+  @@index([sentenceId])
+  @@map("lesson_sentences")
+}

--- a/packages/db/src/prisma/seed.ts
+++ b/packages/db/src/prisma/seed.ts
@@ -10,8 +10,10 @@ import { seedCourses } from "./seed/courses";
 import { seedLessons } from "./seed/lessons";
 import { seedOrganizations } from "./seed/orgs";
 import { seedProgress } from "./seed/progress";
+import { seedSentences } from "./seed/sentences";
 import { seedSteps } from "./seed/steps";
 import { seedUsers } from "./seed/users";
+import { seedWords } from "./seed/words";
 
 async function main() {
   const users = await seedUsers(prisma);
@@ -21,6 +23,8 @@ async function main() {
   await seedCategories(prisma, orgs.ai);
   await seedChapters(prisma, orgs.ai);
   await seedLessons(prisma, orgs.ai);
+  await seedWords(prisma, orgs.ai);
+  await seedSentences(prisma, orgs.ai);
   await seedAlternativeTitles(prisma, orgs.ai);
   await seedCourseUsers(prisma, orgs.ai, users);
   await seedActivities(prisma, orgs.ai);

--- a/packages/db/src/prisma/seed/sentences.ts
+++ b/packages/db/src/prisma/seed/sentences.ts
@@ -1,0 +1,113 @@
+import type { Organization, PrismaClient } from "../../generated/prisma/client";
+
+type SentenceSeedData = {
+  targetLanguage: string;
+  userLanguage: string;
+  sentence: string;
+  translation: string;
+  romanization?: string;
+  audioUrl?: string;
+  lessonSlugs: string[];
+};
+
+const sentencesData: SentenceSeedData[] = [
+  {
+    lessonSlugs: ["greetings-introductions"],
+    sentence: "¿Cómo estás?",
+    targetLanguage: "es",
+    translation: "How are you?",
+    userLanguage: "en",
+  },
+  {
+    lessonSlugs: ["greetings-introductions"],
+    sentence: "Me llamo María.",
+    targetLanguage: "es",
+    translation: "My name is María.",
+    userLanguage: "en",
+  },
+  {
+    lessonSlugs: ["greetings-introductions"],
+    sentence: "Mucho gusto.",
+    targetLanguage: "es",
+    translation: "Nice to meet you.",
+    userLanguage: "en",
+  },
+  {
+    lessonSlugs: ["greetings-introductions"],
+    sentence: "¿De dónde eres?",
+    targetLanguage: "es",
+    translation: "Where are you from?",
+    userLanguage: "en",
+  },
+  {
+    lessonSlugs: ["greetings-introductions"],
+    sentence: "Hasta luego.",
+    targetLanguage: "es",
+    translation: "See you later.",
+    userLanguage: "en",
+  },
+];
+
+async function seedSentence(
+  prisma: PrismaClient,
+  org: Organization,
+  data: SentenceSeedData,
+): Promise<void> {
+  const sentence = await prisma.sentence.upsert({
+    create: {
+      audioUrl: data.audioUrl,
+      organizationId: org.id,
+      romanization: data.romanization,
+      sentence: data.sentence,
+      targetLanguage: data.targetLanguage,
+      translation: data.translation,
+      userLanguage: data.userLanguage,
+    },
+    update: {},
+    where: {
+      orgSentence: {
+        organizationId: org.id,
+        sentence: data.sentence,
+        targetLanguage: data.targetLanguage,
+        userLanguage: data.userLanguage,
+      },
+    },
+  });
+
+  const lessonSentencePromises = data.lessonSlugs.map(async (lessonSlug) => {
+    const lesson = await prisma.lesson.findFirst({
+      where: {
+        organizationId: org.id,
+        slug: lessonSlug,
+      },
+    });
+
+    if (lesson) {
+      await prisma.lessonSentence.upsert({
+        create: {
+          lessonId: lesson.id,
+          sentenceId: sentence.id,
+        },
+        update: {},
+        where: {
+          lessonSentence: {
+            lessonId: lesson.id,
+            sentenceId: sentence.id,
+          },
+        },
+      });
+    }
+  });
+
+  await Promise.all(lessonSentencePromises);
+}
+
+export async function seedSentences(
+  prisma: PrismaClient,
+  org: Organization,
+): Promise<void> {
+  const sentencePromises = sentencesData.map((data) =>
+    seedSentence(prisma, org, data),
+  );
+  await Promise.all(sentencePromises);
+}

--- a/packages/db/src/prisma/seed/words.ts
+++ b/packages/db/src/prisma/seed/words.ts
@@ -1,0 +1,118 @@
+import type { Organization, PrismaClient } from "../../generated/prisma/client";
+
+type WordSeedData = {
+  targetLanguage: string;
+  userLanguage: string;
+  word: string;
+  translation: string;
+  pronunciation: string;
+  romanization?: string;
+  audioUrl?: string;
+  lessonSlugs: string[];
+};
+
+const wordsData: WordSeedData[] = [
+  {
+    lessonSlugs: ["greetings-introductions"],
+    pronunciation: "OH-lah",
+    targetLanguage: "es",
+    translation: "hello",
+    userLanguage: "en",
+    word: "hola",
+  },
+  {
+    lessonSlugs: ["greetings-introductions"],
+    pronunciation: "BWEH-nohs DEE-ahs",
+    targetLanguage: "es",
+    translation: "good morning",
+    userLanguage: "en",
+    word: "buenos días",
+  },
+  {
+    lessonSlugs: ["greetings-introductions"],
+    pronunciation: "GRAH-syahs",
+    targetLanguage: "es",
+    translation: "thank you",
+    userLanguage: "en",
+    word: "gracias",
+  },
+  {
+    lessonSlugs: ["greetings-introductions"],
+    pronunciation: "ah-DYOHS",
+    targetLanguage: "es",
+    translation: "goodbye",
+    userLanguage: "en",
+    word: "adiós",
+  },
+  {
+    lessonSlugs: ["greetings-introductions"],
+    pronunciation: "pohr fah-BOHR",
+    targetLanguage: "es",
+    translation: "please",
+    userLanguage: "en",
+    word: "por favor",
+  },
+];
+
+async function seedWord(
+  prisma: PrismaClient,
+  org: Organization,
+  data: WordSeedData,
+): Promise<void> {
+  const word = await prisma.word.upsert({
+    create: {
+      audioUrl: data.audioUrl,
+      organizationId: org.id,
+      pronunciation: data.pronunciation,
+      romanization: data.romanization,
+      targetLanguage: data.targetLanguage,
+      translation: data.translation,
+      userLanguage: data.userLanguage,
+      word: data.word,
+    },
+    update: {},
+    where: {
+      orgWord: {
+        organizationId: org.id,
+        targetLanguage: data.targetLanguage,
+        userLanguage: data.userLanguage,
+        word: data.word,
+      },
+    },
+  });
+
+  const lessonWordPromises = data.lessonSlugs.map(async (lessonSlug) => {
+    const lesson = await prisma.lesson.findFirst({
+      where: {
+        organizationId: org.id,
+        slug: lessonSlug,
+      },
+    });
+
+    if (lesson) {
+      await prisma.lessonWord.upsert({
+        create: {
+          lessonId: lesson.id,
+          wordId: word.id,
+        },
+        update: {},
+        where: {
+          lessonWord: {
+            lessonId: lesson.id,
+            wordId: word.id,
+          },
+        },
+      });
+    }
+  });
+
+  await Promise.all(lessonWordPromises);
+}
+
+export async function seedWords(
+  prisma: PrismaClient,
+  org: Organization,
+): Promise<void> {
+  const wordPromises = wordsData.map((data) => seedWord(prisma, org, data));
+  await Promise.all(wordPromises);
+}


### PR DESCRIPTION
## Summary
- Add `Word` and `Sentence` models for storing vocabulary with translations, pronunciation, and romanization
- Create `LessonWord` and `LessonSentence` join tables for many-to-many relationships with lessons
- Remove unused `pronunciation` ActivityKind enum value
- Add seed data with Spanish vocabulary examples

## Test plan
- [x] Run `pnpm format` - passed
- [x] Run `pnpm lint --write --unsafe` - passed
- [x] Run `pnpm db:generate` - passed
- [x] Run `pnpm typecheck` - passed
- [x] Run `pnpm knip` - passed
- [x] Run `pnpm test` - passed
- [x] Run `pnpm --filter main build` - passed
- [x] Run `pnpm --filter editor build` - passed
- [x] Run `pnpm --filter editor build:e2e` - passed
- [x] Run `pnpm --filter editor e2e` - all 189 tests passed

Closes #626

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Word and Sentence models with many-to-many lesson links to store vocabulary (translations, pronunciation, romanization, audio). Removes the unused ActivityKind "pronunciation" and seeds Spanish examples, addressing Linear #626.

- **New Features**
  - New Word and Sentence tables scoped by organization and language, with unique keys and indexes.
  - LessonWord and LessonSentence join tables to attach vocabulary to lessons.
  - Seeded Spanish words and sentences for “greetings-introductions”.

- **Migration**
  - Run Prisma migrate; the ActivityKind "pronunciation" enum value is removed.
  - Ensure no existing activities use "pronunciation" or the migration will fail.

<sup>Written for commit bd0fae389a2d10ca27f84758cd8263e8f9d41044. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

