### PR TITLE
chore(ai): use gpt-5.4 as default model for core activities

### DIFF
--- a/packages/ai/src/tasks/activities/core/activity-challenge.ts
+++ b/packages/ai/src/tasks/activities/core/activity-challenge.ts
@@ -5,8 +5,8 @@ import { z } from "zod";
 import { formatConceptLines } from "../config";
 import systemPrompt from "./activity-challenge.prompt.md";
 
-const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_CHALLENGE ?? "anthropic/claude-opus-4.6";
-const FALLBACK_MODELS = ["openai/gpt-5.4", "google/gemini-3.1-pro-preview"];
+const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_CHALLENGE ?? "openai/gpt-5.4";
+const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"];
 
 const effectSchema = z.object({
   dimension: z.string(),

--- a/packages/ai/src/tasks/activities/core/activity-explanation.ts
+++ b/packages/ai/src/tasks/activities/core/activity-explanation.ts
@@ -4,8 +4,8 @@ import { Output, generateText } from "ai";
 import { z } from "zod";
 import systemPrompt from "./activity-explanation.prompt.md";
 
-const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_EXPLANATION ?? "anthropic/claude-opus-4.6";
-const FALLBACK_MODELS = ["openai/gpt-5.4", "google/gemini-3.1-pro-preview"];
+const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_EXPLANATION ?? "openai/gpt-5.4";
+const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"];
 
 const schema = z.object({
   steps: z.array(

--- a/packages/ai/src/tasks/activities/core/activity-practice.ts
+++ b/packages/ai/src/tasks/activities/core/activity-practice.ts
@@ -5,8 +5,8 @@ import { z } from "zod";
 import { ACTIVITY_OPTIONS_COUNT } from "../config";
 import systemPrompt from "./activity-practice.prompt.md";
 
-const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_PRACTICE ?? "anthropic/claude-opus-4.6";
-const FALLBACK_MODELS = ["openai/gpt-5.4", "google/gemini-3.1-pro-preview"];
+const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_PRACTICE ?? "openai/gpt-5.4";
+const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"];
 
 const schema = z.object({
   steps: z.array(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set `openai/gpt-5.4` as the default model for core activities (challenge, explanation, practice), with fallbacks now `anthropic/claude-opus-4.6` then `google/gemini-3.1-pro-preview`. Existing `AI_MODEL_ACTIVITY_*` env vars still override the default.

<sup>Written for commit 0ab0cba5d6f46916f24efee33ebc3e7d7b1e5067. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

