### PR TITLE
feat(api): add lesson generation workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ For detailed UX guidelines (interactions, animation, layout, accessibility), see
 - When writing a plan, don't include "manual verification" steps. We always do manual verification, you don't need to do it. Just ensure you add the necessary e2e tests for the task
 - Don't create migration files manually. Run `pnpm --filter @zoonk/db db:migrate --name <migration-name>` to generate migration
 - Workflow files (`"use workflow"`) can't call Node APIs directly; wrap them in `"use step"` functions
+- When adding a new endpoint, add docs for it in `document.ts`
 
 ## Component Organization
 

--- a/apps/api/e2e/docs.test.ts
+++ b/apps/api/e2e/docs.test.ts
@@ -58,6 +58,8 @@ test.describe("API Documentation", () => {
     expect(spec.paths).toHaveProperty("/workflows/course-generation/status");
     expect(spec.paths).toHaveProperty("/workflows/chapter-generation/trigger");
     expect(spec.paths).toHaveProperty("/workflows/chapter-generation/status");
+    expect(spec.paths).toHaveProperty("/workflows/lesson-generation/trigger");
+    expect(spec.paths).toHaveProperty("/workflows/lesson-generation/status");
 
     await apiContext.dispose();
   });

--- a/apps/api/e2e/workflows-lesson-generation.test.ts
+++ b/apps/api/e2e/workflows-lesson-generation.test.ts
@@ -1,0 +1,240 @@
+import { randomUUID } from "node:crypto";
+import { request } from "@playwright/test";
+import { prisma } from "@zoonk/db";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { normalizeString } from "@zoonk/utils/string";
+import { expect, test } from "./fixtures";
+
+test.describe("Lesson Generation Workflow API", () => {
+  let baseURL: string;
+  let aiOrgId: number;
+
+  test.beforeAll(async () => {
+    baseURL = process.env.E2E_BASE_URL ?? "";
+
+    const aiOrg = await prisma.organization.findUnique({
+      where: { slug: AI_ORG_SLUG },
+    });
+
+    if (!aiOrg) {
+      throw new Error("AI organization not found");
+    }
+
+    aiOrgId = aiOrg.id;
+  });
+
+  test.afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  test("returns validation error when lessonId is missing", async () => {
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
+      data: {},
+    });
+
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+
+    await apiContext.dispose();
+  });
+
+  test("returns validation error when lessonId is invalid type", async () => {
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
+      data: { lessonId: "invalid" },
+    });
+
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+
+    await apiContext.dispose();
+  });
+
+  test("returns validation error when lessonId is negative", async () => {
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
+      data: { lessonId: -1 },
+    });
+
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+
+    await apiContext.dispose();
+  });
+
+  test("returns 402 when user has no active subscription", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const courseTitle = `E2E Lesson Test ${uniqueId}`;
+
+    const course = await prisma.course.create({
+      data: {
+        description: "Test course for lesson generation",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString(courseTitle),
+        organizationId: aiOrgId,
+        slug: `e2e-lesson-test-${uniqueId}`,
+        title: courseTitle,
+      },
+    });
+
+    const chapter = await prisma.chapter.create({
+      data: {
+        courseId: course.id,
+        description: "Test chapter description",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString("Test Chapter"),
+        organizationId: aiOrgId,
+        position: 0,
+        slug: `e2e-chapter-${uniqueId}`,
+        title: "Test Chapter",
+      },
+    });
+
+    const lesson = await prisma.lesson.create({
+      data: {
+        chapterId: chapter.id,
+        description: "Test lesson description",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString("Test Lesson"),
+        organizationId: aiOrgId,
+        position: 0,
+        slug: `e2e-lesson-${uniqueId}`,
+        title: "Test Lesson",
+      },
+    });
+
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
+      data: { lessonId: lesson.id },
+    });
+
+    expect(response.status()).toBe(402);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("PAYMENT_REQUIRED");
+    expect(body.error.message).toBe("Active subscription required");
+
+    await prisma.lesson.delete({ where: { id: lesson.id } });
+    await prisma.chapter.delete({ where: { id: chapter.id } });
+    await prisma.course.delete({ where: { id: course.id } });
+    await apiContext.dispose();
+  });
+
+  test("returns validation error for status endpoint when runId is missing", async () => {
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.get("/v1/workflows/lesson-generation/status");
+
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+
+    await apiContext.dispose();
+  });
+
+  test("starts workflow successfully with active subscription", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const email = `e2e-lesson-${uniqueId}@zoonk.test`;
+    const password = "password123";
+
+    const signupContext = await request.newContext({ baseURL });
+    const signupResponse = await signupContext.post("/v1/auth/sign-up/email", {
+      data: { email, name: `E2E User ${uniqueId}`, password },
+    });
+
+    expect(signupResponse.ok()).toBe(true);
+    await signupContext.dispose();
+
+    const user = await prisma.user.findUniqueOrThrow({ where: { email } });
+    await prisma.subscription.create({
+      data: {
+        plan: "hobby",
+        referenceId: String(user.id),
+        status: "active",
+        stripeCustomerId: `cus_test_${uniqueId}`,
+        stripeSubscriptionId: `sub_test_${uniqueId}`,
+      },
+    });
+
+    const course = await prisma.course.create({
+      data: {
+        description: "Test course for lesson generation with subscription",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString(`E2E Lesson Success Test ${uniqueId}`),
+        organizationId: aiOrgId,
+        slug: `e2e-lesson-success-${uniqueId}`,
+        title: `E2E Lesson Success Test ${uniqueId}`,
+      },
+    });
+
+    const chapter = await prisma.chapter.create({
+      data: {
+        courseId: course.id,
+        description: "Test chapter for workflow success",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString("Test Chapter Success"),
+        organizationId: aiOrgId,
+        position: 0,
+        slug: `e2e-chapter-success-${uniqueId}`,
+        title: "Test Chapter Success",
+      },
+    });
+
+    const lesson = await prisma.lesson.create({
+      data: {
+        chapterId: chapter.id,
+        description: "Test lesson for workflow success",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString("Test Lesson Success"),
+        organizationId: aiOrgId,
+        position: 0,
+        slug: `e2e-lesson-success-${uniqueId}`,
+        title: "Test Lesson Success",
+      },
+    });
+
+    const apiContext = await request.newContext({ baseURL });
+    const signInResponse = await apiContext.post("/v1/auth/sign-in/email", {
+      data: { email, password },
+    });
+
+    expect(signInResponse.ok()).toBe(true);
+
+    const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
+      data: { lessonId: lesson.id },
+    });
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+
+    expect(body.message).toBe("Workflow started");
+    expect(body.runId).toBeDefined();
+    expect(typeof body.runId).toBe("string");
+
+    await apiContext.dispose();
+  });
+});

--- a/apps/api/src/app/v1/workflows/lesson-generation/status/route.ts
+++ b/apps/api/src/app/v1/workflows/lesson-generation/status/route.ts
@@ -1,0 +1,24 @@
+import { errors } from "@/lib/api-errors";
+import { workflowStatusQuerySchema } from "@/lib/openapi/schemas/workflows";
+import { parseQueryParams } from "@/lib/query-params";
+import { getRun } from "workflow/api";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+
+  const parsed = parseQueryParams(searchParams, workflowStatusQuerySchema);
+
+  if (!parsed.success) {
+    return errors.validation(parsed.error);
+  }
+
+  const run = getRun(parsed.data.runId);
+
+  const stream = run.getReadable<string>({
+    startIndex: parsed.data.startIndex,
+  });
+
+  return new Response(stream, {
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}

--- a/apps/api/src/app/v1/workflows/lesson-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/lesson-generation/trigger/route.ts
@@ -1,0 +1,39 @@
+import { errors } from "@/lib/api-errors";
+import { parseBody } from "@/lib/body-parser";
+import { lessonGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
+import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
+import { auth } from "@zoonk/core/auth";
+import { findActiveSubscription } from "@zoonk/core/auth/subscription";
+import { type NextRequest, NextResponse } from "next/server";
+import { start } from "workflow/api";
+
+async function getSubscriptions(request: NextRequest) {
+  try {
+    return await auth.api.listActiveSubscriptions({
+      headers: request.headers,
+    });
+  } catch {
+    return [];
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const parsed = await parseBody(request, lessonGenerationTriggerSchema);
+
+  if (!parsed.success) {
+    return errors.validation(parsed.error);
+  }
+
+  const subscriptions = await getSubscriptions(request);
+
+  if (!findActiveSubscription(subscriptions)) {
+    return errors.paymentRequired();
+  }
+
+  const run = await start(lessonGenerationWorkflow, [parsed.data.lessonId]);
+
+  return NextResponse.json({
+    message: "Workflow started",
+    runId: run.runId,
+  });
+}

--- a/apps/api/src/lib/openapi/schemas/responses.ts
+++ b/apps/api/src/lib/openapi/schemas/responses.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+import { errorSchema } from "./common";
+import { workflowStatusQuerySchema, workflowTriggerResponseSchema } from "./workflows";
+
+export const validationErrorResponse = {
+  content: { "application/json": { schema: errorSchema } },
+  description: "Validation error",
+} as const;
+
+const subscriptionRequiredResponse = {
+  content: { "application/json": { schema: errorSchema } },
+  description: "Subscription required",
+} as const;
+
+const workflowStartedResponse = {
+  content: { "application/json": { schema: workflowTriggerResponseSchema } },
+  description: "Workflow started",
+} as const;
+
+const sseStreamResponse = {
+  content: { "text/event-stream": { schema: z.string() } },
+  description: "SSE stream of workflow status",
+} as const;
+
+export function workflowTriggerEndpoint({
+  schema,
+  summary,
+  requiresSubscription = false,
+}: {
+  schema: z.ZodType;
+  summary: string;
+  requiresSubscription?: boolean;
+}) {
+  return {
+    post: {
+      ...(requiresSubscription && { description: "Requires active subscription." }),
+      requestBody: {
+        content: { "application/json": { schema } },
+      },
+      responses: {
+        "200": workflowStartedResponse,
+        "400": validationErrorResponse,
+        ...(requiresSubscription && { "402": subscriptionRequiredResponse }),
+      },
+      summary,
+      tags: ["Workflows"],
+    },
+  };
+}
+
+export function workflowStatusEndpoint(summary: string) {
+  return {
+    get: {
+      description: "Returns a Server-Sent Events stream with workflow status updates.",
+      requestParams: { query: workflowStatusQuerySchema },
+      responses: {
+        "200": sseStreamResponse,
+      },
+      summary,
+      tags: ["Workflows"],
+    },
+  };
+}

--- a/apps/api/src/lib/openapi/schemas/workflows.ts
+++ b/apps/api/src/lib/openapi/schemas/workflows.ts
@@ -20,6 +20,16 @@ export const chapterGenerationTriggerSchema = z
   })
   .meta({ id: "ChapterGenerationTrigger" });
 
+export const lessonGenerationTriggerSchema = z
+  .object({
+    lessonId: z
+      .number()
+      .int()
+      .positive()
+      .meta({ description: "Lesson ID to generate activities for" }),
+  })
+  .meta({ id: "LessonGenerationTrigger" });
+
 export const workflowTriggerResponseSchema = z
   .object({
     message: z.string().meta({ example: "Workflow started" }),

--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
@@ -30,6 +30,18 @@ vi.mock("@zoonk/ai/tasks/chapters/lessons", () => ({
   }),
 }));
 
+vi.mock("@zoonk/ai/tasks/lessons/kind", () => ({
+  generateLessonKind: vi.fn().mockResolvedValue({
+    data: { kind: "core" },
+  }),
+}));
+
+vi.mock("@zoonk/ai/tasks/lessons/activities", () => ({
+  generateLessonActivities: vi.fn().mockResolvedValue({
+    data: { activities: [] },
+  }),
+}));
+
 vi.mock("@zoonk/core/cache/revalidate", () => ({
   revalidateMainApp: vi.fn().mockResolvedValue(null),
 }));

--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.ts
@@ -1,4 +1,5 @@
 import { handleChapterFailureStep } from "@/workflows/course-generation/steps/handle-failure-step";
+import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
 import { getWorkflowMetadata } from "workflow";
 import { addLessonsStep } from "./steps/add-lessons-step";
 import { generateLessonsStep } from "./steps/generate-lessons-step";
@@ -30,7 +31,14 @@ export async function chapterGenerationWorkflow(chapterId: number): Promise<void
 
   try {
     const lessons = await generateLessonsStep(context);
-    await addLessonsStep({ context, lessons });
+    const createdLessons = await addLessonsStep({ context, lessons });
+
+    const firstLesson = createdLessons[0];
+
+    if (firstLesson) {
+      await lessonGenerationWorkflow(firstLesson.id);
+    }
+
     await setChapterAsCompletedStep({ context, workflowRunId });
   } catch (error) {
     await handleChapterFailureStep({ chapterId });

--- a/apps/api/src/workflows/config.ts
+++ b/apps/api/src/workflows/config.ts
@@ -8,6 +8,18 @@ const CHAPTER_STEPS = [
 
 export type ChapterStepName = (typeof CHAPTER_STEPS)[number];
 
+const LESSON_STEPS = [
+  "getLesson",
+  "setLessonAsRunning",
+  "determineLessonKind",
+  "updateLessonKind",
+  "generateCustomActivities",
+  "addActivities",
+  "setLessonAsCompleted",
+] as const;
+
+export type LessonStepName = (typeof LESSON_STEPS)[number];
+
 const COURSE_STEPS = [
   "getCourseSuggestion",
   "checkExistingCourse",
@@ -26,6 +38,9 @@ const COURSE_STEPS = [
   "completeCourseSetup",
 ] as const;
 
+// Chapter workflow includes lesson steps since we generate the first lesson
+export type ChapterWorkflowStepName = ChapterStepName | LessonStepName;
+
 // We also generate the first chapter as part of the course workflow
-// So the course generation is only complete after chapter workflow is done
-export type CourseWorkflowStepName = (typeof COURSE_STEPS)[number] | ChapterStepName;
+// So the course generation is only complete after chapter and lesson workflow is done
+export type CourseWorkflowStepName = (typeof COURSE_STEPS)[number] | ChapterWorkflowStepName;

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -82,6 +82,18 @@ vi.mock("@zoonk/ai/tasks/chapters/lessons", () => ({
   }),
 }));
 
+vi.mock("@zoonk/ai/tasks/lessons/kind", () => ({
+  generateLessonKind: vi.fn().mockResolvedValue({
+    data: { kind: "core" },
+  }),
+}));
+
+vi.mock("@zoonk/ai/tasks/lessons/activities", () => ({
+  generateLessonActivities: vi.fn().mockResolvedValue({
+    data: { activities: [] },
+  }),
+}));
+
 describe(courseGenerationWorkflow, () => {
   let organizationId: number;
 

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
@@ -1,0 +1,343 @@
+import { randomUUID } from "node:crypto";
+import { generateLessonActivities } from "@zoonk/ai/tasks/lessons/activities";
+import { generateLessonKind } from "@zoonk/ai/tasks/lessons/kind";
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { lessonGenerationWorkflow } from "./lesson-generation-workflow";
+
+vi.mock("workflow", () => ({
+  FatalError: class FatalError extends Error {},
+  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
+  getWritable: vi.fn().mockReturnValue({
+    getWriter: () => ({
+      releaseLock: vi.fn(),
+      write: vi.fn().mockResolvedValue(null),
+    }),
+  }),
+}));
+
+vi.mock("@zoonk/ai/tasks/lessons/kind", () => ({
+  generateLessonKind: vi.fn().mockResolvedValue({
+    data: { kind: "core" },
+  }),
+}));
+
+vi.mock("@zoonk/ai/tasks/lessons/activities", () => ({
+  generateLessonActivities: vi.fn().mockResolvedValue({
+    data: {
+      activities: [
+        { description: "Custom activity 1 description", title: "Custom Activity 1" },
+        { description: "Custom activity 2 description", title: "Custom Activity 2" },
+      ],
+    },
+  }),
+}));
+
+vi.mock("@zoonk/core/cache/revalidate", () => ({
+  revalidateMainApp: vi.fn().mockResolvedValue(null),
+}));
+
+describe(lessonGenerationWorkflow, () => {
+  let organizationId: number;
+  let course: Awaited<ReturnType<typeof courseFixture>>;
+  let chapter: Awaited<ReturnType<typeof chapterFixture>>;
+
+  beforeAll(async () => {
+    const org = await aiOrganizationFixture();
+    organizationId = org.id;
+    course = await courseFixture({ organizationId });
+    chapter = await chapterFixture({
+      courseId: course.id,
+      organizationId,
+      title: `Test Chapter ${randomUUID()}`,
+    });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("early returns", () => {
+    test("returns early when generationStatus is 'running'", async () => {
+      const lesson = await lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "running",
+        organizationId,
+        title: `Running Lesson ${randomUUID()}`,
+      });
+
+      await lessonGenerationWorkflow(lesson.id);
+
+      const dbLesson = await prisma.lesson.findUnique({
+        where: { id: lesson.id },
+      });
+
+      expect(dbLesson?.generationStatus).toBe("running");
+      expect(generateLessonKind).not.toHaveBeenCalled();
+    });
+
+    test("returns early when generationStatus is 'completed' and has activities", async () => {
+      const lesson = await lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "completed",
+        organizationId,
+        title: `Completed Lesson ${randomUUID()}`,
+      });
+
+      await activityFixture({
+        lessonId: lesson.id,
+        organizationId,
+        title: `Existing Activity ${randomUUID()}`,
+      });
+
+      await lessonGenerationWorkflow(lesson.id);
+
+      const dbLesson = await prisma.lesson.findUnique({
+        where: { id: lesson.id },
+      });
+
+      expect(dbLesson?.generationStatus).toBe("completed");
+      expect(generateLessonKind).not.toHaveBeenCalled();
+    });
+
+    test("sets as completed and returns when lesson has existing activities but status not completed", async () => {
+      const lesson = await lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "pending",
+        organizationId,
+        title: `Lesson with Activities ${randomUUID()}`,
+      });
+
+      await activityFixture({
+        lessonId: lesson.id,
+        organizationId,
+        title: `Existing Activity ${randomUUID()}`,
+      });
+
+      await lessonGenerationWorkflow(lesson.id);
+
+      const dbLesson = await prisma.lesson.findUnique({
+        where: { id: lesson.id },
+      });
+
+      expect(dbLesson?.generationStatus).toBe("completed");
+      expect(dbLesson?.generationRunId).toBe("test-run-id");
+      expect(generateLessonKind).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("core lesson flow", () => {
+    test("generates 8 fixed activities for core lesson", async () => {
+      vi.mocked(generateLessonKind).mockResolvedValueOnce({
+        data: { kind: "core" },
+      } as Awaited<ReturnType<typeof generateLessonKind>>);
+
+      const title = `Core Lesson ${randomUUID()}`;
+      const lesson = await lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "pending",
+        organizationId,
+        title,
+      });
+
+      await lessonGenerationWorkflow(lesson.id);
+
+      const dbLesson = await prisma.lesson.findUnique({
+        where: { id: lesson.id },
+      });
+
+      expect(dbLesson?.generationStatus).toBe("completed");
+      expect(dbLesson?.kind).toBe("core");
+
+      const activities = await prisma.activity.findMany({
+        orderBy: { position: "asc" },
+        where: { lessonId: lesson.id },
+      });
+
+      expect(activities).toHaveLength(8);
+      expect(activities.map((a) => a.kind)).toEqual([
+        "background",
+        "explanation",
+        "quiz",
+        "mechanics",
+        "examples",
+        "story",
+        "challenge",
+        "review",
+      ]);
+
+      for (const activity of activities) {
+        expect(activity.generationStatus).toBe("pending");
+        expect(activity.isPublished).toBeTruthy();
+        expect(activity.title).toBeNull();
+        expect(activity.description).toBeNull();
+      }
+
+      expect(generateLessonActivities).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("language lesson flow", () => {
+    test("generates 5 fixed activities for language lesson", async () => {
+      vi.mocked(generateLessonKind).mockResolvedValueOnce({
+        data: { kind: "language" },
+      } as Awaited<ReturnType<typeof generateLessonKind>>);
+
+      const title = `Language Lesson ${randomUUID()}`;
+      const lesson = await lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "pending",
+        organizationId,
+        title,
+      });
+
+      await lessonGenerationWorkflow(lesson.id);
+
+      const dbLesson = await prisma.lesson.findUnique({
+        where: { id: lesson.id },
+      });
+
+      expect(dbLesson?.generationStatus).toBe("completed");
+      expect(dbLesson?.kind).toBe("language");
+
+      const activities = await prisma.activity.findMany({
+        orderBy: { position: "asc" },
+        where: { lessonId: lesson.id },
+      });
+
+      expect(activities).toHaveLength(5);
+      expect(activities.map((a) => a.kind)).toEqual([
+        "vocabulary",
+        "grammar",
+        "reading",
+        "listening",
+        "review",
+      ]);
+
+      for (const activity of activities) {
+        expect(activity.generationStatus).toBe("pending");
+        expect(activity.isPublished).toBeTruthy();
+        expect(activity.title).toBeNull();
+        expect(activity.description).toBeNull();
+      }
+
+      expect(generateLessonActivities).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("custom lesson flow", () => {
+    test("generates AI-generated activities for custom lesson", async () => {
+      vi.mocked(generateLessonKind).mockResolvedValueOnce({
+        data: { kind: "custom" },
+      } as Awaited<ReturnType<typeof generateLessonKind>>);
+
+      vi.mocked(generateLessonActivities).mockResolvedValueOnce({
+        data: {
+          activities: [
+            { description: "First custom activity", title: "Custom 1" },
+            { description: "Second custom activity", title: "Custom 2" },
+            { description: "Third custom activity", title: "Custom 3" },
+          ],
+        },
+      } as Awaited<ReturnType<typeof generateLessonActivities>>);
+
+      const title = `Custom Lesson ${randomUUID()}`;
+      const lesson = await lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "pending",
+        organizationId,
+        title,
+      });
+
+      await lessonGenerationWorkflow(lesson.id);
+
+      const dbLesson = await prisma.lesson.findUnique({
+        where: { id: lesson.id },
+      });
+
+      expect(dbLesson?.generationStatus).toBe("completed");
+      expect(dbLesson?.kind).toBe("custom");
+
+      const activities = await prisma.activity.findMany({
+        orderBy: { position: "asc" },
+        where: { lessonId: lesson.id },
+      });
+
+      expect(activities).toHaveLength(3);
+      expect(activities[0]?.kind).toBe("custom");
+      expect(activities[0]?.title).toBe("Custom 1");
+      expect(activities[0]?.description).toBe("First custom activity");
+      expect(activities[1]?.title).toBe("Custom 2");
+      expect(activities[2]?.title).toBe("Custom 3");
+
+      for (const activity of activities) {
+        expect(activity.generationStatus).toBe("pending");
+        expect(activity.isPublished).toBeTruthy();
+      }
+
+      expect(generateLessonActivities).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("error handling", () => {
+    test("marks lesson as 'failed' when AI generation throws", async () => {
+      vi.mocked(generateLessonKind).mockRejectedValueOnce(new Error("AI generation failed"));
+
+      const title = `Error Lesson ${randomUUID()}`;
+      const lesson = await lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "pending",
+        organizationId,
+        title,
+      });
+
+      await expect(lessonGenerationWorkflow(lesson.id)).rejects.toThrow("AI generation failed");
+
+      const dbLesson = await prisma.lesson.findUnique({
+        where: { id: lesson.id },
+      });
+
+      expect(dbLesson?.generationStatus).toBe("failed");
+    });
+
+    test("throws FatalError when lesson not found", async () => {
+      const nonExistentId = 999_999_999;
+
+      await expect(lessonGenerationWorkflow(nonExistentId)).rejects.toThrow("Lesson not found");
+    });
+  });
+
+  describe("status transitions", () => {
+    test("updates lesson status: pending → running → completed", async () => {
+      vi.mocked(generateLessonKind).mockResolvedValueOnce({
+        data: { kind: "core" },
+      } as Awaited<ReturnType<typeof generateLessonKind>>);
+
+      const title = `Status Transition Lesson ${randomUUID()}`;
+      const lesson = await lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "pending",
+        organizationId,
+        title,
+      });
+
+      const initialLesson = await prisma.lesson.findUnique({
+        where: { id: lesson.id },
+      });
+      expect(initialLesson?.generationStatus).toBe("pending");
+
+      await lessonGenerationWorkflow(lesson.id);
+
+      const finalLesson = await prisma.lesson.findUnique({
+        where: { id: lesson.id },
+      });
+      expect(finalLesson?.generationStatus).toBe("completed");
+      expect(finalLesson?.generationRunId).toBe("test-run-id");
+    });
+  });
+});

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
@@ -1,0 +1,46 @@
+import { getWorkflowMetadata } from "workflow";
+import { addActivitiesStep } from "./steps/add-activities-step";
+import { determineLessonKindStep } from "./steps/determine-lesson-kind-step";
+import { generateCustomActivitiesStep } from "./steps/generate-custom-activities-step";
+import { getLessonStep } from "./steps/get-lesson-step";
+import { handleLessonFailureStep } from "./steps/handle-failure-step";
+import { setLessonAsCompletedStep } from "./steps/set-lesson-as-completed-step";
+import { setLessonAsRunningStep } from "./steps/set-lesson-as-running-step";
+import { updateLessonKindStep } from "./steps/update-lesson-kind-step";
+
+export async function lessonGenerationWorkflow(lessonId: number): Promise<void> {
+  "use workflow";
+
+  const { workflowRunId } = getWorkflowMetadata();
+
+  const context = await getLessonStep(lessonId);
+
+  if (context.generationStatus === "running") {
+    return;
+  }
+
+  if (context.generationStatus === "completed" && context._count.activities > 0) {
+    return;
+  }
+
+  if (context._count.activities > 0) {
+    await setLessonAsCompletedStep({ context, workflowRunId });
+    return;
+  }
+
+  await setLessonAsRunningStep({ lessonId, workflowRunId });
+
+  try {
+    const lessonKind = await determineLessonKindStep(context);
+    await updateLessonKindStep({ kind: lessonKind, lessonId });
+
+    const customActivities =
+      lessonKind === "custom" ? await generateCustomActivitiesStep(context) : [];
+
+    await addActivitiesStep({ context, customActivities, lessonKind });
+    await setLessonAsCompletedStep({ context, workflowRunId });
+  } catch (error) {
+    await handleLessonFailureStep({ lessonId });
+    throw error;
+  }
+}

--- a/apps/api/src/workflows/lesson-generation/steps/add-activities-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/add-activities-step.ts
@@ -1,0 +1,88 @@
+import { type ActivityKind, type LessonKind, prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+import { type GeneratedActivity } from "./generate-custom-activities-step";
+import { type LessonContext } from "./get-lesson-step";
+
+const CORE_ACTIVITY_KINDS: ActivityKind[] = [
+  "background",
+  "explanation",
+  "quiz",
+  "mechanics",
+  "examples",
+  "story",
+  "challenge",
+  "review",
+];
+
+const LANGUAGE_ACTIVITY_KINDS: ActivityKind[] = [
+  "vocabulary",
+  "grammar",
+  "reading",
+  "listening",
+  "review",
+];
+
+function getActivitiesForKind(
+  lessonKind: LessonKind,
+  customActivities: GeneratedActivity[],
+): {
+  kind: ActivityKind;
+  title: string | null;
+  description: string | null;
+}[] {
+  if (lessonKind === "core") {
+    return CORE_ACTIVITY_KINDS.map((kind) => ({
+      description: null,
+      kind,
+      title: null,
+    }));
+  }
+
+  if (lessonKind === "language") {
+    return LANGUAGE_ACTIVITY_KINDS.map((kind) => ({
+      description: null,
+      kind,
+      title: null,
+    }));
+  }
+
+  return customActivities.map((activity) => ({
+    description: activity.description,
+    kind: "custom" as const,
+    title: activity.title,
+  }));
+}
+
+export async function addActivitiesStep(input: {
+  context: LessonContext;
+  lessonKind: LessonKind;
+  customActivities: GeneratedActivity[];
+}): Promise<void> {
+  "use step";
+
+  await streamStatus({ status: "started", step: "addActivities" });
+
+  const activitiesToCreate = getActivitiesForKind(input.lessonKind, input.customActivities);
+
+  const activitiesData = activitiesToCreate.map((activity, index) => ({
+    description: activity.description,
+    generationStatus: "pending" as const,
+    isPublished: true,
+    kind: activity.kind,
+    language: input.context.language,
+    lessonId: input.context.id,
+    organizationId: input.context.organizationId,
+    position: index,
+    title: activity.title,
+  }));
+
+  const { error } = await safeAsync(() => prisma.activity.createMany({ data: activitiesData }));
+
+  if (error) {
+    await streamStatus({ status: "error", step: "addActivities" });
+    throw error;
+  }
+
+  await streamStatus({ status: "completed", step: "addActivities" });
+}

--- a/apps/api/src/workflows/lesson-generation/steps/determine-lesson-kind-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/determine-lesson-kind-step.ts
@@ -1,0 +1,27 @@
+import { generateLessonKind } from "@zoonk/ai/tasks/lessons/kind";
+import { type LessonKind } from "@zoonk/db";
+import { streamStatus } from "../stream-status";
+import { type LessonContext } from "./get-lesson-step";
+
+export async function determineLessonKindStep(context: LessonContext): Promise<LessonKind> {
+  "use step";
+
+  await streamStatus({ status: "started", step: "determineLessonKind" });
+
+  try {
+    const { data } = await generateLessonKind({
+      chapterTitle: context.chapter.title,
+      courseTitle: context.chapter.course.title,
+      language: context.language,
+      lessonDescription: context.description,
+      lessonTitle: context.title,
+    });
+
+    await streamStatus({ status: "completed", step: "determineLessonKind" });
+
+    return data.kind;
+  } catch (error) {
+    await streamStatus({ status: "error", step: "determineLessonKind" });
+    throw error;
+  }
+}

--- a/apps/api/src/workflows/lesson-generation/steps/generate-custom-activities-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-custom-activities-step.ts
@@ -1,0 +1,33 @@
+import { generateLessonActivities } from "@zoonk/ai/tasks/lessons/activities";
+import { streamStatus } from "../stream-status";
+import { type LessonContext } from "./get-lesson-step";
+
+export type GeneratedActivity = {
+  title: string;
+  description: string;
+};
+
+export async function generateCustomActivitiesStep(
+  context: LessonContext,
+): Promise<GeneratedActivity[]> {
+  "use step";
+
+  await streamStatus({ status: "started", step: "generateCustomActivities" });
+
+  try {
+    const { data } = await generateLessonActivities({
+      chapterTitle: context.chapter.title,
+      courseTitle: context.chapter.course.title,
+      language: context.language,
+      lessonDescription: context.description,
+      lessonTitle: context.title,
+    });
+
+    await streamStatus({ status: "completed", step: "generateCustomActivities" });
+
+    return data.activities;
+  } catch (error) {
+    await streamStatus({ status: "error", step: "generateCustomActivities" });
+    throw error;
+  }
+}

--- a/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.ts
@@ -1,0 +1,54 @@
+import { prisma } from "@zoonk/db";
+import { FatalError } from "workflow";
+import { streamStatus } from "../stream-status";
+
+async function getLessonForGeneration(lessonId: number) {
+  return prisma.lesson.findUnique({
+    select: {
+      _count: {
+        select: {
+          activities: true,
+        },
+      },
+      chapter: {
+        select: {
+          course: {
+            select: {
+              title: true,
+            },
+          },
+          title: true,
+        },
+      },
+      description: true,
+      generationRunId: true,
+      generationStatus: true,
+      id: true,
+      kind: true,
+      language: true,
+      organizationId: true,
+      slug: true,
+      title: true,
+    },
+    where: { id: lessonId },
+  });
+}
+
+export type LessonContext = NonNullable<Awaited<ReturnType<typeof getLessonForGeneration>>>;
+
+export async function getLessonStep(lessonId: number): Promise<LessonContext> {
+  "use step";
+
+  await streamStatus({ status: "started", step: "getLesson" });
+
+  const lesson = await getLessonForGeneration(lessonId);
+
+  if (!lesson) {
+    await streamStatus({ status: "error", step: "getLesson" });
+    throw new FatalError("Lesson not found");
+  }
+
+  await streamStatus({ status: "completed", step: "getLesson" });
+
+  return lesson;
+}

--- a/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.ts
@@ -1,0 +1,14 @@
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+
+export async function handleLessonFailureStep(input: { lessonId: number }): Promise<void> {
+  "use step";
+
+  await safeAsync(() =>
+    prisma.lesson.update({
+      data: { generationStatus: "failed" },
+      select: { generationStatus: true, id: true },
+      where: { id: input.lessonId },
+    }),
+  );
+}

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-completed-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-completed-step.ts
@@ -1,0 +1,35 @@
+import { revalidateMainApp } from "@zoonk/core/cache/revalidate";
+import { prisma } from "@zoonk/db";
+import { cacheTagLesson } from "@zoonk/utils/cache";
+import { safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+import { type LessonContext } from "./get-lesson-step";
+
+export async function setLessonAsCompletedStep(input: {
+  context: LessonContext;
+  workflowRunId: string;
+}): Promise<void> {
+  "use step";
+
+  await streamStatus({ status: "started", step: "setLessonAsCompleted" });
+
+  const { error } = await safeAsync(() =>
+    prisma.lesson.update({
+      data: {
+        generationRunId: input.workflowRunId,
+        generationStatus: "completed",
+      },
+      select: { generationStatus: true, id: true },
+      where: { id: input.context.id },
+    }),
+  );
+
+  if (error) {
+    await streamStatus({ status: "error", step: "setLessonAsCompleted" });
+    throw error;
+  }
+
+  await revalidateMainApp([cacheTagLesson({ lessonSlug: input.context.slug })]);
+
+  await streamStatus({ status: "completed", step: "setLessonAsCompleted" });
+}

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.ts
@@ -1,0 +1,30 @@
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+
+export async function setLessonAsRunningStep(input: {
+  lessonId: number;
+  workflowRunId: string;
+}): Promise<void> {
+  "use step";
+
+  await streamStatus({ status: "started", step: "setLessonAsRunning" });
+
+  const { error } = await safeAsync(() =>
+    prisma.lesson.update({
+      data: {
+        generationRunId: input.workflowRunId,
+        generationStatus: "running",
+      },
+      select: { generationStatus: true, id: true },
+      where: { id: input.lessonId },
+    }),
+  );
+
+  if (error) {
+    await streamStatus({ status: "error", step: "setLessonAsRunning" });
+    throw error;
+  }
+
+  await streamStatus({ status: "completed", step: "setLessonAsRunning" });
+}

--- a/apps/api/src/workflows/lesson-generation/steps/update-lesson-kind-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/update-lesson-kind-step.ts
@@ -1,0 +1,27 @@
+import { type LessonKind, prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+
+export async function updateLessonKindStep(input: {
+  lessonId: number;
+  kind: LessonKind;
+}): Promise<void> {
+  "use step";
+
+  await streamStatus({ status: "started", step: "updateLessonKind" });
+
+  const { error } = await safeAsync(() =>
+    prisma.lesson.update({
+      data: { kind: input.kind },
+      select: { id: true, kind: true },
+      where: { id: input.lessonId },
+    }),
+  );
+
+  if (error) {
+    await streamStatus({ status: "error", step: "updateLessonKind" });
+    throw error;
+  }
+
+  await streamStatus({ status: "completed", step: "updateLessonKind" });
+}

--- a/apps/api/src/workflows/lesson-generation/stream-status.ts
+++ b/apps/api/src/workflows/lesson-generation/stream-status.ts
@@ -1,0 +1,10 @@
+import {
+  type StepStatus,
+  streamStatus as sharedStreamStatus,
+} from "@/workflows/_shared/stream-status";
+import { type LessonStepName } from "@/workflows/config";
+
+export async function streamStatus(params: { step: LessonStepName; status: StepStatus }) {
+  "use step";
+  return sharedStreamStatus(params);
+}

--- a/apps/api/vitest.config.mts
+++ b/apps/api/vitest.config.mts
@@ -3,6 +3,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  assetsInclude: ["**/*.md"],
   plugins: [tsconfigPaths()],
   resolve: {
     alias: [

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -955,6 +955,12 @@ msgid "Generating lessons"
 msgstr "Generating lessons"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "fY0l+a"
+msgid "Generating activities"
+msgstr "Generating activities"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 msgctxt "V4F+/7"
 msgid "Finishing up"
 msgstr "Finishing up"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -955,6 +955,12 @@ msgid "Generating lessons"
 msgstr "Generando lecciones"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "fY0l+a"
+msgid "Generating activities"
+msgstr "Generando actividades"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 msgctxt "V4F+/7"
 msgid "Finishing up"
 msgstr "Finalizando"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -955,6 +955,12 @@ msgid "Generating lessons"
 msgstr "Gerando aulas"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "fY0l+a"
+msgid "Generating activities"
+msgstr "Gerando atividades"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 msgctxt "V4F+/7"
 msgid "Finishing up"
 msgstr "Finalizando"

--- a/apps/main/src/app/[locale]/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/generation-client.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/generation/generation-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
-import { type ChapterStepName } from "@/workflows/config";
+import { type ChapterWorkflowStepName, LESSON_COMPLETION_STEP } from "@/workflows/config";
 import { type GenerationStatus } from "@zoonk/db";
 import { AI_ORG_SLUG, API_URL } from "@zoonk/utils/constants";
 import { useExtracted } from "next-intl";
@@ -35,8 +35,8 @@ export function GenerationClient({
 }) {
   const t = useExtracted();
 
-  const generation = useWorkflowGeneration<ChapterStepName>({
-    completionStep: "setChapterAsCompleted",
+  const generation = useWorkflowGeneration<ChapterWorkflowStepName>({
+    completionStep: LESSON_COMPLETION_STEP,
     initialRunId: generationRunId,
     initialStatus: generationStatus === "running" ? "streaming" : "idle",
     statusUrl: `${API_URL}/v1/workflows/chapter-generation/status`,

--- a/apps/main/src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { type PhaseStatus } from "@/lib/generation-phases";
-import { type ChapterStepName } from "@/workflows/config";
+import { type ChapterWorkflowStepName } from "@/workflows/config";
 import { useExtracted } from "next-intl";
 import {
   PHASE_ICONS,
@@ -19,13 +19,14 @@ export type PhaseInfo = {
 };
 
 export function useGenerationPhases(
-  completedSteps: ChapterStepName[],
-  currentStep: ChapterStepName | null,
+  completedSteps: ChapterWorkflowStepName[],
+  currentStep: ChapterWorkflowStepName | null,
 ) {
   const t = useExtracted();
 
   const labels: Record<PhaseName, string> = {
     completing: t("Finishing up"),
+    generatingActivities: t("Generating activities"),
     generatingLessons: t("Generating lessons"),
     loadingInfo: t("Loading chapter information"),
   };

--- a/apps/main/src/app/[locale]/generate/cs/[id]/generation-client.tsx
+++ b/apps/main/src/app/[locale]/generate/cs/[id]/generation-client.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/generation/generation-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
-import { CHAPTER_COMPLETION_STEP, type CourseWorkflowStepName } from "@/workflows/config";
+import { type CourseWorkflowStepName, LESSON_COMPLETION_STEP } from "@/workflows/config";
 import { type GenerationStatus } from "@zoonk/db";
 import { AI_ORG_SLUG, API_URL } from "@zoonk/utils/constants";
 import { useExtracted } from "next-intl";
@@ -34,7 +34,7 @@ export function GenerationClient({
   const t = useExtracted();
 
   const generation = useWorkflowGeneration<CourseWorkflowStepName>({
-    completionStep: CHAPTER_COMPLETION_STEP,
+    completionStep: LESSON_COMPLETION_STEP,
     initialRunId: generationRunId,
     initialStatus: generationStatus === "running" ? "streaming" : "idle",
     statusUrl: `${API_URL}/v1/workflows/course-generation/status`,

--- a/apps/main/src/app/[locale]/generate/cs/[id]/generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/cs/[id]/generation-phases.ts
@@ -3,7 +3,12 @@ import {
   calculateWeightedProgress as calculateProgress,
   getPhaseStatus as getStatus,
 } from "@/lib/generation-phases";
-import { CHAPTER_STEPS, COURSE_STEPS, type CourseWorkflowStepName } from "@/workflows/config";
+import {
+  CHAPTER_STEPS,
+  COURSE_STEPS,
+  type CourseWorkflowStepName,
+  LESSON_STEPS,
+} from "@/workflows/config";
 import {
   BookOpenIcon,
   GraduationCapIcon,
@@ -13,6 +18,7 @@ import {
   SearchIcon,
   SettingsIcon,
   SparklesIcon,
+  ZapIcon,
 } from "lucide-react";
 
 export type PhaseName =
@@ -22,10 +28,12 @@ export type PhaseName =
   | "generatingDetails"
   | "savingMetadata"
   | "planningChapters"
-  | "generatingLessons";
+  | "generatingLessons"
+  | "generatingActivities";
 
 const PHASE_STEPS: Record<PhaseName, CourseWorkflowStepName[]> = {
   checkingExisting: ["checkExistingCourse"],
+  generatingActivities: [...LESSON_STEPS],
   generatingDetails: [
     "generateDescription",
     "generateImage",
@@ -64,10 +72,12 @@ export const PHASE_ORDER: PhaseName[] = [
   "savingMetadata",
   "planningChapters",
   "generatingLessons",
+  "generatingActivities",
 ];
 
 export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
   checkingExisting: SearchIcon,
+  generatingActivities: ZapIcon,
   generatingDetails: SparklesIcon,
   generatingLessons: GraduationCapIcon,
   loadingInfo: BookOpenIcon,
@@ -78,8 +88,9 @@ export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
 
 const PHASE_WEIGHTS: Record<PhaseName, number> = {
   checkingExisting: 1,
+  generatingActivities: 19,
   generatingDetails: 19,
-  generatingLessons: 38,
+  generatingLessons: 19,
   loadingInfo: 1,
   planningChapters: 38,
   savingMetadata: 2,

--- a/apps/main/src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
@@ -26,6 +26,7 @@ export function useGenerationPhases(
 
   const labels: Record<PhaseName, string> = {
     checkingExisting: t("Checking for existing course"),
+    generatingActivities: t("Generating activities"),
     generatingDetails: t("Generating course details"),
     generatingLessons: t("Generating lessons"),
     loadingInfo: t("Loading course information"),

--- a/apps/main/src/workflows/config.ts
+++ b/apps/main/src/workflows/config.ts
@@ -7,7 +7,19 @@ export const CHAPTER_STEPS = [
 ] as const;
 
 export type ChapterStepName = (typeof CHAPTER_STEPS)[number];
-export const CHAPTER_COMPLETION_STEP: ChapterStepName = "setChapterAsCompleted";
+
+export const LESSON_STEPS = [
+  "getLesson",
+  "setLessonAsRunning",
+  "determineLessonKind",
+  "updateLessonKind",
+  "generateCustomActivities",
+  "addActivities",
+  "setLessonAsCompleted",
+] as const;
+
+export type LessonStepName = (typeof LESSON_STEPS)[number];
+export const LESSON_COMPLETION_STEP: LessonStepName = "setLessonAsCompleted";
 
 export const COURSE_STEPS = [
   "getCourseSuggestion",
@@ -29,6 +41,9 @@ export const COURSE_STEPS = [
 
 export type CourseStepName = (typeof COURSE_STEPS)[number];
 
+// Chapter workflow includes lesson steps since we generate the first lesson
+export type ChapterWorkflowStepName = ChapterStepName | LessonStepName;
+
 // We also generate the first chapter as part of the course workflow
-// So the course generation is only complete after chapter workflow is done
-export type CourseWorkflowStepName = CourseStepName | ChapterStepName;
+// So the course generation is only complete after chapter and lesson workflow is done
+export type CourseWorkflowStepName = CourseStepName | ChapterWorkflowStepName;

--- a/i18n.lock
+++ b/i18n.lock
@@ -371,6 +371,7 @@ checksums:
     Something%20went%20wrong.%20Please%20try%20again./singular: c62a7718d9a1e9c4ffb707807550f836
     Redirecting%20to%20your%20chapter.../singular: 1187b3b828d92daa195cc8d103ecbcc4
     Generating%20lessons/singular: c4cd98341fd568b3cc5ab0daff85f483
+    Generating%20activities/singular: ee132df58cd4c770e5ef3fd77c6187b8
     Finishing%20up/singular: 5db7ffd9f1807c8e5936ddca2fe8d1b7
     Loading%20chapter%20information/singular: 7a310c88460ccc1d8eb14885361dcfa6
     Creating%20your%20course/singular: 02c33db1106e7478e5cbd00fa5f20532


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a lesson generation workflow with trigger/status endpoints, streaming updates, and UI progress, and auto-runs after chapter creation to generate lesson activities based on lesson kind.

- **New Features**
  - API: /v1/workflows/lesson-generation/trigger (requires active subscription) and /v1/workflows/lesson-generation/status (SSE).
  - Workflow: Detects lesson kind (core, language, custom), creates activities, updates statuses, and handles failures.
  - Auto-run: First lesson of a new chapter starts the lesson workflow.
  - UI: New “Generating activities” phase and updated progress weights; translations added (en/es/pt).

- **Refactors**
  - OpenAPI: DRY helpers for workflow endpoints and standardized validation/error responses.
  - Workflows config: Added lesson step types and integrated into chapter/course step unions.
  - Data: Use createManyAndReturn for lessons to access created IDs.
  - Tests: Added e2e for endpoints and unit tests for lesson workflow; updated docs test; vitest config tweak.
  - Docs: AGENTS.md reminder to document new endpoints.

<sup>Written for commit 063c66b1e4896ca2b777a50f8263925e4ff664fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

