### PR TITLE
fix(main): reset thinking message counter on phase switch

### DIFF
--- a/apps/main/src/lib/workflow/use-thinking-messages.test.ts
+++ b/apps/main/src/lib/workflow/use-thinking-messages.test.ts
@@ -1,12 +1,33 @@
 // @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useThinkingMessages } from "./use-thinking-messages";
+import { createCountingGenerator, useThinkingMessages } from "./use-thinking-messages";
 
-const generators = {
+const cyclingGenerators = {
   phaseA: (index: number) => ["Analyzing...", "Planning...", "Building..."][index % 3] ?? "",
   phaseB: (index: number) => ["Loading...", "Processing..."][index % 2] ?? "",
 };
+
+const countingGenerators = {
+  chapters: createCountingGenerator({
+    intro: ["Planning..."],
+    itemTemplate: (num) => `Chapter ${num}`,
+    reviewMessage: "Reviewing...",
+  }),
+  lessons: createCountingGenerator({
+    intro: ["Exploring..."],
+    itemTemplate: (num) => `Lesson ${num}`,
+    reviewMessage: "Reviewing...",
+  }),
+};
+
+function advanceTicks(count: number) {
+  Array.from({ length: count }).forEach(() => {
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+  });
+}
 
 describe(useThinkingMessages, () => {
   beforeEach(() => {
@@ -18,22 +39,26 @@ describe(useThinkingMessages, () => {
   });
 
   it("returns empty object when no phases are active", () => {
-    const { result } = renderHook(() => useThinkingMessages(generators, []));
+    const { result } = renderHook(() => useThinkingMessages(cyclingGenerators, []));
     expect(result.current).toEqual({});
   });
 
   it("returns first message immediately for active phases", () => {
-    const { result } = renderHook(() => useThinkingMessages(generators, ["phaseA"]));
+    const { result } = renderHook(() => useThinkingMessages(cyclingGenerators, ["phaseA"]));
     expect(result.current).toEqual({ phaseA: "Analyzing..." });
   });
 
   it("returns messages for multiple active phases simultaneously", () => {
-    const { result } = renderHook(() => useThinkingMessages(generators, ["phaseA", "phaseB"]));
+    const { result } = renderHook(() =>
+      useThinkingMessages(cyclingGenerators, ["phaseA", "phaseB"]),
+    );
     expect(result.current).toEqual({ phaseA: "Analyzing...", phaseB: "Loading..." });
   });
 
   it("cycles through messages over time", () => {
-    const { result } = renderHook(() => useThinkingMessages(generators, ["phaseA", "phaseB"]));
+    const { result } = renderHook(() =>
+      useThinkingMessages(cyclingGenerators, ["phaseA", "phaseB"]),
+    );
 
     expect(result.current).toEqual({ phaseA: "Analyzing...", phaseB: "Loading..." });
 
@@ -47,7 +72,7 @@ describe(useThinkingMessages, () => {
   it("uses randomized intervals between 1.5-3s", () => {
     vi.spyOn(Math, "random").mockReturnValue(0);
 
-    const { result } = renderHook(() => useThinkingMessages(generators, ["phaseA"]));
+    const { result } = renderHook(() => useThinkingMessages(cyclingGenerators, ["phaseA"]));
 
     expect(result.current).toEqual({ phaseA: "Analyzing..." });
 
@@ -68,7 +93,7 @@ describe(useThinkingMessages, () => {
 
   it("resets index when becoming inactive", () => {
     const { result, rerender } = renderHook(
-      ({ active }) => useThinkingMessages(generators, active),
+      ({ active }) => useThinkingMessages(cyclingGenerators, active),
       { initialProps: { active: ["phaseA"] as string[] } },
     );
 
@@ -83,5 +108,28 @@ describe(useThinkingMessages, () => {
 
     rerender({ active: ["phaseA"] });
     expect(result.current).toEqual({ phaseA: "Analyzing..." });
+  });
+
+  it("starts lesson numbering at 1 when switching from chapters phase", () => {
+    const { result, rerender } = renderHook(
+      ({ active }) => useThinkingMessages(countingGenerators, active),
+      { initialProps: { active: ["chapters"] as string[] } },
+    );
+
+    expect(result.current).toEqual({ chapters: "Planning..." });
+
+    advanceTicks(5);
+
+    expect(result.current.chapters).toMatch(/Chapter \d+/);
+
+    rerender({ active: ["lessons"] });
+
+    expect(result.current).toEqual({ lessons: "Exploring..." });
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(result.current).toEqual({ lessons: "Lesson 1" });
   });
 });

--- a/apps/main/src/lib/workflow/use-thinking-messages.ts
+++ b/apps/main/src/lib/workflow/use-thinking-messages.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useReducer, useRef } from "react";
 
 export type ThinkingMessageGenerator = (index: number) => string;
 
@@ -54,6 +54,28 @@ function getRandomInterval(): number {
   return MIN_INTERVAL + Math.random() * (MAX_INTERVAL - MIN_INTERVAL);
 }
 
+type ThinkingState = {
+  tick: number;
+  indices: Record<string, number>;
+};
+
+type ThinkingAction = { type: "advance"; phases: readonly string[] } | { type: "reset" };
+
+const INITIAL_STATE: ThinkingState = { indices: {}, tick: 0 };
+
+function thinkingReducer(state: ThinkingState, action: ThinkingAction): ThinkingState {
+  if (action.type === "reset") {
+    return INITIAL_STATE;
+  }
+
+  return {
+    indices: Object.fromEntries(
+      action.phases.map((phase) => [phase, (state.indices[phase] ?? 0) + 1]),
+    ),
+    tick: state.tick + 1,
+  };
+}
+
 /**
  * Cycles through contextual "thinking" messages at randomized intervals.
  * Each active phase gets its own independent message counter.
@@ -66,23 +88,26 @@ export function useThinkingMessages<TPhase extends string>(
   generators: Record<TPhase, ThinkingMessageGenerator>,
   activePhases: TPhase[],
 ): Record<string, string> {
-  const [index, setIndex] = useState(0);
+  const [state, dispatch] = useReducer(thinkingReducer, INITIAL_STATE);
+  const activePhasesRef = useRef(activePhases);
+  activePhasesRef.current = activePhases;
+
   const hasActive = activePhases.length > 0;
 
   useEffect(() => {
     if (!hasActive) {
-      setIndex(0);
+      dispatch({ type: "reset" });
       return;
     }
 
     const timeout = setTimeout(() => {
-      setIndex((prev) => prev + 1);
+      dispatch({ phases: activePhasesRef.current, type: "advance" });
     }, getRandomInterval());
 
     return () => {
       clearTimeout(timeout);
     };
-  }, [hasActive, index]);
+  }, [hasActive, state.tick]);
 
   if (!hasActive) {
     return {};
@@ -90,7 +115,7 @@ export function useThinkingMessages<TPhase extends string>(
 
   return Object.fromEntries(
     activePhases
-      .map((phase) => [phase, generators[phase]?.(index)] as const)
+      .map((phase) => [phase, generators[phase]?.(state.indices[phase] ?? 0)] as const)
       .filter(([, message]) => message !== undefined),
   );
 }


### PR DESCRIPTION
## Summary
- Thinking messages shared a single counter across all phases, so lesson numbering continued from chapter count (e.g. "Lesson 21" instead of "Lesson 1")
- Replace shared `useState(index)` with `useReducer` tracking per-phase indices that reset when a phase first becomes active
- Add test using `createCountingGenerator` to verify lesson numbering starts at 1 after chapters

## Test plan
- [x] Existing tests pass (369/369)
- [x] New test: "starts lesson numbering at 1 when switching from chapters phase"
- [x] `pnpm turbo quality:fix` clean
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes thinking message numbering so each phase has its own counter and resets on phase switch. Lessons now start at 1 after switching from chapters.

- **Bug Fixes**
  - Replaced shared counter with per-phase indices via useReducer; counters reset when phases deactivate and tick only for active phases.
  - Added a unit test using createCountingGenerator to confirm lessons restart at 1 after chapters.

<sup>Written for commit 4c8ca5d90f36e448113c471013697eb61ff4dd88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

