### PR TITLE
fix(utils): make daily metrics timezone-aware and chart dates explicitly UTC

### DIFF
--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
@@ -107,6 +107,7 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
       courseId: activity.lesson.chapter.courseId,
       durationSeconds,
       isChallenge,
+      localDate: input.localDate,
       organizationId: activity.organizationId,
       score,
       startedAt: new Date(input.startedAt),

--- a/apps/main/src/data/progress/submit-activity-completion.test.ts
+++ b/apps/main/src/data/progress/submit-activity-completion.test.ts
@@ -7,8 +7,14 @@ import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { userProgressFixture } from "@zoonk/testing/fixtures/progress";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { userFixture } from "@zoonk/testing/fixtures/users";
+import { parseLocalDate } from "@zoonk/utils/date";
 import { beforeAll, describe, expect, test } from "vitest";
 import { submitActivityCompletion } from "./submit-activity-completion";
+
+function todayLocalDate(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}-${String(now.getUTCDate()).padStart(2, "0")}`;
+}
 
 describe(submitActivityCompletion, () => {
   let org: Awaited<ReturnType<typeof organizationFixture>>;
@@ -64,6 +70,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 10,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
@@ -91,6 +98,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 15,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 15_000),
@@ -116,6 +124,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 10,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
@@ -139,6 +148,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 10,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: org.id,
       score: { brainPower: 10, correctCount: 3, energyDelta: 0.4, incorrectCount: 2 },
       startedAt: new Date(Date.now() - 10_000),
@@ -169,6 +179,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 10,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: org.id,
       score: { brainPower: 10, correctCount: 5, energyDelta: 1, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
@@ -191,6 +202,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 10,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: org.id,
       score: { brainPower: 10, correctCount: 0, energyDelta: -0.5, incorrectCount: 5 },
       startedAt: new Date(Date.now() - 10_000),
@@ -211,6 +223,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 10,
       isChallenge: true,
+      localDate: todayLocalDate(),
       organizationId: org.id,
       score: { brainPower: 100, correctCount: 0, energyDelta: 3, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
@@ -237,6 +250,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 10,
       isChallenge: true,
+      localDate: todayLocalDate(),
       organizationId: org.id,
       score: { brainPower: 10, correctCount: 0, energyDelta: 0.1, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
@@ -257,6 +271,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 10,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
@@ -291,6 +306,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 5,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: org.id,
       score: { brainPower: 10, correctCount: 0, energyDelta: 0.1, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 5000),
@@ -317,6 +333,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 10,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
@@ -338,6 +355,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 10,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: null,
       score: { brainPower: 10, correctCount: 2, energyDelta: 0.3, incorrectCount: 1 },
       startedAt: new Date(Date.now() - 10_000),
@@ -365,6 +383,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 10,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: null as number | null,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
@@ -394,6 +413,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 10,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: null,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
@@ -420,6 +440,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 10,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
@@ -445,6 +466,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 10,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
@@ -490,6 +512,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 10,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
@@ -527,6 +550,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 20,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 20_000),
@@ -541,6 +565,121 @@ describe(submitActivityCompletion, () => {
     expect(progress?.completedAt).not.toBeNull();
     expect(progress?.durationSeconds).toBe(20);
     expect(progress?.startedAt).toEqual(startRecord?.startedAt);
+  });
+
+  test("stores DailyProgress date from localDate, not server UTC", async () => {
+    const user = await userFixture();
+    const userId = Number(user.id);
+
+    await submitActivityCompletion({
+      activityId: activity.id,
+      courseId: course.id,
+      durationSeconds: 10,
+      isChallenge: false,
+      localDate: "2026-03-05",
+      organizationId: org.id,
+      score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
+      startedAt: new Date(Date.now() - 10_000),
+      stepResults: [stepResult(true)],
+      userId,
+    });
+
+    const daily = await prisma.dailyProgress.findFirst({
+      where: { organizationId: org.id, userId },
+    });
+
+    expect(daily).not.toBeNull();
+    expect(daily?.date).toEqual(new Date(Date.UTC(2026, 2, 5)));
+  });
+
+  test("rejects localDate too far in the future", async () => {
+    const user = await userFixture();
+    const userId = Number(user.id);
+
+    await expect(
+      submitActivityCompletion({
+        activityId: activity.id,
+        courseId: course.id,
+        durationSeconds: 10,
+        isChallenge: false,
+        localDate: "9999-12-31",
+        organizationId: org.id,
+        score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
+        startedAt: new Date(Date.now() - 10_000),
+        stepResults: [stepResult(true)],
+        userId,
+      }),
+    ).rejects.toThrow("localDate is too far from server time");
+  });
+
+  test("rejects localDate too far in the past", async () => {
+    const user = await userFixture();
+    const userId = Number(user.id);
+
+    await expect(
+      submitActivityCompletion({
+        activityId: activity.id,
+        courseId: course.id,
+        durationSeconds: 10,
+        isChallenge: false,
+        localDate: "2020-01-01",
+        organizationId: org.id,
+        score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
+        startedAt: new Date(Date.now() - 10_000),
+        stepResults: [stepResult(true)],
+        userId,
+      }),
+    ).rejects.toThrow("localDate is too far from server time");
+  });
+
+  test("decay uses localDate so gaps and energy stay consistent", async () => {
+    const user = await userFixture();
+    const userId = Number(user.id);
+
+    const localDate = todayLocalDate();
+    const todayMs = parseLocalDate(localDate).getTime();
+    const fiveDaysBefore = new Date(todayMs - 5 * 86_400_000);
+
+    await userProgressFixture({
+      currentEnergy: 50,
+      lastActiveAt: fiveDaysBefore,
+      userId,
+    });
+
+    await submitActivityCompletion({
+      activityId: activity.id,
+      courseId: course.id,
+      durationSeconds: 10,
+      isChallenge: false,
+      localDate,
+      organizationId: org.id,
+      score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
+      startedAt: new Date(Date.now() - 10_000),
+      stepResults: [stepResult(true)],
+      userId,
+    });
+
+    // 5 day gap → 4 inactive days → decay=4 → base=46, +0.2 → 46.2
+    const userProgress = await prisma.userProgress.findUnique({ where: { userId } });
+    expect(userProgress?.currentEnergy).toBeCloseTo(46.2);
+
+    // 4 gap records (one per inactive day)
+    const gapRecords = await prisma.dailyProgress.findMany({
+      orderBy: { date: "asc" },
+      where: { organizationId: null, userId },
+    });
+
+    expect(gapRecords).toHaveLength(4);
+    expect(gapRecords[0]?.energyAtEnd).toBe(49);
+    expect(gapRecords[3]?.energyAtEnd).toBe(46);
+
+    // Today's record uses localDate
+    const todayRecord = await prisma.dailyProgress.findFirst({
+      where: { organizationId: org.id, userId },
+    });
+
+    expect(todayRecord?.date).toEqual(parseLocalDate(localDate));
+    expect(todayRecord?.energyAtEnd).toBeCloseTo(46.2);
   });
 
   test("applies decay and fills DailyProgress gaps for inactive days", async () => {
@@ -564,6 +703,7 @@ describe(submitActivityCompletion, () => {
       courseId: course.id,
       durationSeconds: 10,
       isChallenge: false,
+      localDate: todayLocalDate(),
       organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),

--- a/apps/main/src/data/progress/submit-activity-completion.ts
+++ b/apps/main/src/data/progress/submit-activity-completion.ts
@@ -161,6 +161,9 @@ export async function submitActivityCompletion(input: {
   const now = new Date();
   const today = parseLocalDate(input.localDate);
 
+  // localDate is client-provided, so a malicious client could send a far-future
+  // date and cause fillDecayGaps to create millions of records. The ±48h window
+  // is generous enough for all real timezone differences (max ~14h).
   if (Math.abs(today.getTime() - now.getTime()) > MAX_LOCAL_DATE_DRIFT_MS) {
     throw new Error("localDate is too far from server time");
   }

--- a/apps/main/src/data/progress/submit-activity-completion.ts
+++ b/apps/main/src/data/progress/submit-activity-completion.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { type TransactionClient, prisma } from "@zoonk/db";
 import { type ScoreResult } from "@zoonk/player/compute-score";
 import { type BeltLevelResult, calculateBeltLevel } from "@zoonk/utils/belt-level";
-import { MS_PER_DAY } from "@zoonk/utils/date";
+import { MS_PER_DAY, parseLocalDate } from "@zoonk/utils/date";
 import {
   DAILY_DECAY,
   MIN_ENERGY,
@@ -10,6 +10,8 @@ import {
   computeDecayedEnergy,
   toUTCMidnight,
 } from "@zoonk/utils/energy";
+
+const MAX_LOCAL_DATE_DRIFT_MS = 2 * MS_PER_DAY;
 
 function getCompletionField(input: {
   isChallenge: boolean;
@@ -135,6 +137,7 @@ export async function submitActivityCompletion(input: {
   courseId: number;
   durationSeconds: number;
   isChallenge: boolean;
+  localDate: string;
   organizationId: number | null;
   score: ScoreResult;
   startedAt: Date;
@@ -156,7 +159,11 @@ export async function submitActivityCompletion(input: {
   newTotalBp: number;
 }> {
   const now = new Date();
-  const today = toUTCMidnight(now);
+  const today = parseLocalDate(input.localDate);
+
+  if (Math.abs(today.getTime() - now.getTime()) > MAX_LOCAL_DATE_DRIFT_MS) {
+    throw new Error("localDate is too far from server time");
+  }
 
   return prisma.$transaction(async (tx) => {
     // Create StepAttempt records
@@ -217,7 +224,7 @@ export async function submitActivityCompletion(input: {
     });
 
     const decayedBase = existingProgress
-      ? computeDecayedEnergy(existingProgress.currentEnergy, existingProgress.lastActiveAt, now)
+      ? computeDecayedEnergy(existingProgress.currentEnergy, existingProgress.lastActiveAt, today)
       : 0;
 
     // Fill DailyProgress records for inactive days
@@ -252,7 +259,7 @@ export async function submitActivityCompletion(input: {
     await upsertDailyProgress(tx, {
       clampedEnergy,
       date: today,
-      dayOfWeek: now.getUTCDay(),
+      dayOfWeek: today.getUTCDay(),
       durationSeconds: input.durationSeconds,
       field,
       organizationId: input.organizationId,

--- a/packages/e2e/src/helpers.ts
+++ b/packages/e2e/src/helpers.ts
@@ -185,12 +185,12 @@ const ALL_PERIODS = ["month", "6months", "year"] as const;
 function buildGroupDates(today: Date, range: { start: Date; end: Date }, isCurrent: boolean) {
   const baseDate = isCurrent
     ? today
-    : new Date(range.start.getFullYear(), range.start.getMonth(), MID_MONTH_DAY);
+    : new Date(Date.UTC(range.start.getUTCFullYear(), range.start.getUTCMonth(), MID_MONTH_DAY));
 
   return Array.from({ length: DAYS_PER_GROUP }, (_, i) => {
-    const date = new Date(baseDate);
-    date.setDate(baseDate.getDate() - i);
-    date.setHours(0, 0, 0, 0);
+    const date = new Date(
+      Date.UTC(baseDate.getUTCFullYear(), baseDate.getUTCMonth(), baseDate.getUTCDate() - i),
+    );
 
     if (date < range.start || date > range.end) {
       return null;
@@ -215,7 +215,7 @@ function buildDailyProgressInputs(today: Date, orgId: number, userId: number) {
   const seen = new Set<string>();
   return dateEntries
     .filter(({ date }) => {
-      const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+      const key = `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
       if (seen.has(key)) {
         return false;
       }
@@ -269,7 +269,7 @@ async function createE2EProgressData(userId: number): Promise<void> {
   const org = await getAiOrganization();
   const uniqueId = randomUUID().slice(0, UUID_SHORT_LENGTH);
   const now = new Date();
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
 
   const course = await courseFixture({
     isPublished: true,

--- a/packages/player/src/completion-input-schema.ts
+++ b/packages/player/src/completion-input-schema.ts
@@ -68,6 +68,7 @@ export const completionInputSchema = z.object({
   activityId: z.string(),
   answers: z.record(z.string(), selectedAnswerSchema),
   dimensions: z.record(z.string(), z.number()),
+  localDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   startedAt: z.number(),
   stepTimings: z.record(z.string(), stepTimingSchema),
 });

--- a/packages/player/src/use-player-actions.ts
+++ b/packages/player/src/use-player-actions.ts
@@ -36,10 +36,14 @@ export function usePlayerActions(
 
   const fireCompletion = useCallback(
     (completionState: PlayerState) => {
+      const now = new Date();
+      const localDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+
       void onComplete({
         activityId: completionState.activityId,
         answers: completionState.selectedAnswers,
         dimensions: completionState.dimensions,
+        localDate,
         startedAt: completionState.startedAt,
         stepTimings: completionState.stepTimings,
       })

--- a/packages/utils/src/aggregation.test.ts
+++ b/packages/utils/src/aggregation.test.ts
@@ -8,9 +8,9 @@ import {
 
 describe("aggregateByPeriod - week", () => {
   const dataPoints = [
-    { date: new Date(2026, 2, 2), value: 10 }, // Monday
-    { date: new Date(2026, 2, 3), value: 20 }, // Tuesday (same week)
-    { date: new Date(2026, 2, 9), value: 30 }, // Next Monday (different week)
+    { date: new Date(Date.UTC(2026, 2, 2)), value: 10 }, // Monday
+    { date: new Date(Date.UTC(2026, 2, 3)), value: 20 }, // Tuesday (same week)
+    { date: new Date(Date.UTC(2026, 2, 9)), value: 30 }, // Next Monday (different week)
   ];
 
   it("aggregates by sum", () => {
@@ -33,9 +33,9 @@ describe("aggregateByPeriod - week", () => {
 
 describe("aggregateByPeriod - month", () => {
   const dataPoints = [
-    { date: new Date(2026, 0, 5), value: 10 },
-    { date: new Date(2026, 0, 20), value: 20 },
-    { date: new Date(2026, 1, 10), value: 30 },
+    { date: new Date(Date.UTC(2026, 0, 5)), value: 10 },
+    { date: new Date(Date.UTC(2026, 0, 20)), value: 20 },
+    { date: new Date(Date.UTC(2026, 1, 10)), value: 30 },
   ];
 
   it("aggregates by sum", () => {
@@ -58,9 +58,9 @@ describe("aggregateByPeriod - month", () => {
 
 describe("aggregateByPeriod - year", () => {
   const dataPoints = [
-    { date: new Date(2025, 3, 10), value: 10 },
-    { date: new Date(2025, 8, 20), value: 20 },
-    { date: new Date(2026, 1, 5), value: 30 },
+    { date: new Date(Date.UTC(2025, 3, 10)), value: 10 },
+    { date: new Date(Date.UTC(2025, 8, 20)), value: 20 },
+    { date: new Date(Date.UTC(2026, 1, 5)), value: 30 },
   ];
 
   it("aggregates by sum", () => {
@@ -88,9 +88,9 @@ function calcScore(correct: number, incorrect: number) {
 describe("aggregateScoreByPeriod - year", () => {
   it("aggregates correct/incorrect by year and calculates score", () => {
     const dataPoints = [
-      { correct: 8, date: new Date(2025, 3, 10), incorrect: 2 },
-      { correct: 6, date: new Date(2025, 8, 20), incorrect: 4 },
-      { correct: 9, date: new Date(2026, 1, 5), incorrect: 1 },
+      { correct: 8, date: new Date(Date.UTC(2025, 3, 10)), incorrect: 2 },
+      { correct: 6, date: new Date(Date.UTC(2025, 8, 20)), incorrect: 4 },
+      { correct: 9, date: new Date(Date.UTC(2026, 1, 5)), incorrect: 1 },
     ];
 
     const result = aggregateScoreByPeriod(dataPoints, calcScore, "year");
@@ -105,9 +105,9 @@ describe("aggregateScoreByPeriod - year", () => {
 describe("aggregateScoreByPeriod - week", () => {
   it("aggregates correct/incorrect by week and calculates score", () => {
     const dataPoints = [
-      { correct: 8, date: new Date(2026, 2, 2), incorrect: 2 }, // Monday
-      { correct: 6, date: new Date(2026, 2, 3), incorrect: 4 }, // Tuesday (same week)
-      { correct: 9, date: new Date(2026, 2, 9), incorrect: 1 }, // Next Monday
+      { correct: 8, date: new Date(Date.UTC(2026, 2, 2)), incorrect: 2 }, // Monday
+      { correct: 6, date: new Date(Date.UTC(2026, 2, 3)), incorrect: 4 }, // Tuesday (same week)
+      { correct: 9, date: new Date(Date.UTC(2026, 2, 9)), incorrect: 1 }, // Next Monday
     ];
 
     const result = aggregateScoreByPeriod(dataPoints, calcScore, "week");
@@ -122,9 +122,9 @@ describe("aggregateScoreByPeriod - week", () => {
 describe("aggregateScoreByPeriod - month", () => {
   it("aggregates correct/incorrect by month and calculates score", () => {
     const dataPoints = [
-      { correct: 8, date: new Date(2026, 0, 5), incorrect: 2 },
-      { correct: 6, date: new Date(2026, 0, 20), incorrect: 4 },
-      { correct: 9, date: new Date(2026, 1, 10), incorrect: 1 },
+      { correct: 8, date: new Date(Date.UTC(2026, 0, 5)), incorrect: 2 },
+      { correct: 6, date: new Date(Date.UTC(2026, 0, 20)), incorrect: 4 },
+      { correct: 9, date: new Date(Date.UTC(2026, 1, 10)), incorrect: 1 },
     ];
 
     const result = aggregateScoreByPeriod(dataPoints, calcScore, "month");

--- a/packages/utils/src/aggregation.ts
+++ b/packages/utils/src/aggregation.ts
@@ -8,20 +8,19 @@ type TimePeriodConfig = {
 const SUNDAY_DAYS_SINCE_MONDAY = 6;
 
 function getMondayOfWeek(date: Date): Date {
-  const monday = new Date(date);
-  const dayOfWeek = monday.getDay();
+  const dayOfWeek = date.getUTCDay();
   const daysSinceMonday = dayOfWeek === 0 ? SUNDAY_DAYS_SINCE_MONDAY : dayOfWeek - 1;
-  monday.setDate(date.getDate() - daysSinceMonday);
-  monday.setHours(0, 0, 0, 0);
-  return monday;
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() - daysSinceMonday),
+  );
 }
 
 function getFirstOfMonth(date: Date): Date {
-  return new Date(date.getFullYear(), date.getMonth(), 1);
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
 }
 
 function getFirstOfYear(date: Date): Date {
-  return new Date(date.getFullYear(), 0, 1);
+  return new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
 }
 
 function getWeekKey(date: Date): string {
@@ -29,11 +28,11 @@ function getWeekKey(date: Date): string {
 }
 
 function getMonthKey(date: Date): string {
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
 }
 
 function getYearKey(date: Date): string {
-  return date.getFullYear().toString();
+  return date.getUTCFullYear().toString();
 }
 
 const PERIOD_CONFIGS: Record<TimePeriod, TimePeriodConfig> = {

--- a/packages/utils/src/chart.test.ts
+++ b/packages/utils/src/chart.test.ts
@@ -45,37 +45,44 @@ describe(isValidChartPayload, () => {
 
 describe(formatLabel, () => {
   it("formats month period as day + short month", () => {
-    const date = new Date(2026, 2, 15);
+    const date = new Date(Date.UTC(2026, 2, 15));
     const result = formatLabel(date, "month", "en");
     expect(result).toContain("Mar");
     expect(result).toContain("15");
   });
 
   it("formats 6months period as week number", () => {
-    const date = new Date(2026, 0, 15);
+    const date = new Date(Date.UTC(2026, 0, 15));
     const result = formatLabel(date, "6months", "en");
     expect(result).toMatch(/^W\d+$/);
   });
 
   it("formats year period as short month", () => {
-    const date = new Date(2026, 2, 15);
+    const date = new Date(Date.UTC(2026, 2, 15));
     const result = formatLabel(date, "year", "en");
     expect(result).toBe("Mar");
   });
 
   it("formats all period as year string", () => {
-    const date = new Date(2026, 0, 1);
+    const date = new Date(Date.UTC(2026, 0, 1));
     const result = formatLabel(date, "all", "en");
     expect(result).toBe("2026");
+  });
+
+  it("formats UTC midnight date correctly (no timezone shift)", () => {
+    const date = new Date("2026-03-01T00:00:00Z");
+    const result = formatLabel(date, "month", "en");
+    expect(result).toContain("Mar");
+    expect(result).toContain("1");
   });
 });
 
 describe(buildChartData, () => {
   const rawPoints = [
-    { count: 10, date: new Date(2026, 0, 5) },
-    { count: 20, date: new Date(2026, 0, 6) },
-    { count: 30, date: new Date(2026, 0, 20) },
-    { count: 40, date: new Date(2026, 1, 10) },
+    { count: 10, date: new Date(Date.UTC(2026, 0, 5)) },
+    { count: 20, date: new Date(Date.UTC(2026, 0, 6)) },
+    { count: 30, date: new Date(Date.UTC(2026, 0, 20)) },
+    { count: 40, date: new Date(Date.UTC(2026, 1, 10)) },
   ];
 
   it("returns daily data points for 'month' period (no aggregation)", () => {
@@ -99,9 +106,9 @@ describe(buildChartData, () => {
 
   it("aggregates to yearly sums for 'all' period", () => {
     const crossYearPoints = [
-      { count: 10, date: new Date(2025, 3, 5) },
-      { count: 20, date: new Date(2025, 8, 6) },
-      { count: 30, date: new Date(2026, 1, 10) },
+      { count: 10, date: new Date(Date.UTC(2025, 3, 5)) },
+      { count: 20, date: new Date(Date.UTC(2025, 8, 6)) },
+      { count: 30, date: new Date(Date.UTC(2026, 1, 10)) },
     ];
     const result = buildChartData(crossYearPoints, "all", "en");
     expect(result.dataPoints).toHaveLength(2);

--- a/packages/utils/src/chart.ts
+++ b/packages/utils/src/chart.ts
@@ -17,25 +17,25 @@ export function isValidChartPayload<T>(
 
 export function formatLabel(date: Date, period: HistoryPeriod, locale: string): string {
   if (period === "all") {
-    return date.getFullYear().toString();
+    return date.getUTCFullYear().toString();
   }
 
   if (period === "month") {
     return new Intl.DateTimeFormat(locale, {
       day: "numeric",
       month: "short",
+      timeZone: "UTC",
     }).format(date);
   }
 
   if (period === "6months") {
-    const weekNum = Math.ceil(
-      (date.getTime() - new Date(date.getFullYear(), 0, 1).getTime()) / MILLISECONDS_PER_WEEK,
-    );
+    const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+    const weekNum = Math.ceil((date.getTime() - yearStart.getTime()) / MILLISECONDS_PER_WEEK);
     return `W${weekNum}`;
   }
 
   // Year - show month name
-  return new Intl.DateTimeFormat(locale, { month: "short" }).format(date);
+  return new Intl.DateTimeFormat(locale, { month: "short", timeZone: "UTC" }).format(date);
 }
 
 function getAggregatedPoints(

--- a/packages/utils/src/date-ranges.test.ts
+++ b/packages/utils/src/date-ranges.test.ts
@@ -35,110 +35,110 @@ describe(validatePeriod, () => {
 describe(calculateDateRanges, () => {
   it("returns current and previous month for 'month' period in March", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 2, 15)); // March 15, 2026
+    vi.setSystemTime(new Date(Date.UTC(2026, 2, 15)));
 
     const ranges = calculateDateRanges("month", 0);
 
-    expect(ranges.current.start).toEqual(new Date(2026, 2, 1));
-    expect(ranges.current.end).toEqual(new Date(2026, 2, 31));
-    expect(ranges.previous.start).toEqual(new Date(2026, 1, 1));
-    expect(ranges.previous.end).toEqual(new Date(2026, 1, 28));
+    expect(ranges.current.start).toEqual(new Date(Date.UTC(2026, 2, 1)));
+    expect(ranges.current.end).toEqual(new Date(Date.UTC(2026, 2, 31)));
+    expect(ranges.previous.start).toEqual(new Date(Date.UTC(2026, 1, 1)));
+    expect(ranges.previous.end).toEqual(new Date(Date.UTC(2026, 1, 28)));
 
     vi.useRealTimers();
   });
 
   it("returns offset month for 'month' period with offset=1", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 2, 15)); // March 15, 2026
+    vi.setSystemTime(new Date(Date.UTC(2026, 2, 15)));
 
     const ranges = calculateDateRanges("month", 1);
 
-    expect(ranges.current.start).toEqual(new Date(2026, 1, 1));
-    expect(ranges.current.end).toEqual(new Date(2026, 1, 28));
-    expect(ranges.previous.start).toEqual(new Date(2026, 0, 1));
-    expect(ranges.previous.end).toEqual(new Date(2026, 0, 31));
+    expect(ranges.current.start).toEqual(new Date(Date.UTC(2026, 1, 1)));
+    expect(ranges.current.end).toEqual(new Date(Date.UTC(2026, 1, 28)));
+    expect(ranges.previous.start).toEqual(new Date(Date.UTC(2026, 0, 1)));
+    expect(ranges.previous.end).toEqual(new Date(Date.UTC(2026, 0, 31)));
 
     vi.useRealTimers();
   });
 
   it("returns correct half-year ranges in January (H1)", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 0, 15)); // January 15, 2026
+    vi.setSystemTime(new Date(Date.UTC(2026, 0, 15)));
 
     const ranges = calculateDateRanges("6months", 0);
 
-    expect(ranges.current.start).toEqual(new Date(2026, 0, 1));
-    expect(ranges.current.end).toEqual(new Date(2026, 5, 30));
-    expect(ranges.previous.start).toEqual(new Date(2025, 6, 1));
-    expect(ranges.previous.end).toEqual(new Date(2025, 11, 31));
+    expect(ranges.current.start).toEqual(new Date(Date.UTC(2026, 0, 1)));
+    expect(ranges.current.end).toEqual(new Date(Date.UTC(2026, 5, 30)));
+    expect(ranges.previous.start).toEqual(new Date(Date.UTC(2025, 6, 1)));
+    expect(ranges.previous.end).toEqual(new Date(Date.UTC(2025, 11, 31)));
 
     vi.useRealTimers();
   });
 
   it("returns correct half-year ranges in July (H2)", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 6, 15)); // July 15, 2026
+    vi.setSystemTime(new Date(Date.UTC(2026, 6, 15)));
 
     const ranges = calculateDateRanges("6months", 0);
 
-    expect(ranges.current.start).toEqual(new Date(2026, 6, 1));
-    expect(ranges.current.end).toEqual(new Date(2026, 11, 31));
-    expect(ranges.previous.start).toEqual(new Date(2026, 0, 1));
-    expect(ranges.previous.end).toEqual(new Date(2026, 5, 30));
+    expect(ranges.current.start).toEqual(new Date(Date.UTC(2026, 6, 1)));
+    expect(ranges.current.end).toEqual(new Date(Date.UTC(2026, 11, 31)));
+    expect(ranges.previous.start).toEqual(new Date(Date.UTC(2026, 0, 1)));
+    expect(ranges.previous.end).toEqual(new Date(Date.UTC(2026, 5, 30)));
 
     vi.useRealTimers();
   });
 
   it("returns correct year ranges in March", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 2, 15)); // March 15, 2026
+    vi.setSystemTime(new Date(Date.UTC(2026, 2, 15)));
 
     const ranges = calculateDateRanges("year", 0);
 
-    expect(ranges.current.start).toEqual(new Date(2026, 0, 1));
-    expect(ranges.current.end).toEqual(new Date(2026, 11, 31));
-    expect(ranges.previous.start).toEqual(new Date(2025, 0, 1));
-    expect(ranges.previous.end).toEqual(new Date(2025, 11, 31));
+    expect(ranges.current.start).toEqual(new Date(Date.UTC(2026, 0, 1)));
+    expect(ranges.current.end).toEqual(new Date(Date.UTC(2026, 11, 31)));
+    expect(ranges.previous.start).toEqual(new Date(Date.UTC(2025, 0, 1)));
+    expect(ranges.previous.end).toEqual(new Date(Date.UTC(2025, 11, 31)));
 
     vi.useRealTimers();
   });
 
   it("returns correct year ranges in December", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 11, 25)); // December 25, 2026
+    vi.setSystemTime(new Date(Date.UTC(2026, 11, 25)));
 
     const ranges = calculateDateRanges("year", 0);
 
-    expect(ranges.current.start).toEqual(new Date(2026, 0, 1));
-    expect(ranges.current.end).toEqual(new Date(2026, 11, 31));
-    expect(ranges.previous.start).toEqual(new Date(2025, 0, 1));
-    expect(ranges.previous.end).toEqual(new Date(2025, 11, 31));
+    expect(ranges.current.start).toEqual(new Date(Date.UTC(2026, 0, 1)));
+    expect(ranges.current.end).toEqual(new Date(Date.UTC(2026, 11, 31)));
+    expect(ranges.previous.start).toEqual(new Date(Date.UTC(2025, 0, 1)));
+    expect(ranges.previous.end).toEqual(new Date(Date.UTC(2025, 11, 31)));
 
     vi.useRealTimers();
   });
 
   it("returns offset year ranges with offset=1", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 2, 15)); // March 15, 2026
+    vi.setSystemTime(new Date(Date.UTC(2026, 2, 15)));
 
     const ranges = calculateDateRanges("year", 1);
 
-    expect(ranges.current.start).toEqual(new Date(2025, 0, 1));
-    expect(ranges.current.end).toEqual(new Date(2025, 11, 31));
-    expect(ranges.previous.start).toEqual(new Date(2024, 0, 1));
-    expect(ranges.previous.end).toEqual(new Date(2024, 11, 31));
+    expect(ranges.current.start).toEqual(new Date(Date.UTC(2025, 0, 1)));
+    expect(ranges.current.end).toEqual(new Date(Date.UTC(2025, 11, 31)));
+    expect(ranges.previous.start).toEqual(new Date(Date.UTC(2024, 0, 1)));
+    expect(ranges.previous.end).toEqual(new Date(Date.UTC(2024, 11, 31)));
 
     vi.useRealTimers();
   });
 
   it("returns all-time range for 'all' period", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 2, 15)); // March 15, 2026
+    vi.setSystemTime(new Date(Date.UTC(2026, 2, 15)));
 
     const ranges = calculateDateRanges("all", 0);
 
-    expect(ranges.current.start).toEqual(new Date(2025, 0, 1));
-    expect(ranges.current.end).toEqual(new Date(2026, 11, 31));
+    expect(ranges.current.start).toEqual(new Date(Date.UTC(2025, 0, 1)));
+    expect(ranges.current.end).toEqual(new Date(Date.UTC(2026, 11, 31)));
     expect(ranges.previous.start).toEqual(new Date(0));
     expect(ranges.previous.end).toEqual(new Date(0));
 
@@ -155,11 +155,10 @@ describe(getDefaultStartDate, () => {
 
   it("returns lookback date when no ISO string provided", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 2, 15));
+    vi.setSystemTime(new Date(Date.UTC(2026, 2, 15)));
 
     const result = getDefaultStartDate();
-    const expected = new Date(2026, 2, 15);
-    expected.setDate(expected.getDate() - 90);
+    const expected = new Date(Date.UTC(2026, 2, 15 - 90));
 
     expect(result.toISOString().slice(0, 10)).toBe(expected.toISOString().slice(0, 10));
 
@@ -169,30 +168,37 @@ describe(getDefaultStartDate, () => {
 
 describe(formatPeriodLabel, () => {
   it("formats month period as full month and year", () => {
-    const start = new Date(2026, 2, 1);
-    const end = new Date(2026, 2, 31);
+    const start = new Date(Date.UTC(2026, 2, 1));
+    const end = new Date(Date.UTC(2026, 2, 31));
     const result = formatPeriodLabel(start, end, "month", "en");
     expect(result).toBe("March 2026");
   });
 
   it("formats 6months period as short month range with year", () => {
-    const start = new Date(2026, 0, 1);
-    const end = new Date(2026, 5, 30);
+    const start = new Date(Date.UTC(2026, 0, 1));
+    const end = new Date(Date.UTC(2026, 5, 30));
     const result = formatPeriodLabel(start, end, "6months", "en");
     expect(result).toBe("Jan - Jun 2026");
   });
 
   it("formats year period as year number", () => {
-    const start = new Date(2026, 0, 1);
-    const end = new Date(2026, 11, 31);
+    const start = new Date(Date.UTC(2026, 0, 1));
+    const end = new Date(Date.UTC(2026, 11, 31));
     const result = formatPeriodLabel(start, end, "year", "en");
     expect(result).toBe("2026");
   });
 
   it("formats all period as year range", () => {
-    const start = new Date(2025, 0, 1);
-    const end = new Date(2026, 11, 31);
+    const start = new Date(Date.UTC(2025, 0, 1));
+    const end = new Date(Date.UTC(2026, 11, 31));
     const result = formatPeriodLabel(start, end, "all", "en");
     expect(result).toBe("2025 - 2026");
+  });
+
+  it("formats UTC midnight date correctly (no timezone shift)", () => {
+    const start = new Date("2026-03-01T00:00:00Z");
+    const end = new Date("2026-03-31T00:00:00Z");
+    const result = formatPeriodLabel(start, end, "month", "en");
+    expect(result).toBe("March 2026");
   });
 });

--- a/packages/utils/src/date-ranges.ts
+++ b/packages/utils/src/date-ranges.ts
@@ -20,10 +20,10 @@ type DateRange = { start: Date; end: Date };
 type DateRanges = { current: DateRange; previous: DateRange };
 
 function getMonthDateRanges(now: Date, offset: number): DateRanges {
-  const currentStart = new Date(now.getFullYear(), now.getMonth() - offset, 1);
-  const currentEnd = new Date(now.getFullYear(), now.getMonth() - offset + 1, 0);
-  const previousStart = new Date(now.getFullYear(), now.getMonth() - offset - 1, 1);
-  const previousEnd = new Date(now.getFullYear(), now.getMonth() - offset, 0);
+  const currentStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset, 1));
+  const currentEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset + 1, 0));
+  const previousStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset - 1, 1));
+  const previousEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset, 0));
 
   return {
     current: { end: currentEnd, start: currentStart },
@@ -33,12 +33,14 @@ function getMonthDateRanges(now: Date, offset: number): DateRanges {
 
 function getHalfYearDateRanges(now: Date, offset: number): DateRanges {
   const startMonth =
-    (Math.floor(now.getMonth() / MONTHS_PER_HALF_YEAR) - offset) * MONTHS_PER_HALF_YEAR;
+    (Math.floor(now.getUTCMonth() / MONTHS_PER_HALF_YEAR) - offset) * MONTHS_PER_HALF_YEAR;
 
-  const currentStart = new Date(now.getFullYear(), startMonth, 1);
-  const currentEnd = new Date(now.getFullYear(), startMonth + MONTHS_PER_HALF_YEAR, 0);
-  const previousStart = new Date(now.getFullYear(), startMonth - MONTHS_PER_HALF_YEAR, 1);
-  const previousEnd = new Date(now.getFullYear(), startMonth, 0);
+  const currentStart = new Date(Date.UTC(now.getUTCFullYear(), startMonth, 1));
+  const currentEnd = new Date(Date.UTC(now.getUTCFullYear(), startMonth + MONTHS_PER_HALF_YEAR, 0));
+  const previousStart = new Date(
+    Date.UTC(now.getUTCFullYear(), startMonth - MONTHS_PER_HALF_YEAR, 1),
+  );
+  const previousEnd = new Date(Date.UTC(now.getUTCFullYear(), startMonth, 0));
 
   return {
     current: { end: currentEnd, start: currentStart },
@@ -47,11 +49,11 @@ function getHalfYearDateRanges(now: Date, offset: number): DateRanges {
 }
 
 function getYearDateRanges(now: Date, offset: number): DateRanges {
-  const currentYear = now.getFullYear() - offset;
-  const currentStart = new Date(currentYear, 0, 1);
-  const currentEnd = new Date(currentYear, DECEMBER_INDEX, LAST_DAY_OF_DECEMBER);
-  const previousStart = new Date(currentYear - 1, 0, 1);
-  const previousEnd = new Date(currentYear - 1, DECEMBER_INDEX, LAST_DAY_OF_DECEMBER);
+  const currentYear = now.getUTCFullYear() - offset;
+  const currentStart = new Date(Date.UTC(currentYear, 0, 1));
+  const currentEnd = new Date(Date.UTC(currentYear, DECEMBER_INDEX, LAST_DAY_OF_DECEMBER));
+  const previousStart = new Date(Date.UTC(currentYear - 1, 0, 1));
+  const previousEnd = new Date(Date.UTC(currentYear - 1, DECEMBER_INDEX, LAST_DAY_OF_DECEMBER));
 
   return {
     current: { end: currentEnd, start: currentStart },
@@ -64,8 +66,8 @@ function getAllDateRanges(): DateRanges {
 
   return {
     current: {
-      end: new Date(now.getFullYear(), DECEMBER_INDEX, LAST_DAY_OF_DECEMBER),
-      start: new Date(APP_LAUNCH_YEAR, 0, 1),
+      end: new Date(Date.UTC(now.getUTCFullYear(), DECEMBER_INDEX, LAST_DAY_OF_DECEMBER)),
+      start: new Date(Date.UTC(APP_LAUNCH_YEAR, 0, 1)),
     },
     previous: { end: new Date(0), start: new Date(0) },
   };
@@ -95,9 +97,11 @@ export function getDefaultStartDate(startDateIso?: string): Date {
   }
   const now = new Date();
   return new Date(
-    now.getFullYear(),
-    now.getMonth(),
-    now.getDate() - DEFAULT_PROGRESS_LOOKBACK_DAYS,
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() - DEFAULT_PROGRESS_LOOKBACK_DAYS,
+    ),
   );
 }
 
@@ -108,21 +112,30 @@ export function formatPeriodLabel(
   locale: string,
 ): string {
   if (period === "all") {
-    return `${periodStart.getFullYear()} - ${periodEnd.getFullYear()}`;
+    return `${periodStart.getUTCFullYear()} - ${periodEnd.getUTCFullYear()}`;
   }
 
   if (period === "month") {
     return new Intl.DateTimeFormat(locale, {
       month: "long",
+      timeZone: "UTC",
       year: "numeric",
     }).format(periodStart);
   }
 
   if (period === "6months") {
-    const startMonth = new Intl.DateTimeFormat(locale, { month: "short" }).format(periodStart);
-    const endMonth = new Intl.DateTimeFormat(locale, { month: "short" }).format(periodEnd);
-    return `${startMonth} - ${endMonth} ${periodStart.getFullYear()}`;
+    const startMonth = new Intl.DateTimeFormat(locale, {
+      month: "short",
+      timeZone: "UTC",
+    }).format(periodStart);
+
+    const endMonth = new Intl.DateTimeFormat(locale, {
+      month: "short",
+      timeZone: "UTC",
+    }).format(periodEnd);
+
+    return `${startMonth} - ${endMonth} ${periodStart.getUTCFullYear()}`;
   }
 
-  return String(periodStart.getFullYear());
+  return String(periodStart.getUTCFullYear());
 }

--- a/packages/utils/src/date.test.ts
+++ b/packages/utils/src/date.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { parseLocalDate } from "./date";
+
+describe(parseLocalDate, () => {
+  it("parses a valid YYYY-MM-DD string to UTC midnight", () => {
+    const result = parseLocalDate("2026-03-15");
+    expect(result).toEqual(new Date(Date.UTC(2026, 2, 15)));
+  });
+
+  it("returns UTC midnight (hours/minutes/seconds are zero)", () => {
+    const result = parseLocalDate("2026-06-01");
+    expect(result.getUTCHours()).toBe(0);
+    expect(result.getUTCMinutes()).toBe(0);
+    expect(result.getUTCSeconds()).toBe(0);
+  });
+
+  it("handles January correctly (month offset)", () => {
+    const result = parseLocalDate("2026-01-05");
+    expect(result).toEqual(new Date(Date.UTC(2026, 0, 5)));
+  });
+
+  it("handles December correctly", () => {
+    const result = parseLocalDate("2026-12-31");
+    expect(result).toEqual(new Date(Date.UTC(2026, 11, 31)));
+  });
+
+  it("handles leap day", () => {
+    const result = parseLocalDate("2028-02-29");
+    expect(result).toEqual(new Date(Date.UTC(2028, 1, 29)));
+  });
+});

--- a/packages/utils/src/date.ts
+++ b/packages/utils/src/date.ts
@@ -1,3 +1,8 @@
 export const MS_PER_DAY = 86_400_000;
 export const EPOCH_YEAR = 1970;
 export const FIRST_SUNDAY_OFFSET = 4;
+
+export function parseLocalDate(dateString: string): Date {
+  const parts = dateString.split("-").map(Number);
+  return new Date(Date.UTC(parts[0] ?? 0, (parts[1] ?? 1) - 1, parts[2] ?? 1));
+}

--- a/packages/utils/src/date.ts
+++ b/packages/utils/src/date.ts
@@ -2,6 +2,9 @@ export const MS_PER_DAY = 86_400_000;
 export const EPOCH_YEAR = 1970;
 export const FIRST_SUNDAY_OFFSET = 4;
 
+// Intentionally no calendar validation (e.g., month 0-12, Feb 30).
+// Zod regex ensures digit format; Date.UTC silently rolls over edge cases
+// (e.g., Feb 31 → Mar 3), which the server bounds check catches.
 export function parseLocalDate(dateString: string): Date {
   const parts = dateString.split("-").map(Number);
   return new Date(Date.UTC(parts[0] ?? 0, (parts[1] ?? 1) - 1, parts[2] ?? 1));


### PR DESCRIPTION
## Summary

- Client sends `localDate` (YYYY-MM-DD) so `DailyProgress` records reflect the user's local calendar day, not server UTC
- All chart/display utilities (`date-ranges`, `chart`, `aggregation`) switched to explicit UTC methods (`getUTCFullYear`, `Date.UTC`, `timeZone: "UTC"`) so dates render correctly regardless of machine timezone
- Server-side bounds check rejects `localDate` values more than ±2 days from server time
- Decay calculation (`computeDecayedEnergy`) now uses the same `localDate`-derived date as gap-filling to keep energy and gap records consistent

## Test plan

- [x] `parseLocalDate` unit tests (valid input, edge cases, leap day)
- [x] UTC edge case tests for `formatPeriodLabel` and `formatLabel` (UTC midnight dates display correctly)
- [x] All `date-ranges`, `chart`, `aggregation` tests updated to use `Date.UTC()` dates
- [x] Integration test: `localDate` stored correctly in `DailyProgress`
- [x] Integration test: decay + gaps consistent when using `localDate`
- [x] Integration tests: far-future and far-past `localDate` rejected
- [x] All tests pass under `TZ=America/Sao_Paulo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Daily metrics now use the user's local calendar day, and all charts/labels render in UTC to prevent timezone shifts.

- **New Features**
  - Player sends localDate (YYYY-MM-DD). Server stores DailyProgress using that date (UTC midnight).
  - Server rejects localDate values more than ±2 days from server time.
  - Energy decay and gap-filling use localDate so energy and gap records stay aligned.

- **Migration**
  - Clients must include localDate in the completion payload as YYYY-MM-DD.

<sup>Written for commit a57d47f8a3026f8876b8a138d2f9e820bc3b734f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

