### PR TITLE
fix(ui): use pointer media query for command palette positioning

### DIFF
--- a/apps/editor/src/components/navbar/command-palette.tsx
+++ b/apps/editor/src/components/navbar/command-palette.tsx
@@ -104,7 +104,6 @@ export function CommandPalette() {
       </Button>
 
       <CommandDialog
-        className="top-4 translate-y-0 lg:top-1/2 lg:translate-y-[-50%]"
         description={t("Search courses, chapters, lessons, or pages...")}
         onOpenChange={closePalette}
         open={isOpen}

--- a/apps/main/src/app/[locale]/(catalog)/_components/command-palette.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/_components/command-palette.tsx
@@ -81,7 +81,6 @@ export function CommandPalette() {
       </Button>
 
       <CommandDialog
-        className="top-4 translate-y-0 lg:top-1/2 lg:translate-y-[-50%]"
         description={t("Search courses or pages...")}
         onOpenChange={closePalette}
         open={isOpen}

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -53,7 +53,10 @@ function CommandDialog({
         <DialogDescription>{description}</DialogDescription>
       </DialogHeader>
       <DialogContent
-        className={cn("overflow-hidden rounded-4xl! p-0", className)}
+        className={cn(
+          "top-4 translate-y-0 overflow-hidden rounded-4xl! p-0 pointer-fine:top-1/2 pointer-fine:-translate-y-1/2",
+          className,
+        )}
         showCloseButton={showCloseButton}
       >
         <Command>{children}</Command>


### PR DESCRIPTION
## Summary

- Replaces `lg:` breakpoint with `pointer-fine:` for command palette vertical positioning, so tablets with on-screen keyboards keep the palette at the top of the screen
- Moves the positioning into `CommandDialog` in `@zoonk/ui` so all consumers get the correct behavior by default

## Test plan

- [ ] Open command palette on iPad (portrait/landscape) — should appear at top
- [ ] Open command palette on desktop — should be vertically centered
- [ ] Existing e2e tests pass for both `main` and `editor` apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch command palette positioning to a pointer-based media query. Tablets with on-screen keyboards now see the palette at the top; desktops stay centered.

- **Bug Fixes**
  - Default palette to top; center only on pointer-fine devices (desktops) via pointer-fine media query in @zoonk/ui CommandDialog.

- **Refactors**
  - Moved positioning into CommandDialog so all consumers inherit it; removed app-level overrides in main and editor.

<sup>Written for commit 37fdadb77ae16795a96f4a7dad6268f67ed8de20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

