### PR TITLE
feat(main): add visual renderer registry and quote renderer

### DIFF
--- a/apps/main/e2e/step-visual-content.test.ts
+++ b/apps/main/e2e/step-visual-content.test.ts
@@ -1,0 +1,157 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { expect, test } from "./fixtures";
+
+async function createStaticActivityWithVisual(options: {
+  steps: {
+    content: object;
+    position: number;
+    visualContent?: object;
+    visualKind?: "chart" | "code" | "diagram" | "image" | "quote" | "table" | "timeline";
+  }[];
+}) {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-visual-course-${uniqueId}`,
+    title: `E2E Visual Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-visual-chapter-${uniqueId}`,
+    title: `E2E Visual Chapter ${uniqueId}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    description: `E2E visual lesson ${uniqueId}`,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-visual-lesson-${uniqueId}`,
+    title: `E2E Visual Lesson ${uniqueId}`,
+  });
+
+  const activity = await activityFixture({
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "background",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 0,
+    title: `E2E Visual Activity ${uniqueId}`,
+  });
+
+  await Promise.all(
+    options.steps.map((step) =>
+      stepFixture({
+        activityId: activity.id,
+        content: step.content,
+        isPublished: true,
+        position: step.position,
+        visualContent: step.visualContent,
+        visualKind: step.visualKind,
+      }),
+    ),
+  );
+
+  const url = `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/0`;
+
+  return { url };
+}
+
+test.describe("Step Visual Content", () => {
+  test("static step with quote visual renders quote text and author", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createStaticActivityWithVisual({
+      steps: [
+        {
+          content: {
+            text: `Quote body ${uniqueId}`,
+            title: `Quote Title ${uniqueId}`,
+            variant: "text",
+          },
+          position: 0,
+          visualContent: {
+            author: `Author ${uniqueId}`,
+            text: `The only limit is your imagination ${uniqueId}`,
+          },
+          visualKind: "quote",
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(
+      page.getByText(new RegExp(`The only limit is your imagination ${uniqueId}`)),
+    ).toBeVisible();
+    await expect(page.getByText(new RegExp(`Author ${uniqueId}`))).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Quote Title ${uniqueId}`) }),
+    ).toBeVisible();
+  });
+
+  test("static step without visual content renders text content normally", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createStaticActivityWithVisual({
+      steps: [
+        {
+          content: {
+            text: `No visual body ${uniqueId}`,
+            title: `No Visual Title ${uniqueId}`,
+            variant: "text",
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`No Visual Title ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(page.getByText(new RegExp(`No visual body ${uniqueId}`))).toBeVisible();
+  });
+
+  test("static step with unimplemented visual kind renders text content without crashing", async ({
+    page,
+  }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createStaticActivityWithVisual({
+      steps: [
+        {
+          content: {
+            text: `Unimplemented body ${uniqueId}`,
+            title: `Unimplemented Title ${uniqueId}`,
+            variant: "text",
+          },
+          position: 0,
+          visualContent: { code: "console.log('hello')", language: "javascript" },
+          visualKind: "code",
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Unimplemented Title ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(page.getByText(new RegExp(`Unimplemented body ${uniqueId}`))).toBeVisible();
+  });
+});

--- a/apps/main/src/components/activity-player/activity-player-shell.tsx
+++ b/apps/main/src/components/activity-player/activity-player-shell.tsx
@@ -154,7 +154,7 @@ export function ActivityPlayerShell({
           />
         )}
 
-        <PlayerStage phase={state.phase}>
+        <PlayerStage isStatic={view.isStaticStep && state.phase === "playing"} phase={state.phase}>
           <StageContent
             activityId={state.activityId}
             currentResult={view.currentResult}

--- a/apps/main/src/components/activity-player/player-stage.tsx
+++ b/apps/main/src/components/activity-player/player-stage.tsx
@@ -3,15 +3,18 @@ import { type PlayerPhase } from "./player-reducer";
 
 export function PlayerStage({
   className,
+  isStatic,
   phase,
   ...props
 }: React.ComponentProps<"section"> & {
+  isStatic?: boolean;
   phase: PlayerPhase;
 }) {
   return (
     <section
       className={cn(
-        "flex flex-1 flex-col items-center justify-center overflow-y-auto p-4",
+        "flex flex-1 flex-col items-center overflow-y-auto",
+        isStatic ? "p-0" : "justify-center p-4",
         "data-[phase=feedback]:px-6 data-[phase=feedback]:sm:px-8",
         className,
       )}

--- a/apps/main/src/components/activity-player/quote-visual.tsx
+++ b/apps/main/src/components/activity-player/quote-visual.tsx
@@ -21,7 +21,7 @@ export function QuoteVisual({ content }: { content: VisualContentByKind[Supporte
   const parsed = quoteVisualContentSchema.parse(content);
 
   return (
-    <figure className="flex max-w-lg flex-col items-center gap-6 text-center">
+    <figure className="flex w-full max-w-xl flex-col items-center gap-4 px-2 text-center sm:gap-6">
       <QuoteMark />
 
       <blockquote>

--- a/apps/main/src/components/activity-player/quote-visual.tsx
+++ b/apps/main/src/components/activity-player/quote-visual.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import {
+  type SupportedVisualKind,
+  type VisualContentByKind,
+  quoteVisualContentSchema,
+} from "@zoonk/core/steps/visual-content-contract";
+
+function QuoteMark() {
+  return (
+    <span
+      aria-hidden="true"
+      className="text-muted-foreground/20 font-serif text-6xl leading-none select-none"
+    >
+      &ldquo;
+    </span>
+  );
+}
+
+export function QuoteVisual({ content }: { content: VisualContentByKind[SupportedVisualKind] }) {
+  const parsed = quoteVisualContentSchema.parse(content);
+
+  return (
+    <figure className="flex max-w-lg flex-col items-center gap-6 text-center">
+      <QuoteMark />
+
+      <blockquote>
+        <p className="text-xl leading-relaxed font-medium tracking-tight sm:text-2xl sm:leading-relaxed">
+          {parsed.text}
+        </p>
+      </blockquote>
+
+      <figcaption className="text-muted-foreground text-sm tracking-wide">
+        {parsed.author}
+      </figcaption>
+    </figure>
+  );
+}

--- a/apps/main/src/components/activity-player/stage-content.tsx
+++ b/apps/main/src/components/activity-player/stage-content.tsx
@@ -87,7 +87,7 @@ export function StageContent({
   if (phase === "playing" && currentStep) {
     return (
       <div
-        className="animate-in fade-in flex w-full flex-col items-center duration-150 ease-out motion-reduce:animate-none"
+        className="animate-in fade-in flex w-full flex-1 flex-col items-center justify-center duration-150 ease-out motion-reduce:animate-none"
         key={`step-${currentStepIndex}`}
       >
         <StepRenderer

--- a/apps/main/src/components/activity-player/static-step.tsx
+++ b/apps/main/src/components/activity-player/static-step.tsx
@@ -5,6 +5,7 @@ import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { HighlightText } from "./highlight-text";
 import { ContextText } from "./question-text";
 import { StaticStepText, StaticStepVisual } from "./step-layouts";
+import { StepVisualRenderer } from "./step-visual-renderer";
 import { useReplaceName } from "./user-name-context";
 
 function TextVariant({ title, text }: { title: string; text: string }) {
@@ -75,7 +76,9 @@ function StaticStepContent({ step }: { step: SerializedStep }) {
 export function StaticStep({ step }: { step: SerializedStep }) {
   return (
     <>
-      <StaticStepVisual />
+      <StaticStepVisual>
+        <StepVisualRenderer visualContent={step.visualContent} visualKind={step.visualKind} />
+      </StaticStepVisual>
 
       <StaticStepText className="px-6 pt-6 pb-8 sm:px-8 sm:pb-10">
         <StaticStepContent step={step} />

--- a/apps/main/src/components/activity-player/static-step.tsx
+++ b/apps/main/src/components/activity-player/static-step.tsx
@@ -2,6 +2,7 @@
 
 import { type SerializedStep } from "@/data/activities/prepare-activity-data";
 import { parseStepContent } from "@zoonk/core/steps/content-contract";
+import { cn } from "@zoonk/ui/lib/utils";
 import { HighlightText } from "./highlight-text";
 import { ContextText } from "./question-text";
 import { StaticStepText, StaticStepVisual } from "./step-layouts";
@@ -74,13 +75,22 @@ function StaticStepContent({ step }: { step: SerializedStep }) {
 }
 
 export function StaticStep({ step }: { step: SerializedStep }) {
+  const hasVisual = Boolean(step.visualKind && step.visualContent);
+
   return (
     <>
-      <StaticStepVisual>
-        <StepVisualRenderer visualContent={step.visualContent} visualKind={step.visualKind} />
-      </StaticStepVisual>
+      {hasVisual && (
+        <StaticStepVisual>
+          <StepVisualRenderer visualContent={step.visualContent} visualKind={step.visualKind} />
+        </StaticStepVisual>
+      )}
 
-      <StaticStepText className="px-6 pt-6 pb-8 sm:px-8 sm:pb-10">
+      <StaticStepText
+        className={cn(
+          "px-4 pt-5 pb-6 sm:px-6 sm:pt-6 sm:pb-8",
+          hasVisual && "border-border/40 border-t",
+        )}
+      >
         <StaticStepContent step={step} />
       </StaticStepText>
     </>

--- a/apps/main/src/components/activity-player/step-layouts.tsx
+++ b/apps/main/src/components/activity-player/step-layouts.tsx
@@ -13,7 +13,10 @@ export function StaticStepLayout({ className, ...props }: React.ComponentProps<"
 export function StaticStepVisual({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("flex flex-1 items-center justify-center", className)}
+      className={cn(
+        "flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-4 py-6 sm:px-6 sm:py-8",
+        className,
+      )}
       data-slot="static-step-visual"
       {...props}
     />

--- a/apps/main/src/components/activity-player/step-renderer.tsx
+++ b/apps/main/src/components/activity-player/step-renderer.tsx
@@ -65,8 +65,10 @@ export function StepRenderer({
   const swipeHandlers = useSwipeNavigation({ onNavigateNext, onNavigatePrev });
 
   if (step.kind === "static") {
+    const hasVisual = Boolean(step.visualKind && step.visualContent);
+
     return (
-      <StaticStepLayout {...swipeHandlers}>
+      <StaticStepLayout className={hasVisual ? undefined : "justify-center"} {...swipeHandlers}>
         <StaticStep step={step} />
         <StaticTapZones
           isFirst={isFirst}

--- a/apps/main/src/components/activity-player/step-visual-renderer.tsx
+++ b/apps/main/src/components/activity-player/step-visual-renderer.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import {
+  type SupportedVisualKind,
+  type VisualContentByKind,
+} from "@zoonk/core/steps/visual-content-contract";
+import { QuoteVisual } from "./quote-visual";
+
+export function StepVisualRenderer({
+  visualContent,
+  visualKind,
+}: {
+  visualContent: VisualContentByKind[SupportedVisualKind] | null;
+  visualKind: SupportedVisualKind | null;
+}) {
+  if (!visualKind || !visualContent) {
+    return null;
+  }
+
+  if (visualKind === "quote") {
+    return <QuoteVisual content={visualContent} />;
+  }
+
+  // Other visual kinds will be added in Issues 16-22.
+  return null;
+}

--- a/packages/core/src/steps/visual-content-contract.ts
+++ b/packages/core/src/steps/visual-content-contract.ts
@@ -59,7 +59,7 @@ const imageVisualContentSchema = z
   })
   .strict();
 
-const quoteVisualContentSchema = z
+export const quoteVisualContentSchema = z
   .object({
     author: z.string(),
     text: z.string(),


### PR DESCRIPTION
## Summary

- Add `StepVisualRenderer` registry that maps `visualKind` to a renderer component, wired into `StaticStepVisual`
- Add `QuoteVisual` as the first visual renderer (Apple keynote-inspired: centered, semantic HTML, typographic)
- Export `quoteVisualContentSchema` from `@zoonk/core` for type-safe parsing
- Unimplemented visual kinds gracefully return `null` (no crash, no layout change)

## Test plan

- [x] E2E: quote visual renders text and author attribution
- [x] E2E: steps without visual content render normally
- [x] E2E: unimplemented visual kind renders text without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a StepVisualRenderer with a Quote visual, and redesigns the static step layout to split visual and text zones. Unsupported kinds render nothing to keep layouts stable.

- **New Features**
  - QuoteVisual: centered blockquote with author caption; content parsed via exported quoteVisualContentSchema.
  - Renderer returns null when kind/content is missing or unimplemented.
  - Static step layout: scrollable visual zone with its own padding; text zone anchors below with a top border when visual exists; text-only steps are centered and stage padding is removed for static steps.
  - E2E tests for quote rendering, text-only steps, and safe fallback.

<sup>Written for commit 42c92521d9c4e8b10003d1d836e30919f79e47be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

