### PR TITLE
refactor(data): remove unnecessary prisma select usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,13 @@ For detailed UX guidelines (interactions, animation, layout, accessibility), see
 - When adding e2e tests, use `*Fixture()` functions to create unique test data per test - do not modify seed files
 - Avoid inline imports like `await import()`, only do it when dynamic imports are absolutely necessary
 
+## Prisma Queries
+
+- **Don't use `select` by default.** Return the full model — most models have only small columns and `select` adds maintenance cost (manual types, updating selects when adding fields) with negligible performance benefit
+- **Use `omit`** only for models with large columns (`Step.content`, `Step.visualContent`, `StepAttempt.answer`, `StepAttempt.effects`) when you don't need those fields
+- **Use `include`** to load relations. Use `select` on included relations when you only need specific fields from the related model
+- **Don't define manual types** that mirror Prisma query shapes. Use Prisma's generated types (`Course`, `Chapter`, etc.) or derive types from queries using `NonNullable<Awaited<ReturnType<typeof myQueryFn>>>`
+
 ## Compound Components
 
 When writing React components, use compound components. Always read this before creating components:

--- a/apps/api/src/data/progress/get-lesson-activity-completion.ts
+++ b/apps/api/src/data/progress/get-lesson-activity-completion.ts
@@ -11,7 +11,6 @@ export async function getLessonActivityCompletion(
 
   const { data, error } = await safeAsync(() =>
     prisma.activityProgress.findMany({
-      select: { activityId: true },
       where: {
         activity: { isPublished: true, lessonId },
         completedAt: { not: null },

--- a/apps/api/src/data/progress/get-next-activity.ts
+++ b/apps/api/src/data/progress/get-next-activity.ts
@@ -35,30 +35,22 @@ async function findFirstActivity(scope: ActivityScope): Promise<{
 } | null> {
   const { data: activity, error } = await safeAsync(() =>
     prisma.activity.findFirst({
+      include: {
+        lesson: {
+          include: {
+            chapter: {
+              include: {
+                course: { include: { organization: true } },
+              },
+            },
+          },
+        },
+      },
       orderBy: [
         { lesson: { chapter: { position: "asc" } } },
         { lesson: { position: "asc" } },
         { position: "asc" },
       ],
-      select: {
-        lesson: {
-          select: {
-            chapter: {
-              select: {
-                course: {
-                  select: {
-                    organization: { select: { slug: true } },
-                    slug: true,
-                  },
-                },
-                slug: true,
-              },
-            },
-            slug: true,
-          },
-        },
-        position: true,
-      },
       where: { isPublished: true, ...scopeWhere(scope) },
     }),
   );

--- a/apps/editor/src/data/activities/import-activities.ts
+++ b/apps/editor/src/data/activities/import-activities.ts
@@ -117,7 +117,6 @@ export async function importActivities(params: {
       } else {
         const existingActivities = await tx.activity.findMany({
           orderBy: { position: "desc" },
-          select: { position: true },
           take: 1,
           where: { lessonId: params.lessonId },
         });

--- a/apps/editor/src/data/alternative-titles/export-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/export-alternative-titles.ts
@@ -27,7 +27,6 @@ export async function exportAlternativeTitles(params: { courseId: number }): Pro
   const { data: titles, error: titlesError } = await safeAsync(() =>
     prisma.courseAlternativeTitle.findMany({
       orderBy: { slug: "asc" },
-      select: { slug: true },
       where: { courseId: params.courseId },
     }),
   );

--- a/apps/editor/src/data/alternative-titles/list-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/list-alternative-titles.ts
@@ -5,7 +5,6 @@ import { cache } from "react";
 const cachedListAlternativeTitlesById = cache(async (courseId: number): Promise<string[]> => {
   const results = await prisma.courseAlternativeTitle.findMany({
     orderBy: { slug: "asc" },
-    select: { slug: true },
     where: { courseId },
   });
 
@@ -15,7 +14,6 @@ const cachedListAlternativeTitlesById = cache(async (courseId: number): Promise<
 const cachedListAlternativeTitlesBySlug = cache(async (courseSlug: string): Promise<string[]> => {
   const results = await prisma.courseAlternativeTitle.findMany({
     orderBy: { slug: "asc" },
-    select: { slug: true },
     where: { course: { slug: courseSlug } },
   });
 

--- a/apps/editor/src/data/chapters/chapter-slug.ts
+++ b/apps/editor/src/data/chapters/chapter-slug.ts
@@ -6,7 +6,6 @@ import { cache } from "react";
 const cachedChapterSlugExists = cache(async (courseId: number, slug: string): Promise<boolean> => {
   const { data } = await safeAsync(() =>
     prisma.chapter.findFirst({
-      select: { id: true },
       where: { courseId, slug },
     }),
   );

--- a/apps/editor/src/data/chapters/import-chapters.ts
+++ b/apps/editor/src/data/chapters/import-chapters.ts
@@ -96,7 +96,6 @@ export async function importChapters(params: {
       } else {
         const existingChapters = await tx.chapter.findMany({
           orderBy: { position: "desc" },
-          select: { position: true },
           take: 1,
           where: { courseId: params.courseId },
         });

--- a/apps/editor/src/data/chapters/publish-chapter.ts
+++ b/apps/editor/src/data/chapters/publish-chapter.ts
@@ -11,7 +11,6 @@ export async function toggleChapterPublished(params: {
 }): Promise<SafeReturn<Chapter>> {
   const { data: chapter, error: findError } = await safeAsync(() =>
     prisma.chapter.findUnique({
-      select: { id: true, organizationId: true },
       where: { id: params.chapterId },
     }),
   );

--- a/apps/editor/src/data/chapters/search-org-chapters.ts
+++ b/apps/editor/src/data/chapters/search-org-chapters.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { ErrorCode } from "@/lib/app-error";
 import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
-import { type Chapter, prisma } from "@zoonk/db";
+import { type Chapter, type Course, prisma } from "@zoonk/db";
 import { clampQueryItems } from "@zoonk/db/utils";
 import { DEFAULT_SEARCH_LIMIT } from "@zoonk/utils/constants";
 import { AppError, safeAsync } from "@zoonk/utils/error";
@@ -9,7 +9,7 @@ import { normalizeString } from "@zoonk/utils/string";
 import { cache } from "react";
 
 type ChapterWithCourse = Chapter & {
-  course: { slug: string };
+  course: Course;
 };
 
 const cachedSearchOrgChapters = cache(
@@ -30,9 +30,7 @@ const cachedSearchOrgChapters = cache(
         }),
         prisma.chapter.findMany({
           include: {
-            course: {
-              select: { slug: true },
-            },
+            course: true,
           },
           orderBy: { createdAt: "desc" },
           take: limit,

--- a/apps/editor/src/data/courses/course-slug.ts
+++ b/apps/editor/src/data/courses/course-slug.ts
@@ -6,7 +6,6 @@ import { cache } from "react";
 const cachedCourseSlugExists = cache(async (orgSlug: string, slug: string): Promise<boolean> => {
   const { data } = await safeAsync(() =>
     prisma.course.findFirst({
-      select: { id: true },
       where: {
         organization: { slug: orgSlug },
         slug,

--- a/apps/editor/src/data/courses/publish-course.ts
+++ b/apps/editor/src/data/courses/publish-course.ts
@@ -11,7 +11,6 @@ export async function toggleCoursePublished(params: {
 }): Promise<SafeReturn<Course>> {
   const { data: course, error: findError } = await safeAsync(() =>
     prisma.course.findUnique({
-      select: { id: true, organizationId: true },
       where: { id: params.courseId },
     }),
   );

--- a/apps/editor/src/data/lessons/create-lesson.ts
+++ b/apps/editor/src/data/lessons/create-lesson.ts
@@ -17,10 +17,8 @@ export async function createLesson(params: {
   const { data: chapter, error: findError } = await safeAsync(() =>
     prisma.chapter.findUnique({
       include: {
-        course: {
-          select: { categories: { select: { category: true } } },
-        },
-        organization: { select: { slug: true } },
+        course: { include: { categories: true } },
+        organization: true,
       },
       where: { id: params.chapterId },
     }),

--- a/apps/editor/src/data/lessons/import-lessons.ts
+++ b/apps/editor/src/data/lessons/import-lessons.ts
@@ -67,10 +67,8 @@ export async function importLessons(params: {
   const { data: chapter, error: findError } = await safeAsync(() =>
     prisma.chapter.findUnique({
       include: {
-        course: {
-          select: { categories: { select: { category: true } } },
-        },
-        organization: { select: { slug: true } },
+        course: { include: { categories: true } },
+        organization: true,
       },
       where: { id: params.chapterId },
     }),
@@ -108,7 +106,6 @@ export async function importLessons(params: {
       } else {
         const existingLessons = await tx.lesson.findMany({
           orderBy: { position: "desc" },
-          select: { position: true },
           take: 1,
           where: { chapterId: params.chapterId },
         });

--- a/apps/editor/src/data/lessons/lesson-slug.ts
+++ b/apps/editor/src/data/lessons/lesson-slug.ts
@@ -6,7 +6,6 @@ import { cache } from "react";
 const cachedLessonSlugExists = cache(async (chapterId: number, slug: string): Promise<boolean> => {
   const { data } = await safeAsync(() =>
     prisma.lesson.findFirst({
-      select: { id: true },
       where: { chapterId, slug },
     }),
   );

--- a/apps/editor/src/data/lessons/publish-lesson.ts
+++ b/apps/editor/src/data/lessons/publish-lesson.ts
@@ -11,7 +11,6 @@ export async function toggleLessonPublished(params: {
 }): Promise<SafeReturn<Lesson>> {
   const { data: lesson, error: findError } = await safeAsync(() =>
     prisma.lesson.findUnique({
-      select: { id: true, organizationId: true },
       where: { id: params.lessonId },
     }),
   );

--- a/apps/editor/src/data/lessons/search-org-lessons.ts
+++ b/apps/editor/src/data/lessons/search-org-lessons.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { ErrorCode } from "@/lib/app-error";
 import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
-import { type Lesson, prisma } from "@zoonk/db";
+import { type Chapter, type Course, type Lesson, prisma } from "@zoonk/db";
 import { clampQueryItems } from "@zoonk/db/utils";
 import { DEFAULT_SEARCH_LIMIT } from "@zoonk/utils/constants";
 import { AppError, safeAsync } from "@zoonk/utils/error";
@@ -9,7 +9,7 @@ import { normalizeString } from "@zoonk/utils/string";
 import { cache } from "react";
 
 type LessonWithChapter = Lesson & {
-  chapter: { slug: string; course: { slug: string } };
+  chapter: Chapter & { course: Course };
 };
 
 const cachedSearchOrgLessons = cache(
@@ -31,10 +31,7 @@ const cachedSearchOrgLessons = cache(
         prisma.lesson.findMany({
           include: {
             chapter: {
-              select: {
-                course: { select: { slug: true } },
-                slug: true,
-              },
+              include: { course: true },
             },
           },
           orderBy: { createdAt: "desc" },

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
@@ -7,8 +7,8 @@ import {
   CatalogListItemDescription,
   CatalogListItemTitle,
 } from "@/components/catalog/catalog-list";
-import { type ActivityForList } from "@/data/activities/list-lesson-activities";
 import { type ActivityKindInfo } from "@/lib/activities";
+import { type Activity } from "@zoonk/db";
 import { getExtracted } from "next-intl/server";
 
 export async function ActivityList({
@@ -17,7 +17,7 @@ export async function ActivityList({
   kindMeta,
   lessonId,
 }: {
-  activities: ActivityForList[];
+  activities: Activity[];
   baseHref: string;
   kindMeta: Map<string, ActivityKindInfo>;
   lessonId: number;

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -10,7 +10,7 @@ import {
   CatalogListSearch,
 } from "@/components/catalog/catalog-list";
 import { LessonCompletion } from "@/components/catalog/lesson-completion";
-import { type LessonForList } from "@/data/lessons/list-chapter-lessons";
+import { type Lesson } from "@zoonk/db";
 import { formatPosition } from "@zoonk/utils/string";
 import { getExtracted } from "next-intl/server";
 
@@ -25,7 +25,7 @@ export async function LessonList({
   chapterId: number;
   chapterSlug: string;
   courseSlug: string;
-  lessons: LessonForList[];
+  lessons: Lesson[];
 }) {
   if (lessons.length === 0) {
     return null;

--- a/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/main/src/app/[locale]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -10,7 +10,7 @@ import {
   CatalogListSearch,
 } from "@/components/catalog/catalog-list";
 import { ChapterCompletion } from "@/components/catalog/chapter-completion";
-import { type ChapterForList } from "@/data/chapters/list-course-chapters";
+import { type Chapter } from "@zoonk/db";
 import { formatPosition } from "@zoonk/utils/string";
 import { getExtracted } from "next-intl/server";
 
@@ -21,7 +21,7 @@ export async function ChapterList({
   courseSlug,
 }: {
   brandSlug: string;
-  chapters: ChapterForList[];
+  chapters: Chapter[];
   courseId: number;
   courseSlug: string;
 }) {

--- a/apps/main/src/data/activities/get-activity-for-generation.ts
+++ b/apps/main/src/data/activities/get-activity-for-generation.ts
@@ -3,25 +3,14 @@ import { prisma } from "@zoonk/db";
 
 export async function getActivityForGeneration(activityId: bigint) {
   return prisma.activity.findUnique({
-    select: {
-      generationRunId: true,
-      generationStatus: true,
-      id: true,
-      kind: true,
+    include: {
       lesson: {
-        select: {
+        include: {
           chapter: {
-            select: {
-              course: { select: { slug: true } },
-              slug: true,
-            },
+            include: { course: true },
           },
-          id: true,
-          slug: true,
         },
       },
-      position: true,
-      title: true,
     },
     where: { id: activityId },
   });

--- a/apps/main/src/data/activities/get-activity.test.ts
+++ b/apps/main/src/data/activities/get-activity.test.ts
@@ -173,7 +173,7 @@ describe(getActivity, () => {
 
     const result = await getActivity({ lessonId: wordLesson.id, position: 0 });
 
-    expect(result?.steps[0]?.word).toEqual({
+    expect(result?.steps[0]?.word).toMatchObject({
       alternativeTranslations: [],
       audioUrl: "https://example.com/audio.mp3",
       id: word.id,
@@ -220,7 +220,7 @@ describe(getActivity, () => {
 
     const result = await getActivity({ lessonId: sentLesson.id, position: 0 });
 
-    expect(result?.steps[0]?.sentence).toEqual({
+    expect(result?.steps[0]?.sentence).toMatchObject({
       audioUrl: "https://example.com/sent-audio.mp3",
       id: sentence.id,
       romanization: "test-sent-roman",

--- a/apps/main/src/data/activities/get-activity.ts
+++ b/apps/main/src/data/activities/get-activity.ts
@@ -1,97 +1,24 @@
 import "server-only";
-import { type ActivityKind, type GenerationStatus, prisma } from "@zoonk/db";
+import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
-type ActivityWithSteps = {
-  id: bigint;
-  kind: ActivityKind;
-  title: string | null;
-  description: string | null;
-  language: string;
-  organizationId: number | null;
-  position: number;
-  generationStatus: GenerationStatus;
-  generationRunId: string | null;
-  steps: {
-    id: bigint;
-    content: unknown;
-    kind: string;
-    position: number;
-    visualContent: unknown;
-    visualKind: string | null;
-    word: {
-      id: bigint;
-      word: string;
-      translation: string;
-      alternativeTranslations: string[];
-      pronunciation: string | null;
-      romanization: string | null;
-      audioUrl: string | null;
-    } | null;
-    sentence: {
-      id: bigint;
-      sentence: string;
-      translation: string;
-      romanization: string | null;
-      audioUrl: string | null;
-    } | null;
-  }[];
-};
-
-const cachedGetActivity = cache(
-  async (lessonId: number, position: number): Promise<ActivityWithSteps | null> =>
-    prisma.activity.findFirst({
-      orderBy: { position: "asc" },
-      select: {
-        description: true,
-        generationRunId: true,
-        generationStatus: true,
-        id: true,
-        kind: true,
-        language: true,
-        organizationId: true,
-        position: true,
-        steps: {
-          orderBy: { position: "asc" },
-          select: {
-            content: true,
-            id: true,
-            kind: true,
-            position: true,
-            sentence: {
-              select: {
-                audioUrl: true,
-                id: true,
-                romanization: true,
-                sentence: true,
-                translation: true,
-              },
-            },
-            visualContent: true,
-            visualKind: true,
-            word: {
-              select: {
-                alternativeTranslations: true,
-                audioUrl: true,
-                id: true,
-                pronunciation: true,
-                romanization: true,
-                translation: true,
-                word: true,
-              },
-            },
-          },
-          where: { isPublished: true },
+const cachedGetActivity = cache(async (lessonId: number, position: number) =>
+  prisma.activity.findFirst({
+    include: {
+      steps: {
+        include: {
+          sentence: true,
+          word: true,
         },
-        title: true,
+        orderBy: { position: "asc" },
+        where: { isPublished: true },
       },
-      where: { isPublished: true, lessonId, position },
-    }),
+    },
+    orderBy: { position: "asc" },
+    where: { isPublished: true, lessonId, position },
+  }),
 );
 
-export function getActivity(params: {
-  lessonId: number;
-  position: number;
-}): Promise<ActivityWithSteps | null> {
+export function getActivity(params: { lessonId: number; position: number }) {
   return cachedGetActivity(params.lessonId, params.position);
 }

--- a/apps/main/src/data/activities/get-lesson-sentences.test.ts
+++ b/apps/main/src/data/activities/get-lesson-sentences.test.ts
@@ -89,7 +89,7 @@ describe(getLessonSentences, () => {
     const result = await getLessonSentences({ lessonId: newLesson.id });
 
     expect(result).toHaveLength(1);
-    expect(result[0]).toEqual({
+    expect(result[0]).toMatchObject({
       audioUrl: "https://example.com/megusta.mp3",
       id: sentence.id,
       romanization: null,

--- a/apps/main/src/data/activities/get-lesson-sentences.ts
+++ b/apps/main/src/data/activities/get-lesson-sentences.ts
@@ -1,34 +1,16 @@
 import "server-only";
-import { prisma } from "@zoonk/db";
+import { type Sentence, prisma } from "@zoonk/db";
 import { cache } from "react";
 
-type LessonSentenceData = {
-  id: bigint;
-  sentence: string;
-  translation: string;
-  romanization: string | null;
-  audioUrl: string | null;
-};
-
-const cachedGetLessonSentences = cache(async (lessonId: number): Promise<LessonSentenceData[]> => {
+const cachedGetLessonSentences = cache(async (lessonId: number): Promise<Sentence[]> => {
   const lessonSentences = await prisma.lessonSentence.findMany({
-    select: {
-      sentence: {
-        select: {
-          audioUrl: true,
-          id: true,
-          romanization: true,
-          sentence: true,
-          translation: true,
-        },
-      },
-    },
+    include: { sentence: true },
     where: { lessonId },
   });
 
   return lessonSentences.map((ls) => ls.sentence);
 });
 
-export function getLessonSentences(params: { lessonId: number }): Promise<LessonSentenceData[]> {
+export function getLessonSentences(params: { lessonId: number }): Promise<Sentence[]> {
   return cachedGetLessonSentences(params.lessonId);
 }

--- a/apps/main/src/data/activities/get-lesson-words.test.ts
+++ b/apps/main/src/data/activities/get-lesson-words.test.ts
@@ -92,7 +92,7 @@ describe(getLessonWords, () => {
     const result = await getLessonWords({ lessonId: newLesson.id });
 
     expect(result).toHaveLength(1);
-    expect(result[0]).toEqual({
+    expect(result[0]).toMatchObject({
       alternativeTranslations: [],
       audioUrl: "https://example.com/perro.mp3",
       id: word.id,

--- a/apps/main/src/data/activities/get-lesson-words.ts
+++ b/apps/main/src/data/activities/get-lesson-words.ts
@@ -1,38 +1,16 @@
 import "server-only";
-import { prisma } from "@zoonk/db";
+import { type Word, prisma } from "@zoonk/db";
 import { cache } from "react";
 
-type LessonWordData = {
-  id: bigint;
-  word: string;
-  translation: string;
-  alternativeTranslations: string[];
-  pronunciation: string | null;
-  romanization: string | null;
-  audioUrl: string | null;
-};
-
-const cachedGetLessonWords = cache(async (lessonId: number): Promise<LessonWordData[]> => {
+const cachedGetLessonWords = cache(async (lessonId: number): Promise<Word[]> => {
   const lessonWords = await prisma.lessonWord.findMany({
-    select: {
-      word: {
-        select: {
-          alternativeTranslations: true,
-          audioUrl: true,
-          id: true,
-          pronunciation: true,
-          romanization: true,
-          translation: true,
-          word: true,
-        },
-      },
-    },
+    include: { word: true },
     where: { lessonId },
   });
 
   return lessonWords.map((lw) => lw.word);
 });
 
-export function getLessonWords(params: { lessonId: number }): Promise<LessonWordData[]> {
+export function getLessonWords(params: { lessonId: number }): Promise<Word[]> {
   return cachedGetLessonWords(params.lessonId);
 }

--- a/apps/main/src/data/activities/list-lesson-activities.ts
+++ b/apps/main/src/data/activities/list-lesson-activities.ts
@@ -1,30 +1,15 @@
 import "server-only";
-import { type ActivityKind, prisma } from "@zoonk/db";
+import { type Activity, prisma } from "@zoonk/db";
 import { cache } from "react";
 
-export type ActivityForList = {
-  id: bigint;
-  kind: ActivityKind;
-  title: string | null;
-  description: string | null;
-  position: number;
-};
-
 const cachedListLessonActivities = cache(
-  async (lessonId: number): Promise<ActivityForList[]> =>
+  async (lessonId: number): Promise<Activity[]> =>
     prisma.activity.findMany({
       orderBy: { position: "asc" },
-      select: {
-        description: true,
-        id: true,
-        kind: true,
-        position: true,
-        title: true,
-      },
       where: { isPublished: true, lessonId },
     }),
 );
 
-export function listLessonActivities(params: { lessonId: number }): Promise<ActivityForList[]> {
+export function listLessonActivities(params: { lessonId: number }): Promise<Activity[]> {
   return cachedListLessonActivities(params.lessonId);
 }

--- a/apps/main/src/data/activities/prepare-activity-data.test.ts
+++ b/apps/main/src/data/activities/prepare-activity-data.test.ts
@@ -295,7 +295,7 @@ describe(prepareActivityData, () => {
       lessonSentenceFixture({ lessonId: lesson.id, sentenceId: sentence1.id }),
     ]);
 
-    const lessonWords =[
+    const lessonWords = [
       {
         alternativeTranslations: word1.alternativeTranslations,
         audioUrl: word1.audioUrl,
@@ -445,7 +445,7 @@ describe(prepareActivityData, () => {
       title: "Vocabulary",
     };
 
-    const lessonWords =[stepWord, lessonWord];
+    const lessonWords = [stepWord, lessonWord];
     const result = prepareActivityData(activity, lessonWords, []);
     const vocabularyStep = result.steps[0];
     const vocabularyOptions = vocabularyStep?.vocabularyOptions ?? [];
@@ -498,7 +498,7 @@ describe(prepareActivityData, () => {
       sentenceId: sentence.id,
     });
 
-    const lessonWords =[
+    const lessonWords = [
       {
         alternativeTranslations: [],
         audioUrl: null,
@@ -572,7 +572,7 @@ describe(prepareActivityData, () => {
       sentenceId: sentence.id,
     });
 
-    const lessonWords =[
+    const lessonWords = [
       {
         alternativeTranslations: [],
         audioUrl: null,
@@ -639,7 +639,7 @@ describe(prepareActivityData, () => {
     };
 
     // Distractor word "hola" overlaps with correct word "Hola" (case-insensitive)
-    const lessonWords =[
+    const lessonWords = [
       {
         alternativeTranslations: [],
         audioUrl: null,
@@ -700,7 +700,7 @@ describe(prepareActivityData, () => {
     };
 
     // Distractor "you" (from .word) overlaps with correct word "you?" after stripping punctuation
-    const lessonWords =[
+    const lessonWords = [
       {
         alternativeTranslations: [],
         audioUrl: null,
@@ -761,7 +761,7 @@ describe(prepareActivityData, () => {
     };
 
     // Two lesson words produce distractors "tu" and "tu?" after splitting
-    const lessonWords =[
+    const lessonWords = [
       {
         alternativeTranslations: [],
         audioUrl: null,

--- a/apps/main/src/data/activities/prepare-activity-data.test.ts
+++ b/apps/main/src/data/activities/prepare-activity-data.test.ts
@@ -11,11 +11,6 @@ import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { wordFixture } from "@zoonk/testing/fixtures/words";
 import { beforeAll, describe, expect, expectTypeOf, test } from "vitest";
 import { getActivity } from "./get-activity";
-import { type getLessonSentences } from "./get-lesson-sentences";
-import { type getLessonWords } from "./get-lesson-words";
-
-type ActivityWithSteps = NonNullable<Awaited<ReturnType<typeof getActivity>>>;
-type LessonWordData = Awaited<ReturnType<typeof getLessonWords>>[number];
 
 describe(prepareActivityData, () => {
   let org: Awaited<ReturnType<typeof organizationFixture>>;
@@ -300,7 +295,7 @@ describe(prepareActivityData, () => {
       lessonSentenceFixture({ lessonId: lesson.id, sentenceId: sentence1.id }),
     ]);
 
-    const lessonWords: LessonWordData[] = [
+    const lessonWords =[
       {
         alternativeTranslations: word1.alternativeTranslations,
         audioUrl: word1.audioUrl,
@@ -321,7 +316,7 @@ describe(prepareActivityData, () => {
       },
     ];
 
-    const lessonSentences: Awaited<ReturnType<typeof getLessonSentences>>[number][] = [
+    const lessonSentences = [
       {
         audioUrl: sentence1.audioUrl,
         id: sentence1.id,
@@ -448,9 +443,9 @@ describe(prepareActivityData, () => {
         },
       ],
       title: "Vocabulary",
-    } satisfies ActivityWithSteps;
+    };
 
-    const lessonWords: LessonWordData[] = [stepWord, lessonWord];
+    const lessonWords =[stepWord, lessonWord];
     const result = prepareActivityData(activity, lessonWords, []);
     const vocabularyStep = result.steps[0];
     const vocabularyOptions = vocabularyStep?.vocabularyOptions ?? [];
@@ -503,7 +498,7 @@ describe(prepareActivityData, () => {
       sentenceId: sentence.id,
     });
 
-    const lessonWords: LessonWordData[] = [
+    const lessonWords =[
       {
         alternativeTranslations: [],
         audioUrl: null,
@@ -577,7 +572,7 @@ describe(prepareActivityData, () => {
       sentenceId: sentence.id,
     });
 
-    const lessonWords: LessonWordData[] = [
+    const lessonWords =[
       {
         alternativeTranslations: [],
         audioUrl: null,
@@ -641,10 +636,10 @@ describe(prepareActivityData, () => {
         },
       ],
       title: "Reading",
-    } satisfies ActivityWithSteps;
+    };
 
     // Distractor word "hola" overlaps with correct word "Hola" (case-insensitive)
-    const lessonWords: LessonWordData[] = [
+    const lessonWords =[
       {
         alternativeTranslations: [],
         audioUrl: null,
@@ -702,10 +697,10 @@ describe(prepareActivityData, () => {
         },
       ],
       title: "Punctuation Reading",
-    } satisfies ActivityWithSteps;
+    };
 
     // Distractor "you" (from .word) overlaps with correct word "you?" after stripping punctuation
-    const lessonWords: LessonWordData[] = [
+    const lessonWords =[
       {
         alternativeTranslations: [],
         audioUrl: null,
@@ -763,10 +758,10 @@ describe(prepareActivityData, () => {
         },
       ],
       title: "Distractor Dedup",
-    } satisfies ActivityWithSteps;
+    };
 
     // Two lesson words produce distractors "tu" and "tu?" after splitting
-    const lessonWords: LessonWordData[] = [
+    const lessonWords =[
       {
         alternativeTranslations: [],
         audioUrl: null,
@@ -850,7 +845,7 @@ describe(prepareActivityData, () => {
         },
       ],
       title: "Sort Order",
-    } satisfies ActivityWithSteps;
+    };
 
     const result = prepareActivityData(activity, [], []);
     const step = result.steps[0];
@@ -887,7 +882,7 @@ describe(prepareActivityData, () => {
         },
       ],
       title: "Fill Blank",
-    } satisfies ActivityWithSteps;
+    };
 
     const result = prepareActivityData(activity, [], []);
     const step = result.steps[0];
@@ -926,7 +921,7 @@ describe(prepareActivityData, () => {
         },
       ],
       title: "Match Columns",
-    } satisfies ActivityWithSteps;
+    };
 
     const result = prepareActivityData(activity, [], []);
     const step = result.steps[0];
@@ -958,7 +953,7 @@ describe(prepareActivityData, () => {
         },
       ],
       title: "Static",
-    } satisfies ActivityWithSteps;
+    };
 
     const result = prepareActivityData(activity, [], []);
     const step = result.steps[0];

--- a/apps/main/src/data/chapters/get-chapter-for-generation.ts
+++ b/apps/main/src/data/chapters/get-chapter-for-generation.ts
@@ -3,28 +3,9 @@ import { prisma } from "@zoonk/db";
 
 export async function getChapterForGeneration(chapterId: number) {
   return prisma.chapter.findUnique({
-    select: {
-      _count: {
-        select: {
-          lessons: true,
-        },
-      },
-      course: {
-        select: {
-          slug: true,
-          targetLanguage: true,
-          title: true,
-        },
-      },
-      description: true,
-      generationRunId: true,
-      generationStatus: true,
-      id: true,
-      language: true,
-      organizationId: true,
-      position: true,
-      slug: true,
-      title: true,
+    include: {
+      _count: { select: { lessons: true } },
+      course: true,
     },
     where: { id: chapterId },
   });

--- a/apps/main/src/data/chapters/get-chapter.ts
+++ b/apps/main/src/data/chapters/get-chapter.ts
@@ -2,49 +2,23 @@ import "server-only";
 import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
-export type ChapterWithDetails = {
-  id: number;
-  slug: string;
-  title: string;
-  description: string;
-  position: number;
-  course: {
-    slug: string;
-    title: string;
-  };
-};
-
-const cachedGetChapter = cache(
-  async (
-    brandSlug: string,
-    courseSlug: string,
-    chapterSlug: string,
-  ): Promise<ChapterWithDetails | null> =>
-    prisma.chapter.findFirst({
-      select: {
-        course: { select: { slug: true, title: true } },
-        description: true,
-        id: true,
-        position: true,
-        slug: true,
-        title: true,
-      },
-      where: {
-        course: {
-          isPublished: true,
-          organization: { kind: "brand", slug: brandSlug },
-          slug: courseSlug,
-        },
+const cachedGetChapter = cache(async (brandSlug: string, courseSlug: string, chapterSlug: string) =>
+  prisma.chapter.findFirst({
+    include: { course: true },
+    where: {
+      course: {
         isPublished: true,
-        slug: chapterSlug,
+        organization: { kind: "brand", slug: brandSlug },
+        slug: courseSlug,
       },
-    }),
+      isPublished: true,
+      slug: chapterSlug,
+    },
+  }),
 );
 
-export function getChapter(params: {
-  brandSlug: string;
-  chapterSlug: string;
-  courseSlug: string;
-}): Promise<ChapterWithDetails | null> {
+export function getChapter(params: { brandSlug: string; chapterSlug: string; courseSlug: string }) {
   return cachedGetChapter(params.brandSlug, params.courseSlug, params.chapterSlug);
 }
+
+export type ChapterWithDetails = NonNullable<Awaited<ReturnType<typeof getChapter>>>;

--- a/apps/main/src/data/chapters/list-course-chapters.ts
+++ b/apps/main/src/data/chapters/list-course-chapters.ts
@@ -1,32 +1,15 @@
 import "server-only";
-import { type GenerationStatus, prisma } from "@zoonk/db";
+import { type Chapter, prisma } from "@zoonk/db";
 import { cache } from "react";
 
-export type ChapterForList = {
-  id: number;
-  slug: string;
-  title: string;
-  description: string;
-  position: number;
-  generationStatus: GenerationStatus;
-};
-
 const cachedListCourseChapters = cache(
-  async (courseId: number): Promise<ChapterForList[]> =>
+  async (courseId: number): Promise<Chapter[]> =>
     prisma.chapter.findMany({
       orderBy: { position: "asc" },
-      select: {
-        description: true,
-        generationStatus: true,
-        id: true,
-        position: true,
-        slug: true,
-        title: true,
-      },
       where: { courseId, isPublished: true },
     }),
 );
 
-export function listCourseChapters(params: { courseId: number }): Promise<ChapterForList[]> {
+export function listCourseChapters(params: { courseId: number }): Promise<Chapter[]> {
   return cachedListCourseChapters(params.courseId);
 }

--- a/apps/main/src/data/courses/course-suggestions.test.ts
+++ b/apps/main/src/data/courses/course-suggestions.test.ts
@@ -247,7 +247,7 @@ describe("course-suggestions", () => {
 
     const result = await getCourseSuggestionById(item.id);
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       description: "Test description",
       generationRunId: null,
       generationStatus: "pending",
@@ -282,7 +282,7 @@ describe("course-suggestions", () => {
 
     const result = await getCourseSuggestionBySlug({ language, slug });
 
-    expect(result).toEqual({ id: item.id });
+    expect(result).toMatchObject({ id: item.id });
   });
 
   test("getCourseSuggestionBySlug distinguishes between languages", async () => {
@@ -309,8 +309,8 @@ describe("course-suggestions", () => {
     const enResult = await getCourseSuggestionBySlug({ language: "en", slug });
     const ptResult = await getCourseSuggestionBySlug({ language: "pt", slug });
 
-    expect(enResult).toEqual({ id: enItem.id });
-    expect(ptResult).toEqual({ id: ptItem.id });
+    expect(enResult).toMatchObject({ id: enItem.id });
+    expect(ptResult).toMatchObject({ id: ptItem.id });
     expect(enResult?.id).not.toBe(ptResult?.id);
   });
 });

--- a/apps/main/src/data/courses/course-suggestions.ts
+++ b/apps/main/src/data/courses/course-suggestions.ts
@@ -156,28 +156,8 @@ export async function generateCourseSuggestions({
   });
 }
 
-export async function getCourseSuggestionById(
-  id: number,
-): Promise<Pick<
-  CourseSuggestion,
-  | "description"
-  | "generationRunId"
-  | "generationStatus"
-  | "language"
-  | "slug"
-  | "targetLanguage"
-  | "title"
-> | null> {
+export async function getCourseSuggestionById(id: number): Promise<CourseSuggestion | null> {
   return prisma.courseSuggestion.findUnique({
-    select: {
-      description: true,
-      generationRunId: true,
-      generationStatus: true,
-      language: true,
-      slug: true,
-      targetLanguage: true,
-      title: true,
-    },
     where: { id },
   });
 }
@@ -188,9 +168,8 @@ export async function getCourseSuggestionBySlug({
 }: {
   slug: string;
   language: string;
-}): Promise<Pick<CourseSuggestion, "id"> | null> {
+}): Promise<CourseSuggestion | null> {
   return prisma.courseSuggestion.findUnique({
-    select: { id: true },
     where: { languageSlug: { language, slug } },
   });
 }

--- a/apps/main/src/data/courses/find-existing-course.test.ts
+++ b/apps/main/src/data/courses/find-existing-course.test.ts
@@ -50,7 +50,7 @@ describe(findExistingCourse, () => {
 
     expect(result.error).toBeNull();
 
-    expect(result.data).toEqual({
+    expect(result.data).toMatchObject({
       _count: {
         alternativeTitles: 0,
         categories: 0,
@@ -88,7 +88,7 @@ describe(findExistingCourse, () => {
 
     expect(result.error).toBeNull();
 
-    expect(result.data).toEqual({
+    expect(result.data).toMatchObject({
       _count: {
         alternativeTitles: 1,
         categories: 0,

--- a/apps/main/src/data/lessons/get-lesson-for-generation.ts
+++ b/apps/main/src/data/lessons/get-lesson-for-generation.ts
@@ -3,19 +3,10 @@ import { prisma } from "@zoonk/db";
 
 export async function getLessonForGeneration(lessonId: number) {
   return prisma.lesson.findUnique({
-    select: {
+    include: {
       chapter: {
-        select: {
-          course: { select: { slug: true } },
-          slug: true,
-        },
+        include: { course: true },
       },
-      description: true,
-      generationRunId: true,
-      generationStatus: true,
-      id: true,
-      slug: true,
-      title: true,
     },
     where: { id: lessonId },
   });

--- a/apps/main/src/data/lessons/list-chapter-lessons.ts
+++ b/apps/main/src/data/lessons/list-chapter-lessons.ts
@@ -1,32 +1,15 @@
 import "server-only";
-import { type GenerationStatus, prisma } from "@zoonk/db";
+import { type Lesson, prisma } from "@zoonk/db";
 import { cache } from "react";
 
-export type LessonForList = {
-  id: number;
-  slug: string;
-  title: string;
-  description: string;
-  position: number;
-  generationStatus: GenerationStatus;
-};
-
 const cachedListChapterLessons = cache(
-  async (chapterId: number): Promise<LessonForList[]> =>
+  async (chapterId: number): Promise<Lesson[]> =>
     prisma.lesson.findMany({
       orderBy: { position: "asc" },
-      select: {
-        description: true,
-        generationStatus: true,
-        id: true,
-        position: true,
-        slug: true,
-        title: true,
-      },
       where: { chapterId, isPublished: true },
     }),
 );
 
-export function listChapterLessons(params: { chapterId: number }): Promise<LessonForList[]> {
+export function listChapterLessons(params: { chapterId: number }): Promise<Lesson[]> {
   return cachedListChapterLessons(params.chapterId);
 }

--- a/apps/main/src/data/progress/get-belt-level.ts
+++ b/apps/main/src/data/progress/get-belt-level.ts
@@ -16,7 +16,6 @@ export const getBeltLevel = cache(async (headers?: Headers): Promise<BeltLevelRe
 
   const { data: progress, error } = await safeAsync(() =>
     prisma.userProgress.findUnique({
-      select: { totalBrainPower: true },
       where: { userId },
     }),
   );

--- a/apps/main/src/data/progress/get-bp-history.ts
+++ b/apps/main/src/data/progress/get-bp-history.ts
@@ -40,7 +40,6 @@ async function fetchDailyBpData(
   const result = await safeAsync(() =>
     prisma.dailyProgress.findMany({
       orderBy: { date: "asc" },
-      select: { brainPowerEarned: true, date: true },
       where: { date: { gte: start, lte: end }, userId },
     }),
   );
@@ -90,7 +89,6 @@ function getPreviousPeriodTotal(previousData: RawDataPoint[] | null): number | n
 async function hasEarlierData(userId: number, beforeDate: Date): Promise<boolean> {
   const { data } = await safeAsync(() =>
     prisma.dailyProgress.findFirst({
-      select: { id: true },
       where: { date: { lt: beforeDate }, userId },
     }),
   );
@@ -117,7 +115,6 @@ const cachedGetBpHistory = cache(
       fetchDailyBpData(userId, previous.start, previous.end),
       safeAsync(() =>
         prisma.userProgress.findUnique({
-          select: { totalBrainPower: true },
           where: { userId },
         }),
       ),

--- a/apps/main/src/data/progress/get-energy-history.ts
+++ b/apps/main/src/data/progress/get-energy-history.ts
@@ -128,7 +128,6 @@ function getPreviousAverage(
 async function hasEarlierData(userId: number, beforeDate: Date): Promise<boolean> {
   const { data } = await safeAsync(() =>
     prisma.dailyProgress.findFirst({
-      select: { id: true },
       where: { date: { lt: beforeDate }, userId },
     }),
   );
@@ -200,7 +199,6 @@ async function fetchDailyData(
   const result = await safeAsync(() =>
     prisma.dailyProgress.findMany({
       orderBy: { date: "asc" },
-      select: { date: true, energyAtEnd: true },
       where: { date: { gte: start, lte: end }, userId },
     }),
   );

--- a/apps/main/src/data/progress/get-energy-level.ts
+++ b/apps/main/src/data/progress/get-energy-level.ts
@@ -21,7 +21,6 @@ export const getEnergyLevel = cache(
 
     const { data: progress, error } = await safeAsync(() =>
       prisma.userProgress.findUnique({
-        select: { currentEnergy: true, lastActiveAt: true },
         where: { userId },
       }),
     );

--- a/apps/main/src/data/progress/get-next-lesson-id.ts
+++ b/apps/main/src/data/progress/get-next-lesson-id.ts
@@ -8,13 +8,9 @@ import { safeAsync } from "@zoonk/utils/error";
 export async function getNextLessonId(activityId: bigint): Promise<number | null> {
   const { data: activity, error } = await safeAsync(() =>
     prisma.activity.findUnique({
-      select: {
+      include: {
         lesson: {
-          select: {
-            chapter: { select: { courseId: true, id: true, position: true } },
-            id: true,
-            position: true,
-          },
+          include: { chapter: true },
         },
       },
       where: { id: activityId },
@@ -31,7 +27,6 @@ export async function getNextLessonId(activityId: bigint): Promise<number | null
   const { data: nextLesson } = await safeAsync(() =>
     prisma.lesson.findFirst({
       orderBy: [{ chapter: { position: "asc" } }, { position: "asc" }],
-      select: { id: true },
       where: {
         OR: [
           {

--- a/apps/main/src/data/progress/get-score-history.ts
+++ b/apps/main/src/data/progress/get-score-history.ts
@@ -59,7 +59,6 @@ async function fetchDailyData(
   const result = await safeAsync(() =>
     prisma.dailyProgress.findMany({
       orderBy: { date: "asc" },
-      select: { correctAnswers: true, date: true, incorrectAnswers: true },
       where: { date: { gte: start, lte: end }, userId },
     }),
   );
@@ -115,7 +114,6 @@ function getPreviousAverage(
 async function hasEarlierScoreData(userId: number, beforeDate: Date): Promise<boolean> {
   const { data } = await safeAsync(() =>
     prisma.dailyProgress.findFirst({
-      select: { id: true },
       where: {
         OR: [{ correctAnswers: { gt: 0 } }, { incorrectAnswers: { gt: 0 } }],
         date: { lt: beforeDate },

--- a/apps/main/src/data/sitemaps/chapters.ts
+++ b/apps/main/src/data/sitemaps/chapters.ts
@@ -23,17 +23,10 @@ export async function listSitemapChapters(page: number): Promise<
   }[]
 > {
   const chapters = await prisma.chapter.findMany({
-    orderBy: { id: "asc" },
-    select: {
-      course: {
-        select: {
-          organization: { select: { slug: true } },
-          slug: true,
-        },
-      },
-      slug: true,
-      updatedAt: true,
+    include: {
+      course: { include: { organization: true } },
     },
+    orderBy: { id: "asc" },
     skip: page * SITEMAP_BATCH_SIZE,
     take: SITEMAP_BATCH_SIZE,
     where: {

--- a/apps/main/src/data/sitemaps/courses.ts
+++ b/apps/main/src/data/sitemaps/courses.ts
@@ -20,12 +20,8 @@ export async function listSitemapCourses(page: number): Promise<
   }[]
 > {
   const courses = await prisma.course.findMany({
+    include: { organization: true },
     orderBy: { id: "asc" },
-    select: {
-      organization: { select: { slug: true } },
-      slug: true,
-      updatedAt: true,
-    },
     skip: page * SITEMAP_BATCH_SIZE,
     take: SITEMAP_BATCH_SIZE,
     where: {

--- a/apps/main/src/data/sitemaps/lessons.ts
+++ b/apps/main/src/data/sitemaps/lessons.ts
@@ -27,22 +27,14 @@ export async function listSitemapLessons(page: number): Promise<
   }[]
 > {
   const lessons = await prisma.lesson.findMany({
-    orderBy: { id: "asc" },
-    select: {
+    include: {
       chapter: {
-        select: {
-          course: {
-            select: {
-              organization: { select: { slug: true } },
-              slug: true,
-            },
-          },
-          slug: true,
+        include: {
+          course: { include: { organization: true } },
         },
       },
-      slug: true,
-      updatedAt: true,
     },
+    orderBy: { id: "asc" },
     skip: page * SITEMAP_BATCH_SIZE,
     take: SITEMAP_BATCH_SIZE,
     where: {

--- a/packages/core/src/activities/find-last-completed.ts
+++ b/packages/core/src/activities/find-last-completed.ts
@@ -46,40 +46,27 @@ export async function findLastCompleted(
 ): Promise<LastCompletedActivity | null> {
   const { data: progress, error } = await safeAsync(() =>
     prisma.activityProgress.findFirst({
+      include: {
+        activity: {
+          include: {
+            lesson: {
+              include: {
+                chapter: {
+                  include: {
+                    course: { include: { organization: true } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
       orderBy: [
         { completedAt: "desc" },
         { activity: { lesson: { chapter: { position: "desc" } } } },
         { activity: { lesson: { position: "desc" } } },
         { activity: { position: "desc" } },
       ],
-      select: {
-        activity: {
-          select: {
-            lesson: {
-              select: {
-                chapter: {
-                  select: {
-                    course: {
-                      select: {
-                        id: true,
-                        organization: { select: { slug: true } },
-                        slug: true,
-                      },
-                    },
-                    id: true,
-                    position: true,
-                    slug: true,
-                  },
-                },
-                id: true,
-                position: true,
-                slug: true,
-              },
-            },
-            position: true,
-          },
-        },
-      },
       where: {
         activity: {
           isPublished: true,

--- a/packages/core/src/activities/get-next-activity-in-course.ts
+++ b/packages/core/src/activities/get-next-activity-in-course.ts
@@ -27,26 +27,16 @@ const cachedGetNextActivity = cache(
   ): Promise<NextActivityInCourse | null> => {
     const { data: activity, error } = await safeAsync(() =>
       prisma.activity.findFirst({
+        include: {
+          lesson: {
+            include: { chapter: true },
+          },
+        },
         orderBy: [
           { lesson: { chapter: { position: "asc" } } },
           { lesson: { position: "asc" } },
           { position: "asc" },
         ],
-        select: {
-          id: true,
-          kind: true,
-          lesson: {
-            select: {
-              chapter: { select: { id: true, slug: true } },
-              description: true,
-              id: true,
-              slug: true,
-              title: true,
-            },
-          },
-          position: true,
-          title: true,
-        },
         where: {
           OR: [
             {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -35,11 +35,14 @@ export type {
   Invitation,
   Lesson,
   LessonKind,
+  LessonSentence,
+  LessonWord,
   Member,
   Organization,
   RateLimit,
   SearchPrompt,
   SearchPromptSuggestion,
+  Sentence,
   Session,
   Step,
   StepAttempt,
@@ -50,6 +53,7 @@ export type {
   UserLearningProfile,
   UserProgress,
   Verification,
+  Word,
 } from "./generated/prisma/client";
 
 export type { BatchPayload } from "./generated/prisma/internal/prismaNamespace";


### PR DESCRIPTION
## Summary

- Remove `select` from ~40 Prisma queries across main, editor, api apps and core package
- Remove ~15 manually defined types (`ChapterForList`, `LessonForList`, `ActivityForList`, `CourseWithDetails`, `LessonWithDetails`, `ChapterWithDetails`, etc.) that duplicated Prisma query shapes
- Convert relation queries from top-level `select` to `include`
- Derive exported types from query return types using `NonNullable<Awaited<ReturnType<...>>>`
- Export `Word`, `Sentence`, `LessonWord`, `LessonSentence` from `@zoonk/db`
- Add Prisma query conventions to CLAUDE.md

52 files changed, 184 insertions, 582 deletions.

## Test plan

- [x] `pnpm typecheck` passes (main, api, core, editor)
- [x] `pnpm test` — all 11 suites pass
- [x] `pnpm --filter main build`, `pnpm --filter editor build`, `pnpm --filter api build`
- [x] `pnpm --filter main e2e` (375 passed, 4 pre-existing subscription failures)
- [x] `pnpm --filter editor e2e` (193 passed)
- [x] `pnpm --filter api e2e` (56 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored Prisma queries to return full models and use include for relations, removing broad select usage. This simplifies types, reduces maintenance, and keeps behavior the same.

- **Refactors**
  - Removed select from queries and used include for relations
  - Replaced ~15 manual query-shape types with Prisma types or derived return types
  - Exported Word, Sentence, LessonWord, and LessonSentence from @zoonk/db
  - Added Prisma query guidelines to AGENTS.md
  - Fixed formatting

- **Migration**
  - Stop using manual types like ChapterForList/LessonForList; use Prisma model types or derive from query functions
  - Use include for relations and omit for large columns when needed
  - Update tests to use toMatchObject when asserting partial fields

<sup>Written for commit 605a22db96352ffcf0090cfe0291b949f12e05c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

