### PR TITLE
fix(main): fix generation timeline phase progression issues

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -91,6 +91,7 @@
     "typescript/require-await": "off",
     "typescript/strict-boolean-expressions": "off",
     "unicorn/no-array-for-each": "off",
+    "unicorn/no-array-reduce": "off",
     "unicorn/no-null": "off",
     "unicorn/prefer-bigint-literals": "off",
     "unicorn/prefer-native-coercion-functions": "off",

--- a/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.ts
@@ -1,4 +1,3 @@
-import { settled } from "@zoonk/utils/settled";
 import { completeActivityStep } from "../steps/complete-activity-step";
 import {
   type ExplanationResult,
@@ -31,22 +30,13 @@ export async function explanationActivityWorkflow(
     return [{ activity, result }];
   });
 
-  const visualResults = await Promise.allSettled(
-    explanationEntries.map((entry) =>
-      generateVisualsForActivityStep(entry.activity, entry.result.steps),
-    ),
+  await Promise.allSettled(
+    explanationEntries.map(async (entry) => {
+      const visualResult = await generateVisualsForActivityStep(entry.activity, entry.result.steps);
+      await generateImagesForActivityStep(entry.activity, visualResult.visuals);
+    }),
   );
 
-  const imagePromises = explanationEntries.flatMap((entry, index) => {
-    const visualResult = visualResults[index];
-    const visuals = visualResult ? settled(visualResult, { visuals: [] }).visuals : [];
-    if (visuals.length === 0) {
-      return [];
-    }
-    return [generateImagesForActivityStep(entry.activity, visuals)];
-  });
-
-  await Promise.allSettled(imagePromises);
   await completeActivityStep(activities, workflowRunId, "explanation");
 
   return { results };

--- a/apps/api/src/workflows/activity-generation/steps/generate-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-images-step.ts
@@ -85,6 +85,8 @@ export async function generateImagesForActivityStep(
   "use step";
 
   if (visuals.length === 0) {
+    await streamStatus({ status: "started", step: "generateImages" });
+    await streamStatus({ status: "completed", step: "generateImages" });
     return [];
   }
 
@@ -101,6 +103,8 @@ export async function generateImagesForActivityStep(
   const imageSteps = dbSteps.filter((step) => getString(step.content, "kind") === "image");
 
   if (imageSteps.length === 0) {
+    await streamStatus({ status: "started", step: "generateImages" });
+    await streamStatus({ status: "completed", step: "generateImages" });
     return visuals;
   }
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.ts
@@ -93,6 +93,8 @@ export async function generateQuizImagesStep(
   });
 
   if (dbSteps.length === 0) {
+    await streamStatus({ status: "started", step: "generateQuizImages" });
+    await streamStatus({ status: "completed", step: "generateQuizImages" });
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- QuizQuestion is a subtype; url? is optional
     return questions as QuizQuestionWithUrls[];
   }

--- a/apps/api/src/workflows/activity-generation/steps/generate-visuals-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-visuals-step.ts
@@ -42,6 +42,8 @@ export async function generateVisualsForActivityStep(
   "use step";
 
   if (steps.length === 0) {
+    await streamStatus({ status: "started", step: "generateVisuals" });
+    await streamStatus({ status: "completed", step: "generateVisuals" });
     return { visuals: [] };
   }
 
@@ -56,6 +58,8 @@ export async function generateVisualsForActivityStep(
   });
 
   if (dbSteps.length === 0) {
+    await streamStatus({ status: "started", step: "generateVisuals" });
+    await streamStatus({ status: "completed", step: "generateVisuals" });
     return { visuals: [] };
   }
 

--- a/apps/main/src/app/generate/a/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/a/[id]/use-generation-phases.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { type PhaseStatus } from "@/lib/generation-phases";
+import { type PhaseStatus, enforcePhaseProgression } from "@/lib/generation-phases";
 import {
   PHASE_ICONS,
   type PhaseName,
@@ -35,7 +35,7 @@ export function useGenerationPhases(
 
   const phaseOrder = getPhaseOrder(activityKind);
 
-  const phases: {
+  const rawPhases: {
     name: PhaseName;
     label: string;
     status: PhaseStatus;
@@ -46,6 +46,8 @@ export function useGenerationPhases(
     name: phase,
     status: getPhaseStatus(phase, completedSteps, currentStep, activityKind, startedSteps),
   }));
+
+  const phases = enforcePhaseProgression(rawPhases);
 
   const progress = calculateWeightedProgress(
     completedSteps,

--- a/apps/main/src/app/generate/ch/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/ch/[id]/use-generation-phases.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { type PhaseStatus } from "@/lib/generation-phases";
+import { type PhaseStatus, enforcePhaseProgression } from "@/lib/generation-phases";
 import { type ChapterWorkflowStepName } from "@/lib/workflow/config";
 import {
   type ThinkingMessageGenerator,
@@ -39,7 +39,7 @@ export function useGenerationPhases(
 
   const phaseOrder = getPhaseOrder({ completedSteps, currentStep, targetLanguage });
 
-  const phases: {
+  const rawPhases: {
     name: PhaseName;
     label: string;
     status: PhaseStatus;
@@ -50,6 +50,8 @@ export function useGenerationPhases(
     name: phase,
     status: getPhaseStatus(phase, completedSteps, currentStep, targetLanguage, startedSteps),
   }));
+
+  const phases = enforcePhaseProgression(rawPhases);
 
   const progress = calculateWeightedProgress(
     completedSteps,

--- a/apps/main/src/app/generate/cs/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/cs/[id]/use-generation-phases.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { type PhaseStatus } from "@/lib/generation-phases";
+import { type PhaseStatus, enforcePhaseProgression } from "@/lib/generation-phases";
 import { type CourseWorkflowStepName } from "@/lib/workflow/config";
 import {
   type ThinkingMessageGenerator,
@@ -45,7 +45,7 @@ export function useGenerationPhases(
 
   const phaseOrder = getPhaseOrder({ completedSteps, currentStep, targetLanguage });
 
-  const phases: {
+  const rawPhases: {
     name: PhaseName;
     label: string;
     status: PhaseStatus;
@@ -56,6 +56,8 @@ export function useGenerationPhases(
     name: phase,
     status: getPhaseStatus(phase, completedSteps, currentStep, targetLanguage, startedSteps),
   }));
+
+  const phases = enforcePhaseProgression(rawPhases);
 
   const progress = calculateWeightedProgress(
     completedSteps,

--- a/apps/main/src/app/generate/l/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/l/[id]/use-generation-phases.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { type PhaseStatus } from "@/lib/generation-phases";
+import { type PhaseStatus, enforcePhaseProgression } from "@/lib/generation-phases";
 import { type LessonStepName } from "@/lib/workflow/config";
 import { type ThinkingMessageGenerator, cycleMessage } from "@/lib/workflow/use-thinking-messages";
 import { useExtracted } from "next-intl";
@@ -26,7 +26,7 @@ export function useGenerationPhases(
     settingUpActivities: t("Setting up activities"),
   };
 
-  const phases: {
+  const rawPhases: {
     name: PhaseName;
     label: string;
     status: PhaseStatus;
@@ -37,6 +37,8 @@ export function useGenerationPhases(
     name: phase,
     status: getPhaseStatus(phase, completedSteps, currentStep, startedSteps),
   }));
+
+  const phases = enforcePhaseProgression(rawPhases);
 
   const progress = calculateWeightedProgress(completedSteps, currentStep, startedSteps);
 

--- a/apps/main/src/lib/generation-phases.test.ts
+++ b/apps/main/src/lib/generation-phases.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { calculateWeightedProgress, getPhaseStatus } from "./generation-phases";
+import {
+  type PhaseStatus,
+  calculateWeightedProgress,
+  enforcePhaseProgression,
+  getPhaseStatus,
+} from "./generation-phases";
 
 type TestStep = "stepA" | "stepB" | "stepC" | "stepD" | "stepE";
 
@@ -102,5 +107,83 @@ describe(calculateWeightedProgress, () => {
 
     // phase1 complete (10/50 = 20%) + phase2 complete (15/50 = 30%) = 50%
     expect(calculateWeightedProgress(["stepA", "stepB", "stepC"], null, config)).toBe(50);
+  });
+
+  it("clamps finishing phase progress when earlier phases are not completed", () => {
+    const phaseSteps: Record<"start" | "middle" | "finishing", TestStep[]> = {
+      finishing: ["stepE"],
+      middle: ["stepC"],
+      start: ["stepA", "stepB"],
+    };
+
+    const config = {
+      phaseOrder: ["start", "middle", "finishing"] as const,
+      phaseSteps,
+      phaseWeights: { finishing: 10, middle: 30, start: 20 },
+    };
+
+    // stepE is completed (finishing step), but middle is pending.
+    // Without clamping, finishing would add weight. With clamping, it stays pending.
+    const progress = calculateWeightedProgress(["stepA", "stepB", "stepE"], null, config);
+
+    // start: completed (20), middle: pending (0), finishing: clamped to pending (0)
+    // 20/60 * 100 = 33
+    expect(progress).toBe(33);
+  });
+});
+
+function makePhase(status: PhaseStatus) {
+  return { status };
+}
+
+describe(enforcePhaseProgression, () => {
+  it("does not change when all phases are pending", () => {
+    const input = [makePhase("pending"), makePhase("pending"), makePhase("pending")];
+    expect(enforcePhaseProgression(input)).toEqual(input);
+  });
+
+  it("does not change linear [completed, active, pending]", () => {
+    const input = [makePhase("completed"), makePhase("active"), makePhase("pending")];
+    expect(enforcePhaseProgression(input)).toEqual(input);
+  });
+
+  it("does not change when all phases are completed", () => {
+    const input = [makePhase("completed"), makePhase("completed"), makePhase("completed")];
+    expect(enforcePhaseProgression(input)).toEqual(input);
+  });
+
+  it("clamps last phase to pending when earlier phases are not all completed", () => {
+    const input = [makePhase("completed"), makePhase("pending"), makePhase("active")];
+    const result = enforcePhaseProgression(input);
+    expect(result.at(2)?.status).toBe("pending");
+  });
+
+  it("auto-promotes pending to active when previous phase is completed", () => {
+    const input = [makePhase("completed"), makePhase("pending"), makePhase("pending")];
+    const result = enforcePhaseProgression(input);
+    expect(result.at(0)?.status).toBe("completed");
+    expect(result.at(1)?.status).toBe("active");
+    expect(result.at(2)?.status).toBe("pending");
+  });
+
+  it("handles visuals scenario: promotes pending and clamps last", () => {
+    const input = [
+      makePhase("completed"),
+      makePhase("completed"),
+      makePhase("completed"),
+      makePhase("completed"),
+      makePhase("pending"),
+      makePhase("active"),
+    ];
+    const result = enforcePhaseProgression(input);
+    expect(result.at(4)?.status).toBe("active");
+    expect(result.at(5)?.status).toBe("pending");
+  });
+
+  it("preserves original objects when no changes needed", () => {
+    const original = makePhase("completed");
+    const input = [original, makePhase("completed"), makePhase("completed")];
+    const result = enforcePhaseProgression(input);
+    expect(result[0]).toBe(original);
   });
 });

--- a/apps/main/src/lib/generation-phases.ts
+++ b/apps/main/src/lib/generation-phases.ts
@@ -1,3 +1,5 @@
+import { sumOf } from "@zoonk/utils/number";
+
 export type PhaseStatus = "pending" | "active" | "completed";
 
 /**
@@ -37,6 +39,62 @@ export function getPhaseStatus<TPhase extends string, TStep extends string>(
   return "pending";
 }
 
+function shouldPromote<T extends { status: PhaseStatus }>(phase: T, index: number, phases: T[]) {
+  if (index === 0 || phase.status !== "pending") {
+    return false;
+  }
+
+  return phases[index - 1]?.status === "completed";
+}
+
+function clampLastPhase<T extends { status: PhaseStatus }>(phases: T[]): T[] {
+  const allPredecessorsCompleted = phases.slice(0, -1).every((item) => item.status === "completed");
+
+  if (allPredecessorsCompleted) {
+    return phases;
+  }
+
+  const last = phases.at(-1);
+
+  if (!last || last.status === "pending") {
+    return phases;
+  }
+
+  return [...phases.slice(0, -1), { ...last, status: "pending" as const }];
+}
+
+export function enforcePhaseProgression<T extends { status: PhaseStatus }>(phases: T[]): T[] {
+  // Promotion doesn't cascade (pending -> active, not completed), so
+  // each element only needs the original previous element's status.
+  const promoted = phases.map((phase, index) =>
+    shouldPromote(phase, index, phases) ? { ...phase, status: "active" as const } : phase,
+  );
+
+  return clampLastPhase(promoted);
+}
+
+function getPhaseWeightContribution<TPhase extends string, TStep extends string>(
+  phase: TPhase,
+  status: PhaseStatus,
+  completedSteps: TStep[],
+  config: { phaseSteps: Record<TPhase, readonly TStep[]>; phaseWeights: Record<TPhase, number> },
+) {
+  if (status === "pending") {
+    return 0;
+  }
+
+  const weight = config.phaseWeights[phase];
+
+  if (status === "completed") {
+    return weight;
+  }
+
+  const steps = config.phaseSteps[phase];
+  const completedCount = steps.filter((step) => completedSteps.includes(step)).length;
+
+  return (completedCount / steps.length) * weight;
+}
+
 export function calculateWeightedProgress<TPhase extends string, TStep extends string>(
   completedSteps: TStep[],
   currentStep: TStep | null,
@@ -47,33 +105,30 @@ export function calculateWeightedProgress<TPhase extends string, TStep extends s
     startedSteps?: TStep[];
   },
 ): number {
-  const totalWeight = config.phaseOrder.reduce((sum, phase) => sum + config.phaseWeights[phase], 0);
+  const totalWeight = sumOf(config.phaseOrder.map((phase) => config.phaseWeights[phase]));
 
   if (totalWeight === 0) {
     return 0;
   }
 
-  let weightedSum = 0;
-
-  for (const phase of config.phaseOrder) {
-    const status = getPhaseStatus(
+  const rawStatuses = config.phaseOrder.map((phase) => ({
+    phase,
+    status: getPhaseStatus(
       phase,
       completedSteps,
       currentStep,
       config.phaseSteps,
       config.startedSteps,
-    );
-    const weight = config.phaseWeights[phase];
+    ),
+  }));
 
-    if (status === "completed") {
-      weightedSum += weight;
-    } else if (status === "active") {
-      const steps = config.phaseSteps[phase];
-      const completedCount = steps.filter((step) => completedSteps.includes(step)).length;
-      const partialProgress = (completedCount / steps.length) * weight;
-      weightedSum += partialProgress;
-    }
-  }
+  const enforced = enforcePhaseProgression(rawStatuses);
+
+  const weightedSum = sumOf(
+    enforced.map(({ phase, status }) =>
+      getPhaseWeightContribution(phase, status, completedSteps, config),
+    ),
+  );
 
   return Math.round((weightedSum / totalWeight) * 100);
 }

--- a/apps/main/src/lib/generation/activity-generation-phases.test.ts
+++ b/apps/main/src/lib/generation/activity-generation-phases.test.ts
@@ -288,6 +288,7 @@ describe("enforcePhaseProgression integration", () => {
     const finishing = enforced.find((item) => item.name === "finishing");
     const creatingImages = enforced.find((item) => item.name === "creatingImages");
 
+    expect(creatingImages).toBeDefined();
     expect(creatingImages?.status).not.toBe("completed");
     expect(finishing?.status).toBe("pending");
   });

--- a/apps/main/src/lib/generation/activity-generation-phases.test.ts
+++ b/apps/main/src/lib/generation/activity-generation-phases.test.ts
@@ -1,3 +1,4 @@
+import { enforcePhaseProgression } from "@/lib/generation-phases";
 import { describe, expect, test } from "vitest";
 import {
   calculateWeightedProgress,
@@ -258,5 +259,36 @@ describe("reading phase status", () => {
     );
 
     expect(progress).toBeGreaterThan(0);
+  });
+});
+
+describe("enforcePhaseProgression integration", () => {
+  test("clamps finishing to pending when creatingImages is still pending (explanation kind)", () => {
+    const phaseOrder = getPhaseOrder("explanation");
+
+    const rawPhases = phaseOrder.map((phase) => ({
+      name: phase,
+      status: getPhaseStatus(
+        phase,
+        [
+          "getLessonActivities",
+          "getNeighboringConcepts",
+          "setActivityAsRunning",
+          "generateExplanationContent",
+          "generateVisuals",
+          "setChallengeAsCompleted",
+        ],
+        null,
+        "explanation",
+      ),
+    }));
+
+    const enforced = enforcePhaseProgression(rawPhases);
+
+    const finishing = enforced.find((item) => item.name === "finishing");
+    const creatingImages = enforced.find((item) => item.name === "creatingImages");
+
+    expect(creatingImages?.status).not.toBe("completed");
+    expect(finishing?.status).toBe("pending");
   });
 });

--- a/packages/utils/src/number.ts
+++ b/packages/utils/src/number.ts
@@ -27,3 +27,7 @@ export function parseBigIntId(value: string): bigint | null {
 export function formatPosition(position: number): string {
   return String(position + 1).padStart(2, "0");
 }
+
+export function sumOf(values: number[]): number {
+  return values.reduce((a, b) => a + b, 0);
+}


### PR DESCRIPTION
## Summary

- Pipeline visuals→images per-activity in explanation workflow to eliminate the gap between "Preparing illustrations" completing and "Creating images" starting
- Stream started+completed events from step functions on no-op early returns so phases can transition
- Add `enforcePhaseProgression` to gate "Almost done" behind all previous phases completing and auto-promote pending→active
- Disable `unicorn/no-array-reduce` lint rule and move `sumOf` to `@zoonk/utils/number`

## Test plan

- [x] Unit tests for `enforcePhaseProgression` (all states, clamping, auto-promote, visuals scenario)
- [x] Unit test for `calculateWeightedProgress` with finishing clamped
- [x] Integration test: explanation kind with `setChallengeAsCompleted` completed while `creatingImages` pending → finishing clamped
- [ ] Manual: trigger explanation activity generation, verify no gap between visual phases and "Almost done" only appears last

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes phase progression in the generation timeline: visuals and images now run per activity with no gaps, no-op steps emit start/complete events, and the UI enforces phase order so “Almost done” only shows last. Progress now clamps to earlier phases and reflects real work.

- **Bug Fixes**
  - Run explanation visuals → images per activity to remove the gap between “Preparing illustrations” and “Creating images”.
  - Stream started/completed events for no-op steps (`generateVisuals`, `generateImages`, `generateQuizImages`) so phases can advance.
  - Gate the finishing phase behind all prior phases; auto-promote the next pending phase to active when the previous completes.
  - Clamp progress: finishing contributes 0% until all prior phases are completed.

- **Refactors**
  - Added `enforcePhaseProgression` and applied it across `use-generation-phases` hooks.
  - Simplified progress calculation and used `sumOf` from `@zoonk/utils/number`.
  - Disabled `unicorn/no-array-reduce` in `.oxlintrc.json`.
  - Added unit and integration tests for phase progression and progress clamping; tightened assertion to ensure the `creatingImages` phase exists.

<sup>Written for commit 9a436b0acab35a3848d0985d1e05ff6936cee34d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

