### PR TITLE
refactor(agents): remove better auth mcp

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,14 @@
 {
   "mcpServers": {
-    "better-auth": {
+    "better-auth-docs": {
       "type": "http",
       "url": "https://mcp.chonkie.ai/better-auth/better-auth-builder/mcp"
+    },
+    "better-auth": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@better-auth/mcp"],
+      "env": {}
     },
     "context7": {
       "type": "http",

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,15 +1,5 @@
 {
   "mcpServers": {
-    "better-auth-docs": {
-      "type": "http",
-      "url": "https://mcp.chonkie.ai/better-auth/better-auth-builder/mcp"
-    },
-    "better-auth": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["@better-auth/mcp"],
-      "env": {}
-    },
     "context7": {
       "type": "http",
       "url": "https://mcp.context7.com/mcp"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the Better Auth MCP entry from .mcp.json to drop the remote HTTP endpoint and avoid agent misconfiguration.

<sup>Written for commit 02de5d469c226d558290de0f941d3ce9eafe9f47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

