### PR TITLE
chore(apps): disable cache components

### DIFF
--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -3,6 +3,7 @@ import { type NextConfig } from "next";
 const CACHE_IMAGE_DAYS = 30;
 
 const nextConfig: NextConfig = {
+  cacheComponents: true,
   devIndicators: false,
   experimental: {
     authInterrupts: true,

--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -3,7 +3,6 @@ import { type NextConfig } from "next";
 const CACHE_IMAGE_DAYS = 30;
 
 const nextConfig: NextConfig = {
-  cacheComponents: true,
   devIndicators: false,
   experimental: {
     authInterrupts: true,

--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -13,7 +13,6 @@ const e2eAliases: Record<string, string> = isE2E
   : {};
 
 const nextConfig: NextConfig = {
-  cacheComponents: true,
   devIndicators: false,
   distDir: isE2E ? ".next-e2e" : ".next",
   experimental: {

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -15,7 +15,6 @@ const e2eAliases: Record<string, string> = isE2E
   : {};
 
 const nextConfig: NextConfig = {
-  cacheComponents: true,
   devIndicators: false,
   // Use separate build directories so E2E and production builds don't conflict
   distDir: isE2E ? ".next-e2e" : ".next",

--- a/apps/evals/next.config.ts
+++ b/apps/evals/next.config.ts
@@ -2,7 +2,6 @@ import path from "node:path";
 import { type NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  cacheComponents: true,
   devIndicators: false,
   experimental: {
     typedEnv: true,

--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -14,7 +14,6 @@ const e2eAliases: Record<string, string> = isE2E
   : {};
 
 const nextConfig: NextConfig = {
-  cacheComponents: true,
   devIndicators: false,
   // Use separate build directories so E2E and production builds don't conflict
   distDir: isE2E ? ".next-e2e" : ".next",

--- a/apps/main/src/app/sitemaps/chapters/sitemap.ts
+++ b/apps/main/src/app/sitemaps/chapters/sitemap.ts
@@ -1,15 +1,9 @@
-"use cache";
-
 import { countSitemapChapters, listSitemapChapters } from "@/data/sitemaps/chapters";
 import { SITEMAP_BATCH_SIZE } from "@/data/sitemaps/courses";
 import { SITE_URL } from "@zoonk/utils/url";
 import { type MetadataRoute } from "next";
-import { cacheLife, cacheTag } from "next/cache";
 
 export async function generateSitemaps() {
-  cacheTag("sitemap");
-  cacheLife("weeks");
-
   const count = await countSitemapChapters();
   const pages = Math.ceil(count / SITEMAP_BATCH_SIZE);
   return Array.from({ length: Math.max(pages, 1) }, (_, i) => ({ id: i }));
@@ -18,9 +12,6 @@ export async function generateSitemaps() {
 export default async function sitemap(props: {
   id: Promise<string>;
 }): Promise<MetadataRoute.Sitemap> {
-  cacheTag("sitemap");
-  cacheLife("weeks");
-
   const id = Number(await props.id);
   const chapters = await listSitemapChapters(id);
 

--- a/apps/main/src/app/sitemaps/courses/sitemap.ts
+++ b/apps/main/src/app/sitemaps/courses/sitemap.ts
@@ -1,5 +1,3 @@
-"use cache";
-
 import {
   SITEMAP_BATCH_SIZE,
   countSitemapCourses,
@@ -7,12 +5,8 @@ import {
 } from "@/data/sitemaps/courses";
 import { SITE_URL } from "@zoonk/utils/url";
 import { type MetadataRoute } from "next";
-import { cacheLife, cacheTag } from "next/cache";
 
 export async function generateSitemaps() {
-  cacheTag("sitemap");
-  cacheLife("weeks");
-
   const count = await countSitemapCourses();
   const pages = Math.ceil(count / SITEMAP_BATCH_SIZE);
   return Array.from({ length: Math.max(pages, 1) }, (_, i) => ({ id: i }));
@@ -21,9 +15,6 @@ export async function generateSitemaps() {
 export default async function sitemap(props: {
   id: Promise<string>;
 }): Promise<MetadataRoute.Sitemap> {
-  cacheTag("sitemap");
-  cacheLife("weeks");
-
   const id = Number(await props.id);
   const courses = await listSitemapCourses(id);
 

--- a/apps/main/src/app/sitemaps/lessons/sitemap.ts
+++ b/apps/main/src/app/sitemaps/lessons/sitemap.ts
@@ -1,15 +1,9 @@
-"use cache";
-
 import { SITEMAP_BATCH_SIZE } from "@/data/sitemaps/courses";
 import { countSitemapLessons, listSitemapLessons } from "@/data/sitemaps/lessons";
 import { SITE_URL } from "@zoonk/utils/url";
 import { type MetadataRoute } from "next";
-import { cacheLife, cacheTag } from "next/cache";
 
 export async function generateSitemaps() {
-  cacheTag("sitemap");
-  cacheLife("weeks");
-
   const count = await countSitemapLessons();
   const pages = Math.ceil(count / SITEMAP_BATCH_SIZE);
   return Array.from({ length: Math.max(pages, 1) }, (_, i) => ({ id: i }));
@@ -18,9 +12,6 @@ export async function generateSitemaps() {
 export default async function sitemap(props: {
   id: Promise<string>;
 }): Promise<MetadataRoute.Sitemap> {
-  cacheTag("sitemap");
-  cacheLife("weeks");
-
   const id = Number(await props.id);
   const lessons = await listSitemapLessons(id);
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disabled Next.js component caching across all apps and removed sitemap cache usage to ensure fresh renders and avoid stale sitemap entries.

- **Refactors**
  - Removed cacheComponents from next.config in admin, api, editor, evals, and main.
  - Deleted "use cache", cacheTag, and cacheLife from chapters, courses, and lessons sitemaps.

<sup>Written for commit 9399784f92fec4b0ad55a73742918f6499281bd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

