### PR TITLE
chore(lint): enable restriction category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ debug.log
 
 # Tasks for AI agents
 /tasks/
+
+# pnpm
+.pnpm-store/

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,3 @@ debug.log
 
 # Tasks for AI agents
 /tasks/
-
-# pnpm
-.pnpm-store/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+store-dir=.pnpm-store

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-store-dir=.pnpm-store

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -94,7 +94,8 @@
     "eslint/no-plusplus": "error",
     "typescript/use-unknown-in-catch-callback-variable": "error",
     "import/no-default-export": "error",
-    "import/unambiguous": "error"
+    "import/unambiguous": "error",
+    "react/button-has-type": "error"
   },
   "overrides": [
     {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -76,6 +76,7 @@
     "typescript/promise-function-async": "off",
     "typescript/require-await": "off",
     "typescript/strict-boolean-expressions": "off",
+    "unicorn/no-array-for-each": "off",
     "unicorn/no-null": "off",
     "unicorn/prefer-bigint-literals": "off",
     "unicorn/prefer-native-coercion-functions": "off",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -85,7 +85,8 @@
     "zoonk/no-single-use-type-alias": "error",
 
     // temporary rules
-    "eslint/default-case": "error"
+    "eslint/default-case": "error",
+    "typescript/no-non-null-assertion": "error"
   },
   "overrides": [
     {
@@ -128,6 +129,7 @@
         "eslint/max-statements": "off",
         "eslint/no-magic-numbers": "off",
         "import/no-namespace": "off",
+        "typescript/no-non-null-assertion": "off",
         "typescript/no-unsafe-assignment": "off",
         "typescript/no-unsafe-call": "off",
         "typescript/no-unsafe-member-access": "off",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -86,7 +86,8 @@
 
     // temporary rules
     "eslint/default-case": "error",
-    "typescript/no-non-null-assertion": "error"
+    "typescript/no-non-null-assertion": "error",
+    "eslint/no-param-reassign": "error"
   },
   "overrides": [
     {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -63,6 +63,7 @@
     "react/jsx-handler-names": "off",
     "react/jsx-props-no-spreading": "off",
     "react/jsx-pascal-case": ["error", { "allowAllCaps": true }],
+    "react/only-export-components": "off",
     "react/react-in-jsx-scope": "off",
     "typescript/consistent-type-definitions": ["error", "type"],
     "typescript/explicit-function-return-type": "off",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -71,6 +71,7 @@
     "typescript/no-misused-promises": ["error", { "checksVoidReturn": false }],
     "typescript/no-unsafe-type-assertion": "error",
     "typescript/prefer-nullish-coalescing": "off",
+    "typescript/promise-function-async": "off",
     "typescript/require-await": "off",
     "typescript/strict-boolean-expressions": "off",
     "unicorn/no-null": "off",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -28,6 +28,7 @@
     ],
     "eslint/max-params": "off",
     "eslint/max-statements": ["error", { "ignoreTopLevelFunctions": true, "max": 20 }],
+    "eslint/no-console": ["error", { "allow": ["error", "info"] }],
     "eslint/no-inline-comments": "off",
     "eslint/no-magic-numbers": [
       "error",
@@ -62,6 +63,7 @@
     "react/react-in-jsx-scope": "off",
     "typescript/consistent-type-definitions": ["error", "type"],
     "typescript/explicit-function-return-type": "off",
+    "typescript/explicit-module-boundary-types": "off",
     "typescript/no-confusing-void-expression": ["error", { "ignoreArrowShorthand": true }],
     "typescript/no-import-type-side-effects": "off",
     "typescript/no-misused-promises": ["error", { "checksVoidReturn": false }],

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -93,7 +93,8 @@
     "eslint/no-param-reassign": "error",
     "eslint/no-plusplus": "error",
     "typescript/use-unknown-in-catch-callback-variable": "error",
-    "import/no-default-export": "error"
+    "import/no-default-export": "error",
+    "import/unambiguous": "error"
   },
   "overrides": [
     {
@@ -203,6 +204,12 @@
       ],
       "rules": {
         "import/no-default-export": "off"
+      }
+    },
+    {
+      "files": ["**/*.d.ts"],
+      "rules": {
+        "import/unambiguous": "off"
       }
     }
   ],

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -39,6 +39,7 @@
     ],
     "import/no-named-as-default": "off",
     "eslint/no-ternary": "off",
+    "eslint/no-undefined": "off",
     "eslint/prefer-destructuring": "off",
     "eslint/require-await": "off",
     "eslint/sort-imports": ["error", { "ignoreDeclarationSort": true }],

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -60,6 +60,7 @@
     "oxc/no-async-await": "off",
     "oxc/no-barrel-file": ["error", { "threshold": 0 }],
     "oxc/no-map-spread": "off",
+    "oxc/no-optional-chaining": "off",
     "react/jsx-filename-extension": ["error", { "extensions": ["tsx"] }],
     "react/jsx-handler-names": "off",
     "react/jsx-props-no-spreading": "off",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -99,7 +99,8 @@
     "import/no-default-export": "error",
     "import/unambiguous": "error",
     "react/button-has-type": "error",
-    "unicorn/no-process-exit": "error"
+    "unicorn/no-process-exit": "error",
+    "unicorn/no-document-cookie": "error"
   },
   "overrides": [
     {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -91,7 +91,8 @@
     "eslint/default-case": "error",
     "typescript/no-non-null-assertion": "error",
     "eslint/no-param-reassign": "error",
-    "eslint/no-plusplus": "error"
+    "eslint/no-plusplus": "error",
+    "typescript/use-unknown-in-catch-callback-variable": "error"
   },
   "overrides": [
     {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -61,7 +61,9 @@
     "react/jsx-pascal-case": ["error", { "allowAllCaps": true }],
     "react/react-in-jsx-scope": "off",
     "typescript/consistent-type-definitions": ["error", "type"],
+    "typescript/explicit-function-return-type": "off",
     "typescript/no-confusing-void-expression": ["error", { "ignoreArrowShorthand": true }],
+    "typescript/no-import-type-side-effects": "off",
     "typescript/no-misused-promises": ["error", { "checksVoidReturn": false }],
     "typescript/no-unsafe-type-assertion": "error",
     "typescript/prefer-nullish-coalescing": "off",
@@ -78,7 +80,10 @@
 
     // custom rules
     "zoonk/no-object-params-in-cache": ["error", { "exceptions": ["headers"] }],
-    "zoonk/no-single-use-type-alias": "error"
+    "zoonk/no-single-use-type-alias": "error",
+
+    // temporary rules
+    "eslint/default-case": "error"
   },
   "overrides": [
     {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -98,7 +98,8 @@
     "typescript/use-unknown-in-catch-callback-variable": "error",
     "import/no-default-export": "error",
     "import/unambiguous": "error",
-    "react/button-has-type": "error"
+    "react/button-has-type": "error",
+    "unicorn/no-process-exit": "error"
   },
   "overrides": [
     {
@@ -124,6 +125,7 @@
         "eslint/max-statements": "off",
         "eslint/no-magic-numbers": "off",
         "import/no-namespace": "off",
+        "unicorn/no-process-exit": "off",
         "unicorn/prefer-top-level-await": "off"
       }
     },

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -57,6 +57,7 @@
     "jest/no-untyped-mock-factory": "off",
     "jsx-max-depth": ["error", { "max": 5 }],
     "jsx-a11y/no-autofocus": "off",
+    "oxc/no-async-await": "off",
     "oxc/no-barrel-file": ["error", { "threshold": 0 }],
     "oxc/no-map-spread": "off",
     "react/jsx-filename-extension": ["error", { "extensions": ["tsx"] }],

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -92,7 +92,8 @@
     "typescript/no-non-null-assertion": "error",
     "eslint/no-param-reassign": "error",
     "eslint/no-plusplus": "error",
-    "typescript/use-unknown-in-catch-callback-variable": "error"
+    "typescript/use-unknown-in-catch-callback-variable": "error",
+    "import/no-default-export": "error"
   },
   "overrides": [
     {
@@ -181,6 +182,27 @@
       "files": ["**/proxy.ts"],
       "rules": {
         "unicorn/prefer-string-raw": "off"
+      }
+    },
+    {
+      "files": [
+        "**/page.tsx",
+        "**/layout.tsx",
+        "**/error.tsx",
+        "**/loading.tsx",
+        "**/unauthorized.tsx",
+        "**/not-found.tsx",
+        "**/global-error.tsx",
+        "**/*codec.ts",
+        "**/request.ts",
+        "**/*.config.ts",
+        "**/*.mjs",
+        "**/*.mts",
+        "**/*.js",
+        "**/e2e/**/*.ts"
+      ],
+      "rules": {
+        "import/no-default-export": "off"
       }
     }
   ],

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -59,6 +59,7 @@
     "jsx-a11y/no-autofocus": "off",
     "oxc/no-barrel-file": ["error", { "threshold": 0 }],
     "oxc/no-map-spread": "off",
+    "react/jsx-filename-extension": ["error", { "extensions": ["tsx"] }],
     "react/jsx-handler-names": "off",
     "react/jsx-props-no-spreading": "off",
     "react/jsx-pascal-case": ["error", { "allowAllCaps": true }],

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -40,6 +40,7 @@
     "import/no-named-as-default": "off",
     "eslint/no-ternary": "off",
     "eslint/no-undefined": "off",
+    "eslint/no-void": "off",
     "eslint/prefer-destructuring": "off",
     "eslint/require-await": "off",
     "eslint/sort-imports": ["error", { "ignoreDeclarationSort": true }],

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -11,6 +11,7 @@
     "correctness": "error",
     "pedantic": "error",
     "perf": "error",
+    "restriction": "error",
     "style": "error",
     "suspicious": "error"
   },
@@ -61,6 +62,7 @@
     "oxc/no-barrel-file": ["error", { "threshold": 0 }],
     "oxc/no-map-spread": "off",
     "oxc/no-optional-chaining": "off",
+    "oxc/no-rest-spread-properties": "off",
     "react/jsx-filename-extension": ["error", { "extensions": ["tsx"] }],
     "react/jsx-handler-names": "off",
     "react/jsx-props-no-spreading": "off",
@@ -90,19 +92,7 @@
 
     // custom rules
     "zoonk/no-object-params-in-cache": ["error", { "exceptions": ["headers"] }],
-    "zoonk/no-single-use-type-alias": "error",
-
-    // temporary rules
-    "eslint/default-case": "error",
-    "typescript/no-non-null-assertion": "error",
-    "eslint/no-param-reassign": "error",
-    "eslint/no-plusplus": "error",
-    "typescript/use-unknown-in-catch-callback-variable": "error",
-    "import/no-default-export": "error",
-    "import/unambiguous": "error",
-    "react/button-has-type": "error",
-    "unicorn/no-process-exit": "error",
-    "unicorn/no-document-cookie": "error"
+    "zoonk/no-single-use-type-alias": "error"
   },
   "overrides": [
     {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -87,7 +87,8 @@
     // temporary rules
     "eslint/default-case": "error",
     "typescript/no-non-null-assertion": "error",
-    "eslint/no-param-reassign": "error"
+    "eslint/no-param-reassign": "error",
+    "eslint/no-plusplus": "error"
   },
   "overrides": [
     {

--- a/apps/admin/src/app/(private)/courses/course-list.tsx
+++ b/apps/admin/src/app/(private)/courses/course-list.tsx
@@ -4,7 +4,7 @@ import { parseSearchParams } from "@/lib/parse-search-params";
 import { Table, TableBody, TableHead, TableHeader, TableRow } from "@zoonk/ui/components/table";
 import { CourseRow } from "./course-row";
 
-export default async function CourseList({
+export async function CourseList({
   searchParams,
 }: {
   searchParams: PageProps<"/courses">["searchParams"];

--- a/apps/admin/src/app/(private)/courses/page.tsx
+++ b/apps/admin/src/app/(private)/courses/page.tsx
@@ -8,7 +8,7 @@ import {
 } from "@zoonk/ui/components/container";
 import { type Metadata } from "next";
 import { Suspense } from "react";
-import CourseList from "./course-list";
+import { CourseList } from "./course-list";
 import { CourseSearch } from "./course-search";
 
 export const metadata: Metadata = {

--- a/apps/admin/src/app/(private)/users/page.tsx
+++ b/apps/admin/src/app/(private)/users/page.tsx
@@ -8,7 +8,7 @@ import {
 } from "@zoonk/ui/components/container";
 import { type Metadata } from "next";
 import { Suspense } from "react";
-import UserList from "./user-list";
+import { UserList } from "./user-list";
 import { UserSearch } from "./user-search";
 
 export const metadata: Metadata = {

--- a/apps/admin/src/app/(private)/users/user-list.tsx
+++ b/apps/admin/src/app/(private)/users/user-list.tsx
@@ -4,7 +4,7 @@ import { parseSearchParams } from "@/lib/parse-search-params";
 import { Table, TableBody, TableHead, TableHeader, TableRow } from "@zoonk/ui/components/table";
 import { UserRow } from "./user-row";
 
-export default async function UserList({
+export async function UserList({
   searchParams,
 }: {
   searchParams: PageProps<"/users">["searchParams"];

--- a/apps/auth/e2e/helpers/db.ts
+++ b/apps/auth/e2e/helpers/db.ts
@@ -14,7 +14,7 @@ const RETRY_DELAY_MS = 500;
 export async function getOTPForEmail(email: string, maxRetries = 10): Promise<string | null> {
   const identifier = `sign-in-otp-${email}`;
 
-  for (let i = 0; i < maxRetries; i++) {
+  for (let i = 0; i < maxRetries; i += 1) {
     // eslint-disable-next-line no-await-in-loop -- Intentional retry polling
     const verification = await prisma.verification.findFirst({
       orderBy: { createdAt: "desc" },

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -26,7 +26,6 @@
     "@zoonk/next": "workspace:*",
     "@zoonk/ui": "workspace:*",
     "@zoonk/utils": "workspace:*",
-    "js-cookie": "3.0.5",
     "lucide-react": "0.562.0",
     "negotiator": "1.0.0",
     "next": "16.1.0",
@@ -36,7 +35,6 @@
     "server-only": "0.0.1"
   },
   "devDependencies": {
-    "@types/js-cookie": "3.0.6",
     "@types/negotiator": "0.6.4",
     "@types/node": "^24",
     "@types/react": "^19",

--- a/apps/editor/src/components/navbar/locale-switcher.tsx
+++ b/apps/editor/src/components/navbar/locale-switcher.tsx
@@ -6,8 +6,8 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
 } from "@zoonk/ui/components/dropdown-menu";
+import { setCookie } from "@zoonk/utils/cookies";
 import { LOCALE_LABELS, SUPPORTED_LOCALES } from "@zoonk/utils/locale";
-import Cookies from "js-cookie";
 import { CheckIcon, LanguagesIcon } from "lucide-react";
 import { useExtracted, useLocale } from "next-intl";
 
@@ -16,7 +16,7 @@ export function LocaleSwitcher() {
   const locale = useLocale();
 
   function onLocaleChange(nextLocale: string) {
-    Cookies.set("locale", nextLocale, { expires: 365, sameSite: "lax" });
+    setCookie("locale", nextLocale, { expires: 365, sameSite: "lax" });
     globalThis.location.reload();
   }
 

--- a/apps/evals/src/lib/battle-loader.ts
+++ b/apps/evals/src/lib/battle-loader.ts
@@ -61,7 +61,7 @@ function aggregateScoresFromMatchups(matchups: BattleMatchup[]): {
 
   for (const matchup of matchups) {
     for (const judgment of matchup.judgments) {
-      totalJudgments++;
+      totalJudgments += 1;
       for (const ranking of judgment.rankings) {
         const existing = modelScores.get(ranking.modelId) ?? {
           scoresByJudge: {},

--- a/apps/evals/src/lib/battle-runner.ts
+++ b/apps/evals/src/lib/battle-runner.ts
@@ -30,7 +30,7 @@ function getMatchupFilePath(taskId: string, testCaseId: string): string {
 
 function shuffleArray<T>(array: T[]): T[] {
   const shuffled = [...array];
-  for (let i = shuffled.length - 1; i > 0; i--) {
+  for (let i = shuffled.length - 1; i > 0; i -= 1) {
     const j = Math.floor(Math.random() * (i + 1));
     const temp = shuffled[i];
     shuffled[i] = shuffled[j] as T;
@@ -246,7 +246,7 @@ export async function runBattleMode(task: Task): Promise<void> {
       const existingMatchup = await loadExistingMatchup(task.id, testCaseId);
       const result = await runBattleForTestCase(task, testCase, completeOutputs, existingMatchup);
 
-      completedBattles++;
+      completedBattles += 1;
       const remaining = totalBattles - completedBattles;
       console.info(`Battle complete for ${testCaseId}, ${remaining} remaining`);
 

--- a/apps/evals/src/lib/output-generator.ts
+++ b/apps/evals/src/lib/output-generator.ts
@@ -53,7 +53,7 @@ type TestCaseRun = { testCase: TestCase; runNumber: number };
 function collectTestCaseRuns(testCases: TestCase[], existingEntries: OutputEntry[]): TestCaseRun[] {
   const runs: TestCaseRun[] = [];
   for (const testCase of testCases) {
-    for (let runNumber = 1; runNumber <= RUNS_PER_TEST_CASE; runNumber++) {
+    for (let runNumber = 1; runNumber <= RUNS_PER_TEST_CASE; runNumber += 1) {
       if (!shouldSkipTestCase(existingEntries, testCase.id, runNumber)) {
         runs.push({ runNumber, testCase });
       }

--- a/apps/main/src/app/[locale]/(performance)/_lib/chart-payload.ts
+++ b/apps/main/src/app/[locale]/(performance)/_lib/chart-payload.ts
@@ -1,4 +1,6 @@
-export function isValidChartPayload<T>(payload: unknown): payload is { payload: T }[] {
+export function isValidChartPayload<T>(
+  payload: unknown,
+): payload is [{ payload: T }, ...{ payload: T }[]] {
   if (!Array.isArray(payload) || payload.length === 0) {
     return false;
   }

--- a/apps/main/src/app/[locale]/(performance)/energy/energy-chart-client.tsx
+++ b/apps/main/src/app/[locale]/(performance)/energy/energy-chart-client.tsx
@@ -66,7 +66,7 @@ export function EnergyChartClient({
                 return null;
               }
 
-              const data = payload[0]!.payload;
+              const data = payload[0].payload;
               const value = Number(data.energy).toFixed(1);
 
               return (

--- a/apps/main/src/app/[locale]/(performance)/level/level-chart-client.tsx
+++ b/apps/main/src/app/[locale]/(performance)/level/level-chart-client.tsx
@@ -68,7 +68,7 @@ export function LevelChartClient({
                 return null;
               }
 
-              const data = payload[0]!.payload;
+              const data = payload[0].payload;
               const formattedValue = new Intl.NumberFormat(locale).format(data.bp);
 
               return (

--- a/apps/main/src/app/[locale]/(performance)/score/score-chart-client.tsx
+++ b/apps/main/src/app/[locale]/(performance)/score/score-chart-client.tsx
@@ -66,7 +66,7 @@ export function ScoreChartClient({
                 return null;
               }
 
-              const data = payload[0]!.payload;
+              const data = payload[0].payload;
               const value = Number(data.score).toFixed(1);
 
               return (

--- a/apps/main/src/app/[locale]/(settings)/_components/locale-switcher.tsx
+++ b/apps/main/src/app/[locale]/(settings)/_components/locale-switcher.tsx
@@ -8,7 +8,7 @@ import { useExtracted, useLocale } from "next-intl";
 import { useParams } from "next/navigation";
 import { useTransition } from "react";
 
-export default function LocaleSwitcher() {
+export function LocaleSwitcher() {
   const t = useExtracted();
   const locale = useLocale();
   const router = useRouter();

--- a/apps/main/src/app/[locale]/(settings)/language/page.tsx
+++ b/apps/main/src/app/[locale]/(settings)/language/page.tsx
@@ -10,7 +10,7 @@ import {
 } from "@zoonk/ui/components/container";
 import { type Metadata } from "next";
 import { getExtracted, setRequestLocale } from "next-intl/server";
-import LocaleSwitcher from "../_components/locale-switcher";
+import { LocaleSwitcher } from "../_components/locale-switcher";
 
 export async function generateMetadata({
   params,

--- a/apps/main/src/data/courses/list-courses.test.ts
+++ b/apps/main/src/data/courses/list-courses.test.ts
@@ -84,7 +84,7 @@ describe(listCourses, () => {
       result.map((course) => prisma.courseUser.count({ where: { courseId: course.id } })),
     );
 
-    for (let i = 0; i < userCounts.length - 1; i++) {
+    for (let i = 0; i < userCounts.length - 1; i += 1) {
       const current = userCounts[i] ?? 0;
       const next = userCounts[i + 1] ?? 0;
       expect(current).toBeGreaterThanOrEqual(next);

--- a/apps/main/src/lib/workflow/generation-store.ts
+++ b/apps/main/src/lib/workflow/generation-store.ts
@@ -99,5 +99,9 @@ export function handleStreamMessage<TStep extends string>(
     case "error":
       store.send({ error: "Step failed", type: "setError" });
       break;
+    default: {
+      const exhaustiveCheck: never = message.status;
+      throw new Error(`Unexpected status: ${String(exhaustiveCheck)}`);
+    }
   }
 }

--- a/apps/main/src/workflows/course-generation/course-generation-workflow.ts
+++ b/apps/main/src/workflows/course-generation/course-generation-workflow.ts
@@ -34,16 +34,18 @@ export async function courseGenerationWorkflow(courseSuggestionId: number): Prom
     workflowRunId,
   );
 
-  const chapters = await setupCourse(course, courseSuggestionId, existing).catch(async (error) => {
-    await handleCourseFailureStep({
-      courseId: course.courseId,
-      courseSuggestionId,
-    });
+  const chapters = await setupCourse(course, courseSuggestionId, existing).catch(
+    async (error: unknown) => {
+      await handleCourseFailureStep({
+        courseId: course.courseId,
+        courseSuggestionId,
+      });
 
-    console.error(`[workflow ${workflowRunId}] Course generation failed`, error);
+      console.error(`[workflow ${workflowRunId}] Course generation failed`, error);
 
-    throw FatalError;
-  });
+      throw FatalError;
+    },
+  );
 
   // Start chapter generation outside the course error handling.
   // Chapter generation has its own error handling that marks the chapter as failed.

--- a/packages/db/src/prisma/seed.ts
+++ b/packages/db/src/prisma/seed.ts
@@ -38,7 +38,7 @@ main()
     await prisma.$disconnect();
     process.exit(0);
   })
-  .catch(async (error) => {
+  .catch(async (error: unknown) => {
     console.error(error);
     await prisma.$disconnect();
     process.exit(1);

--- a/packages/db/src/prisma/seed/progress.ts
+++ b/packages/db/src/prisma/seed/progress.ts
@@ -109,7 +109,7 @@ function buildE2eDailyProgress(today: Date, orgId: number, userId: number): Dail
   const data: DailyProgressInput[] = [];
 
   // 60 days: current month (75% energy), previous month (65% energy)
-  for (let i = 59; i >= 0; i--) {
+  for (let i = 59; i >= 0; i -= 1) {
     const date = new Date(today.getTime() - i * 24 * 60 * 60 * 1000);
     const isCurrentMonth = i < 30;
     const energy = isCurrentMonth ? 75 : 65;

--- a/packages/next/src/i18n/next-intl-codec.ts
+++ b/packages/next/src/i18n/next-intl-codec.ts
@@ -14,9 +14,8 @@ function setNestedProperty(obj: Record<string, unknown>, keyPath: string, value:
   const keys = keyPath.split(".").filter(Boolean);
   let current = obj;
 
-  for (let i = 0; i < keys.length - 1; i++) {
-    const key = keys[i]!;
-
+  const keysToTraverse = keys.slice(0, -1);
+  for (const key of keysToTraverse) {
     if (!(key in current) || typeof current[key] !== "object" || current[key] === null) {
       current[key] = {};
     }

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -17,6 +17,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@zoonk/ui/components/to
 import { useIsMobile } from "@zoonk/ui/hooks/mobile";
 import { type CSSPropertiesWithVariables } from "@zoonk/ui/lib/css-variables";
 import { cn } from "@zoonk/ui/lib/utils";
+import { setCookie } from "@zoonk/utils/cookies";
 import { type VariantProps, cva } from "class-variance-authority";
 import { PanelLeftIcon } from "lucide-react";
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
@@ -79,7 +80,7 @@ function SidebarProvider({
       }
 
       // This sets the cookie to keep the sidebar state.
-      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+      setCookie(SIDEBAR_COOKIE_NAME, String(openState), { maxAge: SIDEBAR_COOKIE_MAX_AGE });
     },
     [setOpenProp, open],
   );

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -524,11 +524,7 @@ function SidebarMenuButton({
     return comp;
   }
 
-  if (typeof tooltip === "string") {
-    tooltip = {
-      children: tooltip,
-    };
-  }
+  const tooltipProps = typeof tooltip === "string" ? { children: tooltip } : tooltip;
 
   return (
     <Tooltip>
@@ -537,7 +533,7 @@ function SidebarMenuButton({
         align="center"
         hidden={state !== "collapsed" || isMobile}
         side="right"
-        {...tooltip}
+        {...tooltipProps}
       />
     </Tooltip>
   );

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -299,6 +299,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
       onClick={toggleSidebar}
       tabIndex={-1}
       title="Toggle Sidebar"
+      type="button"
       {...props}
     />
   );

--- a/packages/ui/src/components/wizard.tsx
+++ b/packages/ui/src/components/wizard.tsx
@@ -170,8 +170,13 @@ export function useWizard<T extends string>({
 } {
   const [currentStep, setCurrentStep] = useState(initialStep);
 
-  // CurrentStep is always bounded within [0, steps.length - 1] by goToStep
-  const currentStepName = steps[currentStep]!;
+  const currentStepEntry = steps[currentStep];
+
+  if (currentStepEntry === undefined) {
+    throw new Error("Invalid wizard step index");
+  }
+
+  const currentStepName = currentStepEntry;
   const isFirstStep = currentStep === 0;
   const isLastStep = currentStep === steps.length - 1;
   const totalSteps = steps.length;

--- a/packages/ui/src/hooks/use-auto-save.ts
+++ b/packages/ui/src/hooks/use-auto-save.ts
@@ -41,7 +41,8 @@ export function useAutoSave({
       statusTimeoutRef.current = null;
     }
 
-    const currentRequest = ++saveRequestRef.current;
+    saveRequestRef.current += 1;
+    const currentRequest = saveRequestRef.current;
     const valueToSave = debouncedValue;
 
     // Only show "saving" if the request takes longer than the delay

--- a/packages/ui/src/hooks/use-command-palette-search.ts
+++ b/packages/ui/src/hooks/use-command-palette-search.ts
@@ -63,7 +63,8 @@ export function useCommandPaletteSearch<TResults>(options: {
     }
 
     // Increment request ID to handle race conditions
-    const currentRequestId = ++requestIdRef.current;
+    requestIdRef.current += 1;
+    const currentRequestId = requestIdRef.current;
 
     startTransition(async () => {
       try {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "exports": {
     "./belt-level": "./src/belt-level.ts",
+    "./cookies": "./src/cookies.ts",
     "./download": "./src/download.ts",
     "./cache": "./src/cache.ts",
     "./categories": "./src/categories.ts",

--- a/packages/utils/src/cookies.ts
+++ b/packages/utils/src/cookies.ts
@@ -1,0 +1,44 @@
+/**
+ * Sets a cookie using the Cookie Store API with fallback to document.cookie.
+ * Cookie Store API requires HTTPS (except localhost), so we fall back for HTTP.
+ */
+export function setCookie(
+  name: string,
+  value: string,
+  options: {
+    expires?: number;
+    maxAge?: number;
+    sameSite?: "strict" | "lax" | "none";
+  } = {},
+): void {
+  const { expires, maxAge, sameSite = "lax" } = options;
+
+  // Cookie Store API is available and we're in a secure context
+  if ("cookieStore" in globalThis && globalThis.isSecureContext) {
+    const cookieOptions: CookieInit = { name, sameSite, value };
+
+    if (maxAge !== undefined) {
+      cookieOptions.expires = Date.now() + maxAge * 1000;
+    } else if (expires !== undefined) {
+      cookieOptions.expires = Date.now() + expires * 24 * 60 * 60 * 1000;
+    }
+
+    void globalThis.cookieStore.set(cookieOptions);
+    return;
+  }
+
+  // Fallback to document.cookie for older browsers or non-HTTPS
+  const parts = [`${encodeURIComponent(name)}=${encodeURIComponent(value)}`];
+
+  if (maxAge !== undefined) {
+    parts.push(`max-age=${maxAge}`);
+  } else if (expires !== undefined) {
+    parts.push(`max-age=${expires * 24 * 60 * 60}`);
+  }
+
+  parts.push(`path=/`);
+  parts.push(`samesite=${sameSite}`);
+
+  // eslint-disable-next-line unicorn/no-document-cookie -- Fallback for older browsers
+  document.cookie = parts.join("; ");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,9 +187,6 @@ importers:
       '@zoonk/utils':
         specifier: workspace:*
         version: link:../../packages/utils
-      js-cookie:
-        specifier: 3.0.5
-        version: 3.0.5
       lucide-react:
         specifier: 0.562.0
         version: 0.562.0(react@19.2.3)
@@ -212,9 +209,6 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
     devDependencies:
-      '@types/js-cookie':
-        specifier: 3.0.6
-        version: 3.0.6
       '@types/negotiator':
         specifier: 0.6.4
         version: 0.6.4
@@ -3012,9 +3006,6 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
-  '@types/js-cookie@3.0.6':
-    resolution: {integrity: sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==}
-
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -4345,10 +4336,6 @@ packages:
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
-
-  js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -8125,8 +8112,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/js-cookie@3.0.6': {}
-
   '@types/json-schema@7.0.15': {}
 
   '@types/mdast@4.0.4':
@@ -9578,8 +9563,6 @@ snapshots:
   jiti@2.6.1: {}
 
   jose@6.1.3: {}
-
-  js-cookie@3.0.5: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable the “restriction” lint category and tighten ESLint rules across the repo. Replace js-cookie with a shared cookie utility and clean up affected code.

- **Refactors**
  - Enable restriction rules and adjust ESLint (e.g., allow console.info/error only, require button type, scoped default-export exceptions).
  - Fix violations: replace ++ with += 1, add exhaustive default cases, use unknown in catch, remove non-null assertions via stricter type guards; convert a few default exports to named exports; minor UI tweaks (tooltip props, button type).
  - Add shared setCookie (Cookie Store API with fallback) and migrate usages; small safety/clarity updates (wizard step validation, type-safe chart payload, Apple provider config).

- **Dependencies**
  - Remove js-cookie and its types; expose @zoonk/utils/cookies and update imports; prune lockfile.

<sup>Written for commit b921212482dab64ee8792d9df1698cbf0e31d6ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

