### PR TITLE
feat(player): show sentence and translation in arrange-words feedback

### DIFF
--- a/apps/main/e2e/listening-step.test.ts
+++ b/apps/main/e2e/listening-step.test.ts
@@ -144,18 +144,17 @@ test.describe("Listening Step", () => {
     await expect(page.getByText(sentence)).toBeVisible();
   });
 
-  test("correct translation arrangement shows success feedback", async ({ page }) => {
+  test("correct translation arrangement shows success feedback with sentence and translation", async ({
+    page,
+  }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const transWord1 = `Hello-${uniqueId}`;
     const transWord2 = `world-${uniqueId}`;
+    const sentence = `Hola-${uniqueId} mundo-${uniqueId}`;
+    const translation = `${transWord1} ${transWord2}`;
 
     const { url } = await createListeningActivity({
-      sentences: [
-        {
-          sentence: `Hola-${uniqueId} mundo-${uniqueId}`,
-          translation: `${transWord1} ${transWord2}`,
-        },
-      ],
+      sentences: [{ audioUrl: "https://example.com/audio.mp3", sentence, translation }],
       words: [{ translation: `cat-${uniqueId}`, word: `gato-${uniqueId}` }],
     });
 
@@ -175,22 +174,22 @@ test.describe("Listening Step", () => {
     await wordBank.getByRole("button", { exact: true, name: transWord2 }).click();
 
     await page.getByRole("button", { name: /check/i }).click();
-    await expect(page.getByRole("button", { name: /continue/i })).toBeVisible();
+
+    const feedback = page.getByRole("region", { name: /answer feedback/i });
+    await expect(feedback.getByText(/correct!/i)).toBeVisible();
+    await expect(feedback.getByText(sentence)).toBeVisible();
+    await expect(feedback.getByText(translation)).toBeVisible();
   });
 
-  test("wrong arrangement shows correct translation in feedback", async ({ page }) => {
+  test("wrong arrangement shows sentence and translation in feedback", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const transWord1 = `Hello-${uniqueId}`;
     const transWord2 = `world-${uniqueId}`;
+    const sentence = `Hola-${uniqueId} mundo-${uniqueId}`;
     const translation = `${transWord1} ${transWord2}`;
 
     const { url } = await createListeningActivity({
-      sentences: [
-        {
-          sentence: `Hola-${uniqueId} mundo-${uniqueId}`,
-          translation,
-        },
-      ],
+      sentences: [{ audioUrl: "https://example.com/audio.mp3", sentence, translation }],
       words: [{ translation: `cat-${uniqueId}`, word: `gato-${uniqueId}` }],
     });
 
@@ -212,8 +211,10 @@ test.describe("Listening Step", () => {
 
     await page.getByRole("button", { name: /check/i }).click();
 
-    await expect(page.getByText(new RegExp(`Correct answer.*${transWord1}`))).toBeVisible();
-    await expect(page.getByRole("button", { name: /continue/i })).toBeVisible();
+    const feedback = page.getByRole("region", { name: /answer feedback/i });
+    await expect(feedback.getByText(/not quite/i)).toBeVisible();
+    await expect(feedback.getByText(sentence)).toBeVisible();
+    await expect(feedback.getByText(translation)).toBeVisible();
   });
 
   test("full flow: complete all listening steps to completion screen", async ({ page }) => {

--- a/apps/main/e2e/reading-step.test.ts
+++ b/apps/main/e2e/reading-step.test.ts
@@ -249,14 +249,15 @@ test.describe("Reading Step", () => {
     await expect(page.getByRole("button", { name: /continue/i })).toBeVisible();
   });
 
-  test("wrong arrangement shows correct sentence in feedback", async ({ page }) => {
+  test("wrong arrangement shows sentence and translation in feedback", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const word1 = `Buenos-${uniqueId}`;
     const word2 = `dias-${uniqueId}`;
     const sentence = `${word1} ${word2}`;
+    const translation = `Good-${uniqueId} morning-${uniqueId}`;
 
     const { url } = await createReadingActivity({
-      sentences: [{ sentence, translation: `Good-${uniqueId} morning-${uniqueId}` }],
+      sentences: [{ sentence, translation }],
       words: [{ translation: `night-${uniqueId}`, word: `noche-${uniqueId}` }],
     });
 
@@ -278,9 +279,10 @@ test.describe("Reading Step", () => {
 
     await page.getByRole("button", { name: /check/i }).click();
 
-    // Shows the correct answer
-    await expect(page.getByText(new RegExp(`Correct answer.*${word1}`))).toBeVisible();
-    await expect(page.getByRole("button", { name: /continue/i })).toBeVisible();
+    const feedback = page.getByRole("region", { name: /answer feedback/i });
+    await expect(feedback.getByText(/not quite/i)).toBeVisible();
+    await expect(feedback.getByText(sentence)).toBeVisible();
+    await expect(feedback.getByText(translation)).toBeVisible();
   });
 
   test("full flow: complete all reading steps to completion screen", async ({ page }) => {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -42,12 +42,6 @@ msgstr "Position {position}: {item}. Tap to remove."
 
 #: ../../packages/player/src/components/arrange-words.tsx
 #: ../../packages/player/src/components/fill-blank-step.tsx
-msgctxt "xvWuPP"
-msgid "Correct answer: {answer}"
-msgstr "Correct answer: {answer}"
-
-#: ../../packages/player/src/components/arrange-words.tsx
-#: ../../packages/player/src/components/fill-blank-step.tsx
 #: ../../packages/player/src/components/result-announcement.tsx
 #: ../../packages/player/src/components/sort-order-step.tsx
 msgctxt "Ypr9T5"
@@ -283,10 +277,20 @@ msgctxt "wUEGVH"
 msgid "Blank {position}: {item}. Tap to remove."
 msgstr "Blank {position}: {item}. Tap to remove."
 
+#: ../../packages/player/src/components/fill-blank-step.tsx
+msgctxt "xvWuPP"
+msgid "Correct answer: {answer}"
+msgstr "Correct answer: {answer}"
+
 #: ../../packages/player/src/components/inline-feedback.tsx
 msgctxt "++l7ni"
 msgid "Not quite"
 msgstr "Not quite"
+
+#: ../../packages/player/src/components/inline-feedback.tsx
+msgctxt "HvLGEN"
+msgid "Answer feedback"
+msgstr "Answer feedback"
 
 #: ../../packages/player/src/components/inline-feedback.tsx
 msgctxt "xmF49T"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -42,12 +42,6 @@ msgstr "Posición {position}: {item}. Toca para quitar."
 
 #: ../../packages/player/src/components/arrange-words.tsx
 #: ../../packages/player/src/components/fill-blank-step.tsx
-msgctxt "xvWuPP"
-msgid "Correct answer: {answer}"
-msgstr "Respuesta correcta: {answer}"
-
-#: ../../packages/player/src/components/arrange-words.tsx
-#: ../../packages/player/src/components/fill-blank-step.tsx
 #: ../../packages/player/src/components/result-announcement.tsx
 #: ../../packages/player/src/components/sort-order-step.tsx
 msgctxt "Ypr9T5"
@@ -283,10 +277,20 @@ msgctxt "wUEGVH"
 msgid "Blank {position}: {item}. Tap to remove."
 msgstr "Espacio {position}: {item}. Toca para quitar."
 
+#: ../../packages/player/src/components/fill-blank-step.tsx
+msgctxt "xvWuPP"
+msgid "Correct answer: {answer}"
+msgstr "Respuesta correcta: {answer}"
+
 #: ../../packages/player/src/components/inline-feedback.tsx
 msgctxt "++l7ni"
 msgid "Not quite"
 msgstr "No del todo"
+
+#: ../../packages/player/src/components/inline-feedback.tsx
+msgctxt "HvLGEN"
+msgid "Answer feedback"
+msgstr "Comentario de respuesta"
 
 #: ../../packages/player/src/components/inline-feedback.tsx
 msgctxt "xmF49T"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -42,12 +42,6 @@ msgstr "Posição {position}: {item}. Toque para remover."
 
 #: ../../packages/player/src/components/arrange-words.tsx
 #: ../../packages/player/src/components/fill-blank-step.tsx
-msgctxt "xvWuPP"
-msgid "Correct answer: {answer}"
-msgstr "Resposta correta: {answer}"
-
-#: ../../packages/player/src/components/arrange-words.tsx
-#: ../../packages/player/src/components/fill-blank-step.tsx
 #: ../../packages/player/src/components/result-announcement.tsx
 #: ../../packages/player/src/components/sort-order-step.tsx
 msgctxt "Ypr9T5"
@@ -283,10 +277,20 @@ msgctxt "wUEGVH"
 msgid "Blank {position}: {item}. Tap to remove."
 msgstr "Espaço {position}: {item}. Toque para remover."
 
+#: ../../packages/player/src/components/fill-blank-step.tsx
+msgctxt "xvWuPP"
+msgid "Correct answer: {answer}"
+msgstr "Resposta correta: {answer}"
+
 #: ../../packages/player/src/components/inline-feedback.tsx
 msgctxt "++l7ni"
 msgid "Not quite"
 msgstr "Não exatamente"
+
+#: ../../packages/player/src/components/inline-feedback.tsx
+msgctxt "HvLGEN"
+msgid "Answer feedback"
+msgstr "Feedback da resposta"
 
 #: ../../packages/player/src/components/inline-feedback.tsx
 msgctxt "xmF49T"

--- a/i18n.lock
+++ b/i18n.lock
@@ -201,7 +201,6 @@ checksums:
     Word%20bank/singular: ceea720dd5fa3747c7f93ce165f77b2e
     "%7Bitem%7D.%20%7Bresult%7D./singular": 454dd5319c350f361652396801a1c30b
     Position%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: a1b3d3e026bfff43bff3d3e85ccdb952
-    Correct%20answer%3A%20%7Banswer%7D/singular: 7745b2664e841dffff4568203ee443b2
     Incorrect/singular: a86cfbe7b86f19dc8df14a67df073d22
     "%7Bcolor%7D%20belt/singular": 5949446c9b4a223c04cc500fa17a1fe0
     Level%20progress/singular: 286f095acd17006787247db0b69270e3
@@ -246,7 +245,9 @@ checksums:
     Blank%20%7Bposition%7D/singular: 70a4795f65f91685071b6abb1c3a6bad
     Blank%20%7Bposition%7D%3A%20%7Bitem%7D.%20%7Bresult%7D./singular: c64e721cdd1e4cc48eff9f9690f1fc6b
     Blank%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: d7ab9b86256fae5fbb5187fe718afe0b
+    Correct%20answer%3A%20%7Banswer%7D/singular: 7745b2664e841dffff4568203ee443b2
     Not%20quite/singular: e570085e69662802acf485c4565e3e3e
+    Answer%20feedback/singular: 9ec80a1e5b591c3d6c790b8d43266c0f
     Correct!/singular: dda1a98dc04fd9db252887ecf1765d41
     Translate%20this%20sentence%3A/singular: f69b2eec827b3a74bafca50e9058716f
     What%20do%20you%20hear%3F/singular: 9527d094d65c550a40108673bc67744f

--- a/packages/player/src/components/arrange-words.test.tsx
+++ b/packages/player/src/components/arrange-words.test.tsx
@@ -26,7 +26,6 @@ describe(ArrangeWordsInteraction, () => {
     render(
       <ArrangeWordsInteraction
         answerKind="reading"
-        correctSentence="Hola mundo"
         correctWords={["Hola", "mundo"]}
         onSelectAnswer={onSelectAnswer}
         selectedAnswer={undefined}

--- a/packages/player/src/components/arrange-words.tsx
+++ b/packages/player/src/components/arrange-words.tsx
@@ -161,8 +161,8 @@ function WordBank({
 export function ArrangeWordsInteraction({
   answerKind,
   children,
-  correctSentence,
   correctWords,
+  feedbackDetails,
   onSelectAnswer,
   result,
   selectedAnswer,
@@ -171,16 +171,14 @@ export function ArrangeWordsInteraction({
 }: {
   answerKind: "reading" | "listening";
   children: React.ReactNode;
-  correctSentence: string;
   correctWords: string[];
+  feedbackDetails?: { sentence: string; translation: string };
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
   result?: StepResult;
   selectedAnswer: SelectedAnswer | undefined;
   stepId: string;
   wordBankOptions: string[];
 }) {
-  const t = useExtracted();
-
   const [placedWords, setPlacedWords] = useState<string[]>(() => {
     if (result?.answer?.kind === answerKind && "arrangedWords" in result.answer) {
       return result.answer.arrangedWords;
@@ -217,8 +215,6 @@ export function ArrangeWordsInteraction({
     [onSelectAnswer, placedWords, selectedAnswer, stepId],
   );
 
-  const isIncorrect = result && !result.result.isCorrect;
-
   return (
     <InteractiveStepLayout>
       {children}
@@ -234,10 +230,11 @@ export function ArrangeWordsInteraction({
 
       {result && (
         <InlineFeedback result={result}>
-          {isIncorrect && (
-            <p className="text-muted-foreground text-sm">
-              {t("Correct answer: {answer}", { answer: correctSentence })}
-            </p>
+          {feedbackDetails && (
+            <div className="border-border/40 flex flex-col gap-1.5 border-t pt-3">
+              <p className="text-sm font-medium">{feedbackDetails.sentence}</p>
+              <p className="text-muted-foreground text-sm">{feedbackDetails.translation}</p>
+            </div>
           )}
         </InlineFeedback>
       )}

--- a/packages/player/src/components/inline-feedback.tsx
+++ b/packages/player/src/components/inline-feedback.tsx
@@ -19,7 +19,7 @@ export function InlineFeedback({
   const feedback = result.result.feedback ? replaceName(result.result.feedback) : null;
 
   return (
-    <div className="flex flex-col gap-3">
+    <div aria-label={t("Answer feedback")} className="flex flex-col gap-3" role="region">
       <div className="flex items-center gap-1.5 text-sm font-medium">
         {isCorrect ? (
           <>

--- a/packages/player/src/components/listening-step.tsx
+++ b/packages/player/src/components/listening-step.tsx
@@ -77,8 +77,11 @@ export function ListeningStep({
   return (
     <ArrangeWordsInteraction
       answerKind="listening"
-      correctSentence={step.sentence.translation}
       correctWords={step.sentence.translation.split(" ")}
+      feedbackDetails={{
+        sentence: step.sentence.sentence,
+        translation: step.sentence.translation,
+      }}
       onSelectAnswer={onSelectAnswer}
       result={result}
       selectedAnswer={selectedAnswer}

--- a/packages/player/src/components/reading-step.tsx
+++ b/packages/player/src/components/reading-step.tsx
@@ -27,8 +27,11 @@ export function ReadingStep({
   return (
     <ArrangeWordsInteraction
       answerKind="reading"
-      correctSentence={step.sentence.sentence}
       correctWords={step.sentence.sentence.split(" ")}
+      feedbackDetails={{
+        sentence: step.sentence.sentence,
+        translation: step.sentence.translation,
+      }}
       onSelectAnswer={onSelectAnswer}
       result={result}
       selectedAnswer={selectedAnswer}


### PR DESCRIPTION
## Summary
- Show sentence + translation in feedback for both correct and wrong answers in listening and reading steps
- Remove redundant "Correct answer:" line since feedback details now cover it
- Add `role="region"` with `aria-label` to `InlineFeedback` for semantic test querying

## Test plan
- [x] E2E: listening step correct feedback shows sentence and translation
- [x] E2E: listening step wrong feedback shows sentence and translation
- [x] E2E: reading step wrong feedback shows sentence and translation
- [x] All 11 listening + reading e2e tests pass consistently (2 runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the sentence and its translation in arrange-words feedback for listening and reading steps. Removes the old “Correct answer” line and adds an accessible feedback region for clearer, more inclusive feedback.

- **New Features**
  - Show sentence + translation in feedback for correct and wrong answers.
  - Add `role="region"` and `aria-label` (“Answer feedback”) to `InlineFeedback`.
  - Keep “Correct answer” only for fill-blank; remove from arrange-words.
  - Update e2e tests and i18n strings accordingly.

<sup>Written for commit dda7dcfbe4340d09161887366061d6a315066fbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

