### PR TITLE
fix(ui): prevent popover outside click from propagating

### DIFF
--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -23,6 +23,7 @@ function PopoverContent({
   Pick<PopoverPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset">) {
   return (
     <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Backdrop className="fixed inset-0" />
       <PopoverPrimitive.Positioner
         align={align}
         alignOffset={alignOffset}


### PR DESCRIPTION
## Summary
- Add `Popover.Backdrop` to intercept outside clicks so they close the popover without propagating to underlying elements (e.g., links on catalog pages)

## Test plan
- [ ] Open a popover on a catalog page (course, chapter, or lesson header)
- [ ] Click outside the popover on a link — verify the popover closes and the link is NOT followed
- [ ] Verify the dropdown menu in the navbar still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `Popover.Backdrop` to capture outside clicks so the popover closes without triggering underlying elements (e.g., catalog links). Navbar dropdown behavior remains unchanged.

<sup>Written for commit bc122b0ae252369d5d22b53bb971c92e74a594b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

