### PR TITLE
refactor(db): make word pronunciation optional and link steps

### DIFF
--- a/packages/db/src/prisma/migrations/20260208115901_make_word_pronunciation_optional_and_step_word_sentence_optional/migration.sql
+++ b/packages/db/src/prisma/migrations/20260208115901_make_word_pronunciation_optional_and_step_word_sentence_optional/migration.sql
@@ -1,0 +1,18 @@
+-- AlterTable
+ALTER TABLE "steps" ADD COLUMN     "sentence_id" BIGINT,
+ADD COLUMN     "word_id" BIGINT;
+
+-- AlterTable
+ALTER TABLE "words" ALTER COLUMN "pronunciation" DROP NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "steps_word_id_idx" ON "steps"("word_id");
+
+-- CreateIndex
+CREATE INDEX "steps_sentence_id_idx" ON "steps"("sentence_id");
+
+-- AddForeignKey
+ALTER TABLE "steps" ADD CONSTRAINT "steps_word_id_fkey" FOREIGN KEY ("word_id") REFERENCES "words"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "steps" ADD CONSTRAINT "steps_sentence_id_fkey" FOREIGN KEY ("sentence_id") REFERENCES "sentences"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/src/prisma/models/steps.prisma
+++ b/packages/db/src/prisma/models/steps.prisma
@@ -2,6 +2,10 @@ model Step {
   id            BigInt          @id @default(autoincrement())
   activityId    BigInt          @map("activity_id")
   activity      Activity        @relation(fields: [activityId], references: [id], onDelete: Cascade)
+  wordId        BigInt?         @map("word_id")
+  word          Word?           @relation(fields: [wordId], references: [id], onDelete: Cascade)
+  sentenceId    BigInt?         @map("sentence_id")
+  sentence      Sentence?       @relation(fields: [sentenceId], references: [id], onDelete: Cascade)
   kind          StepKind
   position      Int
   content       Json
@@ -12,5 +16,7 @@ model Step {
   attempts      StepAttempt[]
 
   @@index([activityId, position])
+  @@index([wordId])
+  @@index([sentenceId])
   @@map("steps")
 }

--- a/packages/db/src/prisma/models/vocabulary.prisma
+++ b/packages/db/src/prisma/models/vocabulary.prisma
@@ -6,12 +6,13 @@ model Word {
   userLanguage   String       @map("user_language") @db.VarChar(10)
   word           String
   translation    String
-  pronunciation  String
+  pronunciation  String?
   romanization   String?
   audioUrl       String?      @map("audio_url")
   createdAt      DateTime     @default(now()) @map("created_at")
   updatedAt      DateTime     @default(now()) @updatedAt @map("updated_at")
   lessons        LessonWord[]
+  steps          Step[]
 
   @@unique([organizationId, targetLanguage, userLanguage, word], name: "orgWord")
   @@index([organizationId, targetLanguage, userLanguage])
@@ -31,6 +32,7 @@ model Sentence {
   createdAt      DateTime         @default(now()) @map("created_at")
   updatedAt      DateTime         @default(now()) @updatedAt @map("updated_at")
   lessons        LessonSentence[]
+  steps          Step[]
 
   @@unique([organizationId, targetLanguage, userLanguage, sentence], name: "orgSentence")
   @@index([organizationId, targetLanguage, userLanguage])


### PR DESCRIPTION
## summary
- make Word.pronunciation optional in prisma
- add optional Step.wordId and Step.sentenceId with relations and indexes
- add migration for nullable pronunciation and new step foreign keys

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Word.pronunciation optional and allow Step to link to Word and Sentence (both optional). Adds indexes and cascading foreign keys to support these relations.

- **New Features**
  - Word.pronunciation is now nullable.
  - Step can reference Word and Sentence via wordId and sentenceId (optional).
  - Added indexes on steps.word_id and steps.sentence_id, with cascading FKs.

- **Migration**
  - Run prisma migrate to apply the schema changes.
  - Ensure code handles null pronunciation and absent step links.

<sup>Written for commit a947cd381ef599a75658a49556563d2e76f0d442. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

