### PR TITLE
feat(main): add diagram visual renderer for activity player

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1271,6 +1271,11 @@ msgctxt "P768k7"
 msgid "correct"
 msgstr "correct"
 
+#: src/components/activity-player/diagram-visual.tsx
+msgctxt "PBUs06"
+msgid "Diagram"
+msgstr "Diagram"
+
 #: src/components/activity-player/dimension-status-button.tsx
 msgctxt "ehV7Gg"
 msgid "Current dimension scores"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1271,6 +1271,11 @@ msgctxt "P768k7"
 msgid "correct"
 msgstr "correcto"
 
+#: src/components/activity-player/diagram-visual.tsx
+msgctxt "PBUs06"
+msgid "Diagram"
+msgstr "Diagrama"
+
 #: src/components/activity-player/dimension-status-button.tsx
 msgctxt "ehV7Gg"
 msgid "Current dimension scores"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1271,6 +1271,11 @@ msgctxt "P768k7"
 msgid "correct"
 msgstr "correto"
 
+#: src/components/activity-player/diagram-visual.tsx
+msgctxt "PBUs06"
+msgid "Diagram"
+msgstr "Diagrama"
+
 #: src/components/activity-player/dimension-status-button.tsx
 msgctxt "ehV7Gg"
 msgid "Current dimension scores"

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -15,6 +15,7 @@
     "typecheck": "next typegen && tsgo --noEmit"
   },
   "dependencies": {
+    "@dagrejs/dagre": "2.0.4",
     "@tabler/icons-react": "3.36.1",
     "@vercel/analytics": "1.6.1",
     "@xstate/store": "3.15.0",

--- a/apps/main/src/components/activity-player/diagram-layout.test.ts
+++ b/apps/main/src/components/activity-player/diagram-layout.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { computeDiagramLayout } from "./diagram-layout";
+
+describe(computeDiagramLayout, () => {
+  it("positions a linear chain with vertical ordering", () => {
+    const nodes = [
+      { id: "a", label: "Start" },
+      { id: "b", label: "Middle" },
+      { id: "c", label: "End" },
+    ];
+    const edges = [
+      { source: "a", target: "b" },
+      { source: "b", target: "c" },
+    ];
+
+    const layout = computeDiagramLayout(nodes, edges);
+
+    const nodeA = layout.nodes.find((node) => node.id === "a");
+    const nodeB = layout.nodes.find((node) => node.id === "b");
+    const nodeC = layout.nodes.find((node) => node.id === "c");
+
+    expect(nodeA).toBeDefined();
+    expect(nodeB).toBeDefined();
+    expect(nodeC).toBeDefined();
+    expect(nodeA!.y).toBeLessThan(nodeB!.y);
+    expect(nodeB!.y).toBeLessThan(nodeC!.y);
+  });
+
+  it("positions a tree with root above children at the same level", () => {
+    const nodes = [
+      { id: "root", label: "Root" },
+      { id: "left", label: "Left Child" },
+      { id: "right", label: "Right Child" },
+    ];
+    const edges = [
+      { source: "root", target: "left" },
+      { source: "root", target: "right" },
+    ];
+
+    const layout = computeDiagramLayout(nodes, edges);
+
+    const root = layout.nodes.find((node) => node.id === "root");
+    const left = layout.nodes.find((node) => node.id === "left");
+    const right = layout.nodes.find((node) => node.id === "right");
+
+    expect(root!.y).toBeLessThan(left!.y);
+    expect(left!.y).toBe(right!.y);
+
+    // Children should not overlap horizontally
+    const gap = Math.abs(left!.x - right!.x) - (left!.width + right!.width) / 2;
+    expect(gap).toBeGreaterThanOrEqual(0);
+  });
+
+  it("handles a diamond shape with correct layer assignment", () => {
+    const nodes = [
+      { id: "top", label: "Top" },
+      { id: "left", label: "Left" },
+      { id: "right", label: "Right" },
+      { id: "bottom", label: "Bottom" },
+    ];
+    const edges = [
+      { source: "top", target: "left" },
+      { source: "top", target: "right" },
+      { source: "left", target: "bottom" },
+      { source: "right", target: "bottom" },
+    ];
+
+    const layout = computeDiagramLayout(nodes, edges);
+
+    const top = layout.nodes.find((node) => node.id === "top");
+    const left = layout.nodes.find((node) => node.id === "left");
+    const right = layout.nodes.find((node) => node.id === "right");
+    const bottom = layout.nodes.find((node) => node.id === "bottom");
+
+    expect(top!.y).toBeLessThan(left!.y);
+    expect(left!.y).toBe(right!.y);
+    expect(left!.y).toBeLessThan(bottom!.y);
+  });
+
+  it("handles a single node with no edges", () => {
+    const layout = computeDiagramLayout([{ id: "solo", label: "Alone" }], []);
+
+    expect(layout.nodes).toHaveLength(1);
+    expect(layout.edges).toHaveLength(0);
+    expect(layout.width).toBeGreaterThan(0);
+    expect(layout.height).toBeGreaterThan(0);
+  });
+
+  it("preserves edge labels in output", () => {
+    const nodes = [
+      { id: "a", label: "A" },
+      { id: "b", label: "B" },
+    ];
+    const edges = [{ label: "connects to", source: "a", target: "b" }];
+
+    const layout = computeDiagramLayout(nodes, edges);
+    const [edge] = layout.edges;
+
+    expect(edge).toBeDefined();
+    expect(edge!.label).toBe("connects to");
+    expect(edge!.source).toBe("a");
+    expect(edge!.target).toBe("b");
+    expect(edge!.points.length).toBeGreaterThan(0);
+  });
+
+  it("scales node width with label length", () => {
+    const shortLabel = "Hi";
+    const longLabel = "This is a significantly longer label";
+    const nodes = [
+      { id: "short", label: shortLabel },
+      { id: "long", label: longLabel },
+    ];
+
+    const layout = computeDiagramLayout(nodes, []);
+    const shortNode = layout.nodes.find((node) => node.id === "short");
+    const longNode = layout.nodes.find((node) => node.id === "long");
+
+    expect(longNode!.width).toBeGreaterThan(shortNode!.width);
+  });
+
+  it("enforces a minimum node width", () => {
+    const layout = computeDiagramLayout([{ id: "tiny", label: "X" }], []);
+    const [node] = layout.nodes;
+
+    expect(node).toBeDefined();
+    expect(node!.width).toBeGreaterThanOrEqual(100);
+  });
+
+  it("returns layout dimensions that encompass all nodes", () => {
+    const nodes = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ];
+    const edges = [
+      { source: "a", target: "b" },
+      { source: "a", target: "c" },
+    ];
+
+    const layout = computeDiagramLayout(nodes, edges);
+
+    for (const node of layout.nodes) {
+      expect(node.x + node.width / 2).toBeLessThanOrEqual(layout.width);
+      expect(node.y + node.height / 2).toBeLessThanOrEqual(layout.height);
+    }
+  });
+
+  it("handles edges without labels", () => {
+    const nodes = [
+      { id: "a", label: "A" },
+      { id: "b", label: "B" },
+    ];
+    const edges = [{ source: "a", target: "b" }];
+
+    const layout = computeDiagramLayout(nodes, edges);
+    const [edge] = layout.edges;
+
+    expect(edge).toBeDefined();
+    expect(edge!.label).toBeUndefined();
+  });
+});

--- a/apps/main/src/components/activity-player/diagram-layout.ts
+++ b/apps/main/src/components/activity-player/diagram-layout.ts
@@ -1,0 +1,124 @@
+import dagre from "@dagrejs/dagre";
+
+export type PositionedNode = {
+  height: number;
+  id: string;
+  label: string;
+  width: number;
+  x: number;
+  y: number;
+};
+
+export type PositionedEdge = {
+  label?: string;
+  points: { x: number; y: number }[];
+  source: string;
+  target: string;
+};
+
+export type DiagramLayout = {
+  edges: PositionedEdge[];
+  height: number;
+  nodes: PositionedNode[];
+  width: number;
+};
+
+const MIN_NODE_WIDTH = 100;
+const NODE_HEIGHT = 40;
+const CHAR_WIDTH = 7.5;
+const NODE_PADDING = 32;
+const NODE_SEP = 60;
+const RANK_SEP = 60;
+const LAYOUT_PADDING = 40;
+
+function estimateNodeWidth(label: string): number {
+  return Math.max(MIN_NODE_WIDTH, label.length * CHAR_WIDTH + NODE_PADDING);
+}
+
+/* oxlint-disable no-unsafe-member-access -- dagre node properties are untyped after layout */
+function readNodePosition(
+  graph: dagre.graphlib.Graph,
+  id: string,
+): { height: number; width: number; x: number; y: number } {
+  // oxlint-disable-next-line no-unsafe-assignment -- dagre layout mutates nodes in place
+  const node = graph.node(id);
+
+  return {
+    height: Number(node.height),
+    width: Number(node.width),
+    x: Number(node.x),
+    y: Number(node.y),
+  };
+}
+/* oxlint-enable no-unsafe-member-access */
+
+function readEdgePoints(
+  graph: dagre.graphlib.Graph,
+  source: string,
+  target: string,
+): { x: number; y: number }[] {
+  // oxlint-disable-next-line no-unsafe-assignment -- dagre edge data is untyped after layout
+  const edge = graph.edge(source, target);
+  // oxlint-disable-next-line no-unsafe-member-access, no-unsafe-type-assertion -- dagre edge points array is untyped
+  return (edge.points ?? []) as { x: number; y: number }[];
+}
+
+function readGraphDimensions(graph: dagre.graphlib.Graph): { height: number; width: number } {
+  // oxlint-disable-next-line no-unsafe-assignment -- dagre graph dimensions are untyped
+  const info = graph.graph();
+  // oxlint-disable-next-line no-unsafe-member-access -- dagre graph info properties are untyped
+  return { height: Number(info.height ?? 0), width: Number(info.width ?? 0) };
+}
+
+export function computeDiagramLayout(
+  nodes: {
+    id: string;
+    label: string;
+  }[],
+  edges: {
+    label?: string;
+    source: string;
+    target: string;
+  }[],
+): DiagramLayout {
+  const graph = new dagre.graphlib.Graph();
+
+  graph.setGraph({ nodesep: NODE_SEP, rankdir: "TB", ranksep: RANK_SEP });
+  graph.setDefaultEdgeLabel(() => ({}));
+
+  for (const node of nodes) {
+    graph.setNode(node.id, {
+      height: NODE_HEIGHT,
+      label: node.label,
+      width: estimateNodeWidth(node.label),
+    });
+  }
+
+  for (const edge of edges) {
+    graph.setEdge(edge.source, edge.target, { label: edge.label });
+  }
+
+  dagre.layout(graph);
+
+  const positionedNodes = nodes.map((node) => ({
+    ...readNodePosition(graph, node.id),
+    id: node.id,
+    label: node.label,
+  }));
+
+  const positionedEdges = edges.map((edge) => ({
+    label: edge.label,
+    points: readEdgePoints(graph, edge.source, edge.target),
+    source: edge.source,
+    target: edge.target,
+  }));
+
+  const dimensions = readGraphDimensions(graph);
+
+  return {
+    edges: positionedEdges,
+    height: dimensions.height + LAYOUT_PADDING,
+    nodes: positionedNodes,
+    width: dimensions.width + LAYOUT_PADDING,
+  };
+}

--- a/apps/main/src/components/activity-player/diagram-visual.tsx
+++ b/apps/main/src/components/activity-player/diagram-visual.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import {
+  type DiagramVisualContent,
+  diagramVisualContentSchema,
+} from "@zoonk/core/steps/visual-content-contract";
+import { useExtracted } from "next-intl";
+import { useId, useMemo } from "react";
+import {
+  type DiagramLayout,
+  type PositionedEdge,
+  type PositionedNode,
+  computeDiagramLayout,
+} from "./diagram-layout";
+
+const NODE_BORDER_RADIUS = 8;
+const EDGE_STROKE_WIDTH = 1.5;
+const EDGE_OPACITY = 0.25;
+const ARROW_SIZE = 8;
+const EDGE_LABEL_CHAR_WIDTH = 6;
+const EDGE_LABEL_PADDING_X = 6;
+const EDGE_LABEL_PADDING_Y = 3;
+const EDGE_LABEL_FONT_SIZE = 11;
+
+function ArrowMarker({ markerId }: { markerId: string }) {
+  return (
+    <defs>
+      <marker
+        id={markerId}
+        markerHeight={ARROW_SIZE}
+        markerUnits="strokeWidth"
+        markerWidth={ARROW_SIZE}
+        orient="auto-start-reverse"
+        refX={ARROW_SIZE}
+        refY={ARROW_SIZE / 2}
+        viewBox={`0 0 ${ARROW_SIZE} ${ARROW_SIZE}`}
+      >
+        <path
+          d={`M 0 0 L ${ARROW_SIZE} ${ARROW_SIZE / 2} L 0 ${ARROW_SIZE} Z`}
+          fill="currentColor"
+          opacity={EDGE_OPACITY}
+        />
+      </marker>
+    </defs>
+  );
+}
+
+function DiagramEdgeLine({ edge, markerId }: { edge: PositionedEdge; markerId: string }) {
+  const pathData = edge.points
+    .map((point, index) => `${index === 0 ? "M" : "L"} ${point.x} ${point.y}`)
+    .join(" ");
+
+  return (
+    <path
+      d={pathData}
+      fill="none"
+      markerEnd={`url(#${markerId})`}
+      opacity={EDGE_OPACITY}
+      stroke="currentColor"
+      strokeWidth={EDGE_STROKE_WIDTH}
+    />
+  );
+}
+
+function DiagramEdgeLabel({ edge }: { edge: PositionedEdge }) {
+  if (!edge.label) {
+    return null;
+  }
+
+  const midIndex = Math.floor(edge.points.length / 2);
+  const midPoint = edge.points[midIndex];
+
+  if (!midPoint) {
+    return null;
+  }
+
+  const labelWidth = edge.label.length * EDGE_LABEL_CHAR_WIDTH + EDGE_LABEL_PADDING_X * 2;
+  const labelHeight = EDGE_LABEL_FONT_SIZE + EDGE_LABEL_PADDING_Y * 2;
+
+  return (
+    <g>
+      <rect
+        fill="var(--background)"
+        height={labelHeight}
+        rx={4}
+        width={labelWidth}
+        x={midPoint.x - labelWidth / 2}
+        y={midPoint.y - labelHeight / 2}
+      />
+
+      <text
+        dominantBaseline="central"
+        fill="var(--muted-foreground)"
+        fontSize={EDGE_LABEL_FONT_SIZE}
+        textAnchor="middle"
+        x={midPoint.x}
+        y={midPoint.y}
+      >
+        {edge.label}
+      </text>
+    </g>
+  );
+}
+
+function DiagramEdges({ edges, markerId }: { edges: PositionedEdge[]; markerId: string }) {
+  return (
+    <g>
+      {edges.map((edge) => (
+        <g key={`${edge.source}-${edge.target}`}>
+          <DiagramEdgeLine edge={edge} markerId={markerId} />
+          <DiagramEdgeLabel edge={edge} />
+        </g>
+      ))}
+    </g>
+  );
+}
+
+function DiagramNodeRect({ node }: { node: PositionedNode }) {
+  return (
+    <g>
+      <rect
+        fill="var(--background)"
+        height={node.height}
+        rx={NODE_BORDER_RADIUS}
+        ry={NODE_BORDER_RADIUS}
+        stroke="var(--foreground)"
+        strokeOpacity={0.15}
+        strokeWidth={1}
+        width={node.width}
+        x={node.x - node.width / 2}
+        y={node.y - node.height / 2}
+      />
+
+      <text
+        dominantBaseline="central"
+        fill="currentColor"
+        fontSize={14}
+        fontWeight={500}
+        textAnchor="middle"
+        x={node.x}
+        y={node.y}
+      >
+        {node.label}
+      </text>
+    </g>
+  );
+}
+
+function DiagramNodes({ nodes }: { nodes: PositionedNode[] }) {
+  return (
+    <g>
+      {nodes.map((node) => (
+        <DiagramNodeRect key={node.id} node={node} />
+      ))}
+    </g>
+  );
+}
+
+function buildAccessibleDescription(content: DiagramVisualContent): string {
+  const relationships = content.edges.map((edge) => {
+    const sourceNode = content.nodes.find((node) => node.id === edge.source);
+    const targetNode = content.nodes.find((node) => node.id === edge.target);
+    const sourceName = sourceNode?.label ?? edge.source;
+    const targetName = targetNode?.label ?? edge.target;
+    const via = edge.label ? ` (${edge.label})` : "";
+
+    return `${sourceName} connects to ${targetName}${via}`;
+  });
+
+  return relationships.join(". ");
+}
+
+function DiagramSvg({ layout, markerId }: { layout: DiagramLayout; markerId: string }) {
+  return (
+    <svg
+      className="w-full"
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      viewBox={`0 0 ${layout.width} ${layout.height}`}
+    >
+      <ArrowMarker markerId={markerId} />
+      <DiagramEdges edges={layout.edges} markerId={markerId} />
+      <DiagramNodes nodes={layout.nodes} />
+    </svg>
+  );
+}
+
+export function DiagramVisual({ content }: { content: unknown }) {
+  const t = useExtracted();
+  const markerId = useId();
+  const parsed = diagramVisualContentSchema.parse(content);
+
+  const layout = useMemo(
+    () => computeDiagramLayout(parsed.nodes, parsed.edges),
+    [parsed.nodes, parsed.edges],
+  );
+
+  const description = useMemo(() => buildAccessibleDescription(parsed), [parsed]);
+
+  return (
+    <figure aria-label={t("Diagram")} className="w-full max-w-xl">
+      <DiagramSvg layout={layout} markerId={markerId} />
+      <figcaption className="sr-only">{description}</figcaption>
+    </figure>
+  );
+}

--- a/apps/main/src/components/activity-player/step-visual-renderer.tsx
+++ b/apps/main/src/components/activity-player/step-visual-renderer.tsx
@@ -6,6 +6,7 @@ import {
 } from "@zoonk/core/steps/visual-content-contract";
 import { ChartVisual } from "./chart-visual";
 import { CodeVisual } from "./code-visual";
+import { DiagramVisual } from "./diagram-visual";
 import { ImageVisual } from "./image-visual";
 import { QuoteVisual } from "./quote-visual";
 import { TableVisual } from "./table-visual";
@@ -46,6 +47,9 @@ export function StepVisualRenderer({
     return <ChartVisual content={visualContent} />;
   }
 
-  // Other visual kinds will be added in Issue 22 (diagram).
+  if (visualKind === "diagram") {
+    return <DiagramVisual content={visualContent} />;
+  }
+
   return null;
 }

--- a/i18n.lock
+++ b/i18n.lock
@@ -429,6 +429,7 @@ checksums:
     Sign%20up%20to%20track%20your%20progress/singular: 554ed29d9b8a243362c3b3374222af08
     Completed/singular: 0e4bbce9985f25eb673d9a054c8d5334
     correct/singular: 0c2df4a764cea47295c0b550477e8e29
+    Diagram/singular: e0bc1ef7782cb0d749c9582da6775175
     Current%20dimension%20scores/singular: b3a4b7edbd41132e6fb349a6df24a33d
     View%20stats/singular: 707f91e0ff65e7163c95900395dc0297
     Stats/singular: 5cf8b052c89fa1b05397a956ebec69b2

--- a/packages/core/src/steps/visual-content-contract.ts
+++ b/packages/core/src/steps/visual-content-contract.ts
@@ -45,7 +45,7 @@ const diagramEdgeSchema = z
   })
   .strict();
 
-const diagramVisualContentSchema = z
+export const diagramVisualContentSchema = z
   .object({
     edges: z.array(diagramEdgeSchema),
     nodes: z.array(diagramNodeSchema),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,9 @@ importers:
 
   apps/main:
     dependencies:
+      '@dagrejs/dagre':
+        specifier: 2.0.4
+        version: 2.0.4
       '@tabler/icons-react':
         specifier: 3.36.1
         version: 3.36.1(react@19.2.4)
@@ -1188,6 +1191,12 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dagrejs/dagre@2.0.4':
+    resolution: {integrity: sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA==}
+
+  '@dagrejs/graphlib@3.0.4':
+    resolution: {integrity: sha512-HxZ7fCvAwTLCWCO0WjDkzAFQze8LdC6iOpKbetDKHIuDfIgMlIzYzqZ4nxwLlclQX+3ZVeZ1K2OuaOE2WWcyOg==}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -7593,6 +7602,12 @@ snapshots:
   '@csstools/css-syntax-patches-for-csstree@1.0.27': {}
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dagrejs/dagre@2.0.4':
+    dependencies:
+      '@dagrejs/graphlib': 3.0.4
+
+  '@dagrejs/graphlib@3.0.4': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
     dependencies:


### PR DESCRIPTION
## Summary

- Add diagram visual renderer using `@dagrejs/dagre` for automatic node layout
- SVG-based rendering with nodes, directional edges, and optional edge labels
- Accessible via `role="img"` on SVG and sr-only figcaption describing relationships
- Completes all 7 visual kinds (image, quote, code, table, timeline, chart, diagram)

## Test plan

- [x] Unit tests for `computeDiagramLayout` (9 cases: linear chains, trees, diamonds, single nodes, edge labels, width scaling)
- [x] E2E test: diagram renders node labels and edge labels
- [x] E2E test: clicking diagram doesn't navigate to next step
- [x] Removed obsolete "unimplemented visual kind" e2e test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an accessible SVG diagram visual to the Activity Player with automatic node layout, completing support for all 7 visual kinds. Diagrams render nodes, directed edges, and optional edge labels without hijacking step navigation.

- **New Features**
  - DiagramVisual with auto layout via @dagrejs/dagre; supports nodes, directed edges, and edge labels.
  - Integrated into StepVisualRenderer for visualKind="diagram".
  - Accessibility: SVG role="img" with sr-only figcaption; localized "Diagram" label (en/es/pt).
  - Exported diagramVisualContentSchema from core for runtime parsing; added unit and E2E coverage.

- **Dependencies**
  - Added @dagrejs/dagre@2.0.4.

<sup>Written for commit e225d6a0582b85f76821e74f8134c6b34d94521f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

