### PR TITLE
feat(main): allow first chapter generation without auth or subscription

### DIFF
--- a/apps/api/src/app/v1/workflows/chapter-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/chapter-generation/trigger/route.ts
@@ -3,8 +3,17 @@ import { parseBody } from "@/lib/body-parser";
 import { chapterGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
 import { chapterGenerationWorkflow } from "@/workflows/chapter-generation/chapter-generation-workflow";
 import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
+import { prisma } from "@zoonk/db";
 import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
+
+async function getChapterPosition(chapterId: number) {
+  const chapter = await prisma.chapter.findUnique({
+    select: { position: true },
+    where: { id: chapterId },
+  });
+  return chapter;
+}
 
 export async function POST(request: NextRequest) {
   const parsed = await parseBody(request, chapterGenerationTriggerSchema);
@@ -13,10 +22,18 @@ export async function POST(request: NextRequest) {
     return errors.validation(parsed.error);
   }
 
-  const hasSubscription = await hasActiveSubscription(request.headers);
+  const chapter = await getChapterPosition(parsed.data.chapterId);
 
-  if (!hasSubscription) {
-    return errors.paymentRequired();
+  if (!chapter) {
+    return errors.notFound();
+  }
+
+  if (chapter.position !== 0) {
+    const hasSubscription = await hasActiveSubscription(request.headers);
+
+    if (!hasSubscription) {
+      return errors.paymentRequired();
+    }
   }
 
   const run = await start(chapterGenerationWorkflow, [parsed.data.chapterId]);

--- a/apps/main/src/app/[locale]/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/generate-chapter-content.tsx
@@ -36,9 +36,10 @@ export async function GenerateChapterContent({
     notFound();
   }
 
+  const isFirstChapter = chapter.position === 0;
   const t = await getExtracted();
 
-  if (!session) {
+  if (!session && !isFirstChapter) {
     return <LoginRequired title={t("Generate Chapter")} />;
   }
 
@@ -58,7 +59,7 @@ export async function GenerateChapterContent({
       </ContainerHeader>
 
       <ContainerBody>
-        <SubscriptionGate>
+        <SubscriptionGate bypass={isFirstChapter}>
           <GenerationClient
             chapterId={chapterId}
             chapterSlug={chapter.slug}

--- a/apps/main/src/components/subscription/subscription-gate.tsx
+++ b/apps/main/src/components/subscription/subscription-gate.tsx
@@ -3,7 +3,17 @@ import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
 import { headers } from "next/headers";
 import { UpgradeCTA } from "./upgrade-cta";
 
-export async function SubscriptionGate({ children }: { children: React.ReactNode }) {
+export async function SubscriptionGate({
+  bypass,
+  children,
+}: {
+  bypass?: boolean;
+  children: React.ReactNode;
+}) {
+  if (bypass) {
+    return children;
+  }
+
   const hasSubscription = await hasActiveSubscription(await headers());
 
   if (!hasSubscription) {

--- a/apps/main/src/data/chapters/get-chapter-for-generation.test.ts
+++ b/apps/main/src/data/chapters/get-chapter-for-generation.test.ts
@@ -38,6 +38,7 @@ describe(getChapterForGeneration, () => {
       id: chapter.id,
       language: chapter.language,
       organizationId: chapter.organizationId,
+      position: chapter.position,
       title: chapter.title,
     });
   });

--- a/apps/main/src/data/chapters/get-chapter-for-generation.ts
+++ b/apps/main/src/data/chapters/get-chapter-for-generation.ts
@@ -22,6 +22,7 @@ export async function getChapterForGeneration(chapterId: number) {
       id: true,
       language: true,
       organizationId: true,
+      position: true,
       slug: true,
       title: true,
     },


### PR DESCRIPTION
## Summary
- First chapter (position 0) of any course can now be generated without authentication or subscription
- Non-first chapters retain existing auth + subscription requirements
- Both UI layer (main app) and API layer enforce the position check

## Test plan
- [x] Integration test updated to assert `position` field
- [x] Main app e2e: existing auth/subscription tests use non-first chapter (position 1)
- [x] Main app e2e: new "First Chapter Free" tests for unauthenticated and no-subscription users
- [x] API e2e: 402 test uses non-first chapter (position 1)
- [x] API e2e: new test confirms first chapter triggers without subscription
- [x] API e2e passed 3x with zero flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow generating the first chapter of any course without login or subscription. All other chapters keep the existing login + subscription requirements.

- **New Features**
  - API: Skip subscription check when chapter.position is 0; non-first chapters still return 402 without a subscription.
  - UI: Permit unauthenticated users and bypass SubscriptionGate for the first chapter; expose chapter.position to the client.
  - Tests: Added e2e and API tests for “First Chapter Free” and adjusted existing tests to use non-first chapters.

<sup>Written for commit 0c8f9baf42185d599bfce57017d524e274179a6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

