### PR TITLE
feat(api): add listening activity workflow

### DIFF
--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -13,6 +13,7 @@ const nextConfig: NextConfig = {
     minimumCacheTTL: 60 * 60 * 24 * CACHE_IMAGE_DAYS,
     remotePatterns: [
       new URL("https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/**"),
+      new URL("https://mvrkldmanjesbxos.public.blob.vercel-storage.com/**"),
       new URL("https://*.googleusercontent.com/**"),
       new URL("https://*.githubusercontent.com/**"),
     ],

--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
@@ -1,5 +1,7 @@
 import { settled } from "@zoonk/utils/settled";
 import { completeActivityStep } from "./steps/complete-activity-step";
+import { completeListeningActivityStep } from "./steps/complete-listening-activity-step";
+import { copyListeningStepsStep } from "./steps/copy-listening-steps-step";
 import { generateGrammarContentStep } from "./steps/generate-grammar-content-step";
 import { generateReadingAudioStep } from "./steps/generate-reading-audio-step";
 import { generateReadingContentStep } from "./steps/generate-reading-content-step";
@@ -48,10 +50,11 @@ export async function languageActivityWorkflow(
 
   const { savedSentences } = settled(saveSentencesResult, { savedSentences: [] });
 
-  // Wave 4: generate reading audio + complete vocabulary
+  // Wave 4: generate reading audio + complete vocabulary + copy listening steps
   const [readingAudioResult] = await Promise.allSettled([
     generateReadingAudioStep(activities, savedSentences),
     completeActivityStep(activities, workflowRunId, "vocabulary"),
+    copyListeningStepsStep(activities, workflowRunId),
   ]);
 
   const { audioUrls: readingAudioUrls } = settled(readingAudioResult, { audioUrls: {} });
@@ -61,4 +64,7 @@ export async function languageActivityWorkflow(
 
   // Wave 6: complete reading after enrichments are finalized
   await completeActivityStep(activities, workflowRunId, "reading");
+
+  // Wave 7: complete listening only if reading succeeded
+  await completeListeningActivityStep(activities, workflowRunId);
 }

--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
@@ -62,9 +62,9 @@ export async function languageActivityWorkflow(
   // Wave 5: save reading enrichments
   await updateReadingEnrichmentsStep(activities, savedSentences, readingAudioUrls);
 
-  // Wave 6: complete reading after enrichments are finalized
-  await completeActivityStep(activities, workflowRunId, "reading");
-
-  // Wave 7: complete listening only if reading succeeded
-  await completeListeningActivityStep(activities, workflowRunId);
+  // Wave 6: finalize reading + listening in parallel
+  await Promise.allSettled([
+    completeActivityStep(activities, workflowRunId, "reading"),
+    completeListeningActivityStep(activities, workflowRunId),
+  ]);
 }

--- a/apps/api/src/workflows/activity-generation/steps/complete-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/complete-activity-step.ts
@@ -13,6 +13,7 @@ const kindToStepName: Partial<Record<ActivityKind, ActivityStepName>> = {
   examples: "setExamplesAsCompleted",
   explanation: "setExplanationAsCompleted",
   grammar: "setGrammarAsCompleted",
+  listening: "setListeningAsCompleted",
   mechanics: "setMechanicsAsCompleted",
   quiz: "setQuizAsCompleted",
   reading: "setReadingAsCompleted",

--- a/apps/api/src/workflows/activity-generation/steps/complete-listening-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/complete-listening-activity-step.ts
@@ -1,0 +1,40 @@
+import { prisma } from "@zoonk/db";
+import { streamStatus } from "../stream-status";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
+import { completeActivityStep } from "./complete-activity-step";
+import { type LessonActivity } from "./get-lesson-activities-step";
+import { handleActivityFailureStep } from "./handle-failure-step";
+
+export async function completeListeningActivityStep(
+  activities: LessonActivity[],
+  workflowRunId: string,
+): Promise<void> {
+  "use step";
+
+  const listening = findActivityByKind(activities, "listening");
+
+  if (!listening) {
+    return;
+  }
+
+  const reading = findActivityByKind(activities, "reading");
+
+  if (!reading) {
+    await streamStatus({ status: "error", step: "setListeningAsCompleted" });
+    await handleActivityFailureStep({ activityId: listening.id });
+    return;
+  }
+
+  const readingActivity = await prisma.activity.findUnique({
+    select: { generationStatus: true },
+    where: { id: reading.id },
+  });
+
+  if (readingActivity?.generationStatus === "completed") {
+    await completeActivityStep(activities, workflowRunId, "listening");
+    return;
+  }
+
+  await streamStatus({ status: "error", step: "setListeningAsCompleted" });
+  await handleActivityFailureStep({ activityId: listening.id });
+}

--- a/apps/api/src/workflows/activity-generation/steps/complete-listening-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/complete-listening-activity-step.ts
@@ -30,7 +30,7 @@ export async function completeListeningActivityStep(
     where: { id: reading.id },
   });
 
-  if (readingActivity?.generationStatus === "completed") {
+  if (readingActivity?.generationStatus !== "failed") {
     await completeActivityStep(activities, workflowRunId, "listening");
     return;
   }

--- a/apps/api/src/workflows/activity-generation/steps/copy-listening-steps-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/copy-listening-steps-step.ts
@@ -1,0 +1,81 @@
+import { assertStepContent } from "@zoonk/core/steps/content-contract";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { streamStatus } from "../stream-status";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
+import { type LessonActivity } from "./get-lesson-activities-step";
+import { handleActivityFailureStep } from "./handle-failure-step";
+import { setActivityAsRunningStep } from "./set-activity-as-running-step";
+
+export async function copyListeningStepsStep(
+  activities: LessonActivity[],
+  workflowRunId: string,
+): Promise<void> {
+  "use step";
+
+  const listening = findActivityByKind(activities, "listening");
+
+  if (!listening) {
+    return;
+  }
+
+  const current = await prisma.activity.findUnique({
+    select: { generationStatus: true },
+    where: { id: listening.id },
+  });
+
+  if (current?.generationStatus === "completed" || current?.generationStatus === "running") {
+    return;
+  }
+
+  if (current?.generationStatus === "failed") {
+    await safeAsync(() => prisma.step.deleteMany({ where: { activityId: listening.id } }));
+  }
+
+  const reading = findActivityByKind(activities, "reading");
+
+  if (!reading) {
+    await streamStatus({ status: "error", step: "copyListeningSteps" });
+    await handleActivityFailureStep({ activityId: listening.id });
+    return;
+  }
+
+  const readingSteps = await prisma.step.findMany({
+    orderBy: { position: "asc" },
+    select: { position: true, sentenceId: true },
+    where: { activityId: reading.id, kind: "reading" },
+  });
+
+  await streamStatus({ status: "started", step: "copyListeningSteps" });
+
+  if (readingSteps.length === 0) {
+    await streamStatus({ status: "error", step: "copyListeningSteps" });
+    await handleActivityFailureStep({ activityId: listening.id });
+    return;
+  }
+
+  await setActivityAsRunningStep({
+    activityId: listening.id,
+    workflowRunId,
+  });
+
+  const { error } = await safeAsync(() =>
+    prisma.step.createMany({
+      data: readingSteps.map((readingStep) => ({
+        activityId: listening.id,
+        content: assertStepContent("listening", {}),
+        kind: "listening" as const,
+        position: readingStep.position,
+        sentenceId: readingStep.sentenceId,
+      })),
+    }),
+  );
+
+  if (error) {
+    await streamStatus({ status: "error", step: "copyListeningSteps" });
+    await handleActivityFailureStep({ activityId: listening.id });
+    return;
+  }
+
+  await streamStatus({ status: "completed", step: "copyListeningSteps" });
+}

--- a/apps/api/src/workflows/config.ts
+++ b/apps/api/src/workflows/config.ts
@@ -56,8 +56,10 @@ const ACTIVITY_STEPS = [
   "saveSentences",
   "generateAudio",
   "updateSentenceEnrichments",
+  "copyListeningSteps",
   "setVocabularyAsCompleted",
   "setReadingAsCompleted",
+  "setListeningAsCompleted",
   "setActivityAsCompleted",
   "workflowError",
 ] as const;

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -33,6 +33,7 @@ const nextConfig: NextConfig = {
     minimumCacheTTL: 60 * 60 * 24 * CACHE_IMAGE_DAYS,
     remotePatterns: [
       new URL("https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/**"),
+      new URL("https://mvrkldmanjesbxos.public.blob.vercel-storage.com/**"),
       new URL("https://*.googleusercontent.com/**"),
       new URL("https://*.githubusercontent.com/**"),
     ],

--- a/apps/evals/next.config.ts
+++ b/apps/evals/next.config.ts
@@ -8,7 +8,10 @@ const nextConfig: NextConfig = {
     typedEnv: true,
   },
   images: {
-    remotePatterns: [new URL("https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/**")],
+    remotePatterns: [
+      new URL("https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/**"),
+      new URL("https://mvrkldmanjesbxos.public.blob.vercel-storage.com/**"),
+    ],
   },
   pageExtensions: ["ts", "tsx"],
   reactCompiler: true,

--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -39,6 +39,7 @@ const nextConfig: NextConfig = {
     minimumCacheTTL: 60 * 60 * 24 * CACHE_IMAGE_DAYS,
     remotePatterns: [
       new URL("https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/**"),
+      new URL("https://mvrkldmanjesbxos.public.blob.vercel-storage.com/**"),
       new URL("https://*.googleusercontent.com/**"),
       new URL("https://*.githubusercontent.com/**"),
     ],

--- a/apps/main/src/lib/generation/activity-generation-phase-config.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-config.ts
@@ -138,7 +138,7 @@ function getFinishingSteps(exclude: ActivityStepName[]): ActivityStepName[] {
     ...ALL_CONTENT_STEPS.filter((step) => !excluded.has(step)),
     ...ALL_VOCABULARY_STEPS.filter((step) => !excluded.has(step)),
     ...ALL_READING_STEPS.filter((step) => !excluded.has(step)),
-    ...ALL_COMPLETION_STEPS,
+    ...ALL_COMPLETION_STEPS.filter((step) => !excluded.has(step)),
   ];
 }
 
@@ -146,6 +146,25 @@ const EXPLANATION_DEPS: ActivityStepName[] = [
   "setActivityAsRunning",
   "generateBackgroundContent",
   "generateExplanationContent",
+];
+
+const LISTENING_DEPENDENCY_STEPS: ActivityStepName[] = [
+  "setActivityAsRunning",
+  "generateVocabularyContent",
+  "saveVocabularyWords",
+  "generateVocabularyPronunciation",
+  "generateVocabularyAudio",
+  "updateVocabularyEnrichments",
+  "generateGrammarContent",
+  "generateSentences",
+  "setGrammarAsCompleted",
+  "setActivityAsCompleted",
+];
+
+const LISTENING_WRITING_STEPS: ActivityStepName[] = [
+  "copyListeningSteps",
+  "setVocabularyAsCompleted",
+  "setReadingAsCompleted",
 ];
 
 export function getPhaseSteps(kind: ActivityKind): Record<PhaseName, ActivityStepName[]> {
@@ -235,17 +254,20 @@ export function getPhaseSteps(kind: ActivityKind): Record<PhaseName, ActivitySte
         "generateImages",
         "generateQuizImages",
         ...getFinishingSteps([
+          ...LISTENING_DEPENDENCY_STEPS,
+          ...LISTENING_WRITING_STEPS,
           "generateSentences",
           "saveSentences",
           "generateAudio",
           "updateSentenceEnrichments",
-          "copyListeningSteps",
+          "setListeningAsCompleted",
         ]),
+        "setListeningAsCompleted",
       ],
       preparingVisuals: [],
-      processingDependencies: ["setActivityAsRunning", "generateSentences"],
+      processingDependencies: LISTENING_DEPENDENCY_STEPS,
       recordingAudio: ["generateAudio", "updateSentenceEnrichments"],
-      writingContent: ["copyListeningSteps"],
+      writingContent: LISTENING_WRITING_STEPS,
     };
   }
 

--- a/apps/main/src/lib/generation/activity-generation-phase-config.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-config.ts
@@ -1,5 +1,11 @@
 import { ACTIVITY_STEPS, type ActivityStepName } from "@/workflows/config";
 import { type ActivityKind } from "@zoonk/db";
+import {
+  EXPLANATION_DEPS,
+  LISTENING_DEPENDENCY_STEPS,
+  LISTENING_WRITING_STEPS,
+  getFinishingSteps,
+} from "./activity-generation-phase-step-groups";
 
 export { getPhaseWeights } from "./activity-generation-phase-weights";
 
@@ -85,87 +91,6 @@ export function getPhaseOrder(kind: ActivityKind): PhaseName[] {
     "finishing",
   ];
 }
-
-const ALL_CONTENT_STEPS: ActivityStepName[] = [
-  "generateBackgroundContent",
-  "generateChallengeContent",
-  "generateCustomContent",
-  "generateExamplesContent",
-  "generateExplanationContent",
-  "generateMechanicsContent",
-  "generateQuizContent",
-  "generateReviewContent",
-  "generateStoryContent",
-  "generateGrammarContent",
-  "generateSentences",
-  "generateVocabularyContent",
-  "copyListeningSteps",
-];
-
-const ALL_VOCABULARY_STEPS: ActivityStepName[] = [
-  "saveVocabularyWords",
-  "generateVocabularyPronunciation",
-  "generateVocabularyAudio",
-  "updateVocabularyEnrichments",
-];
-
-const ALL_READING_STEPS: ActivityStepName[] = [
-  "saveSentences",
-  "generateAudio",
-  "updateSentenceEnrichments",
-];
-
-const ALL_COMPLETION_STEPS: ActivityStepName[] = [
-  "setBackgroundAsCompleted",
-  "setChallengeAsCompleted",
-  "setCustomAsCompleted",
-  "setExamplesAsCompleted",
-  "setExplanationAsCompleted",
-  "setMechanicsAsCompleted",
-  "setQuizAsCompleted",
-  "setReviewAsCompleted",
-  "setStoryAsCompleted",
-  "setGrammarAsCompleted",
-  "setVocabularyAsCompleted",
-  "setReadingAsCompleted",
-  "setListeningAsCompleted",
-  "setActivityAsCompleted",
-];
-
-function getFinishingSteps(exclude: ActivityStepName[]): ActivityStepName[] {
-  const excluded = new Set(exclude);
-  return [
-    ...ALL_CONTENT_STEPS.filter((step) => !excluded.has(step)),
-    ...ALL_VOCABULARY_STEPS.filter((step) => !excluded.has(step)),
-    ...ALL_READING_STEPS.filter((step) => !excluded.has(step)),
-    ...ALL_COMPLETION_STEPS.filter((step) => !excluded.has(step)),
-  ];
-}
-
-const EXPLANATION_DEPS: ActivityStepName[] = [
-  "setActivityAsRunning",
-  "generateBackgroundContent",
-  "generateExplanationContent",
-];
-
-const LISTENING_DEPENDENCY_STEPS: ActivityStepName[] = [
-  "setActivityAsRunning",
-  "generateVocabularyContent",
-  "saveVocabularyWords",
-  "generateVocabularyPronunciation",
-  "generateVocabularyAudio",
-  "updateVocabularyEnrichments",
-  "generateGrammarContent",
-  "generateSentences",
-  "setGrammarAsCompleted",
-  "setActivityAsCompleted",
-];
-
-const LISTENING_WRITING_STEPS: ActivityStepName[] = [
-  "copyListeningSteps",
-  "setVocabularyAsCompleted",
-  "setReadingAsCompleted",
-];
 
 export function getPhaseSteps(kind: ActivityKind): Record<PhaseName, ActivityStepName[]> {
   const shared = {

--- a/apps/main/src/lib/generation/activity-generation-phase-config.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-config.ts
@@ -53,6 +53,17 @@ export function getPhaseOrder(kind: ActivityKind): PhaseName[] {
     return ["gettingStarted", "buildingWordList", "recordingAudio", "finishing"];
   }
 
+  if (kind === "listening") {
+    return [
+      "gettingStarted",
+      "processingDependencies",
+      "buildingWordList",
+      "recordingAudio",
+      "writingContent",
+      "finishing",
+    ];
+  }
+
   if (kind === "grammar") {
     return ["gettingStarted", "writingContent", "finishing"];
   }
@@ -88,6 +99,7 @@ const ALL_CONTENT_STEPS: ActivityStepName[] = [
   "generateGrammarContent",
   "generateSentences",
   "generateVocabularyContent",
+  "copyListeningSteps",
 ];
 
 const ALL_VOCABULARY_STEPS: ActivityStepName[] = [
@@ -116,6 +128,7 @@ const ALL_COMPLETION_STEPS: ActivityStepName[] = [
   "setGrammarAsCompleted",
   "setVocabularyAsCompleted",
   "setReadingAsCompleted",
+  "setListeningAsCompleted",
   "setActivityAsCompleted",
 ];
 
@@ -212,6 +225,30 @@ export function getPhaseSteps(kind: ActivityKind): Record<PhaseName, ActivitySte
     };
   }
 
+  if (kind === "listening") {
+    return {
+      ...shared,
+      buildingWordList: ["saveSentences"],
+      creatingImages: [],
+      finishing: [
+        "generateVisuals",
+        "generateImages",
+        "generateQuizImages",
+        ...getFinishingSteps([
+          "generateSentences",
+          "saveSentences",
+          "generateAudio",
+          "updateSentenceEnrichments",
+          "copyListeningSteps",
+        ]),
+      ],
+      preparingVisuals: [],
+      processingDependencies: ["setActivityAsRunning", "generateSentences"],
+      recordingAudio: ["generateAudio", "updateSentenceEnrichments"],
+      writingContent: ["copyListeningSteps"],
+    };
+  }
+
   if (kind === "background") {
     return {
       ...shared,
@@ -269,6 +306,7 @@ const SUPPORTED_KINDS: ActivityKind[] = [
   "examples",
   "explanation",
   "grammar",
+  "listening",
   "mechanics",
   "quiz",
   "reading",

--- a/apps/main/src/lib/generation/activity-generation-phase-step-groups.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-step-groups.ts
@@ -1,0 +1,82 @@
+import { type ActivityStepName } from "@/workflows/config";
+
+const ALL_CONTENT_STEPS: ActivityStepName[] = [
+  "generateBackgroundContent",
+  "generateChallengeContent",
+  "generateCustomContent",
+  "generateExamplesContent",
+  "generateExplanationContent",
+  "generateMechanicsContent",
+  "generateQuizContent",
+  "generateReviewContent",
+  "generateStoryContent",
+  "generateGrammarContent",
+  "generateSentences",
+  "generateVocabularyContent",
+  "copyListeningSteps",
+];
+
+const ALL_VOCABULARY_STEPS: ActivityStepName[] = [
+  "saveVocabularyWords",
+  "generateVocabularyPronunciation",
+  "generateVocabularyAudio",
+  "updateVocabularyEnrichments",
+];
+
+const ALL_READING_STEPS: ActivityStepName[] = [
+  "saveSentences",
+  "generateAudio",
+  "updateSentenceEnrichments",
+];
+
+const ALL_COMPLETION_STEPS: ActivityStepName[] = [
+  "setBackgroundAsCompleted",
+  "setChallengeAsCompleted",
+  "setCustomAsCompleted",
+  "setExamplesAsCompleted",
+  "setExplanationAsCompleted",
+  "setMechanicsAsCompleted",
+  "setQuizAsCompleted",
+  "setReviewAsCompleted",
+  "setStoryAsCompleted",
+  "setGrammarAsCompleted",
+  "setVocabularyAsCompleted",
+  "setReadingAsCompleted",
+  "setListeningAsCompleted",
+  "setActivityAsCompleted",
+];
+
+export const EXPLANATION_DEPS: ActivityStepName[] = [
+  "setActivityAsRunning",
+  "generateBackgroundContent",
+  "generateExplanationContent",
+];
+
+export const LISTENING_DEPENDENCY_STEPS: ActivityStepName[] = [
+  "setActivityAsRunning",
+  "generateVocabularyContent",
+  "saveVocabularyWords",
+  "generateVocabularyPronunciation",
+  "generateVocabularyAudio",
+  "updateVocabularyEnrichments",
+  "generateGrammarContent",
+  "generateSentences",
+  "setGrammarAsCompleted",
+  "setActivityAsCompleted",
+];
+
+export const LISTENING_WRITING_STEPS: ActivityStepName[] = [
+  "copyListeningSteps",
+  "setVocabularyAsCompleted",
+  "setReadingAsCompleted",
+];
+
+export function getFinishingSteps(exclude: readonly ActivityStepName[]): ActivityStepName[] {
+  const excluded = new Set(exclude);
+  return [
+    ...ALL_CONTENT_STEPS.filter((step) => !excluded.has(step)),
+    ...ALL_VOCABULARY_STEPS.filter((step) => !excluded.has(step)),
+    ...ALL_READING_STEPS.filter((step) => !excluded.has(step)),
+    ...ALL_COMPLETION_STEPS.filter((step) => !excluded.has(step)),
+  ];
+}

--- a/apps/main/src/lib/generation/activity-generation-phase-weights.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-weights.ts
@@ -58,6 +58,20 @@ export function getPhaseWeights(kind: ActivityKind): Record<PhaseName, number> {
     };
   }
 
+  if (kind === "listening") {
+    return {
+      addingPronunciation: 0,
+      buildingWordList: 10,
+      creatingImages: 0,
+      finishing: 7,
+      gettingStarted: 3,
+      preparingVisuals: 0,
+      processingDependencies: 30,
+      recordingAudio: 45,
+      writingContent: 5,
+    };
+  }
+
   if (kind === "story" || kind === "challenge" || kind === "review") {
     return {
       addingPronunciation: 0,

--- a/apps/main/src/lib/generation/activity-generation-phases.test.ts
+++ b/apps/main/src/lib/generation/activity-generation-phases.test.ts
@@ -142,6 +142,17 @@ describe("listening phase status", () => {
     expect(status).toBe("active");
   });
 
+  test("keeps finishing pending during early dependency processing", () => {
+    const status = getPhaseStatus(
+      "finishing",
+      ["setActivityAsRunning", "generateVocabularyContent", "setActivityAsCompleted"],
+      "generateGrammarContent",
+      "listening",
+    );
+
+    expect(status).toBe("pending");
+  });
+
   test("activates writingContent for copyListeningSteps", () => {
     const status = getPhaseStatus(
       "writingContent",
@@ -153,6 +164,31 @@ describe("listening phase status", () => {
         "updateSentenceEnrichments",
       ],
       "copyListeningSteps",
+      "listening",
+    );
+
+    expect(status).toBe("active");
+  });
+
+  test("activates finishing at terminal listening completion", () => {
+    const status = getPhaseStatus(
+      "finishing",
+      [
+        "setActivityAsRunning",
+        "generateVocabularyContent",
+        "saveVocabularyWords",
+        "generateVocabularyPronunciation",
+        "generateVocabularyAudio",
+        "generateGrammarContent",
+        "generateSentences",
+        "saveSentences",
+        "generateAudio",
+        "updateSentenceEnrichments",
+        "copyListeningSteps",
+        "setVocabularyAsCompleted",
+        "setReadingAsCompleted",
+      ],
+      "setListeningAsCompleted",
       "listening",
     );
 

--- a/apps/main/src/lib/generation/activity-generation-phases.test.ts
+++ b/apps/main/src/lib/generation/activity-generation-phases.test.ts
@@ -119,6 +119,57 @@ describe("grammar phase status", () => {
   });
 });
 
+describe("listening phase status", () => {
+  test("returns correct phase order for listening", () => {
+    expect(getPhaseOrder("listening")).toEqual([
+      "gettingStarted",
+      "processingDependencies",
+      "buildingWordList",
+      "recordingAudio",
+      "writingContent",
+      "finishing",
+    ]);
+  });
+
+  test("activates processingDependencies for generateSentences", () => {
+    const status = getPhaseStatus(
+      "processingDependencies",
+      ["setActivityAsRunning"],
+      "generateSentences",
+      "listening",
+    );
+
+    expect(status).toBe("active");
+  });
+
+  test("activates writingContent for copyListeningSteps", () => {
+    const status = getPhaseStatus(
+      "writingContent",
+      [
+        "setActivityAsRunning",
+        "generateSentences",
+        "saveSentences",
+        "generateAudio",
+        "updateSentenceEnrichments",
+      ],
+      "copyListeningSteps",
+      "listening",
+    );
+
+    expect(status).toBe("active");
+  });
+
+  test("calculates progress for listening flow", () => {
+    const progress = calculateWeightedProgress(
+      ["setActivityAsRunning", "generateSentences", "saveSentences"],
+      "generateAudio",
+      "listening",
+    );
+
+    expect(progress).toBeGreaterThan(0);
+  });
+});
+
 describe("reading phase status", () => {
   test("activates buildingWordList for sentence generation", () => {
     const status = getPhaseStatus(

--- a/apps/main/src/workflows/config.test.ts
+++ b/apps/main/src/workflows/config.test.ts
@@ -9,4 +9,8 @@ describe(getActivityCompletionStep, () => {
   test("returns reading completion step for reading activity kind", () => {
     expect(getActivityCompletionStep("reading")).toBe("setReadingAsCompleted");
   });
+
+  test("returns listening completion step for listening activity kind", () => {
+    expect(getActivityCompletionStep("listening")).toBe("setListeningAsCompleted");
+  });
 });

--- a/apps/main/src/workflows/config.ts
+++ b/apps/main/src/workflows/config.ts
@@ -57,8 +57,10 @@ export const ACTIVITY_STEPS = [
   "saveSentences",
   "generateAudio",
   "updateSentenceEnrichments",
+  "copyListeningSteps",
   "setVocabularyAsCompleted",
   "setReadingAsCompleted",
+  "setListeningAsCompleted",
   "setActivityAsCompleted",
   "workflowError",
 ] as const;
@@ -77,7 +79,8 @@ export type ActivityCompletionStep =
   | "setStoryAsCompleted"
   | "setGrammarAsCompleted"
   | "setVocabularyAsCompleted"
-  | "setReadingAsCompleted";
+  | "setReadingAsCompleted"
+  | "setListeningAsCompleted";
 
 const activityCompletionSteps: Partial<Record<string, ActivityCompletionStep>> = {
   background: "setBackgroundAsCompleted",
@@ -86,6 +89,7 @@ const activityCompletionSteps: Partial<Record<string, ActivityCompletionStep>> =
   examples: "setExamplesAsCompleted",
   explanation: "setExplanationAsCompleted",
   grammar: "setGrammarAsCompleted",
+  listening: "setListeningAsCompleted",
   mechanics: "setMechanicsAsCompleted",
   quiz: "setQuizAsCompleted",
   reading: "setReadingAsCompleted",


### PR DESCRIPTION
## Summary
- Copy reading steps to create listening steps (same `sentenceId`, empty content) for progress tracking via `step_attempts`
- Listening completion depends on reading completion to ensure audio is available on sentences
- Added listening phase config and weights for the generation UI progress display

## Test plan
- [x] Integration tests: mirror steps, completion, failure cascading, skip when completed, pre-completed reading copy (8 tests)
- [x] Unit tests: phase order, phase status, progress calculation (4 tests)
- [x] E2E tests: full workflow completion, correct phase display (2 tests)
- [x] Config test: completion step mapping (1 test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a listening workflow that mirrors reading steps and completes listening alongside reading when reading doesn’t fail. Updates the generation UI with a new dependency-processing view and audio recording for listening.

- **New Features**
  - Copy reading steps into listening (same sentenceId, empty content); skip if completed/running; clear on prior failure; fail if reading is missing or has no steps.
  - Finalize listening in parallel with reading; propagate audio failures; add steps and status events (copyListeningSteps, setListeningAsCompleted) and update phase order/weights, including processingDependencies and writingContent.

- **Refactors**
  - Move phase step groups into activity-generation-phase-step-groups.ts and update phase config to use them.
  - Add new Vercel Blob domain to Next.js image remotePatterns across apps.

<sup>Written for commit 71224b44afe0c2f710a6dc90372e7361b319e7f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

