### PR TITLE
feat(main): add table visual renderer for activity player

### DIFF
--- a/apps/main/e2e/step-visual-content.test.ts
+++ b/apps/main/e2e/step-visual-content.test.ts
@@ -299,6 +299,131 @@ test.describe("Step Visual Content", () => {
     await expect(page.getByText(/2 \/ 2/)).toBeVisible();
   });
 
+  test("static step with table visual renders headers and cell data", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createStaticActivityWithVisual({
+      steps: [
+        {
+          content: {
+            text: `Table body ${uniqueId}`,
+            title: `Table Title ${uniqueId}`,
+            variant: "text",
+          },
+          position: 0,
+          visualContent: {
+            columns: [`Feature ${uniqueId}`, `Python ${uniqueId}`, `JavaScript ${uniqueId}`],
+            rows: [
+              [`Typing ${uniqueId}`, `Dynamic ${uniqueId}`, `Dynamic ${uniqueId}`],
+              [`Paradigm ${uniqueId}`, `Multi ${uniqueId}`, `Multi ${uniqueId}`],
+            ],
+          },
+          visualKind: "table",
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(
+      page.getByRole("columnheader", { name: new RegExp(`Feature ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: new RegExp(`Python ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: new RegExp(`JavaScript ${uniqueId}`) }),
+    ).toBeVisible();
+
+    await expect(page.getByRole("cell", { name: new RegExp(`Typing ${uniqueId}`) })).toBeVisible();
+    await expect(
+      page.getByRole("cell", { name: new RegExp(`Dynamic ${uniqueId}`) }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("cell", { name: new RegExp(`Paradigm ${uniqueId}`) }),
+    ).toBeVisible();
+  });
+
+  test("static step with table visual renders caption", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const captionText = `Comparison of languages ${uniqueId}`;
+    const { url } = await createStaticActivityWithVisual({
+      steps: [
+        {
+          content: {
+            text: `Table caption body ${uniqueId}`,
+            title: `Table Caption Title ${uniqueId}`,
+            variant: "text",
+          },
+          position: 0,
+          visualContent: {
+            caption: captionText,
+            columns: [`Lang ${uniqueId}`, `Year ${uniqueId}`],
+            rows: [[`Python ${uniqueId}`, `1991 ${uniqueId}`]],
+          },
+          visualKind: "table",
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(page.getByText(new RegExp(captionText))).toBeVisible();
+  });
+
+  test("clicking on a table visual does not navigate to the next step", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createStaticActivityWithVisual({
+      steps: [
+        {
+          content: {
+            text: `Click table body ${uniqueId}`,
+            title: `Click Table Step1 ${uniqueId}`,
+            variant: "text",
+          },
+          position: 0,
+          visualContent: {
+            caption: `Table caption ${uniqueId}`,
+            columns: [`Col A ${uniqueId}`, `Col B ${uniqueId}`],
+            rows: [[`Cell 1 ${uniqueId}`, `Cell 2 ${uniqueId}`]],
+          },
+          visualKind: "table",
+        },
+        {
+          content: {
+            text: `Next step body ${uniqueId}`,
+            title: `Click Table Step2 ${uniqueId}`,
+            variant: "text",
+          },
+          position: 1,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(
+      page.getByRole("columnheader", { name: new RegExp(`Col A ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(page.getByText(/1 \/ 2/)).toBeVisible();
+
+    // Click on the table — should NOT navigate
+    await page.getByRole("figure", { name: new RegExp(`Table caption ${uniqueId}`) }).click();
+
+    // Still on step 1
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Click Table Step1 ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(page.getByText(/1 \/ 2/)).toBeVisible();
+
+    // Keyboard navigation still works
+    await page.keyboard.press("ArrowRight");
+
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Click Table Step2 ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(page.getByText(/2 \/ 2/)).toBeVisible();
+  });
+
   test("static step with code visual renders annotations", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const annotationText = `This declares a variable ${uniqueId}`;

--- a/apps/main/src/components/activity-player/step-visual-renderer.tsx
+++ b/apps/main/src/components/activity-player/step-visual-renderer.tsx
@@ -7,6 +7,7 @@ import {
 import dynamic from "next/dynamic";
 import { ImageVisual } from "./image-visual";
 import { QuoteVisual } from "./quote-visual";
+import { TableVisual } from "./table-visual";
 
 const CodeVisual = dynamic(() =>
   import("./code-visual").then((mod) => ({ default: mod.CodeVisual })),
@@ -35,6 +36,10 @@ export function StepVisualRenderer({
     return <CodeVisual content={visualContent} />;
   }
 
-  // Other visual kinds will be added in Issues 19-22.
+  if (visualKind === "table") {
+    return <TableVisual content={visualContent} />;
+  }
+
+  // Other visual kinds will be added in Issues 20-22.
   return null;
 }

--- a/apps/main/src/components/activity-player/table-visual.tsx
+++ b/apps/main/src/components/activity-player/table-visual.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import {
+  type SupportedVisualKind,
+  type VisualContentByKind,
+  tableVisualContentSchema,
+} from "@zoonk/core/steps/visual-content-contract";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@zoonk/ui/components/table";
+
+export function TableVisual({ content }: { content: VisualContentByKind[SupportedVisualKind] }) {
+  const parsed = tableVisualContentSchema.parse(content);
+
+  return (
+    <figure aria-label={parsed.caption} className="w-full max-w-2xl">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            {parsed.columns.map((column) => (
+              <TableHead key={column} scope="col">
+                {column}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+
+        <TableBody>
+          {parsed.rows.map((row) => (
+            <TableRow key={row.join("-")}>
+              {parsed.columns.map((column, columnIndex) => (
+                <TableCell className="whitespace-normal" key={column}>
+                  {row[columnIndex]}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      {parsed.caption ? (
+        <figcaption className="text-muted-foreground mt-3 px-1 text-center text-sm">
+          {parsed.caption}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}

--- a/packages/core/src/steps/visual-content-contract.ts
+++ b/packages/core/src/steps/visual-content-contract.ts
@@ -66,7 +66,7 @@ export const quoteVisualContentSchema = z
   })
   .strict();
 
-const tableVisualContentSchema = z
+export const tableVisualContentSchema = z
   .object({
     caption: z.string().optional(),
     columns: z.array(z.string()),

--- a/packages/db/src/prisma/seed/steps.ts
+++ b/packages/db/src/prisma/seed/steps.ts
@@ -83,6 +83,24 @@ const stepsData: {
         },
         visualKind: "quote",
       },
+      {
+        content: {
+          text: "Each type of machine learning has distinct characteristics, strengths, and typical applications.",
+          title: "Comparing ML Types",
+          variant: "text",
+        },
+        kind: "static",
+        visualContent: {
+          caption: "Key differences between the three main types of machine learning",
+          columns: ["Type", "Data", "Goal", "Example"],
+          rows: [
+            ["Supervised", "Labeled", "Predict outcomes", "Spam detection"],
+            ["Unsupervised", "Unlabeled", "Find patterns", "Customer grouping"],
+            ["Reinforcement", "Rewards", "Maximize score", "Game playing"],
+          ],
+        },
+        visualKind: "table",
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Add `TableVisual` component using existing `Table` primitives from `@zoonk/ui`
- Export `tableVisualContentSchema` from `@zoonk/core`
- Wire table renderer into `StepVisualRenderer`
- Add table example to seed data for previewing
- Add 3 e2e tests (headers/cells, caption, click-no-navigate)

## Test plan

- [x] E2e: table renders headers and cell data
- [x] E2e: table renders caption
- [x] E2e: clicking table does not navigate to next step
- [x] All existing visual tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a table visual to the Activity Player so steps can render tables with optional captions. Wires it into the renderer and adds tests to ensure content renders and clicks don’t advance steps.

- **New Features**
  - New TableVisual using @zoonk/ui table primitives
  - Renderer now supports visualKind "table"
  - Exported tableVisualContentSchema from @zoonk/core
  - Seeded a table example for local preview
  - Added e2e tests for headers/cells, caption, and click-no-navigate

<sup>Written for commit 345df87a0db70a00e0414fea17452cc3c712f407. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

