### PR TITLE
fix(main): prevent stale run ID from blocking workflow retry

### DIFF
--- a/apps/api/src/workflows/activity-generation/steps/handle-workflow-failure-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/handle-workflow-failure-step.ts
@@ -15,7 +15,7 @@ export async function handleWorkflowFailureStep(
 
   await safeAsync(() =>
     prisma.activity.updateMany({
-      data: { generationStatus: "failed" },
+      data: { generationRunId: null, generationStatus: "failed" },
       where: {
         generationRunId: workflowRunId,
         generationStatus: "running",

--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
@@ -326,6 +326,7 @@ describe(chapterGenerationWorkflow, () => {
       });
 
       expect(dbChapter?.generationStatus).toBe("failed");
+      expect(dbChapter?.generationRunId).toBeNull();
 
       const errorCall = writeMock.mock.calls.find(
         (call: string[]) =>

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -476,7 +476,9 @@ describe(courseGenerationWorkflow, () => {
       });
 
       expect(course?.generationStatus).toBe("failed");
+      expect(course?.generationRunId).toBeNull();
       expect(dbSuggestion?.generationStatus).toBe("failed");
+      expect(dbSuggestion?.generationRunId).toBeNull();
 
       const errorCall = writeMock.mock.calls.find(
         (call: string[]) =>

--- a/apps/api/src/workflows/course-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/handle-failure-step.ts
@@ -13,17 +13,17 @@ export async function handleCourseFailureStep(input: {
   if (courseId) {
     await Promise.allSettled([
       prisma.course.update({
-        data: { generationStatus: "failed" },
+        data: { generationRunId: null, generationStatus: "failed" },
         where: { id: courseId },
       }),
       prisma.courseSuggestion.update({
-        data: { generationStatus: "failed" },
+        data: { generationRunId: null, generationStatus: "failed" },
         where: { id: courseSuggestionId },
       }),
     ]);
   } else {
     await prisma.courseSuggestion.update({
-      data: { generationStatus: "failed" },
+      data: { generationRunId: null, generationStatus: "failed" },
       where: { id: courseSuggestionId },
     });
   }
@@ -36,7 +36,7 @@ export async function handleChapterFailureStep(input: { chapterId: number }): Pr
 
   await safeAsync(() =>
     prisma.chapter.update({
-      data: { generationStatus: "failed" },
+      data: { generationRunId: null, generationStatus: "failed" },
       where: { id: input.chapterId },
     }),
   );

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
@@ -410,6 +410,7 @@ describe(lessonGenerationWorkflow, () => {
       });
 
       expect(dbLesson?.generationStatus).toBe("failed");
+      expect(dbLesson?.generationRunId).toBeNull();
 
       const errorCall = writeMock.mock.calls.find(
         (call: string[]) =>

--- a/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.ts
@@ -7,7 +7,7 @@ export async function handleLessonFailureStep(input: { lessonId: number }): Prom
 
   await safeAsync(() =>
     prisma.lesson.update({
-      data: { generationStatus: "failed" },
+      data: { generationRunId: null, generationStatus: "failed" },
       where: { id: input.lessonId },
     }),
   );

--- a/apps/main/src/lib/workflow/use-workflow-generation.ts
+++ b/apps/main/src/lib/workflow/use-workflow-generation.ts
@@ -26,12 +26,14 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
   const hasTriggeredRef = useRef(false);
 
   // Wrapper preserves the TStep generic that useReducer would otherwise widen to string.
+  const resolvedStatus = config.initialStatus ?? "idle";
+
   const [state, dispatch] = useReducer(
     (prev: GenerationState<TStep>, action: GenerationAction<TStep>) =>
       generationReducer(prev, action),
     initialGenerationState<TStep>({
-      runId: config.initialRunId ?? null,
-      status: config.initialRunId ? "streaming" : (config.initialStatus ?? "idle"),
+      runId: resolvedStatus === "streaming" ? (config.initialRunId ?? null) : null,
+      status: resolvedStatus,
     }),
   );
 


### PR DESCRIPTION
## Summary

- Fix `useWorkflowGeneration` using `initialRunId` presence to force `"streaming"` status, ignoring the actual `initialStatus`. When a workflow fails (`generationStatus: "failed"`) but `generationRunId` is non-null, the UI connected to the dead run's SSE stream instead of triggering a new workflow — making retries appear stuck on the first step.
- Clear `generationRunId` in all failure handlers (course, chapter, lesson, activity) so stale run IDs don't persist in the DB after failures.

## Test plan

- [x] Existing workflow tests updated with `generationRunId: null` assertions on failure
- [x] All tests pass (`pnpm test`)
- [x] Typecheck passes
- [x] Build passes for `main` and `api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workflow retries getting stuck by clearing stale `generationRunId` on failures and using the actual initial status in the client. Retries now start a fresh run instead of reconnecting to a dead SSE stream.

- **Bug Fixes**
  - Frontend: `useWorkflowGeneration` now uses `initialStatus` as the source of truth; only keeps `runId` when status is `"streaming"`.
  - Backend: on failure, set `generationRunId = null` and `generationStatus = "failed"` for course, chapter, lesson, and activity workflows.
  - Tests: assert `generationRunId` is `null` after failures across workflows.

<sup>Written for commit 9ba40b2115bcd3ae70678ef1a930d3fb54849d37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

