### PR TITLE
fix(main): filter excluded activity kinds in review validation query

### DIFF
--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { getReviewValidationSteps } from "@/data/activities/get-review-steps";
 import { preloadNextLesson } from "@/data/progress/preload-next-lesson";
 import { submitActivityCompletion } from "@/data/progress/submit-activity-completion";
 import { auth } from "@zoonk/core/auth";
@@ -65,15 +66,7 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
 
     const stepsForValidation =
       activity.kind === "review"
-        ? await prisma.step.findMany({
-            include: { sentence: true, word: true },
-            omit: { visualContent: true },
-            where: {
-              activity: { lessonId: activity.lessonId },
-              id: { in: Object.keys(input.answers).map(BigInt) },
-              isPublished: true,
-            },
-          })
+        ? await getReviewValidationSteps(activity.lessonId, Object.keys(input.answers).map(BigInt))
         : activity.steps;
 
     const stepResults = validateAnswers(stepsForValidation, input.answers);

--- a/apps/main/src/data/activities/get-review-steps.test.ts
+++ b/apps/main/src/data/activities/get-review-steps.test.ts
@@ -7,7 +7,7 @@ import { stepAttemptFixture } from "@zoonk/testing/fixtures/step-attempts";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { beforeAll, describe, expect, test } from "vitest";
-import { getReviewSteps } from "./get-review-steps";
+import { getReviewSteps, getReviewValidationSteps } from "./get-review-steps";
 
 const REVIEW_TARGET_COUNT = 10;
 
@@ -630,6 +630,85 @@ describe(getReviewSteps, () => {
 
     const resultIds = result.map((step) => step.id);
     expect(new Set(resultIds).size).toBe(REVIEW_TARGET_COUNT);
+  });
+});
+
+describe(getReviewValidationSteps, () => {
+  let lesson: Awaited<ReturnType<typeof lessonFixture>>;
+  let quizStep: Awaited<ReturnType<typeof stepFixture>>;
+  let challengeStep: Awaited<ReturnType<typeof stepFixture>>;
+  let reviewStep: Awaited<ReturnType<typeof stepFixture>>;
+  let staticStep: Awaited<ReturnType<typeof stepFixture>>;
+
+  beforeAll(async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({ organizationId: org.id });
+    const chapter = await chapterFixture({ courseId: course.id, organizationId: org.id });
+    lesson = await lessonFixture({ chapterId: chapter.id, organizationId: org.id });
+
+    const mcContent = {
+      kind: "core",
+      options: [
+        { feedback: "Correct!", isCorrect: true, text: "A" },
+        { feedback: "Wrong.", isCorrect: false, text: "B" },
+      ],
+    };
+
+    const [quizActivity, challengeActivity, reviewActivity] = await Promise.all([
+      activityFixture({ kind: "quiz", lessonId: lesson.id, organizationId: org.id }),
+      activityFixture({ kind: "challenge", lessonId: lesson.id, organizationId: org.id }),
+      activityFixture({ kind: "review", lessonId: lesson.id, organizationId: org.id }),
+    ]);
+
+    [quizStep, challengeStep, reviewStep, staticStep] = await Promise.all([
+      stepFixture({
+        activityId: quizActivity.id,
+        content: mcContent,
+        isPublished: true,
+        kind: "multipleChoice",
+      }),
+      stepFixture({
+        activityId: challengeActivity.id,
+        content: mcContent,
+        isPublished: true,
+        kind: "multipleChoice",
+      }),
+      stepFixture({
+        activityId: reviewActivity.id,
+        content: mcContent,
+        isPublished: true,
+        kind: "multipleChoice",
+      }),
+      stepFixture({
+        activityId: quizActivity.id,
+        content: mcContent,
+        isPublished: true,
+        kind: "static",
+      }),
+    ]);
+  });
+
+  test("excludes steps from challenge and review activities", async () => {
+    const steps = await getReviewValidationSteps(lesson.id, [
+      quizStep.id,
+      challengeStep.id,
+      reviewStep.id,
+    ]);
+
+    const stepIds = steps.map((step) => step.id);
+
+    expect(stepIds).toContain(quizStep.id);
+    expect(stepIds).not.toContain(challengeStep.id);
+    expect(stepIds).not.toContain(reviewStep.id);
+  });
+
+  test("excludes static steps", async () => {
+    const steps = await getReviewValidationSteps(lesson.id, [quizStep.id, staticStep.id]);
+
+    const stepIds = steps.map((step) => step.id);
+
+    expect(stepIds).toContain(quizStep.id);
+    expect(stepIds).not.toContain(staticStep.id);
   });
 });
 

--- a/apps/main/src/data/activities/get-review-steps.ts
+++ b/apps/main/src/data/activities/get-review-steps.ts
@@ -5,6 +5,14 @@ import { shuffle } from "@zoonk/utils/shuffle";
 const REVIEW_TARGET_COUNT = 10;
 const EXCLUDED_ACTIVITY_KINDS: ActivityKind[] = ["review", "challenge"];
 
+function reviewableStepFilter(lessonId: number) {
+  return {
+    activity: { kind: { notIn: EXCLUDED_ACTIVITY_KINDS }, lessonId },
+    isPublished: true,
+    kind: { not: "static" as const },
+  };
+}
+
 /**
  * Assembles review steps based on a user's mistakes (incorrect StepAttempt records).
  *
@@ -24,11 +32,7 @@ export async function getReviewSteps({
   lessonId: number;
   userId: number | null;
 }) {
-  const lessonStepFilter = {
-    activity: { kind: { notIn: EXCLUDED_ACTIVITY_KINDS }, lessonId },
-    isPublished: true,
-    kind: { not: "static" as const },
-  };
+  const lessonStepFilter = reviewableStepFilter(lessonId);
 
   if (!userId) {
     const allSteps = await prisma.step.findMany({
@@ -81,4 +85,17 @@ export async function getReviewSteps({
   const fillerCount = Math.max(0, REVIEW_TARGET_COUNT - prioritizedSteps.length);
 
   return shuffle([...prioritizedSteps, ...shuffle(fillerSteps).slice(0, fillerCount)]);
+}
+
+/**
+ * Fetches steps for validating a review activity submission.
+ * Only returns steps that are eligible for review — excludes
+ * steps from review/challenge activities and static steps.
+ */
+export async function getReviewValidationSteps(lessonId: number, stepIds: bigint[]) {
+  return prisma.step.findMany({
+    include: { sentence: true, word: true },
+    omit: { visualContent: true },
+    where: { ...reviewableStepFilter(lessonId), id: { in: stepIds } },
+  });
 }


### PR DESCRIPTION
## Summary

- The validation query in `submitCompletion` for review activities didn't mirror the serving filters from `getReviewSteps` — it accepted steps from challenge/review activities and static steps, allowing crafted requests to create bogus `StepAttempt` records
- Extracted a shared `reviewableStepFilter()` helper used by both `getReviewSteps` and the new `getReviewValidationSteps`, ensuring serving and validation use the same filter
- Added integration tests proving challenge, review, and static steps are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes review submission validation to only accept reviewable steps from the lesson. Prevents crafted requests from validating challenge/review/static steps and creating bogus StepAttempt records.

- **Bug Fixes**
  - Added shared reviewableStepFilter and getReviewValidationSteps to exclude challenge/review activity kinds and static steps.
  - submitCompletion now uses getReviewValidationSteps for validation.
  - Added integration tests to confirm exclusions.

<sup>Written for commit 2d69070e649e8604ac745580735c51f9298bbb03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

