### PR TITLE
feat(core): remove language filter from course search

### DIFF
--- a/apps/api/src/lib/openapi/schemas/courses.ts
+++ b/apps/api/src/lib/openapi/schemas/courses.ts
@@ -5,8 +5,9 @@ export const courseSearchQuerySchema = z
     cursor: z.string().optional().meta({ description: "Pagination cursor" }),
     language: z
       .string()
-      .min(2, "Language code is required")
-      .meta({ description: "Language code", example: "en" }),
+      .min(2, "Language code must be at least 2 characters")
+      .optional()
+      .meta({ description: "Language code for sorting preference", example: "en" }),
     limit: z.coerce
       .number()
       .int()

--- a/apps/main/src/app/[locale]/(catalog)/_components/search-courses-action.ts
+++ b/apps/main/src/app/[locale]/(catalog)/_components/search-courses-action.ts
@@ -8,12 +8,13 @@ export type CourseSearchResult = {
   description: string | null;
   slug: string;
   imageUrl: string | null;
+  language: string;
   brandSlug: string;
 };
 
 export async function searchCoursesAction(params: {
   query: string;
-  language: string;
+  language?: string;
 }): Promise<CourseSearchResult[]> {
   const courses = await searchCourses(params);
 
@@ -22,6 +23,7 @@ export async function searchCoursesAction(params: {
     description: course.description,
     id: course.id,
     imageUrl: course.imageUrl,
+    language: course.language,
     slug: course.slug,
     title: course.title,
   }));


### PR DESCRIPTION
## Summary

- Remove language filter from `searchCourses` so results include all languages (not just the user's locale)
- Sort results so the user's language appears first when provided
- Make `language` optional in `searchCoursesAction`
- Add `language` field to `CourseSearchResult` type

## Test plan

- [x] Integration tests updated: language sorting and no-language search
- [x] `pnpm test` — all passing
- [x] `pnpm typecheck` — clean
- [x] `pnpm --filter main build` — clean
- [ ] Update API e2e test that asserts language filtering (`course-search.test.ts:138`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Course search now returns results from all languages and, if a language is provided, sorts those results to show that language first. The API endpoint and OpenAPI schema now treat language as optional, and each result includes its language.

- **New Features**
  - Removed language filter; searches return all languages.
  - Sorts results so the provided language appears first.
  - Made language optional in core search, API endpoint, and searchCoursesAction; added language to CourseSearchResult.

- **Migration**
  - If you relied on server-side language filtering, filter on the client if needed.
  - Update consumers to handle optional language and the new language field.
  - Regenerate API clients if you use the OpenAPI schema.

<sup>Written for commit ca05567f6b022ff145852d5222729ce71f900f26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

