### PR TITLE
fix(editor): set lesson kind based on org and course category

### DIFF
--- a/apps/editor/src/lib/lesson-kind.ts
+++ b/apps/editor/src/lib/lesson-kind.ts
@@ -1,0 +1,14 @@
+import { type LessonKind } from "@zoonk/db";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+
+export function getLessonKind(params: { orgSlug: string; courseCategories: string[] }): LessonKind {
+  if (params.orgSlug !== AI_ORG_SLUG) {
+    return "custom";
+  }
+
+  if (params.courseCategories.includes("languages")) {
+    return "language";
+  }
+
+  return "core";
+}


### PR DESCRIPTION
## Summary
- Add `getLessonKind` utility to determine lesson kind based on organization and course category
- AI org + languages category → `language`
- AI org + other/no category → `core`
- Non-AI org → `custom`
- Update `createLesson` and `importLessons` to use dynamic kind

## Test plan
- [x] Unit tests for all kind scenarios added

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dynamically set lesson kind when creating or importing lessons based on organization and course category. AI org + languages → language; AI org + other/no category → core; non-AI org → custom.

- **New Features**
  - Added getLessonKind utility (uses org slug and course categories).
  - Updated createLesson and importLessons to apply dynamic kind.
  - Added unit tests covering all mapping scenarios.

<sup>Written for commit 015a67262690fb0eb2d8852a9fa0f625f32c8043. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

