### PR TITLE
fix(main): fix generation phase display for custom and quiz activities

### DIFF
--- a/apps/main/src/lib/generation/activity-generation-phase-config.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-config.ts
@@ -211,7 +211,8 @@ export function getPhaseSteps(kind: ActivityKind): Record<PhaseName, ActivitySte
   if (kind === "custom") {
     return {
       ...SHARED_PHASE_STEPS,
-      finishing: getFinishingSteps(["generateCustomContent"]),
+      finishing: ["getNeighboringConcepts", ...getFinishingSteps(["generateCustomContent"])],
+      gettingStarted: ["getLessonActivities"],
       processingDependencies: [],
       writingContent: ["setActivityAsRunning", "generateCustomContent"],
     };

--- a/apps/main/src/lib/generation/activity-generation-phase-config.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-config.ts
@@ -82,7 +82,7 @@ export function getPhaseOrder(kind: ActivityKind): PhaseName[] {
     return ["gettingStarted", "writingContent", "preparingVisuals", "creatingImages", "finishing"];
   }
 
-  if (kind === "practice" || kind === "challenge") {
+  if (kind === "practice" || kind === "challenge" || kind === "quiz") {
     return ["gettingStarted", "processingDependencies", "writingContent", "finishing"];
   }
 
@@ -227,10 +227,22 @@ export function getPhaseSteps(kind: ActivityKind): Record<PhaseName, ActivitySte
     };
   }
 
+  if (kind === "quiz") {
+    return {
+      ...SHARED_PHASE_STEPS,
+      ...NO_VISUALS_OVERRIDE,
+      finishing: [
+        ...VISUALS_AS_FINISHING,
+        ...getFinishingSteps(["generateExplanationContent", "generateQuizContent"]),
+      ],
+      processingDependencies: EXPLANATION_DEPS,
+      writingContent: ["generateQuizContent"],
+    };
+  }
+
   const contentStepMap: Partial<Record<ActivityKind, ActivityStepName>> = {
     challenge: "generateChallengeContent",
     practice: "generatePracticeContent",
-    quiz: "generateQuizContent",
   };
 
   const writingStep = contentStepMap[kind] ?? "generateQuizContent";

--- a/apps/main/src/lib/generation/activity-generation-phases.test.ts
+++ b/apps/main/src/lib/generation/activity-generation-phases.test.ts
@@ -262,6 +262,19 @@ describe("reading phase status", () => {
   });
 });
 
+describe("custom phase status", () => {
+  test("completes gettingStarted after getLessonActivities (getNeighboringConcepts is not used)", () => {
+    const status = getPhaseStatus(
+      "gettingStarted",
+      ["getLessonActivities"],
+      "setActivityAsRunning",
+      "custom",
+    );
+
+    expect(status).toBe("completed");
+  });
+});
+
 describe("enforcePhaseProgression integration", () => {
   test("clamps finishing to pending when creatingImages is still pending (explanation kind)", () => {
     const phaseOrder = getPhaseOrder("explanation");

--- a/apps/main/src/lib/generation/activity-generation-phases.test.ts
+++ b/apps/main/src/lib/generation/activity-generation-phases.test.ts
@@ -275,6 +275,14 @@ describe("custom phase status", () => {
   });
 });
 
+describe("quiz phase status", () => {
+  test("does not include preparingVisuals or creatingImages phases", () => {
+    const phases = getPhaseOrder("quiz");
+    expect(phases).not.toContain("preparingVisuals");
+    expect(phases).not.toContain("creatingImages");
+  });
+});
+
 describe("enforcePhaseProgression integration", () => {
   test("clamps finishing to pending when creatingImages is still pending (explanation kind)", () => {
     const phaseOrder = getPhaseOrder("explanation");


### PR DESCRIPTION
## Summary
- Custom activities: `gettingStarted` phase never completed because it required `getNeighboringConcepts` which the custom workflow doesn't call. Override to only require `getLessonActivities`
- Quiz activities: `preparingVisuals` and `creatingImages` phases were shown but quiz doesn't run those steps. Remove visual phases and move visual steps to `finishing` bucket

## Test plan
- [x] Added unit test for custom `gettingStarted` phase completion
- [x] Added unit test verifying quiz excludes visual phases
- [x] Verified manually with local course re-generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)