### PR TITLE
feat(ai): add language audio generation task

### DIFF
--- a/apps/evals/src/app/audio-test/actions.ts
+++ b/apps/evals/src/app/audio-test/actions.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import { generateLanguageAudio } from "@zoonk/core/audio/generate";
+import type { TTSVoice } from "@zoonk/utils/constants";
+import { parseFormField } from "@zoonk/utils/form";
+
+export async function generateAudioAction(formData: FormData) {
+  const text = parseFormField(formData, "text");
+  const voice = parseFormField(formData, "voice") as TTSVoice | undefined;
+  const language = parseFormField(formData, "language") || undefined;
+
+  if (!text) {
+    return { error: "Text is required." };
+  }
+
+  const { data: audioUrl, error } = await generateLanguageAudio({
+    language,
+    orgSlug: "evals",
+    text,
+    voice,
+  });
+
+  if (error) {
+    console.error("Error generating audio:", error);
+    return { error: error.message };
+  }
+
+  return { audioUrl, success: true };
+}

--- a/apps/evals/src/app/audio-test/form.tsx
+++ b/apps/evals/src/app/audio-test/form.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { Button } from "@zoonk/ui/components/button";
+import { Input } from "@zoonk/ui/components/input";
+import { Label } from "@zoonk/ui/components/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@zoonk/ui/components/select";
+import { TTS_VOICES } from "@zoonk/utils/constants";
+import { Loader2 } from "lucide-react";
+import { useState, useTransition } from "react";
+import { generateAudioAction } from "./actions";
+
+export function AudioTestForm() {
+  const [isPending, startTransition] = useTransition();
+  const [result, setResult] = useState<{
+    audioUrl?: string;
+    error?: string;
+  } | null>(null);
+
+  async function handleSubmit(formData: FormData) {
+    startTransition(async () => {
+      setResult(null);
+      const response = await generateAudioAction(formData);
+
+      if ("error" in response) {
+        setResult({ error: response.error });
+      } else if (response.success && response.audioUrl) {
+        setResult({ audioUrl: response.audioUrl });
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <form action={handleSubmit} className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="text">Text to speak</Label>
+          <Input
+            disabled={isPending}
+            id="text"
+            name="text"
+            placeholder="Enter a word or sentence…"
+            required
+            type="text"
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="language">Language (ISO 639-1 code)</Label>
+          <Input
+            disabled={isPending}
+            id="language"
+            name="language"
+            placeholder="e.g. en, es, fr, pt, ja"
+            type="text"
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="voice">Voice</Label>
+          <Select defaultValue="marin" name="voice">
+            <SelectTrigger id="voice">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TTS_VOICES.map((voice) => (
+                <SelectItem key={voice} value={voice}>
+                  {voice}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <Button className="self-start" disabled={isPending} type="submit">
+          {isPending && <Loader2 className="animate-spin" />}
+          Generate Audio
+        </Button>
+      </form>
+
+      {result?.error && (
+        <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-4 text-red-500">
+          <p className="font-medium">Error</p>
+          <p className="text-sm">{result.error}</p>
+        </div>
+      )}
+
+      {result?.audioUrl && (
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <p className="font-medium">Generated Audio</p>
+            {/* biome-ignore lint/a11y/useMediaCaption: internal testing tool doesn't need captions */}
+            <audio controls src={result.audioUrl}>
+              Your browser does not support the audio element.
+            </audio>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="audioUrl">Audio URL</Label>
+            <Input
+              className="font-mono text-sm"
+              id="audioUrl"
+              readOnly
+              value={result.audioUrl}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/evals/src/app/audio-test/page.tsx
+++ b/apps/evals/src/app/audio-test/page.tsx
@@ -1,0 +1,40 @@
+import {
+  BreadcrumbItem,
+  BreadcrumbPage,
+} from "@zoonk/ui/components/breadcrumb";
+import {
+  Container,
+  ContainerBody,
+  ContainerDescription,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
+import { AppBreadcrumb, HomeLinkBreadcrumb } from "@/components/breadcrumb";
+import { AudioTestForm } from "./form";
+
+export default function AudioTestPage() {
+  return (
+    <Container>
+      <AppBreadcrumb>
+        <HomeLinkBreadcrumb />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Audio Test</BreadcrumbPage>
+        </BreadcrumbItem>
+      </AppBreadcrumb>
+
+      <ContainerHeader>
+        <ContainerHeaderGroup>
+          <ContainerTitle>Audio Generator</ContainerTitle>
+          <ContainerDescription>
+            Test AI-generated audio for words and sentences
+          </ContainerDescription>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <AudioTestForm />
+      </ContainerBody>
+    </Container>
+  );
+}

--- a/apps/evals/src/app/page.tsx
+++ b/apps/evals/src/app/page.tsx
@@ -89,6 +89,24 @@ export default function Home() {
           </ItemActions>
         </Item>
 
+        <Item variant="outline">
+          <ItemContent>
+            <ItemTitle>Audio Test</ItemTitle>
+            <ItemDescription>
+              Test AI-generated audio for words and sentences
+            </ItemDescription>
+          </ItemContent>
+
+          <ItemActions>
+            <Link
+              className={buttonVariants({ variant: "outline" })}
+              href="/audio-test"
+            >
+              Test Audio
+            </Link>
+          </ItemActions>
+        </Item>
+
         {TASKS.map((task) => (
           <Item key={task.id} variant="outline">
             <ItemContent>

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -23,6 +23,7 @@
     "./tasks/activities/custom": "./src/tasks/activities/custom/activity-custom.ts",
     "./tasks/activities/language/pronunciation": "./src/tasks/activities/language/activity-pronunciation.ts",
     "./tasks/activities/language/vocabulary": "./src/tasks/activities/language/activity-vocabulary.ts",
+    "./tasks/audio": "./src/tasks/audio/generate-language-audio.ts",
     "./tasks/chapters/lessons": "./src/tasks/chapters/chapter-lessons.ts",
     "./tasks/courses/alternative-titles": "./src/tasks/courses/alternative-titles.ts",
     "./tasks/courses/categories": "./src/tasks/courses/course-categories.ts",

--- a/packages/ai/src/tasks/audio/generate-language-audio.ts
+++ b/packages/ai/src/tasks/audio/generate-language-audio.ts
@@ -1,0 +1,46 @@
+import "server-only";
+
+import { openai } from "@ai-sdk/openai";
+import type { TTSVoice } from "@zoonk/utils/constants";
+import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { experimental_generateSpeech as generateSpeech } from "ai";
+
+const DEFAULT_MODEL = openai.speech("gpt-4o-mini-tts");
+
+export type GenerateLanguageAudioParams = {
+  language?: string;
+  text: string;
+  voice?: TTSVoice;
+};
+
+export type GenerateLanguageAudioResult = {
+  audio: Uint8Array;
+};
+
+export async function generateLanguageAudio({
+  language,
+  text,
+  voice = "marin",
+}: GenerateLanguageAudioParams): Promise<
+  SafeReturn<GenerateLanguageAudioResult>
+> {
+  const { data, error } = await safeAsync(async () => {
+    const { audio } = await generateSpeech({
+      instructions: `Speak clearly and at a moderate pace suitable for language learners. Enunciate each word precisely in this language: ${language}.`,
+      language,
+      model: DEFAULT_MODEL,
+      outputFormat: "opus",
+      text,
+      voice,
+    });
+
+    return { audio: audio.uint8Array };
+  });
+
+  if (error) {
+    console.error("Error generating language audio:", error);
+    return { data: null, error };
+  }
+
+  return { data, error: null };
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,8 @@
   "exports": {
     "./ai": "./src/ai.ts",
     "./alternative-titles/add": "./src/alternative-titles/add-alternative-titles.ts",
+    "./audio/generate": "./src/audio/generate-language-audio.ts",
+    "./audio/upload": "./src/audio/upload-audio.ts",
     "./auth": "./src/auth/auth.ts",
     "./auth/client": "./src/auth/client.ts",
     "./auth/hooks/auth-state": "./src/auth/hooks/auth-state.ts",

--- a/packages/core/src/audio/generate-language-audio.ts
+++ b/packages/core/src/audio/generate-language-audio.ts
@@ -1,0 +1,45 @@
+import "server-only";
+
+import { generateLanguageAudio as generateAudio } from "@zoonk/ai/tasks/audio";
+import type { TTSVoice } from "@zoonk/utils/constants";
+import type { SafeReturn } from "@zoonk/utils/error";
+import { toSlug } from "@zoonk/utils/string";
+import { uploadAudio } from "./upload-audio";
+
+export type GenerateLanguageAudioParams = {
+  language?: string;
+  orgSlug: string;
+  text: string;
+  voice?: TTSVoice;
+};
+
+export async function generateLanguageAudio({
+  language,
+  orgSlug,
+  text,
+  voice,
+}: GenerateLanguageAudioParams): Promise<SafeReturn<string>> {
+  const { data: audioResult, error: generateError } = await generateAudio({
+    language,
+    text,
+    voice,
+  });
+
+  if (generateError) {
+    return { data: null, error: generateError };
+  }
+
+  const slug = toSlug(text);
+  const fileName = `audio/${orgSlug}/${slug}.opus`;
+
+  const { data: url, error: uploadError } = await uploadAudio({
+    audio: audioResult.audio,
+    fileName,
+  });
+
+  if (uploadError) {
+    return { data: null, error: uploadError };
+  }
+
+  return { data: url, error: null };
+}

--- a/packages/core/src/audio/upload-audio.ts
+++ b/packages/core/src/audio/upload-audio.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import { put } from "@vercel/blob";
+import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+
+export type UploadAudioParams = {
+  fileName: string;
+  audio: Uint8Array;
+  access?: "public";
+  addRandomSuffix?: boolean;
+};
+
+export async function uploadAudio({
+  fileName,
+  audio,
+  access = "public",
+  addRandomSuffix = true,
+}: UploadAudioParams): Promise<SafeReturn<string>> {
+  const buffer = Buffer.from(audio);
+
+  const { data: blob, error } = await safeAsync(() =>
+    put(fileName, buffer, { access, addRandomSuffix }),
+  );
+
+  if (error) {
+    console.error("Error uploading audio:", error);
+    return { data: null, error };
+  }
+
+  return { data: blob.url, error: null };
+}

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -12,3 +12,21 @@ export const DEFAULT_IMAGE_ACCEPTED_TYPES = [
 ];
 
 export const DEFAULT_SEARCH_LIMIT = 10;
+
+export const TTS_VOICES = [
+  "alloy",
+  "ash",
+  "ballad",
+  "cedar",
+  "coral",
+  "echo",
+  "fable",
+  "marin",
+  "nova",
+  "onyx",
+  "sage",
+  "shimmer",
+  "verse",
+] as const;
+
+export type TTSVoice = (typeof TTS_VOICES)[number];


### PR DESCRIPTION
## Summary
- Add AI task to generate audio for words/sentences using OpenAI's `gpt-4o-mini-tts` model
- Add core wrapper that generates and uploads audio to Vercel Blob
- Add `TTS_VOICES` constant and `TTSVoice` type to utils
- Add audio test playground in evals app

Closes #629

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds language TTS generation for words and sentences using OpenAI and uploads the audio to Vercel Blob, returning a public URL. Includes a simple evals playground to test voices and languages.

- **New Features**
  - AI task to generate speech with gpt-4o-mini-tts (OPUS output), supporting optional language (ISO 639-1) and selectable voice (default: marin).
  - Core wrapper that generates audio, saves to Vercel Blob, and returns the public URL (path: audio/{orgSlug}/{slug}.opus).
  - New TTS_VOICES constant and TTSVoice type for validated voice selection.
  - Evals app: Audio Test page with form (text, language, voice), audio player, and URL output; linked from the home page.

Closes #629

<sup>Written for commit 8f0e0c36bbd59bb99851b249591c2bad2443f955. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

