### PR TITLE
fix(main): align category pills scroll area

### DIFF
--- a/apps/main/src/app/(catalog)/courses/category-pills.tsx
+++ b/apps/main/src/app/(catalog)/courses/category-pills.tsx
@@ -33,8 +33,12 @@ export function CategoryPills({
   const t = useExtracted();
 
   return (
-    <HorizontalScroll className="pb-4">
-      <HorizontalScrollContent aria-label={t("Course categories")} role="navigation">
+    <HorizontalScroll>
+      <HorizontalScrollContent
+        aria-label={t("Course categories")}
+        className="pb-4"
+        role="navigation"
+      >
         <Link
           className={buttonVariants({
             size: "sm",


### PR DESCRIPTION
Move the catalog category pills bottom padding into the scrollable content so the full visible pills area stays within the horizontal swipe target on mobile.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move bottom padding from the `HorizontalScroll` wrapper to `HorizontalScrollContent` to align the category pills’ touch/scroll area on mobile, keeping the entire visible row within the horizontal swipe target.

<sup>Written for commit 326700553f2871ac3549a3beb02b1ada21e4c8b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

