### PR TITLE
feat(main): add progress indicators to course and chapter pages

### DIFF
--- a/apps/api/src/app/v1/progress/chapter-completion/route.ts
+++ b/apps/api/src/app/v1/progress/chapter-completion/route.ts
@@ -1,0 +1,22 @@
+import { getChapterLessonCompletion } from "@/data/progress/get-chapter-lesson-completion";
+import { errors } from "@/lib/api-errors";
+import { chapterCompletionQuerySchema } from "@/lib/openapi/schemas/progress";
+import { parseQueryParams } from "@/lib/query-params";
+import { getSession } from "@zoonk/core/users/session/get";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const parsed = parseQueryParams(searchParams, chapterCompletionQuerySchema);
+
+  if (!parsed.success) {
+    return errors.validation(parsed.error);
+  }
+
+  const { chapterId } = parsed.data;
+  const session = await getSession(request.headers);
+  const userId = session ? Number(session.user.id) : 0;
+  const lessons = await getChapterLessonCompletion(userId, chapterId);
+
+  return NextResponse.json({ lessons });
+}

--- a/apps/api/src/app/v1/progress/course-completion/route.ts
+++ b/apps/api/src/app/v1/progress/course-completion/route.ts
@@ -1,0 +1,22 @@
+import { getCourseChapterCompletion } from "@/data/progress/get-course-chapter-completion";
+import { errors } from "@/lib/api-errors";
+import { courseCompletionQuerySchema } from "@/lib/openapi/schemas/progress";
+import { parseQueryParams } from "@/lib/query-params";
+import { getSession } from "@zoonk/core/users/session/get";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const parsed = parseQueryParams(searchParams, courseCompletionQuerySchema);
+
+  if (!parsed.success) {
+    return errors.validation(parsed.error);
+  }
+
+  const { courseId } = parsed.data;
+  const session = await getSession(request.headers);
+  const userId = session ? Number(session.user.id) : 0;
+  const chapters = await getCourseChapterCompletion(userId, courseId);
+
+  return NextResponse.json({ chapters });
+}

--- a/apps/api/src/data/progress/get-chapter-lesson-completion.test.ts
+++ b/apps/api/src/data/progress/get-chapter-lesson-completion.test.ts
@@ -1,0 +1,257 @@
+import { activityFixture, activityProgressFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { beforeAll, describe, expect, test } from "vitest";
+import { getChapterLessonCompletion } from "./get-chapter-lesson-completion";
+
+describe(getChapterLessonCompletion, () => {
+  let organization: Awaited<ReturnType<typeof organizationFixture>>;
+
+  beforeAll(async () => {
+    organization = await organizationFixture();
+  });
+
+  test("returns empty array when userId is 0", async () => {
+    const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const result = await getChapterLessonCompletion(0, chapter.id);
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array when user has no progress and lessons have no activities", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    // Lesson with no activities - excluded from results
+    await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const result = await getChapterLessonCompletion(Number(user.id), chapter.id);
+    expect(result).toEqual([]);
+  });
+
+  test("returns correct completedActivities and totalActivities counts", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const [activity1, activity2, _activity3] = await Promise.all([
+      activityFixture({
+        isPublished: true,
+        lessonId: lesson.id,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      activityFixture({
+        isPublished: true,
+        lessonId: lesson.id,
+        organizationId: organization.id,
+        position: 1,
+      }),
+      activityFixture({
+        isPublished: true,
+        lessonId: lesson.id,
+        organizationId: organization.id,
+        position: 2,
+      }),
+    ]);
+
+    await Promise.all([
+      activityProgressFixture({
+        activityId: activity1.id,
+        completedAt: new Date(),
+        durationSeconds: 60,
+        userId: Number(user.id),
+      }),
+      activityProgressFixture({
+        activityId: activity2.id,
+        completedAt: new Date(),
+        durationSeconds: 60,
+        userId: Number(user.id),
+      }),
+    ]);
+
+    const result = await getChapterLessonCompletion(Number(user.id), chapter.id);
+    expect(result).toEqual([{ completedActivities: 2, lessonId: lesson.id, totalActivities: 3 }]);
+  });
+
+  test("excludes started-but-not-completed activities", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const [completedActivity, startedActivity] = await Promise.all([
+      activityFixture({
+        isPublished: true,
+        lessonId: lesson.id,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      activityFixture({
+        isPublished: true,
+        lessonId: lesson.id,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    await Promise.all([
+      activityProgressFixture({
+        activityId: completedActivity.id,
+        completedAt: new Date(),
+        durationSeconds: 60,
+        userId: Number(user.id),
+      }),
+      activityProgressFixture({
+        activityId: startedActivity.id,
+        completedAt: null,
+        durationSeconds: 30,
+        userId: Number(user.id),
+      }),
+    ]);
+
+    const result = await getChapterLessonCompletion(Number(user.id), chapter.id);
+    expect(result).toEqual([{ completedActivities: 1, lessonId: lesson.id, totalActivities: 2 }]);
+  });
+
+  test("only counts published activities", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const [publishedActivity] = await Promise.all([
+      activityFixture({
+        isPublished: true,
+        lessonId: lesson.id,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      activityFixture({
+        isPublished: false,
+        lessonId: lesson.id,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    await activityProgressFixture({
+      activityId: publishedActivity.id,
+      completedAt: new Date(),
+      durationSeconds: 60,
+      userId: Number(user.id),
+    });
+
+    const result = await getChapterLessonCompletion(Number(user.id), chapter.id);
+    expect(result).toEqual([{ completedActivities: 1, lessonId: lesson.id, totalActivities: 1 }]);
+  });
+
+  test("lessons with 0 published activities are excluded from results", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const [lessonWithActivities, lessonWithoutActivities] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    await activityFixture({
+      isPublished: true,
+      lessonId: lessonWithActivities.id,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const result = await getChapterLessonCompletion(Number(user.id), chapter.id);
+    // Only the lesson with activities should appear
+    expect(result).toEqual([
+      { completedActivities: 0, lessonId: lessonWithActivities.id, totalActivities: 1 },
+    ]);
+    expect(result.find((row) => row.lessonId === lessonWithoutActivities.id)).toBeUndefined();
+  });
+});

--- a/apps/api/src/data/progress/get-chapter-lesson-completion.ts
+++ b/apps/api/src/data/progress/get-chapter-lesson-completion.ts
@@ -1,0 +1,30 @@
+import { prisma } from "@zoonk/db";
+import { getChapterLessonCompletion as query } from "@zoonk/db/completion/chapter-lessons";
+import { safeAsync } from "@zoonk/utils/error";
+
+export async function getChapterLessonCompletion(
+  userId: number,
+  chapterId: number,
+): Promise<
+  {
+    completedActivities: number;
+    lessonId: number;
+    totalActivities: number;
+  }[]
+> {
+  if (userId === 0) {
+    return [];
+  }
+
+  const { data, error } = await safeAsync(() => prisma.$queryRawTyped(query(userId, chapterId)));
+
+  if (error || !data) {
+    return [];
+  }
+
+  return data.map((row) => ({
+    completedActivities: row.completedActivities ?? 0,
+    lessonId: row.lessonId,
+    totalActivities: row.totalActivities ?? 0,
+  }));
+}

--- a/apps/api/src/data/progress/get-course-chapter-completion.test.ts
+++ b/apps/api/src/data/progress/get-course-chapter-completion.test.ts
@@ -1,0 +1,315 @@
+import { activityFixture, activityProgressFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { beforeAll, describe, expect, test } from "vitest";
+import { getCourseChapterCompletion } from "./get-course-chapter-completion";
+
+describe(getCourseChapterCompletion, () => {
+  let organization: Awaited<ReturnType<typeof organizationFixture>>;
+
+  beforeAll(async () => {
+    organization = await organizationFixture();
+  });
+
+  test("returns empty array when userId is 0", async () => {
+    const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+    const result = await getCourseChapterCompletion(0, course.id);
+    expect(result).toEqual([]);
+  });
+
+  test("returns chapters with zero counts when user has no progress", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    await activityFixture({
+      isPublished: true,
+      lessonId: lesson.id,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const result = await getCourseChapterCompletion(Number(user.id), course.id);
+    expect(result).toEqual([{ chapterId: chapter.id, completedLessons: 0, totalLessons: 1 }]);
+  });
+
+  test("a lesson counts as completed only when ALL its activities are completed", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const [activity1, activity2] = await Promise.all([
+      activityFixture({
+        isPublished: true,
+        lessonId: lesson.id,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      activityFixture({
+        isPublished: true,
+        lessonId: lesson.id,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    // Only complete one of two activities
+    await activityProgressFixture({
+      activityId: activity1.id,
+      completedAt: new Date(),
+      durationSeconds: 60,
+      userId: Number(user.id),
+    });
+
+    const result = await getCourseChapterCompletion(Number(user.id), course.id);
+    expect(result).toEqual([{ chapterId: chapter.id, completedLessons: 0, totalLessons: 1 }]);
+
+    // Now complete the second activity
+    await activityProgressFixture({
+      activityId: activity2.id,
+      completedAt: new Date(),
+      durationSeconds: 60,
+      userId: Number(user.id),
+    });
+
+    const result2 = await getCourseChapterCompletion(Number(user.id), course.id);
+    expect(result2).toEqual([{ chapterId: chapter.id, completedLessons: 1, totalLessons: 1 }]);
+  });
+
+  test("returns correct counts across multiple chapters", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const [chapter1, chapter2] = await Promise.all([
+      chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    const [lesson1, lesson2] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter1.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: chapter2.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 0,
+      }),
+    ]);
+
+    const [activity1, _activity2] = await Promise.all([
+      activityFixture({
+        isPublished: true,
+        lessonId: lesson1.id,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      activityFixture({
+        isPublished: true,
+        lessonId: lesson2.id,
+        organizationId: organization.id,
+        position: 0,
+      }),
+    ]);
+
+    // Complete only the first chapter's lesson
+    await activityProgressFixture({
+      activityId: activity1.id,
+      completedAt: new Date(),
+      durationSeconds: 60,
+      userId: Number(user.id),
+    });
+
+    const result = await getCourseChapterCompletion(Number(user.id), course.id);
+    expect(result).toEqual([
+      { chapterId: chapter1.id, completedLessons: 1, totalLessons: 1 },
+      { chapterId: chapter2.id, completedLessons: 0, totalLessons: 1 },
+    ]);
+  });
+
+  test("excludes started-but-not-completed activities from lesson completion", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const activity = await activityFixture({
+      isPublished: true,
+      lessonId: lesson.id,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    // Started but not completed
+    await activityProgressFixture({
+      activityId: activity.id,
+      completedAt: null,
+      durationSeconds: 30,
+      userId: Number(user.id),
+    });
+
+    const result = await getCourseChapterCompletion(Number(user.id), course.id);
+    expect(result).toEqual([{ chapterId: chapter.id, completedLessons: 0, totalLessons: 1 }]);
+  });
+
+  test("only counts published activities and lessons", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const [publishedLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: false,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    const [publishedActivity] = await Promise.all([
+      activityFixture({
+        isPublished: true,
+        lessonId: publishedLesson.id,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      activityFixture({
+        isPublished: false,
+        lessonId: publishedLesson.id,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    await activityProgressFixture({
+      activityId: publishedActivity.id,
+      completedAt: new Date(),
+      durationSeconds: 60,
+      userId: Number(user.id),
+    });
+
+    const result = await getCourseChapterCompletion(Number(user.id), course.id);
+    // Only the published lesson with the published activity counts
+    expect(result).toEqual([{ chapterId: chapter.id, completedLessons: 1, totalLessons: 1 }]);
+  });
+
+  test("chapters with 0 published lessons return totalLessons 0", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    // Chapter with no lessons at all
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const result = await getCourseChapterCompletion(Number(user.id), course.id);
+    expect(result).toEqual([{ chapterId: chapter.id, completedLessons: 0, totalLessons: 0 }]);
+  });
+
+  test("lessons with 0 published activities are excluded from total count", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    // Lesson with no activities
+    await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const result = await getCourseChapterCompletion(Number(user.id), course.id);
+    // Lesson has no published activities, so it's excluded from totalLessons
+    expect(result).toEqual([{ chapterId: chapter.id, completedLessons: 0, totalLessons: 0 }]);
+  });
+});

--- a/apps/api/src/data/progress/get-course-chapter-completion.ts
+++ b/apps/api/src/data/progress/get-course-chapter-completion.ts
@@ -1,0 +1,30 @@
+import { prisma } from "@zoonk/db";
+import { getCourseChapterCompletion as query } from "@zoonk/db/completion/course-chapters";
+import { safeAsync } from "@zoonk/utils/error";
+
+export async function getCourseChapterCompletion(
+  userId: number,
+  courseId: number,
+): Promise<
+  {
+    chapterId: number;
+    completedLessons: number;
+    totalLessons: number;
+  }[]
+> {
+  if (userId === 0) {
+    return [];
+  }
+
+  const { data, error } = await safeAsync(() => prisma.$queryRawTyped(query(userId, courseId)));
+
+  if (error || !data) {
+    return [];
+  }
+
+  return data.map((row) => ({
+    chapterId: row.chapterId,
+    completedLessons: row.completedLessons ?? 0,
+    totalLessons: row.totalLessons ?? 0,
+  }));
+}

--- a/apps/api/src/lib/openapi/document.ts
+++ b/apps/api/src/lib/openapi/document.ts
@@ -5,6 +5,10 @@ import { courseResultSchema, courseSearchQuerySchema } from "./schemas/courses";
 import {
   activityCompletionQuerySchema,
   activityCompletionResponseSchema,
+  chapterCompletionQuerySchema,
+  chapterCompletionResponseSchema,
+  courseCompletionQuerySchema,
+  courseCompletionResponseSchema,
   nextActivityQuerySchema,
   nextActivityResponseSchema,
 } from "./schemas/progress";
@@ -80,6 +84,42 @@ export const openAPIDocument = createDocument({
           "400": validationErrorResponse,
         },
         summary: "Get completed activities for a lesson",
+        tags: ["Progress"],
+      },
+    },
+    "/progress/chapter-completion": {
+      get: {
+        requestParams: { query: chapterCompletionQuerySchema },
+        responses: {
+          "200": {
+            content: {
+              "application/json": {
+                schema: chapterCompletionResponseSchema,
+              },
+            },
+            description: "Lesson completion status for a chapter",
+          },
+          "400": validationErrorResponse,
+        },
+        summary: "Get lesson completion for a chapter",
+        tags: ["Progress"],
+      },
+    },
+    "/progress/course-completion": {
+      get: {
+        requestParams: { query: courseCompletionQuerySchema },
+        responses: {
+          "200": {
+            content: {
+              "application/json": {
+                schema: courseCompletionResponseSchema,
+              },
+            },
+            description: "Chapter completion status for a course",
+          },
+          "400": validationErrorResponse,
+        },
+        summary: "Get chapter completion for a course",
         tags: ["Progress"],
       },
     },

--- a/apps/api/src/lib/openapi/schemas/progress.ts
+++ b/apps/api/src/lib/openapi/schemas/progress.ts
@@ -14,6 +14,46 @@ export const activityCompletionResponseSchema = z
   })
   .meta({ id: "ActivityCompletionResponse" });
 
+export const courseCompletionQuerySchema = z
+  .object({
+    courseId: z.coerce.number().int().positive().meta({ description: "Course ID" }),
+  })
+  .meta({ id: "CourseCompletionQuery" });
+
+export const courseCompletionResponseSchema = z
+  .object({
+    chapters: z
+      .array(
+        z.object({
+          chapterId: z.number().meta({ description: "Chapter ID" }),
+          completedLessons: z.number().meta({ description: "Number of completed lessons" }),
+          totalLessons: z.number().meta({ description: "Total number of lessons" }),
+        }),
+      )
+      .meta({ description: "Completion status per chapter" }),
+  })
+  .meta({ id: "CourseCompletionResponse" });
+
+export const chapterCompletionQuerySchema = z
+  .object({
+    chapterId: z.coerce.number().int().positive().meta({ description: "Chapter ID" }),
+  })
+  .meta({ id: "ChapterCompletionQuery" });
+
+export const chapterCompletionResponseSchema = z
+  .object({
+    lessons: z
+      .array(
+        z.object({
+          completedActivities: z.number().meta({ description: "Number of completed activities" }),
+          lessonId: z.number().meta({ description: "Lesson ID" }),
+          totalActivities: z.number().meta({ description: "Total number of activities" }),
+        }),
+      )
+      .meta({ description: "Completion status per lesson" }),
+  })
+  .meta({ id: "ChapterCompletionResponse" });
+
 export const nextActivityQuerySchema = z
   .object({
     chapterId: z.coerce.number().int().positive().optional().meta({ description: "Chapter ID" }),

--- a/apps/main/e2e/chapter-progress.test.ts
+++ b/apps/main/e2e/chapter-progress.test.ts
@@ -1,0 +1,153 @@
+import { randomUUID } from "node:crypto";
+import { type Page } from "@playwright/test";
+import { prisma } from "@zoonk/db";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { expect, test } from "./fixtures";
+
+async function createTestChapterWithLessons() {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-chprog-course-${uniqueId}`,
+    title: `E2E ChProg Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    description: `Chapter desc ${uniqueId}`,
+    isPublished: true,
+    organizationId: org.id,
+    position: 0,
+    slug: `e2e-chprog-ch-${uniqueId}`,
+    title: `E2E ChProg Chapter ${uniqueId}`,
+  });
+
+  const [lesson1, lesson2, lesson3] = await Promise.all([
+    lessonFixture({
+      chapterId: chapter.id,
+      description: `Lesson 1 desc ${uniqueId}`,
+      isPublished: true,
+      organizationId: org.id,
+      position: 0,
+      slug: `e2e-l1-${uniqueId}`,
+      title: `E2E Lesson One ${uniqueId}`,
+    }),
+    lessonFixture({
+      chapterId: chapter.id,
+      description: `Lesson 2 desc ${uniqueId}`,
+      isPublished: true,
+      organizationId: org.id,
+      position: 1,
+      slug: `e2e-l2-${uniqueId}`,
+      title: `E2E Lesson Two ${uniqueId}`,
+    }),
+    lessonFixture({
+      chapterId: chapter.id,
+      description: `Lesson 3 desc ${uniqueId}`,
+      isPublished: true,
+      organizationId: org.id,
+      position: 2,
+      slug: `e2e-l3-${uniqueId}`,
+      title: `E2E Lesson Three ${uniqueId}`,
+    }),
+  ]);
+
+  return { chapter, course, lesson1, lesson2, lesson3 };
+}
+
+function mockChapterCompletionAPI(
+  page: Page,
+  lessons: {
+    completedActivities: number;
+    lessonId: number;
+    totalActivities: number;
+  }[],
+) {
+  return page.route("**/v1/progress/chapter-completion**", async (route) => {
+    await route.fulfill({
+      body: JSON.stringify({ lessons }),
+      contentType: "application/json",
+      status: 200,
+    });
+  });
+}
+
+test.describe("Chapter Progress Indicators", () => {
+  test("shows no indicators when API returns empty lessons", async ({ page }) => {
+    const { chapter, course } = await createTestChapterWithLessons();
+
+    await mockChapterCompletionAPI(page, []);
+    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}`);
+
+    await expect(page.getByRole("heading", { level: 1, name: chapter.title })).toBeVisible();
+
+    await expect(page.getByRole("img", { name: /^completed$/i })).toHaveCount(0);
+    await expect(page.getByLabel(/of .+ completed/)).toHaveCount(0);
+  });
+
+  test("shows completed checkmarks for lessons with all activities done", async ({ page }) => {
+    const { chapter, course, lesson1, lesson2, lesson3 } = await createTestChapterWithLessons();
+
+    await mockChapterCompletionAPI(page, [
+      { completedActivities: 4, lessonId: lesson1.id, totalActivities: 4 },
+      { completedActivities: 3, lessonId: lesson2.id, totalActivities: 3 },
+      { completedActivities: 5, lessonId: lesson3.id, totalActivities: 5 },
+    ]);
+
+    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}`);
+
+    await expect(page.getByRole("heading", { level: 1, name: chapter.title })).toBeVisible();
+
+    const completedIndicators = page.getByRole("img", { name: /^completed$/i });
+    await expect(completedIndicators).toHaveCount(3);
+  });
+
+  test("shows fraction text for partially completed lessons", async ({ page }) => {
+    const { chapter, course, lesson1, lesson2, lesson3 } = await createTestChapterWithLessons();
+
+    await mockChapterCompletionAPI(page, [
+      { completedActivities: 2, lessonId: lesson1.id, totalActivities: 4 },
+      { completedActivities: 1, lessonId: lesson2.id, totalActivities: 5 },
+      { completedActivities: 3, lessonId: lesson3.id, totalActivities: 7 },
+    ]);
+
+    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}`);
+
+    await expect(page.getByRole("heading", { level: 1, name: chapter.title })).toBeVisible();
+
+    await expect(page.getByLabel("2 of 4 completed")).toBeVisible();
+    await expect(page.getByLabel("1 of 5 completed")).toBeVisible();
+    await expect(page.getByLabel("3 of 7 completed")).toBeVisible();
+  });
+
+  test("shows mix of completed, in-progress, and not-started states", async ({ page }) => {
+    const { chapter, course, lesson1, lesson2, lesson3 } = await createTestChapterWithLessons();
+
+    await mockChapterCompletionAPI(page, [
+      { completedActivities: 4, lessonId: lesson1.id, totalActivities: 4 },
+      { completedActivities: 2, lessonId: lesson2.id, totalActivities: 6 },
+      { completedActivities: 0, lessonId: lesson3.id, totalActivities: 3 },
+    ]);
+
+    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}`);
+
+    await expect(page.getByRole("heading", { level: 1, name: chapter.title })).toBeVisible();
+
+    // Lesson 1: fully completed -> checkmark
+    const completedIndicators = page.getByRole("img", { name: /^completed$/i });
+    await expect(completedIndicators).toHaveCount(1);
+
+    // Lesson 2: partially completed -> fraction
+    await expect(page.getByLabel("2 of 6 completed")).toBeVisible();
+
+    // Lesson 3: not started -> nothing shown (0 completed)
+  });
+});

--- a/apps/main/e2e/course-progress.test.ts
+++ b/apps/main/e2e/course-progress.test.ts
@@ -1,0 +1,144 @@
+import { randomUUID } from "node:crypto";
+import { type Page } from "@playwright/test";
+import { prisma } from "@zoonk/db";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { expect, test } from "./fixtures";
+
+async function createTestCourseWithChapters() {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-progress-course-${uniqueId}`,
+    title: `E2E Progress Course ${uniqueId}`,
+  });
+
+  const [chapter1, chapter2, chapter3] = await Promise.all([
+    chapterFixture({
+      courseId: course.id,
+      description: `Chapter 1 desc ${uniqueId}`,
+      isPublished: true,
+      organizationId: org.id,
+      position: 0,
+      slug: `e2e-ch1-${uniqueId}`,
+      title: `E2E Chapter One ${uniqueId}`,
+    }),
+    chapterFixture({
+      courseId: course.id,
+      description: `Chapter 2 desc ${uniqueId}`,
+      isPublished: true,
+      organizationId: org.id,
+      position: 1,
+      slug: `e2e-ch2-${uniqueId}`,
+      title: `E2E Chapter Two ${uniqueId}`,
+    }),
+    chapterFixture({
+      courseId: course.id,
+      description: `Chapter 3 desc ${uniqueId}`,
+      isPublished: true,
+      organizationId: org.id,
+      position: 2,
+      slug: `e2e-ch3-${uniqueId}`,
+      title: `E2E Chapter Three ${uniqueId}`,
+    }),
+  ]);
+
+  return { chapter1, chapter2, chapter3, course };
+}
+
+function mockCourseCompletionAPI(
+  page: Page,
+  chapters: {
+    chapterId: number;
+    completedLessons: number;
+    totalLessons: number;
+  }[],
+) {
+  return page.route("**/v1/progress/course-completion**", async (route) => {
+    await route.fulfill({
+      body: JSON.stringify({ chapters }),
+      contentType: "application/json",
+      status: 200,
+    });
+  });
+}
+
+test.describe("Course Progress Indicators", () => {
+  test("shows no indicators when API returns empty chapters", async ({ page }) => {
+    const { course } = await createTestCourseWithChapters();
+
+    await mockCourseCompletionAPI(page, []);
+    await page.goto(`/b/ai/c/${course.slug}`);
+
+    // Verify page loaded
+    await expect(page.getByRole("heading", { level: 1, name: course.title })).toBeVisible();
+
+    // No completion indicators should be visible
+    await expect(page.getByRole("img", { name: /^completed$/i })).toHaveCount(0);
+    await expect(page.getByLabel(/of .+ completed/)).toHaveCount(0);
+  });
+
+  test("shows completed checkmarks for chapters with all lessons done", async ({ page }) => {
+    const { chapter1, chapter2, chapter3, course } = await createTestCourseWithChapters();
+
+    await mockCourseCompletionAPI(page, [
+      { chapterId: chapter1.id, completedLessons: 5, totalLessons: 5 },
+      { chapterId: chapter2.id, completedLessons: 3, totalLessons: 3 },
+      { chapterId: chapter3.id, completedLessons: 4, totalLessons: 4 },
+    ]);
+
+    await page.goto(`/b/ai/c/${course.slug}`);
+
+    await expect(page.getByRole("heading", { level: 1, name: course.title })).toBeVisible();
+
+    const completedIndicators = page.getByRole("img", { name: /^completed$/i });
+    await expect(completedIndicators).toHaveCount(3);
+  });
+
+  test("shows fraction text for partially completed chapters", async ({ page }) => {
+    const { chapter1, chapter2, chapter3, course } = await createTestCourseWithChapters();
+
+    await mockCourseCompletionAPI(page, [
+      { chapterId: chapter1.id, completedLessons: 3, totalLessons: 10 },
+      { chapterId: chapter2.id, completedLessons: 7, totalLessons: 12 },
+      { chapterId: chapter3.id, completedLessons: 1, totalLessons: 5 },
+    ]);
+
+    await page.goto(`/b/ai/c/${course.slug}`);
+
+    await expect(page.getByRole("heading", { level: 1, name: course.title })).toBeVisible();
+
+    await expect(page.getByLabel("3 of 10 completed")).toBeVisible();
+    await expect(page.getByLabel("7 of 12 completed")).toBeVisible();
+    await expect(page.getByLabel("1 of 5 completed")).toBeVisible();
+  });
+
+  test("shows mix of completed, in-progress, and not-started states", async ({ page }) => {
+    const { chapter1, chapter2, chapter3, course } = await createTestCourseWithChapters();
+
+    await mockCourseCompletionAPI(page, [
+      { chapterId: chapter1.id, completedLessons: 5, totalLessons: 5 },
+      { chapterId: chapter2.id, completedLessons: 3, totalLessons: 8 },
+      { chapterId: chapter3.id, completedLessons: 0, totalLessons: 6 },
+    ]);
+
+    await page.goto(`/b/ai/c/${course.slug}`);
+
+    await expect(page.getByRole("heading", { level: 1, name: course.title })).toBeVisible();
+
+    // Chapter 1: fully completed -> checkmark
+    const completedIndicators = page.getByRole("img", { name: /^completed$/i });
+    await expect(completedIndicators).toHaveCount(1);
+
+    // Chapter 2: partially completed -> fraction
+    await expect(page.getByLabel("3 of 8 completed")).toBeVisible();
+
+    // Chapter 3: not started -> nothing shown (0 completed)
+  });
+});

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1180,6 +1180,8 @@ msgid "Not completed"
 msgstr "Not completed"
 
 #: src/components/catalog/activity-completion-indicator.tsx
+#: src/components/catalog/chapter-completion.tsx
+#: src/components/catalog/lesson-completion.tsx
 msgctxt "95stPq"
 msgid "Completed"
 msgstr "Completed"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1180,6 +1180,8 @@ msgid "Not completed"
 msgstr "No completada"
 
 #: src/components/catalog/activity-completion-indicator.tsx
+#: src/components/catalog/chapter-completion.tsx
+#: src/components/catalog/lesson-completion.tsx
 msgctxt "95stPq"
 msgid "Completed"
 msgstr "Completada"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1180,6 +1180,8 @@ msgid "Not completed"
 msgstr "Não concluída"
 
 #: src/components/catalog/activity-completion-indicator.tsx
+#: src/components/catalog/chapter-completion.tsx
+#: src/components/catalog/lesson-completion.tsx
 msgctxt "95stPq"
 msgid "Completed"
 msgstr "Concluída"

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
@@ -47,12 +47,12 @@ export async function ActivityList({
               id={activity.id}
               key={String(activity.id)}
             >
-              <ActivityCompletionIndicator activityId={String(activity.id)} lessonId={lessonId} />
-
               <CatalogListItemContent>
                 <CatalogListItemTitle>{title}</CatalogListItemTitle>
                 <CatalogListItemDescription>{description}</CatalogListItemDescription>
               </CatalogListItemContent>
+
+              <ActivityCompletionIndicator activityId={String(activity.id)} lessonId={lessonId} />
             </CatalogListItem>
           );
         })}

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -9,17 +9,20 @@ import {
   CatalogListItemTitle,
   CatalogListSearch,
 } from "@/components/catalog/catalog-list";
+import { LessonCompletion } from "@/components/catalog/lesson-completion";
 import { type LessonForList } from "@/data/lessons/list-chapter-lessons";
 import { formatPosition } from "@zoonk/utils/string";
 import { getExtracted } from "next-intl/server";
 
 export async function LessonList({
   brandSlug,
+  chapterId,
   chapterSlug,
   courseSlug,
   lessons,
 }: {
   brandSlug: string;
+  chapterId: number;
   chapterSlug: string;
   courseSlug: string;
   lessons: LessonForList[];
@@ -48,6 +51,8 @@ export async function LessonList({
                 <CatalogListItemTitle>{lesson.title}</CatalogListItemTitle>
                 <CatalogListItemDescription>{lesson.description}</CatalogListItemDescription>
               </CatalogListItemContent>
+
+              <LessonCompletion chapterId={chapterId} lessonId={lesson.id} />
             </CatalogListItem>
           ))}
         </CatalogListContent>

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -83,6 +83,7 @@ export default async function ChapterPage({
         <Suspense>
           <LessonList
             brandSlug={brandSlug}
+            chapterId={chapter.id}
             chapterSlug={chapterSlug}
             courseSlug={courseSlug}
             lessons={lessons}

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -9,6 +9,7 @@ import {
   CatalogListItemTitle,
   CatalogListSearch,
 } from "@/components/catalog/catalog-list";
+import { ChapterCompletion } from "@/components/catalog/chapter-completion";
 import { type ChapterForList } from "@/data/chapters/list-course-chapters";
 import { formatPosition } from "@zoonk/utils/string";
 import { getExtracted } from "next-intl/server";
@@ -16,10 +17,12 @@ import { getExtracted } from "next-intl/server";
 export async function ChapterList({
   brandSlug,
   chapters,
+  courseId,
   courseSlug,
 }: {
   brandSlug: string;
   chapters: ChapterForList[];
+  courseId: number;
   courseSlug: string;
 }) {
   if (chapters.length === 0) {
@@ -48,6 +51,8 @@ export async function ChapterList({
                   <CatalogListItemDescription>{chapter.description}</CatalogListItemDescription>
                 )}
               </CatalogListItemContent>
+
+              <ChapterCompletion chapterId={chapter.id} courseId={courseId} />
             </CatalogListItem>
           ))}
         </CatalogListContent>

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
@@ -71,7 +71,12 @@ export default async function CoursePage({
         </CatalogToolbar>
 
         <Suspense>
-          <ChapterList brandSlug={brandSlug} chapters={chapters} courseSlug={courseSlug} />
+          <ChapterList
+            brandSlug={brandSlug}
+            chapters={chapters}
+            courseId={course.id}
+            courseSlug={courseSlug}
+          />
         </Suspense>
       </CatalogContainer>
     </main>

--- a/apps/main/src/components/catalog/catalog-list.tsx
+++ b/apps/main/src/components/catalog/catalog-list.tsx
@@ -177,7 +177,7 @@ export function CatalogListItemIndicator({
       <div
         aria-label={completedLabel}
         className={cn(
-          "bg-success/60 text-background mt-1 flex size-3.5 shrink-0 items-center justify-center rounded-full",
+          "bg-success/60 text-background flex size-3.5 shrink-0 items-center justify-center self-center rounded-full",
           className,
         )}
         data-slot="catalog-list-item-indicator"
@@ -192,7 +192,7 @@ export function CatalogListItemIndicator({
     <div
       aria-label={notCompletedLabel}
       className={cn(
-        "border-muted-foreground/30 mt-1 size-3.5 shrink-0 rounded-full border-2",
+        "border-muted-foreground/30 size-3.5 shrink-0 self-center rounded-full border-2",
         className,
       )}
       data-slot="catalog-list-item-indicator"
@@ -228,5 +228,35 @@ export function CatalogListItemDescription({ className, ...props }: React.Compon
       className={cn("text-muted-foreground line-clamp-2 pt-0.5 text-sm leading-snug", className)}
       data-slot="catalog-list-item-description"
     />
+  );
+}
+
+export function CatalogListItemProgress({
+  completed,
+  completedLabel,
+  total,
+}: {
+  completed: number;
+  completedLabel: string;
+  total: number;
+}) {
+  if (total === 0 || completed === 0) {
+    return null;
+  }
+
+  if (completed >= total) {
+    return (
+      <CatalogListItemIndicator completed completedLabel={completedLabel} notCompletedLabel="" />
+    );
+  }
+
+  return (
+    <span
+      aria-label={`${completed} of ${total} completed`}
+      className="text-muted-foreground/60 shrink-0 self-center font-mono text-xs tabular-nums"
+      data-slot="catalog-list-item-progress"
+    >
+      {completed}/{total}
+    </span>
   );
 }

--- a/apps/main/src/components/catalog/chapter-completion.tsx
+++ b/apps/main/src/components/catalog/chapter-completion.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { CatalogListItemProgress } from "@/components/catalog/catalog-list";
+import { API_URL } from "@zoonk/utils/constants";
+import { isJsonObject } from "@zoonk/utils/json";
+import { useExtracted } from "next-intl";
+import useSWR from "swr";
+
+type ChapterCompletionData = {
+  chapterId: number;
+  completedLessons: number;
+  totalLessons: number;
+};
+
+async function fetchCourseCompletion(url: string): Promise<ChapterCompletionData[]> {
+  const res = await fetch(url, { credentials: "include" });
+  const json: unknown = await res.json();
+
+  if (!isJsonObject(json) || !Array.isArray(json.chapters)) {
+    return [];
+  }
+
+  return json.chapters.filter(
+    (item): item is ChapterCompletionData =>
+      isJsonObject(item) &&
+      typeof item.chapterId === "number" &&
+      typeof item.completedLessons === "number" &&
+      typeof item.totalLessons === "number",
+  );
+}
+
+export function ChapterCompletion({
+  chapterId,
+  courseId,
+}: {
+  chapterId: number;
+  courseId: number;
+}) {
+  const t = useExtracted();
+
+  const { data: chapters } = useSWR(
+    `${API_URL}/v1/progress/course-completion?courseId=${courseId}`,
+    fetchCourseCompletion,
+  );
+
+  const chapter = chapters?.find((item) => item.chapterId === chapterId);
+
+  if (!chapter) {
+    return null;
+  }
+
+  return (
+    <CatalogListItemProgress
+      completed={chapter.completedLessons}
+      completedLabel={t("Completed")}
+      total={chapter.totalLessons}
+    />
+  );
+}

--- a/apps/main/src/components/catalog/lesson-completion.tsx
+++ b/apps/main/src/components/catalog/lesson-completion.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { CatalogListItemProgress } from "@/components/catalog/catalog-list";
+import { API_URL } from "@zoonk/utils/constants";
+import { isJsonObject } from "@zoonk/utils/json";
+import { useExtracted } from "next-intl";
+import useSWR from "swr";
+
+type LessonCompletionData = {
+  completedActivities: number;
+  lessonId: number;
+  totalActivities: number;
+};
+
+async function fetchChapterCompletion(url: string): Promise<LessonCompletionData[]> {
+  const res = await fetch(url, { credentials: "include" });
+  const json: unknown = await res.json();
+
+  if (!isJsonObject(json) || !Array.isArray(json.lessons)) {
+    return [];
+  }
+
+  return json.lessons.filter(
+    (lesson): lesson is LessonCompletionData =>
+      isJsonObject(lesson) &&
+      typeof lesson.lessonId === "number" &&
+      typeof lesson.completedActivities === "number" &&
+      typeof lesson.totalActivities === "number",
+  );
+}
+
+export function LessonCompletion({ chapterId, lessonId }: { chapterId: number; lessonId: number }) {
+  const t = useExtracted();
+
+  const { data: lessons } = useSWR(
+    `${API_URL}/v1/progress/chapter-completion?chapterId=${chapterId}`,
+    fetchChapterCompletion,
+  );
+
+  const lesson = lessons?.find((item) => item.lessonId === lessonId);
+
+  if (!lesson) {
+    return null;
+  }
+
+  return (
+    <CatalogListItemProgress
+      completed={lesson.completedActivities}
+      completedLabel={t("Completed")}
+      total={lesson.totalActivities}
+    />
+  );
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -9,6 +9,8 @@
     "./next-activity/course": "./src/generated/prisma/sql/getNextCourseActivity.ts",
     "./next-activity/lesson": "./src/generated/prisma/sql/getNextLessonActivity.ts",
     "./peak-time": "./src/generated/prisma/sql/getPeakTime.ts",
+    "./completion/chapter-lessons": "./src/generated/prisma/sql/getChapterLessonCompletion.ts",
+    "./completion/course-chapters": "./src/generated/prisma/sql/getCourseChapterCompletion.ts",
     "./utils": "./src/utils.ts"
   },
   "scripts": {

--- a/packages/db/src/prisma/sql/getChapterLessonCompletion.sql
+++ b/packages/db/src/prisma/sql/getChapterLessonCompletion.sql
@@ -1,0 +1,12 @@
+-- @param {Int} $1:userId
+-- @param {Int} $2:chapterId
+SELECT
+  l.id AS "lessonId",
+  COUNT(DISTINCT a.id)::int AS "totalActivities",
+  COUNT(DISTINCT CASE WHEN ap.completed_at IS NOT NULL THEN a.id END)::int AS "completedActivities"
+FROM lessons l
+JOIN activities a ON a.lesson_id = l.id AND a.is_published = true
+LEFT JOIN activity_progress ap ON ap.activity_id = a.id AND ap.user_id = $1
+WHERE l.chapter_id = $2 AND l.is_published = true
+GROUP BY l.id
+ORDER BY l.position;

--- a/packages/db/src/prisma/sql/getCourseChapterCompletion.sql
+++ b/packages/db/src/prisma/sql/getCourseChapterCompletion.sql
@@ -1,0 +1,26 @@
+-- @param {Int} $1:userId
+-- @param {Int} $2:courseId
+WITH lesson_status AS (
+  SELECT
+    l.id AS lesson_id,
+    l.chapter_id,
+    COUNT(a.id)::int AS total_activities,
+    COUNT(CASE WHEN ap.completed_at IS NOT NULL THEN 1 END)::int AS completed_activities
+  FROM lessons l
+  JOIN chapters ch ON ch.id = l.chapter_id AND ch.course_id = $2 AND ch.is_published = true
+  JOIN activities a ON a.lesson_id = l.id AND a.is_published = true
+  LEFT JOIN activity_progress ap ON ap.activity_id = a.id AND ap.user_id = $1
+  WHERE l.is_published = true
+  GROUP BY l.id, l.chapter_id
+)
+SELECT
+  ch.id AS "chapterId",
+  COUNT(ls.lesson_id)::int AS "totalLessons",
+  COUNT(CASE
+    WHEN ls.completed_activities = ls.total_activities THEN 1
+  END)::int AS "completedLessons"
+FROM chapters ch
+LEFT JOIN lesson_status ls ON ls.chapter_id = ch.id
+WHERE ch.course_id = $2 AND ch.is_published = true
+GROUP BY ch.id
+ORDER BY ch.position;


### PR DESCRIPTION
## Summary

- Add completion progress indicators to course pages (lessons per chapter) and chapter pages (activities per lesson)
- Three-state display: nothing for not started, fraction text (e.g. `3/10`) for in progress, green checkmark for fully completed
- Move activity completion indicator from left to right side for consistency across all list types
- Add SQL queries, API endpoints, SWR client components, integration tests, and e2e tests

## Test plan

- [x] Integration tests for `getCourseChapterCompletion` (8 tests) and `getChapterLessonCompletion` (6 tests)
- [x] E2E tests for course progress indicators (4 tests) and chapter progress indicators (4 tests)
- [x] Existing lesson-detail e2e tests still pass (indicator position change)
- [x] All 233 e2e tests pass
- [x] All 232 API integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds progress indicators to course and chapter pages so learners can see completion at a glance. Shows a checkmark when fully done, a fraction when in progress, and nothing when not started; activity indicators are now aligned to the right.

- **New Features**
  - Course page: per-chapter progress via GET /v1/progress/course-completion?courseId=… (SWR-powered ChapterCompletion).
  - Chapter page: per-lesson progress via GET /v1/progress/chapter-completion?chapterId=… (SWR-powered LessonCompletion).
  - UI: move activity completion indicator to the right for consistent list layouts; new CatalogListItemProgress handles 3-state display.
  - API/OpenAPI/Data: new endpoints and schemas; typed SQL for chapter-lessons and course-chapters completion with prisma.$queryRawTyped; DB package exports added.
  - Tests: added integration tests for data queries and e2e tests for course and chapter progress.

<sup>Written for commit a78da81ec398f8e55fd0e97d4269f92cb9d17f50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

