### PR TITLE
fix(ai): reduce number of concepts per lesson

### DIFF
--- a/apps/evals/src/tasks/chapter-lessons/test-cases.ts
+++ b/apps/evals/src/tasks/chapter-lessons/test-cases.ts
@@ -7,7 +7,7 @@ const SHARED_EXPECTATIONS = `
 
   Output is organized into LESSON UNITS (thematic groups) containing CONCEPTS (individual teachable items).
   - Each concept should be a single, specific idea — something a domain expert would consider one teachable unit
-  - Lesson sizes should be 3-8 concepts and should vary naturally across lessons
+  - Lesson sizes should be 3-6 concepts and should vary naturally across lessons
   - Total concept coverage should be exhaustive for the chapter's scope
 
   ## Evaluating concept quality

--- a/apps/evals/src/tasks/language-chapter-lessons/test-cases.ts
+++ b/apps/evals/src/tasks/language-chapter-lessons/test-cases.ts
@@ -7,7 +7,7 @@ const SHARED_EXPECTATIONS = `
 
   Output is organized into LESSON UNITS (thematic groups) containing CONCEPTS (individual teachable items).
   - Each concept should be a single teachable unit appropriate to the chapter's level and topic
-  - Lesson sizes should be 3-8 concepts and should vary naturally across lessons
+  - Lesson sizes should be 3-6 concepts and should vary naturally across lessons
   - Total concept coverage should be exhaustive for the chapter's scope
 
   ## Evaluating concept quality

--- a/packages/ai/src/tasks/chapters/chapter-lessons.prompt.md
+++ b/packages/ai/src/tasks/chapters/chapter-lessons.prompt.md
@@ -60,8 +60,8 @@ This is the most critical aspect. Each concept must be **one single, specific id
 ## Lesson Unit Structure
 
 - Each lesson groups related concepts under a thematic title
-- Include **as many concepts as the theme naturally requires** — some themes need 4, others need 8. Don't force every lesson to the same size
-- **NEVER exceed 8 concepts per lesson** — if a group has more than 8, split it into two lessons with more specific themes. This is a hard limit
+- Include **as many concepts as the theme naturally requires** — some themes need 3, others need 6. Don't force every lesson to the same size
+- **NEVER exceed 6 concepts per lesson** — if a group has more than 6, split it into two lessons with more specific themes. This is a hard limit
 - If a group would have fewer than 3 concepts, merge it with a related group
 - Lessons should follow a logical progression from foundational to advanced
 - Don't add "applications", "integrated practice", or "putting it all together" lessons — every lesson should teach new concepts, not revisit previous ones
@@ -171,7 +171,7 @@ Before finalizing, verify:
 
 1. **Concept granularity**: Can EACH concept be explained in a single tweet? If any concept could have sub-items under it, break it down further.
 2. **No compound concepts**: Does any concept title contain "AND", "OR", or "VS"? If yes, split it.
-3. **Lesson sizes**: Does each lesson have 3-8 concepts? Do lesson sizes vary naturally, or are they all the same number? Split or merge as needed.
+3. **Lesson sizes**: Does each lesson have 3-6 concepts? Do lesson sizes vary naturally, or are they all the same number? Split or merge as needed.
 4. **Complete coverage**: Have you covered EVERYTHING from the chapter description?
 5. **Chapter scope**: Did you stay within the chapter's scope?
 6. **No neighboring overlap**: For each concept, if you moved it to a neighboring chapter's list, would it fit naturally there? If yes, remove it — it belongs there, not here.

--- a/packages/ai/src/tasks/chapters/language-chapter-lessons.prompt.md
+++ b/packages/ai/src/tasks/chapters/language-chapter-lessons.prompt.md
@@ -61,8 +61,8 @@ This is the most critical aspect. Each concept must be **one single, specific la
 ## Lesson Unit Structure
 
 - Each lesson groups related concepts under a thematic title
-- Include **as many concepts as the theme naturally requires** — some themes need 4, others need 8. Don't force every lesson to the same size
-- **NEVER exceed 8 concepts per lesson** — if a group has more than 8, split it into two lessons with more specific themes. This is a hard limit
+- Include **as many concepts as the theme naturally requires** — some themes need 3, others need 6. Don't force every lesson to the same size
+- **NEVER exceed 6 concepts per lesson** — if a group has more than 6, split it into two lessons with more specific themes. This is a hard limit
 - If a group would have fewer than 3 concepts, merge it with a related group
 - Lessons should follow a logical progression from foundational to advanced
 - Don't add "applications", "integrated practice", or "putting it all together" lessons — every lesson should teach new concepts, not revisit previous ones
@@ -171,7 +171,7 @@ Before finalizing, verify:
 2. **No false granularity**: Are any concepts just the same form repeated with different subjects or contexts? If yes, merge them into one concept.
 3. **No duplicates**: Does the same concept appear in multiple lessons? If yes, keep it only in the most relevant lesson.
 4. **No unrelated bundling**: Does any concept join genuinely unrelated topics? If yes, split it. Comparisons and contrasts between related items are fine.
-5. **Lesson sizes**: Does each lesson have 3-8 concepts? Do lesson sizes vary naturally, or are they all the same number? Split or merge as needed.
+5. **Lesson sizes**: Does each lesson have 3-6 concepts? Do lesson sizes vary naturally, or are they all the same number? Split or merge as needed.
 6. **Complete coverage**: Have you covered EVERYTHING from the chapter description?
 7. **Chapter scope and level**: Did you stay within the chapter's scope AND level? An advanced nuance chapter should not include basic grammar that belongs in earlier chapters.
 8. **Anchored in the target language**: Is every concept anchored in concrete target-language items the learner will produce or recognize? Remove culture, career, exam, or literature content.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduce per-lesson concept range from 3–8 to 3–6 for tighter, more focused lessons. Updates prompts in `packages/ai` and eval expectations in `apps/evals` to enforce a hard max of 6 and reflect the new guidance.

<sup>Written for commit 4986fd017d8f4f3d8162ee7e81e1da671d64ac1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

