### PR TITLE
feat(lint): add linting rules to disallow dynamic translation keys and t function as argument

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -92,8 +92,10 @@
     "vitest/require-top-level-describe": "off",
 
     // custom rules
+    "zoonk/no-dynamic-translation-key": "error",
     "zoonk/no-object-params-in-cache": ["error", { "exceptions": ["headers"] }],
-    "zoonk/no-single-use-type-alias": "error"
+    "zoonk/no-single-use-type-alias": "error",
+    "zoonk/no-t-function-as-argument": "error"
   },
   "overrides": [
     {

--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -1,13 +1,17 @@
 import { definePlugin } from "oxlint";
+import noDynamicTranslationKey from "./rules/no-dynamic-translation-key.js";
 import noObjectParamsInCache from "./rules/no-object-params-in-cache.js";
 import noSingleUseTypeAlias from "./rules/no-single-use-type-alias.js";
+import noTFunctionAsArgument from "./rules/no-t-function-as-argument.js";
 
 export default definePlugin({
   meta: {
     name: "zoonk",
   },
   rules: {
+    "no-dynamic-translation-key": noDynamicTranslationKey,
     "no-object-params-in-cache": noObjectParamsInCache,
     "no-single-use-type-alias": noSingleUseTypeAlias,
+    "no-t-function-as-argument": noTFunctionAsArgument,
   },
 });

--- a/packages/eslint-plugin/rules/no-dynamic-translation-key.js
+++ b/packages/eslint-plugin/rules/no-dynamic-translation-key.js
@@ -1,0 +1,128 @@
+import { defineRule } from "oxlint";
+
+function isGetExtractedCall(node) {
+  if (!node) {
+    return false;
+  }
+
+  if (node.type === "AwaitExpression") {
+    return isGetExtractedCall(node.argument);
+  }
+
+  if (node.type !== "CallExpression") {
+    return false;
+  }
+
+  if (node.callee.type === "Identifier" && node.callee.name === "getExtracted") {
+    return true;
+  }
+
+  return false;
+}
+
+function isUseExtractedCall(node) {
+  if (!node) {
+    return false;
+  }
+
+  if (node.type !== "CallExpression") {
+    return false;
+  }
+
+  if (node.callee.type === "Identifier" && node.callee.name === "useExtracted") {
+    return true;
+  }
+
+  return false;
+}
+
+function isTVariable(node) {
+  return isGetExtractedCall(node) || isUseExtractedCall(node);
+}
+
+function isStringLiteral(node) {
+  if (!node) {
+    return false;
+  }
+
+  // String literal
+  if (node.type === "Literal" && typeof node.value === "string") {
+    return true;
+  }
+
+  return false;
+}
+
+export default defineRule({
+  createOnce(context) {
+    let tVariableNames;
+
+    return {
+      before() {
+        tVariableNames = new Set();
+      },
+
+      VariableDeclarator(node) {
+        if (!node.id || node.id.type !== "Identifier") {
+          return;
+        }
+
+        if (isTVariable(node.init)) {
+          tVariableNames.add(node.id.name);
+        }
+      },
+
+      CallExpression(node) {
+        if (tVariableNames.size === 0) {
+          return;
+        }
+
+        // Get the callee name
+        let calleeName = null;
+
+        // Direct call: t("key")
+        if (node.callee.type === "Identifier") {
+          calleeName = node.callee.name;
+        }
+
+        // Method call: t.rich("key"), t.raw("key"), t.markup("key")
+        if (node.callee.type === "MemberExpression" && node.callee.object.type === "Identifier") {
+          calleeName = node.callee.object.name;
+        }
+
+        // Skip if not a t function call
+        if (!calleeName || !tVariableNames.has(calleeName)) {
+          return;
+        }
+
+        const firstArg = node.arguments[0];
+
+        // No arguments - skip (invalid call anyway)
+        if (!firstArg) {
+          return;
+        }
+
+        // Check if first argument is a string literal
+        if (!isStringLiteral(firstArg)) {
+          context.report({
+            loc: firstArg.loc,
+            messageId: "noDynamicKey",
+          });
+        }
+      },
+    };
+  },
+
+  meta: {
+    docs: {
+      description:
+        "Disallow dynamic keys (variables, expressions, template literals) as the first argument to the t() translation function",
+    },
+    messages: {
+      noDynamicKey:
+        'Translation key must be a string literal. Dynamic keys like t(variable) or t(`template`) break i18n extraction. Use t("String literal") instead.',
+    },
+    schema: [],
+    type: "problem",
+  },
+});

--- a/packages/eslint-plugin/rules/no-t-function-as-argument.js
+++ b/packages/eslint-plugin/rules/no-t-function-as-argument.js
@@ -1,0 +1,142 @@
+import { defineRule } from "oxlint";
+
+function isGetExtractedCall(node) {
+  if (!node) {
+    return false;
+  }
+
+  if (node.type === "AwaitExpression") {
+    return isGetExtractedCall(node.argument);
+  }
+
+  if (node.type !== "CallExpression") {
+    return false;
+  }
+
+  if (node.callee.type === "Identifier" && node.callee.name === "getExtracted") {
+    return true;
+  }
+
+  return false;
+}
+
+function isUseExtractedCall(node) {
+  if (!node) {
+    return false;
+  }
+
+  if (node.type !== "CallExpression") {
+    return false;
+  }
+
+  if (node.callee.type === "Identifier" && node.callee.name === "useExtracted") {
+    return true;
+  }
+
+  return false;
+}
+
+function isTVariable(node) {
+  return isGetExtractedCall(node) || isUseExtractedCall(node);
+}
+
+function checkObjectProperty(prop, tVariableNames, context) {
+  if (prop.type !== "Property") {
+    return;
+  }
+
+  // Check shorthand first: { t } - use key since it's the visible identifier
+  if (prop.shorthand && prop.key.type === "Identifier" && tVariableNames.has(prop.key.name)) {
+    context.report({
+      data: { name: prop.key.name },
+      loc: prop.key.loc,
+      messageId: "noTFunctionAsArgument",
+    });
+    return;
+  }
+
+  // Non-shorthand: { translate: t }
+  if (prop.value.type === "Identifier" && tVariableNames.has(prop.value.name)) {
+    context.report({
+      data: { name: prop.value.name },
+      loc: prop.value.loc,
+      messageId: "noTFunctionAsArgument",
+    });
+  }
+}
+
+export default defineRule({
+  createOnce(context) {
+    let tVariableNames;
+
+    return {
+      before() {
+        tVariableNames = new Set();
+      },
+
+      VariableDeclarator(node) {
+        if (!node.id || node.id.type !== "Identifier") {
+          return;
+        }
+
+        if (isTVariable(node.init)) {
+          tVariableNames.add(node.id.name);
+        }
+      },
+
+      CallExpression(node) {
+        if (tVariableNames.size === 0) {
+          return;
+        }
+
+        // Get the callee name for checking if this is a direct t() call
+        let calleeName = null;
+
+        if (node.callee.type === "Identifier") {
+          calleeName = node.callee.name;
+        } else if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.object.type === "Identifier"
+        ) {
+          calleeName = node.callee.object.name;
+        }
+
+        // Skip if this is calling t itself (t("key") or t.rich("key"))
+        if (calleeName && tVariableNames.has(calleeName)) {
+          return;
+        }
+
+        // Check if any argument is the t variable
+        for (const arg of node.arguments) {
+          if (arg.type === "Identifier" && tVariableNames.has(arg.name)) {
+            context.report({
+              data: { name: arg.name },
+              loc: arg.loc,
+              messageId: "noTFunctionAsArgument",
+            });
+          }
+
+          // Also check object properties: someHelper({ translate: t }) or { t }
+          if (arg.type === "ObjectExpression") {
+            for (const prop of arg.properties) {
+              checkObjectProperty(prop, tVariableNames, context);
+            }
+          }
+        }
+      },
+    };
+  },
+
+  meta: {
+    docs: {
+      description:
+        "Disallow passing the t function (from getExtracted/useExtracted) as an argument to other functions, which breaks i18n extraction",
+    },
+    messages: {
+      noTFunctionAsArgument:
+        "Do not pass '{{name}}' as a function argument. This breaks i18n extraction. Instead, create a function that calls getExtracted() or useExtracted() internally.",
+    },
+    schema: [],
+    type: "problem",
+  },
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add lint rules to enforce static translation keys and prevent passing the t function as an argument. This ensures reliable i18n extraction and consistent usage across the codebase.

- **New Features**
  - no-dynamic-translation-key: flags t calls where the first argument is not a string literal (variables, expressions, template literals).
  - no-t-function-as-argument: flags passing t (from getExtracted/useExtracted) as an argument or via object properties; direct t() calls are allowed.
  - Enabled both rules as errors in .oxlintrc.

- **Migration**
  - Use string literals for all translation keys: t("key"), t.rich("key").
  - Do not pass t to other functions. Call getExtracted/useExtracted inside those functions instead.

<sup>Written for commit 41413b0f3a6e3337f6459f18f32fa120d892af2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

