### PR TITLE
fix(player): improve belt progress contrast

### DIFF
--- a/packages/player/src/components/belt-progress.tsx
+++ b/packages/player/src/components/belt-progress.tsx
@@ -103,10 +103,13 @@ export function BeltProgressHint({
         aria-label={t("Level progress")}
         value={animationStarted ? displayPercent : previousPercent}
       >
-        <ProgressTrack className="h-1.5">
+        <ProgressTrack className="h-1.5 overflow-hidden">
           <ProgressIndicator
             className={cn(
               beltColorClasses[displayColor],
+              "rounded-full",
+              displayColor === "white" && "ring-1 ring-black/10 ring-inset dark:ring-0",
+              displayColor === "black" && "dark:ring-1 dark:ring-white/10 dark:ring-inset",
               skipTransition ? "duration-0" : "duration-600 ease-out",
               "motion-reduce:duration-0",
             )}


### PR DESCRIPTION
Improve the completion-screen belt progress bar styling so low-contrast belt colors stay visible.

- round the progress fill inside the track
- add a light-mode inset ring for white belt
- add a dark-mode inset ring for black belt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve the completion-screen belt progress bar contrast so white and black belts stay visible in light and dark modes. Rounded the progress indicator, hid overflow on the track, and added inset rings for white (light) and black (dark) belts.

<sup>Written for commit a9a70dc76722e058115d76448ec8c752bbaa6500. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

