### PR TITLE
feat(admin): add user detail page and simplify user list

### DIFF
--- a/apps/admin/src/app/(private)/users/[id]/_actions/ban-user.ts
+++ b/apps/admin/src/app/(private)/users/[id]/_actions/ban-user.ts
@@ -1,0 +1,40 @@
+"use server";
+
+import { getSession } from "@zoonk/core/users/session/get";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { parseFormField } from "@zoonk/utils/form";
+import { parseNumericId } from "@zoonk/utils/string";
+import { revalidatePath } from "next/cache";
+
+export async function banUserAction(formData: FormData) {
+  const session = await getSession();
+
+  if (session?.user.role !== "admin") {
+    throw new Error("Unauthorized");
+  }
+
+  const userIdRaw = parseFormField(formData, "userId");
+  const userId = userIdRaw ? parseNumericId(userIdRaw) : null;
+
+  if (!userId) {
+    throw new Error("Invalid user ID");
+  }
+
+  const reason = parseFormField(formData, "reason") || null;
+  const expiresRaw = parseFormField(formData, "expires");
+  const banExpires = expiresRaw ? new Date(expiresRaw) : null;
+
+  const { error } = await safeAsync(() =>
+    prisma.user.update({
+      data: { banExpires, banReason: reason, banned: true },
+      where: { id: userId },
+    }),
+  );
+
+  if (error) {
+    throw error;
+  }
+
+  revalidatePath(`/users/${userId}`);
+}

--- a/apps/admin/src/app/(private)/users/[id]/_actions/change-plan.ts
+++ b/apps/admin/src/app/(private)/users/[id]/_actions/change-plan.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { getSession } from "@zoonk/core/users/session/get";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { parseFormField } from "@zoonk/utils/form";
+import { parseNumericId } from "@zoonk/utils/string";
+import { revalidatePath } from "next/cache";
+
+export async function changePlanAction(formData: FormData) {
+  const session = await getSession();
+
+  if (session?.user.role !== "admin") {
+    throw new Error("Unauthorized");
+  }
+
+  const userIdRaw = parseFormField(formData, "userId");
+  const userId = userIdRaw ? parseNumericId(userIdRaw) : null;
+  const plan = parseFormField(formData, "plan");
+
+  if (!userId || !plan) {
+    throw new Error("Invalid form data");
+  }
+
+  const referenceId = String(userId);
+
+  const existing = await prisma.subscription.findFirst({
+    orderBy: { id: "desc" },
+    where: { referenceId },
+  });
+
+  if (existing?.stripeSubscriptionId) {
+    throw new Error("Cannot change plan for Stripe-managed subscriptions");
+  }
+
+  const { error } = await safeAsync(() => {
+    if (existing) {
+      return prisma.subscription.update({
+        data: { periodStart: new Date(), plan, status: "active" },
+        where: { id: existing.id },
+      });
+    }
+
+    return prisma.subscription.create({
+      data: { periodStart: new Date(), plan, referenceId, status: "active" },
+    });
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  revalidatePath(`/users/${userId}`);
+}

--- a/apps/admin/src/app/(private)/users/[id]/_actions/revoke-sessions.ts
+++ b/apps/admin/src/app/(private)/users/[id]/_actions/revoke-sessions.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { getSession } from "@zoonk/core/users/session/get";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { parseFormField } from "@zoonk/utils/form";
+import { parseNumericId } from "@zoonk/utils/string";
+import { revalidatePath } from "next/cache";
+
+export async function revokeSessionsAction(formData: FormData) {
+  const session = await getSession();
+
+  if (session?.user.role !== "admin") {
+    throw new Error("Unauthorized");
+  }
+
+  const userIdRaw = parseFormField(formData, "userId");
+  const userId = userIdRaw ? parseNumericId(userIdRaw) : null;
+
+  if (!userId) {
+    throw new Error("Invalid user ID");
+  }
+
+  const { error } = await safeAsync(() => prisma.session.deleteMany({ where: { userId } }));
+
+  if (error) {
+    throw error;
+  }
+
+  revalidatePath(`/users/${userId}`);
+}

--- a/apps/admin/src/app/(private)/users/[id]/_actions/unban-user.ts
+++ b/apps/admin/src/app/(private)/users/[id]/_actions/unban-user.ts
@@ -1,0 +1,36 @@
+"use server";
+
+import { getSession } from "@zoonk/core/users/session/get";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { parseFormField } from "@zoonk/utils/form";
+import { parseNumericId } from "@zoonk/utils/string";
+import { revalidatePath } from "next/cache";
+
+export async function unbanUserAction(formData: FormData) {
+  const session = await getSession();
+
+  if (session?.user.role !== "admin") {
+    throw new Error("Unauthorized");
+  }
+
+  const userIdRaw = parseFormField(formData, "userId");
+  const userId = userIdRaw ? parseNumericId(userIdRaw) : null;
+
+  if (!userId) {
+    throw new Error("Invalid user ID");
+  }
+
+  const { error } = await safeAsync(() =>
+    prisma.user.update({
+      data: { banExpires: null, banReason: null, banned: false },
+      where: { id: userId },
+    }),
+  );
+
+  if (error) {
+    throw error;
+  }
+
+  revalidatePath(`/users/${userId}`);
+}

--- a/apps/admin/src/app/(private)/users/[id]/ban-user-dialog.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/ban-user-dialog.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@zoonk/ui/components/alert-dialog";
+import { Button } from "@zoonk/ui/components/button";
+import { Input } from "@zoonk/ui/components/input";
+import { Label } from "@zoonk/ui/components/label";
+import { Textarea } from "@zoonk/ui/components/textarea";
+import { banUserAction } from "./_actions/ban-user";
+
+export function BanUserDialog({ userId, userName }: { userId: number; userName: string }) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger render={<Button variant="outline" size="sm" />}>
+        Ban User
+      </AlertDialogTrigger>
+
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Ban {userName}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will prevent the user from accessing the platform.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <form action={banUserAction}>
+          <input type="hidden" name="userId" value={userId} />
+
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="reason">Reason (optional)</Label>
+              <Textarea id="reason" name="reason" placeholder="Reason for banning..." />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="expires">Expires (optional)</Label>
+              <Input id="expires" name="expires" type="date" />
+            </div>
+          </div>
+
+          <AlertDialogFooter className="mt-6">
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction type="submit" variant="destructive">
+              Ban User
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </form>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/admin/src/app/(private)/users/[id]/change-plan-dialog.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/change-plan-dialog.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Button } from "@zoonk/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@zoonk/ui/components/dialog";
+import { Label } from "@zoonk/ui/components/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@zoonk/ui/components/select";
+import { SUBSCRIPTION_PLANS } from "@zoonk/utils/subscription";
+import { useState } from "react";
+import { changePlanAction } from "./_actions/change-plan";
+
+function PlanSelect({
+  value,
+  onValueChange,
+}: {
+  value: string;
+  onValueChange: (newPlan: string) => void;
+}) {
+  return (
+    <Select value={value} onValueChange={(newValue) => newValue && onValueChange(newValue)}>
+      <SelectTrigger>
+        <SelectValue />
+      </SelectTrigger>
+
+      <SelectContent>
+        {SUBSCRIPTION_PLANS.map((plan) => (
+          <SelectItem key={plan.name} value={plan.name}>
+            <span className="capitalize">{plan.name}</span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+export function ChangePlanDialog({ userId, currentPlan }: { userId: number; currentPlan: string }) {
+  const [open, setOpen] = useState(false);
+  const [plan, setPlan] = useState(currentPlan);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger render={<Button variant="outline" size="sm" />}>Change Plan</DialogTrigger>
+
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Change subscription plan</DialogTitle>
+          <DialogDescription>Manually change this user&apos;s subscription plan.</DialogDescription>
+        </DialogHeader>
+
+        <form
+          action={async (formData) => {
+            await changePlanAction(formData);
+            setOpen(false);
+          }}
+        >
+          <input type="hidden" name="userId" value={userId} />
+          <input type="hidden" name="plan" value={plan} />
+
+          <div className="flex flex-col gap-2">
+            <Label>Plan</Label>
+            <PlanSelect value={plan} onValueChange={setPlan} />
+          </div>
+
+          <DialogFooter className="mt-6">
+            <Button type="submit">Save</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/src/app/(private)/users/[id]/detail-field.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/detail-field.tsx
@@ -1,0 +1,8 @@
+export function DetailField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4 py-2">
+      <dt className="text-muted-foreground text-sm">{label}</dt>
+      <dd className="text-right text-sm">{children}</dd>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/users/[id]/page.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/page.tsx
@@ -1,0 +1,100 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@zoonk/ui/components/breadcrumb";
+import {
+  Container,
+  ContainerBody,
+  ContainerHeader,
+  ContainerHeaderGroup,
+} from "@zoonk/ui/components/container";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { parseNumericId } from "@zoonk/utils/string";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import { UserAccount } from "./user-account";
+import { UserActivity } from "./user-activity";
+import { UserHeader } from "./user-header";
+import { UserSubscription } from "./user-subscription";
+
+function UserBreadcrumb() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink render={<Link href="/users" />}>Users</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Details</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}
+
+function HeaderSkeleton() {
+  return (
+    <div className="flex items-center gap-4">
+      <Skeleton className="size-10 rounded-full" />
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-5 w-32" />
+        <Skeleton className="h-4 w-24" />
+      </div>
+    </div>
+  );
+}
+
+function SectionSkeleton() {
+  return (
+    <div className="flex flex-col gap-3">
+      <Skeleton className="h-4 w-24" />
+      <Skeleton className="h-px w-full" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-3/4" />
+    </div>
+  );
+}
+
+export default async function UserDetailPage({ params }: PageProps<"/users/[id]">) {
+  const { id: rawId } = await params;
+  const userId = parseNumericId(String(rawId));
+
+  if (!userId) {
+    notFound();
+  }
+
+  return (
+    <Container>
+      <ContainerHeader variant="sidebar">
+        <ContainerHeaderGroup>
+          <UserBreadcrumb />
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody className="max-w-2xl gap-8">
+        <Suspense fallback={<HeaderSkeleton />}>
+          <UserHeader userId={userId} />
+        </Suspense>
+
+        <Suspense fallback={<SectionSkeleton />}>
+          <UserAccount userId={userId} />
+        </Suspense>
+
+        <Suspense fallback={<SectionSkeleton />}>
+          <UserSubscription userId={userId} />
+        </Suspense>
+
+        <Suspense fallback={<SectionSkeleton />}>
+          <UserActivity userId={userId} />
+        </Suspense>
+      </ContainerBody>
+    </Container>
+  );
+}

--- a/apps/admin/src/app/(private)/users/[id]/revoke-sessions-dialog.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/revoke-sessions-dialog.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@zoonk/ui/components/alert-dialog";
+import { Button } from "@zoonk/ui/components/button";
+import { useState } from "react";
+import { revokeSessionsAction } from "./_actions/revoke-sessions";
+
+export function RevokeSessionsDialog({ userId, userName }: { userId: number; userName: string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger render={<Button variant="outline" size="sm" />}>
+        Revoke Sessions
+      </AlertDialogTrigger>
+
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Revoke all sessions?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will sign {userName} out of all devices.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <form
+          action={async (formData) => {
+            await revokeSessionsAction(formData);
+            setOpen(false);
+          }}
+        >
+          <input type="hidden" name="userId" value={userId} />
+
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <Button type="submit" variant="destructive">
+              Revoke Sessions
+            </Button>
+          </AlertDialogFooter>
+        </form>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/admin/src/app/(private)/users/[id]/unban-user-dialog.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/unban-user-dialog.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@zoonk/ui/components/alert-dialog";
+import { Button } from "@zoonk/ui/components/button";
+import { unbanUserAction } from "./_actions/unban-user";
+
+export function UnbanUserDialog({ userId, userName }: { userId: number; userName: string }) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger render={<Button variant="outline" size="sm" />}>
+        Unban User
+      </AlertDialogTrigger>
+
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Unban {userName}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will restore the user&apos;s access to the platform.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <form action={unbanUserAction}>
+          <input type="hidden" name="userId" value={userId} />
+
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction type="submit">Unban User</AlertDialogAction>
+          </AlertDialogFooter>
+        </form>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/admin/src/app/(private)/users/[id]/user-account.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/user-account.tsx
@@ -1,0 +1,39 @@
+import { getUser } from "@/data/users/get-user";
+import { Separator } from "@zoonk/ui/components/separator";
+import { DetailField } from "./detail-field";
+
+export async function UserAccount({ userId }: { userId: number }) {
+  const user = await getUser(userId);
+
+  if (!user) {
+    return null;
+  }
+
+  const lastLogin = user.sessions[0]?.updatedAt;
+  const providers = user.accounts.map((a) => a.providerId);
+
+  return (
+    <section>
+      <h3 className="mb-2 text-sm font-semibold">Account</h3>
+      <Separator />
+
+      <dl className="mt-2">
+        <DetailField label="Email">{user.email}</DetailField>
+        <DetailField label="Email verified">{user.emailVerified ? "Yes" : "No"}</DetailField>
+
+        <DetailField label="Auth providers">
+          {providers.length > 0 ? <span className="capitalize">{providers.join(", ")}</span> : "—"}
+        </DetailField>
+
+        <DetailField label="Joined">{new Date(user.createdAt).toLocaleDateString()}</DetailField>
+        <DetailField label="Last updated">
+          {new Date(user.updatedAt).toLocaleDateString()}
+        </DetailField>
+
+        <DetailField label="Last login">
+          {lastLogin ? new Date(lastLogin).toLocaleDateString() : "—"}
+        </DetailField>
+      </dl>
+    </section>
+  );
+}

--- a/apps/admin/src/app/(private)/users/[id]/user-activity.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/user-activity.tsx
@@ -1,0 +1,40 @@
+import { getUser } from "@/data/users/get-user";
+import { Separator } from "@zoonk/ui/components/separator";
+import { DetailField } from "./detail-field";
+
+export async function UserActivity({ userId }: { userId: number }) {
+  const user = await getUser(userId);
+
+  if (!user) {
+    return null;
+  }
+
+  const { progress, members, _count } = user;
+
+  return (
+    <section>
+      <h3 className="mb-2 text-sm font-semibold">Activity</h3>
+      <Separator />
+
+      <dl className="mt-2">
+        <DetailField label="Brain power">
+          {progress ? Number(progress.totalBrainPower).toLocaleString() : "0"}
+        </DetailField>
+
+        <DetailField label="Current energy">{progress?.currentEnergy ?? 0}</DetailField>
+
+        <DetailField label="Last active">
+          {progress?.lastActiveAt ? new Date(progress.lastActiveAt).toLocaleDateString() : "—"}
+        </DetailField>
+
+        <DetailField label="Courses owned">{_count.ownedCourses}</DetailField>
+
+        <DetailField label="Organizations">
+          {members.length > 0
+            ? members.map((member) => `${member.organization.name} (${member.role})`).join(", ")
+            : "—"}
+        </DetailField>
+      </dl>
+    </section>
+  );
+}

--- a/apps/admin/src/app/(private)/users/[id]/user-header.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/user-header.tsx
@@ -1,0 +1,68 @@
+import { getUser } from "@/data/users/get-user";
+import { Avatar, AvatarFallback, AvatarImage } from "@zoonk/ui/components/avatar";
+import { Badge } from "@zoonk/ui/components/badge";
+import { notFound } from "next/navigation";
+import { BanUserDialog } from "./ban-user-dialog";
+import { RevokeSessionsDialog } from "./revoke-sessions-dialog";
+import { UnbanUserDialog } from "./unban-user-dialog";
+
+export async function UserHeader({ userId }: { userId: number }) {
+  const user = await getUser(userId);
+
+  if (!user) {
+    notFound();
+  }
+
+  const initials = (user.name || user.email)
+    .split(" ")
+    .map((word) => word[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-center gap-4">
+          <Avatar size="lg">
+            {user.image && <AvatarImage src={user.image} alt={user.name} />}
+            <AvatarFallback>{initials}</AvatarFallback>
+          </Avatar>
+
+          <div className="flex flex-col gap-1">
+            <h2 className="text-lg font-semibold">{user.name || "—"}</h2>
+
+            {user.username && (
+              <span className="text-muted-foreground text-sm">@{user.username}</span>
+            )}
+
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className="capitalize">
+                {user.role || "user"}
+              </Badge>
+
+              {user.emailVerified && <Badge variant="secondary">Verified</Badge>}
+              {user.banned && <Badge variant="destructive">Banned</Badge>}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <RevokeSessionsDialog userId={user.id} userName={user.name} />
+          {user.banned ? (
+            <UnbanUserDialog userId={user.id} userName={user.name} />
+          ) : (
+            <BanUserDialog userId={user.id} userName={user.name} />
+          )}
+        </div>
+      </div>
+
+      {user.banned && (user.banReason || user.banExpires) && (
+        <div className="text-muted-foreground text-sm">
+          {user.banReason && <p>Reason: {user.banReason}</p>}
+          {user.banExpires && <p>Expires: {new Date(user.banExpires).toLocaleDateString()}</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/users/[id]/user-subscription.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/user-subscription.tsx
@@ -1,0 +1,49 @@
+import { getUserSubscription } from "@/data/users/get-user-subscription";
+import { Separator } from "@zoonk/ui/components/separator";
+import { ChangePlanDialog } from "./change-plan-dialog";
+import { DetailField } from "./detail-field";
+
+export async function UserSubscription({ userId }: { userId: number }) {
+  const subscription = await getUserSubscription(userId);
+  const isStripeManaged = Boolean(subscription?.stripeSubscriptionId);
+
+  return (
+    <section>
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="text-sm font-semibold">Subscription</h3>
+        {!isStripeManaged && (
+          <ChangePlanDialog userId={userId} currentPlan={subscription?.plan ?? "free"} />
+        )}
+      </div>
+
+      <Separator />
+
+      <dl className="mt-2">
+        <DetailField label="Plan">
+          <span className="capitalize">{subscription?.plan ?? "Free"}</span>
+        </DetailField>
+
+        <DetailField label="Status">
+          <span className="capitalize">{subscription?.status ?? "—"}</span>
+        </DetailField>
+
+        {subscription?.billingInterval && (
+          <DetailField label="Billing">
+            <span className="capitalize">{subscription.billingInterval}</span>
+          </DetailField>
+        )}
+
+        {subscription?.periodStart && subscription?.periodEnd && (
+          <DetailField label="Current period">
+            {new Date(subscription.periodStart).toLocaleDateString()} –{" "}
+            {new Date(subscription.periodEnd).toLocaleDateString()}
+          </DetailField>
+        )}
+
+        {subscription?.stripeCustomerId && (
+          <DetailField label="Stripe customer">{subscription.stripeCustomerId}</DetailField>
+        )}
+      </dl>
+    </section>
+  );
+}

--- a/apps/admin/src/app/(private)/users/user-list.tsx
+++ b/apps/admin/src/app/(private)/users/user-list.tsx
@@ -19,14 +19,9 @@ export async function UserList({
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Name</TableHead>
+              <TableHead>User</TableHead>
               <TableHead>Username</TableHead>
-              <TableHead>Email</TableHead>
-              <TableHead>Role</TableHead>
-              <TableHead>Email Verified</TableHead>
-              <TableHead>Banned</TableHead>
-              <TableHead>Last Login</TableHead>
-              <TableHead>Created At</TableHead>
+              <TableHead>Subscription</TableHead>
             </TableRow>
           </TableHeader>
 

--- a/apps/admin/src/app/(private)/users/user-row.tsx
+++ b/apps/admin/src/app/(private)/users/user-row.tsx
@@ -1,42 +1,28 @@
 import { type listUsers } from "@/data/users/list-users";
+import { Badge } from "@zoonk/ui/components/badge";
 import { TableCell, TableRow } from "@zoonk/ui/components/table";
+import Link from "next/link";
 
 export function UserRow({
   user,
 }: {
   user: Awaited<ReturnType<typeof listUsers>>["users"][number];
 }) {
-  const lastLogin = user.sessions[0]?.updatedAt;
-
   return (
     <TableRow>
-      <TableCell className="font-medium">{user.name || "—"}</TableCell>
+      <TableCell>
+        <Link className="block" href={`/users/${user.id}`}>
+          <span className="font-medium">{user.name || "—"}</span>
+          <span className="text-muted-foreground block text-xs">{user.email}</span>
+        </Link>
+      </TableCell>
+
       <TableCell>{user.username || "—"}</TableCell>
-      <TableCell>{user.email}</TableCell>
-      <TableCell className="capitalize">{user.role || "user"}</TableCell>
 
       <TableCell>
-        {user.emailVerified ? (
-          <span className="text-success">✓</span>
-        ) : (
-          <span className="text-muted-foreground">—</span>
-        )}
-      </TableCell>
-
-      <TableCell>
-        {user.banned ? (
-          <span className="text-destructive">Yes</span>
-        ) : (
-          <span className="text-muted-foreground">—</span>
-        )}
-      </TableCell>
-
-      <TableCell className="text-muted-foreground">
-        {lastLogin ? new Date(lastLogin).toLocaleDateString() : "—"}
-      </TableCell>
-
-      <TableCell className="text-muted-foreground">
-        {new Date(user.createdAt).toLocaleDateString()}
+        <Badge variant={user.plan === "free" ? "secondary" : "outline"} className="capitalize">
+          {user.plan}
+        </Badge>
       </TableCell>
     </TableRow>
   );

--- a/apps/admin/src/data/users/get-user-subscription.ts
+++ b/apps/admin/src/data/users/get-user-subscription.ts
@@ -1,0 +1,16 @@
+import "server-only";
+import { getSession } from "@zoonk/core/users/session/get";
+import { prisma } from "@zoonk/db";
+
+export async function getUserSubscription(userId: number) {
+  const session = await getSession();
+
+  if (session?.user.role !== "admin") {
+    return null;
+  }
+
+  return prisma.subscription.findFirst({
+    orderBy: { id: "desc" },
+    where: { referenceId: String(userId) },
+  });
+}

--- a/apps/admin/src/data/users/get-user.ts
+++ b/apps/admin/src/data/users/get-user.ts
@@ -1,0 +1,22 @@
+import "server-only";
+import { getSession } from "@zoonk/core/users/session/get";
+import { prisma } from "@zoonk/db";
+
+export async function getUser(id: number) {
+  const session = await getSession();
+
+  if (session?.user.role !== "admin") {
+    return null;
+  }
+
+  return prisma.user.findUnique({
+    include: {
+      _count: { select: { ownedCourses: true } },
+      accounts: { select: { providerId: true } },
+      members: { include: { organization: { select: { name: true, slug: true } } } },
+      progress: true,
+      sessions: { orderBy: { updatedAt: "desc" }, select: { updatedAt: true }, take: 1 },
+    },
+    where: { id },
+  });
+}

--- a/apps/admin/src/data/users/get-user.ts
+++ b/apps/admin/src/data/users/get-user.ts
@@ -1,8 +1,9 @@
 import "server-only";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
+import { cache } from "react";
 
-export async function getUser(id: number) {
+export const getUser = cache(async function getUser(id: number) {
   const session = await getSession();
 
   if (session?.user.role !== "admin") {
@@ -19,4 +20,4 @@ export async function getUser(id: number) {
     },
     where: { id },
   });
-}
+});

--- a/apps/admin/src/data/users/list-users.ts
+++ b/apps/admin/src/data/users/list-users.ts
@@ -23,13 +23,6 @@ export async function listUsers(params: { limit: number; offset: number; search?
 
   const [users, total] = await Promise.all([
     prisma.user.findMany({
-      include: {
-        sessions: {
-          orderBy: { updatedAt: "desc" },
-          select: { updatedAt: true },
-          take: 1,
-        },
-      },
       orderBy: { createdAt: "desc" },
       skip: offset,
       take: limit,
@@ -38,5 +31,24 @@ export async function listUsers(params: { limit: number; offset: number; search?
     prisma.user.count({ where }),
   ]);
 
-  return { total, users };
+  const userIds = users.map((user) => String(user.id));
+
+  const subscriptions =
+    userIds.length > 0
+      ? await prisma.subscription.findMany({
+          distinct: ["referenceId"],
+          orderBy: { id: "desc" },
+          select: { plan: true, referenceId: true },
+          where: { referenceId: { in: userIds } },
+        })
+      : [];
+
+  const subscriptionByUserId = new Map(subscriptions.map((sub) => [sub.referenceId, sub.plan]));
+
+  const usersWithPlan = users.map((user) => ({
+    ...user,
+    plan: subscriptionByUserId.get(String(user.id)) ?? "free",
+  }));
+
+  return { total, users: usersWithPlan };
 }


### PR DESCRIPTION
## Summary

- Simplify user list from 8 columns to 3 (User, Username, Subscription) with rows linking to detail page
- Add `/users/[id]` detail page with account info, subscription, activity sections
- Add admin actions: ban/unban user, revoke sessions, change plan (non-Stripe only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an admin user detail page and streamline the user list to make moderation and account management faster. Admins can ban/unban users, revoke sessions, and change non-Stripe plans.

- **New Features**
  - User list: reduced to User, Username, Subscription; each row links to /users/[id]; shows plan badge.
  - User detail page: header (avatar, role, verified/banned badges) plus Account, Subscription, and Activity sections.
  - Admin actions: ban/unban (reason and optional expiry), revoke all sessions, change plan for non-Stripe subscriptions; server actions enforce admin auth and revalidate the detail page.
  - Data: added getUser (cached with React.cache to deduplicate calls) and getUserSubscription; list-users now joins latest subscription to surface plan.

<sup>Written for commit ab2c4bb16c92dcedfbfdf5e598d612b419df216b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

