### PR TITLE
refactor(data): use id-based lookups for child-listing functions

### DIFF
--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/chapter-list.tsx
@@ -12,6 +12,7 @@ import { getCourse } from "@/data/courses/get-course";
 import { ErrorView } from "@zoonk/ui/patterns/error";
 import { SUPPORT_URL } from "@zoonk/utils/constants";
 import { getExtracted } from "next-intl/server";
+import { notFound } from "next/navigation";
 import {
   exportChaptersAction,
   handleImportChaptersAction,
@@ -28,12 +29,18 @@ export async function ChapterList({
   const { courseSlug, orgSlug } = await params;
   const t = await getExtracted();
 
-  const [{ data: chapters, error }, { data: course }] = await Promise.all([
-    listCourseChapters({ courseSlug, orgSlug }),
-    getCourse({ courseSlug, orgSlug }),
-  ]);
+  const { data: course } = await getCourse({ courseSlug, orgSlug });
 
-  if (error || !course) {
+  if (!course) {
+    notFound();
+  }
+
+  const { data: chapters, error } = await listCourseChapters({
+    courseId: course.id,
+    orgId: course.organizationId,
+  });
+
+  if (error) {
     return (
       <ErrorView
         description={t("We couldn't load the chapters. Please try again.")}

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/course-categories.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/course-categories.tsx
@@ -11,14 +11,13 @@ export async function CourseCategories({
 }) {
   const { courseSlug, orgSlug } = await params;
 
-  const [{ data: course, error }, { data: categories }] = await Promise.all([
-    getCourse({ courseSlug, orgSlug }),
-    listCourseCategories({ courseSlug, orgSlug }),
-  ]);
+  const { data: course, error } = await getCourse({ courseSlug, orgSlug });
 
   if (error || !course) {
     return notFound();
   }
+
+  const { data: categories } = await listCourseCategories({ courseId: course.id });
 
   const routeParams = {
     courseId: course.id,

--- a/apps/editor/src/data/categories/list-course-categories.test.ts
+++ b/apps/editor/src/data/categories/list-course-categories.test.ts
@@ -8,10 +8,7 @@ describe(listCourseCategories, () => {
     const organization = await organizationFixture();
     const course = await courseFixture({ organizationId: organization.id });
 
-    const result = await listCourseCategories({
-      courseSlug: course.slug,
-      orgSlug: organization.slug,
-    });
+    const result = await listCourseCategories({ courseId: course.id });
 
     expect(result.error).toBeNull();
     expect(result.data).toEqual([]);
@@ -27,10 +24,7 @@ describe(listCourseCategories, () => {
       courseCategoryFixture({ category: "math", courseId: course.id }),
     ]);
 
-    const result = await listCourseCategories({
-      courseSlug: course.slug,
-      orgSlug: organization.slug,
-    });
+    const result = await listCourseCategories({ courseId: course.id });
 
     expect(result.error).toBeNull();
     expect(result.data?.length).toBe(3);
@@ -46,10 +40,7 @@ describe(listCourseCategories, () => {
       courseCategoryFixture({ category: "math", courseId: course.id }),
     ]);
 
-    const result = await listCourseCategories({
-      courseSlug: course.slug,
-      orgSlug: organization.slug,
-    });
+    const result = await listCourseCategories({ courseId: course.id });
 
     expect(result.error).toBeNull();
     expect(result.data?.[0]?.category).toBe("arts");
@@ -71,25 +62,10 @@ describe(listCourseCategories, () => {
       courseCategoryFixture({ category: "arts", courseId: course2.id }),
     ]);
 
-    const result = await listCourseCategories({
-      courseSlug: course1.slug,
-      orgSlug: organization.slug,
-    });
+    const result = await listCourseCategories({ courseId: course1.id });
 
     expect(result.error).toBeNull();
     expect(result.data?.length).toBe(2);
     expect(result.data?.every((category) => category.courseId === course1.id)).toBeTruthy();
-  });
-
-  test("returns empty array for non-existent course", async () => {
-    const organization = await organizationFixture();
-
-    const result = await listCourseCategories({
-      courseSlug: "non-existent-course",
-      orgSlug: organization.slug,
-    });
-
-    expect(result.error).toBeNull();
-    expect(result.data).toEqual([]);
   });
 });

--- a/apps/editor/src/data/categories/list-course-categories.ts
+++ b/apps/editor/src/data/categories/list-course-categories.ts
@@ -4,16 +4,11 @@ import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 
 const cachedListCourseCategories = cache(
-  async (courseSlug: string, orgSlug: string): Promise<SafeReturn<CourseCategory[]>> => {
+  async (courseId: number): Promise<SafeReturn<CourseCategory[]>> => {
     const { data, error } = await safeAsync(() =>
       prisma.courseCategory.findMany({
         orderBy: { category: "asc" },
-        where: {
-          course: {
-            organization: { slug: orgSlug },
-            slug: courseSlug,
-          },
-        },
+        where: { courseId },
       }),
     );
 
@@ -26,8 +21,7 @@ const cachedListCourseCategories = cache(
 );
 
 export function listCourseCategories(params: {
-  courseSlug: string;
-  orgSlug: string;
+  courseId: number;
 }): Promise<SafeReturn<CourseCategory[]>> {
-  return cachedListCourseCategories(params.courseSlug, params.orgSlug);
+  return cachedListCourseCategories(params.courseId);
 }

--- a/apps/editor/src/data/chapters/list-course-chapters.test.ts
+++ b/apps/editor/src/data/chapters/list-course-chapters.test.ts
@@ -12,9 +12,9 @@ describe("unauthenticated users", () => {
     const course = await courseFixture({ organizationId: organization.id });
 
     const result = await listCourseChapters({
-      courseSlug: course.slug,
+      courseId: course.id,
       headers: new Headers(),
-      orgSlug: organization.slug,
+      orgId: organization.id,
     });
 
     expect(result.error?.message).toBe(ErrorCode.forbidden);
@@ -32,9 +32,9 @@ describe("members", () => {
     ]);
 
     const result = await listCourseChapters({
-      courseSlug: course.slug,
+      courseId: course.id,
       headers,
-      orgSlug: organization.slug,
+      orgId: organization.id,
     });
 
     expect(result.error?.message).toBe(ErrorCode.forbidden);
@@ -45,16 +45,12 @@ describe("members", () => {
 describe("admins", () => {
   let organization: Awaited<ReturnType<typeof memberFixture>>["organization"];
   let headers: Headers;
-  let _course: Awaited<ReturnType<typeof courseFixture>>;
 
   beforeAll(async () => {
     const fixture = await memberFixture({ role: "admin" });
     organization = fixture.organization;
 
-    [headers, _course] = await Promise.all([
-      signInAs(fixture.user.email, fixture.user.password),
-      courseFixture({ organizationId: fixture.organization.id }),
-    ]);
+    headers = await signInAs(fixture.user.email, fixture.user.password);
   });
 
   test("lists chapters for a course ordered by position", async () => {
@@ -82,9 +78,9 @@ describe("admins", () => {
     ]);
 
     const result = await listCourseChapters({
-      courseSlug: newCourse.slug,
+      courseId: newCourse.id,
       headers,
-      orgSlug: organization.slug,
+      orgId: organization.id,
     });
 
     const expectedChapterCount = 3;
@@ -105,20 +101,9 @@ describe("admins", () => {
     });
 
     const result = await listCourseChapters({
-      courseSlug: emptyCourse.slug,
+      courseId: emptyCourse.id,
       headers,
-      orgSlug: organization.slug,
-    });
-
-    expect(result.error).toBeNull();
-    expect(result.data).toEqual([]);
-  });
-
-  test("returns empty array when course not found", async () => {
-    const result = await listCourseChapters({
-      courseSlug: "non-existent-course",
-      headers,
-      orgSlug: organization.slug,
+      orgId: organization.id,
     });
 
     expect(result.error).toBeNull();
@@ -130,9 +115,9 @@ describe("admins", () => {
     const otherCourse = await courseFixture({ organizationId: otherOrg.id });
 
     const result = await listCourseChapters({
-      courseSlug: otherCourse.slug,
+      courseId: otherCourse.id,
       headers,
-      orgSlug: otherOrg.slug,
+      orgId: otherOrg.id,
     });
 
     expect(result.error?.message).toBe(ErrorCode.forbidden);

--- a/apps/editor/src/data/chapters/list-course-chapters.ts
+++ b/apps/editor/src/data/chapters/list-course-chapters.ts
@@ -7,25 +7,20 @@ import { cache } from "react";
 
 const cachedListCourseChapters = cache(
   async (
-    courseSlug: string,
-    orgSlug: string,
+    courseId: number,
+    orgId: number | null,
     headers?: Headers,
   ): Promise<{ data: Chapter[]; error: Error | null }> => {
     const { data, error } = await safeAsync(() =>
       Promise.all([
         hasCoursePermission({
           headers,
-          orgSlug,
+          orgId,
           permission: "update",
         }),
         prisma.chapter.findMany({
           orderBy: { position: "asc" },
-          where: {
-            course: {
-              organization: { slug: orgSlug },
-              slug: courseSlug,
-            },
-          },
+          where: { courseId },
         }),
       ]),
     );
@@ -45,9 +40,9 @@ const cachedListCourseChapters = cache(
 );
 
 export function listCourseChapters(params: {
-  courseSlug: string;
+  courseId: number;
   headers?: Headers;
-  orgSlug: string;
+  orgId: number | null;
 }): Promise<{ data: Chapter[]; error: Error | null }> {
-  return cachedListCourseChapters(params.courseSlug, params.orgSlug, params.headers);
+  return cachedListCourseChapters(params.courseId, params.orgId, params.headers);
 }

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
@@ -43,16 +43,15 @@ export default async function CoursePage({
   const { brandSlug, courseSlug, locale } = await params;
   setRequestLocale(locale);
 
-  const [course, chapters] = await Promise.all([
-    getCourse({ brandSlug, courseSlug }),
-    listCourseChapters({ brandSlug, courseSlug }),
-  ]);
+  const course = await getCourse({ brandSlug, courseSlug });
 
   cacheTag(cacheTagCourse({ courseSlug }));
 
   if (!course) {
     notFound();
   }
+
+  const chapters = await listCourseChapters({ courseId: course.id });
 
   if (chapters.length === 0) {
     redirect({ href: `/generate/c/${course.slug}`, locale });

--- a/apps/main/src/data/chapters/list-course-chapters.ts
+++ b/apps/main/src/data/chapters/list-course-chapters.ts
@@ -12,7 +12,7 @@ export type ChapterForList = {
 };
 
 const cachedListCourseChapters = cache(
-  async (brandSlug: string, courseSlug: string): Promise<ChapterForList[]> =>
+  async (courseId: number): Promise<ChapterForList[]> =>
     prisma.chapter.findMany({
       orderBy: { position: "asc" },
       select: {
@@ -23,23 +23,10 @@ const cachedListCourseChapters = cache(
         slug: true,
         title: true,
       },
-      where: {
-        course: {
-          isPublished: true,
-          organization: {
-            kind: "brand",
-            slug: brandSlug,
-          },
-          slug: courseSlug,
-        },
-        isPublished: true,
-      },
+      where: { courseId, isPublished: true },
     }),
 );
 
-export function listCourseChapters(params: {
-  brandSlug: string;
-  courseSlug: string;
-}): Promise<ChapterForList[]> {
-  return cachedListCourseChapters(params.brandSlug, params.courseSlug);
+export function listCourseChapters(params: { courseId: number }): Promise<ChapterForList[]> {
+  return cachedListCourseChapters(params.courseId);
 }


### PR DESCRIPTION
## Summary
- Change `listCourseChapters` and `listCourseCategories` to accept IDs instead of slugs, eliminating redundant nested joins
- Fetch parent with `getCourse` first, then pass its ID to child-listing functions (matching the pattern already used by `listChapterLessons` and `listAlternativeTitles`)
- Return `notFound()` instead of `ErrorView` when course is missing in editor chapter-list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch child-listing to ID-based lookups to remove nested joins and standardize queries. Also return a 404 in the editor chapter list when the course is missing.

- **Refactors**
  - listCourseChapters now takes courseId (and orgId for permission checks in editor); listCourseCategories now takes courseId.
  - Simplified Prisma queries to filter by IDs instead of slugs.
  - Fetch course once with getCourse, then pass IDs to child queries (editor and main).
  - Editor: chapter-list uses notFound() if the course isn’t found; tests updated to new signatures and behaviors.

<sup>Written for commit 0fe207ad4248c273637bd023851c35f4d1b98796. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

