### PR TITLE
feat(main): add feedback screen for activity player

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,7 @@ For detailed UX guidelines (interactions, animation, layout, accessibility), see
 - When adding e2e tests, use `*Fixture()` functions to create unique test data per test - do not modify seed files
 - Avoid inline imports like `await import()`, only do it when dynamic imports are absolutely necessary
 - Never use `git push --force` or `git push --force-with-lease`. When you make a change, just add a new commit and push it, no need to rewrite history
+- Never push your changes to GitHub without explicit authorization. Only push when someone asks you to push
 
 ## Component Organization
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1174,6 +1174,21 @@ msgctxt "RDZVQL"
 msgid "Check"
 msgstr "Check"
 
+#: src/components/activity-player/feedback-screen.tsx
+msgctxt "++l7ni"
+msgid "Not quite"
+msgstr "Not quite"
+
+#: src/components/activity-player/feedback-screen.tsx
+msgctxt "iaHymw"
+msgid "Outcome"
+msgstr "Outcome"
+
+#: src/components/activity-player/feedback-screen.tsx
+msgctxt "xmF49T"
+msgid "Correct!"
+msgstr "Correct!"
+
 #: src/components/catalog/activity-completion-indicator.tsx
 msgctxt "4o5CAP"
 msgid "Not completed"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1174,6 +1174,21 @@ msgctxt "RDZVQL"
 msgid "Check"
 msgstr "Verificación"
 
+#: src/components/activity-player/feedback-screen.tsx
+msgctxt "++l7ni"
+msgid "Not quite"
+msgstr "No del todo"
+
+#: src/components/activity-player/feedback-screen.tsx
+msgctxt "iaHymw"
+msgid "Outcome"
+msgstr "Resultado"
+
+#: src/components/activity-player/feedback-screen.tsx
+msgctxt "xmF49T"
+msgid "Correct!"
+msgstr "¡Correcto!"
+
 #: src/components/catalog/activity-completion-indicator.tsx
 msgctxt "4o5CAP"
 msgid "Not completed"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1174,6 +1174,21 @@ msgctxt "RDZVQL"
 msgid "Check"
 msgstr "Verificar"
 
+#: src/components/activity-player/feedback-screen.tsx
+msgctxt "++l7ni"
+msgid "Not quite"
+msgstr "Não exatamente"
+
+#: src/components/activity-player/feedback-screen.tsx
+msgctxt "iaHymw"
+msgid "Outcome"
+msgstr "Resultado"
+
+#: src/components/activity-player/feedback-screen.tsx
+msgctxt "xmF49T"
+msgid "Correct!"
+msgstr "Correto!"
+
 #: src/components/catalog/activity-completion-indicator.tsx
 msgctxt "4o5CAP"
 msgid "Not completed"

--- a/apps/main/src/components/activity-player/activity-player-shell.tsx
+++ b/apps/main/src/components/activity-player/activity-player-shell.tsx
@@ -2,8 +2,10 @@
 
 import { type SerializedActivity } from "@/data/activities/prepare-activity-data";
 import { useRouter } from "@/i18n/navigation";
+import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { useCallback } from "react";
+import { FeedbackScreenContent, getFeedbackVariant } from "./feedback-screen";
 import { PlayerActionBar, PlayerActionButton } from "./player-action-bar";
 import { PlayerCloseLink, PlayerHeader, PlayerStepFraction } from "./player-header";
 import { PlayerProgressBar } from "./player-progress-bar";
@@ -24,6 +26,8 @@ export function ActivityPlayerShell({
   const currentStep = state.steps[state.currentStepIndex];
   const isStaticStep = currentStep?.kind === "static";
   const hasAnswer = currentStep ? Boolean(state.selectedAnswers[currentStep.id]) : false;
+  const currentResult = currentStep ? state.results[currentStep.id] : undefined;
+  const feedbackVariant = currentResult ? getFeedbackVariant(currentResult) : undefined;
   const totalSteps = state.steps.length;
 
   const progressValue =
@@ -73,8 +77,20 @@ export function ActivityPlayerShell({
 
       <PlayerProgressBar value={progressValue} />
 
-      <section className="flex flex-1 flex-col items-center justify-center p-4">
-        {/* Step content will be rendered here by step renderers (Issue 9) */}
+      <section
+        className={cn(
+          "flex flex-1 flex-col items-center overflow-y-auto transition-colors duration-300",
+          state.phase === "feedback"
+            ? "justify-start px-6 pt-16 sm:px-8 sm:pt-24"
+            : "justify-center p-4",
+          feedbackVariant === "correct" && "bg-success/5",
+          feedbackVariant === "incorrect" && "bg-destructive/5",
+        )}
+      >
+        {state.phase === "feedback" && currentResult ? (
+          <FeedbackScreenContent result={currentResult} />
+        ) : // Step content will be rendered here by step renderers (Issue 9)
+        null}
       </section>
 
       {!isStaticStep && (

--- a/apps/main/src/components/activity-player/activity-player-shell.tsx
+++ b/apps/main/src/components/activity-player/activity-player-shell.tsx
@@ -2,13 +2,13 @@
 
 import { type SerializedActivity } from "@/data/activities/prepare-activity-data";
 import { useRouter } from "@/i18n/navigation";
-import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { useCallback } from "react";
 import { FeedbackScreenContent, getFeedbackVariant } from "./feedback-screen";
 import { PlayerActionBar, PlayerActionButton } from "./player-action-bar";
 import { PlayerCloseLink, PlayerHeader, PlayerStepFraction } from "./player-header";
 import { PlayerProgressBar } from "./player-progress-bar";
+import { PlayerStage } from "./player-stage";
 import { usePlayerKeyboard } from "./use-player-keyboard";
 import { usePlayerState } from "./use-player-state";
 
@@ -77,21 +77,12 @@ export function ActivityPlayerShell({
 
       <PlayerProgressBar value={progressValue} />
 
-      <section
-        className={cn(
-          "flex flex-1 flex-col items-center overflow-y-auto transition-colors duration-300",
-          state.phase === "feedback"
-            ? "justify-start px-6 pt-16 sm:px-8 sm:pt-24"
-            : "justify-center p-4",
-          feedbackVariant === "correct" && "bg-success/5",
-          feedbackVariant === "incorrect" && "bg-destructive/5",
-        )}
-      >
+      <PlayerStage feedback={feedbackVariant} phase={state.phase}>
         {state.phase === "feedback" && currentResult ? (
           <FeedbackScreenContent result={currentResult} />
         ) : // Step content will be rendered here by step renderers (Issue 9)
         null}
-      </section>
+      </PlayerStage>
 
       {!isStaticStep && (
         <PlayerActionBar>

--- a/apps/main/src/components/activity-player/feedback-screen.test.ts
+++ b/apps/main/src/components/activity-player/feedback-screen.test.ts
@@ -1,0 +1,46 @@
+import { type AnswerResult } from "@zoonk/core/player/check-answer";
+import { type ChallengeEffect } from "@zoonk/core/steps/content-contract";
+import { describe, expect, test } from "vitest";
+import { getFeedbackVariant } from "./feedback-screen";
+import { type StepResult } from "./player-reducer";
+
+function buildResult(overrides: Partial<StepResult> = {}): StepResult {
+  const result: AnswerResult = overrides.result ?? { feedback: "Good job!", isCorrect: true };
+  const effects: ChallengeEffect[] = overrides.effects ?? [];
+
+  return {
+    answer: undefined,
+    effects,
+    result,
+    stepId: "step-1",
+    ...overrides,
+  };
+}
+
+describe(getFeedbackVariant, () => {
+  test("returns correct when isCorrect is true with no effects", () => {
+    const result = buildResult({ result: { feedback: null, isCorrect: true } });
+    expect(getFeedbackVariant(result)).toBe("correct");
+  });
+
+  test("returns incorrect when isCorrect is false with no effects", () => {
+    const result = buildResult({ result: { feedback: "Try again", isCorrect: false } });
+    expect(getFeedbackVariant(result)).toBe("incorrect");
+  });
+
+  test("returns challenge when effects has entries", () => {
+    const result = buildResult({
+      effects: [{ dimension: "empathy", impact: "positive" }],
+      result: { feedback: "You chose wisely", isCorrect: true },
+    });
+    expect(getFeedbackVariant(result)).toBe("challenge");
+  });
+
+  test("returns challenge regardless of isCorrect when effects exist", () => {
+    const result = buildResult({
+      effects: [{ dimension: "logic", impact: "negative" }],
+      result: { feedback: null, isCorrect: false },
+    });
+    expect(getFeedbackVariant(result)).toBe("challenge");
+  });
+});

--- a/apps/main/src/components/activity-player/feedback-screen.tsx
+++ b/apps/main/src/components/activity-player/feedback-screen.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { type ChallengeEffect } from "@zoonk/core/steps/content-contract";
+import { cn } from "@zoonk/ui/lib/utils";
+import { CircleCheck, CircleX } from "lucide-react";
+import { useExtracted } from "next-intl";
+import { type StepResult } from "./player-reducer";
+
+export function getFeedbackVariant(result: StepResult): "correct" | "incorrect" | "challenge" {
+  if (result.effects.length > 0) {
+    return "challenge";
+  }
+
+  if (result.result.isCorrect) {
+    return "correct";
+  }
+
+  return "incorrect";
+}
+
+function FeedbackScreen({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      aria-live="polite"
+      className={cn(
+        "animate-in fade-in slide-in-from-bottom-1 mx-auto flex w-full max-w-lg flex-col items-center gap-3 duration-200",
+        className,
+      )}
+      data-slot="feedback-screen"
+      role="status"
+      {...props}
+    />
+  );
+}
+
+function FeedbackIcon({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("[&_svg]:size-10", className)} data-slot="feedback-icon" {...props} />;
+}
+
+function FeedbackTitle({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p className={cn("text-xl font-semibold", className)} data-slot="feedback-title" {...props} />
+  );
+}
+
+function FeedbackMessage({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "text-muted-foreground max-w-lg text-center text-sm leading-relaxed",
+        className,
+      )}
+      data-slot="feedback-message"
+      {...props}
+    />
+  );
+}
+
+function FeedbackEffects({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      className={cn("border-border mx-auto max-w-xs border-t pt-6", className)}
+      data-slot="feedback-effects"
+      {...props}
+    />
+  );
+}
+
+function getEffectColor(impact: ChallengeEffect["impact"]): string {
+  if (impact === "positive") {
+    return "text-success";
+  }
+
+  if (impact === "negative") {
+    return "text-destructive";
+  }
+
+  return "text-muted-foreground";
+}
+
+function getEffectLabel(impact: ChallengeEffect["impact"]): string {
+  if (impact === "positive") {
+    return "+1";
+  }
+
+  if (impact === "negative") {
+    return "-1";
+  }
+
+  return "0";
+}
+
+function FeedbackEffect({
+  effect,
+  className,
+  ...props
+}: React.ComponentProps<"li"> & { effect: ChallengeEffect }) {
+  return (
+    <li
+      className={cn("flex items-center justify-between py-1", className)}
+      data-slot="feedback-effect"
+      {...props}
+    >
+      <span className="text-muted-foreground text-sm">{effect.dimension}</span>
+      <span className={cn("text-sm font-medium", getEffectColor(effect.impact))}>
+        {getEffectLabel(effect.impact)}
+      </span>
+    </li>
+  );
+}
+
+export function FeedbackScreenContent({ result }: { result: StepResult }) {
+  const t = useExtracted();
+  const variant = getFeedbackVariant(result);
+
+  if (variant === "challenge") {
+    return (
+      <FeedbackScreen>
+        <FeedbackTitle className="text-foreground">{t("Outcome")}</FeedbackTitle>
+
+        {result.result.feedback ? (
+          <FeedbackMessage>{result.result.feedback}</FeedbackMessage>
+        ) : null}
+
+        {result.effects.length > 0 ? (
+          <FeedbackEffects>
+            {result.effects.map((effect) => (
+              <FeedbackEffect effect={effect} key={effect.dimension} />
+            ))}
+          </FeedbackEffects>
+        ) : null}
+      </FeedbackScreen>
+    );
+  }
+
+  const isCorrect = variant === "correct";
+
+  return (
+    <FeedbackScreen>
+      <FeedbackIcon>
+        {isCorrect ? (
+          <CircleCheck aria-label={t("Correct!")} className="text-success" />
+        ) : (
+          <CircleX aria-label={t("Not quite")} className="text-destructive" />
+        )}
+      </FeedbackIcon>
+
+      <FeedbackTitle className={isCorrect ? "text-success" : "text-destructive"}>
+        {isCorrect ? t("Correct!") : t("Not quite")}
+      </FeedbackTitle>
+
+      {result.result.feedback ? <FeedbackMessage>{result.result.feedback}</FeedbackMessage> : null}
+    </FeedbackScreen>
+  );
+}

--- a/apps/main/src/components/activity-player/player-stage.tsx
+++ b/apps/main/src/components/activity-player/player-stage.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@zoonk/ui/lib/utils";
+import { type PlayerPhase } from "./player-reducer";
+
+export function PlayerStage({
+  className,
+  feedback,
+  phase,
+  ...props
+}: React.ComponentProps<"section"> & {
+  feedback?: "correct" | "incorrect" | "challenge";
+  phase: PlayerPhase;
+}) {
+  return (
+    <section
+      className={cn(
+        "flex flex-1 flex-col items-center overflow-y-auto transition-colors duration-300",
+        "data-[phase=feedback]:justify-start data-[phase=feedback]:px-6 data-[phase=feedback]:pt-16 data-[phase=feedback]:sm:px-8 data-[phase=feedback]:sm:pt-24",
+        "data-[phase=playing]:justify-center data-[phase=playing]:p-4",
+        "data-[phase=completed]:justify-center data-[phase=completed]:p-4",
+        "data-[feedback=correct]:bg-success/5",
+        "data-[feedback=incorrect]:bg-destructive/5",
+        className,
+      )}
+      data-feedback={feedback}
+      data-phase={phase}
+      data-slot="player-stage"
+      {...props}
+    />
+  );
+}

--- a/i18n.lock
+++ b/i18n.lock
@@ -215,8 +215,6 @@ checksums:
     Support/singular: 55aab5fd0f31a9cb055a2edeeedfaf63
     Subscription/singular: ba9f3675e18987d067d48533c8897343
     Chapter%20%7Bposition%7D/singular: f6459365d5d8413a99fa97bc803f9024
-    Not%20completed/singular: d011b1ae92a1a8a2676a5d6999bbe6d4
-    Completed/singular: 0e4bbce9985f25eb673d9a054c8d5334
     Activities/singular: 1c01b2fc4db670ab174e2220cf5e79f8
     Lesson%20%7Bposition%7D/singular: 2283c16cc7404682a2380fb8318f42e2
     No%20lessons%20found/singular: 39a13337bf7998816b2841143d8891e8
@@ -409,13 +407,18 @@ checksums:
     Privacy%20Policy/singular: 7459744a63ef8af4e517a09024bd7c08
     Read%20Zoonk's%20terms%20of%20use%20to%20understand%20the%20rules%20and%20conditions%20for%20using%20our%20platform%20and%20services/singular: 4b82898d60691839a1999e4a17199895
     Terms%20of%20Use/singular: 9ac262b2eda552beeecd904c0b9f8fa2
+    Continue/singular: 3cfba90b4600131e82fc4260c568d044
+    Check/singular: 023cc2ba432775c38e3efc004ad7b9ef
+    Not%20quite/singular: e570085e69662802acf485c4565e3e3e
+    Outcome/singular: 4cfc7a40e384ea8b6658e8da6e351bf0
+    Correct!/singular: dda1a98dc04fd9db252887ecf1765d41
+    Not%20completed/singular: d011b1ae92a1a8a2676a5d6999bbe6d4
+    Completed/singular: 0e4bbce9985f25eb673d9a054c8d5334
+    This%20content%20was%20generated%20by%20AI.%20It%20may%20contain%20errors%20or%20inaccuracies%20and%20should%20not%20be%20considered%20professional%20advice./singular: 269e7c16a722903b9b434f28aa6cf617
     Not%20helpful/singular: ceb8a457e7e4c62a465cd1dd2620990e
     Helpful/singular: 9a25a3e10315cf4a8c65996e31f6cda6
     Thanks%20for%20your%20feedback/singular: 05d6f70cdb81119bcf0ad7443438e82b
     More%20options/singular: 53d90eae6a9b0243b5bc043b3d9de169
-    Continue/singular: 3cfba90b4600131e82fc4260c568d044
-    Check/singular: 023cc2ba432775c38e3efc004ad7b9ef
-    This%20content%20was%20generated%20by%20AI.%20It%20may%20contain%20errors%20or%20inaccuracies%20and%20should%20not%20be%20considered%20professional%20advice./singular: 269e7c16a722903b9b434f28aa6cf617
     Review/singular: 299f75db25382980b2895622d7712927
     Please%20provide%20as%20much%20detail%20as%20possible./singular: 3c8b231283c751d4beae059a6ffc3643
     Failed%20to%20send%20message.%20Please%20try%20again%20or%20email%20us%20directly%20at%20hello%40zoonk.com/singular: 7f36bcd5ba5dad4b9981f85488ff794c


### PR DESCRIPTION
## Summary

- Add `FeedbackScreenContent` compound component with correct/incorrect/challenge variants
- Integrate into `ActivityPlayerShell` with animated fade-in, background color wash, and top-aligned layout during feedback phase
- Unit tests for `getFeedbackVariant` utility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an animated feedback screen to the Activity Player and extracts a reusable PlayerStage to handle phase and feedback styling. Shows correct, incorrect, or challenge outcomes after answer checks with contextual layout and background wash.

- **New Features**
  - FeedbackScreenContent with correct/incorrect/challenge variants and fade-in animation.
  - getFeedbackVariant helper (effects take priority) with unit tests.
  - Added i18n strings for “Correct!”, “Not quite”, and “Outcome” in en/es/pt.

- **Refactors**
  - Extracted PlayerStage for reusable stage layout and data-[phase]/data-[feedback] styling; ActivityPlayerShell now uses it for top-aligned feedback and success/destructive background wash.

<sup>Written for commit 983a86a0d41fb95370c3d6bd15123d552ce1eb3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

