### PR TITLE
refactor(player): extract RomanizationText component and fix SectionLabel duplication

### DIFF
--- a/apps/main/e2e/static-step.test.ts
+++ b/apps/main/e2e/static-step.test.ts
@@ -144,32 +144,6 @@ test.describe("Static Step Rendering", () => {
     await expect(page.getByText(new RegExp(`She runs fast ${uniqueId}`))).toBeVisible();
   });
 
-  test("grammar example without romanization does not render romanization", async ({ page }) => {
-    const uniqueId = randomUUID().slice(0, 8);
-    const { url } = await createStaticActivity({
-      steps: [
-        {
-          content: {
-            highlight: "runs",
-            romanization: null,
-            sentence: `She runs fast ${uniqueId}`,
-            translation: `Ella corre rapido ${uniqueId}`,
-            variant: "grammarExample",
-          },
-          position: 0,
-        },
-      ],
-    });
-
-    await page.goto(url);
-    await expect(page.getByText(new RegExp(`She.*runs.*fast ${uniqueId}`))).toBeVisible();
-    await expect(page.getByText(new RegExp(`Ella corre rapido ${uniqueId}`))).toBeVisible();
-
-    // Verify no italic romanization element is present
-    const italicElements = page.locator("p.italic");
-    await expect(italicElements).toHaveCount(0);
-  });
-
   test("grammar rule renders rule name and summary", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const { url } = await createStaticActivity({

--- a/packages/player/src/components/arrange-words-feedback.tsx
+++ b/packages/player/src/components/arrange-words-feedback.tsx
@@ -82,7 +82,7 @@ export function ArrangeWordsFeedback(props: ArrangeWordsFeedbackProps) {
   return (
     <div className="border-border/40 flex flex-col gap-3 border-t pt-3">
       <WordCards options={props.sentenceWordOptions} />
-      <RomanizationText>{props.translation}</RomanizationText>
+      <p className="text-muted-foreground text-sm italic">{props.translation}</p>
     </div>
   );
 }

--- a/packages/player/src/components/arrange-words-feedback.tsx
+++ b/packages/player/src/components/arrange-words-feedback.tsx
@@ -1,14 +1,13 @@
 import { useExtracted } from "next-intl";
 import { type WordBankOption } from "../prepare-activity-data";
+import { RomanizationText } from "./romanization-text";
 
 function FeedbackWordCard({ option }: { option: WordBankOption }) {
   return (
     <span className="bg-muted/50 flex flex-col items-center rounded-md px-3 py-1.5">
       <span className="text-sm font-medium">{option.word}</span>
 
-      {option.romanization && (
-        <span className="text-muted-foreground text-[11px]">{option.romanization}</span>
-      )}
+      <RomanizationText>{option.romanization}</RomanizationText>
 
       {option.translation && (
         <span className="text-muted-foreground text-xs">{option.translation}</span>
@@ -83,7 +82,7 @@ export function ArrangeWordsFeedback(props: ArrangeWordsFeedbackProps) {
   return (
     <div className="border-border/40 flex flex-col gap-3 border-t pt-3">
       <WordCards options={props.sentenceWordOptions} />
-      <p className="text-muted-foreground text-sm italic">{props.translation}</p>
+      <RomanizationText>{props.translation}</RomanizationText>
     </div>
   );
 }

--- a/packages/player/src/components/arrange-words.tsx
+++ b/packages/player/src/components/arrange-words.tsx
@@ -9,6 +9,7 @@ import { type WordBankOption } from "../prepare-activity-data";
 import { useWordAudio } from "../use-word-audio";
 import { ArrangeWordsFeedback, type ArrangeWordsFeedbackProps } from "./arrange-words-feedback";
 import { InlineFeedback } from "./inline-feedback";
+import { RomanizationText } from "./romanization-text";
 import { InteractiveStepLayout } from "./step-layouts";
 
 function getWordResultState(
@@ -63,9 +64,7 @@ function PlacedWordTile({
     >
       <span>{option.word}</span>
 
-      {option.romanization && (
-        <span className="text-muted-foreground text-xs">{option.romanization}</span>
-      )}
+      <RomanizationText>{option.romanization}</RomanizationText>
     </button>
   );
 }
@@ -112,9 +111,7 @@ function BankTileContent({ option }: { option: WordBankOption }) {
     <>
       <span>{option.word}</span>
 
-      {option.romanization && (
-        <span className="text-muted-foreground text-xs">{option.romanization}</span>
-      )}
+      <RomanizationText>{option.romanization}</RomanizationText>
     </>
   );
 }

--- a/packages/player/src/components/challenge-intro.tsx
+++ b/packages/player/src/components/challenge-intro.tsx
@@ -4,6 +4,7 @@ import { Button } from "@zoonk/ui/components/button";
 import { useExtracted } from "next-intl";
 import { type DimensionInventory } from "../player-reducer";
 import { DimensionList, buildDimensionEntries } from "./dimension-inventory";
+import { SectionLabel } from "./section-label";
 
 export function ChallengeIntro({
   dimensions,
@@ -18,9 +19,7 @@ export function ChallengeIntro({
   return (
     <div className="mx-auto flex w-full max-w-lg flex-col gap-6 text-left">
       <div className="flex flex-col gap-4">
-        <span className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-          {t("Challenge")}
-        </span>
+        <SectionLabel>{t("Challenge")}</SectionLabel>
 
         <h1 className="text-foreground text-xl font-semibold tracking-tight">{t("How to play")}</h1>
 
@@ -34,9 +33,7 @@ export function ChallengeIntro({
       </div>
 
       <div className="flex flex-col gap-2">
-        <span className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-          {t("Your scores")}
-        </span>
+        <SectionLabel>{t("Your scores")}</SectionLabel>
 
         <DimensionList aria-label={t("Starting scores")} entries={entries} variant="intro" />
       </div>

--- a/packages/player/src/components/multiple-choice-step.tsx
+++ b/packages/player/src/components/multiple-choice-step.tsx
@@ -13,6 +13,7 @@ import { useOptionKeyboard } from "../use-option-keyboard";
 import { useReplaceName } from "../user-name-context";
 import { OptionCard } from "./option-card";
 import { ContextText, QuestionText } from "./question-text";
+import { RomanizationText } from "./romanization-text";
 import { SectionLabel } from "./section-label";
 import { InteractiveStepLayout } from "./step-layouts";
 
@@ -32,8 +33,7 @@ function OptionContent({ romanization, text }: { romanization?: string | null; t
   return (
     <>
       <span className="text-base leading-6">{text}</span>
-
-      {romanization && <span className="text-muted-foreground text-sm italic">{romanization}</span>}
+      <RomanizationText>{romanization}</RomanizationText>
     </>
   );
 }
@@ -138,9 +138,7 @@ function LanguageVariant({
         <SpeechBubble>
           <p className="text-base font-semibold">{replaceName(content.context)}</p>
 
-          {content.contextRomanization && (
-            <p className="text-muted-foreground text-sm italic">{content.contextRomanization}</p>
-          )}
+          <RomanizationText>{content.contextRomanization}</RomanizationText>
 
           <p className="text-muted-foreground text-sm">{replaceName(content.contextTranslation)}</p>
         </SpeechBubble>

--- a/packages/player/src/components/romanization-text.tsx
+++ b/packages/player/src/components/romanization-text.tsx
@@ -1,0 +1,7 @@
+export function RomanizationText({ children }: { children: string | null | undefined }) {
+  if (!children) {
+    return null;
+  }
+
+  return <span className="text-muted-foreground text-xs italic">{children}</span>;
+}

--- a/packages/player/src/components/section-label.tsx
+++ b/packages/player/src/components/section-label.tsx
@@ -1,5 +1,7 @@
 export function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
-    <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">{children}</p>
+    <span className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+      {children}
+    </span>
   );
 }

--- a/packages/player/src/components/static-step.tsx
+++ b/packages/player/src/components/static-step.tsx
@@ -5,6 +5,7 @@ import { type SerializedStep } from "../prepare-activity-data";
 import { useReplaceName } from "../user-name-context";
 import { HighlightText } from "./highlight-text";
 import { ContextText, QuestionText } from "./question-text";
+import { RomanizationText } from "./romanization-text";
 import { useSwipeNavigation } from "./static-step-navigation";
 
 function TextVariant({ title, text }: { title: string; text: string }) {
@@ -35,7 +36,7 @@ function GrammarExampleVariant({
         <HighlightText highlight={highlight} text={sentence} />
       </p>
 
-      {romanization && <p className="text-muted-foreground text-sm italic">{romanization}</p>}
+      <RomanizationText>{romanization}</RomanizationText>
 
       <ContextText>{translation}</ContextText>
     </>

--- a/packages/player/src/components/translation-step.tsx
+++ b/packages/player/src/components/translation-step.tsx
@@ -7,6 +7,7 @@ import { useOptionKeyboard } from "../use-option-keyboard";
 import { useWordAudio } from "../use-word-audio";
 import { OptionCard } from "./option-card";
 import { QuestionText } from "./question-text";
+import { RomanizationText } from "./romanization-text";
 import { SectionLabel } from "./section-label";
 import { InteractiveStepLayout } from "./step-layouts";
 
@@ -29,9 +30,7 @@ function TranslationOptionContent({
     <>
       <span className="text-base leading-6">{word.word}</span>
 
-      {word.romanization && (
-        <span className="text-muted-foreground text-sm italic">{word.romanization}</span>
-      )}
+      <RomanizationText>{word.romanization}</RomanizationText>
 
       {isSelected && word.pronunciation && (
         <span className="text-muted-foreground text-sm">{word.pronunciation}</span>

--- a/packages/player/src/components/vocabulary-step.tsx
+++ b/packages/player/src/components/vocabulary-step.tsx
@@ -4,6 +4,7 @@ import { useExtracted } from "next-intl";
 import { type SerializedStep } from "../prepare-activity-data";
 import { PlayAudioButton } from "./play-audio-button";
 import { ContextText } from "./question-text";
+import { RomanizationText } from "./romanization-text";
 import { useSwipeNavigation } from "./static-step-navigation";
 
 export function VocabularyStep({
@@ -38,9 +39,7 @@ export function VocabularyStep({
         <div className="flex flex-col gap-2">
           <p className="text-4xl font-bold tracking-tight sm:text-5xl">{word.word}</p>
 
-          {word.romanization && (
-            <p className="text-muted-foreground text-sm italic">{word.romanization}</p>
-          )}
+          <RomanizationText>{word.romanization}</RomanizationText>
 
           {word.pronunciation && (
             <p className="text-muted-foreground text-sm">{word.pronunciation}</p>


### PR DESCRIPTION
## Summary

- Extract repeated romanization styling (`text-muted-foreground text-xs italic`) into a single `RomanizationText` component that handles null/undefined
- Replace inline `SectionLabel` class duplication in `challenge-intro.tsx` with the existing component
- Change `SectionLabel` to render `<span>` instead of `<p>` for flexibility
- Remove ad-hoc `text-[11px]` size in feedback word cards, standardizing to `text-xs`
- Remove low-value E2E test that used CSS selector (`p.italic`) instead of semantic queries

## Test plan

- [x] `pnpm turbo quality:fix` — no warnings or errors
- [x] `pnpm typecheck` — passes
- [x] `pnpm knip --production` — no unused exports
- [x] `pnpm test` — all unit/integration tests pass
- [x] `pnpm --filter main e2e` — 398 passed
- [x] `pnpm --filter editor e2e` — 194 passed
- [x] `pnpm --filter api e2e` — 56 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies romanization styling via a new `RomanizationText` component and de-duplicates section labels with `SectionLabel`. Reduces repeated markup and standardizes small-text typography.

- **Refactors**
  - Added `RomanizationText` and used it across player steps and feedback cards; returns null for missing values and renders muted `text-xs` italic.
  - Replaced inline section label classes in challenge intro with `SectionLabel`; `SectionLabel` now renders a `span` for layout flexibility.
  - Removed a brittle E2E test that relied on the `p.italic` CSS selector.

<sup>Written for commit 6840fbc60f97c6567574b904ff0b74a1d416d9f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

