### PR TITLE
fix(player): prevent layout shift when inline feedback is displayed

### DIFF
--- a/packages/player/src/components/player-stage.tsx
+++ b/packages/player/src/components/player-stage.tsx
@@ -15,7 +15,6 @@ export function PlayerStage({
       className={cn(
         "flex min-h-0 min-w-0 flex-1 flex-col items-center overflow-y-auto",
         isStatic ? "overflow-hidden p-0" : "justify-center p-4",
-        "data-[phase=feedback]:px-6 data-[phase=feedback]:sm:px-8",
         className,
       )}
       data-phase={phase}


### PR DESCRIPTION
## Summary
- Remove feedback-phase padding override from `PlayerStage` that increased horizontal padding from 16px to 24px (mobile) / 32px (desktop) when transitioning to the feedback phase
- This caused visible layout shift for all steps with inline feedback: fillBlank, selectImage, sortOrder, reading, and listening

## Test plan
- [ ] Open player with a fillBlank step, answer it, confirm no horizontal shift when feedback appears
- [ ] Repeat for selectImage, sortOrder, reading, and listening steps
- [ ] Verify multipleChoice and translation feedback screens still look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents horizontal layout shift when inline feedback appears by removing the feedback-phase padding override in `PlayerStage`. Affects fillBlank, selectImage, sortOrder, reading, and listening; multipleChoice and translation screens are unchanged.

- **Bug Fixes**
  - Removed `data-[phase=feedback]:px-6 data-[phase=feedback]:sm:px-8` from the `PlayerStage` container to keep padding consistent across phases.

<sup>Written for commit df2286fd7dbcd7000e2cc4aee89739402c2a637e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

