### PR TITLE
fix(main): remove brand link from course page

### DIFF
--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-header.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-header.tsx
@@ -1,6 +1,5 @@
 import { AIWarning } from "@/components/catalog/ai-warning";
 import { type CourseWithDetails } from "@/data/courses/get-course";
-import { ClientLink } from "@/i18n/client-link";
 import { Link } from "@/i18n/navigation";
 import { getCategories } from "@/lib/categories/category-server";
 import { Badge } from "@zoonk/ui/components/badge";
@@ -73,7 +72,7 @@ export async function CourseHeader({
 
         <MediaCardPopoverMeta>
           <MediaCardPopoverSource>
-            <MediaCardPopoverSourceLink render={<ClientLink href={`/b/${brandSlug}`} />}>
+            <MediaCardPopoverSourceLink render={<span />}>
               {course.organization.name}
             </MediaCardPopoverSourceLink>
           </MediaCardPopoverSource>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the brand link from the course header so the organization name is no longer clickable. MediaCardPopoverSourceLink now renders plain text instead of ClientLink, preventing navigation to /b/[brandSlug].

<sup>Written for commit b82d8e4da4f9cdb16482905d55a64b7625272489. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

