### PR TITLE
chore(db): add seed for subscriptions

### DIFF
--- a/packages/db/src/prisma/seed.ts
+++ b/packages/db/src/prisma/seed.ts
@@ -12,12 +12,14 @@ import { seedOrganizations } from "./seed/orgs";
 import { seedProgress } from "./seed/progress";
 import { seedSentences } from "./seed/sentences";
 import { seedSteps } from "./seed/steps";
+import { seedSubscriptions } from "./seed/subscriptions";
 import { seedUsers } from "./seed/users";
 import { seedWords } from "./seed/words";
 
 async function main() {
   const users = await seedUsers(prisma);
   await seedAccounts(prisma, users);
+  await seedSubscriptions(prisma, users);
   const orgs = await seedOrganizations(prisma, users);
   await seedCourses(prisma, orgs);
   await seedCategories(prisma, orgs.ai);

--- a/packages/db/src/prisma/seed/subscriptions.ts
+++ b/packages/db/src/prisma/seed/subscriptions.ts
@@ -1,0 +1,28 @@
+import { type PrismaClient } from "../../generated/prisma/client";
+import { type SeedUsers } from "./users";
+
+export async function seedSubscriptions(prisma: PrismaClient, users: SeedUsers): Promise<void> {
+  const userIds = Object.values(users).map((user) => String(user.id));
+
+  await prisma.subscription.deleteMany({
+    where: { referenceId: { in: userIds } },
+  });
+
+  const now = new Date();
+  const oneYearFromNow = new Date(now);
+  oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1);
+
+  const subscriptionData = Object.values(users).map((user) => ({
+    periodEnd: oneYearFromNow,
+    periodStart: now,
+    plan: "hobby",
+    referenceId: String(user.id),
+    status: "active",
+    stripeCustomerId: null,
+    stripeSubscriptionId: null,
+  }));
+
+  await prisma.subscription.createMany({
+    data: subscriptionData,
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add subscription seeding to the Prisma seed script so dev environments have active subscriptions for all seeded users. This supports testing subscription flows locally.

- **New Features**
  - Deletes existing subscriptions for seeded users to avoid duplicates.
  - Creates new subscriptions with periodStart set to now and periodEnd set to +1 year.
  - Runs after account seeding in the main seed flow.

<sup>Written for commit 38a5d0020a4b4fb5946d43c85b9bcf3d36cf84b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

