### PR TITLE
fix(main): strip locale suffix when looking up course suggestions

### DIFF
--- a/apps/main/src/data/courses/course-suggestions.test.ts
+++ b/apps/main/src/data/courses/course-suggestions.test.ts
@@ -285,6 +285,27 @@ describe("course-suggestions", () => {
     expect(result).toMatchObject({ id: item.id });
   });
 
+  test("getCourseSuggestionBySlug finds suggestion when slug has a locale suffix", async () => {
+    const language = "pt";
+    const title = `locale-suffix-${randomUUID()}`;
+    const slug = toSlug(title);
+
+    const item = await prisma.courseSuggestion.create({
+      data: {
+        description: "Test description",
+        language,
+        slug,
+        title,
+      },
+    });
+
+    // Course slugs include a locale suffix (e.g. "my-course-pt"),
+    // but course suggestion slugs don't (e.g. "my-course").
+    const result = await getCourseSuggestionBySlug({ language, slug: `${slug}-${language}` });
+
+    expect(result).toMatchObject({ id: item.id });
+  });
+
   test("getCourseSuggestionBySlug distinguishes between languages", async () => {
     const slug = `multi-lang-${randomUUID()}`;
 

--- a/apps/main/src/data/courses/course-suggestions.ts
+++ b/apps/main/src/data/courses/course-suggestions.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { generateCourseSuggestions as generateTask } from "@zoonk/ai/tasks/courses/suggestions";
 import { type CourseSuggestion, prisma } from "@zoonk/db";
 import { getLanguageName } from "@zoonk/utils/languages";
-import { normalizeString, toSlug } from "@zoonk/utils/string";
+import { normalizeString, removeLocaleSuffix, toSlug } from "@zoonk/utils/string";
 
 type SuggestionResult = Pick<CourseSuggestion, "id" | "title" | "description" | "targetLanguage">;
 
@@ -169,7 +169,9 @@ export async function getCourseSuggestionBySlug({
   slug: string;
   language: string;
 }): Promise<CourseSuggestion | null> {
+  const normalizedSlug = removeLocaleSuffix(slug, language);
+
   return prisma.courseSuggestion.findUnique({
-    where: { languageSlug: { language, slug } },
+    where: { languageSlug: { language, slug: normalizedSlug } },
   });
 }


### PR DESCRIPTION
## Summary
- Course slugs include a locale suffix (e.g. `portugues-pt`) but course suggestion slugs don't (e.g. `portugues`)
- When a course with no chapters redirected to `/generate/c/{slug}`, `getCourseSuggestionBySlug` failed for non-English locales because it matched the suffixed slug verbatim
- Fixed by calling `removeLocaleSuffix` inside `getCourseSuggestionBySlug` so all callers benefit

## Test plan
- [x] Added integration test: lookup with locale-suffixed slug finds the correct suggestion
- [x] Existing tests pass (361/361)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes course suggestion lookups for non-English locales by stripping the locale suffix from course slugs before querying. Prevents failures when courses without chapters redirect to /generate/c/{slug}.

- **Bug Fixes**
  - Normalize slugs in `getCourseSuggestionBySlug` with `removeLocaleSuffix` so `pt`-suffixed course slugs match suggestion slugs.
  - Added an integration test for locale-suffixed slug lookups.

<sup>Written for commit bc66830d9cce0121374e20fce3866aaefb550a78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

