### PR TITLE
fix(api): stream error events to frontend on workflow failures

### DIFF
--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
@@ -10,13 +10,15 @@ import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { chapterGenerationWorkflow } from "./chapter-generation-workflow";
 
+const writeMock = vi.fn().mockResolvedValue(null);
+
 vi.mock("workflow", () => ({
   FatalError: class FatalError extends Error {},
   getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
   getWritable: vi.fn().mockReturnValue({
     getWriter: () => ({
       releaseLock: vi.fn(),
-      write: vi.fn().mockResolvedValue(null),
+      write: writeMock,
     }),
   }),
 }));
@@ -306,7 +308,7 @@ describe(chapterGenerationWorkflow, () => {
       expect(dbChapter?.generationStatus).toBe("completed");
     });
 
-    test("marks chapter as 'failed' when AI generation throws", async () => {
+    test("marks chapter as 'failed' when AI generation throws and streams error", async () => {
       vi.mocked(generateChapterLessons).mockRejectedValueOnce(new Error("AI generation failed"));
 
       const title = `Error Chapter ${randomUUID()}`;
@@ -324,6 +326,12 @@ describe(chapterGenerationWorkflow, () => {
       });
 
       expect(dbChapter?.generationStatus).toBe("failed");
+
+      const errorCall = writeMock.mock.calls.find(
+        (call: string[]) =>
+          call[0]?.includes('"status":"error"') && call[0]?.includes('"step":"workflowError"'),
+      );
+      expect(errorCall).toBeDefined();
     });
 
     test("throws FatalError when chapter not found", async () => {

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -18,7 +18,10 @@ import {
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { toSlug } from "@zoonk/utils/string";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { getOrCreateCourse } from "./_internal/get-or-create-course";
 import { courseGenerationWorkflow } from "./course-generation-workflow";
+
+const writeMock = vi.fn().mockResolvedValue(null);
 
 vi.mock("workflow", () => ({
   FatalError: class FatalError extends Error {},
@@ -26,7 +29,7 @@ vi.mock("workflow", () => ({
   getWritable: vi.fn().mockReturnValue({
     getWriter: () => ({
       releaseLock: vi.fn(),
-      write: vi.fn().mockResolvedValue(null),
+      write: writeMock,
     }),
   }),
 }));
@@ -113,6 +116,15 @@ vi.mock("@zoonk/ai/tasks/lessons/activities", () => ({
     data: { activities: [] },
   }),
 }));
+
+vi.mock("./_internal/get-or-create-course", async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    getOrCreateCourse: vi.fn(
+      (mod as { getOrCreateCourse: typeof getOrCreateCourse }).getOrCreateCourse,
+    ),
+  };
+});
 
 describe(courseGenerationWorkflow, () => {
   let organizationId: number;
@@ -441,7 +453,7 @@ describe(courseGenerationWorkflow, () => {
   });
 
   describe("error handling", () => {
-    test("marks course and suggestion as 'failed' on error", async () => {
+    test("marks course and suggestion as 'failed' on error and streams error", async () => {
       vi.mocked(generateCourseDescription).mockRejectedValueOnce(new Error("AI generation failed"));
 
       const title = `Error Course ${randomUUID()}`;
@@ -465,6 +477,39 @@ describe(courseGenerationWorkflow, () => {
 
       expect(course?.generationStatus).toBe("failed");
       expect(dbSuggestion?.generationStatus).toBe("failed");
+
+      const errorCall = writeMock.mock.calls.find(
+        (call: string[]) =>
+          call[0]?.includes('"status":"error"') && call[0]?.includes('"step":"workflowError"'),
+      );
+      expect(errorCall).toBeDefined();
+    });
+
+    test("marks suggestion as 'failed' when getOrCreateCourse fails", async () => {
+      vi.mocked(getOrCreateCourse).mockRejectedValueOnce(new Error("Organization not found"));
+
+      const title = `Init Fail Course ${randomUUID()}`;
+      const slug = toSlug(title);
+
+      const suggestion = await courseSuggestionFixture({
+        generationStatus: "pending",
+        slug,
+        title,
+      });
+
+      await expect(courseGenerationWorkflow(suggestion.id)).rejects.toThrow();
+
+      const dbSuggestion = await prisma.courseSuggestion.findUnique({
+        where: { id: suggestion.id },
+      });
+
+      expect(dbSuggestion?.generationStatus).toBe("failed");
+
+      const errorCall = writeMock.mock.calls.find(
+        (call: string[]) =>
+          call[0]?.includes('"status":"error"') && call[0]?.includes('"step":"workflowError"'),
+      );
+      expect(errorCall).toBeDefined();
     });
 
     test("marks course and suggestion as 'failed' when generateCourseCategories throws", async () => {

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.ts
@@ -32,7 +32,16 @@ export async function courseGenerationWorkflow(courseSuggestionId: number): Prom
     suggestion,
     courseSuggestionId,
     workflowRunId,
-  );
+  ).catch(async (error: unknown) => {
+    await handleCourseFailureStep({
+      courseId: existingCourse?.id ?? null,
+      courseSuggestionId,
+    });
+
+    console.error(`[workflow ${workflowRunId}] Course initialization failed`, error);
+
+    throw FatalError;
+  });
 
   const chapters = await setupCourse(course, courseSuggestionId, existing).catch(
     async (error: unknown) => {

--- a/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.ts
@@ -1,5 +1,4 @@
 import { prisma } from "@zoonk/db";
-import { safeAsync } from "@zoonk/utils/error";
 import { streamError, streamStatus } from "../stream-status";
 
 export async function completeCourseSetupStep(input: {
@@ -10,26 +9,22 @@ export async function completeCourseSetupStep(input: {
 
   await streamStatus({ status: "started", step: "completeCourseSetup" });
 
-  const [courseResult, suggestionResult] = await Promise.all([
-    safeAsync(() =>
-      prisma.course.update({
-        data: { generationStatus: "completed" },
-        where: { id: input.courseId },
-      }),
-    ),
-    safeAsync(() =>
-      prisma.courseSuggestion.update({
-        data: { generationStatus: "completed" },
-        where: { id: input.courseSuggestionId },
-      }),
-    ),
+  const results = await Promise.allSettled([
+    prisma.course.update({
+      data: { generationStatus: "completed" },
+      where: { id: input.courseId },
+    }),
+    prisma.courseSuggestion.update({
+      data: { generationStatus: "completed" },
+      where: { id: input.courseSuggestionId },
+    }),
   ]);
 
-  const error = courseResult.error || suggestionResult.error;
+  const rejected = results.find((result) => result.status === "rejected");
 
-  if (error) {
+  if (rejected) {
     await streamError({ reason: "dbSaveFailed", step: "completeCourseSetup" });
-    throw error;
+    throw rejected.reason;
   }
 
   await streamStatus({ status: "completed", step: "completeCourseSetup" });

--- a/apps/api/src/workflows/course-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/handle-failure-step.ts
@@ -1,26 +1,34 @@
+import { streamError } from "@/workflows/_shared/stream-error";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 
 export async function handleCourseFailureStep(input: {
-  courseId: number;
+  courseId: number | null;
   courseSuggestionId: number;
 }): Promise<void> {
   "use step";
 
-  await Promise.all([
-    safeAsync(() =>
+  const { courseId, courseSuggestionId } = input;
+
+  if (courseId) {
+    await Promise.allSettled([
       prisma.course.update({
         data: { generationStatus: "failed" },
-        where: { id: input.courseId },
+        where: { id: courseId },
       }),
-    ),
-    safeAsync(() =>
       prisma.courseSuggestion.update({
         data: { generationStatus: "failed" },
-        where: { id: input.courseSuggestionId },
+        where: { id: courseSuggestionId },
       }),
-    ),
-  ]);
+    ]);
+  } else {
+    await prisma.courseSuggestion.update({
+      data: { generationStatus: "failed" },
+      where: { id: courseSuggestionId },
+    });
+  }
+
+  await streamError({ reason: "aiGenerationFailed", step: "workflowError" });
 }
 
 export async function handleChapterFailureStep(input: { chapterId: number }): Promise<void> {
@@ -32,4 +40,6 @@ export async function handleChapterFailureStep(input: { chapterId: number }): Pr
       where: { id: input.chapterId },
     }),
   );
+
+  await streamError({ reason: "aiGenerationFailed", step: "workflowError" });
 }

--- a/apps/api/src/workflows/course-generation/steps/initialize-course-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/initialize-course-step.ts
@@ -15,9 +15,16 @@ export async function initializeCourseStep(input: {
 
   const { suggestion, workflowRunId } = input;
 
-  const aiOrg = await prisma.organization.findUniqueOrThrow({
-    where: { slug: AI_ORG_SLUG },
-  });
+  const { data: aiOrg, error: orgError } = await safeAsync(() =>
+    prisma.organization.findUniqueOrThrow({
+      where: { slug: AI_ORG_SLUG },
+    }),
+  );
+
+  if (orgError || !aiOrg) {
+    await streamError({ reason: "dbFetchFailed", step: "initializeCourse" });
+    throw orgError ?? new Error("AI organization not found");
+  }
 
   // Update course suggestion status to running
   const { error: updateError } = await safeAsync(() =>

--- a/apps/api/src/workflows/course-generation/steps/set-course-as-running-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/set-course-as-running-step.ts
@@ -1,5 +1,4 @@
 import { prisma } from "@zoonk/db";
-import { safeAsync } from "@zoonk/utils/error";
 import { streamError, streamStatus } from "../stream-status";
 
 export async function setCourseAsRunningStep(input: {
@@ -11,29 +10,25 @@ export async function setCourseAsRunningStep(input: {
 
   await streamStatus({ status: "started", step: "setCourseAsRunning" });
 
-  const [courseResult, suggestionResult] = await Promise.all([
-    safeAsync(() =>
-      prisma.course.update({
-        data: { generationStatus: "running" },
-        where: { id: input.courseId },
-      }),
-    ),
-    safeAsync(() =>
-      prisma.courseSuggestion.update({
-        data: {
-          generationRunId: input.workflowRunId,
-          generationStatus: "running",
-        },
-        where: { id: input.courseSuggestionId },
-      }),
-    ),
+  const results = await Promise.allSettled([
+    prisma.course.update({
+      data: { generationStatus: "running" },
+      where: { id: input.courseId },
+    }),
+    prisma.courseSuggestion.update({
+      data: {
+        generationRunId: input.workflowRunId,
+        generationStatus: "running",
+      },
+      where: { id: input.courseSuggestionId },
+    }),
   ]);
 
-  const error = courseResult.error || suggestionResult.error;
+  const rejected = results.find((result) => result.status === "rejected");
 
-  if (error) {
+  if (rejected) {
     await streamError({ reason: "dbSaveFailed", step: "setCourseAsRunning" });
-    throw error;
+    throw rejected.reason;
   }
 
   await streamStatus({ status: "completed", step: "setCourseAsRunning" });

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
@@ -10,13 +10,15 @@ import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { lessonGenerationWorkflow } from "./lesson-generation-workflow";
 
+const writeMock = vi.fn().mockResolvedValue(null);
+
 vi.mock("workflow", () => ({
   FatalError: class FatalError extends Error {},
   getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
   getWritable: vi.fn().mockReturnValue({
     getWriter: () => ({
       releaseLock: vi.fn(),
-      write: vi.fn().mockResolvedValue(null),
+      write: writeMock,
     }),
   }),
 }));
@@ -344,7 +346,7 @@ describe(lessonGenerationWorkflow, () => {
   });
 
   describe("error handling", () => {
-    test("marks lesson as 'failed' when AI generation throws", async () => {
+    test("marks lesson as 'failed' when AI generation throws and streams error", async () => {
       vi.mocked(generateLessonKind).mockRejectedValueOnce(new Error("AI generation failed"));
 
       const title = `Error Lesson ${randomUUID()}`;
@@ -362,6 +364,12 @@ describe(lessonGenerationWorkflow, () => {
       });
 
       expect(dbLesson?.generationStatus).toBe("failed");
+
+      const errorCall = writeMock.mock.calls.find(
+        (call: string[]) =>
+          call[0]?.includes('"status":"error"') && call[0]?.includes('"step":"workflowError"'),
+      );
+      expect(errorCall).toBeDefined();
     });
 
     test("marks lesson as 'failed' when custom activities generation throws", async () => {

--- a/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.ts
@@ -1,3 +1,4 @@
+import { streamError } from "@/workflows/_shared/stream-error";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 
@@ -10,4 +11,6 @@ export async function handleLessonFailureStep(input: { lessonId: number }): Prom
       where: { id: input.lessonId },
     }),
   );
+
+  await streamError({ reason: "aiGenerationFailed", step: "workflowError" });
 }


### PR DESCRIPTION
## Summary

- Failure handlers (course, chapter, lesson) now call `streamError` after DB updates so the frontend shows retry UI instead of staying stuck on "loading"
- Added `.catch()` on `getOrCreateCourse` to handle initialization failures (e.g. missing AI org)
- Wrapped `initializeCourseStep`'s `findUniqueOrThrow` in `safeAsync` for consistent error streaming
- Refactored redundant `safeAsync` + `Promise.all` patterns to `Promise.allSettled` in `handleCourseFailureStep`, `completeCourseSetupStep`, and `setCourseAsRunningStep`

## Test plan

- [x] Extended error handling tests in course, chapter, and lesson workflow test files to verify error events are streamed
- [x] Added test for `getOrCreateCourse` failure path
- [x] All 196 tests pass
- [x] Lint, typecheck, knip, and API build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams error events to the frontend when course, chapter, or lesson workflows fail so the UI shows retry instead of hanging. Also handles initialization failures and hardens DB steps to consistently emit error statuses.

- **Bug Fixes**
  - Stream error events after marking failures in course/chapter/lesson handlers (workflowError).
  - Catch getOrCreateCourse failures; mark suggestion failed and stream error.
  - initializeCourseStep wraps org lookup in safeAsync and streams dbFetchFailed on error.

- **Refactors**
  - Replace safeAsync + Promise.all with Promise.allSettled in setCourseAsRunningStep and completeCourseSetupStep; stream dbSaveFailed on rejection and rethrow the reason.
  - handleCourseFailureStep accepts null courseId, updates suggestion when course is missing, and streams error.

<sup>Written for commit c662a36d500ad7707353e89b28d90296f1f1add7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

