### PR TITLE
refactor: replace hard-coded "ai" slug with AI_ORG_SLUG constant

### DIFF
--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
@@ -12,6 +12,7 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { activityGenerationWorkflow } from "./activity-generation-workflow";
 import { completeListeningActivityStep } from "./steps/complete-listening-activity-step";
@@ -567,12 +568,12 @@ describe("language activity generation", () => {
     expect(generateLanguageAudio).toHaveBeenCalledTimes(2);
     expect(generateLanguageAudio).toHaveBeenCalledWith({
       language: "es",
-      orgSlug: "ai",
+      orgSlug: AI_ORG_SLUG,
       text: "hola",
     });
     expect(generateLanguageAudio).toHaveBeenCalledWith({
       language: "es",
-      orgSlug: "ai",
+      orgSlug: AI_ORG_SLUG,
       text: "gato",
     });
   });
@@ -1580,12 +1581,12 @@ describe("language activity generation", () => {
     expect(generateLanguageAudio).toHaveBeenCalledTimes(2);
     expect(generateLanguageAudio).toHaveBeenCalledWith({
       language: "es",
-      orgSlug: "ai",
+      orgSlug: AI_ORG_SLUG,
       text: "Yo veo un gato.",
     });
     expect(generateLanguageAudio).toHaveBeenCalledWith({
       language: "es",
-      orgSlug: "ai",
+      orgSlug: AI_ORG_SLUG,
       text: "Hola, ¿cómo estás?",
     });
   });

--- a/apps/editor/e2e/activity-list.test.ts
+++ b/apps/editor/e2e/activity-list.test.ts
@@ -5,6 +5,7 @@ import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import tmp from "tmp";
 import { type Page, expect, test } from "./fixtures";
 import { getMoreOptionsButton, importFlow } from "./helpers/import-dialog";
@@ -68,7 +69,7 @@ async function navigateToLessonPage(
   chapterSlug: string,
   lessonSlug: string,
 ) {
-  await page.goto(`/ai/c/en/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`);
+  await page.goto(`/${AI_ORG_SLUG}/c/en/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`);
 
   await expect(page.getByRole("textbox", { name: /edit lesson title/i })).toBeVisible();
 }
@@ -163,7 +164,9 @@ test.describe("Activity List", () => {
 
       await expect(authenticatedPage.getByText(/activity editor coming soon/i)).toBeVisible();
 
-      await authenticatedPage.goto(`/ai/c/en/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+      await authenticatedPage.goto(
+        `/${AI_ORG_SLUG}/c/en/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`,
+      );
 
       await expect(
         authenticatedPage.getByRole("textbox", { name: /edit lesson title/i }),

--- a/apps/editor/e2e/alternative-titles.test.ts
+++ b/apps/editor/e2e/alternative-titles.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import { prisma } from "@zoonk/db";
 import { getAiOrganization } from "@zoonk/e2e/helpers";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import tmp from "tmp";
 import { type Page, expect, test } from "./fixtures";
 import { importFlow } from "./helpers/import-dialog";
@@ -24,7 +25,7 @@ async function createTestCourse() {
 }
 
 async function navigateToCoursePage(page: Page, slug: string) {
-  await page.goto(`/ai/c/en/${slug}`);
+  await page.goto(`/${AI_ORG_SLUG}/c/en/${slug}`);
 
   await expect(page.getByRole("textbox", { name: /edit course title/i })).toBeVisible();
 }

--- a/apps/editor/e2e/chapter-delete.test.ts
+++ b/apps/editor/e2e/chapter-delete.test.ts
@@ -3,6 +3,7 @@ import { prisma } from "@zoonk/db";
 import { getAiOrganization } from "@zoonk/e2e/helpers";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { type Page, expect, test } from "./fixtures";
 
 async function createTestChapter(isPublished: boolean) {
@@ -26,7 +27,7 @@ async function createTestChapter(isPublished: boolean) {
 }
 
 async function navigateToChapterPage(page: Page, courseSlug: string, chapterSlug: string) {
-  await page.goto(`/ai/c/en/${courseSlug}/ch/${chapterSlug}`);
+  await page.goto(`/${AI_ORG_SLUG}/c/en/${courseSlug}/ch/${chapterSlug}`);
 
   await expect(page.getByRole("textbox", { name: /edit chapter title/i })).toBeVisible();
 }
@@ -76,7 +77,7 @@ test.describe("Chapter Delete", () => {
       await openDeleteDialog(authenticatedPage);
       await confirmDelete(authenticatedPage);
 
-      await expect(authenticatedPage).toHaveURL(new RegExp(`/ai/c/en/${course.slug}$`));
+      await expect(authenticatedPage).toHaveURL(new RegExp(`/${AI_ORG_SLUG}/c/en/${course.slug}$`));
       await verifyChapterDeleted(chapter.id);
     });
 
@@ -87,7 +88,7 @@ test.describe("Chapter Delete", () => {
       await openDeleteDialog(ownerPage);
       await confirmDelete(ownerPage);
 
-      await expect(ownerPage).toHaveURL(new RegExp(`/ai/c/en/${course.slug}$`));
+      await expect(ownerPage).toHaveURL(new RegExp(`/${AI_ORG_SLUG}/c/en/${course.slug}$`));
       await verifyChapterDeleted(chapter.id);
     });
 
@@ -98,7 +99,7 @@ test.describe("Chapter Delete", () => {
       await openDeleteDialog(ownerPage);
       await confirmDelete(ownerPage);
 
-      await expect(ownerPage).toHaveURL(new RegExp(`/ai/c/en/${course.slug}$`));
+      await expect(ownerPage).toHaveURL(new RegExp(`/${AI_ORG_SLUG}/c/en/${course.slug}$`));
       await verifyChapterDeleted(chapter.id);
     });
   });

--- a/apps/editor/e2e/chapter-list.test.ts
+++ b/apps/editor/e2e/chapter-list.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import { getAiOrganization } from "@zoonk/e2e/helpers";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import tmp from "tmp";
 import { type Page, expect, test } from "./fixtures";
 import { getMoreOptionsButton, importFlow } from "./helpers/import-dialog";
@@ -41,7 +42,7 @@ async function createTestCourse(chapterCount = 0) {
 }
 
 async function navigateToCoursePage(page: Page, slug: string) {
-  await page.goto(`/ai/c/en/${slug}`);
+  await page.goto(`/${AI_ORG_SLUG}/c/en/${slug}`);
 
   await expect(page.getByRole("textbox", { name: /edit course title/i })).toBeVisible();
 }
@@ -151,7 +152,7 @@ test.describe("Chapter List", () => {
       ).toBeVisible();
 
       // Navigate back to course page to verify insertion
-      await authenticatedPage.goto(`/ai/c/en/${course.slug}`);
+      await authenticatedPage.goto(`/${AI_ORG_SLUG}/c/en/${course.slug}`);
 
       await expect(
         authenticatedPage.getByRole("textbox", { name: /edit course title/i }),

--- a/apps/editor/e2e/chapter-publish.test.ts
+++ b/apps/editor/e2e/chapter-publish.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { getAiOrganization } from "@zoonk/e2e/helpers";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { type Page, expect, test } from "./fixtures";
 
 async function createTestChapter(isPublished: boolean) {
@@ -24,7 +25,7 @@ async function createTestChapter(isPublished: boolean) {
 }
 
 async function navigateToChapterPage(page: Page, courseSlug: string, chapterSlug: string) {
-  await page.goto(`/ai/c/en/${courseSlug}/ch/${chapterSlug}`);
+  await page.goto(`/${AI_ORG_SLUG}/c/en/${courseSlug}/ch/${chapterSlug}`);
 
   await expect(page.getByRole("textbox", { name: /edit chapter title/i })).toBeVisible();
 }

--- a/apps/editor/e2e/course-categories.test.ts
+++ b/apps/editor/e2e/course-categories.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { getAiOrganization } from "@zoonk/e2e/helpers";
 import { courseCategoryFixture, courseFixture } from "@zoonk/testing/fixtures/courses";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { LOCALE_COOKIE } from "@zoonk/utils/locale";
 import { type Page, expect, test } from "./fixtures";
 
@@ -14,7 +15,7 @@ async function createTestCourse() {
 }
 
 async function navigateToCoursePage(page: Page, slug: string) {
-  await page.goto(`/ai/c/en/${slug}`);
+  await page.goto(`/${AI_ORG_SLUG}/c/en/${slug}`);
 
   await expect(page.getByRole("textbox", { name: /edit course title/i })).toBeVisible();
 }
@@ -138,7 +139,7 @@ test.describe("Course Categories Editor", () => {
       .context()
       .addCookies([{ domain: "localhost", name: LOCALE_COOKIE, path: "/", value: "es" }]);
 
-    await authenticatedPage.goto(`/ai/c/en/${course.slug}`);
+    await authenticatedPage.goto(`/${AI_ORG_SLUG}/c/en/${course.slug}`);
 
     await expect(
       authenticatedPage.getByRole("textbox", {

--- a/apps/editor/e2e/course-delete.test.ts
+++ b/apps/editor/e2e/course-delete.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { prisma } from "@zoonk/db";
 import { getAiOrganization } from "@zoonk/e2e/helpers";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { type Page, expect, test } from "./fixtures";
 
 async function createTestCourse(isPublished: boolean) {
@@ -15,7 +16,7 @@ async function createTestCourse(isPublished: boolean) {
 }
 
 async function navigateToCoursePage(page: Page, slug: string) {
-  await page.goto(`/ai/c/en/${slug}`);
+  await page.goto(`/${AI_ORG_SLUG}/c/en/${slug}`);
 
   await expect(page.getByRole("textbox", { name: /edit course title/i })).toBeVisible();
 }
@@ -65,7 +66,7 @@ test.describe("Course Delete", () => {
       await openDeleteDialog(authenticatedPage);
       await confirmDelete(authenticatedPage);
 
-      await expect(authenticatedPage).toHaveURL(/\/ai$/);
+      await expect(authenticatedPage).toHaveURL(new RegExp(`/${AI_ORG_SLUG}$`));
       await verifyCourseDeleted(course.id);
     });
 
@@ -76,7 +77,7 @@ test.describe("Course Delete", () => {
       await openDeleteDialog(ownerPage);
       await confirmDelete(ownerPage);
 
-      await expect(ownerPage).toHaveURL(/\/ai$/);
+      await expect(ownerPage).toHaveURL(new RegExp(`/${AI_ORG_SLUG}$`));
       await verifyCourseDeleted(course.id);
     });
 
@@ -87,7 +88,7 @@ test.describe("Course Delete", () => {
       await openDeleteDialog(ownerPage);
       await confirmDelete(ownerPage);
 
-      await expect(ownerPage).toHaveURL(/\/ai$/);
+      await expect(ownerPage).toHaveURL(new RegExp(`/${AI_ORG_SLUG}$`));
       await verifyCourseDeleted(course.id);
     });
   });

--- a/apps/editor/e2e/course-image.test.ts
+++ b/apps/editor/e2e/course-image.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { getAiOrganization } from "@zoonk/e2e/helpers";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { type Page, expect, test } from "./fixtures";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -26,7 +27,7 @@ async function createTestCourse(imageUrl: string | null = null) {
 }
 
 async function navigateToCoursePage(page: Page, slug: string) {
-  await page.goto(`/ai/c/en/${slug}`);
+  await page.goto(`/${AI_ORG_SLUG}/c/en/${slug}`);
 
   await expect(page.getByRole("textbox", { name: /edit course title/i })).toBeVisible();
 }

--- a/apps/editor/e2e/course-publish.test.ts
+++ b/apps/editor/e2e/course-publish.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { getAiOrganization } from "@zoonk/e2e/helpers";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { type Page, expect, test } from "./fixtures";
 
 async function createTestCourse(isPublished: boolean) {
@@ -14,7 +15,7 @@ async function createTestCourse(isPublished: boolean) {
 }
 
 async function navigateToCoursePage(page: Page, slug: string) {
-  await page.goto(`/ai/c/en/${slug}`);
+  await page.goto(`/${AI_ORG_SLUG}/c/en/${slug}`);
 
   await expect(page.getByRole("textbox", { name: /edit course title/i })).toBeVisible();
 }

--- a/apps/editor/e2e/import-replace-warning.test.ts
+++ b/apps/editor/e2e/import-replace-warning.test.ts
@@ -1,5 +1,6 @@
 import { getAiOrganization } from "@zoonk/e2e/helpers";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { type Page, expect, test } from "./fixtures";
 import { getMoreOptionsButton } from "./helpers/import-dialog";
 
@@ -26,7 +27,7 @@ test.describe("Import Replace Warning", () => {
     authenticatedPage,
   }) => {
     const course = await createTestCourse();
-    await authenticatedPage.goto(`/ai/c/en/${course.slug}`);
+    await authenticatedPage.goto(`/${AI_ORG_SLUG}/c/en/${course.slug}`);
     await expect(
       authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
     ).toBeVisible();
@@ -42,7 +43,7 @@ test.describe("Import Replace Warning", () => {
     authenticatedPage,
   }) => {
     const course = await createTestCourse();
-    await authenticatedPage.goto(`/ai/c/en/${course.slug}`);
+    await authenticatedPage.goto(`/${AI_ORG_SLUG}/c/en/${course.slug}`);
     await expect(
       authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
     ).toBeVisible();
@@ -61,7 +62,7 @@ test.describe("Import Replace Warning", () => {
     authenticatedPage,
   }) => {
     const course = await createTestCourse();
-    await authenticatedPage.goto(`/ai/c/en/${course.slug}`);
+    await authenticatedPage.goto(`/${AI_ORG_SLUG}/c/en/${course.slug}`);
     await expect(
       authenticatedPage.getByRole("textbox", { name: /edit course title/i }),
     ).toBeVisible();

--- a/apps/editor/e2e/lesson-delete.test.ts
+++ b/apps/editor/e2e/lesson-delete.test.ts
@@ -4,6 +4,7 @@ import { getAiOrganization } from "@zoonk/e2e/helpers";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { type Page, expect, test } from "./fixtures";
 
 async function createTestLesson(isPublished: boolean) {
@@ -40,7 +41,7 @@ async function navigateToLessonPage(
   chapterSlug: string,
   lessonSlug: string,
 ) {
-  await page.goto(`/ai/c/en/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`);
+  await page.goto(`/${AI_ORG_SLUG}/c/en/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`);
 
   await expect(page.getByRole("textbox", { name: /edit lesson title/i })).toBeVisible();
 }
@@ -91,7 +92,7 @@ test.describe("Lesson Delete", () => {
       await confirmDelete(authenticatedPage);
 
       await expect(authenticatedPage).toHaveURL(
-        new RegExp(`/ai/c/en/${course.slug}/ch/${chapter.slug}$`),
+        new RegExp(`/${AI_ORG_SLUG}/c/en/${course.slug}/ch/${chapter.slug}$`),
       );
       await verifyLessonDeleted(lesson.id);
     });
@@ -103,7 +104,9 @@ test.describe("Lesson Delete", () => {
       await openDeleteDialog(ownerPage);
       await confirmDelete(ownerPage);
 
-      await expect(ownerPage).toHaveURL(new RegExp(`/ai/c/en/${course.slug}/ch/${chapter.slug}$`));
+      await expect(ownerPage).toHaveURL(
+        new RegExp(`/${AI_ORG_SLUG}/c/en/${course.slug}/ch/${chapter.slug}$`),
+      );
       await verifyLessonDeleted(lesson.id);
     });
 
@@ -114,7 +117,9 @@ test.describe("Lesson Delete", () => {
       await openDeleteDialog(ownerPage);
       await confirmDelete(ownerPage);
 
-      await expect(ownerPage).toHaveURL(new RegExp(`/ai/c/en/${course.slug}/ch/${chapter.slug}$`));
+      await expect(ownerPage).toHaveURL(
+        new RegExp(`/${AI_ORG_SLUG}/c/en/${course.slug}/ch/${chapter.slug}$`),
+      );
       await verifyLessonDeleted(lesson.id);
     });
   });

--- a/apps/editor/e2e/lesson-list.test.ts
+++ b/apps/editor/e2e/lesson-list.test.ts
@@ -4,6 +4,7 @@ import { getAiOrganization } from "@zoonk/e2e/helpers";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import tmp from "tmp";
 import { type Page, expect, test } from "./fixtures";
 import { getMoreOptionsButton, importFlow } from "./helpers/import-dialog";
@@ -51,7 +52,7 @@ async function createTestChapter(lessonCount = 0) {
 }
 
 async function navigateToChapterPage(page: Page, courseSlug: string, chapterSlug: string) {
-  await page.goto(`/ai/c/en/${courseSlug}/ch/${chapterSlug}`);
+  await page.goto(`/${AI_ORG_SLUG}/c/en/${courseSlug}/ch/${chapterSlug}`);
 
   await expect(page.getByRole("textbox", { name: /edit chapter title/i })).toBeVisible();
 }
@@ -161,7 +162,7 @@ test.describe("Lesson List", () => {
       ).toBeVisible();
 
       // Navigate back to chapter page to verify insertion
-      await authenticatedPage.goto(`/ai/c/en/${course.slug}/ch/${chapter.slug}`);
+      await authenticatedPage.goto(`/${AI_ORG_SLUG}/c/en/${course.slug}/ch/${chapter.slug}`);
 
       await expect(
         authenticatedPage.getByRole("textbox", { name: /edit chapter title/i }),

--- a/apps/editor/e2e/lesson-publish.test.ts
+++ b/apps/editor/e2e/lesson-publish.test.ts
@@ -3,6 +3,7 @@ import { getAiOrganization } from "@zoonk/e2e/helpers";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { type Page, expect, test } from "./fixtures";
 
 async function createTestLesson(isPublished: boolean) {
@@ -37,7 +38,7 @@ async function navigateToLessonPage(
   chapterSlug: string,
   lessonSlug: string,
 ) {
-  await page.goto(`/ai/c/en/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`);
+  await page.goto(`/${AI_ORG_SLUG}/c/en/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`);
 
   await expect(page.getByRole("textbox", { name: /edit lesson title/i })).toBeVisible();
 }

--- a/apps/editor/e2e/locale-switcher.test.ts
+++ b/apps/editor/e2e/locale-switcher.test.ts
@@ -1,3 +1,4 @@
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { type Page, expect, test } from "./fixtures";
 
 async function openOrgDropdown(page: Page) {
@@ -21,7 +22,7 @@ async function openLanguageSubmenu(page: Page) {
 
 test.describe("Locale Switcher", () => {
   test.beforeEach(async ({ authenticatedPage }) => {
-    await authenticatedPage.goto("/ai");
+    await authenticatedPage.goto(`/${AI_ORG_SLUG}`);
   });
 
   test("switching locale updates page content", async ({ authenticatedPage }) => {

--- a/apps/editor/e2e/logout-menu-item.test.ts
+++ b/apps/editor/e2e/logout-menu-item.test.ts
@@ -1,3 +1,4 @@
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { type Page, expect, test } from "./fixtures";
 
 async function openOrgDropdown(page: Page) {
@@ -6,7 +7,7 @@ async function openOrgDropdown(page: Page) {
 
 test.describe("Logout Menu Item", () => {
   test("logs out user and shows login button", async ({ authenticatedPage }) => {
-    await authenticatedPage.goto("/ai");
+    await authenticatedPage.goto(`/${AI_ORG_SLUG}`);
 
     await openOrgDropdown(authenticatedPage);
     await authenticatedPage.getByRole("menuitem", { name: /logout/i }).click();

--- a/apps/editor/e2e/org-switcher.test.ts
+++ b/apps/editor/e2e/org-switcher.test.ts
@@ -1,8 +1,9 @@
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { expect, test } from "./fixtures";
 
 test.describe("Org Switcher - Multi-org user", () => {
   test.beforeEach(async ({ multiOrgPage }) => {
-    await multiOrgPage.goto("/ai");
+    await multiOrgPage.goto(`/${AI_ORG_SLUG}`);
 
     await expect(multiOrgPage.getByRole("button", { name: /zoonk ai/i })).toBeVisible();
   });
@@ -22,7 +23,7 @@ test.describe("Org Switcher - Multi-org user", () => {
 test.describe("Org Switcher - Active org update", () => {
   test("navigating to home redirects to newly selected org", async ({ multiOrgPage }) => {
     // Start at the "ai" org
-    await multiOrgPage.goto("/ai");
+    await multiOrgPage.goto(`/${AI_ORG_SLUG}`);
 
     await expect(multiOrgPage.getByRole("button", { name: /zoonk ai/i })).toBeVisible();
 
@@ -50,7 +51,7 @@ test.describe("Org Switcher - Active org update", () => {
 
 test.describe("Org Switcher - Single org user", () => {
   test("shows 'No other organizations' message", async ({ ownerPage }) => {
-    await ownerPage.goto("/ai");
+    await ownerPage.goto(`/${AI_ORG_SLUG}`);
 
     await expect(ownerPage.getByRole("button", { name: /zoonk ai/i })).toBeVisible();
 

--- a/apps/main/e2e/catalog-actions.test.ts
+++ b/apps/main/e2e/catalog-actions.test.ts
@@ -5,6 +5,7 @@ import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { expect, test } from "./fixtures";
 
 async function createTestCourseWithActivity() {
@@ -93,7 +94,7 @@ test.describe("Catalog Actions", () => {
 
     await mockNextActivityAPI(page, {
       activityPosition: 0,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -101,7 +102,7 @@ test.describe("Catalog Actions", () => {
       lessonSlug: lesson.slug,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
     await expect(page.getByRole("button", { name: /more options/i })).toBeVisible();
   });
@@ -111,7 +112,7 @@ test.describe("Catalog Actions", () => {
 
     await mockNextActivityAPI(page, {
       activityPosition: 0,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -119,7 +120,7 @@ test.describe("Catalog Actions", () => {
       lessonSlug: lesson.slug,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
     await openMoreOptions(page);
     await expect(page.getByRole("button", { name: /send feedback/i })).toBeVisible();
@@ -130,7 +131,7 @@ test.describe("Catalog Actions", () => {
 
     await mockNextActivityAPI(page, {
       activityPosition: 0,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -138,7 +139,7 @@ test.describe("Catalog Actions", () => {
       lessonSlug: lesson.slug,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
     await openMoreOptions(page);
     await page.getByRole("button", { name: /send feedback/i }).click();
@@ -153,7 +154,7 @@ test.describe("Catalog Actions", () => {
 
     await mockNextActivityAPI(page, {
       activityPosition: 0,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -161,7 +162,7 @@ test.describe("Catalog Actions", () => {
       lessonSlug: lesson.slug,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`);
 
     await expect(page.getByRole("button", { name: /more options/i })).toBeVisible();
   });
@@ -171,7 +172,7 @@ test.describe("Catalog Actions", () => {
 
     await mockNextActivityAPI(page, {
       activityPosition: 0,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -179,7 +180,7 @@ test.describe("Catalog Actions", () => {
       lessonSlug: lesson.slug,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
     await expect(page.getByRole("button", { name: /more options/i })).toBeVisible();
   });
@@ -189,7 +190,7 @@ test.describe("Catalog Actions", () => {
 
     await mockNextActivityAPI(page, {
       activityPosition: 0,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -197,7 +198,7 @@ test.describe("Catalog Actions", () => {
       lessonSlug: lesson.slug,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
     await openMoreOptions(page);
     await expect(page.getByRole("menuitemradio", { name: /^helpful$/i })).toBeVisible();
@@ -209,7 +210,7 @@ test.describe("Catalog Actions", () => {
 
     await mockNextActivityAPI(page, {
       activityPosition: 0,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -217,7 +218,7 @@ test.describe("Catalog Actions", () => {
       lessonSlug: lesson.slug,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
     await openMoreOptions(page);
     await page.getByRole("menuitemradio", { name: /^helpful$/i }).click();
@@ -230,7 +231,7 @@ test.describe("Catalog Actions", () => {
 
     await mockNextActivityAPI(page, {
       activityPosition: 0,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -238,7 +239,7 @@ test.describe("Catalog Actions", () => {
       lessonSlug: lesson.slug,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
     await openMoreOptions(page);
     await page.getByRole("menuitemradio", { name: /^helpful$/i }).click();
@@ -254,7 +255,7 @@ test.describe("Catalog Actions", () => {
 
     await mockNextActivityAPI(page, {
       activityPosition: 0,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -262,7 +263,7 @@ test.describe("Catalog Actions", () => {
       lessonSlug: lesson.slug,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
     await openMoreOptions(page);
     await page.getByRole("menuitemradio", { name: /^helpful$/i }).click();
@@ -283,7 +284,7 @@ test.describe("Catalog Actions", () => {
 
     await mockNextActivityAPI(page, {
       activityPosition: 0,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -291,7 +292,7 @@ test.describe("Catalog Actions", () => {
       lessonSlug: lesson.slug,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`);
 
     await openMoreOptions(page);
     await expect(page.getByRole("menuitemradio", { name: /^helpful$/i })).toBeVisible();
@@ -303,7 +304,7 @@ test.describe("Catalog Actions", () => {
 
     await mockNextActivityAPI(page, {
       activityPosition: 0,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -311,7 +312,7 @@ test.describe("Catalog Actions", () => {
       lessonSlug: lesson.slug,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
     await openMoreOptions(page);
     await expect(page.getByRole("menuitemradio", { name: /^helpful$/i })).toBeVisible();
@@ -323,7 +324,7 @@ test.describe("Catalog Actions", () => {
 
     await mockNextActivityAPI(page, {
       activityPosition: 0,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -331,7 +332,7 @@ test.describe("Catalog Actions", () => {
       lessonSlug: lesson.slug,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
     await openMoreOptions(page);
     await page.getByRole("menuitemradio", { name: /^helpful$/i }).click();

--- a/apps/main/e2e/continue-activity-link.test.ts
+++ b/apps/main/e2e/continue-activity-link.test.ts
@@ -5,6 +5,7 @@ import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { expect, test } from "./fixtures";
 
 async function createTestCourseWithActivity() {
@@ -86,7 +87,7 @@ test.describe("Continue Activity Link", () => {
 
     await mockNextActivityAPI(page, {
       activityPosition: 0,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -94,7 +95,7 @@ test.describe("Continue Activity Link", () => {
       lessonSlug: lesson.slug,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
     const startLink = page.getByRole("link", { name: /^start$/i });
     await expect(startLink).toBeVisible();
@@ -105,7 +106,7 @@ test.describe("Continue Activity Link", () => {
 
     await mockNextActivityAPI(page, {
       activityPosition: 0,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -113,7 +114,7 @@ test.describe("Continue Activity Link", () => {
       lessonSlug: lesson.slug,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
     const startLink = page.getByRole("link", { name: /^start$/i });
     await expect(startLink).toBeVisible();
@@ -127,7 +128,7 @@ test.describe("Continue Activity Link", () => {
 
     await mockNextActivityAPI(page, {
       activityPosition: 0,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -135,7 +136,7 @@ test.describe("Continue Activity Link", () => {
       lessonSlug: lesson.slug,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`);
 
     const startLink = page.getByRole("link", { name: /^start$/i });
     await expect(startLink).toBeVisible();
@@ -146,7 +147,7 @@ test.describe("Continue Activity Link", () => {
 
     await mockNextActivityAPI(page, {
       activityPosition: 0,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -154,7 +155,7 @@ test.describe("Continue Activity Link", () => {
       lessonSlug: lesson.slug,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
     const startLink = page.getByRole("link", { name: /^start$/i });
     await expect(startLink).toBeVisible();
@@ -164,13 +165,13 @@ test.describe("Continue Activity Link", () => {
     const { chapter, course } = await createTestCourseWithActivity();
     await mockNoActivitiesAPI(page);
 
-    await page.goto(`/b/ai/c/${course.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
     const startLink = page.getByRole("link", { name: /^start$/i });
     await expect(startLink).toBeVisible();
     await expect(startLink).toHaveAttribute(
       "href",
-      expect.stringContaining(`/b/ai/c/${course.slug}/ch/${chapter.slug}`),
+      expect.stringContaining(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`),
     );
   });
 
@@ -178,7 +179,7 @@ test.describe("Continue Activity Link", () => {
     const { chapter, course, lesson } = await createTestCourseWithActivity();
     await mockNoActivitiesAPI(page);
 
-    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`);
 
     const startLink = page.getByRole("link", { name: /^start$/i });
     await expect(startLink).toBeVisible();
@@ -192,7 +193,7 @@ test.describe("Continue Activity Link", () => {
     const { chapter, course, lesson } = await createTestCourseWithActivity();
     await mockNoActivitiesAPI(page);
 
-    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
     const startLink = page.getByRole("link", { name: /^start$/i });
     await expect(startLink).toBeVisible();
@@ -218,7 +219,7 @@ test.describe("Continue Activity Link", () => {
 
     await mockNextActivityAPI(authenticatedPage, {
       activityPosition: 1,
-      brandSlug: "ai",
+      brandSlug: AI_ORG_SLUG,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -226,7 +227,7 @@ test.describe("Continue Activity Link", () => {
       lessonSlug: lesson.slug,
     });
 
-    await authenticatedPage.goto(`/b/ai/c/${course.slug}`);
+    await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
     const continueLink = authenticatedPage.getByRole("link", { name: /^continue$/i });
     await expect(continueLink).toBeVisible();

--- a/packages/db/src/prisma/seed/orgs.ts
+++ b/packages/db/src/prisma/seed/orgs.ts
@@ -1,3 +1,4 @@
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { type Organization, type PrismaClient } from "../../generated/prisma/client";
 import { type SeedUsers } from "./users";
 
@@ -22,10 +23,10 @@ export async function seedOrganizations(
           ],
         },
         name: "Zoonk AI",
-        slug: "ai",
+        slug: AI_ORG_SLUG,
       },
       update: {},
-      where: { slug: "ai" },
+      where: { slug: AI_ORG_SLUG },
     }),
     prisma.organization.upsert({
       create: {


### PR DESCRIPTION
## Summary
- Replace all hard-coded `"ai"` string literals with the `AI_ORG_SLUG` constant from `@zoonk/utils/constants`
- Affects seed data, workflow tests, editor e2e tests, and main app e2e tests (20 files)

## Test plan
- [x] `pnpm turbo quality:fix` — 0 warnings, 0 errors
- [x] `pnpm typecheck` — all packages pass
- [x] `pnpm knip --production` — clean
- [x] `pnpm test` — all 623 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hard-coded org slug values with a shared constant to centralize configuration and reduce brittle tests. Updates URLs, mocks, and expectations across tests and seed data with no behavior changes.

- **Refactors**
  - Use the org slug constant from @zoonk/utils/constants in editor/main e2e, workflow tests, and org seeding.
  - Replace literal paths, regexes, and mock values with constant-based templates.
  - Keeps current behavior while allowing the slug to change in one place.

<sup>Written for commit 282e295885a5e47103c3f8e0c936826c14a8d6a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

