### PR TITLE
feat(main): add select-image step UI

### DIFF
--- a/apps/main/e2e/select-image-step.test.ts
+++ b/apps/main/e2e/select-image-step.test.ts
@@ -1,0 +1,345 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { expect, test } from "./fixtures";
+
+async function createSelectImageActivity(options: {
+  steps: { content: object; position: number }[];
+}) {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-si-course-${uniqueId}`,
+    title: `E2E SI Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-si-chapter-${uniqueId}`,
+    title: `E2E SI Chapter ${uniqueId}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    description: `E2E si lesson ${uniqueId}`,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-si-lesson-${uniqueId}`,
+    title: `E2E SI Lesson ${uniqueId}`,
+  });
+
+  const activity = await activityFixture({
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "background",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 0,
+    title: `E2E SI Activity ${uniqueId}`,
+  });
+
+  await Promise.all(
+    options.steps.map((step) =>
+      stepFixture({
+        activityId: activity.id,
+        content: step.content,
+        isPublished: true,
+        kind: "selectImage",
+        position: step.position,
+      }),
+    ),
+  );
+
+  const url = `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/0`;
+
+  return { activity, chapter, course, lesson, uniqueId, url };
+}
+
+test.describe("Select Image Step", () => {
+  test("renders question and image options as radio buttons", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSelectImageActivity({
+      steps: [
+        {
+          content: {
+            options: [
+              {
+                feedback: "Correct!",
+                isCorrect: true,
+                prompt: `Cat ${uniqueId}`,
+                url: "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/test-cat.jpg",
+              },
+              {
+                feedback: "Not quite",
+                isCorrect: false,
+                prompt: `Dog ${uniqueId}`,
+                url: "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/test-dog.jpg",
+              },
+            ],
+            question: `Which is a cat ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(page.getByText(new RegExp(`Which is a cat ${uniqueId}`))).toBeVisible();
+
+    const radiogroup = page.getByRole("radiogroup", { name: /image options/i });
+    await expect(radiogroup).toBeVisible();
+
+    await expect(
+      radiogroup.getByRole("radio", { name: new RegExp(`Cat ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(
+      radiogroup.getByRole("radio", { name: new RegExp(`Dog ${uniqueId}`) }),
+    ).toBeVisible();
+  });
+
+  test("selecting an image marks it as checked", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSelectImageActivity({
+      steps: [
+        {
+          content: {
+            options: [
+              { feedback: "Yes", isCorrect: true, prompt: `Alpha ${uniqueId}` },
+              { feedback: "No", isCorrect: false, prompt: `Beta ${uniqueId}` },
+            ],
+            question: `Pick one ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const alpha = page.getByRole("radio", { name: new RegExp(`Alpha ${uniqueId}`) });
+    const beta = page.getByRole("radio", { name: new RegExp(`Beta ${uniqueId}`) });
+
+    await alpha.click();
+
+    await expect(alpha).toHaveAttribute("aria-checked", "true");
+    await expect(beta).toHaveAttribute("aria-checked", "false");
+  });
+
+  test("check button disabled until selection", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSelectImageActivity({
+      steps: [
+        {
+          content: {
+            options: [
+              { feedback: "Yes", isCorrect: true, prompt: `Opt1 ${uniqueId}` },
+              { feedback: "No", isCorrect: false, prompt: `Opt2 ${uniqueId}` },
+            ],
+            question: `Select ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByRole("button", { name: /check/i })).toBeDisabled();
+
+    await page.getByRole("radio", { name: new RegExp(`Opt1 ${uniqueId}`) }).click();
+
+    await expect(page.getByRole("button", { name: /check/i })).toBeEnabled();
+  });
+
+  test("correct answer shows feedback", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSelectImageActivity({
+      steps: [
+        {
+          content: {
+            options: [
+              { feedback: `Well done ${uniqueId}`, isCorrect: true, prompt: `Right ${uniqueId}` },
+              { feedback: "Nope", isCorrect: false, prompt: `Wrong ${uniqueId}` },
+            ],
+            question: `Pick correct ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("radio", { name: new RegExp(`Right ${uniqueId}`) }).click();
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByText(/correct!/i)).toBeVisible();
+    await expect(page.getByText(new RegExp(`Well done ${uniqueId}`))).toBeVisible();
+  });
+
+  test("incorrect answer shows feedback", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSelectImageActivity({
+      steps: [
+        {
+          content: {
+            options: [
+              { feedback: "Good job", isCorrect: true, prompt: `Correct ${uniqueId}` },
+              {
+                feedback: `Try again ${uniqueId}`,
+                isCorrect: false,
+                prompt: `Incorrect ${uniqueId}`,
+              },
+            ],
+            question: `Pick one ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("radio", { name: new RegExp(`Incorrect ${uniqueId}`) }).click();
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByText(/not quite/i)).toBeVisible();
+    await expect(page.getByText(new RegExp(`Try again ${uniqueId}`))).toBeVisible();
+  });
+
+  test("changing selection before checking", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSelectImageActivity({
+      steps: [
+        {
+          content: {
+            options: [
+              { feedback: "Yes", isCorrect: true, prompt: `First ${uniqueId}` },
+              { feedback: "No", isCorrect: false, prompt: `Second ${uniqueId}` },
+            ],
+            question: `Change test ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const first = page.getByRole("radio", { name: new RegExp(`First ${uniqueId}`) });
+    const second = page.getByRole("radio", { name: new RegExp(`Second ${uniqueId}`) });
+
+    await first.click();
+    await expect(first).toHaveAttribute("aria-checked", "true");
+    await expect(second).toHaveAttribute("aria-checked", "false");
+
+    await second.click();
+    await expect(second).toHaveAttribute("aria-checked", "true");
+    await expect(first).toHaveAttribute("aria-checked", "false");
+  });
+
+  test("full flow: select, check, feedback, continue, completion", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSelectImageActivity({
+      steps: [
+        {
+          content: {
+            options: [
+              { feedback: `Nice ${uniqueId}`, isCorrect: true, prompt: `Winner ${uniqueId}` },
+              { feedback: "Nope", isCorrect: false, prompt: `Loser ${uniqueId}` },
+            ],
+            question: `Full flow ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("radio", { name: new RegExp(`Winner ${uniqueId}`) }).click();
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByText(/correct!/i)).toBeVisible();
+    await expect(page.getByText(new RegExp(`Nice ${uniqueId}`))).toBeVisible();
+
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await expect(page.getByText("1/1")).toBeVisible();
+    await expect(page.getByText(/correct/i)).toBeVisible();
+  });
+
+  test("missing URL shows prompt text as fallback", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSelectImageActivity({
+      steps: [
+        {
+          content: {
+            options: [
+              { feedback: "Yes", isCorrect: true, prompt: `NoImage ${uniqueId}` },
+              { feedback: "No", isCorrect: false, prompt: `HasImage ${uniqueId}` },
+            ],
+            question: `Fallback test ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    // The option without URL should be rendered and selectable
+    const noImageOption = page.getByRole("radio", { name: new RegExp(`NoImage ${uniqueId}`) });
+    await expect(noImageOption).toBeVisible();
+
+    await noImageOption.click();
+    await expect(noImageOption).toHaveAttribute("aria-checked", "true");
+  });
+
+  test("keyboard shortcut selects option", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createSelectImageActivity({
+      steps: [
+        {
+          content: {
+            options: [
+              { feedback: `Fb1 ${uniqueId}`, isCorrect: true, prompt: `Img1 ${uniqueId}` },
+              { feedback: `Fb2 ${uniqueId}`, isCorrect: false, prompt: `Img2 ${uniqueId}` },
+            ],
+            question: `Keyboard test ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    await page.keyboard.press("1");
+
+    await expect(page.getByRole("button", { name: /check/i })).toBeEnabled();
+
+    await page.keyboard.press("Enter");
+    await expect(page.getByText(new RegExp(`Fb[12] ${uniqueId}`))).toBeVisible();
+  });
+});

--- a/apps/main/src/components/activity-player/select-image-step.tsx
+++ b/apps/main/src/components/activity-player/select-image-step.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { type SerializedStep } from "@/data/activities/prepare-activity-data";
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
+import { cn } from "@zoonk/ui/lib/utils";
+import Image from "next/image";
+import { useState } from "react";
+import { type SelectedAnswer } from "./player-reducer";
+import { QuestionText } from "./question-text";
+import { InteractiveStepLayout } from "./step-layouts";
+import { useOptionKeyboard } from "./use-option-keyboard";
+
+function getSelectedIndex(selectedAnswer: SelectedAnswer | undefined): number | null {
+  if (selectedAnswer?.kind !== "selectImage") {
+    return null;
+  }
+
+  return selectedAnswer.selectedIndex;
+}
+
+function ImageWithFallback({ alt, url }: { alt: string; url: string | undefined }) {
+  const [hasError, setHasError] = useState(false);
+
+  if (!url || hasError) {
+    return (
+      <div className="bg-muted flex aspect-square items-center justify-center p-4">
+        <span className="text-muted-foreground text-center text-sm font-medium">{alt}</span>
+      </div>
+    );
+  }
+
+  return (
+    <Image
+      alt={alt}
+      className="aspect-square object-cover"
+      height={336}
+      onError={() => setHasError(true)}
+      sizes="(max-width: 672px) 50vw, 336px"
+      src={url}
+      width={336}
+    />
+  );
+}
+
+function ImageOptionCard({
+  isSelected,
+  onSelect,
+  prompt,
+  url,
+}: {
+  isSelected: boolean;
+  onSelect: () => void;
+  prompt: string;
+  url: string | undefined;
+}) {
+  return (
+    <button
+      aria-checked={isSelected}
+      className={cn(
+        "focus-visible:border-ring focus-visible:ring-ring/50 overflow-hidden rounded-xl border transition-colors duration-150 outline-none focus-visible:ring-[3px]",
+        isSelected ? "border-primary bg-primary/5" : "border-border hover:bg-accent",
+      )}
+      onClick={onSelect}
+      role="radio"
+      type="button"
+    >
+      <ImageWithFallback alt={prompt} url={url} />
+    </button>
+  );
+}
+
+export function SelectImageStep({
+  onSelectAnswer,
+  selectedAnswer,
+  step,
+}: {
+  onSelectAnswer: (stepId: string, answer: SelectedAnswer) => void;
+  selectedAnswer: SelectedAnswer | undefined;
+  step: SerializedStep;
+}) {
+  const content = parseStepContent("selectImage", step.content);
+  const selectedIndex = getSelectedIndex(selectedAnswer);
+
+  const handleSelect = (index: number) => {
+    onSelectAnswer(step.id, { kind: "selectImage", selectedIndex: index });
+  };
+
+  useOptionKeyboard({
+    enabled: selectedAnswer === undefined || selectedAnswer.kind === "selectImage",
+    onSelect: handleSelect,
+    optionCount: content.options.length,
+  });
+
+  return (
+    <InteractiveStepLayout>
+      {content.question ? <QuestionText>{content.question}</QuestionText> : null}
+
+      <div aria-label="Image options" className="grid grid-cols-2 gap-3" role="radiogroup">
+        {content.options.map((option, index) => (
+          <ImageOptionCard
+            isSelected={selectedIndex === index}
+            key={option.prompt}
+            onSelect={() => handleSelect(index)}
+            prompt={option.prompt}
+            url={option.url}
+          />
+        ))}
+      </div>
+    </InteractiveStepLayout>
+  );
+}

--- a/apps/main/src/components/activity-player/step-renderer.tsx
+++ b/apps/main/src/components/activity-player/step-renderer.tsx
@@ -7,6 +7,7 @@ import { FillBlankStep } from "./fill-blank-step";
 import { MatchColumnsStep } from "./match-columns-step";
 import { MultipleChoiceStep } from "./multiple-choice-step";
 import { type SelectedAnswer, type StepResult } from "./player-reducer";
+import { SelectImageStep } from "./select-image-step";
 import { SortOrderStep } from "./sort-order-step";
 import { StaticStep } from "./static-step";
 import { StaticTapZones, useSwipeNavigation } from "./static-step-navigation";
@@ -95,6 +96,16 @@ export function StepRenderer({
   if (step.kind === "matchColumns") {
     return (
       <MatchColumnsStep
+        onSelectAnswer={onSelectAnswer}
+        selectedAnswer={selectedAnswer}
+        step={step}
+      />
+    );
+  }
+
+  if (step.kind === "selectImage") {
+    return (
+      <SelectImageStep
         onSelectAnswer={onSelectAnswer}
         selectedAnswer={selectedAnswer}
         step={step}


### PR DESCRIPTION
## Summary
- Add `SelectImageStep` component with square image grid, selection styling, keyboard shortcuts, and broken image fallback
- Wire `selectImage` case into `StepRenderer`
- Add 9 E2E tests covering rendering, selection, feedback, full flow, fallback, and keyboard shortcuts

## Test plan
- [x] E2E: renders question and image options as radio buttons
- [x] E2E: selecting an image marks it as checked
- [x] E2E: check button disabled until selection
- [x] E2E: correct/incorrect answer shows feedback
- [x] E2E: changing selection before checking
- [x] E2E: full flow through completion
- [x] E2E: missing URL fallback
- [x] E2E: keyboard shortcut selects option

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SelectImageStep to the activity player: a two-column image grid with radio-style selection, 1–9 keyboard shortcuts, and prompt-text fallback when images are missing or fail. Wires the selectImage kind into StepRenderer and adds 9 E2E tests for rendering, selection, feedback, full flow, fallback, and keyboard interactions.

<sup>Written for commit 9eca5482f3d484fd22dcaca3538d48fc199191f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

