### PR TITLE
fix(test): use test-scoped user in logout e2e test

### DIFF
--- a/apps/editor/e2e/logout-menu-item.test.ts
+++ b/apps/editor/e2e/logout-menu-item.test.ts
@@ -1,3 +1,4 @@
+import { createE2EUser, getBaseURL } from "@zoonk/e2e/helpers";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { type Page, expect, test } from "./fixtures";
 
@@ -6,14 +7,28 @@ async function openOrgDropdown(page: Page) {
 }
 
 test.describe("Logout Menu Item", () => {
-  test("logs out user and shows login button", async ({ authenticatedPage }) => {
-    await authenticatedPage.goto(`/${AI_ORG_SLUG}`);
+  // Logout invalidates the server-side session, making the worker-scoped
+  // adminUser's storageState stale on retry. Use a test-scoped user instead.
+  test("logs out user and shows login button", async ({ browser }) => {
+    const user = await createE2EUser(getBaseURL(), {
+      orgRole: "admin",
+      withSubscription: true,
+    });
+    const ctx = await browser.newContext({ storageState: user.storageState });
+    const page = await ctx.newPage();
 
-    await openOrgDropdown(authenticatedPage);
-    await authenticatedPage.getByRole("menuitem", { name: /logout/i }).click();
+    await page.goto(`/${AI_ORG_SLUG}`);
+
+    await openOrgDropdown(page);
+
+    const logoutItem = page.getByRole("menuitem", { name: /logout/i });
+    await expect(logoutItem).toBeVisible();
+    await logoutItem.click({ force: true });
 
     // After logout (hard navigation), user should see the login button
-    await authenticatedPage.waitForURL("/");
-    await expect(authenticatedPage.getByRole("link", { name: /login/i })).toBeVisible();
+    await page.waitForURL("/");
+    await expect(page.getByRole("link", { name: /login/i })).toBeVisible();
+
+    await ctx.close();
   });
 });


### PR DESCRIPTION
## Summary
- The logout test used the worker-scoped `adminUser`, whose server-side session gets invalidated by `signOut()`. On CI retry, the stale `storageState` caused "Target page, context or browser has been closed" errors.
- Use a test-scoped user via `createE2EUser()` so each attempt gets a fresh session.
- Wait for menuitem visibility and use `force: true` to handle dropdown animation (same pattern as `locale-switcher.test.ts`).

## Test plan
- [x] Ran the test 5 times individually — 0 failures
- [x] Full editor e2e suite passes (194 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the editor logout e2e test by creating a per-test user/session so each retry gets a fresh storage state. Also makes the Logout click reliable by waiting for visibility and using a forced click to handle dropdown animation.

<sup>Written for commit 709fdab809b7dca0cbcebebae2e793ff8f39e645. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

