### PR TITLE
feat(lint): add no-hardcoded-aria-label oxlint rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -99,6 +99,7 @@
     "zoonk/no-get-extracted-in-promise": "error",
     "zoonk/no-object-params-in-cache": ["error", { "exceptions": ["headers"] }],
     "zoonk/no-single-use-type-alias": "error",
+    "zoonk/no-hardcoded-aria-label": "off",
     "zoonk/no-t-function-as-argument": "error"
   },
   "overrides": [
@@ -225,6 +226,12 @@
       "files": ["**/*.d.ts"],
       "rules": {
         "import/unambiguous": "off"
+      }
+    },
+    {
+      "files": ["apps/main/**/*.tsx", "apps/editor/**/*.tsx", "apps/api/**/*.tsx"],
+      "rules": {
+        "zoonk/no-hardcoded-aria-label": "error"
       }
     }
   ],

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1183,6 +1183,11 @@ msgid "Challenge Complete"
 msgstr "Challenge Complete"
 
 #: src/components/activity-player/challenge-completion.tsx
+msgctxt "hOjzbw"
+msgid "Final dimension scores"
+msgstr "Final dimension scores"
+
+#: src/components/activity-player/challenge-completion.tsx
 msgctxt "JOTIo6"
 msgid "Some of your stats went below zero."
 msgstr "Some of your stats went below zero."
@@ -1291,6 +1296,11 @@ msgctxt "xmF49T"
 msgid "Correct!"
 msgstr "Correct!"
 
+#: src/components/activity-player/feedback-screen.tsx
+msgctxt "zZGbEs"
+msgid "Dimension inventory"
+msgstr "Dimension inventory"
+
 #: src/components/activity-player/fill-blank-step.tsx
 msgctxt "e7WNdK"
 msgid "Word bank"
@@ -1310,6 +1320,11 @@ msgstr "Blank {position}: {item}. Tap to remove."
 msgctxt "ja1JDt"
 msgid "All pairs matched. Press Check to continue."
 msgstr "All pairs matched. Press Check to continue."
+
+#: src/components/activity-player/multiple-choice-step.tsx
+msgctxt "akd+cv"
+msgid "Answer options"
+msgstr "Answer options"
 
 #: src/components/activity-player/multiple-choice-step.tsx
 msgctxt "HHBtl4"
@@ -1340,6 +1355,16 @@ msgstr "Step navigation"
 msgctxt "rbrahO"
 msgid "Close"
 msgstr "Close"
+
+#: src/components/activity-player/player-progress-bar.tsx
+msgctxt "OUZtdJ"
+msgid "Activity progress"
+msgstr "Activity progress"
+
+#: src/components/activity-player/select-image-step.tsx
+msgctxt "NA6C/+"
+msgid "Image options"
+msgstr "Image options"
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "/CFOL2"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1183,6 +1183,11 @@ msgid "Challenge Complete"
 msgstr "Desafío completado"
 
 #: src/components/activity-player/challenge-completion.tsx
+msgctxt "hOjzbw"
+msgid "Final dimension scores"
+msgstr "Puntuaciones finales de dimensión"
+
+#: src/components/activity-player/challenge-completion.tsx
 msgctxt "JOTIo6"
 msgid "Some of your stats went below zero."
 msgstr "Algunas de tus estadísticas cayeron por debajo de cero."
@@ -1291,6 +1296,11 @@ msgctxt "xmF49T"
 msgid "Correct!"
 msgstr "¡Correcto!"
 
+#: src/components/activity-player/feedback-screen.tsx
+msgctxt "zZGbEs"
+msgid "Dimension inventory"
+msgstr "Inventario de dimensión"
+
 #: src/components/activity-player/fill-blank-step.tsx
 msgctxt "e7WNdK"
 msgid "Word bank"
@@ -1310,6 +1320,11 @@ msgstr "Espacio {position}: {item}. Toca para quitar."
 msgctxt "ja1JDt"
 msgid "All pairs matched. Press Check to continue."
 msgstr "Todos los pares coinciden. Presiona Verificar para continuar."
+
+#: src/components/activity-player/multiple-choice-step.tsx
+msgctxt "akd+cv"
+msgid "Answer options"
+msgstr "Opciones de respuesta"
 
 #: src/components/activity-player/multiple-choice-step.tsx
 msgctxt "HHBtl4"
@@ -1340,6 +1355,16 @@ msgstr "Navegación de pasos"
 msgctxt "rbrahO"
 msgid "Close"
 msgstr "Cerrar"
+
+#: src/components/activity-player/player-progress-bar.tsx
+msgctxt "OUZtdJ"
+msgid "Activity progress"
+msgstr "Progreso de actividad"
+
+#: src/components/activity-player/select-image-step.tsx
+msgctxt "NA6C/+"
+msgid "Image options"
+msgstr "Opciones de imagen"
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "/CFOL2"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1183,6 +1183,11 @@ msgid "Challenge Complete"
 msgstr "Desafio concluído"
 
 #: src/components/activity-player/challenge-completion.tsx
+msgctxt "hOjzbw"
+msgid "Final dimension scores"
+msgstr "Pontuações finais das dimensões"
+
+#: src/components/activity-player/challenge-completion.tsx
 msgctxt "JOTIo6"
 msgid "Some of your stats went below zero."
 msgstr "Algumas das suas estatísticas ficaram abaixo de zero."
@@ -1291,6 +1296,11 @@ msgctxt "xmF49T"
 msgid "Correct!"
 msgstr "Correto!"
 
+#: src/components/activity-player/feedback-screen.tsx
+msgctxt "zZGbEs"
+msgid "Dimension inventory"
+msgstr "Inventário de dimensões"
+
 #: src/components/activity-player/fill-blank-step.tsx
 msgctxt "e7WNdK"
 msgid "Word bank"
@@ -1310,6 +1320,11 @@ msgstr "Espaço {position}: {item}. Toque para remover."
 msgctxt "ja1JDt"
 msgid "All pairs matched. Press Check to continue."
 msgstr "Todos os pares combinados. Pressione Verificar para continuar."
+
+#: src/components/activity-player/multiple-choice-step.tsx
+msgctxt "akd+cv"
+msgid "Answer options"
+msgstr "Opções de resposta"
 
 #: src/components/activity-player/multiple-choice-step.tsx
 msgctxt "HHBtl4"
@@ -1340,6 +1355,16 @@ msgstr "Navegação de etapas"
 msgctxt "rbrahO"
 msgid "Close"
 msgstr "Fechar"
+
+#: src/components/activity-player/player-progress-bar.tsx
+msgctxt "OUZtdJ"
+msgid "Activity progress"
+msgstr "Progresso da atividade"
+
+#: src/components/activity-player/select-image-step.tsx
+msgctxt "NA6C/+"
+msgid "Image options"
+msgstr "Opções de imagem"
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "/CFOL2"

--- a/apps/main/src/components/activity-player/challenge-completion.tsx
+++ b/apps/main/src/components/activity-player/challenge-completion.tsx
@@ -54,7 +54,7 @@ export function ChallengeSuccessContent({
         <p className="text-lg font-medium">{t("Challenge Complete")}</p>
       </div>
 
-      <DimensionList aria-label="Final dimension scores" entries={entries} variant="success" />
+      <DimensionList aria-label={t("Final dimension scores")} entries={entries} variant="success" />
 
       {children}
 
@@ -84,7 +84,7 @@ export function ChallengeFailureContent({
         <p className="text-muted-foreground text-sm">{t("Some of your stats went below zero.")}</p>
       </div>
 
-      <DimensionList aria-label="Final dimension scores" entries={entries} variant="failure" />
+      <DimensionList aria-label={t("Final dimension scores")} entries={entries} variant="failure" />
 
       <ChallengeActions>
         <Button className="w-full lg:justify-between" onClick={onRestart} size="lg">

--- a/apps/main/src/components/activity-player/feedback-screen.tsx
+++ b/apps/main/src/components/activity-player/feedback-screen.tsx
@@ -75,7 +75,7 @@ export function FeedbackScreenContent({
 
         {feedback ? <FeedbackMessage>{feedback}</FeedbackMessage> : null}
 
-        <DimensionList aria-label="Dimension inventory" entries={entries} variant="feedback" />
+        <DimensionList aria-label={t("Dimension inventory")} entries={entries} variant="feedback" />
       </FeedbackScreen>
     );
   }

--- a/apps/main/src/components/activity-player/multiple-choice-step.tsx
+++ b/apps/main/src/components/activity-player/multiple-choice-step.tsx
@@ -76,8 +76,10 @@ function OptionList({
   options: readonly { text: string; textRomanization?: string | null }[];
   selectedIndex: number | null;
 }) {
+  const t = useExtracted();
+
   return (
-    <div aria-label="Answer options" className="flex flex-col gap-3" role="radiogroup">
+    <div aria-label={t("Answer options")} className="flex flex-col gap-3" role="radiogroup">
       {options.map((option, index) => (
         <OptionCard
           index={index}

--- a/apps/main/src/components/activity-player/player-progress-bar.tsx
+++ b/apps/main/src/components/activity-player/player-progress-bar.tsx
@@ -1,14 +1,19 @@
+"use client";
+
 import { ProgressIndicator, ProgressRoot, ProgressTrack } from "@zoonk/ui/components/progress";
 import { cn } from "@zoonk/ui/lib/utils";
+import { useExtracted } from "next-intl";
 
 export function PlayerProgressBar({
   className,
   value,
   ...props
 }: Omit<React.ComponentProps<"div">, "value"> & { value: number }) {
+  const t = useExtracted();
+
   return (
     <ProgressRoot
-      aria-label="Activity progress"
+      aria-label={t("Activity progress")}
       className={cn("gap-0", className)}
       data-slot="player-progress-bar"
       value={value}

--- a/apps/main/src/components/activity-player/select-image-step.tsx
+++ b/apps/main/src/components/activity-player/select-image-step.tsx
@@ -3,6 +3,7 @@
 import { type SerializedStep } from "@/data/activities/prepare-activity-data";
 import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { cn } from "@zoonk/ui/lib/utils";
+import { useExtracted } from "next-intl";
 import Image from "next/image";
 import { useState } from "react";
 import { type SelectedAnswer } from "./player-reducer";
@@ -78,6 +79,7 @@ export function SelectImageStep({
   selectedAnswer: SelectedAnswer | undefined;
   step: SerializedStep;
 }) {
+  const t = useExtracted();
   const content = parseStepContent("selectImage", step.content);
   const selectedIndex = getSelectedIndex(selectedAnswer);
 
@@ -95,7 +97,7 @@ export function SelectImageStep({
     <InteractiveStepLayout>
       {content.question ? <QuestionText>{content.question}</QuestionText> : null}
 
-      <div aria-label="Image options" className="grid grid-cols-2 gap-3" role="radiogroup">
+      <div aria-label={t("Image options")} className="grid grid-cols-2 gap-3" role="radiogroup">
         {content.options.map((option, index) => (
           <ImageOptionCard
             isSelected={selectedIndex === index}

--- a/i18n.lock
+++ b/i18n.lock
@@ -412,6 +412,7 @@ checksums:
     Check/singular: 023cc2ba432775c38e3efc004ad7b9ef
     Back%20to%20Lesson/singular: e2dbef5a2fefae8f9cee708e53e61cb9
     Challenge%20Complete/singular: 7854472cc9245aaa8a13f54514968506
+    Final%20dimension%20scores/singular: aa4efa7ecef99d375c1daf4c6585ba98
     Some%20of%20your%20stats%20went%20below%20zero./singular: bc281c87ae70abd076e3e73aa263ddc2
     Try%20Again/singular: d65fad81c5f8f90405b26bf6e5d70ab9
     Challenge%20Failed/singular: e9b1d1d02118f2e2ddc34907748955c4
@@ -433,16 +434,20 @@ checksums:
     Not%20quite/singular: e570085e69662802acf485c4565e3e3e
     Outcome/singular: 4cfc7a40e384ea8b6658e8da6e351bf0
     Correct!/singular: dda1a98dc04fd9db252887ecf1765d41
+    Dimension%20inventory/singular: a150bc3e032ae9e9202db1b375029aae
     Word%20bank/singular: ceea720dd5fa3747c7f93ce165f77b2e
     Blank%20%7Bposition%7D/singular: 70a4795f65f91685071b6abb1c3a6bad
     Blank%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: d7ab9b86256fae5fbb5187fe718afe0b
     All%20pairs%20matched.%20Press%20Check%20to%20continue./singular: 0663e33ba7db53b298c5f50a2f3c7ae8
+    Answer%20options/singular: acb0b378cefcb8a8d50a7c43ce77ae39
     What%20do%20you%20say%3F/singular: 75887288b85fc19e67b7d20550d9205e
     Someone%20says%3A/singular: 09f34dce0528b57e89c8757b5745e6c5
     Previous%20step/singular: 96b31ec6dab003c2bbfbbca10a8a9826
     Next%20step/singular: 712c63650b5180cbc14d6246b5d558c2
     Step%20navigation/singular: ec328f28051577e1c0aab044c89b138c
     Close/singular: 2c2e22f8424a1031de89063bd0022e16
+    Activity%20progress/singular: 8ff2fb7372b8a2525f2955c851c4fa42
+    Image%20options/singular: 64a1aee44b26dbaff851cb846eb4274d
     Tap%20items%20in%20the%20correct%20order/singular: 221c7b9ef00241af65f534432965e782
     "%7Bitem%7D.%20Tap%20to%20select%20as%20position%20%7BnextPosition%7D./singular": f8b0d3e60ce3740c02c33c0faaec5e6b
     Correct/singular: c643eeb0a615de2032eca68722c31177

--- a/packages/oxlint-plugin/index.js
+++ b/packages/oxlint-plugin/index.js
@@ -1,6 +1,7 @@
 import { definePlugin } from "oxlint";
 import noDynamicTranslationKey from "./rules/no-dynamic-translation-key.js";
 import noGetExtractedInPromise from "./rules/no-get-extracted-in-promise.js";
+import noHardcodedAriaLabel from "./rules/no-hardcoded-aria-label.js";
 import noObjectParamsInCache from "./rules/no-object-params-in-cache.js";
 import noSingleUseTypeAlias from "./rules/no-single-use-type-alias.js";
 import noTFunctionAsArgument from "./rules/no-t-function-as-argument.js";
@@ -12,6 +13,7 @@ export default definePlugin({
   rules: {
     "no-dynamic-translation-key": noDynamicTranslationKey,
     "no-get-extracted-in-promise": noGetExtractedInPromise,
+    "no-hardcoded-aria-label": noHardcodedAriaLabel,
     "no-object-params-in-cache": noObjectParamsInCache,
     "no-single-use-type-alias": noSingleUseTypeAlias,
     "no-t-function-as-argument": noTFunctionAsArgument,

--- a/packages/oxlint-plugin/rules/no-hardcoded-aria-label.js
+++ b/packages/oxlint-plugin/rules/no-hardcoded-aria-label.js
@@ -1,0 +1,33 @@
+import { defineRule } from "oxlint";
+
+export default defineRule({
+  createOnce(context) {
+    return {
+      JSXAttribute(node) {
+        if (node.name.name !== "aria-label") {
+          return;
+        }
+
+        if (node.value?.type === "Literal") {
+          context.report({
+            loc: node.value.loc,
+            messageId: "noHardcodedAriaLabel",
+            data: { value: node.value.value },
+          });
+        }
+      },
+    };
+  },
+
+  meta: {
+    docs: {
+      description: "Disallow hard-coded aria-label strings. Use t() for i18n translation instead.",
+    },
+    messages: {
+      noHardcodedAriaLabel:
+        'Hard-coded aria-label "{{value}}" must use t("{{value}}") for translation.',
+    },
+    schema: [],
+    type: "problem",
+  },
+});


### PR DESCRIPTION
## Summary

- Add `no-hardcoded-aria-label` oxlint rule that flags `aria-label="text"` (hardcoded strings) in JSX
- Enabled as `error` for `apps/main`, `apps/editor`, `apps/api`; off elsewhere
- Fix all 6 existing violations in `activity-player/` by wrapping with `t()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an oxlint rule to block hard-coded aria-labels and require t() for translated labels. Enabled in main, editor, and api, and updates activity-player to use localized aria-labels.

- **New Features**
  - Added zoonk/no-hardcoded-aria-label rule to flag Literal aria-label values in JSX.
  - Enabled as error for apps/main, apps/editor, and apps/api; off elsewhere.
  - Added en/es/pt messages and updated i18n.lock.

- **Refactors**
  - Replaced hard-coded aria-labels with t() in activity-player (final scores, dimension inventory, answer options, activity progress, image options).

<sup>Written for commit 021fbb85ec372e76f3186e4403da0cae6b87c08d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

