### PR TITLE
feat(api): add mechanics activity generation to workflow

### DIFF
--- a/apps/api/src/workflows/activity-generation/steps/generate-mechanics-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-mechanics-content-step.ts
@@ -1,0 +1,57 @@
+import { generateActivityMechanics } from "@zoonk/ai/tasks/activities/core/mechanics";
+import { safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+import { type ActivitySteps, getActivitySteps } from "./_utils/get-activity-steps";
+import { type LessonActivity } from "./get-lesson-activities-step";
+import { handleActivityFailureStep } from "./handle-failure-step";
+import { setActivityAsRunningStep } from "./set-activity-as-running-step";
+
+export async function generateMechanicsContentStep(
+  activities: LessonActivity[],
+  explanationSteps: ActivitySteps,
+  workflowRunId: string,
+): Promise<{ steps: ActivitySteps }> {
+  "use step";
+
+  const activity = activities.find((a) => a.kind === "mechanics");
+
+  if (!activity) {
+    return { steps: [] };
+  }
+
+  if (activity.generationStatus === "completed" && activity._count.steps > 0) {
+    return { steps: await getActivitySteps(activity.id) };
+  }
+
+  if (activity.generationStatus === "running") {
+    return { steps: [] };
+  }
+
+  if (explanationSteps.length === 0) {
+    return { steps: [] };
+  }
+
+  await streamStatus({ status: "started", step: "generateMechanicsContent" });
+  await setActivityAsRunningStep({ activityId: activity.id, workflowRunId });
+
+  const { data: result, error } = await safeAsync(() =>
+    generateActivityMechanics({
+      chapterTitle: activity.lesson.chapter.title,
+      courseTitle: activity.lesson.chapter.course.title,
+      explanationSteps,
+      language: activity.language,
+      lessonDescription: activity.lesson.description ?? "",
+      lessonTitle: activity.lesson.title,
+    }),
+  );
+
+  if (error) {
+    await streamStatus({ status: "error", step: "generateMechanicsContent" });
+    await handleActivityFailureStep({ activityId: activity.id });
+    throw error;
+  }
+
+  await streamStatus({ status: "completed", step: "generateMechanicsContent" });
+
+  return { steps: result.data.steps };
+}

--- a/apps/api/src/workflows/config.ts
+++ b/apps/api/src/workflows/config.ts
@@ -24,6 +24,7 @@ const ACTIVITY_STEPS = [
   "getLessonActivities",
   "generateBackgroundContent",
   "generateExplanationContent",
+  "generateMechanicsContent",
   "generateQuizContent",
   "generateVisuals",
   "generateImages",


### PR DESCRIPTION
## Summary
- Add `mechanics` activity kind support to the activity generation workflow
- Create `generateMechanicsContentStep` that generates visual steps explaining HOW something works
- Mechanics depends on explanation steps as input
- Add 9 tests covering mechanics generation scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds mechanics activity generation to the workflow. Mechanics builds step-by-step “how it works” content from explanation steps, with visuals and images.

- New Features
  - Added generateMechanicsContentStep; runs only when mechanics is pending and explanation steps exist.
  - Sets mechanics status to running, handles failures, saves steps and images, then marks completed with run ID.
  - Integrated mechanics visuals/images via existing generateVisualsStep and generateImagesStep.
  - Added generateMechanicsContent to workflow status config.
  - Added 9 tests covering no-op cases, dependency on explanation steps, running/completed transitions, failure path, step creation, and final status; updated unsupported kind test to use story.

<sup>Written for commit 2b31a017cd3a3b1b0b196829c64ddaccad3a4124. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

