### PR TITLE
fix(main): add subtle outline to catalog course images

### DIFF
--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-header.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-header.tsx
@@ -41,7 +41,7 @@ export async function CourseHeader({
         <MediaCardImage>
           <Image
             alt={course.title}
-            className="size-full object-cover"
+            className="size-full rounded-xl object-cover outline -outline-offset-1 outline-black/10 dark:outline-white/10"
             fill
             sizes="(max-width: 640px) 80px, 96px"
             src={course.imageUrl}


### PR DESCRIPTION
## Summary
- Add a subtle inset outline to course images in the catalog to prevent white-background images from floating on the page
- Uses CSS `outline` (not `ring`/`box-shadow`) which paints above image content per CSS spec

## Test plan
- [ ] Verify outline is visible on courses with white-background images
- [ ] Verify outline is subtle and not "bordery" on courses with colorful images
- [ ] Verify dark mode appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a subtle outline to catalog course images so white-background images don’t blend into the page.
Uses CSS `outline` with a slight negative offset and theme-aware colors for light/dark modes.

<sup>Written for commit 88999e2cdb941538aecaffe5b861ac5e46a95f34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

