### PR TITLE
fix(main): eliminate client-side request waterfall on catalog pages

### DIFF
--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -3,6 +3,7 @@
 import { CatalogActions } from "@/components/catalog/catalog-actions";
 import { CatalogContainer, CatalogToolbar } from "@/components/catalog/catalog-list";
 import { ContinueActivityLink } from "@/components/catalog/continue-activity-link";
+import { ProgressPreloader } from "@/components/catalog/progress-preloader";
 import { listLessonActivities } from "@/data/activities/list-lesson-activities";
 import { getLesson } from "@/data/lessons/get-lesson";
 import { redirect } from "@/i18n/navigation";
@@ -80,6 +81,7 @@ export default async function LessonPage({
 
   return (
     <main className="flex flex-1 flex-col">
+      <ProgressPreloader lessonId={lesson.id} />
       <LessonHeader
         brandSlug={brandSlug}
         chapterSlug={chapterSlug}

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -3,6 +3,7 @@
 import { CatalogActions } from "@/components/catalog/catalog-actions";
 import { CatalogContainer, CatalogToolbar } from "@/components/catalog/catalog-list";
 import { ContinueActivityLink } from "@/components/catalog/continue-activity-link";
+import { ProgressPreloader } from "@/components/catalog/progress-preloader";
 import { getChapter } from "@/data/chapters/get-chapter";
 import { listChapterLessons } from "@/data/lessons/list-chapter-lessons";
 import { redirect } from "@/i18n/navigation";
@@ -69,6 +70,7 @@ export default async function ChapterPage({
 
   return (
     <main className="flex flex-1 flex-col">
+      <ProgressPreloader chapterId={chapter.id} />
       <ChapterHeader brandSlug={brandSlug} chapter={chapter} courseSlug={courseSlug} />
 
       <CatalogContainer>

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
@@ -3,6 +3,7 @@
 import { CatalogActions } from "@/components/catalog/catalog-actions";
 import { CatalogContainer, CatalogToolbar } from "@/components/catalog/catalog-list";
 import { ContinueActivityLink } from "@/components/catalog/continue-activity-link";
+import { ProgressPreloader } from "@/components/catalog/progress-preloader";
 import { listCourseChapters } from "@/data/chapters/list-course-chapters";
 import { getCourse } from "@/data/courses/get-course";
 import { redirect } from "@/i18n/navigation";
@@ -59,6 +60,7 @@ export default async function CoursePage({
 
   return (
     <main className="flex flex-1 flex-col">
+      <ProgressPreloader courseId={course.id} />
       <CourseHeader brandSlug={brandSlug} course={course} />
 
       <CatalogContainer>

--- a/apps/main/src/components/catalog/activity-completion-indicator.tsx
+++ b/apps/main/src/components/catalog/activity-completion-indicator.tsx
@@ -1,21 +1,9 @@
 "use client";
 
 import { CatalogListItemIndicator } from "@/components/catalog/catalog-list";
-import { API_URL } from "@zoonk/utils/constants";
-import { isJsonObject } from "@zoonk/utils/json";
+import { buildActivityCompletionKey, fetchCompletedActivities } from "@/lib/progress-fetchers";
 import { useExtracted } from "next-intl";
 import useSWR from "swr";
-
-async function fetchCompletedActivities(url: string): Promise<string[]> {
-  const res = await fetch(url, { credentials: "include" });
-  const json: unknown = await res.json();
-
-  if (!isJsonObject(json) || !Array.isArray(json.completedActivityIds)) {
-    return [];
-  }
-
-  return json.completedActivityIds.filter((id): id is string => typeof id === "string");
-}
 
 export function ActivityCompletionIndicator({
   activityId,
@@ -27,7 +15,7 @@ export function ActivityCompletionIndicator({
   const t = useExtracted();
 
   const { data: completedIds } = useSWR(
-    `${API_URL}/v1/progress/activity-completion?lessonId=${lessonId}`,
+    buildActivityCompletionKey(lessonId),
     fetchCompletedActivities,
   );
 

--- a/apps/main/src/components/catalog/chapter-completion.tsx
+++ b/apps/main/src/components/catalog/chapter-completion.tsx
@@ -1,33 +1,9 @@
 "use client";
 
 import { CatalogListItemProgress } from "@/components/catalog/catalog-list";
-import { API_URL } from "@zoonk/utils/constants";
-import { isJsonObject } from "@zoonk/utils/json";
+import { buildCourseCompletionKey, fetchCourseCompletion } from "@/lib/progress-fetchers";
 import { useExtracted } from "next-intl";
 import useSWR from "swr";
-
-type ChapterCompletionData = {
-  chapterId: number;
-  completedLessons: number;
-  totalLessons: number;
-};
-
-async function fetchCourseCompletion(url: string): Promise<ChapterCompletionData[]> {
-  const res = await fetch(url, { credentials: "include" });
-  const json: unknown = await res.json();
-
-  if (!isJsonObject(json) || !Array.isArray(json.chapters)) {
-    return [];
-  }
-
-  return json.chapters.filter(
-    (item): item is ChapterCompletionData =>
-      isJsonObject(item) &&
-      typeof item.chapterId === "number" &&
-      typeof item.completedLessons === "number" &&
-      typeof item.totalLessons === "number",
-  );
-}
 
 export function ChapterCompletion({
   chapterId,
@@ -38,10 +14,7 @@ export function ChapterCompletion({
 }) {
   const t = useExtracted();
 
-  const { data: chapters } = useSWR(
-    `${API_URL}/v1/progress/course-completion?courseId=${courseId}`,
-    fetchCourseCompletion,
-  );
+  const { data: chapters } = useSWR(buildCourseCompletionKey(courseId), fetchCourseCompletion);
 
   const chapter = chapters?.find((item) => item.chapterId === chapterId);
 

--- a/apps/main/src/components/catalog/continue-activity-link.tsx
+++ b/apps/main/src/components/catalog/continue-activity-link.tsx
@@ -1,62 +1,12 @@
 "use client";
 
 import { ClientLink } from "@/i18n/client-link";
+import { buildNextActivityKey, fetchNextActivity } from "@/lib/progress-fetchers";
 import { Button, buttonVariants } from "@zoonk/ui/components/button";
 import { cn } from "@zoonk/ui/lib/utils";
-import { API_URL } from "@zoonk/utils/constants";
-import { getString, isJsonObject } from "@zoonk/utils/json";
 import { ChevronRightIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
 import useSWR from "swr";
-
-function buildQueryString(props: { chapterId?: number; courseId?: number; lessonId?: number }) {
-  if (props.courseId) {
-    return `courseId=${props.courseId}`;
-  }
-
-  if (props.chapterId) {
-    return `chapterId=${props.chapterId}`;
-  }
-
-  if (props.lessonId) {
-    return `lessonId=${props.lessonId}`;
-  }
-
-  return "";
-}
-
-async function fetchNextActivity(url: string): Promise<{
-  activityPosition: number;
-  brandSlug: string;
-  chapterSlug: string;
-  completed: boolean;
-  courseSlug: string;
-  hasStarted: boolean;
-  lessonSlug: string;
-} | null> {
-  const res = await fetch(url, { credentials: "include" });
-  const json: unknown = await res.json();
-
-  if (!isJsonObject(json)) {
-    return null;
-  }
-
-  const brandSlug = getString(json, "brandSlug");
-
-  if (!brandSlug) {
-    return null;
-  }
-
-  return {
-    activityPosition: Number(json.activityPosition),
-    brandSlug,
-    chapterSlug: getString(json, "chapterSlug") ?? "",
-    completed: json.completed === true,
-    courseSlug: getString(json, "courseSlug") ?? "",
-    hasStarted: json.hasStarted === true,
-    lessonSlug: getString(json, "lessonSlug") ?? "",
-  };
-}
 
 export function ContinueActivityLink({
   chapterId,
@@ -70,10 +20,9 @@ export function ContinueActivityLink({
   lessonId?: number;
 }) {
   const t = useExtracted();
-  const queryString = buildQueryString({ chapterId, courseId, lessonId });
 
   const { data, isLoading } = useSWR(
-    `${API_URL}/v1/progress/next-activity?${queryString}`,
+    buildNextActivityKey({ chapterId, courseId, lessonId }),
     fetchNextActivity,
   );
 

--- a/apps/main/src/components/catalog/lesson-completion.tsx
+++ b/apps/main/src/components/catalog/lesson-completion.tsx
@@ -1,41 +1,14 @@
 "use client";
 
 import { CatalogListItemProgress } from "@/components/catalog/catalog-list";
-import { API_URL } from "@zoonk/utils/constants";
-import { isJsonObject } from "@zoonk/utils/json";
+import { buildChapterCompletionKey, fetchChapterCompletion } from "@/lib/progress-fetchers";
 import { useExtracted } from "next-intl";
 import useSWR from "swr";
-
-type LessonCompletionData = {
-  completedActivities: number;
-  lessonId: number;
-  totalActivities: number;
-};
-
-async function fetchChapterCompletion(url: string): Promise<LessonCompletionData[]> {
-  const res = await fetch(url, { credentials: "include" });
-  const json: unknown = await res.json();
-
-  if (!isJsonObject(json) || !Array.isArray(json.lessons)) {
-    return [];
-  }
-
-  return json.lessons.filter(
-    (lesson): lesson is LessonCompletionData =>
-      isJsonObject(lesson) &&
-      typeof lesson.lessonId === "number" &&
-      typeof lesson.completedActivities === "number" &&
-      typeof lesson.totalActivities === "number",
-  );
-}
 
 export function LessonCompletion({ chapterId, lessonId }: { chapterId: number; lessonId: number }) {
   const t = useExtracted();
 
-  const { data: lessons } = useSWR(
-    `${API_URL}/v1/progress/chapter-completion?chapterId=${chapterId}`,
-    fetchChapterCompletion,
-  );
+  const { data: lessons } = useSWR(buildChapterCompletionKey(chapterId), fetchChapterCompletion);
 
   const lesson = lessons?.find((item) => item.lessonId === lessonId);
 

--- a/apps/main/src/components/catalog/progress-preloader.tsx
+++ b/apps/main/src/components/catalog/progress-preloader.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import {
+  buildActivityCompletionKey,
+  buildChapterCompletionKey,
+  buildCourseCompletionKey,
+  buildNextActivityKey,
+  fetchChapterCompletion,
+  fetchCompletedActivities,
+  fetchCourseCompletion,
+  fetchNextActivity,
+} from "@/lib/progress-fetchers";
+import { preload } from "swr";
+
+export function ProgressPreloader({
+  chapterId,
+  courseId,
+  lessonId,
+}: {
+  chapterId?: number;
+  courseId?: number;
+  lessonId?: number;
+}) {
+  void preload(buildNextActivityKey({ chapterId, courseId, lessonId }), fetchNextActivity);
+
+  if (courseId) {
+    void preload(buildCourseCompletionKey(courseId), fetchCourseCompletion);
+  }
+
+  if (chapterId) {
+    void preload(buildChapterCompletionKey(chapterId), fetchChapterCompletion);
+  }
+
+  if (lessonId) {
+    void preload(buildActivityCompletionKey(lessonId), fetchCompletedActivities);
+  }
+
+  return null;
+}

--- a/apps/main/src/lib/progress-fetchers.test.ts
+++ b/apps/main/src/lib/progress-fetchers.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildActivityCompletionKey,
+  buildChapterCompletionKey,
+  buildCourseCompletionKey,
+  buildNextActivityKey,
+} from "./progress-fetchers";
+
+describe(buildNextActivityKey, () => {
+  it("builds key with courseId", () => {
+    expect(buildNextActivityKey({ courseId: 1 })).toMatch(
+      /\/v1\/progress\/next-activity\?courseId=1$/,
+    );
+  });
+
+  it("builds key with chapterId", () => {
+    expect(buildNextActivityKey({ chapterId: 2 })).toMatch(
+      /\/v1\/progress\/next-activity\?chapterId=2$/,
+    );
+  });
+
+  it("builds key with lessonId", () => {
+    expect(buildNextActivityKey({ lessonId: 3 })).toMatch(
+      /\/v1\/progress\/next-activity\?lessonId=3$/,
+    );
+  });
+
+  it("prioritizes courseId over chapterId and lessonId", () => {
+    expect(buildNextActivityKey({ chapterId: 2, courseId: 1, lessonId: 3 })).toMatch(
+      /\/v1\/progress\/next-activity\?courseId=1$/,
+    );
+  });
+
+  it("prioritizes chapterId over lessonId", () => {
+    expect(buildNextActivityKey({ chapterId: 2, lessonId: 3 })).toMatch(
+      /\/v1\/progress\/next-activity\?chapterId=2$/,
+    );
+  });
+
+  it("builds key with empty query string when no IDs provided", () => {
+    expect(buildNextActivityKey({})).toMatch(/\/v1\/progress\/next-activity\?$/);
+  });
+});
+
+describe(buildCourseCompletionKey, () => {
+  it("builds key with courseId", () => {
+    expect(buildCourseCompletionKey(42)).toMatch(/\/v1\/progress\/course-completion\?courseId=42$/);
+  });
+});
+
+describe(buildChapterCompletionKey, () => {
+  it("builds key with chapterId", () => {
+    expect(buildChapterCompletionKey(7)).toMatch(
+      /\/v1\/progress\/chapter-completion\?chapterId=7$/,
+    );
+  });
+});
+
+describe(buildActivityCompletionKey, () => {
+  it("builds key with lessonId", () => {
+    expect(buildActivityCompletionKey(99)).toMatch(
+      /\/v1\/progress\/activity-completion\?lessonId=99$/,
+    );
+  });
+});

--- a/apps/main/src/lib/progress-fetchers.ts
+++ b/apps/main/src/lib/progress-fetchers.ts
@@ -1,0 +1,128 @@
+import { API_URL } from "@zoonk/utils/constants";
+import { getString, isJsonObject } from "@zoonk/utils/json";
+
+function buildQueryString(props: { chapterId?: number; courseId?: number; lessonId?: number }) {
+  if (props.courseId) {
+    return `courseId=${props.courseId}`;
+  }
+
+  if (props.chapterId) {
+    return `chapterId=${props.chapterId}`;
+  }
+
+  if (props.lessonId) {
+    return `lessonId=${props.lessonId}`;
+  }
+
+  return "";
+}
+
+export function buildNextActivityKey(props: {
+  chapterId?: number;
+  courseId?: number;
+  lessonId?: number;
+}) {
+  return `${API_URL}/v1/progress/next-activity?${buildQueryString(props)}`;
+}
+
+export function buildCourseCompletionKey(courseId: number) {
+  return `${API_URL}/v1/progress/course-completion?courseId=${courseId}`;
+}
+
+export function buildChapterCompletionKey(chapterId: number) {
+  return `${API_URL}/v1/progress/chapter-completion?chapterId=${chapterId}`;
+}
+
+export function buildActivityCompletionKey(lessonId: number) {
+  return `${API_URL}/v1/progress/activity-completion?lessonId=${lessonId}`;
+}
+
+export async function fetchNextActivity(url: string): Promise<{
+  activityPosition: number;
+  brandSlug: string;
+  chapterSlug: string;
+  completed: boolean;
+  courseSlug: string;
+  hasStarted: boolean;
+  lessonSlug: string;
+} | null> {
+  const res = await fetch(url, { credentials: "include" });
+  const json: unknown = await res.json();
+
+  if (!isJsonObject(json)) {
+    return null;
+  }
+
+  const brandSlug = getString(json, "brandSlug");
+
+  if (!brandSlug) {
+    return null;
+  }
+
+  return {
+    activityPosition: Number(json.activityPosition),
+    brandSlug,
+    chapterSlug: getString(json, "chapterSlug") ?? "",
+    completed: json.completed === true,
+    courseSlug: getString(json, "courseSlug") ?? "",
+    hasStarted: json.hasStarted === true,
+    lessonSlug: getString(json, "lessonSlug") ?? "",
+  };
+}
+
+type ChapterCompletionData = {
+  chapterId: number;
+  completedLessons: number;
+  totalLessons: number;
+};
+
+export async function fetchCourseCompletion(url: string): Promise<ChapterCompletionData[]> {
+  const res = await fetch(url, { credentials: "include" });
+  const json: unknown = await res.json();
+
+  if (!isJsonObject(json) || !Array.isArray(json.chapters)) {
+    return [];
+  }
+
+  return json.chapters.filter(
+    (item): item is ChapterCompletionData =>
+      isJsonObject(item) &&
+      typeof item.chapterId === "number" &&
+      typeof item.completedLessons === "number" &&
+      typeof item.totalLessons === "number",
+  );
+}
+
+type LessonCompletionData = {
+  completedActivities: number;
+  lessonId: number;
+  totalActivities: number;
+};
+
+export async function fetchChapterCompletion(url: string): Promise<LessonCompletionData[]> {
+  const res = await fetch(url, { credentials: "include" });
+  const json: unknown = await res.json();
+
+  if (!isJsonObject(json) || !Array.isArray(json.lessons)) {
+    return [];
+  }
+
+  return json.lessons.filter(
+    (lesson): lesson is LessonCompletionData =>
+      isJsonObject(lesson) &&
+      typeof lesson.lessonId === "number" &&
+      typeof lesson.completedActivities === "number" &&
+      typeof lesson.totalActivities === "number",
+  );
+}
+
+export async function fetchCompletedActivities(url: string): Promise<string[]> {
+  const res = await fetch(url, { credentials: "include" });
+  const json: unknown = await res.json();
+
+  if (!isJsonObject(json) || !Array.isArray(json.completedActivityIds)) {
+    return [];
+  }
+
+  return json.completedActivityIds.filter((id): id is string => typeof id === "string");
+}


### PR DESCRIPTION
## Summary

- Extract shared SWR fetchers and key builders into `progress-fetchers.ts`
- Add `ProgressPreloader` component that calls `preload()` before Suspense boundaries resolve
- Fire all progress requests in parallel during first hydration pass on course, chapter, and lesson pages

## Test plan

- [ ] Verify course page loads progress indicators correctly
- [ ] Verify chapter page loads progress indicators correctly
- [ ] Verify lesson page loads activity completion indicators correctly
- [ ] Verify "Continue" / "Start" / "Review" button works on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start all progress API requests in parallel on catalog course, chapter, and lesson pages to remove the client-side waterfall and speed up first render. Adds a ProgressPreloader and shared SWR fetchers/keys used by progress components.

- **Refactors**
  - Added ProgressPreloader on course/chapter/lesson pages to start next-activity and completion requests during first hydration.
  - Extracted progress fetchers and SWR key builders into lib/progress-fetchers and updated catalog components to use them.
  - Added unit tests for key builders.

<sup>Written for commit 94462a6ec582d14f9f52626024aaea50a305b8f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

