### PR TITLE
feat(player): add translation, audio, and feedback to language practice

### DIFF
--- a/apps/api/src/workflows/activity-generation/kinds/language-practice-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/language-practice-workflow.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { generateActivityPracticeLanguage } from "@zoonk/ai/tasks/activities/language/practice";
+import { generateLanguageAudio } from "@zoonk/core/audio/generate";
 import { prisma } from "@zoonk/db";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
@@ -37,18 +38,26 @@ vi.mock("@zoonk/ai/tasks/activities/language/practice", () => ({
               isCorrect: true,
               text: "Buenos dias.",
               textRomanization: "bweh-nos dee-as",
+              translation: "Good morning.",
             },
             {
               feedback: "Too abrupt.",
               isCorrect: false,
               text: "Dame cafe.",
               textRomanization: "da-me ka-fe",
+              translation: "Give me coffee.",
             },
           ],
         },
       ],
     },
   }),
+}));
+
+vi.mock("@zoonk/core/audio/generate", () => ({
+  generateLanguageAudio: vi
+    .fn()
+    .mockResolvedValue({ data: null, error: new Error("not available") }),
 }));
 
 async function fetchLessonActivities(lessonId: number): Promise<LessonActivity[]> {
@@ -203,12 +212,14 @@ describe(languagePracticeActivityWorkflow, () => {
                 isCorrect: true,
                 text: "Un café con leche, por favor.",
                 textRomanization: "",
+                translation: "A coffee with milk, please.",
               },
               {
                 feedback: "Too abrupt.",
                 isCorrect: false,
                 text: "Dame café.",
                 textRomanization: "",
+                translation: "Give me coffee.",
               },
             ],
           },
@@ -271,5 +282,324 @@ describe(languagePracticeActivityWorkflow, () => {
     await languagePracticeActivityWorkflow(activities, "test-run-id", [], []);
 
     expect(generateActivityPracticeLanguage).not.toHaveBeenCalled();
+  });
+
+  test("stores translation and audio fields in step content", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `LangPractice Fields ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "languagePractice",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Language Practice ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+    await languagePracticeActivityWorkflow(activities, "test-run-id", [], []);
+
+    const steps = await prisma.step.findMany({
+      orderBy: { position: "asc" },
+      where: { activityId: activity.id, kind: "multipleChoice" },
+    });
+
+    expect(steps).toHaveLength(1);
+
+    const content = steps[0]!.content as Record<string, unknown>;
+    expect(content).toHaveProperty("contextAudioUrl");
+
+    const options = content.options as Record<string, unknown>[];
+
+    for (const option of options) {
+      expect(option).toHaveProperty("audioUrl");
+      expect(option).toHaveProperty("translation");
+      expect(option.translation).toBeTypeOf("string");
+      expect((option.translation as string).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("normalizes punctuation spacing in stored content", async () => {
+    vi.mocked(generateActivityPracticeLanguage).mockResolvedValueOnce({
+      data: {
+        scenario: "You're at a cafe.",
+        steps: [
+          {
+            context: "Bonjour , comment ça va ?",
+            contextRomanization: null,
+            contextTranslation: "Hello , how are you ?",
+            options: [
+              {
+                feedback: "Great choice !",
+                isCorrect: true,
+                text: "Très bien , merci !",
+                textRomanization: null,
+                translation: "Very well , thank you !",
+              },
+              {
+                feedback: "Not quite .",
+                isCorrect: false,
+                text: "Au revoir !",
+                textRomanization: null,
+                translation: "Goodbye !",
+              },
+            ],
+          },
+        ],
+      },
+    } as Awaited<ReturnType<typeof generateActivityPracticeLanguage>>);
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `LangPractice Punctuation ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "languagePractice",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Language Practice ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+    await languagePracticeActivityWorkflow(activities, "test-run-id", [], []);
+
+    const steps = await prisma.step.findMany({
+      where: { activityId: activity.id, kind: "multipleChoice" },
+    });
+
+    const content = steps[0]!.content as Record<string, unknown>;
+    expect(content.context).toBe("Bonjour, comment ça va?");
+    expect(content.contextTranslation).toBe("Hello, how are you?");
+
+    const options = content.options as Record<string, unknown>[];
+    expect(options[0]!.text).toBe("Très bien, merci!");
+    expect(options[0]!.feedback).toBe("Great choice!");
+    expect(options[0]!.translation).toBe("Very well, thank you!");
+    expect(options[1]!.text).toBe("Au revoir!");
+    expect(options[1]!.feedback).toBe("Not quite.");
+    expect(options[1]!.translation).toBe("Goodbye!");
+  });
+
+  test("generates audio and stores URLs in step content when TTS succeeds", async () => {
+    vi.mocked(generateLanguageAudio).mockResolvedValue({
+      data: "https://example.com/audio.mp3",
+      error: null,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `LangPractice Audio ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "languagePractice",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Language Practice ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+    await languagePracticeActivityWorkflow(activities, "test-run-id", [], []);
+
+    const steps = await prisma.step.findMany({
+      where: { activityId: activity.id, kind: "multipleChoice" },
+    });
+
+    const content = steps[0]!.content as Record<string, unknown>;
+    expect(content.contextAudioUrl).toBe("https://example.com/audio.mp3");
+
+    const options = content.options as Record<string, unknown>[];
+
+    for (const option of options) {
+      expect(option.audioUrl).toBe("https://example.com/audio.mp3");
+    }
+  });
+
+  test("skips TTS for sentences that already have a SentenceAudio record", async () => {
+    const id = randomUUID().replaceAll("-", "").slice(0, 8);
+    const existingContext = `Existing context ${id}`;
+
+    await prisma.sentenceAudio.create({
+      data: {
+        audioUrl: "https://example.com/existing-audio.mp3",
+        organizationId,
+        sentence: existingContext,
+        targetLanguage: "es",
+      },
+    });
+
+    vi.mocked(generateLanguageAudio).mockResolvedValue({
+      data: "https://example.com/new-audio.mp3",
+      error: null,
+    });
+
+    vi.mocked(generateActivityPracticeLanguage).mockResolvedValueOnce({
+      data: {
+        scenario: "Test scenario.",
+        steps: [
+          {
+            context: existingContext,
+            contextRomanization: null,
+            contextTranslation: "Existing translation.",
+            options: [
+              {
+                feedback: "Good.",
+                isCorrect: true,
+                text: `New text ${id}`,
+                textRomanization: null,
+                translation: "New translation.",
+              },
+              {
+                feedback: "Bad.",
+                isCorrect: false,
+                text: `Other text ${id}`,
+                textRomanization: null,
+                translation: "Other translation.",
+              },
+            ],
+          },
+        ],
+      },
+    } as Awaited<ReturnType<typeof generateActivityPracticeLanguage>>);
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `LangPractice Dedup ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "languagePractice",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Language Practice ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+    await languagePracticeActivityWorkflow(activities, "test-run-id", [], []);
+
+    // Should NOT call TTS for the existing context sentence
+    expect(generateLanguageAudio).not.toHaveBeenCalledWith(
+      expect.objectContaining({ text: existingContext }),
+    );
+
+    // Should call TTS for the new option texts
+    expect(generateLanguageAudio).toHaveBeenCalledWith(
+      expect.objectContaining({ text: `New text ${id}` }),
+    );
+
+    const steps = await prisma.step.findMany({
+      where: { activityId: activity.id, kind: "multipleChoice" },
+    });
+
+    const content = steps[0]!.content as Record<string, unknown>;
+
+    // Existing audio URL should be used for context
+    expect(content.contextAudioUrl).toBe("https://example.com/existing-audio.mp3");
+
+    // New audio URL should be used for option texts
+    const options = content.options as Record<string, unknown>[];
+
+    for (const option of options) {
+      expect(option.audioUrl).toBe("https://example.com/new-audio.mp3");
+    }
+  });
+
+  test("completes activity even when audio generation fails", async () => {
+    vi.mocked(generateLanguageAudio).mockResolvedValue({
+      data: null,
+      error: new Error("TTS failed"),
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `LangPractice AudioFail ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "languagePractice",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Language Practice ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+    await languagePracticeActivityWorkflow(activities, "test-run-id", [], []);
+
+    const dbActivity = await prisma.activity.findUnique({ where: { id: activity.id } });
+    expect(dbActivity?.generationStatus).toBe("completed");
+  });
+
+  test("skips audio step for unsupported TTS language", async () => {
+    const unsupportedCourse = await courseFixture({
+      organizationId,
+      targetLanguage: "xx",
+    });
+
+    const unsupportedChapter = await chapterFixture({
+      courseId: unsupportedCourse.id,
+      organizationId,
+      title: `LangPractice UnsupportedLang Chapter ${randomUUID()}`,
+    });
+
+    vi.mocked(generateLanguageAudio).mockResolvedValue({
+      data: "https://example.com/audio.mp3",
+      error: null,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: unsupportedChapter.id,
+      kind: "language",
+      organizationId,
+      title: `LangPractice UnsupportedLang ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "languagePractice",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Language Practice ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+    await languagePracticeActivityWorkflow(activities, "test-run-id", [], []);
+
+    // TTS should never be called for unsupported language
+    expect(generateLanguageAudio).not.toHaveBeenCalled();
+
+    // Activity should still complete
+    const dbActivity = await prisma.activity.findUnique({ where: { id: activity.id } });
+    expect(dbActivity?.generationStatus).toBe("completed");
+
+    // Audio URLs should remain null
+    const steps = await prisma.step.findMany({
+      where: { activityId: activity.id, kind: "multipleChoice" },
+    });
+
+    const content = steps[0]!.content as Record<string, unknown>;
+    expect(content.contextAudioUrl).toBeNull();
   });
 });

--- a/apps/api/src/workflows/activity-generation/kinds/language-practice-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/language-practice-workflow.ts
@@ -1,4 +1,5 @@
 import { completeActivityStep } from "../steps/complete-activity-step";
+import { generateLanguagePracticeAudioStep } from "../steps/generate-language-practice-audio-step";
 import { generateLanguagePracticeContentStep } from "../steps/generate-language-practice-content-step";
 import { type LessonActivity } from "../steps/get-lesson-activities-step";
 
@@ -16,5 +17,6 @@ export async function languagePracticeActivityWorkflow(
     concepts,
     neighboringConcepts,
   );
+  await generateLanguagePracticeAudioStep(activities);
   await completeActivityStep(activities, workflowRunId, "languagePractice");
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-language-practice-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-language-practice-audio-step.ts
@@ -1,0 +1,135 @@
+import {
+  type LanguageMultipleChoiceContent,
+  type MultipleChoiceStepContent,
+  parseStepContent,
+} from "@zoonk/core/steps/content-contract";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { isTTSSupportedLanguage } from "@zoonk/utils/languages";
+import { streamError, streamStatus } from "../stream-status";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
+import { generateAudioForText } from "./_utils/generate-audio-for-text";
+import { type LessonActivity } from "./get-lesson-activities-step";
+
+function assertLanguageContent(content: MultipleChoiceStepContent): LanguageMultipleChoiceContent {
+  if (content.kind !== "language") {
+    throw new Error(`Expected language content, got ${content.kind}`);
+  }
+
+  return content;
+}
+
+function extractUniqueTexts(steps: { content: LanguageMultipleChoiceContent }[]): string[] {
+  const texts = new Set<string>();
+
+  for (const step of steps) {
+    texts.add(step.content.context);
+
+    for (const option of step.content.options) {
+      texts.add(option.text);
+    }
+  }
+
+  return [...texts];
+}
+
+export async function generateLanguagePracticeAudioStep(
+  activities: LessonActivity[],
+): Promise<void> {
+  "use step";
+
+  const activity = findActivityByKind(activities, "languagePractice");
+
+  if (!activity) {
+    return;
+  }
+
+  const course = activity.lesson.chapter.course;
+  const targetLanguage = course.targetLanguage;
+
+  await streamStatus({ status: "started", step: "generateLanguagePracticeAudio" });
+
+  if (!isTTSSupportedLanguage(targetLanguage) || !course.organization) {
+    await streamStatus({ status: "completed", step: "generateLanguagePracticeAudio" });
+    return;
+  }
+
+  const organizationId = course.organization.id;
+
+  const dbSteps = await prisma.step.findMany({
+    select: { content: true, id: true },
+    where: { activityId: activity.id, kind: "multipleChoice" },
+  });
+
+  const parsedSteps = dbSteps.map((step) => ({
+    content: assertLanguageContent(parseStepContent("multipleChoice", step.content)),
+    id: step.id,
+  }));
+
+  const uniqueTexts = extractUniqueTexts(parsedSteps);
+
+  const existingAudios = await prisma.sentenceAudio.findMany({
+    select: { audioUrl: true, sentence: true },
+    where: { organizationId, sentence: { in: uniqueTexts }, targetLanguage },
+  });
+
+  const audioMap: Record<string, string> = Object.fromEntries(
+    existingAudios.map((record) => [record.sentence, record.audioUrl]),
+  );
+
+  const textsNeedingAudio = uniqueTexts.filter((text) => !audioMap[text]);
+
+  const results = await Promise.all(
+    textsNeedingAudio.map((text) =>
+      generateAudioForText(text, targetLanguage, course.organization?.slug),
+    ),
+  );
+
+  const fulfilled = results.filter((result) => result !== null);
+
+  await Promise.all(
+    fulfilled.map((result) =>
+      prisma.sentenceAudio.upsert({
+        create: {
+          audioUrl: result.audioUrl,
+          organizationId,
+          sentence: result.text,
+          targetLanguage,
+        },
+        select: { id: true },
+        update: { audioUrl: result.audioUrl },
+        where: {
+          orgSentenceAudio: { organizationId, sentence: result.text, targetLanguage },
+        },
+      }),
+    ),
+  );
+
+  for (const result of fulfilled) {
+    audioMap[result.text] = result.audioUrl;
+  }
+
+  const updates = parsedSteps.map((step) => {
+    const updatedContent: LanguageMultipleChoiceContent = {
+      ...step.content,
+      contextAudioUrl: audioMap[step.content.context] ?? null,
+      options: step.content.options.map((option) => ({
+        ...option,
+        audioUrl: audioMap[option.text] ?? null,
+      })),
+    };
+
+    return prisma.step.update({
+      data: { content: updatedContent },
+      where: { id: step.id },
+    });
+  });
+
+  const { error } = await safeAsync(() => Promise.all(updates));
+
+  if (error || fulfilled.length < textsNeedingAudio.length) {
+    await streamError({ reason: "enrichmentFailed", step: "generateLanguagePracticeAudio" });
+  }
+
+  await streamStatus({ status: "completed", step: "generateLanguagePracticeAudio" });
+}

--- a/apps/api/src/workflows/activity-generation/steps/generate-language-practice-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-language-practice-content-step.ts
@@ -1,7 +1,4 @@
-import {
-  type WorkflowErrorReason,
-  getAIResultErrorReason,
-} from "@/workflows/_shared/stream-status";
+import { type WorkflowErrorReason } from "@/workflows/_shared/stream-status";
 import {
   type ActivityPracticeLanguageSchema,
   generateActivityPracticeLanguage,
@@ -9,6 +6,7 @@ import {
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { prisma } from "@zoonk/db";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { logError, logInfo } from "@zoonk/utils/logger";
 import { emptyToNull, normalizePunctuation } from "@zoonk/utils/string";
 import { z } from "zod";
 import { streamError, streamStatus } from "../stream-status";
@@ -42,7 +40,16 @@ const minimumLanguagePracticeContentSchema = z.object({
 });
 
 function hasMinimumLanguagePracticeContent(data: ActivityPracticeLanguageSchema): boolean {
-  return minimumLanguagePracticeContentSchema.safeParse(data).success;
+  const result = minimumLanguagePracticeContentSchema.safeParse(data);
+
+  if (!result.success) {
+    logError(
+      "[Language Practice] Content validation failed:",
+      JSON.stringify(result.error.issues, null, 2),
+    );
+  }
+
+  return result.success;
 }
 
 function buildLanguagePracticeSteps(
@@ -144,15 +151,37 @@ export async function generateLanguagePracticeContentStep(
       }),
     );
 
-  if (error || !result || !hasMinimumLanguagePracticeContent(result.data)) {
-    const reason = getAIResultErrorReason(error, result);
-    await handleLanguagePracticeError(activity.id, reason);
+  if (error) {
+    logError("[Language Practice] AI generation error:", error.message);
+    await handleLanguagePracticeError(activity.id, "aiGenerationFailed");
     return { generated: false };
   }
+
+  if (!result) {
+    logError("[Language Practice] AI returned empty result");
+    await handleLanguagePracticeError(activity.id, "aiEmptyResult");
+    return { generated: false };
+  }
+
+  if (!hasMinimumLanguagePracticeContent(result.data)) {
+    logError(
+      "[Language Practice] Content validation failed. Step count:",
+      result.data.steps.length,
+      "| First step options:",
+      result.data.steps[0]?.options.length,
+      "| Has translation:",
+      result.data.steps[0]?.options[0] && "translation" in result.data.steps[0].options[0],
+    );
+    await handleLanguagePracticeError(activity.id, "contentValidationFailed");
+    return { generated: false };
+  }
+
+  logInfo("[Language Practice] Content validated, saving steps for activity", activity.id);
 
   const { error: saveError } = await saveLanguagePracticeSteps(activity.id, result.data);
 
   if (saveError) {
+    logError("[Language Practice] DB save error:", saveError.message);
     await handleLanguagePracticeError(activity.id, "dbSaveFailed");
     return { generated: false };
   }

--- a/apps/api/src/workflows/activity-generation/steps/generate-language-practice-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-language-practice-content-step.ts
@@ -9,7 +9,7 @@ import {
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { prisma } from "@zoonk/db";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
-import { emptyToNull } from "@zoonk/utils/string";
+import { emptyToNull, normalizePunctuation } from "@zoonk/utils/string";
 import { z } from "zod";
 import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
@@ -32,6 +32,7 @@ const minimumLanguagePracticeContentSchema = z.object({
               isCorrect: z.boolean(),
               text: z.string().trim().min(1),
               textRomanization: z.string().nullable(),
+              translation: z.string().trim().min(1),
             }),
           )
           .min(1),
@@ -63,15 +64,18 @@ function buildLanguagePracticeSteps(
   const practiceSteps = data.steps.map((step, index) => ({
     activityId,
     content: assertStepContent("multipleChoice", {
-      context: step.context,
+      context: normalizePunctuation(step.context),
+      contextAudioUrl: null,
       contextRomanization: emptyToNull(step.contextRomanization),
-      contextTranslation: step.contextTranslation,
+      contextTranslation: normalizePunctuation(step.contextTranslation),
       kind: "language",
       options: step.options.map((option) => ({
-        feedback: option.feedback,
+        audioUrl: null,
+        feedback: normalizePunctuation(option.feedback),
         isCorrect: option.isCorrect,
-        text: option.text,
+        text: normalizePunctuation(option.text),
         textRomanization: emptyToNull(option.textRomanization),
+        translation: normalizePunctuation(option.translation),
       })),
     }),
     isPublished: true,

--- a/apps/api/src/workflows/activity-generation/steps/generate-language-practice-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-language-practice-content-step.ts
@@ -1,4 +1,7 @@
-import { type WorkflowErrorReason } from "@/workflows/_shared/stream-status";
+import {
+  type WorkflowErrorReason,
+  getAIResultErrorReason,
+} from "@/workflows/_shared/stream-status";
 import {
   type ActivityPracticeLanguageSchema,
   generateActivityPracticeLanguage,
@@ -6,7 +9,6 @@ import {
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { prisma } from "@zoonk/db";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
-import { logError, logInfo } from "@zoonk/utils/logger";
 import { emptyToNull, normalizePunctuation } from "@zoonk/utils/string";
 import { z } from "zod";
 import { streamError, streamStatus } from "../stream-status";
@@ -40,16 +42,7 @@ const minimumLanguagePracticeContentSchema = z.object({
 });
 
 function hasMinimumLanguagePracticeContent(data: ActivityPracticeLanguageSchema): boolean {
-  const result = minimumLanguagePracticeContentSchema.safeParse(data);
-
-  if (!result.success) {
-    logError(
-      "[Language Practice] Content validation failed:",
-      JSON.stringify(result.error.issues, null, 2),
-    );
-  }
-
-  return result.success;
+  return minimumLanguagePracticeContentSchema.safeParse(data).success;
 }
 
 function buildLanguagePracticeSteps(
@@ -151,37 +144,15 @@ export async function generateLanguagePracticeContentStep(
       }),
     );
 
-  if (error) {
-    logError("[Language Practice] AI generation error:", error.message);
-    await handleLanguagePracticeError(activity.id, "aiGenerationFailed");
+  if (error || !result || !hasMinimumLanguagePracticeContent(result.data)) {
+    const reason = getAIResultErrorReason(error, result);
+    await handleLanguagePracticeError(activity.id, reason);
     return { generated: false };
   }
-
-  if (!result) {
-    logError("[Language Practice] AI returned empty result");
-    await handleLanguagePracticeError(activity.id, "aiEmptyResult");
-    return { generated: false };
-  }
-
-  if (!hasMinimumLanguagePracticeContent(result.data)) {
-    logError(
-      "[Language Practice] Content validation failed. Step count:",
-      result.data.steps.length,
-      "| First step options:",
-      result.data.steps[0]?.options.length,
-      "| Has translation:",
-      result.data.steps[0]?.options[0] && "translation" in result.data.steps[0].options[0],
-    );
-    await handleLanguagePracticeError(activity.id, "contentValidationFailed");
-    return { generated: false };
-  }
-
-  logInfo("[Language Practice] Content validated, saving steps for activity", activity.id);
 
   const { error: saveError } = await saveLanguagePracticeSteps(activity.id, result.data);
 
   if (saveError) {
-    logError("[Language Practice] DB save error:", saveError.message);
     await handleLanguagePracticeError(activity.id, "dbSaveFailed");
     return { generated: false };
   }

--- a/apps/api/src/workflows/config.ts
+++ b/apps/api/src/workflows/config.ts
@@ -31,6 +31,7 @@ const ACTIVITY_STEPS = [
   "generatePracticeContent",
   "generateGrammarContent",
   "generateLanguagePracticeContent",
+  "generateLanguagePracticeAudio",
   "generateSentences",
   "generateVisuals",
   "generateImages",

--- a/apps/evals/src/tasks/activity-practice-language/test-cases.ts
+++ b/apps/evals/src/tasks/activity-practice-language/test-cases.ts
@@ -28,15 +28,16 @@ EVALUATION CRITERIA:
    - All 4 options MUST be grammatically correct in TARGET language
    - Options should represent meaningfully different responses
    - textRomanization provided for non-Roman scripts, null for Roman scripts
+   - Each option MUST have a 'translation' field with a clean standalone translation in NATIVE language
    - Penalize SEVERELY if options include translations or hints in NATIVE language
    - Penalize if options are grammatically incorrect or nonsensical
 
 5. FEEDBACK DESIGN (CRITICAL):
-   - Every feedback MUST include the translation of what the learner said
-   - Feedback MUST explain why the choice is correct or incorrect
+   - Feedback contains ONLY the explanation — why the choice is correct or incorrect
    - For incorrect options: explain what would be better
    - Feedback is in NATIVE language
-   - Penalize SEVERELY if feedback is missing translation
+   - Do NOT include the translation in feedback (it's in the separate 'translation' field)
+   - Penalize if feedback repeats the translation instead of providing explanation
    - Penalize if feedback doesn't explain the reasoning
 
 6. ROMANIZATION (CRITICAL):
@@ -94,7 +95,7 @@ ANTI-CHECKLIST GUIDANCE (CRITICAL):
 - Do NOT require specific phrases or sentence structures
 - Do NOT penalize for different valid cultural approaches
 - Do NOT penalize distractors for being "too obviously wrong" or "too nonsensical" — off-topic distractors are valid by design (asking about haircuts at a pharmacy, asking for directions at a cafe). Only penalize if a distractor is grammatically incorrect or breaks immersion
-- Do NOT require a specific feedback format order. The translation can appear anywhere in the feedback (beginning, inline, quoted). Only penalize if the translation is completely absent
+- Do NOT penalize for specific feedback wording — focus on whether it explains why the choice is correct/incorrect
 - Do NOT penalize for output being wrapped in {"scenario": ..., "steps": [...]} vs other valid structures
 - FOCUS ON: structural correctness, immersion principle (no translations in options), feedback quality, romanization correctness
 - The eval model should judge whether the activity creates an immersive language experience, not whether it matches predetermined answers
@@ -116,13 +117,13 @@ KEY REQUIREMENTS:
 - Native speaker (barista/server) speaks natural French
 - Learner must choose appropriate French phrases for ordering
 - Options show ONLY French text, NO English translations
-- Feedback reveals English translation + explanation
+- Feedback contains explanation only (translation is in the separate 'translation' field)
 
 ACCURACY PITFALLS - Penalize SEVERELY if:
 - Options include English translations or hints
 - French dialogue is unnatural or overly formal for a cafe
 - Romanization fields contain any text (must be null)
-- Feedback doesn't include translation of what the learner said
+- Feedback repeats the translation instead of explaining reasoning
 - Steps don't follow a logical cafe interaction flow
 
 ${SHARED_EXPECTATIONS}
@@ -152,7 +153,7 @@ KEY REQUIREMENTS:
 - Receptionist speaks polite Japanese (formal register appropriate for service)
 - Learner must choose appropriate Japanese phrases for check-in
 - Options show ONLY Japanese text with romanization, NO English
-- Feedback reveals English translation + explanation
+- Feedback contains explanation only (translation is in the separate 'translation' field)
 
 ROMANIZATION REQUIREMENTS:
 - MUST include romaji for all Japanese text in context and options
@@ -163,7 +164,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Options include English translations
 - Japanese is too casual for a hotel setting (should use です/ます forms)
 - Romanization is missing or incorrect
-- Feedback doesn't include translation
+- Feedback repeats translation instead of explaining reasoning
 - Steps don't follow a logical hotel check-in sequence
 
 ${SHARED_EXPECTATIONS}
@@ -200,7 +201,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Options include Portuguese translations
 - German dialogue is unnatural or uses overly formal register for a market
 - Romanization fields contain any text (must be null)
-- Feedback (in Portuguese) doesn't include German translation
+- Feedback (in Portuguese) repeats translation instead of explaining reasoning
 - Steps don't follow a logical shopping interaction
 
 ${SHARED_EXPECTATIONS}
@@ -241,7 +242,7 @@ ACCURACY PITFALLS - Penalize SEVERELY if:
 - Options include Spanish translations
 - Korean is inappropriate register (should use polite 요 forms for strangers)
 - Romanization is missing or uses non-standard system
-- Feedback (in Spanish) doesn't include Korean translation
+- Feedback (in Spanish) repeats translation instead of explaining reasoning
 - Steps don't follow a logical interaction for asking directions
 
 ${SHARED_EXPECTATIONS}
@@ -270,13 +271,13 @@ KEY REQUIREMENTS:
 - Pharmacist speaks natural Spanish
 - Learner must describe symptoms and ask for recommendations
 - Options show ONLY Spanish text, NO English translations
-- Feedback reveals English translation + explanation
+- Feedback contains explanation only (translation is in the separate 'translation' field)
 
 ACCURACY PITFALLS - Penalize SEVERELY if:
 - Options include English translations
 - Spanish dialogue is unnatural
 - Romanization fields contain any text (must be null)
-- Feedback doesn't include translation
+- Feedback repeats translation instead of explaining reasoning
 
 ${SHARED_EXPECTATIONS}
     `,

--- a/apps/main/e2e/multiple-choice-step.test.ts
+++ b/apps/main/e2e/multiple-choice-step.test.ts
@@ -242,21 +242,26 @@ test.describe("Language Variant", () => {
         {
           content: {
             context: `Bonjour ${uniqueId}`,
+            contextAudioUrl: null,
             contextRomanization: `bon-zhoor ${uniqueId}`,
             contextTranslation: `Hello ${uniqueId}`,
             kind: "language",
             options: [
               {
+                audioUrl: null,
                 feedback: "Correct!",
                 isCorrect: true,
                 text: `Salut ${uniqueId}`,
                 textRomanization: `sa-loo ${uniqueId}`,
+                translation: `Hi ${uniqueId}`,
               },
               {
+                audioUrl: null,
                 feedback: "Not quite",
                 isCorrect: false,
                 text: `Au revoir ${uniqueId}`,
                 textRomanization: `oh reh-vwar ${uniqueId}`,
+                translation: `Goodbye ${uniqueId}`,
               },
             ],
           },
@@ -288,21 +293,26 @@ test.describe("Language Variant", () => {
         {
           content: {
             context: `Hola ${uniqueId}`,
+            contextAudioUrl: null,
             contextRomanization: null,
             contextTranslation: `Hello ${uniqueId}`,
             kind: "language",
             options: [
               {
+                audioUrl: null,
                 feedback: "Yes",
                 isCorrect: true,
                 text: `Buenos dias ${uniqueId}`,
                 textRomanization: null,
+                translation: `Good morning ${uniqueId}`,
               },
               {
+                audioUrl: null,
                 feedback: "No",
                 isCorrect: false,
                 text: `Adios ${uniqueId}`,
                 textRomanization: null,
+                translation: `Goodbye ${uniqueId}`,
               },
             ],
           },
@@ -318,6 +328,238 @@ test.describe("Language Variant", () => {
 
     await expect(page.getByText(new RegExp(`Hola ${uniqueId}`))).toBeVisible();
     await expect(page.getByText(new RegExp(`Hello ${uniqueId}`))).toBeVisible();
+  });
+
+  test("correct answer feedback shows romanization and translation", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMultipleChoiceActivity({
+      steps: [
+        {
+          content: {
+            context: `こんにちは ${uniqueId}`,
+            contextAudioUrl: null,
+            contextRomanization: `konnichiwa ${uniqueId}`,
+            contextTranslation: `Hello ${uniqueId}`,
+            kind: "language",
+            options: [
+              {
+                audioUrl: null,
+                feedback: `Good job ${uniqueId}`,
+                isCorrect: true,
+                text: `はい ${uniqueId}`,
+                textRomanization: `hai ${uniqueId}`,
+                translation: `Yes ${uniqueId}`,
+              },
+              {
+                audioUrl: null,
+                feedback: "Not quite",
+                isCorrect: false,
+                text: `いいえ ${uniqueId}`,
+                textRomanization: `iie ${uniqueId}`,
+                translation: `No ${uniqueId}`,
+              },
+            ],
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("radio", { name: new RegExp(`はい ${uniqueId}`) }).click();
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByText(/your answer:/i)).toBeVisible();
+    await expect(page.getByText(new RegExp(`はい ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`hai ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`Yes ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`Good job ${uniqueId}`))).toBeVisible();
+  });
+
+  test("incorrect answer feedback shows both answers with romanization and translation", async ({
+    page,
+  }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMultipleChoiceActivity({
+      steps: [
+        {
+          content: {
+            context: `こんにちは ${uniqueId}`,
+            contextAudioUrl: null,
+            contextRomanization: `konnichiwa ${uniqueId}`,
+            contextTranslation: `Hello ${uniqueId}`,
+            kind: "language",
+            options: [
+              {
+                audioUrl: null,
+                feedback: "Good job",
+                isCorrect: true,
+                text: `はい ${uniqueId}`,
+                textRomanization: `hai ${uniqueId}`,
+                translation: `Yes ${uniqueId}`,
+              },
+              {
+                audioUrl: null,
+                feedback: `Wrong choice ${uniqueId}`,
+                isCorrect: false,
+                text: `いいえ ${uniqueId}`,
+                textRomanization: `iie ${uniqueId}`,
+                translation: `No ${uniqueId}`,
+              },
+            ],
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("radio", { name: new RegExp(`いいえ ${uniqueId}`) }).click();
+    await page.getByRole("button", { name: /check/i }).click();
+
+    // User's incorrect answer with romanization and translation
+    await expect(page.getByText(/your answer:/i)).toBeVisible();
+    await expect(page.getByText(new RegExp(`いいえ ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`iie ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`No ${uniqueId}`))).toBeVisible();
+
+    // Correct answer with romanization and translation
+    await expect(page.getByText(/correct answer:/i)).toBeVisible();
+    await expect(page.getByText(new RegExp(`はい ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`hai ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`Yes ${uniqueId}`))).toBeVisible();
+  });
+
+  test("feedback works without romanization (Roman scripts)", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMultipleChoiceActivity({
+      steps: [
+        {
+          content: {
+            context: `Bonjour ${uniqueId}`,
+            contextAudioUrl: null,
+            contextRomanization: null,
+            contextTranslation: `Hello ${uniqueId}`,
+            kind: "language",
+            options: [
+              {
+                audioUrl: null,
+                feedback: `Correct ${uniqueId}`,
+                isCorrect: true,
+                text: `Salut ${uniqueId}`,
+                textRomanization: null,
+                translation: `Hi ${uniqueId}`,
+              },
+              {
+                audioUrl: null,
+                feedback: "Not quite",
+                isCorrect: false,
+                text: `Au revoir ${uniqueId}`,
+                textRomanization: null,
+                translation: `Goodbye ${uniqueId}`,
+              },
+            ],
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("radio", { name: new RegExp(`Salut ${uniqueId}`) }).click();
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByText(/your answer:/i)).toBeVisible();
+    await expect(page.getByText(new RegExp(`Salut ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`Hi ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`Correct ${uniqueId}`))).toBeVisible();
+  });
+
+  test("context audio button is visible when contextAudioUrl present", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMultipleChoiceActivity({
+      steps: [
+        {
+          content: {
+            context: `Bonjour ${uniqueId}`,
+            contextAudioUrl: "https://example.com/audio.mp3",
+            contextRomanization: null,
+            contextTranslation: `Hello ${uniqueId}`,
+            kind: "language",
+            options: [
+              {
+                audioUrl: null,
+                feedback: "Good",
+                isCorrect: true,
+                text: `Salut ${uniqueId}`,
+                textRomanization: null,
+                translation: `Hi ${uniqueId}`,
+              },
+              {
+                audioUrl: null,
+                feedback: "Bad",
+                isCorrect: false,
+                text: `Au revoir ${uniqueId}`,
+                textRomanization: null,
+                translation: `Goodbye ${uniqueId}`,
+              },
+            ],
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(page.getByRole("button", { name: /play pronunciation/i })).toBeVisible();
+  });
+
+  test("context audio button is absent when contextAudioUrl is null", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createMultipleChoiceActivity({
+      steps: [
+        {
+          content: {
+            context: `Hola ${uniqueId}`,
+            contextAudioUrl: null,
+            contextRomanization: null,
+            contextTranslation: `Hello ${uniqueId}`,
+            kind: "language",
+            options: [
+              {
+                audioUrl: null,
+                feedback: "Good",
+                isCorrect: true,
+                text: `Buenos dias ${uniqueId}`,
+                textRomanization: null,
+                translation: `Good morning ${uniqueId}`,
+              },
+              {
+                audioUrl: null,
+                feedback: "Bad",
+                isCorrect: false,
+                text: `Adios ${uniqueId}`,
+                textRomanization: null,
+                translation: `Goodbye ${uniqueId}`,
+              },
+            ],
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(page.getByText(new RegExp(`Hola ${uniqueId}`))).toBeVisible();
+    await expect(page.getByRole("button", { name: /play pronunciation/i })).not.toBeVisible();
   });
 });
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -233,6 +233,7 @@ msgid "View scores"
 msgstr "View scores"
 
 #: ../../packages/player/src/components/feedback-screen.tsx
+#: ../../packages/player/src/components/language-practice-feedback.tsx
 msgctxt "3nOd8f"
 msgid "Your answer:"
 msgstr "Your answer:"
@@ -263,6 +264,7 @@ msgid "{name} is at zero. One more drop and you lose."
 msgstr "{name} is at zero. One more drop and you lose."
 
 #: ../../packages/player/src/components/feedback-screen.tsx
+#: ../../packages/player/src/components/language-practice-feedback.tsx
 msgctxt "QAJ/Tl"
 msgid "Correct answer:"
 msgstr "Correct answer:"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -233,6 +233,7 @@ msgid "View scores"
 msgstr "Ver puntuaciones"
 
 #: ../../packages/player/src/components/feedback-screen.tsx
+#: ../../packages/player/src/components/language-practice-feedback.tsx
 msgctxt "3nOd8f"
 msgid "Your answer:"
 msgstr "Tu respuesta:"
@@ -263,6 +264,7 @@ msgid "{name} is at zero. One more drop and you lose."
 msgstr "{name} está en cero. Una caída más y pierdes."
 
 #: ../../packages/player/src/components/feedback-screen.tsx
+#: ../../packages/player/src/components/language-practice-feedback.tsx
 msgctxt "QAJ/Tl"
 msgid "Correct answer:"
 msgstr "Respuesta correcta:"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -233,6 +233,7 @@ msgid "View scores"
 msgstr "Ver pontuações"
 
 #: ../../packages/player/src/components/feedback-screen.tsx
+#: ../../packages/player/src/components/language-practice-feedback.tsx
 msgctxt "3nOd8f"
 msgid "Your answer:"
 msgstr "Sua resposta:"
@@ -263,6 +264,7 @@ msgid "{name} is at zero. One more drop and you lose."
 msgstr "{name} está em zero. Mais uma queda e você perde."
 
 #: ../../packages/player/src/components/feedback-screen.tsx
+#: ../../packages/player/src/components/language-practice-feedback.tsx
 msgctxt "QAJ/Tl"
 msgid "Correct answer:"
 msgstr "Resposta correta:"

--- a/apps/main/src/lib/generation/activity-generation-phase-config.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-config.ts
@@ -25,7 +25,6 @@ export type FirstActivityKind = "explanation" | "custom" | "vocabulary";
 const CUSTOM_INFERENCE_STEPS = new Set(["generateCustomContent", "setCustomAsCompleted"]);
 const WRITING_ONLY_LANGUAGE_STEP_MAP: Partial<Record<ActivityKind, ActivityStepName>> = {
   grammar: "generateGrammarContent",
-  languagePractice: "generateLanguagePracticeContent",
 };
 
 export function inferFirstActivityKind(params: {
@@ -74,8 +73,12 @@ export function getPhaseOrder(kind: ActivityKind): PhaseName[] {
     ];
   }
 
-  if (kind === "grammar" || kind === "languagePractice") {
+  if (kind === "grammar") {
     return ["gettingStarted", "writingContent", "finishing"];
+  }
+
+  if (kind === "languagePractice") {
+    return ["gettingStarted", "writingContent", "recordingAudio", "finishing"];
   }
 
   if (kind === "custom") {
@@ -139,6 +142,20 @@ function getLanguagePhaseSteps(kind: ActivityKind): Record<PhaseName, ActivitySt
       processingDependencies: [],
       recordingAudio: ["generateVocabularyAudio"],
       writingContent: [],
+    };
+  }
+
+  if (kind === "languagePractice") {
+    return {
+      ...SHARED_PHASE_STEPS,
+      ...NO_VISUALS_OVERRIDE,
+      finishing: [
+        ...VISUALS_AS_FINISHING,
+        ...getFinishingSteps(["generateLanguagePracticeContent", "generateLanguagePracticeAudio"]),
+      ],
+      processingDependencies: [],
+      recordingAudio: ["generateLanguagePracticeAudio"],
+      writingContent: ["setActivityAsRunning", "generateLanguagePracticeContent"],
     };
   }
 

--- a/apps/main/src/lib/generation/activity-generation-phase-step-groups.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-step-groups.ts
@@ -24,6 +24,7 @@ const ALL_READING_STEPS: ActivityStepName[] = [
   "saveSentences",
   "generateAudio",
   "updateSentenceEnrichments",
+  "generateLanguagePracticeAudio",
 ];
 
 const ALL_COMPLETION_STEPS: ActivityStepName[] = [

--- a/apps/main/src/lib/generation/activity-generation-phases.test.ts
+++ b/apps/main/src/lib/generation/activity-generation-phases.test.ts
@@ -75,10 +75,11 @@ describe(getPhaseOrder, () => {
     expect(getPhaseOrder("grammar")).toEqual(["gettingStarted", "writingContent", "finishing"]);
   });
 
-  test("uses language practice order without visual or audio phases", () => {
+  test("uses language practice order with audio phase", () => {
     expect(getPhaseOrder("languagePractice")).toEqual([
       "gettingStarted",
       "writingContent",
+      "recordingAudio",
       "finishing",
     ]);
   });

--- a/apps/main/src/lib/workflow/config.ts
+++ b/apps/main/src/lib/workflow/config.ts
@@ -32,6 +32,7 @@ export const ACTIVITY_STEPS = [
   "generatePracticeContent",
   "generateGrammarContent",
   "generateLanguagePracticeContent",
+  "generateLanguagePracticeAudio",
   "generateSentences",
   "generateVisuals",
   "generateImages",

--- a/packages/ai/src/tasks/activities/language/activity-practice.prompt.md
+++ b/packages/ai/src/tasks/activities/language/activity-practice.prompt.md
@@ -81,20 +81,6 @@ Note: `translation` is a clean, standalone translation of the option text. `feed
 
 # Options Design
 
-## No Translations in Options
-
-This is the most critical design decision. Options show ONLY:
-
-- `text`: The phrase in TARGET language
-- `textRomanization`: Romanization for non-Roman scripts (null for Roman scripts)
-
-**NO translation is shown**. This forces the learner to:
-
-1. Parse the target language directly
-2. Use patterns they've learned
-3. Make educated guesses based on context
-4. Experience the productive struggle of real communication
-
 ## Option Quality
 
 All 4 options must be:

--- a/packages/ai/src/tasks/activities/language/activity-practice.prompt.md
+++ b/packages/ai/src/tasks/activities/language/activity-practice.prompt.md
@@ -74,7 +74,10 @@ The character in the story is a friendly native speaker who:
 | `contextRomanization`        | Romanization | null (for Roman scripts)                                  |
 | `options[].text`             | TARGET       | "Un cafe con leche, por favor."                           |
 | `options[].textRomanization` | Romanization | null (for Roman scripts)                                  |
-| `options[].feedback`         | NATIVE       | "A coffee with milk, please - Perfect! Polite and clear." |
+| `options[].translation`      | NATIVE       | "A coffee with milk, please."                             |
+| `options[].feedback`         | NATIVE       | "Perfect! Polite and clearly communicates what you want." |
+
+Note: `translation` is a clean, standalone translation of the option text. `feedback` is the explanation only — why the choice is correct or incorrect. Do NOT repeat the translation in feedback since it's already shown separately.
 
 # Options Design
 
@@ -156,28 +159,21 @@ Wrong options should be **clearly wrong** because they:
 
 # Feedback Design
 
-Feedback appears AFTER the learner selects an option. Every feedback message MUST include:
-
-1. **Translation**: What the option actually means in the native language
-2. **Explanation**: Why this choice is correct or incorrect for the situation
+Feedback appears AFTER the learner selects an option. The translation is shown separately via `options[].translation`, so `feedback` contains **only the explanation** — why the choice is correct or incorrect. Do NOT include the translation in feedback.
 
 ## Feedback Structure
 
-For **correct** options:
+For **correct** options — explain why it works:
 
 ```
-"[Translation of what they said] - [Why this works in context]"
+"Perfect! This is polite and clearly communicates what you want."
 ```
 
-Example: "A coffee with milk, please - Perfect! This is polite and clearly communicates what you want."
-
-For **incorrect** options:
+For **incorrect** options — explain why it doesn't work and what would be better:
 
 ```
-"[Translation of what they said] - [Why this doesn't work and what would be better]"
+"You're trying to order coffee, not find the restroom. Tell the barista what you'd like to drink."
 ```
-
-Example: "Where is the bathroom? - You're trying to order coffee, not find the restroom. Tell the barista what you'd like to drink."
 
 # Romanization Requirements
 
@@ -256,14 +252,16 @@ Return an object with this structure (abbreviated examples shown):
         {
           "text": "京都までお願いします。",
           "textRomanization": "Kyouto made onegaishimasu.",
+          "translation": "To Kyoto, please.",
           "isCorrect": true,
-          "feedback": "To Kyoto, please - Perfect!"
+          "feedback": "Perfect! Clear and polite."
         },
         {
           "text": "京都は遠いですか？",
           "textRomanization": "Kyouto wa tooi desu ka?",
+          "translation": "Is Kyoto far?",
           "isCorrect": false,
-          "feedback": "Is Kyoto far? - This asks about distance, not for a ticket."
+          "feedback": "This asks about distance, not for a ticket."
         }
       ]
     }
@@ -285,14 +283,16 @@ Return an object with this structure (abbreviated examples shown):
         {
           "text": "Si, me gustaria la paella, por favor.",
           "textRomanization": null,
+          "translation": "Yes, I would like the paella, please.",
           "isCorrect": true,
-          "feedback": "Yes, I would like the paella, please - Perfect!"
+          "feedback": "Perfect! Natural and polite."
         },
         {
           "text": "La cuenta, por favor.",
           "textRomanization": null,
+          "translation": "The check, please.",
           "isCorrect": false,
-          "feedback": "The check, please - You haven't eaten yet!"
+          "feedback": "You haven't eaten yet!"
         }
       ]
     }
@@ -312,7 +312,7 @@ Before finalizing, verify:
 4. **Cultural accuracy**: Interactions reflect how things work in that culture
 5. **Clear progression**: Steps follow a logical narrative arc
 6. **Distinct options**: Each option represents a meaningfully different choice
-7. **Helpful feedback**: Translations and explanations clarify meaning and context
+7. **Helpful feedback**: Explanations clarify why the choice is correct/incorrect (translations are in a separate field)
 8. **Correct romanization**: Follows standard systems for non-Roman scripts, null for Roman scripts
 9. **Scenario relevance**: The story matches the lesson topic
 10. **Appropriate difficulty**: Language complexity matches learner level
@@ -325,5 +325,5 @@ Before finalizing, verify:
 4. **Unnatural responses**: Things a native speaker would never actually say
 5. **Missing romanization**: Forgetting to add romanization for non-Roman scripts
 6. **Adding romanization to Roman scripts**: Spanish, French, etc. should have null
-7. **Feedback without translation**: Always include what the option means
+7. **Translation in feedback**: Do NOT repeat the translation in feedback — it's already in the `translation` field
 8. **Disconnected steps**: Each step should follow logically from the previous one

--- a/packages/ai/src/tasks/activities/language/activity-practice.ts
+++ b/packages/ai/src/tasks/activities/language/activity-practice.ts
@@ -6,9 +6,8 @@ import { ACTIVITY_OPTIONS_COUNT, formatConceptLines } from "../config";
 import { getLanguagePromptContext } from "./_utils/language-prompt-context";
 import systemPrompt from "./activity-practice.prompt.md";
 
-const DEFAULT_MODEL =
-  process.env.AI_MODEL_ACTIVITY_LANGUAGE_PRACTICE ?? "anthropic/claude-opus-4.6";
-const FALLBACK_MODELS = ["openai/gpt-5.4", "google/gemini-3-flash"];
+const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_LANGUAGE_PRACTICE ?? "openai/gpt-5.4";
+const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3-flash"];
 
 const schema = z.object({
   scenario: z.string(),

--- a/packages/ai/src/tasks/activities/language/activity-practice.ts
+++ b/packages/ai/src/tasks/activities/language/activity-practice.ts
@@ -24,6 +24,7 @@ const schema = z.object({
             isCorrect: z.boolean(),
             text: z.string(),
             textRomanization: z.string().nullable(),
+            translation: z.string(),
           }),
         )
         .length(ACTIVITY_OPTIONS_COUNT),

--- a/packages/core/src/steps/content-contract.test.ts
+++ b/packages/core/src/steps/content-contract.test.ts
@@ -67,30 +67,36 @@ describe("step content contracts", () => {
   test("parses language multipleChoice", () => {
     const content = parseStepContent("multipleChoice", {
       context: "You enter a bakery in Madrid.",
+      contextAudioUrl: null,
       contextRomanization: "You enter a bakery in Madrid.",
       contextTranslation: "You enter a bakery in Madrid.",
       kind: "language",
       options: [
         {
+          audioUrl: null,
           feedback: "Great response.",
           isCorrect: true,
           text: "Buenos días, quisiera un café.",
           textRomanization: "bwen-os dee-as kee-sye-ra oon ka-fe",
+          translation: "Good morning, I would like a coffee.",
         },
       ],
     });
 
     expect(content).toEqual({
       context: "You enter a bakery in Madrid.",
+      contextAudioUrl: null,
       contextRomanization: "You enter a bakery in Madrid.",
       contextTranslation: "You enter a bakery in Madrid.",
       kind: "language",
       options: [
         {
+          audioUrl: null,
           feedback: "Great response.",
           isCorrect: true,
           text: "Buenos días, quisiera un café.",
           textRomanization: "bwen-os dee-as kee-sye-ra oon ka-fe",
+          translation: "Good morning, I would like a coffee.",
         },
       ],
     });
@@ -133,18 +139,38 @@ describe("step content contracts", () => {
   test("parses language with null romanization fields", () => {
     const content = parseStepContent("multipleChoice", {
       context: "Context",
+      contextAudioUrl: null,
       contextRomanization: null,
       contextTranslation: "Translation",
       kind: "language",
-      options: [{ feedback: "Great", isCorrect: true, text: "A", textRomanization: null }],
+      options: [
+        {
+          audioUrl: null,
+          feedback: "Great",
+          isCorrect: true,
+          text: "A",
+          textRomanization: null,
+          translation: "A translation",
+        },
+      ],
     });
 
     expect(content).toEqual({
       context: "Context",
+      contextAudioUrl: null,
       contextRomanization: null,
       contextTranslation: "Translation",
       kind: "language",
-      options: [{ feedback: "Great", isCorrect: true, text: "A", textRomanization: null }],
+      options: [
+        {
+          audioUrl: null,
+          feedback: "Great",
+          isCorrect: true,
+          text: "A",
+          textRomanization: null,
+          translation: "A translation",
+        },
+      ],
     });
   });
 

--- a/packages/core/src/steps/content-contract.ts
+++ b/packages/core/src/steps/content-contract.ts
@@ -26,10 +26,12 @@ const challengeOptionSchema = z
 
 const languageOptionSchema = z
   .object({
+    audioUrl: z.string().nullable(),
     feedback: z.string(),
     isCorrect: z.boolean(),
     text: z.string(),
     textRomanization: z.string().min(1).nullable(),
+    translation: z.string(),
   })
   .strict();
 
@@ -54,6 +56,7 @@ const challengeMultipleChoiceContentSchema = z
 const languageMultipleChoiceContentSchema = z
   .object({
     context: z.string(),
+    contextAudioUrl: z.string().nullable(),
     contextRomanization: z.string().min(1).nullable(),
     contextTranslation: z.string(),
     kind: z.literal("language"),

--- a/packages/player/src/check-answer.test.ts
+++ b/packages/player/src/check-answer.test.ts
@@ -99,12 +99,27 @@ describe(checkMultipleChoiceAnswer, () => {
   describe("language kind", () => {
     const content: MultipleChoiceStepContent = {
       context: "You enter a bakery.",
+      contextAudioUrl: null,
       contextRomanization: null,
       contextTranslation: "You enter a bakery.",
       kind: "language",
       options: [
-        { feedback: "Great!", isCorrect: true, text: "Buenos días", textRomanization: null },
-        { feedback: "Not quite.", isCorrect: false, text: "Adiós", textRomanization: null },
+        {
+          audioUrl: null,
+          feedback: "Great!",
+          isCorrect: true,
+          text: "Buenos días",
+          textRomanization: null,
+          translation: "Good morning",
+        },
+        {
+          audioUrl: null,
+          feedback: "Not quite.",
+          isCorrect: false,
+          text: "Adiós",
+          textRomanization: null,
+          translation: "Goodbye",
+        },
       ],
     };
 

--- a/packages/player/src/components/answer-line.tsx
+++ b/packages/player/src/components/answer-line.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@zoonk/ui/lib/utils";
+import { CircleCheck, CircleX } from "lucide-react";
+
+const variantStyles = {
+  correct: { background: "bg-success/10", color: "text-success" },
+  incorrect: { background: "bg-destructive/10", color: "text-destructive" },
+} as const;
+
+const variantIcons = {
+  correct: CircleCheck,
+  incorrect: CircleX,
+} as const;
+
+export function AnswerLine({
+  action,
+  children,
+  label,
+  text,
+  variant,
+}: {
+  action?: React.ReactNode;
+  children?: React.ReactNode;
+  label: string;
+  text: string;
+  variant: "correct" | "incorrect";
+}) {
+  const styles = variantStyles[variant];
+  const Icon = variantIcons[variant];
+
+  return (
+    <div className={cn("rounded-lg px-3 py-2 text-sm", styles.background)}>
+      <div className="flex items-center gap-2">
+        <span className={cn("shrink-0", styles.color)}>
+          <Icon aria-hidden="true" className="size-4" />
+        </span>
+
+        <div className="min-w-0">
+          <span className="text-muted-foreground">{label}</span>{" "}
+          <span className="font-medium">{text}</span>
+        </div>
+
+        {action && <span className="ml-auto shrink-0">{action}</span>}
+      </div>
+
+      {children && <div className="pl-6">{children}</div>}
+    </div>
+  );
+}

--- a/packages/player/src/components/feedback-layout.tsx
+++ b/packages/player/src/components/feedback-layout.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@zoonk/ui/lib/utils";
+
+export function FeedbackScreen({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      aria-live="polite"
+      className={cn(
+        "animate-in fade-in slide-in-from-bottom-1 mx-auto flex w-full max-w-lg flex-col gap-6 duration-200 ease-out motion-reduce:animate-none",
+        className,
+      )}
+      data-slot="feedback-screen"
+      role="status"
+      {...props}
+    />
+  );
+}
+
+export function FeedbackMessage({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      className={cn("text-foreground max-w-md text-lg leading-relaxed", className)}
+      data-slot="feedback-message"
+      {...props}
+    />
+  );
+}

--- a/packages/player/src/components/feedback-screen.tsx
+++ b/packages/player/src/components/feedback-screen.tsx
@@ -2,11 +2,12 @@
 
 import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { cn } from "@zoonk/ui/lib/utils";
-import { CircleAlert, CircleCheck, CircleX, TriangleAlert } from "lucide-react";
+import { CircleAlert, TriangleAlert } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { type DimensionInventory, type StepResult } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
 import { useReplaceName } from "../user-name-context";
+import { AnswerLine } from "./answer-line";
 import {
   type DimensionEntry,
   DimensionList,
@@ -14,23 +15,9 @@ import {
   buildDimensionEntries,
   getWarningDelay,
 } from "./dimension-inventory";
+import { FeedbackMessage, FeedbackScreen } from "./feedback-layout";
 import { LanguagePracticeFeedback } from "./language-practice-feedback";
 import { ResultAnnouncement } from "./result-announcement";
-
-function FeedbackScreen({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      aria-live="polite"
-      className={cn(
-        "animate-in fade-in slide-in-from-bottom-1 mx-auto flex w-full max-w-lg flex-col gap-6 duration-200 ease-out motion-reduce:animate-none",
-        className,
-      )}
-      data-slot="feedback-screen"
-      role="status"
-      {...props}
-    />
-  );
-}
 
 function FeedbackIndicator({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -39,50 +26,6 @@ function FeedbackIndicator({ className, ...props }: React.ComponentProps<"div">)
       data-slot="feedback-indicator"
       {...props}
     />
-  );
-}
-
-function FeedbackMessage({ className, ...props }: React.ComponentProps<"p">) {
-  return (
-    <p
-      className={cn("text-foreground max-w-md text-lg leading-relaxed", className)}
-      data-slot="feedback-message"
-      {...props}
-    />
-  );
-}
-
-function AnswerLine({
-  children,
-  icon,
-  label,
-  variant,
-}: {
-  children: React.ReactNode;
-  icon: React.ReactNode;
-  label: string;
-  variant: "correct" | "incorrect";
-}) {
-  return (
-    <div
-      className={cn(
-        "flex items-start gap-2 rounded-lg px-3 py-2 text-sm",
-        variant === "correct" ? "bg-success/10" : "bg-destructive/10",
-      )}
-    >
-      <span
-        className={cn(
-          "mt-0.5 shrink-0",
-          variant === "correct" ? "text-success" : "text-destructive",
-        )}
-      >
-        {icon}
-      </span>
-      <div>
-        <span className="text-muted-foreground">{label}</span>{" "}
-        <span className="font-medium">{children}</span>
-      </div>
-    </div>
   );
 }
 
@@ -193,33 +136,15 @@ function CoreFeedback({ result }: { result: StepResult }) {
 
         {isCorrect ? (
           selectedText && (
-            <AnswerLine
-              icon={<CircleCheck aria-hidden="true" className="size-4" />}
-              label={t("Your answer:")}
-              variant="correct"
-            >
-              {selectedText}
-            </AnswerLine>
+            <AnswerLine label={t("Your answer:")} text={selectedText} variant="correct" />
           )
         ) : (
           <>
             {selectedText && (
-              <AnswerLine
-                icon={<CircleX aria-hidden="true" className="size-4" />}
-                label={t("Your answer:")}
-                variant="incorrect"
-              >
-                {selectedText}
-              </AnswerLine>
+              <AnswerLine label={t("Your answer:")} text={selectedText} variant="incorrect" />
             )}
             {correctAnswer && (
-              <AnswerLine
-                icon={<CircleCheck aria-hidden="true" className="size-4" />}
-                label={t("Correct answer:")}
-                variant="correct"
-              >
-                {correctAnswer}
-              </AnswerLine>
+              <AnswerLine label={t("Correct answer:")} text={correctAnswer} variant="correct" />
             )}
           </>
         )}

--- a/packages/player/src/components/feedback-screen.tsx
+++ b/packages/player/src/components/feedback-screen.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { cn } from "@zoonk/ui/lib/utils";
 import { CircleAlert, CircleCheck, CircleX, TriangleAlert } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { type DimensionInventory, type StepResult } from "../player-reducer";
+import { type SerializedStep } from "../prepare-activity-data";
 import { useReplaceName } from "../user-name-context";
 import {
   type DimensionEntry,
@@ -12,6 +14,7 @@ import {
   buildDimensionEntries,
   getWarningDelay,
 } from "./dimension-inventory";
+import { LanguagePracticeFeedback } from "./language-practice-feedback";
 import { ResultAnnouncement } from "./result-announcement";
 
 function FeedbackScreen({ className, ...props }: React.ComponentProps<"div">) {
@@ -229,17 +232,32 @@ function CoreFeedback({ result }: { result: StepResult }) {
   );
 }
 
+function isLanguageMultipleChoice(step: SerializedStep | undefined): boolean {
+  if (!step || step.kind !== "multipleChoice") {
+    return false;
+  }
+
+  const content = parseStepContent("multipleChoice", step.content);
+  return content.kind === "language";
+}
+
 export function FeedbackScreenContent({
   dimensions,
   result,
+  step,
 }: {
   dimensions?: DimensionInventory;
   result: StepResult;
+  step?: SerializedStep;
 }) {
   const hasEffects = result.effects.length > 0;
 
   if (hasEffects && dimensions) {
     return <ChallengeFeedback dimensions={dimensions} result={result} />;
+  }
+
+  if (step && isLanguageMultipleChoice(step)) {
+    return <LanguagePracticeFeedback result={result} step={step} />;
   }
 
   return <CoreFeedback result={result} />;

--- a/packages/player/src/components/language-practice-feedback.tsx
+++ b/packages/player/src/components/language-practice-feedback.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
+import { cn } from "@zoonk/ui/lib/utils";
+import { CircleCheck, CircleX } from "lucide-react";
+import { useExtracted } from "next-intl";
+import { type StepResult } from "../player-reducer";
+import { type SerializedStep } from "../prepare-activity-data";
+import { useReplaceName } from "../user-name-context";
+import { PlayAudioButton } from "./play-audio-button";
+import { ResultAnnouncement } from "./result-announcement";
+import { RomanizationText } from "./romanization-text";
+
+function FeedbackScreen({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      aria-live="polite"
+      className={cn(
+        "animate-in fade-in slide-in-from-bottom-1 mx-auto flex w-full max-w-lg flex-col gap-6 duration-200 ease-out motion-reduce:animate-none",
+        className,
+      )}
+      data-slot="feedback-screen"
+      role="status"
+      {...props}
+    />
+  );
+}
+
+function FeedbackMessage({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      className={cn("text-foreground max-w-md text-lg leading-relaxed", className)}
+      data-slot="feedback-message"
+      {...props}
+    />
+  );
+}
+
+function LanguageAnswerLine({
+  audioUrl,
+  label,
+  romanization,
+  text,
+  translation,
+  variant,
+}: {
+  audioUrl: string | null;
+  label: string;
+  romanization: string | null;
+  text: string;
+  translation: string;
+  variant: "correct" | "incorrect";
+}) {
+  const icon =
+    variant === "correct" ? (
+      <CircleCheck aria-hidden="true" className="size-4" />
+    ) : (
+      <CircleX aria-hidden="true" className="size-4" />
+    );
+
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2 rounded-lg px-3 py-2 text-sm",
+        variant === "correct" ? "bg-success/10" : "bg-destructive/10",
+      )}
+    >
+      <span
+        className={cn(
+          "mt-0.5 shrink-0",
+          variant === "correct" ? "text-success" : "text-destructive",
+        )}
+      >
+        {icon}
+      </span>
+      <div className="flex flex-1 flex-col gap-0.5">
+        <div className="flex items-center gap-2">
+          <div>
+            <span className="text-muted-foreground">{label}</span>{" "}
+            <span className="font-medium">{text}</span>
+          </div>
+          {audioUrl && <PlayAudioButton audioUrl={audioUrl} size="xs" />}
+        </div>
+        <RomanizationText>{romanization}</RomanizationText>
+        <span className="text-muted-foreground text-xs">{translation}</span>
+      </div>
+    </div>
+  );
+}
+
+export function LanguagePracticeFeedback({
+  result,
+  step,
+}: {
+  result: StepResult;
+  step: SerializedStep;
+}) {
+  const t = useExtracted();
+  const replaceName = useReplaceName();
+  const parsed = parseStepContent("multipleChoice", step.content);
+
+  if (parsed.kind !== "language") {
+    return null;
+  }
+
+  const content = parsed;
+  const { isCorrect, feedback: rawFeedback } = result.result;
+  const feedback = rawFeedback ? replaceName(rawFeedback) : null;
+
+  const selectedIndex =
+    result.answer?.kind === "multipleChoice" ? result.answer.selectedIndex : null;
+
+  const selectedOption = selectedIndex === null ? null : content.options[selectedIndex];
+  const correctOption = content.options.find((option) => option.isCorrect);
+
+  return (
+    <FeedbackScreen>
+      <div className="flex flex-col gap-2">
+        {isCorrect ? (
+          correctOption && (
+            <LanguageAnswerLine
+              audioUrl={correctOption.audioUrl}
+              label={t("Your answer:")}
+              romanization={correctOption.textRomanization}
+              text={correctOption.text}
+              translation={correctOption.translation}
+              variant="correct"
+            />
+          )
+        ) : (
+          <>
+            {selectedOption && (
+              <LanguageAnswerLine
+                audioUrl={selectedOption.audioUrl}
+                label={t("Your answer:")}
+                romanization={selectedOption.textRomanization}
+                text={selectedOption.text}
+                translation={selectedOption.translation}
+                variant="incorrect"
+              />
+            )}
+            {correctOption && (
+              <LanguageAnswerLine
+                audioUrl={correctOption.audioUrl}
+                label={t("Correct answer:")}
+                romanization={correctOption.textRomanization}
+                text={correctOption.text}
+                translation={correctOption.translation}
+                variant="correct"
+              />
+            )}
+          </>
+        )}
+      </div>
+
+      {feedback && <FeedbackMessage>{feedback}</FeedbackMessage>}
+
+      <ResultAnnouncement isCorrect={isCorrect} />
+    </FeedbackScreen>
+  );
+}

--- a/packages/player/src/components/language-practice-feedback.tsx
+++ b/packages/player/src/components/language-practice-feedback.tsx
@@ -1,94 +1,28 @@
 "use client";
 
 import { parseStepContent } from "@zoonk/core/steps/content-contract";
-import { cn } from "@zoonk/ui/lib/utils";
-import { CircleCheck, CircleX } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { type StepResult } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
 import { useReplaceName } from "../user-name-context";
+import { AnswerLine } from "./answer-line";
+import { FeedbackMessage, FeedbackScreen } from "./feedback-layout";
 import { PlayAudioButton } from "./play-audio-button";
 import { ResultAnnouncement } from "./result-announcement";
 import { RomanizationText } from "./romanization-text";
 
-function FeedbackScreen({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      aria-live="polite"
-      className={cn(
-        "animate-in fade-in slide-in-from-bottom-1 mx-auto flex w-full max-w-lg flex-col gap-6 duration-200 ease-out motion-reduce:animate-none",
-        className,
-      )}
-      data-slot="feedback-screen"
-      role="status"
-      {...props}
-    />
-  );
-}
-
-function FeedbackMessage({ className, ...props }: React.ComponentProps<"p">) {
-  return (
-    <p
-      className={cn("text-foreground max-w-md text-lg leading-relaxed", className)}
-      data-slot="feedback-message"
-      {...props}
-    />
-  );
-}
-
-function LanguageAnswerLine({
-  audioUrl,
-  label,
+function LanguageAnswerExtras({
   romanization,
-  text,
   translation,
-  variant,
 }: {
-  audioUrl: string | null;
-  label: string;
   romanization: string | null;
-  text: string;
   translation: string;
-  variant: "correct" | "incorrect";
 }) {
-  const icon =
-    variant === "correct" ? (
-      <CircleCheck aria-hidden="true" className="size-4" />
-    ) : (
-      <CircleX aria-hidden="true" className="size-4" />
-    );
-
   return (
-    <div
-      className={cn(
-        "flex items-start gap-2 rounded-lg px-3 py-2 text-sm",
-        variant === "correct" ? "bg-success/10" : "bg-destructive/10",
-      )}
-    >
-      <span
-        className={cn(
-          "mt-0.5 shrink-0",
-          variant === "correct" ? "text-success" : "text-destructive",
-        )}
-      >
-        {icon}
-      </span>
-      <div className="flex flex-1 flex-col gap-0.5">
-        <div className="flex items-center gap-2">
-          <div className="min-w-0">
-            <span className="text-muted-foreground">{label}</span>{" "}
-            <span className="font-medium">{text}</span>
-          </div>
-          {audioUrl && (
-            <span className="shrink-0">
-              <PlayAudioButton audioUrl={audioUrl} size="xs" />
-            </span>
-          )}
-        </div>
-        <RomanizationText>{romanization}</RomanizationText>
-        <span className="text-muted-foreground text-xs">{translation}</span>
-      </div>
-    </div>
+    <>
+      <RomanizationText>{romanization}</RomanizationText>
+      <span className="text-muted-foreground text-xs">{translation}</span>
+    </>
   );
 }
 
@@ -107,51 +41,71 @@ export function LanguagePracticeFeedback({
     return null;
   }
 
-  const content = parsed;
   const { isCorrect, feedback: rawFeedback } = result.result;
   const feedback = rawFeedback ? replaceName(rawFeedback) : null;
 
   const selectedIndex =
     result.answer?.kind === "multipleChoice" ? result.answer.selectedIndex : null;
 
-  const selectedOption = selectedIndex === null ? null : content.options[selectedIndex];
-  const correctOption = content.options.find((option) => option.isCorrect);
+  const selectedOption = selectedIndex === null ? null : parsed.options[selectedIndex];
+  const correctOption = parsed.options.find((option) => option.isCorrect);
 
   return (
     <FeedbackScreen>
       <div className="flex flex-col gap-2">
         {isCorrect ? (
           correctOption && (
-            <LanguageAnswerLine
-              audioUrl={correctOption.audioUrl}
+            <AnswerLine
+              action={
+                correctOption.audioUrl && (
+                  <PlayAudioButton audioUrl={correctOption.audioUrl} size="xs" />
+                )
+              }
               label={t("Your answer:")}
-              romanization={correctOption.textRomanization}
               text={correctOption.text}
-              translation={correctOption.translation}
               variant="correct"
-            />
+            >
+              <LanguageAnswerExtras
+                romanization={correctOption.textRomanization}
+                translation={correctOption.translation}
+              />
+            </AnswerLine>
           )
         ) : (
           <>
             {selectedOption && (
-              <LanguageAnswerLine
-                audioUrl={selectedOption.audioUrl}
+              <AnswerLine
+                action={
+                  selectedOption.audioUrl && (
+                    <PlayAudioButton audioUrl={selectedOption.audioUrl} size="xs" />
+                  )
+                }
                 label={t("Your answer:")}
-                romanization={selectedOption.textRomanization}
                 text={selectedOption.text}
-                translation={selectedOption.translation}
                 variant="incorrect"
-              />
+              >
+                <LanguageAnswerExtras
+                  romanization={selectedOption.textRomanization}
+                  translation={selectedOption.translation}
+                />
+              </AnswerLine>
             )}
             {correctOption && (
-              <LanguageAnswerLine
-                audioUrl={correctOption.audioUrl}
+              <AnswerLine
+                action={
+                  correctOption.audioUrl && (
+                    <PlayAudioButton audioUrl={correctOption.audioUrl} size="xs" />
+                  )
+                }
                 label={t("Correct answer:")}
-                romanization={correctOption.textRomanization}
                 text={correctOption.text}
-                translation={correctOption.translation}
                 variant="correct"
-              />
+              >
+                <LanguageAnswerExtras
+                  romanization={correctOption.textRomanization}
+                  translation={correctOption.translation}
+                />
+              </AnswerLine>
             )}
           </>
         )}

--- a/packages/player/src/components/language-practice-feedback.tsx
+++ b/packages/player/src/components/language-practice-feedback.tsx
@@ -75,11 +75,15 @@ function LanguageAnswerLine({
       </span>
       <div className="flex flex-1 flex-col gap-0.5">
         <div className="flex items-center gap-2">
-          <div>
+          <div className="min-w-0">
             <span className="text-muted-foreground">{label}</span>{" "}
             <span className="font-medium">{text}</span>
           </div>
-          {audioUrl && <PlayAudioButton audioUrl={audioUrl} size="xs" />}
+          {audioUrl && (
+            <span className="shrink-0">
+              <PlayAudioButton audioUrl={audioUrl} size="xs" />
+            </span>
+          )}
         </div>
         <RomanizationText>{romanization}</RomanizationText>
         <span className="text-muted-foreground text-xs">{translation}</span>

--- a/packages/player/src/components/multiple-choice-step.tsx
+++ b/packages/player/src/components/multiple-choice-step.tsx
@@ -10,8 +10,10 @@ import { useExtracted } from "next-intl";
 import { type SelectedAnswer } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
 import { useOptionKeyboard } from "../use-option-keyboard";
+import { useWordAudio } from "../use-word-audio";
 import { useReplaceName } from "../user-name-context";
 import { OptionCard } from "./option-card";
+import { PlayAudioButton } from "./play-audio-button";
 import { ContextText, QuestionText } from "./question-text";
 import { RomanizationText } from "./romanization-text";
 import { SectionLabel } from "./section-label";
@@ -129,6 +131,12 @@ function LanguageVariant({
 }) {
   const t = useExtracted();
   const replaceName = useReplaceName();
+  const { play } = useWordAudio();
+
+  const handleSelect = (index: number) => {
+    play(content.options[index]?.audioUrl ?? null);
+    onSelect(index);
+  };
 
   return (
     <>
@@ -136,7 +144,13 @@ function LanguageVariant({
         <SectionLabel>{t("Someone says:")}</SectionLabel>
 
         <SpeechBubble>
-          <p className="text-base font-semibold">{replaceName(content.context)}</p>
+          <div className="flex items-start gap-2">
+            <p className="text-base font-semibold">{replaceName(content.context)}</p>
+
+            {content.contextAudioUrl && (
+              <PlayAudioButton audioUrl={content.contextAudioUrl} size="xs" />
+            )}
+          </div>
 
           <RomanizationText>{content.contextRomanization}</RomanizationText>
 
@@ -146,7 +160,11 @@ function LanguageVariant({
 
       <div className="flex flex-col gap-3">
         <SectionLabel>{t("What do you say?")}</SectionLabel>
-        <OptionList onSelect={onSelect} options={content.options} selectedIndex={selectedIndex} />
+        <OptionList
+          onSelect={handleSelect}
+          options={content.options}
+          selectedIndex={selectedIndex}
+        />
       </div>
     </>
   );

--- a/packages/player/src/components/multiple-choice-step.tsx
+++ b/packages/player/src/components/multiple-choice-step.tsx
@@ -139,10 +139,12 @@ function LanguageVariant({
 
         <SpeechBubble>
           <div className="flex items-start gap-2">
-            <p className="text-base font-semibold">{replaceName(content.context)}</p>
+            <p className="min-w-0 text-base font-semibold">{replaceName(content.context)}</p>
 
             {content.contextAudioUrl && (
-              <PlayAudioButton audioUrl={content.contextAudioUrl} size="xs" />
+              <span className="shrink-0">
+                <PlayAudioButton audioUrl={content.contextAudioUrl} size="xs" />
+              </span>
             )}
           </div>
 

--- a/packages/player/src/components/multiple-choice-step.tsx
+++ b/packages/player/src/components/multiple-choice-step.tsx
@@ -131,12 +131,6 @@ function LanguageVariant({
 }) {
   const t = useExtracted();
   const replaceName = useReplaceName();
-  const { play } = useWordAudio();
-
-  const handleSelect = (index: number) => {
-    play(content.options[index]?.audioUrl ?? null);
-    onSelect(index);
-  };
 
   return (
     <>
@@ -160,11 +154,7 @@ function LanguageVariant({
 
       <div className="flex flex-col gap-3">
         <SectionLabel>{t("What do you say?")}</SectionLabel>
-        <OptionList
-          onSelect={handleSelect}
-          options={content.options}
-          selectedIndex={selectedIndex}
-        />
+        <OptionList onSelect={onSelect} options={content.options} selectedIndex={selectedIndex} />
       </div>
     </>
   );
@@ -181,9 +171,15 @@ export function MultipleChoiceStep({
 }) {
   const content = parseStepContent("multipleChoice", step.content);
   const selectedIndex = getSelectedIndex(selectedAnswer);
+  const { play } = useWordAudio();
 
   const handleSelect = (index: number) => {
     const selectedText = content.options[index]?.text ?? "";
+
+    if (content.kind === "language") {
+      play(content.options[index]?.audioUrl ?? null);
+    }
+
     onSelectAnswer(step.id, { kind: "multipleChoice", selectedIndex: index, selectedText });
   };
 

--- a/packages/player/src/components/play-audio-button.tsx
+++ b/packages/player/src/components/play-audio-button.tsx
@@ -11,7 +11,7 @@ export function PlayAudioButton({
   size = "md",
 }: {
   audioUrl: string;
-  size?: "sm" | "md";
+  size?: "xs" | "sm" | "md";
 }) {
   const t = useExtracted();
   const [isPlaying, setIsPlaying] = useState(false);
@@ -36,12 +36,20 @@ export function PlayAudioButton({
       className={cn(
         "bg-primary text-primary-foreground flex items-center justify-center rounded-full transition-all duration-150",
         "hover:bg-primary/90 focus-visible:ring-ring/50 outline-none hover:scale-105 focus-visible:ring-[3px] active:scale-95",
-        size === "md" ? "size-14" : "size-12",
+        size === "md" && "size-14",
+        size === "sm" && "size-12",
+        size === "xs" && "size-8",
       )}
       onClick={handleClick}
       type="button"
     >
-      <Icon className={size === "md" ? "size-6" : "size-5"} />
+      <Icon
+        className={cn(
+          size === "md" && "size-6",
+          size === "sm" && "size-5",
+          size === "xs" && "size-4",
+        )}
+      />
     </button>
   );
 }

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -71,7 +71,9 @@ export function StageContent({
   }
 
   if (phase === "feedback" && currentResult && (!currentStep || needsFeedbackScreen(currentStep))) {
-    return <FeedbackScreenContent dimensions={dimensions} result={currentResult} />;
+    return (
+      <FeedbackScreenContent dimensions={dimensions} result={currentResult} step={currentStep} />
+    );
   }
 
   if ((phase === "playing" || phase === "feedback") && currentStep) {

--- a/packages/utils/src/string.test.ts
+++ b/packages/utils/src/string.test.ts
@@ -4,6 +4,7 @@ import {
   emptyToNull,
   ensureLocaleSuffix,
   extractUniqueSentenceWords,
+  normalizePunctuation,
   normalizeString,
   removeAccents,
   removeLocaleSuffix,
@@ -363,6 +364,40 @@ describe(extractUniqueSentenceWords, () => {
     expect(result.length).toBeGreaterThan(1);
     expect(result).toContain("猫");
     expect(result).toContain("食べる");
+  });
+});
+
+describe(normalizePunctuation, () => {
+  test("removes space before exclamation mark", () => {
+    expect(normalizePunctuation("Hello !")).toBe("Hello!");
+  });
+
+  test("removes space before question mark", () => {
+    expect(normalizePunctuation("Bonjour , comment allez-vous ?")).toBe(
+      "Bonjour, comment allez-vous?",
+    );
+  });
+
+  test("leaves already-correct text unchanged", () => {
+    expect(normalizePunctuation("Hello, world!")).toBe("Hello, world!");
+  });
+
+  test("handles CJK punctuation", () => {
+    expect(normalizePunctuation("これは何 ？")).toBe("これは何？");
+    expect(normalizePunctuation("はい 。")).toBe("はい。");
+    expect(normalizePunctuation("すごい ！")).toBe("すごい！");
+  });
+
+  test("handles Arabic question mark", () => {
+    expect(normalizePunctuation("مرحبا ؟")).toBe("مرحبا؟");
+  });
+
+  test("handles multiple spaces before punctuation", () => {
+    expect(normalizePunctuation("Hello   !")).toBe("Hello!");
+  });
+
+  test("handles empty string", () => {
+    expect(normalizePunctuation("")).toBe("");
   });
 });
 

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -105,7 +105,7 @@ export function extractUniqueSentenceWords(sentences: string[]): string[] {
 }
 
 export function normalizePunctuation(text: string): string {
-  return text.replaceAll(/\s+([!?.,;:!?。、！？؟])/g, "$1");
+  return text.replaceAll(/(?<!\s)\s+([!?.,;:!?。、！？؟])/g, "$1");
 }
 
 export function replaceNamePlaceholder(text: string, name: string | null): string {

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -104,6 +104,10 @@ export function extractUniqueSentenceWords(sentences: string[]): string[] {
   return [...new Set(words)];
 }
 
+export function normalizePunctuation(text: string): string {
+  return text.replaceAll(/\s+([!?.,;:!?。、！？؟])/g, "$1");
+}
+
 export function replaceNamePlaceholder(text: string, name: string | null): string {
   if (!text.includes(NAME_PLACEHOLDER)) {
     return text;


### PR DESCRIPTION
## Summary
- Add `translation` field to language practice options (clean translation, separate from feedback)
- Add TTS audio generation for context sentences and options (best-effort, non-blocking)
- Add dedicated `LanguagePracticeFeedback` component with romanization, translation, and audio playback
- Add `normalizePunctuation` utility to normalize spacing before punctuation marks
- Add `xs` size to `PlayAudioButton` for inline use in speech bubbles and feedback
- Update feedback to be explanation-only (translation shown separately in answer lines)
- Add streaming support for the new audio generation step in the generation UI
- Update evals test cases for new feedback format

## Test plan
- [x] Unit tests for `normalizePunctuation` (Latin, CJK, Arabic punctuation)
- [x] Content contract tests updated for new schema fields
- [x] Integration tests for audio step: generation, dedup, unsupported language skip, best-effort failure
- [x] Integration tests for content step: translation storage, punctuation normalization
- [x] E2E tests: feedback with romanization/translation, audio button presence/absence
- [x] Phase config test updated for new `recordingAudio` phase
- [x] All existing tests pass across all apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds translations and TTS audio to language practice with a new feedback UI showing romanization, translation, and inline audio. Streams the audio phase, auto‑plays option audio, and polishes the UI with centered feedback icons and stable inline audio buttons.

- **New Features**
  - Store `options[].translation`, `contextAudioUrl`, and `options[].audioUrl` in language multiple choice content.
  - New `generateLanguagePracticeAudio` step (best‑effort, dedup via `SentenceAudio`, skips unsupported languages, non‑blocking with streaming status).
  - New `LanguagePracticeFeedback` with romanization, translation, and inline audio; `PlayAudioButton` adds `xs` size; context audio button shows when available; auto‑plays option audio on select (mouse and keyboard); centered feedback icons and shared `FeedbackScreen`/`AnswerLine` components.
  - `normalizePunctuation` applied to context, options, translations, and feedback; regex hardened to avoid ReDoS.
  - Added `recordingAudio` phase for `languagePractice`; prompt/schema updated; evals and UI stream the audio step.
  - Prompt clarifies `translation` vs `feedback`; default model switched to `openai/gpt-5.4` (fallbacks: `anthropic/claude-opus-4.6`, `google/gemini-3-flash`).

- **Migration**
  - When generating content, include `options[].translation`; keep `options[].feedback` as explanation only.
  - Consumers and fixtures should handle nullable `contextAudioUrl` and `options[].audioUrl`; audio enrichment runs best‑effort in the background.

<sup>Written for commit a4ec13fa9419c249d8abf2f77fd23992b4ab94ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

