### PR TITLE
fix(test): replace networkidle with toPass retry for hydration-safe e2e tests

### DIFF
--- a/apps/main/e2e/fill-blank-step.test.ts
+++ b/apps/main/e2e/fill-blank-step.test.ts
@@ -117,9 +117,15 @@ test.describe("Fill Blank Step", () => {
     await page.goto(url);
 
     const wordBank = page.getByRole("group", { name: /word bank/i });
-    await wordBank.getByRole("button", { name: "sun" }).click();
+    const sunInBlank = page.getByRole("button", { name: /blank 1: sun/i });
 
-    await expect(page.getByRole("button", { name: /blank 1: sun/i })).toBeVisible();
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if (!(await sunInBlank.isVisible())) {
+        await wordBank.getByRole("button", { name: "sun" }).click();
+      }
+      await expect(sunInBlank).toBeVisible({ timeout: 1000 });
+    }).toPass();
   });
 
   test("tapping a placed word returns it to the bank", async ({ page }) => {
@@ -141,10 +147,15 @@ test.describe("Fill Blank Step", () => {
     await page.goto(url);
 
     const wordBank = page.getByRole("group", { name: /word bank/i });
-    await wordBank.getByRole("button", { name: "rain" }).click();
-
     const filledBlank = page.getByRole("button", { name: /blank 1: rain/i });
-    await expect(filledBlank).toBeVisible();
+
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if (!(await filledBlank.isVisible())) {
+        await wordBank.getByRole("button", { name: "rain" }).click();
+      }
+      await expect(filledBlank).toBeVisible({ timeout: 1000 });
+    }).toPass();
 
     await filledBlank.click();
 
@@ -172,10 +183,17 @@ test.describe("Fill Blank Step", () => {
     });
 
     await page.goto(url);
-    await page.waitForLoadState("networkidle");
 
     const wordBank = page.getByRole("group", { name: /word bank/i });
-    await wordBank.getByRole("button", { name: "blue" }).click();
+    const blueInBlank = page.getByRole("button", { name: /blank 1: blue/i });
+
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if (!(await blueInBlank.isVisible())) {
+        await wordBank.getByRole("button", { name: "blue" }).click();
+      }
+      await expect(blueInBlank).toBeVisible({ timeout: 1000 });
+    }).toPass();
 
     await page.getByRole("button", { name: /check/i }).click();
 
@@ -200,10 +218,17 @@ test.describe("Fill Blank Step", () => {
     });
 
     await page.goto(url);
-    await page.waitForLoadState("networkidle");
 
     const wordBank = page.getByRole("group", { name: /word bank/i });
-    await wordBank.getByRole("button", { name: "red" }).click();
+    const redInBlank = page.getByRole("button", { name: /blank 1: red/i });
+
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if (!(await redInBlank.isVisible())) {
+        await wordBank.getByRole("button", { name: "red" }).click();
+      }
+      await expect(redInBlank).toBeVisible({ timeout: 1000 });
+    }).toPass();
 
     await page.getByRole("button", { name: /check/i }).click();
 
@@ -227,13 +252,20 @@ test.describe("Fill Blank Step", () => {
     });
 
     await page.goto(url);
-    await page.waitForLoadState("networkidle");
 
     const checkButton = page.getByRole("button", { name: /check/i });
     await expect(checkButton).toBeDisabled();
 
     const wordBank = page.getByRole("group", { name: /word bank/i });
-    await wordBank.getByRole("button", { name: "one" }).click();
+    const oneInBlank = page.getByRole("button", { name: /blank 1: one/i });
+
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if (!(await oneInBlank.isVisible())) {
+        await wordBank.getByRole("button", { name: "one" }).click();
+      }
+      await expect(oneInBlank).toBeVisible({ timeout: 1000 });
+    }).toPass();
 
     await expect(checkButton).toBeDisabled();
 
@@ -259,15 +291,22 @@ test.describe("Fill Blank Step", () => {
     });
 
     await page.goto(url);
-    await page.waitForLoadState("networkidle");
 
     const checkButton = page.getByRole("button", { name: /check/i });
     const wordBank = page.getByRole("group", { name: /word bank/i });
+    const fastInBlank = page.getByRole("button", { name: /blank 1: fast/i });
 
-    await wordBank.getByRole("button", { name: "fast" }).click();
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if (!(await fastInBlank.isVisible())) {
+        await wordBank.getByRole("button", { name: "fast" }).click();
+      }
+      await expect(fastInBlank).toBeVisible({ timeout: 1000 });
+    }).toPass();
+
     await expect(checkButton).toBeEnabled();
 
-    await page.getByRole("button", { name: /blank 1: fast/i }).click();
+    await fastInBlank.click();
     await expect(checkButton).toBeDisabled();
   });
 
@@ -288,10 +327,17 @@ test.describe("Fill Blank Step", () => {
     });
 
     await page.goto(url);
-    await page.waitForLoadState("networkidle");
 
     const wordBank = page.getByRole("group", { name: /word bank/i });
-    await wordBank.getByRole("button", { name: "world" }).click();
+    const worldInBlank = page.getByRole("button", { name: /blank 1: world/i });
+
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if (!(await worldInBlank.isVisible())) {
+        await wordBank.getByRole("button", { name: "world" }).click();
+      }
+      await expect(worldInBlank).toBeVisible({ timeout: 1000 });
+    }).toPass();
 
     await page.getByRole("button", { name: /check/i }).click();
     await expect(page.getByText(/correct!/i)).toBeVisible();

--- a/apps/main/e2e/match-columns-step.test.ts
+++ b/apps/main/e2e/match-columns-step.test.ts
@@ -112,8 +112,14 @@ test.describe("Match Columns Step", () => {
     await page.goto(url);
 
     const catButton = page.getByRole("button", { name: `Cat ${uniqueId}` });
-    await catButton.click();
-    await expect(catButton).toHaveAttribute("aria-pressed", "true");
+
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if ((await catButton.getAttribute("aria-pressed")) !== "true") {
+        await catButton.click();
+      }
+      await expect(catButton).toHaveAttribute("aria-pressed", "true", { timeout: 1000 });
+    }).toPass();
   });
 
   test("correct match shows success state and locks pair", async ({ page }) => {
@@ -135,11 +141,20 @@ test.describe("Match Columns Step", () => {
 
     await page.goto(url);
 
-    await page.getByRole("button", { name: `Apple ${uniqueId}` }).click();
+    const appleButton = page.getByRole("button", { name: `Apple ${uniqueId}` });
+
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if ((await appleButton.getAttribute("aria-pressed")) !== "true") {
+        await appleButton.click();
+      }
+      await expect(appleButton).toHaveAttribute("aria-pressed", "true", { timeout: 1000 });
+    }).toPass();
+
     await page.getByRole("button", { name: `Fruit ${uniqueId}` }).click();
 
     // Both items should be disabled (locked) after correct match
-    await expect(page.getByRole("button", { name: `Apple ${uniqueId}` })).toBeDisabled();
+    await expect(appleButton).toBeDisabled();
     await expect(page.getByRole("button", { name: `Fruit ${uniqueId}` })).toBeDisabled();
   });
 
@@ -162,7 +177,16 @@ test.describe("Match Columns Step", () => {
 
     await page.goto(url);
 
-    await page.getByRole("button", { name: `Paris ${uniqueId}` }).click();
+    const parisButton = page.getByRole("button", { name: `Paris ${uniqueId}` });
+
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if ((await parisButton.getAttribute("aria-pressed")) !== "true") {
+        await parisButton.click();
+      }
+      await expect(parisButton).toHaveAttribute("aria-pressed", "true", { timeout: 1000 });
+    }).toPass();
+
     await page.getByRole("button", { name: `Japan ${uniqueId}` }).click();
 
     // After flash timeout, items should be back to interactive
@@ -193,8 +217,13 @@ test.describe("Match Columns Step", () => {
 
     const hotButton = page.getByRole("button", { name: `Hot ${uniqueId}` });
 
-    await hotButton.click();
-    await expect(hotButton).toHaveAttribute("aria-pressed", "true");
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if ((await hotButton.getAttribute("aria-pressed")) !== "true") {
+        await hotButton.click();
+      }
+      await expect(hotButton).toHaveAttribute("aria-pressed", "true", { timeout: 1000 });
+    }).toPass();
 
     await hotButton.click();
     await expect(hotButton).toHaveAttribute("aria-pressed", "false");
@@ -218,13 +247,20 @@ test.describe("Match Columns Step", () => {
     });
 
     await page.goto(url);
-    await page.waitForLoadState("networkidle");
 
     const checkButton = page.getByRole("button", { name: /check/i });
     await expect(checkButton).toBeDisabled();
 
-    // Match first pair correctly
-    await page.getByRole("button", { name: `A ${uniqueId}` }).click();
+    const buttonA = page.getByRole("button", { name: `A ${uniqueId}` });
+
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if ((await buttonA.getAttribute("aria-pressed")) !== "true") {
+        await buttonA.click();
+      }
+      await expect(buttonA).toHaveAttribute("aria-pressed", "true", { timeout: 1000 });
+    }).toPass();
+
     await page.getByRole("button", { name: `1 ${uniqueId}` }).click();
 
     // Still disabled — not all matched yet
@@ -265,10 +301,17 @@ test.describe("Match Columns Step", () => {
     });
 
     await page.goto(url);
-    await page.waitForLoadState("networkidle");
 
-    // Complete first step
-    await page.getByRole("button", { name: `Red ${uniqueId}` }).click();
+    const redButton = page.getByRole("button", { name: `Red ${uniqueId}` });
+
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if ((await redButton.getAttribute("aria-pressed")) !== "true") {
+        await redButton.click();
+      }
+      await expect(redButton).toHaveAttribute("aria-pressed", "true", { timeout: 1000 });
+    }).toPass();
+
     await page.getByRole("button", { name: `Rouge ${uniqueId}` }).click();
 
     await page.getByRole("button", { name: `Blue ${uniqueId}` }).click();
@@ -298,10 +341,17 @@ test.describe("Match Columns Step", () => {
     });
 
     await page.goto(url);
-    await page.waitForLoadState("networkidle");
 
-    // Make an incorrect match first
-    await page.getByRole("button", { name: `H2O ${uniqueId}` }).click();
+    const h2oButton = page.getByRole("button", { name: `H2O ${uniqueId}` });
+
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if ((await h2oButton.getAttribute("aria-pressed")) !== "true") {
+        await h2oButton.click();
+      }
+      await expect(h2oButton).toHaveAttribute("aria-pressed", "true", { timeout: 1000 });
+    }).toPass();
+
     await page.getByRole("button", { name: `Salt ${uniqueId}` }).click();
 
     // Wait for flash to clear
@@ -341,9 +391,17 @@ test.describe("Match Columns Step", () => {
     });
 
     await page.goto(url);
-    await page.waitForLoadState("networkidle");
 
-    await page.getByRole("button", { name: `Dog ${uniqueId}` }).click();
+    const dogButton = page.getByRole("button", { name: `Dog ${uniqueId}` });
+
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if ((await dogButton.getAttribute("aria-pressed")) !== "true") {
+        await dogButton.click();
+      }
+      await expect(dogButton).toHaveAttribute("aria-pressed", "true", { timeout: 1000 });
+    }).toPass();
+
     await page.getByRole("button", { name: `Woof ${uniqueId}` }).click();
 
     await page.getByRole("button", { name: `Cat ${uniqueId}` }).click();

--- a/apps/main/e2e/sort-order-step.test.ts
+++ b/apps/main/e2e/sort-order-step.test.ts
@@ -120,13 +120,19 @@ test.describe("Sort Order Step", () => {
     await page.goto(url);
 
     const itemList = page.getByRole("list", { name: /sort items/i });
-    await itemList
-      .getByRole("button", { name: new RegExp(`Alpha ${uniqueId}.*Tap to select`) })
-      .click();
+    const alphaSelected = itemList.getByRole("button", {
+      name: new RegExp(`Position 1.*Alpha ${uniqueId}`),
+    });
 
-    await expect(
-      itemList.getByRole("button", { name: new RegExp(`Position 1.*Alpha ${uniqueId}`) }),
-    ).toBeVisible();
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if (!(await alphaSelected.isVisible())) {
+        await itemList
+          .getByRole("button", { name: new RegExp(`Alpha ${uniqueId}.*Tap to select`) })
+          .click();
+      }
+      await expect(alphaSelected).toBeVisible({ timeout: 1000 });
+    }).toPass();
   });
 
   test("tapping a selected item removes its number and renumbers higher items", async ({
@@ -209,15 +215,24 @@ test.describe("Sort Order Step", () => {
     });
 
     await page.goto(url);
-    await page.waitForLoadState("networkidle");
 
     const checkButton = page.getByRole("button", { name: /check/i });
     await expect(checkButton).toBeDisabled();
 
     const itemList = page.getByRole("list", { name: /sort items/i });
-    await itemList
-      .getByRole("button", { name: new RegExp(`X ${uniqueId}.*Tap to select`) })
-      .click();
+    const xSelected = itemList.getByRole("button", {
+      name: new RegExp(`Position 1.*X ${uniqueId}`),
+    });
+
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if (!(await xSelected.isVisible())) {
+        await itemList
+          .getByRole("button", { name: new RegExp(`X ${uniqueId}.*Tap to select`) })
+          .click();
+      }
+      await expect(xSelected).toBeVisible({ timeout: 1000 });
+    }).toPass();
 
     await expect(checkButton).toBeDisabled();
 
@@ -244,13 +259,22 @@ test.describe("Sort Order Step", () => {
     });
 
     await page.goto(url);
-    await page.waitForLoadState("networkidle");
 
     const itemList = page.getByRole("list", { name: /sort items/i });
+    const step1Selected = itemList.getByRole("button", {
+      name: new RegExp(`Position 1.*Step1 ${uniqueId}`),
+    });
 
-    await itemList
-      .getByRole("button", { name: new RegExp(`Step1 ${uniqueId}.*Tap to select`) })
-      .click();
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if (!(await step1Selected.isVisible())) {
+        await itemList
+          .getByRole("button", { name: new RegExp(`Step1 ${uniqueId}.*Tap to select`) })
+          .click();
+      }
+      await expect(step1Selected).toBeVisible({ timeout: 1000 });
+    }).toPass();
+
     await itemList
       .getByRole("button", { name: new RegExp(`Step2 ${uniqueId}.*Tap to select`) })
       .click();
@@ -285,14 +309,22 @@ test.describe("Sort Order Step", () => {
     });
 
     await page.goto(url);
-    await page.waitForLoadState("networkidle");
 
     const itemList = page.getByRole("list", { name: /sort items/i });
+    const secondSelected = itemList.getByRole("button", {
+      name: new RegExp(`Position 1.*Second ${uniqueId}`),
+    });
 
-    // Place in wrong order
-    await itemList
-      .getByRole("button", { name: new RegExp(`Second ${uniqueId}.*Tap to select`) })
-      .click();
+    // First click: resilient to hydration timing (place in wrong order)
+    await expect(async () => {
+      if (!(await secondSelected.isVisible())) {
+        await itemList
+          .getByRole("button", { name: new RegExp(`Second ${uniqueId}.*Tap to select`) })
+          .click();
+      }
+      await expect(secondSelected).toBeVisible({ timeout: 1000 });
+    }).toPass();
+
     await itemList
       .getByRole("button", { name: new RegExp(`First ${uniqueId}.*Tap to select`) })
       .click();
@@ -327,13 +359,22 @@ test.describe("Sort Order Step", () => {
     });
 
     await page.goto(url);
-    await page.waitForLoadState("networkidle");
 
     const itemList = page.getByRole("list", { name: /sort items/i });
+    const aSelected = itemList.getByRole("button", {
+      name: new RegExp(`Position 1.*A ${uniqueId}`),
+    });
 
-    await itemList
-      .getByRole("button", { name: new RegExp(`A ${uniqueId}.*Tap to select`) })
-      .click();
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if (!(await aSelected.isVisible())) {
+        await itemList
+          .getByRole("button", { name: new RegExp(`A ${uniqueId}.*Tap to select`) })
+          .click();
+      }
+      await expect(aSelected).toBeVisible({ timeout: 1000 });
+    }).toPass();
+
     await itemList
       .getByRole("button", { name: new RegExp(`B ${uniqueId}.*Tap to select`) })
       .click();
@@ -359,13 +400,22 @@ test.describe("Sort Order Step", () => {
     });
 
     await page.goto(url);
-    await page.waitForLoadState("networkidle");
 
     const itemList = page.getByRole("list", { name: /sort items/i });
+    const aSelected = itemList.getByRole("button", {
+      name: new RegExp(`Position 1.*A ${uniqueId}`),
+    });
 
-    await itemList
-      .getByRole("button", { name: new RegExp(`A ${uniqueId}.*Tap to select`) })
-      .click();
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if (!(await aSelected.isVisible())) {
+        await itemList
+          .getByRole("button", { name: new RegExp(`A ${uniqueId}.*Tap to select`) })
+          .click();
+      }
+      await expect(aSelected).toBeVisible({ timeout: 1000 });
+    }).toPass();
+
     await itemList
       .getByRole("button", { name: new RegExp(`B ${uniqueId}.*Tap to select`) })
       .click();


### PR DESCRIPTION
## Summary

- Replace all `waitForLoadState("networkidle")` in fill-blank, match-columns, and sort-order e2e tests with `expect().toPass()` retry pattern
- `networkidle` is unreliable (times out when persistent connections prevent idle state); the retry pattern directly handles pre-hydration click swallowing by re-clicking until the expected state is achieved

## Test plan

- [x] Stress-tested all 3 suites with `--repeat-each=3` (75/75 passed, 0 failures)
- [x] Stress-tested originally flaky tests with `--repeat-each=5` (35/35 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced unreliable networkidle waits with an expect(...).toPass click-retry pattern to make e2e interactions hydration-safe and reduce flakiness across fill-blank, match-columns, and sort-order tests.

- **Bug Fixes**
  - Removed waitForLoadState("networkidle") and added click-retry using expect(...).toPass with a 1s inner timeout.
  - Retries clicks until the expected state appears, handling pre-hydration click swallowing and persistent connections.
  - Stress-tested: 75/75 passes across suites (repeat-each=3) and 35/35 passes on previously flaky tests (repeat-each=5).

<sup>Written for commit 2754fee507716c41fceaeb50a55a022bb5cb4c8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

