### PR TITLE
refactor(db): add `languageStory` and `languageReview` to `ActivityKind`

### DIFF
--- a/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
@@ -2084,63 +2084,6 @@ describe(activityGenerationWorkflow, () => {
       expect(generateActivityReview).not.toHaveBeenCalled();
     });
 
-    test("doesn't call generateActivityReview for language lessons", async () => {
-      const testLesson = await lessonFixture({
-        chapterId: chapter.id,
-        kind: "language",
-        organizationId,
-        title: `Language Lesson ${randomUUID()}`,
-      });
-
-      const activities = await Promise.all([
-        activityFixture({
-          generationStatus: "pending",
-          kind: "background",
-          lessonId: testLesson.id,
-          organizationId,
-          title: `Background ${randomUUID()}`,
-        }),
-        activityFixture({
-          generationStatus: "pending",
-          kind: "explanation",
-          lessonId: testLesson.id,
-          organizationId,
-          title: `Explanation ${randomUUID()}`,
-        }),
-        activityFixture({
-          generationStatus: "pending",
-          kind: "mechanics",
-          lessonId: testLesson.id,
-          organizationId,
-          title: `Mechanics ${randomUUID()}`,
-        }),
-        activityFixture({
-          generationStatus: "pending",
-          kind: "examples",
-          lessonId: testLesson.id,
-          organizationId,
-          title: `Examples ${randomUUID()}`,
-        }),
-        activityFixture({
-          generationStatus: "pending",
-          kind: "review",
-          lessonId: testLesson.id,
-          organizationId,
-          title: `Review ${randomUUID()}`,
-        }),
-      ]);
-
-      await activityGenerationWorkflow(testLesson.id);
-
-      expect(generateActivityReview).not.toHaveBeenCalled();
-
-      const reviewActivity = activities[4];
-      const dbActivity = await prisma.activity.findUnique({
-        where: { id: reviewActivity?.id },
-      });
-      expect(dbActivity?.generationStatus).toBe("pending");
-    });
-
     test("passes all dependency steps to generateActivityReview", async () => {
       const testLesson = await lessonFixture({
         chapterId: chapter.id,

--- a/apps/api/src/workflows/activity-generation/steps/generate-review-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-review-content-step.ts
@@ -62,11 +62,6 @@ export async function generateReviewContentStep(
 ): Promise<void> {
   "use step";
 
-  // Language lessons use a different review generation function (added separately)
-  if (activities[0]?.lesson.kind === "language") {
-    return;
-  }
-
   const resolved = await resolveActivityForGeneration(activities, "review");
 
   if (!resolved.shouldGenerate) {

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
@@ -183,7 +183,7 @@ describe(lessonGenerationWorkflow, () => {
   });
 
   describe("language lesson flow", () => {
-    test("generates 5 fixed activities for language lesson", async () => {
+    test("generates 6 fixed activities for language lesson", async () => {
       vi.mocked(generateLessonKind).mockResolvedValueOnce({
         data: { kind: "language" },
       } as Awaited<ReturnType<typeof generateLessonKind>>);
@@ -210,13 +210,15 @@ describe(lessonGenerationWorkflow, () => {
         where: { lessonId: lesson.id },
       });
 
-      expect(activities).toHaveLength(5);
+      expect(activities).toHaveLength(6);
+
       expect(activities.map((a) => a.kind)).toEqual([
         "vocabulary",
         "grammar",
         "reading",
         "listening",
-        "review",
+        "languageStory",
+        "languageReview",
       ]);
 
       for (const activity of activities) {

--- a/apps/api/src/workflows/lesson-generation/steps/add-activities-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/add-activities-step.ts
@@ -20,7 +20,8 @@ const LANGUAGE_ACTIVITY_KINDS: ActivityKind[] = [
   "grammar",
   "reading",
   "listening",
-  "review",
+  "languageStory",
+  "languageReview",
 ];
 
 function getActivitiesForKind(

--- a/apps/editor/src/data/activities/import-activities.ts
+++ b/apps/editor/src/data/activities/import-activities.ts
@@ -21,6 +21,8 @@ const validActivityKinds = new Set<ActivityKind>([
   "reading",
   "listening",
   "review",
+  "languageStory",
+  "languageReview",
 ]);
 
 type ActivityImportData = {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1271,6 +1271,11 @@ msgid "Tests analytical thinking through decisions with trade-offs. See how each
 msgstr "Tests analytical thinking through decisions with trade-offs. See how each choice impacts different outcomes."
 
 #: src/lib/activities.ts
+msgctxt "i09QqM"
+msgid "A dialogue-based story that helps you practice the language in a real-world context."
+msgstr "A dialogue-based story that helps you practice the language in a real-world context."
+
+#: src/lib/activities.ts
 msgctxt "J9eZ8n"
 msgid "Listen to audio sentences and translate them to practice listening skills."
 msgstr "Listen to audio sentences and translate them to practice listening skills."
@@ -1319,6 +1324,11 @@ msgstr "Review"
 msgctxt "tzNRA/"
 msgid "Explains WHAT this topic is. Breaks down core concepts and definitions using metaphors and analogies."
 msgstr "Explains WHAT this topic is. Breaks down core concepts and definitions using metaphors and analogies."
+
+#: src/lib/activities.ts
+msgctxt "U9yVH/"
+msgid "A comprehensive review covering vocabulary and skills from this lesson."
+msgstr "A comprehensive review covering vocabulary and skills from this lesson."
 
 #: src/lib/activities.ts
 msgctxt "WD76vM"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1271,6 +1271,11 @@ msgid "Tests analytical thinking through decisions with trade-offs. See how each
 msgstr "Evalúa el pensamiento analítico a través de decisiones con compensaciones. Ve cómo cada elección impacta diferentes resultados."
 
 #: src/lib/activities.ts
+msgctxt "i09QqM"
+msgid "A dialogue-based story that helps you practice the language in a real-world context."
+msgstr "Una historia basada en diálogos que te ayuda a practicar el idioma en un contexto del mundo real."
+
+#: src/lib/activities.ts
 msgctxt "J9eZ8n"
 msgid "Listen to audio sentences and translate them to practice listening skills."
 msgstr "Escucha oraciones en audio y tradúcelas para practicar habilidades de escucha."
@@ -1319,6 +1324,11 @@ msgstr "Repaso"
 msgctxt "tzNRA/"
 msgid "Explains WHAT this topic is. Breaks down core concepts and definitions using metaphors and analogies."
 msgstr "Explica QUÉ es este tema. Desglosa conceptos centrales y definiciones usando metáforas y analogías."
+
+#: src/lib/activities.ts
+msgctxt "U9yVH/"
+msgid "A comprehensive review covering vocabulary and skills from this lesson."
+msgstr "Un repaso completo que cubre vocabulario y habilidades de esta lección."
 
 #: src/lib/activities.ts
 msgctxt "WD76vM"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1271,6 +1271,11 @@ msgid "Tests analytical thinking through decisions with trade-offs. See how each
 msgstr "Testa pensamento analítico através de decisões analisando prós e contras. Veja como cada escolha impacta diferentes resultados."
 
 #: src/lib/activities.ts
+msgctxt "i09QqM"
+msgid "A dialogue-based story that helps you practice the language in a real-world context."
+msgstr "Uma história baseada em diálogos que ajuda você a praticar o idioma em um contexto do mundo real."
+
+#: src/lib/activities.ts
 msgctxt "J9eZ8n"
 msgid "Listen to audio sentences and translate them to practice listening skills."
 msgstr "Ouça frases em áudio e traduza elas pra praticar habilidades de escuta."
@@ -1319,6 +1324,11 @@ msgstr "Revisão"
 msgctxt "tzNRA/"
 msgid "Explains WHAT this topic is. Breaks down core concepts and definitions using metaphors and analogies."
 msgstr "Explica O QUE é este tópico. Decompõe conceitos centrais e definições usando metáforas e analogias."
+
+#: src/lib/activities.ts
+msgctxt "U9yVH/"
+msgid "A comprehensive review covering vocabulary and skills from this lesson."
+msgstr "Uma revisão completa cobrindo vocabulário e habilidades desta aula."
 
 #: src/lib/activities.ts
 msgctxt "WD76vM"

--- a/apps/main/src/data/courses/get-continue-learning.ts
+++ b/apps/main/src/data/courses/get-continue-learning.ts
@@ -9,6 +9,7 @@ import {
   prisma,
 } from "@zoonk/db";
 import { getContinueLearning as getContinueLearningQuery } from "@zoonk/db/continue-learning";
+import { toActivityKind } from "@zoonk/db/utils";
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 
@@ -52,7 +53,7 @@ export const getContinueLearning = cache(
     return rows.map((row) => ({
       activity: {
         id: row.activityId,
-        kind: row.activityKind,
+        kind: toActivityKind(row.activityKind),
         position: row.activityPosition,
         title: row.activityTitle,
       },

--- a/apps/main/src/lib/activities.ts
+++ b/apps/main/src/lib/activities.ts
@@ -87,5 +87,17 @@ export async function getActivityKinds(params?: { locale: string }): Promise<Act
       key: "review",
       label: t("Review"),
     },
+    {
+      description: t(
+        "A dialogue-based story that helps you practice the language in a real-world context.",
+      ),
+      key: "languageStory",
+      label: t("Story"),
+    },
+    {
+      description: t("A comprehensive review covering vocabulary and skills from this lesson."),
+      key: "languageReview",
+      label: t("Review"),
+    },
   ];
 }

--- a/i18n.lock
+++ b/i18n.lock
@@ -430,6 +430,7 @@ checksums:
     A%20comprehensive%20quiz%20covering%20everything%20you%20learned%20in%20this%20lesson./singular: bd46bf5022b53951436d9facacacf673
     Learn%20new%20words%20and%20their%20translations%20to%20build%20your%20vocabulary./singular: edf41f5213749b375ab5057e14707380
     Tests%20analytical%20thinking%20through%20decisions%20with%20trade-offs.%20See%20how%20each%20choice%20impacts%20different%20outcomes./singular: 6d49ad51d42b986411df06b5ceb48067
+    A%20dialogue-based%20story%20that%20helps%20you%20practice%20the%20language%20in%20a%20real-world%20context./singular: 1eb319ba42d87bf86a9ff6e17bddee5f
     Listen%20to%20audio%20sentences%20and%20translate%20them%20to%20practice%20listening%20skills./singular: c7f37f13c3e2d3cb1f23c9cc5eee4e1d
     Teaches%20grammar%20rules%20with%20practical%20exercises%20to%20help%20you%20remember%20and%20apply%20them./singular: b1250dcf530d4320d730ad2744d37221
     Vocabulary/singular: 2c8127af4c194fa05463e82d5e414c62
@@ -440,6 +441,7 @@ checksums:
     Grammar/singular: 1d97aca351a45df1d6eb27adbee04832
     Review/singular: 299f75db25382980b2895622d7712927
     Explains%20WHAT%20this%20topic%20is.%20Breaks%20down%20core%20concepts%20and%20definitions%20using%20metaphors%20and%20analogies./singular: 5eb6b1cd33e5c20af8423753d4368a81
+    A%20comprehensive%20review%20covering%20vocabulary%20and%20skills%20from%20this%20lesson./singular: 9d8f77da46237b58839fadcbadc5a0bc
     Explains%20WHY%20this%20topic%20exists.%20Tells%20the%20origin%20story%2C%20the%20problems%20it%20solved%2C%20and%20why%20it%20matters%20today./singular: 8bdce45d80e8a4cfcbc65d2bfe928c82
     Background/singular: 0ceaed10d99ed4ad83cb0934ab970174
     Shows%20WHEN%20to%20apply%20this%20topic.%20A%20dialogue%20with%20a%20colleague%20where%20you%20solve%20a%20real%20problem%20together./singular: 3fb0934c1e0a5ba3e31b6cc5b897b509

--- a/packages/db/src/prisma/enums.prisma
+++ b/packages/db/src/prisma/enums.prisma
@@ -25,6 +25,8 @@ enum ActivityKind {
   reading
   listening
   review
+  languageStory  @map("language_story")
+  languageReview @map("language_review")
 }
 
 enum StepKind {

--- a/packages/db/src/prisma/migrations/20260207172915_add_language_activity_kinds/migration.sql
+++ b/packages/db/src/prisma/migrations/20260207172915_add_language_activity_kinds/migration.sql
@@ -1,0 +1,10 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "ActivityKind" ADD VALUE 'language_story';
+ALTER TYPE "ActivityKind" ADD VALUE 'language_review';

--- a/packages/db/src/prisma/seed/activities.ts
+++ b/packages/db/src/prisma/seed/activities.ts
@@ -109,12 +109,32 @@ const activitiesData: {
       {
         generationStatus: "pending",
         isPublished: true,
-        kind: "background",
+        kind: "vocabulary",
       },
       {
         generationStatus: "pending",
         isPublished: true,
-        kind: "explanation",
+        kind: "grammar",
+      },
+      {
+        generationStatus: "pending",
+        isPublished: true,
+        kind: "reading",
+      },
+      {
+        generationStatus: "pending",
+        isPublished: true,
+        kind: "listening",
+      },
+      {
+        generationStatus: "pending",
+        isPublished: true,
+        kind: "languageStory",
+      },
+      {
+        generationStatus: "pending",
+        isPublished: true,
+        kind: "languageReview",
       },
     ],
     language: "en",

--- a/packages/db/src/utils.ts
+++ b/packages/db/src/utils.ts
@@ -1,6 +1,33 @@
-import { Prisma } from "./generated/prisma/client";
+import { type ActivityKind, Prisma } from "./generated/prisma/client";
+import { type $DbEnums } from "./generated/prisma/sql/$DbEnums";
 
 export const MAX_QUERY_ITEMS = 100;
+
+// Workaround for Prisma TypedSQL bug: $queryRawTyped returns
+// the mapped DB values (language_review) but $DbEnums doesn't
+// map them back to the Prisma schema names (languageReview).
+// https://github.com/prisma/prisma/issues/9877
+const dbActivityKindMap: Record<$DbEnums["ActivityKind"], ActivityKind> = {
+  background: "background",
+  challenge: "challenge",
+  custom: "custom",
+  examples: "examples",
+  explanation: "explanation",
+  grammar: "grammar",
+  language_review: "languageReview",
+  language_story: "languageStory",
+  listening: "listening",
+  mechanics: "mechanics",
+  quiz: "quiz",
+  reading: "reading",
+  review: "review",
+  story: "story",
+  vocabulary: "vocabulary",
+};
+
+export function toActivityKind(dbValue: $DbEnums["ActivityKind"]): ActivityKind {
+  return dbActivityKindMap[dbValue];
+}
 
 export function clampQueryItems(count: number): number {
   return Math.min(Math.max(count, 1), MAX_QUERY_ITEMS);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds two new activity kinds for language lessons: languageStory and languageReview. Language lessons now generate six activities and no longer use the generic review kind.

- **New Features**
  - Added ActivityKind values languageStory and languageReview (Prisma enum + migration).
  - Language lessons now create: vocabulary, grammar, reading, listening, languageStory, languageReview.
  - Updated UI labels/descriptions, i18n strings, editor import, and seed data to support the new kinds.
  - Added toActivityKind to map DB enum values back to Prisma names; used in continue-learning.
  - Removed special-case review handling for language lessons; the review step only runs when a 'review' activity exists.

<sup>Written for commit a317239d4550a8c70faa40fa92d4894ffe260a34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

