### PR TITLE
fix(player): handle empty steps array as completed state

### DIFF
--- a/apps/main/src/data/activities/get-review-steps.test.ts
+++ b/apps/main/src/data/activities/get-review-steps.test.ts
@@ -489,6 +489,17 @@ describe(getReviewSteps, () => {
     expect(result).toHaveLength(5);
   });
 
+  test("returns empty array when lesson has no eligible interactive steps", async () => {
+    const newLesson = await createLessonWithSteps(org.id, 0);
+
+    const result = await getReviewSteps({
+      lessonId: newLesson.lesson.id,
+      userId: null,
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
   test("excludes unpublished steps", async () => {
     const result = await getReviewSteps({
       lessonId: lesson.id,

--- a/packages/player/src/player-reducer.test.ts
+++ b/packages/player/src/player-reducer.test.ts
@@ -751,11 +751,12 @@ describe("edge cases", () => {
     expect(next).toBe(state);
   });
 
-  test("empty steps array", () => {
+  test("empty steps array sets phase to completed", () => {
     const activity = buildActivity({ steps: [] });
     const state = createInitialState(activity);
     expect(state.steps).toEqual([]);
     expect(state.currentStepIndex).toBe(0);
+    expect(state.phase).toBe("completed");
   });
 
   test("CHECK_ANSWER with multiple effects on different dimensions", () => {

--- a/packages/player/src/player-reducer.ts
+++ b/packages/player/src/player-reducer.ts
@@ -114,16 +114,27 @@ function buildInitialAnswers(steps: SerializedStep[]): Record<string, SelectedAn
   );
 }
 
+function getInitialPhase(steps: SerializedStep[], dimensions: DimensionInventory): PlayerPhase {
+  if (steps.length === 0) {
+    return "completed";
+  }
+
+  if (Object.keys(dimensions).length > 0) {
+    return "intro";
+  }
+
+  return "playing";
+}
+
 export function createInitialState(activity: SerializedActivity): PlayerState {
   const dimensions = collectAllDimensions(activity.steps);
-  const isChallenge = Object.keys(dimensions).length > 0;
   const now = Date.now();
 
   return {
     activityId: activity.id,
     currentStepIndex: 0,
     dimensions,
-    phase: isChallenge ? "intro" : "playing",
+    phase: getInitialPhase(activity.steps, dimensions),
     results: {},
     selectedAnswers: buildInitialAnswers(activity.steps),
     startedAt: now,


### PR DESCRIPTION
## Summary

- When `getReviewSteps()` returns `[]` (no eligible interactive steps), the player initialized with `phase: "playing"` and `currentStep: undefined`, rendering a blank screen with visible header/action bar
- Extract `getInitialPhase()` in `player-reducer.ts` to set `phase: "completed"` when steps are empty, so the completion screen renders instead of a blank state

## Test plan

- [x] `player-reducer.test.ts`: empty steps array sets phase to `"completed"`
- [x] `get-review-steps.test.ts`: returns `[]` for lesson with 0 eligible interactive steps


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the player to start in "completed" when there are no eligible interactive steps. This shows the completion screen instead of a blank header-only view.

<sup>Written for commit 8f52985f18358f0cc21f4b2259aa14c1822c4523. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

