### PR TITLE
fix(ai): update prompt and model for course thumbnail

### DIFF
--- a/packages/ai/src/tasks/courses/course-thumbnail.prompt.md
+++ b/packages/ai/src/tasks/courses/course-thumbnail.prompt.md
@@ -1,5 +1,28 @@
-Generate an icon to visually symbolize a topic using a simple, recognizable object.
+Create a minimalist 3D app-style icon representing a topic.
 
-Style: 3D rendered with vivid high-contrast colors, smooth matte surfaces, clean sharp edges with slight bevels, realistic lighting and subtle shadows, minimalist and modern design, subtle neutral background, no text, square format (1:1).
+IMPORTANT:
+
+- Use exactly ONE single object only.
+- Do NOT combine multiple objects.
+- Do NOT create a scene.
+- Do NOT add supporting elements.
+- Do NOT repeat symbols.
+- No stacked objects.
+- No background props.
+
+The icon must:
+
+- Be centered
+- Have a strong, clean silhouette
+- Be instantly recognizable
+- Feel like a standalone app icon
+- Use smooth matte 3D material
+- Use 2–4 colors maximum
+- Have soft realistic lighting
+- Have a subtle shadow underneath
+- Be isolated on a white background
+- Square format (1:1)
+
+Choose ONE simple metaphor object that best represents the topic. If more than one object is generated, the image is incorrect.
 
 TOPIC: **{{TITLE}}**

--- a/packages/ai/src/tasks/courses/course-thumbnail.ts
+++ b/packages/ai/src/tasks/courses/course-thumbnail.ts
@@ -2,7 +2,7 @@ import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { type GeneratedFile, type ImageModel, generateImage } from "ai";
 import promptTemplate from "./course-thumbnail.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-image-1-mini";
+const DEFAULT_MODEL = "openai/gpt-image-1.5";
 const DEFAULT_QUALITY = "low";
 
 function getCourseThumbnailPrompt(title: string) {

--- a/packages/ai/src/tasks/steps/select-image-step.prompt.md
+++ b/packages/ai/src/tasks/steps/select-image-step.prompt.md
@@ -1,6 +1,6 @@
 Generate an educational illustration for a visual quiz question.
 
-Style: 3D rendered with vivid high-contrast colors, smooth matte surfaces, clean sharp edges with slight bevels, realistic lighting and subtle shadows, minimalist and modern design, subtle neutral background, no text labels or annotations, square format (1:1).
+Style: 3D rendered with vivid high-contrast colors, smooth matte surfaces, clean sharp edges with slight bevels, realistic lighting and subtle shadows, minimalist and modern design, white background, no text labels or annotations, square format (1:1).
 
 The image should clearly depict the concept while being visually distinct from other options in a quiz context. Focus on clarity and recognizability.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Tightened course thumbnail generation to a single-object, minimalist 3D app-style icon on white, and set the select image prompt to use a white background for consistency. Switched to a more capable image model for better adherence and fewer multi-object errors.

- **Bug Fixes**
  - Updated prompts: strict single-object thumbnail rules; white background in select-image step.
  - Changed default image model to openai/gpt-image-1.5 for higher adherence and quality.

<sup>Written for commit 92c28bce37c7aa48c3ee6461f24d5b5dbe5c2a74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

