### PR TITLE
feat(admin): track activity starts for completion rate metrics

### DIFF
--- a/apps/admin/src/app/(private)/app-stats-engagement.tsx
+++ b/apps/admin/src/app/(private)/app-stats-engagement.tsx
@@ -4,9 +4,10 @@ import { countActiveLearners } from "@/data/stats/count-active-learners";
 import { getAccuracyRate } from "@/data/stats/get-accuracy-rate";
 import { getAvgActivitiesPerLearner } from "@/data/stats/get-avg-activities-per-learner";
 import { getAvgActivityTime } from "@/data/stats/get-avg-activity-time";
+import { getCompletionRate } from "@/data/stats/get-completion-rate";
 import { getTotalLearningTime } from "@/data/stats/get-total-learning-time";
 import { formatDuration } from "@/lib/format-duration";
-import { ActivityIcon, ClockIcon, LayersIcon, TargetIcon } from "lucide-react";
+import { ActivityIcon, CheckCircleIcon, ClockIcon, LayersIcon, TargetIcon } from "lucide-react";
 import { connection } from "next/server";
 
 const DAYS_7 = 7;
@@ -18,14 +19,21 @@ export async function EngagementStats() {
   const sevenDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - DAYS_7);
   const thirtyDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - DAYS_30);
 
-  const [activeLearners, accuracyRate, avgTime, avgActivitiesPerLearner, totalLearningTime] =
-    await Promise.all([
-      countActiveLearners(sevenDaysAgo, thirtyDaysAgo),
-      getAccuracyRate(),
-      getAvgActivityTime(),
-      getAvgActivitiesPerLearner(),
-      getTotalLearningTime(),
-    ]);
+  const [
+    activeLearners,
+    accuracyRate,
+    avgTime,
+    avgActivitiesPerLearner,
+    completionRate,
+    totalLearningTime,
+  ] = await Promise.all([
+    countActiveLearners(sevenDaysAgo, thirtyDaysAgo),
+    getAccuracyRate(),
+    getAvgActivityTime(),
+    getAvgActivitiesPerLearner(),
+    getCompletionRate(),
+    getTotalLearningTime(),
+  ]);
 
   return (
     <StatsSection subtitle="How learners interact with content" title="Engagement & Learning">
@@ -44,6 +52,14 @@ export async function EngagementStats() {
         icon={<TargetIcon />}
         title="Accuracy Rate"
         value={`${accuracyRate.toFixed(1)}%`}
+      />
+
+      <Stats
+        help="Activities completed vs started"
+        href="/stats/engagement"
+        icon={<CheckCircleIcon />}
+        title="Completion Rate"
+        value={`${completionRate.toFixed(1)}%`}
       />
 
       <Stats

--- a/apps/admin/src/app/(private)/stats/engagement/engagement-metrics.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/engagement-metrics.tsx
@@ -3,11 +3,12 @@ import { getDailyActiveLearners } from "@/data/stats/get-daily-active-learners";
 import { getPeriodAccuracyRate } from "@/data/stats/get-period-accuracy-rate";
 import { getPeriodActiveLearners } from "@/data/stats/get-period-active-learners";
 import { getPeriodAvgActivityTime } from "@/data/stats/get-period-avg-activity-time";
+import { getPeriodCompletionRate } from "@/data/stats/get-period-completion-rate";
 import { getPeriodLearningTime } from "@/data/stats/get-period-learning-time";
 import { formatDuration } from "@/lib/format-duration";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { calculateDateRanges, formatLabel, validatePeriod } from "@zoonk/utils/date-ranges";
-import { ActivityIcon, ClockIcon, TargetIcon, TimerIcon } from "lucide-react";
+import { ActivityIcon, CheckCircleIcon, ClockIcon, TargetIcon, TimerIcon } from "lucide-react";
 import { AdminMetricCard, AdminMetricCardSkeleton } from "../_components/admin-metric-card";
 import { AdminTrendChart } from "../_components/admin-trend-chart";
 import { ActivityBreakdownTable } from "./activity-breakdown-table";
@@ -28,6 +29,8 @@ export async function EngagementMetrics({
     previousAccuracy,
     currentAvgTime,
     previousAvgTime,
+    currentCompletionRate,
+    previousCompletionRate,
     currentLearningTime,
     previousLearningTime,
     dailyActive,
@@ -39,6 +42,8 @@ export async function EngagementMetrics({
     getPeriodAccuracyRate(previous.start, previous.end),
     getPeriodAvgActivityTime(current.start, current.end),
     getPeriodAvgActivityTime(previous.start, previous.end),
+    getPeriodCompletionRate(current.start, current.end),
+    getPeriodCompletionRate(previous.start, previous.end),
     getPeriodLearningTime(current.start, current.end),
     getPeriodLearningTime(previous.start, previous.end),
     getDailyActiveLearners(current.start, current.end),
@@ -58,7 +63,7 @@ export async function EngagementMetrics({
 
   return (
     <div className="flex flex-col gap-8">
-      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 lg:grid-cols-5">
         <AdminMetricCard
           change={{ current: currentActiveLearners, period, previous: previousActiveLearners }}
           help="Distinct users with learning activity"
@@ -73,6 +78,14 @@ export async function EngagementMetrics({
           icon={<TargetIcon />}
           title="Accuracy Rate"
           value={`${currentAccuracy.toFixed(1)}%`}
+        />
+
+        <AdminMetricCard
+          change={{ current: currentCompletionRate, period, previous: previousCompletionRate }}
+          help="Activities completed vs started"
+          icon={<CheckCircleIcon />}
+          title="Completion Rate"
+          value={`${currentCompletionRate.toFixed(1)}%`}
         />
 
         <AdminMetricCard
@@ -116,7 +129,8 @@ export async function EngagementMetrics({
 export function EngagementMetricsSkeleton() {
   return (
     <div className="flex flex-col gap-8">
-      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 lg:grid-cols-5">
+        <AdminMetricCardSkeleton />
         <AdminMetricCardSkeleton />
         <AdminMetricCardSkeleton />
         <AdminMetricCardSkeleton />

--- a/apps/admin/src/data/stats/get-avg-time-by-activity-kind.ts
+++ b/apps/admin/src/data/stats/get-avg-time-by-activity-kind.ts
@@ -13,8 +13,7 @@ export const getAvgTimeByActivityKind = cache(async (start: Date, end: Date) => 
       COUNT(*) as started
     FROM activity_progress ap
     JOIN activities a ON a.id = ap.activity_id
-    WHERE ap.duration_seconds IS NOT NULL
-      AND ap.started_at >= ${start} AND ap.started_at <= ${end}
+    WHERE ap.started_at >= ${start} AND ap.started_at <= ${end}
     GROUP BY a.kind
     ORDER BY avg_duration DESC
   `;

--- a/apps/admin/src/data/stats/get-completion-rate.ts
+++ b/apps/admin/src/data/stats/get-completion-rate.ts
@@ -1,0 +1,12 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getCompletionRate = cache(async () => {
+  const [started, completed] = await Promise.all([
+    prisma.activityProgress.count(),
+    prisma.activityProgress.count({ where: { completedAt: { not: null } } }),
+  ]);
+
+  return started === 0 ? 0 : (completed / started) * 100;
+});

--- a/apps/admin/src/data/stats/get-period-completion-rate.ts
+++ b/apps/admin/src/data/stats/get-period-completion-rate.ts
@@ -1,0 +1,14 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export const getPeriodCompletionRate = cache(async (start: Date, end: Date) => {
+  const where = { startedAt: { gte: start, lte: end } };
+
+  const [started, completed] = await Promise.all([
+    prisma.activityProgress.count({ where }),
+    prisma.activityProgress.count({ where: { ...where, completedAt: { not: null } } }),
+  ]);
+
+  return started === 0 ? 0 : (completed / started) * 100;
+});

--- a/apps/main/e2e/activity-start-tracking.test.ts
+++ b/apps/main/e2e/activity-start-tracking.test.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from "node:crypto";
+import { type Browser } from "@playwright/test";
+import { prisma } from "@zoonk/db";
+import { request } from "@zoonk/e2e/fixtures";
+import { getAiOrganization } from "@zoonk/e2e/helpers";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { expect, test } from "./fixtures";
+
+async function createUniqueUser(baseURL: string) {
+  const uniqueId = randomUUID().slice(0, 8);
+  const email = `e2e-start-${uniqueId}@zoonk.test`;
+
+  const signupContext = await request.newContext({ baseURL });
+  const response = await signupContext.post("/api/auth/sign-up/email", {
+    data: { email, name: `E2E Start ${uniqueId}`, password: "password123" },
+  });
+
+  expect(response.ok()).toBe(true);
+  await signupContext.dispose();
+
+  return email;
+}
+
+async function createAuthenticatedPage(browser: Browser, baseURL: string, email: string) {
+  const context = await request.newContext({ baseURL });
+
+  await context.post("/api/auth/sign-in/email", {
+    data: { email, password: "password123" },
+  });
+
+  const storageState = await context.storageState();
+  await context.dispose();
+
+  const browserContext = await browser.newContext({ storageState });
+  const page = await browserContext.newPage();
+
+  return { browserContext, page };
+}
+
+async function createTestActivity() {
+  const org = await getAiOrganization();
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-start-course-${uniqueId}`,
+    title: `E2E Start Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-start-chapter-${uniqueId}`,
+    title: `E2E Start Chapter ${uniqueId}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-start-lesson-${uniqueId}`,
+    title: `E2E Start Lesson ${uniqueId}`,
+  });
+
+  const activity = await activityFixture({
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "background",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 0,
+  });
+
+  await stepFixture({
+    activityId: activity.id,
+    content: { text: `Step content ${uniqueId}`, title: `Step ${uniqueId}`, variant: "text" },
+    isPublished: true,
+    position: 0,
+  });
+
+  const url = `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/0`;
+
+  return { activity, url };
+}
+
+test.describe("Activity Start Tracking", () => {
+  test("authenticated user visiting activity page creates start record", async ({
+    baseURL,
+    browser,
+  }) => {
+    const [email, { activity, url }] = await Promise.all([
+      createUniqueUser(baseURL!),
+      createTestActivity(),
+    ]);
+
+    const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
+
+    const user = await prisma.user.findFirst({ where: { email } });
+    expect(user).not.toBeNull();
+    const userId = Number(user!.id);
+
+    const before = await prisma.activityProgress.findUnique({
+      where: { userActivity: { activityId: activity.id, userId } },
+    });
+    expect(before).toBeNull();
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    // after() runs asynchronously — use toPass retry pattern
+    await expect(async () => {
+      const progress = await prisma.activityProgress.findUnique({
+        where: { userActivity: { activityId: activity.id, userId } },
+      });
+
+      expect(progress).not.toBeNull();
+      expect(progress?.completedAt).toBeNull();
+      expect(progress?.durationSeconds).toBeNull();
+    }).toPass({ timeout: 5000 });
+
+    await browserContext.close();
+  });
+
+  test("guest user visiting activity page does not create start record", async ({ page }) => {
+    const { activity, url } = await createTestActivity();
+
+    await page.goto(url);
+    await expect(page.getByRole("link", { name: /close/i })).toBeVisible();
+
+    const progress = await prisma.activityProgress.findFirst({
+      where: { activityId: activity.id },
+    });
+
+    expect(progress).toBeNull();
+  });
+});

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
@@ -3,6 +3,7 @@ import { getLessonSentences } from "@/data/activities/get-lesson-sentences";
 import { getLessonWords } from "@/data/activities/get-lesson-words";
 import { getReviewSteps } from "@/data/activities/get-review-steps";
 import { getLesson } from "@/data/lessons/get-lesson";
+import { startActivity } from "@/data/progress/start-activity";
 import { getActivitySeoMeta } from "@/lib/activities";
 import { getNextActivityInCourse } from "@zoonk/core/activities/next-in-course";
 import { getSession } from "@zoonk/core/users/session/get";
@@ -10,6 +11,7 @@ import { prepareActivityData } from "@zoonk/player/prepare-activity-data";
 import { parseNumericId } from "@zoonk/utils/string";
 import { type Metadata } from "next";
 import { notFound } from "next/navigation";
+import { after } from "next/server";
 import { ActivityNotGenerated } from "./activity-not-generated";
 import { ActivityPlayerClient } from "./activity-player-client";
 
@@ -94,6 +96,10 @@ export default async function ActivityPage({ params }: Props) {
     lessonWords,
     lessonSentences,
   );
+
+  if (session) {
+    after(() => startActivity(Number(session.user.id), activity.id));
+  }
 
   return (
     <ActivityPlayerClient

--- a/apps/main/src/data/progress/start-activity.test.ts
+++ b/apps/main/src/data/progress/start-activity.test.ts
@@ -1,0 +1,83 @@
+import { prisma } from "@zoonk/db";
+import { activityFixture, activityProgressFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { beforeAll, describe, expect, test } from "vitest";
+import { startActivity } from "./start-activity";
+
+describe(startActivity, () => {
+  let activity: Awaited<ReturnType<typeof activityFixture>>;
+
+  beforeAll(async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({ organizationId: org.id });
+    const chapter = await chapterFixture({ courseId: course.id, organizationId: org.id });
+    const lesson = await lessonFixture({ chapterId: chapter.id, organizationId: org.id });
+
+    activity = await activityFixture({
+      kind: "quiz",
+      lessonId: lesson.id,
+      organizationId: org.id,
+    });
+  });
+
+  test("creates ActivityProgress with completedAt null and durationSeconds null", async () => {
+    const user = await userFixture();
+    const userId = Number(user.id);
+
+    await startActivity(userId, activity.id);
+
+    const progress = await prisma.activityProgress.findUnique({
+      where: { userActivity: { activityId: activity.id, userId } },
+    });
+
+    expect(progress).not.toBeNull();
+    expect(progress?.completedAt).toBeNull();
+    expect(progress?.durationSeconds).toBeNull();
+    expect(progress?.startedAt).toBeInstanceOf(Date);
+  });
+
+  test("idempotent: second call preserves original startedAt", async () => {
+    const user = await userFixture();
+    const userId = Number(user.id);
+
+    await startActivity(userId, activity.id);
+
+    const first = await prisma.activityProgress.findUnique({
+      where: { userActivity: { activityId: activity.id, userId } },
+    });
+
+    await startActivity(userId, activity.id);
+
+    const second = await prisma.activityProgress.findUnique({
+      where: { userActivity: { activityId: activity.id, userId } },
+    });
+
+    expect(second?.startedAt).toEqual(first?.startedAt);
+  });
+
+  test("does not overwrite a completed record", async () => {
+    const user = await userFixture();
+    const userId = Number(user.id);
+    const completedAt = new Date();
+
+    await activityProgressFixture({
+      activityId: activity.id,
+      completedAt,
+      durationSeconds: 30,
+      userId,
+    });
+
+    await startActivity(userId, activity.id);
+
+    const progress = await prisma.activityProgress.findUnique({
+      where: { userActivity: { activityId: activity.id, userId } },
+    });
+
+    expect(progress?.completedAt).toEqual(completedAt);
+    expect(progress?.durationSeconds).toBe(30);
+  });
+});

--- a/apps/main/src/data/progress/start-activity.ts
+++ b/apps/main/src/data/progress/start-activity.ts
@@ -1,0 +1,10 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+
+export async function startActivity(userId: number, activityId: bigint): Promise<void> {
+  await prisma.activityProgress.upsert({
+    create: { activityId, userId },
+    update: {},
+    where: { userActivity: { activityId, userId } },
+  });
+}

--- a/apps/main/src/data/progress/submit-activity-completion.test.ts
+++ b/apps/main/src/data/progress/submit-activity-completion.test.ts
@@ -507,6 +507,42 @@ describe(submitActivityCompletion, () => {
     expect(decayRecords).toHaveLength(0);
   });
 
+  test("completes a pre-started record: sets completedAt and durationSeconds, preserves startedAt", async () => {
+    const user = await userFixture();
+    const userId = Number(user.id);
+
+    // Simulate startActivity() creating a start-only record
+    await prisma.activityProgress.create({
+      data: { activityId: activity.id, userId },
+    });
+
+    const startRecord = await prisma.activityProgress.findUnique({
+      where: { userActivity: { activityId: activity.id, userId } },
+    });
+
+    expect(startRecord?.completedAt).toBeNull();
+
+    await submitActivityCompletion({
+      activityId: activity.id,
+      courseId: course.id,
+      durationSeconds: 20,
+      isChallenge: false,
+      organizationId: org.id,
+      score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
+      startedAt: new Date(Date.now() - 20_000),
+      stepResults: [stepResult(true)],
+      userId,
+    });
+
+    const progress = await prisma.activityProgress.findUnique({
+      where: { userActivity: { activityId: activity.id, userId } },
+    });
+
+    expect(progress?.completedAt).not.toBeNull();
+    expect(progress?.durationSeconds).toBe(20);
+    expect(progress?.startedAt).toEqual(startRecord?.startedAt);
+  });
+
   test("applies decay and fills DailyProgress gaps for inactive days", async () => {
     const user = await userFixture();
     const userId = Number(user.id);


### PR DESCRIPTION
## Summary
- Record `ActivityProgress` when authenticated users visit an activity page (via `after()`, non-blocking)
- Add completion rate metric to admin dashboard and engagement detail page
- Fix `getAvgTimeByActivityKind` query to include started-but-not-completed records

## Test plan
- [x] Integration tests for `startActivity` (idempotent, doesn't overwrite completed records)
- [x] Integration test for completing a pre-started record
- [x] E2E tests for authenticated start tracking and guest non-tracking
- [x] All existing E2E tests pass (main: 380, editor: 193, api: 56)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tracks activity starts for authenticated users and adds completion rate metrics to the admin dashboard and engagement views. Start tracking runs via after() so it doesn’t block page load.

- **New Features**
  - Create ActivityProgress on activity page visit for signed-in users (non-blocking).
  - Add “Completion Rate” to Engagement & Learning and period-based engagement metrics.
  - Do not record starts for guests.

- **Bug Fixes**
  - Update getAvgTimeByActivityKind to include started-but-not-completed records.

<sup>Written for commit 0216b3f73e7049587339b9235fe604e35607c26b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

