### PR TITLE
fix(main): reduce spacing between info section and start button on catalog pages

### DIFF
--- a/apps/main/src/components/catalog/catalog-list.tsx
+++ b/apps/main/src/components/catalog/catalog-list.tsx
@@ -108,7 +108,7 @@ export function CatalogListContent({ className, ...props }: React.ComponentProps
   return (
     <ul
       {...props}
-      className={cn("flex flex-col", className)}
+      className={cn("-mt-3.5 flex flex-col", className)}
       data-slot="catalog-list-content"
       role="list"
     />

--- a/apps/main/src/components/catalog/catalog-list.tsx
+++ b/apps/main/src/components/catalog/catalog-list.tsx
@@ -17,7 +17,10 @@ export function CatalogContainer({ className, ...props }: React.ComponentProps<"
   return (
     <div
       {...props}
-      className={cn("mx-auto flex w-full flex-col gap-4 px-4 py-8 md:py-10 lg:max-w-xl", className)}
+      className={cn(
+        "mx-auto flex w-full flex-col gap-4 px-4 pt-4 pb-8 md:pb-10 lg:max-w-xl",
+        className,
+      )}
       data-slot="catalog-container"
     />
   );


### PR DESCRIPTION
## Summary
- Reduced top padding on `CatalogContainer` from `py-8 md:py-10` to `pt-4 pb-8 md:pb-10` so the gap between the info section and the start button matches the navbar-to-info spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced top padding in CatalogContainer and added a small negative top margin to CatalogList to tighten vertical spacing on catalog pages. Spacing between the info section, start button, and list now matches the navbar-to-info spacing.

<sup>Written for commit da22140e0e7773659252aecef8d71cfc312123f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

