### PR TITLE
chore(ci): use latest pnpm action version

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -44,9 +44,9 @@ jobs:
             ${{ runner.os }}-turbo-
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+        uses: pnpm/action-setup@9b5745cdf0a2e8c2620f0746130f809adb911c19
         with:
-          version: 10.29.3
+          version: 10.30.2
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v5

--- a/.github/workflows/e2e-api.yml
+++ b/.github/workflows/e2e-api.yml
@@ -66,9 +66,9 @@ jobs:
             ${{ runner.os }}-nextjs-api-
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+        uses: pnpm/action-setup@9b5745cdf0a2e8c2620f0746130f809adb911c19
         with:
-          version: 10.29.3
+          version: 10.30.2
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v5

--- a/.github/workflows/e2e-editor.yml
+++ b/.github/workflows/e2e-editor.yml
@@ -65,9 +65,9 @@ jobs:
             ${{ runner.os }}-nextjs-editor-
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+        uses: pnpm/action-setup@9b5745cdf0a2e8c2620f0746130f809adb911c19
         with:
-          version: 10.29.3
+          version: 10.30.2
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v5

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -69,9 +69,9 @@ jobs:
             ${{ runner.os }}-nextjs-main-
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+        uses: pnpm/action-setup@9b5745cdf0a2e8c2620f0746130f809adb911c19
         with:
-          version: 10.29.3
+          version: 10.30.2
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v5

--- a/package.json
+++ b/package.json
@@ -37,5 +37,5 @@
   "engines": {
     "node": "^24"
   },
-  "packageManager": "pnpm@10.29.3"
+  "packageManager": "pnpm@10.30.2"
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgraded pnpm to 10.30.2 and updated GitHub Actions to use the latest pnpm/action-setup across CI. Ensures consistent installs and up-to-date tooling.

- **Dependencies**
  - package.json: packageManager set to pnpm@10.30.2.
  - Workflows (code-quality, e2e-api, e2e-editor, e2e-main): use pnpm/action-setup@9b5745… with pnpm 10.30.2.

<sup>Written for commit 23d28bca9139075ff2219618580accba01a49200. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

