### PR TITLE
fix(api): allow empty romanization in language story validation

### DIFF
--- a/apps/api/src/workflows/activity-generation/steps/generate-language-story-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-language-story-content-step.ts
@@ -18,7 +18,7 @@ const minimumLanguageStoryContentSchema = z.object({
     .array(
       z.object({
         context: z.string().trim().min(1),
-        contextRomanization: z.string().trim().min(1),
+        contextRomanization: z.string(),
         contextTranslation: z.string().trim().min(1),
         options: z
           .array(
@@ -26,7 +26,7 @@ const minimumLanguageStoryContentSchema = z.object({
               feedback: z.string().trim().min(1),
               isCorrect: z.boolean(),
               text: z.string().trim().min(1),
-              textRomanization: z.string().trim().min(1),
+              textRomanization: z.string(),
             }),
           )
           .min(1),


### PR DESCRIPTION
## Summary

- Relaxed `minimumLanguageStoryContentSchema` to accept empty strings for `contextRomanization` and `textRomanization` fields
- Roman-script languages (Spanish, French, German, etc.) correctly return `""` for romanization, but `.trim().min(1)` validation rejected them, causing the activity to fail despite valid content
- Added integration test verifying language story completes with empty romanization

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow empty romanization fields in language story validation so Roman-script languages no longer fail generation. Adds an integration test to confirm stories complete with empty romanization.

- **Bug Fixes**
  - Relaxed schema to accept "" for contextRomanization and textRomanization.
  - Added integration test covering a Spanish story with empty romanization.

<sup>Written for commit 090f6bf7cd1f2db1b1f31574efc203a61b3be4e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

