### PR TITLE
fix(main): gate activity prefetch by generation state

### DIFF
--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
@@ -55,7 +55,7 @@ export async function ActivityList({
               href={`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}/a/${activity.position}`}
               id={activity.id}
               key={String(activity.id)}
-              prefetch
+              prefetch={activity.generationStatus === "completed"}
             >
               <CatalogListItemContent>
                 <CatalogListItemTitle>{title}</CatalogListItemTitle>

--- a/apps/main/src/components/catalog/continue-activity-link.tsx
+++ b/apps/main/src/components/catalog/continue-activity-link.tsx
@@ -63,7 +63,7 @@ export async function ContinueActivityLink<Href extends string>({
     <Link
       className={cn(buttonVariants(), "min-w-0 flex-1 gap-2")}
       href={`/b/${data.brandSlug}/c/${data.courseSlug}/ch/${data.chapterSlug}/l/${data.lessonSlug}/a/${data.activityPosition}`}
-      prefetch
+      prefetch={data.canPrefetch}
     >
       {getLabel()}
       <ChevronRightIcon aria-hidden="true" />

--- a/packages/core/src/progress/get-next-activity.test.ts
+++ b/packages/core/src/progress/get-next-activity.test.ts
@@ -53,6 +53,7 @@ describe("getNextActivity - course scope", () => {
     expect(result).toEqual({
       activityPosition: 0,
       brandSlug: organization.slug,
+      canPrefetch: true,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -101,6 +102,56 @@ describe("getNextActivity - course scope", () => {
     expect(result).toEqual({
       activityPosition: 0,
       brandSlug: organization.slug,
+      canPrefetch: true,
+      chapterSlug: chapter.slug,
+      completed: false,
+      courseSlug: course.slug,
+      hasStarted: false,
+      lessonSlug: lesson.slug,
+    });
+  });
+
+  test("returns first activity with canPrefetch=false when it is not generated", async () => {
+    const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    await Promise.all([
+      activityFixture({
+        generationStatus: "pending",
+        isPublished: true,
+        lessonId: lesson.id,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        lessonId: lesson.id,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    const result = await getNextActivity({
+      headers: new Headers(),
+      scope: { courseId: course.id },
+    });
+
+    expect(result).toEqual({
+      activityPosition: 0,
+      brandSlug: organization.slug,
+      canPrefetch: false,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -158,6 +209,7 @@ describe("getNextActivity - course scope", () => {
     expect(result).toEqual({
       activityPosition: 1,
       brandSlug: organization.slug,
+      canPrefetch: true,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -256,6 +308,7 @@ describe("getNextActivity - course scope", () => {
     expect(result).toEqual({
       activityPosition: 1,
       brandSlug: organization.slug,
+      canPrefetch: true,
       chapterSlug: chapterB.slug,
       completed: false,
       courseSlug: course.slug,
@@ -319,6 +372,7 @@ describe("getNextActivity - course scope", () => {
     expect(result).toEqual({
       activityPosition: 0,
       brandSlug: organization.slug,
+      canPrefetch: true,
       chapterSlug: chapter.slug,
       completed: true,
       courseSlug: course.slug,
@@ -397,6 +451,7 @@ describe("getNextActivity - course scope", () => {
     expect(result).toEqual({
       activityPosition: 0,
       brandSlug: organization.slug,
+      canPrefetch: true,
       chapterSlug: publishedChapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -451,6 +506,7 @@ describe("getNextActivity - chapter scope", () => {
     expect(result).toEqual({
       activityPosition: 0,
       brandSlug: organization.slug,
+      canPrefetch: true,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -508,6 +564,7 @@ describe("getNextActivity - chapter scope", () => {
     expect(result).toEqual({
       activityPosition: 1,
       brandSlug: organization.slug,
+      canPrefetch: true,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -582,6 +639,7 @@ describe("getNextActivity - chapter scope", () => {
     expect(result).toEqual({
       activityPosition: 0,
       brandSlug: organization.slug,
+      canPrefetch: true,
       chapterSlug: chapter1.slug,
       completed: true,
       courseSlug: course.slug,
@@ -636,6 +694,7 @@ describe("getNextActivity - lesson scope", () => {
     expect(result).toEqual({
       activityPosition: 0,
       brandSlug: organization.slug,
+      canPrefetch: true,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -693,6 +752,7 @@ describe("getNextActivity - lesson scope", () => {
     expect(result).toEqual({
       activityPosition: 1,
       brandSlug: organization.slug,
+      canPrefetch: true,
       chapterSlug: chapter.slug,
       completed: false,
       courseSlug: course.slug,
@@ -759,6 +819,7 @@ describe("getNextActivity - lesson scope", () => {
     expect(result).toEqual({
       activityPosition: 0,
       brandSlug: organization.slug,
+      canPrefetch: true,
       chapterSlug: chapter.slug,
       completed: true,
       courseSlug: course.slug,

--- a/packages/core/src/progress/get-next-activity.ts
+++ b/packages/core/src/progress/get-next-activity.ts
@@ -30,6 +30,7 @@ function scopeWhere(scope: ActivityScope) {
 async function findFirstActivity(scope: ActivityScope): Promise<{
   activityPosition: number;
   brandSlug: string | null;
+  canPrefetch: boolean;
   chapterSlug: string;
   courseSlug: string;
   lessonSlug: string;
@@ -63,6 +64,7 @@ async function findFirstActivity(scope: ActivityScope): Promise<{
   return {
     activityPosition: activity.position,
     brandSlug: activity.lesson.chapter.course.organization?.slug ?? null,
+    canPrefetch: activity.generationStatus === "completed",
     chapterSlug: activity.lesson.chapter.slug,
     courseSlug: activity.lesson.chapter.course.slug,
     lessonSlug: activity.lesson.slug,
@@ -94,6 +96,7 @@ export async function getNextActivity({
 }): Promise<{
   activityPosition: number;
   brandSlug: string | null;
+  canPrefetch: boolean;
   chapterSlug: string;
   completed: boolean;
   courseSlug: string;
@@ -128,6 +131,7 @@ export async function getNextActivity({
     return {
       activityPosition: next.activityPosition,
       brandSlug: lastCompleted.orgSlug,
+      canPrefetch: true,
       chapterSlug: next.chapterSlug,
       completed: false,
       courseSlug: lastCompleted.courseSlug,


### PR DESCRIPTION
## Summary
- gate activity list prefetch behind completed generation status
- expose `canPrefetch` from `getNextActivity` so continue links follow the same rule
- cover the pending first-activity case in core integration tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate activity prefetch to only generated activities to avoid preloading pending content. Continue links follow the same rule via a new canPrefetch flag from getNextActivity.

- **Bug Fixes**
  - Activity list links set prefetch only when generationStatus is "completed".
  - Continue link reads canPrefetch from getNextActivity for consistent behavior.
  - Core now returns canPrefetch; added tests for the pending first-activity case.

<sup>Written for commit d3ec1fba929e4741fab7e3ec5c620d1417897483. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

