### PR TITLE
chore(deps): use typescript native preview

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,6 +37,7 @@
   "editor.formatOnPaste": true,
   "editor.formatOnSave": true,
   "emmet.showExpandedAbbreviation": "never",
+  "typescript.experimental.useTsgo": true,
   "search.exclude": {
     "**/eval-results/**": true,
     "pnpm-lock.yaml": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,14 +37,14 @@
   "editor.formatOnPaste": true,
   "editor.formatOnSave": true,
   "emmet.showExpandedAbbreviation": "never",
-  "typescript.experimental.useTsgo": true,
   "search.exclude": {
-    "**/eval-results/**": true,
-    "pnpm-lock.yaml": true,
     ".agents": true,
     ".claude": true,
     ".codex": true,
     ".github/skills": true,
-    ".opencode": true
-  }
+    ".opencode": true,
+    "**/eval-results/**": true,
+    "pnpm-lock.yaml": true
+  },
+  "typescript.experimental.useTsgo": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,6 +39,11 @@
   "emmet.showExpandedAbbreviation": "never",
   "search.exclude": {
     "**/eval-results/**": true,
-    "pnpm-lock.yaml": true
+    "pnpm-lock.yaml": true,
+    ".agents": true,
+    ".claude": true,
+    ".codex": true,
+    ".github/skills": true,
+    ".opencode": true
   }
 }

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -15,6 +15,7 @@
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
     "@zoonk/tsconfig": "workspace:*",
     "babel-plugin-react-compiler": "1.0.0",
     "typescript": "^5"
@@ -26,7 +27,7 @@
     "build": "next build",
     "dev": "next dev -p 3001",
     "start": "next start -p 3001",
-    "typecheck": "next typegen && tsc --noEmit"
+    "typecheck": "next typegen && tsgo --noEmit"
   },
   "version": "0.1.0"
 }

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -16,6 +16,7 @@
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
     "@zoonk/db": "workspace:*",
     "@zoonk/e2e": "workspace:*",
     "@zoonk/tsconfig": "workspace:*",
@@ -32,7 +33,7 @@
     "e2e": "env $(cat ../../packages/db/.env.e2e | xargs) playwright test",
     "e2e:ui": "env $(cat ../../packages/db/.env.e2e | xargs) playwright test --ui",
     "start": "next start -p 3004",
-    "typecheck": "next typegen && tsc --noEmit"
+    "typecheck": "next typegen && tsgo --noEmit"
   },
   "type": "module",
   "version": "0.1.0"

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -26,6 +26,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/tmp": "0.2.6",
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
     "@zoonk/e2e": "workspace:*",
     "@zoonk/testing": "workspace:*",
     "@zoonk/tsconfig": "workspace:*",
@@ -47,7 +48,7 @@
     "start": "next start -p 3003",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "next typegen && tsc --noEmit"
+    "typecheck": "next typegen && tsgo --noEmit"
   },
   "type": "module",
   "version": "0.1.0"

--- a/apps/evals/package.json
+++ b/apps/evals/package.json
@@ -15,6 +15,7 @@
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
     "@zoonk/tsconfig": "workspace:*",
     "babel-plugin-react-compiler": "1.0.0",
     "raw-loader": "4.0.2",
@@ -28,7 +29,7 @@
     "build-and-start": "pnpm build && pnpm start",
     "dev": "next dev -p 3002",
     "start": "next start -p 3002",
-    "typecheck": "next typegen && tsc --noEmit"
+    "typecheck": "next typegen && tsgo --noEmit"
   },
   "type": "module"
 }

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
     "@zoonk/e2e": "workspace:*",
     "@zoonk/testing": "workspace:*",
     "@zoonk/tsconfig": "workspace:*",
@@ -55,7 +56,7 @@
     "stripe:listen": "stripe listen --forward-to http://localhost:3000/api/auth/stripe/webhook",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "next typegen && tsc --noEmit",
+    "typecheck": "next typegen && tsgo --noEmit",
     "workflow:inspect": "workflow inspect runs",
     "workflow:web": "workflow web"
   },

--- a/knip.json
+++ b/knip.json
@@ -6,6 +6,8 @@
     "@tailwindcss/postcss",
     "@types/react",
     "@types/react-dom",
+    "@typescript/native-preview",
+    "@zoonk/tsconfig",
     "next",
     "next-intl",
     "postcss",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
     "@biomejs/biome": "2.3.11",
     "@playwright/test": "1.57.0",
     "@types/node": "^24",
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
     "knip": "5.80.0",
-    "turbo": "2.7.4",
-    "typescript": "^5"
+    "turbo": "2.7.4"
   },
   "engines": {
     "node": "^24"

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "@types/node": "^24",
     "@zoonk/tsconfig": "workspace:*",
-    "typescript": "^5"
+    "@typescript/native-preview": "7.0.0-dev.20260122.4"
   },
   "exports": {
     "./gateway": "./src/gateway.ts",
@@ -48,7 +48,7 @@
   },
   "private": true,
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "type": "module"
 }

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -7,8 +7,8 @@
   },
   "devDependencies": {
     "@types/node": "^24",
-    "@zoonk/tsconfig": "workspace:*",
-    "@typescript/native-preview": "7.0.0-dev.20260122.4"
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
+    "@zoonk/tsconfig": "workspace:*"
   },
   "exports": {
     "./gateway": "./src/gateway.ts",

--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "compilerOptions": {
-    "baseUrl": "."
-  },
   "exclude": ["node_modules", "dist"],
   "extends": "@zoonk/tsconfig/base.json",
   "include": ["src", "markdown.d.ts"]

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -12,8 +12,8 @@
   "devDependencies": {
     "@types/node": "^24",
     "@types/react": ">=19.2.3",
-    "@zoonk/tsconfig": "workspace:*",
-    "@typescript/native-preview": "7.0.0-dev.20260122.4"
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
+    "@zoonk/tsconfig": "workspace:*"
   },
   "exports": {
     ".": "./src/auth.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -13,7 +13,7 @@
     "@types/node": "^24",
     "@types/react": ">=19.2.3",
     "@zoonk/tsconfig": "workspace:*",
-    "typescript": "^5"
+    "@typescript/native-preview": "7.0.0-dev.20260122.4"
   },
   "exports": {
     ".": "./src/auth.ts",
@@ -33,7 +33,7 @@
   },
   "private": true,
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "type": "module"
 }

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "compilerOptions": {
-    "baseUrl": "."
-  },
   "exclude": ["node_modules", "dist"],
   "extends": "@zoonk/tsconfig/base.json",
   "include": ["src"]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,9 +9,9 @@
   },
   "devDependencies": {
     "@types/react": "^19",
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
     "@zoonk/testing": "workspace:*",
     "@zoonk/tsconfig": "workspace:*",
-    "@typescript/native-preview": "7.0.0-dev.20260122.4",
     "vite-tsconfig-paths": "6.0.3",
     "vitest": "4.0.16"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
     "@types/react": "^19",
     "@zoonk/testing": "workspace:*",
     "@zoonk/tsconfig": "workspace:*",
-    "typescript": "^5",
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
     "vite-tsconfig-paths": "6.0.3",
     "vitest": "4.0.16"
   },
@@ -53,7 +53,7 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "type": "module"
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/fixtures/*": ["./test/fixtures/*"]
     }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -8,11 +8,11 @@
   },
   "devDependencies": {
     "@types/pg": "8.16.0",
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
     "@zoonk/tsconfig": "workspace:*",
     "dotenv": "17.2.3",
     "prisma": "7.3.0",
-    "tsx": "4.20.6",
-    "@typescript/native-preview": "7.0.0-dev.20260122.4"
+    "tsx": "4.20.6"
   },
   "exports": {
     ".": "./src/index.ts",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,7 +12,7 @@
     "dotenv": "17.2.3",
     "prisma": "7.3.0",
     "tsx": "4.20.6",
-    "typescript": "^5"
+    "@typescript/native-preview": "7.0.0-dev.20260122.4"
   },
   "exports": {
     ".": "./src/index.ts",
@@ -37,7 +37,7 @@
     "db:setup:e2e": "env $(cat .env.e2e | xargs) prisma migrate deploy",
     "db:setup:test": "env $(cat .env.test | xargs) prisma migrate deploy",
     "db:studio": "prisma studio",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "type": "module"
 }

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "compilerOptions": {
-    "baseUrl": "."
-  },
   "exclude": ["node_modules", "dist"],
   "extends": "@zoonk/tsconfig/base.json",
   "include": ["src", "prisma.config.ts"]

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -4,8 +4,8 @@
   },
   "devDependencies": {
     "@types/node": "^24",
-    "@zoonk/tsconfig": "workspace:*",
-    "@typescript/native-preview": "7.0.0-dev.20260122.4"
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
+    "@zoonk/tsconfig": "workspace:*"
   },
   "exports": {
     "./base.config": "./src/base.config.ts",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@types/node": "^24",
     "@zoonk/tsconfig": "workspace:*",
-    "typescript": "^5"
+    "@typescript/native-preview": "7.0.0-dev.20260122.4"
   },
   "exports": {
     "./base.config": "./src/base.config.ts",
@@ -14,7 +14,7 @@
   "name": "@zoonk/e2e",
   "private": true,
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "type": "module"
 }

--- a/packages/e2e/tsconfig.json
+++ b/packages/e2e/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "compilerOptions": {
-    "baseUrl": "."
-  },
   "exclude": ["node_modules", "dist"],
   "extends": "@zoonk/tsconfig/base.json",
   "include": ["src"]

--- a/packages/error-reporter/package.json
+++ b/packages/error-reporter/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@types/node": "^24",
     "@zoonk/tsconfig": "workspace:*",
-    "typescript": "^5"
+    "@typescript/native-preview": "7.0.0-dev.20260122.4"
   },
   "exports": {
     "./client": "./src/client.ts",
@@ -23,7 +23,7 @@
   },
   "private": true,
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "type": "module"
 }

--- a/packages/error-reporter/package.json
+++ b/packages/error-reporter/package.json
@@ -4,8 +4,8 @@
   },
   "devDependencies": {
     "@types/node": "^24",
-    "@zoonk/tsconfig": "workspace:*",
-    "@typescript/native-preview": "7.0.0-dev.20260122.4"
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
+    "@zoonk/tsconfig": "workspace:*"
   },
   "exports": {
     "./client": "./src/client.ts",

--- a/packages/error-reporter/tsconfig.json
+++ b/packages/error-reporter/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "compilerOptions": {
-    "baseUrl": "."
-  },
   "exclude": ["node_modules", "dist"],
   "extends": "@zoonk/tsconfig/base.json",
   "include": ["src"]

--- a/packages/mailer/package.json
+++ b/packages/mailer/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@types/node": "^24",
     "@zoonk/tsconfig": "workspace:*",
-    "typescript": "^5"
+    "@typescript/native-preview": "7.0.0-dev.20260122.4"
   },
   "exports": {
     ".": "./src/client.ts"
@@ -13,7 +13,7 @@
   "name": "@zoonk/mailer",
   "private": true,
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "type": "module"
 }

--- a/packages/mailer/package.json
+++ b/packages/mailer/package.json
@@ -4,8 +4,8 @@
   },
   "devDependencies": {
     "@types/node": "^24",
-    "@zoonk/tsconfig": "workspace:*",
-    "@typescript/native-preview": "7.0.0-dev.20260122.4"
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
+    "@zoonk/tsconfig": "workspace:*"
   },
   "exports": {
     ".": "./src/client.ts"

--- a/packages/mailer/tsconfig.json
+++ b/packages/mailer/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "compilerOptions": {
-    "baseUrl": "."
-  },
   "exclude": ["node_modules", "dist"],
   "extends": "@zoonk/tsconfig/base.json",
   "include": ["src"]

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -7,7 +7,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@zoonk/tsconfig": "workspace:*",
-    "typescript": "^5"
+    "@typescript/native-preview": "7.0.0-dev.20260122.4"
   },
   "exports": {
     "./i18n/codec": "./src/i18n/next-intl-codec.ts"
@@ -26,7 +26,7 @@
   },
   "private": true,
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "type": "module",
   "version": "0.0.0"

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -6,8 +6,8 @@
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@zoonk/tsconfig": "workspace:*",
-    "@typescript/native-preview": "7.0.0-dev.20260122.4"
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
+    "@zoonk/tsconfig": "workspace:*"
   },
   "exports": {
     "./i18n/codec": "./src/i18n/next-intl-codec.ts"

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "compilerOptions": {
-    "baseUrl": "."
-  },
   "exclude": ["node_modules", "dist"],
   "extends": "@zoonk/tsconfig/nextjs.json",
   "include": ["src"]

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -6,8 +6,8 @@
   },
   "devDependencies": {
     "@types/node": "^24",
-    "@zoonk/tsconfig": "workspace:*",
-    "@typescript/native-preview": "7.0.0-dev.20260122.4"
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
+    "@zoonk/tsconfig": "workspace:*"
   },
   "exports": {
     "./fixtures/activities": "./src/fixtures/activities.ts",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "@types/node": "^24",
     "@zoonk/tsconfig": "workspace:*",
-    "typescript": "^5"
+    "@typescript/native-preview": "7.0.0-dev.20260122.4"
   },
   "exports": {
     "./fixtures/activities": "./src/fixtures/activities.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,10 +18,10 @@
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
     "@zoonk/tsconfig": "workspace:*",
     "tailwindcss": "^4",
-    "tw-animate-css": "1.3.8",
-    "@typescript/native-preview": "7.0.0-dev.20260122.4"
+    "tw-animate-css": "1.3.8"
   },
   "exports": {
     "./components/*": "./src/components/*.tsx",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,7 +21,7 @@
     "@zoonk/tsconfig": "workspace:*",
     "tailwindcss": "^4",
     "tw-animate-css": "1.3.8",
-    "typescript": "^5"
+    "@typescript/native-preview": "7.0.0-dev.20260122.4"
   },
   "exports": {
     "./components/*": "./src/components/*.tsx",
@@ -50,7 +50,7 @@
   },
   "private": true,
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "type": "module",
   "version": "0.0.0"

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@zoonk/ui/*": ["./src/*"]
     }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,7 +4,7 @@
   },
   "devDependencies": {
     "@zoonk/tsconfig": "workspace:*",
-    "typescript": "^5",
+    "@typescript/native-preview": "7.0.0-dev.20260122.4",
     "vite-tsconfig-paths": "6.0.3",
     "vitest": "4.0.16"
   },
@@ -25,7 +25,7 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "type": "module"
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,8 +3,8 @@
     "slugify": "1.6.6"
   },
   "devDependencies": {
-    "@zoonk/tsconfig": "workspace:*",
     "@typescript/native-preview": "7.0.0-dev.20260122.4",
+    "@zoonk/tsconfig": "workspace:*",
     "vite-tsconfig-paths": "6.0.3",
     "vitest": "4.0.16"
   },

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "compilerOptions": {
-    "baseUrl": "."
-  },
   "exclude": ["node_modules", "dist"],
   "extends": "@zoonk/tsconfig/base.json",
   "include": ["src", "vitest.config.mts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: 1.0.0
         version: 1.0.0
+      typescript:
+        specifier: ^5
+        version: 5.9.3
 
   apps/auth:
     dependencies:
@@ -140,7 +143,7 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       typescript:
-        specifier: 5.9.3
+        specifier: ^5
         version: 5.9.3
 
   apps/editor:
@@ -236,6 +239,9 @@ importers:
       tmp:
         specifier: 0.2.5
         version: 0.2.5
+      typescript:
+        specifier: ^5
+        version: 5.9.3
       vite-tsconfig-paths:
         specifier: 6.0.3
         version: 6.0.3(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6))
@@ -297,6 +303,9 @@ importers:
       raw-loader:
         specifier: 4.0.2
         version: 4.0.2(webpack@5.104.1)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
 
   apps/main:
     dependencies:
@@ -412,6 +421,9 @@ importers:
       tsx:
         specifier: 4.20.5
         version: 4.20.5
+      typescript:
+        specifier: ^5
+        version: 5.9.3
       vite-tsconfig-paths:
         specifier: 6.0.3
         version: 6.0.3(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,15 +17,15 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.10.8
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       knip:
         specifier: 5.80.0
         version: 5.80.0(@types/node@24.10.8)(typescript@5.9.3)
       turbo:
         specifier: 2.7.4
         version: 2.7.4
-      typescript:
-        specifier: ^5
-        version: 5.9.3
 
   apps/admin:
     dependencies:
@@ -69,15 +69,15 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.8)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig
       babel-plugin-react-compiler:
         specifier: 1.0.0
         version: 1.0.0
-      typescript:
-        specifier: ^5
-        version: 5.9.3
 
   apps/auth:
     dependencies:
@@ -124,6 +124,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.8)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       '@zoonk/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -137,7 +140,7 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       typescript:
-        specifier: ^5
+        specifier: 5.9.3
         version: 5.9.3
 
   apps/editor:
@@ -215,6 +218,9 @@ importers:
       '@types/tmp':
         specifier: 0.2.6
         version: 0.2.6
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       '@zoonk/e2e':
         specifier: workspace:*
         version: link:../../packages/e2e
@@ -230,9 +236,6 @@ importers:
       tmp:
         specifier: 0.2.5
         version: 0.2.5
-      typescript:
-        specifier: ^5
-        version: 5.9.3
       vite-tsconfig-paths:
         specifier: 6.0.3
         version: 6.0.3(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6))
@@ -282,6 +285,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.8)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -291,9 +297,6 @@ importers:
       raw-loader:
         specifier: 4.0.2
         version: 4.0.2(webpack@5.104.1)
-      typescript:
-        specifier: ^5
-        version: 5.9.3
 
   apps/main:
     dependencies:
@@ -385,6 +388,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.8)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       '@zoonk/e2e':
         specifier: workspace:*
         version: link:../../packages/e2e
@@ -406,9 +412,6 @@ importers:
       tsx:
         specifier: 4.20.5
         version: 4.20.5
-      typescript:
-        specifier: ^5
-        version: 5.9.3
       vite-tsconfig-paths:
         specifier: 6.0.3
         version: 6.0.3(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5))
@@ -440,12 +443,12 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.10.8
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      typescript:
-        specifier: ^5
-        version: 5.9.3
 
   packages/auth:
     dependencies:
@@ -486,12 +489,12 @@ importers:
       '@types/react':
         specifier: '>=19.2.3'
         version: 19.2.8
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      typescript:
-        specifier: ^5
-        version: 5.9.3
 
   packages/core:
     dependencies:
@@ -529,15 +532,15 @@ importers:
       '@types/react':
         specifier: ^19
         version: 19.2.8
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       '@zoonk/testing':
         specifier: workspace:*
         version: link:../testing
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      typescript:
-        specifier: ^5
-        version: 5.9.3
       vite-tsconfig-paths:
         specifier: 6.0.3
         version: 6.0.3(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6))
@@ -569,6 +572,9 @@ importers:
       '@types/pg':
         specifier: 8.16.0
         version: 8.16.0
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -581,9 +587,6 @@ importers:
       tsx:
         specifier: 4.20.6
         version: 4.20.6
-      typescript:
-        specifier: ^5
-        version: 5.9.3
 
   packages/e2e:
     dependencies:
@@ -594,12 +597,12 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.10.8
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      typescript:
-        specifier: ^5
-        version: 5.9.3
 
   packages/error-reporter:
     dependencies:
@@ -613,12 +616,12 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.10.8
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      typescript:
-        specifier: ^5
-        version: 5.9.3
 
   packages/mailer:
     dependencies:
@@ -629,12 +632,12 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.10.8
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      typescript:
-        specifier: ^5
-        version: 5.9.3
 
   packages/next:
     dependencies:
@@ -663,12 +666,12 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.8)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      typescript:
-        specifier: ^5
-        version: 5.9.3
 
   packages/testing:
     dependencies:
@@ -685,12 +688,12 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.10.8
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      typescript:
-        specifier: ^5
-        version: 5.9.3
 
   packages/tsconfig: {}
 
@@ -757,6 +760,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.8)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -766,9 +772,6 @@ importers:
       tw-animate-css:
         specifier: 1.3.8
         version: 1.3.8
-      typescript:
-        specifier: ^5
-        version: 5.9.3
 
   packages/utils:
     dependencies:
@@ -776,12 +779,12 @@ importers:
         specifier: 1.6.6
         version: 1.6.6
     devDependencies:
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260122.4
+        version: 7.0.0-dev.20260122.4
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      typescript:
-        specifier: ^5
-        version: 5.9.3
       vite-tsconfig-paths:
         specifier: 6.0.3
         version: 6.0.3(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6))
@@ -2965,6 +2968,45 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260122.4':
+    resolution: {integrity: sha512-8hIIPe6LoY+FmUBRvhX7IbsZCr4Puwps0Ok+ez+rzg7d+sJCVuJ37ZxFh1pcNJEM39eII2o5TZ9dTCIT7/aAWA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260122.4':
+    resolution: {integrity: sha512-kJNpVzPW9jcFuRco+QwSHToEFHmfovNmwLo9PY97DLMqGnrvxkSy+k5sClHscEThIdzSRQbi7uZJUVBwgohNmA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260122.4':
+    resolution: {integrity: sha512-QsSNK3PbRyNviv0xru21jGV8fgzTVJ26oMnQwoK0IcyGabXtcLHJe5I5y4lwvLNjZPCbKDNThawso54Fo72FJQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260122.4':
+    resolution: {integrity: sha512-ImSMhsrB9QMK/cT2s4yCWkWOBUGZ+1L6vBaMMdyw3eNrU4tQo85Z3AqTn12M8WRbefLL89OmP6zJppP2TH3PAQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260122.4':
+    resolution: {integrity: sha512-0OyzmbZ2Zq039RPLCyEjcrBhDkCXDfIrwbMJfoOrCyEO9XrK9Icwqzogm7H4bLyhcfuZIgugYSP2mQflaDvOVg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260122.4':
+    resolution: {integrity: sha512-FSRZ0iylGKbrYiimfkqKBXRlhR+PwOz5Jcb57dAU7wzr/7xSGON9bfywb0BhoF31GjYAnZ5Xv+1fuQOiB2HBYw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260122.4':
+    resolution: {integrity: sha512-vAzRnS4nMBAd2XduzdmrhsCAAVSbCzZxVGMIKVvRcL9ljO5+fooggiYq7sk798TIZ1ov7A0rZk5k+o0Wyx2nXA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260122.4':
+    resolution: {integrity: sha512-lboRukXxL3jeIyMKc4EjNHI4QThjOrrT5jjCyaNOUFkrk3JiObrR4z7Z6Z+m+WM/gbSW2tqaRBRFBRMsZGsxKQ==}
+    hasBin: true
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -7991,6 +8033,37 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260122.4':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260122.4':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260122.4':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260122.4':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260122.4':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260122.4':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260122.4':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260122.4':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260122.4
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260122.4
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260122.4
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260122.4
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260122.4
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260122.4
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260122.4
 
   '@ungap/structured-clone@1.3.0': {}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch to TypeScript Native Preview and the tsgo CLI for type checking. Replaces tsc across the monorepo and configures VS Code to use tsgo.

- **Dependencies**
  - Added @typescript/native-preview 7.0.0-dev.20260122.4 and optional platform binaries.
  - Removed typescript and updated all typecheck scripts to use tsgo.
  - Updated pnpm-lock.yaml.
  - Enabled typescript.experimental.useTsgo in VS Code settings.

- **Migration**
  - Run pnpm install to download native binaries for your OS.
  - Use the existing typecheck scripts; they now run tsgo (not tsc).
  - If VS Code doesn’t pick up tsgo, reload the window.

<sup>Written for commit 0824baea0b8c93986a2759e2f87cd9a122a750b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

