### PR TITLE
fix(player): keep static step navigation in text area

### DIFF
--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -7,7 +7,7 @@ import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
 
-const uniqueId = randomUUID().slice(0, 8);
+const uniqueId = randomUUID();
 
 let chapterUrl: string;
 let courseSlug: string;

--- a/apps/main/e2e/static-step.test.ts
+++ b/apps/main/e2e/static-step.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { type Locator } from "@playwright/test";
 import { getAiOrganization } from "@zoonk/e2e/helpers";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
@@ -7,7 +8,38 @@ import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { expect, test } from "./fixtures";
 
-async function createStaticActivity(options: { steps: { content: object; position: number }[] }) {
+async function swipeHorizontally(
+  locator: Locator,
+  options: { endX: number; startX: number; y: number },
+) {
+  await locator.evaluate((element, gesture) => {
+    const startTouch = { clientX: gesture.startX, clientY: gesture.y };
+    const endTouch = { clientX: gesture.endX, clientY: gesture.y };
+
+    const touchStart = new Event("touchstart", { bubbles: true, cancelable: true });
+    Object.defineProperty(touchStart, "touches", { value: [startTouch] });
+    Object.defineProperty(touchStart, "targetTouches", { value: [startTouch] });
+    Object.defineProperty(touchStart, "changedTouches", { value: [startTouch] });
+
+    element.dispatchEvent(touchStart);
+
+    const touchEnd = new Event("touchend", { bubbles: true, cancelable: true });
+    Object.defineProperty(touchEnd, "touches", { value: [] });
+    Object.defineProperty(touchEnd, "targetTouches", { value: [] });
+    Object.defineProperty(touchEnd, "changedTouches", { value: [endTouch] });
+
+    element.dispatchEvent(touchEnd);
+  }, options);
+}
+
+async function createStaticActivity(options: {
+  steps: {
+    content: object;
+    position: number;
+    visualContent?: object;
+    visualKind?: "chart" | "code" | "diagram" | "image" | "quote" | "table" | "timeline";
+  }[];
+}) {
   const org = await getAiOrganization();
 
   const uniqueId = randomUUID().slice(0, 8);
@@ -53,6 +85,8 @@ async function createStaticActivity(options: { steps: { content: object; positio
         content: step.content,
         isPublished: true,
         position: step.position,
+        visualContent: "visualContent" in step ? step.visualContent : undefined,
+        visualKind: "visualKind" in step ? step.visualKind : undefined,
       }),
     ),
   );
@@ -401,7 +435,7 @@ test.describe("Static Step Navigation", () => {
     await expect(page.getByRole("button", { name: /send feedback/i })).toBeVisible();
   });
 
-  test("clicking outside content area navigates between steps", async ({ page }) => {
+  test("only bottom content clicks navigate between steps", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const { url } = await createStaticActivity({
       steps: [
@@ -412,6 +446,11 @@ test.describe("Static Step Navigation", () => {
             variant: "text",
           },
           position: 0,
+          visualContent: {
+            prompt: `Outside visual ${uniqueId}`,
+            url: "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/courses/machine_learning-jmaDwiS0MptNV2EGCZzYWU7RBJs3Qg.webp",
+          },
+          visualKind: "image",
         },
         {
           content: {
@@ -431,19 +470,100 @@ test.describe("Static Step Navigation", () => {
       page.getByRole("heading", { name: new RegExp(`Outside 1 ${uniqueId}`) }),
     ).toBeVisible();
 
-    // Click far-right edge of viewport (outside the max-w-2xl content area)
+    await page.getByRole("img", { name: new RegExp(`Outside visual ${uniqueId}`) }).click();
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Outside 1 ${uniqueId}`) }),
+    ).toBeVisible();
+
     const viewport = page.viewportSize();
     await page.mouse.click(viewport!.width - 10, viewport!.height / 2);
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Outside 1 ${uniqueId}`) }),
+    ).toBeVisible();
+
+    const bodyText = page.getByText(new RegExp(`Outside 1 body ${uniqueId}`));
+    const bodyBox = await bodyText.boundingBox();
+
+    if (!bodyBox || !viewport) {
+      throw new Error("Missing body text box or viewport");
+    }
+
+    await page.mouse.click(viewport.width / 2, bodyBox.y + bodyBox.height / 2);
 
     await expect(
       page.getByRole("heading", { name: new RegExp(`Outside 2 ${uniqueId}`) }),
     ).toBeVisible();
+  });
 
-    // Click far-left edge to go back
-    await page.mouse.click(10, viewport!.height / 2);
+  test("only bottom content swipes navigate between steps", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createStaticActivity({
+      steps: [
+        {
+          content: {
+            text: `Swipe 1 body ${uniqueId}`,
+            title: `Swipe 1 ${uniqueId}`,
+            variant: "text",
+          },
+          position: 0,
+          visualContent: {
+            prompt: `Swipe visual ${uniqueId}`,
+            url: "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/courses/machine_learning-jmaDwiS0MptNV2EGCZzYWU7RBJs3Qg.webp",
+          },
+          visualKind: "image",
+        },
+        {
+          content: {
+            text: `Swipe 2 body ${uniqueId}`,
+            title: `Swipe 2 ${uniqueId}`,
+            variant: "text",
+          },
+          position: 1,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
 
     await expect(
-      page.getByRole("heading", { name: new RegExp(`Outside 1 ${uniqueId}`) }),
+      page.getByRole("heading", { name: new RegExp(`Swipe 1 ${uniqueId}`) }),
+    ).toBeVisible();
+
+    await swipeHorizontally(
+      page.getByRole("img", { name: new RegExp(`Swipe visual ${uniqueId}`) }),
+      {
+        endX: 20,
+        startX: 140,
+        y: 40,
+      },
+    );
+
+    // still at this step when swiping on visual content
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Swipe 1 ${uniqueId}`) }),
+    ).toBeVisible();
+
+    await swipeHorizontally(page.getByText(new RegExp(`Swipe 1 body ${uniqueId}`)), {
+      endX: 20,
+      startX: 140,
+      y: 20,
+    });
+
+    // now should be on step 2 after swiping on body text
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Swipe 2 ${uniqueId}`) }),
+    ).toBeVisible();
+
+    await swipeHorizontally(page.getByText(new RegExp(`Swipe 2 body ${uniqueId}`)), {
+      endX: 140,
+      startX: 20,
+      y: 20,
+    });
+
+    // swiping back to step 1
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Swipe 1 ${uniqueId}`) }),
     ).toBeVisible();
   });
 

--- a/packages/player/src/components/static-step-navigation.tsx
+++ b/packages/player/src/components/static-step-navigation.tsx
@@ -2,6 +2,10 @@
 
 import { useRef } from "react";
 
+const SWIPE_MIN_DISTANCE = 50;
+const SWIPE_MAX_VERTICAL_DRIFT = 75;
+const SWIPE_TAP_SUPPRESSION_MS = 400;
+
 export function StaticTapZones({
   isFirst,
   onNavigateNext,
@@ -32,35 +36,37 @@ export function StaticTapZones({
   );
 }
 
-const SWIPE_MIN_DISTANCE = 50;
-const SWIPE_MAX_VERTICAL_DRIFT = 75;
-
-export function useSwipeNavigation({
+export function useStaticStepNavigation({
+  isFirst,
   onNavigateNext,
   onNavigatePrev,
 }: {
+  isFirst: boolean;
   onNavigateNext: () => void;
   onNavigatePrev: () => void;
 }) {
+  const lastSwipeAt = useRef<number | null>(null);
   const touchStart = useRef<{ x: number; y: number } | null>(null);
 
-  const handleTouchStart = (event: React.TouchEvent) => {
+  const handleTouchStart = (event: React.TouchEvent<HTMLElement>) => {
     const touch = event.touches[0];
 
-    if (touch) {
-      touchStart.current = { x: touch.clientX, y: touch.clientY };
+    if (!touch) {
+      return;
     }
+
+    touchStart.current = { x: touch.clientX, y: touch.clientY };
   };
 
-  const handleTouchEnd = (event: React.TouchEvent) => {
+  const handleTouchEnd = (event: React.TouchEvent<HTMLElement>) => {
     const start = touchStart.current;
     const touch = event.changedTouches[0];
+
+    touchStart.current = null;
 
     if (!start || !touch) {
       return;
     }
-
-    touchStart.current = null;
 
     const deltaX = touch.clientX - start.x;
     const deltaY = Math.abs(touch.clientY - start.y);
@@ -69,12 +75,43 @@ export function useSwipeNavigation({
       return;
     }
 
+    lastSwipeAt.current = Date.now();
+
     if (deltaX < 0) {
       onNavigateNext();
-    } else {
+      return;
+    }
+
+    if (!isFirst) {
       onNavigatePrev();
     }
   };
 
-  return { onTouchEnd: handleTouchEnd, onTouchStart: handleTouchStart };
+  const shouldIgnoreTap = () =>
+    lastSwipeAt.current !== null && Date.now() - lastSwipeAt.current < SWIPE_TAP_SUPPRESSION_MS;
+
+  const handleNavigateNextTap = () => {
+    if (shouldIgnoreTap()) {
+      return;
+    }
+
+    onNavigateNext();
+  };
+
+  const handleNavigatePrevTap = () => {
+    if (shouldIgnoreTap()) {
+      return;
+    }
+
+    onNavigatePrev();
+  };
+
+  return {
+    onNavigateNextTap: handleNavigateNextTap,
+    onNavigatePrevTap: handleNavigatePrevTap,
+    swipeHandlers: {
+      onTouchEnd: handleTouchEnd,
+      onTouchStart: handleTouchStart,
+    },
+  };
 }

--- a/packages/player/src/components/static-step.tsx
+++ b/packages/player/src/components/static-step.tsx
@@ -6,6 +6,7 @@ import { type SerializedStep } from "../prepare-activity-data";
 import { useReplaceName } from "../user-name-context";
 import { HighlightText } from "./highlight-text";
 import { ContextText } from "./question-text";
+import { StaticTapZones, useStaticStepNavigation } from "./static-step-navigation";
 import { StaticStepText, StaticStepVisual } from "./step-layouts";
 import { StepVisualRenderer } from "./step-visual-renderer";
 
@@ -74,8 +75,24 @@ function StaticStepContent({ step }: { step: SerializedStep }) {
   return <TextVariant text={content.text} title={content.title} />;
 }
 
-export function StaticStep({ step }: { step: SerializedStep }) {
+export function StaticStep({
+  isFirst,
+  onNavigateNext,
+  onNavigatePrev,
+  step,
+}: {
+  isFirst: boolean;
+  onNavigateNext: () => void;
+  onNavigatePrev: () => void;
+  step: SerializedStep;
+}) {
   const hasVisual = Boolean(step.visualKind && step.visualContent);
+
+  const { onNavigateNextTap, onNavigatePrevTap, swipeHandlers } = useStaticStepNavigation({
+    isFirst,
+    onNavigateNext,
+    onNavigatePrev,
+  });
 
   return (
     <>
@@ -89,10 +106,16 @@ export function StaticStep({ step }: { step: SerializedStep }) {
 
       <StaticStepText
         className={cn(
-          "mx-4 pt-4 pb-6 sm:mx-6 sm:pt-5 sm:pb-8",
+          "relative mx-4 pt-4 pb-6 sm:mx-6 sm:pt-5 sm:pb-8",
           hasVisual && "border-border/40 border-t xl:border-t-0",
         )}
+        {...swipeHandlers}
       >
+        <StaticTapZones
+          isFirst={isFirst}
+          onNavigateNext={onNavigateNextTap}
+          onNavigatePrev={onNavigatePrevTap}
+        />
         <StaticStepContent step={step} />
       </StaticStepText>
     </>

--- a/packages/player/src/components/step-renderer.tsx
+++ b/packages/player/src/components/step-renderer.tsx
@@ -10,7 +10,6 @@ import { ReadingStep } from "./reading-step";
 import { SelectImageStep } from "./select-image-step";
 import { SortOrderStep } from "./sort-order-step";
 import { StaticStep } from "./static-step";
-import { StaticTapZones, useSwipeNavigation } from "./static-step-navigation";
 import { StaticStepLayout } from "./step-layouts";
 import { VocabularyStep } from "./vocabulary-step";
 
@@ -31,22 +30,19 @@ export function StepRenderer({
   selectedAnswer: SelectedAnswer | undefined;
   step: SerializedStep;
 }) {
-  const swipeHandlers = useSwipeNavigation({ onNavigateNext, onNavigatePrev });
-
   if (step.kind === "static") {
     const hasVisual = Boolean(step.visualKind && step.visualContent);
 
     return (
-      <div className="relative flex min-h-0 w-full flex-1 justify-center" {...swipeHandlers}>
+      <div className="flex min-h-0 w-full flex-1 justify-center">
         <StaticStepLayout className={hasVisual ? "xl:justify-center xl:gap-4" : "justify-center"}>
-          <StaticStep step={step} />
+          <StaticStep
+            isFirst={isFirst}
+            onNavigateNext={onNavigateNext}
+            onNavigatePrev={onNavigatePrev}
+            step={step}
+          />
         </StaticStepLayout>
-
-        <StaticTapZones
-          isFirst={isFirst}
-          onNavigateNext={onNavigateNext}
-          onNavigatePrev={onNavigatePrev}
-        />
       </div>
     );
   }


### PR DESCRIPTION
Move static-step tap and swipe navigation into the bottom text content so visuals no longer trigger accidental navigation while scrolling or zooming.

Also harden the chapter detail E2E fixture ID to avoid collisions during repeated full-suite reruns.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts static-step navigation to the bottom text area so visuals and outer layout no longer trigger accidental step changes. Also strengthens E2E fixtures to avoid ID collisions.

- Bug Fixes
  - Navigation only responds to taps and swipes in the text area; visuals and outer clicks/swipes are ignored.
  - Suppresses taps for 400ms after a swipe and blocks prev navigation on the first step.
  - E2E adds swipe helper and verifies the new behavior; fixtures use full UUIDs to prevent collisions.

- Refactors
  - Moved tap zones and swipe handlers into the text container, replaced the hook with `useStaticStepNavigation`, and updated `StaticStep` to accept `isFirst`, `onNavigateNext`, and `onNavigatePrev`.

<sup>Written for commit 6cf104c2ff3594e47b37b0036abd66ef45121f07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

