### PR TITLE
feat(data): add personalized learning schema and nullable org support

### DIFF
--- a/apps/admin/src/app/(private)/courses/course-row.tsx
+++ b/apps/admin/src/app/(private)/courses/course-row.tsx
@@ -3,18 +3,28 @@ import { TableCell, TableRow } from "@zoonk/ui/components/table";
 
 const EDITOR_URL = process.env.NEXT_PUBLIC_EDITOR_APP_URL;
 
-function getCourseUrl(course: Course & { organization: Organization }) {
+function getCourseUrl(course: Course & { organization: Organization | null }) {
+  if (!course.organization) {
+    return null;
+  }
+
   return `${EDITOR_URL}/${course.organization.slug}/c/${course.language}/${course.slug}`;
 }
 
-export function CourseRow({ course }: { course: Course & { organization: Organization } }) {
+export function CourseRow({ course }: { course: Course & { organization: Organization | null } }) {
+  const courseUrl = getCourseUrl(course);
+
   return (
     <TableRow>
       <TableCell className="font-medium">
-        {/* oxlint-disable-next-line next/no-html-link-for-pages -- cross-app link */}
-        <a href={getCourseUrl(course)}>{course.title}</a>
+        {courseUrl ? (
+          // oxlint-disable-next-line next/no-html-link-for-pages -- cross-app link
+          <a href={courseUrl}>{course.title}</a>
+        ) : (
+          course.title
+        )}
       </TableCell>
-      <TableCell>{course.organization.name}</TableCell>
+      <TableCell>{course.organization?.name ?? "—"}</TableCell>
       <TableCell className="uppercase">{course.language}</TableCell>
 
       <TableCell>

--- a/apps/api/src/data/progress/get-next-activity.ts
+++ b/apps/api/src/data/progress/get-next-activity.ts
@@ -28,7 +28,7 @@ function scopeWhere(scope: ActivityScope) {
 
 async function findFirstActivity(scope: ActivityScope): Promise<{
   activityPosition: number;
-  brandSlug: string;
+  brandSlug: string | null;
   chapterSlug: string;
   courseSlug: string;
   lessonSlug: string;
@@ -69,7 +69,7 @@ async function findFirstActivity(scope: ActivityScope): Promise<{
 
   return {
     activityPosition: activity.position,
-    brandSlug: activity.lesson.chapter.course.organization.slug,
+    brandSlug: activity.lesson.chapter.course.organization?.slug ?? null,
     chapterSlug: activity.lesson.chapter.slug,
     courseSlug: activity.lesson.chapter.course.slug,
     lessonSlug: activity.lesson.slug,
@@ -97,7 +97,7 @@ export async function getNextActivity(
   scope: ActivityScope,
 ): Promise<{
   activityPosition: number;
-  brandSlug: string;
+  brandSlug: string | null;
   chapterSlug: string;
   completed: boolean;
   courseSlug: string;

--- a/apps/api/src/workflows/activity-generation/steps/generate-custom-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-custom-images-step.ts
@@ -23,7 +23,7 @@ async function generateImagesForActivity(activity: LessonActivity): Promise<void
     return;
   }
 
-  const orgSlug = activity.lesson.chapter.course.organization.slug;
+  const orgSlug = activity.lesson.chapter.course.organization?.slug;
 
   const results = await Promise.allSettled(
     imageSteps.map((step) => {

--- a/apps/api/src/workflows/activity-generation/steps/generate-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-images-step.ts
@@ -13,7 +13,7 @@ type ImageStep = { id: bigint | number; visualContent: unknown; visualKind: stri
 
 async function generateAndSaveImages(
   imageSteps: ImageStep[],
-  orgSlug: string,
+  orgSlug?: string,
 ): Promise<{
   hadFailure: boolean;
   results: PromiseSettledResult<{ data: string | null; error: Error | null }>[];
@@ -110,7 +110,7 @@ export async function generateImagesStep(
 
   const { hadFailure, results } = await generateAndSaveImages(
     imageSteps,
-    activity.lesson.chapter.course.organization.slug,
+    activity.lesson.chapter.course.organization?.slug,
   );
 
   if (hadFailure) {

--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.ts
@@ -49,7 +49,7 @@ function toQuizQuestion(step: { content: unknown; kind: string }): QuizQuestionW
 
 async function generateOptionImages(
   options: SelectImageOption[],
-  orgSlug: string,
+  orgSlug?: string,
 ): Promise<{ hadFailure: boolean; updatedOptions: SelectImageOption[] }> {
   const results = await Promise.allSettled(
     options.map(({ prompt }) => generateStepImage({ orgSlug, prompt })),
@@ -97,7 +97,7 @@ export async function generateQuizImagesStep(
 
   await streamStatus({ status: "started", step: "generateQuizImages" });
 
-  const orgSlug = activity.lesson.chapter.course.organization.slug;
+  const orgSlug = activity.lesson.chapter.course.organization?.slug;
 
   const stepResults = await Promise.allSettled(
     dbSteps.map(async (step) => {

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.ts
@@ -9,7 +9,7 @@ import { type SavedSentence } from "./save-reading-sentences-step";
 async function generateAudioForSentence(
   sentence: string,
   language: string,
-  orgSlug: string,
+  orgSlug?: string,
 ): Promise<{ audioUrl: string; sentence: string } | null> {
   const { data, error } = await generateLanguageAudio({
     language,
@@ -48,7 +48,7 @@ export async function generateReadingAudioStep(
 
   const results = await Promise.all(
     savedSentences.map((savedSentence) =>
-      generateAudioForSentence(savedSentence.sentence, targetLanguage, course.organization.slug),
+      generateAudioForSentence(savedSentence.sentence, targetLanguage, course.organization?.slug),
     ),
   );
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-content-step.ts
@@ -17,10 +17,14 @@ import { setActivityAsRunningStep } from "./set-activity-as-running-step";
 export type ReadingSentence = ActivitySentencesSchema["sentences"][number];
 async function getFallbackLessonWords(params: {
   lessonId: number;
-  organizationId: number;
+  organizationId: number | null;
   targetLanguage: string;
   userLanguage: string;
 }): Promise<string[]> {
+  if (!params.organizationId) {
+    return [];
+  }
+
   const words = await prisma.lessonWord.findMany({
     orderBy: { id: "asc" },
     select: { word: { select: { word: true } } },
@@ -46,7 +50,7 @@ function hasValidSentences(sentences: ReadingSentence[]): boolean {
 async function resolveSourceWords(input: {
   currentRunWords: string[];
   lessonId: number;
-  organizationId: number;
+  organizationId: number | null;
   targetLanguage: string;
   userLanguage: string;
 }): Promise<{ error: Error; words: [] } | { error: null; words: string[] }> {
@@ -104,7 +108,7 @@ export async function generateReadingContentStep(
   const sourceWords = await resolveSourceWords({
     currentRunWords,
     lessonId: activity.lessonId,
-    organizationId: course.organization.id,
+    organizationId: course.organization?.id ?? null,
     targetLanguage,
     userLanguage,
   });

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
@@ -9,7 +9,7 @@ import { handleActivityFailureStep } from "./handle-failure-step";
 async function generateAudioForWord(
   word: string,
   language: string,
-  orgSlug: string,
+  orgSlug?: string,
 ): Promise<{ audioUrl: string; word: string } | null> {
   const { data, error } = await generateLanguageAudio({
     language,
@@ -46,7 +46,7 @@ export async function generateVocabularyAudioStep(
     return { audioUrls: {} };
   }
 
-  const orgSlug = course.organization.slug;
+  const orgSlug = course.organization?.slug;
 
   const results = await Promise.all(
     words.map((vocabWord) => generateAudioForWord(vocabWord.word, targetLanguage, orgSlug)),

--- a/apps/api/src/workflows/activity-generation/steps/save-reading-sentences-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-reading-sentences-step.ts
@@ -84,6 +84,11 @@ export async function saveReadingSentencesStep(
   await streamStatus({ status: "started", step: "saveSentences" });
 
   const course = activity.lesson.chapter.course;
+
+  if (!course.organization) {
+    return { savedSentences: [] };
+  }
+
   const targetLanguage = course.targetLanguage ?? "";
   const userLanguage = activity.language;
   const organizationId = course.organization.id;

--- a/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
@@ -81,6 +81,11 @@ export async function saveVocabularyWordsStep(
   await streamStatus({ status: "started", step: "saveVocabularyWords" });
 
   const course = activity.lesson.chapter.course;
+
+  if (!course.organization) {
+    return { savedWords: [] };
+  }
+
   const targetLanguage = course.targetLanguage ?? "";
   const userLanguage = activity.language;
   const organizationId = course.organization.id;

--- a/apps/editor/src/data/activities/list-lesson-activities.ts
+++ b/apps/editor/src/data/activities/list-lesson-activities.ts
@@ -8,9 +8,13 @@ import { cache } from "react";
 const cachedListLessonActivities = cache(
   async (
     lessonId: number,
-    orgId: number,
+    orgId: number | null,
     headers?: Headers,
   ): Promise<{ data: Activity[]; error: Error | null }> => {
+    if (!orgId) {
+      return { data: [], error: new AppError(ErrorCode.forbidden) };
+    }
+
     const { data, error } = await safeAsync(() =>
       Promise.all([
         hasCoursePermission({
@@ -42,7 +46,7 @@ const cachedListLessonActivities = cache(
 export function listLessonActivities(params: {
   headers?: Headers;
   lessonId: number;
-  orgId: number;
+  orgId: number | null;
 }): Promise<{ data: Activity[]; error: Error | null }> {
   return cachedListLessonActivities(params.lessonId, params.orgId, params.headers);
 }

--- a/apps/editor/src/data/lessons/create-lesson.ts
+++ b/apps/editor/src/data/lessons/create-lesson.ts
@@ -49,7 +49,7 @@ export async function createLesson(params: {
 
   const kind = getLessonKind({
     courseCategories: chapter.course.categories.map((cat) => cat.category),
-    orgSlug: chapter.organization.slug,
+    orgSlug: chapter.organization?.slug,
   });
 
   const { data: lesson, error } = await safeAsync(() =>

--- a/apps/editor/src/data/lessons/import-lessons.ts
+++ b/apps/editor/src/data/lessons/import-lessons.ts
@@ -96,7 +96,7 @@ export async function importLessons(params: {
 
   const kind = getLessonKind({
     courseCategories: chapter.course.categories.map((cat) => cat.category),
-    orgSlug: chapter.organization.slug,
+    orgSlug: chapter.organization?.slug,
   });
 
   const { data: result, error: importError } = await safeAsync(() =>

--- a/apps/editor/src/data/lessons/list-chapter-lessons.ts
+++ b/apps/editor/src/data/lessons/list-chapter-lessons.ts
@@ -8,9 +8,13 @@ import { cache } from "react";
 const cachedListChapterLessons = cache(
   async (
     chapterId: number,
-    orgId: number,
+    orgId: number | null,
     headers?: Headers,
   ): Promise<{ data: Lesson[]; error: Error | null }> => {
+    if (!orgId) {
+      return { data: [], error: new AppError(ErrorCode.forbidden) };
+    }
+
     const { data, error } = await safeAsync(() =>
       Promise.all([
         hasCoursePermission({
@@ -42,7 +46,7 @@ const cachedListChapterLessons = cache(
 export function listChapterLessons(params: {
   chapterId: number;
   headers?: Headers;
-  orgId: number;
+  orgId: number | null;
 }): Promise<{ data: Lesson[]; error: Error | null }> {
   return cachedListChapterLessons(params.chapterId, params.orgId, params.headers);
 }

--- a/apps/editor/src/lib/lesson-kind.test.ts
+++ b/apps/editor/src/lib/lesson-kind.test.ts
@@ -1,0 +1,23 @@
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { describe, expect, test } from "vitest";
+import { getLessonKind } from "./lesson-kind";
+
+describe(getLessonKind, () => {
+  test("returns custom when orgSlug is undefined", () => {
+    expect(getLessonKind({ courseCategories: [] })).toBe("custom");
+  });
+
+  test("returns custom when orgSlug is not AI org", () => {
+    expect(getLessonKind({ courseCategories: [], orgSlug: "some-org" })).toBe("custom");
+  });
+
+  test("returns language when AI org with languages category", () => {
+    expect(getLessonKind({ courseCategories: ["languages"], orgSlug: AI_ORG_SLUG })).toBe(
+      "language",
+    );
+  });
+
+  test("returns core when AI org without languages category", () => {
+    expect(getLessonKind({ courseCategories: ["science"], orgSlug: AI_ORG_SLUG })).toBe("core");
+  });
+});

--- a/apps/editor/src/lib/lesson-kind.ts
+++ b/apps/editor/src/lib/lesson-kind.ts
@@ -1,7 +1,10 @@
 import { type LessonKind } from "@zoonk/db";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 
-export function getLessonKind(params: { orgSlug: string; courseCategories: string[] }): LessonKind {
+export function getLessonKind(params: {
+  orgSlug?: string;
+  courseCategories: string[];
+}): LessonKind {
   if (params.orgSlug !== AI_ORG_SLUG) {
     return "custom";
   }

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -457,6 +457,16 @@ msgctxt "BDHWkf"
 msgid "No courses yet"
 msgstr "No courses yet"
 
+#: src/app/[locale]/(catalog)/p/[courseId]/page.tsx
+msgctxt "dtRj3N"
+msgid "Personalized courses are coming soon."
+msgstr "Personalized courses are coming soon."
+
+#: src/app/[locale]/(catalog)/p/[courseId]/page.tsx
+msgctxt "e61Jf3"
+msgid "Coming soon"
+msgstr "Coming soon"
+
 #: src/app/[locale]/(catalog)/page.tsx
 msgctxt "qsfeMJ"
 msgid "Zoonk: AI Learning Platform"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -457,6 +457,16 @@ msgctxt "BDHWkf"
 msgid "No courses yet"
 msgstr "Aún no hay cursos"
 
+#: src/app/[locale]/(catalog)/p/[courseId]/page.tsx
+msgctxt "dtRj3N"
+msgid "Personalized courses are coming soon."
+msgstr "Los cursos personalizados llegarán pronto."
+
+#: src/app/[locale]/(catalog)/p/[courseId]/page.tsx
+msgctxt "e61Jf3"
+msgid "Coming soon"
+msgstr "Próximamente"
+
 #: src/app/[locale]/(catalog)/page.tsx
 msgctxt "qsfeMJ"
 msgid "Zoonk: AI Learning Platform"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -457,6 +457,16 @@ msgctxt "BDHWkf"
 msgid "No courses yet"
 msgstr "Ainda não há cursos"
 
+#: src/app/[locale]/(catalog)/p/[courseId]/page.tsx
+msgctxt "dtRj3N"
+msgid "Personalized courses are coming soon."
+msgstr "Cursos personalizados em breve."
+
+#: src/app/[locale]/(catalog)/p/[courseId]/page.tsx
+msgctxt "e61Jf3"
+msgid "Coming soon"
+msgstr "Em breve"
+
 #: src/app/[locale]/(catalog)/page.tsx
 msgctxt "qsfeMJ"
 msgid "Zoonk: AI Learning Platform"

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-header.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-header.tsx
@@ -73,7 +73,7 @@ export async function CourseHeader({
         <MediaCardPopoverMeta>
           <MediaCardPopoverSource>
             <MediaCardPopoverSourceLink render={<span />}>
-              {course.organization.name}
+              {course.organization?.name}
             </MediaCardPopoverSourceLink>
           </MediaCardPopoverSource>
 

--- a/apps/main/src/app/[locale]/(catalog)/continue-learning-card.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/continue-learning-card.tsx
@@ -20,6 +20,26 @@ import { PlayCircleIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
 import Image from "next/image";
 
+function getCourseHrefs(item: ContinueLearningItem) {
+  const { activity, chapter, course, lesson } = item;
+
+  if (course.organization) {
+    const lessonHref = `/b/${course.organization.slug}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`;
+
+    return {
+      activityHref: `${lessonHref}/a/${activity.position}`,
+      courseHref: `/b/${course.organization.slug}/c/${course.slug}`,
+      lessonHref,
+    };
+  }
+
+  return {
+    activityHref: `/p/${course.id}`,
+    courseHref: `/p/${course.id}`,
+    lessonHref: `/p/${course.id}`,
+  };
+}
+
 export async function ContinueLearningCard({
   item,
   kindLabels,
@@ -30,15 +50,13 @@ export async function ContinueLearningCard({
   fullWidth?: boolean;
 }) {
   const t = await getExtracted();
-  const { activity, chapter, course, lesson } = item;
+  const { activity, course, lesson } = item;
 
   const defaultLabel = t("Activity");
   const activityLabel = activity.title ?? kindLabels.get(activity.kind) ?? defaultLabel;
   const nextLabel = t("Next: {activity}", { activity: activityLabel });
 
-  const lessonHref = `/b/${course.organization.slug}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`;
-  const activityHref = `${lessonHref}/a/${activity.position}`;
-  const courseHref = `/b/${course.organization.slug}/c/${course.slug}`;
+  const { activityHref, courseHref, lessonHref } = getCourseHrefs(item);
 
   return (
     <FeatureCard

--- a/apps/main/src/app/[locale]/(catalog)/courses/course-list-client.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/courses/course-list-client.tsx
@@ -72,7 +72,7 @@ export function CourseListClient({
               ) : undefined
             }
             key={course.id}
-            linkComponent={<ClientLink href={`/b/${course.organization.slug}/c/${course.slug}`} />}
+            linkComponent={<ClientLink href={`/b/${course.organization?.slug}/c/${course.slug}`} />}
           />
         ))}
       </CourseListGroup>

--- a/apps/main/src/app/[locale]/(catalog)/my/user-course-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/my/user-course-list.tsx
@@ -64,7 +64,7 @@ export async function UserCourseList() {
           }
           key={course.id}
           linkComponent={
-            <Link href={`/b/${course.organization.slug}/c/${course.slug}`} prefetch={false} />
+            <Link href={`/b/${course.organization?.slug}/c/${course.slug}`} prefetch={false} />
           }
         />
       ))}

--- a/apps/main/src/app/[locale]/(catalog)/p/[courseId]/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/p/[courseId]/page.tsx
@@ -1,0 +1,12 @@
+import { getExtracted } from "next-intl/server";
+
+export default async function PersonalCoursePage() {
+  const t = await getExtracted();
+
+  return (
+    <main className="container mx-auto flex flex-1 flex-col items-center justify-center gap-2 px-4 py-16">
+      <h1 className="text-2xl font-bold">{t("Coming soon")}</h1>
+      <p className="text-muted-foreground">{t("Personalized courses are coming soon.")}</p>
+    </main>
+  );
+}

--- a/apps/main/src/data/activities/get-activity.ts
+++ b/apps/main/src/data/activities/get-activity.ts
@@ -8,7 +8,7 @@ export type ActivityWithSteps = {
   title: string | null;
   description: string | null;
   language: string;
-  organizationId: number;
+  organizationId: number | null;
   position: number;
   generationStatus: GenerationStatus;
   generationRunId: string | null;

--- a/apps/main/src/data/activities/prepare-activity-data.ts
+++ b/apps/main/src/data/activities/prepare-activity-data.ts
@@ -57,7 +57,7 @@ export type SerializedActivity = {
   title: string | null;
   description: string | null;
   language: string;
-  organizationId: number;
+  organizationId: number | null;
   steps: SerializedStep[];
   lessonWords: SerializedWord[];
   lessonSentences: SerializedSentence[];

--- a/apps/main/src/data/courses/get-continue-learning.ts
+++ b/apps/main/src/data/courses/get-continue-learning.ts
@@ -33,7 +33,7 @@ export type ContinueLearningLesson = Pick<Lesson, "id" | "slug" | "title" | "des
 export type ContinueLearningChapter = Pick<Chapter, "id" | "slug">;
 
 export type ContinueLearningCourse = Pick<Course, "id" | "slug" | "title" | "imageUrl"> & {
-  organization: Pick<Organization, "slug">;
+  organization: Pick<Organization, "slug"> | null;
 };
 
 export type ContinueLearningItem = {
@@ -47,6 +47,9 @@ function toItem(
   row: GetContinueLearningQuery.Result,
   next: NextActivityInCourse,
 ): ContinueLearningItem {
+  // orgSlug is typed as string by Prisma's generated SQL, but LEFT JOIN can return null at runtime
+  const orgSlug = row.orgSlug as string | null;
+
   return {
     activity: {
       id: next.activityId,
@@ -61,7 +64,7 @@ function toItem(
     course: {
       id: row.courseId,
       imageUrl: row.courseImageUrl,
-      organization: { slug: row.orgSlug },
+      organization: orgSlug ? { slug: orgSlug } : null,
       slug: row.courseSlug,
       title: row.courseTitle,
     },

--- a/apps/main/src/data/courses/get-course.test.ts
+++ b/apps/main/src/data/courses/get-course.test.ts
@@ -57,8 +57,8 @@ describe(getCourse, () => {
     expect(result?.id).toBe(publishedCourse.id);
     expect(result?.title).toBe(publishedCourse.title);
     expect(result?.description).toBe(publishedCourse.description);
-    expect(result?.organization.name).toBe(brandOrg.name);
-    expect(result?.organization.slug).toBe(brandOrg.slug);
+    expect(result?.organization?.name).toBe(brandOrg.name);
+    expect(result?.organization?.slug).toBe(brandOrg.slug);
     expect(result?.categories).toHaveLength(2);
     expect(result?.categories.map((item) => item.category)).toContain("tech");
     expect(result?.categories.map((item) => item.category)).toContain("science");

--- a/apps/main/src/data/courses/get-course.ts
+++ b/apps/main/src/data/courses/get-course.ts
@@ -12,7 +12,7 @@ export type CourseWithDetails = {
     name: string;
     slug: string;
     logo: string | null;
-  };
+  } | null;
   categories: { category: string }[];
 };
 

--- a/apps/main/src/data/courses/list-courses.ts
+++ b/apps/main/src/data/courses/list-courses.ts
@@ -7,7 +7,7 @@ import { cache } from "react";
 export const LIST_COURSES_LIMIT = 20;
 
 export type CourseWithOrg = Course & {
-  organization: { slug: string };
+  organization: { slug: string } | null;
 };
 
 const cachedListCourses = cache(

--- a/apps/main/src/data/courses/list-user-courses.test.ts
+++ b/apps/main/src/data/courses/list-user-courses.test.ts
@@ -76,8 +76,8 @@ describe("authenticated users", () => {
 
     const returnedCourse = result.data?.find((item) => item.id === course.id);
     expect(returnedCourse?.organization).toBeDefined();
-    expect(returnedCourse?.organization.id).toBe(organization.id);
-    expect(returnedCourse?.organization.slug).toBe(organization.slug);
+    expect(returnedCourse?.organization?.id).toBe(organization.id);
+    expect(returnedCourse?.organization?.slug).toBe(organization.slug);
   });
 
   test("orders courses by startedAt descending (most recent first)", async () => {

--- a/apps/main/src/data/courses/list-user-courses.ts
+++ b/apps/main/src/data/courses/list-user-courses.ts
@@ -5,7 +5,7 @@ import { type Course, type Organization, prisma } from "@zoonk/db";
 import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 
-export type UserCourse = Course & { organization: Organization };
+export type UserCourse = Course & { organization: Organization | null };
 
 export const listUserCourses = cache(
   async (headers?: Headers): Promise<SafeReturn<UserCourse[]>> => {

--- a/i18n.lock
+++ b/i18n.lock
@@ -276,6 +276,8 @@ checksums:
     View%20all%20the%20courses%20you%20started%20on%20Zoonk.%20Continue%20where%20you%20left%20off%20and%20track%20your%20progress%20across%20interactive%20lessons%20and%20activities./singular: eee1ce9f3b0be49ddc9bb3ce21270796
     Start%20learning%20something%20new%20today./singular: 55903bfd6e1f8c3e95c73ec67427ed11
     No%20courses%20yet/singular: d5fcc38466fdc83a74eab5032a2f85b6
+    Personalized%20courses%20are%20coming%20soon./singular: ad21564f7620bc2a553e298a587daccf
+    Coming%20soon/singular: ee2b0671e00972773210c5be5a9ccb89
     Zoonk%3A%20AI%20Learning%20Platform/singular: 4a2d25490f4a5e5cd4543f48fcec968d
     Zoonk%20is%20an%20AI-powered%20learning%20platform%20where%20you%20can%20learn%20anything%20through%20interactive%20courses%2C%20lessons%2C%20and%20activities./singular: e836899ce8100db55d5fa54fe6375970
     Performance/singular: 28b6d3a3d4a53afa0617a180e318ff4d

--- a/packages/core/src/activities/find-last-completed.ts
+++ b/packages/core/src/activities/find-last-completed.ts
@@ -14,7 +14,7 @@ export type LastCompletedActivity = {
   lessonId: number;
   lessonPosition: number;
   lessonSlug: string;
-  orgSlug: string;
+  orgSlug: string | null;
 };
 
 function scopeFilter(scope: ActivityScope) {
@@ -109,6 +109,6 @@ export async function findLastCompleted(
     lessonId: lesson.id,
     lessonPosition: lesson.position,
     lessonSlug: lesson.slug,
-    orgSlug: chapter.course.organization.slug,
+    orgSlug: chapter.course.organization?.slug ?? null,
   };
 }

--- a/packages/core/src/audio/generate-language-audio.ts
+++ b/packages/core/src/audio/generate-language-audio.ts
@@ -7,7 +7,7 @@ import { uploadAudio } from "./upload-audio";
 
 export type GenerateLanguageAudioParams = {
   language?: string;
-  orgSlug: string;
+  orgSlug?: string;
   text: string;
   voice?: TTSVoice;
 };
@@ -29,7 +29,7 @@ export async function generateLanguageAudio({
   }
 
   const slug = toSlug(text);
-  const fileName = `audio/${orgSlug}/${slug}.opus`;
+  const fileName = `audio/${orgSlug ?? "default"}/${slug}.opus`;
 
   const { data: url, error: uploadError } = await uploadAudio({
     audio: audioResult.audio,

--- a/packages/core/src/courses/search-courses.test.ts
+++ b/packages/core/src/courses/search-courses.test.ts
@@ -331,4 +331,36 @@ describe(searchCourses, () => {
     // With offset clamped to 100 and only 1 result, we get empty array
     expect(result).toEqual([]);
   });
+
+  test("excludes courses without an organization", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const searchTerm = `noorg${uniqueId}`;
+
+    const [withOrg] = await Promise.all([
+      courseFixture({
+        isPublished: true,
+        language: "en",
+        normalizedTitle: searchTerm,
+        organizationId: brandOrg.id,
+        title: searchTerm,
+      }),
+      courseFixture({
+        isPublished: true,
+        language: "en",
+        normalizedTitle: `${searchTerm} personal`,
+        organizationId: null,
+        title: `${searchTerm} Personal`,
+      }),
+    ]);
+
+    const result = await searchCourses({
+      language: "en",
+      query: searchTerm,
+    });
+
+    const ids = result.map((course) => course.id);
+
+    expect(ids).toContain(withOrg.id);
+    expect(result.every((course) => course.organization !== null)).toBeTruthy();
+  });
 });

--- a/packages/core/src/courses/search-courses.ts
+++ b/packages/core/src/courses/search-courses.ts
@@ -50,5 +50,7 @@ export async function searchCourses(params: {
 
   const merged = mergeSearchResults(exactMatch, containsMatches);
 
-  return merged.slice(offset, offset + limit);
+  return merged
+    .filter((course): course is CourseWithOrganization => course.organization !== null)
+    .slice(offset, offset + limit);
 }

--- a/packages/core/src/orgs/org-permissions.ts
+++ b/packages/core/src/orgs/org-permissions.ts
@@ -10,7 +10,7 @@ async function getOrganizationId({
   orgId,
   orgSlug,
 }: {
-  orgId?: number;
+  orgId?: number | null;
   orgSlug?: string;
 }): Promise<number | null> {
   if (orgId) {
@@ -28,7 +28,7 @@ async function getOrganizationId({
 const cachedHasCoursePermission = cache(
   async (
     permission: CoursePermission,
-    orgId: number | undefined,
+    orgId: number | null | undefined,
     orgSlug: string | undefined,
     reqHeaders?: Headers,
   ): Promise<boolean> => {
@@ -59,7 +59,7 @@ const cachedHasCoursePermission = cache(
 export function hasCoursePermission(opts: {
   permission: CoursePermission;
   headers?: Headers;
-  orgId?: number;
+  orgId?: number | null;
   orgSlug?: string;
 }): Promise<boolean> {
   return cachedHasCoursePermission(opts.permission, opts.orgId, opts.orgSlug, opts.headers);

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -27,6 +27,7 @@ export type {
   Course,
   CourseAlternativeTitle,
   CourseCategory,
+  CourseMode,
   CourseSuggestion,
   CourseUser,
   DailyProgress,
@@ -46,6 +47,7 @@ export type {
   StepVisualKind,
   Subscription,
   User,
+  UserLearningProfile,
   UserProgress,
   Verification,
 } from "./generated/prisma/client";

--- a/packages/db/src/prisma/enums.prisma
+++ b/packages/db/src/prisma/enums.prisma
@@ -53,3 +53,10 @@ enum StepVisualKind {
   audio
   video
 }
+
+enum CourseMode {
+  full
+  quickLesson  @map("quick_lesson")
+  personalized
+  examPrep     @map("exam_prep")
+}

--- a/packages/db/src/prisma/migrations/20260218030833_personalized_learning_schema/migration.sql
+++ b/packages/db/src/prisma/migrations/20260218030833_personalized_learning_schema/migration.sql
@@ -1,0 +1,59 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[user_id,language,slug]` on the table `courses` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateEnum
+CREATE TYPE "CourseMode" AS ENUM ('full', 'quick_lesson', 'personalized', 'exam_prep');
+
+-- AlterTable
+ALTER TABLE "activities" ALTER COLUMN "organization_id" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "chapters" ADD COLUMN     "is_locked" BOOLEAN NOT NULL DEFAULT false,
+ALTER COLUMN "organization_id" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "courses" ADD COLUMN     "completed_at" TIMESTAMP(3),
+ADD COLUMN     "mode" "CourseMode" NOT NULL DEFAULT 'full',
+ADD COLUMN     "user_id" INTEGER,
+ALTER COLUMN "organization_id" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "lessons" ADD COLUMN     "is_locked" BOOLEAN NOT NULL DEFAULT false,
+ALTER COLUMN "organization_id" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "step_attempts" ALTER COLUMN "organization_id" DROP NOT NULL;
+
+-- CreateTable
+CREATE TABLE "user_learning_profiles" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "interests" JSONB,
+    "preferences" JSONB,
+    "instructions" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_learning_profiles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_learning_profiles_user_id_key" ON "user_learning_profiles"("user_id");
+
+-- CreateIndex
+CREATE INDEX "courses_user_id_idx" ON "courses"("user_id");
+
+-- CreateIndex
+CREATE INDEX "courses_user_id_mode_idx" ON "courses"("user_id", "mode");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "courses_user_id_language_slug_key" ON "courses"("user_id", "language", "slug");
+
+-- AddForeignKey
+ALTER TABLE "courses" ADD CONSTRAINT "courses_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_learning_profiles" ADD CONSTRAINT "user_learning_profiles_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/src/prisma/models/accounts.prisma
+++ b/packages/db/src/prisma/models/accounts.prisma
@@ -1,25 +1,27 @@
 // Better Auth models for Prisma
 
 model User {
-  id               Int                @id @default(autoincrement())
+  id               Int                  @id @default(autoincrement())
   name             String
   email            String
-  emailVerified    Boolean            @default(false) @map("email_verified")
+  emailVerified    Boolean              @default(false) @map("email_verified")
   image            String?
-  createdAt        DateTime           @default(now()) @map("created_at")
-  updatedAt        DateTime           @updatedAt @map("updated_at")
+  createdAt        DateTime             @default(now()) @map("created_at")
+  updatedAt        DateTime             @updatedAt @map("updated_at")
   role             String?
-  banned           Boolean?           @default(false)
-  banReason        String?            @map("ban_reason")
-  banExpires       DateTime?          @map("ban_expires")
-  stripeCustomerId String?            @map("stripe_customer_id")
+  banned           Boolean?             @default(false)
+  banReason        String?              @map("ban_reason")
+  banExpires       DateTime?            @map("ban_expires")
+  stripeCustomerId String?              @map("stripe_customer_id")
   username         String?
-  displayUsername  String?            @map("display_username")
+  displayUsername  String?              @map("display_username")
   sessions         Session[]
   accounts         Account[]
   members          Member[]
   invitations      Invitation[]
   courses          CourseUser[]
+  ownedCourses     Course[]
+  learningProfile  UserLearningProfile?
   activityProgress ActivityProgress[]
   stepAttempts     StepAttempt[]
   progress         UserProgress?

--- a/packages/db/src/prisma/models/activities.prisma
+++ b/packages/db/src/prisma/models/activities.prisma
@@ -1,7 +1,7 @@
 model Activity {
   id               BigInt             @id @default(autoincrement())
-  organizationId   Int                @map("organization_id")
-  organization     Organization       @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  organizationId   Int?               @map("organization_id")
+  organization     Organization?      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   lessonId         Int                @map("lesson_id")
   lesson           Lesson             @relation(fields: [lessonId], references: [id], onDelete: Cascade)
   isPublished      Boolean            @default(false) @map("is_published")

--- a/packages/db/src/prisma/models/chapters.prisma
+++ b/packages/db/src/prisma/models/chapters.prisma
@@ -1,9 +1,10 @@
 model Chapter {
   id               Int              @id @default(autoincrement())
-  organizationId   Int              @map("organization_id")
-  organization     Organization     @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  organizationId   Int?             @map("organization_id")
+  organization     Organization?    @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   courseId         Int              @map("course_id")
   course           Course           @relation(fields: [courseId], references: [id], onDelete: Cascade)
+  isLocked         Boolean          @default(false) @map("is_locked")
   isPublished      Boolean          @default(false) @map("is_published")
   language         String           @db.VarChar(10)
   slug             String

--- a/packages/db/src/prisma/models/courses.prisma
+++ b/packages/db/src/prisma/models/courses.prisma
@@ -44,8 +44,12 @@ model SearchPromptSuggestion {
 
 model Course {
   id                Int                      @id @default(autoincrement())
-  organizationId    Int                      @map("organization_id")
-  organization      Organization             @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  organizationId    Int?                     @map("organization_id")
+  organization      Organization?            @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  userId            Int?                     @map("user_id")
+  user              User?                    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  mode              CourseMode               @default(full)
+  completedAt       DateTime?                @map("completed_at")
   isPublished       Boolean                  @default(false) @map("is_published")
   language          String                   @db.VarChar(10)
   slug              String
@@ -64,8 +68,11 @@ model Course {
   users             CourseUser[]
 
   @@unique([organizationId, language, slug], name: "orgSlug")
+  @@unique([userId, language, slug], name: "userSlug")
   @@index([organizationId, language, isPublished])
   @@index([organizationId, normalizedTitle])
+  @@index([userId])
+  @@index([userId, mode])
   @@map("courses")
 }
 

--- a/packages/db/src/prisma/models/lessons.prisma
+++ b/packages/db/src/prisma/models/lessons.prisma
@@ -1,9 +1,10 @@
 model Lesson {
   id               Int              @id @default(autoincrement())
-  organizationId   Int              @map("organization_id")
-  organization     Organization     @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  organizationId   Int?             @map("organization_id")
+  organization     Organization?    @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   chapterId        Int              @map("chapter_id")
   chapter          Chapter          @relation(fields: [chapterId], references: [id], onDelete: Cascade)
+  isLocked         Boolean          @default(false) @map("is_locked")
   isPublished      Boolean          @default(false) @map("is_published")
   language         String           @db.VarChar(10)
   kind             LessonKind       @default(core)

--- a/packages/db/src/prisma/models/progress.prisma
+++ b/packages/db/src/prisma/models/progress.prisma
@@ -1,18 +1,18 @@
 model StepAttempt {
-  id              BigInt       @id @default(autoincrement())
-  userId          Int          @map("user_id")
-  user            User         @relation(fields: [userId], references: [id], onDelete: Cascade)
-  stepId          BigInt       @map("step_id")
-  step            Step         @relation(fields: [stepId], references: [id], onDelete: Cascade)
-  organizationId  Int          @map("organization_id")
-  organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  isCorrect       Boolean      @map("is_correct")
+  id              BigInt        @id @default(autoincrement())
+  userId          Int           @map("user_id")
+  user            User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  stepId          BigInt        @map("step_id")
+  step            Step          @relation(fields: [stepId], references: [id], onDelete: Cascade)
+  organizationId  Int?          @map("organization_id")
+  organization    Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  isCorrect       Boolean       @map("is_correct")
   answer          Json
   effects         Json?
-  durationSeconds Int          @map("duration_seconds")
-  answeredAt      DateTime     @default(now()) @map("answered_at")
-  hourOfDay       Int          @map("hour_of_day") @db.SmallInt
-  dayOfWeek       Int          @map("day_of_week") @db.SmallInt
+  durationSeconds Int           @map("duration_seconds")
+  answeredAt      DateTime      @default(now()) @map("answered_at")
+  hourOfDay       Int           @map("hour_of_day") @db.SmallInt
+  dayOfWeek       Int           @map("day_of_week") @db.SmallInt
 
   @@index([userId, answeredAt])
   @@index([stepId])

--- a/packages/db/src/prisma/models/user-learning-profiles.prisma
+++ b/packages/db/src/prisma/models/user-learning-profiles.prisma
@@ -1,0 +1,12 @@
+model UserLearningProfile {
+  id           Int      @id @default(autoincrement())
+  userId       Int      @unique @map("user_id")
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  interests    Json?
+  preferences  Json?
+  instructions String?
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @default(now()) @updatedAt @map("updated_at")
+
+  @@map("user_learning_profiles")
+}

--- a/packages/db/src/prisma/sql/getContinueLearning.sql
+++ b/packages/db/src/prisma/sql/getContinueLearning.sql
@@ -18,7 +18,7 @@ WITH last_per_course AS (
   JOIN lessons l ON l.id = a.lesson_id AND l.is_published = true
   JOIN chapters ch ON ch.id = l.chapter_id AND ch.is_published = true
   JOIN courses c ON c.id = ch.course_id
-  JOIN organizations o ON o.id = c.organization_id
+  LEFT JOIN organizations o ON o.id = c.organization_id
   WHERE ap.user_id = $1 AND ap.completed_at IS NOT NULL
   ORDER BY ch.course_id, ap.completed_at DESC
 )

--- a/packages/testing/src/fixtures/chapters.ts
+++ b/packages/testing/src/fixtures/chapters.ts
@@ -13,6 +13,7 @@ export function chapterAttrs(
     description: "Test chapter description",
     generationRunId: null,
     generationStatus: "completed",
+    isLocked: false,
     isPublished: false,
     language: "en",
     normalizedTitle,

--- a/packages/testing/src/fixtures/courses.ts
+++ b/packages/testing/src/fixtures/courses.ts
@@ -16,17 +16,20 @@ export function courseAttrs(attrs?: Partial<Course>): Omit<
   const { description, ...rest } = attrs ?? {};
 
   return {
+    completedAt: null,
     description: description ?? "Test course description",
     generationRunId: null,
     generationStatus: "completed",
     imageUrl: null,
     isPublished: false,
     language: "en",
+    mode: "full" as const,
     normalizedTitle: "test course",
     organizationId: 0,
     slug: `test-course-${randomUUID()}`,
     targetLanguage: null,
     title: "Test Course",
+    userId: null,
     ...rest,
   };
 }

--- a/packages/testing/src/fixtures/lessons.ts
+++ b/packages/testing/src/fixtures/lessons.ts
@@ -13,6 +13,7 @@ export function lessonAttrs(
     description: "Test lesson description",
     generationRunId: null,
     generationStatus: "completed",
+    isLocked: false,
     isPublished: false,
     kind: "core",
     language: "en",


### PR DESCRIPTION
## Summary

- Add `CourseMode` enum (`full`, `quickLesson`, `personalized`, `examPrep`) and `UserLearningProfile` model
- Make `organizationId` nullable on Course, Chapter, Lesson, Activity, and StepAttempt to support user-owned personal courses
- Add `userId`, `mode`, `completedAt` to Course; add `isLocked` to Chapter and Lesson
- Update `getContinueLearning.sql` to LEFT JOIN organizations and handle personal courses in the continue learning card
- Add `/p/[courseId]` placeholder page for personal courses
- Fix all downstream TypeScript errors from nullable `organizationId` across ~50 files

## Test plan

- [x] `pnpm turbo quality:fix` — 0 errors
- [x] `pnpm typecheck` — 15/15 packages pass
- [x] `pnpm knip` — clean
- [x] `pnpm test` — all tests pass
- [x] `pnpm --filter main build` — success
- [x] `pnpm --filter main build:e2e` — success
- [ ] e2e tests — pre-existing Playwright version conflict (not caused by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds personalized learning with user-owned courses and makes organizations optional across content and progress. Updates data, generators, and UI to handle org-less courses, and adds a personal course page.

- **New Features**
  - Schema: added CourseMode and UserLearningProfile; added userId/mode/completedAt to Course and isLocked to Chapter/Lesson; made organizationId nullable on Course/Chapter/Lesson/Activity/StepAttempt.
  - Progress & UI: submit-activity-completion safely upserts DailyProgress when organizationId is null and records StepAttempt without org; Continue Learning SQL LEFT JOINs orgs and the card builds links for org vs personal courses; added /p/[courseId] placeholder page with translations; tests cover null-org paths and personal course results.
  - Generation & Editor: image/audio steps accept optional orgSlug; reading/vocabulary save steps short-circuit without org; lesson-kind accepts optional orgSlug with unit tests; search excludes courses without orgs; admin/editor links and permissions handle null orgs.

- **Migration**
  - Run Prisma migrations and regenerate the client.

<sup>Written for commit 4fe02ef27eba9a90a2c0850d4655aecf02c9c654. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

