### PR TITLE
fix(core): forbid dots in usernames

### DIFF
--- a/apps/api/messages/en.po
+++ b/apps/api/messages/en.po
@@ -103,11 +103,6 @@ msgid "{username} is available"
 msgstr "{username} is available"
 
 #: src/app/auth/setup/setup-form.tsx
-msgctxt "aW6DOm"
-msgid "3-30 characters. Letters, numbers, underscores, and dots only."
-msgstr "3-30 characters. Letters, numbers, underscores, and dots only."
-
-#: src/app/auth/setup/setup-form.tsx
 msgctxt "HAlOn1"
 msgid "Name"
 msgstr "Name"
@@ -121,6 +116,11 @@ msgstr "Username"
 msgctxt "R76cpj"
 msgid "{username} is already taken"
 msgstr "{username} is already taken"
+
+#: src/app/auth/setup/setup-form.tsx
+msgctxt "vLl7z0"
+msgid "3-30 characters. Letters, numbers, and underscores only."
+msgstr "3-30 characters. Letters, numbers, and underscores only."
 
 #: src/app/auth/setup/setup-form.tsx
 msgctxt "XLl/pd"

--- a/apps/api/messages/es.po
+++ b/apps/api/messages/es.po
@@ -103,11 +103,6 @@ msgid "{username} is available"
 msgstr "{username} está disponible"
 
 #: src/app/auth/setup/setup-form.tsx
-msgctxt "aW6DOm"
-msgid "3-30 characters. Letters, numbers, underscores, and dots only."
-msgstr "3-30 caracteres. Solo letras, números, guiones bajos y puntos."
-
-#: src/app/auth/setup/setup-form.tsx
 msgctxt "HAlOn1"
 msgid "Name"
 msgstr "Nombre"
@@ -121,6 +116,11 @@ msgstr "Nombre de usuario"
 msgctxt "R76cpj"
 msgid "{username} is already taken"
 msgstr "{username} ya está en uso"
+
+#: src/app/auth/setup/setup-form.tsx
+msgctxt "vLl7z0"
+msgid "3-30 characters. Letters, numbers, and underscores only."
+msgstr "3-30 caracteres. Solo letras, números y guiones bajos."
 
 #: src/app/auth/setup/setup-form.tsx
 msgctxt "XLl/pd"

--- a/apps/api/messages/pt.po
+++ b/apps/api/messages/pt.po
@@ -103,11 +103,6 @@ msgid "{username} is available"
 msgstr "{username} está disponível"
 
 #: src/app/auth/setup/setup-form.tsx
-msgctxt "aW6DOm"
-msgid "3-30 characters. Letters, numbers, underscores, and dots only."
-msgstr "3-30 caracteres. Apenas letras, números, underscores e pontos."
-
-#: src/app/auth/setup/setup-form.tsx
 msgctxt "HAlOn1"
 msgid "Name"
 msgstr "Nome"
@@ -121,6 +116,11 @@ msgstr "Nome de usuário"
 msgctxt "R76cpj"
 msgid "{username} is already taken"
 msgstr "{username} já está em uso"
+
+#: src/app/auth/setup/setup-form.tsx
+msgctxt "vLl7z0"
+msgid "3-30 characters. Letters, numbers, and underscores only."
+msgstr "3-30 caracteres. Apenas letras, números e sublinhados."
 
 #: src/app/auth/setup/setup-form.tsx
 msgctxt "XLl/pd"

--- a/apps/api/src/app/auth/setup/setup-form.tsx
+++ b/apps/api/src/app/auth/setup/setup-form.tsx
@@ -50,7 +50,7 @@ function UsernameDescription({ status, username }: { status: UsernameStatus; use
         "text-muted-foreground": status === "idle",
       })}
     >
-      {t("3-30 characters. Letters, numbers, underscores, and dots only.")}
+      {t("3-30 characters. Letters, numbers, and underscores only.")}
     </p>
   );
 }

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1154,11 +1154,6 @@ msgid "{username} is available"
 msgstr "{username} is available"
 
 #: src/app/[locale]/(settings)/profile/profile-form.tsx
-msgctxt "aW6DOm"
-msgid "3-30 characters. Letters, numbers, underscores, and dots only."
-msgstr "3-30 characters. Letters, numbers, underscores, and dots only."
-
-#: src/app/[locale]/(settings)/profile/profile-form.tsx
 msgctxt "HAlOn1"
 msgid "Name"
 msgstr "Name"
@@ -1172,6 +1167,11 @@ msgstr "Username"
 msgctxt "R76cpj"
 msgid "{username} is already taken"
 msgstr "{username} is already taken"
+
+#: src/app/[locale]/(settings)/profile/profile-form.tsx
+msgctxt "vLl7z0"
+msgid "3-30 characters. Letters, numbers, and underscores only."
+msgstr "3-30 characters. Letters, numbers, and underscores only."
 
 #: src/app/[locale]/(settings)/profile/profile-form.tsx
 msgctxt "VT+G/7"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1154,11 +1154,6 @@ msgid "{username} is available"
 msgstr "{username} está disponible"
 
 #: src/app/[locale]/(settings)/profile/profile-form.tsx
-msgctxt "aW6DOm"
-msgid "3-30 characters. Letters, numbers, underscores, and dots only."
-msgstr "3-30 caracteres. Solo letras, números, guiones bajos y puntos."
-
-#: src/app/[locale]/(settings)/profile/profile-form.tsx
 msgctxt "HAlOn1"
 msgid "Name"
 msgstr "Nombre"
@@ -1172,6 +1167,11 @@ msgstr "Nombre de usuario"
 msgctxt "R76cpj"
 msgid "{username} is already taken"
 msgstr "{username} ya está en uso"
+
+#: src/app/[locale]/(settings)/profile/profile-form.tsx
+msgctxt "vLl7z0"
+msgid "3-30 characters. Letters, numbers, and underscores only."
+msgstr "3-30 caracteres. Solo letras, números y guiones bajos."
 
 #: src/app/[locale]/(settings)/profile/profile-form.tsx
 msgctxt "VT+G/7"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1154,11 +1154,6 @@ msgid "{username} is available"
 msgstr "{username} está disponível"
 
 #: src/app/[locale]/(settings)/profile/profile-form.tsx
-msgctxt "aW6DOm"
-msgid "3-30 characters. Letters, numbers, underscores, and dots only."
-msgstr "3-30 caracteres. Apenas letras, números, underscores e pontos."
-
-#: src/app/[locale]/(settings)/profile/profile-form.tsx
 msgctxt "HAlOn1"
 msgid "Name"
 msgstr "Nome"
@@ -1172,6 +1167,11 @@ msgstr "Nome de usuário"
 msgctxt "R76cpj"
 msgid "{username} is already taken"
 msgstr "{username} já está em uso"
+
+#: src/app/[locale]/(settings)/profile/profile-form.tsx
+msgctxt "vLl7z0"
+msgid "3-30 characters. Letters, numbers, and underscores only."
+msgstr "3-30 caracteres. Apenas letras, números e sublinhados."
 
 #: src/app/[locale]/(settings)/profile/profile-form.tsx
 msgctxt "VT+G/7"

--- a/apps/main/src/app/[locale]/(settings)/profile/profile-form.tsx
+++ b/apps/main/src/app/[locale]/(settings)/profile/profile-form.tsx
@@ -49,14 +49,14 @@ function UsernameStatus({ status, username }: { status: UsernameStatusType; user
   if (status === "invalid") {
     return (
       <p className="text-destructive text-sm">
-        {t("3-30 characters. Letters, numbers, underscores, and dots only.")}
+        {t("3-30 characters. Letters, numbers, and underscores only.")}
       </p>
     );
   }
 
   return (
     <FieldDescription>
-      {t("3-30 characters. Letters, numbers, underscores, and dots only.")}
+      {t("3-30 characters. Letters, numbers, and underscores only.")}
     </FieldDescription>
   );
 }

--- a/i18n.lock
+++ b/i18n.lock
@@ -408,10 +408,10 @@ checksums:
     Your%20name%20and%20username%20as%20they%20appear%20to%20others./singular: b972c833827f90df25a18a0b6616210d
     Checking.../singular: 7fb996bee0359e5dbdd92bd6e147a814
     "%7Busername%7D%20is%20available/singular": 7011c6819f17536a661f82840fe3b4a7
-    3-30%20characters.%20Letters%2C%20numbers%2C%20underscores%2C%20and%20dots%20only./singular: 0122d7cb152edd24492d1a51e9a9c1e5
     Name/singular: 9368b5a047572b6051f334af5aa76819
     Username/singular: 2ee65bc2dd2f12cf2672f95b2a054bf8
     "%7Busername%7D%20is%20already%20taken/singular": dfd79c11a80ade1108d4e6279db2e4aa
+    3-30%20characters.%20Letters%2C%20numbers%2C%20and%20underscores%20only./singular: 702e3ea666b130c40c1fbef34a741cf1
     This%20name%20will%20be%20visible%20to%20other%20users./singular: f09fcb0452297983c7b73c689206fa08
     Failed%20to%20update%20your%20profile.%20Please%20try%20again%20or%20contact%20hello%40zoonk.com/singular: bd7a0ae0d6061d6c480c3f85047b4342
     Save%20changes/singular: 53dd9f4f0a4accc822fa5c1f2f6d118a
@@ -668,10 +668,10 @@ checksums:
     Complete%20your%20profile/singular: 061e1acc1b9ebad9de09fd5626e813c7
     Checking.../singular: 7fb996bee0359e5dbdd92bd6e147a814
     "%7Busername%7D%20is%20available/singular": 7011c6819f17536a661f82840fe3b4a7
-    3-30%20characters.%20Letters%2C%20numbers%2C%20underscores%2C%20and%20dots%20only./singular: 0122d7cb152edd24492d1a51e9a9c1e5
     Name/singular: 9368b5a047572b6051f334af5aa76819
     Username/singular: 2ee65bc2dd2f12cf2672f95b2a054bf8
     "%7Busername%7D%20is%20already%20taken/singular": dfd79c11a80ade1108d4e6279db2e4aa
+    3-30%20characters.%20Letters%2C%20numbers%2C%20and%20underscores%20only./singular: 702e3ea666b130c40c1fbef34a741cf1
     your-username/singular: 84d0eb10ffede02a6737a8d2a7247cf1
     Failed%20to%20set%20up%20your%20profile.%20Please%20try%20again%20or%20contact%20hello%40zoonk.com/singular: f99443e6bfc1663931f4953e6ec3895e
     Continue%20to%20Zoonk/singular: 78daa6a6e9d8cebee3648e542a5698c6

--- a/packages/auth/src/username-validator.test.ts
+++ b/packages/auth/src/username-validator.test.ts
@@ -37,6 +37,15 @@ describe(isUsernameAllowed, () => {
     });
   });
 
+  describe("invalid characters", () => {
+    it("blocks usernames containing dots", () => {
+      expect(isUsernameAllowed("dev.ops")).toBeFalsy();
+      expect(isUsernameAllowed("john.doe")).toBeFalsy();
+      expect(isUsernameAllowed(".leading")).toBeFalsy();
+      expect(isUsernameAllowed("trailing.")).toBeFalsy();
+    });
+  });
+
   describe("valid usernames", () => {
     it("allows common names", () => {
       expect(isUsernameAllowed("johndoe")).toBeTruthy();
@@ -46,9 +55,8 @@ describe(isUsernameAllowed, () => {
       expect(isUsernameAllowed("pierre")).toBeTruthy();
     });
 
-    it("allows usernames with numbers and special chars", () => {
+    it("allows usernames with numbers and underscores", () => {
       expect(isUsernameAllowed("user123")).toBeTruthy();
-      expect(isUsernameAllowed("dev.ops")).toBeTruthy();
       expect(isUsernameAllowed("j_smith")).toBeTruthy();
     });
 

--- a/packages/auth/src/username-validator.ts
+++ b/packages/auth/src/username-validator.ts
@@ -1,5 +1,8 @@
 import { BLOCKED_USERNAMES } from "./blocked-usernames";
 
 export function isUsernameAllowed(username: string): boolean {
+  if (username.includes(".")) {
+    return false;
+  }
   return !BLOCKED_USERNAMES.has(username.toLowerCase());
 }

--- a/packages/core/src/auth/hooks/use-username-availability.ts
+++ b/packages/core/src/auth/hooks/use-username-availability.ts
@@ -7,7 +7,7 @@ export type UsernameStatus = "idle" | "checking" | "available" | "taken" | "inva
 
 export const USERNAME_MIN_LENGTH = 3;
 export const USERNAME_MAX_LENGTH = 30;
-const USERNAME_REGEX = /^[a-z0-9_.]{3,30}$/;
+const USERNAME_REGEX = /^[a-z0-9_]{3,30}$/;
 const DEBOUNCE_MS = 300;
 
 export function useUsernameAvailability(currentUsername?: string | null) {

--- a/packages/utils/src/string.test.ts
+++ b/packages/utils/src/string.test.ts
@@ -8,6 +8,7 @@ import {
   parseNumericId,
   removeAccents,
   replaceNamePlaceholder,
+  toSlug,
 } from "./string";
 
 describe(removeAccents, () => {
@@ -193,6 +194,13 @@ describe(ensureLocaleSuffix, () => {
     expect(ensureLocaleSuffix("machine-learning", "es")).toBe("machine-learning-es");
     expect(ensureLocaleSuffix("machine-learning", "fr")).toBe("machine-learning-fr");
     expect(ensureLocaleSuffix("machine-learning", "ja")).toBe("machine-learning-ja");
+  });
+});
+
+describe(toSlug, () => {
+  test("strips dots from input", () => {
+    expect(toSlug("dev.ops")).toBe("devops");
+    expect(toSlug("john.doe.smith")).toBe("johndoesmith");
   });
 });
 


### PR DESCRIPTION
## Summary

- Remove `.` from client-side username regex and add server-side dot validation
- Update helper text in setup and profile forms to no longer mention dots
- Add tests for dot rejection in usernames and dot stripping in slugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disallow dots in usernames across client and server to keep rules consistent and clearer for users. Adds tests to ensure dotted usernames are rejected and that dots are removed when forming slugs.

- **Bug Fixes**
  - Client: remove dots from username regex and update helper text in setup/profile (EN/ES/PT).
  - Server: reject usernames containing dots in the validator.
  - Tests: add cases for dot rejection and verify toSlug strips dots.

<sup>Written for commit ee1d8d74f8d9443b4127eae53ff84097a7321eb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

