### PR TITLE
fix(main): center completion button labels on small screens

### DIFF
--- a/apps/main/src/components/activity-player/challenge-completion.tsx
+++ b/apps/main/src/components/activity-player/challenge-completion.tsx
@@ -87,7 +87,7 @@ export function ChallengeFailureContent({
       <DimensionList aria-label="Final dimension scores" entries={entries} variant="failure" />
 
       <ChallengeActions>
-        <Button className="w-full justify-between" onClick={onRestart} size="lg">
+        <Button className="w-full lg:justify-between" onClick={onRestart} size="lg">
           {t("Try Again")}
           <Kbd className="bg-primary-foreground/15 text-primary-foreground hidden opacity-70 lg:inline-flex">
             R
@@ -95,7 +95,7 @@ export function ChallengeFailureContent({
         </Button>
 
         <ClientLink
-          className={cn(buttonVariants({ variant: "outline" }), "w-full justify-between")}
+          className={cn(buttonVariants({ variant: "outline" }), "w-full lg:justify-between")}
           href={lessonHref}
         >
           {t("Back to Lesson")}

--- a/apps/main/src/components/activity-player/completion-auth-branch.tsx
+++ b/apps/main/src/components/activity-player/completion-auth-branch.tsx
@@ -65,7 +65,7 @@ function SecondaryActions({
     <ClientLink
       className={cn(
         buttonVariants({ variant: isInline ? "outline" : "default" }),
-        isInline ? "flex-1 justify-between" : "w-full justify-between",
+        isInline ? "flex-1 lg:justify-between" : "w-full lg:justify-between",
       )}
       href={lessonHref}
     >
@@ -83,7 +83,7 @@ function SecondaryActions({
 
   const restartButton = (
     <Button
-      className={cn(isInline ? "flex-1" : "w-full", "justify-between")}
+      className={cn(isInline ? "flex-1" : "w-full", "lg:justify-between")}
       onClick={onRestart}
       variant="outline"
     >
@@ -128,7 +128,7 @@ function AuthenticatedContent({
         {nextActivityHref ? (
           <>
             <ClientLink
-              className={cn(buttonVariants({ size: "lg" }), "w-full justify-between")}
+              className={cn(buttonVariants({ size: "lg" }), "w-full lg:justify-between")}
               href={nextActivityHref}
             >
               {t("Next")}


### PR DESCRIPTION
## Summary

- Changed `justify-between` to `lg:justify-between` on completion screen buttons so labels center on small viewports where the `Kbd` shortcut hint is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers completion button labels on small screens by scoping justify-between to lg:justify-between in completion views. Labels now center when Kbd shortcuts are hidden on mobile, while the spaced layout remains on large screens.

<sup>Written for commit 85d678200047d15e1b959deb04ec5725ea23a8b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

