### PR TITLE
fix(editor): check alternative titles when validating course slugs

### DIFF
--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/slug.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/slug.ts
@@ -17,7 +17,11 @@ export async function checkCourseSlugExists(params: {
     ? ensureLocaleSuffix(toSlug(params.slug), params.language)
     : toSlug(params.slug);
 
-  return courseSlugExists({ orgSlug: params.orgSlug, slug: normalizedSlug });
+  return courseSlugExists({
+    language: params.language,
+    orgSlug: params.orgSlug,
+    slug: normalizedSlug,
+  });
 }
 
 export async function updateCourseSlugAction(

--- a/apps/editor/src/app/[orgSlug]/new-course/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/new-course/actions.ts
@@ -26,7 +26,7 @@ export async function checkSlugExists({
   const isAiOrg = orgSlug === AI_ORG_SLUG;
   const normalizedSlug = isAiOrg ? ensureLocaleSuffix(toSlug(slug), language) : toSlug(slug);
 
-  return courseSlugExists({ orgSlug, slug: normalizedSlug });
+  return courseSlugExists({ language, orgSlug, slug: normalizedSlug });
 }
 
 export async function createCourseAction(formData: CourseFormData, orgSlug: string) {

--- a/apps/editor/src/data/courses/course-slug.test.ts
+++ b/apps/editor/src/data/courses/course-slug.test.ts
@@ -1,7 +1,17 @@
-import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { prisma } from "@zoonk/db";
+import { courseAlternativeTitleFixture, courseFixture } from "@zoonk/testing/fixtures/courses";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { beforeAll, describe, expect, test } from "vitest";
 import { courseSlugExists } from "./course-slug";
+
+async function getOrCreateAIOrg() {
+  return prisma.organization.upsert({
+    create: { name: "AI", slug: AI_ORG_SLUG },
+    update: {},
+    where: { slug: AI_ORG_SLUG },
+  });
+}
 
 describe("courseSlugExists()", () => {
   let organization: Awaited<ReturnType<typeof organizationFixture>>;
@@ -14,6 +24,7 @@ describe("courseSlugExists()", () => {
     const course = await courseFixture({ organizationId: organization.id });
 
     const exists = await courseSlugExists({
+      language: "en",
       orgSlug: organization.slug,
       slug: course.slug,
     });
@@ -23,6 +34,7 @@ describe("courseSlugExists()", () => {
 
   test("returns false when slug does not exist", async () => {
     const exists = await courseSlugExists({
+      language: "en",
       orgSlug: organization.slug,
       slug: "non-existent-slug",
     });
@@ -37,6 +49,7 @@ describe("courseSlugExists()", () => {
     });
 
     const exists = await courseSlugExists({
+      language: "pt",
       orgSlug: organization.slug,
       slug: course.slug,
     });
@@ -49,10 +62,71 @@ describe("courseSlugExists()", () => {
     const course = await courseFixture({ organizationId: organization.id });
 
     const exists = await courseSlugExists({
+      language: "en",
       orgSlug: otherOrg.slug,
       slug: course.slug,
     });
 
     expect(exists).toBeFalsy();
+  });
+
+  describe("alternative titles (AI org)", () => {
+    let aiOrg: Awaited<ReturnType<typeof getOrCreateAIOrg>>;
+
+    beforeAll(async () => {
+      aiOrg = await getOrCreateAIOrg();
+    });
+
+    test("returns true when slug matches an alternative title for same language", async () => {
+      const course = await courseFixture({ language: "pt", organizationId: aiOrg.id });
+      const altTitle = await courseAlternativeTitleFixture({
+        courseId: course.id,
+        language: "pt",
+        slug: `alt-title-${course.id}`,
+      });
+
+      const exists = await courseSlugExists({
+        language: "pt",
+        orgSlug: aiOrg.slug,
+        slug: `${altTitle.slug}-pt`,
+      });
+
+      expect(exists).toBeTruthy();
+    });
+
+    test("returns false when slug matches an alternative title in a different language", async () => {
+      const course = await courseFixture({ language: "pt", organizationId: aiOrg.id });
+      await courseAlternativeTitleFixture({
+        courseId: course.id,
+        language: "pt",
+        slug: `alt-diff-lang-${course.id}`,
+      });
+
+      const exists = await courseSlugExists({
+        language: "es",
+        orgSlug: aiOrg.slug,
+        slug: `alt-diff-lang-${course.id}-es`,
+      });
+
+      expect(exists).toBeFalsy();
+    });
+
+    test("returns false when checking alternative titles for a non-AI org", async () => {
+      const nonAiOrg = await organizationFixture();
+      const course = await courseFixture({ language: "pt", organizationId: nonAiOrg.id });
+      const altTitle = await courseAlternativeTitleFixture({
+        courseId: course.id,
+        language: "pt",
+        slug: `alt-non-ai-${course.id}`,
+      });
+
+      const exists = await courseSlugExists({
+        language: "pt",
+        orgSlug: nonAiOrg.slug,
+        slug: `${altTitle.slug}-pt`,
+      });
+
+      expect(exists).toBeFalsy();
+    });
   });
 });

--- a/apps/editor/src/data/courses/course-slug.ts
+++ b/apps/editor/src/data/courses/course-slug.ts
@@ -1,21 +1,36 @@
 import "server-only";
 import { prisma } from "@zoonk/db";
+import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { safeAsync } from "@zoonk/utils/error";
+import { removeLocaleSuffix } from "@zoonk/utils/string";
 import { cache } from "react";
 
-const cachedCourseSlugExists = cache(async (orgSlug: string, slug: string): Promise<boolean> => {
-  const { data } = await safeAsync(() =>
-    prisma.course.findFirst({
-      where: {
-        organization: { slug: orgSlug },
-        slug,
-      },
-    }),
-  );
+const cachedCourseSlugExists = cache(
+  async (orgSlug: string, slug: string, language: string): Promise<boolean> => {
+    const { data } = await safeAsync(() =>
+      Promise.all([
+        prisma.course.findFirst({
+          where: { organization: { slug: orgSlug }, slug },
+        }),
+        prisma.courseAlternativeTitle.findUnique({
+          where: { languageSlug: { language, slug: removeLocaleSuffix(slug, language) } },
+        }),
+      ]),
+    );
 
-  return data !== null;
-});
+    if (!data) {
+      return false;
+    }
 
-export function courseSlugExists(params: { orgSlug: string; slug: string }): Promise<boolean> {
-  return cachedCourseSlugExists(params.orgSlug, params.slug);
+    const [course, altTitle] = data;
+    return Boolean(course) || (orgSlug === AI_ORG_SLUG && Boolean(altTitle));
+  },
+);
+
+export function courseSlugExists(params: {
+  language: string;
+  orgSlug: string;
+  slug: string;
+}): Promise<boolean> {
+  return cachedCourseSlugExists(params.orgSlug, params.slug, params.language);
 }

--- a/packages/utils/src/string.test.ts
+++ b/packages/utils/src/string.test.ts
@@ -7,6 +7,7 @@ import {
   parseBigIntId,
   parseNumericId,
   removeAccents,
+  removeLocaleSuffix,
   replaceNamePlaceholder,
   toSlug,
 } from "./string";
@@ -194,6 +195,31 @@ describe(ensureLocaleSuffix, () => {
     expect(ensureLocaleSuffix("machine-learning", "es")).toBe("machine-learning-es");
     expect(ensureLocaleSuffix("machine-learning", "fr")).toBe("machine-learning-fr");
     expect(ensureLocaleSuffix("machine-learning", "ja")).toBe("machine-learning-ja");
+  });
+});
+
+describe(removeLocaleSuffix, () => {
+  test("returns slug unchanged for English", () => {
+    expect(removeLocaleSuffix("machine-learning", "en")).toBe("machine-learning");
+  });
+
+  test("strips suffix for non-English languages", () => {
+    expect(removeLocaleSuffix("machine-learning-pt", "pt")).toBe("machine-learning");
+    expect(removeLocaleSuffix("machine-learning-es", "es")).toBe("machine-learning");
+    expect(removeLocaleSuffix("machine-learning-fr", "fr")).toBe("machine-learning");
+    expect(removeLocaleSuffix("machine-learning-ja", "ja")).toBe("machine-learning");
+  });
+
+  test("returns slug unchanged if suffix not present", () => {
+    expect(removeLocaleSuffix("machine-learning", "pt")).toBe("machine-learning");
+  });
+
+  test("handles empty string", () => {
+    expect(removeLocaleSuffix("", "pt")).toBe("");
+  });
+
+  test("does not strip partial suffix match", () => {
+    expect(removeLocaleSuffix("report", "pt")).toBe("report");
   });
 });
 

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -56,6 +56,16 @@ export function ensureLocaleSuffix(value: string, language: string): string {
   return `${value}${suffix}`;
 }
 
+export function removeLocaleSuffix(value: string, language: string): string {
+  if (language === "en") {
+    return value;
+  }
+
+  const suffix = `-${language}`;
+
+  return value.endsWith(suffix) ? value.slice(0, -suffix.length) : value;
+}
+
 export function replaceNamePlaceholder(text: string, name: string | null): string {
   if (!text.includes(NAME_PLACEHOLDER)) {
     return text;


### PR DESCRIPTION
## Summary

- Editor's `courseSlugExists` now also queries `CourseAlternativeTitle` in parallel, preventing slug conflicts with alternative titles
- Added `removeLocaleSuffix` utility (inverse of `ensureLocaleSuffix`) to strip language suffixes before querying alternative titles
- Alternative title check is gated to AI org only on return, matching the API and main app behavior

## Test plan

- [x] Unit tests for `removeLocaleSuffix` (English passthrough, suffix stripping, edge cases)
- [x] Integration tests for `courseSlugExists` with alternative titles (same language match, different language, non-AI org)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend editor slug validation to catch conflicts with alternative course titles, so users can’t create slugs that clash with CourseAlternativeTitle. Adds language-aware checks and locale suffix handling; alternative-title matching is limited to the AI org to align with API/app behavior.

- **Bug Fixes**
  - courseSlugExists now checks Course and CourseAlternativeTitle in parallel; alt-title conflicts return true only for the AI org.
  - Added removeLocaleSuffix to strip "-<lang>" before alt-title lookups (English unchanged).
  - Actions pass language to courseSlugExists for accurate checks.
  - Tests cover suffix stripping and alt-title cases across orgs and languages.

<sup>Written for commit c88d86be059d97ccc64392bb947561706ff103e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

