### PR TITLE
fix(ui): add globals css type

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/knip/schema.json",
-  "ignore": [],
+  "ignore": ["**/*.d.**.ts"],
   "ignoreBinaries": ["stripe", "build-and-start", "turbo"],
   "ignoreDependencies": [
     "@prisma/client",

--- a/packages/ui/src/styles/globals.d.css.ts
+++ b/packages/ui/src/styles/globals.d.css.ts
@@ -1,0 +1,4 @@
+declare const styles: string;
+
+// oxlint-disable-next-line no-default-export: off
+export default styles;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a type declaration for globals.css in the UI package so TypeScript can import it without errors. Update Knip config to ignore declaration helper files (*.d.*.ts) to prevent false positives.

<sup>Written for commit 2976752ae9eecdb191a74765a995d422a9083b93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

