### PR TITLE
fix(auth): disable cross subdomain cookies

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -38,7 +38,6 @@ export const baseAuthConfig: Omit<BetterAuthOptions, "rateLimit"> = {
     accountLinking: { enabled: true },
   },
   advanced: {
-    crossSubDomainCookies: { enabled: true },
     database: { generateId: "serial" },
   },
   appName: "Zoonk",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disabled cross-subdomain cookies in auth to stop sharing sessions across subdomains and scope cookies to the current domain. Removed `advanced.crossSubDomainCookies` from `baseAuthConfig` in `packages/auth/src/server.ts`.

<sup>Written for commit b82f4800928522f98c5a0ca943a6d611fe6b9f2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

