### PR TITLE
feat(ai): add language support to image prompt generation

### DIFF
--- a/apps/api/src/workflows/activity-generation/steps/generate-custom-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-custom-images-step.ts
@@ -32,7 +32,7 @@ async function generateImagesForActivity(activity: LessonActivity): Promise<void
       if (!prompt) {
         return Promise.reject(new Error("Missing prompt"));
       }
-      return generateVisualStepImage({ orgSlug, prompt });
+      return generateVisualStepImage({ language: activity.language, orgSlug, prompt });
     }),
   );
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-images-step.ts
@@ -12,10 +12,15 @@ type StepVisualWithUrl = StepVisual & { url?: string };
 
 type ImageStep = { id: bigint | number; visualContent: unknown; visualKind: string | null };
 
-async function generateAndSaveImages(
-  imageSteps: ImageStep[],
-  orgSlug?: string,
-): Promise<{
+async function generateAndSaveImages({
+  imageSteps,
+  language,
+  orgSlug,
+}: {
+  imageSteps: ImageStep[];
+  language: string;
+  orgSlug?: string;
+}): Promise<{
   hadFailure: boolean;
   results: PromiseSettledResult<{ data: string | null; error: Error | null }>[];
 }> {
@@ -25,7 +30,7 @@ async function generateAndSaveImages(
       if (!prompt) {
         return Promise.reject(new Error("Missing prompt"));
       }
-      return generateVisualStepImage({ orgSlug, prompt });
+      return generateVisualStepImage({ language, orgSlug, prompt });
     }),
   );
 
@@ -120,10 +125,11 @@ export async function generateImagesForActivityStep(
 
   await streamStatus({ status: "started", step: "generateImages" });
 
-  const { hadFailure, results } = await generateAndSaveImages(
+  const { hadFailure, results } = await generateAndSaveImages({
     imageSteps,
-    activity.lesson.chapter.course.organization?.slug,
-  );
+    language: activity.language,
+    orgSlug: activity.lesson.chapter.course.organization?.slug,
+  });
 
   if (hadFailure) {
     await handleActivityFailureStep({ activityId: activity.id });

--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.ts
@@ -45,12 +45,17 @@ function toQuizQuestion(step: { content: unknown; kind: string }): QuizQuestionW
   return { format: step.kind, ...toRecord(step.content) } as QuizQuestionWithUrls;
 }
 
-async function generateOptionImages(
-  options: SelectImageOption[],
-  orgSlug?: string,
-): Promise<{ hadFailure: boolean; updatedOptions: SelectImageOption[] }> {
+async function generateOptionImages({
+  options,
+  language,
+  orgSlug,
+}: {
+  options: SelectImageOption[];
+  language: string;
+  orgSlug?: string;
+}): Promise<{ hadFailure: boolean; updatedOptions: SelectImageOption[] }> {
   const results = await Promise.allSettled(
-    options.map(({ prompt }) => generateStepImage({ orgSlug, prompt })),
+    options.map(({ prompt }) => generateStepImage({ language, orgSlug, prompt })),
   );
 
   const updatedOptions = options.map((option, index) => {
@@ -103,10 +108,11 @@ export async function generateQuizImagesStep(
         return { imageFailed: false, updateFailed: false };
       }
 
-      const { hadFailure: imageFailed, updatedOptions } = await generateOptionImages(
+      const { hadFailure: imageFailed, updatedOptions } = await generateOptionImages({
+        language: activity.language,
         options,
         orgSlug,
-      );
+      });
 
       const stepContent = toRecord(step.content);
       const content = assertStepContent("selectImage", {

--- a/apps/evals/src/app/select-image-test/actions.ts
+++ b/apps/evals/src/app/select-image-test/actions.ts
@@ -11,6 +11,7 @@ export async function generateSelectImageAction(formData: FormData) {
   }
 
   const { data: imageUrl, error } = await generateStepImage({
+    language: "en",
     orgSlug: "evals",
     prompt,
   });

--- a/apps/evals/src/app/visual-image-test/actions.ts
+++ b/apps/evals/src/app/visual-image-test/actions.ts
@@ -11,6 +11,7 @@ export async function generateVisualImageAction(formData: FormData) {
   }
 
   const { data: imageUrl, error } = await generateVisualStepImage({
+    language: "en",
     orgSlug: "evals",
     prompt,
   });

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -28,7 +28,7 @@
     "./tasks/courses/thumbnail": "./src/tasks/courses/course-thumbnail.ts",
     "./tasks/lessons/activities": "./src/tasks/lessons/lesson-activities.ts",
     "./tasks/lessons/kind": "./src/tasks/lessons/lesson-kind.ts",
-    "./tasks/steps/select-image": "./src/tasks/steps/select-image-step.ts",
+    "./tasks/steps/select-image": "./src/tasks/steps/step-select-image.ts",
     "./tasks/steps/visual": "./src/tasks/steps/step-visual.ts",
     "./tasks/steps/visual-image": "./src/tasks/steps/step-visual-image.ts",
     "./provider-options": "./src/provider-options.ts"

--- a/packages/ai/src/tasks/activities/_tools/select-image.prompt.md
+++ b/packages/ai/src/tasks/activities/_tools/select-image.prompt.md
@@ -6,5 +6,6 @@ Requirements:
 
 - Only use when visual selection is THE BEST way to test this concept
 - 2-4 image options with generation prompts (describe content, not style)
+- Write all prompts and feedback in the same language specified in the LANGUAGE field
 - NEVER reference copyrighted or trademarked characters (e.g., Mickey Mouse, Spider-Man, Mario, Pikachu). Describe concepts abstractly or use generic, original characters instead
 - Most concepts are better tested with other formats

--- a/packages/ai/src/tasks/steps/_tools/image.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/image.prompt.md
@@ -9,4 +9,5 @@ Requirements:
 - Describe ONLY the content, not the style (style is handled by the image generator)
 - Focus on what should be depicted, not how
 - Be specific enough that the image supports the step's educational content
+- Write the prompt in the same language specified in the LANGUAGE field
 - NEVER reference copyrighted or trademarked characters (e.g., Mickey Mouse, Spider-Man, Mario, Pikachu). If the topic involves such characters, describe the concept abstractly or use generic, original characters instead

--- a/packages/ai/src/tasks/steps/step-select-image.prompt.md
+++ b/packages/ai/src/tasks/steps/step-select-image.prompt.md
@@ -4,4 +4,6 @@ Style: 3D rendered with vivid high-contrast colors, smooth matte surfaces, clean
 
 The image should clearly depict the concept while being visually distinct from other options in a quiz context. Focus on clarity and recognizability.
 
+LANGUAGE: **{{LANGUAGE}}**
+
 CONTENT TO ILLUSTRATE: **{{PROMPT}}**

--- a/packages/ai/src/tasks/steps/step-select-image.ts
+++ b/packages/ai/src/tasks/steps/step-select-image.ts
@@ -1,22 +1,24 @@
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { type GeneratedFile, type ImageModel, generateImage } from "ai";
-import promptTemplate from "./select-image-step.prompt.md";
+import promptTemplate from "./step-select-image.prompt.md";
 
 const DEFAULT_MODEL = "openai/gpt-image-1-mini";
 const DEFAULT_QUALITY = "low";
 
-function getSelectImageStepPrompt(prompt: string) {
-  return promptTemplate.replace("{{PROMPT}}", () => prompt);
+function getSelectImageStepPrompt(prompt: string, language: string) {
+  return promptTemplate.replace("{{PROMPT}}", prompt).replace("{{LANGUAGE}}", language);
 }
 
 export type SelectImageStepParams = {
   prompt: string;
+  language: string;
   model?: ImageModel;
   quality?: "auto" | "low" | "medium" | "high";
 };
 
 export async function generateSelectImageStep({
   prompt,
+  language,
   model = DEFAULT_MODEL,
   quality = DEFAULT_QUALITY,
 }: SelectImageStepParams): Promise<SafeReturn<GeneratedFile>> {
@@ -24,7 +26,7 @@ export async function generateSelectImageStep({
     generateImage({
       maxImagesPerCall: 1,
       model,
-      prompt: getSelectImageStepPrompt(prompt),
+      prompt: getSelectImageStepPrompt(prompt, language),
       providerOptions: {
         openai: { output_format: "webp", quality },
       },

--- a/packages/ai/src/tasks/steps/step-select-image.ts
+++ b/packages/ai/src/tasks/steps/step-select-image.ts
@@ -6,7 +6,7 @@ const DEFAULT_MODEL = "openai/gpt-image-1-mini";
 const DEFAULT_QUALITY = "low";
 
 function getSelectImageStepPrompt(prompt: string, language: string) {
-  return promptTemplate.replace("{{PROMPT}}", prompt).replace("{{LANGUAGE}}", language);
+  return promptTemplate.replace("{{PROMPT}}", () => prompt).replace("{{LANGUAGE}}", () => language);
 }
 
 export type SelectImageStepParams = {

--- a/packages/ai/src/tasks/steps/step-visual-image.prompt.md
+++ b/packages/ai/src/tasks/steps/step-visual-image.prompt.md
@@ -4,4 +4,6 @@ Style: Modern flat illustration with clean geometric shapes, a refined limited c
 
 The illustration should clearly communicate the educational concept while being visually engaging and easy to understand.
 
+LANGUAGE: **{{LANGUAGE}}**
+
 CONTENT TO ILLUSTRATE: **{{PROMPT}}**

--- a/packages/ai/src/tasks/steps/step-visual-image.ts
+++ b/packages/ai/src/tasks/steps/step-visual-image.ts
@@ -6,7 +6,7 @@ const DEFAULT_MODEL = "openai/gpt-image-1.5";
 const DEFAULT_QUALITY = "low";
 
 function getStepVisualImagePrompt(prompt: string, language: string) {
-  return promptTemplate.replace("{{PROMPT}}", prompt).replace("{{LANGUAGE}}", language);
+  return promptTemplate.replace("{{PROMPT}}", () => prompt).replace("{{LANGUAGE}}", () => language);
 }
 
 export type StepVisualImageParams = {

--- a/packages/ai/src/tasks/steps/step-visual-image.ts
+++ b/packages/ai/src/tasks/steps/step-visual-image.ts
@@ -5,18 +5,20 @@ import promptTemplate from "./step-visual-image.prompt.md";
 const DEFAULT_MODEL = "openai/gpt-image-1.5";
 const DEFAULT_QUALITY = "low";
 
-function getStepVisualImagePrompt(prompt: string) {
-  return promptTemplate.replace("{{PROMPT}}", () => prompt);
+function getStepVisualImagePrompt(prompt: string, language: string) {
+  return promptTemplate.replace("{{PROMPT}}", prompt).replace("{{LANGUAGE}}", language);
 }
 
 export type StepVisualImageParams = {
   prompt: string;
+  language: string;
   model?: ImageModel;
   quality?: "auto" | "low" | "medium" | "high";
 };
 
 export async function generateStepVisualImage({
   prompt,
+  language,
   model = DEFAULT_MODEL,
   quality = DEFAULT_QUALITY,
 }: StepVisualImageParams): Promise<SafeReturn<GeneratedFile>> {
@@ -24,7 +26,7 @@ export async function generateStepVisualImage({
     generateImage({
       maxImagesPerCall: 1,
       model,
-      prompt: getStepVisualImagePrompt(prompt),
+      prompt: getStepVisualImagePrompt(prompt, language),
       providerOptions: {
         openai: { output_format: "webp", quality },
       },


### PR DESCRIPTION
## Summary

- Add `language` (required) to image generation params so AI prompts and templates are language-aware
- Thread `activity.language` from workflow callers through the image generation pipeline
- Add language guidance to AI tool prompts (`image.prompt.md`, `select-image.prompt.md`)
- Rename `select-image-step` → `step-select-image` for naming consistency
- Refactor `generateAndSaveImages` and `generateOptionImages` to use object params

## Test plan

- [x] `pnpm turbo quality:fix`
- [x] `pnpm typecheck`
- [x] `pnpm knip --production`
- [x] `pnpm test`
- [x] `pnpm --filter api build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds language-aware image prompt generation across workflows so outputs match the activity/course language. Also fixes template replacement to avoid $-substitution issues in prompts.

- **New Features**
  - Thread `activity.language` through image generation workflows.
  - Require `language` in image params; templates add a LANGUAGE field and guidance to write in that language.
  - Rename `select-image-step` to `step-select-image` and update `packages/ai` export mapping.

- **Migration**
  - Pass `language` when calling image helpers (e.g., `generateStepImage`, `generateVisualStepImage`, `generateSelectImageStep`).
  - Update internal calls to object params: `generateAndSaveImages({ imageSteps, language, orgSlug })`, `generateOptionImages({ options, language, orgSlug })`.

<sup>Written for commit b97ecda09bbc1216361f53fefa5999326040e66f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

