### PR TITLE
refactor(apps): enable `cacheComponents` for admin, editor, and api apps

### DIFF
--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -3,6 +3,7 @@ import { type NextConfig } from "next";
 const CACHE_IMAGE_DAYS = 30;
 
 const nextConfig: NextConfig = {
+  cacheComponents: true,
   devIndicators: false,
   experimental: {
     authInterrupts: true,

--- a/apps/admin/src/app/(private)/app-stats.tsx
+++ b/apps/admin/src/app/(private)/app-stats.tsx
@@ -1,8 +1,13 @@
 import { Stats, StatsSkeleton } from "@/components/stats";
 import { countUsers } from "@/data/stats/count-users";
 import { UsersIcon } from "lucide-react";
+import { cacheLife } from "next/cache";
 
 export async function AppStats() {
+  "use cache";
+
+  cacheLife("minutes");
+
   const totalUsers = await countUsers();
 
   return (

--- a/apps/admin/src/app/(private)/layout.tsx
+++ b/apps/admin/src/app/(private)/layout.tsx
@@ -1,10 +1,12 @@
 import { getSession } from "@zoonk/core/users/session/get";
+import { FullPageLoading } from "@zoonk/ui/components/loading";
 import { SidebarInset, SidebarProvider } from "@zoonk/ui/components/sidebar";
 import { redirect, unauthorized } from "next/navigation";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { Suspense } from "react";
 import { AppSidebar } from "./app-sidebar";
 
-export default async function PrivateLayout({ children }: LayoutProps<"/">) {
+async function PrivateLayoutContent({ children }: React.PropsWithChildren) {
   const session = await getSession();
 
   if (!session) {
@@ -25,5 +27,13 @@ export default async function PrivateLayout({ children }: LayoutProps<"/">) {
         <SidebarInset>{children}</SidebarInset>
       </SidebarProvider>
     </NuqsAdapter>
+  );
+}
+
+export default function PrivateLayout({ children }: LayoutProps<"/">) {
+  return (
+    <Suspense fallback={<FullPageLoading />}>
+      <PrivateLayoutContent>{children}</PrivateLayoutContent>
+    </Suspense>
   );
 }

--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -12,6 +12,7 @@ const e2eAliases: Record<string, string> = isE2E
   : {};
 
 const nextConfig: NextConfig = {
+  cacheComponents: true,
   devIndicators: false,
   distDir: isE2E ? ".next-e2e" : ".next",
   experimental: {

--- a/apps/api/src/app/auth/layout.tsx
+++ b/apps/api/src/app/auth/layout.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export async function AuthLayoutContent({ children }: LayoutProps<"/auth">) {
+async function AuthLayoutContent({ children }: LayoutProps<"/auth">) {
   const locale = await getLocale();
 
   return (

--- a/apps/api/src/app/auth/layout.tsx
+++ b/apps/api/src/app/auth/layout.tsx
@@ -2,7 +2,7 @@ import { Container } from "@zoonk/ui/components/container";
 import { FullPageLoading } from "@zoonk/ui/components/loading";
 import { type Metadata } from "next";
 import { NextIntlClientProvider } from "next-intl";
-import { getExtracted, getLocale } from "next-intl/server";
+import { getExtracted } from "next-intl/server";
 import "@zoonk/ui/globals.css";
 import { Suspense } from "react";
 
@@ -14,11 +14,9 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function AuthLayout({ children }: LayoutProps<"/auth">) {
-  const locale = await getLocale();
-
+export default function AuthLayout({ children }: LayoutProps<"/auth">) {
   return (
-    <html lang={locale}>
+    <html lang="en">
       <body className="font-sans antialiased">
         <Suspense fallback={<FullPageLoading />}>
           <NextIntlClientProvider>

--- a/apps/api/src/app/auth/layout.tsx
+++ b/apps/api/src/app/auth/layout.tsx
@@ -2,9 +2,9 @@ import { Container } from "@zoonk/ui/components/container";
 import { FullPageLoading } from "@zoonk/ui/components/loading";
 import { type Metadata } from "next";
 import { NextIntlClientProvider } from "next-intl";
-import { getExtracted } from "next-intl/server";
-import "@zoonk/ui/globals.css";
+import { getExtracted, getLocale } from "next-intl/server";
 import { Suspense } from "react";
+import "@zoonk/ui/globals.css";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted();
@@ -14,9 +14,11 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default function AuthLayout({ children }: LayoutProps<"/auth">) {
+export async function AuthLayoutContent({ children }: LayoutProps<"/auth">) {
+  const locale = await getLocale();
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <body className="font-sans antialiased">
         <Suspense fallback={<FullPageLoading />}>
           <NextIntlClientProvider>
@@ -25,5 +27,13 @@ export default function AuthLayout({ children }: LayoutProps<"/auth">) {
         </Suspense>
       </body>
     </html>
+  );
+}
+
+export default function AuthLayout(props: LayoutProps<"/auth">) {
+  return (
+    <Suspense fallback={<FullPageLoading />}>
+      <AuthLayoutContent {...props} />
+    </Suspense>
   );
 }

--- a/apps/editor/e2e/chapter-content.test.ts
+++ b/apps/editor/e2e/chapter-content.test.ts
@@ -258,6 +258,9 @@ test.describe("Chapter Content Page", () => {
     await expect(authenticatedPage).toHaveURL(new RegExp(`/ai/c/en/${course.slug}$`));
 
     // Verify the updated description shows in the chapter list
-    await expect(authenticatedPage.getByText(uniqueDescription)).toBeVisible();
+    // Scope to the chapter's link element since getByRole filters by visibility
+    await expect(
+      authenticatedPage.getByRole("link", { name: chapter.title }).getByText(uniqueDescription),
+    ).toBeVisible();
   });
 });

--- a/apps/editor/e2e/lesson-content.test.ts
+++ b/apps/editor/e2e/lesson-content.test.ts
@@ -279,6 +279,9 @@ test.describe("Lesson Content Page", () => {
     );
 
     // Verify the updated description shows in the lesson list
-    await expect(authenticatedPage.getByText(uniqueDescription)).toBeVisible();
+    // Scope to the lesson's link element since getByRole filters by visibility
+    await expect(
+      authenticatedPage.getByRole("link", { name: lesson.title }).getByText(uniqueDescription),
+    ).toBeVisible();
   });
 });

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -15,6 +15,7 @@ const e2eAliases: Record<string, string> = isE2E
   : {};
 
 const nextConfig: NextConfig = {
+  cacheComponents: true,
   devIndicators: false,
   // Use separate build directories so E2E and production builds don't conflict
   distDir: isE2E ? ".next-e2e" : ".next",

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[activityId]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[activityId]/page.tsx
@@ -1,6 +1,7 @@
 import { BackLink, BackLinkSkeleton } from "@/components/back-link";
 import { getLesson } from "@/data/lessons/get-lesson";
 import { Container, ContainerBody } from "@zoonk/ui/components/container";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { getExtracted } from "next-intl/server";
 import { Suspense } from "react";
 
@@ -37,8 +38,16 @@ async function ActivityPlaceholder() {
   );
 }
 
-export default async function ActivityPage(props: ActivityPageProps) {
-  const { chapterSlug, courseSlug, lang, lessonSlug, orgSlug } = await props.params;
+function ActivityPlaceholderSkeleton() {
+  return (
+    <div className="py-12 text-center">
+      <Skeleton className="mx-auto h-5 w-48" />
+    </div>
+  );
+}
+
+async function ActivityPagePreload({ params }: { params: ActivityPageProps["params"] }) {
+  const { chapterSlug, courseSlug, lang, lessonSlug, orgSlug } = await params;
 
   void getLesson({
     chapterSlug,
@@ -48,14 +57,24 @@ export default async function ActivityPage(props: ActivityPageProps) {
     orgSlug,
   });
 
+  return null;
+}
+
+export default function ActivityPage(props: ActivityPageProps) {
   return (
     <Container variant="narrow">
+      <Suspense>
+        <ActivityPagePreload params={props.params} />
+      </Suspense>
+
       <Suspense fallback={<BackLinkSkeleton />}>
         <ActivityBackLink params={props.params} />
       </Suspense>
 
       <ContainerBody>
-        <ActivityPlaceholder />
+        <Suspense fallback={<ActivityPlaceholderSkeleton />}>
+          <ActivityPlaceholder />
+        </Suspense>
       </ContainerBody>
     </Container>
   );

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[activityId]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[activityId]/page.tsx
@@ -46,27 +46,9 @@ function ActivityPlaceholderSkeleton() {
   );
 }
 
-async function ActivityPagePreload({ params }: { params: ActivityPageProps["params"] }) {
-  const { chapterSlug, courseSlug, lang, lessonSlug, orgSlug } = await params;
-
-  void getLesson({
-    chapterSlug,
-    courseSlug,
-    language: lang,
-    lessonSlug,
-    orgSlug,
-  });
-
-  return null;
-}
-
 export default function ActivityPage(props: ActivityPageProps) {
   return (
     <Container variant="narrow">
-      <Suspense>
-        <ActivityPagePreload params={props.params} />
-      </Suspense>
-
       <Suspense fallback={<BackLinkSkeleton />}>
         <ActivityBackLink params={props.params} />
       </Suspense>

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -2,8 +2,6 @@ import { BackLinkSkeleton } from "@/components/back-link";
 import { ContentEditorSkeleton } from "@/components/content-editor";
 import { EditorListSkeleton } from "@/components/editor-list";
 import { SlugEditorSkeleton } from "@/components/slug-editor";
-import { getChapter } from "@/data/chapters/get-chapter";
-import { getLesson } from "@/data/lessons/get-lesson";
 import { Container, ContainerBody } from "@zoonk/ui/components/container";
 import { Suspense } from "react";
 import { ActivityList } from "./activity-list";
@@ -11,37 +9,11 @@ import { LessonBackLink } from "./lesson-back-link";
 import { LessonContent } from "./lesson-content";
 import { LessonSlug } from "./lesson-slug";
 
-async function LessonPagePreload({
-  params,
-}: {
-  params: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]">["params"];
-}) {
-  const { chapterSlug, courseSlug, lang, lessonSlug, orgSlug } = await params;
-
-  // Preload data in parallel (cached, so child components get the same promise)
-  void Promise.all([
-    getChapter({ chapterSlug, courseSlug, language: lang, orgSlug }),
-    getLesson({
-      chapterSlug,
-      courseSlug,
-      language: lang,
-      lessonSlug,
-      orgSlug,
-    }),
-  ]);
-
-  return null;
-}
-
 export default function LessonPage(
   props: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]">,
 ) {
   return (
     <Container variant="narrow">
-      <Suspense>
-        <LessonPagePreload params={props.params} />
-      </Suspense>
-
       <Suspense fallback={<BackLinkSkeleton />}>
         <LessonBackLink params={props.params} />
       </Suspense>

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -11,10 +11,12 @@ import { LessonBackLink } from "./lesson-back-link";
 import { LessonContent } from "./lesson-content";
 import { LessonSlug } from "./lesson-slug";
 
-export default async function LessonPage(
-  props: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]">,
-) {
-  const { chapterSlug, courseSlug, lang, lessonSlug, orgSlug } = await props.params;
+async function LessonPagePreload({
+  params,
+}: {
+  params: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]">["params"];
+}) {
+  const { chapterSlug, courseSlug, lang, lessonSlug, orgSlug } = await params;
 
   // Preload data in parallel (cached, so child components get the same promise)
   void Promise.all([
@@ -28,8 +30,18 @@ export default async function LessonPage(
     }),
   ]);
 
+  return null;
+}
+
+export default function LessonPage(
+  props: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]">,
+) {
   return (
     <Container variant="narrow">
+      <Suspense>
+        <LessonPagePreload params={props.params} />
+      </Suspense>
+
       <Suspense fallback={<BackLinkSkeleton />}>
         <LessonBackLink params={props.params} />
       </Suspense>

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -2,8 +2,6 @@ import { BackLinkSkeleton } from "@/components/back-link";
 import { ContentEditorSkeleton } from "@/components/content-editor";
 import { EditorListSkeleton } from "@/components/editor-list";
 import { SlugEditorSkeleton } from "@/components/slug-editor";
-import { getChapter } from "@/data/chapters/get-chapter";
-import { getCourse } from "@/data/courses/get-course";
 import { Container, ContainerBody } from "@zoonk/ui/components/container";
 import { Suspense } from "react";
 import { ChapterBackLink } from "./chapter-back-link";
@@ -11,31 +9,11 @@ import { ChapterContent } from "./chapter-content";
 import { ChapterSlug } from "./chapter-slug";
 import { LessonList } from "./lesson-list";
 
-async function ChapterPagePreload({
-  params,
-}: {
-  params: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]">["params"];
-}) {
-  const { chapterSlug, courseSlug, lang, orgSlug } = await params;
-
-  // Preload data in parallel (cached, so child components get the same promise)
-  void Promise.all([
-    getCourse({ courseSlug, language: lang, orgSlug }),
-    getChapter({ chapterSlug, courseSlug, language: lang, orgSlug }),
-  ]);
-
-  return null;
-}
-
 export default function ChapterPage(
   props: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]">,
 ) {
   return (
     <Container variant="narrow">
-      <Suspense>
-        <ChapterPagePreload params={props.params} />
-      </Suspense>
-
       <Suspense fallback={<BackLinkSkeleton />}>
         <ChapterBackLink params={props.params} />
       </Suspense>

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -11,10 +11,12 @@ import { ChapterContent } from "./chapter-content";
 import { ChapterSlug } from "./chapter-slug";
 import { LessonList } from "./lesson-list";
 
-export default async function ChapterPage(
-  props: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]">,
-) {
-  const { chapterSlug, courseSlug, lang, orgSlug } = await props.params;
+async function ChapterPagePreload({
+  params,
+}: {
+  params: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]">["params"];
+}) {
+  const { chapterSlug, courseSlug, lang, orgSlug } = await params;
 
   // Preload data in parallel (cached, so child components get the same promise)
   void Promise.all([
@@ -22,8 +24,18 @@ export default async function ChapterPage(
     getChapter({ chapterSlug, courseSlug, language: lang, orgSlug }),
   ]);
 
+  return null;
+}
+
+export default function ChapterPage(
+  props: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]/ch/[chapterSlug]">,
+) {
   return (
     <Container variant="narrow">
+      <Suspense>
+        <ChapterPagePreload params={props.params} />
+      </Suspense>
+
       <Suspense fallback={<BackLinkSkeleton />}>
         <ChapterBackLink params={props.params} />
       </Suspense>

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
@@ -3,9 +3,6 @@ import { CategoryEditorSkeleton } from "@/components/category/category-editor";
 import { ContentEditorSkeleton } from "@/components/content-editor";
 import { EditorListSkeleton } from "@/components/editor-list";
 import { SlugEditorSkeleton } from "@/components/slug-editor";
-import { listCourseCategories } from "@/data/categories/list-course-categories";
-import { listCourseChapters } from "@/data/chapters/list-course-chapters";
-import { getCourse } from "@/data/courses/get-course";
 import { Container, ContainerBody } from "@zoonk/ui/components/container";
 import { ImageUploadSkeleton } from "@zoonk/ui/components/image-upload";
 import { Suspense } from "react";
@@ -16,30 +13,9 @@ import { CourseContent } from "./course-content";
 import { CourseImage } from "./course-image";
 import { CourseSlug } from "./course-slug";
 
-async function CoursePagePreload({
-  params,
-}: {
-  params: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]">["params"];
-}) {
-  const { courseSlug, lang, orgSlug } = await params;
-
-  // Preload data in parallel (cached, so child components get the same promise)
-  void Promise.all([
-    getCourse({ courseSlug, language: lang, orgSlug }),
-    listCourseCategories({ courseSlug, language: lang, orgSlug }),
-    listCourseChapters({ courseSlug, language: lang, orgSlug }),
-  ]);
-
-  return null;
-}
-
 export default function CoursePage(props: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]">) {
   return (
     <Container variant="narrow">
-      <Suspense>
-        <CoursePagePreload params={props.params} />
-      </Suspense>
-
       <Suspense fallback={<ImageUploadSkeleton />}>
         <CourseImage params={props.params} />
       </Suspense>

--- a/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[lang]/[courseSlug]/page.tsx
@@ -16,8 +16,12 @@ import { CourseContent } from "./course-content";
 import { CourseImage } from "./course-image";
 import { CourseSlug } from "./course-slug";
 
-export default async function CoursePage(props: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]">) {
-  const { courseSlug, lang, orgSlug } = await props.params;
+async function CoursePagePreload({
+  params,
+}: {
+  params: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]">["params"];
+}) {
+  const { courseSlug, lang, orgSlug } = await params;
 
   // Preload data in parallel (cached, so child components get the same promise)
   void Promise.all([
@@ -26,8 +30,16 @@ export default async function CoursePage(props: PageProps<"/[orgSlug]/c/[lang]/[
     listCourseChapters({ courseSlug, language: lang, orgSlug }),
   ]);
 
+  return null;
+}
+
+export default function CoursePage(props: PageProps<"/[orgSlug]/c/[lang]/[courseSlug]">) {
   return (
     <Container variant="narrow">
+      <Suspense>
+        <CoursePagePreload params={props.params} />
+      </Suspense>
+
       <Suspense fallback={<ImageUploadSkeleton />}>
         <CourseImage params={props.params} />
       </Suspense>

--- a/apps/editor/src/app/[orgSlug]/layout.tsx
+++ b/apps/editor/src/app/[orgSlug]/layout.tsx
@@ -1,6 +1,7 @@
 import { EditorNavbar } from "@/components/navbar";
 import { getOrganization } from "@zoonk/core/orgs/get";
 import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
+import { FullPageLoading } from "@zoonk/ui/components/loading";
 import { notFound, unauthorized } from "next/navigation";
 import { Suspense } from "react";
 
@@ -31,7 +32,7 @@ async function LayoutPermissions({ children, navbarActions, params }: LayoutProp
 
 export default async function OrgHomeLayout({ children, ...props }: LayoutProps<"/[orgSlug]">) {
   return (
-    <Suspense>
+    <Suspense fallback={<FullPageLoading />}>
       <LayoutPermissions {...props}>{children}</LayoutPermissions>
     </Suspense>
   );

--- a/apps/editor/src/app/[orgSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/page.tsx
@@ -1,5 +1,6 @@
 import { getOrganization } from "@zoonk/core/orgs/get";
-import { Container } from "@zoonk/ui/components/container";
+import { Container, ContainerHeader } from "@zoonk/ui/components/container";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { CourseListSkeleton } from "@zoonk/ui/patterns/courses/list";
 import { type Metadata } from "next";
 import { Suspense } from "react";
@@ -17,10 +18,20 @@ export async function generateMetadata({ params }: PageProps<"/[orgSlug]">): Pro
   return { title: org.name };
 }
 
-export default async function OrgHomePage({ params }: PageProps<"/[orgSlug]">) {
+function HomeContainerHeaderSkeleton() {
+  return (
+    <ContainerHeader>
+      <Skeleton className="h-7 w-32" />
+    </ContainerHeader>
+  );
+}
+
+export default function OrgHomePage({ params }: PageProps<"/[orgSlug]">) {
   return (
     <Container variant="list">
-      <HomeContainerHeader params={params} />
+      <Suspense fallback={<HomeContainerHeaderSkeleton />}>
+        <HomeContainerHeader params={params} />
+      </Suspense>
 
       <Suspense fallback={<CourseListSkeleton />}>
         <ListCourses params={params} />

--- a/apps/editor/src/app/layout.tsx
+++ b/apps/editor/src/app/layout.tsx
@@ -1,8 +1,9 @@
+import { FullPageLoading } from "@zoonk/ui/components/loading";
 import { Toaster } from "@zoonk/ui/components/sonner";
 import { type Metadata } from "next";
 import { NextIntlClientProvider } from "next-intl";
+import { Suspense } from "react";
 import "@zoonk/ui/globals.css";
-import { getLocale } from "next-intl/server";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://editor.zoonk.com"),
@@ -12,13 +13,13 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function LocaleLayout({ children }: LayoutProps<"/">) {
-  const locale = await getLocale();
-
+export default function LocaleLayout({ children }: LayoutProps<"/">) {
   return (
-    <html lang={locale}>
+    <html lang="en">
       <body className="font-sans antialiased">
-        <NextIntlClientProvider>{children}</NextIntlClientProvider>
+        <Suspense fallback={<FullPageLoading />}>
+          <NextIntlClientProvider>{children}</NextIntlClientProvider>
+        </Suspense>
         <Toaster />
       </body>
     </html>

--- a/apps/editor/src/app/layout.tsx
+++ b/apps/editor/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { FullPageLoading } from "@zoonk/ui/components/loading";
 import { Toaster } from "@zoonk/ui/components/sonner";
 import { type Metadata } from "next";
 import { NextIntlClientProvider } from "next-intl";
+import { getLocale } from "next-intl/server";
 import { Suspense } from "react";
 import "@zoonk/ui/globals.css";
 
@@ -13,9 +14,11 @@ export const metadata: Metadata = {
   },
 };
 
-export default function LocaleLayout({ children }: LayoutProps<"/">) {
+async function AppLayoutContent({ children }: LayoutProps<"/">) {
+  const locale = await getLocale();
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <body className="font-sans antialiased">
         <Suspense fallback={<FullPageLoading />}>
           <NextIntlClientProvider>{children}</NextIntlClientProvider>
@@ -23,5 +26,13 @@ export default function LocaleLayout({ children }: LayoutProps<"/">) {
         <Toaster />
       </body>
     </html>
+  );
+}
+
+export default function AppLayout(props: LayoutProps<"/">) {
+  return (
+    <Suspense fallback={<FullPageLoading />}>
+      <AppLayoutContent {...props} />
+    </Suspense>
   );
 }

--- a/apps/editor/src/app/login/page.tsx
+++ b/apps/editor/src/app/login/page.tsx
@@ -1,8 +1,20 @@
 import { externalRedirect } from "@zoonk/next/navigation/external-redirect";
+import { FullPageLoading } from "@zoonk/ui/components/loading";
 import { buildAuthLoginUrl, getBaseUrl } from "@zoonk/utils/url";
+import { connection } from "next/server";
+import { Suspense } from "react";
 
-export default async function LoginPage() {
+async function LoginPageContent(): Promise<React.ReactNode> {
+  await connection();
   const callbackUrl = `${getBaseUrl()}/auth/callback`;
   const authUrl = buildAuthLoginUrl({ callbackUrl });
-  externalRedirect(authUrl);
+  return externalRedirect(authUrl);
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={<FullPageLoading />}>
+      <LoginPageContent />
+    </Suspense>
+  );
 }

--- a/apps/editor/src/app/page.tsx
+++ b/apps/editor/src/app/page.tsx
@@ -1,9 +1,11 @@
 import { findOrganizationById } from "@zoonk/core/orgs/find";
 import { listUserOrgs } from "@zoonk/core/users/orgs/list";
 import { getSession } from "@zoonk/core/users/session/get";
+import { FullPageLoading } from "@zoonk/ui/components/loading";
 import { redirect, unauthorized } from "next/navigation";
+import { Suspense } from "react";
 
-export default async function HomePage() {
+async function HomePageContent() {
   const [userSession, orgs] = await Promise.all([getSession(), listUserOrgs()]);
 
   const firstOrg = orgs.data[0];
@@ -18,4 +20,12 @@ export default async function HomePage() {
 
   // Restrict access when they don't belong to any organization
   return unauthorized();
+}
+
+export default function HomePage() {
+  return (
+    <Suspense fallback={<FullPageLoading />}>
+      <HomePageContent />
+    </Suspense>
+  );
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enabled Next.js cacheComponents across admin, editor, and api to improve client-side navigation and performance. Refactored pages and tests to work with Activity-based navigation and hidden DOM.

- **Refactors**
  - Enabled cacheComponents in admin, editor, and api next.config.
  - Added Suspense fallbacks (FullPageLoading, skeletons) to key layouts and pages.
  - Removed manual data preloads in editor pages; rely on cacheComponents + Suspense.
  - Added "use cache" and cacheLife("minutes") to admin AppStats.
  - Simplified locale/auth: set html lang from the current locale and moved login redirect into a Suspense flow with connection().

- **Bug Fixes**
  - Updated editor E2E selectors to scope assertions with getByRole to avoid strict mode violations from hidden Activity components.
  - Documented testing guidance for cacheComponents/Activity in SKILL.md.

<sup>Written for commit 41ca3c0b66c0bf91e8d4316d5176ea55d96636f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

