### PR TITLE
fix(main): extend static step tap/swipe zones to full viewport width

### DIFF
--- a/apps/main/e2e/static-step.test.ts
+++ b/apps/main/e2e/static-step.test.ts
@@ -403,6 +403,52 @@ test.describe("Static Step Navigation", () => {
     await expect(page.getByRole("button", { name: /send feedback/i })).toBeVisible();
   });
 
+  test("clicking outside content area navigates between steps", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createStaticActivity({
+      steps: [
+        {
+          content: {
+            text: `Outside 1 body ${uniqueId}`,
+            title: `Outside 1 ${uniqueId}`,
+            variant: "text",
+          },
+          position: 0,
+        },
+        {
+          content: {
+            text: `Outside 2 body ${uniqueId}`,
+            title: `Outside 2 ${uniqueId}`,
+            variant: "text",
+          },
+          position: 1,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Outside 1 ${uniqueId}`) }),
+    ).toBeVisible();
+
+    // Click far-right edge of viewport (outside the max-w-2xl content area)
+    const viewport = page.viewportSize();
+    await page.mouse.click(viewport!.width - 10, viewport!.height / 2);
+
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Outside 2 ${uniqueId}`) }),
+    ).toBeVisible();
+
+    // Click far-left edge to go back
+    await page.mouse.click(10, viewport!.height / 2);
+
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Outside 1 ${uniqueId}`) }),
+    ).toBeVisible();
+  });
+
   test("header nav buttons navigate between steps", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const { url } = await createStaticActivity({

--- a/apps/main/src/components/activity-player/step-layouts.tsx
+++ b/apps/main/src/components/activity-player/step-layouts.tsx
@@ -3,7 +3,7 @@ import { cn } from "@zoonk/ui/lib/utils";
 export function StaticStepLayout({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("relative flex w-full max-w-2xl flex-1 flex-col", className)}
+      className={cn("flex w-full max-w-2xl flex-1 flex-col", className)}
       data-slot="static-step-layout"
       {...props}
     />

--- a/apps/main/src/components/activity-player/step-renderer.tsx
+++ b/apps/main/src/components/activity-player/step-renderer.tsx
@@ -68,14 +68,17 @@ export function StepRenderer({
     const hasVisual = Boolean(step.visualKind && step.visualContent);
 
     return (
-      <StaticStepLayout className={hasVisual ? undefined : "justify-center"} {...swipeHandlers}>
-        <StaticStep step={step} />
+      <div className="relative flex w-full flex-1 justify-center" {...swipeHandlers}>
+        <StaticStepLayout className={hasVisual ? undefined : "justify-center"}>
+          <StaticStep step={step} />
+        </StaticStepLayout>
+
         <StaticTapZones
           isFirst={isFirst}
           onNavigateNext={onNavigateNext}
           onNavigatePrev={onNavigatePrev}
         />
-      </StaticStepLayout>
+      </div>
     );
   }
 


### PR DESCRIPTION
## Summary
- Wrap static step in a full-width container so tap zones and swipe handlers span the entire viewport, not just the `max-w-2xl` content area
- Move `StaticTapZones` outside `StaticStepLayout` to be a sibling, bounded by the full-width wrapper
- Remove `relative` from `StaticStepLayout` since it no longer needs to be a positioning context

## Test plan
- [x] E2E test: clicking outside the content area (far-left/far-right edges) navigates between steps
- [x] All 20 existing static step e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend tap and swipe zones for static steps to the full viewport so edge clicks/swipes reliably navigate between steps. Improves navigation on desktop and touch devices.

- **Bug Fixes**
  - Wrap static step in a full-width container and move tap zones next to the content so zones span the entire screen.
  - Shift swipe handlers to the wrapper; remove unnecessary `relative` from `StaticStepLayout`.
  - Add e2e test for clicking far-left/right edges; all existing static step tests pass.

<sup>Written for commit 3ae0d96c7fcf9ee452a39b4b999866c4f4d3b662. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

