### PR TITLE
feat(main): add completion screen for activity player

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ Zoonk is a web app where users can learn anything using AI. This app uses AI to 
 ## Engineering Mindset
 
 - **Build for growth, not current size.** "We only have N of X" is NEVER a valid reason to skip proper patterns. Early-stage projects grow. Build infrastructure that scales with the project from the start.
+- **Structure code for known growth.** When a plan or issue tracker shows a file will grow (e.g., new renderers, phases, or features), extract components and helpers proactively — don't wait for it to become a problem. "One-time use" is not a reason to inline if we already know more uses are coming.
 - **Single source of truth always wins.** If two things must stay in sync (schemas + docs, types + validation), generate one from the other. Manual duplication WILL drift.
 - **Setup cost is amortized.** The effort to set up reusable code and automations always pays off. Don't optimize for today's sprint. Focus on long-term velocity.
 - **Principles override plans.** If a plan marks something as "optional" but skipping it would violate core principles (like single source of truth), do it anyway. Plans are guidance; principles are non-negotiable. When in doubt, ask: "Does skipping this create duplicate sources of truth or technical debt?"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -9,6 +9,7 @@ msgstr ""
 #: src/app/[locale]/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/[locale]/(performance)/_components/performance-empty-state.tsx
 #: src/app/[locale]/(settings)/_components/protected-section.tsx
+#: src/components/activity-player/completion-screen.tsx
 #: src/components/auth/login-required.tsx
 msgctxt "AyGauy"
 msgid "Login"
@@ -637,6 +638,7 @@ msgid "Level {current} of 10 in {color} belt"
 msgstr "Level {current} of 10 in {color} belt"
 
 #: src/app/[locale]/(performance)/level/level-progression.tsx
+#: src/components/activity-player/completion-screen.tsx
 msgctxt "JXdbo8"
 msgid "Done"
 msgstr "Done"
@@ -1173,6 +1175,21 @@ msgstr "Continue"
 msgctxt "RDZVQL"
 msgid "Check"
 msgstr "Check"
+
+#: src/components/activity-player/completion-screen.tsx
+msgctxt "e1M39C"
+msgid "Sign up to track your progress"
+msgstr "Sign up to track your progress"
+
+#: src/components/activity-player/completion-screen.tsx
+msgctxt "GB+0+G"
+msgid "Next Activity"
+msgstr "Next Activity"
+
+#: src/components/activity-player/completion-screen.tsx
+msgctxt "P768k7"
+msgid "correct"
+msgstr "correct"
 
 #: src/components/activity-player/feedback-screen.tsx
 msgctxt "++l7ni"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -9,6 +9,7 @@ msgstr ""
 #: src/app/[locale]/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/[locale]/(performance)/_components/performance-empty-state.tsx
 #: src/app/[locale]/(settings)/_components/protected-section.tsx
+#: src/components/activity-player/completion-screen.tsx
 #: src/components/auth/login-required.tsx
 msgctxt "AyGauy"
 msgid "Login"
@@ -637,6 +638,7 @@ msgid "Level {current} of 10 in {color} belt"
 msgstr "Nivel {current} de 10 en cinturón {color}"
 
 #: src/app/[locale]/(performance)/level/level-progression.tsx
+#: src/components/activity-player/completion-screen.tsx
 msgctxt "JXdbo8"
 msgid "Done"
 msgstr "Listo"
@@ -1173,6 +1175,21 @@ msgstr "Continuar"
 msgctxt "RDZVQL"
 msgid "Check"
 msgstr "Verificación"
+
+#: src/components/activity-player/completion-screen.tsx
+msgctxt "e1M39C"
+msgid "Sign up to track your progress"
+msgstr "Regístrate para seguir tu progreso"
+
+#: src/components/activity-player/completion-screen.tsx
+msgctxt "GB+0+G"
+msgid "Next Activity"
+msgstr "Siguiente actividad"
+
+#: src/components/activity-player/completion-screen.tsx
+msgctxt "P768k7"
+msgid "correct"
+msgstr "correcto"
 
 #: src/components/activity-player/feedback-screen.tsx
 msgctxt "++l7ni"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -9,6 +9,7 @@ msgstr ""
 #: src/app/[locale]/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/[locale]/(performance)/_components/performance-empty-state.tsx
 #: src/app/[locale]/(settings)/_components/protected-section.tsx
+#: src/components/activity-player/completion-screen.tsx
 #: src/components/auth/login-required.tsx
 msgctxt "AyGauy"
 msgid "Login"
@@ -637,6 +638,7 @@ msgid "Level {current} of 10 in {color} belt"
 msgstr "Nível {current} de 10 na faixa {color}"
 
 #: src/app/[locale]/(performance)/level/level-progression.tsx
+#: src/components/activity-player/completion-screen.tsx
 msgctxt "JXdbo8"
 msgid "Done"
 msgstr "Pronto"
@@ -1173,6 +1175,21 @@ msgstr "Continuar"
 msgctxt "RDZVQL"
 msgid "Check"
 msgstr "Verificar"
+
+#: src/components/activity-player/completion-screen.tsx
+msgctxt "e1M39C"
+msgid "Sign up to track your progress"
+msgstr "Cadastre-se para acompanhar seu progresso"
+
+#: src/components/activity-player/completion-screen.tsx
+msgctxt "GB+0+G"
+msgid "Next Activity"
+msgstr "Próxima atividade"
+
+#: src/components/activity-player/completion-screen.tsx
+msgctxt "P768k7"
+msgid "correct"
+msgstr "correto"
 
 #: src/components/activity-player/feedback-screen.tsx
 msgctxt "++l7ni"

--- a/apps/main/src/app/[locale]/(catalog)/learn/[prompt]/content-feedback.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/learn/[prompt]/content-feedback.tsx
@@ -11,13 +11,18 @@ import { useState } from "react";
 export function ContentFeedback({
   kind,
   contentId,
+  variant = "default",
   className,
+  ...props
 }: {
   kind: FeedbackKind;
   contentId: string;
+  variant?: "default" | "minimal";
 } & React.ComponentProps<"footer">) {
   const t = useExtracted();
   const [feedback, setFeedback] = useState<FeedbackValue | null>(null);
+  const isMinimal = variant === "minimal";
+  const iconSize = isMinimal ? "size-7" : "size-8";
 
   function handleFeedback(value: FeedbackValue) {
     if (feedback !== value) {
@@ -27,15 +32,18 @@ export function ContentFeedback({
   }
 
   return (
-    <footer className={cn("flex flex-col items-center gap-1 text-center", className)}>
-      <h6 className="text-muted-foreground text-sm">{t("Did you like this content?")}</h6>
+    <footer className={cn("flex flex-col items-center gap-1 text-center", className)} {...props}>
+      {!isMinimal && (
+        <h6 className="text-muted-foreground text-sm">{t("Did you like this content?")}</h6>
+      )}
 
       <div className="flex gap-1">
         <Button
           aria-pressed={feedback === "upvote"}
           className={cn(
-            "size-8 hover:bg-green-50 hover:text-green-600",
-            feedback === "upvote" && "bg-green-50 text-green-600",
+            iconSize,
+            "hover:bg-success/10 hover:text-success",
+            feedback === "upvote" && "bg-success/10 text-success",
           )}
           onClick={() => handleFeedback("upvote")}
           size="icon"
@@ -48,8 +56,9 @@ export function ContentFeedback({
         <Button
           aria-pressed={feedback === "downvote"}
           className={cn(
-            "size-8 hover:bg-red-50 hover:text-red-600",
-            feedback === "downvote" && "bg-red-50 text-red-600",
+            iconSize,
+            "hover:bg-destructive/10 hover:text-destructive",
+            feedback === "downvote" && "bg-destructive/10 text-destructive",
           )}
           onClick={() => handleFeedback("downvote")}
           size="icon"
@@ -60,12 +69,14 @@ export function ContentFeedback({
         </Button>
       </div>
 
-      <FeedbackDialog>
-        <Button className="text-muted-foreground" size="sm" variant="ghost">
-          <MessageSquareIcon aria-hidden="true" />
-          {t("Send feedback")}
-        </Button>
-      </FeedbackDialog>
+      {!isMinimal && (
+        <FeedbackDialog>
+          <Button className="text-muted-foreground" size="sm" variant="ghost">
+            <MessageSquareIcon aria-hidden="true" />
+            {t("Send feedback")}
+          </Button>
+        </FeedbackDialog>
+      )}
     </footer>
   );
 }

--- a/apps/main/src/app/[locale]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
+++ b/apps/main/src/app/[locale]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
@@ -6,6 +6,7 @@ import { getLessonSentences } from "@/data/activities/get-lesson-sentences";
 import { getLessonWords } from "@/data/activities/get-lesson-words";
 import { prepareActivityData } from "@/data/activities/prepare-activity-data";
 import { getLesson } from "@/data/lessons/get-lesson";
+import { getNextActivityInCourse } from "@zoonk/core/activities/next-in-course";
 import { cacheTagActivity } from "@zoonk/utils/cache";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { parseNumericId } from "@zoonk/utils/string";
@@ -57,10 +58,18 @@ export default async function ActivityPage({ params }: Props) {
     notFound();
   }
 
-  const [activity, lessonWords, lessonSentences] = await Promise.all([
+  const [activity, lessonWords, lessonSentences, nextActivity] = await Promise.all([
     getActivity({ lessonId: lesson.id, position: activityPosition }),
     getLessonWords({ lessonId: lesson.id }),
     getLessonSentences({ lessonId: lesson.id }),
+    getNextActivityInCourse({
+      activityPosition,
+      chapterId: lesson.chapter.id,
+      chapterPosition: lesson.chapter.position,
+      courseId: lesson.chapter.course.id,
+      lessonId: lesson.id,
+      lessonPosition: lesson.position,
+    }),
   ]);
 
   if (!activity) {
@@ -79,6 +88,15 @@ export default async function ActivityPage({ params }: Props) {
 
   const serialized = prepareActivityData(activity, lessonWords, lessonSentences);
   const lessonHref = `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`;
+  const nextActivityHref = nextActivity
+    ? `/b/${brandSlug}/c/${courseSlug}/ch/${nextActivity.chapterSlug}/l/${nextActivity.lessonSlug}/a/${nextActivity.activityPosition}`
+    : null;
 
-  return <ActivityPlayerShell activity={serialized} lessonHref={lessonHref} />;
+  return (
+    <ActivityPlayerShell
+      activity={serialized}
+      lessonHref={lessonHref}
+      nextActivityHref={nextActivityHref}
+    />
+  );
 }

--- a/apps/main/src/components/activity-player/activity-player-shell.tsx
+++ b/apps/main/src/components/activity-player/activity-player-shell.tsx
@@ -4,20 +4,23 @@ import { type SerializedActivity } from "@/data/activities/prepare-activity-data
 import { useRouter } from "@/i18n/navigation";
 import { useExtracted } from "next-intl";
 import { useCallback } from "react";
-import { FeedbackScreenContent, getFeedbackVariant } from "./feedback-screen";
+import { getFeedbackVariant } from "./feedback-screen";
 import { PlayerActionBar, PlayerActionButton } from "./player-action-bar";
 import { PlayerCloseLink, PlayerHeader, PlayerStepFraction } from "./player-header";
 import { PlayerProgressBar } from "./player-progress-bar";
 import { PlayerStage } from "./player-stage";
+import { StageContent } from "./stage-content";
 import { usePlayerKeyboard } from "./use-player-keyboard";
 import { usePlayerState } from "./use-player-state";
 
 export function ActivityPlayerShell({
   activity,
   lessonHref,
+  nextActivityHref,
 }: {
   activity: SerializedActivity;
   lessonHref: string;
+  nextActivityHref: string | null;
 }) {
   const t = useExtracted();
   const router = useRouter();
@@ -29,9 +32,9 @@ export function ActivityPlayerShell({
   const currentResult = currentStep ? state.results[currentStep.id] : undefined;
   const feedbackVariant = currentResult ? getFeedbackVariant(currentResult) : undefined;
   const totalSteps = state.steps.length;
+  const isCompleted = state.phase === "completed";
 
-  const progressValue =
-    state.phase === "completed" ? 100 : computeProgress(state.currentStepIndex, totalSteps);
+  const progressValue = isCompleted ? 100 : computeProgress(state.currentStepIndex, totalSteps);
 
   const handleEscape = useCallback(() => {
     router.push(lessonHref);
@@ -78,13 +81,18 @@ export function ActivityPlayerShell({
       <PlayerProgressBar value={progressValue} />
 
       <PlayerStage feedback={feedbackVariant} phase={state.phase}>
-        {state.phase === "feedback" && currentResult ? (
-          <FeedbackScreenContent result={currentResult} />
-        ) : // Step content will be rendered here by step renderers (Issue 9)
-        null}
+        <StageContent
+          activityId={state.activityId}
+          currentResult={currentResult}
+          isCompleted={isCompleted}
+          lessonHref={lessonHref}
+          nextActivityHref={nextActivityHref}
+          phase={state.phase}
+          results={state.results}
+        />
       </PlayerStage>
 
-      {!isStaticStep && (
+      {!isStaticStep && !isCompleted && (
         <PlayerActionBar>
           <PlayerActionButton
             disabled={state.phase === "playing" && !hasAnswer}

--- a/apps/main/src/components/activity-player/completion-screen.tsx
+++ b/apps/main/src/components/activity-player/completion-screen.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { ContentFeedback } from "@/app/[locale]/(catalog)/learn/[prompt]/content-feedback";
+import { ClientLink } from "@/i18n/client-link";
+import { useAuthState } from "@zoonk/core/auth/hooks/auth-state";
+import { computeScore } from "@zoonk/core/player/compute-score";
+import { buttonVariants } from "@zoonk/ui/components/button";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { cn } from "@zoonk/ui/lib/utils";
+import { useExtracted } from "next-intl";
+import { type StepResult } from "./player-reducer";
+
+function CompletionScreen({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      aria-live="polite"
+      className={cn(
+        "animate-in fade-in slide-in-from-bottom-1 mx-auto flex w-full max-w-lg flex-col items-center gap-4 duration-200",
+        className,
+      )}
+      data-slot="completion-screen"
+      role="status"
+      {...props}
+    />
+  );
+}
+
+function CompletionScore({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("flex flex-col items-center gap-1", className)}
+      data-slot="completion-score"
+      {...props}
+    />
+  );
+}
+
+function CompletionActions({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("flex w-full flex-col gap-3", className)}
+      data-slot="completion-actions"
+      {...props}
+    />
+  );
+}
+
+function AuthenticatedContent({
+  activityId,
+  lessonHref,
+  nextActivityHref,
+}: {
+  activityId: string;
+  lessonHref: string;
+  nextActivityHref: string | null;
+}) {
+  const t = useExtracted();
+
+  return (
+    <>
+      <p className="text-muted-foreground text-sm">+10 BP</p>
+
+      <CompletionActions>
+        {nextActivityHref && (
+          <ClientLink className={cn(buttonVariants(), "w-full")} href={nextActivityHref}>
+            {t("Next Activity")}
+          </ClientLink>
+        )}
+
+        <ClientLink
+          className={cn(buttonVariants({ variant: "outline" }), "w-full")}
+          href={lessonHref}
+        >
+          {t("Done")}
+        </ClientLink>
+      </CompletionActions>
+
+      <ContentFeedback className="pt-8" contentId={activityId} kind="activity" variant="minimal" />
+    </>
+  );
+}
+
+function UnauthenticatedContent({ lessonHref }: { lessonHref: string }) {
+  const t = useExtracted();
+
+  return (
+    <>
+      <p className="text-muted-foreground text-sm">{t("Sign up to track your progress")}</p>
+
+      <CompletionActions>
+        <ClientLink className={cn(buttonVariants(), "w-full")} href="/login">
+          {t("Login")}
+        </ClientLink>
+
+        <ClientLink
+          className={cn(buttonVariants({ variant: "outline" }), "w-full")}
+          href={lessonHref}
+        >
+          {t("Done")}
+        </ClientLink>
+      </CompletionActions>
+    </>
+  );
+}
+
+function PendingContent({ lessonHref }: { lessonHref: string }) {
+  const t = useExtracted();
+
+  return (
+    <>
+      <Skeleton className="h-4 w-32" />
+
+      <CompletionActions>
+        <ClientLink
+          className={cn(buttonVariants({ variant: "outline" }), "w-full")}
+          href={lessonHref}
+        >
+          {t("Done")}
+        </ClientLink>
+      </CompletionActions>
+    </>
+  );
+}
+
+function AuthBranch(props: {
+  activityId: string;
+  lessonHref: string;
+  nextActivityHref: string | null;
+}) {
+  const authState = useAuthState();
+
+  if (authState === "pending") {
+    return <PendingContent lessonHref={props.lessonHref} />;
+  }
+
+  if (authState === "unauthenticated") {
+    return <UnauthenticatedContent lessonHref={props.lessonHref} />;
+  }
+
+  return <AuthenticatedContent {...props} />;
+}
+
+export function CompletionScreenContent({
+  activityId,
+  lessonHref,
+  nextActivityHref,
+  results,
+}: {
+  activityId: string;
+  lessonHref: string;
+  nextActivityHref: string | null;
+  results: Record<string, StepResult>;
+}) {
+  const t = useExtracted();
+  const resultList = Object.values(results);
+  const score = computeScore({
+    results: resultList.map((stepResult) => ({ isCorrect: stepResult.result.isCorrect })),
+  });
+
+  return (
+    <CompletionScreen>
+      <CompletionScore>
+        <p className="text-4xl font-bold tabular-nums">
+          {score.correctCount}/{resultList.length}
+        </p>
+        <p className="text-muted-foreground text-sm">{t("correct")}</p>
+      </CompletionScore>
+
+      <AuthBranch
+        activityId={activityId}
+        lessonHref={lessonHref}
+        nextActivityHref={nextActivityHref}
+      />
+    </CompletionScreen>
+  );
+}

--- a/apps/main/src/components/activity-player/stage-content.tsx
+++ b/apps/main/src/components/activity-player/stage-content.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { CompletionScreenContent } from "./completion-screen";
+import { FeedbackScreenContent } from "./feedback-screen";
+import { type StepResult } from "./player-reducer";
+
+export function StageContent({
+  currentResult,
+  isCompleted,
+  activityId,
+  lessonHref,
+  nextActivityHref,
+  results,
+  phase,
+}: {
+  currentResult: StepResult | undefined;
+  isCompleted: boolean;
+  activityId: string;
+  lessonHref: string;
+  nextActivityHref: string | null;
+  results: Record<string, StepResult>;
+  phase: string;
+}) {
+  if (isCompleted) {
+    return (
+      <CompletionScreenContent
+        activityId={activityId}
+        lessonHref={lessonHref}
+        nextActivityHref={nextActivityHref}
+        results={results}
+      />
+    );
+  }
+
+  if (phase === "feedback" && currentResult) {
+    return <FeedbackScreenContent result={currentResult} />;
+  }
+
+  // Step content will be rendered here by step renderers (Issue 9)
+  return null;
+}

--- a/apps/main/src/data/lessons/get-lesson.ts
+++ b/apps/main/src/data/lessons/get-lesson.ts
@@ -9,9 +9,12 @@ export type LessonWithDetails = {
   description: string;
   position: number;
   chapter: {
+    id: number;
+    position: number;
     slug: string;
     title: string;
     course: {
+      id: number;
       slug: string;
       title: string;
     };
@@ -24,7 +27,9 @@ const cachedGetLesson = cache(
       select: {
         chapter: {
           select: {
-            course: { select: { slug: true, title: true } },
+            course: { select: { id: true, slug: true, title: true } },
+            id: true,
+            position: true,
             slug: true,
             title: true,
           },

--- a/apps/main/src/lib/track-feedback.ts
+++ b/apps/main/src/lib/track-feedback.ts
@@ -1,6 +1,6 @@
 import { track } from "@vercel/analytics";
 
-export type FeedbackKind = "course" | "chapter" | "lesson" | "courseSuggestions";
+export type FeedbackKind = "activity" | "course" | "chapter" | "lesson" | "courseSuggestions";
 
 export type FeedbackValue = "upvote" | "downvote";
 

--- a/i18n.lock
+++ b/i18n.lock
@@ -411,6 +411,9 @@ checksums:
     Terms%20of%20Use/singular: 9ac262b2eda552beeecd904c0b9f8fa2
     Continue/singular: 3cfba90b4600131e82fc4260c568d044
     Check/singular: 023cc2ba432775c38e3efc004ad7b9ef
+    Sign%20up%20to%20track%20your%20progress/singular: 554ed29d9b8a243362c3b3374222af08
+    Next%20Activity/singular: 90a2c70d1a053926e3144ee05627f687
+    correct/singular: 0c2df4a764cea47295c0b550477e8e29
     Not%20quite/singular: e570085e69662802acf485c4565e3e3e
     Outcome/singular: 4cfc7a40e384ea8b6658e8da6e351bf0
     Correct!/singular: dda1a98dc04fd9db252887ecf1765d41

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./activities/next-in-course": "./src/activities/get-next-activity-in-course.ts",
     "./ai": "./src/ai.ts",
     "./alternative-titles/add": "./src/alternative-titles/add-alternative-titles.ts",
     "./audio/generate": "./src/audio/generate-language-audio.ts",

--- a/packages/core/src/activities/get-next-activity-in-course.test.ts
+++ b/packages/core/src/activities/get-next-activity-in-course.test.ts
@@ -1,0 +1,479 @@
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, describe, expect, test } from "vitest";
+import { getNextActivityInCourse } from "./get-next-activity-in-course";
+
+describe(getNextActivityInCourse, () => {
+  let courseId: number;
+  let orgId: number;
+
+  let ch1Id: number;
+  let ch1Slug: string;
+  let ch2Id: number;
+  let ch2Slug: string;
+
+  let l1Id: number;
+  let l1Slug: string;
+  let l2Id: number;
+  let l2Slug: string;
+  let l3Id: number;
+  let l3Slug: string;
+
+  beforeAll(async () => {
+    const org = await organizationFixture({ kind: "brand" });
+    orgId = org.id;
+
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: orgId,
+    });
+    courseId = course.id;
+
+    const [ch1, ch2] = await Promise.all([
+      chapterFixture({
+        courseId,
+        isPublished: true,
+        organizationId: orgId,
+        position: 0,
+      }),
+      chapterFixture({
+        courseId,
+        isPublished: true,
+        organizationId: orgId,
+        position: 1,
+      }),
+    ]);
+
+    ch1Id = ch1.id;
+    ch1Slug = ch1.slug;
+    ch2Id = ch2.id;
+    ch2Slug = ch2.slug;
+
+    // Chapter 1: 2 lessons
+    const [lesson1, lesson2] = await Promise.all([
+      lessonFixture({
+        chapterId: ch1Id,
+        isPublished: true,
+        organizationId: orgId,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: ch1Id,
+        isPublished: true,
+        organizationId: orgId,
+        position: 1,
+      }),
+    ]);
+
+    l1Id = lesson1.id;
+    l1Slug = lesson1.slug;
+    l2Id = lesson2.id;
+    l2Slug = lesson2.slug;
+
+    // Chapter 2: 1 lesson
+    const lesson3 = await lessonFixture({
+      chapterId: ch2Id,
+      isPublished: true,
+      organizationId: orgId,
+      position: 0,
+    });
+
+    l3Id = lesson3.id;
+    l3Slug = lesson3.slug;
+
+    // Lesson 1: activities at positions 0, 1
+    // Lesson 2: activity at position 0
+    // Lesson 3 (ch2): activity at position 0
+    await Promise.all([
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        lessonId: l1Id,
+        organizationId: orgId,
+        position: 0,
+      }),
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        lessonId: l1Id,
+        organizationId: orgId,
+        position: 1,
+      }),
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        lessonId: l2Id,
+        organizationId: orgId,
+        position: 0,
+      }),
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        lessonId: l3Id,
+        organizationId: orgId,
+        position: 0,
+      }),
+    ]);
+  });
+
+  test("returns next activity in same lesson", async () => {
+    const result = await getNextActivityInCourse({
+      activityPosition: 0,
+      chapterId: ch1Id,
+      chapterPosition: 0,
+      courseId,
+      lessonId: l1Id,
+      lessonPosition: 0,
+    });
+
+    expect(result).toEqual({
+      activityPosition: 1,
+      chapterSlug: ch1Slug,
+      lessonSlug: l1Slug,
+    });
+  });
+
+  test("returns first activity of next lesson when at last activity of current lesson", async () => {
+    const result = await getNextActivityInCourse({
+      activityPosition: 1,
+      chapterId: ch1Id,
+      chapterPosition: 0,
+      courseId,
+      lessonId: l1Id,
+      lessonPosition: 0,
+    });
+
+    expect(result).toEqual({
+      activityPosition: 0,
+      chapterSlug: ch1Slug,
+      lessonSlug: l2Slug,
+    });
+  });
+
+  test("returns first activity of next chapter when at last lesson of current chapter", async () => {
+    const result = await getNextActivityInCourse({
+      activityPosition: 0,
+      chapterId: ch1Id,
+      chapterPosition: 0,
+      courseId,
+      lessonId: l2Id,
+      lessonPosition: 1,
+    });
+
+    expect(result).toEqual({
+      activityPosition: 0,
+      chapterSlug: ch2Slug,
+      lessonSlug: l3Slug,
+    });
+  });
+
+  test("returns null when at the last activity of the course", async () => {
+    const result = await getNextActivityInCourse({
+      activityPosition: 0,
+      chapterId: ch2Id,
+      chapterPosition: 1,
+      courseId,
+      lessonId: l3Id,
+      lessonPosition: 0,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null for a non-existent course", async () => {
+    const result = await getNextActivityInCourse({
+      activityPosition: 0,
+      chapterId: ch1Id,
+      chapterPosition: 0,
+      courseId: 999_999,
+      lessonId: l1Id,
+      lessonPosition: 0,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("skips unpublished activities", async () => {
+    const testOrg = await organizationFixture({ kind: "brand" });
+    const testCourse = await courseFixture({
+      isPublished: true,
+      organizationId: testOrg.id,
+    });
+    const testChapter = await chapterFixture({
+      courseId: testCourse.id,
+      isPublished: true,
+      organizationId: testOrg.id,
+      position: 0,
+    });
+    const testLesson = await lessonFixture({
+      chapterId: testChapter.id,
+      isPublished: true,
+      organizationId: testOrg.id,
+      position: 0,
+    });
+
+    await Promise.all([
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        lessonId: testLesson.id,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: false,
+        lessonId: testLesson.id,
+        organizationId: testOrg.id,
+        position: 1,
+      }),
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        lessonId: testLesson.id,
+        organizationId: testOrg.id,
+        position: 2,
+      }),
+    ]);
+
+    const result = await getNextActivityInCourse({
+      activityPosition: 0,
+      chapterId: testChapter.id,
+      chapterPosition: 0,
+      courseId: testCourse.id,
+      lessonId: testLesson.id,
+      lessonPosition: 0,
+    });
+
+    expect(result).toEqual({
+      activityPosition: 2,
+      chapterSlug: testChapter.slug,
+      lessonSlug: testLesson.slug,
+    });
+  });
+
+  test("skips activities with incomplete generation", async () => {
+    const testOrg = await organizationFixture({ kind: "brand" });
+    const testCourse = await courseFixture({
+      isPublished: true,
+      organizationId: testOrg.id,
+    });
+    const testChapter = await chapterFixture({
+      courseId: testCourse.id,
+      isPublished: true,
+      organizationId: testOrg.id,
+      position: 0,
+    });
+    const testLesson = await lessonFixture({
+      chapterId: testChapter.id,
+      isPublished: true,
+      organizationId: testOrg.id,
+      position: 0,
+    });
+
+    await Promise.all([
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        lessonId: testLesson.id,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+      activityFixture({
+        generationStatus: "pending",
+        isPublished: true,
+        lessonId: testLesson.id,
+        organizationId: testOrg.id,
+        position: 1,
+      }),
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        lessonId: testLesson.id,
+        organizationId: testOrg.id,
+        position: 2,
+      }),
+    ]);
+
+    const result = await getNextActivityInCourse({
+      activityPosition: 0,
+      chapterId: testChapter.id,
+      chapterPosition: 0,
+      courseId: testCourse.id,
+      lessonId: testLesson.id,
+      lessonPosition: 0,
+    });
+
+    expect(result).toEqual({
+      activityPosition: 2,
+      chapterSlug: testChapter.slug,
+      lessonSlug: testLesson.slug,
+    });
+  });
+
+  test("skips activities in unpublished lessons", async () => {
+    const testOrg = await organizationFixture({ kind: "brand" });
+    const testCourse = await courseFixture({
+      isPublished: true,
+      organizationId: testOrg.id,
+    });
+    const testChapter = await chapterFixture({
+      courseId: testCourse.id,
+      isPublished: true,
+      organizationId: testOrg.id,
+      position: 0,
+    });
+
+    const [publishedLesson, unpublishedLesson, nextPublishedLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: testChapter.id,
+        isPublished: true,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: testChapter.id,
+        isPublished: false,
+        organizationId: testOrg.id,
+        position: 1,
+      }),
+      lessonFixture({
+        chapterId: testChapter.id,
+        isPublished: true,
+        organizationId: testOrg.id,
+        position: 2,
+      }),
+    ]);
+
+    await Promise.all([
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        lessonId: publishedLesson.id,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        lessonId: unpublishedLesson.id,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        lessonId: nextPublishedLesson.id,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+    ]);
+
+    const result = await getNextActivityInCourse({
+      activityPosition: 0,
+      chapterId: testChapter.id,
+      chapterPosition: 0,
+      courseId: testCourse.id,
+      lessonId: publishedLesson.id,
+      lessonPosition: 0,
+    });
+
+    expect(result).toEqual({
+      activityPosition: 0,
+      chapterSlug: testChapter.slug,
+      lessonSlug: nextPublishedLesson.slug,
+    });
+  });
+
+  test("skips activities in unpublished chapters", async () => {
+    const testOrg = await organizationFixture({ kind: "brand" });
+    const testCourse = await courseFixture({
+      isPublished: true,
+      organizationId: testOrg.id,
+    });
+
+    const [publishedCh, unpublishedCh, nextPublishedCh] = await Promise.all([
+      chapterFixture({
+        courseId: testCourse.id,
+        isPublished: true,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+      chapterFixture({
+        courseId: testCourse.id,
+        isPublished: false,
+        organizationId: testOrg.id,
+        position: 1,
+      }),
+      chapterFixture({
+        courseId: testCourse.id,
+        isPublished: true,
+        organizationId: testOrg.id,
+        position: 2,
+      }),
+    ]);
+
+    const [lesson1, lesson2, lesson3] = await Promise.all([
+      lessonFixture({
+        chapterId: publishedCh.id,
+        isPublished: true,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: unpublishedCh.id,
+        isPublished: true,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: nextPublishedCh.id,
+        isPublished: true,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+    ]);
+
+    await Promise.all([
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        lessonId: lesson1.id,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        lessonId: lesson2.id,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        lessonId: lesson3.id,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+    ]);
+
+    const result = await getNextActivityInCourse({
+      activityPosition: 0,
+      chapterId: publishedCh.id,
+      chapterPosition: 0,
+      courseId: testCourse.id,
+      lessonId: lesson1.id,
+      lessonPosition: 0,
+    });
+
+    expect(result).toEqual({
+      activityPosition: 0,
+      chapterSlug: nextPublishedCh.slug,
+      lessonSlug: lesson3.slug,
+    });
+  });
+});

--- a/packages/core/src/activities/get-next-activity-in-course.ts
+++ b/packages/core/src/activities/get-next-activity-in-course.ts
@@ -1,0 +1,103 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { cache } from "react";
+
+export type NextActivityInCourse = {
+  activityPosition: number;
+  chapterSlug: string;
+  lessonSlug: string;
+};
+
+const cachedGetNextActivity = cache(
+  async (
+    activityPosition: number,
+    chapterId: number,
+    chapterPosition: number,
+    courseId: number,
+    lessonId: number,
+    lessonPosition: number,
+  ): Promise<NextActivityInCourse | null> => {
+    const { data: activity, error } = await safeAsync(() =>
+      prisma.activity.findFirst({
+        orderBy: [
+          { lesson: { chapter: { position: "asc" } } },
+          { lesson: { position: "asc" } },
+          { position: "asc" },
+        ],
+        select: {
+          lesson: {
+            select: {
+              chapter: { select: { slug: true } },
+              slug: true,
+            },
+          },
+          position: true,
+        },
+        where: {
+          OR: [
+            {
+              lesson: {
+                chapter: { position: chapterPosition },
+                id: lessonId,
+              },
+              position: { gt: activityPosition },
+            },
+            {
+              lesson: {
+                chapter: { id: chapterId, position: chapterPosition },
+                position: { gt: lessonPosition },
+              },
+            },
+            {
+              lesson: {
+                chapter: { position: { gt: chapterPosition } },
+              },
+            },
+          ],
+          generationStatus: "completed",
+          isPublished: true,
+          lesson: {
+            chapter: {
+              course: { id: courseId },
+              isPublished: true,
+            },
+            isPublished: true,
+          },
+        },
+      }),
+    );
+
+    if (error || !activity) {
+      return null;
+    }
+
+    return {
+      activityPosition: activity.position,
+      chapterSlug: activity.lesson.chapter.slug,
+      lessonSlug: activity.lesson.slug,
+    };
+  },
+);
+
+/**
+ * Finds the next published, generated activity in course order
+ * using structural position (not user progress).
+ */
+export function getNextActivityInCourse(params: {
+  activityPosition: number;
+  chapterId: number;
+  chapterPosition: number;
+  courseId: number;
+  lessonId: number;
+  lessonPosition: number;
+}): Promise<NextActivityInCourse | null> {
+  return cachedGetNextActivity(
+    params.activityPosition,
+    params.chapterId,
+    params.chapterPosition,
+    params.courseId,
+    params.lessonId,
+    params.lessonPosition,
+  );
+}


### PR DESCRIPTION
## Summary

- Add `CompletionScreenContent` component with score display, auth-aware actions (BP for logged-in users, sign-up CTA for guests), next activity / done buttons, and minimal feedback variant
- Add `getNextActivityInCourse()` data function in `@zoonk/core` to find the next published activity in course order (same lesson > next lesson > next chapter), with integration tests
- Add `StageContent` component to orchestrate player stage rendering (completion / feedback / step content)
- Extend `ContentFeedback` with `variant="minimal"` for compact inline use
- Extend `getLesson()` to include chapter/course IDs and chapter position needed for next-activity lookup

Implements Issue 8 from `tasks/ISSUES.md`.

## Test plan

- [ ] Integration tests for `getNextActivityInCourse()` (same lesson, next lesson, next chapter, last activity, unpublished/incomplete skip)
- [ ] Verify completion screen renders score, BP, next activity button, and done button for authenticated users
- [ ] Verify guests see score + sign-up CTA instead of BP/feedback
- [ ] Verify "Next Activity" button is hidden when no next activity exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a completion screen to the activity player with score and clear next steps, and enables “Next Activity” navigation across lessons and chapters. Implements Issue 8.

- New Features
  - Completion screen with score, auth-aware actions (+10 BP text, Next Activity/Done for users; login CTA for guests), and minimal inline feedback.
  - Next-activity lookup in @zoonk/core (getNextActivityInCourse) to jump to the next published, generated activity in course order; integrated into ActivityPage and the player; hides when none; includes tests.
  - StageContent orchestrates player phases (step, feedback, completion).

- Refactors
  - ContentFeedback supports variant="minimal" and new kind "activity".
  - getLesson now returns chapter/course IDs and chapter position for next-activity lookup.
  - Player shell accepts nextActivityHref and hides the action bar on completion; new i18n strings added.

<sup>Written for commit 968ceb620ec75cc11b0d87e07f84677b565b15ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

