### PR TITLE
chore(core): add no-get-extracted-in-promise lint rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -96,6 +96,7 @@
 
     // custom rules
     "zoonk/no-dynamic-translation-key": "error",
+    "zoonk/no-get-extracted-in-promise": "error",
     "zoonk/no-object-params-in-cache": ["error", { "exceptions": ["headers"] }],
     "zoonk/no-single-use-type-alias": "error",
     "zoonk/no-t-function-as-argument": "error"

--- a/packages/oxlint-plugin/index.js
+++ b/packages/oxlint-plugin/index.js
@@ -1,5 +1,6 @@
 import { definePlugin } from "oxlint";
 import noDynamicTranslationKey from "./rules/no-dynamic-translation-key.js";
+import noGetExtractedInPromise from "./rules/no-get-extracted-in-promise.js";
 import noObjectParamsInCache from "./rules/no-object-params-in-cache.js";
 import noSingleUseTypeAlias from "./rules/no-single-use-type-alias.js";
 import noTFunctionAsArgument from "./rules/no-t-function-as-argument.js";
@@ -10,6 +11,7 @@ export default definePlugin({
   },
   rules: {
     "no-dynamic-translation-key": noDynamicTranslationKey,
+    "no-get-extracted-in-promise": noGetExtractedInPromise,
     "no-object-params-in-cache": noObjectParamsInCache,
     "no-single-use-type-alias": noSingleUseTypeAlias,
     "no-t-function-as-argument": noTFunctionAsArgument,

--- a/packages/oxlint-plugin/rules/no-get-extracted-in-promise.js
+++ b/packages/oxlint-plugin/rules/no-get-extracted-in-promise.js
@@ -1,0 +1,98 @@
+import { defineRule } from "oxlint";
+
+const PROMISE_METHODS = new Set(["all", "allSettled", "race", "any"]);
+
+function containsGetExtractedCall(node) {
+  if (!node) {
+    return false;
+  }
+
+  if (node.type === "CallExpression") {
+    if (node.callee.type === "Identifier" && node.callee.name === "getExtracted") {
+      return true;
+    }
+
+    return (
+      node.arguments.some((arg) => containsGetExtractedCall(arg)) ||
+      containsGetExtractedCall(node.callee)
+    );
+  }
+
+  if (node.type === "AwaitExpression") {
+    return containsGetExtractedCall(node.argument);
+  }
+
+  if (node.type === "ArrayExpression") {
+    return node.elements.some((element) => containsGetExtractedCall(element));
+  }
+
+  if (node.type === "ArrowFunctionExpression" || node.type === "FunctionExpression") {
+    return containsGetExtractedCall(node.body);
+  }
+
+  if (node.type === "BlockStatement") {
+    return node.body.some((statement) => containsGetExtractedCall(statement));
+  }
+
+  if (node.type === "ReturnStatement" || node.type === "ExpressionStatement") {
+    return containsGetExtractedCall(node.expression);
+  }
+
+  if (node.type === "VariableDeclaration") {
+    return node.declarations.some((decl) => containsGetExtractedCall(decl));
+  }
+
+  if (node.type === "VariableDeclarator") {
+    return containsGetExtractedCall(node.init);
+  }
+
+  return false;
+}
+
+function isPromiseCombinator(node) {
+  if (node.callee.type !== "MemberExpression") {
+    return false;
+  }
+
+  const { object, property } = node.callee;
+
+  return (
+    object.type === "Identifier" && object.name === "Promise" && PROMISE_METHODS.has(property.name)
+  );
+}
+
+export default defineRule({
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (!isPromiseCombinator(node)) {
+          return;
+        }
+
+        const methodName = node.callee.property.name;
+
+        for (const arg of node.arguments) {
+          if (containsGetExtractedCall(arg)) {
+            context.report({
+              loc: arg.loc,
+              messageId: "noGetExtractedInPromise",
+              data: { method: methodName },
+            });
+          }
+        }
+      },
+    };
+  },
+
+  meta: {
+    docs: {
+      description:
+        "Disallow getExtracted() inside Promise.all, Promise.allSettled, Promise.race, or Promise.any",
+    },
+    messages: {
+      noGetExtractedInPromise: "getExtracted() cannot be used inside Promise.{{method}}().",
+    },
+    schema: [],
+    type: "problem",
+  },
+});


### PR DESCRIPTION
## Summary

- Add `no-get-extracted-in-promise` oxlint rule that prevents `getExtracted()` from being called inside `Promise.all`, `Promise.allSettled`, `Promise.race`, or `Promise.any`
- `getExtracted()` relies on React's `cache()` and Next.js request context which may not propagate correctly in parallel promise branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new oxlint rule, no-get-extracted-in-promise, and enable it as an error. It blocks calling getExtracted() inside Promise combinators to prevent React cache/Next.js request context issues.

- **New Features**
  - Flags getExtracted() used in Promise.all, Promise.allSettled, Promise.race, and Promise.any arguments.
  - Reports at the offending argument location for clear guidance.

<sup>Written for commit f7bb623e2af7f593589b37dd0100cb79e772d974. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

