### PR TITLE
fix(api): add safeAsync error handling to workflow steps

### DIFF
--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -447,6 +447,90 @@ describe(courseGenerationWorkflow, () => {
       expect(dbSuggestion?.generationStatus).toBe("failed");
     });
 
+    test("marks course and suggestion as 'failed' when generateCourseCategories throws", async () => {
+      vi.mocked(generateCourseCategories).mockRejectedValueOnce(
+        new Error("Categories generation failed"),
+      );
+
+      const title = `Error Course Categories ${randomUUID()}`;
+      const slug = toSlug(title);
+
+      const suggestion = await courseSuggestionFixture({
+        generationStatus: "pending",
+        slug,
+        title,
+      });
+
+      await expect(courseGenerationWorkflow(suggestion.id)).rejects.toThrow();
+
+      const course = await prisma.course.findFirst({
+        where: { slug },
+      });
+
+      const dbSuggestion = await prisma.courseSuggestion.findUnique({
+        where: { id: suggestion.id },
+      });
+
+      expect(course?.generationStatus).toBe("failed");
+      expect(dbSuggestion?.generationStatus).toBe("failed");
+    });
+
+    test("marks course and suggestion as 'failed' when generateAlternativeTitles throws", async () => {
+      vi.mocked(generateAlternativeTitles).mockRejectedValueOnce(
+        new Error("Alternative titles generation failed"),
+      );
+
+      const title = `Error Course Alt Titles ${randomUUID()}`;
+      const slug = toSlug(title);
+
+      const suggestion = await courseSuggestionFixture({
+        generationStatus: "pending",
+        slug,
+        title,
+      });
+
+      await expect(courseGenerationWorkflow(suggestion.id)).rejects.toThrow();
+
+      const course = await prisma.course.findFirst({
+        where: { slug },
+      });
+
+      const dbSuggestion = await prisma.courseSuggestion.findUnique({
+        where: { id: suggestion.id },
+      });
+
+      expect(course?.generationStatus).toBe("failed");
+      expect(dbSuggestion?.generationStatus).toBe("failed");
+    });
+
+    test("marks course and suggestion as 'failed' when generateCourseChapters throws", async () => {
+      vi.mocked(generateCourseChapters).mockRejectedValueOnce(
+        new Error("Chapters generation failed"),
+      );
+
+      const title = `Error Course Chapters ${randomUUID()}`;
+      const slug = toSlug(title);
+
+      const suggestion = await courseSuggestionFixture({
+        generationStatus: "pending",
+        slug,
+        title,
+      });
+
+      await expect(courseGenerationWorkflow(suggestion.id)).rejects.toThrow();
+
+      const course = await prisma.course.findFirst({
+        where: { slug },
+      });
+
+      const dbSuggestion = await prisma.courseSuggestion.findUnique({
+        where: { id: suggestion.id },
+      });
+
+      expect(course?.generationStatus).toBe("failed");
+      expect(dbSuggestion?.generationStatus).toBe("failed");
+    });
+
     test("chapter generation errors don't mark course as failed", async () => {
       vi.mocked(generateChapterLessons).mockRejectedValueOnce(
         new Error("Chapter generation failed"),

--- a/apps/api/src/workflows/course-generation/steps/generate-alternative-titles-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-alternative-titles-step.ts
@@ -1,4 +1,5 @@
 import { generateAlternativeTitles } from "@zoonk/ai/tasks/courses/alternative-titles";
+import { safeAsync } from "@zoonk/utils/error";
 import { streamStatus } from "../stream-status";
 import { type CourseContext } from "../types";
 
@@ -7,15 +8,22 @@ export async function generateAlternativeTitlesStep(course: CourseContext): Prom
 
   await streamStatus({ status: "started", step: "generateAlternativeTitles" });
 
-  const { data } = await generateAlternativeTitles({
-    language: course.language,
-    title: course.courseTitle,
-  });
+  const { data: result, error } = await safeAsync(() =>
+    generateAlternativeTitles({
+      language: course.language,
+      title: course.courseTitle,
+    }),
+  );
+
+  if (error) {
+    await streamStatus({ status: "error", step: "generateAlternativeTitles" });
+    throw error;
+  }
 
   await streamStatus({
     status: "completed",
     step: "generateAlternativeTitles",
   });
 
-  return data.alternatives;
+  return result.data.alternatives;
 }

--- a/apps/api/src/workflows/course-generation/steps/generate-categories-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-categories-step.ts
@@ -1,4 +1,5 @@
 import { generateCourseCategories } from "@zoonk/ai/tasks/courses/categories";
+import { safeAsync } from "@zoonk/utils/error";
 import { streamStatus } from "../stream-status";
 import { type CourseContext } from "../types";
 
@@ -7,11 +8,18 @@ export async function generateCategoriesStep(course: CourseContext): Promise<str
 
   await streamStatus({ status: "started", step: "generateCategories" });
 
-  const { data } = await generateCourseCategories({
-    courseTitle: course.courseTitle,
-  });
+  const { data: result, error } = await safeAsync(() =>
+    generateCourseCategories({
+      courseTitle: course.courseTitle,
+    }),
+  );
+
+  if (error) {
+    await streamStatus({ status: "error", step: "generateCategories" });
+    throw error;
+  }
 
   await streamStatus({ status: "completed", step: "generateCategories" });
 
-  return data.categories;
+  return result.data.categories;
 }


### PR DESCRIPTION
## Summary

- Add `safeAsync` error handling to course, chapter, and lesson generation workflow steps
- Steps now properly set stream status to "error" when AI calls fail
- Add tests for failure scenarios in course and lesson generation

## Changed Files

**Course generation steps:**
- `generate-description-step.ts`
- `generate-categories-step.ts`  
- `generate-alternative-titles-step.ts`
- `generate-chapters-step.ts`

**Chapter generation steps:**
- `generate-lessons-step.ts`

**Lesson generation steps:**
- `determine-lesson-kind-step.ts`
- `generate-custom-activities-step.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add safeAsync error handling to course, chapter, and lesson generation steps for consistent failure reporting. Workflows now set stream status to "error" and correctly mark courses, suggestions, and lessons as failed when generation tasks throw.

- **Bug Fixes**
  - Wrapped generation calls in safeAsync across steps and rethrew errors.
  - Stream status now emits started/completed/error consistently per step.
  - Mark course and suggestion as failed when categories, alternative titles, or chapters generation fails; chapter lesson failures no longer mark the course as failed.
  - Mark lesson as failed when custom activities generation fails.
  - Added tests covering these failure scenarios.

<sup>Written for commit c1706400b78921e54e27a08768bb96eeb9e721f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

