### PR TITLE
fix(main): shorten activity kind descriptions

### DIFF
--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -164,16 +164,16 @@ test.describe("Lesson Detail Page", () => {
     const activityList = page.getByRole("list", { name: /activities/i });
 
     await expect(activityList.getByRole("link", { name: /background/i })).toBeVisible();
-    await expect(activityList.getByText(/explains why this topic exists/i)).toBeVisible();
+    await expect(activityList.getByText(/why this topic exists and why it matters/i)).toBeVisible();
 
     await expect(activityList.getByRole("link", { name: /explanation/i })).toBeVisible();
-    await expect(activityList.getByText(/explains what this topic is/i)).toBeVisible();
+    await expect(activityList.getByText(/core concepts and definitions/i)).toBeVisible();
 
     await expect(activityList.getByRole("link", { name: /quiz/i })).toBeVisible();
-    await expect(activityList.getByText(/tests your understanding/i)).toBeVisible();
+    await expect(activityList.getByText(/test your knowledge/i)).toBeVisible();
 
     await expect(activityList.getByRole("link", { name: /challenge/i })).toBeVisible();
-    await expect(activityList.getByText(/tests analytical thinking/i)).toBeVisible();
+    await expect(activityList.getByText(/make decisions with real trade-offs/i)).toBeVisible();
   });
 
   test("clicking activity link navigates to activity page", async ({ page }) => {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -2179,6 +2179,11 @@ msgid "Generating content with AI requires an active subscription."
 msgstr "Generating content with AI requires an active subscription."
 
 #: src/lib/activities.ts
+msgctxt "/WTXNi"
+msgid "Review everything you learned"
+msgstr "Review everything you learned"
+
+#: src/lib/activities.ts
 msgctxt "1TOMnj"
 msgid "Listening"
 msgstr "Listening"
@@ -2194,9 +2199,9 @@ msgid "Examples"
 msgstr "Examples"
 
 #: src/lib/activities.ts
-msgctxt "7Jwa/p"
-msgid "Shows HOW things work through practical demonstrations and WHERE they appear in real life."
-msgstr "Shows HOW things work through practical demonstrations and WHERE they appear in real life."
+msgctxt "7X/3vJ"
+msgid "Build your vocabulary"
+msgstr "Build your vocabulary"
 
 #: src/lib/activities.ts
 msgctxt "BB51/R"
@@ -2219,24 +2224,24 @@ msgid "Review everything you learned about {topic} with a comprehensive quiz."
 msgstr "Review everything you learned about {topic} with a comprehensive quiz."
 
 #: src/lib/activities.ts
+msgctxt "CaEilC"
+msgid "Make decisions with real trade-offs"
+msgstr "Make decisions with real trade-offs"
+
+#: src/lib/activities.ts
+msgctxt "cxvnSI"
+msgid "Apply the topic in a real scenario"
+msgstr "Apply the topic in a real scenario"
+
+#: src/lib/activities.ts
 msgctxt "E1bF/X"
 msgid "Explanation"
 msgstr "Explanation"
 
 #: src/lib/activities.ts
-msgctxt "EBP23n"
-msgid "Read sentences and translate them to practice reading comprehension."
-msgstr "Read sentences and translate them to practice reading comprehension."
-
-#: src/lib/activities.ts
-msgctxt "EUjQSf"
-msgid "A comprehensive quiz covering everything you learned in this lesson."
-msgstr "A comprehensive quiz covering everything you learned in this lesson."
-
-#: src/lib/activities.ts
-msgctxt "f9gZnh"
-msgid "Learn new words and their translations to build your vocabulary."
-msgstr "Learn new words and their translations to build your vocabulary."
+msgctxt "EhgTzV"
+msgid "Practice listening skills"
+msgstr "Practice listening skills"
 
 #: src/lib/activities.ts
 msgctxt "gAYlHX"
@@ -2244,19 +2249,9 @@ msgid "Sharpen your {topic} listening skills by translating audio sentences."
 msgstr "Sharpen your {topic} listening skills by translating audio sentences."
 
 #: src/lib/activities.ts
-msgctxt "gyZY3d"
-msgid "Tests analytical thinking through decisions with trade-offs. See how each choice impacts different outcomes."
-msgstr "Tests analytical thinking through decisions with trade-offs. See how each choice impacts different outcomes."
-
-#: src/lib/activities.ts
 msgctxt "h2acN8"
 msgid "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
 msgstr "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
-
-#: src/lib/activities.ts
-msgctxt "i09QqM"
-msgid "A dialogue-based story that helps you practice the language in a real-world context."
-msgstr "A dialogue-based story that helps you practice the language in a real-world context."
 
 #: src/lib/activities.ts
 msgctxt "ICIYNP"
@@ -2264,14 +2259,24 @@ msgid "Discover why {topic} matters — its origins, the problems it solved, and
 msgstr "Discover why {topic} matters — its origins, the problems it solved, and why it's important today."
 
 #: src/lib/activities.ts
-msgctxt "J9eZ8n"
-msgid "Listen to audio sentences and translate them to practice listening skills."
-msgstr "Listen to audio sentences and translate them to practice listening skills."
+msgctxt "iOvuhZ"
+msgid "Test your knowledge"
+msgstr "Test your knowledge"
 
 #: src/lib/activities.ts
-msgctxt "kmCCVm"
-msgid "Teaches grammar rules with practical exercises to help you remember and apply them."
-msgstr "Teaches grammar rules with practical exercises to help you remember and apply them."
+msgctxt "KQeUad"
+msgid "Practice grammar rules"
+msgstr "Practice grammar rules"
+
+#: src/lib/activities.ts
+msgctxt "liTyj7"
+msgid "Practice reading comprehension"
+msgstr "Practice reading comprehension"
+
+#: src/lib/activities.ts
+msgctxt "lLKXNA"
+msgid "See how it works in practice"
+msgstr "See how it works in practice"
 
 #: src/lib/activities.ts
 msgctxt "lqtP+R"
@@ -2287,6 +2292,11 @@ msgstr "{lesson} {activity}"
 msgctxt "MOK/yK"
 msgid "Reading"
 msgstr "Reading"
+
+#: src/lib/activities.ts
+msgctxt "mUgz2t"
+msgid "Core concepts and definitions"
+msgstr "Core concepts and definitions"
 
 #: src/lib/activities.ts
 msgctxt "olZHUk"
@@ -2309,6 +2319,11 @@ msgid "Learn about {topic} through an interactive activity."
 msgstr "Learn about {topic} through an interactive activity."
 
 #: src/lib/activities.ts
+msgctxt "S4v52l"
+msgid "Why this topic exists and why it matters"
+msgstr "Why this topic exists and why it matters"
+
+#: src/lib/activities.ts
 msgctxt "T24ZU7"
 msgid "Apply your knowledge of {topic} through analytical decisions with real trade-offs."
 msgstr "Apply your knowledge of {topic} through analytical decisions with real trade-offs."
@@ -2324,19 +2339,14 @@ msgid "Practice {topic} grammar rules with exercises designed to help you rememb
 msgstr "Practice {topic} grammar rules with exercises designed to help you remember and apply them."
 
 #: src/lib/activities.ts
-msgctxt "tzNRA/"
-msgid "Explains WHAT this topic is. Breaks down core concepts and definitions using metaphors and analogies."
-msgstr "Explains WHAT this topic is. Breaks down core concepts and definitions using metaphors and analogies."
-
-#: src/lib/activities.ts
 msgctxt "UDijXW"
 msgid "{activity} - {lesson}"
 msgstr "{activity} - {lesson}"
 
 #: src/lib/activities.ts
-msgctxt "WD76vM"
-msgid "Explains WHY this topic exists. Tells the origin story, the problems it solved, and why it matters today."
-msgstr "Explains WHY this topic exists. Tells the origin story, the problems it solved, and why it matters today."
+msgctxt "WlmsO/"
+msgid "Practice in a real-world dialogue"
+msgstr "Practice in a real-world dialogue"
 
 #: src/lib/activities.ts
 msgctxt "XQZA8e"
@@ -2347,16 +2357,6 @@ msgstr "Background"
 msgctxt "XzxpBZ"
 msgid "Improve your {topic} reading comprehension by translating sentences and passages."
 msgstr "Improve your {topic} reading comprehension by translating sentences and passages."
-
-#: src/lib/activities.ts
-msgctxt "y21Ybw"
-msgid "Shows WHEN to apply this topic. A dialogue with a colleague where you solve a real problem together."
-msgstr "Shows WHEN to apply this topic. A dialogue with a colleague where you solve a real problem together."
-
-#: src/lib/activities.ts
-msgctxt "ypy024"
-msgid "Tests your understanding with questions. Uses new scenarios to check if you grasped the concept, not just memorized it."
-msgstr "Tests your understanding with questions. Uses new scenarios to check if you grasped the concept, not just memorized it."
 
 #: src/lib/categories/category.ts
 msgctxt "4HKnmB"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -2179,6 +2179,11 @@ msgid "Generating content with AI requires an active subscription."
 msgstr "Generar contenido con IA requiere una suscripción activa."
 
 #: src/lib/activities.ts
+msgctxt "/WTXNi"
+msgid "Review everything you learned"
+msgstr "Repasa todo lo que aprendiste"
+
+#: src/lib/activities.ts
 msgctxt "1TOMnj"
 msgid "Listening"
 msgstr "Escucha"
@@ -2194,9 +2199,9 @@ msgid "Examples"
 msgstr "Ejemplos"
 
 #: src/lib/activities.ts
-msgctxt "7Jwa/p"
-msgid "Shows HOW things work through practical demonstrations and WHERE they appear in real life."
-msgstr "Muestra CÓMO funcionan las cosas a través de demostraciones prácticas y DÓNDE aparecen en la vida real."
+msgctxt "7X/3vJ"
+msgid "Build your vocabulary"
+msgstr "Amplía tu vocabulario"
 
 #: src/lib/activities.ts
 msgctxt "BB51/R"
@@ -2219,24 +2224,24 @@ msgid "Review everything you learned about {topic} with a comprehensive quiz."
 msgstr "Repasa todo lo que aprendiste sobre {topic} con un cuestionario completo."
 
 #: src/lib/activities.ts
+msgctxt "CaEilC"
+msgid "Make decisions with real trade-offs"
+msgstr "Toma decisiones con consecuencias reales"
+
+#: src/lib/activities.ts
+msgctxt "cxvnSI"
+msgid "Apply the topic in a real scenario"
+msgstr "Aplica el tema en un escenario real"
+
+#: src/lib/activities.ts
 msgctxt "E1bF/X"
 msgid "Explanation"
 msgstr "Explicación"
 
 #: src/lib/activities.ts
-msgctxt "EBP23n"
-msgid "Read sentences and translate them to practice reading comprehension."
-msgstr "Lee oraciones y tradúcelas para practicar comprensión de lectura."
-
-#: src/lib/activities.ts
-msgctxt "EUjQSf"
-msgid "A comprehensive quiz covering everything you learned in this lesson."
-msgstr "Un cuestionario completo que cubre todo lo que aprendiste en esta lección."
-
-#: src/lib/activities.ts
-msgctxt "f9gZnh"
-msgid "Learn new words and their translations to build your vocabulary."
-msgstr "Aprende nuevas palabras y sus traducciones para ampliar tu vocabulario."
+msgctxt "EhgTzV"
+msgid "Practice listening skills"
+msgstr "Practica tus habilidades de escucha"
 
 #: src/lib/activities.ts
 msgctxt "gAYlHX"
@@ -2244,19 +2249,9 @@ msgid "Sharpen your {topic} listening skills by translating audio sentences."
 msgstr "Afina tus habilidades de escucha en {topic} traduciendo oraciones de audio."
 
 #: src/lib/activities.ts
-msgctxt "gyZY3d"
-msgid "Tests analytical thinking through decisions with trade-offs. See how each choice impacts different outcomes."
-msgstr "Evalúa el pensamiento analítico a través de decisiones con compensaciones. Ve cómo cada elección impacta diferentes resultados."
-
-#: src/lib/activities.ts
 msgctxt "h2acN8"
 msgid "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
 msgstr "Pon a prueba tu comprensión de {topic} con preguntas diseñadas para verificar la comprensión real, no solo la memorización."
-
-#: src/lib/activities.ts
-msgctxt "i09QqM"
-msgid "A dialogue-based story that helps you practice the language in a real-world context."
-msgstr "Una historia basada en diálogos que te ayuda a practicar el idioma en un contexto del mundo real."
 
 #: src/lib/activities.ts
 msgctxt "ICIYNP"
@@ -2264,14 +2259,24 @@ msgid "Discover why {topic} matters — its origins, the problems it solved, and
 msgstr "Descubre por qué {topic} importa: sus orígenes, los problemas que resolvió y por qué es importante hoy."
 
 #: src/lib/activities.ts
-msgctxt "J9eZ8n"
-msgid "Listen to audio sentences and translate them to practice listening skills."
-msgstr "Escucha oraciones en audio y tradúcelas para practicar habilidades de escucha."
+msgctxt "iOvuhZ"
+msgid "Test your knowledge"
+msgstr "Pon a prueba tus conocimientos"
 
 #: src/lib/activities.ts
-msgctxt "kmCCVm"
-msgid "Teaches grammar rules with practical exercises to help you remember and apply them."
-msgstr "Enseña reglas gramaticales con ejercicios prácticos para ayudarte a recordarlas y aplicarlas."
+msgctxt "KQeUad"
+msgid "Practice grammar rules"
+msgstr "Practica las reglas gramaticales"
+
+#: src/lib/activities.ts
+msgctxt "liTyj7"
+msgid "Practice reading comprehension"
+msgstr "Practica la comprensión de lectura"
+
+#: src/lib/activities.ts
+msgctxt "lLKXNA"
+msgid "See how it works in practice"
+msgstr "Ve cómo funciona en la práctica"
 
 #: src/lib/activities.ts
 msgctxt "lqtP+R"
@@ -2287,6 +2292,11 @@ msgstr "{lesson} {activity}"
 msgctxt "MOK/yK"
 msgid "Reading"
 msgstr "Lectura"
+
+#: src/lib/activities.ts
+msgctxt "mUgz2t"
+msgid "Core concepts and definitions"
+msgstr "Conceptos básicos y definiciones"
 
 #: src/lib/activities.ts
 msgctxt "olZHUk"
@@ -2309,6 +2319,11 @@ msgid "Learn about {topic} through an interactive activity."
 msgstr "Aprende sobre {topic} a través de una actividad interactiva."
 
 #: src/lib/activities.ts
+msgctxt "S4v52l"
+msgid "Why this topic exists and why it matters"
+msgstr "Por qué existe este tema y por qué importa"
+
+#: src/lib/activities.ts
 msgctxt "T24ZU7"
 msgid "Apply your knowledge of {topic} through analytical decisions with real trade-offs."
 msgstr "Aplica tu conocimiento de {topic} a través de decisiones analíticas con compensaciones reales."
@@ -2324,19 +2339,14 @@ msgid "Practice {topic} grammar rules with exercises designed to help you rememb
 msgstr "Practica las reglas gramaticales de {topic} con ejercicios diseñados para ayudarte a recordarlas y aplicarlas."
 
 #: src/lib/activities.ts
-msgctxt "tzNRA/"
-msgid "Explains WHAT this topic is. Breaks down core concepts and definitions using metaphors and analogies."
-msgstr "Explica QUÉ es este tema. Desglosa conceptos centrales y definiciones usando metáforas y analogías."
-
-#: src/lib/activities.ts
 msgctxt "UDijXW"
 msgid "{activity} - {lesson}"
 msgstr "{activity} - {lesson}"
 
 #: src/lib/activities.ts
-msgctxt "WD76vM"
-msgid "Explains WHY this topic exists. Tells the origin story, the problems it solved, and why it matters today."
-msgstr "Explica POR QUÉ existe este tema. Cuenta la historia de origen, los problemas que resolvió y por qué importa hoy."
+msgctxt "WlmsO/"
+msgid "Practice in a real-world dialogue"
+msgstr "Practica en un diálogo del mundo real"
 
 #: src/lib/activities.ts
 msgctxt "XQZA8e"
@@ -2347,16 +2357,6 @@ msgstr "Contexto"
 msgctxt "XzxpBZ"
 msgid "Improve your {topic} reading comprehension by translating sentences and passages."
 msgstr "Mejora tu comprensión de lectura en {topic} traduciendo oraciones y pasajes."
-
-#: src/lib/activities.ts
-msgctxt "y21Ybw"
-msgid "Shows WHEN to apply this topic. A dialogue with a colleague where you solve a real problem together."
-msgstr "Muestra CUÁNDO aplicar este tema. Un diálogo con un colega donde resuelven juntos un problema real."
-
-#: src/lib/activities.ts
-msgctxt "ypy024"
-msgid "Tests your understanding with questions. Uses new scenarios to check if you grasped the concept, not just memorized it."
-msgstr "Evalúa tu comprensión con preguntas. Usa nuevos escenarios para verificar si captaste el concepto, no solo lo memorizaste."
 
 #: src/lib/categories/category.ts
 msgctxt "4HKnmB"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -2179,6 +2179,11 @@ msgid "Generating content with AI requires an active subscription."
 msgstr "Gerar conteúdo com IA requer uma assinatura ativa."
 
 #: src/lib/activities.ts
+msgctxt "/WTXNi"
+msgid "Review everything you learned"
+msgstr "Revise tudo que você aprendeu"
+
+#: src/lib/activities.ts
 msgctxt "1TOMnj"
 msgid "Listening"
 msgstr "Escuta"
@@ -2194,9 +2199,9 @@ msgid "Examples"
 msgstr "Exemplos"
 
 #: src/lib/activities.ts
-msgctxt "7Jwa/p"
-msgid "Shows HOW things work through practical demonstrations and WHERE they appear in real life."
-msgstr "Mostra COMO as coisas funcionam através de demonstrações práticas e ONDE elas aparecem na vida real."
+msgctxt "7X/3vJ"
+msgid "Build your vocabulary"
+msgstr "Construa seu vocabulário"
 
 #: src/lib/activities.ts
 msgctxt "BB51/R"
@@ -2219,24 +2224,24 @@ msgid "Review everything you learned about {topic} with a comprehensive quiz."
 msgstr "Revise tudo que você aprendeu sobre {topic} com um quiz abrangente."
 
 #: src/lib/activities.ts
+msgctxt "CaEilC"
+msgid "Make decisions with real trade-offs"
+msgstr "Tome decisões com dilemas reais"
+
+#: src/lib/activities.ts
+msgctxt "cxvnSI"
+msgid "Apply the topic in a real scenario"
+msgstr "Aplique o tema em um cenário real"
+
+#: src/lib/activities.ts
 msgctxt "E1bF/X"
 msgid "Explanation"
 msgstr "Explicação"
 
 #: src/lib/activities.ts
-msgctxt "EBP23n"
-msgid "Read sentences and translate them to practice reading comprehension."
-msgstr "Leia frases e traduza elas pra praticar compreensão de leitura."
-
-#: src/lib/activities.ts
-msgctxt "EUjQSf"
-msgid "A comprehensive quiz covering everything you learned in this lesson."
-msgstr "Um quiz completo cobrindo tudo que você aprendeu nesta aula."
-
-#: src/lib/activities.ts
-msgctxt "f9gZnh"
-msgid "Learn new words and their translations to build your vocabulary."
-msgstr "Aprenda novas palavras e traduções para construir seu vocabulário."
+msgctxt "EhgTzV"
+msgid "Practice listening skills"
+msgstr "Pratique habilidades de escuta"
 
 #: src/lib/activities.ts
 msgctxt "gAYlHX"
@@ -2244,19 +2249,9 @@ msgid "Sharpen your {topic} listening skills by translating audio sentences."
 msgstr "Aprimore suas habilidades de escuta em {topic} traduzindo frases de áudio."
 
 #: src/lib/activities.ts
-msgctxt "gyZY3d"
-msgid "Tests analytical thinking through decisions with trade-offs. See how each choice impacts different outcomes."
-msgstr "Testa pensamento analítico através de decisões analisando prós e contras. Veja como cada escolha impacta diferentes resultados."
-
-#: src/lib/activities.ts
 msgctxt "h2acN8"
 msgid "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
 msgstr "Teste sua compreensão de {topic} com perguntas projetadas para verificar compreensão real, não apenas memorização."
-
-#: src/lib/activities.ts
-msgctxt "i09QqM"
-msgid "A dialogue-based story that helps you practice the language in a real-world context."
-msgstr "Uma história baseada em diálogos que ajuda você a praticar o idioma em um contexto do mundo real."
 
 #: src/lib/activities.ts
 msgctxt "ICIYNP"
@@ -2264,14 +2259,24 @@ msgid "Discover why {topic} matters — its origins, the problems it solved, and
 msgstr "Descubra por que {topic} importa — suas origens, os problemas que resolveu e por que é importante hoje."
 
 #: src/lib/activities.ts
-msgctxt "J9eZ8n"
-msgid "Listen to audio sentences and translate them to practice listening skills."
-msgstr "Ouça frases em áudio e traduza elas pra praticar habilidades de escuta."
+msgctxt "iOvuhZ"
+msgid "Test your knowledge"
+msgstr "Teste seu conhecimento"
 
 #: src/lib/activities.ts
-msgctxt "kmCCVm"
-msgid "Teaches grammar rules with practical exercises to help you remember and apply them."
-msgstr "Ensina regras gramaticais com exercícios práticos pra te ajudar a lembrar e aplicar elas."
+msgctxt "KQeUad"
+msgid "Practice grammar rules"
+msgstr "Pratique regras de gramática"
+
+#: src/lib/activities.ts
+msgctxt "liTyj7"
+msgid "Practice reading comprehension"
+msgstr "Pratique compreensão de leitura"
+
+#: src/lib/activities.ts
+msgctxt "lLKXNA"
+msgid "See how it works in practice"
+msgstr "Veja como funciona na prática"
 
 #: src/lib/activities.ts
 msgctxt "lqtP+R"
@@ -2287,6 +2292,11 @@ msgstr "{lesson} {activity}"
 msgctxt "MOK/yK"
 msgid "Reading"
 msgstr "Leitura"
+
+#: src/lib/activities.ts
+msgctxt "mUgz2t"
+msgid "Core concepts and definitions"
+msgstr "Conceitos centrais e definições"
 
 #: src/lib/activities.ts
 msgctxt "olZHUk"
@@ -2309,6 +2319,11 @@ msgid "Learn about {topic} through an interactive activity."
 msgstr "Aprenda sobre {topic} através de uma atividade interativa."
 
 #: src/lib/activities.ts
+msgctxt "S4v52l"
+msgid "Why this topic exists and why it matters"
+msgstr "Por que esse tema existe e por que é importante"
+
+#: src/lib/activities.ts
 msgctxt "T24ZU7"
 msgid "Apply your knowledge of {topic} through analytical decisions with real trade-offs."
 msgstr "Aplique seu conhecimento de {topic} através de decisões analíticas com trade-offs reais."
@@ -2324,19 +2339,14 @@ msgid "Practice {topic} grammar rules with exercises designed to help you rememb
 msgstr "Pratique regras gramaticais de {topic} com exercícios projetados pra te ajudar a lembrar e aplicar elas."
 
 #: src/lib/activities.ts
-msgctxt "tzNRA/"
-msgid "Explains WHAT this topic is. Breaks down core concepts and definitions using metaphors and analogies."
-msgstr "Explica O QUE é este tópico. Decompõe conceitos centrais e definições usando metáforas e analogias."
-
-#: src/lib/activities.ts
 msgctxt "UDijXW"
 msgid "{activity} - {lesson}"
 msgstr "{activity} - {lesson}"
 
 #: src/lib/activities.ts
-msgctxt "WD76vM"
-msgid "Explains WHY this topic exists. Tells the origin story, the problems it solved, and why it matters today."
-msgstr "Explica POR QUE este tópico existe. Conta a história de origem, os problemas que ele resolveu e por que ele importa hoje."
+msgctxt "WlmsO/"
+msgid "Practice in a real-world dialogue"
+msgstr "Pratique em um diálogo do mundo real"
 
 #: src/lib/activities.ts
 msgctxt "XQZA8e"
@@ -2347,16 +2357,6 @@ msgstr "Contexto"
 msgctxt "XzxpBZ"
 msgid "Improve your {topic} reading comprehension by translating sentences and passages."
 msgstr "Melhore sua compreensão de leitura em {topic} traduzindo frases e passagens."
-
-#: src/lib/activities.ts
-msgctxt "y21Ybw"
-msgid "Shows WHEN to apply this topic. A dialogue with a colleague where you solve a real problem together."
-msgstr "Mostra QUANDO aplicar este tópico. Um diálogo com um colega onde vocês resolvem um problema real juntos."
-
-#: src/lib/activities.ts
-msgctxt "ypy024"
-msgid "Tests your understanding with questions. Uses new scenarios to check if you grasped the concept, not just memorized it."
-msgstr "Testa sua compreensão com perguntas. Usa cenários novos pra verificar se você entendeu o conceito, não só memorizou ele."
 
 #: src/lib/categories/category.ts
 msgctxt "4HKnmB"

--- a/apps/main/src/lib/activities.ts
+++ b/apps/main/src/lib/activities.ts
@@ -12,78 +12,62 @@ export async function getActivityKinds(): Promise<
 
   return [
     {
-      description: t(
-        "Explains WHY this topic exists. Tells the origin story, the problems it solved, and why it matters today.",
-      ),
+      description: t("Why this topic exists and why it matters"),
       key: "background",
       label: t("Background"),
     },
     {
-      description: t(
-        "Explains WHAT this topic is. Breaks down core concepts and definitions using metaphors and analogies.",
-      ),
+      description: t("Core concepts and definitions"),
       key: "explanation",
       label: t("Explanation"),
     },
     {
-      description: t(
-        "Tests your understanding with questions. Uses new scenarios to check if you grasped the concept, not just memorized it.",
-      ),
+      description: t("Test your knowledge"),
       key: "quiz",
       label: t("Quiz"),
     },
     {
-      description: t(
-        "Shows HOW things work through practical demonstrations and WHERE they appear in real life.",
-      ),
+      description: t("See how it works in practice"),
       key: "examples",
       label: t("Examples"),
     },
     {
-      description: t(
-        "Shows WHEN to apply this topic. A dialogue with a colleague where you solve a real problem together.",
-      ),
+      description: t("Apply the topic in a real scenario"),
       key: "story",
       label: t("Story"),
     },
     {
-      description: t(
-        "Tests analytical thinking through decisions with trade-offs. See how each choice impacts different outcomes.",
-      ),
+      description: t("Make decisions with real trade-offs"),
       key: "challenge",
       label: t("Challenge"),
     },
     {
-      description: t("Learn new words and their translations to build your vocabulary."),
+      description: t("Build your vocabulary"),
       key: "vocabulary",
       label: t("Vocabulary"),
     },
     {
-      description: t(
-        "Teaches grammar rules with practical exercises to help you remember and apply them.",
-      ),
+      description: t("Practice grammar rules"),
       key: "grammar",
       label: t("Grammar"),
     },
     {
-      description: t("Read sentences and translate them to practice reading comprehension."),
+      description: t("Practice reading comprehension"),
       key: "reading",
       label: t("Reading"),
     },
     {
-      description: t("Listen to audio sentences and translate them to practice listening skills."),
+      description: t("Practice listening skills"),
       key: "listening",
       label: t("Listening"),
     },
     {
-      description: t("A comprehensive quiz covering everything you learned in this lesson."),
+      description: t("Review everything you learned"),
       key: "review",
       label: t("Review"),
     },
     {
-      description: t(
-        "A dialogue-based story that helps you practice the language in a real-world context.",
-      ),
+      description: t("Practice in a real-world dialogue"),
       key: "languageStory",
       label: t("Story"),
     },

--- a/i18n.lock
+++ b/i18n.lock
@@ -203,10 +203,10 @@ checksums:
     Position%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: a1b3d3e026bfff43bff3d3e85ccdb952
     Correct%20answer%3A%20%7Banswer%7D/singular: 7745b2664e841dffff4568203ee443b2
     Incorrect/singular: a86cfbe7b86f19dc8df14a67df073d22
-    Belt/singular: fa36e8e36732c223d2876c0337d372e9
+    "%7Bcolor%7D%20belt/singular": 5949446c9b4a223c04cc500fa17a1fe0
     Level%20progress/singular: 286f095acd17006787247db0b69270e3
     "%7Bvalue%7D%20BP%20to%20level%20up/singular": 755c2fe6e435645cb35b57bf92af09d3
-    Level/singular: 1e3bf31d5c6083e898dd3e3359fbb0c2
+    "%7Bcolor%7D%20Belt%20%E2%80%94%20Level%20%7Blevel%7D/singular": 367f2e902d39199c8507aaad09e8907a
     Back%20to%20Lesson/singular: e2dbef5a2fefae8f9cee708e53e61cb9
     Challenge%20Complete/singular: 7854472cc9245aaa8a13f54514968506
     Final%20dimension%20scores/singular: aa4efa7ecef99d375c1daf4c6585ba98
@@ -311,10 +311,10 @@ checksums:
     Learn%20anything%20with%20AI/singular: 0ee713125135f591c75af6e19f94f03a
     Explore%20courses/singular: 3a60fa1d4a1a6cfffcc0573e3366cd35
     Interactive%20courses%20built%20for%20you.%20Just%20tell%20us%20what%20you%20want%20to%20learn./singular: 30ce55333f2080aaf0681647cb26bfbb
-    "%7Bcolor%7D%20belt/singular": 5949446c9b4a223c04cc500fa17a1fe0
     "%7Bvalue%7D%20BP%20to%20next%20level/singular": dc80ce93407f21e5e909760ec2c9aaef
     Max%20level%20reached/singular: 5bfdf2d9ba3929b456dcf5c253315e92
     "%7Bcolor%7D%20Belt%20-%20Level%20%7Blevel%7D/singular": abb5a7600bd66f523906425beffbaff4
+    Level/singular: 1e3bf31d5c6083e898dd3e3359fbb0c2
     Zoonk%3A%20AI%20Learning%20Platform/singular: 4a2d25490f4a5e5cd4543f48fcec968d
     Zoonk%20is%20an%20AI-powered%20learning%20platform%20where%20you%20can%20learn%20anything%20through%20interactive%20courses%2C%20lessons%2C%20and%20activities./singular: e836899ce8100db55d5fa54fe6375970
     Performance/singular: 28b6d3a3d4a53afa0617a180e318ff4d
@@ -594,42 +594,42 @@ checksums:
     Upgrade/singular: 63c3b52882e0d779859307d672c178c2
     Upgrade%20to%20generate/singular: 9c4baffb6ff3a12a322dfe02735ac35c
     Generating%20content%20with%20AI%20requires%20an%20active%20subscription./singular: ee3e62a18f3437b719f6793dd01d66f8
+    Review%20everything%20you%20learned/singular: 43765847b62600b35e41399405799505
     Listening/singular: 9e680c44cd88a178b953349ed8881ef2
     Experience%20when%20to%20apply%20%7Btopic%7D%20through%20a%20real-world%20dialogue%20scenario./singular: d143d122b526618096d637288c66f50a
     Examples/singular: 9dacb7c56bc894e4bcad39f41265e3a0
-    Shows%20HOW%20things%20work%20through%20practical%20demonstrations%20and%20WHERE%20they%20appear%20in%20real%20life./singular: b165f936cd5dcecc05d9aa3144c1df1c
+    Build%20your%20vocabulary/singular: 577b45f6453f5461f7078c757d96beec
     Practice%20%7Btopic%7D%20in%20context%20through%20a%20dialogue-based%20story%20set%20in%20real-world%20situations./singular: e1b3079ec8c6a2c89d20e5c7c48bfc59
     Story/singular: fabac3f62af801d429e2cd7115bf14c9
     Build%20your%20%7Btopic%7D%20vocabulary%20with%20new%20words%2C%20translations%2C%20and%20pronunciation./singular: 2c0f84dadf5fcbfb5842260046bfa956
     Review%20everything%20you%20learned%20about%20%7Btopic%7D%20with%20a%20comprehensive%20quiz./singular: 8acf9006cabdcbaac217c7565943f068
+    Make%20decisions%20with%20real%20trade-offs/singular: ac5d6c3a0bbcc1ca93344dfd5b79f197
+    Apply%20the%20topic%20in%20a%20real%20scenario/singular: 65a73c601b8c332c525ccc19f96ba23d
     Explanation/singular: f6b595df4ffb1a5b0cbbe1dda5993522
-    Read%20sentences%20and%20translate%20them%20to%20practice%20reading%20comprehension./singular: b084920876df6266904d73e2ddfc6f19
-    A%20comprehensive%20quiz%20covering%20everything%20you%20learned%20in%20this%20lesson./singular: bd46bf5022b53951436d9facacacf673
-    Learn%20new%20words%20and%20their%20translations%20to%20build%20your%20vocabulary./singular: edf41f5213749b375ab5057e14707380
+    Practice%20listening%20skills/singular: 9c71545510620dd5ca2e71a6884a7991
     Sharpen%20your%20%7Btopic%7D%20listening%20skills%20by%20translating%20audio%20sentences./singular: b624ceffbbfc91a29cec43a0037b067f
-    Tests%20analytical%20thinking%20through%20decisions%20with%20trade-offs.%20See%20how%20each%20choice%20impacts%20different%20outcomes./singular: 6d49ad51d42b986411df06b5ceb48067
     Test%20your%20understanding%20of%20%7Btopic%7D%20with%20questions%20designed%20to%20check%20real%20comprehension%2C%20not%20just%20memorization./singular: d9f3e39d19b1c6969b481bc8aec8fc10
-    A%20dialogue-based%20story%20that%20helps%20you%20practice%20the%20language%20in%20a%20real-world%20context./singular: 1eb319ba42d87bf86a9ff6e17bddee5f
     Discover%20why%20%7Btopic%7D%20matters%20%E2%80%94%20its%20origins%2C%20the%20problems%20it%20solved%2C%20and%20why%20it's%20important%20today./singular: 4ab5d214b2548bd9399cbc3a8eef6284
-    Listen%20to%20audio%20sentences%20and%20translate%20them%20to%20practice%20listening%20skills./singular: c7f37f13c3e2d3cb1f23c9cc5eee4e1d
-    Teaches%20grammar%20rules%20with%20practical%20exercises%20to%20help%20you%20remember%20and%20apply%20them./singular: b1250dcf530d4320d730ad2744d37221
+    Test%20your%20knowledge/singular: 34eff98731fb7afc50a9db11237766d3
+    Practice%20grammar%20rules/singular: 569fcc41ef5320c1f9f8d2c9b465433b
+    Practice%20reading%20comprehension/singular: d930ea447a24f0084a9ec9a0fe0c06bb
+    See%20how%20it%20works%20in%20practice/singular: 150fd4dfc4af732e6821c63d76b0987a
     Vocabulary/singular: 2c8127af4c194fa05463e82d5e414c62
     "%7Blesson%7D%20%7Bactivity%7D/singular": d959fed1ee77dca493e8cf0a3b3129c0
     Reading/singular: 9d93f1dff4a01a9e1566f23b401b8868
+    Core%20concepts%20and%20definitions/singular: ca63fbf3fbf474f50c18ba15f3a4fa54
     See%20how%20%7Btopic%7D%20works%20through%20practical%20demonstrations%20and%20where%20it%20appears%20in%20real%20life./singular: 4229b8b2a33f8a182a1d436a4f7acea8
     Quiz/singular: 22bce287f7a90d3b41b418108eaab43b
     Grammar/singular: 1d97aca351a45df1d6eb27adbee04832
     Learn%20about%20%7Btopic%7D%20through%20an%20interactive%20activity./singular: 94f8ca153ea2ee6b539f507266548201
+    Why%20this%20topic%20exists%20and%20why%20it%20matters/singular: b9ceed8055b8917f6fbc67c4de20c710
     Apply%20your%20knowledge%20of%20%7Btopic%7D%20through%20analytical%20decisions%20with%20real%20trade-offs./singular: a45d6f6551b5ec5c1206d7886bff0437
     Understand%20what%20%7Btopic%7D%20is%20%E2%80%94%20core%20concepts%20and%20definitions%20explained%20with%20clear%20metaphors%20and%20analogies./singular: ec3b49a710ebac5f592523bdaa68ceff
     Practice%20%7Btopic%7D%20grammar%20rules%20with%20exercises%20designed%20to%20help%20you%20remember%20and%20apply%20them./singular: 107adae09992e8b4deb051afa38da3bd
-    Explains%20WHAT%20this%20topic%20is.%20Breaks%20down%20core%20concepts%20and%20definitions%20using%20metaphors%20and%20analogies./singular: 5eb6b1cd33e5c20af8423753d4368a81
     "%7Bactivity%7D%20-%20%7Blesson%7D/singular": 0aad8d82851f799d79c052a0f2b90d67
-    Explains%20WHY%20this%20topic%20exists.%20Tells%20the%20origin%20story%2C%20the%20problems%20it%20solved%2C%20and%20why%20it%20matters%20today./singular: 8bdce45d80e8a4cfcbc65d2bfe928c82
+    Practice%20in%20a%20real-world%20dialogue/singular: 35a3583ab576eb0a857b1956c27ba00a
     Background/singular: 0ceaed10d99ed4ad83cb0934ab970174
     Improve%20your%20%7Btopic%7D%20reading%20comprehension%20by%20translating%20sentences%20and%20passages./singular: 60baac4222f76009cc1eb1b6065b403b
-    Shows%20WHEN%20to%20apply%20this%20topic.%20A%20dialogue%20with%20a%20colleague%20where%20you%20solve%20a%20real%20problem%20together./singular: 3fb0934c1e0a5ba3e31b6cc5b897b509
-    Tests%20your%20understanding%20with%20questions.%20Uses%20new%20scenarios%20to%20check%20if%20you%20grasped%20the%20concept%2C%20not%20just%20memorized%20it./singular: feeb1e59f787035a964dd93290e180e7
     "%7Bcategory%7D%20Courses/singular": f82680a650c487992e1025b66f324d4c
     Math/singular: 0a604ffa5ef57408918fe98ef05eb05a
     Explore%20all%20%7Bcategory%7D%20courses/singular: b1f2775c67b4a61b3d92b4345b8b852e


### PR DESCRIPTION
## Summary

- Replace verbose activity kind descriptions with shorter, concise phrases
- Update e2e test assertions to match new description text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortened activity descriptions to clear, concise phrases across the app, and updated translations and e2e tests to match. Improves readability in lesson and activity UIs.

- **Refactors**
  - Updated `apps/main/src/lib/activities.ts` with shorter descriptions (e.g., “Why this topic exists and why it matters”, “Core concepts and definitions”, “Test your knowledge”).
  - Synced `en.po`, `es.po`, `pt.po`, and `i18n.lock` with new strings.
  - Adjusted lesson detail e2e assertions to use the new phrasing.

<sup>Written for commit c03dbdc958030eaa2c7c121db6b357d2de56b4fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

