### PR TITLE
feat(main): add visible breadcrumb navigation to chapter and lesson pages

### DIFF
--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
@@ -1,8 +1,9 @@
 import { AIWarning } from "@/components/catalog/ai-warning";
 import { type ChapterWithDetails } from "@/data/chapters/get-chapter";
-import { ClientLink } from "@/i18n/client-link";
+import { Link } from "@/i18n/navigation";
 import {
   MediaCard,
+  MediaCardBreadcrumb,
   MediaCardContent,
   MediaCardDescription,
   MediaCardHeader,
@@ -10,9 +11,6 @@ import {
   MediaCardIconText,
   MediaCardIndicator,
   MediaCardPopover,
-  MediaCardPopoverMeta,
-  MediaCardPopoverSource,
-  MediaCardPopoverSourceLink,
   MediaCardPopoverText,
   MediaCardTitle,
   MediaCardTrigger,
@@ -34,37 +32,32 @@ export async function ChapterHeader({
 
   return (
     <MediaCard>
-      <MediaCardTrigger>
-        <MediaCardIcon
-          aria-label={t("Chapter {position}", { position: chapterPosition })}
-          role="img"
-        >
-          <MediaCardIconText>{chapterPosition}</MediaCardIconText>
-        </MediaCardIcon>
+      <MediaCardIcon aria-label={t("Chapter {position}", { position: chapterPosition })} role="img">
+        <MediaCardIconText>{chapterPosition}</MediaCardIconText>
+      </MediaCardIcon>
 
-        <MediaCardContent>
+      <MediaCardContent>
+        <MediaCardBreadcrumb>
+          <Link
+            className="hover:text-foreground transition-colors"
+            href={`/b/${brandSlug}/c/${courseSlug}`}
+          >
+            {chapter.course.title}
+          </Link>
+        </MediaCardBreadcrumb>
+
+        <MediaCardTrigger>
           <MediaCardHeader>
             <MediaCardTitle>{chapter.title}</MediaCardTitle>
             <MediaCardIndicator />
           </MediaCardHeader>
           <MediaCardDescription>{chapter.description}</MediaCardDescription>
-        </MediaCardContent>
-      </MediaCardTrigger>
+        </MediaCardTrigger>
+      </MediaCardContent>
 
       <MediaCardPopover>
         <AIWarning brandSlug={brandSlug} />
-
         <MediaCardPopoverText>{chapter.description}</MediaCardPopoverText>
-
-        <MediaCardPopoverMeta>
-          <MediaCardPopoverSource>
-            <MediaCardPopoverSourceLink
-              render={<ClientLink href={`/b/${brandSlug}/c/${courseSlug}`} />}
-            >
-              {chapter.course.title}
-            </MediaCardPopoverSourceLink>
-          </MediaCardPopoverSource>
-        </MediaCardPopoverMeta>
       </MediaCardPopover>
     </MediaCard>
   );

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
@@ -39,7 +39,7 @@ export async function ChapterHeader({
       <MediaCardContent>
         <MediaCardBreadcrumb>
           <Link
-            className="hover:text-foreground transition-colors"
+            className="hover:text-foreground truncate transition-colors"
             href={`/b/${brandSlug}/c/${courseSlug}`}
           >
             {chapter.course.title}

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-header.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-header.tsx
@@ -45,19 +45,19 @@ export async function LessonHeader({
 
       <MediaCardContent>
         <MediaCardBreadcrumb>
-          <BreadcrumbList className="text-xs">
-            <BreadcrumbItem>
+          <BreadcrumbList className="flex-nowrap text-xs">
+            <BreadcrumbItem className="min-w-0">
               <Link
-                className="hover:text-foreground transition-colors"
+                className="hover:text-foreground truncate transition-colors"
                 href={`/b/${brandSlug}/c/${courseSlug}`}
               >
                 {lesson.chapter.course.title}
               </Link>
             </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
+            <BreadcrumbSeparator className="shrink-0" />
+            <BreadcrumbItem className="min-w-0">
               <Link
-                className="hover:text-foreground transition-colors"
+                className="hover:text-foreground truncate transition-colors"
                 href={`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}`}
               >
                 {lesson.chapter.title}

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-header.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-header.tsx
@@ -1,8 +1,14 @@
 import { AIWarning } from "@/components/catalog/ai-warning";
 import { type LessonWithDetails } from "@/data/lessons/get-lesson";
-import { ClientLink } from "@/i18n/client-link";
+import { Link } from "@/i18n/navigation";
+import {
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from "@zoonk/ui/components/breadcrumb";
 import {
   MediaCard,
+  MediaCardBreadcrumb,
   MediaCardContent,
   MediaCardDescription,
   MediaCardHeader,
@@ -10,10 +16,6 @@ import {
   MediaCardIconText,
   MediaCardIndicator,
   MediaCardPopover,
-  MediaCardPopoverMeta,
-  MediaCardPopoverSource,
-  MediaCardPopoverSourceLink,
-  MediaCardPopoverSourceSeparator,
   MediaCardPopoverText,
   MediaCardTitle,
   MediaCardTrigger,
@@ -37,40 +39,45 @@ export async function LessonHeader({
 
   return (
     <MediaCard>
-      <MediaCardTrigger>
-        <MediaCardIcon aria-label={t("Lesson {position}", { position: lessonPosition })} role="img">
-          <MediaCardIconText>{lessonPosition}</MediaCardIconText>
-        </MediaCardIcon>
+      <MediaCardIcon aria-label={t("Lesson {position}", { position: lessonPosition })} role="img">
+        <MediaCardIconText>{lessonPosition}</MediaCardIconText>
+      </MediaCardIcon>
 
-        <MediaCardContent>
+      <MediaCardContent>
+        <MediaCardBreadcrumb>
+          <BreadcrumbList className="text-xs">
+            <BreadcrumbItem>
+              <Link
+                className="hover:text-foreground transition-colors"
+                href={`/b/${brandSlug}/c/${courseSlug}`}
+              >
+                {lesson.chapter.course.title}
+              </Link>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <Link
+                className="hover:text-foreground transition-colors"
+                href={`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}`}
+              >
+                {lesson.chapter.title}
+              </Link>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </MediaCardBreadcrumb>
+
+        <MediaCardTrigger>
           <MediaCardHeader>
             <MediaCardTitle>{lesson.title}</MediaCardTitle>
             <MediaCardIndicator />
           </MediaCardHeader>
           <MediaCardDescription>{lesson.description}</MediaCardDescription>
-        </MediaCardContent>
-      </MediaCardTrigger>
+        </MediaCardTrigger>
+      </MediaCardContent>
 
       <MediaCardPopover>
         <AIWarning brandSlug={brandSlug} />
-
         <MediaCardPopoverText>{lesson.description}</MediaCardPopoverText>
-
-        <MediaCardPopoverMeta>
-          <MediaCardPopoverSource>
-            <MediaCardPopoverSourceLink
-              render={<ClientLink href={`/b/${brandSlug}/c/${courseSlug}`} />}
-            >
-              {lesson.chapter.course.title}
-            </MediaCardPopoverSourceLink>
-            <MediaCardPopoverSourceSeparator />
-            <MediaCardPopoverSourceLink
-              render={<ClientLink href={`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}`} />}
-            >
-              {lesson.chapter.title}
-            </MediaCardPopoverSourceLink>
-          </MediaCardPopoverSource>
-        </MediaCardPopoverMeta>
       </MediaCardPopover>
     </MediaCard>
   );

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-header.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-header.tsx
@@ -39,31 +39,31 @@ export async function CourseHeader({
 
   return (
     <MediaCard>
-      <MediaCardTrigger>
-        {course.imageUrl ? (
-          <MediaCardImage>
-            <Image
-              alt={course.title}
-              className="size-full object-cover"
-              fill
-              sizes="(max-width: 640px) 80px, 96px"
-              src={course.imageUrl}
-            />
-          </MediaCardImage>
-        ) : (
-          <MediaCardIcon aria-label={course.title} role="img">
-            <NotebookPenIcon aria-hidden="true" className="text-muted-foreground/80 size-8" />
-          </MediaCardIcon>
-        )}
+      {course.imageUrl ? (
+        <MediaCardImage>
+          <Image
+            alt={course.title}
+            className="size-full object-cover"
+            fill
+            sizes="(max-width: 640px) 80px, 96px"
+            src={course.imageUrl}
+          />
+        </MediaCardImage>
+      ) : (
+        <MediaCardIcon aria-label={course.title} role="img">
+          <NotebookPenIcon aria-hidden="true" className="text-muted-foreground/80 size-8" />
+        </MediaCardIcon>
+      )}
 
-        <MediaCardContent>
+      <MediaCardContent>
+        <MediaCardTrigger>
           <MediaCardHeader>
             <MediaCardTitle>{course.title}</MediaCardTitle>
             <MediaCardIndicator />
           </MediaCardHeader>
           <MediaCardDescription>{course.description}</MediaCardDescription>
-        </MediaCardContent>
-      </MediaCardTrigger>
+        </MediaCardTrigger>
+      </MediaCardContent>
 
       <MediaCardPopover>
         <AIWarning brandSlug={brandSlug} />

--- a/packages/ui/src/components/media-card.tsx
+++ b/packages/ui/src/components/media-card.tsx
@@ -7,23 +7,26 @@ import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { cn } from "@zoonk/ui/lib/utils";
 import { ChevronRightIcon, SparklesIcon } from "lucide-react";
 
-export function MediaCard({ children, className }: React.ComponentProps<"div">) {
+export function MediaCard({ children, className }: React.ComponentProps<"header">) {
   return (
     <Popover>
-      <div className={cn("mx-auto w-full px-4 lg:max-w-xl", className)} data-slot="media-card">
+      <header
+        className={cn("mx-auto flex w-full items-start gap-4 px-4 lg:max-w-xl", className)}
+        data-slot="media-card"
+      >
         {children}
-      </div>
+      </header>
     </Popover>
   );
 }
 
-export function MediaCardTrigger({ children, className }: React.ComponentProps<"header">) {
+export function MediaCardTrigger({ children, className }: React.ComponentProps<"div">) {
   return (
     <PopoverTrigger
-      className={cn("flex w-full cursor-pointer flex-row items-start gap-4 text-left", className)}
+      className={cn("w-full cursor-pointer text-left", className)}
       data-slot="media-card-trigger"
       nativeButton={false}
-      render={<header />}
+      render={<div />}
     >
       {children}
     </PopoverTrigger>
@@ -78,6 +81,18 @@ export function MediaCardContent({ children, className }: React.ComponentProps<"
   );
 }
 
+export function MediaCardBreadcrumb({ children, className }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      aria-label="breadcrumb"
+      className={cn("text-muted-foreground pb-1 text-xs", className)}
+      data-slot="media-card-breadcrumb"
+    >
+      {children}
+    </nav>
+  );
+}
+
 export function MediaCardHeader({ children, className }: React.ComponentProps<"div">) {
   return (
     <div
@@ -107,7 +122,7 @@ export function MediaCardDescription({ children, className }: React.ComponentPro
   return (
     <p
       className={cn(
-        "text-muted-foreground mt-0.5 line-clamp-3 text-sm leading-snug text-pretty md:leading-relaxed",
+        "text-muted-foreground mt-0.5 line-clamp-2 text-sm leading-snug text-pretty md:leading-relaxed",
         className,
       )}
       data-slot="media-card-description"
@@ -241,17 +256,18 @@ export function MediaCardPopoverAIWarning({ children, className }: React.Compone
 
 export function MediaCardSkeleton({ className }: { className?: string }) {
   return (
-    <div className={cn("mx-auto w-full px-4 lg:max-w-xl", className)} data-slot="media-card">
-      <header className="flex w-full flex-row items-start gap-4" data-slot="media-card-trigger">
-        <Skeleton className="size-20 shrink-0 rounded-xl sm:size-24" />
-        <div className="flex min-w-0 flex-1 flex-col">
-          <div className="grid grid-cols-[1fr_auto] items-center gap-1">
-            <Skeleton className="h-5 w-3/4 sm:h-6" />
-            <Skeleton className="size-4 shrink-0 rounded-full" />
-          </div>
-          <Skeleton className="mt-1 h-12 w-full sm:h-14" />
+    <header
+      className={cn("mx-auto flex w-full items-start gap-4 px-4 lg:max-w-xl", className)}
+      data-slot="media-card"
+    >
+      <Skeleton className="size-20 shrink-0 rounded-xl sm:size-24" />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="grid grid-cols-[1fr_auto] items-center gap-1">
+          <Skeleton className="h-5 w-3/4 sm:h-6" />
+          <Skeleton className="size-4 shrink-0 rounded-full" />
         </div>
-      </header>
-    </div>
+        <Skeleton className="mt-1 h-12 w-full sm:h-14" />
+      </div>
+    </header>
   );
 }


### PR DESCRIPTION
## Summary

- Restructure `MediaCard` so the popover trigger only wraps title + description, not the icon or breadcrumb
- Add `MediaCardBreadcrumb` compound component for eyebrow navigation above the title
- Chapter pages show a breadcrumb link to the parent course
- Lesson pages show a two-level breadcrumb: course > chapter
- Remove now-redundant navigation links from popover meta sections

## Test plan

- [ ] Verify chapter page shows course name breadcrumb above the title
- [ ] Verify lesson page shows course > chapter breadcrumb above the title
- [ ] Verify breadcrumb links navigate to correct pages
- [ ] Verify clicking title/description area still opens the popover
- [ ] Verify course page renders correctly without breadcrumbs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds visible breadcrumbs above titles on chapter and lesson pages to improve navigation. Refactors MediaCard so only the title and description are clickable, enabling an eyebrow breadcrumb and removing redundant popover links.

- **New Features**
  - Chapter pages show a course breadcrumb; lesson pages show course > chapter.
  - Breadcrumb links use Link and replace popover meta navigation; long titles truncate.

- **Refactors**
  - MediaCard trigger now wraps only title + description; icon and breadcrumb are outside.
  - Added MediaCardBreadcrumb; switched container to header and trigger to div, tightened description to 2 lines, and updated skeleton.

<sup>Written for commit d195cceca523559a5ea3db6278628e10ff80f446. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

