### PR TITLE
refactor(core): standardize romanization fields to use null instead of empty strings

### DIFF
--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
@@ -1260,8 +1260,8 @@ describe("language activity generation", () => {
 
     expect(steps).toHaveLength(2);
     expect(steps[1]?.content).toMatchObject({
-      contextRomanization: "",
-      options: expect.arrayContaining([expect.objectContaining({ textRomanization: "" })]),
+      contextRomanization: null,
+      options: expect.arrayContaining([expect.objectContaining({ textRomanization: null })]),
     });
   });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-grammar-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-grammar-content-step.ts
@@ -9,6 +9,7 @@ import {
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { prisma } from "@zoonk/db";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { emptyToNull } from "@zoonk/utils/string";
 import { z } from "zod";
 import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
@@ -50,7 +51,7 @@ function buildGrammarSteps(activityId: bigint | number, data: ActivityGrammarSch
   const exampleSteps = data.examples.map((example) => {
     const content = assertStepContent("static", {
       highlight: example.highlight,
-      romanization: example.romanization,
+      romanization: emptyToNull(example.romanization),
       sentence: example.sentence,
       translation: example.translation,
       variant: "grammarExample",

--- a/apps/api/src/workflows/activity-generation/steps/generate-language-story-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-language-story-content-step.ts
@@ -9,6 +9,7 @@ import {
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { prisma } from "@zoonk/db";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { emptyToNull } from "@zoonk/utils/string";
 import { z } from "zod";
 import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
@@ -22,7 +23,7 @@ const minimumLanguageStoryContentSchema = z.object({
     .array(
       z.object({
         context: z.string().trim().min(1),
-        contextRomanization: z.string(),
+        contextRomanization: z.string().nullable(),
         contextTranslation: z.string().trim().min(1),
         options: z
           .array(
@@ -30,7 +31,7 @@ const minimumLanguageStoryContentSchema = z.object({
               feedback: z.string().trim().min(1),
               isCorrect: z.boolean(),
               text: z.string().trim().min(1),
-              textRomanization: z.string(),
+              textRomanization: z.string().nullable(),
             }),
           )
           .min(1),
@@ -59,14 +60,14 @@ function buildLanguageStorySteps(activityId: bigint | number, data: ActivityStor
     activityId,
     content: assertStepContent("multipleChoice", {
       context: step.context,
-      contextRomanization: step.contextRomanization,
+      contextRomanization: emptyToNull(step.contextRomanization),
       contextTranslation: step.contextTranslation,
       kind: "language",
       options: step.options.map((option) => ({
         feedback: option.feedback,
         isCorrect: option.isCorrect,
         text: option.text,
-        textRomanization: option.textRomanization,
+        textRomanization: emptyToNull(option.textRomanization),
       })),
     }),
     kind: "multipleChoice" as const,

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.ts
@@ -7,7 +7,7 @@ import { handleActivityFailureStep } from "./handle-failure-step";
 import { setActivityAsRunningStep } from "./set-activity-as-running-step";
 
 export type VocabularyWord = {
-  romanization: string;
+  romanization: string | null;
   translation: string;
   word: string;
 };

--- a/apps/api/src/workflows/activity-generation/steps/save-reading-sentences-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-reading-sentences-step.ts
@@ -1,6 +1,7 @@
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
+import { emptyToNull } from "@zoonk/utils/string";
 import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type ReadingSentence } from "./generate-reading-content-step";
@@ -25,14 +26,14 @@ function buildSaveOneSentence(params: {
     const record = await prisma.sentence.upsert({
       create: {
         organizationId,
-        romanization: readingSentence.romanization,
+        romanization: emptyToNull(readingSentence.romanization),
         sentence: readingSentence.sentence,
         targetLanguage,
         translation: readingSentence.translation,
         userLanguage,
       },
       update: {
-        romanization: readingSentence.romanization,
+        romanization: emptyToNull(readingSentence.romanization),
         translation: readingSentence.translation,
       },
       where: {

--- a/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
@@ -1,6 +1,7 @@
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
+import { emptyToNull } from "@zoonk/utils/string";
 import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type VocabularyWord } from "./generate-vocabulary-content-step";
@@ -25,14 +26,14 @@ function buildSaveOneWord(params: {
     const record = await prisma.word.upsert({
       create: {
         organizationId,
-        romanization: vocabWord.romanization,
+        romanization: emptyToNull(vocabWord.romanization),
         targetLanguage,
         translation: vocabWord.translation,
         userLanguage,
         word: vocabWord.word,
       },
       update: {
-        romanization: vocabWord.romanization,
+        romanization: emptyToNull(vocabWord.romanization),
         translation: vocabWord.translation,
       },
       where: {

--- a/apps/evals/src/tasks/activity-grammar/test-cases.ts
+++ b/apps/evals/src/tasks/activity-grammar/test-cases.ts
@@ -49,7 +49,7 @@ EVALUATION CRITERIA:
    - For non-Roman scripts (Japanese, Korean, Chinese, Arabic, Russian, Greek, Thai, Hindi, etc.):
      romanization MUST be included and accurate using standard systems (romaji, romanization, pinyin, etc.)
    - For Roman-script languages (Spanish, French, German, Portuguese, Italian, etc.):
-     romanization MUST be empty string ""
+     romanization MUST be null
    - Penalize SEVERELY if romanization is missing for non-Roman scripts
    - Penalize SEVERELY if romanization contains text for Roman scripts
 
@@ -126,7 +126,7 @@ LANGUAGE: English output required.
 
 TOPIC: Spanish present tense conjugation of regular -ar verbs - how verbs ending in -ar change their endings to match the subject.
 
-SCRIPT: Roman (romanization should be empty string "")
+SCRIPT: Roman (romanization should be null)
 
 GRAMMAR PATTERN: Regular -ar verbs in Spanish follow a consistent conjugation pattern in present tense. The -ar ending is replaced with: -o (yo), -as (tu), -a (el/ella), -amos (nosotros), -an (ellos/ellas).
 
@@ -143,7 +143,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Conjugation endings are incorrect
 - Examples use irregular verbs instead of regular -ar verbs
 - Examples mix -ar verbs with -er or -ir verbs (those belong in separate lessons)
-- Romanization contains any text (should be empty string)
+- Romanization contains any text (should be null)
 - Discovery question tests vocabulary instead of conjugation patterns
 - Exercises test irregular verb forms
 
@@ -165,7 +165,7 @@ LANGUAGE: English output required.
 
 TOPIC: German verb-second (V2) word order - in German main clauses, the conjugated verb must be in the second position.
 
-SCRIPT: Roman (romanization should be empty string "")
+SCRIPT: Roman (romanization should be null)
 
 GRAMMAR PATTERN: In German declarative sentences, the conjugated verb MUST occupy the second position. The first position can be filled by the subject, an adverb, or another element, but the verb always comes second.
 
@@ -173,7 +173,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Examples show verb in positions other than second without explanation
 - Examples use subordinate clauses (which have different word order)
 - The pattern demonstrated is not clearly V2
-- Romanization contains any text (should be empty string)
+- Romanization contains any text (should be null)
 - Discovery question tests vocabulary instead of word order
 - Exercises do not clearly test V2 word order
 
@@ -195,7 +195,7 @@ LANGUAGE: Brazilian Portuguese output required (NOT English).
 
 TOPIC: French adjective-noun gender agreement - adjectives must match the gender of the noun they modify.
 
-SCRIPT: Roman (romanization should be empty string "")
+SCRIPT: Roman (romanization should be null)
 
 GRAMMAR PATTERN: In French, adjectives must agree in gender with the noun they modify. Masculine nouns take masculine adjectives; feminine nouns take feminine adjectives. Most adjectives add -e for feminine form.
 
@@ -204,7 +204,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Examples show incorrect gender agreement
 - Adjective forms do not match noun gender
 - Examples use invariable adjectives that do not demonstrate the pattern
-- Romanization contains any text (should be empty string)
+- Romanization contains any text (should be null)
 - Discovery question tests vocabulary instead of gender agreement
 - Exercises do not clearly test gender agreement
 

--- a/apps/evals/src/tasks/activity-sentences/test-cases.ts
+++ b/apps/evals/src/tasks/activity-sentences/test-cases.ts
@@ -17,7 +17,7 @@ EVALUATION CRITERIA:
 3. ROMANIZATION (required field):
    - For Japanese, Chinese, Korean, Arabic, Russian, Greek, Thai, Hindi, etc.: romanization MUST contain the Roman letter representation of the sentence
    - Use standard romanization systems (romaji for Japanese, pinyin for Chinese, etc.)
-   - For Roman-script languages (Spanish, French, German, etc.): romanization MUST be an empty string ""
+   - For Roman-script languages (Spanish, French, German, etc.): romanization MUST be null
    - Penalize if romanization is missing for non-Roman scripts or contains text for Roman scripts
 
 4. GRAMMATICAL CORRECTNESS:
@@ -77,7 +77,7 @@ LANGUAGE: English output required for translations.
 
 TOPIC: Spanish sentences for greetings and introductions - using basic greeting vocabulary.
 
-SCRIPT: Roman (romanization should be empty string "")
+SCRIPT: Roman (romanization should be null)
 
 VOCABULARY WORDS PROVIDED: hola, buenos dias, buenas noches, adios, gracias
 These words MUST appear in the generated sentences.
@@ -86,7 +86,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Any sentence doesn't use at least one of the provided vocabulary words
 - Greetings are used incorrectly (e.g., "buenas noches" used for morning)
 - Translations don't match the Spanish sentences
-- Romanization contains any text (should be empty string)
+- Romanization contains any text (should be null)
 
 CONTEXT EXPECTATIONS:
 - Sentences should demonstrate natural use of greetings
@@ -109,7 +109,7 @@ LANGUAGE: English output required for translations.
 
 TOPIC: French sentences for food and dining - using food-related vocabulary.
 
-SCRIPT: Roman (romanization should be empty string "")
+SCRIPT: Roman (romanization should be null)
 
 VOCABULARY WORDS PROVIDED: le pain, le fromage, le vin, la soupe, le dessert
 These words MUST appear in the generated sentences.
@@ -119,7 +119,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Food items are used in unrealistic contexts
 - Gender agreement is incorrect (le/la must match the noun)
 - Translations don't accurately convey the French meaning
-- Romanization contains any text (should be empty string)
+- Romanization contains any text (should be null)
 
 CONTEXT EXPECTATIONS:
 - Sentences about ordering, eating, or discussing food
@@ -142,7 +142,7 @@ LANGUAGE: English output required for translations.
 
 TOPIC: German sentences for family members - using family vocabulary.
 
-SCRIPT: Roman (romanization should be empty string "")
+SCRIPT: Roman (romanization should be null)
 
 VOCABULARY WORDS PROVIDED: die Mutter, der Vater, die Schwester, der Bruder, die Familie
 These words MUST appear in the generated sentences.
@@ -152,7 +152,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Case endings are incorrect (nominative, accusative, dative contexts)
 - Article-noun agreement is wrong
 - Translations don't accurately convey the German meaning
-- Romanization contains any text (should be empty string)
+- Romanization contains any text (should be null)
 
 CONTEXT EXPECTATIONS:
 - Sentences about family relationships and activities
@@ -252,7 +252,7 @@ LANGUAGE: Brazilian Portuguese output required for translations (NOT English).
 
 TOPIC: Italian sentences for travel and transportation - using travel vocabulary.
 
-SCRIPT: Roman (romanization should be empty string "")
+SCRIPT: Roman (romanization should be null)
 
 VOCABULARY WORDS PROVIDED: il treno, l'aereo, la macchina, il biglietto, la stazione
 These words MUST appear in the generated sentences.
@@ -262,7 +262,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Article contractions are incorrect (e.g., l'aereo not la aereo)
 - Translations are in English instead of Portuguese
 - Gender agreement is incorrect
-- Romanization contains any text (should be empty string)
+- Romanization contains any text (should be null)
 
 CONTEXT EXPECTATIONS:
 - Sentences about traveling, booking tickets, transportation
@@ -285,7 +285,7 @@ LANGUAGE: Brazilian Portuguese output required for translations (NOT English).
 
 TOPIC: Spanish sentences for shopping - using shopping vocabulary.
 
-SCRIPT: Roman (romanization should be empty string "")
+SCRIPT: Roman (romanization should be null)
 
 VOCABULARY WORDS PROVIDED: comprar, la tienda, el precio, caro, barato
 These words MUST appear in the generated sentences.
@@ -295,7 +295,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Verb conjugation is incorrect (comprar conjugated forms)
 - Adjective gender agreement is wrong (caro/cara, barato/barata)
 - Translations are in English instead of Portuguese
-- Romanization contains any text (should be empty string)
+- Romanization contains any text (should be null)
 
 CONTEXT EXPECTATIONS:
 - Sentences about buying, prices, stores
@@ -318,7 +318,7 @@ LANGUAGE: Latin American Spanish output required for translations (NOT English).
 
 TOPIC: French sentences for weather - using weather vocabulary.
 
-SCRIPT: Roman (romanization should be empty string "")
+SCRIPT: Roman (romanization should be null)
 
 VOCABULARY WORDS PROVIDED: le soleil, la pluie, le vent, il fait chaud, il fait froid
 These words/expressions MUST appear in the generated sentences.
@@ -327,7 +327,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Any sentence doesn't use at least one of the provided vocabulary words/expressions
 - Weather expressions are used incorrectly
 - Translations are in English instead of Spanish
-- Romanization contains any text (should be empty string)
+- Romanization contains any text (should be null)
 
 CONTEXT EXPECTATIONS:
 - Sentences describing weather conditions
@@ -505,7 +505,7 @@ LANGUAGE: English output required for translations.
 
 TOPIC: Portuguese sentences for emotions and feelings - using emotion vocabulary.
 
-SCRIPT: Roman (romanization should be empty string "")
+SCRIPT: Roman (romanization should be null)
 
 VOCABULARY WORDS PROVIDED: feliz, triste, cansado, com fome, com sede
 These words/expressions MUST appear in the generated sentences.
@@ -515,7 +515,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Estar vs ser usage is incorrect for states (estar feliz, not ser feliz for temporary states)
 - Gender agreement is wrong (cansado/cansada)
 - Translations don't match the Portuguese sentences
-- Romanization contains any text (should be empty string)
+- Romanization contains any text (should be null)
 
 CONTEXT EXPECTATIONS:
 - Sentences expressing how someone feels
@@ -538,7 +538,7 @@ LANGUAGE: Brazilian Portuguese output required for translations (NOT English).
 
 TOPIC: German sentences for daily routines - using routine action vocabulary.
 
-SCRIPT: Roman (romanization should be empty string "")
+SCRIPT: Roman (romanization should be null)
 
 VOCABULARY WORDS PROVIDED: aufstehen, fruhstucken, arbeiten, schlafen, essen
 These verbs MUST appear in the generated sentences.
@@ -548,7 +548,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Separable prefix verbs are handled incorrectly (aufstehen -> ich stehe auf)
 - Verb conjugation is wrong
 - Translations are in English instead of Portuguese
-- Romanization contains any text (should be empty string)
+- Romanization contains any text (should be null)
 
 CONTEXT EXPECTATIONS:
 - Sentences about daily activities and schedules

--- a/apps/evals/src/tasks/activity-story-language/test-cases.ts
+++ b/apps/evals/src/tasks/activity-story-language/test-cases.ts
@@ -27,7 +27,7 @@ EVALUATION CRITERIA:
    - Options MUST show only TARGET language text (NO translations)
    - All 4 options MUST be grammatically correct in TARGET language
    - Options should represent meaningfully different responses
-   - textRomanization provided for non-Roman scripts, empty string for Roman scripts
+   - textRomanization provided for non-Roman scripts, null for Roman scripts
    - Penalize SEVERELY if options include translations or hints in NATIVE language
    - Penalize if options are grammatically incorrect or nonsensical
 
@@ -43,7 +43,7 @@ EVALUATION CRITERIA:
    - For non-Roman scripts (Japanese, Korean, Chinese, Arabic, Russian, Greek, Thai, Hindi, etc.):
      BOTH contextRomanization AND textRomanization MUST be included and accurate
    - For Roman-script languages (Spanish, French, German, Portuguese, Italian, etc.):
-     BOTH romanization fields MUST be empty strings ""
+     BOTH romanization fields MUST be null
    - Penalize SEVERELY if romanization is missing for non-Roman scripts
    - Penalize SEVERELY if romanization contains text for Roman scripts
 
@@ -96,7 +96,7 @@ LANGUAGE: English output required (scenario, questions, feedback).
 
 TOPIC: Ordering coffee and pastries at a cafe in France.
 
-SCRIPT: Roman (ALL romanization fields must be empty strings "")
+SCRIPT: Roman (ALL romanization fields must be null)
 
 SCENARIO TYPE: Food & Dining - casual cafe interaction
 
@@ -110,7 +110,7 @@ KEY REQUIREMENTS:
 ACCURACY PITFALLS - Penalize SEVERELY if:
 - Options include English translations or hints
 - French dialogue is unnatural or overly formal for a cafe
-- Romanization fields contain any text (must be empty string)
+- Romanization fields contain any text (must be null)
 - Feedback doesn't include translation of what the learner said
 - Steps don't follow a logical cafe interaction flow
 
@@ -173,7 +173,7 @@ LANGUAGE: Brazilian Portuguese output required (NOT English).
 
 TOPIC: Buying groceries at a market in Germany.
 
-SCRIPT: Roman (ALL romanization fields must be empty strings "")
+SCRIPT: Roman (ALL romanization fields must be null)
 
 SCENARIO TYPE: Shopping - grocery market interaction
 
@@ -188,7 +188,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Output is in English instead of Portuguese
 - Options include Portuguese translations
 - German dialogue is unnatural or uses overly formal register for a market
-- Romanization fields contain any text (must be empty strings)
+- Romanization fields contain any text (must be null)
 - Feedback (in Portuguese) doesn't include German translation
 - Steps don't follow a logical shopping interaction
 
@@ -250,7 +250,7 @@ LANGUAGE: English output required.
 
 TOPIC: Visiting a pharmacy in Spain with a minor ailment.
 
-SCRIPT: Roman (ALL romanization fields must be empty strings "")
+SCRIPT: Roman (ALL romanization fields must be null)
 
 SCENARIO TYPE: Healthcare - pharmacy interaction
 
@@ -264,7 +264,7 @@ KEY REQUIREMENTS:
 ACCURACY PITFALLS - Penalize SEVERELY if:
 - Options include English translations
 - Spanish dialogue is unnatural
-- Romanization fields contain any text (must be empty strings)
+- Romanization fields contain any text (must be null)
 - Feedback doesn't include translation
 
 ${SHARED_EXPECTATIONS}

--- a/apps/evals/src/tasks/activity-vocabulary/test-cases.ts
+++ b/apps/evals/src/tasks/activity-vocabulary/test-cases.ts
@@ -17,7 +17,7 @@ EVALUATION CRITERIA:
 3. ROMANIZATION (required field):
    - For Japanese, Chinese, Korean, Arabic, Russian, Greek, Thai, Hindi, etc.: romanization MUST contain the Roman letter representation
    - Use standard romanization (romaji for Japanese, pinyin for Chinese, etc.)
-   - For Roman-script languages (Spanish, French, German, etc.): romanization MUST be an empty string ""
+   - For Roman-script languages (Spanish, French, German, etc.): romanization MUST be null
    - Penalize if romanization is missing for non-Roman scripts or contains text for Roman scripts
 
 4. TOPIC FOCUS (STRICT BOUNDARY ENFORCEMENT): Words must be INSIDE the lesson's specific scope. Penalize SEVERELY if:
@@ -80,7 +80,7 @@ LANGUAGE: English output required.
 
 TOPIC: Spanish vocabulary for ordering coffee - focused specifically on coffee drinks, sizes, milk options, and common cafe phrases.
 
-SCRIPT: Roman (romanization should be empty string "")
+SCRIPT: Roman (romanization should be null)
 
 TOPIC SCOPE: This is a narrow, focused lesson. Vocabulary should include:
 - Coffee drink types (espresso, latte, cappuccino, americano, etc.)
@@ -92,7 +92,7 @@ TOPIC SCOPE: This is a narrow, focused lesson. Vocabulary should include:
 ACCURACY PITFALLS - Penalize SEVERELY if:
 - Coffee-specific terms are mistranslated
 - Vocabulary drifts to general food/restaurant terms unrelated to coffee ordering
-- Romanization contains any text (should be empty string)
+- Romanization contains any text (should be null)
 - Articles are missing from nouns (el cafe, la leche, not cafe, leche)
 
 ${SHARED_EXPECTATIONS}
@@ -113,7 +113,7 @@ LANGUAGE: English output required.
 
 TOPIC: French vocabulary for breads and pastries - focused specifically on bakery items found in a French boulangerie/patisserie.
 
-SCRIPT: Roman (romanization should be empty string "")
+SCRIPT: Roman (romanization should be null)
 
 TOPIC SCOPE: This is a narrow, focused lesson. Vocabulary should include:
 - Types of bread (baguette, pain de campagne, brioche, etc.)
@@ -125,7 +125,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Bakery items are mistranslated
 - Vocabulary drifts to general cooking or restaurant terms
 - Gendered articles are missing (le pain, la baguette, not pain, baguette)
-- Romanization contains any text (should be empty string)
+- Romanization contains any text (should be null)
 
 ${SHARED_EXPECTATIONS}
     `,
@@ -145,7 +145,7 @@ LANGUAGE: English output required.
 
 TOPIC: German vocabulary for parents and siblings - focused specifically on immediate family members (mother, father, brother, sister, and their variations).
 
-SCRIPT: Roman (romanization should be empty string "")
+SCRIPT: Roman (romanization should be null)
 
 TOPIC SCOPE: This is a narrow, focused lesson. Vocabulary should include:
 - Parents (mother, father, mom, dad, step-parents)
@@ -157,7 +157,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Parent/sibling terms are mistranslated (Mutter=mother, Vater=father, Bruder=brother, Schwester=sister)
 - Vocabulary includes extended family members (this lesson is specifically about parents and siblings)
 - German articles (der/die/das) are missing from nouns
-- Romanization contains any text (should be empty string)
+- Romanization contains any text (should be null)
 
 ${SHARED_EXPECTATIONS}
     `,
@@ -177,7 +177,7 @@ LANGUAGE: Brazilian Portuguese output required (NOT English).
 
 TOPIC: Italian vocabulary for common pets - focused specifically on household pets and basic pet care terms.
 
-SCRIPT: Roman (romanization should be empty string "")
+SCRIPT: Roman (romanization should be null)
 
 TOPIC SCOPE: This is a narrow, focused lesson. Vocabulary should include:
 - Common household pets (dog, cat, fish, bird, hamster, rabbit, turtle, etc.)
@@ -192,7 +192,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Output is in English instead of Portuguese
 - Italian articles are missing from nouns (il cane, il gatto, not cane, gatto)
 - Grammatical gender is incorrect (masculine article with feminine noun or vice versa)
-- Romanization contains any text (should be empty string)
+- Romanization contains any text (should be null)
 
 ${SHARED_EXPECTATIONS}
     `,

--- a/packages/ai/src/tasks/activities/language/activity-grammar.prompt.md
+++ b/packages/ai/src/tasks/activities/language/activity-grammar.prompt.md
@@ -188,7 +188,7 @@ Use the standard romanization system for each language:
 - **Thai**: Royal Thai General System (e.g., ฉันเป็นนักเรียน → "chan pen nakrian")
 - **Hindi**: IAST or Hunterian (e.g., मैं छात्र हूँ → "main chhatr hoon")
 
-**For languages using Roman letters** (Spanish, French, German, Portuguese, Italian, etc.), set `romanization` to an empty string `""`.
+**For languages using Roman letters** (Spanish, French, German, Portuguese, Italian, etc.), set `romanization` to `null`.
 
 # Linguistic Accuracy Requirements
 
@@ -226,19 +226,19 @@ Return an object with this structure:
     {
       "sentence": "Yo hablo español.",
       "translation": "I speak Spanish.",
-      "romanization": "",
+      "romanization": null,
       "highlight": "hablo"
     },
     {
       "sentence": "Ella habla con su madre.",
       "translation": "She speaks with her mother.",
-      "romanization": "",
+      "romanization": null,
       "highlight": "habla"
     },
     {
       "sentence": "Nosotros hablamos mucho.",
       "translation": "We speak a lot.",
-      "romanization": "",
+      "romanization": null,
       "highlight": "hablamos"
     }
   ],

--- a/packages/ai/src/tasks/activities/language/activity-grammar.ts
+++ b/packages/ai/src/tasks/activities/language/activity-grammar.ts
@@ -30,7 +30,7 @@ const schema = z.object({
   examples: z.array(
     z.object({
       highlight: z.string(),
-      romanization: z.string(),
+      romanization: z.string().nullable(),
       sentence: z.string(),
       translation: z.string(),
     }),

--- a/packages/ai/src/tasks/activities/language/activity-sentences.prompt.md
+++ b/packages/ai/src/tasks/activities/language/activity-sentences.prompt.md
@@ -94,7 +94,7 @@ Use the standard romanization system for each language:
 - **Thai**: Royal Thai General System (e.g., ฉันชอบแมว → "chan chop maeo")
 - **Hindi**: IAST or Hunterian (e.g., मुझे बिल्लियाँ पसंद हैं → "mujhe billiyaan pasand hain")
 
-**For languages using Roman letters** (Spanish, French, German, Portuguese, Italian, etc.), set `romanization` to an empty string `""`.
+**For languages using Roman letters** (Spanish, French, German, Portuguese, Italian, etc.), set `romanization` to `null`.
 
 # Output Format
 
@@ -102,9 +102,9 @@ Return an object with a `sentences` array. Each sentence object must include:
 
 - `sentence`: The complete sentence in the target language
 - `translation`: The translation in the native language
-- `romanization`: Roman letter representation for non-Roman scripts, or empty string `""` for Roman scripts
+- `romanization`: Roman letter representation for non-Roman scripts, or `null` for Roman scripts
 
-**Example for Spanish (Roman script) - romanization is empty:**
+**Example for Spanish (Roman script) - romanization is null:**
 
 ```json
 {
@@ -112,12 +112,12 @@ Return an object with a `sentences` array. Each sentence object must include:
     {
       "sentence": "Mi hermana trabaja en un hospital.",
       "translation": "My sister works at a hospital.",
-      "romanization": ""
+      "romanization": null
     },
     {
       "sentence": "¿Dónde está la estación de tren?",
       "translation": "Where is the train station?",
-      "romanization": ""
+      "romanization": null
     }
   ]
 }

--- a/packages/ai/src/tasks/activities/language/activity-sentences.ts
+++ b/packages/ai/src/tasks/activities/language/activity-sentences.ts
@@ -16,7 +16,7 @@ const FALLBACK_MODELS = [
 const schema = z.object({
   sentences: z.array(
     z.object({
-      romanization: z.string(),
+      romanization: z.string().nullable(),
       sentence: z.string(),
       translation: z.string(),
     }),

--- a/packages/ai/src/tasks/activities/language/activity-story.prompt.md
+++ b/packages/ai/src/tasks/activities/language/activity-story.prompt.md
@@ -71,9 +71,9 @@ The character in the story is a friendly native speaker who:
 | `scenario`                   | NATIVE       | "You're at a cafe in Madrid and want to order coffee."    |
 | `context`                    | TARGET       | "Buenos dias, que le pongo?"                              |
 | `contextTranslation`         | NATIVE       | "Good morning, what can I get you?"                       |
-| `contextRomanization`        | Romanization | "" (empty for Roman scripts)                              |
+| `contextRomanization`        | Romanization | null (for Roman scripts)                                  |
 | `options[].text`             | TARGET       | "Un cafe con leche, por favor."                           |
-| `options[].textRomanization` | Romanization | "" (empty for Roman scripts)                              |
+| `options[].textRomanization` | Romanization | null (for Roman scripts)                                  |
 | `options[].feedback`         | NATIVE       | "A coffee with milk, please - Perfect! Polite and clear." |
 
 # Options Design
@@ -83,7 +83,7 @@ The character in the story is a friendly native speaker who:
 This is the most critical design decision. Options show ONLY:
 
 - `text`: The phrase in TARGET language
-- `textRomanization`: Romanization for non-Roman scripts (empty string for Roman scripts)
+- `textRomanization`: Romanization for non-Roman scripts (null for Roman scripts)
 
 **NO translation is shown**. This forces the learner to:
 
@@ -160,7 +160,7 @@ For languages using non-Roman writing systems (Japanese, Chinese, Korean, Arabic
 
 ## Roman Scripts
 
-For languages using Roman letters (Spanish, French, German, Portuguese, Italian, etc.), set both `contextRomanization` and `textRomanization` to empty strings `""`.
+For languages using Roman letters (Spanish, French, German, Portuguese, Italian, etc.), set both `contextRomanization` and `textRomanization` to `null`.
 
 # Story Arc
 
@@ -232,17 +232,17 @@ Return an object with this structure (abbreviated examples shown):
     {
       "context": "Buenas noches. Estan listos para pedir?",
       "contextTranslation": "Good evening. Are you ready to order?",
-      "contextRomanization": "",
+      "contextRomanization": null,
       "options": [
         {
           "text": "Si, me gustaria la paella, por favor.",
-          "textRomanization": "",
+          "textRomanization": null,
           "isCorrect": true,
           "feedback": "Yes, I would like the paella, please - Perfect!"
         },
         {
           "text": "La cuenta, por favor.",
-          "textRomanization": "",
+          "textRomanization": null,
           "isCorrect": false,
           "feedback": "The check, please - You haven't eaten yet!"
         }
@@ -265,7 +265,7 @@ Before finalizing, verify:
 5. **Clear progression**: Steps follow a logical narrative arc
 6. **Distinct options**: Each option represents a meaningfully different choice
 7. **Helpful feedback**: Translations and explanations clarify meaning and context
-8. **Correct romanization**: Follows standard systems for non-Roman scripts, empty for Roman scripts
+8. **Correct romanization**: Follows standard systems for non-Roman scripts, null for Roman scripts
 9. **Scenario relevance**: The story matches the lesson topic
 10. **Appropriate difficulty**: Language complexity matches learner level
 
@@ -276,6 +276,6 @@ Before finalizing, verify:
 3. **Inconsistent register**: Mixing formal and informal inappropriately
 4. **Unnatural responses**: Things a native speaker would never actually say
 5. **Missing romanization**: Forgetting to add romanization for non-Roman scripts
-6. **Adding romanization to Roman scripts**: Spanish, French, etc. should have empty strings
+6. **Adding romanization to Roman scripts**: Spanish, French, etc. should have null
 7. **Feedback without translation**: Always include what the option means
 8. **Disconnected steps**: Each step should follow logically from the previous one

--- a/packages/ai/src/tasks/activities/language/activity-story.ts
+++ b/packages/ai/src/tasks/activities/language/activity-story.ts
@@ -21,7 +21,7 @@ const schema = z.object({
   steps: z.array(
     z.object({
       context: z.string(),
-      contextRomanization: z.string(),
+      contextRomanization: z.string().nullable(),
       contextTranslation: z.string(),
       options: z
         .array(
@@ -29,7 +29,7 @@ const schema = z.object({
             feedback: z.string(),
             isCorrect: z.boolean(),
             text: z.string(),
-            textRomanization: z.string(),
+            textRomanization: z.string().nullable(),
           }),
         )
         .length(ACTIVITY_OPTIONS_COUNT),

--- a/packages/ai/src/tasks/activities/language/activity-vocabulary.prompt.md
+++ b/packages/ai/src/tasks/activities/language/activity-vocabulary.prompt.md
@@ -109,7 +109,7 @@ Use the standard romanization system for each language:
 - **Thai**: Royal Thai General System (e.g., สวัสดี → "sawatdi", แมว → "maeo")
 - **Hindi**: IAST or Hunterian (e.g., नमस्ते → "namaste", बिल्ली → "billi")
 
-**For languages using Roman letters** (Spanish, French, German, Portuguese, Italian, etc.), set `romanization` to an empty string `""`.
+**For languages using Roman letters** (Spanish, French, German, Portuguese, Italian, etc.), set `romanization` to `null`.
 
 # Output Format
 
@@ -117,9 +117,9 @@ Return an object with a `words` array. Each word object must include:
 
 - `word`: The word in the target language (with article for gendered nouns)
 - `translation`: The translation in the native language
-- `romanization`: Roman letter representation for non-Roman scripts, or empty string `""` for Roman scripts
+- `romanization`: Roman letter representation for non-Roman scripts, or `null` for Roman scripts
 
-**Example for Spanish (Roman script) - romanization is empty:**
+**Example for Spanish (Roman script) - romanization is null:**
 
 ```json
 {
@@ -127,12 +127,12 @@ Return an object with a `words` array. Each word object must include:
     {
       "word": "la casa",
       "translation": "the house",
-      "romanization": ""
+      "romanization": null
     },
     {
       "word": "el gato",
       "translation": "the cat",
-      "romanization": ""
+      "romanization": null
     }
   ]
 }

--- a/packages/ai/src/tasks/activities/language/activity-vocabulary.ts
+++ b/packages/ai/src/tasks/activities/language/activity-vocabulary.ts
@@ -17,7 +17,7 @@ const FALLBACK_MODELS = [
 const schema = z.object({
   words: z.array(
     z.object({
-      romanization: z.string(),
+      romanization: z.string().nullable(),
       translation: z.string(),
       word: z.string(),
     }),

--- a/packages/core/src/steps/content-contract.test.ts
+++ b/packages/core/src/steps/content-contract.test.ts
@@ -130,20 +130,34 @@ describe("step content contracts", () => {
     ).toThrow();
   });
 
-  test("parses language without optional romanization fields", () => {
+  test("parses language with null romanization fields", () => {
     const content = parseStepContent("multipleChoice", {
       context: "Context",
+      contextRomanization: null,
       contextTranslation: "Translation",
       kind: "language",
-      options: [{ feedback: "Great", isCorrect: true, text: "A" }],
+      options: [{ feedback: "Great", isCorrect: true, text: "A", textRomanization: null }],
     });
 
     expect(content).toEqual({
       context: "Context",
+      contextRomanization: null,
       contextTranslation: "Translation",
       kind: "language",
-      options: [{ feedback: "Great", isCorrect: true, text: "A" }],
+      options: [{ feedback: "Great", isCorrect: true, text: "A", textRomanization: null }],
     });
+  });
+
+  test("rejects empty string contextRomanization in language kind", () => {
+    expect(() =>
+      parseStepContent("multipleChoice", {
+        context: "Context",
+        contextRomanization: "",
+        contextTranslation: "Translation",
+        kind: "language",
+        options: [{ feedback: "Great", isCorrect: true, text: "A" }],
+      }),
+    ).toThrow();
   });
 
   test("rejects language without required contextTranslation", () => {
@@ -278,6 +292,36 @@ describe("step content contracts", () => {
       options: [{ feedback: "Correct", isCorrect: true, prompt: "A cat", url: "https://a.co/x" }],
       question: "Which image shows a cat?",
     });
+  });
+
+  test("parses grammar example with null romanization", () => {
+    const content = parseStepContent("static", {
+      highlight: "hablo",
+      romanization: null,
+      sentence: "Yo hablo español.",
+      translation: "I speak Spanish.",
+      variant: "grammarExample",
+    });
+
+    expect(content).toEqual({
+      highlight: "hablo",
+      romanization: null,
+      sentence: "Yo hablo español.",
+      translation: "I speak Spanish.",
+      variant: "grammarExample",
+    });
+  });
+
+  test("rejects grammar example with empty string romanization", () => {
+    expect(() =>
+      parseStepContent("static", {
+        highlight: "hablo",
+        romanization: "",
+        sentence: "Yo hablo español.",
+        translation: "I speak Spanish.",
+        variant: "grammarExample",
+      }),
+    ).toThrow();
   });
 
   test("throws for invalid fillBlank", () => {

--- a/packages/core/src/steps/content-contract.ts
+++ b/packages/core/src/steps/content-contract.ts
@@ -29,7 +29,7 @@ const languageOptionSchema = z
     feedback: z.string(),
     isCorrect: z.boolean(),
     text: z.string(),
-    textRomanization: z.string().optional(),
+    textRomanization: z.string().min(1).nullable(),
   })
   .strict();
 
@@ -54,7 +54,7 @@ const challengeMultipleChoiceContentSchema = z
 const languageMultipleChoiceContentSchema = z
   .object({
     context: z.string(),
-    contextRomanization: z.string().optional(),
+    contextRomanization: z.string().min(1).nullable(),
     contextTranslation: z.string(),
     kind: z.literal("language"),
     options: z.array(languageOptionSchema).min(1),
@@ -128,7 +128,7 @@ export const staticTextContentSchema = z
 export const staticGrammarExampleContentSchema = z
   .object({
     highlight: z.string(),
-    romanization: z.string(),
+    romanization: z.string().min(1).nullable(),
     sentence: z.string(),
     translation: z.string(),
     variant: z.literal("grammarExample"),

--- a/packages/utils/src/string.test.ts
+++ b/packages/utils/src/string.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  emptyToNull,
   formatPosition,
   normalizeString,
   parseBigIntId,
@@ -136,6 +137,28 @@ describe(parseBigIntId, () => {
 
   test("returns null for empty string", () => {
     expect(parseBigIntId("")).toBeNull();
+  });
+});
+
+describe(emptyToNull, () => {
+  test("converts empty string to null", () => {
+    expect(emptyToNull("")).toBeNull();
+  });
+
+  test("converts whitespace-only string to null", () => {
+    expect(emptyToNull("  ")).toBeNull();
+  });
+
+  test("converts null to null", () => {
+    expect(emptyToNull(null)).toBeNull();
+  });
+
+  test("converts undefined to null", () => {
+    expect(emptyToNull()).toBeNull();
+  });
+
+  test("returns non-empty string as-is", () => {
+    expect(emptyToNull("romaji")).toBe("romaji");
   });
 });
 

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -36,3 +36,7 @@ export function toSlug(str: string): string {
 export function formatPosition(position: number): string {
   return String(position + 1).padStart(2, "0");
 }
+
+export function emptyToNull(value?: string | null): string | null {
+  return value?.trim() || null;
+}


### PR DESCRIPTION
## Summary

- Add `emptyToNull` helper in `@zoonk/utils` to convert empty/whitespace strings to `null`
- Update AI prompts to instruct `null` instead of `""` for Roman-script romanization
- Change Zod schemas to `.nullable()` for all romanization fields (AI tasks + content contract)
- Apply `emptyToNull()` at the workflow boundary in all 4 activity generation steps
- Content contract now rejects empty strings via `.min(1).nullable()`

## Test plan

- [x] Unit tests for `emptyToNull` helper
- [x] Content contract tests: `null` parses, `""` rejects for romanization fields
- [x] Integration test: mock AI returns `""`, assert stored content has `null`
- [x] Eval test cases updated to expect `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized all romanization fields to use null (not empty strings) for Roman-script languages. This unifies validation, prompts, and storage, and prevents empty-string edge cases.

- **Refactors**
  - Added emptyToNull in @zoonk/utils and applied at workflow boundaries (grammar, story, sentences, vocabulary, save steps).
  - Updated content contract: romanization fields are now .min(1).nullable(); empty strings are rejected.
  - Updated AI task schemas and prompts to expect/produce null for Roman scripts; adjusted eval cases accordingly.
  - Updated types where needed (e.g., VocabularyWord.romanization is string | null).

- **Migration**
  - Producers must send null for Roman-script romanization and a non-empty string for non-Roman scripts.
  - Remove any usage of "" for romanization; handle null in clients and UI.
  - Optionally backfill stored "" values to null.

<sup>Written for commit 82004e4d6811ac6a66510097012cbe83af9123c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

