### PR TITLE
feat(api): add activity generation workflow

### DIFF
--- a/apps/api/e2e/workflows-activity-generation.test.ts
+++ b/apps/api/e2e/workflows-activity-generation.test.ts
@@ -1,0 +1,267 @@
+import { randomUUID } from "node:crypto";
+import { request } from "@playwright/test";
+import { prisma } from "@zoonk/db";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { normalizeString } from "@zoonk/utils/string";
+import { expect, test } from "./fixtures";
+
+test.describe("Activity Generation Workflow API", () => {
+  let baseURL: string;
+  let aiOrgId: number;
+
+  test.beforeAll(async () => {
+    baseURL = process.env.E2E_BASE_URL ?? "";
+
+    const aiOrg = await prisma.organization.findUnique({
+      where: { slug: AI_ORG_SLUG },
+    });
+
+    if (!aiOrg) {
+      throw new Error("AI organization not found");
+    }
+
+    aiOrgId = aiOrg.id;
+  });
+
+  test.afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  test("returns validation error when activityId is missing", async () => {
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.post("/v1/workflows/activity-generation/trigger", {
+      data: {},
+    });
+
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+
+    await apiContext.dispose();
+  });
+
+  test("returns validation error when activityId is invalid type", async () => {
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.post("/v1/workflows/activity-generation/trigger", {
+      data: { activityId: "invalid" },
+    });
+
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+
+    await apiContext.dispose();
+  });
+
+  test("returns validation error when activityId is negative", async () => {
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.post("/v1/workflows/activity-generation/trigger", {
+      data: { activityId: -1 },
+    });
+
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+
+    await apiContext.dispose();
+  });
+
+  test("returns 402 when user has no active subscription", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const courseTitle = `E2E Activity Test ${uniqueId}`;
+
+    const course = await prisma.course.create({
+      data: {
+        description: "Test course for activity generation",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString(courseTitle),
+        organizationId: aiOrgId,
+        slug: `e2e-activity-test-${uniqueId}`,
+        title: courseTitle,
+      },
+    });
+
+    const chapter = await prisma.chapter.create({
+      data: {
+        courseId: course.id,
+        description: "Test chapter description",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString("Test Chapter"),
+        organizationId: aiOrgId,
+        position: 0,
+        slug: `e2e-activity-chapter-${uniqueId}`,
+        title: "Test Chapter",
+      },
+    });
+
+    const lesson = await prisma.lesson.create({
+      data: {
+        chapterId: chapter.id,
+        description: "Test lesson description",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString("Test Lesson"),
+        organizationId: aiOrgId,
+        position: 0,
+        slug: `e2e-activity-lesson-${uniqueId}`,
+        title: "Test Lesson",
+      },
+    });
+
+    const activity = await prisma.activity.create({
+      data: {
+        description: "Test activity description",
+        isPublished: true,
+        kind: "background",
+        language: "en",
+        lessonId: lesson.id,
+        organizationId: aiOrgId,
+        position: 0,
+        title: "Test Activity",
+      },
+    });
+
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.post("/v1/workflows/activity-generation/trigger", {
+      data: { activityId: Number(activity.id) },
+    });
+
+    expect(response.status()).toBe(402);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("PAYMENT_REQUIRED");
+    expect(body.error.message).toBe("Active subscription required");
+
+    await prisma.activity.delete({ where: { id: activity.id } });
+    await prisma.lesson.delete({ where: { id: lesson.id } });
+    await prisma.chapter.delete({ where: { id: chapter.id } });
+    await prisma.course.delete({ where: { id: course.id } });
+    await apiContext.dispose();
+  });
+
+  test("returns validation error for status endpoint when runId is missing", async () => {
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.get("/v1/workflows/activity-generation/status");
+
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+
+    await apiContext.dispose();
+  });
+
+  test("starts workflow successfully with active subscription", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const email = `e2e-activity-${uniqueId}@zoonk.test`;
+    const password = "password123";
+
+    const signupContext = await request.newContext({ baseURL });
+    const signupResponse = await signupContext.post("/v1/auth/sign-up/email", {
+      data: { email, name: `E2E User ${uniqueId}`, password },
+    });
+
+    expect(signupResponse.ok()).toBe(true);
+    await signupContext.dispose();
+
+    const user = await prisma.user.findUniqueOrThrow({ where: { email } });
+    await prisma.subscription.create({
+      data: {
+        plan: "hobby",
+        referenceId: String(user.id),
+        status: "active",
+        stripeCustomerId: `cus_test_${uniqueId}`,
+        stripeSubscriptionId: `sub_test_${uniqueId}`,
+      },
+    });
+
+    const course = await prisma.course.create({
+      data: {
+        description: "Test course for activity generation with subscription",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString(`E2E Activity Success Test ${uniqueId}`),
+        organizationId: aiOrgId,
+        slug: `e2e-activity-success-${uniqueId}`,
+        title: `E2E Activity Success Test ${uniqueId}`,
+      },
+    });
+
+    const chapter = await prisma.chapter.create({
+      data: {
+        courseId: course.id,
+        description: "Test chapter for workflow success",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString("Test Chapter Success"),
+        organizationId: aiOrgId,
+        position: 0,
+        slug: `e2e-activity-chapter-success-${uniqueId}`,
+        title: "Test Chapter Success",
+      },
+    });
+
+    const lesson = await prisma.lesson.create({
+      data: {
+        chapterId: chapter.id,
+        description: "Test lesson for workflow success",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString("Test Lesson Success"),
+        organizationId: aiOrgId,
+        position: 0,
+        slug: `e2e-activity-lesson-success-${uniqueId}`,
+        title: "Test Lesson Success",
+      },
+    });
+
+    const activity = await prisma.activity.create({
+      data: {
+        description: "Test activity for workflow success",
+        isPublished: true,
+        kind: "background",
+        language: "en",
+        lessonId: lesson.id,
+        organizationId: aiOrgId,
+        position: 0,
+        title: "Test Activity Success",
+      },
+    });
+
+    const apiContext = await request.newContext({ baseURL });
+    const signInResponse = await apiContext.post("/v1/auth/sign-in/email", {
+      data: { email, password },
+    });
+
+    expect(signInResponse.ok()).toBe(true);
+
+    const response = await apiContext.post("/v1/workflows/activity-generation/trigger", {
+      data: { activityId: Number(activity.id) },
+    });
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+
+    expect(body.message).toBe("Workflow started");
+    expect(body.runId).toBeDefined();
+    expect(typeof body.runId).toBe("string");
+
+    await apiContext.dispose();
+  });
+});

--- a/apps/api/src/app/v1/workflows/activity-generation/status/route.ts
+++ b/apps/api/src/app/v1/workflows/activity-generation/status/route.ts
@@ -1,0 +1,24 @@
+import { errors } from "@/lib/api-errors";
+import { workflowStatusQuerySchema } from "@/lib/openapi/schemas/workflows";
+import { parseQueryParams } from "@/lib/query-params";
+import { getRun } from "workflow/api";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+
+  const parsed = parseQueryParams(searchParams, workflowStatusQuerySchema);
+
+  if (!parsed.success) {
+    return errors.validation(parsed.error);
+  }
+
+  const run = getRun(parsed.data.runId);
+
+  const stream = run.getReadable<string>({
+    startIndex: parsed.data.startIndex,
+  });
+
+  return new Response(stream, {
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}

--- a/apps/api/src/app/v1/workflows/activity-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/activity-generation/trigger/route.ts
@@ -1,0 +1,39 @@
+import { errors } from "@/lib/api-errors";
+import { parseBody } from "@/lib/body-parser";
+import { activityGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
+import { activityGenerationWorkflow } from "@/workflows/activity-generation/activity-generation-workflow";
+import { auth } from "@zoonk/core/auth";
+import { findActiveSubscription } from "@zoonk/core/auth/subscription";
+import { type NextRequest, NextResponse } from "next/server";
+import { start } from "workflow/api";
+
+async function getSubscriptions(request: NextRequest) {
+  try {
+    return await auth.api.listActiveSubscriptions({
+      headers: request.headers,
+    });
+  } catch {
+    return [];
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const parsed = await parseBody(request, activityGenerationTriggerSchema);
+
+  if (!parsed.success) {
+    return errors.validation(parsed.error);
+  }
+
+  const subscriptions = await getSubscriptions(request);
+
+  if (!findActiveSubscription(subscriptions)) {
+    return errors.paymentRequired();
+  }
+
+  const run = await start(activityGenerationWorkflow, [BigInt(parsed.data.activityId)]);
+
+  return NextResponse.json({
+    message: "Workflow started",
+    runId: run.runId,
+  });
+}

--- a/apps/api/src/lib/openapi/document.ts
+++ b/apps/api/src/lib/openapi/document.ts
@@ -8,6 +8,7 @@ import {
   workflowTriggerEndpoint,
 } from "./schemas/responses";
 import {
+  activityGenerationTriggerSchema,
   chapterGenerationTriggerSchema,
   courseGenerationTriggerSchema,
   lessonGenerationTriggerSchema,
@@ -58,6 +59,14 @@ export const openAPIDocument = createDocument({
         tags: ["Courses"],
       },
     },
+    "/workflows/activity-generation/status": workflowStatusEndpoint(
+      "Stream activity generation status (SSE)",
+    ),
+    "/workflows/activity-generation/trigger": workflowTriggerEndpoint({
+      requiresSubscription: true,
+      schema: activityGenerationTriggerSchema,
+      summary: "Trigger activity generation workflow",
+    }),
     "/workflows/chapter-generation/status": workflowStatusEndpoint(
       "Stream chapter generation status (SSE)",
     ),

--- a/apps/api/src/lib/openapi/schemas/workflows.ts
+++ b/apps/api/src/lib/openapi/schemas/workflows.ts
@@ -30,6 +30,16 @@ export const lessonGenerationTriggerSchema = z
   })
   .meta({ id: "LessonGenerationTrigger" });
 
+export const activityGenerationTriggerSchema = z
+  .object({
+    activityId: z
+      .number()
+      .int()
+      .positive()
+      .meta({ description: "Activity ID to generate content for" }),
+  })
+  .meta({ id: "ActivityGenerationTrigger" });
+
 export const workflowTriggerResponseSchema = z
   .object({
     message: z.string().meta({ example: "Workflow started" }),

--- a/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
@@ -1,0 +1,359 @@
+import { randomUUID } from "node:crypto";
+import { generateActivityBackground } from "@zoonk/ai/tasks/activities/core/background";
+import { generateStepVisuals } from "@zoonk/ai/tasks/steps/visual";
+import { generateVisualStepImage } from "@zoonk/core/steps/visual-image";
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { activityGenerationWorkflow } from "./activity-generation-workflow";
+
+vi.mock("workflow", () => ({
+  FatalError: class FatalError extends Error {},
+  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
+  getWritable: vi.fn().mockReturnValue({
+    getWriter: () => ({
+      releaseLock: vi.fn(),
+      write: vi.fn().mockResolvedValue(null),
+    }),
+  }),
+}));
+
+vi.mock("@zoonk/ai/tasks/activities/core/background", () => ({
+  generateActivityBackground: vi.fn().mockResolvedValue({
+    data: {
+      steps: [
+        { text: "Step 1 text content", title: "Step 1" },
+        { text: "Step 2 text content", title: "Step 2" },
+      ],
+    },
+  }),
+}));
+
+vi.mock("@zoonk/ai/tasks/steps/visual", () => ({
+  generateStepVisuals: vi.fn().mockResolvedValue({
+    data: {
+      visuals: [
+        { kind: "image", prompt: "A visual prompt for step 1", stepIndex: 0 },
+        { code: "const x = 1;", kind: "code", language: "typescript", stepIndex: 1 },
+      ],
+    },
+  }),
+}));
+
+vi.mock("@zoonk/core/steps/visual-image", () => ({
+  generateVisualStepImage: vi.fn().mockResolvedValue({
+    data: "https://example.com/image.webp",
+    error: null,
+  }),
+}));
+
+vi.mock("@zoonk/core/cache/revalidate", () => ({
+  revalidateMainApp: vi.fn().mockResolvedValue(null),
+}));
+
+describe(activityGenerationWorkflow, () => {
+  let organizationId: number;
+  let course: Awaited<ReturnType<typeof courseFixture>>;
+  let chapter: Awaited<ReturnType<typeof chapterFixture>>;
+  let lesson: Awaited<ReturnType<typeof lessonFixture>>;
+
+  beforeAll(async () => {
+    const org = await aiOrganizationFixture();
+    organizationId = org.id;
+    course = await courseFixture({ organizationId });
+    chapter = await chapterFixture({
+      courseId: course.id,
+      organizationId,
+      title: `Test Chapter ${randomUUID()}`,
+    });
+    lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Test Lesson ${randomUUID()}`,
+    });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("early returns", () => {
+    test("returns early when generationStatus is 'running'", async () => {
+      const activity = await activityFixture({
+        generationStatus: "running",
+        kind: "background",
+        lessonId: lesson.id,
+        organizationId,
+        title: `Running Activity ${randomUUID()}`,
+      });
+
+      await activityGenerationWorkflow(activity.id);
+
+      const dbActivity = await prisma.activity.findUnique({
+        where: { id: activity.id },
+      });
+
+      expect(dbActivity?.generationStatus).toBe("running");
+      expect(generateActivityBackground).not.toHaveBeenCalled();
+    });
+
+    test("returns early when generationStatus is 'completed' and has steps", async () => {
+      const activity = await activityFixture({
+        generationStatus: "completed",
+        kind: "background",
+        lessonId: lesson.id,
+        organizationId,
+        title: `Completed Activity ${randomUUID()}`,
+      });
+
+      await stepFixture({
+        activityId: activity.id,
+        content: { text: "Existing step text", title: "Existing Step" },
+      });
+
+      await activityGenerationWorkflow(activity.id);
+
+      const dbActivity = await prisma.activity.findUnique({
+        where: { id: activity.id },
+      });
+
+      expect(dbActivity?.generationStatus).toBe("completed");
+      expect(generateActivityBackground).not.toHaveBeenCalled();
+    });
+
+    test("returns early when activity kind is not 'background'", async () => {
+      const activity = await activityFixture({
+        generationStatus: "pending",
+        kind: "explanation",
+        lessonId: lesson.id,
+        organizationId,
+        title: `Non-Background Activity ${randomUUID()}`,
+      });
+
+      await activityGenerationWorkflow(activity.id);
+
+      const dbActivity = await prisma.activity.findUnique({
+        where: { id: activity.id },
+      });
+
+      expect(dbActivity?.generationStatus).toBe("pending");
+      expect(generateActivityBackground).not.toHaveBeenCalled();
+    });
+
+    test("sets as completed and returns when activity has existing steps but status not completed", async () => {
+      const activity = await activityFixture({
+        generationStatus: "pending",
+        kind: "background",
+        lessonId: lesson.id,
+        organizationId,
+        title: `Activity with Steps ${randomUUID()}`,
+      });
+
+      await stepFixture({
+        activityId: activity.id,
+        content: { text: "Existing step text", title: "Existing Step" },
+      });
+
+      await activityGenerationWorkflow(activity.id);
+
+      const dbActivity = await prisma.activity.findUnique({
+        where: { id: activity.id },
+      });
+
+      expect(dbActivity?.generationStatus).toBe("completed");
+      expect(dbActivity?.generationRunId).toBe("test-run-id");
+      expect(generateActivityBackground).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("background activity flow", () => {
+    test("generates steps with visuals for background activity", async () => {
+      const title = `Background Activity ${randomUUID()}`;
+      const activity = await activityFixture({
+        generationStatus: "pending",
+        kind: "background",
+        lessonId: lesson.id,
+        organizationId,
+        title,
+      });
+
+      await activityGenerationWorkflow(activity.id);
+
+      const dbActivity = await prisma.activity.findUnique({
+        where: { id: activity.id },
+      });
+
+      expect(dbActivity?.generationStatus).toBe("completed");
+
+      const steps = await prisma.step.findMany({
+        orderBy: { position: "asc" },
+        where: { activityId: activity.id },
+      });
+
+      expect(steps).toHaveLength(2);
+      expect(steps[0]?.kind).toBe("static");
+      expect(steps[0]?.content).toEqual({ text: "Step 1 text content", title: "Step 1" });
+      expect(steps[0]?.visualKind).toBe("image");
+      expect(steps[0]?.visualContent).toEqual({
+        prompt: "A visual prompt for step 1",
+        url: "https://example.com/image.webp",
+      });
+
+      expect(steps[1]?.kind).toBe("static");
+      expect(steps[1]?.content).toEqual({ text: "Step 2 text content", title: "Step 2" });
+      expect(steps[1]?.visualKind).toBe("code");
+      expect(steps[1]?.visualContent).toEqual({
+        code: "const x = 1;",
+        language: "typescript",
+      });
+
+      expect(generateActivityBackground).toHaveBeenCalledOnce();
+      expect(generateStepVisuals).toHaveBeenCalledOnce();
+      expect(generateVisualStepImage).toHaveBeenCalledOnce();
+    });
+
+    test("creates steps in database with correct content and visual mapping", async () => {
+      vi.mocked(generateStepVisuals).mockResolvedValueOnce({
+        data: {
+          visuals: [
+            {
+              edges: [{ source: "1", target: "2" }],
+              kind: "diagram",
+              nodes: [
+                { id: "1", label: "Node 1" },
+                { id: "2", label: "Node 2" },
+              ],
+              stepIndex: 0,
+            },
+            { kind: "quote", quote: "A famous quote", source: "Author", stepIndex: 1 },
+          ],
+        },
+      } as Awaited<ReturnType<typeof generateStepVisuals>>);
+
+      const activity = await activityFixture({
+        generationStatus: "pending",
+        kind: "background",
+        lessonId: lesson.id,
+        organizationId,
+        title: `Activity with Diagram ${randomUUID()}`,
+      });
+
+      await activityGenerationWorkflow(activity.id);
+
+      const steps = await prisma.step.findMany({
+        orderBy: { position: "asc" },
+        where: { activityId: activity.id },
+      });
+
+      expect(steps[0]?.visualKind).toBe("diagram");
+      expect(steps[0]?.visualContent).toEqual({
+        edges: [{ source: "1", target: "2" }],
+        nodes: [
+          { id: "1", label: "Node 1" },
+          { id: "2", label: "Node 2" },
+        ],
+      });
+
+      expect(steps[1]?.visualKind).toBe("quote");
+      expect(steps[1]?.visualContent).toEqual({
+        quote: "A famous quote",
+        source: "Author",
+      });
+    });
+  });
+
+  describe("error handling", () => {
+    test("marks activity as 'failed' when AI generation throws", async () => {
+      vi.mocked(generateActivityBackground).mockRejectedValueOnce(
+        new Error("AI generation failed"),
+      );
+
+      const title = `Error Activity ${randomUUID()}`;
+      const activity = await activityFixture({
+        generationStatus: "pending",
+        kind: "background",
+        lessonId: lesson.id,
+        organizationId,
+        title,
+      });
+
+      await expect(activityGenerationWorkflow(activity.id)).rejects.toThrow("AI generation failed");
+
+      const dbActivity = await prisma.activity.findUnique({
+        where: { id: activity.id },
+      });
+
+      expect(dbActivity?.generationStatus).toBe("failed");
+    });
+
+    test("throws FatalError when activity not found", async () => {
+      const nonExistentId = BigInt(999_999_999);
+
+      await expect(activityGenerationWorkflow(nonExistentId)).rejects.toThrow("Activity not found");
+    });
+
+    test("continues without URL when image generation fails", async () => {
+      vi.mocked(generateVisualStepImage).mockResolvedValueOnce({
+        data: null,
+        error: new Error("Image generation failed"),
+      });
+
+      const activity = await activityFixture({
+        generationStatus: "pending",
+        kind: "background",
+        lessonId: lesson.id,
+        organizationId,
+        title: `Activity Image Fail ${randomUUID()}`,
+      });
+
+      await activityGenerationWorkflow(activity.id);
+
+      const dbActivity = await prisma.activity.findUnique({
+        where: { id: activity.id },
+      });
+
+      expect(dbActivity?.generationStatus).toBe("completed");
+
+      const steps = await prisma.step.findMany({
+        orderBy: { position: "asc" },
+        where: { activityId: activity.id },
+      });
+
+      expect(steps[0]?.visualKind).toBe("image");
+      expect(steps[0]?.visualContent).toEqual({
+        prompt: "A visual prompt for step 1",
+      });
+    });
+  });
+
+  describe("status transitions", () => {
+    test("updates activity status: pending → running → completed", async () => {
+      const title = `Status Transition Activity ${randomUUID()}`;
+      const activity = await activityFixture({
+        generationStatus: "pending",
+        kind: "background",
+        lessonId: lesson.id,
+        organizationId,
+        title,
+      });
+
+      const initialActivity = await prisma.activity.findUnique({
+        where: { id: activity.id },
+      });
+      expect(initialActivity?.generationStatus).toBe("pending");
+
+      await activityGenerationWorkflow(activity.id);
+
+      const finalActivity = await prisma.activity.findUnique({
+        where: { id: activity.id },
+      });
+      expect(finalActivity?.generationStatus).toBe("completed");
+      expect(finalActivity?.generationRunId).toBe("test-run-id");
+    });
+  });
+});

--- a/apps/api/src/workflows/activity-generation/activity-generation-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/activity-generation-workflow.ts
@@ -1,0 +1,55 @@
+import { getWorkflowMetadata } from "workflow";
+import { addStepsStep } from "./steps/add-steps-step";
+import { generateBackgroundStep } from "./steps/generate-background-step";
+import { generateVisualImagesStep } from "./steps/generate-visual-images-step";
+import { generateVisualsStep } from "./steps/generate-visuals-step";
+import { getActivityStep } from "./steps/get-activity-step";
+import { handleActivityFailureStep } from "./steps/handle-failure-step";
+import { setActivityAsCompletedStep } from "./steps/set-activity-as-completed-step";
+import { setActivityAsRunningStep } from "./steps/set-activity-as-running-step";
+
+export async function activityGenerationWorkflow(activityId: bigint): Promise<void> {
+  "use workflow";
+
+  const { workflowRunId } = getWorkflowMetadata();
+
+  const context = await getActivityStep(activityId);
+
+  if (context.generationStatus === "running") {
+    return;
+  }
+
+  if (context.generationStatus === "completed" && context._count.steps > 0) {
+    return;
+  }
+
+  // Only handle "background" activity kind for now
+  // Other kinds will be implemented in future tasks
+  if (context.kind !== "background") {
+    return;
+  }
+
+  if (context._count.steps > 0) {
+    await setActivityAsCompletedStep({ context, workflowRunId });
+    return;
+  }
+
+  await setActivityAsRunningStep({ activityId: context.id, workflowRunId });
+
+  try {
+    const backgroundData = await generateBackgroundStep(context);
+    const visuals = await generateVisualsStep(context, backgroundData.steps);
+    const visualsWithUrls = await generateVisualImagesStep(context, visuals.visuals);
+
+    await addStepsStep({
+      context,
+      steps: backgroundData.steps,
+      visuals: visualsWithUrls,
+    });
+
+    await setActivityAsCompletedStep({ context, workflowRunId });
+  } catch (error) {
+    await handleActivityFailureStep({ activityId: context.id });
+    throw error;
+  }
+}

--- a/apps/api/src/workflows/activity-generation/steps/add-steps-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/add-steps-step.ts
@@ -1,0 +1,73 @@
+import { type StepVisualKind, prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+import { type VisualWithUrl } from "./generate-visual-images-step";
+import { type ActivityContext } from "./get-activity-step";
+
+const VALID_VISUAL_KINDS: Record<StepVisualKind, true> = {
+  audio: true,
+  chart: true,
+  code: true,
+  diagram: true,
+  image: true,
+  quote: true,
+  table: true,
+  timeline: true,
+  video: true,
+};
+
+function isValidVisualKind(kind: string): kind is StepVisualKind {
+  return kind in VALID_VISUAL_KINDS;
+}
+
+function mapVisualKind(kind: string): StepVisualKind {
+  return isValidVisualKind(kind) ? kind : "image";
+}
+
+function extractVisualContent(visual: VisualWithUrl) {
+  const { kind: _kind, stepIndex: _stepIndex, ...rest } = visual;
+  return rest;
+}
+
+export async function addStepsStep(input: {
+  context: ActivityContext;
+  steps: {
+    title: string;
+    text: string;
+  }[];
+  visuals: VisualWithUrl[];
+}): Promise<void> {
+  "use step";
+
+  await streamStatus({ status: "started", step: "addSteps" });
+
+  const stepsData = input.steps.map((step, index) => {
+    const visual = input.visuals.find((item) => item.stepIndex === index);
+
+    const baseData = {
+      activityId: input.context.id,
+      content: { text: step.text, title: step.title },
+      kind: "static" as const,
+      position: index,
+    };
+
+    if (!visual) {
+      return baseData;
+    }
+
+    return {
+      ...baseData,
+      visualContent: extractVisualContent(visual),
+      visualKind: mapVisualKind(visual.kind),
+    };
+  });
+
+  const { error } = await safeAsync(() => prisma.step.createMany({ data: stepsData }));
+
+  if (error) {
+    await streamStatus({ status: "error", step: "addSteps" });
+    throw error;
+  }
+
+  await streamStatus({ status: "completed", step: "addSteps" });
+}

--- a/apps/api/src/workflows/activity-generation/steps/add-steps-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/add-steps-step.ts
@@ -4,31 +4,6 @@ import { streamStatus } from "../stream-status";
 import { type VisualWithUrl } from "./generate-visual-images-step";
 import { type ActivityContext } from "./get-activity-step";
 
-const VALID_VISUAL_KINDS: Record<StepVisualKind, true> = {
-  audio: true,
-  chart: true,
-  code: true,
-  diagram: true,
-  image: true,
-  quote: true,
-  table: true,
-  timeline: true,
-  video: true,
-};
-
-function isValidVisualKind(kind: string): kind is StepVisualKind {
-  return kind in VALID_VISUAL_KINDS;
-}
-
-function mapVisualKind(kind: string): StepVisualKind {
-  return isValidVisualKind(kind) ? kind : "image";
-}
-
-function extractVisualContent(visual: VisualWithUrl) {
-  const { kind: _kind, stepIndex: _stepIndex, ...rest } = visual;
-  return rest;
-}
-
 export async function addStepsStep(input: {
   context: ActivityContext;
   steps: {
@@ -55,10 +30,12 @@ export async function addStepsStep(input: {
       return baseData;
     }
 
+    const { kind, stepIndex: _stepIndex, ...visualContent } = visual;
+
     return {
       ...baseData,
-      visualContent: extractVisualContent(visual),
-      visualKind: mapVisualKind(visual.kind),
+      visualContent,
+      visualKind: kind as StepVisualKind,
     };
   });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-background-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-background-step.ts
@@ -2,6 +2,7 @@ import {
   type ActivityBackgroundSchema,
   generateActivityBackground,
 } from "@zoonk/ai/tasks/activities/core/background";
+import { safeAsync } from "@zoonk/utils/error";
 import { streamStatus } from "../stream-status";
 import { type ActivityContext } from "./get-activity-step";
 
@@ -12,15 +13,22 @@ export async function generateBackgroundStep(
 
   await streamStatus({ status: "started", step: "generateBackground" });
 
-  const { data } = await generateActivityBackground({
-    chapterTitle: context.lesson.chapter.title,
-    courseTitle: context.lesson.chapter.course.title,
-    language: context.language,
-    lessonDescription: context.lesson.description ?? "",
-    lessonTitle: context.lesson.title,
-  });
+  const { data: result, error } = await safeAsync(() =>
+    generateActivityBackground({
+      chapterTitle: context.lesson.chapter.title,
+      courseTitle: context.lesson.chapter.course.title,
+      language: context.language,
+      lessonDescription: context.lesson.description ?? "",
+      lessonTitle: context.lesson.title,
+    }),
+  );
+
+  if (error) {
+    await streamStatus({ status: "error", step: "generateBackground" });
+    throw error;
+  }
 
   await streamStatus({ status: "completed", step: "generateBackground" });
 
-  return data;
+  return result.data;
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-background-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-background-step.ts
@@ -1,0 +1,26 @@
+import {
+  type ActivityBackgroundSchema,
+  generateActivityBackground,
+} from "@zoonk/ai/tasks/activities/core/background";
+import { streamStatus } from "../stream-status";
+import { type ActivityContext } from "./get-activity-step";
+
+export async function generateBackgroundStep(
+  context: ActivityContext,
+): Promise<ActivityBackgroundSchema> {
+  "use step";
+
+  await streamStatus({ status: "started", step: "generateBackground" });
+
+  const { data } = await generateActivityBackground({
+    chapterTitle: context.lesson.chapter.title,
+    courseTitle: context.lesson.chapter.course.title,
+    language: context.language,
+    lessonDescription: context.lesson.description ?? "",
+    lessonTitle: context.lesson.title,
+  });
+
+  await streamStatus({ status: "completed", step: "generateBackground" });
+
+  return data;
+}

--- a/apps/api/src/workflows/activity-generation/steps/generate-visual-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-visual-images-step.ts
@@ -1,0 +1,47 @@
+import { type StepVisualSchema } from "@zoonk/ai/tasks/steps/visual";
+import { generateVisualStepImage } from "@zoonk/core/steps/visual-image";
+import { streamStatus } from "../stream-status";
+import { type ActivityContext } from "./get-activity-step";
+
+type StepVisualResource = StepVisualSchema["visuals"][number];
+export type VisualWithUrl = StepVisualResource & { url?: string };
+
+async function processImageVisual(
+  visual: Extract<StepVisualResource, { kind: "image" }>,
+  orgSlug: string,
+): Promise<VisualWithUrl> {
+  const { data: url, error } = await generateVisualStepImage({
+    orgSlug,
+    prompt: visual.prompt,
+  });
+
+  if (error) {
+    return visual;
+  }
+
+  return { ...visual, url };
+}
+
+export async function generateVisualImagesStep(
+  context: ActivityContext,
+  visuals: StepVisualResource[],
+): Promise<VisualWithUrl[]> {
+  "use step";
+
+  await streamStatus({ status: "started", step: "generateVisualImages" });
+
+  const orgSlug = context.lesson.chapter.course.organization.slug;
+
+  const results = await Promise.all(
+    visuals.map((visual) => {
+      if (visual.kind === "image") {
+        return processImageVisual(visual, orgSlug);
+      }
+      return Promise.resolve(visual as VisualWithUrl);
+    }),
+  );
+
+  await streamStatus({ status: "completed", step: "generateVisualImages" });
+
+  return results;
+}

--- a/apps/api/src/workflows/activity-generation/steps/generate-visuals-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-visuals-step.ts
@@ -1,0 +1,25 @@
+import { type StepVisualSchema, generateStepVisuals } from "@zoonk/ai/tasks/steps/visual";
+import { streamStatus } from "../stream-status";
+import { type ActivityContext } from "./get-activity-step";
+
+export async function generateVisualsStep(
+  context: ActivityContext,
+  steps: { title: string; text: string }[],
+): Promise<StepVisualSchema> {
+  "use step";
+
+  await streamStatus({ status: "started", step: "generateVisuals" });
+
+  const { data } = await generateStepVisuals({
+    chapterTitle: context.lesson.chapter.title,
+    courseTitle: context.lesson.chapter.course.title,
+    language: context.language,
+    lessonDescription: context.lesson.description ?? "",
+    lessonTitle: context.lesson.title,
+    steps,
+  });
+
+  await streamStatus({ status: "completed", step: "generateVisuals" });
+
+  return data;
+}

--- a/apps/api/src/workflows/activity-generation/steps/generate-visuals-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-visuals-step.ts
@@ -1,4 +1,5 @@
 import { type StepVisualSchema, generateStepVisuals } from "@zoonk/ai/tasks/steps/visual";
+import { safeAsync } from "@zoonk/utils/error";
 import { streamStatus } from "../stream-status";
 import { type ActivityContext } from "./get-activity-step";
 
@@ -10,16 +11,23 @@ export async function generateVisualsStep(
 
   await streamStatus({ status: "started", step: "generateVisuals" });
 
-  const { data } = await generateStepVisuals({
-    chapterTitle: context.lesson.chapter.title,
-    courseTitle: context.lesson.chapter.course.title,
-    language: context.language,
-    lessonDescription: context.lesson.description ?? "",
-    lessonTitle: context.lesson.title,
-    steps,
-  });
+  const { data: result, error } = await safeAsync(() =>
+    generateStepVisuals({
+      chapterTitle: context.lesson.chapter.title,
+      courseTitle: context.lesson.chapter.course.title,
+      language: context.language,
+      lessonDescription: context.lesson.description ?? "",
+      lessonTitle: context.lesson.title,
+      steps,
+    }),
+  );
+
+  if (error) {
+    await streamStatus({ status: "error", step: "generateVisuals" });
+    throw error;
+  }
 
   await streamStatus({ status: "completed", step: "generateVisuals" });
 
-  return data;
+  return result.data;
 }

--- a/apps/api/src/workflows/activity-generation/steps/get-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/get-activity-step.ts
@@ -1,0 +1,61 @@
+import { prisma } from "@zoonk/db";
+import { FatalError } from "workflow";
+import { streamStatus } from "../stream-status";
+
+async function getActivityForGeneration(activityId: bigint) {
+  return prisma.activity.findUnique({
+    select: {
+      _count: {
+        select: {
+          steps: true,
+        },
+      },
+      generationRunId: true,
+      generationStatus: true,
+      id: true,
+      kind: true,
+      language: true,
+      lesson: {
+        select: {
+          chapter: {
+            select: {
+              course: {
+                select: {
+                  organization: {
+                    select: {
+                      slug: true,
+                    },
+                  },
+                  title: true,
+                },
+              },
+              title: true,
+            },
+          },
+          description: true,
+          title: true,
+        },
+      },
+    },
+    where: { id: activityId },
+  });
+}
+
+export type ActivityContext = NonNullable<Awaited<ReturnType<typeof getActivityForGeneration>>>;
+
+export async function getActivityStep(activityId: bigint): Promise<ActivityContext> {
+  "use step";
+
+  await streamStatus({ status: "started", step: "getActivity" });
+
+  const activity = await getActivityForGeneration(activityId);
+
+  if (!activity) {
+    await streamStatus({ status: "error", step: "getActivity" });
+    throw new FatalError("Activity not found");
+  }
+
+  await streamStatus({ status: "completed", step: "getActivity" });
+
+  return activity;
+}

--- a/apps/api/src/workflows/activity-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/handle-failure-step.ts
@@ -1,0 +1,14 @@
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+
+export async function handleActivityFailureStep(input: { activityId: bigint }): Promise<void> {
+  "use step";
+
+  await safeAsync(() =>
+    prisma.activity.update({
+      data: { generationStatus: "failed" },
+      select: { generationStatus: true, id: true },
+      where: { id: input.activityId },
+    }),
+  );
+}

--- a/apps/api/src/workflows/activity-generation/steps/set-activity-as-completed-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/set-activity-as-completed-step.ts
@@ -1,0 +1,35 @@
+import { revalidateMainApp } from "@zoonk/core/cache/revalidate";
+import { prisma } from "@zoonk/db";
+import { cacheTagActivity } from "@zoonk/utils/cache";
+import { safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+import { type ActivityContext } from "./get-activity-step";
+
+export async function setActivityAsCompletedStep(input: {
+  context: ActivityContext;
+  workflowRunId: string;
+}): Promise<void> {
+  "use step";
+
+  await streamStatus({ status: "started", step: "setActivityAsCompleted" });
+
+  const { error } = await safeAsync(() =>
+    prisma.activity.update({
+      data: {
+        generationRunId: input.workflowRunId,
+        generationStatus: "completed",
+      },
+      select: { generationStatus: true, id: true },
+      where: { id: input.context.id },
+    }),
+  );
+
+  if (error) {
+    await streamStatus({ status: "error", step: "setActivityAsCompleted" });
+    throw error;
+  }
+
+  await revalidateMainApp([cacheTagActivity({ activityId: input.context.id })]);
+
+  await streamStatus({ status: "completed", step: "setActivityAsCompleted" });
+}

--- a/apps/api/src/workflows/activity-generation/steps/set-activity-as-running-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/set-activity-as-running-step.ts
@@ -1,0 +1,30 @@
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+
+export async function setActivityAsRunningStep(input: {
+  activityId: bigint;
+  workflowRunId: string;
+}): Promise<void> {
+  "use step";
+
+  await streamStatus({ status: "started", step: "setActivityAsRunning" });
+
+  const { error } = await safeAsync(() =>
+    prisma.activity.update({
+      data: {
+        generationRunId: input.workflowRunId,
+        generationStatus: "running",
+      },
+      select: { generationStatus: true, id: true },
+      where: { id: input.activityId },
+    }),
+  );
+
+  if (error) {
+    await streamStatus({ status: "error", step: "setActivityAsRunning" });
+    throw error;
+  }
+
+  await streamStatus({ status: "completed", step: "setActivityAsRunning" });
+}

--- a/apps/api/src/workflows/activity-generation/stream-status.ts
+++ b/apps/api/src/workflows/activity-generation/stream-status.ts
@@ -1,0 +1,10 @@
+import {
+  type StepStatus,
+  streamStatus as sharedStreamStatus,
+} from "@/workflows/_shared/stream-status";
+import { type ActivityStepName } from "@/workflows/config";
+
+export async function streamStatus(params: { step: ActivityStepName; status: StepStatus }) {
+  "use step";
+  return sharedStreamStatus(params);
+}

--- a/apps/api/src/workflows/config.ts
+++ b/apps/api/src/workflows/config.ts
@@ -20,6 +20,18 @@ const LESSON_STEPS = [
 
 export type LessonStepName = (typeof LESSON_STEPS)[number];
 
+const ACTIVITY_STEPS = [
+  "getActivity",
+  "setActivityAsRunning",
+  "generateBackground",
+  "generateVisuals",
+  "generateVisualImages",
+  "addSteps",
+  "setActivityAsCompleted",
+] as const;
+
+export type ActivityStepName = (typeof ACTIVITY_STEPS)[number];
+
 const COURSE_STEPS = [
   "getCourseSuggestion",
   "checkExistingCourse",

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -43,6 +43,7 @@ export type {
   Step,
   StepAttempt,
   StepKind,
+  StepVisualKind,
   Subscription,
   User,
   UserProgress,

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -12,6 +12,7 @@
     "./fixtures/lessons": "./src/fixtures/lessons.ts",
     "./fixtures/orgs": "./src/fixtures/orgs.ts",
     "./fixtures/progress": "./src/fixtures/progress.ts",
+    "./fixtures/steps": "./src/fixtures/steps.ts",
     "./fixtures/users": "./src/fixtures/users.ts"
   },
   "dependencies": {

--- a/packages/testing/src/fixtures/steps.ts
+++ b/packages/testing/src/fixtures/steps.ts
@@ -1,0 +1,22 @@
+import { type StepKind, type StepVisualKind, prisma } from "@zoonk/db";
+
+export async function stepFixture(attrs: {
+  activityId: bigint;
+  content?: { text: string; title: string };
+  kind?: StepKind;
+  position?: number;
+  visualContent?: object;
+  visualKind?: StepVisualKind;
+}) {
+  const step = await prisma.step.create({
+    data: {
+      activityId: attrs.activityId,
+      content: attrs.content ?? { text: "Test step content", title: "Test Step" },
+      kind: attrs.kind ?? "static",
+      position: attrs.position ?? 0,
+      visualContent: attrs.visualContent,
+      visualKind: attrs.visualKind,
+    },
+  });
+  return step;
+}

--- a/packages/utils/src/cache.ts
+++ b/packages/utils/src/cache.ts
@@ -16,6 +16,10 @@ export function cacheTagOrgCourses({ orgSlug }: { orgSlug: string }) {
   return `org-courses:${orgSlug}`.slice(0, CACHE_TAG_LIMIT);
 }
 
+export function cacheTagActivity({ activityId }: { activityId: bigint }) {
+  return `activity:${activityId}`.slice(0, CACHE_TAG_LIMIT);
+}
+
 export function cacheTagCoursesList({ language }: { language: string }) {
   return `courses-list:${language}`.slice(0, CACHE_TAG_LIMIT);
 }


### PR DESCRIPTION
## Summary

- Add API endpoints for activity generation (`/v1/workflows/activity-generation/trigger` and `/status`)
- Create workflow that generates steps for "background" activity kind
- Generate visual resources (images, code, diagrams, etc.) for each step
- Upload generated images to Vercel Blob
- Add step fixture for testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an activity generation workflow and APIs to create “background” activity steps with visuals, and stream run status via SSE. Requires an active subscription to trigger runs.

- **New Features**
  - POST /v1/workflows/activity-generation/trigger to start a run (subscription required).
  - GET /v1/workflows/activity-generation/status to stream status updates (SSE).
  - Workflow for “background” activities: generates text steps, creates visuals (image, code, diagram, quote, etc.), and uploads images to Vercel Blob.
  - Status tracking: pending → running → completed; failure marked as failed.
  - OpenAPI docs updated; activity trigger schema added.
  - Cache revalidation for activity pages after completion.

- **Migration**
  - Trigger payload: { activityId: number > 0 }.
  - Only “background” kind is supported now; others will follow.
  - Use the status endpoint with runId (and optional startIndex) to stream progress.

<sup>Written for commit cf60641d2107b9493517469d30f2a645fbc866c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

