### PR TITLE
feat(main): replace activity list with icon path for core/language lessons

### DIFF
--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -130,24 +130,16 @@ test.describe("Lesson Detail Page", () => {
     await expect(page.getByText(/not found|404/i)).toBeVisible();
   });
 
-  test("displays activity list with titles and descriptions", async ({ page }) => {
+  test("displays activity path with kind labels for core lessons", async ({ page }) => {
     const { chapter, course, lesson } = await createTestLessonWithActivities();
     await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
-    // Scope to the activity list for precise queries
     const activityList = page.getByRole("list", { name: /activities/i });
 
     await expect(activityList.getByRole("link", { name: /practice/i })).toBeVisible();
-    await expect(activityList.getByText(/apply the topic in a real scenario/i)).toBeVisible();
-
     await expect(activityList.getByRole("link", { name: /explanation/i })).toBeVisible();
-    await expect(activityList.getByText(/concepts and definitions/i)).toBeVisible();
-
     await expect(activityList.getByRole("link", { name: /quiz/i })).toBeVisible();
-    await expect(activityList.getByText(/test your knowledge/i)).toBeVisible();
-
     await expect(activityList.getByRole("link", { name: /challenge/i })).toBeVisible();
-    await expect(activityList.getByText(/make decisions with real trade-offs/i)).toBeVisible();
   });
 
   test("clicking activity link navigates to activity page", async ({ page }) => {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -170,6 +170,7 @@ msgstr "Sign up to track your progress"
 
 #: ../../packages/player/src/components/completion-screen.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-path.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgctxt "95stPq"
@@ -729,11 +730,13 @@ msgid "Chapter {position}"
 msgstr "Chapter {position}"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-path.tsx
 msgctxt "4o5CAP"
 msgid "Not completed"
 msgstr "Not completed"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-path.tsx
 msgctxt "UmEsZF"
 msgid "Activities"
 msgstr "Activities"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -170,6 +170,7 @@ msgstr "Regístrate para seguir tu progreso"
 
 #: ../../packages/player/src/components/completion-screen.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-path.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgctxt "95stPq"
@@ -729,11 +730,13 @@ msgid "Chapter {position}"
 msgstr "Capítulo {position}"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-path.tsx
 msgctxt "4o5CAP"
 msgid "Not completed"
 msgstr "No completada"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-path.tsx
 msgctxt "UmEsZF"
 msgid "Activities"
 msgstr "Actividades"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -170,6 +170,7 @@ msgstr "Cadastre-se para acompanhar seu progresso"
 
 #: ../../packages/player/src/components/completion-screen.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-path.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgctxt "95stPq"
@@ -729,11 +730,13 @@ msgid "Chapter {position}"
 msgstr "Capítulo {position}"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-path.tsx
 msgctxt "4o5CAP"
 msgid "Not completed"
 msgstr "Não concluída"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-path.tsx
 msgctxt "UmEsZF"
 msgid "Activities"
 msgstr "Atividades"

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
@@ -5,11 +5,12 @@ import {
   CatalogListItemContent,
   CatalogListItemDescription,
   CatalogListItemIndicator,
+  CatalogListItemPosition,
   CatalogListItemTitle,
 } from "@/components/catalog/catalog-list";
-import { getActivityKinds } from "@/lib/activities";
 import { getActivityProgress } from "@zoonk/core/progress/activities";
 import { type Activity } from "@zoonk/db";
+import { formatPosition } from "@zoonk/utils/number";
 import { getExtracted } from "next-intl/server";
 
 export async function ActivityList({
@@ -32,22 +33,12 @@ export async function ActivityList({
   }
 
   const t = await getExtracted();
-  const [activityKinds, completedIds] = await Promise.all([
-    getActivityKinds(),
-    getActivityProgress({ lessonId }),
-  ]);
-
-  const kindMeta = new Map(activityKinds.map((kind) => [kind.key, kind]));
+  const completedIds = await getActivityProgress({ lessonId });
 
   return (
     <CatalogList>
       <CatalogListContent aria-label={t("Activities")}>
         {activities.map((activity) => {
-          const meta = kindMeta.get(activity.kind);
-
-          const title = activity.title ?? meta?.label;
-          const description = activity.description ?? meta?.description;
-
           const completed = completedIds.includes(String(activity.id));
 
           return (
@@ -57,9 +48,13 @@ export async function ActivityList({
               key={String(activity.id)}
               prefetch={activity.generationStatus === "completed"}
             >
+              <CatalogListItemPosition>
+                {formatPosition(activity.position + 1)}
+              </CatalogListItemPosition>
+
               <CatalogListItemContent>
-                <CatalogListItemTitle>{title}</CatalogListItemTitle>
-                <CatalogListItemDescription>{description}</CatalogListItemDescription>
+                <CatalogListItemTitle>{activity.title}</CatalogListItemTitle>
+                <CatalogListItemDescription>{activity.description}</CatalogListItemDescription>
               </CatalogListItemContent>
 
               <CatalogListItemIndicator

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-path.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-path.tsx
@@ -1,0 +1,105 @@
+import { CatalogListItemIndicator } from "@/components/catalog/catalog-list";
+import { getActivityIcon, getActivityKinds } from "@/lib/activities";
+import { getActivityProgress } from "@zoonk/core/progress/activities";
+import { type Activity } from "@zoonk/db";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { getExtracted } from "next-intl/server";
+import Link from "next/link";
+
+export async function ActivityPath({
+  activities,
+  brandSlug,
+  chapterSlug,
+  courseSlug,
+  lessonId,
+  lessonSlug,
+}: {
+  activities: Activity[];
+  brandSlug: string;
+  chapterSlug: string;
+  courseSlug: string;
+  lessonId: number;
+  lessonSlug: string;
+}) {
+  if (activities.length === 0) {
+    return null;
+  }
+
+  const t = await getExtracted();
+  const [activityKinds, completedIds] = await Promise.all([
+    getActivityKinds(),
+    getActivityProgress({ lessonId }),
+  ]);
+
+  const kindMeta = new Map(activityKinds.map((kind) => [kind.key, kind]));
+
+  return (
+    <ul aria-label={t("Activities")} className="flex flex-col" role="list">
+      {activities.map((activity, index) => {
+        const meta = kindMeta.get(activity.kind);
+        const Icon = getActivityIcon(activity.kind);
+        const completed = completedIds.includes(String(activity.id));
+        const isLast = index === activities.length - 1;
+        const title = activity.title ?? meta?.label;
+
+        return (
+          <li key={String(activity.id)}>
+            <Link
+              className="hover:bg-muted/30 -mx-3 flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors"
+              href={`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}/a/${activity.position}`}
+              prefetch={activity.generationStatus === "completed"}
+            >
+              <div className="relative flex flex-col items-center self-stretch">
+                <div className="text-muted-foreground/50 flex size-6 shrink-0 items-center justify-center">
+                  <Icon aria-hidden="true" className="size-4" />
+                </div>
+
+                {!isLast && (
+                  <div
+                    className="bg-border/30 absolute top-6 w-px flex-1 self-center"
+                    style={{ bottom: "-10px" }}
+                  />
+                )}
+              </div>
+
+              <span className="text-foreground/90 min-w-0 flex-1 text-sm leading-snug font-medium">
+                {title}
+              </span>
+
+              <CatalogListItemIndicator
+                completed={completed}
+                completedLabel={t("Completed")}
+                notCompletedLabel={t("Not completed")}
+              />
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export function ActivityPathSkeleton({ count }: { count: number }) {
+  return (
+    <ul className="flex flex-col">
+      {Array.from({ length: count }).map((_, i) => (
+        // oxlint-disable-next-line eslint/no-array-index-key -- static skeleton
+        <li className="-mx-3 flex items-center gap-3 px-3 py-2.5" key={i}>
+          <div className="relative flex flex-col items-center self-stretch">
+            <Skeleton className="size-6 shrink-0 rounded" />
+            {i < count - 1 && (
+              <div
+                className="bg-border/30 absolute top-6 w-px flex-1 self-center"
+                style={{ bottom: "-10px" }}
+              />
+            )}
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <Skeleton className="h-4 w-2/5" />
+          </div>
+          <Skeleton className="size-3.5 shrink-0 rounded-full" />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -12,6 +12,7 @@ import { type Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import { Suspense } from "react";
 import { ActivityList } from "./activity-list";
+import { ActivityPath, ActivityPathSkeleton } from "./activity-path";
 import { LessonHeader } from "./lesson-header";
 
 export async function generateMetadata({
@@ -80,16 +81,31 @@ export default async function LessonPage({
           />
         </CatalogToolbar>
 
-        <Suspense fallback={<CatalogListSkeleton count={activities.length} variant="indicator" />}>
-          <ActivityList
-            activities={activities}
-            brandSlug={brandSlug}
-            chapterSlug={chapterSlug}
-            courseSlug={courseSlug}
-            lessonId={lesson.id}
-            lessonSlug={lessonSlug}
-          />
-        </Suspense>
+        {lesson.kind === "custom" ? (
+          <Suspense
+            fallback={<CatalogListSkeleton count={activities.length} variant="indicator" />}
+          >
+            <ActivityList
+              activities={activities}
+              brandSlug={brandSlug}
+              chapterSlug={chapterSlug}
+              courseSlug={courseSlug}
+              lessonId={lesson.id}
+              lessonSlug={lessonSlug}
+            />
+          </Suspense>
+        ) : (
+          <Suspense fallback={<ActivityPathSkeleton count={activities.length} />}>
+            <ActivityPath
+              activities={activities}
+              brandSlug={brandSlug}
+              chapterSlug={chapterSlug}
+              courseSlug={courseSlug}
+              lessonId={lesson.id}
+              lessonSlug={lessonSlug}
+            />
+          </Suspense>
+        )}
       </CatalogContainer>
     </main>
   );

--- a/apps/main/src/lib/activities.ts
+++ b/apps/main/src/lib/activities.ts
@@ -1,4 +1,18 @@
 import { type ActivityKind } from "@zoonk/db";
+import {
+  BookOpenIcon,
+  BookTextIcon,
+  BracesIcon,
+  CircleHelpIcon,
+  FlameIcon,
+  HeadphonesIcon,
+  LanguagesIcon,
+  type LucideIcon,
+  MessageSquareIcon,
+  RotateCcwIcon,
+  SparklesIcon,
+  TargetIcon,
+} from "lucide-react";
 import { getExtracted } from "next-intl/server";
 
 export async function getActivityKinds(): Promise<
@@ -148,4 +162,22 @@ async function getSeoActivityDescription(
   }
 
   return getSeoDescription(activity.kind, lessonTitle);
+}
+
+const ACTIVITY_ICONS: Record<ActivityKind, LucideIcon> = {
+  challenge: FlameIcon,
+  custom: SparklesIcon,
+  explanation: BookOpenIcon,
+  grammar: BracesIcon,
+  languagePractice: MessageSquareIcon,
+  listening: HeadphonesIcon,
+  practice: TargetIcon,
+  quiz: CircleHelpIcon,
+  reading: BookTextIcon,
+  review: RotateCcwIcon,
+  vocabulary: LanguagesIcon,
+};
+
+export function getActivityIcon(kind: ActivityKind): LucideIcon {
+  return ACTIVITY_ICONS[kind];
 }


### PR DESCRIPTION
## Summary
- Add `ActivityPath` component for core/language lessons — vertical connected path with Lucide icons per activity kind, replacing the generic catalog list
- Custom lessons keep the existing `CatalogList` format with position numbers added
- Remove repetitive generic descriptions ("Concepts and definitions", "Test your knowledge") — icons communicate the type, custom titles carry the real information

## Test plan
- [x] E2E tests updated and passing (9/9)
- [x] Typecheck, lint, knip all pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the generic activity list with a vertical icon-based path for core/language lessons to make activity types clearer and reduce noise. Custom lessons keep the list UI and now show position numbers.

- **New Features**
  - Added ActivityPath with Lucide icons per activity kind, connected vertical line, and completion indicator.
  - Kept ActivityList for custom lessons; added position numbers and removed kind fallbacks.
  - Introduced getActivityIcon and icon mapping in `apps/main/src/lib/activities.ts`; added ActivityPathSkeleton.
  - Updated translations and e2e tests to reflect the new path and labels.

<sup>Written for commit 4bdc02a824d665577f28ff463bd2d4cd372ea8fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

