### PR TITLE
refactor: replace map+filter chains with flatMap

### DIFF
--- a/apps/editor/src/data/alternative-titles/import-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/import-alternative-titles.ts
@@ -57,8 +57,14 @@ export async function importAlternativeTitles(params: {
     return { data: null, error: new AppError(ErrorCode.courseNotFound) };
   }
 
-  const slugs = importData.alternativeTitles.map((title) => toSlug(title));
-  const uniqueSlugs = [...new Set(slugs)].filter(Boolean);
+  const uniqueSlugs = [
+    ...new Set(
+      importData.alternativeTitles.flatMap((title) => {
+        const slug = toSlug(title);
+        return slug ? [slug] : [];
+      }),
+    ),
+  ];
 
   if (uniqueSlugs.length === 0) {
     return { data: [], error: null };

--- a/packages/ai/src/tasks/steps/step-visual.ts
+++ b/packages/ai/src/tasks/steps/step-visual.ts
@@ -65,12 +65,9 @@ ${formattedSteps}`;
   // Tool calls are typed by Vercel AI SDK but output structure matches StepVisualResource
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- AI tool outputs match expected schema
   const visuals = generationSteps.flatMap((step) =>
-    step.toolCalls
-      .filter((call) => !call.dynamic)
-      .map((call) => ({
-        kind: call.toolName,
-        ...call.input,
-      })),
+    step.toolCalls.flatMap((call) =>
+      call.dynamic ? [] : [{ kind: call.toolName, ...call.input }],
+    ),
   ) as StepVisualResource[];
 
   return { data: { visuals }, systemPrompt, usage, userPrompt };

--- a/packages/core/src/alternative-titles/add-alternative-titles.ts
+++ b/packages/core/src/alternative-titles/add-alternative-titles.ts
@@ -8,8 +8,14 @@ export async function addAlternativeTitles(params: {
   titles: string[];
   language: string;
 }): Promise<SafeReturn<BatchPayload | null>> {
-  const slugs = params.titles.map((title) => toSlug(title));
-  const uniqueSlugs = [...new Set(slugs)].filter(Boolean);
+  const uniqueSlugs = [
+    ...new Set(
+      params.titles.flatMap((title) => {
+        const slug = toSlug(title);
+        return slug ? [slug] : [];
+      }),
+    ),
+  ];
 
   if (uniqueSlugs.length === 0) {
     return { data: null, error: null };

--- a/packages/player/src/build-word-bank-options.ts
+++ b/packages/player/src/build-word-bank-options.ts
@@ -90,9 +90,10 @@ export function buildWordBankOptions(
 
   const uniqueDistractors = [
     ...new Map(
-      allDistractorWords
-        .filter((word) => !correctSet.has(stripPunctuation(word).toLowerCase()))
-        .map((word) => [stripPunctuation(word).toLowerCase(), word] as const),
+      allDistractorWords.flatMap((word) => {
+        const key = stripPunctuation(word).toLowerCase();
+        return correctSet.has(key) ? [] : [[key, word] as const];
+      }),
     ).values(),
   ];
 

--- a/packages/player/src/prepare-activity-data.ts
+++ b/packages/player/src/prepare-activity-data.ts
@@ -229,20 +229,27 @@ export function prepareActivityData(
 
   const sentenceWordMap = new Map(sentenceWords.map((sw) => [sw.word.toLowerCase(), sw]));
 
-  const steps = activity.steps
-    .map((step) => serializeStep(step))
-    .filter((step): step is SerializedStep => step !== null)
-    .map((step) => ({
-      ...step,
-      fillBlankOptions: buildFillBlankOptions(step),
-      matchColumnsRightItems: buildMatchColumnsRightItems(step),
-      sentenceWordOptions: step.sentence
-        ? buildSentenceWordOptions(step.sentence.sentence, serializedLessonWords, sentenceWordMap)
-        : [],
-      sortOrderItems: buildSortOrderItems(step),
-      translationOptions: buildTranslationOptions(step, serializedLessonWords),
-      wordBankOptions: buildWordBankOptions(step, serializedLessonWords, sentenceWordMap),
-    }));
+  const steps = activity.steps.flatMap((raw) => {
+    const step = serializeStep(raw);
+
+    if (!step) {
+      return [];
+    }
+
+    return [
+      {
+        ...step,
+        fillBlankOptions: buildFillBlankOptions(step),
+        matchColumnsRightItems: buildMatchColumnsRightItems(step),
+        sentenceWordOptions: step.sentence
+          ? buildSentenceWordOptions(step.sentence.sentence, serializedLessonWords, sentenceWordMap)
+          : [],
+        sortOrderItems: buildSortOrderItems(step),
+        translationOptions: buildTranslationOptions(step, serializedLessonWords),
+        wordBankOptions: buildWordBankOptions(step, serializedLessonWords, sentenceWordMap),
+      },
+    ];
+  });
 
   return {
     description: activity.description,

--- a/packages/utils/src/settled.ts
+++ b/packages/utils/src/settled.ts
@@ -27,7 +27,5 @@ function hasValueError(value: unknown): boolean {
  * Extracts the fulfilled values from a Promise.allSettled array, dropping rejections.
  */
 export function settledValues<T>(results: PromiseSettledResult<T>[]): T[] {
-  return results
-    .filter((result): result is PromiseFulfilledResult<T> => result.status === "fulfilled")
-    .map((result) => result.value);
+  return results.flatMap((result) => (result.status === "fulfilled" ? [result.value] : []));
 }


### PR DESCRIPTION
## Summary
- Replace `.map().filter()` and `.filter().map()` chains with `.flatMap()` across 6 files
- Eliminates intermediate arrays and redundant iterations
- Also avoids duplicate `stripPunctuation` calls in `build-word-bank-options.ts`

## Test plan
- [x] All 544 tests pass
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors several modules to replace map+filter chains with flatMap, reducing intermediate arrays and extra iterations. Improves readability and avoids duplicate normalization in the word bank builder.

- **Refactors**
  - Swapped map/filter chains for flatMap in `apps/editor`, `packages/ai`, `packages/core`, `packages/player`, and `packages/utils`.
  - Generates unique slugs in one pass, skipping falsy results.
  - Word bank distractors normalize each word once to avoid duplicate `stripPunctuation` calls.
  - Builds steps via flatMap to drop nulls and remove extra passes; simplifies `settledValues` to flatten fulfilled results directly.

<sup>Written for commit 3cdfd123006599163657956eb132736eb9ffd5b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

