### PR TITLE
refactor(ui): auto-preventDefault in useKeyboardCallback

### DIFF
--- a/apps/main/src/components/activity-player/use-player-keyboard.ts
+++ b/apps/main/src/components/activity-player/use-player-keyboard.ts
@@ -63,7 +63,7 @@ export function usePlayerKeyboard({
 }: PlayerKeyboardParams) {
   useKeyboardCallback(
     "Enter",
-    (event) => {
+    () => {
       const action = getEnterAction({
         hasAnswer,
         onCheck,
@@ -74,43 +74,43 @@ export function usePlayerKeyboard({
         phase,
       });
 
-      if (action) {
-        event.preventDefault();
-        action();
+      if (!action) {
+        return false;
       }
+      action();
     },
     { mode: "none" },
   );
 
   useKeyboardCallback(
     "r",
-    (event) => {
-      if (phase === "completed") {
-        event.preventDefault();
-        onRestart();
+    () => {
+      if (phase !== "completed") {
+        return false;
       }
+      onRestart();
     },
     { ignoreEditable: true, mode: "none" },
   );
 
   useKeyboardCallback(
     "ArrowRight",
-    (event) => {
-      if (phase === "playing" && isStaticStep) {
-        event.preventDefault();
-        onNavigateNext();
+    () => {
+      if (phase !== "playing" || !isStaticStep) {
+        return false;
       }
+      onNavigateNext();
     },
     { mode: "none" },
   );
 
   useKeyboardCallback(
     "ArrowLeft",
-    (event) => {
-      if (phase === "playing" && isStaticStep) {
-        event.preventDefault();
-        onNavigatePrev();
+    () => {
+      if (phase !== "playing" || !isStaticStep) {
+        return false;
       }
+      onNavigatePrev();
     },
     { mode: "none" },
   );

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -93,14 +93,10 @@ function SidebarProvider({
   );
 
   // Adds a keyboard shortcut to toggle the sidebar.
-  useKeyboardCallback(
-    SIDEBAR_KEYBOARD_SHORTCUT,
-    (event) => {
-      event.preventDefault();
-      toggleSidebar();
-    },
-    { mode: "any", modifiers: { ctrlKey: true, metaKey: true } },
-  );
+  useKeyboardCallback(SIDEBAR_KEYBOARD_SHORTCUT, () => toggleSidebar(), {
+    mode: "any",
+    modifiers: { ctrlKey: true, metaKey: true },
+  });
 
   // We add a state so that we can do data-state="expanded" or "collapsed".
   // This makes it easier to style the sidebar with Tailwind classes.

--- a/packages/ui/src/components/wizard.tsx
+++ b/packages/ui/src/components/wizard.tsx
@@ -232,37 +232,33 @@ export function useWizardKeyboard({
   onNext: () => void;
   onSubmit: () => void;
 }) {
-  useKeyboardCallback("Escape", (event) => {
-    event.preventDefault();
-    onClose();
-  });
+  useKeyboardCallback("Escape", () => onClose());
 
   useKeyboardCallback(
     "ArrowLeft",
-    (event) => {
-      if (!isFirstStep) {
-        event.preventDefault();
-        onBack();
+    () => {
+      if (isFirstStep) {
+        return false;
       }
+      onBack();
     },
     { mode: "none" },
   );
 
   useKeyboardCallback(
     "ArrowRight",
-    (event) => {
-      if (canProceed && !isLastStep) {
-        event.preventDefault();
-        onNext();
+    () => {
+      if (!canProceed || isLastStep) {
+        return false;
       }
+      onNext();
     },
     { mode: "none" },
   );
 
   useKeyboardCallback(
     "Enter",
-    (event) => {
-      event.preventDefault();
+    () => {
       if (isLastStep) {
         onSubmit();
       } else {

--- a/packages/ui/src/hooks/use-command-palette-search.ts
+++ b/packages/ui/src/hooks/use-command-palette-search.ts
@@ -34,17 +34,10 @@ export function useCommandPaletteSearch<TResults>(options: {
   const [isPending, startTransition] = useTransition();
   const requestIdRef = useRef(0);
 
-  useKeyboardCallback(
-    "k",
-    (event) => {
-      event.preventDefault();
-      setIsOpen((prev) => !prev);
-    },
-    {
-      mode: "any",
-      modifiers: { ctrlKey: true, metaKey: true },
-    },
-  );
+  useKeyboardCallback("k", () => setIsOpen((prev) => !prev), {
+    mode: "any",
+    modifiers: { ctrlKey: true, metaKey: true },
+  });
 
   const open = useCallback(() => setIsOpen(true), []);
   const toggle = useCallback(() => setIsOpen((prev) => !prev), []);


### PR DESCRIPTION
## Summary

- `useKeyboardCallback` now calls `event.preventDefault()` automatically — callbacks no longer receive the event
- Callbacks return `void` (handled, preventDefault called) or `false` (not handled, preventDefault skipped)
- Simplified all 10 call sites across sidebar, command palette, wizard, and activity player

## Test plan

- [x] `pnpm turbo quality:fix` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] e2e tests pass for api, main, and editor (3x each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored useKeyboardCallback to auto-call preventDefault and simplify handler signatures. Updated all consumers to return false when a key is not handled, removing boilerplate and making shortcuts consistent.

- **Refactors**
  - useKeyboardCallback now calls preventDefault by default; callbacks no longer receive the event.
  - Callbacks return void (handled) or false (not handled, skip preventDefault).
  - Updated 10 call sites in sidebar, command palette, wizard, and activity player.

- **Migration**
  - Remove the event argument from keyboard callbacks.
  - Return false in callbacks when you want to allow default browser behavior.
  - Existing options (modifiers, mode, ignoreEditable) are unchanged.

<sup>Written for commit 0dedc8a07a2859376de627ab91ccbec91f041ddb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

