### PR TITLE
fix(test): fix flaky slug redirect e2e test

### DIFF
--- a/apps/editor/e2e/course-content.test.ts
+++ b/apps/editor/e2e/course-content.test.ts
@@ -123,6 +123,7 @@ test.describe("Course Content Page", () => {
     const uniqueSlug = `test-slug-${randomUUID().slice(0, 8)}`;
 
     await slugInput.fill(uniqueSlug);
+    await authenticatedPage.waitForLoadState("networkidle");
 
     const saveButton = authenticatedPage.getByRole("button", {
       name: /^save$/i,


### PR DESCRIPTION
## Summary
- Wait for `networkidle` after filling the slug input before clicking save, matching the pattern already used in the "saves on Enter key" test
- The `useDebounce` hook (300ms) triggers a slug-exists network check after fill — clicking save before that settles caused a race condition where the redirect wouldn't happen

## Test plan
- [x] Ran the specific test 3 times with zero failures
- [x] Verified other slug tests in the same file don't need the same fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky slug redirect e2e test by waiting for network idle after filling the slug input before clicking Save. This avoids a race with the 300ms debounced slug-exists request so the redirect reliably triggers.

<sup>Written for commit 1f5e3aec413ad55dca2fdb4118202bfa4cb693a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

