### PR TITLE
fix(main): revalidate home page after activity completion

### DIFF
--- a/apps/main/e2e/continue-learning-revalidation.test.ts
+++ b/apps/main/e2e/continue-learning-revalidation.test.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { createE2EUser, getAiOrganization } from "@zoonk/e2e/helpers";
+import { activityFixture, activityProgressFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { expect, test } from "./fixtures";
+
+async function createCourseWithThreeActivities() {
+  const org = await getAiOrganization();
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-cl-reval-course-${uniqueId}`,
+    title: `E2E CL Reval Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-cl-reval-chapter-${uniqueId}`,
+    title: `E2E CL Reval Chapter ${uniqueId}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    description: `E2E continue learning revalidation lesson ${uniqueId}`,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-cl-reval-lesson-${uniqueId}`,
+    title: `E2E CL Reval Lesson ${uniqueId}`,
+  });
+
+  // Activity 0: will be pre-completed by the user
+  const activity0 = await activityFixture({
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "background",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 0,
+    title: `Completed Act ${uniqueId}`,
+  });
+
+  // Activity 1: the current "next" activity (static, user will complete it in the test)
+  const activity1 = await activityFixture({
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "background",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 1,
+    title: `Current Next ${uniqueId}`,
+  });
+
+  // Activity 2: will become "next" after completing activity 1
+  const activity2 = await activityFixture({
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "background",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 2,
+    title: `After Next ${uniqueId}`,
+  });
+
+  // Add a static step to activity 1 so we can complete it
+  await stepFixture({
+    activityId: activity1.id,
+    content: { text: `Step body ${uniqueId}`, title: `Step Title ${uniqueId}`, variant: "text" },
+    isPublished: true,
+    position: 0,
+  });
+
+  const activityUrl = `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/1`;
+
+  return { activity0, activity1, activity2, activityUrl, course, uniqueId };
+}
+
+test.describe("Continue Learning Revalidation", () => {
+  test("home page updates continue learning after completing an activity", async ({
+    baseURL,
+    browser,
+  }) => {
+    const user = await createE2EUser(baseURL!);
+    const browserContext = await browser.newContext({ storageState: user.storageState });
+    const page = await browserContext.newPage();
+    const { activity0, course, uniqueId } = await createCourseWithThreeActivities();
+
+    // Pre-complete activity 0 so getContinueLearning returns this course with activity 1 as "next"
+    await Promise.all([
+      activityProgressFixture({
+        activityId: activity0.id,
+        completedAt: new Date(),
+        durationSeconds: 60,
+        userId: user.id,
+      }),
+      prisma.courseUser.create({ data: { courseId: course.id, userId: user.id } }),
+    ]);
+
+    // 1. Navigate to home page (full load)
+    await page.goto("/");
+    const nextLink = page.getByRole("link", {
+      name: new RegExp(`Next:.*Current Next ${uniqueId}`),
+    });
+    await expect(nextLink.first()).toBeVisible();
+
+    // 2. Click the continue learning card link (client-side navigation)
+    await nextLink.first().click();
+    await page.waitForURL(new RegExp(`/a/1`));
+    await page.waitForLoadState("networkidle");
+
+    // 3. Complete the static activity
+    await page.keyboard.press("ArrowRight");
+    await expect(page.getByRole("status")).toBeVisible();
+    await expect(page.getByText(/completed/i)).toBeVisible();
+
+    // 4. Click "Back to Lesson" (client-side navigation)
+    await page.getByRole("link", { name: /back to lesson/i }).click();
+    await page.waitForURL(new RegExp(`e2e-cl-reval-lesson-${uniqueId}`));
+
+    // 5. Click the Home link in the navbar (client-side navigation — Router Cache)
+    await page.getByRole("link", { name: /home page/i }).click();
+    await page.waitForURL(/\/$/);
+
+    // 6. Continue learning should show the NEW next activity, not the old one
+    await expect(page.getByText(new RegExp(`Next:.*After Next ${uniqueId}`)).first()).toBeVisible();
+
+    await browserContext.close();
+  });
+});

--- a/apps/main/src/components/activity-player/submit-completion-action.ts
+++ b/apps/main/src/components/activity-player/submit-completion-action.ts
@@ -11,6 +11,8 @@ import { validateAnswers } from "@zoonk/core/player/validate-answers";
 import { prisma } from "@zoonk/db";
 import { type BeltLevelResult } from "@zoonk/utils/belt-level";
 import { safeAsync } from "@zoonk/utils/error";
+import { getLocale } from "next-intl/server";
+import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 import { hasNegativeDimension } from "./has-negative-dimension";
 
@@ -118,6 +120,9 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
   if (error || !data) {
     return { status: "error" };
   }
+
+  const locale = await getLocale();
+  revalidatePath(`/${locale}`);
 
   return {
     belt: data.belt,


### PR DESCRIPTION
## Summary
- Call `revalidatePath` in the activity completion server action to invalidate the Router Cache for the home page
- Add e2e test that reproduces the bug: navigate home → click continue learning → complete activity → back to lesson → click home navbar link → verify the "Next" card updated

## Test plan
- [x] e2e test fails without fix (stale Router Cache serves old "Next" activity)
- [x] e2e test passes with fix (5/5 runs, no flakiness)
- [x] Full main e2e suite passes (374/374)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revalidates the home page after activity completion so the “Continue learning” card shows the correct next activity on return to Home. Fixes stale Router Cache when navigating back via the navbar.

- **Bug Fixes**
  - Call revalidatePath(`/${locale}`) in submitCompletion to invalidate the home page.
  - Add e2e test that completes an activity and verifies the Home “Next” card updates.

<sup>Written for commit 83ad8c55b74bba75a06dfda6048b6be0d4a8bcda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

