### PR TITLE
feat(main): add fill-blank step UI with word bank

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -136,11 +136,12 @@
       }
     },
     {
-      "files": ["*.test.ts"],
+      "files": ["*.test.ts", "*.test.tsx"],
       "rules": {
         "eslint/max-lines": "off",
         "eslint/max-lines-per-function": "off",
         "eslint/max-statements": "off",
+        "eslint/no-empty-function": "off",
         "eslint/no-magic-numbers": "off",
         "import/no-namespace": "off",
         "typescript/no-explicit-any": "off",

--- a/apps/main/e2e/fill-blank-step.test.ts
+++ b/apps/main/e2e/fill-blank-step.test.ts
@@ -1,0 +1,303 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { expect, test } from "./fixtures";
+
+async function createFillBlankActivity(options: {
+  steps: { content: object; position: number }[];
+}) {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-fb-course-${uniqueId}`,
+    title: `E2E FB Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-fb-chapter-${uniqueId}`,
+    title: `E2E FB Chapter ${uniqueId}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    description: `E2E fb lesson ${uniqueId}`,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-fb-lesson-${uniqueId}`,
+    title: `E2E FB Lesson ${uniqueId}`,
+  });
+
+  const activity = await activityFixture({
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "background",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 0,
+    title: `E2E FB Activity ${uniqueId}`,
+  });
+
+  await Promise.all(
+    options.steps.map((step) =>
+      stepFixture({
+        activityId: activity.id,
+        content: step.content,
+        isPublished: true,
+        kind: "fillBlank",
+        position: step.position,
+      }),
+    ),
+  );
+
+  const url = `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/0`;
+
+  return { activity, chapter, course, lesson, uniqueId, url };
+}
+
+test.describe("Fill Blank Step", () => {
+  test("renders template text and word bank tiles", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createFillBlankActivity({
+      steps: [
+        {
+          content: {
+            answers: ["cat", "mat"],
+            distractors: ["dog"],
+            feedback: `Good job ${uniqueId}`,
+            question: `Fill the blanks ${uniqueId}`,
+            template: `The ${uniqueId} [BLANK] sat on the [BLANK]`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(page.getByText(new RegExp(`Fill the blanks ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`The ${uniqueId}`))).toBeVisible();
+
+    const wordBank = page.getByRole("group", { name: /word bank/i });
+    await expect(wordBank).toBeVisible();
+
+    await expect(wordBank.getByRole("button", { name: "cat" })).toBeVisible();
+    await expect(wordBank.getByRole("button", { name: "mat" })).toBeVisible();
+    await expect(wordBank.getByRole("button", { name: "dog" })).toBeVisible();
+  });
+
+  test("tapping a word places it in the first empty blank", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createFillBlankActivity({
+      steps: [
+        {
+          content: {
+            answers: ["sun"],
+            distractors: ["moon"],
+            feedback: `Feedback ${uniqueId}`,
+            template: `The ${uniqueId} [BLANK] is bright`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    const wordBank = page.getByRole("group", { name: /word bank/i });
+    await wordBank.getByRole("button", { name: "sun" }).click();
+
+    await expect(page.getByRole("button", { name: /blank 1: sun/i })).toBeVisible();
+  });
+
+  test("tapping a placed word returns it to the bank", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createFillBlankActivity({
+      steps: [
+        {
+          content: {
+            answers: ["rain"],
+            distractors: ["snow"],
+            feedback: `Feedback ${uniqueId}`,
+            template: `The ${uniqueId} [BLANK] falls`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    const wordBank = page.getByRole("group", { name: /word bank/i });
+    await wordBank.getByRole("button", { name: "rain" }).click();
+
+    const filledBlank = page.getByRole("button", { name: /blank 1: rain/i });
+    await expect(filledBlank).toBeVisible();
+
+    await filledBlank.click();
+
+    await expect(page.getByRole("button", { name: /blank 1: rain/i })).not.toBeVisible();
+    await expect(wordBank.getByRole("button", { name: "rain" })).not.toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  test("correct answer shows Correct! feedback", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createFillBlankActivity({
+      steps: [
+        {
+          content: {
+            answers: ["blue"],
+            distractors: ["red"],
+            feedback: `Well done ${uniqueId}`,
+            template: `The sky is [BLANK] ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const wordBank = page.getByRole("group", { name: /word bank/i });
+    await wordBank.getByRole("button", { name: "blue" }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByText(/correct!/i)).toBeVisible();
+    await expect(page.getByText(new RegExp(`Well done ${uniqueId}`))).toBeVisible();
+  });
+
+  test("incorrect answer shows Not quite", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createFillBlankActivity({
+      steps: [
+        {
+          content: {
+            answers: ["blue"],
+            distractors: ["red"],
+            feedback: `Try again ${uniqueId}`,
+            template: `The sky is [BLANK] ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const wordBank = page.getByRole("group", { name: /word bank/i });
+    await wordBank.getByRole("button", { name: "red" }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByText(/not quite/i)).toBeVisible();
+  });
+
+  test("check button disabled until all blanks filled", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createFillBlankActivity({
+      steps: [
+        {
+          content: {
+            answers: ["one", "two"],
+            distractors: ["three"],
+            feedback: `Feedback ${uniqueId}`,
+            template: `Count ${uniqueId} [BLANK] and [BLANK]`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const checkButton = page.getByRole("button", { name: /check/i });
+    await expect(checkButton).toBeDisabled();
+
+    const wordBank = page.getByRole("group", { name: /word bank/i });
+    await wordBank.getByRole("button", { name: "one" }).click();
+
+    await expect(checkButton).toBeDisabled();
+
+    await wordBank.getByRole("button", { name: "two" }).click();
+
+    await expect(checkButton).toBeEnabled();
+  });
+
+  test("clearing a blank disables Check button", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createFillBlankActivity({
+      steps: [
+        {
+          content: {
+            answers: ["fast"],
+            distractors: ["slow"],
+            feedback: `Feedback ${uniqueId}`,
+            template: `The car is [BLANK] ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const checkButton = page.getByRole("button", { name: /check/i });
+    const wordBank = page.getByRole("group", { name: /word bank/i });
+
+    await wordBank.getByRole("button", { name: "fast" }).click();
+    await expect(checkButton).toBeEnabled();
+
+    await page.getByRole("button", { name: /blank 1: fast/i }).click();
+    await expect(checkButton).toBeDisabled();
+  });
+
+  test("full flow: fill, check, continue, completion", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createFillBlankActivity({
+      steps: [
+        {
+          content: {
+            answers: ["world"],
+            distractors: ["earth"],
+            feedback: `Nice ${uniqueId}`,
+            template: `Hello [BLANK] ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const wordBank = page.getByRole("group", { name: /word bank/i });
+    await wordBank.getByRole("button", { name: "world" }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+    await expect(page.getByText(/correct!/i)).toBeVisible();
+
+    await page.getByRole("button", { name: /continue/i }).click();
+    await expect(page.getByText("1/1")).toBeVisible();
+    await expect(page.getByText(/correct/i)).toBeVisible();
+  });
+});

--- a/apps/main/src/components/activity-player/activity-player-shell.tsx
+++ b/apps/main/src/components/activity-player/activity-player-shell.tsx
@@ -68,8 +68,12 @@ export function ActivityPlayerShell({
   }, [router, lessonHref]);
 
   const handleSelectAnswer = useCallback(
-    (stepId: string, answer: SelectedAnswer) => {
-      dispatch({ answer, stepId, type: "SELECT_ANSWER" });
+    (stepId: string, answer: SelectedAnswer | null) => {
+      if (answer) {
+        dispatch({ answer, stepId, type: "SELECT_ANSWER" });
+      } else {
+        dispatch({ stepId, type: "CLEAR_ANSWER" });
+      }
     },
     [dispatch],
   );

--- a/apps/main/src/components/activity-player/fill-blank-step.test.tsx
+++ b/apps/main/src/components/activity-player/fill-blank-step.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { type ReactNode, StrictMode, useCallback, useState } from "react";
+import { type Mock, afterEach, describe, expect, it, vi } from "vitest";
+import { FillBlankStep } from "./fill-blank-step";
+import { type SelectedAnswer } from "./player-reducer";
+
+vi.mock("next-intl", () => ({
+  useExtracted: () => (value: string) => value,
+}));
+
+vi.mock("./user-name-context", () => ({
+  useReplaceName: () => (value: string) => value,
+}));
+
+vi.mock("@zoonk/utils/shuffle", () => ({
+  shuffle: <T,>(array: readonly T[]): T[] => [...array],
+}));
+
+function buildFillBlankStep(overrides: Record<string, unknown> = {}) {
+  return {
+    content: {
+      answers: ["alpha", "beta"],
+      distractors: ["gamma"],
+      feedback: "Good",
+      template: "Say [BLANK] then [BLANK]",
+    },
+    id: "step-fb",
+    kind: "fillBlank" as const,
+    position: 0,
+    sentence: null,
+    visualContent: null,
+    visualKind: null,
+    word: null,
+    ...overrides,
+  };
+}
+
+// Wrapper that holds real state, mimicking ActivityPlayerShell.
+// The bug triggers when onSelectAnswer dispatches a state update
+// to this parent while FillBlankStep's state updater is running.
+function ParentWithState({
+  children,
+}: {
+  children: (props: {
+    onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
+    selectedAnswer: SelectedAnswer | undefined;
+  }) => ReactNode;
+}) {
+  const [answers, setAnswers] = useState<Record<string, SelectedAnswer>>({});
+
+  const handleSelectAnswer = useCallback((stepId: string, answer: SelectedAnswer | null) => {
+    if (answer) {
+      setAnswers((prev) => ({ ...prev, [stepId]: answer }));
+    } else {
+      setAnswers((prev) => {
+        const { [stepId]: _, ...rest } = prev;
+        return rest;
+      });
+    }
+  }, []);
+
+  return (
+    <>{children({ onSelectAnswer: handleSelectAnswer, selectedAnswer: answers["step-fb"] })}</>
+  );
+}
+
+describe("fill in the blank step", () => {
+  let consoleErrorSpy: Mock;
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("filling last blank dispatches answer without triggering setState-in-render warning", () => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const step = buildFillBlankStep();
+
+    render(
+      <StrictMode>
+        <ParentWithState>
+          {({ onSelectAnswer, selectedAnswer }) => (
+            <FillBlankStep
+              onSelectAnswer={onSelectAnswer}
+              selectedAnswer={selectedAnswer}
+              step={step}
+            />
+          )}
+        </ParentWithState>
+      </StrictMode>,
+    );
+
+    const wordBank = screen.getByRole("group", { name: /word bank/i });
+    const buttons = [...wordBank.querySelectorAll("button")];
+    const alphaButton = buttons.find((button) => button.textContent === "alpha");
+    const betaButton = buttons.find((button) => button.textContent === "beta");
+
+    fireEvent.click(alphaButton!);
+    fireEvent.click(betaButton!);
+
+    const renderWarnings = consoleErrorSpy.mock.calls.filter((args: unknown[]) =>
+      String(args[0]).includes("Cannot update a component"),
+    );
+
+    expect(renderWarnings).toStrictEqual([]);
+  });
+});

--- a/apps/main/src/components/activity-player/fill-blank-step.tsx
+++ b/apps/main/src/components/activity-player/fill-blank-step.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { type SerializedStep } from "@/data/activities/prepare-activity-data";
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
+import { cn } from "@zoonk/ui/lib/utils";
+import { shuffle } from "@zoonk/utils/shuffle";
+import { useCallback, useMemo, useState } from "react";
+import { type SelectedAnswer } from "./player-reducer";
+import { InteractiveStepLayout } from "./step-layouts";
+import { useReplaceName } from "./user-name-context";
+
+function QuestionText({ children }: { children: React.ReactNode }) {
+  return <p className="text-base font-semibold">{children}</p>;
+}
+
+function BlankSlot({
+  index,
+  onRemove,
+  word,
+}: {
+  index: number;
+  onRemove: () => void;
+  word: string | null;
+}) {
+  if (word) {
+    return (
+      <button
+        aria-label={`Blank ${index + 1}: ${word}. Tap to remove.`}
+        className="border-primary/30 text-primary inline-flex min-w-16 items-center justify-center border-b-2 px-1 font-medium transition-all duration-150"
+        onClick={onRemove}
+        type="button"
+      >
+        {word}
+      </button>
+    );
+  }
+
+  return (
+    <span
+      aria-label={`Blank ${index + 1}`}
+      className="border-muted-foreground/30 inline-flex min-w-16 border-b-2"
+      role="img"
+    />
+  );
+}
+
+function TemplateText({
+  blanks,
+  onRemoveWord,
+  template,
+}: {
+  blanks: (string | null)[];
+  onRemoveWord: (blankIndex: number) => void;
+  template: string;
+}) {
+  const segments = template.split("[BLANK]");
+
+  return (
+    <p className="text-base leading-10">
+      {segments.map((segment, index) => (
+        <span key={`seg-${segment}-${index}`}>
+          {segment}
+
+          {index < segments.length - 1 ? (
+            <BlankSlot
+              index={index}
+              onRemove={() => onRemoveWord(index)}
+              word={blanks[index] ?? null}
+            />
+          ) : null}
+        </span>
+      ))}
+    </p>
+  );
+}
+
+function WordTile({
+  isUsed,
+  onPlace,
+  word,
+}: {
+  isUsed: boolean;
+  onPlace: () => void;
+  word: string;
+}) {
+  return (
+    <button
+      aria-disabled={isUsed}
+      className={cn(
+        "border-border min-h-11 rounded-lg border px-4 py-2.5 transition-all duration-150",
+        isUsed
+          ? "pointer-events-none opacity-50"
+          : "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]",
+      )}
+      onClick={onPlace}
+      tabIndex={isUsed ? -1 : 0}
+      type="button"
+    >
+      {word}
+    </button>
+  );
+}
+
+function WordBank({
+  blanks,
+  onPlaceWord,
+  words,
+}: {
+  blanks: (string | null)[];
+  onPlaceWord: (word: string) => void;
+  words: string[];
+}) {
+  const usedWords = blanks.filter(Boolean);
+
+  return (
+    <div aria-label="Word bank" className="flex flex-wrap gap-2.5" role="group">
+      {words.map((word, index) => {
+        const usedCount = usedWords.filter((used) => used === word).length;
+        const totalCount = words.slice(0, index + 1).filter((item) => item === word).length;
+        const isUsed = usedCount >= totalCount;
+
+        return (
+          <WordTile
+            isUsed={isUsed}
+            key={`${word}-${index}`}
+            onPlace={() => onPlaceWord(word)}
+            word={word}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function isComplete(blanks: (string | null)[]): blanks is string[] {
+  return blanks.every((blank) => blank !== null);
+}
+
+export function FillBlankStep({
+  onSelectAnswer,
+  selectedAnswer,
+  step,
+}: {
+  onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
+  selectedAnswer: SelectedAnswer | undefined;
+  step: SerializedStep;
+}) {
+  const content = parseStepContent("fillBlank", step.content);
+  const replaceName = useReplaceName();
+  const blankCount = content.answers.length;
+
+  const shuffledWords = useMemo(
+    () => shuffle([...content.answers, ...content.distractors]),
+    [content.answers, content.distractors],
+  );
+
+  const [blanks, setBlanks] = useState<(string | null)[]>(() =>
+    Array.from({ length: blankCount }, () => null),
+  );
+
+  const handlePlaceWord = useCallback(
+    (word: string) => {
+      const firstEmptyIndex = blanks.indexOf(null);
+
+      if (firstEmptyIndex === -1) {
+        return;
+      }
+
+      const next = [...blanks];
+      next[firstEmptyIndex] = word;
+      setBlanks(next);
+
+      if (isComplete(next)) {
+        onSelectAnswer(step.id, { kind: "fillBlank", userAnswers: next });
+      }
+    },
+    [blanks, onSelectAnswer, step.id],
+  );
+
+  const handleRemoveWord = useCallback(
+    (blankIndex: number) => {
+      if (!blanks[blankIndex]) {
+        return;
+      }
+
+      const next = [...blanks];
+      next[blankIndex] = null;
+      setBlanks(next);
+
+      if (selectedAnswer) {
+        onSelectAnswer(step.id, null);
+      }
+    },
+    [blanks, onSelectAnswer, selectedAnswer, step.id],
+  );
+
+  return (
+    <InteractiveStepLayout>
+      {content.question ? <QuestionText>{replaceName(content.question)}</QuestionText> : null}
+
+      <TemplateText blanks={blanks} onRemoveWord={handleRemoveWord} template={content.template} />
+
+      <WordBank blanks={blanks} onPlaceWord={handlePlaceWord} words={shuffledWords} />
+    </InteractiveStepLayout>
+  );
+}

--- a/apps/main/src/components/activity-player/fill-blank-step.tsx
+++ b/apps/main/src/components/activity-player/fill-blank-step.tsx
@@ -145,7 +145,7 @@ export function FillBlankStep({
   selectedAnswer: SelectedAnswer | undefined;
   step: SerializedStep;
 }) {
-  const content = parseStepContent("fillBlank", step.content);
+  const content = useMemo(() => parseStepContent("fillBlank", step.content), [step.content]);
   const replaceName = useReplaceName();
   const blankCount = content.answers.length;
 

--- a/apps/main/src/components/activity-player/player-reducer.test.ts
+++ b/apps/main/src/components/activity-player/player-reducer.test.ts
@@ -488,6 +488,38 @@ describe("RESTART", () => {
   });
 });
 
+describe("CLEAR_ANSWER", () => {
+  test("removes the selected answer for the given stepId", () => {
+    const state = buildState({
+      selectedAnswers: {
+        "step-1": multipleChoiceAnswer,
+        "step-2": { kind: "fillBlank", userAnswers: ["cat", "mat"] },
+      },
+    });
+    const next = playerReducer(state, { stepId: "step-1", type: "CLEAR_ANSWER" });
+    expect(next.selectedAnswers).toEqual({
+      "step-2": { kind: "fillBlank", userAnswers: ["cat", "mat"] },
+    });
+  });
+
+  test("no-ops when stepId is not in selectedAnswers", () => {
+    const state = buildState({
+      selectedAnswers: { "step-1": multipleChoiceAnswer },
+    });
+    const next = playerReducer(state, { stepId: "step-99", type: "CLEAR_ANSWER" });
+    expect(next.selectedAnswers).toEqual({ "step-1": multipleChoiceAnswer });
+  });
+
+  test("does not change phase or index", () => {
+    const state = buildState({
+      selectedAnswers: { "step-1": multipleChoiceAnswer },
+    });
+    const next = playerReducer(state, { stepId: "step-1", type: "CLEAR_ANSWER" });
+    expect(next.phase).toBe("playing");
+    expect(next.currentStepIndex).toBe(0);
+  });
+});
+
 describe("edge cases", () => {
   test("unknown action returns state unchanged", () => {
     const state = buildState();

--- a/apps/main/src/components/activity-player/player-reducer.ts
+++ b/apps/main/src/components/activity-player/player-reducer.ts
@@ -38,6 +38,7 @@ export type PlayerState = {
 
 export type PlayerAction =
   | { type: "SELECT_ANSWER"; stepId: string; answer: SelectedAnswer }
+  | { type: "CLEAR_ANSWER"; stepId: string }
   | { type: "CHECK_ANSWER"; stepId: string; result: AnswerResult; effects: ChallengeEffect[] }
   | { type: "CONTINUE" }
   | { type: "COMPLETE" }
@@ -121,6 +122,14 @@ function handleSelectAnswer(
     ...state,
     selectedAnswers: { ...state.selectedAnswers, [action.stepId]: action.answer },
   };
+}
+
+function handleClearAnswer(
+  state: PlayerState,
+  action: Extract<PlayerAction, { type: "CLEAR_ANSWER" }>,
+): PlayerState {
+  const { [action.stepId]: _, ...rest } = state.selectedAnswers;
+  return { ...state, selectedAnswers: rest };
 }
 
 function handleCheckAnswer(
@@ -225,6 +234,9 @@ export function playerReducer(state: PlayerState, action: PlayerAction): PlayerS
   switch (action.type) {
     case "SELECT_ANSWER":
       return handleSelectAnswer(state, action);
+
+    case "CLEAR_ANSWER":
+      return handleClearAnswer(state, action);
 
     case "CHECK_ANSWER":
       return handleCheckAnswer(state, action);

--- a/apps/main/src/components/activity-player/stage-content.tsx
+++ b/apps/main/src/components/activity-player/stage-content.tsx
@@ -41,7 +41,7 @@ export function StageContent({
   onNavigateNext: () => void;
   onNavigatePrev: () => void;
   onRestart: () => void;
-  onSelectAnswer: (stepId: string, answer: SelectedAnswer) => void;
+  onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
   onStartChallenge: () => void;
   results: Record<string, StepResult>;
   phase: PlayerPhase;

--- a/apps/main/src/components/activity-player/step-renderer.tsx
+++ b/apps/main/src/components/activity-player/step-renderer.tsx
@@ -3,6 +3,7 @@
 import { type SerializedStep } from "@/data/activities/prepare-activity-data";
 import { Button } from "@zoonk/ui/components/button";
 import { useExtracted } from "next-intl";
+import { FillBlankStep } from "./fill-blank-step";
 import { MultipleChoiceStep } from "./multiple-choice-step";
 import { type SelectedAnswer } from "./player-reducer";
 import { StaticStep } from "./static-step";
@@ -15,7 +16,7 @@ function PlaceholderInteractiveStep({
   selectedAnswer,
   step,
 }: {
-  onSelectAnswer: (stepId: string, answer: SelectedAnswer) => void;
+  onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
   selectedAnswer: SelectedAnswer | undefined;
   step: SerializedStep;
 }) {
@@ -52,7 +53,7 @@ export function StepRenderer({
   isFirst: boolean;
   onNavigateNext: () => void;
   onNavigatePrev: () => void;
-  onSelectAnswer: (stepId: string, answer: SelectedAnswer) => void;
+  onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
   selectedAnswer: SelectedAnswer | undefined;
   step: SerializedStep;
 }) {
@@ -78,6 +79,12 @@ export function StepRenderer({
         selectedAnswer={selectedAnswer}
         step={step}
       />
+    );
+  }
+
+  if (step.kind === "fillBlank") {
+    return (
+      <FillBlankStep onSelectAnswer={onSelectAnswer} selectedAnswer={selectedAnswer} step={step} />
     );
   }
 


### PR DESCRIPTION
## Summary

- Implement `FillBlankStep` component that parses `[BLANK]` templates into inline blank slots with a shuffled word bank
- Add `CLEAR_ANSWER` reducer action to handle answer deselection when removing a placed word
- Update `onSelectAnswer` prop chain to accept `null` for clearing answers
- Add regression test for React setState-in-render warning (StrictMode + real parent state)

## Test plan

- [x] Unit tests: 3 tests for `CLEAR_ANSWER` reducer, 1 component test for setState-in-render regression
- [x] E2E tests: 8 tests covering rendering, word placement/removal, correct/incorrect answers, Check button state, and full flow
- [x] All quality checks pass (lint, typecheck, knip, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds FillBlankStep with inline [BLANK] parsing and a stable shuffled word bank for tap-to-place and tap-to-remove. Adds CLEAR_ANSWER so removing a word clears the answer and keeps Check disabled until all blanks are filled.

- New Features
  - Render template blanks with accessible labels; used tiles are disabled to prevent duplicates.
  - onSelectAnswer now accepts null; ActivityPlayerShell dispatches SELECT_ANSWER/CLEAR_ANSWER; reducer adds CLEAR_ANSWER.
  - E2E coverage for render, placement/removal, correctness, button states, and full flow; regression test for StrictMode setState-in-render; test lint rules updated.

- Bug Fixes
  - Memoized parsed fill-blank content to prevent the word bank from reshuffling on state updates.

<sup>Written for commit 33d0472254f990a7243a9fd1467ee9ca0176f9ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

