### PR TITLE
feat(main): add animated progress and rebalance generation weights

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -41,6 +41,7 @@
     "@mdx-js/react": "3.1.1",
     "@next/mdx": "16.1.5",
     "@tailwindcss/postcss": "4.1.17",
+    "@testing-library/react": "16.3.2",
     "@types/mdx": "2.0.13",
     "@types/node": "^24",
     "@types/react": "^19",

--- a/apps/main/src/app/[locale]/generate/a/[id]/generation-client.tsx
+++ b/apps/main/src/app/[locale]/generate/a/[id]/generation-client.tsx
@@ -10,6 +10,7 @@ import {
   GenerationTimelineSteps,
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
+import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
 import { type ActivityStepName, getActivityCompletionStep } from "@/workflows/config";
@@ -58,6 +59,11 @@ export function GenerationClient({
     activityKind,
   );
 
+  const displayProgress = useAnimatedProgress(
+    progress,
+    generation.status === "triggering" || generation.status === "streaming",
+  );
+
   useCompletionRedirect({
     status: generation.status,
     url: `/${locale}/b/${AI_ORG_SLUG}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}/a/${position}`,
@@ -68,7 +74,7 @@ export function GenerationClient({
       <GenerationTimeline>
         <GenerationTimelineHeader>
           <GenerationTimelineTitle>{t("Creating your activity")}</GenerationTimelineTitle>
-          <GenerationTimelineProgress label={t("Progress")} value={progress} />
+          <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
         </GenerationTimelineHeader>
 
         <GenerationTimelineSteps>

--- a/apps/main/src/app/[locale]/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/generation-client.tsx
@@ -10,6 +10,7 @@ import {
   GenerationTimelineSteps,
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
+import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
 import {
@@ -52,6 +53,11 @@ export function GenerationClient({
     generation.currentStep,
   );
 
+  const displayProgress = useAnimatedProgress(
+    progress,
+    generation.status === "triggering" || generation.status === "streaming",
+  );
+
   useCompletionRedirect({
     status: generation.status,
     url: `/${locale}/b/${AI_ORG_SLUG}/c/${courseSlug}/ch/${chapterSlug}`,
@@ -62,7 +68,7 @@ export function GenerationClient({
       <GenerationTimeline>
         <GenerationTimelineHeader>
           <GenerationTimelineTitle>{t("Creating your lessons")}</GenerationTimelineTitle>
-          <GenerationTimelineProgress label={t("Progress")} value={progress} />
+          <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
         </GenerationTimelineHeader>
 
         <GenerationTimelineSteps>

--- a/apps/main/src/app/[locale]/generate/ch/[id]/generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/generation-phases.ts
@@ -119,13 +119,13 @@ export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
 };
 
 const PHASE_WEIGHTS: Record<PhaseName, number> = {
-  creatingImages: 20,
-  figuringOutApproach: 3,
-  finishing: 1,
-  preparingLessons: 5,
-  preparingVisuals: 22,
-  settingUpActivities: 3,
-  writingContent: 20,
+  creatingImages: 24,
+  figuringOutApproach: 2,
+  finishing: 2,
+  preparingLessons: 24,
+  preparingVisuals: 11,
+  settingUpActivities: 4,
+  writingContent: 33,
 };
 
 export function getPhaseStatus(

--- a/apps/main/src/app/[locale]/generate/cs/[id]/generation-client.tsx
+++ b/apps/main/src/app/[locale]/generate/cs/[id]/generation-client.tsx
@@ -10,6 +10,7 @@ import {
   GenerationTimelineSteps,
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
+import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
 import {
@@ -50,6 +51,11 @@ export function GenerationClient({
     generation.currentStep,
   );
 
+  const displayProgress = useAnimatedProgress(
+    progress,
+    generation.status === "triggering" || generation.status === "streaming",
+  );
+
   useCompletionRedirect({
     status: generation.status,
     url: `/${locale}/b/${AI_ORG_SLUG}/c/${courseSlug}`,
@@ -60,7 +66,7 @@ export function GenerationClient({
       <GenerationTimeline>
         <GenerationTimelineHeader>
           <GenerationTimelineTitle>{t("Creating your course")}</GenerationTimelineTitle>
-          <GenerationTimelineProgress label={t("Progress")} value={progress} />
+          <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
         </GenerationTimelineHeader>
 
         <GenerationTimelineSteps>

--- a/apps/main/src/app/[locale]/generate/cs/[id]/generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/cs/[id]/generation-phases.ts
@@ -170,19 +170,19 @@ export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
 };
 
 const PHASE_WEIGHTS: Record<PhaseName, number> = {
-  categorizingCourse: 2,
-  creatingCoverImage: 8,
-  creatingImages: 12,
-  figuringOutApproach: 3,
+  categorizingCourse: 3,
+  creatingCoverImage: 7,
+  creatingImages: 16,
+  figuringOutApproach: 1,
   finishing: 1,
   gettingReady: 1,
-  outliningChapters: 12,
-  planningLessons: 5,
-  preparingVisuals: 15,
+  outliningChapters: 19,
+  planningLessons: 16,
+  preparingVisuals: 8,
   savingCourseInfo: 1,
   settingUpActivities: 3,
-  writingContent: 16,
-  writingDescription: 5,
+  writingContent: 21,
+  writingDescription: 3,
 };
 
 export function getPhaseStatus(

--- a/apps/main/src/app/[locale]/generate/l/[id]/generation-client.tsx
+++ b/apps/main/src/app/[locale]/generate/l/[id]/generation-client.tsx
@@ -10,6 +10,7 @@ import {
   GenerationTimelineSteps,
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
+import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
 import { LESSON_COMPLETION_STEP, type LessonStepName } from "@/workflows/config";
@@ -51,6 +52,11 @@ export function GenerationClient({
     generation.currentStep,
   );
 
+  const displayProgress = useAnimatedProgress(
+    progress,
+    generation.status === "triggering" || generation.status === "streaming",
+  );
+
   useCompletionRedirect({
     status: generation.status,
     url: `/${locale}/b/${AI_ORG_SLUG}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`,
@@ -61,7 +67,7 @@ export function GenerationClient({
       <GenerationTimeline>
         <GenerationTimelineHeader>
           <GenerationTimelineTitle>{t("Creating your activities")}</GenerationTimelineTitle>
-          <GenerationTimelineProgress label={t("Progress")} value={progress} />
+          <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
         </GenerationTimelineHeader>
 
         <GenerationTimelineSteps>

--- a/apps/main/src/components/generation/generation-progress.tsx
+++ b/apps/main/src/components/generation/generation-progress.tsx
@@ -39,7 +39,10 @@ function GenerationTimelineTitle({ children }: { children: ReactNode }) {
 
 function GenerationTimelineProgress({ label, value }: { label: string; value: number }) {
   return (
-    <Progress className="**:data-[slot=progress-track]:h-2" value={value}>
+    <Progress
+      className="**:data-[slot=progress-indicator]:duration-700 **:data-[slot=progress-indicator]:ease-out **:data-[slot=progress-track]:h-2"
+      value={value}
+    >
       <ProgressLabel className="sr-only">{label}</ProgressLabel>
       <ProgressValue />
     </Progress>

--- a/apps/main/src/lib/workflow/use-animated-progress.test.ts
+++ b/apps/main/src/lib/workflow/use-animated-progress.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAnimatedProgress } from "./use-animated-progress";
+
+describe(useAnimatedProgress, () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns realProgress when not active", () => {
+    const { result } = renderHook(() => useAnimatedProgress(42, false));
+    expect(result.current).toBe(42);
+  });
+
+  it("returns realProgress initially when active", () => {
+    const { result } = renderHook(() => useAnimatedProgress(10, true));
+    expect(result.current).toBe(10);
+  });
+
+  it("drifts forward when active and stalled", () => {
+    const { result } = renderHook(() => useAnimatedProgress(10, true));
+
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+
+    expect(result.current).toBeGreaterThan(10);
+  });
+
+  it("never exceeds realProgress + MAX_DRIFT (20)", () => {
+    const { result } = renderHook(() => useAnimatedProgress(10, true));
+
+    act(() => {
+      vi.advanceTimersByTime(300_000);
+    });
+
+    expect(result.current).toBeLessThanOrEqual(30);
+  });
+
+  it("never exceeds CAP (97)", () => {
+    const { result } = renderHook(() => useAnimatedProgress(90, true));
+
+    act(() => {
+      vi.advanceTimersByTime(300_000);
+    });
+
+    expect(result.current).toBeLessThanOrEqual(97);
+  });
+
+  it("snaps to real progress when it updates", () => {
+    const { result, rerender } = renderHook(
+      ({ progress, active }) => useAnimatedProgress(progress, active),
+      { initialProps: { active: true, progress: 10 } },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+
+    const driftedValue = result.current;
+    expect(driftedValue).toBeGreaterThan(10);
+
+    rerender({ active: true, progress: 50 });
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current).toBeGreaterThanOrEqual(50);
+  });
+
+  it("stops drifting when active becomes false", () => {
+    const { result, rerender } = renderHook(
+      ({ progress, active }) => useAnimatedProgress(progress, active),
+      { initialProps: { active: true, progress: 30 } },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    rerender({ active: false, progress: 30 });
+
+    expect(result.current).toBe(30);
+  });
+
+  it("cleans up animation frame on unmount", () => {
+    const cancelSpy = vi.spyOn(globalThis, "cancelAnimationFrame");
+    const { unmount } = renderHook(() => useAnimatedProgress(10, true));
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    unmount();
+    expect(cancelSpy).toHaveBeenCalled();
+    cancelSpy.mockRestore();
+  });
+});

--- a/apps/main/src/lib/workflow/use-animated-progress.ts
+++ b/apps/main/src/lib/workflow/use-animated-progress.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const MAX_DRIFT = 20;
+const HALF_LIFE = 15_000;
+const CAP = 97;
+
+/**
+ * Wraps a real progress value and slowly ticks it forward
+ * while streaming is active, creating the illusion of movement
+ * during long-running backend steps.
+ */
+export function useAnimatedProgress(realProgress: number, active: boolean): number {
+  const [display, setDisplay] = useState(realProgress);
+  const rafRef = useRef<number>(0);
+  const startTimeRef = useRef<number>(0);
+  const baseRef = useRef(realProgress);
+
+  // Reset the drift timer whenever realProgress changes
+  useEffect(() => {
+    baseRef.current = realProgress;
+    startTimeRef.current = performance.now();
+  }, [realProgress]);
+
+  useEffect(() => {
+    if (!active) {
+      setDisplay(realProgress);
+      cancelAnimationFrame(rafRef.current);
+      return;
+    }
+
+    function tick() {
+      const elapsed = performance.now() - startTimeRef.current;
+      const drift = MAX_DRIFT * (1 - 1 / (1 + elapsed / HALF_LIFE));
+      const animated = baseRef.current + drift;
+      const capped = Math.min(animated, CAP);
+      const final = Math.max(capped, baseRef.current);
+
+      setDisplay((prev) => {
+        const rounded = Math.floor(final);
+        return rounded === Math.floor(prev) ? prev : rounded;
+      });
+
+      rafRef.current = requestAnimationFrame(tick);
+    }
+
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [active, realProgress]);
+
+  return display;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,6 +409,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: 4.1.17
         version: 4.1.17
+      '@testing-library/react':
+        specifier: 16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/mdx':
         specifier: 2.0.13
         version: 2.0.13
@@ -3335,6 +3338,25 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
     engines: {node: '>=18'}
@@ -3348,6 +3370,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -3829,6 +3854,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -3846,6 +3875,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -4362,6 +4394,9 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -5143,6 +5178,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -5696,6 +5735,10 @@ packages:
     resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
     engines: {node: '>=12'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prisma@7.3.0:
     resolution: {integrity: sha512-ApYSOLHfMN8WftJA+vL6XwAPOh/aZ0BgUyyKPwUFgjARmG6EBI9LzDPf6SWULQMSAxydV9qn5gLj037nPNlg2w==}
     engines: {node: ^20.19 || ^22.12 || >=24.0}
@@ -5761,6 +5804,9 @@ packages:
     peerDependencies:
       react: '>=19'
       react-dom: '>=19'
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@19.2.4:
     resolution: {integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==}
@@ -9062,6 +9108,27 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.1.18
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.28.6
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.10
+      '@types/react-dom': 19.2.3(@types/react@19.2.10)
+
   '@tokenizer/inflate@0.2.7':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -9083,6 +9150,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -9791,6 +9860,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   ansis@3.17.0: {}
@@ -9802,6 +9873,10 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-union@2.1.0: {}
 
@@ -10243,6 +10318,8 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dom-accessibility-api@0.5.16: {}
 
   dotenv@16.6.1: {}
 
@@ -11058,6 +11135,8 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -11823,6 +11902,12 @@ snapshots:
 
   postgres@3.4.7: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:
       '@prisma/config': 7.3.0
@@ -11895,6 +11980,8 @@ snapshots:
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+
+  react-is@17.0.2: {}
 
   react-is@19.2.4: {}
 


### PR DESCRIPTION
## Summary

- Add `useAnimatedProgress` hook that drifts the progress bar forward during long-running backend steps using a decelerating curve (rAF + throttled setState)
- Add smooth CSS transition (`duration-700 ease-out`) to the progress indicator
- Rebalance chapter weights (74 → 100) and course weights (84 → 100) proportionally to actual task durations
- Integrate the animated progress hook in all 4 generation clients (activity, chapter, course, lesson)

## Test plan

- [x] 8 unit tests for `useAnimatedProgress` (drift, cap, snap, cleanup)
- [x] All 200 existing tests pass
- [x] `pnpm turbo quality:fix` — 0 warnings, 0 errors
- [x] `pnpm typecheck` — passes
- [x] `pnpm knip` — passes
- [x] `pnpm --filter main build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add animated progress with smooth transitions so the bar keeps moving during long backend steps, and retune phase weights so progress better matches real durations.

- **New Features**
  - Animated progress via useAnimatedProgress with a gentle decelerating drift (capped) that snaps to real updates.
  - Applied across activity, lesson, chapter, and course generation UIs; progress indicator now transitions smoothly.
  - Rebalanced phase weights for chapter and course to 100 based on observed task durations.

- **Dependencies**
  - Added @testing-library/react for hook unit tests.

<sup>Written for commit 3a0db08feedff56e6e4d6829227c3a1d02efed3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

