### PR TITLE
fix(editor): revalidate org home after creating a course

### DIFF
--- a/.agents/skills/zoonk-testing/SKILL.md
+++ b/.agents/skills/zoonk-testing/SKILL.md
@@ -25,6 +25,49 @@ Follow TDD (Test-Driven Development) for all features and bug fixes. **Always wr
 - **New feature**: Write a test showing the feature doesn't exist yet
 - **Refactoring**: Ensure tests exist before changing code
 
+### CRITICAL: Verify the Test Fails First
+
+**You MUST run the test before implementing the fix to confirm it fails.** This is non-negotiable.
+
+If the test passes before you write the fix, **the test is wrong**. A passing test means one of:
+
+1. The bug doesn't exist (investigate further)
+2. The test is matching existing/seeded data instead of new behavior
+3. The test assertion is too loose
+
+**Never use workarounds to make a failing test pass.** Common anti-patterns:
+
+```typescript
+// BAD: Using .first() to avoid "strict mode violation" with multiple matches
+await expect(page.getByText(courseTitle).first()).toBeVisible();
+// This passes even if the item existed before your fix!
+
+// BAD: Using loose assertions that match existing data
+const courseTitle = "Test Course"; // Generic name that might exist
+await expect(page.getByText(courseTitle)).toBeVisible();
+
+// GOOD: Use unique identifiers to ensure you're testing NEW behavior
+const uniqueId = randomUUID().slice(0, 8);
+const courseTitle = `Test Course ${uniqueId}`;
+await expect(page.getByText(courseTitle)).toBeVisible();
+// This ONLY passes if your code actually created this specific item
+```
+
+**When you see "strict mode violation: resolved to N elements":**
+
+1. Don't add `.first()` - that masks the real issue
+2. Ask: "Why are there multiple matches?"
+3. Make your test data unique so only ONE element can match but DO NOT use locators to make it unique, still use accessible queries like `getByRole` or `getByText`, just make the content unique
+4. The test should fail before the fix and pass after
+
+**TDD verification checklist:**
+
+1. ✅ Write the test
+2. ✅ Run the test - **it MUST fail**
+3. ✅ If it passes, the test is wrong - fix the test first
+4. ✅ Write the implementation
+5. ✅ Run the test - it should now pass
+
 ## Test Types
 
 | When                    | Test Type   | Framework  | Location                              |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ For detailed examples and patterns, see `.agents/skills/zoonk-compound-component
 2. **Use the `e2e-test-architect` agent** if available - It knows the testing patterns
 3. **Invoke the `/testing` skill** - Use `Skill(testing)` to get guidance
 
-**Always follow TDD (Test-Driven Development)**: Write a failing test first, then write the code to make it pass.
+**VERY IMPORTANT**: **Always follow TDD (Test-Driven Development)**: Write a failing test first, **run the test to confirm it fails**, then write the code to make it pass. If the test passes before your fix, the test is wrong—never use workarounds like `.first()` or loose assertions to make tests pass. Use unique test data (e.g., UUIDs in titles) to ensure tests catch regressions.
 
 - **E2E tests**: For app/UI features, use Playwright (`apps/{app}/e2e/`)
 - **Integration tests**: For data functions with Prisma (`apps/{app}/src/data/`)

--- a/apps/editor/src/app/[orgSlug]/new-course/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/new-course/actions.ts
@@ -7,6 +7,7 @@ import { revalidateMainApp } from "@zoonk/core/cache/revalidate";
 import { cacheTagOrgCourses } from "@zoonk/utils/cache";
 import { toSlug } from "@zoonk/utils/string";
 import { getExtracted } from "next-intl/server";
+import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { after } from "next/server";
 import { type CourseFormData } from "./use-course-form";
@@ -55,5 +56,6 @@ export async function createCourseAction(formData: CourseFormData, orgSlug: stri
     await revalidateMainApp([cacheTagOrgCourses({ orgSlug })]);
   });
 
+  revalidatePath(`/${orgSlug}`);
   redirect(`/${orgSlug}/c/${course.language}/${course.slug}`);
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Revalidates the org home page after creating a course so the new course shows up immediately without a hard refresh. Adds an E2E test to prevent regressions and tightens TDD guidance.

- **Bug Fixes**
  - Editor: call revalidatePath(`/${orgSlug}`) after course creation to refresh the org home cache.
  - E2E: add a test that creates a unique course, soft-navigates back home, and asserts the new course appears.
  - Docs: strengthen TDD guidance to confirm tests fail first and avoid loose assertions (e.g., `.first()`); use unique test data.

<sup>Written for commit 90995c3eed983e0d1f4beed982a0431620beca62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

