### PR TITLE
fix(player): clarify completion screen action labels

### DIFF
--- a/apps/main/e2e/continue-learning-revalidation.test.ts
+++ b/apps/main/e2e/continue-learning-revalidation.test.ts
@@ -137,8 +137,8 @@ test.describe("Continue Learning Revalidation", () => {
     // Wait for the server action response (includes the revalidatePath signal for Router Cache)
     await serverActionResponse;
 
-    // 4. Click "Back to Lesson" (client-side navigation)
-    await page.getByRole("link", { name: /back to lesson/i }).click();
+    // 4. Click "All Activities" (client-side navigation)
+    await page.getByRole("link", { name: /all activities/i }).click();
     await page.waitForURL(new RegExp(`e2e-cl-reval-lesson-${uniqueId}`));
 
     // 5. Click the Home link in the navbar (client-side navigation — Router Cache)

--- a/apps/main/e2e/static-step.test.ts
+++ b/apps/main/e2e/static-step.test.ts
@@ -671,7 +671,7 @@ test.describe("Completion Screen", () => {
     await expect(page.getByRole("navigation", { name: /step navigation/i })).not.toBeVisible();
   });
 
-  test("shows Back to Lesson link and Restart button", async ({ page }) => {
+  test("shows All Activities link and Try Again button", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const { url } = await createStaticActivity({
       steps: [
@@ -691,8 +691,8 @@ test.describe("Completion Screen", () => {
     await page.keyboard.press("ArrowRight");
 
     await expect(page.getByRole("status")).toBeVisible();
-    await expect(page.getByRole("link", { name: /back to lesson/i })).toBeVisible();
-    await expect(page.getByRole("button", { name: /restart/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /all activities/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /try again/i })).toBeVisible();
   });
 
   test("pressing R on completion screen restarts activity", async ({ page }) => {
@@ -765,7 +765,7 @@ test.describe("Completion Screen", () => {
     await page.waitForURL(new RegExp(lesson.slug));
   });
 
-  test("clicking Restart resets to first step", async ({ page }) => {
+  test("clicking Try Again resets to first step", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const { url } = await createStaticActivity({
       steps: [
@@ -796,8 +796,8 @@ test.describe("Completion Screen", () => {
     await page.keyboard.press("ArrowRight");
     await expect(page.getByRole("status")).toBeVisible();
 
-    // Click Restart
-    await page.getByRole("button", { name: /restart/i }).click();
+    // Click Try Again
+    await page.getByRole("button", { name: /try again/i }).click();
 
     // Should be back at step 1
     await expect(

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -81,12 +81,6 @@ msgid "Game over."
 msgstr "Game over."
 
 #: ../../packages/player/src/components/challenge-completion.tsx
-#: ../../packages/player/src/components/completion-auth-branch.tsx
-msgctxt "7tB7n/"
-msgid "Back to Lesson"
-msgstr "Back to Lesson"
-
-#: ../../packages/player/src/components/challenge-completion.tsx
 msgctxt "a0e1mh"
 msgid "Challenge Complete"
 msgstr "Challenge Complete"
@@ -97,19 +91,30 @@ msgid "{names} dropped below zero."
 msgstr "{names} dropped below zero."
 
 #: ../../packages/player/src/components/challenge-completion.tsx
+#: ../../packages/player/src/components/completion-auth-branch.tsx
+msgctxt "CC/yEt"
+msgid "All Activities"
+msgstr "All Activities"
+
+#: ../../packages/player/src/components/challenge-completion.tsx
 msgctxt "EQISGX"
 msgid "{name} dropped to {value}."
 msgstr "{name} dropped to {value}."
 
 #: ../../packages/player/src/components/challenge-completion.tsx
+#: ../../packages/player/src/components/completion-auth-branch.tsx
+#: src/app/generate/a/[id]/generation-client.tsx
+#: src/app/generate/ch/[id]/generation-client.tsx
+#: src/app/generate/cs/[id]/generation-client.tsx
+#: src/app/generate/l/[id]/generation-client.tsx
+msgctxt "FazwRl"
+msgid "Try again"
+msgstr "Try again"
+
+#: ../../packages/player/src/components/challenge-completion.tsx
 msgctxt "gjP7K/"
 msgid "Final scores"
 msgstr "Final scores"
-
-#: ../../packages/player/src/components/challenge-completion.tsx
-msgctxt "jsy7pk"
-msgid "Try Again"
-msgstr "Try Again"
 
 #: ../../packages/player/src/components/challenge-completion.tsx
 msgctxt "me6E3h"
@@ -167,11 +172,6 @@ msgstr "Your scores"
 msgctxt "WPIaw8"
 msgid "You start at 0 in every score."
 msgstr "You start at 0 in every score."
-
-#: ../../packages/player/src/components/completion-auth-branch.tsx
-msgctxt "5kK+j9"
-msgid "Restart"
-msgstr "Restart"
 
 #: ../../packages/player/src/components/completion-auth-branch.tsx
 msgctxt "9+Ddtu"
@@ -1604,14 +1604,6 @@ msgstr "Create content for this activity"
 msgctxt "0LAuA1"
 msgid "Your activity is ready"
 msgstr "Your activity is ready"
-
-#: src/app/generate/a/[id]/generation-client.tsx
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
-msgctxt "FazwRl"
-msgid "Try again"
-msgstr "Try again"
 
 #: src/app/generate/a/[id]/generation-client.tsx
 #: src/app/generate/ch/[id]/generation-client.tsx

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -81,12 +81,6 @@ msgid "Game over."
 msgstr "Fin del juego."
 
 #: ../../packages/player/src/components/challenge-completion.tsx
-#: ../../packages/player/src/components/completion-auth-branch.tsx
-msgctxt "7tB7n/"
-msgid "Back to Lesson"
-msgstr "Volver a la lección"
-
-#: ../../packages/player/src/components/challenge-completion.tsx
 msgctxt "a0e1mh"
 msgid "Challenge Complete"
 msgstr "Desafío completado"
@@ -97,19 +91,30 @@ msgid "{names} dropped below zero."
 msgstr "{names} cayeron por debajo de cero."
 
 #: ../../packages/player/src/components/challenge-completion.tsx
+#: ../../packages/player/src/components/completion-auth-branch.tsx
+msgctxt "CC/yEt"
+msgid "All Activities"
+msgstr "Todas las Actividades"
+
+#: ../../packages/player/src/components/challenge-completion.tsx
 msgctxt "EQISGX"
 msgid "{name} dropped to {value}."
 msgstr "{name} cayó a {value}."
 
 #: ../../packages/player/src/components/challenge-completion.tsx
+#: ../../packages/player/src/components/completion-auth-branch.tsx
+#: src/app/generate/a/[id]/generation-client.tsx
+#: src/app/generate/ch/[id]/generation-client.tsx
+#: src/app/generate/cs/[id]/generation-client.tsx
+#: src/app/generate/l/[id]/generation-client.tsx
+msgctxt "FazwRl"
+msgid "Try again"
+msgstr "Intentar de nuevo"
+
+#: ../../packages/player/src/components/challenge-completion.tsx
 msgctxt "gjP7K/"
 msgid "Final scores"
 msgstr "Puntuaciones finales"
-
-#: ../../packages/player/src/components/challenge-completion.tsx
-msgctxt "jsy7pk"
-msgid "Try Again"
-msgstr "Intentar de nuevo"
 
 #: ../../packages/player/src/components/challenge-completion.tsx
 msgctxt "me6E3h"
@@ -167,11 +172,6 @@ msgstr "Tus puntajes"
 msgctxt "WPIaw8"
 msgid "You start at 0 in every score."
 msgstr "Empiezas en 0 en cada puntuación."
-
-#: ../../packages/player/src/components/completion-auth-branch.tsx
-msgctxt "5kK+j9"
-msgid "Restart"
-msgstr "Reiniciar"
 
 #: ../../packages/player/src/components/completion-auth-branch.tsx
 msgctxt "9+Ddtu"
@@ -1604,14 +1604,6 @@ msgstr "Crear contenido para esta actividad"
 msgctxt "0LAuA1"
 msgid "Your activity is ready"
 msgstr "Tu actividad está lista"
-
-#: src/app/generate/a/[id]/generation-client.tsx
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
-msgctxt "FazwRl"
-msgid "Try again"
-msgstr "Intentar de nuevo"
 
 #: src/app/generate/a/[id]/generation-client.tsx
 #: src/app/generate/ch/[id]/generation-client.tsx

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -81,12 +81,6 @@ msgid "Game over."
 msgstr "Fim de jogo."
 
 #: ../../packages/player/src/components/challenge-completion.tsx
-#: ../../packages/player/src/components/completion-auth-branch.tsx
-msgctxt "7tB7n/"
-msgid "Back to Lesson"
-msgstr "Voltar para a aula"
-
-#: ../../packages/player/src/components/challenge-completion.tsx
 msgctxt "a0e1mh"
 msgid "Challenge Complete"
 msgstr "Desafio Completo"
@@ -97,19 +91,30 @@ msgid "{names} dropped below zero."
 msgstr "{names} caíram abaixo de zero."
 
 #: ../../packages/player/src/components/challenge-completion.tsx
+#: ../../packages/player/src/components/completion-auth-branch.tsx
+msgctxt "CC/yEt"
+msgid "All Activities"
+msgstr "Todas as Atividades"
+
+#: ../../packages/player/src/components/challenge-completion.tsx
 msgctxt "EQISGX"
 msgid "{name} dropped to {value}."
 msgstr "{name} caiu para {value}."
 
 #: ../../packages/player/src/components/challenge-completion.tsx
+#: ../../packages/player/src/components/completion-auth-branch.tsx
+#: src/app/generate/a/[id]/generation-client.tsx
+#: src/app/generate/ch/[id]/generation-client.tsx
+#: src/app/generate/cs/[id]/generation-client.tsx
+#: src/app/generate/l/[id]/generation-client.tsx
+msgctxt "FazwRl"
+msgid "Try again"
+msgstr "Tentar de novo"
+
+#: ../../packages/player/src/components/challenge-completion.tsx
 msgctxt "gjP7K/"
 msgid "Final scores"
 msgstr "Pontuações finais"
-
-#: ../../packages/player/src/components/challenge-completion.tsx
-msgctxt "jsy7pk"
-msgid "Try Again"
-msgstr "Tentar novamente"
 
 #: ../../packages/player/src/components/challenge-completion.tsx
 msgctxt "me6E3h"
@@ -167,11 +172,6 @@ msgstr "Suas pontuações"
 msgctxt "WPIaw8"
 msgid "You start at 0 in every score."
 msgstr "A gente começa em 0 em cada pontuação."
-
-#: ../../packages/player/src/components/completion-auth-branch.tsx
-msgctxt "5kK+j9"
-msgid "Restart"
-msgstr "Reiniciar"
 
 #: ../../packages/player/src/components/completion-auth-branch.tsx
 msgctxt "9+Ddtu"
@@ -1604,14 +1604,6 @@ msgstr "Criar conteúdo para esta atividade"
 msgctxt "0LAuA1"
 msgid "Your activity is ready"
 msgstr "Sua atividade está pronta"
-
-#: src/app/generate/a/[id]/generation-client.tsx
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
-msgctxt "FazwRl"
-msgid "Try again"
-msgstr "Tentar novamente"
 
 #: src/app/generate/a/[id]/generation-client.tsx
 #: src/app/generate/ch/[id]/generation-client.tsx

--- a/i18n.lock
+++ b/i18n.lock
@@ -208,9 +208,9 @@ checksums:
     "%7Bvalue%7D%20BP%20to%20level%20up/singular": 755c2fe6e435645cb35b57bf92af09d3
     "%7Bcolor%7D%20Belt%20%E2%80%94%20Level%20%7Blevel%7D/singular": 367f2e902d39199c8507aaad09e8907a
     Game%20over./singular: 7f7c4f4404b868e6062363dfffd9adf7
-    Back%20to%20Lesson/singular: e2dbef5a2fefae8f9cee708e53e61cb9
     Challenge%20Complete/singular: 7854472cc9245aaa8a13f54514968506
     "%7Bnames%7D%20dropped%20below%20zero./singular": 36735509d5747d09d3519324aa0f1493
+    All%20Activities/singular: 9eee26b7ca58444c6d0db6bcd7ea7eda
     "%7Bname%7D%20dropped%20to%20%7Bvalue%7D./singular": 95e21895ac0d6fa49a9a2117ccd8fd6a
     Final%20scores/singular: e772441fda83e82c2101876fee323481
     Try%20Again/singular: d65fad81c5f8f90405b26bf6e5d70ab9
@@ -225,7 +225,6 @@ checksums:
     Each%20choice%20raises%20some%20scores%20and%20lowers%20others./singular: f2fe298b9617dcbd9b1783eeb47acfcb
     Your%20scores/singular: 1700f65ead0647bc4876f4b3b6453a8b
     You%20start%20at%200%20in%20every%20score./singular: ef7c9e35b5b066d492618fcaec8eef46
-    Restart/singular: bab6232e89f24e3129f8e48268739d5b
     Next/singular: 89ddbcf710eba274963494f312bdc8a9
     Login/singular: f4f219abeb5a465ecb1c7efaf50246de
     Sign%20up%20to%20track%20your%20progress/singular: 554ed29d9b8a243362c3b3374222af08

--- a/packages/player/src/components/challenge-completion.tsx
+++ b/packages/player/src/components/challenge-completion.tsx
@@ -167,7 +167,7 @@ export function ChallengeFailureContent({
 
       <ChallengeActions>
         <Button className="w-full lg:justify-between" onClick={onRestart} size="lg">
-          {t("Try Again")}
+          {t("Try again")}
           <Kbd className="bg-primary-foreground/15 text-primary-foreground hidden opacity-70 lg:inline-flex">
             R
           </Kbd>
@@ -177,7 +177,7 @@ export function ChallengeFailureContent({
           className={cn(buttonVariants({ variant: "outline" }), "w-full lg:justify-between")}
           href={lessonHref}
         >
-          {t("Back to Lesson")}
+          {t("All Activities")}
           <Kbd className="hidden opacity-60 lg:inline-flex">Esc</Kbd>
         </Link>
       </ChallengeActions>

--- a/packages/player/src/components/completion-auth-branch.tsx
+++ b/packages/player/src/components/completion-auth-branch.tsx
@@ -46,7 +46,7 @@ function SecondaryActions({
       )}
       href={lessonHref}
     >
-      {t("Back to Lesson")}
+      {t("All Activities")}
       <Kbd
         className={cn(
           "hidden lg:inline-flex",
@@ -64,7 +64,7 @@ function SecondaryActions({
       onClick={onRestart}
       variant="outline"
     >
-      {t("Restart")}
+      {t("Try again")}
       <Kbd className="hidden opacity-60 lg:inline-flex">R</Kbd>
     </Button>
   );


### PR DESCRIPTION
## Summary

- Rename "Back to Lesson" to "All Activities" — describes the destination (activity list) instead of ambiguous "lesson"
- Rename "Restart" to "Try again" — scopes clearly to the current activity, consistent with the challenge failure screen
- Consolidate "Try Again" (title case) and "Try again" (sentence case) into a single "Try again" string across all usages

## Test plan

- [ ] Complete an activity and verify "All Activities" and "Try again" labels appear
- [ ] Verify "All Activities" navigates to the lesson detail page (activity list)
- [ ] Verify "Try again" restarts the current activity
- [ ] Verify challenge failure screen still shows "Try again"
- [ ] Check PT and ES translations render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the player completion screen. “Back to Lesson” is now “All Activities” and “Restart” is “Try again”, with casing unified for consistency.

- **Bug Fixes**
  - Updated `packages/player` components (`challenge-completion.tsx`, `completion-auth-branch.tsx`) to use the new labels.
  - Synced EN/ES/PT translations and updated `i18n.lock`.
  - Adjusted E2E tests to expect “All Activities” and “Try again”.

<sup>Written for commit fa3294961718afab18ca798d6d4851a73533dc7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

