### PR TITLE
feat(api): preload next lesson activities on activity completion

### DIFF
--- a/apps/api/src/app/v1/workflows/lesson-preload/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/lesson-preload/trigger/route.ts
@@ -1,0 +1,28 @@
+import { errors } from "@/lib/api-errors";
+import { parseBody } from "@/lib/body-parser";
+import { lessonPreloadTriggerSchema } from "@/lib/openapi/schemas/workflows";
+import { lessonPreloadWorkflow } from "@/workflows/lesson-preload/lesson-preload-workflow";
+import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
+import { type NextRequest, NextResponse } from "next/server";
+import { start } from "workflow/api";
+
+export async function POST(request: NextRequest) {
+  const parsed = await parseBody(request, lessonPreloadTriggerSchema);
+
+  if (!parsed.success) {
+    return errors.validation(parsed.error);
+  }
+
+  const hasSubscription = await hasActiveSubscription(request.headers);
+
+  if (!hasSubscription) {
+    return errors.paymentRequired();
+  }
+
+  const run = await start(lessonPreloadWorkflow, [parsed.data.lessonId]);
+
+  return NextResponse.json({
+    message: "Workflow started",
+    runId: run.runId,
+  });
+}

--- a/apps/api/src/lib/openapi/document.ts
+++ b/apps/api/src/lib/openapi/document.ts
@@ -22,6 +22,7 @@ import {
   chapterGenerationTriggerSchema,
   courseGenerationTriggerSchema,
   lessonGenerationTriggerSchema,
+  lessonPreloadTriggerSchema,
 } from "./schemas/workflows";
 
 export const openAPIDocument = createDocument({
@@ -171,6 +172,11 @@ export const openAPIDocument = createDocument({
       requiresSubscription: true,
       schema: lessonGenerationTriggerSchema,
       summary: "Trigger lesson generation workflow",
+    }),
+    "/workflows/lesson-preload/trigger": workflowTriggerEndpoint({
+      requiresSubscription: true,
+      schema: lessonPreloadTriggerSchema,
+      summary: "Trigger lesson preload workflow",
     }),
   },
   servers: [{ description: "API v1", url: "/v1" }],

--- a/apps/api/src/lib/openapi/schemas/workflows.ts
+++ b/apps/api/src/lib/openapi/schemas/workflows.ts
@@ -40,6 +40,12 @@ export const activityGenerationTriggerSchema = z
   })
   .meta({ id: "ActivityGenerationTrigger" });
 
+export const lessonPreloadTriggerSchema = z
+  .object({
+    lessonId: z.number().int().positive().meta({ description: "Lesson ID to preload content for" }),
+  })
+  .meta({ id: "LessonPreloadTrigger" });
+
 export const workflowTriggerResponseSchema = z
   .object({
     message: z.string().meta({ example: "Workflow started" }),

--- a/apps/api/src/workflows/lesson-preload/lesson-preload-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-preload/lesson-preload-workflow.test.ts
@@ -38,13 +38,6 @@ describe(lessonPreloadWorkflow, () => {
     expect(callOrder).toEqual(["lessonGeneration", "activityGeneration"]);
   });
 
-  test("passes the lessonId to both workflows", async () => {
-    await lessonPreloadWorkflow(123);
-
-    expect(lessonGenerationWorkflow).toHaveBeenCalledWith(123);
-    expect(activityGenerationWorkflow).toHaveBeenCalledWith(123);
-  });
-
   test("propagates errors from lessonGenerationWorkflow", async () => {
     vi.mocked(lessonGenerationWorkflow).mockRejectedValueOnce(new Error("lesson gen failed"));
 

--- a/apps/api/src/workflows/lesson-preload/lesson-preload-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-preload/lesson-preload-workflow.test.ts
@@ -1,0 +1,61 @@
+import { activityGenerationWorkflow } from "@/workflows/activity-generation/activity-generation-workflow";
+import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { lessonPreloadWorkflow } from "./lesson-preload-workflow";
+
+vi.mock("workflow", () => ({
+  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
+}));
+
+vi.mock("@/workflows/lesson-generation/lesson-generation-workflow", () => ({
+  lessonGenerationWorkflow: vi.fn().mockImplementation(async () => {}),
+}));
+
+vi.mock("@/workflows/activity-generation/activity-generation-workflow", () => ({
+  activityGenerationWorkflow: vi.fn().mockImplementation(async () => {}),
+}));
+
+describe(lessonPreloadWorkflow, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("calls lessonGenerationWorkflow then activityGenerationWorkflow in sequence", async () => {
+    const callOrder: string[] = [];
+
+    vi.mocked(lessonGenerationWorkflow).mockImplementation(async () => {
+      callOrder.push("lessonGeneration");
+    });
+
+    vi.mocked(activityGenerationWorkflow).mockImplementation(async () => {
+      callOrder.push("activityGeneration");
+    });
+
+    await lessonPreloadWorkflow(42);
+
+    expect(lessonGenerationWorkflow).toHaveBeenCalledWith(42);
+    expect(activityGenerationWorkflow).toHaveBeenCalledWith(42);
+    expect(callOrder).toEqual(["lessonGeneration", "activityGeneration"]);
+  });
+
+  test("passes the lessonId to both workflows", async () => {
+    await lessonPreloadWorkflow(123);
+
+    expect(lessonGenerationWorkflow).toHaveBeenCalledWith(123);
+    expect(activityGenerationWorkflow).toHaveBeenCalledWith(123);
+  });
+
+  test("propagates errors from lessonGenerationWorkflow", async () => {
+    vi.mocked(lessonGenerationWorkflow).mockRejectedValueOnce(new Error("lesson gen failed"));
+
+    await expect(lessonPreloadWorkflow(1)).rejects.toThrow("lesson gen failed");
+    expect(activityGenerationWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("propagates errors from activityGenerationWorkflow", async () => {
+    vi.mocked(activityGenerationWorkflow).mockRejectedValueOnce(new Error("activity gen failed"));
+
+    await expect(lessonPreloadWorkflow(1)).rejects.toThrow("activity gen failed");
+    expect(lessonGenerationWorkflow).toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/api/src/workflows/lesson-preload/lesson-preload-workflow.ts
+++ b/apps/api/src/workflows/lesson-preload/lesson-preload-workflow.ts
@@ -1,0 +1,8 @@
+import { activityGenerationWorkflow } from "@/workflows/activity-generation/activity-generation-workflow";
+import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
+
+export async function lessonPreloadWorkflow(lessonId: number): Promise<void> {
+  "use workflow";
+  await lessonGenerationWorkflow(lessonId);
+  await activityGenerationWorkflow(lessonId);
+}

--- a/apps/main/src/components/activity-player/submit-completion-action.ts
+++ b/apps/main/src/components/activity-player/submit-completion-action.ts
@@ -54,6 +54,8 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
 
   const userId = Number(session.user.id);
 
+  const activityId = BigInt(input.activityId);
+
   const { data, error } = await safeAsync(async () => {
     const activity = await prisma.activity.findUnique({
       select: {
@@ -73,7 +75,7 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
           where: { isPublished: true },
         },
       },
-      where: { id: BigInt(input.activityId) },
+      where: { id: activityId },
     });
 
     if (!activity) {
@@ -128,7 +130,7 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
   const locale = await getLocale();
   revalidatePath(`/${locale}`);
 
-  after(() => preloadNextLesson(BigInt(input.activityId), reqHeaders.get("cookie") ?? ""));
+  after(() => preloadNextLesson(activityId, reqHeaders.get("cookie") ?? ""));
 
   return {
     belt: data.belt,

--- a/apps/main/src/components/activity-player/submit-completion-action.ts
+++ b/apps/main/src/components/activity-player/submit-completion-action.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { preloadNextLesson } from "@/data/progress/preload-next-lesson";
 import { submitActivityCompletion } from "@/data/progress/submit-activity-completion";
 import { auth } from "@zoonk/core/auth";
 import {
@@ -14,6 +15,7 @@ import { safeAsync } from "@zoonk/utils/error";
 import { getLocale } from "next-intl/server";
 import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
+import { after } from "next/server";
 import { hasNegativeDimension } from "./has-negative-dimension";
 
 export type CompletionResult =
@@ -125,6 +127,8 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
 
   const locale = await getLocale();
   revalidatePath(`/${locale}`);
+
+  after(() => preloadNextLesson(BigInt(input.activityId), reqHeaders.get("cookie") ?? ""));
 
   return {
     belt: data.belt,

--- a/apps/main/src/data/progress/get-next-lesson-id.test.ts
+++ b/apps/main/src/data/progress/get-next-lesson-id.test.ts
@@ -1,0 +1,210 @@
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, describe, expect, test } from "vitest";
+import { getNextLessonId } from "./get-next-lesson-id";
+
+describe(getNextLessonId, () => {
+  let orgId: number;
+  let courseId: number;
+
+  let chapter1Id: number;
+  let chapter2Id: number;
+
+  let lesson1Id: number;
+  let lesson2Id: number;
+  let lesson3Id: number;
+
+  let activity1Id: bigint;
+  let activity2Id: bigint;
+  let activity3Id: bigint;
+
+  beforeAll(async () => {
+    const org = await organizationFixture({ kind: "brand" });
+    orgId = org.id;
+
+    const course = await courseFixture({ isPublished: true, organizationId: orgId });
+    courseId = course.id;
+
+    const [ch1, ch2] = await Promise.all([
+      chapterFixture({ courseId, isPublished: true, organizationId: orgId, position: 0 }),
+      chapterFixture({ courseId, isPublished: true, organizationId: orgId, position: 1 }),
+    ]);
+
+    chapter1Id = ch1.id;
+    chapter2Id = ch2.id;
+
+    const [ls1, ls2] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter1Id,
+        isPublished: true,
+        organizationId: orgId,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: chapter1Id,
+        isPublished: true,
+        organizationId: orgId,
+        position: 1,
+      }),
+    ]);
+
+    lesson1Id = ls1.id;
+    lesson2Id = ls2.id;
+
+    const ls3 = await lessonFixture({
+      chapterId: chapter2Id,
+      isPublished: true,
+      organizationId: orgId,
+      position: 0,
+    });
+
+    lesson3Id = ls3.id;
+
+    const [act1, act2, act3] = await Promise.all([
+      activityFixture({
+        isPublished: true,
+        lessonId: lesson1Id,
+        organizationId: orgId,
+        position: 0,
+      }),
+      activityFixture({
+        isPublished: true,
+        lessonId: lesson2Id,
+        organizationId: orgId,
+        position: 0,
+      }),
+      activityFixture({
+        isPublished: true,
+        lessonId: lesson3Id,
+        organizationId: orgId,
+        position: 0,
+      }),
+    ]);
+
+    activity1Id = act1.id;
+    activity2Id = act2.id;
+    activity3Id = act3.id;
+  });
+
+  test("returns next lesson in same chapter", async () => {
+    const result = await getNextLessonId(activity1Id);
+    expect(result).toBe(lesson2Id);
+  });
+
+  test("returns first lesson of next chapter when current is last in chapter", async () => {
+    const result = await getNextLessonId(activity2Id);
+    expect(result).toBe(lesson3Id);
+  });
+
+  test("returns null when on last lesson of course", async () => {
+    const result = await getNextLessonId(activity3Id);
+    expect(result).toBeNull();
+  });
+
+  test("returns null for non-existent activity", async () => {
+    const result = await getNextLessonId(BigInt(999_999_999));
+    expect(result).toBeNull();
+  });
+
+  test("skips unpublished lessons", async () => {
+    const testOrg = await organizationFixture({ kind: "brand" });
+    const testCourse = await courseFixture({ isPublished: true, organizationId: testOrg.id });
+    const testChapter = await chapterFixture({
+      courseId: testCourse.id,
+      isPublished: true,
+      organizationId: testOrg.id,
+      position: 0,
+    });
+
+    const [publishedLesson, , nextPublishedLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: testChapter.id,
+        isPublished: true,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: testChapter.id,
+        isPublished: false,
+        organizationId: testOrg.id,
+        position: 1,
+      }),
+      lessonFixture({
+        chapterId: testChapter.id,
+        isPublished: true,
+        organizationId: testOrg.id,
+        position: 2,
+      }),
+    ]);
+
+    const testActivity = await activityFixture({
+      isPublished: true,
+      lessonId: publishedLesson.id,
+      organizationId: testOrg.id,
+      position: 0,
+    });
+
+    const result = await getNextLessonId(testActivity.id);
+    expect(result).toBe(nextPublishedLesson.id);
+  });
+
+  test("skips unpublished chapters", async () => {
+    const testOrg = await organizationFixture({ kind: "brand" });
+    const testCourse = await courseFixture({ isPublished: true, organizationId: testOrg.id });
+
+    const [publishedCh, , nextPublishedCh] = await Promise.all([
+      chapterFixture({
+        courseId: testCourse.id,
+        isPublished: true,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+      chapterFixture({
+        courseId: testCourse.id,
+        isPublished: false,
+        organizationId: testOrg.id,
+        position: 1,
+      }),
+      chapterFixture({
+        courseId: testCourse.id,
+        isPublished: true,
+        organizationId: testOrg.id,
+        position: 2,
+      }),
+    ]);
+
+    const [currentLesson, , nextLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: publishedCh.id,
+        isPublished: true,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: publishedCh.id,
+        isPublished: false,
+        organizationId: testOrg.id,
+        position: 1,
+      }),
+      lessonFixture({
+        chapterId: nextPublishedCh.id,
+        isPublished: true,
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+    ]);
+
+    const testActivity = await activityFixture({
+      isPublished: true,
+      lessonId: currentLesson.id,
+      organizationId: testOrg.id,
+      position: 0,
+    });
+
+    const result = await getNextLessonId(testActivity.id);
+    expect(result).toBe(nextLesson.id);
+  });
+});

--- a/apps/main/src/data/progress/get-next-lesson-id.ts
+++ b/apps/main/src/data/progress/get-next-lesson-id.ts
@@ -1,0 +1,55 @@
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+
+/**
+ * Given an activityId, finds the next lesson in course order.
+ * Returns the lessonId or null if no next lesson exists.
+ */
+export async function getNextLessonId(activityId: bigint): Promise<number | null> {
+  const { data: activity, error } = await safeAsync(() =>
+    prisma.activity.findUnique({
+      select: {
+        lesson: {
+          select: {
+            chapter: { select: { courseId: true, id: true, position: true } },
+            id: true,
+            position: true,
+          },
+        },
+      },
+      where: { id: activityId },
+    }),
+  );
+
+  if (error || !activity) {
+    return null;
+  }
+
+  const { lesson } = activity;
+  const { chapter } = lesson;
+
+  const { data: nextLesson } = await safeAsync(() =>
+    prisma.lesson.findFirst({
+      orderBy: [{ chapter: { position: "asc" } }, { position: "asc" }],
+      select: { id: true },
+      where: {
+        OR: [
+          {
+            chapter: { id: chapter.id, position: chapter.position },
+            position: { gt: lesson.position },
+          },
+          {
+            chapter: { position: { gt: chapter.position } },
+          },
+        ],
+        chapter: {
+          course: { id: chapter.courseId },
+          isPublished: true,
+        },
+        isPublished: true,
+      },
+    }),
+  );
+
+  return nextLesson?.id ?? null;
+}

--- a/apps/main/src/data/progress/get-next-lesson-id.ts
+++ b/apps/main/src/data/progress/get-next-lesson-id.ts
@@ -35,7 +35,7 @@ export async function getNextLessonId(activityId: bigint): Promise<number | null
       where: {
         OR: [
           {
-            chapter: { id: chapter.id, position: chapter.position },
+            chapter: { id: chapter.id },
             position: { gt: lesson.position },
           },
           {

--- a/apps/main/src/data/progress/preload-next-lesson.test.ts
+++ b/apps/main/src/data/progress/preload-next-lesson.test.ts
@@ -1,13 +1,10 @@
+import { API_URL } from "@zoonk/utils/constants";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { getNextLessonId } from "./get-next-lesson-id";
 import { preloadNextLesson } from "./preload-next-lesson";
 
 vi.mock("./get-next-lesson-id", () => ({
   getNextLessonId: vi.fn(),
-}));
-
-vi.mock("@zoonk/utils/constants", () => ({
-  API_URL: "https://api.test.com",
 }));
 
 describe(preloadNextLesson, () => {
@@ -27,17 +24,14 @@ describe(preloadNextLesson, () => {
 
     await preloadNextLesson(BigInt(1), "session=abc123");
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      "https://api.test.com/v1/workflows/lesson-preload/trigger",
-      {
-        body: JSON.stringify({ lessonId: 42 }),
-        headers: {
-          "Content-Type": "application/json",
-          Cookie: "session=abc123",
-        },
-        method: "POST",
+    expect(mockFetch).toHaveBeenCalledWith(`${API_URL}/v1/workflows/lesson-preload/trigger`, {
+      body: JSON.stringify({ lessonId: 42 }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: "session=abc123",
       },
-    );
+      method: "POST",
+    });
   });
 
   test("does not call API when no next lesson exists", async () => {

--- a/apps/main/src/data/progress/preload-next-lesson.test.ts
+++ b/apps/main/src/data/progress/preload-next-lesson.test.ts
@@ -48,12 +48,4 @@ describe(preloadNextLesson, () => {
 
     await expect(preloadNextLesson(BigInt(1), "session=abc123")).resolves.toBeUndefined();
   });
-
-  test("passes activityId to getNextLessonId", async () => {
-    vi.mocked(getNextLessonId).mockResolvedValue(null);
-
-    await preloadNextLesson(BigInt(99), "session=abc123");
-
-    expect(getNextLessonId).toHaveBeenCalledWith(BigInt(99));
-  });
 });

--- a/apps/main/src/data/progress/preload-next-lesson.test.ts
+++ b/apps/main/src/data/progress/preload-next-lesson.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { getNextLessonId } from "./get-next-lesson-id";
+import { preloadNextLesson } from "./preload-next-lesson";
+
+vi.mock("./get-next-lesson-id", () => ({
+  getNextLessonId: vi.fn(),
+}));
+
+vi.mock("@zoonk/utils/constants", () => ({
+  API_URL: "https://api.test.com",
+}));
+
+describe(preloadNextLesson, () => {
+  const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  test("calls API with correct lessonId and cookie when next lesson exists", async () => {
+    vi.mocked(getNextLessonId).mockResolvedValue(42);
+
+    await preloadNextLesson(BigInt(1), "session=abc123");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.test.com/v1/workflows/lesson-preload/trigger",
+      {
+        body: JSON.stringify({ lessonId: 42 }),
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: "session=abc123",
+        },
+        method: "POST",
+      },
+    );
+  });
+
+  test("does not call API when no next lesson exists", async () => {
+    vi.mocked(getNextLessonId).mockResolvedValue(null);
+
+    await preloadNextLesson(BigInt(1), "session=abc123");
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test("silently handles fetch errors without throwing", async () => {
+    vi.mocked(getNextLessonId).mockResolvedValue(42);
+    mockFetch.mockRejectedValue(new Error("network error"));
+
+    await expect(preloadNextLesson(BigInt(1), "session=abc123")).resolves.toBeUndefined();
+  });
+
+  test("passes activityId to getNextLessonId", async () => {
+    vi.mocked(getNextLessonId).mockResolvedValue(null);
+
+    await preloadNextLesson(BigInt(99), "session=abc123");
+
+    expect(getNextLessonId).toHaveBeenCalledWith(BigInt(99));
+  });
+});

--- a/apps/main/src/data/progress/preload-next-lesson.ts
+++ b/apps/main/src/data/progress/preload-next-lesson.ts
@@ -1,0 +1,27 @@
+import { API_URL } from "@zoonk/utils/constants";
+import { getNextLessonId } from "./get-next-lesson-id";
+
+/**
+ * Best-effort preloading of the next lesson's content.
+ * Silently ignores errors since preloading is an optimization.
+ */
+export async function preloadNextLesson(activityId: bigint, cookieHeader: string): Promise<void> {
+  const nextLessonId = await getNextLessonId(activityId);
+
+  if (!nextLessonId) {
+    return;
+  }
+
+  try {
+    await fetch(`${API_URL}/v1/workflows/lesson-preload/trigger`, {
+      body: JSON.stringify({ lessonId: nextLessonId }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookieHeader,
+      },
+      method: "POST",
+    });
+  } catch {
+    // Preloading is best-effort; silently ignore errors.
+  }
+}


### PR DESCRIPTION
## Summary

- Add `lessonPreloadWorkflow` that chains lesson + activity generation for a given lesson
- Add `/workflows/lesson-preload/trigger` API endpoint (requires subscription)
- After activity completion, use `after()` to find the next lesson and trigger preloading in the background
- Next lesson lookup traverses same-chapter and cross-chapter boundaries, skipping unpublished content

## Test plan

- [x] Workflow test: sequential execution, error propagation
- [x] `getNextLessonId` integration tests: same chapter, cross-chapter, last lesson, non-existent, unpublished skipping
- [x] `preloadNextLesson` unit tests: API call, no-op on null, silent error handling
- [x] All existing e2e tests pass (main, api, editor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preloads the next lesson after an activity is completed to reduce wait time on the next screen. Adds a background workflow and a subscription-gated API endpoint to generate lessons and activities ahead of time.

- New Features
  - Added lessonPreloadWorkflow that runs lesson then activity generation for a lesson.
  - Added POST /v1/workflows/lesson-preload/trigger (requires subscription) with OpenAPI docs.
  - On activity completion, uses after() to find the next lesson and trigger preloading in the background.
  - Implemented getNextLessonId to traverse same/next chapters and skip unpublished items.
  - Added tests for workflow sequencing, next-lesson lookup, and preload behavior.

- Refactors
  - Cleanup: simplified next-lesson query, extracted BigInt conversion, removed duplicate tests, and used real API_URL in tests.

<sup>Written for commit 295f3f0bf903f178f66c9ef8c6362aa8c2240410. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

