### PR TITLE
fix(main): update generation time estimates

### DIFF
--- a/apps/main/e2e/generate-activity.test.ts
+++ b/apps/main/e2e/generate-activity.test.ts
@@ -1055,7 +1055,7 @@ test.describe("Generate Activity Page - With Subscription", () => {
       timeout: 10_000,
     });
 
-    await expect(userWithoutProgress.getByText(/this usually takes 1-2 minutes/i)).toBeVisible();
+    await expect(userWithoutProgress.getByText(/this usually takes about a minute/i)).toBeVisible();
   });
 
   test("shows practice-content phase and skips pronunciation phase for reading", async ({

--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -226,7 +226,7 @@ test.describe("Generate Chapter Page - With Subscription", () => {
       timeout: 10_000,
     });
 
-    await expect(userWithoutProgress.getByText(/this usually takes 2-4 minutes/i)).toBeVisible();
+    await expect(userWithoutProgress.getByText(/this usually takes 1-2 minutes/i)).toBeVisible();
     await expect(userWithoutProgress.getByText(/adding pronunciation/i)).toBeVisible();
     await expect(userWithoutProgress.getByText(/recording audio/i)).toBeVisible();
     await expect(userWithoutProgress.getByText(/writing the content/i)).toHaveCount(0);

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -141,7 +141,7 @@ test.describe("Generate Course Page", () => {
         timeout: 10_000,
       });
 
-      await expect(page.getByText(/this usually takes 4-6 minutes/i)).toBeVisible();
+      await expect(page.getByText(/this usually takes 2-3 minutes/i)).toBeVisible();
     });
 
     test("shows vocabulary-specific activity phases for language courses", async ({ page }) => {

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -259,7 +259,7 @@ test.describe("Generate Lesson Page - With Subscription", () => {
 
     await userWithoutProgress.goto(`/generate/l/${lesson.id}`);
 
-    await expect(userWithoutProgress.getByText(/this usually takes about a minute/i)).toBeVisible({
+    await expect(userWithoutProgress.getByText(/this usually takes a few seconds/i)).toBeVisible({
       timeout: 10_000,
     });
   });

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1622,11 +1622,6 @@ msgid "Your activity is ready"
 msgstr "Your activity is ready"
 
 #: src/app/generate/a/[id]/generation-client.tsx
-msgctxt "3vY0Zu"
-msgid "This usually takes 1-2 minutes"
-msgstr "This usually takes 1-2 minutes"
-
-#: src/app/generate/a/[id]/generation-client.tsx
 #: src/app/generate/ch/[id]/generation-client.tsx
 #: src/app/generate/cs/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
@@ -1641,6 +1636,11 @@ msgstr "Try again"
 msgctxt "JqiqNj"
 msgid "Something went wrong"
 msgstr "Something went wrong"
+
+#: src/app/generate/a/[id]/generation-client.tsx
+msgctxt "kiZUDf"
+msgid "This usually takes about a minute"
+msgstr "This usually takes about a minute"
 
 #: src/app/generate/a/[id]/generation-client.tsx
 msgctxt "KWLxEA"
@@ -1893,6 +1893,11 @@ msgid "Create Chapter"
 msgstr "Create Chapter"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
+msgctxt "3vY0Zu"
+msgid "This usually takes 1-2 minutes"
+msgstr "This usually takes 1-2 minutes"
+
+#: src/app/generate/ch/[id]/generation-client.tsx
 msgctxt "45uo73"
 msgid "Your lessons are ready"
 msgstr "Your lessons are ready"
@@ -1901,11 +1906,6 @@ msgstr "Your lessons are ready"
 msgctxt "5c2xtK"
 msgid "Taking you to your chapter..."
 msgstr "Taking you to your chapter..."
-
-#: src/app/generate/ch/[id]/generation-client.tsx
-msgctxt "Tp34ZM"
-msgid "This usually takes 2-4 minutes"
-msgstr "This usually takes 2-4 minutes"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgctxt "ViO6Dt"
@@ -1994,14 +1994,14 @@ msgid "Your course is ready"
 msgstr "Your course is ready"
 
 #: src/app/generate/cs/[id]/generation-client.tsx
-msgctxt "bXKvjZ"
-msgid "This usually takes 4-6 minutes"
-msgstr "This usually takes 4-6 minutes"
-
-#: src/app/generate/cs/[id]/generation-client.tsx
 msgctxt "DFlapX"
 msgid "Creating your course"
 msgstr "Creating your course"
+
+#: src/app/generate/cs/[id]/generation-client.tsx
+msgctxt "ux13iV"
+msgid "This usually takes 2-3 minutes"
+msgstr "This usually takes 2-3 minutes"
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "4uQ1Ek"
@@ -2119,14 +2119,14 @@ msgid "Creating your activities"
 msgstr "Creating your activities"
 
 #: src/app/generate/l/[id]/generation-client.tsx
-msgctxt "kiZUDf"
-msgid "This usually takes about a minute"
-msgstr "This usually takes about a minute"
-
-#: src/app/generate/l/[id]/generation-client.tsx
 msgctxt "T2TGxR"
 msgid "Taking you to your lesson..."
 msgstr "Taking you to your lesson..."
+
+#: src/app/generate/l/[id]/generation-client.tsx
+msgctxt "THvPMp"
+msgid "This usually takes a few seconds"
+msgstr "This usually takes a few seconds"
 
 #: src/app/privacy/page.tsx
 msgctxt "iql85X"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1622,11 +1622,6 @@ msgid "Your activity is ready"
 msgstr "Tu actividad está lista"
 
 #: src/app/generate/a/[id]/generation-client.tsx
-msgctxt "3vY0Zu"
-msgid "This usually takes 1-2 minutes"
-msgstr "Esto suele tomar 1-2 minutos"
-
-#: src/app/generate/a/[id]/generation-client.tsx
 #: src/app/generate/ch/[id]/generation-client.tsx
 #: src/app/generate/cs/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
@@ -1641,6 +1636,11 @@ msgstr "Intentar de nuevo"
 msgctxt "JqiqNj"
 msgid "Something went wrong"
 msgstr "Algo salió mal"
+
+#: src/app/generate/a/[id]/generation-client.tsx
+msgctxt "kiZUDf"
+msgid "This usually takes about a minute"
+msgstr "Esto suele tomar alrededor de un minuto"
 
 #: src/app/generate/a/[id]/generation-client.tsx
 msgctxt "KWLxEA"
@@ -1893,6 +1893,11 @@ msgid "Create Chapter"
 msgstr "Crear Capítulo"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
+msgctxt "3vY0Zu"
+msgid "This usually takes 1-2 minutes"
+msgstr "Esto suele tomar 1-2 minutos"
+
+#: src/app/generate/ch/[id]/generation-client.tsx
 msgctxt "45uo73"
 msgid "Your lessons are ready"
 msgstr "Tus lecciones están listas"
@@ -1901,11 +1906,6 @@ msgstr "Tus lecciones están listas"
 msgctxt "5c2xtK"
 msgid "Taking you to your chapter..."
 msgstr "Llevándote a tu capítulo..."
-
-#: src/app/generate/ch/[id]/generation-client.tsx
-msgctxt "Tp34ZM"
-msgid "This usually takes 2-4 minutes"
-msgstr "Esto suele tomar 2-4 minutos"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgctxt "ViO6Dt"
@@ -1994,14 +1994,14 @@ msgid "Your course is ready"
 msgstr "Tu curso está listo"
 
 #: src/app/generate/cs/[id]/generation-client.tsx
-msgctxt "bXKvjZ"
-msgid "This usually takes 4-6 minutes"
-msgstr "Esto suele tomar de 4 a 6 minutos"
-
-#: src/app/generate/cs/[id]/generation-client.tsx
 msgctxt "DFlapX"
 msgid "Creating your course"
 msgstr "Creando tu curso"
+
+#: src/app/generate/cs/[id]/generation-client.tsx
+msgctxt "ux13iV"
+msgid "This usually takes 2-3 minutes"
+msgstr "Esto generalmente toma 2-3 minutos"
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "4uQ1Ek"
@@ -2119,14 +2119,14 @@ msgid "Creating your activities"
 msgstr "Creando tus actividades"
 
 #: src/app/generate/l/[id]/generation-client.tsx
-msgctxt "kiZUDf"
-msgid "This usually takes about a minute"
-msgstr "Esto suele tomar alrededor de un minuto"
-
-#: src/app/generate/l/[id]/generation-client.tsx
 msgctxt "T2TGxR"
 msgid "Taking you to your lesson..."
 msgstr "Llevándote a tu lección..."
+
+#: src/app/generate/l/[id]/generation-client.tsx
+msgctxt "THvPMp"
+msgid "This usually takes a few seconds"
+msgstr "Esto generalmente toma unos segundos"
 
 #: src/app/privacy/page.tsx
 msgctxt "iql85X"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1622,11 +1622,6 @@ msgid "Your activity is ready"
 msgstr "Sua atividade está pronta"
 
 #: src/app/generate/a/[id]/generation-client.tsx
-msgctxt "3vY0Zu"
-msgid "This usually takes 1-2 minutes"
-msgstr "Isso geralmente leva 1-2 minutos"
-
-#: src/app/generate/a/[id]/generation-client.tsx
 #: src/app/generate/ch/[id]/generation-client.tsx
 #: src/app/generate/cs/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
@@ -1641,6 +1636,11 @@ msgstr "Tentar novamente"
 msgctxt "JqiqNj"
 msgid "Something went wrong"
 msgstr "Algo deu errado"
+
+#: src/app/generate/a/[id]/generation-client.tsx
+msgctxt "kiZUDf"
+msgid "This usually takes about a minute"
+msgstr "Isso geralmente leva cerca de um minuto"
 
 #: src/app/generate/a/[id]/generation-client.tsx
 msgctxt "KWLxEA"
@@ -1893,6 +1893,11 @@ msgid "Create Chapter"
 msgstr "Criar Capítulo"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
+msgctxt "3vY0Zu"
+msgid "This usually takes 1-2 minutes"
+msgstr "Isso geralmente leva 1-2 minutos"
+
+#: src/app/generate/ch/[id]/generation-client.tsx
 msgctxt "45uo73"
 msgid "Your lessons are ready"
 msgstr "Suas aulas estão prontas"
@@ -1901,11 +1906,6 @@ msgstr "Suas aulas estão prontas"
 msgctxt "5c2xtK"
 msgid "Taking you to your chapter..."
 msgstr "Levando você para seu capítulo..."
-
-#: src/app/generate/ch/[id]/generation-client.tsx
-msgctxt "Tp34ZM"
-msgid "This usually takes 2-4 minutes"
-msgstr "Isso geralmente leva 2-4 minutos"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgctxt "ViO6Dt"
@@ -1994,14 +1994,14 @@ msgid "Your course is ready"
 msgstr "Seu curso está pronto"
 
 #: src/app/generate/cs/[id]/generation-client.tsx
-msgctxt "bXKvjZ"
-msgid "This usually takes 4-6 minutes"
-msgstr "Isso geralmente leva de 4 a 6 minutos"
-
-#: src/app/generate/cs/[id]/generation-client.tsx
 msgctxt "DFlapX"
 msgid "Creating your course"
 msgstr "Criando seu curso"
+
+#: src/app/generate/cs/[id]/generation-client.tsx
+msgctxt "ux13iV"
+msgid "This usually takes 2-3 minutes"
+msgstr "Isso geralmente leva de 2 a 3 minutos"
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "4uQ1Ek"
@@ -2119,14 +2119,14 @@ msgid "Creating your activities"
 msgstr "Criando suas atividades"
 
 #: src/app/generate/l/[id]/generation-client.tsx
-msgctxt "kiZUDf"
-msgid "This usually takes about a minute"
-msgstr "Isso geralmente leva cerca de um minuto"
-
-#: src/app/generate/l/[id]/generation-client.tsx
 msgctxt "T2TGxR"
 msgid "Taking you to your lesson..."
 msgstr "Levando você para sua aula..."
+
+#: src/app/generate/l/[id]/generation-client.tsx
+msgctxt "THvPMp"
+msgid "This usually takes a few seconds"
+msgstr "Isso geralmente leva alguns segundos"
 
 #: src/app/privacy/page.tsx
 msgctxt "iql85X"

--- a/apps/main/src/app/generate/a/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/a/[id]/generation-client.tsx
@@ -79,7 +79,7 @@ export function GenerationClient({
         <GenerationTimelineHeader>
           <GenerationTimelineTitle>{t("Creating your activity")}</GenerationTimelineTitle>
           <GenerationTimelineSubtitle>
-            {t("This usually takes 1-2 minutes")}
+            {t("This usually takes about a minute")}
           </GenerationTimelineSubtitle>
           <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
         </GenerationTimelineHeader>

--- a/apps/main/src/app/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generation-client.tsx
@@ -76,7 +76,7 @@ export function GenerationClient({
         <GenerationTimelineHeader>
           <GenerationTimelineTitle>{t("Creating your lessons")}</GenerationTimelineTitle>
           <GenerationTimelineSubtitle>
-            {t("This usually takes 2-4 minutes")}
+            {t("This usually takes 1-2 minutes")}
           </GenerationTimelineSubtitle>
           <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
         </GenerationTimelineHeader>

--- a/apps/main/src/app/generate/cs/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generation-client.tsx
@@ -74,7 +74,7 @@ export function GenerationClient({
         <GenerationTimelineHeader>
           <GenerationTimelineTitle>{t("Creating your course")}</GenerationTimelineTitle>
           <GenerationTimelineSubtitle>
-            {t("This usually takes 4-6 minutes")}
+            {t("This usually takes 2-3 minutes")}
           </GenerationTimelineSubtitle>
           <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
         </GenerationTimelineHeader>

--- a/apps/main/src/app/generate/l/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/l/[id]/generation-client.tsx
@@ -72,7 +72,7 @@ export function GenerationClient({
         <GenerationTimelineHeader>
           <GenerationTimelineTitle>{t("Creating your activities")}</GenerationTimelineTitle>
           <GenerationTimelineSubtitle>
-            {t("This usually takes about a minute")}
+            {t("This usually takes a few seconds")}
           </GenerationTimelineSubtitle>
           <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
         </GenerationTimelineHeader>

--- a/i18n.lock
+++ b/i18n.lock
@@ -499,9 +499,9 @@ checksums:
     Create%20Activity/singular: ceaf06ac3cbfcfcf824b9e9acf66cfb9
     Create%20content%20for%20this%20activity/singular: e48e26e5fc10415a118d5d6c9f6d032e
     Your%20activity%20is%20ready/singular: e7385c4096b843839bb9a96023f0eea9
-    This%20usually%20takes%201-2%20minutes/singular: bd7260323fa4b3a50a0300ed136fcbd2
     Try%20again/singular: 33dd8820e743e35a66e6977f69e9d3b5
     Something%20went%20wrong/singular: a3cd2f01c073f1f5ff436d4b132d39cf
+    This%20usually%20takes%20about%20a%20minute/singular: 8b679d39d752ba8a57fbabd4eb745f28
     Taking%20you%20to%20your%20activity.../singular: c6714da27762cce70a0e2465878abaed
     Creating%20your%20activity/singular: cac8f88defaeee245484bd91660d32d6
     Progress/singular: dd0200d5849ebb7d64c15098ae91d229
@@ -539,9 +539,9 @@ checksums:
     Setting%20things%20up.../singular: 4696c8e1048ec21837f886410864dfe2
     Refining%20the%20details.../singular: eaf7a7ca135f8919dc93f80095040ab0
     Create%20Chapter/singular: eff367b47e651ac3234f8b4655d5a078
+    This%20usually%20takes%201-2%20minutes/singular: bd7260323fa4b3a50a0300ed136fcbd2
     Your%20lessons%20are%20ready/singular: fe8d9df59ba42f451b249fd750813cba
     Taking%20you%20to%20your%20chapter.../singular: fc59b426c3d393ec40f534253309ee9f
-    This%20usually%20takes%202-4%20minutes/singular: a5cf03e3d2ed405722955fde29b1fef0
     Creating%20your%20lessons/singular: 93571965dc04dcef0bf92f212b3b34d3
     Designing%20practice%20exercises.../singular: 9f1ddddd3324e1586eb427a2c96ee399
     Thinking%20about%20how%20to%20teach%20this.../singular: e71e60276db8c3d5ddb63542b0c7251e
@@ -556,8 +556,8 @@ checksums:
     Writing%20lesson%20%7Bnumber%7D.../singular: 9a81f245c815438ea4e925777f711894
     Taking%20you%20to%20your%20course.../singular: f1522561681357abdaad3936d36fdfe7
     Your%20course%20is%20ready/singular: b54659084218a9b9bcf7b5f1cfcf3fbf
-    This%20usually%20takes%204-6%20minutes/singular: bd0d37fe2b4aaa9dd8f1a6ffae3824c5
     Creating%20your%20course/singular: 02c33db1106e7478e5cbd00fa5f20532
+    This%20usually%20takes%202-3%20minutes/singular: c7d31ba5ff2bf3b6ec27d5fd9590d034
     Writing%20the%20lesson%20content/singular: 2b3243b19b65a83cfe355bef089b7ce8
     Writing%20the%20overview.../singular: 14d71db32539c19803e72da8a4553a0f
     Summarizing%20what%20you'll%20learn.../singular: bb6b58ff4b46ee6e8c59789464e9bced
@@ -581,8 +581,8 @@ checksums:
     Create%20Lesson/singular: af03c55d9ad5e6063bfad0ce8a35e385
     Your%20lesson%20is%20ready/singular: 3d745fd67b57e47ed10851f1e5404ccc
     Creating%20your%20activities/singular: 6651e663a48e18486f5f873e614cd512
-    This%20usually%20takes%20about%20a%20minute/singular: 8b679d39d752ba8a57fbabd4eb745f28
     Taking%20you%20to%20your%20lesson.../singular: 7a47c8664a900646ef51c9f27e2886e0
+    This%20usually%20takes%20a%20few%20seconds/singular: d95f1b6378326c1aeb3792bd9cd643e7
     Read%20Zoonk's%20privacy%20policy%20to%20understand%20how%20we%20collect%2C%20use%2C%20and%20protect%20your%20personal%20information./singular: 044f3586abe7d9915820a6629cef08e4
     Privacy%20Policy/singular: 7459744a63ef8af4e517a09024bd7c08
     Read%20Zoonk's%20terms%20of%20use%20to%20understand%20the%20rules%20and%20conditions%20for%20using%20our%20platform%20and%20services/singular: 4b82898d60691839a1999e4a17199895


### PR DESCRIPTION
## Summary
- Course: 4-6 minutes → 2-3 minutes
- Chapter: 2-4 minutes → 1-2 minutes
- Lesson: about a minute → a few seconds
- Activity: 1-2 minutes → about a minute

## Test plan
- [ ] Verify each generate page displays the updated time estimate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated generation time estimates in generate pages: course 2–3 min, chapter 1–2 min, lesson a few seconds, activity about a minute. Synced UI subtitles, updated translations in `en`, `es`, `pt` (and `i18n.lock`), and aligned E2E tests.

<sup>Written for commit 37a56c97adc27a8981f93d0139d37a911098069c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

