### PR TITLE
feat(main): add activity player state reducer with sessionStorage persistence

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,9 @@
       "Read(.env.production)",
       "Read(**/.env.production)",
       "Read(.env.staging)",
-      "Read(**/.env.staging)"
+      "Read(**/.env.staging)",
+      "Bash(git push --force-with-lease:*)",
+      "Bash(git push --force:*)"
     ]
   },
   "enabledPlugins": {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -142,6 +142,7 @@
         "eslint/max-statements": "off",
         "eslint/no-magic-numbers": "off",
         "import/no-namespace": "off",
+        "typescript/no-explicit-any": "off",
         "typescript/no-non-null-assertion": "off",
         "typescript/no-unsafe-assignment": "off",
         "typescript/no-unsafe-call": "off",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ For detailed UX guidelines (interactions, animation, layout, accessibility), see
 - When adding a new endpoint, add docs for it in `document.ts`
 - When adding e2e tests, use `*Fixture()` functions to create unique test data per test - do not modify seed files
 - Avoid inline imports like `await import()`, only do it when dynamic imports are absolutely necessary
+- Never use `git push --force` or `git push --force-with-lease`. When you make a change, just add a new commit and push it, no need to rewrite history
 
 ## Component Organization
 

--- a/apps/main/src/components/activity-player/player-reducer.test.ts
+++ b/apps/main/src/components/activity-player/player-reducer.test.ts
@@ -1,0 +1,384 @@
+import {
+  type SerializedActivity,
+  type SerializedStep,
+} from "@/data/activities/prepare-activity-data";
+import { describe, expect, test } from "vitest";
+import {
+  PLAYER_STATE_VERSION,
+  type PlayerAction,
+  type PlayerState,
+  type SelectedAnswer,
+  type StepResult,
+  createInitialState,
+  playerReducer,
+} from "./player-reducer";
+
+function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
+  return {
+    content: { text: "Hello", title: "Intro", variant: "text" as const },
+    id: overrides.id ?? "step-1",
+    kind: overrides.kind ?? "static",
+    position: overrides.position ?? 0,
+    sentence: null,
+    visualContent: null,
+    visualKind: null,
+    word: null,
+    ...overrides,
+  };
+}
+
+function buildActivity(steps: SerializedStep[] = [buildStep()]): SerializedActivity {
+  return {
+    description: null,
+    id: "activity-1",
+    kind: "core",
+    language: "en",
+    lessonSentences: [],
+    lessonWords: [],
+    organizationId: 1,
+    steps,
+    title: "Test Activity",
+  };
+}
+
+function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
+  return {
+    activityId: "activity-1",
+    currentStepIndex: 0,
+    dimensions: {},
+    phase: "playing",
+    results: {},
+    selectedAnswers: {},
+    steps: [buildStep()],
+    version: PLAYER_STATE_VERSION,
+    ...overrides,
+  };
+}
+
+const mcAnswer: SelectedAnswer = { kind: "multipleChoice", selectedIndex: 0 };
+
+describe(createInitialState, () => {
+  test("sets phase to playing and index to 0", () => {
+    const activity = buildActivity();
+    const state = createInitialState(activity);
+    expect(state.phase).toBe("playing");
+    expect(state.currentStepIndex).toBe(0);
+  });
+
+  test("copies activityId and steps", () => {
+    const steps = [buildStep({ id: "s1" }), buildStep({ id: "s2", position: 1 })];
+    const activity = buildActivity(steps);
+    const state = createInitialState(activity);
+    expect(state.activityId).toBe("activity-1");
+    expect(state.steps).toEqual(steps);
+  });
+
+  test("initializes empty maps", () => {
+    const state = createInitialState(buildActivity());
+    expect(state.selectedAnswers).toEqual({});
+    expect(state.results).toEqual({});
+    expect(state.dimensions).toEqual({});
+  });
+
+  test("sets version to current", () => {
+    const state = createInitialState(buildActivity());
+    expect(state.version).toBe(PLAYER_STATE_VERSION);
+  });
+});
+
+describe("SELECT_ANSWER", () => {
+  test("stores answer by stepId", () => {
+    const state = buildState();
+    const next = playerReducer(state, {
+      answer: mcAnswer,
+      stepId: "step-1",
+      type: "SELECT_ANSWER",
+    });
+    expect(next.selectedAnswers["step-1"]).toEqual(mcAnswer);
+  });
+
+  test("does not change phase or index", () => {
+    const state = buildState();
+    const next = playerReducer(state, {
+      answer: mcAnswer,
+      stepId: "step-1",
+      type: "SELECT_ANSWER",
+    });
+    expect(next.phase).toBe("playing");
+    expect(next.currentStepIndex).toBe(0);
+  });
+
+  test("overwrites previous answer for same step", () => {
+    const state = buildState({
+      selectedAnswers: { "step-1": { kind: "multipleChoice", selectedIndex: 1 } },
+    });
+    const next = playerReducer(state, {
+      answer: mcAnswer,
+      stepId: "step-1",
+      type: "SELECT_ANSWER",
+    });
+    expect(next.selectedAnswers["step-1"]).toEqual(mcAnswer);
+  });
+});
+
+describe("CHECK_ANSWER", () => {
+  test("transitions from playing to feedback and stores result", () => {
+    const step = buildStep({ id: "mc-1", kind: "multipleChoice" });
+    const state = buildState({ steps: [step] });
+    const next = playerReducer(state, {
+      effects: [],
+      result: { feedback: "Correct!", isCorrect: true },
+      stepId: "mc-1",
+      type: "CHECK_ANSWER",
+    });
+    expect(next.phase).toBe("feedback");
+    expect(next.results["mc-1"]).toEqual({
+      answer: undefined,
+      effects: [],
+      result: { feedback: "Correct!", isCorrect: true },
+      stepId: "mc-1",
+    });
+  });
+
+  test("includes selected answer in the result", () => {
+    const step = buildStep({ id: "mc-1", kind: "multipleChoice" });
+    const state = buildState({
+      selectedAnswers: { "mc-1": mcAnswer },
+      steps: [step],
+    });
+    const next = playerReducer(state, {
+      effects: [],
+      result: { feedback: "Correct!", isCorrect: true },
+      stepId: "mc-1",
+      type: "CHECK_ANSWER",
+    });
+    expect(next.results["mc-1"]?.answer).toEqual(mcAnswer);
+  });
+
+  test("applies positive effect to dimensions", () => {
+    const state = buildState();
+    const next = playerReducer(state, {
+      effects: [{ dimension: "Quality", impact: "positive" }],
+      result: { feedback: null, isCorrect: true },
+      stepId: "step-1",
+      type: "CHECK_ANSWER",
+    });
+    expect(next.dimensions).toEqual({ Quality: 1 });
+  });
+
+  test("applies negative effect to dimensions", () => {
+    const state = buildState();
+    const next = playerReducer(state, {
+      effects: [{ dimension: "Quality", impact: "negative" }],
+      result: { feedback: null, isCorrect: true },
+      stepId: "step-1",
+      type: "CHECK_ANSWER",
+    });
+    expect(next.dimensions).toEqual({ Quality: -1 });
+  });
+
+  test("applies neutral effect (zero change)", () => {
+    const state = buildState();
+    const next = playerReducer(state, {
+      effects: [{ dimension: "Quality", impact: "neutral" }],
+      result: { feedback: null, isCorrect: true },
+      stepId: "step-1",
+      type: "CHECK_ANSWER",
+    });
+    expect(next.dimensions).toEqual({ Quality: 0 });
+  });
+
+  test("accumulates effects on same dimension across multiple calls", () => {
+    const steps = [
+      buildStep({ id: "s1", kind: "multipleChoice" }),
+      buildStep({ id: "s2", kind: "multipleChoice", position: 1 }),
+    ];
+    let state = buildState({ steps });
+    state = playerReducer(state, {
+      effects: [{ dimension: "Quality", impact: "positive" }],
+      result: { feedback: null, isCorrect: true },
+      stepId: "s1",
+      type: "CHECK_ANSWER",
+    });
+    // Simulate continue + next step
+    state = { ...state, currentStepIndex: 1, phase: "playing" };
+    state = playerReducer(state, {
+      effects: [{ dimension: "Quality", impact: "positive" }],
+      result: { feedback: null, isCorrect: true },
+      stepId: "s2",
+      type: "CHECK_ANSWER",
+    });
+    expect(state.dimensions).toEqual({ Quality: 2 });
+  });
+
+  test("no-ops in feedback phase", () => {
+    const state = buildState({ phase: "feedback" });
+    const next = playerReducer(state, {
+      effects: [],
+      result: { feedback: null, isCorrect: true },
+      stepId: "step-1",
+      type: "CHECK_ANSWER",
+    });
+    expect(next).toBe(state);
+  });
+
+  test("no-ops in completed phase", () => {
+    const state = buildState({ phase: "completed" });
+    const next = playerReducer(state, {
+      effects: [],
+      result: { feedback: null, isCorrect: true },
+      stepId: "step-1",
+      type: "CHECK_ANSWER",
+    });
+    expect(next).toBe(state);
+  });
+});
+
+describe("CONTINUE", () => {
+  test("advances from feedback to playing on next step", () => {
+    const steps = [buildStep({ id: "s1" }), buildStep({ id: "s2", position: 1 })];
+    const state = buildState({ currentStepIndex: 0, phase: "feedback", steps });
+    const next = playerReducer(state, { type: "CONTINUE" });
+    expect(next.phase).toBe("playing");
+    expect(next.currentStepIndex).toBe(1);
+  });
+
+  test("sets completed when on last step", () => {
+    const state = buildState({ currentStepIndex: 0, phase: "feedback", steps: [buildStep()] });
+    const next = playerReducer(state, { type: "CONTINUE" });
+    expect(next.phase).toBe("completed");
+  });
+
+  test("no-ops in playing phase", () => {
+    const state = buildState({ phase: "playing" });
+    const next = playerReducer(state, { type: "CONTINUE" });
+    expect(next).toBe(state);
+  });
+
+  test("no-ops in completed phase", () => {
+    const state = buildState({ phase: "completed" });
+    const next = playerReducer(state, { type: "CONTINUE" });
+    expect(next).toBe(state);
+  });
+});
+
+describe("NAVIGATE_STEP", () => {
+  const staticSteps = [
+    buildStep({ id: "s1", kind: "static", position: 0 }),
+    buildStep({ id: "s2", kind: "static", position: 1 }),
+    buildStep({ id: "s3", kind: "static", position: 2 }),
+  ];
+
+  test("next advances on static step", () => {
+    const state = buildState({ currentStepIndex: 0, steps: staticSteps });
+    const next = playerReducer(state, { direction: "next", type: "NAVIGATE_STEP" });
+    expect(next.currentStepIndex).toBe(1);
+    expect(next.phase).toBe("playing");
+  });
+
+  test("prev goes back on static step", () => {
+    const state = buildState({ currentStepIndex: 1, steps: staticSteps });
+    const next = playerReducer(state, { direction: "prev", type: "NAVIGATE_STEP" });
+    expect(next.currentStepIndex).toBe(0);
+  });
+
+  test("prev clamps at 0", () => {
+    const state = buildState({ currentStepIndex: 0, steps: staticSteps });
+    const next = playerReducer(state, { direction: "prev", type: "NAVIGATE_STEP" });
+    expect(next.currentStepIndex).toBe(0);
+  });
+
+  test("next on last step sets completed", () => {
+    const state = buildState({ currentStepIndex: 2, steps: staticSteps });
+    const next = playerReducer(state, { direction: "next", type: "NAVIGATE_STEP" });
+    expect(next.phase).toBe("completed");
+  });
+
+  test("no-ops on interactive step", () => {
+    const steps = [buildStep({ id: "mc-1", kind: "multipleChoice" })];
+    const state = buildState({ steps });
+    const next = playerReducer(state, { direction: "next", type: "NAVIGATE_STEP" });
+    expect(next).toBe(state);
+  });
+
+  test("no-ops in feedback phase", () => {
+    const state = buildState({ phase: "feedback", steps: staticSteps });
+    const next = playerReducer(state, { direction: "next", type: "NAVIGATE_STEP" });
+    expect(next).toBe(state);
+  });
+
+  test("no-ops in completed phase", () => {
+    const state = buildState({ phase: "completed", steps: staticSteps });
+    const next = playerReducer(state, { direction: "next", type: "NAVIGATE_STEP" });
+    expect(next).toBe(state);
+  });
+});
+
+describe("COMPLETE", () => {
+  test("sets completed from playing", () => {
+    const state = buildState({ phase: "playing" });
+    const next = playerReducer(state, { type: "COMPLETE" });
+    expect(next.phase).toBe("completed");
+  });
+
+  test("sets completed from feedback", () => {
+    const state = buildState({ phase: "feedback" });
+    const next = playerReducer(state, { type: "COMPLETE" });
+    expect(next.phase).toBe("completed");
+  });
+
+  test("no-ops when already completed", () => {
+    const state = buildState({ phase: "completed" });
+    const next = playerReducer(state, { type: "COMPLETE" });
+    expect(next).toBe(state);
+  });
+});
+
+describe("edge cases", () => {
+  test("unknown action returns state unchanged", () => {
+    const state = buildState();
+    const next = playerReducer(state, { type: "UNKNOWN" } as any as PlayerAction);
+    expect(next).toBe(state);
+  });
+
+  test("empty steps array", () => {
+    const activity = buildActivity([]);
+    const state = createInitialState(activity);
+    expect(state.steps).toEqual([]);
+    expect(state.currentStepIndex).toBe(0);
+  });
+
+  test("CHECK_ANSWER with multiple effects on different dimensions", () => {
+    const state = buildState();
+    const next = playerReducer(state, {
+      effects: [
+        { dimension: "Quality", impact: "positive" },
+        { dimension: "Speed", impact: "negative" },
+        { dimension: "Budget", impact: "neutral" },
+      ],
+      result: { feedback: null, isCorrect: true },
+      stepId: "step-1",
+      type: "CHECK_ANSWER",
+    });
+    expect(next.dimensions).toEqual({ Budget: 0, Quality: 1, Speed: -1 });
+  });
+
+  test("results include the stored StepResult structure", () => {
+    const step = buildStep({ id: "mc-1", kind: "multipleChoice" });
+    const answer: SelectedAnswer = { kind: "multipleChoice", selectedIndex: 2 };
+    const state = buildState({ selectedAnswers: { "mc-1": answer }, steps: [step] });
+    const next = playerReducer(state, {
+      effects: [{ dimension: "Quality", impact: "positive" }],
+      result: { feedback: "Good!", isCorrect: true },
+      stepId: "mc-1",
+      type: "CHECK_ANSWER",
+    });
+    const expected: StepResult = {
+      answer,
+      effects: [{ dimension: "Quality", impact: "positive" }],
+      result: { feedback: "Good!", isCorrect: true },
+      stepId: "mc-1",
+    };
+    expect(next.results["mc-1"]).toEqual(expected);
+  });
+});

--- a/apps/main/src/components/activity-player/player-reducer.ts
+++ b/apps/main/src/components/activity-player/player-reducer.ts
@@ -1,0 +1,205 @@
+import {
+  type SerializedActivity,
+  type SerializedStep,
+} from "@/data/activities/prepare-activity-data";
+import { type AnswerResult } from "@zoonk/core/player/check-answer";
+import { type ChallengeEffect } from "@zoonk/core/steps/content-contract";
+
+export const PLAYER_STATE_VERSION = 1;
+
+export type PlayerPhase = "playing" | "feedback" | "completed";
+
+export type SelectedAnswer =
+  | { kind: "fillBlank"; userAnswers: string[] }
+  | { kind: "listening"; arrangedWords: string[] }
+  | { kind: "matchColumns"; userPairs: { left: string; right: string }[] }
+  | { kind: "multipleChoice"; selectedIndex: number }
+  | { kind: "reading"; arrangedWords: string[] }
+  | { kind: "selectImage"; selectedIndex: number }
+  | { kind: "sortOrder"; userOrder: string[] }
+  | { kind: "vocabulary"; selectedWordId: string };
+
+export type StepResult = {
+  stepId: string;
+  answer: SelectedAnswer | undefined;
+  result: AnswerResult;
+  effects: ChallengeEffect[];
+};
+
+export type DimensionInventory = Record<string, number>;
+
+export type PlayerState = {
+  activityId: string;
+  steps: SerializedStep[];
+  currentStepIndex: number;
+  phase: PlayerPhase;
+  selectedAnswers: Record<string, SelectedAnswer>;
+  results: Record<string, StepResult>;
+  dimensions: DimensionInventory;
+  version: number;
+};
+
+export type PlayerAction =
+  | { type: "SELECT_ANSWER"; stepId: string; answer: SelectedAnswer }
+  | { type: "CHECK_ANSWER"; stepId: string; result: AnswerResult; effects: ChallengeEffect[] }
+  | { type: "CONTINUE" }
+  | { type: "COMPLETE" }
+  | { type: "NAVIGATE_STEP"; direction: "next" | "prev" };
+
+function effectDelta(impact: ChallengeEffect["impact"]): number {
+  if (impact === "positive") {
+    return 1;
+  }
+
+  if (impact === "negative") {
+    return -1;
+  }
+
+  return 0;
+}
+
+function applyEffects(
+  dimensions: DimensionInventory,
+  effects: ChallengeEffect[],
+): DimensionInventory {
+  if (effects.length === 0) {
+    return dimensions;
+  }
+
+  const next = { ...dimensions };
+
+  for (const effect of effects) {
+    next[effect.dimension] = (next[effect.dimension] ?? 0) + effectDelta(effect.impact);
+  }
+
+  return next;
+}
+
+function isStaticStep(step: SerializedStep): boolean {
+  return step.kind === "static";
+}
+
+export function createInitialState(activity: SerializedActivity): PlayerState {
+  return {
+    activityId: activity.id,
+    currentStepIndex: 0,
+    dimensions: {},
+    phase: "playing",
+    results: {},
+    selectedAnswers: {},
+    steps: activity.steps,
+    version: PLAYER_STATE_VERSION,
+  };
+}
+
+function handleSelectAnswer(
+  state: PlayerState,
+  action: Extract<PlayerAction, { type: "SELECT_ANSWER" }>,
+): PlayerState {
+  return {
+    ...state,
+    selectedAnswers: { ...state.selectedAnswers, [action.stepId]: action.answer },
+  };
+}
+
+function handleCheckAnswer(
+  state: PlayerState,
+  action: Extract<PlayerAction, { type: "CHECK_ANSWER" }>,
+): PlayerState {
+  if (state.phase !== "playing") {
+    return state;
+  }
+
+  const stepResult: StepResult = {
+    answer: state.selectedAnswers[action.stepId],
+    effects: action.effects,
+    result: action.result,
+    stepId: action.stepId,
+  };
+
+  return {
+    ...state,
+    dimensions: applyEffects(state.dimensions, action.effects),
+    phase: "feedback",
+    results: { ...state.results, [action.stepId]: stepResult },
+  };
+}
+
+function handleContinue(state: PlayerState): PlayerState {
+  if (state.phase !== "feedback") {
+    return state;
+  }
+
+  const nextIndex = state.currentStepIndex + 1;
+  const isLast = nextIndex >= state.steps.length;
+
+  return {
+    ...state,
+    currentStepIndex: isLast ? state.currentStepIndex : nextIndex,
+    phase: isLast ? "completed" : "playing",
+  };
+}
+
+function handleNavigateStep(
+  state: PlayerState,
+  action: Extract<PlayerAction, { type: "NAVIGATE_STEP" }>,
+): PlayerState {
+  if (state.phase !== "playing") {
+    return state;
+  }
+
+  const currentStep = state.steps[state.currentStepIndex];
+
+  if (!currentStep || !isStaticStep(currentStep)) {
+    return state;
+  }
+
+  if (action.direction === "prev") {
+    const prevIndex = Math.max(0, state.currentStepIndex - 1);
+
+    if (prevIndex === state.currentStepIndex) {
+      return state;
+    }
+
+    return { ...state, currentStepIndex: prevIndex };
+  }
+
+  const nextIndex = state.currentStepIndex + 1;
+  const isLast = nextIndex >= state.steps.length;
+
+  return {
+    ...state,
+    currentStepIndex: isLast ? state.currentStepIndex : nextIndex,
+    phase: isLast ? "completed" : "playing",
+  };
+}
+
+function handleComplete(state: PlayerState): PlayerState {
+  if (state.phase === "completed") {
+    return state;
+  }
+
+  return { ...state, phase: "completed" };
+}
+
+export function playerReducer(state: PlayerState, action: PlayerAction): PlayerState {
+  switch (action.type) {
+    case "SELECT_ANSWER":
+      return handleSelectAnswer(state, action);
+
+    case "CHECK_ANSWER":
+      return handleCheckAnswer(state, action);
+
+    case "CONTINUE":
+      return handleContinue(state);
+
+    case "NAVIGATE_STEP":
+      return handleNavigateStep(state, action);
+
+    case "COMPLETE":
+      return handleComplete(state);
+
+    default:
+      return state;
+  }
+}

--- a/apps/main/src/components/activity-player/use-player-state.test.ts
+++ b/apps/main/src/components/activity-player/use-player-state.test.ts
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+import {
+  type SerializedActivity,
+  type SerializedStep,
+} from "@/data/activities/prepare-activity-data";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
+import { PLAYER_STATE_VERSION, createInitialState } from "./player-reducer";
+import { playerStorageKey, usePlayerState } from "./use-player-state";
+
+function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
+  return {
+    content: { text: "Hello", title: "Intro", variant: "text" as const },
+    id: overrides.id ?? "step-1",
+    kind: overrides.kind ?? "static",
+    position: overrides.position ?? 0,
+    sentence: null,
+    visualContent: null,
+    visualKind: null,
+    word: null,
+    ...overrides,
+  };
+}
+
+function buildActivity(overrides: Partial<SerializedActivity> = {}): SerializedActivity {
+  return {
+    description: null,
+    id: overrides.id ?? "activity-test",
+    kind: "core",
+    language: "en",
+    lessonSentences: [],
+    lessonWords: [],
+    organizationId: 1,
+    steps: overrides.steps ?? [
+      buildStep(),
+      buildStep({ id: "step-2", kind: "multipleChoice", position: 1 }),
+    ],
+    title: "Test Activity",
+    ...overrides,
+  };
+}
+
+describe(usePlayerState, () => {
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  describe("initialization", () => {
+    test("creates fresh state when no sessionStorage data", () => {
+      const activity = buildActivity();
+      const { result } = renderHook(() => usePlayerState(activity));
+      expect(result.current.state.phase).toBe("playing");
+      expect(result.current.state.currentStepIndex).toBe(0);
+      expect(result.current.state.activityId).toBe("activity-test");
+    });
+
+    test("resumes from sessionStorage with matching version", () => {
+      const activity = buildActivity();
+      const persisted = {
+        ...createInitialState(activity),
+        currentStepIndex: 1,
+        phase: "feedback" as const,
+      };
+      sessionStorage.setItem(playerStorageKey(activity.id), JSON.stringify(persisted));
+
+      const { result } = renderHook(() => usePlayerState(activity));
+      expect(result.current.state.currentStepIndex).toBe(1);
+      expect(result.current.state.phase).toBe("feedback");
+    });
+
+    test("discards data with mismatched version", () => {
+      const activity = buildActivity();
+      const persisted = {
+        ...createInitialState(activity),
+        currentStepIndex: 1,
+        version: 999,
+      };
+      sessionStorage.setItem(playerStorageKey(activity.id), JSON.stringify(persisted));
+
+      const { result } = renderHook(() => usePlayerState(activity));
+      expect(result.current.state.currentStepIndex).toBe(0);
+      expect(result.current.state.version).toBe(PLAYER_STATE_VERSION);
+    });
+
+    test("discards corrupt (non-JSON) data", () => {
+      const activity = buildActivity();
+      sessionStorage.setItem(playerStorageKey(activity.id), "not-json{{{");
+
+      const { result } = renderHook(() => usePlayerState(activity));
+      expect(result.current.state.phase).toBe("playing");
+      expect(result.current.state.currentStepIndex).toBe(0);
+    });
+  });
+
+  describe("persistence", () => {
+    test("writes to sessionStorage after dispatch", () => {
+      const activity = buildActivity();
+      const { result } = renderHook(() => usePlayerState(activity));
+
+      act(() => {
+        result.current.dispatch({
+          answer: { kind: "multipleChoice", selectedIndex: 0 },
+          stepId: "step-1",
+          type: "SELECT_ANSWER",
+        });
+      });
+
+      const stored = sessionStorage.getItem(playerStorageKey(activity.id));
+      expect(stored).not.toBeNull();
+      const parsed = JSON.parse(stored!);
+      expect(parsed.selectedAnswers["step-1"]).toEqual({
+        kind: "multipleChoice",
+        selectedIndex: 0,
+      });
+    });
+
+    test("key format is zoonk:player:{activityId}", () => {
+      expect(playerStorageKey("abc-123")).toBe("zoonk:player:abc-123");
+    });
+
+    test("clears storage when completed", () => {
+      const activity = buildActivity({ steps: [buildStep()] });
+      const { result } = renderHook(() => usePlayerState(activity));
+
+      act(() => {
+        result.current.dispatch({
+          effects: [],
+          result: { feedback: null, isCorrect: true },
+          stepId: "step-1",
+          type: "CHECK_ANSWER",
+        });
+      });
+
+      expect(sessionStorage.getItem(playerStorageKey(activity.id))).not.toBeNull();
+
+      act(() => {
+        result.current.dispatch({ type: "CONTINUE" });
+      });
+
+      expect(result.current.state.phase).toBe("completed");
+      expect(sessionStorage.getItem(playerStorageKey(activity.id))).toBeNull();
+    });
+
+    test("persists multiple dispatches correctly", () => {
+      const activity = buildActivity();
+      const { result } = renderHook(() => usePlayerState(activity));
+
+      act(() => {
+        result.current.dispatch({
+          answer: { kind: "multipleChoice", selectedIndex: 0 },
+          stepId: "step-1",
+          type: "SELECT_ANSWER",
+        });
+      });
+
+      act(() => {
+        result.current.dispatch({
+          effects: [],
+          result: { feedback: "Good!", isCorrect: true },
+          stepId: "step-1",
+          type: "CHECK_ANSWER",
+        });
+      });
+
+      const stored = sessionStorage.getItem(playerStorageKey(activity.id));
+      const parsed = JSON.parse(stored!);
+      expect(parsed.phase).toBe("feedback");
+      expect(parsed.results["step-1"].result.isCorrect).toBeTruthy();
+    });
+  });
+});

--- a/apps/main/src/components/activity-player/use-player-state.ts
+++ b/apps/main/src/components/activity-player/use-player-state.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { type SerializedActivity } from "@/data/activities/prepare-activity-data";
+import { isJsonObject } from "@zoonk/utils/json";
+import { useCallback, useState } from "react";
+import {
+  PLAYER_STATE_VERSION,
+  type PlayerAction,
+  type PlayerState,
+  createInitialState,
+  playerReducer,
+} from "./player-reducer";
+
+export function playerStorageKey(activityId: string): string {
+  return `zoonk:player:${activityId}`;
+}
+
+function loadPersistedState(activityId: string): PlayerState | null {
+  if (typeof sessionStorage === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = sessionStorage.getItem(playerStorageKey(activityId));
+
+    if (!raw) {
+      return null;
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+
+    if (!isJsonObject(parsed) || parsed.version !== PLAYER_STATE_VERSION) {
+      return null;
+    }
+
+    // oxlint-disable-next-line no-unsafe-type-assertion -- version-gated self-written sessionStorage data
+    return parsed as PlayerState;
+  } catch {
+    return null;
+  }
+}
+
+function persistState(state: PlayerState): void {
+  try {
+    sessionStorage.setItem(playerStorageKey(state.activityId), JSON.stringify(state));
+  } catch {
+    // setItem throws on quota exceeded or in private browsing
+  }
+}
+
+export function usePlayerState(activity: SerializedActivity) {
+  const [state, setState] = useState<PlayerState>(
+    () => loadPersistedState(activity.id) ?? createInitialState(activity),
+  );
+
+  const dispatch = useCallback((action: PlayerAction) => {
+    setState((prev) => {
+      const next = playerReducer(prev, action);
+
+      if (next.phase === "completed") {
+        sessionStorage.removeItem(playerStorageKey(next.activityId));
+      } else {
+        persistState(next);
+      }
+
+      return next;
+    });
+  }, []);
+
+  return { dispatch, state };
+}

--- a/knip.json
+++ b/knip.json
@@ -35,6 +35,8 @@
       "ignore": [
         "e2e/**",
         "setup-tests.ts",
+        "src/components/activity-player/player-reducer.ts",
+        "src/components/activity-player/use-player-state.ts",
         "src/data/activities/get-lesson-sentences.ts",
         "src/data/activities/get-lesson-words.ts",
         "src/data/activities/prepare-activity-data.ts"

--- a/packages/core/src/steps/content-contract.ts
+++ b/packages/core/src/steps/content-contract.ts
@@ -179,6 +179,8 @@ export type VocabularyStepContent = z.infer<typeof vocabularyContentSchema>;
 export type ReadingStepContent = z.infer<typeof readingContentSchema>;
 export type ListeningStepContent = z.infer<typeof listeningContentSchema>;
 
+export type ChallengeEffect = z.infer<typeof challengeEffectSchema>;
+
 export type StepContentByKind = {
   fillBlank: FillBlankStepContent;
   listening: ListeningStepContent;


### PR DESCRIPTION
## Summary

- Add pure `playerReducer` with 5 actions: `SELECT_ANSWER`, `CHECK_ANSWER`, `CONTINUE`, `NAVIGATE_STEP`, `COMPLETE`
- Add `usePlayerState` hook with `sessionStorage` persistence (no `useEffect` — persists synchronously via `useState` functional updater)
- Export `ChallengeEffect` type from `@zoonk/core/steps/content-contract`

## Test plan

- [x] 33 unit tests for all reducer transitions and edge cases
- [x] 8 hook tests (jsdom) for initialization, persistence, version gating, and cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reducer-driven activity player and a state hook with sessionStorage persistence so progress survives reloads and step flow stays consistent. Also exports ChallengeEffect for effect tracking.

- **New Features**
  - Pure playerReducer with actions: SELECT_ANSWER, CHECK_ANSWER, CONTINUE, NAVIGATE_STEP, COMPLETE.
  - Stores per-step results and aggregates ChallengeEffect impacts into a dimensions inventory.
  - Static steps support prev/next; interactive steps advance via CHECK_ANSWER; phases: playing → feedback → completed.
  - usePlayerState persists to sessionStorage (zoonk:player:{activityId}), resumes only on matching version, and clears on completion.
  - Exports ChallengeEffect from @zoonk/core/steps/content-contract.

- **Refactors**
  - Documented “no force push” policy; updated lint and knip configs for the new player files.

<sup>Written for commit 9daf46728bf44232d6fb818fccfdddda59470055. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

