### PR TITLE
fix(utils): normalize punctuation in arrange words and DB storage

### DIFF
--- a/apps/api/src/workflows/activity-generation/steps/save-reading-sentences-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-reading-sentences-step.ts
@@ -1,7 +1,7 @@
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { emptyToNull } from "@zoonk/utils/string";
+import { emptyToNull, normalizePunctuation } from "@zoonk/utils/string";
 import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type ReadingSentence } from "./generate-reading-content-step";
@@ -23,23 +23,26 @@ function buildSaveOneSentence(params: {
   const { activityId, lessonId, organizationId, targetLanguage, userLanguage } = params;
 
   return async (readingSentence: ReadingSentence, position: number): Promise<SavedSentence> => {
+    const sentence = normalizePunctuation(readingSentence.sentence);
+    const translation = normalizePunctuation(readingSentence.translation);
+
     const record = await prisma.sentence.upsert({
       create: {
         organizationId,
         romanization: emptyToNull(readingSentence.romanization),
-        sentence: readingSentence.sentence,
+        sentence,
         targetLanguage,
-        translation: readingSentence.translation,
+        translation,
         userLanguage,
       },
       update: {
         romanization: emptyToNull(readingSentence.romanization),
-        translation: readingSentence.translation,
+        translation,
       },
       where: {
         orgSentence: {
           organizationId,
-          sentence: readingSentence.sentence,
+          sentence,
           targetLanguage,
           userLanguage,
         },
@@ -65,7 +68,7 @@ function buildSaveOneSentence(params: {
       },
     });
 
-    return { sentence: readingSentence.sentence, sentenceId: Number(sentenceId) };
+    return { sentence, sentenceId: Number(sentenceId) };
   };
 }
 

--- a/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
@@ -2,7 +2,7 @@ import { type VocabularyWord } from "@zoonk/ai/tasks/activities/language/vocabul
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { emptyToNull } from "@zoonk/utils/string";
+import { emptyToNull, normalizePunctuation } from "@zoonk/utils/string";
 import { streamError, streamStatus } from "../stream-status";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
@@ -32,20 +32,22 @@ function buildSaveOneWord(params: {
   } = params;
 
   return async (vocabWord: VocabularyWord, position: number): Promise<SavedWord> => {
+    const translation = normalizePunctuation(vocabWord.translation);
+
     const record = await prisma.word.upsert({
       create: {
         alternativeTranslations: vocabWord.alternativeTranslations,
         organizationId,
         romanization: emptyToNull(vocabWord.romanization),
         targetLanguage,
-        translation: vocabWord.translation,
+        translation,
         userLanguage,
         word: vocabWord.word,
       },
       update: {
         alternativeTranslations: vocabWord.alternativeTranslations,
         romanization: emptyToNull(vocabWord.romanization),
-        translation: vocabWord.translation,
+        translation,
       },
       where: {
         orgWord: { organizationId, targetLanguage, userLanguage, word: vocabWord.word },

--- a/packages/utils/src/string.test.ts
+++ b/packages/utils/src/string.test.ts
@@ -4,6 +4,7 @@ import {
   emptyToNull,
   ensureLocaleSuffix,
   extractUniqueSentenceWords,
+  normalizePunctuation,
   normalizeString,
   removeAccents,
   removeLocaleSuffix,
@@ -273,6 +274,46 @@ describe(deduplicateSlugs, () => {
   });
 });
 
+describe(normalizePunctuation, () => {
+  test("removes space before exclamation mark", () => {
+    expect(normalizePunctuation("Hello !")).toBe("Hello!");
+  });
+
+  test("removes space before question mark", () => {
+    expect(normalizePunctuation("Comment ?")).toBe("Comment?");
+  });
+
+  test("removes space before period", () => {
+    expect(normalizePunctuation("Fin .")).toBe("Fin.");
+  });
+
+  test("removes multiple spaces before punctuation", () => {
+    expect(normalizePunctuation("Hello  !")).toBe("Hello!");
+  });
+
+  test("leaves already-correct text unchanged", () => {
+    expect(normalizePunctuation("Hello!")).toBe("Hello!");
+  });
+
+  test("handles CJK punctuation", () => {
+    expect(normalizePunctuation("これは何 ？")).toBe("これは何？");
+  });
+
+  test("handles Arabic question mark", () => {
+    expect(normalizePunctuation("مرحبا ؟")).toBe("مرحبا؟");
+  });
+
+  test("handles empty string", () => {
+    expect(normalizePunctuation("")).toBe("");
+  });
+
+  test("handles multiple punctuation in one sentence", () => {
+    expect(normalizePunctuation("Bonjour , comment allez-vous ?")).toBe(
+      "Bonjour, comment allez-vous?",
+    );
+  });
+});
+
 describe(segmentWords, () => {
   test("splits space-delimited text by spaces", () => {
     expect(segmentWords("Hola mundo")).toEqual(["Hola", "mundo"]);
@@ -304,6 +345,15 @@ describe(segmentWords, () => {
   test("filters empty tokens from consecutive spaces", () => {
     expect(segmentWords("hello  world")).toEqual(["hello", "world"]);
     expect(segmentWords("a  b  c")).toEqual(["a", "b", "c"]);
+  });
+
+  test("attaches French-style punctuation to preceding word", () => {
+    expect(segmentWords("Comment allez-vous ?")).toEqual(["Comment", "allez-vous?"]);
+    expect(segmentWords("Bonjour !")).toEqual(["Bonjour!"]);
+  });
+
+  test("handles multiple French-style punctuation in one sentence", () => {
+    expect(segmentWords("Oui , je suis là !")).toEqual(["Oui,", "je", "suis", "là!"]);
   });
 });
 

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -74,6 +74,10 @@ export function removeLocaleSuffix(value: string, language: string): string {
   return value.endsWith(suffix) ? value.slice(0, -suffix.length) : value;
 }
 
+export function normalizePunctuation(text: string): string {
+  return text.replaceAll(/(?<!\s)\s+([!?.,;:!?。、！？؟])/g, "$1");
+}
+
 export function stripPunctuation(text: string): string {
   return text.replaceAll(/[^\p{L}\p{N}\s]/gu, "");
 }
@@ -84,7 +88,7 @@ export function stripPunctuation(text: string): string {
  */
 export function segmentWords(text: string): string[] {
   if (text.includes(" ")) {
-    return text.split(" ").filter(Boolean);
+    return normalizePunctuation(text).split(" ").filter(Boolean);
   }
 
   const segmenter = new Intl.Segmenter(undefined, { granularity: "word" });


### PR DESCRIPTION
## Summary

- Add `normalizePunctuation` to remove spaces before punctuation (French `"Comment ?"` → `"Comment?"`)
- Apply in `segmentWords` so arrange words no longer shows standalone punctuation tiles
- Normalize sentences and translations before DB storage to prevent bad data at the source

## Test plan

- [x] Unit tests for `normalizePunctuation` (Latin, CJK, Arabic, edge cases)
- [x] Unit tests for `segmentWords` with French-style punctuation
- [ ] Manual: French reading activity should no longer show standalone punctuation tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize punctuation spacing in sentences and translations to stop standalone punctuation tiles and keep DB data consistent. Applies normalization in `segmentWords` and before saving sentences and vocabulary.

- **Bug Fixes**
  - Added `normalizePunctuation` in `@zoonk/utils/string` to remove spaces before punctuation (Latin, CJK, Arabic).
  - Used in `segmentWords` so arrange words no longer shows punctuation as separate tiles.
  - Applied during sentence and vocabulary upserts to normalize `sentence` and `translation` fields.

<sup>Written for commit 4cde55ee7199854fec1746d9dac3c85b24edb02b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

