### PR TITLE
feat(api): add OpenAPI docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ Zoonk is a web app where users can learn anything using AI. This app uses AI to 
 - **Build for growth, not current size.** "We only have N of X" is NEVER a valid reason to skip proper patterns. Early-stage projects grow. Build infrastructure that scales with the project from the start.
 - **Single source of truth always wins.** If two things must stay in sync (schemas + docs, types + validation), generate one from the other. Manual duplication WILL drift.
 - **Setup cost is amortized.** The effort to set up reusable code and automations always pays off. Don't optimize for today's sprint. Focus on long-term velocity.
+- **Principles override plans.** If a plan marks something as "optional" but skipping it would violate core principles (like single source of truth), do it anyway. Plans are guidance; principles are non-negotiable. When in doubt, ask: "Does skipping this create duplicate sources of truth or technical debt?"
 
 ## Design Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,12 @@ Zoonk is a web app where users can learn anything using AI. This app uses AI to 
 - `pnpm --filter {app} build:e2e` (always run this before running e2e tests)
 - `pnpm --filter {app} e2e`
 
+## Engineering Mindset
+
+- **Build for growth, not current size.** "We only have N of X" is NEVER a valid reason to skip proper patterns. Early-stage projects grow. Build infrastructure that scales with the project from the start.
+- **Single source of truth always wins.** If two things must stay in sync (schemas + docs, types + validation), generate one from the other. Manual duplication WILL drift.
+- **Setup cost is amortized.** The effort to set up reusable code and automations always pays off. Don't optimize for today's sprint. Focus on long-term velocity.
+
 ## Design Style
 
 Whenever you're designing something, follow this design style:

--- a/apps/api/e2e/docs.test.ts
+++ b/apps/api/e2e/docs.test.ts
@@ -1,0 +1,80 @@
+import { request } from "@playwright/test";
+import { expect, test } from "./fixtures";
+
+test.describe("API Documentation", () => {
+  let baseURL: string;
+
+  test.beforeAll(() => {
+    baseURL = process.env.E2E_BASE_URL ?? "";
+  });
+
+  test("/v1/docs returns HTML with Scalar UI", async () => {
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.get("/v1/docs");
+
+    expect(response.status()).toBe(200);
+
+    const contentType = response.headers()["content-type"];
+
+    expect(contentType).toContain("text/html");
+
+    const body = await response.text();
+
+    expect(body).toContain("<!doctype html>");
+
+    await apiContext.dispose();
+  });
+
+  test("/v1/docs/openapi.json returns valid OpenAPI spec", async () => {
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.get("/v1/docs/openapi.json");
+
+    expect(response.status()).toBe(200);
+
+    const contentType = response.headers()["content-type"];
+
+    expect(contentType).toContain("application/json");
+
+    const spec = await response.json();
+
+    expect(spec.openapi).toBe("3.1.0");
+    expect(spec.info.title).toBe("Zoonk API");
+    expect(spec.info.version).toBe("1.0.0");
+
+    await apiContext.dispose();
+  });
+
+  test("OpenAPI spec includes custom API paths", async () => {
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.get("/v1/docs/openapi.json");
+
+    expect(response.status()).toBe(200);
+
+    const spec = await response.json();
+
+    expect(spec.paths).toHaveProperty("/auth/health");
+    expect(spec.paths).toHaveProperty("/courses/search");
+    expect(spec.paths).toHaveProperty("/workflows/course-generation/trigger");
+    expect(spec.paths).toHaveProperty("/workflows/course-generation/status");
+    expect(spec.paths).toHaveProperty("/workflows/chapter-generation/trigger");
+    expect(spec.paths).toHaveProperty("/workflows/chapter-generation/status");
+
+    await apiContext.dispose();
+  });
+
+  test("OpenAPI spec includes Better Auth endpoints", async () => {
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.get("/v1/docs/openapi.json");
+
+    expect(response.status()).toBe(200);
+
+    const spec = await response.json();
+
+    expect(spec.paths).toHaveProperty("/sign-in/email");
+    expect(spec.paths).toHaveProperty("/sign-up/email");
+    expect(spec.paths).toHaveProperty("/sign-out");
+    expect(spec.components).toBeDefined();
+
+    await apiContext.dispose();
+  });
+});

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -37,6 +37,7 @@
     "zod": "4.3.5"
   },
   "devDependencies": {
+    "@scalar/nextjs-api-reference": "0.9.18",
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -49,6 +50,7 @@
     "raw-loader": "4.0.2",
     "typescript": "^5",
     "vite-tsconfig-paths": "6.0.3",
-    "vitest": "4.0.16"
+    "vitest": "4.0.16",
+    "zod-openapi": "5.4.6"
   }
 }

--- a/apps/api/src/app/v1/courses/search/route.ts
+++ b/apps/api/src/app/v1/courses/search/route.ts
@@ -1,16 +1,9 @@
 import { errors } from "@/lib/api-errors";
+import { courseSearchQuerySchema } from "@/lib/openapi/schemas/courses";
 import { type PaginatedResponse, createPaginatedResponse, decodeCursor } from "@/lib/pagination";
 import { parseQueryParams } from "@/lib/query-params";
 import { searchCourses } from "@zoonk/core/courses/search";
 import { NextResponse } from "next/server";
-import { z } from "zod";
-
-const searchParamsSchema = z.object({
-  cursor: z.string().optional(),
-  language: z.string().min(2, "Language code is required"),
-  limit: z.coerce.number().int().min(1).max(100).optional().default(10),
-  query: z.string().min(1, "Search query is required"),
-});
 
 export async function GET(request: Request): Promise<
   | NextResponse<
@@ -33,7 +26,7 @@ export async function GET(request: Request): Promise<
 > {
   const { searchParams } = new URL(request.url);
 
-  const parsed = parseQueryParams(searchParams, searchParamsSchema);
+  const parsed = parseQueryParams(searchParams, courseSearchQuerySchema);
 
   if (!parsed.success) {
     return errors.validation(parsed.error);

--- a/apps/api/src/app/v1/docs/openapi.json/route.ts
+++ b/apps/api/src/app/v1/docs/openapi.json/route.ts
@@ -1,0 +1,22 @@
+import { openAPIDocument } from "@/lib/openapi/document";
+import { auth } from "@zoonk/core/auth";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const authSchema = await auth.api.generateOpenAPISchema();
+
+  const mergedDocument = {
+    ...openAPIDocument,
+    components: {
+      ...authSchema.components,
+      ...openAPIDocument.components,
+    },
+    paths: {
+      ...authSchema.paths,
+      ...openAPIDocument.paths,
+    },
+    tags: [...(authSchema.tags ?? []), ...(openAPIDocument.tags ?? [])],
+  };
+
+  return NextResponse.json(mergedDocument);
+}

--- a/apps/api/src/app/v1/docs/route.ts
+++ b/apps/api/src/app/v1/docs/route.ts
@@ -1,0 +1,8 @@
+import { ApiReference } from "@scalar/nextjs-api-reference";
+
+// oxlint-disable-next-line new-cap
+export const GET = ApiReference({
+  darkMode: true,
+  theme: "default",
+  url: "/v1/docs/openapi.json",
+});

--- a/apps/api/src/app/v1/workflows/chapter-generation/status/route.ts
+++ b/apps/api/src/app/v1/workflows/chapter-generation/status/route.ts
@@ -1,17 +1,12 @@
 import { errors } from "@/lib/api-errors";
+import { workflowStatusQuerySchema } from "@/lib/openapi/schemas/workflows";
 import { parseQueryParams } from "@/lib/query-params";
 import { getRun } from "workflow/api";
-import { z } from "zod";
-
-const schema = z.object({
-  runId: z.string().min(1),
-  startIndex: z.coerce.number().int().optional(),
-});
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
 
-  const parsed = parseQueryParams(searchParams, schema);
+  const parsed = parseQueryParams(searchParams, workflowStatusQuerySchema);
 
   if (!parsed.success) {
     return errors.validation(parsed.error);

--- a/apps/api/src/app/v1/workflows/chapter-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/chapter-generation/trigger/route.ts
@@ -1,15 +1,11 @@
 import { errors } from "@/lib/api-errors";
 import { parseBody } from "@/lib/body-parser";
+import { chapterGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
 import { chapterGenerationWorkflow } from "@/workflows/chapter-generation/chapter-generation-workflow";
 import { auth } from "@zoonk/core/auth";
 import { findActiveSubscription } from "@zoonk/core/auth/subscription";
 import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
-import { z } from "zod";
-
-const schema = z.object({
-  chapterId: z.number().int().positive(),
-});
 
 async function getSubscriptions(request: NextRequest) {
   try {
@@ -22,7 +18,7 @@ async function getSubscriptions(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const parsed = await parseBody(request, schema);
+  const parsed = await parseBody(request, chapterGenerationTriggerSchema);
 
   if (!parsed.success) {
     return errors.validation(parsed.error);

--- a/apps/api/src/app/v1/workflows/course-generation/status/route.ts
+++ b/apps/api/src/app/v1/workflows/course-generation/status/route.ts
@@ -1,17 +1,12 @@
 import { errors } from "@/lib/api-errors";
+import { workflowStatusQuerySchema } from "@/lib/openapi/schemas/workflows";
 import { parseQueryParams } from "@/lib/query-params";
 import { getRun } from "workflow/api";
-import { z } from "zod";
-
-const schema = z.object({
-  runId: z.string().min(1),
-  startIndex: z.coerce.number().int().optional(),
-});
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
 
-  const parsed = parseQueryParams(searchParams, schema);
+  const parsed = parseQueryParams(searchParams, workflowStatusQuerySchema);
 
   if (!parsed.success) {
     return errors.validation(parsed.error);

--- a/apps/api/src/app/v1/workflows/course-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/course-generation/trigger/route.ts
@@ -1,16 +1,12 @@
 import { errors } from "@/lib/api-errors";
 import { parseBody } from "@/lib/body-parser";
+import { courseGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
 import { courseGenerationWorkflow } from "@/workflows/course-generation/course-generation-workflow";
 import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
-import { z } from "zod";
-
-const schema = z.object({
-  courseSuggestionId: z.number().int().positive(),
-});
 
 export async function POST(request: NextRequest) {
-  const parsed = await parseBody(request, schema);
+  const parsed = await parseBody(request, courseGenerationTriggerSchema);
 
   if (!parsed.success) {
     return errors.validation(parsed.error);

--- a/apps/api/src/lib/openapi/document.ts
+++ b/apps/api/src/lib/openapi/document.ts
@@ -1,0 +1,133 @@
+import { z } from "zod";
+import { createDocument } from "zod-openapi";
+import { errorSchema, paginationSchema } from "./schemas/common";
+import { courseResultSchema, courseSearchQuerySchema } from "./schemas/courses";
+import {
+  chapterGenerationTriggerSchema,
+  courseGenerationTriggerSchema,
+  workflowStatusQuerySchema,
+  workflowTriggerResponseSchema,
+} from "./schemas/workflows";
+
+export const openAPIDocument = createDocument({
+  info: {
+    description: "API for the Zoonk learning platform",
+    title: "Zoonk API",
+    version: "1.0.0",
+  },
+  openapi: "3.1.0",
+  paths: {
+    "/auth/health": {
+      get: {
+        responses: {
+          "200": {
+            content: {
+              "application/json": {
+                schema: z.object({ status: z.literal("ok") }),
+              },
+            },
+            description: "Service is healthy",
+          },
+        },
+        summary: "Health check",
+        tags: ["Health"],
+      },
+    },
+    "/courses/search": {
+      get: {
+        requestParams: { query: courseSearchQuerySchema },
+        responses: {
+          "200": {
+            content: {
+              "application/json": {
+                schema: z.object({
+                  data: z.array(courseResultSchema),
+                  pagination: paginationSchema,
+                }),
+              },
+            },
+            description: "Paginated course results",
+          },
+          "400": {
+            content: { "application/json": { schema: errorSchema } },
+            description: "Validation error",
+          },
+        },
+        summary: "Search published courses",
+        tags: ["Courses"],
+      },
+    },
+    "/workflows/chapter-generation/status": {
+      get: {
+        description: "Returns a Server-Sent Events stream with workflow status updates.",
+        requestParams: { query: workflowStatusQuerySchema },
+        responses: {
+          "200": {
+            content: { "text/event-stream": { schema: z.string() } },
+            description: "SSE stream of workflow status",
+          },
+        },
+        summary: "Stream chapter generation status (SSE)",
+        tags: ["Workflows"],
+      },
+    },
+    "/workflows/chapter-generation/trigger": {
+      post: {
+        description: "Requires active subscription.",
+        requestBody: {
+          content: { "application/json": { schema: chapterGenerationTriggerSchema } },
+        },
+        responses: {
+          "200": {
+            content: { "application/json": { schema: workflowTriggerResponseSchema } },
+            description: "Workflow started",
+          },
+          "400": {
+            content: { "application/json": { schema: errorSchema } },
+            description: "Validation error",
+          },
+          "402": {
+            content: { "application/json": { schema: errorSchema } },
+            description: "Subscription required",
+          },
+        },
+        summary: "Trigger chapter generation workflow",
+        tags: ["Workflows"],
+      },
+    },
+    "/workflows/course-generation/status": {
+      get: {
+        description: "Returns a Server-Sent Events stream with workflow status updates.",
+        requestParams: { query: workflowStatusQuerySchema },
+        responses: {
+          "200": {
+            content: { "text/event-stream": { schema: z.string() } },
+            description: "SSE stream of workflow status",
+          },
+        },
+        summary: "Stream course generation status (SSE)",
+        tags: ["Workflows"],
+      },
+    },
+    "/workflows/course-generation/trigger": {
+      post: {
+        requestBody: {
+          content: { "application/json": { schema: courseGenerationTriggerSchema } },
+        },
+        responses: {
+          "200": {
+            content: { "application/json": { schema: workflowTriggerResponseSchema } },
+            description: "Workflow started",
+          },
+          "400": {
+            content: { "application/json": { schema: errorSchema } },
+            description: "Validation error",
+          },
+        },
+        summary: "Trigger course generation workflow",
+        tags: ["Workflows"],
+      },
+    },
+  },
+  servers: [{ description: "API v1", url: "/v1" }],
+});

--- a/apps/api/src/lib/openapi/schemas/common.ts
+++ b/apps/api/src/lib/openapi/schemas/common.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const errorSchema = z
+  .object({
+    error: z.object({
+      code: z.string().meta({ description: "Error code", example: "VALIDATION_ERROR" }),
+      details: z.unknown().optional().meta({ description: "Additional error details" }),
+      message: z.string().meta({ description: "Error message" }),
+    }),
+  })
+  .meta({ description: "Standard error response", id: "Error" });
+
+export const paginationSchema = z
+  .object({
+    hasMore: z.boolean().meta({ description: "Whether more results exist" }),
+    nextCursor: z.string().nullable().meta({ description: "Cursor for next page" }),
+  })
+  .meta({ id: "Pagination" });

--- a/apps/api/src/lib/openapi/schemas/courses.ts
+++ b/apps/api/src/lib/openapi/schemas/courses.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+export const courseSearchQuerySchema = z
+  .object({
+    cursor: z.string().optional().meta({ description: "Pagination cursor" }),
+    language: z
+      .string()
+      .min(2, "Language code is required")
+      .meta({ description: "Language code", example: "en" }),
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .default(10)
+      .meta({ description: "Results per page" }),
+    query: z
+      .string()
+      .min(1, "Search query is required")
+      .meta({ description: "Search query", example: "javascript" }),
+  })
+  .meta({ id: "CourseSearchQuery" });
+
+const organizationSummarySchema = z
+  .object({
+    id: z.number().meta({ description: "Organization ID" }),
+    logo: z.string().nullable().meta({ description: "Organization logo URL" }),
+    name: z.string().meta({ description: "Organization name" }),
+    slug: z.string().meta({ description: "Organization slug" }),
+  })
+  .meta({ id: "OrganizationSummary" });
+
+export const courseResultSchema = z
+  .object({
+    description: z.string().nullable().meta({ description: "Course description" }),
+    id: z.number().meta({ description: "Course ID" }),
+    imageUrl: z.string().nullable().meta({ description: "Cover image URL" }),
+    language: z.string().meta({ description: "Language code" }),
+    organization: organizationSummarySchema,
+    slug: z.string().meta({ description: "URL slug" }),
+    title: z.string().meta({ description: "Course title" }),
+  })
+  .meta({ id: "CourseResult" });

--- a/apps/api/src/lib/openapi/schemas/workflows.ts
+++ b/apps/api/src/lib/openapi/schemas/workflows.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+export const courseGenerationTriggerSchema = z
+  .object({
+    courseSuggestionId: z
+      .number()
+      .int()
+      .positive()
+      .meta({ description: "Course suggestion ID to generate from" }),
+  })
+  .meta({ id: "CourseGenerationTrigger" });
+
+export const chapterGenerationTriggerSchema = z
+  .object({
+    chapterId: z
+      .number()
+      .int()
+      .positive()
+      .meta({ description: "Chapter ID to generate content for" }),
+  })
+  .meta({ id: "ChapterGenerationTrigger" });
+
+export const workflowTriggerResponseSchema = z
+  .object({
+    message: z.string().meta({ example: "Workflow started" }),
+    runId: z.string().meta({ description: "Workflow run ID for status tracking" }),
+  })
+  .meta({ id: "WorkflowTriggerResponse" });
+
+export const workflowStatusQuerySchema = z
+  .object({
+    runId: z.string().min(1).meta({ description: "Workflow run ID" }),
+    startIndex: z.coerce
+      .number()
+      .int()
+      .optional()
+      .meta({ description: "Event index to start from" }),
+  })
+  .meta({ id: "WorkflowStatusQuery" });

--- a/packages/auth/src/config.ts
+++ b/packages/auth/src/config.ts
@@ -8,6 +8,7 @@ import {
   emailOTP,
   jwt,
   oneTimeToken,
+  openAPI,
   organization,
 } from "better-auth/plugins";
 import { type BetterAuthOptions } from "better-auth/types";
@@ -99,6 +100,7 @@ export const fullPlugins = [
   bearer(),
   stripePlugin(),
   trustedOriginPlugin(),
+  openAPI({ disableDefaultReference: true }),
   // NextCookies should be the last plugin in the array
   nextCookies(),
 ] as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
         specifier: 4.3.5
         version: 4.3.5
     devDependencies:
+      '@scalar/nextjs-api-reference':
+        specifier: 0.9.18
+        version: 0.9.18(next@16.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.58.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@types/node':
         specifier: ^24
         version: 24.10.9
@@ -181,6 +184,9 @@ importers:
       vitest:
         specifier: 4.0.16
         version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(jiti@2.6.1)(jsdom@27.0.0)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.20.6)
+      zod-openapi:
+        specifier: 5.4.6
+        version: 5.4.6(zod@4.3.5)
 
   apps/editor:
     dependencies:
@@ -2652,6 +2658,25 @@ packages:
     resolution: {integrity: sha512-Zv7v6q6aV+VslnpwzqKAmrk5JdVkLUzok2208ZXGipjb+msxBr/fJPZyeEXiFgH7k62Ak0SLIfxQRZQvTuf7rQ==}
     cpu: [x64]
     os: [win32]
+
+  '@scalar/core@0.3.37':
+    resolution: {integrity: sha512-cQWMHsGD9jCiYHi91acR3tOsj+qGk+dRQ2W+N5+au1NZ/GkUNT5TUEufekn/sj1S8af+lOnn3y0xXoTI34jCog==}
+    engines: {node: '>=20'}
+
+  '@scalar/helpers@0.2.11':
+    resolution: {integrity: sha512-Y7DLt1bIZF9dvHzJwSJTcC1lpSr1Tbf4VBhHOCRIHu23Rr7/lhQnddRxFmPV1tZXwEQKz7F7yRrubwCfKPCucw==}
+    engines: {node: '>=20'}
+
+  '@scalar/nextjs-api-reference@0.9.18':
+    resolution: {integrity: sha512-bye1QJfHkJKSg5lun/GN+RHSYDGQl2FtdUCxqHCD17D4zSjBEeaZK+m7anQFrm8zB92/pTpDdu3x6rUjGpDAZA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      next: ^15.0.0 || ^16.0.0
+      react: ^19.0.0
+
+  '@scalar/types@0.6.2':
+    resolution: {integrity: sha512-VWfY/z9R5NT8PpKVmvmIj6QSh56MMcl8x3JsGiNxR+w7txGQEq+QzEl35aU56uSBFmLfPk1oyInoaHhkosKooA==}
+    engines: {node: '>=20'}
 
   '@schummar/icu-type-parser@1.21.5':
     resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
@@ -5614,6 +5639,10 @@ packages:
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwind-merge@3.3.1:
     resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
 
@@ -5778,6 +5807,10 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  type-fest@5.4.3:
+    resolution: {integrity: sha512-AXSAQJu79WGc79/3e9/CR77I/KQgeY1AhNvcShIH4PTcGYyC4xv6H4R4AUOwkPS5799KlVDAu8zExeCrkGquiA==}
+    engines: {node: '>=20'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -6124,6 +6157,12 @@ packages:
 
   zeptomatch@2.1.0:
     resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
+
+  zod-openapi@5.4.6:
+    resolution: {integrity: sha512-P2jsOOBAq/6hCwUsMCjUATZ8szkMsV5VAwZENfyxp2Hc/XPJQpVwAgevWZc65xZauCwWB9LAn7zYeiCJFAEL+A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      zod: ^3.25.74 || ^4.0.0
 
   zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
@@ -7817,6 +7856,25 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.57.0':
     optional: true
+
+  '@scalar/core@0.3.37':
+    dependencies:
+      '@scalar/types': 0.6.2
+
+  '@scalar/helpers@0.2.11': {}
+
+  '@scalar/nextjs-api-reference@0.9.18(next@16.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.58.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@scalar/core': 0.3.37
+      next: 16.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.58.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+
+  '@scalar/types@0.6.2':
+    dependencies:
+      '@scalar/helpers': 0.2.11
+      nanoid: 5.1.6
+      type-fest: 5.4.3
+      zod: 4.3.5
 
   '@schummar/icu-type-parser@1.21.5': {}
 
@@ -11183,6 +11241,8 @@ snapshots:
 
   tabbable@6.4.0: {}
 
+  tagged-tag@1.0.0: {}
+
   tailwind-merge@3.3.1: {}
 
   tailwindcss@4.1.17: {}
@@ -11321,6 +11381,10 @@ snapshots:
   type-fest@0.21.3: {}
 
   type-fest@4.41.0: {}
+
+  type-fest@5.4.3:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typescript@5.9.3: {}
 
@@ -11797,6 +11861,10 @@ snapshots:
     dependencies:
       grammex: 3.1.12
       graphmatch: 1.1.0
+
+  zod-openapi@5.4.6(zod@4.3.5):
+    dependencies:
+      zod: 4.3.5
 
   zod@4.1.11: {}
 


### PR DESCRIPTION
Closes #665 
Closes #654 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenAPI documentation with a hosted UI at /v1/docs and a generated spec at /v1/docs/openapi.json. Schemas are centralized with zod-openapi and merged with Better Auth routes to keep validation and docs in sync.

- **New Features**
  - Generated OpenAPI spec from Zod schemas (courses, workflows, SSE endpoints).
  - Merged Better Auth OpenAPI schema into our document.
  - Served docs UI via Scalar at /v1/docs.
  - Added e2e tests for docs UI, spec basics, and path coverage.

- **Refactors**
  - Replaced inline Zod validation in v1 routes with shared schemas (course search, workflow triggers/status).
  - Enabled Better Auth openAPI plugin and disabled its default reference page.

<sup>Written for commit 731e0aa0d251a6aa0f30483aea01a51d87858f47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

