### PR TITLE
refactor(main): remove locale from url

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,7 +33,8 @@
     "**/.next/**": true,
     "**/.next-e2e/**": true,
     "pnpm-lock.yaml": true,
-    "**/tsconfig.tsbuildinfo": true
+    "**/tsconfig.tsbuildinfo": true,
+    "**/turbo-*": true
   },
   "typescript.experimental.useTsgo": true
 }

--- a/apps/main/e2e/auth-callback.test.ts
+++ b/apps/main/e2e/auth-callback.test.ts
@@ -44,10 +44,10 @@ test.describe("Auth Callback - Invalid Token", () => {
       }
     });
 
-    await page.goto("/pt/auth/callback/invalid-token");
+    await page.goto("/auth/callback/invalid-token");
 
     // Check for link to Portuguese login page
-    await expect(page.locator('a[href="/pt/login"]')).toBeVisible();
+    await expect(page.locator('a[href="/login"]')).toBeVisible();
   });
 });
 

--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -142,7 +142,7 @@ test.beforeAll(async () => {
     title: `Introdução ao E2E ${uniqueId}`,
   });
 
-  ptChapterUrl = `/pt/b/${AI_ORG_SLUG}/c/${ptCourse.slug}/ch/${ptChapter.slug}`;
+  ptChapterUrl = `/b/${AI_ORG_SLUG}/c/${ptCourse.slug}/ch/${ptChapter.slug}`;
 
   ptLessonNames = {
     first: `O que é E2E Testing ${uniqueId}`,

--- a/apps/main/e2e/course-chapters.test.ts
+++ b/apps/main/e2e/course-chapters.test.ts
@@ -1,10 +1,9 @@
 import { randomUUID } from "node:crypto";
-import { getAiOrganization } from "@zoonk/e2e/helpers";
+import { getAiOrganization, setLocale } from "@zoonk/e2e/helpers";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
-import { LOCALE_COOKIE } from "@zoonk/utils/locale";
 import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
 
@@ -163,9 +162,7 @@ test.describe("Course Chapters List", () => {
 
 test.describe("Course Chapters - Locale", () => {
   test("shows chapters in Portuguese for Portuguese locale", async ({ page }) => {
-    await page
-      .context()
-      .addCookies([{ domain: "localhost", name: LOCALE_COOKIE, path: "/", value: "pt" }]);
+    await setLocale(page, "pt");
     await page.goto(ptCourseUrl);
 
     await expect(page.getByRole("link", { name: ptChapterNames.first })).toBeVisible();
@@ -220,9 +217,7 @@ test.describe("Course Chapter Search", () => {
   test("matches Portuguese chapters without accents (accent-insensitive search)", async ({
     page,
   }) => {
-    await page
-      .context()
-      .addCookies([{ domain: "localhost", name: LOCALE_COOKIE, path: "/", value: "pt" }]);
+    await setLocale(page, "pt");
     await page.goto(ptCourseUrl);
 
     await page.getByLabel(/buscar capítulos/i).fill("introducao");

--- a/apps/main/e2e/course-chapters.test.ts
+++ b/apps/main/e2e/course-chapters.test.ts
@@ -163,9 +163,9 @@ test.describe("Course Chapters List", () => {
 
 test.describe("Course Chapters - Locale", () => {
   test("shows chapters in Portuguese for Portuguese locale", async ({ page }) => {
-    await page.context().addCookies([
-      { name: LOCALE_COOKIE, value: "pt", domain: "localhost", path: "/" },
-    ]);
+    await page
+      .context()
+      .addCookies([{ domain: "localhost", name: LOCALE_COOKIE, path: "/", value: "pt" }]);
     await page.goto(ptCourseUrl);
 
     await expect(page.getByRole("link", { name: ptChapterNames.first })).toBeVisible();
@@ -220,9 +220,9 @@ test.describe("Course Chapter Search", () => {
   test("matches Portuguese chapters without accents (accent-insensitive search)", async ({
     page,
   }) => {
-    await page.context().addCookies([
-      { name: LOCALE_COOKIE, value: "pt", domain: "localhost", path: "/" },
-    ]);
+    await page
+      .context()
+      .addCookies([{ domain: "localhost", name: LOCALE_COOKIE, path: "/", value: "pt" }]);
     await page.goto(ptCourseUrl);
 
     await page.getByLabel(/buscar capítulos/i).fill("introducao");

--- a/apps/main/e2e/course-chapters.test.ts
+++ b/apps/main/e2e/course-chapters.test.ts
@@ -4,6 +4,7 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { LOCALE_COOKIE } from "@zoonk/utils/locale";
 import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
 
@@ -162,6 +163,9 @@ test.describe("Course Chapters List", () => {
 
 test.describe("Course Chapters - Locale", () => {
   test("shows chapters in Portuguese for Portuguese locale", async ({ page }) => {
+    await page.context().addCookies([
+      { name: LOCALE_COOKIE, value: "pt", domain: "localhost", path: "/" },
+    ]);
     await page.goto(ptCourseUrl);
 
     await expect(page.getByRole("link", { name: ptChapterNames.first })).toBeVisible();
@@ -216,6 +220,9 @@ test.describe("Course Chapter Search", () => {
   test("matches Portuguese chapters without accents (accent-insensitive search)", async ({
     page,
   }) => {
+    await page.context().addCookies([
+      { name: LOCALE_COOKIE, value: "pt", domain: "localhost", path: "/" },
+    ]);
     await page.goto(ptCourseUrl);
 
     await page.getByLabel(/buscar capítulos/i).fill("introducao");

--- a/apps/main/e2e/course-chapters.test.ts
+++ b/apps/main/e2e/course-chapters.test.ts
@@ -121,7 +121,7 @@ test.beforeAll(async () => {
     }),
   ]);
 
-  ptCourseUrl = `/pt/b/${AI_ORG_SLUG}/c/${ptCourse.slug}`;
+  ptCourseUrl = `/b/${AI_ORG_SLUG}/c/${ptCourse.slug}`;
 });
 
 test.describe("Course Chapters List", () => {

--- a/apps/main/e2e/course-detail.test.ts
+++ b/apps/main/e2e/course-detail.test.ts
@@ -5,6 +5,7 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseSuggestionFixture } from "@zoonk/testing/fixtures/course-suggestions";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { LOCALE_COOKIE } from "@zoonk/utils/locale";
 import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
 
@@ -192,9 +193,12 @@ test.describe("Course Detail Page", () => {
 });
 
 test.describe("Course Detail Page - Locale", () => {
-  test("clicking course from PT list preserves locale", async ({ page }) => {
+  test("course page renders in Portuguese locale", async ({ page }) => {
+    await page.context().addCookies([
+      { name: LOCALE_COOKIE, value: "pt", domain: "localhost", path: "/" },
+    ]);
     await page.goto(testData.ptCourseUrl);
 
-    await expect(page).toHaveURL(/\/pt\/b\/ai\/c\//);
+    await expect(page).toHaveURL(new RegExp(`/b/${AI_ORG_SLUG}/c/`));
   });
 });

--- a/apps/main/e2e/course-detail.test.ts
+++ b/apps/main/e2e/course-detail.test.ts
@@ -124,7 +124,7 @@ test.beforeAll(async () => {
 
   testData.courseWithImageUrl = `/b/${AI_ORG_SLUG}/c/${courseWithImage.slug}`;
   testData.courseNoImageUrl = `/b/${AI_ORG_SLUG}/c/${courseNoImage.slug}`;
-  testData.ptCourseUrl = `/pt/b/${AI_ORG_SLUG}/c/${ptCourse.slug}`;
+  testData.ptCourseUrl = `/b/${AI_ORG_SLUG}/c/${ptCourse.slug}`;
 });
 
 test.describe("Course Detail Page", () => {

--- a/apps/main/e2e/course-detail.test.ts
+++ b/apps/main/e2e/course-detail.test.ts
@@ -194,9 +194,9 @@ test.describe("Course Detail Page", () => {
 
 test.describe("Course Detail Page - Locale", () => {
   test("course page renders in Portuguese locale", async ({ page }) => {
-    await page.context().addCookies([
-      { name: LOCALE_COOKIE, value: "pt", domain: "localhost", path: "/" },
-    ]);
+    await page
+      .context()
+      .addCookies([{ domain: "localhost", name: LOCALE_COOKIE, path: "/", value: "pt" }]);
     await page.goto(testData.ptCourseUrl);
 
     await expect(page).toHaveURL(new RegExp(`/b/${AI_ORG_SLUG}/c/`));

--- a/apps/main/e2e/course-detail.test.ts
+++ b/apps/main/e2e/course-detail.test.ts
@@ -1,11 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { type Route } from "@playwright/test";
-import { getAiOrganization } from "@zoonk/e2e/helpers";
+import { getAiOrganization, setLocale } from "@zoonk/e2e/helpers";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseSuggestionFixture } from "@zoonk/testing/fixtures/course-suggestions";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
-import { LOCALE_COOKIE } from "@zoonk/utils/locale";
 import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
 
@@ -194,9 +193,7 @@ test.describe("Course Detail Page", () => {
 
 test.describe("Course Detail Page - Locale", () => {
   test("course page renders in Portuguese locale", async ({ page }) => {
-    await page
-      .context()
-      .addCookies([{ domain: "localhost", name: LOCALE_COOKIE, path: "/", value: "pt" }]);
+    await setLocale(page, "pt");
     await page.goto(testData.ptCourseUrl);
 
     await expect(page).toHaveURL(new RegExp(`/b/${AI_ORG_SLUG}/c/`));

--- a/apps/main/e2e/courses.test.ts
+++ b/apps/main/e2e/courses.test.ts
@@ -120,6 +120,7 @@ test.describe("Courses Page - Locale", () => {
       title,
     });
 
+    await setLocale(page, "pt");
     await page.goto("/courses");
 
     await expect(page.getByText(unpublishedCourse.title)).not.toBeVisible();

--- a/apps/main/e2e/courses.test.ts
+++ b/apps/main/e2e/courses.test.ts
@@ -1,10 +1,9 @@
 import { randomUUID } from "node:crypto";
-import { getAiOrganization, revalidateCacheTags } from "@zoonk/e2e/helpers";
+import { getAiOrganization, revalidateCacheTags, setLocale } from "@zoonk/e2e/helpers";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { cacheTagCoursesList } from "@zoonk/utils/cache";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
-import { LOCALE_COOKIE } from "@zoonk/utils/locale";
 import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
 
@@ -101,9 +100,7 @@ test.describe("Courses Page - Infinite Loading", () => {
 
 test.describe("Courses Page - Locale", () => {
   test("Portuguese locale shows translated content", async ({ page }) => {
-    await page
-      .context()
-      .addCookies([{ domain: "localhost", name: LOCALE_COOKIE, path: "/", value: "pt" }]);
+    await setLocale(page, "pt");
     await page.goto("/courses");
 
     await expect(page.getByRole("heading", { name: /explorar cursos/i })).toBeVisible();

--- a/apps/main/e2e/courses.test.ts
+++ b/apps/main/e2e/courses.test.ts
@@ -101,9 +101,9 @@ test.describe("Courses Page - Infinite Loading", () => {
 
 test.describe("Courses Page - Locale", () => {
   test("Portuguese locale shows translated content", async ({ page }) => {
-    await page.context().addCookies([
-      { name: LOCALE_COOKIE, value: "pt", domain: "localhost", path: "/" },
-    ]);
+    await page
+      .context()
+      .addCookies([{ domain: "localhost", name: LOCALE_COOKIE, path: "/", value: "pt" }]);
     await page.goto("/courses");
 
     await expect(page.getByRole("heading", { name: /explorar cursos/i })).toBeVisible();

--- a/apps/main/e2e/courses.test.ts
+++ b/apps/main/e2e/courses.test.ts
@@ -100,7 +100,7 @@ test.describe("Courses Page - Infinite Loading", () => {
 
 test.describe("Courses Page - Locale", () => {
   test("Portuguese locale shows translated content", async ({ page }) => {
-    await page.goto("/pt/courses");
+    await page.goto("/courses");
 
     await expect(page.getByRole("heading", { name: /explorar cursos/i })).toBeVisible();
   });
@@ -119,7 +119,7 @@ test.describe("Courses Page - Locale", () => {
       title,
     });
 
-    await page.goto("/pt/courses");
+    await page.goto("/courses");
 
     await expect(page.getByText(unpublishedCourse.title)).not.toBeVisible();
   });

--- a/apps/main/e2e/courses.test.ts
+++ b/apps/main/e2e/courses.test.ts
@@ -4,6 +4,7 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { cacheTagCoursesList } from "@zoonk/utils/cache";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { LOCALE_COOKIE } from "@zoonk/utils/locale";
 import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
 
@@ -100,6 +101,9 @@ test.describe("Courses Page - Infinite Loading", () => {
 
 test.describe("Courses Page - Locale", () => {
   test("Portuguese locale shows translated content", async ({ page }) => {
+    await page.context().addCookies([
+      { name: LOCALE_COOKIE, value: "pt", domain: "localhost", path: "/" },
+    ]);
     await page.goto("/courses");
 
     await expect(page.getByRole("heading", { name: /explorar cursos/i })).toBeVisible();

--- a/apps/main/e2e/language.test.ts
+++ b/apps/main/e2e/language.test.ts
@@ -17,7 +17,7 @@ test.describe("Language settings page", () => {
     const selector = page.getByRole("combobox", { name: /update language/i });
     await selector.selectOption("es");
 
-    await page.waitForURL("**/es/language");
+    await page.waitForURL("**/language");
 
     await expect(page.getByRole("heading", { level: 1, name: /^idioma$/i })).toBeVisible();
   });
@@ -28,7 +28,7 @@ test.describe("Language settings page", () => {
     const selector = page.getByRole("combobox", { name: /update language/i });
     await selector.selectOption("pt");
 
-    await page.waitForURL("**/pt/language");
+    await page.waitForURL("**/language");
 
     await expect(page.getByRole("heading", { level: 1, name: /^idioma$/i })).toBeVisible();
 

--- a/apps/main/e2e/locale.test.ts
+++ b/apps/main/e2e/locale.test.ts
@@ -1,4 +1,11 @@
+import { LOCALE_COOKIE } from "@zoonk/utils/locale";
 import { expect, test } from "./fixtures";
+
+async function setPortugueseLocale(page: import("@playwright/test").Page) {
+  await page.context().addCookies([
+    { name: LOCALE_COOKIE, value: "pt", domain: "localhost", path: "/" },
+  ]);
+}
 
 test.describe("Locale Behavior - English", () => {
   test("home page shows English content", async ({ page }) => {
@@ -18,7 +25,8 @@ test.describe("Locale Behavior - English", () => {
 
 test.describe("Locale Behavior - Portuguese", () => {
   test("Portuguese home shows Portuguese content", async ({ page }) => {
-    await page.goto("/pt");
+    await setPortugueseLocale(page);
+    await page.goto("/");
 
     const nav = page.getByRole("navigation");
 
@@ -35,14 +43,14 @@ test.describe("Locale Behavior - Portuguese", () => {
 });
 
 test.describe("Locale Navigation", () => {
-  test("clicking navbar links from /pt keeps user in Portuguese", async ({ page }) => {
-    await page.goto("/pt");
+  test("clicking navbar links keeps user in Portuguese", async ({ page }) => {
+    await setPortugueseLocale(page);
+    await page.goto("/");
 
     // Click Courses link in navbar (scoped to navigation to avoid hero links)
     await page.getByRole("navigation").getByRole("link", { exact: true, name: "Cursos" }).click();
 
-    // Should be on Portuguese courses page
-    await expect(page).toHaveURL(/\/pt\/courses/);
+    await expect(page).toHaveURL(/\/courses/);
 
     await expect(page.getByRole("heading", { name: /explorar cursos/i })).toBeVisible();
   });

--- a/apps/main/e2e/locale.test.ts
+++ b/apps/main/e2e/locale.test.ts
@@ -1,11 +1,5 @@
-import { LOCALE_COOKIE } from "@zoonk/utils/locale";
-import { type Page, expect, test } from "./fixtures";
-
-async function setPortugueseLocale(page: Page) {
-  await page
-    .context()
-    .addCookies([{ domain: "localhost", name: LOCALE_COOKIE, path: "/", value: "pt" }]);
-}
+import { setLocale } from "@zoonk/e2e/helpers";
+import { expect, test } from "./fixtures";
 
 test.describe("Locale Behavior - English", () => {
   test("home page shows English content", async ({ page }) => {
@@ -25,7 +19,7 @@ test.describe("Locale Behavior - English", () => {
 
 test.describe("Locale Behavior - Portuguese", () => {
   test("Portuguese home shows Portuguese content", async ({ page }) => {
-    await setPortugueseLocale(page);
+    await setLocale(page, "pt");
     await page.goto("/");
 
     const nav = page.getByRole("navigation");
@@ -44,7 +38,7 @@ test.describe("Locale Behavior - Portuguese", () => {
 
 test.describe("Locale Navigation", () => {
   test("clicking navbar links keeps user in Portuguese", async ({ page }) => {
-    await setPortugueseLocale(page);
+    await setLocale(page, "pt");
     await page.goto("/");
 
     // Click Courses link in navbar (scoped to navigation to avoid hero links)

--- a/apps/main/e2e/locale.test.ts
+++ b/apps/main/e2e/locale.test.ts
@@ -1,10 +1,10 @@
 import { LOCALE_COOKIE } from "@zoonk/utils/locale";
-import { expect, test } from "./fixtures";
+import { type Page, expect, test } from "./fixtures";
 
-async function setPortugueseLocale(page: import("@playwright/test").Page) {
-  await page.context().addCookies([
-    { name: LOCALE_COOKIE, value: "pt", domain: "localhost", path: "/" },
-  ]);
+async function setPortugueseLocale(page: Page) {
+  await page
+    .context()
+    .addCookies([{ domain: "localhost", name: LOCALE_COOKIE, path: "/", value: "pt" }]);
 }
 
 test.describe("Locale Behavior - English", () => {

--- a/apps/main/src/app/sitemap.ts
+++ b/apps/main/src/app/sitemap.ts
@@ -1,23 +1,10 @@
 import { SITE_URL } from "@zoonk/utils/constants";
-import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from "@zoonk/utils/locale";
 import { type MetadataRoute } from "next";
 
 const STATIC_PATHS = ["/", "/courses", "/learn", "/privacy", "/terms"];
 
-function buildAlternates(path: string): Record<string, string> {
-  const defaultUrl = `${SITE_URL}${path}`;
-
-  const localeEntries: [string, string][] = SUPPORTED_LOCALES.map((locale) => {
-    const prefix = locale === DEFAULT_LOCALE ? "" : `/${locale}`;
-    return [locale, `${SITE_URL}${prefix}${path}`];
-  });
-
-  return Object.fromEntries([["x-default", defaultUrl], ...localeEntries]);
-}
-
 export default function sitemap(): MetadataRoute.Sitemap {
   return STATIC_PATHS.map((path) => ({
-    alternates: { languages: buildAlternates(path) },
     url: `${SITE_URL}${path}`,
   }));
 }

--- a/apps/main/src/app/sitemaps/chapters/sitemap.ts
+++ b/apps/main/src/app/sitemaps/chapters/sitemap.ts
@@ -4,7 +4,6 @@ import { countSitemapChapters, listSitemapChapters } from "@/data/sitemaps/chapt
 import { SITEMAP_BATCH_SIZE } from "@/data/sitemaps/courses";
 import { cacheTagSitemap } from "@zoonk/utils/cache";
 import { SITE_URL } from "@zoonk/utils/constants";
-import { DEFAULT_LOCALE } from "@zoonk/utils/locale";
 import { type MetadataRoute } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 
@@ -26,12 +25,8 @@ export default async function sitemap(props: {
   const id = Number(await props.id);
   const chapters = await listSitemapChapters(id);
 
-  return chapters.map(({ brandSlug, chapterSlug, courseSlug, language, updatedAt }) => {
-    const prefix = language === DEFAULT_LOCALE ? "" : `/${language}`;
-
-    return {
-      lastModified: updatedAt,
-      url: `${SITE_URL}${prefix}/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}`,
-    };
-  });
+  return chapters.map(({ brandSlug, chapterSlug, courseSlug, updatedAt }) => ({
+    lastModified: updatedAt,
+    url: `${SITE_URL}/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}`,
+  }));
 }

--- a/apps/main/src/app/sitemaps/courses/sitemap.ts
+++ b/apps/main/src/app/sitemaps/courses/sitemap.ts
@@ -7,7 +7,6 @@ import {
 } from "@/data/sitemaps/courses";
 import { cacheTagSitemap } from "@zoonk/utils/cache";
 import { SITE_URL } from "@zoonk/utils/constants";
-import { DEFAULT_LOCALE } from "@zoonk/utils/locale";
 import { type MetadataRoute } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 
@@ -29,12 +28,8 @@ export default async function sitemap(props: {
   const id = Number(await props.id);
   const courses = await listSitemapCourses(id);
 
-  return courses.map(({ brandSlug, courseSlug, language, updatedAt }) => {
-    const prefix = language === DEFAULT_LOCALE ? "" : `/${language}`;
-
-    return {
-      lastModified: updatedAt,
-      url: `${SITE_URL}${prefix}/b/${brandSlug}/c/${courseSlug}`,
-    };
-  });
+  return courses.map(({ brandSlug, courseSlug, updatedAt }) => ({
+    lastModified: updatedAt,
+    url: `${SITE_URL}/b/${brandSlug}/c/${courseSlug}`,
+  }));
 }

--- a/apps/main/src/app/sitemaps/lessons/sitemap.ts
+++ b/apps/main/src/app/sitemaps/lessons/sitemap.ts
@@ -4,7 +4,6 @@ import { SITEMAP_BATCH_SIZE } from "@/data/sitemaps/courses";
 import { countSitemapLessons, listSitemapLessons } from "@/data/sitemaps/lessons";
 import { cacheTagSitemap } from "@zoonk/utils/cache";
 import { SITE_URL } from "@zoonk/utils/constants";
-import { DEFAULT_LOCALE } from "@zoonk/utils/locale";
 import { type MetadataRoute } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 
@@ -26,12 +25,8 @@ export default async function sitemap(props: {
   const id = Number(await props.id);
   const lessons = await listSitemapLessons(id);
 
-  return lessons.map(({ brandSlug, chapterSlug, courseSlug, language, lessonSlug, updatedAt }) => {
-    const prefix = language === DEFAULT_LOCALE ? "" : `/${language}`;
-
-    return {
-      lastModified: updatedAt,
-      url: `${SITE_URL}${prefix}/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`,
-    };
-  });
+  return lessons.map(({ brandSlug, chapterSlug, courseSlug, lessonSlug, updatedAt }) => ({
+    lastModified: updatedAt,
+    url: `${SITE_URL}/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`,
+  }));
 }

--- a/apps/main/src/data/sitemaps/chapters.test.ts
+++ b/apps/main/src/data/sitemaps/chapters.test.ts
@@ -40,7 +40,6 @@ describe(listSitemapChapters, () => {
       brandSlug: org.slug,
       chapterSlug: chapter.slug,
       courseSlug: course.slug,
-      language: "es",
       updatedAt: expect.any(Date),
     });
   });

--- a/apps/main/src/data/sitemaps/chapters.ts
+++ b/apps/main/src/data/sitemaps/chapters.ts
@@ -19,7 +19,6 @@ export async function listSitemapChapters(page: number): Promise<
     brandSlug: string;
     chapterSlug: string;
     courseSlug: string;
-    language: string;
     updatedAt: Date;
   }[]
 > {
@@ -28,7 +27,6 @@ export async function listSitemapChapters(page: number): Promise<
     select: {
       course: {
         select: {
-          language: true,
           organization: { select: { slug: true } },
           slug: true,
         },
@@ -51,7 +49,6 @@ export async function listSitemapChapters(page: number): Promise<
     brandSlug: chapter.course.organization?.slug ?? "",
     chapterSlug: chapter.slug,
     courseSlug: chapter.course.slug,
-    language: chapter.course.language,
     updatedAt: chapter.updatedAt,
   }));
 }

--- a/apps/main/src/data/sitemaps/courses.test.ts
+++ b/apps/main/src/data/sitemaps/courses.test.ts
@@ -31,7 +31,6 @@ describe(listSitemapCourses, () => {
     expect(found).toEqual({
       brandSlug: org.slug,
       courseSlug: course.slug,
-      language: "pt",
       updatedAt: expect.any(Date),
     });
   });

--- a/apps/main/src/data/sitemaps/courses.ts
+++ b/apps/main/src/data/sitemaps/courses.ts
@@ -16,14 +16,12 @@ export async function listSitemapCourses(page: number): Promise<
   {
     brandSlug: string;
     courseSlug: string;
-    language: string;
     updatedAt: Date;
   }[]
 > {
   const courses = await prisma.course.findMany({
     orderBy: { id: "asc" },
     select: {
-      language: true,
       organization: { select: { slug: true } },
       slug: true,
       updatedAt: true,
@@ -39,7 +37,6 @@ export async function listSitemapCourses(page: number): Promise<
   return courses.map((course) => ({
     brandSlug: course.organization?.slug ?? "",
     courseSlug: course.slug,
-    language: course.language,
     updatedAt: course.updatedAt,
   }));
 }

--- a/apps/main/src/data/sitemaps/lessons.test.ts
+++ b/apps/main/src/data/sitemaps/lessons.test.ts
@@ -47,7 +47,6 @@ describe(listSitemapLessons, () => {
       brandSlug: org.slug,
       chapterSlug: chapter.slug,
       courseSlug: course.slug,
-      language: "pt",
       lessonSlug: lesson.slug,
       updatedAt: expect.any(Date),
     });

--- a/apps/main/src/data/sitemaps/lessons.ts
+++ b/apps/main/src/data/sitemaps/lessons.ts
@@ -22,7 +22,6 @@ export async function listSitemapLessons(page: number): Promise<
     brandSlug: string;
     chapterSlug: string;
     courseSlug: string;
-    language: string;
     lessonSlug: string;
     updatedAt: Date;
   }[]
@@ -34,7 +33,6 @@ export async function listSitemapLessons(page: number): Promise<
         select: {
           course: {
             select: {
-              language: true,
               organization: { select: { slug: true } },
               slug: true,
             },
@@ -63,7 +61,6 @@ export async function listSitemapLessons(page: number): Promise<
     brandSlug: lesson.chapter.course.organization?.slug ?? "",
     chapterSlug: lesson.chapter.slug,
     courseSlug: lesson.chapter.course.slug,
-    language: lesson.chapter.course.language,
     lessonSlug: lesson.slug,
     updatedAt: lesson.updatedAt,
   }));

--- a/apps/main/src/i18n/routing.ts
+++ b/apps/main/src/i18n/routing.ts
@@ -3,6 +3,6 @@ import { defineRouting } from "next-intl/routing";
 
 export const routing = defineRouting({
   defaultLocale: DEFAULT_LOCALE,
-  localePrefix: "as-needed",
+  localePrefix: "never",
   locales: SUPPORTED_LOCALES,
 });

--- a/apps/main/src/proxy.test.ts
+++ b/apps/main/src/proxy.test.ts
@@ -1,4 +1,3 @@
-import { LOCALE_COOKIE } from "@zoonk/utils/locale";
 import {
   unstable_doesMiddlewareMatch as doesMiddlewareMatch,
   getRedirectUrl,
@@ -37,38 +36,6 @@ describe("next.js proxy", () => {
   test("doesn't match paths starting with 149e (BotID paths)", () => {
     // https://x.com/andrewqu/status/1988640986520842672?s=20
     expect(doesMiddlewareMatch({ config, url: "/149eabcd" })).toBeFalsy();
-  });
-
-  test("redirects home page to language-specific URL", () => {
-    const request = new NextRequest("https://zoonk.com");
-    request.cookies.set(LOCALE_COOKIE, "pt");
-    const response = proxy(request);
-
-    expect(getRedirectUrl(response)).toBe("https://zoonk.com/pt");
-  });
-
-  test("redirects nested page to language-specific URL", () => {
-    const request = new NextRequest("https://zoonk.com/some/page");
-    request.cookies.set(LOCALE_COOKIE, "pt");
-    const response = proxy(request);
-
-    expect(getRedirectUrl(response)).toBe("https://zoonk.com/some/page");
-  });
-
-  test("don't redirect home page if using default locale", () => {
-    const request = new NextRequest("https://zoonk.com");
-    request.cookies.set(LOCALE_COOKIE, "en");
-    const response = proxy(request);
-
-    expect(getRedirectUrl(response)).toBeFalsy();
-  });
-
-  test("don't redirect nested page if using default locale", () => {
-    const request = new NextRequest("https://zoonk.com/some/page");
-    request.cookies.set(LOCALE_COOKIE, "en");
-    const response = proxy(request);
-
-    expect(getRedirectUrl(response)).toBeFalsy();
   });
 
   test("remove default locale from URL", () => {

--- a/apps/main/src/proxy.test.ts
+++ b/apps/main/src/proxy.test.ts
@@ -52,7 +52,7 @@ describe("next.js proxy", () => {
     request.cookies.set(LOCALE_COOKIE, "pt");
     const response = proxy(request);
 
-    expect(getRedirectUrl(response)).toBe("https://zoonk.com/pt/some/page");
+    expect(getRedirectUrl(response)).toBe("https://zoonk.com/some/page");
   });
 
   test("don't redirect home page if using default locale", () => {

--- a/packages/e2e/src/helpers.ts
+++ b/packages/e2e/src/helpers.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { type Locator, expect, request } from "@playwright/test";
+import { type Locator, type Page, expect, request } from "@playwright/test";
 import { prisma } from "@zoonk/db";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
@@ -8,6 +8,7 @@ import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { dailyProgressFixtureMany, userProgressFixture } from "@zoonk/testing/fixtures/progress";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { LOCALE_COOKIE } from "@zoonk/utils/locale";
 
 const UUID_SHORT_LENGTH = 8;
 
@@ -16,6 +17,12 @@ const UUID_SHORT_LENGTH = 8;
  * to revalidate cached pages via the /api/revalidate endpoint.
  */
 export const E2E_REVALIDATE_SECRET = "e2e-revalidate-secret";
+
+export async function setLocale(page: Page, locale: string) {
+  await page
+    .context()
+    .addCookies([{ domain: "localhost", name: LOCALE_COOKIE, path: "/", value: locale }]);
+}
 
 export function getBaseURL(): string {
   const url = process.env.E2E_BASE_URL;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove locale prefixes from all public URLs and rely on the locale cookie for language selection. Updates routing, sitemaps, and tests to the new scheme.

- **Refactors**
  - Set next-intl routing to localePrefix: "never" so URLs never include the locale.
  - Remove locale segments from all app routes and sitemaps (courses, chapters, lessons, static pages); URLs are now locale-agnostic.
  - Drop hreflang alternates from the main sitemap.
  - Remove middleware redirect behavior and related proxy tests.
  - Add setLocale(page, locale) test helper and update E2E tests to use the cookie, navigate to non-prefixed paths, and verify navigation keeps the locale.
  - Remove language fields from sitemap data and tests.

- **Migration**
  - Replace any hardcoded locale-prefixed links (/pt/..., /es/...) with non-prefixed paths.
  - For tests or scripts that relied on locale in the URL, set LOCALE_COOKIE (or use setLocale) and navigate to the non-prefixed route.

<sup>Written for commit 8309aa2f65f5f2284432990dcd4151397d8c878c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

