### PR TITLE
fix(utils): preserve non-latin characters in slug generation

### DIFF
--- a/apps/api/src/workflows/chapter-generation/steps/add-lessons-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/add-lessons-step.ts
@@ -1,7 +1,7 @@
 import { type ChapterLesson } from "@zoonk/ai/tasks/chapters/lessons";
 import { type Lesson, type LessonCreateManyInput, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { normalizeString, toSlug } from "@zoonk/utils/string";
+import { deduplicateSlugs, normalizeString, toSlug } from "@zoonk/utils/string";
 import { streamError, streamStatus } from "../stream-status";
 import { type ChapterContext } from "./get-chapter-step";
 
@@ -13,19 +13,21 @@ export async function addLessonsStep(input: {
 
   await streamStatus({ status: "started", step: "addLessons" });
 
-  const lessonsData: LessonCreateManyInput[] = input.lessons.map((lesson, index) => ({
-    chapterId: input.context.id,
-    concepts: lesson.concepts,
-    description: lesson.description,
-    generationStatus: "pending",
-    isPublished: true,
-    language: input.context.language,
-    normalizedTitle: normalizeString(lesson.title),
-    organizationId: input.context.organizationId,
-    position: index,
-    slug: toSlug(lesson.title),
-    title: lesson.title,
-  }));
+  const lessonsData: LessonCreateManyInput[] = deduplicateSlugs(
+    input.lessons.map((lesson, index) => ({
+      chapterId: input.context.id,
+      concepts: lesson.concepts,
+      description: lesson.description,
+      generationStatus: "pending" as const,
+      isPublished: true,
+      language: input.context.language,
+      normalizedTitle: normalizeString(lesson.title),
+      organizationId: input.context.organizationId,
+      position: index,
+      slug: toSlug(lesson.title),
+      title: lesson.title,
+    })),
+  );
 
   const { data: createdLessons, error } = await safeAsync(() =>
     prisma.lesson.createManyAndReturn({

--- a/apps/api/src/workflows/course-generation/steps/add-chapters-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/add-chapters-step.ts
@@ -1,7 +1,7 @@
 import { type CourseChapter } from "@zoonk/ai/tasks/courses/chapters";
 import { type Chapter, type ChapterCreateManyInput, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { normalizeString, toSlug } from "@zoonk/utils/string";
+import { deduplicateSlugs, normalizeString, toSlug } from "@zoonk/utils/string";
 import { streamError, streamStatus } from "../stream-status";
 import { type CourseContext } from "./initialize-course-step";
 
@@ -13,18 +13,20 @@ export async function addChaptersStep(input: {
 
   await streamStatus({ status: "started", step: "addChapters" });
 
-  const chaptersData: ChapterCreateManyInput[] = input.chapters.map((chapter, index) => ({
-    courseId: input.course.courseId,
-    description: chapter.description,
-    generationStatus: "pending",
-    isPublished: true,
-    language: input.course.language,
-    normalizedTitle: normalizeString(chapter.title),
-    organizationId: input.course.organizationId,
-    position: index,
-    slug: toSlug(chapter.title),
-    title: chapter.title,
-  }));
+  const chaptersData: ChapterCreateManyInput[] = deduplicateSlugs(
+    input.chapters.map((chapter, index) => ({
+      courseId: input.course.courseId,
+      description: chapter.description,
+      generationStatus: "pending" as const,
+      isPublished: true,
+      language: input.course.language,
+      normalizedTitle: normalizeString(chapter.title),
+      organizationId: input.course.organizationId,
+      position: index,
+      slug: toSlug(chapter.title),
+      title: chapter.title,
+    })),
+  );
 
   const { data: createdChapters, error } = await safeAsync(() =>
     prisma.chapter.createManyAndReturn({

--- a/apps/main/src/data/courses/find-existing-course.test.ts
+++ b/apps/main/src/data/courses/find-existing-course.test.ts
@@ -34,7 +34,7 @@ describe(findExistingCourse, () => {
   });
 
   test("returns course when found by slug + language in courses table (AI org)", async () => {
-    const uniqueSlug = `ai-course-slug-${randomUUID()}`;
+    const uniqueSlug = `ai-${randomUUID()}`;
 
     const course = await courseFixture({
       generationStatus: "completed",
@@ -65,8 +65,8 @@ describe(findExistingCourse, () => {
   });
 
   test("returns course when found by slug + language in alternative titles table", async () => {
-    const uniqueSlug = `original-course-slug-${randomUUID()}`;
-    const altSlug = `alternative-slug-${randomUUID()}`;
+    const uniqueSlug = `orig-${randomUUID()}`;
+    const altSlug = `alt-${randomUUID()}`;
 
     const course = await courseFixture({
       generationStatus: "completed",
@@ -103,7 +103,7 @@ describe(findExistingCourse, () => {
   });
 
   test("returns null for courses from non-AI organizations", async () => {
-    const uniqueSlug = `non-ai-course-${randomUUID()}`;
+    const uniqueSlug = `nonai-${randomUUID()}`;
 
     await courseFixture({
       language: "en",
@@ -121,7 +121,7 @@ describe(findExistingCourse, () => {
   });
 
   test("prioritizes direct course match over alternative title match", async () => {
-    const uniqueSlug = `priority-test-slug-${randomUUID()}`;
+    const uniqueSlug = `prio-${randomUUID()}`;
 
     const directCourse = await courseFixture({
       generationStatus: "completed",
@@ -134,7 +134,7 @@ describe(findExistingCourse, () => {
       generationStatus: "pending",
       language: "en",
       organizationId: aiOrg.id,
-      slug: `alt-course-for-priority-${randomUUID()}`,
+      slug: `altprio-${randomUUID()}`,
     });
 
     await courseAlternativeTitleFixture({
@@ -172,7 +172,7 @@ describe(findExistingCourse, () => {
   });
 
   test("handles different languages correctly", async () => {
-    const uniqueSlug = `language-test-course-${randomUUID()}`;
+    const uniqueSlug = `lang-${randomUUID()}`;
 
     const [enCourse, ptCourse] = await Promise.all([
       courseFixture({

--- a/packages/core/src/steps/step-image.ts
+++ b/packages/core/src/steps/step-image.ts
@@ -4,7 +4,7 @@ import {
 } from "@zoonk/ai/tasks/steps/select-image";
 import { type SafeReturn } from "@zoonk/utils/error";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
-import { SLUG_MAX_LENGTH, toSlug } from "@zoonk/utils/string";
+import { toSlug } from "@zoonk/utils/string";
 import { optimizeImage } from "../images/optimize-image";
 import { uploadImage } from "../images/upload-image";
 
@@ -32,7 +32,7 @@ export async function generateStepImage({
     return { data: null, error: optimizeError };
   }
 
-  const slug = toSlug(prompt.slice(0, SLUG_MAX_LENGTH));
+  const slug = toSlug(prompt);
   const org = orgSlug ?? AI_ORG_SLUG;
   const fileName = `steps/${org}/${slug}.webp`;
 

--- a/packages/core/src/steps/step-visual-image.ts
+++ b/packages/core/src/steps/step-visual-image.ts
@@ -4,7 +4,7 @@ import {
 } from "@zoonk/ai/tasks/steps/visual-image";
 import { type SafeReturn } from "@zoonk/utils/error";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
-import { SLUG_MAX_LENGTH, toSlug } from "@zoonk/utils/string";
+import { toSlug } from "@zoonk/utils/string";
 import { optimizeImage } from "../images/optimize-image";
 import { uploadImage } from "../images/upload-image";
 
@@ -32,7 +32,7 @@ export async function generateVisualStepImage({
     return { data: null, error: optimizeError };
   }
 
-  const slug = toSlug(prompt.slice(0, SLUG_MAX_LENGTH));
+  const slug = toSlug(prompt);
   const org = orgSlug ?? AI_ORG_SLUG;
   const fileName = `steps/${org}/visual-${slug}.webp`;
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -38,12 +38,10 @@
   },
   "dependencies": {
     "@formatjs/intl-localematcher": "0.8.1",
-    "negotiator": "1.0.0",
-    "slug": "11.0.1"
+    "negotiator": "1.0.0"
   },
   "devDependencies": {
     "@types/negotiator": "0.6.4",
-    "@types/slug": "5.0.9",
     "@typescript/native-preview": "7.0.0-dev.20260314.1",
     "@zoonk/tsconfig": "workspace:*",
     "vitest": "4.1.0"

--- a/packages/utils/src/string.test.ts
+++ b/packages/utils/src/string.test.ts
@@ -225,6 +225,12 @@ describe(toSlug, () => {
       toSlug("Introduction to Conditional Probability and Bayesian Inference Methods"),
     ).toHaveLength(50);
   });
+
+  test("strips trailing hyphen left by truncation", () => {
+    expect(toSlug("Existing Completed Course 7cf0f58c-c844-4e77-b93d-862b088c72e0")).toBe(
+      "existing-completed-course-7cf0f58c-c844-4e77-b93d",
+    );
+  });
 });
 
 describe(deduplicateSlugs, () => {

--- a/packages/utils/src/string.test.ts
+++ b/packages/utils/src/string.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  deduplicateSlugs,
   emptyToNull,
   ensureLocaleSuffix,
   extractUniqueSentenceWords,
@@ -141,9 +142,128 @@ describe(removeLocaleSuffix, () => {
 });
 
 describe(toSlug, () => {
-  test("strips dots from input", () => {
+  test("basic slug behavior", () => {
+    expect(toSlug("Hello World")).toBe("hello-world");
+    expect(toSlug("  Hello   World  ")).toBe("hello-world");
+    expect(toSlug("hello-world")).toBe("hello-world");
+    expect(toSlug("---hello---world---")).toBe("hello-world");
+    expect(toSlug("hello\tworld\nfoo")).toBe("hello-world-foo");
+    expect(toSlug("UPPERCASE")).toBe("uppercase");
+    expect(toSlug("a")).toBe("a");
+  });
+
+  test("strips Latin accents", () => {
+    expect(toSlug("Café")).toBe("cafe");
+    expect(toSlug("São Paulo")).toBe("sao-paulo");
+    expect(toSlug("El Niño")).toBe("el-nino");
+    expect(toSlug("Über")).toBe("uber");
+    expect(toSlug("Façade")).toBe("facade");
+    expect(toSlug("Français Español Português")).toBe("francais-espanol-portugues");
+  });
+
+  test("preserves special Latin characters as Unicode", () => {
+    expect(toSlug("Straße")).toBe("straße");
+    expect(toSlug("Ærø")).toBe("ærø");
+  });
+
+  test("preserves CJK characters", () => {
+    expect(toSlug("わけはずもの")).toBe("わけはずもの");
+    expect(toSlug("日本語が話せます")).toBe("日本語が話せます");
+    expect(toSlug("你好世界")).toBe("你好世界");
+    expect(toSlug("당근마켓")).toBe("당근마켓");
+  });
+
+  test("handles mixed Latin and CJK (the bug fix)", () => {
+    expect(toSlug("Estruturas com わけ・はず・もの")).toBe("estruturas-com-わけはずもの");
+    expect(toSlug("Estruturas com よう・みたい・らしい")).toBe("estruturas-com-ようみたいらしい");
+    expect(toSlug("Condicional com と")).toBe("condicional-com-と");
+    expect(toSlug("Condicional com たら")).toBe("condicional-com-たら");
+
+    const slugs = [
+      toSlug("Estruturas com わけ・はず・もの"),
+      toSlug("Estruturas com よう・みたい・らしい"),
+      toSlug("Condicional com と"),
+      toSlug("Condicional com たら"),
+    ];
+
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  test("preserves other Unicode scripts", () => {
+    expect(toSlug("สวัสดี")).toBe("สวัสดี");
+    expect(toSlug("हिन्दी")).toBe("हिन्दी");
+    expect(toSlug("مرحبا")).toBe("مرحبا");
+    expect(toSlug("αλφα βήτα")).toBe("αλφα-βητα");
+    expect(toSlug("москва")).toBe("москва");
+    expect(toSlug("שלום")).toBe("שלום");
+    expect(toSlug("თბილისი")).toBe("თბილისი");
+  });
+
+  test("removes punctuation and symbols", () => {
     expect(toSlug("dev.ops")).toBe("devops");
     expect(toSlug("john.doe.smith")).toBe("johndoesmith");
+    expect(toSlug("Hello (World) [Test]")).toBe("hello-world-test");
+    expect(toSlug("Rock & Roll")).toBe("rock-roll");
+    expect(toSlug("Hello! @World #1")).toBe("hello-world-1");
+    expect(toSlug("5★ stars")).toBe("5-stars");
+    expect(toSlug("Hello 😀 World")).toBe("hello-world");
+    expect(toSlug("わけ・はず")).toBe("わけはず");
+  });
+
+  test("edge cases", () => {
+    expect(toSlug("")).toBe("");
+    expect(toSlug("   ")).toBe("");
+    expect(toSlug("...!!!")).toBe("");
+    expect(toSlug("123")).toBe("123");
+    expect(toSlug("Test 123 Foo")).toBe("test-123-foo");
+  });
+
+  test("truncates to SLUG_MAX_LENGTH", () => {
+    const long = "a".repeat(100);
+    expect(toSlug(long)).toBe("a".repeat(50));
+    expect(
+      toSlug("Introduction to Conditional Probability and Bayesian Inference Methods"),
+    ).toHaveLength(50);
+  });
+});
+
+describe(deduplicateSlugs, () => {
+  test("leaves unique slugs unchanged", () => {
+    const items = [{ slug: "a" }, { slug: "b" }];
+    expect(deduplicateSlugs(items)).toEqual([{ slug: "a" }, { slug: "b" }]);
+  });
+
+  test("appends counter suffix to duplicate slugs", () => {
+    const items = [{ slug: "x" }, { slug: "x" }, { slug: "x" }];
+    expect(deduplicateSlugs(items)).toEqual([{ slug: "x" }, { slug: "x-1" }, { slug: "x-2" }]);
+  });
+
+  test("uses 1-based counter regardless of array position", () => {
+    const items = [{ slug: "a" }, { slug: "x" }, { slug: "x" }];
+    expect(deduplicateSlugs(items)).toEqual([{ slug: "a" }, { slug: "x" }, { slug: "x-1" }]);
+  });
+
+  test("avoids collision with pre-existing slugs", () => {
+    const items = [{ slug: "x" }, { slug: "x" }, { slug: "x-1" }];
+    expect(deduplicateSlugs(items)).toEqual([{ slug: "x" }, { slug: "x-2" }, { slug: "x-1" }]);
+  });
+
+  test("preserves extra properties", () => {
+    const items = [
+      { slug: "a", title: "A" },
+      { slug: "a", title: "B" },
+    ];
+    const result = deduplicateSlugs(items);
+    expect(result[0]).toEqual({ slug: "a", title: "A" });
+    expect(result[1]).toEqual({ slug: "a-1", title: "B" });
+  });
+
+  test("handles empty array", () => {
+    expect(deduplicateSlugs([])).toEqual([]);
+  });
+
+  test("handles single item", () => {
+    expect(deduplicateSlugs([{ slug: "a" }])).toEqual([{ slug: "a" }]);
   });
 });
 

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -1,6 +1,4 @@
-import slug from "slug";
-
-export const SLUG_MAX_LENGTH = 50;
+const SLUG_MAX_LENGTH = 50;
 const NAME_PLACEHOLDER = "{{NAME}}";
 
 export function removeAccents(str: string): string {
@@ -12,7 +10,40 @@ export function normalizeString(str: string): string {
 }
 
 export function toSlug(str: string): string {
-  return slug(str.trim());
+  return removeAccents(str.trim())
+    .normalize("NFC")
+    .toLowerCase()
+    .replaceAll(/[^\p{L}\p{N}\p{M}\s-]/gu, "")
+    .replaceAll(/\s+/g, "-")
+    .replaceAll(/-+/g, "-")
+    .replaceAll(/^-|-$/g, "")
+    .slice(0, SLUG_MAX_LENGTH);
+}
+
+function nextAvailableSlug(base: string, taken: Set<string>): string {
+  let counter = 1;
+
+  while (taken.has(`${base}-${counter}`)) {
+    counter += 1;
+  }
+
+  return `${base}-${counter}`;
+}
+
+export function deduplicateSlugs<T extends { slug: string }>(items: T[]): T[] {
+  const taken = new Set<string>(items.map((item) => item.slug));
+  const seen = new Set<string>();
+
+  return items.map((item) => {
+    if (!seen.has(item.slug)) {
+      seen.add(item.slug);
+      return item;
+    }
+
+    const candidate = nextAvailableSlug(item.slug, taken);
+    taken.add(candidate);
+    return { ...item, slug: candidate };
+  });
 }
 
 export function emptyToNull(value?: string | null): string | null {

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -16,8 +16,8 @@ export function toSlug(str: string): string {
     .replaceAll(/[^\p{L}\p{N}\p{M}\s-]/gu, "")
     .replaceAll(/\s+/g, "-")
     .replaceAll(/-+/g, "-")
-    .replaceAll(/^-|-$/g, "")
-    .slice(0, SLUG_MAX_LENGTH);
+    .slice(0, SLUG_MAX_LENGTH)
+    .replaceAll(/^-|-$/g, "");
 }
 
 function nextAvailableSlug(base: string, taken: Set<string>): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,7 +113,7 @@ importers:
     dependencies:
       '@sentry/nextjs':
         specifier: 10.43.0
-        version: 10.43.0(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4(@swc/core@1.15.3)(esbuild@0.27.4))
+        version: 10.43.0(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4(@swc/core@1.15.3)(esbuild@0.27.4))
       '@tabler/icons-react':
         specifier: 3.40.0
         version: 3.40.0(react@19.2.4)
@@ -158,14 +158,14 @@ importers:
         version: 0.0.1
       workflow:
         specifier: 4.2.0-beta.70
-        version: 4.2.0-beta.70(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+        version: 4.2.0-beta.70(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       zod:
         specifier: 4.3.6
         version: 4.3.6
     devDependencies:
       '@scalar/nextjs-api-reference':
         specifier: 0.10.3
-        version: 0.10.3(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 0.10.3(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@types/node':
         specifier: ^24
         version: 24.12.0
@@ -368,7 +368,7 @@ importers:
         version: 3.40.0(react@19.2.4)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 2.0.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@zoonk/ai':
         specifier: workspace:*
         version: link:../../packages/ai
@@ -919,16 +919,10 @@ importers:
       negotiator:
         specifier: 1.0.0
         version: 1.0.0
-      slug:
-        specifier: 11.0.1
-        version: 11.0.1
     devDependencies:
       '@types/negotiator':
         specifier: 0.6.4
         version: 0.6.4
-      '@types/slug':
-        specifier: 5.0.9
-        version: 5.0.9
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260314.1
         version: 7.0.0-dev.20260314.1
@@ -4014,9 +4008,6 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
-  '@types/slug@5.0.9':
-    resolution: {integrity: sha512-6Yp8BSplP35Esa/wOG1wLNKiqXevpQTEF/RcL/NV6BBQaMmZh4YlDwCgrrFSoUE4xAGvnKd5c+lkQJmPrBAzfQ==}
-
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
@@ -6958,10 +6949,6 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  slug@11.0.1:
-    resolution: {integrity: sha512-VrM060OM/E7rdLQSnp6JHrzFfJFmqQBp0+TMhZStnEB8PfNliaZ9UWYjTHGHLUFVJorZ8TjVd/aKvIxHWU2O7g==}
-    hasBin: true
-
   smol-toml@1.6.0:
     resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
     engines: {node: '>= 18'}
@@ -9690,7 +9677,7 @@ snapshots:
 
   '@scalar/helpers@0.4.1': {}
 
-  '@scalar/nextjs-api-reference@0.10.3(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+  '@scalar/nextjs-api-reference@0.10.3(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@scalar/core': 0.4.3
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -9792,7 +9779,7 @@ snapshots:
 
   '@sentry/core@10.43.0': {}
 
-  '@sentry/nextjs@10.43.0(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4(@swc/core@1.15.3)(esbuild@0.27.4))':
+  '@sentry/nextjs@10.43.0(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4(@swc/core@1.15.3)(esbuild@0.27.4))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -10601,8 +10588,6 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@types/slug@5.0.9': {}
-
   '@types/tedious@4.0.14':
     dependencies:
       '@types/node': 24.12.0
@@ -10654,7 +10639,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vercel/analytics@2.0.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+  '@vercel/analytics@2.0.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     optionalDependencies:
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -10925,7 +10910,7 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@workflow/next@4.0.1-beta.66(@opentelemetry/api@1.9.0)(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@workflow/next@4.0.1-beta.66(@opentelemetry/api@1.9.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@swc/core': 1.15.3
       '@workflow/builders': 4.0.1-beta.61(@opentelemetry/api@1.9.0)
@@ -14008,8 +13993,6 @@ snapshots:
 
   slash@3.0.0: {}
 
-  slug@11.0.1: {}
-
   smol-toml@1.6.0: {}
 
   sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -14699,14 +14682,14 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  workflow@4.2.0-beta.70(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3):
+  workflow@4.2.0-beta.70(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3):
     dependencies:
       '@workflow/astro': 4.0.0-beta.44(@opentelemetry/api@1.9.0)
       '@workflow/cli': 4.2.0-beta.70(@opentelemetry/api@1.9.0)
       '@workflow/core': 4.2.0-beta.70(@opentelemetry/api@1.9.0)
       '@workflow/errors': 4.1.0-beta.18
       '@workflow/nest': 0.0.0-beta.19(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)
-      '@workflow/next': 4.0.1-beta.66(@opentelemetry/api@1.9.0)(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@workflow/next': 4.0.1-beta.66(@opentelemetry/api@1.9.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@workflow/nitro': 4.0.1-beta.65(@opentelemetry/api@1.9.0)
       '@workflow/nuxt': 4.0.1-beta.54(@opentelemetry/api@1.9.0)
       '@workflow/rollup': 4.0.0-beta.27(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
## Summary

- Replace `slug` npm package with custom Unicode-aware `toSlug` using `\p{L}`, `\p{N}`, `\p{M}` regex classes — preserves CJK, Cyrillic, Arabic, Thai, and other scripts in slugs
- Add `deduplicateSlugs` utility with collision-safe suffix generation, applied in `addChaptersStep` and `addLessonsStep` batch creates
- Enforce `SLUG_MAX_LENGTH` inside `toSlug` so all callers get truncation automatically (removed redundant manual truncation from `step-image.ts` and `step-visual-image.ts`)
- Remove `slug` and `@types/slug` dependencies

Closes #1036

## Test plan

- [x] 271 unit tests pass (comprehensive slug tests for Latin accents, CJK, mixed scripts, punctuation, edge cases, deduplication with collision avoidance)
- [x] All apps build (main, editor, api)
- [x] E2E tests pass for all apps
- [x] `pnpm typecheck`, `pnpm knip --production`, `pnpm turbo quality:fix` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the `slug` package with a Unicode‑aware `toSlug` that preserves non‑Latin characters, and added `deduplicateSlugs` to prevent collisions in batch chapter/lesson creates. Addresses #1036.

- **Bug Fixes**
  - Preserve CJK, Cyrillic, Arabic, Thai, and mixed scripts; remove punctuation; collapse dashes; normalize accents; enforce a 50‑char `SLUG_MAX_LENGTH`.
  - Strip trailing hyphens after truncation.
  - Apply `deduplicateSlugs` in `addChaptersStep` and `addLessonsStep` to suffix duplicates (`-1`, `-2`, …).
  - Remove manual truncation from step image generators since `toSlug` now truncates.

- **Dependencies**
  - Remove `slug` and `@types/slug` from `packages/utils`.

<sup>Written for commit f6525d3aa8ee6a7825c8b899bfa1073bfcdee2ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

