### PR TITLE
refactor(api): rename saveActivityStep to completeActivityStep

### DIFF
--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.ts
@@ -1,4 +1,5 @@
 import { settled } from "@zoonk/utils/settled";
+import { completeActivityStep } from "./steps/complete-activity-step";
 import { generateBackgroundContentStep } from "./steps/generate-background-content-step";
 import { generateChallengeContentStep } from "./steps/generate-challenge-content-step";
 import { generateExamplesContentStep } from "./steps/generate-examples-content-step";
@@ -11,7 +12,6 @@ import { generateReviewContentStep } from "./steps/generate-review-content-step"
 import { generateStoryContentStep } from "./steps/generate-story-content-step";
 import { generateVisualsStep } from "./steps/generate-visuals-step";
 import { type LessonActivity } from "./steps/get-lesson-activities-step";
-import { saveActivityStep } from "./steps/save-activity-step";
 
 /**
  * Core lesson pipeline: background → explanation → mechanics, quiz, examples, story, challenge → review.
@@ -66,9 +66,9 @@ export async function coreActivityWorkflow(
       examplesContent.steps,
       workflowRunId,
     ),
-    saveActivityStep(activities, workflowRunId, "background"),
-    saveActivityStep(activities, workflowRunId, "story"),
-    saveActivityStep(activities, workflowRunId, "challenge"),
+    completeActivityStep(activities, workflowRunId, "background"),
+    completeActivityStep(activities, workflowRunId, "story"),
+    completeActivityStep(activities, workflowRunId, "challenge"),
   ]);
 
   const mechVisuals = settled(mechVisualsResult, { visuals: [] });
@@ -78,14 +78,14 @@ export async function coreActivityWorkflow(
   await Promise.allSettled([
     generateImagesStep(activities, mechVisuals.visuals, "mechanics"),
     generateImagesStep(activities, examplesVisuals.visuals, "examples"),
-    saveActivityStep(activities, workflowRunId, "explanation"),
-    saveActivityStep(activities, workflowRunId, "quiz"),
-    saveActivityStep(activities, workflowRunId, "review"),
+    completeActivityStep(activities, workflowRunId, "explanation"),
+    completeActivityStep(activities, workflowRunId, "quiz"),
+    completeActivityStep(activities, workflowRunId, "review"),
   ]);
 
   // Wave 6: save mechanics + save examples
   await Promise.allSettled([
-    saveActivityStep(activities, workflowRunId, "mechanics"),
-    saveActivityStep(activities, workflowRunId, "examples"),
+    completeActivityStep(activities, workflowRunId, "mechanics"),
+    completeActivityStep(activities, workflowRunId, "examples"),
   ]);
 }

--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
@@ -1,4 +1,5 @@
 import { settled } from "@zoonk/utils/settled";
+import { completeActivityStep } from "./steps/complete-activity-step";
 import { generateGrammarContentStep } from "./steps/generate-grammar-content-step";
 import { generateReadingAudioStep } from "./steps/generate-reading-audio-step";
 import { generateReadingContentStep } from "./steps/generate-reading-content-step";
@@ -6,7 +7,6 @@ import { generateVocabularyAudioStep } from "./steps/generate-vocabulary-audio-s
 import { generateVocabularyContentStep } from "./steps/generate-vocabulary-content-step";
 import { generateVocabularyPronunciationStep } from "./steps/generate-vocabulary-pronunciation-step";
 import { type LessonActivity } from "./steps/get-lesson-activities-step";
-import { saveActivityStep } from "./steps/save-activity-step";
 import { saveReadingSentencesStep } from "./steps/save-reading-sentences-step";
 import { saveVocabularyWordsStep } from "./steps/save-vocabulary-words-step";
 import { updateReadingEnrichmentsStep } from "./steps/update-reading-enrichments-step";
@@ -32,7 +32,7 @@ export async function languageActivityWorkflow(
       generateVocabularyPronunciationStep(activities, words),
       generateVocabularyAudioStep(activities, words),
       generateReadingContentStep(activities, workflowRunId, currentRunWords),
-      saveActivityStep(activities, workflowRunId, "grammar"),
+      completeActivityStep(activities, workflowRunId, "grammar"),
     ]);
 
   const { savedWords } = settled(saveWordsResult, { savedWords: [] });
@@ -51,7 +51,7 @@ export async function languageActivityWorkflow(
   // Wave 4: generate reading audio + complete vocabulary
   const [readingAudioResult] = await Promise.allSettled([
     generateReadingAudioStep(activities, savedSentences),
-    saveActivityStep(activities, workflowRunId, "vocabulary"),
+    completeActivityStep(activities, workflowRunId, "vocabulary"),
   ]);
 
   const { audioUrls: readingAudioUrls } = settled(readingAudioResult, { audioUrls: {} });
@@ -60,5 +60,5 @@ export async function languageActivityWorkflow(
   await updateReadingEnrichmentsStep(activities, savedSentences, readingAudioUrls);
 
   // Wave 6: complete reading after enrichments are finalized
-  await saveActivityStep(activities, workflowRunId, "reading");
+  await completeActivityStep(activities, workflowRunId, "reading");
 }

--- a/apps/api/src/workflows/activity-generation/steps/complete-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/complete-activity-step.ts
@@ -21,7 +21,7 @@ const kindToStepName: Partial<Record<ActivityKind, ActivityStepName>> = {
   vocabulary: "setVocabularyAsCompleted",
 };
 
-export async function saveActivityStep(
+export async function completeActivityStep(
   activities: LessonActivity[],
   workflowRunId: string,
   activityKind: ActivityKind,


### PR DESCRIPTION
## Summary
- Renamed `saveActivityStep` → `completeActivityStep` to reflect what the function actually does (marks `generationStatus` as `"completed"`, doesn't save content)
- Renamed file `save-activity-step.ts` → `complete-activity-step.ts`
- Updated all call sites in `core-activity-workflow.ts` and `language-activity-workflow.ts`

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm turbo quality:fix` passes
- [x] `pnpm knip` passes
- [x] `pnpm test` — all 167 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed saveActivityStep to completeActivityStep to match its actual role of marking activities as completed. No behavior change; clearer naming across activity workflows.

- **Refactors**
  - Renamed function and file: saveActivityStep → completeActivityStep; save-activity-step.ts → complete-activity-step.ts
  - Updated all imports and call sites in core- and language-activity workflows

<sup>Written for commit 835a12ded3e3462a823f5bda7a426b05c32e858f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

