### PR TITLE
feat(api): invert activity ratio to 2 stories + 1 quiz

### DIFF
--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
@@ -522,7 +522,7 @@ describe("core activity workflow", () => {
   });
 
   describe("dependency cascade failures", () => {
-    test("explanation returns empty → quiz marked as failed (quiz depends on explanation)", async () => {
+    test("explanation returns empty → quiz and story marked as failed (both depend on explanation)", async () => {
       vi.mocked(generateActivityExplanation).mockResolvedValueOnce({
         data: { steps: [] },
         systemPrompt: "test",
@@ -536,7 +536,7 @@ describe("core activity workflow", () => {
         title: `Exp Empty Cascade Lesson ${randomUUID()}`,
       });
 
-      const [expActivity, quizActivity] = await Promise.all([
+      const [expActivity, quizActivity, storyActivity] = await Promise.all([
         activityFixture({
           generationStatus: "pending",
           kind: "explanation",
@@ -551,22 +551,32 @@ describe("core activity workflow", () => {
           organizationId,
           title: `Quiz ${randomUUID()}`,
         }),
+        activityFixture({
+          generationStatus: "pending",
+          kind: "story",
+          lessonId: testLesson.id,
+          organizationId,
+          title: `Story ${randomUUID()}`,
+        }),
       ]);
 
       await activityGenerationWorkflow(testLesson.id);
 
-      const [dbExp, dbQuiz] = await Promise.all([
+      const [dbExp, dbQuiz, dbStory] = await Promise.all([
         prisma.activity.findUnique({ where: { id: expActivity.id } }),
         prisma.activity.findUnique({ where: { id: quizActivity.id } }),
+        prisma.activity.findUnique({ where: { id: storyActivity.id } }),
       ]);
 
       expect(dbExp?.generationStatus).toBe("failed");
       expect(dbQuiz?.generationStatus).toBe("failed");
+      expect(dbStory?.generationStatus).toBe("failed");
 
       expect(generateActivityQuiz).not.toHaveBeenCalled();
+      expect(generateActivityStory).not.toHaveBeenCalled();
     });
 
-    test("empty concepts → examples, story, and challenge marked as failed", async () => {
+    test("empty concepts → examples and challenge marked as failed", async () => {
       const testLesson = await lessonFixture({
         chapterId: chapter.id,
         concepts: [],
@@ -574,20 +584,13 @@ describe("core activity workflow", () => {
         title: `Empty Concepts Cascade Lesson ${randomUUID()}`,
       });
 
-      const [examplesActivity, storyActivity, challengeActivity] = await Promise.all([
+      const [examplesActivity, challengeActivity] = await Promise.all([
         activityFixture({
           generationStatus: "pending",
           kind: "examples",
           lessonId: testLesson.id,
           organizationId,
           title: `Examples ${randomUUID()}`,
-        }),
-        activityFixture({
-          generationStatus: "pending",
-          kind: "story",
-          lessonId: testLesson.id,
-          organizationId,
-          title: `Story ${randomUUID()}`,
         }),
         activityFixture({
           generationStatus: "pending",
@@ -600,18 +603,15 @@ describe("core activity workflow", () => {
 
       await activityGenerationWorkflow(testLesson.id);
 
-      const [dbExamples, dbStory, dbChallenge] = await Promise.all([
+      const [dbExamples, dbChallenge] = await Promise.all([
         prisma.activity.findUnique({ where: { id: examplesActivity.id } }),
-        prisma.activity.findUnique({ where: { id: storyActivity.id } }),
         prisma.activity.findUnique({ where: { id: challengeActivity.id } }),
       ]);
 
       expect(dbExamples?.generationStatus).toBe("failed");
-      expect(dbStory?.generationStatus).toBe("failed");
       expect(dbChallenge?.generationStatus).toBe("failed");
 
       expect(generateActivityExamples).not.toHaveBeenCalled();
-      expect(generateActivityStory).not.toHaveBeenCalled();
       expect(generateActivityChallenge).not.toHaveBeenCalled();
     });
 
@@ -899,9 +899,6 @@ describe("core activity workflow", () => {
         expect.objectContaining({ neighboringConcepts: ["Neighbor A"] }),
       );
       expect(generateActivityExamples).toHaveBeenCalledWith(
-        expect.objectContaining({ neighboringConcepts: ["Neighbor A"] }),
-      );
-      expect(generateActivityStory).toHaveBeenCalledWith(
         expect.objectContaining({ neighboringConcepts: ["Neighbor A"] }),
       );
       expect(generateActivityChallenge).toHaveBeenCalledWith(

--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.ts
@@ -14,18 +14,20 @@ export async function coreActivityWorkflow(
   workflowRunId: string,
 ): Promise<void> {
   const concepts = activities[0]?.lesson?.concepts ?? [];
-  const totalQuizzes = findActivitiesByKind(activities, "quiz").length;
+  const totalStories = findActivitiesByKind(activities, "story").length;
   const neighboringConcepts = await getNeighboringConceptsStep(activities);
 
   const [, explanationResult] = await Promise.allSettled([
     backgroundActivityWorkflow(activities, workflowRunId, concepts, neighboringConcepts),
     explanationActivityWorkflow(activities, workflowRunId, concepts, neighboringConcepts),
     examplesActivityWorkflow(activities, workflowRunId, concepts, neighboringConcepts),
-    storyActivityWorkflow(activities, workflowRunId, concepts, neighboringConcepts),
     challengeActivityWorkflow(activities, workflowRunId, concepts, neighboringConcepts),
   ]);
 
   const { results } = settled(explanationResult, { results: [] });
 
-  await quizActivityWorkflow(activities, workflowRunId, results, totalQuizzes);
+  await Promise.allSettled([
+    storyActivityWorkflow(activities, workflowRunId, results, totalStories),
+    quizActivityWorkflow(activities, workflowRunId, results),
+  ]);
 }

--- a/apps/api/src/workflows/activity-generation/kinds/quiz-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/quiz-workflow.test.ts
@@ -118,7 +118,7 @@ describe("quiz activity workflow", () => {
     const activities = await getLessonActivitiesStep(testLesson.id);
     const explanationResults = buildExplanationResults(Number(explanationActivity.id));
 
-    await quizActivityWorkflow(activities, "test-run-id", explanationResults, 1);
+    await quizActivityWorkflow(activities, "test-run-id", explanationResults);
 
     const steps = await prisma.step.findMany({
       orderBy: { position: "asc" },
@@ -163,7 +163,7 @@ describe("quiz activity workflow", () => {
     const activities = await getLessonActivitiesStep(testLesson.id);
     const explanationResults = buildExplanationResults(Number(explanationActivity.id));
 
-    await quizActivityWorkflow(activities, "test-run-id", explanationResults, 1);
+    await quizActivityWorkflow(activities, "test-run-id", explanationResults);
 
     const dbActivity = await prisma.activity.findUnique({
       where: { id: quizActivity.id },
@@ -202,7 +202,7 @@ describe("quiz activity workflow", () => {
     const activities = await getLessonActivitiesStep(testLesson.id);
     const explanationResults = buildExplanationResults(Number(explanationActivity.id));
 
-    await quizActivityWorkflow(activities, "test-run-id", explanationResults, 1);
+    await quizActivityWorkflow(activities, "test-run-id", explanationResults);
 
     const dbActivity = await prisma.activity.findUnique({
       where: { id: quizActivity.id },
@@ -228,7 +228,7 @@ describe("quiz activity workflow", () => {
 
     const activities = await getLessonActivitiesStep(testLesson.id);
 
-    await quizActivityWorkflow(activities, "test-run-id", [], 1);
+    await quizActivityWorkflow(activities, "test-run-id", []);
 
     const dbActivity = await prisma.activity.findUnique({
       where: { id: quizActivity.id },
@@ -264,7 +264,7 @@ describe("quiz activity workflow", () => {
     const activities = await getLessonActivitiesStep(testLesson.id);
     const explanationResults = buildExplanationResults(Number(explanationActivity.id));
 
-    await quizActivityWorkflow(activities, "test-run-id", explanationResults, 1);
+    await quizActivityWorkflow(activities, "test-run-id", explanationResults);
 
     const steps = await prisma.step.findMany({
       orderBy: { position: "asc" },
@@ -319,412 +319,8 @@ describe("quiz activity workflow", () => {
     const activities = await getLessonActivitiesStep(testLesson.id);
     const explanationResults = buildExplanationResults(Number(explanationActivity.id));
 
-    await quizActivityWorkflow(activities, "test-run-id", explanationResults, 1);
+    await quizActivityWorkflow(activities, "test-run-id", explanationResults);
 
     expect(generateActivityQuiz).not.toHaveBeenCalled();
-  });
-
-  describe("multi-quiz behavior", () => {
-    test("creates two quizzes when lesson has 4+ concepts", async () => {
-      const testLesson = await lessonFixture({
-        chapterId: chapter.id,
-        concepts: ["Q1", "Q2", "Q3", "Q4"],
-        organizationId,
-        title: `Two Quiz Lesson ${randomUUID()}`,
-      });
-
-      const [expQ1, expQ2, expQ3, expQ4] = await Promise.all([
-        activityFixture({
-          generationStatus: "completed",
-          kind: "explanation",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 1,
-          title: "Q1",
-        }),
-        activityFixture({
-          generationStatus: "completed",
-          kind: "explanation",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 2,
-          title: "Q2",
-        }),
-        activityFixture({
-          generationStatus: "completed",
-          kind: "explanation",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 3,
-          title: "Q3",
-        }),
-        activityFixture({
-          generationStatus: "completed",
-          kind: "explanation",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 4,
-          title: "Q4",
-        }),
-      ]);
-
-      await Promise.all([
-        activityFixture({
-          generationStatus: "pending",
-          kind: "quiz",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 5,
-          title: `Quiz 1 ${randomUUID()}`,
-        }),
-        activityFixture({
-          generationStatus: "pending",
-          kind: "quiz",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 6,
-          title: `Quiz 2 ${randomUUID()}`,
-        }),
-      ]);
-
-      const activities = await getLessonActivitiesStep(testLesson.id);
-      const explanationResults: ExplanationResult[] = [
-        { activityId: Number(expQ1.id), concept: "Q1", steps: [{ text: "Q1 text", title: "Q1" }] },
-        { activityId: Number(expQ2.id), concept: "Q2", steps: [{ text: "Q2 text", title: "Q2" }] },
-        { activityId: Number(expQ3.id), concept: "Q3", steps: [{ text: "Q3 text", title: "Q3" }] },
-        { activityId: Number(expQ4.id), concept: "Q4", steps: [{ text: "Q4 text", title: "Q4" }] },
-      ];
-
-      await quizActivityWorkflow(activities, "test-run-id", explanationResults, 2);
-
-      expect(generateActivityQuiz).toHaveBeenCalledTimes(2);
-    });
-
-    test("quiz 1 gets first half of explanation steps, quiz 2 gets second half", async () => {
-      const testLesson = await lessonFixture({
-        chapterId: chapter.id,
-        concepts: ["Half1A", "Half1B", "Half2A", "Half2B"],
-        organizationId,
-        title: `Quiz Split Lesson ${randomUUID()}`,
-      });
-
-      const [expH1A, expH1B, expH2A, expH2B] = await Promise.all([
-        activityFixture({
-          generationStatus: "completed",
-          kind: "explanation",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 1,
-          title: "Half1A",
-        }),
-        activityFixture({
-          generationStatus: "completed",
-          kind: "explanation",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 2,
-          title: "Half1B",
-        }),
-        activityFixture({
-          generationStatus: "completed",
-          kind: "explanation",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 3,
-          title: "Half2A",
-        }),
-        activityFixture({
-          generationStatus: "completed",
-          kind: "explanation",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 4,
-          title: "Half2B",
-        }),
-      ]);
-
-      await Promise.all([
-        activityFixture({
-          generationStatus: "pending",
-          kind: "quiz",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 5,
-          title: `Quiz 1 ${randomUUID()}`,
-        }),
-        activityFixture({
-          generationStatus: "pending",
-          kind: "quiz",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 6,
-          title: `Quiz 2 ${randomUUID()}`,
-        }),
-      ]);
-
-      const activities = await getLessonActivitiesStep(testLesson.id);
-      const explanationResults: ExplanationResult[] = [
-        {
-          activityId: Number(expH1A.id),
-          concept: "Half1A",
-          steps: [{ text: "H1A text", title: "H1A" }],
-        },
-        {
-          activityId: Number(expH1B.id),
-          concept: "Half1B",
-          steps: [{ text: "H1B text", title: "H1B" }],
-        },
-        {
-          activityId: Number(expH2A.id),
-          concept: "Half2A",
-          steps: [{ text: "H2A text", title: "H2A" }],
-        },
-        {
-          activityId: Number(expH2B.id),
-          concept: "Half2B",
-          steps: [{ text: "H2B text", title: "H2B" }],
-        },
-      ];
-
-      await quizActivityWorkflow(activities, "test-run-id", explanationResults, 2);
-
-      expect(generateActivityQuiz).toHaveBeenCalledTimes(2);
-
-      // Quiz 1 should get first half explanation steps (H1A, H1B)
-      expect(generateActivityQuiz).toHaveBeenCalledWith(
-        expect.objectContaining({
-          explanationSteps: [
-            { text: "H1A text", title: "H1A" },
-            { text: "H1B text", title: "H1B" },
-          ],
-        }),
-      );
-
-      // Quiz 2 should get second half explanation steps (H2A, H2B)
-      expect(generateActivityQuiz).toHaveBeenCalledWith(
-        expect.objectContaining({
-          explanationSteps: [
-            { text: "H2A text", title: "H2A" },
-            { text: "H2B text", title: "H2B" },
-          ],
-        }),
-      );
-    });
-
-    test("single quiz gets all explanation steps when < 4 concepts", async () => {
-      const testLesson = await lessonFixture({
-        chapterId: chapter.id,
-        concepts: ["Single A", "Single B"],
-        organizationId,
-        title: `Single Quiz Lesson ${randomUUID()}`,
-      });
-
-      const [expSA, expSB] = await Promise.all([
-        activityFixture({
-          generationStatus: "completed",
-          kind: "explanation",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 1,
-          title: "Single A",
-        }),
-        activityFixture({
-          generationStatus: "completed",
-          kind: "explanation",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 2,
-          title: "Single B",
-        }),
-      ]);
-
-      await activityFixture({
-        generationStatus: "pending",
-        kind: "quiz",
-        lessonId: testLesson.id,
-        organizationId,
-        position: 3,
-        title: `Single Quiz ${randomUUID()}`,
-      });
-
-      const activities = await getLessonActivitiesStep(testLesson.id);
-      const explanationResults: ExplanationResult[] = [
-        {
-          activityId: Number(expSA.id),
-          concept: "Single A",
-          steps: [{ text: "SA text", title: "SA" }],
-        },
-        {
-          activityId: Number(expSB.id),
-          concept: "Single B",
-          steps: [{ text: "SB text", title: "SB" }],
-        },
-      ];
-
-      await quizActivityWorkflow(activities, "test-run-id", explanationResults, 1);
-
-      expect(generateActivityQuiz).toHaveBeenCalledOnce();
-      expect(generateActivityQuiz).toHaveBeenCalledWith(
-        expect.objectContaining({
-          explanationSteps: [
-            { text: "SA text", title: "SA" },
-            { text: "SB text", title: "SB" },
-          ],
-        }),
-      );
-    });
-
-    test("quiz 1 gets content when only one explanation result exists with two quizzes", async () => {
-      const testLesson = await lessonFixture({
-        chapterId: chapter.id,
-        concepts: ["OnlyConcept"],
-        organizationId,
-        title: `Single Explanation Two Quizzes ${randomUUID()}`,
-      });
-
-      const expOnly = await activityFixture({
-        generationStatus: "completed",
-        kind: "explanation",
-        lessonId: testLesson.id,
-        organizationId,
-        position: 1,
-        title: "OnlyConcept",
-      });
-
-      await Promise.all([
-        activityFixture({
-          generationStatus: "pending",
-          kind: "quiz",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 2,
-          title: `Quiz 1 ${randomUUID()}`,
-        }),
-        activityFixture({
-          generationStatus: "pending",
-          kind: "quiz",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 3,
-          title: `Quiz 2 ${randomUUID()}`,
-        }),
-      ]);
-
-      const activities = await getLessonActivitiesStep(testLesson.id);
-      const explanationResults: ExplanationResult[] = [
-        {
-          activityId: Number(expOnly.id),
-          concept: "OnlyConcept",
-          steps: [{ text: "Only text", title: "Only" }],
-        },
-      ];
-
-      await quizActivityWorkflow(activities, "test-run-id", explanationResults, 2);
-
-      // Quiz 1 must get the single explanation result (not an empty array)
-      expect(generateActivityQuiz).toHaveBeenCalledOnce();
-      expect(generateActivityQuiz).toHaveBeenCalledWith(
-        expect.objectContaining({
-          explanationSteps: [{ text: "Only text", title: "Only" }],
-        }),
-      );
-    });
-
-    test("completes both quiz activities when lesson has two quizzes", async () => {
-      const testLesson = await lessonFixture({
-        chapterId: chapter.id,
-        concepts: ["QC1", "QC2", "QC3", "QC4"],
-        organizationId,
-        title: `Both Quizzes Complete Lesson ${randomUUID()}`,
-      });
-
-      const [expQC1, expQC2, expQC3, expQC4] = await Promise.all([
-        activityFixture({
-          generationStatus: "completed",
-          kind: "explanation",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 1,
-          title: "QC1",
-        }),
-        activityFixture({
-          generationStatus: "completed",
-          kind: "explanation",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 2,
-          title: "QC2",
-        }),
-        activityFixture({
-          generationStatus: "completed",
-          kind: "explanation",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 3,
-          title: "QC3",
-        }),
-        activityFixture({
-          generationStatus: "completed",
-          kind: "explanation",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 4,
-          title: "QC4",
-        }),
-      ]);
-
-      const [quiz1, quiz2] = await Promise.all([
-        activityFixture({
-          generationStatus: "pending",
-          kind: "quiz",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 5,
-          title: `Quiz Complete 1 ${randomUUID()}`,
-        }),
-        activityFixture({
-          generationStatus: "pending",
-          kind: "quiz",
-          lessonId: testLesson.id,
-          organizationId,
-          position: 6,
-          title: `Quiz Complete 2 ${randomUUID()}`,
-        }),
-      ]);
-
-      const activities = await getLessonActivitiesStep(testLesson.id);
-      const explanationResults: ExplanationResult[] = [
-        {
-          activityId: Number(expQC1.id),
-          concept: "QC1",
-          steps: [{ text: "QC1 text", title: "QC1" }],
-        },
-        {
-          activityId: Number(expQC2.id),
-          concept: "QC2",
-          steps: [{ text: "QC2 text", title: "QC2" }],
-        },
-        {
-          activityId: Number(expQC3.id),
-          concept: "QC3",
-          steps: [{ text: "QC3 text", title: "QC3" }],
-        },
-        {
-          activityId: Number(expQC4.id),
-          concept: "QC4",
-          steps: [{ text: "QC4 text", title: "QC4" }],
-        },
-      ];
-
-      await quizActivityWorkflow(activities, "test-run-id", explanationResults, 2);
-
-      const [dbQuiz1, dbQuiz2] = await Promise.all([
-        prisma.activity.findUnique({ where: { id: quiz1.id } }),
-        prisma.activity.findUnique({ where: { id: quiz2.id } }),
-      ]);
-
-      expect(dbQuiz1?.generationStatus).toBe("completed");
-      expect(dbQuiz2?.generationStatus).toBe("completed");
-    });
   });
 });

--- a/apps/api/src/workflows/activity-generation/kinds/quiz-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/quiz-workflow.ts
@@ -1,55 +1,18 @@
-import { settled } from "@zoonk/utils/settled";
-import { type ActivitySteps } from "../steps/_utils/get-activity-steps";
 import { completeActivityStep } from "../steps/complete-activity-step";
 import { type ExplanationResult } from "../steps/generate-explanation-content-step";
 import { generateQuizContentStep } from "../steps/generate-quiz-content-step";
 import { generateQuizImagesStep } from "../steps/generate-quiz-images-step";
 import { type LessonActivity } from "../steps/get-lesson-activities-step";
 
-function getExplanationStepsForQuiz(
-  explanationResults: ExplanationResult[],
-  quizIndex: number,
-  totalQuizzes: number,
-): ActivitySteps {
-  if (totalQuizzes <= 1) {
-    return explanationResults.flatMap((result) => result.steps);
-  }
-
-  const splitIndex = Math.max(1, Math.floor(explanationResults.length / 2));
-  const group =
-    quizIndex === 0
-      ? explanationResults.slice(0, splitIndex)
-      : explanationResults.slice(splitIndex);
-
-  return group.flatMap((result) => result.steps);
-}
-
 export async function quizActivityWorkflow(
   activities: LessonActivity[],
   workflowRunId: string,
   explanationResults: ExplanationResult[],
-  totalQuizzes: number,
 ): Promise<void> {
   "use workflow";
 
-  const quizIndices = Array.from({ length: totalQuizzes }, (_, i) => i);
-
-  const quizResults = await Promise.allSettled(
-    quizIndices.map((quizIndex) =>
-      generateQuizContentStep(
-        activities,
-        getExplanationStepsForQuiz(explanationResults, quizIndex, totalQuizzes),
-        workflowRunId,
-        quizIndex,
-      ),
-    ),
-  );
-
-  const quizzes = quizResults.map((result) => settled(result, { questions: [] }));
-
-  await Promise.allSettled(
-    quizzes.map((quiz, quizIndex) => generateQuizImagesStep(activities, quiz.questions, quizIndex)),
-  );
-
+  const explanationSteps = explanationResults.flatMap((result) => result.steps);
+  const { questions } = await generateQuizContentStep(activities, explanationSteps, workflowRunId);
+  await generateQuizImagesStep(activities, questions);
   await completeActivityStep(activities, workflowRunId, "quiz");
 }

--- a/apps/api/src/workflows/activity-generation/kinds/story-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/story-workflow.test.ts
@@ -8,6 +8,7 @@ import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { type ExplanationResult } from "../steps/generate-explanation-content-step";
 import { getLessonActivitiesStep } from "../steps/get-lesson-activities-step";
 import { storyActivityWorkflow } from "./story-workflow";
 
@@ -42,6 +43,19 @@ vi.mock("@zoonk/ai/tasks/activities/core/story", () => ({
   }),
 }));
 
+function buildExplanationResults(activityId: number): ExplanationResult[] {
+  return [
+    {
+      activityId,
+      concept: "Test Concept",
+      steps: [
+        { text: "Explanation step 1", title: "Step 1" },
+        { text: "Explanation step 2", title: "Step 2" },
+      ],
+    },
+  ];
+}
+
 describe("story activity workflow", () => {
   let organizationId: number;
   let course: Awaited<ReturnType<typeof courseFixture>>;
@@ -70,6 +84,14 @@ describe("story activity workflow", () => {
       title: `Story Content Lesson ${randomUUID()}`,
     });
 
+    const expActivity = await activityFixture({
+      generationStatus: "completed",
+      kind: "explanation",
+      lessonId: testLesson.id,
+      organizationId,
+      title: "Test Concept",
+    });
+
     const activity = await activityFixture({
       generationStatus: "pending",
       kind: "story",
@@ -79,9 +101,9 @@ describe("story activity workflow", () => {
     });
 
     const activities = await getLessonActivitiesStep(testLesson.id);
-    const concepts = activities[0]?.lesson?.concepts ?? [];
+    const explanationResults = buildExplanationResults(Number(expActivity.id));
 
-    await storyActivityWorkflow(activities, "test-run-id", concepts, []);
+    await storyActivityWorkflow(activities, "test-run-id", explanationResults, 1);
 
     const steps = await prisma.step.findMany({
       orderBy: { position: "asc" },
@@ -112,6 +134,14 @@ describe("story activity workflow", () => {
       title: `Story Completed Lesson ${randomUUID()}`,
     });
 
+    const expActivity = await activityFixture({
+      generationStatus: "completed",
+      kind: "explanation",
+      lessonId: testLesson.id,
+      organizationId,
+      title: "Test Concept",
+    });
+
     const activity = await activityFixture({
       generationStatus: "pending",
       kind: "story",
@@ -121,9 +151,9 @@ describe("story activity workflow", () => {
     });
 
     const activities = await getLessonActivitiesStep(testLesson.id);
-    const concepts = activities[0]?.lesson?.concepts ?? [];
+    const explanationResults = buildExplanationResults(Number(expActivity.id));
 
-    await storyActivityWorkflow(activities, "test-run-id", concepts, []);
+    await storyActivityWorkflow(activities, "test-run-id", explanationResults, 1);
 
     const dbActivity = await prisma.activity.findUnique({
       where: { id: activity.id },
@@ -142,7 +172,15 @@ describe("story activity workflow", () => {
       title: `Story Failed Lesson ${randomUUID()}`,
     });
 
-    const activity = await activityFixture({
+    const expActivity = await activityFixture({
+      generationStatus: "completed",
+      kind: "explanation",
+      lessonId: testLesson.id,
+      organizationId,
+      title: "Test Concept",
+    });
+
+    await activityFixture({
       generationStatus: "pending",
       kind: "story",
       lessonId: testLesson.id,
@@ -151,22 +189,22 @@ describe("story activity workflow", () => {
     });
 
     const activities = await getLessonActivitiesStep(testLesson.id);
-    const concepts = activities[0]?.lesson?.concepts ?? [];
+    const explanationResults = buildExplanationResults(Number(expActivity.id));
 
-    await storyActivityWorkflow(activities, "test-run-id", concepts, []);
+    await storyActivityWorkflow(activities, "test-run-id", explanationResults, 1);
 
-    const dbActivity = await prisma.activity.findUnique({
-      where: { id: activity.id },
+    const dbStory = await prisma.activity.findFirst({
+      where: { kind: "story", lessonId: testLesson.id },
     });
-    expect(dbActivity?.generationStatus).toBe("failed");
+    expect(dbStory?.generationStatus).toBe("failed");
   });
 
-  test("sets story status to 'failed' when concepts are empty", async () => {
+  test("sets story status to 'failed' when explanation results are empty", async () => {
     const testLesson = await lessonFixture({
       chapterId: chapter.id,
       concepts: [],
       organizationId,
-      title: `Story No Concepts Lesson ${randomUUID()}`,
+      title: `Story No Explanations Lesson ${randomUUID()}`,
     });
 
     const activity = await activityFixture({
@@ -179,7 +217,7 @@ describe("story activity workflow", () => {
 
     const activities = await getLessonActivitiesStep(testLesson.id);
 
-    await storyActivityWorkflow(activities, "test-run-id", [], []);
+    await storyActivityWorkflow(activities, "test-run-id", [], 1);
 
     const dbActivity = await prisma.activity.findUnique({
       where: { id: activity.id },
@@ -193,6 +231,14 @@ describe("story activity workflow", () => {
       concepts: ["Test Concept"],
       organizationId,
       title: `Story Skip Lesson ${randomUUID()}`,
+    });
+
+    const expActivity = await activityFixture({
+      generationStatus: "completed",
+      kind: "explanation",
+      lessonId: testLesson.id,
+      organizationId,
+      title: "Test Concept",
     });
 
     const activity = await activityFixture({
@@ -216,10 +262,414 @@ describe("story activity workflow", () => {
     });
 
     const activities = await getLessonActivitiesStep(testLesson.id);
-    const concepts = activities[0]?.lesson?.concepts ?? [];
+    const explanationResults = buildExplanationResults(Number(expActivity.id));
 
-    await storyActivityWorkflow(activities, "test-run-id", concepts, []);
+    await storyActivityWorkflow(activities, "test-run-id", explanationResults, 1);
 
     expect(generateActivityStory).not.toHaveBeenCalled();
+  });
+
+  describe("multi-story behavior", () => {
+    test("creates two stories when lesson has 4+ concepts", async () => {
+      const testLesson = await lessonFixture({
+        chapterId: chapter.id,
+        concepts: ["S1", "S2", "S3", "S4"],
+        organizationId,
+        title: `Two Story Lesson ${randomUUID()}`,
+      });
+
+      const [expS1, expS2, expS3, expS4] = await Promise.all([
+        activityFixture({
+          generationStatus: "completed",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 1,
+          title: "S1",
+        }),
+        activityFixture({
+          generationStatus: "completed",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 2,
+          title: "S2",
+        }),
+        activityFixture({
+          generationStatus: "completed",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 3,
+          title: "S3",
+        }),
+        activityFixture({
+          generationStatus: "completed",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 4,
+          title: "S4",
+        }),
+      ]);
+
+      await Promise.all([
+        activityFixture({
+          generationStatus: "pending",
+          kind: "story",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 5,
+          title: `Story 1 ${randomUUID()}`,
+        }),
+        activityFixture({
+          generationStatus: "pending",
+          kind: "story",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 6,
+          title: `Story 2 ${randomUUID()}`,
+        }),
+      ]);
+
+      const activities = await getLessonActivitiesStep(testLesson.id);
+      const explanationResults: ExplanationResult[] = [
+        { activityId: Number(expS1.id), concept: "S1", steps: [{ text: "S1 text", title: "S1" }] },
+        { activityId: Number(expS2.id), concept: "S2", steps: [{ text: "S2 text", title: "S2" }] },
+        { activityId: Number(expS3.id), concept: "S3", steps: [{ text: "S3 text", title: "S3" }] },
+        { activityId: Number(expS4.id), concept: "S4", steps: [{ text: "S4 text", title: "S4" }] },
+      ];
+
+      await storyActivityWorkflow(activities, "test-run-id", explanationResults, 2);
+
+      expect(generateActivityStory).toHaveBeenCalledTimes(2);
+    });
+
+    test("story 1 gets first half of explanation steps, story 2 gets second half", async () => {
+      const testLesson = await lessonFixture({
+        chapterId: chapter.id,
+        concepts: ["Half1A", "Half1B", "Half2A", "Half2B"],
+        organizationId,
+        title: `Story Split Lesson ${randomUUID()}`,
+      });
+
+      const [expH1A, expH1B, expH2A, expH2B] = await Promise.all([
+        activityFixture({
+          generationStatus: "completed",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 1,
+          title: "Half1A",
+        }),
+        activityFixture({
+          generationStatus: "completed",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 2,
+          title: "Half1B",
+        }),
+        activityFixture({
+          generationStatus: "completed",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 3,
+          title: "Half2A",
+        }),
+        activityFixture({
+          generationStatus: "completed",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 4,
+          title: "Half2B",
+        }),
+      ]);
+
+      await Promise.all([
+        activityFixture({
+          generationStatus: "pending",
+          kind: "story",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 5,
+          title: `Story 1 ${randomUUID()}`,
+        }),
+        activityFixture({
+          generationStatus: "pending",
+          kind: "story",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 6,
+          title: `Story 2 ${randomUUID()}`,
+        }),
+      ]);
+
+      const activities = await getLessonActivitiesStep(testLesson.id);
+      const explanationResults: ExplanationResult[] = [
+        {
+          activityId: Number(expH1A.id),
+          concept: "Half1A",
+          steps: [{ text: "H1A text", title: "H1A" }],
+        },
+        {
+          activityId: Number(expH1B.id),
+          concept: "Half1B",
+          steps: [{ text: "H1B text", title: "H1B" }],
+        },
+        {
+          activityId: Number(expH2A.id),
+          concept: "Half2A",
+          steps: [{ text: "H2A text", title: "H2A" }],
+        },
+        {
+          activityId: Number(expH2B.id),
+          concept: "Half2B",
+          steps: [{ text: "H2B text", title: "H2B" }],
+        },
+      ];
+
+      await storyActivityWorkflow(activities, "test-run-id", explanationResults, 2);
+
+      expect(generateActivityStory).toHaveBeenCalledTimes(2);
+
+      // Story 1 should get first half explanation steps (H1A, H1B)
+      expect(generateActivityStory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          explanationSteps: [
+            { text: "H1A text", title: "H1A" },
+            { text: "H1B text", title: "H1B" },
+          ],
+        }),
+      );
+
+      // Story 2 should get second half explanation steps (H2A, H2B)
+      expect(generateActivityStory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          explanationSteps: [
+            { text: "H2A text", title: "H2A" },
+            { text: "H2B text", title: "H2B" },
+          ],
+        }),
+      );
+    });
+
+    test("single story gets all explanation steps when < 4 concepts", async () => {
+      const testLesson = await lessonFixture({
+        chapterId: chapter.id,
+        concepts: ["Single A", "Single B"],
+        organizationId,
+        title: `Single Story Lesson ${randomUUID()}`,
+      });
+
+      const [expSA, expSB] = await Promise.all([
+        activityFixture({
+          generationStatus: "completed",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 1,
+          title: "Single A",
+        }),
+        activityFixture({
+          generationStatus: "completed",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 2,
+          title: "Single B",
+        }),
+      ]);
+
+      await activityFixture({
+        generationStatus: "pending",
+        kind: "story",
+        lessonId: testLesson.id,
+        organizationId,
+        position: 3,
+        title: `Single Story ${randomUUID()}`,
+      });
+
+      const activities = await getLessonActivitiesStep(testLesson.id);
+      const explanationResults: ExplanationResult[] = [
+        {
+          activityId: Number(expSA.id),
+          concept: "Single A",
+          steps: [{ text: "SA text", title: "SA" }],
+        },
+        {
+          activityId: Number(expSB.id),
+          concept: "Single B",
+          steps: [{ text: "SB text", title: "SB" }],
+        },
+      ];
+
+      await storyActivityWorkflow(activities, "test-run-id", explanationResults, 1);
+
+      expect(generateActivityStory).toHaveBeenCalledOnce();
+      expect(generateActivityStory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          explanationSteps: [
+            { text: "SA text", title: "SA" },
+            { text: "SB text", title: "SB" },
+          ],
+        }),
+      );
+    });
+
+    test("completes both story activities when lesson has two stories", async () => {
+      const testLesson = await lessonFixture({
+        chapterId: chapter.id,
+        concepts: ["SC1", "SC2", "SC3", "SC4"],
+        organizationId,
+        title: `Both Stories Complete Lesson ${randomUUID()}`,
+      });
+
+      const [expSC1, expSC2, expSC3, expSC4] = await Promise.all([
+        activityFixture({
+          generationStatus: "completed",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 1,
+          title: "SC1",
+        }),
+        activityFixture({
+          generationStatus: "completed",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 2,
+          title: "SC2",
+        }),
+        activityFixture({
+          generationStatus: "completed",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 3,
+          title: "SC3",
+        }),
+        activityFixture({
+          generationStatus: "completed",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 4,
+          title: "SC4",
+        }),
+      ]);
+
+      const [story1, story2] = await Promise.all([
+        activityFixture({
+          generationStatus: "pending",
+          kind: "story",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 5,
+          title: `Story Complete 1 ${randomUUID()}`,
+        }),
+        activityFixture({
+          generationStatus: "pending",
+          kind: "story",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 6,
+          title: `Story Complete 2 ${randomUUID()}`,
+        }),
+      ]);
+
+      const activities = await getLessonActivitiesStep(testLesson.id);
+      const explanationResults: ExplanationResult[] = [
+        {
+          activityId: Number(expSC1.id),
+          concept: "SC1",
+          steps: [{ text: "SC1 text", title: "SC1" }],
+        },
+        {
+          activityId: Number(expSC2.id),
+          concept: "SC2",
+          steps: [{ text: "SC2 text", title: "SC2" }],
+        },
+        {
+          activityId: Number(expSC3.id),
+          concept: "SC3",
+          steps: [{ text: "SC3 text", title: "SC3" }],
+        },
+        {
+          activityId: Number(expSC4.id),
+          concept: "SC4",
+          steps: [{ text: "SC4 text", title: "SC4" }],
+        },
+      ];
+
+      await storyActivityWorkflow(activities, "test-run-id", explanationResults, 2);
+
+      const [dbStory1, dbStory2] = await Promise.all([
+        prisma.activity.findUnique({ where: { id: story1.id } }),
+        prisma.activity.findUnique({ where: { id: story2.id } }),
+      ]);
+
+      expect(dbStory1?.generationStatus).toBe("completed");
+      expect(dbStory2?.generationStatus).toBe("completed");
+    });
+
+    test("story 1 gets content when only one explanation result exists with two stories", async () => {
+      const testLesson = await lessonFixture({
+        chapterId: chapter.id,
+        concepts: ["OnlyConcept"],
+        organizationId,
+        title: `Single Explanation Two Stories ${randomUUID()}`,
+      });
+
+      const expOnly = await activityFixture({
+        generationStatus: "completed",
+        kind: "explanation",
+        lessonId: testLesson.id,
+        organizationId,
+        position: 1,
+        title: "OnlyConcept",
+      });
+
+      await Promise.all([
+        activityFixture({
+          generationStatus: "pending",
+          kind: "story",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 2,
+          title: `Story 1 ${randomUUID()}`,
+        }),
+        activityFixture({
+          generationStatus: "pending",
+          kind: "story",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 3,
+          title: `Story 2 ${randomUUID()}`,
+        }),
+      ]);
+
+      const activities = await getLessonActivitiesStep(testLesson.id);
+      const explanationResults: ExplanationResult[] = [
+        {
+          activityId: Number(expOnly.id),
+          concept: "OnlyConcept",
+          steps: [{ text: "Only text", title: "Only" }],
+        },
+      ];
+
+      await storyActivityWorkflow(activities, "test-run-id", explanationResults, 2);
+
+      // Story 1 must get the single explanation result (not an empty array)
+      expect(generateActivityStory).toHaveBeenCalledOnce();
+      expect(generateActivityStory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          explanationSteps: [{ text: "Only text", title: "Only" }],
+        }),
+      );
+    });
   });
 });

--- a/apps/api/src/workflows/activity-generation/kinds/story-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/story-workflow.ts
@@ -1,15 +1,48 @@
+import { type ActivitySteps } from "../steps/_utils/get-activity-steps";
 import { completeActivityStep } from "../steps/complete-activity-step";
+import { type ExplanationResult } from "../steps/generate-explanation-content-step";
 import { generateStoryContentStep } from "../steps/generate-story-content-step";
 import { type LessonActivity } from "../steps/get-lesson-activities-step";
+
+function getExplanationStepsForStory(
+  explanationResults: ExplanationResult[],
+  storyIndex: number,
+  totalStories: number,
+): ActivitySteps {
+  if (totalStories <= 1) {
+    return explanationResults.flatMap((result) => result.steps);
+  }
+
+  const splitIndex = Math.max(1, Math.floor(explanationResults.length / 2));
+
+  const group =
+    storyIndex === 0
+      ? explanationResults.slice(0, splitIndex)
+      : explanationResults.slice(splitIndex);
+
+  return group.flatMap((result) => result.steps);
+}
 
 export async function storyActivityWorkflow(
   activities: LessonActivity[],
   workflowRunId: string,
-  concepts: string[],
-  neighboringConcepts: string[],
+  explanationResults: ExplanationResult[],
+  totalStories: number,
 ): Promise<void> {
   "use workflow";
 
-  await generateStoryContentStep(activities, concepts, neighboringConcepts, workflowRunId);
+  const storyIndices = Array.from({ length: totalStories }, (_, i) => i);
+
+  await Promise.allSettled(
+    storyIndices.map((storyIndex) =>
+      generateStoryContentStep(
+        activities,
+        getExplanationStepsForStory(explanationResults, storyIndex, totalStories),
+        workflowRunId,
+        storyIndex,
+      ),
+    ),
+  );
+
   await completeActivityStep(activities, workflowRunId, "story");
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.ts
@@ -11,6 +11,8 @@ import { prisma } from "@zoonk/db";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { streamError, streamStatus } from "../stream-status";
 import { resolveActivityForGeneration } from "./_utils/content-step-helpers";
+import { findActivitiesByKind } from "./_utils/find-activity-by-kind";
+import { type ActivitySteps } from "./_utils/get-activity-steps";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
 import { setActivityAsRunningStep } from "./set-activity-as-running-step";
@@ -67,13 +69,19 @@ async function saveAndCompleteStory(
 
 export async function generateStoryContentStep(
   activities: LessonActivity[],
-  concepts: string[],
-  neighboringConcepts: string[],
+  explanationSteps: ActivitySteps,
   workflowRunId: string,
+  storyIndex = 0,
 ): Promise<void> {
   "use step";
 
-  const resolved = await resolveActivityForGeneration(activities, "story");
+  const storyActivity = findActivitiesByKind(activities, "story")[storyIndex];
+
+  if (!storyActivity) {
+    return;
+  }
+
+  const resolved = await resolveActivityForGeneration(storyActivity);
 
   if (!resolved.shouldGenerate) {
     return;
@@ -81,7 +89,7 @@ export async function generateStoryContentStep(
 
   const { activity } = resolved;
 
-  if (concepts.length === 0) {
+  if (explanationSteps.length === 0) {
     await handleActivityFailureStep({ activityId: activity.id });
     return;
   }
@@ -92,12 +100,11 @@ export async function generateStoryContentStep(
   const { data: result, error }: SafeReturn<{ data: ActivityStorySchema }> = await safeAsync(() =>
     generateActivityStory({
       chapterTitle: activity.lesson.chapter.title,
-      concepts,
       courseTitle: activity.lesson.chapter.course.title,
+      explanationSteps,
       language: activity.language,
       lessonDescription: activity.lesson.description ?? "",
       lessonTitle: activity.lesson.title,
-      neighboringConcepts,
     }),
   );
 

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
@@ -177,39 +177,39 @@ describe(lessonGenerationWorkflow, () => {
       expect(explanations.map((item) => item.title)).toEqual(["A", "B", "C"]);
     });
 
-    test("4 concepts → 2 explanation groups + 2 quizzes", async () => {
+    test("4 concepts → 2 explanation groups + 2 stories", async () => {
       const activities = await createCoreLesson(["A", "B", "C", "D"]);
       const explanations = activities.filter((a) => a.kind === "explanation");
-      const quizzes = activities.filter((a) => a.kind === "quiz");
+      const stories = activities.filter((a) => a.kind === "story");
 
       expect(explanations).toHaveLength(4);
-      expect(quizzes).toHaveLength(2);
+      expect(stories).toHaveLength(2);
     });
 
-    test("5 concepts → split 2/3 with quiz between each group", async () => {
+    test("5 concepts → split 2/3 with story between each group", async () => {
       const activities = await createCoreLesson(["A", "B", "C", "D", "E"]);
       const explanations = activities.filter((a) => a.kind === "explanation");
-      const quizzes = activities.filter((a) => a.kind === "quiz");
+      const stories = activities.filter((a) => a.kind === "story");
 
       expect(explanations).toHaveLength(5);
-      expect(quizzes).toHaveLength(2);
+      expect(stories).toHaveLength(2);
 
       const kinds = activities.map((a) => a.kind);
-      const firstQuizIdx = kinds.indexOf("quiz");
-      const secondQuizIdx = kinds.indexOf("quiz", firstQuizIdx + 1);
+      const firstStoryIdx = kinds.indexOf("story");
+      const secondStoryIdx = kinds.indexOf("story", firstStoryIdx + 1);
 
-      const explanationsBeforeFirstQuiz = activities
-        .slice(0, firstQuizIdx)
+      const explanationsBeforeFirstStory = activities
+        .slice(0, firstStoryIdx)
         .filter((a) => a.kind === "explanation");
-      const explanationsBetweenQuizzes = activities
-        .slice(firstQuizIdx + 1, secondQuizIdx)
+      const explanationsBetweenStories = activities
+        .slice(firstStoryIdx + 1, secondStoryIdx)
         .filter((a) => a.kind === "explanation");
 
-      expect(explanationsBeforeFirstQuiz).toHaveLength(2);
-      expect(explanationsBetweenQuizzes).toHaveLength(3);
+      expect(explanationsBeforeFirstStory).toHaveLength(2);
+      expect(explanationsBetweenStories).toHaveLength(3);
     });
 
-    test("activity order: background, explanations, quiz(es), examples, story, challenge, review", async () => {
+    test("activity order: background, explanations, story(ies), examples, quiz, challenge, review", async () => {
       const activities = await createCoreLesson(["A", "B"]);
       const kinds = activities.map((a) => a.kind);
 
@@ -217,9 +217,9 @@ describe(lessonGenerationWorkflow, () => {
         "background",
         "explanation",
         "explanation",
-        "quiz",
-        "examples",
         "story",
+        "examples",
+        "quiz",
         "challenge",
         "review",
       ]);

--- a/apps/api/src/workflows/lesson-generation/steps/add-activities-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/add-activities-step.ts
@@ -44,10 +44,10 @@ function getCoreActivities(concepts: string[]): ActivityEntry[] {
   const review: ActivityEntry = { description: null, kind: "review", title: null };
   const quiz: ActivityEntry = { description: null, kind: "quiz", title: null };
 
-  const minConceptsForTwoQuizzes = 4;
+  const minConceptsForTwoStories = 4;
 
-  if (concepts.length < minConceptsForTwoQuizzes) {
-    return [background, ...allExplanations, quiz, examples, story, challenge, review];
+  if (concepts.length < minConceptsForTwoStories) {
+    return [background, ...allExplanations, story, examples, quiz, challenge, review];
   }
 
   const splitIndex = Math.floor(concepts.length / 2);
@@ -57,11 +57,11 @@ function getCoreActivities(concepts: string[]): ActivityEntry[] {
   return [
     background,
     ...firstGroup,
-    quiz,
-    ...secondGroup,
-    quiz,
-    examples,
     story,
+    ...secondGroup,
+    story,
+    examples,
+    quiz,
     challenge,
     review,
   ];

--- a/apps/evals/src/tasks/activity-story/test-cases.ts
+++ b/apps/evals/src/tasks/activity-story/test-cases.ts
@@ -51,18 +51,29 @@ ${SHARED_EXPECTATIONS}
     id: "en-web-data-movement",
     userInput: {
       chapterTitle: "Networking fundamentals",
-      concepts: [
-        "Encapsulation",
-        "Hop-by-Hop Forwarding",
-        "Maximum Transmission Unit",
-        "Packet Fragmentation",
-      ],
       courseTitle: "Web Development",
+      explanationSteps: [
+        {
+          text: "Data is wrapped in headers at each network layer (application, transport, network, link) before transmission, with each layer adding its own control information.",
+          title: "Encapsulation",
+        },
+        {
+          text: "Each router makes independent forwarding decisions based on its own routing table, passing packets one hop at a time toward the destination.",
+          title: "Hop-by-Hop Forwarding",
+        },
+        {
+          text: "The maximum size of a single frame that can be transmitted over a network link, typically 1500 bytes for Ethernet.",
+          title: "Maximum Transmission Unit",
+        },
+        {
+          text: "When a packet exceeds the MTU of a link, it is split into smaller fragments that are reassembled at the destination.",
+          title: "Packet Fragmentation",
+        },
+      ],
       language: "en",
       lessonDescription:
         "Core building blocks for how data moves across networks, from encapsulation to hop-by-hop forwarding constraints.",
       lessonTitle: "How Data Moves on Networks",
-      neighboringConcepts: ["DNS Resolution", "TCP Handshake", "Socket Programming"],
     },
   },
   {
@@ -84,22 +95,29 @@ ${SHARED_EXPECTATIONS}
     id: "pt-python-float-bool",
     userInput: {
       chapterTitle: "Tipos numéricos e valores especiais",
-      concepts: [
-        "Ponto Flutuante",
-        "Booleanos como Inteiros",
-        "Literais Numéricos",
-        "Hierarquia de Tipos",
-      ],
       courseTitle: "Python",
+      explanationSteps: [
+        {
+          text: "Números de ponto flutuante usam representação IEEE 754, o que pode causar imprecisões em cálculos decimais como 0.1 + 0.2 != 0.3.",
+          title: "Ponto Flutuante",
+        },
+        {
+          text: "Em Python, bool é uma subclasse de int, onde True == 1 e False == 0, permitindo operações aritméticas com booleanos.",
+          title: "Booleanos como Inteiros",
+        },
+        {
+          text: "Python suporta diferentes formas de literais numéricos: inteiros decimais, hexadecimais (0x), octais (0o), binários (0b) e notação científica para floats.",
+          title: "Literais Numéricos",
+        },
+        {
+          text: "A hierarquia de tipos numéricos em Python vai de bool → int → float → complex, com conversões implícitas seguindo essa ordem.",
+          title: "Hierarquia de Tipos",
+        },
+      ],
       language: "pt",
       lessonDescription:
         "Valores de ponto flutuante e booleanos, sintaxe de literais e a relação estrutural entre bool e int.",
       lessonTitle: "Float e bool como tipos numéricos",
-      neighboringConcepts: [
-        "Conversão de Tipos",
-        "Operadores Aritméticos",
-        "Comparação de Valores",
-      ],
     },
   },
   {
@@ -119,18 +137,29 @@ ${SHARED_EXPECTATIONS}
     id: "en-economics-labor-cycles",
     userInput: {
       chapterTitle: "Business cycles",
-      concepts: [
-        "Unemployment Rate",
-        "Hours Worked",
-        "Labor Force Participation",
-        "Discouraged Workers",
-      ],
       courseTitle: "Economics",
+      explanationSteps: [
+        {
+          text: "The percentage of the labor force that is jobless and actively seeking work; it is a lagging indicator that peaks after GDP has already started recovering.",
+          title: "Unemployment Rate",
+        },
+        {
+          text: "Total hours worked across the economy tend to drop before unemployment rises during downturns, as employers cut hours before cutting jobs.",
+          title: "Hours Worked",
+        },
+        {
+          text: "The share of the working-age population that is either employed or actively looking for work; it can decline during prolonged downturns as people exit the labor force.",
+          title: "Labor Force Participation",
+        },
+        {
+          text: "Workers who have stopped looking for employment because they believe no jobs are available; they are not counted in the official unemployment rate.",
+          title: "Discouraged Workers",
+        },
+      ],
       language: "en",
       lessonDescription:
         "Empirical regularities linking downturns to labor market outcomes at the level of aggregate fluctuations, without modeling search or wage-setting mechanisms.",
       lessonTitle: "Labor market aggregates over the cycle",
-      neighboringConcepts: ["GDP Growth Rate", "Inflation Targeting", "Fiscal Multiplier"],
     },
   },
   {
@@ -152,22 +181,29 @@ ${SHARED_EXPECTATIONS}
     id: "es-quimica-acidez-enolatos",
     userInput: {
       chapterTitle: "Carbonilos y enolatos",
-      concepts: [
-        "Acidez en Posición Alfa",
-        "Estabilización por Resonancia",
-        "Enolato como Nucleófilo",
-        "Condensación Aldólica",
-      ],
       courseTitle: "Química",
+      explanationSteps: [
+        {
+          text: "Los hidrógenos en posición alfa al carbonilo son ácidos debido a la estabilización por resonancia del carbanión resultante con el grupo C=O.",
+          title: "Acidez en Posición Alfa",
+        },
+        {
+          text: "El enolato se estabiliza por deslocalización de la carga negativa entre el carbono alfa y el oxígeno del carbonilo, formando dos estructuras resonantes.",
+          title: "Estabilización por Resonancia",
+        },
+        {
+          text: "El enolato actúa como nucleófilo rico en electrones que ataca electrófilos como haluros de alquilo o carbonilos de otros compuestos.",
+          title: "Enolato como Nucleófilo",
+        },
+        {
+          text: "Reacción donde un enolato ataca el carbonilo de otra molécula, formando un β-hidroxicarbonilo que puede deshidratarse a un producto α,β-insaturado.",
+          title: "Condensación Aldólica",
+        },
+      ],
       language: "es",
       lessonDescription:
         "Origen de la acidez en α y cómo se forma el enolato como nucleófilo clave en reacciones de construcción C–C.",
       lessonTitle: "Acidez en α y formación de enolatos",
-      neighboringConcepts: [
-        "Adición Nucleofílica",
-        "Reducción de Carbonilos",
-        "Protección de Grupos Funcionales",
-      ],
     },
   },
   {
@@ -189,22 +225,29 @@ ${SHARED_EXPECTATIONS}
     id: "pt-direito-medicao-automacao",
     userInput: {
       chapterTitle: "Legal tech e automação de documentos",
-      concepts: [
-        "Métricas de Qualidade Documental",
-        "Rastros de Auditoria",
-        "Classificação de Erros",
-        "Indicadores de Segurança",
-      ],
       courseTitle: "Direito",
+      explanationSteps: [
+        {
+          text: "Indicadores como taxa de erro, completude de campos e conformidade com templates que medem a qualidade dos documentos gerados automaticamente.",
+          title: "Métricas de Qualidade Documental",
+        },
+        {
+          text: "Registros detalhados de cada ação realizada pelo sistema de automação, incluindo quem iniciou, quando executou e quais alterações foram feitas.",
+          title: "Rastros de Auditoria",
+        },
+        {
+          text: "Categorização de erros em níveis de severidade (crítico, alto, médio, baixo) para priorizar correções e identificar padrões recorrentes.",
+          title: "Classificação de Erros",
+        },
+        {
+          text: "Métricas que monitoram riscos de segurança como acesso não autorizado, vazamento de dados sensíveis e integridade dos documentos gerados.",
+          title: "Indicadores de Segurança",
+        },
+      ],
       language: "pt",
       lessonDescription:
         "Métricas operacionais focadas em qualidade e segurança da automação documental, com rastros para auditoria.",
       lessonTitle: "Medição e monitoramento da automação",
-      neighboringConcepts: [
-        "Templates Jurídicos",
-        "Integração com Sistemas Judiciais",
-        "Assinatura Digital",
-      ],
     },
   },
   {
@@ -224,18 +267,29 @@ ${SHARED_EXPECTATIONS}
     id: "en-web-debugging-mental-models",
     userInput: {
       chapterTitle: "Networking fundamentals",
-      concepts: [
-        "Layer-by-Layer Isolation",
-        "Host Configuration Check",
-        "Gateway Reachability",
-        "Service-Layer Diagnosis",
-      ],
       courseTitle: "Web Development",
+      explanationSteps: [
+        {
+          text: "A systematic approach to debugging connectivity by testing each network layer independently, starting from the physical/link layer up to the application layer.",
+          title: "Layer-by-Layer Isolation",
+        },
+        {
+          text: "Verifying local network settings including IP address assignment, subnet mask, DNS resolver configuration, and routing table entries.",
+          title: "Host Configuration Check",
+        },
+        {
+          text: "Testing whether the default gateway is reachable, which confirms the local network segment is functioning and the first hop router is accessible.",
+          title: "Gateway Reachability",
+        },
+        {
+          text: "Diagnosing issues at the application layer such as DNS resolution failures, TLS handshake errors, or service port connectivity problems.",
+          title: "Service-Layer Diagnosis",
+        },
+      ],
       language: "en",
       lessonDescription:
         "Practical mental models for narrowing a problem to host, subnet, gateway, path, or service-layer reachability without relying on protocol-specific details.",
       lessonTitle: "Connectivity Debugging Mental Models",
-      neighboringConcepts: ["Latency Measurement", "Load Balancing", "Network Address Translation"],
     },
   },
 ];

--- a/packages/ai/src/tasks/activities/core/activity-story.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-story.prompt.md
@@ -41,8 +41,7 @@ Each step should feel like you're eavesdropping on a real conversation — no na
 - `CHAPTER_TITLE`: The chapter context (for understanding scope)
 - `COURSE_TITLE`: The course context (for understanding audience level)
 - `LANGUAGE`: Output language
-- `CONCEPTS`: The key concepts this lesson teaches (use these to ground the story in relevant scenarios)
-- `NEIGHBORING_CONCEPTS`: Concepts from adjacent lessons (avoid overlapping with these)
+- `EXPLANATION_STEPS`: Explanation of each concept the story should incorporate. EXPLANATION_STEPS tells you WHAT concepts to weave into the story scenario. Create situations where these concepts are naturally applied.
 
 ## Language Guidelines
 
@@ -134,25 +133,6 @@ Every decision must:
 - **Stay focused**: The problem should specifically require THIS lesson's concept to solve
 - **Don't expand**: Other lessons cover related topics — this story tests this lesson
 - **Don't narrow**: If the lesson is broad, the problem should engage multiple aspects of it
-
-## Relationship to Previous Activities
-
-The learner has already completed:
-
-- **Background**: WHY this exists (origin story, problems solved, historical context)
-- **Explanation**: WHAT it is (core concepts, components, definitions)
-- **Mechanics**: HOW it works (processes in action, cause-effect chains)
-- **Examples**: WHERE it appears (real-world contexts, applications)
-
-Your Story activity answers WHEN DO I USE THIS? (applying concepts to solve realistic problems). These complement each other:
-
-- Background: "WHY did we need this?"
-- Explanation: "WHAT exactly is it?"
-- Mechanics: "HOW does it actually work?"
-- Examples: "WHERE will I encounter this?"
-- Story: "WHEN do I apply this to solve real problems?"
-
-The learner knows what the concept IS, how it WORKS, and where they'll SEE it. Now they practice USING it in a realistic scenario.
 
 # Structure Guide
 

--- a/packages/ai/src/tasks/activities/core/activity-story.ts
+++ b/packages/ai/src/tasks/activities/core/activity-story.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { ACTIVITY_OPTIONS_COUNT, formatConceptLines } from "../config";
+import { ACTIVITY_OPTIONS_COUNT } from "../config";
 import systemPrompt from "./activity-story.prompt.md";
 
 const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_STORY ?? "openai/gpt-5.2";
@@ -41,8 +41,7 @@ export type ActivityStoryParams = {
   chapterTitle: string;
   courseTitle: string;
   language: string;
-  concepts: string[];
-  neighboringConcepts: string[];
+  explanationSteps: { title: string; text: string }[];
   model?: string;
   useFallback?: boolean;
   reasoningEffort?: ReasoningEffort;
@@ -54,18 +53,22 @@ export async function generateActivityStory({
   chapterTitle,
   courseTitle,
   language,
-  concepts,
-  neighboringConcepts,
+  explanationSteps,
   model = DEFAULT_MODEL,
   useFallback = true,
   reasoningEffort,
 }: ActivityStoryParams) {
+  const formattedExplanationSteps = explanationSteps
+    .map((step, index) => `${index + 1}. ${step.title}: ${step.text}`)
+    .join("\n");
+
   const userPrompt = `LESSON_TITLE: ${lessonTitle}
 LESSON_DESCRIPTION: ${lessonDescription}
 CHAPTER_TITLE: ${chapterTitle}
 COURSE_TITLE: ${courseTitle}
 LANGUAGE: ${language}
-${formatConceptLines(concepts, neighboringConcepts)}`;
+EXPLANATION_STEPS:
+${formattedExplanationSteps}`;
 
   const providerOptions = buildProviderOptions({
     fallbackModels: FALLBACK_MODELS,


### PR DESCRIPTION
## Summary

- Invert core lesson activity ratio: generate **2 stories + 1 quiz** instead of 2 quizzes + 1 story
- Stories now depend on explanation results (moved from wave 1 to wave 2), receiving explanation steps as input instead of raw concepts
- Quiz workflow simplified — always 1 quiz using all explanation steps, no splitting logic
- Story workflow rewritten to mirror the previous quiz-workflow pattern (split explanation steps across stories for 4+ concepts)
- Updated AI prompt to reflect new activity ordering (story comes after explanation, before examples/quiz)

## Test plan

- [x] Updated `story-workflow.test.ts` with new signature and multi-story describe block
- [x] Updated `quiz-workflow.test.ts` — removed multi-quiz tests, simplified calls
- [x] Updated `core-activity-workflow.test.ts` — cascade failure and neighboring concepts tests
- [x] Updated `lesson-generation-workflow.test.ts` — activity ordering assertions
- [x] Updated evals test cases to use `explanationSteps` instead of `concepts`/`neighboringConcepts`
- [x] All 166 unit/integration tests pass
- [x] API, main, editor e2e tests pass
- [x] Typecheck, knip, quality:fix all clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch core lesson ratio to 2 stories + 1 quiz to emphasize narrative practice. Stories now depend on explanation results; quiz is a single activity using all explanation steps.

- **Refactors**
  - Move stories to wave 2 and feed them `explanationSteps`; split across two stories when there are 4+ concepts.
  - Simplify quizzes to one per lesson; remove split/multi-quiz logic and indexes.
  - Update activity order: background → explanations → story(ies) → examples → quiz → challenge → review.
  - Update story prompt and API: generator now accepts `explanationSteps` (not `concepts`/`neighboringConcepts`).
  - Adjust cascade: empty explanation results fail both story and quiz; tests/evals updated.

<sup>Written for commit 763fa32cef18b44d0fce53e4317e16f16ceeaa65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

