### PR TITLE
refactor(player): unify result states with settled wash pattern

### DIFF
--- a/packages/player/src/components/arrange-words.tsx
+++ b/packages/player/src/components/arrange-words.tsx
@@ -49,8 +49,9 @@ function PlacedWordTile({
         hasResult && "pointer-events-none",
         !hasResult &&
           "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]",
-        resultState === "correct" && "border-l-success border-l-2",
-        resultState === "incorrect" && "border-l-destructive border-l-2",
+        resultState === "correct" && "bg-success/5 text-success border-transparent opacity-75",
+        resultState === "incorrect" &&
+          "bg-destructive/5 text-destructive border-transparent opacity-75",
       )}
       disabled={hasResult}
       onClick={onClick}

--- a/packages/player/src/components/fill-blank-step.tsx
+++ b/packages/player/src/components/fill-blank-step.tsx
@@ -58,8 +58,8 @@ function BlankSlot({
           "inline-flex min-w-16 items-center justify-center border-b-2 px-1 font-medium transition-all duration-150",
           hasResult && "pointer-events-none",
           !resultState && "border-primary/30 text-primary",
-          resultState === "correct" && "border-success text-success",
-          resultState === "incorrect" && "border-destructive text-destructive",
+          resultState === "correct" && "border-success/50 text-success opacity-75",
+          resultState === "incorrect" && "border-destructive/50 text-destructive opacity-75",
         )}
         disabled={hasResult}
         onClick={onRemove}

--- a/packages/player/src/components/match-columns-step.tsx
+++ b/packages/player/src/components/match-columns-step.tsx
@@ -2,7 +2,6 @@
 
 import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { cn } from "@zoonk/ui/lib/utils";
-import { CircleCheck } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { Fragment, useCallback, useMemo, useRef, useState } from "react";
 import { checkSingleMatchPair } from "../check-answer";
@@ -47,7 +46,7 @@ function getItemVisualState({
 
 function getItemClassName(state: ItemVisualState): string {
   if (state === "correct") {
-    return "border-success bg-success/5 pointer-events-none";
+    return "bg-success/5 border-transparent text-success opacity-75 pointer-events-none";
   }
 
   if (state === "incorrectFlash") {
@@ -77,17 +76,14 @@ function MatchItem({
       aria-label={label}
       aria-pressed={state === "selected"}
       className={cn(
-        "border-border flex min-h-11 items-center gap-2 rounded-lg border px-2.5 py-2.5 text-left text-sm wrap-break-word transition-all duration-150 sm:px-4 sm:py-3.5 sm:text-base",
+        "border-border flex min-h-11 items-center rounded-lg border px-2.5 py-2.5 text-left text-sm wrap-break-word transition-all duration-150 sm:px-4 sm:py-3.5 sm:text-base",
         getItemClassName(state),
       )}
+      aria-disabled={isLocked || undefined}
       disabled={isLocked}
       onClick={onTap}
       type="button"
     >
-      {state === "correct" && (
-        <CircleCheck aria-hidden="true" className="text-success size-3.5 shrink-0" />
-      )}
-
       <span>{label}</span>
     </button>
   );

--- a/packages/player/src/components/multiple-choice-step.tsx
+++ b/packages/player/src/components/multiple-choice-step.tsx
@@ -77,25 +77,29 @@ function OptionList({
 
   return (
     <div aria-label={t("Answer options")} className="flex flex-col gap-3" role="radiogroup">
-      {options.map((option, index) => (
-        <OptionCard
-          disabled={disabled}
-          index={index}
-          isSelected={selectedIndex === index}
-          key={option.text}
-          onSelect={() => onSelect(index)}
-          resultState={
-            disabled && selectedIndex !== null
-              ? getOptionResultState(index, content, selectedIndex)
-              : undefined
-          }
-        >
-          <OptionContent
-            romanization={"textRomanization" in option ? option.textRomanization : undefined}
-            text={option.text}
-          />
-        </OptionCard>
-      ))}
+      {options.map((option, index) => {
+        const resultState =
+          disabled && selectedIndex !== null
+            ? getOptionResultState(index, content, selectedIndex)
+            : undefined;
+
+        return (
+          <OptionCard
+            disabled={disabled}
+            index={index}
+            isDimmed={disabled && selectedIndex !== null && !resultState}
+            isSelected={selectedIndex === index}
+            key={option.text}
+            onSelect={() => onSelect(index)}
+            resultState={resultState}
+          >
+            <OptionContent
+              romanization={"textRomanization" in option ? option.textRomanization : undefined}
+              text={option.text}
+            />
+          </OptionCard>
+        );
+      })}
     </div>
   );
 }

--- a/packages/player/src/components/option-card.tsx
+++ b/packages/player/src/components/option-card.tsx
@@ -5,6 +5,7 @@ export function OptionCard({
   children,
   disabled,
   index,
+  isDimmed,
   isSelected,
   onSelect,
   resultState,
@@ -12,6 +13,7 @@ export function OptionCard({
   children: React.ReactNode;
   disabled?: boolean;
   index: number;
+  isDimmed?: boolean;
   isSelected: boolean;
   onSelect: () => void;
   resultState?: "correct" | "incorrect";
@@ -24,8 +26,10 @@ export function OptionCard({
         !disabled && !isSelected && "border-border hover:bg-accent",
         !disabled && isSelected && "border-primary bg-primary/5",
         disabled && "pointer-events-none",
-        resultState === "correct" && "border-l-success border-l-2",
-        resultState === "incorrect" && "border-l-destructive border-l-2",
+        isDimmed && "opacity-40",
+        resultState === "correct" && "bg-success/5 text-success border-transparent opacity-75",
+        resultState === "incorrect" &&
+          "bg-destructive/5 text-destructive border-transparent opacity-75",
       )}
       disabled={disabled}
       onClick={onSelect}

--- a/packages/player/src/components/result-kbd.tsx
+++ b/packages/player/src/components/result-kbd.tsx
@@ -1,6 +1,5 @@
 import { Kbd } from "@zoonk/ui/components/kbd";
 import { cn } from "@zoonk/ui/lib/utils";
-import { CheckIcon, XIcon } from "lucide-react";
 
 export function ResultKbd({
   children,
@@ -11,24 +10,15 @@ export function ResultKbd({
   isSelected?: boolean;
   resultState?: "correct" | "incorrect";
 }) {
-  if (resultState === "correct") {
-    return (
-      <Kbd aria-hidden="true" className="bg-success text-white">
-        <CheckIcon aria-hidden="true" className="size-3" />
-      </Kbd>
-    );
-  }
-
-  if (resultState === "incorrect") {
-    return (
-      <Kbd aria-hidden="true" className="bg-destructive text-white">
-        <XIcon aria-hidden="true" className="size-3" />
-      </Kbd>
-    );
-  }
-
   return (
-    <Kbd aria-hidden="true" className={cn(isSelected && "bg-primary text-primary-foreground")}>
+    <Kbd
+      aria-hidden="true"
+      className={cn(
+        isSelected && !resultState && "bg-primary text-primary-foreground",
+        resultState === "correct" && "text-success",
+        resultState === "incorrect" && "text-destructive",
+      )}
+    >
       {children}
     </Kbd>
   );

--- a/packages/player/src/components/select-image-step.tsx
+++ b/packages/player/src/components/select-image-step.tsx
@@ -2,7 +2,6 @@
 
 import { type SelectImageStepContent, parseStepContent } from "@zoonk/core/steps/content-contract";
 import { cn } from "@zoonk/ui/lib/utils";
-import { CircleCheck, CircleX } from "lucide-react";
 import { useExtracted } from "next-intl";
 import Image from "next/image";
 import { useState } from "react";
@@ -61,23 +60,6 @@ function ImageWithFallback({ alt, url }: { alt: string; url: string | undefined 
   );
 }
 
-function ResultBadge({ state }: { state: "correct" | "incorrect" }) {
-  return (
-    <div
-      className={cn(
-        "absolute top-2 right-2 rounded-full p-0.5",
-        state === "correct" ? "bg-success text-success-foreground" : "bg-destructive text-white",
-      )}
-    >
-      {state === "correct" ? (
-        <CircleCheck aria-hidden="true" className="size-4" />
-      ) : (
-        <CircleX aria-hidden="true" className="size-4" />
-      )}
-    </div>
-  );
-}
-
 function ImageOptionCard({
   disabled,
   isDimmed,
@@ -104,8 +86,8 @@ function ImageOptionCard({
         isDimmed && "opacity-50",
         !resultState && isSelected && "border-primary bg-primary/5",
         !resultState && !isSelected && "border-border hover:bg-accent",
-        resultState === "correct" && "border-success",
-        resultState === "incorrect" && "border-destructive",
+        resultState === "correct" && "border-success/60 opacity-80",
+        resultState === "incorrect" && "border-destructive/60 opacity-80",
       )}
       disabled={disabled}
       onClick={onSelect}
@@ -113,8 +95,6 @@ function ImageOptionCard({
       type="button"
     >
       <ImageWithFallback alt={prompt} url={url} />
-
-      {resultState && <ResultBadge state={resultState} />}
     </button>
   );
 }

--- a/packages/player/src/components/sort-order-step.tsx
+++ b/packages/player/src/components/sort-order-step.tsx
@@ -201,8 +201,10 @@ function ResultItemList({
               })}
               className={cn(
                 "pointer-events-none flex min-h-11 items-center gap-3 rounded-lg border px-3 py-2 text-left sm:px-4 sm:py-2.5",
-                resultState === "correct" && "border-l-success border-l-2",
-                resultState === "incorrect" && "border-l-destructive border-l-2",
+                resultState === "correct" &&
+                  "bg-success/5 text-success border-transparent opacity-75",
+                resultState === "incorrect" &&
+                  "bg-destructive/5 text-destructive border-transparent opacity-75",
               )}
               // oxlint-disable-next-line react/no-array-index-key -- Items can repeat, no unique ID
               key={`${item}-${index}`}


### PR DESCRIPTION
## Summary

- Replace left accent bars (`border-l-success/destructive border-l-2`) and icon overlays with a consistent "settled" visual treatment across all step types
- Correct items: subtle green background wash + green text + reduced opacity
- Incorrect items: subtle red background wash + red text + reduced opacity
- Neutral options: dimmed to 40% opacity after submission
- `ResultKbd` keeps numbers visible instead of replacing with check/X icons
- Remove `ResultBadge` overlay from image selection step

## Test plan

- [x] `pnpm turbo quality:fix` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm knip --production` passes
- [x] `pnpm test` passes (515 tests)
- [x] `pnpm --filter main build` passes
- [x] Main e2e: 378 passed
- [x] Editor e2e: 193 passed
- [x] API e2e: 56 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies result visuals across all player steps with a subtle “settled” wash to improve clarity and consistency. Replaces left accent bars and icon overlays with background tints, text color, and reduced opacity.

- **Refactors**
  - Apply wash pattern for correct/incorrect across arrange words, fill blank, match columns, multiple choice, and sort order.
  - Dim neutral options after submission (OptionCard adds isDimmed).
  - Keep numbers visible in ResultKbd; remove check/X; tint text on result.
  - Remove image ResultBadge; use border tint + opacity in select image.
  - Remove success icons in match columns; add aria-disabled; simplify classes.

<sup>Written for commit 0d444e2305b7ead00d5dbb86a41be678b2210d77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

