### PR TITLE
feat(admin): add dashboard metrics and stats detail pages

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -20,6 +20,7 @@
     "nuqs": "2.8.9",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "recharts": "3.7.0",
     "server-only": "0.0.1"
   },
   "devDependencies": {

--- a/apps/admin/src/app/(private)/app-sidebar.tsx
+++ b/apps/admin/src/app/(private)/app-sidebar.tsx
@@ -9,12 +9,13 @@ import {
   SidebarMenu,
   SidebarTrigger,
 } from "@zoonk/ui/components/sidebar";
-import { BookOpen, CheckSquareIcon, HomeIcon, Users } from "lucide-react";
+import { BarChart3Icon, BookOpen, CheckSquareIcon, HomeIcon, Users } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { AppSidebarMenuItem } from "./app-sidebar-menu-item";
 
 const menuItems = [
   { icon: HomeIcon, label: "Home", url: "/" },
+  { icon: BarChart3Icon, label: "Stats", url: "/stats" },
   { icon: Users, label: "Users", url: "/users" },
   { icon: BookOpen, label: "Courses", url: "/courses" },
   { icon: CheckSquareIcon, label: "Review", url: "/review" },

--- a/apps/admin/src/app/(private)/app-stats-content.tsx
+++ b/apps/admin/src/app/(private)/app-stats-content.tsx
@@ -1,0 +1,65 @@
+import { Stats } from "@/components/stats";
+import { StatsSection } from "@/components/stats-section";
+import { countContent } from "@/data/stats/count-content";
+import { countCourses } from "@/data/stats/count-courses";
+import { countTotalPendingReviews } from "@/data/stats/count-total-pending-reviews";
+import { AlertCircleIcon, BookOpenIcon, LayersIcon } from "lucide-react";
+import { connection } from "next/server";
+
+export async function ContentStats() {
+  await connection();
+
+  const [totalCourses, content, pendingReviews] = await Promise.all([
+    countCourses(),
+    countContent(),
+    countTotalPendingReviews(),
+  ]);
+
+  return (
+    <StatsSection subtitle="Content catalog and review pipeline" title="Content & Operations">
+      <Stats
+        help="Published and draft courses"
+        href="/courses"
+        icon={<BookOpenIcon />}
+        title="Courses"
+        value={totalCourses.toLocaleString()}
+      />
+
+      <Stats
+        help="Total chapter count"
+        icon={<LayersIcon />}
+        title="Chapters"
+        value={content.chapters.toLocaleString()}
+      />
+
+      <Stats
+        help="Total lesson count"
+        icon={<LayersIcon />}
+        title="Lessons"
+        value={content.lessons.toLocaleString()}
+      />
+
+      <Stats
+        help="Total activity count"
+        icon={<LayersIcon />}
+        title="Activities"
+        value={content.activities.toLocaleString()}
+      />
+
+      <Stats
+        help="Total step count"
+        icon={<LayersIcon />}
+        title="Steps"
+        value={content.steps.toLocaleString()}
+      />
+
+      <Stats
+        help="Content awaiting admin review"
+        href="/review"
+        icon={<AlertCircleIcon />}
+        title="Pending Reviews"
+        value={pendingReviews.toLocaleString()}
+      />
+    </StatsSection>
+  );
+}

--- a/apps/admin/src/app/(private)/app-stats-engagement.tsx
+++ b/apps/admin/src/app/(private)/app-stats-engagement.tsx
@@ -1,0 +1,72 @@
+import { Stats } from "@/components/stats";
+import { StatsSection } from "@/components/stats-section";
+import { countActiveLearners } from "@/data/stats/count-active-learners";
+import { getAccuracyRate } from "@/data/stats/get-accuracy-rate";
+import { getAvgActivitiesPerLearner } from "@/data/stats/get-avg-activities-per-learner";
+import { getAvgActivityTime } from "@/data/stats/get-avg-activity-time";
+import { getTotalLearningTime } from "@/data/stats/get-total-learning-time";
+import { formatDuration } from "@/lib/format-duration";
+import { ActivityIcon, ClockIcon, LayersIcon, TargetIcon } from "lucide-react";
+import { connection } from "next/server";
+
+const DAYS_7 = 7;
+const DAYS_30 = 30;
+
+export async function EngagementStats() {
+  await connection();
+  const now = new Date();
+  const sevenDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - DAYS_7);
+  const thirtyDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - DAYS_30);
+
+  const [activeLearners, accuracyRate, avgTime, avgActivitiesPerLearner, totalLearningTime] =
+    await Promise.all([
+      countActiveLearners(sevenDaysAgo, thirtyDaysAgo),
+      getAccuracyRate(),
+      getAvgActivityTime(),
+      getAvgActivitiesPerLearner(),
+      getTotalLearningTime(),
+    ]);
+
+  return (
+    <StatsSection subtitle="How learners interact with content" title="Engagement & Learning">
+      <Stats
+        description={`vs ${activeLearners.last30Days.toLocaleString()} in last 30d`}
+        help="Users with activity in the last 7 days"
+        href="/stats/engagement"
+        icon={<ActivityIcon />}
+        title="Active Learners (7d)"
+        value={activeLearners.last7Days.toLocaleString()}
+      />
+
+      <Stats
+        help="Correct answers vs total attempts"
+        href="/stats/engagement"
+        icon={<TargetIcon />}
+        title="Accuracy Rate"
+        value={`${accuracyRate.toFixed(1)}%`}
+      />
+
+      <Stats
+        help="Average time to complete an activity"
+        href="/stats/engagement"
+        icon={<ClockIcon />}
+        title="Avg Time / Activity"
+        value={formatDuration(avgTime)}
+      />
+
+      <Stats
+        help="Average activities completed per active learner"
+        icon={<LayersIcon />}
+        title="Activities / Learner"
+        value={avgActivitiesPerLearner.toLocaleString()}
+      />
+
+      <Stats
+        help="Cumulative time spent learning on the platform"
+        icon={<ClockIcon />}
+        title="Total Learning Time"
+        value={formatDuration(totalLearningTime)}
+      />
+    </StatsSection>
+  );
+}

--- a/apps/admin/src/app/(private)/app-stats-growth.tsx
+++ b/apps/admin/src/app/(private)/app-stats-growth.tsx
@@ -1,0 +1,59 @@
+import { Stats } from "@/components/stats";
+import { StatsSection } from "@/components/stats-section";
+import { countSubscribersByPlan } from "@/data/stats/count-subscribers-by-plan";
+import { countUsers } from "@/data/stats/count-users";
+import { getActivationRate } from "@/data/stats/get-activation-rate";
+import { getConversionRate } from "@/data/stats/get-conversion-rate";
+import { CreditCardIcon, TargetIcon, UsersIcon } from "lucide-react";
+import { connection } from "next/server";
+
+export async function GrowthStats() {
+  await connection();
+
+  const [totalUsers, subscribersByPlan, activation, conversion] = await Promise.all([
+    countUsers(),
+    countSubscribersByPlan(),
+    getActivationRate(),
+    getConversionRate(),
+  ]);
+
+  return (
+    <StatsSection subtitle="Platform growth and revenue health" title="Growth & Sustainability">
+      <Stats
+        help="All registered accounts"
+        href="/users"
+        icon={<UsersIcon />}
+        title="Total Users"
+        value={totalUsers.toLocaleString()}
+      />
+
+      <Stats
+        description={`${activation.activated.toLocaleString()} of ${activation.total.toLocaleString()} users`}
+        help="Users who completed at least 1 lesson"
+        href="/stats/growth"
+        icon={<TargetIcon />}
+        title="Activation Rate"
+        value={`${activation.rate.toFixed(1)}%`}
+      />
+
+      <Stats
+        description={`${conversion.paid.toLocaleString()} paid of ${conversion.total.toLocaleString()} total`}
+        help="Active paid subscribers vs all users"
+        href="/stats/growth"
+        icon={<CreditCardIcon />}
+        title="Free-to-Paid"
+        value={`${conversion.rate.toFixed(1)}%`}
+      />
+
+      {subscribersByPlan.map((sub) => (
+        <Stats
+          help={`Active subscribers on ${sub.plan} plan`}
+          icon={<CreditCardIcon />}
+          key={sub.plan}
+          title={`${sub.plan.charAt(0).toUpperCase() + sub.plan.slice(1)} Subscribers`}
+          value={sub.count.toLocaleString()}
+        />
+      ))}
+    </StatsSection>
+  );
+}

--- a/apps/admin/src/app/(private)/app-stats.tsx
+++ b/apps/admin/src/app/(private)/app-stats.tsx
@@ -1,33 +1,33 @@
-import { Stats, StatsSkeleton } from "@/components/stats";
-import { countUsers } from "@/data/stats/count-users";
-import { UsersIcon } from "lucide-react";
-import { cacheLife } from "next/cache";
+import { StatsSectionSkeleton } from "@/components/stats-section";
+import { Suspense } from "react";
+import { ContentStats } from "./app-stats-content";
+import { EngagementStats } from "./app-stats-engagement";
+import { GrowthStats } from "./app-stats-growth";
 
-export async function AppStats() {
-  "use cache";
-
-  cacheLife("minutes");
-
-  const totalUsers = await countUsers();
-
+export function AppStats() {
   return (
-    <div className="flex items-center">
-      <div className="grid w-full grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-4">
-        <Stats icon={<UsersIcon />} title="Users" value={totalUsers} />
-      </div>
+    <div className="flex flex-col gap-12">
+      <Suspense fallback={<StatsSectionSkeleton items={4} />}>
+        <GrowthStats />
+      </Suspense>
+
+      <Suspense fallback={<StatsSectionSkeleton items={6} />}>
+        <EngagementStats />
+      </Suspense>
+
+      <Suspense fallback={<StatsSectionSkeleton items={6} />}>
+        <ContentStats />
+      </Suspense>
     </div>
   );
 }
 
 export function AppStatsFallback() {
   return (
-    <div className="flex items-center">
-      <div className="grid w-full grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-4">
-        <StatsSkeleton />
-        <StatsSkeleton />
-        <StatsSkeleton />
-        <StatsSkeleton />
-      </div>
+    <div className="flex flex-col gap-12">
+      <StatsSectionSkeleton items={4} />
+      <StatsSectionSkeleton items={6} />
+      <StatsSectionSkeleton items={6} />
     </div>
   );
 }

--- a/apps/admin/src/app/(private)/page.tsx
+++ b/apps/admin/src/app/(private)/page.tsx
@@ -20,7 +20,7 @@ export default function Home() {
       <ContainerHeader variant="sidebar">
         <ContainerHeaderGroup>
           <ContainerTitle>Admin Dashboard</ContainerTitle>
-          <ContainerDescription>Manage users and system settings</ContainerDescription>
+          <ContainerDescription>Overview of platform metrics and activity.</ContainerDescription>
         </ContainerHeaderGroup>
       </ContainerHeader>
 

--- a/apps/admin/src/app/(private)/stats/_components/admin-metric-card.tsx
+++ b/apps/admin/src/app/(private)/stats/_components/admin-metric-card.tsx
@@ -1,0 +1,106 @@
+import { StatsTitle } from "@/components/stats-title";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { cn } from "@zoonk/ui/lib/utils";
+import { type HistoryPeriod } from "@zoonk/utils/date-ranges";
+import { TrendingDownIcon, TrendingUpIcon } from "lucide-react";
+
+function getComparisonLabel(period: HistoryPeriod) {
+  if (period === "month") {
+    return "vs last month";
+  }
+
+  if (period === "6months") {
+    return "vs last 6 months";
+  }
+
+  return "vs last year";
+}
+
+function ChangeIndicator({
+  current,
+  previous,
+  period,
+}: {
+  current: number;
+  previous: number;
+  period: HistoryPeriod;
+}) {
+  if (previous === 0) {
+    return null;
+  }
+
+  const percentageChange = ((current - previous) / previous) * 100;
+  const isPositive = percentageChange >= 0;
+
+  const formattedChange = new Intl.NumberFormat("en", {
+    maximumFractionDigits: 1,
+    signDisplay: "always",
+    trailingZeroDisplay: "stripIfInteger",
+  }).format(percentageChange);
+
+  const Icon = isPositive ? TrendingUpIcon : TrendingDownIcon;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1 text-sm tabular-nums",
+        isPositive ? "text-success" : "text-destructive",
+      )}
+    >
+      <Icon aria-hidden className="size-4 shrink-0" />
+      <span className="whitespace-nowrap">
+        {formattedChange}% {getComparisonLabel(period)}
+      </span>
+    </div>
+  );
+}
+
+export function AdminMetricCard({
+  title,
+  value,
+  help,
+  description,
+  icon,
+  change,
+}: {
+  title: string;
+  value: string | number;
+  help?: string;
+  description?: string;
+  icon?: React.ReactNode;
+  change?: { current: number; previous: number; period: HistoryPeriod };
+}) {
+  return (
+    <div className="flex w-full flex-col gap-1">
+      <header className="text-muted-foreground flex items-center gap-1.5">
+        {icon && <span className="flex size-4 items-center justify-center">{icon}</span>}
+        <StatsTitle help={help} title={title} />
+      </header>
+
+      <div className="text-foreground text-3xl font-medium tracking-tight">{value}</div>
+
+      {description && <p className="text-muted-foreground text-sm">{description}</p>}
+
+      {change && (
+        <ChangeIndicator
+          current={change.current}
+          period={change.period}
+          previous={change.previous}
+        />
+      )}
+    </div>
+  );
+}
+
+export function AdminMetricCardSkeleton() {
+  return (
+    <div className="flex w-full flex-col gap-1">
+      <header className="flex items-center gap-1.5">
+        <Skeleton className="size-4 rounded-lg" />
+        <Skeleton className="h-4 w-24 rounded" />
+      </header>
+      <Skeleton className="h-8 w-32 rounded" />
+      <Skeleton className="h-4 w-20 rounded" />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/_components/admin-period-tabs.tsx
+++ b/apps/admin/src/app/(private)/stats/_components/admin-period-tabs.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Button } from "@zoonk/ui/components/button";
+import { type HistoryPeriod } from "@zoonk/utils/date-ranges";
+import { useQueryState } from "nuqs";
+
+const periods: { label: string; value: HistoryPeriod }[] = [
+  { label: "Month", value: "month" },
+  { label: "6 Months", value: "6months" },
+  { label: "Year", value: "year" },
+];
+
+export function AdminPeriodTabs() {
+  const [period, setPeriod] = useQueryState("period", {
+    defaultValue: "month",
+    shallow: false,
+  });
+
+  return (
+    <nav aria-label="Period selection" className="flex gap-1">
+      {periods.map((item) => (
+        <Button
+          key={item.value}
+          onClick={() => void setPeriod(item.value)}
+          size="sm"
+          variant={period === item.value ? "default" : "outline"}
+        >
+          {item.label}
+        </Button>
+      ))}
+    </nav>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/_components/admin-trend-chart.tsx
+++ b/apps/admin/src/app/(private)/stats/_components/admin-trend-chart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { isValidChartPayload } from "@zoonk/utils/chart";
+import { useId } from "react";
 import {
   Area,
   AreaChart,
@@ -27,12 +28,14 @@ export function AdminTrendChart({
   dataPoints: DataPoint[];
   valueLabel: string;
 }) {
+  const gradientId = useId();
+
   return (
     <figure aria-label={`${valueLabel} chart`} className="h-64 w-full">
       <ResponsiveContainer height="100%" width="100%">
         <AreaChart data={dataPoints} margin={{ bottom: 0, left: 0, right: 0, top: 10 }}>
           <defs>
-            <linearGradient id="trendGradient" x1="0" x2="0" y1="0" y2="1">
+            <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
               <stop offset="5%" stopColor="var(--foreground)" stopOpacity={0.15} />
               <stop offset="95%" stopColor="var(--foreground)" stopOpacity={0} />
             </linearGradient>
@@ -91,7 +94,7 @@ export function AdminTrendChart({
 
           <Area
             dataKey="value"
-            fill="url(#trendGradient)"
+            fill={`url(#${gradientId})`}
             fillOpacity={1}
             stroke="var(--foreground)"
             strokeWidth={2}

--- a/apps/admin/src/app/(private)/stats/_components/admin-trend-chart.tsx
+++ b/apps/admin/src/app/(private)/stats/_components/admin-trend-chart.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { isValidChartPayload } from "@zoonk/utils/chart";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+type DataPoint = {
+  date: string;
+  label: string;
+  value: number;
+};
+
+export function AdminTrendChart({
+  average,
+  dataPoints,
+  valueLabel,
+}: {
+  average: number;
+  dataPoints: DataPoint[];
+  valueLabel: string;
+}) {
+  return (
+    <figure aria-label={`${valueLabel} chart`} className="h-64 w-full">
+      <ResponsiveContainer height="100%" width="100%">
+        <AreaChart data={dataPoints} margin={{ bottom: 0, left: 0, right: 0, top: 10 }}>
+          <defs>
+            <linearGradient id="trendGradient" x1="0" x2="0" y1="0" y2="1">
+              <stop offset="5%" stopColor="var(--foreground)" stopOpacity={0.15} />
+              <stop offset="95%" stopColor="var(--foreground)" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+
+          <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
+
+          <XAxis
+            axisLine={false}
+            dataKey="label"
+            fontSize={12}
+            stroke="var(--muted-foreground)"
+            tickLine={false}
+            tickMargin={8}
+          />
+
+          <YAxis
+            axisLine={false}
+            fontSize={12}
+            stroke="var(--muted-foreground)"
+            tickLine={false}
+            tickMargin={8}
+            width={40}
+          />
+
+          <Tooltip
+            content={({ active, payload }) => {
+              if (!active || !isValidChartPayload<DataPoint>(payload)) {
+                return null;
+              }
+
+              const data = payload[0].payload;
+
+              return (
+                <div className="bg-background rounded-lg border px-3 py-2 shadow-sm">
+                  <p className="text-muted-foreground text-xs">{data.label}</p>
+                  <p className="text-sm font-medium">
+                    {data.value.toLocaleString()} {valueLabel}
+                  </p>
+                </div>
+              );
+            }}
+          />
+
+          <ReferenceLine
+            label={{
+              fill: "var(--muted-foreground)",
+              fontSize: 11,
+              position: "insideBottomRight",
+              value: `Avg: ${average.toLocaleString()}`,
+            }}
+            stroke="var(--muted-foreground)"
+            strokeDasharray="3 3"
+            y={average}
+          />
+
+          <Area
+            dataKey="value"
+            fill="url(#trendGradient)"
+            fillOpacity={1}
+            stroke="var(--foreground)"
+            strokeWidth={2}
+            type="monotone"
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </figure>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/_components/stats-page-layout.tsx
+++ b/apps/admin/src/app/(private)/stats/_components/stats-page-layout.tsx
@@ -1,0 +1,56 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@zoonk/ui/components/breadcrumb";
+import {
+  Container,
+  ContainerBody,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
+import Link from "next/link";
+import { AdminPeriodTabs } from "./admin-period-tabs";
+
+function StatsBreadcrumb({ title }: { title: string }) {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink render={<Link href="/" />}>Dashboard</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink render={<Link href="/stats" />}>Stats</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>{title}</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}
+
+export function StatsPageLayout({ children, title }: { children: React.ReactNode; title: string }) {
+  return (
+    <Container>
+      <ContainerHeader variant="sidebar">
+        <ContainerHeaderGroup>
+          <StatsBreadcrumb title={title} />
+
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <ContainerTitle>{title}</ContainerTitle>
+            <AdminPeriodTabs />
+          </div>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>{children}</ContainerBody>
+    </Container>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/content/content-metrics.tsx
+++ b/apps/admin/src/app/(private)/stats/content/content-metrics.tsx
@@ -1,0 +1,88 @@
+import { countContent } from "@/data/stats/count-content";
+import { countTotalPendingReviews } from "@/data/stats/count-total-pending-reviews";
+import { getPeriodContentCreated } from "@/data/stats/get-period-content-created";
+import { getPeriodReviewsResolved } from "@/data/stats/get-period-reviews-resolved";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { calculateDateRanges, validatePeriod } from "@zoonk/utils/date-ranges";
+import { AlertCircleIcon, BookOpenIcon, CheckCircleIcon, LayersIcon } from "lucide-react";
+import { AdminMetricCard, AdminMetricCardSkeleton } from "../_components/admin-metric-card";
+import { ContentTotalsTable } from "./content-totals-table";
+
+export async function ContentMetrics({
+  searchParams,
+}: {
+  searchParams: Promise<{ period?: string }>;
+}) {
+  const { period: rawPeriod } = await searchParams;
+  const period = validatePeriod(rawPeriod ?? "month");
+  const { current, previous } = calculateDateRanges(period, 0);
+
+  const [currentCreated, previousCreated, currentReviews, previousReviews, pendingReviews, totals] =
+    await Promise.all([
+      getPeriodContentCreated(current.start, current.end),
+      getPeriodContentCreated(previous.start, previous.end),
+      getPeriodReviewsResolved(current.start, current.end),
+      getPeriodReviewsResolved(previous.start, previous.end),
+      countTotalPendingReviews(),
+      countContent(),
+    ]);
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 lg:grid-cols-4">
+        <AdminMetricCard
+          change={{ current: currentCreated.courses, period, previous: previousCreated.courses }}
+          help="Courses created in this period"
+          icon={<BookOpenIcon />}
+          title="New Courses"
+          value={currentCreated.courses.toLocaleString()}
+        />
+
+        <AdminMetricCard
+          change={{ current: currentCreated.lessons, period, previous: previousCreated.lessons }}
+          help="Lessons created in this period"
+          icon={<LayersIcon />}
+          title="New Lessons"
+          value={currentCreated.lessons.toLocaleString()}
+        />
+
+        <AdminMetricCard
+          change={{ current: currentReviews, period, previous: previousReviews }}
+          help="Content reviews completed in this period"
+          icon={<CheckCircleIcon />}
+          title="Reviews Resolved"
+          value={currentReviews.toLocaleString()}
+        />
+
+        <AdminMetricCard
+          help="Content awaiting admin review"
+          icon={<AlertCircleIcon />}
+          title="Pending Reviews"
+          value={pendingReviews.toLocaleString()}
+        />
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h3 className="text-base font-semibold tracking-tight">Content Totals</h3>
+
+        <div className="rounded-lg border">
+          <ContentTotalsTable periodCreated={currentCreated} totals={totals} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ContentMetricsSkeleton() {
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 lg:grid-cols-4">
+        <AdminMetricCardSkeleton />
+        <AdminMetricCardSkeleton />
+        <AdminMetricCardSkeleton />
+        <AdminMetricCardSkeleton />
+      </div>
+      <Skeleton className="h-48 w-full rounded-lg" />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/content/content-totals-table.tsx
+++ b/apps/admin/src/app/(private)/stats/content/content-totals-table.tsx
@@ -1,0 +1,52 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@zoonk/ui/components/table";
+
+export function ContentTotalsTable({
+  totals,
+  periodCreated,
+}: {
+  totals: { chapters: number; lessons: number; activities: number; steps: number };
+  periodCreated: { courses: number; lessons: number; activities: number };
+}) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Type</TableHead>
+          <TableHead className="text-right">Total</TableHead>
+          <TableHead className="text-right">Created This Period</TableHead>
+        </TableRow>
+      </TableHeader>
+
+      <TableBody>
+        <ContentRow count={periodCreated.courses} title="Courses" total={totals.chapters} />
+        <ContentRow title="Chapters" total={totals.chapters} />
+        <ContentRow count={periodCreated.lessons} title="Lessons" total={totals.lessons} />
+        <ContentRow count={periodCreated.activities} title="Activities" total={totals.activities} />
+        <ContentRow title="Steps" total={totals.steps} />
+      </TableBody>
+    </Table>
+  );
+}
+
+function ContentRow({ title, total, count }: { title: string; total: number; count?: number }) {
+  return (
+    <TableRow>
+      <TableCell className="font-medium">{title}</TableCell>
+      <TableCell className="text-right tabular-nums">{total.toLocaleString()}</TableCell>
+      <TableCell className="text-right tabular-nums">
+        {count === undefined ? (
+          <span className="text-muted-foreground">—</span>
+        ) : (
+          count.toLocaleString()
+        )}
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/content/content-totals-table.tsx
+++ b/apps/admin/src/app/(private)/stats/content/content-totals-table.tsx
@@ -11,7 +11,7 @@ export function ContentTotalsTable({
   totals,
   periodCreated,
 }: {
-  totals: { chapters: number; lessons: number; activities: number; steps: number };
+  totals: { courses: number; chapters: number; lessons: number; activities: number; steps: number };
   periodCreated: { courses: number; lessons: number; activities: number };
 }) {
   return (
@@ -25,7 +25,7 @@ export function ContentTotalsTable({
       </TableHeader>
 
       <TableBody>
-        <ContentRow count={periodCreated.courses} title="Courses" total={totals.chapters} />
+        <ContentRow count={periodCreated.courses} title="Courses" total={totals.courses} />
         <ContentRow title="Chapters" total={totals.chapters} />
         <ContentRow count={periodCreated.lessons} title="Lessons" total={totals.lessons} />
         <ContentRow count={periodCreated.activities} title="Activities" total={totals.activities} />

--- a/apps/admin/src/app/(private)/stats/content/page.tsx
+++ b/apps/admin/src/app/(private)/stats/content/page.tsx
@@ -1,0 +1,20 @@
+import { type Metadata } from "next";
+import { Suspense } from "react";
+import { StatsPageLayout } from "../_components/stats-page-layout";
+import { ContentMetrics, ContentMetricsSkeleton } from "./content-metrics";
+
+export const metadata: Metadata = {
+  title: "Content & Operations",
+};
+
+export default async function ContentPage({ searchParams }: PageProps<"/stats/content">) {
+  const { period } = await searchParams;
+
+  return (
+    <StatsPageLayout title="Content & Operations">
+      <Suspense fallback={<ContentMetricsSkeleton />} key={String(period)}>
+        <ContentMetrics searchParams={searchParams} />
+      </Suspense>
+    </StatsPageLayout>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/engagement/activity-breakdown-table.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/activity-breakdown-table.tsx
@@ -1,0 +1,81 @@
+import { formatDuration } from "@/lib/format-duration";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@zoonk/ui/components/table";
+
+const activityKindLabels: Record<string, string> = {
+  background: "Background",
+  challenge: "Challenge",
+  custom: "Custom",
+  examples: "Examples",
+  explanation: "Explanation",
+  grammar: "Grammar",
+  language_story: "Language Story",
+  listening: "Listening",
+  quiz: "Quiz",
+  reading: "Reading",
+  review: "Review",
+  story: "Story",
+  vocabulary: "Vocabulary",
+};
+
+type ActivityBreakdownRow = {
+  kind: string;
+  avgDuration: number;
+  completionRate: number;
+  completionCount: number;
+};
+
+export function ActivityBreakdownTable({ data }: { data: ActivityBreakdownRow[] }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Activity Type</TableHead>
+          <TableHead>Avg Duration</TableHead>
+          <TableHead>Completion Rate</TableHead>
+          <TableHead className="text-right">Completions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {data.map((row) => (
+          <ActivityBreakdownRow key={row.kind} row={row} />
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function ActivityBreakdownRow({ row }: { row: ActivityBreakdownRow }) {
+  return (
+    <TableRow>
+      <TableCell className="font-medium">{activityKindLabels[row.kind] ?? row.kind}</TableCell>
+      <TableCell className="tabular-nums">{formatDuration(row.avgDuration)}</TableCell>
+      <TableCell>
+        <CompletionBar rate={row.completionRate} />
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {row.completionCount.toLocaleString()}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function CompletionBar({ rate }: { rate: number }) {
+  return (
+    <div className="flex items-center gap-3">
+      <div className="bg-foreground/10 h-1.5 w-24 overflow-hidden rounded-full">
+        <div
+          className="bg-foreground/80 h-full rounded-full"
+          style={{ width: `${Math.min(rate, 100)}%` }}
+        />
+      </div>
+      <span className="text-muted-foreground text-sm tabular-nums">{rate.toFixed(1)}%</span>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/engagement/engagement-metrics.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/engagement-metrics.tsx
@@ -1,0 +1,129 @@
+import { getAvgTimeByActivityKind } from "@/data/stats/get-avg-time-by-activity-kind";
+import { getDailyActiveLearners } from "@/data/stats/get-daily-active-learners";
+import { getPeriodAccuracyRate } from "@/data/stats/get-period-accuracy-rate";
+import { getPeriodActiveLearners } from "@/data/stats/get-period-active-learners";
+import { getPeriodAvgActivityTime } from "@/data/stats/get-period-avg-activity-time";
+import { getPeriodLearningTime } from "@/data/stats/get-period-learning-time";
+import { formatDuration } from "@/lib/format-duration";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { calculateDateRanges, formatLabel, validatePeriod } from "@zoonk/utils/date-ranges";
+import { ActivityIcon, ClockIcon, TargetIcon, TimerIcon } from "lucide-react";
+import { AdminMetricCard, AdminMetricCardSkeleton } from "../_components/admin-metric-card";
+import { AdminTrendChart } from "../_components/admin-trend-chart";
+import { ActivityBreakdownTable } from "./activity-breakdown-table";
+
+export async function EngagementMetrics({
+  searchParams,
+}: {
+  searchParams: Promise<{ period?: string }>;
+}) {
+  const { period: rawPeriod } = await searchParams;
+  const period = validatePeriod(rawPeriod ?? "month");
+  const { current, previous } = calculateDateRanges(period, 0);
+
+  const [
+    currentActiveLearners,
+    previousActiveLearners,
+    currentAccuracy,
+    previousAccuracy,
+    currentAvgTime,
+    previousAvgTime,
+    currentLearningTime,
+    previousLearningTime,
+    dailyActive,
+    activityBreakdown,
+  ] = await Promise.all([
+    getPeriodActiveLearners(current.start, current.end),
+    getPeriodActiveLearners(previous.start, previous.end),
+    getPeriodAccuracyRate(current.start, current.end),
+    getPeriodAccuracyRate(previous.start, previous.end),
+    getPeriodAvgActivityTime(current.start, current.end),
+    getPeriodAvgActivityTime(previous.start, previous.end),
+    getPeriodLearningTime(current.start, current.end),
+    getPeriodLearningTime(previous.start, previous.end),
+    getDailyActiveLearners(current.start, current.end),
+    getAvgTimeByActivityKind(),
+  ]);
+
+  const chartData = dailyActive.map((point) => ({
+    date: point.date.toISOString(),
+    label: formatLabel(point.date, period, "en"),
+    value: point.count,
+  }));
+
+  const chartAverage =
+    chartData.length === 0
+      ? 0
+      : Math.round(chartData.reduce((sum, point) => sum + point.value, 0) / chartData.length);
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 lg:grid-cols-4">
+        <AdminMetricCard
+          change={{ current: currentActiveLearners, period, previous: previousActiveLearners }}
+          help="Distinct users with learning activity"
+          icon={<ActivityIcon />}
+          title="Active Learners"
+          value={currentActiveLearners.toLocaleString()}
+        />
+
+        <AdminMetricCard
+          change={{ current: currentAccuracy, period, previous: previousAccuracy }}
+          help="Correct answers vs total attempts"
+          icon={<TargetIcon />}
+          title="Accuracy Rate"
+          value={`${currentAccuracy.toFixed(1)}%`}
+        />
+
+        <AdminMetricCard
+          change={{ current: currentAvgTime, period, previous: previousAvgTime }}
+          help="Average time to complete an activity"
+          icon={<ClockIcon />}
+          title="Avg Time / Activity"
+          value={formatDuration(currentAvgTime)}
+        />
+
+        <AdminMetricCard
+          change={{ current: currentLearningTime, period, previous: previousLearningTime }}
+          help="Total time spent learning in this period"
+          icon={<TimerIcon />}
+          title="Total Learning Time"
+          value={formatDuration(currentLearningTime)}
+        />
+      </div>
+
+      {chartData.length > 0 && (
+        <AdminTrendChart
+          average={chartAverage}
+          dataPoints={chartData}
+          valueLabel="active learners"
+        />
+      )}
+
+      {activityBreakdown.length > 0 && (
+        <div className="flex flex-col gap-3">
+          <h3 className="text-base font-semibold tracking-tight">Activity Time Breakdown</h3>
+
+          <div className="rounded-lg border">
+            <ActivityBreakdownTable data={activityBreakdown} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function EngagementMetricsSkeleton() {
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 lg:grid-cols-4">
+        <AdminMetricCardSkeleton />
+        <AdminMetricCardSkeleton />
+        <AdminMetricCardSkeleton />
+        <AdminMetricCardSkeleton />
+      </div>
+      <Skeleton className="h-64 w-full rounded-xl" />
+      <Skeleton className="h-48 w-full rounded-lg" />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/engagement/engagement-metrics.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/engagement-metrics.tsx
@@ -42,7 +42,7 @@ export async function EngagementMetrics({
     getPeriodLearningTime(current.start, current.end),
     getPeriodLearningTime(previous.start, previous.end),
     getDailyActiveLearners(current.start, current.end),
-    getAvgTimeByActivityKind(),
+    getAvgTimeByActivityKind(current.start, current.end),
   ]);
 
   const chartData = dailyActive.map((point) => ({

--- a/apps/admin/src/app/(private)/stats/engagement/page.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/page.tsx
@@ -1,0 +1,20 @@
+import { type Metadata } from "next";
+import { Suspense } from "react";
+import { StatsPageLayout } from "../_components/stats-page-layout";
+import { EngagementMetrics, EngagementMetricsSkeleton } from "./engagement-metrics";
+
+export const metadata: Metadata = {
+  title: "Engagement & Learning",
+};
+
+export default async function EngagementPage({ searchParams }: PageProps<"/stats/engagement">) {
+  const { period } = await searchParams;
+
+  return (
+    <StatsPageLayout title="Engagement & Learning">
+      <Suspense fallback={<EngagementMetricsSkeleton />} key={String(period)}>
+        <EngagementMetrics searchParams={searchParams} />
+      </Suspense>
+    </StatsPageLayout>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/growth/growth-metrics.tsx
+++ b/apps/admin/src/app/(private)/stats/growth/growth-metrics.tsx
@@ -1,0 +1,102 @@
+import { countSubscribersByPlan } from "@/data/stats/count-subscribers-by-plan";
+import { getActivationRate } from "@/data/stats/get-activation-rate";
+import { getConversionRate } from "@/data/stats/get-conversion-rate";
+import { getDailySignups } from "@/data/stats/get-daily-signups";
+import { getNewSignups } from "@/data/stats/get-new-signups";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { calculateDateRanges, formatLabel, validatePeriod } from "@zoonk/utils/date-ranges";
+import { CreditCardIcon, TargetIcon, UsersIcon } from "lucide-react";
+import { AdminMetricCard, AdminMetricCardSkeleton } from "../_components/admin-metric-card";
+import { AdminTrendChart } from "../_components/admin-trend-chart";
+import { SubscribersTable } from "./subscribers-table";
+
+export async function GrowthMetrics({
+  searchParams,
+}: {
+  searchParams: Promise<{ period?: string }>;
+}) {
+  const { period: rawPeriod } = await searchParams;
+  const period = validatePeriod(rawPeriod ?? "month");
+  const { current, previous } = calculateDateRanges(period, 0);
+
+  const [
+    currentSignups,
+    previousSignups,
+    currentActivation,
+    currentConversion,
+    dailySignups,
+    subscribers,
+  ] = await Promise.all([
+    getNewSignups(current.start, current.end),
+    getNewSignups(previous.start, previous.end),
+    getActivationRate(),
+    getConversionRate(),
+    getDailySignups(current.start, current.end),
+    countSubscribersByPlan(),
+  ]);
+
+  const chartData = dailySignups.map((point) => ({
+    date: point.date.toISOString(),
+    label: formatLabel(point.date, period, "en"),
+    value: point.count,
+  }));
+
+  const chartAverage =
+    chartData.length === 0
+      ? 0
+      : Math.round(chartData.reduce((sum, point) => sum + point.value, 0) / chartData.length);
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 lg:grid-cols-3">
+        <AdminMetricCard
+          change={{ current: currentSignups, period, previous: previousSignups }}
+          help="New user registrations in this period"
+          icon={<UsersIcon />}
+          title="New Signups"
+          value={currentSignups.toLocaleString()}
+        />
+
+        <AdminMetricCard
+          description={`${currentActivation.activated.toLocaleString()} of ${currentActivation.total.toLocaleString()} users`}
+          help="Users who completed at least 1 lesson"
+          icon={<TargetIcon />}
+          title="Activation Rate"
+          value={`${currentActivation.rate.toFixed(1)}%`}
+        />
+
+        <AdminMetricCard
+          description={`${currentConversion.paid.toLocaleString()} paid of ${currentConversion.total.toLocaleString()} total`}
+          help="Active paid subscribers vs all users"
+          icon={<CreditCardIcon />}
+          title="Free-to-Paid"
+          value={`${currentConversion.rate.toFixed(1)}%`}
+        />
+      </div>
+
+      {chartData.length > 0 && (
+        <AdminTrendChart average={chartAverage} dataPoints={chartData} valueLabel="signups" />
+      )}
+
+      {subscribers.length > 0 && (
+        <div className="rounded-lg border">
+          <SubscribersTable data={subscribers} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function GrowthMetricsSkeleton() {
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 lg:grid-cols-3">
+        <AdminMetricCardSkeleton />
+        <AdminMetricCardSkeleton />
+        <AdminMetricCardSkeleton />
+      </div>
+      <Skeleton className="h-64 w-full rounded-xl" />
+      <Skeleton className="h-32 w-full rounded-lg" />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/growth/page.tsx
+++ b/apps/admin/src/app/(private)/stats/growth/page.tsx
@@ -1,0 +1,20 @@
+import { type Metadata } from "next";
+import { Suspense } from "react";
+import { StatsPageLayout } from "../_components/stats-page-layout";
+import { GrowthMetrics, GrowthMetricsSkeleton } from "./growth-metrics";
+
+export const metadata: Metadata = {
+  title: "Growth & Sustainability",
+};
+
+export default async function GrowthPage({ searchParams }: PageProps<"/stats/growth">) {
+  const { period } = await searchParams;
+
+  return (
+    <StatsPageLayout title="Growth & Sustainability">
+      <Suspense fallback={<GrowthMetricsSkeleton />} key={String(period)}>
+        <GrowthMetrics searchParams={searchParams} />
+      </Suspense>
+    </StatsPageLayout>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/growth/subscribers-table.tsx
+++ b/apps/admin/src/app/(private)/stats/growth/subscribers-table.tsx
@@ -1,0 +1,30 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@zoonk/ui/components/table";
+
+export function SubscribersTable({ data }: { data: { plan: string; count: number }[] }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Plan</TableHead>
+          <TableHead className="text-right">Subscribers</TableHead>
+        </TableRow>
+      </TableHeader>
+
+      <TableBody>
+        {data.map((sub) => (
+          <TableRow key={sub.plan}>
+            <TableCell className="font-medium capitalize">{sub.plan}</TableCell>
+            <TableCell className="text-right tabular-nums">{sub.count.toLocaleString()}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/page.tsx
+++ b/apps/admin/src/app/(private)/stats/page.tsx
@@ -1,0 +1,78 @@
+import {
+  Container,
+  ContainerBody,
+  ContainerDescription,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemMedia,
+  ItemTitle,
+} from "@zoonk/ui/components/item";
+import { ActivityIcon, ArrowRightIcon, BookOpenIcon, TrendingUpIcon } from "lucide-react";
+import { type Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Stats",
+};
+
+const sections = [
+  {
+    description: "New signups, activation rate, free-to-paid conversion, and subscriber breakdown.",
+    href: "/stats/growth",
+    icon: TrendingUpIcon,
+    title: "Growth & Sustainability",
+  },
+  {
+    description:
+      "Active learners, accuracy rate, time per activity, learning time trends, and activity breakdown.",
+    href: "/stats/engagement",
+    icon: ActivityIcon,
+    title: "Engagement & Learning",
+  },
+  {
+    description: "New courses and lessons, review resolution, pending reviews, and content totals.",
+    href: "/stats/content",
+    icon: BookOpenIcon,
+    title: "Content & Operations",
+  },
+] as const;
+
+export default function StatsPage() {
+  return (
+    <Container>
+      <ContainerHeader variant="sidebar">
+        <ContainerHeaderGroup>
+          <ContainerTitle>Stats</ContainerTitle>
+          <ContainerDescription>Detailed analytics for your platform.</ContainerDescription>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <ItemGroup>
+          {sections.map((section) => (
+            <Item key={section.href} render={<Link href={section.href} />}>
+              <ItemMedia variant="icon">
+                <section.icon />
+              </ItemMedia>
+              <ItemContent>
+                <ItemTitle>{section.title}</ItemTitle>
+                <ItemDescription>{section.description}</ItemDescription>
+              </ItemContent>
+              <ItemActions>
+                <ArrowRightIcon aria-hidden className="text-muted-foreground/50 size-4" />
+              </ItemActions>
+            </Item>
+          ))}
+        </ItemGroup>
+      </ContainerBody>
+    </Container>
+  );
+}

--- a/apps/admin/src/components/stats-section.tsx
+++ b/apps/admin/src/components/stats-section.tsx
@@ -1,0 +1,44 @@
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { StatsSkeleton } from "./stats";
+
+export function StatsSection({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-4">
+      <header className="flex flex-col gap-0.5">
+        <h2 className="text-base font-semibold tracking-tight">{title}</h2>
+        {subtitle && <p className="text-muted-foreground/70 text-sm">{subtitle}</p>}
+      </header>
+
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 lg:grid-cols-4">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+const DEFAULT_SKELETON_ITEMS = 4;
+
+export function StatsSectionSkeleton({ items = DEFAULT_SKELETON_ITEMS }: { items?: number }) {
+  return (
+    <section className="flex flex-col gap-4">
+      <header className="flex flex-col gap-0.5">
+        <Skeleton className="h-5 w-48" />
+        <Skeleton className="h-4 w-64" />
+      </header>
+
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: items }, (_, i) => (
+          <StatsSkeleton key={i} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/admin/src/components/stats-title.tsx
+++ b/apps/admin/src/components/stats-title.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@zoonk/ui/components/tooltip";
+
+export function StatsTitle({ title, help }: { title: string; help?: string }) {
+  if (!help) {
+    return <h3 className="text-sm leading-tight font-medium">{title}</h3>;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger className="decoration-muted-foreground/50 cursor-help text-sm leading-tight font-medium decoration-dotted underline-offset-4 hover:underline">
+        {title}
+      </TooltipTrigger>
+      <TooltipContent>{help}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/admin/src/components/stats.tsx
+++ b/apps/admin/src/components/stats.tsx
@@ -1,27 +1,63 @@
 import { Skeleton } from "@zoonk/ui/components/skeleton";
+import Link from "next/link";
+import { StatsTitle } from "./stats-title";
 
-export function Stats({
+function StatsContent({
   title,
   value,
   icon,
+  description,
+  help,
 }: {
   title: string;
   value: string | number;
   icon?: React.ReactNode;
+  description?: string;
+  help?: string;
 }) {
   return (
     <div className="flex w-full flex-wrap items-baseline justify-between gap-x-4 gap-y-2">
       <header className="text-muted-foreground flex items-center gap-1.5">
         {icon && <span className="flex size-4 items-center justify-center rounded-lg">{icon}</span>}
-
-        <h3 className="text-sm leading-tight font-medium">{title}</h3>
+        <StatsTitle help={help} title={title} />
       </header>
 
-      <div className="text-foreground w-full flex-none text-3xl font-medium tracking-tight">
-        {value}
+      <div className="w-full flex-none">
+        <div className="text-foreground text-3xl font-medium tracking-tight">{value}</div>
+        {description && <p className="text-muted-foreground mt-1 text-sm">{description}</p>}
       </div>
     </div>
   );
+}
+
+export function Stats({
+  title,
+  value,
+  icon,
+  description,
+  help,
+  href,
+}: {
+  title: string;
+  value: string | number;
+  icon?: React.ReactNode;
+  description?: string;
+  help?: string;
+  href?: string;
+}) {
+  const content = (
+    <StatsContent description={description} help={help} icon={icon} title={title} value={value} />
+  );
+
+  if (href) {
+    return (
+      <Link className="hover:bg-muted/50 rounded-lg p-2 transition-colors" href={href}>
+        {content}
+      </Link>
+    );
+  }
+
+  return content;
 }
 
 export function StatsSkeleton() {

--- a/apps/admin/src/data/stats/count-active-learners.ts
+++ b/apps/admin/src/data/stats/count-active-learners.ts
@@ -1,0 +1,23 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const countActiveLearners = cache(async (sevenDaysAgo: Date, thirtyDaysAgo: Date) => {
+  const [last7DaysResult, last30DaysResult] = await Promise.all([
+    prisma.$queryRaw<[{ count: bigint }]>`
+      SELECT COUNT(DISTINCT user_id) as count
+      FROM daily_progress
+      WHERE date >= ${sevenDaysAgo}
+    `,
+    prisma.$queryRaw<[{ count: bigint }]>`
+      SELECT COUNT(DISTINCT user_id) as count
+      FROM daily_progress
+      WHERE date >= ${thirtyDaysAgo}
+    `,
+  ]);
+
+  return {
+    last30Days: Number(last30DaysResult[0].count),
+    last7Days: Number(last7DaysResult[0].count),
+  };
+});

--- a/apps/admin/src/data/stats/count-content.ts
+++ b/apps/admin/src/data/stats/count-content.ts
@@ -1,0 +1,14 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const countContent = cache(async () => {
+  const [chapters, lessons, activities, steps] = await Promise.all([
+    prisma.chapter.count(),
+    prisma.lesson.count(),
+    prisma.activity.count(),
+    prisma.step.count(),
+  ]);
+
+  return { activities, chapters, lessons, steps };
+});

--- a/apps/admin/src/data/stats/count-content.ts
+++ b/apps/admin/src/data/stats/count-content.ts
@@ -3,12 +3,13 @@ import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
 export const countContent = cache(async () => {
-  const [chapters, lessons, activities, steps] = await Promise.all([
+  const [courses, chapters, lessons, activities, steps] = await Promise.all([
+    prisma.course.count(),
     prisma.chapter.count(),
     prisma.lesson.count(),
     prisma.activity.count(),
     prisma.step.count(),
   ]);
 
-  return { activities, chapters, lessons, steps };
+  return { activities, chapters, courses, lessons, steps };
 });

--- a/apps/admin/src/data/stats/count-courses.ts
+++ b/apps/admin/src/data/stats/count-courses.ts
@@ -1,0 +1,5 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const countCourses = cache(() => prisma.course.count());

--- a/apps/admin/src/data/stats/count-subscribers-by-plan.ts
+++ b/apps/admin/src/data/stats/count-subscribers-by-plan.ts
@@ -1,0 +1,13 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const countSubscribersByPlan = cache(async () => {
+  const results = await prisma.subscription.groupBy({
+    _count: { plan: true },
+    by: ["plan"],
+    where: { status: "active" },
+  });
+
+  return results.map((row) => ({ count: row._count.plan, plan: row.plan }));
+});

--- a/apps/admin/src/data/stats/count-total-pending-reviews.ts
+++ b/apps/admin/src/data/stats/count-total-pending-reviews.ts
@@ -1,0 +1,8 @@
+import "server-only";
+import { countPendingReviews } from "@/data/review/count-pending-reviews";
+import { cache } from "react";
+
+export const countTotalPendingReviews = cache(async () => {
+  const counts = await countPendingReviews();
+  return Object.values(counts).reduce((sum, count) => sum + count, 0);
+});

--- a/apps/admin/src/data/stats/get-accuracy-rate.ts
+++ b/apps/admin/src/data/stats/get-accuracy-rate.ts
@@ -1,0 +1,12 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getAccuracyRate = cache(async () => {
+  const [total, correct] = await Promise.all([
+    prisma.stepAttempt.count(),
+    prisma.stepAttempt.count({ where: { isCorrect: true } }),
+  ]);
+
+  return total === 0 ? 0 : (correct / total) * 100;
+});

--- a/apps/admin/src/data/stats/get-activation-rate.ts
+++ b/apps/admin/src/data/stats/get-activation-rate.ts
@@ -1,0 +1,19 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getActivationRate = cache(async () => {
+  const [activatedResult, total] = await Promise.all([
+    prisma.$queryRaw<[{ count: bigint }]>`
+      SELECT COUNT(DISTINCT user_id) as count
+      FROM activity_progress
+      WHERE completed_at IS NOT NULL
+    `,
+    prisma.user.count(),
+  ]);
+
+  const activated = Number(activatedResult[0].count);
+  const rate = total === 0 ? 0 : (activated / total) * 100;
+
+  return { activated, rate, total };
+});

--- a/apps/admin/src/data/stats/get-avg-activities-per-learner.ts
+++ b/apps/admin/src/data/stats/get-avg-activities-per-learner.ts
@@ -1,0 +1,18 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getAvgActivitiesPerLearner = cache(async () => {
+  const result = await prisma.$queryRaw<[{ total: bigint; learners: bigint }]>`
+    SELECT
+      COUNT(*) as total,
+      COUNT(DISTINCT user_id) as learners
+    FROM activity_progress
+    WHERE completed_at IS NOT NULL
+  `;
+
+  const total = Number(result[0].total);
+  const learners = Number(result[0].learners);
+
+  return learners === 0 ? 0 : Math.round((total / learners) * 10) / 10;
+});

--- a/apps/admin/src/data/stats/get-avg-activity-time.ts
+++ b/apps/admin/src/data/stats/get-avg-activity-time.ts
@@ -1,0 +1,12 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getAvgActivityTime = cache(async () => {
+  const result = await prisma.activityProgress.aggregate({
+    _avg: { durationSeconds: true },
+    where: { durationSeconds: { not: null } },
+  });
+
+  return result._avg.durationSeconds ?? 0;
+});

--- a/apps/admin/src/data/stats/get-avg-time-by-activity-kind.ts
+++ b/apps/admin/src/data/stats/get-avg-time-by-activity-kind.ts
@@ -1,0 +1,29 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getAvgTimeByActivityKind = cache(async () => {
+  const results = await prisma.$queryRaw<
+    { kind: string; avg_duration: number; completed: bigint; started: bigint }[]
+  >`
+    SELECT
+      a.kind,
+      AVG(ap.duration_seconds) as avg_duration,
+      COUNT(*) FILTER (WHERE ap.completed_at IS NOT NULL) as completed,
+      COUNT(*) as started
+    FROM activity_progress ap
+    JOIN activities a ON a.id = ap.activity_id
+    WHERE ap.duration_seconds IS NOT NULL
+    GROUP BY a.kind
+    ORDER BY avg_duration DESC
+  `;
+
+  return results.map((row) => ({
+    avgDuration: Math.round(row.avg_duration),
+    completionCount: Number(row.completed),
+    completionRate:
+      Number(row.started) === 0 ? 0 : (Number(row.completed) / Number(row.started)) * 100,
+    kind: row.kind,
+    startedCount: Number(row.started),
+  }));
+});

--- a/apps/admin/src/data/stats/get-avg-time-by-activity-kind.ts
+++ b/apps/admin/src/data/stats/get-avg-time-by-activity-kind.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
-export const getAvgTimeByActivityKind = cache(async () => {
+export const getAvgTimeByActivityKind = cache(async (start: Date, end: Date) => {
   const results = await prisma.$queryRaw<
     { kind: string; avg_duration: number; completed: bigint; started: bigint }[]
   >`
@@ -14,6 +14,7 @@ export const getAvgTimeByActivityKind = cache(async () => {
     FROM activity_progress ap
     JOIN activities a ON a.id = ap.activity_id
     WHERE ap.duration_seconds IS NOT NULL
+      AND ap.started_at >= ${start} AND ap.started_at <= ${end}
     GROUP BY a.kind
     ORDER BY avg_duration DESC
   `;

--- a/apps/admin/src/data/stats/get-conversion-rate.ts
+++ b/apps/admin/src/data/stats/get-conversion-rate.ts
@@ -1,0 +1,14 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getConversionRate = cache(async () => {
+  const [paid, total] = await Promise.all([
+    prisma.subscription.count({ where: { plan: { not: "free" }, status: "active" } }),
+    prisma.user.count(),
+  ]);
+
+  const rate = total === 0 ? 0 : (paid / total) * 100;
+
+  return { paid, rate, total };
+});

--- a/apps/admin/src/data/stats/get-daily-active-learners.ts
+++ b/apps/admin/src/data/stats/get-daily-active-learners.ts
@@ -1,0 +1,18 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getDailyActiveLearners = cache(async (start: Date, end: Date) => {
+  const results = await prisma.$queryRaw<{ date: Date; count: bigint }[]>`
+    SELECT date, COUNT(DISTINCT user_id) as count
+    FROM daily_progress
+    WHERE date >= ${start} AND date <= ${end}
+    GROUP BY date
+    ORDER BY date ASC
+  `;
+
+  return results.map((row) => ({
+    count: Number(row.count),
+    date: row.date,
+  }));
+});

--- a/apps/admin/src/data/stats/get-daily-signups.ts
+++ b/apps/admin/src/data/stats/get-daily-signups.ts
@@ -1,0 +1,18 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getDailySignups = cache(async (start: Date, end: Date) => {
+  const results = await prisma.$queryRaw<{ date: Date; count: bigint }[]>`
+    SELECT DATE(created_at) as date, COUNT(*) as count
+    FROM users
+    WHERE created_at >= ${start} AND created_at <= ${end}
+    GROUP BY DATE(created_at)
+    ORDER BY date ASC
+  `;
+
+  return results.map((row) => ({
+    count: Number(row.count),
+    date: row.date,
+  }));
+});

--- a/apps/admin/src/data/stats/get-new-signups.ts
+++ b/apps/admin/src/data/stats/get-new-signups.ts
@@ -1,0 +1,9 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getNewSignups = cache(async (start: Date, end: Date) =>
+  prisma.user.count({
+    where: { createdAt: { gte: start, lte: end } },
+  }),
+);

--- a/apps/admin/src/data/stats/get-period-accuracy-rate.ts
+++ b/apps/admin/src/data/stats/get-period-accuracy-rate.ts
@@ -1,0 +1,16 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getPeriodAccuracyRate = cache(async (start: Date, end: Date) => {
+  const [total, correct] = await Promise.all([
+    prisma.stepAttempt.count({
+      where: { answeredAt: { gte: start, lte: end } },
+    }),
+    prisma.stepAttempt.count({
+      where: { answeredAt: { gte: start, lte: end }, isCorrect: true },
+    }),
+  ]);
+
+  return total === 0 ? 0 : (correct / total) * 100;
+});

--- a/apps/admin/src/data/stats/get-period-active-learners.ts
+++ b/apps/admin/src/data/stats/get-period-active-learners.ts
@@ -1,0 +1,13 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getPeriodActiveLearners = cache(async (start: Date, end: Date) => {
+  const result = await prisma.$queryRaw<[{ count: bigint }]>`
+    SELECT COUNT(DISTINCT user_id) as count
+    FROM daily_progress
+    WHERE date >= ${start} AND date <= ${end}
+  `;
+
+  return Number(result[0].count);
+});

--- a/apps/admin/src/data/stats/get-period-avg-activity-time.ts
+++ b/apps/admin/src/data/stats/get-period-avg-activity-time.ts
@@ -1,0 +1,15 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getPeriodAvgActivityTime = cache(async (start: Date, end: Date) => {
+  const result = await prisma.activityProgress.aggregate({
+    _avg: { durationSeconds: true },
+    where: {
+      completedAt: { gte: start, lte: end },
+      durationSeconds: { not: null },
+    },
+  });
+
+  return result._avg.durationSeconds ?? 0;
+});

--- a/apps/admin/src/data/stats/get-period-content-created.ts
+++ b/apps/admin/src/data/stats/get-period-content-created.ts
@@ -1,0 +1,13 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getPeriodContentCreated = cache(async (start: Date, end: Date) => {
+  const [courses, lessons, activities] = await Promise.all([
+    prisma.course.count({ where: { createdAt: { gte: start, lte: end } } }),
+    prisma.lesson.count({ where: { createdAt: { gte: start, lte: end } } }),
+    prisma.activity.count({ where: { createdAt: { gte: start, lte: end } } }),
+  ]);
+
+  return { activities, courses, lessons };
+});

--- a/apps/admin/src/data/stats/get-period-learning-time.ts
+++ b/apps/admin/src/data/stats/get-period-learning-time.ts
@@ -1,0 +1,12 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getPeriodLearningTime = cache(async (start: Date, end: Date) => {
+  const result = await prisma.dailyProgress.aggregate({
+    _sum: { timeSpentSeconds: true },
+    where: { date: { gte: start, lte: end } },
+  });
+
+  return result._sum.timeSpentSeconds ?? 0;
+});

--- a/apps/admin/src/data/stats/get-period-reviews-resolved.ts
+++ b/apps/admin/src/data/stats/get-period-reviews-resolved.ts
@@ -1,0 +1,9 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getPeriodReviewsResolved = cache(async (start: Date, end: Date) =>
+  prisma.contentReview.count({
+    where: { reviewedAt: { gte: start, lte: end } },
+  }),
+);

--- a/apps/admin/src/data/stats/get-total-learning-time.ts
+++ b/apps/admin/src/data/stats/get-total-learning-time.ts
@@ -1,0 +1,11 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getTotalLearningTime = cache(async () => {
+  const result = await prisma.dailyProgress.aggregate({
+    _sum: { timeSpentSeconds: true },
+  });
+
+  return result._sum.timeSpentSeconds ?? 0;
+});

--- a/apps/admin/src/lib/format-duration.ts
+++ b/apps/admin/src/lib/format-duration.ts
@@ -7,8 +7,9 @@ export function formatDuration(totalSeconds: number): string {
     return `${Math.round(totalSeconds / 60)}m`;
   }
 
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.round((totalSeconds % 3600) / 60);
+  const totalMinutes = Math.round(totalSeconds / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
 
   return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
 }

--- a/apps/admin/src/lib/format-duration.ts
+++ b/apps/admin/src/lib/format-duration.ts
@@ -1,0 +1,14 @@
+export function formatDuration(totalSeconds: number): string {
+  if (totalSeconds < 60) {
+    return `${Math.round(totalSeconds)}s`;
+  }
+
+  if (totalSeconds < 3600) {
+    return `${Math.round(totalSeconds / 60)}m`;
+  }
+
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.round((totalSeconds % 3600) / 60);
+
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+}

--- a/packages/ui/src/components/item.tsx
+++ b/packages/ui/src/components/item.tsx
@@ -95,7 +95,7 @@ const itemMediaVariants = cva(
     variants: {
       variant: {
         default: "bg-transparent",
-        icon: "bg-muted/70 rounded-lg [&_svg:not([class*='size-'])]:size-4",
+        icon: "[&_svg:not([class*='size-'])]:size-4",
         image:
           "size-10 overflow-hidden rounded-lg group-data-[size=sm]/item:size-8 group-data-[size=xs]/item:size-6 group-data-[size=xs]/item:rounded-md [&_img]:size-full [&_img]:object-cover",
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      recharts:
+        specifier: 3.7.0
+        version: 3.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(redux@5.0.1)
       server-only:
         specifier: 0.0.1
         version: 0.0.1


### PR DESCRIPTION
## Summary
- Redesigned admin dashboard home with 3 metric sections: Growth & Sustainability, Engagement & Learning, Content & Operations
- Each stat has help tooltips, descriptions with context (e.g., "312 of 1,450 users"), and clickable links to detail pages
- Added `/stats` landing page with navigation to 3 detail pages
- Added `/stats/growth`, `/stats/engagement`, `/stats/content` detail pages with period comparison (Month/6 Months/Year), trend charts, change indicators, and supporting tables
- Added 20+ data query functions for metrics like activation rate, conversion rate, active learners, accuracy rate, avg activity time, learning time, content creation, and more
- Added Stats item to sidebar
- Removed `bg-muted/70` from `ItemMedia` icon variant

## Test plan
- [ ] Navigate to `/` — verify all 3 metric sections render
- [ ] Click stat links (Total Users → /users, Courses → /courses, etc.)
- [ ] Navigate to `/stats` — verify landing page with 3 section links
- [ ] On `/stats/growth` — verify metric cards, signups chart, subscriber table
- [ ] On `/stats/engagement` — verify metric cards, active learners chart, activity breakdown table
- [ ] On `/stats/content` — verify metric cards, content totals table
- [ ] Switch period tabs (Month/6 Months/Year) — verify data updates on all detail pages
- [ ] Hover stat titles — verify help tooltips appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a metrics-focused admin dashboard with a Stats landing page and three detail pages (Growth, Engagement, Content). Includes period comparisons, charts, and drill-downs with accurate time displays and correct period filtering.

- **New Features**
  - Redesigned dashboard home into 3 sections: Growth, Engagement, Content.
  - Added /stats, /stats/growth, /stats/engagement, /stats/content with Month/6 Months/Year tabs, change indicators, trend charts, and supporting tables.
  - Clickable stat cards with tooltips and contextual descriptions.
  - Reusable components (metric card, period tabs, trend chart, layout, stats section/title) and 20+ data queries covering activation/conversion, active learners, accuracy, activity time, learning time, signups, content created/reviewed, totals, and subscribers by plan.
  - Sidebar: added “Stats”. UI polish: removed bg-muted/70 from ItemMedia icon variant. Added recharts 3.7.0 for charts.

- **Bug Fixes**
  - Consistent duration rounding (seconds, minutes, hours).
  - Corrected course totals in content tables.
  - Unique chart gradient IDs to prevent collisions.
  - Period tabs now correctly filter metrics and charts across detail pages.

<sup>Written for commit 83f1d7033c88d42b9f8d2f8117852d7c13661459. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

