### PR TITLE
fix(utils): fair period-to-date comparisons for charts

### DIFF
--- a/apps/main/src/data/progress/get-bp-history.test.ts
+++ b/apps/main/src/data/progress/get-bp-history.test.ts
@@ -129,7 +129,7 @@ describe("authenticated users", () => {
       const headers = await signInAs(user.email, user.password);
 
       const currentMonth = createSafeDate(0);
-      const lastMonth = createSafeDate(1);
+      const lastMonth = createSafeDate(1, 14);
 
       await prisma.dailyProgress.createMany({
         data: [

--- a/apps/main/src/data/progress/get-energy-history.test.ts
+++ b/apps/main/src/data/progress/get-energy-history.test.ts
@@ -98,7 +98,7 @@ describe("authenticated users", () => {
       const headers = await signInAs(user.email, user.password);
 
       const currentMonth = createSafeDate(0);
-      const lastMonth = createSafeDate(1);
+      const lastMonth = createSafeDate(1, 14);
 
       await prisma.dailyProgress.createMany({
         data: [

--- a/apps/main/src/data/progress/get-score-history.test.ts
+++ b/apps/main/src/data/progress/get-score-history.test.ts
@@ -113,7 +113,7 @@ describe("authenticated users", () => {
       const headers = await signInAs(user.email, user.password);
 
       const currentMonth = createSafeDate(0);
-      const lastMonth = createSafeDate(1);
+      const lastMonth = createSafeDate(1, 14);
 
       await prisma.dailyProgress.createMany({
         data: [

--- a/packages/e2e/src/helpers.ts
+++ b/packages/e2e/src/helpers.ts
@@ -172,7 +172,6 @@ export async function openDialog(trigger: Locator, dialog: Locator) {
 
 // Daily progress test fixture constants
 const DAYS_PER_GROUP = 5;
-const MID_MONTH_DAY = 15;
 const CURRENT_MONTH_CORRECT = 17;
 const PREVIOUS_MONTH_CORRECT = 13;
 const CURRENT_MONTH_ENERGY = 75;
@@ -183,9 +182,9 @@ const PREVIOUS_MONTH_INCORRECT = 7;
 const ALL_PERIODS = ["month", "6months", "year"] as const;
 
 function buildGroupDates(today: Date, range: { start: Date; end: Date }, isCurrent: boolean) {
-  const baseDate = isCurrent
-    ? today
-    : new Date(Date.UTC(range.start.getUTCFullYear(), range.start.getUTCMonth(), MID_MONTH_DAY));
+  const midpointMs = range.start.getTime() + (range.end.getTime() - range.start.getTime()) / 2;
+  const midpoint = new Date(midpointMs);
+  const baseDate = isCurrent ? today : midpoint;
 
   return Array.from({ length: DAYS_PER_GROUP }, (_, i) => {
     const date = new Date(

--- a/packages/utils/src/date-ranges.test.ts
+++ b/packages/utils/src/date-ranges.test.ts
@@ -6,6 +6,10 @@ import {
   validatePeriod,
 } from "./date-ranges";
 
+function eod(year: number, month: number, day: number): Date {
+  return new Date(Date.UTC(year, month, day, 23, 59, 59, 999));
+}
+
 describe(validatePeriod, () => {
   it("returns 'month' unchanged", () => {
     expect(validatePeriod("month")).toBe("month");
@@ -40,9 +44,23 @@ describe(calculateDateRanges, () => {
     const ranges = calculateDateRanges("month", 0);
 
     expect(ranges.current.start).toEqual(new Date(Date.UTC(2026, 2, 1)));
-    expect(ranges.current.end).toEqual(new Date(Date.UTC(2026, 2, 31)));
+    expect(ranges.current.end).toEqual(eod(2026, 2, 31));
     expect(ranges.previous.start).toEqual(new Date(Date.UTC(2026, 1, 1)));
-    expect(ranges.previous.end).toEqual(new Date(Date.UTC(2026, 1, 28)));
+    expect(ranges.previous.end).toEqual(eod(2026, 1, 15));
+
+    vi.useRealTimers();
+  });
+
+  it("caps previous.end at previous period boundary when current elapsed exceeds it", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2026, 2, 30)));
+
+    const ranges = calculateDateRanges("month", 0);
+
+    expect(ranges.current.start).toEqual(new Date(Date.UTC(2026, 2, 1)));
+    expect(ranges.current.end).toEqual(eod(2026, 2, 31));
+    expect(ranges.previous.start).toEqual(new Date(Date.UTC(2026, 1, 1)));
+    expect(ranges.previous.end).toEqual(eod(2026, 1, 28));
 
     vi.useRealTimers();
   });
@@ -54,9 +72,9 @@ describe(calculateDateRanges, () => {
     const ranges = calculateDateRanges("month", 1);
 
     expect(ranges.current.start).toEqual(new Date(Date.UTC(2026, 1, 1)));
-    expect(ranges.current.end).toEqual(new Date(Date.UTC(2026, 1, 28)));
+    expect(ranges.current.end).toEqual(eod(2026, 1, 28));
     expect(ranges.previous.start).toEqual(new Date(Date.UTC(2026, 0, 1)));
-    expect(ranges.previous.end).toEqual(new Date(Date.UTC(2026, 0, 31)));
+    expect(ranges.previous.end).toEqual(eod(2026, 0, 31));
 
     vi.useRealTimers();
   });
@@ -68,9 +86,9 @@ describe(calculateDateRanges, () => {
     const ranges = calculateDateRanges("6months", 0);
 
     expect(ranges.current.start).toEqual(new Date(Date.UTC(2026, 0, 1)));
-    expect(ranges.current.end).toEqual(new Date(Date.UTC(2026, 5, 30)));
+    expect(ranges.current.end).toEqual(eod(2026, 5, 30));
     expect(ranges.previous.start).toEqual(new Date(Date.UTC(2025, 6, 1)));
-    expect(ranges.previous.end).toEqual(new Date(Date.UTC(2025, 11, 31)));
+    expect(ranges.previous.end).toEqual(eod(2025, 6, 15));
 
     vi.useRealTimers();
   });
@@ -82,9 +100,9 @@ describe(calculateDateRanges, () => {
     const ranges = calculateDateRanges("6months", 0);
 
     expect(ranges.current.start).toEqual(new Date(Date.UTC(2026, 6, 1)));
-    expect(ranges.current.end).toEqual(new Date(Date.UTC(2026, 11, 31)));
+    expect(ranges.current.end).toEqual(eod(2026, 11, 31));
     expect(ranges.previous.start).toEqual(new Date(Date.UTC(2026, 0, 1)));
-    expect(ranges.previous.end).toEqual(new Date(Date.UTC(2026, 5, 30)));
+    expect(ranges.previous.end).toEqual(eod(2026, 0, 15));
 
     vi.useRealTimers();
   });
@@ -96,9 +114,9 @@ describe(calculateDateRanges, () => {
     const ranges = calculateDateRanges("year", 0);
 
     expect(ranges.current.start).toEqual(new Date(Date.UTC(2026, 0, 1)));
-    expect(ranges.current.end).toEqual(new Date(Date.UTC(2026, 11, 31)));
+    expect(ranges.current.end).toEqual(eod(2026, 11, 31));
     expect(ranges.previous.start).toEqual(new Date(Date.UTC(2025, 0, 1)));
-    expect(ranges.previous.end).toEqual(new Date(Date.UTC(2025, 11, 31)));
+    expect(ranges.previous.end).toEqual(eod(2025, 2, 15));
 
     vi.useRealTimers();
   });
@@ -110,9 +128,9 @@ describe(calculateDateRanges, () => {
     const ranges = calculateDateRanges("year", 0);
 
     expect(ranges.current.start).toEqual(new Date(Date.UTC(2026, 0, 1)));
-    expect(ranges.current.end).toEqual(new Date(Date.UTC(2026, 11, 31)));
+    expect(ranges.current.end).toEqual(eod(2026, 11, 31));
     expect(ranges.previous.start).toEqual(new Date(Date.UTC(2025, 0, 1)));
-    expect(ranges.previous.end).toEqual(new Date(Date.UTC(2025, 11, 31)));
+    expect(ranges.previous.end).toEqual(eod(2025, 11, 25));
 
     vi.useRealTimers();
   });
@@ -124,9 +142,9 @@ describe(calculateDateRanges, () => {
     const ranges = calculateDateRanges("year", 1);
 
     expect(ranges.current.start).toEqual(new Date(Date.UTC(2025, 0, 1)));
-    expect(ranges.current.end).toEqual(new Date(Date.UTC(2025, 11, 31)));
+    expect(ranges.current.end).toEqual(eod(2025, 11, 31));
     expect(ranges.previous.start).toEqual(new Date(Date.UTC(2024, 0, 1)));
-    expect(ranges.previous.end).toEqual(new Date(Date.UTC(2024, 11, 31)));
+    expect(ranges.previous.end).toEqual(eod(2024, 11, 31));
 
     vi.useRealTimers();
   });
@@ -138,7 +156,7 @@ describe(calculateDateRanges, () => {
     const ranges = calculateDateRanges("all", 0);
 
     expect(ranges.current.start).toEqual(new Date(Date.UTC(2025, 0, 1)));
-    expect(ranges.current.end).toEqual(new Date(Date.UTC(2026, 11, 31)));
+    expect(ranges.current.end).toEqual(eod(2026, 11, 31));
     expect(ranges.previous.start).toEqual(new Date(0));
     expect(ranges.previous.end).toEqual(new Date(0));
 

--- a/packages/utils/src/date-ranges.ts
+++ b/packages/utils/src/date-ranges.ts
@@ -5,8 +5,15 @@ const APP_LAUNCH_YEAR = 2025;
 const MONTHS_PER_HALF_YEAR = 6;
 const DECEMBER_INDEX = 11;
 const LAST_DAY_OF_DECEMBER = 31;
+const END_OF_DAY_HOURS = 23;
+const END_OF_DAY_MINUTES = 59;
+const END_OF_DAY_SECONDS = 59;
+const END_OF_DAY_MS = 999;
 
 export type HistoryPeriod = (typeof HISTORY_PERIODS)[number];
+
+type DateRange = { start: Date; end: Date };
+type DateRanges = { current: DateRange; previous: DateRange };
 
 function isHistoryPeriod(value: string): value is HistoryPeriod {
   return (HISTORY_PERIODS as readonly string[]).includes(value);
@@ -16,14 +23,29 @@ export function validatePeriod(value: string): HistoryPeriod {
   return isHistoryPeriod(value) ? value : "month";
 }
 
-type DateRange = { start: Date; end: Date };
-type DateRanges = { current: DateRange; previous: DateRange };
+function endOfDay(date: Date): Date {
+  return new Date(
+    Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate(),
+      END_OF_DAY_HOURS,
+      END_OF_DAY_MINUTES,
+      END_OF_DAY_SECONDS,
+      END_OF_DAY_MS,
+    ),
+  );
+}
 
 function getMonthDateRanges(now: Date, offset: number): DateRanges {
   const currentStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset, 1));
-  const currentEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset + 1, 0));
+  const currentEnd = endOfDay(
+    new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset + 1, 0)),
+  );
   const previousStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset - 1, 1));
-  const previousEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset, 0));
+  const previousEnd = endOfDay(
+    new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset, 0)),
+  );
 
   return {
     current: { end: currentEnd, start: currentStart },
@@ -36,11 +58,13 @@ function getHalfYearDateRanges(now: Date, offset: number): DateRanges {
     (Math.floor(now.getUTCMonth() / MONTHS_PER_HALF_YEAR) - offset) * MONTHS_PER_HALF_YEAR;
 
   const currentStart = new Date(Date.UTC(now.getUTCFullYear(), startMonth, 1));
-  const currentEnd = new Date(Date.UTC(now.getUTCFullYear(), startMonth + MONTHS_PER_HALF_YEAR, 0));
+  const currentEnd = endOfDay(
+    new Date(Date.UTC(now.getUTCFullYear(), startMonth + MONTHS_PER_HALF_YEAR, 0)),
+  );
   const previousStart = new Date(
     Date.UTC(now.getUTCFullYear(), startMonth - MONTHS_PER_HALF_YEAR, 1),
   );
-  const previousEnd = new Date(Date.UTC(now.getUTCFullYear(), startMonth, 0));
+  const previousEnd = endOfDay(new Date(Date.UTC(now.getUTCFullYear(), startMonth, 0)));
 
   return {
     current: { end: currentEnd, start: currentStart },
@@ -51,9 +75,13 @@ function getHalfYearDateRanges(now: Date, offset: number): DateRanges {
 function getYearDateRanges(now: Date, offset: number): DateRanges {
   const currentYear = now.getUTCFullYear() - offset;
   const currentStart = new Date(Date.UTC(currentYear, 0, 1));
-  const currentEnd = new Date(Date.UTC(currentYear, DECEMBER_INDEX, LAST_DAY_OF_DECEMBER));
+  const currentEnd = endOfDay(
+    new Date(Date.UTC(currentYear, DECEMBER_INDEX, LAST_DAY_OF_DECEMBER)),
+  );
   const previousStart = new Date(Date.UTC(currentYear - 1, 0, 1));
-  const previousEnd = new Date(Date.UTC(currentYear - 1, DECEMBER_INDEX, LAST_DAY_OF_DECEMBER));
+  const previousEnd = endOfDay(
+    new Date(Date.UTC(currentYear - 1, DECEMBER_INDEX, LAST_DAY_OF_DECEMBER)),
+  );
 
   return {
     current: { end: currentEnd, start: currentStart },
@@ -66,20 +94,14 @@ function getAllDateRanges(): DateRanges {
 
   return {
     current: {
-      end: new Date(Date.UTC(now.getUTCFullYear(), DECEMBER_INDEX, LAST_DAY_OF_DECEMBER)),
+      end: endOfDay(new Date(Date.UTC(now.getUTCFullYear(), DECEMBER_INDEX, LAST_DAY_OF_DECEMBER))),
       start: new Date(Date.UTC(APP_LAUNCH_YEAR, 0, 1)),
     },
     previous: { end: new Date(0), start: new Date(0) },
   };
 }
 
-export function calculateDateRanges(period: HistoryPeriod, offset: number): DateRanges {
-  if (period === "all") {
-    return getAllDateRanges();
-  }
-
-  const now = new Date();
-
+function getRangesForPeriod(period: HistoryPeriod, now: Date, offset: number): DateRanges {
   if (period === "month") {
     return getMonthDateRanges(now, offset);
   }
@@ -89,6 +111,30 @@ export function calculateDateRanges(period: HistoryPeriod, offset: number): Date
   }
 
   return getYearDateRanges(now, offset);
+}
+
+function clampPreviousEnd(ranges: DateRanges, now: Date): DateRanges {
+  const today = endOfDay(now);
+  const elapsedMs = today.getTime() - ranges.current.start.getTime();
+  const clampedEnd = new Date(ranges.previous.start.getTime() + elapsedMs);
+
+  return {
+    current: ranges.current,
+    previous: {
+      end: clampedEnd < ranges.previous.end ? clampedEnd : ranges.previous.end,
+      start: ranges.previous.start,
+    },
+  };
+}
+
+export function calculateDateRanges(period: HistoryPeriod, offset: number): DateRanges {
+  if (period === "all") {
+    return getAllDateRanges();
+  }
+
+  const now = new Date();
+  const ranges = getRangesForPeriod(period, now, offset);
+  return offset === 0 ? clampPreviousEnd(ranges, now) : ranges;
 }
 
 export function getDefaultStartDate(startDateIso?: string): Date {


### PR DESCRIPTION
## Summary

- Set all end dates to end-of-day (`23:59:59.999Z`) to fix DATETIME undercount on the final day
- Clamp `previous.end` when `offset=0` so mid-period comparisons only cover the same elapsed days as the current period
- Update e2e fixture to use range midpoint instead of hardcoded day 15

## Test plan

- [x] Unit tests updated for end-of-day and clamping behavior
- [x] Integration tests adjusted for clamped previous period range
- [x] E2E tests pass across all apps (main, editor, api)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes period-to-date chart comparisons by ending all ranges at end-of-day and clamping the previous period to the same elapsed days as the current period. This removes last-day undercounts and makes mid-period comparisons fair.

- **Bug Fixes**
  - Set all range ends to 23:59:59.999Z to avoid last-day undercounts on DATETIME columns.
  - For offset=0, clamp previous.end to previous.start + elapsed time from current.start to today (EOD), capped at its boundary.
  - No changes for historical offsets or the “all” period.
  - Tests updated: added end-of-day and clamping cases; e2e fixture now uses the range midpoint instead of a hardcoded day.

<sup>Written for commit 5b8abdfa3709557f1e7f989794f35a9fddeb7548. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

