### PR TITLE
feat(main): apply energy decay on read and write

### DIFF
--- a/apps/main/src/data/progress/get-energy-level.test.ts
+++ b/apps/main/src/data/progress/get-energy-level.test.ts
@@ -39,8 +39,13 @@ describe("authenticated users", () => {
   test("applies decay when lastActiveAt is 5 days ago", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);
-    const fiveDaysAgo = new Date();
-    fiveDaysAgo.setUTCDate(fiveDaysAgo.getUTCDate() - 5);
+
+    // Anchor to UTC midnight so a midnight rollover can't shift the day count
+    const today = new Date();
+    const todayMidnight = new Date(
+      Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()),
+    );
+    const fiveDaysAgo = new Date(todayMidnight.getTime() - 5 * 86_400_000);
 
     await prisma.userProgress.create({
       data: {
@@ -57,8 +62,12 @@ describe("authenticated users", () => {
   test("clamps decayed energy at 0", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);
-    const longAgo = new Date();
-    longAgo.setUTCDate(longAgo.getUTCDate() - 100);
+
+    const today = new Date();
+    const todayMidnight = new Date(
+      Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()),
+    );
+    const longAgo = new Date(todayMidnight.getTime() - 100 * 86_400_000);
 
     await prisma.userProgress.create({
       data: {

--- a/apps/main/src/data/progress/get-energy-level.ts
+++ b/apps/main/src/data/progress/get-energy-level.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
+import { computeDecayedEnergy } from "@zoonk/utils/energy";
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 
@@ -20,7 +21,7 @@ export const getEnergyLevel = cache(
 
     const { data: progress, error } = await safeAsync(() =>
       prisma.userProgress.findUnique({
-        select: { currentEnergy: true },
+        select: { currentEnergy: true, lastActiveAt: true },
         where: { userId },
       }),
     );
@@ -30,7 +31,11 @@ export const getEnergyLevel = cache(
     }
 
     return {
-      currentEnergy: progress.currentEnergy,
+      currentEnergy: computeDecayedEnergy(
+        progress.currentEnergy,
+        progress.lastActiveAt,
+        new Date(),
+      ),
     };
   },
 );

--- a/apps/main/src/data/progress/submit-activity-completion.test.ts
+++ b/apps/main/src/data/progress/submit-activity-completion.test.ts
@@ -162,7 +162,7 @@ describe(submitActivityCompletion, () => {
   test("energy clamps at 100", async () => {
     const user = await userFixture();
     const userId = Number(user.id);
-    await userProgressFixture({ currentEnergy: 99.5, userId });
+    await userProgressFixture({ currentEnergy: 99.5, lastActiveAt: new Date(), userId });
 
     const result = await submitActivityCompletion({
       activityId: activity.id,
@@ -184,7 +184,7 @@ describe(submitActivityCompletion, () => {
   test("energy clamps at 0", async () => {
     const user = await userFixture();
     const userId = Number(user.id);
-    await userProgressFixture({ currentEnergy: 0.05, userId });
+    await userProgressFixture({ currentEnergy: 0.05, lastActiveAt: new Date(), userId });
 
     await submitActivityCompletion({
       activityId: activity.id,
@@ -466,5 +466,55 @@ describe(submitActivityCompletion, () => {
       where: { courseId: course.id, userId },
     });
     expect(courseUsers).toHaveLength(1);
+  });
+
+  test("applies decay and fills DailyProgress gaps for inactive days", async () => {
+    const user = await userFixture();
+    const userId = Number(user.id);
+
+    const fiveDaysAgo = new Date();
+    fiveDaysAgo.setUTCDate(fiveDaysAgo.getUTCDate() - 5);
+
+    await userProgressFixture({
+      currentEnergy: 50,
+      lastActiveAt: fiveDaysAgo,
+      userId,
+    });
+
+    await submitActivityCompletion({
+      activityId: activity.id,
+      courseId: course.id,
+      durationSeconds: 10,
+      isChallenge: false,
+      organizationId: org.id,
+      score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
+      startedAt: new Date(Date.now() - 10_000),
+      stepResults: [stepResult(true)],
+      userId,
+    });
+
+    // 5 day gap → 4 inactive days → decay=4 → base=46, +0.2 → 46.2
+    const userProgress = await prisma.userProgress.findUnique({ where: { userId } });
+    expect(userProgress?.currentEnergy).toBeCloseTo(46.2);
+
+    // Should have 4 decay DailyProgress records (one per inactive day) + 1 for today
+    const dailyRecords = await prisma.dailyProgress.findMany({
+      orderBy: { date: "asc" },
+      where: { organizationId: null, userId },
+    });
+
+    expect(dailyRecords).toHaveLength(4);
+
+    // Decay records: energy decreases by 1 each day
+    expect(dailyRecords[0]?.energyAtEnd).toBe(49);
+    expect(dailyRecords[1]?.energyAtEnd).toBe(48);
+    expect(dailyRecords[2]?.energyAtEnd).toBe(47);
+    expect(dailyRecords[3]?.energyAtEnd).toBe(46);
+
+    // Today's record is in the org-scoped DailyProgress
+    const todayRecord = await prisma.dailyProgress.findFirst({
+      where: { organizationId: org.id, userId },
+    });
+    expect(todayRecord?.energyAtEnd).toBeCloseTo(46.2);
   });
 });

--- a/apps/main/src/data/progress/submit-activity-completion.test.ts
+++ b/apps/main/src/data/progress/submit-activity-completion.test.ts
@@ -472,8 +472,12 @@ describe(submitActivityCompletion, () => {
     const user = await userFixture();
     const userId = Number(user.id);
 
-    const yesterday = new Date();
-    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+    // Anchor to UTC midnight so a midnight rollover can't shift the day count
+    const today = new Date();
+    const todayMidnight = new Date(
+      Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()),
+    );
+    const yesterday = new Date(todayMidnight.getTime() - 86_400_000);
 
     await userProgressFixture({
       currentEnergy: 50,
@@ -507,8 +511,11 @@ describe(submitActivityCompletion, () => {
     const user = await userFixture();
     const userId = Number(user.id);
 
-    const fiveDaysAgo = new Date();
-    fiveDaysAgo.setUTCDate(fiveDaysAgo.getUTCDate() - 5);
+    const today = new Date();
+    const todayMidnight = new Date(
+      Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()),
+    );
+    const fiveDaysAgo = new Date(todayMidnight.getTime() - 5 * 86_400_000);
 
     await userProgressFixture({
       currentEnergy: 50,

--- a/apps/main/src/data/progress/submit-activity-completion.ts
+++ b/apps/main/src/data/progress/submit-activity-completion.ts
@@ -2,8 +2,8 @@ import "server-only";
 import { type ScoreResult } from "@zoonk/core/player/compute-score";
 import { type TransactionClient, prisma } from "@zoonk/db";
 import { type BeltLevelResult, calculateBeltLevel } from "@zoonk/utils/belt-level";
-import { MAX_ENERGY, MIN_ENERGY } from "@zoonk/utils/constants";
-import { computeDecayedEnergy, getDateOnly } from "@zoonk/utils/energy";
+import { DAILY_DECAY, MIN_ENERGY, MS_PER_DAY } from "@zoonk/utils/constants";
+import { clampEnergy, computeDecayedEnergy, toUTCMidnight } from "@zoonk/utils/energy";
 
 function getCompletionField(input: {
   isChallenge: boolean;
@@ -20,12 +20,8 @@ function getCompletionField(input: {
   return "interactiveCompleted";
 }
 
-function clampEnergy(value: number): number {
-  return Math.min(MAX_ENERGY, Math.max(MIN_ENERGY, value));
-}
-
-const MS_PER_DAY = 86_400_000;
-
+// Decay is org-independent: a user's energy decays globally regardless of
+// which organization they were active in, so gap records use organizationId: null.
 async function fillDecayGaps(
   tx: TransactionClient,
   userId: number,
@@ -41,7 +37,7 @@ async function fillDecayGaps(
 
   const records = Array.from({ length: dayDiff - 1 }, (_, i) => {
     const date = new Date(lastActiveDate.getTime() + (i + 1) * MS_PER_DAY);
-    const decayedEnergy = Math.max(0, currentEnergy - (i + 1));
+    const decayedEnergy = Math.max(MIN_ENERGY, currentEnergy - (i + 1) * DAILY_DECAY);
 
     return {
       date,
@@ -155,7 +151,7 @@ export async function submitActivityCompletion(input: {
   newTotalBp: number;
 }> {
   const now = new Date();
-  const today = getDateOnly(now);
+  const today = toUTCMidnight(now);
 
   return prisma.$transaction(async (tx) => {
     // Create StepAttempt records
@@ -211,19 +207,19 @@ export async function submitActivityCompletion(input: {
     }
 
     // Find existing UserProgress to apply decay
-    const existing = await tx.userProgress.findUnique({
+    const existingProgress = await tx.userProgress.findUnique({
       select: { currentEnergy: true, lastActiveAt: true },
       where: { userId: input.userId },
     });
 
-    const decayedBase = existing
-      ? computeDecayedEnergy(existing.currentEnergy, existing.lastActiveAt, now)
+    const decayedBase = existingProgress
+      ? computeDecayedEnergy(existingProgress.currentEnergy, existingProgress.lastActiveAt, now)
       : 0;
 
     // Fill DailyProgress records for inactive days
-    if (existing) {
-      const lastActiveDate = getDateOnly(existing.lastActiveAt);
-      await fillDecayGaps(tx, input.userId, existing.currentEnergy, lastActiveDate, today);
+    if (existingProgress) {
+      const lastActiveDate = toUTCMidnight(existingProgress.lastActiveAt);
+      await fillDecayGaps(tx, input.userId, existingProgress.currentEnergy, lastActiveDate, today);
     }
 
     const clampedEnergy = clampEnergy(decayedBase + input.score.energyDelta);
@@ -250,7 +246,7 @@ export async function submitActivityCompletion(input: {
     await upsertDailyProgress(tx, {
       clampedEnergy,
       date: today,
-      dayOfWeek: now.getDay(),
+      dayOfWeek: now.getUTCDay(),
       durationSeconds: input.durationSeconds,
       field,
       organizationId: input.organizationId,

--- a/apps/main/src/data/progress/submit-activity-completion.ts
+++ b/apps/main/src/data/progress/submit-activity-completion.ts
@@ -224,7 +224,9 @@ export async function submitActivityCompletion(input: {
 
     const clampedEnergy = clampEnergy(decayedBase + input.score.energyDelta);
 
-    // UserProgress upsert with absolute energy (decay already applied)
+    // Absolute write is safe: the interactive transaction serializes row access,
+    // so concurrent requests block until the prior commit completes.
+
     const updatedProgress = await tx.userProgress.upsert({
       create: {
         currentEnergy: clampedEnergy,

--- a/packages/e2e/src/helpers.ts
+++ b/packages/e2e/src/helpers.ts
@@ -5,11 +5,7 @@ import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
-import {
-  dailyProgressFixtureMany,
-  stepAttemptFixture,
-  userProgressFixture,
-} from "@zoonk/testing/fixtures/progress";
+import { dailyProgressFixtureMany, userProgressFixture } from "@zoonk/testing/fixtures/progress";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 
@@ -240,7 +236,7 @@ async function createStepAttempts(
     })),
   ]);
 
-  await Promise.all(attempts.map((attempt) => stepAttemptFixture(attempt)));
+  await prisma.stepAttempt.createMany({ data: attempts });
 }
 
 async function createE2EProgressData(userId: number): Promise<void> {

--- a/packages/testing/src/fixtures/progress.ts
+++ b/packages/testing/src/fixtures/progress.ts
@@ -44,12 +44,14 @@ const DEFAULT_ENERGY = 50;
 
 export async function userProgressFixture(attrs: {
   currentEnergy?: number;
+  lastActiveAt?: Date;
   totalBrainPower?: bigint;
   userId: number;
 }) {
   return prisma.userProgress.create({
     data: {
       currentEnergy: attrs.currentEnergy ?? DEFAULT_ENERGY,
+      lastActiveAt: attrs.lastActiveAt ?? new Date(),
       totalBrainPower: attrs.totalBrainPower ?? 0n,
       userId: attrs.userId,
     },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,6 +9,7 @@
     "./cache": "./src/cache.ts",
     "./categories": "./src/categories.ts",
     "./constants": "./src/constants.ts",
+    "./energy": "./src/energy.ts",
     "./error": "./src/error.ts",
     "./form": "./src/form.ts",
     "./json": "./src/json.ts",

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -58,6 +58,7 @@ export const BRAIN_POWER_PER_ACTIVITY = 10;
 export const BRAIN_POWER_PER_CHALLENGE = 100;
 export const CHALLENGE_FAILURE_ENERGY = 0.1;
 export const DAILY_DECAY = 1;
+export const MS_PER_DAY = 86_400_000;
 export const ENERGY_PER_CORRECT = 0.2;
 export const ENERGY_PER_INCORRECT = -0.1;
 export const ENERGY_PER_STATIC = 0.1;

--- a/packages/utils/src/energy.test.ts
+++ b/packages/utils/src/energy.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+import { computeDecayedEnergy, getDateOnly } from "./energy";
+
+describe(getDateOnly, () => {
+  test("strips time and creates UTC midnight", () => {
+    const date = new Date("2025-03-15T14:30:45.123Z");
+    const result = getDateOnly(date);
+
+    expect(result.getUTCHours()).toBe(0);
+    expect(result.getUTCMinutes()).toBe(0);
+    expect(result.getUTCSeconds()).toBe(0);
+    expect(result.getUTCMilliseconds()).toBe(0);
+    expect(result.getUTCFullYear()).toBe(2025);
+    expect(result.getUTCMonth()).toBe(2);
+    expect(result.getUTCDate()).toBe(15);
+  });
+});
+
+describe(computeDecayedEnergy, () => {
+  test("same day: no decay", () => {
+    const lastActiveAt = new Date("2025-01-10T10:00:00Z");
+    const now = new Date("2025-01-10T23:00:00Z");
+
+    expect(computeDecayedEnergy(50, lastActiveAt, now)).toBe(50);
+  });
+
+  test("1 day gap: 0 inactive days, no decay", () => {
+    const lastActiveAt = new Date("2025-01-10T10:00:00Z");
+    const now = new Date("2025-01-11T10:00:00Z");
+
+    expect(computeDecayedEnergy(50, lastActiveAt, now)).toBe(50);
+  });
+
+  test("3 day gap: 2 inactive days, decay=2", () => {
+    const lastActiveAt = new Date("2025-01-10T10:00:00Z");
+    const now = new Date("2025-01-13T10:00:00Z");
+
+    expect(computeDecayedEnergy(50, lastActiveAt, now)).toBe(48);
+  });
+
+  test("5 day gap: 4 inactive days, decay=4", () => {
+    const lastActiveAt = new Date("2025-01-10T10:00:00Z");
+    const now = new Date("2025-01-15T10:00:00Z");
+
+    expect(computeDecayedEnergy(50, lastActiveAt, now)).toBe(46);
+  });
+
+  test("energy clamped at 0", () => {
+    const lastActiveAt = new Date("2025-01-10T10:00:00Z");
+    const now = new Date("2025-01-20T10:00:00Z");
+
+    expect(computeDecayedEnergy(2, lastActiveAt, now)).toBe(0);
+  });
+
+  test("cross-day boundary: lastActive=Jan 10 11pm, now=Jan 12 1am → 1 inactive day, decay=1", () => {
+    const lastActiveAt = new Date("2025-01-10T23:00:00Z");
+    const now = new Date("2025-01-12T01:00:00Z");
+
+    expect(computeDecayedEnergy(50, lastActiveAt, now)).toBe(49);
+  });
+});

--- a/packages/utils/src/energy.test.ts
+++ b/packages/utils/src/energy.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { computeDecayedEnergy, getDateOnly } from "./energy";
+import { clampEnergy, computeDecayedEnergy, toUTCMidnight } from "./energy";
 
-describe(getDateOnly, () => {
+describe(toUTCMidnight, () => {
   test("strips time and creates UTC midnight", () => {
     const date = new Date("2025-03-15T14:30:45.123Z");
-    const result = getDateOnly(date);
+    const result = toUTCMidnight(date);
 
     expect(result.getUTCHours()).toBe(0);
     expect(result.getUTCMinutes()).toBe(0);
@@ -13,6 +13,28 @@ describe(getDateOnly, () => {
     expect(result.getUTCFullYear()).toBe(2025);
     expect(result.getUTCMonth()).toBe(2);
     expect(result.getUTCDate()).toBe(15);
+  });
+});
+
+describe(clampEnergy, () => {
+  test("clamps below minimum to 0", () => {
+    expect(clampEnergy(-5)).toBe(0);
+  });
+
+  test("clamps above maximum to 100", () => {
+    expect(clampEnergy(150)).toBe(100);
+  });
+
+  test("returns value unchanged when within bounds", () => {
+    expect(clampEnergy(50)).toBe(50);
+  });
+
+  test("returns 0 at exact minimum", () => {
+    expect(clampEnergy(0)).toBe(0);
+  });
+
+  test("returns 100 at exact maximum", () => {
+    expect(clampEnergy(100)).toBe(100);
   });
 });
 

--- a/packages/utils/src/energy.ts
+++ b/packages/utils/src/energy.ts
@@ -1,14 +1,18 @@
-const MS_PER_DAY = 86_400_000;
+import { DAILY_DECAY, MAX_ENERGY, MIN_ENERGY, MS_PER_DAY } from "./constants";
 
-export function getDateOnly(date: Date): Date {
+export function toUTCMidnight(date: Date): Date {
   return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
 }
 
+export function clampEnergy(value: number): number {
+  return Math.min(MAX_ENERGY, Math.max(MIN_ENERGY, value));
+}
+
 export function computeDecayedEnergy(currentEnergy: number, lastActiveAt: Date, now: Date): number {
-  const lastActiveDate = getDateOnly(lastActiveAt);
-  const today = getDateOnly(now);
+  const lastActiveDate = toUTCMidnight(lastActiveAt);
+  const today = toUTCMidnight(now);
   const dayDiff = Math.round((today.getTime() - lastActiveDate.getTime()) / MS_PER_DAY);
   const inactiveDays = Math.max(0, dayDiff - 1);
 
-  return Math.max(0, currentEnergy - inactiveDays);
+  return Math.max(MIN_ENERGY, currentEnergy - inactiveDays * DAILY_DECAY);
 }

--- a/packages/utils/src/energy.ts
+++ b/packages/utils/src/energy.ts
@@ -1,0 +1,14 @@
+const MS_PER_DAY = 86_400_000;
+
+export function getDateOnly(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+export function computeDecayedEnergy(currentEnergy: number, lastActiveAt: Date, now: Date): number {
+  const lastActiveDate = getDateOnly(lastActiveAt);
+  const today = getDateOnly(now);
+  const dayDiff = Math.round((today.getTime() - lastActiveDate.getTime()) / MS_PER_DAY);
+  const inactiveDays = Math.max(0, dayDiff - 1);
+
+  return Math.max(0, currentEnergy - inactiveDays);
+}


### PR DESCRIPTION
## Summary

- Apply -1/day energy decay for each full inactive calendar day on both read (`getEnergyLevel`) and write (`submitActivityCompletion`)
- Fill `DailyProgress` gap records for missed inactive days when a user completes an activity
- Extract `computeDecayedEnergy` and `getDateOnly` into `@zoonk/utils/energy` for reuse
- Fix e2e flakiness by batching step attempt creation with `createMany` instead of 30 concurrent individual creates

## Test plan

- [x] Unit tests for `computeDecayedEnergy` and `getDateOnly` (7 cases)
- [x] Integration tests for `getEnergyLevel` with decay (5 cases)
- [x] Integration tests for `submitActivityCompletion` with decay gap-filling (17 cases)
- [x] E2E tests: main (373), editor (193), api (55) — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)