### PR TITLE
refactor(admin): use bar chart for content created stats

### DIFF
--- a/apps/admin/src/app/(private)/stats/_components/admin-trend-chart.tsx
+++ b/apps/admin/src/app/(private)/stats/_components/admin-trend-chart.tsx
@@ -5,6 +5,8 @@ import { useId } from "react";
 import {
   Area,
   AreaChart,
+  Bar,
+  BarChart,
   CartesianGrid,
   ReferenceLine,
   ResponsiveContainer,
@@ -12,6 +14,10 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+
+const BAR_OPACITY = 0.8;
+const BAR_CORNER_RADIUS = 4;
+const BAR_RADIUS: [number, number, number, number] = [BAR_CORNER_RADIUS, BAR_CORNER_RADIUS, 0, 0];
 
 type DataPoint = {
   date: string;
@@ -23,84 +29,104 @@ export function AdminTrendChart({
   average,
   dataPoints,
   valueLabel,
+  variant = "area",
 }: {
   average: number;
   dataPoints: DataPoint[];
   valueLabel: string;
+  variant?: "area" | "bar";
 }) {
   const gradientId = useId();
+
+  const sharedElements = (
+    <>
+      <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
+
+      <XAxis
+        axisLine={false}
+        dataKey="label"
+        fontSize={12}
+        stroke="var(--muted-foreground)"
+        tickLine={false}
+        tickMargin={8}
+      />
+
+      <YAxis
+        axisLine={false}
+        fontSize={12}
+        stroke="var(--muted-foreground)"
+        tickLine={false}
+        tickMargin={8}
+        width={40}
+      />
+
+      <Tooltip
+        content={({ active, payload }) => {
+          if (!active || !isValidChartPayload<DataPoint>(payload)) {
+            return null;
+          }
+
+          const data = payload[0].payload;
+
+          return (
+            <div className="bg-background rounded-lg border px-3 py-2 shadow-sm">
+              <p className="text-muted-foreground text-xs">{data.label}</p>
+              <p className="text-sm font-medium">
+                {data.value.toLocaleString()} {valueLabel}
+              </p>
+            </div>
+          );
+        }}
+      />
+
+      <ReferenceLine
+        label={{
+          fill: "var(--muted-foreground)",
+          fontSize: 11,
+          position: "insideBottomRight",
+          value: `Avg: ${average.toLocaleString()}`,
+        }}
+        stroke="var(--muted-foreground)"
+        strokeDasharray="3 3"
+        y={average}
+      />
+    </>
+  );
 
   return (
     <figure aria-label={`${valueLabel} chart`} className="h-64 w-full">
       <ResponsiveContainer height="100%" width="100%">
-        <AreaChart data={dataPoints} margin={{ bottom: 0, left: 0, right: 0, top: 10 }}>
-          <defs>
-            <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
-              <stop offset="5%" stopColor="var(--foreground)" stopOpacity={0.15} />
-              <stop offset="95%" stopColor="var(--foreground)" stopOpacity={0} />
-            </linearGradient>
-          </defs>
+        {variant === "bar" ? (
+          <BarChart data={dataPoints} margin={{ bottom: 0, left: 0, right: 0, top: 10 }}>
+            {sharedElements}
+            <Bar
+              dataKey="value"
+              fill="var(--foreground)"
+              opacity={BAR_OPACITY}
+              radius={BAR_RADIUS}
+            />
+          </BarChart>
+        ) : (
+          <AreaChart data={dataPoints} margin={{ bottom: 0, left: 0, right: 0, top: 10 }}>
+            <defs>
+              <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+                <stop offset="5%" stopColor="var(--foreground)" stopOpacity={0.15} />
+                <stop offset="95%" stopColor="var(--foreground)" stopOpacity={0} />
+              </linearGradient>
+            </defs>
 
-          <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
+            {sharedElements}
 
-          <XAxis
-            axisLine={false}
-            dataKey="label"
-            fontSize={12}
-            stroke="var(--muted-foreground)"
-            tickLine={false}
-            tickMargin={8}
-          />
-
-          <YAxis
-            axisLine={false}
-            fontSize={12}
-            stroke="var(--muted-foreground)"
-            tickLine={false}
-            tickMargin={8}
-            width={40}
-          />
-
-          <Tooltip
-            content={({ active, payload }) => {
-              if (!active || !isValidChartPayload<DataPoint>(payload)) {
-                return null;
-              }
-
-              const data = payload[0].payload;
-
-              return (
-                <div className="bg-background rounded-lg border px-3 py-2 shadow-sm">
-                  <p className="text-muted-foreground text-xs">{data.label}</p>
-                  <p className="text-sm font-medium">
-                    {data.value.toLocaleString()} {valueLabel}
-                  </p>
-                </div>
-              );
-            }}
-          />
-
-          <ReferenceLine
-            label={{
-              fill: "var(--muted-foreground)",
-              fontSize: 11,
-              position: "insideBottomRight",
-              value: `Avg: ${average.toLocaleString()}`,
-            }}
-            stroke="var(--muted-foreground)"
-            strokeDasharray="3 3"
-            y={average}
-          />
-
-          <Area
-            dataKey="value"
-            fill={`url(#${gradientId})`}
-            fillOpacity={1}
-            stroke="var(--foreground)"
-            strokeWidth={2}
-            type="monotone"
-          />
-        </AreaChart>
+            <Area
+              dataKey="value"
+              fill={`url(#${gradientId})`}
+              fillOpacity={1}
+              stroke="var(--foreground)"
+              strokeWidth={2}
+              type="monotone"
+            />
+          </AreaChart>
+        )}
       </ResponsiveContainer>
     </figure>
   );

--- a/apps/admin/src/app/(private)/stats/content/content-chart-filter.tsx
+++ b/apps/admin/src/app/(private)/stats/content/content-chart-filter.tsx
@@ -57,7 +57,12 @@ export function ContentChart({
       </nav>
 
       {dataPoints.length > 0 && (
-        <AdminTrendChart average={average} dataPoints={dataPoints} valueLabel="items" />
+        <AdminTrendChart
+          average={average}
+          dataPoints={dataPoints}
+          valueLabel="items"
+          variant="bar"
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- Add `variant` prop (`"area" | "bar"`) to `AdminTrendChart`, defaulting to `"area"`
- Content created stats page now uses bar chart — better suited for discrete production counts
- Shared chart elements (grid, axes, tooltip, reference line) extracted to avoid duplication between variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the content created stats to a bar chart for clearer discrete counts. Adds a bar/area variant to AdminTrendChart without changing existing defaults.

- **New Features**
  - AdminTrendChart supports variant: "area" | "bar" (default "area").
  - Content created chart now uses variant="bar" with rounded bars.

- **Refactors**
  - Extracted shared chart pieces (grid, axes, tooltip, average line) for reuse across variants.

<sup>Written for commit 5eb280a4e7af4475850a24b68d49a38d67f7fbab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

