### PR TITLE
fix(ai): remove unsupported language param from audio generation

### DIFF
--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
@@ -426,12 +426,10 @@ describe("language activity generation", () => {
 
     expect(generateLanguageAudio).toHaveBeenCalledTimes(2);
     expect(generateLanguageAudio).toHaveBeenCalledWith({
-      language: "es",
       orgSlug: "ai",
       text: "hola",
     });
     expect(generateLanguageAudio).toHaveBeenCalledWith({
-      language: "es",
       orgSlug: "ai",
       text: "gato",
     });
@@ -1105,12 +1103,10 @@ describe("language activity generation", () => {
 
     expect(generateLanguageAudio).toHaveBeenCalledTimes(2);
     expect(generateLanguageAudio).toHaveBeenCalledWith({
-      language: "es",
       orgSlug: "ai",
       text: "Yo veo un gato.",
     });
     expect(generateLanguageAudio).toHaveBeenCalledWith({
-      language: "es",
       orgSlug: "ai",
       text: "Hola, ¿cómo estás?",
     });

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.ts
@@ -8,11 +8,9 @@ import { type SavedSentence } from "./save-reading-sentences-step";
 
 async function generateAudioForSentence(
   sentence: string,
-  language: string,
   orgSlug: string,
 ): Promise<{ audioUrl: string; sentence: string } | null> {
   const { data, error } = await generateLanguageAudio({
-    language,
     orgSlug,
     text: sentence,
   });
@@ -48,7 +46,7 @@ export async function generateReadingAudioStep(
 
   const results = await Promise.all(
     savedSentences.map((savedSentence) =>
-      generateAudioForSentence(savedSentence.sentence, targetLanguage, course.organization.slug),
+      generateAudioForSentence(savedSentence.sentence, course.organization.slug),
     ),
   );
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
@@ -8,11 +8,9 @@ import { handleActivityFailureStep } from "./handle-failure-step";
 
 async function generateAudioForWord(
   word: string,
-  language: string,
   orgSlug: string,
 ): Promise<{ audioUrl: string; word: string } | null> {
   const { data, error } = await generateLanguageAudio({
-    language,
     orgSlug,
     text: word,
   });
@@ -49,7 +47,7 @@ export async function generateVocabularyAudioStep(
   const orgSlug = course.organization.slug;
 
   const results = await Promise.all(
-    words.map((vocabWord) => generateAudioForWord(vocabWord.word, targetLanguage, orgSlug)),
+    words.map((vocabWord) => generateAudioForWord(vocabWord.word, orgSlug)),
   );
 
   const fulfilled = results.filter((result) => result !== null);

--- a/apps/evals/src/app/audio-test/actions.ts
+++ b/apps/evals/src/app/audio-test/actions.ts
@@ -7,14 +7,12 @@ import { parseFormField } from "@zoonk/utils/form";
 export async function generateAudioAction(formData: FormData) {
   const text = parseFormField(formData, "text");
   const voice = parseFormField(formData, "voice") as TTSVoice | undefined;
-  const language = parseFormField(formData, "language") || undefined;
 
   if (!text) {
     return { error: "Text is required." };
   }
 
   const { data: audioUrl, error } = await generateLanguageAudio({
-    language,
     orgSlug: "evals",
     text,
     voice,

--- a/apps/evals/src/app/audio-test/form.tsx
+++ b/apps/evals/src/app/audio-test/form.tsx
@@ -51,17 +51,6 @@ export function AudioTestForm() {
         </div>
 
         <div className="flex flex-col gap-2">
-          <Label htmlFor="language">Language (ISO 639-1 code)</Label>
-          <Input
-            disabled={isPending}
-            id="language"
-            name="language"
-            placeholder="e.g. en, es, fr, pt, ja"
-            type="text"
-          />
-        </div>
-
-        <div className="flex flex-col gap-2">
           <Label htmlFor="voice">Voice</Label>
           <Select defaultValue="marin" name="voice">
             <SelectTrigger id="voice">

--- a/packages/ai/src/tasks/audio/generate-language-audio.ts
+++ b/packages/ai/src/tasks/audio/generate-language-audio.ts
@@ -7,7 +7,6 @@ import { experimental_generateSpeech as generateSpeech } from "ai";
 const DEFAULT_MODEL = openai.speech("gpt-4o-mini-tts");
 
 export type GenerateLanguageAudioParams = {
-  language?: string;
   text: string;
   voice?: TTSVoice;
 };
@@ -17,14 +16,12 @@ export type GenerateLanguageAudioResult = {
 };
 
 export async function generateLanguageAudio({
-  language,
   text,
   voice = "marin",
 }: GenerateLanguageAudioParams): Promise<SafeReturn<GenerateLanguageAudioResult>> {
   const { data, error } = await safeAsync(async () => {
     const { audio } = await generateSpeech({
-      instructions: `Speak clearly and at a moderate pace suitable for language learners. Enunciate each word precisely in this language: ${language}.`,
-      language,
+      instructions: "Speak clearly and at a moderate pace suitable for language learners. Enunciate each word precisely.",
       model: DEFAULT_MODEL,
       outputFormat: "opus",
       text,

--- a/packages/ai/src/tasks/audio/generate-language-audio.ts
+++ b/packages/ai/src/tasks/audio/generate-language-audio.ts
@@ -21,7 +21,8 @@ export async function generateLanguageAudio({
 }: GenerateLanguageAudioParams): Promise<SafeReturn<GenerateLanguageAudioResult>> {
   const { data, error } = await safeAsync(async () => {
     const { audio } = await generateSpeech({
-      instructions: "Speak clearly and at a moderate pace suitable for language learners. Enunciate each word precisely.",
+      instructions:
+        "Speak clearly and at a moderate pace suitable for language learners. Enunciate each word precisely.",
       model: DEFAULT_MODEL,
       outputFormat: "opus",
       text,

--- a/packages/core/src/audio/generate-language-audio.ts
+++ b/packages/core/src/audio/generate-language-audio.ts
@@ -6,20 +6,17 @@ import { toSlug } from "@zoonk/utils/string";
 import { uploadAudio } from "./upload-audio";
 
 export type GenerateLanguageAudioParams = {
-  language?: string;
   orgSlug: string;
   text: string;
   voice?: TTSVoice;
 };
 
 export async function generateLanguageAudio({
-  language,
   orgSlug,
   text,
   voice,
 }: GenerateLanguageAudioParams): Promise<SafeReturn<string>> {
   const { data: audioResult, error: generateError } = await generateAudio({
-    language,
     text,
     voice,
   });


### PR DESCRIPTION
## Summary

- Removed `language` parameter from `generateLanguageAudio` across all layers (AI task, core wrapper, workflow steps, evals)
- The `gpt-4o-mini-tts` model doesn't support a `language` option — it infers the language from the input text, so the parameter had no effect
- Simplified the TTS instructions prompt accordingly

## Test plan

- [x] Updated test assertions to remove `language` from expected call args
- [x] Existing `isTTSSupportedLanguage` checks remain in place to gate audio generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unsupported language parameter from text-to-speech audio generation. The model infers language from the input text, so this removes a no-op option and simplifies the API and UI.

- **Bug Fixes**
  - Dropped language from generateLanguageAudio types and all call sites (ai/core, workflows, evals).
  - Simplified TTS instructions; behavior unchanged.
  - Updated tests; existing language gating checks remain.
  - Fixed lint warnings in modified files.

- **Migration**
  - Remove the language argument from any generateLanguageAudio calls and delete related UI fields.

<sup>Written for commit 9506f4666d0e5b16e8ef4b4d80f89126b825a221. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

