### PR TITLE
fix(ui): preserve horizontal scroll end padding

### DIFF
--- a/packages/ui/src/components/horizontal-scroll.tsx
+++ b/packages/ui/src/components/horizontal-scroll.tsx
@@ -88,7 +88,7 @@ function HorizontalScroll({ className, children, ...props }: React.ComponentProp
 function HorizontalScrollContent({ className, children, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("flex min-w-full w-max gap-2 px-4 pb-1", className)}
+      className={cn("flex w-max min-w-full gap-2 px-4 pb-1", className)}
       data-slot="horizontal-scroll-content"
       {...props}
     >

--- a/packages/ui/src/components/horizontal-scroll.tsx
+++ b/packages/ui/src/components/horizontal-scroll.tsx
@@ -88,7 +88,7 @@ function HorizontalScroll({ className, children, ...props }: React.ComponentProp
 function HorizontalScrollContent({ className, children, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("flex gap-2 px-4 pb-1", className)}
+      className={cn("flex min-w-full w-max gap-2 px-4 pb-1", className)}
       data-slot="horizontal-scroll-content"
       {...props}
     >


### PR DESCRIPTION
Update the shared horizontal scroll content sizing so the trailing right padding remains visible after scrolling to the end.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves end padding in horizontal scrolls so the right spacing stays visible when scrolled to the end. Adds `min-w-full w-max` to `HorizontalScrollContent` to prevent shrink and keep trailing padding; formats classes.

<sup>Written for commit 721f9ef7566941dc04ba0e57a61944a5e87fa031. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

