### PR TITLE
feat(main): add chart visual renderer for activity player

### DIFF
--- a/apps/main/e2e/step-visual-content.test.ts
+++ b/apps/main/e2e/step-visual-content.test.ts
@@ -543,6 +543,183 @@ test.describe("Step Visual Content", () => {
     await expect(page.getByText(/2 \/ 2/)).toBeVisible();
   });
 
+  test("static step with bar chart visual renders title and category labels", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const chartTitle = `Data Usage ${uniqueId}`;
+    const { url } = await createStaticActivityWithVisual({
+      steps: [
+        {
+          content: {
+            text: `Bar chart body ${uniqueId}`,
+            title: `Bar Chart Title ${uniqueId}`,
+            variant: "text",
+          },
+          position: 0,
+          visualContent: {
+            chartType: "bar",
+            data: [
+              { name: `Alpha ${uniqueId}`, value: 70 },
+              { name: `Beta ${uniqueId}`, value: 45 },
+              { name: `Gamma ${uniqueId}`, value: 90 },
+            ],
+            title: chartTitle,
+          },
+          visualKind: "chart",
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(async () => {
+      await expect(page.getByRole("figure", { name: chartTitle })).toBeVisible();
+    }).toPass();
+
+    const chart = page.getByRole("figure", { name: chartTitle });
+    await expect(chart.getByText(chartTitle)).toBeVisible();
+    await expect(chart.getByText(new RegExp(`Alpha ${uniqueId}`))).toBeVisible();
+    await expect(chart.getByText(new RegExp(`Beta ${uniqueId}`))).toBeVisible();
+    await expect(chart.getByText(new RegExp(`Gamma ${uniqueId}`))).toBeVisible();
+  });
+
+  test("static step with line chart visual renders title and category labels", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const chartTitle = `Trend Data ${uniqueId}`;
+    const { url } = await createStaticActivityWithVisual({
+      steps: [
+        {
+          content: {
+            text: `Line chart body ${uniqueId}`,
+            title: `Line Chart Title ${uniqueId}`,
+            variant: "text",
+          },
+          position: 0,
+          visualContent: {
+            chartType: "line",
+            data: [
+              { name: `Jan ${uniqueId}`, value: 10 },
+              { name: `Feb ${uniqueId}`, value: 25 },
+              { name: `Mar ${uniqueId}`, value: 40 },
+            ],
+            title: chartTitle,
+          },
+          visualKind: "chart",
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(async () => {
+      await expect(page.getByRole("figure", { name: chartTitle })).toBeVisible();
+    }).toPass();
+
+    const chart = page.getByRole("figure", { name: chartTitle });
+    await expect(chart.getByText(chartTitle)).toBeVisible();
+    await expect(chart.getByText(new RegExp(`Jan ${uniqueId}`))).toBeVisible();
+    await expect(chart.getByText(new RegExp(`Feb ${uniqueId}`))).toBeVisible();
+    await expect(chart.getByText(new RegExp(`Mar ${uniqueId}`))).toBeVisible();
+  });
+
+  test("static step with pie chart visual renders title and legend", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const chartTitle = `Distribution ${uniqueId}`;
+    const { url } = await createStaticActivityWithVisual({
+      steps: [
+        {
+          content: {
+            text: `Pie chart body ${uniqueId}`,
+            title: `Pie Chart Title ${uniqueId}`,
+            variant: "text",
+          },
+          position: 0,
+          visualContent: {
+            chartType: "pie",
+            data: [
+              { name: `Red ${uniqueId}`, value: 40 },
+              { name: `Blue ${uniqueId}`, value: 35 },
+              { name: `Green ${uniqueId}`, value: 25 },
+            ],
+            title: chartTitle,
+          },
+          visualKind: "chart",
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(async () => {
+      await expect(page.getByRole("figure", { name: chartTitle })).toBeVisible();
+    }).toPass();
+
+    await expect(page.getByText(chartTitle)).toBeVisible();
+
+    const legend = page.getByRole("list", { name: /legend/i });
+    await expect(legend.getByText(new RegExp(`Red ${uniqueId}`))).toBeVisible();
+    await expect(legend.getByText(new RegExp(`Blue ${uniqueId}`))).toBeVisible();
+    await expect(legend.getByText(new RegExp(`Green ${uniqueId}`))).toBeVisible();
+  });
+
+  test("clicking on a chart visual does not navigate to the next step", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const chartTitle = `Click Chart ${uniqueId}`;
+    const { url } = await createStaticActivityWithVisual({
+      steps: [
+        {
+          content: {
+            text: `Click chart body ${uniqueId}`,
+            title: `Click Chart Step1 ${uniqueId}`,
+            variant: "text",
+          },
+          position: 0,
+          visualContent: {
+            chartType: "bar",
+            data: [
+              { name: `ItemA ${uniqueId}`, value: 50 },
+              { name: `ItemB ${uniqueId}`, value: 30 },
+            ],
+            title: chartTitle,
+          },
+          visualKind: "chart",
+        },
+        {
+          content: {
+            text: `Next step body ${uniqueId}`,
+            title: `Click Chart Step2 ${uniqueId}`,
+            variant: "text",
+          },
+          position: 1,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(async () => {
+      await expect(page.getByRole("figure", { name: chartTitle })).toBeVisible();
+    }).toPass();
+
+    await expect(page.getByText(/1 \/ 2/)).toBeVisible();
+
+    // Click on the chart — should NOT navigate
+    await page.getByRole("figure", { name: chartTitle }).click();
+
+    // Still on step 1
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Click Chart Step1 ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(page.getByText(/1 \/ 2/)).toBeVisible();
+
+    // Keyboard navigation still works
+    await page.keyboard.press("ArrowRight");
+
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Click Chart Step2 ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(page.getByText(/2 \/ 2/)).toBeVisible();
+  });
+
   test("static step with code visual renders annotations", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const annotationText = `This declares a variable ${uniqueId}`;

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1238,6 +1238,11 @@ msgctxt "SFKe0U"
 msgid "Your scores"
 msgstr "Your scores"
 
+#: src/components/activity-player/chart-visual.tsx
+msgctxt "iZuO+L"
+msgid "Legend"
+msgstr "Legend"
+
 #: src/components/activity-player/completion-auth-branch.tsx
 msgctxt "5kK+j9"
 msgid "Restart"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1238,6 +1238,11 @@ msgctxt "SFKe0U"
 msgid "Your scores"
 msgstr "Tus puntajes"
 
+#: src/components/activity-player/chart-visual.tsx
+msgctxt "iZuO+L"
+msgid "Legend"
+msgstr "Leyenda"
+
 #: src/components/activity-player/completion-auth-branch.tsx
 msgctxt "5kK+j9"
 msgid "Restart"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1238,6 +1238,11 @@ msgctxt "SFKe0U"
 msgid "Your scores"
 msgstr "Suas pontuações"
 
+#: src/components/activity-player/chart-visual.tsx
+msgctxt "iZuO+L"
+msgid "Legend"
+msgstr "Legenda"
+
 #: src/components/activity-player/completion-auth-branch.tsx
 msgctxt "5kK+j9"
 msgid "Restart"

--- a/apps/main/src/components/activity-player/chart-visual.tsx
+++ b/apps/main/src/components/activity-player/chart-visual.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import {
+  type ChartVisualContent,
+  chartVisualContentSchema,
+} from "@zoonk/core/steps/visual-content-contract";
+import { useExtracted } from "next-intl";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+} from "recharts";
+import { isValidChartPayload } from "../../app/[locale]/(performance)/_lib/chart-payload";
+
+type ChartDataPoint = ChartVisualContent["data"][number];
+
+const BAR_RADIUS = 3;
+
+// oxlint-disable-next-line eslint/id-length -- `r` is the SVG circle radius attribute required by recharts
+const ACTIVE_DOT_STYLE = { fill: "var(--foreground)", r: 4, strokeWidth: 0 };
+
+const CHART_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+];
+
+function ChartTooltip({ active, payload }: { active?: boolean; payload?: unknown }) {
+  if (!(active && isValidChartPayload<ChartDataPoint>(payload))) {
+    return null;
+  }
+
+  const data = payload[0].payload;
+
+  return (
+    <div className="bg-background rounded-lg border px-3 py-2 shadow-sm">
+      <p className="text-muted-foreground text-xs">{data.name}</p>
+      <p className="text-sm font-medium">{data.value}</p>
+    </div>
+  );
+}
+
+function BarChartVisual({ data }: { data: ChartDataPoint[] }) {
+  return (
+    <ResponsiveContainer height={224} width="100%">
+      <BarChart data={data} margin={{ bottom: 0, left: 0, right: 0, top: 0 }}>
+        <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
+
+        <XAxis
+          axisLine={false}
+          dataKey="name"
+          fontSize={12}
+          interval={0}
+          stroke="var(--muted-foreground)"
+          tickLine={false}
+          tickMargin={8}
+        />
+
+        <Tooltip content={ChartTooltip} />
+
+        <Bar
+          dataKey="value"
+          fill="var(--foreground)"
+          isAnimationActive={false}
+          radius={[BAR_RADIUS, BAR_RADIUS, 0, 0]}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function LineChartVisual({ data }: { data: ChartDataPoint[] }) {
+  return (
+    <ResponsiveContainer height={224} width="100%">
+      <AreaChart data={data} margin={{ bottom: 0, left: 0, right: 0, top: 0 }}>
+        <defs>
+          <linearGradient id="chartLineGradient" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="5%" stopColor="var(--foreground)" stopOpacity={0.12} />
+            <stop offset="95%" stopColor="var(--foreground)" stopOpacity={0} />
+          </linearGradient>
+        </defs>
+
+        <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
+
+        <XAxis
+          axisLine={false}
+          dataKey="name"
+          fontSize={12}
+          interval={0}
+          stroke="var(--muted-foreground)"
+          tickLine={false}
+          tickMargin={8}
+        />
+
+        <Tooltip content={ChartTooltip} />
+
+        <Area
+          activeDot={ACTIVE_DOT_STYLE}
+          dataKey="value"
+          dot={false}
+          fill="url(#chartLineGradient)"
+          fillOpacity={1}
+          isAnimationActive={false}
+          stroke="var(--foreground)"
+          strokeWidth={2}
+          type="monotone"
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}
+
+function PieChartVisual({ data }: { data: ChartDataPoint[] }) {
+  const t = useExtracted();
+  const coloredData = data.map((entry, index) => ({
+    ...entry,
+    fill: CHART_COLORS[index % CHART_COLORS.length],
+  }));
+
+  return (
+    <div>
+      <ResponsiveContainer height={192} width="100%">
+        <PieChart>
+          <Tooltip content={ChartTooltip} />
+
+          <Pie
+            data={coloredData}
+            dataKey="value"
+            innerRadius="55%"
+            isAnimationActive={false}
+            nameKey="name"
+            outerRadius="80%"
+            stroke="var(--background)"
+            strokeWidth={2}
+          />
+        </PieChart>
+      </ResponsiveContainer>
+
+      <ul aria-label={t("Legend")} className="mt-3 flex flex-wrap justify-center gap-x-4 gap-y-1">
+        {coloredData.map((entry) => (
+          <li className="flex items-center gap-1.5 text-sm" key={entry.name}>
+            <span
+              aria-hidden="true"
+              className="size-2 shrink-0 rounded-full"
+              style={{ backgroundColor: entry.fill }}
+            />
+            <span className="text-muted-foreground">{entry.name}</span>
+            <span className="font-medium">{entry.value}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ChartContent({ parsed }: { parsed: ChartVisualContent }) {
+  if (parsed.chartType === "bar") {
+    return <BarChartVisual data={parsed.data} />;
+  }
+
+  if (parsed.chartType === "line") {
+    return <LineChartVisual data={parsed.data} />;
+  }
+
+  return <PieChartVisual data={parsed.data} />;
+}
+
+export function ChartVisual({ content }: { content: unknown }) {
+  const parsed = chartVisualContentSchema.parse(content);
+
+  return (
+    <figure aria-label={parsed.title} className="w-full max-w-xl">
+      <figcaption className="text-muted-foreground mb-4 text-center text-sm font-medium">
+        {parsed.title}
+      </figcaption>
+
+      <ChartContent parsed={parsed} />
+    </figure>
+  );
+}

--- a/apps/main/src/components/activity-player/chart-visual.tsx
+++ b/apps/main/src/components/activity-player/chart-visual.tsx
@@ -5,6 +5,7 @@ import {
   chartVisualContentSchema,
 } from "@zoonk/core/steps/visual-content-contract";
 import { useExtracted } from "next-intl";
+import { useId } from "react";
 import {
   Area,
   AreaChart,
@@ -79,11 +80,13 @@ function BarChartVisual({ data }: { data: ChartDataPoint[] }) {
 }
 
 function LineChartVisual({ data }: { data: ChartDataPoint[] }) {
+  const gradientId = useId();
+
   return (
     <ResponsiveContainer height={224} width="100%">
       <AreaChart data={data} margin={{ bottom: 0, left: 0, right: 0, top: 0 }}>
         <defs>
-          <linearGradient id="chartLineGradient" x1="0" x2="0" y1="0" y2="1">
+          <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
             <stop offset="5%" stopColor="var(--foreground)" stopOpacity={0.12} />
             <stop offset="95%" stopColor="var(--foreground)" stopOpacity={0} />
           </linearGradient>
@@ -107,7 +110,7 @@ function LineChartVisual({ data }: { data: ChartDataPoint[] }) {
           activeDot={ACTIVE_DOT_STYLE}
           dataKey="value"
           dot={false}
-          fill="url(#chartLineGradient)"
+          fill={`url(#${gradientId})`}
           fillOpacity={1}
           isAnimationActive={false}
           stroke="var(--foreground)"

--- a/apps/main/src/components/activity-player/step-visual-renderer.tsx
+++ b/apps/main/src/components/activity-player/step-visual-renderer.tsx
@@ -4,15 +4,12 @@ import {
   type SupportedVisualKind,
   type VisualContentByKind,
 } from "@zoonk/core/steps/visual-content-contract";
-import dynamic from "next/dynamic";
+import { ChartVisual } from "./chart-visual";
+import { CodeVisual } from "./code-visual";
 import { ImageVisual } from "./image-visual";
 import { QuoteVisual } from "./quote-visual";
 import { TableVisual } from "./table-visual";
 import { TimelineVisual } from "./timeline-visual";
-
-const CodeVisual = dynamic(() =>
-  import("./code-visual").then((mod) => ({ default: mod.CodeVisual })),
-);
 
 export function StepVisualRenderer({
   visualContent,
@@ -45,6 +42,10 @@ export function StepVisualRenderer({
     return <TimelineVisual content={visualContent} />;
   }
 
-  // Other visual kinds will be added in Issues 21-22.
+  if (visualKind === "chart") {
+    return <ChartVisual content={visualContent} />;
+  }
+
+  // Other visual kinds will be added in Issue 22 (diagram).
   return null;
 }

--- a/i18n.lock
+++ b/i18n.lock
@@ -423,6 +423,7 @@ checksums:
     Starting%20scores/singular: 6a21f8424cdc75e477c3d7857a97db6d
     Begin/singular: cc2a17a662cb60dd2d8335a2e8440997
     Your%20scores/singular: 1700f65ead0647bc4876f4b3b6453a8b
+    Legend/singular: 3b588fbd2fe35ded6ca38334e15400c3
     Restart/singular: bab6232e89f24e3129f8e48268739d5b
     Next/singular: 89ddbcf710eba274963494f312bdc8a9
     Sign%20up%20to%20track%20your%20progress/singular: 554ed29d9b8a243362c3b3374222af08

--- a/packages/core/src/steps/visual-content-contract.ts
+++ b/packages/core/src/steps/visual-content-contract.ts
@@ -22,7 +22,7 @@ const chartDataPointSchema = z
   })
   .strict();
 
-const chartVisualContentSchema = z
+export const chartVisualContentSchema = z
   .object({
     chartType: z.enum(["bar", "line", "pie"]),
     data: z.array(chartDataPointSchema),

--- a/packages/db/src/prisma/seed/steps.ts
+++ b/packages/db/src/prisma/seed/steps.ts
@@ -101,6 +101,25 @@ const stepsData: {
         },
         visualKind: "table",
       },
+      {
+        content: {
+          text: "Different types of ML require different amounts of labeled data to achieve good performance.",
+          title: "Data Requirements",
+          variant: "text",
+        },
+        kind: "static",
+        visualContent: {
+          chartType: "bar",
+          data: [
+            { name: "Supervised", value: 85 },
+            { name: "Semi-supervised", value: 40 },
+            { name: "Unsupervised", value: 5 },
+            { name: "Reinforcement", value: 15 },
+          ],
+          title: "Labeled Data Required (%)",
+        },
+        visualKind: "chart",
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Add chart visual renderer supporting bar, line, and pie charts via recharts
- Export `chartVisualContentSchema` from the visual content contract
- Register chart renderer in `StepVisualRenderer` (static import, no dynamic loading)
- Add bar chart seed data to ML lesson
- Add 4 e2e tests: bar/line/pie rendering + click-navigation prevention

Closes #21

## Test plan

- [x] Bar chart renders title and all category labels
- [x] Line chart renders title and all category labels
- [x] Pie chart renders title and legend items
- [x] Clicking chart does not navigate to next step
- [x] All 17 visual content e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a chart visual renderer to the Activity Player with bar, line, and pie charts to improve lesson visuals. Meets Linear #21 by adding chart visuals, exporting the schema, and adding e2e coverage.

- **New Features**
  - Support bar, line, and donut-style pie charts with custom tooltip and accessible legend.
  - Register chart renderer; export chartVisualContentSchema; add ML lesson bar chart seed; add translatable “Legend”.
  - E2E tests for bar/line/pie rendering and click-navigation prevention.
  - Fix unique gradient IDs for line charts to prevent collisions when multiple charts render.

<sup>Written for commit 2f9ba99d9bd7f45e2850042994081fc88adb49eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

