### PR TITLE
fix(main): show pending courses in continue learning and fix hero condition

### DIFF
--- a/apps/main/e2e/continue-learning-revalidation.test.ts
+++ b/apps/main/e2e/continue-learning-revalidation.test.ts
@@ -5,6 +5,7 @@ import { activityFixture, activityProgressFixture } from "@zoonk/testing/fixture
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { userProgressFixture } from "@zoonk/testing/fixtures/progress";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { expect, test } from "./fixtures";
 
@@ -100,6 +101,7 @@ test.describe("Continue Learning Revalidation", () => {
         durationSeconds: 60,
         userId: user.id,
       }),
+      userProgressFixture({ totalBrainPower: 100n, userId: user.id }),
       prisma.courseUser.create({ data: { courseId: course.id, userId: user.id } }),
       prisma.course.update({
         data: { userCount: { increment: 1 } },

--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -1,3 +1,11 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { createE2EUser, getAiOrganization } from "@zoonk/e2e/helpers";
+import { activityFixture, activityProgressFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { userProgressFixture } from "@zoonk/testing/fixtures/progress";
 import { expect, test } from "./fixtures";
 
 test.describe("Home Page - Unauthenticated", () => {
@@ -51,6 +59,80 @@ test.describe("Home Page - Authenticated", () => {
         name: /learn anything with ai/i,
       }),
     ).toBeVisible();
+  });
+
+  test("shows pending course when next lesson has no generated activities", async ({
+    baseURL,
+    browser,
+  }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const org = await getAiOrganization();
+    const user = await createE2EUser(baseURL!);
+
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: org.id,
+      slug: `e2e-pending-course-${uniqueId}`,
+      title: `E2E Pending Course ${uniqueId}`,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: org.id,
+      position: 0,
+    });
+
+    const lesson1 = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: org.id,
+      position: 0,
+    });
+
+    await lessonFixture({
+      chapterId: chapter.id,
+      description: `E2E Pending Lesson Description ${uniqueId}`,
+      generationStatus: "pending",
+      isPublished: true,
+      organizationId: org.id,
+      position: 1,
+      title: `E2E Pending Lesson ${uniqueId}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "completed",
+      isPublished: true,
+      lessonId: lesson1.id,
+      organizationId: org.id,
+      position: 0,
+    });
+
+    await Promise.all([
+      activityProgressFixture({
+        activityId: activity.id,
+        completedAt: new Date(),
+        durationSeconds: 60,
+        userId: user.id,
+      }),
+      userProgressFixture({ totalBrainPower: 100n, userId: user.id }),
+      prisma.courseUser.create({ data: { courseId: course.id, userId: user.id } }),
+    ]);
+
+    const ctx = await browser.newContext({ storageState: user.storageState });
+    const page = await ctx.newPage();
+
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { name: /continue learning/i }).first()).toBeVisible();
+
+    await expect(page.getByRole("heading", { name: /learn anything with ai/i })).not.toBeVisible();
+
+    await expect(page.getByRole("link", { name: /continue/i }).first()).toBeVisible();
+    await expect(page.getByText(new RegExp(`E2E Pending Course ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`E2E Pending Lesson ${uniqueId}`))).toBeVisible();
+
+    await ctx.close();
   });
 });
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -368,6 +368,7 @@ msgid "Activity progress"
 msgstr "Activity progress"
 
 #: ../../packages/player/src/components/player-shell.tsx
+#: src/app/(catalog)/(home)/continue-learning-card.tsx
 #: src/components/catalog/continue-activity-link.tsx
 msgctxt "acrOoz"
 msgid "Continue"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -368,6 +368,7 @@ msgid "Activity progress"
 msgstr "Progreso de actividad"
 
 #: ../../packages/player/src/components/player-shell.tsx
+#: src/app/(catalog)/(home)/continue-learning-card.tsx
 #: src/components/catalog/continue-activity-link.tsx
 msgctxt "acrOoz"
 msgid "Continue"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -368,6 +368,7 @@ msgid "Activity progress"
 msgstr "Progresso da atividade"
 
 #: ../../packages/player/src/components/player-shell.tsx
+#: src/app/(catalog)/(home)/continue-learning-card.tsx
 #: src/components/catalog/continue-activity-link.tsx
 msgctxt "acrOoz"
 msgid "Continue"

--- a/apps/main/src/app/(catalog)/(home)/continue-learning-card.tsx
+++ b/apps/main/src/app/(catalog)/(home)/continue-learning-card.tsx
@@ -20,25 +20,43 @@ import { getExtracted } from "next-intl/server";
 import Image from "next/image";
 import Link from "next/link";
 
-function getCourseHrefs(item: ContinueLearningItem) {
-  const { activity, chapter, course, lesson } = item;
+async function getHeaderLabel(item: ContinueLearningItem, kindLabels: Map<string, string>) {
+  const t = await getExtracted();
 
-  if (course.organization) {
-    const lessonHref =
-      `/b/${course.organization.slug}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}` as const;
+  if (item.status === "pending") {
+    return t("Continue");
+  }
 
+  const defaultLabel = t("Activity");
+  const activityLabel = item.activity.title ?? kindLabels.get(item.activity.kind) ?? defaultLabel;
+
+  return t("Next: {activity}", { activity: activityLabel });
+}
+
+function getHrefs(item: ContinueLearningItem) {
+  const { chapter, course, lesson } = item;
+
+  if (!course.organization) {
+    const href = `/p/${course.id}` as const;
+    return { courseHref: href, headerHref: href, lessonHref: href, prefetch: false };
+  }
+
+  const courseHref = `/b/${course.organization.slug}/c/${course.slug}` as const;
+
+  const lessonHref = lesson
+    ? (`/b/${course.organization.slug}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}` as const)
+    : (`/b/${course.organization.slug}/c/${course.slug}/ch/${chapter.slug}` as const);
+
+  if (item.status === "completed") {
     return {
-      activityHref: `${lessonHref}/a/${activity.position}` as const,
-      courseHref: `/b/${course.organization.slug}/c/${course.slug}` as const,
+      courseHref,
+      headerHref: `${lessonHref}/a/${item.activity.position}` as const,
       lessonHref,
+      prefetch: true,
     };
   }
 
-  return {
-    activityHref: `/p/${course.id}` as const,
-    courseHref: `/p/${course.id}` as const,
-    lessonHref: `/p/${course.id}` as const,
-  };
+  return { courseHref, headerHref: lessonHref, lessonHref, prefetch: false };
 }
 
 export async function ContinueLearningCard({
@@ -48,31 +66,26 @@ export async function ContinueLearningCard({
   item: ContinueLearningItem;
   kindLabels: Map<string, string>;
 }) {
-  const t = await getExtracted();
-  const { activity, course, lesson } = item;
-
-  const defaultLabel = t("Activity");
-  const activityLabel = activity.title ?? kindLabels.get(activity.kind) ?? defaultLabel;
-  const nextLabel = t("Next: {activity}", { activity: activityLabel });
-
-  const { activityHref, courseHref, lessonHref } = getCourseHrefs(item);
+  const { course, lesson } = item;
+  const headerLabel = await getHeaderLabel(item, kindLabels);
+  const { courseHref, headerHref, lessonHref, prefetch } = getHrefs(item);
 
   return (
     <FeatureCard>
-      <Link href={activityHref} prefetch>
+      <Link href={headerHref} prefetch={prefetch}>
         <FeatureCardHeader>
           <FeatureCardHeaderContent>
             <FeatureCardIcon>
               <PlayCircleIcon />
             </FeatureCardIcon>
-            <FeatureCardLabel>{nextLabel}</FeatureCardLabel>
+            <FeatureCardLabel>{headerLabel}</FeatureCardLabel>
           </FeatureCardHeaderContent>
           <FeatureCardIndicator />
         </FeatureCardHeader>
       </Link>
 
       <FeatureCardContent>
-        <Link href={activityHref} prefetch>
+        <Link href={headerHref} prefetch={prefetch}>
           <FeatureCardThumbnail size="lg">
             {course.imageUrl ? (
               <FeatureCardThumbnailImage>
@@ -93,19 +106,29 @@ export async function ContinueLearningCard({
         </Link>
 
         <FeatureCardBody>
-          <FeatureCardTitle>
-            <Link href={lessonHref} prefetch>
-              {lesson.title}
-            </Link>
-          </FeatureCardTitle>
+          {lesson ? (
+            <>
+              <FeatureCardTitle>
+                <Link href={lessonHref} prefetch={prefetch}>
+                  {lesson.title}
+                </Link>
+              </FeatureCardTitle>
 
-          <FeatureCardSubtitle>
-            <Link href={courseHref} prefetch>
-              {course.title}
-            </Link>
-          </FeatureCardSubtitle>
+              <FeatureCardSubtitle>
+                <Link href={courseHref} prefetch>
+                  {course.title}
+                </Link>
+              </FeatureCardSubtitle>
 
-          <FeatureCardDescription>{lesson.description}</FeatureCardDescription>
+              <FeatureCardDescription>{lesson.description}</FeatureCardDescription>
+            </>
+          ) : (
+            <FeatureCardTitle>
+              <Link href={courseHref} prefetch>
+                {course.title}
+              </Link>
+            </FeatureCardTitle>
+          )}
         </FeatureCardBody>
       </FeatureCardContent>
     </FeatureCard>

--- a/apps/main/src/app/(catalog)/(home)/continue-learning.tsx
+++ b/apps/main/src/app/(catalog)/(home)/continue-learning.tsx
@@ -1,6 +1,7 @@
 import {
   type ContinueLearningItem,
   MAX_CONTINUE_LEARNING_ITEMS,
+  getContinueLearning,
 } from "@/data/courses/get-continue-learning";
 import { getActivityKinds } from "@/lib/activities";
 import {
@@ -47,14 +48,20 @@ function ContinueLearningLayout({
   );
 }
 
-export async function ContinueLearningList({ items }: { items: ContinueLearningItem[] }) {
+export async function ContinueLearningList() {
+  const items = await getContinueLearning();
+
+  if (items.length === 0) {
+    return null;
+  }
+
   const t = await getExtracted();
   const activityKinds = await getActivityKinds();
   const itemCount = items.length;
 
   const kindLabels = new Map<string, string>(activityKinds.map((kind) => [kind.key, kind.label]));
   const cards = items.map((item) => (
-    <ContinueLearningItem itemCount={itemCount} key={item.activity.id}>
+    <ContinueLearningItem itemCount={itemCount} key={item.course.id}>
       <ContinueLearningCard item={item} kindLabels={kindLabels} />
     </ContinueLearningItem>
   ));

--- a/apps/main/src/app/(catalog)/(home)/home-content.tsx
+++ b/apps/main/src/app/(catalog)/(home)/home-content.tsx
@@ -1,20 +1,20 @@
-import { getContinueLearning } from "@/data/courses/get-continue-learning";
+import { getBeltLevel } from "@/data/progress/get-belt-level";
 import { Suspense } from "react";
 import { ContinueLearningList, ContinueLearningSkeleton } from "./continue-learning";
 import { Hero } from "./hero";
 import { Performance, PerformanceSkeleton } from "./performance";
 
 export async function HomeContent() {
-  const items = await getContinueLearning();
+  const beltData = await getBeltLevel();
 
-  if (items.length === 0) {
+  if (!beltData) {
     return <Hero />;
   }
 
   return (
     <>
       <Suspense fallback={<ContinueLearningSkeleton />}>
-        <ContinueLearningList items={items} />
+        <ContinueLearningList />
       </Suspense>
 
       <Suspense fallback={<PerformanceSkeleton />}>

--- a/apps/main/src/data/courses/get-continue-learning.test.ts
+++ b/apps/main/src/data/courses/get-continue-learning.test.ts
@@ -88,10 +88,13 @@ describe("authenticated users", () => {
     const result = await getContinueLearning(headers);
 
     expect(result).toHaveLength(1);
-    expect(result[0]?.course.id).toBe(course.id);
-    expect(result[0]?.chapter.id).toBe(chapter.id);
-    expect(result[0]?.lesson.id).toBe(lesson.id);
-    expect(result[0]?.activity.id).toBe(activity2.id);
+    expect(result[0]).toMatchObject({
+      activity: { id: activity2.id },
+      chapter: { id: chapter.id },
+      course: { id: course.id },
+      lesson: { id: lesson.id },
+      status: "completed",
+    });
   });
 
   test("orders by most recent completion", async () => {
@@ -121,8 +124,8 @@ describe("authenticated users", () => {
     const result = await getContinueLearning(headers);
 
     expect(result).toHaveLength(2);
-    expect(result[0]?.course.id).toBe(data2.course.id);
-    expect(result[1]?.course.id).toBe(data1.course.id);
+    expect(result[0]).toMatchObject({ course: { id: data2.course.id }, status: "completed" });
+    expect(result[1]).toMatchObject({ course: { id: data1.course.id }, status: "completed" });
   });
 
   test("limits to max items", async () => {
@@ -245,8 +248,11 @@ describe("authenticated users", () => {
     const result = await getContinueLearning(headers);
 
     expect(result).toHaveLength(1);
-    expect(result[0]?.activity.id).toBe(activity2.id);
-    expect(result[0]?.chapter.id).toBe(chapter2.id);
+    expect(result[0]).toMatchObject({
+      activity: { id: activity2.id },
+      chapter: { id: chapter2.id },
+      status: "completed",
+    });
   });
 
   test("excludes courses from non-brand organizations", async () => {
@@ -328,8 +334,123 @@ describe("authenticated users", () => {
     const result = await getContinueLearning(headers);
 
     expect(result).toHaveLength(1);
-    expect(result[0]?.course.id).toBe(course.id);
-    expect(result[0]?.course.organization).toBeNull();
-    expect(result[0]?.activity.id).toBe(activity2.id);
+    expect(result[0]).toMatchObject({
+      activity: { id: activity2.id },
+      course: { id: course.id, organization: null },
+      status: "completed",
+    });
+  });
+
+  test("returns pending item when next lesson has no generated activities", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: organization.id,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const lesson1 = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const lesson2 = await lessonFixture({
+      chapterId: chapter.id,
+      generationStatus: "pending",
+      isPublished: true,
+      organizationId: organization.id,
+      position: 1,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "completed",
+      isPublished: true,
+      lessonId: lesson1.id,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    await activityProgressFixture({
+      activityId: activity.id,
+      completedAt: new Date(),
+      durationSeconds: 60,
+      userId: Number(user.id),
+    });
+
+    const result = await getContinueLearning(headers);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      chapter: { id: chapter.id, slug: chapter.slug },
+      course: { id: course.id },
+      lesson: { id: lesson2.id, slug: lesson2.slug, title: lesson2.title },
+      status: "pending",
+    });
+  });
+
+  test("returns pending item linking to chapter when no next published lesson", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: organization.id,
+    });
+
+    const chapter1 = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const chapter2 = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 1,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter1.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "completed",
+      isPublished: true,
+      lessonId: lesson.id,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    await activityProgressFixture({
+      activityId: activity.id,
+      completedAt: new Date(),
+      durationSeconds: 60,
+      userId: Number(user.id),
+    });
+
+    const result = await getContinueLearning(headers);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      chapter: { id: chapter2.id, slug: chapter2.slug },
+      course: { id: course.id },
+      lesson: null,
+      status: "pending",
+    });
   });
 });

--- a/apps/main/src/data/courses/get-continue-learning.ts
+++ b/apps/main/src/data/courses/get-continue-learning.ts
@@ -14,6 +14,7 @@ import {
 } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
+import { getNextSibling } from "../progress/get-next-sibling";
 
 export const MAX_CONTINUE_LEARNING_ITEMS = 4;
 
@@ -35,24 +36,47 @@ type ContinueLearningRow = {
   chapterPosition: number;
 };
 
-export type ContinueLearningActivity = Pick<Activity, "id" | "kind" | "title" | "position">;
+type ContinueLearningActivity = Pick<Activity, "id" | "kind" | "title" | "position">;
 
-export type ContinueLearningLesson = Pick<Lesson, "id" | "slug" | "title" | "description">;
+type ContinueLearningLesson = Pick<Lesson, "id" | "slug" | "title" | "description">;
 
-export type ContinueLearningChapter = Pick<Chapter, "id" | "slug">;
+type ContinueLearningChapter = Pick<Chapter, "id" | "slug">;
 
-export type ContinueLearningCourse = Pick<Course, "id" | "slug" | "title" | "imageUrl"> & {
+type ContinueLearningCourse = Pick<Course, "id" | "slug" | "title" | "imageUrl"> & {
   organization: Pick<Organization, "slug"> | null;
 };
 
-export type ContinueLearningItem = {
-  course: ContinueLearningCourse;
-  chapter: ContinueLearningChapter;
-  lesson: ContinueLearningLesson;
+export type ContinueLearningCompletedItem = {
+  status: "completed";
   activity: ContinueLearningActivity;
+  chapter: ContinueLearningChapter;
+  course: ContinueLearningCourse;
+  lesson: ContinueLearningLesson;
 };
 
-function toItem(row: ContinueLearningRow, next: NextActivityInCourse): ContinueLearningItem {
+export type ContinueLearningPendingItem = {
+  status: "pending";
+  chapter: ContinueLearningChapter;
+  course: ContinueLearningCourse;
+  lesson: ContinueLearningLesson | null;
+};
+
+export type ContinueLearningItem = ContinueLearningCompletedItem | ContinueLearningPendingItem;
+
+function toCourse(row: ContinueLearningRow): ContinueLearningCourse {
+  return {
+    id: row.courseId,
+    imageUrl: row.courseImageUrl,
+    organization: row.orgSlug ? { slug: row.orgSlug } : null,
+    slug: row.courseSlug,
+    title: row.courseTitle,
+  };
+}
+
+function toCompletedItem(
+  row: ContinueLearningRow,
+  next: NextActivityInCourse,
+): ContinueLearningCompletedItem {
   return {
     activity: {
       id: next.activityId,
@@ -64,20 +88,57 @@ function toItem(row: ContinueLearningRow, next: NextActivityInCourse): ContinueL
       id: next.chapterId,
       slug: next.chapterSlug,
     },
-    course: {
-      id: row.courseId,
-      imageUrl: row.courseImageUrl,
-      organization: row.orgSlug ? { slug: row.orgSlug } : null,
-      slug: row.courseSlug,
-      title: row.courseTitle,
-    },
+    course: toCourse(row),
     lesson: {
       description: next.lessonDescription,
       id: next.lessonId,
       slug: next.lessonSlug,
       title: next.lessonTitle,
     },
+    status: "completed",
   };
+}
+
+type PendingTarget = {
+  chapter: ContinueLearningChapter;
+  lesson: ContinueLearningLesson | null;
+};
+
+async function findPendingTarget(row: ContinueLearningRow): Promise<PendingTarget | null> {
+  const nextLesson = await getNextSibling({
+    chapterId: row.chapterId,
+    chapterPosition: row.chapterPosition,
+    courseId: row.courseId,
+    lessonPosition: row.lessonPosition,
+    level: "lesson",
+  });
+
+  if (nextLesson) {
+    return {
+      chapter: { id: nextLesson.chapterId, slug: nextLesson.chapterSlug },
+      lesson: {
+        description: nextLesson.lessonDescription,
+        id: nextLesson.lessonId,
+        slug: nextLesson.lessonSlug,
+        title: nextLesson.lessonTitle,
+      },
+    };
+  }
+
+  const nextChapter = await getNextSibling({
+    chapterPosition: row.chapterPosition,
+    courseId: row.courseId,
+    level: "chapter",
+  });
+
+  if (nextChapter) {
+    return {
+      chapter: { id: nextChapter.chapterId, slug: nextChapter.chapterSlug },
+      lesson: null,
+    };
+  }
+
+  return null;
 }
 
 export const getContinueLearning = cache(
@@ -149,10 +210,27 @@ export const getContinueLearning = cache(
       ),
     );
 
+    const pendingTargets = await Promise.all(
+      rows.map((row, idx) =>
+        nextActivities[idx] ? Promise.resolve(null) : findPendingTarget(row),
+      ),
+    );
+
     return rows
-      .flatMap((row, idx) => {
+      .flatMap<ContinueLearningItem>((row, idx) => {
         const next = nextActivities[idx];
-        return next ? [toItem(row, next)] : [];
+
+        if (next) {
+          return [toCompletedItem(row, next)];
+        }
+
+        const target = pendingTargets[idx];
+
+        if (!target) {
+          return [];
+        }
+
+        return [{ ...target, course: toCourse(row), status: "pending" as const }];
       })
       .slice(0, MAX_CONTINUE_LEARNING_ITEMS);
   },

--- a/apps/main/src/data/progress/get-next-sibling.test.ts
+++ b/apps/main/src/data/progress/get-next-sibling.test.ts
@@ -68,7 +68,7 @@ describe("getNextSibling - lesson level", () => {
       level: "lesson",
     });
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       brandSlug: orgSlug,
       chapterSlug: expect.any(String),
       courseSlug,
@@ -85,7 +85,7 @@ describe("getNextSibling - lesson level", () => {
       level: "lesson",
     });
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       brandSlug: orgSlug,
       chapterSlug: chapter2Slug,
       courseSlug,
@@ -196,7 +196,7 @@ describe("getNextSibling - chapter level", () => {
       level: "chapter",
     });
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       brandSlug: orgSlug,
       chapterSlug: chapter2Slug,
       courseSlug,

--- a/apps/main/src/data/progress/get-next-sibling.ts
+++ b/apps/main/src/data/progress/get-next-sibling.ts
@@ -17,13 +17,18 @@ type ChapterScope = {
 
 type LessonResult = {
   brandSlug: string;
+  chapterId: number;
   chapterSlug: string;
   courseSlug: string;
+  lessonDescription: string;
+  lessonId: number;
   lessonSlug: string;
+  lessonTitle: string;
 };
 
 type ChapterResult = {
   brandSlug: string;
+  chapterId: number;
   chapterSlug: string;
   courseSlug: string;
 };
@@ -64,9 +69,13 @@ async function getNextLessonSibling(scope: LessonScope): Promise<LessonResult | 
 
   return {
     brandSlug: lesson.chapter.course.organization?.slug ?? "",
+    chapterId: lesson.chapter.id,
     chapterSlug: lesson.chapter.slug,
     courseSlug: lesson.chapter.course.slug,
+    lessonDescription: lesson.description,
+    lessonId: lesson.id,
     lessonSlug: lesson.slug,
+    lessonTitle: lesson.title,
   };
 }
 
@@ -91,6 +100,7 @@ async function getNextChapterSibling(scope: ChapterScope): Promise<ChapterResult
 
   return {
     brandSlug: chapter.course.organization?.slug ?? "",
+    chapterId: chapter.id,
     chapterSlug: chapter.slug,
     courseSlug: chapter.course.slug,
   };


### PR DESCRIPTION
## Summary

- **Hero condition**: Changed from `getContinueLearning().length === 0` to `getBeltLevel() === null` so the hero only shows for users who have never completed any activity
- **Pending courses**: When `getNextActivityInCourse` returns null (next lesson still generating), falls back to `getNextSibling` to find the next lesson/chapter and shows a "Continue" card with course title, lesson title/description, and proper links
- **Unified card**: Single `ContinueLearningCard` component handles both completed and pending items — only the header label/href varies, rest of the structure is shared

## Test plan

- [x] Integration tests: 2 new tests for pending items (lesson-level and chapter-level fallback), existing tests updated for `status` discriminant
- [x] E2E test: new test verifying user with BP but pending next lesson sees continue learning card (not hero) with course and lesson titles
- [x] All 401 main e2e tests pass (5 consecutive runs, no flakiness)
- [x] All 194 editor e2e tests pass
- [x] All 56 api e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the home hero so it only shows for brand‑new users and updates Continue Learning to include courses with pending next lessons, giving users a valid "Continue" target.

- **Bug Fixes**
  - Hero now checks `getBeltLevel()` (has the user ever completed anything?) instead of `getContinueLearning().length === 0`.
  - Continue Learning includes courses where the next activity isn’t generated by falling back to `getNextSibling()` for the next lesson or chapter.
  - Header label now shows "Continue" for pending items and "Next: {activity}" for completed ones, with correct links.

- **Refactors**
  - Unified `ContinueLearningCard` to handle both completed and pending states; computes course/lesson/activity hrefs and prefetch behavior in one place.
  - `ContinueLearningList` fetches its own items and hides the section when empty.
  - `get-continue-learning` returns a discriminated `status` ("completed" | "pending") and uses shared course mapping; pending items include the next lesson or chapter.

<sup>Written for commit 963564a9590fd66b1731c2968af617ada146cb90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

