### PR TITLE
refactor(editor): extract shared slug utils and simplify import files

### DIFF
--- a/apps/editor/src/data/activities/import-activities.ts
+++ b/apps/editor/src/data/activities/import-activities.ts
@@ -124,8 +124,6 @@ export async function importActivities(params: {
         startPosition = (existingActivities[0]?.position ?? -1) + 1;
       }
 
-      const imported: Activity[] = [];
-
       const activityOperations = importData.activities.map(async (activityData, i) => {
         const activity = await tx.activity.create({
           data: {
@@ -145,11 +143,7 @@ export async function importActivities(params: {
 
       const results = await Promise.all(activityOperations);
 
-      results.sort((a, b) => a.index - b.index);
-
-      for (const activityResult of results) {
-        imported.push(activityResult.activity);
-      }
+      const imported = results.toSorted((a, b) => a.index - b.index).map((item) => item.activity);
 
       await tx.lesson.update({
         data: { generationStatus: "completed" },

--- a/apps/editor/src/lib/import-slug.test.ts
+++ b/apps/editor/src/lib/import-slug.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { deduplicateImportSlugs, resolveImportSlug } from "./import-slug";
+
+vi.mock("server-only", () => ({}));
+
+describe(resolveImportSlug, () => {
+  it("preserves explicit slugs even when a record exists", () => {
+    const result = resolveImportSlug({
+      existingRecord: { id: 1 },
+      hasExplicitSlug: true,
+      index: 0,
+      slug: "my-slug",
+    });
+
+    expect(result).toBe("my-slug");
+  });
+
+  it("preserves slug when no collision exists", () => {
+    const result = resolveImportSlug({
+      existingRecord: null,
+      hasExplicitSlug: false,
+      index: 0,
+      slug: "my-slug",
+    });
+
+    expect(result).toBe("my-slug");
+  });
+
+  it("appends unique suffix for auto-generated slug with collision", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_234_567_890);
+
+    const result = resolveImportSlug({
+      existingRecord: { id: 1 },
+      hasExplicitSlug: false,
+      index: 3,
+      slug: "my-slug",
+    });
+
+    expect(result).toBe("my-slug-1234567890-3");
+
+    vi.restoreAllMocks();
+  });
+});
+
+describe(deduplicateImportSlugs, () => {
+  it("leaves unique slugs unchanged", () => {
+    const items = [
+      { index: 0, slug: "alpha" },
+      { index: 1, slug: "beta" },
+      { index: 2, slug: "gamma" },
+    ];
+
+    const result = deduplicateImportSlugs(items);
+
+    expect(result).toEqual([
+      { index: 0, slug: "alpha" },
+      { index: 1, slug: "beta" },
+      { index: 2, slug: "gamma" },
+    ]);
+  });
+
+  it("appends suffix to duplicate slugs", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_234_567_890);
+
+    const items = [
+      { index: 0, slug: "same" },
+      { index: 1, slug: "same" },
+      { index: 2, slug: "same" },
+    ];
+
+    const result = deduplicateImportSlugs(items);
+
+    expect(result.map((item) => item.slug)).toEqual([
+      "same",
+      "same-1234567890-1",
+      "same-1234567890-2",
+    ]);
+
+    vi.restoreAllMocks();
+  });
+
+  it("preserves order and extra properties", () => {
+    const items = [
+      { extra: "a", index: 0, slug: "one" },
+      { extra: "b", index: 1, slug: "two" },
+    ];
+
+    const result = deduplicateImportSlugs(items);
+
+    expect(result).toEqual([
+      { extra: "a", index: 0, slug: "one" },
+      { extra: "b", index: 1, slug: "two" },
+    ]);
+  });
+});

--- a/apps/editor/src/lib/import-slug.ts
+++ b/apps/editor/src/lib/import-slug.ts
@@ -1,0 +1,37 @@
+import "server-only";
+
+/**
+ * Resolves slug collision with an existing DB record.
+ * Explicit slugs are always preserved. Auto-generated slugs
+ * get a unique suffix when they collide with existing records.
+ */
+export function resolveImportSlug(params: {
+  existingRecord: unknown;
+  hasExplicitSlug: boolean;
+  index: number;
+  slug: string;
+}): string {
+  if (params.hasExplicitSlug || !params.existingRecord) {
+    return params.slug;
+  }
+
+  return `${params.slug}-${Date.now()}-${params.index}`;
+}
+
+/**
+ * Deduplicates slugs within an import batch to prevent
+ * unique constraint violations when multiple items generate
+ * the same slug.
+ */
+export function deduplicateImportSlugs<T extends { index: number; slug: string }>(items: T[]): T[] {
+  const slugCounts = new Map<string, number>();
+
+  return items.map((item) => {
+    const count = slugCounts.get(item.slug) ?? 0;
+    slugCounts.set(item.slug, count + 1);
+
+    const slug = count > 0 ? `${item.slug}-${Date.now()}-${item.index}` : item.slug;
+
+    return { ...item, slug };
+  });
+}


### PR DESCRIPTION
## Summary

- Extract `resolveImportSlug` and `deduplicateImportSlugs` into shared `import-slug.ts` — previously duplicated identically in lessons and chapters
- Extract `resolveLesson` and `resolveChapter` helpers with early returns, eliminating `let` + nested conditionals
- Replace mutable `imported` array + `for`/`push` with `.toSorted().map()` in all three import files

## Test plan

- [x] All 403 editor integration tests pass (unchanged — pure refactoring)
- [x] Added 6 unit tests for the new shared slug utilities


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted shared slug utilities and simplified import logic for chapters, lessons, and activities to remove duplication and make slug collisions predictable. No behavior changes; improves readability and adds tests.

- **Refactors**
  - Moved resolveImportSlug and deduplicateImportSlugs to apps/editor/src/lib/import-slug.ts.
  - Introduced resolveLesson and resolveChapter helpers with early returns.
  - Replaced mutable arrays + manual sort with toSorted(...).map(...) in import files.
  - Added unit tests for slug utilities.

<sup>Written for commit 3a5fe940e0edee7d09700474886f62759a3e1777. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

