### PR TITLE
fix(main): capitalize brain power consistently

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1206,9 +1206,9 @@ msgid "Belt Progression"
 msgstr "Belt Progression"
 
 #: src/app/(performance)/level/level-progression.tsx
-msgctxt "pabu7K"
-msgid "{color} Belt, Level {level} of 10. {bp} brain power until next level."
-msgstr "{color} Belt, Level {level} of 10. {bp} brain power until next level."
+msgctxt "t2WYIo"
+msgid "{color} Belt, Level {level} of 10. {bp} Brain Power until next level."
+msgstr "{color} Belt, Level {level} of 10. {bp} Brain Power until next level."
 
 #: src/app/(performance)/level/level-progression.tsx
 msgctxt "VHH0kD"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1158,12 +1158,12 @@ msgstr "Rastrea tu energía de aprendizaje a lo largo del tiempo"
 #: src/app/(performance)/level/level-chart-client.tsx
 msgctxt "GA8RuL"
 msgid "Brain Power chart"
-msgstr "Gráfico de poder mental"
+msgstr "Gráfico de Poder Mental"
 
 #: src/app/(performance)/level/level-chart-client.tsx
 msgctxt "tDbspx"
 msgid "Total Brain Power earned: {total}"
-msgstr "poder mental total ganado: {total}"
+msgstr "Poder Mental total ganado: {total}"
 
 #: src/app/(performance)/level/level-chart-client.tsx
 msgctxt "XdkaHc"
@@ -1173,7 +1173,7 @@ msgstr "{value} PM"
 #: src/app/(performance)/level/level-explanation.tsx
 msgctxt "C6bCZT"
 msgid "Brain Power (BP) represents your knowledge growth. Unlike energy, BP never decreases - it only grows as you learn more."
-msgstr "El poder mental (PM) representa tu crecimiento de conocimiento. A diferencia de la energía, el PM nunca disminuye, solo crece a medida que aprendes más."
+msgstr "El Poder Mental (PM) representa tu crecimiento de conocimiento. A diferencia de la energía, el PM nunca disminuye, solo crece a medida que aprendes más."
 
 #: src/app/(performance)/level/level-explanation.tsx
 msgctxt "J60fb6"
@@ -1188,7 +1188,7 @@ msgstr "Sobre Niveles"
 #: src/app/(performance)/level/level-explanation.tsx
 msgctxt "wPDPFc"
 msgid "Every time you complete an activity, you earn Brain Power. As you accumulate BP, you progress through 10 belt colors, each with 10 levels."
-msgstr "Cada vez que completas una actividad, ganas poder mental. A medida que acumulas PM, avanzas a través de 10 colores de cinturón, cada uno con 10 niveles."
+msgstr "Cada vez que completas una actividad, ganas Poder Mental. A medida que acumulas PM, avanzas a través de 10 colores de cinturón, cada uno con 10 niveles."
 
 #: src/app/(performance)/level/level-progression.tsx
 msgctxt "FM+wHG"
@@ -1206,9 +1206,9 @@ msgid "Belt Progression"
 msgstr "Progresión de cinturón"
 
 #: src/app/(performance)/level/level-progression.tsx
-msgctxt "pabu7K"
-msgid "{color} Belt, Level {level} of 10. {bp} brain power until next level."
-msgstr "Cinturón {color}, nivel {level} de 10. {bp} poder mental hasta el siguiente nivel."
+msgctxt "t2WYIo"
+msgid "{color} Belt, Level {level} of 10. {bp} Brain Power until next level."
+msgstr "Cinturón {color}, nivel {level} de 10. {bp} de Poder Mental hasta el siguiente nivel."
 
 #: src/app/(performance)/level/level-progression.tsx
 msgctxt "VHH0kD"
@@ -1228,7 +1228,7 @@ msgstr "{value} PM ganado"
 #: src/app/(performance)/level/level-stats.tsx
 msgctxt "v5yNm3"
 msgid "Total Brain Power"
-msgstr "poder mental total"
+msgstr "Poder Mental total"
 
 #: src/app/(performance)/level/page.tsx
 msgctxt "4+USpX"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1158,12 +1158,12 @@ msgstr "Acompanhe sua energia de aprendizado ao longo do tempo"
 #: src/app/(performance)/level/level-chart-client.tsx
 msgctxt "GA8RuL"
 msgid "Brain Power chart"
-msgstr "Gráfico de poder mental"
+msgstr "Gráfico de Poder Mental"
 
 #: src/app/(performance)/level/level-chart-client.tsx
 msgctxt "tDbspx"
 msgid "Total Brain Power earned: {total}"
-msgstr "Total de poder mental ganho: {total}"
+msgstr "Total de Poder Mental ganho: {total}"
 
 #: src/app/(performance)/level/level-chart-client.tsx
 msgctxt "XdkaHc"
@@ -1173,7 +1173,7 @@ msgstr "{value} PM"
 #: src/app/(performance)/level/level-explanation.tsx
 msgctxt "C6bCZT"
 msgid "Brain Power (BP) represents your knowledge growth. Unlike energy, BP never decreases - it only grows as you learn more."
-msgstr "poder mental (PM) representa seu crescimento de conhecimento. Diferente da energia, o PM nunca diminui - ele só cresce conforme você aprende mais."
+msgstr "Poder Mental (PM) representa seu crescimento de conhecimento. Diferente da energia, o PM nunca diminui - ele só cresce conforme você aprende mais."
 
 #: src/app/(performance)/level/level-explanation.tsx
 msgctxt "J60fb6"
@@ -1188,7 +1188,7 @@ msgstr "Sobre Níveis"
 #: src/app/(performance)/level/level-explanation.tsx
 msgctxt "wPDPFc"
 msgid "Every time you complete an activity, you earn Brain Power. As you accumulate BP, you progress through 10 belt colors, each with 10 levels."
-msgstr "Toda vez que você completa uma atividade, ganha poder mental. Conforme acumula PM, você progride por 10 cores de faixa, cada uma com 10 níveis."
+msgstr "Toda vez que você completa uma atividade, ganha Poder Mental. Conforme acumula PM, você progride por 10 cores de faixa, cada uma com 10 níveis."
 
 #: src/app/(performance)/level/level-progression.tsx
 msgctxt "FM+wHG"
@@ -1206,9 +1206,9 @@ msgid "Belt Progression"
 msgstr "Progressão de faixa"
 
 #: src/app/(performance)/level/level-progression.tsx
-msgctxt "pabu7K"
-msgid "{color} Belt, Level {level} of 10. {bp} brain power until next level."
-msgstr "Faixa {color}, nível {level} de 10. {bp} de poder mental até o próximo nível."
+msgctxt "t2WYIo"
+msgid "{color} Belt, Level {level} of 10. {bp} Brain Power until next level."
+msgstr "Faixa {color}, nível {level} de 10. {bp} de Poder Mental até o próximo nível."
 
 #: src/app/(performance)/level/level-progression.tsx
 msgctxt "VHH0kD"
@@ -1228,7 +1228,7 @@ msgstr "{value} PM ganho"
 #: src/app/(performance)/level/level-stats.tsx
 msgctxt "v5yNm3"
 msgid "Total Brain Power"
-msgstr "poder mental total"
+msgstr "Poder Mental total"
 
 #: src/app/(performance)/level/page.tsx
 msgctxt "4+USpX"

--- a/apps/main/src/app/(performance)/level/level-progression.tsx
+++ b/apps/main/src/app/(performance)/level/level-progression.tsx
@@ -18,7 +18,7 @@ export async function LevelProgression({ currentBelt }: { currentBelt: BeltLevel
         color: colorName,
         level: String(currentBelt.level),
       })
-    : t("{color} Belt, Level {level} of 10. {bp} brain power until next level.", {
+    : t("{color} Belt, Level {level} of 10. {bp} Brain Power until next level.", {
         bp: formattedBpToNext,
         color: colorName,
         level: String(currentBelt.level),


### PR DESCRIPTION
## Summary
- Capitalize "brain power" to "Brain Power" in the English source string in `level-progression.tsx`
- Update all pt/es PO translations from "poder mental" to "Poder Mental"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes capitalization of "Brain Power" across the level experience to ensure consistent UI text.
Updates the English source in level progression and adjusts Spanish and Portuguese PO entries to use "Poder Mental" in chart, explanation, and stats strings.

<sup>Written for commit 3a354c4fe550ae94c74eb8ac5c680f717bde568f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

