### PR TITLE
fix(test): use specific selectors to prevent flaky form tests

### DIFF
--- a/apps/editor/e2e/command-palette.test.ts
+++ b/apps/editor/e2e/command-palette.test.ts
@@ -257,39 +257,33 @@ test.describe("Command Palette - Keyboard Navigation", () => {
     await expect(firstOption).toBeVisible();
     const firstName = await firstOption.textContent();
 
-    // Press ArrowDown and wait for selection to change
-    await ownerPage.keyboard.press("ArrowDown");
-
     if (!firstName) {
       throw new Error("Expected first option to have text content");
     }
 
-    // Wait for the selection to move to a DIFFERENT item
-    await expect(dialog.getByRole("option", { name: firstName, selected: true })).not.toBeVisible();
+    // Press ArrowDown and poll until selection changes to a different item
+    await ownerPage.keyboard.press("ArrowDown");
+    await expect(async () => {
+      const currentSelected = dialog.getByRole("option", { selected: true });
+      const currentName = await currentSelected.textContent();
+      expect(currentName).not.toBe(firstName);
+    }).toPass();
 
-    // Verify a new item is selected
+    // Get the second item's name for the ArrowUp test
     const secondOption = dialog.getByRole("option", { selected: true });
-    await expect(secondOption).toBeVisible();
     const secondName = await secondOption.textContent();
-    expect(secondName).not.toBe(firstName);
-
-    // Press ArrowUp and wait for selection to change back
-    await ownerPage.keyboard.press("ArrowUp");
 
     if (!secondName) {
       throw new Error("Expected second option to have text content");
     }
 
-    // Wait for selection to move away from second item
-    await expect(
-      dialog.getByRole("option", {
-        name: secondName,
-        selected: true,
-      }),
-    ).not.toBeVisible();
-
-    // Verify we're back on the first item
-    await expect(dialog.getByRole("option", { name: firstName, selected: true })).toBeVisible();
+    // Press ArrowUp and poll until selection changes back to first item
+    await ownerPage.keyboard.press("ArrowUp");
+    await expect(async () => {
+      const currentSelected = dialog.getByRole("option", { selected: true });
+      const currentName = await currentSelected.textContent();
+      expect(currentName).toBe(firstName);
+    }).toPass();
   });
 
   test("Enter to select navigates correctly", async ({ ownerPage }) => {

--- a/apps/editor/e2e/new-course.test.ts
+++ b/apps/editor/e2e/new-course.test.ts
@@ -148,8 +148,10 @@ test.describe("Course Creation Wizard - Keyboard Shortcuts", () => {
 
   test("Escape closes wizard and returns to org home", async ({ authenticatedPage }) => {
     // Wait for the input to be focused, ensuring the component is fully interactive
-    // And the keyboard handler is attached via useEffect
     await expect(authenticatedPage.getByPlaceholder(/course title/i)).toBeFocused();
+
+    // Wait for all network requests to complete, ensuring keyboard handlers are attached
+    await authenticatedPage.waitForLoadState("networkidle");
 
     await authenticatedPage.keyboard.press("Escape");
 

--- a/apps/main/e2e/content-feedback.test.ts
+++ b/apps/main/e2e/content-feedback.test.ts
@@ -32,13 +32,15 @@ test.describe("Content Feedback", () => {
     await page.getByRole("button", { name: /send feedback/i }).click();
 
     const dialog = page.getByRole("dialog");
-    const emailInput = dialog.getByLabel(/email/i);
+    const emailInput = dialog.getByRole("textbox", { name: /email address/i });
+    const messageInput = dialog.getByRole("textbox", { name: /^message$/i });
 
-    // Wait for dialog to be fully visible and email input to be enabled
+    // Wait for dialog to be fully visible and inputs to be enabled
     await expect(emailInput).toBeEnabled();
+    await expect(messageInput).toBeEnabled();
 
     await emailInput.fill("test@example.com");
-    await dialog.getByLabel(/message/i).fill("This is test feedback");
+    await messageInput.fill("This is test feedback");
     await dialog.getByRole("button", { name: /send message/i }).click();
 
     await expect(dialog.getByText(/message sent successfully/i)).toBeVisible();
@@ -48,13 +50,15 @@ test.describe("Content Feedback", () => {
     await page.getByRole("button", { name: /send feedback/i }).click();
 
     const dialog = page.getByRole("dialog");
-    const emailInput = dialog.getByLabel(/email/i);
+    const emailInput = dialog.getByRole("textbox", { name: /email address/i });
+    const messageInput = dialog.getByRole("textbox", { name: /^message$/i });
 
-    // Wait for dialog to be fully visible and email input to be enabled
+    // Wait for dialog to be fully visible and inputs to be enabled
     await expect(emailInput).toBeEnabled();
+    await expect(messageInput).toBeEnabled();
 
     await emailInput.fill("invalid-email");
-    await dialog.getByLabel(/message/i).fill("This is test feedback");
+    await messageInput.fill("This is test feedback");
     await dialog.getByRole("button", { name: /send message/i }).click();
 
     // Browser validation prevents submission - verify semantically:
@@ -69,15 +73,17 @@ test.describe("Content Feedback", () => {
     await page.getByRole("button", { name: /send feedback/i }).click();
 
     const dialog = page.getByRole("dialog");
-    const emailInput = dialog.getByLabel(/email/i);
+    const emailInput = dialog.getByRole("textbox", { name: /email address/i });
+    const messageInput = dialog.getByRole("textbox", { name: /^message$/i });
 
-    // Wait for dialog to be fully visible and email input to be enabled
+    // Wait for dialog to be fully visible and inputs to be enabled
     await expect(emailInput).toBeEnabled();
+    await expect(messageInput).toBeEnabled();
 
     await emailInput.fill("test@example.com");
 
     // Whitespace passes HTML5 "required" but fails server-side when trimmed
-    await dialog.getByLabel(/message/i).fill("   ");
+    await messageInput.fill("   ");
     await dialog.getByRole("button", { name: /send message/i }).click();
 
     await expect(dialog.getByText(/failed to send message/i)).toBeVisible();
@@ -92,7 +98,7 @@ test.describe("Content Feedback - Authenticated", () => {
 
     await authenticatedPage.getByRole("button", { name: /send feedback/i }).click();
 
-    const emailInput = authenticatedPage.getByLabel(/email/i);
+    const emailInput = authenticatedPage.getByRole("textbox", { name: /email address/i });
 
     // Wait for dialog to be fully visible and email input to be enabled
     await expect(emailInput).toBeEnabled();

--- a/apps/main/e2e/course-detail.test.ts
+++ b/apps/main/e2e/course-detail.test.ts
@@ -116,6 +116,9 @@ test.describe("Course Detail Page - Locale", () => {
 
     await expect(page).toHaveURL(/\/pt\/b\/ai\/c\/machine-learning/);
 
+    // Wait for the course detail page to fully render
+    await page.waitForLoadState("domcontentloaded");
+
     await expect(page.getByText(/permite que computadores identifiquem/i).first()).toBeVisible();
   });
 });

--- a/apps/main/e2e/support.test.ts
+++ b/apps/main/e2e/support.test.ts
@@ -17,10 +17,14 @@ test.describe("Support page", () => {
     await page.getByRole("button", { name: /contact support/i }).click();
 
     const dialog = page.getByRole("dialog");
-    const emailInput = dialog.getByLabel(/email/i);
+    const emailInput = dialog.getByRole("textbox", { name: /email address/i });
+    const messageInput = dialog.getByRole("textbox", { name: /^message$/i });
+
     await expect(emailInput).toBeEnabled();
+    await expect(messageInput).toBeEnabled();
+
     await emailInput.fill("test@example.com");
-    await dialog.getByLabel(/message/i).fill("Test message");
+    await messageInput.fill("Test message");
     await dialog.getByRole("button", { name: /send message/i }).click();
 
     await expect(dialog.getByText(/message sent successfully/i)).toBeVisible();
@@ -30,10 +34,14 @@ test.describe("Support page", () => {
     await page.getByRole("button", { name: /contact support/i }).click();
 
     const dialog = page.getByRole("dialog");
-    const emailInput = dialog.getByLabel(/email/i);
+    const emailInput = dialog.getByRole("textbox", { name: /email address/i });
+    const messageInput = dialog.getByRole("textbox", { name: /^message$/i });
+
     await expect(emailInput).toBeEnabled();
+    await expect(messageInput).toBeEnabled();
+
     await emailInput.fill("invalid-email");
-    await dialog.getByLabel(/message/i).fill("Test message");
+    await messageInput.fill("Test message");
     await dialog.getByRole("button", { name: /send message/i }).click();
 
     // Browser validation prevents submission - verify semantically:
@@ -48,12 +56,16 @@ test.describe("Support page", () => {
     await page.getByRole("button", { name: /contact support/i }).click();
 
     const dialog = page.getByRole("dialog");
-    const emailInput = dialog.getByLabel(/email/i);
+    const emailInput = dialog.getByRole("textbox", { name: /email address/i });
+    const messageInput = dialog.getByRole("textbox", { name: /^message$/i });
+
     await expect(emailInput).toBeEnabled();
+    await expect(messageInput).toBeEnabled();
+
     await emailInput.fill("test@example.com");
 
     // Whitespace passes HTML5 "required" but fails server-side when trimmed
-    await dialog.getByLabel(/message/i).fill("   ");
+    await messageInput.fill("   ");
     await dialog.getByRole("button", { name: /send message/i }).click();
 
     await expect(dialog.getByText(/failed to send message/i)).toBeVisible();
@@ -66,7 +78,9 @@ test.describe("Support page - Authenticated", () => {
 
     await authenticatedPage.getByRole("button", { name: /contact support/i }).click();
 
-    const emailInput = authenticatedPage.getByRole("dialog").getByLabel(/email/i);
+    const emailInput = authenticatedPage
+      .getByRole("dialog")
+      .getByRole("textbox", { name: /email address/i });
 
     await expect(emailInput).toBeEnabled();
 

--- a/packages/db/src/prisma/seed/subscriptions.ts
+++ b/packages/db/src/prisma/seed/subscriptions.ts
@@ -8,11 +8,15 @@ export async function seedSubscriptions(prisma: PrismaClient, users: SeedUsers):
     where: { referenceId: { in: userIds } },
   });
 
+  // Only seed subscriptions for non-e2e users.
+  // E2E test users need to start without subscriptions so tests can verify "no subscription" states.
+  const regularUsers = [users.owner, users.admin, users.member, users.logoutTest, users.multiOrg];
+
   const now = new Date();
   const oneYearFromNow = new Date(now);
   oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1);
 
-  const subscriptionData = Object.values(users).map((user) => ({
+  const subscriptionData = regularUsers.map((user) => ({
     periodEnd: oneYearFromNow,
     periodStart: now,
     plan: "hobby",


### PR DESCRIPTION
## Summary
- Replace loose `getByLabel(/email/i)` selectors with precise `getByRole("textbox", { name: /email address/i })` in content-feedback and support tests
- Add guidance to testing skill about avoiding loose regex patterns that cause flaky tests

## Root Cause
Loose regex patterns like `getByLabel(/email/i)` intermittently matched wrong elements, causing text to be filled into the email field instead of the message field. Screenshot from failure showed: `test@example.comThis is test feedback` in the email input.

## Test plan
- [x] Ran flaky test 30 times consecutively with 0 failures (was ~10% failure rate)
- [x] Full test suite passes (151/151)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky E2E tests by using precise role-based selectors and adding targeted waits/mocks across key flows. Also stops seeding subscriptions for E2E users to keep “no plan” states testable.

- **Bug Fixes**
  - Forms: use getByRole("textbox", { name: /email address/i }) and /^message$/i; wait for inputs to be enabled (content-feedback and support).
  - Command palette: poll selected option with expect().toPass() for ArrowUp/Down to avoid timing races.
  - Page loads: add networkidle/domcontentloaded waits in new-course and course-detail tests.
  - Generate course: create a unique suggestion with fixtures and set up mocks before navigation to avoid PPR caching; shows triggering state immediately.
  - Seeding: skip subscriptions for E2E users.

- **Refactors**
  - Testing guidance: SKILL.md now recommends getByRole with exact/anchored names and warns against loose regex in getByLabel, with examples.

<sup>Written for commit e4474f665ef28d09853e3bcdd11010aeb14751f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

