### PR TITLE
fix(player): derive challenge dimensions server-side

### DIFF
--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
@@ -11,7 +11,7 @@ import {
   completionInputSchema,
 } from "@zoonk/player/completion-input-schema";
 import { computeChallengeScore, computeScore } from "@zoonk/player/compute-score";
-import { hasNegativeDimension } from "@zoonk/player/has-negative-dimension";
+import { computeDimensions, hasNegativeDimension } from "@zoonk/player/dimensions";
 import { validateAnswers } from "@zoonk/player/validate-answers";
 import { safeAsync } from "@zoonk/utils/error";
 import { getLocale } from "next-intl/server";
@@ -71,10 +71,15 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
 
     const stepResults = validateAnswers(stepsForValidation, input.answers);
     const isChallenge = activity.kind === "challenge";
-    const isSuccessful = !hasNegativeDimension(input.dimensions);
+
+    const dimensions = isChallenge
+      ? computeDimensions(stepResults.map((result) => result.effects))
+      : {};
+
+    const isSuccessful = !hasNegativeDimension(dimensions);
 
     const score = isChallenge
-      ? computeChallengeScore({ dimensions: input.dimensions, isSuccessful })
+      ? computeChallengeScore({ dimensions, isSuccessful })
       : computeScore({
           results: stepResults.map((step) => ({ isCorrect: step.isCorrect })),
         });

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -5,7 +5,7 @@
   "exports": {
     "./check-answer": "./src/check-answer.ts",
     "./completion-input-schema": "./src/completion-input-schema.ts",
-    "./has-negative-dimension": "./src/has-negative-dimension.ts",
+    "./dimensions": "./src/dimensions.ts",
     "./compute-score": "./src/compute-score.ts",
     "./distractor-words": "./src/get-distractor-words.ts",
     "./prepare-activity-data": "./src/prepare-activity-data.ts",

--- a/packages/player/src/check-step.test.ts
+++ b/packages/player/src/check-step.test.ts
@@ -38,7 +38,11 @@ describe(checkStep, () => {
     });
 
     test("correct answer returns isCorrect true with empty effects", () => {
-      const answer: SelectedAnswer = { kind: "multipleChoice", selectedIndex: 0 };
+      const answer: SelectedAnswer = {
+        kind: "multipleChoice",
+        selectedIndex: 0,
+        selectedText: "4",
+      };
       const { effects, result } = checkStep(step, answer);
       expect(result.isCorrect).toBeTruthy();
       expect(result.feedback).toBe("Correct!");
@@ -46,7 +50,11 @@ describe(checkStep, () => {
     });
 
     test("incorrect answer returns isCorrect false", () => {
-      const answer: SelectedAnswer = { kind: "multipleChoice", selectedIndex: 1 };
+      const answer: SelectedAnswer = {
+        kind: "multipleChoice",
+        selectedIndex: 1,
+        selectedText: "3",
+      };
       const { result } = checkStep(step, answer);
       expect(result.isCorrect).toBeFalsy();
       expect(result.feedback).toBe("Wrong!");
@@ -77,14 +85,22 @@ describe(checkStep, () => {
     });
 
     test("returns effects from selected option", () => {
-      const answer: SelectedAnswer = { kind: "multipleChoice", selectedIndex: 0 };
+      const answer: SelectedAnswer = {
+        kind: "multipleChoice",
+        selectedIndex: 0,
+        selectedText: "Option A",
+      };
       const { effects, result } = checkStep(step, answer);
       expect(result.isCorrect).toBeTruthy();
       expect(effects).toEqual([{ dimension: "Quality", impact: "positive" }]);
     });
 
     test("returns effects from second option", () => {
-      const answer: SelectedAnswer = { kind: "multipleChoice", selectedIndex: 1 };
+      const answer: SelectedAnswer = {
+        kind: "multipleChoice",
+        selectedIndex: 1,
+        selectedText: "Option B",
+      };
       const { effects } = checkStep(step, answer);
       expect(effects).toEqual([{ dimension: "Quality", impact: "negative" }]);
     });
@@ -320,7 +336,7 @@ describe(checkStep, () => {
 
     test("static step returns mismatch result", () => {
       const step = buildStep();
-      const answer: SelectedAnswer = { kind: "multipleChoice", selectedIndex: 0 };
+      const answer: SelectedAnswer = { kind: "multipleChoice", selectedIndex: 0, selectedText: "" };
       const { effects, result } = checkStep(step, answer);
       expect(result.isCorrect).toBeFalsy();
       expect(result.feedback).toBeNull();

--- a/packages/player/src/completion-input-schema.ts
+++ b/packages/player/src/completion-input-schema.ts
@@ -23,6 +23,7 @@ const matchColumnsAnswerSchema = z.object({
 const multipleChoiceAnswerSchema = z.object({
   kind: z.literal("multipleChoice"),
   selectedIndex: z.number(),
+  selectedText: z.string(),
 });
 
 const readingAnswerSchema = z.object({

--- a/packages/player/src/components/completion-screen.tsx
+++ b/packages/player/src/components/completion-screen.tsx
@@ -6,7 +6,7 @@ import { type Route } from "next";
 import { useExtracted } from "next-intl";
 import { type CompletionResult } from "../completion-input-schema";
 import { computeScore } from "../compute-score";
-import { hasNegativeDimension } from "../has-negative-dimension";
+import { hasNegativeDimension } from "../dimensions";
 import { usePlayer } from "../player-context";
 import { type DimensionInventory, type StepResult } from "../player-reducer";
 import { ChallengeFailureContent, ChallengeSuccessContent } from "./challenge-completion";

--- a/packages/player/src/components/dimension-inventory.test.ts
+++ b/packages/player/src/components/dimension-inventory.test.ts
@@ -1,26 +1,7 @@
 import { type ChallengeEffect } from "@zoonk/core/steps/content-contract";
 import { describe, expect, test } from "vitest";
-import { hasNegativeDimension } from "../has-negative-dimension";
 import { type DimensionInventory } from "../player-reducer";
 import { buildDimensionEntries } from "./dimension-inventory";
-
-describe(hasNegativeDimension, () => {
-  test("returns true when any dimension is negative", () => {
-    expect(hasNegativeDimension({ Courage: 2, Diplomacy: -1, Speed: 0 })).toBeTruthy();
-  });
-
-  test("returns false when all dimensions are non-negative", () => {
-    expect(hasNegativeDimension({ Courage: 2, Diplomacy: 0, Speed: 1 })).toBeFalsy();
-  });
-
-  test("returns false for empty dimensions", () => {
-    expect(hasNegativeDimension({})).toBeFalsy();
-  });
-
-  test("returns true when all dimensions are negative", () => {
-    expect(hasNegativeDimension({ Courage: -1, Diplomacy: -2 })).toBeTruthy();
-  });
-});
 
 describe(buildDimensionEntries, () => {
   test("returns all dimensions with zero deltas when no effects", () => {

--- a/packages/player/src/components/dimension-inventory.tsx
+++ b/packages/player/src/components/dimension-inventory.tsx
@@ -2,7 +2,8 @@
 
 import { type ChallengeEffect } from "@zoonk/core/steps/content-contract";
 import { cn } from "@zoonk/ui/lib/utils";
-import { type DimensionInventory as DimensionInventoryType, effectDelta } from "../player-reducer";
+import { IMPACT_DELTA } from "../dimensions";
+import { type DimensionInventory as DimensionInventoryType } from "../player-reducer";
 
 type DimensionEntry = {
   delta: number;
@@ -33,7 +34,7 @@ export function buildDimensionEntries(
   const deltas: Record<string, number> = {};
 
   for (const effect of effects) {
-    deltas[effect.dimension] = (deltas[effect.dimension] ?? 0) + effectDelta(effect.impact);
+    deltas[effect.dimension] = (deltas[effect.dimension] ?? 0) + IMPACT_DELTA[effect.impact];
   }
 
   return Object.entries(dimensions)

--- a/packages/player/src/components/dimension-status-button.tsx
+++ b/packages/player/src/components/dimension-status-button.tsx
@@ -11,7 +11,7 @@ import {
 import { cn } from "@zoonk/ui/lib/utils";
 import { BarChart3Icon } from "lucide-react";
 import { useExtracted } from "next-intl";
-import { hasNegativeDimension } from "../has-negative-dimension";
+import { hasNegativeDimension } from "../dimensions";
 import { type DimensionInventory } from "../player-reducer";
 import { DimensionList, buildDimensionEntries } from "./dimension-inventory";
 

--- a/packages/player/src/components/multiple-choice-step.tsx
+++ b/packages/player/src/components/multiple-choice-step.tsx
@@ -236,7 +236,8 @@ export function MultipleChoiceStep({
       return;
     }
 
-    onSelectAnswer(step.id, { kind: "multipleChoice", selectedIndex: index });
+    const selectedText = content.options[index]?.text ?? "";
+    onSelectAnswer(step.id, { kind: "multipleChoice", selectedIndex: index, selectedText });
   };
 
   useOptionKeyboard({

--- a/packages/player/src/dimensions.test.ts
+++ b/packages/player/src/dimensions.test.ts
@@ -1,0 +1,65 @@
+import { type ChallengeEffect } from "@zoonk/core/steps/content-contract";
+import { describe, expect, it } from "vitest";
+import { computeDimensions, hasNegativeDimension } from "./dimensions";
+
+describe(computeDimensions, () => {
+  it("returns empty dimensions for empty effects", () => {
+    expect(computeDimensions([])).toEqual({});
+  });
+
+  it("returns +1 for a single positive effect", () => {
+    const effects: ChallengeEffect[][] = [[{ dimension: "health", impact: "positive" }]];
+    expect(computeDimensions(effects)).toEqual({ health: 1 });
+  });
+
+  it("returns -1 for a single negative effect", () => {
+    const effects: ChallengeEffect[][] = [[{ dimension: "health", impact: "negative" }]];
+    expect(computeDimensions(effects)).toEqual({ health: -1 });
+  });
+
+  it("returns 0 for a single neutral effect", () => {
+    const effects: ChallengeEffect[][] = [[{ dimension: "health", impact: "neutral" }]];
+    expect(computeDimensions(effects)).toEqual({ health: 0 });
+  });
+
+  it("accumulates effects across multiple steps", () => {
+    const effects: ChallengeEffect[][] = [
+      [{ dimension: "health", impact: "positive" }],
+      [{ dimension: "health", impact: "positive" }],
+      [{ dimension: "health", impact: "negative" }],
+    ];
+    expect(computeDimensions(effects)).toEqual({ health: 1 });
+  });
+
+  it("handles mixed dimensions across steps", () => {
+    const effects: ChallengeEffect[][] = [
+      [
+        { dimension: "health", impact: "positive" },
+        { dimension: "wealth", impact: "negative" },
+      ],
+      [
+        { dimension: "health", impact: "negative" },
+        { dimension: "reputation", impact: "positive" },
+      ],
+    ];
+    expect(computeDimensions(effects)).toEqual({ health: 0, reputation: 1, wealth: -1 });
+  });
+});
+
+describe(hasNegativeDimension, () => {
+  it("returns true when any dimension is negative", () => {
+    expect(hasNegativeDimension({ Courage: 2, Diplomacy: -1, Speed: 0 })).toBeTruthy();
+  });
+
+  it("returns false when all dimensions are non-negative", () => {
+    expect(hasNegativeDimension({ Courage: 2, Diplomacy: 0, Speed: 1 })).toBeFalsy();
+  });
+
+  it("returns false for empty dimensions", () => {
+    expect(hasNegativeDimension({})).toBeFalsy();
+  });
+
+  it("returns true when all dimensions are negative", () => {
+    expect(hasNegativeDimension({ Courage: -1, Diplomacy: -2 })).toBeTruthy();
+  });
+});

--- a/packages/player/src/dimensions.ts
+++ b/packages/player/src/dimensions.ts
@@ -1,0 +1,22 @@
+import { type ChallengeEffect } from "@zoonk/core/steps/content-contract";
+
+export const IMPACT_DELTA: Record<ChallengeEffect["impact"], number> = {
+  negative: -1,
+  neutral: 0,
+  positive: 1,
+};
+
+export function computeDimensions(stepEffects: ChallengeEffect[][]): Record<string, number> {
+  const dimensions: Record<string, number> = {};
+
+  for (const effect of stepEffects.flat()) {
+    dimensions[effect.dimension] =
+      (dimensions[effect.dimension] ?? 0) + IMPACT_DELTA[effect.impact];
+  }
+
+  return dimensions;
+}
+
+export function hasNegativeDimension(dimensions: Record<string, number>): boolean {
+  return Object.values(dimensions).some((value) => value < 0);
+}

--- a/packages/player/src/has-negative-dimension.ts
+++ b/packages/player/src/has-negative-dimension.ts
@@ -1,3 +1,0 @@
-export function hasNegativeDimension(dimensions: Record<string, number>): boolean {
-  return Object.values(dimensions).some((value) => value < 0);
-}

--- a/packages/player/src/player-provider.tsx
+++ b/packages/player/src/player-provider.tsx
@@ -3,7 +3,7 @@
 import { type Route } from "next";
 import { useCallback, useReducer } from "react";
 import { type CompletionInput, type CompletionResult } from "./completion-input-schema";
-import { hasNegativeDimension } from "./has-negative-dimension";
+import { hasNegativeDimension } from "./dimensions";
 import { PlayerContext, type PlayerContextValue } from "./player-context";
 import { type PlayerState, createInitialState, playerReducer } from "./player-reducer";
 import { type SerializedActivity } from "./prepare-activity-data";

--- a/packages/player/src/player-reducer.test.ts
+++ b/packages/player/src/player-reducer.test.ts
@@ -70,7 +70,11 @@ function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
   };
 }
 
-const multipleChoiceAnswer: SelectedAnswer = { kind: "multipleChoice", selectedIndex: 0 };
+const multipleChoiceAnswer: SelectedAnswer = {
+  kind: "multipleChoice",
+  selectedIndex: 0,
+  selectedText: "Option A",
+};
 
 const challengeContent = {
   context: "A scenario",
@@ -202,7 +206,9 @@ describe("SELECT_ANSWER", () => {
 
   test("overwrites previous answer for same step", () => {
     const state = buildState({
-      selectedAnswers: { "step-1": { kind: "multipleChoice", selectedIndex: 1 } },
+      selectedAnswers: {
+        "step-1": { kind: "multipleChoice", selectedIndex: 1, selectedText: "Option B" },
+      },
     });
     const next = playerReducer(state, {
       answer: multipleChoiceAnswer,
@@ -776,7 +782,11 @@ describe("edge cases", () => {
 
   test("results include the stored StepResult structure", () => {
     const step = buildMultipleChoiceStep({ id: "mc-1" });
-    const answer: SelectedAnswer = { kind: "multipleChoice", selectedIndex: 2 };
+    const answer: SelectedAnswer = {
+      kind: "multipleChoice",
+      selectedIndex: 2,
+      selectedText: "Option C",
+    };
     const state = buildState({ selectedAnswers: { "mc-1": answer }, steps: [step] });
     const next = playerReducer(state, {
       effects: [{ dimension: "Quality", impact: "positive" }],

--- a/packages/player/src/player-reducer.ts
+++ b/packages/player/src/player-reducer.ts
@@ -1,5 +1,6 @@
 import { type ChallengeEffect, parseStepContent } from "@zoonk/core/steps/content-contract";
 import { type AnswerResult } from "./check-answer";
+import { IMPACT_DELTA } from "./dimensions";
 import { type SerializedActivity, type SerializedStep } from "./prepare-activity-data";
 
 export type PlayerPhase = "intro" | "playing" | "feedback" | "completed";
@@ -8,7 +9,7 @@ export type SelectedAnswer =
   | { kind: "fillBlank"; userAnswers: string[] }
   | { kind: "listening"; arrangedWords: string[] }
   | { kind: "matchColumns"; userPairs: { left: string; right: string }[]; mistakes: number }
-  | { kind: "multipleChoice"; selectedIndex: number }
+  | { kind: "multipleChoice"; selectedIndex: number; selectedText: string }
   | { kind: "reading"; arrangedWords: string[] }
   | { kind: "selectImage"; selectedIndex: number }
   | { kind: "sortOrder"; userOrder: string[] }
@@ -53,18 +54,6 @@ type PlayerAction =
   | { type: "RESTART" }
   | { type: "START_CHALLENGE" };
 
-export function effectDelta(impact: ChallengeEffect["impact"]): number {
-  if (impact === "positive") {
-    return 1;
-  }
-
-  if (impact === "negative") {
-    return -1;
-  }
-
-  return 0;
-}
-
 function applyEffects(
   dimensions: DimensionInventory,
   effects: ChallengeEffect[],
@@ -76,7 +65,7 @@ function applyEffects(
   const next = { ...dimensions };
 
   for (const effect of effects) {
-    next[effect.dimension] = (next[effect.dimension] ?? 0) + effectDelta(effect.impact);
+    next[effect.dimension] = (next[effect.dimension] ?? 0) + IMPACT_DELTA[effect.impact];
   }
 
   return next;

--- a/packages/player/src/prepare-activity-data.ts
+++ b/packages/player/src/prepare-activity-data.ts
@@ -143,7 +143,7 @@ function shuffleMultipleChoiceContent(
     case "core":
       return { ...content, options: shuffle(content.options) };
     case "challenge":
-      return { ...content, options: shuffle(content.options) };
+      return content;
     case "language":
       return { ...content, options: shuffle(content.options) };
     default:

--- a/packages/player/src/validate-answers.test.ts
+++ b/packages/player/src/validate-answers.test.ts
@@ -39,7 +39,7 @@ describe(validateAnswers, () => {
     const steps = [{ content: coreMultipleChoiceContent, id: 1n, kind: "multipleChoice" }];
 
     const results = validateAnswers(steps, {
-      "1": { kind: "multipleChoice", selectedIndex: 0 },
+      "1": { kind: "multipleChoice", selectedIndex: 0, selectedText: "Option A" },
     });
 
     expect(results).toHaveLength(1);
@@ -52,7 +52,7 @@ describe(validateAnswers, () => {
     const steps = [{ content: coreMultipleChoiceContent, id: 1n, kind: "multipleChoice" }];
 
     const results = validateAnswers(steps, {
-      "1": { kind: "multipleChoice", selectedIndex: 1 },
+      "1": { kind: "multipleChoice", selectedIndex: 1, selectedText: "Option B" },
     });
 
     expect(results).toHaveLength(1);
@@ -74,11 +74,22 @@ describe(validateAnswers, () => {
     const steps = [{ content: challengeMultipleChoiceContent, id: 3n, kind: "multipleChoice" }];
 
     const results = validateAnswers(steps, {
-      "3": { kind: "multipleChoice", selectedIndex: 0 },
+      "3": { kind: "multipleChoice", selectedIndex: 0, selectedText: "Option A" },
     });
 
     expect(results).toHaveLength(1);
     expect(results[0]?.effects).toEqual([{ dimension: "Courage", impact: "positive" }]);
+  });
+
+  test("challenge multipleChoice resolves correct option by text when index is shuffled", () => {
+    const steps = [{ content: challengeMultipleChoiceContent, id: 3n, kind: "multipleChoice" }];
+
+    const results = validateAnswers(steps, {
+      "3": { kind: "multipleChoice", selectedIndex: 0, selectedText: "Option B" },
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.effects).toEqual([{ dimension: "Diplomacy", impact: "negative" }]);
   });
 
   test("skips steps with no client answer", () => {
@@ -88,7 +99,7 @@ describe(validateAnswers, () => {
     ];
 
     const results = validateAnswers(steps, {
-      "1": { kind: "multipleChoice", selectedIndex: 0 },
+      "1": { kind: "multipleChoice", selectedIndex: 0, selectedText: "Option A" },
     });
 
     expect(results).toHaveLength(1);
@@ -171,7 +182,7 @@ describe(validateAnswers, () => {
     const steps = [{ content: {}, id: 7n, kind: "unknownKind" }];
 
     const results = validateAnswers(steps, {
-      "7": { kind: "multipleChoice", selectedIndex: 0 },
+      "7": { kind: "multipleChoice", selectedIndex: 0, selectedText: "Option A" },
     });
 
     expect(results).toHaveLength(0);

--- a/packages/player/src/validate-answers.test.ts
+++ b/packages/player/src/validate-answers.test.ts
@@ -92,6 +92,18 @@ describe(validateAnswers, () => {
     expect(results[0]?.effects).toEqual([{ dimension: "Diplomacy", impact: "negative" }]);
   });
 
+  test("unmatched selectedText returns incorrect with no effects", () => {
+    const steps = [{ content: challengeMultipleChoiceContent, id: 3n, kind: "multipleChoice" }];
+
+    const results = validateAnswers(steps, {
+      "3": { kind: "multipleChoice", selectedIndex: 0, selectedText: "Nonexistent" },
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.isCorrect).toBeFalsy();
+    expect(results[0]?.effects).toEqual([]);
+  });
+
   test("skips steps with no client answer", () => {
     const steps = [
       { content: coreMultipleChoiceContent, id: 1n, kind: "multipleChoice" },

--- a/packages/player/src/validate-answers.ts
+++ b/packages/player/src/validate-answers.ts
@@ -18,7 +18,7 @@ type SelectedAnswer =
   | { kind: "fillBlank"; userAnswers: string[] }
   | { kind: "listening"; arrangedWords: string[] }
   | { kind: "matchColumns"; userPairs: { left: string; right: string }[]; mistakes: number }
-  | { kind: "multipleChoice"; selectedIndex: number }
+  | { kind: "multipleChoice"; selectedIndex: number; selectedText: string }
   | { kind: "reading"; arrangedWords: string[] }
   | { kind: "selectImage"; selectedIndex: number }
   | { kind: "sortOrder"; userOrder: string[] }
@@ -48,9 +48,10 @@ function validateMultipleChoice(
   }
 
   const content = parseStepContent("multipleChoice", step.content);
-  const result = checkMultipleChoiceAnswer(content, answer.selectedIndex);
-  const effects =
-    content.kind === "challenge" ? (content.options[answer.selectedIndex]?.effects ?? []) : [];
+  const originalIndex = content.options.findIndex((option) => option.text === answer.selectedText);
+  const index = originalIndex === -1 ? answer.selectedIndex : originalIndex;
+  const result = checkMultipleChoiceAnswer(content, index);
+  const effects = content.kind === "challenge" ? (content.options[index]?.effects ?? []) : [];
 
   return { answer, effects, isCorrect: result.isCorrect, stepId: step.id };
 }

--- a/packages/player/src/validate-answers.ts
+++ b/packages/player/src/validate-answers.ts
@@ -48,8 +48,12 @@ function validateMultipleChoice(
   }
 
   const content = parseStepContent("multipleChoice", step.content);
-  const originalIndex = content.options.findIndex((option) => option.text === answer.selectedText);
-  const index = originalIndex === -1 ? answer.selectedIndex : originalIndex;
+  const index = content.options.findIndex((option) => option.text === answer.selectedText);
+
+  if (index === -1) {
+    return { answer, effects: [], isCorrect: false, stepId: step.id };
+  }
+
   const result = checkMultipleChoiceAnswer(content, index);
   const effects = content.kind === "challenge" ? (content.options[index]?.effects ?? []) : [];
 


### PR DESCRIPTION
## Summary

- Server now computes challenge dimensions from validated step effects instead of trusting client-supplied `input.dimensions`, preventing score spoofing
- Added `selectedText` to multipleChoice answers so the server resolves the correct option by text regardless of client-side shuffle order (fixes inverted scores for challenges and incorrect `isCorrect` for quizzes)
- Consolidated `has-negative-dimension.ts`, `compute-dimensions.ts`, and `effectDelta` from `player-reducer.ts` into a single `dimensions.ts` module

## Test plan

- [x] Unit tests for `computeDimensions` and `hasNegativeDimension` in `dimensions.test.ts`
- [x] Regression test: shuffled index with correct `selectedText` resolves the right option
- [x] E2E: challenge success (+100 BP) and failure (+10 BP) verified stable across multiple runs
- [x] All 378 main e2e, 193 editor e2e, 56 api e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compute challenge dimensions on the server from validated step effects to prevent score spoofing and stabilize challenge results. Multiple-choice answers now use selectedText for resolution; unmatched text is rejected to avoid index mismatches.

- **Bug Fixes**
  - Derive challenge dimensions server-side with computeDimensions and use them for success checks and computeChallengeScore.
  - Resolve multiple-choice answers by selectedText; reject unmatched text (no effects, isCorrect false) to prevent fallback to selectedIndex.
  - Stop shuffling challenge multipleChoice options to keep option mapping stable.

- **Refactors**
  - Added dimensions.ts with IMPACT_DELTA, computeDimensions, and hasNegativeDimension; updated exports and imports.
  - Removed has-negative-dimension.ts and effectDelta; updated components, reducer, and tests accordingly.

<sup>Written for commit f960fd40d4193376de565989cd11b3e5444f9d9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

