### PR TITLE
test(e2e): resolve flaky tests across main and editor apps

### DIFF
--- a/apps/editor/e2e/command-palette.test.ts
+++ b/apps/editor/e2e/command-palette.test.ts
@@ -271,7 +271,8 @@ test.describe("Command Palette - Course Search", () => {
 
     await dialog.getByPlaceholder(/search/i).fill(course.title);
 
-    await expect(dialog.getByText(course.title)).toBeVisible();
+    // Search results depend on API response which can be slow under parallel test load
+    await expect(dialog.getByText(course.title)).toBeVisible({ timeout: 10_000 });
   });
 });
 

--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -39,8 +39,7 @@ function getModifierKey(): "Meta" | "Control" {
 test.describe("Command Palette - Unauthenticated", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
-    // Wait for the page to be fully interactive before testing keyboard shortcuts
-    // Scoped to navigation to avoid strict mode violation
+    await page.waitForLoadState("networkidle");
     await expect(
       page.getByRole("navigation").getByRole("button", { name: /search/i }),
     ).toBeVisible();

--- a/apps/main/e2e/course-chapters.test.ts
+++ b/apps/main/e2e/course-chapters.test.ts
@@ -7,7 +7,7 @@ import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
 
-const uniqueId = randomUUID().slice(0, 8);
+const uniqueId = randomUUID();
 
 let courseUrl: string;
 let ptCourseUrl: string;

--- a/apps/main/e2e/step-visual-content.test.ts
+++ b/apps/main/e2e/step-visual-content.test.ts
@@ -270,6 +270,7 @@ test.describe("Step Visual Content", () => {
     await expect(page.getByText(/1 \/ 2/)).toBeVisible();
 
     // Keyboard navigation still works
+    await page.waitForLoadState("networkidle");
     await page.keyboard.press("ArrowRight");
 
     await expect(
@@ -355,6 +356,7 @@ test.describe("Step Visual Content", () => {
     await expect(page.getByText(/1 \/ 2/)).toBeVisible();
 
     // Keyboard navigation still works
+    await page.waitForLoadState("networkidle");
     await page.keyboard.press("ArrowRight");
 
     await expect(
@@ -480,6 +482,7 @@ test.describe("Step Visual Content", () => {
     await expect(page.getByText(/1 \/ 2/)).toBeVisible();
 
     // Keyboard navigation still works
+    await page.waitForLoadState("networkidle");
     await page.keyboard.press("ArrowRight");
 
     await expect(
@@ -599,6 +602,7 @@ test.describe("Step Visual Content", () => {
     await expect(page.getByText(/1 \/ 2/)).toBeVisible();
 
     // Keyboard navigation still works
+    await page.waitForLoadState("networkidle");
     await page.keyboard.press("ArrowRight");
 
     await expect(
@@ -776,6 +780,7 @@ test.describe("Step Visual Content", () => {
     await expect(page.getByText(/1 \/ 2/)).toBeVisible();
 
     // Keyboard navigation still works
+    await page.waitForLoadState("networkidle");
     await page.keyboard.press("ArrowRight");
 
     await expect(


### PR DESCRIPTION
## Summary

- **continue-learning-revalidation**: `toPass()` retries ArrowRight until hydration completes; `waitForResponse` on the server action POST replaces unreliable `networkidle`/badge checks — waits for exactly the right thing with no arbitrary timeout
- **course-chapters**: full UUID instead of truncated 8 chars to eliminate slug collisions after the uniqueness constraint change
- **command-palette (main)**: `networkidle` in `beforeEach` ensures React hydration before `Cmd+K`/`Ctrl+K` keyboard shortcuts
- **step-visual-content**: `networkidle` before all 5 ArrowRight presses in "clicking visual does not navigate" tests
- **command-palette (editor)**: 10s timeout for search API assertion under parallel load

## Test plan

- [x] Each fixed test file passes 3+ consecutive runs in isolation
- [x] Full `main` e2e suite (379 tests): 5 consecutive runs, 0 failures
- [x] Full `editor` e2e suite (193 tests): 3 consecutive runs, 0 failures
- [x] Full `api` e2e suite (56 tests): 3 consecutive runs, 0 failures
- [x] `pnpm turbo quality:fix` and `pnpm typecheck` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky e2e tests in main and editor by waiting for hydration/network idle and server action responses. Stabilizes keyboard navigation and search assertions under parallel load.

- **Bug Fixes**
  - continue-learning-revalidation: wrap ArrowRight in toPass; waitForResponse on POST to server action; wait for networkidle after Home nav
  - command-palette (main): wait for networkidle in beforeEach so keyboard shortcuts are reliable
  - step-visual-content: wait for networkidle before all ArrowRight presses
  - course-chapters: use full UUID to prevent slug collisions
  - command-palette (editor): increase search result visibility timeout to 10s

<sup>Written for commit 7071c901581ca2ad79f58cfea30ed77105498b55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

