### PR TITLE
fix(ai): make chapters more focused on course subject

### DIFF
--- a/apps/evals/src/tasks/course-chapters/test-cases.ts
+++ b/apps/evals/src/tasks/course-chapters/test-cases.ts
@@ -1,16 +1,18 @@
 const SHARED_EXPECTATIONS = `
   - It should assume learners start with no prior knowledge of the subject
-  - Should create a progressive learning path going from basic/beginner to mastery of the subject
-  - By the end of this course, they should be able to lead very complex projects and tasks in this field
-  - They should be prepared for certifications or advanced studies in this subject like a master's degree or PhD
-  - Should include **EVERYTHING** a student needs to be at the top 1% of the field
+  - Should create a progressive learning path going from beginner foundations to deep mastery of the subject
+  - Should stay tightly focused on the course title instead of drifting into generic academic or professional content
+  - Early chapters should cover canonical topics learners would reasonably expect from the course title
+  - Should include the essential knowledge and practical skills needed to become highly capable in the field
   - Should follow the language specified by language parameter
   - Should follow title and description guidelines: no fluff, be concise, straight to the point
-  - Should cover latest trends in the field
+  - Should keep the curriculum modern and relevant without replacing canonical foundations with trends
+  - If supporting topics like research methods, communication, statistics, ethics, regulation, or career are included, they should be clearly scoped to the course title rather than generic
+  - Generic cross-disciplinary chapters that could be copied unchanged into many different courses are a major error unless they are explicitly the subject of the course
   - Prefer concept names over vendor names in chapter titles/descriptions (e.g., "Package management" instead of "npm"). Ecosystem-level tools (npm, yarn, Redux, Zustand) should be avoided in titles
     - Exception: foundational tools that ARE the course subject matter are allowed (e.g., "Git" in a programming course, "Node.js" in a web dev course, "Docker" in a DevOps course). The test: would a chapter about this subject be incomplete without mentioning this tool?
     - Vendor name usage is a minor issue — it affects title quality but not pedagogical content. Do NOT treat it as a major error
-  - This is an eval system for a learning platform, of course the definition of "ready for a job" doesn't mean they have the legal requirements to work in the field (eg. medical license, law license, etc.). That's not important here, we're assessing if the course prepares the student with the necessary knowledge and skills.
+  - For professional fields, practical readiness refers to knowledge and skills, not legal licenses or credentials. That's not important here
   - You don't need to evaluate the output format here, just focus on the chapter content quality.
   - Titles should be concise and straight to the point, no fluff/filler words. For example:
     - Just "HTML" is better than "HTML Structure and Semantics" (structure and semantics are implied if this is the only HTML chapter). Similarly, if we only have one CSS chapter, just "CSS" is better than "CSS Styling and Layout".
@@ -23,7 +25,7 @@ const SHARED_EXPECTATIONS = `
     - "Styling with CSS: Selectors, properties, the box model, Flexbox, CSS Grid, and cascade principles." is better than "Master styling and layout with CSS, including selectors, properties, the box model, Flexbox, CSS Grid, and cascade principles." - "Master" is fluff, and so are words like "learn", "understand", "explore", etc.
     - "Properties of matter, states, and phase transitions." is better than "Explore the definition of Chemistry, properties of matter, states, and phase transitions." - "Explore the definition of Chemistry" are filler/unnecessary words.
   - Don't add assessment-style chapters: no final projects, capstone assignments, exercises, quizzes, or "test your knowledge" chapters. A theoretical synthesis chapter (e.g., "Design Patterns in Architecture") is fine even if it synthesizes prior material — the rule targets assessment/project chapters, not synthesis of knowledge. If a chapter uses the word "capstone" but is theoretical (not an assignment), treat it as a minor issue at most, not a major error
-  - It shouldn't mention in title or description references to 1% or similar instructions about being top 1%
+  - It shouldn't mention in title or description prompt instructions or performance claims about the learner
 `;
 
 export const TEST_CASES = [
@@ -68,6 +70,17 @@ export const TEST_CASES = [
   },
   {
     expectations: `
+      - MUST be in Brazilian Portuguese
+      - The opening chapters should feel unmistakably like biology, with canonical foundations such as cells, biomolecules, genetics, evolution, physiology, ecology, or other core biology topics
+      - Generic titles like "Pensamento científico", "prática de pesquisa", "literatura científica", or "comunicação acadêmica" do not belong unless they are explicitly scoped to biology and are not the main opening focus
+
+      ${SHARED_EXPECTATIONS}
+    `,
+    id: "pt-biologia",
+    userInput: { courseTitle: "Biologia", language: "pt" },
+  },
+  {
+    expectations: `
       - MUST be in US English
 
       ${SHARED_EXPECTATIONS}
@@ -83,6 +96,17 @@ export const TEST_CASES = [
     `,
     id: "pt-neurociencia",
     userInput: { courseTitle: "Neurociência", language: "pt" },
+  },
+  {
+    expectations: `
+      - MUST be in Brazilian Portuguese
+      - Should cover core computer science areas such as computation, programming, data structures, algorithms, systems, data, or AI
+      - Should stay focused on computer science itself rather than generic professional advice
+
+      ${SHARED_EXPECTATIONS}
+    `,
+    id: "pt-ciencia-da-computacao",
+    userInput: { courseTitle: "Ciência da Computação", language: "pt" },
   },
   {
     expectations: `

--- a/packages/ai/src/tasks/chapters/chapter-lessons.ts
+++ b/packages/ai/src/tasks/chapters/chapter-lessons.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./chapter-lessons.prompt.md";
 
-const DEFAULT_MODEL = process.env.AI_MODEL_CHAPTER_LESSONS ?? "openai/gpt-5.2";
+const DEFAULT_MODEL = process.env.AI_MODEL_CHAPTER_LESSONS ?? "openai/gpt-5.4";
 const FALLBACK_MODELS = ["anthropic/claude-opus-4.6"];
 
 const schema = z.object({

--- a/packages/ai/src/tasks/courses/course-chapters.prompt.md
+++ b/packages/ai/src/tasks/courses/course-chapters.prompt.md
@@ -1,12 +1,12 @@
 # Role
 
-You are designing a **comprehensive** course curriculum to help learners go from no knowledge to mastery of a subject.
+You are designing a course curriculum that helps learners go from no knowledge to deep mastery of a subject.
 
-You have expertise in instructional design, curriculum development, and subject matter expertise in various professional fields. You have worked at top educational institutions and corporate training programs, creating curricula that prepare learners for real-world job performance.
+You have expertise in instructional design, curriculum development, and subject matter expertise in various professional fields.
 
-Your mission is to create a curriculum that fully equips learners to be at the **top 1%** in their field, ready to lead complex projects at top companies and organizations.
+Your mission is to create a curriculum that is accurate, focused, complete, and genuinely useful for someone who wants to master `COURSE_TITLE`.
 
-You deeply care about quality education and are committed to producing content that is up-to-date, relevant, and aligned with industry standards.
+You deeply care about quality education and are committed to producing content that is relevant, well-structured, and tightly aligned with the course topic.
 
 # Inputs
 
@@ -21,25 +21,27 @@ You deeply care about quality education and are committed to producing content t
 
 # Goal
 
-Produce a **complete**, **extensive**, and **comprehensive** set of chapters that teaches **everything** needed to be at the **top 1%** in `COURSE_TITLE`. After finishing this course, learners should be able to lead very complex projects and tasks in this field. They should also be prepared for certifications or advanced studies in this subject like a PhD.
+Produce a complete set of chapters that teaches everything essential to master `COURSE_TITLE`.
 
-It should cover everything needed to land a job at top firms in this field.
+The curriculum should make the learner highly capable in the subject itself. For professional fields, it should also prepare them for serious practical work and later specialization. Focus on mastery of the topic, not generic academic training around the topic, unless the course title explicitly asks for that.
 
 # Requirements
 
-- Cover all **knowledge and practical skills** required for going from no knowledge to mastery.
-- Include **as many chapters as needed**. Do not limit the number of chapters arbitrarily.
-- Order from **foundational concepts** to **job-ready skills** to **advanced applications and concepts**, following a logical progression building upon previous chapters.
+- Cover all **knowledge and practical skills** required for going from no knowledge to deep mastery.
+- Include **as many chapters as needed**. Do not limit the number of chapters arbitrarily, but do not pad the curriculum with generic material.
+- Order from **foundational and canonical topics** to **intermediate applications** to **advanced and specialized topics**, following a logical progression building upon previous chapters.
+- Start with the topics a learner would reasonably expect from `COURSE_TITLE`.
+- Every chapter must be clearly about `COURSE_TITLE`. If a chapter title could be copied unchanged into many unrelated courses, it probably does not belong here.
+- Avoid generic cross-disciplinary chapters that are not specific to the course title, such as "Scientific Thinking", "Academic Writing", "Literature Review", "Communication Skills", or "Career Development".
+- If supporting topics like research methods, statistics, ethics, regulation, tools, or career paths are truly important, scope them explicitly to `COURSE_TITLE` in both the title and description.
+- For broad academic subjects such as biology, chemistry, economics, history, or psychology, primarily teach the field itself rather than how academics study the field.
 - Write **clear, concise** text in the specified `LANGUAGE` input.
 - Avoid fluff/fillers/unnecessary words.
-- Should be **up-to-date**, **modern**, and cover the **latest trends** in this field.
+- Keep the curriculum **modern and relevant**, but do not sacrifice canonical foundations for trends.
 - No assessments, projects, or capstones.
 - For hobbies, pop culture, or non-professional topics, you don't need to focus on job readiness. Instead, focus on comprehensive coverage of the topic.
-- Add at least one chapter covering how to start a career in this field, except for courses where this is not applicable (e.g., hobbies, pop culture, non-professional topics, etc.).
-- Cover **everything** they need to be at the top 1% in this field. This is very important.
-- Don't mention prompt instructions (like "top 1%") in the chapter titles or descriptions.
-
-Build a curriculum that would make hiring managers excited to hire someone who completed it. A person completing this course should have all knowledge to be the "Einstein" of this field.
+- Career chapters are optional. Include them only when they are genuinely useful and can be clearly specific to `COURSE_TITLE`.
+- Don't mention prompt instructions such as "mastery" in the chapter titles or descriptions.
 
 ## Hobbies, Pop Culture, Non-Professional Topics
 
@@ -68,7 +70,7 @@ Be **vendor neutral** unless the field has widely accepted standards (then name 
 
 # Scope & Granularity Guidelines
 
-- Prefer **practical, job-linked** chapter scopes (e.g., "Forms & Validation" rather than "Advanced Miscellaneous").
+- Prefer **concrete, course-linked** chapter scopes (e.g., "Forms & Validation" rather than "Advanced Miscellaneous").
 - Where the field spans multiple modalities (e.g., theory + tools + ops), make that explicit with separate chapters.
 - Where safety or compliance applies, include a dedicated chapter.
 - Where performance, reliability, or scalability matters, include a dedicated chapter.
@@ -90,6 +92,8 @@ Good chapter titles include:
 - Just "HTML" is better than "HTML Structure and Semantics" (structure and semantics are implied if this is the only HTML chapter).
 - "Lean Startup" is better than "The Lean Startup Methodology: An Overview" (too verbose)
 
+Avoid generic titles that could belong to many unrelated courses unless they are explicitly the course subject. For example, "Scientific Thinking", "Academic Communication", or "Career Development" are usually too generic for a course about biology, chemistry, or psychology.
+
 **TIP:** Go straight to the point. Avoid verbose titles. If necessary, add details in the description instead.
 
 ### Description
@@ -106,10 +110,10 @@ Good chapter descriptions:
 
 Before finishing this course, review the entire content and ask yourself:
 
-- "Does this curriculum enable a learner to be at the **top 1%** in this field?" If the answer is "no," identify the gaps and add the necessary content to fill them.
+- "Does this curriculum stay tightly focused on `COURSE_TITLE`?" If the answer is "no," remove or rewrite the off-topic chapters.
+- "Do the opening chapters cover the canonical topics learners expect from `COURSE_TITLE`?" If the answer is "no," fix the order and coverage.
+- "Am I adding generic chapters that could fit many unrelated courses unchanged?" If the answer is "yes," remove them or scope them specifically to `COURSE_TITLE`.
 - "Am I missing any important chapters or topics?" If the answer is "yes," add them.
-- "Does this curriculum have enough depth?" for this learner to be at the top 1% in this field. If the answer is "no," add more depth to the chapters or add new chapters as needed.
+- "Does this curriculum have enough depth for real mastery of the subject?" If the answer is "no," add more depth to the chapters or add new chapters as needed.
 
-Make sure this is the **BEST** possible curriculum for this subject. No other curriculum should be able to surpass this one.
-
-It should be the most **complete**, **extensive**, and **comprehensive** curriculum available for this subject in the world, covering **EVERYTHING** needed to be at the top 1% in this field.
+Make sure this is a focused, complete, and high-quality curriculum for this subject.

--- a/packages/ai/src/tasks/courses/course-chapters.ts
+++ b/packages/ai/src/tasks/courses/course-chapters.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./course-chapters.prompt.md";
 
-const DEFAULT_MODEL = process.env.AI_MODEL_COURSE_CHAPTERS ?? "openai/gpt-5.2";
+const DEFAULT_MODEL = process.env.AI_MODEL_COURSE_CHAPTERS ?? "openai/gpt-5.4";
 const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"];
 
 const DEFAULT_REASONING_EFFORT: ReasoningEffort = "high";

--- a/packages/ai/src/tasks/courses/language-course-chapters.ts
+++ b/packages/ai/src/tasks/courses/language-course-chapters.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./language-course-chapters.prompt.md";
 
-const DEFAULT_MODEL = process.env.AI_MODEL_LANGUAGE_COURSE_CHAPTERS ?? "openai/gpt-5.2";
+const DEFAULT_MODEL = process.env.AI_MODEL_LANGUAGE_COURSE_CHAPTERS ?? "openai/gpt-5.4";
 const FALLBACK_MODELS = ["google/gemini-3.1-pro-preview", "anthropic/claude-sonnet-4.6"];
 
 const schema = z.object({

--- a/packages/ai/src/tasks/lessons/lesson-activities.ts
+++ b/packages/ai/src/tasks/lessons/lesson-activities.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./lesson-activities.prompt.md";
 
-const DEFAULT_MODEL = process.env.AI_MODEL_LESSON_ACTIVITIES ?? "openai/gpt-5.2";
+const DEFAULT_MODEL = process.env.AI_MODEL_LESSON_ACTIVITIES ?? "openai/gpt-5.4";
 const FALLBACK_MODELS = ["anthropic/claude-opus-4.5", "google/gemini-3-flash"];
 
 const schema = z.object({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Tightens course chapter generation to stay focused on the course subject and start with canonical foundations. Adds evals to prevent generic academic content and bumps defaults to `openai/gpt-5.4`.

- **Bug Fixes**
  - Reworked `course-chapters.prompt.md` to avoid generic cross-disciplinary chapters and scope supporting topics to the course title.
  - Emphasized canonical foundations and simple, concise wording; removed "top 1%" and similar claims.
  - Strengthened evals: updated shared expectations and added pt-BR cases for "Biologia" and "Ciência da Computação" to catch topic drift.

- **Dependencies**
  - Updated default models from `openai/gpt-5.2` to `openai/gpt-5.4` for chapters, language chapters, chapter lessons, and lesson activities.

<sup>Written for commit 79e080544d59ca3325b33182979983f952d11f68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

