### PR TITLE
refactor(admin): add React.cache to all data queries

### DIFF
--- a/apps/admin/src/data/courses/list-courses.ts
+++ b/apps/admin/src/data/courses/list-courses.ts
@@ -1,15 +1,18 @@
 import "server-only";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
+import { cache } from "react";
 
-export async function listCourses(params: { limit: number; offset: number; search?: string }) {
+const cachedListCourses = cache(async function cachedListCourses(
+  limit: number,
+  offset: number,
+  search: string | undefined,
+) {
   const session = await getSession();
 
   if (session?.user.role !== "admin") {
     return { courses: [], total: 0 };
   }
-
-  const { limit, offset, search } = params;
 
   const where = search
     ? { normalizedTitle: { contains: search, mode: "insensitive" as const } }
@@ -27,4 +30,8 @@ export async function listCourses(params: { limit: number; offset: number; searc
   ]);
 
   return { courses, total };
+});
+
+export async function listCourses(params: { limit: number; offset: number; search?: string }) {
+  return cachedListCourses(params.limit, params.offset, params.search);
 }

--- a/apps/admin/src/data/review/count-pending-reviews.ts
+++ b/apps/admin/src/data/review/count-pending-reviews.ts
@@ -3,17 +3,22 @@ import { REVIEW_TASK_TYPES, type ReviewTaskType } from "@/lib/review-utils";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { cache } from "react";
 
-export async function reviewedEntityIds(taskType: ReviewTaskType): Promise<bigint[]> {
+export const reviewedEntityIds = cache(async function reviewedEntityIds(
+  taskType: ReviewTaskType,
+): Promise<bigint[]> {
   const reviews = await prisma.contentReview.findMany({
     select: { entityId: true },
     where: { taskType },
   });
 
   return reviews.map((review) => review.entityId);
-}
+});
 
-export async function countPendingForTask(taskType: ReviewTaskType): Promise<number> {
+export const countPendingForTask = cache(async function countPendingForTask(
+  taskType: ReviewTaskType,
+): Promise<number> {
   const excludeIds = await reviewedEntityIds(taskType);
 
   switch (taskType) {
@@ -55,7 +60,7 @@ export async function countPendingForTask(taskType: ReviewTaskType): Promise<num
     default:
       return 0;
   }
-}
+});
 
 function emptyCountRecord(): Record<ReviewTaskType, number> {
   return {
@@ -66,7 +71,9 @@ function emptyCountRecord(): Record<ReviewTaskType, number> {
   };
 }
 
-export async function countPendingReviews(): Promise<Record<ReviewTaskType, number>> {
+export const countPendingReviews = cache(async function countPendingReviews(): Promise<
+  Record<ReviewTaskType, number>
+> {
   const session = await getSession();
 
   if (session?.user.role !== "admin") {
@@ -81,4 +88,4 @@ export async function countPendingReviews(): Promise<Record<ReviewTaskType, numb
   );
 
   return { ...emptyCountRecord(), ...Object.fromEntries(counts) };
-}
+});

--- a/apps/admin/src/data/review/count-review-statuses.ts
+++ b/apps/admin/src/data/review/count-review-statuses.ts
@@ -2,9 +2,12 @@ import "server-only";
 import { type ReviewTaskType } from "@/lib/review-utils";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
+import { cache } from "react";
 import { countPendingForTask } from "./count-pending-reviews";
 
-export async function countReviewStatuses(taskType: ReviewTaskType): Promise<{
+export const countReviewStatuses = cache(async function countReviewStatuses(
+  taskType: ReviewTaskType,
+): Promise<{
   pending: number;
   needsChanges: number;
 }> {
@@ -22,4 +25,4 @@ export async function countReviewStatuses(taskType: ReviewTaskType): Promise<{
   ]);
 
   return { needsChanges, pending };
-}
+});

--- a/apps/admin/src/data/review/get-next-review-item.ts
+++ b/apps/admin/src/data/review/get-next-review-item.ts
@@ -3,6 +3,7 @@ import { type ReviewTaskType } from "@/lib/review-utils";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
+import { cache } from "react";
 import { reviewedEntityIds } from "./count-pending-reviews";
 
 type ReviewQueueResult = {
@@ -83,7 +84,9 @@ async function getNextWordAudio(): Promise<ReviewQueueResult> {
   return { entityId: next?.id ?? null, remaining };
 }
 
-export async function getNextReviewItem(taskType: ReviewTaskType): Promise<ReviewQueueResult> {
+export const getNextReviewItem = cache(async function getNextReviewItem(
+  taskType: ReviewTaskType,
+): Promise<ReviewQueueResult> {
   const session = await getSession();
 
   if (session?.user.role !== "admin") {
@@ -102,4 +105,4 @@ export async function getNextReviewItem(taskType: ReviewTaskType): Promise<Revie
     default:
       return EMPTY_RESULT;
   }
-}
+});

--- a/apps/admin/src/data/review/get-review-item.ts
+++ b/apps/admin/src/data/review/get-review-item.ts
@@ -1,13 +1,16 @@
 import "server-only";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
+import { cache } from "react";
 
 async function adminGuard() {
   const session = await getSession();
   return session?.user.role === "admin";
 }
 
-export async function getCourseSuggestionReview(entityId: bigint) {
+export const getCourseSuggestionReview = cache(async function getCourseSuggestionReview(
+  entityId: bigint,
+) {
   if (!(await adminGuard())) {
     return null;
   }
@@ -21,9 +24,9 @@ export async function getCourseSuggestionReview(entityId: bigint) {
     },
     where: { id: Number(entityId) },
   });
-}
+});
 
-export async function getStepVisualReview(entityId: bigint) {
+export const getStepVisualReview = cache(async function getStepVisualReview(entityId: bigint) {
   if (!(await adminGuard())) {
     return null;
   }
@@ -32,9 +35,9 @@ export async function getStepVisualReview(entityId: bigint) {
     include: { activity: { select: { title: true } } },
     where: { id: entityId },
   });
-}
+});
 
-export async function getWordAudioReview(entityId: bigint) {
+export const getWordAudioReview = cache(async function getWordAudioReview(entityId: bigint) {
   if (!(await adminGuard())) {
     return null;
   }
@@ -42,4 +45,4 @@ export async function getWordAudioReview(entityId: bigint) {
   return prisma.word.findUnique({
     where: { id: entityId },
   });
-}
+});

--- a/apps/admin/src/data/review/list-reviewed-items.ts
+++ b/apps/admin/src/data/review/list-reviewed-items.ts
@@ -2,20 +2,19 @@ import "server-only";
 import { type ReviewTaskType } from "@/lib/review-utils";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
+import { cache } from "react";
 
-export async function listReviewedItems(params: {
-  taskType: ReviewTaskType;
-  status: string;
-  limit: number;
-  offset: number;
-}) {
+const cachedListReviewedItems = cache(async function cachedListReviewedItems(
+  taskType: string,
+  status: string,
+  limit: number,
+  offset: number,
+) {
   const session = await getSession();
 
   if (session?.user.role !== "admin") {
     return { items: [], total: 0 };
   }
-
-  const { taskType, status, limit, offset } = params;
   const where = { status, taskType };
 
   const [items, total] = await Promise.all([
@@ -30,4 +29,13 @@ export async function listReviewedItems(params: {
   ]);
 
   return { items, total };
+});
+
+export async function listReviewedItems(params: {
+  taskType: ReviewTaskType;
+  status: string;
+  limit: number;
+  offset: number;
+}) {
+  return cachedListReviewedItems(params.taskType, params.status, params.limit, params.offset);
 }

--- a/apps/admin/src/data/users/get-user-subscription.ts
+++ b/apps/admin/src/data/users/get-user-subscription.ts
@@ -1,8 +1,9 @@
 import "server-only";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
+import { cache } from "react";
 
-export async function getUserSubscription(userId: number) {
+export const getUserSubscription = cache(async function getUserSubscription(userId: number) {
   const session = await getSession();
 
   if (session?.user.role !== "admin") {
@@ -13,4 +14,4 @@ export async function getUserSubscription(userId: number) {
     orderBy: { id: "desc" },
     where: { referenceId: String(userId) },
   });
-}
+});

--- a/apps/admin/src/data/users/list-users.ts
+++ b/apps/admin/src/data/users/list-users.ts
@@ -1,15 +1,18 @@
 import "server-only";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
+import { cache } from "react";
 
-export async function listUsers(params: { limit: number; offset: number; search?: string }) {
+const cachedListUsers = cache(async function cachedListUsers(
+  limit: number,
+  offset: number,
+  search: string | undefined,
+) {
   const session = await getSession();
 
   if (session?.user.role !== "admin") {
     return { total: 0, users: [] };
   }
-
-  const { limit, offset, search } = params;
 
   const where = search
     ? {
@@ -51,4 +54,8 @@ export async function listUsers(params: { limit: number; offset: number; search?
   }));
 
   return { total, users: usersWithPlan };
+});
+
+export async function listUsers(params: { limit: number; offset: number; search?: string }) {
+  return cachedListUsers(params.limit, params.offset, params.search);
 }


### PR DESCRIPTION
## Summary

- Wrap all admin data-fetching functions with `React.cache` for request deduplication
- Single primitive arg functions use direct `cache()` export
- Object param functions use private cached helper + public wrapper

## Files changed

8 files in `apps/admin/src/data/` (users, courses, review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add React.cache to all admin data queries to dedupe identical requests and reduce duplicate DB work. No API or behavior changes; admin pages should be faster with fewer queries.

- **Refactors**
  - Wrapped users, courses, and review data functions with React.cache.
  - For object-param functions, added private cached helpers (primitive args) and public wrappers to keep the same signatures.
  - Kept admin guards and return shapes unchanged.

<sup>Written for commit 93aa54c9db85e5cdcacef4b07d40136071337e56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

