### PR TITLE
fix(main): wrap catalog layout children in suspense

### DIFF
--- a/apps/main/src/app/[locale]/(catalog)/layout.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/layout.tsx
@@ -20,7 +20,9 @@ export default async function CatalogLayout({ children, params }: LayoutProps<"/
         <UserAvatarMenu />
       </Navbar>
 
-      <Suspense>{children}</Suspense>
+      <Suspense>
+        <div>{children}</div>
+      </Suspense>
     </div>
   );
 }

--- a/apps/main/src/app/[locale]/(catalog)/layout.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/layout.tsx
@@ -21,7 +21,7 @@ export default async function CatalogLayout({ children, params }: LayoutProps<"/
       </Navbar>
 
       <Suspense>
-        <div>{children}</div>
+        <div className="flex flex-1 flex-col">{children}</div>
       </Suspense>
     </div>
   );

--- a/apps/main/src/app/[locale]/(catalog)/layout.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/layout.tsx
@@ -20,7 +20,7 @@ export default async function CatalogLayout({ children, params }: LayoutProps<"/
         <UserAvatarMenu />
       </Navbar>
 
-      {children}
+      <Suspense>{children}</Suspense>
     </div>
   );
 }

--- a/apps/main/src/app/[locale]/(catalog)/loading.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/loading.tsx
@@ -1,3 +1,0 @@
-export default function Loading() {
-  return <div>Loading...</div>;
-}

--- a/apps/main/src/app/[locale]/(catalog)/loading.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div>Loading...</div>;
+}


### PR DESCRIPTION
avoid blocking route on ISR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrapped catalog layout children in Suspense to avoid route blocking during ISR and render the group's loading UI. Added a flex column container around children to fix alignment and preserve layout.

<sup>Written for commit 6ab34c495bc3f3969bf493d66a62ffb5d56bd894. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

