### PR TITLE
fix(utils): prioritize NEXT_PUBLIC_APP_DOMAIN over VERCEL_URL in getBaseUrl

### DIFF
--- a/packages/utils/src/url.ts
+++ b/packages/utils/src/url.ts
@@ -18,28 +18,27 @@ function getScheme(domain: string): "http" | "https" {
  * Gets the base URL for the current app based on the environment.
  *
  * Uses the following logic:
- * 1. For localhost domains, uses `http://` scheme
- * 2. In Vercel preview environments, uses `VERCEL_URL` with `https://`
- * 3. Otherwise, uses `NEXT_PUBLIC_APP_DOMAIN` with `https://`
+ * 1. Uses `NEXT_PUBLIC_APP_DOMAIN` when set (with `http://` for localhost, `https://` otherwise)
+ * 2. Falls back to `VERCEL_URL` in Vercel preview environments
+ * 3. Throws if neither is available
  *
  * @returns The full base URL including scheme (e.g., "https://zoonk.com" or "http://localhost:3000")
  */
 export function getBaseUrl(): string {
-  // In Vercel preview deployments, use the deployment URL
+  const domain = process.env.NEXT_PUBLIC_APP_DOMAIN;
+
+  if (domain) {
+    return `${getScheme(domain)}://${domain}`;
+  }
+
   if (process.env.VERCEL_ENV === "preview" && process.env.VERCEL_URL) {
     return `https://${process.env.VERCEL_URL}`;
   }
 
-  const domain = process.env.NEXT_PUBLIC_APP_DOMAIN;
-
-  if (!domain) {
-    throw new Error(
-      "NEXT_PUBLIC_APP_DOMAIN environment variable is not set. " +
-        "Please set it to your app domain (e.g., 'zoonk.com' or 'localhost:3000').",
-    );
-  }
-
-  return `${getScheme(domain)}://${domain}`;
+  throw new Error(
+    "NEXT_PUBLIC_APP_DOMAIN environment variable is not set. " +
+      "Please set it to your app domain (e.g., 'zoonk.com' or 'localhost:3000').",
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- Swap priority in `getBaseUrl()` so `NEXT_PUBLIC_APP_DOMAIN` is checked before `VERCEL_URL`, fixing staging OAuth callback URLs using deployment-specific Vercel URLs instead of `api.zoonk.dev`
- Add unit tests for `getBaseUrl()` covering domain priority, localhost scheme, fallback, and error cases

## Test plan

- [x] Unit tests for all `getBaseUrl()` branches
- [x] `pnpm turbo quality:fix` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] `pnpm knip --production` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated getBaseUrl to prefer NEXT_PUBLIC_APP_DOMAIN over VERCEL_URL so staging OAuth callbacks use api.zoonk.dev (or the configured domain) instead of per-deploy Vercel URLs. Added unit tests for domain priority, localhost http scheme, Vercel preview fallback, and the error when neither variable is set.

<sup>Written for commit ff3aa85ca58ddaaeb1e08ac09e50d9aae4190c43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

