### PR TITLE
feat(main): prefetch only completed chapters/lessons

### DIFF
--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -40,6 +40,7 @@ export async function LessonList({
               href={`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lesson.slug}`}
               id={lesson.id}
               key={lesson.id}
+              prefetch={lesson.generationStatus === "completed"}
             >
               <CatalogListItemPosition>{formatPosition(lesson.position)}</CatalogListItemPosition>
 

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -9,7 +9,7 @@ import {
   CatalogListItemTitle,
   CatalogListSearch,
 } from "@/components/catalog/catalog-list";
-import { type ChapterWithLessons } from "@/data/chapters/list-course-chapters";
+import { type ChapterForList } from "@/data/chapters/list-course-chapters";
 import { formatPosition } from "@zoonk/utils/string";
 import { getExtracted } from "next-intl/server";
 
@@ -19,7 +19,7 @@ export async function ChapterList({
   courseSlug,
 }: {
   brandSlug: string;
-  chapters: ChapterWithLessons[];
+  chapters: ChapterForList[];
   courseSlug: string;
 }) {
   if (chapters.length === 0) {
@@ -38,6 +38,7 @@ export async function ChapterList({
               href={`/b/${brandSlug}/c/${courseSlug}/ch/${chapter.slug}`}
               id={chapter.id}
               key={chapter.id}
+              prefetch={chapter.generationStatus === "completed"}
             >
               <CatalogListItemPosition>{formatPosition(chapter.position)}</CatalogListItemPosition>
 

--- a/apps/main/src/components/catalog/catalog-list.tsx
+++ b/apps/main/src/components/catalog/catalog-list.tsx
@@ -117,11 +117,13 @@ export function CatalogListItem({
   className,
   href,
   id,
+  prefetch,
 }: {
   children: ReactNode;
   className?: string;
   href: string;
   id: string | number | bigint;
+  prefetch?: boolean;
 }) {
   const context = use(CatalogListContext);
   const filteredIds = context?.filteredIds ?? null;
@@ -138,6 +140,7 @@ export function CatalogListItem({
           className,
         )}
         href={href}
+        prefetch={prefetch}
       >
         {children}
       </ClientLink>

--- a/apps/main/src/data/chapters/list-course-chapters.ts
+++ b/apps/main/src/data/chapters/list-course-chapters.ts
@@ -1,40 +1,24 @@
 import "server-only";
-import { prisma } from "@zoonk/db";
+import { type GenerationStatus, prisma } from "@zoonk/db";
 import { cache } from "react";
 
-export type ChapterWithLessons = {
+export type ChapterForList = {
   id: number;
   slug: string;
   title: string;
   description: string;
   position: number;
-  lessons: {
-    id: number;
-    slug: string;
-    title: string;
-    description: string;
-    position: number;
-  }[];
+  generationStatus: GenerationStatus;
 };
 
 const cachedListCourseChapters = cache(
-  async (brandSlug: string, courseSlug: string, language: string): Promise<ChapterWithLessons[]> =>
+  async (brandSlug: string, courseSlug: string, language: string): Promise<ChapterForList[]> =>
     prisma.chapter.findMany({
       orderBy: { position: "asc" },
       select: {
         description: true,
+        generationStatus: true,
         id: true,
-        lessons: {
-          orderBy: { position: "asc" },
-          select: {
-            description: true,
-            id: true,
-            position: true,
-            slug: true,
-            title: true,
-          },
-          where: { isPublished: true },
-        },
         position: true,
         slug: true,
         title: true,
@@ -58,6 +42,6 @@ export function listCourseChapters(params: {
   brandSlug: string;
   courseSlug: string;
   language: string;
-}): Promise<ChapterWithLessons[]> {
+}): Promise<ChapterForList[]> {
   return cachedListCourseChapters(params.brandSlug, params.courseSlug, params.language);
 }

--- a/apps/main/src/data/lessons/list-chapter-lessons.test.ts
+++ b/apps/main/src/data/lessons/list-chapter-lessons.test.ts
@@ -115,5 +115,6 @@ describe(listChapterLessons, () => {
     expect(lesson).toHaveProperty("title");
     expect(lesson).toHaveProperty("description");
     expect(lesson).toHaveProperty("position");
+    expect(lesson).toHaveProperty("generationStatus");
   });
 });

--- a/apps/main/src/data/lessons/list-chapter-lessons.ts
+++ b/apps/main/src/data/lessons/list-chapter-lessons.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { prisma } from "@zoonk/db";
+import { type GenerationStatus, prisma } from "@zoonk/db";
 import { cache } from "react";
 
 export type LessonForList = {
@@ -8,6 +8,7 @@ export type LessonForList = {
   title: string;
   description: string;
   position: number;
+  generationStatus: GenerationStatus;
 };
 
 const cachedListChapterLessons = cache(
@@ -16,6 +17,7 @@ const cachedListChapterLessons = cache(
       orderBy: { position: "asc" },
       select: {
         description: true,
+        generationStatus: true,
         id: true,
         position: true,
         slug: true,


### PR DESCRIPTION
## Summary

- Only prefetch chapter/lesson links when `generationStatus === "completed"`, avoiding wasted bandwidth for pages whose content hasn't been generated yet
- Remove unused nested `lessons` subquery from `listCourseChapters` — the chapter list only renders chapter-level fields
- Rename `ChapterWithLessons` to `ChapterForList` for consistency with `LessonForList`

## Test plan

- [x] Integration tests updated: removed lesson-related tests from chapter query, added `generationStatus` assertions to both chapter and lesson query tests
- [x] All 317 main app tests pass
- [x] All 225 e2e tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefetch chapter and lesson links only when generationStatus is completed to cut wasted requests and make catalog navigation faster. Also simplified the chapter list query and aligned types.

- **New Features**
  - Gate ClientLink prefetch for chapters and lessons using generationStatus === "completed".
  - Add generationStatus to ChapterForList and LessonForList responses.

- **Refactors**
  - Remove unused nested lessons from listCourseChapters; rename ChapterWithLessons to ChapterForList.
  - Update tests to match new shapes and assert generationStatus.

<sup>Written for commit e973d180eb96bcabbf981fb0fb64b3f2b4c47431. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

