### PR TITLE
fix(main): update metadataBase to use SITE_URL constant

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,7 +32,8 @@
     "**/eval-results/**": true,
     "**/.next/**": true,
     "**/.next-e2e/**": true,
-    "pnpm-lock.yaml": true
+    "pnpm-lock.yaml": true,
+    "**/tsconfig.tsbuildinfo": true
   },
   "typescript.experimental.useTsgo": true
 }

--- a/apps/main/src/app/[locale]/layout.tsx
+++ b/apps/main/src/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import { routing } from "@/i18n/routing";
 import { Analytics } from "@vercel/analytics/next";
 import { Toaster } from "@zoonk/ui/components/sonner";
+import { SITE_URL } from "@zoonk/utils/constants";
 import { type Metadata } from "next";
 import { NextIntlClientProvider, hasLocale } from "next-intl";
 import { setRequestLocale } from "next-intl/server";
@@ -9,7 +10,7 @@ import { NuqsAdapter } from "nuqs/adapters/next/app";
 import "@zoonk/ui/globals.css";
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://zoonk.com"),
+  metadataBase: new URL(SITE_URL),
   title: {
     default: "",
     template: "%s | Zoonk",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use the shared SITE_URL constant for Next.js metadataBase to remove the hardcoded domain and ensure correct absolute URLs across environments. Also hide tsconfig.tsbuildinfo in VS Code search for a cleaner workspace.

<sup>Written for commit dfb5962fb540e1c414e1727b6981259a22ceaaaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

