### PR TITLE
chore(ci): add path filtering and shard main e2e tests

### DIFF
--- a/.github/workflows/e2e-api.yml
+++ b/.github/workflows/e2e-api.yml
@@ -1,6 +1,12 @@
 name: E2E Tests (API App)
 
-on: push
+on:
+  push:
+    paths:
+      - "apps/api/**"
+      - "packages/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/e2e-api.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-editor.yml
+++ b/.github/workflows/e2e-editor.yml
@@ -1,6 +1,12 @@
 name: E2E Tests (Editor App)
 
-on: push
+on:
+  push:
+    paths:
+      - "apps/editor/**"
+      - "packages/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/e2e-editor.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -1,6 +1,12 @@
 name: E2E Tests (Main App)
 
-on: push
+on:
+  push:
+    paths:
+      - "apps/main/**"
+      - "packages/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/e2e-main.yml"
 
 permissions:
   contents: read
@@ -12,6 +18,10 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     env:
       BETTER_AUTH_SECRET: test-secret-for-ci
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/zoonk_e2e
@@ -87,4 +97,4 @@ jobs:
         run: pnpm build:e2e --filter main
 
       - name: Run E2E tests
-        run: pnpm e2e --filter main
+        run: pnpm e2e --filter main -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -6,7 +6,6 @@ const CACHE_IMAGE_DAYS = 30;
 
 const isE2E = process.env.E2E_TESTING === "true";
 
-// test only editor e2e runs
 // Swap modules for E2E-specific config during E2E builds
 const e2eAliases: Record<string, string> = isE2E
   ? {

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -6,6 +6,7 @@ const CACHE_IMAGE_DAYS = 30;
 
 const isE2E = process.env.E2E_TESTING === "true";
 
+// test only editor e2e runs
 // Swap modules for E2E-specific config during E2E builds
 const e2eAliases: Record<string, string> = isE2E
   ? {


### PR DESCRIPTION
## Summary

- Add `on.push.paths` filtering to all 3 E2E workflows so they only run when relevant files change
- Shard main app E2E tests into 3 parallel jobs for faster CI

## Test plan

- [ ] Verify workflows skip on unrelated file changes
- [ ] Verify main E2E shards run in parallel and all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add path filtering to all E2E workflows and shard the main app E2E tests into 3 parallel jobs to speed up CI and skip unrelated pushes. Workflows trigger only on app/packages/pnpm-lock/workflow changes, and shards run with fail-fast disabled while passing the shard index to the test runner.

<sup>Written for commit b89f1c175aaf0721c1f511e3676f70a2fa5f7d99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

