### PR TITLE
fix(ui): prevent dialog and dropdown flash from activity route caching

### DIFF
--- a/apps/main/src/app/[locale]/(catalog)/layout.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/layout.tsx
@@ -1,5 +1,3 @@
-"use cache";
-
 import { Navbar } from "@zoonk/ui/components/navbar";
 import { setRequestLocale } from "next-intl/server";
 import { Suspense } from "react";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,6 +12,7 @@
     "./hooks/debounce": "./src/hooks/use-debounce.ts",
     "./hooks/infinite-list": "./src/hooks/use-infinite-list.ts",
     "./hooks/is-mounted": "./src/hooks/use-is-mounted.ts",
+    "./hooks/hide-element": "./src/hooks/use-hide-element.ts",
     "./hooks/keyboard": "./src/hooks/use-keyboard.ts",
     "./hooks/mobile": "./src/hooks/use-mobile.ts",
     "./lib/*": "./src/lib/*.ts",

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -2,12 +2,27 @@
 
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { Button } from "@zoonk/ui/components/button";
+import { useHideElement } from "@zoonk/ui/hooks/hide-element";
 import { cn } from "@zoonk/ui/lib/utils";
 import { XIcon } from "lucide-react";
+import { createContext, useContext } from "react";
 import type * as React from "react";
 
-function Dialog({ ...props }: DialogPrimitive.Root.Props) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+/**
+ * Passes the `open` state from Dialog to DialogPortal so it can hide the portal
+ * on Activity cleanup (preventing flash on back-navigation) and only remove
+ * the hidden class on genuine close-to-open transitions.
+ *
+ * Workaround for: https://github.com/vercel/next.js/issues/86577
+ */
+const DialogOpenContext = createContext<boolean | undefined>(undefined);
+
+function Dialog({ open, ...props }: DialogPrimitive.Root.Props) {
+  return (
+    <DialogOpenContext.Provider value={open}>
+      <DialogPrimitive.Root data-slot="dialog" open={open} {...props} />
+    </DialogOpenContext.Provider>
+  );
 }
 
 function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
@@ -15,7 +30,9 @@ function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
 }
 
 function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+  const open = useContext(DialogOpenContext);
+  const ref = useHideElement<HTMLDivElement>(open);
+  return <DialogPrimitive.Portal data-slot="dialog-portal" ref={ref} {...props} />;
 }
 
 function DialogClose({ ...props }: DialogPrimitive.Close.Props) {

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Menu as MenuPrimitive } from "@base-ui/react/menu";
+import { useHideElement } from "@zoonk/ui/hooks/hide-element";
 import { cn } from "@zoonk/ui/lib/utils";
 import { CheckIcon, ChevronRightIcon } from "lucide-react";
 import type * as React from "react";
@@ -34,8 +35,10 @@ function DropdownMenuContent({
   ...props
 }: MenuPrimitive.Popup.Props &
   Pick<MenuPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset">) {
+  const ref = useHideElement<HTMLDivElement>();
+
   return (
-    <MenuPrimitive.Portal>
+    <MenuPrimitive.Portal ref={ref}>
       <MenuPrimitive.Positioner
         align={align}
         alignOffset={alignOffset}

--- a/packages/ui/src/hooks/use-hide-element.ts
+++ b/packages/ui/src/hooks/use-hide-element.ts
@@ -1,0 +1,32 @@
+import { useLayoutEffect, useRef } from "react";
+
+/**
+ * Hides an element on unmount.
+ *
+ * This is a workaround for next.js route caching, which uses React Activity to preserve a route's state:
+ * https://github.com/vercel/next.js/issues/86577
+ *
+ * When `open` is provided, hidden is only removed on genuine close-to-open transitions,
+ * preventing stale Activity state from flashing the element on back-navigation.
+ */
+export function useHideElement<Element extends HTMLElement>(open?: boolean) {
+  const ref = useRef<Element | null>(null);
+  const prevOpen = useRef(open);
+
+  useLayoutEffect(
+    () => () => {
+      ref.current?.classList.add("hidden");
+    },
+    [],
+  );
+
+  useLayoutEffect(() => {
+    if (open && !prevOpen.current) {
+      ref.current?.classList.remove("hidden");
+    }
+
+    prevOpen.current = open;
+  }, [open]);
+
+  return ref;
+}


### PR DESCRIPTION
## Summary

- Removes `use cache` from catalog layout
- Adds `useHideElement` hook that hides portal elements on React Activity cleanup, preventing stale cached state from flashing on back-navigation
- Applies the hook to `DialogPortal` (via context to read `open` state) and `DropdownMenuContent`

Workaround for https://github.com/vercel/next.js/issues/86577

## Test plan

- [ ] Open command palette, click a link, navigate back — no flash
- [ ] Open a dropdown menu, navigate away, navigate back — no flash
- [ ] Verify command palette still opens/closes normally after back-navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops dialogs and dropdowns from flashing their previous open state when navigating back. Hides portal elements on route cleanup and only shows them again on real open events.

- **Bug Fixes**
  - Removed "use cache" from the catalog layout to avoid cached UI state.
  - Added useHideElement hook to hide portals on cleanup and prevent back-navigation flash.
  - Applied the hook to DialogPortal (via open state context) and DropdownMenuContent.

<sup>Written for commit f3ccb13397e4d845d947c51da040c4001d4296f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

