### PR TITLE
fix(main): switch course list from cursor to offset pagination

### DIFF
--- a/apps/main/src/app/[locale]/(catalog)/courses/actions.ts
+++ b/apps/main/src/app/[locale]/(catalog)/courses/actions.ts
@@ -5,13 +5,13 @@ import { type CourseCategory } from "@zoonk/utils/categories";
 
 export async function loadMoreCourses(params: {
   category?: CourseCategory;
-  cursor: number;
   language: string;
+  offset: number;
 }) {
   const courses = await listCourses({
     category: params.category,
-    cursor: params.cursor,
     language: params.language,
+    offset: params.offset,
   });
 
   return courses;

--- a/apps/main/src/app/[locale]/(catalog)/courses/course-list-client.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/courses/course-list-client.tsx
@@ -42,9 +42,8 @@ export function CourseListClient({
     items: courses,
     isLoading,
     sentryRef,
-  } = useInfiniteList<CourseWithOrg, number>({
-    fetchMore: (cursor) => loadMoreCourses({ category, cursor, language }),
-    getCursor: (course) => course.id,
+  } = useInfiniteList<CourseWithOrg>({
+    fetchMore: (offset) => loadMoreCourses({ category, language, offset }),
     getKey: (course) => course.id,
     initialItems: initialCourses,
     limit,

--- a/apps/main/src/data/courses/list-courses.ts
+++ b/apps/main/src/data/courses/list-courses.ts
@@ -15,7 +15,7 @@ const cachedListCourses = cache(
     language: string,
     limit: number,
     category?: CourseCategory,
-    cursor?: number,
+    offset?: number,
   ): Promise<CourseWithOrg[]> => {
     const courses = await prisma.course.findMany({
       include: {
@@ -25,10 +25,7 @@ const cachedListCourses = cache(
       },
       orderBy: [{ users: { _count: "desc" } }, { createdAt: "desc" }],
       take: limit,
-      ...(cursor && {
-        cursor: { id: cursor },
-        skip: 1,
-      }),
+      ...(offset && { skip: offset }),
       where: {
         isPublished: true,
         language,
@@ -45,10 +42,10 @@ const cachedListCourses = cache(
 
 export function listCourses(params: {
   category?: CourseCategory;
-  cursor?: number;
   language: string;
   limit?: number;
+  offset?: number;
 }): Promise<CourseWithOrg[]> {
   const limit = clampQueryItems(params.limit ?? LIST_COURSES_LIMIT);
-  return cachedListCourses(params.language, limit, params.category, params.cursor);
+  return cachedListCourses(params.language, limit, params.category, params.offset);
 }


### PR DESCRIPTION
## Summary

- Prisma cursor-based pagination doesn't work with `orderBy` on relation counts (`users._count`), causing infinite scroll to never load more items
- Switched `listCourses` from cursor-based to offset-based pagination
- Simplified `useInfiniteList` hook to track offset internally (removed `getCursor`/`TCursor`)

## Test plan

- [x] Integration test for offset pagination in `list-courses.test.ts`
- [x] E2E test for infinite scroll in `courses.test.ts` (scrolls to bottom, verifies more items load)
- [x] All 374 main e2e tests pass
- [x] All 435 unit/integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched course listing to offset-based pagination to fix infinite scroll with popularity sorting. Infinite loading now consistently fetches more courses.

- **Bug Fixes**
  - Replaced cursor pagination with offset in listCourses to work with orderBy on relation counts (users._count).
  - Added tests: integration for offset pagination and E2E for infinite scroll.

- **Migration**
  - useInfiniteList API changed: remove getCursor/TCursor; fetchMore now receives an offset number. Update call sites accordingly.

<sup>Written for commit 2920cd54c03625b568cc4221e21426f6e957de36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

