### PR TITLE
fix(main): avoid routing cache after content generation

### DIFF
--- a/apps/main/src/lib/workflow/use-completion-redirect.ts
+++ b/apps/main/src/lib/workflow/use-completion-redirect.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useEffect, useEffectEvent } from "react";
 import { type GenerationStatus } from "./generation-store";
 
@@ -12,11 +11,9 @@ export function useCompletionRedirect(config: {
   url: string;
 }) {
   const { delay = DEFAULT_REDIRECT_DELAY_MS, status, url } = config;
-  const router = useRouter();
 
   const onRedirect = useEffectEvent(() => {
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- dynamic route string requires assertion
-    router.push(url as never);
+    globalThis.location.href = url;
   });
 
   useEffect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Force a hard redirect after content generation to bypass the Next.js router cache so users see fresh content. Replaces router.push with location.href in useCompletionRedirect.

- **Bug Fixes**
  - Use globalThis.location.href instead of router.push to trigger a full page load after generation.

<sup>Written for commit cd64d92165a9a97114e92db30bd684098f54c4a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

