### PR TITLE
feat(editor): cascade publish to all children when publishing a course

### DIFF
--- a/apps/editor/e2e/course-publish.test.ts
+++ b/apps/editor/e2e/course-publish.test.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { prisma } from "@zoonk/db";
 import { getAiOrganization } from "@zoonk/e2e/helpers";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { type Page, expect, test } from "./fixtures";
 
@@ -61,6 +65,50 @@ test.describe("Course Publish Toggle", () => {
     await expect(async () => {
       const record = await prisma.course.findUniqueOrThrow({ where: { id: course.id } });
       expect(record.isPublished).toBe(true);
+    }).toPass({ timeout: 10_000 });
+  });
+
+  test("publishes all child content when publishing a draft course", async ({
+    authenticatedPage,
+  }) => {
+    const course = await createTestCourse(false);
+    const orgId = course.organizationId;
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: false,
+      organizationId: orgId,
+    });
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: false,
+      organizationId: orgId,
+    });
+    const activity = await activityFixture({
+      isPublished: false,
+      lessonId: lesson.id,
+      organizationId: orgId,
+    });
+    const step = await stepFixture({ activityId: activity.id, isPublished: false });
+
+    await navigateToCoursePage(authenticatedPage, course.slug);
+
+    const toggle = authenticatedPage.getByRole("switch");
+    await expect(toggle).not.toBeChecked();
+    await toggle.click();
+    await expect(toggle).toBeChecked();
+
+    await expect(async () => {
+      const [dbChapter, dbLesson, dbActivity, dbStep] = await Promise.all([
+        prisma.chapter.findUniqueOrThrow({ where: { id: chapter.id } }),
+        prisma.lesson.findUniqueOrThrow({ where: { id: lesson.id } }),
+        prisma.activity.findUniqueOrThrow({ where: { id: activity.id } }),
+        prisma.step.findUniqueOrThrow({ where: { id: step.id } }),
+      ]);
+
+      expect(dbChapter.isPublished).toBe(true);
+      expect(dbLesson.isPublished).toBe(true);
+      expect(dbActivity.isPublished).toBe(true);
+      expect(dbStep.isPublished).toBe(true);
     }).toPass({ timeout: 10_000 });
   });
 

--- a/apps/editor/src/data/courses/publish-course.test.ts
+++ b/apps/editor/src/data/courses/publish-course.test.ts
@@ -1,8 +1,12 @@
 import { ErrorCode } from "@/lib/app-error";
 import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { memberFixture, organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { beforeAll, describe, expect, test } from "vitest";
 import { toggleCoursePublished } from "./publish-course";
 
@@ -96,6 +100,108 @@ describe("admins", () => {
 
     expect(result.error).toBeNull();
     expect(result.data?.isPublished).toBeFalsy();
+  });
+
+  test("publishes all child content when publishing a course", async () => {
+    const course = await courseFixture({
+      isPublished: false,
+      organizationId: organization.id,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: false,
+      organizationId: organization.id,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: false,
+      organizationId: organization.id,
+    });
+
+    const activity = await activityFixture({
+      isPublished: false,
+      lessonId: lesson.id,
+      organizationId: organization.id,
+    });
+
+    const step = await stepFixture({
+      activityId: activity.id,
+      isPublished: false,
+    });
+
+    const result = await toggleCoursePublished({
+      courseId: course.id,
+      headers,
+      isPublished: true,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.isPublished).toBeTruthy();
+
+    const [updatedChapter, updatedLesson, updatedActivity, updatedStep] = await Promise.all([
+      prisma.chapter.findUniqueOrThrow({ where: { id: chapter.id } }),
+      prisma.lesson.findUniqueOrThrow({ where: { id: lesson.id } }),
+      prisma.activity.findUniqueOrThrow({ where: { id: activity.id } }),
+      prisma.step.findUniqueOrThrow({ where: { id: step.id } }),
+    ]);
+
+    expect(updatedChapter.isPublished).toBeTruthy();
+    expect(updatedLesson.isPublished).toBeTruthy();
+    expect(updatedActivity.isPublished).toBeTruthy();
+    expect(updatedStep.isPublished).toBeTruthy();
+  });
+
+  test("does not cascade unpublish to child content", async () => {
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: organization.id,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: organization.id,
+    });
+
+    const activity = await activityFixture({
+      isPublished: true,
+      lessonId: lesson.id,
+      organizationId: organization.id,
+    });
+
+    const step = await stepFixture({
+      activityId: activity.id,
+      isPublished: true,
+    });
+
+    const result = await toggleCoursePublished({
+      courseId: course.id,
+      headers,
+      isPublished: false,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.isPublished).toBeFalsy();
+
+    const [updatedChapter, updatedLesson, updatedActivity, updatedStep] = await Promise.all([
+      prisma.chapter.findUniqueOrThrow({ where: { id: chapter.id } }),
+      prisma.lesson.findUniqueOrThrow({ where: { id: lesson.id } }),
+      prisma.activity.findUniqueOrThrow({ where: { id: activity.id } }),
+      prisma.step.findUniqueOrThrow({ where: { id: step.id } }),
+    ]);
+
+    expect(updatedChapter.isPublished).toBeTruthy();
+    expect(updatedLesson.isPublished).toBeTruthy();
+    expect(updatedActivity.isPublished).toBeTruthy();
+    expect(updatedStep.isPublished).toBeTruthy();
   });
 
   test("returns Forbidden for course in different organization", async () => {

--- a/apps/editor/src/data/courses/publish-course.ts
+++ b/apps/editor/src/data/courses/publish-course.ts
@@ -34,10 +34,38 @@ export async function toggleCoursePublished(params: {
   }
 
   const { data, error } = await safeAsync(() =>
-    prisma.course.update({
-      data: { isPublished: params.isPublished },
-      where: { id: course.id },
-    }),
+    params.isPublished
+      ? prisma.$transaction(async (tx) => {
+          const updated = await tx.course.update({
+            data: { isPublished: true },
+            where: { id: course.id },
+          });
+
+          await Promise.all([
+            tx.chapter.updateMany({
+              data: { isPublished: true },
+              where: { courseId: course.id },
+            }),
+            tx.lesson.updateMany({
+              data: { isPublished: true },
+              where: { chapter: { courseId: course.id } },
+            }),
+            tx.activity.updateMany({
+              data: { isPublished: true },
+              where: { lesson: { chapter: { courseId: course.id } } },
+            }),
+            tx.step.updateMany({
+              data: { isPublished: true },
+              where: { activity: { lesson: { chapter: { courseId: course.id } } } },
+            }),
+          ]);
+
+          return updated;
+        })
+      : prisma.course.update({
+          data: { isPublished: false },
+          where: { id: course.id },
+        }),
   );
 
   if (error) {


### PR DESCRIPTION
## Summary
- When publishing a course, all descendants (chapters, lessons, activities, steps) are now cascade-published atomically via `$transaction`
- Unpublishing only affects the course itself — children remain published
- Added integration tests for both publish cascade and no-cascade-on-unpublish
- Added E2E test verifying cascade publish through the UI

## Test plan
- [x] Integration: publishes all child content when publishing a course
- [x] Integration: does not cascade unpublish to child content
- [x] E2E: publishes all child content when publishing a draft course
- [x] All existing tests pass (editor, main, api)
- [x] All E2E suites pass (editor, main, api)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishing a course now automatically publishes all chapters, lessons, activities, and steps in one atomic transaction. Unpublishing only affects the course and leaves children as-is.

- **New Features**
  - Cascade publish implemented with `prisma.$transaction` to update chapters, lessons, activities, and steps together.
  - Added integration and E2E tests to verify cascade on publish and no cascade on unpublish.

<sup>Written for commit 6020b054c5ee2d2d24703232cb80b922ef114fb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

