### PR TITLE
feat(api): add languageReview activity generation

### DIFF
--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.ts
@@ -1,6 +1,7 @@
 import { settled } from "@zoonk/utils/settled";
 import { completeActivityStep } from "./steps/complete-activity-step";
 import { completeListeningActivityStep } from "./steps/complete-listening-activity-step";
+import { copyLanguageReviewStepsStep } from "./steps/copy-language-review-steps-step";
 import { copyListeningStepsStep } from "./steps/copy-listening-steps-step";
 import { generateGrammarContentStep } from "./steps/generate-grammar-content-step";
 import { generateLanguageStoryContentStep } from "./steps/generate-language-story-content-step";
@@ -58,6 +59,7 @@ export async function languageActivityWorkflow(
     generateReadingAudioStep(activities, savedSentences),
     completeActivityStep(activities, workflowRunId, "vocabulary"),
     copyListeningStepsStep(activities, workflowRunId),
+    copyLanguageReviewStepsStep(activities, workflowRunId),
   ]);
 
   const { audioUrls: readingAudioUrls } = settled(readingAudioResult, { audioUrls: {} });
@@ -65,9 +67,10 @@ export async function languageActivityWorkflow(
   // Wave 5: save reading enrichments
   await updateReadingEnrichmentsStep(activities, savedSentences, readingAudioUrls);
 
-  // Wave 6: finalize reading + listening in parallel
+  // Wave 6: finalize reading + listening + languageReview in parallel
   await Promise.allSettled([
     completeActivityStep(activities, workflowRunId, "reading"),
     completeListeningActivityStep(activities, workflowRunId),
+    completeActivityStep(activities, workflowRunId, "languageReview"),
   ]);
 }

--- a/apps/api/src/workflows/activity-generation/steps/complete-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/complete-activity-step.ts
@@ -13,6 +13,7 @@ const kindToStepName: Partial<Record<ActivityKind, ActivityStepName>> = {
   examples: "setExamplesAsCompleted",
   explanation: "setExplanationAsCompleted",
   grammar: "setGrammarAsCompleted",
+  languageReview: "setLanguageReviewAsCompleted",
   languageStory: "setLanguageStoryAsCompleted",
   listening: "setListeningAsCompleted",
   mechanics: "setMechanicsAsCompleted",

--- a/apps/api/src/workflows/activity-generation/steps/copy-language-review-steps-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/copy-language-review-steps-step.ts
@@ -1,0 +1,94 @@
+import { assertStepContent } from "@zoonk/core/steps/content-contract";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { streamError, streamStatus } from "../stream-status";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
+import { type LessonActivity } from "./get-lesson-activities-step";
+import { handleActivityFailureStep } from "./handle-failure-step";
+import { setActivityAsRunningStep } from "./set-activity-as-running-step";
+
+export async function copyLanguageReviewStepsStep(
+  activities: LessonActivity[],
+  workflowRunId: string,
+): Promise<void> {
+  "use step";
+
+  const languageReview = findActivityByKind(activities, "languageReview");
+
+  if (!languageReview) {
+    return;
+  }
+
+  const current = await prisma.activity.findUnique({
+    select: { generationStatus: true },
+    where: { id: languageReview.id },
+  });
+
+  if (current?.generationStatus === "completed" || current?.generationStatus === "running") {
+    return;
+  }
+
+  if (current?.generationStatus === "failed") {
+    await safeAsync(() => prisma.step.deleteMany({ where: { activityId: languageReview.id } }));
+  }
+
+  const vocabulary = findActivityByKind(activities, "vocabulary");
+  const reading = findActivityByKind(activities, "reading");
+
+  const vocabularySteps = vocabulary
+    ? await prisma.step.findMany({
+        orderBy: { position: "asc" },
+        select: { position: true, wordId: true },
+        where: { activityId: vocabulary.id, kind: "vocabulary" },
+      })
+    : [];
+
+  const readingSteps = reading
+    ? await prisma.step.findMany({
+        orderBy: { position: "asc" },
+        select: { position: true, sentenceId: true },
+        where: { activityId: reading.id, kind: "reading" },
+      })
+    : [];
+
+  if (vocabularySteps.length === 0 && readingSteps.length === 0) {
+    await streamError({ reason: "noSourceData", step: "copyLanguageReviewSteps" });
+    await handleActivityFailureStep({ activityId: languageReview.id });
+    return;
+  }
+
+  await setActivityAsRunningStep({
+    activityId: languageReview.id,
+    workflowRunId,
+  });
+
+  await streamStatus({ status: "started", step: "copyLanguageReviewSteps" });
+
+  const vocabData = vocabularySteps.map((step, idx) => ({
+    activityId: languageReview.id,
+    content: assertStepContent("vocabulary", {}),
+    kind: "vocabulary" as const,
+    position: idx,
+    wordId: step.wordId,
+  }));
+
+  const readingData = readingSteps.map((step, idx) => ({
+    activityId: languageReview.id,
+    content: assertStepContent("reading", {}),
+    kind: "reading" as const,
+    position: vocabularySteps.length + idx,
+    sentenceId: step.sentenceId,
+  }));
+
+  const { error } = await safeAsync(() =>
+    prisma.step.createMany({ data: [...vocabData, ...readingData] }),
+  );
+
+  if (error) {
+    await streamError({ reason: "dbSaveFailed", step: "copyLanguageReviewSteps" });
+    await handleActivityFailureStep({ activityId: languageReview.id });
+    return;
+  }
+
+  await streamStatus({ status: "completed", step: "copyLanguageReviewSteps" });
+}

--- a/apps/api/src/workflows/config.ts
+++ b/apps/api/src/workflows/config.ts
@@ -59,9 +59,11 @@ const ACTIVITY_STEPS = [
   "generateAudio",
   "updateSentenceEnrichments",
   "copyListeningSteps",
+  "copyLanguageReviewSteps",
   "setVocabularyAsCompleted",
   "setReadingAsCompleted",
   "setListeningAsCompleted",
+  "setLanguageReviewAsCompleted",
   "setActivityAsCompleted",
   "workflowError",
 ] as const;

--- a/apps/main/e2e/generate-activity.test.ts
+++ b/apps/main/e2e/generate-activity.test.ts
@@ -268,6 +268,59 @@ async function createPendingLanguageStoryActivity() {
   return { activity, chapter, course, lesson };
 }
 
+async function createPendingLanguageReviewActivity() {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const uniqueId = randomUUID().slice(0, 8);
+  const courseTitle = `E2E LangReview Course ${uniqueId}`;
+  const chapterTitle = `E2E LangReview Chapter ${uniqueId}`;
+  const lessonTitle = `E2E LangReview Lesson ${uniqueId}`;
+  const activityTitle = `E2E LangReview Activity ${uniqueId}`;
+
+  const course = await courseFixture({
+    isPublished: true,
+    normalizedTitle: normalizeString(courseTitle),
+    organizationId: org.id,
+    slug: `e2e-lang-review-course-${uniqueId}`,
+    targetLanguage: "es",
+    title: courseTitle,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    generationStatus: "completed",
+    isPublished: true,
+    normalizedTitle: normalizeString(chapterTitle),
+    organizationId: org.id,
+    slug: `e2e-lang-review-chapter-${uniqueId}`,
+    title: chapterTitle,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "language",
+    normalizedTitle: normalizeString(lessonTitle),
+    organizationId: org.id,
+    slug: `e2e-lang-review-lesson-${uniqueId}`,
+    title: lessonTitle,
+  });
+
+  const activity = await activityFixture({
+    generationStatus: "pending",
+    isPublished: true,
+    kind: "languageReview",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    title: activityTitle,
+  });
+
+  return { activity, chapter, course, lesson };
+}
+
 /**
  * Creates a test subscription for the test user.
  */
@@ -1004,6 +1057,46 @@ test.describe("Generate Activity Page - With Subscription", () => {
         { status: "completed", step: "generateLanguageStoryContent" },
         { status: "started", step: "setLanguageStoryAsCompleted" },
         { status: "completed", step: "setLanguageStoryAsCompleted" },
+        { status: "started", step: "setActivityAsCompleted" },
+        { status: "completed", step: "setActivityAsCompleted" },
+      ],
+    });
+
+    await userWithoutProgress.goto(`/generate/a/${activity.id}`);
+
+    await expect(userWithoutProgress.getByText(/your activity is ready/i)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await expect(userWithoutProgress.getByText(/taking you to your activity/i)).toBeVisible();
+
+    await prisma.activity.update({
+      data: { generationStatus: "completed" },
+      where: { id: activity.id },
+    });
+
+    await userWithoutProgress.waitForURL(
+      new RegExp(
+        `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/${activity.position}`,
+      ),
+      { timeout: 10_000 },
+    );
+  });
+
+  test("completes workflow for languageReview activity kind", async ({ userWithoutProgress }) => {
+    await createTestSubscription();
+    const { activity, chapter, course, lesson } = await createPendingLanguageReviewActivity();
+
+    await setupMockApis(userWithoutProgress, {
+      streamMessages: [
+        { status: "started", step: "getLessonActivities" },
+        { status: "completed", step: "getLessonActivities" },
+        { status: "started", step: "setActivityAsRunning" },
+        { status: "completed", step: "setActivityAsRunning" },
+        { status: "started", step: "copyLanguageReviewSteps" },
+        { status: "completed", step: "copyLanguageReviewSteps" },
+        { status: "started", step: "setLanguageReviewAsCompleted" },
+        { status: "completed", step: "setLanguageReviewAsCompleted" },
         { status: "started", step: "setActivityAsCompleted" },
         { status: "completed", step: "setActivityAsCompleted" },
       ],

--- a/apps/main/src/lib/generation/activity-generation-phase-step-groups.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-step-groups.ts
@@ -15,6 +15,7 @@ const ALL_CONTENT_STEPS: ActivityStepName[] = [
   "generateSentences",
   "generateVocabularyContent",
   "copyListeningSteps",
+  "copyLanguageReviewSteps",
 ];
 
 const ALL_VOCABULARY_STEPS: ActivityStepName[] = [
@@ -45,6 +46,7 @@ const ALL_COMPLETION_STEPS: ActivityStepName[] = [
   "setVocabularyAsCompleted",
   "setReadingAsCompleted",
   "setListeningAsCompleted",
+  "setLanguageReviewAsCompleted",
   "setActivityAsCompleted",
 ];
 
@@ -63,6 +65,20 @@ export const LISTENING_DEPENDENCY_STEPS: ActivityStepName[] = [
   "updateVocabularyEnrichments",
   "generateGrammarContent",
   "generateSentences",
+  "setGrammarAsCompleted",
+  "setActivityAsCompleted",
+];
+
+export const LANGUAGE_REVIEW_DEPENDENCY_STEPS: ActivityStepName[] = [
+  "setActivityAsRunning",
+  "generateVocabularyContent",
+  "saveVocabularyWords",
+  "generateVocabularyPronunciation",
+  "generateVocabularyAudio",
+  "updateVocabularyEnrichments",
+  "generateGrammarContent",
+  "generateSentences",
+  "saveSentences",
   "setGrammarAsCompleted",
   "setActivityAsCompleted",
 ];

--- a/apps/main/src/lib/generation/activity-generation-phase-weights.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-weights.ts
@@ -72,6 +72,20 @@ export function getPhaseWeights(kind: ActivityKind): Record<PhaseName, number> {
     };
   }
 
+  if (kind === "languageReview") {
+    return {
+      addingPronunciation: 0,
+      buildingWordList: 0,
+      creatingImages: 0,
+      finishing: 5,
+      gettingStarted: 5,
+      preparingVisuals: 0,
+      processingDependencies: 75,
+      recordingAudio: 0,
+      writingContent: 15,
+    };
+  }
+
   if (kind === "story" || kind === "challenge" || kind === "review") {
     return {
       addingPronunciation: 0,

--- a/apps/main/src/lib/generation/activity-generation-phases.test.ts
+++ b/apps/main/src/lib/generation/activity-generation-phases.test.ts
@@ -237,6 +237,61 @@ describe("listening phase status", () => {
   });
 });
 
+describe("languageReview phase status", () => {
+  test("returns correct phase order for languageReview", () => {
+    expect(getPhaseOrder("languageReview")).toEqual([
+      "gettingStarted",
+      "processingDependencies",
+      "writingContent",
+      "finishing",
+    ]);
+  });
+
+  test("activates processingDependencies for dependency steps", () => {
+    const status = getPhaseStatus(
+      "processingDependencies",
+      ["setActivityAsRunning"],
+      "generateVocabularyContent",
+      "languageReview",
+    );
+
+    expect(status).toBe("active");
+  });
+
+  test("activates writingContent for copyLanguageReviewSteps", () => {
+    const status = getPhaseStatus(
+      "writingContent",
+      [
+        "setActivityAsRunning",
+        "generateVocabularyContent",
+        "saveVocabularyWords",
+        "generateVocabularyPronunciation",
+        "generateVocabularyAudio",
+        "updateVocabularyEnrichments",
+        "generateGrammarContent",
+        "generateSentences",
+        "saveSentences",
+        "setGrammarAsCompleted",
+        "setActivityAsCompleted",
+      ],
+      "copyLanguageReviewSteps",
+      "languageReview",
+    );
+
+    expect(status).toBe("active");
+  });
+
+  test("calculates progress for languageReview flow", () => {
+    const progress = calculateWeightedProgress(
+      ["setActivityAsRunning", "generateVocabularyContent", "saveVocabularyWords"],
+      "generateGrammarContent",
+      "languageReview",
+    );
+
+    expect(progress).toBeGreaterThan(0);
+  });
+});
+
 describe("reading phase status", () => {
   test("activates buildingWordList for sentence generation", () => {
     const status = getPhaseStatus(

--- a/apps/main/src/workflows/config.ts
+++ b/apps/main/src/workflows/config.ts
@@ -60,9 +60,11 @@ export const ACTIVITY_STEPS = [
   "generateAudio",
   "updateSentenceEnrichments",
   "copyListeningSteps",
+  "copyLanguageReviewSteps",
   "setVocabularyAsCompleted",
   "setReadingAsCompleted",
   "setListeningAsCompleted",
+  "setLanguageReviewAsCompleted",
   "setActivityAsCompleted",
   "workflowError",
 ] as const;
@@ -83,7 +85,8 @@ export type ActivityCompletionStep =
   | "setLanguageStoryAsCompleted"
   | "setVocabularyAsCompleted"
   | "setReadingAsCompleted"
-  | "setListeningAsCompleted";
+  | "setListeningAsCompleted"
+  | "setLanguageReviewAsCompleted";
 
 const activityCompletionSteps: Partial<Record<string, ActivityCompletionStep>> = {
   background: "setBackgroundAsCompleted",
@@ -92,6 +95,7 @@ const activityCompletionSteps: Partial<Record<string, ActivityCompletionStep>> =
   examples: "setExamplesAsCompleted",
   explanation: "setExplanationAsCompleted",
   grammar: "setGrammarAsCompleted",
+  languageReview: "setLanguageReviewAsCompleted",
   languageStory: "setLanguageStoryAsCompleted",
   listening: "setListeningAsCompleted",
   mechanics: "setMechanicsAsCompleted",


### PR DESCRIPTION
## Summary
- Add `copyLanguageReviewStepsStep` that copies vocabulary and reading steps into the `languageReview` activity for progress tracking via `step_attempts`
- Wire into language workflow Wave 4 (copy) and Wave 6 (completion) alongside listening
- Add phase config, weights, and step groups for `languageReview` in the main app generation UI

## Test plan
- [x] Integration tests: step creation, completion, vocab-only/reading-only, no-source failure, skip when completed, position ordering
- [x] Unit tests: phase order, dependency activation, writing activation, progress calculation
- [x] E2E test: full workflow completes and redirects for languageReview kind

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds languageReview activity generation by copying vocabulary and reading steps so progress is tracked via step_attempts. Integrates into the language workflow (Wave 4 copy, Wave 6 completion) and updates the generation UI to show correct phases and progress.

- **New Features**
  - Added copyLanguageReviewStepsStep to clone vocabulary and reading steps into languageReview, with vocabulary positioned before reading.
  - Handles edge cases: fails when no source steps, skips if already completed, clears stale steps on prior failure.
  - Finalizes languageReview in parallel with listening; added setLanguageReviewAsCompleted and new activity steps in API and main app configs.
  - Updated phase order, step groups, and weights for languageReview so UI progress and redirects work as expected.
  - Tests cover step creation/completion, vocab-only/reading-only flows, ordering, failure/skip paths, and full E2E redirect.

<sup>Written for commit b63e5218cf00f4b59401aa979bed594da49359f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

