### PR TITLE
refactor(db): deduplicate TTS audio with WordAudio/SentenceAudio tables

### DIFF
--- a/apps/api/src/workflows/activity-generation/kinds/reading-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/reading-workflow.test.ts
@@ -384,19 +384,28 @@ describe(readingActivityWorkflow, () => {
     expect(allVariants[0]!.word).toBe(capitalizedWord);
   });
 
-  test("skips TTS for sentence words that already have an audioUrl", async () => {
+  test("skips TTS for sentence words that already have a WordAudio record", async () => {
     const id = randomUUID().replaceAll("-", "").slice(0, 8);
     const existingWord = `zexist${id}`;
     const newWord = `znew${id}`;
 
-    await prisma.word.create({
+    const wordAudio = await prisma.wordAudio.create({
       data: {
         audioUrl: "https://example.com/existing-audio.mp3",
+        organizationId,
+        targetLanguage: "es",
+        word: existingWord,
+      },
+    });
+
+    await prisma.word.create({
+      data: {
         organizationId,
         targetLanguage: "es",
         translation: "existing",
         userLanguage: "en",
         word: existingWord,
+        wordAudioId: wordAudio.id,
       },
     });
 

--- a/apps/api/src/workflows/activity-generation/kinds/reading-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/reading-workflow.ts
@@ -31,8 +31,8 @@ export async function readingActivityWorkflow(
 
   const { savedSentences } = await saveReadingSentencesStep(activities, sentences);
 
-  const { audioUrls } = await generateReadingAudioStep(activities, savedSentences);
-  await updateReadingEnrichmentsStep(activities, savedSentences, audioUrls);
+  const { sentenceAudioIds } = await generateReadingAudioStep(activities, savedSentences);
+  await updateReadingEnrichmentsStep(activities, savedSentences, sentenceAudioIds);
 
   const { wordMetadata } = await generateSentenceWordMetadataStep(activities, savedSentences);
 
@@ -42,8 +42,8 @@ export async function readingActivityWorkflow(
     wordMetadata,
   );
 
-  const { wordAudioUrls } = await generateSentenceWordAudioStep(activities, savedSentenceWords);
-  await updateSentenceWordEnrichmentsStep(activities, savedSentenceWords, wordAudioUrls);
+  const { wordAudioIds } = await generateSentenceWordAudioStep(activities, savedSentenceWords);
+  await updateSentenceWordEnrichmentsStep(activities, savedSentenceWords, wordAudioIds);
 
   await completeActivityStep(activities, workflowRunId, "reading");
 }

--- a/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.test.ts
@@ -350,6 +350,74 @@ describe(vocabularyActivityWorkflow, () => {
     expect(result.words).toHaveLength(0);
   });
 
+  test("preserves existing wordAudioId when audio step fails but pronunciation succeeds", async () => {
+    const id = randomUUID().replaceAll("-", "").slice(0, 8);
+    const existingWord = `zkeep${id}`;
+    const newWord = `znew${id}`;
+
+    const wordAudio = await prisma.wordAudio.create({
+      data: {
+        audioUrl: "https://example.com/keep-audio.mp3",
+        organizationId,
+        targetLanguage: "es",
+        word: existingWord,
+      },
+    });
+
+    await prisma.word.create({
+      data: {
+        organizationId,
+        targetLanguage: "es",
+        translation: "existing",
+        userLanguage: "en",
+        word: existingWord,
+        wordAudioId: wordAudio.id,
+      },
+    });
+
+    const mockWords: VocabularyWord[] = [
+      {
+        alternativeTranslations: [],
+        romanization: "r1",
+        translation: "existing",
+        word: existingWord,
+      },
+      { alternativeTranslations: [], romanization: "r2", translation: "new", word: newWord },
+    ];
+
+    vi.mocked(generateActivityVocabulary).mockResolvedValueOnce({
+      data: { words: mockWords },
+    } as Awaited<ReturnType<typeof generateActivityVocabulary>>);
+
+    // Audio rejects for the new word → audio step throws → settled returns {}
+    vi.mocked(generateLanguageAudio).mockRejectedValueOnce(new Error("TTS failed"));
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `Vocab KeepAudio ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+    await vocabularyActivityWorkflow(activities, "test-run-id", [], []);
+
+    const updatedWord = await prisma.word.findFirst({
+      where: { organizationId, targetLanguage: "es", word: existingWord },
+    });
+
+    expect(updatedWord?.wordAudioId).toBe(wordAudio.id);
+  });
+
   test("skips TTS for vocabulary words that already have a WordAudio record", async () => {
     const id = randomUUID().replaceAll("-", "").slice(0, 8);
     const existingWord = `zexist${id}`;

--- a/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.test.ts
@@ -350,18 +350,16 @@ describe(vocabularyActivityWorkflow, () => {
     expect(result.words).toHaveLength(0);
   });
 
-  test("skips TTS for vocabulary words that already have an audioUrl", async () => {
+  test("skips TTS for vocabulary words that already have a WordAudio record", async () => {
     const id = randomUUID().replaceAll("-", "").slice(0, 8);
     const existingWord = `zexist${id}`;
     const newWord = `znew${id}`;
 
-    await prisma.word.create({
+    await prisma.wordAudio.create({
       data: {
         audioUrl: "https://example.com/existing-audio.mp3",
         organizationId,
         targetLanguage: "es",
-        translation: "existing",
-        userLanguage: "en",
         word: existingWord,
       },
     });

--- a/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.ts
@@ -31,9 +31,9 @@ export async function vocabularyActivityWorkflow(
 
   const { savedWords } = settled(saveWordsResult, { savedWords: [] });
   const { pronunciations } = settled(pronunciationResult, { pronunciations: {} });
-  const { audioUrls } = settled(audioResult, { audioUrls: {} });
+  const { wordAudioIds } = settled(audioResult, { wordAudioIds: {} });
 
-  await updateVocabularyEnrichmentsStep(activities, savedWords, pronunciations, audioUrls);
+  await updateVocabularyEnrichmentsStep(activities, savedWords, pronunciations, wordAudioIds);
   await completeActivityStep(activities, workflowRunId, "vocabulary");
   await completeActivityStep(activities, workflowRunId, "translation");
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.ts
@@ -1,3 +1,4 @@
+import { prisma } from "@zoonk/db";
 import { isTTSSupportedLanguage } from "@zoonk/utils/languages";
 import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
@@ -9,13 +10,13 @@ import { type SavedSentence } from "./save-reading-sentences-step";
 export async function generateReadingAudioStep(
   activities: LessonActivity[],
   savedSentences: SavedSentence[],
-): Promise<{ audioUrls: Record<string, string> }> {
+): Promise<{ sentenceAudioIds: Record<string, bigint> }> {
   "use step";
 
   const activity = findActivityByKind(activities, "reading");
 
   if (!activity || savedSentences.length === 0) {
-    return { audioUrls: {} };
+    return { sentenceAudioIds: {} };
   }
 
   const course = activity.lesson.chapter.course;
@@ -23,29 +24,65 @@ export async function generateReadingAudioStep(
 
   await streamStatus({ status: "started", step: "generateAudio" });
 
-  if (!isTTSSupportedLanguage(targetLanguage)) {
+  if (!isTTSSupportedLanguage(targetLanguage) || !course.organization) {
     await streamStatus({ status: "completed", step: "generateAudio" });
-    return { audioUrls: {} };
+    return { sentenceAudioIds: {} };
   }
 
+  const organizationId = course.organization.id;
+
+  const existingAudios = await prisma.sentenceAudio.findMany({
+    select: { id: true, sentence: true },
+    where: {
+      organizationId,
+      sentence: { in: savedSentences.map((saved) => saved.sentence) },
+      targetLanguage,
+    },
+  });
+
+  const existingAudioIds: Record<string, bigint> = Object.fromEntries(
+    existingAudios.map((record) => [record.sentence, record.id]),
+  );
+
+  const sentencesNeedingAudio = savedSentences.filter((saved) => !existingAudioIds[saved.sentence]);
+
   const results = await Promise.all(
-    savedSentences.map((saved) =>
+    sentencesNeedingAudio.map((saved) =>
       generateAudioForText(saved.sentence, targetLanguage, course.organization?.slug),
     ),
   );
 
   const fulfilled = results.filter((result) => result !== null);
 
-  const audioUrls: Record<string, string> = Object.fromEntries(
-    fulfilled.map(({ text, audioUrl }) => [text, audioUrl]),
+  const newAudioRecords = await Promise.all(
+    fulfilled.map((result) =>
+      prisma.sentenceAudio.upsert({
+        create: {
+          audioUrl: result.audioUrl,
+          organizationId,
+          sentence: result.text,
+          targetLanguage,
+        },
+        select: { id: true, sentence: true },
+        update: { audioUrl: result.audioUrl },
+        where: {
+          orgSentenceAudio: { organizationId, sentence: result.text, targetLanguage },
+        },
+      }),
+    ),
   );
 
-  if (fulfilled.length < savedSentences.length) {
+  const sentenceAudioIds: Record<string, bigint> = {
+    ...existingAudioIds,
+    ...Object.fromEntries(newAudioRecords.map((record) => [record.sentence, record.id])),
+  };
+
+  if (fulfilled.length < sentencesNeedingAudio.length) {
     await streamError({ reason: "enrichmentFailed", step: "generateAudio" });
     await handleActivityFailureStep({ activityId: activity.id });
-    return { audioUrls };
+    return { sentenceAudioIds };
   }
 
   await streamStatus({ status: "completed", step: "generateAudio" });
-  return { audioUrls };
+  return { sentenceAudioIds };
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-audio-step.ts
@@ -1,3 +1,4 @@
+import { prisma } from "@zoonk/db";
 import { isTTSSupportedLanguage } from "@zoonk/utils/languages";
 import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
@@ -9,13 +10,13 @@ import { type SavedSentenceWord } from "./save-sentence-words-step";
 export async function generateSentenceWordAudioStep(
   activities: LessonActivity[],
   savedSentenceWords: SavedSentenceWord[],
-): Promise<{ wordAudioUrls: Record<string, string> }> {
+): Promise<{ wordAudioIds: Record<string, bigint> }> {
   "use step";
 
   const activity = findActivityByKind(activities, "reading");
 
   if (!activity || savedSentenceWords.length === 0) {
-    return { wordAudioUrls: {} };
+    return { wordAudioIds: {} };
   }
 
   const course = activity.lesson.chapter.course;
@@ -23,16 +24,29 @@ export async function generateSentenceWordAudioStep(
 
   await streamStatus({ status: "started", step: "generateSentenceWordAudio" });
 
-  if (!isTTSSupportedLanguage(targetLanguage)) {
+  if (!isTTSSupportedLanguage(targetLanguage) || !course.organization) {
     await streamStatus({ status: "completed", step: "generateSentenceWordAudio" });
-    return { wordAudioUrls: {} };
+    return { wordAudioIds: {} };
   }
 
-  const orgSlug = course.organization?.slug;
+  const orgSlug = course.organization.slug;
+  const organizationId = course.organization.id;
 
-  const wordsNeedingAudio = savedSentenceWords.filter((saved) => !saved.audioUrl);
-  const existingAudioUrls: Record<string, string> = Object.fromEntries(
-    savedSentenceWords.flatMap((saved) => (saved.audioUrl ? [[saved.word, saved.audioUrl]] : [])),
+  const existingAudios = await prisma.wordAudio.findMany({
+    select: { id: true, word: true },
+    where: {
+      organizationId,
+      targetLanguage,
+      word: { in: savedSentenceWords.map((saved) => saved.word) },
+    },
+  });
+
+  const existingAudioIds: Record<string, bigint> = Object.fromEntries(
+    existingAudios.map((record) => [record.word, record.id]),
+  );
+
+  const wordsNeedingAudio = savedSentenceWords.filter(
+    (saved) => !saved.wordAudioId && !existingAudioIds[saved.word],
   );
 
   const results = await Promise.all(
@@ -41,17 +55,38 @@ export async function generateSentenceWordAudioStep(
 
   const fulfilled = results.filter((result) => result !== null);
 
-  const wordAudioUrls: Record<string, string> = {
-    ...existingAudioUrls,
-    ...Object.fromEntries(fulfilled.map(({ text, audioUrl }) => [text, audioUrl])),
+  const newAudioRecords = await Promise.all(
+    fulfilled.map((result) =>
+      prisma.wordAudio.upsert({
+        create: {
+          audioUrl: result.audioUrl,
+          organizationId,
+          targetLanguage,
+          word: result.text,
+        },
+        select: { id: true, word: true },
+        update: { audioUrl: result.audioUrl },
+        where: { orgWordAudio: { organizationId, targetLanguage, word: result.text } },
+      }),
+    ),
+  );
+
+  const wordAudioIds: Record<string, bigint> = {
+    ...existingAudioIds,
+    ...Object.fromEntries(
+      savedSentenceWords.flatMap((saved) =>
+        saved.wordAudioId ? [[saved.word, saved.wordAudioId]] : [],
+      ),
+    ),
+    ...Object.fromEntries(newAudioRecords.map((record) => [record.word, record.id])),
   };
 
   if (fulfilled.length < wordsNeedingAudio.length) {
     await streamError({ reason: "enrichmentFailed", step: "generateSentenceWordAudio" });
     await handleActivityFailureStep({ activityId: activity.id });
-    return { wordAudioUrls };
+    return { wordAudioIds };
   }
 
   await streamStatus({ status: "completed", step: "generateSentenceWordAudio" });
-  return { wordAudioUrls };
+  return { wordAudioIds };
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
@@ -10,13 +10,13 @@ import { handleActivityFailureStep } from "./handle-failure-step";
 export async function generateVocabularyAudioStep(
   activities: LessonActivity[],
   words: VocabularyWord[],
-): Promise<{ audioUrls: Record<string, string> }> {
+): Promise<{ wordAudioIds: Record<string, bigint> }> {
   "use step";
 
   const activity = findActivityByKind(activities, "vocabulary");
 
   if (!activity || words.length === 0) {
-    return { audioUrls: {} };
+    return { wordAudioIds: {} };
   }
 
   const course = activity.lesson.chapter.course;
@@ -26,29 +26,26 @@ export async function generateVocabularyAudioStep(
 
   if (!isTTSSupportedLanguage(targetLanguage) || !course.organization) {
     await streamStatus({ status: "completed", step: "generateVocabularyAudio" });
-    return { audioUrls: {} };
+    return { wordAudioIds: {} };
   }
 
   const orgSlug = course.organization.slug;
   const organizationId = course.organization.id;
-  const userLanguage = activity.language;
 
-  const wordsWithAudio = await prisma.word.findMany({
-    select: { audioUrl: true, word: true },
+  const existingAudios = await prisma.wordAudio.findMany({
+    select: { id: true, word: true },
     where: {
-      audioUrl: { not: null },
       organizationId,
       targetLanguage,
-      userLanguage,
       word: { in: words.map((vocab) => vocab.word) },
     },
   });
 
-  const existingAudioUrls: Record<string, string> = Object.fromEntries(
-    wordsWithAudio.flatMap((record) => (record.audioUrl ? [[record.word, record.audioUrl]] : [])),
+  const existingAudioIds: Record<string, bigint> = Object.fromEntries(
+    existingAudios.map((record) => [record.word, record.id]),
   );
 
-  const wordsNeedingAudio = words.filter((vocab) => !existingAudioUrls[vocab.word]);
+  const wordsNeedingAudio = words.filter((vocab) => !existingAudioIds[vocab.word]);
 
   const results = await Promise.all(
     wordsNeedingAudio.map((vocabWord) =>
@@ -58,17 +55,33 @@ export async function generateVocabularyAudioStep(
 
   const fulfilled = results.filter((result) => result !== null);
 
-  const audioUrls: Record<string, string> = {
-    ...existingAudioUrls,
-    ...Object.fromEntries(fulfilled.map(({ text, audioUrl }) => [text, audioUrl])),
+  const newAudioRecords = await Promise.all(
+    fulfilled.map((result) =>
+      prisma.wordAudio.upsert({
+        create: {
+          audioUrl: result.audioUrl,
+          organizationId,
+          targetLanguage,
+          word: result.text,
+        },
+        select: { id: true, word: true },
+        update: { audioUrl: result.audioUrl },
+        where: { orgWordAudio: { organizationId, targetLanguage, word: result.text } },
+      }),
+    ),
+  );
+
+  const wordAudioIds: Record<string, bigint> = {
+    ...existingAudioIds,
+    ...Object.fromEntries(newAudioRecords.map((record) => [record.word, record.id])),
   };
 
   if (fulfilled.length < wordsNeedingAudio.length) {
     await streamError({ reason: "enrichmentFailed", step: "generateVocabularyAudio" });
     await handleActivityFailureStep({ activityId: activity.id });
-    return { audioUrls };
+    return { wordAudioIds };
   }
 
   await streamStatus({ status: "completed", step: "generateVocabularyAudio" });
-  return { audioUrls };
+  return { wordAudioIds };
 }

--- a/apps/api/src/workflows/activity-generation/steps/save-sentence-words-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-sentence-words-step.ts
@@ -8,8 +8,8 @@ import { handleActivityFailureStep } from "./handle-failure-step";
 import { type SavedSentence } from "./save-reading-sentences-step";
 
 export type SavedSentenceWord = {
-  audioUrl: string | null;
   word: string;
+  wordAudioId: bigint | null;
   wordId: number;
 };
 
@@ -70,7 +70,7 @@ function buildSaveOneWord(params: {
       },
     });
 
-    return { audioUrl: record.audioUrl, word, wordId: Number(record.id) };
+    return { word, wordAudioId: record.wordAudioId, wordId: Number(record.id) };
   };
 }
 

--- a/apps/api/src/workflows/activity-generation/steps/update-reading-enrichments-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/update-reading-enrichments-step.ts
@@ -9,7 +9,7 @@ import { type SavedSentence } from "./save-reading-sentences-step";
 export async function updateReadingEnrichmentsStep(
   activities: LessonActivity[],
   savedSentences: SavedSentence[],
-  audioUrls: Record<string, string>,
+  sentenceAudioIds: Record<string, bigint>,
 ): Promise<void> {
   "use step";
 
@@ -22,10 +22,10 @@ export async function updateReadingEnrichmentsStep(
   await streamStatus({ status: "started", step: "updateSentenceEnrichments" });
 
   const updates = savedSentences
-    .filter((saved) => audioUrls[saved.sentence])
+    .filter((saved) => sentenceAudioIds[saved.sentence])
     .map((saved) =>
       prisma.sentence.update({
-        data: { audioUrl: audioUrls[saved.sentence] },
+        data: { sentenceAudioId: sentenceAudioIds[saved.sentence] ?? null },
         where: { id: saved.sentenceId },
       }),
     );

--- a/apps/api/src/workflows/activity-generation/steps/update-sentence-word-enrichments-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/update-sentence-word-enrichments-step.ts
@@ -25,7 +25,7 @@ export async function updateSentenceWordEnrichmentsStep(
     .filter((saved) => wordAudioIds[saved.word])
     .map((saved) =>
       prisma.word.update({
-        data: { wordAudioId: wordAudioIds[saved.word] ?? null },
+        data: { wordAudioId: wordAudioIds[saved.word] },
         where: { id: saved.wordId },
       }),
     );

--- a/apps/api/src/workflows/activity-generation/steps/update-sentence-word-enrichments-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/update-sentence-word-enrichments-step.ts
@@ -9,7 +9,7 @@ import { type SavedSentenceWord } from "./save-sentence-words-step";
 export async function updateSentenceWordEnrichmentsStep(
   activities: LessonActivity[],
   savedSentenceWords: SavedSentenceWord[],
-  wordAudioUrls: Record<string, string>,
+  wordAudioIds: Record<string, bigint>,
 ): Promise<void> {
   "use step";
 
@@ -22,10 +22,10 @@ export async function updateSentenceWordEnrichmentsStep(
   await streamStatus({ status: "started", step: "updateSentenceWordEnrichments" });
 
   const updates = savedSentenceWords
-    .filter((saved) => wordAudioUrls[saved.word])
+    .filter((saved) => wordAudioIds[saved.word])
     .map((saved) =>
       prisma.word.update({
-        data: { audioUrl: wordAudioUrls[saved.word] },
+        data: { wordAudioId: wordAudioIds[saved.word] ?? null },
         where: { id: saved.wordId },
       }),
     );

--- a/apps/api/src/workflows/activity-generation/steps/update-vocabulary-enrichments-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/update-vocabulary-enrichments-step.ts
@@ -10,7 +10,7 @@ export async function updateVocabularyEnrichmentsStep(
   activities: LessonActivity[],
   savedWords: SavedWord[],
   pronunciations: Record<string, string>,
-  audioUrls: Record<string, string>,
+  wordAudioIds: Record<string, bigint>,
 ): Promise<void> {
   "use step";
 
@@ -23,10 +23,13 @@ export async function updateVocabularyEnrichmentsStep(
   await streamStatus({ status: "started", step: "updateVocabularyEnrichments" });
 
   const updates = savedWords
-    .filter((saved) => pronunciations[saved.word] || audioUrls[saved.word])
+    .filter((saved) => pronunciations[saved.word] || wordAudioIds[saved.word])
     .map((saved) =>
       prisma.word.update({
-        data: { audioUrl: audioUrls[saved.word], pronunciation: pronunciations[saved.word] },
+        data: {
+          pronunciation: pronunciations[saved.word],
+          wordAudioId: wordAudioIds[saved.word] ?? null,
+        },
         where: { id: saved.wordId },
       }),
     );

--- a/apps/api/src/workflows/activity-generation/steps/update-vocabulary-enrichments-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/update-vocabulary-enrichments-step.ts
@@ -28,7 +28,7 @@ export async function updateVocabularyEnrichmentsStep(
       prisma.word.update({
         data: {
           pronunciation: pronunciations[saved.word],
-          wordAudioId: wordAudioIds[saved.word] ?? null,
+          wordAudioId: wordAudioIds[saved.word],
         },
         where: { id: saved.wordId },
       }),

--- a/apps/main/e2e/listening-step.test.ts
+++ b/apps/main/e2e/listening-step.test.ts
@@ -6,7 +6,7 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonSentenceFixture } from "@zoonk/testing/fixtures/lesson-sentences";
 import { lessonWordFixture } from "@zoonk/testing/fixtures/lesson-words";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
-import { sentenceFixture } from "@zoonk/testing/fixtures/sentences";
+import { sentenceAudioFixture, sentenceFixture } from "@zoonk/testing/fixtures/sentences";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { wordFixture } from "@zoonk/testing/fixtures/words";
 import { type Page, expect, test } from "./fixtures";
@@ -44,27 +44,36 @@ async function createListeningActivity(options: {
     title: `E2E Listen Lesson ${uniqueId}`,
   });
 
-  const [createdWords, createdSentences] = await Promise.all([
-    Promise.all(
-      options.words.map((wordData) =>
-        wordFixture({
-          organizationId: org.id,
-          translation: wordData.translation,
-          word: wordData.word,
-        }),
-      ),
+  const createdWords = await Promise.all(
+    options.words.map((wordData) =>
+      wordFixture({
+        organizationId: org.id,
+        translation: wordData.translation,
+        word: wordData.word,
+      }),
     ),
-    Promise.all(
-      options.sentences.map((sentenceData) =>
-        sentenceFixture({
-          audioUrl: sentenceData.audioUrl ?? null,
+  );
+
+  const createdSentences = await Promise.all(
+    options.sentences.map(async (sentenceData) => {
+      let sentenceAudioId: bigint | null = null;
+
+      if (sentenceData.audioUrl) {
+        const audio = await sentenceAudioFixture({
+          audioUrl: sentenceData.audioUrl,
           organizationId: org.id,
-          sentence: sentenceData.sentence,
-          translation: sentenceData.translation,
-        }),
-      ),
-    ),
-  ]);
+        });
+        sentenceAudioId = audio.id;
+      }
+
+      return sentenceFixture({
+        organizationId: org.id,
+        sentence: sentenceData.sentence,
+        sentenceAudioId,
+        translation: sentenceData.translation,
+      });
+    }),
+  );
 
   await Promise.all([
     ...createdWords.map((word) => lessonWordFixture({ lessonId: lesson.id, wordId: word.id })),

--- a/apps/main/e2e/reading-step.test.ts
+++ b/apps/main/e2e/reading-step.test.ts
@@ -6,7 +6,7 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonSentenceFixture } from "@zoonk/testing/fixtures/lesson-sentences";
 import { lessonWordFixture } from "@zoonk/testing/fixtures/lesson-words";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
-import { sentenceFixture } from "@zoonk/testing/fixtures/sentences";
+import { sentenceAudioFixture, sentenceFixture } from "@zoonk/testing/fixtures/sentences";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { wordFixture } from "@zoonk/testing/fixtures/words";
 import { type Page, expect, test } from "./fixtures";
@@ -48,29 +48,38 @@ async function createReadingActivity(options: {
     title: `E2E Reading Lesson ${uniqueId}`,
   });
 
-  const [createdWords, createdSentences] = await Promise.all([
-    Promise.all(
-      options.words.map((wordData) =>
-        wordFixture({
-          organizationId: org.id,
-          romanization: wordData.romanization ?? null,
-          translation: wordData.translation,
-          word: wordData.word,
-        }),
-      ),
+  const createdWords = await Promise.all(
+    options.words.map((wordData) =>
+      wordFixture({
+        organizationId: org.id,
+        romanization: wordData.romanization ?? null,
+        translation: wordData.translation,
+        word: wordData.word,
+      }),
     ),
-    Promise.all(
-      options.sentences.map((sentenceData) =>
-        sentenceFixture({
-          audioUrl: sentenceData.audioUrl ?? null,
+  );
+
+  const createdSentences = await Promise.all(
+    options.sentences.map(async (sentenceData) => {
+      let sentenceAudioId: bigint | null = null;
+
+      if (sentenceData.audioUrl) {
+        const audio = await sentenceAudioFixture({
+          audioUrl: sentenceData.audioUrl,
           organizationId: org.id,
-          romanization: sentenceData.romanization ?? null,
-          sentence: sentenceData.sentence,
-          translation: sentenceData.translation,
-        }),
-      ),
-    ),
-  ]);
+        });
+        sentenceAudioId = audio.id;
+      }
+
+      return sentenceFixture({
+        organizationId: org.id,
+        romanization: sentenceData.romanization ?? null,
+        sentence: sentenceData.sentence,
+        sentenceAudioId,
+        translation: sentenceData.translation,
+      });
+    }),
+  );
 
   await Promise.all([
     ...createdWords.map((word) => lessonWordFixture({ lessonId: lesson.id, wordId: word.id })),

--- a/apps/main/e2e/vocabulary-flashcard-step.test.ts
+++ b/apps/main/e2e/vocabulary-flashcard-step.test.ts
@@ -14,7 +14,6 @@ async function createFlashcardActivity(options: {
     word: string;
     translation: string;
     romanization?: string | null;
-    audioUrl?: string | null;
   }[];
 }) {
   const org = await getAiOrganization();
@@ -48,7 +47,6 @@ async function createFlashcardActivity(options: {
   const createdWords = await Promise.all(
     options.words.map((wordData) =>
       wordFixture({
-        audioUrl: wordData.audioUrl ?? null,
         organizationId: org.id,
         romanization: wordData.romanization ?? null,
         translation: wordData.translation,

--- a/apps/main/src/data/activities/get-activity.test.ts
+++ b/apps/main/src/data/activities/get-activity.test.ts
@@ -3,9 +3,9 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { sentenceFixture } from "@zoonk/testing/fixtures/sentences";
+import { sentenceAudioFixture, sentenceFixture } from "@zoonk/testing/fixtures/sentences";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
-import { wordFixture } from "@zoonk/testing/fixtures/words";
+import { wordAudioFixture, wordFixture } from "@zoonk/testing/fixtures/words";
 import { beforeAll, describe, expect, test } from "vitest";
 import { getActivity } from "./get-activity";
 
@@ -144,6 +144,11 @@ describe(getActivity, () => {
       organizationId: org.id,
     });
 
+    const wordAudio = await wordAudioFixture({
+      audioUrl: "https://example.com/audio.mp3",
+      organizationId: org.id,
+    });
+
     const [wordActivity, word] = await Promise.all([
       activityFixture({
         generationStatus: "completed",
@@ -155,12 +160,12 @@ describe(getActivity, () => {
         position: 0,
       }),
       wordFixture({
-        audioUrl: "https://example.com/audio.mp3",
         organizationId: org.id,
         pronunciation: "test-pron",
         romanization: "test-roman",
         translation: "test-translation",
         word: `test-word-${crypto.randomUUID()}`,
+        wordAudioId: wordAudio.id,
       }),
     ]);
 
@@ -175,12 +180,12 @@ describe(getActivity, () => {
 
     expect(result?.steps[0]?.word).toMatchObject({
       alternativeTranslations: [],
-      audioUrl: "https://example.com/audio.mp3",
       id: word.id,
       pronunciation: "test-pron",
       romanization: "test-roman",
       translation: "test-translation",
       word: word.word,
+      wordAudio: { audioUrl: "https://example.com/audio.mp3" },
     });
   });
 
@@ -189,6 +194,11 @@ describe(getActivity, () => {
       chapterId: chapter.id,
       isPublished: true,
       language: "en",
+      organizationId: org.id,
+    });
+
+    const sentAudio = await sentenceAudioFixture({
+      audioUrl: "https://example.com/sent-audio.mp3",
       organizationId: org.id,
     });
 
@@ -203,10 +213,10 @@ describe(getActivity, () => {
         position: 0,
       }),
       sentenceFixture({
-        audioUrl: "https://example.com/sent-audio.mp3",
         organizationId: org.id,
         romanization: "test-sent-roman",
         sentence: `test-sentence-${crypto.randomUUID()}`,
+        sentenceAudioId: sentAudio.id,
         translation: "test-sent-translation",
       }),
     ]);
@@ -221,10 +231,10 @@ describe(getActivity, () => {
     const result = await getActivity({ lessonId: sentLesson.id, position: 0 });
 
     expect(result?.steps[0]?.sentence).toMatchObject({
-      audioUrl: "https://example.com/sent-audio.mp3",
       id: sentence.id,
       romanization: "test-sent-roman",
       sentence: sentence.sentence,
+      sentenceAudio: { audioUrl: "https://example.com/sent-audio.mp3" },
       translation: "test-sent-translation",
     });
   });

--- a/apps/main/src/data/activities/get-activity.ts
+++ b/apps/main/src/data/activities/get-activity.ts
@@ -7,8 +7,8 @@ const cachedGetActivity = cache(async (lessonId: number, position: number) =>
     include: {
       steps: {
         include: {
-          sentence: true,
-          word: true,
+          sentence: { include: { sentenceAudio: true } },
+          word: { include: { wordAudio: true } },
         },
         orderBy: { position: "asc" },
         where: { isPublished: true },

--- a/apps/main/src/data/activities/get-lesson-sentences.test.ts
+++ b/apps/main/src/data/activities/get-lesson-sentences.test.ts
@@ -3,7 +3,7 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonSentenceFixture } from "@zoonk/testing/fixtures/lesson-sentences";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { sentenceFixture } from "@zoonk/testing/fixtures/sentences";
+import { sentenceAudioFixture, sentenceFixture } from "@zoonk/testing/fixtures/sentences";
 import { beforeAll, describe, expect, test } from "vitest";
 import { getLessonSentences } from "./get-lesson-sentences";
 
@@ -75,11 +75,17 @@ describe(getLessonSentences, () => {
       organizationId: org.id,
     });
 
-    const sentence = await sentenceFixture({
+    const sentAudio = await sentenceAudioFixture({
       audioUrl: "https://example.com/megusta.mp3",
+      organizationId: org.id,
+      targetLanguage: "es",
+    });
+
+    const sentence = await sentenceFixture({
       organizationId: org.id,
       romanization: null,
       sentence: `Me gusta ${crypto.randomUUID()}`,
+      sentenceAudioId: sentAudio.id,
       targetLanguage: "es",
       translation: "I like",
     });
@@ -90,10 +96,10 @@ describe(getLessonSentences, () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
-      audioUrl: "https://example.com/megusta.mp3",
       id: sentence.id,
       romanization: null,
       sentence: sentence.sentence,
+      sentenceAudio: { audioUrl: "https://example.com/megusta.mp3" },
       translation: "I like",
     });
   });

--- a/apps/main/src/data/activities/get-lesson-sentences.ts
+++ b/apps/main/src/data/activities/get-lesson-sentences.ts
@@ -1,16 +1,16 @@
 import "server-only";
-import { type Sentence, prisma } from "@zoonk/db";
+import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
-const cachedGetLessonSentences = cache(async (lessonId: number): Promise<Sentence[]> => {
+const cachedGetLessonSentences = cache(async (lessonId: number) => {
   const lessonSentences = await prisma.lessonSentence.findMany({
-    include: { sentence: true },
+    include: { sentence: { include: { sentenceAudio: true } } },
     where: { lessonId },
   });
 
   return lessonSentences.map((ls) => ls.sentence);
 });
 
-export function getLessonSentences(params: { lessonId: number }): Promise<Sentence[]> {
+export function getLessonSentences(params: { lessonId: number }) {
   return cachedGetLessonSentences(params.lessonId);
 }

--- a/apps/main/src/data/activities/get-lesson-words.test.ts
+++ b/apps/main/src/data/activities/get-lesson-words.test.ts
@@ -3,7 +3,7 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonWordFixture } from "@zoonk/testing/fixtures/lesson-words";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { wordFixture } from "@zoonk/testing/fixtures/words";
+import { wordAudioFixture, wordFixture } from "@zoonk/testing/fixtures/words";
 import { beforeAll, describe, expect, test } from "vitest";
 import { getLessonWords } from "./get-lesson-words";
 
@@ -77,14 +77,20 @@ describe(getLessonWords, () => {
       organizationId: org.id,
     });
 
-    const word = await wordFixture({
+    const wordAudio = await wordAudioFixture({
       audioUrl: "https://example.com/perro.mp3",
+      organizationId: org.id,
+      targetLanguage: "es",
+    });
+
+    const word = await wordFixture({
       organizationId: org.id,
       pronunciation: "peh-roh",
       romanization: null,
       targetLanguage: "es",
       translation: "dog",
       word: `perro-${crypto.randomUUID()}`,
+      wordAudioId: wordAudio.id,
     });
 
     await lessonWordFixture({ lessonId: newLesson.id, wordId: word.id });
@@ -94,12 +100,12 @@ describe(getLessonWords, () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       alternativeTranslations: [],
-      audioUrl: "https://example.com/perro.mp3",
       id: word.id,
       pronunciation: "peh-roh",
       romanization: null,
       translation: "dog",
       word: word.word,
+      wordAudio: { audioUrl: "https://example.com/perro.mp3" },
     });
   });
 

--- a/apps/main/src/data/activities/get-lesson-words.ts
+++ b/apps/main/src/data/activities/get-lesson-words.ts
@@ -1,16 +1,16 @@
 import "server-only";
-import { type Word, prisma } from "@zoonk/db";
+import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
-const cachedGetLessonWords = cache(async (lessonId: number): Promise<Word[]> => {
+const cachedGetLessonWords = cache(async (lessonId: number) => {
   const lessonWords = await prisma.lessonWord.findMany({
-    include: { word: true },
+    include: { word: { include: { wordAudio: true } } },
     where: { lessonId },
   });
 
   return lessonWords.map((lw) => lw.word);
 });
 
-export function getLessonWords(params: { lessonId: number }): Promise<Word[]> {
+export function getLessonWords(params: { lessonId: number }) {
   return cachedGetLessonWords(params.lessonId);
 }

--- a/apps/main/src/data/activities/get-review-steps.ts
+++ b/apps/main/src/data/activities/get-review-steps.ts
@@ -37,7 +37,10 @@ export async function getReviewSteps({
 
   if (!userId) {
     const allSteps = await prisma.step.findMany({
-      include: { sentence: true, word: true },
+      include: {
+        sentence: { include: { sentenceAudio: true } },
+        word: { include: { wordAudio: true } },
+      },
       where: lessonStepFilter,
     });
 
@@ -49,7 +52,10 @@ export async function getReviewSteps({
   // and avoids extra queries for prioritized/filler IDs.
   const [allSteps, incorrectAttempts, correctAttempts] = await Promise.all([
     prisma.step.findMany({
-      include: { sentence: true, word: true },
+      include: {
+        sentence: { include: { sentenceAudio: true } },
+        word: { include: { wordAudio: true } },
+      },
       where: lessonStepFilter,
     }),
     prisma.stepAttempt.findMany({
@@ -95,7 +101,10 @@ export async function getReviewSteps({
  */
 export async function getReviewValidationSteps(lessonId: number, stepIds: bigint[]) {
   return prisma.step.findMany({
-    include: { sentence: true, word: true },
+    include: {
+      sentence: { include: { sentenceAudio: true } },
+      word: { include: { wordAudio: true } },
+    },
     where: { ...reviewableStepFilter(lessonId), id: { in: stepIds } },
   });
 }

--- a/apps/main/src/data/activities/get-sentence-words.ts
+++ b/apps/main/src/data/activities/get-sentence-words.ts
@@ -1,9 +1,9 @@
 import "server-only";
-import { type Word, prisma } from "@zoonk/db";
+import { prisma } from "@zoonk/db";
 import { extractUniqueSentenceWords } from "@zoonk/utils/string";
 import { cache } from "react";
 
-const cachedGetSentenceWords = cache(async (lessonId: number): Promise<Word[]> => {
+const cachedGetSentenceWords = cache(async (lessonId: number) => {
   const lessonSentences = await prisma.lessonSentence.findMany({
     include: { sentence: true },
     where: { lessonId },
@@ -29,6 +29,7 @@ const cachedGetSentenceWords = cache(async (lessonId: number): Promise<Word[]> =
   const { organizationId, targetLanguage, userLanguage } = firstSentence;
 
   return prisma.word.findMany({
+    include: { wordAudio: true },
     where: {
       organizationId,
       targetLanguage,
@@ -38,6 +39,6 @@ const cachedGetSentenceWords = cache(async (lessonId: number): Promise<Word[]> =
   });
 });
 
-export function getSentenceWords(params: { lessonId: number }): Promise<Word[]> {
+export function getSentenceWords(params: { lessonId: number }) {
   return cachedGetSentenceWords(params.lessonId);
 }

--- a/apps/main/src/data/activities/prepare-activity-data.test.ts
+++ b/apps/main/src/data/activities/prepare-activity-data.test.ts
@@ -6,9 +6,9 @@ import { lessonSentenceFixture } from "@zoonk/testing/fixtures/lesson-sentences"
 import { lessonWordFixture } from "@zoonk/testing/fixtures/lesson-words";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { sentenceFixture } from "@zoonk/testing/fixtures/sentences";
+import { sentenceAudioFixture, sentenceFixture } from "@zoonk/testing/fixtures/sentences";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
-import { wordFixture } from "@zoonk/testing/fixtures/words";
+import { wordAudioFixture, wordFixture } from "@zoonk/testing/fixtures/words";
 import { beforeAll, describe, expect, expectTypeOf, test } from "vitest";
 import { getActivity } from "./get-activity";
 
@@ -104,14 +104,19 @@ describe(prepareActivityData, () => {
   });
 
   test("serializes word data on steps with word relations", async () => {
+    const wordAudio = await wordAudioFixture({
+      audioUrl: "https://example.com/word.mp3",
+      organizationId: org.id,
+    });
+
     const [word, activity] = await Promise.all([
       wordFixture({
-        audioUrl: "https://example.com/word.mp3",
         organizationId: org.id,
         pronunciation: "hola",
         romanization: null,
         translation: "hello",
         word: `hola-${crypto.randomUUID()}`,
+        wordAudioId: wordAudio.id,
       }),
       activityFixture({
         generationStatus: "completed",
@@ -148,12 +153,17 @@ describe(prepareActivityData, () => {
   });
 
   test("serializes sentence data on steps with sentence relations", async () => {
+    const sentAudio = await sentenceAudioFixture({
+      audioUrl: "https://example.com/sent.mp3",
+      organizationId: org.id,
+    });
+
     const [sentence, activity] = await Promise.all([
       sentenceFixture({
-        audioUrl: "https://example.com/sent.mp3",
         organizationId: org.id,
         romanization: "konnichiwa",
         sentence: `konnichiwa-${crypto.randomUUID()}`,
+        sentenceAudioId: sentAudio.id,
         translation: "hello",
       }),
       activityFixture({
@@ -239,30 +249,30 @@ describe(prepareActivityData, () => {
     const lessonWords = [
       {
         alternativeTranslations: word1.alternativeTranslations,
-        audioUrl: word1.audioUrl,
         id: word1.id,
         pronunciation: word1.pronunciation,
         romanization: word1.romanization,
         translation: word1.translation,
         word: word1.word,
+        wordAudio: word1.wordAudio,
       },
       {
         alternativeTranslations: word2.alternativeTranslations,
-        audioUrl: word2.audioUrl,
         id: word2.id,
         pronunciation: word2.pronunciation,
         romanization: word2.romanization,
         translation: word2.translation,
         word: word2.word,
+        wordAudio: word2.wordAudio,
       },
     ];
 
     const lessonSentences = [
       {
-        audioUrl: sentence1.audioUrl,
         id: sentence1.id,
         romanization: sentence1.romanization,
         sentence: sentence1.sentence,
+        sentenceAudio: sentence1.sentenceAudio,
         translation: sentence1.translation,
       },
     ];
@@ -344,22 +354,22 @@ describe(prepareActivityData, () => {
   test("copies alternativeTranslations arrays for translation options", () => {
     const stepWord = {
       alternativeTranslations: ["hello"],
-      audioUrl: null,
       id: BigInt(1),
       pronunciation: null,
       romanization: null,
       translation: "hello",
       word: "hola",
+      wordAudio: null,
     };
 
     const lessonWord = {
       alternativeTranslations: ["cat"],
-      audioUrl: null,
       id: BigInt(2),
       pronunciation: null,
       romanization: null,
       translation: "cat",
       word: "gato",
+      wordAudio: null,
     };
 
     const activity = {
@@ -440,21 +450,21 @@ describe(prepareActivityData, () => {
     const lessonWords = [
       {
         alternativeTranslations: [],
-        audioUrl: null,
         id: word1.id,
         pronunciation: null,
         romanization: null,
         translation: word1.translation,
         word: word1.word,
+        wordAudio: null,
       },
       {
         alternativeTranslations: [],
-        audioUrl: null,
         id: word2.id,
         pronunciation: null,
         romanization: null,
         translation: word2.translation,
         word: word2.word,
+        wordAudio: null,
       },
     ];
 
@@ -514,21 +524,21 @@ describe(prepareActivityData, () => {
     const lessonWords = [
       {
         alternativeTranslations: [],
-        audioUrl: null,
         id: word1.id,
         pronunciation: null,
         romanization: null,
         translation: word1.translation,
         word: word1.word,
+        wordAudio: null,
       },
       {
         alternativeTranslations: [],
-        audioUrl: null,
         id: word2.id,
         pronunciation: null,
         romanization: null,
         translation: word2.translation,
         word: word2.word,
+        wordAudio: null,
       },
     ];
 
@@ -563,10 +573,10 @@ describe(prepareActivityData, () => {
           kind: "reading",
           position: 0,
           sentence: {
-            audioUrl: null,
             id: BigInt(72),
             romanization: null,
             sentence: "gato bonito",
+            sentenceAudio: null,
             translation: "pretty cat",
           },
           word: null,
@@ -578,12 +588,12 @@ describe(prepareActivityData, () => {
     const lessonWords = [
       {
         alternativeTranslations: [],
-        audioUrl: "https://example.com/gato.mp3",
         id: BigInt(73),
         pronunciation: null,
         romanization: "ga-to",
         translation: "cat",
         word: "gato",
+        wordAudio: { audioUrl: "https://example.com/gato.mp3" },
       },
     ];
 
@@ -615,10 +625,10 @@ describe(prepareActivityData, () => {
           kind: "reading",
           position: 0,
           sentence: {
-            audioUrl: null,
             id: BigInt(76),
             romanization: null,
             sentence: "gato bonito",
+            sentenceAudio: null,
             translation: "pretty cat",
           },
           word: null,
@@ -630,24 +640,24 @@ describe(prepareActivityData, () => {
     const lessonWords = [
       {
         alternativeTranslations: [],
-        audioUrl: "https://example.com/lesson-gato.mp3",
         id: BigInt(77),
         pronunciation: null,
         romanization: null,
         translation: "cat (lesson)",
         word: "gato",
+        wordAudio: { audioUrl: "https://example.com/lesson-gato.mp3" },
       },
     ];
 
     const sentenceWords = [
       {
         alternativeTranslations: [],
-        audioUrl: "https://example.com/sentence-gato.mp3",
         id: BigInt(78),
         pronunciation: null,
         romanization: "ga-to",
         translation: "cat (sentence)",
         word: "gato",
+        wordAudio: { audioUrl: "https://example.com/sentence-gato.mp3" },
       },
     ];
 
@@ -678,10 +688,10 @@ describe(prepareActivityData, () => {
           kind: "reading",
           position: 0,
           sentence: {
-            audioUrl: null,
             id: BigInt(22),
             romanization: null,
             sentence: "Hola mundo",
+            sentenceAudio: null,
             translation: "Hello world",
           },
           word: null,
@@ -694,21 +704,21 @@ describe(prepareActivityData, () => {
     const lessonWords = [
       {
         alternativeTranslations: [],
-        audioUrl: null,
         id: BigInt(23),
         pronunciation: null,
         romanization: null,
         translation: "hello",
         word: "hola",
+        wordAudio: null,
       },
       {
         alternativeTranslations: [],
-        audioUrl: null,
         id: BigInt(24),
         pronunciation: null,
         romanization: null,
         translation: "cat",
         word: "gato",
+        wordAudio: null,
       },
     ];
 
@@ -737,10 +747,10 @@ describe(prepareActivityData, () => {
           kind: "reading",
           position: 0,
           sentence: {
-            audioUrl: null,
             id: BigInt(32),
             romanization: null,
             sentence: "Sabes you?",
+            sentenceAudio: null,
             translation: "Know you?",
           },
           word: null,
@@ -753,21 +763,21 @@ describe(prepareActivityData, () => {
     const lessonWords = [
       {
         alternativeTranslations: [],
-        audioUrl: null,
         id: BigInt(33),
         pronunciation: null,
         romanization: null,
         translation: "you",
         word: "you",
+        wordAudio: null,
       },
       {
         alternativeTranslations: [],
-        audioUrl: null,
         id: BigInt(34),
         pronunciation: null,
         romanization: null,
         translation: "cat",
         word: "gato",
+        wordAudio: null,
       },
     ];
 
@@ -796,10 +806,10 @@ describe(prepareActivityData, () => {
           kind: "reading",
           position: 0,
           sentence: {
-            audioUrl: null,
             id: BigInt(42),
             romanization: null,
             sentence: "Hola amigos",
+            sentenceAudio: null,
             translation: "Hello friends",
           },
           word: null,
@@ -812,21 +822,21 @@ describe(prepareActivityData, () => {
     const lessonWords = [
       {
         alternativeTranslations: [],
-        audioUrl: null,
         id: BigInt(43),
         pronunciation: null,
         romanization: null,
         translation: "you",
         word: "tu",
+        wordAudio: null,
       },
       {
         alternativeTranslations: [],
-        audioUrl: null,
         id: BigInt(44),
         pronunciation: null,
         romanization: null,
         translation: "you?",
         word: "tu?",
+        wordAudio: null,
       },
     ];
 
@@ -883,10 +893,10 @@ describe(prepareActivityData, () => {
           kind: "reading",
           position: 0,
           sentence: {
-            audioUrl: null,
             id: BigInt(92),
             romanization: null,
             sentence: "gato bonito",
+            sentenceAudio: null,
             translation: "pretty cat",
           },
           word: null,
@@ -898,12 +908,12 @@ describe(prepareActivityData, () => {
     const lessonWords = [
       {
         alternativeTranslations: [],
-        audioUrl: "https://example.com/gato.mp3",
         id: BigInt(93),
         pronunciation: null,
         romanization: "ga-to",
         translation: "cat",
         word: "gato",
+        wordAudio: { audioUrl: "https://example.com/gato.mp3" },
       },
     ];
 
@@ -942,10 +952,10 @@ describe(prepareActivityData, () => {
           kind: "listening",
           position: 0,
           sentence: {
-            audioUrl: null,
             id: BigInt(96),
             romanization: null,
             sentence: "gato bonito",
+            sentenceAudio: null,
             translation: "pretty cat",
           },
           word: null,
@@ -957,12 +967,12 @@ describe(prepareActivityData, () => {
     const sentenceWords = [
       {
         alternativeTranslations: [],
-        audioUrl: "https://example.com/sw-gato.mp3",
         id: BigInt(97),
         pronunciation: null,
         romanization: "ga-to-sw",
         translation: "cat (sw)",
         word: "gato",
+        wordAudio: { audioUrl: "https://example.com/sw-gato.mp3" },
       },
     ];
 

--- a/packages/db/src/prisma/migrations/20260316000000_deduplicate_tts_audio/migration.sql
+++ b/packages/db/src/prisma/migrations/20260316000000_deduplicate_tts_audio/migration.sql
@@ -1,0 +1,53 @@
+-- CreateTable
+CREATE TABLE "word_audio" (
+    "id" BIGSERIAL NOT NULL,
+    "organization_id" INTEGER NOT NULL,
+    "target_language" VARCHAR(10) NOT NULL,
+    "word" TEXT NOT NULL,
+    "audio_url" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "word_audio_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "sentence_audio" (
+    "id" BIGSERIAL NOT NULL,
+    "organization_id" INTEGER NOT NULL,
+    "target_language" VARCHAR(10) NOT NULL,
+    "sentence" TEXT NOT NULL,
+    "audio_url" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "sentence_audio_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable
+ALTER TABLE "words" ADD COLUMN "word_audio_id" BIGINT;
+
+-- AlterTable
+ALTER TABLE "sentences" ADD COLUMN "sentence_audio_id" BIGINT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "word_audio_organization_id_target_language_word_key" ON "word_audio"("organization_id", "target_language", "word");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sentence_audio_organization_id_target_language_sentence_key" ON "sentence_audio"("organization_id", "target_language", "sentence");
+
+-- AddForeignKey
+ALTER TABLE "word_audio" ADD CONSTRAINT "word_audio_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sentence_audio" ADD CONSTRAINT "sentence_audio_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "words" ADD CONSTRAINT "words_word_audio_id_fkey" FOREIGN KEY ("word_audio_id") REFERENCES "word_audio"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sentences" ADD CONSTRAINT "sentences_sentence_audio_id_fkey" FOREIGN KEY ("sentence_audio_id") REFERENCES "sentence_audio"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- DropColumn (after FK setup)
+ALTER TABLE "words" DROP COLUMN "audio_url";
+
+-- DropColumn (after FK setup)
+ALTER TABLE "sentences" DROP COLUMN "audio_url";

--- a/packages/db/src/prisma/models/accounts.prisma
+++ b/packages/db/src/prisma/models/accounts.prisma
@@ -102,7 +102,9 @@ model Organization {
   dailyProgress    DailyProgress[]
   stripeCustomerId String?         @map("stripe_customer_id")
   words            Word[]
+  wordAudios       WordAudio[]
   sentences        Sentence[]
+  sentenceAudios   SentenceAudio[]
 
   @@unique([slug])
   @@map("organizations")

--- a/packages/db/src/prisma/models/vocabulary.prisma
+++ b/packages/db/src/prisma/models/vocabulary.prisma
@@ -1,3 +1,31 @@
+model WordAudio {
+  id             BigInt       @id @default(autoincrement())
+  organizationId Int          @map("organization_id")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  targetLanguage String       @map("target_language") @db.VarChar(10)
+  word           String
+  audioUrl       String       @map("audio_url")
+  createdAt      DateTime     @default(now()) @map("created_at")
+  words          Word[]
+
+  @@unique([organizationId, targetLanguage, word], name: "orgWordAudio")
+  @@map("word_audio")
+}
+
+model SentenceAudio {
+  id             BigInt       @id @default(autoincrement())
+  organizationId Int          @map("organization_id")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  targetLanguage String       @map("target_language") @db.VarChar(10)
+  sentence       String
+  audioUrl       String       @map("audio_url")
+  createdAt      DateTime     @default(now()) @map("created_at")
+  sentences      Sentence[]
+
+  @@unique([organizationId, targetLanguage, sentence], name: "orgSentenceAudio")
+  @@map("sentence_audio")
+}
+
 model Word {
   id                      BigInt       @id @default(autoincrement())
   organizationId          Int          @map("organization_id")
@@ -9,7 +37,8 @@ model Word {
   alternativeTranslations String[]     @default([]) @map("alternative_translations")
   pronunciation           String?
   romanization            String?
-  audioUrl                String?      @map("audio_url")
+  wordAudioId             BigInt?      @map("word_audio_id")
+  wordAudio               WordAudio?   @relation(fields: [wordAudioId], references: [id], onDelete: SetNull)
   createdAt               DateTime     @default(now()) @map("created_at")
   updatedAt               DateTime     @default(now()) @updatedAt @map("updated_at")
   lessons                 LessonWord[]
@@ -21,19 +50,20 @@ model Word {
 }
 
 model Sentence {
-  id             BigInt           @id @default(autoincrement())
-  organizationId Int              @map("organization_id")
-  organization   Organization     @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  targetLanguage String           @map("target_language") @db.VarChar(10)
-  userLanguage   String           @map("user_language") @db.VarChar(10)
-  sentence       String
-  translation    String
-  romanization   String?
-  audioUrl       String?          @map("audio_url")
-  createdAt      DateTime         @default(now()) @map("created_at")
-  updatedAt      DateTime         @default(now()) @updatedAt @map("updated_at")
-  lessons        LessonSentence[]
-  steps          Step[]
+  id              BigInt           @id @default(autoincrement())
+  organizationId  Int              @map("organization_id")
+  organization    Organization     @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  targetLanguage  String           @map("target_language") @db.VarChar(10)
+  userLanguage    String           @map("user_language") @db.VarChar(10)
+  sentence        String
+  translation     String
+  romanization    String?
+  sentenceAudioId BigInt?          @map("sentence_audio_id")
+  sentenceAudio   SentenceAudio?   @relation(fields: [sentenceAudioId], references: [id], onDelete: SetNull)
+  createdAt       DateTime         @default(now()) @map("created_at")
+  updatedAt       DateTime         @default(now()) @updatedAt @map("updated_at")
+  lessons         LessonSentence[]
+  steps           Step[]
 
   @@unique([organizationId, targetLanguage, userLanguage, sentence], name: "orgSentence")
   @@index([organizationId, targetLanguage, userLanguage])

--- a/packages/db/src/prisma/seed/sentences.ts
+++ b/packages/db/src/prisma/seed/sentences.ts
@@ -6,7 +6,6 @@ type SentenceSeedData = {
   sentence: string;
   translation: string;
   romanization?: string;
-  audioUrl?: string;
   lessonSlugs: string[];
 };
 
@@ -55,7 +54,6 @@ async function seedSentence(
 ): Promise<void> {
   const sentence = await prisma.sentence.upsert({
     create: {
-      audioUrl: data.audioUrl,
       organizationId: org.id,
       romanization: data.romanization,
       sentence: data.sentence,

--- a/packages/db/src/prisma/seed/words.ts
+++ b/packages/db/src/prisma/seed/words.ts
@@ -7,7 +7,6 @@ type WordSeedData = {
   translation: string;
   pronunciation: string;
   romanization?: string;
-  audioUrl?: string;
   lessonSlugs: string[];
 };
 
@@ -61,7 +60,6 @@ async function seedWord(
 ): Promise<void> {
   const word = await prisma.word.upsert({
     create: {
-      audioUrl: data.audioUrl,
       organizationId: org.id,
       pronunciation: data.pronunciation,
       romanization: data.romanization,

--- a/packages/player/src/build-word-bank-options.ts
+++ b/packages/player/src/build-word-bank-options.ts
@@ -9,10 +9,10 @@ import {
 const WORD_BANK_DISTRACTOR_COUNT = 8;
 
 type WordDataInput = {
-  audioUrl: string | null;
   romanization: string | null;
   translation: string;
   word: string;
+  wordAudio: { audioUrl: string } | null;
 };
 
 function enrichWord(
@@ -27,7 +27,7 @@ function enrichWord(
   );
 
   return {
-    audioUrl: fromSentenceWords?.audioUrl ?? fromLessonWords?.audioUrl ?? null,
+    audioUrl: fromSentenceWords?.wordAudio?.audioUrl ?? fromLessonWords?.audioUrl ?? null,
     romanization: fromSentenceWords?.romanization ?? fromLessonWords?.romanization ?? null,
     translation: fromSentenceWords?.translation ?? fromLessonWords?.translation ?? null,
     word,

--- a/packages/player/src/prepare-activity-data.ts
+++ b/packages/player/src/prepare-activity-data.ts
@@ -80,7 +80,7 @@ type WordDataInput = {
   alternativeTranslations: string[];
   pronunciation: string | null;
   romanization: string | null;
-  audioUrl: string | null;
+  wordAudio: { audioUrl: string } | null;
 };
 
 type SentenceDataInput = {
@@ -88,13 +88,13 @@ type SentenceDataInput = {
   sentence: string;
   translation: string;
   romanization: string | null;
-  audioUrl: string | null;
+  sentenceAudio: { audioUrl: string } | null;
 };
 
 function serializeWord(word: WordDataInput): SerializedWord {
   return {
     alternativeTranslations: [...word.alternativeTranslations],
-    audioUrl: word.audioUrl,
+    audioUrl: word.wordAudio?.audioUrl ?? null,
     id: String(word.id),
     pronunciation: word.pronunciation,
     romanization: word.romanization,
@@ -105,7 +105,7 @@ function serializeWord(word: WordDataInput): SerializedWord {
 
 function serializeSentence(sentence: SentenceDataInput): SerializedSentence {
   return {
-    audioUrl: sentence.audioUrl,
+    audioUrl: sentence.sentenceAudio?.audioUrl ?? null,
     id: String(sentence.id),
     romanization: sentence.romanization,
     sentence: sentence.sentence,
@@ -221,7 +221,7 @@ export function prepareActivityData(
 ): SerializedActivity {
   const serializedLessonWords = lessonWords.map((word) => ({
     alternativeTranslations: [...word.alternativeTranslations],
-    audioUrl: word.audioUrl,
+    audioUrl: word.wordAudio?.audioUrl ?? null,
     id: String(word.id),
     pronunciation: word.pronunciation,
     romanization: word.romanization,
@@ -252,7 +252,7 @@ export function prepareActivityData(
     kind: activity.kind,
     language: activity.language,
     lessonSentences: lessonSentences.map((sentence) => ({
-      audioUrl: sentence.audioUrl,
+      audioUrl: sentence.sentenceAudio?.audioUrl ?? null,
       id: String(sentence.id),
       romanization: sentence.romanization,
       sentence: sentence.sentence,

--- a/packages/testing/src/fixtures/sentences.ts
+++ b/packages/testing/src/fixtures/sentences.ts
@@ -1,5 +1,21 @@
 import { prisma } from "@zoonk/db";
 
+export async function sentenceAudioFixture(attrs: {
+  organizationId: number;
+  targetLanguage?: string;
+  sentence?: string;
+  audioUrl?: string;
+}) {
+  return prisma.sentenceAudio.create({
+    data: {
+      audioUrl: attrs.audioUrl ?? `https://example.com/${crypto.randomUUID()}.mp3`,
+      organizationId: attrs.organizationId,
+      sentence: attrs.sentence ?? `sentence-${crypto.randomUUID()}`,
+      targetLanguage: attrs.targetLanguage ?? "es",
+    },
+  });
+}
+
 export async function sentenceFixture(attrs: {
   organizationId: number;
   sentence?: string;
@@ -7,17 +23,18 @@ export async function sentenceFixture(attrs: {
   targetLanguage?: string;
   userLanguage?: string;
   romanization?: string | null;
-  audioUrl?: string | null;
+  sentenceAudioId?: bigint | null;
 }) {
   return prisma.sentence.create({
     data: {
-      audioUrl: attrs.audioUrl ?? null,
       organizationId: attrs.organizationId,
       romanization: attrs.romanization ?? null,
       sentence: attrs.sentence ?? `sentence-${crypto.randomUUID()}`,
+      sentenceAudioId: attrs.sentenceAudioId ?? null,
       targetLanguage: attrs.targetLanguage ?? "es",
       translation: attrs.translation ?? `translation-${crypto.randomUUID()}`,
       userLanguage: attrs.userLanguage ?? "en",
     },
+    include: { sentenceAudio: true },
   });
 }

--- a/packages/testing/src/fixtures/words.ts
+++ b/packages/testing/src/fixtures/words.ts
@@ -1,5 +1,21 @@
 import { prisma } from "@zoonk/db";
 
+export async function wordAudioFixture(attrs: {
+  organizationId: number;
+  targetLanguage?: string;
+  word?: string;
+  audioUrl?: string;
+}) {
+  return prisma.wordAudio.create({
+    data: {
+      audioUrl: attrs.audioUrl ?? `https://example.com/${crypto.randomUUID()}.mp3`,
+      organizationId: attrs.organizationId,
+      targetLanguage: attrs.targetLanguage ?? "es",
+      word: attrs.word ?? `word-${crypto.randomUUID()}`,
+    },
+  });
+}
+
 export async function wordFixture(attrs: {
   organizationId: number;
   word?: string;
@@ -8,11 +24,10 @@ export async function wordFixture(attrs: {
   userLanguage?: string;
   pronunciation?: string | null;
   romanization?: string | null;
-  audioUrl?: string | null;
+  wordAudioId?: bigint | null;
 }) {
   return prisma.word.create({
     data: {
-      audioUrl: attrs.audioUrl ?? null,
       organizationId: attrs.organizationId,
       pronunciation: attrs.pronunciation ?? "test-pronunciation",
       romanization: attrs.romanization ?? null,
@@ -20,6 +35,8 @@ export async function wordFixture(attrs: {
       translation: attrs.translation ?? `translation-${crypto.randomUUID()}`,
       userLanguage: attrs.userLanguage ?? "en",
       word: attrs.word ?? `word-${crypto.randomUUID()}`,
+      wordAudioId: attrs.wordAudioId ?? null,
     },
+    include: { wordAudio: true },
   });
 }


### PR DESCRIPTION
## Summary

- Add normalized `WordAudio` and `SentenceAudio` tables keyed by `(organizationId, targetLanguage, text)` so TTS audio is generated once per word/sentence regardless of learner language
- Remove `audioUrl` from `Word`/`Sentence` models, replacing with FK references to the new audio tables
- Update all workflow steps to upsert audio records and pass IDs instead of URL strings
- Serialization layer flattens the relation back into `audioUrl` on `SerializedWord`/`SerializedSentence` — player components require zero changes

## Test plan

- [x] All integration tests updated and passing (552 tests)
- [x] `pnpm turbo quality:fix` — no warnings or errors
- [x] `pnpm typecheck` — all 16 packages pass
- [x] `pnpm knip --production` — clean
- [x] `pnpm --filter main build` and `pnpm --filter api build` — both succeed
- [x] `pnpm --filter main e2e` — all passing
- [x] `pnpm --filter api e2e` — 56 passed
- [x] `pnpm --filter editor e2e` — 194 passed

Closes #1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates TTS by adding `WordAudio` and `SentenceAudio` tables keyed by `(organizationId, targetLanguage, text)` and switching to `wordAudioId`/`sentenceAudioId` while keeping `audioUrl` in serialized responses. Also preserves existing audio when TTS fails in vocabulary generation. Satisfies #1037.

- **Refactors**
  - Added `WordAudio`/`SentenceAudio` with unique indexes; linked `words`/`sentences` via FKs.
  - Generation/enrichment steps upsert audio and pass IDs; skip TTS when a record exists.
  - `apps/main` loaders include audio relations; `packages/player` flattens to `audioUrl` so UI stays unchanged.
  - Updated fixtures and tests to create/use audio records.

- **Migration**
  - Run Prisma migration to create audio tables, add FKs, and drop legacy `audio_url` columns.

<sup>Written for commit b8d902cdaf3a7af4ba7a18d06236edc68774ee56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

