### PR TITLE
feat(main): replace sort order tap-to-sequence with drag-and-drop

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1277,7 +1277,6 @@ msgid "{item}. {result}."
 msgstr "{item}. {result}."
 
 #: src/components/activity-player/arrange-words.tsx
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "vPyO9S"
 msgid "Position {position}: {item}. Tap to remove."
 msgstr "Position {position}: {item}. Tap to remove."
@@ -1534,19 +1533,19 @@ msgid "Image options"
 msgstr "Image options"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "/CFOL2"
-msgid "Tap items in the correct order"
-msgstr "Tap items in the correct order"
-
-#: src/components/activity-player/sort-order-step.tsx
-msgctxt "1za4AW"
-msgid "{item}. Tap to select as position {nextPosition}."
-msgstr "{item}. Tap to select as position {nextPosition}."
+msgctxt "9lc1oV"
+msgid "Drag items into the correct order"
+msgstr "Drag items into the correct order"
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "p5llOK"
 msgid "Sort items"
 msgstr "Sort items"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "VA8c/A"
+msgid "Correct order:"
+msgstr "Correct order:"
 
 #: src/components/activity-player/timeline-visual.tsx
 msgctxt "zWkvNO"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1277,7 +1277,6 @@ msgid "{item}. {result}."
 msgstr "{item}. {result}."
 
 #: src/components/activity-player/arrange-words.tsx
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "vPyO9S"
 msgid "Position {position}: {item}. Tap to remove."
 msgstr "Posición {position}: {item}. Toca para quitar."
@@ -1534,19 +1533,19 @@ msgid "Image options"
 msgstr "Opciones de imagen"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "/CFOL2"
-msgid "Tap items in the correct order"
-msgstr "Toca los elementos en el orden correcto"
-
-#: src/components/activity-player/sort-order-step.tsx
-msgctxt "1za4AW"
-msgid "{item}. Tap to select as position {nextPosition}."
-msgstr "{item}. Toca para seleccionar como posición {nextPosition}."
+msgctxt "9lc1oV"
+msgid "Drag items into the correct order"
+msgstr "Arrastra los elementos en el orden correcto"
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "p5llOK"
 msgid "Sort items"
 msgstr "Ordenar elementos"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "VA8c/A"
+msgid "Correct order:"
+msgstr "Orden correcto:"
 
 #: src/components/activity-player/timeline-visual.tsx
 msgctxt "zWkvNO"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1277,7 +1277,6 @@ msgid "{item}. {result}."
 msgstr "{item}. {result}."
 
 #: src/components/activity-player/arrange-words.tsx
-#: src/components/activity-player/sort-order-step.tsx
 msgctxt "vPyO9S"
 msgid "Position {position}: {item}. Tap to remove."
 msgstr "Posição {position}: {item}. Toque para remover."
@@ -1534,19 +1533,19 @@ msgid "Image options"
 msgstr "Opções de imagem"
 
 #: src/components/activity-player/sort-order-step.tsx
-msgctxt "/CFOL2"
-msgid "Tap items in the correct order"
-msgstr "Toque nos itens na ordem correta"
-
-#: src/components/activity-player/sort-order-step.tsx
-msgctxt "1za4AW"
-msgid "{item}. Tap to select as position {nextPosition}."
-msgstr "{item}. Toque para selecionar como posição {nextPosition}."
+msgctxt "9lc1oV"
+msgid "Drag items into the correct order"
+msgstr "Arraste os itens para a ordem correta"
 
 #: src/components/activity-player/sort-order-step.tsx
 msgctxt "p5llOK"
 msgid "Sort items"
 msgstr "Ordenar itens"
+
+#: src/components/activity-player/sort-order-step.tsx
+msgctxt "VA8c/A"
+msgid "Correct order:"
+msgstr "Ordem correta:"
 
 #: src/components/activity-player/timeline-visual.tsx
 msgctxt "zWkvNO"

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -16,6 +16,9 @@
   },
   "dependencies": {
     "@dagrejs/dagre": "2.0.4",
+    "@dnd-kit/core": "6.3.1",
+    "@dnd-kit/sortable": "10.0.0",
+    "@dnd-kit/utilities": "3.2.2",
     "@tabler/icons-react": "3.36.1",
     "@vercel/analytics": "1.6.1",
     "@xstate/store": "3.15.0",

--- a/apps/main/src/components/activity-player/player-reducer.test.ts
+++ b/apps/main/src/components/activity-player/player-reducer.test.ts
@@ -134,6 +134,25 @@ describe(createInitialState, () => {
     const state = createInitialState(buildChallengeActivity());
     expect(state.dimensions).toEqual({ Courage: 0, Diplomacy: 0 });
   });
+
+  test("pre-populates selectedAnswers for sortOrder steps", () => {
+    const sortItems = ["Banana", "Apple", "Cherry"];
+    const steps = [buildStep({ id: "sort-1", kind: "sortOrder", sortOrderItems: sortItems })];
+    const state = createInitialState(buildActivity({ steps }));
+    expect(state.selectedAnswers["sort-1"]).toEqual({
+      kind: "sortOrder",
+      userOrder: sortItems,
+    });
+  });
+
+  test("does not pre-populate selectedAnswers for non-sortOrder steps", () => {
+    const steps = [
+      buildStep({ id: "s1", kind: "static" }),
+      buildMultipleChoiceStep({ id: "mc-1" }),
+    ];
+    const state = createInitialState(buildActivity({ steps }));
+    expect(state.selectedAnswers).toEqual({});
+  });
 });
 
 describe("START_CHALLENGE", () => {
@@ -547,6 +566,27 @@ describe("RESTART", () => {
     const next = playerReducer(state, { type: "RESTART" });
     expect(next.activityId).toBe("my-activity");
     expect(next.steps).toEqual(steps);
+  });
+
+  test("re-seeds sortOrder answers on restart", () => {
+    const sortItems = ["Banana", "Apple", "Cherry"];
+    const steps = [
+      buildStep({ id: "sort-1", kind: "sortOrder", sortOrderItems: sortItems }),
+      buildMultipleChoiceStep({ id: "mc-1", position: 1 }),
+    ];
+    const state = buildState({
+      phase: "completed",
+      results: {},
+      selectedAnswers: {},
+      steps,
+    });
+
+    const next = playerReducer(state, { type: "RESTART" });
+    expect(next.selectedAnswers["sort-1"]).toEqual({
+      kind: "sortOrder",
+      userOrder: sortItems,
+    });
+    expect(next.selectedAnswers["mc-1"]).toBeUndefined();
   });
 
   test("resets to playing (not intro) for challenge activities", () => {

--- a/apps/main/src/components/activity-player/player-reducer.ts
+++ b/apps/main/src/components/activity-player/player-reducer.ts
@@ -109,6 +109,14 @@ function collectAllDimensions(steps: SerializedStep[]): DimensionInventory {
   return Object.fromEntries(effects.map((effect) => [effect.dimension, 0]));
 }
 
+function buildInitialAnswers(steps: SerializedStep[]): Record<string, SelectedAnswer> {
+  return Object.fromEntries(
+    steps
+      .filter((step) => step.kind === "sortOrder" && step.sortOrderItems.length > 0)
+      .map((step) => [step.id, { kind: "sortOrder" as const, userOrder: step.sortOrderItems }]),
+  );
+}
+
 export function createInitialState(activity: SerializedActivity): PlayerState {
   const dimensions = collectAllDimensions(activity.steps);
   const isChallenge = Object.keys(dimensions).length > 0;
@@ -120,7 +128,7 @@ export function createInitialState(activity: SerializedActivity): PlayerState {
     dimensions,
     phase: isChallenge ? "intro" : "playing",
     results: {},
-    selectedAnswers: {},
+    selectedAnswers: buildInitialAnswers(activity.steps),
     startedAt: now,
     stepStartedAt: now,
     stepTimings: {},
@@ -252,7 +260,7 @@ function handleRestart(state: PlayerState): PlayerState {
     dimensions: collectAllDimensions(state.steps),
     phase: "playing",
     results: {},
-    selectedAnswers: {},
+    selectedAnswers: buildInitialAnswers(state.steps),
     startedAt: now,
     stepStartedAt: now,
     stepTimings: {},

--- a/apps/main/src/components/activity-player/sort-order-step.tsx
+++ b/apps/main/src/components/activity-player/sort-order-step.tsx
@@ -24,7 +24,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
-import { useCallback, useEffect, useId, useMemo, useState } from "react";
+import { useCallback, useId, useMemo, useState } from "react";
 import { InlineFeedback } from "./inline-feedback";
 import { type SelectedAnswer, type StepResult } from "./player-reducer";
 import { QuestionText } from "./question-text";
@@ -240,17 +240,6 @@ export function SortOrderStep({
   const content = useMemo(() => parseStepContent("sortOrder", step.content), [step.content]);
   const replaceName = useReplaceName();
   const [items, setItems] = useState<SortItem[]>(() => initItems(step, result));
-
-  // Register the initial shuffled order as the answer on mount.
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional mount-only effect
-  useEffect(() => {
-    if (!result) {
-      onSelectAnswer(step.id, {
-        kind: "sortOrder",
-        userOrder: items.map((item) => item.text),
-      });
-    }
-  }, []); // oxlint-disable-line react-hooks/exhaustive-deps -- mount-only
 
   const handleReorder = useCallback(
     (reordered: SortItem[]) => {

--- a/apps/main/src/components/activity-player/sort-order-step.tsx
+++ b/apps/main/src/components/activity-player/sort-order-step.tsx
@@ -1,10 +1,30 @@
 "use client";
 
 import { type SerializedStep } from "@/data/activities/prepare-activity-data";
+import {
+  DndContext,
+  type DragEndEvent,
+  DragOverlay,
+  type DragStartEvent,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import { InlineFeedback } from "./inline-feedback";
 import { type SelectedAnswer, type StepResult } from "./player-reducer";
 import { QuestionText } from "./question-text";
@@ -12,118 +32,203 @@ import { ResultKbd } from "./result-kbd";
 import { InteractiveStepLayout } from "./step-layouts";
 import { useReplaceName } from "./user-name-context";
 
+type SortItem = { id: string; text: string };
+
 function getItemResultState(
   item: string,
   position: number,
-  correctItems: string[],
+  userOrder: string[],
 ): "correct" | "incorrect" {
-  return correctItems[position] === item ? "correct" : "incorrect";
+  return userOrder[position] === item ? "correct" : "incorrect";
 }
 
-function ItemButton({
+function SortableItem({
+  activeId,
+  index,
   item,
-  nextPosition,
-  onClick,
-  position,
-  resultState,
 }: {
-  item: string;
-  nextPosition: number;
-  onClick: () => void;
-  position: number | null;
-  resultState?: "correct" | "incorrect";
+  activeId: string | null;
+  index: number;
+  item: SortItem;
 }) {
-  const t = useExtracted();
-  const hasResult = resultState !== undefined;
-  const isSelected = position !== null;
+  const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({
+    id: item.id,
+  });
 
-  const ariaLabel = (() => {
-    if (hasResult) {
-      const result = resultState === "correct" ? t("Correct") : t("Incorrect");
-      return t("{item}. {result}.", { item, result });
-    }
-
-    if (isSelected) {
-      return t("Position {position}: {item}. Tap to remove.", {
-        item,
-        position: String(position + 1),
-      });
-    }
-
-    return t("{item}. Tap to select as position {nextPosition}.", {
-      item,
-      nextPosition: String(nextPosition),
-    });
-  })();
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
 
   return (
-    <button
-      aria-label={ariaLabel}
-      className={cn(
-        "flex min-h-11 items-center gap-3 rounded-lg border px-3 py-2 text-left transition-all duration-150 sm:px-4 sm:py-2.5",
-        hasResult && "pointer-events-none",
-        !hasResult &&
-          !isSelected &&
-          "border-border/50 hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 border-dashed outline-none focus-visible:ring-[3px]",
-        !hasResult && isSelected && "border-border",
-        resultState === "correct" && "border-l-success border-l-2",
-        resultState === "incorrect" && "border-l-destructive border-l-2",
-      )}
-      disabled={hasResult}
-      onClick={onClick}
-      type="button"
+    <div
+      className={cn("rounded-lg border", isDragging && "opacity-30")}
+      ref={setNodeRef}
+      role="listitem"
+      style={style}
     >
-      <ResultKbd isSelected={isSelected} resultState={resultState}>
-        {isSelected ? String(position + 1) : "\u00A0"}
-      </ResultKbd>
-
-      <span className="text-base">{item}</span>
-    </button>
-  );
-}
-
-function SortItemList({
-  correctItems,
-  items,
-  onToggle,
-  selections,
-}: {
-  correctItems?: string[];
-  items: string[];
-  onToggle: (item: string) => void;
-  selections: string[];
-}) {
-  const t = useExtracted();
-  const nextPosition = selections.length + 1;
-  const displayItems = correctItems ?? items;
-
-  return (
-    <div aria-label={t("Sort items")} className="flex flex-col gap-2" role="list">
-      {displayItems.map((item, index) => {
-        const resultState = correctItems ? getItemResultState(item, index, selections) : undefined;
-        const position = correctItems ? index : selections.indexOf(item);
-        const isSelected = position !== -1;
-
-        return (
-          <ItemButton
-            item={item}
-            // oxlint-disable-next-line react/no-array-index-key -- Items can repeat, no unique ID
-            key={`${item}-${index}`}
-            nextPosition={nextPosition}
-            onClick={() => onToggle(item)}
-            position={isSelected ? position : null}
-            resultState={resultState}
-          />
-        );
-      })}
+      <button
+        {...attributes}
+        {...listeners}
+        aria-label={item.text}
+        className={cn(
+          "flex min-h-11 w-full touch-none items-center gap-3 px-3 py-2 text-left select-none sm:px-4 sm:py-2.5",
+          !isDragging && "hover:bg-muted/50",
+          activeId ? "cursor-grabbing" : "cursor-grab",
+        )}
+        type="button"
+      >
+        <ResultKbd isSelected>{String(index + 1)}</ResultKbd>
+        <span className="text-base">{item.text}</span>
+      </button>
     </div>
   );
+}
+
+function DragOverlayItem({ index, item }: { index: number; item: SortItem }) {
+  return (
+    <div className="bg-background flex min-h-11 items-center gap-3 rounded-lg border px-3 py-2 text-left shadow-md sm:px-4 sm:py-2.5">
+      <ResultKbd isSelected>{String(index + 1)}</ResultKbd>
+      <span className="text-base">{item.text}</span>
+    </div>
+  );
+}
+
+function SortableItemList({
+  items,
+  onReorder,
+}: {
+  items: SortItem[];
+  onReorder: (reordered: SortItem[]) => void;
+}) {
+  const t = useExtracted();
+  const dndId = useId();
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    if (typeof navigator !== "undefined" && navigator.vibrate) {
+      navigator.vibrate(10);
+    }
+
+    setActiveId(String(event.active.id));
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      setActiveId(null);
+
+      if (!over || active.id === over.id) {
+        return;
+      }
+
+      const oldIndex = items.findIndex((item) => item.id === String(active.id));
+      const newIndex = items.findIndex((item) => item.id === String(over.id));
+
+      if (oldIndex === -1 || newIndex === -1) {
+        return;
+      }
+
+      onReorder(arrayMove(items, oldIndex, newIndex));
+    },
+    [items, onReorder],
+  );
+
+  const handleDragCancel = useCallback(() => {
+    setActiveId(null);
+  }, []);
+
+  const itemIds = useMemo(() => items.map((item) => item.id), [items]);
+  const activeItem = activeId ? items.find((item) => item.id === activeId) : null;
+  const activeIndex = activeItem ? items.indexOf(activeItem) : -1;
+
+  return (
+    <DndContext
+      collisionDetection={closestCenter}
+      id={dndId}
+      onDragCancel={handleDragCancel}
+      onDragEnd={handleDragEnd}
+      onDragStart={handleDragStart}
+      sensors={sensors}
+    >
+      <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+        <div aria-label={t("Sort items")} className="flex flex-col gap-2" role="list">
+          {items.map((item, index) => (
+            <SortableItem activeId={activeId} index={index} item={item} key={item.id} />
+          ))}
+        </div>
+      </SortableContext>
+
+      <DragOverlay>
+        {activeItem && <DragOverlayItem index={activeIndex} item={activeItem} />}
+      </DragOverlay>
+    </DndContext>
+  );
+}
+
+function ResultItemList({
+  correctItems,
+  isCorrect,
+  userOrder,
+}: {
+  correctItems: string[];
+  isCorrect: boolean;
+  userOrder: string[];
+}) {
+  const t = useExtracted();
+
+  return (
+    <div className="flex flex-col gap-2">
+      {!isCorrect && (
+        <p className="text-muted-foreground text-sm font-medium">{t("Correct order:")}</p>
+      )}
+
+      <div aria-label={t("Sort items")} className="flex flex-col gap-2" role="list">
+        {correctItems.map((item, index) => {
+          const resultState = getItemResultState(item, index, userOrder);
+
+          return (
+            <div
+              aria-label={t("{item}. {result}.", {
+                item,
+                result: resultState === "correct" ? t("Correct") : t("Incorrect"),
+              })}
+              className={cn(
+                "pointer-events-none flex min-h-11 items-center gap-3 rounded-lg border px-3 py-2 text-left sm:px-4 sm:py-2.5",
+                resultState === "correct" && "border-l-success border-l-2",
+                resultState === "incorrect" && "border-l-destructive border-l-2",
+              )}
+              // oxlint-disable-next-line react/no-array-index-key -- Items can repeat, no unique ID
+              key={`${item}-${index}`}
+              role="listitem"
+            >
+              <ResultKbd resultState={resultState}>{String(index + 1)}</ResultKbd>
+              <span className="text-base">{item}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function initItems(step: SerializedStep, result?: StepResult): SortItem[] {
+  if (result?.answer?.kind === "sortOrder") {
+    return result.answer.userOrder.map((text, index) => ({ id: String(index), text }));
+  }
+
+  return step.sortOrderItems.map((text, index) => ({ id: String(index), text }));
 }
 
 export function SortOrderStep({
   onSelectAnswer,
   result,
-  selectedAnswer,
   step,
 }: {
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
@@ -134,54 +239,50 @@ export function SortOrderStep({
   const t = useExtracted();
   const content = useMemo(() => parseStepContent("sortOrder", step.content), [step.content]);
   const replaceName = useReplaceName();
+  const [items, setItems] = useState<SortItem[]>(() => initItems(step, result));
 
-  const [selections, setSelections] = useState<string[]>(() => {
-    if (result?.answer?.kind === "sortOrder") {
-      return result.answer.userOrder;
+  // Register the initial shuffled order as the answer on mount.
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional mount-only effect
+  useEffect(() => {
+    if (!result) {
+      onSelectAnswer(step.id, {
+        kind: "sortOrder",
+        userOrder: items.map((item) => item.text),
+      });
     }
+  }, []); // oxlint-disable-line react-hooks/exhaustive-deps -- mount-only
 
-    return [];
-  });
-
-  const handleToggle = useCallback(
-    (item: string) => {
-      const index = selections.indexOf(item);
-
-      if (index !== -1) {
-        const next = selections.filter((_, idx) => idx !== index);
-        setSelections(next);
-
-        if (selectedAnswer) {
-          onSelectAnswer(step.id, null);
-        }
-
-        return;
-      }
-
-      const next = [...selections, item];
-      setSelections(next);
-
-      if (next.length === content.items.length) {
-        onSelectAnswer(step.id, { kind: "sortOrder", userOrder: next });
-      }
+  const handleReorder = useCallback(
+    (reordered: SortItem[]) => {
+      setItems(reordered);
+      onSelectAnswer(step.id, {
+        kind: "sortOrder",
+        userOrder: reordered.map((item) => item.text),
+      });
     },
-    [content.items.length, onSelectAnswer, selectedAnswer, selections, step.id],
+    [onSelectAnswer, step.id],
   );
 
   const hasResult = result !== undefined;
+  const userOrder = items.map((item) => item.text);
 
   return (
     <InteractiveStepLayout>
       {content.question && <QuestionText>{replaceName(content.question)}</QuestionText>}
 
-      <p className="text-muted-foreground text-sm">{t("Tap items in the correct order")}</p>
+      {!hasResult && (
+        <p className="text-muted-foreground text-sm">{t("Drag items into the correct order")}</p>
+      )}
 
-      <SortItemList
-        correctItems={hasResult ? content.items : undefined}
-        items={step.sortOrderItems}
-        onToggle={handleToggle}
-        selections={selections}
-      />
+      {hasResult ? (
+        <ResultItemList
+          correctItems={content.items}
+          isCorrect={result.result.isCorrect}
+          userOrder={userOrder}
+        />
+      ) : (
+        <SortableItemList items={items} onReorder={handleReorder} />
+      )}
 
       {result && <InlineFeedback result={result} />}
     </InteractiveStepLayout>

--- a/i18n.lock
+++ b/i18n.lock
@@ -479,9 +479,9 @@ checksums:
     Belt/singular: fa36e8e36732c223d2876c0337d372e9
     BP%20to%20next%20level/singular: e77c5d6498ff38284c1f6b0721b8b33d
     Image%20options/singular: 64a1aee44b26dbaff851cb846eb4274d
-    Tap%20items%20in%20the%20correct%20order/singular: 221c7b9ef00241af65f534432965e782
-    "%7Bitem%7D.%20Tap%20to%20select%20as%20position%20%7BnextPosition%7D./singular": f8b0d3e60ce3740c02c33c0faaec5e6b
+    Drag%20items%20into%20the%20correct%20order/singular: 8ccab82ee3ba645ac23da4ca14a0dd2a
     Sort%20items/singular: 3b1072a596203b5acdc5718d38161392
+    Correct%20order%3A/singular: df3f446653ec8cde9c29d8d5912636ef
     Timeline/singular: 342b1e646f0634e47112092db1a24f49
     Translate%20this%20word%3A/singular: 05fede3c583e9ea39f27ac9fdf17fcc3
     Not%20completed/singular: d011b1ae92a1a8a2676a5d6999bbe6d4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,6 +340,15 @@ importers:
       '@dagrejs/dagre':
         specifier: 2.0.4
         version: 2.0.4
+      '@dnd-kit/core':
+        specifier: 6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: 10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: 3.2.2
+        version: 3.2.2(react@19.2.4)
       '@tabler/icons-react':
         specifier: 3.36.1
         version: 3.36.1(react@19.2.4)


### PR DESCRIPTION
## Summary

- Replace tap-to-sequence interaction with drag-and-drop using `@dnd-kit`
- Check button always enabled (items start with positions from shuffle)
- Show "Correct order:" label on incorrect answers
- Rewrite e2e tests for new drag interaction

## Test plan

- [x] `pnpm turbo quality:fix` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm --filter main build` succeeds
- [x] `pnpm --filter main test` — 435 tests pass
- [x] `pnpm --filter main e2e` — 6 sort order tests pass (3/3 flakiness check)
- [x] `pnpm --filter editor e2e` — 193 tests pass
- [x] `pnpm --filter api e2e` — 55 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces tap-to-sequence with drag-and-drop in the Sort Order step. Positions are pre-seeded in the reducer from the shuffled list so Check is always enabled, and incorrect answers show a “Correct order:” label.

- **New Features**
  - Drag-and-drop list using @dnd-kit with mouse, touch, and keyboard support.
  - Answers update on reorder; items start numbered from the shuffle so Check is always enabled.
  - Result view shows per-item correctness and “Correct order:” when wrong.
  - Updated copy/i18n and e2e tests for the new interaction.

- **Dependencies**
  - Added @dnd-kit/core, @dnd-kit/sortable, @dnd-kit/utilities.

<sup>Written for commit 6053e71b62362d9370e3bb4c9e0d1b250241b6c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

