### PR TITLE
fix(main): make continue learning card full-width on mobile with single item

### DIFF
--- a/apps/main/src/app/[locale]/(catalog)/continue-learning-card.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/continue-learning-card.tsx
@@ -23,9 +23,11 @@ import Image from "next/image";
 export async function ContinueLearningCard({
   item,
   kindLabels,
+  fullWidth,
 }: {
   item: ContinueLearningItem;
   kindLabels: Map<string, string>;
+  fullWidth?: boolean;
 }) {
   const t = await getExtracted();
   const { activity, chapter, course, lesson } = item;
@@ -39,7 +41,11 @@ export async function ContinueLearningCard({
   const courseHref = `/b/${course.organization.slug}/c/${course.slug}`;
 
   return (
-    <FeatureCard className="w-[85vw] shrink-0 snap-start sm:w-[45vw] 2xl:w-[calc(25%-1rem)]">
+    <FeatureCard
+      className={
+        fullWidth ? undefined : "w-[85vw] shrink-0 snap-start sm:w-[45vw] 2xl:w-[calc(25%-1rem)]"
+      }
+    >
       <Link href={activityHref}>
         <FeatureCardHeader>
           <FeatureCardHeaderContent>

--- a/apps/main/src/app/[locale]/(catalog)/continue-learning.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/continue-learning.tsx
@@ -22,15 +22,28 @@ export async function ContinueLearningList({ items }: { items: ContinueLearningI
     <section className="flex flex-col gap-3 py-4 md:py-6">
       <FeatureCardSectionTitle className="px-4">{t("Continue learning")}</FeatureCardSectionTitle>
 
-      <ScrollArea className="w-full px-4 pb-2">
-        <div className="flex snap-x snap-mandatory gap-4">
+      {items.length === 1 ? (
+        <div className="px-4">
           {items.map((item) => (
-            <ContinueLearningCard item={item} key={item.activity.id} kindLabels={kindLabels} />
+            <ContinueLearningCard
+              item={item}
+              key={item.activity.id}
+              kindLabels={kindLabels}
+              fullWidth
+            />
           ))}
         </div>
+      ) : (
+        <ScrollArea className="w-full px-4 pb-2">
+          <div className="flex snap-x snap-mandatory gap-4">
+            {items.map((item) => (
+              <ContinueLearningCard item={item} key={item.activity.id} kindLabels={kindLabels} />
+            ))}
+          </div>
 
-        <ScrollBar orientation="horizontal" />
-      </ScrollArea>
+          <ScrollBar orientation="horizontal" />
+        </ScrollArea>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- Skip `ScrollArea` when there's only one course in progress, rendering the card full-width instead
- Add `fullWidth` prop to `ContinueLearningCard` that removes the fixed-width/shrink classes
- Multiple items still use horizontal scroll with 85vw peek affordance (unchanged)

## Test plan

- [ ] Verify single-item layout renders full-width on mobile (no scroll container, no empty space)
- [ ] Verify multi-item layout still scrolls horizontally with peek affordance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the single Continue Learning card fill the screen on mobile by skipping the scroll container. Multiple items still scroll horizontally with the same peek affordance.

- **Bug Fixes**
  - Skip ScrollArea when there’s only one item; render the card full-width.
  - Add a fullWidth prop to ContinueLearningCard to remove fixed width/shrink classes.

<sup>Written for commit e2b8831f15bef33d2ea19b948b136034d7842b43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

