### PR TITLE
fix(main): fix flaky e2e tests caused by pre-hydration interactions

### DIFF
--- a/apps/main/e2e/content-feedback.test.ts
+++ b/apps/main/e2e/content-feedback.test.ts
@@ -1,3 +1,4 @@
+import { openDialog } from "@zoonk/e2e/helpers";
 import { expect, test } from "./fixtures";
 
 // Content feedback is tested on the course suggestions page where it's used
@@ -29,9 +30,10 @@ test.describe("Content Feedback", () => {
   });
 
   test("submit with valid data shows success message", async ({ page }) => {
-    await page.getByRole("button", { name: /send feedback/i }).click();
-
+    const feedbackButton = page.getByRole("button", { name: /send feedback/i });
     const dialog = page.getByRole("dialog");
+    await openDialog(feedbackButton, dialog);
+
     const emailInput = dialog.getByRole("textbox", { name: /email address/i });
     const messageInput = dialog.getByRole("textbox", { name: /^message$/i });
 
@@ -47,9 +49,10 @@ test.describe("Content Feedback", () => {
   });
 
   test("submit with invalid email shows validation error", async ({ page }) => {
-    await page.getByRole("button", { name: /send feedback/i }).click();
-
+    const feedbackButton = page.getByRole("button", { name: /send feedback/i });
     const dialog = page.getByRole("dialog");
+    await openDialog(feedbackButton, dialog);
+
     const emailInput = dialog.getByRole("textbox", { name: /email address/i });
     const messageInput = dialog.getByRole("textbox", { name: /^message$/i });
 
@@ -70,9 +73,10 @@ test.describe("Content Feedback", () => {
   });
 
   test("submit failure shows error message", async ({ page }) => {
-    await page.getByRole("button", { name: /send feedback/i }).click();
-
+    const feedbackButton = page.getByRole("button", { name: /send feedback/i });
     const dialog = page.getByRole("dialog");
+    await openDialog(feedbackButton, dialog);
+
     const emailInput = dialog.getByRole("textbox", { name: /email address/i });
     const messageInput = dialog.getByRole("textbox", { name: /^message$/i });
 
@@ -96,11 +100,12 @@ test.describe("Content Feedback - Authenticated", () => {
     // Wait for content to load
     await expect(authenticatedPage.getByText("Introduction to Testing")).toBeVisible();
 
-    await authenticatedPage.getByRole("button", { name: /send feedback/i }).click();
+    const feedbackButton = authenticatedPage.getByRole("button", { name: /send feedback/i });
+    const dialog = authenticatedPage.getByRole("dialog");
+    await openDialog(feedbackButton, dialog);
 
-    const emailInput = authenticatedPage.getByRole("textbox", { name: /email address/i });
+    const emailInput = dialog.getByRole("textbox", { name: /email address/i });
 
-    // Wait for dialog to be fully visible and email input to be enabled
     await expect(emailInput).toBeEnabled();
 
     // Should be pre-filled with user's email

--- a/apps/main/e2e/multiple-choice-step.test.ts
+++ b/apps/main/e2e/multiple-choice-step.test.ts
@@ -409,9 +409,12 @@ test.describe("Challenge Variant", () => {
     await page.goto(url);
     await expect(page.getByText(/make choices/i)).toBeVisible();
 
-    await page.keyboard.press("Enter");
-
-    await expect(page.getByText(new RegExp(`Enter question ${uniqueId}`))).toBeVisible();
+    await expect(async () => {
+      await page.keyboard.press("Enter");
+      await expect(page.getByText(new RegExp(`Enter question ${uniqueId}`))).toBeVisible({
+        timeout: 1000,
+      });
+    }).toPass();
   });
 
   test("renders context, question, and options after begin", async ({ page }) => {

--- a/apps/main/e2e/sort-order-step.test.ts
+++ b/apps/main/e2e/sort-order-step.test.ts
@@ -150,24 +150,31 @@ test.describe("Sort Order Step", () => {
 
     const itemList = page.getByRole("list", { name: /sort items/i });
 
-    // Select three items
-    await itemList
-      .getByRole("button", { name: new RegExp(`Uno ${uniqueId}.*Tap to select`) })
-      .click();
+    // First click: resilient to hydration timing
+    const unoSelected = itemList.getByRole("button", {
+      name: new RegExp(`Position 1.*Uno ${uniqueId}`),
+    });
+
+    await expect(async () => {
+      if (!(await unoSelected.isVisible())) {
+        await itemList
+          .getByRole("button", { name: new RegExp(`Uno ${uniqueId}.*Tap to select`) })
+          .click();
+      }
+      await expect(unoSelected).toBeVisible({ timeout: 1000 });
+    }).toPass();
+
+    // Subsequent clicks: page is hydrated, add assertions for determinism
     await itemList
       .getByRole("button", { name: new RegExp(`Dos ${uniqueId}.*Tap to select`) })
       .click();
-    await itemList
-      .getByRole("button", { name: new RegExp(`Tres ${uniqueId}.*Tap to select`) })
-      .click();
-
-    // Verify positions
-    await expect(
-      itemList.getByRole("button", { name: new RegExp(`Position 1.*Uno ${uniqueId}`) }),
-    ).toBeVisible();
     await expect(
       itemList.getByRole("button", { name: new RegExp(`Position 2.*Dos ${uniqueId}`) }),
     ).toBeVisible();
+
+    await itemList
+      .getByRole("button", { name: new RegExp(`Tres ${uniqueId}.*Tap to select`) })
+      .click();
     await expect(
       itemList.getByRole("button", { name: new RegExp(`Position 3.*Tres ${uniqueId}`) }),
     ).toBeVisible();

--- a/apps/main/e2e/support.test.ts
+++ b/apps/main/e2e/support.test.ts
@@ -1,3 +1,4 @@
+import { openDialog } from "@zoonk/e2e/helpers";
 import { expect, test } from "./fixtures";
 
 test.describe("Support page", () => {
@@ -14,9 +15,9 @@ test.describe("Support page", () => {
   });
 
   test("submit with valid data shows success message", async ({ page }) => {
-    await page.getByRole("button", { name: /contact support/i }).click();
-
+    const supportButton = page.getByRole("button", { name: /contact support/i });
     const dialog = page.getByRole("dialog");
+    await openDialog(supportButton, dialog);
     const emailInput = dialog.getByRole("textbox", { name: /email address/i });
     const messageInput = dialog.getByRole("textbox", { name: /^message$/i });
 
@@ -31,9 +32,9 @@ test.describe("Support page", () => {
   });
 
   test("submit with invalid email shows validation error", async ({ page }) => {
-    await page.getByRole("button", { name: /contact support/i }).click();
-
+    const supportButton = page.getByRole("button", { name: /contact support/i });
     const dialog = page.getByRole("dialog");
+    await openDialog(supportButton, dialog);
     const emailInput = dialog.getByRole("textbox", { name: /email address/i });
     const messageInput = dialog.getByRole("textbox", { name: /^message$/i });
 
@@ -53,9 +54,9 @@ test.describe("Support page", () => {
   });
 
   test("submit failure shows error message", async ({ page }) => {
-    await page.getByRole("button", { name: /contact support/i }).click();
-
+    const supportButton = page.getByRole("button", { name: /contact support/i });
     const dialog = page.getByRole("dialog");
+    await openDialog(supportButton, dialog);
     const emailInput = dialog.getByRole("textbox", { name: /email address/i });
     const messageInput = dialog.getByRole("textbox", { name: /^message$/i });
 
@@ -76,11 +77,11 @@ test.describe("Support page - Authenticated", () => {
   test("email field shows authenticated user's email", async ({ authenticatedPage }) => {
     await authenticatedPage.goto("/support");
 
-    await authenticatedPage.getByRole("button", { name: /contact support/i }).click();
+    const supportButton = authenticatedPage.getByRole("button", { name: /contact support/i });
+    const dialog = authenticatedPage.getByRole("dialog");
+    await openDialog(supportButton, dialog);
 
-    const emailInput = authenticatedPage
-      .getByRole("dialog")
-      .getByRole("textbox", { name: /email address/i });
+    const emailInput = dialog.getByRole("textbox", { name: /email address/i });
 
     await expect(emailInput).toBeEnabled();
 

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "exports": {
     "./base.config": "./src/base.config.ts",
-    "./fixtures": "./src/fixtures/index.ts"
+    "./fixtures": "./src/fixtures/index.ts",
+    "./helpers": "./src/helpers.ts"
   },
   "scripts": {
     "typecheck": "tsgo --noEmit"

--- a/packages/e2e/src/helpers.ts
+++ b/packages/e2e/src/helpers.ts
@@ -1,0 +1,15 @@
+import { type Locator, expect } from "@playwright/test";
+
+/**
+ * Click a dialog trigger and wait for the dialog to open.
+ * Retries the click if the dialog doesn't appear (handles pre-hydration timing).
+ * Uses a visibility guard to avoid toggling the dialog closed on retry.
+ */
+export async function openDialog(trigger: Locator, dialog: Locator) {
+  await expect(async () => {
+    if (!(await dialog.isVisible())) {
+      await trigger.click();
+    }
+    await expect(dialog).toBeVisible({ timeout: 1000 });
+  }).toPass();
+}


### PR DESCRIPTION
## Summary

- Add `openDialog` helper in `@zoonk/e2e/helpers` that retries dialog trigger clicks until the dialog opens, handling pre-hydration timing
- Wrap Enter key press in `toPass()` retry for challenge intro test
- Apply `openDialog` to all 8 dialog-opening tests in content-feedback and support
- Make first click in sort-order deselect test resilient with visibility guard + intermediate assertions

## Test plan

- [x] All 5 previously flaky tests pass consistently
- [x] Stress-tested with `--repeat-each=5` (70 runs, 0 failures)
- [x] `pnpm turbo quality:fix` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm knip` passes
- [x] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky e2e tests caused by pre-hydration by making early interactions resilient. Stabilizes content feedback, support dialogs, challenge intro, and sort order flows.

- **Bug Fixes**
  - Added openDialog helper in @zoonk/e2e/helpers that retries trigger clicks until the dialog is visible; exported in packages/e2e.
  - Applied openDialog to all dialog-opening tests in content-feedback and support.
  - Wrapped the initial Enter key press in the challenge intro with expect(...).toPass() for retry.
  - Hardened the first click in the sort-order test with a visibility guard and deterministic assertions.

<sup>Written for commit 03eaeb7393adec0429cae096d4f59428b86b1aa1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

