### PR TITLE
feat(api): add story activity to generation workflow

### DIFF
--- a/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.ts
@@ -1,0 +1,91 @@
+import {
+  type ActivityStorySchema,
+  generateActivityStory,
+} from "@zoonk/ai/tasks/activities/core/story";
+import { prisma } from "@zoonk/db";
+import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+import { resolveActivityForGeneration } from "./_utils/content-step-helpers";
+import { type ActivitySteps } from "./_utils/get-activity-steps";
+import { type LessonActivity } from "./get-lesson-activities-step";
+import { handleActivityFailureStep } from "./handle-failure-step";
+import { setActivityAsRunningStep } from "./set-activity-as-running-step";
+
+type StoryStep = ActivityStorySchema["steps"][number];
+
+async function saveStorySteps(
+  activityId: bigint | number,
+  steps: StoryStep[],
+): Promise<{ error: Error | null }> {
+  return safeAsync(() =>
+    prisma.step.createMany({
+      data: steps.map((step, index) => ({
+        activityId,
+        content: { context: step.context, options: step.options, question: step.question },
+        kind: "multipleChoice",
+        position: index,
+      })),
+    }),
+  );
+}
+
+async function handleStoryError(activityId: bigint | number): Promise<void> {
+  await streamStatus({ status: "error", step: "generateStoryContent" });
+  await handleActivityFailureStep({ activityId });
+}
+
+async function saveAndCompleteStory(
+  activityId: bigint | number,
+  steps: StoryStep[],
+): Promise<void> {
+  const { error } = await saveStorySteps(activityId, steps);
+
+  if (error) {
+    await handleStoryError(activityId);
+    return;
+  }
+
+  await streamStatus({ status: "completed", step: "generateStoryContent" });
+}
+
+export async function generateStoryContentStep(
+  activities: LessonActivity[],
+  explanationSteps: ActivitySteps,
+  workflowRunId: string,
+): Promise<void> {
+  "use step";
+
+  const resolved = await resolveActivityForGeneration(activities, "story");
+
+  if (!resolved.shouldGenerate) {
+    return;
+  }
+
+  const { activity } = resolved;
+
+  if (explanationSteps.length === 0) {
+    await handleActivityFailureStep({ activityId: activity.id });
+    return;
+  }
+
+  await streamStatus({ status: "started", step: "generateStoryContent" });
+  await setActivityAsRunningStep({ activityId: activity.id, workflowRunId });
+
+  const { data: result, error }: SafeReturn<{ data: ActivityStorySchema }> = await safeAsync(() =>
+    generateActivityStory({
+      chapterTitle: activity.lesson.chapter.title,
+      courseTitle: activity.lesson.chapter.course.title,
+      explanationSteps,
+      language: activity.language,
+      lessonDescription: activity.lesson.description ?? "",
+      lessonTitle: activity.lesson.title,
+    }),
+  );
+
+  if (error || !result || result.data.steps.length === 0) {
+    await handleStoryError(activity.id);
+    return;
+  }
+
+  await saveAndCompleteStory(activity.id, result.data.steps);
+}

--- a/apps/api/src/workflows/activity-generation/steps/save-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-activity-step.ts
@@ -12,6 +12,7 @@ const kindToStepName: Partial<Record<ActivityKind, ActivityStepName>> = {
   explanation: "setExplanationAsCompleted",
   mechanics: "setMechanicsAsCompleted",
   quiz: "setQuizAsCompleted",
+  story: "setStoryAsCompleted",
 };
 
 export async function saveActivityStep(

--- a/apps/api/src/workflows/config.ts
+++ b/apps/api/src/workflows/config.ts
@@ -27,6 +27,7 @@ const ACTIVITY_STEPS = [
   "generateExamplesContent",
   "generateMechanicsContent",
   "generateQuizContent",
+  "generateStoryContent",
   "generateVisuals",
   "generateImages",
   "generateQuizImages",
@@ -36,6 +37,7 @@ const ACTIVITY_STEPS = [
   "setExplanationAsCompleted",
   "setMechanicsAsCompleted",
   "setQuizAsCompleted",
+  "setStoryAsCompleted",
   "setActivityAsCompleted",
   "workflowError",
 ] as const;

--- a/apps/main/e2e/generate-activity.test.ts
+++ b/apps/main/e2e/generate-activity.test.ts
@@ -340,6 +340,94 @@ test.describe("Generate Activity Page - With Subscription", () => {
     );
   });
 
+  test("completes workflow for story activity kind", async ({ userWithoutProgress }) => {
+    await createTestSubscription();
+
+    const org = await prisma.organization.findUniqueOrThrow({
+      where: { slug: "ai" },
+    });
+
+    const uniqueId = randomUUID().slice(0, 8);
+    const courseTitle = `E2E Story Course ${uniqueId}`;
+    const chapterTitle = `E2E Story Chapter ${uniqueId}`;
+    const lessonTitle = `E2E Story Lesson ${uniqueId}`;
+    const activityTitle = `E2E Story Activity ${uniqueId}`;
+
+    const course = await courseFixture({
+      isPublished: true,
+      normalizedTitle: normalizeString(courseTitle),
+      organizationId: org.id,
+      slug: `e2e-story-course-${uniqueId}`,
+      title: courseTitle,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      generationStatus: "completed",
+      isPublished: true,
+      normalizedTitle: normalizeString(chapterTitle),
+      organizationId: org.id,
+      slug: `e2e-story-chapter-${uniqueId}`,
+      title: chapterTitle,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      generationStatus: "completed",
+      isPublished: true,
+      normalizedTitle: normalizeString(lessonTitle),
+      organizationId: org.id,
+      slug: `e2e-story-lesson-${uniqueId}`,
+      title: lessonTitle,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      isPublished: true,
+      kind: "story",
+      lessonId: lesson.id,
+      organizationId: org.id,
+      title: activityTitle,
+    });
+
+    await setupMockApis(userWithoutProgress, {
+      streamMessages: [
+        { status: "started", step: "getLessonActivities" },
+        { status: "completed", step: "getLessonActivities" },
+        { status: "started", step: "setActivityAsRunning" },
+        { status: "completed", step: "setActivityAsRunning" },
+        { status: "started", step: "generateBackgroundContent" },
+        { status: "completed", step: "generateBackgroundContent" },
+        { status: "started", step: "generateExplanationContent" },
+        { status: "completed", step: "generateExplanationContent" },
+        { status: "started", step: "generateStoryContent" },
+        { status: "completed", step: "generateStoryContent" },
+        { status: "started", step: "setStoryAsCompleted" },
+        { status: "completed", step: "setStoryAsCompleted" },
+      ],
+    });
+
+    await userWithoutProgress.goto(`/generate/a/${activity.id}`);
+
+    await expect(userWithoutProgress.getByText(/your activity is ready/i)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await expect(userWithoutProgress.getByText(/taking you to your activity/i)).toBeVisible();
+
+    await prisma.activity.update({
+      data: { generationStatus: "completed" },
+      where: { id: activity.id },
+    });
+
+    await userWithoutProgress.waitForURL(
+      new RegExp(
+        `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/${activity.position}`,
+      ),
+      { timeout: 10_000 },
+    );
+  });
+
   test("shows error when stream returns error status", async ({ userWithoutProgress }) => {
     await createTestSubscription();
     const { activity } = await createPendingActivity();

--- a/apps/main/src/app/[locale]/generate/a/[id]/generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/a/[id]/generation-phases.ts
@@ -28,6 +28,10 @@ export function getPhaseOrder(kind: ActivityKind): PhaseName[] {
     return ["gettingStarted", "writingContent", "preparingVisuals", "creatingImages", "finishing"];
   }
 
+  if (kind === "story") {
+    return ["gettingStarted", "processingDependencies", "writingContent", "finishing"];
+  }
+
   return [
     "gettingStarted",
     "processingDependencies",
@@ -53,11 +57,13 @@ function getPhaseSteps(kind: ActivityKind): Record<PhaseName, ActivityStepName[]
         "generateExplanationContent",
         "generateMechanicsContent",
         "generateQuizContent",
+        "generateStoryContent",
         "setBackgroundAsCompleted",
         "setExamplesAsCompleted",
         "setExplanationAsCompleted",
         "setMechanicsAsCompleted",
         "setQuizAsCompleted",
+        "setStoryAsCompleted",
         "setActivityAsCompleted",
       ],
       processingDependencies: [],
@@ -72,11 +78,13 @@ function getPhaseSteps(kind: ActivityKind): Record<PhaseName, ActivityStepName[]
         "generateExamplesContent",
         "generateMechanicsContent",
         "generateQuizContent",
+        "generateStoryContent",
         "setBackgroundAsCompleted",
         "setExamplesAsCompleted",
         "setExplanationAsCompleted",
         "setMechanicsAsCompleted",
         "setQuizAsCompleted",
+        "setStoryAsCompleted",
         "setActivityAsCompleted",
       ],
       processingDependencies: ["setActivityAsRunning", "generateBackgroundContent"],
@@ -90,11 +98,13 @@ function getPhaseSteps(kind: ActivityKind): Record<PhaseName, ActivityStepName[]
       finishing: [
         "generateExamplesContent",
         "generateQuizContent",
+        "generateStoryContent",
         "setBackgroundAsCompleted",
         "setExamplesAsCompleted",
         "setExplanationAsCompleted",
         "setMechanicsAsCompleted",
         "setQuizAsCompleted",
+        "setStoryAsCompleted",
         "setActivityAsCompleted",
       ],
       processingDependencies: [
@@ -112,11 +122,13 @@ function getPhaseSteps(kind: ActivityKind): Record<PhaseName, ActivityStepName[]
       finishing: [
         "generateMechanicsContent",
         "generateQuizContent",
+        "generateStoryContent",
         "setBackgroundAsCompleted",
         "setExamplesAsCompleted",
         "setExplanationAsCompleted",
         "setMechanicsAsCompleted",
         "setQuizAsCompleted",
+        "setStoryAsCompleted",
         "setActivityAsCompleted",
       ],
       processingDependencies: [
@@ -128,17 +140,43 @@ function getPhaseSteps(kind: ActivityKind): Record<PhaseName, ActivityStepName[]
     };
   }
 
+  if (kind === "story") {
+    return {
+      ...shared,
+      finishing: [
+        "generateExamplesContent",
+        "generateMechanicsContent",
+        "generateQuizContent",
+        "setBackgroundAsCompleted",
+        "setExamplesAsCompleted",
+        "setExplanationAsCompleted",
+        "setMechanicsAsCompleted",
+        "setQuizAsCompleted",
+        "setStoryAsCompleted",
+        "setActivityAsCompleted",
+      ],
+      processingDependencies: [
+        "setActivityAsRunning",
+        "generateBackgroundContent",
+        "generateExplanationContent",
+      ],
+      writingContent: ["generateStoryContent"],
+    };
+  }
+
   // quiz (and fallback for other kinds)
   return {
     ...shared,
     finishing: [
       "generateExamplesContent",
       "generateMechanicsContent",
+      "generateStoryContent",
       "setBackgroundAsCompleted",
       "setExamplesAsCompleted",
       "setExplanationAsCompleted",
       "setMechanicsAsCompleted",
       "setQuizAsCompleted",
+      "setStoryAsCompleted",
       "setActivityAsCompleted",
     ],
     processingDependencies: [
@@ -162,6 +200,17 @@ function getPhaseWeights(kind: ActivityKind): Record<PhaseName, number> {
     };
   }
 
+  if (kind === "story") {
+    return {
+      creatingImages: 0,
+      finishing: 10,
+      gettingStarted: 5,
+      preparingVisuals: 0,
+      processingDependencies: 40,
+      writingContent: 45,
+    };
+  }
+
   return {
     creatingImages: 35,
     finishing: 9,
@@ -178,6 +227,7 @@ const SUPPORTED_KINDS: ActivityKind[] = [
   "explanation",
   "mechanics",
   "quiz",
+  "story",
 ];
 
 for (const kind of SUPPORTED_KINDS) {

--- a/apps/main/src/app/[locale]/generate/ch/[id]/generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/generation-phases.ts
@@ -44,6 +44,7 @@ const PHASE_STEPS = {
     "setExplanationAsCompleted",
     "setMechanicsAsCompleted",
     "setQuizAsCompleted",
+    "setStoryAsCompleted",
     "setActivityAsCompleted",
   ],
   preparingLessons: [
@@ -67,6 +68,7 @@ const PHASE_STEPS = {
     "generateExplanationContent",
     "generateMechanicsContent",
     "generateQuizContent",
+    "generateStoryContent",
   ],
 } as const satisfies Record<PhaseName, readonly ChapterWorkflowStepName[]>;
 

--- a/apps/main/src/app/[locale]/generate/cs/[id]/generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/cs/[id]/generation-phases.ts
@@ -57,6 +57,7 @@ const PHASE_STEPS = {
     "setExplanationAsCompleted",
     "setMechanicsAsCompleted",
     "setQuizAsCompleted",
+    "setStoryAsCompleted",
     "setActivityAsCompleted",
   ],
   gettingReady: [
@@ -95,6 +96,7 @@ const PHASE_STEPS = {
     "generateExplanationContent",
     "generateMechanicsContent",
     "generateQuizContent",
+    "generateStoryContent",
   ],
   writingDescription: ["generateDescription"],
 } as const satisfies Record<PhaseName, readonly CourseWorkflowStepName[]>;

--- a/apps/main/src/workflows/config.ts
+++ b/apps/main/src/workflows/config.ts
@@ -29,6 +29,7 @@ export const ACTIVITY_STEPS = [
   "generateExamplesContent",
   "generateMechanicsContent",
   "generateQuizContent",
+  "generateStoryContent",
   "generateVisuals",
   "generateImages",
   "generateQuizImages",
@@ -38,6 +39,7 @@ export const ACTIVITY_STEPS = [
   "setExplanationAsCompleted",
   "setMechanicsAsCompleted",
   "setQuizAsCompleted",
+  "setStoryAsCompleted",
   "setActivityAsCompleted",
   "workflowError",
 ] as const;
@@ -49,7 +51,8 @@ export type ActivityCompletionStep =
   | "setExamplesAsCompleted"
   | "setExplanationAsCompleted"
   | "setMechanicsAsCompleted"
-  | "setQuizAsCompleted";
+  | "setQuizAsCompleted"
+  | "setStoryAsCompleted";
 
 const activityCompletionSteps: Partial<Record<string, ActivityCompletionStep>> = {
   background: "setBackgroundAsCompleted",
@@ -57,13 +60,14 @@ const activityCompletionSteps: Partial<Record<string, ActivityCompletionStep>> =
   explanation: "setExplanationAsCompleted",
   mechanics: "setMechanicsAsCompleted",
   quiz: "setQuizAsCompleted",
+  story: "setStoryAsCompleted",
 };
 
 /**
  * Get the completion step name for an activity kind.
  * Used by the UI to detect when generation is complete.
  *
- * For unsupported kinds (story, etc.), returns a fallback.
+ * For unsupported kinds, returns a fallback.
  * These kinds shouldn't reach the generation page, but if they do,
  * the UI won't redirect until the correct step is emitted.
  */


### PR DESCRIPTION
## Summary

- Add story content generation step using `generateActivityStory` from `@zoonk/ai`
- Story runs in Wave 3 (parallel with mechanics/quiz/examples) and saves in Wave 4
- Story has no visuals or images — just content generation with `multipleChoice` steps
- Update all generation phase configs (activity, chapter, course) to include story steps

## Test plan

- [x] Integration tests: 6 new story-specific tests + updated cascade/full pipeline tests
- [x] E2E test: story activity kind completion flow
- [x] All 97 integration tests pass
- [x] All 185 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “story” activity to the generation workflow, creating multiple-choice story content from explanation steps. Runs in Wave 3 and completes in Wave 4; the UI now shows correct progress for story generation.

- **New Features**
  - API: added generateStoryContentStep (uses generateActivityStory) and saves multipleChoice steps; no visuals or images.
  - Workflow: story runs parallel with mechanics/quiz/examples and is saved via setStoryAsCompleted.
  - Dependencies: uses explanation steps; skips when no story activity; marks failed on empty explanation or generation errors.
  - Config/UI: added generateStoryContent and setStoryAsCompleted to configs and phase maps; introduced “story” kind with tailored phases and weights across activity/chapter/course pages.
  - Tests: added story integration tests, updated full-pipeline tests, and a new E2E flow for story activities.

<sup>Written for commit 3678ccfa1ad017bcf69954f89b3b3ac875782344. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

