### PR TITLE
fix(main): filter non-brand orgs from continue learning and my courses

### DIFF
--- a/apps/main/src/data/courses/get-continue-learning.test.ts
+++ b/apps/main/src/data/courses/get-continue-learning.test.ts
@@ -256,42 +256,7 @@ describe("authenticated users", () => {
     const headers = await signInAs(user.email, user.password);
 
     const schoolOrg = await organizationFixture({ kind: "school" });
-
-    const course = await courseFixture({
-      isPublished: true,
-      organizationId: schoolOrg.id,
-    });
-
-    const chapter = await chapterFixture({
-      courseId: course.id,
-      isPublished: true,
-      organizationId: schoolOrg.id,
-      position: 0,
-    });
-
-    const lesson = await lessonFixture({
-      chapterId: chapter.id,
-      isPublished: true,
-      organizationId: schoolOrg.id,
-      position: 0,
-    });
-
-    const [activity1, activity2] = await Promise.all([
-      activityFixture({
-        generationStatus: "completed",
-        isPublished: true,
-        lessonId: lesson.id,
-        organizationId: schoolOrg.id,
-        position: 0,
-      }),
-      activityFixture({
-        generationStatus: "completed",
-        isPublished: true,
-        lessonId: lesson.id,
-        organizationId: schoolOrg.id,
-        position: 1,
-      }),
-    ]);
+    const { activity1, activity2 } = await createCourseWithActivities(schoolOrg.id);
 
     await Promise.all([
       activityProgressFixture({

--- a/apps/main/src/data/courses/list-user-courses.ts
+++ b/apps/main/src/data/courses/list-user-courses.ts
@@ -21,7 +21,12 @@ export const listUserCourses = cache(
       prisma.courseUser.findMany({
         include: { course: { include: { organization: true } } },
         orderBy: { startedAt: "desc" },
-        where: { userId },
+        where: {
+          course: {
+            OR: [{ organization: { kind: "brand" } }, { organizationId: null }],
+          },
+          userId,
+        },
       }),
     );
 

--- a/packages/db/src/prisma/sql/getContinueLearning.sql
+++ b/packages/db/src/prisma/sql/getContinueLearning.sql
@@ -19,7 +19,7 @@ WITH last_per_course AS (
   JOIN chapters ch ON ch.id = l.chapter_id AND ch.is_published = true
   JOIN courses c ON c.id = ch.course_id
   LEFT JOIN organizations o ON o.id = c.organization_id
-  WHERE ap.user_id = $1 AND ap.completed_at IS NOT NULL
+  WHERE ap.user_id = $1 AND ap.completed_at IS NOT NULL AND (o.kind = 'brand' OR o.id IS NULL)
   ORDER BY ch.course_id, ap.completed_at DESC
 )
 SELECT


### PR DESCRIPTION
## Summary

- Add org kind filter (`brand` or `null`) to `getContinueLearning` SQL query and `listUserCourses` Prisma query
- Non-brand org courses (school, team, creator) no longer appear in the main app's continue learning or my courses sections

## Test plan

- [x] Integration test: `getContinueLearning` excludes courses from non-brand orgs
- [x] Integration test: `listUserCourses` excludes non-brand orgs
- [x] Integration test: `listUserCourses` includes personal courses (null org)
- [x] All existing tests pass
- [x] E2E suites pass for main, editor, and api

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters out non-brand org courses from Continue Learning and My Courses so users only see brand org and personal courses.

- **Bug Fixes**
  - Applied org filter in getContinueLearning SQL and listUserCourses: only brand orgs or null org.
  - Added tests to ensure non-brand orgs are excluded and personal courses are included.
  - Reused createCourseWithActivities helper in tests.

<sup>Written for commit 4b936da01a2b7b6d7ca61ac1482b27d940fc3113. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

