### PR TITLE
feat(admin): add editing capabilities to flagged review items

### DIFF
--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -7,6 +7,9 @@ const nextConfig: NextConfig = {
   devIndicators: false,
   experimental: {
     authInterrupts: true,
+    serverActions: {
+      bodySizeLimit: "10mb",
+    },
     typedEnv: true,
   },
   images: {

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/approve-flagged.ts
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/approve-flagged.ts
@@ -1,0 +1,38 @@
+"use server";
+
+import { assertAdmin } from "@/lib/admin-guard";
+import { type ReviewTaskType, getTaskPath, isValidTaskType } from "@/lib/review-utils";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { parseBigIntId } from "@zoonk/utils/string";
+import { redirect } from "next/navigation";
+
+export async function approveFlaggedAction(taskType: ReviewTaskType, rawEntityId: string) {
+  const session = await assertAdmin();
+
+  if (!isValidTaskType(taskType)) {
+    throw new Error("Invalid task type");
+  }
+
+  const entityId = parseBigIntId(rawEntityId);
+
+  if (!entityId) {
+    throw new Error("Invalid entity ID");
+  }
+
+  const userId = Number(session.user.id);
+
+  const { error } = await safeAsync(() =>
+    prisma.contentReview.upsert({
+      create: { entityId, status: "approved", taskType, userId },
+      update: { reviewedAt: new Date(), status: "approved", userId },
+      where: { taskEntity: { entityId, taskType } },
+    }),
+  );
+
+  if (error) {
+    throw error;
+  }
+
+  redirect(`${getTaskPath(taskType)}?view=flagged`);
+}

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/course-suggestion.ts
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/course-suggestion.ts
@@ -1,0 +1,110 @@
+"use server";
+
+import { assertAdmin } from "@/lib/admin-guard";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { parseFormField } from "@zoonk/utils/form";
+import { toSlug } from "@zoonk/utils/string";
+import { revalidatePath } from "next/cache";
+
+export async function updateCourseSuggestionAction(formData: FormData) {
+  await assertAdmin();
+
+  const suggestionIdRaw = parseFormField(formData, "suggestionId");
+  const title = parseFormField(formData, "title");
+  const description = parseFormField(formData, "description");
+
+  if (!suggestionIdRaw || !title || !description) {
+    throw new Error("Invalid form data");
+  }
+
+  const suggestionId = Number(suggestionIdRaw);
+
+  const { error } = await safeAsync(() =>
+    prisma.courseSuggestion.update({
+      data: { description, slug: toSlug(title), title },
+      where: { id: suggestionId },
+    }),
+  );
+
+  if (error) {
+    throw error;
+  }
+
+  revalidatePath("/review");
+}
+
+export async function removeCourseSuggestionAction(formData: FormData) {
+  await assertAdmin();
+
+  const searchPromptIdRaw = parseFormField(formData, "searchPromptId");
+  const courseSuggestionIdRaw = parseFormField(formData, "courseSuggestionId");
+
+  if (!searchPromptIdRaw || !courseSuggestionIdRaw) {
+    throw new Error("Invalid form data");
+  }
+
+  const searchPromptId = Number(searchPromptIdRaw);
+  const courseSuggestionId = Number(courseSuggestionIdRaw);
+
+  const { error } = await safeAsync(() =>
+    prisma.searchPromptSuggestion.delete({
+      where: { promptSuggestion: { courseSuggestionId, searchPromptId } },
+    }),
+  );
+
+  if (error) {
+    throw error;
+  }
+
+  revalidatePath("/review");
+}
+
+export async function addCourseSuggestionAction(formData: FormData) {
+  await assertAdmin();
+
+  const searchPromptIdRaw = parseFormField(formData, "searchPromptId");
+  const title = parseFormField(formData, "title");
+  const description = parseFormField(formData, "description");
+  const language = parseFormField(formData, "language");
+  const targetLanguage = parseFormField(formData, "targetLanguage");
+
+  const searchPromptId = searchPromptIdRaw ? Number(searchPromptIdRaw) : null;
+
+  if (!searchPromptId || !title || !description || !language) {
+    throw new Error("Invalid form data");
+  }
+
+  const { error } = await safeAsync(async () => {
+    const maxPosition = await prisma.searchPromptSuggestion.aggregate({
+      _max: { position: true },
+      where: { searchPromptId },
+    });
+
+    const position = (maxPosition._max.position ?? -1) + 1;
+
+    const slug = toSlug(title);
+
+    const suggestion = await prisma.courseSuggestion.upsert({
+      create: {
+        description,
+        language,
+        slug,
+        targetLanguage: targetLanguage || null,
+        title,
+      },
+      update: { description, title },
+      where: { languageSlug: { language, slug } },
+    });
+
+    await prisma.searchPromptSuggestion.create({
+      data: { courseSuggestionId: suggestion.id, position, searchPromptId },
+    });
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  revalidatePath("/review");
+}

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/step-image.ts
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/step-image.ts
@@ -1,0 +1,85 @@
+"use server";
+
+import { isAdmin } from "@/lib/admin-guard";
+import { processAndUploadImage } from "@zoonk/core/images/process-and-upload";
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
+import { parseVisualContent } from "@zoonk/core/steps/visual-content-contract";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { parseBigIntId } from "@zoonk/utils/string";
+import { revalidatePath } from "next/cache";
+
+export async function uploadStepImageAction(
+  params: {
+    stepId: string;
+    imageTarget: "visual" | number;
+  },
+  formData: FormData,
+): Promise<{ error: string | null }> {
+  if (!(await isAdmin())) {
+    return { error: "Unauthorized" };
+  }
+
+  const stepId = parseBigIntId(params.stepId);
+
+  if (!stepId) {
+    return { error: "Invalid step ID" };
+  }
+
+  const { imageTarget } = params;
+  const file = formData.get("file");
+
+  if (!(file && file instanceof File)) {
+    return { error: "No file provided" };
+  }
+
+  const targetLabel = imageTarget === "visual" ? "visual" : `option-${imageTarget}`;
+  const { data: imageUrl, error: uploadError } = await processAndUploadImage({
+    file,
+    fileName: `steps/admin-review/${stepId}-${targetLabel}.webp`,
+  });
+
+  if (uploadError) {
+    const errorMessages: Record<typeof uploadError, string> = {
+      invalidType: "Invalid file type. Please upload a JPEG, PNG, WebP, or GIF image.",
+      optimizeFailed: "Failed to process image. Please try again.",
+      tooLarge: "File is too large. Maximum size is 5MB.",
+      uploadFailed: "Failed to upload image. Please try again.",
+    };
+
+    return { error: errorMessages[uploadError] };
+  }
+
+  const step = await prisma.step.findUnique({ where: { id: stepId } });
+
+  if (!step) {
+    return { error: "Step not found" };
+  }
+
+  const { error: updateError } = await safeAsync(() => {
+    if (imageTarget === "visual") {
+      const visual = parseVisualContent("image", step.visualContent);
+      return prisma.step.update({
+        data: { visualContent: { ...visual, url: imageUrl } },
+        where: { id: stepId },
+      });
+    }
+
+    const content = parseStepContent("selectImage", step.content);
+    const updatedOptions = content.options.map((option, index) =>
+      index === imageTarget ? { ...option, url: imageUrl } : option,
+    );
+
+    return prisma.step.update({
+      data: { content: { ...content, options: updatedOptions } },
+      where: { id: stepId },
+    });
+  });
+
+  if (updateError) {
+    return { error: "Failed to update step. Please try again." };
+  }
+
+  revalidatePath("/review");
+  return { error: null };
+}

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/course-suggestion-edit.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/course-suggestion-edit.tsx
@@ -1,0 +1,103 @@
+import { type getCourseSuggestionReview } from "@/data/review/get-review-item";
+import { Badge } from "@zoonk/ui/components/badge";
+import { Input } from "@zoonk/ui/components/input";
+import { Textarea } from "@zoonk/ui/components/textarea";
+import { SubmitButton } from "@zoonk/ui/patterns/buttons/submit";
+import {
+  addCourseSuggestionAction,
+  updateCourseSuggestionAction,
+} from "./_actions/course-suggestion";
+import { RemoveSuggestionButton } from "./remove-suggestion-button";
+
+type CourseSuggestionReviewData = NonNullable<
+  Awaited<ReturnType<typeof getCourseSuggestionReview>>
+>;
+
+function SuggestionForm({
+  suggestion,
+  searchPromptId,
+}: {
+  suggestion: CourseSuggestionReviewData["suggestions"][number]["courseSuggestion"];
+  searchPromptId: number;
+}) {
+  return (
+    <div className="flex flex-col gap-3 border-b pb-4 last:border-b-0">
+      <form action={updateCourseSuggestionAction} className="flex flex-col gap-3">
+        <input type="hidden" name="suggestionId" value={suggestion.id} />
+
+        <Input name="title" defaultValue={suggestion.title} aria-label="Title" />
+
+        <Textarea
+          name="description"
+          defaultValue={suggestion.description}
+          rows={3}
+          aria-label="Description"
+        />
+
+        <div className="flex items-center justify-between">
+          <SubmitButton className="self-start">Save</SubmitButton>
+
+          <RemoveSuggestionButton
+            searchPromptId={searchPromptId}
+            courseSuggestionId={suggestion.id}
+          />
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function AddSuggestionForm({
+  searchPromptId,
+  language,
+}: {
+  searchPromptId: number;
+  language: string;
+}) {
+  return (
+    <form action={addCourseSuggestionAction} className="flex flex-col gap-3 border-t pt-4">
+      <h3 className="text-sm font-medium">Add suggestion</h3>
+
+      <input type="hidden" name="searchPromptId" value={searchPromptId} />
+      <input type="hidden" name="language" value={language} />
+
+      <Input name="title" placeholder="Title" aria-label="New suggestion title" />
+
+      <Textarea
+        name="description"
+        placeholder="Description"
+        rows={3}
+        aria-label="New suggestion description"
+      />
+
+      <SubmitButton className="self-start">Add</SubmitButton>
+    </form>
+  );
+}
+
+export function CourseSuggestionEdit({ item }: { item: CourseSuggestionReviewData }) {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-2xl font-semibold">{item.prompt}</h2>
+        <Badge variant="outline">{item.language}</Badge>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        <h3 className="text-muted-foreground text-sm font-medium tracking-wider uppercase">
+          Suggestions ({item.suggestions.length})
+        </h3>
+
+        {item.suggestions.map(({ courseSuggestion }) => (
+          <SuggestionForm
+            key={courseSuggestion.id}
+            suggestion={courseSuggestion}
+            searchPromptId={item.id}
+          />
+        ))}
+      </div>
+
+      <AddSuggestionForm searchPromptId={item.id} language={item.language} />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/flagged-item-actions.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/flagged-item-actions.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { type ReviewTaskType } from "@/lib/review-utils";
+import { Button } from "@zoonk/ui/components/button";
+import { SubmitButton } from "@zoonk/ui/patterns/buttons/submit";
+import { unflagAction } from "../unflag-action";
+import { approveFlaggedAction } from "./_actions/approve-flagged";
+
+export function FlaggedItemActions({
+  taskType,
+  entityId,
+}: {
+  taskType: ReviewTaskType;
+  entityId: string;
+}) {
+  return (
+    <div className="flex items-center justify-between pt-4">
+      <form action={unflagAction}>
+        <input type="hidden" name="taskType" value={taskType} />
+        <input type="hidden" name="entityId" value={entityId} />
+        <Button variant="outline" type="submit">
+          Return to queue
+        </Button>
+      </form>
+
+      <form action={approveFlaggedAction.bind(null, taskType, entityId)}>
+        <SubmitButton>Mark as approved</SubmitButton>
+      </form>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/flagged-item-content.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/flagged-item-content.tsx
@@ -1,0 +1,58 @@
+import { getCourseSuggestionReview, getStepVisualReview } from "@/data/review/get-review-item";
+import { type ReviewTaskType, getVisualKindFromTaskType } from "@/lib/review-utils";
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
+import { parseVisualContent } from "@zoonk/core/steps/visual-content-contract";
+import { notFound } from "next/navigation";
+import { CourseSuggestionEdit } from "./course-suggestion-edit";
+import { StepSelectImageEdit } from "./step-select-image-edit";
+import { StepVisualImageEdit } from "./step-visual-image-edit";
+
+export async function FlaggedItemContent({
+  taskType,
+  entityId,
+}: {
+  taskType: ReviewTaskType;
+  entityId: bigint;
+}) {
+  const visualKind = getVisualKindFromTaskType(taskType);
+
+  if (visualKind) {
+    const step = await getStepVisualReview(entityId);
+
+    if (!step) {
+      notFound();
+    }
+
+    const visual = parseVisualContent("image", step.visualContent);
+    return (
+      <StepVisualImageEdit
+        item={{ activity: step.activity, id: step.id.toString(), visualContent: visual }}
+      />
+    );
+  }
+
+  if (taskType === "stepSelectImage") {
+    const step = await getStepVisualReview(entityId);
+
+    if (!step) {
+      notFound();
+    }
+
+    const content = parseStepContent("selectImage", step.content);
+    return (
+      <StepSelectImageEdit item={{ activity: step.activity, content, id: step.id.toString() }} />
+    );
+  }
+
+  if (taskType === "courseSuggestions") {
+    const item = await getCourseSuggestionReview(entityId);
+
+    if (!item) {
+      notFound();
+    }
+
+    return <CourseSuggestionEdit item={item} />;
+  }
+
+  notFound();
+}

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/page.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/page.tsx
@@ -1,0 +1,99 @@
+import {
+  type ReviewTaskType,
+  getTaskLabel,
+  getTaskPath,
+  resolveTaskType,
+} from "@/lib/review-utils";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@zoonk/ui/components/breadcrumb";
+import {
+  Container,
+  ContainerBody,
+  ContainerHeader,
+  ContainerHeaderGroup,
+} from "@zoonk/ui/components/container";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { parseBigIntId } from "@zoonk/utils/string";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import { FlaggedItemActions } from "./flagged-item-actions";
+import { FlaggedItemContent } from "./flagged-item-content";
+
+function FlaggedItemBreadcrumb({
+  taskType,
+  entityId,
+}: {
+  taskType: ReviewTaskType;
+  entityId: string;
+}) {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink render={<Link href="/review" />}>Review</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink render={<Link href={`${getTaskPath(taskType)}?view=flagged`} />}>
+            {getTaskLabel(taskType)}
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>{entityId}</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}
+
+function ContentSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Skeleton className="h-4 w-32" />
+      <Skeleton className="mt-4 h-48 w-full" />
+    </div>
+  );
+}
+
+export default async function FlaggedItemPage({
+  params,
+}: PageProps<"/review/[group]/[task]/[entityId]">) {
+  const { group, task, entityId: rawEntityId } = await params;
+  const taskType = resolveTaskType(String(group), String(task));
+
+  if (!taskType) {
+    notFound();
+  }
+
+  const entityId = parseBigIntId(String(rawEntityId));
+
+  if (!entityId) {
+    notFound();
+  }
+
+  return (
+    <Container>
+      <ContainerHeader variant="sidebar">
+        <ContainerHeaderGroup>
+          <FlaggedItemBreadcrumb taskType={taskType} entityId={entityId.toString()} />
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody className="max-w-2xl gap-8">
+        <Suspense fallback={<ContentSkeleton />}>
+          <FlaggedItemContent taskType={taskType} entityId={entityId} />
+        </Suspense>
+
+        <FlaggedItemActions taskType={taskType} entityId={entityId.toString()} />
+      </ContainerBody>
+    </Container>
+  );
+}

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/remove-suggestion-button.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/remove-suggestion-button.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@zoonk/ui/components/alert-dialog";
+import { Button } from "@zoonk/ui/components/button";
+import { useTransition } from "react";
+import { removeCourseSuggestionAction } from "./_actions/course-suggestion";
+
+export function RemoveSuggestionButton({
+  searchPromptId,
+  courseSuggestionId,
+}: {
+  searchPromptId: number;
+  courseSuggestionId: number;
+}) {
+  const [pending, startTransition] = useTransition();
+
+  function handleRemove() {
+    startTransition(async () => {
+      const formData = new FormData();
+      formData.append("searchPromptId", String(searchPromptId));
+      formData.append("courseSuggestionId", String(courseSuggestionId));
+      await removeCourseSuggestionAction(formData);
+    });
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger
+        render={
+          <Button variant="destructive" disabled={pending} type="button">
+            Remove
+          </Button>
+        }
+      />
+
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remove suggestion</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will unlink this suggestion from the search prompt. This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" onClick={handleRemove}>
+            Remove
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/step-select-image-edit.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/step-select-image-edit.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Badge } from "@zoonk/ui/components/badge";
+import {
+  ImageUploadActionButton,
+  ImageUploadLoading,
+  ImageUploadOverlay,
+  ImageUploadPlaceholder,
+  ImageUploadProvider,
+  ImageUploadTrigger,
+} from "@zoonk/ui/components/image-upload";
+import { ImageIcon, UploadIcon } from "lucide-react";
+import Image from "next/image";
+import { uploadStepImageAction } from "./_actions/step-image";
+
+const noopRemove = async () => ({ error: null });
+
+function SelectImageOption({
+  option,
+  index,
+  stepId,
+}: {
+  option: { prompt: string; url?: string; feedback: string; isCorrect: boolean };
+  index: number;
+  stepId: string;
+}) {
+  const params = { imageTarget: index, stepId };
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border p-3">
+      <ImageUploadProvider
+        currentImageUrl={option.url ?? null}
+        onRemove={noopRemove}
+        onUpload={uploadStepImageAction.bind(null, params)}
+      >
+        <ImageUploadTrigger
+          aria-label={
+            option.url
+              ? `Replace image for "${option.prompt}"`
+              : `Upload image for "${option.prompt}"`
+          }
+          className="aspect-square w-full"
+          size={undefined}
+        >
+          {option.url ? (
+            <Image
+              alt={option.prompt}
+              className="object-contain transition-opacity group-hover:opacity-80"
+              fill
+              sizes="300px"
+              src={option.url}
+            />
+          ) : (
+            <ImageUploadPlaceholder>
+              <ImageIcon />
+            </ImageUploadPlaceholder>
+          )}
+
+          <ImageUploadOverlay>
+            <ImageUploadActionButton>
+              <UploadIcon />
+            </ImageUploadActionButton>
+          </ImageUploadOverlay>
+
+          <ImageUploadLoading />
+        </ImageUploadTrigger>
+      </ImageUploadProvider>
+
+      <p className="text-muted-foreground text-sm">{option.prompt}</p>
+      <p className="text-muted-foreground text-xs italic">{option.feedback}</p>
+
+      <Badge variant={option.isCorrect ? "default" : "outline"}>
+        {option.isCorrect ? "Correct" : "Incorrect"}
+      </Badge>
+    </div>
+  );
+}
+
+export function StepSelectImageEdit({
+  item,
+}: {
+  item: {
+    id: string;
+    content: {
+      question: string;
+      options: { prompt: string; url?: string; feedback: string; isCorrect: boolean }[];
+    };
+    activity: { title: string | null };
+  };
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <Badge variant="outline">selectImage</Badge>
+        <span className="text-muted-foreground text-sm">{item.activity.title}</span>
+      </div>
+
+      <p className="text-lg font-medium">{item.content.question}</p>
+
+      <div className="grid grid-cols-2 gap-4">
+        {item.content.options.map((option, index) => (
+          <SelectImageOption key={option.prompt} option={option} index={index} stepId={item.id} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/step-visual-image-edit.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/step-visual-image-edit.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Badge } from "@zoonk/ui/components/badge";
+import {
+  ImageUploadActionButton,
+  ImageUploadLoading,
+  ImageUploadOverlay,
+  ImageUploadPlaceholder,
+  ImageUploadProvider,
+  ImageUploadTrigger,
+} from "@zoonk/ui/components/image-upload";
+import { ImageIcon, UploadIcon } from "lucide-react";
+import Image from "next/image";
+import { uploadStepImageAction } from "./_actions/step-image";
+
+const noopRemove = async () => ({ error: null });
+
+export function StepVisualImageEdit({
+  item,
+}: {
+  item: {
+    id: string;
+    visualContent: { prompt: string; url?: string };
+    activity: { title: string | null };
+  };
+}) {
+  const params = { imageTarget: "visual" as const, stepId: item.id };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <Badge variant="outline">image</Badge>
+        <span className="text-muted-foreground text-sm">{item.activity.title}</span>
+      </div>
+
+      <p className="text-muted-foreground font-mono text-sm">{item.visualContent.prompt}</p>
+
+      <ImageUploadProvider
+        currentImageUrl={item.visualContent.url ?? null}
+        onRemove={noopRemove}
+        onUpload={uploadStepImageAction.bind(null, params)}
+      >
+        <ImageUploadTrigger
+          aria-label={item.visualContent.url ? "Replace image" : "Upload image"}
+          className="h-96 w-full max-w-150"
+          size={undefined}
+        >
+          {item.visualContent.url ? (
+            <Image
+              alt={item.visualContent.prompt}
+              className="object-contain transition-opacity group-hover:opacity-80"
+              fill
+              sizes="600px"
+              src={item.visualContent.url}
+            />
+          ) : (
+            <ImageUploadPlaceholder>
+              <ImageIcon />
+            </ImageUploadPlaceholder>
+          )}
+
+          <ImageUploadOverlay>
+            <ImageUploadActionButton>
+              <UploadIcon />
+            </ImageUploadActionButton>
+          </ImageUploadOverlay>
+
+          <ImageUploadLoading />
+        </ImageUploadTrigger>
+      </ImageUploadProvider>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/review/[group]/[task]/flagged-list.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/flagged-list.tsx
@@ -10,32 +10,28 @@ import {
   TableHeader,
   TableRow,
 } from "@zoonk/ui/components/table";
-import { SubmitButton } from "@zoonk/ui/patterns/buttons/submit";
-import { unflagAction } from "./unflag-action";
+import Link from "next/link";
 
 function FlaggedRow({
   entityId,
   flaggedBy,
   flaggedAt,
-  taskType,
+  taskPath,
 }: {
   entityId: string;
   flaggedBy: string;
   flaggedAt: string;
-  taskType: string;
+  taskPath: string;
 }) {
   return (
     <TableRow>
-      <TableCell>{entityId}</TableCell>
+      <TableCell>
+        <Link href={`${taskPath}/${entityId}`} className="underline">
+          {entityId}
+        </Link>
+      </TableCell>
       <TableCell>{flaggedBy}</TableCell>
       <TableCell>{flaggedAt}</TableCell>
-      <TableCell>
-        <form action={unflagAction}>
-          <input type="hidden" name="taskType" value={taskType} />
-          <input type="hidden" name="entityId" value={entityId} />
-          <SubmitButton>Return to queue</SubmitButton>
-        </form>
-      </TableCell>
     </TableRow>
   );
 }
@@ -56,6 +52,8 @@ export async function FlaggedList({
   });
   const totalPages = Math.ceil(total / limit);
 
+  const taskPath = getTaskPath(taskType);
+
   if (items.length === 0) {
     return <p className="text-muted-foreground text-sm">No flagged items.</p>;
   }
@@ -69,7 +67,6 @@ export async function FlaggedList({
               <TableHead>Entity ID</TableHead>
               <TableHead>Flagged by</TableHead>
               <TableHead>Date</TableHead>
-              <TableHead />
             </TableRow>
           </TableHeader>
 
@@ -80,7 +77,7 @@ export async function FlaggedList({
                 entityId={item.entityId.toString()}
                 flaggedBy={item.user.name}
                 flaggedAt={item.reviewedAt.toLocaleDateString()}
-                taskType={item.taskType}
+                taskPath={taskPath}
               />
             ))}
           </TableBody>
@@ -88,7 +85,7 @@ export async function FlaggedList({
       </div>
 
       <AdminPagination
-        basePath={`${getTaskPath(taskType)}?view=flagged`}
+        basePath={`${taskPath}?view=flagged`}
         limit={limit}
         page={page}
         totalPages={totalPages}

--- a/apps/admin/src/app/(private)/review/[group]/[task]/unflag-action.ts
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/unflag-action.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getSession } from "@zoonk/core/users/session/get";
+import { assertAdmin } from "@/lib/admin-guard";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
@@ -8,11 +8,7 @@ import { parseBigIntId } from "@zoonk/utils/string";
 import { revalidatePath } from "next/cache";
 
 export async function unflagAction(formData: FormData) {
-  const session = await getSession();
-
-  if (session?.user.role !== "admin") {
-    throw new Error("Unauthorized");
-  }
+  await assertAdmin();
 
   const taskType = parseFormField(formData, "taskType");
   const entityIdRaw = parseFormField(formData, "entityId");

--- a/apps/admin/src/app/(private)/review/_actions/mark-needs-changes.ts
+++ b/apps/admin/src/app/(private)/review/_actions/mark-needs-changes.ts
@@ -1,8 +1,8 @@
 "use server";
 
 import { getNextReviewItem } from "@/data/review/get-next-review-item";
+import { assertAdmin } from "@/lib/admin-guard";
 import { getTaskPath, isValidTaskType } from "@/lib/review-utils";
-import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
@@ -10,11 +10,7 @@ import { parseBigIntId } from "@zoonk/utils/string";
 import { redirect } from "next/navigation";
 
 export async function markNeedsChangesAction(formData: FormData) {
-  const session = await getSession();
-
-  if (session?.user.role !== "admin") {
-    throw new Error("Unauthorized");
-  }
+  const session = await assertAdmin();
 
   const taskType = parseFormField(formData, "taskType");
   const entityIdRaw = parseFormField(formData, "entityId");

--- a/apps/admin/src/app/(private)/review/_actions/mark-reviewed.ts
+++ b/apps/admin/src/app/(private)/review/_actions/mark-reviewed.ts
@@ -1,8 +1,8 @@
 "use server";
 
 import { getNextReviewItem } from "@/data/review/get-next-review-item";
+import { assertAdmin } from "@/lib/admin-guard";
 import { getTaskPath, isValidTaskType } from "@/lib/review-utils";
-import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
@@ -10,11 +10,7 @@ import { parseBigIntId } from "@zoonk/utils/string";
 import { redirect } from "next/navigation";
 
 export async function markReviewedAction(formData: FormData) {
-  const session = await getSession();
-
-  if (session?.user.role !== "admin") {
-    throw new Error("Unauthorized");
-  }
+  const session = await assertAdmin();
 
   const taskType = parseFormField(formData, "taskType");
   const entityIdRaw = parseFormField(formData, "entityId");

--- a/apps/admin/src/app/(private)/users/[id]/_actions/ban-user.ts
+++ b/apps/admin/src/app/(private)/users/[id]/_actions/ban-user.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getSession } from "@zoonk/core/users/session/get";
+import { assertAdmin } from "@/lib/admin-guard";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
@@ -8,11 +8,7 @@ import { parseNumericId } from "@zoonk/utils/string";
 import { revalidatePath } from "next/cache";
 
 export async function banUserAction(formData: FormData) {
-  const session = await getSession();
-
-  if (session?.user.role !== "admin") {
-    throw new Error("Unauthorized");
-  }
+  await assertAdmin();
 
   const userIdRaw = parseFormField(formData, "userId");
   const userId = userIdRaw ? parseNumericId(userIdRaw) : null;

--- a/apps/admin/src/app/(private)/users/[id]/_actions/change-plan.ts
+++ b/apps/admin/src/app/(private)/users/[id]/_actions/change-plan.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getSession } from "@zoonk/core/users/session/get";
+import { assertAdmin } from "@/lib/admin-guard";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
@@ -8,11 +8,7 @@ import { parseNumericId } from "@zoonk/utils/string";
 import { revalidatePath } from "next/cache";
 
 export async function changePlanAction(formData: FormData) {
-  const session = await getSession();
-
-  if (session?.user.role !== "admin") {
-    throw new Error("Unauthorized");
-  }
+  await assertAdmin();
 
   const userIdRaw = parseFormField(formData, "userId");
   const userId = userIdRaw ? parseNumericId(userIdRaw) : null;

--- a/apps/admin/src/app/(private)/users/[id]/_actions/revoke-sessions.ts
+++ b/apps/admin/src/app/(private)/users/[id]/_actions/revoke-sessions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getSession } from "@zoonk/core/users/session/get";
+import { assertAdmin } from "@/lib/admin-guard";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
@@ -8,11 +8,7 @@ import { parseNumericId } from "@zoonk/utils/string";
 import { revalidatePath } from "next/cache";
 
 export async function revokeSessionsAction(formData: FormData) {
-  const session = await getSession();
-
-  if (session?.user.role !== "admin") {
-    throw new Error("Unauthorized");
-  }
+  await assertAdmin();
 
   const userIdRaw = parseFormField(formData, "userId");
   const userId = userIdRaw ? parseNumericId(userIdRaw) : null;

--- a/apps/admin/src/app/(private)/users/[id]/_actions/unban-user.ts
+++ b/apps/admin/src/app/(private)/users/[id]/_actions/unban-user.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getSession } from "@zoonk/core/users/session/get";
+import { assertAdmin } from "@/lib/admin-guard";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
@@ -8,11 +8,7 @@ import { parseNumericId } from "@zoonk/utils/string";
 import { revalidatePath } from "next/cache";
 
 export async function unbanUserAction(formData: FormData) {
-  const session = await getSession();
-
-  if (session?.user.role !== "admin") {
-    throw new Error("Unauthorized");
-  }
+  await assertAdmin();
 
   const userIdRaw = parseFormField(formData, "userId");
   const userId = userIdRaw ? parseNumericId(userIdRaw) : null;

--- a/apps/admin/src/data/courses/list-courses.ts
+++ b/apps/admin/src/data/courses/list-courses.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { getSession } from "@zoonk/core/users/session/get";
+import { isAdmin } from "@/lib/admin-guard";
 import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
@@ -8,9 +8,7 @@ const cachedListCourses = cache(async function cachedListCourses(
   offset: number,
   search: string | undefined,
 ) {
-  const session = await getSession();
-
-  if (session?.user.role !== "admin") {
+  if (!(await isAdmin())) {
     return { courses: [], total: 0 };
   }
 

--- a/apps/admin/src/data/review/count-pending-reviews.ts
+++ b/apps/admin/src/data/review/count-pending-reviews.ts
@@ -1,10 +1,10 @@
 import "server-only";
+import { isAdmin } from "@/lib/admin-guard";
 import {
   REVIEW_TASK_TYPES,
   type ReviewTaskType,
   getVisualKindFromTaskType,
 } from "@/lib/review-utils";
-import { getSession } from "@zoonk/core/users/session/get";
 import { type StepVisualKind, prisma } from "@zoonk/db";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { cache } from "react";
@@ -70,9 +70,7 @@ function emptyCountRecord(): Record<ReviewTaskType, number> {
 export const countPendingReviews = cache(async function countPendingReviews(): Promise<
   Record<ReviewTaskType, number>
 > {
-  const session = await getSession();
-
-  if (session?.user.role !== "admin") {
+  if (!(await isAdmin())) {
     return emptyCountRecord();
   }
 

--- a/apps/admin/src/data/review/count-review-statuses.ts
+++ b/apps/admin/src/data/review/count-review-statuses.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { isAdmin } from "@/lib/admin-guard";
 import { type ReviewTaskType } from "@/lib/review-utils";
-import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
 import { cache } from "react";
 import { countPendingForTask } from "./count-pending-reviews";
@@ -11,9 +11,7 @@ export const countReviewStatuses = cache(async function countReviewStatuses(
   pending: number;
   needsChanges: number;
 }> {
-  const session = await getSession();
-
-  if (session?.user.role !== "admin") {
+  if (!(await isAdmin())) {
     return { needsChanges: 0, pending: 0 };
   }
 

--- a/apps/admin/src/data/review/get-next-review-item.ts
+++ b/apps/admin/src/data/review/get-next-review-item.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { isAdmin } from "@/lib/admin-guard";
 import { type ReviewTaskType, getVisualKindFromTaskType } from "@/lib/review-utils";
-import { getSession } from "@zoonk/core/users/session/get";
 import { type StepVisualKind, prisma } from "@zoonk/db";
 import { AI_ORG_SLUG } from "@zoonk/utils/constants";
 import { cache } from "react";
@@ -73,9 +73,7 @@ async function getNextStepSelectImage(): Promise<ReviewQueueResult> {
 export const getNextReviewItem = cache(async function getNextReviewItem(
   taskType: ReviewTaskType,
 ): Promise<ReviewQueueResult> {
-  const session = await getSession();
-
-  if (session?.user.role !== "admin") {
+  if (!(await isAdmin())) {
     return EMPTY_RESULT;
   }
 

--- a/apps/admin/src/data/review/get-review-item.ts
+++ b/apps/admin/src/data/review/get-review-item.ts
@@ -1,17 +1,12 @@
 import "server-only";
-import { getSession } from "@zoonk/core/users/session/get";
+import { isAdmin } from "@/lib/admin-guard";
 import { prisma } from "@zoonk/db";
 import { cache } from "react";
-
-async function adminGuard() {
-  const session = await getSession();
-  return session?.user.role === "admin";
-}
 
 export const getCourseSuggestionReview = cache(async function getCourseSuggestionReview(
   entityId: bigint,
 ) {
-  if (!(await adminGuard())) {
+  if (!(await isAdmin())) {
     return null;
   }
 
@@ -27,7 +22,7 @@ export const getCourseSuggestionReview = cache(async function getCourseSuggestio
 });
 
 export const getStepVisualReview = cache(async function getStepVisualReview(entityId: bigint) {
-  if (!(await adminGuard())) {
+  if (!(await isAdmin())) {
     return null;
   }
 

--- a/apps/admin/src/data/review/list-reviewed-items.ts
+++ b/apps/admin/src/data/review/list-reviewed-items.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { isAdmin } from "@/lib/admin-guard";
 import { type ReviewTaskType } from "@/lib/review-utils";
-import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
@@ -10,9 +10,7 @@ const cachedListReviewedItems = cache(async function cachedListReviewedItems(
   limit: number,
   offset: number,
 ) {
-  const session = await getSession();
-
-  if (session?.user.role !== "admin") {
+  if (!(await isAdmin())) {
     return { items: [], total: 0 };
   }
   const where = { status, taskType };

--- a/apps/admin/src/data/users/get-user-subscription.ts
+++ b/apps/admin/src/data/users/get-user-subscription.ts
@@ -1,12 +1,10 @@
 import "server-only";
-import { getSession } from "@zoonk/core/users/session/get";
+import { isAdmin } from "@/lib/admin-guard";
 import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
 export const getUserSubscription = cache(async function getUserSubscription(userId: number) {
-  const session = await getSession();
-
-  if (session?.user.role !== "admin") {
+  if (!(await isAdmin())) {
     return null;
   }
 

--- a/apps/admin/src/data/users/get-user.ts
+++ b/apps/admin/src/data/users/get-user.ts
@@ -1,12 +1,10 @@
 import "server-only";
-import { getSession } from "@zoonk/core/users/session/get";
+import { isAdmin } from "@/lib/admin-guard";
 import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
 export const getUser = cache(async function getUser(id: number) {
-  const session = await getSession();
-
-  if (session?.user.role !== "admin") {
+  if (!(await isAdmin())) {
     return null;
   }
 

--- a/apps/admin/src/data/users/list-users.ts
+++ b/apps/admin/src/data/users/list-users.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { getSession } from "@zoonk/core/users/session/get";
+import { isAdmin } from "@/lib/admin-guard";
 import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
@@ -8,9 +8,7 @@ const cachedListUsers = cache(async function cachedListUsers(
   offset: number,
   search: string | undefined,
 ) {
-  const session = await getSession();
-
-  if (session?.user.role !== "admin") {
+  if (!(await isAdmin())) {
     return { total: 0, users: [] };
   }
 

--- a/apps/admin/src/lib/admin-guard.ts
+++ b/apps/admin/src/lib/admin-guard.ts
@@ -1,0 +1,17 @@
+import "server-only";
+import { getSession } from "@zoonk/core/users/session/get";
+
+export async function assertAdmin() {
+  const session = await getSession();
+
+  if (session?.user.role !== "admin") {
+    throw new Error("Unauthorized");
+  }
+
+  return session;
+}
+
+export async function isAdmin() {
+  const session = await getSession();
+  return session?.user.role === "admin";
+}


### PR DESCRIPTION
## Summary

- Add detail page (`/review/[group]/[task]/[entityId]`) for flagged review items with breadcrumb navigation
- **Images**: view current image and upload replacements for step visual and select images via `ImageUploadProvider`
- **Course suggestions**: add, edit, and remove suggestions linked to a search prompt, with confirmation dialog for removal
- Extract shared `assertAdmin()`/`isAdmin()` guard utilities, replacing 18 duplicated admin checks
- Increase server action body size limit to 10mb for image uploads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a detail page for flagged review items with editing for step images and course suggestions. Streamlines the review flow with approve/unflag actions and links from the flagged list.

- **New Features**
  - Detail page at /review/[group]/[task]/[entityId] with breadcrumb.
  - Edit step images (visual and select options) with upload, validation, and error messages.
  - Manage course suggestions: add, edit, remove with confirmation and slug updates.
  - Approve flagged items or return them to the queue; redirects to the flagged view.
  - Increase server action body size limit to 10mb for image uploads.

- **Refactors**
  - Added assertAdmin/isAdmin utilities and replaced duplicated admin checks across actions and loaders.
  - Flagged list links directly to item detail pages for editing.

<sup>Written for commit 6f43ad9c81f2c7bf385d785b7d47f60f00428f5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

