### PR TITLE
feat(utils): support hiding subscription plans via env var

### DIFF
--- a/apps/main/src/app/[locale]/(settings)/subscription/subscription-plans.tsx
+++ b/apps/main/src/app/[locale]/(settings)/subscription/subscription-plans.tsx
@@ -84,7 +84,7 @@ export function SubscriptionPlansSkeleton() {
       <Skeleton className="h-9 w-48" />
 
       <div className="flex flex-col gap-3">
-        {Array.from({ length: 4 }, (_, i) => (
+        {Array.from({ length: SUBSCRIPTION_PLANS.length }, (_, i) => (
           <PlanRowSkeleton key={i} />
         ))}
       </div>

--- a/packages/utils/src/subscription.ts
+++ b/packages/utils/src/subscription.ts
@@ -28,7 +28,11 @@ export const FREE_PLAN: SubscriptionPlan = {
   tier: 0,
 };
 
-export const PAID_PLANS: readonly PaidPlan[] = [
+const HIDDEN_PLANS = new Set(
+  (process.env.HIDDEN_SUBSCRIPTION_PLANS ?? "").split(",").filter(Boolean),
+);
+
+const ALL_PAID_PLANS: readonly PaidPlan[] = [
   {
     annualLookupKey: PLAN_LOOKUP_KEYS.hobby.yearly,
     lookupKey: PLAN_LOOKUP_KEYS.hobby.monthly,
@@ -49,11 +53,16 @@ export const PAID_PLANS: readonly PaidPlan[] = [
   },
 ];
 
+export const PAID_PLANS: readonly PaidPlan[] = ALL_PAID_PLANS.filter(
+  (plan) => !HIDDEN_PLANS.has(plan.name),
+);
+
+const ALL_SUBSCRIPTION_PLANS: readonly SubscriptionPlan[] = [FREE_PLAN, ...ALL_PAID_PLANS];
 export const SUBSCRIPTION_PLANS: readonly SubscriptionPlan[] = [FREE_PLAN, ...PAID_PLANS];
 
 export function getPlanTier(planName: string | null): number {
   if (!planName) {
     return 0;
   }
-  return SUBSCRIPTION_PLANS.find((plan) => plan.name === planName)?.tier ?? 0;
+  return ALL_SUBSCRIPTION_PLANS.find((plan) => plan.name === planName)?.tier ?? 0;
 }


### PR DESCRIPTION
## Summary

- Add `HIDDEN_SUBSCRIPTION_PLANS` env var (comma-separated plan names) to filter plans at the data source in `subscription.ts`
- `getPlanTier` uses the full unfiltered list so existing subscribers on hidden plans still resolve correctly
- Skeleton row count now derives from `SUBSCRIPTION_PLANS.length` instead of hardcoded `4`

## Deployment

Set `HIDDEN_SUBSCRIPTION_PLANS=plus,pro` on Vercel to hide Plus and Pro. Remove (or empty) to re-enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for hiding specific subscription plans via the HIDDEN_SUBSCRIPTION_PLANS env var. Hidden plans are filtered at the data source, and existing subscribers on those plans still resolve to the correct tier.

- **New Features**
  - Hide paid plans by name via HIDDEN_SUBSCRIPTION_PLANS (comma-separated).
  - SubscriptionPlansSkeleton now uses SUBSCRIPTION_PLANS.length to render rows.

- **Migration**
  - Set HIDDEN_SUBSCRIPTION_PLANS=plus,pro on Vercel to hide Plus and Pro; remove or empty to show all.

<sup>Written for commit b77f597bcd0bfcbd59a22c48957ebef3100f0d0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

