### PR TITLE
fix(turbo): add db:generate dependency to lint and typecheck tasks

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -47,8 +47,13 @@
   "tasks": {
     "//#format": {},
     "//#format:fix": { "cache": false },
-    "//#lint": {},
-    "//#lint:fix": { "cache": false },
+    "//#lint": {
+      "dependsOn": ["@zoonk/db#db:generate"]
+    },
+    "//#lint:fix": {
+      "cache": false,
+      "dependsOn": ["@zoonk/db#db:generate"]
+    },
     "//#quality": {
       "dependsOn": ["//#lint", "//#format"]
     },
@@ -97,7 +102,7 @@
       "persistent": true
     },
     "typecheck": {
-      "dependsOn": ["^typecheck"],
+      "dependsOn": ["^db:generate", "^typecheck"],
       "outputs": [".next/types/**"]
     }
   },


### PR DESCRIPTION
## Summary
- Add `@zoonk/db#db:generate` as dependency for `//#lint` and `//#lint:fix` root tasks
- Add `^db:generate` as dependency for `typecheck` workspace task
- Fixes failures when Prisma types haven't been generated before running lint (`oxlint --type-aware`) or typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Prisma types are generated before linting and typecheck by making db:generate a Turbo dependency. Prevents failures in type-aware lint (oxlint) and typecheck when Prisma types are missing.

- **Bug Fixes**
  - Add @zoonk/db#db:generate as a dependency for //#lint and //#lint:fix.
  - Add ^db:generate to the typecheck task’s dependsOn alongside ^typecheck.

<sup>Written for commit 324c7c66347162f66173d1f2915984945932ab2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

