### PR TITLE
fix(utils): add zoonk.dev to trusted origins

### DIFF
--- a/packages/utils/src/url.ts
+++ b/packages/utils/src/url.ts
@@ -82,7 +82,7 @@ export function getDevTrustedOrigins(): string[] {
   return ["http://localhost:*", ...customOrigins];
 }
 
-const ZOONK_DOMAINS = [".zoonk.com", ".zoonk.app", ".zoonk.school", ".zoonk.team"];
+const ZOONK_DOMAINS = [".zoonk.com", ".zoonk.app", ".zoonk.school", ".zoonk.team", ".zoonk.dev"];
 
 /**
  * Checks if an origin is allowed for CORS.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add .zoonk.dev to the trusted origin list so CORS accepts requests from *.zoonk.dev. This unblocks the new dev domain and prevents CORS errors in development and staging.

<sup>Written for commit 9b24bbc21e5efaaf4af353c6085caaab301c4d8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

