### PR TITLE
feat(main): add vocabulary step to activity player

### DIFF
--- a/apps/editor/src/components/editor-list/editor-sortable-list.tsx
+++ b/apps/editor/src/components/editor-list/editor-sortable-list.tsx
@@ -155,14 +155,14 @@ export function EditorSortableList<T extends SortableItem>({
         </SortableContext>
 
         <DragOverlay>
-          {activeItem && renderOverlay ? (
+          {activeItem && renderOverlay && (
             <div
               className="bg-background rounded-md border shadow-md"
               data-slot="editor-drag-overlay"
             >
               {renderOverlay(activeItem)}
             </div>
-          ) : null}
+          )}
         </DragOverlay>
       </DndContext>
     </EditorSortableContext.Provider>

--- a/apps/main/e2e/vocabulary-step.test.ts
+++ b/apps/main/e2e/vocabulary-step.test.ts
@@ -1,0 +1,395 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonWordFixture } from "@zoonk/testing/fixtures/lesson-words";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { wordFixture } from "@zoonk/testing/fixtures/words";
+import { type Page, expect, test } from "./fixtures";
+
+async function createVocabularyActivity(options: {
+  words: {
+    word: string;
+    translation: string;
+    pronunciation?: string | null;
+    romanization?: string | null;
+  }[];
+}) {
+  const org = await prisma.organization.findUniqueOrThrow({
+    where: { slug: "ai" },
+  });
+
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-vocab-course-${uniqueId}`,
+    title: `E2E Vocab Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-vocab-chapter-${uniqueId}`,
+    title: `E2E Vocab Chapter ${uniqueId}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    description: `E2E vocab lesson ${uniqueId}`,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-vocab-lesson-${uniqueId}`,
+    title: `E2E Vocab Lesson ${uniqueId}`,
+  });
+
+  const createdWords = await Promise.all(
+    options.words.map((wordData) =>
+      wordFixture({
+        organizationId: org.id,
+        pronunciation: wordData.pronunciation ?? null,
+        romanization: wordData.romanization ?? null,
+        translation: wordData.translation,
+        word: wordData.word,
+      }),
+    ),
+  );
+
+  await Promise.all(
+    createdWords.map((word) => lessonWordFixture({ lessonId: lesson.id, wordId: word.id })),
+  );
+
+  const activity = await activityFixture({
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "vocabulary",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 0,
+    title: `E2E Vocab Activity ${uniqueId}`,
+  });
+
+  await Promise.all(
+    createdWords.map((word, index) =>
+      stepFixture({
+        activityId: activity.id,
+        content: {},
+        isPublished: true,
+        kind: "vocabulary",
+        position: index,
+        wordId: word.id,
+      }),
+    ),
+  );
+
+  const url = `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/0`;
+
+  return { url };
+}
+
+async function answerVocabularyStep(page: Page, wordText: string, translation: string) {
+  const radiogroup = page.getByRole("radiogroup", { name: /answer options/i });
+  await expect(page.getByText(translation)).toBeVisible();
+
+  const option = radiogroup.getByRole("radio", { name: new RegExp(wordText) });
+
+  await expect(async () => {
+    const isChecked = await option.getAttribute("aria-checked");
+
+    if (isChecked !== "true") {
+      await option.click();
+    }
+
+    await expect(option).toHaveAttribute("aria-checked", "true", { timeout: 1000 });
+  }).toPass();
+
+  await page.getByRole("button", { name: /check/i }).click();
+  await page.getByRole("button", { name: /continue/i }).click();
+}
+
+test.describe("Vocabulary Step", () => {
+  test("renders translation prompt and 4 answer options with correct word among them", async ({
+    page,
+  }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const word = `hola-${uniqueId}`;
+    const translation = `hello-${uniqueId}`;
+
+    const { url } = await createVocabularyActivity({
+      words: [
+        { translation, word },
+        { translation: `goodbye-${uniqueId}`, word: `adiós-${uniqueId}` },
+        { translation: `thanks-${uniqueId}`, word: `gracias-${uniqueId}` },
+        { translation: `please-${uniqueId}`, word: `por favor-${uniqueId}` },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(page.getByText(/translate this word/i)).toBeVisible();
+    await expect(page.getByText(translation)).toBeVisible();
+
+    const radiogroup = page.getByRole("radiogroup", { name: /answer options/i });
+    await expect(radiogroup).toBeVisible();
+    await expect(radiogroup.getByRole("radio")).toHaveCount(4);
+    await expect(radiogroup.getByRole("radio", { name: new RegExp(word) })).toBeVisible();
+  });
+
+  test("select correct option and check shows green indicator", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const correctWord = `gato-${uniqueId}`;
+
+    const { url } = await createVocabularyActivity({
+      words: [
+        { translation: `cat-${uniqueId}`, word: correctWord },
+        { translation: `dog-${uniqueId}`, word: `perro-${uniqueId}` },
+        { translation: `bird-${uniqueId}`, word: `pájaro-${uniqueId}` },
+        { translation: `fish-${uniqueId}`, word: `pez-${uniqueId}` },
+      ],
+    });
+
+    await page.goto(url);
+
+    const radiogroup = page.getByRole("radiogroup", { name: /answer options/i });
+    const correctOption = radiogroup.getByRole("radio", { name: new RegExp(correctWord) });
+
+    await expect(async () => {
+      const isChecked = await correctOption.getAttribute("aria-checked");
+
+      if (isChecked !== "true") {
+        await correctOption.click();
+      }
+
+      await expect(correctOption).toHaveAttribute("aria-checked", "true", { timeout: 1000 });
+    }).toPass();
+
+    await page.getByRole("button", { name: /check/i }).click();
+    await expect(page.getByRole("button", { name: /continue/i })).toBeVisible();
+  });
+
+  test("select wrong option and check shows red on wrong and green on correct", async ({
+    page,
+  }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const correctWord = `rojo-${uniqueId}`;
+    const wrongWord = `azul-${uniqueId}`;
+
+    const { url } = await createVocabularyActivity({
+      words: [
+        { translation: `red-${uniqueId}`, word: correctWord },
+        { translation: `blue-${uniqueId}`, word: wrongWord },
+        { translation: `green-${uniqueId}`, word: `verde-${uniqueId}` },
+        { translation: `yellow-${uniqueId}`, word: `amarillo-${uniqueId}` },
+      ],
+    });
+
+    await page.goto(url);
+
+    const radiogroup = page.getByRole("radiogroup", { name: /answer options/i });
+    const wrongOption = radiogroup.getByRole("radio", { name: new RegExp(wrongWord) });
+
+    await expect(async () => {
+      const isChecked = await wrongOption.getAttribute("aria-checked");
+
+      if (isChecked !== "true") {
+        await wrongOption.click();
+      }
+
+      await expect(wrongOption).toHaveAttribute("aria-checked", "true", { timeout: 1000 });
+    }).toPass();
+
+    await page.getByRole("button", { name: /check/i }).click();
+    await expect(page.getByRole("button", { name: /continue/i })).toBeVisible();
+    await expect(radiogroup.getByRole("radio", { name: new RegExp(correctWord) })).toBeVisible();
+  });
+
+  test("keyboard selection: pressing number key selects corresponding option", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const { url } = await createVocabularyActivity({
+      words: [
+        { translation: `one-${uniqueId}`, word: `uno-${uniqueId}` },
+        { translation: `two-${uniqueId}`, word: `dos-${uniqueId}` },
+        { translation: `three-${uniqueId}`, word: `tres-${uniqueId}` },
+        { translation: `four-${uniqueId}`, word: `cuatro-${uniqueId}` },
+      ],
+    });
+
+    await page.goto(url);
+
+    const radiogroup = page.getByRole("radiogroup", { name: /answer options/i });
+    await expect(radiogroup).toBeVisible();
+
+    await expect(async () => {
+      await page.keyboard.press("1");
+      const options = radiogroup.getByRole("radio");
+      await expect(options.first()).toHaveAttribute("aria-checked", "true", { timeout: 1000 });
+    }).toPass();
+
+    await expect(page.getByRole("button", { name: /check/i })).toBeEnabled();
+  });
+
+  test("full flow: select, check, continue to completion", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createVocabularyActivity({
+      words: [
+        { translation: `sun-${uniqueId}`, word: `sol-${uniqueId}` },
+        { translation: `moon-${uniqueId}`, word: `luna-${uniqueId}` },
+        { translation: `star-${uniqueId}`, word: `estrella-${uniqueId}` },
+        { translation: `sky-${uniqueId}`, word: `cielo-${uniqueId}` },
+      ],
+    });
+
+    await page.goto(url);
+
+    await answerVocabularyStep(page, `sol-${uniqueId}`, `sun-${uniqueId}`);
+    await answerVocabularyStep(page, `luna-${uniqueId}`, `moon-${uniqueId}`);
+    await answerVocabularyStep(page, `estrella-${uniqueId}`, `star-${uniqueId}`);
+    await answerVocabularyStep(page, `cielo-${uniqueId}`, `sky-${uniqueId}`);
+
+    // Completion screen
+    await expect(page.getByText("4/4")).toBeVisible();
+    await expect(page.getByText(/correct/i)).toBeVisible();
+  });
+
+  test("feedback preserves the same options shown during playing", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+
+    // Use 10 words so the distractor pool is large (9 eligible, 3 chosen).
+    // If the component remounts, getDistractorWords picks different random words.
+    const allWords = Array.from({ length: 10 }, (_, idx) => ({
+      translation: `trans${idx}-${uniqueId}`,
+      word: `word${idx}-${uniqueId}`,
+    }));
+
+    const { url } = await createVocabularyActivity({ words: allWords });
+
+    await page.goto(url);
+
+    const radiogroup = page.getByRole("radiogroup", { name: /answer options/i });
+    await expect(radiogroup.getByRole("radio")).toHaveCount(4);
+
+    // Record which of the 10 words are shown as the 4 options
+    const visibility = await Promise.all(
+      allWords.map(async (item) => ({
+        isShown: await radiogroup
+          .getByText(item.word, { exact: true })
+          .isVisible()
+          .catch(() => false),
+        word: item.word,
+      })),
+    );
+
+    const shownWords = visibility.filter((item) => item.isShown).map((item) => item.word);
+    expect(shownWords).toHaveLength(4);
+
+    // Select the correct word (first in the input list) and check
+    const correctWord = `word0-${uniqueId}`;
+    const correctOption = radiogroup.getByRole("radio", { name: new RegExp(correctWord) });
+
+    await expect(async () => {
+      const isChecked = await correctOption.getAttribute("aria-checked");
+
+      if (isChecked !== "true") {
+        await correctOption.click();
+      }
+
+      await expect(correctOption).toHaveAttribute("aria-checked", "true", { timeout: 1000 });
+    }).toPass();
+
+    await page.getByRole("button", { name: /check/i }).click();
+    await expect(page.getByRole("button", { name: /continue/i })).toBeVisible();
+
+    // After feedback, the same 4 words must still be visible
+    await Promise.all(
+      shownWords.map(async (wordText) => {
+        await expect(radiogroup.getByText(wordText, { exact: true })).toBeVisible();
+      }),
+    );
+  });
+
+  test("romanization is displayed below the word text", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const { url } = await createVocabularyActivity({
+      words: [
+        {
+          romanization: `konnichiwa-${uniqueId}`,
+          translation: `hello-${uniqueId}`,
+          word: `\u3053\u3093\u306B\u3061\u306F-${uniqueId}`,
+        },
+        {
+          romanization: `sayounara-${uniqueId}`,
+          translation: `goodbye-${uniqueId}`,
+          word: `\u3055\u3088\u3046\u306A\u3089-${uniqueId}`,
+        },
+        {
+          romanization: `arigatou-${uniqueId}`,
+          translation: `thanks-${uniqueId}`,
+          word: `\u3042\u308A\u304C\u3068\u3046-${uniqueId}`,
+        },
+        {
+          romanization: `onegai-${uniqueId}`,
+          translation: `please-${uniqueId}`,
+          word: `\u304A\u306D\u304C\u3044-${uniqueId}`,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await expect(page.getByText(new RegExp(`konnichiwa-${uniqueId}`))).toBeVisible();
+  });
+
+  test("pronunciation is shown only on the selected option", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const word = `hola-${uniqueId}`;
+    const pronunciation = `pron-hola-${uniqueId}`;
+
+    const { url } = await createVocabularyActivity({
+      words: [
+        { pronunciation, translation: `hello-${uniqueId}`, word },
+        {
+          pronunciation: `pron-adios-${uniqueId}`,
+          translation: `goodbye-${uniqueId}`,
+          word: `adiós-${uniqueId}`,
+        },
+        {
+          pronunciation: `pron-gracias-${uniqueId}`,
+          translation: `thanks-${uniqueId}`,
+          word: `gracias-${uniqueId}`,
+        },
+        {
+          pronunciation: `pron-favor-${uniqueId}`,
+          translation: `please-${uniqueId}`,
+          word: `por favor-${uniqueId}`,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    const radiogroup = page.getByRole("radiogroup", { name: /answer options/i });
+
+    // Before selecting, pronunciation should not be visible
+    await expect(page.getByText(new RegExp(pronunciation))).not.toBeVisible();
+
+    const option = radiogroup.getByRole("radio", { name: new RegExp(word) });
+
+    await expect(async () => {
+      const isChecked = await option.getAttribute("aria-checked");
+
+      if (isChecked !== "true") {
+        await option.click();
+      }
+
+      await expect(option).toHaveAttribute("aria-checked", "true", { timeout: 1000 });
+    }).toPass();
+
+    // After selecting, pronunciation should be visible on the selected option
+    await expect(page.getByText(new RegExp(pronunciation))).toBeVisible();
+  });
+});

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1436,6 +1436,18 @@ msgctxt "OUZtdJ"
 msgid "Activity progress"
 msgstr "Activity progress"
 
+#: src/components/activity-player/result-announcement.tsx
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "6NoIUl"
+msgid "Correct"
+msgstr "Correct"
+
+#: src/components/activity-player/result-announcement.tsx
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "Ypr9T5"
+msgid "Incorrect"
+msgstr "Incorrect"
+
 #: src/components/activity-player/select-image-step.tsx
 msgctxt "NA6C/+"
 msgid "Image options"
@@ -1452,12 +1464,6 @@ msgid "{item}. Tap to select as position {nextPosition}."
 msgstr "{item}. Tap to select as position {nextPosition}."
 
 #: src/components/activity-player/sort-order-step.tsx
-#: src/components/activity-player/vocabulary-step.tsx
-msgctxt "6NoIUl"
-msgid "Correct"
-msgstr "Correct"
-
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "hFFOe+"
 msgid "{item}. {result}."
 msgstr "{item}. {result}."
@@ -1471,12 +1477,6 @@ msgstr "Sort items"
 msgctxt "vPyO9S"
 msgid "Position {position}: {item}. Tap to remove."
 msgstr "Position {position}: {item}. Tap to remove."
-
-#: src/components/activity-player/sort-order-step.tsx
-#: src/components/activity-player/vocabulary-step.tsx
-msgctxt "Ypr9T5"
-msgid "Incorrect"
-msgstr "Incorrect"
 
 #: src/components/activity-player/step-renderer.tsx
 msgctxt "4pTU5S"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1396,6 +1396,7 @@ msgid "All pairs matched. Press Check to continue."
 msgstr "All pairs matched. Press Check to continue."
 
 #: src/components/activity-player/multiple-choice-step.tsx
+#: src/components/activity-player/vocabulary-step.tsx
 msgctxt "akd+cv"
 msgid "Answer options"
 msgstr "Answer options"
@@ -1451,6 +1452,7 @@ msgid "{item}. Tap to select as position {nextPosition}."
 msgstr "{item}. Tap to select as position {nextPosition}."
 
 #: src/components/activity-player/sort-order-step.tsx
+#: src/components/activity-player/vocabulary-step.tsx
 msgctxt "6NoIUl"
 msgid "Correct"
 msgstr "Correct"
@@ -1471,6 +1473,7 @@ msgid "Position {position}: {item}. Tap to remove."
 msgstr "Position {position}: {item}. Tap to remove."
 
 #: src/components/activity-player/sort-order-step.tsx
+#: src/components/activity-player/vocabulary-step.tsx
 msgctxt "Ypr9T5"
 msgid "Incorrect"
 msgstr "Incorrect"
@@ -1489,6 +1492,11 @@ msgstr "Select answer"
 msgctxt "zWkvNO"
 msgid "Timeline"
 msgstr "Timeline"
+
+#: src/components/activity-player/vocabulary-step.tsx
+msgctxt "MxLxkr"
+msgid "Translate this word:"
+msgstr "Translate this word:"
 
 #: src/components/catalog/activity-completion-indicator.tsx
 msgctxt "4o5CAP"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1436,6 +1436,18 @@ msgctxt "OUZtdJ"
 msgid "Activity progress"
 msgstr "Progreso de actividad"
 
+#: src/components/activity-player/result-announcement.tsx
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "6NoIUl"
+msgid "Correct"
+msgstr "Correcto"
+
+#: src/components/activity-player/result-announcement.tsx
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "Ypr9T5"
+msgid "Incorrect"
+msgstr "Incorrecto"
+
 #: src/components/activity-player/select-image-step.tsx
 msgctxt "NA6C/+"
 msgid "Image options"
@@ -1452,12 +1464,6 @@ msgid "{item}. Tap to select as position {nextPosition}."
 msgstr "{item}. Toca para seleccionar como posición {nextPosition}."
 
 #: src/components/activity-player/sort-order-step.tsx
-#: src/components/activity-player/vocabulary-step.tsx
-msgctxt "6NoIUl"
-msgid "Correct"
-msgstr "Correcto"
-
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "hFFOe+"
 msgid "{item}. {result}."
 msgstr "{item}. {result}."
@@ -1471,12 +1477,6 @@ msgstr "Ordenar elementos"
 msgctxt "vPyO9S"
 msgid "Position {position}: {item}. Tap to remove."
 msgstr "Posición {position}: {item}. Toca para quitar."
-
-#: src/components/activity-player/sort-order-step.tsx
-#: src/components/activity-player/vocabulary-step.tsx
-msgctxt "Ypr9T5"
-msgid "Incorrect"
-msgstr "Incorrecto"
 
 #: src/components/activity-player/step-renderer.tsx
 msgctxt "4pTU5S"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1396,6 +1396,7 @@ msgid "All pairs matched. Press Check to continue."
 msgstr "Todos los pares coinciden. Presiona Verificar para continuar."
 
 #: src/components/activity-player/multiple-choice-step.tsx
+#: src/components/activity-player/vocabulary-step.tsx
 msgctxt "akd+cv"
 msgid "Answer options"
 msgstr "Opciones de respuesta"
@@ -1451,6 +1452,7 @@ msgid "{item}. Tap to select as position {nextPosition}."
 msgstr "{item}. Toca para seleccionar como posición {nextPosition}."
 
 #: src/components/activity-player/sort-order-step.tsx
+#: src/components/activity-player/vocabulary-step.tsx
 msgctxt "6NoIUl"
 msgid "Correct"
 msgstr "Correcto"
@@ -1471,6 +1473,7 @@ msgid "Position {position}: {item}. Tap to remove."
 msgstr "Posición {position}: {item}. Toca para quitar."
 
 #: src/components/activity-player/sort-order-step.tsx
+#: src/components/activity-player/vocabulary-step.tsx
 msgctxt "Ypr9T5"
 msgid "Incorrect"
 msgstr "Incorrecto"
@@ -1489,6 +1492,11 @@ msgstr "Seleccionar respuesta"
 msgctxt "zWkvNO"
 msgid "Timeline"
 msgstr "Línea de tiempo"
+
+#: src/components/activity-player/vocabulary-step.tsx
+msgctxt "MxLxkr"
+msgid "Translate this word:"
+msgstr "Traduce esta palabra:"
 
 #: src/components/catalog/activity-completion-indicator.tsx
 msgctxt "4o5CAP"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1436,6 +1436,18 @@ msgctxt "OUZtdJ"
 msgid "Activity progress"
 msgstr "Progresso da atividade"
 
+#: src/components/activity-player/result-announcement.tsx
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "6NoIUl"
+msgid "Correct"
+msgstr "Correto"
+
+#: src/components/activity-player/result-announcement.tsx
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "Ypr9T5"
+msgid "Incorrect"
+msgstr "Incorreto"
+
 #: src/components/activity-player/select-image-step.tsx
 msgctxt "NA6C/+"
 msgid "Image options"
@@ -1452,12 +1464,6 @@ msgid "{item}. Tap to select as position {nextPosition}."
 msgstr "{item}. Toque para selecionar como posição {nextPosition}."
 
 #: src/components/activity-player/sort-order-step.tsx
-#: src/components/activity-player/vocabulary-step.tsx
-msgctxt "6NoIUl"
-msgid "Correct"
-msgstr "Correto"
-
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "hFFOe+"
 msgid "{item}. {result}."
 msgstr "{item}. {result}."
@@ -1471,12 +1477,6 @@ msgstr "Ordenar itens"
 msgctxt "vPyO9S"
 msgid "Position {position}: {item}. Tap to remove."
 msgstr "Posição {position}: {item}. Toque para remover."
-
-#: src/components/activity-player/sort-order-step.tsx
-#: src/components/activity-player/vocabulary-step.tsx
-msgctxt "Ypr9T5"
-msgid "Incorrect"
-msgstr "Incorreto"
 
 #: src/components/activity-player/step-renderer.tsx
 msgctxt "4pTU5S"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1396,6 +1396,7 @@ msgid "All pairs matched. Press Check to continue."
 msgstr "Todos os pares combinados. Pressione Verificar para continuar."
 
 #: src/components/activity-player/multiple-choice-step.tsx
+#: src/components/activity-player/vocabulary-step.tsx
 msgctxt "akd+cv"
 msgid "Answer options"
 msgstr "Opções de resposta"
@@ -1451,6 +1452,7 @@ msgid "{item}. Tap to select as position {nextPosition}."
 msgstr "{item}. Toque para selecionar como posição {nextPosition}."
 
 #: src/components/activity-player/sort-order-step.tsx
+#: src/components/activity-player/vocabulary-step.tsx
 msgctxt "6NoIUl"
 msgid "Correct"
 msgstr "Correto"
@@ -1471,6 +1473,7 @@ msgid "Position {position}: {item}. Tap to remove."
 msgstr "Posição {position}: {item}. Toque para remover."
 
 #: src/components/activity-player/sort-order-step.tsx
+#: src/components/activity-player/vocabulary-step.tsx
 msgctxt "Ypr9T5"
 msgid "Incorrect"
 msgstr "Incorreto"
@@ -1489,6 +1492,11 @@ msgstr "Selecionar resposta"
 msgctxt "zWkvNO"
 msgid "Timeline"
 msgstr "Linha do tempo"
+
+#: src/components/activity-player/vocabulary-step.tsx
+msgctxt "MxLxkr"
+msgid "Translate this word:"
+msgstr "Traduza esta palavra:"
 
 #: src/components/catalog/activity-completion-indicator.tsx
 msgctxt "4o5CAP"

--- a/apps/main/src/components/activity-player/check-step.test.ts
+++ b/apps/main/src/components/activity-player/check-step.test.ts
@@ -12,6 +12,7 @@ function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
     sentence: null,
     visualContent: null,
     visualKind: null,
+    vocabularyOptions: [],
     word: null,
     ...overrides,
   };

--- a/apps/main/src/components/activity-player/dimension-inventory.tsx
+++ b/apps/main/src/components/activity-player/dimension-inventory.tsx
@@ -162,9 +162,7 @@ function DimensionRow({
           {entry.total}
         </span>
 
-        {variant === "feedback" ? (
-          <DeltaPill delta={entry.delta} hidden={entry.delta === 0} />
-        ) : null}
+        {variant === "feedback" && <DeltaPill delta={entry.delta} hidden={entry.delta === 0} />}
       </span>
     </li>
   );

--- a/apps/main/src/components/activity-player/fill-blank-step.test.tsx
+++ b/apps/main/src/components/activity-player/fill-blank-step.test.tsx
@@ -31,6 +31,7 @@ function buildFillBlankStep(overrides: Record<string, unknown> = {}) {
     sentence: null,
     visualContent: null,
     visualKind: null,
+    vocabularyOptions: [],
     word: null,
     ...overrides,
   };

--- a/apps/main/src/components/activity-player/fill-blank-step.tsx
+++ b/apps/main/src/components/activity-player/fill-blank-step.tsx
@@ -65,13 +65,13 @@ function TemplateText({
         <span key={`seg-${segment}-${index}`}>
           {segment}
 
-          {index < segments.length - 1 ? (
+          {index < segments.length - 1 && (
             <BlankSlot
               index={index}
               onRemove={() => onRemoveWord(index)}
               word={blanks[index] ?? null}
             />
-          ) : null}
+          )}
         </span>
       ))}
     </p>
@@ -202,7 +202,7 @@ export function FillBlankStep({
 
   return (
     <InteractiveStepLayout>
-      {content.question ? <QuestionText>{replaceName(content.question)}</QuestionText> : null}
+      {content.question && <QuestionText>{replaceName(content.question)}</QuestionText>}
 
       <TemplateText blanks={blanks} onRemoveWord={handleRemoveWord} template={content.template} />
 

--- a/apps/main/src/components/activity-player/match-columns-step.tsx
+++ b/apps/main/src/components/activity-player/match-columns-step.tsx
@@ -78,7 +78,7 @@ function MatchItem({
       aria-label={label}
       aria-pressed={state === "selected"}
       className={cn(
-        "border-border flex min-h-11 items-center gap-2 rounded-lg border px-2.5 py-2.5 text-left text-sm break-words transition-all duration-150 sm:px-4 sm:py-3.5 sm:text-base",
+        "border-border flex min-h-11 items-center gap-2 rounded-lg border px-2.5 py-2.5 text-left text-sm wrap-break-word transition-all duration-150 sm:px-4 sm:py-3.5 sm:text-base",
         getItemClassName(state),
       )}
       disabled={isLocked}

--- a/apps/main/src/components/activity-player/match-columns-step.tsx
+++ b/apps/main/src/components/activity-player/match-columns-step.tsx
@@ -85,9 +85,9 @@ function MatchItem({
       onClick={onTap}
       type="button"
     >
-      {state === "correct" ? (
+      {state === "correct" && (
         <CircleCheck aria-hidden="true" className="text-success size-3.5 shrink-0" />
-      ) : null}
+      )}
 
       <span>{label}</span>
     </button>
@@ -237,7 +237,7 @@ export function MatchColumnsStep({
 
   return (
     <InteractiveStepLayout>
-      {content.question ? <QuestionText>{replaceName(content.question)}</QuestionText> : null}
+      {content.question && <QuestionText>{replaceName(content.question)}</QuestionText>}
 
       <MatchGrid
         correctPairs={correctPairs}
@@ -250,7 +250,7 @@ export function MatchColumnsStep({
       />
 
       <div aria-live="polite" className="sr-only" role="status">
-        {allMatched ? t("All pairs matched. Press Check to continue.") : null}
+        {allMatched && t("All pairs matched. Press Check to continue.")}
       </div>
     </InteractiveStepLayout>
   );

--- a/apps/main/src/components/activity-player/multiple-choice-step.tsx
+++ b/apps/main/src/components/activity-player/multiple-choice-step.tsx
@@ -7,11 +7,12 @@ import {
   type LanguageMultipleChoiceContent,
   parseStepContent,
 } from "@zoonk/core/steps/content-contract";
-import { Kbd } from "@zoonk/ui/components/kbd";
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { type SelectedAnswer } from "./player-reducer";
 import { ContextText, QuestionText } from "./question-text";
+import { ResultKbd } from "./result-kbd";
+import { SectionLabel } from "./section-label";
 import { InteractiveStepLayout } from "./step-layouts";
 import { useOptionKeyboard } from "./use-option-keyboard";
 import { useReplaceName } from "./user-name-context";
@@ -52,9 +53,7 @@ function OptionCard({
       role="radio"
       type="button"
     >
-      <Kbd aria-hidden="true" className={cn(isSelected && "bg-primary text-primary-foreground")}>
-        {index + 1}
-      </Kbd>
+      <ResultKbd isSelected={isSelected}>{index + 1}</ResultKbd>
 
       <div className="flex flex-col">
         <span className="text-base leading-6">{text}</span>
@@ -137,12 +136,6 @@ function ChallengeVariant({
 
       <OptionList onSelect={onSelect} options={content.options} selectedIndex={selectedIndex} />
     </>
-  );
-}
-
-function SectionLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">{children}</p>
   );
 }
 

--- a/apps/main/src/components/activity-player/multiple-choice-step.tsx
+++ b/apps/main/src/components/activity-player/multiple-choice-step.tsx
@@ -59,9 +59,9 @@ function OptionCard({
       <div className="flex flex-col">
         <span className="text-base leading-6">{text}</span>
 
-        {romanization ? (
+        {romanization && (
           <span className="text-muted-foreground text-sm italic">{romanization}</span>
-        ) : null}
+        )}
       </div>
     </button>
   );
@@ -108,8 +108,8 @@ function CoreVariant({
   return (
     <>
       <StepTextGroup>
-        {content.context ? <ContextText>{replaceName(content.context)}</ContextText> : null}
-        {content.question ? <QuestionText>{replaceName(content.question)}</QuestionText> : null}
+        {content.context && <ContextText>{replaceName(content.context)}</ContextText>}
+        {content.question && <QuestionText>{replaceName(content.question)}</QuestionText>}
       </StepTextGroup>
 
       <OptionList onSelect={onSelect} options={content.options} selectedIndex={selectedIndex} />
@@ -170,9 +170,9 @@ function LanguageVariant({
         <SpeechBubble>
           <p className="text-base font-semibold">{replaceName(content.context)}</p>
 
-          {content.contextRomanization ? (
+          {content.contextRomanization && (
             <p className="text-muted-foreground text-sm italic">{content.contextRomanization}</p>
-          ) : null}
+          )}
 
           <p className="text-muted-foreground text-sm">{replaceName(content.contextTranslation)}</p>
         </SpeechBubble>
@@ -210,17 +210,17 @@ export function MultipleChoiceStep({
 
   return (
     <InteractiveStepLayout>
-      {content.kind === "challenge" ? (
+      {content.kind === "challenge" && (
         <ChallengeVariant content={content} onSelect={handleSelect} selectedIndex={selectedIndex} />
-      ) : null}
+      )}
 
-      {content.kind === "core" ? (
+      {content.kind === "core" && (
         <CoreVariant content={content} onSelect={handleSelect} selectedIndex={selectedIndex} />
-      ) : null}
+      )}
 
-      {content.kind === "language" ? (
+      {content.kind === "language" && (
         <LanguageVariant content={content} onSelect={handleSelect} selectedIndex={selectedIndex} />
-      ) : null}
+      )}
     </InteractiveStepLayout>
   );
 }

--- a/apps/main/src/components/activity-player/player-reducer.test.ts
+++ b/apps/main/src/components/activity-player/player-reducer.test.ts
@@ -29,6 +29,7 @@ function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
     sentence: null,
     visualContent: null,
     visualKind: null,
+    vocabularyOptions: [],
     word: null,
     ...overrides,
   };

--- a/apps/main/src/components/activity-player/result-announcement.tsx
+++ b/apps/main/src/components/activity-player/result-announcement.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useExtracted } from "next-intl";
+
+export function ResultAnnouncement({ isCorrect }: { isCorrect: boolean }) {
+  const t = useExtracted();
+
+  return (
+    <div aria-live="polite" className="sr-only" role="status">
+      {isCorrect ? t("Correct") : t("Incorrect")}
+    </div>
+  );
+}

--- a/apps/main/src/components/activity-player/result-kbd.tsx
+++ b/apps/main/src/components/activity-player/result-kbd.tsx
@@ -1,0 +1,35 @@
+import { Kbd } from "@zoonk/ui/components/kbd";
+import { cn } from "@zoonk/ui/lib/utils";
+import { CheckIcon, XIcon } from "lucide-react";
+
+export function ResultKbd({
+  children,
+  isSelected,
+  resultState,
+}: {
+  children: React.ReactNode;
+  isSelected?: boolean;
+  resultState?: "correct" | "incorrect";
+}) {
+  if (resultState === "correct") {
+    return (
+      <Kbd aria-hidden="true" className="bg-success text-white">
+        <CheckIcon aria-hidden="true" className="size-3" />
+      </Kbd>
+    );
+  }
+
+  if (resultState === "incorrect") {
+    return (
+      <Kbd aria-hidden="true" className="bg-destructive text-white">
+        <XIcon aria-hidden="true" className="size-3" />
+      </Kbd>
+    );
+  }
+
+  return (
+    <Kbd aria-hidden="true" className={cn(isSelected && "bg-primary text-primary-foreground")}>
+      {children}
+    </Kbd>
+  );
+}

--- a/apps/main/src/components/activity-player/section-label.tsx
+++ b/apps/main/src/components/activity-player/section-label.tsx
@@ -1,0 +1,5 @@
+export function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">{children}</p>
+  );
+}

--- a/apps/main/src/components/activity-player/sort-order-step.tsx
+++ b/apps/main/src/components/activity-player/sort-order-step.tsx
@@ -2,14 +2,14 @@
 
 import { type SerializedStep } from "@/data/activities/prepare-activity-data";
 import { parseStepContent } from "@zoonk/core/steps/content-contract";
-import { Kbd } from "@zoonk/ui/components/kbd";
 import { cn } from "@zoonk/ui/lib/utils";
 import { shuffle } from "@zoonk/utils/shuffle";
-import { CheckIcon, XIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { useCallback, useMemo, useState } from "react";
 import { type SelectedAnswer, type StepResult } from "./player-reducer";
 import { QuestionText } from "./question-text";
+import { ResultAnnouncement } from "./result-announcement";
+import { ResultKbd } from "./result-kbd";
 import { InteractiveStepLayout } from "./step-layouts";
 import { useReplaceName } from "./user-name-context";
 
@@ -57,22 +57,6 @@ function ItemButton({
     });
   })();
 
-  const kbdContent = (() => {
-    if (resultState === "correct") {
-      return <CheckIcon aria-hidden="true" className="size-3" />;
-    }
-
-    if (resultState === "incorrect") {
-      return <XIcon aria-hidden="true" className="size-3" />;
-    }
-
-    if (isSelected) {
-      return String(position + 1);
-    }
-
-    return "\u00A0";
-  })();
-
   return (
     <button
       aria-label={ariaLabel}
@@ -90,15 +74,9 @@ function ItemButton({
       onClick={onClick}
       type="button"
     >
-      <Kbd
-        className={cn(
-          isSelected && !hasResult && "bg-primary text-primary-foreground",
-          resultState === "correct" && "bg-success text-white",
-          resultState === "incorrect" && "bg-destructive text-white",
-        )}
-      >
-        {kbdContent}
-      </Kbd>
+      <ResultKbd isSelected={isSelected} resultState={resultState}>
+        {isSelected ? String(position + 1) : "\u00A0"}
+      </ResultKbd>
 
       <span className="text-base">{item}</span>
     </button>
@@ -150,16 +128,13 @@ function InlineFeedback({
   content: { feedback: string | null };
   result: StepResult;
 }) {
-  const t = useExtracted();
   const replaceName = useReplaceName();
   const isCorrect = result.result.isCorrect;
   const feedback = content.feedback ? replaceName(content.feedback) : null;
 
   return (
     <div className="flex flex-col gap-3">
-      <div aria-live="polite" className="sr-only" role="status">
-        {isCorrect ? t("Correct") : t("Incorrect")}
-      </div>
+      <ResultAnnouncement isCorrect={isCorrect} />
 
       {feedback ? <p className="text-muted-foreground text-sm">{feedback}</p> : null}
     </div>

--- a/apps/main/src/components/activity-player/stage-content.tsx
+++ b/apps/main/src/components/activity-player/stage-content.tsx
@@ -65,19 +65,25 @@ export function StageContent({
   }
 
   if (phase === "feedback" && currentResult) {
-    const hasInlineFeedback = currentStep?.kind === "sortOrder";
+    const hasInlineFeedback =
+      currentStep?.kind === "sortOrder" || currentStep?.kind === "vocabulary";
 
     if (hasInlineFeedback && currentStep) {
       return (
-        <StepRenderer
-          isFirst={isFirst}
-          onNavigateNext={onNavigateNext}
-          onNavigatePrev={onNavigatePrev}
-          onSelectAnswer={onSelectAnswer}
-          result={currentResult}
-          selectedAnswer={selectedAnswer}
-          step={currentStep}
-        />
+        <div
+          className="animate-in fade-in flex w-full flex-1 flex-col items-center justify-center duration-150 ease-out motion-reduce:animate-none"
+          key={`step-${currentStepIndex}`}
+        >
+          <StepRenderer
+            isFirst={isFirst}
+            onNavigateNext={onNavigateNext}
+            onNavigatePrev={onNavigatePrev}
+            onSelectAnswer={onSelectAnswer}
+            result={currentResult}
+            selectedAnswer={selectedAnswer}
+            step={currentStep}
+          />
+        </div>
       );
     }
 

--- a/apps/main/src/components/activity-player/step-renderer.test.ts
+++ b/apps/main/src/components/activity-player/step-renderer.test.ts
@@ -11,6 +11,7 @@ function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
     sentence: null,
     visualContent: null,
     visualKind: null,
+    vocabularyOptions: [],
     word: null,
     ...overrides,
   };

--- a/apps/main/src/components/activity-player/step-renderer.tsx
+++ b/apps/main/src/components/activity-player/step-renderer.tsx
@@ -13,6 +13,7 @@ import { StaticStep } from "./static-step";
 import { StaticTapZones, useSwipeNavigation } from "./static-step-navigation";
 import { InteractiveStepLayout, StaticStepLayout } from "./step-layouts";
 import { getMockAnswer, getStepSummary } from "./step-renderer-utils";
+import { VocabularyStep } from "./vocabulary-step";
 
 function PlaceholderInteractiveStep({
   onSelectAnswer,
@@ -121,6 +122,17 @@ export function StepRenderer({
   if (step.kind === "sortOrder") {
     return (
       <SortOrderStep
+        onSelectAnswer={onSelectAnswer}
+        result={result}
+        selectedAnswer={selectedAnswer}
+        step={step}
+      />
+    );
+  }
+
+  if (step.kind === "vocabulary") {
+    return (
+      <VocabularyStep
         onSelectAnswer={onSelectAnswer}
         result={result}
         selectedAnswer={selectedAnswer}

--- a/apps/main/src/components/activity-player/table-visual.tsx
+++ b/apps/main/src/components/activity-player/table-visual.tsx
@@ -43,11 +43,11 @@ export function TableVisual({ content }: { content: VisualContentByKind[Supporte
         </TableBody>
       </Table>
 
-      {parsed.caption ? (
+      {parsed.caption && (
         <figcaption className="text-muted-foreground mt-3 px-1 text-center text-sm">
           {parsed.caption}
         </figcaption>
-      ) : null}
+      )}
     </figure>
   );
 }

--- a/apps/main/src/components/activity-player/timeline-visual.tsx
+++ b/apps/main/src/components/activity-player/timeline-visual.tsx
@@ -25,9 +25,9 @@ function TimelineEvent({
         <time className="text-muted-foreground text-xs font-medium tracking-wide">{date}</time>
       </div>
 
-      {hasLine ? (
+      {hasLine && (
         <span aria-hidden="true" className="bg-border absolute top-4.5 bottom-0 left-0.75 w-px" />
-      ) : null}
+      )}
 
       <div className="pl-5">
         <p className="text-sm font-semibold">{title}</p>

--- a/apps/main/src/components/activity-player/use-player-state.test.ts
+++ b/apps/main/src/components/activity-player/use-player-state.test.ts
@@ -16,6 +16,7 @@ function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
     sentence: null,
     visualContent: null,
     visualKind: null,
+    vocabularyOptions: [],
     word: null,
     ...overrides,
   };

--- a/apps/main/src/components/activity-player/use-word-audio.ts
+++ b/apps/main/src/components/activity-player/use-word-audio.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+export function useWordAudio(): { play: (url: string | null) => void } {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const play = useCallback((url: string | null) => {
+    if (!url) {
+      return;
+    }
+
+    if (!audioRef.current) {
+      audioRef.current = new Audio();
+    }
+
+    const audio = audioRef.current;
+    audio.pause();
+    audio.src = url;
+    void audio.play();
+  }, []);
+
+  useEffect(
+    () => () => {
+      audioRef.current?.pause();
+    },
+    [],
+  );
+
+  return { play };
+}

--- a/apps/main/src/components/activity-player/vocabulary-step.tsx
+++ b/apps/main/src/components/activity-player/vocabulary-step.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { type SerializedStep, type SerializedWord } from "@/data/activities/prepare-activity-data";
-import { Kbd } from "@zoonk/ui/components/kbd";
 import { cn } from "@zoonk/ui/lib/utils";
-import { CheckIcon, Volume2Icon, XIcon } from "lucide-react";
+import { Volume2Icon } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { type SelectedAnswer, type StepResult } from "./player-reducer";
+import { ResultAnnouncement } from "./result-announcement";
+import { ResultKbd } from "./result-kbd";
+import { SectionLabel } from "./section-label";
 import { InteractiveStepLayout } from "./step-layouts";
 import { useOptionKeyboard } from "./use-option-keyboard";
 import { useWordAudio } from "./use-word-audio";
@@ -32,44 +34,6 @@ function getOptionResultState(
   }
 
   return undefined;
-}
-
-function SectionLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">{children}</p>
-  );
-}
-
-function OptionKbd({
-  index,
-  isSelected,
-  resultState,
-}: {
-  index: number;
-  isSelected: boolean;
-  resultState?: "correct" | "incorrect";
-}) {
-  if (resultState === "correct") {
-    return (
-      <Kbd aria-hidden="true" className="bg-success text-white">
-        <CheckIcon aria-hidden="true" className="size-3" />
-      </Kbd>
-    );
-  }
-
-  if (resultState === "incorrect") {
-    return (
-      <Kbd aria-hidden="true" className="bg-destructive text-white">
-        <XIcon aria-hidden="true" className="size-3" />
-      </Kbd>
-    );
-  }
-
-  return (
-    <Kbd aria-hidden="true" className={cn(isSelected && "bg-primary text-primary-foreground")}>
-      {index + 1}
-    </Kbd>
-  );
 }
 
 function OptionCard({
@@ -103,7 +67,9 @@ function OptionCard({
       role="radio"
       type="button"
     >
-      <OptionKbd index={index} isSelected={isSelected} resultState={resultState} />
+      <ResultKbd isSelected={isSelected} resultState={resultState}>
+        {index + 1}
+      </ResultKbd>
 
       <div className="flex flex-col">
         <span className="text-base leading-6">{word.word}</span>
@@ -189,11 +155,7 @@ export function VocabularyStep({
         ))}
       </div>
 
-      {result && (
-        <div aria-live="polite" className="sr-only" role="status">
-          {result.result.isCorrect ? t("Correct") : t("Incorrect")}
-        </div>
-      )}
+      {result && <ResultAnnouncement isCorrect={result.result.isCorrect} />}
     </InteractiveStepLayout>
   );
 }

--- a/apps/main/src/components/activity-player/vocabulary-step.tsx
+++ b/apps/main/src/components/activity-player/vocabulary-step.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { type SerializedStep, type SerializedWord } from "@/data/activities/prepare-activity-data";
+import { Kbd } from "@zoonk/ui/components/kbd";
+import { cn } from "@zoonk/ui/lib/utils";
+import { CheckIcon, Volume2Icon, XIcon } from "lucide-react";
+import { useExtracted } from "next-intl";
+import { type SelectedAnswer, type StepResult } from "./player-reducer";
+import { InteractiveStepLayout } from "./step-layouts";
+import { useOptionKeyboard } from "./use-option-keyboard";
+import { useWordAudio } from "./use-word-audio";
+
+function getSelectedWordId(selectedAnswer: SelectedAnswer | undefined): string | null {
+  if (selectedAnswer?.kind !== "vocabulary") {
+    return null;
+  }
+
+  return selectedAnswer.selectedWordId;
+}
+
+function getOptionResultState(
+  wordId: string,
+  correctWordId: string,
+  selectedWordId: string,
+): "correct" | "incorrect" | undefined {
+  if (wordId === correctWordId) {
+    return "correct";
+  }
+
+  if (wordId === selectedWordId) {
+    return "incorrect";
+  }
+
+  return undefined;
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">{children}</p>
+  );
+}
+
+function OptionKbd({
+  index,
+  isSelected,
+  resultState,
+}: {
+  index: number;
+  isSelected: boolean;
+  resultState?: "correct" | "incorrect";
+}) {
+  if (resultState === "correct") {
+    return (
+      <Kbd aria-hidden="true" className="bg-success text-white">
+        <CheckIcon aria-hidden="true" className="size-3" />
+      </Kbd>
+    );
+  }
+
+  if (resultState === "incorrect") {
+    return (
+      <Kbd aria-hidden="true" className="bg-destructive text-white">
+        <XIcon aria-hidden="true" className="size-3" />
+      </Kbd>
+    );
+  }
+
+  return (
+    <Kbd aria-hidden="true" className={cn(isSelected && "bg-primary text-primary-foreground")}>
+      {index + 1}
+    </Kbd>
+  );
+}
+
+function OptionCard({
+  index,
+  isSelected,
+  onSelect,
+  resultState,
+  word,
+}: {
+  index: number;
+  isSelected: boolean;
+  onSelect: () => void;
+  resultState?: "correct" | "incorrect";
+  word: SerializedWord;
+}) {
+  const hasResult = resultState !== undefined;
+
+  return (
+    <button
+      aria-checked={isSelected}
+      className={cn(
+        "focus-visible:border-ring focus-visible:ring-ring/50 flex w-full items-center gap-3 rounded-xl border px-4 py-3.5 text-left transition-colors duration-150 outline-none focus-visible:ring-[3px]",
+        !hasResult && !isSelected && "border-border hover:bg-accent",
+        !hasResult && isSelected && "border-primary bg-primary/5",
+        hasResult && "pointer-events-none",
+        resultState === "correct" && "border-l-success border-l-2",
+        resultState === "incorrect" && "border-l-destructive border-l-2",
+      )}
+      disabled={hasResult}
+      onClick={onSelect}
+      role="radio"
+      type="button"
+    >
+      <OptionKbd index={index} isSelected={isSelected} resultState={resultState} />
+
+      <div className="flex flex-col">
+        <span className="text-base leading-6">{word.word}</span>
+
+        {word.romanization ? (
+          <span className="text-muted-foreground text-sm italic">{word.romanization}</span>
+        ) : null}
+
+        {isSelected && word.pronunciation ? (
+          <span className="text-muted-foreground flex items-center gap-1 text-sm">
+            <Volume2Icon aria-hidden="true" className="size-3.5" />
+            {word.pronunciation}
+          </span>
+        ) : null}
+      </div>
+    </button>
+  );
+}
+
+export function VocabularyStep({
+  onSelectAnswer,
+  result,
+  selectedAnswer,
+  step,
+}: {
+  onSelectAnswer: (stepId: string, answer: SelectedAnswer) => void;
+  result?: StepResult;
+  selectedAnswer: SelectedAnswer | undefined;
+  step: SerializedStep;
+}) {
+  const t = useExtracted();
+  const { play } = useWordAudio();
+  const correctWord = step.word;
+  const selectedWordId = getSelectedWordId(selectedAnswer);
+  const options = step.vocabularyOptions;
+
+  const handleSelect = (index: number) => {
+    if (result) {
+      return;
+    }
+
+    const word = options[index];
+
+    if (!word) {
+      return;
+    }
+
+    play(word.audioUrl);
+    onSelectAnswer(step.id, { kind: "vocabulary", selectedWordId: word.id });
+  };
+
+  useOptionKeyboard({
+    enabled: !result,
+    onSelect: handleSelect,
+    optionCount: options.length,
+  });
+
+  if (!correctWord) {
+    return null;
+  }
+
+  return (
+    <InteractiveStepLayout>
+      <div className="flex flex-col gap-2">
+        <SectionLabel>{t("Translate this word:")}</SectionLabel>
+        <p className="text-xl font-semibold">{correctWord.translation}</p>
+      </div>
+
+      <div aria-label={t("Answer options")} className="flex flex-col gap-3" role="radiogroup">
+        {options.map((word, index) => (
+          <OptionCard
+            index={index}
+            isSelected={selectedWordId === word.id}
+            key={word.id}
+            onSelect={() => handleSelect(index)}
+            resultState={
+              result && selectedWordId
+                ? getOptionResultState(word.id, correctWord.id, selectedWordId)
+                : undefined
+            }
+            word={word}
+          />
+        ))}
+      </div>
+
+      {result ? (
+        <div aria-live="polite" className="sr-only" role="status">
+          {result.result.isCorrect ? t("Correct") : t("Incorrect")}
+        </div>
+      ) : null}
+    </InteractiveStepLayout>
+  );
+}

--- a/apps/main/src/components/activity-player/vocabulary-step.tsx
+++ b/apps/main/src/components/activity-player/vocabulary-step.tsx
@@ -108,16 +108,16 @@ function OptionCard({
       <div className="flex flex-col">
         <span className="text-base leading-6">{word.word}</span>
 
-        {word.romanization ? (
+        {word.romanization && (
           <span className="text-muted-foreground text-sm italic">{word.romanization}</span>
-        ) : null}
+        )}
 
-        {isSelected && word.pronunciation ? (
+        {isSelected && word.pronunciation && (
           <span className="text-muted-foreground flex items-center gap-1 text-sm">
             <Volume2Icon aria-hidden="true" className="size-3.5" />
             {word.pronunciation}
           </span>
-        ) : null}
+        )}
       </div>
     </button>
   );
@@ -189,11 +189,11 @@ export function VocabularyStep({
         ))}
       </div>
 
-      {result ? (
+      {result && (
         <div aria-live="polite" className="sr-only" role="status">
           {result.result.isCorrect ? t("Correct") : t("Incorrect")}
         </div>
-      ) : null}
+      )}
     </InteractiveStepLayout>
   );
 }

--- a/apps/main/src/components/activity-player/vocabulary-step.tsx
+++ b/apps/main/src/components/activity-player/vocabulary-step.tsx
@@ -37,32 +37,32 @@ function getOptionResultState(
 }
 
 function OptionCard({
+  disabled,
   index,
   isSelected,
   onSelect,
   resultState,
   word,
 }: {
+  disabled: boolean;
   index: number;
   isSelected: boolean;
   onSelect: () => void;
   resultState?: "correct" | "incorrect";
   word: SerializedWord;
 }) {
-  const hasResult = resultState !== undefined;
-
   return (
     <button
       aria-checked={isSelected}
       className={cn(
         "focus-visible:border-ring focus-visible:ring-ring/50 flex w-full items-center gap-3 rounded-xl border px-4 py-3.5 text-left transition-colors duration-150 outline-none focus-visible:ring-[3px]",
-        !hasResult && !isSelected && "border-border hover:bg-accent",
-        !hasResult && isSelected && "border-primary bg-primary/5",
-        hasResult && "pointer-events-none",
+        !disabled && !isSelected && "border-border hover:bg-accent",
+        !disabled && isSelected && "border-primary bg-primary/5",
+        disabled && "pointer-events-none",
         resultState === "correct" && "border-l-success border-l-2",
         resultState === "incorrect" && "border-l-destructive border-l-2",
       )}
-      disabled={hasResult}
+      disabled={disabled}
       onClick={onSelect}
       role="radio"
       type="button"
@@ -141,6 +141,7 @@ export function VocabularyStep({
       <div aria-label={t("Answer options")} className="flex flex-col gap-3" role="radiogroup">
         {options.map((word, index) => (
           <OptionCard
+            disabled={Boolean(result)}
             index={index}
             isSelected={selectedWordId === word.id}
             key={word.id}

--- a/apps/main/src/data/activities/prepare-activity-data.ts
+++ b/apps/main/src/data/activities/prepare-activity-data.ts
@@ -65,7 +65,7 @@ function serializeWord(
   word: NonNullable<ActivityWithSteps["steps"][number]["word"]>,
 ): SerializedWord {
   return {
-    alternativeTranslations: word.alternativeTranslations,
+    alternativeTranslations: [...word.alternativeTranslations],
     audioUrl: word.audioUrl,
     id: String(word.id),
     pronunciation: word.pronunciation,
@@ -137,7 +137,10 @@ function buildVocabularyOptions(
     serializedLessonWords,
     VOCABULARY_DISTRACTOR_COUNT,
   );
-  return shuffle([step.word, ...distractors]);
+  return shuffle([step.word, ...distractors]).map((word) => ({
+    ...word,
+    alternativeTranslations: [...word.alternativeTranslations],
+  }));
 }
 
 function serializeStep(step: ActivityWithSteps["steps"][number]): SerializedStep | null {
@@ -175,7 +178,7 @@ export function prepareActivityData(
   lessonSentences: LessonSentenceData[],
 ): SerializedActivity {
   const serializedLessonWords = lessonWords.map((word) => ({
-    alternativeTranslations: word.alternativeTranslations,
+    alternativeTranslations: [...word.alternativeTranslations],
     audioUrl: word.audioUrl,
     id: String(word.id),
     pronunciation: word.pronunciation,

--- a/apps/main/src/data/activities/prepare-activity-data.ts
+++ b/apps/main/src/data/activities/prepare-activity-data.ts
@@ -1,3 +1,4 @@
+import { getDistractorWords } from "@zoonk/core/player/distractor-words";
 import {
   type MultipleChoiceStepContent,
   type StepContentByKind,
@@ -15,6 +16,8 @@ import { shuffle } from "@zoonk/utils/shuffle";
 import { type ActivityWithSteps } from "./get-activity";
 import { type LessonSentenceData } from "./get-lesson-sentences";
 import { type LessonWordData } from "./get-lesson-words";
+
+const VOCABULARY_DISTRACTOR_COUNT = 3;
 
 export type SerializedWord = {
   id: string;
@@ -43,6 +46,7 @@ export type SerializedStep<Kind extends SupportedStepKind = SupportedStepKind> =
   visualContent: VisualContentByKind[SupportedVisualKind] | null;
   word: SerializedWord | null;
   sentence: SerializedSentence | null;
+  vocabularyOptions: SerializedWord[];
 };
 
 export type SerializedActivity = {
@@ -120,6 +124,22 @@ function shuffleMultipleChoiceContent(
   }
 }
 
+function buildVocabularyOptions(
+  step: SerializedStep,
+  serializedLessonWords: SerializedWord[],
+): SerializedWord[] {
+  if (step.kind !== "vocabulary" || !step.word) {
+    return [];
+  }
+
+  const distractors = getDistractorWords(
+    step.word,
+    serializedLessonWords,
+    VOCABULARY_DISTRACTOR_COUNT,
+  );
+  return shuffle([step.word, ...distractors]);
+}
+
 function serializeStep(step: ActivityWithSteps["steps"][number]): SerializedStep | null {
   if (!isSupportedStepKind(step.kind)) {
     return null;
@@ -141,6 +161,7 @@ function serializeStep(step: ActivityWithSteps["steps"][number]): SerializedStep
       sentence: step.sentence ? serializeSentence(step.sentence) : null,
       visualContent: visual?.content ?? null,
       visualKind: visual?.kind ?? null,
+      vocabularyOptions: [],
       word: step.word ? serializeWord(step.word) : null,
     };
   } catch {
@@ -153,9 +174,23 @@ export function prepareActivityData(
   lessonWords: LessonWordData[],
   lessonSentences: LessonSentenceData[],
 ): SerializedActivity {
+  const serializedLessonWords = lessonWords.map((word) => ({
+    alternativeTranslations: word.alternativeTranslations,
+    audioUrl: word.audioUrl,
+    id: String(word.id),
+    pronunciation: word.pronunciation,
+    romanization: word.romanization,
+    translation: word.translation,
+    word: word.word,
+  }));
+
   const steps = activity.steps
     .map((step) => serializeStep(step))
-    .filter((step): step is SerializedStep => step !== null);
+    .filter((step): step is SerializedStep => step !== null)
+    .map((step) => ({
+      ...step,
+      vocabularyOptions: buildVocabularyOptions(step, serializedLessonWords),
+    }));
 
   return {
     description: activity.description,
@@ -169,15 +204,7 @@ export function prepareActivityData(
       sentence: sentence.sentence,
       translation: sentence.translation,
     })),
-    lessonWords: lessonWords.map((word) => ({
-      alternativeTranslations: word.alternativeTranslations,
-      audioUrl: word.audioUrl,
-      id: String(word.id),
-      pronunciation: word.pronunciation,
-      romanization: word.romanization,
-      translation: word.translation,
-      word: word.word,
-    })),
+    lessonWords: serializedLessonWords,
     organizationId: activity.organizationId,
     steps,
     title: activity.title,

--- a/i18n.lock
+++ b/i18n.lock
@@ -473,6 +473,7 @@ checksums:
     Answer%20selected/singular: 43c2c02a2f5ab63d04a3ba140a03b769
     Select%20answer/singular: 4951d9f093550e70ff5f399634b2b595
     Timeline/singular: 342b1e646f0634e47112092db1a24f49
+    Translate%20this%20word%3A/singular: 05fede3c583e9ea39f27ac9fdf17fcc3
     Not%20completed/singular: d011b1ae92a1a8a2676a5d6999bbe6d4
     This%20content%20was%20generated%20by%20AI.%20It%20may%20contain%20errors%20or%20inaccuracies%20and%20should%20not%20be%20considered%20professional%20advice./singular: 269e7c16a722903b9b434f28aa6cf617
     Not%20helpful/singular: ceb8a457e7e4c62a465cd1dd2620990e


### PR DESCRIPTION
## Summary
- Implement vocabulary step UI: users see a word's translation and pick the correct target-language word from 4 shuffled options
- Compute vocabulary options server-side in `prepareActivityData` to avoid hydration mismatches from client-side `Math.random()`
- Add inline feedback with correct/incorrect indicators, keyboard selection (1-4), audio playback, romanization, and pronunciation display
- Add 8 e2e tests covering rendering, selection, feedback, keyboard, full flow, romanization, pronunciation, and feedback option stability

## Test plan
- [x] 8 new e2e tests in `vocabulary-step.test.ts`
- [x] Updated unit test fixtures to include `vocabularyOptions` field
- [x] All 354 e2e tests passing
- [x] All 448 unit tests passing
- [x] Typecheck, lint, knip, build all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Vocabulary step to the activity player where learners translate a word and pick the correct target-language word from 4 server-generated options, with inline feedback, keyboard shortcuts, and audio. UI is unified with shared components and small styling/accessibility tweaks.

- New Features
  - Compute and shuffle options server-side in prepareActivityData using distractor words to avoid hydration mismatches.
  - Inline feedback with correct/incorrect indicators on option cards; disable all options in feedback mode.
  - Keyboard selection with 1–4 keys; play audio on selection; show romanization; show pronunciation only on the selected option.
  - Integrated into StepRenderer and StageContent; i18n for “Translate this word:”, “Answer options”, “Correct”, “Incorrect”.
  - 8 e2e tests covering rendering, selection, feedback, keyboard, full flow, romanization, pronunciation, and option stability.

- Refactors
  - Extracted shared components (SectionLabel, ResultKbd, ResultAnnouncement) and reused across vocabulary, multiple-choice, and sort-order steps.
  - Replaced ternary-null patterns with logical AND; applied wrap-break-word to fix text wrapping.
  - Copy alternativeTranslations arrays when serializing lesson words and vocabulary options to avoid shared references.

<sup>Written for commit 05f972678b85386d6d07e13eaff90cbfedbee7c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

