### PR TITLE
fix(main): prevent visual clicks from triggering step navigation

### DIFF
--- a/apps/main/src/components/activity-player/step-layouts.tsx
+++ b/apps/main/src/components/activity-player/step-layouts.tsx
@@ -14,7 +14,7 @@ export function StaticStepVisual({ className, ...props }: React.ComponentProps<"
   return (
     <div
       className={cn(
-        "flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-4 py-6 sm:px-6 sm:py-8 xl:max-h-[50vh] xl:flex-initial xl:py-10",
+        "relative z-20 flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-4 py-6 sm:px-6 sm:py-8 xl:max-h-[50vh] xl:flex-initial xl:py-10",
         className,
       )}
       data-slot="static-step-visual"


### PR DESCRIPTION
## Summary

- Add `relative z-20` to `StaticStepVisual` so it sits above the `z-10` tap zone buttons, allowing clicks on visuals (code, images, quotes) to interact with content instead of navigating
- Add e2e test verifying clicking a code visual doesn't trigger navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent accidental navigation when clicking visuals in the activity player. Visuals now sit above tap zones, so clicks interact with the content instead of advancing the step.

- **Bug Fixes**
  - Raised StaticStepVisual to z-20 (with relative) to sit above z-10 tap zones.
  - Added an e2e test to confirm clicking a code visual doesn’t navigate; keyboard navigation still works.

<sup>Written for commit 19c512ee734a3dcb1161a355f2c7a498fa074b7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

