### PR TITLE
feat(ui): add horizontal scroll component with chevron navigation

### DIFF
--- a/apps/main/e2e/horizontal-scroll.test.ts
+++ b/apps/main/e2e/horizontal-scroll.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "./fixtures";
+
+test.describe("Horizontal Scroll - Category Pills", () => {
+  test("shows scroll right button when content overflows", async ({ page }) => {
+    await page.goto("/courses");
+
+    const scrollRight = page.getByRole("button", { name: /scroll right/i });
+    await expect(scrollRight).toBeVisible();
+
+    // Left button should not be visible at the start
+    await expect(page.getByRole("button", { name: /scroll left/i })).not.toBeVisible();
+  });
+
+  test("clicking scroll right reveals scroll left button", async ({ page }) => {
+    await page.goto("/courses");
+
+    const scrollRight = page.getByRole("button", { name: /scroll right/i });
+    await scrollRight.click();
+
+    // After scrolling right, the left button should appear
+    const scrollLeft = page.getByRole("button", { name: /scroll left/i });
+    await expect(scrollLeft).toBeVisible();
+  });
+});

--- a/apps/main/src/app/[locale]/(catalog)/courses/category-pills.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/courses/category-pills.tsx
@@ -3,6 +3,7 @@
 import { Link } from "@/i18n/navigation";
 import { useCategories } from "@/lib/categories/category-client";
 import { buttonVariants } from "@zoonk/ui/components/button";
+import { HorizontalScroll, HorizontalScrollContent } from "@zoonk/ui/components/horizontal-scroll";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { useExtracted } from "next-intl";
 import { useSelectedLayoutSegment } from "next/navigation";
@@ -28,35 +29,38 @@ export function CategoryPills() {
   const t = useExtracted();
 
   return (
-    <nav
-      aria-label={t("Course categories")}
-      className="flex w-full gap-2 overflow-x-auto overflow-y-hidden px-4 pb-4 [-webkit-overflow-scrolling:touch] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-    >
-      <Link
-        className={buttonVariants({
-          size: "sm",
-          variant: segment === null ? "default" : "outline",
-        })}
-        href="/courses"
+    <HorizontalScroll className="pb-4">
+      <HorizontalScrollContent
+        aria-label={t("Course categories")}
+        className="px-4"
+        role="navigation"
       >
-        {t("All")}
-      </Link>
+        <Link
+          className={buttonVariants({
+            size: "sm",
+            variant: segment === null ? "default" : "outline",
+          })}
+          href="/courses"
+        >
+          {t("All")}
+        </Link>
 
-      {categories
-        .toSorted((a, b) => a.label.localeCompare(b.label))
-        .map((category) => (
-          <Link
-            className={buttonVariants({
-              size: "sm",
-              variant: segment === category.key ? "default" : "outline",
-            })}
-            href={`/courses/${category.key}`}
-            key={category.key}
-          >
-            <category.icon aria-hidden className="size-4" />
-            {category.label}
-          </Link>
-        ))}
-    </nav>
+        {categories
+          .toSorted((a, b) => a.label.localeCompare(b.label))
+          .map((category) => (
+            <Link
+              className={buttonVariants({
+                size: "sm",
+                variant: segment === category.key ? "default" : "outline",
+              })}
+              href={`/courses/${category.key}`}
+              key={category.key}
+            >
+              <category.icon aria-hidden className="size-4" />
+              {category.label}
+            </Link>
+          ))}
+      </HorizontalScrollContent>
+    </HorizontalScroll>
   );
 }

--- a/apps/main/src/app/[locale]/(performance)/_components/metric-pills.tsx
+++ b/apps/main/src/app/[locale]/(performance)/_components/metric-pills.tsx
@@ -6,7 +6,7 @@ import { buttonVariants } from "@zoonk/ui/components/button";
 import { useExtracted } from "next-intl";
 import { useSelectedLayoutSegment } from "next/navigation";
 
-export function MetricPills() {
+export function MetricPillLinks() {
   const segment = useSelectedLayoutSegment();
   const t = useExtracted();
 
@@ -15,7 +15,7 @@ export function MetricPills() {
   const score = getMenu("score");
 
   return (
-    <div className="flex gap-2 overflow-x-auto overflow-y-hidden pb-1 [-webkit-overflow-scrolling:touch] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+    <>
       <Link
         className={buttonVariants({
           size: "sm",
@@ -48,6 +48,6 @@ export function MetricPills() {
         <score.icon aria-hidden className="size-4" />
         {t("Score")}
       </Link>
-    </div>
+    </>
   );
 }

--- a/apps/main/src/app/[locale]/(performance)/_components/performance-navbar.tsx
+++ b/apps/main/src/app/[locale]/(performance)/_components/performance-navbar.tsx
@@ -2,27 +2,26 @@
 
 import { Link } from "@/i18n/navigation";
 import { buttonVariants } from "@zoonk/ui/components/button";
+import { HorizontalScroll, HorizontalScrollContent } from "@zoonk/ui/components/horizontal-scroll";
 import { HomeIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
-import { MetricPills } from "./metric-pills";
+import { MetricPillLinks } from "./metric-pills";
 
 export function PerformanceNavbar() {
   const t = useExtracted();
 
   return (
-    <nav className="bg-background/95 supports-backdrop-filter:bg-background/60 sticky top-0 z-10 flex w-full items-center gap-2 px-4 pt-4 backdrop-blur">
-      <Link
-        className={buttonVariants({
-          size: "icon",
-          variant: "outline",
-        })}
-        href="/"
-      >
-        <HomeIcon aria-hidden="true" />
-        <span className="sr-only">{t("Home page")}</span>
-      </Link>
+    <nav className="bg-background/95 supports-backdrop-filter:bg-background/60 sticky top-0 z-10 pt-4 backdrop-blur">
+      <HorizontalScroll>
+        <HorizontalScrollContent className="px-4">
+          <Link className={buttonVariants({ size: "icon", variant: "outline" })} href="/">
+            <HomeIcon aria-hidden="true" />
+            <span className="sr-only">{t("Home page")}</span>
+          </Link>
 
-      <MetricPills />
+          <MetricPillLinks />
+        </HorizontalScrollContent>
+      </HorizontalScroll>
     </nav>
   );
 }

--- a/apps/main/src/app/[locale]/(settings)/_components/settings-navbar.tsx
+++ b/apps/main/src/app/[locale]/(settings)/_components/settings-navbar.tsx
@@ -4,9 +4,10 @@ import { Link } from "@/i18n/navigation";
 import { getMenu } from "@/lib/menu";
 import { authClient } from "@zoonk/core/auth/client";
 import { buttonVariants } from "@zoonk/ui/components/button";
+import { HorizontalScroll, HorizontalScrollContent } from "@zoonk/ui/components/horizontal-scroll";
 import { LogOutIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
-import { SettingsPills } from "./settings-pills";
+import { SettingsPillLinks } from "./settings-pills";
 
 const homeMenu = getMenu("home");
 
@@ -16,35 +17,35 @@ export function SettingsNavbar() {
   const isLoggedIn = Boolean(session);
 
   return (
-    <nav className="bg-background/95 supports-backdrop-filter:bg-background/60 sticky top-0 z-10 flex w-full items-center justify-between gap-2 px-4 pt-4 backdrop-blur">
-      <div className="flex min-w-0 items-center gap-2">
-        <Link
-          className={buttonVariants({
-            size: "icon",
-            variant: "outline",
-          })}
-          href={homeMenu.url}
-        >
-          <homeMenu.icon aria-hidden="true" />
-          <span className="sr-only">{t("Home page")}</span>
-        </Link>
+    <nav className="bg-background/95 supports-backdrop-filter:bg-background/60 sticky top-0 z-10 pt-4 backdrop-blur">
+      <HorizontalScroll>
+        <HorizontalScrollContent className="px-4">
+          <Link
+            className={buttonVariants({ size: "icon", variant: "outline" })}
+            href={homeMenu.url}
+          >
+            <homeMenu.icon aria-hidden="true" />
+            <span className="sr-only">{t("Home page")}</span>
+          </Link>
 
-        <SettingsPills />
-      </div>
+          <SettingsPillLinks />
 
-      {isLoggedIn && (
-        <Link
-          className={buttonVariants({
-            size: "icon",
-            variant: "secondary",
-          })}
-          href="/logout"
-          prefetch={false}
-        >
-          <LogOutIcon aria-hidden="true" />
-          <span className="sr-only">{t("Logout")}</span>
-        </Link>
-      )}
+          {isLoggedIn && (
+            <Link
+              className={buttonVariants({
+                className: "ml-auto",
+                size: "icon",
+                variant: "secondary",
+              })}
+              href="/logout"
+              prefetch={false}
+            >
+              <LogOutIcon aria-hidden="true" />
+              <span className="sr-only">{t("Logout")}</span>
+            </Link>
+          )}
+        </HorizontalScrollContent>
+      </HorizontalScroll>
     </nav>
   );
 }

--- a/apps/main/src/app/[locale]/(settings)/_components/settings-pills.tsx
+++ b/apps/main/src/app/[locale]/(settings)/_components/settings-pills.tsx
@@ -6,7 +6,7 @@ import { buttonVariants } from "@zoonk/ui/components/button";
 import { useExtracted } from "next-intl";
 import { useSelectedLayoutSegment } from "next/navigation";
 
-export function SettingsPills() {
+export function SettingsPillLinks() {
   const segment = useSelectedLayoutSegment();
   const t = useExtracted();
 
@@ -17,21 +17,17 @@ export function SettingsPills() {
     { label: t("Support"), segment: "support", ...getMenu("support") },
   ];
 
-  return (
-    <div className="flex gap-2 overflow-x-auto overflow-y-hidden pb-1 [-webkit-overflow-scrolling:touch] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-      {items.map((item) => (
-        <Link
-          className={buttonVariants({
-            size: "sm",
-            variant: segment === item.segment ? "default" : "outline",
-          })}
-          href={item.url}
-          key={item.segment}
-        >
-          <item.icon aria-hidden className="size-4" />
-          {item.label}
-        </Link>
-      ))}
-    </div>
-  );
+  return items.map((item) => (
+    <Link
+      className={buttonVariants({
+        size: "sm",
+        variant: segment === item.segment ? "default" : "outline",
+      })}
+      href={item.url}
+      key={item.segment}
+    >
+      <item.icon aria-hidden className="size-4" />
+      {item.label}
+    </Link>
+  ));
 }

--- a/packages/ui/src/components/horizontal-scroll.tsx
+++ b/packages/ui/src/components/horizontal-scroll.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { cn } from "@zoonk/ui/lib/utils";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+function HorizontalScroll({ className, children, ...props }: React.ComponentProps<"div">) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const checkScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) {
+      return;
+    }
+
+    setCanScrollLeft(el.scrollLeft > 1);
+    setCanScrollRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) {
+      return;
+    }
+
+    checkScroll();
+
+    const observer = new ResizeObserver(checkScroll);
+    observer.observe(el);
+
+    el.addEventListener("scroll", checkScroll, { passive: true });
+
+    return () => {
+      observer.disconnect();
+      el.removeEventListener("scroll", checkScroll);
+    };
+  }, [checkScroll]);
+
+  function scroll(direction: "left" | "right") {
+    scrollRef.current?.scrollBy({
+      behavior: "smooth",
+      left: direction === "left" ? -200 : 200,
+    });
+  }
+
+  const showOverflow = canScrollLeft || canScrollRight;
+
+  return (
+    <div className={cn("relative", className)} data-slot="horizontal-scroll" {...props}>
+      <div
+        className={cn(
+          "overflow-x-auto [-webkit-overflow-scrolling:touch] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+          showOverflow &&
+            canScrollLeft &&
+            canScrollRight &&
+            "mask-[linear-gradient(to_right,transparent,black_64px,black_calc(100%-64px),transparent)]",
+          showOverflow &&
+            canScrollLeft &&
+            !canScrollRight &&
+            "mask-[linear-gradient(to_right,transparent,black_64px)]",
+          showOverflow &&
+            !canScrollLeft &&
+            canScrollRight &&
+            "mask-[linear-gradient(to_right,black_calc(100%-64px),transparent)]",
+        )}
+        onScroll={checkScroll}
+        ref={scrollRef}
+      >
+        {children}
+      </div>
+
+      {canScrollLeft && (
+        <button
+          aria-label="Scroll left"
+          className="border-border bg-background hover:bg-accent absolute top-1/2 left-3 z-10 flex size-9 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full border shadow-sm transition-colors pointer-coarse:hidden"
+          onClick={() => scroll("left")}
+          type="button"
+        >
+          <ChevronLeft className="text-muted-foreground size-4" />
+        </button>
+      )}
+
+      {canScrollRight && (
+        <button
+          aria-label="Scroll right"
+          className="border-border bg-background hover:bg-accent absolute top-1/2 right-3 z-10 flex size-9 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full border shadow-sm transition-colors pointer-coarse:hidden"
+          onClick={() => scroll("right")}
+          type="button"
+        >
+          <ChevronRight className="text-muted-foreground size-4" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+function HorizontalScrollContent({ className, children, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("flex gap-2 pb-1 after:w-4 after:shrink-0 after:content-['']", className)}
+      data-slot="horizontal-scroll-content"
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export { HorizontalScroll, HorizontalScrollContent };

--- a/packages/ui/src/components/horizontal-scroll.tsx
+++ b/packages/ui/src/components/horizontal-scroll.tsx
@@ -2,41 +2,36 @@
 
 import { cn } from "@zoonk/ui/lib/utils";
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 function HorizontalScroll({ className, children, ...props }: React.ComponentProps<"div">) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
 
-  const checkScroll = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) {
-      return;
-    }
-
-    setCanScrollLeft(el.scrollLeft > 1);
-    setCanScrollRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 1);
-  }, []);
-
   useEffect(() => {
     const el = scrollRef.current;
+
     if (!el) {
       return;
     }
+
+    const checkScroll = () => {
+      setCanScrollLeft(el.scrollLeft > 1);
+      setCanScrollRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 1);
+    };
 
     checkScroll();
 
     const observer = new ResizeObserver(checkScroll);
     observer.observe(el);
-
     el.addEventListener("scroll", checkScroll, { passive: true });
 
     return () => {
       observer.disconnect();
       el.removeEventListener("scroll", checkScroll);
     };
-  }, [checkScroll]);
+  }, []);
 
   function scroll(direction: "left" | "right") {
     scrollRef.current?.scrollBy({
@@ -45,27 +40,21 @@ function HorizontalScroll({ className, children, ...props }: React.ComponentProp
     });
   }
 
-  const showOverflow = canScrollLeft || canScrollRight;
-
   return (
     <div className={cn("relative", className)} data-slot="horizontal-scroll" {...props}>
       <div
         className={cn(
           "overflow-x-auto [-webkit-overflow-scrolling:touch] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
-          showOverflow &&
-            canScrollLeft &&
+          canScrollLeft &&
             canScrollRight &&
             "mask-[linear-gradient(to_right,transparent,black_64px,black_calc(100%-64px),transparent)]",
-          showOverflow &&
-            canScrollLeft &&
+          canScrollLeft &&
             !canScrollRight &&
             "mask-[linear-gradient(to_right,transparent,black_64px)]",
-          showOverflow &&
-            !canScrollLeft &&
+          !canScrollLeft &&
             canScrollRight &&
             "mask-[linear-gradient(to_right,black_calc(100%-64px),transparent)]",
         )}
-        onScroll={checkScroll}
         ref={scrollRef}
       >
         {children}


### PR DESCRIPTION
## Summary

- Add `HorizontalScroll` and `HorizontalScrollContent` compound components to `@zoonk/ui` for horizontal pill navigation
- Gradient masks at edges hint at overflow, chevron buttons let mouse users scroll, buttons hide on touch devices
- Refactor settings/performance navbars to scroll all items (Home, pills, Logout) together, eliminating z-index conflicts
- Pill components (`SettingsPillLinks`, `MetricPillLinks`) now export bare links; navbars own the scroll wrapper

## Test plan

- [ ] Verify chevron buttons appear on `/courses` when pills overflow and scroll correctly
- [ ] Verify gradient masks fade at correct edges based on scroll position
- [ ] Verify settings and performance navbars scroll all items together
- [ ] Verify chevron buttons are hidden on touch devices
- [ ] Run e2e tests: `pnpm --filter main e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable HorizontalScroll component with chevron navigation and edge masks to improve horizontal pill navigation. Refactors courses, settings, and performance navbars to use it so all items scroll together and layout conflicts are removed.

- **New Features**
  - Added HorizontalScroll and HorizontalScrollContent to @zoonk/ui.
  - Edge masks hint overflow; chevrons provide smooth 200px scroll; buttons hide on touch.
  - E2E tests verify scroll button visibility and behavior on /courses.

- **Refactors**
  - Courses category pills now render inside HorizontalScrollContent with proper navigation roles.
  - Performance: MetricPills → MetricPillLinks (bare links); navbar wraps Home + pill links in HorizontalScroll.
  - Settings: SettingsPills → SettingsPillLinks (bare links); navbar wraps Home + pill links + Logout in HorizontalScroll, with Logout aligned right (ml-auto).

<sup>Written for commit 39c506d7137f379eec5eb30366b9484cfa2fae26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

