### PR TITLE
fix(mailer): set reply-to as user email on contact form

### DIFF
--- a/apps/main/src/components/feedback/contact-form-action.ts
+++ b/apps/main/src/components/feedback/contact-form-action.ts
@@ -12,6 +12,7 @@ export async function contactFormAction(_prevState: unknown, formData: FormData)
   }
 
   const { error } = await sendEmail({
+    replyTo: email,
     subject: "Zoonk Request",
     text: `
         <p><strong>From:</strong> ${email}</p>

--- a/packages/mailer/src/client.ts
+++ b/packages/mailer/src/client.ts
@@ -27,7 +27,7 @@ export async function sendEmail({
       body: JSON.stringify({
         from: { address: "hello@zoonk.com", name: "Zoonk" },
         htmlBody: text,
-        ...(replyTo && { reply_to: { address: replyTo } }),
+        ...(replyTo && { reply_to: [{ address: replyTo }] }),
         subject,
         to: [{ email_address: { address: to } }],
       }),

--- a/packages/mailer/src/client.ts
+++ b/packages/mailer/src/client.ts
@@ -9,10 +9,12 @@ export async function sendEmail({
   to,
   subject,
   text,
+  replyTo,
 }: {
   to: string;
   subject: string;
   text: string;
+  replyTo?: string;
 }): Promise<SafeReturn<Response>> {
   if (sendEmailDisabled) {
     logInfo("Email sending is disabled.");
@@ -25,6 +27,7 @@ export async function sendEmail({
       body: JSON.stringify({
         from: { address: "hello@zoonk.com", name: "Zoonk" },
         htmlBody: text,
+        ...(replyTo && { reply_to: { address: replyTo } }),
         subject,
         to: [{ email_address: { address: to } }],
       }),


### PR DESCRIPTION
## Summary
- Add optional `replyTo` param to `sendEmail` in the mailer package
- Pass user's email as `replyTo` in the contact form action so replies go directly to the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set Reply-To to the user's email for contact form submissions so replies go directly to them. Adds optional `replyTo` to `mailer`'s `sendEmail` and sends it using ZeptoMail’s required array format.

<sup>Written for commit cb0124d2a6f10b82c3b485fc4e3afdf43f651154. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

