### PR TITLE
fix(i18n): update lingo api key name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 # lingo.dev API key for translations
-LINGODOTDEV_API_KEY=
+LINGO_API_KEY=

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ We recommend using [mise](https://mise.jdx.dev/) to manage your Node.js and pnpm
 
 You can use [lingo.dev](https://lingo.dev/) to manage translations for this project. Run `pnpm i18n` from the root directory to translate missing keys.
 
-This is optional. If using `lingo.dev`, make sure to set the `LINGODOTDEV_API_KEY` environment variable in your local `.env` file.
+This is optional. If using `lingo.dev`, make sure to set the `LINGO_API_KEY` environment variable in your local `.env` file.
 
 ## Remote Caching
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the translation API key env var to `LINGO_API_KEY` to match lingo.dev and prevent setup errors. Replaced `LINGODOTDEV_API_KEY` in `.env.example` and README.

<sup>Written for commit f32247ec4f0e20570ab68301977148bc9737419c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

