### PR TITLE
fix(api): filter non-language lessons from language courses

### DIFF
--- a/apps/api/src/workflows/config.ts
+++ b/apps/api/src/workflows/config.ts
@@ -13,6 +13,7 @@ const LESSON_STEPS = [
   "setLessonAsRunning",
   "determineLessonKind",
   "updateLessonKind",
+  "removeNonLanguageLesson",
   "generateCustomActivities",
   "addActivities",
   "setLessonAsCompleted",

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -4,6 +4,7 @@ import { generateAlternativeTitles } from "@zoonk/ai/tasks/courses/alternative-t
 import { generateCourseCategories } from "@zoonk/ai/tasks/courses/categories";
 import { generateCourseChapters } from "@zoonk/ai/tasks/courses/chapters";
 import { generateCourseDescription } from "@zoonk/ai/tasks/courses/description";
+import { generateLessonKind } from "@zoonk/ai/tasks/lessons/kind";
 import { generateCourseImage } from "@zoonk/core/courses/image";
 import { prisma } from "@zoonk/db";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
@@ -569,6 +570,10 @@ describe(courseGenerationWorkflow, () => {
     test("creates language course with correct title and targetLanguage", async () => {
       // The data layer resolves "es" to "Spanish" via Intl before persisting the suggestion.
       // The workflow should propagate both the Intl-derived title and targetLanguage to the course.
+      vi.mocked(generateLessonKind).mockResolvedValueOnce({
+        data: { kind: "language" },
+      } as Awaited<ReturnType<typeof generateLessonKind>>);
+
       const title = `Spanish ${randomUUID()}`;
       const slug = toSlug(title);
 
@@ -612,6 +617,10 @@ describe(courseGenerationWorkflow, () => {
     });
 
     test("language course gets 'languages' category without AI call", async () => {
+      vi.mocked(generateLessonKind).mockResolvedValueOnce({
+        data: { kind: "language" },
+      } as Awaited<ReturnType<typeof generateLessonKind>>);
+
       const title = `Spanish Lang Course ${randomUUID()}`;
       const slug = toSlug(title);
 

--- a/apps/api/src/workflows/lesson-generation/steps/remove-non-language-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/remove-non-language-lesson-step.ts
@@ -1,0 +1,18 @@
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+
+export async function removeNonLanguageLessonStep(input: { lessonId: number }): Promise<void> {
+  "use step";
+
+  await streamStatus({ status: "started", step: "removeNonLanguageLesson" });
+
+  const { error } = await safeAsync(() => prisma.lesson.delete({ where: { id: input.lessonId } }));
+
+  if (error) {
+    await streamStatus({ status: "error", step: "removeNonLanguageLesson" });
+    throw error;
+  }
+
+  await streamStatus({ status: "completed", step: "removeNonLanguageLesson" });
+}


### PR DESCRIPTION
## Summary

- When a language course lesson is classified as "core" or "custom" by the AI, delete it instead of populating it with inappropriate activities
- Add `removeNonLanguageLesson` step that deletes the lesson after kind determination
- Update course generation tests to mock correct lesson kind for language courses

## Test plan

- [x] Language course + core kind → lesson deleted
- [x] Language course + custom kind → lesson deleted
- [x] Language course + language kind → lesson kept
- [x] Non-language course + core kind → lesson kept (no false positives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters out non-language lessons in language courses by deleting them when classified as core or custom, preventing mismatched activities. Adds a removal step to the lesson workflow and updates tests to cover the new behavior.

- **Bug Fixes**
  - Added removeNonLanguageLesson step after kind detection; deletes the lesson if the course has a targetLanguage and kind !== "language".
  - Short-circuits the workflow (returns "filtered") to skip activity generation and completion status when a lesson is removed.
  - Updated config to include the new step and expanded tests to cover delete/keep scenarios for language and non-language courses.

<sup>Written for commit 0e2dd42c4b6fb8259c4aa2521356b39e3ceaeabf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

