### PR TITLE
chore(main): add unique seo metadata to activity pages

### DIFF
--- a/apps/main/e2e/activity-detail.test.ts
+++ b/apps/main/e2e/activity-detail.test.ts
@@ -252,6 +252,17 @@ test.describe("Activity Detail Page", () => {
     await expect(page.getByText(/not found|404/i)).toBeVisible();
   });
 
+  test("page title contains kind label and lesson title", async ({ page }) => {
+    const { chapter, course, lesson } = await createTestActivity({
+      generationStatus: "completed",
+    });
+
+    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/0`);
+
+    await expect(page).toHaveTitle(new RegExp(lesson.title));
+    await expect(page).toHaveTitle(/background/i);
+  });
+
   test("unpublished activity shows 404 page", async ({ page }) => {
     const org = await prisma.organization.findUniqueOrThrow({
       where: { slug: "ai" },

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -227,7 +227,6 @@ msgid "Next: {activity}"
 msgstr "Next: {activity}"
 
 #: src/app/[locale]/(catalog)/continue-learning-card.tsx
-#: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
 #: src/app/[locale]/generate/a/[id]/generate-activity-content.tsx
 msgctxt "ZmlNQ3"
 msgid "Activity"
@@ -889,11 +888,6 @@ msgctxt "U7Ymq9"
 msgid "This activity hasn't been generated yet."
 msgstr "This activity hasn't been generated yet."
 
-#: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
-msgctxt "qtQJTV"
-msgid "Complete this activity to reinforce your learning and track your progress."
-msgstr "Complete this activity to reinforce your learning and track your progress."
-
 #: src/app/[locale]/generate/a/[id]/generate-activity-content.tsx
 msgctxt "eG5JXd"
 msgid "Generate content for this activity"
@@ -1367,6 +1361,11 @@ msgid "Listening"
 msgstr "Listening"
 
 #: src/lib/activities.ts
+msgctxt "3fwFEk"
+msgid "Experience when to apply {topic} through a real-world dialogue scenario."
+msgstr "Experience when to apply {topic} through a real-world dialogue scenario."
+
+#: src/lib/activities.ts
 msgctxt "3GLH+d"
 msgid "Examples"
 msgstr "Examples"
@@ -1377,9 +1376,24 @@ msgid "Challenge"
 msgstr "Challenge"
 
 #: src/lib/activities.ts
+msgctxt "BB51/R"
+msgid "Practice {topic} in context through a dialogue-based story set in real-world situations."
+msgstr "Practice {topic} in context through a dialogue-based story set in real-world situations."
+
+#: src/lib/activities.ts
 msgctxt "Bfq+7w"
 msgid "Story"
 msgstr "Story"
+
+#: src/lib/activities.ts
+msgctxt "Bpkt6m"
+msgid "Build your {topic} vocabulary with new words, translations, and pronunciation."
+msgstr "Build your {topic} vocabulary with new words, translations, and pronunciation."
+
+#: src/lib/activities.ts
+msgctxt "bzFQEy"
+msgid "Review everything you learned about {topic} with a comprehensive quiz."
+msgstr "Review everything you learned about {topic} with a comprehensive quiz."
 
 #: src/lib/activities.ts
 msgctxt "E1bF/X"
@@ -1402,14 +1416,34 @@ msgid "Learn new words and their translations to build your vocabulary."
 msgstr "Learn new words and their translations to build your vocabulary."
 
 #: src/lib/activities.ts
+msgctxt "G/JvLV"
+msgid "See where {topic} appears in real life — in daily routines, work, pop culture, and unexpected places."
+msgstr "See where {topic} appears in real life — in daily routines, work, pop culture, and unexpected places."
+
+#: src/lib/activities.ts
+msgctxt "gAYlHX"
+msgid "Sharpen your {topic} listening skills by translating audio sentences."
+msgstr "Sharpen your {topic} listening skills by translating audio sentences."
+
+#: src/lib/activities.ts
 msgctxt "gyZY3d"
 msgid "Tests analytical thinking through decisions with trade-offs. See how each choice impacts different outcomes."
 msgstr "Tests analytical thinking through decisions with trade-offs. See how each choice impacts different outcomes."
 
 #: src/lib/activities.ts
+msgctxt "h2acN8"
+msgid "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
+msgstr "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
+
+#: src/lib/activities.ts
 msgctxt "i09QqM"
 msgid "A dialogue-based story that helps you practice the language in a real-world context."
 msgstr "A dialogue-based story that helps you practice the language in a real-world context."
+
+#: src/lib/activities.ts
+msgctxt "ICIYNP"
+msgid "Discover why {topic} matters — its origins, the problems it solved, and why it's important today."
+msgstr "Discover why {topic} matters — its origins, the problems it solved, and why it's important today."
 
 #: src/lib/activities.ts
 msgctxt "J9eZ8n"
@@ -1432,6 +1466,11 @@ msgid "Shows WHERE this topic appears in real life. Helps you recognize it in da
 msgstr "Shows WHERE this topic appears in real life. Helps you recognize it in daily routines, work, pop culture, and unexpected places."
 
 #: src/lib/activities.ts
+msgctxt "MfGqY2"
+msgid "{lesson} {activity}"
+msgstr "{lesson} {activity}"
+
+#: src/lib/activities.ts
 msgctxt "MOK/yK"
 msgid "Reading"
 msgstr "Reading"
@@ -1452,6 +1491,31 @@ msgid "Grammar"
 msgstr "Grammar"
 
 #: src/lib/activities.ts
+msgctxt "RtjVBh"
+msgid "Learn about {topic} through an interactive activity."
+msgstr "Learn about {topic} through an interactive activity."
+
+#: src/lib/activities.ts
+msgctxt "SM2LhV"
+msgid "Review vocabulary and skills from {topic} with a comprehensive assessment."
+msgstr "Review vocabulary and skills from {topic} with a comprehensive assessment."
+
+#: src/lib/activities.ts
+msgctxt "T24ZU7"
+msgid "Apply your knowledge of {topic} through analytical decisions with real trade-offs."
+msgstr "Apply your knowledge of {topic} through analytical decisions with real trade-offs."
+
+#: src/lib/activities.ts
+msgctxt "THPcKi"
+msgid "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies."
+msgstr "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies."
+
+#: src/lib/activities.ts
+msgctxt "tlgfSZ"
+msgid "Practice {topic} grammar rules with exercises designed to help you remember and apply them."
+msgstr "Practice {topic} grammar rules with exercises designed to help you remember and apply them."
+
+#: src/lib/activities.ts
 msgctxt "tzNRA/"
 msgid "Explains WHAT this topic is. Breaks down core concepts and definitions using metaphors and analogies."
 msgstr "Explains WHAT this topic is. Breaks down core concepts and definitions using metaphors and analogies."
@@ -1462,14 +1526,29 @@ msgid "A comprehensive review covering vocabulary and skills from this lesson."
 msgstr "A comprehensive review covering vocabulary and skills from this lesson."
 
 #: src/lib/activities.ts
+msgctxt "UDijXW"
+msgid "{activity} - {lesson}"
+msgstr "{activity} - {lesson}"
+
+#: src/lib/activities.ts
 msgctxt "WD76vM"
 msgid "Explains WHY this topic exists. Tells the origin story, the problems it solved, and why it matters today."
 msgstr "Explains WHY this topic exists. Tells the origin story, the problems it solved, and why it matters today."
 
 #: src/lib/activities.ts
+msgctxt "Wg8Pln"
+msgid "Learn how {topic} works under the hood — processes, sequences, and cause-effect chains explained."
+msgstr "Learn how {topic} works under the hood — processes, sequences, and cause-effect chains explained."
+
+#: src/lib/activities.ts
 msgctxt "XQZA8e"
 msgid "Background"
 msgstr "Background"
+
+#: src/lib/activities.ts
+msgctxt "XzxpBZ"
+msgid "Improve your {topic} reading comprehension by translating sentences and passages."
+msgstr "Improve your {topic} reading comprehension by translating sentences and passages."
 
 #: src/lib/activities.ts
 msgctxt "y21Ybw"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -227,7 +227,6 @@ msgid "Next: {activity}"
 msgstr "Siguiente: {activity}"
 
 #: src/app/[locale]/(catalog)/continue-learning-card.tsx
-#: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
 #: src/app/[locale]/generate/a/[id]/generate-activity-content.tsx
 msgctxt "ZmlNQ3"
 msgid "Activity"
@@ -889,11 +888,6 @@ msgctxt "U7Ymq9"
 msgid "This activity hasn't been generated yet."
 msgstr "Esta actividad aún no ha sido generada."
 
-#: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
-msgctxt "qtQJTV"
-msgid "Complete this activity to reinforce your learning and track your progress."
-msgstr "Completa esta actividad para reforzar tu aprendizaje y seguir tu progreso."
-
 #: src/app/[locale]/generate/a/[id]/generate-activity-content.tsx
 msgctxt "eG5JXd"
 msgid "Generate content for this activity"
@@ -1367,6 +1361,11 @@ msgid "Listening"
 msgstr "Escucha"
 
 #: src/lib/activities.ts
+msgctxt "3fwFEk"
+msgid "Experience when to apply {topic} through a real-world dialogue scenario."
+msgstr "Experimenta cuándo aplicar {topic} a través de un escenario de diálogo del mundo real."
+
+#: src/lib/activities.ts
 msgctxt "3GLH+d"
 msgid "Examples"
 msgstr "Ejemplos"
@@ -1377,9 +1376,24 @@ msgid "Challenge"
 msgstr "Desafío"
 
 #: src/lib/activities.ts
+msgctxt "BB51/R"
+msgid "Practice {topic} in context through a dialogue-based story set in real-world situations."
+msgstr "Practica {topic} en contexto a través de una historia basada en diálogos ambientada en situaciones del mundo real."
+
+#: src/lib/activities.ts
 msgctxt "Bfq+7w"
 msgid "Story"
 msgstr "Historia"
+
+#: src/lib/activities.ts
+msgctxt "Bpkt6m"
+msgid "Build your {topic} vocabulary with new words, translations, and pronunciation."
+msgstr "Construye tu vocabulario de {topic} con nuevas palabras, traducciones y pronunciación."
+
+#: src/lib/activities.ts
+msgctxt "bzFQEy"
+msgid "Review everything you learned about {topic} with a comprehensive quiz."
+msgstr "Repasa todo lo que aprendiste sobre {topic} con un cuestionario completo."
 
 #: src/lib/activities.ts
 msgctxt "E1bF/X"
@@ -1402,14 +1416,34 @@ msgid "Learn new words and their translations to build your vocabulary."
 msgstr "Aprende nuevas palabras y sus traducciones para ampliar tu vocabulario."
 
 #: src/lib/activities.ts
+msgctxt "G/JvLV"
+msgid "See where {topic} appears in real life — in daily routines, work, pop culture, and unexpected places."
+msgstr "Mira dónde aparece {topic} en la vida real: en rutinas diarias, trabajo, cultura popular y lugares inesperados."
+
+#: src/lib/activities.ts
+msgctxt "gAYlHX"
+msgid "Sharpen your {topic} listening skills by translating audio sentences."
+msgstr "Afina tus habilidades de escucha en {topic} traduciendo oraciones de audio."
+
+#: src/lib/activities.ts
 msgctxt "gyZY3d"
 msgid "Tests analytical thinking through decisions with trade-offs. See how each choice impacts different outcomes."
 msgstr "Evalúa el pensamiento analítico a través de decisiones con compensaciones. Ve cómo cada elección impacta diferentes resultados."
 
 #: src/lib/activities.ts
+msgctxt "h2acN8"
+msgid "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
+msgstr "Pon a prueba tu comprensión de {topic} con preguntas diseñadas para verificar la comprensión real, no solo la memorización."
+
+#: src/lib/activities.ts
 msgctxt "i09QqM"
 msgid "A dialogue-based story that helps you practice the language in a real-world context."
 msgstr "Una historia basada en diálogos que te ayuda a practicar el idioma en un contexto del mundo real."
+
+#: src/lib/activities.ts
+msgctxt "ICIYNP"
+msgid "Discover why {topic} matters — its origins, the problems it solved, and why it's important today."
+msgstr "Descubre por qué {topic} importa: sus orígenes, los problemas que resolvió y por qué es importante hoy."
 
 #: src/lib/activities.ts
 msgctxt "J9eZ8n"
@@ -1432,6 +1466,11 @@ msgid "Shows WHERE this topic appears in real life. Helps you recognize it in da
 msgstr "Muestra DÓNDE aparece este tema en la vida real. Te ayuda a reconocerlo en rutinas diarias, trabajo, cultura popular y lugares inesperados."
 
 #: src/lib/activities.ts
+msgctxt "MfGqY2"
+msgid "{lesson} {activity}"
+msgstr "{lesson} {activity}"
+
+#: src/lib/activities.ts
 msgctxt "MOK/yK"
 msgid "Reading"
 msgstr "Lectura"
@@ -1452,6 +1491,31 @@ msgid "Grammar"
 msgstr "Gramática"
 
 #: src/lib/activities.ts
+msgctxt "RtjVBh"
+msgid "Learn about {topic} through an interactive activity."
+msgstr "Aprende sobre {topic} a través de una actividad interactiva."
+
+#: src/lib/activities.ts
+msgctxt "SM2LhV"
+msgid "Review vocabulary and skills from {topic} with a comprehensive assessment."
+msgstr "Repasa vocabulario y habilidades de {topic} con una evaluación completa."
+
+#: src/lib/activities.ts
+msgctxt "T24ZU7"
+msgid "Apply your knowledge of {topic} through analytical decisions with real trade-offs."
+msgstr "Aplica tu conocimiento de {topic} a través de decisiones analíticas con compensaciones reales."
+
+#: src/lib/activities.ts
+msgctxt "THPcKi"
+msgid "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies."
+msgstr "Entiende qué es {topic}: conceptos centrales y definiciones explicados con metáforas y analogías claras."
+
+#: src/lib/activities.ts
+msgctxt "tlgfSZ"
+msgid "Practice {topic} grammar rules with exercises designed to help you remember and apply them."
+msgstr "Practica las reglas gramaticales de {topic} con ejercicios diseñados para ayudarte a recordarlas y aplicarlas."
+
+#: src/lib/activities.ts
 msgctxt "tzNRA/"
 msgid "Explains WHAT this topic is. Breaks down core concepts and definitions using metaphors and analogies."
 msgstr "Explica QUÉ es este tema. Desglosa conceptos centrales y definiciones usando metáforas y analogías."
@@ -1462,14 +1526,29 @@ msgid "A comprehensive review covering vocabulary and skills from this lesson."
 msgstr "Un repaso completo que cubre vocabulario y habilidades de esta lección."
 
 #: src/lib/activities.ts
+msgctxt "UDijXW"
+msgid "{activity} - {lesson}"
+msgstr "{activity} - {lesson}"
+
+#: src/lib/activities.ts
 msgctxt "WD76vM"
 msgid "Explains WHY this topic exists. Tells the origin story, the problems it solved, and why it matters today."
 msgstr "Explica POR QUÉ existe este tema. Cuenta la historia de origen, los problemas que resolvió y por qué importa hoy."
 
 #: src/lib/activities.ts
+msgctxt "Wg8Pln"
+msgid "Learn how {topic} works under the hood — processes, sequences, and cause-effect chains explained."
+msgstr "Aprende cómo funciona {topic} por dentro: procesos, secuencias y cadenas de causa-efecto explicados."
+
+#: src/lib/activities.ts
 msgctxt "XQZA8e"
 msgid "Background"
 msgstr "Contexto"
+
+#: src/lib/activities.ts
+msgctxt "XzxpBZ"
+msgid "Improve your {topic} reading comprehension by translating sentences and passages."
+msgstr "Mejora tu comprensión de lectura en {topic} traduciendo oraciones y pasajes."
 
 #: src/lib/activities.ts
 msgctxt "y21Ybw"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -227,7 +227,6 @@ msgid "Next: {activity}"
 msgstr "Próximo: {activity}"
 
 #: src/app/[locale]/(catalog)/continue-learning-card.tsx
-#: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
 #: src/app/[locale]/generate/a/[id]/generate-activity-content.tsx
 msgctxt "ZmlNQ3"
 msgid "Activity"
@@ -889,11 +888,6 @@ msgctxt "U7Ymq9"
 msgid "This activity hasn't been generated yet."
 msgstr "Esta atividade ainda não foi gerada."
 
-#: src/app/[locale]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
-msgctxt "qtQJTV"
-msgid "Complete this activity to reinforce your learning and track your progress."
-msgstr "Complete esta atividade para reforçar seu aprendizado e acompanhar seu progresso."
-
 #: src/app/[locale]/generate/a/[id]/generate-activity-content.tsx
 msgctxt "eG5JXd"
 msgid "Generate content for this activity"
@@ -1367,6 +1361,11 @@ msgid "Listening"
 msgstr "Escuta"
 
 #: src/lib/activities.ts
+msgctxt "3fwFEk"
+msgid "Experience when to apply {topic} through a real-world dialogue scenario."
+msgstr "Experimente quando aplicar {topic} através de um cenário de diálogo do mundo real."
+
+#: src/lib/activities.ts
 msgctxt "3GLH+d"
 msgid "Examples"
 msgstr "Exemplos"
@@ -1377,9 +1376,24 @@ msgid "Challenge"
 msgstr "Desafio"
 
 #: src/lib/activities.ts
+msgctxt "BB51/R"
+msgid "Practice {topic} in context through a dialogue-based story set in real-world situations."
+msgstr "Pratique {topic} em contexto através de uma história baseada em diálogos ambientada em situações do mundo real."
+
+#: src/lib/activities.ts
 msgctxt "Bfq+7w"
 msgid "Story"
 msgstr "História"
+
+#: src/lib/activities.ts
+msgctxt "Bpkt6m"
+msgid "Build your {topic} vocabulary with new words, translations, and pronunciation."
+msgstr "Construa seu vocabulário de {topic} com novas palavras, traduções e pronúncia."
+
+#: src/lib/activities.ts
+msgctxt "bzFQEy"
+msgid "Review everything you learned about {topic} with a comprehensive quiz."
+msgstr "Revise tudo que você aprendeu sobre {topic} com um quiz abrangente."
 
 #: src/lib/activities.ts
 msgctxt "E1bF/X"
@@ -1402,14 +1416,34 @@ msgid "Learn new words and their translations to build your vocabulary."
 msgstr "Aprenda novas palavras e traduções para construir seu vocabulário."
 
 #: src/lib/activities.ts
+msgctxt "G/JvLV"
+msgid "See where {topic} appears in real life — in daily routines, work, pop culture, and unexpected places."
+msgstr "Veja onde {topic} aparece na vida real — em rotinas diárias, trabalho, cultura pop e lugares inesperados."
+
+#: src/lib/activities.ts
+msgctxt "gAYlHX"
+msgid "Sharpen your {topic} listening skills by translating audio sentences."
+msgstr "Aprimore suas habilidades de escuta em {topic} traduzindo frases de áudio."
+
+#: src/lib/activities.ts
 msgctxt "gyZY3d"
 msgid "Tests analytical thinking through decisions with trade-offs. See how each choice impacts different outcomes."
 msgstr "Testa pensamento analítico através de decisões analisando prós e contras. Veja como cada escolha impacta diferentes resultados."
 
 #: src/lib/activities.ts
+msgctxt "h2acN8"
+msgid "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
+msgstr "Teste sua compreensão de {topic} com perguntas projetadas para verificar compreensão real, não apenas memorização."
+
+#: src/lib/activities.ts
 msgctxt "i09QqM"
 msgid "A dialogue-based story that helps you practice the language in a real-world context."
 msgstr "Uma história baseada em diálogos que ajuda você a praticar o idioma em um contexto do mundo real."
+
+#: src/lib/activities.ts
+msgctxt "ICIYNP"
+msgid "Discover why {topic} matters — its origins, the problems it solved, and why it's important today."
+msgstr "Descubra por que {topic} importa — suas origens, os problemas que resolveu e por que é importante hoje."
 
 #: src/lib/activities.ts
 msgctxt "J9eZ8n"
@@ -1432,6 +1466,11 @@ msgid "Shows WHERE this topic appears in real life. Helps you recognize it in da
 msgstr "Mostra ONDE este assunto aparece na vida real. Te ajuda a reconhecer ele em rotinas diárias, trabalho, cultura pop e lugares inesperados."
 
 #: src/lib/activities.ts
+msgctxt "MfGqY2"
+msgid "{lesson} {activity}"
+msgstr "{lesson} {activity}"
+
+#: src/lib/activities.ts
 msgctxt "MOK/yK"
 msgid "Reading"
 msgstr "Leitura"
@@ -1452,6 +1491,31 @@ msgid "Grammar"
 msgstr "Gramática"
 
 #: src/lib/activities.ts
+msgctxt "RtjVBh"
+msgid "Learn about {topic} through an interactive activity."
+msgstr "Aprenda sobre {topic} através de uma atividade interativa."
+
+#: src/lib/activities.ts
+msgctxt "SM2LhV"
+msgid "Review vocabulary and skills from {topic} with a comprehensive assessment."
+msgstr "Revise vocabulário e habilidades de {topic} com uma avaliação abrangente."
+
+#: src/lib/activities.ts
+msgctxt "T24ZU7"
+msgid "Apply your knowledge of {topic} through analytical decisions with real trade-offs."
+msgstr "Aplique seu conhecimento de {topic} através de decisões analíticas com trade-offs reais."
+
+#: src/lib/activities.ts
+msgctxt "THPcKi"
+msgid "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies."
+msgstr "Entenda o que é {topic} — conceitos centrais e definições explicados com metáforas e analogias claras."
+
+#: src/lib/activities.ts
+msgctxt "tlgfSZ"
+msgid "Practice {topic} grammar rules with exercises designed to help you remember and apply them."
+msgstr "Pratique regras gramaticais de {topic} com exercícios projetados pra te ajudar a lembrar e aplicar elas."
+
+#: src/lib/activities.ts
 msgctxt "tzNRA/"
 msgid "Explains WHAT this topic is. Breaks down core concepts and definitions using metaphors and analogies."
 msgstr "Explica O QUE é este tópico. Decompõe conceitos centrais e definições usando metáforas e analogias."
@@ -1462,14 +1526,29 @@ msgid "A comprehensive review covering vocabulary and skills from this lesson."
 msgstr "Uma revisão completa cobrindo vocabulário e habilidades desta aula."
 
 #: src/lib/activities.ts
+msgctxt "UDijXW"
+msgid "{activity} - {lesson}"
+msgstr "{activity} - {lesson}"
+
+#: src/lib/activities.ts
 msgctxt "WD76vM"
 msgid "Explains WHY this topic exists. Tells the origin story, the problems it solved, and why it matters today."
 msgstr "Explica POR QUE este tópico existe. Conta a história de origem, os problemas que ele resolveu e por que ele importa hoje."
 
 #: src/lib/activities.ts
+msgctxt "Wg8Pln"
+msgid "Learn how {topic} works under the hood — processes, sequences, and cause-effect chains explained."
+msgstr "Aprenda como {topic} funciona por dentro — processos, sequências e cadeias de causa-efeito explicados."
+
+#: src/lib/activities.ts
 msgctxt "XQZA8e"
 msgid "Background"
 msgstr "Contexto"
+
+#: src/lib/activities.ts
+msgctxt "XzxpBZ"
+msgid "Improve your {topic} reading comprehension by translating sentences and passages."
+msgstr "Melhore sua compreensão de leitura em {topic} traduzindo frases e passagens."
 
 #: src/lib/activities.ts
 msgctxt "y21Ybw"

--- a/apps/main/src/app/[locale]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
+++ b/apps/main/src/app/[locale]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
@@ -6,12 +6,13 @@ import { getLessonSentences } from "@/data/activities/get-lesson-sentences";
 import { getLessonWords } from "@/data/activities/get-lesson-words";
 import { prepareActivityData } from "@/data/activities/prepare-activity-data";
 import { getLesson } from "@/data/lessons/get-lesson";
+import { getActivitySeoMeta } from "@/lib/activities";
 import { getNextActivityInCourse } from "@zoonk/core/activities/next-in-course";
 import { cacheTagActivity } from "@zoonk/utils/cache";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { parseNumericId } from "@zoonk/utils/string";
 import { type Metadata } from "next";
-import { getExtracted, setRequestLocale } from "next-intl/server";
+import { setRequestLocale } from "next-intl/server";
 import { cacheTag } from "next/cache";
 import { notFound } from "next/navigation";
 import { ActivityNotGenerated } from "./activity-not-generated";
@@ -33,13 +34,28 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { locale } = await params;
-  const t = await getExtracted({ locale });
+  const { brandSlug, chapterSlug, courseSlug, lessonSlug, locale, position } = await params;
+  const lesson = await getLesson({ brandSlug, chapterSlug, courseSlug, lessonSlug });
 
-  return {
-    description: t("Complete this activity to reinforce your learning and track your progress."),
-    title: t("Activity"),
-  };
+  if (!lesson) {
+    return {};
+  }
+
+  const activityPosition = parseNumericId(position);
+
+  if (activityPosition === null) {
+    return {};
+  }
+
+  const activity = await getActivity({ lessonId: lesson.id, position: activityPosition });
+
+  if (!activity) {
+    return {};
+  }
+
+  const { title, description } = await getActivitySeoMeta(activity, lesson.title, { locale });
+
+  return { description, title };
 }
 
 export default async function ActivityPage({ params }: Props) {

--- a/apps/main/src/lib/activities.ts
+++ b/apps/main/src/lib/activities.ts
@@ -101,3 +101,112 @@ export async function getActivityKinds(params?: { locale: string }): Promise<Act
     },
   ];
 }
+
+async function getSeoDescription(
+  kind: ActivityKind,
+  topic: string,
+  params?: { locale: string },
+): Promise<string> {
+  const t = await getExtracted(params);
+
+  const descriptions: Record<ActivityKind, string> = {
+    background: t(
+      "Discover why {topic} matters — its origins, the problems it solved, and why it's important today.",
+      { topic },
+    ),
+    challenge: t(
+      "Apply your knowledge of {topic} through analytical decisions with real trade-offs.",
+      { topic },
+    ),
+    custom: t("Learn about {topic} through an interactive activity.", { topic }),
+    examples: t(
+      "See where {topic} appears in real life — in daily routines, work, pop culture, and unexpected places.",
+      { topic },
+    ),
+    explanation: t(
+      "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies.",
+      { topic },
+    ),
+    grammar: t(
+      "Practice {topic} grammar rules with exercises designed to help you remember and apply them.",
+      { topic },
+    ),
+    languageReview: t(
+      "Review vocabulary and skills from {topic} with a comprehensive assessment.",
+      { topic },
+    ),
+    languageStory: t(
+      "Practice {topic} in context through a dialogue-based story set in real-world situations.",
+      { topic },
+    ),
+    listening: t("Sharpen your {topic} listening skills by translating audio sentences.", {
+      topic,
+    }),
+    mechanics: t(
+      "Learn how {topic} works under the hood — processes, sequences, and cause-effect chains explained.",
+      { topic },
+    ),
+    quiz: t(
+      "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization.",
+      { topic },
+    ),
+    reading: t(
+      "Improve your {topic} reading comprehension by translating sentences and passages.",
+      { topic },
+    ),
+    review: t("Review everything you learned about {topic} with a comprehensive quiz.", { topic }),
+    story: t("Experience when to apply {topic} through a real-world dialogue scenario.", { topic }),
+    vocabulary: t(
+      "Build your {topic} vocabulary with new words, translations, and pronunciation.",
+      { topic },
+    ),
+  };
+
+  return descriptions[kind];
+}
+
+export async function getActivitySeoMeta(
+  activity: { kind: ActivityKind; title: string | null; description: string | null },
+  lessonTitle: string,
+  params?: { locale: string },
+): Promise<{ title: string; description: string }> {
+  const [title, description] = await Promise.all([
+    getSeoTitle(activity, lessonTitle, params),
+    getSeoActivityDescription(activity, lessonTitle, params),
+  ]);
+
+  return { description, title };
+}
+
+async function getSeoTitle(
+  activity: { kind: ActivityKind; title: string | null },
+  lessonTitle: string,
+  params?: { locale: string },
+): Promise<string> {
+  const t = await getExtracted(params);
+
+  if (activity.kind === "custom" && activity.title) {
+    return t("{activity} - {lesson}", { activity: activity.title, lesson: lessonTitle });
+  }
+
+  const kinds = await getActivityKinds(params);
+  const kindInfo = kinds.find((kind) => kind.key === activity.kind);
+
+  if (kindInfo) {
+    return t("{lesson} {activity}", { activity: kindInfo.label, lesson: lessonTitle });
+  }
+
+  return lessonTitle;
+}
+
+async function getSeoActivityDescription(
+  activity: { kind: ActivityKind; description: string | null },
+  lessonTitle: string,
+  params?: { locale: string },
+): Promise<string> {
+  if (activity.kind === "custom" && activity.description) {
+    return activity.description;
+  }
+
+  return getSeoDescription(activity.kind, lessonTitle, params);
+}

--- a/i18n.lock
+++ b/i18n.lock
@@ -360,7 +360,6 @@ checksums:
     Generate%20activity/singular: 4fbbc27fc1d296a0414ed0d7f57e4ba0
     Activity%20not%20available/singular: a76f6331aa0aad825903108429b132a0
     This%20activity%20hasn't%20been%20generated%20yet./singular: 631d7c5e190d95c7697df1f6a4bb9a1c
-    Complete%20this%20activity%20to%20reinforce%20your%20learning%20and%20track%20your%20progress./singular: ae9411230fe031bbbd7471a8fde4b17d
     Generate%20content%20for%20this%20activity/singular: 0ac20ea56d4391004d976cd8f377a645
     Generate%20Activity/singular: e386c80be3da0ee0b54a940afc4de373
     Your%20activity%20is%20ready/singular: e7385c4096b843839bb9a96023f0eea9
@@ -448,27 +447,44 @@ checksums:
     Generating%20content%20with%20AI%20requires%20an%20active%20subscription./singular: ee3e62a18f3437b719f6793dd01d66f8
     Explains%20HOW%20things%20work%20under%20the%20hood.%20Shows%20the%20processes%2C%20sequences%2C%20and%20cause-effect%20chains%20in%20action./singular: 89c176fd862db6d6178194b091e8544d
     Listening/singular: 9e680c44cd88a178b953349ed8881ef2
+    Experience%20when%20to%20apply%20%7Btopic%7D%20through%20a%20real-world%20dialogue%20scenario./singular: d143d122b526618096d637288c66f50a
     Examples/singular: 9dacb7c56bc894e4bcad39f41265e3a0
     Challenge/singular: 7f333a59ee7a3596e27a2f8c3401b764
+    Practice%20%7Btopic%7D%20in%20context%20through%20a%20dialogue-based%20story%20set%20in%20real-world%20situations./singular: e1b3079ec8c6a2c89d20e5c7c48bfc59
     Story/singular: fabac3f62af801d429e2cd7115bf14c9
+    Build%20your%20%7Btopic%7D%20vocabulary%20with%20new%20words%2C%20translations%2C%20and%20pronunciation./singular: 2c0f84dadf5fcbfb5842260046bfa956
+    Review%20everything%20you%20learned%20about%20%7Btopic%7D%20with%20a%20comprehensive%20quiz./singular: 8acf9006cabdcbaac217c7565943f068
     Explanation/singular: f6b595df4ffb1a5b0cbbe1dda5993522
     Read%20sentences%20and%20translate%20them%20to%20practice%20reading%20comprehension./singular: b084920876df6266904d73e2ddfc6f19
     A%20comprehensive%20quiz%20covering%20everything%20you%20learned%20in%20this%20lesson./singular: bd46bf5022b53951436d9facacacf673
     Learn%20new%20words%20and%20their%20translations%20to%20build%20your%20vocabulary./singular: edf41f5213749b375ab5057e14707380
+    See%20where%20%7Btopic%7D%20appears%20in%20real%20life%20%E2%80%94%20in%20daily%20routines%2C%20work%2C%20pop%20culture%2C%20and%20unexpected%20places./singular: a9a8d8e02fec7e88426b9ca04018f353
+    Sharpen%20your%20%7Btopic%7D%20listening%20skills%20by%20translating%20audio%20sentences./singular: b624ceffbbfc91a29cec43a0037b067f
     Tests%20analytical%20thinking%20through%20decisions%20with%20trade-offs.%20See%20how%20each%20choice%20impacts%20different%20outcomes./singular: 6d49ad51d42b986411df06b5ceb48067
+    Test%20your%20understanding%20of%20%7Btopic%7D%20with%20questions%20designed%20to%20check%20real%20comprehension%2C%20not%20just%20memorization./singular: d9f3e39d19b1c6969b481bc8aec8fc10
     A%20dialogue-based%20story%20that%20helps%20you%20practice%20the%20language%20in%20a%20real-world%20context./singular: 1eb319ba42d87bf86a9ff6e17bddee5f
+    Discover%20why%20%7Btopic%7D%20matters%20%E2%80%94%20its%20origins%2C%20the%20problems%20it%20solved%2C%20and%20why%20it's%20important%20today./singular: 4ab5d214b2548bd9399cbc3a8eef6284
     Listen%20to%20audio%20sentences%20and%20translate%20them%20to%20practice%20listening%20skills./singular: c7f37f13c3e2d3cb1f23c9cc5eee4e1d
     Teaches%20grammar%20rules%20with%20practical%20exercises%20to%20help%20you%20remember%20and%20apply%20them./singular: b1250dcf530d4320d730ad2744d37221
     Vocabulary/singular: 2c8127af4c194fa05463e82d5e414c62
     Shows%20WHERE%20this%20topic%20appears%20in%20real%20life.%20Helps%20you%20recognize%20it%20in%20daily%20routines%2C%20work%2C%20pop%20culture%2C%20and%20unexpected%20places./singular: bd7cdd212990640d3e21ae67a305379f
+    "%7Blesson%7D%20%7Bactivity%7D/singular": d959fed1ee77dca493e8cf0a3b3129c0
     Reading/singular: 9d93f1dff4a01a9e1566f23b401b8868
     Mechanics/singular: 9885fd6c35db2bd26affb830d537046b
     Quiz/singular: 22bce287f7a90d3b41b418108eaab43b
     Grammar/singular: 1d97aca351a45df1d6eb27adbee04832
+    Learn%20about%20%7Btopic%7D%20through%20an%20interactive%20activity./singular: 94f8ca153ea2ee6b539f507266548201
+    Review%20vocabulary%20and%20skills%20from%20%7Btopic%7D%20with%20a%20comprehensive%20assessment./singular: c903b125483f18bcc4a59f0b0ea31eef
+    Apply%20your%20knowledge%20of%20%7Btopic%7D%20through%20analytical%20decisions%20with%20real%20trade-offs./singular: a45d6f6551b5ec5c1206d7886bff0437
+    Understand%20what%20%7Btopic%7D%20is%20%E2%80%94%20core%20concepts%20and%20definitions%20explained%20with%20clear%20metaphors%20and%20analogies./singular: ec3b49a710ebac5f592523bdaa68ceff
+    Practice%20%7Btopic%7D%20grammar%20rules%20with%20exercises%20designed%20to%20help%20you%20remember%20and%20apply%20them./singular: 107adae09992e8b4deb051afa38da3bd
     Explains%20WHAT%20this%20topic%20is.%20Breaks%20down%20core%20concepts%20and%20definitions%20using%20metaphors%20and%20analogies./singular: 5eb6b1cd33e5c20af8423753d4368a81
     A%20comprehensive%20review%20covering%20vocabulary%20and%20skills%20from%20this%20lesson./singular: 9d8f77da46237b58839fadcbadc5a0bc
+    "%7Bactivity%7D%20-%20%7Blesson%7D/singular": 0aad8d82851f799d79c052a0f2b90d67
     Explains%20WHY%20this%20topic%20exists.%20Tells%20the%20origin%20story%2C%20the%20problems%20it%20solved%2C%20and%20why%20it%20matters%20today./singular: 8bdce45d80e8a4cfcbc65d2bfe928c82
+    Learn%20how%20%7Btopic%7D%20works%20under%20the%20hood%20%E2%80%94%20processes%2C%20sequences%2C%20and%20cause-effect%20chains%20explained./singular: 6d836bff9577f6063c768783327531b8
     Background/singular: 0ceaed10d99ed4ad83cb0934ab970174
+    Improve%20your%20%7Btopic%7D%20reading%20comprehension%20by%20translating%20sentences%20and%20passages./singular: 60baac4222f76009cc1eb1b6065b403b
     Shows%20WHEN%20to%20apply%20this%20topic.%20A%20dialogue%20with%20a%20colleague%20where%20you%20solve%20a%20real%20problem%20together./singular: 3fb0934c1e0a5ba3e31b6cc5b897b509
     Tests%20your%20understanding%20with%20questions.%20Uses%20new%20scenarios%20to%20check%20if%20you%20grasped%20the%20concept%2C%20not%20just%20memorized%20it./singular: feeb1e59f787035a964dd93290e180e7
     Green/singular: 482ff383a4258357ba404f283682471d


### PR DESCRIPTION
## Summary
- Generate kind-specific titles and descriptions for each activity page (e.g., "Photosynthesis Quiz | Zoonk") instead of generic "Activity"
- Add `getActivitySeoMeta` helper with kind-aware SEO description templates
- Add e2e test verifying page title contains kind label and lesson title

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add kind-specific SEO titles and descriptions to activity pages to replace the generic “Activity” metadata. This improves search relevance and differentiation across activities.

- **New Features**
  - Added getActivitySeoMeta with localized, kind-aware description templates (en, es, pt).
  - Updated activity page generateMetadata to build titles/descriptions from activity kind and lesson title, with safe fallbacks.
  - Added e2e test to ensure the page title includes the kind label and the lesson title.

<sup>Written for commit 1861d8813c936005c24929abf91b1f67c2a7fd96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

