### PR TITLE
refactor(main): add streaming with suspense to eliminate route blocking

### DIFF
--- a/apps/main/src/app/(catalog)/(home)/page.tsx
+++ b/apps/main/src/app/(catalog)/(home)/page.tsx
@@ -1,9 +1,3 @@
-import { getContinueLearning } from "@/data/courses/get-continue-learning";
-import { getBeltLevel } from "@/data/progress/get-belt-level";
-import { getBestDay } from "@/data/progress/get-best-day";
-import { getBestTime } from "@/data/progress/get-best-time";
-import { getEnergyLevel } from "@/data/progress/get-energy-level";
-import { getScore } from "@/data/progress/get-score";
 import { type Metadata } from "next";
 import { getExtracted } from "next-intl/server";
 import { Suspense } from "react";
@@ -20,17 +14,7 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Home() {
-  // Preload data for Suspense boundaries
-  void Promise.all([
-    getContinueLearning(),
-    getEnergyLevel(),
-    getBeltLevel(),
-    getScore(),
-    getBestDay(),
-    getBestTime(),
-  ]);
-
+export default function Home() {
   return (
     <Suspense fallback={<HomeContentSkeleton />}>
       <HomeContent />

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
@@ -7,7 +7,7 @@ import {
   CatalogListItemIndicator,
   CatalogListItemTitle,
 } from "@/components/catalog/catalog-list";
-import { type ActivityKindInfo } from "@/lib/activities";
+import { getActivityKinds } from "@/lib/activities";
 import { getActivityProgress } from "@zoonk/core/progress/activities";
 import { type Activity } from "@zoonk/db";
 import { getExtracted } from "next-intl/server";
@@ -17,7 +17,6 @@ export async function ActivityList({
   brandSlug,
   chapterSlug,
   courseSlug,
-  kindMeta,
   lessonId,
   lessonSlug,
 }: {
@@ -25,7 +24,6 @@ export async function ActivityList({
   brandSlug: string;
   chapterSlug: string;
   courseSlug: string;
-  kindMeta: Map<string, ActivityKindInfo>;
   lessonId: number;
   lessonSlug: string;
 }) {
@@ -34,7 +32,12 @@ export async function ActivityList({
   }
 
   const t = await getExtracted();
-  const completedIds = await getActivityProgress({ lessonId });
+  const [activityKinds, completedIds] = await Promise.all([
+    getActivityKinds(),
+    getActivityProgress({ lessonId }),
+  ]);
+
+  const kindMeta = new Map(activityKinds.map((kind) => [kind.key, kind]));
 
   return (
     <CatalogList>

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/loading.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/loading.tsx
@@ -1,0 +1,9 @@
+import { CatalogPageSkeleton } from "@/components/catalog/catalog-skeletons";
+
+export default function LessonLoading() {
+  return (
+    <main className="flex flex-1 flex-col">
+      <CatalogPageSkeleton listVariant="indicator" showSearch={false} />
+    </main>
+  );
+}

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -1,16 +1,12 @@
 import { CatalogActions } from "@/components/catalog/catalog-actions";
-import {
-  CatalogContainer,
-  CatalogListSkeleton,
-  CatalogToolbar,
-} from "@/components/catalog/catalog-list";
+import { CatalogContainer, CatalogToolbar } from "@/components/catalog/catalog-list";
+import { CatalogListSkeleton } from "@/components/catalog/catalog-skeletons";
 import {
   ContinueActivityLink,
   ContinueActivityLinkSkeleton,
 } from "@/components/catalog/continue-activity-link";
 import { listLessonActivities } from "@/data/activities/list-lesson-activities";
 import { getLesson } from "@/data/lessons/get-lesson";
-import { getActivityKinds } from "@/lib/activities";
 import { getSession } from "@zoonk/core/users/session/get";
 import { type Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
@@ -60,9 +56,6 @@ export default async function LessonPage({
     redirect(`/generate/l/${lesson.id}`);
   }
 
-  const activityKinds = await getActivityKinds();
-  const kindMeta = new Map(activityKinds.map((kind) => [kind.key, kind]));
-
   return (
     <main className="flex flex-1 flex-col">
       <LessonHeader
@@ -86,13 +79,13 @@ export default async function LessonPage({
             kind="lesson"
           />
         </CatalogToolbar>
+
         <Suspense fallback={<CatalogListSkeleton count={activities.length} variant="indicator" />}>
           <ActivityList
             activities={activities}
             brandSlug={brandSlug}
             chapterSlug={chapterSlug}
             courseSlug={courseSlug}
-            kindMeta={kindMeta}
             lessonId={lesson.id}
             lessonSlug={lessonSlug}
           />

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/loading.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/loading.tsx
@@ -1,0 +1,9 @@
+import { CatalogPageSkeleton } from "@/components/catalog/catalog-skeletons";
+
+export default function ChapterLoading() {
+  return (
+    <main className="flex flex-1 flex-col">
+      <CatalogPageSkeleton />
+    </main>
+  );
+}

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -1,9 +1,6 @@
 import { CatalogActions } from "@/components/catalog/catalog-actions";
-import {
-  CatalogContainer,
-  CatalogListSkeleton,
-  CatalogToolbar,
-} from "@/components/catalog/catalog-list";
+import { CatalogContainer, CatalogToolbar } from "@/components/catalog/catalog-list";
+import { CatalogListSkeleton } from "@/components/catalog/catalog-skeletons";
 import {
   ContinueActivityLink,
   ContinueActivityLinkSkeleton,

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/loading.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/loading.tsx
@@ -1,0 +1,9 @@
+import { CatalogPageSkeleton } from "@/components/catalog/catalog-skeletons";
+
+export default function CourseLoading() {
+  return (
+    <main className="flex flex-1 flex-col">
+      <CatalogPageSkeleton />
+    </main>
+  );
+}

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
@@ -1,9 +1,6 @@
 import { CatalogActions } from "@/components/catalog/catalog-actions";
-import {
-  CatalogContainer,
-  CatalogListSkeleton,
-  CatalogToolbar,
-} from "@/components/catalog/catalog-list";
+import { CatalogContainer, CatalogToolbar } from "@/components/catalog/catalog-list";
+import { CatalogListSkeleton } from "@/components/catalog/catalog-skeletons";
 import {
   ContinueActivityLink,
   ContinueActivityLinkSkeleton,

--- a/apps/main/src/app/(catalog)/courses/course-list-skeleton.tsx
+++ b/apps/main/src/app/(catalog)/courses/course-list-skeleton.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+
+const SKELETON_COUNT = 8;
+
+export function CourseListSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+        // oxlint-disable-next-line eslint/no-array-index-key -- static skeleton
+        <div className="flex items-center gap-4 py-2" key={i}>
+          <Skeleton className="size-16 shrink-0 rounded-lg" />
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <Skeleton className="h-4 w-2/3" />
+            <Skeleton className="h-3.5 w-full" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/main/src/app/(catalog)/courses/page.tsx
+++ b/apps/main/src/app/(catalog)/courses/page.tsx
@@ -8,7 +8,9 @@ import {
 } from "@zoonk/ui/components/container";
 import { type Metadata } from "next";
 import { getExtracted, getLocale } from "next-intl/server";
+import { Suspense } from "react";
 import { CourseListClient } from "./course-list-client";
+import { CourseListSkeleton } from "./course-list-skeleton";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted();
@@ -21,10 +23,14 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Courses() {
+async function CourseListContent() {
   const locale = await getLocale();
-  const t = await getExtracted();
   const courses = await listCourses({ language: locale });
+  return <CourseListClient initialCourses={courses} language={locale} limit={LIST_COURSES_LIMIT} />;
+}
+
+export default async function Courses() {
+  const t = await getExtracted();
 
   return (
     <Container variant="list">
@@ -35,7 +41,9 @@ export default async function Courses() {
         </ContainerHeaderGroup>
       </ContainerHeader>
 
-      <CourseListClient initialCourses={courses} language={locale} limit={LIST_COURSES_LIMIT} />
+      <Suspense fallback={<CourseListSkeleton />}>
+        <CourseListContent />
+      </Suspense>
     </Container>
   );
 }

--- a/apps/main/src/app/(catalog)/layout.tsx
+++ b/apps/main/src/app/(catalog)/layout.tsx
@@ -5,14 +5,17 @@ import { Suspense } from "react";
 import { NavbarLinks, NavbarLinksSkeleton } from "./_components/navbar-links";
 import { UserAvatarMenu } from "./_components/user-avatar-menu";
 
-export default async function CatalogLayout({ children }: LayoutProps<"/">) {
+async function NavbarLinksWithAuth() {
   const session = await getSession();
+  return <NavbarLinks isLoggedIn={Boolean(session)} />;
+}
 
+export default function CatalogLayout({ children }: LayoutProps<"/">) {
   return (
     <div className="flex min-h-dvh flex-col">
       <Navbar>
         <Suspense fallback={<NavbarLinksSkeleton />}>
-          <NavbarLinks isLoggedIn={Boolean(session)} />
+          <NavbarLinksWithAuth />
         </Suspense>
 
         <Suspense fallback={<AvatarSkeleton />}>

--- a/apps/main/src/app/(catalog)/layout.tsx
+++ b/apps/main/src/app/(catalog)/layout.tsx
@@ -20,9 +20,7 @@ export default async function CatalogLayout({ children }: LayoutProps<"/">) {
         </Suspense>
       </Navbar>
 
-      <Suspense>
-        <div className="flex flex-1 flex-col">{children}</div>
-      </Suspense>
+      {children}
     </div>
   );
 }

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
@@ -53,7 +53,7 @@ export default async function ActivityPage({ params }: Props) {
     notFound();
   }
 
-  const [activity, lessonWords, lessonSentences, nextActivity] = await Promise.all([
+  const [activity, lessonWords, lessonSentences, nextActivity, session] = await Promise.all([
     getActivity({ lessonId: lesson.id, position: activityPosition }),
     getLessonWords({ lessonId: lesson.id }),
     getLessonSentences({ lessonId: lesson.id }),
@@ -65,6 +65,7 @@ export default async function ActivityPage({ params }: Props) {
       lessonId: lesson.id,
       lessonPosition: lesson.position,
     }),
+    getSession(),
   ]);
 
   if (!activity) {
@@ -80,7 +81,6 @@ export default async function ActivityPage({ params }: Props) {
   }
 
   const serialized = prepareActivityData(activity, lessonWords, lessonSentences);
-  const session = await getSession();
 
   return (
     <ActivityPlayerClient

--- a/apps/main/src/components/catalog/catalog-list.tsx
+++ b/apps/main/src/components/catalog/catalog-list.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Input } from "@zoonk/ui/components/input";
-import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { cn } from "@zoonk/ui/lib/utils";
 import { normalizeString } from "@zoonk/utils/string";
 import { CheckIcon, SearchIcon } from "lucide-react";
@@ -263,54 +262,5 @@ export function CatalogListItemProgress({
     >
       {completed}/{total}
     </span>
-  );
-}
-
-function CatalogListItemSkeleton() {
-  return (
-    <li className="-mx-3 flex items-start gap-3 px-3 py-3.5">
-      <Skeleton className="h-4 w-6 shrink-0" />
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <Skeleton className="h-4 w-3/4" />
-        <Skeleton className="h-3.5 w-full" />
-      </div>
-    </li>
-  );
-}
-
-function CatalogListItemIndicatorSkeleton() {
-  return (
-    <li className="-mx-3 flex items-start gap-3 px-3 py-3.5">
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <Skeleton className="h-4 w-1/3" />
-        <Skeleton className="h-3.5 w-full" />
-      </div>
-      <Skeleton className="size-3.5 shrink-0 self-center rounded-full" />
-    </li>
-  );
-}
-
-export function CatalogListSkeleton({
-  count,
-  search = false,
-  variant = "position",
-}: {
-  count: number;
-  search?: boolean;
-  variant?: "indicator" | "position";
-}) {
-  const ItemSkeleton =
-    variant === "indicator" ? CatalogListItemIndicatorSkeleton : CatalogListItemSkeleton;
-
-  return (
-    <div className="flex flex-col gap-4">
-      {search && <Skeleton className="h-9 w-full rounded-md" />}
-      <ul className="flex flex-col">
-        {Array.from({ length: count }).map((_, i) => (
-          // oxlint-disable-next-line eslint/no-array-index-key -- static skeleton
-          <ItemSkeleton key={i} />
-        ))}
-      </ul>
-    </div>
   );
 }

--- a/apps/main/src/components/catalog/catalog-skeletons.tsx
+++ b/apps/main/src/components/catalog/catalog-skeletons.tsx
@@ -1,0 +1,77 @@
+import { MediaCardSkeleton } from "@zoonk/ui/components/media-card";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { CatalogContainer, CatalogToolbar } from "./catalog-list";
+
+function CatalogListItemSkeleton() {
+  return (
+    <li className="-mx-3 flex items-start gap-3 px-3 py-3.5">
+      <Skeleton className="h-4 w-6 shrink-0" />
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-3.5 w-full" />
+      </div>
+    </li>
+  );
+}
+
+function CatalogListItemIndicatorSkeleton() {
+  return (
+    <li className="-mx-3 flex items-start gap-3 px-3 py-3.5">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <Skeleton className="h-4 w-1/3" />
+        <Skeleton className="h-3.5 w-full" />
+      </div>
+      <Skeleton className="size-3.5 shrink-0 self-center rounded-full" />
+    </li>
+  );
+}
+
+export function CatalogListSkeleton({
+  count,
+  search = false,
+  variant = "position",
+}: {
+  count: number;
+  search?: boolean;
+  variant?: "indicator" | "position";
+}) {
+  const ItemSkeleton =
+    variant === "indicator" ? CatalogListItemIndicatorSkeleton : CatalogListItemSkeleton;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {search && <Skeleton className="h-9 w-full rounded-md" />}
+      <ul className="flex flex-col">
+        {Array.from({ length: count }).map((_, i) => (
+          // oxlint-disable-next-line eslint/no-array-index-key -- static skeleton
+          <ItemSkeleton key={i} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+const DEFAULT_LIST_COUNT = 5;
+
+export function CatalogPageSkeleton({
+  listCount = DEFAULT_LIST_COUNT,
+  listVariant,
+  showSearch = true,
+}: {
+  listCount?: number;
+  listVariant?: "indicator";
+  showSearch?: boolean;
+}) {
+  return (
+    <>
+      <MediaCardSkeleton />
+      <CatalogContainer>
+        <CatalogToolbar>
+          <Skeleton className="h-9 flex-1 rounded-md" />
+          <Skeleton className="size-9 rounded-md" />
+        </CatalogToolbar>
+        <CatalogListSkeleton count={listCount} search={showSearch} variant={listVariant} />
+      </CatalogContainer>
+    </>
+  );
+}

--- a/apps/main/src/lib/activities.ts
+++ b/apps/main/src/lib/activities.ts
@@ -1,13 +1,13 @@
 import { type ActivityKind } from "@zoonk/db";
 import { getExtracted } from "next-intl/server";
 
-export type ActivityKindInfo = {
-  key: ActivityKind;
-  label: string;
-  description: string;
-};
-
-export async function getActivityKinds(): Promise<ActivityKindInfo[]> {
+export async function getActivityKinds(): Promise<
+  {
+    key: ActivityKind;
+    label: string;
+    description: string;
+  }[]
+> {
   const t = await getExtracted();
 
   return [


### PR DESCRIPTION
## Summary

- Unblock catalog layout by moving `getSession()` into an async wrapper inside Suspense
- Add `loading.tsx` skeletons to course, chapter, and lesson routes for instant page shells
- Wrap course listing pages in Suspense so headers render immediately
- Remove preloading from home page (children already fetch inside Suspense)
- Parallelize `getSession()` in activity page `Promise.all`
- Internalize `getActivityKinds()` in `ActivityList` (sole consumer)
- Extract catalog skeletons into `catalog-skeletons.tsx`

## Test plan

- [x] All quality checks pass (`quality:fix`, `typecheck`, `knip`, `test`)
- [x] `pnpm --filter main build` succeeds
- [x] 377 main e2e tests pass
- [x] 193 editor e2e tests pass
- [x] 56 api e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamed catalog routes with React Suspense so headers and page shells render immediately while data loads. Added route-level skeletons and parallelized key fetches to eliminate blocking and improve perceived performance.

- **Refactors**
  - Moved auth state into a Suspense-wrapped NavbarLinksWithAuth (getSession), and removed layout-level Suspense to avoid blocking route content.
  - Added loading.tsx and shared skeletons (CatalogPageSkeleton, CatalogListSkeleton, CourseListSkeleton) for course, chapter, lesson, and course list routes.
  - Wrapped Courses and Category pages in Suspense with CourseListSkeleton fallback so headers render instantly.
  - Removed home page preloading; children already fetch inside Suspense.
  - Internalized activity kinds lookup in ActivityList and fetched it in parallel with progress; fetched session in parallel on the activity page.

<sup>Written for commit f53a91ba8ed51d2a3eba90dd5f7fd8de85926d0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

