### PR TITLE
feat(oxlint-plugin): add prefer-flatmap rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -109,7 +109,8 @@
     "zoonk/no-get-extracted-in-promise": "error",
     "zoonk/no-object-params-in-cache": ["error", { "exceptions": ["headers"] }],
     "zoonk/no-hardcoded-aria-label": "off",
-    "zoonk/no-t-function-as-argument": "error"
+    "zoonk/no-t-function-as-argument": "error",
+    "zoonk/prefer-flatmap": "error"
   },
   "overrides": [
     {

--- a/apps/evals/src/lib/eval-runner.ts
+++ b/apps/evals/src/lib/eval-runner.ts
@@ -122,17 +122,17 @@ export async function runEval(task: Task, modelId: string): Promise<TaskEvalResu
     }),
   );
 
-  const newResults: ScoredResult[] = results
-    .map((result) => {
-      if (result.status === "fulfilled") {
-        return result.value;
-      }
-      console.error(
-        `Error scoring output: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`,
-      );
-      return null;
-    })
-    .filter((res): res is ScoredResult => res !== null);
+  const newResults: ScoredResult[] = results.flatMap((result) => {
+    if (result.status === "fulfilled") {
+      return [result.value];
+    }
+
+    console.error(
+      `Error scoring output: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`,
+    );
+
+    return [];
+  });
 
   const allScoredResults = [...existingResults, ...newResults];
 

--- a/apps/evals/src/lib/leaderboard.ts
+++ b/apps/evals/src/lib/leaderboard.ts
@@ -38,26 +38,26 @@ export type SortDirection = "asc" | "desc";
  * Filters out results whose model cannot be resolved.
  */
 export function getLeaderboardEntries(results: TaskEvalResults[]): LeaderboardEntry[] {
-  return results
-    .map((result) => {
-      const model = getModelById(result.modelId);
+  return results.flatMap((result) => {
+    const model = getModelById(result.modelId);
 
-      if (!model) {
-        return null;
-      }
+    if (!model) {
+      return [];
+    }
 
-      const stats = getStatsFromResults(result);
+    const stats = getStatsFromResults(result);
 
-      return {
+    return [
+      {
         averageDuration: stats.averageDuration,
         averageScore: calculateAverageScore(result),
         modelId: result.modelId,
         modelName: getModelDisplayName(model),
         provider: result.modelId.split("/")[0] ?? result.modelId,
         totalCost: stats.totalCost,
-      } satisfies LeaderboardEntry;
-    })
-    .filter(Boolean) as LeaderboardEntry[];
+      } satisfies LeaderboardEntry,
+    ];
+  });
 }
 
 export function getDefaultSortDirection(key: SortKey): SortDirection {

--- a/apps/evals/src/lib/output-generator.ts
+++ b/apps/evals/src/lib/output-generator.ts
@@ -63,17 +63,17 @@ function collectTestCaseRuns(testCases: TestCase[], existingEntries: OutputEntry
 }
 
 function extractSuccessfulOutputs(results: PromiseSettledResult<OutputEntry>[]): OutputEntry[] {
-  return results
-    .map((result) => {
-      if (result.status === "fulfilled") {
-        return result.value;
-      }
-      console.error(
-        `Error generating output: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`,
-      );
-      return null;
-    })
-    .filter((res): res is OutputEntry => res !== null);
+  return results.flatMap((result) => {
+    if (result.status === "fulfilled") {
+      return [result.value];
+    }
+
+    console.error(
+      `Error generating output: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`,
+    );
+
+    return [];
+  });
 }
 
 function createModelOutputs(taskId: string, modelId: string, outputs: OutputEntry[]): ModelOutputs {

--- a/apps/main/src/lib/workflow/use-thinking-messages.ts
+++ b/apps/main/src/lib/workflow/use-thinking-messages.ts
@@ -114,8 +114,9 @@ export function useThinkingMessages<TPhase extends string>(
   }
 
   return Object.fromEntries(
-    activePhases
-      .map((phase) => [phase, generators[phase]?.(state.indices[phase] ?? 0)] as const)
-      .filter(([, message]) => message !== undefined),
+    activePhases.flatMap((phase) => {
+      const message = generators[phase]?.(state.indices[phase] ?? 0);
+      return message === undefined ? [] : [[phase, message] as const];
+    }),
   );
 }

--- a/packages/auth/src/stripe/prices.ts
+++ b/packages/auth/src/stripe/prices.ts
@@ -34,9 +34,10 @@ export async function getStripePrices(
       lookup_keys: lookupKeys,
     });
 
-    const entries = prices.data
-      .map((price) => extractPrice(price, currency.toLowerCase()))
-      .filter((entry): entry is [string, PriceInfo] => entry !== null);
+    const entries = prices.data.flatMap((price) => {
+      const entry = extractPrice(price, currency.toLowerCase());
+      return entry ? [entry] : [];
+    });
 
     return new Map(entries);
   } catch {

--- a/packages/oxlint-plugin/index.js
+++ b/packages/oxlint-plugin/index.js
@@ -4,6 +4,7 @@ import noGetExtractedInPromise from "./rules/no-get-extracted-in-promise.js";
 import noHardcodedAriaLabel from "./rules/no-hardcoded-aria-label.js";
 import noObjectParamsInCache from "./rules/no-object-params-in-cache.js";
 import noTFunctionAsArgument from "./rules/no-t-function-as-argument.js";
+import preferFlatMap from "./rules/prefer-flatmap.js";
 
 /** @public */
 export default eslintCompatPlugin({
@@ -16,5 +17,6 @@ export default eslintCompatPlugin({
     "no-hardcoded-aria-label": noHardcodedAriaLabel,
     "no-object-params-in-cache": noObjectParamsInCache,
     "no-t-function-as-argument": noTFunctionAsArgument,
+    "prefer-flatmap": preferFlatMap,
   },
 });

--- a/packages/oxlint-plugin/rules/prefer-flatmap.js
+++ b/packages/oxlint-plugin/rules/prefer-flatmap.js
@@ -1,0 +1,53 @@
+import { defineRule } from "@oxlint/plugins";
+
+function isFilterCall(node) {
+  return (
+    node.type === "CallExpression" &&
+    node.callee.type === "MemberExpression" &&
+    node.callee.property.name === "filter"
+  );
+}
+
+function isMapCall(node) {
+  return (
+    node.type === "CallExpression" &&
+    node.callee.type === "MemberExpression" &&
+    node.callee.property.name === "map"
+  );
+}
+
+export default defineRule({
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (!isFilterCall(node)) {
+          return;
+        }
+
+        const mapCall = node.callee.object;
+
+        if (!isMapCall(mapCall)) {
+          return;
+        }
+
+        context.report({
+          loc: node.loc,
+          messageId: "preferFlatMap",
+        });
+      },
+    };
+  },
+
+  meta: {
+    docs: {
+      description:
+        "Prefer flatMap over map followed by filter. flatMap transforms and filters in a single pass, avoiding an intermediate array.",
+    },
+    messages: {
+      preferFlatMap:
+        "Use flatMap() instead of map().filter(). flatMap transforms and filters in one pass without creating an intermediate array.",
+    },
+    schema: [],
+    type: "suggestion",
+  },
+});

--- a/packages/player/src/validate-answers.ts
+++ b/packages/player/src/validate-answers.ts
@@ -163,20 +163,15 @@ export function validateAnswers(
   steps: StepData[],
   clientAnswers: Record<string, SelectedAnswer>,
 ): ValidatedStepResult[] {
-  return steps
-    .map((step) => {
-      const answer = clientAnswers[String(step.id)];
+  return steps.flatMap((step) => {
+    const answer = clientAnswers[String(step.id)];
 
-      if (!answer) {
-        return null;
-      }
+    if (!answer || !isSupportedStepKind(step.kind)) {
+      return [];
+    }
 
-      if (!isSupportedStepKind(step.kind)) {
-        return null;
-      }
-
-      const validator = validators[step.kind];
-      return validator(step, answer);
-    })
-    .filter((result): result is ValidatedStepResult => result !== null);
+    const validator = validators[step.kind];
+    const result = validator(step, answer);
+    return result ? [result] : [];
+  });
 }

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -100,9 +100,10 @@ export function segmentWords(text: string): string[] {
 
 export function extractUniqueSentenceWords(sentences: string[]): string[] {
   const words = sentences.flatMap((sentence) =>
-    segmentWords(sentence)
-      .map((token) => stripPunctuation(token).toLowerCase())
-      .filter((token) => token.length > 0),
+    segmentWords(sentence).flatMap((token) => {
+      const stripped = stripPunctuation(token).toLowerCase();
+      return stripped.length > 0 ? [stripped] : [];
+    }),
   );
 
   return [...new Set(words)];


### PR DESCRIPTION
## Summary
- Add custom oxlint rule `zoonk/prefer-flatmap` that catches any `.map().filter()` chain and suggests using `.flatMap()` instead
- Fix all existing violations across the codebase (7 files)

## Test plan
- [x] Verified rule detects `.map().filter(Boolean)` patterns
- [x] Verified rule detects `.map().filter(predicate)` patterns
- [x] `pnpm turbo quality:fix` passes
- [x] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a custom `oxlint` rule `zoonk/prefer-flatmap` to replace `.map().filter()` chains with `.flatMap()`. This enforces a single-pass transform, avoids intermediate arrays, and updates existing code to comply.

- **New Features**
  - Added `zoonk/prefer-flatmap` to flag `.map().filter(...)` (including `.filter(Boolean)`), enabled as `error` in `.oxlintrc.json`.

- **Refactors**
  - Replaced `map(...).filter(...)` with `flatMap(...)` across evals, main workflow messages, Stripe prices, player answer validation, and string utils (7 files).

<sup>Written for commit d9287c3ff1fd7c9b1fbb0cc408222baae6407840. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

