### PR TITLE
refactor(ai): update fallback models

### DIFF
--- a/packages/ai/src/tasks/activities/core/activity-challenge.ts
+++ b/packages/ai/src/tasks/activities/core/activity-challenge.ts
@@ -5,15 +5,8 @@ import { z } from "zod";
 import { formatConceptLines } from "../config";
 import systemPrompt from "./activity-challenge.prompt.md";
 
-const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_CHALLENGE ?? "openai/gpt-5.2";
-
-const FALLBACK_MODELS = [
-  "google/gemini-3.1-pro-preview",
-  "openai/gpt-5-mini",
-  "anthropic/claude-opus-4.5",
-  "anthropic/claude-sonnet-4.5",
-  "google/gemini-3-flash",
-];
+const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_CHALLENGE ?? "openai/gpt-5.4";
+const FALLBACK_MODELS = ["google/gemini-3.1-pro-preview", "anthropic/claude-sonnet-4.6"];
 
 const effectSchema = z.object({
   dimension: z.string(),

--- a/packages/ai/src/tasks/activities/core/activity-explanation.ts
+++ b/packages/ai/src/tasks/activities/core/activity-explanation.ts
@@ -4,14 +4,8 @@ import { Output, generateText } from "ai";
 import { z } from "zod";
 import systemPrompt from "./activity-explanation.prompt.md";
 
-const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_EXPLANATION ?? "openai/gpt-5.2";
-
-const FALLBACK_MODELS = [
-  "anthropic/claude-opus-4.6",
-  "anthropic/claude-opus-4.5",
-  "openai/gpt-5-mini",
-  "google/gemini-3.1-pro-preview",
-];
+const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_EXPLANATION ?? "openai/gpt-5.4";
+const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"];
 
 const schema = z.object({
   steps: z.array(

--- a/packages/ai/src/tasks/activities/core/activity-practice.ts
+++ b/packages/ai/src/tasks/activities/core/activity-practice.ts
@@ -5,15 +5,8 @@ import { z } from "zod";
 import { ACTIVITY_OPTIONS_COUNT } from "../config";
 import systemPrompt from "./activity-practice.prompt.md";
 
-const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_PRACTICE ?? "openai/gpt-5.2";
-
-const FALLBACK_MODELS = [
-  "anthropic/claude-opus-4.5",
-  "openai/gpt-5-mini",
-  "google/gemini-3.1-pro-preview",
-  "anthropic/claude-sonnet-4.5",
-  "anthropic/claude-haiku-4.5",
-];
+const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_PRACTICE ?? "openai/gpt-5.4";
+const FALLBACK_MODELS = ["anthropic/claude-opus-4.5", "google/gemini-3.1-pro-preview"];
 
 const schema = z.object({
   steps: z.array(

--- a/packages/ai/src/tasks/activities/core/activity-quiz.ts
+++ b/packages/ai/src/tasks/activities/core/activity-quiz.ts
@@ -4,14 +4,8 @@ import { generateText, stepCountIs } from "ai";
 import { type QuizQuestion, type SelectImageQuestion, quizTools } from "../_tools/quiz";
 import systemPrompt from "./activity-quiz.prompt.md";
 
-const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_QUIZ ?? "openai/gpt-5.2";
-
-const FALLBACK_MODELS = [
-  "anthropic/claude-opus-4.5",
-  "anthropic/claude-sonnet-4.5",
-  "google/gemini-3-flash",
-  "google/gemini-3.1-pro-preview",
-];
+const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_QUIZ ?? "openai/gpt-5.4";
+const FALLBACK_MODELS = ["anthropic/claude-opus-4.5", "google/gemini-3-flash"];
 
 export type ActivityQuizSchema = {
   questions: QuizQuestion[];

--- a/packages/ai/src/tasks/activities/custom/activity-custom.ts
+++ b/packages/ai/src/tasks/activities/custom/activity-custom.ts
@@ -4,14 +4,8 @@ import { Output, generateText } from "ai";
 import { z } from "zod";
 import systemPrompt from "./activity-custom.prompt.md";
 
-const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_CUSTOM ?? "openai/gpt-5.2";
-
-const FALLBACK_MODELS = [
-  "openai/gpt-5-mini",
-  "google/gemini-3.1-pro-preview",
-  "anthropic/claude-opus-4.5",
-  "anthropic/claude-sonnet-4.5",
-];
+const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_CUSTOM ?? "openai/gpt-5.4";
+const FALLBACK_MODELS = ["google/gemini-3.1-pro-preview", "anthropic/claude-opus-4.5"];
 
 const schema = z.object({
   steps: z.array(

--- a/packages/ai/src/tasks/activities/language/activity-grammar.ts
+++ b/packages/ai/src/tasks/activities/language/activity-grammar.ts
@@ -7,14 +7,7 @@ import { getLanguagePromptContext } from "./_utils/language-prompt-context";
 import systemPrompt from "./activity-grammar.prompt.md";
 
 const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_GRAMMAR ?? "google/gemini-3-flash";
-
-const FALLBACK_MODELS = [
-  "openai/gpt-5.2",
-  "google/gemini-3.1-pro-preview",
-  "anthropic/claude-sonnet-4.5",
-  "openai/gpt-5-mini",
-  "anthropic/claude-opus-4.5",
-];
+const FALLBACK_MODELS = ["openai/gpt-5.4", "anthropic/claude-sonnet-4.6"];
 
 const schema = z.object({
   discovery: z.object({

--- a/packages/ai/src/tasks/activities/language/activity-practice.ts
+++ b/packages/ai/src/tasks/activities/language/activity-practice.ts
@@ -8,14 +8,7 @@ import systemPrompt from "./activity-practice.prompt.md";
 
 const DEFAULT_MODEL =
   process.env.AI_MODEL_ACTIVITY_LANGUAGE_PRACTICE ?? "anthropic/claude-opus-4.5";
-
-const FALLBACK_MODELS = [
-  "openai/gpt-5.2",
-  "google/gemini-3-flash",
-  "google/gemini-3.1-pro-preview",
-  "openai/gpt-5-mini",
-  "anthropic/claude-sonnet-4.5",
-];
+const FALLBACK_MODELS = ["openai/gpt-5.4", "google/gemini-3-flash"];
 
 const schema = z.object({
   scenario: z.string(),

--- a/packages/ai/src/tasks/activities/language/activity-pronunciation.ts
+++ b/packages/ai/src/tasks/activities/language/activity-pronunciation.ts
@@ -6,16 +6,7 @@ import { getLanguagePromptContext } from "./_utils/language-prompt-context";
 import systemPrompt from "./activity-pronunciation.prompt.md";
 
 const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_PRONUNCIATION ?? "google/gemini-3-flash";
-
-const FALLBACK_MODELS = [
-  "anthropic/claude-sonnet-4.5",
-  "anthropic/claude-opus-4.5",
-  "google/gemini-3.1-pro-preview",
-  "anthropic/claude-haiku-4.5",
-  "openai/gpt-5.1-instant",
-  "openai/gpt-5.2",
-  "openai/gpt-5-mini",
-];
+const FALLBACK_MODELS = ["anthropic/claude-sonnet-4.6", "openai/gpt-5.1-instant"];
 
 const schema = z.object({
   pronunciation: z.string(),

--- a/packages/ai/src/tasks/activities/language/activity-sentences.ts
+++ b/packages/ai/src/tasks/activities/language/activity-sentences.ts
@@ -7,12 +7,7 @@ import { getLanguagePromptContext } from "./_utils/language-prompt-context";
 import systemPrompt from "./activity-sentences.prompt.md";
 
 const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_SENTENCES ?? "google/gemini-3-flash";
-
-const FALLBACK_MODELS = [
-  "google/gemini-3.1-pro-preview",
-  "openai/gpt-5-mini",
-  "anthropic/claude-opus-4.5",
-];
+const FALLBACK_MODELS = ["openai/gpt-5-mini", "anthropic/claude-opus-4.5"];
 
 const schema = z.object({
   sentences: z.array(

--- a/packages/ai/src/tasks/activities/language/activity-vocabulary.ts
+++ b/packages/ai/src/tasks/activities/language/activity-vocabulary.ts
@@ -7,13 +7,7 @@ import { getLanguagePromptContext } from "./_utils/language-prompt-context";
 import systemPrompt from "./activity-vocabulary.prompt.md";
 
 const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_VOCABULARY ?? "google/gemini-3-flash";
-
-const FALLBACK_MODELS = [
-  "openai/gpt-5.2",
-  "openai/gpt-5-mini",
-  "anthropic/claude-opus-4.5",
-  "google/gemini-3.1-pro-preview",
-];
+const FALLBACK_MODELS = ["openai/gpt-5.4", "anthropic/claude-opus-4.5"];
 
 const schema = z.object({
   words: z.array(

--- a/packages/ai/src/tasks/chapters/chapter-lessons.ts
+++ b/packages/ai/src/tasks/chapters/chapter-lessons.ts
@@ -5,8 +5,7 @@ import { type ReasoningEffort, buildProviderOptions } from "../../provider-optio
 import systemPrompt from "./chapter-lessons.prompt.md";
 
 const DEFAULT_MODEL = process.env.AI_MODEL_CHAPTER_LESSONS ?? "openai/gpt-5.2";
-
-const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "openai/gpt-5-mini"];
+const FALLBACK_MODELS = ["anthropic/claude-opus-4.6"];
 
 const schema = z.object({
   lessons: z.array(

--- a/packages/ai/src/tasks/chapters/language-chapter-lessons.ts
+++ b/packages/ai/src/tasks/chapters/language-chapter-lessons.ts
@@ -5,14 +5,8 @@ import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./language-chapter-lessons.prompt.md";
 
-const DEFAULT_MODEL = process.env.AI_MODEL_LANGUAGE_CHAPTER_LESSONS ?? "openai/gpt-5.2";
-
-const FALLBACK_MODELS = [
-  "google/gemini-3.1-pro-preview",
-  "openai/gpt-5-mini",
-  "google/gemini-3-flash",
-  "anthropic/claude-sonnet-4.6",
-];
+const DEFAULT_MODEL = process.env.AI_MODEL_LANGUAGE_CHAPTER_LESSONS ?? "openai/gpt-5.4";
+const FALLBACK_MODELS = ["google/gemini-3.1-pro-preview", "anthropic/claude-sonnet-4.6"];
 
 const schema = z.object({
   lessons: z.array(

--- a/packages/ai/src/tasks/courses/alternative-titles.ts
+++ b/packages/ai/src/tasks/courses/alternative-titles.ts
@@ -4,14 +4,8 @@ import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./alternative-titles.prompt.md";
 
-const DEFAULT_MODEL = process.env.AI_MODEL_ALTERNATIVE_TITLES || "openai/gpt-5.2";
-
-const FALLBACK_MODELS = [
-  "openai/gpt-5-mini",
-  "anthropic/claude-opus-4.6",
-  "anthropic/claude-sonnet-4.6",
-  "google/gemini-3.1-pro-preview",
-];
+const DEFAULT_MODEL = process.env.AI_MODEL_ALTERNATIVE_TITLES || "openai/gpt-5.4";
+const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"];
 
 const schema = z.object({
   alternatives: z.array(z.string()),

--- a/packages/ai/src/tasks/courses/course-categories.ts
+++ b/packages/ai/src/tasks/courses/course-categories.ts
@@ -6,14 +6,7 @@ import { type ReasoningEffort, buildProviderOptions } from "../../provider-optio
 import promptTemplate from "./course-categories.prompt.md";
 
 const DEFAULT_MODEL = process.env.AI_MODEL_COURSE_CATEGORIES ?? "google/gemini-3-flash";
-
-const FALLBACK_MODELS = [
-  "meta/llama-4-scout",
-  "google/gemini-2.5-flash-lite",
-  "xai/grok-4-fast-reasoning",
-  "google/gemini-2.5-flash",
-  "openai/gpt-4.1-mini",
-];
+const FALLBACK_MODELS = ["meta/llama-4-scout", "xai/grok-4-fast-reasoning", "openai/gpt-4.1-mini"];
 
 /**
  * Categories available for AI assignment.

--- a/packages/ai/src/tasks/courses/course-chapters.ts
+++ b/packages/ai/src/tasks/courses/course-chapters.ts
@@ -5,14 +5,7 @@ import { type ReasoningEffort, buildProviderOptions } from "../../provider-optio
 import systemPrompt from "./course-chapters.prompt.md";
 
 const DEFAULT_MODEL = process.env.AI_MODEL_COURSE_CHAPTERS ?? "openai/gpt-5.2";
-
-const FALLBACK_MODELS = [
-  "openai/gpt-5",
-  "anthropic/claude-opus-4.6",
-  "openai/gpt-5-mini",
-  "anthropic/claude-sonnet-4.6",
-  "google/gemini-3.1-pro-preview",
-];
+const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"];
 
 const DEFAULT_REASONING_EFFORT: ReasoningEffort = "high";
 

--- a/packages/ai/src/tasks/courses/course-description.ts
+++ b/packages/ai/src/tasks/courses/course-description.ts
@@ -5,14 +5,7 @@ import { type ReasoningEffort, buildProviderOptions } from "../../provider-optio
 import systemPrompt from "./course-description.prompt.md";
 
 const DEFAULT_MODEL = process.env.AI_MODEL_COURSE_DESCRIPTION || "xai/grok-4-fast-reasoning";
-
-const FALLBACK_MODELS = [
-  "google/gemini-2.5-flash",
-  "google/gemini-3-flash",
-  "openai/gpt-4.1-nano",
-  "openai/gpt-oss-120b",
-  "meta/llama-4-scout",
-];
+const FALLBACK_MODELS = ["google/gemini-3-flash", "openai/gpt-4.1-nano", "meta/llama-4-scout"];
 
 const schema = z.object({
   description: z.string(),

--- a/packages/ai/src/tasks/courses/course-suggestions.ts
+++ b/packages/ai/src/tasks/courses/course-suggestions.ts
@@ -5,13 +5,7 @@ import { type ReasoningEffort, buildProviderOptions } from "../../provider-optio
 import systemPrompt from "./course-suggestions.prompt.md";
 
 const DEFAULT_MODEL = process.env.AI_MODEL_COURSE_SUGGESTIONS || "google/gemini-3-flash";
-
-const FALLBACK_MODELS = [
-  "openai/gpt-5-mini",
-  "openai/gpt-5.1-instant",
-  "google/gemini-3.1-pro-preview",
-  "openai/gpt-5.2",
-];
+const FALLBACK_MODELS = ["openai/gpt-5-mini"];
 
 const schema = z.object({
   courses: z.array(

--- a/packages/ai/src/tasks/courses/language-course-chapters.ts
+++ b/packages/ai/src/tasks/courses/language-course-chapters.ts
@@ -6,13 +6,7 @@ import { type ReasoningEffort, buildProviderOptions } from "../../provider-optio
 import systemPrompt from "./language-course-chapters.prompt.md";
 
 const DEFAULT_MODEL = process.env.AI_MODEL_LANGUAGE_COURSE_CHAPTERS ?? "openai/gpt-5.2";
-
-const FALLBACK_MODELS = [
-  "google/gemini-3.1-pro-preview",
-  "anthropic/claude-sonnet-4.6",
-  "google/gemini-3-flash",
-  "anthropic/claude-opus-4.6",
-];
+const FALLBACK_MODELS = ["google/gemini-3.1-pro-preview", "anthropic/claude-sonnet-4.6"];
 
 const schema = z.object({
   chapters: z.array(

--- a/packages/ai/src/tasks/lessons/lesson-activities.ts
+++ b/packages/ai/src/tasks/lessons/lesson-activities.ts
@@ -5,14 +5,7 @@ import { type ReasoningEffort, buildProviderOptions } from "../../provider-optio
 import systemPrompt from "./lesson-activities.prompt.md";
 
 const DEFAULT_MODEL = process.env.AI_MODEL_LESSON_ACTIVITIES ?? "openai/gpt-5.2";
-
-const FALLBACK_MODELS = [
-  "openai/gpt-5-mini",
-  "anthropic/claude-haiku-4.5",
-  "openai/gpt-5.1-instant",
-  "anthropic/claude-opus-4.5",
-  "google/gemini-3-flash",
-];
+const FALLBACK_MODELS = ["anthropic/claude-opus-4.5", "google/gemini-3-flash"];
 
 const schema = z.object({
   activities: z.array(

--- a/packages/ai/src/tasks/steps/step-visual.ts
+++ b/packages/ai/src/tasks/steps/step-visual.ts
@@ -4,16 +4,8 @@ import { type ReasoningEffort, buildProviderOptions } from "../../provider-optio
 import { type StepVisualResource, visualTools } from "./_tools/visual";
 import systemPrompt from "./step-visual.prompt.md";
 
-const DEFAULT_MODEL = process.env.AI_MODEL_STEP_VISUAL ?? "google/gemini-3-flash";
-
-const FALLBACK_MODELS = [
-  "openai/gpt-5.2",
-  "anthropic/claude-haiku-4.5",
-  "openai/gpt-5-mini",
-  "anthropic/claude-sonnet-4.5",
-  "anthropic/claude-opus-4.5",
-  "google/gemini-3.1-pro-preview",
-];
+const DEFAULT_MODEL = process.env.AI_MODEL_STEP_VISUAL ?? "openai/gpt-5.4";
+const FALLBACK_MODELS = ["anthropic/claude-opus-4.5"];
 
 export type StepVisualSchema = {
   visuals: StepVisualResource[];


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized default and fallback LLM models across tasks to improve reliability and simplify routing, promoting `openai/gpt-5.4` where appropriate and trimming fallback lists to 1–2 high-availability options.

- **Refactors**
  - Promoted default to `openai/gpt-5.4` for core activities, language chapter lessons, course alternative titles, and step visuals.
  - Aligned fallbacks to focused pairs like `google/gemini-3.1-pro-preview`, `anthropic/claude-opus-4.6`, `anthropic/claude-sonnet-4.6`, or `google/gemini-3-flash`.
  - Removed older/low-priority options (e.g., `openai/gpt-5-mini`, various `-4.5` where possible) and reduced fallback arrays across tasks to 1–2 entries.

- **Migration**
  - No action needed. If you require prior behavior, set the relevant `AI_MODEL_*` env var for that task.

<sup>Written for commit 9187c54458596dff1a5dfd51e5b59d84e7de3000. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

