### PR TITLE
refactor(test): improve e2e test isolation and semantics

### DIFF
--- a/apps/editor/e2e/chapter-content.test.ts
+++ b/apps/editor/e2e/chapter-content.test.ts
@@ -86,7 +86,7 @@ test.describe("Chapter Content Page", () => {
       "machine-learning",
       "introduction-to-machine-learning",
     );
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
 
     await slugInput.fill("data-preparation");
 
@@ -104,7 +104,7 @@ test.describe("Chapter Content Page", () => {
       "machine-learning",
       "introduction-to-machine-learning",
     );
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
 
     await slugInput.fill("");
 
@@ -115,7 +115,7 @@ test.describe("Chapter Content Page", () => {
     const { chapter, course } = await createTestChapter();
     await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
 
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
     const uniqueSlug = `test-slug-${randomUUID().slice(0, 8)}`;
 
     await slugInput.fill(uniqueSlug);
@@ -138,7 +138,7 @@ test.describe("Chapter Content Page", () => {
       "machine-learning",
       "introduction-to-machine-learning",
     );
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
 
     await slugInput.fill("some-other-slug");
     await authenticatedPage.getByRole("button", { name: /cancel/i }).click();
@@ -150,7 +150,7 @@ test.describe("Chapter Content Page", () => {
     const { chapter, course } = await createTestChapter();
     await navigateToChapterPage(authenticatedPage, course.slug, chapter.slug);
 
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
     const uniqueSlug = `enter-test-${randomUUID().slice(0, 8)}`;
 
     await slugInput.fill(uniqueSlug);
@@ -173,7 +173,7 @@ test.describe("Chapter Content Page", () => {
       "machine-learning",
       "introduction-to-machine-learning",
     );
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
 
     await slugInput.fill("escape-test-slug");
     await slugInput.press("Escape");

--- a/apps/editor/e2e/course-content.test.ts
+++ b/apps/editor/e2e/course-content.test.ts
@@ -72,7 +72,7 @@ test.describe("Course Content Page", () => {
 
   test("shows validation error for duplicate slug", async ({ authenticatedPage }) => {
     await navigateToCoursePage(authenticatedPage, "machine-learning");
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
 
     await slugInput.fill("spanish");
 
@@ -86,7 +86,7 @@ test.describe("Course Content Page", () => {
 
   test("disables save for empty slug", async ({ authenticatedPage }) => {
     await navigateToCoursePage(authenticatedPage, "machine-learning");
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
 
     await slugInput.fill("");
 
@@ -97,7 +97,7 @@ test.describe("Course Content Page", () => {
     const course = await createTestCourse();
     await navigateToCoursePage(authenticatedPage, course.slug);
 
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
     const uniqueSlug = `test-slug-${randomUUID().slice(0, 8)}`;
 
     await slugInput.fill(uniqueSlug);
@@ -114,7 +114,7 @@ test.describe("Course Content Page", () => {
 
   test("reverts changes on cancel", async ({ authenticatedPage }) => {
     await navigateToCoursePage(authenticatedPage, "machine-learning");
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
 
     await slugInput.fill("some-other-slug");
     await authenticatedPage.getByRole("button", { name: /cancel/i }).click();
@@ -126,7 +126,7 @@ test.describe("Course Content Page", () => {
     const course = await createTestCourse();
     await navigateToCoursePage(authenticatedPage, course.slug);
 
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
     const uniqueSlug = `enter-test-${randomUUID().slice(0, 8)}`;
 
     await slugInput.fill(uniqueSlug);
@@ -143,7 +143,7 @@ test.describe("Course Content Page", () => {
 
   test("cancels on Escape key", async ({ authenticatedPage }) => {
     await navigateToCoursePage(authenticatedPage, "machine-learning");
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
 
     await slugInput.fill("escape-test-slug");
     await slugInput.press("Escape");

--- a/apps/editor/e2e/lesson-content.test.ts
+++ b/apps/editor/e2e/lesson-content.test.ts
@@ -100,7 +100,7 @@ test.describe("Lesson Content Page", () => {
       "introduction-to-machine-learning",
       "what-is-machine-learning",
     );
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
 
     await slugInput.fill("history-of-ml");
 
@@ -119,7 +119,7 @@ test.describe("Lesson Content Page", () => {
       "introduction-to-machine-learning",
       "what-is-machine-learning",
     );
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
 
     await slugInput.fill("");
 
@@ -130,7 +130,7 @@ test.describe("Lesson Content Page", () => {
     const { chapter, course, lesson } = await createTestLesson();
     await navigateToLessonPage(authenticatedPage, course.slug, chapter.slug, lesson.slug);
 
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
     const uniqueSlug = `test-slug-${randomUUID().slice(0, 8)}`;
 
     await slugInput.fill(uniqueSlug);
@@ -154,7 +154,7 @@ test.describe("Lesson Content Page", () => {
       "introduction-to-machine-learning",
       "what-is-machine-learning",
     );
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
 
     await slugInput.fill("some-other-slug");
     await authenticatedPage.getByRole("button", { name: /cancel/i }).click();
@@ -166,7 +166,7 @@ test.describe("Lesson Content Page", () => {
     const { chapter, course, lesson } = await createTestLesson();
     await navigateToLessonPage(authenticatedPage, course.slug, chapter.slug, lesson.slug);
 
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
     const uniqueSlug = `enter-test-${randomUUID().slice(0, 8)}`;
 
     await slugInput.fill(uniqueSlug);
@@ -190,7 +190,7 @@ test.describe("Lesson Content Page", () => {
       "introduction-to-machine-learning",
       "what-is-machine-learning",
     );
-    const slugInput = authenticatedPage.getByLabel(/url address/i);
+    const slugInput = authenticatedPage.getByRole("textbox", { name: /url address/i });
 
     await slugInput.fill("escape-test-slug");
     await slugInput.press("Escape");

--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -263,7 +263,7 @@ test.describe("Command Palette - Course Search", () => {
     const courseOption = dialog.getByRole("option").filter({ hasText: courseName });
     await expect(courseOption).toBeVisible();
 
-    // Course description should be visible within the option
+    // Course description should be visible
     await expect(courseOption.getByText(courseDescription, { exact: false })).toBeVisible();
 
     // Click the course option to navigate

--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -1,4 +1,26 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { normalizeString } from "@zoonk/utils/string";
 import { type Page, expect, test } from "./fixtures";
+
+async function createTestCourse() {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const uniqueId = randomUUID().slice(0, 8);
+  const title = `E2E Course ${uniqueId}`;
+
+  return courseFixture({
+    description: `E2E test course description ${uniqueId}`,
+    isPublished: true,
+    normalizedTitle: normalizeString(title),
+    organizationId: org.id,
+    slug: `e2e-${uniqueId}`,
+    title,
+  });
+}
 
 // Helper to open command palette via click (reliable for tests that don't test keyboard shortcuts)
 // Scoped to navigation to avoid strict mode violation when multiple search buttons exist during streaming
@@ -212,39 +234,49 @@ test.describe("Command Palette - Authenticated", () => {
 });
 
 test.describe("Command Palette - Course Search", () => {
-  test.beforeEach(async ({ page }) => {
+  test("does not search with fewer than 2 characters", async ({ page }) => {
+    const course = await createTestCourse();
     await page.goto("/");
     await openCommandPalette(page);
-  });
 
-  test("does not search with fewer than 2 characters", async ({ page }) => {
     const dialog = page.getByRole("dialog");
-    await dialog.getByPlaceholder(/search/i).fill("M");
+    // Type single character from unique course title
+    await dialog.getByPlaceholder(/search/i).fill(course.title.charAt(0));
 
     // Should not show course search results with single character
-    await expect(dialog.getByText("Machine Learning")).not.toBeVisible();
+    await expect(dialog.getByText(course.title)).not.toBeVisible();
   });
 
-  test("shows course in results", async ({ page }) => {
+  test("shows course in results and navigates to detail page", async ({ page }) => {
+    // Use a seeded course (Machine Learning) that is pre-rendered for navigation testing
+    // New courses created via fixtures won't have their detail pages pre-rendered
+    const courseName = "Machine Learning";
+    const courseDescription = "Machine learning enables computers";
+
+    await page.goto("/");
+    await openCommandPalette(page);
+
     const dialog = page.getByRole("dialog");
-    await dialog.getByPlaceholder(/search/i).fill("machine");
+    await dialog.getByPlaceholder(/search/i).fill(courseName);
 
-    // Wait for results
-    await expect(dialog.getByText("Machine Learning").first()).toBeVisible();
+    // Wait for the course option to appear in results
+    const courseOption = dialog.getByRole("option").filter({ hasText: courseName });
+    await expect(courseOption).toBeVisible();
 
-    // Course description should be visible
-    await expect(
-      dialog.getByText(/patterns|predictions|computers|identify/i).first(),
-    ).toBeVisible();
+    // Course description should be visible within the option
+    await expect(courseOption.getByText(courseDescription, { exact: false })).toBeVisible();
 
-    // Wait for and click the course result
-    await dialog.getByText("Machine Learning").first().click();
+    // Click the course option to navigate
+    await courseOption.click();
 
-    // Verify user sees course detail page (level: 1 for main title, not chapter headings)
-    await expect(page.getByRole("heading", { level: 1, name: /machine learning/i })).toBeVisible();
+    // Verify user sees course detail page
+    await expect(page.getByRole("heading", { level: 1, name: courseName })).toBeVisible();
   });
 
   test("shows No results found for non-matching query", async ({ page }) => {
+    await page.goto("/");
+    await openCommandPalette(page);
+
     const dialog = page.getByRole("dialog");
     await dialog.getByPlaceholder(/search/i).fill("xyznonexistent");
 
@@ -252,33 +284,46 @@ test.describe("Command Palette - Course Search", () => {
   });
 
   test("handles rapid typing correctly", async ({ page }) => {
+    const course = await createTestCourse();
+    await page.goto("/");
+    await openCommandPalette(page);
+
     const dialog = page.getByRole("dialog");
 
-    // Type rapidly with corrections
-    await dialog.getByPlaceholder(/search/i).pressSequentially("Machi", { delay: 50 });
+    // Type rapidly with corrections using unique title
+    const partialTitle = course.title.slice(0, 5);
+    await dialog.getByPlaceholder(/search/i).pressSequentially(partialTitle, { delay: 50 });
 
-    await dialog.getByPlaceholder(/search/i).fill("Machine");
+    await dialog.getByPlaceholder(/search/i).fill(course.title);
 
     // Should show correct results after debounce
-    await expect(dialog.getByText("Machine Learning").first()).toBeVisible();
+    await expect(dialog.getByText(course.title)).toBeVisible();
   });
 
   test("shows exact match first when searching", async ({ page }) => {
+    await page.goto("/");
+    await openCommandPalette(page);
+
     const dialog = page.getByRole("dialog");
     await dialog.getByPlaceholder(/search/i).fill("law");
 
-    // Wait for results to load
-    await expect(dialog.getByText("Law").first()).toBeVisible();
-
-    // Get all course results - they should be in listbox options
+    // Wait for results to load - multiple law courses exist (Law, Criminal Law, Tax Law, Civil Law)
+    // The first option should be the exact match "Law", not a partial match
     const options = dialog.getByRole("option");
-    const firstOption = options.first();
+    await expect(options.first()).toBeVisible();
 
-    // The first result should be the exact match "Law", not "Criminal Law" or others
-    await expect(firstOption).toContainText("Law");
-    await expect(firstOption).not.toContainText("Criminal Law");
-    await expect(firstOption).not.toContainText("Tax Law");
-    await expect(firstOption).not.toContainText("Civil Law");
+    // The first result should be the exact match "Law", not "Criminal Law", "Tax Law", or "Civil Law"
+    // Text format is "TitleDescription" (concatenated), so we check it starts with "Law" followed
+    // by the description, not by another word like "Criminal"
+    const firstOption = options.first();
+    const firstOptionText = await firstOption.textContent();
+
+    // Should start with "Law" but NOT with partial matches like "Criminal Law", "Tax Law", "Civil Law"
+    expect(firstOptionText).toBeTruthy();
+    expect(firstOptionText!.startsWith("Law")).toBe(true);
+    expect(firstOptionText!.startsWith("Criminal Law")).toBe(false);
+    expect(firstOptionText!.startsWith("Tax Law")).toBe(false);
+    expect(firstOptionText!.startsWith("Civil Law")).toBe(false);
   });
 });
 

--- a/apps/main/e2e/course-detail.test.ts
+++ b/apps/main/e2e/course-detail.test.ts
@@ -107,18 +107,20 @@ test.describe("Course Detail Page", () => {
 });
 
 test.describe("Course Detail Page - Locale", () => {
-  test("navigating from Portuguese courses page preserves locale", async ({ page }) => {
+  test("clicking course from PT list preserves locale and shows PT content", async ({ page }) => {
     await page.goto("/pt/courses");
 
-    const courseLink = page.getByRole("link", { name: /^Machine Learning/ });
-    await expect(courseLink).toBeVisible();
+    // Wait for list to load with PT heading
+    await expect(page.getByRole("heading", { name: /explorar cursos/i })).toBeVisible();
+
+    // Click first visible course link
+    const courseLink = page.getByRole("list").getByRole("link").first();
     await courseLink.click();
 
-    await expect(page).toHaveURL(/\/pt\/b\/ai\/c\/machine-learning/);
+    // Verify locale is preserved in URL
+    await expect(page).toHaveURL(/\/pt\//);
 
-    // Wait for the course detail page to fully render
-    await page.waitForLoadState("domcontentloaded");
-
-    await expect(page.getByText(/permite que computadores identifiquem/i).first()).toBeVisible();
+    // Verify page rendered successfully with a heading
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
   });
 });

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -140,6 +140,11 @@ msgctxt "95stPq"
 msgid "Completed"
 msgstr "Completed"
 
+#: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/c/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+msgctxt "UmEsZF"
+msgid "Activities"
+msgstr "Activities"
+
 #: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/c/[chapterSlug]/l/[lessonSlug]/lesson-header.tsx
 msgctxt "Dane8c"
 msgid "Lesson {position}"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -140,6 +140,11 @@ msgctxt "95stPq"
 msgid "Completed"
 msgstr "Completada"
 
+#: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/c/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+msgctxt "UmEsZF"
+msgid "Activities"
+msgstr "Actividades"
+
 #: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/c/[chapterSlug]/l/[lessonSlug]/lesson-header.tsx
 msgctxt "Dane8c"
 msgid "Lesson {position}"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -140,6 +140,11 @@ msgctxt "95stPq"
 msgid "Completed"
 msgstr "Concluída"
 
+#: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/c/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+msgctxt "UmEsZF"
+msgid "Activities"
+msgstr "Atividades"
+
 #: src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/c/[chapterSlug]/l/[lessonSlug]/lesson-header.tsx
 msgctxt "Dane8c"
 msgid "Lesson {position}"

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/c/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/c/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
@@ -1,9 +1,10 @@
 import { type ActivityForList } from "@/data/activities/list-lesson-activities";
 import { Link } from "@/i18n/navigation";
 import { type ActivityKindInfo } from "@/lib/activities";
+import { getExtracted } from "next-intl/server";
 import { ActivityIndicator } from "./activity-indicator";
 
-export function ActivityList({
+export async function ActivityList({
   activities,
   baseHref,
   kindMeta,
@@ -12,12 +13,14 @@ export function ActivityList({
   baseHref: string;
   kindMeta: Map<string, ActivityKindInfo>;
 }) {
+  const t = await getExtracted();
+
   if (activities.length === 0) {
     return null;
   }
 
   return (
-    <ul className="flex flex-col gap-1">
+    <ul aria-label={t("Activities")} className="flex flex-col gap-1">
       {activities.map((activity) => {
         const meta = kindMeta.get(activity.kind);
 

--- a/i18n.lock
+++ b/i18n.lock
@@ -202,7 +202,6 @@ checksums:
     Search%20courses%20or%20pages.../singular: d059e326784d4e9b074d82e7957a3eef
     No%20results%20found/singular: 5518f2865757dc73900aa03ef8be6934
     My%20courses/singular: d97cf4146d15d6ff06df054f89cf2bbd
-    Manage%20settings/singular: 72d60ef4e53cd4eb8c041576b9382b51
     Learn%20something/singular: 2b9c846ff3fe4df7416deac9aa405e30
     Update%20language/singular: 578f6d1e35422e5fdc38bf8c85126585
     Manage%20subscription/singular: b83a75127b8eabc21dfa1e0f7104db56
@@ -213,11 +212,11 @@ checksums:
     Language/singular: 277fd1a41cc237a437cd1d5e4a80463b
     Learn/singular: 6559e2075ab6947a1d4fa43e19a5d66b
     User%20menu/singular: ee471ecb3870493792e60d1b41fcce86
-    Settings/singular: 8df6777277469c1fd88cc18dde2f1cc3
     Support/singular: 55aab5fd0f31a9cb055a2edeeedfaf63
     Subscription/singular: ba9f3675e18987d067d48533c8897343
     Not%20completed/singular: d011b1ae92a1a8a2676a5d6999bbe6d4
     Completed/singular: 0e4bbce9985f25eb673d9a054c8d5334
+    Activities/singular: 1c01b2fc4db670ab174e2220cf5e79f8
     Lesson%20%7Bposition%7D/singular: 2283c16cc7404682a2380fb8318f42e2
     Lessons%20haven't%20been%20generated%20for%20this%20chapter%20yet./singular: ab7a5c1b0cf16f1a8b9cf87487800e3f
     Generate%20lessons/singular: 99814020e2da40d3f3146eaba4e42959
@@ -233,9 +232,9 @@ checksums:
     Afternoon/singular: b34f73070b6ce5e811f2aeec93798d7d
     Evening/singular: d401caa89963f8017a148bcdd1749c2d
     "%7Bperiod%7D%20with%20%7Bvalue%7D%25/singular": 958bc2c65d9a6823edee6f2585fd6501
-    Continue%20learning/singular: ff5ff528cbacf657af36fb9b711431d6
     Next%3A%20%7Bactivity%7D/singular: 9208679843466247d2161793249e5eda
     Activity/singular: 1948763de8e531483a798b68195e297e
+    Continue%20learning/singular: ff5ff528cbacf657af36fb9b711431d6
     Course%20categories/singular: 3c86af7c305be0c0f5b65077fb06708d
     All/singular: 5e2e93f8e2a5f315b6fecdd0a0e6f55f
     Loading%20more%20courses%E2%80%A6/singular: 290733f8b53c88f64b385ba9dd320acf
@@ -256,11 +255,11 @@ checksums:
     Send%20feedback/singular: 9631cc08d49da04475b30a0d320ce97c
     I%20didn't%20like%20it/singular: 9761a96b22323e7db7d7176b77cf7caa
     I%20liked%20it/singular: ed20592186f53abcc526360869bd0f55
+    Generate/singular: 0345bf322c191e70d01fd6607ec5c2f8
     Cancel/singular: 2e2a849c2223911717de8caa2c71bade
     Cooking%20up%20some%20course%20ideas/singular: a42520f96dbac3580a2ccae4bd6ceb31
     We're%20putting%20together%20a%20few%20course%20suggestions%20for%20you.%20This%20may%20take%20a%20few%20seconds./singular: 8467af30434eb8bfb2f13e109b1d9334
     Course%20ideas%20for%20%7Bprompt%7D/singular: 23f94da8ce9272d654ff40bb80e6a352
-    Generate/singular: 0345bf322c191e70d01fd6607ec5c2f8
     Change%20subject/singular: 8585bb703ba2d857dd9a7b36f97be507
     Discover%20personalized%20courses%20and%20resources%20to%20learn%20%7Bprompt%7D.%20Zoonk%20uses%20AI%20to%20generate%20interactive%20lessons%20and%20activities%20tailored%20to%20you./singular: 7d54c62a9c8d49b713626fa25edff820
     Learn%20%7Bprompt%7D%20with%20AI/singular: 5a8a8ee7f52faf0cb790e0f0cfbcce7d
@@ -343,8 +342,6 @@ checksums:
     Set%20or%20update%20your%20Zoonk%20display%20name.%20This%20name%20may%20be%20visible%20to%20others%20and%20will%20be%20used%20when%20referring%20to%20you%20in%20lessons%20and%20activities./singular: 27a489da570cb0d40c7b47d81d271213
     Update%20Display%20Name/singular: 6583c6a89e7dfe4373ba2e6033547b69
     This%20is%20the%20name%20others%20may%20see%20and%20the%20one%20we'll%20use%20to%20refer%20to%20you%20in%20activities./singular: 84084520f32cbe01700e2f32c43558aa
-    Customize%20your%20Zoonk%20learning%20experience.%20Manage%20account%20settings%2C%20profile%2C%20and%20preferences%20to%20get%20the%20most%20out%20of%20our%20education%20platform./singular: 36a3ad216744e032858a6279929bd37b
-    Manage%20your%20account%20settings%2C%20profile%2C%20and%20preferences./singular: fb026dbc30e3549c3d15e6c254e7d70e
     Manage%20Subscription/singular: 31cafd367fc70d656d8dd979d537dc96
     Manage%20your%20Zoonk%20subscription.%20View%20your%20current%20plan%2C%20upgrade%20or%20downgrade%2C%20and%20see%20available%20benefits./singular: 47f6b6e7b8217ffc7b8135863f626906
     Check%20your%20plan%20details%20and%20manage%20your%20subscription./singular: b9c54ab5f7759daa9fde43d201b05a3d
@@ -410,9 +407,9 @@ checksums:
     Explanation/singular: f6b595df4ffb1a5b0cbbe1dda5993522
     Read%20sentences%20and%20translate%20them%20to%20practice%20reading%20comprehension./singular: b084920876df6266904d73e2ddfc6f19
     A%20comprehensive%20quiz%20covering%20everything%20you%20learned%20in%20this%20lesson./singular: bd46bf5022b53951436d9facacacf673
+    Learn%20new%20words%20and%20their%20translations%20to%20build%20your%20vocabulary./singular: edf41f5213749b375ab5057e14707380
     Tests%20analytical%20thinking%20through%20decisions%20with%20trade-offs.%20See%20how%20each%20choice%20impacts%20different%20outcomes./singular: 6d49ad51d42b986411df06b5ceb48067
     Listen%20to%20audio%20sentences%20and%20translate%20them%20to%20practice%20listening%20skills./singular: c7f37f13c3e2d3cb1f23c9cc5eee4e1d
-    Learn%20new%20words%20with%20their%20translations.%20Includes%20articles%20for%20gendered%20languages%20and%20pronunciation%20for%20non-Roman%20scripts./singular: b8169ec164159b9d0beb9676e2fcb3d0
     Teaches%20grammar%20rules%20with%20practical%20exercises%20to%20help%20you%20remember%20and%20apply%20them./singular: b1250dcf530d4320d730ad2744d37221
     Vocabulary/singular: 2c8127af4c194fa05463e82d5e414c62
     Shows%20WHERE%20this%20topic%20appears%20in%20real%20life.%20Helps%20you%20recognize%20it%20in%20daily%20routines%2C%20work%2C%20pop%20culture%2C%20and%20unexpected%20places./singular: bd7cdd212990640d3e21ae67a305379f


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactors E2E tests to be isolated, deterministic, and accessibility-first, reducing flakiness across editor and main apps. Adds an accessible Activities list label (with translations) to support reliable role-based queries.

- **Refactors**
  - Replaced loose selectors with getByRole for slug inputs and other fields.
  - Created unique test data via Prisma fixtures (courses/chapters/lessons/activities) instead of asserting seeded content; stabilized command palette and lesson detail flows, including debounced search and navigation checks.
  - Simplified locale tests to verify locale in URL and page render without content coupling.
  - Updated testing guidelines (SKILL.md) to emphasize isolation, simplest proof, query priority, handling animations, server actions, and fixture patterns; removed fragile/redundant examples.

- **New Features**
  - ActivityList is now async and sets an aria-label from i18n ("Activities"); added en/es/pt strings and updated i18n.lock.
  - Tests use the Activities list label for precise, accessible assertions.

<sup>Written for commit f293ed5007840d1013d8720b817f227d2c6ec434. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

