### PR TITLE
fix(main): use suffixed slug for client-side redirect on non-English courses

### DIFF
--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -223,6 +223,62 @@ test.describe("Generate Course Page", () => {
       // Should complete and redirect to course page
       await page.waitForURL(/\/b\/ai\/c\//, { timeout: 10_000 });
     });
+
+    test("redirects to suffixed slug for non-English courses", async ({ page }) => {
+      const slug = `e2e-locale-${randomUUID().slice(0, 8)}`;
+      const suffixedSlug = `${slug}-pt`;
+      const org = await getAiOrganization();
+
+      const [suggestion] = await Promise.all([
+        courseSuggestionFixture({
+          generationStatus: "pending",
+          language: "pt",
+          slug,
+          title: "E2E Locale Redirect Test",
+        }),
+        // Use generationStatus "running" so the server-side redirect is skipped
+        // and the client-side redirect (the one we're testing) fires instead.
+        courseFixture({
+          generationStatus: "running",
+          isPublished: true,
+          organizationId: org.id,
+          slug: suffixedSlug,
+          title: "E2E Locale Redirect Test",
+        }).then(async (course) => {
+          const chapter = await chapterFixture({
+            courseId: course.id,
+            isPublished: true,
+            organizationId: org.id,
+          });
+
+          await lessonFixture({
+            chapterId: chapter.id,
+            isPublished: true,
+            organizationId: org.id,
+          });
+        }),
+      ]);
+
+      await setupMockApis(page, {
+        streamMessages: [
+          { status: "started", step: "getCourseSuggestion" },
+          { status: "completed", step: "getCourseSuggestion" },
+          { status: "started", step: "addLessons" },
+          { status: "completed", step: "addLessons" },
+          { status: "started", step: "setLessonAsCompleted" },
+          { status: "completed", step: "setLessonAsCompleted" },
+          { status: "started", step: "setActivityAsCompleted" },
+          { status: "completed", step: "setActivityAsCompleted" },
+        ],
+      });
+
+      await page.goto(`/generate/cs/${suggestion.id}`);
+
+      // Should redirect to the suffixed slug, not the raw suggestion slug
+      await page.waitForURL(new RegExp(`/b/ai/c/${suffixedSlug}`), {
+        timeout: 10_000,
+      });
+    });
   });
 
   test.describe("Error handling", () => {

--- a/apps/main/src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
@@ -11,7 +11,7 @@ import {
 import { Empty, EmptyContent, EmptyHeader } from "@zoonk/ui/components/empty";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
-import { parseNumericId } from "@zoonk/utils/string";
+import { ensureLocaleSuffix, parseNumericId } from "@zoonk/utils/string";
 import { notFound, redirect } from "next/navigation";
 import { GenerationClient } from "./generation-client";
 
@@ -53,7 +53,7 @@ export async function GenerateCourseSuggestionContent({
 
       <ContainerBody>
         <GenerationClient
-          courseSlug={suggestion.slug}
+          courseSlug={ensureLocaleSuffix(suggestion.slug, suggestion.language)}
           generationRunId={suggestion.generationRunId}
           generationStatus={suggestion.generationStatus}
           suggestionId={suggestionId}


### PR DESCRIPTION
## Summary

- Fix client-side redirect after course generation using `suggestion.slug` (no language suffix) instead of the actual course slug (with suffix like `-pt`)
- Add `ensureLocaleSuffix` to the `courseSlug` prop passed to `GenerationClient`
- Add e2e test that exercises the client-side redirect path for non-English courses

## Test plan

- [x] New e2e test fails without fix, passes with fix (verified 3 runs)
- [x] Full e2e suite for main, editor, and api apps passes
- [x] `pnpm turbo quality:fix`, `pnpm typecheck`, `pnpm knip --production`, `pnpm test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes client-side redirect after course generation for non-English courses by using the locale-suffixed slug. Users are now redirected to the correct localized course page (e.g., "-pt").

- **Bug Fixes**
  - Pass locale-suffixed slug to GenerationClient with ensureLocaleSuffix.
  - Add e2e test to verify redirect to suffixed slug for non-English courses.

<sup>Written for commit ae58c75b0fc76c59afab2a7039ed7f816e1294ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

