### PR TITLE
fix(turbo): restore db:deploy dependency in build task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -59,7 +59,7 @@
       "dependsOn": ["//#lint:fix", "//#format:fix"]
     },
     "build": {
-      "dependsOn": ["^db:generate", "^build"],
+      "dependsOn": ["^db:generate", "^db:deploy", "^build"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "build:e2e": {


### PR DESCRIPTION
## Summary

- Restore `^db:deploy` as a dependency of the `build` task in `turbo.json`
- This was accidentally removed in #962 (March 6), which stopped `prisma migrate deploy` from running during Vercel builds

## Test plan

- [ ] Verify next deployment runs pending migrations against production DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the `^db:deploy` dependency on the `build` task in `turbo.json`. This ensures `prisma migrate deploy` runs during Vercel builds and pending migrations are applied.

<sup>Written for commit 03f00effb70fba99f63552f88e0b13f4061351d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

