### PR TITLE
fix(main): centered slide layout for static steps with visuals on desktop

### DIFF
--- a/apps/main/src/components/activity-player/player-header.tsx
+++ b/apps/main/src/components/activity-player/player-header.tsx
@@ -10,7 +10,7 @@ export function PlayerHeader({ className, ...props }: React.ComponentProps<"head
   return (
     <header
       className={cn(
-        "relative flex items-center justify-between px-3 py-1.5 sm:py-2.5 lg:p-4",
+        "relative flex items-center justify-between px-3 py-1.5 sm:py-2.5 xl:p-4",
         className,
       )}
       data-slot="player-header"

--- a/apps/main/src/components/activity-player/static-step.tsx
+++ b/apps/main/src/components/activity-player/static-step.tsx
@@ -87,8 +87,8 @@ export function StaticStep({ step }: { step: SerializedStep }) {
 
       <StaticStepText
         className={cn(
-          "px-4 pt-5 pb-6 sm:px-6 sm:pt-6 sm:pb-8",
-          hasVisual && "border-border/40 border-t",
+          "mx-4 pt-4 pb-6 sm:mx-6 sm:pt-5 sm:pb-8",
+          hasVisual && "border-border/40 border-t xl:border-t-0",
         )}
       >
         <StaticStepContent step={step} />

--- a/apps/main/src/components/activity-player/step-layouts.tsx
+++ b/apps/main/src/components/activity-player/step-layouts.tsx
@@ -14,7 +14,7 @@ export function StaticStepVisual({ className, ...props }: React.ComponentProps<"
   return (
     <div
       className={cn(
-        "flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-4 py-6 sm:px-6 sm:py-8",
+        "flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-4 py-6 sm:px-6 sm:py-8 xl:max-h-[50vh] xl:flex-initial xl:py-10",
         className,
       )}
       data-slot="static-step-visual"

--- a/apps/main/src/components/activity-player/step-renderer.tsx
+++ b/apps/main/src/components/activity-player/step-renderer.tsx
@@ -69,7 +69,7 @@ export function StepRenderer({
 
     return (
       <div className="relative flex w-full flex-1 justify-center" {...swipeHandlers}>
-        <StaticStepLayout className={hasVisual ? undefined : "justify-center"}>
+        <StaticStepLayout className={hasVisual ? "xl:justify-center xl:gap-4" : "justify-center"}>
           <StaticStep step={step} />
         </StaticStepLayout>
 


### PR DESCRIPTION
## Summary

- On desktop (`xl:` / ≥1280px), static steps with visuals now vertically center the visual + text as a unified "slide" composition instead of pushing text to the bottom
- Visual is constrained to `max-h-[50vh]` with natural sizing (`flex-initial`) on desktop
- Border between visual and text uses `mx` instead of `px` so it aligns with text edges on mobile/tablet
- Border is removed on desktop (`xl:border-t-0`) where the gap alone provides sufficient separation
- Tightened vertical padding between border and text content (`pt-5/pt-6` → `pt-4/pt-5`)

## Test plan

- [x] Verify on mobile: layout unchanged, text at bottom, border aligns with text
- [x] Verify on tablet (1024px landscape): no centering, border aligns with text edges
- [x] Verify on desktop (≥1280px): visual + text centered, no border, proper gap
- [x] Existing e2e tests pass (content visibility unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Center static step visuals and text as a single slide on desktop for better balance and readability. Mobile and tablet layouts stay the same with refined spacing for cleaner alignment.

- **New Features**
  - Desktop (xl): center visual + text and add a small gap.
  - Visual: max height capped at 50vh with natural sizing.
  - Spacing: remove border on desktop; align border with text edges on smaller screens; slightly tighter padding; header uses xl:p-4.

<sup>Written for commit cc5c69ba02b654a1c0f4cb2275c3ae67a1182f2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

