### PR TITLE
chore(apps): disable turbopackFileSystemCacheForBuild

### DIFF
--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -6,7 +6,6 @@ const nextConfig: NextConfig = {
   devIndicators: false,
   experimental: {
     authInterrupts: true,
-    turbopackFileSystemCacheForBuild: true,
     typedEnv: true,
   },
   images: {

--- a/apps/auth/next.config.ts
+++ b/apps/auth/next.config.ts
@@ -16,7 +16,6 @@ const nextConfig: NextConfig = {
   distDir: isE2E ? ".next-e2e" : ".next",
   experimental: {
     authInterrupts: true,
-    turbopackFileSystemCacheForBuild: true,
     typedEnv: true,
   },
   reactCompiler: true,

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -26,7 +26,6 @@ const nextConfig: NextConfig = {
     staleTimes: {
       dynamic: 300,
     },
-    turbopackFileSystemCacheForBuild: true,
     typedEnv: true,
   },
   images: {

--- a/apps/evals/next.config.ts
+++ b/apps/evals/next.config.ts
@@ -5,7 +5,6 @@ const nextConfig: NextConfig = {
   cacheComponents: true,
   devIndicators: false,
   experimental: {
-    turbopackFileSystemCacheForBuild: true,
     typedEnv: true,
   },
   images: {

--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -34,7 +34,6 @@ const nextConfig: NextConfig = {
     staleTimes: {
       dynamic: 300,
     },
-    turbopackFileSystemCacheForBuild: true,
     typedEnv: true,
   },
   images: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable Turbopack file system build cache across all apps to prevent stale artifacts and stabilize builds. Applies to admin, auth, editor, evals, and main.

<sup>Written for commit e7e1c946832f84739362be7be639b6440929a514. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

