### PR TITLE
feat(main): add challenge intro screen and in-play stats popover

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1197,6 +1197,42 @@ msgctxt "w48TcP"
 msgid "Challenge Failed"
 msgstr "Challenge Failed"
 
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "/DZ4Fx"
+msgid "Make choices."
+msgstr "Make choices."
+
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "4vTq4b"
+msgid "Balance the outcome."
+msgstr "Balance the outcome."
+
+#: src/components/activity-player/challenge-intro.tsx
+#: src/lib/activities.ts
+msgctxt "9MidH4"
+msgid "Challenge"
+msgstr "Challenge"
+
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "c+wn4p"
+msgid "You'll face a series of decisions. Each one shifts your scores. Don't let any go negative."
+msgstr "You'll face a series of decisions. Each one shifts your scores. Don't let any go negative."
+
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "kKztdT"
+msgid "Starting scores"
+msgstr "Starting scores"
+
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "PVe26p"
+msgid "Begin"
+msgstr "Begin"
+
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "SFKe0U"
+msgid "Your scores"
+msgstr "Your scores"
+
 #: src/components/activity-player/completion-auth-branch.tsx
 msgctxt "5kK+j9"
 msgid "Restart"
@@ -1224,6 +1260,21 @@ msgstr "Completed"
 msgctxt "P768k7"
 msgid "correct"
 msgstr "correct"
+
+#: src/components/activity-player/dimension-status-button.tsx
+msgctxt "ehV7Gg"
+msgid "Current dimension scores"
+msgstr "Current dimension scores"
+
+#: src/components/activity-player/dimension-status-button.tsx
+msgctxt "EUdKC+"
+msgid "View stats"
+msgstr "View stats"
+
+#: src/components/activity-player/dimension-status-button.tsx
+msgctxt "U86B6w"
+msgid "Stats"
+msgstr "Stats"
 
 #: src/components/activity-player/feedback-screen.tsx
 msgctxt "++l7ni"
@@ -1421,11 +1472,6 @@ msgstr "Experience when to apply {topic} through a real-world dialogue scenario.
 msgctxt "3GLH+d"
 msgid "Examples"
 msgstr "Examples"
-
-#: src/lib/activities.ts
-msgctxt "9MidH4"
-msgid "Challenge"
-msgstr "Challenge"
 
 #: src/lib/activities.ts
 msgctxt "BB51/R"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1197,6 +1197,42 @@ msgctxt "w48TcP"
 msgid "Challenge Failed"
 msgstr "Desafío fallido"
 
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "/DZ4Fx"
+msgid "Make choices."
+msgstr "Toma decisiones."
+
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "4vTq4b"
+msgid "Balance the outcome."
+msgstr "Equilibra el resultado."
+
+#: src/components/activity-player/challenge-intro.tsx
+#: src/lib/activities.ts
+msgctxt "9MidH4"
+msgid "Challenge"
+msgstr "Desafío"
+
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "c+wn4p"
+msgid "You'll face a series of decisions. Each one shifts your scores. Don't let any go negative."
+msgstr "Enfrentarás una serie de decisiones. Cada una cambia tus puntajes. No dejes que ninguno sea negativo."
+
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "kKztdT"
+msgid "Starting scores"
+msgstr "Puntajes iniciales"
+
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "PVe26p"
+msgid "Begin"
+msgstr "Comenzar"
+
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "SFKe0U"
+msgid "Your scores"
+msgstr "Tus puntajes"
+
 #: src/components/activity-player/completion-auth-branch.tsx
 msgctxt "5kK+j9"
 msgid "Restart"
@@ -1224,6 +1260,21 @@ msgstr "Completada"
 msgctxt "P768k7"
 msgid "correct"
 msgstr "correcto"
+
+#: src/components/activity-player/dimension-status-button.tsx
+msgctxt "ehV7Gg"
+msgid "Current dimension scores"
+msgstr "Puntajes de dimensión actuales"
+
+#: src/components/activity-player/dimension-status-button.tsx
+msgctxt "EUdKC+"
+msgid "View stats"
+msgstr "Ver estadísticas"
+
+#: src/components/activity-player/dimension-status-button.tsx
+msgctxt "U86B6w"
+msgid "Stats"
+msgstr "Estadísticas"
 
 #: src/components/activity-player/feedback-screen.tsx
 msgctxt "++l7ni"
@@ -1421,11 +1472,6 @@ msgstr "Experimenta cuándo aplicar {topic} a través de un escenario de diálog
 msgctxt "3GLH+d"
 msgid "Examples"
 msgstr "Ejemplos"
-
-#: src/lib/activities.ts
-msgctxt "9MidH4"
-msgid "Challenge"
-msgstr "Desafío"
 
 #: src/lib/activities.ts
 msgctxt "BB51/R"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1197,6 +1197,42 @@ msgctxt "w48TcP"
 msgid "Challenge Failed"
 msgstr "Desafio falhou"
 
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "/DZ4Fx"
+msgid "Make choices."
+msgstr "Faça escolhas."
+
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "4vTq4b"
+msgid "Balance the outcome."
+msgstr "Equilibre o resultado."
+
+#: src/components/activity-player/challenge-intro.tsx
+#: src/lib/activities.ts
+msgctxt "9MidH4"
+msgid "Challenge"
+msgstr "Desafio"
+
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "c+wn4p"
+msgid "You'll face a series of decisions. Each one shifts your scores. Don't let any go negative."
+msgstr "Você vai enfrentar uma série de decisões. Cada uma muda suas pontuações. Não deixe nenhuma ficar negativa."
+
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "kKztdT"
+msgid "Starting scores"
+msgstr "Pontuações iniciais"
+
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "PVe26p"
+msgid "Begin"
+msgstr "Começar"
+
+#: src/components/activity-player/challenge-intro.tsx
+msgctxt "SFKe0U"
+msgid "Your scores"
+msgstr "Suas pontuações"
+
 #: src/components/activity-player/completion-auth-branch.tsx
 msgctxt "5kK+j9"
 msgid "Restart"
@@ -1224,6 +1260,21 @@ msgstr "Concluída"
 msgctxt "P768k7"
 msgid "correct"
 msgstr "correto"
+
+#: src/components/activity-player/dimension-status-button.tsx
+msgctxt "ehV7Gg"
+msgid "Current dimension scores"
+msgstr "Pontuações atuais das dimensões"
+
+#: src/components/activity-player/dimension-status-button.tsx
+msgctxt "EUdKC+"
+msgid "View stats"
+msgstr "Ver estatísticas"
+
+#: src/components/activity-player/dimension-status-button.tsx
+msgctxt "U86B6w"
+msgid "Stats"
+msgstr "Estatísticas"
 
 #: src/components/activity-player/feedback-screen.tsx
 msgctxt "++l7ni"
@@ -1421,11 +1472,6 @@ msgstr "Experimente quando aplicar {topic} através de um cenário de diálogo d
 msgctxt "3GLH+d"
 msgid "Examples"
 msgstr "Exemplos"
-
-#: src/lib/activities.ts
-msgctxt "9MidH4"
-msgid "Challenge"
-msgstr "Desafio"
 
 #: src/lib/activities.ts
 msgctxt "BB51/R"

--- a/apps/main/src/components/activity-player/challenge-intro.tsx
+++ b/apps/main/src/components/activity-player/challenge-intro.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Button } from "@zoonk/ui/components/button";
+import { useExtracted } from "next-intl";
+import { DimensionList, buildDimensionEntries } from "./dimension-inventory";
+import { type DimensionInventory } from "./player-reducer";
+
+export function ChallengeIntro({
+  dimensions,
+  onStart,
+}: {
+  dimensions: DimensionInventory;
+  onStart: () => void;
+}) {
+  const t = useExtracted();
+  const entries = buildDimensionEntries(dimensions, []);
+
+  return (
+    <div className="mx-auto flex w-full max-w-lg flex-col gap-6 text-left">
+      <div className="flex flex-col gap-4">
+        <span className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+          {t("Challenge")}
+        </span>
+
+        <h1 className="text-foreground text-2xl font-bold tracking-tight">
+          {t("Make choices.")}
+          <br />
+          {t("Balance the outcome.")}
+        </h1>
+
+        <p className="text-muted-foreground text-base leading-relaxed">
+          {t(
+            "You'll face a series of decisions. Each one shifts your scores. Don't let any go negative.",
+          )}
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+          {t("Your scores")}
+        </span>
+
+        <DimensionList aria-label={t("Starting scores")} entries={entries} variant="intro" />
+      </div>
+
+      <Button className="w-full" onClick={onStart} size="lg">
+        {t("Begin")}
+      </Button>
+    </div>
+  );
+}

--- a/apps/main/src/components/activity-player/dimension-inventory.test.ts
+++ b/apps/main/src/components/activity-player/dimension-inventory.test.ts
@@ -4,6 +4,7 @@ import {
   buildDimensionEntries,
   formatDelta,
   getDeltaColor,
+  getStatusTotalColor,
   hasNegativeDimension,
 } from "./dimension-inventory";
 import { type DimensionInventory } from "./player-reducer";
@@ -109,5 +110,19 @@ describe(buildDimensionEntries, () => {
     const result = buildDimensionEntries(dims, []);
 
     expect(result.map((entry) => entry.name)).toEqual(["Courage", "Diplomacy", "Morale"]);
+  });
+});
+
+describe(getStatusTotalColor, () => {
+  test("returns text-foreground for positive total", () => {
+    expect(getStatusTotalColor(3)).toBe("text-foreground");
+  });
+
+  test("returns text-warning for zero total", () => {
+    expect(getStatusTotalColor(0)).toBe("text-warning");
+  });
+
+  test("returns text-destructive for negative total", () => {
+    expect(getStatusTotalColor(-1)).toBe("text-destructive");
   });
 });

--- a/apps/main/src/components/activity-player/dimension-inventory.tsx
+++ b/apps/main/src/components/activity-player/dimension-inventory.tsx
@@ -26,6 +26,18 @@ export function getDeltaColor(delta: number): string {
   return "text-success";
 }
 
+export function getStatusTotalColor(total: number): string {
+  if (total < 0) {
+    return "text-destructive";
+  }
+
+  if (total === 0) {
+    return "text-warning";
+  }
+
+  return "text-foreground";
+}
+
 export function buildDimensionEntries(
   dimensions: DimensionInventoryType,
   effects: ChallengeEffect[],
@@ -71,10 +83,9 @@ function DeltaPill({ delta, hidden }: { delta: number; hidden?: boolean }) {
   );
 }
 
-function getRowBackground(
-  variant: "feedback" | "success" | "failure",
-  entry: DimensionEntry,
-): string | false {
+type DimensionVariant = "feedback" | "failure" | "intro" | "status" | "success";
+
+function getRowBackground(variant: DimensionVariant, entry: DimensionEntry): string | false {
   if (variant === "feedback" && entry.delta > 0) {
     return "bg-success/5";
   }
@@ -90,6 +101,30 @@ function getRowBackground(
   return false;
 }
 
+function getTotalColor(variant: DimensionVariant, entry: DimensionEntry): string {
+  if (variant === "intro") {
+    return "text-muted-foreground";
+  }
+
+  if (variant === "status") {
+    return getStatusTotalColor(entry.total);
+  }
+
+  if (variant === "success") {
+    return "text-muted-foreground";
+  }
+
+  if (variant === "failure" && entry.total < 0) {
+    return "text-destructive font-semibold";
+  }
+
+  if (entry.total < 0) {
+    return "text-destructive";
+  }
+
+  return "text-foreground";
+}
+
 function DimensionRow({
   entry,
   variant,
@@ -97,10 +132,9 @@ function DimensionRow({
   ...props
 }: React.ComponentProps<"li"> & {
   entry: DimensionEntry;
-  variant: "feedback" | "success" | "failure";
+  variant: DimensionVariant;
 }) {
-  const isNegativeTotal = entry.total < 0;
-  const isFailureHighlight = variant === "failure" && isNegativeTotal;
+  const isFailureHighlight = variant === "failure" && entry.total < 0;
 
   return (
     <li
@@ -122,9 +156,7 @@ function DimensionRow({
         <span
           className={cn(
             "min-w-6 text-right text-sm font-medium tabular-nums",
-            isNegativeTotal ? "text-destructive" : "text-foreground",
-            variant === "success" && "text-muted-foreground",
-            isFailureHighlight && "text-destructive font-semibold",
+            getTotalColor(variant, entry),
           )}
         >
           {entry.total}
@@ -145,7 +177,7 @@ export function DimensionList({
 }: {
   "aria-label": string;
   entries: DimensionEntry[];
-  variant: "feedback" | "success" | "failure";
+  variant: DimensionVariant;
 }) {
   if (entries.length === 0) {
     return null;

--- a/apps/main/src/components/activity-player/dimension-status-button.tsx
+++ b/apps/main/src/components/activity-player/dimension-status-button.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Button } from "@zoonk/ui/components/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@zoonk/ui/components/popover";
+import { cn } from "@zoonk/ui/lib/utils";
+import { BarChart3Icon } from "lucide-react";
+import { useExtracted } from "next-intl";
+import { DimensionList, buildDimensionEntries, hasNegativeDimension } from "./dimension-inventory";
+import { type DimensionInventory } from "./player-reducer";
+
+function getIconColor(dimensions: DimensionInventory): string {
+  if (hasNegativeDimension(dimensions)) {
+    return "text-destructive";
+  }
+
+  if (Object.values(dimensions).some((value) => value === 0)) {
+    return "text-warning";
+  }
+
+  return "text-muted-foreground";
+}
+
+export function DimensionStatusButton({ dimensions }: { dimensions: DimensionInventory }) {
+  const t = useExtracted();
+  const entries = buildDimensionEntries(dimensions, []);
+  const iconColor = getIconColor(dimensions);
+
+  return (
+    <Popover>
+      <PopoverTrigger render={<Button aria-label={t("View stats")} size="icon" variant="ghost" />}>
+        <BarChart3Icon className={cn("size-4", iconColor)} />
+      </PopoverTrigger>
+
+      <PopoverContent align="end" side="bottom">
+        <PopoverHeader>
+          <PopoverTitle>{t("Stats")}</PopoverTitle>
+        </PopoverHeader>
+
+        <DimensionList
+          aria-label={t("Current dimension scores")}
+          entries={entries}
+          variant="status"
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/main/src/components/activity-player/stage-content.tsx
+++ b/apps/main/src/components/activity-player/stage-content.tsx
@@ -1,7 +1,13 @@
 import { type SerializedStep } from "@/data/activities/prepare-activity-data";
+import { ChallengeIntro } from "./challenge-intro";
 import { CompletionScreenContent } from "./completion-screen";
 import { FeedbackScreenContent } from "./feedback-screen";
-import { type DimensionInventory, type SelectedAnswer, type StepResult } from "./player-reducer";
+import {
+  type DimensionInventory,
+  type PlayerPhase,
+  type SelectedAnswer,
+  type StepResult,
+} from "./player-reducer";
 import { StepRenderer } from "./step-renderer";
 
 export function StageContent({
@@ -18,6 +24,7 @@ export function StageContent({
   onNavigatePrev,
   onRestart,
   onSelectAnswer,
+  onStartChallenge,
   results,
   phase,
   selectedAnswer,
@@ -35,10 +42,15 @@ export function StageContent({
   onNavigatePrev: () => void;
   onRestart: () => void;
   onSelectAnswer: (stepId: string, answer: SelectedAnswer) => void;
+  onStartChallenge: () => void;
   results: Record<string, StepResult>;
-  phase: string;
+  phase: PlayerPhase;
   selectedAnswer: SelectedAnswer | undefined;
 }) {
+  if (phase === "intro") {
+    return <ChallengeIntro dimensions={dimensions} onStart={onStartChallenge} />;
+  }
+
   if (isCompleted) {
     return (
       <CompletionScreenContent

--- a/apps/main/src/components/activity-player/use-player-keyboard.test.ts
+++ b/apps/main/src/components/activity-player/use-player-keyboard.test.ts
@@ -15,6 +15,7 @@ function buildOptions(overrides: Partial<Parameters<typeof usePlayerKeyboard>[0]
     onNavigatePrev: vi.fn(),
     onNext: null as (() => void) | null,
     onRestart: vi.fn(),
+    onStartChallenge: null as (() => void) | null,
     phase: "playing" as PlayerPhase,
     ...overrides,
   };
@@ -31,6 +32,28 @@ describe(usePlayerKeyboard, () => {
   });
 
   describe("Enter key", () => {
+    test("calls onStartChallenge when intro phase", () => {
+      const onStartChallenge = vi.fn();
+      const opts = buildOptions({ onStartChallenge, phase: "intro" });
+      renderHook(() => usePlayerKeyboard(opts));
+
+      fireKey("Enter");
+
+      expect(onStartChallenge).toHaveBeenCalledOnce();
+      expect(opts.onCheck).not.toHaveBeenCalled();
+    });
+
+    test("does not call onStartChallenge when playing", () => {
+      const onStartChallenge = vi.fn();
+      const opts = buildOptions({ hasAnswer: true, onStartChallenge, phase: "playing" });
+      renderHook(() => usePlayerKeyboard(opts));
+
+      fireKey("Enter");
+
+      expect(onStartChallenge).not.toHaveBeenCalled();
+      expect(opts.onCheck).toHaveBeenCalledOnce();
+    });
+
     test("calls onCheck when playing and hasAnswer", () => {
       const opts = buildOptions({ hasAnswer: true, phase: "playing" });
       renderHook(() => usePlayerKeyboard(opts));

--- a/apps/main/src/components/activity-player/use-player-keyboard.ts
+++ b/apps/main/src/components/activity-player/use-player-keyboard.ts
@@ -13,6 +13,7 @@ export function usePlayerKeyboard({
   onNavigatePrev,
   onNext,
   onRestart,
+  onStartChallenge,
   phase,
 }: {
   hasAnswer: boolean;
@@ -24,12 +25,15 @@ export function usePlayerKeyboard({
   onNavigatePrev: () => void;
   onNext: (() => void) | null;
   onRestart: () => void;
+  onStartChallenge: (() => void) | null;
   phase: PlayerPhase;
 }) {
   useKeyboardCallback(
     "Enter",
     () => {
-      if (phase === "playing" && hasAnswer) {
+      if (phase === "intro" && onStartChallenge) {
+        onStartChallenge();
+      } else if (phase === "playing" && hasAnswer) {
         onCheck();
       } else if (phase === "feedback") {
         onContinue();

--- a/apps/main/src/components/activity-player/use-player-keyboard.ts
+++ b/apps/main/src/components/activity-player/use-player-keyboard.ts
@@ -3,6 +3,51 @@
 import { useKeyboardCallback } from "@zoonk/ui/hooks/keyboard";
 import { type PlayerPhase } from "./player-reducer";
 
+type PlayerKeyboardParams = {
+  hasAnswer: boolean;
+  isStaticStep: boolean;
+  onCheck: () => void;
+  onContinue: () => void;
+  onEscape: () => void;
+  onNavigateNext: () => void;
+  onNavigatePrev: () => void;
+  onNext: (() => void) | null;
+  onRestart: () => void;
+  onStartChallenge: (() => void) | null;
+  phase: PlayerPhase;
+};
+
+function getEnterAction({
+  hasAnswer,
+  onCheck,
+  onContinue,
+  onEscape,
+  onNext,
+  onStartChallenge,
+  phase,
+}: Pick<
+  PlayerKeyboardParams,
+  "hasAnswer" | "onCheck" | "onContinue" | "onEscape" | "onNext" | "onStartChallenge" | "phase"
+>): (() => void) | null {
+  if (phase === "intro" && onStartChallenge) {
+    return onStartChallenge;
+  }
+
+  if (phase === "playing" && hasAnswer) {
+    return onCheck;
+  }
+
+  if (phase === "feedback") {
+    return onContinue;
+  }
+
+  if (phase === "completed") {
+    return onNext ?? onEscape;
+  }
+
+  return null;
+}
+
 export function usePlayerKeyboard({
   hasAnswer,
   isStaticStep,
@@ -15,35 +60,19 @@ export function usePlayerKeyboard({
   onRestart,
   onStartChallenge,
   phase,
-}: {
-  hasAnswer: boolean;
-  isStaticStep: boolean;
-  onCheck: () => void;
-  onContinue: () => void;
-  onEscape: () => void;
-  onNavigateNext: () => void;
-  onNavigatePrev: () => void;
-  onNext: (() => void) | null;
-  onRestart: () => void;
-  onStartChallenge: (() => void) | null;
-  phase: PlayerPhase;
-}) {
+}: PlayerKeyboardParams) {
   useKeyboardCallback(
     "Enter",
     () => {
-      if (phase === "intro" && onStartChallenge) {
-        onStartChallenge();
-      } else if (phase === "playing" && hasAnswer) {
-        onCheck();
-      } else if (phase === "feedback") {
-        onContinue();
-      } else if (phase === "completed") {
-        if (onNext) {
-          onNext();
-        } else {
-          onEscape();
-        }
-      }
+      getEnterAction({
+        hasAnswer,
+        onCheck,
+        onContinue,
+        onEscape,
+        onNext,
+        onStartChallenge,
+        phase,
+      })?.();
     },
     { mode: "none" },
   );

--- a/apps/main/src/components/catalog/catalog-list.tsx
+++ b/apps/main/src/components/catalog/catalog-list.tsx
@@ -108,7 +108,7 @@ export function CatalogListContent({ className, ...props }: React.ComponentProps
   return (
     <ul
       {...props}
-      className={cn("-mt-3.5 flex flex-col", className)}
+      className={cn("flex flex-col", className)}
       data-slot="catalog-list-content"
       role="list"
     />

--- a/i18n.lock
+++ b/i18n.lock
@@ -415,11 +415,21 @@ checksums:
     Some%20of%20your%20stats%20went%20below%20zero./singular: bc281c87ae70abd076e3e73aa263ddc2
     Try%20Again/singular: d65fad81c5f8f90405b26bf6e5d70ab9
     Challenge%20Failed/singular: e9b1d1d02118f2e2ddc34907748955c4
+    Make%20choices./singular: 0861e9651cbff7146aee6cafb92128a8
+    Balance%20the%20outcome./singular: bce81c0b25b5ab019b5ce5dba5a12c3f
+    Challenge/singular: 7f333a59ee7a3596e27a2f8c3401b764
+    You'll%20face%20a%20series%20of%20decisions.%20Each%20one%20shifts%20your%20scores.%20Don't%20let%20any%20go%20negative./singular: 026dc19377a9b04a9bfce46cf8bcfa16
+    Starting%20scores/singular: 6a21f8424cdc75e477c3d7857a97db6d
+    Begin/singular: cc2a17a662cb60dd2d8335a2e8440997
+    Your%20scores/singular: 1700f65ead0647bc4876f4b3b6453a8b
     Restart/singular: bab6232e89f24e3129f8e48268739d5b
     Next/singular: 89ddbcf710eba274963494f312bdc8a9
     Sign%20up%20to%20track%20your%20progress/singular: 554ed29d9b8a243362c3b3374222af08
     Completed/singular: 0e4bbce9985f25eb673d9a054c8d5334
     correct/singular: 0c2df4a764cea47295c0b550477e8e29
+    Current%20dimension%20scores/singular: b3a4b7edbd41132e6fb349a6df24a33d
+    View%20stats/singular: 707f91e0ff65e7163c95900395dc0297
+    Stats/singular: 5cf8b052c89fa1b05397a956ebec69b2
     Not%20quite/singular: e570085e69662802acf485c4565e3e3e
     Outcome/singular: 4cfc7a40e384ea8b6658e8da6e351bf0
     Correct!/singular: dda1a98dc04fd9db252887ecf1765d41
@@ -459,7 +469,6 @@ checksums:
     Listening/singular: 9e680c44cd88a178b953349ed8881ef2
     Experience%20when%20to%20apply%20%7Btopic%7D%20through%20a%20real-world%20dialogue%20scenario./singular: d143d122b526618096d637288c66f50a
     Examples/singular: 9dacb7c56bc894e4bcad39f41265e3a0
-    Challenge/singular: 7f333a59ee7a3596e27a2f8c3401b764
     Practice%20%7Btopic%7D%20in%20context%20through%20a%20dialogue-based%20story%20set%20in%20real-world%20situations./singular: e1b3079ec8c6a2c89d20e5c7c48bfc59
     Story/singular: fabac3f62af801d429e2cd7115bf14c9
     Build%20your%20%7Btopic%7D%20vocabulary%20with%20new%20words%2C%20translations%2C%20and%20pronunciation./singular: 2c0f84dadf5fcbfb5842260046bfa956


### PR DESCRIPTION
## Summary

- Add intro phase before challenge activities with a game briefing explaining mechanics, starting scores, and a Begin button
- Add stats popover button in the header during challenge play for checking dimension scores at any time
- Add `"intro"` variant to dimension list for displaying starting scores on the briefing screen

## Test plan

- [x] Unit tests for reducer (intro phase, START_CHALLENGE action, restart skips intro)
- [x] Unit tests for keyboard hook (Enter on intro phase)
- [x] Unit tests for dimension inventory (status + intro variants)
- [x] E2E tests for intro screen, Begin button, Enter key, non-challenge skip, stats popover, accumulated stats, restart skips intro

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a challenge intro screen and an in‑play stats popover. Also refines Enter key behavior and cleans up catalog list spacing.

- New Features
  - Intro phase for challenge activities with a short briefing, starting scores, and a Begin button (Enter key also starts).
  - Header stats button during challenge play; popover shows current dimension totals with warning colors for zero/negative.
  - Flow tweaks: restart skips the intro; non-challenge activities start directly at the first step.

- Refactors
  - Reducer: adds an intro phase and START_CHALLENGE; collects dimensions at init.
  - Keyboard + view: extracted helper for Enter key (intro begin/check/continue/next), derived view state in the player shell, hid header/progress during intro; StageContent renders ChallengeIntro.
  - Inventory + UI: added “intro”/“status” variants with total color logic; removed negative margin from the catalog list.

<sup>Written for commit fd829f2af715d739ed2e1820b5e3bc0d4f9f5f01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

