### PR TITLE
feat(main): fix progress regression, phase flickering, and add perceived progress

### DIFF
--- a/apps/main/e2e/generate-activity.test.ts
+++ b/apps/main/e2e/generate-activity.test.ts
@@ -1334,6 +1334,8 @@ test.describe("Generate Activity Page - With Subscription", () => {
     await expect(userWithoutProgress.getByText(/recording audio/i)).toBeVisible({
       timeout: 10_000,
     });
+
+    await expect(userWithoutProgress.getByText(/this usually takes 1-2 minutes/i)).toBeVisible();
   });
 
   test("shows practice-content phase and skips pronunciation phase for reading", async ({

--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -226,6 +226,7 @@ test.describe("Generate Chapter Page - With Subscription", () => {
       timeout: 10_000,
     });
 
+    await expect(userWithoutProgress.getByText(/this usually takes 2-4 minutes/i)).toBeVisible();
     await expect(userWithoutProgress.getByText(/adding pronunciation/i)).toBeVisible();
     await expect(userWithoutProgress.getByText(/recording audio/i)).toBeVisible();
     await expect(userWithoutProgress.getByText(/writing the content/i)).toHaveCount(0);

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -140,6 +140,8 @@ test.describe("Generate Course Page", () => {
       await expect(page.getByText(/creating your course/i)).toBeVisible({
         timeout: 10_000,
       });
+
+      await expect(page.getByText(/this usually takes 4-6 minutes/i)).toBeVisible();
     });
 
     test("shows vocabulary-specific activity phases for language courses", async ({ page }) => {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1387,6 +1387,11 @@ msgid "Your activity is ready"
 msgstr "Your activity is ready"
 
 #: src/app/[locale]/generate/a/[id]/generation-client.tsx
+msgctxt "3vY0Zu"
+msgid "This usually takes 1-2 minutes"
+msgstr "This usually takes 1-2 minutes"
+
+#: src/app/[locale]/generate/a/[id]/generation-client.tsx
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 #: src/app/[locale]/generate/l/[id]/generation-client.tsx
@@ -1431,9 +1436,80 @@ msgstr "Something went wrong. Please try again."
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "2hb6pr"
+msgid "Adding examples..."
+msgstr "Adding examples..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "4xvh9e"
+msgid "Getting the pronunciation right..."
+msgstr "Getting the pronunciation right..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "5InW8H"
+msgid "Recording the audio..."
+msgstr "Recording the audio..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "5nJVpw"
+msgid "Getting everything ready..."
+msgstr "Getting everything ready..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "8lInA7"
+msgid "Sketching out ideas..."
+msgstr "Sketching out ideas..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "abtOR3"
+msgid "Planning the layout..."
+msgstr "Planning the layout..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "aeeXxf"
+msgid "Wrapping up..."
+msgstr "Wrapping up..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 msgctxt "aKNA/b"
 msgid "Creating images"
 msgstr "Creating images"
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "bJVUNz"
+msgid "Adding some color..."
+msgstr "Adding some color..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "dQnsCW"
+msgid "Choosing the right style..."
+msgstr "Choosing the right style..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "EAqAX/"
+msgid "Thinking about what to illustrate..."
+msgstr "Thinking about what to illustrate..."
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
@@ -1449,12 +1525,72 @@ msgid "Preparing practice content"
 msgstr "Preparing practice content"
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+msgctxt "hfXRZ0"
+msgid "Reviewing earlier activities..."
+msgstr "Reviewing earlier activities..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
 msgctxt "HYmCaW"
 msgid "Almost done"
 msgstr "Almost done"
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "i+rNdh"
+msgid "Picking the key vocabulary..."
+msgstr "Picking the key vocabulary..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "IdWf9/"
+msgid "Choosing words to practice..."
+msgstr "Choosing words to practice..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+msgctxt "JBrEHg"
+msgid "Connecting the pieces..."
+msgstr "Connecting the pieces..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "JGNN92"
+msgid "Drawing an illustration..."
+msgstr "Drawing an illustration..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "K/JznZ"
+msgid "Writing the explanation..."
+msgstr "Writing the explanation..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "MNQpiA"
+msgid "Almost there..."
+msgstr "Almost there..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "O8xr9p"
+msgid "Working on the visuals..."
+msgstr "Working on the visuals..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "r8xznK"
+msgid "Researching the topic..."
+msgstr "Researching the topic..."
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 msgctxt "sISitf"
@@ -1488,6 +1624,34 @@ msgctxt "v4iFHN"
 msgid "Writing the content"
 msgstr "Writing the content"
 
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "VADOBa"
+msgid "Looking up how each word sounds..."
+msgstr "Looking up how each word sounds..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "WnqJeL"
+msgid "Mapping out the pronunciation..."
+msgstr "Mapping out the pronunciation..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "xrLiIe"
+msgid "Setting things up..."
+msgstr "Setting things up..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "Yoev2R"
+msgid "Refining the details..."
+msgstr "Refining the details..."
+
 #: src/app/[locale]/generate/ch/[id]/generate-chapter-content.tsx
 msgctxt "9GwOlW"
 msgid "Generate Chapter"
@@ -1504,9 +1668,41 @@ msgid "Taking you to your chapter..."
 msgstr "Taking you to your chapter..."
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+msgctxt "Tp34ZM"
+msgid "This usually takes 2-4 minutes"
+msgstr "This usually takes 2-4 minutes"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 msgctxt "ViO6Dt"
 msgid "Creating your lessons"
 msgstr "Creating your lessons"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "6xEJTk"
+msgid "Designing practice exercises..."
+msgstr "Designing practice exercises..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "GTTucy"
+msgid "Thinking about how to teach this..."
+msgstr "Thinking about how to teach this..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "HWSnYS"
+msgid "Reviewing the flow so far..."
+msgstr "Reviewing the flow so far..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "igBmpz"
+msgid "Making it interactive..."
+msgstr "Making it interactive..."
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
@@ -1523,9 +1719,34 @@ msgid "Figuring out the best approach"
 msgstr "Figuring out the best approach"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "Nhva19"
+msgid "Choosing the right approach..."
+msgstr "Choosing the right approach..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "nwGJ65"
+msgid "Exploring your topic..."
+msgstr "Exploring your topic..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 msgctxt "SF9AtA"
 msgid "Preparing lessons"
 msgstr "Preparing lessons"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "VKFa/t"
+msgid "Mapping out the learning path..."
+msgstr "Mapping out the learning path..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "zQWv1/"
+msgid "Writing lesson {number}..."
+msgstr "Writing lesson {number}..."
 
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 msgctxt "0o41MR"
@@ -1538,6 +1759,11 @@ msgid "Your course is ready"
 msgstr "Your course is ready"
 
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+msgctxt "bXKvjZ"
+msgid "This usually takes 4-6 minutes"
+msgstr "This usually takes 4-6 minutes"
+
+#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 msgctxt "DFlapX"
 msgid "Creating your course"
 msgstr "Creating your course"
@@ -1548,9 +1774,34 @@ msgid "Writing the lesson content"
 msgstr "Writing the lesson content"
 
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "9r/4zz"
+msgid "Writing the overview..."
+msgstr "Writing the overview..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "a7FJJd"
+msgid "Summarizing what you'll learn..."
+msgstr "Summarizing what you'll learn..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "AEG3Ol"
+msgid "Planning the course structure..."
+msgstr "Planning the course structure..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "aev/pt"
+msgid "Figuring out the right categories..."
+msgstr "Figuring out the right categories..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 msgctxt "aJev/w"
 msgid "Getting things ready"
 msgstr "Getting things ready"
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "At4rk1"
+msgid "Adding finishing touches..."
+msgstr "Adding finishing touches..."
 
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 msgctxt "bkPdBd"
@@ -1561,6 +1812,11 @@ msgstr "Planning your first lesson"
 msgctxt "CFWOGF"
 msgid "Saving your course"
 msgstr "Saving your course"
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "EKAN6s"
+msgid "Tagging your course..."
+msgstr "Tagging your course..."
 
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 msgctxt "Gjutu+"
@@ -1578,9 +1834,39 @@ msgid "Categorizing your course"
 msgstr "Categorizing your course"
 
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
-msgctxt "vFYF4v"
-msgid "Outlining chapters"
-msgstr "Outlining chapters"
+msgctxt "lxBtcx"
+msgid "Designing the cover..."
+msgstr "Designing the cover..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "OW9vMd"
+msgid "Writing chapter {number}..."
+msgstr "Writing chapter {number}..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "tXkuD8"
+msgid "Reviewing the overall flow..."
+msgstr "Reviewing the overall flow..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "txvxwS"
+msgid "Saving your progress..."
+msgstr "Saving your progress..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "W8n2i3"
+msgid "Picking the right look..."
+msgstr "Picking the right look..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "WZpB8D"
+msgid "Writing chapters"
+msgstr "Writing chapters"
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "XxZuJi"
+msgid "Putting it all together..."
+msgstr "Putting it all together..."
 
 #: src/app/[locale]/generate/l/[id]/generate-lesson-content.tsx
 msgctxt "GG4VCc"
@@ -1596,6 +1882,11 @@ msgstr "Your lesson is ready"
 msgctxt "dO1XtE"
 msgid "Creating your activities"
 msgstr "Creating your activities"
+
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
+msgctxt "kiZUDf"
+msgid "This usually takes about a minute"
+msgstr "This usually takes about a minute"
 
 #: src/app/[locale]/generate/l/[id]/generation-client.tsx
 msgctxt "T2TGxR"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1387,6 +1387,11 @@ msgid "Your activity is ready"
 msgstr "Tu actividad está lista"
 
 #: src/app/[locale]/generate/a/[id]/generation-client.tsx
+msgctxt "3vY0Zu"
+msgid "This usually takes 1-2 minutes"
+msgstr "Esto suele tomar 1-2 minutos"
+
+#: src/app/[locale]/generate/a/[id]/generation-client.tsx
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 #: src/app/[locale]/generate/l/[id]/generation-client.tsx
@@ -1431,9 +1436,80 @@ msgstr "Algo salió mal. Por favor, intenta de nuevo."
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "2hb6pr"
+msgid "Adding examples..."
+msgstr "Agregando ejemplos..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "4xvh9e"
+msgid "Getting the pronunciation right..."
+msgstr "Ajustando la pronunciación..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "5InW8H"
+msgid "Recording the audio..."
+msgstr "Grabando el audio..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "5nJVpw"
+msgid "Getting everything ready..."
+msgstr "Preparando todo..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "8lInA7"
+msgid "Sketching out ideas..."
+msgstr "Esbozando ideas..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "abtOR3"
+msgid "Planning the layout..."
+msgstr "Planificando el diseño..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "aeeXxf"
+msgid "Wrapping up..."
+msgstr "Terminando..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 msgctxt "aKNA/b"
 msgid "Creating images"
 msgstr "Creando imágenes"
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "bJVUNz"
+msgid "Adding some color..."
+msgstr "Agregando algo de color..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "dQnsCW"
+msgid "Choosing the right style..."
+msgstr "Eligiendo el estilo correcto..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "EAqAX/"
+msgid "Thinking about what to illustrate..."
+msgstr "Pensando qué ilustrar..."
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
@@ -1449,12 +1525,72 @@ msgid "Preparing practice content"
 msgstr "Preparando contenido de práctica"
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+msgctxt "hfXRZ0"
+msgid "Reviewing earlier activities..."
+msgstr "Revisando actividades anteriores..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
 msgctxt "HYmCaW"
 msgid "Almost done"
 msgstr "Casi listo"
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "i+rNdh"
+msgid "Picking the key vocabulary..."
+msgstr "Seleccionando el vocabulario clave..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "IdWf9/"
+msgid "Choosing words to practice..."
+msgstr "Eligiendo palabras para practicar..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+msgctxt "JBrEHg"
+msgid "Connecting the pieces..."
+msgstr "Conectando las piezas..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "JGNN92"
+msgid "Drawing an illustration..."
+msgstr "Dibujando una ilustración..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "K/JznZ"
+msgid "Writing the explanation..."
+msgstr "Escribiendo la explicación..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "MNQpiA"
+msgid "Almost there..."
+msgstr "Casi listo..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "O8xr9p"
+msgid "Working on the visuals..."
+msgstr "Trabajando en las imágenes..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "r8xznK"
+msgid "Researching the topic..."
+msgstr "Investigando el tema..."
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 msgctxt "sISitf"
@@ -1488,6 +1624,34 @@ msgctxt "v4iFHN"
 msgid "Writing the content"
 msgstr "Escribiendo el contenido"
 
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "VADOBa"
+msgid "Looking up how each word sounds..."
+msgstr "Buscando cómo suena cada palabra..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "WnqJeL"
+msgid "Mapping out the pronunciation..."
+msgstr "Mapeando la pronunciación..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "xrLiIe"
+msgid "Setting things up..."
+msgstr "Configurando todo..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "Yoev2R"
+msgid "Refining the details..."
+msgstr "Refinando los detalles..."
+
 #: src/app/[locale]/generate/ch/[id]/generate-chapter-content.tsx
 msgctxt "9GwOlW"
 msgid "Generate Chapter"
@@ -1504,9 +1668,41 @@ msgid "Taking you to your chapter..."
 msgstr "Llevándote a tu capítulo..."
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+msgctxt "Tp34ZM"
+msgid "This usually takes 2-4 minutes"
+msgstr "Esto suele tomar 2-4 minutos"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 msgctxt "ViO6Dt"
 msgid "Creating your lessons"
 msgstr "Creando tus lecciones"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "6xEJTk"
+msgid "Designing practice exercises..."
+msgstr "Diseñando ejercicios de práctica..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "GTTucy"
+msgid "Thinking about how to teach this..."
+msgstr "Pensando cómo enseñar esto..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "HWSnYS"
+msgid "Reviewing the flow so far..."
+msgstr "Revisando el flujo hasta ahora..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "igBmpz"
+msgid "Making it interactive..."
+msgstr "Haciéndolo interactivo..."
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
@@ -1523,9 +1719,34 @@ msgid "Figuring out the best approach"
 msgstr "Determinando el mejor enfoque"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "Nhva19"
+msgid "Choosing the right approach..."
+msgstr "Eligiendo el enfoque correcto..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "nwGJ65"
+msgid "Exploring your topic..."
+msgstr "Explorando tu tema..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 msgctxt "SF9AtA"
 msgid "Preparing lessons"
 msgstr "Preparando lecciones"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "VKFa/t"
+msgid "Mapping out the learning path..."
+msgstr "Trazando el camino de aprendizaje..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "zQWv1/"
+msgid "Writing lesson {number}..."
+msgstr "Escribiendo la lección {number}..."
 
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 msgctxt "0o41MR"
@@ -1538,6 +1759,11 @@ msgid "Your course is ready"
 msgstr "Tu curso está listo"
 
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+msgctxt "bXKvjZ"
+msgid "This usually takes 4-6 minutes"
+msgstr "Esto suele tomar de 4 a 6 minutos"
+
+#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 msgctxt "DFlapX"
 msgid "Creating your course"
 msgstr "Creando tu curso"
@@ -1548,9 +1774,34 @@ msgid "Writing the lesson content"
 msgstr "Escribiendo el contenido de la lección"
 
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "9r/4zz"
+msgid "Writing the overview..."
+msgstr "Escribiendo la descripción general..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "a7FJJd"
+msgid "Summarizing what you'll learn..."
+msgstr "Resumiendo lo que aprenderás..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "AEG3Ol"
+msgid "Planning the course structure..."
+msgstr "Planificando la estructura del curso..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "aev/pt"
+msgid "Figuring out the right categories..."
+msgstr "Determinando las categorías correctas..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 msgctxt "aJev/w"
 msgid "Getting things ready"
 msgstr "Preparando todo"
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "At4rk1"
+msgid "Adding finishing touches..."
+msgstr "Agregando toques finales..."
 
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 msgctxt "bkPdBd"
@@ -1561,6 +1812,11 @@ msgstr "Planeando tu primera lección"
 msgctxt "CFWOGF"
 msgid "Saving your course"
 msgstr "Guardando tu curso"
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "EKAN6s"
+msgid "Tagging your course..."
+msgstr "Etiquetando tu curso..."
 
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 msgctxt "Gjutu+"
@@ -1578,9 +1834,39 @@ msgid "Categorizing your course"
 msgstr "Categorizando tu curso"
 
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
-msgctxt "vFYF4v"
-msgid "Outlining chapters"
-msgstr "Delineando capítulos"
+msgctxt "lxBtcx"
+msgid "Designing the cover..."
+msgstr "Diseñando la portada..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "OW9vMd"
+msgid "Writing chapter {number}..."
+msgstr "Escribiendo capítulo {number}..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "tXkuD8"
+msgid "Reviewing the overall flow..."
+msgstr "Revisando el flujo general..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "txvxwS"
+msgid "Saving your progress..."
+msgstr "Guardando tu progreso..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "W8n2i3"
+msgid "Picking the right look..."
+msgstr "Eligiendo la apariencia correcta..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "WZpB8D"
+msgid "Writing chapters"
+msgstr "Escribiendo capítulos"
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "XxZuJi"
+msgid "Putting it all together..."
+msgstr "Juntando todo..."
 
 #: src/app/[locale]/generate/l/[id]/generate-lesson-content.tsx
 msgctxt "GG4VCc"
@@ -1596,6 +1882,11 @@ msgstr "Tu lección está lista"
 msgctxt "dO1XtE"
 msgid "Creating your activities"
 msgstr "Creando tus actividades"
+
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
+msgctxt "kiZUDf"
+msgid "This usually takes about a minute"
+msgstr "Esto suele tomar alrededor de un minuto"
 
 #: src/app/[locale]/generate/l/[id]/generation-client.tsx
 msgctxt "T2TGxR"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1387,6 +1387,11 @@ msgid "Your activity is ready"
 msgstr "Sua atividade está pronta"
 
 #: src/app/[locale]/generate/a/[id]/generation-client.tsx
+msgctxt "3vY0Zu"
+msgid "This usually takes 1-2 minutes"
+msgstr "Isso geralmente leva 1-2 minutos"
+
+#: src/app/[locale]/generate/a/[id]/generation-client.tsx
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 #: src/app/[locale]/generate/l/[id]/generation-client.tsx
@@ -1431,9 +1436,80 @@ msgstr "Algo deu errado. Por favor, tente novamente."
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "2hb6pr"
+msgid "Adding examples..."
+msgstr "Adicionando exemplos..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "4xvh9e"
+msgid "Getting the pronunciation right..."
+msgstr "Acertando a pronúncia..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "5InW8H"
+msgid "Recording the audio..."
+msgstr "Gravando o áudio..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "5nJVpw"
+msgid "Getting everything ready..."
+msgstr "Preparando tudo..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "8lInA7"
+msgid "Sketching out ideas..."
+msgstr "Esboçando ideias..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "abtOR3"
+msgid "Planning the layout..."
+msgstr "Planejando o layout..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "aeeXxf"
+msgid "Wrapping up..."
+msgstr "Finalizando..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 msgctxt "aKNA/b"
 msgid "Creating images"
 msgstr "Criando imagens"
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "bJVUNz"
+msgid "Adding some color..."
+msgstr "Adicionando um pouco de cor..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "dQnsCW"
+msgid "Choosing the right style..."
+msgstr "Escolhendo o estilo certo..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "EAqAX/"
+msgid "Thinking about what to illustrate..."
+msgstr "Pensando no que ilustrar..."
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
@@ -1449,12 +1525,72 @@ msgid "Preparing practice content"
 msgstr "Preparando conteúdo para prática"
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+msgctxt "hfXRZ0"
+msgid "Reviewing earlier activities..."
+msgstr "Revisando atividades anteriores..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
 msgctxt "HYmCaW"
 msgid "Almost done"
 msgstr "Quase pronto"
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "i+rNdh"
+msgid "Picking the key vocabulary..."
+msgstr "Escolhendo o vocabulário principal..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "IdWf9/"
+msgid "Choosing words to practice..."
+msgstr "Escolhendo palavras pra praticar..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+msgctxt "JBrEHg"
+msgid "Connecting the pieces..."
+msgstr "Conectando as peças..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "JGNN92"
+msgid "Drawing an illustration..."
+msgstr "Desenhando uma ilustração..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "K/JznZ"
+msgid "Writing the explanation..."
+msgstr "Escrevendo a explicação..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "MNQpiA"
+msgid "Almost there..."
+msgstr "Quase lá..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "O8xr9p"
+msgid "Working on the visuals..."
+msgstr "Trabalhando nos visuais..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "r8xznK"
+msgid "Researching the topic..."
+msgstr "Pesquisando o tópico..."
 
 #: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
 msgctxt "sISitf"
@@ -1488,6 +1624,34 @@ msgctxt "v4iFHN"
 msgid "Writing the content"
 msgstr "Escrevendo o conteúdo"
 
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "VADOBa"
+msgid "Looking up how each word sounds..."
+msgstr "Procurando como cada palavra soa..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "WnqJeL"
+msgid "Mapping out the pronunciation..."
+msgstr "Mapeando a pronúncia..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "xrLiIe"
+msgid "Setting things up..."
+msgstr "Configurando as coisas..."
+
+#: src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "Yoev2R"
+msgid "Refining the details..."
+msgstr "Refinando os detalhes..."
+
 #: src/app/[locale]/generate/ch/[id]/generate-chapter-content.tsx
 msgctxt "9GwOlW"
 msgid "Generate Chapter"
@@ -1504,9 +1668,41 @@ msgid "Taking you to your chapter..."
 msgstr "Levando você para seu capítulo..."
 
 #: src/app/[locale]/generate/ch/[id]/generation-client.tsx
+msgctxt "Tp34ZM"
+msgid "This usually takes 2-4 minutes"
+msgstr "Isso geralmente leva 2-4 minutos"
+
+#: src/app/[locale]/generate/ch/[id]/generation-client.tsx
 msgctxt "ViO6Dt"
 msgid "Creating your lessons"
 msgstr "Criando suas aulas"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "6xEJTk"
+msgid "Designing practice exercises..."
+msgstr "Criando exercícios de prática..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "GTTucy"
+msgid "Thinking about how to teach this..."
+msgstr "Pensando em como ensinar isso..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "HWSnYS"
+msgid "Reviewing the flow so far..."
+msgstr "Revisando o fluxo até agora..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "igBmpz"
+msgid "Making it interactive..."
+msgstr "Tornando interativo..."
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
@@ -1523,9 +1719,34 @@ msgid "Figuring out the best approach"
 msgstr "Descobrindo a melhor abordagem"
 
 #: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/l/[id]/use-generation-phases.ts
+msgctxt "Nhva19"
+msgid "Choosing the right approach..."
+msgstr "Escolhendo a abordagem certa..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "nwGJ65"
+msgid "Exploring your topic..."
+msgstr "Explorando seu tópico..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
 msgctxt "SF9AtA"
 msgid "Preparing lessons"
 msgstr "Preparando aulas"
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "VKFa/t"
+msgid "Mapping out the learning path..."
+msgstr "Mapeando o caminho de aprendizado..."
+
+#: src/app/[locale]/generate/ch/[id]/use-generation-phases.ts
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "zQWv1/"
+msgid "Writing lesson {number}..."
+msgstr "Escrevendo a aula {number}..."
 
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 msgctxt "0o41MR"
@@ -1538,6 +1759,11 @@ msgid "Your course is ready"
 msgstr "Seu curso está pronto"
 
 #: src/app/[locale]/generate/cs/[id]/generation-client.tsx
+msgctxt "bXKvjZ"
+msgid "This usually takes 4-6 minutes"
+msgstr "Isso geralmente leva de 4 a 6 minutos"
+
+#: src/app/[locale]/generate/cs/[id]/generation-client.tsx
 msgctxt "DFlapX"
 msgid "Creating your course"
 msgstr "Criando seu curso"
@@ -1548,9 +1774,34 @@ msgid "Writing the lesson content"
 msgstr "Escrevendo o conteúdo da aula"
 
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "9r/4zz"
+msgid "Writing the overview..."
+msgstr "Escrevendo a visão geral..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "a7FJJd"
+msgid "Summarizing what you'll learn..."
+msgstr "Resumindo o que você vai aprender..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "AEG3Ol"
+msgid "Planning the course structure..."
+msgstr "Planejando a estrutura do curso..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "aev/pt"
+msgid "Figuring out the right categories..."
+msgstr "Descobrindo as categorias certas..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 msgctxt "aJev/w"
 msgid "Getting things ready"
 msgstr "Preparando as coisas"
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "At4rk1"
+msgid "Adding finishing touches..."
+msgstr "Adicionando os toques finais..."
 
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 msgctxt "bkPdBd"
@@ -1561,6 +1812,11 @@ msgstr "Planejando sua primeira aula"
 msgctxt "CFWOGF"
 msgid "Saving your course"
 msgstr "Salvando seu curso"
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "EKAN6s"
+msgid "Tagging your course..."
+msgstr "Marcando seu curso..."
 
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
 msgctxt "Gjutu+"
@@ -1578,9 +1834,39 @@ msgid "Categorizing your course"
 msgstr "Categorizando seu curso"
 
 #: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
-msgctxt "vFYF4v"
-msgid "Outlining chapters"
-msgstr "Delineando capítulos"
+msgctxt "lxBtcx"
+msgid "Designing the cover..."
+msgstr "Criando a capa..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "OW9vMd"
+msgid "Writing chapter {number}..."
+msgstr "Escrevendo o capítulo {number}..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "tXkuD8"
+msgid "Reviewing the overall flow..."
+msgstr "Revisando o fluxo geral..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "txvxwS"
+msgid "Saving your progress..."
+msgstr "Salvando seu progresso..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "W8n2i3"
+msgid "Picking the right look..."
+msgstr "Escolhendo a aparência certa..."
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "WZpB8D"
+msgid "Writing chapters"
+msgstr "Escrevendo capítulos"
+
+#: src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+msgctxt "XxZuJi"
+msgid "Putting it all together..."
+msgstr "Juntando tudo..."
 
 #: src/app/[locale]/generate/l/[id]/generate-lesson-content.tsx
 msgctxt "GG4VCc"
@@ -1596,6 +1882,11 @@ msgstr "Sua aula está pronta"
 msgctxt "dO1XtE"
 msgid "Creating your activities"
 msgstr "Criando suas atividades"
+
+#: src/app/[locale]/generate/l/[id]/generation-client.tsx
+msgctxt "kiZUDf"
+msgid "This usually takes about a minute"
+msgstr "Isso geralmente leva cerca de um minuto"
 
 #: src/app/[locale]/generate/l/[id]/generation-client.tsx
 msgctxt "T2TGxR"

--- a/apps/main/src/app/[locale]/generate/a/[id]/generation-client.tsx
+++ b/apps/main/src/app/[locale]/generate/a/[id]/generation-client.tsx
@@ -8,10 +8,12 @@ import {
   GenerationTimelineProgress,
   GenerationTimelineStep,
   GenerationTimelineSteps,
+  GenerationTimelineSubtitle,
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
+import { useThinkingMessages } from "@/lib/workflow/use-thinking-messages";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
 import { type ActivityStepName, getActivityCompletionStep } from "@/workflows/config";
 import { type ActivityKind, type GenerationStatus } from "@zoonk/db";
@@ -53,15 +55,18 @@ export function GenerationClient({
     triggerUrl: `${API_URL}/v1/workflows/activity-generation/trigger`,
   });
 
-  const { phases, progress } = useGenerationPhases(
+  const { activePhaseNames, phases, progress, thinkingGenerators } = useGenerationPhases(
     generation.completedSteps,
     generation.currentStep,
     activityKind,
+    generation.startedSteps,
   );
 
-  const displayProgress = useAnimatedProgress(
-    progress,
-    generation.status === "triggering" || generation.status === "streaming",
+  const isActive = generation.status === "triggering" || generation.status === "streaming";
+  const displayProgress = useAnimatedProgress(progress, isActive);
+  const thinkingMessages = useThinkingMessages(
+    thinkingGenerators,
+    isActive ? activePhaseNames : [],
   );
 
   useCompletionRedirect({
@@ -69,17 +74,21 @@ export function GenerationClient({
     url: `/${locale}/b/${AI_ORG_SLUG}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}/a/${position}`,
   });
 
-  if (generation.status === "triggering" || generation.status === "streaming") {
+  if (isActive) {
     return (
       <GenerationTimeline>
         <GenerationTimelineHeader>
           <GenerationTimelineTitle>{t("Creating your activity")}</GenerationTimelineTitle>
+          <GenerationTimelineSubtitle>
+            {t("This usually takes 1-2 minutes")}
+          </GenerationTimelineSubtitle>
           <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
         </GenerationTimelineHeader>
 
         <GenerationTimelineSteps>
           {phases.map((phase, index) => (
             <GenerationTimelineStep
+              detail={thinkingMessages[phase.name]}
               icon={phase.icon}
               isLast={index === phases.length - 1}
               key={phase.name}

--- a/apps/main/src/app/[locale]/generate/a/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/a/[id]/use-generation-phases.ts
@@ -8,6 +8,7 @@ import {
   getPhaseOrder,
   getPhaseStatus,
 } from "@/lib/generation/activity-generation-phases";
+import { type ThinkingMessageGenerator, cycleMessage } from "@/lib/workflow/use-thinking-messages";
 import { type ActivityStepName } from "@/workflows/config";
 import { type ActivityKind } from "@zoonk/db";
 import { useExtracted } from "next-intl";
@@ -16,6 +17,7 @@ export function useGenerationPhases(
   completedSteps: ActivityStepName[],
   currentStep: ActivityStepName | null,
   activityKind: ActivityKind,
+  startedSteps?: ActivityStepName[],
 ) {
   const t = useExtracted();
 
@@ -42,11 +44,61 @@ export function useGenerationPhases(
     icon: PHASE_ICONS[phase],
     label: labels[phase],
     name: phase,
-    status: getPhaseStatus(phase, completedSteps, currentStep, activityKind),
+    status: getPhaseStatus(phase, completedSteps, currentStep, activityKind, startedSteps),
   }));
 
-  const progress = calculateWeightedProgress(completedSteps, currentStep, activityKind);
-  const activePhase = phases.find((phase) => phase.status === "active");
+  const progress = calculateWeightedProgress(
+    completedSteps,
+    currentStep,
+    activityKind,
+    startedSteps,
+  );
 
-  return { activePhase, phases, progress };
+  const activePhaseNames = phases
+    .filter((phase) => phase.status === "active")
+    .map((phase) => phase.name);
+
+  const thinkingGenerators: Record<PhaseName, ThinkingMessageGenerator> = {
+    addingPronunciation: (index) =>
+      cycleMessage(
+        [t("Looking up how each word sounds..."), t("Mapping out the pronunciation...")],
+        index,
+      ),
+    buildingWordList: (index) =>
+      cycleMessage([t("Picking the key vocabulary..."), t("Choosing words to practice...")], index),
+    creatingImages: (index) =>
+      cycleMessage(
+        [
+          t("Drawing an illustration..."),
+          t("Working on the visuals..."),
+          t("Adding some color..."),
+          t("Refining the details..."),
+        ],
+        index,
+      ),
+    finishing: (index) => cycleMessage([t("Wrapping up..."), t("Almost there...")], index),
+    gettingStarted: (index) =>
+      cycleMessage([t("Getting everything ready..."), t("Setting things up...")], index),
+    preparingVisuals: (index) =>
+      cycleMessage(
+        [
+          t("Thinking about what to illustrate..."),
+          t("Sketching out ideas..."),
+          t("Choosing the right style..."),
+          t("Planning the layout..."),
+        ],
+        index,
+      ),
+    processingDependencies: (index) =>
+      cycleMessage([t("Reviewing earlier activities..."), t("Connecting the pieces...")], index),
+    recordingAudio: (index) =>
+      cycleMessage([t("Recording the audio..."), t("Getting the pronunciation right...")], index),
+    writingContent: (index) =>
+      cycleMessage(
+        [t("Researching the topic..."), t("Writing the explanation..."), t("Adding examples...")],
+        index,
+      ),
+  };
+
+  return { activePhaseNames, phases, progress, thinkingGenerators };
 }

--- a/apps/main/src/app/[locale]/generate/ch/[id]/generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/ch/[id]/generation-phases.ts
@@ -184,15 +184,17 @@ export function getPhaseStatus(
   completedSteps: ChapterWorkflowStepName[],
   currentStep: ChapterWorkflowStepName | null,
   targetLanguage: string | null,
+  startedSteps?: ChapterWorkflowStepName[],
 ): PhaseStatus {
   const kind = getInferredFirstActivityKind(completedSteps, currentStep, targetLanguage);
-  return getStatus(phase, completedSteps, currentStep, getPhaseSteps(kind));
+  return getStatus(phase, completedSteps, currentStep, getPhaseSteps(kind), startedSteps);
 }
 
 export function calculateWeightedProgress(
   completedSteps: ChapterWorkflowStepName[],
   currentStep: ChapterWorkflowStepName | null,
   targetLanguage: string | null,
+  startedSteps?: ChapterWorkflowStepName[],
 ): number {
   const kind = getInferredFirstActivityKind(completedSteps, currentStep, targetLanguage);
 
@@ -200,5 +202,6 @@ export function calculateWeightedProgress(
     phaseOrder: getPhaseOrder({ completedSteps, currentStep, targetLanguage }),
     phaseSteps: getPhaseSteps(kind),
     phaseWeights: getPhaseWeights(kind),
+    startedSteps,
   });
 }

--- a/apps/main/src/app/[locale]/generate/cs/[id]/generation-client.tsx
+++ b/apps/main/src/app/[locale]/generate/cs/[id]/generation-client.tsx
@@ -8,10 +8,12 @@ import {
   GenerationTimelineProgress,
   GenerationTimelineStep,
   GenerationTimelineSteps,
+  GenerationTimelineSubtitle,
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
+import { useThinkingMessages } from "@/lib/workflow/use-thinking-messages";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
 import {
   ACTIVITY_GENERATION_COMPLETION_STEP,
@@ -48,15 +50,18 @@ export function GenerationClient({
     triggerUrl: `${API_URL}/v1/workflows/course-generation/trigger`,
   });
 
-  const { phases, progress } = useGenerationPhases(
+  const { activePhaseNames, phases, progress, thinkingGenerators } = useGenerationPhases(
     generation.completedSteps,
     generation.currentStep,
     targetLanguage,
+    generation.startedSteps,
   );
 
-  const displayProgress = useAnimatedProgress(
-    progress,
-    generation.status === "triggering" || generation.status === "streaming",
+  const isActive = generation.status === "triggering" || generation.status === "streaming";
+  const displayProgress = useAnimatedProgress(progress, isActive);
+  const thinkingMessages = useThinkingMessages(
+    thinkingGenerators,
+    isActive ? activePhaseNames : [],
   );
 
   useCompletionRedirect({
@@ -64,17 +69,21 @@ export function GenerationClient({
     url: `/${locale}/b/${AI_ORG_SLUG}/c/${courseSlug}`,
   });
 
-  if (generation.status === "triggering" || generation.status === "streaming") {
+  if (isActive) {
     return (
       <GenerationTimeline>
         <GenerationTimelineHeader>
           <GenerationTimelineTitle>{t("Creating your course")}</GenerationTimelineTitle>
+          <GenerationTimelineSubtitle>
+            {t("This usually takes 4-6 minutes")}
+          </GenerationTimelineSubtitle>
           <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
         </GenerationTimelineHeader>
 
         <GenerationTimelineSteps>
           {phases.map((phase, index) => (
             <GenerationTimelineStep
+              detail={thinkingMessages[phase.name]}
               icon={phase.icon}
               isLast={index === phases.length - 1}
               key={phase.name}

--- a/apps/main/src/app/[locale]/generate/cs/[id]/generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/cs/[id]/generation-phases.ts
@@ -235,15 +235,17 @@ export function getPhaseStatus(
   completedSteps: CourseWorkflowStepName[],
   currentStep: CourseWorkflowStepName | null,
   targetLanguage: string | null,
+  startedSteps?: CourseWorkflowStepName[],
 ): PhaseStatus {
   const kind = getInferredFirstActivityKind(completedSteps, currentStep, targetLanguage);
-  return getStatus(phase, completedSteps, currentStep, getPhaseSteps(kind));
+  return getStatus(phase, completedSteps, currentStep, getPhaseSteps(kind), startedSteps);
 }
 
 export function calculateWeightedProgress(
   completedSteps: CourseWorkflowStepName[],
   currentStep: CourseWorkflowStepName | null,
   targetLanguage: string | null,
+  startedSteps?: CourseWorkflowStepName[],
 ): number {
   const kind = getInferredFirstActivityKind(completedSteps, currentStep, targetLanguage);
 
@@ -251,5 +253,6 @@ export function calculateWeightedProgress(
     phaseOrder: getPhaseOrder({ completedSteps, currentStep, targetLanguage }),
     phaseSteps: getPhaseSteps(kind),
     phaseWeights: getPhaseWeights(kind),
+    startedSteps,
   });
 }

--- a/apps/main/src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/cs/[id]/use-generation-phases.ts
@@ -1,6 +1,11 @@
 "use client";
 
 import { type PhaseStatus } from "@/lib/generation-phases";
+import {
+  type ThinkingMessageGenerator,
+  createCountingGenerator,
+  cycleMessage,
+} from "@/lib/workflow/use-thinking-messages";
 import { type CourseWorkflowStepName } from "@/workflows/config";
 import { useExtracted } from "next-intl";
 import {
@@ -15,6 +20,7 @@ export function useGenerationPhases(
   completedSteps: CourseWorkflowStepName[],
   currentStep: CourseWorkflowStepName | null,
   targetLanguage: string | null,
+  startedSteps?: CourseWorkflowStepName[],
 ) {
   const t = useExtracted();
 
@@ -27,7 +33,7 @@ export function useGenerationPhases(
     figuringOutApproach: t("Figuring out the best approach"),
     finishing: t("Almost done"),
     gettingReady: t("Getting things ready"),
-    outliningChapters: t("Outlining chapters"),
+    outliningChapters: t("Writing chapters"),
     planningLessons: t("Planning your first lesson"),
     preparingVisuals: t("Preparing illustrations"),
     recordingAudio: t("Recording audio"),
@@ -48,11 +54,91 @@ export function useGenerationPhases(
     icon: PHASE_ICONS[phase],
     label: labels[phase],
     name: phase,
-    status: getPhaseStatus(phase, completedSteps, currentStep, targetLanguage),
+    status: getPhaseStatus(phase, completedSteps, currentStep, targetLanguage, startedSteps),
   }));
 
-  const progress = calculateWeightedProgress(completedSteps, currentStep, targetLanguage);
-  const activePhase = phases.find((phase) => phase.status === "active");
+  const progress = calculateWeightedProgress(
+    completedSteps,
+    currentStep,
+    targetLanguage,
+    startedSteps,
+  );
 
-  return { activePhase, phases, progress };
+  const activePhaseNames = phases
+    .filter((phase) => phase.status === "active")
+    .map((phase) => phase.name);
+
+  const thinkingGenerators: Record<PhaseName, ThinkingMessageGenerator> = {
+    addingPronunciation: (index) =>
+      cycleMessage(
+        [t("Looking up how each word sounds..."), t("Mapping out the pronunciation...")],
+        index,
+      ),
+    buildingWordList: (index) =>
+      cycleMessage([t("Picking the key vocabulary..."), t("Choosing words to practice...")], index),
+    categorizingCourse: (index) =>
+      cycleMessage([t("Figuring out the right categories..."), t("Tagging your course...")], index),
+    creatingCoverImage: (index) =>
+      cycleMessage(
+        [
+          t("Designing the cover..."),
+          t("Picking the right look..."),
+          t("Adding finishing touches..."),
+        ],
+        index,
+      ),
+    creatingImages: (index) =>
+      cycleMessage(
+        [
+          t("Drawing an illustration..."),
+          t("Working on the visuals..."),
+          t("Adding some color..."),
+          t("Refining the details..."),
+        ],
+        index,
+      ),
+    figuringOutApproach: (index) =>
+      cycleMessage(
+        [t("Thinking about how to teach this..."), t("Choosing the right approach...")],
+        index,
+      ),
+    finishing: (index) => cycleMessage([t("Wrapping up..."), t("Almost there...")], index),
+    gettingReady: (index) =>
+      cycleMessage([t("Setting things up..."), t("Getting everything ready...")], index),
+    outliningChapters: createCountingGenerator({
+      intro: [t("Planning the course structure...")],
+      itemTemplate: (num) => t("Writing chapter {number}...", { number: String(num) }),
+      reviewMessage: t("Reviewing the overall flow..."),
+    }),
+    planningLessons: createCountingGenerator({
+      intro: [t("Exploring your topic..."), t("Mapping out the learning path...")],
+      itemTemplate: (num) => t("Writing lesson {number}...", { number: String(num) }),
+      reviewMessage: t("Reviewing the flow so far..."),
+    }),
+    preparingVisuals: (index) =>
+      cycleMessage(
+        [
+          t("Thinking about what to illustrate..."),
+          t("Sketching out ideas..."),
+          t("Choosing the right style..."),
+          t("Planning the layout..."),
+        ],
+        index,
+      ),
+    recordingAudio: (index) =>
+      cycleMessage([t("Recording the audio..."), t("Getting the pronunciation right...")], index),
+    savingCourseInfo: (index) =>
+      cycleMessage([t("Saving your progress..."), t("Putting it all together...")], index),
+    settingUpActivities: (index) =>
+      cycleMessage([t("Designing practice exercises..."), t("Making it interactive...")], index),
+    writingContent: (index) =>
+      cycleMessage(
+        [t("Researching the topic..."), t("Writing the explanation..."), t("Adding examples...")],
+        index,
+      ),
+    writingDescription: (index) =>
+      cycleMessage([t("Summarizing what you'll learn..."), t("Writing the overview...")], index),
+  };
+
+  return { activePhaseNames, phases, progress, thinkingGenerators };
 }

--- a/apps/main/src/app/[locale]/generate/l/[id]/generation-phases.ts
+++ b/apps/main/src/app/[locale]/generate/l/[id]/generation-phases.ts
@@ -56,17 +56,20 @@ export function getPhaseStatus(
   phase: PhaseName,
   completedSteps: LessonStepName[],
   currentStep: LessonStepName | null,
+  startedSteps?: LessonStepName[],
 ): PhaseStatus {
-  return getStatus(phase, completedSteps, currentStep, PHASE_STEPS);
+  return getStatus(phase, completedSteps, currentStep, PHASE_STEPS, startedSteps);
 }
 
 export function calculateWeightedProgress(
   completedSteps: LessonStepName[],
   currentStep: LessonStepName | null,
+  startedSteps?: LessonStepName[],
 ): number {
   return calculateProgress(completedSteps, currentStep, {
     phaseOrder: PHASE_ORDER,
     phaseSteps: PHASE_STEPS,
     phaseWeights: PHASE_WEIGHTS,
+    startedSteps,
   });
 }

--- a/apps/main/src/components/generation/generation-progress.tsx
+++ b/apps/main/src/components/generation/generation-progress.tsx
@@ -90,13 +90,34 @@ function GenerationTimelineStepIndicator({
   );
 }
 
+function GenerationTimelineSubtitle({ children }: { children: ReactNode }) {
+  return (
+    <p className="text-muted-foreground text-sm" data-slot="generation-timeline-subtitle">
+      {children}
+    </p>
+  );
+}
+
+function GenerationTimelineStepDetail({ children }: { children: ReactNode }) {
+  return (
+    <span
+      className="text-muted-foreground/50 block text-xs transition-opacity duration-300"
+      data-slot="generation-timeline-step-detail"
+    >
+      {children}
+    </span>
+  );
+}
+
 function GenerationTimelineStep({
   children,
+  detail,
   icon,
   isLast,
   status,
 }: {
   children: ReactNode;
+  detail?: string | null;
   icon: LucideIcon;
   isLast?: boolean;
   status: PhaseStatus;
@@ -115,17 +136,22 @@ function GenerationTimelineStep({
           />
         )}
       </div>
-      <span
-        className={cn(
-          "pt-0.5 text-sm",
-          status === "completed" && "text-muted-foreground",
-          status === "active" &&
-            "animate-shimmer-text motion-reduce:text-foreground bg-[linear-gradient(90deg,var(--foreground)_0%,var(--foreground)_40%,var(--muted-foreground)_50%,var(--foreground)_60%,var(--foreground)_100%)] bg-size-[200%_100%] bg-clip-text font-medium text-transparent motion-reduce:animate-none motion-reduce:bg-none",
-          status === "pending" && "text-muted-foreground/60",
+      <div className="flex flex-col gap-0.5">
+        <span
+          className={cn(
+            "pt-0.5 text-sm",
+            status === "completed" && "text-muted-foreground",
+            status === "active" &&
+              "animate-shimmer-text motion-reduce:text-foreground bg-[linear-gradient(90deg,var(--foreground)_0%,var(--foreground)_40%,var(--muted-foreground)_50%,var(--foreground)_60%,var(--foreground)_100%)] bg-size-[200%_100%] bg-clip-text font-medium text-transparent motion-reduce:animate-none motion-reduce:bg-none",
+            status === "pending" && "text-muted-foreground/60",
+          )}
+        >
+          {children}
+        </span>
+        {status === "active" && detail && (
+          <GenerationTimelineStepDetail>{detail}</GenerationTimelineStepDetail>
         )}
-      >
-        {children}
-      </span>
+      </div>
     </div>
   );
 }
@@ -183,5 +209,6 @@ export {
   GenerationTimelineProgress,
   GenerationTimelineStep,
   GenerationTimelineSteps,
+  GenerationTimelineSubtitle,
   GenerationTimelineTitle,
 };

--- a/apps/main/src/lib/generation-phases.test.ts
+++ b/apps/main/src/lib/generation-phases.test.ts
@@ -36,6 +36,19 @@ describe(getPhaseStatus, () => {
     expect(getPhaseStatus("phase1", ["stepC", "stepD"], null, testPhaseSteps)).toBe("pending");
   });
 
+  it("returns 'active' when a step has been started via startedSteps", () => {
+    expect(getPhaseStatus("phase1", [], null, testPhaseSteps, ["stepA"])).toBe("active");
+  });
+
+  it("returns 'active' via startedSteps even when currentStep is in another phase", () => {
+    expect(getPhaseStatus("phase1", [], "stepC", testPhaseSteps, ["stepA"])).toBe("active");
+  });
+
+  it("backward-compatible when startedSteps is omitted", () => {
+    expect(getPhaseStatus("phase1", [], null, testPhaseSteps)).toBe("pending");
+    expect(getPhaseStatus("phase1", [], null, testPhaseSteps)).toBe("pending");
+  });
+
   it("returns 'completed' for single-step phase when that step is done", () => {
     expect(getPhaseStatus("phase2", ["stepC"], null, testPhaseSteps)).toBe("completed");
   });

--- a/apps/main/src/lib/generation-phases.ts
+++ b/apps/main/src/lib/generation-phases.ts
@@ -13,6 +13,7 @@ export function getPhaseStatus<TPhase extends string, TStep extends string>(
   completedSteps: TStep[],
   currentStep: TStep | null,
   phaseSteps: Record<TPhase, readonly TStep[]>,
+  startedSteps?: TStep[],
 ): PhaseStatus {
   const steps = phaseSteps[phase];
   const completedCount = steps.filter((step) => completedSteps.includes(step)).length;
@@ -29,6 +30,10 @@ export function getPhaseStatus<TPhase extends string, TStep extends string>(
     return "active";
   }
 
+  if (startedSteps && steps.some((step) => startedSteps.includes(step))) {
+    return "active";
+  }
+
   return "pending";
 }
 
@@ -39,6 +44,7 @@ export function calculateWeightedProgress<TPhase extends string, TStep extends s
     phaseSteps: Record<TPhase, readonly TStep[]>;
     phaseOrder: readonly TPhase[];
     phaseWeights: Record<TPhase, number>;
+    startedSteps?: TStep[];
   },
 ): number {
   const totalWeight = config.phaseOrder.reduce((sum, phase) => sum + config.phaseWeights[phase], 0);
@@ -50,7 +56,13 @@ export function calculateWeightedProgress<TPhase extends string, TStep extends s
   let weightedSum = 0;
 
   for (const phase of config.phaseOrder) {
-    const status = getPhaseStatus(phase, completedSteps, currentStep, config.phaseSteps);
+    const status = getPhaseStatus(
+      phase,
+      completedSteps,
+      currentStep,
+      config.phaseSteps,
+      config.startedSteps,
+    );
     const weight = config.phaseWeights[phase];
 
     if (status === "completed") {

--- a/apps/main/src/lib/generation/activity-generation-phases.ts
+++ b/apps/main/src/lib/generation/activity-generation-phases.ts
@@ -46,18 +46,21 @@ export function getPhaseStatus(
   completedSteps: ActivityStepName[],
   currentStep: ActivityStepName | null,
   activityKind: ActivityKind,
+  startedSteps?: ActivityStepName[],
 ): PhaseStatus {
-  return getStatus(phase, completedSteps, currentStep, getPhaseSteps(activityKind));
+  return getStatus(phase, completedSteps, currentStep, getPhaseSteps(activityKind), startedSteps);
 }
 
 export function calculateWeightedProgress(
   completedSteps: ActivityStepName[],
   currentStep: ActivityStepName | null,
   activityKind: ActivityKind,
+  startedSteps?: ActivityStepName[],
 ): number {
   return calculateProgress(completedSteps, currentStep, {
     phaseOrder: getPhaseOrder(activityKind),
     phaseSteps: getPhaseSteps(activityKind),
     phaseWeights: getPhaseWeights(activityKind),
+    startedSteps,
   });
 }

--- a/apps/main/src/lib/workflow/generation-store.ts
+++ b/apps/main/src/lib/workflow/generation-store.ts
@@ -24,6 +24,7 @@ export function createGenerationStore<TStep extends string = string>(
       currentStep: null as TStep | null,
       error: null as string | null,
       runId: null as string | null,
+      startedSteps: [] as TStep[],
       status: "idle" as GenerationStatus,
       ...initialContext,
     },
@@ -33,6 +34,7 @@ export function createGenerationStore<TStep extends string = string>(
         currentStep: null as TStep | null,
         error: null as string | null,
         runId: null as string | null,
+        startedSteps: [] as TStep[],
         status: "idle" as GenerationStatus,
       }),
 
@@ -53,6 +55,9 @@ export function createGenerationStore<TStep extends string = string>(
       stepStarted: (ctx, event: { step: TStep }) => ({
         ...ctx,
         currentStep: event.step,
+        startedSteps: ctx.startedSteps.includes(event.step)
+          ? ctx.startedSteps
+          : [...ctx.startedSteps, event.step],
       }),
       triggerStart: (ctx) => ({
         ...ctx,

--- a/apps/main/src/lib/workflow/use-thinking-messages.test.ts
+++ b/apps/main/src/lib/workflow/use-thinking-messages.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useThinkingMessages } from "./use-thinking-messages";
+
+const generators = {
+  phaseA: (index: number) => ["Analyzing...", "Planning...", "Building..."][index % 3] ?? "",
+  phaseB: (index: number) => ["Loading...", "Processing..."][index % 2] ?? "",
+};
+
+describe(useThinkingMessages, () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns empty object when no phases are active", () => {
+    const { result } = renderHook(() => useThinkingMessages(generators, []));
+    expect(result.current).toEqual({});
+  });
+
+  it("returns first message immediately for active phases", () => {
+    const { result } = renderHook(() => useThinkingMessages(generators, ["phaseA"]));
+    expect(result.current).toEqual({ phaseA: "Analyzing..." });
+  });
+
+  it("returns messages for multiple active phases simultaneously", () => {
+    const { result } = renderHook(() => useThinkingMessages(generators, ["phaseA", "phaseB"]));
+    expect(result.current).toEqual({ phaseA: "Analyzing...", phaseB: "Loading..." });
+  });
+
+  it("cycles through messages over time", () => {
+    const { result } = renderHook(() => useThinkingMessages(generators, ["phaseA", "phaseB"]));
+
+    expect(result.current).toEqual({ phaseA: "Analyzing...", phaseB: "Loading..." });
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(result.current).toEqual({ phaseA: "Planning...", phaseB: "Processing..." });
+  });
+
+  it("uses randomized intervals between 1.5-3s", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    const { result } = renderHook(() => useThinkingMessages(generators, ["phaseA"]));
+
+    expect(result.current).toEqual({ phaseA: "Analyzing..." });
+
+    act(() => {
+      vi.advanceTimersByTime(1499);
+    });
+
+    expect(result.current).toEqual({ phaseA: "Analyzing..." });
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(result.current).toEqual({ phaseA: "Planning..." });
+
+    vi.spyOn(Math, "random").mockRestore();
+  });
+
+  it("resets index when becoming inactive", () => {
+    const { result, rerender } = renderHook(
+      ({ active }) => useThinkingMessages(generators, active),
+      { initialProps: { active: ["phaseA"] as string[] } },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(result.current).toEqual({ phaseA: "Planning..." });
+
+    rerender({ active: [] });
+    expect(result.current).toEqual({});
+
+    rerender({ active: ["phaseA"] });
+    expect(result.current).toEqual({ phaseA: "Analyzing..." });
+  });
+});

--- a/apps/main/src/lib/workflow/use-thinking-messages.ts
+++ b/apps/main/src/lib/workflow/use-thinking-messages.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export type ThinkingMessageGenerator = (index: number) => string;
+
+/**
+ * Cycles through an array of messages based on the index.
+ * Returns the message at `index % messages.length`.
+ */
+export function cycleMessage(messages: string[], index: number): string {
+  return messages[index % messages.length] ?? "";
+}
+
+const DEFAULT_REVIEW_INTERVAL = 3;
+const ITEM_NUMBER_SCALE = 0.7;
+
+/**
+ * Creates a generator that produces incrementing "item N..." messages
+ * with periodic review messages interspersed.
+ *
+ * @param intro - Messages to show before the numbered sequence
+ * @param itemTemplate - Function that returns the "item N..." message
+ * @param reviewMessage - Periodic message shown every `reviewInterval` items
+ * @param reviewInterval - How often to show the review message (default: 3)
+ */
+export function createCountingGenerator(config: {
+  intro: string[];
+  itemTemplate: (num: number) => string;
+  reviewInterval?: number;
+  reviewMessage: string;
+}): ThinkingMessageGenerator {
+  const interval = config.reviewInterval ?? DEFAULT_REVIEW_INTERVAL;
+
+  return (index) => {
+    if (index < config.intro.length) {
+      return config.intro[index] ?? "";
+    }
+
+    const itemIndex = index - config.intro.length;
+
+    if (itemIndex % interval === interval - 1) {
+      return config.reviewMessage;
+    }
+
+    return config.itemTemplate(Math.ceil((itemIndex + 1) * ITEM_NUMBER_SCALE));
+  };
+}
+
+const MIN_INTERVAL = 1500;
+const MAX_INTERVAL = 3000;
+
+function getRandomInterval(): number {
+  return MIN_INTERVAL + Math.random() * (MAX_INTERVAL - MIN_INTERVAL);
+}
+
+/**
+ * Cycles through contextual "thinking" messages at randomized intervals.
+ * Each active phase gets its own independent message counter.
+ *
+ * @param generators - Map of phase names to their message generators
+ * @param activePhases - Set of phase names currently active
+ * @returns Map of phase name → current thinking message
+ */
+export function useThinkingMessages<TPhase extends string>(
+  generators: Record<TPhase, ThinkingMessageGenerator>,
+  activePhases: TPhase[],
+): Record<string, string> {
+  const [index, setIndex] = useState(0);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasActive = activePhases.length > 0;
+
+  useEffect(() => {
+    if (!hasActive) {
+      setIndex(0);
+      return;
+    }
+
+    function scheduleNext() {
+      timeoutRef.current = setTimeout(() => {
+        setIndex((prev) => prev + 1);
+        scheduleNext();
+      }, getRandomInterval());
+    }
+
+    scheduleNext();
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [hasActive]);
+
+  if (!hasActive) {
+    return {};
+  }
+
+  const messages: Record<string, string> = {};
+
+  for (const phase of activePhases) {
+    const generator = generators[phase];
+
+    if (generator) {
+      messages[phase] = generator(index);
+    }
+  }
+
+  return messages;
+}

--- a/apps/main/src/lib/workflow/use-workflow-generation.ts
+++ b/apps/main/src/lib/workflow/use-workflow-generation.ts
@@ -36,6 +36,7 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
   const currentStep = useSelector(store, (state) => state.context.currentStep);
   const error = useSelector(store, (state) => state.context.error);
   const runId = useSelector(store, (state) => state.context.runId);
+  const startedSteps = useSelector(store, (state) => state.context.startedSteps);
   const status = useSelector(store, (state) => state.context.status);
 
   const handleMessage = useCallback(
@@ -127,6 +128,7 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
     currentStep,
     error,
     retry,
+    startedSteps,
     status,
   };
 }

--- a/i18n.lock
+++ b/i18n.lock
@@ -203,6 +203,10 @@ checksums:
     Position%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: a1b3d3e026bfff43bff3d3e85ccdb952
     Correct%20answer%3A%20%7Banswer%7D/singular: 7745b2664e841dffff4568203ee443b2
     Incorrect/singular: a86cfbe7b86f19dc8df14a67df073d22
+    Belt/singular: fa36e8e36732c223d2876c0337d372e9
+    Level%20progress/singular: 286f095acd17006787247db0b69270e3
+    "%7Bvalue%7D%20BP%20to%20level%20up/singular": 755c2fe6e435645cb35b57bf92af09d3
+    Level/singular: 1e3bf31d5c6083e898dd3e3359fbb0c2
     Back%20to%20Lesson/singular: e2dbef5a2fefae8f9cee708e53e61cb9
     Challenge%20Complete/singular: 7854472cc9245aaa8a13f54514968506
     Final%20dimension%20scores/singular: aa4efa7ecef99d375c1daf4c6585ba98
@@ -249,10 +253,6 @@ checksums:
     Check/singular: 023cc2ba432775c38e3efc004ad7b9ef
     BP/singular: 842ed01b3a4d0efa6fe96ae8c595726c
     Energy/singular: 958809db5050650b97519e0f1f3e1951
-    Belt/singular: fa36e8e36732c223d2876c0337d372e9
-    Level%20progress/singular: 286f095acd17006787247db0b69270e3
-    "%7Bvalue%7D%20BP%20to%20level%20up/singular": 755c2fe6e435645cb35b57bf92af09d3
-    Level/singular: 1e3bf31d5c6083e898dd3e3359fbb0c2
     Image%20options/singular: 64a1aee44b26dbaff851cb846eb4274d
     Drag%20items%20into%20the%20correct%20order/singular: 8ccab82ee3ba645ac23da4ca14a0dd2a
     Sort%20items/singular: 3b1072a596203b5acdc5718d38161392
@@ -454,42 +454,89 @@ checksums:
     Generate%20content%20for%20this%20activity/singular: 0ac20ea56d4391004d976cd8f377a645
     Generate%20Activity/singular: e386c80be3da0ee0b54a940afc4de373
     Your%20activity%20is%20ready/singular: e7385c4096b843839bb9a96023f0eea9
+    This%20usually%20takes%201-2%20minutes/singular: bd7260323fa4b3a50a0300ed136fcbd2
     Try%20again/singular: 33dd8820e743e35a66e6977f69e9d3b5
     Something%20went%20wrong/singular: a3cd2f01c073f1f5ff436d4b132d39cf
     Taking%20you%20to%20your%20activity.../singular: c6714da27762cce70a0e2465878abaed
     Creating%20your%20activity/singular: cac8f88defaeee245484bd91660d32d6
     Progress/singular: dd0200d5849ebb7d64c15098ae91d229
     Something%20went%20wrong.%20Please%20try%20again./singular: c62a7718d9a1e9c4ffb707807550f836
+    Adding%20examples.../singular: 1aa5528fd3cd9a20a6bdd6eb35a33305
+    Getting%20the%20pronunciation%20right.../singular: a809bb5d01620f015cae9a4f0eeede13
+    Recording%20the%20audio.../singular: e6e8da2d75c102373fec6056189d54ba
+    Getting%20everything%20ready.../singular: 8695db1d7ae8e0b7774c0a2b57a26e99
+    Sketching%20out%20ideas.../singular: 26ec605c90c1c3b83e6d489330a8f623
+    Planning%20the%20layout.../singular: 034a73e1a9ece4ec350cbcd36dd16f99
+    Wrapping%20up.../singular: f53e2507f652df36db205a5201fe5008
     Creating%20images/singular: ab6fe5010daa5a4deb52eabed6ca071f
+    Adding%20some%20color.../singular: 80aec5cf210399ff202a166190660fa2
+    Choosing%20the%20right%20style.../singular: 7c273483546943a1553fbc762646c079
+    Thinking%20about%20what%20to%20illustrate.../singular: fe3a341a8fba909f02f4a26fb4510637
     Getting%20started/singular: 8e5e7bd026b5bec46bbfdce02ab9e0b8
     Preparing%20practice%20content/singular: 00fb505f6c2aec84f56054b9ab972655
+    Reviewing%20earlier%20activities.../singular: a2d03625de1081bf8df82bd87f1e9873
     Almost%20done/singular: fa5f270ea4b185be8dd47cfb91b87810
+    Picking%20the%20key%20vocabulary.../singular: 0cf4cef9dc1941ff8fedefd7a632ed3f
+    Choosing%20words%20to%20practice.../singular: b412e7e986b60c99cb7481686615c820
+    Connecting%20the%20pieces.../singular: 5ce9df0f436e6012f7142adf94006327
+    Drawing%20an%20illustration.../singular: 5b6fbaeca062dc204a246839c499d5d4
+    Writing%20the%20explanation.../singular: cb3b01d1dc07a25447ee138dde5bfdde
+    Almost%20there.../singular: decd6d1e84363cf4c89e5446eab55dc9
+    Working%20on%20the%20visuals.../singular: 21d3d631b915edf6c2c2c1882f387a12
+    Researching%20the%20topic.../singular: 54c9981da59b1efccfbba3c40bb1fdd5
     Processing%20earlier%20activities/singular: 162ae4b3d730c56cf76023bb37004e59
     Preparing%20illustrations/singular: ebb0d8d739dd029c1ac7327ab6adf8b7
     Recording%20audio/singular: 528bf44d9d7b8a1c8be7ec526307a703
     Adding%20pronunciation/singular: f4a57ae308d27a1b5d4214f4cbf0370c
     Writing%20the%20content/singular: 8c98570945250d1750e3b95270cbecae
+    Looking%20up%20how%20each%20word%20sounds.../singular: 2417013c03464cbb2d4aa6d0ad6dcee0
+    Mapping%20out%20the%20pronunciation.../singular: 6f8b9708ba6726ef8e471bbba8b38f8b
+    Setting%20things%20up.../singular: 4696c8e1048ec21837f886410864dfe2
+    Refining%20the%20details.../singular: eaf7a7ca135f8919dc93f80095040ab0
     Generate%20Chapter/singular: 12160bab066da65413de4b511e402446
     Your%20lessons%20are%20ready/singular: fe8d9df59ba42f451b249fd750813cba
     Taking%20you%20to%20your%20chapter.../singular: fc59b426c3d393ec40f534253309ee9f
+    This%20usually%20takes%202-4%20minutes/singular: a5cf03e3d2ed405722955fde29b1fef0
     Creating%20your%20lessons/singular: 93571965dc04dcef0bf92f212b3b34d3
+    Designing%20practice%20exercises.../singular: 9f1ddddd3324e1586eb427a2c96ee399
+    Thinking%20about%20how%20to%20teach%20this.../singular: e71e60276db8c3d5ddb63542b0c7251e
+    Reviewing%20the%20flow%20so%20far.../singular: 4412a2800906a2b7ea847a9493cd5ac4
+    Making%20it%20interactive.../singular: 1379852e804db4736e71c068cd50982e
     Setting%20up%20activities/singular: a644864fddf71801feef8c789333456a
     Figuring%20out%20the%20best%20approach/singular: 0cbd8e2d3c43eb874e25dd6b30fff474
+    Choosing%20the%20right%20approach.../singular: 2ed5698b6fd002b38e10035a29a815dc
+    Exploring%20your%20topic.../singular: 01c8bbcee210a5270bd7629f2fe35e4b
     Preparing%20lessons/singular: efa9d3dc1167beadeae4a660574c8696
+    Mapping%20out%20the%20learning%20path.../singular: 92e90eda50e4c4dea6701f916ef2e853
+    Writing%20lesson%20%7Bnumber%7D.../singular: 9a81f245c815438ea4e925777f711894
     Taking%20you%20to%20your%20course.../singular: f1522561681357abdaad3936d36fdfe7
     Your%20course%20is%20ready/singular: b54659084218a9b9bcf7b5f1cfcf3fbf
+    This%20usually%20takes%204-6%20minutes/singular: bd0d37fe2b4aaa9dd8f1a6ffae3824c5
     Creating%20your%20course/singular: 02c33db1106e7478e5cbd00fa5f20532
     Writing%20the%20lesson%20content/singular: 2b3243b19b65a83cfe355bef089b7ce8
+    Writing%20the%20overview.../singular: 14d71db32539c19803e72da8a4553a0f
+    Summarizing%20what%20you'll%20learn.../singular: bb6b58ff4b46ee6e8c59789464e9bced
+    Planning%20the%20course%20structure.../singular: 752a256e319aa780a5116e8981d4dffb
+    Figuring%20out%20the%20right%20categories.../singular: 6ba5a3ad0241d1b53ad3df38af600d96
     Getting%20things%20ready/singular: eeb67bd061dfaf280e6971c00e7b7999
+    Adding%20finishing%20touches.../singular: 071e61c7a9adfabf2ea37b921bcd7a6d
     Planning%20your%20first%20lesson/singular: 7f427574ea313b46b889fdef3253d5c6
     Saving%20your%20course/singular: 52dd36a207730a97e851bd6571fffd85
+    Tagging%20your%20course.../singular: 3e5051038112611e998fe0787b804c20
     Creating%20the%20cover%20image/singular: f58c3380093e8204ad6ade3b6a0a2691
     Writing%20your%20course%20description/singular: 0d9406e9cd2914a068892907337cae61
     Categorizing%20your%20course/singular: a7ff108a5a4721c5550cec3cc67acede
-    Outlining%20chapters/singular: c18531fa3b5a68df4e28cab77650db8f
+    Designing%20the%20cover.../singular: 1a65a35fdfdc5c38c17b7c03054f6c33
+    Writing%20chapter%20%7Bnumber%7D.../singular: 1634bab54867d26fb32455bfe4e2a98f
+    Reviewing%20the%20overall%20flow.../singular: 35a915dd127d3ebd503cfc6b8a3e5082
+    Saving%20your%20progress.../singular: 15fd06dcc4a2ae41403787c26babdc83
+    Picking%20the%20right%20look.../singular: 697bdd3a4fa077ddd50c64d57775baf6
+    Writing%20chapters/singular: b2e7e149ee761e4e5a45225e37e5441a
+    Putting%20it%20all%20together.../singular: 12349256a2104ecf09b213ba1437c636
     Generate%20Lesson/singular: 741a967eb90694565df5e9b44991f58e
     Your%20lesson%20is%20ready/singular: 3d745fd67b57e47ed10851f1e5404ccc
     Creating%20your%20activities/singular: 6651e663a48e18486f5f873e614cd512
+    This%20usually%20takes%20about%20a%20minute/singular: 8b679d39d752ba8a57fbabd4eb745f28
     Taking%20you%20to%20your%20lesson.../singular: 7a47c8664a900646ef51c9f27e2886e0
     Read%20Zoonk's%20privacy%20policy%20to%20understand%20how%20we%20collect%2C%20use%2C%20and%20protect%20your%20personal%20information./singular: 044f3586abe7d9915820a6629cef08e4
     Privacy%20Policy/singular: 7459744a63ef8af4e517a09024bd7c08

--- a/packages/ai/src/tasks/activities/core/activity-review.ts
+++ b/packages/ai/src/tasks/activities/core/activity-review.ts
@@ -9,12 +9,12 @@ import {
 } from "../constants";
 import systemPrompt from "./activity-review.prompt.md";
 
-const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_REVIEW ?? "anthropic/claude-opus-4.5";
+const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_REVIEW ?? "openai/gpt-5.2";
 
 const FALLBACK_MODELS = [
+  "anthropic/claude-opus-4.6",
   "google/gemini-3-pro-preview",
   "google/gemini-3-flash",
-  "openai/gpt-5.2",
   "openai/gpt-5-mini",
 ];
 


### PR DESCRIPTION
## Summary

- **Monotonic progress bar**: Added high-water mark to `useAnimatedProgress` so the displayed value never decreases. Reduced `MAX_DRIFT` from 20 → 8 (thinking messages compensate for perceived slowness)
- **Fix phase flickering**: Track `startedSteps` in the generation store so parallel workflow steps don't lose their "active" status when `currentStep` changes
- **Time estimate subtitle**: Each generation page shows how long it typically takes (e.g. "This usually takes 4-6 minutes" for courses)
- **Per-phase thinking messages**: Contextual messages cycle under active steps at randomized intervals (1.5-3s), giving users a sense of active work. Each active phase gets its own independent message

## Test plan

- [x] Unit tests for monotonic progress (never decreases, drift continues below high water)
- [x] Unit tests for `startedSteps` in `getPhaseStatus` (active via startedSteps, backward-compatible)
- [x] Unit tests for `useThinkingMessages` (cycles, resets, multiple active phases)
- [x] E2E tests for time estimate visibility on all generation pages
- [x] `pnpm turbo quality:fix` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (348 tests)
- [x] `pnpm --filter main e2e` passes (379 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized and improved the generation experience: progress never drops, phase states stay active without flicker, and users see short time estimates with rotating contextual messages during each step.

- **Refactors**
  - Simplified useThinkingMessages with an index-driven timer and per-phase generators; resets cleanly when phases become inactive.

- **Dependencies**
  - Set the default activity review model to openai/gpt-5.2 and updated fallbacks (now includes anthropic/claude-opus-4.6).

<sup>Written for commit b2d8f4f5c9ca41e325e7ee42dfb19750944da011. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

