### PR TITLE
feat(admin): add username, last login columns and multi-field search

### DIFF
--- a/apps/admin/src/app/(private)/users/user-list.tsx
+++ b/apps/admin/src/app/(private)/users/user-list.tsx
@@ -20,10 +20,12 @@ export async function UserList({
           <TableHeader>
             <TableRow>
               <TableHead>Name</TableHead>
+              <TableHead>Username</TableHead>
               <TableHead>Email</TableHead>
               <TableHead>Role</TableHead>
               <TableHead>Email Verified</TableHead>
               <TableHead>Banned</TableHead>
+              <TableHead>Last Login</TableHead>
               <TableHead>Created At</TableHead>
             </TableRow>
           </TableHeader>

--- a/apps/admin/src/app/(private)/users/user-row.tsx
+++ b/apps/admin/src/app/(private)/users/user-row.tsx
@@ -1,10 +1,17 @@
-import { type UserWithRole } from "@zoonk/core/types";
+import { type listUsers } from "@/data/users/list-users";
 import { TableCell, TableRow } from "@zoonk/ui/components/table";
 
-export function UserRow({ user }: { user: UserWithRole }) {
+export function UserRow({
+  user,
+}: {
+  user: Awaited<ReturnType<typeof listUsers>>["users"][number];
+}) {
+  const lastLogin = user.sessions[0]?.updatedAt;
+
   return (
     <TableRow>
       <TableCell className="font-medium">{user.name || "—"}</TableCell>
+      <TableCell>{user.username || "—"}</TableCell>
       <TableCell>{user.email}</TableCell>
       <TableCell className="capitalize">{user.role || "user"}</TableCell>
 
@@ -22,6 +29,10 @@ export function UserRow({ user }: { user: UserWithRole }) {
         ) : (
           <span className="text-muted-foreground">—</span>
         )}
+      </TableCell>
+
+      <TableCell className="text-muted-foreground">
+        {lastLogin ? new Date(lastLogin).toLocaleDateString() : "—"}
       </TableCell>
 
       <TableCell className="text-muted-foreground">

--- a/apps/admin/src/app/(private)/users/user-search.tsx
+++ b/apps/admin/src/app/(private)/users/user-search.tsx
@@ -17,7 +17,7 @@ export function UserSearch() {
       <Input
         className="pl-9"
         onChange={(event) => setSearch(event.target.value)}
-        placeholder="Search by email..."
+        placeholder="Search by name, username, or email..."
         type="search"
         value={search}
       />

--- a/apps/admin/src/data/users/list-users.ts
+++ b/apps/admin/src/data/users/list-users.ts
@@ -1,24 +1,42 @@
 import "server-only";
-import { auth } from "@zoonk/core/auth";
-import { headers } from "next/headers";
+import { getSession } from "@zoonk/core/users/session/get";
+import { prisma } from "@zoonk/db";
 
 export async function listUsers(params: { limit: number; offset: number; search?: string }) {
+  const session = await getSession();
+
+  if (session?.user.role !== "admin") {
+    return { total: 0, users: [] };
+  }
+
   const { limit, offset, search } = params;
 
-  const result = await auth.api.listUsers({
-    headers: await headers(),
-    query: {
-      limit,
-      offset,
-      sortBy: "createdAt",
-      sortDirection: "desc",
-      ...(search && {
-        searchField: "email",
-        searchOperator: "contains",
-        searchValue: search,
-      }),
-    },
-  });
+  const where = search
+    ? {
+        OR: [
+          { name: { contains: search, mode: "insensitive" as const } },
+          { email: { contains: search, mode: "insensitive" as const } },
+          { username: { contains: search, mode: "insensitive" as const } },
+        ],
+      }
+    : undefined;
 
-  return { total: result.total, users: result.users };
+  const [users, total] = await Promise.all([
+    prisma.user.findMany({
+      include: {
+        sessions: {
+          orderBy: { updatedAt: "desc" },
+          select: { updatedAt: true },
+          take: 1,
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      skip: offset,
+      take: limit,
+      where,
+    }),
+    prisma.user.count({ where }),
+  ]);
+
+  return { total, users };
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,6 @@
     "@zoonk/db": "workspace:*",
     "@zoonk/mailer": "workspace:*",
     "@zoonk/utils": "workspace:*",
-    "better-auth": "1.5.0",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,6 +2,4 @@ import { type auth } from "@zoonk/auth";
 
 export type AuthOrganization = typeof auth.$Infer.Organization;
 
-export type { UserWithRole } from "better-auth/plugins";
-
 export type { Organization } from "@zoonk/db";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -580,9 +580,6 @@ importers:
       '@zoonk/utils':
         specifier: workspace:*
         version: link:../utils
-      better-auth:
-        specifier: 1.5.0
-        version: 1.5.0(66dc62a7c254178cd477dad05dc5aaf3)
       next:
         specifier: '>=16'
         version: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -10078,39 +10075,6 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)
-    transitivePeerDependencies:
-      - '@cloudflare/workers-types'
-
-  better-auth@1.5.0(66dc62a7c254178cd477dad05dc5aaf3):
-    dependencies:
-      '@better-auth/core': 1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/drizzle-adapter': 1.5.0(@better-auth/core@1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.18.0)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.19.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))
-      '@better-auth/kysely-adapter': 1.5.0(@better-auth/core@1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)
-      '@better-auth/memory-adapter': 1.5.0(@better-auth/core@1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
-      '@better-auth/mongo-adapter': 1.5.0(@better-auth/core@1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0)
-      '@better-auth/prisma-adapter': 1.5.0(@better-auth/core@1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
-      '@better-auth/telemetry': 1.5.0(@better-auth/core@1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      '@noble/ciphers': 2.1.1
-      '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@4.3.6)
-      defu: 6.1.4
-      jose: 6.1.3
-      kysely: 0.28.11
-      nanostores: 1.1.1
-      zod: 4.3.6
-    optionalDependencies:
-      '@prisma/client': 7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
-      drizzle-orm: 0.45.1(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.18.0)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.19.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
-      mongodb: 7.1.0
-      mysql2: 3.15.3
-      next: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      pg: 8.19.0
-      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
 


### PR DESCRIPTION
## Summary

- Replace `auth.api.listUsers` with direct Prisma query for multi-field OR search (name, username, email)
- Add username and last login columns to the user list table
- Include most recent session data to display last login time
- Remove unused `UserWithRole` type and `better-auth` dependency from `@zoonk/core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Username and Last Login to the admin user list and enables case-insensitive search by name, username, or email.

- **New Features**
  - New columns: Username and Last Login (shows most recent session time or —).
  - Multi-field OR search across name, username, and email.
  - Updated search placeholder to match new fields.

- **Refactors**
  - Replaced auth.api.listUsers with a Prisma query (includes latest session, paginated, ordered by createdAt desc).
  - Added admin-only guard using getSession; non-admins receive an empty result.
  - Removed unused UserWithRole type and the better-auth dependency from @zoonk/core.

<sup>Written for commit c738edcf34193244fa1d42b5e1934684633f6213. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

