### PR TITLE
fix(ui): allow feature card label to truncate properly

### DIFF
--- a/packages/ui/src/components/feature.tsx
+++ b/packages/ui/src/components/feature.tsx
@@ -60,7 +60,7 @@ function FeatureCardHeader({ children, className, ...props }: React.ComponentPro
 function FeatureCardHeaderContent({ children, className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("flex items-center gap-1.5", className)}
+      className={cn("flex min-w-0 items-center gap-1.5", className)}
       data-slot="feature-card-header-content"
       {...props}
     >


### PR DESCRIPTION
## Summary

- Add `min-w-0` to `FeatureCardHeaderContent` so the flex item can shrink below its content width, enabling truncation on `FeatureCardLabel` (e.g. the "Next: ..." label in continue learning cards)

## Test plan

- [ ] Verify the "Next: {activity}" label in the continue learning section truncates with ellipsis when the title is long

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes label truncation in feature cards by allowing the header content flex item to shrink.
Adds `min-w-0` to `FeatureCardHeaderContent` in `packages/ui/src/components/feature.tsx`, so long labels like "Next: …" now ellipsize instead of overflowing.

<sup>Written for commit 28e02b819f4383e71798d476adeba4f92f2f79da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

