### PR TITLE
fix(ai): remove unsupported `language` option

### DIFF
--- a/packages/ai/src/tasks/audio/generate-language-audio.ts
+++ b/packages/ai/src/tasks/audio/generate-language-audio.ts
@@ -24,7 +24,6 @@ export async function generateLanguageAudio({
   const { data, error } = await safeAsync(async () => {
     const { audio } = await generateSpeech({
       instructions: `Speak clearly and at a moderate pace suitable for language learners. Enunciate each word precisely in this language: ${language}.`,
-      language,
       model: DEFAULT_MODEL,
       outputFormat: "opus",
       text,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the unsupported language option from generateSpeech in generate-language-audio to align with the API and prevent runtime errors. Language is still guided via the instructions, so behavior remains the same for users.

<sup>Written for commit 33409c3c10352fb2113e12362ba61e924c1234a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

