### PR TITLE
fix(main): add loading eager to above-the-fold images

### DIFF
--- a/apps/main/src/app/(catalog)/(home)/continue-learning-card.tsx
+++ b/apps/main/src/app/(catalog)/(home)/continue-learning-card.tsx
@@ -76,7 +76,13 @@ export async function ContinueLearningCard({
           <FeatureCardThumbnail size="lg">
             {course.imageUrl ? (
               <FeatureCardThumbnailImage>
-                <Image alt={course.title} height={96} src={course.imageUrl} width={96} />
+                <Image
+                  alt={course.title}
+                  height={96}
+                  loading="eager"
+                  src={course.imageUrl}
+                  width={96}
+                />
               </FeatureCardThumbnailImage>
             ) : (
               <FeatureCardThumbnailPlaceholder>

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-header.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-header.tsx
@@ -43,6 +43,7 @@ export async function CourseHeader({
             alt={course.title}
             className="size-full rounded-xl object-cover outline -outline-offset-1 outline-black/10 dark:outline-white/10"
             fill
+            loading="eager"
             sizes="(max-width: 640px) 80px, 96px"
             src={course.imageUrl}
           />

--- a/packages/player/src/components/select-image-step.tsx
+++ b/packages/player/src/components/select-image-step.tsx
@@ -52,6 +52,7 @@ function ImageWithFallback({ alt, url }: { alt: string; url: string | undefined 
       alt={alt}
       className="aspect-square object-cover"
       height={336}
+      loading="eager"
       onError={() => setHasError(true)}
       sizes="(max-width: 672px) 50vw, 336px"
       src={url}

--- a/packages/player/src/components/visuals/image-visual.tsx
+++ b/packages/player/src/components/visuals/image-visual.tsx
@@ -24,6 +24,7 @@ export function ImageVisual({ content }: { content: ImageVisualContent }) {
       alt={content.prompt}
       className="aspect-square w-full max-w-md rounded-2xl object-cover"
       height={1024}
+      loading="eager"
       onError={() => setErrorUrl(content.url ?? null)}
       sizes="(max-width: 640px) calc(100vw - 2rem), 448px"
       src={content.url}


### PR DESCRIPTION
## Summary

- Add `loading="eager"` to above-the-fold images: course header, continue learning card, player visual steps, and select-image steps

## Test plan

- [ ] Verify LCP warning is gone on the course page
- [ ] Verify images load immediately on course page, home page, and player

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load above-the-fold images eagerly to improve LCP and show key visuals immediately on course, home, and player pages.

- **Bug Fixes**
  - Set `loading="eager"` on the course header image.
  - Set `loading="eager"` on the home "Continue learning" card thumbnail.
  - Set `loading="eager"` on player visuals and the select-image step.
  - Removes the LCP warning on the course page.

<sup>Written for commit a8c6e59d80b570c18ca06243f80cb4c601575e5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

