### PR TITLE
chore(ci): use playwright docker image for e2e workflows

### DIFF
--- a/.github/workflows/e2e-api.yml
+++ b/.github/workflows/e2e-api.yml
@@ -12,17 +12,17 @@ on:
 permissions:
   contents: read
 
-env:
-  NODE_VERSION: 24
-
 jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      options: --ipc=host
     env:
       BETTER_AUTH_SECRET: test-secret-for-ci
-      DATABASE_URL: postgres://postgres:postgres@localhost:5432/zoonk_e2e
-      DATABASE_URL_UNPOOLED: postgres://postgres:postgres@localhost:5432/zoonk_e2e
+      DATABASE_URL: postgres://postgres:postgres@db:5432/zoonk_e2e
+      DATABASE_URL_UNPOOLED: postgres://postgres:postgres@db:5432/zoonk_e2e
       E2E_TESTING: "true"
       NEXT_PUBLIC_APP_DOMAIN: localhost:4000
       NEXT_PUBLIC_API_URL: http://localhost:4000
@@ -70,17 +70,11 @@ jobs:
         with:
           version: 10.30.2
 
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v5
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: "pnpm"
-
       - name: Install dependencies
         run: pnpm install
 
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+      - name: Configure database host for container networking
+        run: sed -i 's/@localhost:5432/@db:5432/g' packages/db/.env.e2e
 
       - name: Setup database
         run: pnpm --filter @zoonk/db db:setup:e2e

--- a/.github/workflows/e2e-editor.yml
+++ b/.github/workflows/e2e-editor.yml
@@ -12,17 +12,17 @@ on:
 permissions:
   contents: read
 
-env:
-  NODE_VERSION: 24
-
 jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      options: --ipc=host
     env:
       BETTER_AUTH_SECRET: test-secret-for-ci
-      DATABASE_URL: postgres://postgres:postgres@localhost:5432/zoonk_e2e
-      DATABASE_URL_UNPOOLED: postgres://postgres:postgres@localhost:5432/zoonk_e2e
+      DATABASE_URL: postgres://postgres:postgres@db:5432/zoonk_e2e
+      DATABASE_URL_UNPOOLED: postgres://postgres:postgres@db:5432/zoonk_e2e
       E2E_TESTING: "true"
       NEXT_PUBLIC_APP_DOMAIN: localhost:3101
       NEXT_PUBLIC_API_URL: http://localhost:4000
@@ -69,17 +69,11 @@ jobs:
         with:
           version: 10.30.2
 
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v5
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: "pnpm"
-
       - name: Install dependencies
         run: pnpm install
 
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+      - name: Configure database host for container networking
+        run: sed -i 's/@localhost:5432/@db:5432/g' packages/db/.env.e2e
 
       - name: Setup database
         run: pnpm --filter @zoonk/db db:setup:e2e

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -12,21 +12,21 @@ on:
 permissions:
   contents: read
 
-env:
-  NODE_VERSION: 24
-
 jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      options: --ipc=host
     strategy:
       fail-fast: false
       matrix:
         shard: [1, 2, 3]
     env:
       BETTER_AUTH_SECRET: test-secret-for-ci
-      DATABASE_URL: postgres://postgres:postgres@localhost:5432/zoonk_e2e
-      DATABASE_URL_UNPOOLED: postgres://postgres:postgres@localhost:5432/zoonk_e2e
+      DATABASE_URL: postgres://postgres:postgres@db:5432/zoonk_e2e
+      DATABASE_URL_UNPOOLED: postgres://postgres:postgres@db:5432/zoonk_e2e
       E2E_TESTING: "true"
       NEXT_PUBLIC_APP_DOMAIN: localhost:3000
       NEXT_PUBLIC_API_URL: http://localhost:4000
@@ -73,17 +73,11 @@ jobs:
         with:
           version: 10.30.2
 
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v5
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: "pnpm"
-
       - name: Install dependencies
         run: pnpm install
 
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+      - name: Configure database host for container networking
+        run: sed -i 's/@localhost:5432/@db:5432/g' packages/db/.env.e2e
 
       - name: Setup database
         run: pnpm --filter @zoonk/db db:setup:e2e

--- a/packages/e2e/src/base.config.ts
+++ b/packages/e2e/src/base.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 import { E2E_REVALIDATE_SECRET } from "./helpers";
 
-const E2E_DATABASE_URL = "postgres://postgres:postgres@localhost:5432/zoonk_e2e";
+const E2E_DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgres://postgres:postgres@localhost:5432/zoonk_e2e";
 const E2E_API_URL = "http://localhost:49152";
 
 export function createBaseConfig(options: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Run e2e workflows inside the official Playwright Docker image to standardize browsers and reduce CI flakiness. Updated database connections for container networking and made the e2e config read DATABASE_URL from env.

- **Refactors**
  - Run jobs in mcr.microsoft.com/playwright:v1.58.2-noble (with --ipc=host).
  - Remove Node setup and Playwright browser install steps.
  - Use db host in DATABASE_URL and patch packages/db/.env.e2e during CI.
  - Read DATABASE_URL from env in packages/e2e/src/base.config.ts (fallback to localhost).

<sup>Written for commit 86c17f95bf43824f8ddca4a67cfb3cb74c2bf035. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

