### PR TITLE
refactor(api): simplify saveActivityStep guard condition

### DIFF
--- a/apps/api/src/workflows/activity-generation/steps/save-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-activity-step.ts
@@ -36,11 +36,7 @@ export async function saveActivityStep(
     where: { id: activity.id },
   });
 
-  const isCompleted = current?.generationStatus === "completed";
-  const isFailed = current?.generationStatus === "failed";
-  const isPending = current?.generationStatus === "pending";
-
-  if (isCompleted || isFailed || isPending) {
+  if (current?.generationStatus !== "running") {
     return;
   }
 


### PR DESCRIPTION
## Summary

- Replace 3 boolean variables + compound `if` with a single `!== "running"` guard in `saveActivityStep`
- Aligns with the pattern already used in `saveCustomActivitiesStep`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the saveActivityStep guard by replacing three status checks with a single return when generationStatus !== "running". Matches saveCustomActivitiesStep and reduces branching with no behavior change.

<sup>Written for commit 58a1ed2a417afa3c2663776a58450756811359fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

