### PR TITLE
refactor(main): replace xstate store with useReducer

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -21,8 +21,6 @@
     "@dnd-kit/utilities": "3.2.2",
     "@tabler/icons-react": "3.37.1",
     "@vercel/analytics": "1.6.1",
-    "@xstate/store": "3.16.0",
-    "@xstate/store-react": "1.0.1",
     "@zoonk/ai": "workspace:*",
     "@zoonk/core": "workspace:*",
     "@zoonk/db": "workspace:*",

--- a/apps/main/src/lib/workflow/generation-store.test.ts
+++ b/apps/main/src/lib/workflow/generation-store.test.ts
@@ -1,110 +1,130 @@
 import { describe, expect, it } from "vitest";
-import { type StreamMessage, createGenerationStore, handleStreamMessage } from "./generation-store";
+import {
+  type GenerationAction,
+  type GenerationState,
+  type StreamMessage,
+  generationReducer,
+  handleStreamMessage,
+  initialGenerationState,
+} from "./generation-store";
 
-describe(createGenerationStore, () => {
+describe(generationReducer, () => {
   describe("stepCompleted", () => {
     it("adds step to completedSteps", () => {
-      const store = createGenerationStore<"stepA" | "stepB">();
-      store.send({ step: "stepA", type: "stepCompleted" });
-      expect(store.getSnapshot().context.completedSteps).toEqual(["stepA"]);
+      const state = generationReducer(initialGenerationState(), {
+        step: "stepA",
+        type: "stepCompleted",
+      });
+      expect(state.completedSteps).toEqual(["stepA"]);
     });
 
     it("does not add duplicate steps", () => {
-      const store = createGenerationStore<"stepA" | "stepB">();
-      store.send({ step: "stepA", type: "stepCompleted" });
-      store.send({ step: "stepA", type: "stepCompleted" });
-      expect(store.getSnapshot().context.completedSteps).toEqual(["stepA"]);
+      const first = generationReducer(initialGenerationState(), {
+        step: "stepA",
+        type: "stepCompleted",
+      });
+      const second = generationReducer(first, { step: "stepA", type: "stepCompleted" });
+      expect(second.completedSteps).toEqual(["stepA"]);
     });
 
     it("clears currentStep when it matches the completed step", () => {
-      const store = createGenerationStore<"stepA" | "stepB">({
-        currentStep: "stepA",
+      const state = generationReducer(initialGenerationState({ currentStep: "stepA" }), {
+        step: "stepA",
+        type: "stepCompleted",
       });
-      store.send({ step: "stepA", type: "stepCompleted" });
-      expect(store.getSnapshot().context.currentStep).toBeNull();
+      expect(state.currentStep).toBeNull();
     });
 
     it("does NOT clear currentStep when a different step completes", () => {
-      const store = createGenerationStore<"stepA" | "stepB">({
-        currentStep: "stepB",
+      const state = generationReducer(initialGenerationState({ currentStep: "stepB" }), {
+        step: "stepA",
+        type: "stepCompleted",
       });
-      store.send({ step: "stepA", type: "stepCompleted" });
-      expect(store.getSnapshot().context.currentStep).toBe("stepB");
+      expect(state.currentStep).toBe("stepB");
     });
   });
 
   describe("stepStarted", () => {
     it("sets currentStep", () => {
-      const store = createGenerationStore<"stepA" | "stepB">();
-      store.send({ step: "stepA", type: "stepStarted" });
-      expect(store.getSnapshot().context.currentStep).toBe("stepA");
+      const state = generationReducer(initialGenerationState(), {
+        step: "stepA",
+        type: "stepStarted",
+      });
+      expect(state.currentStep).toBe("stepA");
     });
   });
 
   describe("workflowCompleted", () => {
     it("does not transition from error state", () => {
-      const store = createGenerationStore({
-        error: "Some error",
-        status: "error",
-      });
-      store.send({ type: "workflowCompleted" });
-      expect(store.getSnapshot().context.status).toBe("error");
+      const state = generationReducer(
+        initialGenerationState({ error: "Some error", status: "error" }),
+        {
+          type: "workflowCompleted",
+        },
+      );
+      expect(state.status).toBe("error");
     });
 
     it("transitions to completed from streaming state", () => {
-      const store = createGenerationStore({ status: "streaming" });
-      store.send({ type: "workflowCompleted" });
-      expect(store.getSnapshot().context.status).toBe("completed");
+      const state = generationReducer(initialGenerationState({ status: "streaming" }), {
+        type: "workflowCompleted",
+      });
+      expect(state.status).toBe("completed");
     });
   });
 });
 
 describe(handleStreamMessage, () => {
+  function applyActions(actions: GenerationAction[], initial: GenerationState) {
+    let state = initial;
+    for (const action of actions) {
+      state = generationReducer(state, action);
+    }
+    return state;
+  }
+
+  function applyMessage(
+    message: StreamMessage,
+    initial?: Parameters<typeof initialGenerationState>[0],
+  ) {
+    const actions: GenerationAction[] = [];
+    handleStreamMessage(message, (a) => actions.push(a));
+    return applyActions(actions, initialGenerationState(initial));
+  }
+
   it("routes 'started' to stepStarted", () => {
-    const store = createGenerationStore<"stepA">();
-    const message: StreamMessage<"stepA"> = { status: "started", step: "stepA" };
-    handleStreamMessage(message, store);
-    expect(store.getSnapshot().context.currentStep).toBe("stepA");
+    const state = applyMessage({ status: "started", step: "stepA" });
+    expect(state.currentStep).toBe("stepA");
   });
 
   it("routes 'completed' to stepCompleted", () => {
-    const store = createGenerationStore<"stepA">();
-    const message: StreamMessage<"stepA"> = { status: "completed", step: "stepA" };
-    handleStreamMessage(message, store);
-    expect(store.getSnapshot().context.completedSteps).toEqual(["stepA"]);
+    const state = applyMessage({ status: "completed", step: "stepA" });
+    expect(state.completedSteps).toEqual(["stepA"]);
   });
 
   it("triggers workflowCompleted on completionStep match", () => {
-    const store = createGenerationStore<"stepA" | "done">({ status: "streaming" });
-    const message: StreamMessage<"stepA" | "done"> = { status: "completed", step: "done" };
-    handleStreamMessage(message, store, "done");
-    expect(store.getSnapshot().context.status).toBe("completed");
+    const actions: GenerationAction[] = [];
+    handleStreamMessage({ status: "completed", step: "done" }, (a) => actions.push(a), "done");
+    const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
+    expect(state.status).toBe("completed");
   });
 
   it("does not trigger workflowCompleted for non-completion steps", () => {
-    const store = createGenerationStore<"stepA" | "done">({ status: "streaming" });
-    const message: StreamMessage<"stepA" | "done"> = { status: "completed", step: "stepA" };
-    handleStreamMessage(message, store, "done");
-    expect(store.getSnapshot().context.status).toBe("streaming");
+    const actions: GenerationAction[] = [];
+    handleStreamMessage({ status: "completed", step: "stepA" }, (a) => actions.push(a), "done");
+    const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
+    expect(state.status).toBe("streaming");
   });
 
   it("routes 'error' to setError with step name", () => {
-    const store = createGenerationStore<"stepA">();
-    const message: StreamMessage<"stepA"> = { status: "error", step: "stepA" };
-    handleStreamMessage(message, store);
-    expect(store.getSnapshot().context.status).toBe("error");
-    expect(store.getSnapshot().context.error).toBe('Step "stepA" failed');
+    const state = applyMessage({ status: "error", step: "stepA" });
+    expect(state.status).toBe("error");
+    expect(state.error).toBe('Step "stepA" failed');
   });
 
   it("routes 'error' with reason to setError", () => {
-    const store = createGenerationStore<"stepA">();
-    const message: StreamMessage<"stepA"> = {
-      reason: "aiGenerationFailed",
-      status: "error",
-      step: "stepA",
-    };
-    handleStreamMessage(message, store);
-    expect(store.getSnapshot().context.status).toBe("error");
-    expect(store.getSnapshot().context.error).toBe("stepA: aiGenerationFailed");
+    const state = applyMessage({ reason: "aiGenerationFailed", status: "error", step: "stepA" });
+    expect(state.status).toBe("error");
+    expect(state.error).toBe("stepA: aiGenerationFailed");
   });
 });

--- a/apps/main/src/lib/workflow/generation-store.test.ts
+++ b/apps/main/src/lib/workflow/generation-store.test.ts
@@ -54,22 +54,44 @@ describe(generationReducer, () => {
     });
   });
 
-  describe("workflowCompleted", () => {
+  describe("streamEnded", () => {
     it("does not transition from error state", () => {
       const state = generationReducer(
         initialGenerationState({ error: "Some error", status: "error" }),
-        {
-          type: "workflowCompleted",
-        },
+        { type: "streamEnded" },
       );
       expect(state.status).toBe("error");
     });
 
-    it("transitions to completed from streaming state", () => {
-      const state = generationReducer(initialGenerationState({ status: "streaming" }), {
-        type: "workflowCompleted",
+    it("does not transition from completed state", () => {
+      const state = generationReducer(initialGenerationState({ status: "completed" }), {
+        type: "streamEnded",
       });
       expect(state.status).toBe("completed");
+    });
+
+    it("transitions to completed from streaming state", () => {
+      const state = generationReducer(initialGenerationState({ status: "streaming" }), {
+        type: "streamEnded",
+      });
+      expect(state.status).toBe("completed");
+    });
+
+    it("transitions to completed when completionStep is in completedSteps", () => {
+      const state = generationReducer(
+        initialGenerationState({ completedSteps: ["done"], status: "streaming" }),
+        { completionStep: "done", type: "streamEnded" },
+      );
+      expect(state.status).toBe("completed");
+    });
+
+    it("transitions to error when completionStep is missing from completedSteps", () => {
+      const state = generationReducer(initialGenerationState({ status: "streaming" }), {
+        completionStep: "done",
+        type: "streamEnded",
+      });
+      expect(state.status).toBe("error");
+      expect(state.error).toBe("Generation ended unexpectedly. Please try again.");
     });
   });
 });
@@ -102,14 +124,14 @@ describe(handleStreamMessage, () => {
     expect(state.completedSteps).toEqual(["stepA"]);
   });
 
-  it("triggers workflowCompleted on completionStep match", () => {
+  it("triggers streamEnded on completionStep match", () => {
     const actions: GenerationAction[] = [];
     handleStreamMessage({ status: "completed", step: "done" }, (a) => actions.push(a), "done");
     const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
     expect(state.status).toBe("completed");
   });
 
-  it("does not trigger workflowCompleted for non-completion steps", () => {
+  it("does not trigger streamEnded for non-completion steps", () => {
     const actions: GenerationAction[] = [];
     handleStreamMessage({ status: "completed", step: "stepA" }, (a) => actions.push(a), "done");
     const state = applyActions(actions, initialGenerationState({ status: "streaming" }));

--- a/apps/main/src/lib/workflow/generation-store.ts
+++ b/apps/main/src/lib/workflow/generation-store.ts
@@ -21,9 +21,9 @@ export type GenerationAction<TStep extends string = string> =
   | { type: "setError"; error: string }
   | { type: "stepCompleted"; step: TStep }
   | { type: "stepStarted"; step: TStep }
+  | { type: "streamEnded"; completionStep?: TStep }
   | { type: "triggerStart" }
-  | { type: "triggerSuccess"; runId: string }
-  | { type: "workflowCompleted" };
+  | { type: "triggerSuccess"; runId: string };
 
 export function initialGenerationState<TStep extends string = string>(
   overrides?: Partial<GenerationState<TStep>>,
@@ -64,12 +64,23 @@ export function generationReducer<TStep extends string>(
           ? state.startedSteps
           : [...state.startedSteps, action.step],
       };
+    case "streamEnded":
+      if (state.status === "completed" || state.status === "error") {
+        return state;
+      }
+      if (action.completionStep && !state.completedSteps.includes(action.completionStep)) {
+        return {
+          ...state,
+          error: "Generation ended unexpectedly. Please try again.",
+          status: "error",
+        };
+      }
+      return { ...state, status: "completed" };
+
     case "triggerStart":
       return { ...state, error: null, status: "triggering" };
     case "triggerSuccess":
       return { ...state, runId: action.runId, status: "streaming" };
-    case "workflowCompleted":
-      return state.status === "error" ? state : { ...state, status: "completed" };
     default: {
       const exhaustiveCheck: never = action;
       throw new Error(`Unexpected action: ${JSON.stringify(exhaustiveCheck)}`);
@@ -89,7 +100,7 @@ export function handleStreamMessage<TStep extends string>(
     case "completed":
       dispatch({ step: message.step, type: "stepCompleted" });
       if (completionStep && message.step === completionStep) {
-        dispatch({ type: "workflowCompleted" });
+        dispatch({ completionStep, type: "streamEnded" });
       }
       break;
     case "error": {

--- a/apps/main/src/lib/workflow/generation-store.ts
+++ b/apps/main/src/lib/workflow/generation-store.ts
@@ -1,5 +1,3 @@
-import { createStore } from "@xstate/store";
-
 export type StepStatus = "started" | "completed" | "error";
 export type GenerationStatus = "idle" | "triggering" | "streaming" | "completed" | "error";
 
@@ -9,102 +7,96 @@ export type StreamMessage<TStep extends string = string> = {
   status: StepStatus;
 };
 
-export function createGenerationStore<TStep extends string = string>(
-  initialContext?: Partial<{
-    completedSteps: TStep[];
-    currentStep: TStep | null;
-    error: string | null;
-    runId: string | null;
-    status: GenerationStatus;
-  }>,
-) {
-  return createStore({
-    context: {
-      completedSteps: [] as TStep[],
-      currentStep: null as TStep | null,
-      error: null as string | null,
-      runId: null as string | null,
-      startedSteps: [] as TStep[],
-      status: "idle" as GenerationStatus,
-      ...initialContext,
-    },
-    on: {
-      reset: () => ({
-        completedSteps: [] as TStep[],
-        currentStep: null as TStep | null,
-        error: null as string | null,
-        runId: null as string | null,
-        startedSteps: [] as TStep[],
-        status: "idle" as GenerationStatus,
-      }),
+export type GenerationState<TStep extends string = string> = {
+  completedSteps: TStep[];
+  currentStep: TStep | null;
+  error: string | null;
+  runId: string | null;
+  startedSteps: TStep[];
+  status: GenerationStatus;
+};
 
-      setError: (ctx, event: { error: string }) => ({
-        ...ctx,
-        error: event.error,
-        status: "error" as const,
-      }),
+export type GenerationAction<TStep extends string = string> =
+  | { type: "reset" }
+  | { type: "setError"; error: string }
+  | { type: "stepCompleted"; step: TStep }
+  | { type: "stepStarted"; step: TStep }
+  | { type: "triggerStart" }
+  | { type: "triggerSuccess"; runId: string }
+  | { type: "workflowCompleted" };
 
-      stepCompleted: (ctx, event: { step: TStep }) => ({
-        ...ctx,
-        completedSteps: ctx.completedSteps.includes(event.step)
-          ? ctx.completedSteps
-          : [...ctx.completedSteps, event.step],
-        currentStep: ctx.currentStep === event.step ? null : ctx.currentStep,
-      }),
+export function initialGenerationState<TStep extends string = string>(
+  overrides?: Partial<GenerationState<TStep>>,
+): GenerationState<TStep> {
+  return {
+    completedSteps: [] as TStep[],
+    currentStep: null,
+    error: null,
+    runId: null,
+    startedSteps: [] as TStep[],
+    status: "idle",
+    ...overrides,
+  };
+}
 
-      stepStarted: (ctx, event: { step: TStep }) => ({
-        ...ctx,
-        currentStep: event.step,
-        startedSteps: ctx.startedSteps.includes(event.step)
-          ? ctx.startedSteps
-          : [...ctx.startedSteps, event.step],
-      }),
-      triggerStart: (ctx) => ({
-        ...ctx,
-        error: null,
-        status: "triggering" as const,
-      }),
-
-      triggerSuccess: (ctx, event: { runId: string }) => ({
-        ...ctx,
-        runId: event.runId,
-        status: "streaming" as const,
-      }),
-
-      workflowCompleted: (ctx) => {
-        // Don't transition to completed if there was an error
-        if (ctx.status === "error") {
-          return ctx;
-        }
-        return {
-          ...ctx,
-          status: "completed" as const,
-        };
-      },
-    },
-  });
+export function generationReducer<TStep extends string>(
+  state: GenerationState<TStep>,
+  action: GenerationAction<TStep>,
+): GenerationState<TStep> {
+  switch (action.type) {
+    case "reset":
+      return initialGenerationState<TStep>();
+    case "setError":
+      return { ...state, error: action.error, status: "error" };
+    case "stepCompleted":
+      return {
+        ...state,
+        completedSteps: state.completedSteps.includes(action.step)
+          ? state.completedSteps
+          : [...state.completedSteps, action.step],
+        currentStep: state.currentStep === action.step ? null : state.currentStep,
+      };
+    case "stepStarted":
+      return {
+        ...state,
+        currentStep: action.step,
+        startedSteps: state.startedSteps.includes(action.step)
+          ? state.startedSteps
+          : [...state.startedSteps, action.step],
+      };
+    case "triggerStart":
+      return { ...state, error: null, status: "triggering" };
+    case "triggerSuccess":
+      return { ...state, runId: action.runId, status: "streaming" };
+    case "workflowCompleted":
+      return state.status === "error" ? state : { ...state, status: "completed" };
+    default: {
+      const exhaustiveCheck: never = action;
+      throw new Error(`Unexpected action: ${JSON.stringify(exhaustiveCheck)}`);
+    }
+  }
 }
 
 export function handleStreamMessage<TStep extends string>(
   message: StreamMessage<TStep>,
-  store: ReturnType<typeof createGenerationStore<TStep>>,
+  dispatch: (action: GenerationAction<TStep>) => void,
   completionStep?: TStep,
 ) {
   switch (message.status) {
     case "started":
-      store.send({ step: message.step, type: "stepStarted" });
+      dispatch({ step: message.step, type: "stepStarted" });
       break;
     case "completed":
-      store.send({ step: message.step, type: "stepCompleted" });
+      dispatch({ step: message.step, type: "stepCompleted" });
       if (completionStep && message.step === completionStep) {
-        store.send({ type: "workflowCompleted" });
+        dispatch({ type: "workflowCompleted" });
       }
       break;
     case "error": {
       const errorMessage = message.reason
         ? `${message.step}: ${message.reason}`
         : `Step "${message.step}" failed`;
-      store.send({ error: errorMessage, type: "setError" });
+      dispatch({ error: errorMessage, type: "setError" });
       break;
     }
     default: {

--- a/apps/main/src/lib/workflow/use-workflow-generation.ts
+++ b/apps/main/src/lib/workflow/use-workflow-generation.ts
@@ -40,19 +40,7 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
   );
 
   const handleComplete = useEffectEvent(() => {
-    if (state.status === "completed" || state.status === "error") {
-      return;
-    }
-
-    if (completionStep && !state.completedSteps.includes(completionStep)) {
-      dispatch({
-        error: "Generation ended unexpectedly. Please try again.",
-        type: "setError",
-      });
-      return;
-    }
-
-    dispatch({ type: "workflowCompleted" });
+    dispatch({ completionStep, type: "streamEnded" });
   });
 
   const handleError = useEffectEvent((err: Error) =>

--- a/apps/main/src/lib/workflow/use-workflow-generation.ts
+++ b/apps/main/src/lib/workflow/use-workflow-generation.ts
@@ -1,13 +1,15 @@
 "use client";
 
-import { useSelector } from "@xstate/store-react";
 import { getString } from "@zoonk/utils/json";
-import { useCallback, useEffect, useEffectEvent, useMemo, useRef } from "react";
+import { useCallback, useEffect, useEffectEvent, useReducer, useRef } from "react";
 import {
+  type GenerationAction,
+  type GenerationState,
   type GenerationStatus,
   type StreamMessage,
-  createGenerationStore,
+  generationReducer,
   handleStreamMessage,
+  initialGenerationState,
 } from "./generation-store";
 import { useSSE } from "./use-sse";
 
@@ -23,54 +25,42 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
   const { autoTrigger = true, completionStep, statusUrl, triggerBody, triggerUrl } = config;
   const hasTriggeredRef = useRef(false);
 
-  const store = useMemo(
-    () =>
-      createGenerationStore<TStep>({
-        runId: config.initialRunId ?? null,
-        status: config.initialRunId ? "streaming" : (config.initialStatus ?? "idle"),
-      }),
-    [config.initialRunId, config.initialStatus],
+  // Wrapper preserves the TStep generic that useReducer would otherwise widen to string.
+  const [state, dispatch] = useReducer(
+    (prev: GenerationState<TStep>, action: GenerationAction<TStep>) =>
+      generationReducer(prev, action),
+    initialGenerationState<TStep>({
+      runId: config.initialRunId ?? null,
+      status: config.initialRunId ? "streaming" : (config.initialStatus ?? "idle"),
+    }),
   );
 
-  const completedSteps = useSelector(store, (state) => state.context.completedSteps);
-  const currentStep = useSelector(store, (state) => state.context.currentStep);
-  const storeError = useSelector(store, (state) => state.context.error);
-  const runId = useSelector(store, (state) => state.context.runId);
-  const startedSteps = useSelector(store, (state) => state.context.startedSteps);
-  const status = useSelector(store, (state) => state.context.status);
-
-  const handleMessage = useCallback(
-    (msg: StreamMessage<TStep>) => handleStreamMessage(msg, store, completionStep),
-    [store, completionStep],
+  const handleMessage = useEffectEvent((msg: StreamMessage<TStep>) =>
+    handleStreamMessage(msg, dispatch, completionStep),
   );
 
-  const handleComplete = useCallback(() => {
-    const snapshot = store.getSnapshot();
-
-    // If handleStreamMessage already transitioned to completed or error, do nothing.
-    if (snapshot.context.status === "completed" || snapshot.context.status === "error") {
+  const handleComplete = useEffectEvent(() => {
+    if (state.status === "completed" || state.status === "error") {
       return;
     }
 
-    // Stream ended without the completion step — premature close.
-    if (completionStep && !snapshot.context.completedSteps.includes(completionStep)) {
-      store.send({
+    if (completionStep && !state.completedSteps.includes(completionStep)) {
+      dispatch({
         error: "Generation ended unexpectedly. Please try again.",
         type: "setError",
       });
       return;
     }
 
-    store.send({ type: "workflowCompleted" });
-  }, [store, completionStep]);
+    dispatch({ type: "workflowCompleted" });
+  });
 
-  const handleError = useCallback(
-    (err: Error) => store.send({ error: err.message, type: "setError" }),
-    [store],
+  const handleError = useEffectEvent((err: Error) =>
+    dispatch({ error: err.message, type: "setError" }),
   );
 
   const { resetIndex } = useSSE<StreamMessage<TStep>>(
-    status === "streaming" && runId ? `${statusUrl}?runId=${runId}` : null,
+    state.status === "streaming" && state.runId ? `${statusUrl}?runId=${state.runId}` : null,
     {
       onComplete: handleComplete,
       onError: handleError,
@@ -79,7 +69,7 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
   );
 
   const startTrigger = useEffectEvent(async () => {
-    store.send({ type: "triggerStart" });
+    dispatch({ type: "triggerStart" });
 
     try {
       const response = await fetch(triggerUrl, {
@@ -100,9 +90,9 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
         throw new Error("Invalid response: missing runId");
       }
 
-      store.send({ runId: newRunId, type: "triggerSuccess" });
+      dispatch({ runId: newRunId, type: "triggerSuccess" });
     } catch (error) {
-      store.send({
+      dispatch({
         error: error instanceof Error ? error.message : "Failed to start",
         type: "setError",
       });
@@ -110,25 +100,25 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
   });
 
   useEffect(() => {
-    if (!autoTrigger || status !== "idle" || hasTriggeredRef.current) {
+    if (!autoTrigger || state.status !== "idle" || hasTriggeredRef.current) {
       return;
     }
     hasTriggeredRef.current = true;
     void startTrigger();
-  }, [autoTrigger, status]);
+  }, [autoTrigger, state.status]);
 
   const retry = useCallback(() => {
     hasTriggeredRef.current = false;
     resetIndex();
-    store.send({ type: "reset" });
-  }, [resetIndex, store]);
+    dispatch({ type: "reset" });
+  }, [resetIndex]);
 
   return {
-    completedSteps,
-    currentStep,
-    error: storeError,
+    completedSteps: state.completedSteps,
+    currentStep: state.currentStep,
+    error: state.error,
     retry,
-    startedSteps,
-    status,
+    startedSteps: state.startedSteps,
+    status: state.status,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,12 +355,6 @@ importers:
       '@vercel/analytics':
         specifier: 1.6.1
         version: 1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
-      '@xstate/store':
-        specifier: 3.16.0
-        version: 3.16.0(react@19.2.4)
-      '@xstate/store-react':
-        specifier: 1.0.1
-        version: 1.0.1(react@19.2.4)
       '@zoonk/ai':
         specifier: workspace:*
         version: link:../../packages/ai
@@ -3815,22 +3809,6 @@ packages:
   '@xhmikosr/os-filter-obj@3.0.0':
     resolution: {integrity: sha512-siPY6BD5dQ2SZPl3I0OZBHL27ZqZvLEosObsZRQ1NUB8qcxegwt0T9eKtV96JMFQpIz1elhkzqOg4c/Ri6Dp9A==}
     engines: {node: ^14.14.0 || >=16.0.0}
-
-  '@xstate/store-react@1.0.1':
-    resolution: {integrity: sha512-J/pShjtAXYNZDLVGdx1W0OSH8kon1/pFjaQYpXEJpqsG4jAdptO0YjguqAIHK+3UvMSBf5HYlO+gMS0rRhkz8A==}
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-
-  '@xstate/store@3.16.0':
-    resolution: {integrity: sha512-FWIapfCeTN99Nrhwe/r5qABcyDdeGM6gZ+SNL5IF50a2vgtEzhYthS9MYEz4HXjqxXdGN+WaMb+CIzv62jGRbA==}
-    peerDependencies:
-      react: ^18.2.0 || ^19.0.0
-      solid-js: ^1.7.6
-    peerDependenciesMeta:
-      react:
-        optional: true
-      solid-js:
-        optional: true
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -9908,17 +9886,6 @@ snapshots:
   '@xhmikosr/os-filter-obj@3.0.0':
     dependencies:
       arch: 3.0.0
-
-  '@xstate/store-react@1.0.1(react@19.2.4)':
-    dependencies:
-      '@xstate/store': 3.16.0(react@19.2.4)
-      react: 19.2.4
-    transitivePeerDependencies:
-      - solid-js
-
-  '@xstate/store@3.16.0(react@19.2.4)':
-    optionalDependencies:
-      react: 19.2.4
 
   '@xtuc/ieee754@1.2.0': {}
 


### PR DESCRIPTION
## Summary
- Replace `@xstate/store` and `@xstate/store-react` with React's built-in `useReducer`
- Replace `useCallback` + `stateRef` pattern with `useEffectEvent` for SSE callbacks
- Update tests to use pure reducer function calls instead of mutable store instances

## Test plan
- [x] All 331 unit/integration tests pass
- [x] `pnpm --filter main build` succeeds
- [x] `pnpm knip --production` clean
- [x] Lint and typecheck pass for changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced XState with React useReducer for workflow generation, and moved completion handling into the reducer to prevent stale state and premature/incorrect completions.

- **Bug Fixes**
  - Moved completion check into the reducer via a new streamEnded action to avoid stale snapshots.
  - handleStreamMessage now dispatches streamEnded when the completion step finishes; premature stream end sets a clear error.

- **Refactors**
  - Added GenerationState/GenerationAction, generationReducer, and initialGenerationState.
  - Replaced workflowCompleted with streamEnded; handleStreamMessage now dispatches actions.
  - useWorkflowGeneration uses useReducer and useEffectEvent; simplified retry/reset flow.
  - Tests use pure reducer action sequences; added cases for streamEnded success/failure.
  - Removed @xstate/store and @xstate/store-react.

<sup>Written for commit 73578ba7a32b99213cd9e60680f94ef3aefeaffe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

