### PR TITLE
fix(ai): improve explanation prompt tone

### DIFF
--- a/apps/evals/src/tasks/activity-explanation/test-cases.ts
+++ b/apps/evals/src/tasks/activity-explanation/test-cases.ts
@@ -9,11 +9,13 @@ EVALUATION CRITERIA:
 
 4. FORMAT: Each step must have a title (max 50 chars) and text (max 300 chars).
 
-5. TONE: Conversational, like explaining to a curious friend. Include analogies from everyday life.
+5. TONE: Conversational, warm, and plainspoken, like an expert explaining to a complete beginner. It should feel human and friendly, not academic.
 
-6. FOCUS: Explains WHAT something IS, not history or origin stories.
+6. CONCRETE CLARITY: Explanations should start concrete and objective, then use well-chosen comparisons, mini-scenarios, or analogies when they help.
 
-7. SCOPE: Content matches the lesson scope exactly.
+7. FOCUS: Explains WHAT something IS, not history or origin stories.
+
+8. SCOPE: Content matches the lesson scope exactly.
 
 ANTI-CHECKLIST GUIDANCE (CRITICAL):
 - Do NOT penalize for missing components, phases, or concepts you might expect
@@ -21,7 +23,9 @@ ANTI-CHECKLIST GUIDANCE (CRITICAL):
 - Do NOT check against an imagined "complete" explanation
 - Do NOT penalize for output format or structure (e.g., JSON wrapping, key names, array nesting). We use structured outputs, so focus exclusively on content quality
 - Do NOT penalize for the ordering of explanation steps. Different valid structures and sequences exist
-- ONLY penalize for: factual errors, superficial treatment of complex topics, not using the conversational tone (everyday language) we asked or poor explanation structure
+- Do NOT require a specific number of analogies or comparisons
+- Penalize if the explanation reads like lecture notes, uses only one weak throwaway analogy, swings back to an analogy in nearly every step, or relies on canned explainer phrases that do not sound like real speech
+- ONLY penalize for: factual errors, superficial treatment of complex topics, not using the warm/conversational tone we asked for, canned or robotic phrasing, weak or unhelpful concrete comparisons, or poor explanation structure
 - Different valid explanatory approaches exist - assess the quality of what IS provided
 `;
 

--- a/packages/ai/src/tasks/activities/core/activity-explanation.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-explanation.prompt.md
@@ -4,9 +4,11 @@ You are an expert instructional designer creating an **Explanation** activity fo
 
 You specialize in transforming complex theoretical ideas into clear, engaging explanations that help learners truly understand what something IS and how it functions.
 
+Write like a knowledgeable expert talking to a complete beginner with zero background. Think: how a great teacher, engineer, doctor, lawyer, or craftsperson would explain something to a curious grandparent, teenager, or friend who keeps saying, "Wait, what does that actually mean?"
+
 # The Art of Conceptual Explanation
 
-A great Explanation activity doesn't just define terms — it builds understanding layer by layer. Think of it like being a guide who helps someone see a new city: you point out landmarks, explain how neighborhoods connect, and help them build a mental map.
+A great Explanation activity doesn't just define terms — it builds understanding layer by layer. It should feel less like a textbook and more like a patient conversation where an expert keeps turning abstract ideas into something the learner can picture.
 
 ## Why Layered Explanation Works
 
@@ -20,10 +22,10 @@ A great Explanation activity doesn't just define terms — it builds understandi
 
 Every great Explanation follows a concept-building arc:
 
-- **Core Definition**: What is this thing in the simplest, most objective terms? Be precise and clear — no metaphors yet.
+- **Plain-Language Definition**: What is this thing in the simplest, most objective terms? Be precise and clear first.
 - **Components**: What parts or elements make up this concept?
 - **Relationships**: How do these parts connect or interact?
-- **Everyday Analogy**: Bridge the abstract to the concrete with a relatable comparison from daily life — cooking, sports, games, music, etc. This is where "think of it like..." makes the concept click.
+- **Concrete Comparisons**: Use relatable comparisons or mini-scenarios from daily life when they genuinely make the idea easier to picture.
 - **Real-World Connection**: Where does this show up in practice?
 
 ## Why Short Steps Work
@@ -62,10 +64,32 @@ Each step must have:
 
 ## Tone & Style
 
-- **Conversational**: Write as if explaining to a curious friend who genuinely wants to understand
-- **Layered depth**: Start with clear, objective definitions. Then use analogies from everyday life (sports, cooking, games, music, travel, etc) to deepen understanding — "think of it like..." bridges the abstract and concrete after the foundation is set
-- **Clarifying**: Focus on making things click — use "think of it like..." and "imagine..." to bridge the abstract and concrete
+- **Conversational throughout**: The whole activity should sound like a human explanation, not like lecture notes with one friendly line at the end
+- **Warm expert voice**: Sound like a patient expert helping a beginner feel oriented, not judged
+- **Concrete first**: Start with a clear, objective explanation in plain language before introducing comparisons
+- **Helpful comparisons**: Use 1-3 analogies, comparisons, or mini-scenarios across the activity when they genuinely clarify the idea. More than one is often useful, but do NOT force one into every step
+- **Different jobs for different comparisons**: If you use more than one comparison, each should explain a different aspect of the concept instead of repeating the same point
+- **Natural phrasing**: Sound like real speech. Prefer natural sentence rhythm and contractions when they fit the language
 - **Encouraging**: Make the learner feel capable of understanding, not overwhelmed
+
+## Tone Examples
+
+Aim for this kind of voice. These are examples of natural phrasing, not templates to copy:
+
+- "Basically, this is..."
+- "What’s happening here is..."
+- "A simple way to picture it is..."
+- "The confusing part is usually..."
+- "You’ve probably seen this when..."
+
+Do NOT sound like this:
+
+- "At the simplest level, this is..."
+- "The key idea is..."
+- "This concept refers to..."
+- "It is important to note that..."
+- "The learner should understand..."
+- "This activity explains..."
 
 ## What to Avoid
 
@@ -74,6 +98,11 @@ Each step must have:
 - Technical jargon without explanation
 - Diving into "how to do it" (that's for practice activities)
 - Generic statements that could apply to any topic
+- Saving all warmth for a single analogy step at the end
+- Forcing an analogy into every step
+- Using one weak analogy and treating the job as done
+- Canned tutorial phrases that sound prewritten or robotic
+- Academic, formal, or overly abstract phrasing
 - Starting with "In this activity..." or similar meta-commentary
 
 ## Scope
@@ -97,7 +126,7 @@ While every topic is unique, most Explanation activities touch on these themes (
 1. **The Core Idea**: What is this in plain, precise language? No analogies — just clarity.
 2. **The Key Components**: What are the essential parts or elements?
 3. **How Parts Connect**: How do these elements work together?
-4. **The Everyday Analogy**: Make it click with a relatable comparison from daily life — "think of it like..." bridges the abstract and concrete.
+4. **Concrete Comparison Moments**: Add one or more well-chosen comparisons or mini-scenarios wherever they help, instead of saving all analogy work for a single isolated step.
 5. **Real-World Connection**: Where does this show up in practice? What problems does it solve?
 6. **Common Confusions**: What do people often misunderstand?
 7. **The "So What"**: Why does understanding this matter?
@@ -110,7 +139,9 @@ Before finalizing, verify:
 
 - [ ] Does the explanation start with the core concept in accessible language?
 - [ ] Does each step build on the previous one to deepen understanding?
-- [ ] Is there an everyday analogy that makes the concept click?
+- [ ] Does the explanation feel warm, friendly, and easy to follow from the first step?
+- [ ] Are there one or more concrete comparisons or mini-scenarios where they genuinely help?
+- [ ] Do the comparisons strengthen understanding without taking over every step?
 - [ ] Does the learner end up able to explain this concept in their own words?
 - [ ] Is there NO overlap with NEIGHBORING_CONCEPTS?
 - [ ] Are there real-world connections showing where this concept appears in practice?


### PR DESCRIPTION
Improve the explanation activity prompt so it sounds more like a patient expert talking to a complete beginner.

Align the eval rubric with the updated tone, phrasing, and comparison expectations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Explanation activity prompt sound like a warm, patient expert guiding a complete beginner. Align the eval rubric to reward concrete-first clarity and helpful, natural comparisons.

- **Refactors**
  - Rewrote `packages/ai/src/tasks/activities/core/activity-explanation.prompt.md` to start concrete, use a warm conversational voice, add natural phrasing examples, and guide 1–3 targeted comparisons instead of a single forced analogy.
  - Updated `apps/evals/src/tasks/activity-explanation/test-cases.ts` to match: clarified tone expectations, emphasized concrete-first clarity, discouraged canned/robotic phrasing, and refined penalties for weak or overused analogies.

<sup>Written for commit 166218e28e631cca8f9ea48a02c864eb8bdbbee3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

