### PR TITLE
fix(ui): remove redundant pseudo-element from HorizontalScrollContent

### DIFF
--- a/apps/main/src/app/[locale]/(catalog)/courses/category-pills.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/courses/category-pills.tsx
@@ -30,11 +30,7 @@ export function CategoryPills() {
 
   return (
     <HorizontalScroll className="pb-4">
-      <HorizontalScrollContent
-        aria-label={t("Course categories")}
-        className="px-4"
-        role="navigation"
-      >
+      <HorizontalScrollContent aria-label={t("Course categories")} role="navigation">
         <Link
           className={buttonVariants({
             size: "sm",

--- a/apps/main/src/app/[locale]/(performance)/_components/performance-navbar.tsx
+++ b/apps/main/src/app/[locale]/(performance)/_components/performance-navbar.tsx
@@ -13,7 +13,7 @@ export function PerformanceNavbar() {
   return (
     <nav className="bg-background/95 supports-backdrop-filter:bg-background/60 sticky top-0 z-10 pt-4 backdrop-blur">
       <HorizontalScroll>
-        <HorizontalScrollContent className="px-4">
+        <HorizontalScrollContent>
           <Link className={buttonVariants({ size: "icon", variant: "outline" })} href="/">
             <HomeIcon aria-hidden="true" />
             <span className="sr-only">{t("Home page")}</span>

--- a/apps/main/src/app/[locale]/(settings)/_components/settings-navbar.tsx
+++ b/apps/main/src/app/[locale]/(settings)/_components/settings-navbar.tsx
@@ -19,7 +19,7 @@ export function SettingsNavbar() {
   return (
     <nav className="bg-background/95 supports-backdrop-filter:bg-background/60 sticky top-0 z-10 pt-4 backdrop-blur">
       <HorizontalScroll>
-        <HorizontalScrollContent className="px-4">
+        <HorizontalScrollContent>
           <Link
             className={buttonVariants({ size: "icon", variant: "outline" })}
             href={homeMenu.url}

--- a/packages/ui/src/components/horizontal-scroll.tsx
+++ b/packages/ui/src/components/horizontal-scroll.tsx
@@ -88,7 +88,7 @@ function HorizontalScroll({ className, children, ...props }: React.ComponentProp
 function HorizontalScrollContent({ className, children, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("flex gap-2 pb-1 after:w-4 after:shrink-0 after:content-['']", className)}
+      className={cn("flex gap-2 px-4 pb-1", className)}
       data-slot="horizontal-scroll-content"
       {...props}
     >


### PR DESCRIPTION
## Summary

- Remove the `::after` pseudo-element from `HorizontalScrollContent` (legacy workaround for scroll container end-padding)
- Bake `px-4` into `HorizontalScrollContent` as the default padding, removing duplication from all 3 consumers
- Fixes logout button right-alignment in settings navbar (`ml-auto` now works flush against the edge)

## Test plan

- [ ] Visual check: settings navbar logout button aligns flush-right on large screens
- [ ] Visual check: horizontal scroll padding looks correct on all 3 consumers (settings, performance, category pills)
- [ ] Verify scroll behavior still works on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the legacy ::after spacer and set px-4 as the default padding in HorizontalScrollContent. This simplifies consumers and fixes the settings navbar logout button aligning flush-right.

- **Refactors**
  - Removed ::after spacer and added default px-4 in HorizontalScrollContent; dropped redundant px-4 in settings, performance, and category pills.

- **Bug Fixes**
  - Settings navbar logout button now aligns flush-right (ml-auto works without extra end gap).

<sup>Written for commit 7a7d56db09b25e90aca6043004c230346ece5b50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

