### PR TITLE
refactor(core): add kind discriminator to multiple choice content schema

### DIFF
--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
@@ -1675,6 +1675,7 @@ describe("core activity workflow", () => {
       expect(storySteps[0]?.kind).toBe("multipleChoice");
       expect(storySteps[0]?.content).toEqual({
         context: "Your colleague turns to you during a meeting...",
+        kind: "core",
         options: [
           { feedback: "Great choice!", isCorrect: true, text: "Option A" },
           { feedback: "Not quite.", isCorrect: false, text: "Option B" },
@@ -1933,6 +1934,7 @@ describe("core activity workflow", () => {
       expect(challengeSteps[0]?.kind).toBe("multipleChoice");
       expect(challengeSteps[0]?.content).toEqual({
         context: "Your team lead asks you to choose...",
+        kind: "challenge",
         options: [
           {
             consequence: "Great outcome",
@@ -2256,6 +2258,7 @@ describe("core activity workflow", () => {
       expect(reviewSteps[0]?.kind).toBe("multipleChoice");
       expect(reviewSteps[0]?.content).toEqual({
         context: "Review context about the lesson content...",
+        kind: "core",
         options: [
           { feedback: "Correct!", isCorrect: true, text: "Option A" },
           { feedback: "Not quite.", isCorrect: false, text: "Option B" },
@@ -2495,6 +2498,7 @@ describe("core activity workflow", () => {
         activityId: quizActivity.id,
         content: {
           context: "Test",
+          kind: "core",
           options: [{ feedback: "Yes", isCorrect: true, text: "A" }],
           question: "Q?",
         },

--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
@@ -822,6 +822,7 @@ describe("language activity generation", () => {
     });
 
     expect(steps[2]?.content).toEqual({
+      kind: "core",
       options: [
         { feedback: "Correct", isCorrect: true, text: "Pattern A" },
         { feedback: "Try again", isCorrect: false, text: "Pattern B" },
@@ -1104,6 +1105,7 @@ describe("language activity generation", () => {
       context: "The clerk smiles and asks what you'd like to drink.",
       contextRomanization: "The clerk smiles and asks what you'd like to drink.",
       contextTranslation: "The clerk smiles and asks what you'd like to drink.",
+      kind: "language",
       options: [
         {
           feedback: "Perfectly polite and natural.",

--- a/apps/api/src/workflows/activity-generation/steps/generate-challenge-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-challenge-content-step.ts
@@ -27,6 +27,7 @@ async function saveChallengeSteps(
         data: steps.map((step, index) => {
           const content = assertStepContent("multipleChoice", {
             context: step.context,
+            kind: "challenge",
             options: step.options,
             question: step.question,
           });

--- a/apps/api/src/workflows/activity-generation/steps/generate-grammar-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-grammar-content-step.ts
@@ -70,6 +70,7 @@ function buildGrammarSteps(activityId: bigint | number, data: ActivityGrammarSch
     activityId,
     content: assertStepContent("multipleChoice", {
       ...(discoveryContext ? { context: discoveryContext } : {}),
+      kind: "core",
       options: data.discovery.options,
       ...(discoveryQuestion ? { question: discoveryQuestion } : {}),
     }),

--- a/apps/api/src/workflows/activity-generation/steps/generate-language-story-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-language-story-content-step.ts
@@ -61,6 +61,7 @@ function buildLanguageStorySteps(activityId: bigint | number, data: ActivityStor
       context: step.context,
       contextRomanization: step.contextRomanization,
       contextTranslation: step.contextTranslation,
+      kind: "language",
       options: step.options.map((option) => ({
         feedback: option.feedback,
         isCorrect: option.isCorrect,

--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-content-step.ts
@@ -25,10 +25,14 @@ async function saveQuizSteps(
     prisma.step.createMany({
       data: questions.map((question, index) => {
         const { format, ...rawContent } = question;
+        const content =
+          format === "multipleChoice"
+            ? assertStepContent(format, { ...rawContent, kind: "core" })
+            : assertStepContent(format, rawContent);
 
         return {
           activityId,
-          content: assertStepContent(format, rawContent),
+          content,
           kind: format,
           position: index,
         };

--- a/apps/api/src/workflows/activity-generation/steps/generate-review-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-review-content-step.ts
@@ -27,6 +27,7 @@ async function saveReviewSteps(
       data: questions.map((question, index) => {
         const content = assertStepContent("multipleChoice", {
           context: question.context,
+          kind: "core",
           options: question.options,
           question: question.question,
         });

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.ts
@@ -27,6 +27,7 @@ async function saveStorySteps(
       data: steps.map((step, index) => {
         const content = assertStepContent("multipleChoice", {
           context: step.context,
+          kind: "core",
           options: step.options,
           question: step.question,
         });

--- a/apps/main/src/data/progress/get-best-time.test.ts
+++ b/apps/main/src/data/progress/get-best-time.test.ts
@@ -68,7 +68,10 @@ async function createTestStep(orgId: number) {
   const step = await prisma.step.create({
     data: {
       activityId: activity.id,
-      content: {},
+      content: {
+        kind: "core",
+        options: [{ feedback: "Yes", isCorrect: true, text: "A" }],
+      },
       kind: "multipleChoice",
       position: 0,
     },

--- a/packages/core/src/steps/content-contract.test.ts
+++ b/packages/core/src/steps/content-contract.test.ts
@@ -130,12 +130,28 @@ describe("step content contracts", () => {
     ).toThrow();
   });
 
-  test("rejects language without required romanization fields", () => {
+  test("parses language without optional romanization fields", () => {
+    const content = parseStepContent("multipleChoice", {
+      context: "Context",
+      contextTranslation: "Translation",
+      kind: "language",
+      options: [{ feedback: "Great", isCorrect: true, text: "A" }],
+    });
+
+    expect(content).toEqual({
+      context: "Context",
+      contextTranslation: "Translation",
+      kind: "language",
+      options: [{ feedback: "Great", isCorrect: true, text: "A" }],
+    });
+  });
+
+  test("rejects language without required contextTranslation", () => {
     expect(() =>
       parseStepContent("multipleChoice", {
         context: "Context",
         kind: "language",
-        options: [{ feedback: "Great", isCorrect: true, text: "A", textRomanization: "a" }],
+        options: [{ feedback: "Great", isCorrect: true, text: "A" }],
       }),
     ).toThrow();
   });

--- a/packages/core/src/steps/content-contract.test.ts
+++ b/packages/core/src/steps/content-contract.test.ts
@@ -2,21 +2,74 @@ import { describe, expect, test } from "vitest";
 import { assertStepContent, parseStepContent } from "./content-contract";
 
 describe("step content contracts", () => {
-  test("parses multipleChoice with optional context/question omitted", () => {
+  test("parses core multipleChoice with optional context/question omitted", () => {
     const content = parseStepContent("multipleChoice", {
+      kind: "core",
       options: [{ feedback: "Correct", isCorrect: true, text: "A" }],
     });
 
     expect(content).toEqual({
+      kind: "core",
       options: [{ feedback: "Correct", isCorrect: true, text: "A" }],
     });
   });
 
-  test("parses multipleChoice with optional language story fields", () => {
+  test("parses core multipleChoice with all fields", () => {
+    const content = parseStepContent("multipleChoice", {
+      context: "Some context",
+      kind: "core",
+      options: [
+        { feedback: "Correct!", isCorrect: true, text: "A" },
+        { feedback: "Wrong.", isCorrect: false, text: "B" },
+      ],
+      question: "What is correct?",
+    });
+
+    expect(content).toEqual({
+      context: "Some context",
+      kind: "core",
+      options: [
+        { feedback: "Correct!", isCorrect: true, text: "A" },
+        { feedback: "Wrong.", isCorrect: false, text: "B" },
+      ],
+      question: "What is correct?",
+    });
+  });
+
+  test("parses challenge multipleChoice", () => {
+    const content = parseStepContent("multipleChoice", {
+      context: "You face a decision.",
+      kind: "challenge",
+      options: [
+        {
+          consequence: "Good outcome",
+          effects: [{ dimension: "Quality", impact: "positive" }],
+          text: "Option A",
+        },
+      ],
+      question: "What do you do?",
+    });
+
+    expect(content).toEqual({
+      context: "You face a decision.",
+      kind: "challenge",
+      options: [
+        {
+          consequence: "Good outcome",
+          effects: [{ dimension: "Quality", impact: "positive" }],
+          text: "Option A",
+        },
+      ],
+      question: "What do you do?",
+    });
+  });
+
+  test("parses language multipleChoice", () => {
     const content = parseStepContent("multipleChoice", {
       context: "You enter a bakery in Madrid.",
       contextRomanization: "You enter a bakery in Madrid.",
       contextTranslation: "You enter a bakery in Madrid.",
+      kind: "language",
       options: [
         {
           feedback: "Great response.",
@@ -31,6 +84,7 @@ describe("step content contracts", () => {
       context: "You enter a bakery in Madrid.",
       contextRomanization: "You enter a bakery in Madrid.",
       contextTranslation: "You enter a bakery in Madrid.",
+      kind: "language",
       options: [
         {
           feedback: "Great response.",
@@ -40,6 +94,59 @@ describe("step content contracts", () => {
         },
       ],
     });
+  });
+
+  test("rejects multipleChoice without kind", () => {
+    expect(() =>
+      parseStepContent("multipleChoice", {
+        options: [{ feedback: "Correct", isCorrect: true, text: "A" }],
+      }),
+    ).toThrow();
+  });
+
+  test("rejects core options with challenge fields", () => {
+    expect(() =>
+      parseStepContent("multipleChoice", {
+        kind: "core",
+        options: [
+          {
+            consequence: "Something",
+            effects: [{ dimension: "X", impact: "positive" }],
+            text: "A",
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  test("rejects challenge options with core fields", () => {
+    expect(() =>
+      parseStepContent("multipleChoice", {
+        context: "Context",
+        kind: "challenge",
+        options: [{ feedback: "Great", isCorrect: true, text: "A" }],
+        question: "Q?",
+      }),
+    ).toThrow();
+  });
+
+  test("rejects language without required romanization fields", () => {
+    expect(() =>
+      parseStepContent("multipleChoice", {
+        context: "Context",
+        kind: "language",
+        options: [{ feedback: "Great", isCorrect: true, text: "A", textRomanization: "a" }],
+      }),
+    ).toThrow();
+  });
+
+  test("rejects unknown kind value", () => {
+    expect(() =>
+      parseStepContent("multipleChoice", {
+        kind: "unknown",
+        options: [{ feedback: "Correct", isCorrect: true, text: "A" }],
+      }),
+    ).toThrow();
   });
 
   test("parses fillBlank with optional question omitted", () => {

--- a/packages/core/src/steps/content-contract.ts
+++ b/packages/core/src/steps/content-contract.ts
@@ -29,7 +29,7 @@ const languageOptionSchema = z
     feedback: z.string(),
     isCorrect: z.boolean(),
     text: z.string(),
-    textRomanization: z.string(),
+    textRomanization: z.string().optional(),
   })
   .strict();
 
@@ -54,7 +54,7 @@ const challengeMultipleChoiceContentSchema = z
 const languageMultipleChoiceContentSchema = z
   .object({
     context: z.string(),
-    contextRomanization: z.string(),
+    contextRomanization: z.string().optional(),
     contextTranslation: z.string(),
     kind: z.literal("language"),
     options: z.array(languageOptionSchema).min(1),

--- a/packages/core/src/steps/content-contract.ts
+++ b/packages/core/src/steps/content-contract.ts
@@ -8,26 +8,64 @@ const challengeEffectSchema = z
   })
   .strict();
 
-const multipleChoiceOptionSchema = z
+const coreOptionSchema = z
   .object({
-    consequence: z.string().optional(),
-    effects: z.array(challengeEffectSchema).optional(),
-    feedback: z.string().optional(),
-    isCorrect: z.boolean().optional(),
+    feedback: z.string(),
+    isCorrect: z.boolean(),
     text: z.string(),
-    textRomanization: z.string().optional(),
   })
   .strict();
 
-export const multipleChoiceContentSchema = z
+const challengeOptionSchema = z
+  .object({
+    consequence: z.string(),
+    effects: z.array(challengeEffectSchema),
+    text: z.string(),
+  })
+  .strict();
+
+const languageOptionSchema = z
+  .object({
+    feedback: z.string(),
+    isCorrect: z.boolean(),
+    text: z.string(),
+    textRomanization: z.string(),
+  })
+  .strict();
+
+const coreMultipleChoiceContentSchema = z
   .object({
     context: z.string().optional(),
-    contextRomanization: z.string().optional(),
-    contextTranslation: z.string().optional(),
-    options: z.array(multipleChoiceOptionSchema).min(1),
+    kind: z.literal("core"),
+    options: z.array(coreOptionSchema).min(1),
     question: z.string().optional(),
   })
   .strict();
+
+const challengeMultipleChoiceContentSchema = z
+  .object({
+    context: z.string(),
+    kind: z.literal("challenge"),
+    options: z.array(challengeOptionSchema).min(1),
+    question: z.string(),
+  })
+  .strict();
+
+const languageMultipleChoiceContentSchema = z
+  .object({
+    context: z.string(),
+    contextRomanization: z.string(),
+    contextTranslation: z.string(),
+    kind: z.literal("language"),
+    options: z.array(languageOptionSchema).min(1),
+  })
+  .strict();
+
+export const multipleChoiceContentSchema = z.discriminatedUnion("kind", [
+  coreMultipleChoiceContentSchema,
+  challengeMultipleChoiceContentSchema,
+  languageMultipleChoiceContentSchema,
+]);
 
 const fillBlankChoiceSchema = z.string();
 
@@ -129,6 +167,9 @@ const stepContentSchemas = {
 
 export type SupportedStepKind = keyof typeof stepContentSchemas;
 
+export type CoreMultipleChoiceContent = z.infer<typeof coreMultipleChoiceContentSchema>;
+export type ChallengeMultipleChoiceContent = z.infer<typeof challengeMultipleChoiceContentSchema>;
+export type LanguageMultipleChoiceContent = z.infer<typeof languageMultipleChoiceContentSchema>;
 export type MultipleChoiceStepContent = z.infer<typeof multipleChoiceContentSchema>;
 export type FillBlankStepContent = z.infer<typeof fillBlankContentSchema>;
 export type MatchColumnsStepContent = z.infer<typeof matchColumnsContentSchema>;

--- a/packages/db/src/prisma/seed/steps.ts
+++ b/packages/db/src/prisma/seed/steps.ts
@@ -93,6 +93,7 @@ const stepsData: {
       {
         content: {
           context: "Traditional programming requires explicit rules for every scenario.",
+          kind: "core",
           options: [
             {
               feedback: "Both use electricity. Think about how they solve problems.",
@@ -195,31 +196,35 @@ const stepsData: {
       },
       {
         content: {
+          context:
+            "Your team is building an ML model and discovers the training data has quality issues.",
+          kind: "challenge",
           options: [
             {
-              effects: { dataQuality: -10, modelAccuracy: -15, teamMorale: -5 },
-              feedback: "Garbage in, garbage out. Poor data quality leads to poor models.",
-              isCorrect: false,
+              consequence: "Garbage in, garbage out. Poor data quality leads to poor models.",
+              effects: [
+                { dimension: "Data Quality", impact: "negative" },
+                { dimension: "Model Accuracy", impact: "negative" },
+                { dimension: "Team Morale", impact: "negative" },
+              ],
               text: "Ignore it and proceed with training",
             },
             {
-              effects: {
-                computeResources: -5,
-                dataQuality: 20,
-                modelAccuracy: 10,
-              },
-              feedback: "Good choice! Clean data is the foundation of good ML models.",
-              isCorrect: true,
+              consequence: "Good choice! Clean data is the foundation of good ML models.",
+              effects: [
+                { dimension: "Data Quality", impact: "positive" },
+                { dimension: "Model Accuracy", impact: "positive" },
+                { dimension: "Compute Resources", impact: "negative" },
+              ],
               text: "Spend time cleaning and validating the data",
             },
             {
-              effects: {
-                computeResources: -25,
-                dataQuality: 15,
-                teamMorale: -10,
-              },
-              feedback: "This wastes resources when cleaning could suffice.",
-              isCorrect: false,
+              consequence: "This wastes resources when cleaning could suffice.",
+              effects: [
+                { dimension: "Data Quality", impact: "positive" },
+                { dimension: "Compute Resources", impact: "negative" },
+                { dimension: "Team Morale", impact: "negative" },
+              ],
               text: "Collect entirely new data from scratch",
             },
           ],
@@ -229,27 +234,31 @@ const stepsData: {
       },
       {
         content: {
+          context:
+            "The model is underperforming and a team member suggests using a more complex architecture.",
+          kind: "challenge",
           options: [
             {
-              effects: {
-                computeResources: -20,
-                modelAccuracy: 5,
-                teamMorale: 5,
-              },
-              feedback: "Complex models need more compute and may overfit. Start simple!",
-              isCorrect: false,
+              consequence: "Complex models need more compute and may overfit. Start simple!",
+              effects: [
+                { dimension: "Compute Resources", impact: "negative" },
+                { dimension: "Model Accuracy", impact: "positive" },
+                { dimension: "Team Morale", impact: "positive" },
+              ],
               text: "Immediately switch to the complex model",
             },
             {
-              effects: { dataQuality: 5, modelAccuracy: 15, teamMorale: 10 },
-              feedback: "Smart! Understanding the problem helps choose the right solution.",
-              isCorrect: true,
+              consequence: "Smart! Understanding the problem helps choose the right solution.",
+              effects: [
+                { dimension: "Data Quality", impact: "positive" },
+                { dimension: "Model Accuracy", impact: "positive" },
+                { dimension: "Team Morale", impact: "positive" },
+              ],
               text: "First analyze why the current model is failing",
             },
             {
-              effects: { teamMorale: -20 },
-              feedback: "Ignoring team input hurts morale and misses opportunities.",
-              isCorrect: false,
+              consequence: "Ignoring team input hurts morale and misses opportunities.",
+              effects: [{ dimension: "Team Morale", impact: "negative" }],
               text: "Dismiss the suggestion without discussion",
             },
           ],


### PR DESCRIPTION
## Summary

- Replace flat `multipleChoiceContentSchema` with `z.discriminatedUnion("kind", [...])` using three variants: `core`, `challenge`, `language`
- Add `kind` field to all workflow steps that construct multiple choice content
- Update seed data to use the new discriminated format

## Test plan

- [x] Unit tests for all three kinds plus rejection cases (21 tests in content-contract)
- [x] Integration tests updated with `kind` in content assertions (core + language workflows)
- [x] All 182 API tests pass
- [x] All 237 main app tests pass
- [x] TypeScript, lint, knip, and build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored multiple-choice content to a discriminated union with a required kind (core, challenge, language) for stronger validation and clearer types. Made romanization fields optional for language content and updated generators, tests, and seed data.

- **Refactors**
  - Replaced multipleChoiceContentSchema with z.discriminatedUnion("kind", ["core", "challenge", "language"]).
  - Added kind to all multiple-choice step builders (quiz, story, review, grammar, challenge, language story).
  - Enforced kind-specific shapes:
    - core: context/question optional; options { feedback, isCorrect, text }.
    - challenge: context and question required; options { consequence, effects[], text }.
    - language: contextTranslation required; contextRomanization optional; options { feedback, isCorrect, text, textRomanization? }.
  - Expanded tests to cover kind parsing, invalid mixes, and romanization optionality; updated workflows and app tests.
  - Updated seed data to the new shapes (including challenge effects lists).

- **Migration**
  - Always set content.kind for multiple-choice steps:
    - core for standard/quiz/story/review/grammar
    - challenge for challenge steps
    - language for language story steps
  - Provide required fields per kind; remove mismatched fields (e.g., no feedback/isCorrect on challenge options). Language only requires contextTranslation; all romanization fields are optional.

<sup>Written for commit 7c94d3a0abc836ea1799c78ec4de2fe8645efa30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

