### PR TITLE
fix(ai): avoid text in step images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,19 @@ When writing React components, use compound components. Always read this before 
 
 **VERY IMPORTANT**: **Default to TDD (Test-Driven Development) when the behavior is meaningfully testable**: Write a failing test first, **run the test to confirm it fails**, then write the code to make it pass. If the test passes before your fix, the test is wrong—never use workarounds like `.first()` or loose assertions to make tests pass. Use unique test data (e.g., UUIDs in titles) to ensure tests catch regressions.
 
-- Don't take the TDD rule too literally. **Use TDD when the behavior is clearly testable at the right level.** You don't need to follow TDD for things like CSS/style changes, prompt, docs, etc. Ask yourself: Does it make sense to test this change? Don't write meaningless tests just to check a box. For example, tests like `expect(1 + 1).toBe(2)` or `expect(true).toBe(true)` are not useful.
+- **Use this decision rule before writing any test**:
+  1. What behavior changed for the user or the system?
+  2. Can that behavior be verified with a deterministic assertion?
+  3. Is there a test at the right boundary that would fail for a real regression and pass for a real fix?
+  4. Would the test validate behavior instead of wording, implementation details, or framework internals?
+     If the answer to any of these is "no", do **not** force TDD. Explain briefly why a test is not appropriate and how you verified the change instead.
+- Don't take the TDD rule too literally. **Use TDD when the behavior is clearly testable at the right level.** You don't need to follow TDD for things like CSS/style changes, prompt wording, docs, or other changes where tests would only assert copy or implementation details. Don't write meaningless tests just to check a box. For example, tests like `expect(1 + 1).toBe(2)` or `expect(true).toBe(true)` are not useful.
+- **AI/prompt-specific rule**: Do **not** write tests that only assert exact prompt strings, exact prompt files, or other brittle wording-level details. For AI changes, add tests only when there is a deterministic contract to verify, such as parsing, schema validation, tool selection constraints, fallback behavior, retries, error handling, or post-processing logic. For prompt-quality changes, prefer evals, manual output review, or stronger guardrails in the prompt itself.
+- **If you're unsure whether to use TDD, stop and classify the change first**:
+  - Deterministic behavior change: use TDD
+  - Non-deterministic AI output quality change: usually no TDD
+  - Copy, docs, prompt wording, or visual polish change: usually no TDD
+  - Refactor with unchanged behavior: add or update tests only if there is a real regression risk or missing coverage at the correct boundary
 - **For UI changes, prefer Playwright E2E tests.** Avoid unit tests for React components, hooks, or wiring unless they contain real standalone business logic.
 - **Don't test implementation details.** Test expected behavior, not implementation details. If no new test is appropriate, say why and explain how you verified the change.
 

--- a/packages/ai/src/tasks/steps/_tools/image.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/image.prompt.md
@@ -9,5 +9,7 @@ Requirements:
 - Describe ONLY the content, not the style (style is handled by the image generator)
 - Focus on what should be depicted, not how
 - Be specific enough that the image supports the step's educational content
+- Avoid text by default. Only include text when it is necessary to make the image clearer
+- If text is necessary, keep it minimal and spell it exactly in the requested language, with correct accents and other diacritics
 - Write the prompt in the same language specified in the LANGUAGE field
 - NEVER reference copyrighted or trademarked characters (e.g., Mickey Mouse, Spider-Man, Mario, Pikachu). If the topic involves such characters, describe the concept abstractly or use generic, original characters instead

--- a/packages/ai/src/tasks/steps/_tools/image.ts
+++ b/packages/ai/src/tasks/steps/_tools/image.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 
 export const imageInputSchema = z.object({
-  prompt: z.string().describe("Content description only, not style"),
+  prompt: z
+    .string()
+    .describe(
+      "Content description only, not style. Avoid text unless it is necessary for clarity; if text is needed, keep it minimal and spell it exactly in the requested language, including accents and diacritics.",
+    ),
   stepIndex: z.number().describe("The step index (0-based) this visual is for"),
 });

--- a/packages/ai/src/tasks/steps/step-visual-image.prompt.md
+++ b/packages/ai/src/tasks/steps/step-visual-image.prompt.md
@@ -4,6 +4,10 @@ Style: Modern flat illustration with clean geometric shapes, a refined limited c
 
 The illustration should clearly communicate the educational concept while being visually engaging and easy to understand.
 
+Do not add labels, captions, signs, annotations, or other visible text unless the concept genuinely needs text to be understood. Prefer communicating the idea through objects, composition, and context.
+
+If text is necessary, use the minimum amount possible and spell it exactly in the requested language, with correct accents and other diacritics.
+
 LANGUAGE: **{{LANGUAGE}}**
 
 CONTENT TO ILLUSTRATE: **{{PROMPT}}**

--- a/packages/ai/src/tasks/steps/step-visual.prompt.md
+++ b/packages/ai/src/tasks/steps/step-visual.prompt.md
@@ -30,7 +30,7 @@ Choose the visual type that BEST fits each step's content:
 # Rules
 
 1. **One visual per step**: Generate exactly one visual for each step using the stepIndex field. This is mandatory
-2. **Language consistency**: All text in visuals must match the specified language
+2. **Language consistency**: If a visual includes text, every word must match the specified language
 3. **Content accuracy**: Visuals must accurately represent the educational content
 4. **Appropriate selection**: Choose the visual type that genuinely enhances understanding
 5. **Default to image**: When no specialized type fits, use the image tool with a descriptive prompt
@@ -79,6 +79,8 @@ Choose the visual type that BEST fits each step's content:
 - Use as fallback when no other type fits
 - Describe content only, not style
 - Be specific enough to convey the concept
+- Avoid text by default. Only include text in image visuals when it materially improves clarity
+- If text is necessary, keep it minimal and ensure spelling, accents, and other diacritics are exact in the requested language
 - NEVER reference copyrighted or trademarked characters (e.g., Mickey Mouse, Spider-Man, Mario, Pikachu). Describe concepts abstractly or use generic, original characters instead
 
 # Quality Checklist
@@ -90,4 +92,4 @@ Before finalizing, verify:
 3. **No duplicates**: No two visuals use the same `stepIndex`
 4. **No omissions**: No step is missing a visual
 5. **Best-fit visual**: Each step uses the most appropriate visual type
-6. **Language match**: All text in every visual matches the requested language
+6. **Language match**: Any text that appears in a visual matches the requested language exactly


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Default to no text in step images to reduce wrong-language labels and visual clutter. Adds strict rules to only include minimal, exactly spelled text when it truly improves clarity.

- **Bug Fixes**
  - Updated image and step-visual prompts to avoid labels, captions, and annotations by default; allow minimal text only when necessary and in the requested language with correct accents/diacritics.
  - Tightened `imageInputSchema.prompt` description and step-visual rules, including checklist updates so language checks apply only when text is present.

- **Refactors**
  - Expanded testing guidance in AGENTS.md with a simple decision rule and prompt-focused advice to avoid brittle wording-only tests.

<sup>Written for commit 335324e39ad1f00e6f7bcfa6e5cd06021cb49954. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

