### PR TITLE
feat(admin): add period-aware charts to stats pages

### DIFF
--- a/apps/admin/src/app/(private)/stats/content/content-chart-filter.tsx
+++ b/apps/admin/src/app/(private)/stats/content/content-chart-filter.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { type DailyContentRow } from "@/data/stats/get-daily-content-created";
+import { Button } from "@zoonk/ui/components/button";
+import { type HistoryPeriod, buildChartData } from "@zoonk/utils/date-ranges";
+import { useMemo, useState } from "react";
+import { AdminTrendChart } from "../_components/admin-trend-chart";
+
+type ContentFilterValue = "all" | "courses" | "chapters" | "lessons" | "activities" | "steps";
+
+const filters: { label: string; value: ContentFilterValue }[] = [
+  { label: "All", value: "all" },
+  { label: "Courses", value: "courses" },
+  { label: "Chapters", value: "chapters" },
+  { label: "Lessons", value: "lessons" },
+  { label: "Activities", value: "activities" },
+  { label: "Steps", value: "steps" },
+];
+
+function getCountForFilter(row: DailyContentRow, filter: ContentFilterValue): number {
+  if (filter === "all") {
+    return row.courses + row.chapters + row.lessons + row.activities + row.steps;
+  }
+  return row[filter];
+}
+
+export function ContentChart({
+  dailyContent,
+  period,
+}: {
+  dailyContent: DailyContentRow[];
+  period: HistoryPeriod;
+}) {
+  const [filter, setFilter] = useState<ContentFilterValue>("all");
+
+  const { average, dataPoints } = useMemo(() => {
+    const filtered = dailyContent.map((row) => ({
+      count: getCountForFilter(row, filter),
+      date: row.date,
+    }));
+    return buildChartData(filtered, period, "en");
+  }, [dailyContent, filter, period]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <nav aria-label="Content type filter" className="flex flex-wrap gap-1">
+        {filters.map((item) => (
+          <Button
+            key={item.value}
+            onClick={() => setFilter(item.value)}
+            size="sm"
+            variant={filter === item.value ? "default" : "outline"}
+          >
+            {item.label}
+          </Button>
+        ))}
+      </nav>
+
+      {dataPoints.length > 0 && (
+        <AdminTrendChart average={average} dataPoints={dataPoints} valueLabel="items" />
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/content/content-metrics.tsx
+++ b/apps/admin/src/app/(private)/stats/content/content-metrics.tsx
@@ -1,12 +1,26 @@
 import { countContent } from "@/data/stats/count-content";
-import { countTotalPendingReviews } from "@/data/stats/count-total-pending-reviews";
+import { getDailyContentCreated } from "@/data/stats/get-daily-content-created";
 import { getPeriodContentCreated } from "@/data/stats/get-period-content-created";
-import { getPeriodReviewsResolved } from "@/data/stats/get-period-reviews-resolved";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
-import { calculateDateRanges, validatePeriod } from "@zoonk/utils/date-ranges";
-import { AlertCircleIcon, BookOpenIcon, CheckCircleIcon, LayersIcon } from "lucide-react";
+import { type HistoryPeriod, calculateDateRanges, validatePeriod } from "@zoonk/utils/date-ranges";
+import { BookOpenIcon, LayersIcon } from "lucide-react";
+import { Suspense } from "react";
 import { AdminMetricCard, AdminMetricCardSkeleton } from "../_components/admin-metric-card";
+import { ContentChart } from "./content-chart-filter";
 import { ContentTotalsTable } from "./content-totals-table";
+
+async function ContentChartSection({
+  start,
+  end,
+  period,
+}: {
+  start: Date;
+  end: Date;
+  period: HistoryPeriod;
+}) {
+  const dailyContent = await getDailyContentCreated(start, end);
+  return <ContentChart dailyContent={dailyContent} period={period} />;
+}
 
 export async function ContentMetrics({
   searchParams,
@@ -17,19 +31,15 @@ export async function ContentMetrics({
   const period = validatePeriod(rawPeriod ?? "month");
   const { current, previous } = calculateDateRanges(period, 0);
 
-  const [currentCreated, previousCreated, currentReviews, previousReviews, pendingReviews, totals] =
-    await Promise.all([
-      getPeriodContentCreated(current.start, current.end),
-      getPeriodContentCreated(previous.start, previous.end),
-      getPeriodReviewsResolved(current.start, current.end),
-      getPeriodReviewsResolved(previous.start, previous.end),
-      countTotalPendingReviews(),
-      countContent(),
-    ]);
+  const [currentCreated, previousCreated, totals] = await Promise.all([
+    getPeriodContentCreated(current.start, current.end),
+    getPeriodContentCreated(previous.start, previous.end),
+    countContent(),
+  ]);
 
   return (
     <div className="flex flex-col gap-8">
-      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2">
         <AdminMetricCard
           change={{ current: currentCreated.courses, period, previous: previousCreated.courses }}
           help="Courses created in this period"
@@ -45,22 +55,11 @@ export async function ContentMetrics({
           title="New Lessons"
           value={currentCreated.lessons.toLocaleString()}
         />
-
-        <AdminMetricCard
-          change={{ current: currentReviews, period, previous: previousReviews }}
-          help="Content reviews completed in this period"
-          icon={<CheckCircleIcon />}
-          title="Reviews Resolved"
-          value={currentReviews.toLocaleString()}
-        />
-
-        <AdminMetricCard
-          help="Content awaiting admin review"
-          icon={<AlertCircleIcon />}
-          title="Pending Reviews"
-          value={pendingReviews.toLocaleString()}
-        />
       </div>
+
+      <Suspense fallback={<Skeleton className="h-64 w-full rounded-xl" />}>
+        <ContentChartSection end={current.end} period={period} start={current.start} />
+      </Suspense>
 
       <div className="flex flex-col gap-3">
         <h3 className="text-base font-semibold tracking-tight">Content Totals</h3>
@@ -76,12 +75,11 @@ export async function ContentMetrics({
 export function ContentMetricsSkeleton() {
   return (
     <div className="flex flex-col gap-8">
-      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 lg:grid-cols-4">
-        <AdminMetricCardSkeleton />
-        <AdminMetricCardSkeleton />
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2">
         <AdminMetricCardSkeleton />
         <AdminMetricCardSkeleton />
       </div>
+      <Skeleton className="h-64 w-full rounded-xl" />
       <Skeleton className="h-48 w-full rounded-lg" />
     </div>
   );

--- a/apps/admin/src/app/(private)/stats/engagement/engagement-metrics.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/engagement-metrics.tsx
@@ -7,7 +7,7 @@ import { getPeriodCompletionRate } from "@/data/stats/get-period-completion-rate
 import { getPeriodLearningTime } from "@/data/stats/get-period-learning-time";
 import { formatDuration } from "@/lib/format-duration";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
-import { calculateDateRanges, formatLabel, validatePeriod } from "@zoonk/utils/date-ranges";
+import { buildChartData, calculateDateRanges, validatePeriod } from "@zoonk/utils/date-ranges";
 import { ActivityIcon, CheckCircleIcon, ClockIcon, TargetIcon, TimerIcon } from "lucide-react";
 import { AdminMetricCard, AdminMetricCardSkeleton } from "../_components/admin-metric-card";
 import { AdminTrendChart } from "../_components/admin-trend-chart";
@@ -50,16 +50,11 @@ export async function EngagementMetrics({
     getAvgTimeByActivityKind(current.start, current.end),
   ]);
 
-  const chartData = dailyActive.map((point) => ({
-    date: point.date.toISOString(),
-    label: formatLabel(point.date, period, "en"),
-    value: point.count,
-  }));
-
-  const chartAverage =
-    chartData.length === 0
-      ? 0
-      : Math.round(chartData.reduce((sum, point) => sum + point.value, 0) / chartData.length);
+  const { average: chartAverage, dataPoints: chartData } = buildChartData(
+    dailyActive,
+    period,
+    "en",
+  );
 
   return (
     <div className="flex flex-col gap-8">

--- a/apps/admin/src/app/(private)/stats/growth/growth-metrics.tsx
+++ b/apps/admin/src/app/(private)/stats/growth/growth-metrics.tsx
@@ -4,7 +4,7 @@ import { getConversionRate } from "@/data/stats/get-conversion-rate";
 import { getDailySignups } from "@/data/stats/get-daily-signups";
 import { getNewSignups } from "@/data/stats/get-new-signups";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
-import { calculateDateRanges, formatLabel, validatePeriod } from "@zoonk/utils/date-ranges";
+import { buildChartData, calculateDateRanges, validatePeriod } from "@zoonk/utils/date-ranges";
 import { CreditCardIcon, TargetIcon, UsersIcon } from "lucide-react";
 import { AdminMetricCard, AdminMetricCardSkeleton } from "../_components/admin-metric-card";
 import { AdminTrendChart } from "../_components/admin-trend-chart";
@@ -35,16 +35,11 @@ export async function GrowthMetrics({
     countSubscribersByPlan(),
   ]);
 
-  const chartData = dailySignups.map((point) => ({
-    date: point.date.toISOString(),
-    label: formatLabel(point.date, period, "en"),
-    value: point.count,
-  }));
-
-  const chartAverage =
-    chartData.length === 0
-      ? 0
-      : Math.round(chartData.reduce((sum, point) => sum + point.value, 0) / chartData.length);
+  const { average: chartAverage, dataPoints: chartData } = buildChartData(
+    dailySignups,
+    period,
+    "en",
+  );
 
   return (
     <div className="flex flex-col gap-8">

--- a/apps/admin/src/app/(private)/stats/page.tsx
+++ b/apps/admin/src/app/(private)/stats/page.tsx
@@ -38,7 +38,7 @@ const sections = [
     title: "Engagement & Learning",
   },
   {
-    description: "New courses and lessons, review resolution, pending reviews, and content totals.",
+    description: "New courses and lessons, content creation trends, and content totals.",
     href: "/stats/content",
     icon: BookOpenIcon,
     title: "Content & Operations",

--- a/apps/admin/src/data/stats/get-daily-content-created.ts
+++ b/apps/admin/src/data/stats/get-daily-content-created.ts
@@ -1,0 +1,81 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export type DailyContentRow = {
+  activities: number;
+  chapters: number;
+  courses: number;
+  date: Date;
+  lessons: number;
+  steps: number;
+};
+
+export const getDailyContentCreated = cache(async (start: Date, end: Date) => {
+  const results = await prisma.$queryRaw<{ date: Date; type: string; count: bigint }[]>`
+    SELECT DATE(created_at) as date, 'courses' as type, COUNT(*) as count
+    FROM courses
+    WHERE created_at >= ${start} AND created_at <= ${end}
+    GROUP BY DATE(created_at)
+
+    UNION ALL
+
+    SELECT DATE(created_at) as date, 'chapters' as type, COUNT(*) as count
+    FROM chapters
+    WHERE created_at >= ${start} AND created_at <= ${end}
+    GROUP BY DATE(created_at)
+
+    UNION ALL
+
+    SELECT DATE(created_at) as date, 'lessons' as type, COUNT(*) as count
+    FROM lessons
+    WHERE created_at >= ${start} AND created_at <= ${end}
+    GROUP BY DATE(created_at)
+
+    UNION ALL
+
+    SELECT DATE(created_at) as date, 'activities' as type, COUNT(*) as count
+    FROM activities
+    WHERE created_at >= ${start} AND created_at <= ${end}
+    GROUP BY DATE(created_at)
+
+    UNION ALL
+
+    SELECT DATE(created_at) as date, 'steps' as type, COUNT(*) as count
+    FROM steps
+    WHERE created_at >= ${start} AND created_at <= ${end}
+    GROUP BY DATE(created_at)
+
+    ORDER BY date ASC
+  `;
+
+  const dateMap = new Map<string, DailyContentRow>();
+  const contentTypes: readonly string[] = ["courses", "chapters", "lessons", "activities", "steps"];
+
+  for (const row of results) {
+    const key = row.date.toISOString().slice(0, 10);
+    const existing = dateMap.get(key) ?? {
+      activities: 0,
+      chapters: 0,
+      courses: 0,
+      date: row.date,
+      lessons: 0,
+      steps: 0,
+    };
+
+    if (isContentType(row.type, contentTypes)) {
+      existing[row.type] = Number(row.count);
+    }
+
+    dateMap.set(key, existing);
+  }
+
+  return [...dateMap.values()].toSorted((a, b) => a.date.getTime() - b.date.getTime());
+});
+
+function isContentType(
+  value: string,
+  types: readonly string[],
+): value is keyof Omit<DailyContentRow, "date"> {
+  return types.includes(value);
+}

--- a/apps/admin/src/data/stats/get-period-reviews-resolved.ts
+++ b/apps/admin/src/data/stats/get-period-reviews-resolved.ts
@@ -1,9 +1,0 @@
-import "server-only";
-import { prisma } from "@zoonk/db";
-import { cache } from "react";
-
-export const getPeriodReviewsResolved = cache(async (start: Date, end: Date) =>
-  prisma.contentReview.count({
-    where: { reviewedAt: { gte: start, lte: end } },
-  }),
-);

--- a/packages/utils/src/date-ranges.test.ts
+++ b/packages/utils/src/date-ranges.test.ts
@@ -5,6 +5,7 @@ import {
   aggregateByWeek,
   aggregateScoreByMonth,
   aggregateScoreByWeek,
+  buildChartData,
   calculateDateRanges,
   findBestByScore,
   formatLabel,
@@ -261,6 +262,49 @@ describe(getDefaultStartDate, () => {
     expect(result.toISOString().slice(0, 10)).toBe(expected.toISOString().slice(0, 10));
 
     vi.useRealTimers();
+  });
+});
+
+describe(buildChartData, () => {
+  const rawPoints = [
+    { count: 10, date: new Date(2026, 0, 5) },
+    { count: 20, date: new Date(2026, 0, 6) },
+    { count: 30, date: new Date(2026, 0, 20) },
+    { count: 40, date: new Date(2026, 1, 10) },
+  ];
+
+  it("returns daily data points for 'month' period (no aggregation)", () => {
+    const result = buildChartData(rawPoints, "month", "en");
+    expect(result.dataPoints).toHaveLength(4);
+    expect(result.dataPoints.map((dp) => dp.value)).toEqual([10, 20, 30, 40]);
+  });
+
+  it("aggregates to weekly sums for '6months' period", () => {
+    const result = buildChartData(rawPoints, "6months", "en");
+    expect(result.dataPoints.length).toBeLessThan(4);
+    const totalValue = result.dataPoints.reduce((sum, dp) => sum + dp.value, 0);
+    expect(totalValue).toBe(100);
+  });
+
+  it("aggregates to monthly sums for 'year' period", () => {
+    const result = buildChartData(rawPoints, "year", "en");
+    expect(result.dataPoints).toHaveLength(2);
+    expect(result.dataPoints.map((dp) => dp.value)).toEqual([60, 40]);
+  });
+
+  it("returns empty data points and zero average for empty input", () => {
+    const result = buildChartData([], "month", "en");
+    expect(result).toEqual({ average: 0, dataPoints: [] });
+  });
+
+  it("calculates average correctly", () => {
+    const result = buildChartData(rawPoints, "month", "en");
+    expect(result.average).toBe(Math.round((10 + 20 + 30 + 40) / 4));
+  });
+
+  it("calculates average correctly for aggregated data", () => {
+    const result = buildChartData(rawPoints, "year", "en");
+    expect(result.average).toBe(Math.round((60 + 40) / 2));
   });
 });
 

--- a/packages/utils/src/date-ranges.ts
+++ b/packages/utils/src/date-ranges.ts
@@ -237,6 +237,45 @@ export function getDefaultStartDate(startDateIso?: string): Date {
   );
 }
 
+export function buildChartData(
+  rawPoints: { date: Date; count: number }[],
+  period: HistoryPeriod,
+  locale: string,
+): { average: number; dataPoints: { date: string; label: string; value: number }[] } {
+  if (rawPoints.length === 0) {
+    return { average: 0, dataPoints: [] };
+  }
+
+  const aggregated = getAggregatedPoints(rawPoints, period);
+
+  const dataPoints = aggregated.map((point) => ({
+    date: point.date.toISOString(),
+    label: formatLabel(point.date, period, locale),
+    value: point.value,
+  }));
+
+  const average = Math.round(
+    dataPoints.reduce((sum, point) => sum + point.value, 0) / dataPoints.length,
+  );
+
+  return { average, dataPoints };
+}
+
+function getAggregatedPoints(
+  rawPoints: { date: Date; count: number }[],
+  period: HistoryPeriod,
+): { date: Date; value: number }[] {
+  if (period === "6months") {
+    return aggregateByWeek(rawPoints, (point) => point.count, "sum");
+  }
+
+  if (period === "year") {
+    return aggregateByMonth(rawPoints, (point) => point.count, "sum");
+  }
+
+  return rawPoints.map((point) => ({ date: point.date, value: point.count }));
+}
+
 export type ScoredRow = { key: number; correct: number; incorrect: number };
 
 export function findBestByScore(rows: ScoredRow[]): { key: number; score: number } | null {


### PR DESCRIPTION
## Summary

- Add `buildChartData` utility that aggregates chart data by period (daily/weekly/monthly) using existing `aggregateByWeek`/`aggregateByMonth`
- Apply period-aware aggregation to Growth and Engagement charts
- Add content creation chart with client-side type filter (All/Courses/Chapters/Lessons/Activities/Steps)
- Remove review metrics from Content stats (belong on review pages) — fixes slow period switching caused by `countTotalPendingReviews` sequential queries
- Stream chart data via its own Suspense boundary to avoid blocking metric cards

## Test plan

- [ ] Visit `/stats/growth`, `/stats/engagement`, `/stats/content` and toggle Month/6 Months/Year — chart granularity changes appropriately
- [ ] On Content page, verify filter buttons update chart instantly without page reload
- [ ] Verify period switching on Content page no longer shows full-page skeleton
- [ ] `pnpm test` passes (6 new unit tests for `buildChartData`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds period-aware charts to admin stats and a new content creation chart with a type filter. Charts show the right granularity and the Content page loads faster.

- **New Features**
  - Period-aware aggregation for Growth and Engagement (daily, weekly, monthly).
  - Content creation trend chart with client-side type filter (All/Courses/Chapters/Lessons/Activities/Steps).

- **Refactors**
  - Added buildChartData utility to aggregate daily data to weekly/monthly for longer periods.
  - Streamed chart data via a dedicated Suspense boundary so metric cards render immediately.
  - Moved review metrics off the Content stats page to fix slow period switching.

<sup>Written for commit 2a4bae72420363a5f31534c19c8d62e627935f4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

