### PR TITLE
fix(api): add case-insensitive dedup for vocabulary words and audio

### DIFF
--- a/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.test.ts
@@ -418,6 +418,134 @@ describe(vocabularyActivityWorkflow, () => {
     expect(updatedWord?.wordAudioId).toBe(wordAudio.id);
   });
 
+  test("reuses existing Word record when casing differs", async () => {
+    const id = randomUUID().replaceAll("-", "").slice(0, 8);
+    const existingWord = `Hola${id}`;
+
+    const wordAudio = await prisma.wordAudio.create({
+      data: {
+        audioUrl: "https://example.com/hola-audio.mp3",
+        organizationId,
+        targetLanguage: "es",
+        word: existingWord,
+      },
+    });
+
+    const existingRecord = await prisma.word.create({
+      data: {
+        organizationId,
+        targetLanguage: "es",
+        translation: "hello",
+        userLanguage: "en",
+        word: existingWord,
+        wordAudioId: wordAudio.id,
+      },
+    });
+
+    const mockWords: VocabularyWord[] = [
+      {
+        alternativeTranslations: ["hi"],
+        romanization: "o-la",
+        translation: "hello",
+        word: existingWord.toLowerCase(),
+      },
+      { alternativeTranslations: [], romanization: "ga-to", translation: "cat", word: `gato${id}` },
+    ];
+
+    vi.mocked(generateActivityVocabulary).mockResolvedValueOnce({
+      data: { words: mockWords },
+    } as Awaited<ReturnType<typeof generateActivityVocabulary>>);
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `Vocab CaseDedup ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+    await vocabularyActivityWorkflow(activities, "test-run-id", [], []);
+
+    const words = await prisma.word.findMany({
+      where: {
+        organizationId,
+        targetLanguage: "es",
+        userLanguage: "en",
+        word: { in: [existingWord, existingWord.toLowerCase()], mode: "insensitive" },
+      },
+    });
+
+    // Should reuse the existing "Hola..." record, not create a new "hola..." one
+    expect(words).toHaveLength(1);
+    expect(words[0]!.word).toBe(existingWord);
+    expect(words[0]!.id).toBe(existingRecord.id);
+  });
+
+  test("reuses existing WordAudio when casing differs", async () => {
+    const id = randomUUID().replaceAll("-", "").slice(0, 8);
+    const existingWord = `Gato${id}`;
+
+    const wordAudio = await prisma.wordAudio.create({
+      data: {
+        audioUrl: "https://example.com/gato-audio.mp3",
+        organizationId,
+        targetLanguage: "es",
+        word: existingWord,
+      },
+    });
+
+    const mockWords: VocabularyWord[] = [
+      {
+        alternativeTranslations: [],
+        romanization: "ga-to",
+        translation: "cat",
+        word: existingWord.toLowerCase(),
+      },
+    ];
+
+    vi.mocked(generateActivityVocabulary).mockResolvedValueOnce({
+      data: { words: mockWords },
+    } as Awaited<ReturnType<typeof generateActivityVocabulary>>);
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      kind: "language",
+      organizationId,
+      title: `Vocab AudioCase ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Vocabulary ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+    await vocabularyActivityWorkflow(activities, "test-run-id", [], []);
+
+    // Should not call TTS since WordAudio for "Gato..." already exists
+    expect(generateLanguageAudio).not.toHaveBeenCalled();
+
+    // The Word record should be linked to the existing WordAudio
+    const word = await prisma.word.findFirst({
+      where: { organizationId, targetLanguage: "es", word: existingWord.toLowerCase() },
+    });
+
+    expect(word?.wordAudioId).toBe(wordAudio.id);
+  });
+
   test("skips TTS for vocabulary words that already have a WordAudio record", async () => {
     const id = randomUUID().replaceAll("-", "").slice(0, 8);
     const existingWord = `zexist${id}`;

--- a/apps/api/src/workflows/activity-generation/steps/_utils/fetch-existing-word-casing.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/fetch-existing-word-casing.ts
@@ -1,0 +1,20 @@
+import { prisma } from "@zoonk/db";
+
+export async function fetchExistingWordCasing(params: {
+  organizationId: number;
+  targetLanguage: string;
+  userLanguage: string;
+  words: string[];
+}): Promise<Record<string, string>> {
+  const existing = await prisma.word.findMany({
+    select: { word: true },
+    where: {
+      organizationId: params.organizationId,
+      targetLanguage: params.targetLanguage,
+      userLanguage: params.userLanguage,
+      word: { in: params.words, mode: "insensitive" },
+    },
+  });
+
+  return Object.fromEntries(existing.map((record) => [record.word.toLowerCase(), record.word]));
+}

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
@@ -37,15 +37,24 @@ export async function generateVocabularyAudioStep(
     where: {
       organizationId,
       targetLanguage,
-      word: { in: words.map((vocab) => vocab.word) },
+      word: { in: words.map((vocab) => vocab.word), mode: "insensitive" },
     },
   });
 
-  const existingAudioIds: Record<string, bigint> = Object.fromEntries(
-    existingAudios.map((record) => [record.word, record.id]),
+  const existingAudioByLower: Record<string, bigint> = Object.fromEntries(
+    existingAudios.map((record) => [record.word.toLowerCase(), record.id]),
   );
 
-  const wordsNeedingAudio = words.filter((vocab) => !existingAudioIds[vocab.word]);
+  const existingAudioIds: Record<string, bigint> = Object.fromEntries(
+    words.flatMap((vocab) => {
+      const audioId = existingAudioByLower[vocab.word.toLowerCase()];
+      return audioId ? [[vocab.word, audioId]] : [];
+    }),
+  );
+
+  const wordsNeedingAudio = words.filter(
+    (vocab) => !existingAudioByLower[vocab.word.toLowerCase()],
+  );
 
   const results = await Promise.all(
     wordsNeedingAudio.map((vocabWord) =>

--- a/apps/api/src/workflows/activity-generation/steps/save-sentence-words-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-sentence-words-step.ts
@@ -2,6 +2,7 @@ import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { emptyToNull, extractUniqueSentenceWords } from "@zoonk/utils/string";
 import { streamError, streamStatus } from "../stream-status";
+import { fetchExistingWordCasing } from "./_utils/fetch-existing-word-casing";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
@@ -17,25 +18,6 @@ type WordMetadataEntry = {
   romanization: string | null;
   translation: string;
 };
-
-async function fetchExistingWordCasing(params: {
-  organizationId: number;
-  targetLanguage: string;
-  userLanguage: string;
-  words: string[];
-}): Promise<Record<string, string>> {
-  const existing = await prisma.word.findMany({
-    select: { word: true },
-    where: {
-      organizationId: params.organizationId,
-      targetLanguage: params.targetLanguage,
-      userLanguage: params.userLanguage,
-      word: { in: params.words, mode: "insensitive" },
-    },
-  });
-
-  return Object.fromEntries(existing.map((record) => [record.word.toLowerCase(), record.word]));
-}
 
 function buildSaveOneWord(params: {
   existingCasing: Record<string, string>;

--- a/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
@@ -4,6 +4,7 @@ import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { emptyToNull, normalizePunctuation } from "@zoonk/utils/string";
 import { streamError, streamStatus } from "../stream-status";
+import { fetchExistingWordCasing } from "./_utils/fetch-existing-word-casing";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
@@ -15,6 +16,7 @@ export type SavedWord = {
 };
 
 function buildSaveOneWord(params: {
+  existingCasing: Record<string, string>;
   vocabularyActivityId: number;
   translationActivityId: number | null;
   lessonId: number;
@@ -23,6 +25,7 @@ function buildSaveOneWord(params: {
   userLanguage: string;
 }) {
   const {
+    existingCasing,
     vocabularyActivityId,
     translationActivityId,
     lessonId,
@@ -33,6 +36,7 @@ function buildSaveOneWord(params: {
 
   return async (vocabWord: VocabularyWord, position: number): Promise<SavedWord> => {
     const translation = normalizePunctuation(vocabWord.translation);
+    const dbWord = existingCasing[vocabWord.word.toLowerCase()] ?? vocabWord.word;
 
     const record = await prisma.word.upsert({
       create: {
@@ -42,7 +46,7 @@ function buildSaveOneWord(params: {
         targetLanguage,
         translation,
         userLanguage,
-        word: vocabWord.word,
+        word: dbWord,
       },
       update: {
         alternativeTranslations: vocabWord.alternativeTranslations,
@@ -50,7 +54,7 @@ function buildSaveOneWord(params: {
         translation,
       },
       where: {
-        orgWord: { organizationId, targetLanguage, userLanguage, word: vocabWord.word },
+        orgWord: { organizationId, targetLanguage, userLanguage, word: dbWord },
       },
     });
 
@@ -123,7 +127,15 @@ export async function saveVocabularyWordsStep(
   const userLanguage = vocabularyActivity.language;
   const organizationId = course.organization.id;
 
+  const existingCasing = await fetchExistingWordCasing({
+    organizationId,
+    targetLanguage,
+    userLanguage,
+    words: words.map((vocab) => vocab.word),
+  });
+
   const saveOneWord = buildSaveOneWord({
+    existingCasing,
     lessonId: vocabularyActivity.lessonId,
     organizationId,
     targetLanguage,


### PR DESCRIPTION
## Summary

- Extract `fetchExistingWordCasing` from `saveSentenceWordsStep` to shared `_utils/` so both sentence and vocabulary steps can use it
- Add case-insensitive `Word` lookup in `saveVocabularyWordsStep` so "hola" reuses an existing "Hola" record instead of creating a duplicate
- Add case-insensitive `WordAudio` lookup in `generateVocabularyAudioStep` so existing audio is found regardless of casing, avoiding redundant TTS calls

## Test plan

- [x] Added integration test: reuses existing `Word` record when casing differs
- [x] Added integration test: reuses existing `WordAudio` when casing differs
- [x] All existing vocabulary workflow tests pass (166/166)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make vocabulary word and audio deduplication case-insensitive to prevent duplicate records and unnecessary TTS calls. Also extracted a shared utility to keep casing consistent across sentence and vocabulary steps.

- **Bug Fixes**
  - Case-insensitive `Word` lookup in `saveVocabularyWordsStep` to reuse existing records (e.g., "hola" matches "Hola").
  - Case-insensitive `WordAudio` lookup in `generateVocabularyAudioStep` to reuse existing audio and skip TTS when casing differs.

- **Refactors**
  - Moved `fetchExistingWordCasing` to `_utils/fetch-existing-word-casing.ts` for reuse by both sentence and vocabulary steps.

<sup>Written for commit 51dfb62c13d1c0f3661b9d46f82c4a01cdad2c71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

