### PR TITLE
fix(ui): prevent scroll locking and fix pagination spacing

### DIFF
--- a/apps/admin/src/components/pagination.tsx
+++ b/apps/admin/src/components/pagination.tsx
@@ -63,7 +63,7 @@ export function AdminPagination({
   const pagesWithEllipses = addEllipsesToPages(visiblePages);
 
   return (
-    <Pagination className="mt-6">
+    <Pagination>
       <PaginationContent>
         <PaginationItem>
           <PaginationPrevious

--- a/packages/ui/src/components/container.tsx
+++ b/packages/ui/src/components/container.tsx
@@ -123,7 +123,9 @@ export type ContainerBodyProps = React.ComponentProps<"div">;
 
 export function ContainerBody({ children, className }: ContainerBodyProps) {
   return (
-    <section className={cn("flex w-full flex-1 flex-col gap-4 px-4 sm:flex-initial", className)}>
+    <section
+      className={cn("flex w-full flex-1 flex-col gap-4 px-4 pb-4 sm:flex-initial", className)}
+    >
       {children}
     </section>
   );

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -304,7 +304,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
   return (
     <main
       className={cn(
-        "bg-background relative flex min-w-0 flex-1 flex-col overflow-x-hidden md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        "bg-background relative flex min-w-0 flex-1 flex-col overflow-x-clip md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className,
       )}
       data-slot="sidebar-inset"


### PR DESCRIPTION
## Summary

- **Fix scroll locking**: `SidebarInset` used `overflow-x-hidden` which triggers a CSS spec quirk where `overflow-y` computes to `auto`, creating an unintended scroll container. Changed to `overflow-x-clip` which clips without creating a scroll container
- **Fix pagination spacing**: Added `pb-4` to `ContainerBody` for consistent bottom padding and removed redundant `mt-6` from admin pagination (the parent's `gap-4` already handles spacing)

## Test plan

- [ ] Verify scrolling works on first attempt in admin course list (with 50+ courses to trigger pagination)
- [ ] Verify pagination has balanced spacing above and below
- [ ] Verify no horizontal overflow issues in sidebar layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents sidebar scroll locking and evens out pagination spacing in admin lists.

- **Bug Fixes**
  - Sidebar: switched overflow-x-hidden to overflow-x-clip to avoid creating an unintended scroll container.
  - Layout: added pb-4 to ContainerBody for consistent bottom padding; removed mt-6 from AdminPagination since parent gap-4 handles spacing.

<sup>Written for commit 554f80ad085ba81abde8786723b485e329b1c503. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

