### PR TITLE
feat(player): show multiple choice feedback on dedicated screen

### DIFF
--- a/apps/main/e2e/multiple-choice-step.test.ts
+++ b/apps/main/e2e/multiple-choice-step.test.ts
@@ -103,7 +103,7 @@ test.describe("Core Variant", () => {
     ).toBeVisible();
   });
 
-  test("correct answer shows inline Correct! feedback with question visible", async ({ page }) => {
+  test("correct answer shows feedback screen with user's answer highlighted", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const { url } = await createMultipleChoiceActivity({
       steps: [
@@ -111,8 +111,12 @@ test.describe("Core Variant", () => {
           content: {
             kind: "core",
             options: [
-              { feedback: `Wrong answer ${uniqueId}`, isCorrect: false, text: "Option A" },
-              { feedback: `Well done ${uniqueId}`, isCorrect: true, text: "Option B" },
+              {
+                feedback: `Wrong answer ${uniqueId}`,
+                isCorrect: false,
+                text: `Option A ${uniqueId}`,
+              },
+              { feedback: `Well done ${uniqueId}`, isCorrect: true, text: `Option B ${uniqueId}` },
             ],
             question: `Test question ${uniqueId}`,
           },
@@ -124,22 +128,22 @@ test.describe("Core Variant", () => {
     await page.goto(url);
     await page.waitForLoadState("networkidle");
 
-    await page.getByRole("radio", { name: /option b/i }).click();
+    await page.getByRole("radio", { name: new RegExp(`Option B ${uniqueId}`, "i") }).click();
     await page.getByRole("button", { name: /check/i }).click();
 
-    // Inline feedback visible
-    await expect(page.getByText(/correct!/i)).toBeVisible();
+    // Feedback screen shows the user's answer and feedback message
+    await expect(page.getByText(/your answer:/i)).toBeVisible();
+    await expect(page.getByText(new RegExp(`Option B ${uniqueId}`))).toBeVisible();
     await expect(page.getByText(new RegExp(`Well done ${uniqueId}`))).toBeVisible();
 
-    // Question and options remain visible
-    await expect(page.getByText(new RegExp(`Test question ${uniqueId}`))).toBeVisible();
-    await expect(page.getByRole("radio", { name: /option a/i })).toBeVisible();
-    await expect(page.getByRole("radio", { name: /option b/i })).toBeVisible();
+    // No "Correct answer:" line when the user got it right
+    await expect(page.getByText(/correct answer:/i)).not.toBeVisible();
+
+    // Question and options are NOT visible (replaced by feedback screen)
+    await expect(page.getByText(new RegExp(`Test question ${uniqueId}`))).not.toBeVisible();
   });
 
-  test("incorrect answer shows inline Not quite feedback with question visible", async ({
-    page,
-  }) => {
+  test("incorrect answer shows feedback screen with user and correct answers", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const { url } = await createMultipleChoiceActivity({
       steps: [
@@ -147,8 +151,8 @@ test.describe("Core Variant", () => {
           content: {
             kind: "core",
             options: [
-              { feedback: `Nope ${uniqueId}`, isCorrect: false, text: "Wrong choice" },
-              { feedback: "Good job", isCorrect: true, text: "Right choice" },
+              { feedback: `Nope ${uniqueId}`, isCorrect: false, text: `Wrong choice ${uniqueId}` },
+              { feedback: "Good job", isCorrect: true, text: `Right choice ${uniqueId}` },
             ],
             question: `Test question ${uniqueId}`,
           },
@@ -160,17 +164,17 @@ test.describe("Core Variant", () => {
     await page.goto(url);
     await page.waitForLoadState("networkidle");
 
-    await page.getByRole("radio", { name: /wrong choice/i }).click();
+    await page.getByRole("radio", { name: new RegExp(`Wrong choice ${uniqueId}`, "i") }).click();
     await page.getByRole("button", { name: /check/i }).click();
 
-    // Inline feedback visible
-    await expect(page.getByText(/not quite/i)).toBeVisible();
+    // Feedback screen shows answer lines and feedback message
+    await expect(page.getByText(/your answer:/i)).toBeVisible();
     await expect(page.getByText(new RegExp(`Nope ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`Wrong choice ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`Right choice ${uniqueId}`))).toBeVisible();
 
-    // Question and options remain visible
-    await expect(page.getByText(new RegExp(`Test question ${uniqueId}`))).toBeVisible();
-    await expect(page.getByRole("radio", { name: /wrong choice/i })).toBeVisible();
-    await expect(page.getByRole("radio", { name: /right choice/i })).toBeVisible();
+    // Question and options are NOT visible (replaced by feedback screen)
+    await expect(page.getByText(new RegExp(`Test question ${uniqueId}`))).not.toBeVisible();
   });
 
   test("renders without question when omitted", async ({ page }) => {
@@ -878,8 +882,12 @@ test.describe("Interaction Mechanics", () => {
     await page.getByRole("radio", { name: /answer a/i }).click();
     await page.keyboard.press("Enter");
 
-    await expect(page.getByText(/correct!/i)).toBeVisible();
+    // Feedback screen appears with answer and feedback
+    await expect(page.getByText(/your answer:/i)).toBeVisible();
     await expect(page.getByText(new RegExp(`Feedback ${uniqueId}`))).toBeVisible();
+
+    // Question no longer visible
+    await expect(page.getByText(new RegExp(`Enter key test ${uniqueId}`))).not.toBeVisible();
   });
 
   test("number key shortcuts select corresponding option", async ({ page }) => {
@@ -909,9 +917,12 @@ test.describe("Interaction Mechanics", () => {
     // Check button should now be enabled
     await expect(page.getByRole("button", { name: /check/i })).toBeEnabled();
 
-    // Verify pressing Enter submits and shows feedback (correct or incorrect)
+    // Verify pressing Enter submits and shows feedback screen
     await page.keyboard.press("Enter");
     await expect(page.getByText(new RegExp(`Feedback [AB] ${uniqueId}`))).toBeVisible();
+
+    // Question no longer visible (feedback screen)
+    await expect(page.getByText(new RegExp(`Shortcut test ${uniqueId}`))).not.toBeVisible();
   });
 
   test("changing selection before checking updates the highlighted option", async ({ page }) => {
@@ -957,7 +968,7 @@ test.describe("Interaction Mechanics", () => {
     );
   });
 
-  test("options are disabled after checking", async ({ page }) => {
+  test("feedback screen replaces step after checking", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const { url } = await createMultipleChoiceActivity({
       steps: [
@@ -981,18 +992,19 @@ test.describe("Interaction Mechanics", () => {
     await page.getByRole("radio", { name: new RegExp(`Opt A ${uniqueId}`, "i") }).click();
     await page.getByRole("button", { name: /check/i }).click();
 
-    await expect(page.getByText(/correct!/i)).toBeVisible();
+    // Feedback screen replaces the step
+    await expect(page.getByText(/your answer:/i)).toBeVisible();
 
-    // Options should be disabled
+    // Options are not visible (feedback screen replaces the step)
     await expect(
       page.getByRole("radio", { name: new RegExp(`Opt A ${uniqueId}`, "i") }),
-    ).toBeDisabled();
+    ).not.toBeVisible();
     await expect(
       page.getByRole("radio", { name: new RegExp(`Opt B ${uniqueId}`, "i") }),
-    ).toBeDisabled();
+    ).not.toBeVisible();
   });
 
-  test("correct option highlighted when user answers incorrectly", async ({ page }) => {
+  test("feedback screen shows both answers when user answers incorrectly", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const { url } = await createMultipleChoiceActivity({
       steps: [
@@ -1017,15 +1029,11 @@ test.describe("Interaction Mechanics", () => {
     await page.getByRole("radio", { name: new RegExp(`Wrong opt ${uniqueId}`, "i") }).click();
     await page.getByRole("button", { name: /check/i }).click();
 
-    await expect(page.getByText(/not quite/i)).toBeVisible();
-
-    // Both options should be disabled and visible
-    await expect(
-      page.getByRole("radio", { name: new RegExp(`Wrong opt ${uniqueId}`, "i") }),
-    ).toBeDisabled();
-    await expect(
-      page.getByRole("radio", { name: new RegExp(`Right opt ${uniqueId}`, "i") }),
-    ).toBeDisabled();
+    // Feedback screen shows both answers
+    await expect(page.getByText(/your answer:/i)).toBeVisible();
+    await expect(page.getByText(new RegExp(`Wrong opt ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(/correct answer:/i)).toBeVisible();
+    await expect(page.getByText(new RegExp(`Right opt ${uniqueId}`))).toBeVisible();
   });
 
   test("challenge variant still shows feedback screen with dimension inventory", async ({
@@ -1075,7 +1083,9 @@ test.describe("Interaction Mechanics", () => {
     await expect(inventory.getByText(new RegExp(dim))).toBeVisible();
   });
 
-  test("full flow: select -> check -> continue -> completion screen", async ({ page }) => {
+  test("full flow: select -> check -> feedback screen -> continue -> completion", async ({
+    page,
+  }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const { url } = await createMultipleChoiceActivity({
       steps: [
@@ -1099,10 +1109,11 @@ test.describe("Interaction Mechanics", () => {
     // Select answer
     await page.getByRole("radio", { name: /right/i }).click();
 
-    // Check - question stays visible with inline feedback
+    // Check - feedback screen replaces question
     await page.getByRole("button", { name: /check/i }).click();
-    await expect(page.getByText(/correct!/i)).toBeVisible();
-    await expect(page.getByText(new RegExp(`Full flow test ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(/your answer:/i)).toBeVisible();
+    await expect(page.getByText(new RegExp(`Good ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`Full flow test ${uniqueId}`))).not.toBeVisible();
 
     // Continue
     await page.getByRole("button", { name: /continue/i }).click();

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -197,9 +197,19 @@ msgid "Stats"
 msgstr "Stats"
 
 #: ../../packages/player/src/components/feedback-screen.tsx
+msgctxt "3nOd8f"
+msgid "Your answer:"
+msgstr "Your answer:"
+
+#: ../../packages/player/src/components/feedback-screen.tsx
 msgctxt "iaHymw"
 msgid "Outcome"
 msgstr "Outcome"
+
+#: ../../packages/player/src/components/feedback-screen.tsx
+msgctxt "QAJ/Tl"
+msgid "Correct answer:"
+msgstr "Correct answer:"
 
 #: ../../packages/player/src/components/feedback-screen.tsx
 msgctxt "zZGbEs"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -197,9 +197,19 @@ msgid "Stats"
 msgstr "Estadísticas"
 
 #: ../../packages/player/src/components/feedback-screen.tsx
+msgctxt "3nOd8f"
+msgid "Your answer:"
+msgstr "Tu respuesta:"
+
+#: ../../packages/player/src/components/feedback-screen.tsx
 msgctxt "iaHymw"
 msgid "Outcome"
 msgstr "Resultado"
+
+#: ../../packages/player/src/components/feedback-screen.tsx
+msgctxt "QAJ/Tl"
+msgid "Correct answer:"
+msgstr "Respuesta correcta:"
 
 #: ../../packages/player/src/components/feedback-screen.tsx
 msgctxt "zZGbEs"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -197,9 +197,19 @@ msgid "Stats"
 msgstr "Estatísticas"
 
 #: ../../packages/player/src/components/feedback-screen.tsx
+msgctxt "3nOd8f"
+msgid "Your answer:"
+msgstr "Sua resposta:"
+
+#: ../../packages/player/src/components/feedback-screen.tsx
 msgctxt "iaHymw"
 msgid "Outcome"
 msgstr "Resultado"
+
+#: ../../packages/player/src/components/feedback-screen.tsx
+msgctxt "QAJ/Tl"
+msgid "Correct answer:"
+msgstr "Resposta correta:"
 
 #: ../../packages/player/src/components/feedback-screen.tsx
 msgctxt "zZGbEs"

--- a/i18n.lock
+++ b/i18n.lock
@@ -229,7 +229,9 @@ checksums:
     Current%20dimension%20scores/singular: b3a4b7edbd41132e6fb349a6df24a33d
     View%20stats/singular: 707f91e0ff65e7163c95900395dc0297
     Stats/singular: 5cf8b052c89fa1b05397a956ebec69b2
+    Your%20answer%3A/singular: 663abc310ccb6229c6325f8c857adce2
     Outcome/singular: 4cfc7a40e384ea8b6658e8da6e351bf0
+    Correct%20answer%3A/singular: a8b8cc0d5d0059cbfeee0ad4721540d5
     Dimension%20inventory/singular: a150bc3e032ae9e9202db1b375029aae
     Blank%20%7Bposition%7D/singular: 70a4795f65f91685071b6abb1c3a6bad
     Blank%20%7Bposition%7D%3A%20%7Bitem%7D.%20%7Bresult%7D./singular: c64e721cdd1e4cc48eff9f9690f1fc6b
@@ -336,13 +338,13 @@ checksums:
     Start%20learning%20something%20new%20today/singular: 727ed4b5249a54fc3975f77b91e96757
     Online%20Courses%20using%20AI/singular: 4e3c619f363cc66f3f2e604e372ca038
     Explore%20all%20Zoonk%20courses%20to%20learn%20anything%20using%20AI.%20Find%20interactive%20lessons%2C%20challenges%2C%20and%20activities%20to%20learn%20subjects%20like%20science%2C%20math%2C%20technology%2C%20and%20more./singular: c3f4a7dfd17b4523b5535f40170c7731
-    Generate/singular: 0345bf322c191e70d01fd6607ec5c2f8
+    Create/singular: 757ccd28dd533ff3a933355273c1e32a
     Cancel/singular: 2e2a849c2223911717de8caa2c71bade
     Cooking%20up%20some%20course%20ideas/singular: a42520f96dbac3580a2ccae4bd6ceb31
     We're%20putting%20together%20a%20few%20course%20suggestions%20for%20you.%20This%20may%20take%20a%20few%20seconds./singular: 8467af30434eb8bfb2f13e109b1d9334
     Course%20ideas%20for%20%7Bprompt%7D/singular: 23f94da8ce9272d654ff40bb80e6a352
     Change%20subject/singular: 8585bb703ba2d857dd9a7b36f97be507
-    Discover%20personalized%20courses%20and%20resources%20to%20learn%20%7Bprompt%7D.%20Zoonk%20uses%20AI%20to%20generate%20interactive%20lessons%20and%20activities%20tailored%20to%20you./singular: 7d54c62a9c8d49b713626fa25edff820
+    Discover%20personalized%20courses%20and%20resources%20to%20learn%20%7Bprompt%7D.%20Zoonk%20uses%20AI%20to%20create%20interactive%20lessons%20and%20activities%20tailored%20to%20you./singular: c6a0dc2a0e422036e1e25ad7589f5fb3
     Learn%20%7Bprompt%7D%20with%20AI/singular: 5a8a8ee7f52faf0cb790e0f0cfbcce7d
     Start/singular: dbe56303d9a6d3fad1a8d4cbcc97f365
     Enter%20a%20subject/singular: 4590e12cd42fdc491ab95457e66e13eb
@@ -351,7 +353,6 @@ checksums:
     Solar%20system/singular: 684faf696d526eec0e0cc796e4cab959
     UFOs/singular: 09df9f18916bd2d3b48768d415de2004
     Creative%20Writing/singular: 8777bd1ffa60ab1acea0ac053d7ddfc1
-    Tell%20Zoonk%20what%20you%20want%20to%20learn%20and%20get%20a%20course%20generated%20by%20AI.%20Start%20learning%20any%20subject%20with%20interactive%20lessons%20and%20activities./singular: bce6930e3cd7b20455ea7996a65cbe4f
     Harry%20Potter/singular: aec9665b12a8723b9946b20f40e4a141
     Black%20holes/singular: 91313be3a188e7f5307d420d44c1c635
     Artificial%20intelligence/singular: 9f816a13d925ef0d06d951f9c744ed48
@@ -363,6 +364,7 @@ checksums:
     Deep%20sea%20creatures/singular: f3c0a0f3b84d1be92fa3642a7a8fdf72
     Economics/singular: 3931d28200c67977f6ecdf9b2aa61014
     Computer%20Science/singular: fb0a00d8442f2429c8fab8e20d19ae03
+    Tell%20Zoonk%20what%20you%20want%20to%20learn%20and%20get%20a%20course%20created%20with%20AI.%20Start%20learning%20any%20subject%20with%20interactive%20lessons%20and%20activities./singular: af35303a9ef9ca17c39a0b977b97e9f7
     How%20volcanoes%20work/singular: fa35b6c9bdc18c39d17f0573e78a62be
     Molecular%20biology/singular: 5157b95a95d558b7848ceadcf83a9e8b
     Suggested%20subjects/singular: d2d996b64130d889f9be70a6193443c8
@@ -418,7 +420,7 @@ checksums:
     Level%20%7Bcurrent%7D%20of%2010%20in%20%7Bcolor%7D%20belt/singular: 2b6cc01675b41d1269ce8a1050728622
     Done/singular: ffd408fa29d5bc9039ef8ea1b9b699bb
     Belt%20Progression/singular: 7d421f5c2e2169fdeec9027d242bf4d2
-    "%7Bcolor%7D%20Belt%2C%20Level%20%7Blevel%7D%20of%2010.%20%7Bbp%7D%20brain%20power%20until%20next%20level./singular": e367a07e36f925916dfd40e71129786b
+    "%7Bcolor%7D%20Belt%2C%20Level%20%7Blevel%7D%20of%2010.%20%7Bbp%7D%20Brain%20Power%20until%20next%20level./singular": 4e7d88ce286e8fb592dbc68ddac7c702
     "%7Bcolor%7D%20Belt%2C%20Level%20%7Blevel%7D%20of%2010.%20Maximum%20level%20achieved./singular": f76961b35ae61781509ea9f0b5c19849
     "%7Bcurrent%7D%2F10/singular": ae23c13a041f3d7fe6e13ca4927ad01e
     "%7Bvalue%7D%20BP%20earned/singular": 583e121af4a624edef99166b4af272c0
@@ -476,11 +478,11 @@ checksums:
     Email%20us%20at%20hello%40zoonk.com/singular: f30da451e0bc14b7463bde402c876af9
     Follow%20us/singular: 778f7a4744f77dbcbd31a8c778cb5209
     Contact%20Support/singular: fcbd9e317c7286b3e08752eb73eb1a81
-    Generate%20activity/singular: 4fbbc27fc1d296a0414ed0d7f57e4ba0
+    Create%20activity/singular: 355e3245a3822ed6e0618137d52fcb50
+    This%20activity%20hasn't%20been%20created%20yet./singular: c1e71adf6ff4ecd34e0b5ba242110397
     Activity%20not%20available/singular: a76f6331aa0aad825903108429b132a0
-    This%20activity%20hasn't%20been%20generated%20yet./singular: 631d7c5e190d95c7697df1f6a4bb9a1c
-    Generate%20content%20for%20this%20activity/singular: 0ac20ea56d4391004d976cd8f377a645
-    Generate%20Activity/singular: e386c80be3da0ee0b54a940afc4de373
+    Create%20Activity/singular: ceaf06ac3cbfcfcf824b9e9acf66cfb9
+    Create%20content%20for%20this%20activity/singular: e48e26e5fc10415a118d5d6c9f6d032e
     Your%20activity%20is%20ready/singular: e7385c4096b843839bb9a96023f0eea9
     This%20usually%20takes%201-2%20minutes/singular: bd7260323fa4b3a50a0300ed136fcbd2
     Try%20again/singular: 33dd8820e743e35a66e6977f69e9d3b5
@@ -521,7 +523,7 @@ checksums:
     Mapping%20out%20the%20pronunciation.../singular: 6f8b9708ba6726ef8e471bbba8b38f8b
     Setting%20things%20up.../singular: 4696c8e1048ec21837f886410864dfe2
     Refining%20the%20details.../singular: eaf7a7ca135f8919dc93f80095040ab0
-    Generate%20Chapter/singular: 12160bab066da65413de4b511e402446
+    Create%20Chapter/singular: eff367b47e651ac3234f8b4655d5a078
     Your%20lessons%20are%20ready/singular: fe8d9df59ba42f451b249fd750813cba
     Taking%20you%20to%20your%20chapter.../singular: fc59b426c3d393ec40f534253309ee9f
     This%20usually%20takes%202-4%20minutes/singular: a5cf03e3d2ed405722955fde29b1fef0
@@ -561,7 +563,7 @@ checksums:
     Picking%20the%20right%20look.../singular: 697bdd3a4fa077ddd50c64d57775baf6
     Writing%20chapters/singular: b2e7e149ee761e4e5a45225e37e5441a
     Putting%20it%20all%20together.../singular: 12349256a2104ecf09b213ba1437c636
-    Generate%20Lesson/singular: 741a967eb90694565df5e9b44991f58e
+    Create%20Lesson/singular: af03c55d9ad5e6063bfad0ce8a35e385
     Your%20lesson%20is%20ready/singular: 3d745fd67b57e47ed10851f1e5404ccc
     Creating%20your%20activities/singular: 6651e663a48e18486f5f873e614cd512
     This%20usually%20takes%20about%20a%20minute/singular: 8b679d39d752ba8a57fbabd4eb745f28
@@ -570,7 +572,7 @@ checksums:
     Privacy%20Policy/singular: 7459744a63ef8af4e517a09024bd7c08
     Read%20Zoonk's%20terms%20of%20use%20to%20understand%20the%20rules%20and%20conditions%20for%20using%20our%20platform%20and%20services/singular: 4b82898d60691839a1999e4a17199895
     Terms%20of%20Use/singular: 9ac262b2eda552beeecd904c0b9f8fa2
-    This%20content%20was%20generated%20by%20AI.%20It%20may%20contain%20errors%20or%20inaccuracies%20and%20should%20not%20be%20considered%20professional%20advice./singular: 269e7c16a722903b9b434f28aa6cf617
+    This%20content%20was%20created%20by%20AI.%20It%20may%20contain%20errors%20or%20inaccuracies%20and%20should%20not%20be%20considered%20professional%20advice./singular: c5253a4fcd151a271ab77a7e7835e1ac
     Not%20helpful/singular: ceb8a457e7e4c62a465cd1dd2620990e
     Helpful/singular: 9a25a3e10315cf4a8c65996e31f6cda6
     Thanks%20for%20your%20feedback/singular: 05d6f70cdb81119bcf0ad7443438e82b
@@ -592,8 +594,8 @@ checksums:
     Feedback/singular: 6fac88806e0c269a30777b283988c61c
     Send%20feedback%2C%20questions%2C%20or%20suggestions%20to%20us.%20Fill%20in%20the%20form%20below%20or%20email%20us%20directly%20at%20hello%40zoonk.com./singular: 6ce5e55ddeeb7de9480b806358aa5b95
     Upgrade/singular: 63c3b52882e0d779859307d672c178c2
-    Upgrade%20to%20generate/singular: 9c4baffb6ff3a12a322dfe02735ac35c
-    Generating%20content%20with%20AI%20requires%20an%20active%20subscription./singular: ee3e62a18f3437b719f6793dd01d66f8
+    Upgrade%20to%20create/singular: d8be0e2d204b5a7601612cc44cca5cd5
+    Creating%20content%20with%20AI%20requires%20an%20active%20subscription./singular: 7a1e2747c5271495f525ae7360db6fe0
     Review%20everything%20you%20learned/singular: 43765847b62600b35e41399405799505
     Listening/singular: 9e680c44cd88a178b953349ed8881ef2
     Experience%20when%20to%20apply%20%7Btopic%7D%20through%20a%20real-world%20dialogue%20scenario./singular: d143d122b526618096d637288c66f50a

--- a/packages/player/src/check-answer.test.ts
+++ b/packages/player/src/check-answer.test.ts
@@ -29,6 +29,7 @@ describe(checkMultipleChoiceAnswer, () => {
 
     test("returns correct with feedback for correct index", () => {
       expect(checkMultipleChoiceAnswer(content, 0)).toEqual({
+        correctAnswer: "A",
         feedback: "Correct!",
         isCorrect: true,
       });
@@ -36,6 +37,7 @@ describe(checkMultipleChoiceAnswer, () => {
 
     test("returns incorrect with feedback for wrong index", () => {
       expect(checkMultipleChoiceAnswer(content, 1)).toEqual({
+        correctAnswer: "A",
         feedback: "Wrong.",
         isCorrect: false,
       });
@@ -43,6 +45,7 @@ describe(checkMultipleChoiceAnswer, () => {
 
     test("returns incorrect with null feedback for out-of-bounds index", () => {
       expect(checkMultipleChoiceAnswer(content, 5)).toEqual({
+        correctAnswer: "A",
         feedback: null,
         isCorrect: false,
       });
@@ -70,6 +73,7 @@ describe(checkMultipleChoiceAnswer, () => {
 
     test("always returns correct with consequence as feedback", () => {
       expect(checkMultipleChoiceAnswer(content, 0)).toEqual({
+        correctAnswer: null,
         feedback: "Good outcome",
         isCorrect: true,
       });
@@ -77,6 +81,7 @@ describe(checkMultipleChoiceAnswer, () => {
 
     test("returns correct for any valid index", () => {
       expect(checkMultipleChoiceAnswer(content, 1)).toEqual({
+        correctAnswer: null,
         feedback: "Bad outcome",
         isCorrect: true,
       });
@@ -84,6 +89,7 @@ describe(checkMultipleChoiceAnswer, () => {
 
     test("returns incorrect with null feedback for out-of-bounds index", () => {
       expect(checkMultipleChoiceAnswer(content, 10)).toEqual({
+        correctAnswer: null,
         feedback: null,
         isCorrect: false,
       });
@@ -104,6 +110,7 @@ describe(checkMultipleChoiceAnswer, () => {
 
     test("returns correct with feedback for correct index", () => {
       expect(checkMultipleChoiceAnswer(content, 0)).toEqual({
+        correctAnswer: "Buenos días",
         feedback: "Great!",
         isCorrect: true,
       });
@@ -111,6 +118,7 @@ describe(checkMultipleChoiceAnswer, () => {
 
     test("returns incorrect with feedback for wrong index", () => {
       expect(checkMultipleChoiceAnswer(content, 1)).toEqual({
+        correctAnswer: "Buenos días",
         feedback: "Not quite.",
         isCorrect: false,
       });
@@ -128,6 +136,7 @@ describe(checkFillBlankAnswer, () => {
 
   test("returns correct for exact match", () => {
     expect(checkFillBlankAnswer(content, ["hablo", "español"])).toEqual({
+      correctAnswer: null,
       feedback: "Use first person singular.",
       isCorrect: true,
     });
@@ -135,6 +144,7 @@ describe(checkFillBlankAnswer, () => {
 
   test("returns correct for case-insensitive match", () => {
     expect(checkFillBlankAnswer(content, ["HABLO", "ESPAÑOL"])).toEqual({
+      correctAnswer: null,
       feedback: "Use first person singular.",
       isCorrect: true,
     });
@@ -142,6 +152,7 @@ describe(checkFillBlankAnswer, () => {
 
   test("returns correct with trimmed whitespace", () => {
     expect(checkFillBlankAnswer(content, ["  hablo  ", " español "])).toEqual({
+      correctAnswer: null,
       feedback: "Use first person singular.",
       isCorrect: true,
     });
@@ -149,6 +160,7 @@ describe(checkFillBlankAnswer, () => {
 
   test("returns incorrect for wrong answer", () => {
     expect(checkFillBlankAnswer(content, ["habla", "español"])).toEqual({
+      correctAnswer: null,
       feedback: "Use first person singular.",
       isCorrect: false,
     });
@@ -156,6 +168,7 @@ describe(checkFillBlankAnswer, () => {
 
   test("returns incorrect when user provides extra answers", () => {
     expect(checkFillBlankAnswer(content, ["hablo", "español", "extra"])).toEqual({
+      correctAnswer: null,
       feedback: "Use first person singular.",
       isCorrect: false,
     });
@@ -196,6 +209,7 @@ describe(checkMatchColumnsAnswer, () => {
     ];
 
     expect(checkMatchColumnsAnswer(content, userPairs, 0)).toEqual({
+      correctAnswer: null,
       feedback: null,
       isCorrect: true,
     });
@@ -208,6 +222,7 @@ describe(checkMatchColumnsAnswer, () => {
     ];
 
     expect(checkMatchColumnsAnswer(content, userPairs, 0)).toEqual({
+      correctAnswer: null,
       feedback: null,
       isCorrect: true,
     });
@@ -220,6 +235,7 @@ describe(checkMatchColumnsAnswer, () => {
     ];
 
     expect(checkMatchColumnsAnswer(content, userPairs, 1)).toEqual({
+      correctAnswer: null,
       feedback: null,
       isCorrect: false,
     });
@@ -232,6 +248,7 @@ describe(checkMatchColumnsAnswer, () => {
     ];
 
     expect(checkMatchColumnsAnswer(content, userPairs, 0)).toEqual({
+      correctAnswer: null,
       feedback: null,
       isCorrect: false,
     });
@@ -241,6 +258,7 @@ describe(checkMatchColumnsAnswer, () => {
     const userPairs = [{ left: "A", right: "1" }];
 
     expect(checkMatchColumnsAnswer(content, userPairs, 0)).toEqual({
+      correctAnswer: null,
       feedback: null,
       isCorrect: false,
     });
@@ -256,6 +274,7 @@ describe(checkSortOrderAnswer, () => {
 
   test("returns correct for matching order", () => {
     expect(checkSortOrderAnswer(content, ["one", "two", "three"])).toEqual({
+      correctAnswer: null,
       feedback: "Correct order.",
       isCorrect: true,
     });
@@ -263,6 +282,7 @@ describe(checkSortOrderAnswer, () => {
 
   test("returns incorrect for wrong order", () => {
     expect(checkSortOrderAnswer(content, ["three", "two", "one"])).toEqual({
+      correctAnswer: null,
       feedback: "Correct order.",
       isCorrect: false,
     });
@@ -270,6 +290,7 @@ describe(checkSortOrderAnswer, () => {
 
   test("returns incorrect when user provides extra entries", () => {
     expect(checkSortOrderAnswer(content, ["one", "two", "three", "four"])).toEqual({
+      correctAnswer: null,
       feedback: "Correct order.",
       isCorrect: false,
     });
@@ -287,6 +308,7 @@ describe(checkSelectImageAnswer, () => {
 
   test("returns correct with feedback for correct index", () => {
     expect(checkSelectImageAnswer(content, 0)).toEqual({
+      correctAnswer: null,
       feedback: "Yes, a cat!",
       isCorrect: true,
     });
@@ -294,6 +316,7 @@ describe(checkSelectImageAnswer, () => {
 
   test("returns incorrect with feedback for wrong index", () => {
     expect(checkSelectImageAnswer(content, 1)).toEqual({
+      correctAnswer: null,
       feedback: "That's a dog.",
       isCorrect: false,
     });
@@ -301,6 +324,7 @@ describe(checkSelectImageAnswer, () => {
 
   test("returns incorrect with null feedback for out-of-bounds index", () => {
     expect(checkSelectImageAnswer(content, 99)).toEqual({
+      correctAnswer: null,
       feedback: null,
       isCorrect: false,
     });
@@ -310,6 +334,7 @@ describe(checkSelectImageAnswer, () => {
 describe(checkVocabularyAnswer, () => {
   test("returns correct for matching IDs", () => {
     expect(checkVocabularyAnswer("word-1", "word-1")).toEqual({
+      correctAnswer: null,
       feedback: null,
       isCorrect: true,
     });
@@ -317,6 +342,7 @@ describe(checkVocabularyAnswer, () => {
 
   test("returns incorrect for non-matching IDs", () => {
     expect(checkVocabularyAnswer("word-1", "word-2")).toEqual({
+      correctAnswer: null,
       feedback: null,
       isCorrect: false,
     });
@@ -326,6 +352,7 @@ describe(checkVocabularyAnswer, () => {
 describe(checkArrangeWordsAnswer, () => {
   test("returns correct for matching sequence", () => {
     expect(checkArrangeWordsAnswer(["I", "speak", "Spanish"], ["I", "speak", "Spanish"])).toEqual({
+      correctAnswer: null,
       feedback: null,
       isCorrect: true,
     });
@@ -333,6 +360,7 @@ describe(checkArrangeWordsAnswer, () => {
 
   test("returns incorrect for wrong sequence", () => {
     expect(checkArrangeWordsAnswer(["I", "speak", "Spanish"], ["Spanish", "I", "speak"])).toEqual({
+      correctAnswer: null,
       feedback: null,
       isCorrect: false,
     });
@@ -342,6 +370,7 @@ describe(checkArrangeWordsAnswer, () => {
     expect(
       checkArrangeWordsAnswer(["I", "speak", "Spanish"], ["I", "speak", "Spanish", "well"]),
     ).toEqual({
+      correctAnswer: null,
       feedback: null,
       isCorrect: false,
     });

--- a/packages/player/src/check-answer.ts
+++ b/packages/player/src/check-answer.ts
@@ -7,6 +7,7 @@ import {
 } from "@zoonk/core/steps/content-contract";
 
 export type AnswerResult = {
+  correctAnswer: string | null;
   isCorrect: boolean;
   feedback: string | null;
 };
@@ -18,16 +19,17 @@ export function checkMultipleChoiceAnswer(
   if (content.kind === "challenge") {
     const option = content.options[selectedIndex];
     if (!option) {
-      return { feedback: null, isCorrect: false };
+      return { correctAnswer: null, feedback: null, isCorrect: false };
     }
-    return { feedback: option.consequence, isCorrect: true };
+    return { correctAnswer: null, feedback: option.consequence, isCorrect: true };
   }
 
+  const correctAnswer = content.options.find((opt) => opt.isCorrect)?.text ?? null;
   const option = content.options[selectedIndex];
   if (!option) {
-    return { feedback: null, isCorrect: false };
+    return { correctAnswer, feedback: null, isCorrect: false };
   }
-  return { feedback: option.feedback, isCorrect: option.isCorrect };
+  return { correctAnswer, feedback: option.feedback, isCorrect: option.isCorrect };
 }
 
 export function checkFillBlankAnswer(
@@ -40,7 +42,7 @@ export function checkFillBlankAnswer(
     content.answers.every(
       (answer, index) => answer.toLowerCase() === (userAnswers[index] ?? "").trim().toLowerCase(),
     );
-  return { feedback: content.feedback, isCorrect };
+  return { correctAnswer: null, feedback: content.feedback, isCorrect };
 }
 
 export function checkSingleMatchPair(
@@ -63,7 +65,7 @@ export function checkMatchColumnsAnswer(
       userPairs.some((userPair) => userPair.left === pair.left && userPair.right === pair.right),
     );
 
-  return { feedback: null, isCorrect: allPairsCorrect && mistakes === 0 };
+  return { correctAnswer: null, feedback: null, isCorrect: allPairsCorrect && mistakes === 0 };
 }
 
 export function checkSortOrderAnswer(
@@ -72,7 +74,7 @@ export function checkSortOrderAnswer(
 ): AnswerResult {
   const isSameLength = content.items.length === userOrder.length;
   const isCorrect = isSameLength && content.items.every((item, index) => item === userOrder[index]);
-  return { feedback: content.feedback, isCorrect };
+  return { correctAnswer: null, feedback: content.feedback, isCorrect };
 }
 
 export function checkSelectImageAnswer(
@@ -81,17 +83,17 @@ export function checkSelectImageAnswer(
 ): AnswerResult {
   const option = content.options[selectedIndex];
   if (!option) {
-    return { feedback: null, isCorrect: false };
+    return { correctAnswer: null, feedback: null, isCorrect: false };
   }
-  return { feedback: option.feedback, isCorrect: option.isCorrect };
+  return { correctAnswer: null, feedback: option.feedback, isCorrect: option.isCorrect };
 }
 
 export function checkVocabularyAnswer(correctWordId: string, selectedWordId: string): AnswerResult {
-  return { feedback: null, isCorrect: correctWordId === selectedWordId };
+  return { correctAnswer: null, feedback: null, isCorrect: correctWordId === selectedWordId };
 }
 
 export function checkArrangeWordsAnswer(correctWords: string[], userWords: string[]): AnswerResult {
   const isSameLength = correctWords.length === userWords.length;
   const isCorrect = isSameLength && correctWords.every((word, index) => word === userWords[index]);
-  return { feedback: null, isCorrect };
+  return { correctAnswer: null, feedback: null, isCorrect };
 }

--- a/packages/player/src/check-step.ts
+++ b/packages/player/src/check-step.ts
@@ -19,7 +19,7 @@ type CheckStepResult = {
 
 const MISMATCH_RESULT: CheckStepResult = {
   effects: [],
-  result: { feedback: null, isCorrect: false },
+  result: { correctAnswer: null, feedback: null, isCorrect: false },
 };
 
 function checkMultipleChoice(step: SerializedStep, answer: SelectedAnswer): CheckStepResult {

--- a/packages/player/src/components/feedback-screen.tsx
+++ b/packages/player/src/components/feedback-screen.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { cn } from "@zoonk/ui/lib/utils";
+import { CircleCheck, CircleX } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { type DimensionInventory, type StepResult } from "../player-reducer";
 import { useReplaceName } from "../user-name-context";
 import { DimensionList, buildDimensionEntries } from "./dimension-inventory";
+import { ResultAnnouncement } from "./result-announcement";
 
 function FeedbackScreen({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -41,7 +43,41 @@ function FeedbackMessage({ className, ...props }: React.ComponentProps<"p">) {
   );
 }
 
-export function FeedbackScreenContent({
+function AnswerLine({
+  children,
+  icon,
+  label,
+  variant,
+}: {
+  children: React.ReactNode;
+  icon: React.ReactNode;
+  label: string;
+  variant: "correct" | "incorrect";
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2 rounded-lg px-3 py-2 text-sm",
+        variant === "correct" ? "bg-success/10" : "bg-destructive/10",
+      )}
+    >
+      <span
+        className={cn(
+          "mt-0.5 shrink-0",
+          variant === "correct" ? "text-success" : "text-destructive",
+        )}
+      >
+        {icon}
+      </span>
+      <div>
+        <span className="text-muted-foreground">{label}</span>{" "}
+        <span className="font-medium">{children}</span>
+      </div>
+    </div>
+  );
+}
+
+function ChallengeFeedback({
   dimensions,
   result,
 }: {
@@ -62,4 +98,71 @@ export function FeedbackScreenContent({
       <DimensionList aria-label={t("Dimension inventory")} entries={entries} variant="feedback" />
     </FeedbackScreen>
   );
+}
+
+function CoreFeedback({ result }: { result: StepResult }) {
+  const t = useExtracted();
+  const replaceName = useReplaceName();
+  const { isCorrect, feedback: rawFeedback, correctAnswer } = result.result;
+  const feedback = rawFeedback ? replaceName(rawFeedback) : null;
+  const selectedText = result.answer?.kind === "multipleChoice" ? result.answer.selectedText : null;
+
+  return (
+    <FeedbackScreen>
+      <div className="flex flex-col gap-2">
+        {isCorrect ? (
+          selectedText && (
+            <AnswerLine
+              icon={<CircleCheck aria-hidden="true" className="size-4" />}
+              label={t("Your answer:")}
+              variant="correct"
+            >
+              {selectedText}
+            </AnswerLine>
+          )
+        ) : (
+          <>
+            {selectedText && (
+              <AnswerLine
+                icon={<CircleX aria-hidden="true" className="size-4" />}
+                label={t("Your answer:")}
+                variant="incorrect"
+              >
+                {selectedText}
+              </AnswerLine>
+            )}
+            {correctAnswer && (
+              <AnswerLine
+                icon={<CircleCheck aria-hidden="true" className="size-4" />}
+                label={t("Correct answer:")}
+                variant="correct"
+              >
+                {correctAnswer}
+              </AnswerLine>
+            )}
+          </>
+        )}
+      </div>
+
+      {feedback && <FeedbackMessage>{feedback}</FeedbackMessage>}
+
+      <ResultAnnouncement isCorrect={isCorrect} />
+    </FeedbackScreen>
+  );
+}
+
+export function FeedbackScreenContent({
+  dimensions,
+  result,
+}: {
+  dimensions?: DimensionInventory;
+  result: StepResult;
+}) {
+  const hasEffects = result.effects.length > 0;
+
+  if (hasEffects && dimensions) {
+    return <ChallengeFeedback dimensions={dimensions} result={result} />;
+  }
+
+  return <CoreFeedback result={result} />;
 }

--- a/packages/player/src/components/multiple-choice-step.tsx
+++ b/packages/player/src/components/multiple-choice-step.tsx
@@ -4,15 +4,13 @@ import {
   type ChallengeMultipleChoiceContent,
   type CoreMultipleChoiceContent,
   type LanguageMultipleChoiceContent,
-  type MultipleChoiceStepContent,
   parseStepContent,
 } from "@zoonk/core/steps/content-contract";
 import { useExtracted } from "next-intl";
-import { type SelectedAnswer, type StepResult } from "../player-reducer";
+import { type SelectedAnswer } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
 import { useOptionKeyboard } from "../use-option-keyboard";
 import { useReplaceName } from "../user-name-context";
-import { InlineFeedback } from "./inline-feedback";
 import { OptionCard } from "./option-card";
 import { ContextText, QuestionText } from "./question-text";
 import { SectionLabel } from "./section-label";
@@ -24,26 +22,6 @@ function getSelectedIndex(selectedAnswer: SelectedAnswer | undefined): number | 
   }
 
   return selectedAnswer.selectedIndex;
-}
-
-function getOptionResultState(
-  index: number,
-  content: MultipleChoiceStepContent,
-  selectedIndex: number,
-): "correct" | "incorrect" | undefined {
-  if (content.kind === "challenge") {
-    return undefined;
-  }
-
-  if (content.options[index]?.isCorrect) {
-    return "correct";
-  }
-
-  if (index === selectedIndex) {
-    return "incorrect";
-  }
-
-  return undefined;
 }
 
 function StepTextGroup({ children }: { children: React.ReactNode }) {
@@ -61,14 +39,10 @@ function OptionContent({ romanization, text }: { romanization?: string | null; t
 }
 
 function OptionList({
-  content,
-  disabled,
   onSelect,
   options,
   selectedIndex,
 }: {
-  content: MultipleChoiceStepContent;
-  disabled: boolean;
   onSelect: (index: number) => void;
   options: readonly { text: string; textRomanization?: string | null }[];
   selectedIndex: number | null;
@@ -77,44 +51,30 @@ function OptionList({
 
   return (
     <div aria-label={t("Answer options")} className="flex flex-col gap-3" role="radiogroup">
-      {options.map((option, index) => {
-        const resultState =
-          disabled && selectedIndex !== null
-            ? getOptionResultState(index, content, selectedIndex)
-            : undefined;
-
-        return (
-          <OptionCard
-            disabled={disabled}
-            index={index}
-            isDimmed={disabled && selectedIndex !== null && !resultState}
-            isSelected={selectedIndex === index}
-            key={option.text}
-            onSelect={() => onSelect(index)}
-            resultState={resultState}
-          >
-            <OptionContent
-              romanization={"textRomanization" in option ? option.textRomanization : undefined}
-              text={option.text}
-            />
-          </OptionCard>
-        );
-      })}
+      {options.map((option, index) => (
+        <OptionCard
+          index={index}
+          isSelected={selectedIndex === index}
+          key={option.text}
+          onSelect={() => onSelect(index)}
+        >
+          <OptionContent
+            romanization={"textRomanization" in option ? option.textRomanization : undefined}
+            text={option.text}
+          />
+        </OptionCard>
+      ))}
     </div>
   );
 }
 
 function CoreVariant({
   content,
-  disabled,
   onSelect,
-  result,
   selectedIndex,
 }: {
   content: CoreMultipleChoiceContent;
-  disabled: boolean;
   onSelect: (index: number) => void;
-  result?: StepResult;
   selectedIndex: number | null;
 }) {
   const replaceName = useReplaceName();
@@ -126,15 +86,7 @@ function CoreVariant({
         {content.question && <QuestionText>{replaceName(content.question)}</QuestionText>}
       </StepTextGroup>
 
-      <OptionList
-        content={content}
-        disabled={disabled}
-        onSelect={onSelect}
-        options={content.options}
-        selectedIndex={selectedIndex}
-      />
-
-      {result && <InlineFeedback result={result} />}
+      <OptionList onSelect={onSelect} options={content.options} selectedIndex={selectedIndex} />
     </>
   );
 }
@@ -157,13 +109,7 @@ function ChallengeVariant({
         <QuestionText>{replaceName(content.question)}</QuestionText>
       </StepTextGroup>
 
-      <OptionList
-        content={content}
-        disabled={false}
-        onSelect={onSelect}
-        options={content.options}
-        selectedIndex={selectedIndex}
-      />
+      <OptionList onSelect={onSelect} options={content.options} selectedIndex={selectedIndex} />
     </>
   );
 }
@@ -174,15 +120,11 @@ function SpeechBubble({ children }: { children: React.ReactNode }) {
 
 function LanguageVariant({
   content,
-  disabled,
   onSelect,
-  result,
   selectedIndex,
 }: {
   content: LanguageMultipleChoiceContent;
-  disabled: boolean;
   onSelect: (index: number) => void;
-  result?: StepResult;
   selectedIndex: number | null;
 }) {
   const t = useExtracted();
@@ -206,46 +148,31 @@ function LanguageVariant({
 
       <div className="flex flex-col gap-3">
         <SectionLabel>{t("What do you say?")}</SectionLabel>
-        <OptionList
-          content={content}
-          disabled={disabled}
-          onSelect={onSelect}
-          options={content.options}
-          selectedIndex={selectedIndex}
-        />
+        <OptionList onSelect={onSelect} options={content.options} selectedIndex={selectedIndex} />
       </div>
-
-      {result && <InlineFeedback result={result} />}
     </>
   );
 }
 
 export function MultipleChoiceStep({
   onSelectAnswer,
-  result,
   selectedAnswer,
   step,
 }: {
   onSelectAnswer: (stepId: string, answer: SelectedAnswer) => void;
-  result?: StepResult;
   selectedAnswer: SelectedAnswer | undefined;
   step: SerializedStep;
 }) {
   const content = parseStepContent("multipleChoice", step.content);
   const selectedIndex = getSelectedIndex(selectedAnswer);
-  const hasResult = Boolean(result);
 
   const handleSelect = (index: number) => {
-    if (result) {
-      return;
-    }
-
     const selectedText = content.options[index]?.text ?? "";
     onSelectAnswer(step.id, { kind: "multipleChoice", selectedIndex: index, selectedText });
   };
 
   useOptionKeyboard({
-    enabled: !result && (selectedAnswer === undefined || selectedAnswer.kind === "multipleChoice"),
+    enabled: selectedAnswer === undefined || selectedAnswer.kind === "multipleChoice",
     onSelect: handleSelect,
     optionCount: content.options.length,
   });
@@ -257,23 +184,11 @@ export function MultipleChoiceStep({
       )}
 
       {content.kind === "core" && (
-        <CoreVariant
-          content={content}
-          disabled={hasResult}
-          onSelect={handleSelect}
-          result={result}
-          selectedIndex={selectedIndex}
-        />
+        <CoreVariant content={content} onSelect={handleSelect} selectedIndex={selectedIndex} />
       )}
 
       {content.kind === "language" && (
-        <LanguageVariant
-          content={content}
-          disabled={hasResult}
-          onSelect={handleSelect}
-          result={result}
-          selectedIndex={selectedIndex}
-        />
+        <LanguageVariant content={content} onSelect={handleSelect} selectedIndex={selectedIndex} />
       )}
     </InteractiveStepLayout>
   );

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -1,4 +1,3 @@
-import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { type Route } from "next";
 import { type CompletionResult } from "../completion-input-schema";
 import {
@@ -14,12 +13,7 @@ import { FeedbackScreenContent } from "./feedback-screen";
 import { StepRenderer } from "./step-renderer";
 
 function needsFeedbackScreen(step: SerializedStep): boolean {
-  if (step.kind === "multipleChoice") {
-    const content = parseStepContent("multipleChoice", step.content);
-    return content.kind === "challenge";
-  }
-
-  return false;
+  return step.kind === "multipleChoice";
 }
 
 export function StageContent({

--- a/packages/player/src/components/step-renderer.tsx
+++ b/packages/player/src/components/step-renderer.tsx
@@ -51,7 +51,6 @@ export function StepRenderer({
     return (
       <MultipleChoiceStep
         onSelectAnswer={onSelectAnswer}
-        result={result}
         selectedAnswer={selectedAnswer}
         step={step}
       />

--- a/packages/player/src/player-reducer.test.ts
+++ b/packages/player/src/player-reducer.test.ts
@@ -225,7 +225,7 @@ describe("CHECK_ANSWER", () => {
     const state = buildState({ steps: [step] });
     const next = playerReducer(state, {
       effects: [],
-      result: { feedback: "Correct!", isCorrect: true },
+      result: { correctAnswer: null, feedback: "Correct!", isCorrect: true },
       stepId: "mc-1",
       type: "CHECK_ANSWER",
     });
@@ -233,7 +233,7 @@ describe("CHECK_ANSWER", () => {
     expect(next.results["mc-1"]).toEqual({
       answer: undefined,
       effects: [],
-      result: { feedback: "Correct!", isCorrect: true },
+      result: { correctAnswer: null, feedback: "Correct!", isCorrect: true },
       stepId: "mc-1",
     });
   });
@@ -246,7 +246,7 @@ describe("CHECK_ANSWER", () => {
     });
     const next = playerReducer(state, {
       effects: [],
-      result: { feedback: "Correct!", isCorrect: true },
+      result: { correctAnswer: null, feedback: "Correct!", isCorrect: true },
       stepId: "mc-1",
       type: "CHECK_ANSWER",
     });
@@ -257,7 +257,7 @@ describe("CHECK_ANSWER", () => {
     const state = buildState();
     const next = playerReducer(state, {
       effects: [{ dimension: "Quality", impact: "positive" }],
-      result: { feedback: null, isCorrect: true },
+      result: { correctAnswer: null, feedback: null, isCorrect: true },
       stepId: "step-1",
       type: "CHECK_ANSWER",
     });
@@ -268,7 +268,7 @@ describe("CHECK_ANSWER", () => {
     const state = buildState();
     const next = playerReducer(state, {
       effects: [{ dimension: "Quality", impact: "negative" }],
-      result: { feedback: null, isCorrect: true },
+      result: { correctAnswer: null, feedback: null, isCorrect: true },
       stepId: "step-1",
       type: "CHECK_ANSWER",
     });
@@ -279,7 +279,7 @@ describe("CHECK_ANSWER", () => {
     const state = buildState();
     const next = playerReducer(state, {
       effects: [{ dimension: "Quality", impact: "neutral" }],
-      result: { feedback: null, isCorrect: true },
+      result: { correctAnswer: null, feedback: null, isCorrect: true },
       stepId: "step-1",
       type: "CHECK_ANSWER",
     });
@@ -294,7 +294,7 @@ describe("CHECK_ANSWER", () => {
     let state = buildState({ steps });
     state = playerReducer(state, {
       effects: [{ dimension: "Quality", impact: "positive" }],
-      result: { feedback: null, isCorrect: true },
+      result: { correctAnswer: null, feedback: null, isCorrect: true },
       stepId: "s1",
       type: "CHECK_ANSWER",
     });
@@ -302,7 +302,7 @@ describe("CHECK_ANSWER", () => {
     state = { ...state, currentStepIndex: 1, phase: "playing" };
     state = playerReducer(state, {
       effects: [{ dimension: "Quality", impact: "positive" }],
-      result: { feedback: null, isCorrect: true },
+      result: { correctAnswer: null, feedback: null, isCorrect: true },
       stepId: "s2",
       type: "CHECK_ANSWER",
     });
@@ -318,7 +318,7 @@ describe("CHECK_ANSWER", () => {
       const state = buildState({ steps });
       const next = playerReducer(state, {
         effects: [],
-        result: { feedback: null, isCorrect: true },
+        result: { correctAnswer: null, feedback: null, isCorrect: true },
         stepId: "mc-1",
         type: "CHECK_ANSWER",
       });
@@ -327,7 +327,7 @@ describe("CHECK_ANSWER", () => {
       expect(next.results["mc-1"]).toEqual({
         answer: undefined,
         effects: [],
-        result: { feedback: null, isCorrect: true },
+        result: { correctAnswer: null, feedback: null, isCorrect: true },
         stepId: "mc-1",
       });
     });
@@ -337,7 +337,7 @@ describe("CHECK_ANSWER", () => {
       const state = buildState({ steps });
       const next = playerReducer(state, {
         effects: [],
-        result: { feedback: null, isCorrect: true },
+        result: { correctAnswer: null, feedback: null, isCorrect: true },
         stepId: "mc-1",
         type: "CHECK_ANSWER",
       });
@@ -345,7 +345,7 @@ describe("CHECK_ANSWER", () => {
       expect(next.results["mc-1"]).toEqual({
         answer: undefined,
         effects: [],
-        result: { feedback: null, isCorrect: true },
+        result: { correctAnswer: null, feedback: null, isCorrect: true },
         stepId: "mc-1",
       });
     });
@@ -362,7 +362,7 @@ describe("CHECK_ANSWER", () => {
 
       const next = playerReducer(state, {
         effects: [],
-        result: { feedback: null, isCorrect: true },
+        result: { correctAnswer: null, feedback: null, isCorrect: true },
         stepId: "mc-1",
         type: "CHECK_ANSWER",
       });
@@ -383,7 +383,7 @@ describe("CHECK_ANSWER", () => {
     const state = buildState({ phase: "feedback" });
     const next = playerReducer(state, {
       effects: [],
-      result: { feedback: null, isCorrect: true },
+      result: { correctAnswer: null, feedback: null, isCorrect: true },
       stepId: "step-1",
       type: "CHECK_ANSWER",
     });
@@ -394,7 +394,7 @@ describe("CHECK_ANSWER", () => {
     const state = buildState({ phase: "completed" });
     const next = playerReducer(state, {
       effects: [],
-      result: { feedback: null, isCorrect: true },
+      result: { correctAnswer: null, feedback: null, isCorrect: true },
       stepId: "step-1",
       type: "CHECK_ANSWER",
     });
@@ -522,7 +522,7 @@ describe("RESTART", () => {
         s1: {
           answer: multipleChoiceAnswer,
           effects: [],
-          result: { feedback: null, isCorrect: true },
+          result: { correctAnswer: null, feedback: null, isCorrect: true },
           stepId: "s1",
         },
       },
@@ -544,7 +544,7 @@ describe("RESTART", () => {
         s1: {
           answer: multipleChoiceAnswer,
           effects: [{ dimension: "Quality", impact: "positive" }],
-          result: { feedback: null, isCorrect: true },
+          result: { correctAnswer: null, feedback: null, isCorrect: true },
           stepId: "s1",
         },
       },
@@ -666,7 +666,7 @@ describe("timing", () => {
     vi.setSystemTime(new Date("2026-03-15T14:30:05"));
     const next = playerReducer(state, {
       effects: [],
-      result: { feedback: "Correct!", isCorrect: true },
+      result: { correctAnswer: null, feedback: "Correct!", isCorrect: true },
       stepId: "mc-1",
       type: "CHECK_ANSWER",
     });
@@ -773,7 +773,7 @@ describe("edge cases", () => {
         { dimension: "Speed", impact: "negative" },
         { dimension: "Budget", impact: "neutral" },
       ],
-      result: { feedback: null, isCorrect: true },
+      result: { correctAnswer: null, feedback: null, isCorrect: true },
       stepId: "step-1",
       type: "CHECK_ANSWER",
     });
@@ -790,14 +790,14 @@ describe("edge cases", () => {
     const state = buildState({ selectedAnswers: { "mc-1": answer }, steps: [step] });
     const next = playerReducer(state, {
       effects: [{ dimension: "Quality", impact: "positive" }],
-      result: { feedback: "Good!", isCorrect: true },
+      result: { correctAnswer: null, feedback: "Good!", isCorrect: true },
       stepId: "mc-1",
       type: "CHECK_ANSWER",
     });
     const expected: StepResult = {
       answer,
       effects: [{ dimension: "Quality", impact: "positive" }],
-      result: { feedback: "Good!", isCorrect: true },
+      result: { correctAnswer: null, feedback: "Good!", isCorrect: true },
       stepId: "mc-1",
     };
     expect(next.results["mc-1"]).toEqual(expected);


### PR DESCRIPTION
## Summary
- Replace inline feedback for core/language MC steps with a dedicated feedback screen, matching the existing challenge variant pattern
- Show color-coded answer lines (green checkmark for correct, red X for incorrect) so users instantly see their answer vs the correct one
- Add `correctAnswer` field to `AnswerResult` for core/language variants
- Clean up dead code from `MultipleChoiceStep` (removed `result`, `disabled` props and `InlineFeedback` usage)

## Test plan
- [x] Unit tests updated (`check-answer`, `check-step`, `player-reducer`)
- [x] E2E tests updated (7 tests rewritten for feedback screen behavior)
- [x] E2E tests pass 3x with no flakiness
- [x] All apps E2E pass (main 392, editor 194, api 56)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move multiple-choice feedback to a dedicated screen for core/language steps so users clearly see what they chose and what was correct, matching the existing challenge flow. Improves readability, especially on mobile.

- **New Features**
  - Dedicated feedback screen shows “Your answer” and (if wrong) “Correct answer” with green check/red X.
  - Added `correctAnswer` to `AnswerResult` for core/language multiple choice; other step types return `null`.
  - Route all multiple-choice steps through the feedback screen in the player.
  - Added i18n strings for “Your answer:” and “Correct answer:” in `en`, `es`, `pt`.
  - Updated unit and E2E tests to cover the new flow.

- **Refactors**
  - Simplified `MultipleChoiceStep`; removed `result`/`disabled` props and inline feedback logic.
  - Centralized rendering in `FeedbackScreenContent` with a core path alongside challenge.
  - Removed option disabled/dimming after check; keyboard handling remains active until submit.

<sup>Written for commit 25f531553e6180c77f0305b67a9ae588094f388d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

