### PR TITLE
refactor(test): use dragTo with steps for drag-and-drop e2e tests

### DIFF
--- a/.agents/skills/zoonk-testing/SKILL.md
+++ b/.agents/skills/zoonk-testing/SKILL.md
@@ -294,6 +294,19 @@ await page.getByRole("button", { name: /submit/i }).click();
 await expect(page.getByRole("alert")).toBeVisible();
 ```
 
+### Drag and Drop (dnd-kit)
+
+Use `locator.dragTo()` with the `steps` parameter. The `steps` option emits intermediate `mousemove` events, which dnd-kit's `PointerSensor` requires to activate a drag:
+
+```typescript
+const firstHandle = page.getByRole("button", { name: "Drag to reorder" }).first();
+const secondHandle = page.getByRole("button", { name: "Drag to reorder" }).nth(1);
+
+await firstHandle.dragTo(secondHandle, { steps: 10 });
+```
+
+**Why `steps` matters**: Without `steps`, Playwright emits a single `mousemove` at the destination, which isn't enough for dnd-kit's PointerSensor to recognize a drag gesture. Use `steps: 10` to generate enough intermediate movements.
+
 ## Common Thinking Mistakes
 
 ### Over-Testing Through UI Mechanics

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,8 @@ page.getByLabel(/email/i);
 
 **E2E builds**: Apps use separate build directories for E2E testing (e.g., `.next-e2e` instead of `.next`). When running E2E tests, build with `pnpm --filter {app} build:e2e`
 
+**IMPORTANT:** Before writing E2E tests, **always** read the [zoonk-testing skill](.agents/skills/zoonk-testing/SKILL.md).
+
 ## i18n
 
 - Use `getExtracted` (server) or `useExtracted` (client) for translations, don't use `getTranslations` or `useTranslations`

--- a/apps/editor/e2e/activity-list.test.ts
+++ b/apps/editor/e2e/activity-list.test.ts
@@ -201,39 +201,7 @@ test.describe("Activity List", () => {
         .getByRole("button", { exact: true, name: "Drag to reorder" })
         .nth(1);
 
-      type BoundingBox = Awaited<ReturnType<typeof firstHandle.boundingBox>>;
-      const boxes: { first: BoundingBox; second: BoundingBox } = {
-        first: null,
-        second: null,
-      };
-
-      await expect(async () => {
-        boxes.first = await firstHandle.boundingBox();
-        boxes.second = await secondHandle.boundingBox();
-        expect(boxes.first).toBeTruthy();
-        expect(boxes.second).toBeTruthy();
-      }).toPass({ timeout: 10_000 });
-
-      if (!(boxes.first && boxes.second)) {
-        throw new Error("Drag handle bounding boxes should exist");
-      }
-
-      await firstHandle.hover();
-      await authenticatedPage.mouse.down();
-
-      const targetY = boxes.second.y + boxes.second.height / 2 + 5;
-
-      await authenticatedPage.mouse.move(
-        boxes.first.x + boxes.first.width / 2,
-        boxes.first.y + 20,
-        { steps: 5 },
-      );
-
-      await authenticatedPage.mouse.move(boxes.first.x + boxes.first.width / 2, targetY, {
-        steps: 10,
-      });
-
-      await authenticatedPage.mouse.up();
+      await firstHandle.dragTo(secondHandle, { steps: 10 });
 
       const reorderedActivities = [
         { position: 1, title: "Activity 2" },

--- a/apps/editor/e2e/chapter-list.test.ts
+++ b/apps/editor/e2e/chapter-list.test.ts
@@ -182,7 +182,6 @@ test.describe("Chapter List", () => {
         { position: 3, title: "Chapter 3" },
       ]);
 
-      // Get the drag handle buttons
       const firstHandle = authenticatedPage
         .getByRole("button", { exact: true, name: "Drag to reorder" })
         .first();
@@ -191,41 +190,7 @@ test.describe("Chapter List", () => {
         .getByRole("button", { exact: true, name: "Drag to reorder" })
         .nth(1);
 
-      // Wait for drag handles to have stable bounding boxes (handles hydration timing)
-      type BoundingBox = Awaited<ReturnType<typeof firstHandle.boundingBox>>;
-      const boxes: { first: BoundingBox; second: BoundingBox } = {
-        first: null,
-        second: null,
-      };
-
-      await expect(async () => {
-        boxes.first = await firstHandle.boundingBox();
-        boxes.second = await secondHandle.boundingBox();
-        expect(boxes.first).toBeTruthy();
-        expect(boxes.second).toBeTruthy();
-      }).toPass({ timeout: 10_000 });
-
-      if (!(boxes.first && boxes.second)) {
-        throw new Error("Drag handle bounding boxes should exist");
-      }
-
-      // Perform drag past 8px activation threshold (PointerSensor uses distance)
-      await firstHandle.hover();
-      await authenticatedPage.mouse.down();
-
-      const targetY = boxes.second.y + boxes.second.height / 2 + 5;
-
-      await authenticatedPage.mouse.move(
-        boxes.first.x + boxes.first.width / 2,
-        boxes.first.y + 20,
-        { steps: 5 },
-      );
-
-      await authenticatedPage.mouse.move(boxes.first.x + boxes.first.width / 2, targetY, {
-        steps: 10,
-      });
-
-      await authenticatedPage.mouse.up();
+      await firstHandle.dragTo(secondHandle, { steps: 10 });
 
       // After reorder: Chapter 1 moves from first to last position
       const reorderedChapters = [

--- a/apps/editor/e2e/lesson-list.test.ts
+++ b/apps/editor/e2e/lesson-list.test.ts
@@ -192,7 +192,6 @@ test.describe("Lesson List", () => {
         { position: 3, title: "Lesson 3" },
       ]);
 
-      // Get the drag handle buttons
       const firstHandle = authenticatedPage
         .getByRole("button", { exact: true, name: "Drag to reorder" })
         .first();
@@ -201,43 +200,9 @@ test.describe("Lesson List", () => {
         .getByRole("button", { exact: true, name: "Drag to reorder" })
         .nth(1);
 
-      // Wait for drag handles to have stable bounding boxes (handles hydration timing)
-      type BoundingBox = Awaited<ReturnType<typeof firstHandle.boundingBox>>;
-      const boxes: { first: BoundingBox; second: BoundingBox } = {
-        first: null,
-        second: null,
-      };
+      await firstHandle.dragTo(secondHandle, { steps: 10 });
 
-      await expect(async () => {
-        boxes.first = await firstHandle.boundingBox();
-        boxes.second = await secondHandle.boundingBox();
-        expect(boxes.first).toBeTruthy();
-        expect(boxes.second).toBeTruthy();
-      }).toPass({ timeout: 10_000 });
-
-      if (!(boxes.first && boxes.second)) {
-        throw new Error("Drag handle bounding boxes should exist");
-      }
-
-      // Perform drag past 8px activation threshold (PointerSensor uses distance)
-      await firstHandle.hover();
-      await authenticatedPage.mouse.down();
-
-      const targetY = boxes.second.y + boxes.second.height / 2 + 5;
-
-      await authenticatedPage.mouse.move(
-        boxes.first.x + boxes.first.width / 2,
-        boxes.first.y + 20,
-        { steps: 5 },
-      );
-
-      await authenticatedPage.mouse.move(boxes.first.x + boxes.first.width / 2, targetY, {
-        steps: 10,
-      });
-
-      await authenticatedPage.mouse.up();
-
-      // After reorder: Lesson 1 moves from first to second position
+      // After reorder: Lesson 1 swaps with Lesson 2
       const reorderedLessons = [
         { position: 1, title: "Lesson 2" },
         { position: 2, title: "Lesson 1" },


### PR DESCRIPTION
## Summary

- Replace manual `mouse.down()`/`mouse.move()`/`mouse.up()` sequences with Playwright's `dragTo({ steps })` API in all three reorder tests (chapters, lessons, activities)
- Add drag-and-drop (dnd-kit) guidance to the testing skill docs

## Test plan

- [x] All three reorder tests pass: chapters, lessons, activities
- [x] Each test run 5 times with no flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored drag-and-drop reorder tests to use Playwright locator.dragTo with steps so dnd-kit’s PointerSensor reliably detects drags. This simplifies the tests and reduces flakiness; added guidance to the testing skill docs.

- **Refactors**
  - Replaced manual mouse down/move/up with dragTo({ steps: 10 }) in chapter, lesson, and activity tests.
  - Removed boundingBox and hover logic; use locator targets directly.
  - Verified all three tests pass; ran each 5 times with no flakiness.

<sup>Written for commit 31647f9cf9328a87a55fc05264f921b92c504923. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

