### PR TITLE
fix(player): hide reward skeletons for unauthenticated users on challenge completion

### DIFF
--- a/apps/main/e2e/activity-completion.test.ts
+++ b/apps/main/e2e/activity-completion.test.ts
@@ -261,4 +261,56 @@ test.describe("Activity Completion", () => {
 
     await browserContext.close();
   });
+
+  test("guest user sees login prompt, no reward skeletons on challenge completion", async ({
+    page,
+  }) => {
+    const { buildUrl, lesson, org, uniqueId } = await createTestHierarchy("chguest");
+    const dim = `Grit ${uniqueId}`;
+
+    const activity = await activityFixture({
+      generationStatus: "completed",
+      isPublished: true,
+      kind: "challenge",
+      lessonId: lesson.id,
+      organizationId: org.id,
+      position: 0,
+    });
+
+    await stepFixture({
+      activityId: activity.id,
+      content: {
+        context: `Guest challenge ${uniqueId}`,
+        kind: "challenge",
+        options: [
+          {
+            consequence: `Great outcome ${uniqueId}`,
+            effects: [{ dimension: dim, impact: "positive" }],
+            text: `Good ${uniqueId}`,
+          },
+          {
+            consequence: "Bad outcome",
+            effects: [{ dimension: dim, impact: "negative" }],
+            text: "Bad",
+          },
+        ],
+        question: `Guest Q ${uniqueId}`,
+      },
+      isPublished: true,
+      kind: "multipleChoice",
+    });
+
+    await page.goto(buildUrl());
+    await page.getByRole("button", { name: /begin/i }).click();
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("radio", { name: new RegExp(`Good ${uniqueId}`) }).click();
+    await page.getByRole("button", { name: /check/i }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await expect(page.getByText(/challenge complete/i)).toBeVisible();
+    await expect(page.getByText(/sign up to track your progress/i)).toBeVisible();
+    await expect(page.getByRole("progressbar", { name: /level progress/i })).not.toBeVisible();
+    await expect(page.getByText(/\+\d+ BP/)).not.toBeVisible();
+  });
 });

--- a/packages/player/src/components/challenge-completion.tsx
+++ b/packages/player/src/components/challenge-completion.tsx
@@ -82,7 +82,7 @@ export function ChallengeSuccessContent({
   dimensions: DimensionInventory;
 }) {
   const t = useExtracted();
-  const { completionFooter } = usePlayer();
+  const { completionFooter, isAuthenticated } = usePlayer();
   const entries = buildDimensionEntries(dimensions, []);
 
   return (
@@ -94,7 +94,7 @@ export function ChallengeSuccessContent({
 
       <DimensionList aria-label={t("Final dimension scores")} entries={entries} variant="success" />
 
-      <ChallengeRewardBadges completionResult={completionResult} isSuccess />
+      {isAuthenticated && <ChallengeRewardBadges completionResult={completionResult} isSuccess />}
 
       {children}
 
@@ -115,7 +115,7 @@ export function ChallengeFailureContent({
   onRestart: () => void;
 }) {
   const t = useExtracted();
-  const { completionFooter } = usePlayer();
+  const { completionFooter, isAuthenticated } = usePlayer();
   const entries = buildDimensionEntries(dimensions, []);
 
   return (
@@ -127,7 +127,9 @@ export function ChallengeFailureContent({
 
       <DimensionList aria-label={t("Final dimension scores")} entries={entries} variant="failure" />
 
-      <ChallengeRewardBadges completionResult={completionResult} isSuccess={false} />
+      {isAuthenticated && (
+        <ChallengeRewardBadges completionResult={completionResult} isSuccess={false} />
+      )}
 
       <ChallengeActions>
         <Button className="w-full lg:justify-between" onClick={onRestart} size="lg">


### PR DESCRIPTION
## Summary

- `ChallengeRewardBadges` (skeletons + real badges) now only render when `isAuthenticated` is true, fixing permanently-visible skeletons for guest users on both success and failure screens
- Added e2e test verifying guest challenge completion shows login prompt without reward skeletons

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide reward UI (skeletons and badges) for guests on challenge completion screens. Rewards now only render for authenticated users, with an e2e test to prevent regressions.

- **Bug Fixes**
  - Guarded ChallengeRewardBadges with isAuthenticated in ChallengeSuccessContent and ChallengeFailureContent.
  - Added e2e test: guest completion shows “Sign up to track your progress” and hides level progress and “+BP” indicators.

<sup>Written for commit 59053159cde633b756d511eb0c4b21bd8d98a82d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

