### PR TITLE
feat(api): add quiz activity generation to workflow

### DIFF
--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-content-step.ts
@@ -1,0 +1,62 @@
+import {
+  type ActivityExplanationQuizSchema,
+  type QuizQuestion,
+  generateActivityExplanationQuiz,
+} from "@zoonk/ai/tasks/activities/core/explanation-quiz";
+import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+import { type ActivitySteps } from "./_utils/get-activity-steps";
+import { type LessonActivity } from "./get-lesson-activities-step";
+import { handleActivityFailureStep } from "./handle-failure-step";
+import { setActivityAsRunningStep } from "./set-activity-as-running-step";
+
+export async function generateQuizContentStep(
+  activities: LessonActivity[],
+  explanationSteps: ActivitySteps,
+  workflowRunId: string,
+): Promise<{ questions: QuizQuestion[] }> {
+  "use step";
+
+  const activity = activities.find((a) => a.kind === "quiz");
+
+  if (!activity) {
+    return { questions: [] };
+  }
+
+  if (activity.generationStatus === "completed" && activity._count.steps > 0) {
+    return { questions: [] };
+  }
+
+  if (activity.generationStatus === "running") {
+    return { questions: [] };
+  }
+
+  if (explanationSteps.length === 0) {
+    return { questions: [] };
+  }
+
+  await streamStatus({ status: "started", step: "generateQuizContent" });
+  await setActivityAsRunningStep({ activityId: activity.id, workflowRunId });
+
+  const { data: result, error }: SafeReturn<{ data: ActivityExplanationQuizSchema }> =
+    await safeAsync(() =>
+      generateActivityExplanationQuiz({
+        chapterTitle: activity.lesson.chapter.title,
+        courseTitle: activity.lesson.chapter.course.title,
+        explanationSteps,
+        language: activity.language,
+        lessonDescription: activity.lesson.description ?? "",
+        lessonTitle: activity.lesson.title,
+      }),
+    );
+
+  if (error) {
+    await streamStatus({ status: "error", step: "generateQuizContent" });
+    await handleActivityFailureStep({ activityId: activity.id });
+    throw error;
+  }
+
+  await streamStatus({ status: "completed", step: "generateQuizContent" });
+
+  return { questions: result.data.questions };
+}

--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.ts
@@ -1,0 +1,103 @@
+import {
+  type QuizQuestion,
+  type SelectImageQuestion,
+} from "@zoonk/ai/tasks/activities/core/explanation-quiz";
+import { generateStepImage } from "@zoonk/core/steps/image";
+import { streamStatus } from "../stream-status";
+import { type LessonActivity } from "./get-lesson-activities-step";
+
+type SelectImageOption = SelectImageQuestion["options"][number];
+type SelectImageOptionWithUrl = SelectImageOption & { url?: string };
+type SelectImageQuestionWithUrls = Omit<SelectImageQuestion, "options"> & {
+  options: SelectImageOptionWithUrl[];
+};
+
+export type QuizQuestionWithUrls =
+  | Exclude<QuizQuestion, SelectImageQuestion>
+  | SelectImageQuestionWithUrls;
+
+async function processSelectImageOption(
+  option: SelectImageOption,
+  orgSlug: string,
+): Promise<SelectImageOptionWithUrl> {
+  const { data: url, error } = await generateStepImage({
+    orgSlug,
+    prompt: option.prompt,
+  });
+
+  if (error) {
+    return option;
+  }
+
+  return { ...option, url };
+}
+
+async function processSelectImageQuestion(
+  question: SelectImageQuestion,
+  orgSlug: string,
+): Promise<SelectImageQuestionWithUrls> {
+  const settledOptions = await Promise.allSettled(
+    question.options.map((option) => processSelectImageOption(option, orgSlug)),
+  );
+
+  const optionsWithUrls = question.options.map((option, index): SelectImageOptionWithUrl => {
+    const result = settledOptions[index];
+
+    if (result?.status === "fulfilled") {
+      return result.value;
+    }
+
+    return option;
+  });
+
+  return { ...question, options: optionsWithUrls };
+}
+
+function isSelectImageQuestion(question: QuizQuestion): question is SelectImageQuestion {
+  return question.format === "selectImage";
+}
+
+export async function generateQuizImagesStep(
+  activities: LessonActivity[],
+  questions: QuizQuestion[],
+): Promise<QuizQuestionWithUrls[]> {
+  "use step";
+
+  const activity = activities.find((a) => a.kind === "quiz");
+
+  if (!activity || questions.length === 0) {
+    return [];
+  }
+
+  if (activity.generationStatus === "completed") {
+    return [];
+  }
+
+  await streamStatus({ status: "started", step: "generateQuizImages" });
+
+  const orgSlug = activity.lesson.chapter.course.organization.slug;
+
+  const settledResults = await Promise.allSettled(
+    questions.map(async (question): Promise<QuizQuestionWithUrls> => {
+      if (!isSelectImageQuestion(question)) {
+        return question;
+      }
+
+      return processSelectImageQuestion(question, orgSlug);
+    }),
+  );
+
+  const processedQuestions = questions.map((question, index): QuizQuestionWithUrls => {
+    const result = settledResults[index];
+
+    if (result?.status === "fulfilled") {
+      return result.value;
+    }
+
+    return question;
+  });
+
+  await streamStatus({ status: "completed", step: "generateQuizImages" });
+
+  return processedQuestions;
+}

--- a/apps/api/src/workflows/activity-generation/steps/save-quiz-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-quiz-activity-step.ts
@@ -1,0 +1,49 @@
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+import { type QuizQuestionWithUrls } from "./generate-quiz-images-step";
+import { type LessonActivity } from "./get-lesson-activities-step";
+import { handleActivityFailureStep } from "./handle-failure-step";
+import { setActivityAsCompletedStep } from "./set-activity-as-completed-step";
+
+export async function saveQuizActivityStep(
+  activities: LessonActivity[],
+  questions: QuizQuestionWithUrls[],
+  workflowRunId: string,
+): Promise<void> {
+  "use step";
+
+  const activity = activities.find((a) => a.kind === "quiz");
+
+  if (!activity || questions.length === 0) {
+    return;
+  }
+
+  if (activity.generationStatus === "completed") {
+    return;
+  }
+
+  await streamStatus({ status: "started", step: "saveQuizActivity" });
+
+  const stepsData = questions.map((question, index) => {
+    const { format, ...content } = question;
+
+    return {
+      activityId: activity.id,
+      content,
+      kind: format,
+      position: index,
+    };
+  });
+
+  const { error } = await safeAsync(() => prisma.step.createMany({ data: stepsData }));
+
+  if (error) {
+    await streamStatus({ status: "error", step: "saveQuizActivity" });
+    await handleActivityFailureStep({ activityId: activity.id });
+    throw error;
+  }
+
+  await setActivityAsCompletedStep({ activityId: activity.id, workflowRunId });
+  await streamStatus({ status: "completed", step: "saveQuizActivity" });
+}

--- a/apps/api/src/workflows/config.ts
+++ b/apps/api/src/workflows/config.ts
@@ -24,9 +24,12 @@ const ACTIVITY_STEPS = [
   "getLessonActivities",
   "generateBackgroundContent",
   "generateExplanationContent",
+  "generateQuizContent",
   "generateVisuals",
   "generateImages",
+  "generateQuizImages",
   "saveActivity",
+  "saveQuizActivity",
   "setActivityAsRunning",
   "setActivityAsCompleted",
 ] as const;

--- a/packages/ai/src/tasks/activities/core/activity-explanation-quiz.ts
+++ b/packages/ai/src/tasks/activities/core/activity-explanation-quiz.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { generateText, stepCountIs } from "ai";
-import { type QuizQuestion, quizTools } from "../_tools/quiz";
+import { type QuizQuestion, type SelectImageQuestion, quizTools } from "../_tools/quiz";
 import systemPrompt from "./activity-explanation-quiz.prompt.md";
 
 const DEFAULT_MODEL =
@@ -84,3 +84,5 @@ Generate quiz questions that test understanding of these concepts. Use the avail
 
   return { data: { questions }, systemPrompt, usage, userPrompt };
 }
+
+export type { QuizQuestion, SelectImageQuestion };


### PR DESCRIPTION
## Summary
- Add quiz content generation step that creates questions from explanation steps
- Add image generation for `selectImage` question options
- Save quiz steps to database with `kind` matching question format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds quiz activity generation to the activity-generation workflow. Builds quiz questions from explanation steps, generates images for selectImage options, and saves quiz steps to the database with the correct kind.

- New Features
  - Generate quiz content from explanation steps and integrate new steps: generateQuizContent, generateQuizImages, saveQuizActivity.
  - Create images for selectImage options; continue on failures and omit URLs when an image can’t be generated.
  - Save quiz steps with kind = question format, set generationRunId, and mark the quiz activity completed.
  - Skip generation when there’s no quiz, when quiz is running/completed, or when explanation steps are empty; added status streaming entries and config step names.

<sup>Written for commit 64cf51685651fefed000d57fc623788fdb00dfe9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

