### PR TITLE
fix(ui): remove button link variant

### DIFF
--- a/apps/api/src/app/auth/otp/page.tsx
+++ b/apps/api/src/app/auth/otp/page.tsx
@@ -21,7 +21,7 @@ export default async function OTPPage({ searchParams }: PageProps<"/auth/otp">) 
       <OTPForm email={String(email)} redirectTo={String(redirectTo)} />
 
       <Link
-        className={buttonVariants({ variant: "link" })}
+        className={buttonVariants({ variant: "outline" })}
         href={{
           pathname: "/auth/login",
           query: { redirectTo: String(redirectTo) },

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -29,7 +29,6 @@ const buttonVariants = cva(
           "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 dark:hover:bg-destructive/30 border-transparent",
         ghost:
           "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 border-transparent",
-        link: "text-primary underline-offset-4 hover:underline",
         outline:
           "border-border bg-background hover:bg-input/50 hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground",
         secondary:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the "link" button variant from the UI library and updated the OTP page to use the "outline" variant. This cleans up unused styles and fixes inconsistent link styling on /auth/otp.

<sup>Written for commit 5bbf81dc74a716180228aca775250797f162d902. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

