### PR TITLE
feat(player): allow bidirectional selection in match columns

### DIFF
--- a/apps/main/e2e/match-columns-step.test.ts
+++ b/apps/main/e2e/match-columns-step.test.ts
@@ -371,6 +371,177 @@ test.describe("Match Columns Step", () => {
     await expect(page.getByText("0/1")).toBeVisible();
   });
 
+  test("tapping right item first highlights it", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMatchColumnsActivity({
+      steps: [
+        {
+          content: {
+            pairs: [
+              { left: `Left1 ${uniqueId}`, right: `Right1 ${uniqueId}` },
+              { left: `Left2 ${uniqueId}`, right: `Right2 ${uniqueId}` },
+            ],
+            question: `Match right-first ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    const rightButton = page.getByRole("button", { name: `Right1 ${uniqueId}` });
+
+    await expect(async () => {
+      if ((await rightButton.getAttribute("aria-pressed")) !== "true") {
+        await rightButton.click();
+      }
+      await expect(rightButton).toHaveAttribute("aria-pressed", "true", { timeout: 1000 });
+    }).toPass();
+  });
+
+  test("right-first correct match locks pair", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMatchColumnsActivity({
+      steps: [
+        {
+          content: {
+            pairs: [
+              { left: `Alpha ${uniqueId}`, right: `One ${uniqueId}` },
+              { left: `Beta ${uniqueId}`, right: `Two ${uniqueId}` },
+            ],
+            question: `Match right-first lock ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    const rightButton = page.getByRole("button", { name: `One ${uniqueId}` });
+
+    await expect(async () => {
+      if ((await rightButton.getAttribute("aria-pressed")) !== "true") {
+        await rightButton.click();
+      }
+      await expect(rightButton).toHaveAttribute("aria-pressed", "true", { timeout: 1000 });
+    }).toPass();
+
+    await page.getByRole("button", { name: `Alpha ${uniqueId}` }).click();
+
+    await expect(rightButton).toBeDisabled();
+    await expect(page.getByRole("button", { name: `Alpha ${uniqueId}` })).toBeDisabled();
+  });
+
+  test("right-first incorrect match flashes and resets", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMatchColumnsActivity({
+      steps: [
+        {
+          content: {
+            pairs: [
+              { left: `Rome ${uniqueId}`, right: `Italy ${uniqueId}` },
+              { left: `Berlin ${uniqueId}`, right: `Germany ${uniqueId}` },
+            ],
+            question: `Match right-first incorrect ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    const germanyButton = page.getByRole("button", { name: `Germany ${uniqueId}` });
+
+    await expect(async () => {
+      if ((await germanyButton.getAttribute("aria-pressed")) !== "true") {
+        await germanyButton.click();
+      }
+      await expect(germanyButton).toHaveAttribute("aria-pressed", "true", { timeout: 1000 });
+    }).toPass();
+
+    await page.getByRole("button", { name: `Rome ${uniqueId}` }).click();
+
+    // After flash timeout, items should be back to interactive
+    await expect(page.getByRole("button", { name: `Rome ${uniqueId}` })).toBeEnabled({
+      timeout: 2000,
+    });
+    await expect(germanyButton).toBeEnabled();
+  });
+
+  test("deselecting a right item", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMatchColumnsActivity({
+      steps: [
+        {
+          content: {
+            pairs: [
+              { left: `Up ${uniqueId}`, right: `Down ${uniqueId}` },
+              { left: `In ${uniqueId}`, right: `Out ${uniqueId}` },
+            ],
+            question: `Match deselect-right ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    const downButton = page.getByRole("button", { name: `Down ${uniqueId}` });
+
+    await expect(async () => {
+      if ((await downButton.getAttribute("aria-pressed")) !== "true") {
+        await downButton.click();
+      }
+      await expect(downButton).toHaveAttribute("aria-pressed", "true", { timeout: 1000 });
+    }).toPass();
+
+    await downButton.click();
+    await expect(downButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  test("full flow right-first shows correct on completion", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMatchColumnsActivity({
+      steps: [
+        {
+          content: {
+            pairs: [
+              { left: `Agua ${uniqueId}`, right: `Water ${uniqueId}` },
+              { left: `Fuego ${uniqueId}`, right: `Fire ${uniqueId}` },
+            ],
+            question: `Match right-first full ${uniqueId}`,
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    const waterButton = page.getByRole("button", { name: `Water ${uniqueId}` });
+
+    // First click: resilient to hydration timing
+    await expect(async () => {
+      if ((await waterButton.getAttribute("aria-pressed")) !== "true") {
+        await waterButton.click();
+      }
+      await expect(waterButton).toHaveAttribute("aria-pressed", "true", { timeout: 1000 });
+    }).toPass();
+
+    await page.getByRole("button", { name: `Agua ${uniqueId}` }).click();
+
+    await page.getByRole("button", { name: `Fire ${uniqueId}` }).click();
+    await page.getByRole("button", { name: `Fuego ${uniqueId}` }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+    await expect(page.getByText("1/1")).toBeVisible();
+    await expect(page.getByText(/correct/i)).toBeVisible();
+  });
+
   test("full flow with no mistakes shows correct on completion", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const { url } = await createMatchColumnsActivity({

--- a/packages/player/src/components/match-columns-step.tsx
+++ b/packages/player/src/components/match-columns-step.tsx
@@ -16,17 +16,19 @@ type ItemVisualState = "correct" | "idle" | "incorrectFlash" | "selected";
 
 const FLASH_DURATION = 800;
 
+type Selection = { item: string; side: "left" | "right" };
+
 function getItemVisualState({
   correctPairs,
   flashingPair,
   item,
-  selectedLeft,
+  selected,
   side,
 }: {
   correctPairs: Pair[];
   flashingPair: Pair | null;
   item: string;
-  selectedLeft: string | null;
+  selected: Selection | null;
   side: "left" | "right";
 }): ItemVisualState {
   if (correctPairs.some((pair) => pair[side] === item)) {
@@ -37,7 +39,7 @@ function getItemVisualState({
     return "incorrectFlash";
   }
 
-  if (side === "left" && selectedLeft === item) {
+  if (selected && selected.side === side && selected.item === item) {
     return "selected";
   }
 
@@ -93,18 +95,16 @@ function MatchGrid({
   correctPairs,
   flashingPair,
   leftItems,
-  onTapLeft,
-  onTapRight,
+  onTap,
   rightItems,
-  selectedLeft,
+  selected,
 }: {
   correctPairs: Pair[];
   flashingPair: Pair | null;
   leftItems: string[];
-  onTapLeft: (item: string) => void;
-  onTapRight: (item: string) => void;
+  onTap: (side: "left" | "right", item: string) => void;
   rightItems: string[];
-  selectedLeft: string | null;
+  selected: Selection | null;
 }) {
   return (
     <div className="grid grid-cols-2 gap-2 sm:gap-3">
@@ -118,7 +118,7 @@ function MatchGrid({
           correctPairs,
           flashingPair,
           item: left,
-          selectedLeft,
+          selected,
           side: "left",
         });
 
@@ -126,14 +126,14 @@ function MatchGrid({
           correctPairs,
           flashingPair,
           item: right,
-          selectedLeft,
+          selected,
           side: "right",
         });
 
         return (
           <Fragment key={left}>
-            <MatchItem label={left} onTap={() => onTapLeft(left)} state={leftState} />
-            <MatchItem label={right} onTap={() => onTapRight(right)} state={rightState} />
+            <MatchItem label={left} onTap={() => onTap("left", left)} state={leftState} />
+            <MatchItem label={right} onTap={() => onTap("right", right)} state={rightState} />
           </Fragment>
         );
       })}
@@ -155,15 +155,15 @@ export function MatchColumnsStep({
 
   const leftItems = useMemo(() => content.pairs.map((pair) => pair.left), [content.pairs]);
 
-  const [selectedLeft, setSelectedLeft] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Selection | null>(null);
   const [correctPairs, setCorrectPairs] = useState<Pair[]>([]);
   const [flashingPair, setFlashingPair] = useState<Pair | null>(null);
   const [mistakes, setMistakes] = useState(0);
   const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleTapLeft = useCallback(
-    (item: string) => {
-      if (correctPairs.some((pair) => pair.left === item)) {
+  const handleTap = useCallback(
+    (side: "left" | "right", item: string) => {
+      if (correctPairs.some((pair) => pair[side] === item)) {
         return;
       }
 
@@ -171,32 +171,27 @@ export function MatchColumnsStep({
         return;
       }
 
-      setSelectedLeft(selectedLeft === item ? null : item);
-    },
-    [correctPairs, flashingPair, selectedLeft],
-  );
-
-  const handleTapRight = useCallback(
-    (item: string) => {
-      if (correctPairs.some((pair) => pair.right === item)) {
+      if (!selected) {
+        setSelected({ item, side });
         return;
       }
 
-      if (flashingPair) {
+      if (selected.side === side) {
+        setSelected(selected.item === item ? null : { item, side });
         return;
       }
 
-      if (!selectedLeft) {
-        return;
-      }
+      const pair: Pair =
+        side === "left"
+          ? { left: item, right: selected.item }
+          : { left: selected.item, right: item };
 
-      const pair: Pair = { left: selectedLeft, right: item };
       const isCorrectPair = checkSingleMatchPair(content, pair);
 
       if (isCorrectPair) {
         const nextCorrect = [...correctPairs, pair];
         setCorrectPairs(nextCorrect);
-        setSelectedLeft(null);
+        setSelected(null);
 
         if (nextCorrect.length === content.pairs.length) {
           onSelectAnswer(step.id, {
@@ -208,7 +203,7 @@ export function MatchColumnsStep({
       } else {
         setMistakes((prev) => prev + 1);
         setFlashingPair(pair);
-        setSelectedLeft(null);
+        setSelected(null);
 
         if (flashTimeoutRef.current) {
           clearTimeout(flashTimeoutRef.current);
@@ -220,7 +215,7 @@ export function MatchColumnsStep({
         }, FLASH_DURATION);
       }
     },
-    [content, correctPairs, flashingPair, mistakes, onSelectAnswer, selectedLeft, step.id],
+    [content, correctPairs, flashingPair, mistakes, onSelectAnswer, selected, step.id],
   );
 
   const allMatched = correctPairs.length === content.pairs.length;
@@ -233,10 +228,9 @@ export function MatchColumnsStep({
         correctPairs={correctPairs}
         flashingPair={flashingPair}
         leftItems={leftItems}
-        onTapLeft={handleTapLeft}
-        onTapRight={handleTapRight}
+        onTap={handleTap}
         rightItems={step.matchColumnsRightItems}
-        selectedLeft={selectedLeft}
+        selected={selected}
       />
 
       <div aria-live="polite" className="sr-only" role="status">


### PR DESCRIPTION
## Summary
- Users can now tap either column first when matching pairs (previously left-only)
- Unified `handleTapLeft`/`handleTapRight` into a single `handleTap(side, item)` handler
- Added 5 new e2e tests covering right-first selection, matching, flashing, deselecting, and full flow

## Test plan
- [x] All 14 match columns e2e tests pass (3 runs, no flakiness)
- [x] Editor e2e (194 passed), API e2e (56 passed)
- [x] Unit tests (361 passed), typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable starting matches from either the left or right column in the Match Columns step to make pairing more flexible. Adds e2e coverage for right-first interactions while keeping feedback and completion behavior consistent.

- **New Features**
  - Users can select from either column first; correct pairs lock, incorrect pairs flash and reset, and items can be deselected on both sides.
  - Added 5 e2e tests for right-first selection, correct/incorrect matching, flashing, deselection, and full flow.

- **Refactors**
  - Replaced `handleTapLeft`/`handleTapRight` with a unified `handleTap(side, item)` and track `selected` as `{ side, item }`.
  - Updated `MatchGrid` and visual state logic to be side-aware via a single `selected` state.

<sup>Written for commit 009723eb4bbcbb42e825b4f5d05d20eb3976e040. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

