### PR TITLE
fix(test): override NEXT_PUBLIC_API_URL to prevent requests leaking to dev server

### DIFF
--- a/apps/api/e2e/otp.test.ts
+++ b/apps/api/e2e/otp.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "./fixtures";
 import { cleanupVerifications, disconnectDb, getOTPForEmail } from "./helpers/db";
 
 const TEST_EMAIL = `e2e-otp-${Date.now()}@zoonk.test`;
-const REDIRECT_URL = "http://localhost:3000/test";
+const REDIRECT_URL = "http://localhost:49152/test";
 
 test.describe("OTP Login Flow", () => {
   test.afterAll(async () => {
@@ -77,7 +77,7 @@ test.describe("OTP Login Flow", () => {
   });
 
   test("handles redirect URL with trailing slash without double slashes", async ({ page }) => {
-    const trailingSlashUrl = "http://localhost:3000/test/";
+    const trailingSlashUrl = "http://localhost:49152/test/";
     await page.goto(`/auth/login?redirectTo=${encodeURIComponent(trailingSlashUrl)}`);
     await page.getByLabel(/email/i).fill(TEST_EMAIL);
     await page.getByRole("button", { name: /^continue$/i }).click();
@@ -91,7 +91,7 @@ test.describe("OTP Login Flow", () => {
 
     const redirectPromise = page.waitForRequest((request) => {
       const url = request.url();
-      return url.startsWith("http://localhost:3000/test/") && url.length > 27;
+      return url.startsWith("http://localhost:49152/test/") && url.length > 28;
     });
 
     await page.getByRole("textbox").click();

--- a/packages/db/.env.e2e
+++ b/packages/db/.env.e2e
@@ -1,3 +1,4 @@
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/zoonk_e2e
 DATABASE_URL_UNPOOLED=postgres://postgres:postgres@localhost:5432/zoonk_e2e
 E2E_TESTING=true
+NEXT_PUBLIC_API_URL=http://localhost:49152

--- a/packages/e2e/src/base.config.ts
+++ b/packages/e2e/src/base.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const E2E_DATABASE_URL = "postgres://postgres:postgres@localhost:5432/zoonk_e2e";
+const E2E_API_URL = "http://localhost:49152";
 
 export function createBaseConfig(options: {
   globalSetup?: string;
@@ -31,6 +32,7 @@ export function createBaseConfig(options: {
         DATABASE_URL: E2E_DATABASE_URL,
         DATABASE_URL_UNPOOLED: E2E_DATABASE_URL,
         E2E_TESTING: "true",
+        NEXT_PUBLIC_API_URL: E2E_API_URL,
         ...options.webServerEnv,
       },
       timeout: 120_000,


### PR DESCRIPTION
## Summary

- Override `NEXT_PUBLIC_API_URL` in E2E env to point to port 49152 (unused) instead of the dev API server on port 4000
- Add the override to both `packages/db/.env.e2e` (build-time) and `packages/e2e/src/base.config.ts` (runtime)
- Update hardcoded `localhost:3000` URLs in API OTP tests to use the same test port

## Test plan

- [ ] `pnpm --filter main build:e2e` succeeds
- [ ] Run main E2E tests with dev API server on port 4000 — no requests leak to it
- [ ] API and editor E2E tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents E2E requests from hitting the local dev API by overriding NEXT_PUBLIC_API_URL to an unused port and aligning OTP test URLs. This isolates E2E runs from local servers.

- **Bug Fixes**
  - Set NEXT_PUBLIC_API_URL to http://localhost:49152 for E2E at build time (.env.e2e) and runtime (base.config.ts).
  - Updated OTP E2E tests to use localhost:49152 instead of localhost:3000.

<sup>Written for commit 858474cd197acaa4a05d9ae4f7280fb459b670b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

