### PR TITLE
fix(ai): prevent copyrighted characters in image prompts

### DIFF
--- a/packages/ai/src/tasks/activities/_tools/select-image.prompt.md
+++ b/packages/ai/src/tasks/activities/_tools/select-image.prompt.md
@@ -6,4 +6,5 @@ Requirements:
 
 - Only use when visual selection is THE BEST way to test this concept
 - 2-4 image options with generation prompts (describe content, not style)
+- NEVER reference copyrighted or trademarked characters (e.g., Mickey Mouse, Spider-Man, Mario, Pikachu). Describe concepts abstractly or use generic, original characters instead
 - Most concepts are better tested with other formats

--- a/packages/ai/src/tasks/steps/_tools/image.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/image.prompt.md
@@ -9,3 +9,4 @@ Requirements:
 - Describe ONLY the content, not the style (style is handled by the image generator)
 - Focus on what should be depicted, not how
 - Be specific enough that the image supports the step's educational content
+- NEVER reference copyrighted or trademarked characters (e.g., Mickey Mouse, Spider-Man, Mario, Pikachu). If the topic involves such characters, describe the concept abstractly or use generic, original characters instead

--- a/packages/ai/src/tasks/steps/step-visual.prompt.md
+++ b/packages/ai/src/tasks/steps/step-visual.prompt.md
@@ -70,3 +70,4 @@ Choose the visual type that BEST fits each step's content:
 - Use as fallback when no other type fits
 - Describe content only, not style
 - Be specific enough to convey the concept
+- NEVER reference copyrighted or trademarked characters (e.g., Mickey Mouse, Spider-Man, Mario, Pikachu). Describe concepts abstractly or use generic, original characters instead


### PR DESCRIPTION
## Summary

- Add rules to all image prompt-crafting instructions to never reference copyrighted or trademarked characters (e.g., Mickey Mouse, Spider-Man, Mario, Pikachu)
- Updated step visual image tool, step visual main prompt, and quiz select-image tool
- When copyrighted characters are relevant to the topic, the AI should describe concepts abstractly or use generic original characters instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a hard rule to image prompt instructions to never reference copyrighted or trademarked characters (e.g., Mickey Mouse, Spider-Man). When relevant, prompts must describe concepts abstractly or use generic, original characters.

Updates the step visual image tool, step visual prompt, and quiz select-image tool in `packages/ai`.

<sup>Written for commit 88c6fb4c1aac40fc04bc2713d15ec82a7f140ae4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

