### PR TITLE
refactor(utils): add rejected and settledValues helpers

### DIFF
--- a/apps/api/src/workflows/activity-generation/steps/generate-custom-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-custom-content-step.ts
@@ -1,6 +1,7 @@
 import { generateActivityCustom } from "@zoonk/ai/tasks/activities/custom";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
+import { settledValues } from "@zoonk/utils/settled";
 import { streamStatus } from "../stream-status";
 import { saveContentSteps } from "./_utils/content-step-helpers";
 import { type ActivitySteps, parseActivitySteps } from "./_utils/get-activity-steps";
@@ -98,11 +99,7 @@ export async function generateCustomContentStep(
     customActivities.map((act) => generateForActivity(act, workflowRunId)),
   );
 
-  const settled = results.map((result) =>
-    result.status === "fulfilled" ? result.value : { activityId: 0, steps: [] as ActivitySteps },
-  );
-
   await streamStatus({ status: "completed", step: "generateCustomContent" });
 
-  return settled.filter((result) => result.activityId !== 0);
+  return settledValues(results);
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-custom-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-custom-images-step.ts
@@ -1,6 +1,7 @@
 import { generateVisualStepImage } from "@zoonk/core/steps/visual-image";
 import { prisma } from "@zoonk/db";
 import { getString, toRecord } from "@zoonk/utils/json";
+import { rejected } from "@zoonk/utils/settled";
 import { streamStatus } from "../stream-status";
 import { type CustomVisualResult } from "./generate-custom-visuals-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
@@ -48,9 +49,7 @@ async function generateImagesForActivity(activity: LessonActivity): Promise<void
     }),
   );
 
-  const hadFailure =
-    results.some((result) => result.status === "rejected" || result.value.error) ||
-    updateResults.some((result) => result.status === "rejected");
+  const hadFailure = rejected(results) || rejected(updateResults);
 
   if (hadFailure) {
     await handleActivityFailureStep({ activityId: activity.id });

--- a/apps/api/src/workflows/activity-generation/steps/generate-custom-visuals-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-custom-visuals-step.ts
@@ -1,14 +1,16 @@
 import { type StepVisualSchema, generateStepVisuals } from "@zoonk/ai/tasks/steps/visual";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
+import { settledValues } from "@zoonk/utils/settled";
 import { streamStatus } from "../stream-status";
 import { type CustomContentResult } from "./generate-custom-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
 
-type StepVisual = StepVisualSchema["visuals"][number];
-
-export type CustomVisualResult = { activityId: number; visuals: StepVisual[] };
+export type CustomVisualResult = {
+  activityId: number;
+  visuals: StepVisualSchema["visuals"][number][];
+};
 
 async function generateVisualsForActivity(
   activity: LessonActivity,
@@ -96,11 +98,7 @@ export async function generateCustomVisualsStep(
     }),
   );
 
-  const settled = results.map((result) =>
-    result.status === "fulfilled" ? result.value : { activityId: 0, visuals: [] as StepVisual[] },
-  );
-
   await streamStatus({ status: "completed", step: "generateVisuals" });
 
-  return settled.filter((result) => result.activityId !== 0);
+  return settledValues(results);
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-images-step.ts
@@ -1,6 +1,7 @@
 import { generateVisualStepImage } from "@zoonk/core/steps/visual-image";
 import { type ActivityKind, prisma } from "@zoonk/db";
 import { getString, toRecord } from "@zoonk/utils/json";
+import { rejected } from "@zoonk/utils/settled";
 import { streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type StepVisual } from "./generate-visuals-step";
@@ -41,9 +42,7 @@ async function generateAndSaveImages(
     }),
   );
 
-  const hadFailure =
-    results.some((result) => result.status === "rejected" || result.value.error) ||
-    updateResults.some((result) => result.status === "rejected");
+  const hadFailure = rejected(results) || rejected(updateResults);
 
   return { hadFailure, results };
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.ts
@@ -4,6 +4,7 @@ import { generateStepImage } from "@zoonk/core/steps/image";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { isJsonObject, toRecord } from "@zoonk/utils/json";
+import { rejected } from "@zoonk/utils/settled";
 import { streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
@@ -60,9 +61,7 @@ async function generateOptionImages(
     return option;
   });
 
-  const hadFailure = results.some((result) => result.status === "rejected" || result.value.error);
-
-  return { hadFailure, updatedOptions };
+  return { hadFailure: rejected(results), updatedOptions };
 }
 
 export async function generateQuizImagesStep(
@@ -124,12 +123,12 @@ export async function generateQuizImagesStep(
     }),
   );
 
-  const hadFailure = stepResults.some(
-    (result) =>
-      result.status === "rejected" ||
-      (result.status === "fulfilled" && result.value?.imageFailed) ||
-      (result.status === "fulfilled" && result.value?.updateFailed),
-  );
+  const hadFailure =
+    rejected(stepResults) ||
+    stepResults.some(
+      (result) =>
+        result.status === "fulfilled" && (result.value?.imageFailed || result.value?.updateFailed),
+    );
 
   if (hadFailure) {
     await handleActivityFailureStep({ activityId: activity.id });

--- a/apps/api/src/workflows/activity-generation/steps/save-custom-activities-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-custom-activities-step.ts
@@ -1,29 +1,21 @@
 import { prisma } from "@zoonk/db";
-import { safeAsync } from "@zoonk/utils/error";
+import { rejected } from "@zoonk/utils/settled";
 import { streamError, streamStatus } from "../stream-status";
 import { type LessonActivity } from "./get-lesson-activities-step";
 
-async function saveActivity(activity: LessonActivity, workflowRunId: string): Promise<boolean> {
+async function saveActivity(activity: LessonActivity, workflowRunId: string): Promise<void> {
   const current = await prisma.activity.findUnique({
     where: { id: activity.id },
   });
 
   if (current?.generationStatus !== "running") {
-    return true;
+    return;
   }
 
-  const { error } = await safeAsync(() =>
-    prisma.activity.update({
-      data: { generationRunId: workflowRunId, generationStatus: "completed" },
-      where: { id: activity.id },
-    }),
-  );
-
-  if (error) {
-    return false;
-  }
-
-  return true;
+  await prisma.activity.update({
+    data: { generationRunId: workflowRunId, generationStatus: "completed" },
+    where: { id: activity.id },
+  });
 }
 
 export async function saveCustomActivitiesStep(
@@ -45,11 +37,7 @@ export async function saveCustomActivitiesStep(
     customActivities.map((act) => saveActivity(act, workflowRunId)),
   );
 
-  const hasFailure = results.some(
-    (result) => result.status === "rejected" || (result.status === "fulfilled" && !result.value),
-  );
-
-  if (hasFailure) {
+  if (rejected(results)) {
     await streamError({ reason: "dbSaveFailed", step: "setCustomAsCompleted" });
     await streamStatus({ status: "error", step: "setActivityAsCompleted" });
     return;

--- a/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@zoonk/db";
+import { rejected } from "@zoonk/utils/settled";
 import { streamError, streamStatus } from "../stream-status";
 
 export async function completeCourseSetupStep(input: {
@@ -20,11 +21,9 @@ export async function completeCourseSetupStep(input: {
     }),
   ]);
 
-  const rejected = results.find((result) => result.status === "rejected");
-
-  if (rejected) {
+  if (rejected(results)) {
     await streamError({ reason: "dbSaveFailed", step: "completeCourseSetup" });
-    throw rejected.reason;
+    throw new Error("DB save failed in completeCourseSetup");
   }
 
   await streamStatus({ status: "completed", step: "completeCourseSetup" });

--- a/apps/api/src/workflows/course-generation/steps/set-course-as-running-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/set-course-as-running-step.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@zoonk/db";
+import { rejected } from "@zoonk/utils/settled";
 import { streamError, streamStatus } from "../stream-status";
 
 export async function setCourseAsRunningStep(input: {
@@ -24,11 +25,9 @@ export async function setCourseAsRunningStep(input: {
     }),
   ]);
 
-  const rejected = results.find((result) => result.status === "rejected");
-
-  if (rejected) {
+  if (rejected(results)) {
     await streamError({ reason: "dbSaveFailed", step: "setCourseAsRunning" });
-    throw rejected.reason;
+    throw new Error("DB save failed in setCourseAsRunning");
   }
 
   await streamStatus({ status: "completed", step: "setCourseAsRunning" });

--- a/packages/utils/src/settled.test.ts
+++ b/packages/utils/src/settled.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { settled } from "./settled";
+import { rejected, settled, settledValues } from "./settled";
 
 describe(settled, () => {
   test("returns fulfilled value", () => {
@@ -18,5 +18,79 @@ describe(settled, () => {
     };
 
     expect(settled(result, "fallback")).toBe("fallback");
+  });
+});
+
+describe(rejected, () => {
+  test("returns true when any result is rejected", () => {
+    const results: PromiseSettledResult<string>[] = [
+      { status: "fulfilled", value: "ok" },
+      { reason: new Error("fail"), status: "rejected" },
+    ];
+
+    expect(rejected(results)).toBeTruthy();
+  });
+
+  test("returns true when a fulfilled value has a truthy error property", () => {
+    const results: PromiseSettledResult<{ data: null; error: Error }>[] = [
+      { status: "fulfilled", value: { data: null, error: new Error("fail") } },
+    ];
+
+    expect(rejected(results)).toBeTruthy();
+  });
+
+  test("returns false when a fulfilled value has a falsy error property", () => {
+    const results: PromiseSettledResult<{ data: string; error: null }>[] = [
+      { status: "fulfilled", value: { data: "ok", error: null } },
+    ];
+
+    expect(rejected(results)).toBeFalsy();
+  });
+
+  test("returns false when all results are fulfilled without errors", () => {
+    const results: PromiseSettledResult<string>[] = [
+      { status: "fulfilled", value: "a" },
+      { status: "fulfilled", value: "b" },
+    ];
+
+    expect(rejected(results)).toBeFalsy();
+  });
+
+  test("returns false for an empty array", () => {
+    expect(rejected([])).toBeFalsy();
+  });
+});
+
+describe(settledValues, () => {
+  test("extracts fulfilled values and drops rejections", () => {
+    const results: PromiseSettledResult<number>[] = [
+      { status: "fulfilled", value: 1 },
+      { reason: new Error("fail"), status: "rejected" },
+      { status: "fulfilled", value: 3 },
+    ];
+
+    expect(settledValues(results)).toEqual([1, 3]);
+  });
+
+  test("returns all values when none are rejected", () => {
+    const results: PromiseSettledResult<string>[] = [
+      { status: "fulfilled", value: "a" },
+      { status: "fulfilled", value: "b" },
+    ];
+
+    expect(settledValues(results)).toEqual(["a", "b"]);
+  });
+
+  test("returns an empty array when all are rejected", () => {
+    const results: PromiseSettledResult<string>[] = [
+      { reason: new Error("a"), status: "rejected" },
+      { reason: new Error("b"), status: "rejected" },
+    ];
+
+    expect(settledValues(results)).toEqual([]);
+  });
+
+  test("returns an empty array for empty input", () => {
+    expect(settledValues([])).toEqual([]);
   });
 });

--- a/packages/utils/src/settled.ts
+++ b/packages/utils/src/settled.ts
@@ -1,6 +1,33 @@
+import { isJsonObject } from "./json";
+
 /**
  * Extracts a single Promise.allSettled result with a fallback for rejected promises.
  */
 export function settled<T>(result: PromiseSettledResult<T>, fallback: T): T {
   return result.status === "fulfilled" ? result.value : fallback;
+}
+
+/**
+ * Checks if any Promise.allSettled result failed — either by rejection or by
+ * resolving with a truthy `error` property (the `{ data, error }` pattern).
+ */
+export function rejected(results: PromiseSettledResult<unknown>[]): boolean {
+  return results.some(
+    (result) =>
+      result.status === "rejected" ||
+      (result.status === "fulfilled" && hasValueError(result.value)),
+  );
+}
+
+function hasValueError(value: unknown): boolean {
+  return isJsonObject(value) && "error" in value && Boolean(value.error);
+}
+
+/**
+ * Extracts the fulfilled values from a Promise.allSettled array, dropping rejections.
+ */
+export function settledValues<T>(results: PromiseSettledResult<T>[]): T[] {
+  return results
+    .filter((result): result is PromiseFulfilledResult<T> => result.status === "fulfilled")
+    .map((result) => result.value);
 }


### PR DESCRIPTION
## Summary

- Add `rejected(results)` helper that returns `boolean` — checks for rejections and fulfilled values with truthy `.error` (the `{ data, error }` pattern)
- Add `settledValues(results)` helper that extracts fulfilled values, dropping rejections
- Refactor 8 workflow files to use these helpers, replacing inline `status === "rejected"` checks and sentinel-value-then-filter patterns
- Simplify `saveActivity` to let errors throw naturally instead of wrapping with `safeAsync` + boolean return

## Test plan

- [x] Unit tests for `rejected` (rejection, value.error, falsy error, all fulfilled, empty)
- [x] Unit tests for `settledValues` (mixed, all fulfilled, all rejected, empty)
- [x] `pnpm typecheck` passes
- [x] `pnpm knip --production` clean
- [x] `pnpm --filter api build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add rejected and settledValues helpers to the utils settled module and refactor 8 workflow steps to use them, removing inline status checks and sentinel filtering. This simplifies error handling (saveActivity now throws naturally) and makes the generation steps easier to read.

- **New Features**
  - rejected: true if any result is rejected or a fulfilled value has a truthy error.
  - settledValues: returns only fulfilled values from allSettled results.
  - Unit tests added for both helpers.

- **Refactors**
  - Replace status checks and sentinel filters across activity/course generation steps with the new helpers.
  - saveCustomActivitiesStep now uses rejected; saveActivity no longer wraps with safeAsync and returns void.
  - Cleaned up CustomVisualResult type to use StepVisualSchema["visuals"][number].

<sup>Written for commit bfd04f5b28f7ff9777947e48f5a9a7e625ce4d3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

