### PR TITLE
feat(db): add isPublished field to step model

### DIFF
--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
@@ -365,6 +365,11 @@ describe("core activity workflow", () => {
       });
 
       expect(backgroundSteps).toHaveLength(2);
+
+      for (const step of backgroundSteps) {
+        expect(step.isPublished).toBeTruthy();
+      }
+
       expect(backgroundSteps[0]?.content).toEqual({
         text: "Background step 1 text",
         title: "Background Step 1",
@@ -786,6 +791,11 @@ describe("core activity workflow", () => {
       });
 
       expect(explanationSteps).toHaveLength(2);
+
+      for (const step of explanationSteps) {
+        expect(step.isPublished).toBeTruthy();
+      }
+
       expect(explanationSteps[0]?.content).toEqual({
         text: "Explanation step 1 text",
         title: "Explanation Step 1",
@@ -1034,6 +1044,11 @@ describe("core activity workflow", () => {
       });
 
       expect(quizSteps).toHaveLength(2);
+
+      for (const step of quizSteps) {
+        expect(step.isPublished).toBeTruthy();
+      }
+
       expect(quizSteps[0]?.kind).toBe("multipleChoice");
       expect(quizSteps[1]?.kind).toBe("selectImage");
     });
@@ -1417,6 +1432,11 @@ describe("core activity workflow", () => {
       });
 
       expect(examplesSteps).toHaveLength(2);
+
+      for (const step of examplesSteps) {
+        expect(step.isPublished).toBeTruthy();
+      }
+
       expect(examplesSteps[0]?.content).toEqual({
         text: "Examples step 1 text",
         title: "Examples Step 1",
@@ -1672,6 +1692,7 @@ describe("core activity workflow", () => {
       });
 
       expect(storySteps).toHaveLength(1);
+      expect(storySteps[0]?.isPublished).toBeTruthy();
       expect(storySteps[0]?.kind).toBe("multipleChoice");
       expect(storySteps[0]?.content).toEqual({
         context: "Your colleague turns to you during a meeting...",
@@ -2285,6 +2306,7 @@ describe("core activity workflow", () => {
       });
 
       expect(reviewSteps).toHaveLength(1);
+      expect(reviewSteps[0]?.isPublished).toBeTruthy();
       expect(reviewSteps[0]?.kind).toBe("multipleChoice");
       expect(reviewSteps[0]?.content).toEqual({
         context: "Review context about the lesson content...",

--- a/apps/api/src/workflows/activity-generation/custom-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/custom-activity-workflow.test.ts
@@ -257,6 +257,11 @@ describe("custom activity workflow", () => {
     });
 
     expect(customSteps).toHaveLength(2);
+
+    for (const step of customSteps) {
+      expect(step.isPublished).toBeTruthy();
+    }
+
     expect(customSteps[0]?.kind).toBe("static");
     expect(customSteps[0]?.content).toEqual({
       text: "Custom step 1 text",

--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
@@ -405,6 +405,7 @@ describe("language activity generation", () => {
     expect(steps).toHaveLength(2);
 
     for (const step of steps) {
+      expect(step.isPublished).toBeTruthy();
       expect(step.wordId).not.toBeNull();
       expect(step.kind).toBe("vocabulary");
       expect(step.content).toEqual({});
@@ -804,6 +805,10 @@ describe("language activity generation", () => {
 
     expect(steps).toHaveLength(6);
 
+    for (const step of steps) {
+      expect(step.isPublished).toBeTruthy();
+    }
+
     expect(steps.map((step) => step.kind)).toEqual([
       "static",
       "static",
@@ -1093,6 +1098,11 @@ describe("language activity generation", () => {
     });
 
     expect(steps).toHaveLength(2);
+
+    for (const step of steps) {
+      expect(step.isPublished).toBeTruthy();
+    }
+
     expect(steps.map((step) => step.kind)).toEqual(["static", "multipleChoice"]);
 
     expect(steps[0]?.content).toEqual({
@@ -1440,6 +1450,7 @@ describe("language activity generation", () => {
     expect(steps).toHaveLength(2);
 
     for (const step of steps) {
+      expect(step.isPublished).toBeTruthy();
       expect(step.sentenceId).not.toBeNull();
       expect(step.kind).toBe("reading");
       expect(step.content).toEqual({});
@@ -1642,6 +1653,7 @@ describe("language activity generation", () => {
     expect(listeningSteps).toHaveLength(readingSteps.length);
 
     listeningSteps.forEach((listeningStep, idx) => {
+      expect(listeningStep.isPublished).toBeTruthy();
       expect(listeningStep.sentenceId).toBe(readingSteps[idx]?.sentenceId);
       expect(listeningStep.position).toBe(readingSteps[idx]?.position);
       expect(listeningStep.kind).toBe("listening");
@@ -2049,11 +2061,13 @@ describe("language activity generation", () => {
 
     // Vocabulary steps come first, reading steps after
     for (const vocabStep of reviewVocabSteps) {
+      expect(vocabStep.isPublished).toBeTruthy();
       expect(vocabStep.wordId).not.toBeNull();
       expect(vocabStep.content).toEqual({});
     }
 
     for (const readingStep of reviewReadingSteps) {
+      expect(readingStep.isPublished).toBeTruthy();
       expect(readingStep.sentenceId).not.toBeNull();
       expect(readingStep.content).toEqual({});
     }

--- a/apps/api/src/workflows/activity-generation/steps/_utils/content-step-helpers.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/content-step-helpers.ts
@@ -81,6 +81,7 @@ export async function saveContentSteps(
           title: step.title,
           variant: "text",
         }),
+        isPublished: true,
         kind: "static" as const,
         position: index,
       })),

--- a/apps/api/src/workflows/activity-generation/steps/copy-language-review-steps-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/copy-language-review-steps-step.ts
@@ -67,6 +67,7 @@ export async function copyLanguageReviewStepsStep(
   const vocabData = vocabularySteps.map((step, idx) => ({
     activityId: languageReview.id,
     content: assertStepContent("vocabulary", {}),
+    isPublished: true,
     kind: "vocabulary" as const,
     position: idx,
     wordId: step.wordId,
@@ -75,6 +76,7 @@ export async function copyLanguageReviewStepsStep(
   const readingData = readingSteps.map((step, idx) => ({
     activityId: languageReview.id,
     content: assertStepContent("reading", {}),
+    isPublished: true,
     kind: "reading" as const,
     position: vocabularySteps.length + idx,
     sentenceId: step.sentenceId,

--- a/apps/api/src/workflows/activity-generation/steps/copy-listening-steps-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/copy-listening-steps-step.ts
@@ -64,6 +64,7 @@ export async function copyListeningStepsStep(
       data: readingSteps.map((readingStep) => ({
         activityId: listening.id,
         content: assertStepContent("listening", {}),
+        isPublished: true,
         kind: "listening" as const,
         position: readingStep.position,
         sentenceId: readingStep.sentenceId,

--- a/apps/api/src/workflows/activity-generation/steps/generate-challenge-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-challenge-content-step.ts
@@ -23,6 +23,7 @@ async function saveChallengeSteps(
   const introStep = {
     activityId,
     content: assertStepContent("static", { text: data.intro, title: "", variant: "text" }),
+    isPublished: true,
     kind: "static" as const,
     position: 0,
   };
@@ -35,6 +36,7 @@ async function saveChallengeSteps(
       options: step.options,
       question: step.question,
     }),
+    isPublished: true,
     kind: "multipleChoice" as const,
     position: index + 1,
   }));
@@ -42,6 +44,7 @@ async function saveChallengeSteps(
   const reflectionStep = {
     activityId,
     content: assertStepContent("static", { text: data.reflection, title: "", variant: "text" }),
+    isPublished: true,
     kind: "static" as const,
     position: data.steps.length + 1,
   };

--- a/apps/api/src/workflows/activity-generation/steps/generate-grammar-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-grammar-content-step.ts
@@ -106,6 +106,7 @@ function buildGrammarSteps(activityId: bigint | number, data: ActivityGrammarSch
 
   return [...exampleSteps, discoveryStep, ruleStep, ...practiceSteps].map((step, position) => ({
     ...step,
+    isPublished: true,
     position,
   }));
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-language-story-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-language-story-content-step.ts
@@ -52,6 +52,7 @@ function buildLanguageStorySteps(activityId: bigint | number, data: ActivityStor
       title: "Scenario",
       variant: "text",
     }),
+    isPublished: true,
     kind: "static" as const,
     position: 0,
   };
@@ -70,6 +71,7 @@ function buildLanguageStorySteps(activityId: bigint | number, data: ActivityStor
         textRomanization: emptyToNull(option.textRomanization),
       })),
     }),
+    isPublished: true,
     kind: "multipleChoice" as const,
     position: index + 1,
   }));

--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-content-step.ts
@@ -33,6 +33,7 @@ async function saveQuizSteps(
         return {
           activityId,
           content,
+          isPublished: true,
           kind: format,
           position: index,
         };

--- a/apps/api/src/workflows/activity-generation/steps/generate-review-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-review-content-step.ts
@@ -35,6 +35,7 @@ async function saveReviewSteps(
         return {
           activityId,
           content,
+          isPublished: true,
           kind: "multipleChoice",
           position: index,
         };

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.ts
@@ -35,6 +35,7 @@ async function saveStorySteps(
         return {
           activityId,
           content,
+          isPublished: true,
           kind: "multipleChoice",
           position: index,
         };

--- a/apps/api/src/workflows/activity-generation/steps/save-reading-sentences-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-reading-sentences-step.ts
@@ -58,6 +58,7 @@ function buildSaveOneSentence(params: {
       data: {
         activityId,
         content: assertStepContent("reading", {}),
+        isPublished: true,
         kind: "reading",
         position,
         sentenceId,

--- a/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
@@ -53,6 +53,7 @@ function buildSaveOneWord(params: {
       data: {
         activityId,
         content: assertStepContent("vocabulary", {}),
+        isPublished: true,
         kind: "vocabulary",
         position,
         wordId,

--- a/apps/main/e2e/activity-detail.test.ts
+++ b/apps/main/e2e/activity-detail.test.ts
@@ -63,6 +63,7 @@ async function createTestActivity(options?: {
             title: `Step ${uniqueId} #${idx}`,
             variant: "text",
           },
+          isPublished: true,
           position: idx,
         }),
       ),
@@ -123,6 +124,7 @@ async function createTestActivityWithInteractiveStep() {
       ],
       question: `Test question ${uniqueId}?`,
     },
+    isPublished: true,
     kind: "multipleChoice",
     position: 0,
   });

--- a/apps/main/e2e/static-step.test.ts
+++ b/apps/main/e2e/static-step.test.ts
@@ -53,6 +53,7 @@ async function createStaticActivity(options: { steps: { content: object; positio
       stepFixture({
         activityId: activity.id,
         content: step.content,
+        isPublished: true,
         position: step.position,
       }),
     ),

--- a/apps/main/src/data/activities/get-activity.ts
+++ b/apps/main/src/data/activities/get-activity.ts
@@ -79,6 +79,7 @@ const cachedGetActivity = cache(
               },
             },
           },
+          where: { isPublished: true },
         },
         title: true,
       },

--- a/apps/main/src/data/activities/prepare-activity-data.test.ts
+++ b/apps/main/src/data/activities/prepare-activity-data.test.ts
@@ -58,6 +58,7 @@ describe(prepareActivityData, () => {
     await stepFixture({
       activityId: activity.id,
       content: { text: "test", title: "Test", variant: "text" },
+      isPublished: true,
       position: 0,
     });
 
@@ -83,6 +84,7 @@ describe(prepareActivityData, () => {
     await stepFixture({
       activityId: activity.id,
       content: { text: "Hello world", title: "Intro", variant: "text" },
+      isPublished: true,
       kind: "static",
       position: 0,
     });
@@ -113,6 +115,7 @@ describe(prepareActivityData, () => {
     await stepFixture({
       activityId: activity.id,
       content: { text: "Code example", title: "Code", variant: "text" },
+      isPublished: true,
       kind: "static",
       position: 0,
       visualContent: { code: "console.log('hi')", language: "javascript" },
@@ -143,6 +146,7 @@ describe(prepareActivityData, () => {
     await stepFixture({
       activityId: activity.id,
       content: { text: "Audio step", title: "Audio", variant: "text" },
+      isPublished: true,
       kind: "static",
       position: 0,
       visualContent: { src: "audio.mp3" },
@@ -180,6 +184,7 @@ describe(prepareActivityData, () => {
     await stepFixture({
       activityId: activity.id,
       content: {},
+      isPublished: true,
       kind: "vocabulary",
       position: 0,
       wordId: word.id,
@@ -221,6 +226,7 @@ describe(prepareActivityData, () => {
     await stepFixture({
       activityId: activity.id,
       content: {},
+      isPublished: true,
       kind: "reading",
       position: 0,
       sentenceId: sentence.id,
@@ -253,12 +259,14 @@ describe(prepareActivityData, () => {
       stepFixture({
         activityId: activity.id,
         content: { text: "Valid step", title: "Valid", variant: "text" },
+        isPublished: true,
         kind: "static",
         position: 0,
       }),
       stepFixture({
         activityId: activity.id,
         content: {},
+        isPublished: true,
         kind: "arrangeWords",
         position: 1,
       }),
@@ -326,6 +334,7 @@ describe(prepareActivityData, () => {
     await stepFixture({
       activityId: activity.id,
       content: {},
+      isPublished: true,
       kind: "vocabulary",
       position: 0,
     });
@@ -354,6 +363,7 @@ describe(prepareActivityData, () => {
     await stepFixture({
       activityId: activity.id,
       content: { text: "test", title: "Test", variant: "text" },
+      isPublished: true,
       position: 0,
     });
 

--- a/packages/db/src/prisma/migrations/20260213210438_add_step_is_published/migration.sql
+++ b/packages/db/src/prisma/migrations/20260213210438_add_step_is_published/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "steps" ADD COLUMN     "is_published" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/src/prisma/models/steps.prisma
+++ b/packages/db/src/prisma/models/steps.prisma
@@ -8,6 +8,7 @@ model Step {
   sentence      Sentence?       @relation(fields: [sentenceId], references: [id], onDelete: Cascade)
   kind          StepKind
   position      Int
+  isPublished   Boolean         @default(false) @map("is_published")
   content       Json
   visualKind    StepVisualKind? @map("visual_kind")
   visualContent Json?           @map("visual_content")

--- a/packages/db/src/prisma/seed/steps.ts
+++ b/packages/db/src/prisma/seed/steps.ts
@@ -318,6 +318,7 @@ export async function seedSteps(prisma: PrismaClient, org: Organization): Promis
           data: {
             activityId: activity.id,
             content: stepData.content,
+            isPublished: true,
             kind: stepData.kind,
             position,
             visualContent: stepData.visualContent,

--- a/packages/testing/src/fixtures/steps.ts
+++ b/packages/testing/src/fixtures/steps.ts
@@ -3,6 +3,7 @@ import { type StepKind, type StepVisualKind, prisma } from "@zoonk/db";
 export async function stepFixture(attrs: {
   activityId: bigint;
   content?: object;
+  isPublished?: boolean;
   kind?: StepKind;
   position?: number;
   sentenceId?: bigint;
@@ -14,6 +15,7 @@ export async function stepFixture(attrs: {
     data: {
       activityId: attrs.activityId,
       content: attrs.content ?? { text: "Test step content", title: "Test Step" },
+      isPublished: attrs.isPublished,
       kind: attrs.kind ?? "static",
       position: attrs.position ?? 0,
       sentenceId: attrs.sentenceId,


### PR DESCRIPTION
## Summary

- Add `isPublished` boolean (default `false`) to the Step model with migration
- Set `isPublished: true` on all 11 AI step creation paths so generated steps are visible
- Filter steps by `isPublished: true` in the activity player query (`getActivity`)
- Update seed data, fixture, and existing tests to account for the new field
- Add `isPublished` regression assertions across 12 workflow integration tests

## Test plan

- [x] New integration tests: "excludes unpublished steps" and "returns no steps when all are unpublished" in `get-activity.test.ts`
- [x] Existing `get-activity` and `prepare-activity-data` tests updated with `isPublished: true`
- [x] `isPublished` assertions added to core, custom, and language workflow tests (one per creation path)
- [x] All tests pass (`pnpm test` — 610 tests across 6 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add isPublished to Step to hide individual steps within published activities. Generated steps now default to published, and the activity player only returns published steps.

- **New Features**
  - Added isPublished boolean to Step (default false).
  - Set isPublished: true across all step creation and copy paths.
  - Filtered getActivity to include only isPublished steps; added tests for excluding unpublished steps and when all are unpublished.
  - Updated seeds, test fixtures (including e2e), and test helpers to support isPublished.

- **Migration**
  - Run database migrations.
  - Backfill existing steps that should remain visible: set is_published = true for those records (especially steps in published activities).

<sup>Written for commit f7181586c2a5dc1ca2dda4b41c37bc84aa2472a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

