### PR TITLE
fix(test): use correct playwright wait primitives for navigation-based e2e tests

### DIFF
--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -272,6 +272,6 @@ test.describe("Chapter - No Lessons", () => {
   test("chapter with no lessons redirects to generate page", async ({ page }) => {
     await page.goto(noLessonsChapterUrl);
 
-    await expect(page).toHaveURL(new RegExp(`/generate/ch/${noLessonsChapterId}`));
+    await page.waitForURL(new RegExp(`/generate/ch/${noLessonsChapterId}`));
   });
 });

--- a/apps/main/e2e/language.test.ts
+++ b/apps/main/e2e/language.test.ts
@@ -15,9 +15,11 @@ test.describe("Language settings page", () => {
     await page.goto("/language");
 
     const selector = page.getByRole("combobox", { name: /update language/i });
-    await selector.selectOption("es");
 
-    await page.waitForURL("**/language");
+    // Start listening for the reload before triggering it
+    const reloadPromise = page.waitForEvent("load");
+    await selector.selectOption("es");
+    await reloadPromise;
 
     await expect(page.getByRole("heading", { level: 1, name: /^idioma$/i })).toBeVisible();
   });
@@ -26,9 +28,11 @@ test.describe("Language settings page", () => {
     await page.goto("/language");
 
     const selector = page.getByRole("combobox", { name: /update language/i });
-    await selector.selectOption("pt");
 
-    await page.waitForURL("**/language");
+    // Start listening for the reload before triggering it
+    const reloadPromise = page.waitForEvent("load");
+    await selector.selectOption("pt");
+    await reloadPromise;
 
     await expect(page.getByRole("heading", { level: 1, name: /^idioma$/i })).toBeVisible();
 

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -257,7 +257,7 @@ test.describe("Lesson Detail Page", () => {
 
     await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
-    await expect(page).toHaveURL(new RegExp(`/generate/l/${lesson.id}`));
+    await page.waitForURL(new RegExp(`/generate/l/${lesson.id}`));
   });
 
   test("shows not-completed indicators for unauthenticated user", async ({ page }) => {


### PR DESCRIPTION
## Summary

- **Language tests**: replaced `waitForURL("**/language")` (resolved immediately before `location.reload()` started) with `waitForEvent("load")` to properly await the page reload cycle
- **Lesson/chapter redirect tests**: replaced `expect(page).toHaveURL()` (5s expect timeout) with `page.waitForURL()` (30s navigation timeout) — the correct Playwright primitive for server-side redirects

## Test plan

- [x] `language.test.ts` passed 5/5 runs locally
- [x] `lesson-detail.test.ts` passed 5/5 runs locally
- [x] `chapter-detail.test.ts` passed 5/5 runs locally
- [x] Full e2e suite: main (399), editor (193), api (56) all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes navigation-based e2e tests by using the correct Playwright wait primitives. Fixes flaky language reloads and server-side redirect checks.

- **Bug Fixes**
  - Language page: listen for reload with `page.waitForEvent("load")` started before `selectOption`, replacing `waitForURL("**/language")`.
  - Lesson/chapter redirects: use `page.waitForURL(...)` instead of `expect(page).toHaveURL(...)` to rely on navigation timeout for server-side redirects.
  - Verification: language, lesson-detail, and chapter-detail each passed 5/5 local runs; full e2e suites passing.

<sup>Written for commit ca73d12e2c0514c08df96105cd5e86c18e31fcd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

