### PR TITLE
fix(player): improve static step visual layout

### DIFF
--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -43,7 +43,7 @@ export function PlayerShell() {
   const buttonLabel = phase === "feedback" ? t("Continue") : t("Check");
 
   return (
-    <main className="flex min-h-dvh flex-col">
+    <main className="flex h-dvh flex-col overflow-hidden">
       {isIntro && (
         <div className="bg-background/95 sticky top-0 z-30 backdrop-blur-sm">
           <PlayerHeader>

--- a/packages/player/src/components/player-stage.tsx
+++ b/packages/player/src/components/player-stage.tsx
@@ -13,8 +13,8 @@ export function PlayerStage({
   return (
     <section
       className={cn(
-        "flex flex-1 flex-col items-center overflow-y-auto",
-        isStatic ? "p-0" : "justify-center p-4",
+        "flex min-h-0 flex-1 flex-col items-center overflow-y-auto",
+        isStatic ? "overflow-hidden p-0" : "justify-center p-4",
         "data-[phase=feedback]:px-6 data-[phase=feedback]:sm:px-8",
         className,
       )}

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -83,7 +83,7 @@ export function StageContent({
   if ((phase === "playing" || phase === "feedback") && currentStep) {
     return (
       <div
-        className="animate-in fade-in flex w-full flex-1 flex-col items-center duration-150 ease-out motion-reduce:animate-none sm:justify-center"
+        className="animate-in fade-in flex min-h-0 w-full flex-1 flex-col items-center duration-150 ease-out motion-reduce:animate-none sm:justify-center"
         key={`step-${currentStepIndex}`}
       >
         <StepRenderer

--- a/packages/player/src/components/static-step.tsx
+++ b/packages/player/src/components/static-step.tsx
@@ -81,7 +81,9 @@ export function StaticStep({ step }: { step: SerializedStep }) {
     <>
       {hasVisual && (
         <StaticStepVisual>
-          <StepVisualRenderer visualContent={step.visualContent} visualKind={step.visualKind} />
+          <div className="my-auto flex w-full justify-center">
+            <StepVisualRenderer visualContent={step.visualContent} visualKind={step.visualKind} />
+          </div>
         </StaticStepVisual>
       )}
 

--- a/packages/player/src/components/step-layouts.tsx
+++ b/packages/player/src/components/step-layouts.tsx
@@ -3,7 +3,7 @@ import { cn } from "@zoonk/ui/lib/utils";
 export function StaticStepLayout({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("flex w-full max-w-2xl flex-1 flex-col", className)}
+      className={cn("flex min-h-0 w-full max-w-2xl flex-1 flex-col", className)}
       data-slot="static-step-layout"
       {...props}
     />
@@ -14,7 +14,7 @@ export function StaticStepVisual({ className, ...props }: React.ComponentProps<"
   return (
     <div
       className={cn(
-        "relative z-20 flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-4 py-6 sm:px-6 sm:py-8 xl:max-h-[50vh] xl:flex-initial xl:py-10",
+        "relative z-20 flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-4 py-6 sm:px-6 sm:py-8 xl:max-h-[50vh] xl:flex-initial xl:py-10",
         className,
       )}
       data-slot="static-step-visual"
@@ -26,7 +26,7 @@ export function StaticStepVisual({ className, ...props }: React.ComponentProps<"
 export function StaticStepText({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("flex flex-col gap-1 text-left", className)}
+      className={cn("flex shrink-0 flex-col gap-1 text-left", className)}
       data-slot="static-step-text"
       {...props}
     />

--- a/packages/player/src/components/step-layouts.tsx
+++ b/packages/player/src/components/step-layouts.tsx
@@ -14,7 +14,7 @@ export function StaticStepVisual({ className, ...props }: React.ComponentProps<"
   return (
     <div
       className={cn(
-        "relative z-20 flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-4 py-6 sm:px-6 sm:py-8 xl:max-h-[50vh] xl:flex-initial xl:py-10",
+        "relative z-20 flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-4 py-6 sm:px-6 sm:py-8 xl:max-h-[calc(100dvh-14rem)] xl:flex-initial xl:py-10",
         className,
       )}
       data-slot="static-step-visual"

--- a/packages/player/src/components/step-renderer.tsx
+++ b/packages/player/src/components/step-renderer.tsx
@@ -37,7 +37,7 @@ export function StepRenderer({
     const hasVisual = Boolean(step.visualKind && step.visualContent);
 
     return (
-      <div className="relative flex w-full flex-1 justify-center" {...swipeHandlers}>
+      <div className="relative flex min-h-0 w-full flex-1 justify-center" {...swipeHandlers}>
         <StaticStepLayout className={hasVisual ? "xl:justify-center xl:gap-4" : "justify-center"}>
           <StaticStep step={step} />
         </StaticStepLayout>

--- a/packages/player/src/components/visuals/diagram-visual.tsx
+++ b/packages/player/src/components/visuals/diagram-visual.tsx
@@ -198,7 +198,7 @@ export function DiagramVisual({ content }: { content: unknown }) {
   const description = useMemo(() => buildAccessibleDescription(parsed), [parsed]);
 
   return (
-    <figure aria-label={t("Diagram")} className="w-full max-w-xl">
+    <figure aria-label={t("Diagram")} className="mx-auto w-full max-w-xl">
       <DiagramSvg layout={layout} markerId={markerId} />
       <figcaption className="sr-only">{description}</figcaption>
     </figure>

--- a/packages/player/src/diagram-layout.ts
+++ b/packages/player/src/diagram-layout.ts
@@ -30,6 +30,7 @@ const NODE_PADDING = 32;
 const NODE_SEP = 60;
 const RANK_SEP = 60;
 const LAYOUT_PADDING = 40;
+const LAYOUT_OFFSET = LAYOUT_PADDING / 2;
 
 function estimateNodeWidth(label: string): number {
   return Math.max(MIN_NODE_WIDTH, label.length * CHAR_WIDTH + NODE_PADDING);
@@ -101,14 +102,14 @@ export function computeDiagramLayout(
   dagre.layout(graph);
 
   const positionedNodes = nodes.map((node) => ({
-    ...readNodePosition(graph, node.id),
+    ...translateNode(readNodePosition(graph, node.id)),
     id: node.id,
     label: node.label,
   }));
 
   const positionedEdges = edges.map((edge) => ({
     label: edge.label,
-    points: readEdgePoints(graph, edge.source, edge.target),
+    points: translatePoints(readEdgePoints(graph, edge.source, edge.target)),
     source: edge.source,
     target: edge.target,
   }));
@@ -121,4 +122,19 @@ export function computeDiagramLayout(
     nodes: positionedNodes,
     width: dimensions.width + LAYOUT_PADDING,
   };
+}
+
+function translateNode(node: { height: number; width: number; x: number; y: number }) {
+  return {
+    ...node,
+    x: node.x + LAYOUT_OFFSET,
+    y: node.y + LAYOUT_OFFSET,
+  };
+}
+
+function translatePoints(points: { x: number; y: number }[]) {
+  return points.map((point) => ({
+    x: point.x + LAYOUT_OFFSET,
+    y: point.y + LAYOUT_OFFSET,
+  }));
 }


### PR DESCRIPTION
## Summary
- fix static-step overflow so mobile and tablet visuals scroll while the step text stays pinned
- center diagram visuals and add symmetric diagram padding in the SVG layout
- let desktop visuals use more available height before scrolling while keeping smaller visuals visually grouped with the text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes static-step layout so visuals scroll independently on mobile/tablet while the text stays pinned. Diagrams are centered with symmetric padding, and desktop uses more visual height before scrolling.

- **Bug Fixes**
  - Contained overflow within the player and stage to prevent body scrolling and layout jumps.
  - Made the visual area scrollable on small screens while keeping the text section fixed.
  - Centered diagrams and added symmetric SVG padding by offsetting layout coordinates; increased desktop visual max height.

<sup>Written for commit 7ee6bbb0061a7a7a5a8c0e733f676b588f2b77d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

