### PR TITLE
chore(apps): update ports

### DIFF
--- a/.github/workflows/e2e-editor.yml
+++ b/.github/workflows/e2e-editor.yml
@@ -17,7 +17,7 @@ jobs:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/zoonk_e2e
       DATABASE_URL_UNPOOLED: postgres://postgres:postgres@localhost:5432/zoonk_e2e
       E2E_TESTING: "true"
-      NEXT_PUBLIC_APP_DOMAIN: localhost:3003
+      NEXT_PUBLIC_APP_DOMAIN: localhost:3101
       NEXT_PUBLIC_API_URL: http://localhost:4000
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -7,12 +7,12 @@ DATABASE_URL=postgresql://USER:PASSWORD@localhost:5432/zoonk
 # Direct database connection URL for Prisma Migrate
 DATABASE_URL_UNPOOLED=
 
-# This app's domain (eg localhost:3001, admin.zoonk.com)
-NEXT_PUBLIC_APP_DOMAIN=localhost:3001
+# This app's domain (eg localhost:3200, admin.zoonk.com)
+NEXT_PUBLIC_APP_DOMAIN=localhost:3200
 
 # Centralized API App URL
 NEXT_PUBLIC_API_URL=http://localhost:4000
-NEXT_PUBLIC_EDITOR_APP_URL=http://localhost:3003
+NEXT_PUBLIC_EDITOR_APP_URL=http://localhost:3101
 
 ### OPTIONAL VARIABLES ###
 

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "analyze": "next experimental-analyze",
     "build": "next build",
-    "dev": "next dev -p 3001",
-    "start": "next start -p 3001",
+    "dev": "next dev -p 3200",
+    "start": "next start -p 3200",
     "typecheck": "next typegen && tsgo --noEmit"
   },
   "dependencies": {

--- a/apps/editor/.env.example
+++ b/apps/editor/.env.example
@@ -7,8 +7,8 @@ DATABASE_URL=postgresql://USER:PASSWORD@localhost:5432/zoonk
 # Direct database connection URL for Prisma Migrate
 DATABASE_URL_UNPOOLED=
 
-# This app's domain (eg localhost:3003, zoonk.com)
-NEXT_PUBLIC_APP_DOMAIN=localhost:3003
+# This app's domain (eg localhost:3101, zoonk.com)
+NEXT_PUBLIC_APP_DOMAIN=localhost:3101
 
 # Centralized API App URL
 NEXT_PUBLIC_API_URL=http://localhost:4000

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -7,10 +7,10 @@
     "analyze": "next experimental-analyze",
     "build": "next build",
     "build:e2e": "env $(cat ../../packages/db/.env.e2e | xargs) next build",
-    "dev": "next dev -p 3003",
+    "dev": "next dev -p 3101",
     "e2e": "env $(cat ../../packages/db/.env.e2e | xargs) playwright test",
     "e2e:ui": "env $(cat ../../packages/db/.env.e2e | xargs) playwright test --ui",
-    "start": "next start -p 3003",
+    "start": "next start -p 3101",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "next typegen && tsgo --noEmit"

--- a/apps/evals/README.md
+++ b/apps/evals/README.md
@@ -16,7 +16,7 @@ From the root directory of the repository, run:
 pnpm evals
 ```
 
-This will build the evals app and start the server. You can then access the app at `http://localhost:3002`.
+This will build the evals app and start the server. You can then access the app at `http://localhost:3201`.
 
 From there, you'll have a UI to run evals for different models and tasks.
 

--- a/apps/evals/package.json
+++ b/apps/evals/package.json
@@ -6,8 +6,8 @@
     "analyze": "next experimental-analyze",
     "build": "next build",
     "build-and-start": "pnpm build && pnpm start",
-    "dev": "next dev -p 3002",
-    "start": "next start -p 3002",
+    "dev": "next dev -p 3201",
+    "start": "next start -p 3201",
     "typecheck": "next typegen && tsgo --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized local development ports and env variables across Admin, Editor, and Evals to reduce conflicts. Updated E2E workflow and docs to reflect the new URLs.

- **Migration**
  - New ports: Admin 3200, Editor 3101, Evals 3201.
  - Update local .env files to match examples (NEXT_PUBLIC_APP_DOMAIN; in Admin also set NEXT_PUBLIC_EDITOR_APP_URL=http://localhost:3101).
  - Restart dev servers and update any local bookmarks/proxies.

<sup>Written for commit 817794ff74554118eafdd26a690db0f09dece5c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

