### PR TITLE
chore(agents): clarify commit scope rules

### DIFF
--- a/.agents/skills/zoonk-commit/SKILL.md
+++ b/.agents/skills/zoonk-commit/SKILL.md
@@ -24,11 +24,14 @@ type(scope): short message
 
 ## Scopes
 
-Use the app or package name as scope when working in a monorepo:
+Use the owning app or package name as scope when working in this monorepo.
 
-**Apps**: `web`, `mobile`, `api`, `admin`, `docs`
+### Scope Selection Order
 
-**Packages**: `ui`, `utils`, `core`, `db`, `config`
+1. If the change is fully owned by one app in `apps/<name>`, use that app name.
+2. If the change is fully owned by one package in `packages/<name>`, use that package name.
+3. Only use an inferred scope like `deps`, `data`, `ci`, or `agents` when the change truly spans multiple workspaces or does not belong to a single app/package.
+4. Do not pick a scope based on the kind of code changed (`data`, `ui`, styling, tests, etc.) when the files clearly belong to one app/package. The workspace owner wins.
 
 **Inferred scopes** (when change doesn't fit an app/package):
 
@@ -37,10 +40,24 @@ Use the app or package name as scope when working in a monorepo:
 - `deps` - dependency updates across multiple packages
 - `data` - data layer changes spanning multiple packages
 
+### Good Scope Choices
+
+- `fix(player): improve belt progress contrast` for changes in `packages/player/...`
+- `fix(main): correct level page copy` for changes in `apps/main/...`
+- `fix(api): handle null response in auth` for changes in `apps/api/...`
+- `fix(data): normalize progress query` only when the data-layer change spans multiple apps/packages
+
+### Avoid These Mistakes
+
+- `fix(ui): improve belt progress contrast` when the change is in `packages/player`
+- `fix(data): update main progress query` when the change is only in `apps/main`
+- `fix(ui): restyle main level card` when the change is only in `apps/main`
+
 ## Examples
 
 ```
-feat(web): add user profile page
+feat(main): add user profile page
+fix(player): improve belt progress contrast
 fix(api): handle null response in auth
 refactor(db): use enum for status field
 chore(deps): update react to v19
@@ -56,5 +73,7 @@ fix(ci): update node version in workflow
 - Use imperative mood ("add" not "added")
 
 # PR Descriptions
+
+Use the same `type(scope): short message` format as the commit title.
 
 Keep descriptions brief. Focus on what changed. No need to list verification commands run.


### PR DESCRIPTION
Clarify the commit skill's scope guidance for this monorepo.

- prefer the owning app or package name as the scope
- reserve inferred scopes like data for truly cross-workspace changes
- add concrete examples for main and player

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies commit scope rules for this monorepo in the `zoonk-commit` skill, prioritizing the owning app/package (`apps/<name>`, `packages/<name>`) and reserving inferred scopes like `deps`, `data`, `ci`, `agents` for truly cross-workspace changes. Adds a 4-step scope selection order, concrete do/don’t examples using `main` and `player`, and updates examples to use `main` instead of `web`.

<sup>Written for commit 5d68cc3d6afaab89041d2a96ebb479ed6bc9ad0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

