### PR TITLE
feat(main): add lesson generation page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ For detailed UX guidelines (interactions, animation, layout, accessibility), see
 - Don't create migration files manually. Run `pnpm --filter @zoonk/db db:migrate --name <migration-name>` to generate migration
 - Workflow files (`"use workflow"`) can't call Node APIs directly; wrap them in `"use step"` functions
 - When adding a new endpoint, add docs for it in `document.ts`
+- When adding e2e tests, use `*Fixture()` functions to create unique test data per test - do not modify seed files
 
 ## Component Organization
 

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -1,0 +1,288 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { type Page, type Route } from "@zoonk/e2e/fixtures";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { normalizeString } from "@zoonk/utils/string";
+import { expect, test } from "./fixtures";
+
+/**
+ * Test Architecture for Lesson Generation Page
+ *
+ * The generation page has 3 access states:
+ * 1. Unauthenticated - Shows login prompt
+ * 2. Authenticated without subscription - Shows upgrade CTA
+ * 3. Authenticated with subscription - Shows generation UI
+ *
+ * The generation flow interacts with 2 APIs on the API server:
+ * 1. POST ${API_BASE_URL}/v1/workflows/lesson-generation/trigger - Starts the workflow, returns { runId: string }
+ * 2. GET ${API_BASE_URL}/v1/workflows/lesson-generation/status?runId=X&startIndex=N - Returns SSE stream of step updates
+ */
+
+const TEST_RUN_ID = "test-run-id-lesson-12345";
+const TEST_USER_EMAIL = "e2e-new@zoonk.test";
+
+type MockApiOptions = {
+  triggerResponse?: { runId?: string; error?: string; status?: number };
+  streamMessages?: { step: string; status: string }[];
+  streamError?: boolean;
+};
+
+/**
+ * Creates a mock SSE stream response from an array of messages.
+ */
+function createSSEStream(messages: { step: string; status: string }[]): string {
+  return messages.map((msg) => `data: ${JSON.stringify(msg)}\n\n`).join("");
+}
+
+/**
+ * Creates the route handler function for mocking APIs.
+ */
+function createRouteHandler(options: MockApiOptions) {
+  const {
+    triggerResponse = { runId: TEST_RUN_ID },
+    streamMessages = [],
+    streamError = false,
+  } = options;
+
+  return async (route: Route) => {
+    const url = route.request().url();
+    const method = route.request().method();
+
+    // Mock trigger API
+    if (url.includes("/v1/workflows/lesson-generation/trigger") && method === "POST") {
+      if (triggerResponse.error) {
+        await route.fulfill({
+          body: JSON.stringify({ error: triggerResponse.error }),
+          contentType: "application/json",
+          status: triggerResponse.status ?? 500,
+        });
+        return;
+      }
+      await route.fulfill({
+        body: JSON.stringify({
+          message: "Workflow started",
+          runId: triggerResponse.runId,
+        }),
+        contentType: "application/json",
+        status: 200,
+      });
+      return;
+    }
+
+    // Mock status stream API
+    if (url.includes("/v1/workflows/lesson-generation/status")) {
+      if (streamError) {
+        await route.abort("failed");
+        return;
+      }
+      await route.fulfill({
+        body: createSSEStream(streamMessages),
+        contentType: "text/event-stream",
+        status: 200,
+      });
+      return;
+    }
+
+    // Continue with all other requests
+    await route.continue();
+  };
+}
+
+/**
+ * Sets up route interception for lesson generation APIs.
+ */
+async function setupMockApis(page: Page, options: MockApiOptions = {}): Promise<void> {
+  const handler = createRouteHandler(options);
+  await page.route("**/v1/workflows/lesson-generation/**", handler);
+}
+
+/**
+ * Creates a lesson with pending generation status for testing the generation workflow.
+ */
+async function createPendingLesson() {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const uniqueId = randomUUID().slice(0, 8);
+  const courseTitle = `E2E Lesson Course ${uniqueId}`;
+  const chapterTitle = `E2E Lesson Chapter ${uniqueId}`;
+  const lessonTitle = `E2E Generation Lesson ${uniqueId}`;
+
+  const course = await courseFixture({
+    isPublished: true,
+    normalizedTitle: normalizeString(courseTitle),
+    organizationId: org.id,
+    slug: `e2e-lesson-course-${uniqueId}`,
+    title: courseTitle,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    generationStatus: "completed",
+    isPublished: true,
+    normalizedTitle: normalizeString(chapterTitle),
+    organizationId: org.id,
+    slug: `e2e-lesson-chapter-${uniqueId}`,
+    title: chapterTitle,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    generationStatus: "pending",
+    isPublished: true,
+    normalizedTitle: normalizeString(lessonTitle),
+    organizationId: org.id,
+    slug: `e2e-gen-lesson-${uniqueId}`,
+    title: lessonTitle,
+  });
+
+  return { chapter, course, lesson, organizationId: org.id };
+}
+
+/**
+ * Creates a test subscription for the test user.
+ */
+async function createTestSubscription() {
+  const uniqueId = randomUUID();
+
+  const user = await prisma.user.findUniqueOrThrow({
+    where: { email: TEST_USER_EMAIL },
+  });
+
+  const subscription = await prisma.subscription.create({
+    data: {
+      plan: "hobby",
+      referenceId: String(user.id),
+      status: "active",
+      stripeCustomerId: `cus_test_e2e_lesson_${uniqueId}`,
+      stripeSubscriptionId: `sub_test_e2e_lesson_${uniqueId}`,
+    },
+  });
+
+  return subscription;
+}
+
+test.describe("Generate Lesson Page - Unauthenticated", () => {
+  test("shows login prompt with link to login page", async ({ page }) => {
+    const { lesson } = await createPendingLesson();
+    await page.goto(`/generate/l/${lesson.id}`);
+
+    await expect(page.getByRole("alert").filter({ hasText: /logged in/i })).toBeVisible();
+
+    const loginLink = page.getByRole("link", { name: /login/i });
+    await expect(loginLink).toBeVisible();
+    await expect(loginLink).toHaveAttribute("href", "/login");
+  });
+});
+
+test.describe("Generate Lesson Page - No Subscription", () => {
+  test("shows upgrade CTA when authenticated without subscription", async ({
+    authenticatedPage,
+  }) => {
+    const { lesson } = await createPendingLesson();
+    await authenticatedPage.goto(`/generate/l/${lesson.id}`);
+
+    await expect(authenticatedPage.getByText(/upgrade to generate/i)).toBeVisible();
+
+    await expect(authenticatedPage.getByRole("button", { name: /upgrade/i })).toBeVisible();
+  });
+
+  test("upgrade button shows loading state when clicked", async ({ authenticatedPage }) => {
+    const { lesson } = await createPendingLesson();
+    await authenticatedPage.goto(`/generate/l/${lesson.id}`);
+
+    const upgradeButton = authenticatedPage.getByRole("button", {
+      name: /upgrade/i,
+    });
+
+    await upgradeButton.click();
+    await expect(upgradeButton).toBeDisabled();
+  });
+});
+
+test.describe("Generate Lesson Page - With Subscription", () => {
+  test("shows generation UI and completes workflow", async ({ userWithoutProgress }) => {
+    await createTestSubscription();
+    const { lesson, organizationId } = await createPendingLesson();
+
+    // Create an activity so the lesson page doesn't redirect back to /generate
+    const uniqueId = randomUUID().slice(0, 8);
+    await activityFixture({
+      isPublished: true,
+      lessonId: lesson.id,
+      organizationId,
+      title: `E2E Generated Activity ${uniqueId}`,
+    });
+
+    await setupMockApis(userWithoutProgress, {
+      streamMessages: [
+        { status: "started", step: "getLesson" },
+        { status: "completed", step: "getLesson" },
+        { status: "started", step: "setLessonAsRunning" },
+        { status: "completed", step: "setLessonAsRunning" },
+        { status: "started", step: "determineLessonKind" },
+        { status: "completed", step: "determineLessonKind" },
+        { status: "started", step: "updateLessonKind" },
+        { status: "completed", step: "updateLessonKind" },
+        { status: "started", step: "generateCustomActivities" },
+        { status: "completed", step: "generateCustomActivities" },
+        { status: "started", step: "addActivities" },
+        { status: "completed", step: "addActivities" },
+        { status: "started", step: "setLessonAsCompleted" },
+        { status: "completed", step: "setLessonAsCompleted" },
+      ],
+    });
+
+    await userWithoutProgress.goto(`/generate/l/${lesson.id}`);
+
+    // Should show completion message
+    await expect(userWithoutProgress.getByText(/activities generated/i)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await expect(userWithoutProgress.getByText(/redirecting to your lesson/i)).toBeVisible();
+
+    // Update lesson status - the redirect will happen in ~1.5s via location.href
+    await prisma.lesson.update({
+      data: { generationStatus: "completed" },
+      where: { id: lesson.id },
+    });
+
+    // Should redirect to lesson page
+    await userWithoutProgress.waitForURL(/\/b\/ai\/c\//, { timeout: 10_000 });
+  });
+
+  test("shows error when stream returns error status", async ({ userWithoutProgress }) => {
+    await createTestSubscription();
+    const { lesson } = await createPendingLesson();
+
+    await setupMockApis(userWithoutProgress, {
+      streamMessages: [
+        { status: "started", step: "getLesson" },
+        { status: "error", step: "getLesson" },
+      ],
+    });
+
+    await userWithoutProgress.goto(`/generate/l/${lesson.id}`);
+
+    await expect(userWithoutProgress.getByText(/generation failed/i)).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});
+
+test.describe("Generate Lesson Page - Not Found", () => {
+  test("invalid lesson ID shows 404 page", async ({ page }) => {
+    await page.goto("/generate/l/999999");
+    await expect(page.getByText(/not found|404/i)).toBeVisible();
+  });
+
+  test("non-numeric lesson ID shows 404 page", async ({ page }) => {
+    await page.goto("/generate/l/invalid-id");
+    await expect(page.getByText(/not found|404/i)).toBeVisible();
+  });
+});

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -911,18 +911,21 @@ msgstr "Generate Chapter"
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
 msgctxt "/Nrb/0"
 msgid "Generation progress"
 msgstr "Generation progress"
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
 msgctxt "FazwRl"
 msgid "Try again"
 msgstr "Try again"
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
 msgctxt "ssRq8D"
 msgid "Generation failed"
 msgstr "Generation failed"
@@ -939,6 +942,7 @@ msgstr "Creating your lessons"
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
 msgctxt "W/5hwr"
 msgid "Something went wrong. Please try again."
 msgstr "Something went wrong. Please try again."
@@ -956,11 +960,13 @@ msgstr "Generating lessons"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
 msgctxt "fY0l+a"
 msgid "Generating activities"
 msgstr "Generating activities"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
 msgctxt "V4F+/7"
 msgid "Finishing up"
 msgstr "Finishing up"
@@ -1014,6 +1020,36 @@ msgstr "Planning chapters"
 msgctxt "rso9iW"
 msgid "Checking for existing course"
 msgstr "Checking for existing course"
+
+#: src/app/[locale]/generate/l/[id]/generate-lesson-content.tsx
+msgctxt "GG4VCc"
+msgid "Generate Lesson"
+msgstr "Generate Lesson"
+
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
+msgctxt "dO1XtE"
+msgid "Creating your activities"
+msgstr "Creating your activities"
+
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
+msgctxt "FYb23f"
+msgid "Activities generated"
+msgstr "Activities generated"
+
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
+msgctxt "hkEZZA"
+msgid "Redirecting to your lesson..."
+msgstr "Redirecting to your lesson..."
+
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "C5CAfi"
+msgid "Loading lesson information"
+msgstr "Loading lesson information"
+
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "cYDCI+"
+msgid "Determining lesson type"
+msgstr "Determining lesson type"
 
 #: src/app/[locale]/privacy/page.tsx
 msgctxt "iql85X"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -911,18 +911,21 @@ msgstr "Generar capítulo"
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
 msgctxt "/Nrb/0"
 msgid "Generation progress"
 msgstr "Progreso de generación"
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
 msgctxt "FazwRl"
 msgid "Try again"
 msgstr "Intentar de nuevo"
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
 msgctxt "ssRq8D"
 msgid "Generation failed"
 msgstr "La generación falló"
@@ -939,6 +942,7 @@ msgstr "Creando tus lecciones"
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
 msgctxt "W/5hwr"
 msgid "Something went wrong. Please try again."
 msgstr "Algo salió mal. Por favor, intenta de nuevo."
@@ -956,11 +960,13 @@ msgstr "Generando lecciones"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
 msgctxt "fY0l+a"
 msgid "Generating activities"
 msgstr "Generando actividades"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
 msgctxt "V4F+/7"
 msgid "Finishing up"
 msgstr "Finalizando"
@@ -1014,6 +1020,36 @@ msgstr "Planeando capítulos"
 msgctxt "rso9iW"
 msgid "Checking for existing course"
 msgstr "Verificando si el curso existe"
+
+#: src/app/[locale]/generate/l/[id]/generate-lesson-content.tsx
+msgctxt "GG4VCc"
+msgid "Generate Lesson"
+msgstr "Generar lección"
+
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
+msgctxt "dO1XtE"
+msgid "Creating your activities"
+msgstr "Creando tus actividades"
+
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
+msgctxt "FYb23f"
+msgid "Activities generated"
+msgstr "Actividades generadas"
+
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
+msgctxt "hkEZZA"
+msgid "Redirecting to your lesson..."
+msgstr "Redirigiendo a tu lección..."
+
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "C5CAfi"
+msgid "Loading lesson information"
+msgstr "Cargando información de la lección"
+
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "cYDCI+"
+msgid "Determining lesson type"
+msgstr "Determinando tipo de lección"
 
 #: src/app/[locale]/privacy/page.tsx
 msgctxt "iql85X"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -911,18 +911,21 @@ msgstr "Gerar capítulo"
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
 msgctxt "/Nrb/0"
 msgid "Generation progress"
 msgstr "Progresso da geração"
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
 msgctxt "FazwRl"
 msgid "Try again"
 msgstr "Tentar novamente"
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
 msgctxt "ssRq8D"
 msgid "Generation failed"
 msgstr "Geração falhou"
@@ -939,6 +942,7 @@ msgstr "Criando suas aulas"
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
 msgctxt "W/5hwr"
 msgid "Something went wrong. Please try again."
 msgstr "Algo deu errado. Por favor, tente novamente."
@@ -956,11 +960,13 @@ msgstr "Gerando aulas"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
 msgctxt "fY0l+a"
 msgid "Generating activities"
 msgstr "Gerando atividades"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
 msgctxt "V4F+/7"
 msgid "Finishing up"
 msgstr "Finalizando"
@@ -1014,6 +1020,36 @@ msgstr "Planejando capítulos"
 msgctxt "rso9iW"
 msgid "Checking for existing course"
 msgstr "Verificando curso existente"
+
+#: src/app/[locale]/generate/l/[id]/generate-lesson-content.tsx
+msgctxt "GG4VCc"
+msgid "Generate Lesson"
+msgstr "Gerar aula"
+
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
+msgctxt "dO1XtE"
+msgid "Creating your activities"
+msgstr "Criando suas atividades"
+
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
+msgctxt "FYb23f"
+msgid "Activities generated"
+msgstr "Atividades geradas"
+
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
+msgctxt "hkEZZA"
+msgid "Redirecting to your lesson..."
+msgstr "Redirecionando para a sua aula..."
+
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "C5CAfi"
+msgid "Loading lesson information"
+msgstr "Carregando informações da aula"
+
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "cYDCI+"
+msgid "Determining lesson type"
+msgstr "Determinando tipo de aula"
 
 #: src/app/[locale]/privacy/page.tsx
 msgctxt "iql85X"

--- a/apps/main/src/app/[locale]/generate/l/[id]/generate-lesson-content.tsx
+++ b/apps/main/src/app/[locale]/generate/l/[id]/generate-lesson-content.tsx
@@ -1,0 +1,93 @@
+import { LoginRequired } from "@/components/auth/login-required";
+import { SubscriptionGate } from "@/components/subscription/subscription-gate";
+import { getLessonForGeneration } from "@/data/lessons/get-lesson-for-generation";
+import { getSession } from "@zoonk/core/users/session/get";
+import {
+  Container,
+  ContainerBody,
+  ContainerDescription,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { parseNumericId } from "@zoonk/utils/string";
+import { getExtracted } from "next-intl/server";
+import { notFound, redirect } from "next/navigation";
+import { GenerationClient } from "./generation-client";
+
+export async function GenerateLessonContent({
+  params,
+}: {
+  params: Promise<{ id: string; locale: string }>;
+}) {
+  const { id, locale } = await params;
+  const lessonId = parseNumericId(id);
+
+  if (lessonId === null) {
+    notFound();
+  }
+
+  const [session, lesson] = await Promise.all([getSession(), getLessonForGeneration(lessonId)]);
+
+  if (!lesson) {
+    notFound();
+  }
+
+  const t = await getExtracted();
+
+  if (!session) {
+    return <LoginRequired title={t("Generate Lesson")} />;
+  }
+
+  if (lesson.generationStatus === "completed") {
+    redirect(
+      `/${locale}/b/${AI_ORG_SLUG}/c/${lesson.chapter.course.slug}/ch/${lesson.chapter.slug}/l/${lesson.slug}`,
+    );
+  }
+
+  const returnUrl = `/generate/l/${lessonId}`;
+
+  return (
+    <Container variant="narrow">
+      <ContainerHeader>
+        <ContainerHeaderGroup>
+          <ContainerTitle>{lesson.title}</ContainerTitle>
+          <ContainerDescription>{lesson.description}</ContainerDescription>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <SubscriptionGate returnUrl={returnUrl}>
+          <GenerationClient
+            chapterSlug={lesson.chapter.slug}
+            courseSlug={lesson.chapter.course.slug}
+            generationRunId={lesson.generationRunId}
+            generationStatus={lesson.generationStatus}
+            lessonId={lessonId}
+            lessonSlug={lesson.slug}
+            locale={locale}
+          />
+        </SubscriptionGate>
+      </ContainerBody>
+    </Container>
+  );
+}
+
+export function GenerateLessonFallback() {
+  return (
+    <Container variant="narrow">
+      <ContainerHeader>
+        <ContainerHeaderGroup>
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="mt-1 h-4 w-72" />
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <Skeleton className="h-64 w-full rounded-xl" />
+      </ContainerBody>
+    </Container>
+  );
+}

--- a/apps/main/src/app/[locale]/generate/l/[id]/generation-client.tsx
+++ b/apps/main/src/app/[locale]/generate/l/[id]/generation-client.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import {
+  GenerationProgressCompleted,
+  GenerationProgressError,
+  GenerationTimeline,
+  GenerationTimelineHeader,
+  GenerationTimelineProgress,
+  GenerationTimelineStep,
+  GenerationTimelineSteps,
+  GenerationTimelineTitle,
+} from "@/components/generation/generation-progress";
+import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
+import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
+import { LESSON_COMPLETION_STEP, type LessonStepName } from "@/workflows/config";
+import { type GenerationStatus } from "@zoonk/db";
+import { AI_ORG_SLUG, API_URL } from "@zoonk/utils/constants";
+import { useExtracted } from "next-intl";
+import { useGenerationPhases } from "./use-generation-phases";
+
+export function GenerationClient({
+  chapterSlug,
+  courseSlug,
+  generationRunId,
+  generationStatus,
+  lessonId,
+  lessonSlug,
+  locale,
+}: {
+  chapterSlug: string;
+  courseSlug: string;
+  generationRunId: string | null;
+  generationStatus: GenerationStatus;
+  lessonId: number;
+  lessonSlug: string;
+  locale: string;
+}) {
+  const t = useExtracted();
+
+  const generation = useWorkflowGeneration<LessonStepName>({
+    completionStep: LESSON_COMPLETION_STEP,
+    initialRunId: generationRunId,
+    initialStatus: generationStatus === "running" ? "streaming" : "idle",
+    statusUrl: `${API_URL}/v1/workflows/lesson-generation/status`,
+    triggerBody: { lessonId },
+    triggerUrl: `${API_URL}/v1/workflows/lesson-generation/trigger`,
+  });
+
+  const { phases, progress } = useGenerationPhases(
+    generation.completedSteps,
+    generation.currentStep,
+  );
+
+  useCompletionRedirect({
+    status: generation.status,
+    url: `/${locale}/b/${AI_ORG_SLUG}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`,
+  });
+
+  if (generation.status === "triggering" || generation.status === "streaming") {
+    return (
+      <GenerationTimeline>
+        <GenerationTimelineHeader>
+          <GenerationTimelineTitle>{t("Creating your activities")}</GenerationTimelineTitle>
+          <GenerationTimelineProgress label={t("Generation progress")} value={progress} />
+        </GenerationTimelineHeader>
+
+        <GenerationTimelineSteps>
+          {phases.map((phase, index) => (
+            <GenerationTimelineStep
+              icon={phase.icon}
+              isLast={index === phases.length - 1}
+              key={phase.name}
+              status={phase.status}
+            >
+              {phase.label}
+            </GenerationTimelineStep>
+          ))}
+        </GenerationTimelineSteps>
+      </GenerationTimeline>
+    );
+  }
+
+  if (generation.status === "completed") {
+    return (
+      <GenerationProgressCompleted subtitle={t("Redirecting to your lesson...")}>
+        {t("Activities generated")}
+      </GenerationProgressCompleted>
+    );
+  }
+
+  if (generation.status === "error") {
+    return (
+      <GenerationProgressError
+        description={generation.error || t("Something went wrong. Please try again.")}
+        onRetry={generation.retry}
+        retryLabel={t("Try again")}
+      >
+        {t("Generation failed")}
+      </GenerationProgressError>
+    );
+  }
+
+  return null;
+}

--- a/apps/main/src/app/[locale]/generate/l/[id]/generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/l/[id]/generation-phases.ts
@@ -1,0 +1,72 @@
+import {
+  type PhaseStatus,
+  calculateWeightedProgress as calculateProgress,
+  getPhaseStatus as getStatus,
+} from "@/lib/generation-phases";
+import { LESSON_STEPS, type LessonStepName } from "@/workflows/config";
+import {
+  BookOpenIcon,
+  CheckCircleIcon,
+  type LucideIcon,
+  SearchIcon,
+  SparklesIcon,
+} from "lucide-react";
+
+export type PhaseName = "loadingInfo" | "determiningKind" | "generatingActivities" | "completing";
+
+const PHASE_STEPS: Record<PhaseName, LessonStepName[]> = {
+  completing: ["setLessonAsCompleted"],
+  determiningKind: ["determineLessonKind", "updateLessonKind"],
+  generatingActivities: ["generateCustomActivities", "addActivities"],
+  loadingInfo: ["getLesson", "setLessonAsRunning"],
+};
+
+const allPhaseSteps = new Set(Object.values(PHASE_STEPS).flat());
+const missingLessonSteps = LESSON_STEPS.filter((step) => !allPhaseSteps.has(step));
+
+if (missingLessonSteps.length > 0) {
+  throw new Error(
+    `Missing lesson steps in PHASE_STEPS: ${missingLessonSteps.join(", ")}. ` +
+      "Add them to the appropriate phase in generation-phases.ts",
+  );
+}
+
+export const PHASE_ORDER: PhaseName[] = [
+  "loadingInfo",
+  "determiningKind",
+  "generatingActivities",
+  "completing",
+];
+
+export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
+  completing: CheckCircleIcon,
+  determiningKind: SearchIcon,
+  generatingActivities: SparklesIcon,
+  loadingInfo: BookOpenIcon,
+};
+
+const PHASE_WEIGHTS: Record<PhaseName, number> = {
+  completing: 5,
+  determiningKind: 25,
+  generatingActivities: 65,
+  loadingInfo: 5,
+};
+
+export function getPhaseStatus(
+  phase: PhaseName,
+  completedSteps: LessonStepName[],
+  currentStep: LessonStepName | null,
+): PhaseStatus {
+  return getStatus(phase, completedSteps, currentStep, PHASE_STEPS);
+}
+
+export function calculateWeightedProgress(
+  completedSteps: LessonStepName[],
+  currentStep: LessonStepName | null,
+): number {
+  return calculateProgress(completedSteps, currentStep, {
+    phaseOrder: PHASE_ORDER,
+    phaseSteps: PHASE_STEPS,
+    phaseWeights: PHASE_WEIGHTS,
+  });
+}

--- a/apps/main/src/app/[locale]/generate/l/[id]/page.tsx
+++ b/apps/main/src/app/[locale]/generate/l/[id]/page.tsx
@@ -1,3 +1,10 @@
-export default function GenerateLessonActivitiesPage() {
-  return <div>placeholder page, this will be updated soon</div>;
+import { Suspense } from "react";
+import { GenerateLessonContent, GenerateLessonFallback } from "./generate-lesson-content";
+
+export default function GenerateLessonPage(props: PageProps<"/[locale]/generate/l/[id]">) {
+  return (
+    <Suspense fallback={<GenerateLessonFallback />}>
+      <GenerateLessonContent params={props.params} />
+    </Suspense>
+  );
 }

--- a/apps/main/src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/l/[id]/use-generation-phases.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { type PhaseStatus } from "@/lib/generation-phases";
+import { type LessonStepName } from "@/workflows/config";
+import { useExtracted } from "next-intl";
+import {
+  PHASE_ICONS,
+  PHASE_ORDER,
+  type PhaseName,
+  calculateWeightedProgress,
+  getPhaseStatus,
+} from "./generation-phases";
+
+export type PhaseInfo = {
+  name: PhaseName;
+  label: string;
+  status: PhaseStatus;
+  icon: (typeof PHASE_ICONS)[PhaseName];
+};
+
+export function useGenerationPhases(
+  completedSteps: LessonStepName[],
+  currentStep: LessonStepName | null,
+) {
+  const t = useExtracted();
+
+  const labels: Record<PhaseName, string> = {
+    completing: t("Finishing up"),
+    determiningKind: t("Determining lesson type"),
+    generatingActivities: t("Generating activities"),
+    loadingInfo: t("Loading lesson information"),
+  };
+
+  const phases: PhaseInfo[] = PHASE_ORDER.map((phase) => ({
+    icon: PHASE_ICONS[phase],
+    label: labels[phase],
+    name: phase,
+    status: getPhaseStatus(phase, completedSteps, currentStep),
+  }));
+
+  const progress = calculateWeightedProgress(completedSteps, currentStep);
+  const activePhase = phases.find((phase) => phase.status === "active");
+
+  return { activePhase, phases, progress };
+}

--- a/apps/main/src/data/lessons/get-lesson-for-generation.ts
+++ b/apps/main/src/data/lessons/get-lesson-for-generation.ts
@@ -1,0 +1,22 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+
+export async function getLessonForGeneration(lessonId: number) {
+  return prisma.lesson.findUnique({
+    select: {
+      chapter: {
+        select: {
+          course: { select: { slug: true } },
+          slug: true,
+        },
+      },
+      description: true,
+      generationRunId: true,
+      generationStatus: true,
+      id: true,
+      slug: true,
+      title: true,
+    },
+    where: { id: lessonId },
+  });
+}

--- a/i18n.lock
+++ b/i18n.lock
@@ -383,6 +383,12 @@ checksums:
     Saving%20course%20metadata/singular: 027b0161877e67f73fe1c6a6ea65b08e
     Planning%20chapters/singular: 6b60ca8718a75e4e0f05ee74f042a7ae
     Checking%20for%20existing%20course/singular: f58c4dbf1463586a47a2d031f1eb7642
+    Generate%20Lesson/singular: 741a967eb90694565df5e9b44991f58e
+    Creating%20your%20activities/singular: 6651e663a48e18486f5f873e614cd512
+    Activities%20generated/singular: 7c425103a6496b0de828a631f6bed8b4
+    Redirecting%20to%20your%20lesson.../singular: 625a270c33c5da6f757bd6a95de1d80f
+    Loading%20lesson%20information/singular: afa5291c65d23ee739d273e859f8d261
+    Determining%20lesson%20type/singular: 8ba4c5600d99ae8a0ae05905265e1dfd
     Read%20Zoonk's%20privacy%20policy%20to%20understand%20how%20we%20collect%2C%20use%2C%20and%20protect%20your%20personal%20information./singular: 044f3586abe7d9915820a6629cef08e4
     Privacy%20Policy/singular: 7459744a63ef8af4e517a09024bd7c08
     Read%20Zoonk's%20terms%20of%20use%20to%20understand%20the%20rules%20and%20conditions%20for%20using%20our%20platform%20and%20services/singular: 4b82898d60691839a1999e4a17199895


### PR DESCRIPTION
## Summary
- Add `/generate/l/[id]` page that triggers lesson workflow to generate activities
- Follow patterns from chapter generation (`/generate/ch/[id]`)
- Redirect to lesson page after completion

## Test plan
- [x] Run `pnpm turbo quality:fix`
- [x] Run `pnpm typecheck`
- [x] Run `pnpm knip`
- [x] Run `pnpm test`
- [x] Run `pnpm --filter main build:e2e`
- [x] Run `pnpm --filter main e2e` (165 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds /generate/l/[id] to generate lesson activities. Shows progress, gates by auth/subscription, and redirects to the lesson on completion.

- **New Features**
  - New lesson generation page with server fallback and client workflow runner.
  - Triggers lesson-generation workflow and streams status via SSE with weighted phase progress.
  - Handles three states: login required, upgrade required, and subscribed with generation UI.
  - Redirects to the lesson if generation is already completed or when it finishes.
  - Adds getLessonForGeneration query, localized copy (en/es/pt), and a narrow container UI.
  - E2E coverage for auth/subscription states, success flow with redirect, stream error, and 404s.
  - Docs: AGENTS.md note to use *Fixture() helpers for e2e test data.

<sup>Written for commit 54d31feab86c9ad8cf063466d80b42ebe4320456. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

