### PR TITLE
feat(utils): add "all" period to charts with yearly aggregation

### DIFF
--- a/apps/admin/src/app/(private)/stats/_components/admin-period-tabs.tsx
+++ b/apps/admin/src/app/(private)/stats/_components/admin-period-tabs.tsx
@@ -8,6 +8,7 @@ const periods: { label: string; value: HistoryPeriod }[] = [
   { label: "Month", value: "month" },
   { label: "6 Months", value: "6months" },
   { label: "Year", value: "year" },
+  { label: "All", value: "all" },
 ];
 
 export function AdminPeriodTabs() {

--- a/apps/main/e2e/energy.test.ts
+++ b/apps/main/e2e/energy.test.ts
@@ -70,6 +70,24 @@ test.describe("Energy Page", () => {
       await expect(authenticatedPage.getByText(/vs last 6 months/i)).not.toBeVisible();
     });
 
+    test("switching to all hides comparison text", async ({ authenticatedPage }) => {
+      await authenticatedPage.goto("/energy");
+
+      // Verify we start with month comparison
+      await expect(authenticatedPage.getByText(/vs last month/i)).toBeVisible();
+
+      // Switch to all
+      await authenticatedPage.getByRole("button", { name: /^all$/i }).click();
+
+      // No comparison text should be visible
+      await expect(authenticatedPage.getByText(/vs last month/i)).not.toBeVisible();
+      await expect(authenticatedPage.getByText(/vs last 6 months/i)).not.toBeVisible();
+      await expect(authenticatedPage.getByText(/vs last year/i)).not.toBeVisible();
+
+      // Page still shows data
+      await expect(authenticatedPage.getByRole("heading", { name: /^energy$/i })).toBeVisible();
+    });
+
     test("resets offset when switching periods", async ({ authenticatedPage }) => {
       await authenticatedPage.goto("/energy");
 

--- a/apps/main/e2e/level.test.ts
+++ b/apps/main/e2e/level.test.ts
@@ -84,6 +84,29 @@ test.describe("Level Page", () => {
       await expect(authenticatedPage.getByText(/vs last 6 months/i)).not.toBeVisible();
     });
 
+    test("switching to all hides comparison text", async ({ authenticatedPage }) => {
+      await authenticatedPage.goto("/level");
+
+      // Verify we start with month comparison
+      await expect(authenticatedPage.getByText(/vs last month/i)).toBeVisible();
+
+      // Switch to all
+      await authenticatedPage.getByRole("button", { name: /^all$/i }).click();
+
+      // No comparison text should be visible
+      await expect(authenticatedPage.getByText(/vs last month/i)).not.toBeVisible();
+      await expect(authenticatedPage.getByText(/vs last 6 months/i)).not.toBeVisible();
+      await expect(authenticatedPage.getByText(/vs last year/i)).not.toBeVisible();
+
+      // Page still shows data
+      await expect(
+        authenticatedPage.getByRole("heading", {
+          level: 1,
+          name: /^level$/i,
+        }),
+      ).toBeVisible();
+    });
+
     test("resets offset when switching periods", async ({ authenticatedPage }) => {
       await authenticatedPage.goto("/level");
 

--- a/apps/main/e2e/score.test.ts
+++ b/apps/main/e2e/score.test.ts
@@ -62,6 +62,24 @@ test.describe("Score Page", () => {
       await expect(authenticatedPage.getByText(/vs last 6 months/i)).not.toBeVisible();
     });
 
+    test("switching to all hides comparison text", async ({ authenticatedPage }) => {
+      await authenticatedPage.goto("/score");
+
+      // Verify we start with month comparison
+      await expect(authenticatedPage.getByText(/vs last month/i)).toBeVisible();
+
+      // Switch to all
+      await authenticatedPage.getByRole("button", { name: /^all$/i }).click();
+
+      // No comparison text should be visible
+      await expect(authenticatedPage.getByText(/vs last month/i)).not.toBeVisible();
+      await expect(authenticatedPage.getByText(/vs last 6 months/i)).not.toBeVisible();
+      await expect(authenticatedPage.getByText(/vs last year/i)).not.toBeVisible();
+
+      // Page still shows data
+      await expect(authenticatedPage.getByRole("heading", { name: /^score$/i })).toBeVisible();
+    });
+
     test("resets offset when switching periods", async ({ authenticatedPage }) => {
       await authenticatedPage.goto("/score");
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -751,6 +751,7 @@ msgid "Course categories"
 msgstr "Course categories"
 
 #: src/app/(catalog)/courses/category-pills.tsx
+#: src/app/(performance)/_components/period-tabs.tsx
 msgctxt "zQvVDJ"
 msgid "All"
 msgstr "All"
@@ -1048,6 +1049,11 @@ msgstr "Personalized courses are coming soon."
 msgctxt "e61Jf3"
 msgid "Coming soon"
 msgstr "Coming soon"
+
+#: src/app/(performance)/_components/metric-comparison.tsx
+msgctxt "HOfw3D"
+msgid "all time"
+msgstr "all time"
 
 #: src/app/(performance)/_components/metric-comparison.tsx
 #: src/app/(performance)/energy/energy-chart-client.tsx

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -751,6 +751,7 @@ msgid "Course categories"
 msgstr "Categorías de cursos"
 
 #: src/app/(catalog)/courses/category-pills.tsx
+#: src/app/(performance)/_components/period-tabs.tsx
 msgctxt "zQvVDJ"
 msgid "All"
 msgstr "Todos"
@@ -1048,6 +1049,11 @@ msgstr "Los cursos personalizados llegarán pronto."
 msgctxt "e61Jf3"
 msgid "Coming soon"
 msgstr "Próximamente"
+
+#: src/app/(performance)/_components/metric-comparison.tsx
+msgctxt "HOfw3D"
+msgid "all time"
+msgstr "todo el tiempo"
 
 #: src/app/(performance)/_components/metric-comparison.tsx
 #: src/app/(performance)/energy/energy-chart-client.tsx

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -751,6 +751,7 @@ msgid "Course categories"
 msgstr "Categorias de cursos"
 
 #: src/app/(catalog)/courses/category-pills.tsx
+#: src/app/(performance)/_components/period-tabs.tsx
 msgctxt "zQvVDJ"
 msgid "All"
 msgstr "Todos"
@@ -1048,6 +1049,11 @@ msgstr "Cursos personalizados em breve."
 msgctxt "e61Jf3"
 msgid "Coming soon"
 msgstr "Em breve"
+
+#: src/app/(performance)/_components/metric-comparison.tsx
+msgctxt "HOfw3D"
+msgid "all time"
+msgstr "todo o período"
 
 #: src/app/(performance)/_components/metric-comparison.tsx
 #: src/app/(performance)/energy/energy-chart-client.tsx

--- a/apps/main/src/app/(performance)/_components/metric-comparison.tsx
+++ b/apps/main/src/app/(performance)/_components/metric-comparison.tsx
@@ -39,6 +39,10 @@ export async function MetricComparison({
       return t("vs last 6 months");
     }
 
+    if (period === "all") {
+      return t("all time");
+    }
+
     return t("vs last year");
   }
 

--- a/apps/main/src/app/(performance)/_components/period-tabs.tsx
+++ b/apps/main/src/app/(performance)/_components/period-tabs.tsx
@@ -45,6 +45,14 @@ export function PeriodTabs() {
       >
         {t("Year")}
       </Button>
+
+      <Button
+        onClick={() => handlePeriodChange("all")}
+        size="sm"
+        variant={period === "all" ? "default" : "outline"}
+      >
+        {t("All")}
+      </Button>
     </nav>
   );
 }

--- a/apps/main/src/app/(performance)/_utils.ts
+++ b/apps/main/src/app/(performance)/_utils.ts
@@ -6,6 +6,10 @@ export function formatPeriodLabel(
   period: HistoryPeriod,
   locale: string,
 ): string {
+  if (period === "all") {
+    return `${periodStart.getFullYear()} - ${periodEnd.getFullYear()}`;
+  }
+
   if (period === "month") {
     return new Intl.DateTimeFormat(locale, {
       month: "long",

--- a/apps/main/src/data/progress/get-bp-history.test.ts
+++ b/apps/main/src/data/progress/get-bp-history.test.ts
@@ -265,6 +265,31 @@ describe("authenticated users", () => {
     });
   });
 
+  describe("all period", () => {
+    test("returns yearly aggregated data points", async () => {
+      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const headers = await signInAs(user.email, user.password);
+
+      const today = createSafeDate(0);
+
+      await prisma.dailyProgress.create({
+        data: {
+          brainPowerEarned: 200,
+          date: today,
+          dayOfWeek: today.getDay(),
+          organizationId: org.id,
+          userId: Number(user.id),
+        },
+      });
+
+      const result = await getBpHistory({ headers, period: "all" });
+
+      expect(result).not.toBeNull();
+      expect(result?.dataPoints.length).toBeGreaterThanOrEqual(1);
+      expect(result?.previousPeriodTotal).toBeNull();
+    });
+  });
+
   describe("navigation flags", () => {
     test("hasPreviousPeriod is true when historical data exists", async () => {
       const [user, org] = await Promise.all([userFixture(), organizationFixture()]);

--- a/apps/main/src/data/progress/get-bp-history.ts
+++ b/apps/main/src/data/progress/get-bp-history.ts
@@ -6,6 +6,7 @@ import {
   type HistoryPeriod,
   aggregateByMonth,
   aggregateByWeek,
+  aggregateByYear,
   calculateDateRanges,
   formatLabel,
 } from "@zoonk/utils/date-ranges";
@@ -58,6 +59,13 @@ async function fetchDailyBpData(
 }
 
 function processBpData(rawData: RawDataPoint[], period: HistoryPeriod): RawDataPoint[] {
+  if (period === "all") {
+    return aggregateByYear(rawData, (point) => point.bp, "sum").map((item) => ({
+      bp: item.value,
+      date: item.date,
+    }));
+  }
+
   if (period === "6months") {
     return aggregateByWeek(rawData, (point) => point.bp, "sum").map((item) => ({
       bp: item.value,

--- a/apps/main/src/data/progress/get-energy-history.test.ts
+++ b/apps/main/src/data/progress/get-energy-history.test.ts
@@ -233,6 +233,31 @@ describe("authenticated users", () => {
     });
   });
 
+  describe("all period", () => {
+    test("returns yearly aggregated data points", async () => {
+      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const headers = await signInAs(user.email, user.password);
+
+      const today = createSafeDate(0);
+
+      await prisma.dailyProgress.create({
+        data: {
+          date: today,
+          dayOfWeek: today.getDay(),
+          energyAtEnd: 85,
+          organizationId: org.id,
+          userId: Number(user.id),
+        },
+      });
+
+      const result = await getEnergyHistory({ headers, period: "all" });
+
+      expect(result).not.toBeNull();
+      expect(result?.dataPoints.length).toBeGreaterThanOrEqual(1);
+      expect(result?.previousAverage).toBeNull();
+    });
+  });
+
   describe("navigation flags", () => {
     test("hasPreviousPeriod is true when historical data exists", async () => {
       const [user, org] = await Promise.all([userFixture(), organizationFixture()]);

--- a/apps/main/src/data/progress/get-energy-history.ts
+++ b/apps/main/src/data/progress/get-energy-history.ts
@@ -5,6 +5,7 @@ import {
   type HistoryPeriod,
   aggregateByMonth,
   aggregateByWeek,
+  aggregateByYear,
   calculateDateRanges,
   formatLabel,
 } from "@zoonk/utils/date-ranges";
@@ -156,8 +157,19 @@ async function fetchDailyData(
   };
 }
 
+function aggregateEnergyByYear(dataPoints: RawDataPoint[]): RawDataPoint[] {
+  return aggregateByYear(dataPoints, (point) => point.energy, "average").map((item) => ({
+    date: item.date,
+    energy: item.value,
+  }));
+}
+
 function processEnergyData(rawData: RawDataPoint[], period: EnergyPeriod): RawDataPoint[] {
   const withDecay = fillGapsWithDecay(rawData);
+
+  if (period === "all") {
+    return aggregateEnergyByYear(withDecay);
+  }
 
   if (period === "6months") {
     return aggregateEnergyByWeek(withDecay);

--- a/apps/main/src/data/progress/get-score-history.test.ts
+++ b/apps/main/src/data/progress/get-score-history.test.ts
@@ -293,6 +293,32 @@ describe("authenticated users", () => {
     });
   });
 
+  describe("all period", () => {
+    test("returns yearly aggregated data points", async () => {
+      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const headers = await signInAs(user.email, user.password);
+
+      const today = createSafeDate(0);
+
+      await prisma.dailyProgress.create({
+        data: {
+          correctAnswers: 9,
+          date: today,
+          dayOfWeek: today.getDay(),
+          incorrectAnswers: 1,
+          organizationId: org.id,
+          userId: Number(user.id),
+        },
+      });
+
+      const result = await getScoreHistory({ headers, period: "all" });
+
+      expect(result).not.toBeNull();
+      expect(result?.dataPoints.length).toBeGreaterThanOrEqual(1);
+      expect(result?.previousAverage).toBeNull();
+    });
+  });
+
   describe("navigation flags", () => {
     test("hasPreviousPeriod is true when historical data exists", async () => {
       const [user, org] = await Promise.all([userFixture(), organizationFixture()]);

--- a/apps/main/src/data/progress/get-score-history.ts
+++ b/apps/main/src/data/progress/get-score-history.ts
@@ -5,6 +5,7 @@ import {
   type HistoryPeriod,
   aggregateScoreByMonth,
   aggregateScoreByWeek,
+  aggregateScoreByYear,
   calculateDateRanges,
   formatLabel,
 } from "@zoonk/utils/date-ranges";
@@ -90,6 +91,10 @@ function processScoreData(
 
   if (period === "6months") {
     return aggregateScoreByWeek(rawData, calculateScore);
+  }
+
+  if (period === "all") {
+    return aggregateScoreByYear(rawData, calculateScore);
   }
 
   return aggregateScoreByMonth(rawData, calculateScore);

--- a/i18n.lock
+++ b/i18n.lock
@@ -388,6 +388,7 @@ checksums:
     No%20courses%20yet/singular: d5fcc38466fdc83a74eab5032a2f85b6
     Personalized%20courses%20are%20coming%20soon./singular: ad21564f7620bc2a553e298a587daccf
     Coming%20soon/singular: ee2b0671e00972773210c5be5a9ccb89
+    all%20time/singular: 7eca3f0ebc2bc0adbdc7512cf3ed5038
     "%7Bvalue%7D%25/singular": 35cbe4d3fffd3e6b5415eea333f532d7
     vs%20last%20month/singular: 642c3b71173b2adbd876aa05d53d47cf
     vs%20last%206%20months/singular: 82e8ff0c71a42ab0aa345474035d29b4

--- a/packages/utils/src/date-ranges.test.ts
+++ b/packages/utils/src/date-ranges.test.ts
@@ -3,8 +3,10 @@ import {
   type ScoredRow,
   aggregateByMonth,
   aggregateByWeek,
+  aggregateByYear,
   aggregateScoreByMonth,
   aggregateScoreByWeek,
+  aggregateScoreByYear,
   buildChartData,
   calculateDateRanges,
   findBestByScore,
@@ -36,6 +38,10 @@ describe(validatePeriod, () => {
 
   it("defaults empty string to 'month'", () => {
     expect(validatePeriod("")).toBe("month");
+  });
+
+  it("returns 'all' unchanged", () => {
+    expect(validatePeriod("all")).toBe("all");
   });
 });
 
@@ -137,6 +143,20 @@ describe(calculateDateRanges, () => {
 
     vi.useRealTimers();
   });
+
+  it("returns all-time range for 'all' period", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 15)); // March 15, 2026
+
+    const ranges = calculateDateRanges("all", 0);
+
+    expect(ranges.current.start).toEqual(new Date(2025, 0, 1));
+    expect(ranges.current.end).toEqual(new Date(2026, 11, 31));
+    expect(ranges.previous.start).toEqual(new Date(0));
+    expect(ranges.previous.end).toEqual(new Date(0));
+
+    vi.useRealTimers();
+  });
 });
 
 describe(formatLabel, () => {
@@ -157,6 +177,12 @@ describe(formatLabel, () => {
     const date = new Date(2026, 2, 15);
     const result = formatLabel(date, "year", "en");
     expect(result).toBe("Mar");
+  });
+
+  it("formats all period as year string", () => {
+    const date = new Date(2026, 0, 1);
+    const result = formatLabel(date, "all", "en");
+    expect(result).toBe("2026");
   });
 });
 
@@ -207,6 +233,48 @@ describe(aggregateByMonth, () => {
     const result = aggregateByMonth(reversed, (point) => point.value, "sum");
     const times = result.map((row) => row.date.getTime());
     expect(times).toEqual([...times].toSorted((left, right) => left - right));
+  });
+});
+
+describe(aggregateByYear, () => {
+  const dataPoints = [
+    { date: new Date(2025, 3, 10), value: 10 },
+    { date: new Date(2025, 8, 20), value: 20 },
+    { date: new Date(2026, 1, 5), value: 30 },
+  ];
+
+  it("aggregates by sum", () => {
+    const result = aggregateByYear(dataPoints, (point) => point.value, "sum");
+    expect(result.map((row) => row.value)).toEqual([30, 30]); // 2025: 10+20, 2026: 30
+  });
+
+  it("aggregates by average", () => {
+    const result = aggregateByYear(dataPoints, (point) => point.value, "average");
+    expect(result.map((row) => row.value)).toEqual([15, 30]); // 2025: (10+20)/2, 2026: 30/1
+  });
+
+  it("returns sorted results", () => {
+    const reversed = [...dataPoints].toReversed();
+    const result = aggregateByYear(reversed, (point) => point.value, "sum");
+    const times = result.map((row) => row.date.getTime());
+    expect(times).toEqual([...times].toSorted((left, right) => left - right));
+  });
+});
+
+describe(aggregateScoreByYear, () => {
+  it("aggregates correct/incorrect by year and calculates score", () => {
+    const dataPoints = [
+      { correct: 8, date: new Date(2025, 3, 10), incorrect: 2 },
+      { correct: 6, date: new Date(2025, 8, 20), incorrect: 4 },
+      { correct: 9, date: new Date(2026, 1, 5), incorrect: 1 },
+    ];
+
+    const result = aggregateScoreByYear(dataPoints, calcScore);
+
+    expect(result.map((row) => row.score)).toEqual([
+      calcScore(14, 6), // 2025: 8+6=14 correct, 2+4=6 incorrect
+      calcScore(9, 1), // 2026: 9 correct, 1 incorrect
+    ]);
   });
 });
 
@@ -290,6 +358,18 @@ describe(buildChartData, () => {
     const result = buildChartData(rawPoints, "year", "en");
     expect(result.dataPoints).toHaveLength(2);
     expect(result.dataPoints.map((dp) => dp.value)).toEqual([60, 40]);
+  });
+
+  it("aggregates to yearly sums for 'all' period", () => {
+    const crossYearPoints = [
+      { count: 10, date: new Date(2025, 3, 5) },
+      { count: 20, date: new Date(2025, 8, 6) },
+      { count: 30, date: new Date(2026, 1, 10) },
+    ];
+    const result = buildChartData(crossYearPoints, "all", "en");
+    expect(result.dataPoints).toHaveLength(2);
+    expect(result.dataPoints.map((dp) => dp.value)).toEqual([30, 30]);
+    expect(result.dataPoints.map((dp) => dp.label)).toEqual(["2025", "2026"]);
   });
 
   it("returns empty data points and zero average for empty input", () => {

--- a/packages/utils/src/date-ranges.ts
+++ b/packages/utils/src/date-ranges.ts
@@ -1,6 +1,8 @@
 import { DEFAULT_PROGRESS_LOOKBACK_DAYS } from "./constants";
 
-const HISTORY_PERIODS = ["month", "6months", "year"] as const;
+const HISTORY_PERIODS = ["month", "6months", "year", "all"] as const;
+
+const APP_LAUNCH_YEAR = 2025;
 
 const MONTHS_PER_HALF_YEAR = 6;
 const DECEMBER_INDEX = 11;
@@ -71,18 +73,41 @@ function getYearDateRanges(now: Date, offset: number): DateRanges {
   };
 }
 
-export function calculateDateRanges(period: HistoryPeriod, offset: number): DateRanges {
+function getAllDateRanges(): DateRanges {
   const now = new Date();
+
+  return {
+    current: {
+      end: new Date(now.getFullYear(), DECEMBER_INDEX, LAST_DAY_OF_DECEMBER),
+      start: new Date(APP_LAUNCH_YEAR, 0, 1),
+    },
+    previous: { end: new Date(0), start: new Date(0) },
+  };
+}
+
+export function calculateDateRanges(period: HistoryPeriod, offset: number): DateRanges {
+  if (period === "all") {
+    return getAllDateRanges();
+  }
+
+  const now = new Date();
+
   if (period === "month") {
     return getMonthDateRanges(now, offset);
   }
+
   if (period === "6months") {
     return getHalfYearDateRanges(now, offset);
   }
+
   return getYearDateRanges(now, offset);
 }
 
 export function formatLabel(date: Date, period: HistoryPeriod, locale: string): string {
+  if (period === "all") {
+    return date.getFullYear().toString();
+  }
+
   if (period === "month") {
     return new Intl.DateTimeFormat(locale, {
       day: "numeric",
@@ -127,8 +152,17 @@ type TimePeriodConfig = {
   getNormalizedDate: (date: Date) => Date;
 };
 
+function getYearKey(date: Date): string {
+  return date.getFullYear().toString();
+}
+
+function getFirstOfYear(date: Date): Date {
+  return new Date(date.getFullYear(), 0, 1);
+}
+
 const weekConfig: TimePeriodConfig = { getKey: getWeekKey, getNormalizedDate: getMondayOfWeek };
 const monthConfig: TimePeriodConfig = { getKey: getMonthKey, getNormalizedDate: getFirstOfMonth };
+const yearConfig: TimePeriodConfig = { getKey: getYearKey, getNormalizedDate: getFirstOfYear };
 
 type AggregationStrategy = "sum" | "average";
 
@@ -179,6 +213,14 @@ export function aggregateByMonth<T extends { date: Date }>(
   return aggregateByPeriod(dataPoints, getValue, strategy, monthConfig);
 }
 
+export function aggregateByYear<T extends { date: Date }>(
+  dataPoints: T[],
+  getValue: (point: T) => number,
+  strategy: AggregationStrategy,
+): { date: Date; value: number }[] {
+  return aggregateByPeriod(dataPoints, getValue, strategy, yearConfig);
+}
+
 type ScoreDataPoint = { date: Date; correct: number; incorrect: number };
 
 function aggregateScoreByPeriod(
@@ -225,6 +267,13 @@ export function aggregateScoreByMonth(
   return aggregateScoreByPeriod(dataPoints, calculateScore, monthConfig);
 }
 
+export function aggregateScoreByYear(
+  dataPoints: ScoreDataPoint[],
+  calculateScore: (correct: number, incorrect: number) => number,
+): { date: Date; score: number }[] {
+  return aggregateScoreByPeriod(dataPoints, calculateScore, yearConfig);
+}
+
 export function getDefaultStartDate(startDateIso?: string): Date {
   if (startDateIso) {
     return new Date(startDateIso);
@@ -265,6 +314,10 @@ function getAggregatedPoints(
   rawPoints: { date: Date; count: number }[],
   period: HistoryPeriod,
 ): { date: Date; value: number }[] {
+  if (period === "all") {
+    return aggregateByYear(rawPoints, (point) => point.count, "sum");
+  }
+
   if (period === "6months") {
     return aggregateByWeek(rawPoints, (point) => point.count, "sum");
   }


### PR DESCRIPTION
## Summary

- Add `"all"` to `HistoryPeriod` type with yearly aggregation (groups daily data into yearly sums/averages)
- Current range spans from app launch year (2025) to end of current year; previous range is empty so comparison indicators naturally hide
- Add `aggregateByYear` and `aggregateScoreByYear` utilities reusing existing `aggregateByPeriod` infrastructure
- Thread `"all"` through both admin and main app: period tabs, date ranges, labels, data functions, and comparison indicators

## Test plan

- [x] Unit tests for `validatePeriod`, `calculateDateRanges`, `formatLabel`, `aggregateByYear`, `aggregateScoreByYear`, `buildChartData` with "all"
- [x] Integration tests for `getEnergyHistory`, `getScoreHistory`, `getBpHistory` with "all" period
- [x] E2E tests for energy, score, and level pages verifying "All" button hides comparison text
- [x] E2E tests verified stable across 4 consecutive runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an “All” period to performance charts with yearly aggregation from app launch (2025) through the current year. Updates tabs, labels, data processing, and i18n, and hides comparisons for this view.

- **New Features**
  - Yearly aggregation for “all”: sum for Brain Power, average for Energy, computed score for Answers.
  - Date range spans 2025 → end of current year; previous range empty so comparison indicators hide.
  - “All” tab added to admin and main apps; labels show “YYYY - YYYY” and point labels show year.
  - New utils: aggregateByYear and aggregateScoreByYear; wired through buildChartData and data fetchers.
  - i18n entries added for “All” and “all time”; unit, integration, and E2E tests cover the new period.

<sup>Written for commit a57fcbaa73453db20db30e79626fe608ab3a5b59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

