### PR TITLE
fix(e2e): prevent stripe api calls during e2e tests

### DIFF
--- a/packages/auth/src/e2e.ts
+++ b/packages/auth/src/e2e.ts
@@ -2,6 +2,7 @@ import { betterAuth } from "better-auth/minimal";
 import { emailOTP, oneTimeToken } from "better-auth/plugins";
 import { sendVerificationOTP } from "./plugins/otp";
 import { baseAuthConfig, baseAuthPlugins, fullPlugins, socialProviders } from "./server";
+import { stripePlugin } from "./stripe/plugin";
 
 /**
  * @public
@@ -21,7 +22,11 @@ export const auth = betterAuth({
   },
   plugins: [
     ...baseAuthPlugins,
-    ...fullPlugins.filter((plugin) => plugin.id !== "email-otp" && plugin.id !== "one-time-token"),
+    ...fullPlugins.filter(
+      (plugin) =>
+        plugin.id !== "email-otp" && plugin.id !== "one-time-token" && plugin.id !== "stripe",
+    ),
+    stripePlugin({ createCustomerOnSignUp: false }),
     emailOTP({
       overrideDefaultEmailVerification: true,
       sendVerificationOTP,

--- a/packages/auth/src/stripe/plugin.ts
+++ b/packages/auth/src/stripe/plugin.ts
@@ -4,9 +4,13 @@ import { stripeClient } from "./client";
 
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET ?? "";
 
-export function stripePlugin() {
+type StripePluginOptions = {
+  createCustomerOnSignUp?: boolean;
+};
+
+export function stripePlugin({ createCustomerOnSignUp = true }: StripePluginOptions = {}) {
   return stripe({
-    createCustomerOnSignUp: true,
+    createCustomerOnSignUp,
     organization: { enabled: true },
     stripeClient,
     stripeWebhookSecret: webhookSecret,

--- a/packages/e2e/src/base.config.ts
+++ b/packages/e2e/src/base.config.ts
@@ -34,6 +34,7 @@ export function createBaseConfig(options: {
         DATABASE_URL_UNPOOLED: E2E_DATABASE_URL,
         E2E_TESTING: "true",
         NEXT_PUBLIC_API_URL: E2E_API_URL,
+        STRIPE_SECRET_KEY: "sk_test_fake",
         ...options.webServerEnv,
       },
       timeout: 120_000,


### PR DESCRIPTION
## Summary

- Disable `createCustomerOnSignUp` in the e2e stripe plugin so user signup doesn't hit the Stripe API
- Set `STRIPE_SECRET_KEY=sk_test_fake` in the e2e web server env as a safety net

## Test plan

- [ ] Run e2e tests and verify no Stripe customers are created in the sandbox
- [ ] Verify subscription-related e2e tests still pass (they use DB fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Stripe API calls during e2e by disabling customer creation on sign-up and setting a fake Stripe secret in the e2e web server env.

- **Bug Fixes**
  - In e2e auth config, exclude the default `stripe` plugin from `fullPlugins` and re-add `stripePlugin({ createCustomerOnSignUp: false })`.
  - Set `STRIPE_SECRET_KEY=sk_test_fake` in the e2e web server env to guard against accidental calls.

- **Refactors**
  - `stripePlugin` now accepts `createCustomerOnSignUp` (default: true) to control customer creation behavior.

<sup>Written for commit e4f2f6c5816573644218d909d632fd56148ab6d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

