### PR TITLE
refactor(main): replace tap with arrow buttons in sort order step

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1271,13 +1271,11 @@ msgid "Word bank"
 msgstr "Word bank"
 
 #: src/components/activity-player/arrange-words.tsx
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "hFFOe+"
 msgid "{item}. {result}."
 msgstr "{item}. {result}."
 
 #: src/components/activity-player/arrange-words.tsx
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "vPyO9S"
 msgid "Position {position}: {item}. Tap to remove."
 msgstr "Position {position}: {item}. Tap to remove."
@@ -1534,19 +1532,44 @@ msgid "Image options"
 msgstr "Image options"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "/CFOL2"
-msgid "Tap items in the correct order"
-msgstr "Tap items in the correct order"
+msgctxt "E2Dn6t"
+msgid "Position {position}: {item}"
+msgstr "Position {position}: {item}"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "1za4AW"
-msgid "{item}. Tap to select as position {nextPosition}."
-msgstr "{item}. Tap to select as position {nextPosition}."
+msgctxt "e4MHav"
+msgid "Move {item} up"
+msgstr "Move {item} up"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "Gjog5F"
+msgid "Tap arrows to reorder"
+msgstr "Tap arrows to reorder"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "kayUDP"
+msgid "Correct order: {answer}"
+msgstr "Correct order: {answer}"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "NSI0LD"
+msgid "{item} moved to position {position}"
+msgstr "{item} moved to position {position}"
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "p5llOK"
 msgid "Sort items"
 msgstr "Sort items"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "uQ20ns"
+msgid "you had: #{position}"
+msgstr "you had: #{position}"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "y6DROt"
+msgid "Move {item} down"
+msgstr "Move {item} down"
 
 #: src/components/activity-player/timeline-visual.tsx
 msgctxt "zWkvNO"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1271,13 +1271,11 @@ msgid "Word bank"
 msgstr "Banco de palabras"
 
 #: src/components/activity-player/arrange-words.tsx
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "hFFOe+"
 msgid "{item}. {result}."
 msgstr "{item}. {result}."
 
 #: src/components/activity-player/arrange-words.tsx
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "vPyO9S"
 msgid "Position {position}: {item}. Tap to remove."
 msgstr "Posición {position}: {item}. Toca para quitar."
@@ -1534,19 +1532,44 @@ msgid "Image options"
 msgstr "Opciones de imagen"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "/CFOL2"
-msgid "Tap items in the correct order"
-msgstr "Toca los elementos en el orden correcto"
+msgctxt "E2Dn6t"
+msgid "Position {position}: {item}"
+msgstr "Posición {position}: {item}"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "1za4AW"
-msgid "{item}. Tap to select as position {nextPosition}."
-msgstr "{item}. Toca para seleccionar como posición {nextPosition}."
+msgctxt "e4MHav"
+msgid "Move {item} up"
+msgstr "Mover {item} hacia arriba"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "Gjog5F"
+msgid "Tap arrows to reorder"
+msgstr "Toca las flechas para reordenar"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "kayUDP"
+msgid "Correct order: {answer}"
+msgstr "Orden correcto: {answer}"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "NSI0LD"
+msgid "{item} moved to position {position}"
+msgstr "{item} movido a la posición {position}"
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "p5llOK"
 msgid "Sort items"
 msgstr "Ordenar elementos"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "uQ20ns"
+msgid "you had: #{position}"
+msgstr "tú tenías: #{position}"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "y6DROt"
+msgid "Move {item} down"
+msgstr "Mover {item} hacia abajo"
 
 #: src/components/activity-player/timeline-visual.tsx
 msgctxt "zWkvNO"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1271,13 +1271,11 @@ msgid "Word bank"
 msgstr "Banco de palavras"
 
 #: src/components/activity-player/arrange-words.tsx
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "hFFOe+"
 msgid "{item}. {result}."
 msgstr "{item}. {result}."
 
 #: src/components/activity-player/arrange-words.tsx
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "vPyO9S"
 msgid "Position {position}: {item}. Tap to remove."
 msgstr "Posição {position}: {item}. Toque para remover."
@@ -1534,19 +1532,44 @@ msgid "Image options"
 msgstr "Opções de imagem"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "/CFOL2"
-msgid "Tap items in the correct order"
-msgstr "Toque nos itens na ordem correta"
+msgctxt "E2Dn6t"
+msgid "Position {position}: {item}"
+msgstr "Posição {position}: {item}"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "1za4AW"
-msgid "{item}. Tap to select as position {nextPosition}."
-msgstr "{item}. Toque para selecionar como posição {nextPosition}."
+msgctxt "e4MHav"
+msgid "Move {item} up"
+msgstr "Mover {item} para cima"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "Gjog5F"
+msgid "Tap arrows to reorder"
+msgstr "Toque nas setas para reordenar"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "kayUDP"
+msgid "Correct order: {answer}"
+msgstr "Ordem correta: {answer}"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "NSI0LD"
+msgid "{item} moved to position {position}"
+msgstr "{item} movido para a posição {position}"
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "p5llOK"
 msgid "Sort items"
 msgstr "Ordenar itens"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "uQ20ns"
+msgid "you had: #{position}"
+msgstr "você tinha: #{position}"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "y6DROt"
+msgid "Move {item} down"
+msgstr "Mover {item} para baixo"
 
 #: src/components/activity-player/timeline-visual.tsx
 msgctxt "zWkvNO"

--- a/apps/main/src/components/activity-player/check-step.test.ts
+++ b/apps/main/src/components/activity-player/check-step.test.ts
@@ -10,6 +10,7 @@ function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
     kind: "static",
     position: 0,
     sentence: null,
+    sortOrderItems: [],
     visualContent: null,
     visualKind: null,
     vocabularyOptions: [],

--- a/apps/main/src/components/activity-player/fill-blank-step.test.tsx
+++ b/apps/main/src/components/activity-player/fill-blank-step.test.tsx
@@ -29,6 +29,7 @@ function buildFillBlankStep(overrides: Record<string, unknown> = {}) {
     kind: "fillBlank" as const,
     position: 0,
     sentence: null,
+    sortOrderItems: [],
     visualContent: null,
     visualKind: null,
     vocabularyOptions: [],

--- a/apps/main/src/components/activity-player/player-reducer.test.ts
+++ b/apps/main/src/components/activity-player/player-reducer.test.ts
@@ -27,6 +27,7 @@ function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
     kind: "static",
     position: 0,
     sentence: null,
+    sortOrderItems: [],
     visualContent: null,
     visualKind: null,
     vocabularyOptions: [],

--- a/apps/main/src/components/activity-player/sort-order-step.tsx
+++ b/apps/main/src/components/activity-player/sort-order-step.tsx
@@ -2,10 +2,11 @@
 
 import { type SerializedStep } from "@/data/activities/prepare-activity-data";
 import { parseStepContent } from "@zoonk/core/steps/content-contract";
+import { Button } from "@zoonk/ui/components/button";
 import { cn } from "@zoonk/ui/lib/utils";
-import { shuffle } from "@zoonk/utils/shuffle";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { useExtracted } from "next-intl";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { InlineFeedback } from "./inline-feedback";
 import { type SelectedAnswer, type StepResult } from "./player-reducer";
 import { QuestionText } from "./question-text";
@@ -13,110 +14,135 @@ import { ResultKbd } from "./result-kbd";
 import { InteractiveStepLayout } from "./step-layouts";
 import { useReplaceName } from "./user-name-context";
 
-function getItemResultState(
-  item: string,
-  position: number,
-  correctItems: string[],
-): "correct" | "incorrect" {
-  return correctItems[position] === item ? "correct" : "incorrect";
+type OrderItem = {
+  id: string;
+  text: string;
+};
+
+function getUserPosition(item: string, userOrder: string[]): number {
+  return userOrder.indexOf(item) + 1;
 }
 
-function ItemButton({
+function getFocusDirection(fromIndex: number, toIndex: number, itemCount: number): "down" | "up" {
+  const atBoundary =
+    (toIndex === 0 && fromIndex > toIndex) || (toIndex === itemCount - 1 && fromIndex < toIndex);
+
+  if (atBoundary) {
+    return fromIndex < toIndex ? "up" : "down";
+  }
+
+  return fromIndex < toIndex ? "down" : "up";
+}
+
+function ReorderRow({
+  index,
+  isLast,
   item,
-  nextPosition,
-  onClick,
-  position,
-  resultState,
+  onMove,
 }: {
-  item: string;
-  nextPosition: number;
-  onClick: () => void;
-  position: number | null;
-  resultState?: "correct" | "incorrect";
+  index: number;
+  isLast: boolean;
+  item: OrderItem;
+  onMove: (fromIndex: number, toIndex: number) => void;
 }) {
   const t = useExtracted();
-  const hasResult = resultState !== undefined;
-  const isSelected = position !== null;
+  const isFirst = index === 0;
 
-  const ariaLabel = (() => {
-    if (hasResult) {
-      const result = resultState === "correct" ? t("Correct") : t("Incorrect");
-      return t("{item}. {result}.", { item, result });
+  function handleKeyDown(event: React.KeyboardEvent) {
+    if (event.key === "ArrowUp" && !isFirst) {
+      event.preventDefault();
+      onMove(index, index - 1);
     }
 
-    if (isSelected) {
-      return t("Position {position}: {item}. Tap to remove.", {
-        item,
-        position: String(position + 1),
-      });
+    if (event.key === "ArrowDown" && !isLast) {
+      event.preventDefault();
+      onMove(index, index + 1);
     }
-
-    return t("{item}. Tap to select as position {nextPosition}.", {
-      item,
-      nextPosition: String(nextPosition),
-    });
-  })();
+  }
 
   return (
-    <button
-      aria-label={ariaLabel}
-      className={cn(
-        "flex min-h-11 items-center gap-3 rounded-lg border px-3 py-2 text-left transition-all duration-150 sm:px-4 sm:py-2.5",
-        hasResult && "pointer-events-none",
-        !hasResult &&
-          !isSelected &&
-          "border-border/50 hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 border-dashed outline-none focus-visible:ring-[3px]",
-        !hasResult && isSelected && "border-border",
-        resultState === "correct" && "border-l-success border-l-2",
-        resultState === "incorrect" && "border-l-destructive border-l-2",
-      )}
-      disabled={hasResult}
-      onClick={onClick}
-      type="button"
+    <div
+      aria-label={t("Position {position}: {item}", {
+        item: item.text,
+        position: String(index + 1),
+      })}
+      className="border-border flex min-h-11 items-center gap-3 rounded-lg border px-3 py-2 text-left transition-all duration-150 motion-reduce:transition-none sm:px-4 sm:py-2.5"
+      onKeyDown={handleKeyDown}
+      role="listitem"
     >
-      <ResultKbd isSelected={isSelected} resultState={resultState}>
-        {isSelected ? String(position + 1) : "\u00A0"}
-      </ResultKbd>
+      <ResultKbd isSelected>{String(index + 1)}</ResultKbd>
 
-      <span className="text-base">{item}</span>
-    </button>
+      <span className="min-w-0 flex-1 text-base">{item.text}</span>
+
+      <span className="ml-auto flex shrink-0 gap-0.5">
+        {isFirst ? (
+          <span aria-hidden="true" className="size-8" />
+        ) : (
+          <Button
+            aria-label={t("Move {item} up", { item: item.text })}
+            onClick={() => {
+              onMove(index, index - 1);
+            }}
+            size="icon-sm"
+            variant="ghost"
+          >
+            <ChevronUp className="size-4" />
+          </Button>
+        )}
+
+        {isLast ? (
+          <span aria-hidden="true" className="size-8" />
+        ) : (
+          <Button
+            aria-label={t("Move {item} down", { item: item.text })}
+            onClick={() => {
+              onMove(index, index + 1);
+            }}
+            size="icon-sm"
+            variant="ghost"
+          >
+            <ChevronDown className="size-4" />
+          </Button>
+        )}
+      </span>
+    </div>
   );
 }
 
-function SortItemList({
-  correctItems,
-  items,
-  onToggle,
-  selections,
+function FeedbackRow({
+  correctIndex,
+  item,
+  userOrder,
 }: {
-  correctItems?: string[];
-  items: string[];
-  onToggle: (item: string) => void;
-  selections: string[];
+  correctIndex: number;
+  item: string;
+  userOrder: string[];
 }) {
   const t = useExtracted();
-  const nextPosition = selections.length + 1;
-  const displayItems = correctItems ?? items;
+  const userPosition = getUserPosition(item, userOrder);
+  const isCorrect = userPosition === correctIndex + 1;
+  const resultState = isCorrect ? "correct" : "incorrect";
 
   return (
-    <div aria-label={t("Sort items")} className="flex flex-col gap-2" role="list">
-      {displayItems.map((item, index) => {
-        const resultState = correctItems ? getItemResultState(item, index, selections) : undefined;
-        const position = correctItems ? index : selections.indexOf(item);
-        const isSelected = position !== -1;
+    <div
+      aria-label={`${item}. ${isCorrect ? t("Correct") : t("Incorrect")}.`}
+      className={cn(
+        "flex min-h-11 items-center gap-3 rounded-lg border px-3 py-2 text-left sm:px-4 sm:py-2.5",
+        "pointer-events-none",
+        resultState === "correct" && "border-l-success border-l-2",
+        resultState === "incorrect" && "border-l-destructive border-l-2",
+      )}
+      role="listitem"
+    >
+      <ResultKbd resultState={resultState}>{String(correctIndex + 1)}</ResultKbd>
 
-        return (
-          <ItemButton
-            item={item}
-            // oxlint-disable-next-line react/no-array-index-key -- Items can repeat, no unique ID
-            key={`${item}-${index}`}
-            nextPosition={nextPosition}
-            onClick={() => onToggle(item)}
-            position={isSelected ? position : null}
-            resultState={resultState}
-          />
-        );
-      })}
+      <span className="text-base">{item}</span>
+
+      {!isCorrect && (
+        <span className="text-muted-foreground ml-auto text-xs">
+          {t("you had: #{position}", { position: String(userPosition) })}
+        </span>
+      )}
     </div>
   );
 }
@@ -124,7 +150,6 @@ function SortItemList({
 export function SortOrderStep({
   onSelectAnswer,
   result,
-  selectedAnswer,
   step,
 }: {
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
@@ -136,57 +161,146 @@ export function SortOrderStep({
   const content = useMemo(() => parseStepContent("sortOrder", step.content), [step.content]);
   const replaceName = useReplaceName();
 
-  const shuffledItems = useMemo(() => shuffle(content.items), [content.items]);
+  const initialItems = useMemo<OrderItem[]>(
+    () => step.sortOrderItems.map((text, index) => ({ id: `item-${index}`, text })),
+    [step.sortOrderItems],
+  );
 
-  const [selections, setSelections] = useState<string[]>(() => {
+  const [items, setItems] = useState<OrderItem[]>(() => {
     if (result?.answer?.kind === "sortOrder") {
-      return result.answer.userOrder;
+      return result.answer.userOrder.map((text, index) => ({ id: `item-${index}`, text }));
     }
 
-    return [];
+    return initialItems;
   });
 
-  const handleToggle = useCallback(
-    (item: string) => {
-      const index = selections.indexOf(item);
+  const [announcement, setAnnouncement] = useState("");
+  const focusTarget = useRef<{ direction: "down" | "up"; itemIndex: number } | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
 
-      if (index !== -1) {
-        const next = selections.filter((_, idx) => idx !== index);
-        setSelections(next);
+  // Register initial shuffled order as the answer on mount
+  useEffect(() => {
+    if (!result) {
+      onSelectAnswer(step.id, {
+        kind: "sortOrder",
+        userOrder: items.map((item) => item.text),
+      });
+    }
+    // Only run on mount
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-        if (selectedAnswer) {
-          onSelectAnswer(step.id, null);
-        }
+  // Focus management after a move
+  useEffect(() => {
+    if (!focusTarget.current || !listRef.current) {
+      return;
+    }
 
+    const { direction, itemIndex } = focusTarget.current;
+    const row = listRef.current.querySelectorAll("[role='listitem']")[itemIndex];
+
+    if (row) {
+      const selector = `button[aria-label*="${direction === "up" ? "up" : "down"}"]`;
+      const button = row.querySelector<HTMLButtonElement>(selector);
+
+      if (button) {
+        button.focus();
+      } else {
+        // At boundary — focus opposite arrow
+        const opposite = `button[aria-label*="${direction === "up" ? "down" : "up"}"]`;
+        row.querySelector<HTMLButtonElement>(opposite)?.focus();
+      }
+    }
+
+    focusTarget.current = null;
+  }, [items]);
+
+  const handleMove = useCallback(
+    (fromIndex: number, toIndex: number) => {
+      const moved = items[fromIndex];
+
+      if (!moved) {
         return;
       }
 
-      const next = [...selections, item];
-      setSelections(next);
+      const next = [...items];
+      next.splice(fromIndex, 1);
+      next.splice(toIndex, 0, moved);
 
-      if (next.length === content.items.length) {
-        onSelectAnswer(step.id, { kind: "sortOrder", userOrder: next });
-      }
+      setItems(next);
+
+      onSelectAnswer(step.id, {
+        kind: "sortOrder",
+        userOrder: next.map((item) => item.text),
+      });
+
+      setAnnouncement(
+        t("{item} moved to position {position}", {
+          item: moved.text,
+          position: String(toIndex + 1),
+        }),
+      );
+
+      focusTarget.current = {
+        direction: getFocusDirection(fromIndex, toIndex, next.length),
+        itemIndex: toIndex,
+      };
     },
-    [content.items.length, onSelectAnswer, selectedAnswer, selections, step.id],
+    [items, onSelectAnswer, step.id, t],
   );
 
   const hasResult = result !== undefined;
+  const isIncorrect = hasResult && !result.result.isCorrect;
+  const userOrder = items.map((item) => item.text);
 
   return (
     <InteractiveStepLayout>
       {content.question && <QuestionText>{replaceName(content.question)}</QuestionText>}
 
-      <p className="text-muted-foreground text-sm">{t("Tap items in the correct order")}</p>
+      {!hasResult && <p className="text-muted-foreground text-sm">{t("Tap arrows to reorder")}</p>}
 
-      <SortItemList
-        correctItems={hasResult ? content.items : undefined}
-        items={shuffledItems}
-        onToggle={handleToggle}
-        selections={selections}
-      />
+      {hasResult && (
+        <div aria-label={t("Sort items")} className="flex flex-col gap-2" role="list">
+          {content.items.map((item, index) => (
+            <FeedbackRow
+              correctIndex={index}
+              item={item}
+              // oxlint-disable-next-line react/no-array-index-key -- Items can repeat, no unique ID
+              key={`feedback-${index}`}
+              userOrder={userOrder}
+            />
+          ))}
+        </div>
+      )}
 
-      {result && <InlineFeedback result={result} />}
+      {!hasResult && (
+        <div aria-label={t("Sort items")} className="flex flex-col gap-2" ref={listRef} role="list">
+          {items.map((item, index) => (
+            <ReorderRow
+              index={index}
+              isLast={index === items.length - 1}
+              item={item}
+              // oxlint-disable-next-line react/no-array-index-key -- Items can repeat, no unique ID
+              key={item.id}
+              onMove={handleMove}
+            />
+          ))}
+        </div>
+      )}
+
+      <div aria-live="polite" className="sr-only" role="status">
+        {announcement}
+      </div>
+
+      {result && (
+        <InlineFeedback result={result}>
+          {isIncorrect && (
+            <p className="text-muted-foreground text-sm">
+              {t("Correct order: {answer}", { answer: content.items.join(" → ") })}
+            </p>
+          )}
+        </InlineFeedback>
+      )}
     </InteractiveStepLayout>
   );
 }

--- a/apps/main/src/components/activity-player/use-player-state.test.ts
+++ b/apps/main/src/components/activity-player/use-player-state.test.ts
@@ -14,6 +14,7 @@ function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
     kind: "static",
     position: 0,
     sentence: null,
+    sortOrderItems: [],
     visualContent: null,
     visualKind: null,
     vocabularyOptions: [],

--- a/apps/main/src/data/activities/prepare-activity-data.ts
+++ b/apps/main/src/data/activities/prepare-activity-data.ts
@@ -47,6 +47,7 @@ export type SerializedStep<Kind extends SupportedStepKind = SupportedStepKind> =
   visualContent: VisualContentByKind[SupportedVisualKind] | null;
   word: SerializedWord | null;
   sentence: SerializedSentence | null;
+  sortOrderItems: string[];
   vocabularyOptions: SerializedWord[];
   wordBankOptions: string[];
 };
@@ -192,6 +193,15 @@ function buildWordBankOptions(
   return shuffle([...correctWords, ...selected]);
 }
 
+function buildSortOrderItems(step: SerializedStep): string[] {
+  if (step.kind !== "sortOrder") {
+    return [];
+  }
+
+  const content = parseStepContent("sortOrder", step.content);
+  return shuffle([...content.items]);
+}
+
 function serializeStep(step: ActivityWithSteps["steps"][number]): SerializedStep | null {
   if (!isSupportedStepKind(step.kind)) {
     return null;
@@ -211,6 +221,7 @@ function serializeStep(step: ActivityWithSteps["steps"][number]): SerializedStep
       kind: step.kind,
       position: step.position,
       sentence: step.sentence ? serializeSentence(step.sentence) : null,
+      sortOrderItems: [],
       visualContent: visual?.content ?? null,
       visualKind: visual?.kind ?? null,
       vocabularyOptions: [],
@@ -242,6 +253,7 @@ export function prepareActivityData(
     .filter((step): step is SerializedStep => step !== null)
     .map((step) => ({
       ...step,
+      sortOrderItems: buildSortOrderItems(step),
       vocabularyOptions: buildVocabularyOptions(step, serializedLessonWords),
       wordBankOptions: buildWordBankOptions(step, serializedLessonWords),
     }));

--- a/i18n.lock
+++ b/i18n.lock
@@ -479,9 +479,14 @@ checksums:
     Belt/singular: fa36e8e36732c223d2876c0337d372e9
     BP%20to%20next%20level/singular: e77c5d6498ff38284c1f6b0721b8b33d
     Image%20options/singular: 64a1aee44b26dbaff851cb846eb4274d
-    Tap%20items%20in%20the%20correct%20order/singular: 221c7b9ef00241af65f534432965e782
-    "%7Bitem%7D.%20Tap%20to%20select%20as%20position%20%7BnextPosition%7D./singular": f8b0d3e60ce3740c02c33c0faaec5e6b
+    Position%20%7Bposition%7D%3A%20%7Bitem%7D/singular: c113a155a3e6b0cf88e442bbd4f4cbdd
+    Move%20%7Bitem%7D%20up/singular: c18fce90954378eb8573f5c3050bf140
+    Tap%20arrows%20to%20reorder/singular: 60d25a33cf81c3a9a317e50793ea30c6
+    Correct%20order%3A%20%7Banswer%7D/singular: cc7bc55cd5c85185a099b18fe5114b45
+    "%7Bitem%7D%20moved%20to%20position%20%7Bposition%7D/singular": 2f24d19c36ea2a21ce51881619ecdca5
     Sort%20items/singular: 3b1072a596203b5acdc5718d38161392
+    you%20had%3A%20%23%7Bposition%7D/singular: e4a05888e048a724927a5c107c97e41a
+    Move%20%7Bitem%7D%20down/singular: 479ab9ea756d1d814f7dcfe7cd7c21ba
     Timeline/singular: 342b1e646f0634e47112092db1a24f49
     Translate%20this%20word%3A/singular: 05fede3c583e9ea39f27ac9fdf17fcc3
     Not%20completed/singular: d011b1ae92a1a8a2676a5d6999bbe6d4


### PR DESCRIPTION
## Summary

- Replace `@dnd-kit` drag-and-drop with up/down arrow buttons for reordering sort order steps
- Move item shuffling server-side (`prepare-activity-data.ts`) to avoid hydration mismatches
- Add keyboard ArrowUp/ArrowDown support and screen reader live region announcements
- Remove `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` from main app
- Rewrite e2e tests: deterministic button clicks replace fragile drag simulation

## Test plan

- [x] `pnpm turbo quality:fix` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm knip` passes
- [x] `pnpm test` passes (451 tests)
- [x] `pnpm --filter main build` succeeds
- [x] 9 e2e tests pass including new boundary and keyboard tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced drag-and-drop with up/down arrows in the Sort Order step to improve accessibility and stability. Items render pre-placed via server-side shuffling, with improved feedback, keyboard/screen reader support, and fixes for duplicate items and focus across locales.

- **New Features**
  - Up/down arrows to reorder; buttons hide at list boundaries.
  - Keyboard ArrowUp/ArrowDown to move the focused row; focus stays on the moved item.
  - Live region announcements (e.g., “{item} moved to position N”).
  - Inline feedback: “you had: #N” for misplaced items; “Correct order: …” on incorrect.
  - “Check” enabled from the start; instruction updated to “Tap arrows to reorder.”

- **Refactors**
  - Shuffle moved server-side and stored in SerializedStep.sortOrderItems; items render pre-placed to avoid hydration issues.
  - Removed @dnd-kit/core, @dnd-kit/sortable, and @dnd-kit/utilities.
  - Rewrote e2e tests for deterministic button/keyboard actions; added boundary and keyboard cases; updated i18n (en/es/pt).
  - Fix: occurrence-based feedback for duplicate items; locale-independent focus using data-direction attributes.

<sup>Written for commit c71f2b5eeffeaefcc6fe4e3b9cf1e96fcfb90700. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

