### PR TITLE
feat(main): skip auth/subscription checks when generation has started

### DIFF
--- a/apps/main/e2e/generate-activity.test.ts
+++ b/apps/main/e2e/generate-activity.test.ts
@@ -1259,6 +1259,62 @@ test.describe("Generate Activity Page - With Subscription", () => {
   });
 });
 
+test.describe("Generate Activity Page - Running Generation Bypasses Auth", () => {
+  test("unauthenticated user sees generation UI when status is running", async ({ page }) => {
+    const org = await getAiOrganization();
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const course = await courseFixture({
+      isPublished: true,
+      normalizedTitle: normalizeString(`E2E Running Activity Course ${uniqueId}`),
+      organizationId: org.id,
+      slug: `e2e-running-activity-course-${uniqueId}`,
+      title: `E2E Running Activity Course ${uniqueId}`,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      generationStatus: "completed",
+      isPublished: true,
+      normalizedTitle: normalizeString(`E2E Running Activity Chapter ${uniqueId}`),
+      organizationId: org.id,
+      slug: `e2e-running-activity-chapter-${uniqueId}`,
+      title: `E2E Running Activity Chapter ${uniqueId}`,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      generationStatus: "completed",
+      isPublished: true,
+      normalizedTitle: normalizeString(`E2E Running Activity Lesson ${uniqueId}`),
+      organizationId: org.id,
+      slug: `e2e-running-activity-lesson-${uniqueId}`,
+      title: `E2E Running Activity Lesson ${uniqueId}`,
+    });
+
+    const activity = await activityFixture({
+      generationRunId: `run-${uniqueId}`,
+      generationStatus: "running",
+      isPublished: true,
+      kind: "background",
+      lessonId: lesson.id,
+      organizationId: org.id,
+      title: `E2E Running Activity ${uniqueId}`,
+    });
+
+    await setupMockApis(page, {
+      streamDelayMs: 2500,
+      streamMessages: [{ status: "started", step: "getLessonActivities" }],
+    });
+
+    await page.goto(`/generate/a/${activity.id}`);
+
+    await expect(page.getByRole("alert").filter({ hasText: /logged in/i })).toHaveCount(0);
+    await expect(page.getByText(/upgrade to generate/i)).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: activity.title! })).toBeVisible();
+  });
+});
+
 test.describe("Generate Activity Page - Not Found", () => {
   test("invalid activity ID shows 404 page", async ({ page }) => {
     await page.goto("/generate/a/999999");

--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -343,6 +343,47 @@ test.describe("Generate Chapter Page - First Chapter Free", () => {
   });
 });
 
+test.describe("Generate Chapter Page - Running Generation Bypasses Auth", () => {
+  test("unauthenticated user sees generation UI for non-first chapter when status is running", async ({
+    page,
+  }) => {
+    const org = await getAiOrganization();
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const course = await courseFixture({
+      isPublished: true,
+      normalizedTitle: normalizeString(`E2E Running Chapter Course ${uniqueId}`),
+      organizationId: org.id,
+      slug: `e2e-running-chapter-course-${uniqueId}`,
+      targetLanguage: null,
+      title: `E2E Running Chapter Course ${uniqueId}`,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      generationRunId: `run-${uniqueId}`,
+      generationStatus: "running",
+      isPublished: true,
+      normalizedTitle: normalizeString(`E2E Running Chapter ${uniqueId}`),
+      organizationId: org.id,
+      position: 1,
+      slug: `e2e-running-chapter-${uniqueId}`,
+      title: `E2E Running Chapter ${uniqueId}`,
+    });
+
+    await setupMockApis(page, {
+      statusDelayMs: 2500,
+      streamMessages: [{ status: "started", step: "getChapter" }],
+    });
+
+    await page.goto(`/generate/ch/${chapter.id}`);
+
+    await expect(page.getByRole("alert").filter({ hasText: /logged in/i })).toHaveCount(0);
+    await expect(page.getByText(/upgrade to generate/i)).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: chapter.title })).toBeVisible();
+  });
+});
+
 test.describe("Generate Chapter Page - Not Found", () => {
   test("invalid chapter ID shows 404 page", async ({ page }) => {
     await page.goto("/generate/ch/999999");

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -286,6 +286,53 @@ test.describe("Generate Lesson Page - With Subscription", () => {
   });
 });
 
+test.describe("Generate Lesson Page - Running Generation Bypasses Auth", () => {
+  test("unauthenticated user sees generation UI when status is running", async ({ page }) => {
+    const org = await getAiOrganization();
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const course = await courseFixture({
+      isPublished: true,
+      normalizedTitle: normalizeString(`E2E Running Lesson Course ${uniqueId}`),
+      organizationId: org.id,
+      slug: `e2e-running-lesson-course-${uniqueId}`,
+      title: `E2E Running Lesson Course ${uniqueId}`,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      generationStatus: "completed",
+      isPublished: true,
+      normalizedTitle: normalizeString(`E2E Running Lesson Chapter ${uniqueId}`),
+      organizationId: org.id,
+      slug: `e2e-running-lesson-chapter-${uniqueId}`,
+      title: `E2E Running Lesson Chapter ${uniqueId}`,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      generationRunId: `run-${uniqueId}`,
+      generationStatus: "running",
+      isPublished: true,
+      normalizedTitle: normalizeString(`E2E Running Lesson ${uniqueId}`),
+      organizationId: org.id,
+      slug: `e2e-running-lesson-${uniqueId}`,
+      title: `E2E Running Lesson ${uniqueId}`,
+    });
+
+    await setupMockApis(page, {
+      statusDelayMs: 2500,
+      streamMessages: [{ status: "started", step: "getLesson" }],
+    });
+
+    await page.goto(`/generate/l/${lesson.id}`);
+
+    await expect(page.getByRole("alert").filter({ hasText: /logged in/i })).toHaveCount(0);
+    await expect(page.getByText(/upgrade to generate/i)).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: lesson.title })).toBeVisible();
+  });
+});
+
 test.describe("Generate Lesson Page - Not Found", () => {
   test("invalid lesson ID shows 404 page", async ({ page }) => {
     await page.goto("/generate/l/999999");

--- a/apps/main/src/app/generate/a/[id]/generate-activity-content.tsx
+++ b/apps/main/src/app/generate/a/[id]/generate-activity-content.tsx
@@ -34,9 +34,10 @@ export async function GenerateActivityContent({ params }: { params: Promise<{ id
     notFound();
   }
 
+  const hasStarted = activity.generationStatus !== "pending";
   const t = await getExtracted();
 
-  if (!session) {
+  if (!session && !hasStarted) {
     return <LoginRequired title={t("Generate Activity")} />;
   }
 
@@ -56,7 +57,7 @@ export async function GenerateActivityContent({ params }: { params: Promise<{ id
       </ContainerHeader>
 
       <ContainerBody>
-        <SubscriptionGate>
+        <SubscriptionGate bypass={hasStarted}>
           <GenerationClient
             activityKind={activity.kind}
             chapterSlug={activity.lesson.chapter.slug}

--- a/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
@@ -31,10 +31,12 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
     notFound();
   }
 
+  const hasStarted = chapter.generationStatus !== "pending";
   const isFirstChapter = chapter.position === 0;
+  const bypassAuth = isFirstChapter || hasStarted;
   const t = await getExtracted();
 
-  if (!session && !isFirstChapter) {
+  if (!session && !bypassAuth) {
     return <LoginRequired title={t("Generate Chapter")} />;
   }
 
@@ -54,7 +56,7 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
       </ContainerHeader>
 
       <ContainerBody>
-        <SubscriptionGate bypass={isFirstChapter}>
+        <SubscriptionGate bypass={bypassAuth}>
           <GenerationClient
             chapterId={chapterId}
             chapterSlug={chapter.slug}

--- a/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
+++ b/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
@@ -31,9 +31,10 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
     notFound();
   }
 
+  const hasStarted = lesson.generationStatus !== "pending";
   const t = await getExtracted();
 
-  if (!session) {
+  if (!session && !hasStarted) {
     return <LoginRequired title={t("Generate Lesson")} />;
   }
 
@@ -53,7 +54,7 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
       </ContainerHeader>
 
       <ContainerBody>
-        <SubscriptionGate>
+        <SubscriptionGate bypass={hasStarted}>
           <GenerationClient
             chapterSlug={lesson.chapter.slug}
             courseSlug={lesson.chapter.course.slug}


### PR DESCRIPTION
## Summary

- Skip login and subscription gates on generate pages (`/generate/a/[id]`, `/generate/l/[id]`, `/generate/ch/[id]`) when the generation has already started (`running` or `failed` status)
- Since `completed` already triggers a redirect, the bypass applies to any non-`pending` status
- For chapters, the existing first-chapter bypass is combined with the new `hasStarted` bypass via `bypassAuth`

## Test plan

- [x] E2E: unauthenticated user sees generation UI for activity with `running` status
- [x] E2E: unauthenticated user sees generation UI for lesson with `running` status
- [x] E2E: unauthenticated user sees generation UI for non-first chapter with `running` status
- [ ] Verify existing auth tests still pass (pending status still requires login)
- [ ] Verify existing subscription tests still pass (pending status still requires subscription)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip login and subscription on generate pages when a generation has already started (running or failed), so anyone with the link can follow progress. Pending generations still require login and subscription; completed continues to redirect.

- New Features
  - Bypass auth and subscription on `/generate/a/[id]`, `/generate/l/[id]`, and `/generate/ch/[id]` when status is not `pending`.
  - Chapters combine the existing first-chapter bypass with the new started-generation bypass via `bypassAuth`.
  - Added E2E tests to verify unauthenticated access for running generations across activity, lesson, and chapter pages.

<sup>Written for commit b934eb76e9ef193251b4fad9ca43e0626cb8d86a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

