### PR TITLE
refactor(data): remove unnecessary prisma select statements

### DIFF
--- a/apps/api/src/workflows/activity-generation/steps/complete-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/complete-activity-step.ts
@@ -37,7 +37,6 @@ export async function completeActivityStep(
   }
 
   const current = await prisma.activity.findUnique({
-    select: { generationStatus: true },
     where: { id: activity.id },
   });
 

--- a/apps/api/src/workflows/activity-generation/steps/complete-listening-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/complete-listening-activity-step.ts
@@ -26,7 +26,6 @@ export async function completeListeningActivityStep(
   }
 
   const readingActivity = await prisma.activity.findUnique({
-    select: { generationStatus: true },
     where: { id: reading.id },
   });
 

--- a/apps/api/src/workflows/activity-generation/steps/copy-language-review-steps-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/copy-language-review-steps-step.ts
@@ -20,7 +20,6 @@ export async function copyLanguageReviewStepsStep(
   }
 
   const current = await prisma.activity.findUnique({
-    select: { generationStatus: true },
     where: { id: languageReview.id },
   });
 

--- a/apps/api/src/workflows/activity-generation/steps/copy-listening-steps-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/copy-listening-steps-step.ts
@@ -20,7 +20,6 @@ export async function copyListeningStepsStep(
   }
 
   const current = await prisma.activity.findUnique({
-    select: { generationStatus: true },
     where: { id: listening.id },
   });
 

--- a/apps/api/src/workflows/activity-generation/steps/get-lesson-activities-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/get-lesson-activities-step.ts
@@ -5,36 +5,19 @@ import { streamError, streamStatus } from "../stream-status";
 
 async function getLessonActivities(lessonId: number) {
   const activities = await prisma.activity.findMany({
-    orderBy: { position: "asc" },
-    select: {
+    include: {
       _count: { select: { steps: true } },
-      description: true,
-      generationStatus: true,
-      id: true,
-      kind: true,
-      language: true,
       lesson: {
-        select: {
+        include: {
           chapter: {
-            select: {
-              course: {
-                select: {
-                  organization: { select: { id: true, slug: true } },
-                  targetLanguage: true,
-                  title: true,
-                },
-              },
-              title: true,
+            include: {
+              course: { include: { organization: true } },
             },
           },
-          description: true,
-          kind: true,
-          title: true,
         },
       },
-      lessonId: true,
-      title: true,
     },
+    orderBy: { position: "asc" },
     where: { lessonId },
   });
 

--- a/apps/api/src/workflows/activity-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/handle-failure-step.ts
@@ -9,7 +9,6 @@ export async function handleActivityFailureStep(input: {
   await safeAsync(() =>
     prisma.activity.update({
       data: { generationStatus: "failed" },
-      select: { generationStatus: true, id: true },
       where: { id: input.activityId },
     }),
   );

--- a/apps/api/src/workflows/activity-generation/steps/save-custom-activities-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-custom-activities-step.ts
@@ -5,7 +5,6 @@ import { type LessonActivity } from "./get-lesson-activities-step";
 
 async function saveActivity(activity: LessonActivity, workflowRunId: string): Promise<boolean> {
   const current = await prisma.activity.findUnique({
-    select: { generationStatus: true },
     where: { id: activity.id },
   });
 

--- a/apps/api/src/workflows/activity-generation/steps/set-activity-as-running-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/set-activity-as-running-step.ts
@@ -16,7 +16,6 @@ export async function setActivityAsRunningStep(input: {
         generationRunId: input.workflowRunId,
         generationStatus: "running",
       },
-      select: { generationStatus: true, id: true },
       where: { id: input.activityId },
     }),
   );

--- a/apps/api/src/workflows/chapter-generation/steps/add-lessons-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/add-lessons-step.ts
@@ -1,4 +1,4 @@
-import { prisma } from "@zoonk/db";
+import { type Lesson, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { normalizeString, toSlug } from "@zoonk/utils/string";
 import { streamError, streamStatus } from "../stream-status";
@@ -8,14 +8,7 @@ import { type ChapterContext } from "./get-chapter-step";
 export async function addLessonsStep(input: {
   context: ChapterContext;
   lessons: GeneratedLesson[];
-}): Promise<
-  {
-    id: number;
-    position: number;
-    slug: string;
-    title: string;
-  }[]
-> {
+}): Promise<Lesson[]> {
   "use step";
 
   await streamStatus({ status: "started", step: "addLessons" });
@@ -36,7 +29,6 @@ export async function addLessonsStep(input: {
   const { data: createdLessons, error } = await safeAsync(() =>
     prisma.lesson.createManyAndReturn({
       data: lessonsData,
-      select: { id: true, position: true, slug: true, title: true },
     }),
   );
 

--- a/apps/api/src/workflows/chapter-generation/steps/get-chapter-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/get-chapter-step.ts
@@ -4,29 +4,9 @@ import { streamError, streamStatus } from "../stream-status";
 
 async function getChapterForGeneration(chapterId: number) {
   return prisma.chapter.findUnique({
-    select: {
-      _count: {
-        select: {
-          lessons: true,
-        },
-      },
-      course: {
-        select: {
-          slug: true,
-          targetLanguage: true,
-          title: true,
-        },
-      },
-      courseId: true,
-      description: true,
-      generationRunId: true,
-      generationStatus: true,
-      id: true,
-      language: true,
-      organizationId: true,
-      position: true,
-      slug: true,
-      title: true,
+    include: {
+      _count: { select: { lessons: true } },
+      course: true,
     },
     where: { id: chapterId },
   });

--- a/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-completed-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-completed-step.ts
@@ -17,7 +17,6 @@ export async function setChapterAsCompletedStep(input: {
         generationRunId: input.workflowRunId,
         generationStatus: "completed",
       },
-      select: { generationStatus: true, id: true },
       where: { id: input.context.id },
     }),
   );

--- a/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-running-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-running-step.ts
@@ -16,7 +16,6 @@ export async function setChapterAsRunningStep(input: {
         generationRunId: input.workflowRunId,
         generationStatus: "running",
       },
-      select: { generationStatus: true, id: true },
       where: { id: input.chapterId },
     }),
   );

--- a/apps/api/src/workflows/course-generation/_internal/persist-generated-content.ts
+++ b/apps/api/src/workflows/course-generation/_internal/persist-generated-content.ts
@@ -1,9 +1,10 @@
+import { type Chapter } from "@zoonk/db";
 import { addAlternativeTitlesStep } from "../steps/add-alternative-titles-step";
 import { addCategoriesStep } from "../steps/add-categories-step";
 import { addChaptersStep } from "../steps/add-chapters-step";
 import { updateCourseStep } from "../steps/update-course-step";
 import { streamStatus } from "../stream-status";
-import { type CourseContext, type CreatedChapter, type ExistingCourseContent } from "../types";
+import { type CourseContext, type ExistingCourseContent } from "../types";
 import { type GeneratedContent } from "./generate-missing-content";
 
 async function emitSkippedPersistSteps(
@@ -30,7 +31,7 @@ export async function persistGeneratedContent(
   course: CourseContext,
   content: GeneratedContent,
   existing: ExistingCourseContent,
-): Promise<CreatedChapter[]> {
+): Promise<Chapter[]> {
   const needsCourseUpdate = !(existing.description && existing.imageUrl);
 
   const needsAlternativeTitles =
@@ -65,7 +66,7 @@ export async function persistGeneratedContent(
   const [chapters] = await Promise.all([
     needsChapters
       ? addChaptersStep({ chapters: content.chapters, course })
-      : Promise.resolve<CreatedChapter[]>([]),
+      : Promise.resolve<Chapter[]>([]),
     ...metadataOps,
   ]);
 

--- a/apps/api/src/workflows/course-generation/_internal/setup-course.ts
+++ b/apps/api/src/workflows/course-generation/_internal/setup-course.ts
@@ -1,15 +1,16 @@
+import { type Chapter } from "@zoonk/db";
 import { completeCourseSetupStep } from "../steps/complete-course-setup-step";
 import { getCourseChaptersStep } from "../steps/get-course-chapters-step";
 import { streamStatus } from "../stream-status";
-import { type CourseContext, type CreatedChapter, type ExistingCourseContent } from "../types";
+import { type CourseContext, type ExistingCourseContent } from "../types";
 import { generateMissingContent } from "./generate-missing-content";
 import { persistGeneratedContent } from "./persist-generated-content";
 
 async function getChapters(
   courseId: number,
-  createdChapters: CreatedChapter[],
+  createdChapters: Chapter[],
   hasChapters: boolean,
-): Promise<CreatedChapter[]> {
+): Promise<Chapter[]> {
   if (hasChapters) {
     return getCourseChaptersStep(courseId);
   }
@@ -22,7 +23,7 @@ export async function setupCourse(
   course: CourseContext,
   courseSuggestionId: number,
   existing: ExistingCourseContent,
-): Promise<CreatedChapter[]> {
+): Promise<Chapter[]> {
   const content = await generateMissingContent(course, existing);
 
   const createdChapters = await persistGeneratedContent(course, content, existing);

--- a/apps/api/src/workflows/course-generation/steps/add-chapters-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/add-chapters-step.ts
@@ -1,13 +1,13 @@
-import { prisma } from "@zoonk/db";
+import { type Chapter, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { normalizeString, toSlug } from "@zoonk/utils/string";
 import { streamError, streamStatus } from "../stream-status";
-import { type CourseContext, type CreatedChapter, type GeneratedChapter } from "../types";
+import { type CourseContext, type GeneratedChapter } from "../types";
 
 export async function addChaptersStep(input: {
   course: CourseContext;
   chapters: GeneratedChapter[];
-}): Promise<CreatedChapter[]> {
+}): Promise<Chapter[]> {
   "use step";
 
   await streamStatus({ status: "started", step: "addChapters" });
@@ -28,13 +28,6 @@ export async function addChaptersStep(input: {
   const { data: createdChapters, error } = await safeAsync(() =>
     prisma.chapter.createManyAndReturn({
       data: chaptersData,
-      select: {
-        description: true,
-        id: true,
-        position: true,
-        slug: true,
-        title: true,
-      },
     }),
   );
 

--- a/apps/api/src/workflows/course-generation/steps/check-existing-course-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/check-existing-course-step.ts
@@ -5,18 +5,19 @@ import { ensureLocaleSuffix, toSlug } from "@zoonk/utils/string";
 import { streamError, streamStatus } from "../stream-status";
 import { type CourseSuggestionData } from "../types";
 
-export type ExistingCourse = {
-  id: number;
-  slug: string;
-  generationStatus: string;
-  description: string | null;
-  imageUrl: string | null;
+const courseInclude = {
   _count: {
-    alternativeTitles: number;
-    categories: number;
-    chapters: number;
-  };
-};
+    select: {
+      alternativeTitles: true,
+      categories: true,
+      chapters: true,
+    },
+  },
+} as const;
+
+export type ExistingCourse = NonNullable<
+  Awaited<ReturnType<typeof prisma.course.findFirst<{ include: typeof courseInclude }>>>
+>;
 
 export async function checkExistingCourseStep(
   suggestion: CourseSuggestionData,
@@ -27,35 +28,18 @@ export async function checkExistingCourseStep(
 
   const normalizedSlug = toSlug(suggestion.slug);
 
-  const courseSelect = {
-    _count: {
-      select: {
-        alternativeTitles: true,
-        categories: true,
-        chapters: true,
-      },
-    },
-    description: true,
-    generationStatus: true,
-    id: true,
-    imageUrl: true,
-    slug: true,
-  } as const;
-
   const { data, error } = await safeAsync(() =>
     Promise.all([
       prisma.course.findFirst({
-        select: courseSelect,
+        include: courseInclude,
         where: {
           organization: { slug: AI_ORG_SLUG },
           slug: ensureLocaleSuffix(normalizedSlug, suggestion.language),
         },
       }),
       prisma.courseAlternativeTitle.findUnique({
-        select: {
-          course: {
-            select: courseSelect,
-          },
+        include: {
+          course: { include: courseInclude },
         },
         where: {
           languageSlug: { language: suggestion.language, slug: normalizedSlug },

--- a/apps/api/src/workflows/course-generation/steps/get-course-chapters-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/get-course-chapters-step.ts
@@ -1,9 +1,8 @@
-import { prisma } from "@zoonk/db";
+import { type Chapter, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { streamError, streamStatus } from "../stream-status";
-import { type CreatedChapter } from "../types";
 
-export async function getCourseChaptersStep(courseId: number): Promise<CreatedChapter[]> {
+export async function getCourseChaptersStep(courseId: number): Promise<Chapter[]> {
   "use step";
 
   await streamStatus({ status: "started", step: "getExistingChapters" });
@@ -11,13 +10,6 @@ export async function getCourseChaptersStep(courseId: number): Promise<CreatedCh
   const { data: chapters, error } = await safeAsync(() =>
     prisma.chapter.findMany({
       orderBy: { position: "asc" },
-      select: {
-        description: true,
-        id: true,
-        position: true,
-        slug: true,
-        title: true,
-      },
       where: { courseId },
     }),
   );

--- a/apps/api/src/workflows/course-generation/steps/get-course-suggestion-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/get-course-suggestion-step.ts
@@ -11,15 +11,6 @@ export async function getCourseSuggestionStep(
   await streamStatus({ status: "started", step: "getCourseSuggestion" });
 
   const suggestion = await prisma.courseSuggestion.findUnique({
-    select: {
-      description: true,
-      generationRunId: true,
-      generationStatus: true,
-      language: true,
-      slug: true,
-      targetLanguage: true,
-      title: true,
-    },
     where: { id: courseSuggestionId },
   });
 
@@ -37,14 +28,5 @@ export async function getCourseSuggestionStep(
 
   await streamStatus({ status: "completed", step: "getCourseSuggestion" });
 
-  return {
-    description: suggestion.description,
-    generationRunId: suggestion.generationRunId,
-    generationStatus: suggestion.generationStatus,
-    id: courseSuggestionId,
-    language: suggestion.language,
-    slug: suggestion.slug,
-    targetLanguage: suggestion.targetLanguage,
-    title: suggestion.title,
-  };
+  return suggestion;
 }

--- a/apps/api/src/workflows/course-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/handle-failure-step.ts
@@ -29,7 +29,6 @@ export async function handleChapterFailureStep(input: { chapterId: number }): Pr
   await safeAsync(() =>
     prisma.chapter.update({
       data: { generationStatus: "failed" },
-      select: { generationStatus: true, id: true },
       where: { id: input.chapterId },
     }),
   );

--- a/apps/api/src/workflows/course-generation/steps/initialize-course-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/initialize-course-step.ts
@@ -16,7 +16,6 @@ export async function initializeCourseStep(input: {
   const { suggestion, workflowRunId } = input;
 
   const aiOrg = await prisma.organization.findUniqueOrThrow({
-    select: { id: true },
     where: { slug: AI_ORG_SLUG },
   });
 
@@ -53,7 +52,6 @@ export async function initializeCourseStep(input: {
         targetLanguage: suggestion.targetLanguage,
         title: suggestion.title,
       },
-      select: { id: true, slug: true },
     }),
   );
 

--- a/apps/api/src/workflows/course-generation/types.ts
+++ b/apps/api/src/workflows/course-generation/types.ts
@@ -32,11 +32,3 @@ export type GeneratedChapter = {
   title: string;
   description: string;
 };
-
-export type CreatedChapter = {
-  id: number;
-  slug: string;
-  title: string;
-  description: string;
-  position: number;
-};

--- a/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.ts
@@ -4,32 +4,9 @@ import { streamError, streamStatus } from "../stream-status";
 
 async function getLessonForGeneration(lessonId: number) {
   return prisma.lesson.findUnique({
-    select: {
-      _count: {
-        select: {
-          activities: true,
-        },
-      },
-      chapter: {
-        select: {
-          course: {
-            select: {
-              targetLanguage: true,
-              title: true,
-            },
-          },
-          title: true,
-        },
-      },
-      description: true,
-      generationRunId: true,
-      generationStatus: true,
-      id: true,
-      kind: true,
-      language: true,
-      organizationId: true,
-      slug: true,
-      title: true,
+    include: {
+      _count: { select: { activities: true } },
+      chapter: { include: { course: true } },
     },
     where: { id: lessonId },
   });

--- a/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.ts
@@ -7,7 +7,6 @@ export async function handleLessonFailureStep(input: { lessonId: number }): Prom
   await safeAsync(() =>
     prisma.lesson.update({
       data: { generationStatus: "failed" },
-      select: { generationStatus: true, id: true },
       where: { id: input.lessonId },
     }),
   );

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-completed-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-completed-step.ts
@@ -17,7 +17,6 @@ export async function setLessonAsCompletedStep(input: {
         generationRunId: input.workflowRunId,
         generationStatus: "completed",
       },
-      select: { generationStatus: true, id: true },
       where: { id: input.context.id },
     }),
   );

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.ts
@@ -16,7 +16,6 @@ export async function setLessonAsRunningStep(input: {
         generationRunId: input.workflowRunId,
         generationStatus: "running",
       },
-      select: { generationStatus: true, id: true },
       where: { id: input.lessonId },
     }),
   );

--- a/apps/api/src/workflows/lesson-generation/steps/update-lesson-kind-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/update-lesson-kind-step.ts
@@ -13,7 +13,6 @@ export async function updateLessonKindStep(input: {
   const { error } = await safeAsync(() =>
     prisma.lesson.update({
       data: { kind: input.kind },
-      select: { id: true, kind: true },
       where: { id: input.lessonId },
     }),
   );

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
@@ -47,20 +47,12 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
 
   const { data, error } = await safeAsync(async () => {
     const activity = await prisma.activity.findUnique({
-      select: {
-        id: true,
-        kind: true,
-        lesson: { select: { chapter: { select: { courseId: true } } } },
-        organizationId: true,
+      include: {
+        lesson: { include: { chapter: true } },
         steps: {
+          include: { sentence: true, word: true },
+          omit: { visualContent: true },
           orderBy: { position: "asc" },
-          select: {
-            content: true,
-            id: true,
-            kind: true,
-            sentence: { select: { id: true, sentence: true, translation: true } },
-            word: { select: { id: true } },
-          },
           where: { isPublished: true },
         },
       },

--- a/apps/main/src/data/progress/submit-activity-completion.ts
+++ b/apps/main/src/data/progress/submit-activity-completion.ts
@@ -107,7 +107,6 @@ async function upsertDailyProgress(
   // When organizationId is null, the compound unique can't be used.
   // Find an existing record by individual fields instead.
   const existing = await tx.dailyProgress.findFirst({
-    select: { id: true },
     where: {
       date: params.date,
       organizationId: null,
@@ -208,7 +207,6 @@ export async function submitActivityCompletion(input: {
 
     // Find existing UserProgress to apply decay
     const existingProgress = await tx.userProgress.findUnique({
-      select: { currentEnergy: true, lastActiveAt: true },
       where: { userId: input.userId },
     });
 


### PR DESCRIPTION
## Summary

- Remove unnecessary top-level `select` from Prisma queries across workflow steps and main app, following the convention of returning full models
- Replace `select` with `include` for relation loading in data-fetching queries (`get-chapter-step`, `get-lesson-step`, `get-lesson-activities-step`, `check-existing-course-step`, `submit-completion-action`)
- Remove manual type definitions (`CreatedChapter`, `ExistingCourse`) in favor of Prisma-derived types (`Chapter`, `NonNullable<Awaited<ReturnType<...>>>`)
- Remove field-by-field reconstruction in `get-course-suggestion-step`, returning the full model directly

## Test plan

- [x] `pnpm typecheck` passes (all 15 tasks)
- [x] `pnpm test` passes (195 tests)
- [x] `pnpm --filter api build` and `pnpm --filter main build` succeed
- [x] `pnpm --filter main e2e` passes (378 tests)
- [x] `pnpm --filter api e2e` passes (56 tests)
- [x] `pnpm --filter editor e2e` passes (192 tests)
- [x] `pnpm knip --production` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized Prisma queries to return full models by removing unnecessary select statements. This reduces boilerplate, improves type safety, and keeps relation loading explicit with include/omit.

- **Refactors**
  - Replaced top-level select with include across activity, lesson, chapter, and course workflow steps, plus submit-completion-action.
  - Used omit where needed to exclude heavy fields (e.g., steps.visualContent).
  - Removed manual types (e.g., CreatedChapter, ExistingCourse) in favor of Prisma-derived types (Chapter, NonNullable<Awaited<...>>).
  - Updated step return types to return full models (e.g., addChaptersStep, addLessonsStep, getCourseChaptersStep, getCourseSuggestionStep).
  - Kept ordering and relation loading via include (e.g., lesson→chapter→course; steps.sentence/word).

<sup>Written for commit a020ad2d9eb17ade882faf88ff004c5d50f972ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

