### PR TITLE
feat(api): chain activity generation into chapter workflow

### DIFF
--- a/apps/api/src/workflows/activity-generation/steps/save-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-activity-step.ts
@@ -21,12 +21,9 @@ export async function saveActivityStep(
   "use step";
 
   const activity = activities.find((a) => a.kind === activityKind);
-  if (!activity) {
-    return;
-  }
-
   const stepName = kindToStepName[activityKind];
-  if (!stepName) {
+
+  if (!activity || !stepName) {
     return;
   }
 
@@ -35,14 +32,15 @@ export async function saveActivityStep(
     where: { id: activity.id },
   });
 
-  if (current?.generationStatus === "completed") {
-    return;
-  }
-  if (current?.generationStatus === "failed") {
+  const isCompleted = current?.generationStatus === "completed";
+  const isFailed = current?.generationStatus === "failed";
+
+  if (isCompleted || isFailed) {
     return;
   }
 
   await streamStatus({ status: "started", step: stepName });
+  await streamStatus({ status: "completed", step: "setActivityAsCompleted" });
 
   const { error } = await safeAsync(() =>
     prisma.activity.update({
@@ -53,12 +51,12 @@ export async function saveActivityStep(
 
   if (error) {
     await streamStatus({ status: "error", step: stepName });
+    await streamStatus({ status: "error", step: "setActivityAsCompleted" });
     return;
   }
 
   await revalidateMainApp([cacheTagActivity({ activityId: BigInt(activity.id) })]);
-  await streamStatus({ status: "completed", step: stepName });
 
-  await streamStatus({ status: "started", step: "setActivityAsCompleted" });
+  await streamStatus({ status: "completed", step: stepName });
   await streamStatus({ status: "completed", step: "setActivityAsCompleted" });
 }

--- a/apps/api/src/workflows/activity-generation/steps/save-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-activity-step.ts
@@ -40,7 +40,7 @@ export async function saveActivityStep(
   }
 
   await streamStatus({ status: "started", step: stepName });
-  await streamStatus({ status: "completed", step: "setActivityAsCompleted" });
+  await streamStatus({ status: "started", step: "setActivityAsCompleted" });
 
   const { error } = await safeAsync(() =>
     prisma.activity.update({

--- a/apps/api/src/workflows/activity-generation/steps/save-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-activity-step.ts
@@ -58,4 +58,7 @@ export async function saveActivityStep(
 
   await revalidateMainApp([cacheTagActivity({ activityId: BigInt(activity.id) })]);
   await streamStatus({ status: "completed", step: stepName });
+
+  await streamStatus({ status: "started", step: "setActivityAsCompleted" });
+  await streamStatus({ status: "completed", step: "setActivityAsCompleted" });
 }

--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
@@ -38,7 +38,7 @@ vi.mock("@zoonk/ai/tasks/lessons/kind", () => ({
 }));
 
 vi.mock("@/workflows/activity-generation/activity-generation-workflow", () => ({
-  activityGenerationWorkflow: vi.fn().mockResolvedValue(undefined),
+  activityGenerationWorkflow: vi.fn().mockResolvedValue({}),
 }));
 
 vi.mock("@zoonk/ai/tasks/lessons/activities", () => ({

--- a/apps/api/src/workflows/config.ts
+++ b/apps/api/src/workflows/config.ts
@@ -34,6 +34,7 @@ const ACTIVITY_STEPS = [
   "setExplanationAsCompleted",
   "setMechanicsAsCompleted",
   "setQuizAsCompleted",
+  "setActivityAsCompleted",
   "workflowError",
 ] as const;
 
@@ -58,7 +59,7 @@ const COURSE_STEPS = [
 ] as const;
 
 // Chapter workflow includes lesson steps since we generate the first lesson
-export type ChapterWorkflowStepName = ChapterStepName | LessonStepName;
+export type ChapterWorkflowStepName = ChapterStepName | LessonStepName | ActivityStepName;
 
 // We also generate the first chapter as part of the course workflow
 // So the course generation is only complete after chapter and lesson workflow is done

--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -241,13 +241,15 @@ test.describe("Generate Chapter Page - With Subscription", () => {
         { status: "completed", step: "setChapterAsCompleted" },
         { status: "started", step: "setLessonAsCompleted" },
         { status: "completed", step: "setLessonAsCompleted" },
+        { status: "started", step: "setActivityAsCompleted" },
+        { status: "completed", step: "setActivityAsCompleted" },
       ],
     });
 
     await userWithoutProgress.goto(`/generate/ch/${chapter.id}`);
 
     // Should show completion message
-    await expect(userWithoutProgress.getByText(/lessons generated/i)).toBeVisible({
+    await expect(userWithoutProgress.getByText(/chapter generated/i)).toBeVisible({
       timeout: 10_000,
     });
 

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -177,6 +177,8 @@ test.describe("Generate Course Page", () => {
           { status: "completed", step: "addLessons" },
           { status: "started", step: "setLessonAsCompleted" },
           { status: "completed", step: "setLessonAsCompleted" },
+          { status: "started", step: "setActivityAsCompleted" },
+          { status: "completed", step: "setActivityAsCompleted" },
         ],
       });
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -993,7 +993,6 @@ msgid "Generating content"
 msgstr "Generating content"
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
-#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
 msgctxt "V4F+/7"
 msgid "Finishing up"
@@ -1005,11 +1004,6 @@ msgid "Generate Chapter"
 msgstr "Generate Chapter"
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
-msgctxt "TFEFX2"
-msgid "Lessons generated"
-msgstr "Lessons generated"
-
-#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 msgctxt "ViO6Dt"
 msgid "Creating your lessons"
 msgstr "Creating your lessons"
@@ -1018,6 +1012,11 @@ msgstr "Creating your lessons"
 msgctxt "X7COCl"
 msgid "Redirecting to your chapter..."
 msgstr "Redirecting to your chapter..."
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+msgctxt "Zzxe/0"
+msgid "Chapter generated"
+msgstr "Chapter generated"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
@@ -1031,6 +1030,11 @@ msgstr "Generating lessons"
 msgctxt "fY0l+a"
 msgid "Generating activities"
 msgstr "Generating activities"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+msgctxt "NcACsR"
+msgid "Setting up activities"
+msgstr "Setting up activities"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 msgctxt "Z2/Dlq"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -993,7 +993,6 @@ msgid "Generating content"
 msgstr "Generando contenido"
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
-#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
 msgctxt "V4F+/7"
 msgid "Finishing up"
@@ -1005,11 +1004,6 @@ msgid "Generate Chapter"
 msgstr "Generar capítulo"
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
-msgctxt "TFEFX2"
-msgid "Lessons generated"
-msgstr "Lecciones generadas"
-
-#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 msgctxt "ViO6Dt"
 msgid "Creating your lessons"
 msgstr "Creando tus lecciones"
@@ -1018,6 +1012,11 @@ msgstr "Creando tus lecciones"
 msgctxt "X7COCl"
 msgid "Redirecting to your chapter..."
 msgstr "Redirigiendo a tu capítulo..."
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+msgctxt "Zzxe/0"
+msgid "Chapter generated"
+msgstr "Capítulo generado"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
@@ -1031,6 +1030,11 @@ msgstr "Generando lecciones"
 msgctxt "fY0l+a"
 msgid "Generating activities"
 msgstr "Generando actividades"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+msgctxt "NcACsR"
+msgid "Setting up activities"
+msgstr "Configurando actividades"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 msgctxt "Z2/Dlq"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -993,7 +993,6 @@ msgid "Generating content"
 msgstr "Gerando conteúdo"
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
-#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
 msgctxt "V4F+/7"
 msgid "Finishing up"
@@ -1005,11 +1004,6 @@ msgid "Generate Chapter"
 msgstr "Gerar capítulo"
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
-msgctxt "TFEFX2"
-msgid "Lessons generated"
-msgstr "Aulas geradas"
-
-#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 msgctxt "ViO6Dt"
 msgid "Creating your lessons"
 msgstr "Criando suas aulas"
@@ -1018,6 +1012,11 @@ msgstr "Criando suas aulas"
 msgctxt "X7COCl"
 msgid "Redirecting to your chapter..."
 msgstr "Redirecionando para o seu capítulo..."
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+msgctxt "Zzxe/0"
+msgid "Chapter generated"
+msgstr "Capítulo gerado"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
@@ -1031,6 +1030,11 @@ msgstr "Gerando aulas"
 msgctxt "fY0l+a"
 msgid "Generating activities"
 msgstr "Gerando atividades"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+msgctxt "NcACsR"
+msgid "Setting up activities"
+msgstr "Configurando atividades"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 msgctxt "Z2/Dlq"

--- a/apps/main/src/app/[locale]/generate/a/[id]/generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/a/[id]/generation-phases.ts
@@ -31,7 +31,7 @@ function getPhaseSteps(activityKind: ActivityKind): Record<PhaseName, ActivitySt
   const completionStep = getActivityCompletionStep(activityKind);
 
   return {
-    completing: [completionStep],
+    completing: [completionStep, "setActivityAsCompleted"],
     generatingContent: [
       "generateBackgroundContent",
       "generateExplanationContent",
@@ -45,7 +45,7 @@ function getPhaseSteps(activityKind: ActivityKind): Record<PhaseName, ActivitySt
 
 // Verify all ACTIVITY_STEPS are covered (using all completion steps for validation)
 const validationPhaseSteps: Record<PhaseName, ActivityStepName[]> = {
-  completing: ALL_COMPLETION_STEPS,
+  completing: [...ALL_COMPLETION_STEPS, "setActivityAsCompleted"],
   generatingContent: [
     "generateBackgroundContent",
     "generateExplanationContent",

--- a/apps/main/src/app/[locale]/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/generation-client.tsx
@@ -12,7 +12,10 @@ import {
 } from "@/components/generation/generation-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
-import { type ChapterWorkflowStepName, LESSON_COMPLETION_STEP } from "@/workflows/config";
+import {
+  ACTIVITY_GENERATION_COMPLETION_STEP,
+  type ChapterWorkflowStepName,
+} from "@/workflows/config";
 import { type GenerationStatus } from "@zoonk/db";
 import { AI_ORG_SLUG, API_URL } from "@zoonk/utils/constants";
 import { useExtracted } from "next-intl";
@@ -36,7 +39,7 @@ export function GenerationClient({
   const t = useExtracted();
 
   const generation = useWorkflowGeneration<ChapterWorkflowStepName>({
-    completionStep: LESSON_COMPLETION_STEP,
+    completionStep: ACTIVITY_GENERATION_COMPLETION_STEP,
     initialRunId: generationRunId,
     initialStatus: generationStatus === "running" ? "streaming" : "idle",
     statusUrl: `${API_URL}/v1/workflows/chapter-generation/status`,
@@ -81,7 +84,7 @@ export function GenerationClient({
   if (generation.status === "completed") {
     return (
       <GenerationProgressCompleted subtitle={t("Redirecting to your chapter...")}>
-        {t("Lessons generated")}
+        {t("Chapter generated")}
       </GenerationProgressCompleted>
     );
   }

--- a/apps/main/src/app/[locale]/generate/ch/[id]/generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/generation-phases.ts
@@ -3,24 +3,39 @@ import {
   calculateWeightedProgress as calculateProgress,
   getPhaseStatus as getStatus,
 } from "@/lib/generation-phases";
-import { CHAPTER_STEPS, type ChapterWorkflowStepName, LESSON_STEPS } from "@/workflows/config";
+import {
+  ACTIVITY_STEPS,
+  type ActivityStepName,
+  CHAPTER_STEPS,
+  type ChapterWorkflowStepName,
+  LESSON_STEPS,
+} from "@/workflows/config";
 import {
   BookOpenIcon,
-  CheckCircleIcon,
   GraduationCapIcon,
+  LayoutListIcon,
   type LucideIcon,
   SparklesIcon,
 } from "lucide-react";
 
-export type PhaseName = "loadingInfo" | "generatingLessons" | "generatingActivities" | "completing";
+export type PhaseName =
+  | "loadingInfo"
+  | "generatingLessons"
+  | "settingUpActivities"
+  | "generatingActivities";
+
+const activityPhaseSteps: ActivityStepName[] = ACTIVITY_STEPS.filter(
+  (step) => step !== "workflowError",
+);
 
 const PHASE_STEPS: Record<PhaseName, ChapterWorkflowStepName[]> = {
-  completing: ["setChapterAsCompleted"],
-  generatingActivities: [...LESSON_STEPS],
-  generatingLessons: ["generateLessons", "addLessons"],
+  generatingActivities: activityPhaseSteps,
+  generatingLessons: ["generateLessons", "addLessons", "setChapterAsCompleted"],
   loadingInfo: ["getChapter", "setChapterAsRunning"],
+  settingUpActivities: [...LESSON_STEPS],
 };
 
+// Runtime check: ensure all steps are assigned to a phase.
 const allPhaseSteps = new Set(Object.values(PHASE_STEPS).flat());
 const missingChapterSteps = CHAPTER_STEPS.filter((step) => !allPhaseSteps.has(step));
 
@@ -31,25 +46,45 @@ if (missingChapterSteps.length > 0) {
   );
 }
 
+const missingLessonSteps = LESSON_STEPS.filter((step) => !allPhaseSteps.has(step));
+
+if (missingLessonSteps.length > 0) {
+  throw new Error(
+    `Missing lesson steps in PHASE_STEPS: ${missingLessonSteps.join(", ")}. ` +
+      "Add them to the appropriate phase in generation-phases.ts",
+  );
+}
+
+const missingActivitySteps = ACTIVITY_STEPS.filter(
+  (step) => step !== "workflowError" && !allPhaseSteps.has(step),
+);
+
+if (missingActivitySteps.length > 0) {
+  throw new Error(
+    `Missing activity steps in PHASE_STEPS: ${missingActivitySteps.join(", ")}. ` +
+      "Add them to the appropriate phase in generation-phases.ts",
+  );
+}
+
 export const PHASE_ORDER: PhaseName[] = [
   "loadingInfo",
   "generatingLessons",
+  "settingUpActivities",
   "generatingActivities",
-  "completing",
 ];
 
 export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
-  completing: CheckCircleIcon,
   generatingActivities: SparklesIcon,
   generatingLessons: GraduationCapIcon,
   loadingInfo: BookOpenIcon,
+  settingUpActivities: LayoutListIcon,
 };
 
 const PHASE_WEIGHTS: Record<PhaseName, number> = {
-  completing: 5,
-  generatingActivities: 45,
-  generatingLessons: 45,
-  loadingInfo: 5,
+  generatingActivities: 75,
+  generatingLessons: 8,
+  loadingInfo: 2,
+  settingUpActivities: 15,
 };
 
 export function getPhaseStatus(

--- a/apps/main/src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
@@ -25,10 +25,10 @@ export function useGenerationPhases(
   const t = useExtracted();
 
   const labels: Record<PhaseName, string> = {
-    completing: t("Finishing up"),
     generatingActivities: t("Generating activities"),
     generatingLessons: t("Generating lessons"),
     loadingInfo: t("Loading chapter information"),
+    settingUpActivities: t("Setting up activities"),
   };
 
   const phases: PhaseInfo[] = PHASE_ORDER.map((phase) => ({

--- a/apps/main/src/app/[locale]/generate/cs/[id]/generation-client.tsx
+++ b/apps/main/src/app/[locale]/generate/cs/[id]/generation-client.tsx
@@ -12,7 +12,10 @@ import {
 } from "@/components/generation/generation-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
-import { type CourseWorkflowStepName, LESSON_COMPLETION_STEP } from "@/workflows/config";
+import {
+  ACTIVITY_GENERATION_COMPLETION_STEP,
+  type CourseWorkflowStepName,
+} from "@/workflows/config";
 import { type GenerationStatus } from "@zoonk/db";
 import { AI_ORG_SLUG, API_URL } from "@zoonk/utils/constants";
 import { useExtracted } from "next-intl";
@@ -34,7 +37,7 @@ export function GenerationClient({
   const t = useExtracted();
 
   const generation = useWorkflowGeneration<CourseWorkflowStepName>({
-    completionStep: LESSON_COMPLETION_STEP,
+    completionStep: ACTIVITY_GENERATION_COMPLETION_STEP,
     initialRunId: generationRunId,
     initialStatus: generationStatus === "running" ? "streaming" : "idle",
     statusUrl: `${API_URL}/v1/workflows/course-generation/status`,

--- a/apps/main/src/workflows/config.ts
+++ b/apps/main/src/workflows/config.ts
@@ -20,6 +20,7 @@ export const LESSON_STEPS = [
 
 export type LessonStepName = (typeof LESSON_STEPS)[number];
 export const LESSON_COMPLETION_STEP: LessonStepName = "setLessonAsCompleted";
+export const ACTIVITY_GENERATION_COMPLETION_STEP: ActivityStepName = "setActivityAsCompleted";
 
 export const ACTIVITY_STEPS = [
   "getLessonActivities",
@@ -35,6 +36,7 @@ export const ACTIVITY_STEPS = [
   "setExplanationAsCompleted",
   "setMechanicsAsCompleted",
   "setQuizAsCompleted",
+  "setActivityAsCompleted",
   "workflowError",
 ] as const;
 
@@ -86,7 +88,7 @@ export const COURSE_STEPS = [
 export type CourseStepName = (typeof COURSE_STEPS)[number];
 
 // Chapter workflow includes lesson steps since we generate the first lesson
-export type ChapterWorkflowStepName = ChapterStepName | LessonStepName;
+export type ChapterWorkflowStepName = ChapterStepName | LessonStepName | ActivityStepName;
 
 // We also generate the first chapter as part of the course workflow
 // So the course generation is only complete after chapter and lesson workflow is done

--- a/i18n.lock
+++ b/i18n.lock
@@ -379,11 +379,12 @@ checksums:
     Generating%20content/singular: 5d8fd5d4162bf21d523d4a80b5cccc24
     Finishing%20up/singular: 5db7ffd9f1807c8e5936ddca2fe8d1b7
     Generate%20Chapter/singular: 12160bab066da65413de4b511e402446
-    Lessons%20generated/singular: 7c32079f95da198e0d7f5351e47eb64f
     Creating%20your%20lessons/singular: 93571965dc04dcef0bf92f212b3b34d3
     Redirecting%20to%20your%20chapter.../singular: 1187b3b828d92daa195cc8d103ecbcc4
+    Chapter%20generated/singular: 8aeed5b0a222dfd13585f52d56071966
     Generating%20lessons/singular: c4cd98341fd568b3cc5ab0daff85f483
     Generating%20activities/singular: ee132df58cd4c770e5ef3fd77c6187b8
+    Setting%20up%20activities/singular: a644864fddf71801feef8c789333456a
     Loading%20chapter%20information/singular: 7a310c88460ccc1d8eb14885361dcfa6
     Creating%20your%20course/singular: 02c33db1106e7478e5cbd00fa5f20532
     Redirecting%20to%20your%20course.../singular: 9f268e497368578b98d0125f5ac95902


### PR DESCRIPTION
## Summary

- Calls `activityGenerationWorkflow` after lesson generation in the chapter workflow
- Moves `setChapterAsCompleted` before lesson/activity gen so chapter stays completed even if downstream fails
- Adds generic `setActivityAsCompleted` step emitted after every activity kind completes
- Updates chapter and course generation pages to show activity progress and redirect on `setActivityAsCompleted`

## Test plan

- [x] Unit: chapter workflow calls activity generation with first lesson ID
- [x] Unit: chapter stays completed when activity gen throws
- [x] E2E: chapter generation page redirects after activity completion
- [x] E2E: course generation page redirects after activity completion
- [x] Build-time phase validation passes for all generation pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Chains activity generation into the chapter workflow so the first lesson gets activities automatically. Updates generation pages to track activity completion and redirect when activities finish.

- **New Features**
  - Run activityGenerationWorkflow after lessonGenerationWorkflow for the first lesson.
  - Emit a generic setActivityAsCompleted step after each activity completes; expose ACTIVITY_GENERATION_COMPLETION_STEP.
  - Update chapter/course generation UIs to show activity phases (“Setting up activities”, “Generating activities”), display “Chapter generated”, and redirect on activity completion.

- **Refactors**
  - Mark chapters as completed before lesson/activity generation; keep chapter completed if downstream fails. Handle chapter failures only for chapter-specific work.
  - Include activity steps in ChapterWorkflowStepName and phase validation; adjust weights and phases accordingly.
  - Add unit and E2E tests for chaining, status stability, and redirects; update i18n strings.

<sup>Written for commit 763d61332e905c5ba4417f499d2e38c0a817473e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

