### PR TITLE
fix(ai): use default reasoning for content generation

### DIFF
--- a/packages/ai/src/tasks/activities/language/activity-grammar.ts
+++ b/packages/ai/src/tasks/activities/language/activity-grammar.ts
@@ -64,7 +64,7 @@ export async function generateActivityGrammar({
   lessonTitle,
   model = DEFAULT_MODEL,
   neighboringConcepts = [],
-  reasoningEffort = "high",
+  reasoningEffort,
   targetLanguage,
   userLanguage,
   useFallback = true,

--- a/packages/ai/src/tasks/activities/language/activity-practice.ts
+++ b/packages/ai/src/tasks/activities/language/activity-practice.ts
@@ -53,7 +53,7 @@ export async function generateActivityPracticeLanguage({
   lessonTitle,
   model = DEFAULT_MODEL,
   neighboringConcepts = [],
-  reasoningEffort = "high",
+  reasoningEffort,
   targetLanguage,
   userLanguage,
   useFallback = true,

--- a/packages/ai/src/tasks/courses/course-chapters.ts
+++ b/packages/ai/src/tasks/courses/course-chapters.ts
@@ -7,8 +7,6 @@ import systemPrompt from "./course-chapters.prompt.md";
 const DEFAULT_MODEL = process.env.AI_MODEL_COURSE_CHAPTERS ?? "openai/gpt-5.4";
 const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"];
 
-const DEFAULT_REASONING_EFFORT: ReasoningEffort = "high";
-
 const schema = z.object({
   chapters: z.array(
     z.object({
@@ -34,7 +32,7 @@ export async function generateCourseChapters({
   courseTitle,
   model = DEFAULT_MODEL,
   useFallback = true,
-  reasoningEffort = DEFAULT_REASONING_EFFORT,
+  reasoningEffort,
 }: CourseChaptersParams) {
   const userPrompt = `
     LANGUAGE: ${language}

--- a/packages/ai/src/tasks/courses/language-course-chapters.ts
+++ b/packages/ai/src/tasks/courses/language-course-chapters.ts
@@ -32,7 +32,7 @@ export async function generateLanguageCourseChapters({
   targetLanguage,
   model = DEFAULT_MODEL,
   useFallback = true,
-  reasoningEffort = "high",
+  reasoningEffort,
 }: LanguageCourseChaptersParams) {
   const targetLanguageName = getLanguageName({ targetLanguage, userLanguage });
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop forcing "high" reasoning effort in content generation. Tasks now use the provided `reasoningEffort` or fall back to model/global defaults to reduce cost and match expected behavior.

- **Bug Fixes**
  - Removed hardcoded "high" defaults in activity grammar/practice and course chapter generators.
  - Deleted `DEFAULT_REASONING_EFFORT` in `course-chapters.ts`.
  - `reasoningEffort` is now passed through without a default; callers or model defaults decide.

<sup>Written for commit 600cbca8715ab7df41180c7485dfa29dc826c90a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

