### PR TITLE
feat(main): replace {{NAME}} placeholder with user display name

### DIFF
--- a/apps/main/e2e/step-user-name.test.ts
+++ b/apps/main/e2e/step-user-name.test.ts
@@ -1,0 +1,208 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { expect, test } from "./fixtures";
+import { E2E_USERS } from "./global-setup";
+
+async function createActivityWithNamePlaceholder(options: {
+  steps: { content: object; position: number }[];
+}) {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-name-course-${uniqueId}`,
+    title: `E2E Name Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-name-chapter-${uniqueId}`,
+    title: `E2E Name Chapter ${uniqueId}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    description: `E2E name lesson ${uniqueId}`,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-name-lesson-${uniqueId}`,
+    title: `E2E Name Lesson ${uniqueId}`,
+  });
+
+  const activity = await activityFixture({
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "background",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 0,
+    title: `E2E Name Activity ${uniqueId}`,
+  });
+
+  await Promise.all(
+    options.steps.map((step) =>
+      stepFixture({
+        activityId: activity.id,
+        content: step.content,
+        isPublished: true,
+        kind: "multipleChoice",
+        position: step.position,
+      }),
+    ),
+  );
+
+  const url = `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/0`;
+
+  return { uniqueId, url };
+}
+
+async function getAuthenticatedUserName(): Promise<string> {
+  const user = await prisma.user.findUniqueOrThrow({
+    select: { name: true },
+    where: { email: E2E_USERS.withProgress.email },
+  });
+
+  return user.name;
+}
+
+test.describe("Name placeholder replacement", () => {
+  test("unauthenticated user sees clean text without {{NAME}}", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createActivityWithNamePlaceholder({
+      steps: [
+        {
+          content: {
+            context: `{{NAME}}, I think we have a problem ${uniqueId}`,
+            kind: "core",
+            options: [
+              { feedback: "Yes", isCorrect: true, text: "Option A" },
+              { feedback: "No", isCorrect: false, text: "Option B" },
+            ],
+            question: `What do you think ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(page.getByText(new RegExp(`I think we have a problem ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText("{{NAME}}")).not.toBeVisible();
+  });
+
+  test("authenticated user sees their display name instead of {{NAME}}", async ({
+    authenticatedPage,
+  }) => {
+    const [userName, uniqueId] = await Promise.all([
+      getAuthenticatedUserName(),
+      Promise.resolve(randomUUID().slice(0, 8)),
+    ]);
+
+    const { url } = await createActivityWithNamePlaceholder({
+      steps: [
+        {
+          content: {
+            context: `{{NAME}}, I think we have a problem ${uniqueId}`,
+            kind: "core",
+            options: [
+              { feedback: "Yes", isCorrect: true, text: "Option A" },
+              { feedback: "No", isCorrect: false, text: "Option B" },
+            ],
+            question: `What do you think ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await authenticatedPage.goto(url);
+
+    await expect(
+      authenticatedPage.getByText(new RegExp(`${userName}, I think we have a problem ${uniqueId}`)),
+    ).toBeVisible();
+    await expect(authenticatedPage.getByText("{{NAME}}")).not.toBeVisible();
+  });
+
+  test("feedback text replaces {{NAME}} for authenticated user", async ({ authenticatedPage }) => {
+    const [userName, uniqueId] = await Promise.all([
+      getAuthenticatedUserName(),
+      Promise.resolve(randomUUID().slice(0, 8)),
+    ]);
+
+    const { url } = await createActivityWithNamePlaceholder({
+      steps: [
+        {
+          content: {
+            kind: "core",
+            options: [
+              {
+                feedback: `{{NAME}}, great job ${uniqueId}`,
+                isCorrect: true,
+                text: "Correct answer",
+              },
+              { feedback: "Try again", isCorrect: false, text: "Wrong answer" },
+            ],
+            question: `Test question ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await authenticatedPage.goto(url);
+    await authenticatedPage.waitForLoadState("networkidle");
+
+    await authenticatedPage.getByRole("radio", { name: /correct answer/i }).click();
+    await authenticatedPage.getByRole("button", { name: /check/i }).click();
+
+    await expect(
+      authenticatedPage.getByText(new RegExp(`${userName}, great job ${uniqueId}`)),
+    ).toBeVisible();
+    await expect(authenticatedPage.getByText("{{NAME}}")).not.toBeVisible();
+  });
+
+  test("feedback text strips {{NAME}} for unauthenticated user", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createActivityWithNamePlaceholder({
+      steps: [
+        {
+          content: {
+            kind: "core",
+            options: [
+              {
+                feedback: `{{NAME}}, great job ${uniqueId}`,
+                isCorrect: true,
+                text: "Correct answer",
+              },
+              { feedback: "Try again", isCorrect: false, text: "Wrong answer" },
+            ],
+            question: `Test question ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("radio", { name: /correct answer/i }).click();
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByText(new RegExp(`great job ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText("{{NAME}}")).not.toBeVisible();
+  });
+});

--- a/apps/main/e2e/step-user-name.test.ts
+++ b/apps/main/e2e/step-user-name.test.ts
@@ -5,6 +5,7 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { STORAGE_KEY_DISPLAY_NAME } from "@zoonk/utils/constants";
 import { expect, test } from "./fixtures";
 import { E2E_USERS } from "./global-setup";
 
@@ -128,6 +129,11 @@ test.describe("Name placeholder replacement", () => {
       ],
     });
 
+    await authenticatedPage.addInitScript(({ key, name }) => localStorage.setItem(key, name), {
+      key: STORAGE_KEY_DISPLAY_NAME,
+      name: userName,
+    });
+
     await authenticatedPage.goto(url);
 
     await expect(
@@ -160,6 +166,11 @@ test.describe("Name placeholder replacement", () => {
           position: 0,
         },
       ],
+    });
+
+    await authenticatedPage.addInitScript(({ key, name }) => localStorage.setItem(key, name), {
+      key: STORAGE_KEY_DISPLAY_NAME,
+      name: userName,
     });
 
     await authenticatedPage.goto(url);

--- a/apps/main/src/components/activity-player/activity-player-shell.tsx
+++ b/apps/main/src/components/activity-player/activity-player-shell.tsx
@@ -21,6 +21,7 @@ import { PlayerStage } from "./player-stage";
 import { StageContent } from "./stage-content";
 import { usePlayerKeyboard } from "./use-player-keyboard";
 import { usePlayerState } from "./use-player-state";
+import { UserNameProvider } from "./user-name-context";
 
 export function ActivityPlayerShell({
   activity,
@@ -111,71 +112,73 @@ export function ActivityPlayerShell({
   const buttonLabel = state.phase === "feedback" ? t("Continue") : t("Check");
 
   return (
-    <main className="flex min-h-dvh flex-col">
-      {!isCompleted && (
-        <PlayerHeader>
-          <PlayerCloseLink href={lessonHref} />
+    <UserNameProvider>
+      <main className="flex min-h-dvh flex-col">
+        {!isCompleted && (
+          <PlayerHeader>
+            <PlayerCloseLink href={lessonHref} />
 
-          {isStaticStep && (
-            <PlayerNav>
-              <PlayerNavGroup>
-                <PlayerNavButton
-                  direction="prev"
-                  disabled={isFirstStep}
-                  onClick={handleNavigatePrev}
-                />
-                <PlayerStepFraction>
-                  {state.currentStepIndex + 1} / {totalSteps}
-                </PlayerStepFraction>
-                <PlayerNavButton direction="next" onClick={handleNavigateNext} />
-              </PlayerNavGroup>
-            </PlayerNav>
-          )}
+            {isStaticStep && (
+              <PlayerNav>
+                <PlayerNavGroup>
+                  <PlayerNavButton
+                    direction="prev"
+                    disabled={isFirstStep}
+                    onClick={handleNavigatePrev}
+                  />
+                  <PlayerStepFraction>
+                    {state.currentStepIndex + 1} / {totalSteps}
+                  </PlayerStepFraction>
+                  <PlayerNavButton direction="next" onClick={handleNavigateNext} />
+                </PlayerNavGroup>
+              </PlayerNav>
+            )}
 
-          {!isStaticStep && (
-            <PlayerStepFraction>
-              {state.currentStepIndex + 1} / {totalSteps}
-            </PlayerStepFraction>
-          )}
+            {!isStaticStep && (
+              <PlayerStepFraction>
+                {state.currentStepIndex + 1} / {totalSteps}
+              </PlayerStepFraction>
+            )}
 
-          <div className="size-9" aria-hidden="true" />
-        </PlayerHeader>
-      )}
+            <div className="size-9" aria-hidden="true" />
+          </PlayerHeader>
+        )}
 
-      {!isCompleted && <PlayerProgressBar value={progressValue} />}
+        {!isCompleted && <PlayerProgressBar value={progressValue} />}
 
-      <PlayerStage phase={state.phase}>
-        <StageContent
-          activityId={state.activityId}
-          currentResult={currentResult}
-          currentStep={currentStep}
-          currentStepIndex={state.currentStepIndex}
-          dimensions={state.dimensions}
-          isCompleted={isCompleted}
-          isFirst={isFirstStep}
-          lessonHref={lessonHref}
-          nextActivityHref={nextActivityHref}
-          onNavigateNext={handleNavigateNext}
-          onNavigatePrev={handleNavigatePrev}
-          onRestart={handleRestart}
-          onSelectAnswer={handleSelectAnswer}
-          phase={state.phase}
-          results={state.results}
-          selectedAnswer={currentStep ? state.selectedAnswers[currentStep.id] : undefined}
-        />
-      </PlayerStage>
+        <PlayerStage phase={state.phase}>
+          <StageContent
+            activityId={state.activityId}
+            currentResult={currentResult}
+            currentStep={currentStep}
+            currentStepIndex={state.currentStepIndex}
+            dimensions={state.dimensions}
+            isCompleted={isCompleted}
+            isFirst={isFirstStep}
+            lessonHref={lessonHref}
+            nextActivityHref={nextActivityHref}
+            onNavigateNext={handleNavigateNext}
+            onNavigatePrev={handleNavigatePrev}
+            onRestart={handleRestart}
+            onSelectAnswer={handleSelectAnswer}
+            phase={state.phase}
+            results={state.results}
+            selectedAnswer={currentStep ? state.selectedAnswers[currentStep.id] : undefined}
+          />
+        </PlayerStage>
 
-      {!isStaticStep && !isCompleted && (
-        <PlayerActionBar>
-          <PlayerActionButton
-            disabled={state.phase === "playing" && !hasAnswer}
-            onClick={state.phase === "feedback" ? handleContinue : handleCheck}
-          >
-            {buttonLabel}
-          </PlayerActionButton>
-        </PlayerActionBar>
-      )}
-    </main>
+        {!isStaticStep && !isCompleted && (
+          <PlayerActionBar>
+            <PlayerActionButton
+              disabled={state.phase === "playing" && !hasAnswer}
+              onClick={state.phase === "feedback" ? handleContinue : handleCheck}
+            >
+              {buttonLabel}
+            </PlayerActionButton>
+          </PlayerActionBar>
+        )}
+      </main>
+    </UserNameProvider>
   );
 }
 

--- a/apps/main/src/components/activity-player/feedback-screen.tsx
+++ b/apps/main/src/components/activity-player/feedback-screen.tsx
@@ -5,6 +5,7 @@ import { CircleCheck, CircleX } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { DimensionList, buildDimensionEntries } from "./dimension-inventory";
 import { type DimensionInventory, type StepResult } from "./player-reducer";
+import { useReplaceName } from "./user-name-context";
 
 export function getFeedbackVariant(result: StepResult): "correct" | "incorrect" | "challenge" {
   if (result.effects.length > 0) {
@@ -61,7 +62,9 @@ export function FeedbackScreenContent({
   result: StepResult;
 }) {
   const t = useExtracted();
+  const replaceName = useReplaceName();
   const variant = getFeedbackVariant(result);
+  const feedback = result.result.feedback ? replaceName(result.result.feedback) : null;
 
   if (variant === "challenge") {
     const entries = buildDimensionEntries(dimensions, result.effects);
@@ -70,9 +73,7 @@ export function FeedbackScreenContent({
       <FeedbackScreen>
         <FeedbackIndicator className="text-foreground">{t("Outcome")}</FeedbackIndicator>
 
-        {result.result.feedback ? (
-          <FeedbackMessage>{result.result.feedback}</FeedbackMessage>
-        ) : null}
+        {feedback ? <FeedbackMessage>{feedback}</FeedbackMessage> : null}
 
         <DimensionList aria-label="Dimension inventory" entries={entries} variant="feedback" />
       </FeedbackScreen>
@@ -92,7 +93,7 @@ export function FeedbackScreenContent({
         <span>{isCorrect ? t("Correct!") : t("Not quite")}</span>
       </FeedbackIndicator>
 
-      {result.result.feedback ? <FeedbackMessage>{result.result.feedback}</FeedbackMessage> : null}
+      {feedback ? <FeedbackMessage>{feedback}</FeedbackMessage> : null}
     </FeedbackScreen>
   );
 }

--- a/apps/main/src/components/activity-player/multiple-choice-step.tsx
+++ b/apps/main/src/components/activity-player/multiple-choice-step.tsx
@@ -13,6 +13,7 @@ import { useExtracted } from "next-intl";
 import { type SelectedAnswer } from "./player-reducer";
 import { InteractiveStepLayout } from "./step-layouts";
 import { useOptionKeyboard } from "./use-option-keyboard";
+import { useReplaceName } from "./user-name-context";
 
 function getSelectedIndex(selectedAnswer: SelectedAnswer | undefined): number | null {
   if (selectedAnswer?.kind !== "multipleChoice") {
@@ -107,11 +108,13 @@ function CoreVariant({
   onSelect: (index: number) => void;
   selectedIndex: number | null;
 }) {
+  const replaceName = useReplaceName();
+
   return (
     <>
       <StepTextGroup>
-        {content.context ? <ContextText>{content.context}</ContextText> : null}
-        {content.question ? <QuestionText>{content.question}</QuestionText> : null}
+        {content.context ? <ContextText>{replaceName(content.context)}</ContextText> : null}
+        {content.question ? <QuestionText>{replaceName(content.question)}</QuestionText> : null}
       </StepTextGroup>
 
       <OptionList onSelect={onSelect} options={content.options} selectedIndex={selectedIndex} />
@@ -128,11 +131,13 @@ function ChallengeVariant({
   onSelect: (index: number) => void;
   selectedIndex: number | null;
 }) {
+  const replaceName = useReplaceName();
+
   return (
     <>
       <StepTextGroup>
-        <ContextText>{content.context}</ContextText>
-        <QuestionText>{content.question}</QuestionText>
+        <ContextText>{replaceName(content.context)}</ContextText>
+        <QuestionText>{replaceName(content.question)}</QuestionText>
       </StepTextGroup>
 
       <OptionList onSelect={onSelect} options={content.options} selectedIndex={selectedIndex} />
@@ -160,6 +165,7 @@ function LanguageVariant({
   selectedIndex: number | null;
 }) {
   const t = useExtracted();
+  const replaceName = useReplaceName();
 
   return (
     <>
@@ -167,13 +173,13 @@ function LanguageVariant({
         <SectionLabel>{t("Someone says:")}</SectionLabel>
 
         <SpeechBubble>
-          <p className="text-base font-semibold">{content.context}</p>
+          <p className="text-base font-semibold">{replaceName(content.context)}</p>
 
           {content.contextRomanization ? (
             <p className="text-muted-foreground text-sm italic">{content.contextRomanization}</p>
           ) : null}
 
-          <p className="text-muted-foreground text-sm">{content.contextTranslation}</p>
+          <p className="text-muted-foreground text-sm">{replaceName(content.contextTranslation)}</p>
         </SpeechBubble>
       </div>
 

--- a/apps/main/src/components/activity-player/static-step.tsx
+++ b/apps/main/src/components/activity-player/static-step.tsx
@@ -4,12 +4,15 @@ import { type SerializedStep } from "@/data/activities/prepare-activity-data";
 import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { HighlightText } from "./highlight-text";
 import { StaticStepText, StaticStepVisual } from "./step-layouts";
+import { useReplaceName } from "./user-name-context";
 
 function TextVariant({ title, text }: { title: string; text: string }) {
+  const replaceName = useReplaceName();
+
   return (
     <>
-      <h2 className="text-base font-semibold">{title}</h2>
-      <p className="text-muted-foreground text-base">{text}</p>
+      <h2 className="text-base font-semibold">{replaceName(title)}</h2>
+      <p className="text-muted-foreground text-base">{replaceName(text)}</p>
     </>
   );
 }

--- a/apps/main/src/components/activity-player/user-name-context.tsx
+++ b/apps/main/src/components/activity-player/user-name-context.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { authClient } from "@zoonk/core/auth/client";
+import { STORAGE_KEY_DISPLAY_NAME } from "@zoonk/utils/constants";
+import { replaceNamePlaceholder } from "@zoonk/utils/string";
+import { createContext, useCallback, useContext, useEffect, useSyncExternalStore } from "react";
+
+const UserNameContext = createContext<string | null>(null);
+
+function subscribe(callback: () => void): () => void {
+  globalThis.addEventListener("storage", callback);
+  return () => globalThis.removeEventListener("storage", callback);
+}
+
+function getSnapshot(): string | null {
+  return localStorage.getItem(STORAGE_KEY_DISPLAY_NAME);
+}
+
+function getServerSnapshot(): null {
+  return null;
+}
+
+export function UserNameProvider({ children }: { children: React.ReactNode }) {
+  const { data } = authClient.useSession();
+  const sessionName = data?.user.name ?? null;
+  const cachedName = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  useEffect(() => {
+    if (sessionName) {
+      localStorage.setItem(STORAGE_KEY_DISPLAY_NAME, sessionName);
+    }
+  }, [sessionName]);
+
+  const name = sessionName ?? cachedName;
+
+  return <UserNameContext value={name}>{children}</UserNameContext>;
+}
+
+export function useReplaceName(): (text: string) => string {
+  const name = useContext(UserNameContext);
+  return useCallback((text: string) => replaceNamePlaceholder(text, name), [name]);
+}

--- a/apps/main/src/components/activity-player/user-name-context.tsx
+++ b/apps/main/src/components/activity-player/user-name-context.tsx
@@ -21,15 +21,17 @@ function getServerSnapshot(): null {
 }
 
 export function UserNameProvider({ children }: { children: React.ReactNode }) {
-  const { data } = authClient.useSession();
+  const { data, isPending } = authClient.useSession();
   const sessionName = data?.user.name ?? null;
   const cachedName = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
   useEffect(() => {
     if (sessionName) {
       localStorage.setItem(STORAGE_KEY_DISPLAY_NAME, sessionName);
+    } else if (!isPending) {
+      localStorage.removeItem(STORAGE_KEY_DISPLAY_NAME);
     }
-  }, [sessionName]);
+  }, [sessionName, isPending]);
 
   const name = sessionName ?? cachedName;
 

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -53,3 +53,6 @@ export const TTS_VOICES = [
 ] as const;
 
 export type TTSVoice = (typeof TTS_VOICES)[number];
+
+export const STORAGE_KEY_DISPLAY_NAME = "zoonk:displayName";
+export const NAME_PLACEHOLDER = "{{NAME}}";

--- a/packages/utils/src/string.test.ts
+++ b/packages/utils/src/string.test.ts
@@ -6,6 +6,7 @@ import {
   parseBigIntId,
   parseNumericId,
   removeAccents,
+  replaceNamePlaceholder,
 } from "./string";
 
 describe(removeAccents, () => {
@@ -171,5 +172,34 @@ describe(formatPosition, () => {
   test("formats double digit positions without leading zero", () => {
     expect(formatPosition(9)).toBe("10");
     expect(formatPosition(99)).toBe("100");
+  });
+});
+
+describe(replaceNamePlaceholder, () => {
+  test("replaces {{NAME}} with provided name", () => {
+    expect(replaceNamePlaceholder("Hello, {{NAME}}!", "Alice")).toBe("Hello, Alice!");
+  });
+
+  test("handles multiple occurrences", () => {
+    expect(replaceNamePlaceholder("{{NAME}}, meet {{NAME}}", "Bob")).toBe("Bob, meet Bob");
+  });
+
+  test("strips '{{NAME}}, ' pattern when name is null", () => {
+    expect(replaceNamePlaceholder("{{NAME}}, I think we have a problem.", null)).toBe(
+      "I think we have a problem.",
+    );
+  });
+
+  test("strips ', {{NAME}}' pattern when name is null", () => {
+    expect(replaceNamePlaceholder("Hello there, {{NAME}}", null)).toBe("Hello there");
+  });
+
+  test("strips standalone {{NAME}} when name is null", () => {
+    expect(replaceNamePlaceholder("{{NAME}} welcome back", null)).toBe("welcome back");
+  });
+
+  test("returns original text when no placeholder present", () => {
+    expect(replaceNamePlaceholder("No placeholder here", "Alice")).toBe("No placeholder here");
+    expect(replaceNamePlaceholder("No placeholder here", null)).toBe("No placeholder here");
   });
 });

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -1,3 +1,4 @@
+import { NAME_PLACEHOLDER } from "@zoonk/utils/constants";
 import slugify from "slugify";
 
 const NUMERIC_ID_PATTERN = /^\d+$/;
@@ -39,4 +40,20 @@ export function formatPosition(position: number): string {
 
 export function emptyToNull(value?: string | null): string | null {
   return value?.trim() || null;
+}
+
+export function replaceNamePlaceholder(text: string, name: string | null): string {
+  if (!text.includes(NAME_PLACEHOLDER)) {
+    return text;
+  }
+
+  if (name) {
+    return text.replaceAll(NAME_PLACEHOLDER, name);
+  }
+
+  return text
+    .replaceAll(/\{\{NAME\}\},\s*/g, "")
+    .replaceAll(/,\s*\{\{NAME\}\}/g, "")
+    .replaceAll(NAME_PLACEHOLDER, "")
+    .trim();
 }


### PR DESCRIPTION
## Summary

- Add `replaceNamePlaceholder` utility that substitutes `{{NAME}}` with the user's display name, or cleanly strips it (including surrounding punctuation) when no name is available
- Add `UserNameProvider` using `useSyncExternalStore` with localStorage for flicker-free hydration across page reloads
- Apply replacement in `StaticStep`, `MultipleChoiceStep` (all variants), and `FeedbackScreenContent`

## Test plan

- [x] Unit tests for `replaceNamePlaceholder` (6 cases: with name, multiple occurrences, null stripping patterns, no placeholder)
- [x] E2E tests for authenticated user seeing their name, unauthenticated user seeing clean text, and feedback text replacement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Personalizes activity text by replacing {{NAME}} with the user’s display name and cleanly stripping it when no name is available. Avoids hydration flicker and clears cached names on logout.

- **New Features**
  - Client-side replacement via UserNameProvider/useReplaceName and replaceNamePlaceholder, using useSyncExternalStore + localStorage (NAME_PLACEHOLDER, STORAGE_KEY_DISPLAY_NAME).
  - Applied in StaticStep, MultipleChoiceStep (core/challenge/language), and FeedbackScreen; provider wraps ActivityPlayerShell.

- **Bug Fixes**
  - Isolated step-user-name E2E tests from shared DB state by asserting a comma-prefixed pattern instead of specific names to prevent flakes.

<sup>Written for commit 716c7d8f0b16d460a4cd5992fc41bace5ad12e13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

