### PR TITLE
feat(db): add concepts column to lesson model

### DIFF
--- a/packages/db/src/prisma/migrations/20260302183930_add_lesson_concepts/migration.sql
+++ b/packages/db/src/prisma/migrations/20260302183930_add_lesson_concepts/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "lessons" ADD COLUMN     "concepts" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/packages/db/src/prisma/models/lessons.prisma
+++ b/packages/db/src/prisma/models/lessons.prisma
@@ -12,6 +12,7 @@ model Lesson {
   title            String
   normalizedTitle  String           @map("normalized_title")
   description      String
+  concepts         String[]         @default([])
   generationStatus GenerationStatus @default(pending) @map("generation_status")
   generationRunId  String?          @map("generation_run_id")
   position         Int

--- a/packages/db/src/prisma/seed/lessons.ts
+++ b/packages/db/src/prisma/seed/lessons.ts
@@ -10,6 +10,7 @@ const lessonsData: {
   chapterSlug: string;
   language: string;
   lessons: {
+    concepts: string[];
     description: string;
     generationStatus: GenerationStatus;
     isPublished: boolean;
@@ -23,6 +24,13 @@ const lessonsData: {
     language: "en",
     lessons: [
       {
+        concepts: [
+          "definition of machine learning",
+          "traditional programming vs ML",
+          "training data",
+          "model predictions",
+          "pattern recognition",
+        ],
         description:
           "Learn what machine learning is and how it differs from traditional programming.",
         generationStatus: "completed",
@@ -31,6 +39,13 @@ const lessonsData: {
         title: "What is Machine Learning?",
       },
       {
+        concepts: [
+          "origins of artificial intelligence",
+          "perceptron model",
+          "neural network winter",
+          "deep learning revolution",
+          "modern ML milestones",
+        ],
         description:
           "Explore the history of machine learning from its origins to modern developments.",
         generationStatus: "completed",
@@ -39,6 +54,13 @@ const lessonsData: {
         title: "History of Machine Learning",
       },
       {
+        concepts: [
+          "supervised learning",
+          "unsupervised learning",
+          "reinforcement learning",
+          "labeled vs unlabeled data",
+          "reward-based training",
+        ],
         description: "Understand supervised, unsupervised, and reinforcement learning approaches.",
         generationStatus: "completed",
         isPublished: false,
@@ -53,6 +75,13 @@ const lessonsData: {
     language: "pt",
     lessons: [
       {
+        concepts: [
+          "definição de machine learning",
+          "programação tradicional vs ML",
+          "dados de treinamento",
+          "previsões de modelo",
+          "reconhecimento de padrões",
+        ],
         description:
           "Aprenda o que é machine learning e como ele difere da programação tradicional.",
         generationStatus: "completed",
@@ -61,6 +90,13 @@ const lessonsData: {
         title: "O que é Machine Learning?",
       },
       {
+        concepts: [
+          "origens da inteligência artificial",
+          "modelo perceptron",
+          "inverno das redes neurais",
+          "revolução do deep learning",
+          "marcos modernos do ML",
+        ],
         description:
           "Explore a história do machine learning desde suas origens até os desenvolvimentos modernos.",
         generationStatus: "completed",
@@ -75,6 +111,12 @@ const lessonsData: {
     language: "en",
     lessons: [
       {
+        concepts: [
+          "structured vs unstructured data",
+          "public datasets",
+          "data quality metrics",
+          "dataset size considerations",
+        ],
         description:
           "Learn about different types of datasets and where to find quality data for your projects.",
         generationStatus: "pending",
@@ -83,6 +125,13 @@ const lessonsData: {
         title: "Understanding Datasets",
       },
       {
+        concepts: [
+          "handling missing values",
+          "outlier detection",
+          "data normalization",
+          "feature encoding",
+          "data validation",
+        ],
         description: "Master techniques for cleaning and preprocessing raw data before training.",
         generationStatus: "pending",
         isPublished: true,
@@ -96,6 +145,13 @@ const lessonsData: {
     language: "en",
     lessons: [
       {
+        concepts: [
+          "Spanish vowel sounds",
+          "consonant pronunciation",
+          "letter ñ",
+          "accent marks",
+          "alphabet song",
+        ],
         description: "Learn the Spanish alphabet, vowel sounds, and basic pronunciation rules.",
         generationStatus: "completed",
         isPublished: true,
@@ -103,6 +159,12 @@ const lessonsData: {
         title: "The Spanish Alphabet",
       },
       {
+        concepts: [
+          "hola and adiós",
+          "formal vs informal greetings",
+          "introducing yourself",
+          "asking someone's name",
+        ],
         description: "Master common greetings and introductions for everyday conversations.",
         generationStatus: "pending",
         isPublished: true,
@@ -116,6 +178,13 @@ const lessonsData: {
     language: "en",
     lessons: [
       {
+        concepts: [
+          "solar structure",
+          "nuclear fusion",
+          "solar energy output",
+          "Sun's life cycle",
+          "solar wind",
+        ],
         description: "Learn about the Sun, its structure, and its importance to our solar system.",
         generationStatus: "completed",
         isPublished: true,
@@ -123,6 +192,13 @@ const lessonsData: {
         title: "The Sun",
       },
       {
+        concepts: [
+          "Mercury's orbit",
+          "Venus atmosphere",
+          "Earth's water",
+          "Mars surface features",
+          "rocky planet characteristics",
+        ],
         description: "Explore the inner planets: Mercury, Venus, Earth, and Mars.",
         generationStatus: "pending",
         isPublished: true,
@@ -136,6 +212,12 @@ const lessonsData: {
     language: "en",
     lessons: [
       {
+        concepts: [
+          "Python installation",
+          "REPL environment",
+          "Hello World program",
+          "running Python scripts",
+        ],
         description: "Set up Python on your computer and write your first Hello World program.",
         generationStatus: "completed",
         isPublished: true,
@@ -143,6 +225,14 @@ const lessonsData: {
         title: "Getting Started with Python",
       },
       {
+        concepts: [
+          "variable assignment",
+          "integers and floats",
+          "strings",
+          "booleans",
+          "type conversion",
+          "arithmetic operators",
+        ],
         description: "Understand variables, data types, and basic operations in Python.",
         generationStatus: "pending",
         isPublished: true,
@@ -156,6 +246,13 @@ const lessonsData: {
     language: "en",
     lessons: [
       {
+        concepts: [
+          "HTML document structure",
+          "tags and elements",
+          "head vs body",
+          "creating a web page",
+          "HTML attributes",
+        ],
         description:
           "Understand HTML document structure, elements, and create your first web page.",
         generationStatus: "completed",
@@ -164,6 +261,13 @@ const lessonsData: {
         title: "Introduction to HTML",
       },
       {
+        concepts: [
+          "semantic elements",
+          "header and footer tags",
+          "article and section",
+          "accessibility benefits",
+          "SEO impact",
+        ],
         description:
           "Learn about semantic HTML elements and how to structure content meaningfully.",
         generationStatus: "pending",
@@ -178,6 +282,12 @@ const lessonsData: {
     language: "en",
     lessons: [
       {
+        concepts: [
+          "data science definition",
+          "data scientist role",
+          "data science vs statistics",
+          "business applications of data science",
+        ],
         description:
           "Understand what data science is and the role of a data scientist in modern organizations.",
         generationStatus: "completed",
@@ -186,6 +296,13 @@ const lessonsData: {
         title: "What is Data Science?",
       },
       {
+        concepts: [
+          "quantitative vs qualitative data",
+          "primary vs secondary data",
+          "data collection methods",
+          "data sources",
+          "sampling techniques",
+        ],
         description:
           "Learn about different types of data, data sources, and how to collect data for analysis.",
         generationStatus: "pending",
@@ -217,6 +334,7 @@ export async function seedLessons(prisma: PrismaClient, org: Organization): Prom
             prisma.lesson.upsert({
               create: {
                 chapterId: chapter.id,
+                concepts: lessonData.concepts,
                 description: lessonData.description,
                 generationStatus: lessonData.generationStatus,
                 isPublished: lessonData.isPublished,

--- a/packages/testing/src/fixtures/lessons.ts
+++ b/packages/testing/src/fixtures/lessons.ts
@@ -10,6 +10,7 @@ export function lessonAttrs(
 
   return {
     chapterId: 0,
+    concepts: [],
     description: "Test lesson description",
     generationRunId: null,
     generationStatus: "completed",


### PR DESCRIPTION
## Summary

- Add `concepts String[] @default([])` column to the Lesson model for storing granular, single-idea topics per lesson
- Update seed data with realistic concept arrays for all 18 lessons
- Update test fixture with default `concepts: []`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a concepts String[] column to Lesson to store granular topics per lesson. Seeds all lessons with concept arrays and updates test fixtures.

- **New Features**
  - Lesson model: concepts String[] with default [].
  - Seed: realistic concepts for all 18 lessons.
  - Testing: fixture sets concepts: [].

- **Migration**
  - Run prisma migrate and regenerate the Prisma client.
  - No breaking changes; existing lessons get an empty array by default.

<sup>Written for commit ce0a9ca5225894f3a04b46246c2f0126e227d25b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

