### PR TITLE
fix(main): move shuffle calls from client to server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ For detailed UX guidelines (interactions, animation, layout, accessibility), see
 
 - Prefer server components over client components. Only use client components when absolutely necessary
 - Avoid `useEffect` and `useState` unless absolutely required
+- **Required**: Every time you use `useEffect` you **MUST** read the [vercel-react-best-practices skill](.agents/skills/vercel-react-best-practices/SKILL.md) AND these docs: https://react.dev/learn/you-might-not-need-an-effect
 - Fetch data on the server whenever possible and use `Suspense` with a fallback for loading states, [see docs for streaming data](https://nextjs.org/docs/app/getting-started/fetching-data#streaming)
 - Keep comments minimal—explain **why**, not **what**
 - Use `safeAsync` when using `await` to better handle errors

--- a/apps/main/src/components/activity-player/check-step.test.ts
+++ b/apps/main/src/components/activity-player/check-step.test.ts
@@ -6,10 +6,13 @@ import { type SelectedAnswer } from "./player-reducer";
 function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
   return {
     content: { text: "Hello", title: "Intro", variant: "text" as const },
+    fillBlankOptions: [],
     id: "step-1",
     kind: "static",
+    matchColumnsRightItems: [],
     position: 0,
     sentence: null,
+    sortOrderItems: [],
     visualContent: null,
     visualKind: null,
     vocabularyOptions: [],

--- a/apps/main/src/components/activity-player/fill-blank-step.test.tsx
+++ b/apps/main/src/components/activity-player/fill-blank-step.test.tsx
@@ -13,10 +13,6 @@ vi.mock("./user-name-context", () => ({
   useReplaceName: () => (value: string) => value,
 }));
 
-vi.mock("@zoonk/utils/shuffle", () => ({
-  shuffle: <T,>(array: readonly T[]): T[] => [...array],
-}));
-
 function buildFillBlankStep(overrides: Record<string, unknown> = {}) {
   return {
     content: {
@@ -25,10 +21,13 @@ function buildFillBlankStep(overrides: Record<string, unknown> = {}) {
       feedback: "Good",
       template: "Say [BLANK] then [BLANK]",
     },
+    fillBlankOptions: ["alpha", "beta", "gamma"],
     id: "step-fb",
     kind: "fillBlank" as const,
+    matchColumnsRightItems: [],
     position: 0,
     sentence: null,
+    sortOrderItems: [],
     visualContent: null,
     visualKind: null,
     vocabularyOptions: [],

--- a/apps/main/src/components/activity-player/fill-blank-step.tsx
+++ b/apps/main/src/components/activity-player/fill-blank-step.tsx
@@ -3,7 +3,6 @@
 import { type SerializedStep } from "@/data/activities/prepare-activity-data";
 import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { cn } from "@zoonk/ui/lib/utils";
-import { shuffle } from "@zoonk/utils/shuffle";
 import { useExtracted } from "next-intl";
 import { useCallback, useMemo, useState } from "react";
 import { InlineFeedback } from "./inline-feedback";
@@ -209,11 +208,6 @@ export function FillBlankStep({
   const blankCount = content.answers.length;
   const hasResult = result !== undefined;
 
-  const shuffledWords = useMemo(
-    () => shuffle([...content.answers, ...content.distractors]),
-    [content.answers, content.distractors],
-  );
-
   const [blanks, setBlanks] = useState<(string | null)[]>(() => {
     if (result?.answer?.kind === "fillBlank") {
       return result.answer.userAnswers;
@@ -276,7 +270,7 @@ export function FillBlankStep({
         blanks={blanks}
         disabled={hasResult}
         onPlaceWord={handlePlaceWord}
-        words={shuffledWords}
+        words={step.fillBlankOptions}
       />
 
       {result && (

--- a/apps/main/src/components/activity-player/match-columns-step.tsx
+++ b/apps/main/src/components/activity-player/match-columns-step.tsx
@@ -4,7 +4,6 @@ import { type SerializedStep } from "@/data/activities/prepare-activity-data";
 import { checkSingleMatchPair } from "@zoonk/core/player/check-answer";
 import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { cn } from "@zoonk/ui/lib/utils";
-import { shuffle } from "@zoonk/utils/shuffle";
 import { CircleCheck } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { Fragment, useCallback, useMemo, useRef, useState } from "react";
@@ -158,11 +157,6 @@ export function MatchColumnsStep({
   const replaceName = useReplaceName();
   const t = useExtracted();
 
-  const shuffledRight = useMemo(
-    () => shuffle(content.pairs.map((pair) => pair.right)),
-    [content.pairs],
-  );
-
   const leftItems = useMemo(() => content.pairs.map((pair) => pair.left), [content.pairs]);
 
   const [selectedLeft, setSelectedLeft] = useState<string | null>(null);
@@ -245,7 +239,7 @@ export function MatchColumnsStep({
         leftItems={leftItems}
         onTapLeft={handleTapLeft}
         onTapRight={handleTapRight}
-        rightItems={shuffledRight}
+        rightItems={step.matchColumnsRightItems}
         selectedLeft={selectedLeft}
       />
 

--- a/apps/main/src/components/activity-player/player-reducer.test.ts
+++ b/apps/main/src/components/activity-player/player-reducer.test.ts
@@ -23,10 +23,13 @@ const coreMultipleChoiceContent = {
 function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
   return {
     content: { text: "Hello", title: "Intro", variant: "text" as const },
+    fillBlankOptions: [],
     id: "step-1",
     kind: "static",
+    matchColumnsRightItems: [],
     position: 0,
     sentence: null,
+    sortOrderItems: [],
     visualContent: null,
     visualKind: null,
     vocabularyOptions: [],

--- a/apps/main/src/components/activity-player/sort-order-step.tsx
+++ b/apps/main/src/components/activity-player/sort-order-step.tsx
@@ -3,7 +3,6 @@
 import { type SerializedStep } from "@/data/activities/prepare-activity-data";
 import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { cn } from "@zoonk/ui/lib/utils";
-import { shuffle } from "@zoonk/utils/shuffle";
 import { useExtracted } from "next-intl";
 import { useCallback, useMemo, useState } from "react";
 import { InlineFeedback } from "./inline-feedback";
@@ -136,8 +135,6 @@ export function SortOrderStep({
   const content = useMemo(() => parseStepContent("sortOrder", step.content), [step.content]);
   const replaceName = useReplaceName();
 
-  const shuffledItems = useMemo(() => shuffle(content.items), [content.items]);
-
   const [selections, setSelections] = useState<string[]>(() => {
     if (result?.answer?.kind === "sortOrder") {
       return result.answer.userOrder;
@@ -181,7 +178,7 @@ export function SortOrderStep({
 
       <SortItemList
         correctItems={hasResult ? content.items : undefined}
-        items={shuffledItems}
+        items={step.sortOrderItems}
         onToggle={handleToggle}
         selections={selections}
       />

--- a/apps/main/src/components/activity-player/use-player-state.test.ts
+++ b/apps/main/src/components/activity-player/use-player-state.test.ts
@@ -10,10 +10,13 @@ import { usePlayerState } from "./use-player-state";
 function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
   return {
     content: { text: "Hello", title: "Intro", variant: "text" as const },
+    fillBlankOptions: [],
     id: "step-1",
     kind: "static",
+    matchColumnsRightItems: [],
     position: 0,
     sentence: null,
+    sortOrderItems: [],
     visualContent: null,
     visualKind: null,
     vocabularyOptions: [],

--- a/apps/main/src/data/activities/prepare-activity-data.test.ts
+++ b/apps/main/src/data/activities/prepare-activity-data.test.ts
@@ -820,6 +820,151 @@ describe(prepareActivityData, () => {
     expect(result.steps[0]?.wordBankOptions).toEqual([]);
   });
 
+  test("sortOrder step populates sortOrderItems with all items", () => {
+    const activity = {
+      description: null,
+      generationRunId: null,
+      generationStatus: "completed",
+      id: BigInt(50),
+      kind: "background",
+      language: "en",
+      organizationId: 1,
+      position: 0,
+      steps: [
+        {
+          content: {
+            feedback: "Good",
+            items: ["First", "Second", "Third"],
+            question: "Order these",
+          },
+          id: BigInt(51),
+          kind: "sortOrder",
+          position: 0,
+          sentence: null,
+          visualContent: null,
+          visualKind: null,
+          word: null,
+        },
+      ],
+      title: "Sort Order",
+    } satisfies ActivityWithSteps;
+
+    const result = prepareActivityData(activity, [], []);
+    const step = result.steps[0];
+
+    expect(step?.sortOrderItems).toHaveLength(3);
+    expect(step?.sortOrderItems.toSorted()).toEqual(["First", "Second", "Third"]);
+  });
+
+  test("fillBlank step populates fillBlankOptions with answers and distractors", () => {
+    const activity = {
+      description: null,
+      generationRunId: null,
+      generationStatus: "completed",
+      id: BigInt(52),
+      kind: "background",
+      language: "en",
+      organizationId: 1,
+      position: 0,
+      steps: [
+        {
+          content: {
+            answers: ["alpha", "beta"],
+            distractors: ["gamma", "delta"],
+            feedback: "Nice",
+            template: "Say [BLANK] then [BLANK]",
+          },
+          id: BigInt(53),
+          kind: "fillBlank",
+          position: 0,
+          sentence: null,
+          visualContent: null,
+          visualKind: null,
+          word: null,
+        },
+      ],
+      title: "Fill Blank",
+    } satisfies ActivityWithSteps;
+
+    const result = prepareActivityData(activity, [], []);
+    const step = result.steps[0];
+
+    expect(step?.fillBlankOptions).toHaveLength(4);
+    expect(step?.fillBlankOptions.toSorted()).toEqual(["alpha", "beta", "delta", "gamma"]);
+  });
+
+  test("matchColumns step populates matchColumnsRightItems with right-column values", () => {
+    const activity = {
+      description: null,
+      generationRunId: null,
+      generationStatus: "completed",
+      id: BigInt(54),
+      kind: "background",
+      language: "en",
+      organizationId: 1,
+      position: 0,
+      steps: [
+        {
+          content: {
+            pairs: [
+              { left: "A", right: "1" },
+              { left: "B", right: "2" },
+              { left: "C", right: "3" },
+            ],
+            question: "Match these",
+          },
+          id: BigInt(55),
+          kind: "matchColumns",
+          position: 0,
+          sentence: null,
+          visualContent: null,
+          visualKind: null,
+          word: null,
+        },
+      ],
+      title: "Match Columns",
+    } satisfies ActivityWithSteps;
+
+    const result = prepareActivityData(activity, [], []);
+    const step = result.steps[0];
+
+    expect(step?.matchColumnsRightItems).toHaveLength(3);
+    expect(step?.matchColumnsRightItems.toSorted()).toEqual(["1", "2", "3"]);
+  });
+
+  test("non-matching step kinds return empty arrays for sortOrderItems, fillBlankOptions, matchColumnsRightItems", () => {
+    const activity = {
+      description: null,
+      generationRunId: null,
+      generationStatus: "completed",
+      id: BigInt(56),
+      kind: "background",
+      language: "en",
+      organizationId: 1,
+      position: 0,
+      steps: [
+        {
+          content: { text: "test", title: "Test", variant: "text" },
+          id: BigInt(57),
+          kind: "static",
+          position: 0,
+          sentence: null,
+          visualContent: null,
+          visualKind: null,
+          word: null,
+        },
+      ],
+      title: "Static",
+    } satisfies ActivityWithSteps;
+
+    const result = prepareActivityData(activity, [], []);
+    const step = result.steps[0];
+
+    expect(step?.sortOrderItems).toEqual([]);
+    expect(step?.fillBlankOptions).toEqual([]);
+    expect(step?.matchColumnsRightItems).toEqual([]);
+  });
+
   test("includes language and organizationId", async () => {
     const activity = await activityFixture({
       generationStatus: "completed",


### PR DESCRIPTION
## Summary

- Moved `shuffle` calls for sort-order, fill-blank, and match-columns steps from client `useMemo` to server-side `prepareActivityData`, preventing hydration mismatches
- Added `sortOrderItems`, `fillBlankOptions`, and `matchColumnsRightItems` fields to `SerializedStep`
- Added integration tests for the new server-side shuffle fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved shuffling for sort-order, fill-blank, and match-columns to the server in prepareActivityData, and exposed pre-shuffled arrays on SerializedStep. This fixes hydration mismatches and keeps item order stable between SSR and client.

- **Bug Fixes**
  - Added SerializedStep fields: sortOrderItems, fillBlankOptions, matchColumnsRightItems.
  - Updated SortOrderStep, FillBlankStep, and MatchColumnsStep to use these server-provided arrays instead of client-side shuffle.
  - Added integration tests for prepareActivityData to validate these fields.
  - Tightened AGENTS.md guidance: read React docs before using useEffect.

<sup>Written for commit f00fa40ce44dfadcc78258f4d4540470a3b5bc5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

