### PR TITLE
fix(main): correct custom activity numbering

### DIFF
--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -76,6 +76,64 @@ async function createTestLessonWithActivities() {
   };
 }
 
+async function createTestCustomLessonWithActivities() {
+  const org = await getAiOrganization();
+
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-custom-course-${uniqueId}`,
+    title: `E2E Custom Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-custom-chapter-${uniqueId}`,
+    title: `E2E Custom Chapter ${uniqueId}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    description: `E2E custom lesson description ${uniqueId}`,
+    isPublished: true,
+    kind: "custom",
+    organizationId: org.id,
+    slug: `e2e-custom-lesson-${uniqueId}`,
+    title: `E2E Custom Lesson ${uniqueId}`,
+  });
+
+  const firstActivity = await activityFixture({
+    description: `First custom activity ${uniqueId}`,
+    isPublished: true,
+    kind: "custom",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 0,
+    title: `First custom activity ${uniqueId}`,
+  });
+
+  const secondActivity = await activityFixture({
+    description: `Second custom activity ${uniqueId}`,
+    isPublished: true,
+    kind: "custom",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 1,
+    title: `Second custom activity ${uniqueId}`,
+  });
+
+  return {
+    activities: { firstActivity, secondActivity },
+    chapter,
+    course,
+    lesson,
+  };
+}
+
 test.describe("Lesson Detail Page", () => {
   test("shows lesson content with title, description, and position", async ({ page }) => {
     const { chapter, course, lesson } = await createTestLessonWithActivities();
@@ -140,6 +198,25 @@ test.describe("Lesson Detail Page", () => {
     await expect(activityList.getByRole("link", { name: /explanation/i })).toBeVisible();
     await expect(activityList.getByRole("link", { name: /quiz/i })).toBeVisible();
     await expect(activityList.getByRole("link", { name: /challenge/i })).toBeVisible();
+  });
+
+  test("displays custom activity numbers from zero-based positions", async ({ page }) => {
+    const { activities, chapter, course, lesson } = await createTestCustomLessonWithActivities();
+
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+
+    const activityList = page.getByRole("list", { name: /activities/i });
+    const firstActivityLink = activityList.getByRole("link", {
+      name: new RegExp(activities.firstActivity.title ?? "", "i"),
+    });
+    const secondActivityLink = activityList.getByRole("link", {
+      name: new RegExp(activities.secondActivity.title ?? "", "i"),
+    });
+
+    await expect(firstActivityLink).toContainText("01");
+    await expect(secondActivityLink).toContainText("02");
+    await expect(firstActivityLink).toHaveAttribute("href", /\/a\/0$/);
+    await expect(secondActivityLink).toHaveAttribute("href", /\/a\/1$/);
   });
 
   test("clicking activity link navigates to activity page", async ({ page }) => {

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
@@ -48,9 +48,7 @@ export async function ActivityList({
               key={String(activity.id)}
               prefetch={activity.generationStatus === "completed"}
             >
-              <CatalogListItemPosition>
-                {formatPosition(activity.position + 1)}
-              </CatalogListItemPosition>
+              <CatalogListItemPosition>{formatPosition(activity.position)}</CatalogListItemPosition>
 
               <CatalogListItemContent>
                 <CatalogListItemTitle>{activity.title}</CatalogListItemTitle>


### PR DESCRIPTION
fix(main): correct custom activity numbering

Fix custom lesson activity numbering by formatting zero-based positions once in the catalog list and add an e2e regression test for the lesson page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes custom lesson activity numbering by formatting zero‑based positions in the activity list. Ensures labels like 01, 02 match zero-based routes.

- **Bug Fixes**
  - Render with `formatPosition(activity.position)` in `activity-list.tsx`.
  - Add e2e test to verify numbers and hrefs for custom lessons.

<sup>Written for commit af68423a08c1534fb814b8d71ad24497d2155975. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

