### PR TITLE
fix(player): improve static step text contrast

### DIFF
--- a/packages/player/src/components/question-text.tsx
+++ b/packages/player/src/components/question-text.tsx
@@ -1,7 +1,7 @@
 export function ContextText({ children }: { children: React.ReactNode }) {
-  return <p className="text-muted-foreground text-base">{children}</p>;
+  return <p className="text-base">{children}</p>;
 }
 
 export function QuestionText({ children }: { children: React.ReactNode }) {
-  return <p className="text-base font-semibold">{children}</p>;
+  return <p className="text-muted-foreground text-base font-semibold">{children}</p>;
 }

--- a/packages/player/src/components/static-step.tsx
+++ b/packages/player/src/components/static-step.tsx
@@ -5,7 +5,7 @@ import { cn } from "@zoonk/ui/lib/utils";
 import { type SerializedStep } from "../prepare-activity-data";
 import { useReplaceName } from "../user-name-context";
 import { HighlightText } from "./highlight-text";
-import { ContextText } from "./question-text";
+import { ContextText, QuestionText } from "./question-text";
 import { StaticTapZones, useStaticStepNavigation } from "./static-step-navigation";
 import { StaticStepText, StaticStepVisual } from "./step-layouts";
 import { StepVisualRenderer } from "./step-visual-renderer";
@@ -15,7 +15,7 @@ function TextVariant({ title, text }: { title: string; text: string }) {
 
   return (
     <>
-      <h2 className="text-base font-semibold">{replaceName(title)}</h2>
+      <QuestionText>{replaceName(title)}</QuestionText>
       <ContextText>{replaceName(text)}</ContextText>
     </>
   );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve text contrast in static steps in the `player` package for better readability. Removed muted color from context text, applied it to the title via the shared QuestionText component, and replaced the inline heading with QuestionText for consistent styling.

<sup>Written for commit adad1d500f67024c88469676be52ea6562114dbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

