### PR TITLE
feat(main): add code visual renderer for activity player

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -35,6 +35,7 @@
     "react-dom": "19.2.4",
     "recharts": "3.6.0",
     "server-only": "0.0.1",
+    "shiki": "3.22.0",
     "swr": "2.4.0"
   },
   "devDependencies": {

--- a/apps/main/src/components/activity-player/code-visual.tsx
+++ b/apps/main/src/components/activity-player/code-visual.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import {
+  type SupportedVisualKind,
+  type VisualContentByKind,
+  codeVisualContentSchema,
+} from "@zoonk/core/steps/visual-content-contract";
+import { Fragment, useEffect, useState } from "react";
+import { type BundledLanguage, type ThemedToken, codeToTokens } from "shiki";
+
+type TokenLine = ThemedToken[];
+
+function buildAnnotationMap(
+  annotations:
+    | {
+        line: number;
+        text: string;
+      }[]
+    | undefined,
+): Map<number, string> {
+  const map = new Map<number, string>();
+
+  if (!annotations) {
+    return map;
+  }
+
+  for (const annotation of annotations) {
+    map.set(annotation.line, annotation.text);
+  }
+
+  return map;
+}
+
+function useHighlightedCode(code: string, language: string): TokenLine[] | null {
+  const [tokens, setTokens] = useState<TokenLine[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    codeToTokens(code, {
+      // oxlint-disable-next-line no-unsafe-type-assertion -- language comes from AI-generated content; unsupported languages are caught below
+      lang: language as BundledLanguage,
+      themes: { dark: "github-dark-dimmed", light: "github-light" },
+    })
+      .then((result) => {
+        if (!cancelled) {
+          setTokens(result.tokens);
+        }
+      })
+      .catch(() => {
+        // Unknown language or shiki error — stay on plain text fallback.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [code, language]);
+
+  return tokens;
+}
+
+function CodeLanguageLabel({ language }: { language: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="text-muted-foreground/60 absolute top-3 right-3 font-mono text-xs tracking-wider uppercase select-none"
+    >
+      {language}
+    </span>
+  );
+}
+
+function CodeLine({ children, lineNumber }: { children: React.ReactNode; lineNumber: number }) {
+  return (
+    <div className="flex font-mono text-sm leading-relaxed whitespace-pre">
+      <span
+        aria-hidden="true"
+        className="text-muted-foreground/40 w-8 shrink-0 pr-4 text-right select-none"
+      >
+        {lineNumber}
+      </span>
+      <code>{children}</code>
+    </div>
+  );
+}
+
+function CodeAnnotationLine({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="text-muted-foreground border-primary/20 my-1 ml-8 border-l-2 py-1 pl-3 font-sans text-xs whitespace-normal"
+      role="note"
+    >
+      {children}
+    </div>
+  );
+}
+
+export function CodeVisual({ content }: { content: VisualContentByKind[SupportedVisualKind] }) {
+  const parsed = codeVisualContentSchema.parse(content);
+  const codeLines = parsed.code.split("\n");
+  const tokens = useHighlightedCode(parsed.code, parsed.language);
+  const annotationMap = buildAnnotationMap(parsed.annotations);
+
+  return (
+    <figure
+      className="bg-muted relative w-full max-w-2xl overflow-x-auto rounded-xl p-4 sm:p-5"
+      data-code-visual=""
+    >
+      <figcaption className="sr-only">{parsed.language}</figcaption>
+      <CodeLanguageLabel language={parsed.language} />
+
+      <div role="presentation">
+        {codeLines.map((line, index) => {
+          const lineNum = index + 1;
+          return (
+            <Fragment key={lineNum}>
+              <CodeLine lineNumber={lineNum}>
+                {tokens?.[index]
+                  ? tokens[index].map((token) => (
+                      <span key={token.offset} style={token.htmlStyle}>
+                        {token.content}
+                      </span>
+                    ))
+                  : line}
+              </CodeLine>
+
+              {annotationMap.has(lineNum) && (
+                <CodeAnnotationLine>{annotationMap.get(lineNum)}</CodeAnnotationLine>
+              )}
+            </Fragment>
+          );
+        })}
+      </div>
+    </figure>
+  );
+}

--- a/apps/main/src/components/activity-player/step-visual-renderer.tsx
+++ b/apps/main/src/components/activity-player/step-visual-renderer.tsx
@@ -4,8 +4,13 @@ import {
   type SupportedVisualKind,
   type VisualContentByKind,
 } from "@zoonk/core/steps/visual-content-contract";
+import dynamic from "next/dynamic";
 import { ImageVisual } from "./image-visual";
 import { QuoteVisual } from "./quote-visual";
+
+const CodeVisual = dynamic(() =>
+  import("./code-visual").then((mod) => ({ default: mod.CodeVisual })),
+);
 
 export function StepVisualRenderer({
   visualContent,
@@ -26,6 +31,10 @@ export function StepVisualRenderer({
     return <ImageVisual content={visualContent} />;
   }
 
-  // Other visual kinds will be added in Issues 17-22.
+  if (visualKind === "code") {
+    return <CodeVisual content={visualContent} />;
+  }
+
+  // Other visual kinds will be added in Issues 19-22.
   return null;
 }

--- a/packages/core/src/steps/visual-content-contract.ts
+++ b/packages/core/src/steps/visual-content-contract.ts
@@ -7,7 +7,7 @@ const codeAnnotationSchema = z
   })
   .strict();
 
-const codeVisualContentSchema = z
+export const codeVisualContentSchema = z
   .object({
     annotations: z.array(codeAnnotationSchema).optional(),
     code: z.string(),

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -193,6 +193,11 @@
     --score: var(--color-green-400);
     --belt-black: var(--color-neutral-700);
   }
+
+  [data-code-visual] span[style] {
+    color: var(--shiki-dark) !important;
+    background-color: var(--shiki-dark-bg) !important;
+  }
 }
 
 @media (prefers-color-scheme: dark) and (prefers-contrast: more) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,6 +396,9 @@ importers:
       server-only:
         specifier: 0.0.1
         version: 0.0.1
+      shiki:
+        specifier: 3.22.0
+        version: 3.22.0
       swr:
         specifier: 2.4.0
         version: 2.4.0(react@19.2.4)
@@ -2945,6 +2948,27 @@ packages:
   '@schummar/icu-type-parser@1.21.5':
     resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
 
+  '@shikijs/core@3.22.0':
+    resolution: {integrity: sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA==}
+
+  '@shikijs/engine-javascript@3.22.0':
+    resolution: {integrity: sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw==}
+
+  '@shikijs/engine-oniguruma@3.22.0':
+    resolution: {integrity: sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA==}
+
+  '@shikijs/langs@3.22.0':
+    resolution: {integrity: sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA==}
+
+  '@shikijs/themes@3.22.0':
+    resolution: {integrity: sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g==}
+
+  '@shikijs/types@3.22.0':
+    resolution: {integrity: sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@sindresorhus/is@5.6.0':
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
     engines: {node: '>=14.16'}
@@ -4867,6 +4891,9 @@ packages:
   hast-util-to-estree@3.1.3:
     resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -4880,6 +4907,9 @@ packages:
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -5649,6 +5679,12 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  oniguruma-parser@0.12.1:
+    resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
+
+  oniguruma-to-es@4.3.4:
+    resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
+
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
@@ -6018,6 +6054,15 @@ packages:
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   regexp-to-ast@0.5.0:
     resolution: {integrity: sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==}
 
@@ -6166,6 +6211,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shiki@3.22.0:
+    resolution: {integrity: sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -8775,6 +8823,39 @@ snapshots:
 
   '@schummar/icu-type-parser@1.21.5': {}
 
+  '@shikijs/core@3.22.0':
+    dependencies:
+      '@shikijs/types': 3.22.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@3.22.0':
+    dependencies:
+      '@shikijs/types': 3.22.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.4
+
+  '@shikijs/engine-oniguruma@3.22.0':
+    dependencies:
+      '@shikijs/types': 3.22.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.22.0':
+    dependencies:
+      '@shikijs/types': 3.22.0
+
+  '@shikijs/themes@3.22.0':
+    dependencies:
+      '@shikijs/types': 3.22.0
+
+  '@shikijs/types@3.22.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@sindresorhus/is@5.6.0': {}
 
   '@smithy/abort-controller@4.2.8':
@@ -10986,6 +11067,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -11015,6 +11110,8 @@ snapshots:
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
+
+  html-void-elements@3.0.0: {}
 
   http-cache-semantics@4.2.0: {}
 
@@ -11901,6 +11998,14 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  oniguruma-parser@0.12.1: {}
+
+  oniguruma-to-es@4.3.4:
+    dependencies:
+      oniguruma-parser: 0.12.1
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   open@10.2.0:
     dependencies:
       default-browser: 5.4.0
@@ -12327,6 +12432,16 @@ snapshots:
 
   reflect-metadata@0.2.2: {}
 
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   regexp-to-ast@0.5.0: {}
 
   rehype-recma@1.0.0:
@@ -12520,6 +12635,17 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shiki@3.22.0:
+    dependencies:
+      '@shikijs/core': 3.22.0
+      '@shikijs/engine-javascript': 3.22.0
+      '@shikijs/engine-oniguruma': 3.22.0
+      '@shikijs/langs': 3.22.0
+      '@shikijs/themes': 3.22.0
+      '@shikijs/types': 3.22.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   side-channel-list@1.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Add syntax-highlighted code block renderer with shiki (`codeToTokens` API with dual themes for light/dark mode)
- Support per-line annotations that render inline below annotated code lines
- Lazy-load via `next/dynamic` so shiki is only downloaded when a code visual is rendered
- Export `codeVisualContentSchema` from core for parsing
- Add dark mode CSS for shiki token color switching

## Test plan

- [x] E2E: code visual renders code text and language label
- [x] E2E: code visual renders annotations
- [x] E2E: unimplemented visual kind test updated to use `diagram`
- [x] All 327 existing e2e tests pass
- [x] All 439 unit/integration tests pass
- [x] Lint, typecheck, build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a syntax-highlighted code visual to the Activity Player with per-line annotations and light/dark theme support. Shiki is lazy-loaded so the main bundle stays lean.

- **New Features**
  - New CodeVisual using Shiki codeToTokens with dual themes (light/dark).
  - Line numbers, language label, and inline per-line annotations.
  - Lazy-load CodeVisual via next/dynamic.
  - StepVisualRenderer now handles visualKind "code".
  - Exported codeVisualContentSchema from core for parsing.
  - CSS updates for dark mode token colors.
  - E2E coverage for code visuals and annotations; updated unimplemented test to use "diagram".

- **Dependencies**
  - Added shiki 3.22.0.

<sup>Written for commit 0b5ddc869f53171729047ef9fea5afd8730ccbaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

