### PR TITLE
fix(player): use parameterized string for belt level translation

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -55,9 +55,11 @@ msgid "Incorrect"
 msgstr "Incorrect"
 
 #: ../../packages/player/src/components/belt-progress.tsx
-msgctxt "erSdxr"
-msgid "Belt"
-msgstr "Belt"
+#: src/app/(catalog)/(home)/level.tsx
+#: src/app/(performance)/level/level-stats.tsx
+msgctxt "3UK8wh"
+msgid "{color} belt"
+msgstr "{color} belt"
 
 #: ../../packages/player/src/components/belt-progress.tsx
 msgctxt "IGs0wl"
@@ -70,12 +72,9 @@ msgid "{value} BP to level up"
 msgstr "{value} BP to level up"
 
 #: ../../packages/player/src/components/belt-progress.tsx
-#: src/app/(catalog)/(home)/level.tsx
-#: src/app/(performance)/_components/metric-pills.tsx
-#: src/app/(performance)/level/page.tsx
-msgctxt "y1Qr81"
-msgid "Level"
-msgstr "Level"
+msgctxt "xiSVL4"
+msgid "{color} Belt — Level {level}"
+msgstr "{color} Belt — Level {level}"
 
 #: ../../packages/player/src/components/challenge-completion.tsx
 #: ../../packages/player/src/components/completion-auth-branch.tsx
@@ -656,12 +655,6 @@ msgstr "Interactive courses built for you. Just tell us what you want to learn."
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(performance)/level/level-stats.tsx
-msgctxt "3UK8wh"
-msgid "{color} belt"
-msgstr "{color} belt"
-
-#: src/app/(catalog)/(home)/level.tsx
-#: src/app/(performance)/level/level-stats.tsx
 msgctxt "8N9BRu"
 msgid "{value} BP to next level"
 msgstr "{value} BP to next level"
@@ -677,6 +670,13 @@ msgstr "Max level reached"
 msgctxt "uiwFZe"
 msgid "{color} Belt - Level {level}"
 msgstr "{color} Belt - Level {level}"
+
+#: src/app/(catalog)/(home)/level.tsx
+#: src/app/(performance)/_components/metric-pills.tsx
+#: src/app/(performance)/level/page.tsx
+msgctxt "y1Qr81"
+msgid "Level"
+msgstr "Level"
 
 #: src/app/(catalog)/(home)/page.tsx
 msgctxt "qsfeMJ"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -55,9 +55,11 @@ msgid "Incorrect"
 msgstr "Incorrecto"
 
 #: ../../packages/player/src/components/belt-progress.tsx
-msgctxt "erSdxr"
-msgid "Belt"
-msgstr "Cinturón"
+#: src/app/(catalog)/(home)/level.tsx
+#: src/app/(performance)/level/level-stats.tsx
+msgctxt "3UK8wh"
+msgid "{color} belt"
+msgstr "Cinturón {color}"
 
 #: ../../packages/player/src/components/belt-progress.tsx
 msgctxt "IGs0wl"
@@ -70,12 +72,9 @@ msgid "{value} BP to level up"
 msgstr "{value} PM para subir de nivel"
 
 #: ../../packages/player/src/components/belt-progress.tsx
-#: src/app/(catalog)/(home)/level.tsx
-#: src/app/(performance)/_components/metric-pills.tsx
-#: src/app/(performance)/level/page.tsx
-msgctxt "y1Qr81"
-msgid "Level"
-msgstr "Nivel"
+msgctxt "xiSVL4"
+msgid "{color} Belt — Level {level}"
+msgstr "Cinturón {color} — Nivel {level}"
 
 #: ../../packages/player/src/components/challenge-completion.tsx
 #: ../../packages/player/src/components/completion-auth-branch.tsx
@@ -656,12 +655,6 @@ msgstr "Cursos interactivos creados para ti. Solo dinos qué quieres aprender."
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(performance)/level/level-stats.tsx
-msgctxt "3UK8wh"
-msgid "{color} belt"
-msgstr "Cinturón {color}"
-
-#: src/app/(catalog)/(home)/level.tsx
-#: src/app/(performance)/level/level-stats.tsx
 msgctxt "8N9BRu"
 msgid "{value} BP to next level"
 msgstr "{value} PM para el siguiente nivel"
@@ -677,6 +670,13 @@ msgstr "Nivel máximo alcanzado"
 msgctxt "uiwFZe"
 msgid "{color} Belt - Level {level}"
 msgstr "Cinturón {color} - Nivel {level}"
+
+#: src/app/(catalog)/(home)/level.tsx
+#: src/app/(performance)/_components/metric-pills.tsx
+#: src/app/(performance)/level/page.tsx
+msgctxt "y1Qr81"
+msgid "Level"
+msgstr "Nivel"
 
 #: src/app/(catalog)/(home)/page.tsx
 msgctxt "qsfeMJ"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -55,9 +55,11 @@ msgid "Incorrect"
 msgstr "Incorreto"
 
 #: ../../packages/player/src/components/belt-progress.tsx
-msgctxt "erSdxr"
-msgid "Belt"
-msgstr "Faixa"
+#: src/app/(catalog)/(home)/level.tsx
+#: src/app/(performance)/level/level-stats.tsx
+msgctxt "3UK8wh"
+msgid "{color} belt"
+msgstr "faixa {color}"
 
 #: ../../packages/player/src/components/belt-progress.tsx
 msgctxt "IGs0wl"
@@ -70,12 +72,9 @@ msgid "{value} BP to level up"
 msgstr "{value} PM para subir de nível"
 
 #: ../../packages/player/src/components/belt-progress.tsx
-#: src/app/(catalog)/(home)/level.tsx
-#: src/app/(performance)/_components/metric-pills.tsx
-#: src/app/(performance)/level/page.tsx
-msgctxt "y1Qr81"
-msgid "Level"
-msgstr "Nível"
+msgctxt "xiSVL4"
+msgid "{color} Belt — Level {level}"
+msgstr "Faixa {color} — Nível {level}"
 
 #: ../../packages/player/src/components/challenge-completion.tsx
 #: ../../packages/player/src/components/completion-auth-branch.tsx
@@ -656,12 +655,6 @@ msgstr "Cursos interativos criados para você. Apenas nos diga o que você quer 
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(performance)/level/level-stats.tsx
-msgctxt "3UK8wh"
-msgid "{color} belt"
-msgstr "faixa {color}"
-
-#: src/app/(catalog)/(home)/level.tsx
-#: src/app/(performance)/level/level-stats.tsx
 msgctxt "8N9BRu"
 msgid "{value} BP to next level"
 msgstr "{value} PM para o próximo nível"
@@ -677,6 +670,13 @@ msgstr "Nível máximo alcançado"
 msgctxt "uiwFZe"
 msgid "{color} Belt - Level {level}"
 msgstr "Faixa {color} - Nível {level}"
+
+#: src/app/(catalog)/(home)/level.tsx
+#: src/app/(performance)/_components/metric-pills.tsx
+#: src/app/(performance)/level/page.tsx
+msgctxt "y1Qr81"
+msgid "Level"
+msgstr "Nível"
 
 #: src/app/(catalog)/(home)/page.tsx
 msgctxt "qsfeMJ"

--- a/packages/player/src/components/belt-progress.tsx
+++ b/packages/player/src/components/belt-progress.tsx
@@ -92,11 +92,11 @@ export function BeltProgressHint({
         <BeltIndicator
           className={didLevelUp ? "animate-dot-pulse motion-reduce:animate-none" : undefined}
           color={displayColor}
-          label={displayLabel}
+          label={t("{color} belt", { color: displayLabel })}
           size="sm"
         />
         <span className="text-foreground text-sm font-medium">
-          {displayLabel} {t("Belt")} — {t("Level")} {displayLevel}
+          {t("{color} Belt — Level {level}", { color: displayLabel, level: String(displayLevel) })}
         </span>
       </div>
       <ProgressRoot


### PR DESCRIPTION
## Summary

- Replace word concatenation (`{color} {t("Belt")} — {t("Level")} {level}`) with a single parameterized translation string (`t("{color} Belt — Level {level}", { color, level })`) so translators can control word order
- Fix `BeltIndicator` aria-label to use the existing `"{color} belt"` parameterized string
- Add pt/es translations for the new string

## Test plan

- [x] `pnpm turbo quality:fix`
- [x] `pnpm typecheck`
- [x] `pnpm --filter main build`
- [x] `pnpm --filter main e2e` (387 passed)
- [x] `pnpm --filter editor e2e` (193 passed)
- [x] `pnpm --filter api e2e` (56 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch belt/level text to a single parameterized translation so each locale controls word order, and fix the belt indicator’s aria-label for better accessibility. Adds `pt` and `es` translations for the new strings.

- **Bug Fixes**
  - Replace concatenation with `t("{color} Belt — Level {level}", { color, level })` in `packages/player`.
  - Use `t("{color} belt")` for `BeltIndicator` aria-label.
  - Update `en`, `es`, and `pt` `.po` files with the new keys.

<sup>Written for commit 6a84a1c5af8b13db1db25a9146f0f10e2e9f4ef1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

