### PR TITLE
feat(main): navigate to next lesson/chapter when scope is completed

### DIFF
--- a/apps/main/e2e/continue-activity-link.test.ts
+++ b/apps/main/e2e/continue-activity-link.test.ts
@@ -221,4 +221,156 @@ test.describe("Continue Activity Link", () => {
     const continueLink = authenticatedPage.getByRole("link", { name: /^continue$/i });
     await expect(continueLink).toBeVisible();
   });
+
+  test("lesson page shows Continue linking to next lesson when completed", async ({
+    authenticatedPage,
+    withProgressUser,
+  }) => {
+    const { activity, chapter, course, lesson, org } = await createTestCourseWithActivity();
+
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const nextLesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: org.id,
+      position: 1,
+      slug: `e2e-cal-next-l-${uniqueId}`,
+      title: `E2E CAL Next Lesson ${uniqueId}`,
+    });
+
+    await activityFixture({
+      generationStatus: "completed",
+      isPublished: true,
+      kind: "explanation",
+      lessonId: nextLesson.id,
+      organizationId: org.id,
+      position: 0,
+    });
+
+    await activityProgressFixture({
+      activityId: activity.id,
+      completedAt: new Date(),
+      durationSeconds: 60,
+      userId: withProgressUser.id,
+    });
+
+    await authenticatedPage.goto(
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`,
+    );
+
+    const continueLink = authenticatedPage.getByRole("link", { name: /^continue$/i });
+    await expect(continueLink).toBeVisible();
+    await expect(continueLink).toHaveAttribute(
+      "href",
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${nextLesson.slug}`,
+    );
+  });
+
+  test("chapter page shows Continue linking to next chapter when completed", async ({
+    authenticatedPage,
+    withProgressUser,
+  }) => {
+    const org = await getAiOrganization();
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: org.id,
+      slug: `e2e-cal-chcomp-${uniqueId}`,
+      title: `E2E CAL ChComp ${uniqueId}`,
+    });
+
+    const [chapter1, chapter2] = await Promise.all([
+      chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        organizationId: org.id,
+        position: 0,
+        slug: `e2e-cal-chcomp-ch1-${uniqueId}`,
+        title: `E2E CAL ChComp Ch1 ${uniqueId}`,
+      }),
+      chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        organizationId: org.id,
+        position: 1,
+        slug: `e2e-cal-chcomp-ch2-${uniqueId}`,
+        title: `E2E CAL ChComp Ch2 ${uniqueId}`,
+      }),
+    ]);
+
+    const [lesson1, lesson2] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter1.id,
+        isPublished: true,
+        organizationId: org.id,
+        position: 0,
+        slug: `e2e-cal-chcomp-l1-${uniqueId}`,
+        title: `E2E CAL ChComp L1 ${uniqueId}`,
+      }),
+      lessonFixture({
+        chapterId: chapter2.id,
+        isPublished: true,
+        organizationId: org.id,
+        position: 0,
+        slug: `e2e-cal-chcomp-l2-${uniqueId}`,
+        title: `E2E CAL ChComp L2 ${uniqueId}`,
+      }),
+    ]);
+
+    const [activity1] = await Promise.all([
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "explanation",
+        lessonId: lesson1.id,
+        organizationId: org.id,
+        position: 0,
+      }),
+      activityFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "explanation",
+        lessonId: lesson2.id,
+        organizationId: org.id,
+        position: 0,
+      }),
+    ]);
+
+    await activityProgressFixture({
+      activityId: activity1.id,
+      completedAt: new Date(),
+      durationSeconds: 60,
+      userId: withProgressUser.id,
+    });
+
+    await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter1.slug}`);
+
+    const continueLink = authenticatedPage.getByRole("link", { name: /^continue$/i });
+    await expect(continueLink).toBeVisible();
+    await expect(continueLink).toHaveAttribute(
+      "href",
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter2.slug}`,
+    );
+  });
+
+  test("course page shows Review when all activities completed", async ({
+    authenticatedPage,
+    withProgressUser,
+  }) => {
+    const { activity, course } = await createTestCourseWithActivity();
+
+    await activityProgressFixture({
+      activityId: activity.id,
+      completedAt: new Date(),
+      durationSeconds: 60,
+      userId: withProgressUser.id,
+    });
+
+    await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
+
+    const reviewLink = authenticatedPage.getByRole("link", { name: /^review$/i });
+    await expect(reviewLink).toBeVisible();
+  });
 });

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/catalog/continue-activity-link";
 import { listLessonActivities } from "@/data/activities/list-lesson-activities";
 import { getLesson } from "@/data/lessons/get-lesson";
+import { getNextSibling } from "@/data/progress/get-next-sibling";
 import { getSession } from "@zoonk/core/users/session/get";
 import { type Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
@@ -51,11 +52,24 @@ export default async function LessonPage({
     notFound();
   }
 
-  const activities = await listLessonActivities({ lessonId: lesson.id });
+  const [activities, nextSibling] = await Promise.all([
+    listLessonActivities({ lessonId: lesson.id }),
+    getNextSibling({
+      chapterId: lesson.chapter.id,
+      chapterPosition: lesson.chapter.position,
+      courseId: lesson.chapter.courseId,
+      lessonPosition: lesson.position,
+      level: "lesson",
+    }),
+  ]);
 
   if (activities.length === 0) {
     redirect(`/generate/l/${lesson.id}`);
   }
+
+  const completedHref = nextSibling
+    ? (`/b/${nextSibling.brandSlug}/c/${nextSibling.courseSlug}/ch/${nextSibling.chapterSlug}/l/${nextSibling.lessonSlug}` as const)
+    : undefined;
 
   return (
     <main className="flex flex-1 flex-col">
@@ -70,6 +84,7 @@ export default async function LessonPage({
         <CatalogToolbar>
           <Suspense fallback={<ContinueActivityLinkSkeleton />}>
             <ContinueActivityLink
+              completedHref={completedHref}
               fallbackHref={`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}/a/${activities[0]?.position}`}
               lessonId={lesson.id}
             />

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/catalog/continue-activity-link";
 import { getChapter } from "@/data/chapters/get-chapter";
 import { listChapterLessons } from "@/data/lessons/list-chapter-lessons";
+import { getNextSibling } from "@/data/progress/get-next-sibling";
 import { getSession } from "@zoonk/core/users/session/get";
 import { type Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
@@ -49,11 +50,22 @@ export default async function ChapterPage({
     notFound();
   }
 
-  const lessons = await listChapterLessons({ chapterId: chapter.id });
+  const [lessons, nextSibling] = await Promise.all([
+    listChapterLessons({ chapterId: chapter.id }),
+    getNextSibling({
+      chapterPosition: chapter.position,
+      courseId: chapter.courseId,
+      level: "chapter",
+    }),
+  ]);
 
   if (lessons.length === 0) {
     redirect(`/generate/ch/${chapter.id}`);
   }
+
+  const completedHref = nextSibling
+    ? (`/b/${nextSibling.brandSlug}/c/${nextSibling.courseSlug}/ch/${nextSibling.chapterSlug}` as const)
+    : undefined;
 
   return (
     <main className="flex flex-1 flex-col">
@@ -64,6 +76,7 @@ export default async function ChapterPage({
           <Suspense fallback={<ContinueActivityLinkSkeleton />}>
             <ContinueActivityLink
               chapterId={chapter.id}
+              completedHref={completedHref}
               fallbackHref={`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessons[0]?.slug}`}
             />
           </Suspense>

--- a/apps/main/src/components/catalog/continue-activity-link.tsx
+++ b/apps/main/src/components/catalog/continue-activity-link.tsx
@@ -23,13 +23,15 @@ function getScope(props: {
   return { lessonId: props.lessonId ?? 0 };
 }
 
-export async function ContinueActivityLink<Href extends string>({
+export async function ContinueActivityLink<Href extends string, CompletedHref extends string>({
   chapterId,
+  completedHref,
   courseId,
   fallbackHref,
   lessonId,
 }: {
   chapterId?: number;
+  completedHref?: Route<CompletedHref>;
   courseId?: number;
   fallbackHref: Route<Href>;
   lessonId?: number;
@@ -49,7 +51,7 @@ export async function ContinueActivityLink<Href extends string>({
 
   const getLabel = () => {
     if (data.completed) {
-      return t("Review");
+      return completedHref ? t("Continue") : t("Review");
     }
 
     if (data.hasStarted) {
@@ -58,6 +60,15 @@ export async function ContinueActivityLink<Href extends string>({
 
     return t("Start");
   };
+
+  if (data.completed && completedHref) {
+    return (
+      <Link className={cn(buttonVariants(), "min-w-0 flex-1 gap-2")} href={completedHref}>
+        {getLabel()}
+        <ChevronRightIcon aria-hidden="true" />
+      </Link>
+    );
+  }
 
   return (
     <Link

--- a/apps/main/src/data/progress/get-next-sibling.test.ts
+++ b/apps/main/src/data/progress/get-next-sibling.test.ts
@@ -1,0 +1,253 @@
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, describe, expect, test } from "vitest";
+import { getNextSibling } from "./get-next-sibling";
+
+describe("getNextSibling - lesson level", () => {
+  let orgSlug: string;
+  let courseId: number;
+  let courseSlug: string;
+
+  let chapter1Id: number;
+  let chapter1Position: number;
+  let chapter2Id: number;
+  let chapter2Position: number;
+  let chapter2Slug: string;
+
+  let lesson1Position: number;
+  let lesson2Slug: string;
+  let lesson3Position: number;
+  let lesson3Slug: string;
+
+  beforeAll(async () => {
+    const org = await organizationFixture({ kind: "brand" });
+    orgSlug = org.slug;
+
+    const course = await courseFixture({ isPublished: true, organizationId: org.id });
+    courseId = course.id;
+    courseSlug = course.slug;
+
+    const [ch1, ch2] = await Promise.all([
+      chapterFixture({ courseId, isPublished: true, organizationId: org.id, position: 0 }),
+      chapterFixture({ courseId, isPublished: true, organizationId: org.id, position: 1 }),
+    ]);
+
+    chapter1Id = ch1.id;
+    chapter1Position = ch1.position;
+    chapter2Id = ch2.id;
+    chapter2Position = ch2.position;
+    chapter2Slug = ch2.slug;
+
+    const [ls1, ls2] = await Promise.all([
+      lessonFixture({ chapterId: ch1.id, isPublished: true, organizationId: org.id, position: 0 }),
+      lessonFixture({ chapterId: ch1.id, isPublished: true, organizationId: org.id, position: 1 }),
+    ]);
+
+    lesson1Position = ls1.position;
+    lesson2Slug = ls2.slug;
+
+    const ls3 = await lessonFixture({
+      chapterId: ch2.id,
+      isPublished: true,
+      organizationId: org.id,
+      position: 0,
+    });
+
+    lesson3Position = ls3.position;
+    lesson3Slug = ls3.slug;
+  });
+
+  test("returns next lesson in same chapter", async () => {
+    const result = await getNextSibling({
+      chapterId: chapter1Id,
+      chapterPosition: chapter1Position,
+      courseId,
+      lessonPosition: lesson1Position,
+      level: "lesson",
+    });
+
+    expect(result).toEqual({
+      brandSlug: orgSlug,
+      chapterSlug: expect.any(String),
+      courseSlug,
+      lessonSlug: lesson2Slug,
+    });
+  });
+
+  test("returns first lesson of next chapter when last in current chapter", async () => {
+    const result = await getNextSibling({
+      chapterId: chapter1Id,
+      chapterPosition: chapter1Position,
+      courseId,
+      lessonPosition: 1,
+      level: "lesson",
+    });
+
+    expect(result).toEqual({
+      brandSlug: orgSlug,
+      chapterSlug: chapter2Slug,
+      courseSlug,
+      lessonSlug: lesson3Slug,
+    });
+  });
+
+  test("returns null when last lesson in course", async () => {
+    const result = await getNextSibling({
+      chapterId: chapter2Id,
+      chapterPosition: chapter2Position,
+      courseId,
+      lessonPosition: lesson3Position,
+      level: "lesson",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("skips unpublished lessons and chapters", async () => {
+    const org = await organizationFixture({ kind: "brand" });
+    const course = await courseFixture({ isPublished: true, organizationId: org.id });
+
+    const [pubCh, , nextPubCh] = await Promise.all([
+      chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        organizationId: org.id,
+        position: 0,
+      }),
+      chapterFixture({
+        courseId: course.id,
+        isPublished: false,
+        organizationId: org.id,
+        position: 1,
+      }),
+      chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        organizationId: org.id,
+        position: 2,
+      }),
+    ]);
+
+    const [currentLesson, , nextLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: pubCh.id,
+        isPublished: true,
+        organizationId: org.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: pubCh.id,
+        isPublished: false,
+        organizationId: org.id,
+        position: 1,
+      }),
+      lessonFixture({
+        chapterId: nextPubCh.id,
+        isPublished: true,
+        organizationId: org.id,
+        position: 0,
+      }),
+    ]);
+
+    const result = await getNextSibling({
+      chapterId: pubCh.id,
+      chapterPosition: pubCh.position,
+      courseId: course.id,
+      lessonPosition: currentLesson.position,
+      level: "lesson",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        lessonSlug: nextLesson.slug,
+      }),
+    );
+  });
+});
+
+describe("getNextSibling - chapter level", () => {
+  let orgSlug: string;
+  let courseId: number;
+  let courseSlug: string;
+  let chapter2Slug: string;
+
+  beforeAll(async () => {
+    const org = await organizationFixture({ kind: "brand" });
+    orgSlug = org.slug;
+
+    const course = await courseFixture({ isPublished: true, organizationId: org.id });
+    courseId = course.id;
+    courseSlug = course.slug;
+
+    const [, ch2] = await Promise.all([
+      chapterFixture({ courseId, isPublished: true, organizationId: org.id, position: 0 }),
+      chapterFixture({ courseId, isPublished: true, organizationId: org.id, position: 1 }),
+    ]);
+
+    chapter2Slug = ch2.slug;
+  });
+
+  test("returns next chapter in course", async () => {
+    const result = await getNextSibling({
+      chapterPosition: 0,
+      courseId,
+      level: "chapter",
+    });
+
+    expect(result).toEqual({
+      brandSlug: orgSlug,
+      chapterSlug: chapter2Slug,
+      courseSlug,
+    });
+  });
+
+  test("returns null when last chapter", async () => {
+    const result = await getNextSibling({
+      chapterPosition: 1,
+      courseId,
+      level: "chapter",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("skips unpublished chapters", async () => {
+    const org = await organizationFixture({ kind: "brand" });
+    const course = await courseFixture({ isPublished: true, organizationId: org.id });
+
+    const chapters = await Promise.all([
+      chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        organizationId: org.id,
+        position: 0,
+      }),
+      chapterFixture({
+        courseId: course.id,
+        isPublished: false,
+        organizationId: org.id,
+        position: 1,
+      }),
+      chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        organizationId: org.id,
+        position: 2,
+      }),
+    ]);
+
+    const result = await getNextSibling({
+      chapterPosition: 0,
+      courseId: course.id,
+      level: "chapter",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        chapterSlug: chapters[2]?.slug,
+      }),
+    );
+  });
+});

--- a/apps/main/src/data/progress/get-next-sibling.ts
+++ b/apps/main/src/data/progress/get-next-sibling.ts
@@ -1,0 +1,109 @@
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+
+type LessonScope = {
+  chapterId: number;
+  chapterPosition: number;
+  courseId: number;
+  lessonPosition: number;
+  level: "lesson";
+};
+
+type ChapterScope = {
+  chapterPosition: number;
+  courseId: number;
+  level: "chapter";
+};
+
+type LessonResult = {
+  brandSlug: string;
+  chapterSlug: string;
+  courseSlug: string;
+  lessonSlug: string;
+};
+
+type ChapterResult = {
+  brandSlug: string;
+  chapterSlug: string;
+  courseSlug: string;
+};
+
+async function getNextLessonSibling(scope: LessonScope): Promise<LessonResult | null> {
+  const { data: lesson, error } = await safeAsync(() =>
+    prisma.lesson.findFirst({
+      include: {
+        chapter: {
+          include: {
+            course: { include: { organization: true } },
+          },
+        },
+      },
+      orderBy: [{ chapter: { position: "asc" } }, { position: "asc" }],
+      where: {
+        OR: [
+          {
+            chapter: { id: scope.chapterId },
+            position: { gt: scope.lessonPosition },
+          },
+          {
+            chapter: { position: { gt: scope.chapterPosition } },
+          },
+        ],
+        chapter: {
+          course: { id: scope.courseId },
+          isPublished: true,
+        },
+        isPublished: true,
+      },
+    }),
+  );
+
+  if (error || !lesson) {
+    return null;
+  }
+
+  return {
+    brandSlug: lesson.chapter.course.organization?.slug ?? "",
+    chapterSlug: lesson.chapter.slug,
+    courseSlug: lesson.chapter.course.slug,
+    lessonSlug: lesson.slug,
+  };
+}
+
+async function getNextChapterSibling(scope: ChapterScope): Promise<ChapterResult | null> {
+  const { data: chapter, error } = await safeAsync(() =>
+    prisma.chapter.findFirst({
+      include: {
+        course: { include: { organization: true } },
+      },
+      orderBy: { position: "asc" },
+      where: {
+        courseId: scope.courseId,
+        isPublished: true,
+        position: { gt: scope.chapterPosition },
+      },
+    }),
+  );
+
+  if (error || !chapter) {
+    return null;
+  }
+
+  return {
+    brandSlug: chapter.course.organization?.slug ?? "",
+    chapterSlug: chapter.slug,
+    courseSlug: chapter.course.slug,
+  };
+}
+
+export function getNextSibling(scope: LessonScope): Promise<LessonResult | null>;
+export function getNextSibling(scope: ChapterScope): Promise<ChapterResult | null>;
+export function getNextSibling(
+  scope: LessonScope | ChapterScope,
+): Promise<LessonResult | ChapterResult | null> {
+  if (scope.level === "lesson") {
+    return getNextLessonSibling(scope);
+  }
+
+  return getNextChapterSibling(scope);
+}


### PR DESCRIPTION
## Summary

- When a user completes all activities in a lesson, the continue button now links to the **next lesson** (or next chapter if last lesson) instead of showing "Review"
- When a user completes all activities in a chapter, the continue button links to the **next chapter** instead of showing "Review"
- Course page behavior unchanged — still shows "Review" since there's no concept of "next course"

## Changes

- New `getNextSibling` data function with discriminated union scope (lesson-level and chapter-level queries)
- Added `completedHref` prop to `ContinueActivityLink` — when provided and scope is completed, renders "Continue" linking to the next sibling instead of "Review" linking back to start
- Lesson and chapter pages compute the next sibling URL and pass it down

## Test plan

- [x] Integration tests for `getNextSibling` (7 cases: next in same chapter, cross-chapter, null at end, skip unpublished)
- [x] E2E tests for lesson/chapter/course completion behavior (3 new tests)
- [x] All existing e2e tests pass across main, editor, and api apps


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Continue now takes users to the next published lesson or chapter when they finish a lesson/chapter, instead of showing "Review". Course pages are unchanged and still show "Review".

- **New Features**
  - Added `getNextSibling` to find the next published lesson/chapter, skipping unpublished items.
  - `ContinueActivityLink` now accepts `completedHref` and shows "Continue" to the next sibling when completed.
  - Lesson and chapter pages compute `completedHref` via `getNextSibling` and pass it to `ContinueActivityLink`.

<sup>Written for commit 7d42941bc9212ac94813b6e422f234ebdab9943a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

