### PR TITLE
feat(main): add image visual renderer for activity player

### DIFF
--- a/apps/main/e2e/step-visual-content.test.ts
+++ b/apps/main/e2e/step-visual-content.test.ts
@@ -105,6 +105,59 @@ test.describe("Step Visual Content", () => {
     ).toBeVisible();
   });
 
+  test("static step with image visual renders the image", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createStaticActivityWithVisual({
+      steps: [
+        {
+          content: {
+            text: `Image body ${uniqueId}`,
+            title: `Image Title ${uniqueId}`,
+            variant: "text",
+          },
+          position: 0,
+          visualContent: {
+            prompt: `A beautiful sunset ${uniqueId}`,
+            url: "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/courses/machine_learning-jmaDwiS0MptNV2EGCZzYWU7RBJs3Qg.webp",
+          },
+          visualKind: "image",
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(async () => {
+      await expect(
+        page.getByRole("img", { name: new RegExp(`A beautiful sunset ${uniqueId}`) }),
+      ).toBeVisible();
+    }).toPass();
+  });
+
+  test("static step with image visual without URL shows fallback", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createStaticActivityWithVisual({
+      steps: [
+        {
+          content: {
+            text: `Image fallback body ${uniqueId}`,
+            title: `Image Fallback Title ${uniqueId}`,
+            variant: "text",
+          },
+          position: 0,
+          visualContent: {
+            prompt: `A unique fallback text ${uniqueId}`,
+          },
+          visualKind: "image",
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(page.getByText(new RegExp(`A unique fallback text ${uniqueId}`))).toBeVisible();
+  });
+
   test("static step without visual content renders text content normally", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const { url } = await createStaticActivityWithVisual({

--- a/apps/main/src/components/activity-player/image-visual.tsx
+++ b/apps/main/src/components/activity-player/image-visual.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import {
+  type SupportedVisualKind,
+  type VisualContentByKind,
+  imageVisualContentSchema,
+} from "@zoonk/core/steps/visual-content-contract";
+import Image from "next/image";
+import { useState } from "react";
+
+function ImageFallback({ prompt }: { prompt: string }) {
+  return (
+    <div className="bg-muted flex aspect-square w-full max-w-md items-center justify-center rounded-2xl p-6">
+      <span className="text-muted-foreground text-center text-sm font-medium">{prompt}</span>
+    </div>
+  );
+}
+
+export function ImageVisual({ content }: { content: VisualContentByKind[SupportedVisualKind] }) {
+  const parsed = imageVisualContentSchema.parse(content);
+  const [hasError, setHasError] = useState(false);
+
+  if (!parsed.url || hasError) {
+    return <ImageFallback prompt={parsed.prompt} />;
+  }
+
+  return (
+    <Image
+      alt={parsed.prompt}
+      className="aspect-square w-full max-w-md rounded-2xl object-cover"
+      height={1024}
+      onError={() => setHasError(true)}
+      sizes="(max-width: 640px) calc(100vw - 2rem), 448px"
+      src={parsed.url}
+      width={1024}
+    />
+  );
+}

--- a/apps/main/src/components/activity-player/image-visual.tsx
+++ b/apps/main/src/components/activity-player/image-visual.tsx
@@ -18,9 +18,9 @@ function ImageFallback({ prompt }: { prompt: string }) {
 
 export function ImageVisual({ content }: { content: VisualContentByKind[SupportedVisualKind] }) {
   const parsed = imageVisualContentSchema.parse(content);
-  const [hasError, setHasError] = useState(false);
+  const [errorUrl, setErrorUrl] = useState<string | null>(null);
 
-  if (!parsed.url || hasError) {
+  if (!parsed.url || errorUrl === parsed.url) {
     return <ImageFallback prompt={parsed.prompt} />;
   }
 
@@ -29,7 +29,7 @@ export function ImageVisual({ content }: { content: VisualContentByKind[Supporte
       alt={parsed.prompt}
       className="aspect-square w-full max-w-md rounded-2xl object-cover"
       height={1024}
-      onError={() => setHasError(true)}
+      onError={() => setErrorUrl(parsed.url ?? null)}
       sizes="(max-width: 640px) calc(100vw - 2rem), 448px"
       src={parsed.url}
       width={1024}

--- a/apps/main/src/components/activity-player/step-visual-renderer.tsx
+++ b/apps/main/src/components/activity-player/step-visual-renderer.tsx
@@ -4,6 +4,7 @@ import {
   type SupportedVisualKind,
   type VisualContentByKind,
 } from "@zoonk/core/steps/visual-content-contract";
+import { ImageVisual } from "./image-visual";
 import { QuoteVisual } from "./quote-visual";
 
 export function StepVisualRenderer({
@@ -21,6 +22,10 @@ export function StepVisualRenderer({
     return <QuoteVisual content={visualContent} />;
   }
 
-  // Other visual kinds will be added in Issues 16-22.
+  if (visualKind === "image") {
+    return <ImageVisual content={visualContent} />;
+  }
+
+  // Other visual kinds will be added in Issues 17-22.
   return null;
 }

--- a/packages/core/src/steps/visual-content-contract.ts
+++ b/packages/core/src/steps/visual-content-contract.ts
@@ -52,7 +52,7 @@ const diagramVisualContentSchema = z
   })
   .strict();
 
-const imageVisualContentSchema = z
+export const imageVisualContentSchema = z
   .object({
     prompt: z.string(),
     url: z.string().optional(),


### PR DESCRIPTION
## Summary
- Export `imageVisualContentSchema` from `@zoonk/core` for use in the renderer
- Add `ImageVisual` component with Next.js `<Image>` (1024x1024) and prompt-based fallback for missing/broken URLs
- Wire `"image"` branch into `StepVisualRenderer` registry
- Add e2e tests for image rendering and fallback states

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds image visual rendering to the activity player. Images load via Next.js Image with a prompt-based fallback, and the error state resets when the URL changes between steps.

- **New Features**
  - ImageVisual renders a 1024x1024 image with alt text from the prompt; shows a prompt-based fallback on error or no URL.
  - StepVisualRenderer now supports visualKind "image".
  - Exported imageVisualContentSchema from @zoonk/core and added e2e tests for render and fallback states.

<sup>Written for commit 6882e1b4ee422b54f48700e47c6b093169bc3db0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

