### PR TITLE
feat(auth): add baseURL and cross-subdomain cookies to better auth config

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -16,10 +16,6 @@ NEXT_PUBLIC_EDITOR_APP_URL=http://localhost:3101
 
 ### OPTIONAL VARIABLES ###
 
-# Better Auth base URL (required for production deployments)
-# Set to your app's public URL (e.g., https://api.zoonk.com)
-BETTER_AUTH_URL=
-
 # Cookie domain for cross-subdomain auth (production only)
 # Set to your root domain (e.g., zoonk.com) to share sessions across subdomains
 BETTER_AUTH_COOKIE_DOMAIN=

--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -16,6 +16,14 @@ NEXT_PUBLIC_EDITOR_APP_URL=http://localhost:3101
 
 ### OPTIONAL VARIABLES ###
 
+# Better Auth base URL (required for production deployments)
+# Set to your app's public URL (e.g., https://api.zoonk.com)
+BETTER_AUTH_URL=
+
+# Cookie domain for cross-subdomain auth (production only)
+# Set to your root domain (e.g., zoonk.com) to share sessions across subdomains
+BETTER_AUTH_COOKIE_DOMAIN=
+
 # Mailer API key for email services
 MAILER_API_KEY=
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -22,6 +22,14 @@ NEXT_PUBLIC_AUTH_BASE_PATH=/v1/auth
 
 ### OPTIONAL VARIABLES ###
 
+# Better Auth base URL (required for production deployments)
+# Set to your app's public URL (e.g., https://api.zoonk.com)
+BETTER_AUTH_URL=
+
+# Cookie domain for cross-subdomain auth (production only)
+# Set to your root domain (e.g., zoonk.com) to share sessions across subdomains
+BETTER_AUTH_COOKIE_DOMAIN=
+
 # Cache Revalidation
 # Use the same secret used on the `main` app
 REVALIDATE_SECRET=

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -22,10 +22,6 @@ NEXT_PUBLIC_AUTH_BASE_PATH=/v1/auth
 
 ### OPTIONAL VARIABLES ###
 
-# Better Auth base URL (required for production deployments)
-# Set to your app's public URL (e.g., https://api.zoonk.com)
-BETTER_AUTH_URL=
-
 # Cookie domain for cross-subdomain auth (production only)
 # Set to your root domain (e.g., zoonk.com) to share sessions across subdomains
 BETTER_AUTH_COOKIE_DOMAIN=

--- a/apps/api/vitest.config.mts
+++ b/apps/api/vitest.config.mts
@@ -23,6 +23,7 @@ export default defineConfig({
     env: {
       DATABASE_URL: "postgres://postgres:postgres@localhost:5432/zoonk_test",
       DATABASE_URL_UNPOOLED: "postgres://postgres:postgres@localhost:5432/zoonk_test",
+      NEXT_PUBLIC_APP_DOMAIN: "localhost:9002",
     },
     environment: "node",
     exclude: ["**/node_modules/**", "**/e2e/**"],

--- a/apps/editor/.env.example
+++ b/apps/editor/.env.example
@@ -15,10 +15,6 @@ NEXT_PUBLIC_API_URL=http://localhost:4000
 
 ### OPTIONAL VARIABLES ###
 
-# Better Auth base URL (required for production deployments)
-# Set to your app's public URL (e.g., https://api.zoonk.com)
-BETTER_AUTH_URL=
-
 # Cookie domain for cross-subdomain auth (production only)
 # Set to your root domain (e.g., zoonk.com) to share sessions across subdomains
 BETTER_AUTH_COOKIE_DOMAIN=

--- a/apps/editor/.env.example
+++ b/apps/editor/.env.example
@@ -15,6 +15,14 @@ NEXT_PUBLIC_API_URL=http://localhost:4000
 
 ### OPTIONAL VARIABLES ###
 
+# Better Auth base URL (required for production deployments)
+# Set to your app's public URL (e.g., https://api.zoonk.com)
+BETTER_AUTH_URL=
+
+# Cookie domain for cross-subdomain auth (production only)
+# Set to your root domain (e.g., zoonk.com) to share sessions across subdomains
+BETTER_AUTH_COOKIE_DOMAIN=
+
 # Mailer API key for email services
 MAILER_API_KEY=
 

--- a/apps/editor/vitest.config.mts
+++ b/apps/editor/vitest.config.mts
@@ -17,6 +17,7 @@ export default defineConfig({
     env: {
       DATABASE_URL: "postgres://postgres:postgres@localhost:5432/zoonk_test",
       DATABASE_URL_UNPOOLED: "postgres://postgres:postgres@localhost:5432/zoonk_test",
+      NEXT_PUBLIC_APP_DOMAIN: "localhost:9001",
     },
     environment: "node",
     exclude: ["**/node_modules/**", "**/e2e/**"],

--- a/apps/main/.env.example
+++ b/apps/main/.env.example
@@ -19,6 +19,14 @@ NEXT_PUBLIC_API_URL=http://localhost:4000
 
 ### OPTIONAL VARIABLES ###
 
+# Better Auth base URL (required for production deployments)
+# Set to your app's public URL (e.g., https://api.zoonk.com)
+BETTER_AUTH_URL=
+
+# Cookie domain for cross-subdomain auth (production only)
+# Set to your root domain (e.g., zoonk.com) to share sessions across subdomains
+BETTER_AUTH_COOKIE_DOMAIN=
+
 # Mailer API key for email services
 MAILER_API_KEY=
 

--- a/apps/main/.env.example
+++ b/apps/main/.env.example
@@ -19,10 +19,6 @@ NEXT_PUBLIC_API_URL=http://localhost:4000
 
 ### OPTIONAL VARIABLES ###
 
-# Better Auth base URL (required for production deployments)
-# Set to your app's public URL (e.g., https://api.zoonk.com)
-BETTER_AUTH_URL=
-
 # Cookie domain for cross-subdomain auth (production only)
 # Set to your root domain (e.g., zoonk.com) to share sessions across subdomains
 BETTER_AUTH_COOKIE_DOMAIN=

--- a/apps/main/vitest.config.mts
+++ b/apps/main/vitest.config.mts
@@ -21,6 +21,7 @@ export default defineConfig({
     env: {
       DATABASE_URL: "postgres://postgres:postgres@localhost:5432/zoonk_test",
       DATABASE_URL_UNPOOLED: "postgres://postgres:postgres@localhost:5432/zoonk_test",
+      NEXT_PUBLIC_APP_DOMAIN: "localhost:9000",
     },
     environment: "node",
     exclude: ["**/node_modules/**", "**/e2e/**"],

--- a/packages/auth/src/config.test.ts
+++ b/packages/auth/src/config.test.ts
@@ -1,38 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getAuthBaseUrl, getCrossSubDomainCookies } from "./env";
-
-describe(getAuthBaseUrl, () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
-  it("returns VERCEL_URL with https in preview environment", () => {
-    vi.stubEnv("VERCEL_ENV", "preview");
-    vi.stubEnv("VERCEL_URL", "my-app-abc123.vercel.app");
-    expect(getAuthBaseUrl()).toBe("https://my-app-abc123.vercel.app");
-  });
-
-  it("returns BETTER_AUTH_URL when not in preview", () => {
-    vi.stubEnv("VERCEL_ENV", "production");
-    vi.stubEnv("BETTER_AUTH_URL", "https://api.zoonk.com");
-    expect(getAuthBaseUrl()).toBe("https://api.zoonk.com");
-  });
-
-  it("returns BETTER_AUTH_URL when VERCEL_ENV is not set", () => {
-    vi.stubEnv("BETTER_AUTH_URL", "https://api.zoonk.com");
-    expect(getAuthBaseUrl()).toBe("https://api.zoonk.com");
-  });
-
-  it("returns undefined when no env vars are set", () => {
-    expect(getAuthBaseUrl()).toBeUndefined();
-  });
-
-  it("returns BETTER_AUTH_URL when VERCEL_ENV is preview but VERCEL_URL is missing", () => {
-    vi.stubEnv("VERCEL_ENV", "preview");
-    vi.stubEnv("BETTER_AUTH_URL", "https://api.zoonk.com");
-    expect(getAuthBaseUrl()).toBe("https://api.zoonk.com");
-  });
-});
+import { getCrossSubDomainCookies } from "./env";
 
 describe(getCrossSubDomainCookies, () => {
   afterEach(() => {

--- a/packages/auth/src/config.test.ts
+++ b/packages/auth/src/config.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getAuthBaseUrl, getCrossSubDomainCookies } from "./env";
+
+describe(getAuthBaseUrl, () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns VERCEL_URL with https in preview environment", () => {
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("VERCEL_URL", "my-app-abc123.vercel.app");
+    expect(getAuthBaseUrl()).toBe("https://my-app-abc123.vercel.app");
+  });
+
+  it("returns BETTER_AUTH_URL when not in preview", () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("BETTER_AUTH_URL", "https://api.zoonk.com");
+    expect(getAuthBaseUrl()).toBe("https://api.zoonk.com");
+  });
+
+  it("returns BETTER_AUTH_URL when VERCEL_ENV is not set", () => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://api.zoonk.com");
+    expect(getAuthBaseUrl()).toBe("https://api.zoonk.com");
+  });
+
+  it("returns undefined when no env vars are set", () => {
+    expect(getAuthBaseUrl()).toBeUndefined();
+  });
+
+  it("returns BETTER_AUTH_URL when VERCEL_ENV is preview but VERCEL_URL is missing", () => {
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("BETTER_AUTH_URL", "https://api.zoonk.com");
+    expect(getAuthBaseUrl()).toBe("https://api.zoonk.com");
+  });
+});
+
+describe(getCrossSubDomainCookies, () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns cookie config in production with domain set", () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("BETTER_AUTH_COOKIE_DOMAIN", "zoonk.com");
+    expect(getCrossSubDomainCookies()).toEqual({
+      domain: "zoonk.com",
+      enabled: true,
+    });
+  });
+
+  it("returns undefined when not in production", () => {
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("BETTER_AUTH_COOKIE_DOMAIN", "zoonk.com");
+    expect(getCrossSubDomainCookies()).toBeUndefined();
+  });
+
+  it("returns undefined when domain is not set", () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    expect(getCrossSubDomainCookies()).toBeUndefined();
+  });
+
+  it("returns undefined when no env vars are set", () => {
+    expect(getCrossSubDomainCookies()).toBeUndefined();
+  });
+});

--- a/packages/auth/src/config.ts
+++ b/packages/auth/src/config.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@zoonk/db";
-import { getDevTrustedOrigins, getVercelTrustedOrigins } from "@zoonk/utils/url";
+import { getBaseUrl, getDevTrustedOrigins, getVercelTrustedOrigins } from "@zoonk/utils/url";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { nextCookies } from "better-auth/next-js";
 import {
@@ -14,7 +14,7 @@ import {
 } from "better-auth/plugins";
 import { type BetterAuthOptions } from "better-auth/types";
 import { BETTER_AUTH_BASE_PATH } from "./constants";
-import { getAuthBaseUrl, getCrossSubDomainCookies } from "./env";
+import { getCrossSubDomainCookies } from "./env";
 import { ac, admin, member, owner } from "./permissions";
 import { sendVerificationOTP } from "./plugins/otp";
 import { stripePlugin } from "./plugins/stripe";
@@ -45,7 +45,7 @@ export const baseAuthConfig: Omit<BetterAuthOptions, "rateLimit"> = {
   },
   appName: "Zoonk",
   basePath: BETTER_AUTH_BASE_PATH,
-  baseURL: getAuthBaseUrl(),
+  baseURL: getBaseUrl(),
   database: prismaAdapter(prisma, { provider: "postgresql" }),
   experimental: {
     joins: true,

--- a/packages/auth/src/config.ts
+++ b/packages/auth/src/config.ts
@@ -14,6 +14,7 @@ import {
 } from "better-auth/plugins";
 import { type BetterAuthOptions } from "better-auth/types";
 import { BETTER_AUTH_BASE_PATH } from "./constants";
+import { getAuthBaseUrl, getCrossSubDomainCookies } from "./env";
 import { ac, admin, member, owner } from "./permissions";
 import { sendVerificationOTP } from "./plugins/otp";
 import { stripePlugin } from "./plugins/stripe";
@@ -39,10 +40,12 @@ export const baseAuthConfig: Omit<BetterAuthOptions, "rateLimit"> = {
     accountLinking: { enabled: true },
   },
   advanced: {
+    crossSubDomainCookies: getCrossSubDomainCookies(),
     database: { generateId: "serial" },
   },
   appName: "Zoonk",
   basePath: BETTER_AUTH_BASE_PATH,
+  baseURL: getAuthBaseUrl(),
   database: prismaAdapter(prisma, { provider: "postgresql" }),
   experimental: {
     joins: true,

--- a/packages/auth/src/env.ts
+++ b/packages/auth/src/env.ts
@@ -1,11 +1,3 @@
-export function getAuthBaseUrl(): string | undefined {
-  if (process.env.VERCEL_ENV === "preview" && process.env.VERCEL_URL) {
-    return `https://${process.env.VERCEL_URL}`;
-  }
-
-  return process.env.BETTER_AUTH_URL;
-}
-
 export function getCrossSubDomainCookies():
   | {
       enabled: boolean;

--- a/packages/auth/src/env.ts
+++ b/packages/auth/src/env.ts
@@ -1,0 +1,23 @@
+export function getAuthBaseUrl(): string | undefined {
+  if (process.env.VERCEL_ENV === "preview" && process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+
+  return process.env.BETTER_AUTH_URL;
+}
+
+export function getCrossSubDomainCookies():
+  | {
+      enabled: boolean;
+      domain: string;
+    }
+  | undefined {
+  if (process.env.VERCEL_ENV === "production" && process.env.BETTER_AUTH_COOKIE_DOMAIN) {
+    return {
+      domain: process.env.BETTER_AUTH_COOKIE_DOMAIN,
+      enabled: true,
+    };
+  }
+
+  return undefined;
+}

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -7,6 +7,7 @@ export default defineConfig({
     env: {
       DATABASE_URL: "postgres://postgres:postgres@localhost:5432/zoonk_test",
       DATABASE_URL_UNPOOLED: "postgres://postgres:postgres@localhost:5432/zoonk_test",
+      NEXT_PUBLIC_APP_DOMAIN: "localhost:9000",
     },
     environment: "node",
     setupFiles: ["./setup-tests.ts"],


### PR DESCRIPTION
## Summary
- Add `baseURL` and `crossSubDomainCookies` to Better Auth config for proper Vercel preview/production support
- Extract env helpers (`getAuthBaseUrl`, `getCrossSubDomainCookies`) into `packages/auth/src/env.ts` with unit tests
- Add `BETTER_AUTH_URL` and `BETTER_AUTH_COOKIE_DOMAIN` env vars to all app `.env.example` files

## Test plan
- [x] Unit tests for both helpers (9 tests covering preview, production, and fallback cases)
- [x] `pnpm turbo quality:fix` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm knip` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds baseURL to Better Auth using getBaseUrl and enables cross-subdomain cookies to fix Vercel preview/production URLs and share sessions across subdomains. Improves reliability of auth callbacks in multi-app deployments.

- **New Features**
  - Config uses baseURL via getBaseUrl and crossSubDomainCookies via env getCrossSubDomainCookies.
  - Added getCrossSubDomainCookies helper with unit tests; added NEXT_PUBLIC_APP_DOMAIN to Vitest configs so getBaseUrl works in tests.
  - Added BETTER_AUTH_COOKIE_DOMAIN to all app .env.example files.

- **Migration**
  - Set BETTER_AUTH_COOKIE_DOMAIN to your root domain to share sessions across subdomains.
  - No change needed in Vercel preview; baseURL derives from VERCEL_URL automatically.

<sup>Written for commit ab37d563de00d2bd792f7d2b7312592e458c579f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

