### PR TITLE
fix(main): refine continue learning layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,8 @@ When writing React components, use compound components. Always read this before 
 
 **VERY IMPORTANT**: **Always follow TDD (Test-Driven Development)**: Write a failing test first, **run the test to confirm it fails**, then write the code to make it pass. If the test passes before your fix, the test is wrong—never use workarounds like `.first()` or loose assertions to make tests pass. Use unique test data (e.g., UUIDs in titles) to ensure tests catch regressions.
 
+**EXCEPTION:** You don't need to follow TDD for CSS/style only changes since those should be tested manually/visually, not with automated tests.
+
 - **Parallelize independent fixtures**: When test setup creates multiple entities that don't depend on each other (e.g., `user` + `course`, sibling chapters, multiple `activityProgressFixture` calls), use `Promise.all` instead of sequential awaits
 - **E2E tests**: For app/UI features, use Playwright (`apps/{app}/e2e/`)
 - **Integration tests**: For data functions with Prisma (`apps/{app}/src/data/`)

--- a/apps/main/src/app/(catalog)/(home)/continue-learning-card.tsx
+++ b/apps/main/src/app/(catalog)/(home)/continue-learning-card.tsx
@@ -44,11 +44,9 @@ function getCourseHrefs(item: ContinueLearningItem) {
 export async function ContinueLearningCard({
   item,
   kindLabels,
-  fullWidth,
 }: {
   item: ContinueLearningItem;
   kindLabels: Map<string, string>;
-  fullWidth?: boolean;
 }) {
   const t = await getExtracted();
   const { activity, course, lesson } = item;
@@ -60,11 +58,7 @@ export async function ContinueLearningCard({
   const { activityHref, courseHref, lessonHref } = getCourseHrefs(item);
 
   return (
-    <FeatureCard
-      className={
-        fullWidth ? undefined : "w-[85vw] shrink-0 snap-start sm:w-[45vw] 2xl:w-[calc(25%-1rem)]"
-      }
-    >
+    <FeatureCard>
       <Link href={activityHref} prefetch>
         <FeatureCardHeader>
           <FeatureCardHeaderContent>

--- a/apps/main/src/app/(catalog)/(home)/continue-learning.tsx
+++ b/apps/main/src/app/(catalog)/(home)/continue-learning.tsx
@@ -1,4 +1,7 @@
-import { type ContinueLearningItem } from "@/data/courses/get-continue-learning";
+import {
+  type ContinueLearningItem,
+  MAX_CONTINUE_LEARNING_ITEMS,
+} from "@/data/courses/get-continue-learning";
 import { getActivityKinds } from "@/lib/activities";
 import {
   FeatureCard,
@@ -7,44 +10,83 @@ import {
   FeatureCardSectionTitle,
   FeatureCardThumbnail,
 } from "@zoonk/ui/components/feature";
-import { ScrollArea, ScrollBar } from "@zoonk/ui/components/scroll-area";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { getExtracted } from "next-intl/server";
+import { type ReactNode } from "react";
 import { ContinueLearningCard } from "./continue-learning-card";
+
+function ContinueLearningItem({ children, itemCount }: { children: ReactNode; itemCount: number }) {
+  if (itemCount === 1) {
+    return <div className="w-full">{children}</div>;
+  }
+
+  return <div className="w-72 shrink-0 snap-start sm:w-auto sm:shrink">{children}</div>;
+}
+
+function ContinueLearningLayout({
+  children,
+  itemCount,
+}: {
+  children: ReactNode;
+  itemCount: number;
+}) {
+  if (itemCount === 1) {
+    return (
+      <div className="grid grid-cols-1 gap-4 px-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto [scrollbar-width:none] sm:overflow-x-visible [&::-webkit-scrollbar]:hidden">
+      <div className="flex w-max min-w-full snap-x snap-mandatory gap-4 px-4 pb-1 sm:grid sm:w-auto sm:min-w-0 sm:snap-none sm:grid-cols-2 sm:pb-0 lg:grid-cols-3 xl:grid-cols-4">
+        {children}
+      </div>
+    </div>
+  );
+}
 
 export async function ContinueLearningList({ items }: { items: ContinueLearningItem[] }) {
   const t = await getExtracted();
   const activityKinds = await getActivityKinds();
+  const itemCount = items.length;
 
   const kindLabels = new Map<string, string>(activityKinds.map((kind) => [kind.key, kind.label]));
+  const cards = items.map((item) => (
+    <ContinueLearningItem itemCount={itemCount} key={item.activity.id}>
+      <ContinueLearningCard item={item} kindLabels={kindLabels} />
+    </ContinueLearningItem>
+  ));
 
   return (
-    <section className="flex flex-col gap-3 py-4 md:py-6">
-      <FeatureCardSectionTitle className="px-4">{t("Continue learning")}</FeatureCardSectionTitle>
+    <section aria-labelledby="continue-learning-title" className="flex flex-col gap-3 py-4 md:py-6">
+      <FeatureCardSectionTitle className="px-4" id="continue-learning-title">
+        {t("Continue learning")}
+      </FeatureCardSectionTitle>
 
-      {items.length === 1 ? (
-        <div className="px-4">
-          {items.map((item) => (
-            <ContinueLearningCard
-              item={item}
-              key={item.activity.id}
-              kindLabels={kindLabels}
-              fullWidth
-            />
-          ))}
-        </div>
-      ) : (
-        <ScrollArea className="w-full px-4 pb-2">
-          <div className="flex snap-x snap-mandatory gap-4">
-            {items.map((item) => (
-              <ContinueLearningCard item={item} key={item.activity.id} kindLabels={kindLabels} />
-            ))}
-          </div>
-
-          <ScrollBar orientation="horizontal" />
-        </ScrollArea>
-      )}
+      <ContinueLearningLayout itemCount={itemCount}>{cards}</ContinueLearningLayout>
     </section>
+  );
+}
+
+function ContinueLearningCardSkeleton() {
+  return (
+    <FeatureCard>
+      <Skeleton className="h-5 w-full" />
+
+      <FeatureCardContent>
+        <FeatureCardThumbnail size="lg">
+          <Skeleton className="size-full" />
+        </FeatureCardThumbnail>
+
+        <FeatureCardBody className="gap-1">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-3 w-2/3" />
+          <Skeleton className="h-6 w-full" />
+        </FeatureCardBody>
+      </FeatureCardContent>
+    </FeatureCard>
   );
 }
 
@@ -53,26 +95,14 @@ export function ContinueLearningSkeleton() {
     <section className="flex flex-col gap-3 py-4 md:py-6">
       <Skeleton className="mx-4 h-5 w-32" />
 
-      <div className="flex gap-6 overflow-hidden px-4 pb-2">
-        {Array.from({ length: 5 }).map((_, i) => (
-          // eslint-disable-next-line react/no-array-index-key -- static skeleton
-          <FeatureCard className="w-72 shrink-0 md:w-80" key={i}>
-            <Skeleton className="h-5 w-full" />
-
-            <FeatureCardContent>
-              <FeatureCardThumbnail size="lg">
-                <Skeleton className="size-full" />
-              </FeatureCardThumbnail>
-
-              <FeatureCardBody className="gap-1">
-                <Skeleton className="h-4 w-full" />
-                <Skeleton className="h-3 w-2/3" />
-                <Skeleton className="h-6 w-full" />
-              </FeatureCardBody>
-            </FeatureCardContent>
-          </FeatureCard>
+      <ContinueLearningLayout itemCount={MAX_CONTINUE_LEARNING_ITEMS}>
+        {/* eslint-disable react/no-array-index-key -- static skeleton */}
+        {Array.from({ length: MAX_CONTINUE_LEARNING_ITEMS }).map((_, i) => (
+          <ContinueLearningItem itemCount={MAX_CONTINUE_LEARNING_ITEMS} key={i}>
+            <ContinueLearningCardSkeleton />
+          </ContinueLearningItem>
         ))}
-      </div>
+      </ContinueLearningLayout>
     </section>
   );
 }

--- a/apps/main/src/data/courses/get-continue-learning.test.ts
+++ b/apps/main/src/data/courses/get-continue-learning.test.ts
@@ -6,9 +6,7 @@ import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { beforeAll, describe, expect, test } from "vitest";
-import { getContinueLearning } from "./get-continue-learning";
-
-const MAX_CONTINUE_LEARNING_ITEMS = 4;
+import { MAX_CONTINUE_LEARNING_ITEMS, getContinueLearning } from "./get-continue-learning";
 
 async function createCourseWithActivities(organizationId: number) {
   const course = await courseFixture({

--- a/apps/main/src/data/courses/get-continue-learning.ts
+++ b/apps/main/src/data/courses/get-continue-learning.ts
@@ -15,7 +15,7 @@ import {
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 
-const MAX_CONTINUE_LEARNING_ITEMS = 4;
+export const MAX_CONTINUE_LEARNING_ITEMS = 4;
 
 /**
  * Over-fetch to account for completed courses being filtered out.


### PR DESCRIPTION
## Summary
- fix the continue learning mobile spacing and single-item layout
- simplify the section structure with small compositional wrappers
- share the continue learning item limit between data, skeleton, and tests
- document the manual-testing exception for css-only changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refined the Continue Learning layout to fix mobile spacing and render a single item correctly. Simplified the section structure and unified the item limit across data, skeleton, and tests.

- **Bug Fixes**
  - Fixed mobile spacing and horizontal scroll behavior by replacing `ScrollArea`/`ScrollBar` with a simple overflow container.
  - Correct single-item layout with full-width rendering and an accessible title via `aria-labelledby`.

- **Refactors**
  - Added small wrappers (`ContinueLearningItem`, `ContinueLearningLayout`) to control widths and layout.
  - Exported `MAX_CONTINUE_LEARNING_ITEMS` and reused it in the skeleton and tests.
  - Documented the CSS-only manual testing exception in `AGENTS.md`.

<sup>Written for commit e898a57fbf1ae1f69313f2b59e7fcb6701007480. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

