### PR TITLE
feat(api): add api handlers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Zoonk is a web app where users can learn anything using AI. This app uses AI to 
 - Code must be modular, following SOLID and DRY principles
 - Avoid nested conditionals and complex logic
 - Prefer short and composable functions
+- **Split files with multiple concerns.** If a file has distinct responsibilities (e.g., utils, validation, parsing, main logic), extract them into a `_utils/` folder (if internal) or separate files. A file should have one clear purpose, avoid doing too many things in a single file
 - Prefer functional programming over OOP
 - Avoid mutations: return new values instead of modifying existing data or state
 - Use `[condition && value, ...].filter(Boolean)` instead of `let` + `.push()` for conditional arrays

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,12 @@
     "typecheck": "next typegen && tsgo --noEmit"
   },
   "dependencies": {
-    "next": "16.1.5"
+    "@zoonk/auth": "workspace:*",
+    "@zoonk/core": "workspace:*",
+    "@zoonk/db": "workspace:*",
+    "@zoonk/utils": "workspace:*",
+    "next": "16.1.5",
+    "zod": "4.3.5"
   },
   "devDependencies": {
     "@types/node": "^24",

--- a/apps/api/src/lib/_utils/api-key.ts
+++ b/apps/api/src/lib/_utils/api-key.ts
@@ -33,13 +33,7 @@ async function validateApiKey(req: NextRequest): Promise<ApiKeyInfo | null> {
 
 export async function resolveApiKey(
   req: NextRequest,
-  skip?: boolean,
 ): Promise<{ apiKey: ApiKeyInfo } | { error: NextResponse }> {
-  if (skip) {
-    return { apiKey: { isSystemKey: false, key: "", orgSlug: null } };
-  }
-
   const apiKey = await validateApiKey(req);
-
   return apiKey ? { apiKey } : { error: errors.invalidApiKey() };
 }

--- a/apps/api/src/lib/_utils/api-key.ts
+++ b/apps/api/src/lib/_utils/api-key.ts
@@ -1,0 +1,45 @@
+import { auth } from "@zoonk/auth";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { safeAsync } from "@zoonk/utils/error";
+import { type NextRequest, type NextResponse } from "next/server";
+import { z } from "zod";
+import { errors } from "../api-errors";
+
+export type ApiKeyInfo = {
+  key: string;
+  orgSlug: string | null;
+  isSystemKey: boolean;
+};
+
+const apiKeyMetadataSchema = z.object({ orgSlug: z.string().optional() }).optional();
+
+async function validateApiKey(req: NextRequest): Promise<ApiKeyInfo | null> {
+  const key = req.headers.get("x-api-key");
+
+  if (!key) {
+    return null;
+  }
+
+  const { data: result } = await safeAsync(() => auth.api.verifyApiKey({ body: { key } }));
+  if (!result?.valid || !result.key) {
+    return null;
+  }
+
+  const parseResult = apiKeyMetadataSchema.safeParse(result.key.metadata);
+  const orgSlug = parseResult.success ? (parseResult.data?.orgSlug ?? null) : null;
+
+  return { isSystemKey: orgSlug === AI_ORG_SLUG, key, orgSlug };
+}
+
+export async function resolveApiKey(
+  req: NextRequest,
+  skip?: boolean,
+): Promise<{ apiKey: ApiKeyInfo } | { error: NextResponse }> {
+  if (skip) {
+    return { apiKey: { isSystemKey: false, key: "", orgSlug: null } };
+  }
+
+  const apiKey = await validateApiKey(req);
+
+  return apiKey ? { apiKey } : { error: errors.invalidApiKey() };
+}

--- a/apps/api/src/lib/_utils/body-parser.ts
+++ b/apps/api/src/lib/_utils/body-parser.ts
@@ -6,8 +6,7 @@ export async function parseBody<TBody>(
   req: NextRequest,
   schema: z.ZodType<TBody>,
 ): Promise<{ data: TBody; success: true } | { error: z.ZodError; success: false }> {
-  // oxlint-disable-next-line typescript/no-unsafe-assignment -- JSON parsing returns unknown
-  const { data: json, error } = await safeAsync(() => req.json());
+  const { data: json, error } = await safeAsync<unknown>(() => req.json());
 
   if (error) {
     return {

--- a/apps/api/src/lib/_utils/body-parser.ts
+++ b/apps/api/src/lib/_utils/body-parser.ts
@@ -1,0 +1,24 @@
+import { safeAsync } from "@zoonk/utils/error";
+import { type NextRequest } from "next/server";
+import { z } from "zod";
+
+export async function parseBody<TBody>(
+  req: NextRequest,
+  schema: z.ZodType<TBody>,
+): Promise<{ data: TBody; success: true } | { error: z.ZodError; success: false }> {
+  // oxlint-disable-next-line typescript/no-unsafe-assignment -- JSON parsing returns unknown
+  const { data: json, error } = await safeAsync(() => req.json());
+
+  if (error) {
+    return {
+      error: new z.ZodError([{ code: "custom", message: "Invalid JSON body", path: [] }]),
+      success: false,
+    };
+  }
+
+  const result = schema.safeParse(json);
+
+  return result.success
+    ? { data: result.data, success: true }
+    : { error: result.error, success: false };
+}

--- a/apps/api/src/lib/_utils/session.ts
+++ b/apps/api/src/lib/_utils/session.ts
@@ -1,0 +1,18 @@
+import { auth } from "@zoonk/auth";
+import { safeAsync } from "@zoonk/utils/error";
+import { type NextRequest } from "next/server";
+
+export type UserInfo = {
+  id: number;
+  sessionId: number;
+};
+
+export async function getUser(req: NextRequest): Promise<UserInfo | null> {
+  const { data: session } = await safeAsync(() => auth.api.getSession({ headers: req.headers }));
+
+  if (!session?.user) {
+    return null;
+  }
+
+  return { id: Number(session.user.id), sessionId: Number(session.session.id) };
+}

--- a/apps/api/src/lib/api-errors.ts
+++ b/apps/api/src/lib/api-errors.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { type z } from "zod";
+
+const HTTP_BAD_REQUEST = 400;
+const HTTP_UNAUTHORIZED = 401;
+const HTTP_FORBIDDEN = 403;
+const HTTP_NOT_FOUND = 404;
+const HTTP_CONFLICT = 409;
+const HTTP_INTERNAL_ERROR = 500;
+
+function errorResponse(code: string, message: string, status: number, details?: unknown) {
+  return NextResponse.json({ error: { code, details, message } }, { status });
+}
+
+export const errors = {
+  conflict: (msg = "Resource already exists") => errorResponse("CONFLICT", msg, HTTP_CONFLICT),
+  forbidden: (msg = "Access denied") => errorResponse("FORBIDDEN", msg, HTTP_FORBIDDEN),
+  internal: (msg = "Internal server error") =>
+    errorResponse("INTERNAL_ERROR", msg, HTTP_INTERNAL_ERROR),
+  invalidApiKey: () =>
+    errorResponse("UNAUTHORIZED", "Invalid or missing API key", HTTP_UNAUTHORIZED),
+  notFound: (msg = "Resource not found") => errorResponse("NOT_FOUND", msg, HTTP_NOT_FOUND),
+  unauthorized: (msg = "Authentication required") =>
+    errorResponse("UNAUTHORIZED", msg, HTTP_UNAUTHORIZED),
+  validation: (zodError: z.ZodError) => {
+    const details = zodError.issues.map((issue) => ({
+      message: issue.message,
+      path: issue.path,
+    }));
+    return errorResponse("VALIDATION_ERROR", "Invalid request", HTTP_BAD_REQUEST, details);
+  },
+} as const;

--- a/apps/api/src/lib/api-handler.ts
+++ b/apps/api/src/lib/api-handler.ts
@@ -1,90 +1,65 @@
 import { type NextRequest, type NextResponse } from "next/server";
-import { type z } from "zod";
 import { type ApiKeyInfo, resolveApiKey } from "./_utils/api-key";
-import { parseBody } from "./_utils/body-parser";
 import { type UserInfo, getUser } from "./_utils/session";
 import { errors } from "./api-errors";
 
-type ApiContextBase = {
+type RouteParams = { params: Promise<Record<string, string>> };
+
+export type ApiContext = {
   req: NextRequest;
   params: Record<string, string>;
   apiKey: ApiKeyInfo;
 };
 
-type ApiContextWithUser<TBody = never> = ApiContextBase & { user: UserInfo } & BodyContext<TBody>;
+export type ApiContextWithUser = ApiContext & { user: UserInfo };
 
-type ApiContextOptionalUser<TBody = never> = ApiContextBase & {
-  user: UserInfo | null;
-} & BodyContext<TBody>;
-
-type BodyContext<TBody> = [TBody] extends [never] ? object : { body: TBody };
-
-type RouteParams = { params: Promise<Record<string, string>> };
-
-type ConfigWithAuth<TBody = never> = {
-  skipAuth?: false;
-  skipApiKey?: boolean;
-  body?: z.ZodType<TBody>;
-};
-
-type ConfigWithoutAuth<TBody = never> = {
-  skipAuth: true;
-  skipApiKey?: boolean;
-  body?: z.ZodType<TBody>;
-};
-
-export function apiHandler<TBody = never>(
-  config: ConfigWithAuth<TBody>,
-  handler: (ctx: ApiContextWithUser<TBody>) => Promise<NextResponse> | NextResponse,
-): (req: NextRequest, opts: RouteParams) => Promise<NextResponse>;
-
-export function apiHandler<TBody = never>(
-  config: ConfigWithoutAuth<TBody>,
-  handler: (ctx: ApiContextOptionalUser<TBody>) => Promise<NextResponse> | NextResponse,
-): (req: NextRequest, opts: RouteParams) => Promise<NextResponse>;
-
-export function apiHandler<TBody = never>(
-  config: ConfigWithAuth<TBody> | ConfigWithoutAuth<TBody>,
-  handler:
-    | ((ctx: ApiContextWithUser<TBody>) => Promise<NextResponse> | NextResponse)
-    | ((ctx: ApiContextOptionalUser<TBody>) => Promise<NextResponse> | NextResponse),
+/**
+ * Handler for public API routes.
+ * Requires API key only.
+ */
+export function apiHandler(
+  handler: (ctx: ApiContext) => Promise<NextResponse> | NextResponse,
 ): (req: NextRequest, opts: RouteParams) => Promise<NextResponse> {
-  return async (req: NextRequest, { params }: RouteParams): Promise<NextResponse> => {
-    const resolvedParams = await params;
-
-    const apiKeyResult = await resolveApiKey(req, config.skipApiKey);
+  return async (req, { params }) => {
+    const apiKeyResult = await resolveApiKey(req);
 
     if ("error" in apiKeyResult) {
       return apiKeyResult.error;
     }
 
-    const { apiKey } = apiKeyResult;
+    return handler({
+      apiKey: apiKeyResult.apiKey,
+      params: await params,
+      req,
+    });
+  };
+}
+
+/**
+ * Handler for protected API routes.
+ * Requires API key AND auth.
+ */
+export function apiHandlerWithAuth(
+  handler: (ctx: ApiContextWithUser) => Promise<NextResponse> | NextResponse,
+): (req: NextRequest, opts: RouteParams) => Promise<NextResponse> {
+  return async (req, { params }) => {
+    const apiKeyResult = await resolveApiKey(req);
+
+    if ("error" in apiKeyResult) {
+      return apiKeyResult.error;
+    }
 
     const user = await getUser(req);
 
-    if (!config.skipAuth && !user) {
+    if (!user) {
       return errors.unauthorized();
     }
 
-    const baseCtx: ApiContextOptionalUser = { apiKey, params: resolvedParams, req, user };
-
-    if (config.body) {
-      const bodyResult = await parseBody(req, config.body);
-
-      if (!bodyResult.success) {
-        return errors.validation(bodyResult.error);
-      }
-
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- function overloads ensure type safety at call sites
-      return (handler as (ctx: ApiContextOptionalUser<TBody>) => Promise<NextResponse>)({
-        ...baseCtx,
-        body: bodyResult.data,
-      } as ApiContextOptionalUser<TBody>);
-    }
-
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- function overloads ensure type safety at call sites
-    const ctx = baseCtx as ApiContextOptionalUser<TBody>;
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- function overloads ensure type safety at call sites
-    return (handler as (ctx: ApiContextOptionalUser<TBody>) => Promise<NextResponse>)(ctx);
+    return handler({
+      apiKey: apiKeyResult.apiKey,
+      params: await params,
+      req,
+      user,
+    });
   };
 }

--- a/apps/api/src/lib/api-handler.ts
+++ b/apps/api/src/lib/api-handler.ts
@@ -1,15 +1,9 @@
 import { auth } from "@zoonk/auth";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { safeAsync } from "@zoonk/utils/error";
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest, type NextResponse } from "next/server";
 import { z } from "zod";
-
-const HTTP_BAD_REQUEST = 400;
-const HTTP_UNAUTHORIZED = 401;
-const HTTP_FORBIDDEN = 403;
-const HTTP_NOT_FOUND = 404;
-const HTTP_CONFLICT = 409;
-const HTTP_INTERNAL_ERROR = 500;
+import { errors } from "./api-errors";
 
 type ApiKeyInfo = {
   key: string;
@@ -35,29 +29,6 @@ type ApiContextOptionalUser = {
   apiKey: ApiKeyInfo;
   user: UserInfo | null;
 };
-
-function errorResponse(code: string, message: string, status: number, details?: unknown) {
-  return NextResponse.json({ error: { code, details, message } }, { status });
-}
-
-export const errors = {
-  conflict: (msg = "Resource already exists") => errorResponse("CONFLICT", msg, HTTP_CONFLICT),
-  forbidden: (msg = "Access denied") => errorResponse("FORBIDDEN", msg, HTTP_FORBIDDEN),
-  internal: (msg = "Internal server error") =>
-    errorResponse("INTERNAL_ERROR", msg, HTTP_INTERNAL_ERROR),
-  invalidApiKey: () =>
-    errorResponse("UNAUTHORIZED", "Invalid or missing API key", HTTP_UNAUTHORIZED),
-  notFound: (msg = "Resource not found") => errorResponse("NOT_FOUND", msg, HTTP_NOT_FOUND),
-  unauthorized: (msg = "Authentication required") =>
-    errorResponse("UNAUTHORIZED", msg, HTTP_UNAUTHORIZED),
-  validation: (zodError: z.ZodError) => {
-    const details = zodError.issues.map((issue) => ({
-      message: issue.message,
-      path: issue.path,
-    }));
-    return errorResponse("VALIDATION_ERROR", "Invalid request", HTTP_BAD_REQUEST, details);
-  },
-} as const;
 
 const apiKeyMetadataSchema = z.object({ orgSlug: z.string().optional() }).optional();
 

--- a/apps/api/src/lib/permissions.ts
+++ b/apps/api/src/lib/permissions.ts
@@ -11,6 +11,7 @@ export function canAccessOrg(
   if (apiKey.isSystemKey) {
     return true;
   }
+
   return apiKey.orgSlug === targetOrgSlug;
 }
 

--- a/apps/api/src/lib/permissions.ts
+++ b/apps/api/src/lib/permissions.ts
@@ -1,0 +1,23 @@
+import { type CoursePermission } from "@zoonk/auth/types";
+import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
+
+export function canAccessOrg(
+  apiKey: {
+    orgSlug: string | null;
+    isSystemKey: boolean;
+  },
+  targetOrgSlug: string,
+): boolean {
+  if (apiKey.isSystemKey) {
+    return true;
+  }
+  return apiKey.orgSlug === targetOrgSlug;
+}
+
+export async function checkCoursePermission(
+  permission: CoursePermission,
+  orgSlug: string,
+  headers: Headers,
+): Promise<boolean> {
+  return hasCoursePermission({ headers, orgSlug, permission });
+}

--- a/knip.json
+++ b/knip.json
@@ -22,6 +22,10 @@
   },
   "tags": ["-lintignore"],
   "workspaces": {
+    "apps/api": {
+      "ignore": ["src/lib/**"],
+      "ignoreDependencies": ["@zoonk/auth", "@zoonk/core", "@zoonk/db", "@zoonk/utils", "zod"]
+    },
     "apps/auth": {
       "entry": ["src/i18n/codec.ts"]
     },

--- a/packages/auth/src/client.ts
+++ b/packages/auth/src/client.ts
@@ -1,6 +1,7 @@
 import { stripeClient } from "@better-auth/stripe/client";
 import {
   adminClient,
+  apiKeyClient,
   emailOTPClient,
   inferOrgAdditionalFields,
   oneTimeTokenClient,
@@ -13,6 +14,7 @@ import { ac, admin, member, owner } from "./permissions";
 export const authClient = createAuthClient({
   plugins: [
     adminClient(),
+    apiKeyClient(),
     emailOTPClient(),
     oneTimeTokenClient(),
     organizationClient({

--- a/packages/auth/src/config.ts
+++ b/packages/auth/src/config.ts
@@ -2,7 +2,15 @@ import { prisma } from "@zoonk/db";
 import { getDevTrustedOrigins, getVercelTrustedOrigins } from "@zoonk/utils/url";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { nextCookies } from "better-auth/next-js";
-import { admin as adminPlugin, emailOTP, oneTimeToken, organization } from "better-auth/plugins";
+import {
+  admin as adminPlugin,
+  apiKey,
+  bearer,
+  emailOTP,
+  jwt,
+  oneTimeToken,
+  organization,
+} from "better-auth/plugins";
 import { type BetterAuthOptions } from "better-auth/types";
 import { ac, admin, member, owner } from "./permissions";
 import { sendVerificationOTP } from "./plugins/otp";
@@ -80,6 +88,9 @@ export const fullPlugins = [
   oneTimeToken({
     storeToken: "hashed",
   }),
+  jwt(),
+  apiKey({ enableMetadata: true }),
+  bearer(),
   stripePlugin(),
   trustedOriginPlugin(),
   // NextCookies should be the last plugin in the array

--- a/packages/db/src/prisma/migrations/20260127175820_add_jwks_api_keys/migration.sql
+++ b/packages/db/src/prisma/migrations/20260127175820_add_jwks_api_keys/migration.sql
@@ -1,0 +1,46 @@
+-- CreateTable
+CREATE TABLE "jwks" (
+    "id" SERIAL NOT NULL,
+    "public_key" TEXT NOT NULL,
+    "private_key" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL,
+    "expires_at" TIMESTAMP(3),
+
+    CONSTRAINT "jwks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "api_keys" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT,
+    "start" TEXT,
+    "prefix" TEXT,
+    "key" TEXT NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "refill_interval" INTEGER,
+    "refill_amount" INTEGER,
+    "last_refill_at" TIMESTAMP(3),
+    "enabled" BOOLEAN DEFAULT true,
+    "rate_limit_enabled" BOOLEAN DEFAULT true,
+    "rate_limit_time_window" INTEGER DEFAULT 86400000,
+    "rate_limit_max" INTEGER DEFAULT 10,
+    "request_count" INTEGER DEFAULT 0,
+    "remaining" INTEGER,
+    "last_request" TIMESTAMP(3),
+    "expires_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "permissions" TEXT,
+    "metadata" TEXT,
+
+    CONSTRAINT "api_keys_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "api_keys_key_idx" ON "api_keys"("key");
+
+-- CreateIndex
+CREATE INDEX "api_keys_user_id_idx" ON "api_keys"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/src/prisma/migrations/20260127202928_add_defaults_to_created_updated_at/migration.sql
+++ b/packages/db/src/prisma/migrations/20260127202928_add_defaults_to_created_updated_at/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "api_keys" ALTER COLUMN "updated_at" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "jwks" ALTER COLUMN "created_at" SET DEFAULT CURRENT_TIMESTAMP;

--- a/packages/db/src/prisma/models/accounts.prisma
+++ b/packages/db/src/prisma/models/accounts.prisma
@@ -23,6 +23,8 @@ model User {
   progress         UserProgress?
   dailyProgress    DailyProgress[]
 
+  apikeys Apikey[]
+
   @@unique([email])
   @@map("users")
 }
@@ -159,4 +161,43 @@ model RateLimit {
   lastRequest BigInt? @map("last_request")
 
   @@map("rate_limits")
+}
+
+model Jwks {
+  id         Int       @id @default(autoincrement())
+  publicKey  String    @map("public_key")
+  privateKey String    @map("private_key")
+  createdAt  DateTime  @map("created_at")
+  expiresAt  DateTime? @map("expires_at")
+
+  @@map("jwks")
+}
+
+model Apikey {
+  id                  Int       @id @default(autoincrement())
+  name                String?
+  start               String?
+  prefix              String?
+  key                 String
+  userId              Int       @map("user_id")
+  user                User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  refillInterval      Int?      @map("refill_interval")
+  refillAmount        Int?      @map("refill_amount")
+  lastRefillAt        DateTime? @map("last_refill_at")
+  enabled             Boolean?  @default(true)
+  rateLimitEnabled    Boolean?  @default(true) @map("rate_limit_enabled")
+  rateLimitTimeWindow Int?      @default(86400000) @map("rate_limit_time_window")
+  rateLimitMax        Int?      @default(10) @map("rate_limit_max")
+  requestCount        Int?      @default(0) @map("request_count")
+  remaining           Int?
+  lastRequest         DateTime? @map("last_request")
+  expiresAt           DateTime? @map("expires_at")
+  createdAt           DateTime  @default(now()) @map("created_at")
+  updatedAt           DateTime  @default(now()) @map("updated_at")
+  permissions         String?
+  metadata            String?
+
+  @@index([key])
+  @@index([userId])
+  @@map("api_keys")
 }

--- a/packages/db/src/prisma/models/accounts.prisma
+++ b/packages/db/src/prisma/models/accounts.prisma
@@ -167,7 +167,7 @@ model Jwks {
   id         Int       @id @default(autoincrement())
   publicKey  String    @map("public_key")
   privateKey String    @map("private_key")
-  createdAt  DateTime  @map("created_at")
+  createdAt  DateTime  @default(now()) @map("created_at")
   expiresAt  DateTime? @map("expires_at")
 
   @@map("jwks")
@@ -193,7 +193,7 @@ model Apikey {
   lastRequest         DateTime? @map("last_request")
   expiresAt           DateTime? @map("expires_at")
   createdAt           DateTime  @default(now()) @map("created_at")
-  updatedAt           DateTime  @default(now()) @map("updated_at")
+  updatedAt           DateTime  @updatedAt @map("updated_at")
   permissions         String?
   metadata            String?
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,9 +93,24 @@ importers:
 
   apps/api:
     dependencies:
+      '@zoonk/auth':
+        specifier: workspace:*
+        version: link:../../packages/auth
+      '@zoonk/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@zoonk/db':
+        specifier: workspace:*
+        version: link:../../packages/db
+      '@zoonk/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
       next:
         specifier: 16.1.5
         version: 16.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.58.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      zod:
+        specifier: 4.3.5
+        version: 4.3.5
     devDependencies:
       '@types/node':
         specifier: ^24


### PR DESCRIPTION
Closes #664
Closes #666
Closes #660
Closes #661

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds unified API route handlers with API key verification and optional user auth, plus structured error responses. Implements JWKS and API key storage to support key management and org-scoped access; satisfies #664, #666, #660, #661.

- New Features
  - Unified handlers: apiHandler and apiHandlerWithAuth (API key required; optional user auth).
  - Key and org access: validate x-api-key; support org scoping and system keys (AI_ORG_SLUG).
  - Helpers: parseBody (zod), consistent errors, permissions checks, session resolver.
  - Auth updates: enable apiKey, jwt, bearer plugins; add apiKeyClient.

- Migration
  - Add jwks and api_keys tables with indexes and user FK.
  - Run Prisma migrate.
  - Create API keys and set org metadata where needed.

<sup>Written for commit 3734c32e8e585d799bdec10d7e19722dfe1b4461. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

