### PR TITLE
refactor(ai): consistent naming for language course chapters and chapter lessons

### DIFF
--- a/apps/api/src/workflows/chapter-generation/steps/generate-lessons-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/generate-lessons-step.ts
@@ -14,9 +14,8 @@ function generateLessons(context: ChapterContext) {
     return generateLanguageChapterLessons({
       chapterDescription: context.description,
       chapterTitle: context.title,
-      courseTitle: context.course.title,
-      language: context.language,
       targetLanguage: context.course.targetLanguage,
+      userLanguage: context.language,
     });
   }
 

--- a/apps/api/src/workflows/course-generation/steps/generate-chapters-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-chapters-step.ts
@@ -7,9 +7,8 @@ import { type CourseContext, type GeneratedChapter } from "../types";
 function generateChapters(course: CourseContext) {
   if (course.targetLanguage) {
     return generateLanguageCourseChapters({
-      courseTitle: course.courseTitle,
-      language: course.language,
       targetLanguage: course.targetLanguage,
+      userLanguage: course.language,
     });
   }
 

--- a/apps/evals/src/tasks/language-chapter-lessons/test-cases.ts
+++ b/apps/evals/src/tasks/language-chapter-lessons/test-cases.ts
@@ -37,9 +37,8 @@ export const TEST_CASES = [
       chapterDescription:
         "Regular and irregular verb conjugations in the present tense for everyday actions.",
       chapterTitle: "Present Tense Verbs",
-      courseTitle: "Spanish",
-      language: "en",
       targetLanguage: "es",
+      userLanguage: "en",
     },
   },
   {
@@ -56,9 +55,8 @@ export const TEST_CASES = [
       chapterDescription:
         "The hiragana syllabary: basic characters, dakuten, handakuten, and combination characters.",
       chapterTitle: "Hiragana",
-      courseTitle: "Japonês",
-      language: "pt",
       targetLanguage: "ja",
+      userLanguage: "pt",
     },
   },
   {
@@ -75,9 +73,8 @@ export const TEST_CASES = [
       chapterDescription:
         "Common greetings, introductions, and polite expressions for everyday encounters.",
       chapterTitle: "Basic Greetings & Introductions",
-      courseTitle: "French",
-      language: "en",
       targetLanguage: "fr",
+      userLanguage: "en",
     },
   },
   {
@@ -94,9 +91,8 @@ export const TEST_CASES = [
       chapterDescription:
         "Simple past, past continuous, present perfect, and past perfect tenses with regular and irregular verbs.",
       chapterTitle: "Tiempos Pasados",
-      courseTitle: "Inglés",
-      language: "es",
       targetLanguage: "en",
+      userLanguage: "es",
     },
   },
 ];

--- a/apps/evals/src/tasks/language-course-chapters/test-cases.ts
+++ b/apps/evals/src/tasks/language-course-chapters/test-cases.ts
@@ -26,7 +26,7 @@ export const TEST_CASES = [
       ${SHARED_EXPECTATIONS}
     `,
     id: "en-learning-spanish",
-    userInput: { courseTitle: "Spanish", language: "en", targetLanguage: "es" },
+    userInput: { targetLanguage: "es", userLanguage: "en" },
   },
   {
     expectations: `
@@ -38,7 +38,7 @@ export const TEST_CASES = [
       ${SHARED_EXPECTATIONS}
     `,
     id: "pt-learning-japanese",
-    userInput: { courseTitle: "Japonês", language: "pt", targetLanguage: "ja" },
+    userInput: { targetLanguage: "ja", userLanguage: "pt" },
   },
   {
     expectations: `
@@ -50,7 +50,7 @@ export const TEST_CASES = [
       ${SHARED_EXPECTATIONS}
     `,
     id: "en-learning-french",
-    userInput: { courseTitle: "French", language: "en", targetLanguage: "fr" },
+    userInput: { targetLanguage: "fr", userLanguage: "en" },
   },
   {
     expectations: `
@@ -62,6 +62,6 @@ export const TEST_CASES = [
       ${SHARED_EXPECTATIONS}
     `,
     id: "es-learning-english",
-    userInput: { courseTitle: "Inglés", language: "es", targetLanguage: "en" },
+    userInput: { targetLanguage: "en", userLanguage: "es" },
   },
 ];

--- a/packages/ai/src/tasks/chapters/language-chapter-lessons.prompt.md
+++ b/packages/ai/src/tasks/chapters/language-chapter-lessons.prompt.md
@@ -10,10 +10,9 @@ You deeply care about making language learning accessible, focused, and efficien
 
 # Inputs
 
-- `COURSE_TITLE`: name of the overall course
 - `CHAPTER_TITLE`: title of this specific chapter
 - `CHAPTER_DESCRIPTION`: what this chapter covers
-- `LANGUAGE`: output language for titles and descriptions
+- `USER_LANGUAGE`: output language for titles and descriptions
 - `TARGET_LANGUAGE`: the language being learned
 
 ## Language

--- a/packages/ai/src/tasks/chapters/language-chapter-lessons.ts
+++ b/packages/ai/src/tasks/chapters/language-chapter-lessons.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { getLanguageName } from "@zoonk/utils/languages";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
@@ -26,8 +27,7 @@ export type LanguageChapterLessonsSchema = z.infer<typeof schema>;
 export type LanguageChapterLessonsParams = {
   chapterDescription: string;
   chapterTitle: string;
-  courseTitle: string;
-  language: string;
+  userLanguage: string;
   targetLanguage: string;
   model?: string;
   useFallback?: boolean;
@@ -37,19 +37,19 @@ export type LanguageChapterLessonsParams = {
 export async function generateLanguageChapterLessons({
   chapterDescription,
   chapterTitle,
-  courseTitle,
-  language,
+  userLanguage,
   targetLanguage,
   model = DEFAULT_MODEL,
   useFallback = true,
   reasoningEffort,
 }: LanguageChapterLessonsParams) {
+  const targetLanguageName = getLanguageName({ targetLanguage, userLanguage });
+
   const userPrompt = `
-    LANGUAGE: ${language}
-    COURSE_TITLE: ${courseTitle}
+    USER_LANGUAGE: ${userLanguage}
     CHAPTER_TITLE: ${chapterTitle}
     CHAPTER_DESCRIPTION: ${chapterDescription}
-    TARGET_LANGUAGE: ${targetLanguage}
+    TARGET_LANGUAGE: ${targetLanguageName}
   `;
 
   const providerOptions = buildProviderOptions({

--- a/packages/ai/src/tasks/courses/language-course-chapters.prompt.md
+++ b/packages/ai/src/tasks/courses/language-course-chapters.prompt.md
@@ -10,8 +10,7 @@ You deeply care about quality language education and are committed to producing 
 
 # Inputs
 
-- `COURSE_TITLE`: name of the language course
-- `LANGUAGE`: output language for titles and descriptions
+- `USER_LANGUAGE`: output language for titles and descriptions
 - `TARGET_LANGUAGE`: the language being learned
 
 ## Language
@@ -37,7 +36,7 @@ This means chapters should focus on **content domains** — grammar structures, 
 - Cover **everything** from complete beginner (A1) to mastery (C2).
 - Include **as many chapters as needed**. Do not limit the number of chapters arbitrarily.
 - Order progressively: **fundamentals → intermediate → advanced**, following a logical progression building upon previous chapters.
-- Write **clear, concise** text in the specified `LANGUAGE` input.
+- Write **clear, concise** text in the specified `USER_LANGUAGE` input.
 - Avoid fluff/fillers/unnecessary words.
 - No assessments, projects, or capstones.
 - Don't mention prompt instructions (like "CEFR" or "A1/B2") in the chapter titles or descriptions. The progression should be implicit in the ordering.

--- a/packages/ai/src/tasks/courses/language-course-chapters.ts
+++ b/packages/ai/src/tasks/courses/language-course-chapters.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { getLanguageName } from "@zoonk/utils/languages";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
@@ -24,8 +25,7 @@ const schema = z.object({
 export type LanguageCourseChaptersSchema = z.infer<typeof schema>;
 
 export type LanguageCourseChaptersParams = {
-  courseTitle: string;
-  language: string;
+  userLanguage: string;
   targetLanguage: string;
   model?: string;
   useFallback?: boolean;
@@ -33,17 +33,17 @@ export type LanguageCourseChaptersParams = {
 };
 
 export async function generateLanguageCourseChapters({
-  courseTitle,
-  language,
+  userLanguage,
   targetLanguage,
   model = DEFAULT_MODEL,
   useFallback = true,
   reasoningEffort = "high",
 }: LanguageCourseChaptersParams) {
+  const targetLanguageName = getLanguageName({ targetLanguage, userLanguage });
+
   const userPrompt = `
-    LANGUAGE: ${language}
-    COURSE_TITLE: ${courseTitle}
-    TARGET_LANGUAGE: ${targetLanguage}
+    USER_LANGUAGE: ${userLanguage}
+    TARGET_LANGUAGE: ${targetLanguageName}
   `;
 
   const providerOptions = buildProviderOptions({


### PR DESCRIPTION
## Summary

- Rename `language` → `userLanguage` in `language-course-chapters` and `language-chapter-lessons` AI tasks, matching the convention from commit 6743d98f
- Remove redundant `courseTitle` param from both language-specific tasks — `targetLanguage` (resolved via `getLanguageName`) already provides the course name
- Update prompt files to use `USER_LANGUAGE` instead of `LANGUAGE`
- Update workflow step callers and eval test cases accordingly

## Test plan

- [x] `pnpm turbo quality:fix` — 0 warnings, 0 errors
- [x] `pnpm typecheck` — all packages pass
- [x] `pnpm knip` — clean
- [x] `pnpm test` — 221 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes language task inputs: rename language to userLanguage and drop courseTitle. Prompts now use USER_LANGUAGE, and TARGET_LANGUAGE is resolved to a human-readable name via getLanguageName.

- **Refactors**
  - Rename language → userLanguage in language-course-chapters and language-chapter-lessons (and prompts: LANGUAGE → USER_LANGUAGE).
  - Remove courseTitle; derive course name from targetLanguage using getLanguageName.
  - Update API workflow callers and eval test cases.

- **Migration**
  - Pass userLanguage instead of language.
  - Remove courseTitle from all callers.
  - Continue passing targetLanguage; it is now converted to a display name internally.

<sup>Written for commit 97db33af062cc4846bcfb0f7c8a29f11782ec934. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

