### PR TITLE
fix(utils): move date-ranges to shared package and fix e2e fixture

### DIFF
--- a/apps/main/src/app/(performance)/_components/metric-comparison.tsx
+++ b/apps/main/src/app/(performance)/_components/metric-comparison.tsx
@@ -1,5 +1,5 @@
-import { type HistoryPeriod } from "@/data/progress/_utils";
 import { cn } from "@zoonk/ui/lib/utils";
+import { type HistoryPeriod } from "@zoonk/utils/date-ranges";
 import { TrendingDownIcon, TrendingUpIcon } from "lucide-react";
 import { getExtracted, getLocale } from "next-intl/server";
 

--- a/apps/main/src/app/(performance)/_utils.ts
+++ b/apps/main/src/app/(performance)/_utils.ts
@@ -1,4 +1,4 @@
-import { type HistoryPeriod } from "@/data/progress/_utils";
+import { type HistoryPeriod } from "@zoonk/utils/date-ranges";
 
 export function formatPeriodLabel(
   periodStart: Date,

--- a/apps/main/src/app/(performance)/energy/energy-content.tsx
+++ b/apps/main/src/app/(performance)/energy/energy-content.tsx
@@ -1,7 +1,7 @@
-import { validatePeriod } from "@/data/progress/_utils";
 import { getEnergyHistory } from "@/data/progress/get-energy-history";
 import { getSession } from "@zoonk/core/users/session/get";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { validatePeriod } from "@zoonk/utils/date-ranges";
 import { getLocale } from "next-intl/server";
 import { PerformanceChartSkeleton } from "../_components/performance-chart-skeleton";
 import { PerformanceEmptyState } from "../_components/performance-empty-state";

--- a/apps/main/src/app/(performance)/energy/energy-stats.tsx
+++ b/apps/main/src/app/(performance)/energy/energy-stats.tsx
@@ -1,5 +1,5 @@
-import { type HistoryPeriod } from "@/data/progress/_utils";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { type HistoryPeriod } from "@zoonk/utils/date-ranges";
 import { getExtracted, getLocale } from "next-intl/server";
 import { MetricComparison } from "../_components/metric-comparison";
 import { formatPeriodLabel } from "../_utils";

--- a/apps/main/src/app/(performance)/level/level-chart.tsx
+++ b/apps/main/src/app/(performance)/level/level-chart.tsx
@@ -1,5 +1,5 @@
-import { type HistoryPeriod } from "@/data/progress/_utils";
 import { type BpDataPoint } from "@/data/progress/get-bp-history";
+import { type HistoryPeriod } from "@zoonk/utils/date-ranges";
 import { getLocale } from "next-intl/server";
 import { PerformanceChartLayout } from "../_components/performance-chart-layout";
 import { formatPeriodLabel } from "../_utils";

--- a/apps/main/src/app/(performance)/level/level-content.tsx
+++ b/apps/main/src/app/(performance)/level/level-content.tsx
@@ -1,7 +1,7 @@
-import { validatePeriod } from "@/data/progress/_utils";
 import { getBpHistory } from "@/data/progress/get-bp-history";
 import { getSession } from "@zoonk/core/users/session/get";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { validatePeriod } from "@zoonk/utils/date-ranges";
 import { getLocale } from "next-intl/server";
 import { PerformanceChartSkeleton } from "../_components/performance-chart-skeleton";
 import { PerformanceEmptyState } from "../_components/performance-empty-state";

--- a/apps/main/src/app/(performance)/level/level-stats.tsx
+++ b/apps/main/src/app/(performance)/level/level-stats.tsx
@@ -1,8 +1,8 @@
-import { type HistoryPeriod } from "@/data/progress/_utils";
 import { getBeltColorLabel } from "@/lib/belt-colors";
 import { BeltIndicator } from "@zoonk/ui/components/belt-indicator";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { type BeltLevelResult } from "@zoonk/utils/belt-level";
+import { type HistoryPeriod } from "@zoonk/utils/date-ranges";
 import { getExtracted, getLocale } from "next-intl/server";
 import { MetricComparison } from "../_components/metric-comparison";
 import { formatPeriodLabel } from "../_utils";

--- a/apps/main/src/app/(performance)/score/score-content.tsx
+++ b/apps/main/src/app/(performance)/score/score-content.tsx
@@ -1,7 +1,7 @@
-import { validatePeriod } from "@/data/progress/_utils";
 import { getScoreHistory } from "@/data/progress/get-score-history";
 import { getSession } from "@zoonk/core/users/session/get";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { validatePeriod } from "@zoonk/utils/date-ranges";
 import { getLocale } from "next-intl/server";
 import { PerformanceChartSkeleton } from "../_components/performance-chart-skeleton";
 import { PerformanceEmptyState } from "../_components/performance-empty-state";

--- a/apps/main/src/app/(performance)/score/score-insights.tsx
+++ b/apps/main/src/app/(performance)/score/score-insights.tsx
@@ -1,4 +1,3 @@
-import { type HistoryPeriod } from "@/data/progress/_utils";
 import { getBestDay } from "@/data/progress/get-best-day";
 import { getBestTime } from "@/data/progress/get-best-time";
 import {
@@ -13,6 +12,7 @@ import {
 } from "@zoonk/ui/components/feature";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { EPOCH_YEAR, FIRST_SUNDAY_OFFSET } from "@zoonk/utils/constants";
+import { type HistoryPeriod } from "@zoonk/utils/date-ranges";
 import { CalendarDays, Clock } from "lucide-react";
 import { getExtracted, getLocale } from "next-intl/server";
 

--- a/apps/main/src/app/(performance)/score/score-stats.tsx
+++ b/apps/main/src/app/(performance)/score/score-stats.tsx
@@ -1,5 +1,5 @@
-import { type HistoryPeriod } from "@/data/progress/_utils";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { type HistoryPeriod } from "@zoonk/utils/date-ranges";
 import { getExtracted, getLocale } from "next-intl/server";
 import { MetricComparison } from "../_components/metric-comparison";
 import { formatPeriodLabel } from "../_utils";

--- a/apps/main/src/data/progress/get-best-day.ts
+++ b/apps/main/src/data/progress/get-best-day.ts
@@ -1,8 +1,8 @@
 import "server-only";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
+import { type ScoredRow, findBestByScore, getDefaultStartDate } from "@zoonk/utils/date-ranges";
 import { cache } from "react";
-import { type ScoredRow, findBestByScore, getDefaultStartDate } from "./_utils";
 
 type BestDayData = {
   score: number;

--- a/apps/main/src/data/progress/get-best-time.ts
+++ b/apps/main/src/data/progress/get-best-time.ts
@@ -2,9 +2,9 @@ import "server-only";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
 import { getPeakTime as getPeakTimeQuery } from "@zoonk/db/peak-time";
+import { type ScoredRow, findBestByScore, getDefaultStartDate } from "@zoonk/utils/date-ranges";
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
-import { type ScoredRow, findBestByScore, getDefaultStartDate } from "./_utils";
 
 type BestTimeData = {
   score: number;

--- a/apps/main/src/data/progress/get-bp-history.ts
+++ b/apps/main/src/data/progress/get-bp-history.ts
@@ -2,15 +2,15 @@ import "server-only";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
 import { type BeltLevelResult, calculateBeltLevel } from "@zoonk/utils/belt-level";
-import { safeAsync } from "@zoonk/utils/error";
-import { cache } from "react";
 import {
   type HistoryPeriod,
   aggregateByMonth,
   aggregateByWeek,
   calculateDateRanges,
   formatLabel,
-} from "./_utils";
+} from "@zoonk/utils/date-ranges";
+import { safeAsync } from "@zoonk/utils/error";
+import { cache } from "react";
 
 export type BpDataPoint = {
   date: Date;

--- a/apps/main/src/data/progress/get-energy-history.ts
+++ b/apps/main/src/data/progress/get-energy-history.ts
@@ -1,16 +1,16 @@
 import "server-only";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
-import { safeAsync } from "@zoonk/utils/error";
-import { cache } from "react";
-import { fillGapsWithDecay } from "./_fill-gaps";
 import {
   type HistoryPeriod,
   aggregateByMonth,
   aggregateByWeek,
   calculateDateRanges,
   formatLabel,
-} from "./_utils";
+} from "@zoonk/utils/date-ranges";
+import { safeAsync } from "@zoonk/utils/error";
+import { cache } from "react";
+import { fillGapsWithDecay } from "./_fill-gaps";
 
 export type EnergyPeriod = HistoryPeriod;
 

--- a/apps/main/src/data/progress/get-score-history.ts
+++ b/apps/main/src/data/progress/get-score-history.ts
@@ -1,15 +1,15 @@
 import "server-only";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
-import { safeAsync } from "@zoonk/utils/error";
-import { cache } from "react";
 import {
   type HistoryPeriod,
   aggregateScoreByMonth,
   aggregateScoreByWeek,
   calculateDateRanges,
   formatLabel,
-} from "./_utils";
+} from "@zoonk/utils/date-ranges";
+import { safeAsync } from "@zoonk/utils/error";
+import { cache } from "react";
 
 export type ScorePeriod = HistoryPeriod;
 

--- a/packages/e2e/src/helpers.ts
+++ b/packages/e2e/src/helpers.ts
@@ -215,7 +215,7 @@ function buildDailyProgressInputs(today: Date, orgId: number, userId: number) {
   const seen = new Set<string>();
   return dateEntries
     .filter(({ date }) => {
-      const key = date.toISOString().slice(0, 10);
+      const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
       if (seen.has(key)) {
         return false;
       }

--- a/packages/e2e/src/helpers.ts
+++ b/packages/e2e/src/helpers.ts
@@ -8,6 +8,7 @@ import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { dailyProgressFixtureMany, userProgressFixture } from "@zoonk/testing/fixtures/progress";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { calculateDateRanges } from "@zoonk/utils/date-ranges";
 import { getString } from "@zoonk/utils/json";
 import { LOCALE_COOKIE } from "@zoonk/utils/locale";
 
@@ -170,8 +171,8 @@ export async function openDialog(trigger: Locator, dialog: Locator) {
 }
 
 // Daily progress test fixture constants
-const PROGRESS_DAYS = 60;
-const PROGRESS_LAST_INDEX = 59;
+const DAYS_PER_GROUP = 5;
+const MID_MONTH_DAY = 15;
 const CURRENT_MONTH_CORRECT = 17;
 const PREVIOUS_MONTH_CORRECT = 13;
 const CURRENT_MONTH_ENERGY = 75;
@@ -179,22 +180,49 @@ const PREVIOUS_MONTH_ENERGY = 65;
 const CURRENT_MONTH_INCORRECT = 3;
 const PREVIOUS_MONTH_INCORRECT = 7;
 
-function buildDailyProgressInputs(today: Date, orgId: number, userId: number) {
-  return Array.from({ length: PROGRESS_DAYS }, (_, reverseIdx) => {
-    const idx = PROGRESS_LAST_INDEX - reverseIdx;
-    const date = new Date(today.getTime() - idx * 24 * 60 * 60 * 1000);
-    const isCurrentMonth = idx < 30;
+const ALL_PERIODS = ["month", "6months", "year"] as const;
+
+function buildGroupDates(today: Date, range: { start: Date; end: Date }, isCurrent: boolean) {
+  const baseDate = isCurrent
+    ? today
+    : new Date(range.start.getFullYear(), range.start.getMonth(), MID_MONTH_DAY);
+
+  return Array.from({ length: DAYS_PER_GROUP }, (_, i) => {
+    const date = new Date(baseDate);
+    date.setDate(baseDate.getDate() - i);
+    date.setHours(0, 0, 0, 0);
+
+    if (date < range.start || date > range.end) {
+      return null;
+    }
 
     return {
       brainPowerEarned: 250,
-      correctAnswers: isCurrentMonth ? CURRENT_MONTH_CORRECT : PREVIOUS_MONTH_CORRECT,
+      correctAnswers: isCurrent ? CURRENT_MONTH_CORRECT : PREVIOUS_MONTH_CORRECT,
       date,
-      energyAtEnd: isCurrentMonth ? CURRENT_MONTH_ENERGY : PREVIOUS_MONTH_ENERGY,
-      incorrectAnswers: isCurrentMonth ? CURRENT_MONTH_INCORRECT : PREVIOUS_MONTH_INCORRECT,
-      organizationId: orgId,
-      userId,
+      energyAtEnd: isCurrent ? CURRENT_MONTH_ENERGY : PREVIOUS_MONTH_ENERGY,
+      incorrectAnswers: isCurrent ? CURRENT_MONTH_INCORRECT : PREVIOUS_MONTH_INCORRECT,
     };
+  }).filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+}
+
+function buildDailyProgressInputs(today: Date, orgId: number, userId: number) {
+  const dateEntries = ALL_PERIODS.flatMap((period) => {
+    const { current, previous } = calculateDateRanges(period, 0);
+    return [...buildGroupDates(today, current, true), ...buildGroupDates(today, previous, false)];
   });
+
+  const seen = new Set<string>();
+  return dateEntries
+    .filter(({ date }) => {
+      const key = date.toISOString().slice(0, 10);
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    })
+    .map((entry) => ({ ...entry, organizationId: orgId, userId }));
 }
 
 async function createStepAttempts(

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,6 +21,7 @@
     "./string": "./src/string.ts",
     "./subscription": "./src/subscription.ts",
     "./currency": "./src/currency.ts",
+    "./date-ranges": "./src/date-ranges.ts",
     "./url": "./src/url.ts"
   },
   "scripts": {

--- a/packages/utils/src/date-ranges.test.ts
+++ b/packages/utils/src/date-ranges.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ScoredRow,
+  aggregateByMonth,
+  aggregateByWeek,
+  aggregateScoreByMonth,
+  aggregateScoreByWeek,
+  calculateDateRanges,
+  findBestByScore,
+  formatLabel,
+  getDefaultStartDate,
+  validatePeriod,
+} from "./date-ranges";
+
+function calcScore(correct: number, incorrect: number) {
+  return (correct / (correct + incorrect)) * 100;
+}
+
+describe(validatePeriod, () => {
+  it("returns 'month' unchanged", () => {
+    expect(validatePeriod("month")).toBe("month");
+  });
+
+  it("returns '6months' unchanged", () => {
+    expect(validatePeriod("6months")).toBe("6months");
+  });
+
+  it("returns 'year' unchanged", () => {
+    expect(validatePeriod("year")).toBe("year");
+  });
+
+  it("defaults invalid value to 'month'", () => {
+    expect(validatePeriod("invalid")).toBe("month");
+  });
+
+  it("defaults empty string to 'month'", () => {
+    expect(validatePeriod("")).toBe("month");
+  });
+});
+
+describe(calculateDateRanges, () => {
+  it("returns current and previous month for 'month' period in March", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 15)); // March 15, 2026
+
+    const ranges = calculateDateRanges("month", 0);
+
+    expect(ranges.current.start).toEqual(new Date(2026, 2, 1));
+    expect(ranges.current.end).toEqual(new Date(2026, 2, 31));
+    expect(ranges.previous.start).toEqual(new Date(2026, 1, 1));
+    expect(ranges.previous.end).toEqual(new Date(2026, 1, 28));
+
+    vi.useRealTimers();
+  });
+
+  it("returns offset month for 'month' period with offset=1", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 15)); // March 15, 2026
+
+    const ranges = calculateDateRanges("month", 1);
+
+    expect(ranges.current.start).toEqual(new Date(2026, 1, 1));
+    expect(ranges.current.end).toEqual(new Date(2026, 1, 28));
+    expect(ranges.previous.start).toEqual(new Date(2026, 0, 1));
+    expect(ranges.previous.end).toEqual(new Date(2026, 0, 31));
+
+    vi.useRealTimers();
+  });
+
+  it("returns correct half-year ranges in January (H1)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 15)); // January 15, 2026
+
+    const ranges = calculateDateRanges("6months", 0);
+
+    expect(ranges.current.start).toEqual(new Date(2026, 0, 1));
+    expect(ranges.current.end).toEqual(new Date(2026, 5, 30));
+    expect(ranges.previous.start).toEqual(new Date(2025, 6, 1));
+    expect(ranges.previous.end).toEqual(new Date(2025, 11, 31));
+
+    vi.useRealTimers();
+  });
+
+  it("returns correct half-year ranges in July (H2)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 6, 15)); // July 15, 2026
+
+    const ranges = calculateDateRanges("6months", 0);
+
+    expect(ranges.current.start).toEqual(new Date(2026, 6, 1));
+    expect(ranges.current.end).toEqual(new Date(2026, 11, 31));
+    expect(ranges.previous.start).toEqual(new Date(2026, 0, 1));
+    expect(ranges.previous.end).toEqual(new Date(2026, 5, 30));
+
+    vi.useRealTimers();
+  });
+
+  it("returns correct year ranges in March", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 15)); // March 15, 2026
+
+    const ranges = calculateDateRanges("year", 0);
+
+    expect(ranges.current.start).toEqual(new Date(2026, 0, 1));
+    expect(ranges.current.end).toEqual(new Date(2026, 11, 31));
+    expect(ranges.previous.start).toEqual(new Date(2025, 0, 1));
+    expect(ranges.previous.end).toEqual(new Date(2025, 11, 31));
+
+    vi.useRealTimers();
+  });
+
+  it("returns correct year ranges in December", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 11, 25)); // December 25, 2026
+
+    const ranges = calculateDateRanges("year", 0);
+
+    expect(ranges.current.start).toEqual(new Date(2026, 0, 1));
+    expect(ranges.current.end).toEqual(new Date(2026, 11, 31));
+    expect(ranges.previous.start).toEqual(new Date(2025, 0, 1));
+    expect(ranges.previous.end).toEqual(new Date(2025, 11, 31));
+
+    vi.useRealTimers();
+  });
+
+  it("returns offset year ranges with offset=1", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 15)); // March 15, 2026
+
+    const ranges = calculateDateRanges("year", 1);
+
+    expect(ranges.current.start).toEqual(new Date(2025, 0, 1));
+    expect(ranges.current.end).toEqual(new Date(2025, 11, 31));
+    expect(ranges.previous.start).toEqual(new Date(2024, 0, 1));
+    expect(ranges.previous.end).toEqual(new Date(2024, 11, 31));
+
+    vi.useRealTimers();
+  });
+});
+
+describe(formatLabel, () => {
+  it("formats month period as day + short month", () => {
+    const date = new Date(2026, 2, 15);
+    const result = formatLabel(date, "month", "en");
+    expect(result).toContain("Mar");
+    expect(result).toContain("15");
+  });
+
+  it("formats 6months period as week number", () => {
+    const date = new Date(2026, 0, 15);
+    const result = formatLabel(date, "6months", "en");
+    expect(result).toMatch(/^W\d+$/);
+  });
+
+  it("formats year period as short month", () => {
+    const date = new Date(2026, 2, 15);
+    const result = formatLabel(date, "year", "en");
+    expect(result).toBe("Mar");
+  });
+});
+
+describe(aggregateByWeek, () => {
+  const dataPoints = [
+    { date: new Date(2026, 2, 2), value: 10 }, // Monday
+    { date: new Date(2026, 2, 3), value: 20 }, // Tuesday (same week)
+    { date: new Date(2026, 2, 9), value: 30 }, // Next Monday (different week)
+  ];
+
+  it("aggregates by sum", () => {
+    const result = aggregateByWeek(dataPoints, (point) => point.value, "sum");
+    expect(result.map((row) => row.value)).toEqual([30, 30]); // 10+20, 30
+  });
+
+  it("aggregates by average", () => {
+    const result = aggregateByWeek(dataPoints, (point) => point.value, "average");
+    expect(result.map((row) => row.value)).toEqual([15, 30]); // (10+20)/2, 30/1
+  });
+
+  it("returns sorted results", () => {
+    const reversed = [...dataPoints].toReversed();
+    const result = aggregateByWeek(reversed, (point) => point.value, "sum");
+    const times = result.map((row) => row.date.getTime());
+    expect(times).toEqual([...times].toSorted((left, right) => left - right));
+  });
+});
+
+describe(aggregateByMonth, () => {
+  const dataPoints = [
+    { date: new Date(2026, 0, 5), value: 10 },
+    { date: new Date(2026, 0, 20), value: 20 },
+    { date: new Date(2026, 1, 10), value: 30 },
+  ];
+
+  it("aggregates by sum", () => {
+    const result = aggregateByMonth(dataPoints, (point) => point.value, "sum");
+    expect(result.map((row) => row.value)).toEqual([30, 30]); // Jan: 10+20, Feb: 30
+  });
+
+  it("aggregates by average", () => {
+    const result = aggregateByMonth(dataPoints, (point) => point.value, "average");
+    expect(result.map((row) => row.value)).toEqual([15, 30]); // Jan: (10+20)/2, Feb: 30/1
+  });
+
+  it("returns sorted results", () => {
+    const reversed = [...dataPoints].toReversed();
+    const result = aggregateByMonth(reversed, (point) => point.value, "sum");
+    const times = result.map((row) => row.date.getTime());
+    expect(times).toEqual([...times].toSorted((left, right) => left - right));
+  });
+});
+
+describe(aggregateScoreByWeek, () => {
+  it("aggregates correct/incorrect by week and calculates score", () => {
+    const dataPoints = [
+      { correct: 8, date: new Date(2026, 2, 2), incorrect: 2 }, // Monday
+      { correct: 6, date: new Date(2026, 2, 3), incorrect: 4 }, // Tuesday (same week)
+      { correct: 9, date: new Date(2026, 2, 9), incorrect: 1 }, // Next Monday
+    ];
+
+    const result = aggregateScoreByWeek(dataPoints, calcScore);
+
+    expect(result.map((row) => row.score)).toEqual([
+      calcScore(14, 6), // Week 1: 8+6=14 correct, 2+4=6 incorrect
+      calcScore(9, 1), // Week 2: 9 correct, 1 incorrect
+    ]);
+  });
+});
+
+describe(aggregateScoreByMonth, () => {
+  it("aggregates correct/incorrect by month and calculates score", () => {
+    const dataPoints = [
+      { correct: 8, date: new Date(2026, 0, 5), incorrect: 2 },
+      { correct: 6, date: new Date(2026, 0, 20), incorrect: 4 },
+      { correct: 9, date: new Date(2026, 1, 10), incorrect: 1 },
+    ];
+
+    const result = aggregateScoreByMonth(dataPoints, calcScore);
+
+    expect(result.map((row) => row.score)).toEqual([
+      calcScore(14, 6), // Jan
+      calcScore(9, 1), // Feb
+    ]);
+  });
+});
+
+describe(getDefaultStartDate, () => {
+  it("returns parsed date from ISO string", () => {
+    const iso = "2026-01-15T00:00:00.000Z";
+    const result = getDefaultStartDate(iso);
+    expect(result.toISOString()).toBe(iso);
+  });
+
+  it("returns lookback date when no ISO string provided", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 15));
+
+    const result = getDefaultStartDate();
+    const expected = new Date(2026, 2, 15);
+    expected.setDate(expected.getDate() - 90);
+
+    expect(result.toISOString().slice(0, 10)).toBe(expected.toISOString().slice(0, 10));
+
+    vi.useRealTimers();
+  });
+});
+
+describe(findBestByScore, () => {
+  it("finds row with highest score", () => {
+    const rows: ScoredRow[] = [
+      { correct: 7, incorrect: 3, key: 1 },
+      { correct: 9, incorrect: 1, key: 2 },
+      { correct: 5, incorrect: 5, key: 3 },
+    ];
+
+    const result = findBestByScore(rows);
+    expect(result).toEqual({ key: 2, score: 90 });
+  });
+
+  it("breaks ties by total", () => {
+    const rows: ScoredRow[] = [
+      { correct: 8, incorrect: 2, key: 1 }, // 80%, total 10
+      { correct: 16, incorrect: 4, key: 2 }, // 80%, total 20
+    ];
+
+    const result = findBestByScore(rows);
+    expect(result).toEqual({ key: 2, score: 80 });
+  });
+
+  it("returns null for empty array", () => {
+    expect(findBestByScore([])).toBeNull();
+  });
+
+  it("returns null when all rows have zero data", () => {
+    const rows: ScoredRow[] = [{ correct: 0, incorrect: 0, key: 1 }];
+    expect(findBestByScore(rows)).toBeNull();
+  });
+});

--- a/packages/utils/src/date-ranges.ts
+++ b/packages/utils/src/date-ranges.ts
@@ -1,5 +1,4 @@
-import "server-only";
-import { DEFAULT_PROGRESS_LOOKBACK_DAYS } from "@zoonk/utils/constants";
+import { DEFAULT_PROGRESS_LOOKBACK_DAYS } from "./constants";
 
 const HISTORY_PERIODS = ["month", "6months", "year"] as const;
 
@@ -7,10 +6,11 @@ const MONTHS_PER_HALF_YEAR = 6;
 const DECEMBER_INDEX = 11;
 const LAST_DAY_OF_DECEMBER = 31;
 const SUNDAY_TO_MONDAY_OFFSET = -6;
+const MILLISECONDS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
 export type HistoryPeriod = (typeof HISTORY_PERIODS)[number];
 
 function isHistoryPeriod(value: string): value is HistoryPeriod {
-  return HISTORY_PERIODS.some((period) => period === value);
+  return (HISTORY_PERIODS as readonly string[]).includes(value);
 }
 
 export function validatePeriod(value: string): HistoryPeriod {
@@ -92,27 +92,13 @@ export function formatLabel(date: Date, period: HistoryPeriod, locale: string): 
 
   if (period === "6months") {
     const weekNum = Math.ceil(
-      (date.getTime() - new Date(date.getFullYear(), 0, 1).getTime()) / (7 * 24 * 60 * 60 * 1000),
+      (date.getTime() - new Date(date.getFullYear(), 0, 1).getTime()) / MILLISECONDS_PER_WEEK,
     );
     return `W${weekNum}`;
   }
 
   // Year - show month name
   return new Intl.DateTimeFormat(locale, { month: "short" }).format(date);
-}
-
-function getWeekKey(date: Date): string {
-  const normalizedDate = new Date(date);
-  normalizedDate.setHours(0, 0, 0, 0);
-  // Get Monday of this week
-  const day = normalizedDate.getDay();
-  const diff = normalizedDate.getDate() - day + (day === 0 ? SUNDAY_TO_MONDAY_OFFSET : 1);
-  normalizedDate.setDate(diff);
-  return normalizedDate.toISOString().slice(0, 10);
-}
-
-function getMonthKey(date: Date): string {
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
 }
 
 function getMondayOfWeek(date: Date): Date {
@@ -128,17 +114,34 @@ function getFirstOfMonth(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), 1);
 }
 
+function getWeekKey(date: Date): string {
+  return getMondayOfWeek(date).toISOString().slice(0, 10);
+}
+
+function getMonthKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+}
+
+type TimePeriodConfig = {
+  getKey: (date: Date) => string;
+  getNormalizedDate: (date: Date) => Date;
+};
+
+const weekConfig: TimePeriodConfig = { getKey: getWeekKey, getNormalizedDate: getMondayOfWeek };
+const monthConfig: TimePeriodConfig = { getKey: getMonthKey, getNormalizedDate: getFirstOfMonth };
+
 type AggregationStrategy = "sum" | "average";
 
-export function aggregateByWeek<T extends { date: Date }>(
+function aggregateByPeriod<T extends { date: Date }>(
   dataPoints: T[],
   getValue: (point: T) => number,
   strategy: AggregationStrategy,
+  { getKey, getNormalizedDate }: TimePeriodConfig,
 ): { date: Date; value: number }[] {
   const map = new Map<string, { total: number; count: number; date: Date }>();
 
   for (const point of dataPoints) {
-    const key = getWeekKey(point.date);
+    const key = getKey(point.date);
     const existing = map.get(key);
     if (existing) {
       existing.total += getValue(point);
@@ -146,7 +149,7 @@ export function aggregateByWeek<T extends { date: Date }>(
     } else {
       map.set(key, {
         count: 1,
-        date: getMondayOfWeek(point.date),
+        date: getNormalizedDate(point.date),
         total: getValue(point),
       });
     }
@@ -158,6 +161,14 @@ export function aggregateByWeek<T extends { date: Date }>(
       value: strategy === "sum" ? item.total : item.total / item.count,
     }))
     .toSorted((a, b) => a.date.getTime() - b.date.getTime());
+}
+
+export function aggregateByWeek<T extends { date: Date }>(
+  dataPoints: T[],
+  getValue: (point: T) => number,
+  strategy: AggregationStrategy,
+): { date: Date; value: number }[] {
+  return aggregateByPeriod(dataPoints, getValue, strategy, weekConfig);
 }
 
 export function aggregateByMonth<T extends { date: Date }>(
@@ -165,41 +176,20 @@ export function aggregateByMonth<T extends { date: Date }>(
   getValue: (point: T) => number,
   strategy: AggregationStrategy,
 ): { date: Date; value: number }[] {
-  const map = new Map<string, { total: number; count: number; date: Date }>();
-
-  for (const point of dataPoints) {
-    const key = getMonthKey(point.date);
-    const existing = map.get(key);
-    if (existing) {
-      existing.total += getValue(point);
-      existing.count += 1;
-    } else {
-      map.set(key, {
-        count: 1,
-        date: getFirstOfMonth(point.date),
-        total: getValue(point),
-      });
-    }
-  }
-
-  return [...map.values()]
-    .map((item) => ({
-      date: item.date,
-      value: strategy === "sum" ? item.total : item.total / item.count,
-    }))
-    .toSorted((a, b) => a.date.getTime() - b.date.getTime());
+  return aggregateByPeriod(dataPoints, getValue, strategy, monthConfig);
 }
 
 type ScoreDataPoint = { date: Date; correct: number; incorrect: number };
 
-export function aggregateScoreByWeek(
+function aggregateScoreByPeriod(
   dataPoints: ScoreDataPoint[],
   calculateScore: (correct: number, incorrect: number) => number,
+  { getKey, getNormalizedDate }: TimePeriodConfig,
 ): { date: Date; score: number }[] {
   const map = new Map<string, { correct: number; incorrect: number; date: Date }>();
 
   for (const point of dataPoints) {
-    const key = getWeekKey(point.date);
+    const key = getKey(point.date);
     const existing = map.get(key);
     if (existing) {
       existing.correct += point.correct;
@@ -207,7 +197,7 @@ export function aggregateScoreByWeek(
     } else {
       map.set(key, {
         correct: point.correct,
-        date: getMondayOfWeek(point.date),
+        date: getNormalizedDate(point.date),
         incorrect: point.incorrect,
       });
     }
@@ -219,64 +209,49 @@ export function aggregateScoreByWeek(
       score: calculateScore(item.correct, item.incorrect),
     }))
     .toSorted((a, b) => a.date.getTime() - b.date.getTime());
+}
+
+export function aggregateScoreByWeek(
+  dataPoints: ScoreDataPoint[],
+  calculateScore: (correct: number, incorrect: number) => number,
+): { date: Date; score: number }[] {
+  return aggregateScoreByPeriod(dataPoints, calculateScore, weekConfig);
 }
 
 export function aggregateScoreByMonth(
   dataPoints: ScoreDataPoint[],
   calculateScore: (correct: number, incorrect: number) => number,
 ): { date: Date; score: number }[] {
-  const map = new Map<string, { correct: number; incorrect: number; date: Date }>();
-
-  for (const point of dataPoints) {
-    const key = getMonthKey(point.date);
-    const existing = map.get(key);
-    if (existing) {
-      existing.correct += point.correct;
-      existing.incorrect += point.incorrect;
-    } else {
-      map.set(key, {
-        correct: point.correct,
-        date: getFirstOfMonth(point.date),
-        incorrect: point.incorrect,
-      });
-    }
-  }
-
-  return [...map.values()]
-    .map((item) => ({
-      date: item.date,
-      score: calculateScore(item.correct, item.incorrect),
-    }))
-    .toSorted((a, b) => a.date.getTime() - b.date.getTime());
+  return aggregateScoreByPeriod(dataPoints, calculateScore, monthConfig);
 }
 
-export function getDefaultStartDate(startDateIso: string | undefined): Date {
+export function getDefaultStartDate(startDateIso?: string): Date {
   if (startDateIso) {
     return new Date(startDateIso);
   }
-  const date = new Date();
-  date.setDate(date.getDate() - DEFAULT_PROGRESS_LOOKBACK_DAYS);
-  return date;
+  const now = new Date();
+  return new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate() - DEFAULT_PROGRESS_LOOKBACK_DAYS,
+  );
 }
 
 export type ScoredRow = { key: number; correct: number; incorrect: number };
 
 export function findBestByScore(rows: ScoredRow[]): { key: number; score: number } | null {
-  let best: { key: number; score: number } | null = null;
-  let bestTotal = 0;
+  const scored = rows
+    .filter((row) => row.correct + row.incorrect > 0)
+    .map((row) => {
+      const total = row.correct + row.incorrect;
+      return { key: row.key, score: (row.correct / total) * 100, total };
+    });
 
-  const rowsWithData = rows.filter((row) => row.correct + row.incorrect > 0);
+  const best = scored.toSorted((a, b) => b.score - a.score || b.total - a.total).at(0);
 
-  for (const row of rowsWithData) {
-    const total = row.correct + row.incorrect;
-    const score = (row.correct / total) * 100;
-    const isBetter = !best || score > best.score || (score === best.score && total > bestTotal);
-
-    if (isBetter) {
-      best = { key: row.key, score };
-      bestTotal = total;
-    }
+  if (!best) {
+    return null;
   }
 
-  return best;
+  return { key: best.key, score: best.score };
 }


### PR DESCRIPTION
## Summary

- Move pure date-range functions from `apps/main/src/data/progress/_utils.ts` to `@zoonk/utils/date-ranges` (remove `server-only` dep, deduplicate aggregate logic, refactor to functional style)
- Fix E2E fixture `buildDailyProgressInputs` to use `calculateDateRanges` so progress data always spans both current and previous periods — fixes 9 tests that fail when run >60 days into a half-year/year
- Add 29 unit tests for all exported `date-ranges` functions

## Test plan

- [x] `pnpm turbo quality:fix` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm knip --production` passes
- [x] `pnpm test` — 188 unit tests pass (29 new)
- [x] `pnpm --filter main e2e` — 378 passed (energy/level/score comparison tests now stable)
- [x] `pnpm --filter editor e2e` — 193 passed
- [x] `pnpm --filter api e2e` — 56 passed
- [x] E2E energy/level/score tests run 2x with zero flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved date-range utilities to @zoonk/utils and rebuilt the E2E progress fixture to use them, making energy/level/score comparisons stable across month, 6-month, and year views.

- **Refactors**
  - Moved pure date-range utilities to @zoonk/utils/date-ranges and updated imports in performance/progress.
  - Unified weekly/monthly aggregation and scoring; added label formatting and period validation.
  - Removed server-only from pure functions, added a package export, and 29 unit tests.

- **Bug Fixes**
  - Rebuilt buildDailyProgressInputs to use calculateDateRanges for all periods, generate small groups for current/previous, dedupe by day, and drop the 60-day sliding window.
  - Fixes 9 failing comparison tests and removes E2E flakes.

<sup>Written for commit 40478592f600ef80a8f404b5ce73b9826b70daf7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

