### PR TITLE
fix(main): make activity player header sticky

### DIFF
--- a/apps/main/src/components/activity-player/activity-player-shell.tsx
+++ b/apps/main/src/components/activity-player/activity-player-shell.tsx
@@ -6,17 +6,9 @@ import { useExtracted } from "next-intl";
 import { useCallback } from "react";
 import { checkStep } from "./check-step";
 import { hasNegativeDimension } from "./dimension-inventory";
-import { DimensionStatusButton } from "./dimension-status-button";
+import { InPlayStickyHeader } from "./in-play-sticky-header";
 import { PlayerActionBar, PlayerActionButton } from "./player-action-bar";
-import {
-  PlayerCloseLink,
-  PlayerHeader,
-  PlayerNav,
-  PlayerNavButton,
-  PlayerNavGroup,
-  PlayerStepFraction,
-} from "./player-header";
-import { PlayerProgressBar } from "./player-progress-bar";
+import { PlayerCloseLink, PlayerHeader } from "./player-header";
 import { type PlayerState, type SelectedAnswer } from "./player-reducer";
 import { PlayerStage } from "./player-stage";
 import { StageContent } from "./stage-content";
@@ -139,47 +131,28 @@ export function ActivityPlayerShell({
     <UserNameProvider>
       <main className="flex min-h-dvh flex-col">
         {view.isIntro && (
-          <PlayerHeader>
-            <PlayerCloseLink href={lessonHref} />
-            <div className="size-9" aria-hidden="true" />
-          </PlayerHeader>
+          <div className="bg-background/95 sticky top-0 z-30 backdrop-blur-sm">
+            <PlayerHeader>
+              <PlayerCloseLink href={lessonHref} />
+              <div className="size-9" aria-hidden="true" />
+            </PlayerHeader>
+          </div>
         )}
 
         {view.showHeader && (
-          <PlayerHeader>
-            <PlayerCloseLink href={lessonHref} />
-
-            {view.isStaticStep && (
-              <PlayerNav>
-                <PlayerNavGroup>
-                  <PlayerNavButton
-                    direction="prev"
-                    disabled={view.isFirstStep}
-                    onClick={handleNavigatePrev}
-                  />
-                  <PlayerStepFraction>
-                    {state.currentStepIndex + 1} / {view.totalSteps}
-                  </PlayerStepFraction>
-                  <PlayerNavButton direction="next" onClick={handleNavigateNext} />
-                </PlayerNavGroup>
-              </PlayerNav>
-            )}
-
-            {!view.isStaticStep && (
-              <PlayerStepFraction>
-                {state.currentStepIndex + 1} / {view.totalSteps}
-              </PlayerStepFraction>
-            )}
-
-            {view.hasDimensions ? (
-              <DimensionStatusButton dimensions={state.dimensions} />
-            ) : (
-              <div className="size-9" aria-hidden="true" />
-            )}
-          </PlayerHeader>
+          <InPlayStickyHeader
+            currentStepIndex={state.currentStepIndex}
+            dimensions={state.dimensions}
+            hasDimensions={view.hasDimensions}
+            isFirstStep={view.isFirstStep}
+            isStaticStep={view.isStaticStep}
+            lessonHref={lessonHref}
+            onNavigateNext={handleNavigateNext}
+            onNavigatePrev={handleNavigatePrev}
+            progressValue={view.progressValue}
+            totalSteps={view.totalSteps}
+          />
         )}
-
-        {view.showHeader && <PlayerProgressBar value={view.progressValue} />}
 
         <PlayerStage phase={state.phase}>
           <StageContent

--- a/apps/main/src/components/activity-player/in-play-sticky-header.tsx
+++ b/apps/main/src/components/activity-player/in-play-sticky-header.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { DimensionStatusButton } from "./dimension-status-button";
+import {
+  PlayerCloseLink,
+  PlayerHeader,
+  PlayerNav,
+  PlayerNavButton,
+  PlayerNavGroup,
+  PlayerStepFraction,
+} from "./player-header";
+import { PlayerProgressBar } from "./player-progress-bar";
+import { type PlayerState } from "./player-reducer";
+
+export function InPlayStickyHeader({
+  currentStepIndex,
+  dimensions,
+  hasDimensions,
+  isFirstStep,
+  isStaticStep,
+  lessonHref,
+  onNavigateNext,
+  onNavigatePrev,
+  progressValue,
+  totalSteps,
+}: {
+  currentStepIndex: number;
+  dimensions: PlayerState["dimensions"];
+  hasDimensions: boolean;
+  isFirstStep: boolean;
+  isStaticStep: boolean;
+  lessonHref: string;
+  onNavigateNext: () => void;
+  onNavigatePrev: () => void;
+  progressValue: number;
+  totalSteps: number;
+}) {
+  return (
+    <div className="bg-background/95 sticky top-0 z-30 backdrop-blur-sm">
+      <PlayerHeader>
+        <PlayerCloseLink href={lessonHref} />
+
+        {isStaticStep && (
+          <PlayerNav>
+            <PlayerNavGroup>
+              <PlayerNavButton direction="prev" disabled={isFirstStep} onClick={onNavigatePrev} />
+              <PlayerStepFraction>
+                {currentStepIndex + 1} / {totalSteps}
+              </PlayerStepFraction>
+              <PlayerNavButton direction="next" onClick={onNavigateNext} />
+            </PlayerNavGroup>
+          </PlayerNav>
+        )}
+
+        {!isStaticStep && (
+          <PlayerStepFraction>
+            {currentStepIndex + 1} / {totalSteps}
+          </PlayerStepFraction>
+        )}
+
+        {hasDimensions ? (
+          <DimensionStatusButton dimensions={dimensions} />
+        ) : (
+          <div className="size-9" aria-hidden="true" />
+        )}
+      </PlayerHeader>
+
+      <PlayerProgressBar value={progressValue} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Make the activity player header and progress bar sticky (`sticky top-0`) so they remain visible when scrolling long content
- Extract `InPlayStickyHeader` into its own file to stay within `jsx-max-depth` lint rule
- Apply matching visual treatment (`bg-background/95 backdrop-blur-sm`) to mirror the bottom action bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the activity player header and progress bar sticky so they stay visible while scrolling. Introduces InPlayStickyHeader to encapsulate header UI, navigation, and progress.

- **New Features**
  - Sticky header across intro and in-play views (sticky top-0).
  - Progress bar now sits under the header and scrolls with it.
  - Matches bottom action bar styling (bg-background/95, backdrop-blur-sm).

- **Refactors**
  - Extracted InPlayStickyHeader to satisfy jsx-max-depth and simplify ActivityPlayerShell.
  - Replaced inline header logic in ActivityPlayerShell and removed separate PlayerProgressBar render.

<sup>Written for commit 20604f72e05599b93f55a050578953d749cd0793. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

