### PR TITLE
feat(main): track course users on activity completion and denormalize userCount

### DIFF
--- a/apps/main/e2e/continue-learning-revalidation.test.ts
+++ b/apps/main/e2e/continue-learning-revalidation.test.ts
@@ -101,6 +101,10 @@ test.describe("Continue Learning Revalidation", () => {
         userId: user.id,
       }),
       prisma.courseUser.create({ data: { courseId: course.id, userId: user.id } }),
+      prisma.course.update({
+        data: { userCount: { increment: 1 } },
+        where: { id: course.id },
+      }),
     ]);
 
     // 1. Navigate to home page (full load)

--- a/apps/main/src/app/[locale]/(catalog)/courses/actions.ts
+++ b/apps/main/src/app/[locale]/(catalog)/courses/actions.ts
@@ -5,13 +5,13 @@ import { type CourseCategory } from "@zoonk/utils/categories";
 
 export async function loadMoreCourses(params: {
   category?: CourseCategory;
+  cursor: number;
   language: string;
-  offset: number;
 }) {
   const courses = await listCourses({
     category: params.category,
+    cursor: params.cursor,
     language: params.language,
-    offset: params.offset,
   });
 
   return courses;

--- a/apps/main/src/app/[locale]/(catalog)/courses/course-list-client.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/courses/course-list-client.tsx
@@ -43,7 +43,7 @@ export function CourseListClient({
     isLoading,
     sentryRef,
   } = useInfiniteList<CourseWithOrg>({
-    fetchMore: (offset) => loadMoreCourses({ category, language, offset }),
+    fetchMore: (cursor) => loadMoreCourses({ category, cursor: Number(cursor), language }),
     getKey: (course) => course.id,
     initialItems: initialCourses,
     limit,

--- a/apps/main/src/components/activity-player/submit-completion-action.ts
+++ b/apps/main/src/components/activity-player/submit-completion-action.ts
@@ -57,6 +57,7 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
       select: {
         id: true,
         kind: true,
+        lesson: { select: { chapter: { select: { courseId: true } } } },
         organizationId: true,
         steps: {
           orderBy: { position: "asc" },
@@ -107,6 +108,7 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
 
     return submitActivityCompletion({
       activityId: activity.id,
+      courseId: activity.lesson.chapter.courseId,
       durationSeconds,
       isChallenge,
       organizationId: activity.organizationId,

--- a/apps/main/src/data/courses/list-courses.ts
+++ b/apps/main/src/data/courses/list-courses.ts
@@ -15,7 +15,7 @@ const cachedListCourses = cache(
     language: string,
     limit: number,
     category?: CourseCategory,
-    offset?: number,
+    cursor?: number,
   ): Promise<CourseWithOrg[]> => {
     const courses = await prisma.course.findMany({
       include: {
@@ -23,9 +23,9 @@ const cachedListCourses = cache(
           select: { slug: true },
         },
       },
-      orderBy: [{ users: { _count: "desc" } }, { createdAt: "desc" }],
+      orderBy: [{ userCount: "desc" }, { id: "desc" }],
       take: limit,
-      ...(offset && { skip: offset }),
+      ...(cursor && { cursor: { id: cursor }, skip: 1 }),
       where: {
         isPublished: true,
         language,
@@ -42,10 +42,10 @@ const cachedListCourses = cache(
 
 export function listCourses(params: {
   category?: CourseCategory;
+  cursor?: number;
   language: string;
   limit?: number;
-  offset?: number;
 }): Promise<CourseWithOrg[]> {
   const limit = clampQueryItems(params.limit ?? LIST_COURSES_LIMIT);
-  return cachedListCourses(params.language, limit, params.category, params.offset);
+  return cachedListCourses(params.language, limit, params.category, params.cursor);
 }

--- a/packages/db/src/prisma/migrations/20260220182636_add_course_user_count/migration.sql
+++ b/packages/db/src/prisma/migrations/20260220182636_add_course_user_count/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "courses" ADD COLUMN     "user_count" INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill existing user counts
+UPDATE courses SET user_count = (SELECT COUNT(*) FROM course_users WHERE course_id = courses.id);

--- a/packages/db/src/prisma/models/courses.prisma
+++ b/packages/db/src/prisma/models/courses.prisma
@@ -60,6 +60,7 @@ model Course {
   generationStatus  GenerationStatus         @default(completed) @map("generation_status")
   generationRunId   String?                  @map("generation_run_id")
   imageUrl          String?                  @map("image_url")
+  userCount         Int                      @default(0) @map("user_count")
   createdAt         DateTime                 @default(now()) @map("created_at")
   updatedAt         DateTime                 @default(now()) @updatedAt @map("updated_at")
   alternativeTitles CourseAlternativeTitle[]

--- a/packages/db/src/prisma/seed/course-users.ts
+++ b/packages/db/src/prisma/seed/course-users.ts
@@ -55,4 +55,15 @@ export async function seedCourseUsers(
       },
     });
   }
+
+  // Sync userCount for all enrolled courses
+  await Promise.all(
+    courses.map(async (course) => {
+      const count = await prisma.courseUser.count({ where: { courseId: course.id } });
+      await prisma.course.update({
+        data: { userCount: count },
+        where: { id: course.id },
+      });
+    }),
+  );
 }

--- a/packages/e2e/src/helpers.ts
+++ b/packages/e2e/src/helpers.ts
@@ -330,5 +330,9 @@ async function createE2EProgressData(userId: number): Promise<void> {
     prisma.courseUser.create({
       data: { courseId: course.id, userId },
     }),
+    prisma.course.update({
+      data: { userCount: { increment: 1 } },
+      where: { id: course.id },
+    }),
   ]);
 }

--- a/packages/testing/src/fixtures/courses.ts
+++ b/packages/testing/src/fixtures/courses.ts
@@ -29,6 +29,7 @@ export function courseAttrs(attrs?: Partial<Course>): Omit<
     slug: `test-course-${randomUUID()}`,
     targetLanguage: null,
     title: "Test Course",
+    userCount: 0,
     userId: null,
     ...rest,
   };
@@ -50,12 +51,18 @@ export async function courseCategoryFixture(attrs: Omit<CourseCategory, "id" | "
 }
 
 export async function courseUserFixture(attrs: Omit<CourseUser, "id" | "startedAt">) {
-  const courseUser = await prisma.courseUser.create({
-    data: {
-      courseId: attrs.courseId,
-      userId: attrs.userId,
-    },
-  });
+  const [courseUser] = await prisma.$transaction([
+    prisma.courseUser.create({
+      data: {
+        courseId: attrs.courseId,
+        userId: attrs.userId,
+      },
+    }),
+    prisma.course.update({
+      data: { userCount: { increment: 1 } },
+      where: { id: attrs.courseId },
+    }),
+  ]);
 
   return courseUser;
 }


### PR DESCRIPTION
## Summary

- Auto-create `CourseUser` records on first activity completion per course (inside existing transaction with `skipDuplicates`)
- Denormalize `userCount` on `Course` table, enabling cursor-based pagination instead of offset
- Switch `listCourses` from `{ users: { _count: "desc" } }` ordering to `{ userCount: "desc" }` with cursor pagination
- Update `useInfiniteList` hook from offset-based to cursor-based fetching
- Simplify e2e course tests (direct `userCount` instead of creating 50 fake users)

## Test plan

- [x] Integration: all 16 `submitActivityCompletion` tests pass (12 updated + 2 new: CourseUser creation, idempotency)
- [x] Integration: `listCourses` tests updated for cursor pagination and explicit `userCount` sorting
- [x] E2E: main (375), editor (193), api (55) — all pass 3x with zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tracks course enrollment on first activity completion and denormalizes Course.userCount to speed up course listings with cursor-based pagination. listCourses now sorts by userCount and uses cursors; the infinite list hook was updated.

- **New Features**
  - Create CourseUser on first completion; increment userCount once (idempotent).
  - Add Course.userCount column with backfill; seed syncs counts.
  - listCourses: order by userCount desc and paginate by cursor (course id).

- **Migration**
  - Run Prisma migration to add user_count and backfill.
  - Update submitActivityCompletion calls to include courseId.
  - Switch consumers to cursor-based fetching (useInfiniteList fetchMore now takes a cursor).

<sup>Written for commit a65463eb2bc9f86235832264425d535a51ef3543. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

