### PR TITLE
feat(main): add match-columns and sort-order step UI

### DIFF
--- a/apps/main/e2e/match-columns-step.test.ts
+++ b/apps/main/e2e/match-columns-step.test.ts
@@ -1,0 +1,366 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { expect, test } from "./fixtures";
+
+async function createMatchColumnsActivity(options: {
+  steps: { content: object; position: number }[];
+}) {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-mc-course-${uniqueId}`,
+    title: `E2E MC Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-mc-chapter-${uniqueId}`,
+    title: `E2E MC Chapter ${uniqueId}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    description: `E2E mc lesson ${uniqueId}`,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-mc-lesson-${uniqueId}`,
+    title: `E2E MC Lesson ${uniqueId}`,
+  });
+
+  const activity = await activityFixture({
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "background",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 0,
+    title: `E2E MC Activity ${uniqueId}`,
+  });
+
+  await Promise.all(
+    options.steps.map((step) =>
+      stepFixture({
+        activityId: activity.id,
+        content: step.content,
+        isPublished: true,
+        kind: "matchColumns",
+        position: step.position,
+      }),
+    ),
+  );
+
+  const url = `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/0`;
+
+  return { activity, chapter, course, lesson, uniqueId, url };
+}
+
+test.describe("Match Columns Step", () => {
+  test("renders question and both columns", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMatchColumnsActivity({
+      steps: [
+        {
+          content: {
+            pairs: [
+              { left: `Sun ${uniqueId}`, right: `Star ${uniqueId}` },
+              { left: `Moon ${uniqueId}`, right: `Satellite ${uniqueId}` },
+            ],
+            question: `Match the pairs ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(page.getByText(new RegExp(`Match the pairs ${uniqueId}`))).toBeVisible();
+
+    const leftColumn = page.getByRole("group", { name: /left column/i });
+    await expect(leftColumn.getByRole("button", { name: `Sun ${uniqueId}` })).toBeVisible();
+    await expect(leftColumn.getByRole("button", { name: `Moon ${uniqueId}` })).toBeVisible();
+
+    const rightColumn = page.getByRole("group", { name: /right column/i });
+    await expect(rightColumn.getByRole("button", { name: `Star ${uniqueId}` })).toBeVisible();
+    await expect(rightColumn.getByRole("button", { name: `Satellite ${uniqueId}` })).toBeVisible();
+  });
+
+  test("tapping left item highlights it", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMatchColumnsActivity({
+      steps: [
+        {
+          content: {
+            pairs: [
+              { left: `Cat ${uniqueId}`, right: `Meow ${uniqueId}` },
+              { left: `Dog ${uniqueId}`, right: `Bark ${uniqueId}` },
+            ],
+            question: `Match sounds ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    const leftColumn = page.getByRole("group", { name: /left column/i });
+    const catButton = leftColumn.getByRole("button", { name: `Cat ${uniqueId}` });
+
+    await catButton.click();
+
+    await expect(catButton).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("tapping right item after selecting left creates a match", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMatchColumnsActivity({
+      steps: [
+        {
+          content: {
+            pairs: [
+              { left: `Apple ${uniqueId}`, right: `Fruit ${uniqueId}` },
+              { left: `Carrot ${uniqueId}`, right: `Veggie ${uniqueId}` },
+            ],
+            question: `Match categories ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    const leftColumn = page.getByRole("group", { name: /left column/i });
+    const rightColumn = page.getByRole("group", { name: /right column/i });
+
+    await leftColumn.getByRole("button", { name: `Apple ${uniqueId}` }).click();
+    await rightColumn.getByRole("button", { name: `Fruit ${uniqueId}` }).click();
+
+    await expect(
+      leftColumn.getByRole("button", {
+        name: new RegExp(`Apple ${uniqueId}.*matched.*Fruit ${uniqueId}`),
+      }),
+    ).toBeVisible();
+  });
+
+  test("tapping a matched pair unmatches it", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMatchColumnsActivity({
+      steps: [
+        {
+          content: {
+            pairs: [
+              { left: `Red ${uniqueId}`, right: `Color ${uniqueId}` },
+              { left: `Three ${uniqueId}`, right: `Number ${uniqueId}` },
+            ],
+            question: `Match types ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    const leftColumn = page.getByRole("group", { name: /left column/i });
+    const rightColumn = page.getByRole("group", { name: /right column/i });
+
+    await leftColumn.getByRole("button", { name: `Red ${uniqueId}` }).click();
+    await rightColumn.getByRole("button", { name: `Color ${uniqueId}` }).click();
+
+    // Tap the matched left item to unmatch
+    await leftColumn.getByRole("button", { name: new RegExp(`Red ${uniqueId}.*matched`) }).click();
+
+    // Should be back to unmatched state
+    await expect(leftColumn.getByRole("button", { name: `Red ${uniqueId}` })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  test("deselecting a left item", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMatchColumnsActivity({
+      steps: [
+        {
+          content: {
+            pairs: [
+              { left: `Hot ${uniqueId}`, right: `Cold ${uniqueId}` },
+              { left: `Big ${uniqueId}`, right: `Small ${uniqueId}` },
+            ],
+            question: `Match opposites ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    const leftColumn = page.getByRole("group", { name: /left column/i });
+    const hotButton = leftColumn.getByRole("button", { name: `Hot ${uniqueId}` });
+
+    await hotButton.click();
+    await expect(hotButton).toHaveAttribute("aria-pressed", "true");
+
+    await hotButton.click();
+    await expect(hotButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  test("check button disabled until all pairs matched", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMatchColumnsActivity({
+      steps: [
+        {
+          content: {
+            pairs: [
+              { left: `A ${uniqueId}`, right: `1 ${uniqueId}` },
+              { left: `B ${uniqueId}`, right: `2 ${uniqueId}` },
+            ],
+            question: `Match letters ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const checkButton = page.getByRole("button", { name: /check/i });
+    await expect(checkButton).toBeDisabled();
+
+    const leftColumn = page.getByRole("group", { name: /left column/i });
+    const rightColumn = page.getByRole("group", { name: /right column/i });
+
+    await leftColumn.getByRole("button", { name: `A ${uniqueId}` }).click();
+    await rightColumn.getByRole("button", { name: `1 ${uniqueId}` }).click();
+
+    await expect(checkButton).toBeDisabled();
+
+    await leftColumn.getByRole("button", { name: `B ${uniqueId}` }).click();
+    await rightColumn.getByRole("button", { name: `2 ${uniqueId}` }).click();
+
+    await expect(checkButton).toBeEnabled();
+  });
+
+  test("correct answer shows Correct! feedback", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMatchColumnsActivity({
+      steps: [
+        {
+          content: {
+            pairs: [
+              { left: `H2O ${uniqueId}`, right: `Water ${uniqueId}` },
+              { left: `NaCl ${uniqueId}`, right: `Salt ${uniqueId}` },
+            ],
+            question: `Match formulas ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const leftColumn = page.getByRole("group", { name: /left column/i });
+    const rightColumn = page.getByRole("group", { name: /right column/i });
+
+    await leftColumn.getByRole("button", { name: `H2O ${uniqueId}` }).click();
+    await rightColumn.getByRole("button", { name: `Water ${uniqueId}` }).click();
+
+    await leftColumn.getByRole("button", { name: `NaCl ${uniqueId}` }).click();
+    await rightColumn.getByRole("button", { name: `Salt ${uniqueId}` }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByText(/correct!/i)).toBeVisible();
+  });
+
+  test("incorrect answer shows Not quite feedback", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMatchColumnsActivity({
+      steps: [
+        {
+          content: {
+            pairs: [
+              { left: `Paris ${uniqueId}`, right: `France ${uniqueId}` },
+              { left: `Tokyo ${uniqueId}`, right: `Japan ${uniqueId}` },
+            ],
+            question: `Match capitals ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const leftColumn = page.getByRole("group", { name: /left column/i });
+    const rightColumn = page.getByRole("group", { name: /right column/i });
+
+    // Match incorrectly: Paris → Japan, Tokyo → France
+    await leftColumn.getByRole("button", { name: `Paris ${uniqueId}` }).click();
+    await rightColumn.getByRole("button", { name: `Japan ${uniqueId}` }).click();
+
+    await leftColumn.getByRole("button", { name: `Tokyo ${uniqueId}` }).click();
+    await rightColumn.getByRole("button", { name: `France ${uniqueId}` }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByText(/not quite/i)).toBeVisible();
+  });
+
+  test("full flow: match all, check, continue, completion", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMatchColumnsActivity({
+      steps: [
+        {
+          content: {
+            pairs: [
+              { left: `Dog ${uniqueId}`, right: `Woof ${uniqueId}` },
+              { left: `Cat ${uniqueId}`, right: `Meow ${uniqueId}` },
+            ],
+            question: `Match sounds ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const leftColumn = page.getByRole("group", { name: /left column/i });
+    const rightColumn = page.getByRole("group", { name: /right column/i });
+
+    await leftColumn.getByRole("button", { name: `Dog ${uniqueId}` }).click();
+    await rightColumn.getByRole("button", { name: `Woof ${uniqueId}` }).click();
+
+    await leftColumn.getByRole("button", { name: `Cat ${uniqueId}` }).click();
+    await rightColumn.getByRole("button", { name: `Meow ${uniqueId}` }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+    await expect(page.getByText(/correct!/i)).toBeVisible();
+
+    await page.getByRole("button", { name: /continue/i }).click();
+    await expect(page.getByText("1/1")).toBeVisible();
+    await expect(page.getByText(/correct/i)).toBeVisible();
+  });
+});

--- a/apps/main/e2e/sort-order-step.test.ts
+++ b/apps/main/e2e/sort-order-step.test.ts
@@ -1,0 +1,310 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { expect, test } from "./fixtures";
+
+async function createSortOrderActivity(options: {
+  steps: { content: object; position: number }[];
+}) {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-so-course-${uniqueId}`,
+    title: `E2E SO Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-so-chapter-${uniqueId}`,
+    title: `E2E SO Chapter ${uniqueId}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    description: `E2E so lesson ${uniqueId}`,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-so-lesson-${uniqueId}`,
+    title: `E2E SO Lesson ${uniqueId}`,
+  });
+
+  const activity = await activityFixture({
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "background",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 0,
+    title: `E2E SO Activity ${uniqueId}`,
+  });
+
+  await Promise.all(
+    options.steps.map((step) =>
+      stepFixture({
+        activityId: activity.id,
+        content: step.content,
+        isPublished: true,
+        kind: "sortOrder",
+        position: step.position,
+      }),
+    ),
+  );
+
+  const url = `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/0`;
+
+  return { activity, chapter, course, lesson, uniqueId, url };
+}
+
+test.describe("Sort Order Step", () => {
+  test("renders question, empty slots, and item tiles", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSortOrderActivity({
+      steps: [
+        {
+          content: {
+            feedback: `Great ${uniqueId}`,
+            items: [`First ${uniqueId}`, `Second ${uniqueId}`, `Third ${uniqueId}`],
+            question: `Sort these items ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(page.getByText(new RegExp(`Sort these items ${uniqueId}`))).toBeVisible();
+
+    const slotList = page.getByRole("list", { name: /answer slots/i });
+    await expect(slotList).toBeVisible();
+
+    const itemPool = page.getByRole("group", { name: /available items/i });
+    await expect(itemPool.getByRole("button", { name: `First ${uniqueId}` })).toBeVisible();
+    await expect(itemPool.getByRole("button", { name: `Second ${uniqueId}` })).toBeVisible();
+    await expect(itemPool.getByRole("button", { name: `Third ${uniqueId}` })).toBeVisible();
+  });
+
+  test("tapping an item places it in the first empty slot", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSortOrderActivity({
+      steps: [
+        {
+          content: {
+            feedback: `Feedback ${uniqueId}`,
+            items: [`Alpha ${uniqueId}`, `Beta ${uniqueId}`],
+            question: `Order ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    const itemPool = page.getByRole("group", { name: /available items/i });
+    await itemPool.getByRole("button", { name: `Alpha ${uniqueId}` }).click();
+
+    await expect(
+      page.getByRole("button", { name: new RegExp(`Slot 1.*Alpha ${uniqueId}`) }),
+    ).toBeVisible();
+  });
+
+  test("tapping a filled slot returns item to pool", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSortOrderActivity({
+      steps: [
+        {
+          content: {
+            feedback: `Feedback ${uniqueId}`,
+            items: [`Uno ${uniqueId}`, `Dos ${uniqueId}`],
+            question: `Order ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    const itemPool = page.getByRole("group", { name: /available items/i });
+    await itemPool.getByRole("button", { name: `Uno ${uniqueId}` }).click();
+
+    const filledSlot = page.getByRole("button", { name: new RegExp(`Slot 1.*Uno ${uniqueId}`) });
+    await expect(filledSlot).toBeVisible();
+
+    await filledSlot.click();
+
+    await expect(
+      page.getByRole("button", { name: new RegExp(`Slot 1.*Uno ${uniqueId}`) }),
+    ).not.toBeVisible();
+
+    await expect(itemPool.getByRole("button", { name: `Uno ${uniqueId}` })).not.toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  test("check button disabled until all slots filled", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSortOrderActivity({
+      steps: [
+        {
+          content: {
+            feedback: `Feedback ${uniqueId}`,
+            items: [`X ${uniqueId}`, `Y ${uniqueId}`],
+            question: `Order ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const checkButton = page.getByRole("button", { name: /check/i });
+    await expect(checkButton).toBeDisabled();
+
+    const itemPool = page.getByRole("group", { name: /available items/i });
+    await itemPool.getByRole("button", { name: `X ${uniqueId}` }).click();
+
+    await expect(checkButton).toBeDisabled();
+
+    await itemPool.getByRole("button", { name: `Y ${uniqueId}` }).click();
+
+    await expect(checkButton).toBeEnabled();
+  });
+
+  test("clearing a slot re-disables Check button", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSortOrderActivity({
+      steps: [
+        {
+          content: {
+            feedback: `Feedback ${uniqueId}`,
+            items: [`One ${uniqueId}`, `Two ${uniqueId}`],
+            question: `Order ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const checkButton = page.getByRole("button", { name: /check/i });
+    const itemPool = page.getByRole("group", { name: /available items/i });
+
+    await itemPool.getByRole("button", { name: `One ${uniqueId}` }).click();
+    await itemPool.getByRole("button", { name: `Two ${uniqueId}` }).click();
+
+    await expect(checkButton).toBeEnabled();
+
+    await page.getByRole("button", { name: new RegExp(`Slot 1.*One ${uniqueId}`) }).click();
+
+    await expect(checkButton).toBeDisabled();
+  });
+
+  test("correct answer shows feedback", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSortOrderActivity({
+      steps: [
+        {
+          content: {
+            feedback: `Well done ${uniqueId}`,
+            items: [`Step1 ${uniqueId}`, `Step2 ${uniqueId}`],
+            question: `Order correctly ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const itemPool = page.getByRole("group", { name: /available items/i });
+
+    // Place in correct order
+    await itemPool.getByRole("button", { name: `Step1 ${uniqueId}` }).click();
+    await itemPool.getByRole("button", { name: `Step2 ${uniqueId}` }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByText(/correct!/i)).toBeVisible();
+    await expect(page.getByText(new RegExp(`Well done ${uniqueId}`))).toBeVisible();
+  });
+
+  test("incorrect answer shows Not quite", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSortOrderActivity({
+      steps: [
+        {
+          content: {
+            feedback: `Try again ${uniqueId}`,
+            items: [`First ${uniqueId}`, `Second ${uniqueId}`],
+            question: `Order ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const itemPool = page.getByRole("group", { name: /available items/i });
+
+    // Place in wrong order
+    await itemPool.getByRole("button", { name: `Second ${uniqueId}` }).click();
+    await itemPool.getByRole("button", { name: `First ${uniqueId}` }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByText(/not quite/i)).toBeVisible();
+  });
+
+  test("full flow: place all, check, continue, completion", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSortOrderActivity({
+      steps: [
+        {
+          content: {
+            feedback: `Nice ${uniqueId}`,
+            items: [`A ${uniqueId}`, `B ${uniqueId}`],
+            question: `Sort ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const itemPool = page.getByRole("group", { name: /available items/i });
+
+    await itemPool.getByRole("button", { name: `A ${uniqueId}` }).click();
+    await itemPool.getByRole("button", { name: `B ${uniqueId}` }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+    await expect(page.getByText(/correct!/i)).toBeVisible();
+
+    await page.getByRole("button", { name: /continue/i }).click();
+    await expect(page.getByText("1/1")).toBeVisible();
+    await expect(page.getByText(/correct/i)).toBeVisible();
+  });
+});

--- a/apps/main/e2e/sort-order-step.test.ts
+++ b/apps/main/e2e/sort-order-step.test.ts
@@ -253,16 +253,16 @@ test.describe("Sort Order Step", () => {
     // Custom feedback is shown
     await expect(page.getByText(new RegExp(`Well done ${uniqueId}`))).toBeVisible();
 
-    // Items show correct result state
+    // Items show correct result state (list reorders to correct order)
     await expect(
-      itemList.getByRole("button", { name: new RegExp(`Position 1.*Step1 ${uniqueId}.*Correct`) }),
+      itemList.getByRole("button", { name: new RegExp(`Step1 ${uniqueId}.*Correct`) }),
     ).toBeVisible();
     await expect(
-      itemList.getByRole("button", { name: new RegExp(`Position 2.*Step2 ${uniqueId}.*Correct`) }),
+      itemList.getByRole("button", { name: new RegExp(`Step2 ${uniqueId}.*Correct`) }),
     ).toBeVisible();
   });
 
-  test("incorrect answer shows inline expected hints", async ({ page }) => {
+  test("incorrect answer reorders list to correct order with red indicators", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const { url } = await createSortOrderActivity({
       steps: [
@@ -292,16 +292,16 @@ test.describe("Sort Order Step", () => {
 
     await page.getByRole("button", { name: /check/i }).click();
 
-    // Shows inline expected hints instead of "Correct order:" list
-    await expect(page.getByText(new RegExp(`Expected: "First ${uniqueId}"`))).toBeVisible();
-    await expect(page.getByText(new RegExp(`Expected: "Second ${uniqueId}"`))).toBeVisible();
+    // List reorders to correct order with incorrect indicators
+    await expect(
+      itemList.getByRole("button", { name: new RegExp(`First ${uniqueId}.*Incorrect`) }),
+    ).toBeVisible();
+    await expect(
+      itemList.getByRole("button", { name: new RegExp(`Second ${uniqueId}.*Incorrect`) }),
+    ).toBeVisible();
 
     // Custom feedback shown
     await expect(page.getByText(new RegExp(`Try again ${uniqueId}`))).toBeVisible();
-
-    // No "Correct order:" list or "Not quite" visible text
-    await expect(page.getByText(/correct order:/i)).not.toBeVisible();
-    await expect(page.getByText(/not quite/i)).not.toBeVisible();
   });
 
   test("continue button appears after checking", async ({ page }) => {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1277,7 +1277,6 @@ msgid "Stats"
 msgstr "Stats"
 
 #: src/components/activity-player/feedback-screen.tsx
-#: src/components/activity-player/match-columns-step.tsx
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "++l7ni"
 msgid "Not quite"
@@ -1289,7 +1288,6 @@ msgid "Outcome"
 msgstr "Outcome"
 
 #: src/components/activity-player/feedback-screen.tsx
-#: src/components/activity-player/match-columns-step.tsx
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "xmF49T"
 msgid "Correct!"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1291,6 +1291,36 @@ msgctxt "xmF49T"
 msgid "Correct!"
 msgstr "Correct!"
 
+#: src/components/activity-player/fill-blank-step.tsx
+msgctxt "e7WNdK"
+msgid "Word bank"
+msgstr "Word bank"
+
+#: src/components/activity-player/fill-blank-step.tsx
+msgctxt "FmmJ/j"
+msgid "Blank {position}"
+msgstr "Blank {position}"
+
+#: src/components/activity-player/fill-blank-step.tsx
+msgctxt "wUEGVH"
+msgid "Blank {position}: {item}. Tap to remove."
+msgstr "Blank {position}: {item}. Tap to remove."
+
+#: src/components/activity-player/match-columns-step.tsx
+msgctxt "FiksC2"
+msgid "Right column"
+msgstr "Right column"
+
+#: src/components/activity-player/match-columns-step.tsx
+msgctxt "HqBZKC"
+msgid "Left column"
+msgstr "Left column"
+
+#: src/components/activity-player/match-columns-step.tsx
+msgctxt "JF7Y01"
+msgid "{item}, matched with {match}. Tap to unmatch."
+msgstr "{item}, matched with {match}. Tap to unmatch."
+
 #: src/components/activity-player/multiple-choice-step.tsx
 msgctxt "HHBtl4"
 msgid "What do you say?"
@@ -1320,6 +1350,26 @@ msgstr "Step navigation"
 msgctxt "rbrahO"
 msgid "Close"
 msgstr "Close"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "7Af5sM"
+msgid "Slot {position}"
+msgstr "Slot {position}"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "fXxL3z"
+msgid "Available items"
+msgstr "Available items"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "KoFztx"
+msgid "Slot {position}: {item}. Tap to remove."
+msgstr "Slot {position}: {item}. Tap to remove."
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "yZaQVq"
+msgid "Answer slots"
+msgstr "Answer slots"
 
 #: src/components/activity-player/step-renderer.tsx
 msgctxt "4pTU5S"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1277,7 +1277,6 @@ msgid "Stats"
 msgstr "Stats"
 
 #: src/components/activity-player/feedback-screen.tsx
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "++l7ni"
 msgid "Not quite"
 msgstr "Not quite"
@@ -1288,7 +1287,6 @@ msgid "Outcome"
 msgstr "Outcome"
 
 #: src/components/activity-player/feedback-screen.tsx
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "xmF49T"
 msgid "Correct!"
 msgstr "Correct!"
@@ -1344,44 +1342,44 @@ msgid "Close"
 msgstr "Close"
 
 #: src/components/activity-player/sort-order-step.tsx
+msgctxt "/CFOL2"
+msgid "Tap items in the correct order"
+msgstr "Tap items in the correct order"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "1za4AW"
+msgid "{item}. Tap to select as position {nextPosition}."
+msgstr "{item}. Tap to select as position {nextPosition}."
+
+#: src/components/activity-player/sort-order-step.tsx
 msgctxt "6NoIUl"
 msgid "Correct"
 msgstr "Correct"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "7Af5sM"
-msgid "Slot {position}"
-msgstr "Slot {position}"
+msgctxt "oqRIWD"
+msgid "Position {position}: {item}. {result}."
+msgstr "Position {position}: {item}. {result}."
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "8PMLyr"
-msgid "Slot {position}: {item}. {result}."
-msgstr "Slot {position}: {item}. {result}."
+msgctxt "p5llOK"
+msgid "Sort items"
+msgstr "Sort items"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "fXxL3z"
-msgid "Available items"
-msgstr "Available items"
+msgctxt "rNTHBv"
+msgid "Expected: \"{expectedItem}\""
+msgstr "Expected: \"{expectedItem}\""
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "KoFztx"
-msgid "Slot {position}: {item}. Tap to remove."
-msgstr "Slot {position}: {item}. Tap to remove."
-
-#: src/components/activity-player/sort-order-step.tsx
-msgctxt "VA8c/A"
-msgid "Correct order:"
-msgstr "Correct order:"
+msgctxt "vPyO9S"
+msgid "Position {position}: {item}. Tap to remove."
+msgstr "Position {position}: {item}. Tap to remove."
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "Ypr9T5"
 msgid "Incorrect"
 msgstr "Incorrect"
-
-#: src/components/activity-player/sort-order-step.tsx
-msgctxt "yZaQVq"
-msgid "Answer slots"
-msgstr "Answer slots"
 
 #: src/components/activity-player/step-renderer.tsx
 msgctxt "4pTU5S"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1357,19 +1357,14 @@ msgid "Correct"
 msgstr "Correct"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "oqRIWD"
-msgid "Position {position}: {item}. {result}."
-msgstr "Position {position}: {item}. {result}."
+msgctxt "hFFOe+"
+msgid "{item}. {result}."
+msgstr "{item}. {result}."
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "p5llOK"
 msgid "Sort items"
 msgstr "Sort items"
-
-#: src/components/activity-player/sort-order-step.tsx
-msgctxt "rNTHBv"
-msgid "Expected: \"{expectedItem}\""
-msgstr "Expected: \"{expectedItem}\""
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "vPyO9S"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1277,6 +1277,8 @@ msgid "Stats"
 msgstr "Stats"
 
 #: src/components/activity-player/feedback-screen.tsx
+#: src/components/activity-player/match-columns-step.tsx
+#: src/components/activity-player/sort-order-step.tsx
 msgctxt "++l7ni"
 msgid "Not quite"
 msgstr "Not quite"
@@ -1287,6 +1289,8 @@ msgid "Outcome"
 msgstr "Outcome"
 
 #: src/components/activity-player/feedback-screen.tsx
+#: src/components/activity-player/match-columns-step.tsx
+#: src/components/activity-player/sort-order-step.tsx
 msgctxt "xmF49T"
 msgid "Correct!"
 msgstr "Correct!"
@@ -1307,19 +1311,9 @@ msgid "Blank {position}: {item}. Tap to remove."
 msgstr "Blank {position}: {item}. Tap to remove."
 
 #: src/components/activity-player/match-columns-step.tsx
-msgctxt "FiksC2"
-msgid "Right column"
-msgstr "Right column"
-
-#: src/components/activity-player/match-columns-step.tsx
-msgctxt "HqBZKC"
-msgid "Left column"
-msgstr "Left column"
-
-#: src/components/activity-player/match-columns-step.tsx
-msgctxt "JF7Y01"
-msgid "{item}, matched with {match}. Tap to unmatch."
-msgstr "{item}, matched with {match}. Tap to unmatch."
+msgctxt "ja1JDt"
+msgid "All pairs matched. Press Check to continue."
+msgstr "All pairs matched. Press Check to continue."
 
 #: src/components/activity-player/multiple-choice-step.tsx
 msgctxt "HHBtl4"
@@ -1352,9 +1346,19 @@ msgid "Close"
 msgstr "Close"
 
 #: src/components/activity-player/sort-order-step.tsx
+msgctxt "6NoIUl"
+msgid "Correct"
+msgstr "Correct"
+
+#: src/components/activity-player/sort-order-step.tsx
 msgctxt "7Af5sM"
 msgid "Slot {position}"
 msgstr "Slot {position}"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "8PMLyr"
+msgid "Slot {position}: {item}. {result}."
+msgstr "Slot {position}: {item}. {result}."
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "fXxL3z"
@@ -1365,6 +1369,16 @@ msgstr "Available items"
 msgctxt "KoFztx"
 msgid "Slot {position}: {item}. Tap to remove."
 msgstr "Slot {position}: {item}. Tap to remove."
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "VA8c/A"
+msgid "Correct order:"
+msgstr "Correct order:"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "Ypr9T5"
+msgid "Incorrect"
+msgstr "Incorrect"
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "yZaQVq"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1277,6 +1277,8 @@ msgid "Stats"
 msgstr "Estadísticas"
 
 #: src/components/activity-player/feedback-screen.tsx
+#: src/components/activity-player/match-columns-step.tsx
+#: src/components/activity-player/sort-order-step.tsx
 msgctxt "++l7ni"
 msgid "Not quite"
 msgstr "No del todo"
@@ -1287,6 +1289,8 @@ msgid "Outcome"
 msgstr "Resultado"
 
 #: src/components/activity-player/feedback-screen.tsx
+#: src/components/activity-player/match-columns-step.tsx
+#: src/components/activity-player/sort-order-step.tsx
 msgctxt "xmF49T"
 msgid "Correct!"
 msgstr "¡Correcto!"
@@ -1307,19 +1311,9 @@ msgid "Blank {position}: {item}. Tap to remove."
 msgstr "Espacio {position}: {item}. Toca para quitar."
 
 #: src/components/activity-player/match-columns-step.tsx
-msgctxt "FiksC2"
-msgid "Right column"
-msgstr "Columna derecha"
-
-#: src/components/activity-player/match-columns-step.tsx
-msgctxt "HqBZKC"
-msgid "Left column"
-msgstr "Columna izquierda"
-
-#: src/components/activity-player/match-columns-step.tsx
-msgctxt "JF7Y01"
-msgid "{item}, matched with {match}. Tap to unmatch."
-msgstr "{item}, emparejado con {match}. Toca para desemparejar."
+msgctxt "ja1JDt"
+msgid "All pairs matched. Press Check to continue."
+msgstr "Todos los pares coinciden. Presiona Verificar para continuar."
 
 #: src/components/activity-player/multiple-choice-step.tsx
 msgctxt "HHBtl4"
@@ -1352,9 +1346,19 @@ msgid "Close"
 msgstr "Cerrar"
 
 #: src/components/activity-player/sort-order-step.tsx
+msgctxt "6NoIUl"
+msgid "Correct"
+msgstr "Correcto"
+
+#: src/components/activity-player/sort-order-step.tsx
 msgctxt "7Af5sM"
 msgid "Slot {position}"
 msgstr "Casilla {position}"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "8PMLyr"
+msgid "Slot {position}: {item}. {result}."
+msgstr "Casilla {position}: {item}. {result}."
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "fXxL3z"
@@ -1365,6 +1369,16 @@ msgstr "Elementos disponibles"
 msgctxt "KoFztx"
 msgid "Slot {position}: {item}. Tap to remove."
 msgstr "Casilla {position}: {item}. Toca para quitar."
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "VA8c/A"
+msgid "Correct order:"
+msgstr "Orden correcto:"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "Ypr9T5"
+msgid "Incorrect"
+msgstr "Incorrecto"
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "yZaQVq"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1291,6 +1291,36 @@ msgctxt "xmF49T"
 msgid "Correct!"
 msgstr "¡Correcto!"
 
+#: src/components/activity-player/fill-blank-step.tsx
+msgctxt "e7WNdK"
+msgid "Word bank"
+msgstr "Banco de palabras"
+
+#: src/components/activity-player/fill-blank-step.tsx
+msgctxt "FmmJ/j"
+msgid "Blank {position}"
+msgstr "Espacio {position}"
+
+#: src/components/activity-player/fill-blank-step.tsx
+msgctxt "wUEGVH"
+msgid "Blank {position}: {item}. Tap to remove."
+msgstr "Espacio {position}: {item}. Toca para quitar."
+
+#: src/components/activity-player/match-columns-step.tsx
+msgctxt "FiksC2"
+msgid "Right column"
+msgstr "Columna derecha"
+
+#: src/components/activity-player/match-columns-step.tsx
+msgctxt "HqBZKC"
+msgid "Left column"
+msgstr "Columna izquierda"
+
+#: src/components/activity-player/match-columns-step.tsx
+msgctxt "JF7Y01"
+msgid "{item}, matched with {match}. Tap to unmatch."
+msgstr "{item}, emparejado con {match}. Toca para desemparejar."
+
 #: src/components/activity-player/multiple-choice-step.tsx
 msgctxt "HHBtl4"
 msgid "What do you say?"
@@ -1320,6 +1350,26 @@ msgstr "Navegación de pasos"
 msgctxt "rbrahO"
 msgid "Close"
 msgstr "Cerrar"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "7Af5sM"
+msgid "Slot {position}"
+msgstr "Casilla {position}"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "fXxL3z"
+msgid "Available items"
+msgstr "Elementos disponibles"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "KoFztx"
+msgid "Slot {position}: {item}. Tap to remove."
+msgstr "Casilla {position}: {item}. Toca para quitar."
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "yZaQVq"
+msgid "Answer slots"
+msgstr "Casillas de respuesta"
 
 #: src/components/activity-player/step-renderer.tsx
 msgctxt "4pTU5S"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1277,7 +1277,6 @@ msgid "Stats"
 msgstr "Estadísticas"
 
 #: src/components/activity-player/feedback-screen.tsx
-#: src/components/activity-player/match-columns-step.tsx
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "++l7ni"
 msgid "Not quite"
@@ -1289,7 +1288,6 @@ msgid "Outcome"
 msgstr "Resultado"
 
 #: src/components/activity-player/feedback-screen.tsx
-#: src/components/activity-player/match-columns-step.tsx
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "xmF49T"
 msgid "Correct!"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1277,7 +1277,6 @@ msgid "Stats"
 msgstr "Estadísticas"
 
 #: src/components/activity-player/feedback-screen.tsx
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "++l7ni"
 msgid "Not quite"
 msgstr "No del todo"
@@ -1288,7 +1287,6 @@ msgid "Outcome"
 msgstr "Resultado"
 
 #: src/components/activity-player/feedback-screen.tsx
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "xmF49T"
 msgid "Correct!"
 msgstr "¡Correcto!"
@@ -1344,44 +1342,44 @@ msgid "Close"
 msgstr "Cerrar"
 
 #: src/components/activity-player/sort-order-step.tsx
+msgctxt "/CFOL2"
+msgid "Tap items in the correct order"
+msgstr "Toca los elementos en el orden correcto"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "1za4AW"
+msgid "{item}. Tap to select as position {nextPosition}."
+msgstr "{item}. Toca para seleccionar como posición {nextPosition}."
+
+#: src/components/activity-player/sort-order-step.tsx
 msgctxt "6NoIUl"
 msgid "Correct"
 msgstr "Correcto"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "7Af5sM"
-msgid "Slot {position}"
-msgstr "Casilla {position}"
+msgctxt "oqRIWD"
+msgid "Position {position}: {item}. {result}."
+msgstr "Posición {position}: {item}. {result}."
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "8PMLyr"
-msgid "Slot {position}: {item}. {result}."
-msgstr "Casilla {position}: {item}. {result}."
+msgctxt "p5llOK"
+msgid "Sort items"
+msgstr "Ordenar elementos"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "fXxL3z"
-msgid "Available items"
-msgstr "Elementos disponibles"
+msgctxt "rNTHBv"
+msgid "Expected: \"{expectedItem}\""
+msgstr "Esperado: \"{expectedItem}\""
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "KoFztx"
-msgid "Slot {position}: {item}. Tap to remove."
-msgstr "Casilla {position}: {item}. Toca para quitar."
-
-#: src/components/activity-player/sort-order-step.tsx
-msgctxt "VA8c/A"
-msgid "Correct order:"
-msgstr "Orden correcto:"
+msgctxt "vPyO9S"
+msgid "Position {position}: {item}. Tap to remove."
+msgstr "Posición {position}: {item}. Toca para quitar."
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "Ypr9T5"
 msgid "Incorrect"
 msgstr "Incorrecto"
-
-#: src/components/activity-player/sort-order-step.tsx
-msgctxt "yZaQVq"
-msgid "Answer slots"
-msgstr "Casillas de respuesta"
 
 #: src/components/activity-player/step-renderer.tsx
 msgctxt "4pTU5S"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1357,19 +1357,14 @@ msgid "Correct"
 msgstr "Correcto"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "oqRIWD"
-msgid "Position {position}: {item}. {result}."
-msgstr "Posición {position}: {item}. {result}."
+msgctxt "hFFOe+"
+msgid "{item}. {result}."
+msgstr "{item}. {result}."
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "p5llOK"
 msgid "Sort items"
 msgstr "Ordenar elementos"
-
-#: src/components/activity-player/sort-order-step.tsx
-msgctxt "rNTHBv"
-msgid "Expected: \"{expectedItem}\""
-msgstr "Esperado: \"{expectedItem}\""
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "vPyO9S"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1357,19 +1357,14 @@ msgid "Correct"
 msgstr "Correto"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "oqRIWD"
-msgid "Position {position}: {item}. {result}."
-msgstr "Posição {position}: {item}. {result}."
+msgctxt "hFFOe+"
+msgid "{item}. {result}."
+msgstr "{item}. {result}."
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "p5llOK"
 msgid "Sort items"
 msgstr "Ordenar itens"
-
-#: src/components/activity-player/sort-order-step.tsx
-msgctxt "rNTHBv"
-msgid "Expected: \"{expectedItem}\""
-msgstr "Esperado: \"{expectedItem}\""
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "vPyO9S"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1277,6 +1277,8 @@ msgid "Stats"
 msgstr "Estatísticas"
 
 #: src/components/activity-player/feedback-screen.tsx
+#: src/components/activity-player/match-columns-step.tsx
+#: src/components/activity-player/sort-order-step.tsx
 msgctxt "++l7ni"
 msgid "Not quite"
 msgstr "Não exatamente"
@@ -1287,6 +1289,8 @@ msgid "Outcome"
 msgstr "Resultado"
 
 #: src/components/activity-player/feedback-screen.tsx
+#: src/components/activity-player/match-columns-step.tsx
+#: src/components/activity-player/sort-order-step.tsx
 msgctxt "xmF49T"
 msgid "Correct!"
 msgstr "Correto!"
@@ -1307,19 +1311,9 @@ msgid "Blank {position}: {item}. Tap to remove."
 msgstr "Espaço {position}: {item}. Toque para remover."
 
 #: src/components/activity-player/match-columns-step.tsx
-msgctxt "FiksC2"
-msgid "Right column"
-msgstr "Coluna direita"
-
-#: src/components/activity-player/match-columns-step.tsx
-msgctxt "HqBZKC"
-msgid "Left column"
-msgstr "Coluna esquerda"
-
-#: src/components/activity-player/match-columns-step.tsx
-msgctxt "JF7Y01"
-msgid "{item}, matched with {match}. Tap to unmatch."
-msgstr "{item}, combinado com {match}. Toque para desfazer."
+msgctxt "ja1JDt"
+msgid "All pairs matched. Press Check to continue."
+msgstr "Todos os pares combinados. Pressione Verificar para continuar."
 
 #: src/components/activity-player/multiple-choice-step.tsx
 msgctxt "HHBtl4"
@@ -1352,9 +1346,19 @@ msgid "Close"
 msgstr "Fechar"
 
 #: src/components/activity-player/sort-order-step.tsx
+msgctxt "6NoIUl"
+msgid "Correct"
+msgstr "Correto"
+
+#: src/components/activity-player/sort-order-step.tsx
 msgctxt "7Af5sM"
 msgid "Slot {position}"
 msgstr "Posição {position}"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "8PMLyr"
+msgid "Slot {position}: {item}. {result}."
+msgstr "Posição {position}: {item}. {result}."
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "fXxL3z"
@@ -1365,6 +1369,16 @@ msgstr "Itens disponíveis"
 msgctxt "KoFztx"
 msgid "Slot {position}: {item}. Tap to remove."
 msgstr "Posição {position}: {item}. Toque para remover."
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "VA8c/A"
+msgid "Correct order:"
+msgstr "Ordem correta:"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "Ypr9T5"
+msgid "Incorrect"
+msgstr "Incorreto"
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "yZaQVq"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1291,6 +1291,36 @@ msgctxt "xmF49T"
 msgid "Correct!"
 msgstr "Correto!"
 
+#: src/components/activity-player/fill-blank-step.tsx
+msgctxt "e7WNdK"
+msgid "Word bank"
+msgstr "Banco de palavras"
+
+#: src/components/activity-player/fill-blank-step.tsx
+msgctxt "FmmJ/j"
+msgid "Blank {position}"
+msgstr "Espaço {position}"
+
+#: src/components/activity-player/fill-blank-step.tsx
+msgctxt "wUEGVH"
+msgid "Blank {position}: {item}. Tap to remove."
+msgstr "Espaço {position}: {item}. Toque para remover."
+
+#: src/components/activity-player/match-columns-step.tsx
+msgctxt "FiksC2"
+msgid "Right column"
+msgstr "Coluna direita"
+
+#: src/components/activity-player/match-columns-step.tsx
+msgctxt "HqBZKC"
+msgid "Left column"
+msgstr "Coluna esquerda"
+
+#: src/components/activity-player/match-columns-step.tsx
+msgctxt "JF7Y01"
+msgid "{item}, matched with {match}. Tap to unmatch."
+msgstr "{item}, combinado com {match}. Toque para desfazer."
+
 #: src/components/activity-player/multiple-choice-step.tsx
 msgctxt "HHBtl4"
 msgid "What do you say?"
@@ -1320,6 +1350,26 @@ msgstr "Navegação de etapas"
 msgctxt "rbrahO"
 msgid "Close"
 msgstr "Fechar"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "7Af5sM"
+msgid "Slot {position}"
+msgstr "Posição {position}"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "fXxL3z"
+msgid "Available items"
+msgstr "Itens disponíveis"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "KoFztx"
+msgid "Slot {position}: {item}. Tap to remove."
+msgstr "Posição {position}: {item}. Toque para remover."
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "yZaQVq"
+msgid "Answer slots"
+msgstr "Espaços de resposta"
 
 #: src/components/activity-player/step-renderer.tsx
 msgctxt "4pTU5S"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1277,7 +1277,6 @@ msgid "Stats"
 msgstr "Estatísticas"
 
 #: src/components/activity-player/feedback-screen.tsx
-#: src/components/activity-player/match-columns-step.tsx
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "++l7ni"
 msgid "Not quite"
@@ -1289,7 +1288,6 @@ msgid "Outcome"
 msgstr "Resultado"
 
 #: src/components/activity-player/feedback-screen.tsx
-#: src/components/activity-player/match-columns-step.tsx
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "xmF49T"
 msgid "Correct!"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1277,7 +1277,6 @@ msgid "Stats"
 msgstr "Estatísticas"
 
 #: src/components/activity-player/feedback-screen.tsx
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "++l7ni"
 msgid "Not quite"
 msgstr "Não exatamente"
@@ -1288,7 +1287,6 @@ msgid "Outcome"
 msgstr "Resultado"
 
 #: src/components/activity-player/feedback-screen.tsx
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "xmF49T"
 msgid "Correct!"
 msgstr "Correto!"
@@ -1344,44 +1342,44 @@ msgid "Close"
 msgstr "Fechar"
 
 #: src/components/activity-player/sort-order-step.tsx
+msgctxt "/CFOL2"
+msgid "Tap items in the correct order"
+msgstr "Toque nos itens na ordem correta"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "1za4AW"
+msgid "{item}. Tap to select as position {nextPosition}."
+msgstr "{item}. Toque para selecionar como posição {nextPosition}."
+
+#: src/components/activity-player/sort-order-step.tsx
 msgctxt "6NoIUl"
 msgid "Correct"
 msgstr "Correto"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "7Af5sM"
-msgid "Slot {position}"
-msgstr "Posição {position}"
-
-#: src/components/activity-player/sort-order-step.tsx
-msgctxt "8PMLyr"
-msgid "Slot {position}: {item}. {result}."
+msgctxt "oqRIWD"
+msgid "Position {position}: {item}. {result}."
 msgstr "Posição {position}: {item}. {result}."
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "fXxL3z"
-msgid "Available items"
-msgstr "Itens disponíveis"
+msgctxt "p5llOK"
+msgid "Sort items"
+msgstr "Ordenar itens"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "KoFztx"
-msgid "Slot {position}: {item}. Tap to remove."
+msgctxt "rNTHBv"
+msgid "Expected: \"{expectedItem}\""
+msgstr "Esperado: \"{expectedItem}\""
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "vPyO9S"
+msgid "Position {position}: {item}. Tap to remove."
 msgstr "Posição {position}: {item}. Toque para remover."
-
-#: src/components/activity-player/sort-order-step.tsx
-msgctxt "VA8c/A"
-msgid "Correct order:"
-msgstr "Ordem correta:"
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "Ypr9T5"
 msgid "Incorrect"
 msgstr "Incorreto"
-
-#: src/components/activity-player/sort-order-step.tsx
-msgctxt "yZaQVq"
-msgid "Answer slots"
-msgstr "Espaços de resposta"
 
 #: src/components/activity-player/step-renderer.tsx
 msgctxt "4pTU5S"

--- a/apps/main/src/components/activity-player/check-step.test.ts
+++ b/apps/main/src/components/activity-player/check-step.test.ts
@@ -127,6 +127,7 @@ describe(checkStep, () => {
     test("correct pairs", () => {
       const answer: SelectedAnswer = {
         kind: "matchColumns",
+        mistakes: 0,
         userPairs: [
           { left: "A", right: "1" },
           { left: "B", right: "2" },
@@ -140,6 +141,7 @@ describe(checkStep, () => {
     test("incorrect pairs", () => {
       const answer: SelectedAnswer = {
         kind: "matchColumns",
+        mistakes: 0,
         userPairs: [
           { left: "A", right: "2" },
           { left: "B", right: "1" },

--- a/apps/main/src/components/activity-player/check-step.ts
+++ b/apps/main/src/components/activity-player/check-step.ts
@@ -50,7 +50,10 @@ function checkMatchColumns(step: SerializedStep, answer: SelectedAnswer): CheckS
   }
 
   const content = parseStepContent("matchColumns", step.content);
-  return { effects: [], result: checkMatchColumnsAnswer(content, answer.userPairs) };
+  return {
+    effects: [],
+    result: checkMatchColumnsAnswer(content, answer.userPairs, answer.mistakes),
+  };
 }
 
 function checkSortOrder(step: SerializedStep, answer: SelectedAnswer): CheckStepResult {

--- a/apps/main/src/components/activity-player/fill-blank-step.tsx
+++ b/apps/main/src/components/activity-player/fill-blank-step.tsx
@@ -4,14 +4,12 @@ import { type SerializedStep } from "@/data/activities/prepare-activity-data";
 import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { cn } from "@zoonk/ui/lib/utils";
 import { shuffle } from "@zoonk/utils/shuffle";
+import { useExtracted } from "next-intl";
 import { useCallback, useMemo, useState } from "react";
 import { type SelectedAnswer } from "./player-reducer";
+import { QuestionText } from "./question-text";
 import { InteractiveStepLayout } from "./step-layouts";
 import { useReplaceName } from "./user-name-context";
-
-function QuestionText({ children }: { children: React.ReactNode }) {
-  return <p className="text-base font-semibold">{children}</p>;
-}
 
 function BlankSlot({
   index,
@@ -22,10 +20,15 @@ function BlankSlot({
   onRemove: () => void;
   word: string | null;
 }) {
+  const t = useExtracted();
+
   if (word) {
     return (
       <button
-        aria-label={`Blank ${index + 1}: ${word}. Tap to remove.`}
+        aria-label={t("Blank {position}: {item}. Tap to remove.", {
+          item: word,
+          position: String(index + 1),
+        })}
         className="border-primary/30 text-primary inline-flex min-w-16 items-center justify-center border-b-2 px-1 font-medium transition-all duration-150"
         onClick={onRemove}
         type="button"
@@ -37,7 +40,7 @@ function BlankSlot({
 
   return (
     <span
-      aria-label={`Blank ${index + 1}`}
+      aria-label={t("Blank {position}", { position: String(index + 1) })}
       className="border-muted-foreground/30 inline-flex min-w-16 border-b-2"
       role="img"
     />
@@ -110,10 +113,11 @@ function WordBank({
   onPlaceWord: (word: string) => void;
   words: string[];
 }) {
+  const t = useExtracted();
   const usedWords = blanks.filter(Boolean);
 
   return (
-    <div aria-label="Word bank" className="flex flex-wrap gap-2.5" role="group">
+    <div aria-label={t("Word bank")} className="flex flex-wrap gap-2.5" role="group">
       {words.map((word, index) => {
         const usedCount = usedWords.filter((used) => used === word).length;
         const totalCount = words.slice(0, index + 1).filter((item) => item === word).length;

--- a/apps/main/src/components/activity-player/match-columns-step.tsx
+++ b/apps/main/src/components/activity-player/match-columns-step.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { type SerializedStep } from "@/data/activities/prepare-activity-data";
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
+import { cn } from "@zoonk/ui/lib/utils";
+import { shuffle } from "@zoonk/utils/shuffle";
+import { useExtracted } from "next-intl";
+import { useCallback, useMemo, useState } from "react";
+import { type SelectedAnswer } from "./player-reducer";
+import { QuestionText } from "./question-text";
+import { InteractiveStepLayout } from "./step-layouts";
+import { useReplaceName } from "./user-name-context";
+
+type Pair = { left: string; right: string };
+
+function findMatch(matchedPairs: Pair[], item: string, side: "left" | "right"): Pair | undefined {
+  return matchedPairs.find((pair) => pair[side] === item);
+}
+
+function MatchItem({
+  isMatched,
+  isSelected,
+  label,
+  onTap,
+}: {
+  isMatched: boolean;
+  isSelected: boolean;
+  label: string;
+  onTap: () => void;
+}) {
+  return (
+    <button
+      aria-label={label}
+      aria-pressed={isSelected}
+      className={cn(
+        "border-border min-h-11 rounded-lg border px-4 py-3.5 text-left transition-all duration-150",
+        isMatched && "opacity-50",
+        isSelected && "border-primary bg-primary/5",
+        !isMatched &&
+          !isSelected &&
+          "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]",
+      )}
+      onClick={onTap}
+      type="button"
+    >
+      {label}
+    </button>
+  );
+}
+
+function MatchGrid({
+  leftItems,
+  matchedPairs,
+  onTapLeft,
+  onTapRight,
+  rightItems,
+  selectedLeft,
+}: {
+  leftItems: string[];
+  matchedPairs: Pair[];
+  onTapLeft: (item: string) => void;
+  onTapRight: (item: string) => void;
+  rightItems: string[];
+  selectedLeft: string | null;
+}) {
+  const t = useExtracted();
+
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <div aria-label={t("Left column")} className="flex flex-col gap-3" role="group">
+        {leftItems.map((item) => {
+          const match = findMatch(matchedPairs, item, "left");
+          const isMatched = match !== undefined;
+          const isSelected = selectedLeft === item && !isMatched;
+          const label = isMatched
+            ? t("{item}, matched with {match}. Tap to unmatch.", {
+                item,
+                match: match.right,
+              })
+            : item;
+
+          return (
+            <MatchItem
+              isMatched={isMatched}
+              isSelected={isSelected}
+              key={item}
+              label={label}
+              onTap={() => onTapLeft(item)}
+            />
+          );
+        })}
+      </div>
+
+      <div aria-label={t("Right column")} className="flex flex-col gap-3" role="group">
+        {rightItems.map((item) => {
+          const match = findMatch(matchedPairs, item, "right");
+          const isMatched = match !== undefined;
+          const label = isMatched
+            ? t("{item}, matched with {match}. Tap to unmatch.", {
+                item,
+                match: match.left,
+              })
+            : item;
+
+          return (
+            <MatchItem
+              isMatched={isMatched}
+              isSelected={false}
+              key={item}
+              label={label}
+              onTap={() => onTapRight(item)}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function MatchColumnsStep({
+  onSelectAnswer,
+  selectedAnswer,
+  step,
+}: {
+  onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
+  selectedAnswer: SelectedAnswer | undefined;
+  step: SerializedStep;
+}) {
+  const content = useMemo(() => parseStepContent("matchColumns", step.content), [step.content]);
+  const replaceName = useReplaceName();
+
+  const shuffledRight = useMemo(
+    () => shuffle(content.pairs.map((pair) => pair.right)),
+    [content.pairs],
+  );
+
+  const leftItems = useMemo(() => content.pairs.map((pair) => pair.left), [content.pairs]);
+
+  const [selectedLeft, setSelectedLeft] = useState<string | null>(null);
+  const [matchedPairs, setMatchedPairs] = useState<Pair[]>([]);
+
+  const handleTapLeft = useCallback(
+    (item: string) => {
+      const existingMatch = findMatch(matchedPairs, item, "left");
+
+      if (existingMatch) {
+        const next = matchedPairs.filter((pair) => pair.left !== item);
+        setMatchedPairs(next);
+        setSelectedLeft(null);
+
+        if (selectedAnswer) {
+          onSelectAnswer(step.id, null);
+        }
+
+        return;
+      }
+
+      setSelectedLeft(selectedLeft === item ? null : item);
+    },
+    [matchedPairs, onSelectAnswer, selectedAnswer, selectedLeft, step.id],
+  );
+
+  const handleTapRight = useCallback(
+    (item: string) => {
+      const existingMatch = findMatch(matchedPairs, item, "right");
+
+      if (existingMatch) {
+        const next = matchedPairs.filter((pair) => pair.right !== item);
+        setMatchedPairs(next);
+        setSelectedLeft(null);
+
+        if (selectedAnswer) {
+          onSelectAnswer(step.id, null);
+        }
+
+        return;
+      }
+
+      if (!selectedLeft) {
+        return;
+      }
+
+      const newPair: Pair = { left: selectedLeft, right: item };
+      const next = [...matchedPairs, newPair];
+      setMatchedPairs(next);
+      setSelectedLeft(null);
+
+      if (next.length === content.pairs.length) {
+        onSelectAnswer(step.id, { kind: "matchColumns", userPairs: next });
+      }
+    },
+    [content.pairs.length, matchedPairs, onSelectAnswer, selectedAnswer, selectedLeft, step.id],
+  );
+
+  return (
+    <InteractiveStepLayout>
+      {content.question ? <QuestionText>{replaceName(content.question)}</QuestionText> : null}
+
+      <MatchGrid
+        leftItems={leftItems}
+        matchedPairs={matchedPairs}
+        onTapLeft={handleTapLeft}
+        onTapRight={handleTapRight}
+        rightItems={shuffledRight}
+        selectedLeft={selectedLeft}
+      />
+    </InteractiveStepLayout>
+  );
+}

--- a/apps/main/src/components/activity-player/match-columns-step.tsx
+++ b/apps/main/src/components/activity-player/match-columns-step.tsx
@@ -8,7 +8,7 @@ import { shuffle } from "@zoonk/utils/shuffle";
 import { CircleCheck } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { Fragment, useCallback, useMemo, useRef, useState } from "react";
-import { type SelectedAnswer, type StepResult } from "./player-reducer";
+import { type SelectedAnswer } from "./player-reducer";
 import { QuestionText } from "./question-text";
 import { InteractiveStepLayout } from "./step-layouts";
 import { useReplaceName } from "./user-name-context";
@@ -146,32 +146,11 @@ function MatchGrid({
   );
 }
 
-function InlineFeedback({ result }: { result: StepResult }) {
-  const t = useExtracted();
-  const isCorrect = result.result.isCorrect;
-
-  return (
-    <div
-      aria-live="polite"
-      className={cn(
-        "flex items-center gap-1.5 text-sm font-medium",
-        isCorrect ? "text-success" : "text-destructive",
-      )}
-      role="status"
-    >
-      <CircleCheck aria-hidden="true" className="size-4" />
-      <span>{isCorrect ? t("Correct!") : t("Not quite")}</span>
-    </div>
-  );
-}
-
 export function MatchColumnsStep({
   onSelectAnswer,
-  result,
   step,
 }: {
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
-  result?: StepResult;
   selectedAnswer: SelectedAnswer | undefined;
   step: SerializedStep;
 }) {
@@ -273,8 +252,6 @@ export function MatchColumnsStep({
       <div aria-live="polite" className="sr-only" role="status">
         {allMatched ? t("All pairs matched. Press Check to continue.") : null}
       </div>
-
-      {result ? <InlineFeedback result={result} /> : null}
     </InteractiveStepLayout>
   );
 }

--- a/apps/main/src/components/activity-player/multiple-choice-step.tsx
+++ b/apps/main/src/components/activity-player/multiple-choice-step.tsx
@@ -11,6 +11,7 @@ import { Kbd } from "@zoonk/ui/components/kbd";
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { type SelectedAnswer } from "./player-reducer";
+import { QuestionText } from "./question-text";
 import { InteractiveStepLayout } from "./step-layouts";
 import { useOptionKeyboard } from "./use-option-keyboard";
 import { useReplaceName } from "./user-name-context";
@@ -21,10 +22,6 @@ function getSelectedIndex(selectedAnswer: SelectedAnswer | undefined): number | 
   }
 
   return selectedAnswer.selectedIndex;
-}
-
-function QuestionText({ children }: { children: React.ReactNode }) {
-  return <p className="text-base font-semibold">{children}</p>;
 }
 
 function ContextText({ children }: { children: React.ReactNode }) {

--- a/apps/main/src/components/activity-player/multiple-choice-step.tsx
+++ b/apps/main/src/components/activity-player/multiple-choice-step.tsx
@@ -11,7 +11,7 @@ import { Kbd } from "@zoonk/ui/components/kbd";
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { type SelectedAnswer } from "./player-reducer";
-import { QuestionText } from "./question-text";
+import { ContextText, QuestionText } from "./question-text";
 import { InteractiveStepLayout } from "./step-layouts";
 import { useOptionKeyboard } from "./use-option-keyboard";
 import { useReplaceName } from "./user-name-context";
@@ -22,10 +22,6 @@ function getSelectedIndex(selectedAnswer: SelectedAnswer | undefined): number | 
   }
 
   return selectedAnswer.selectedIndex;
-}
-
-function ContextText({ children }: { children: React.ReactNode }) {
-  return <p className="text-muted-foreground text-base">{children}</p>;
 }
 
 function StepTextGroup({ children }: { children: React.ReactNode }) {

--- a/apps/main/src/components/activity-player/player-reducer.test.ts
+++ b/apps/main/src/components/activity-player/player-reducer.test.ts
@@ -280,6 +280,48 @@ describe("CHECK_ANSWER", () => {
     expect(state.dimensions).toEqual({ Quality: 2 });
   });
 
+  describe("matchColumns auto-advance", () => {
+    test("auto-advances to next step instead of entering feedback phase", () => {
+      const steps = [
+        buildStep({ id: "mc-1", kind: "matchColumns", position: 0 }),
+        buildStep({ id: "mc-2", kind: "matchColumns", position: 1 }),
+      ];
+      const state = buildState({ steps });
+      const next = playerReducer(state, {
+        effects: [],
+        result: { feedback: null, isCorrect: true },
+        stepId: "mc-1",
+        type: "CHECK_ANSWER",
+      });
+      expect(next.phase).toBe("playing");
+      expect(next.currentStepIndex).toBe(1);
+      expect(next.results["mc-1"]).toEqual({
+        answer: undefined,
+        effects: [],
+        result: { feedback: null, isCorrect: true },
+        stepId: "mc-1",
+      });
+    });
+
+    test("sets completed when matchColumns is the last step", () => {
+      const steps = [buildStep({ id: "mc-1", kind: "matchColumns", position: 0 })];
+      const state = buildState({ steps });
+      const next = playerReducer(state, {
+        effects: [],
+        result: { feedback: null, isCorrect: true },
+        stepId: "mc-1",
+        type: "CHECK_ANSWER",
+      });
+      expect(next.phase).toBe("completed");
+      expect(next.results["mc-1"]).toEqual({
+        answer: undefined,
+        effects: [],
+        result: { feedback: null, isCorrect: true },
+        stepId: "mc-1",
+      });
+    });
+  });
+
   test("no-ops in feedback phase", () => {
     const state = buildState({ phase: "feedback" });
     const next = playerReducer(state, {

--- a/apps/main/src/components/activity-player/player-reducer.ts
+++ b/apps/main/src/components/activity-player/player-reducer.ts
@@ -140,6 +140,8 @@ function handleCheckAnswer(
     return state;
   }
 
+  const currentStep = state.steps[state.currentStepIndex];
+
   const stepResult: StepResult = {
     answer: state.selectedAnswers[action.stepId],
     effects: action.effects,
@@ -147,12 +149,19 @@ function handleCheckAnswer(
     stepId: action.stepId,
   };
 
-  return {
+  const checked: PlayerState = {
     ...state,
     dimensions: applyEffects(state.dimensions, action.effects),
     phase: "feedback",
     results: { ...state.results, [action.stepId]: stepResult },
   };
+
+  // matchColumns validates each pair during interaction, so feedback is redundant.
+  if (currentStep?.kind === "matchColumns") {
+    return handleContinue(checked);
+  }
+
+  return checked;
 }
 
 function handleContinue(state: PlayerState): PlayerState {

--- a/apps/main/src/components/activity-player/player-reducer.ts
+++ b/apps/main/src/components/activity-player/player-reducer.ts
@@ -10,7 +10,7 @@ export type PlayerPhase = "intro" | "playing" | "feedback" | "completed";
 export type SelectedAnswer =
   | { kind: "fillBlank"; userAnswers: string[] }
   | { kind: "listening"; arrangedWords: string[] }
-  | { kind: "matchColumns"; userPairs: { left: string; right: string }[] }
+  | { kind: "matchColumns"; userPairs: { left: string; right: string }[]; mistakes: number }
   | { kind: "multipleChoice"; selectedIndex: number }
   | { kind: "reading"; arrangedWords: string[] }
   | { kind: "selectImage"; selectedIndex: number }

--- a/apps/main/src/components/activity-player/question-text.tsx
+++ b/apps/main/src/components/activity-player/question-text.tsx
@@ -1,3 +1,7 @@
+export function ContextText({ children }: { children: React.ReactNode }) {
+  return <p className="text-muted-foreground text-base">{children}</p>;
+}
+
 export function QuestionText({ children }: { children: React.ReactNode }) {
   return <p className="text-base font-semibold">{children}</p>;
 }

--- a/apps/main/src/components/activity-player/question-text.tsx
+++ b/apps/main/src/components/activity-player/question-text.tsx
@@ -1,0 +1,3 @@
+export function QuestionText({ children }: { children: React.ReactNode }) {
+  return <p className="text-base font-semibold">{children}</p>;
+}

--- a/apps/main/src/components/activity-player/sort-order-step.tsx
+++ b/apps/main/src/components/activity-player/sort-order-step.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { type SerializedStep } from "@/data/activities/prepare-activity-data";
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
+import { Kbd } from "@zoonk/ui/components/kbd";
+import { cn } from "@zoonk/ui/lib/utils";
+import { shuffle } from "@zoonk/utils/shuffle";
+import { useExtracted } from "next-intl";
+import { useCallback, useMemo, useState } from "react";
+import { type SelectedAnswer } from "./player-reducer";
+import { QuestionText } from "./question-text";
+import { InteractiveStepLayout } from "./step-layouts";
+import { useReplaceName } from "./user-name-context";
+
+function OrderSlot({
+  index,
+  item,
+  onRemove,
+}: {
+  index: number;
+  item: string | null;
+  onRemove: () => void;
+}) {
+  const t = useExtracted();
+  const position = String(index + 1);
+
+  if (item) {
+    return (
+      <button
+        aria-label={t("Slot {position}: {item}. Tap to remove.", { item, position })}
+        className="flex min-h-11 items-center gap-3 rounded-lg border border-transparent px-4 py-2.5 text-left transition-all duration-150"
+        onClick={onRemove}
+        type="button"
+      >
+        <Kbd className="bg-primary text-primary-foreground">{position}</Kbd>
+        <span className="text-base">{item}</span>
+      </button>
+    );
+  }
+
+  return (
+    <div
+      aria-label={t("Slot {position}", { position })}
+      className="border-border/50 flex min-h-11 items-center gap-3 rounded-lg border border-dashed px-4 py-2.5"
+    >
+      <Kbd>{position}</Kbd>
+    </div>
+  );
+}
+
+function SlotList({
+  onRemove,
+  slots,
+}: {
+  onRemove: (index: number) => void;
+  slots: (string | null)[];
+}) {
+  const t = useExtracted();
+
+  return (
+    <div aria-label={t("Answer slots")} className="flex flex-col gap-2" role="list">
+      {slots.map((item, index) => (
+        <OrderSlot
+          index={index}
+          item={item}
+          key={`slot-${index}`}
+          onRemove={() => onRemove(index)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ItemTile({
+  isUsed,
+  onPlace,
+  word,
+}: {
+  isUsed: boolean;
+  onPlace: () => void;
+  word: string;
+}) {
+  return (
+    <button
+      aria-disabled={isUsed}
+      className={cn(
+        "border-border min-h-11 rounded-lg border px-4 py-2.5 transition-all duration-150",
+        isUsed
+          ? "pointer-events-none opacity-50"
+          : "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]",
+      )}
+      onClick={onPlace}
+      tabIndex={isUsed ? -1 : 0}
+      type="button"
+    >
+      {word}
+    </button>
+  );
+}
+
+function ItemPool({
+  onPlace,
+  slots,
+  words,
+}: {
+  onPlace: (word: string) => void;
+  slots: (string | null)[];
+  words: string[];
+}) {
+  const t = useExtracted();
+  const usedWords = slots.filter(Boolean);
+
+  return (
+    <div aria-label={t("Available items")} className="flex flex-wrap gap-2.5" role="group">
+      {words.map((word, index) => {
+        const usedCount = usedWords.filter((used) => used === word).length;
+        const totalCount = words.slice(0, index + 1).filter((item) => item === word).length;
+        const isUsed = usedCount >= totalCount;
+
+        return (
+          <ItemTile
+            isUsed={isUsed}
+            key={`${word}-${index}`}
+            onPlace={() => onPlace(word)}
+            word={word}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function isComplete(slots: (string | null)[]): slots is string[] {
+  return slots.every((slot) => slot !== null);
+}
+
+export function SortOrderStep({
+  onSelectAnswer,
+  selectedAnswer,
+  step,
+}: {
+  onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
+  selectedAnswer: SelectedAnswer | undefined;
+  step: SerializedStep;
+}) {
+  const content = useMemo(() => parseStepContent("sortOrder", step.content), [step.content]);
+  const replaceName = useReplaceName();
+
+  const shuffledItems = useMemo(() => shuffle(content.items), [content.items]);
+
+  const [slots, setSlots] = useState<(string | null)[]>(() =>
+    Array.from({ length: content.items.length }, () => null),
+  );
+
+  const handlePlace = useCallback(
+    (word: string) => {
+      const firstEmptyIndex = slots.indexOf(null);
+
+      if (firstEmptyIndex === -1) {
+        return;
+      }
+
+      const next = [...slots];
+      next[firstEmptyIndex] = word;
+      setSlots(next);
+
+      if (isComplete(next)) {
+        onSelectAnswer(step.id, { kind: "sortOrder", userOrder: next });
+      }
+    },
+    [onSelectAnswer, slots, step.id],
+  );
+
+  const handleRemove = useCallback(
+    (index: number) => {
+      if (!slots[index]) {
+        return;
+      }
+
+      const next = [...slots];
+      next[index] = null;
+      setSlots(next);
+
+      if (selectedAnswer) {
+        onSelectAnswer(step.id, null);
+      }
+    },
+    [onSelectAnswer, selectedAnswer, slots, step.id],
+  );
+
+  return (
+    <InteractiveStepLayout>
+      {content.question ? <QuestionText>{replaceName(content.question)}</QuestionText> : null}
+
+      <SlotList onRemove={handleRemove} slots={slots} />
+
+      <ItemPool onPlace={handlePlace} slots={slots} words={shuffledItems} />
+    </InteractiveStepLayout>
+  );
+}

--- a/apps/main/src/components/activity-player/sort-order-step.tsx
+++ b/apps/main/src/components/activity-player/sort-order-step.tsx
@@ -5,34 +5,74 @@ import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { Kbd } from "@zoonk/ui/components/kbd";
 import { cn } from "@zoonk/ui/lib/utils";
 import { shuffle } from "@zoonk/utils/shuffle";
+import { CircleCheck, CircleX } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { useCallback, useMemo, useState } from "react";
-import { type SelectedAnswer } from "./player-reducer";
+import { type SelectedAnswer, type StepResult } from "./player-reducer";
 import { QuestionText } from "./question-text";
 import { InteractiveStepLayout } from "./step-layouts";
 import { useReplaceName } from "./user-name-context";
+
+function getSlotResultState(
+  item: string,
+  index: number,
+  correctItems: string[],
+): "correct" | "incorrect" | null {
+  const correctItem = correctItems[index];
+
+  if (!correctItem) {
+    return null;
+  }
+
+  return item === correctItem ? "correct" : "incorrect";
+}
 
 function OrderSlot({
   index,
   item,
   onRemove,
+  resultState,
 }: {
   index: number;
   item: string | null;
   onRemove: () => void;
+  resultState?: "correct" | "incorrect" | null;
 }) {
   const t = useExtracted();
   const position = String(index + 1);
+  const hasResult = resultState !== undefined && resultState !== null;
 
   if (item) {
+    const ariaLabel = hasResult
+      ? t("Slot {position}: {item}. {result}.", {
+          item,
+          position,
+          result: resultState === "correct" ? t("Correct") : t("Incorrect"),
+        })
+      : t("Slot {position}: {item}. Tap to remove.", { item, position });
+
     return (
       <button
-        aria-label={t("Slot {position}: {item}. Tap to remove.", { item, position })}
-        className="flex min-h-11 items-center gap-3 rounded-lg border border-transparent px-4 py-2.5 text-left transition-all duration-150"
+        aria-label={ariaLabel}
+        className={cn(
+          "flex min-h-11 items-center gap-3 rounded-lg border border-transparent px-3 py-2 text-left transition-all duration-150 sm:px-4 sm:py-2.5",
+          hasResult && "pointer-events-none",
+          resultState === "correct" && "border-l-success border-l-2",
+          resultState === "incorrect" && "border-l-destructive border-l-2",
+        )}
+        disabled={hasResult}
         onClick={onRemove}
         type="button"
       >
-        <Kbd className="bg-primary text-primary-foreground">{position}</Kbd>
+        <Kbd
+          className={cn(
+            "bg-primary text-primary-foreground",
+            resultState === "correct" && "bg-success text-white",
+            resultState === "incorrect" && "bg-destructive text-white",
+          )}
+        >
+          {position}
+        </Kbd>
         <span className="text-base">{item}</span>
       </button>
     );
@@ -41,7 +81,7 @@ function OrderSlot({
   return (
     <div
       aria-label={t("Slot {position}", { position })}
-      className="border-border/50 flex min-h-11 items-center gap-3 rounded-lg border border-dashed px-4 py-2.5"
+      className="border-border/50 flex min-h-11 items-center gap-3 rounded-lg border border-dashed px-3 py-2 sm:px-4 sm:py-2.5"
     >
       <Kbd>{position}</Kbd>
     </div>
@@ -49,9 +89,11 @@ function OrderSlot({
 }
 
 function SlotList({
+  correctItems,
   onRemove,
   slots,
 }: {
+  correctItems?: string[];
   onRemove: (index: number) => void;
   slots: (string | null)[];
 }) {
@@ -59,14 +101,20 @@ function SlotList({
 
   return (
     <div aria-label={t("Answer slots")} className="flex flex-col gap-2" role="list">
-      {slots.map((item, index) => (
-        <OrderSlot
-          index={index}
-          item={item}
-          key={`slot-${index}`}
-          onRemove={() => onRemove(index)}
-        />
-      ))}
+      {slots.map((item, index) => {
+        const resultState =
+          correctItems && item ? getSlotResultState(item, index, correctItems) : undefined;
+
+        return (
+          <OrderSlot
+            index={index}
+            item={item}
+            key={`slot-${index}`}
+            onRemove={() => onRemove(index)}
+            resultState={resultState}
+          />
+        );
+      })}
     </div>
   );
 }
@@ -84,7 +132,7 @@ function ItemTile({
     <button
       aria-disabled={isUsed}
       className={cn(
-        "border-border min-h-11 rounded-lg border px-4 py-2.5 transition-all duration-150",
+        "border-border min-h-11 w-full rounded-lg border px-4 py-2.5 text-left transition-all duration-150",
         isUsed
           ? "pointer-events-none opacity-50"
           : "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]",
@@ -111,7 +159,7 @@ function ItemPool({
   const usedWords = slots.filter(Boolean);
 
   return (
-    <div aria-label={t("Available items")} className="flex flex-wrap gap-2.5" role="group">
+    <div aria-label={t("Available items")} className="flex flex-col gap-2" role="group">
       {words.map((word, index) => {
         const usedCount = usedWords.filter((used) => used === word).length;
         const totalCount = words.slice(0, index + 1).filter((item) => item === word).length;
@@ -130,16 +178,64 @@ function ItemPool({
   );
 }
 
+function InlineFeedback({
+  content,
+  result,
+}: {
+  content: { feedback: string | null; items: string[] };
+  result: StepResult;
+}) {
+  const t = useExtracted();
+  const replaceName = useReplaceName();
+  const isCorrect = result.result.isCorrect;
+  const feedback = content.feedback ? replaceName(content.feedback) : null;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div
+        aria-live="polite"
+        className={cn(
+          "flex items-center gap-1.5 text-sm font-medium",
+          isCorrect ? "text-success" : "text-destructive",
+        )}
+        role="status"
+      >
+        {isCorrect ? (
+          <CircleCheck aria-hidden="true" className="size-4" />
+        ) : (
+          <CircleX aria-hidden="true" className="size-4" />
+        )}
+        <span>{isCorrect ? t("Correct!") : t("Not quite")}</span>
+      </div>
+
+      {feedback ? <p className="text-muted-foreground text-base">{feedback}</p> : null}
+
+      {isCorrect ? null : (
+        <div className="text-muted-foreground text-sm">
+          <p className="font-medium">{t("Correct order:")}</p>
+          <ol className="mt-1 list-inside list-decimal">
+            {content.items.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ol>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function isComplete(slots: (string | null)[]): slots is string[] {
   return slots.every((slot) => slot !== null);
 }
 
 export function SortOrderStep({
   onSelectAnswer,
+  result,
   selectedAnswer,
   step,
 }: {
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
+  result?: StepResult;
   selectedAnswer: SelectedAnswer | undefined;
   step: SerializedStep;
 }) {
@@ -148,9 +244,13 @@ export function SortOrderStep({
 
   const shuffledItems = useMemo(() => shuffle(content.items), [content.items]);
 
-  const [slots, setSlots] = useState<(string | null)[]>(() =>
-    Array.from({ length: content.items.length }, () => null),
-  );
+  const [slots, setSlots] = useState<(string | null)[]>(() => {
+    if (result?.answer?.kind === "sortOrder") {
+      return result.answer.userOrder;
+    }
+
+    return Array.from({ length: content.items.length }, () => null);
+  });
 
   const handlePlace = useCallback(
     (word: string) => {
@@ -188,13 +288,21 @@ export function SortOrderStep({
     [onSelectAnswer, selectedAnswer, slots, step.id],
   );
 
+  const hasResult = result !== undefined;
+
   return (
     <InteractiveStepLayout>
       {content.question ? <QuestionText>{replaceName(content.question)}</QuestionText> : null}
 
-      <SlotList onRemove={handleRemove} slots={slots} />
+      <SlotList
+        correctItems={hasResult ? content.items : undefined}
+        onRemove={handleRemove}
+        slots={slots}
+      />
 
-      <ItemPool onPlace={handlePlace} slots={slots} words={shuffledItems} />
+      {hasResult ? null : <ItemPool onPlace={handlePlace} slots={slots} words={shuffledItems} />}
+
+      {result ? <InlineFeedback content={content} result={result} /> : null}
     </InteractiveStepLayout>
   );
 }

--- a/apps/main/src/components/activity-player/stage-content.tsx
+++ b/apps/main/src/components/activity-player/stage-content.tsx
@@ -65,6 +65,23 @@ export function StageContent({
   }
 
   if (phase === "feedback" && currentResult) {
+    const hasInlineFeedback =
+      currentStep?.kind === "matchColumns" || currentStep?.kind === "sortOrder";
+
+    if (hasInlineFeedback && currentStep) {
+      return (
+        <StepRenderer
+          isFirst={isFirst}
+          onNavigateNext={onNavigateNext}
+          onNavigatePrev={onNavigatePrev}
+          onSelectAnswer={onSelectAnswer}
+          result={currentResult}
+          selectedAnswer={selectedAnswer}
+          step={currentStep}
+        />
+      );
+    }
+
     return <FeedbackScreenContent dimensions={dimensions} result={currentResult} />;
   }
 

--- a/apps/main/src/components/activity-player/stage-content.tsx
+++ b/apps/main/src/components/activity-player/stage-content.tsx
@@ -65,8 +65,7 @@ export function StageContent({
   }
 
   if (phase === "feedback" && currentResult) {
-    const hasInlineFeedback =
-      currentStep?.kind === "matchColumns" || currentStep?.kind === "sortOrder";
+    const hasInlineFeedback = currentStep?.kind === "sortOrder";
 
     if (hasInlineFeedback && currentStep) {
       return (

--- a/apps/main/src/components/activity-player/static-step.tsx
+++ b/apps/main/src/components/activity-player/static-step.tsx
@@ -3,6 +3,7 @@
 import { type SerializedStep } from "@/data/activities/prepare-activity-data";
 import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { HighlightText } from "./highlight-text";
+import { ContextText } from "./question-text";
 import { StaticStepText, StaticStepVisual } from "./step-layouts";
 import { useReplaceName } from "./user-name-context";
 
@@ -12,7 +13,7 @@ function TextVariant({ title, text }: { title: string; text: string }) {
   return (
     <>
       <h2 className="text-base font-semibold">{replaceName(title)}</h2>
-      <p className="text-muted-foreground text-base">{replaceName(text)}</p>
+      <ContextText>{replaceName(text)}</ContextText>
     </>
   );
 }
@@ -36,7 +37,7 @@ function GrammarExampleVariant({
 
       {romanization && <p className="text-muted-foreground text-sm italic">{romanization}</p>}
 
-      <p className="text-muted-foreground text-base">{translation}</p>
+      <ContextText>{translation}</ContextText>
     </>
   );
 }
@@ -45,7 +46,7 @@ function GrammarRuleVariant({ ruleName, ruleSummary }: { ruleName: string; ruleS
   return (
     <>
       <h2 className="text-base font-semibold tracking-tight">{ruleName}</h2>
-      <p className="text-muted-foreground text-base">{ruleSummary}</p>
+      <ContextText>{ruleSummary}</ContextText>
     </>
   );
 }

--- a/apps/main/src/components/activity-player/step-renderer-utils.ts
+++ b/apps/main/src/components/activity-player/step-renderer-utils.ts
@@ -89,6 +89,7 @@ export function getMockAnswer(step: SerializedStep): SelectedAnswer | null {
     case "matchColumns":
       return {
         kind: "matchColumns",
+        mistakes: 0,
         userPairs: parseStepContent("matchColumns", step.content).pairs,
       };
 

--- a/apps/main/src/components/activity-player/step-renderer.test.ts
+++ b/apps/main/src/components/activity-player/step-renderer.test.ts
@@ -233,6 +233,7 @@ describe(getMockAnswer, () => {
     });
     expect(getMockAnswer(step)).toEqual({
       kind: "matchColumns",
+      mistakes: 0,
       userPairs: [{ left: "A", right: "1" }],
     });
   });

--- a/apps/main/src/components/activity-player/step-renderer.tsx
+++ b/apps/main/src/components/activity-player/step-renderer.tsx
@@ -6,7 +6,7 @@ import { useExtracted } from "next-intl";
 import { FillBlankStep } from "./fill-blank-step";
 import { MatchColumnsStep } from "./match-columns-step";
 import { MultipleChoiceStep } from "./multiple-choice-step";
-import { type SelectedAnswer } from "./player-reducer";
+import { type SelectedAnswer, type StepResult } from "./player-reducer";
 import { SortOrderStep } from "./sort-order-step";
 import { StaticStep } from "./static-step";
 import { StaticTapZones, useSwipeNavigation } from "./static-step-navigation";
@@ -49,6 +49,7 @@ export function StepRenderer({
   onNavigateNext,
   onNavigatePrev,
   onSelectAnswer,
+  result,
   selectedAnswer,
   step,
 }: {
@@ -56,6 +57,7 @@ export function StepRenderer({
   onNavigateNext: () => void;
   onNavigatePrev: () => void;
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
+  result?: StepResult;
   selectedAnswer: SelectedAnswer | undefined;
   step: SerializedStep;
 }) {
@@ -94,6 +96,7 @@ export function StepRenderer({
     return (
       <MatchColumnsStep
         onSelectAnswer={onSelectAnswer}
+        result={result}
         selectedAnswer={selectedAnswer}
         step={step}
       />
@@ -102,7 +105,12 @@ export function StepRenderer({
 
   if (step.kind === "sortOrder") {
     return (
-      <SortOrderStep onSelectAnswer={onSelectAnswer} selectedAnswer={selectedAnswer} step={step} />
+      <SortOrderStep
+        onSelectAnswer={onSelectAnswer}
+        result={result}
+        selectedAnswer={selectedAnswer}
+        step={step}
+      />
     );
   }
 

--- a/apps/main/src/components/activity-player/step-renderer.tsx
+++ b/apps/main/src/components/activity-player/step-renderer.tsx
@@ -96,7 +96,6 @@ export function StepRenderer({
     return (
       <MatchColumnsStep
         onSelectAnswer={onSelectAnswer}
-        result={result}
         selectedAnswer={selectedAnswer}
         step={step}
       />

--- a/apps/main/src/components/activity-player/step-renderer.tsx
+++ b/apps/main/src/components/activity-player/step-renderer.tsx
@@ -4,8 +4,10 @@ import { type SerializedStep } from "@/data/activities/prepare-activity-data";
 import { Button } from "@zoonk/ui/components/button";
 import { useExtracted } from "next-intl";
 import { FillBlankStep } from "./fill-blank-step";
+import { MatchColumnsStep } from "./match-columns-step";
 import { MultipleChoiceStep } from "./multiple-choice-step";
 import { type SelectedAnswer } from "./player-reducer";
+import { SortOrderStep } from "./sort-order-step";
 import { StaticStep } from "./static-step";
 import { StaticTapZones, useSwipeNavigation } from "./static-step-navigation";
 import { InteractiveStepLayout, StaticStepLayout } from "./step-layouts";
@@ -85,6 +87,22 @@ export function StepRenderer({
   if (step.kind === "fillBlank") {
     return (
       <FillBlankStep onSelectAnswer={onSelectAnswer} selectedAnswer={selectedAnswer} step={step} />
+    );
+  }
+
+  if (step.kind === "matchColumns") {
+    return (
+      <MatchColumnsStep
+        onSelectAnswer={onSelectAnswer}
+        selectedAnswer={selectedAnswer}
+        step={step}
+      />
+    );
+  }
+
+  if (step.kind === "sortOrder") {
+    return (
+      <SortOrderStep onSelectAnswer={onSelectAnswer} selectedAnswer={selectedAnswer} step={step} />
     );
   }
 

--- a/i18n.lock
+++ b/i18n.lock
@@ -433,12 +433,22 @@ checksums:
     Not%20quite/singular: e570085e69662802acf485c4565e3e3e
     Outcome/singular: 4cfc7a40e384ea8b6658e8da6e351bf0
     Correct!/singular: dda1a98dc04fd9db252887ecf1765d41
+    Word%20bank/singular: ceea720dd5fa3747c7f93ce165f77b2e
+    Blank%20%7Bposition%7D/singular: 70a4795f65f91685071b6abb1c3a6bad
+    Blank%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: d7ab9b86256fae5fbb5187fe718afe0b
+    Right%20column/singular: 543eba2cadacf4a570f16029d2314db5
+    Left%20column/singular: 325de16ded7fbe868f3fbfff4f11e510
+    "%7Bitem%7D%2C%20matched%20with%20%7Bmatch%7D.%20Tap%20to%20unmatch./singular": b77325cc70fd75ccf8279ac6c2d7cf2d
     What%20do%20you%20say%3F/singular: 75887288b85fc19e67b7d20550d9205e
     Someone%20says%3A/singular: 09f34dce0528b57e89c8757b5745e6c5
     Previous%20step/singular: 96b31ec6dab003c2bbfbbca10a8a9826
     Next%20step/singular: 712c63650b5180cbc14d6246b5d558c2
     Step%20navigation/singular: ec328f28051577e1c0aab044c89b138c
     Close/singular: 2c2e22f8424a1031de89063bd0022e16
+    Slot%20%7Bposition%7D/singular: 860581010a2082a83dcdfcb2803fce82
+    Available%20items/singular: 4ddce93f2455bfafb212b3eb68f18bf1
+    Slot%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: 87edef45f4f5f40c8ee3902e4500ff87
+    Answer%20slots/singular: 439a0650c67bd8bbdc46fe8ceb72edab
     Answer%20selected/singular: 43c2c02a2f5ab63d04a3ba140a03b769
     Select%20answer/singular: 4951d9f093550e70ff5f399634b2b595
     Not%20completed/singular: d011b1ae92a1a8a2676a5d6999bbe6d4

--- a/i18n.lock
+++ b/i18n.lock
@@ -446,9 +446,8 @@ checksums:
     Tap%20items%20in%20the%20correct%20order/singular: 221c7b9ef00241af65f534432965e782
     "%7Bitem%7D.%20Tap%20to%20select%20as%20position%20%7BnextPosition%7D./singular": f8b0d3e60ce3740c02c33c0faaec5e6b
     Correct/singular: c643eeb0a615de2032eca68722c31177
-    Position%20%7Bposition%7D%3A%20%7Bitem%7D.%20%7Bresult%7D./singular: af22d79f69dfa3f725721db4d668814d
+    "%7Bitem%7D.%20%7Bresult%7D./singular": 454dd5319c350f361652396801a1c30b
     Sort%20items/singular: 3b1072a596203b5acdc5718d38161392
-    Expected%3A%20%22%7BexpectedItem%7D%22/singular: e7904d0034072590249b13ffdde17f3c
     Position%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: a1b3d3e026bfff43bff3d3e85ccdb952
     Incorrect/singular: a86cfbe7b86f19dc8df14a67df073d22
     Answer%20selected/singular: 43c2c02a2f5ab63d04a3ba140a03b769

--- a/i18n.lock
+++ b/i18n.lock
@@ -436,18 +436,20 @@ checksums:
     Word%20bank/singular: ceea720dd5fa3747c7f93ce165f77b2e
     Blank%20%7Bposition%7D/singular: 70a4795f65f91685071b6abb1c3a6bad
     Blank%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: d7ab9b86256fae5fbb5187fe718afe0b
-    Right%20column/singular: 543eba2cadacf4a570f16029d2314db5
-    Left%20column/singular: 325de16ded7fbe868f3fbfff4f11e510
-    "%7Bitem%7D%2C%20matched%20with%20%7Bmatch%7D.%20Tap%20to%20unmatch./singular": b77325cc70fd75ccf8279ac6c2d7cf2d
+    All%20pairs%20matched.%20Press%20Check%20to%20continue./singular: 0663e33ba7db53b298c5f50a2f3c7ae8
     What%20do%20you%20say%3F/singular: 75887288b85fc19e67b7d20550d9205e
     Someone%20says%3A/singular: 09f34dce0528b57e89c8757b5745e6c5
     Previous%20step/singular: 96b31ec6dab003c2bbfbbca10a8a9826
     Next%20step/singular: 712c63650b5180cbc14d6246b5d558c2
     Step%20navigation/singular: ec328f28051577e1c0aab044c89b138c
     Close/singular: 2c2e22f8424a1031de89063bd0022e16
+    Correct/singular: c643eeb0a615de2032eca68722c31177
     Slot%20%7Bposition%7D/singular: 860581010a2082a83dcdfcb2803fce82
+    Slot%20%7Bposition%7D%3A%20%7Bitem%7D.%20%7Bresult%7D./singular: babff11abd6c298cb6b8c27291f4a30f
     Available%20items/singular: 4ddce93f2455bfafb212b3eb68f18bf1
     Slot%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: 87edef45f4f5f40c8ee3902e4500ff87
+    Correct%20order%3A/singular: df3f446653ec8cde9c29d8d5912636ef
+    Incorrect/singular: a86cfbe7b86f19dc8df14a67df073d22
     Answer%20slots/singular: 439a0650c67bd8bbdc46fe8ceb72edab
     Answer%20selected/singular: 43c2c02a2f5ab63d04a3ba140a03b769
     Select%20answer/singular: 4951d9f093550e70ff5f399634b2b595

--- a/i18n.lock
+++ b/i18n.lock
@@ -443,14 +443,14 @@ checksums:
     Next%20step/singular: 712c63650b5180cbc14d6246b5d558c2
     Step%20navigation/singular: ec328f28051577e1c0aab044c89b138c
     Close/singular: 2c2e22f8424a1031de89063bd0022e16
+    Tap%20items%20in%20the%20correct%20order/singular: 221c7b9ef00241af65f534432965e782
+    "%7Bitem%7D.%20Tap%20to%20select%20as%20position%20%7BnextPosition%7D./singular": f8b0d3e60ce3740c02c33c0faaec5e6b
     Correct/singular: c643eeb0a615de2032eca68722c31177
-    Slot%20%7Bposition%7D/singular: 860581010a2082a83dcdfcb2803fce82
-    Slot%20%7Bposition%7D%3A%20%7Bitem%7D.%20%7Bresult%7D./singular: babff11abd6c298cb6b8c27291f4a30f
-    Available%20items/singular: 4ddce93f2455bfafb212b3eb68f18bf1
-    Slot%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: 87edef45f4f5f40c8ee3902e4500ff87
-    Correct%20order%3A/singular: df3f446653ec8cde9c29d8d5912636ef
+    Position%20%7Bposition%7D%3A%20%7Bitem%7D.%20%7Bresult%7D./singular: af22d79f69dfa3f725721db4d668814d
+    Sort%20items/singular: 3b1072a596203b5acdc5718d38161392
+    Expected%3A%20%22%7BexpectedItem%7D%22/singular: e7904d0034072590249b13ffdde17f3c
+    Position%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: a1b3d3e026bfff43bff3d3e85ccdb952
     Incorrect/singular: a86cfbe7b86f19dc8df14a67df073d22
-    Answer%20slots/singular: 439a0650c67bd8bbdc46fe8ceb72edab
     Answer%20selected/singular: 43c2c02a2f5ab63d04a3ba140a03b769
     Select%20answer/singular: 4951d9f093550e70ff5f399634b2b595
     Not%20completed/singular: d011b1ae92a1a8a2676a5d6999bbe6d4

--- a/packages/core/src/player/check-answer.test.ts
+++ b/packages/core/src/player/check-answer.test.ts
@@ -12,6 +12,7 @@ import {
   checkMatchColumnsAnswer,
   checkMultipleChoiceAnswer,
   checkSelectImageAnswer,
+  checkSingleMatchPair,
   checkSortOrderAnswer,
   checkVocabularyAnswer,
 } from "./check-answer";
@@ -161,6 +162,24 @@ describe(checkFillBlankAnswer, () => {
   });
 });
 
+describe(checkSingleMatchPair, () => {
+  const content: MatchColumnsStepContent = {
+    pairs: [
+      { left: "A", right: "1" },
+      { left: "B", right: "2" },
+    ],
+    question: "Match the items.",
+  };
+
+  test("returns true for a correct pair", () => {
+    expect(checkSingleMatchPair(content, { left: "A", right: "1" })).toBeTruthy();
+  });
+
+  test("returns false for an incorrect pair", () => {
+    expect(checkSingleMatchPair(content, { left: "A", right: "2" })).toBeFalsy();
+  });
+});
+
 describe(checkMatchColumnsAnswer, () => {
   const content: MatchColumnsStepContent = {
     pairs: [
@@ -170,27 +189,39 @@ describe(checkMatchColumnsAnswer, () => {
     question: "Match the items.",
   };
 
-  test("returns correct when all pairs match (same order)", () => {
+  test("returns correct when all pairs match with no mistakes", () => {
     const userPairs = [
       { left: "A", right: "1" },
       { left: "B", right: "2" },
     ];
 
-    expect(checkMatchColumnsAnswer(content, userPairs)).toEqual({
+    expect(checkMatchColumnsAnswer(content, userPairs, 0)).toEqual({
       feedback: null,
       isCorrect: true,
     });
   });
 
-  test("returns correct when all pairs match (different order)", () => {
+  test("returns correct when all pairs match in different order with no mistakes", () => {
     const userPairs = [
       { left: "B", right: "2" },
       { left: "A", right: "1" },
     ];
 
-    expect(checkMatchColumnsAnswer(content, userPairs)).toEqual({
+    expect(checkMatchColumnsAnswer(content, userPairs, 0)).toEqual({
       feedback: null,
       isCorrect: true,
+    });
+  });
+
+  test("returns incorrect when all pairs match but mistakes > 0", () => {
+    const userPairs = [
+      { left: "A", right: "1" },
+      { left: "B", right: "2" },
+    ];
+
+    expect(checkMatchColumnsAnswer(content, userPairs, 1)).toEqual({
+      feedback: null,
+      isCorrect: false,
     });
   });
 
@@ -200,7 +231,7 @@ describe(checkMatchColumnsAnswer, () => {
       { left: "B", right: "1" },
     ];
 
-    expect(checkMatchColumnsAnswer(content, userPairs)).toEqual({
+    expect(checkMatchColumnsAnswer(content, userPairs, 0)).toEqual({
       feedback: null,
       isCorrect: false,
     });
@@ -209,7 +240,7 @@ describe(checkMatchColumnsAnswer, () => {
   test("returns incorrect when counts differ", () => {
     const userPairs = [{ left: "A", right: "1" }];
 
-    expect(checkMatchColumnsAnswer(content, userPairs)).toEqual({
+    expect(checkMatchColumnsAnswer(content, userPairs, 0)).toEqual({
       feedback: null,
       isCorrect: false,
     });

--- a/packages/core/src/player/check-answer.ts
+++ b/packages/core/src/player/check-answer.ts
@@ -43,19 +43,27 @@ export function checkFillBlankAnswer(
   return { feedback: content.feedback, isCorrect };
 }
 
+export function checkSingleMatchPair(
+  content: MatchColumnsStepContent,
+  pair: { left: string; right: string },
+): boolean {
+  return content.pairs.some(
+    (correct) => correct.left === pair.left && correct.right === pair.right,
+  );
+}
+
 export function checkMatchColumnsAnswer(
   content: MatchColumnsStepContent,
   userPairs: { left: string; right: string }[],
+  mistakes: number,
 ): AnswerResult {
-  if (content.pairs.length !== userPairs.length) {
-    return { feedback: null, isCorrect: false };
-  }
+  const allPairsCorrect =
+    content.pairs.length === userPairs.length &&
+    content.pairs.every((pair) =>
+      userPairs.some((userPair) => userPair.left === pair.left && userPair.right === pair.right),
+    );
 
-  const isCorrect = content.pairs.every((pair) =>
-    userPairs.some((userPair) => userPair.left === pair.left && userPair.right === pair.right),
-  );
-
-  return { feedback: null, isCorrect };
+  return { feedback: null, isCorrect: allPairsCorrect && mistakes === 0 };
 }
 
 export function checkSortOrderAnswer(

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -14,6 +14,7 @@
   --radius-2xl: calc(var(--radius) + 8px);
   --radius-3xl: calc(var(--radius) + 12px);
   --radius-4xl: calc(var(--radius) + 16px);
+  --animate-shake: shake 0.4s ease-in-out;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -263,6 +264,25 @@
   }
   100% {
     background-position: -200% center;
+  }
+}
+
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-4px);
+  }
+  40% {
+    transform: translateX(4px);
+  }
+  60% {
+    transform: translateX(-3px);
+  }
+  80% {
+    transform: translateX(3px);
   }
 }
 


### PR DESCRIPTION
## Summary
- Extract shared `QuestionText` component from fill-blank and multiple-choice steps
- Add interactive match-columns step with tap-to-match/unmatch and opacity-based matched state
- Add sort-order step with numbered `Kbd` slots and tap-to-place item pool
- Translate hard-coded aria-labels in fill-blank step for i18n
- Add 17 e2e tests covering both new step types

## Test plan
- [x] 17 new e2e tests pass (9 match-columns, 8 sort-order)
- [x] Existing fill-blank and multiple-choice e2e tests pass (no regressions)
- [x] `pnpm typecheck`, `pnpm turbo quality:fix`, `pnpm knip`, `pnpm test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned Sort Order into a single tap-to-sequence list and added an interactive Match Columns step with instant pair validation, mistake-aware scoring, and localized, accessible UI. Sort Order now shows inline results with check/X icons and reorders to the correct answer; Match Columns auto-advances after Check.

- **New Features**
  - Match Columns: aligned grid; tap left to select, tap right to validate; correct pairs lock; incorrect pairs shake; tracks mistakes for scoring; Check enabled only when all pairs are matched; auto-advances after Check; screen-reader status when all pairs matched.
  - Sort Order: single shuffled list; tap to assign numbers; tap again to remove and renumber; Check enabled when all items are selected; after Check, inline feedback shows correct order with check/X icons; Continue appears.
  - Accessibility/i18n: localized aria labels and status messages (en/es/pt) across steps, including fill-blank (“Word bank”, “Blank {position}”).

- **Refactors**
  - Extract shared QuestionText and ContextText components for reuse (multiple-choice, static, fill-blank).
  - Core: add checkSingleMatchPair; pass mistakes into checkMatchColumnsAnswer so any mistake marks the step incorrect.
  - Stage flow: render inline feedback within sort-order via StageContent; skip feedback screen for match-columns.

<sup>Written for commit bc14996d3bbf2a214e535f336e220bb30ac3ccba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

