### PR TITLE
feat(utils): add logger utility to suppress console output in tests

### DIFF
--- a/apps/api/src/app/auth/callback/actions.ts
+++ b/apps/api/src/app/auth/callback/actions.ts
@@ -2,6 +2,7 @@
 
 import { auth } from "@zoonk/core/auth";
 import { safeAsync } from "@zoonk/utils/error";
+import { logError } from "@zoonk/utils/logger";
 import { headers } from "next/headers";
 
 const TRAILING_SLASHES = /\/+$/;
@@ -32,7 +33,7 @@ export async function createOneTimeTokenAction(
   );
 
   if (validationError) {
-    console.error("Untrusted origin:", JSON.stringify(redirectTo));
+    logError("Untrusted origin:", JSON.stringify(redirectTo));
     return { error: "UNTRUSTED_ORIGIN", success: false };
   }
 
@@ -43,7 +44,7 @@ export async function createOneTimeTokenAction(
   );
 
   if (error) {
-    console.error("Error generating one-time token:", error);
+    logError("Error generating one-time token:", error);
     return { error: "UNTRUSTED_ORIGIN", success: false };
   }
 

--- a/apps/api/src/app/auth/login/social-login.tsx
+++ b/apps/api/src/app/auth/login/social-login.tsx
@@ -2,6 +2,7 @@
 
 import { LoginError, LoginSocial, LoginWithApple, LoginWithGoogle } from "@/components/login";
 import { authClient } from "@zoonk/core/auth/client";
+import { logError } from "@zoonk/utils/logger";
 import { useExtracted } from "next-intl";
 import { useState } from "react";
 
@@ -28,7 +29,7 @@ export function SocialLogin({ redirectTo }: { redirectTo?: string }) {
     });
 
     if (error) {
-      console.error("Social login error:", error);
+      logError("Social login error:", error);
       setState("error");
     }
   };

--- a/apps/api/src/app/auth/setup/actions.ts
+++ b/apps/api/src/app/auth/setup/actions.ts
@@ -3,6 +3,7 @@
 import { auth } from "@zoonk/core/auth";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
+import { logError } from "@zoonk/utils/logger";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
@@ -28,7 +29,7 @@ export async function setupProfileAction(
   );
 
   if (error) {
-    console.error("Error setting up profile:", error);
+    logError("Error setting up profile:", error);
     return { status: "error" };
   }
 

--- a/apps/api/src/workflows/_shared/stream-error.ts
+++ b/apps/api/src/workflows/_shared/stream-error.ts
@@ -1,3 +1,4 @@
+import { logError } from "@zoonk/utils/logger";
 import { type WorkflowErrorReason, streamStatus } from "./stream-status";
 
 export async function streamError<T extends string>(params: {
@@ -6,7 +7,7 @@ export async function streamError<T extends string>(params: {
 }): Promise<void> {
   "use step";
 
-  console.error("[Workflow Error]", JSON.stringify(params));
+  logError("[Workflow Error]", JSON.stringify(params));
 
   await streamStatus({
     reason: params.reason,

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.ts
@@ -1,4 +1,5 @@
 import { chapterGenerationWorkflow } from "@/workflows/chapter-generation/chapter-generation-workflow";
+import { logError } from "@zoonk/utils/logger";
 import { FatalError, getWorkflowMetadata } from "workflow";
 import { getOrCreateCourse } from "./_internal/get-or-create-course";
 import { setupCourse } from "./_internal/setup-course";
@@ -38,7 +39,7 @@ export async function courseGenerationWorkflow(courseSuggestionId: number): Prom
       courseSuggestionId,
     });
 
-    console.error(`[workflow ${workflowRunId}] Course initialization failed`, error);
+    logError(`[workflow ${workflowRunId}] Course initialization failed`, error);
 
     throw FatalError;
   });
@@ -50,7 +51,7 @@ export async function courseGenerationWorkflow(courseSuggestionId: number): Prom
         courseSuggestionId,
       });
 
-      console.error(`[workflow ${workflowRunId}] Course generation failed`, error);
+      logError(`[workflow ${workflowRunId}] Course generation failed`, error);
 
       throw FatalError;
     },

--- a/apps/editor/src/components/editor-list/editor-list-provider.tsx
+++ b/apps/editor/src/components/editor-list/editor-list-provider.tsx
@@ -2,6 +2,7 @@
 
 import { toast } from "@zoonk/ui/components/sonner";
 import { isNextRedirectError } from "@zoonk/utils/error";
+import { logError } from "@zoonk/utils/logger";
 import { useCallback, useMemo, useTransition } from "react";
 import { EditorListContext, type EditorListContextValue } from "./editor-list-context";
 
@@ -21,7 +22,7 @@ export function EditorListProvider({
           await onInsert(position);
         } catch (error) {
           if (!isNextRedirectError(error)) {
-            console.error(`Failed to insert item at position ${position}:`, error);
+            logError(`Failed to insert item at position ${position}:`, error);
 
             toast.error(error instanceof Error ? error.message : String(error));
           }

--- a/apps/main/src/app/(settings)/profile/actions.ts
+++ b/apps/main/src/app/(settings)/profile/actions.ts
@@ -3,6 +3,7 @@
 import { auth } from "@zoonk/core/auth";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
+import { logError } from "@zoonk/utils/logger";
 import { headers } from "next/headers";
 
 export async function profileFormAction(_prevState: unknown, formData: FormData) {
@@ -31,7 +32,7 @@ export async function profileFormAction(_prevState: unknown, formData: FormData)
   );
 
   if (error) {
-    console.error("Error updating profile:", error);
+    logError("Error updating profile:", error);
     return { name, status: "error" as const, username };
   }
 

--- a/packages/ai/src/tasks/audio/generate-language-audio.ts
+++ b/packages/ai/src/tasks/audio/generate-language-audio.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { openai } from "@ai-sdk/openai";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { type TTSVoice } from "@zoonk/utils/languages";
+import { logError } from "@zoonk/utils/logger";
 import { experimental_generateSpeech as generateSpeech } from "ai";
 
 const DEFAULT_MODEL = openai.speech("gpt-4o-mini-tts");
@@ -32,7 +33,7 @@ export async function generateLanguageAudio({
   });
 
   if (error) {
-    console.error("Error generating language audio:", error);
+    logError("Error generating language audio:", error);
     return { data: null, error };
   }
 

--- a/packages/ai/src/tasks/courses/course-thumbnail.ts
+++ b/packages/ai/src/tasks/courses/course-thumbnail.ts
@@ -1,4 +1,5 @@
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { logError } from "@zoonk/utils/logger";
 import { type GeneratedFile, type ImageModel, generateImage } from "ai";
 import promptTemplate from "./course-thumbnail.prompt.md";
 
@@ -33,7 +34,7 @@ export async function generateCourseThumbnail({
   );
 
   if (error) {
-    console.error("Error generating course thumbnail:", error);
+    logError("Error generating course thumbnail:", error);
     return { data: null, error };
   }
 

--- a/packages/ai/src/tasks/steps/step-select-image.ts
+++ b/packages/ai/src/tasks/steps/step-select-image.ts
@@ -1,4 +1,5 @@
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { logError } from "@zoonk/utils/logger";
 import { type GeneratedFile, type ImageModel, generateImage } from "ai";
 import promptTemplate from "./step-select-image.prompt.md";
 
@@ -35,7 +36,7 @@ export async function generateSelectImageStep({
   );
 
   if (error) {
-    console.error("Error generating select image step:", error);
+    logError("Error generating select image step:", error);
     return { data: null, error };
   }
 

--- a/packages/ai/src/tasks/steps/step-visual-image.ts
+++ b/packages/ai/src/tasks/steps/step-visual-image.ts
@@ -1,4 +1,5 @@
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { logError } from "@zoonk/utils/logger";
 import { type GeneratedFile, type ImageModel, generateImage } from "ai";
 import promptTemplate from "./step-visual-image.prompt.md";
 
@@ -35,7 +36,7 @@ export async function generateStepVisualImage({
   );
 
   if (error) {
-    console.error("Error generating step visual image:", error);
+    logError("Error generating step visual image:", error);
     return { data: null, error };
   }
 

--- a/packages/core/src/audio/upload-audio.ts
+++ b/packages/core/src/audio/upload-audio.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { put } from "@vercel/blob";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { logError } from "@zoonk/utils/logger";
 
 export async function uploadAudio({
   fileName,
@@ -20,7 +21,7 @@ export async function uploadAudio({
   );
 
   if (error) {
-    console.error("Error uploading audio:", error);
+    logError("Error uploading audio:", error);
     return { data: null, error };
   }
 

--- a/packages/core/src/images/optimize-image.ts
+++ b/packages/core/src/images/optimize-image.ts
@@ -1,4 +1,5 @@
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { logError } from "@zoonk/utils/logger";
 import { DEFAULT_IMAGE_QUALITY } from "@zoonk/utils/upload";
 import sharp from "sharp";
 
@@ -27,7 +28,7 @@ export async function optimizeImage({
   });
 
   if (error) {
-    console.error("Error optimizing image:", error);
+    logError("Error optimizing image:", error);
     return { data: null, error };
   }
 

--- a/packages/core/src/images/upload-image.ts
+++ b/packages/core/src/images/upload-image.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { put } from "@vercel/blob";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { logError } from "@zoonk/utils/logger";
 
 export async function uploadImage({
   fileName,
@@ -18,7 +19,7 @@ export async function uploadImage({
   );
 
   if (error) {
-    console.error("Error uploading image:", error);
+    logError("Error uploading image:", error);
     return { data: null, error };
   }
 

--- a/packages/mailer/src/client.ts
+++ b/packages/mailer/src/client.ts
@@ -1,4 +1,5 @@
 import { type SafeReturn, toError } from "@zoonk/utils/error";
+import { logError, logInfo } from "@zoonk/utils/logger";
 
 const apiUrl = "https://api.zeptomail.com/v1.1/email";
 const apiKey = process.env.MAILER_API_KEY;
@@ -14,8 +15,8 @@ export async function sendEmail({
   text: string;
 }): Promise<SafeReturn<Response>> {
   if (sendEmailDisabled) {
-    console.info("Email sending is disabled.");
-    console.info({ subject, text, to });
+    logInfo("Email sending is disabled.");
+    logInfo({ subject, text, to });
     return { data: Response.json({ ok: true }), error: null };
   }
 
@@ -36,7 +37,7 @@ export async function sendEmail({
     });
 
     if (!response.ok) {
-      console.error("Email send failed", await response.text());
+      logError("Email send failed", await response.text());
 
       return {
         data: null,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,6 +19,7 @@
     "./form": "./src/form.ts",
     "./json": "./src/json.ts",
     "./languages": "./src/languages.ts",
+    "./logger": "./src/logger.ts",
     "./locale": "./src/locale.ts",
     "./number": "./src/number.ts",
     "./org": "./src/org.ts",

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,0 +1,15 @@
+function isTestEnvironment(): boolean {
+  return process.env.NODE_ENV === "test";
+}
+
+export function logError(...args: unknown[]): void {
+  if (!isTestEnvironment()) {
+    console.error(...args);
+  }
+}
+
+export function logInfo(...args: unknown[]): void {
+  if (!isTestEnvironment()) {
+    console.info(...args);
+  }
+}


### PR DESCRIPTION
## Summary

- Add `@zoonk/utils/logger` with `logError` and `logInfo` that suppress output when `NODE_ENV === "test"`
- Migrate all `console.error`/`console.info` calls in packages (`core`, `ai`, `mailer`) and apps (`api`, `main`, `editor`) to use the new logger
- Eliminates noisy stderr output from workflow tests

## Test plan

- [x] `pnpm turbo quality:fix` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm knip --production` — clean
- [x] `pnpm test` — all pass
- [x] `pnpm --filter main build` / `pnpm --filter editor build` / `pnpm --filter api build` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `@zoonk/utils/logger` with `logError` and `logInfo` that no-op when `NODE_ENV === "test"` to suppress noisy test output. Replaced all console.error/info calls across apps and packages with the new logger; no behavior change in production.

<sup>Written for commit 9ca216bdc5e19997eed38e8cc625bc4574149f80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

