### PR TITLE
chore: silence sentry source map upload logs

### DIFF
--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -51,7 +51,7 @@ const withNextIntl = createNextIntlPlugin({
 export default withSentryConfig(withWorkflow(withBotId(withNextIntl(nextConfig))), {
   org: "zoonk",
   project: "zoonk-api",
-  silent: !process.env.CI,
+  silent: true,
   webpack: {
     treeshake: {
       removeDebugLogging: true,

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -69,7 +69,7 @@ const withNextIntl = createNextIntlPlugin({
 export default withSentryConfig(withNextIntl(nextConfig), {
   org: "zoonk",
   project: "zoonk-editor",
-  silent: !process.env.CI,
+  silent: true,
   webpack: {
     treeshake: {
       removeDebugLogging: true,

--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -75,7 +75,7 @@ const withNextIntl = createNextIntlPlugin({
 export default withSentryConfig(withBotId(withNextIntl(withMDX(nextConfig))), {
   org: "zoonk",
   project: "zoonk",
-  silent: !process.env.CI,
+  silent: true,
   webpack: {
     treeshake: {
       removeDebugLogging: true,


### PR DESCRIPTION
## Summary
- Set `silent: true` in Sentry config for all apps (main, editor, api) to suppress noisy source map upload logs during Vercel builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences Sentry source map upload logs in `apps/main`, `apps/editor`, and `apps/api` to reduce noise in Vercel build output. Sets `silent: true` in the `@sentry/nextjs` config for each app.

<sup>Written for commit dbdf67de91c302ffa3b4dffc9d950e95b58c850f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

