### PR TITLE
feat(db): add vocabulary, reading, listening step kinds

### DIFF
--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
@@ -361,8 +361,8 @@ describe("language activity generation", () => {
 
     for (const step of steps) {
       expect(step.wordId).not.toBeNull();
-      expect(step.kind).toBe("static");
-      expect(step.content).toEqual({ variant: "vocabularyWordRef" });
+      expect(step.kind).toBe("vocabulary");
+      expect(step.content).toEqual({});
     }
 
     const wordNames = steps.map((step) => step.word?.word);
@@ -1072,8 +1072,8 @@ describe("language activity generation", () => {
 
     for (const step of steps) {
       expect(step.sentenceId).not.toBeNull();
-      expect(step.kind).toBe("static");
-      expect(step.content).toEqual({ variant: "readingSentenceRef" });
+      expect(step.kind).toBe("reading");
+      expect(step.content).toEqual({});
     }
 
     expect(steps[0]?.sentence?.sentence).toBe("Yo veo un gato.");

--- a/apps/api/src/workflows/activity-generation/steps/save-reading-sentences-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-reading-sentences-step.ts
@@ -56,8 +56,8 @@ function buildSaveOneSentence(params: {
     await prisma.step.create({
       data: {
         activityId,
-        content: assertStepContent("static", { variant: "readingSentenceRef" }),
-        kind: "static",
+        content: assertStepContent("reading", {}),
+        kind: "reading",
         position,
         sentenceId,
       },

--- a/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
@@ -51,8 +51,8 @@ function buildSaveOneWord(params: {
     await prisma.step.create({
       data: {
         activityId,
-        content: assertStepContent("static", { variant: "vocabularyWordRef" }),
-        kind: "static",
+        content: assertStepContent("vocabulary", {}),
+        kind: "vocabulary",
         position,
         wordId,
       },

--- a/packages/core/src/steps/content-contract.test.ts
+++ b/packages/core/src/steps/content-contract.test.ts
@@ -74,14 +74,19 @@ describe("step content contracts", () => {
     });
   });
 
-  test("parses static vocabularyWordRef variant", () => {
-    const content = parseStepContent("static", { variant: "vocabularyWordRef" });
-    expect(content).toEqual({ variant: "vocabularyWordRef" });
+  test("parses vocabulary step content", () => {
+    const content = parseStepContent("vocabulary", {});
+    expect(content).toEqual({});
   });
 
-  test("parses static readingSentenceRef variant", () => {
-    const content = parseStepContent("static", { variant: "readingSentenceRef" });
-    expect(content).toEqual({ variant: "readingSentenceRef" });
+  test("parses reading step content", () => {
+    const content = parseStepContent("reading", {});
+    expect(content).toEqual({});
+  });
+
+  test("parses listening step content", () => {
+    const content = parseStepContent("listening", {});
+    expect(content).toEqual({});
   });
 
   test("parses matchColumns", () => {

--- a/packages/core/src/steps/content-contract.ts
+++ b/packages/core/src/steps/content-contract.ts
@@ -102,33 +102,26 @@ export const staticGrammarRuleContentSchema = z
   })
   .strict();
 
-export const staticVocabularyWordRefContentSchema = z
-  .object({
-    variant: z.literal("vocabularyWordRef"),
-  })
-  .strict();
-
-export const staticReadingSentenceRefContentSchema = z
-  .object({
-    variant: z.literal("readingSentenceRef"),
-  })
-  .strict();
-
 export const staticContentSchema = z.discriminatedUnion("variant", [
   staticTextContentSchema,
   staticGrammarExampleContentSchema,
   staticGrammarRuleContentSchema,
-  staticVocabularyWordRefContentSchema,
-  staticReadingSentenceRefContentSchema,
 ]);
+
+export const vocabularyContentSchema = z.object({}).strict();
+export const readingContentSchema = z.object({}).strict();
+export const listeningContentSchema = z.object({}).strict();
 
 const stepContentSchemas = {
   fillBlank: fillBlankContentSchema,
+  listening: listeningContentSchema,
   matchColumns: matchColumnsContentSchema,
   multipleChoice: multipleChoiceContentSchema,
+  reading: readingContentSchema,
   selectImage: selectImageContentSchema,
   sortOrder: sortOrderContentSchema,
   static: staticContentSchema,
+  vocabulary: vocabularyContentSchema,
 } as const;
 
 export type SupportedStepKind = keyof typeof stepContentSchemas;
@@ -139,14 +132,20 @@ export type MatchColumnsStepContent = z.infer<typeof matchColumnsContentSchema>;
 export type SortOrderStepContent = z.infer<typeof sortOrderContentSchema>;
 export type SelectImageStepContent = z.infer<typeof selectImageContentSchema>;
 export type StaticStepContent = z.infer<typeof staticContentSchema>;
+export type VocabularyStepContent = z.infer<typeof vocabularyContentSchema>;
+export type ReadingStepContent = z.infer<typeof readingContentSchema>;
+export type ListeningStepContent = z.infer<typeof listeningContentSchema>;
 
 export type StepContentByKind = {
   fillBlank: FillBlankStepContent;
+  listening: ListeningStepContent;
   matchColumns: MatchColumnsStepContent;
   multipleChoice: MultipleChoiceStepContent;
+  reading: ReadingStepContent;
   selectImage: SelectImageStepContent;
   sortOrder: SortOrderStepContent;
   static: StaticStepContent;
+  vocabulary: VocabularyStepContent;
 };
 
 export function isSupportedStepKind(kind: StepKind): kind is SupportedStepKind {
@@ -154,14 +153,17 @@ export function isSupportedStepKind(kind: StepKind): kind is SupportedStepKind {
 }
 
 export function parseStepContent(kind: "fillBlank", content: unknown): FillBlankStepContent;
+export function parseStepContent(kind: "listening", content: unknown): ListeningStepContent;
 export function parseStepContent(kind: "matchColumns", content: unknown): MatchColumnsStepContent;
 export function parseStepContent(
   kind: "multipleChoice",
   content: unknown,
 ): MultipleChoiceStepContent;
+export function parseStepContent(kind: "reading", content: unknown): ReadingStepContent;
 export function parseStepContent(kind: "selectImage", content: unknown): SelectImageStepContent;
 export function parseStepContent(kind: "sortOrder", content: unknown): SortOrderStepContent;
 export function parseStepContent(kind: "static", content: unknown): StaticStepContent;
+export function parseStepContent(kind: "vocabulary", content: unknown): VocabularyStepContent;
 export function parseStepContent(
   kind: SupportedStepKind,
   content: unknown,
@@ -171,14 +173,17 @@ export function parseStepContent(kind: SupportedStepKind, content: unknown) {
 }
 
 export function assertStepContent(kind: "fillBlank", content: unknown): FillBlankStepContent;
+export function assertStepContent(kind: "listening", content: unknown): ListeningStepContent;
 export function assertStepContent(kind: "matchColumns", content: unknown): MatchColumnsStepContent;
 export function assertStepContent(
   kind: "multipleChoice",
   content: unknown,
 ): MultipleChoiceStepContent;
+export function assertStepContent(kind: "reading", content: unknown): ReadingStepContent;
 export function assertStepContent(kind: "selectImage", content: unknown): SelectImageStepContent;
 export function assertStepContent(kind: "sortOrder", content: unknown): SortOrderStepContent;
 export function assertStepContent(kind: "static", content: unknown): StaticStepContent;
+export function assertStepContent(kind: "vocabulary", content: unknown): VocabularyStepContent;
 export function assertStepContent(
   kind: SupportedStepKind,
   content: unknown,

--- a/packages/db/src/prisma/enums.prisma
+++ b/packages/db/src/prisma/enums.prisma
@@ -37,6 +37,9 @@ enum StepKind {
   selectImage    @map("select_image")
   sortOrder      @map("sort_order")
   arrangeWords   @map("arrange_words")
+  vocabulary
+  reading
+  listening
 }
 
 enum StepVisualKind {

--- a/packages/db/src/prisma/migrations/20260209205218_add_lang_step_kinds/migration.sql
+++ b/packages/db/src/prisma/migrations/20260209205218_add_lang_step_kinds/migration.sql
@@ -1,0 +1,11 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "StepKind" ADD VALUE 'vocabulary';
+ALTER TYPE "StepKind" ADD VALUE 'reading';
+ALTER TYPE "StepKind" ADD VALUE 'listening';

--- a/packages/db/src/prisma/seed/activities.ts
+++ b/packages/db/src/prisma/seed/activities.ts
@@ -143,6 +143,22 @@ const activitiesData: {
   {
     activities: [
       {
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "vocabulary",
+      },
+      {
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "reading",
+      },
+    ],
+    language: "en",
+    lessonSlug: "greetings-introductions",
+  },
+  {
+    activities: [
+      {
         generationStatus: "pending",
         isPublished: true,
         kind: "background",


### PR DESCRIPTION
## Summary

- Add `vocabulary`, `reading`, `listening` to `StepKind` enum
- Remove `vocabularyWordRef` and `readingSentenceRef` static content variants
- Add dedicated content schemas (empty objects — data comes from `wordId`/`sentenceId` FKs)
- Update vocabulary/reading workflow steps to use the new kinds
- Add vocabulary/reading activity seeds for `greetings-introductions` lesson

## Test plan

- [x] Unit tests updated for new content schemas
- [x] Integration tests updated for vocabulary/reading step assertions
- [x] All 167 API tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added new step kinds for vocabulary, reading, and listening to replace static variants, making step intent explicit and simplifying frontend logic.

- **New Features**
  - Added StepKind values: vocabulary, reading, listening (DB + core).
  - Introduced empty content schemas for these kinds; data comes from wordId/sentenceId.
  - Updated save-vocabulary and save-reading steps to use the new kinds.
  - Seeded vocabulary and reading activities for the greetings-introductions lesson.

- **Migration**
  - Run Prisma migrate.
  - Replace checks for static variants (vocabularyWordRef, readingSentenceRef) with kind === 'vocabulary' or 'reading'.
  - Expect empty content objects for these kinds; use wordId/sentenceId to fetch data.

<sup>Written for commit a8225dbe738f11fed05e166656013849e3746e27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

