### PR TITLE
fix(api): fix flaky custom activity failure isolation test

### DIFF
--- a/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
@@ -2711,16 +2711,21 @@ describe(activityGenerationWorkflow, () => {
     });
 
     test("one custom activity fails while others still complete", async () => {
-      vi.mocked(generateActivityCustom)
-        .mockRejectedValueOnce(new Error("First custom failed"))
-        .mockResolvedValueOnce({
+      vi.mocked(generateActivityCustom).mockImplementation(({ activityTitle }) => {
+        if (activityTitle.startsWith("Failing Custom")) {
+          return Promise.reject(new Error("First custom failed"));
+        }
+
+        return Promise.resolve({
           data: {
             steps: [{ text: "Second succeeds", title: "Second Custom" }],
           },
           systemPrompt: "test",
+          // oxlint-disable-next-line no-unsafe-type-assertion -- test mock
           usage: {} as Awaited<ReturnType<typeof generateActivityCustom>>["usage"],
           userPrompt: "test",
         });
+      });
 
       const testLesson = await lessonFixture({
         chapterId: chapter.id,


### PR DESCRIPTION
## Summary

- Replace order-dependent sequential mocks (`mockRejectedValueOnce`/`mockResolvedValueOnce`) with argument-based `mockImplementation` that routes by `activityTitle`
- Eliminates race condition where concurrent `Promise.allSettled` calls consume mocks in non-deterministic order under CI load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the “one custom activity fails while others still complete” test by removing order-dependent mocks. Ensures deterministic behavior under concurrent Promise.allSettled.

- **Bug Fixes**
  - Replaced sequential mockRejectedValueOnce/mockResolvedValueOnce with an argument-based mockImplementation that routes by activityTitle.
  - Added a test-only lint suppression for the usage type assertion.

<sup>Written for commit a0d3551e789ac80c308dff59c728a0f81099e6f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

