### PR TITLE
fix(core): show continue instead of review for ungenerated lessons

### DIFF
--- a/apps/main/e2e/continue-activity-link.test.ts
+++ b/apps/main/e2e/continue-activity-link.test.ts
@@ -158,6 +158,41 @@ test.describe("Continue Activity Link", () => {
     );
   });
 
+  test("shows Continue linking to lesson page when next lesson is ungenerated", async ({
+    authenticatedPage,
+    withProgressUser,
+  }) => {
+    const { activity, chapter, course, org } = await createTestCourseWithActivity();
+
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const pendingLesson = await lessonFixture({
+      chapterId: chapter.id,
+      generationStatus: "pending",
+      isPublished: true,
+      organizationId: org.id,
+      position: 1,
+      slug: `e2e-cal-pending-l-${uniqueId}`,
+      title: `E2E CAL Pending Lesson ${uniqueId}`,
+    });
+
+    await activityProgressFixture({
+      activityId: activity.id,
+      completedAt: new Date(),
+      durationSeconds: 60,
+      userId: withProgressUser.id,
+    });
+
+    await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
+
+    const continueLink = authenticatedPage.getByRole("link", { name: /^continue$/i });
+    await expect(continueLink).toBeVisible();
+    await expect(continueLink).toHaveAttribute(
+      "href",
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${pendingLesson.slug}`,
+    );
+  });
+
   test("authenticated user with progress sees Continue on course page", async ({
     authenticatedPage,
     withProgressUser,

--- a/apps/main/src/components/catalog/continue-activity-link.tsx
+++ b/apps/main/src/components/catalog/continue-activity-link.tsx
@@ -62,7 +62,11 @@ export async function ContinueActivityLink<Href extends string>({
   return (
     <Link
       className={cn(buttonVariants(), "min-w-0 flex-1 gap-2")}
-      href={`/b/${data.brandSlug}/c/${data.courseSlug}/ch/${data.chapterSlug}/l/${data.lessonSlug}/a/${data.activityPosition}`}
+      href={
+        data.canPrefetch
+          ? `/b/${data.brandSlug}/c/${data.courseSlug}/ch/${data.chapterSlug}/l/${data.lessonSlug}/a/${data.activityPosition}`
+          : `/b/${data.brandSlug}/c/${data.courseSlug}/ch/${data.chapterSlug}/l/${data.lessonSlug}`
+      }
       prefetch={data.canPrefetch}
     >
       {getLabel()}

--- a/packages/core/src/progress/get-next-activity.test.ts
+++ b/packages/core/src/progress/get-next-activity.test.ts
@@ -381,6 +381,132 @@ describe("getNextActivity - course scope", () => {
     });
   });
 
+  test("returns pending lesson when all generated activities are completed but a lesson is ungenerated", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const [lesson1, lesson2] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "pending",
+        isPublished: true,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    const activity1 = await activityFixture({
+      generationStatus: "completed",
+      isPublished: true,
+      lessonId: lesson1.id,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    await activityProgressFixture({
+      activityId: activity1.id,
+      completedAt: new Date(),
+      durationSeconds: 60,
+      userId: Number(user.id),
+    });
+
+    const headers = await signInAs(user.email, user.password);
+    const result = await getNextActivity({ headers, scope: { courseId: course.id } });
+
+    expect(result).toEqual({
+      activityPosition: 0,
+      brandSlug: organization.slug,
+      canPrefetch: false,
+      chapterSlug: chapter.slug,
+      completed: false,
+      courseSlug: course.slug,
+      hasStarted: true,
+      lessonSlug: lesson2.slug,
+    });
+  });
+
+  test("returns pending lesson when all generated activities are completed but an activity is ungenerated", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const [lesson1, lesson2] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    const [activity1] = await Promise.all([
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        lessonId: lesson1.id,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      activityFixture({
+        generationStatus: "pending",
+        isPublished: true,
+        lessonId: lesson2.id,
+        organizationId: organization.id,
+        position: 0,
+      }),
+    ]);
+
+    await activityProgressFixture({
+      activityId: activity1.id,
+      completedAt: new Date(),
+      durationSeconds: 60,
+      userId: Number(user.id),
+    });
+
+    const headers = await signInAs(user.email, user.password);
+    const result = await getNextActivity({ headers, scope: { courseId: course.id } });
+
+    expect(result).toEqual({
+      activityPosition: 0,
+      brandSlug: organization.slug,
+      canPrefetch: false,
+      chapterSlug: chapter.slug,
+      completed: false,
+      courseSlug: course.slug,
+      hasStarted: true,
+      lessonSlug: lesson2.slug,
+    });
+  });
+
   test("returns null when no published activities exist", async () => {
     const course = await courseFixture({ isPublished: true, organizationId: organization.id });
     const chapter = await chapterFixture({

--- a/packages/core/src/progress/get-next-activity.ts
+++ b/packages/core/src/progress/get-next-activity.ts
@@ -71,6 +71,64 @@ async function findFirstActivity(scope: ActivityScope): Promise<{
   };
 }
 
+async function findFirstPendingLesson(scope: ActivityScope) {
+  const chapterFilter = (() => {
+    if ("courseId" in scope) {
+      return { courseId: scope.courseId, isPublished: true };
+    }
+
+    if ("chapterId" in scope) {
+      return { id: scope.chapterId, isPublished: true };
+    }
+
+    return { isPublished: true };
+  })();
+
+  const lessonIdFilter = "lessonId" in scope ? { id: scope.lessonId } : {};
+
+  const { data: lesson, error } = await safeAsync(() =>
+    prisma.lesson.findFirst({
+      include: {
+        chapter: {
+          include: {
+            course: { include: { organization: true } },
+          },
+        },
+      },
+      orderBy: [{ chapter: { position: "asc" } }, { position: "asc" }],
+      where: {
+        ...lessonIdFilter,
+        OR: [
+          { generationStatus: { not: "completed" } },
+          {
+            activities: {
+              some: {
+                generationStatus: { not: "completed" },
+                isPublished: true,
+              },
+            },
+          },
+        ],
+        chapter: chapterFilter,
+        isPublished: true,
+      },
+    }),
+  );
+
+  if (error || !lesson) {
+    return null;
+  }
+
+  return {
+    activityPosition: 0,
+    brandSlug: lesson.chapter.course.organization?.slug ?? null,
+    canPrefetch: false,
+    chapterSlug: lesson.chapter.slug,
+    courseSlug: lesson.chapter.course.slug,
+    lessonSlug: lesson.slug,
+  };
+}
+
 function isWithinScope(
   next: { chapterSlug: string; lessonSlug: string },
   scope: ActivityScope,
@@ -138,6 +196,12 @@ export async function getNextActivity({
       hasStarted: true,
       lessonSlug: next.lessonSlug,
     };
+  }
+
+  const pending = await findFirstPendingLesson(scope);
+
+  if (pending) {
+    return { ...pending, completed: false, hasStarted: true };
   }
 
   const first = await findFirstActivity(scope);


### PR DESCRIPTION
## Summary

- When all generated activities are completed but ungenerated lessons/activities exist in scope, the continue button now shows "Continue" (not "Review") and links to the lesson page (not an activity URL)
- Added `findFirstPendingLesson()` in `get-next-activity.ts` to detect lessons with `generationStatus !== "completed"` or activities with pending generation
- Updated `continue-activity-link.tsx` to link to the lesson page when `canPrefetch` is false

## Test plan

- [x] Integration tests: user completed all activities but lesson 2 has `generationStatus: "pending"` → returns `completed: false`, `canPrefetch: false`
- [x] Integration tests: user completed all activities but an activity has `generationStatus: "pending"` → returns `completed: false`
- [x] E2E test: pending lesson shows "Continue" button linking to lesson page
- [x] All existing tests pass (133 integration, 8 main e2e, 194 editor e2e, 56 api e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "Continue" button when lessons or activities are still generating. We now show "Continue" and link to the lesson page instead of "Review" to an activity URL.

- **Bug Fixes**
  - Core (`packages/core`): added `findFirstPendingLesson()` to detect pending lessons/activities; `getNextActivity()` now returns `completed: false` and `canPrefetch: false` when pending work exists.
  - Web (`apps/main`): `continue-activity-link.tsx` links to the lesson page when `canPrefetch` is false. Added integration and E2E tests for pending lesson and pending activity cases.

<sup>Written for commit 9be34f25f1971f6b0cf9cc71bd6a30ad48b16848. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

