### PR TITLE
fix(editor): refresh list after import

### DIFF
--- a/apps/editor/src/components/entity/entity-list-actions.tsx
+++ b/apps/editor/src/components/entity/entity-list-actions.tsx
@@ -12,6 +12,7 @@ import { toast } from "@zoonk/ui/components/sonner";
 import { downloadJson } from "@zoonk/utils/download";
 import { DownloadIcon, EllipsisVerticalIcon, UploadIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
+import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import { ImportProvider } from "../import";
 import { EntityImportDialog } from "./entity-import-dialog";
@@ -26,6 +27,7 @@ export function EntityListActions({
   onImport: (formData: FormData) => Promise<{ error: string | null }>;
 }) {
   const t = useExtracted();
+  const router = useRouter();
   const [importOpen, setImportOpen] = useState(false);
   const [pending, startTransition] = useTransition();
 
@@ -67,6 +69,7 @@ export function EntityListActions({
   }
 
   function handleImportSuccess() {
+    router.refresh();
     toast.success(entityLabels.importSuccess);
     setImportOpen(false);
   }


### PR DESCRIPTION
## Summary
- Add `router.refresh()` after successful import to force re-fetch of server component data
- Fixes intermittent issue where list wouldn't update after importing chapters, lessons, or activities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh entity lists in the editor after a successful import so new chapters, lessons, and activities appear immediately. Adds router.refresh() on import success to re-fetch server component data and fix the intermittent stale list issue.

<sup>Written for commit 0b41794aeb6348faa4c029d989e950aef3cd2aa6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

