### PR TITLE
chore(agents): clarify handling of spec numbers in issue planning skills

### DIFF
--- a/.agents/skills/zoonk-github-issues/SKILL.md
+++ b/.agents/skills/zoonk-github-issues/SKILL.md
@@ -322,6 +322,37 @@ get_issue_id() {
 - Plus, you shouldn't add references to our temporary files to the GitHub issue body like this: `specs, see /tasks/specs/whatever`. Instead write the full spec to the issue body
 - When you have multiple issues to add, you may want to create a temporary bash script to process them in batch instead of running each command individually
 
+### Never Trust #NUMBER References from Specs
+
+When creating issues from specs:
+
+1. **Spec numbers are NOT GitHub issue numbers** - A spec named `18-get-org-courses.md` does NOT correspond to GitHub issue #18
+
+2. **Handle #NUMBER references carefully**:
+   - Remove "Blocked by: #X" lines entirely (use GitHub API instead)
+   - For context references like "Out of scope, see #X":
+     - If creating issues fresh: don't keep those spec references in the issue body, those are our internal spec numbers
+     - If issue already exists: verify the GitHub issue number is correct first
+
+3. **Build a mapping as you create issues**:
+   - Track: Spec filename → GitHub issue number
+   - Use this mapping to fix cross-references in issue bodies
+
+4. **Cross-references ARE okay** when they're verified GitHub issues:
+   - GOOD: "Out of scope, handled by #1234" (verified this is a real issue)
+   - BAD: "See #18 for details" (spec number, not verified)
+
+### Content That Should NOT Be in Issue Bodies
+
+Remove before creating (GitHub handles these automatically):
+
+- `**Blocked by**: #X` - Use GitHub blocked-by relationship
+- `**Type**: Feature` - Use GitHub issue type
+- Summary tables listing sub-issues - Use GitHub sub-issue feature
+- Numbered lists of child issues - Use GitHub sub-issue feature
+- `Parent: #X` - GitHub shows parent automatically
+- Don't add any metadata that GitHub manages or displays in the UI already, focus only on the task
+
 ## Troubleshooting
 
 ### "Resource not accessible by integration"

--- a/.agents/skills/zoonk-issue-planning/SKILL.md
+++ b/.agents/skills/zoonk-issue-planning/SKILL.md
@@ -51,6 +51,22 @@ Split smaller. It's easier to combine issues later than to split them mid-implem
 
 ## Critical Rules
 
+### Spec Numbers Are NOT GitHub Issue Numbers
+
+When breaking down work, you use local numbering (1, 2, 3...) for organization. These numbers are NOT GitHub issue numbers.
+
+**Never use `#NUMBER` format in specs or breakdowns:**
+
+- BAD: "This is blocked by #5"
+- GOOD: "This is blocked by spec 05-add-auth-middleware.md"
+
+When specs reference each other, use **file names**, not numbers:
+
+- BAD: "See issue #18 for details"
+- GOOD: "See spec `18-get-org-courses.md` for details"
+
+GitHub issue numbers are assigned when issues are created - you cannot know them in advance during the planning phase.
+
 ### Tests Are Always Included
 
 Every issue that adds functionality MUST include its tests in the same issue. Never create separate "testing" issues.

--- a/.agents/skills/zoonk-issue-writer/SKILL.md
+++ b/.agents/skills/zoonk-issue-writer/SKILL.md
@@ -93,6 +93,32 @@ Use this adaptive template. Required sections appear in every issue. Optional se
 | Technical Notes     | Planning revealed specific insights | Generic implementation |
 | Acceptance Criteria | Always                              | Never                  |
 
+## Issue References in Specs
+
+### During Spec Writing (Before GitHub Issues Exist)
+
+When writing specs that will become GitHub issues later:
+
+1. **Never use `#NUMBER` format in specs** - These aren't GitHub issues yet
+2. **Reference other specs by file name** instead:
+   - BAD: `See issue #18 for details`
+   - GOOD: `See spec 18-get-org-courses.md for details`
+
+3. **Never add relationship metadata** - GitHub handles these:
+   - No "Blocked by: #X" lines (use GitHub API)
+   - No "Parent: #X" lines (use sub-issue feature)
+   - No sub-issue lists (GitHub shows these automatically)
+   - No summary tables (GitHub UI displays this)
+
+### After GitHub Issues Exist
+
+Cross-references to **real GitHub issues** are fine when providing context:
+
+- "Out of scope, handled by #1234"
+- "See #1234 for the course endpoint this depends on"
+
+**But verify the reference first** - never trust #NUMBER from specs. Check GitHub to confirm the issue exists and is the correct one.
+
 ## Writing Guidelines
 
 ### 1. Context Over Commands


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified rules across issue planning, writing, and GitHub issues skills to prevent misuse of spec “#NUMBER” as GitHub issue numbers. Use spec filenames for references, verify real GitHub issue links, remove relationship metadata GitHub manages, and build a spec-to-issue mapping when creating issues.

<sup>Written for commit 93bb99f093f04c3384b14f91bce07c8108b69537. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

