### PR TITLE
refactor(main): remove unused activity kind descriptions

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -2271,11 +2271,6 @@ msgid "Translation"
 msgstr "Translation"
 
 #: src/lib/activities.ts
-msgctxt "/WTXNi"
-msgid "Review everything you learned"
-msgstr "Review everything you learned"
-
-#: src/lib/activities.ts
 msgctxt "1TOMnj"
 msgid "Listening"
 msgstr "Listening"
@@ -2296,24 +2291,9 @@ msgid "Practice {topic} in context through a dialogue-based scenario set in real
 msgstr "Practice {topic} in context through a dialogue-based scenario set in real-world situations."
 
 #: src/lib/activities.ts
-msgctxt "CaEilC"
-msgid "Make decisions with real trade-offs"
-msgstr "Make decisions with real trade-offs"
-
-#: src/lib/activities.ts
-msgctxt "cxvnSI"
-msgid "Apply the topic in a real scenario"
-msgstr "Apply the topic in a real scenario"
-
-#: src/lib/activities.ts
 msgctxt "E1bF/X"
 msgid "Explanation"
 msgstr "Explanation"
-
-#: src/lib/activities.ts
-msgctxt "EhgTzV"
-msgid "Practice listening skills"
-msgstr "Practice listening skills"
 
 #: src/lib/activities.ts
 msgctxt "gAYlHX"
@@ -2321,39 +2301,14 @@ msgid "Sharpen your {topic} listening skills by translating audio sentences."
 msgstr "Sharpen your {topic} listening skills by translating audio sentences."
 
 #: src/lib/activities.ts
-msgctxt "GV+7mf"
-msgid "Translate words you've learned"
-msgstr "Translate words you've learned"
-
-#: src/lib/activities.ts
 msgctxt "h2acN8"
 msgid "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
 msgstr "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
 
 #: src/lib/activities.ts
-msgctxt "iOvuhZ"
-msgid "Test your knowledge"
-msgstr "Test your knowledge"
-
-#: src/lib/activities.ts
-msgctxt "Ixg0z3"
-msgid "Learn new words"
-msgstr "Learn new words"
-
-#: src/lib/activities.ts
-msgctxt "KQeUad"
-msgid "Practice grammar rules"
-msgstr "Practice grammar rules"
-
-#: src/lib/activities.ts
 msgctxt "KV+O0y"
 msgid "Practice"
 msgstr "Practice"
-
-#: src/lib/activities.ts
-msgctxt "liTyj7"
-msgid "Practice reading comprehension"
-msgstr "Practice reading comprehension"
 
 #: src/lib/activities.ts
 msgctxt "MfGqY2"
@@ -2364,11 +2319,6 @@ msgstr "{lesson} {activity}"
 msgctxt "MOK/yK"
 msgid "Reading"
 msgstr "Reading"
-
-#: src/lib/activities.ts
-msgctxt "OQQjs9"
-msgid "Concepts and definitions"
-msgstr "Concepts and definitions"
 
 #: src/lib/activities.ts
 msgctxt "OuR/Ij"
@@ -2409,11 +2359,6 @@ msgstr "Practice {topic} grammar rules with exercises designed to help you remem
 msgctxt "UDijXW"
 msgid "{activity} - {lesson}"
 msgstr "{activity} - {lesson}"
-
-#: src/lib/activities.ts
-msgctxt "WlmsO/"
-msgid "Practice in a real-world dialogue"
-msgstr "Practice in a real-world dialogue"
 
 #: src/lib/activities.ts
 msgctxt "XzxpBZ"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -2271,11 +2271,6 @@ msgid "Translation"
 msgstr "Traducción"
 
 #: src/lib/activities.ts
-msgctxt "/WTXNi"
-msgid "Review everything you learned"
-msgstr "Repasa todo lo que aprendiste"
-
-#: src/lib/activities.ts
 msgctxt "1TOMnj"
 msgid "Listening"
 msgstr "Escucha"
@@ -2296,24 +2291,9 @@ msgid "Practice {topic} in context through a dialogue-based scenario set in real
 msgstr "Practica {topic} en contexto a través de un escenario de diálogo basado en situaciones del mundo real."
 
 #: src/lib/activities.ts
-msgctxt "CaEilC"
-msgid "Make decisions with real trade-offs"
-msgstr "Toma decisiones con consecuencias reales"
-
-#: src/lib/activities.ts
-msgctxt "cxvnSI"
-msgid "Apply the topic in a real scenario"
-msgstr "Aplica el tema en un escenario real"
-
-#: src/lib/activities.ts
 msgctxt "E1bF/X"
 msgid "Explanation"
 msgstr "Explicación"
-
-#: src/lib/activities.ts
-msgctxt "EhgTzV"
-msgid "Practice listening skills"
-msgstr "Practica tus habilidades de escucha"
 
 #: src/lib/activities.ts
 msgctxt "gAYlHX"
@@ -2321,39 +2301,14 @@ msgid "Sharpen your {topic} listening skills by translating audio sentences."
 msgstr "Afina tus habilidades de escucha en {topic} traduciendo oraciones de audio."
 
 #: src/lib/activities.ts
-msgctxt "GV+7mf"
-msgid "Translate words you've learned"
-msgstr "Traduce las palabras que aprendiste"
-
-#: src/lib/activities.ts
 msgctxt "h2acN8"
 msgid "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
 msgstr "Pon a prueba tu comprensión de {topic} con preguntas diseñadas para verificar la comprensión real, no solo la memorización."
 
 #: src/lib/activities.ts
-msgctxt "iOvuhZ"
-msgid "Test your knowledge"
-msgstr "Pon a prueba tus conocimientos"
-
-#: src/lib/activities.ts
-msgctxt "Ixg0z3"
-msgid "Learn new words"
-msgstr "Aprende nuevas palabras"
-
-#: src/lib/activities.ts
-msgctxt "KQeUad"
-msgid "Practice grammar rules"
-msgstr "Practica las reglas gramaticales"
-
-#: src/lib/activities.ts
 msgctxt "KV+O0y"
 msgid "Practice"
 msgstr "Practica"
-
-#: src/lib/activities.ts
-msgctxt "liTyj7"
-msgid "Practice reading comprehension"
-msgstr "Practica la comprensión de lectura"
 
 #: src/lib/activities.ts
 msgctxt "MfGqY2"
@@ -2364,11 +2319,6 @@ msgstr "{lesson} {activity}"
 msgctxt "MOK/yK"
 msgid "Reading"
 msgstr "Lectura"
-
-#: src/lib/activities.ts
-msgctxt "OQQjs9"
-msgid "Concepts and definitions"
-msgstr "Conceptos y definiciones"
 
 #: src/lib/activities.ts
 msgctxt "OuR/Ij"
@@ -2409,11 +2359,6 @@ msgstr "Practica las reglas gramaticales de {topic} con ejercicios diseñados pa
 msgctxt "UDijXW"
 msgid "{activity} - {lesson}"
 msgstr "{activity} - {lesson}"
-
-#: src/lib/activities.ts
-msgctxt "WlmsO/"
-msgid "Practice in a real-world dialogue"
-msgstr "Practica en un diálogo del mundo real"
 
 #: src/lib/activities.ts
 msgctxt "XzxpBZ"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -2271,11 +2271,6 @@ msgid "Translation"
 msgstr "Tradução"
 
 #: src/lib/activities.ts
-msgctxt "/WTXNi"
-msgid "Review everything you learned"
-msgstr "Revise tudo que você aprendeu"
-
-#: src/lib/activities.ts
 msgctxt "1TOMnj"
 msgid "Listening"
 msgstr "Escuta"
@@ -2296,24 +2291,9 @@ msgid "Practice {topic} in context through a dialogue-based scenario set in real
 msgstr "Pratique {topic} no contexto através de um cenário de diálogo baseado em situações do mundo real."
 
 #: src/lib/activities.ts
-msgctxt "CaEilC"
-msgid "Make decisions with real trade-offs"
-msgstr "Tome decisões com dilemas reais"
-
-#: src/lib/activities.ts
-msgctxt "cxvnSI"
-msgid "Apply the topic in a real scenario"
-msgstr "Aplique o tema em um cenário real"
-
-#: src/lib/activities.ts
 msgctxt "E1bF/X"
 msgid "Explanation"
 msgstr "Explicação"
-
-#: src/lib/activities.ts
-msgctxt "EhgTzV"
-msgid "Practice listening skills"
-msgstr "Pratique habilidades de escuta"
 
 #: src/lib/activities.ts
 msgctxt "gAYlHX"
@@ -2321,39 +2301,14 @@ msgid "Sharpen your {topic} listening skills by translating audio sentences."
 msgstr "Aprimore suas habilidades de escuta em {topic} traduzindo frases de áudio."
 
 #: src/lib/activities.ts
-msgctxt "GV+7mf"
-msgid "Translate words you've learned"
-msgstr "Traduza palavras que você aprendeu"
-
-#: src/lib/activities.ts
 msgctxt "h2acN8"
 msgid "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
 msgstr "Teste sua compreensão de {topic} com perguntas projetadas para verificar compreensão real, não apenas memorização."
 
 #: src/lib/activities.ts
-msgctxt "iOvuhZ"
-msgid "Test your knowledge"
-msgstr "Teste seu conhecimento"
-
-#: src/lib/activities.ts
-msgctxt "Ixg0z3"
-msgid "Learn new words"
-msgstr "Aprenda novas palavras"
-
-#: src/lib/activities.ts
-msgctxt "KQeUad"
-msgid "Practice grammar rules"
-msgstr "Pratique regras de gramática"
-
-#: src/lib/activities.ts
 msgctxt "KV+O0y"
 msgid "Practice"
 msgstr "Praticar"
-
-#: src/lib/activities.ts
-msgctxt "liTyj7"
-msgid "Practice reading comprehension"
-msgstr "Pratique compreensão de leitura"
 
 #: src/lib/activities.ts
 msgctxt "MfGqY2"
@@ -2364,11 +2319,6 @@ msgstr "{lesson} {activity}"
 msgctxt "MOK/yK"
 msgid "Reading"
 msgstr "Leitura"
-
-#: src/lib/activities.ts
-msgctxt "OQQjs9"
-msgid "Concepts and definitions"
-msgstr "Conceitos e definições"
 
 #: src/lib/activities.ts
 msgctxt "OuR/Ij"
@@ -2409,11 +2359,6 @@ msgstr "Pratique regras gramaticais de {topic} com exercícios projetados pra te
 msgctxt "UDijXW"
 msgid "{activity} - {lesson}"
 msgstr "{activity} - {lesson}"
-
-#: src/lib/activities.ts
-msgctxt "WlmsO/"
-msgid "Practice in a real-world dialogue"
-msgstr "Pratique em um diálogo do mundo real"
 
 #: src/lib/activities.ts
 msgctxt "XzxpBZ"

--- a/apps/main/src/lib/activities.ts
+++ b/apps/main/src/lib/activities.ts
@@ -16,71 +16,21 @@ import {
 } from "lucide-react";
 import { getExtracted } from "next-intl/server";
 
-export async function getActivityKinds(): Promise<
-  {
-    key: ActivityKind;
-    label: string;
-    description: string;
-  }[]
-> {
+export async function getActivityKinds(): Promise<{ key: ActivityKind; label: string }[]> {
   const t = await getExtracted();
 
   return [
-    {
-      description: t("Concepts and definitions"),
-      key: "explanation",
-      label: t("Explanation"),
-    },
-    {
-      description: t("Test your knowledge"),
-      key: "quiz",
-      label: t("Quiz"),
-    },
-    {
-      description: t("Apply the topic in a real scenario"),
-      key: "practice",
-      label: t("Practice"),
-    },
-    {
-      description: t("Make decisions with real trade-offs"),
-      key: "challenge",
-      label: t("Challenge"),
-    },
-    {
-      description: t("Learn new words"),
-      key: "vocabulary",
-      label: t("Vocabulary"),
-    },
-    {
-      description: t("Translate words you've learned"),
-      key: "translation",
-      label: t("Translation"),
-    },
-    {
-      description: t("Practice grammar rules"),
-      key: "grammar",
-      label: t("Grammar"),
-    },
-    {
-      description: t("Practice reading comprehension"),
-      key: "reading",
-      label: t("Reading"),
-    },
-    {
-      description: t("Practice listening skills"),
-      key: "listening",
-      label: t("Listening"),
-    },
-    {
-      description: t("Review everything you learned"),
-      key: "review",
-      label: t("Review"),
-    },
-    {
-      description: t("Practice in a real-world dialogue"),
-      key: "languagePractice",
-      label: t("Practice"),
-    },
+    { key: "explanation", label: t("Explanation") },
+    { key: "quiz", label: t("Quiz") },
+    { key: "practice", label: t("Practice") },
+    { key: "challenge", label: t("Challenge") },
+    { key: "vocabulary", label: t("Vocabulary") },
+    { key: "translation", label: t("Translation") },
+    { key: "grammar", label: t("Grammar") },
+    { key: "reading", label: t("Reading") },
+    { key: "listening", label: t("Listening") },
+    { key: "review", label: t("Review") },
+    { key: "languagePractice", label: t("Practice") },
   ];
 }
 


### PR DESCRIPTION
## Summary
- Remove unused `description` field from `getActivityKinds` return type — no consumer reads it
- Clean up corresponding translation entries from en/es/pt PO files
- SEO descriptions (`getSeoDescription`) are unaffected

## Test plan
- [ ] Verify `pnpm typecheck` passes
- [ ] Verify `pnpm --filter main build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused description field from activity kinds and pruned related translation strings in `en.po`, `es.po`, and `pt.po`. getActivityKinds now returns only key and label; no user-visible changes and SEO descriptions via getSeoDescription remain unchanged.

<sup>Written for commit 8b0653182202b3b03129529e0487dd4358f8bffb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

