### PR TITLE
refactor(utils): allow any language for courses, skip audio for unsupported

### DIFF
--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
@@ -28,7 +28,12 @@ async function generateActivities(
   const lessonKind = await determineLessonKindStep(context);
   await updateLessonKindStep({ kind: lessonKind, lessonId });
   const customActivities = await getCustomActivities(context, lessonKind);
-  await addActivitiesStep({ context, customActivities, lessonKind });
+  await addActivitiesStep({
+    context,
+    customActivities,
+    lessonKind,
+    targetLanguage: context.chapter.course.targetLanguage,
+  });
 }
 
 export async function lessonGenerationWorkflow(lessonId: number): Promise<void> {

--- a/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.ts
@@ -14,6 +14,7 @@ async function getLessonForGeneration(lessonId: number) {
         select: {
           course: {
             select: {
+              targetLanguage: true,
               title: true,
             },
           },

--- a/apps/main/src/data/courses/course-suggestions.test.ts
+++ b/apps/main/src/data/courses/course-suggestions.test.ts
@@ -172,17 +172,17 @@ describe("course-suggestions", () => {
     expect(result.suggestions[0]?.targetLanguage).toBe("en");
   });
 
-  test("keeps AI title for unsupported targetLanguageCode", async () => {
+  test("accepts non-TTS language and uses Intl-derived title", async () => {
     const spy = vi.spyOn(courseSuggestions, "generateCourseSuggestions");
 
     const language = "en";
-    const prompt = `unsupported-lang-${randomUUID()}`;
+    const prompt = `non-tts-lang-${randomUUID()}`;
 
     const generatedSuggestions = [
       {
-        description: "Learn this language.",
-        targetLanguageCode: "xx",
-        title: "Unknown Language",
+        description: "Learn Amharic.",
+        targetLanguageCode: "am",
+        title: "Amharic Course",
       },
     ];
 
@@ -191,8 +191,8 @@ describe("course-suggestions", () => {
 
     const result = await generateCourseSuggestions({ language, prompt });
 
-    expect(result.suggestions[0]?.title).toBe("Unknown Language");
-    expect(result.suggestions[0]?.targetLanguage).toBeNull();
+    expect(result.suggestions[0]?.title).toBe("Amharic");
+    expect(result.suggestions[0]?.targetLanguage).toBe("am");
   });
 
   test("deduplicates suggestions with the same targetLanguageCode", async () => {

--- a/apps/main/src/data/courses/course-suggestions.ts
+++ b/apps/main/src/data/courses/course-suggestions.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { generateCourseSuggestions as generateTask } from "@zoonk/ai/tasks/courses/suggestions";
 import { type CourseSuggestion, prisma } from "@zoonk/db";
-import { getLanguageName, isSupportedLanguage } from "@zoonk/utils/languages";
+import { getLanguageName } from "@zoonk/utils/languages";
 import { normalizeString, toSlug } from "@zoonk/utils/string";
 
 type SuggestionResult = Pick<CourseSuggestion, "id" | "title" | "description" | "targetLanguage">;
@@ -90,12 +90,8 @@ function resolveLanguageSuggestion(
   suggestion: { title: string; description: string; targetLanguageCode: string | null },
   language: string,
 ): SuggestionInput {
-  if (!isSupportedLanguage(suggestion.targetLanguageCode)) {
-    return {
-      description: suggestion.description,
-      targetLanguage: null,
-      title: suggestion.title,
-    };
+  if (!suggestion.targetLanguageCode) {
+    return { description: suggestion.description, targetLanguage: null, title: suggestion.title };
   }
 
   const title = getLanguageName({

--- a/packages/utils/src/languages.test.ts
+++ b/packages/utils/src/languages.test.ts
@@ -1,29 +1,29 @@
 import { describe, expect, test } from "vitest";
-import { SUPPORTED_LANGUAGE_CODES, getLanguageName, isSupportedLanguage } from "./languages";
+import { TTS_SUPPORTED_LANGUAGE_CODES, getLanguageName, isTTSSupportedLanguage } from "./languages";
 
-describe(isSupportedLanguage, () => {
+describe(isTTSSupportedLanguage, () => {
   test("supported language codes has exactly 57 entries", () => {
-    expect(SUPPORTED_LANGUAGE_CODES).toHaveLength(57);
+    expect(TTS_SUPPORTED_LANGUAGE_CODES).toHaveLength(57);
   });
 
   test("returns true for a valid language code", () => {
-    expect(isSupportedLanguage("es")).toBeTruthy();
+    expect(isTTSSupportedLanguage("es")).toBeTruthy();
   });
 
   test("returns true for another valid language code", () => {
-    expect(isSupportedLanguage("ja")).toBeTruthy();
+    expect(isTTSSupportedLanguage("ja")).toBeTruthy();
   });
 
   test("returns false for an invalid language code", () => {
-    expect(isSupportedLanguage("xx")).toBeFalsy();
+    expect(isTTSSupportedLanguage("xx")).toBeFalsy();
   });
 
   test("returns false for null", () => {
-    expect(isSupportedLanguage(null)).toBeFalsy();
+    expect(isTTSSupportedLanguage(null)).toBeFalsy();
   });
 
   test("returns false for a number", () => {
-    expect(isSupportedLanguage(42)).toBeFalsy();
+    expect(isTTSSupportedLanguage(42)).toBeFalsy();
   });
 });
 

--- a/packages/utils/src/languages.ts
+++ b/packages/utils/src/languages.ts
@@ -2,7 +2,7 @@
  * ISO 639-1 codes for languages supported by OpenAI TTS (gpt-4o-mini-tts).
  * Source: https://platform.openai.com/docs/guides/text-to-speech
  */
-export const SUPPORTED_LANGUAGE_CODES = [
+export const TTS_SUPPORTED_LANGUAGE_CODES = [
   "af",
   "ar",
   "hy",
@@ -62,12 +62,12 @@ export const SUPPORTED_LANGUAGE_CODES = [
   "cy",
 ] as const;
 
-export type SupportedLanguageCode = (typeof SUPPORTED_LANGUAGE_CODES)[number];
+export type TTSSupportedLanguageCode = (typeof TTS_SUPPORTED_LANGUAGE_CODES)[number];
 
-const SUPPORTED_LANGUAGE_SET: ReadonlySet<string> = new Set(SUPPORTED_LANGUAGE_CODES);
+const TTS_SUPPORTED_LANGUAGE_SET: ReadonlySet<string> = new Set(TTS_SUPPORTED_LANGUAGE_CODES);
 
-export function isSupportedLanguage(code: unknown): code is SupportedLanguageCode {
-  return typeof code === "string" && SUPPORTED_LANGUAGE_SET.has(code);
+export function isTTSSupportedLanguage(code: unknown): code is TTSSupportedLanguageCode {
+  return typeof code === "string" && TTS_SUPPORTED_LANGUAGE_SET.has(code);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Rename TTS-specific exports (`SUPPORTED_LANGUAGE_CODES` → `TTS_SUPPORTED_LANGUAGE_CODES`, `isSupportedLanguage` → `isTTSSupportedLanguage`) to clarify they only apply to audio features
- Remove TTS restriction from `resolveLanguageSuggestion` so any valid language code creates a language course
- Conditionally exclude "listening" activities for languages not supported by OpenAI TTS

## Test plan

- [x] Unit tests updated for renamed TTS exports
- [x] Integration test updated: non-TTS language (Amharic) now creates a language course with Intl-derived title
- [x] Integration test added: non-TTS language lesson generates 5 activities (no listening)
- [x] Existing TTS language test updated to explicitly use a TTS-supported course (`targetLanguage: "es"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow language courses for any language. Skip listening for languages without TTS support and rename TTS helpers for clarity.

- **New Features**
  - Accept any language code when creating language courses.
  - For non-TTS languages, generate 5 activities (no listening); TTS languages still get 6.
  - Derive course titles from Intl for the target language.

- **Refactors**
  - Rename SUPPORTED_LANGUAGE_CODES → TTS_SUPPORTED_LANGUAGE_CODES and isSupportedLanguage → isTTSSupportedLanguage.
  - Pass targetLanguage into activity creation and include it in the lesson context.
  - Update tests to cover TTS and non-TTS flows.

<sup>Written for commit 5167cc01ed651008c4b10e4cf588b6b8c716acae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

