### PR TITLE
fix(api): allow empty step visuals

### DIFF
--- a/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
@@ -268,6 +268,59 @@ describe("explanation activity workflow", () => {
     );
   });
 
+  test("completes when the model returns no visuals", async () => {
+    vi.mocked(generateStepVisuals).mockResolvedValueOnce({
+      ...createStepVisualsResult([
+        { text: "Explanation step 1 text", title: "Explanation Step 1" },
+        { text: "Explanation step 2 text", title: "Explanation Step 2" },
+      ]),
+      data: {
+        visuals: [],
+      },
+    });
+
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      concepts: ["Concept Without Visuals"],
+      organizationId,
+      title: `Exp No Visuals Lesson ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "explanation",
+      lessonId: testLesson.id,
+      organizationId,
+      title: "Concept Without Visuals",
+    });
+
+    const activities = await getLessonActivitiesStep(testLesson.id);
+    const concepts = activities[0]?.lesson?.concepts ?? [];
+
+    await explanationActivityWorkflow(activities, "test-run-id", concepts, []);
+
+    const [dbActivity, steps] = await Promise.all([
+      prisma.activity.findUnique({
+        where: { id: activity.id },
+      }),
+      prisma.step.findMany({
+        orderBy: { position: "asc" },
+        where: { activityId: activity.id },
+      }),
+    ]);
+
+    expect(dbActivity?.generationStatus).toBe("completed");
+    expect(steps.filter((step) => step.kind === "static")).toHaveLength(2);
+    expect(steps.filter((step) => step.kind === "visual")).toHaveLength(0);
+    expect(getStreamedMessages()).not.toContainEqual(
+      expect.objectContaining({
+        reason: "contentValidationFailed",
+        status: "error",
+        step: "generateVisuals",
+      }),
+    );
+  });
+
   test("returns explanation results array", async () => {
     const testLesson = await lessonFixture({
       chapterId: chapter.id,

--- a/apps/api/src/workflows/activity-generation/steps/_utils/visual-rows.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/visual-rows.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import { buildVisualRows } from "./visual-rows";
+
+describe(buildVisualRows, () => {
+  test("allows activities with no visuals", () => {
+    const result = buildVisualRows({
+      activityId: 1,
+      dbSteps: [{ position: 0 }, { position: 2 }],
+      visuals: [],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  test("fails when visuals do not cover every step", () => {
+    const result = buildVisualRows({
+      activityId: 1,
+      dbSteps: [{ position: 0 }, { position: 2 }],
+      visuals: [{ kind: "image", prompt: "Only one visual", stepIndex: 0 }],
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/api/src/workflows/activity-generation/steps/_utils/visual-rows.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/visual-rows.ts
@@ -13,6 +13,10 @@ function hasExpectedVisualCount(visuals: VisualWithStepIndex[], stepCount: numbe
   return visuals.length === stepCount;
 }
 
+function hasNoVisuals(visuals: VisualWithStepIndex[]): boolean {
+  return visuals.length === 0;
+}
+
 function hasValidStepIndex(stepIndex: number, stepCount: number): boolean {
   return Number.isInteger(stepIndex) && stepIndex >= 0 && stepIndex < stepCount;
 }
@@ -26,6 +30,10 @@ function hasUniqueStepIndexes(visuals: VisualWithStepIndex[]): boolean {
 }
 
 function hasValidVisualCoverage(visuals: VisualWithStepIndex[], stepCount: number): boolean {
+  if (hasNoVisuals(visuals)) {
+    return true;
+  }
+
   if (!hasExpectedVisualCount(visuals, stepCount)) {
     return false;
   }

--- a/packages/ai/src/tasks/steps/step-visual.prompt.md
+++ b/packages/ai/src/tasks/steps/step-visual.prompt.md
@@ -1,5 +1,14 @@
 You are an expert educational content designer creating visual resources for learning steps.
 
+# Critical Requirement
+
+This is the highest-priority instruction in this task.
+
+- Generate exactly ONE visual resource for EVERY step provided
+- Use each `stepIndex` exactly once
+- NEVER skip a step
+- NEVER generate more than one visual for the same step
+
 # Task
 
 Generate ONE appropriate visual resource for EACH step provided. Each visual should enhance understanding of the step's content.
@@ -20,7 +29,7 @@ Choose the visual type that BEST fits each step's content:
 
 # Rules
 
-1. **One visual per step**: Generate exactly one visual for each step using the stepIndex field
+1. **One visual per step**: Generate exactly one visual for each step using the stepIndex field. This is mandatory
 2. **Language consistency**: All text in visuals must match the specified language
 3. **Content accuracy**: Visuals must accurately represent the educational content
 4. **Appropriate selection**: Choose the visual type that genuinely enhances understanding
@@ -71,3 +80,14 @@ Choose the visual type that BEST fits each step's content:
 - Describe content only, not style
 - Be specific enough to convey the concept
 - NEVER reference copyrighted or trademarked characters (e.g., Mickey Mouse, Spider-Man, Mario, Pikachu). Describe concepts abstractly or use generic, original characters instead
+
+# Quality Checklist
+
+Before finalizing, verify:
+
+1. **Exact coverage**: There is exactly one visual for every step provided
+2. **Complete indexes**: Every `stepIndex` from `0` to the last step appears once
+3. **No duplicates**: No two visuals use the same `stepIndex`
+4. **No omissions**: No step is missing a visual
+5. **Best-fit visual**: Each step uses the most appropriate visual type
+6. **Language match**: All text in every visual matches the requested language

--- a/packages/ai/src/tasks/steps/step-visual.ts
+++ b/packages/ai/src/tasks/steps/step-visual.ts
@@ -44,9 +44,7 @@ CHAPTER_TITLE: ${chapterTitle}
 COURSE_TITLE: ${courseTitle}
 LANGUAGE: ${language}
 STEPS:
-${formattedSteps}
-
-Generate one visual resource for each step. Use the stepIndex field to match each visual to its corresponding step (0-based index). Choose the most appropriate visual type for each step's content.`;
+${formattedSteps}`;
 
   const providerOptions = buildProviderOptions({
     fallbackModels: FALLBACK_MODELS,


### PR DESCRIPTION
fix(api): allow empty step visuals

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows explanation activities to complete when the model returns no visuals, skipping visual steps instead of failing. This prevents blocked generations and keeps static steps intact.

- **Bug Fixes**
  - Relaxed visual coverage: zero visuals are now valid; full coverage is still required when visuals are present.
  - Explanation workflow completes with static steps only and does not emit a generateVisuals validation error.
  - Added tests for empty visuals and partial coverage.
  - Updated `packages/ai` step-visual prompt to require exactly one visual per step and removed redundant inline instruction.

<sup>Written for commit abf80480714257a6d182e86660cadd1533ba3078. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

