### PR TITLE
refactor(editor): swap slug and description steps in course creation wizard

### DIFF
--- a/apps/editor/e2e/new-course.test.ts
+++ b/apps/editor/e2e/new-course.test.ts
@@ -31,12 +31,12 @@ async function fillCourseForm(
   // Step 2: Language - use default
   await page.keyboard.press("Enter");
 
-  // Step 3: Description
-  await page.getByPlaceholder(/brief description/i).fill(description);
+  // Step 3: Slug
+  await page.getByPlaceholder(/course-title/i).fill(slug);
   await page.keyboard.press("Enter");
 
-  // Step 4: Slug
-  await page.getByPlaceholder(/course-title/i).fill(slug);
+  // Step 4: Description
+  await page.getByPlaceholder(/brief description/i).fill(description);
 }
 
 function getProgressBar(page: Page) {
@@ -288,30 +288,32 @@ test.describe("Course Creation Wizard - Form Validation", () => {
 
     await authenticatedPage.keyboard.press("Enter");
     await authenticatedPage.keyboard.press("Enter");
+    await authenticatedPage.keyboard.press("Enter");
 
     await expect(authenticatedPage.getByText(/course description/i)).toBeVisible();
 
-    await expect(authenticatedPage.getByRole("button", { name: /next/i })).toBeDisabled();
+    await expect(authenticatedPage.getByRole("button", { name: /create/i })).toBeDisabled();
 
     await authenticatedPage.getByPlaceholder(/brief description/i).fill("   ");
-    await expect(authenticatedPage.getByRole("button", { name: /next/i })).toBeDisabled();
+    await expect(authenticatedPage.getByRole("button", { name: /create/i })).toBeDisabled();
 
     await authenticatedPage.getByPlaceholder(/brief description/i).fill("A valid description");
-    await expect(authenticatedPage.getByRole("button", { name: /next/i })).toBeEnabled();
+    await expect(authenticatedPage.getByRole("button", { name: /create/i })).toBeEnabled();
   });
 
   test("slug step shows error for existing slug", async ({ authenticatedPage }) => {
-    await fillCourseForm(authenticatedPage, {
-      description: "Test description",
-      slug: existingCourseSlug,
-      title: "Test Course",
-    });
+    await authenticatedPage.getByPlaceholder(/course title/i).fill("Test Course");
+    await authenticatedPage.keyboard.press("Enter");
+    await authenticatedPage.keyboard.press("Enter");
+
+    // Now on slug step (step 3) - fill with existing slug
+    await authenticatedPage.getByPlaceholder(/course-title/i).fill(existingCourseSlug);
 
     await expect(
       authenticatedPage.getByText(/a course with this url already exists/i),
     ).toBeVisible();
 
-    await expect(authenticatedPage.getByRole("button", { name: /create/i })).toBeDisabled();
+    await expect(authenticatedPage.getByRole("button", { name: /next/i })).toBeDisabled();
   });
 
   test("slug step allows unique slug", async ({ authenticatedPage }) => {
@@ -336,13 +338,9 @@ test.describe("Course Creation Wizard - Form Validation", () => {
     await authenticatedPage.keyboard.press("Enter");
     await authenticatedPage.keyboard.press("Enter");
 
-    await authenticatedPage.getByPlaceholder(/brief description/i).fill("Description");
-
-    await authenticatedPage.keyboard.press("Enter");
-
     await authenticatedPage.getByPlaceholder(/course-title/i).clear();
 
-    await expect(authenticatedPage.getByRole("button", { name: /create/i })).toBeDisabled();
+    await expect(authenticatedPage.getByRole("button", { name: /next/i })).toBeDisabled();
   });
 });
 
@@ -385,10 +383,6 @@ test.describe("Course Creation Wizard - Successful Creation", () => {
     await authenticatedPage.getByPlaceholder(/course title/i).fill("My Amazing Course");
 
     await authenticatedPage.keyboard.press("Enter");
-    await authenticatedPage.keyboard.press("Enter");
-
-    await authenticatedPage.getByPlaceholder(/brief description/i).fill("Description");
-
     await authenticatedPage.keyboard.press("Enter");
 
     await expect(authenticatedPage.getByPlaceholder(/course-title/i)).toHaveValue(
@@ -475,28 +469,25 @@ test.describe("Course Creation Wizard - Input Auto-focus", () => {
     await expect(authenticatedPage.getByPlaceholder(/course title/i)).toBeFocused();
   });
 
-  test("description textarea is auto-focused on step", async ({ authenticatedPage }) => {
-    await authenticatedPage.goto(`/${AI_ORG_SLUG}/new-course`);
-
-    await authenticatedPage.getByPlaceholder(/course title/i).fill("Test Course");
-    await authenticatedPage.keyboard.press("Enter");
-    await authenticatedPage.keyboard.press("Enter");
-
-    await expect(authenticatedPage.getByPlaceholder(/brief description/i)).toBeFocused();
-  });
-
   test("slug input is auto-focused on step", async ({ authenticatedPage }) => {
     await authenticatedPage.goto(`/${AI_ORG_SLUG}/new-course`);
 
     await authenticatedPage.getByPlaceholder(/course title/i).fill("Test Course");
-
     await authenticatedPage.keyboard.press("Enter");
-    await authenticatedPage.keyboard.press("Enter");
-
-    await authenticatedPage.getByPlaceholder(/brief description/i).fill("Description");
-
     await authenticatedPage.keyboard.press("Enter");
 
     await expect(authenticatedPage.getByPlaceholder(/course-title/i)).toBeFocused();
+  });
+
+  test("description textarea is auto-focused on step", async ({ authenticatedPage }) => {
+    await authenticatedPage.goto(`/${AI_ORG_SLUG}/new-course`);
+
+    await authenticatedPage.getByPlaceholder(/course title/i).fill("Test Course");
+
+    await authenticatedPage.keyboard.press("Enter");
+    await authenticatedPage.keyboard.press("Enter");
+    await authenticatedPage.keyboard.press("Enter");
+
+    await expect(authenticatedPage.getByPlaceholder(/brief description/i)).toBeFocused();
   });
 });

--- a/apps/editor/src/app/[orgSlug]/new-course/create-course-wizard.tsx
+++ b/apps/editor/src/app/[orgSlug]/new-course/create-course-wizard.tsx
@@ -13,7 +13,7 @@ import { SlugStep } from "./steps/slug-step";
 import { TitleStep } from "./steps/title-step";
 import { useCourseForm } from "./use-course-form";
 
-const STEPS = ["title", "language", "description", "slug"] as const;
+const STEPS = ["title", "language", "slug", "description"] as const;
 
 export function CreateCourseWizard({ orgSlug }: { orgSlug: string }) {
   const router = useRouter();
@@ -37,7 +37,7 @@ export function CreateCourseWizard({ orgSlug }: { orgSlug: string }) {
     }
 
     // Auto-fill slug from title when entering the slug step
-    if (wizard.currentStepName === "description" && !formData.slug) {
+    if (wizard.currentStepName === "language" && !formData.slug) {
       const baseSlug = toSlug(formData.title);
       const slug = isAiOrg ? ensureLocaleSuffix(baseSlug, formData.language) : baseSlug;
 
@@ -100,18 +100,18 @@ export function CreateCourseWizard({ orgSlug }: { orgSlug: string }) {
           />
         )}
 
-        {wizard.currentStepName === "description" && (
-          <DescriptionStep
-            onChange={(value) => updateField("description", value)}
-            value={formData.description}
-          />
-        )}
-
         {wizard.currentStepName === "slug" && (
           <SlugStep
             error={submitError || getStepError("slug")}
             onChange={(value) => updateField("slug", value)}
             value={formData.slug}
+          />
+        )}
+
+        {wizard.currentStepName === "description" && (
+          <DescriptionStep
+            onChange={(value) => updateField("description", value)}
+            value={formData.description}
           />
         )}
       </WizardContent>


### PR DESCRIPTION
## Summary

- Reorder course creation wizard steps from Title → Language → Description → Slug to Title → Language → Slug → Description
- Auto-fill slug from title when leaving the language step instead of the description step
- Update e2e tests to reflect the new step order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swapped slug and description steps in the course wizard to collect slug earlier and auto-fill it from the title after the language step. Updated e2e tests and focus/validation to match the new flow.

- **Refactors**
  - Step order: Title → Language → Slug → Description.
  - Auto-fill slug from title when leaving Language; keeps AI org locale suffix.
  - E2E updates for autofocus, button states (Next/Create), and slug uniqueness checks.

<sup>Written for commit 96e9fa05ac174f77845d913e4070885223dd9d89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

