### PR TITLE
feat(player): add animated belt progress bar to completion screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,10 +50,12 @@ yarn-error.log*
 tasks.json
 i18n.cache
 
-# Cursor
+# AI
 debug.log
+.claude/agent-memory
 
 # Tasks for AI agents
 /tasks/
+
 # next-agents-md
 .next-docs/

--- a/apps/main/e2e/activity-completion.test.ts
+++ b/apps/main/e2e/activity-completion.test.ts
@@ -114,7 +114,7 @@ test.describe("Activity Completion", () => {
 
     await expect(page.getByText("1/1")).toBeVisible();
     await expect(page.getByText("+10 BP")).toBeVisible();
-    await expect(page.getByText(/BP to next level/i)).toBeVisible();
+    await expect(page.getByRole("progressbar", { name: /level progress/i })).toBeVisible();
 
     await browserContext.close();
   });
@@ -154,7 +154,7 @@ test.describe("Activity Completion", () => {
 
     await expect(page.getByText("1/1")).toBeVisible();
     await expect(page.getByText(/sign up to track your progress/i)).toBeVisible();
-    await expect(page.getByText(/BP to next level/i)).not.toBeVisible();
+    await expect(page.getByRole("progressbar", { name: /level progress/i })).not.toBeVisible();
   });
 
   test("challenge success shows +100 BP badge", async ({ baseURL, browser }) => {
@@ -205,6 +205,7 @@ test.describe("Activity Completion", () => {
 
     await expect(page.getByText(/challenge complete/i)).toBeVisible();
     await expect(page.getByText("+100 BP")).toBeVisible();
+    await expect(page.getByRole("progressbar", { name: /level progress/i })).toBeVisible();
 
     await browserContext.close();
   });

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -307,9 +307,14 @@ msgid "Belt"
 msgstr "Belt"
 
 #: ../../packages/player/src/components/reward-badges.tsx
-msgctxt "HiBQnL"
-msgid "BP to next level"
-msgstr "BP to next level"
+msgctxt "IGs0wl"
+msgid "Level progress"
+msgstr "Level progress"
+
+#: ../../packages/player/src/components/reward-badges.tsx
+msgctxt "oMEE4o"
+msgid "{value} BP to level up"
+msgstr "{value} BP to level up"
 
 #: ../../packages/player/src/components/reward-badges.tsx
 #: src/app/[locale]/(catalog)/level.tsx

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -54,6 +54,29 @@ msgctxt "Ypr9T5"
 msgid "Incorrect"
 msgstr "Incorrect"
 
+#: ../../packages/player/src/components/belt-progress.tsx
+msgctxt "erSdxr"
+msgid "Belt"
+msgstr "Belt"
+
+#: ../../packages/player/src/components/belt-progress.tsx
+msgctxt "IGs0wl"
+msgid "Level progress"
+msgstr "Level progress"
+
+#: ../../packages/player/src/components/belt-progress.tsx
+msgctxt "oMEE4o"
+msgid "{value} BP to level up"
+msgstr "{value} BP to level up"
+
+#: ../../packages/player/src/components/belt-progress.tsx
+#: src/app/[locale]/(catalog)/level.tsx
+#: src/app/[locale]/(performance)/_components/metric-pills.tsx
+#: src/app/[locale]/(performance)/level/page.tsx
+msgctxt "y1Qr81"
+msgid "Level"
+msgstr "Level"
+
 #: ../../packages/player/src/components/challenge-completion.tsx
 #: ../../packages/player/src/components/completion-auth-branch.tsx
 msgctxt "7tB7n/"
@@ -300,29 +323,6 @@ msgstr "BP"
 msgctxt "cVpmV7"
 msgid "Energy"
 msgstr "Energy"
-
-#: ../../packages/player/src/components/reward-badges.tsx
-msgctxt "erSdxr"
-msgid "Belt"
-msgstr "Belt"
-
-#: ../../packages/player/src/components/reward-badges.tsx
-msgctxt "IGs0wl"
-msgid "Level progress"
-msgstr "Level progress"
-
-#: ../../packages/player/src/components/reward-badges.tsx
-msgctxt "oMEE4o"
-msgid "{value} BP to level up"
-msgstr "{value} BP to level up"
-
-#: ../../packages/player/src/components/reward-badges.tsx
-#: src/app/[locale]/(catalog)/level.tsx
-#: src/app/[locale]/(performance)/_components/metric-pills.tsx
-#: src/app/[locale]/(performance)/level/page.tsx
-msgctxt "y1Qr81"
-msgid "Level"
-msgstr "Level"
 
 #: ../../packages/player/src/components/select-image-step.tsx
 msgctxt "NA6C/+"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -54,6 +54,29 @@ msgctxt "Ypr9T5"
 msgid "Incorrect"
 msgstr "Incorrecto"
 
+#: ../../packages/player/src/components/belt-progress.tsx
+msgctxt "erSdxr"
+msgid "Belt"
+msgstr "Cinturón"
+
+#: ../../packages/player/src/components/belt-progress.tsx
+msgctxt "IGs0wl"
+msgid "Level progress"
+msgstr "Progreso de nivel"
+
+#: ../../packages/player/src/components/belt-progress.tsx
+msgctxt "oMEE4o"
+msgid "{value} BP to level up"
+msgstr "{value} PM para subir de nivel"
+
+#: ../../packages/player/src/components/belt-progress.tsx
+#: src/app/[locale]/(catalog)/level.tsx
+#: src/app/[locale]/(performance)/_components/metric-pills.tsx
+#: src/app/[locale]/(performance)/level/page.tsx
+msgctxt "y1Qr81"
+msgid "Level"
+msgstr "Nivel"
+
 #: ../../packages/player/src/components/challenge-completion.tsx
 #: ../../packages/player/src/components/completion-auth-branch.tsx
 msgctxt "7tB7n/"
@@ -300,29 +323,6 @@ msgstr "PM"
 msgctxt "cVpmV7"
 msgid "Energy"
 msgstr "Energía"
-
-#: ../../packages/player/src/components/reward-badges.tsx
-msgctxt "erSdxr"
-msgid "Belt"
-msgstr "Cinturón"
-
-#: ../../packages/player/src/components/reward-badges.tsx
-msgctxt "IGs0wl"
-msgid "Level progress"
-msgstr "Progreso de nivel"
-
-#: ../../packages/player/src/components/reward-badges.tsx
-msgctxt "oMEE4o"
-msgid "{value} BP to level up"
-msgstr "{value} PM para subir de nivel"
-
-#: ../../packages/player/src/components/reward-badges.tsx
-#: src/app/[locale]/(catalog)/level.tsx
-#: src/app/[locale]/(performance)/_components/metric-pills.tsx
-#: src/app/[locale]/(performance)/level/page.tsx
-msgctxt "y1Qr81"
-msgid "Level"
-msgstr "Nivel"
 
 #: ../../packages/player/src/components/select-image-step.tsx
 msgctxt "NA6C/+"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -307,9 +307,14 @@ msgid "Belt"
 msgstr "Cinturón"
 
 #: ../../packages/player/src/components/reward-badges.tsx
-msgctxt "HiBQnL"
-msgid "BP to next level"
-msgstr "PM para el siguiente nivel"
+msgctxt "IGs0wl"
+msgid "Level progress"
+msgstr "Progreso de nivel"
+
+#: ../../packages/player/src/components/reward-badges.tsx
+msgctxt "oMEE4o"
+msgid "{value} BP to level up"
+msgstr "{value} PM para subir de nivel"
 
 #: ../../packages/player/src/components/reward-badges.tsx
 #: src/app/[locale]/(catalog)/level.tsx

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -54,6 +54,29 @@ msgctxt "Ypr9T5"
 msgid "Incorrect"
 msgstr "Incorreto"
 
+#: ../../packages/player/src/components/belt-progress.tsx
+msgctxt "erSdxr"
+msgid "Belt"
+msgstr "Faixa"
+
+#: ../../packages/player/src/components/belt-progress.tsx
+msgctxt "IGs0wl"
+msgid "Level progress"
+msgstr "Progresso do nível"
+
+#: ../../packages/player/src/components/belt-progress.tsx
+msgctxt "oMEE4o"
+msgid "{value} BP to level up"
+msgstr "{value} PM para subir de nível"
+
+#: ../../packages/player/src/components/belt-progress.tsx
+#: src/app/[locale]/(catalog)/level.tsx
+#: src/app/[locale]/(performance)/_components/metric-pills.tsx
+#: src/app/[locale]/(performance)/level/page.tsx
+msgctxt "y1Qr81"
+msgid "Level"
+msgstr "Nível"
+
 #: ../../packages/player/src/components/challenge-completion.tsx
 #: ../../packages/player/src/components/completion-auth-branch.tsx
 msgctxt "7tB7n/"
@@ -300,29 +323,6 @@ msgstr "PM"
 msgctxt "cVpmV7"
 msgid "Energy"
 msgstr "Energia"
-
-#: ../../packages/player/src/components/reward-badges.tsx
-msgctxt "erSdxr"
-msgid "Belt"
-msgstr "Faixa"
-
-#: ../../packages/player/src/components/reward-badges.tsx
-msgctxt "IGs0wl"
-msgid "Level progress"
-msgstr "Progresso do nível"
-
-#: ../../packages/player/src/components/reward-badges.tsx
-msgctxt "oMEE4o"
-msgid "{value} BP to level up"
-msgstr "{value} PM para subir de nível"
-
-#: ../../packages/player/src/components/reward-badges.tsx
-#: src/app/[locale]/(catalog)/level.tsx
-#: src/app/[locale]/(performance)/_components/metric-pills.tsx
-#: src/app/[locale]/(performance)/level/page.tsx
-msgctxt "y1Qr81"
-msgid "Level"
-msgstr "Nível"
 
 #: ../../packages/player/src/components/select-image-step.tsx
 msgctxt "NA6C/+"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -307,9 +307,14 @@ msgid "Belt"
 msgstr "Faixa"
 
 #: ../../packages/player/src/components/reward-badges.tsx
-msgctxt "HiBQnL"
-msgid "BP to next level"
-msgstr "PM para o próximo nível"
+msgctxt "IGs0wl"
+msgid "Level progress"
+msgstr "Progresso do nível"
+
+#: ../../packages/player/src/components/reward-badges.tsx
+msgctxt "oMEE4o"
+msgid "{value} BP to level up"
+msgstr "{value} PM para subir de nível"
 
 #: ../../packages/player/src/components/reward-badges.tsx
 #: src/app/[locale]/(catalog)/level.tsx

--- a/apps/main/src/data/progress/get-belt-level.test.ts
+++ b/apps/main/src/data/progress/get-belt-level.test.ts
@@ -33,10 +33,12 @@ describe("authenticated users", () => {
 
     const result = await getBeltLevel(headers);
     expect(result).toEqual({
+      bpPerLevel: 1000,
       bpToNextLevel: 500,
       color: "orange",
       isMaxLevel: false,
       level: 8,
+      progressInLevel: 500,
     });
   });
 
@@ -54,10 +56,12 @@ describe("authenticated users", () => {
     const result = await getBeltLevel(headers);
 
     expect(result).toEqual({
+      bpPerLevel: 250,
       bpToNextLevel: 250,
       color: "white",
       isMaxLevel: false,
       level: 1,
+      progressInLevel: 0,
     });
   });
 });

--- a/i18n.lock
+++ b/i18n.lock
@@ -195,7 +195,82 @@ checksums:
     Business/singular: 7682c7966c6e718836388561e7e68cab
     Geography/singular: fd93fe516c40f1f2dd96f53a507ce95d
   9270df1bc9e10fdb8026bb4ab67061d4:
+    Your%20answer/singular: 016cfa0eceeaa32f8ed699a0668a278b
+    Correct/singular: c643eeb0a615de2032eca68722c31177
+    Tap%20words%20to%20build%20your%20answer/singular: 025315562266cdfc630efa8b5de74961
+    Word%20bank/singular: ceea720dd5fa3747c7f93ce165f77b2e
+    "%7Bitem%7D.%20%7Bresult%7D./singular": 454dd5319c350f361652396801a1c30b
+    Position%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: a1b3d3e026bfff43bff3d3e85ccdb952
+    Correct%20answer%3A%20%7Banswer%7D/singular: 7745b2664e841dffff4568203ee443b2
+    Incorrect/singular: a86cfbe7b86f19dc8df14a67df073d22
+    Back%20to%20Lesson/singular: e2dbef5a2fefae8f9cee708e53e61cb9
+    Challenge%20Complete/singular: 7854472cc9245aaa8a13f54514968506
+    Final%20dimension%20scores/singular: aa4efa7ecef99d375c1daf4c6585ba98
+    Some%20of%20your%20stats%20went%20below%20zero./singular: bc281c87ae70abd076e3e73aa263ddc2
+    Try%20Again/singular: d65fad81c5f8f90405b26bf6e5d70ab9
+    Challenge%20Failed/singular: e9b1d1d02118f2e2ddc34907748955c4
+    Make%20choices./singular: 0861e9651cbff7146aee6cafb92128a8
+    Balance%20the%20outcome./singular: bce81c0b25b5ab019b5ce5dba5a12c3f
+    Challenge/singular: 7f333a59ee7a3596e27a2f8c3401b764
+    You'll%20face%20a%20series%20of%20decisions.%20Each%20one%20shifts%20your%20scores.%20Don't%20let%20any%20go%20negative./singular: 026dc19377a9b04a9bfce46cf8bcfa16
+    Starting%20scores/singular: 6a21f8424cdc75e477c3d7857a97db6d
+    Begin/singular: cc2a17a662cb60dd2d8335a2e8440997
+    Your%20scores/singular: 1700f65ead0647bc4876f4b3b6453a8b
+    Restart/singular: bab6232e89f24e3129f8e48268739d5b
+    Next/singular: 89ddbcf710eba274963494f312bdc8a9
     Login/singular: f4f219abeb5a465ecb1c7efaf50246de
+    Sign%20up%20to%20track%20your%20progress/singular: 554ed29d9b8a243362c3b3374222af08
+    Completed/singular: 0e4bbce9985f25eb673d9a054c8d5334
+    correct/singular: 0c2df4a764cea47295c0b550477e8e29
+    Current%20dimension%20scores/singular: b3a4b7edbd41132e6fb349a6df24a33d
+    View%20stats/singular: 707f91e0ff65e7163c95900395dc0297
+    Stats/singular: 5cf8b052c89fa1b05397a956ebec69b2
+    Outcome/singular: 4cfc7a40e384ea8b6658e8da6e351bf0
+    Dimension%20inventory/singular: a150bc3e032ae9e9202db1b375029aae
+    Blank%20%7Bposition%7D/singular: 70a4795f65f91685071b6abb1c3a6bad
+    Blank%20%7Bposition%7D%3A%20%7Bitem%7D.%20%7Bresult%7D./singular: c64e721cdd1e4cc48eff9f9690f1fc6b
+    Blank%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: d7ab9b86256fae5fbb5187fe718afe0b
+    Not%20quite/singular: e570085e69662802acf485c4565e3e3e
+    Correct!/singular: dda1a98dc04fd9db252887ecf1765d41
+    Translate%20this%20sentence%3A/singular: f69b2eec827b3a74bafca50e9058716f
+    What%20do%20you%20hear%3F/singular: 9527d094d65c550a40108673bc67744f
+    Pause%20audio/singular: a18f2dcad1748fe33e5f8ab62bc49075
+    Play%20audio/singular: b144bc2118a0803bb8c05c58740c33ba
+    All%20pairs%20matched.%20Press%20Check%20to%20continue./singular: 0663e33ba7db53b298c5f50a2f3c7ae8
+    Answer%20options/singular: acb0b378cefcb8a8d50a7c43ce77ae39
+    What%20do%20you%20say%3F/singular: 75887288b85fc19e67b7d20550d9205e
+    Someone%20says%3A/singular: 09f34dce0528b57e89c8757b5745e6c5
+    Previous%20step/singular: 96b31ec6dab003c2bbfbbca10a8a9826
+    Next%20step/singular: 712c63650b5180cbc14d6246b5d558c2
+    Step%20navigation/singular: ec328f28051577e1c0aab044c89b138c
+    Close/singular: 2c2e22f8424a1031de89063bd0022e16
+    Activity%20progress/singular: 8ff2fb7372b8a2525f2955c851c4fa42
+    Continue/singular: 3cfba90b4600131e82fc4260c568d044
+    Check/singular: 023cc2ba432775c38e3efc004ad7b9ef
+    BP/singular: 842ed01b3a4d0efa6fe96ae8c595726c
+    Energy/singular: 958809db5050650b97519e0f1f3e1951
+    Belt/singular: fa36e8e36732c223d2876c0337d372e9
+    Level%20progress/singular: 286f095acd17006787247db0b69270e3
+    "%7Bvalue%7D%20BP%20to%20level%20up/singular": 755c2fe6e435645cb35b57bf92af09d3
+    Level/singular: 1e3bf31d5c6083e898dd3e3359fbb0c2
+    Image%20options/singular: 64a1aee44b26dbaff851cb846eb4274d
+    Drag%20items%20into%20the%20correct%20order/singular: 8ccab82ee3ba645ac23da4ca14a0dd2a
+    Sort%20items/singular: 3b1072a596203b5acdc5718d38161392
+    Correct%20order%3A/singular: df3f446653ec8cde9c29d8d5912636ef
+    Legend/singular: 3b588fbd2fe35ded6ca38334e15400c3
+    Diagram/singular: e0bc1ef7782cb0d749c9582da6775175
+    Timeline/singular: 342b1e646f0634e47112092db1a24f49
+    Translate%20this%20word%3A/singular: 05fede3c583e9ea39f27ac9fdf17fcc3
+    Green/singular: 482ff383a4258357ba404f283682471d
+    Yellow/singular: 15d533755d35af887dfa584975549fda
+    Red/singular: bace0083b78cdb188523bc4abc7b55c6
+    Brown/singular: 82d5fc088538ffd2a24581d1ca1836ef
+    Blue/singular: a5cf034b2d370a976119335cd99f4217
+    Orange/singular: 836094fa3fcf7488957f6d7cba7c1f60
+    White/singular: 5d3dd2b57ed2fc668362b9b9efd8fb41
+    Purple/singular: 547ba93b6f68317e2dfbafb16cabc30f
+    Black/singular: 0a78282fb00e09a335608b154ffa01de
+    Gray/singular: 54ec745c22b59509822468ba82070d74
     Logout/singular: 07948fdf20705e04a7bf68ab197512bf
     Pages/singular: 75088c94fb3c374efd452624d4b74be8
     My%20account/singular: 4791806fd9fadc33912e3df7e4e3911c
@@ -246,7 +321,6 @@ checksums:
     Explore%20courses/singular: 3a60fa1d4a1a6cfffcc0573e3366cd35
     Explore%20all%20Zoonk%20courses%20to%20learn%20anything%20using%20AI.%20Find%20interactive%20lessons%2C%20challenges%2C%20and%20activities%20to%20learn%20subjects%20like%20science%2C%20math%2C%20technology%2C%20and%20more./singular: c3f4a7dfd17b4523b5535f40170c7731
     Your%20energy%20is%20%7Bvalue%7D%25/singular: d5ae9aecd778267fbc44c9e681c91637
-    Energy/singular: 958809db5050650b97519e0f1f3e1951
     Keep%20learning%20to%20increase%20it/singular: a3c3f15ac29089d9448b0971126cabf7
     Keep%20learning%20to%20maintain%20it/singular: 0d21c6a7c014a9e42e97c37d4e8d9674
     Learn%20anything/singular: 1409ee983014ff2deefb61aa0fbc570d
@@ -270,7 +344,6 @@ checksums:
     "%7Bvalue%7D%20BP%20to%20next%20level/singular": dc80ce93407f21e5e909760ec2c9aaef
     Max%20level%20reached/singular: 5bfdf2d9ba3929b456dcf5c253315e92
     "%7Bcolor%7D%20Belt%20-%20Level%20%7Blevel%7D/singular": abb5a7600bd66f523906425beffbaff4
-    Level/singular: 1e3bf31d5c6083e898dd3e3359fbb0c2
     Continue%20where%20you%20left%20off/singular: c3ef4fd14e046d53816ede13fc5d27fc
     My%20Courses/singular: 3031c7801404796addff2b7d796fa4c2
     View%20all%20the%20courses%20you%20started%20on%20Zoonk.%20Continue%20where%20you%20left%20off%20and%20track%20your%20progress%20across%20interactive%20lessons%20and%20activities./singular: eee1ce9f3b0be49ddc9bb3ce21270796
@@ -315,7 +388,6 @@ checksums:
     "%7Bcolor%7D%20Belt%2C%20Level%20%7Blevel%7D%20of%2010.%20%7Bbp%7D%20brain%20power%20until%20next%20level./singular": e367a07e36f925916dfd40e71129786b
     "%7Bcolor%7D%20Belt%2C%20Level%20%7Blevel%7D%20of%2010.%20Maximum%20level%20achieved./singular": f76961b35ae61781509ea9f0b5c19849
     "%7Bcurrent%7D%2F10/singular": ae23c13a041f3d7fe6e13ca4927ad01e
-    BP/singular: 842ed01b3a4d0efa6fe96ae8c595726c
     "%7Bvalue%7D%20BP%20earned/singular": 583e121af4a624edef99166b4af272c0
     Total%20Brain%20Power/singular: d20bd99b8345101df62b8fa365c9b2dc
     Track%20your%20level%20progress%20and%20see%20how%20you%20advance./singular: 25792319622e431462e5963816d3a1c1
@@ -423,67 +495,6 @@ checksums:
     Privacy%20Policy/singular: 7459744a63ef8af4e517a09024bd7c08
     Read%20Zoonk's%20terms%20of%20use%20to%20understand%20the%20rules%20and%20conditions%20for%20using%20our%20platform%20and%20services/singular: 4b82898d60691839a1999e4a17199895
     Terms%20of%20Use/singular: 9ac262b2eda552beeecd904c0b9f8fa2
-    Continue/singular: 3cfba90b4600131e82fc4260c568d044
-    Check/singular: 023cc2ba432775c38e3efc004ad7b9ef
-    Your%20answer/singular: 016cfa0eceeaa32f8ed699a0668a278b
-    Correct/singular: c643eeb0a615de2032eca68722c31177
-    Tap%20words%20to%20build%20your%20answer/singular: 025315562266cdfc630efa8b5de74961
-    Word%20bank/singular: ceea720dd5fa3747c7f93ce165f77b2e
-    "%7Bitem%7D.%20%7Bresult%7D./singular": 454dd5319c350f361652396801a1c30b
-    Position%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: a1b3d3e026bfff43bff3d3e85ccdb952
-    Correct%20answer%3A%20%7Banswer%7D/singular: 7745b2664e841dffff4568203ee443b2
-    Incorrect/singular: a86cfbe7b86f19dc8df14a67df073d22
-    Back%20to%20Lesson/singular: e2dbef5a2fefae8f9cee708e53e61cb9
-    Challenge%20Complete/singular: 7854472cc9245aaa8a13f54514968506
-    Final%20dimension%20scores/singular: aa4efa7ecef99d375c1daf4c6585ba98
-    Some%20of%20your%20stats%20went%20below%20zero./singular: bc281c87ae70abd076e3e73aa263ddc2
-    Try%20Again/singular: d65fad81c5f8f90405b26bf6e5d70ab9
-    Challenge%20Failed/singular: e9b1d1d02118f2e2ddc34907748955c4
-    Make%20choices./singular: 0861e9651cbff7146aee6cafb92128a8
-    Balance%20the%20outcome./singular: bce81c0b25b5ab019b5ce5dba5a12c3f
-    Challenge/singular: 7f333a59ee7a3596e27a2f8c3401b764
-    You'll%20face%20a%20series%20of%20decisions.%20Each%20one%20shifts%20your%20scores.%20Don't%20let%20any%20go%20negative./singular: 026dc19377a9b04a9bfce46cf8bcfa16
-    Starting%20scores/singular: 6a21f8424cdc75e477c3d7857a97db6d
-    Begin/singular: cc2a17a662cb60dd2d8335a2e8440997
-    Your%20scores/singular: 1700f65ead0647bc4876f4b3b6453a8b
-    Legend/singular: 3b588fbd2fe35ded6ca38334e15400c3
-    Restart/singular: bab6232e89f24e3129f8e48268739d5b
-    Next/singular: 89ddbcf710eba274963494f312bdc8a9
-    Sign%20up%20to%20track%20your%20progress/singular: 554ed29d9b8a243362c3b3374222af08
-    Completed/singular: 0e4bbce9985f25eb673d9a054c8d5334
-    correct/singular: 0c2df4a764cea47295c0b550477e8e29
-    Diagram/singular: e0bc1ef7782cb0d749c9582da6775175
-    Current%20dimension%20scores/singular: b3a4b7edbd41132e6fb349a6df24a33d
-    View%20stats/singular: 707f91e0ff65e7163c95900395dc0297
-    Stats/singular: 5cf8b052c89fa1b05397a956ebec69b2
-    Outcome/singular: 4cfc7a40e384ea8b6658e8da6e351bf0
-    Dimension%20inventory/singular: a150bc3e032ae9e9202db1b375029aae
-    Blank%20%7Bposition%7D/singular: 70a4795f65f91685071b6abb1c3a6bad
-    Blank%20%7Bposition%7D%3A%20%7Bitem%7D.%20%7Bresult%7D./singular: c64e721cdd1e4cc48eff9f9690f1fc6b
-    Blank%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: d7ab9b86256fae5fbb5187fe718afe0b
-    Not%20quite/singular: e570085e69662802acf485c4565e3e3e
-    Correct!/singular: dda1a98dc04fd9db252887ecf1765d41
-    Translate%20this%20sentence%3A/singular: f69b2eec827b3a74bafca50e9058716f
-    What%20do%20you%20hear%3F/singular: 9527d094d65c550a40108673bc67744f
-    Pause%20audio/singular: a18f2dcad1748fe33e5f8ab62bc49075
-    Play%20audio/singular: b144bc2118a0803bb8c05c58740c33ba
-    All%20pairs%20matched.%20Press%20Check%20to%20continue./singular: 0663e33ba7db53b298c5f50a2f3c7ae8
-    Answer%20options/singular: acb0b378cefcb8a8d50a7c43ce77ae39
-    What%20do%20you%20say%3F/singular: 75887288b85fc19e67b7d20550d9205e
-    Someone%20says%3A/singular: 09f34dce0528b57e89c8757b5745e6c5
-    Previous%20step/singular: 96b31ec6dab003c2bbfbbca10a8a9826
-    Next%20step/singular: 712c63650b5180cbc14d6246b5d558c2
-    Step%20navigation/singular: ec328f28051577e1c0aab044c89b138c
-    Close/singular: 2c2e22f8424a1031de89063bd0022e16
-    Activity%20progress/singular: 8ff2fb7372b8a2525f2955c851c4fa42
-    Belt/singular: fa36e8e36732c223d2876c0337d372e9
-    BP%20to%20next%20level/singular: e77c5d6498ff38284c1f6b0721b8b33d
-    Image%20options/singular: 64a1aee44b26dbaff851cb846eb4274d
-    Drag%20items%20into%20the%20correct%20order/singular: 8ccab82ee3ba645ac23da4ca14a0dd2a
-    Sort%20items/singular: 3b1072a596203b5acdc5718d38161392
-    Correct%20order%3A/singular: df3f446653ec8cde9c29d8d5912636ef
-    Timeline/singular: 342b1e646f0634e47112092db1a24f49
-    Translate%20this%20word%3A/singular: 05fede3c583e9ea39f27ac9fdf17fcc3
     Not%20completed/singular: d011b1ae92a1a8a2676a5d6999bbe6d4
     This%20content%20was%20generated%20by%20AI.%20It%20may%20contain%20errors%20or%20inaccuracies%20and%20should%20not%20be%20considered%20professional%20advice./singular: 269e7c16a722903b9b434f28aa6cf617
     Not%20helpful/singular: ceb8a457e7e4c62a465cd1dd2620990e
@@ -550,16 +561,6 @@ checksums:
     Improve%20your%20%7Btopic%7D%20reading%20comprehension%20by%20translating%20sentences%20and%20passages./singular: 60baac4222f76009cc1eb1b6065b403b
     Shows%20WHEN%20to%20apply%20this%20topic.%20A%20dialogue%20with%20a%20colleague%20where%20you%20solve%20a%20real%20problem%20together./singular: 3fb0934c1e0a5ba3e31b6cc5b897b509
     Tests%20your%20understanding%20with%20questions.%20Uses%20new%20scenarios%20to%20check%20if%20you%20grasped%20the%20concept%2C%20not%20just%20memorized%20it./singular: feeb1e59f787035a964dd93290e180e7
-    Green/singular: 482ff383a4258357ba404f283682471d
-    Yellow/singular: 15d533755d35af887dfa584975549fda
-    Red/singular: bace0083b78cdb188523bc4abc7b55c6
-    Brown/singular: 82d5fc088538ffd2a24581d1ca1836ef
-    Blue/singular: a5cf034b2d370a976119335cd99f4217
-    Orange/singular: 836094fa3fcf7488957f6d7cba7c1f60
-    White/singular: 5d3dd2b57ed2fc668362b9b9efd8fb41
-    Purple/singular: 547ba93b6f68317e2dfbafb16cabc30f
-    Black/singular: 0a78282fb00e09a335608b154ffa01de
-    Gray/singular: 54ec745c22b59509822468ba82070d74
     History/singular: b0578d6d225f512e42f823fbca2e3c32
     Math/singular: 0a604ffa5ef57408918fe98ef05eb05a
     Arts/singular: 9b1845cec1210e57ea990b1a90823228

--- a/packages/player/src/components/belt-progress.tsx
+++ b/packages/player/src/components/belt-progress.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { BeltIndicator, beltColorClasses } from "@zoonk/ui/components/belt-indicator";
+import { ProgressIndicator, ProgressRoot, ProgressTrack } from "@zoonk/ui/components/progress";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { cn } from "@zoonk/ui/lib/utils";
+import { calculateBeltLevel, getBeltProgressPercent } from "@zoonk/utils/belt-level";
+import { useExtracted } from "next-intl";
+import { useEffect, useState } from "react";
+import { usePlayer } from "../player-context";
+import { useBeltColorLabel } from "../use-belt-color-label";
+
+type LevelUpPhase = "filling" | "resetting" | "done";
+
+/**
+ * Triggers animation start after first paint.
+ *
+ * This is a legitimate useEffect: we need the browser to paint the
+ * initial state (previousPercent) before transitioning to the target.
+ * No event handler exists for "component finished painting."
+ */
+function useAnimationStarted(): boolean {
+  const [started, setStarted] = useState(false);
+  useEffect(() => setStarted(true), []);
+  return started;
+}
+
+function getDisplayPercent(phase: LevelUpPhase, currentPercent: number): number {
+  if (phase === "filling") {
+    return 100;
+  }
+  if (phase === "resetting") {
+    return 0;
+  }
+  return currentPercent;
+}
+
+export function BeltProgressHint({
+  brainPower,
+  newTotalBp,
+}: {
+  brainPower: number;
+  newTotalBp: number;
+}) {
+  const t = useExtracted();
+  const { levelHref, LinkComponent } = usePlayer();
+  const currentBelt = calculateBeltLevel(newTotalBp);
+  const previousBelt = calculateBeltLevel(newTotalBp - brainPower);
+  const didLevelUp =
+    currentBelt.color !== previousBelt.color || currentBelt.level !== previousBelt.level;
+  const currentColorLabel = useBeltColorLabel(currentBelt.color);
+  const previousColorLabel = useBeltColorLabel(previousBelt.color);
+
+  const currentPercent = getBeltProgressPercent(currentBelt);
+  const previousPercent = getBeltProgressPercent(previousBelt);
+
+  const animationStarted = useAnimationStarted();
+  const [levelUpPhase, setLevelUpPhase] = useState<LevelUpPhase>("filling");
+
+  const showCurrentBelt = !didLevelUp || levelUpPhase !== "filling";
+  const displayColor = showCurrentBelt ? currentBelt.color : previousBelt.color;
+  const displayLabel = showCurrentBelt ? currentColorLabel : previousColorLabel;
+  const displayLevel = showCurrentBelt ? currentBelt.level : previousBelt.level;
+
+  const displayPercent = getDisplayPercent(
+    animationStarted && didLevelUp ? levelUpPhase : "done",
+    currentPercent,
+  );
+
+  const skipTransition = levelUpPhase === "resetting";
+
+  function handleTransitionEnd() {
+    if (!didLevelUp || levelUpPhase !== "filling") {
+      return;
+    }
+    // Two-frame sequence: first frame paints 0% with no transition,
+    // second frame starts the transition to currentPercent.
+    setLevelUpPhase("resetting");
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => setLevelUpPhase("done"));
+    });
+  }
+
+  if (currentBelt.isMaxLevel || !levelHref) {
+    return null;
+  }
+
+  return (
+    <LinkComponent className="flex flex-col gap-1.5" href={levelHref}>
+      <div className="flex items-center gap-1.5">
+        <BeltIndicator
+          className={didLevelUp ? "animate-dot-pulse motion-reduce:animate-none" : undefined}
+          color={displayColor}
+          label={displayLabel}
+          size="sm"
+        />
+        <span className="text-foreground text-sm font-medium">
+          {displayLabel} {t("Belt")} — {t("Level")} {displayLevel}
+        </span>
+      </div>
+      <ProgressRoot
+        aria-label={t("Level progress")}
+        value={animationStarted ? displayPercent : previousPercent}
+      >
+        <ProgressTrack className="h-1.5">
+          <ProgressIndicator
+            className={cn(
+              beltColorClasses[displayColor],
+              skipTransition ? "duration-0" : "duration-600 ease-out",
+              "motion-reduce:duration-0",
+            )}
+            onTransitionEnd={handleTransitionEnd}
+          />
+        </ProgressTrack>
+      </ProgressRoot>
+      <span className="text-muted-foreground text-xs tabular-nums">
+        {t("{value} BP to level up", { value: String(currentBelt.bpToNextLevel) })}
+      </span>
+    </LinkComponent>
+  );
+}
+
+export function BeltProgressSkeleton() {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-1.5">
+        <Skeleton className="size-3 rounded-full" />
+        <Skeleton className="h-4 w-36" />
+      </div>
+      <Skeleton className="h-1.5 w-full rounded-4xl" />
+      <Skeleton className="h-3 w-16" />
+    </div>
+  );
+}

--- a/packages/player/src/components/challenge-completion.tsx
+++ b/packages/player/src/components/challenge-completion.tsx
@@ -8,13 +8,9 @@ import { useExtracted } from "next-intl";
 import { type CompletionResult } from "../completion-input-schema";
 import { usePlayer } from "../player-context";
 import { type DimensionInventory } from "../player-reducer";
+import { BeltProgressHint, BeltProgressSkeleton } from "./belt-progress";
 import { DimensionList, buildDimensionEntries } from "./dimension-inventory";
-import {
-  BeltProgressHint,
-  BeltProgressSkeleton,
-  RewardBadges,
-  RewardBadgesSkeleton,
-} from "./reward-badges";
+import { RewardBadges, RewardBadgesSkeleton } from "./reward-badges";
 
 function ChallengeScreen({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/packages/player/src/components/challenge-completion.tsx
+++ b/packages/player/src/components/challenge-completion.tsx
@@ -9,7 +9,12 @@ import { type CompletionResult } from "../completion-input-schema";
 import { usePlayer } from "../player-context";
 import { type DimensionInventory } from "../player-reducer";
 import { DimensionList, buildDimensionEntries } from "./dimension-inventory";
-import { RewardBadges, RewardBadgesSkeleton } from "./reward-badges";
+import {
+  BeltProgressHint,
+  BeltProgressSkeleton,
+  RewardBadges,
+  RewardBadgesSkeleton,
+} from "./reward-badges";
 
 function ChallengeScreen({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -44,15 +49,28 @@ function ChallengeRewardBadges({
   isSuccess: boolean;
 }) {
   if (!completionResult || completionResult.status !== "success") {
-    return <RewardBadgesSkeleton />;
+    return (
+      <>
+        <RewardBadgesSkeleton />
+        {isSuccess && <BeltProgressSkeleton />}
+      </>
+    );
   }
 
   return (
-    <RewardBadges
-      brainPower={completionResult.brainPower}
-      energyDelta={completionResult.energyDelta}
-      isChallenge={isSuccess}
-    />
+    <>
+      <RewardBadges
+        brainPower={completionResult.brainPower}
+        energyDelta={completionResult.energyDelta}
+        isChallenge={isSuccess}
+      />
+      {isSuccess && (
+        <BeltProgressHint
+          brainPower={completionResult.brainPower}
+          newTotalBp={completionResult.newTotalBp}
+        />
+      )}
+    </>
   );
 }
 

--- a/packages/player/src/components/completion-auth-branch.tsx
+++ b/packages/player/src/components/completion-auth-branch.tsx
@@ -8,12 +8,8 @@ import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { type CompletionResult } from "../completion-input-schema";
 import { usePlayer } from "../player-context";
-import {
-  BeltProgressHint,
-  BeltProgressSkeleton,
-  RewardBadges,
-  RewardBadgesSkeleton,
-} from "./reward-badges";
+import { BeltProgressHint, BeltProgressSkeleton } from "./belt-progress";
+import { RewardBadges, RewardBadgesSkeleton } from "./reward-badges";
 
 function CompletionActions({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/packages/player/src/components/reward-badges.tsx
+++ b/packages/player/src/components/reward-badges.tsx
@@ -1,16 +1,10 @@
 "use client";
 
 import { Badge } from "@zoonk/ui/components/badge";
-import { BeltIndicator, beltColorClasses } from "@zoonk/ui/components/belt-indicator";
-import { ProgressIndicator, ProgressRoot, ProgressTrack } from "@zoonk/ui/components/progress";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { cn } from "@zoonk/ui/lib/utils";
-import { calculateBeltLevel, getBeltProgressPercent } from "@zoonk/utils/belt-level";
 import { BrainIcon, ZapIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
-import { useEffect, useState } from "react";
-import { usePlayer } from "../player-context";
-import { useBeltColorLabel } from "../use-belt-color-label";
 
 function formatEnergyDelta(delta: number): string {
   const sign = delta >= 0 ? "+" : "";
@@ -55,152 +49,6 @@ export function RewardBadgesSkeleton() {
     <div className="flex gap-2">
       <Skeleton className="h-5 w-20" />
       <Skeleton className="h-5 w-16" />
-    </div>
-  );
-}
-
-const ANIMATION_START_DELAY = 50;
-const LEVEL_UP_RESET_DELAY = 700;
-
-function useBeltProgressAnimation({
-  currentPercent,
-  didLevelUp,
-  levelUpUpdater,
-  previousPercent,
-}: {
-  currentPercent: number;
-  didLevelUp: boolean;
-  levelUpUpdater: () => void;
-  previousPercent: number;
-}) {
-  const [displayPercent, setDisplayPercent] = useState(previousPercent);
-  const [skipTransition, setSkipTransition] = useState(false);
-
-  useEffect(() => {
-    const timers: ReturnType<typeof setTimeout>[] = [];
-    const frames: number[] = [];
-
-    if (!didLevelUp) {
-      timers.push(setTimeout(() => setDisplayPercent(currentPercent), ANIMATION_START_DELAY));
-      return () => timers.forEach((timer) => clearTimeout(timer));
-    }
-
-    timers.push(setTimeout(() => setDisplayPercent(100), ANIMATION_START_DELAY));
-
-    timers.push(
-      setTimeout(() => {
-        setSkipTransition(true);
-        setDisplayPercent(0);
-        levelUpUpdater();
-
-        frames.push(
-          requestAnimationFrame(() => {
-            frames.push(
-              requestAnimationFrame(() => {
-                setSkipTransition(false);
-                setDisplayPercent(currentPercent);
-              }),
-            );
-          }),
-        );
-      }, LEVEL_UP_RESET_DELAY),
-    );
-
-    return () => {
-      timers.forEach((timer) => clearTimeout(timer));
-      frames.forEach((frame) => cancelAnimationFrame(frame));
-    };
-    // Animation runs only on mount — values are captured in closure
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  return { displayPercent, skipTransition };
-}
-
-export function BeltProgressHint({
-  brainPower,
-  newTotalBp,
-}: {
-  brainPower: number;
-  newTotalBp: number;
-}) {
-  const t = useExtracted();
-  const { levelHref, LinkComponent } = usePlayer();
-  const currentBelt = calculateBeltLevel(newTotalBp);
-  const previousBelt = calculateBeltLevel(newTotalBp - brainPower);
-  const didLevelUp =
-    currentBelt.color !== previousBelt.color || currentBelt.level !== previousBelt.level;
-  const currentColorLabel = useBeltColorLabel(currentBelt.color);
-  const previousColorLabel = useBeltColorLabel(previousBelt.color);
-
-  const currentPercent = getBeltProgressPercent(currentBelt);
-  const previousPercent = getBeltProgressPercent(previousBelt);
-
-  const [displayColor, setDisplayColor] = useState(
-    didLevelUp ? previousBelt.color : currentBelt.color,
-  );
-  const [displayLabel, setDisplayLabel] = useState(
-    didLevelUp ? previousColorLabel : currentColorLabel,
-  );
-  const [displayLevel, setDisplayLevel] = useState(
-    didLevelUp ? previousBelt.level : currentBelt.level,
-  );
-
-  const { displayPercent, skipTransition } = useBeltProgressAnimation({
-    currentPercent,
-    didLevelUp,
-    levelUpUpdater: () => {
-      setDisplayColor(currentBelt.color);
-      setDisplayLabel(currentColorLabel);
-      setDisplayLevel(currentBelt.level);
-    },
-    previousPercent,
-  });
-
-  if (currentBelt.isMaxLevel || !levelHref) {
-    return null;
-  }
-
-  return (
-    <LinkComponent className="flex flex-col gap-1.5" href={levelHref}>
-      <div className="flex items-center gap-1.5">
-        <BeltIndicator
-          className={didLevelUp ? "animate-dot-pulse motion-reduce:animate-none" : undefined}
-          color={displayColor}
-          label={displayLabel}
-          size="sm"
-        />
-        <span className="text-foreground text-sm font-medium">
-          {displayLabel} {t("Belt")} — {t("Level")} {displayLevel}
-        </span>
-      </div>
-      <ProgressRoot aria-label={t("Level progress")} value={displayPercent}>
-        <ProgressTrack className="h-1.5">
-          <ProgressIndicator
-            className={cn(
-              beltColorClasses[displayColor],
-              skipTransition ? "duration-0" : "duration-600 ease-out",
-              "motion-reduce:duration-0",
-            )}
-          />
-        </ProgressTrack>
-      </ProgressRoot>
-      <span className="text-muted-foreground text-xs tabular-nums">
-        {t("{value} BP to level up", { value: String(currentBelt.bpToNextLevel) })}
-      </span>
-    </LinkComponent>
-  );
-}
-
-export function BeltProgressSkeleton() {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex items-center gap-1.5">
-        <Skeleton className="size-3 rounded-full" />
-        <Skeleton className="h-4 w-36" />
-      </div>
-      <Skeleton className="h-1.5 w-full rounded-4xl" />
-      <Skeleton className="h-3 w-16" />
     </div>
   );
 }

--- a/packages/player/src/components/reward-badges.tsx
+++ b/packages/player/src/components/reward-badges.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { Badge } from "@zoonk/ui/components/badge";
-import { BeltIndicator } from "@zoonk/ui/components/belt-indicator";
+import { BeltIndicator, beltColorClasses } from "@zoonk/ui/components/belt-indicator";
+import { ProgressIndicator, ProgressRoot, ProgressTrack } from "@zoonk/ui/components/progress";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { cn } from "@zoonk/ui/lib/utils";
-import { calculateBeltLevel } from "@zoonk/utils/belt-level";
+import { calculateBeltLevel, getBeltProgressPercent } from "@zoonk/utils/belt-level";
 import { BrainIcon, ZapIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
+import { useEffect, useState } from "react";
 import { usePlayer } from "../player-context";
 import { useBeltColorLabel } from "../use-belt-color-label";
 
@@ -57,6 +59,64 @@ export function RewardBadgesSkeleton() {
   );
 }
 
+const ANIMATION_START_DELAY = 50;
+const LEVEL_UP_RESET_DELAY = 700;
+
+function useBeltProgressAnimation({
+  currentPercent,
+  didLevelUp,
+  levelUpUpdater,
+  previousPercent,
+}: {
+  currentPercent: number;
+  didLevelUp: boolean;
+  levelUpUpdater: () => void;
+  previousPercent: number;
+}) {
+  const [displayPercent, setDisplayPercent] = useState(previousPercent);
+  const [skipTransition, setSkipTransition] = useState(false);
+
+  useEffect(() => {
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const frames: number[] = [];
+
+    if (!didLevelUp) {
+      timers.push(setTimeout(() => setDisplayPercent(currentPercent), ANIMATION_START_DELAY));
+      return () => timers.forEach((timer) => clearTimeout(timer));
+    }
+
+    timers.push(setTimeout(() => setDisplayPercent(100), ANIMATION_START_DELAY));
+
+    timers.push(
+      setTimeout(() => {
+        setSkipTransition(true);
+        setDisplayPercent(0);
+        levelUpUpdater();
+
+        frames.push(
+          requestAnimationFrame(() => {
+            frames.push(
+              requestAnimationFrame(() => {
+                setSkipTransition(false);
+                setDisplayPercent(currentPercent);
+              }),
+            );
+          }),
+        );
+      }, LEVEL_UP_RESET_DELAY),
+    );
+
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+      frames.forEach((frame) => cancelAnimationFrame(frame));
+    };
+    // Animation runs only on mount — values are captured in closure
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { displayPercent, skipTransition };
+}
+
 export function BeltProgressHint({
   brainPower,
   newTotalBp,
@@ -70,33 +130,63 @@ export function BeltProgressHint({
   const previousBelt = calculateBeltLevel(newTotalBp - brainPower);
   const didLevelUp =
     currentBelt.color !== previousBelt.color || currentBelt.level !== previousBelt.level;
-  const colorLabel = useBeltColorLabel(currentBelt.color);
+  const currentColorLabel = useBeltColorLabel(currentBelt.color);
+  const previousColorLabel = useBeltColorLabel(previousBelt.color);
+
+  const currentPercent = getBeltProgressPercent(currentBelt);
+  const previousPercent = getBeltProgressPercent(previousBelt);
+
+  const [displayColor, setDisplayColor] = useState(
+    didLevelUp ? previousBelt.color : currentBelt.color,
+  );
+  const [displayLabel, setDisplayLabel] = useState(
+    didLevelUp ? previousColorLabel : currentColorLabel,
+  );
+  const [displayLevel, setDisplayLevel] = useState(
+    didLevelUp ? previousBelt.level : currentBelt.level,
+  );
+
+  const { displayPercent, skipTransition } = useBeltProgressAnimation({
+    currentPercent,
+    didLevelUp,
+    levelUpUpdater: () => {
+      setDisplayColor(currentBelt.color);
+      setDisplayLabel(currentColorLabel);
+      setDisplayLevel(currentBelt.level);
+    },
+    previousPercent,
+  });
 
   if (currentBelt.isMaxLevel || !levelHref) {
     return null;
   }
 
-  if (didLevelUp) {
-    return (
-      <LinkComponent className="flex items-center gap-1.5" href={levelHref}>
+  return (
+    <LinkComponent className="flex flex-col gap-1.5" href={levelHref}>
+      <div className="flex items-center gap-1.5">
         <BeltIndicator
-          className="animate-dot-pulse motion-reduce:animate-none"
-          color={currentBelt.color}
-          label={colorLabel}
+          className={didLevelUp ? "animate-dot-pulse motion-reduce:animate-none" : undefined}
+          color={displayColor}
+          label={displayLabel}
           size="sm"
         />
         <span className="text-foreground text-sm font-medium">
-          {colorLabel} {t("Belt")} — {t("Level")} {currentBelt.level}
+          {displayLabel} {t("Belt")} — {t("Level")} {displayLevel}
         </span>
-      </LinkComponent>
-    );
-  }
-
-  return (
-    <LinkComponent className="flex items-center gap-1.5" href={levelHref}>
-      <BeltIndicator color={currentBelt.color} label={colorLabel} size="sm" />
-      <span className="text-muted-foreground text-xs">
-        {currentBelt.bpToNextLevel} {t("BP to next level")}
+      </div>
+      <ProgressRoot aria-label={t("Level progress")} value={displayPercent}>
+        <ProgressTrack className="h-1.5">
+          <ProgressIndicator
+            className={cn(
+              beltColorClasses[displayColor],
+              skipTransition ? "duration-0" : "duration-600 ease-out",
+              "motion-reduce:duration-0",
+            )}
+          />
+        </ProgressTrack>
+      </ProgressRoot>
+      <span className="text-muted-foreground text-xs tabular-nums">
+        {t("{value} BP to level up", { value: String(currentBelt.bpToNextLevel) })}
       </span>
     </LinkComponent>
   );
@@ -104,9 +194,13 @@ export function BeltProgressHint({
 
 export function BeltProgressSkeleton() {
   return (
-    <div className="flex items-center gap-1.5">
-      <Skeleton className="size-3 rounded-full" />
-      <Skeleton className="h-3 w-28" />
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-1.5">
+        <Skeleton className="size-3 rounded-full" />
+        <Skeleton className="h-4 w-36" />
+      </div>
+      <Skeleton className="h-1.5 w-full rounded-4xl" />
+      <Skeleton className="h-3 w-16" />
     </div>
   );
 }

--- a/packages/ui/src/components/belt-indicator.tsx
+++ b/packages/ui/src/components/belt-indicator.tsx
@@ -47,4 +47,4 @@ function BeltIndicator({
   );
 }
 
-export { BeltIndicator };
+export { BeltIndicator, beltColorClasses };

--- a/packages/utils/src/belt-level.test.ts
+++ b/packages/utils/src/belt-level.test.ts
@@ -1,55 +1,65 @@
 import { describe, expect, test } from "vitest";
-import { calculateBeltLevel } from "./belt-level";
+import { calculateBeltLevel, getBeltProgressPercent } from "./belt-level";
 
 describe(calculateBeltLevel, () => {
   describe("white belt (250 BP per level)", () => {
     test("0 BP returns White 1 with 250 BP to next", () => {
       const result = calculateBeltLevel(0);
       expect(result).toEqual({
+        bpPerLevel: 250,
         bpToNextLevel: 250,
         color: "white",
         isMaxLevel: false,
         level: 1,
+        progressInLevel: 0,
       });
     });
 
     test("249 BP returns White 1 with 1 BP to next", () => {
       const result = calculateBeltLevel(249);
       expect(result).toEqual({
+        bpPerLevel: 250,
         bpToNextLevel: 1,
         color: "white",
         isMaxLevel: false,
         level: 1,
+        progressInLevel: 249,
       });
     });
 
     test("250 BP returns White 2 with 250 BP to next", () => {
       const result = calculateBeltLevel(250);
       expect(result).toEqual({
+        bpPerLevel: 250,
         bpToNextLevel: 250,
         color: "white",
         isMaxLevel: false,
         level: 2,
+        progressInLevel: 0,
       });
     });
 
     test("2250 BP returns White 10 with 250 BP to next", () => {
       const result = calculateBeltLevel(2250);
       expect(result).toEqual({
+        bpPerLevel: 250,
         bpToNextLevel: 250,
         color: "white",
         isMaxLevel: false,
         level: 10,
+        progressInLevel: 0,
       });
     });
 
     test("2499 BP returns White 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(2499);
       expect(result).toEqual({
+        bpPerLevel: 250,
         bpToNextLevel: 1,
         color: "white",
         isMaxLevel: false,
         level: 10,
+        progressInLevel: 249,
       });
     });
   });
@@ -58,30 +68,36 @@ describe(calculateBeltLevel, () => {
     test("2500 BP returns Yellow 1 with 500 BP to next", () => {
       const result = calculateBeltLevel(2500);
       expect(result).toEqual({
+        bpPerLevel: 500,
         bpToNextLevel: 500,
         color: "yellow",
         isMaxLevel: false,
         level: 1,
+        progressInLevel: 0,
       });
     });
 
     test("7000 BP returns Yellow 10 with 500 BP to next", () => {
       const result = calculateBeltLevel(7000);
       expect(result).toEqual({
+        bpPerLevel: 500,
         bpToNextLevel: 500,
         color: "yellow",
         isMaxLevel: false,
         level: 10,
+        progressInLevel: 0,
       });
     });
 
     test("7499 BP returns Yellow 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(7499);
       expect(result).toEqual({
+        bpPerLevel: 500,
         bpToNextLevel: 1,
         color: "yellow",
         isMaxLevel: false,
         level: 10,
+        progressInLevel: 499,
       });
     });
   });
@@ -90,30 +106,36 @@ describe(calculateBeltLevel, () => {
     test("7500 BP returns Orange 1 with 1000 BP to next", () => {
       const result = calculateBeltLevel(7500);
       expect(result).toEqual({
+        bpPerLevel: 1000,
         bpToNextLevel: 1000,
         color: "orange",
         isMaxLevel: false,
         level: 1,
+        progressInLevel: 0,
       });
     });
 
     test("15000 BP returns Orange 8 with 500 BP to next (E2E test user)", () => {
       const result = calculateBeltLevel(15_000);
       expect(result).toEqual({
+        bpPerLevel: 1000,
         bpToNextLevel: 500,
         color: "orange",
         isMaxLevel: false,
         level: 8,
+        progressInLevel: 500,
       });
     });
 
     test("17499 BP returns Orange 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(17_499);
       expect(result).toEqual({
+        bpPerLevel: 1000,
         bpToNextLevel: 1,
         color: "orange",
         isMaxLevel: false,
         level: 10,
+        progressInLevel: 999,
       });
     });
   });
@@ -122,20 +144,24 @@ describe(calculateBeltLevel, () => {
     test("17500 BP returns Green 1 with 5000 BP to next", () => {
       const result = calculateBeltLevel(17_500);
       expect(result).toEqual({
+        bpPerLevel: 5000,
         bpToNextLevel: 5000,
         color: "green",
         isMaxLevel: false,
         level: 1,
+        progressInLevel: 0,
       });
     });
 
     test("67499 BP returns Green 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(67_499);
       expect(result).toEqual({
+        bpPerLevel: 5000,
         bpToNextLevel: 1,
         color: "green",
         isMaxLevel: false,
         level: 10,
+        progressInLevel: 4999,
       });
     });
   });
@@ -144,20 +170,24 @@ describe(calculateBeltLevel, () => {
     test("67500 BP returns Blue 1 with 10000 BP to next", () => {
       const result = calculateBeltLevel(67_500);
       expect(result).toEqual({
+        bpPerLevel: 10_000,
         bpToNextLevel: 10_000,
         color: "blue",
         isMaxLevel: false,
         level: 1,
+        progressInLevel: 0,
       });
     });
 
     test("167499 BP returns Blue 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(167_499);
       expect(result).toEqual({
+        bpPerLevel: 10_000,
         bpToNextLevel: 1,
         color: "blue",
         isMaxLevel: false,
         level: 10,
+        progressInLevel: 9999,
       });
     });
   });
@@ -166,20 +196,24 @@ describe(calculateBeltLevel, () => {
     test("167500 BP returns Purple 1 with 20000 BP to next", () => {
       const result = calculateBeltLevel(167_500);
       expect(result).toEqual({
+        bpPerLevel: 20_000,
         bpToNextLevel: 20_000,
         color: "purple",
         isMaxLevel: false,
         level: 1,
+        progressInLevel: 0,
       });
     });
 
     test("367499 BP returns Purple 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(367_499);
       expect(result).toEqual({
+        bpPerLevel: 20_000,
         bpToNextLevel: 1,
         color: "purple",
         isMaxLevel: false,
         level: 10,
+        progressInLevel: 19_999,
       });
     });
   });
@@ -188,20 +222,24 @@ describe(calculateBeltLevel, () => {
     test("367500 BP returns Brown 1 with 40000 BP to next", () => {
       const result = calculateBeltLevel(367_500);
       expect(result).toEqual({
+        bpPerLevel: 40_000,
         bpToNextLevel: 40_000,
         color: "brown",
         isMaxLevel: false,
         level: 1,
+        progressInLevel: 0,
       });
     });
 
     test("767499 BP returns Brown 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(767_499);
       expect(result).toEqual({
+        bpPerLevel: 40_000,
         bpToNextLevel: 1,
         color: "brown",
         isMaxLevel: false,
         level: 10,
+        progressInLevel: 39_999,
       });
     });
   });
@@ -210,20 +248,24 @@ describe(calculateBeltLevel, () => {
     test("767500 BP returns Red 1 with 60000 BP to next", () => {
       const result = calculateBeltLevel(767_500);
       expect(result).toEqual({
+        bpPerLevel: 60_000,
         bpToNextLevel: 60_000,
         color: "red",
         isMaxLevel: false,
         level: 1,
+        progressInLevel: 0,
       });
     });
 
     test("1367499 BP returns Red 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(1_367_499);
       expect(result).toEqual({
+        bpPerLevel: 60_000,
         bpToNextLevel: 1,
         color: "red",
         isMaxLevel: false,
         level: 10,
+        progressInLevel: 59_999,
       });
     });
   });
@@ -232,20 +274,24 @@ describe(calculateBeltLevel, () => {
     test("1367500 BP returns Gray 1 with 80000 BP to next", () => {
       const result = calculateBeltLevel(1_367_500);
       expect(result).toEqual({
+        bpPerLevel: 80_000,
         bpToNextLevel: 80_000,
         color: "gray",
         isMaxLevel: false,
         level: 1,
+        progressInLevel: 0,
       });
     });
 
     test("2167499 BP returns Gray 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(2_167_499);
       expect(result).toEqual({
+        bpPerLevel: 80_000,
         bpToNextLevel: 1,
         color: "gray",
         isMaxLevel: false,
         level: 10,
+        progressInLevel: 79_999,
       });
     });
   });
@@ -254,30 +300,36 @@ describe(calculateBeltLevel, () => {
     test("2167500 BP returns Black 1 with 100000 BP to next", () => {
       const result = calculateBeltLevel(2_167_500);
       expect(result).toEqual({
+        bpPerLevel: 100_000,
         bpToNextLevel: 100_000,
         color: "black",
         isMaxLevel: false,
         level: 1,
+        progressInLevel: 0,
       });
     });
 
     test("3067500 BP returns Black 10 at max level", () => {
       const result = calculateBeltLevel(3_067_500);
       expect(result).toEqual({
+        bpPerLevel: 100_000,
         bpToNextLevel: 0,
         color: "black",
         isMaxLevel: true,
         level: 10,
+        progressInLevel: 0,
       });
     });
 
     test("beyond max level still returns Black 10", () => {
       const result = calculateBeltLevel(5_000_000);
       expect(result).toEqual({
+        bpPerLevel: 100_000,
         bpToNextLevel: 0,
         color: "black",
         isMaxLevel: true,
         level: 10,
+        progressInLevel: 0,
       });
     });
   });
@@ -286,11 +338,55 @@ describe(calculateBeltLevel, () => {
     test("negative BP is treated as 0", () => {
       const result = calculateBeltLevel(-100);
       expect(result).toEqual({
+        bpPerLevel: 250,
         bpToNextLevel: 250,
         color: "white",
         isMaxLevel: false,
         level: 1,
+        progressInLevel: 0,
       });
     });
+  });
+
+  describe("progress percentage at boundaries", () => {
+    test("0% progress at start of level", () => {
+      const result = calculateBeltLevel(0);
+      expect(result.progressInLevel).toBe(0);
+      expect(getBeltProgressPercent(result)).toBe(0);
+    });
+
+    test("50% progress at mid-level", () => {
+      const result = calculateBeltLevel(125);
+      expect(result.progressInLevel).toBe(125);
+      expect(getBeltProgressPercent(result)).toBe(50);
+    });
+
+    test("99% progress just before level-up", () => {
+      const result = calculateBeltLevel(248);
+      expect(result.progressInLevel).toBe(248);
+      expect(getBeltProgressPercent(result)).toBe(99);
+    });
+  });
+});
+
+describe(getBeltProgressPercent, () => {
+  test("returns 0 for start of level", () => {
+    const result = calculateBeltLevel(250);
+    expect(getBeltProgressPercent(result)).toBe(0);
+  });
+
+  test("returns 50 for mid-level", () => {
+    const result = calculateBeltLevel(375);
+    expect(getBeltProgressPercent(result)).toBe(50);
+  });
+
+  test("returns 100 for near-boundary (rounds up)", () => {
+    const result = calculateBeltLevel(249);
+    expect(getBeltProgressPercent(result)).toBe(100);
+  });
+
+  test("returns 0 for max level", () => {
+    const result = calculateBeltLevel(5_000_000);
+    expect(getBeltProgressPercent(result)).toBe(0);
   });
 });

--- a/packages/utils/src/belt-level.ts
+++ b/packages/utils/src/belt-level.ts
@@ -24,10 +24,12 @@ export const BELT_COLORS_ORDER: BeltColor[] = [
 ];
 
 export type BeltLevelResult = {
+  bpPerLevel: number;
   bpToNextLevel: number;
   color: BeltColor;
   isMaxLevel: boolean;
   level: number;
+  progressInLevel: number;
 };
 
 type BeltConfig = {
@@ -70,20 +72,29 @@ export function calculateBeltLevel(totalBrainPower: number): BeltLevelResult {
 
   if (isMaxLevel) {
     return {
+      bpPerLevel: currentBelt.bpPerLevel,
       bpToNextLevel: 0,
       color: currentBelt.color,
       isMaxLevel: true,
       level: LEVELS_PER_COLOR,
+      progressInLevel: 0,
     };
   }
 
   const bpForCurrentLevel = (level - 1) * currentBelt.bpPerLevel;
   const bpToNextLevel = currentBelt.bpPerLevel - (bpInCurrentBelt - bpForCurrentLevel);
+  const progressInLevel = currentBelt.bpPerLevel - bpToNextLevel;
 
   return {
+    bpPerLevel: currentBelt.bpPerLevel,
     bpToNextLevel,
     color: currentBelt.color,
     isMaxLevel: false,
     level,
+    progressInLevel,
   };
+}
+
+export function getBeltProgressPercent(result: BeltLevelResult): number {
+  return Math.round((result.progressInLevel / result.bpPerLevel) * 100);
 }


### PR DESCRIPTION
## Summary

- Replace static "BP to next level" text with an animated progress bar on activity/challenge completion
- Bar animates from previous position to new position (~600ms ease-out), making earned BP feel tangible
- Level-up animation sequences: fill to 100%, pause, reset to 0%, fill to new position
- Add `bpPerLevel` and `progressInLevel` fields to `BeltLevelResult` as single source of truth
- Add `getBeltProgressPercent` utility to avoid duplicating math in components
- Add belt progress bar to challenge success screen (was missing previously)
- Respect `prefers-reduced-motion` with instant transitions

## Test plan

- [x] Unit tests updated for new `BeltLevelResult` fields (34 tests passing)
- [x] Integration tests updated for `getBeltLevel` data function
- [x] E2E tests assert `progressbar` role with "Level progress" aria-label
- [x] E2E: authenticated quiz completion shows progress bar
- [x] E2E: guest user does NOT see progress bar
- [x] E2E: challenge success shows progress bar
- [x] All e2e suites pass 3x with zero failures (main: 373, editor: 193, api: 55)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an animated belt progress bar to activity and challenge completion to show level progression and make BP gains feel tangible. The animation is event-driven, smooth, accessible, and respects reduced motion.

- **New Features**
  - Animated progress bar that eases from previous to new position (~600ms).
  - Level-up sequence: fill to 100%, reset, then fill to the new level.
  - Added to the challenge success screen with skeleton states.
  - Accessible progressbar with “Level progress” label and “{value} BP to level up” text.

- **Refactors**
  - Replaced timer-based logic with onTransitionEnd and moved BeltProgressHint/Skeleton to belt-progress.tsx.
  - Extended BeltLevelResult with bpPerLevel and progressInLevel; added getBeltProgressPercent.
  - Updated tests to assert the progressbar role and expanded boundary coverage; refreshed i18n strings (en/es/pt).

<sup>Written for commit bd92eb88730ef083a2ca8283ed26db4f670d4b9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

