### PR TITLE
refactor(utils): consolidate api url configuration

### DIFF
--- a/apps/main/src/app/[locale]/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/generation-client.tsx
@@ -14,7 +14,7 @@ import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
 import { type ChapterStepName } from "@/workflows/config";
 import { type GenerationStatus } from "@zoonk/db";
-import { AI_ORG_SLUG, API_BASE_URL } from "@zoonk/utils/constants";
+import { AI_ORG_SLUG, API_URL } from "@zoonk/utils/constants";
 import { useExtracted } from "next-intl";
 import { useGenerationPhases } from "./use-generation-phases";
 
@@ -39,9 +39,9 @@ export function GenerationClient({
     completionStep: "setChapterAsCompleted",
     initialRunId: generationRunId,
     initialStatus: generationStatus === "running" ? "streaming" : "idle",
-    statusUrl: `${API_BASE_URL}/v1/workflows/chapter-generation/status`,
+    statusUrl: `${API_URL}/v1/workflows/chapter-generation/status`,
     triggerBody: { chapterId },
-    triggerUrl: `${API_BASE_URL}/v1/workflows/chapter-generation/trigger`,
+    triggerUrl: `${API_URL}/v1/workflows/chapter-generation/trigger`,
   });
 
   const { phases, progress } = useGenerationPhases(

--- a/apps/main/src/app/[locale]/generate/cs/[id]/generation-client.tsx
+++ b/apps/main/src/app/[locale]/generate/cs/[id]/generation-client.tsx
@@ -14,7 +14,7 @@ import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
 import { CHAPTER_COMPLETION_STEP, type CourseWorkflowStepName } from "@/workflows/config";
 import { type GenerationStatus } from "@zoonk/db";
-import { AI_ORG_SLUG, API_BASE_URL } from "@zoonk/utils/constants";
+import { AI_ORG_SLUG, API_URL } from "@zoonk/utils/constants";
 import { useExtracted } from "next-intl";
 import { useGenerationPhases } from "./use-generation-phases";
 
@@ -37,9 +37,9 @@ export function GenerationClient({
     completionStep: CHAPTER_COMPLETION_STEP,
     initialRunId: generationRunId,
     initialStatus: generationStatus === "running" ? "streaming" : "idle",
-    statusUrl: `${API_BASE_URL}/v1/workflows/course-generation/status`,
+    statusUrl: `${API_URL}/v1/workflows/course-generation/status`,
     triggerBody: { courseSuggestionId: suggestionId },
-    triggerUrl: `${API_BASE_URL}/v1/workflows/course-generation/trigger`,
+    triggerUrl: `${API_URL}/v1/workflows/course-generation/trigger`,
   });
 
   const { phases, progress } = useGenerationPhases(

--- a/packages/error-reporter/src/client.ts
+++ b/packages/error-reporter/src/client.ts
@@ -1,3 +1,5 @@
+import { API_URL } from "@zoonk/utils/constants";
+
 const DEDUPE_WINDOW_MS = 60_000;
 const recentErrors = new Map<string, number>();
 
@@ -68,9 +70,7 @@ export function reportError(error: unknown): void {
     userAgent: typeof navigator === "undefined" ? undefined : navigator.userAgent,
   };
 
-  const apiBaseUrl = process.env.NEXT_PUBLIC_API_URL || "https://api.zoonk.com";
-
-  fetch(`${apiBaseUrl}/v1/errors`, {
+  fetch(`${API_URL}/v1/errors`, {
     body: JSON.stringify(payload),
     headers: { "Content-Type": "application/json" },
     method: "POST",

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -1,5 +1,22 @@
 export const AI_ORG_SLUG = "ai";
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+
+function getDefaultApiUrl(): string {
+  if (process.env.NEXT_PUBLIC_API_URL) {
+    return process.env.NEXT_PUBLIC_API_URL;
+  }
+
+  if (process.env.NODE_ENV === "development") {
+    return "http://localhost:4000";
+  }
+
+  if (process.env.VERCEL_ENV !== "production") {
+    return "https://api.zoonk.dev";
+  }
+
+  return "https://api.zoonk.com";
+}
+
+export const API_URL = getDefaultApiUrl();
 export const SUPPORT_URL = "https://www.zoonk.com/help";
 
 export const BYTES_PER_MB = 1024 * 1024;

--- a/packages/utils/src/url.ts
+++ b/packages/utils/src/url.ts
@@ -1,4 +1,4 @@
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.zoonk.com";
+import { API_URL } from "./constants";
 
 const isVercelProduction = process.env.VERCEL_ENV === "production";
 const isProduction = process.env.NODE_ENV === "production";
@@ -51,13 +51,6 @@ export function buildAuthLoginUrl({ callbackUrl }: { callbackUrl: string }): str
   authUrl.searchParams.set("redirectTo", callbackUrl);
 
   return authUrl.toString();
-}
-
-/**
- * Returns the base URL of the API app.
- */
-export function getApiUrl(): string {
-  return API_URL;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Consolidate three separate API URL definitions into a single `API_URL` constant
- Add environment-aware default values (dev → localhost, preview → api.zoonk.dev, prod → api.zoonk.com)
- Remove unused `getApiUrl()` function
- Rename `API_BASE_URL` → `API_URL` in consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated API URL configuration into a single environment-aware API_URL constant and updated all consumers. This simplifies setup across dev, preview, and prod and removes duplicate logic.

- **Refactors**
  - Added API_URL in utils/constants with automatic defaults: env var → dev localhost:4000 → preview api.zoonk.dev → prod api.zoonk.com.
  - Replaced API_BASE_URL and hardcoded URLs in generation clients and error reporter with API_URL.
  - Removed getApiUrl() from utils/url.ts.

- **Migration**
  - Import API_URL from @zoonk/utils/constants and remove uses of API_BASE_URL/getApiUrl().
  - Set NEXT_PUBLIC_API_URL to override defaults if needed.

<sup>Written for commit 38339184bdf542ec556dae233b4603558917d495. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

