### PR TITLE
fix(main): auto-scroll to active phase on generation pages

### DIFF
--- a/apps/main/src/components/generation/generation-progress.tsx
+++ b/apps/main/src/components/generation/generation-progress.tsx
@@ -5,7 +5,7 @@ import { Button } from "@zoonk/ui/components/button";
 import { Progress, ProgressLabel, ProgressValue } from "@zoonk/ui/components/progress";
 import { cn } from "@zoonk/ui/lib/utils";
 import { AlertCircleIcon, CheckIcon, type LucideIcon } from "lucide-react";
-import { type ReactNode } from "react";
+import { type ReactNode, useEffect, useRef } from "react";
 
 type PhaseStatus = "pending" | "active" | "completed";
 
@@ -122,8 +122,23 @@ function GenerationTimelineStep({
   isLast?: boolean;
   status: PhaseStatus;
 }) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (status !== "active" || !ref.current) {
+      return;
+    }
+
+    const prefersReducedMotion = globalThis.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    ref.current.scrollIntoView({
+      behavior: prefersReducedMotion ? "instant" : "smooth",
+      block: "nearest",
+    });
+  }, [status]);
+
   return (
-    <div className="flex items-start gap-3" data-slot="generation-timeline-step">
+    <div ref={ref} className="flex items-start gap-3" data-slot="generation-timeline-step">
       <div className="flex flex-col items-center">
         <GenerationTimelineStepIndicator icon={icon} status={status} />
         {!isLast && (


### PR DESCRIPTION
## Summary

- Auto-scroll the active generation phase into view when it transitions to active, keeping the current step visible on mobile where long timelines push it off-screen
- Uses `scrollIntoView({ behavior: "smooth", block: "nearest" })` so it only scrolls when the element is actually off-screen
- Respects `prefers-reduced-motion` by using instant scroll for users who prefer reduced motion

## Test plan

- [ ] Open a generation page on mobile (course-suggestion has the most phases)
- [ ] Verify the active phase stays visible as it progresses through the timeline
- [ ] Verify no scroll happens on desktop when all phases fit on screen
- [ ] Verify `prefers-reduced-motion` uses instant scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-scrolls the active generation phase into view when it becomes active to keep the current step visible on mobile. Improves readability on long timelines without affecting desktop.

- **Bug Fixes**
  - Uses `scrollIntoView({ block: "nearest" })` with smooth behavior; switches to instant when `prefers-reduced-motion` is enabled.
  - Runs on active status changes only, and doesn’t scroll when all phases already fit on screen.

<sup>Written for commit 4ef225395237bf8253ba42c4581d10a78ee06258. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

