### PR TITLE
feat(api): add diagnostic error reasons to workflow step failures

### DIFF
--- a/apps/api/src/workflows/_shared/stream-error.ts
+++ b/apps/api/src/workflows/_shared/stream-error.ts
@@ -1,0 +1,24 @@
+import { sendErrorEmail } from "@zoonk/error-reporter/server";
+import { type WorkflowErrorReason, streamStatus } from "./stream-status";
+
+export async function streamError<T extends string>(params: {
+  reason: WorkflowErrorReason;
+  step: T;
+}): Promise<void> {
+  "use step";
+
+  console.error("[Workflow Error]", JSON.stringify(params));
+
+  await streamStatus({
+    reason: params.reason,
+    status: "error",
+    step: params.step,
+  });
+
+  await sendErrorEmail({
+    message: `${params.step}: ${params.reason}`,
+    name: "WorkflowStepError",
+    routeType: "workflow",
+    source: "server",
+  });
+}

--- a/apps/api/src/workflows/_shared/stream-status.ts
+++ b/apps/api/src/workflows/_shared/stream-status.ts
@@ -2,7 +2,34 @@ import { getWritable } from "workflow";
 
 export type StepStatus = "started" | "completed" | "error";
 
-export async function streamStatus<T extends string>(params: { step: T; status: StepStatus }) {
+export type WorkflowErrorReason =
+  | "aiEmptyResult"
+  | "aiGenerationFailed"
+  | "contentValidationFailed"
+  | "dbFetchFailed"
+  | "dbSaveFailed"
+  | "enrichmentFailed"
+  | "noSourceData"
+  | "notFound";
+
+export function getAIResultErrorReason(
+  error: Error | null | undefined,
+  result: unknown,
+): WorkflowErrorReason {
+  if (error) {
+    return "aiGenerationFailed";
+  }
+  if (!result) {
+    return "aiEmptyResult";
+  }
+  return "contentValidationFailed";
+}
+
+export async function streamStatus<T extends string>(params: {
+  reason?: WorkflowErrorReason;
+  step: T;
+  status: StepStatus;
+}) {
   "use step";
 
   const writable = getWritable<string>();

--- a/apps/api/src/workflows/activity-generation/steps/complete-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/complete-activity-step.ts
@@ -3,7 +3,7 @@ import { revalidateMainApp } from "@zoonk/core/cache/revalidate";
 import { type ActivityKind, prisma } from "@zoonk/db";
 import { cacheTagActivity } from "@zoonk/utils/cache";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
 
@@ -57,7 +57,7 @@ export async function completeActivityStep(
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: stepName });
+    await streamError({ reason: "dbSaveFailed", step: stepName });
     await streamStatus({ status: "error", step: "setActivityAsCompleted" });
     return;
   }

--- a/apps/api/src/workflows/activity-generation/steps/complete-listening-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/complete-listening-activity-step.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@zoonk/db";
-import { streamStatus } from "../stream-status";
+import { streamError } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { completeActivityStep } from "./complete-activity-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
@@ -20,7 +20,7 @@ export async function completeListeningActivityStep(
   const reading = findActivityByKind(activities, "reading");
 
   if (!reading) {
-    await streamStatus({ status: "error", step: "setListeningAsCompleted" });
+    await streamError({ reason: "noSourceData", step: "setListeningAsCompleted" });
     await handleActivityFailureStep({ activityId: listening.id });
     return;
   }
@@ -35,6 +35,6 @@ export async function completeListeningActivityStep(
     return;
   }
 
-  await streamStatus({ status: "error", step: "setListeningAsCompleted" });
+  await streamError({ reason: "noSourceData", step: "setListeningAsCompleted" });
   await handleActivityFailureStep({ activityId: listening.id });
 }

--- a/apps/api/src/workflows/activity-generation/steps/copy-listening-steps-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/copy-listening-steps-step.ts
@@ -1,7 +1,7 @@
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
@@ -35,7 +35,7 @@ export async function copyListeningStepsStep(
   const reading = findActivityByKind(activities, "reading");
 
   if (!reading) {
-    await streamStatus({ status: "error", step: "copyListeningSteps" });
+    await streamError({ reason: "noSourceData", step: "copyListeningSteps" });
     await handleActivityFailureStep({ activityId: listening.id });
     return;
   }
@@ -49,7 +49,7 @@ export async function copyListeningStepsStep(
   await streamStatus({ status: "started", step: "copyListeningSteps" });
 
   if (readingSteps.length === 0) {
-    await streamStatus({ status: "error", step: "copyListeningSteps" });
+    await streamError({ reason: "noSourceData", step: "copyListeningSteps" });
     await handleActivityFailureStep({ activityId: listening.id });
     return;
   }
@@ -72,7 +72,7 @@ export async function copyListeningStepsStep(
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "copyListeningSteps" });
+    await streamError({ reason: "dbSaveFailed", step: "copyListeningSteps" });
     await handleActivityFailureStep({ activityId: listening.id });
     return;
   }

--- a/apps/api/src/workflows/activity-generation/steps/generate-examples-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-examples-content-step.ts
@@ -1,6 +1,6 @@
 import { generateActivityExamples } from "@zoonk/ai/tasks/activities/core/examples";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { resolveActivityForGeneration, saveContentSteps } from "./_utils/content-step-helpers";
 import { type ActivitySteps } from "./_utils/get-activity-steps";
 import { type LessonActivity } from "./get-lesson-activities-step";
@@ -42,7 +42,8 @@ export async function generateExamplesContentStep(
   );
 
   if (error || !result) {
-    await streamStatus({ status: "error", step: "generateExamplesContent" });
+    const reason = error ? "aiGenerationFailed" : "aiEmptyResult";
+    await streamError({ reason, step: "generateExamplesContent" });
     await handleActivityFailureStep({ activityId: activity.id });
     return { steps: [] };
   }
@@ -57,7 +58,7 @@ async function saveAndStreamResult(
   const { error } = await saveContentSteps(activityId, steps);
 
   if (error) {
-    await streamStatus({ status: "error", step: "generateExamplesContent" });
+    await streamError({ reason: "dbSaveFailed", step: "generateExamplesContent" });
     await handleActivityFailureStep({ activityId });
     return { steps: [] };
   }

--- a/apps/api/src/workflows/activity-generation/steps/generate-explanation-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-explanation-content-step.ts
@@ -1,6 +1,6 @@
 import { generateActivityExplanation } from "@zoonk/ai/tasks/activities/core/explanation";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { resolveActivityForGeneration, saveContentSteps } from "./_utils/content-step-helpers";
 import { type ActivitySteps } from "./_utils/get-activity-steps";
 import { type LessonActivity } from "./get-lesson-activities-step";
@@ -42,7 +42,8 @@ export async function generateExplanationContentStep(
   );
 
   if (error || !result) {
-    await streamStatus({ status: "error", step: "generateExplanationContent" });
+    const reason = error ? "aiGenerationFailed" : "aiEmptyResult";
+    await streamError({ reason, step: "generateExplanationContent" });
     await handleActivityFailureStep({ activityId: activity.id });
     return { steps: [] };
   }
@@ -57,7 +58,7 @@ async function saveAndStreamResult(
   const { error } = await saveContentSteps(activityId, steps);
 
   if (error) {
-    await streamStatus({ status: "error", step: "generateExplanationContent" });
+    await streamError({ reason: "dbSaveFailed", step: "generateExplanationContent" });
     await handleActivityFailureStep({ activityId });
     return { steps: [] };
   }

--- a/apps/api/src/workflows/activity-generation/steps/generate-mechanics-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-mechanics-content-step.ts
@@ -1,6 +1,6 @@
 import { generateActivityMechanics } from "@zoonk/ai/tasks/activities/core/mechanics";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { resolveActivityForGeneration, saveContentSteps } from "./_utils/content-step-helpers";
 import { type ActivitySteps } from "./_utils/get-activity-steps";
 import { type LessonActivity } from "./get-lesson-activities-step";
@@ -42,7 +42,8 @@ export async function generateMechanicsContentStep(
   );
 
   if (error || !result) {
-    await streamStatus({ status: "error", step: "generateMechanicsContent" });
+    const reason = error ? "aiGenerationFailed" : "aiEmptyResult";
+    await streamError({ reason, step: "generateMechanicsContent" });
     await handleActivityFailureStep({ activityId: activity.id });
     return { steps: [] };
   }
@@ -57,7 +58,7 @@ async function saveAndStreamResult(
   const { error } = await saveContentSteps(activityId, steps);
 
   if (error) {
-    await streamStatus({ status: "error", step: "generateMechanicsContent" });
+    await streamError({ reason: "dbSaveFailed", step: "generateMechanicsContent" });
     await handleActivityFailureStep({ activityId });
     return { steps: [] };
   }

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.ts
@@ -1,6 +1,6 @@
 import { generateLanguageAudio } from "@zoonk/core/audio/generate";
 import { isTTSSupportedLanguage } from "@zoonk/utils/languages";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
@@ -59,7 +59,7 @@ export async function generateReadingAudioStep(
   );
 
   if (fulfilled.length < savedSentences.length) {
-    await streamStatus({ status: "error", step: "generateAudio" });
+    await streamError({ reason: "enrichmentFailed", step: "generateAudio" });
     await handleActivityFailureStep({ activityId: activity.id });
     return { audioUrls };
   }

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
@@ -1,6 +1,6 @@
 import { generateLanguageAudio } from "@zoonk/core/audio/generate";
 import { isTTSSupportedLanguage } from "@zoonk/utils/languages";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type VocabularyWord } from "./generate-vocabulary-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
@@ -59,7 +59,7 @@ export async function generateVocabularyAudioStep(
   );
 
   if (fulfilled.length < words.length) {
-    await streamStatus({ status: "error", step: "generateVocabularyAudio" });
+    await streamError({ reason: "enrichmentFailed", step: "generateVocabularyAudio" });
     await handleActivityFailureStep({ activityId: activity.id });
     return { audioUrls };
   }

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.ts
@@ -1,6 +1,6 @@
 import { generateActivityVocabulary } from "@zoonk/ai/tasks/activities/language/vocabulary";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { resolveActivityForGeneration } from "./_utils/content-step-helpers";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
@@ -41,13 +41,14 @@ export async function generateVocabularyContentStep(
   );
 
   if (error || !result) {
-    await streamStatus({ status: "error", step: "generateVocabularyContent" });
+    const reason = error ? "aiGenerationFailed" : "aiEmptyResult";
+    await streamError({ reason, step: "generateVocabularyContent" });
     await handleActivityFailureStep({ activityId: activity.id });
     return { words: [] };
   }
 
   if (result.data.words.length === 0) {
-    await streamStatus({ status: "error", step: "generateVocabularyContent" });
+    await streamError({ reason: "contentValidationFailed", step: "generateVocabularyContent" });
     await handleActivityFailureStep({ activityId: activity.id });
     return { words: [] };
   }

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-pronunciation-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-pronunciation-step.ts
@@ -1,6 +1,6 @@
 import { generateActivityPronunciation } from "@zoonk/ai/tasks/activities/language/pronunciation";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type VocabularyWord } from "./generate-vocabulary-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
@@ -51,7 +51,7 @@ export async function generateVocabularyPronunciationStep(
   );
 
   if (fulfilled.length < words.length) {
-    await streamStatus({ status: "error", step: "generateVocabularyPronunciation" });
+    await streamError({ reason: "enrichmentFailed", step: "generateVocabularyPronunciation" });
     await handleActivityFailureStep({ activityId: activity.id });
     return { pronunciations };
   }

--- a/apps/api/src/workflows/activity-generation/steps/get-lesson-activities-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/get-lesson-activities-step.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { FatalError } from "workflow";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 
 async function getLessonActivities(lessonId: number) {
   const activities = await prisma.activity.findMany({
@@ -52,12 +52,12 @@ export async function getLessonActivitiesStep(lessonId: number): Promise<LessonA
   const { data: activities, error } = await safeAsync(() => getLessonActivities(lessonId));
 
   if (error) {
-    await streamStatus({ status: "error", step: "getLessonActivities" });
+    await streamError({ reason: "dbFetchFailed", step: "getLessonActivities" });
     throw error;
   }
 
   if (activities.length === 0) {
-    await streamStatus({ status: "error", step: "getLessonActivities" });
+    await streamError({ reason: "noSourceData", step: "getLessonActivities" });
     throw new FatalError("No activities found for lesson");
   }
 

--- a/apps/api/src/workflows/activity-generation/steps/handle-workflow-failure-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/handle-workflow-failure-step.ts
@@ -1,6 +1,6 @@
+import { streamError } from "@/workflows/_shared/stream-error";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { getWritable } from "workflow";
 
 /**
  * Marks activities left in "running" state by this workflow as failed.
@@ -24,12 +24,5 @@ export async function handleWorkflowFailureStep(
     }),
   );
 
-  const writable = getWritable<string>();
-  const writer = writable.getWriter();
-
-  try {
-    await writer.write(`data: ${JSON.stringify({ status: "error", step: "workflowError" })}\n\n`);
-  } finally {
-    writer.releaseLock();
-  }
+  await streamError({ reason: "aiGenerationFailed", step: "workflowError" });
 }

--- a/apps/api/src/workflows/activity-generation/steps/save-custom-activities-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-custom-activities-step.ts
@@ -2,7 +2,7 @@ import { revalidateMainApp } from "@zoonk/core/cache/revalidate";
 import { prisma } from "@zoonk/db";
 import { cacheTagActivity } from "@zoonk/utils/cache";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type LessonActivity } from "./get-lesson-activities-step";
 
 async function saveActivity(activity: LessonActivity, workflowRunId: string): Promise<boolean> {
@@ -54,7 +54,7 @@ export async function saveCustomActivitiesStep(
   );
 
   if (hasFailure) {
-    await streamStatus({ status: "error", step: "setCustomAsCompleted" });
+    await streamError({ reason: "dbSaveFailed", step: "setCustomAsCompleted" });
     await streamStatus({ status: "error", step: "setActivityAsCompleted" });
     return;
   }

--- a/apps/api/src/workflows/activity-generation/steps/save-reading-sentences-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-reading-sentences-step.ts
@@ -1,7 +1,7 @@
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type ReadingSentence } from "./generate-reading-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
@@ -99,7 +99,7 @@ export async function saveReadingSentencesStep(
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "saveSentences" });
+    await streamError({ reason: "dbSaveFailed", step: "saveSentences" });
     await handleActivityFailureStep({ activityId: activity.id });
     return { savedSentences: [] };
   }

--- a/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
@@ -1,7 +1,7 @@
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type VocabularyWord } from "./generate-vocabulary-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
@@ -94,7 +94,7 @@ export async function saveVocabularyWordsStep(
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "saveVocabularyWords" });
+    await streamError({ reason: "dbSaveFailed", step: "saveVocabularyWords" });
     await handleActivityFailureStep({ activityId: activity.id });
     return { savedWords: [] };
   }

--- a/apps/api/src/workflows/activity-generation/steps/set-activity-as-running-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/set-activity-as-running-step.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 
 export async function setActivityAsRunningStep(input: {
   activityId: bigint | number;
@@ -22,7 +22,7 @@ export async function setActivityAsRunningStep(input: {
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "setActivityAsRunning" });
+    await streamError({ reason: "dbSaveFailed", step: "setActivityAsRunning" });
     throw error;
   }
 

--- a/apps/api/src/workflows/activity-generation/steps/update-reading-enrichments-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/update-reading-enrichments-step.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
@@ -33,7 +33,7 @@ export async function updateReadingEnrichmentsStep(
   const { error } = await safeAsync(() => prisma.$transaction(updates));
 
   if (error) {
-    await streamStatus({ status: "error", step: "updateSentenceEnrichments" });
+    await streamError({ reason: "dbSaveFailed", step: "updateSentenceEnrichments" });
     await handleActivityFailureStep({ activityId: activity.id });
     return;
   }

--- a/apps/api/src/workflows/activity-generation/steps/update-vocabulary-enrichments-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/update-vocabulary-enrichments-step.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
@@ -34,7 +34,7 @@ export async function updateVocabularyEnrichmentsStep(
   const { error } = await safeAsync(() => prisma.$transaction(updates));
 
   if (error) {
-    await streamStatus({ status: "error", step: "updateVocabularyEnrichments" });
+    await streamError({ reason: "dbSaveFailed", step: "updateVocabularyEnrichments" });
     await handleActivityFailureStep({ activityId: activity.id });
     return;
   }

--- a/apps/api/src/workflows/activity-generation/stream-status.ts
+++ b/apps/api/src/workflows/activity-generation/stream-status.ts
@@ -1,10 +1,24 @@
+import { streamError as sharedStreamError } from "@/workflows/_shared/stream-error";
 import {
   type StepStatus,
+  type WorkflowErrorReason,
   streamStatus as sharedStreamStatus,
 } from "@/workflows/_shared/stream-status";
 import { type ActivityStepName } from "@/workflows/config";
 
-export async function streamStatus(params: { step: ActivityStepName; status: StepStatus }) {
+export async function streamStatus(params: {
+  reason?: WorkflowErrorReason;
+  step: ActivityStepName;
+  status: StepStatus;
+}) {
   "use step";
   return sharedStreamStatus(params);
+}
+
+export async function streamError(params: {
+  reason: WorkflowErrorReason;
+  step: ActivityStepName;
+}): Promise<void> {
+  "use step";
+  return sharedStreamError(params);
 }

--- a/apps/api/src/workflows/chapter-generation/steps/add-lessons-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/add-lessons-step.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { normalizeString, toSlug } from "@zoonk/utils/string";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type GeneratedLesson } from "./generate-lessons-step";
 import { type ChapterContext } from "./get-chapter-step";
 
@@ -41,7 +41,7 @@ export async function addLessonsStep(input: {
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "addLessons" });
+    await streamError({ reason: "dbSaveFailed", step: "addLessons" });
     throw error;
   }
 

--- a/apps/api/src/workflows/chapter-generation/steps/generate-lessons-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/generate-lessons-step.ts
@@ -1,7 +1,7 @@
 import { generateLanguageChapterLessons } from "@zoonk/ai/tasks/chapters/language-lessons";
 import { generateChapterLessons } from "@zoonk/ai/tasks/chapters/lessons";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type ChapterContext } from "./get-chapter-step";
 
 export type GeneratedLesson = {
@@ -36,7 +36,7 @@ export async function generateLessonsStep(context: ChapterContext): Promise<Gene
   const { data: result, error } = await safeAsync(() => generateLessons(context));
 
   if (error) {
-    await streamStatus({ status: "error", step: "generateLessons" });
+    await streamError({ reason: "aiGenerationFailed", step: "generateLessons" });
     throw error;
   }
 

--- a/apps/api/src/workflows/chapter-generation/steps/get-chapter-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/get-chapter-step.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { FatalError } from "workflow";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 
 async function getChapterForGeneration(chapterId: number) {
   return prisma.chapter.findUnique({
@@ -40,7 +40,7 @@ export async function getChapterStep(chapterId: number): Promise<ChapterContext>
   const chapter = await getChapterForGeneration(chapterId);
 
   if (!chapter) {
-    await streamStatus({ status: "error", step: "getChapter" });
+    await streamError({ reason: "notFound", step: "getChapter" });
     throw new FatalError("Chapter not found");
   }
 

--- a/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-completed-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-completed-step.ts
@@ -2,7 +2,7 @@ import { revalidateMainApp } from "@zoonk/core/cache/revalidate";
 import { prisma } from "@zoonk/db";
 import { cacheTagChapter } from "@zoonk/utils/cache";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type ChapterContext } from "./get-chapter-step";
 
 export async function setChapterAsCompletedStep(input: {
@@ -25,7 +25,7 @@ export async function setChapterAsCompletedStep(input: {
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "setChapterAsCompleted" });
+    await streamError({ reason: "dbSaveFailed", step: "setChapterAsCompleted" });
     throw error;
   }
 

--- a/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-running-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-running-step.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 
 export async function setChapterAsRunningStep(input: {
   chapterId: number;
@@ -22,7 +22,7 @@ export async function setChapterAsRunningStep(input: {
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "setChapterAsRunning" });
+    await streamError({ reason: "dbSaveFailed", step: "setChapterAsRunning" });
     throw error;
   }
 

--- a/apps/api/src/workflows/chapter-generation/stream-status.ts
+++ b/apps/api/src/workflows/chapter-generation/stream-status.ts
@@ -1,10 +1,24 @@
+import { streamError as sharedStreamError } from "@/workflows/_shared/stream-error";
 import {
   type StepStatus,
+  type WorkflowErrorReason,
   streamStatus as sharedStreamStatus,
 } from "@/workflows/_shared/stream-status";
 import { type ChapterStepName } from "@/workflows/config";
 
-export async function streamStatus(params: { step: ChapterStepName; status: StepStatus }) {
+export async function streamStatus(params: {
+  reason?: WorkflowErrorReason;
+  step: ChapterStepName;
+  status: StepStatus;
+}) {
   "use step";
   return sharedStreamStatus(params);
+}
+
+export async function streamError(params: {
+  reason: WorkflowErrorReason;
+  step: ChapterStepName;
+}): Promise<void> {
+  "use step";
+  return sharedStreamError(params);
 }

--- a/apps/api/src/workflows/course-generation/steps/add-alternative-titles-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/add-alternative-titles-step.ts
@@ -1,5 +1,5 @@
 import { addAlternativeTitles } from "@zoonk/core/alternative-titles/add";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type CourseContext } from "../types";
 
 export async function addAlternativeTitlesStep(input: {
@@ -17,7 +17,7 @@ export async function addAlternativeTitlesStep(input: {
   });
 
   if (error) {
-    await streamStatus({ status: "error", step: "addAlternativeTitles" });
+    await streamError({ reason: "dbSaveFailed", step: "addAlternativeTitles" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/add-categories-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/add-categories-step.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type CourseContext } from "../types";
 
 export async function addCategoriesStep(input: {
@@ -24,7 +24,7 @@ export async function addCategoriesStep(input: {
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "addCategories" });
+    await streamError({ reason: "dbSaveFailed", step: "addCategories" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/add-chapters-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/add-chapters-step.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { normalizeString, toSlug } from "@zoonk/utils/string";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type CourseContext, type CreatedChapter, type GeneratedChapter } from "../types";
 
 export async function addChaptersStep(input: {
@@ -39,7 +39,7 @@ export async function addChaptersStep(input: {
   );
 
   if (error || !createdChapters) {
-    await streamStatus({ status: "error", step: "addChapters" });
+    await streamError({ reason: "dbSaveFailed", step: "addChapters" });
     throw error ?? new Error("Failed to create chapters");
   }
 

--- a/apps/api/src/workflows/course-generation/steps/check-existing-course-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/check-existing-course-step.ts
@@ -2,7 +2,7 @@ import { prisma } from "@zoonk/db";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { safeAsync } from "@zoonk/utils/error";
 import { toSlug } from "@zoonk/utils/string";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type CourseSuggestionData } from "../types";
 
 export type ExistingCourse = {
@@ -66,7 +66,7 @@ export async function checkExistingCourseStep(
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "checkExistingCourse" });
+    await streamError({ reason: "dbFetchFailed", step: "checkExistingCourse" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 
 export async function completeCourseSetupStep(input: {
   courseSuggestionId: number;
@@ -28,7 +28,7 @@ export async function completeCourseSetupStep(input: {
   const error = courseResult.error || suggestionResult.error;
 
   if (error) {
-    await streamStatus({ status: "error", step: "completeCourseSetup" });
+    await streamError({ reason: "dbSaveFailed", step: "completeCourseSetup" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/generate-alternative-titles-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-alternative-titles-step.ts
@@ -1,6 +1,6 @@
 import { generateAlternativeTitles } from "@zoonk/ai/tasks/courses/alternative-titles";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type CourseContext } from "../types";
 
 export async function generateAlternativeTitlesStep(course: CourseContext): Promise<string[]> {
@@ -16,7 +16,7 @@ export async function generateAlternativeTitlesStep(course: CourseContext): Prom
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "generateAlternativeTitles" });
+    await streamError({ reason: "aiGenerationFailed", step: "generateAlternativeTitles" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/generate-categories-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-categories-step.ts
@@ -1,6 +1,6 @@
 import { generateCourseCategories } from "@zoonk/ai/tasks/courses/categories";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type CourseContext } from "../types";
 
 export async function generateCategoriesStep(course: CourseContext): Promise<string[]> {
@@ -15,7 +15,7 @@ export async function generateCategoriesStep(course: CourseContext): Promise<str
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "generateCategories" });
+    await streamError({ reason: "aiGenerationFailed", step: "generateCategories" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/generate-chapters-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-chapters-step.ts
@@ -1,7 +1,7 @@
 import { generateCourseChapters } from "@zoonk/ai/tasks/courses/chapters";
 import { generateLanguageCourseChapters } from "@zoonk/ai/tasks/courses/language-chapters";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type CourseContext, type GeneratedChapter } from "../types";
 
 function generateChapters(course: CourseContext) {
@@ -27,7 +27,7 @@ export async function generateChaptersStep(course: CourseContext): Promise<Gener
   const { data: result, error } = await safeAsync(() => generateChapters(course));
 
   if (error) {
-    await streamStatus({ status: "error", step: "generateChapters" });
+    await streamError({ reason: "aiGenerationFailed", step: "generateChapters" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/generate-description-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-description-step.ts
@@ -1,6 +1,6 @@
 import { generateCourseDescription } from "@zoonk/ai/tasks/courses/description";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type CourseContext } from "../types";
 
 export async function generateDescriptionStep(course: CourseContext): Promise<string> {
@@ -16,7 +16,7 @@ export async function generateDescriptionStep(course: CourseContext): Promise<st
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "generateDescription" });
+    await streamError({ reason: "aiGenerationFailed", step: "generateDescription" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/get-course-chapters-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/get-course-chapters-step.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type CreatedChapter } from "../types";
 
 export async function getCourseChaptersStep(courseId: number): Promise<CreatedChapter[]> {
@@ -23,7 +23,7 @@ export async function getCourseChaptersStep(courseId: number): Promise<CreatedCh
   );
 
   if (error || !chapters) {
-    await streamStatus({ status: "error", step: "getExistingChapters" });
+    await streamError({ reason: "dbFetchFailed", step: "getExistingChapters" });
     throw error ?? new Error("Failed to fetch existing chapters");
   }
 

--- a/apps/api/src/workflows/course-generation/steps/get-course-suggestion-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/get-course-suggestion-step.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { FatalError } from "workflow";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type CourseSuggestionData } from "../types";
 
 export async function getCourseSuggestionStep(
@@ -24,7 +24,7 @@ export async function getCourseSuggestionStep(
   });
 
   if (!suggestion) {
-    await streamStatus({ status: "error", step: "getCourseSuggestion" });
+    await streamError({ reason: "notFound", step: "getCourseSuggestion" });
     throw new FatalError("Course suggestion not found");
   }
 

--- a/apps/api/src/workflows/course-generation/steps/initialize-course-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/initialize-course-step.ts
@@ -2,7 +2,7 @@ import { prisma } from "@zoonk/db";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { safeAsync } from "@zoonk/utils/error";
 import { normalizeString, toSlug } from "@zoonk/utils/string";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type CourseContext, type CourseSuggestionData } from "../types";
 
 export async function initializeCourseStep(input: {
@@ -32,7 +32,7 @@ export async function initializeCourseStep(input: {
   );
 
   if (updateError) {
-    await streamStatus({ status: "error", step: "initializeCourse" });
+    await streamError({ reason: "dbSaveFailed", step: "initializeCourse" });
     throw updateError;
   }
 
@@ -58,7 +58,7 @@ export async function initializeCourseStep(input: {
   );
 
   if (createError || !course) {
-    await streamStatus({ status: "error", step: "initializeCourse" });
+    await streamError({ reason: "dbSaveFailed", step: "initializeCourse" });
     throw createError ?? new Error("Failed to create course");
   }
 

--- a/apps/api/src/workflows/course-generation/steps/set-course-as-running-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/set-course-as-running-step.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 
 export async function setCourseAsRunningStep(input: {
   courseId: number;
@@ -32,7 +32,7 @@ export async function setCourseAsRunningStep(input: {
   const error = courseResult.error || suggestionResult.error;
 
   if (error) {
-    await streamStatus({ status: "error", step: "setCourseAsRunning" });
+    await streamError({ reason: "dbSaveFailed", step: "setCourseAsRunning" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/update-course-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/update-course-step.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type CourseContext } from "../types";
 
 export async function updateCourseStep(input: {
@@ -24,7 +24,7 @@ export async function updateCourseStep(input: {
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "updateCourse" });
+    await streamError({ reason: "dbSaveFailed", step: "updateCourse" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/stream-status.ts
+++ b/apps/api/src/workflows/course-generation/stream-status.ts
@@ -1,10 +1,24 @@
+import { streamError as sharedStreamError } from "@/workflows/_shared/stream-error";
 import {
   type StepStatus,
+  type WorkflowErrorReason,
   streamStatus as sharedStreamStatus,
 } from "@/workflows/_shared/stream-status";
 import { type CourseWorkflowStepName } from "@/workflows/config";
 
-export async function streamStatus(params: { step: CourseWorkflowStepName; status: StepStatus }) {
+export async function streamStatus(params: {
+  reason?: WorkflowErrorReason;
+  step: CourseWorkflowStepName;
+  status: StepStatus;
+}) {
   "use step";
   return sharedStreamStatus(params);
+}
+
+export async function streamError(params: {
+  reason: WorkflowErrorReason;
+  step: CourseWorkflowStepName;
+}): Promise<void> {
+  "use step";
+  return sharedStreamError(params);
 }

--- a/apps/api/src/workflows/lesson-generation/steps/add-activities-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/add-activities-step.ts
@@ -1,7 +1,7 @@
 import { type ActivityKind, type LessonKind, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { isTTSSupportedLanguage } from "@zoonk/utils/languages";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type GeneratedActivity } from "./generate-custom-activities-step";
 import { type LessonContext } from "./get-lesson-step";
 
@@ -96,7 +96,7 @@ export async function addActivitiesStep(input: {
   const { error } = await safeAsync(() => prisma.activity.createMany({ data: activitiesData }));
 
   if (error) {
-    await streamStatus({ status: "error", step: "addActivities" });
+    await streamError({ reason: "dbSaveFailed", step: "addActivities" });
     throw error;
   }
 

--- a/apps/api/src/workflows/lesson-generation/steps/determine-lesson-kind-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/determine-lesson-kind-step.ts
@@ -1,7 +1,7 @@
 import { generateLessonKind } from "@zoonk/ai/tasks/lessons/kind";
 import { type LessonKind } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type LessonContext } from "./get-lesson-step";
 
 export async function determineLessonKindStep(context: LessonContext): Promise<LessonKind> {
@@ -20,7 +20,7 @@ export async function determineLessonKindStep(context: LessonContext): Promise<L
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "determineLessonKind" });
+    await streamError({ reason: "aiGenerationFailed", step: "determineLessonKind" });
     throw error;
   }
 

--- a/apps/api/src/workflows/lesson-generation/steps/generate-custom-activities-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-custom-activities-step.ts
@@ -1,6 +1,6 @@
 import { generateLessonActivities } from "@zoonk/ai/tasks/lessons/activities";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type LessonContext } from "./get-lesson-step";
 
 export type GeneratedActivity = {
@@ -26,7 +26,7 @@ export async function generateCustomActivitiesStep(
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "generateCustomActivities" });
+    await streamError({ reason: "aiGenerationFailed", step: "generateCustomActivities" });
     throw error;
   }
 

--- a/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { FatalError } from "workflow";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 
 async function getLessonForGeneration(lessonId: number) {
   return prisma.lesson.findUnique({
@@ -45,7 +45,7 @@ export async function getLessonStep(lessonId: number): Promise<LessonContext> {
   const lesson = await getLessonForGeneration(lessonId);
 
   if (!lesson) {
-    await streamStatus({ status: "error", step: "getLesson" });
+    await streamError({ reason: "notFound", step: "getLesson" });
     throw new FatalError("Lesson not found");
   }
 

--- a/apps/api/src/workflows/lesson-generation/steps/remove-non-language-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/remove-non-language-lesson-step.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 
 export async function removeNonLanguageLessonStep(input: { lessonId: number }): Promise<void> {
   "use step";
@@ -10,7 +10,7 @@ export async function removeNonLanguageLessonStep(input: { lessonId: number }): 
   const { error } = await safeAsync(() => prisma.lesson.delete({ where: { id: input.lessonId } }));
 
   if (error) {
-    await streamStatus({ status: "error", step: "removeNonLanguageLesson" });
+    await streamError({ reason: "dbSaveFailed", step: "removeNonLanguageLesson" });
     throw error;
   }
 

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-completed-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-completed-step.ts
@@ -2,7 +2,7 @@ import { revalidateMainApp } from "@zoonk/core/cache/revalidate";
 import { prisma } from "@zoonk/db";
 import { cacheTagLesson } from "@zoonk/utils/cache";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 import { type LessonContext } from "./get-lesson-step";
 
 export async function setLessonAsCompletedStep(input: {
@@ -25,7 +25,7 @@ export async function setLessonAsCompletedStep(input: {
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "setLessonAsCompleted" });
+    await streamError({ reason: "dbSaveFailed", step: "setLessonAsCompleted" });
     throw error;
   }
 

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 
 export async function setLessonAsRunningStep(input: {
   lessonId: number;
@@ -22,7 +22,7 @@ export async function setLessonAsRunningStep(input: {
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "setLessonAsRunning" });
+    await streamError({ reason: "dbSaveFailed", step: "setLessonAsRunning" });
     throw error;
   }
 

--- a/apps/api/src/workflows/lesson-generation/steps/update-lesson-kind-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/update-lesson-kind-step.ts
@@ -1,6 +1,6 @@
 import { type LessonKind, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { streamStatus } from "../stream-status";
+import { streamError, streamStatus } from "../stream-status";
 
 export async function updateLessonKindStep(input: {
   lessonId: number;
@@ -19,7 +19,7 @@ export async function updateLessonKindStep(input: {
   );
 
   if (error) {
-    await streamStatus({ status: "error", step: "updateLessonKind" });
+    await streamError({ reason: "dbSaveFailed", step: "updateLessonKind" });
     throw error;
   }
 

--- a/apps/api/src/workflows/lesson-generation/stream-status.ts
+++ b/apps/api/src/workflows/lesson-generation/stream-status.ts
@@ -1,10 +1,24 @@
+import { streamError as sharedStreamError } from "@/workflows/_shared/stream-error";
 import {
   type StepStatus,
+  type WorkflowErrorReason,
   streamStatus as sharedStreamStatus,
 } from "@/workflows/_shared/stream-status";
 import { type LessonStepName } from "@/workflows/config";
 
-export async function streamStatus(params: { step: LessonStepName; status: StepStatus }) {
+export async function streamStatus(params: {
+  reason?: WorkflowErrorReason;
+  step: LessonStepName;
+  status: StepStatus;
+}) {
   "use step";
   return sharedStreamStatus(params);
+}
+
+export async function streamError(params: {
+  reason: WorkflowErrorReason;
+  step: LessonStepName;
+}): Promise<void> {
+  "use step";
+  return sharedStreamError(params);
 }

--- a/apps/main/e2e/generate-activity.test.ts
+++ b/apps/main/e2e/generate-activity.test.ts
@@ -27,14 +27,14 @@ const TEST_USER_EMAIL = "e2e-new@zoonk.test";
 type MockApiOptions = {
   triggerResponse?: { runId?: string; error?: string; status?: number };
   streamDelayMs?: number;
-  streamMessages?: { step: string; status: string }[];
+  streamMessages?: { reason?: string; step: string; status: string }[];
   streamError?: boolean;
 };
 
 /**
  * Creates a mock SSE stream response from an array of messages.
  */
-function createSSEStream(messages: { step: string; status: string }[]): string {
+function createSSEStream(messages: { reason?: string; step: string; status: string }[]): string {
   return messages.map((msg) => `data: ${JSON.stringify(msg)}\n\n`).join("");
 }
 
@@ -1261,7 +1261,7 @@ test.describe("Generate Activity Page - With Subscription", () => {
     await setupMockApis(userWithoutProgress, {
       streamMessages: [
         { status: "started", step: "getLessonActivities" },
-        { status: "error", step: "getLessonActivities" },
+        { reason: "dbFetchFailed", status: "error", step: "getLessonActivities" },
       ],
     });
 
@@ -1318,7 +1318,7 @@ test.describe("Generate Activity Page - With Subscription", () => {
     await setupMockApis(userWithoutProgress, {
       streamMessages: [
         { status: "started", step: "getLessonActivities" },
-        { status: "error", step: "workflowError" },
+        { reason: "aiGenerationFailed", status: "error", step: "workflowError" },
       ],
     });
 

--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -25,7 +25,7 @@ const TEST_USER_EMAIL = "e2e-new@zoonk.test";
 
 type MockApiOptions = {
   triggerResponse?: { runId?: string; error?: string; status?: number };
-  streamMessages?: { step: string; status: string }[];
+  streamMessages?: { reason?: string; step: string; status: string }[];
   streamError?: boolean;
   statusDelayMs?: number;
 };
@@ -33,7 +33,7 @@ type MockApiOptions = {
 /**
  * Creates a mock SSE stream response from an array of messages.
  */
-function createSSEStream(messages: { step: string; status: string }[]): string {
+function createSSEStream(messages: { reason?: string; step: string; status: string }[]): string {
   return messages.map((msg) => `data: ${JSON.stringify(msg)}\n\n`).join("");
 }
 
@@ -330,7 +330,7 @@ test.describe("Generate Chapter Page - With Subscription", () => {
     await setupMockApis(userWithoutProgress, {
       streamMessages: [
         { status: "started", step: "getChapter" },
-        { status: "error", step: "getChapter" },
+        { reason: "notFound", status: "error", step: "getChapter" },
       ],
     });
 

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -28,7 +28,7 @@ const TEST_RUN_ID = "test-run-id-12345";
 
 type MockApiOptions = {
   triggerResponse?: { runId?: string; error?: string; status?: number };
-  streamMessages?: { step: string; status: string }[];
+  streamMessages?: { reason?: string; step: string; status: string }[];
   streamError?: boolean;
   statusDelayMs?: number;
 };
@@ -37,7 +37,7 @@ type MockApiOptions = {
  * Creates a mock SSE stream response from an array of messages.
  * Each message follows the SSE format: "data: {...}\n\n"
  */
-function createSSEStream(messages: { step: string; status: string }[]): string {
+function createSSEStream(messages: { reason?: string; step: string; status: string }[]): string {
   return messages.map((msg) => `data: ${JSON.stringify(msg)}\n\n`).join("");
 }
 
@@ -233,7 +233,7 @@ test.describe("Generate Course Page", () => {
       await navigateWithMocks(page, {
         streamMessages: [
           { status: "started", step: "getCourseSuggestion" },
-          { status: "error", step: "getCourseSuggestion" },
+          { reason: "notFound", status: "error", step: "getCourseSuggestion" },
         ],
       });
 

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -26,14 +26,14 @@ const TEST_USER_EMAIL = "e2e-new@zoonk.test";
 
 type MockApiOptions = {
   triggerResponse?: { runId?: string; error?: string; status?: number };
-  streamMessages?: { step: string; status: string }[];
+  streamMessages?: { reason?: string; step: string; status: string }[];
   streamError?: boolean;
 };
 
 /**
  * Creates a mock SSE stream response from an array of messages.
  */
-function createSSEStream(messages: { step: string; status: string }[]): string {
+function createSSEStream(messages: { reason?: string; step: string; status: string }[]): string {
   return messages.map((msg) => `data: ${JSON.stringify(msg)}\n\n`).join("");
 }
 
@@ -263,7 +263,7 @@ test.describe("Generate Lesson Page - With Subscription", () => {
     await setupMockApis(userWithoutProgress, {
       streamMessages: [
         { status: "started", step: "getLesson" },
-        { status: "error", step: "getLesson" },
+        { reason: "notFound", status: "error", step: "getLesson" },
       ],
     });
 

--- a/apps/main/src/lib/workflow/generation-store.test.ts
+++ b/apps/main/src/lib/workflow/generation-store.test.ts
@@ -88,11 +88,23 @@ describe(handleStreamMessage, () => {
     expect(store.getSnapshot().context.status).toBe("streaming");
   });
 
-  it("routes 'error' to setError", () => {
+  it("routes 'error' to setError with step name", () => {
     const store = createGenerationStore<"stepA">();
     const message: StreamMessage<"stepA"> = { status: "error", step: "stepA" };
     handleStreamMessage(message, store);
     expect(store.getSnapshot().context.status).toBe("error");
-    expect(store.getSnapshot().context.error).toBe("Step failed");
+    expect(store.getSnapshot().context.error).toBe('Step "stepA" failed');
+  });
+
+  it("routes 'error' with reason to setError", () => {
+    const store = createGenerationStore<"stepA">();
+    const message: StreamMessage<"stepA"> = {
+      reason: "aiGenerationFailed",
+      status: "error",
+      step: "stepA",
+    };
+    handleStreamMessage(message, store);
+    expect(store.getSnapshot().context.status).toBe("error");
+    expect(store.getSnapshot().context.error).toBe("stepA: aiGenerationFailed");
   });
 });

--- a/apps/main/src/lib/workflow/generation-store.ts
+++ b/apps/main/src/lib/workflow/generation-store.ts
@@ -4,6 +4,7 @@ export type StepStatus = "started" | "completed" | "error";
 export type GenerationStatus = "idle" | "triggering" | "streaming" | "completed" | "error";
 
 export type StreamMessage<TStep extends string = string> = {
+  reason?: string;
   step: TStep;
   status: StepStatus;
 };
@@ -96,9 +97,13 @@ export function handleStreamMessage<TStep extends string>(
         store.send({ type: "workflowCompleted" });
       }
       break;
-    case "error":
-      store.send({ error: "Step failed", type: "setError" });
+    case "error": {
+      const errorMessage = message.reason
+        ? `${message.step}: ${message.reason}`
+        : `Step "${message.step}" failed`;
+      store.send({ error: errorMessage, type: "setError" });
       break;
+    }
     default: {
       const exhaustiveCheck: never = message.status;
       throw new Error(`Unexpected status: ${String(exhaustiveCheck)}`);


### PR DESCRIPTION
## Summary

- Add typed `WorkflowErrorReason` union with 8 reason codes (`aiGenerationFailed`, `aiEmptyResult`, `contentValidationFailed`, `dbFetchFailed`, `dbSaveFailed`, `enrichmentFailed`, `noSourceData`, `notFound`)
- Create `streamError` helper that combines error streaming + `console.error` + `sendErrorEmail` in a single call
- Replace all ~65 `streamStatus({ status: "error" })` calls with `streamError({ reason, step })` across activity, course, chapter, and lesson workflows
- Display reason codes in the client-side error UI (e.g. `"generateExplanationContent: aiGenerationFailed"` instead of `"Step failed"`)

## Test plan

- [x] Unit test: error without reason shows `Step "stepA" failed`
- [x] Unit test: error with reason shows `stepA: aiGenerationFailed`
- [x] E2E: mock SSE error messages include reason field
- [x] All 182 unit tests pass
- [x] All 197 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add diagnostic error reasons to workflow step failures and surface them in the UI to make debugging faster. Introduces a streamError helper that streams, logs, and emails errors in one call.

- New Features
  - Typed WorkflowErrorReason with 8 codes: aiGenerationFailed, aiEmptyResult, contentValidationFailed, dbFetchFailed, dbSaveFailed, enrichmentFailed, noSourceData, notFound
  - streamError helper combines SSE streaming, console.error, and sendErrorEmail
  - SSE messages and client errors now include a reason (e.g., generateExplanationContent: aiGenerationFailed)

- Refactors
  - Replaced ~65 streamStatus({ status: "error" }) calls with streamError across activity, lesson, chapter, and course workflows
  - Added getAIResultErrorReason to standardize generation error mapping
  - Updated unit and e2e tests to assert the new reason field

<sup>Written for commit d161f21b131247c0b6810b91ed67093ec3c3a8ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

