### PR TITLE
fix(player): improve mobile spacing for reading steps

### DIFF
--- a/packages/player/src/components/player-bottom-bar.tsx
+++ b/packages/player/src/components/player-bottom-bar.tsx
@@ -10,7 +10,7 @@ export function PlayerBottomBar({ className, ...props }: React.ComponentProps<"d
     <div
       className={cn(
         "bg-background/95 sticky bottom-0 z-30 backdrop-blur-sm",
-        "mx-auto w-full max-w-2xl px-6 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]",
+        "mx-auto w-full max-w-2xl p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]",
         className,
       )}
       data-slot="player-bottom-bar"

--- a/packages/player/src/components/static-step.tsx
+++ b/packages/player/src/components/static-step.tsx
@@ -88,7 +88,7 @@ export function StaticStep({
 
   return (
     <div
-      className="relative flex min-h-0 w-full max-w-2xl flex-1 flex-col items-start justify-center gap-3 px-6 sm:px-8"
+      className="relative flex min-h-0 w-full max-w-2xl flex-1 flex-col items-start justify-center gap-3 px-8 sm:px-10"
       {...swipeHandlers}
     >
       <StaticStepContent step={step} />

--- a/packages/player/src/components/visual-step.tsx
+++ b/packages/player/src/components/visual-step.tsx
@@ -13,7 +13,7 @@ export function VisualStep({ step }: { step: SerializedStep }) {
     <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
       <div
         aria-label={t("Visual content")}
-        className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain px-6 py-6 sm:px-8 sm:py-8"
+        className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain px-8 py-6 sm:px-10 sm:py-8"
         role="region"
       >
         <div className="flex min-h-full w-full min-w-0 items-center justify-center">

--- a/packages/player/src/components/vocabulary-step.tsx
+++ b/packages/player/src/components/vocabulary-step.tsx
@@ -29,7 +29,7 @@ export function VocabularyStep({
   return (
     <div
       aria-label={`${t("Vocabulary")}: ${word.word}`}
-      className="flex w-full max-w-2xl flex-1 flex-col items-start justify-center px-10 sm:px-16"
+      className="flex w-full max-w-2xl flex-1 flex-col items-start justify-center px-8 sm:px-10"
       role="region"
       {...swipeHandlers}
     >


### PR DESCRIPTION
## Summary
- Increase horizontal padding on static and visual steps from `px-6` to `px-8` for better reading comfort on mobile
- Normalize vocabulary step padding from `px-10` (outlier) to `px-8` for consistency
- Simplify bottom bar padding to uniform `p-3`

## Test plan
- [ ] Open a static step on mobile — text should have more breathing room from edges
- [ ] Open a visual step on mobile — same improved spacing
- [ ] Open a vocabulary step on mobile — spacing should feel consistent with other steps
- [ ] Verify bottom bar aligns well with header close button
- [ ] Interactive steps should be unchanged (tighter padding is intentional for tap targets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve mobile reading comfort in `packages/player` by increasing horizontal padding on reading steps and simplifying the bottom bar spacing. Static/visual steps go from px-6→px-8 (sm: px-10), vocabulary from px-10→px-8 (sm: px-10), and the bottom bar uses uniform p-3 with safe-area padding preserved.

<sup>Written for commit b69d735b83a29ca6989770942a5d0f43a3b1b17f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

