### PR TITLE
feat(api): add vocabulary generation workflow

### DIFF
--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.ts
@@ -1,4 +1,4 @@
-import { settled } from "./_utils/settled";
+import { settled } from "@zoonk/utils/settled";
 import { generateBackgroundContentStep } from "./steps/generate-background-content-step";
 import { generateChallengeContentStep } from "./steps/generate-challenge-content-step";
 import { generateExamplesContentStep } from "./steps/generate-examples-content-step";

--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
-import { generateActivityBackground } from "@zoonk/ai/tasks/activities/core/background";
-import { generateActivityCustom } from "@zoonk/ai/tasks/activities/custom";
+import { generateActivityPronunciation } from "@zoonk/ai/tasks/activities/language/pronunciation";
+import { generateActivityVocabulary } from "@zoonk/ai/tasks/activities/language/vocabulary";
+import { generateLanguageAudio } from "@zoonk/core/audio/generate";
 import { prisma } from "@zoonk/db";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
@@ -20,6 +21,30 @@ vi.mock("workflow", () => ({
     }),
   }),
   workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
+}));
+
+vi.mock("@zoonk/ai/tasks/activities/language/vocabulary", () => ({
+  generateActivityVocabulary: vi.fn().mockResolvedValue({
+    data: {
+      words: [
+        { romanization: "o-la", translation: "hello", word: "hola" },
+        { romanization: "ga-to", translation: "cat", word: "gato" },
+      ],
+    },
+  }),
+}));
+
+vi.mock("@zoonk/ai/tasks/activities/language/pronunciation", () => ({
+  generateActivityPronunciation: vi.fn().mockResolvedValue({
+    data: { pronunciation: "OH-lah" },
+  }),
+}));
+
+vi.mock("@zoonk/core/audio/generate", () => ({
+  generateLanguageAudio: vi.fn().mockResolvedValue({
+    data: "https://example.com/audio.mp3",
+    error: null,
+  }),
 }));
 
 vi.mock("@zoonk/ai/tasks/activities/core/background", () => ({
@@ -78,7 +103,7 @@ vi.mock("@zoonk/core/cache/revalidate", () => ({
   revalidateMainApp: vi.fn().mockResolvedValue(null),
 }));
 
-describe("language activity workflow", () => {
+describe("vocabulary activity generation", () => {
   let organizationId: number;
   let course: Awaited<ReturnType<typeof courseFixture>>;
   let chapter: Awaited<ReturnType<typeof chapterFixture>>;
@@ -86,7 +111,7 @@ describe("language activity workflow", () => {
   beforeAll(async () => {
     const org = await aiOrganizationFixture();
     organizationId = org.id;
-    course = await courseFixture({ organizationId });
+    course = await courseFixture({ organizationId, targetLanguage: "es" });
     chapter = await chapterFixture({
       courseId: course.id,
       organizationId,
@@ -98,12 +123,12 @@ describe("language activity workflow", () => {
     vi.clearAllMocks();
   });
 
-  test("routes to language workflow (no-op) without calling any AI tasks", async () => {
+  test("doesn't call generateActivityVocabulary when lesson has no vocabulary activities", async () => {
     const testLesson = await lessonFixture({
       chapterId: chapter.id,
       kind: "language",
       organizationId,
-      title: `Language Lesson ${randomUUID()}`,
+      title: `Lang No Vocab ${randomUUID()}`,
     });
 
     await activityFixture({
@@ -116,19 +141,422 @@ describe("language activity workflow", () => {
 
     await activityGenerationWorkflow(testLesson.id);
 
-    expect(generateActivityBackground).not.toHaveBeenCalled();
-    expect(generateActivityCustom).not.toHaveBeenCalled();
+    expect(generateActivityVocabulary).not.toHaveBeenCalled();
   });
 
-  test("activities remain pending after language workflow (no-op)", async () => {
+  test("calls generateActivityVocabulary with correct params", async () => {
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      description: "Learn basic greetings",
+      kind: "language",
+      organizationId,
+      title: `Vocab Params ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    await activityGenerationWorkflow(testLesson.id);
+
+    expect(generateActivityVocabulary).toHaveBeenCalledWith({
+      chapterTitle: chapter.title,
+      courseTitle: course.title,
+      language: "es",
+      lessonDescription: "Learn basic greetings",
+      lessonTitle: testLesson.title,
+    });
+  });
+
+  test("creates word records in the words table with correct targetLanguage and userLanguage", async () => {
     const testLesson = await lessonFixture({
       chapterId: chapter.id,
       kind: "language",
       organizationId,
-      title: `Language Pending Lesson ${randomUUID()}`,
+      title: `Vocab Words ${randomUUID()}`,
     });
 
     const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      language: "en",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    await activityGenerationWorkflow(testLesson.id);
+
+    const words = await prisma.word.findMany({
+      where: {
+        organizationId,
+        steps: { some: { activityId: activity.id } },
+        targetLanguage: "es",
+        userLanguage: "en",
+      },
+    });
+
+    expect(words).toHaveLength(2);
+    expect(words.map((word) => word.word).toSorted()).toEqual(["gato", "hola"]);
+  });
+
+  test("creates lesson_words junction records for each word", async () => {
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `Vocab LessonWords ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    await activityGenerationWorkflow(testLesson.id);
+
+    const lessonWords = await prisma.lessonWord.findMany({
+      where: { lessonId: testLesson.id },
+    });
+
+    expect(lessonWords).toHaveLength(2);
+  });
+
+  test("creates steps with wordId links and correct content", async () => {
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `Vocab Steps ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    await activityGenerationWorkflow(testLesson.id);
+
+    const steps = await prisma.step.findMany({
+      orderBy: { position: "asc" },
+      where: { activityId: activity.id },
+    });
+
+    expect(steps).toHaveLength(2);
+
+    for (const step of steps) {
+      expect(step.wordId).not.toBeNull();
+      expect(step.kind).toBe("static");
+    }
+
+    const holaStep = steps.find(
+      (step) => (step.content as Record<string, unknown>).title === "hola",
+    );
+    expect(holaStep).toBeDefined();
+
+    // oxlint-disable-next-line no-non-null-assertion -- asserted above
+    const holaContent = holaStep!.content as Record<string, unknown>;
+    expect(holaContent.text).toBe("hello");
+  });
+
+  test("calls generateActivityPronunciation once per word with correct params", async () => {
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `Vocab Pron ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      language: "en",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    await activityGenerationWorkflow(testLesson.id);
+
+    expect(generateActivityPronunciation).toHaveBeenCalledTimes(2);
+    expect(generateActivityPronunciation).toHaveBeenCalledWith({
+      nativeLanguage: "en",
+      targetLanguage: "es",
+      word: "hola",
+    });
+    expect(generateActivityPronunciation).toHaveBeenCalledWith({
+      nativeLanguage: "en",
+      targetLanguage: "es",
+      word: "gato",
+    });
+  });
+
+  test("calls generateLanguageAudio once per word when targetLanguage supports TTS", async () => {
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `Vocab Audio ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    await activityGenerationWorkflow(testLesson.id);
+
+    expect(generateLanguageAudio).toHaveBeenCalledTimes(2);
+    expect(generateLanguageAudio).toHaveBeenCalledWith({
+      language: "es",
+      orgSlug: "ai",
+      text: "hola",
+    });
+    expect(generateLanguageAudio).toHaveBeenCalledWith({
+      language: "es",
+      orgSlug: "ai",
+      text: "gato",
+    });
+  });
+
+  test("does not call generateLanguageAudio when targetLanguage does not support TTS", async () => {
+    const unsupportedCourse = await courseFixture({
+      organizationId,
+      targetLanguage: "xx",
+    });
+
+    const unsupportedChapter = await chapterFixture({
+      courseId: unsupportedCourse.id,
+      organizationId,
+      title: `Unsupported Chapter ${randomUUID()}`,
+    });
+
+    const testLesson = await lessonFixture({
+      chapterId: unsupportedChapter.id,
+      kind: "language",
+      organizationId,
+      title: `Vocab NoTTS ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    await activityGenerationWorkflow(testLesson.id);
+
+    expect(generateLanguageAudio).not.toHaveBeenCalled();
+    expect(generateActivityPronunciation).toHaveBeenCalledTimes(2);
+  });
+
+  test("updates word records with pronunciation and audioUrl", async () => {
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `Vocab Enrich ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    await activityGenerationWorkflow(testLesson.id);
+
+    const words = await prisma.word.findMany({
+      where: { steps: { some: { activityId: activity.id } } },
+    });
+
+    for (const word of words) {
+      expect(word.pronunciation).toBe("OH-lah");
+      expect(word.audioUrl).toBe("https://example.com/audio.mp3");
+    }
+  });
+
+  test("sets activity generationStatus to 'completed' with generationRunId", async () => {
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `Vocab Complete ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    await activityGenerationWorkflow(testLesson.id);
+
+    const dbActivity = await prisma.activity.findUnique({
+      where: { id: activity.id },
+    });
+
+    expect(dbActivity?.generationStatus).toBe("completed");
+    expect(dbActivity?.generationRunId).toBe("test-run-id");
+  });
+
+  test("sets activity to 'failed' when generateActivityVocabulary throws", async () => {
+    vi.mocked(generateActivityVocabulary).mockRejectedValueOnce(new Error("AI failed"));
+
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `Vocab Fail ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    await activityGenerationWorkflow(testLesson.id);
+
+    const dbActivity = await prisma.activity.findUnique({
+      where: { id: activity.id },
+    });
+
+    expect(dbActivity?.generationStatus).toBe("failed");
+  });
+
+  test("sets activity to 'failed' when generateActivityPronunciation fails for all words", async () => {
+    vi.mocked(generateActivityPronunciation).mockRejectedValue(new Error("Pronunciation failed"));
+
+    // Use unique targetLanguage to avoid shared word records from other tests
+    const pronFailCourse = await courseFixture({ organizationId, targetLanguage: "fr" });
+    const pronFailChapter = await chapterFixture({
+      courseId: pronFailCourse.id,
+      organizationId,
+      title: `PronFail Chapter ${randomUUID()}`,
+    });
+
+    const testLesson = await lessonFixture({
+      chapterId: pronFailChapter.id,
+      kind: "language",
+      organizationId,
+      title: `Vocab PronFail ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    await activityGenerationWorkflow(testLesson.id);
+
+    const dbActivity = await prisma.activity.findUnique({
+      where: { id: activity.id },
+    });
+
+    expect(dbActivity?.generationStatus).toBe("failed");
+  });
+
+  test("sets activity to 'failed' when generateLanguageAudio fails for all words", async () => {
+    vi.mocked(generateLanguageAudio).mockResolvedValue({
+      data: null,
+      error: new Error("Audio failed"),
+    });
+
+    // Use unique targetLanguage to avoid shared word records from other tests
+    const audioFailCourse = await courseFixture({ organizationId, targetLanguage: "de" });
+    const audioFailChapter = await chapterFixture({
+      courseId: audioFailCourse.id,
+      organizationId,
+      title: `AudioFail Chapter ${randomUUID()}`,
+    });
+
+    const testLesson = await lessonFixture({
+      chapterId: audioFailChapter.id,
+      kind: "language",
+      organizationId,
+      title: `Vocab AudioFail ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    await activityGenerationWorkflow(testLesson.id);
+
+    const dbActivity = await prisma.activity.findUnique({
+      where: { id: activity.id },
+    });
+
+    expect(dbActivity?.generationStatus).toBe("failed");
+  });
+
+  test("skips vocabulary generation if activity is already completed", async () => {
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `Vocab Skip ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "completed",
+      kind: "vocabulary",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    await activityGenerationWorkflow(testLesson.id);
+
+    expect(generateActivityVocabulary).not.toHaveBeenCalled();
+  });
+
+  test("does not process non-vocabulary activities", async () => {
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `Vocab Only ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    await activityFixture({
       generationStatus: "pending",
       kind: "background",
       lessonId: testLesson.id,
@@ -138,9 +566,10 @@ describe("language activity workflow", () => {
 
     await activityGenerationWorkflow(testLesson.id);
 
-    const dbActivity = await prisma.activity.findUnique({
-      where: { id: activity.id },
-    });
-    expect(dbActivity?.generationStatus).toBe("pending");
+    expect(generateActivityVocabulary).toHaveBeenCalled();
+
+    const { generateActivityBackground } =
+      await import("@zoonk/ai/tasks/activities/core/background");
+    expect(generateActivityBackground).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
@@ -608,40 +608,6 @@ describe("vocabulary activity generation", () => {
     }
   });
 
-  test("sets activity to 'failed' when word saving fails", async () => {
-    const saveStepModule = await import("./steps/save-vocabulary-words-step");
-    const spy = vi
-      .spyOn(saveStepModule, "saveVocabularyWordsStep")
-      .mockRejectedValueOnce(new Error("DB error"));
-
-    try {
-      const testLesson = await lessonFixture({
-        chapterId: chapter.id,
-        kind: "language",
-        organizationId,
-        title: `Vocab SaveFail ${randomUUID()}`,
-      });
-
-      const activity = await activityFixture({
-        generationStatus: "pending",
-        kind: "vocabulary",
-        lessonId: testLesson.id,
-        organizationId,
-        title: `Vocabulary ${randomUUID()}`,
-      });
-
-      await activityGenerationWorkflow(testLesson.id);
-
-      const dbActivity = await prisma.activity.findUnique({
-        where: { id: activity.id },
-      });
-
-      expect(dbActivity?.generationStatus).toBe("failed");
-    } finally {
-      spy.mockRestore();
-    }
-  });
-
   test("skips vocabulary generation if activity is already completed", async () => {
     const testLesson = await lessonFixture({
       chapterId: chapter.id,

--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
@@ -1,4 +1,5 @@
 import { settled } from "@zoonk/utils/settled";
+import { findActivityByKind } from "./steps/_utils/find-activity-by-kind";
 import { generateVocabularyAudioStep } from "./steps/generate-vocabulary-audio-step";
 import { generateVocabularyContentStep } from "./steps/generate-vocabulary-content-step";
 import { generateVocabularyPronunciationStep } from "./steps/generate-vocabulary-pronunciation-step";
@@ -31,7 +32,7 @@ export async function languageActivityWorkflow(
   const { audioUrls } = settled(audioResult, { audioUrls: {} });
 
   if (savedWords.length === 0) {
-    const vocabActivity = activities.find((act) => act.kind === "vocabulary");
+    const vocabActivity = findActivityByKind(activities, "vocabulary");
 
     if (vocabActivity) {
       await handleActivityFailureStep({ activityId: vocabActivity.id });

--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
@@ -1,25 +1,11 @@
-import { isTTSSupportedLanguage } from "@zoonk/utils/languages";
-import { settled } from "./_utils/settled";
+import { settled } from "@zoonk/utils/settled";
 import { generateVocabularyAudioStep } from "./steps/generate-vocabulary-audio-step";
 import { generateVocabularyContentStep } from "./steps/generate-vocabulary-content-step";
 import { generateVocabularyPronunciationStep } from "./steps/generate-vocabulary-pronunciation-step";
 import { type LessonActivity } from "./steps/get-lesson-activities-step";
-import { handleActivityFailureStep } from "./steps/handle-failure-step";
 import { saveActivityStep } from "./steps/save-activity-step";
 import { saveVocabularyWordsStep } from "./steps/save-vocabulary-words-step";
 import { updateVocabularyEnrichmentsStep } from "./steps/update-vocabulary-enrichments-step";
-
-function hasEnrichmentFailure(
-  activity: LessonActivity,
-  pronunciations: Record<string, string>,
-  audioUrls: Record<string, string>,
-): boolean {
-  const targetLanguage = activity.lesson.chapter.course.targetLanguage;
-  const pronunciationFailed = Object.keys(pronunciations).length === 0;
-  const audioFailed = isTTSSupportedLanguage(targetLanguage) && Object.keys(audioUrls).length === 0;
-
-  return pronunciationFailed || audioFailed;
-}
 
 export async function languageActivityWorkflow(
   activities: LessonActivity[],
@@ -42,14 +28,6 @@ export async function languageActivityWorkflow(
   const { savedWords } = settled(saveResult, { savedWords: [] });
   const { pronunciations } = settled(pronResult, { pronunciations: {} });
   const { audioUrls } = settled(audioResult, { audioUrls: {} });
-
-  // Mark as failed if pronunciation or audio generation failed entirely
-  const activity = activities.find((act) => act.kind === "vocabulary");
-
-  if (activity && hasEnrichmentFailure(activity, pronunciations, audioUrls)) {
-    await handleActivityFailureStep({ activityId: activity.id });
-    return;
-  }
 
   // Wave 3: Update word records with enrichments
   await updateVocabularyEnrichmentsStep(savedWords, pronunciations, audioUrls);

--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
@@ -42,7 +42,7 @@ export async function languageActivityWorkflow(
   }
 
   // Wave 3: Update word records with enrichments
-  await updateVocabularyEnrichmentsStep(savedWords, pronunciations, audioUrls);
+  await updateVocabularyEnrichmentsStep(activities, savedWords, pronunciations, audioUrls);
 
   // Wave 4: Mark activity as completed
   await saveActivityStep(activities, workflowRunId, "vocabulary");

--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
@@ -3,6 +3,7 @@ import { generateVocabularyAudioStep } from "./steps/generate-vocabulary-audio-s
 import { generateVocabularyContentStep } from "./steps/generate-vocabulary-content-step";
 import { generateVocabularyPronunciationStep } from "./steps/generate-vocabulary-pronunciation-step";
 import { type LessonActivity } from "./steps/get-lesson-activities-step";
+import { handleActivityFailureStep } from "./steps/handle-failure-step";
 import { saveActivityStep } from "./steps/save-activity-step";
 import { saveVocabularyWordsStep } from "./steps/save-vocabulary-words-step";
 import { updateVocabularyEnrichmentsStep } from "./steps/update-vocabulary-enrichments-step";
@@ -28,6 +29,16 @@ export async function languageActivityWorkflow(
   const { savedWords } = settled(saveResult, { savedWords: [] });
   const { pronunciations } = settled(pronResult, { pronunciations: {} });
   const { audioUrls } = settled(audioResult, { audioUrls: {} });
+
+  if (savedWords.length === 0) {
+    const vocabActivity = activities.find((act) => act.kind === "vocabulary");
+
+    if (vocabActivity) {
+      await handleActivityFailureStep({ activityId: vocabActivity.id });
+    }
+
+    return;
+  }
 
   // Wave 3: Update word records with enrichments
   await updateVocabularyEnrichmentsStep(savedWords, pronunciations, audioUrls);

--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
@@ -1,10 +1,8 @@
 import { settled } from "@zoonk/utils/settled";
-import { findActivityByKind } from "./steps/_utils/find-activity-by-kind";
 import { generateVocabularyAudioStep } from "./steps/generate-vocabulary-audio-step";
 import { generateVocabularyContentStep } from "./steps/generate-vocabulary-content-step";
 import { generateVocabularyPronunciationStep } from "./steps/generate-vocabulary-pronunciation-step";
 import { type LessonActivity } from "./steps/get-lesson-activities-step";
-import { handleActivityFailureStep } from "./steps/handle-failure-step";
 import { saveActivityStep } from "./steps/save-activity-step";
 import { saveVocabularyWordsStep } from "./steps/save-vocabulary-words-step";
 import { updateVocabularyEnrichmentsStep } from "./steps/update-vocabulary-enrichments-step";
@@ -30,16 +28,6 @@ export async function languageActivityWorkflow(
   const { savedWords } = settled(saveResult, { savedWords: [] });
   const { pronunciations } = settled(pronResult, { pronunciations: {} });
   const { audioUrls } = settled(audioResult, { audioUrls: {} });
-
-  if (savedWords.length === 0) {
-    const vocabActivity = findActivityByKind(activities, "vocabulary");
-
-    if (vocabActivity) {
-      await handleActivityFailureStep({ activityId: vocabActivity.id });
-    }
-
-    return;
-  }
 
   // Wave 3: Update word records with enrichments
   await updateVocabularyEnrichmentsStep(activities, savedWords, pronunciations, audioUrls);

--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
@@ -1,18 +1,59 @@
+import { isTTSSupportedLanguage } from "@zoonk/utils/languages";
+import { settled } from "./_utils/settled";
+import { generateVocabularyAudioStep } from "./steps/generate-vocabulary-audio-step";
+import { generateVocabularyContentStep } from "./steps/generate-vocabulary-content-step";
+import { generateVocabularyPronunciationStep } from "./steps/generate-vocabulary-pronunciation-step";
 import { type LessonActivity } from "./steps/get-lesson-activities-step";
+import { handleActivityFailureStep } from "./steps/handle-failure-step";
+import { saveActivityStep } from "./steps/save-activity-step";
+import { saveVocabularyWordsStep } from "./steps/save-vocabulary-words-step";
+import { updateVocabularyEnrichmentsStep } from "./steps/update-vocabulary-enrichments-step";
 
-/**
- * Language lesson pipeline (placeholder).
- *
- * TODO: Implement when language AI tasks are available.
- * Expected wave structure:
- * - Wave 1: vocabulary/grammar generation
- * - Wave 2: reading/listening generation
- * - Wave 3: languageStory/languageReview generation
- * - Wave 4: save
- */
+function hasEnrichmentFailure(
+  activity: LessonActivity,
+  pronunciations: Record<string, string>,
+  audioUrls: Record<string, string>,
+): boolean {
+  const targetLanguage = activity.lesson.chapter.course.targetLanguage;
+  const pronunciationFailed = Object.keys(pronunciations).length === 0;
+  const audioFailed = isTTSSupportedLanguage(targetLanguage) && Object.keys(audioUrls).length === 0;
+
+  return pronunciationFailed || audioFailed;
+}
+
 export async function languageActivityWorkflow(
-  _activities: LessonActivity[],
-  _workflowRunId: string,
+  activities: LessonActivity[],
+  workflowRunId: string,
 ): Promise<void> {
-  // No-op until language AI tasks exist
+  // Wave 1: Build word list (AI)
+  const { words } = await generateVocabularyContentStep(activities, workflowRunId);
+
+  if (words.length === 0) {
+    return;
+  }
+
+  // Wave 2: Save words + add pronunciation + record audio in parallel
+  const [saveResult, pronResult, audioResult] = await Promise.allSettled([
+    saveVocabularyWordsStep(activities, words),
+    generateVocabularyPronunciationStep(activities, words),
+    generateVocabularyAudioStep(activities, words),
+  ]);
+
+  const { savedWords } = settled(saveResult, { savedWords: [] });
+  const { pronunciations } = settled(pronResult, { pronunciations: {} });
+  const { audioUrls } = settled(audioResult, { audioUrls: {} });
+
+  // Mark as failed if pronunciation or audio generation failed entirely
+  const activity = activities.find((act) => act.kind === "vocabulary");
+
+  if (activity && hasEnrichmentFailure(activity, pronunciations, audioUrls)) {
+    await handleActivityFailureStep({ activityId: activity.id });
+    return;
+  }
+
+  // Wave 3: Update word records with enrichments
+  await updateVocabularyEnrichmentsStep(savedWords, pronunciations, audioUrls);
+
+  // Wave 4: Mark activity as completed
+  await saveActivityStep(activities, workflowRunId, "vocabulary");
 }

--- a/apps/api/src/workflows/activity-generation/steps/_utils/content-step-helpers.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/content-step-helpers.ts
@@ -1,6 +1,7 @@
 import { type ActivityKind, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { type LessonActivity } from "../get-lesson-activities-step";
+import { findActivityByKind } from "./find-activity-by-kind";
 import { type ActivitySteps, parseActivitySteps } from "./get-activity-steps";
 
 /**
@@ -34,7 +35,7 @@ export async function resolveActivityForGeneration(
   | { activity: LessonActivity; shouldGenerate: true; existingSteps?: undefined }
   | { activity?: undefined; shouldGenerate: false; existingSteps: ActivitySteps }
 > {
-  const activity = activities.find((act) => act.kind === kind);
+  const activity = findActivityByKind(activities, kind);
 
   if (!activity) {
     return { existingSteps: [], shouldGenerate: false };

--- a/apps/api/src/workflows/activity-generation/steps/_utils/find-activity-by-kind.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/find-activity-by-kind.ts
@@ -1,0 +1,6 @@
+import { type ActivityKind } from "@zoonk/db";
+import { type LessonActivity } from "../get-lesson-activities-step";
+
+export function findActivityByKind(activities: LessonActivity[], kind: ActivityKind) {
+  return activities.find((act) => act.kind === kind);
+}

--- a/apps/api/src/workflows/activity-generation/steps/generate-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-images-step.ts
@@ -2,6 +2,7 @@ import { generateVisualStepImage } from "@zoonk/core/steps/visual-image";
 import { type ActivityKind, prisma } from "@zoonk/db";
 import { getString, toRecord } from "@zoonk/utils/json";
 import { streamStatus } from "../stream-status";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type StepVisual } from "./generate-visuals-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
@@ -83,7 +84,7 @@ export async function generateImagesStep(
 ): Promise<StepVisualWithUrl[]> {
   "use step";
 
-  const activity = activities.find((act) => act.kind === activityKind);
+  const activity = findActivityByKind(activities, activityKind);
 
   if (!activity || visuals.length === 0) {
     return [];

--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.ts
@@ -7,6 +7,7 @@ import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { isJsonObject, toRecord } from "@zoonk/utils/json";
 import { streamStatus } from "../stream-status";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
 
@@ -63,7 +64,7 @@ export async function generateQuizImagesStep(
 ): Promise<QuizQuestionWithUrls[]> {
   "use step";
 
-  const activity = activities.find((act) => act.kind === "quiz");
+  const activity = findActivityByKind(activities, "quiz");
 
   if (!activity || questions.length === 0) {
     return [];

--- a/apps/api/src/workflows/activity-generation/steps/generate-visuals-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-visuals-step.ts
@@ -2,6 +2,7 @@ import { type StepVisualSchema, generateStepVisuals } from "@zoonk/ai/tasks/step
 import { type ActivityKind, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { streamStatus } from "../stream-status";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type ActivitySteps } from "./_utils/get-activity-steps";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
@@ -42,7 +43,7 @@ export async function generateVisualsStep(
 ): Promise<{ visuals: StepVisual[] }> {
   "use step";
 
-  const activity = activities.find((act) => act.kind === activityKind);
+  const activity = findActivityByKind(activities, activityKind);
 
   if (!activity || steps.length === 0) {
     return { visuals: [] };

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
@@ -1,10 +1,10 @@
 import { generateLanguageAudio } from "@zoonk/core/audio/generate";
 import { isTTSSupportedLanguage } from "@zoonk/utils/languages";
 import { streamStatus } from "../stream-status";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type VocabularyWord } from "./generate-vocabulary-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
-import { findActivityByKind } from "./_utils/find-activity-by-kind";
 
 async function generateAudioForWord(
   word: string,

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
@@ -4,6 +4,7 @@ import { streamStatus } from "../stream-status";
 import { type VocabularyWord } from "./generate-vocabulary-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
 
 async function generateAudioForWord(
   word: string,
@@ -29,7 +30,7 @@ export async function generateVocabularyAudioStep(
 ): Promise<{ audioUrls: Record<string, string> }> {
   "use step";
 
-  const activity = activities.find((act) => act.kind === "vocabulary");
+  const activity = findActivityByKind(activities, "vocabulary");
 
   if (!activity || words.length === 0) {
     return { audioUrls: {} };

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
@@ -1,0 +1,63 @@
+import { generateLanguageAudio } from "@zoonk/core/audio/generate";
+import { isTTSSupportedLanguage } from "@zoonk/utils/languages";
+import { streamStatus } from "../stream-status";
+import { type VocabularyWord } from "./generate-vocabulary-content-step";
+import { type LessonActivity } from "./get-lesson-activities-step";
+
+async function generateAudioForWord(
+  word: string,
+  language: string,
+  orgSlug: string,
+): Promise<{ audioUrl: string; word: string } | null> {
+  const { data, error } = await generateLanguageAudio({
+    language,
+    orgSlug,
+    text: word,
+  });
+
+  if (error || !data) {
+    return null;
+  }
+
+  return { audioUrl: data, word };
+}
+
+export async function generateVocabularyAudioStep(
+  activities: LessonActivity[],
+  words: VocabularyWord[],
+): Promise<{ audioUrls: Record<string, string> }> {
+  "use step";
+
+  const activity = activities.find((act) => act.kind === "vocabulary");
+
+  if (!activity || words.length === 0) {
+    return { audioUrls: {} };
+  }
+
+  const course = activity.lesson.chapter.course;
+  const targetLanguage = course.targetLanguage;
+
+  await streamStatus({ status: "started", step: "generateVocabularyAudio" });
+
+  if (!isTTSSupportedLanguage(targetLanguage)) {
+    await streamStatus({ status: "completed", step: "generateVocabularyAudio" });
+    return { audioUrls: {} };
+  }
+
+  const orgSlug = course.organization.slug;
+
+  const results = await Promise.allSettled(
+    words.map((vocabWord) => generateAudioForWord(vocabWord.word, targetLanguage, orgSlug)),
+  );
+
+  const audioUrls: Record<string, string> = {};
+
+  for (const result of results) {
+    if (result.status === "fulfilled" && result.value) {
+      audioUrls[result.value.word] = result.value.audioUrl;
+    }
+  }
+
+  await streamStatus({ status: "completed", step: "generateVocabularyAudio" });
+  return { audioUrls };
+}

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.ts
@@ -47,13 +47,19 @@ export async function generateVocabularyContentStep(
     generateActivityVocabulary({
       chapterTitle: activity.lesson.chapter.title,
       courseTitle: activity.lesson.chapter.course.title,
-      language: activity.lesson.chapter.course.targetLanguage ?? "",
+      language: activity.language,
       lessonDescription: activity.lesson.description ?? "",
       lessonTitle: activity.lesson.title,
     }),
   );
 
   if (error || !result) {
+    await streamStatus({ status: "error", step: "generateVocabularyContent" });
+    await handleActivityFailureStep({ activityId: activity.id });
+    return { words: [] };
+  }
+
+  if (result.data.words.length === 0) {
     await streamStatus({ status: "error", step: "generateVocabularyContent" });
     await handleActivityFailureStep({ activityId: activity.id });
     return { words: [] };

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.ts
@@ -4,6 +4,7 @@ import { safeAsync } from "@zoonk/utils/error";
 import { streamStatus } from "../stream-status";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { setActivityAsRunningStep } from "./set-activity-as-running-step";
 
 export type VocabularyWord = {
@@ -11,10 +12,6 @@ export type VocabularyWord = {
   translation: string;
   word: string;
 };
-
-function findVocabularyActivity(activities: LessonActivity[]) {
-  return activities.find((act) => act.kind === "vocabulary");
-}
 
 async function handleFailedActivity(activityId: number) {
   await prisma.step.deleteMany({ where: { activityId } });
@@ -26,7 +23,7 @@ export async function generateVocabularyContentStep(
 ): Promise<{ words: VocabularyWord[] }> {
   "use step";
 
-  const activity = findVocabularyActivity(activities);
+  const activity = findActivityByKind(activities, "vocabulary");
 
   if (!activity) {
     return { words: [] };

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.ts
@@ -1,0 +1,64 @@
+import { generateActivityVocabulary } from "@zoonk/ai/tasks/activities/language/vocabulary";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+import { type LessonActivity } from "./get-lesson-activities-step";
+import { handleActivityFailureStep } from "./handle-failure-step";
+import { setActivityAsRunningStep } from "./set-activity-as-running-step";
+
+export type VocabularyWord = {
+  romanization: string;
+  translation: string;
+  word: string;
+};
+
+function findVocabularyActivity(activities: LessonActivity[]) {
+  return activities.find((act) => act.kind === "vocabulary");
+}
+
+async function handleFailedActivity(activityId: number) {
+  await prisma.step.deleteMany({ where: { activityId } });
+}
+
+export async function generateVocabularyContentStep(
+  activities: LessonActivity[],
+  workflowRunId: string,
+): Promise<{ words: VocabularyWord[] }> {
+  "use step";
+
+  const activity = findVocabularyActivity(activities);
+
+  if (!activity) {
+    return { words: [] };
+  }
+
+  if (activity.generationStatus === "completed" || activity.generationStatus === "running") {
+    return { words: [] };
+  }
+
+  if (activity.generationStatus === "failed") {
+    await handleFailedActivity(activity.id);
+  }
+
+  await streamStatus({ status: "started", step: "generateVocabularyContent" });
+  await setActivityAsRunningStep({ activityId: activity.id, workflowRunId });
+
+  const { data: result, error } = await safeAsync(() =>
+    generateActivityVocabulary({
+      chapterTitle: activity.lesson.chapter.title,
+      courseTitle: activity.lesson.chapter.course.title,
+      language: activity.lesson.chapter.course.targetLanguage ?? "",
+      lessonDescription: activity.lesson.description ?? "",
+      lessonTitle: activity.lesson.title,
+    }),
+  );
+
+  if (error || !result) {
+    await streamStatus({ status: "error", step: "generateVocabularyContent" });
+    await handleActivityFailureStep({ activityId: activity.id });
+    return { words: [] };
+  }
+
+  await streamStatus({ status: "completed", step: "generateVocabularyContent" });
+  return { words: result.data.words };
+}

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.ts
@@ -2,9 +2,9 @@ import { generateActivityVocabulary } from "@zoonk/ai/tasks/activities/language/
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { streamStatus } from "../stream-status";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
-import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { setActivityAsRunningStep } from "./set-activity-as-running-step";
 
 export type VocabularyWord = {

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-pronunciation-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-pronunciation-step.ts
@@ -4,6 +4,7 @@ import { streamStatus } from "../stream-status";
 import { type VocabularyWord } from "./generate-vocabulary-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
 
 async function generatePronunciation(
   word: string,
@@ -33,7 +34,7 @@ export async function generateVocabularyPronunciationStep(
 ): Promise<{ pronunciations: Record<string, string> }> {
   "use step";
 
-  const activity = activities.find((act) => act.kind === "vocabulary");
+  const activity = findActivityByKind(activities, "vocabulary");
 
   if (!activity || words.length === 0) {
     return { pronunciations: {} };

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-pronunciation-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-pronunciation-step.ts
@@ -15,17 +15,11 @@ async function generatePronunciation(
     generateActivityPronunciation({ nativeLanguage, targetLanguage, word }),
   );
 
-  if (error || !result) {
+  if (error || !result?.data) {
     return null;
   }
 
-  const output = result.data;
-
-  if (!output) {
-    return null;
-  }
-
-  return { pronunciation: output.pronunciation, word };
+  return { pronunciation: result.data.pronunciation, word };
 }
 
 export async function generateVocabularyPronunciationStep(

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-pronunciation-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-pronunciation-step.ts
@@ -1,10 +1,10 @@
 import { generateActivityPronunciation } from "@zoonk/ai/tasks/activities/language/pronunciation";
 import { safeAsync } from "@zoonk/utils/error";
 import { streamStatus } from "../stream-status";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type VocabularyWord } from "./generate-vocabulary-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
-import { findActivityByKind } from "./_utils/find-activity-by-kind";
 
 async function generatePronunciation(
   word: string,

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-pronunciation-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-pronunciation-step.ts
@@ -1,0 +1,61 @@
+import { generateActivityPronunciation } from "@zoonk/ai/tasks/activities/language/pronunciation";
+import { safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+import { type VocabularyWord } from "./generate-vocabulary-content-step";
+import { type LessonActivity } from "./get-lesson-activities-step";
+
+async function generatePronunciation(
+  word: string,
+  nativeLanguage: string,
+  targetLanguage: string,
+): Promise<{ pronunciation: string; word: string } | null> {
+  const { data: result, error } = await safeAsync(() =>
+    generateActivityPronunciation({ nativeLanguage, targetLanguage, word }),
+  );
+
+  if (error || !result) {
+    return null;
+  }
+
+  const output = result.data;
+
+  if (!output) {
+    return null;
+  }
+
+  return { pronunciation: output.pronunciation, word };
+}
+
+export async function generateVocabularyPronunciationStep(
+  activities: LessonActivity[],
+  words: VocabularyWord[],
+): Promise<{ pronunciations: Record<string, string> }> {
+  "use step";
+
+  const activity = activities.find((act) => act.kind === "vocabulary");
+
+  if (!activity || words.length === 0) {
+    return { pronunciations: {} };
+  }
+
+  await streamStatus({ status: "started", step: "generateVocabularyPronunciation" });
+
+  const course = activity.lesson.chapter.course;
+  const targetLanguage = course.targetLanguage ?? "";
+  const nativeLanguage = activity.language;
+
+  const results = await Promise.allSettled(
+    words.map((vocabWord) => generatePronunciation(vocabWord.word, nativeLanguage, targetLanguage)),
+  );
+
+  const pronunciations: Record<string, string> = {};
+
+  for (const result of results) {
+    if (result.status === "fulfilled" && result.value) {
+      pronunciations[result.value.word] = result.value.pronunciation;
+    }
+  }
+
+  await streamStatus({ status: "completed", step: "generateVocabularyPronunciation" });
+  return { pronunciations };
+}

--- a/apps/api/src/workflows/activity-generation/steps/get-lesson-activities-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/get-lesson-activities-step.ts
@@ -19,7 +19,7 @@ async function getLessonActivities(lessonId: number) {
             select: {
               course: {
                 select: {
-                  organization: { select: { slug: true } },
+                  organization: { select: { id: true, slug: true } },
                   targetLanguage: true,
                   title: true,
                 },
@@ -32,6 +32,7 @@ async function getLessonActivities(lessonId: number) {
           title: true,
         },
       },
+      lessonId: true,
       title: true,
     },
     where: { lessonId },

--- a/apps/api/src/workflows/activity-generation/steps/save-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-activity-step.ts
@@ -4,6 +4,7 @@ import { type ActivityKind, prisma } from "@zoonk/db";
 import { cacheTagActivity } from "@zoonk/utils/cache";
 import { safeAsync } from "@zoonk/utils/error";
 import { streamStatus } from "../stream-status";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
 
 const kindToStepName: Partial<Record<ActivityKind, ActivityStepName>> = {
@@ -25,7 +26,7 @@ export async function saveActivityStep(
 ): Promise<void> {
   "use step";
 
-  const activity = activities.find((a) => a.kind === activityKind);
+  const activity = findActivityByKind(activities, activityKind);
   const stepName = kindToStepName[activityKind];
 
   if (!activity || !stepName) {

--- a/apps/api/src/workflows/activity-generation/steps/save-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-activity-step.ts
@@ -15,6 +15,7 @@ const kindToStepName: Partial<Record<ActivityKind, ActivityStepName>> = {
   quiz: "setQuizAsCompleted",
   review: "setReviewAsCompleted",
   story: "setStoryAsCompleted",
+  vocabulary: "setVocabularyAsCompleted",
 };
 
 export async function saveActivityStep(

--- a/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
@@ -1,10 +1,10 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { streamStatus } from "../stream-status";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type VocabularyWord } from "./generate-vocabulary-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
-import { findActivityByKind } from "./_utils/find-activity-by-kind";
 
 export type SavedWord = {
   word: string;

--- a/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
@@ -48,7 +48,7 @@ async function saveOneWord(
   await prisma.step.create({
     data: {
       activityId,
-      content: { text: vocabWord.translation, title: vocabWord.word },
+      content: {},
       kind: "static",
       position,
       wordId,

--- a/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
@@ -4,6 +4,7 @@ import { streamStatus } from "../stream-status";
 import { type VocabularyWord } from "./generate-vocabulary-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
 
 export type SavedWord = {
   word: string;
@@ -64,7 +65,7 @@ export async function saveVocabularyWordsStep(
 ): Promise<{ savedWords: SavedWord[] }> {
   "use step";
 
-  const activity = activities.find((act) => act.kind === "vocabulary");
+  const activity = findActivityByKind(activities, "vocabulary");
 
   if (!activity || words.length === 0) {
     return { savedWords: [] };

--- a/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
@@ -1,0 +1,102 @@
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+import { type VocabularyWord } from "./generate-vocabulary-content-step";
+import { type LessonActivity } from "./get-lesson-activities-step";
+
+export type SavedWord = {
+  word: string;
+  wordId: number;
+};
+
+async function saveOneWord(
+  vocabWord: VocabularyWord,
+  activityId: number,
+  lessonId: number,
+  organizationId: number,
+  targetLanguage: string,
+  userLanguage: string,
+  position: number,
+): Promise<SavedWord> {
+  const record = await prisma.word.upsert({
+    create: {
+      organizationId,
+      romanization: vocabWord.romanization,
+      targetLanguage,
+      translation: vocabWord.translation,
+      userLanguage,
+      word: vocabWord.word,
+    },
+    update: {
+      romanization: vocabWord.romanization,
+      translation: vocabWord.translation,
+    },
+    where: {
+      orgWord: { organizationId, targetLanguage, userLanguage, word: vocabWord.word },
+    },
+  });
+
+  const wordId = record.id;
+
+  await prisma.lessonWord.upsert({
+    create: { lessonId, wordId },
+    update: {},
+    where: { lessonWord: { lessonId, wordId } },
+  });
+
+  await prisma.step.create({
+    data: {
+      activityId,
+      content: { text: vocabWord.translation, title: vocabWord.word },
+      kind: "static",
+      position,
+      wordId,
+    },
+  });
+
+  return { word: vocabWord.word, wordId: Number(wordId) };
+}
+
+export async function saveVocabularyWordsStep(
+  activities: LessonActivity[],
+  words: VocabularyWord[],
+): Promise<{ savedWords: SavedWord[] }> {
+  "use step";
+
+  const activity = activities.find((act) => act.kind === "vocabulary");
+
+  if (!activity || words.length === 0) {
+    return { savedWords: [] };
+  }
+
+  await streamStatus({ status: "started", step: "saveVocabularyWords" });
+
+  const course = activity.lesson.chapter.course;
+  const targetLanguage = course.targetLanguage ?? "";
+  const userLanguage = activity.language;
+  const organizationId = course.organization.id;
+
+  const { data: savedWords, error } = await safeAsync(() =>
+    Promise.all(
+      words.map((vocabWord, index) =>
+        saveOneWord(
+          vocabWord,
+          activity.id,
+          activity.lessonId,
+          organizationId,
+          targetLanguage,
+          userLanguage,
+          index,
+        ),
+      ),
+    ),
+  );
+
+  if (error) {
+    await streamStatus({ status: "error", step: "saveVocabularyWords" });
+    return { savedWords: [] };
+  }
+
+  await streamStatus({ status: "completed", step: "saveVocabularyWords" });
+  return { savedWords };
+}

--- a/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
@@ -3,6 +3,7 @@ import { safeAsync } from "@zoonk/utils/error";
 import { streamStatus } from "../stream-status";
 import { type VocabularyWord } from "./generate-vocabulary-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
+import { handleActivityFailureStep } from "./handle-failure-step";
 
 export type SavedWord = {
   word: string;
@@ -94,6 +95,7 @@ export async function saveVocabularyWordsStep(
 
   if (error) {
     await streamStatus({ status: "error", step: "saveVocabularyWords" });
+    await handleActivityFailureStep({ activityId: activity.id });
     return { savedWords: [] };
   }
 

--- a/apps/api/src/workflows/activity-generation/steps/update-vocabulary-enrichments-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/update-vocabulary-enrichments-step.ts
@@ -1,0 +1,48 @@
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+import { type SavedWord } from "./save-vocabulary-words-step";
+
+export async function updateVocabularyEnrichmentsStep(
+  savedWords: SavedWord[],
+  pronunciations: Record<string, string>,
+  audioUrls: Record<string, string>,
+): Promise<void> {
+  "use step";
+
+  if (savedWords.length === 0) {
+    return;
+  }
+
+  await streamStatus({ status: "started", step: "updateVocabularyEnrichments" });
+
+  const updates = savedWords
+    .map((saved) => {
+      const pronunciation = pronunciations[saved.word];
+      const audioUrl = audioUrls[saved.word];
+
+      if (!pronunciation && !audioUrl) {
+        return null;
+      }
+
+      return prisma.word.update({
+        data: {
+          ...(audioUrl ? { audioUrl } : {}),
+          ...(pronunciation ? { pronunciation } : {}),
+        },
+        where: { id: saved.wordId },
+      });
+    })
+    .filter((update) => update !== null);
+
+  if (updates.length > 0) {
+    const { error } = await safeAsync(() => prisma.$transaction(updates));
+
+    if (error) {
+      await streamStatus({ status: "error", step: "updateVocabularyEnrichments" });
+      return;
+    }
+  }
+
+  await streamStatus({ status: "completed", step: "updateVocabularyEnrichments" });
+}

--- a/apps/api/src/workflows/activity-generation/steps/update-vocabulary-enrichments-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/update-vocabulary-enrichments-step.ts
@@ -1,47 +1,50 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { streamStatus } from "../stream-status";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
+import { type LessonActivity } from "./get-lesson-activities-step";
+import { handleActivityFailureStep } from "./handle-failure-step";
 import { type SavedWord } from "./save-vocabulary-words-step";
 
 export async function updateVocabularyEnrichmentsStep(
+  activities: LessonActivity[],
   savedWords: SavedWord[],
   pronunciations: Record<string, string>,
   audioUrls: Record<string, string>,
 ): Promise<void> {
   "use step";
 
-  if (savedWords.length === 0) {
+  const activity = findActivityByKind(activities, "vocabulary");
+
+  if (!activity || savedWords.length === 0) {
     return;
   }
 
   await streamStatus({ status: "started", step: "updateVocabularyEnrichments" });
 
-  const updates = savedWords
-    .map((saved) => {
-      const pronunciation = pronunciations[saved.word];
-      const audioUrl = audioUrls[saved.word];
+  const updates = savedWords.flatMap((saved) => {
+    const pronunciation = pronunciations[saved.word];
+    const audioUrl = audioUrls[saved.word];
 
-      if (!pronunciation && !audioUrl) {
-        return null;
-      }
-
-      return prisma.word.update({
-        data: {
-          ...(audioUrl ? { audioUrl } : {}),
-          ...(pronunciation ? { pronunciation } : {}),
-        },
-        where: { id: saved.wordId },
-      });
-    })
-    .filter((update) => update !== null);
-
-  if (updates.length > 0) {
-    const { error } = await safeAsync(() => prisma.$transaction(updates));
-
-    if (error) {
-      await streamStatus({ status: "error", step: "updateVocabularyEnrichments" });
-      return;
+    if (!pronunciation && !audioUrl) {
+      return [];
     }
+
+    return prisma.word.update({
+      data: {
+        ...(audioUrl ? { audioUrl } : {}),
+        ...(pronunciation ? { pronunciation } : {}),
+      },
+      where: { id: saved.wordId },
+    });
+  });
+
+  const { error } = await safeAsync(() => prisma.$transaction(updates));
+
+  if (error) {
+    await streamStatus({ status: "error", step: "updateVocabularyEnrichments" });
+    await handleActivityFailureStep({ activityId: activity.id });
+    return;
   }
 
   await streamStatus({ status: "completed", step: "updateVocabularyEnrichments" });

--- a/apps/api/src/workflows/config.ts
+++ b/apps/api/src/workflows/config.ts
@@ -45,6 +45,12 @@ const ACTIVITY_STEPS = [
   "setQuizAsCompleted",
   "setReviewAsCompleted",
   "setStoryAsCompleted",
+  "generateVocabularyContent",
+  "saveVocabularyWords",
+  "generateVocabularyPronunciation",
+  "generateVocabularyAudio",
+  "updateVocabularyEnrichments",
+  "setVocabularyAsCompleted",
   "setActivityAsCompleted",
   "workflowError",
 ] as const;

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -999,6 +999,11 @@ msgid "Almost done"
 msgstr "Almost done"
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+msgctxt "N3SU2T"
+msgid "Building your word list"
+msgstr "Building your word list"
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 msgctxt "sISitf"
 msgid "Processing earlier activities"
 msgstr "Processing earlier activities"
@@ -1009,6 +1014,16 @@ msgstr "Processing earlier activities"
 msgctxt "sLBFa0"
 msgid "Preparing illustrations"
 msgstr "Preparing illustrations"
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+msgctxt "T00GEW"
+msgid "Recording audio"
+msgstr "Recording audio"
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+msgctxt "TlrPFF"
+msgid "Adding pronunciation"
+msgstr "Adding pronunciation"
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -999,6 +999,11 @@ msgid "Almost done"
 msgstr "Casi listo"
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+msgctxt "N3SU2T"
+msgid "Building your word list"
+msgstr "Construyendo tu lista de palabras"
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 msgctxt "sISitf"
 msgid "Processing earlier activities"
 msgstr "Procesando actividades anteriores"
@@ -1009,6 +1014,16 @@ msgstr "Procesando actividades anteriores"
 msgctxt "sLBFa0"
 msgid "Preparing illustrations"
 msgstr "Preparando ilustraciones"
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+msgctxt "T00GEW"
+msgid "Recording audio"
+msgstr "Grabando audio"
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+msgctxt "TlrPFF"
+msgid "Adding pronunciation"
+msgstr "Agregando pronunciación"
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -999,6 +999,11 @@ msgid "Almost done"
 msgstr "Quase pronto"
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+msgctxt "N3SU2T"
+msgid "Building your word list"
+msgstr "Construindo sua lista de palavras"
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 msgctxt "sISitf"
 msgid "Processing earlier activities"
 msgstr "Processando atividades anteriores"
@@ -1009,6 +1014,16 @@ msgstr "Processando atividades anteriores"
 msgctxt "sLBFa0"
 msgid "Preparing illustrations"
 msgstr "Preparando ilustrações"
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+msgctxt "T00GEW"
+msgid "Recording audio"
+msgstr "Gravando áudio"
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+msgctxt "TlrPFF"
+msgid "Adding pronunciation"
+msgstr "Adicionando pronúncia"
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts

--- a/apps/main/src/app/[locale]/generate/a/[id]/generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/a/[id]/generation-phases.ts
@@ -6,11 +6,14 @@ import {
 import { ACTIVITY_STEPS, type ActivityStepName } from "@/workflows/config";
 import { type ActivityKind } from "@zoonk/db";
 import {
+  AudioLinesIcon,
   BookOpenIcon,
+  BookTextIcon,
   CheckCircleIcon,
   ImageIcon,
   LayersIcon,
   type LucideIcon,
+  MicIcon,
   PaletteIcon,
   PenLineIcon,
 } from "lucide-react";
@@ -21,9 +24,22 @@ export type PhaseName =
   | "writingContent"
   | "preparingVisuals"
   | "creatingImages"
+  | "buildingWordList"
+  | "addingPronunciation"
+  | "recordingAudio"
   | "finishing";
 
 export function getPhaseOrder(kind: ActivityKind): PhaseName[] {
+  if (kind === "vocabulary") {
+    return [
+      "gettingStarted",
+      "buildingWordList",
+      "addingPronunciation",
+      "recordingAudio",
+      "finishing",
+    ];
+  }
+
   if (kind === "background" || kind === "custom") {
     return ["gettingStarted", "writingContent", "preparingVisuals", "creatingImages", "finishing"];
   }
@@ -52,6 +68,14 @@ const ALL_CONTENT_STEPS: ActivityStepName[] = [
   "generateQuizContent",
   "generateReviewContent",
   "generateStoryContent",
+  "generateVocabularyContent",
+];
+
+const ALL_VOCABULARY_STEPS: ActivityStepName[] = [
+  "saveVocabularyWords",
+  "generateVocabularyPronunciation",
+  "generateVocabularyAudio",
+  "updateVocabularyEnrichments",
 ];
 
 const ALL_COMPLETION_STEPS: ActivityStepName[] = [
@@ -64,16 +88,21 @@ const ALL_COMPLETION_STEPS: ActivityStepName[] = [
   "setQuizAsCompleted",
   "setReviewAsCompleted",
   "setStoryAsCompleted",
+  "setVocabularyAsCompleted",
   "setActivityAsCompleted",
 ];
 
 /**
- * Builds a finishing array that includes all content and completion steps
+ * Builds a finishing array that includes all content, vocabulary, and completion steps
  * except the ones assigned to other phases for this kind.
  */
 function getFinishingSteps(exclude: ActivityStepName[]): ActivityStepName[] {
   const excluded = new Set(exclude);
-  return [...ALL_CONTENT_STEPS.filter((step) => !excluded.has(step)), ...ALL_COMPLETION_STEPS];
+  return [
+    ...ALL_CONTENT_STEPS.filter((step) => !excluded.has(step)),
+    ...ALL_VOCABULARY_STEPS.filter((step) => !excluded.has(step)),
+    ...ALL_COMPLETION_STEPS,
+  ];
 }
 
 const EXPLANATION_DEPS: ActivityStepName[] = [
@@ -84,10 +113,41 @@ const EXPLANATION_DEPS: ActivityStepName[] = [
 
 function getPhaseSteps(kind: ActivityKind): Record<PhaseName, ActivityStepName[]> {
   const shared = {
+    addingPronunciation: [] as ActivityStepName[],
+    buildingWordList: [] as ActivityStepName[],
     creatingImages: ["generateImages", "generateQuizImages"] as ActivityStepName[],
     gettingStarted: ["getLessonActivities"] as ActivityStepName[],
     preparingVisuals: ["generateVisuals"] as ActivityStepName[],
+    recordingAudio: [] as ActivityStepName[],
   };
+
+  if (kind === "vocabulary") {
+    return {
+      addingPronunciation: ["generateVocabularyPronunciation"],
+      buildingWordList: [
+        "setActivityAsRunning",
+        "generateVocabularyContent",
+        "saveVocabularyWords",
+      ],
+      creatingImages: [],
+      finishing: [
+        "generateVisuals",
+        "generateImages",
+        "generateQuizImages",
+        ...getFinishingSteps([
+          "generateVocabularyContent",
+          "saveVocabularyWords",
+          "generateVocabularyPronunciation",
+          "generateVocabularyAudio",
+        ]),
+      ],
+      gettingStarted: ["getLessonActivities"],
+      preparingVisuals: [],
+      processingDependencies: [],
+      recordingAudio: ["generateVocabularyAudio"],
+      writingContent: [],
+    };
+  }
 
   if (kind === "background") {
     return {
@@ -140,34 +200,57 @@ function getPhaseSteps(kind: ActivityKind): Record<PhaseName, ActivityStepName[]
 }
 
 function getPhaseWeights(kind: ActivityKind): Record<PhaseName, number> {
+  if (kind === "vocabulary") {
+    return {
+      addingPronunciation: 25,
+      buildingWordList: 20,
+      creatingImages: 0,
+      finishing: 10,
+      gettingStarted: 3,
+      preparingVisuals: 0,
+      processingDependencies: 0,
+      recordingAudio: 42,
+      writingContent: 0,
+    };
+  }
+
   if (kind === "background" || kind === "custom") {
     return {
+      addingPronunciation: 0,
+      buildingWordList: 0,
       creatingImages: 43,
       finishing: 7,
       gettingStarted: 3,
       preparingVisuals: 22,
       processingDependencies: 0,
+      recordingAudio: 0,
       writingContent: 25,
     };
   }
 
   if (kind === "story" || kind === "challenge" || kind === "review") {
     return {
+      addingPronunciation: 0,
+      buildingWordList: 0,
       creatingImages: 0,
       finishing: 10,
       gettingStarted: 5,
       preparingVisuals: 0,
       processingDependencies: 40,
+      recordingAudio: 0,
       writingContent: 45,
     };
   }
 
   return {
+    addingPronunciation: 0,
+    buildingWordList: 0,
     creatingImages: 35,
     finishing: 9,
     gettingStarted: 3,
     preparingVisuals: 18,
     processingDependencies: 15,
+    recordingAudio: 0,
     writingContent: 20,
   };
 }
@@ -182,6 +265,7 @@ const SUPPORTED_KINDS: ActivityKind[] = [
   "quiz",
   "review",
   "story",
+  "vocabulary",
 ];
 
 for (const kind of SUPPORTED_KINDS) {
@@ -200,11 +284,14 @@ for (const kind of SUPPORTED_KINDS) {
 }
 
 export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
+  addingPronunciation: MicIcon,
+  buildingWordList: BookTextIcon,
   creatingImages: ImageIcon,
   finishing: CheckCircleIcon,
   gettingStarted: BookOpenIcon,
   preparingVisuals: PaletteIcon,
   processingDependencies: LayersIcon,
+  recordingAudio: AudioLinesIcon,
   writingContent: PenLineIcon,
 };
 

--- a/apps/main/src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/a/[id]/use-generation-phases.ts
@@ -27,11 +27,14 @@ export function useGenerationPhases(
   const t = useExtracted();
 
   const labels: Record<PhaseName, string> = {
+    addingPronunciation: t("Adding pronunciation"),
+    buildingWordList: t("Building your word list"),
     creatingImages: t("Creating images"),
     finishing: t("Almost done"),
     gettingStarted: t("Getting started"),
     preparingVisuals: t("Preparing illustrations"),
     processingDependencies: t("Processing earlier activities"),
+    recordingAudio: t("Recording audio"),
     writingContent: t("Writing the content"),
   };
 

--- a/apps/main/src/app/[locale]/generate/ch/[id]/generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/generation-phases.ts
@@ -48,6 +48,7 @@ const PHASE_STEPS = {
     "setQuizAsCompleted",
     "setReviewAsCompleted",
     "setStoryAsCompleted",
+    "setVocabularyAsCompleted",
     "setActivityAsCompleted",
   ],
   preparingLessons: [
@@ -75,6 +76,11 @@ const PHASE_STEPS = {
     "generateQuizContent",
     "generateReviewContent",
     "generateStoryContent",
+    "generateVocabularyContent",
+    "saveVocabularyWords",
+    "generateVocabularyPronunciation",
+    "generateVocabularyAudio",
+    "updateVocabularyEnrichments",
   ],
 } as const satisfies Record<PhaseName, readonly ChapterWorkflowStepName[]>;
 

--- a/apps/main/src/app/[locale]/generate/cs/[id]/generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/cs/[id]/generation-phases.ts
@@ -61,6 +61,7 @@ const PHASE_STEPS = {
     "setQuizAsCompleted",
     "setReviewAsCompleted",
     "setStoryAsCompleted",
+    "setVocabularyAsCompleted",
     "setActivityAsCompleted",
   ],
   gettingReady: [
@@ -103,6 +104,11 @@ const PHASE_STEPS = {
     "generateQuizContent",
     "generateReviewContent",
     "generateStoryContent",
+    "generateVocabularyContent",
+    "saveVocabularyWords",
+    "generateVocabularyPronunciation",
+    "generateVocabularyAudio",
+    "updateVocabularyEnrichments",
   ],
   writingDescription: ["generateDescription"],
 } as const satisfies Record<PhaseName, readonly CourseWorkflowStepName[]>;

--- a/apps/main/src/workflows/config.ts
+++ b/apps/main/src/workflows/config.ts
@@ -46,6 +46,12 @@ export const ACTIVITY_STEPS = [
   "setQuizAsCompleted",
   "setReviewAsCompleted",
   "setStoryAsCompleted",
+  "generateVocabularyContent",
+  "saveVocabularyWords",
+  "generateVocabularyPronunciation",
+  "generateVocabularyAudio",
+  "updateVocabularyEnrichments",
+  "setVocabularyAsCompleted",
   "setActivityAsCompleted",
   "workflowError",
 ] as const;
@@ -61,7 +67,8 @@ export type ActivityCompletionStep =
   | "setMechanicsAsCompleted"
   | "setQuizAsCompleted"
   | "setReviewAsCompleted"
-  | "setStoryAsCompleted";
+  | "setStoryAsCompleted"
+  | "setVocabularyAsCompleted";
 
 const activityCompletionSteps: Partial<Record<string, ActivityCompletionStep>> = {
   background: "setBackgroundAsCompleted",
@@ -73,6 +80,7 @@ const activityCompletionSteps: Partial<Record<string, ActivityCompletionStep>> =
   quiz: "setQuizAsCompleted",
   review: "setReviewAsCompleted",
   story: "setStoryAsCompleted",
+  vocabulary: "setVocabularyAsCompleted",
 };
 
 /**

--- a/i18n.lock
+++ b/i18n.lock
@@ -377,8 +377,11 @@ checksums:
     Creating%20images/singular: ab6fe5010daa5a4deb52eabed6ca071f
     Getting%20started/singular: 8e5e7bd026b5bec46bbfdce02ab9e0b8
     Almost%20done/singular: fa5f270ea4b185be8dd47cfb91b87810
+    Building%20your%20word%20list/singular: 72d48fdf27708f78aed15651559d029a
     Processing%20earlier%20activities/singular: 162ae4b3d730c56cf76023bb37004e59
     Preparing%20illustrations/singular: ebb0d8d739dd029c1ac7327ab6adf8b7
+    Recording%20audio/singular: 528bf44d9d7b8a1c8be7ec526307a703
+    Adding%20pronunciation/singular: f4a57ae308d27a1b5d4214f4cbf0370c
     Writing%20the%20content/singular: 8c98570945250d1750e3b95270cbecae
     Generate%20Chapter/singular: 12160bab066da65413de4b511e402446
     Your%20lessons%20are%20ready/singular: fe8d9df59ba42f451b249fd750813cba

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -15,6 +15,7 @@
     "./languages": "./src/languages.ts",
     "./locale": "./src/locale.ts",
     "./search": "./src/search.ts",
+    "./settled": "./src/settled.ts",
     "./string": "./src/string.ts",
     "./url": "./src/url.ts"
   },

--- a/packages/utils/src/settled.test.ts
+++ b/packages/utils/src/settled.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { settled } from "./settled";
+
+describe(settled, () => {
+  test("returns fulfilled value", () => {
+    const result: PromiseSettledResult<string> = {
+      status: "fulfilled",
+      value: "hello",
+    };
+
+    expect(settled(result, "fallback")).toBe("hello");
+  });
+
+  test("returns fallback for rejected", () => {
+    const result: PromiseSettledResult<string> = {
+      reason: new Error("fail"),
+      status: "rejected",
+    };
+
+    expect(settled(result, "fallback")).toBe("fallback");
+  });
+});

--- a/packages/utils/src/settled.ts
+++ b/packages/utils/src/settled.ts
@@ -1,3 +1,6 @@
+/**
+ * Extracts a single Promise.allSettled result with a fallback for rejected promises.
+ */
 export function settled<T>(result: PromiseSettledResult<T>, fallback: T): T {
   return result.status === "fulfilled" ? result.value : fallback;
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the end-to-end vocabulary generation workflow and updates the generate page with word list, pronunciation, and audio phases. Simplifies failure handling so each vocabulary step marks the activity failed on error.

- **New Features**
  - Vocabulary pipeline: generate list → save words → pronunciation → audio → enrich → complete.
  - Creates Word records and lesson links; steps reference wordId with empty content.
  - Skips TTS for unsupported target languages; stores pronunciation/audio when available.
  - Generate page shows “Building your word list”, “Adding pronunciation”, and “Recording audio” with icons and i18n; registers all vocabulary steps, including setVocabularyAsCompleted.
  - Extracts findActivityByKind; moves settled to @zoonk/utils; adds unit and E2E tests for vocabulary.

- **Bug Fixes**
  - Use activity.language for vocabulary prompts.
  - Fail activity when AI returns empty words, saving words fails, or pronunciation/audio generation fails for all words.
  - Skip when lesson has no vocabulary activity or activity is already completed.
  - Fix test mock leakage with mockRejectedValueOnce.

<sup>Written for commit b5d662cc46dd609cb16bc2a1d8711ef9adbb3ca6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



