### PR TITLE
refactor(player): model player state explicitly

### DIFF
--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-player-client.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-player-client.tsx
@@ -5,6 +5,7 @@ import { type SerializedActivity } from "@zoonk/player/prepare-activity-data";
 import { PlayerProvider } from "@zoonk/player/provider";
 import { PlayerShell } from "@zoonk/player/shell";
 import { useRouter } from "next/navigation";
+import { buildActivityPlayerModel } from "./activity-player-model";
 import { submitCompletion } from "./submit-completion-action";
 
 export function ActivityPlayerClient({
@@ -14,7 +15,6 @@ export function ActivityPlayerClient({
   chapterSlug,
   isAuthenticated,
   lessonSlug,
-  lessonTitle,
   nextActivity,
   nextSibling,
   userEmail,
@@ -26,7 +26,6 @@ export function ActivityPlayerClient({
   chapterSlug: string;
   isAuthenticated: boolean;
   lessonSlug: string;
-  lessonTitle: string;
   nextActivity: {
     chapterSlug: string;
     lessonSlug: string;
@@ -44,114 +43,38 @@ export function ActivityPlayerClient({
   userName: string | null;
 }) {
   const router = useRouter();
-
-  const lessonHref = `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}` as const;
-
-  const nextActivityHref = nextActivity
-    ? (`/b/${brandSlug}/c/${courseSlug}/ch/${nextActivity.chapterSlug}/l/${nextActivity.lessonSlug}/a/${String(nextActivity.activityPosition)}` as const)
-    : null;
-
-  const isLastInLesson =
-    !nextActivity ||
-    nextActivity.lessonSlug !== lessonSlug ||
-    nextActivity.chapterSlug !== chapterSlug;
-
-  const nextLessonHref = (() => {
-    if (!isLastInLesson) {
-      return null;
-    }
-
-    if (nextActivity) {
-      return `/b/${brandSlug}/c/${courseSlug}/ch/${nextActivity.chapterSlug}/l/${nextActivity.lessonSlug}` as const;
-    }
-
-    if (nextSibling) {
-      return `/b/${nextSibling.brandSlug}/c/${nextSibling.courseSlug}/ch/${nextSibling.chapterSlug}/l/${nextSibling.lessonSlug}` as const;
-    }
-
-    return null;
-  })();
-
-  const isNextChapter = (() => {
-    if (nextActivity) {
-      return nextActivity.chapterSlug !== chapterSlug;
-    }
-
-    if (nextSibling) {
-      return nextSibling.chapterSlug !== chapterSlug;
-    }
-
-    return false;
-  })();
-
-  const nextLessonTitle = (() => {
-    if (!isLastInLesson) {
-      return null;
-    }
-
-    if (nextActivity) {
-      return nextActivity.lessonTitle;
-    }
-
-    if (nextSibling) {
-      return nextSibling.lessonTitle;
-    }
-
-    return null;
-  })();
-
-  const chapterHref = `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}` as const;
-  const courseHref = `/b/${brandSlug}/c/${courseSlug}` as const;
-  const isCourseComplete = isLastInLesson && !nextActivity && !nextSibling;
-
-  const nextChapterHref = (() => {
-    if (!isNextChapter) {
-      return null;
-    }
-
-    if (nextActivity) {
-      return `/b/${brandSlug}/c/${courseSlug}/ch/${nextActivity.chapterSlug}` as const;
-    }
-
-    if (nextSibling) {
-      return `/b/${nextSibling.brandSlug}/c/${nextSibling.courseSlug}/ch/${nextSibling.chapterSlug}` as const;
-    }
-
-    return null;
-  })();
-
-  const onNextHref = nextActivityHref ?? nextLessonHref;
+  const model = buildActivityPlayerModel({
+    brandSlug,
+    chapterSlug,
+    courseSlug,
+    lessonSlug,
+    nextActivity,
+    nextSibling,
+  });
+  const onNextHref = model.onNextHref;
+  const handleNext = onNextHref ? () => router.push(onNextHref) : undefined;
 
   return (
     <PlayerProvider
       activity={activity}
-      isAuthenticated={isAuthenticated}
-      isLastInLesson={isLastInLesson}
-      isCourseComplete={isCourseComplete}
-      isNextChapter={isNextChapter}
-      chapterHref={chapterHref}
-      courseHref={courseHref}
-      completionFooter={
-        <ContentFeedback
-          className="pt-8"
-          contentId={activity.id}
-          defaultEmail={userEmail}
-          kind="activity"
-          variant="minimal"
-        />
-      }
-      lessonHref={lessonHref}
-      lessonTitle={lessonTitle}
-      levelHref="/level"
-      loginHref="/login"
-      nextActivityHref={nextActivityHref}
-      nextChapterHref={nextChapterHref}
-      nextLessonHref={nextLessonHref}
-      nextLessonTitle={nextLessonTitle}
+      milestone={model.milestone}
+      navigation={model.navigation}
       onComplete={submitCompletion}
-      onEscape={() => router.push(lessonHref)}
-      onNext={onNextHref ? () => router.push(onNextHref) : undefined}
-      userName={userName}
+      onEscape={() => router.push(model.navigation.lessonHref)}
+      onNext={handleNext}
+      viewer={{
+        completionFooter: (
+          <ContentFeedback
+            className="pt-8"
+            contentId={activity.id}
+            defaultEmail={userEmail}
+            kind="activity"
+            variant="minimal"
+          />
+        ),
+        isAuthenticated,
+        userName,
+      }}
     >
       <PlayerShell />
     </PlayerProvider>

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-player-model.test.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-player-model.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+import { buildActivityPlayerModel } from "./activity-player-model";
+
+describe(buildActivityPlayerModel, () => {
+  test("returns an activity milestone when another activity exists in the same lesson", () => {
+    const model = buildActivityPlayerModel({
+      brandSlug: "brand",
+      chapterSlug: "chapter-1",
+      courseSlug: "course",
+      lessonSlug: "lesson-1",
+      nextActivity: {
+        activityPosition: 2,
+        chapterSlug: "chapter-1",
+        lessonSlug: "lesson-1",
+        lessonTitle: "Lesson 1",
+      },
+      nextSibling: null,
+    });
+
+    expect(model.milestone).toEqual({ kind: "activity" });
+    expect(model.navigation.nextActivityHref).toBe("/b/brand/c/course/ch/chapter-1/l/lesson-1/a/2");
+    expect(model.onNextHref).toBe("/b/brand/c/course/ch/chapter-1/l/lesson-1/a/2");
+  });
+
+  test("returns a lesson milestone when the next lesson is in the same chapter", () => {
+    const model = buildActivityPlayerModel({
+      brandSlug: "brand",
+      chapterSlug: "chapter-1",
+      courseSlug: "course",
+      lessonSlug: "lesson-1",
+      nextActivity: {
+        activityPosition: 1,
+        chapterSlug: "chapter-1",
+        lessonSlug: "lesson-2",
+        lessonTitle: "Lesson 2",
+      },
+      nextSibling: null,
+    });
+
+    expect(model.milestone).toEqual({
+      kind: "lesson",
+      nextHref: "/b/brand/c/course/ch/chapter-1/l/lesson-2",
+      reviewHref: "/b/brand/c/course/ch/chapter-1/l/lesson-1",
+    });
+    expect(model.onNextHref).toBe("/b/brand/c/course/ch/chapter-1/l/lesson-2/a/1");
+  });
+
+  test("returns a chapter milestone when the next lesson is in another chapter", () => {
+    const model = buildActivityPlayerModel({
+      brandSlug: "brand",
+      chapterSlug: "chapter-1",
+      courseSlug: "course",
+      lessonSlug: "lesson-1",
+      nextActivity: {
+        activityPosition: 1,
+        chapterSlug: "chapter-2",
+        lessonSlug: "lesson-2",
+        lessonTitle: "Lesson 2",
+      },
+      nextSibling: null,
+    });
+
+    expect(model.milestone).toEqual({
+      kind: "chapter",
+      nextHref: "/b/brand/c/course/ch/chapter-2",
+      reviewHref: "/b/brand/c/course/ch/chapter-1",
+    });
+    expect(model.onNextHref).toBe("/b/brand/c/course/ch/chapter-2/l/lesson-2/a/1");
+  });
+
+  test("returns a course milestone when there is no next activity or sibling", () => {
+    const model = buildActivityPlayerModel({
+      brandSlug: "brand",
+      chapterSlug: "chapter-1",
+      courseSlug: "course",
+      lessonSlug: "lesson-1",
+      nextActivity: null,
+      nextSibling: null,
+    });
+
+    expect(model.milestone).toEqual({
+      kind: "course",
+      reviewHref: "/b/brand/c/course",
+      secondaryReviewHref: "/b/brand/c/course/ch/chapter-1",
+    });
+    expect(model.onNextHref).toBe(null);
+  });
+});

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-player-model.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-player-model.ts
@@ -1,0 +1,126 @@
+import { type Route } from "next";
+
+type NextActivity = {
+  activityPosition: number;
+  chapterSlug: string;
+  lessonSlug: string;
+  lessonTitle: string;
+};
+
+type NextSibling = {
+  brandSlug: string;
+  chapterSlug: string;
+  courseSlug: string;
+  lessonSlug: string;
+  lessonTitle: string;
+};
+
+function route<Href extends string>(href: Route<Href>): Route<Href> {
+  return href;
+}
+
+export function buildActivityPlayerModel({
+  brandSlug,
+  chapterSlug,
+  courseSlug,
+  lessonSlug,
+  nextActivity,
+  nextSibling,
+}: {
+  brandSlug: string;
+  chapterSlug: string;
+  courseSlug: string;
+  lessonSlug: string;
+  nextActivity: NextActivity | null;
+  nextSibling: NextSibling | null;
+}) {
+  const lessonHref = route(`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`);
+  const chapterHref = route(`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}`);
+  const courseHref = route(`/b/${brandSlug}/c/${courseSlug}`);
+
+  const nextActivityHref = nextActivity
+    ? route(
+        `/b/${brandSlug}/c/${courseSlug}/ch/${nextActivity.chapterSlug}/l/${nextActivity.lessonSlug}/a/${String(nextActivity.activityPosition)}`,
+      )
+    : null;
+
+  const isLastInLesson =
+    !nextActivity ||
+    nextActivity.lessonSlug !== lessonSlug ||
+    nextActivity.chapterSlug !== chapterSlug;
+
+  const nextLessonHref = (() => {
+    if (!isLastInLesson) {
+      return null;
+    }
+
+    if (nextActivity) {
+      return route(
+        `/b/${brandSlug}/c/${courseSlug}/ch/${nextActivity.chapterSlug}/l/${nextActivity.lessonSlug}`,
+      );
+    }
+
+    if (nextSibling) {
+      return route(
+        `/b/${nextSibling.brandSlug}/c/${nextSibling.courseSlug}/ch/${nextSibling.chapterSlug}/l/${nextSibling.lessonSlug}`,
+      );
+    }
+
+    return null;
+  })();
+
+  const nextChapterHref = (() => {
+    if (nextActivity && nextActivity.chapterSlug !== chapterSlug) {
+      return route(`/b/${brandSlug}/c/${courseSlug}/ch/${nextActivity.chapterSlug}`);
+    }
+
+    if (nextSibling && nextSibling.chapterSlug !== chapterSlug) {
+      return route(
+        `/b/${nextSibling.brandSlug}/c/${nextSibling.courseSlug}/ch/${nextSibling.chapterSlug}`,
+      );
+    }
+
+    return null;
+  })();
+
+  const milestone = (() => {
+    if (!isLastInLesson) {
+      return { kind: "activity" as const };
+    }
+
+    if (!nextActivity && !nextSibling) {
+      return {
+        kind: "course" as const,
+        reviewHref: courseHref,
+        secondaryReviewHref: chapterHref,
+      };
+    }
+
+    if (nextChapterHref) {
+      return {
+        kind: "chapter" as const,
+        nextHref: nextChapterHref,
+        reviewHref: chapterHref,
+      };
+    }
+
+    return {
+      kind: "lesson" as const,
+      nextHref: nextLessonHref,
+      reviewHref: lessonHref,
+    };
+  })();
+
+  return {
+    milestone,
+    navigation: {
+      chapterHref,
+      courseHref,
+      lessonHref,
+      levelHref: route("/level"),
+      loginHref: route("/login"),
+      nextActivityHref,
+    },
+    onNextHref: nextActivityHref ?? nextLessonHref,
+  };
+}

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
@@ -115,7 +115,6 @@ export default async function ActivityPage({ params }: Props) {
       chapterSlug={chapterSlug}
       isAuthenticated={Boolean(session)}
       lessonSlug={lessonSlug}
-      lessonTitle={lesson.title}
       nextActivity={nextActivity}
       nextSibling={nextSibling}
       userEmail={session?.user.email}

--- a/packages/player/src/components/belt-progress.tsx
+++ b/packages/player/src/components/belt-progress.tsx
@@ -6,9 +6,9 @@ import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { cn } from "@zoonk/ui/lib/utils";
 import { calculateBeltLevel, getBeltProgressPercent } from "@zoonk/utils/belt-level";
 import { useExtracted } from "next-intl";
-import Link from "next/link";
 import { useEffect, useState } from "react";
-import { usePlayer } from "../player-context";
+import { usePlayerNavigation } from "../player-context";
+import { PlayerLink } from "../player-link";
 import { useBeltColorLabel } from "../use-belt-color-label";
 
 type LevelUpPhase = "filling" | "resetting" | "done";
@@ -44,7 +44,7 @@ export function BeltProgressHint({
   newTotalBp: number;
 }) {
   const t = useExtracted();
-  const { levelHref } = usePlayer();
+  const { levelHref } = usePlayerNavigation();
   const currentBelt = calculateBeltLevel(newTotalBp);
   const previousBelt = calculateBeltLevel(newTotalBp - brainPower);
   const didLevelUp =
@@ -87,7 +87,7 @@ export function BeltProgressHint({
   }
 
   return (
-    <Link className="flex flex-col gap-1.5" href={levelHref}>
+    <PlayerLink className="flex flex-col gap-1.5" href={levelHref}>
       <div className="flex items-center gap-1.5">
         <BeltIndicator
           className={didLevelUp ? "animate-dot-pulse motion-reduce:animate-none" : undefined}
@@ -120,7 +120,7 @@ export function BeltProgressHint({
       <span className="text-muted-foreground text-xs tabular-nums">
         {t("{value} BP to level up", { value: String(currentBelt.bpToNextLevel) })}
       </span>
-    </Link>
+    </PlayerLink>
   );
 }
 

--- a/packages/player/src/components/challenge-completion.tsx
+++ b/packages/player/src/components/challenge-completion.tsx
@@ -2,10 +2,9 @@
 
 import { Button } from "@zoonk/ui/components/button";
 import { cn } from "@zoonk/ui/lib/utils";
-import { type Route } from "next";
 import { useExtracted } from "next-intl";
 import { type CompletionResult } from "../completion-input-schema";
-import { usePlayer } from "../player-context";
+import { type PlayerRoute, usePlayerViewer } from "../player-context";
 import { type DimensionInventory } from "../player-reducer";
 import { BeltProgressHint, BeltProgressSkeleton } from "./belt-progress";
 import { PrimaryKbd, SecondaryActionLink } from "./completion-action-link";
@@ -110,7 +109,7 @@ export function ChallengeSuccessContent({
   dimensions: DimensionInventory;
 }) {
   const t = useExtracted();
-  const { completionFooter, isAuthenticated } = usePlayer();
+  const { completionFooter, isAuthenticated } = usePlayerViewer();
   const entries = buildDimensionEntries(dimensions, []);
 
   return (
@@ -139,11 +138,11 @@ export function ChallengeFailureContent({
 }: {
   completionResult: CompletionResult | null;
   dimensions: DimensionInventory;
-  lessonHref: Route;
+  lessonHref: PlayerRoute;
   onRestart: () => void;
 }) {
   const t = useExtracted();
-  const { completionFooter, isAuthenticated } = usePlayer();
+  const { completionFooter, isAuthenticated } = usePlayerViewer();
   const entries = buildDimensionEntries(dimensions, []);
   const { names, single } = getFailureSubtitle(dimensions);
 

--- a/packages/player/src/components/completion-action-link.tsx
+++ b/packages/player/src/components/completion-action-link.tsx
@@ -3,8 +3,8 @@
 import { buttonVariants } from "@zoonk/ui/components/button";
 import { Kbd } from "@zoonk/ui/components/kbd";
 import { cn } from "@zoonk/ui/lib/utils";
-import { type Route } from "next";
-import Link from "next/link";
+import { type PlayerRoute } from "../player-context";
+import { PlayerLink } from "../player-link";
 
 export function PrimaryKbd({ children }: { children: React.ReactNode }) {
   return (
@@ -18,7 +18,7 @@ export function SecondaryKbd({ children }: { children: React.ReactNode }) {
   return <Kbd className="hidden opacity-60 lg:inline-flex">{children}</Kbd>;
 }
 
-export function PrimaryActionLink<T extends string>({
+export function PrimaryActionLink({
   children,
   className,
   href,
@@ -26,21 +26,21 @@ export function PrimaryActionLink<T extends string>({
 }: {
   children: React.ReactNode;
   className?: string;
-  href: Route<T>;
+  href: PlayerRoute;
   shortcut: string;
 }) {
   return (
-    <Link
+    <PlayerLink
       className={cn(buttonVariants({ size: "lg" }), "w-full lg:justify-between", className)}
       href={href}
     >
       {children}
       <PrimaryKbd>{shortcut}</PrimaryKbd>
-    </Link>
+    </PlayerLink>
   );
 }
 
-export function SecondaryActionLink<T extends string>({
+export function SecondaryActionLink({
   children,
   className,
   href,
@@ -48,16 +48,16 @@ export function SecondaryActionLink<T extends string>({
 }: {
   children: React.ReactNode;
   className?: string;
-  href: Route<T>;
+  href: PlayerRoute;
   shortcut: string;
 }) {
   return (
-    <Link
+    <PlayerLink
       className={cn(buttonVariants({ variant: "outline" }), "w-full lg:justify-between", className)}
       href={href}
     >
       {children}
       <SecondaryKbd>{shortcut}</SecondaryKbd>
-    </Link>
+    </PlayerLink>
   );
 }

--- a/packages/player/src/components/completion-auth-branch.tsx
+++ b/packages/player/src/components/completion-auth-branch.tsx
@@ -2,11 +2,15 @@
 
 import { Button, buttonVariants } from "@zoonk/ui/components/button";
 import { cn } from "@zoonk/ui/lib/utils";
-import { type Route } from "next";
 import { useExtracted } from "next-intl";
-import Link from "next/link";
 import { type CompletionResult } from "../completion-input-schema";
-import { usePlayer } from "../player-context";
+import {
+  type PlayerRoute,
+  usePlayerMilestone,
+  usePlayerNavigation,
+  usePlayerViewer,
+} from "../player-context";
+import { PlayerLink } from "../player-link";
 import { BeltProgressHint, BeltProgressSkeleton } from "./belt-progress";
 import { PrimaryActionLink, PrimaryKbd, SecondaryKbd } from "./completion-action-link";
 import { MilestoneActions, UnauthenticatedMilestoneActions } from "./completion-milestone-actions";
@@ -31,7 +35,7 @@ function SecondaryActions({
   onRestart,
   variant,
 }: {
-  lessonHref: Route;
+  lessonHref: PlayerRoute;
   onRestart: () => void;
   variant: "inline" | "stacked";
 }) {
@@ -40,7 +44,7 @@ function SecondaryActions({
   const isInline = variant === "inline";
 
   const backLink = (
-    <Link
+    <PlayerLink
       className={cn(
         buttonVariants({ variant: isInline ? "outline" : "default" }),
         isInline ? "flex-1 lg:justify-between" : "w-full lg:justify-between",
@@ -49,7 +53,7 @@ function SecondaryActions({
     >
       {t("All Activities")}
       {isInline ? <SecondaryKbd>Esc</SecondaryKbd> : <PrimaryKbd>Esc</PrimaryKbd>}
-    </Link>
+    </PlayerLink>
   );
 
   const restartButton = (
@@ -88,20 +92,20 @@ function AuthenticatedContent({
   showRewards,
 }: {
   completionResult: CompletionResult | null;
-  lessonHref: Route;
-  nextActivityHref: Route | null;
+  lessonHref: PlayerRoute;
+  nextActivityHref: PlayerRoute | null;
   onRestart: () => void;
   showRewards: boolean;
 }) {
   const t = useExtracted();
-  const { isLastInLesson } = usePlayer();
+  const milestone = usePlayerMilestone();
 
   const isLoading = !completionResult || completionResult.status !== "success";
 
-  if (isLastInLesson) {
+  if (milestone.kind !== "activity") {
     return (
       <CompletionActions>
-        <MilestoneActions lessonHref={lessonHref} />
+        <MilestoneActions />
       </CompletionActions>
     );
   }
@@ -150,15 +154,15 @@ function UnauthenticatedContent({
   loginHref,
   onRestart,
 }: {
-  lessonHref: Route;
-  loginHref: Route;
+  lessonHref: PlayerRoute;
+  loginHref: PlayerRoute;
   onRestart: () => void;
 }) {
   const t = useExtracted();
-  const { isLastInLesson } = usePlayer();
+  const milestone = usePlayerMilestone();
 
-  if (isLastInLesson) {
-    return <UnauthenticatedMilestoneActions lessonHref={lessonHref} loginHref={loginHref} />;
+  if (milestone.kind !== "activity") {
+    return <UnauthenticatedMilestoneActions loginHref={loginHref} />;
   }
 
   return (
@@ -166,9 +170,9 @@ function UnauthenticatedContent({
       <p className="text-muted-foreground text-sm">{t("Sign up to track your progress")}</p>
 
       <CompletionActions>
-        <Link className={cn(buttonVariants(), "w-full")} href={loginHref}>
+        <PlayerLink className={cn(buttonVariants(), "w-full")} href={loginHref}>
           {t("Login")}
-        </Link>
+        </PlayerLink>
 
         <SecondaryActions lessonHref={lessonHref} onRestart={onRestart} variant="inline" />
       </CompletionActions>
@@ -184,12 +188,13 @@ export function AuthBranch({
   showRewards = true,
 }: {
   completionResult: CompletionResult | null;
-  lessonHref: Route;
-  nextActivityHref: Route | null;
+  lessonHref: PlayerRoute;
+  nextActivityHref: PlayerRoute | null;
   onRestart: () => void;
   showRewards?: boolean;
 }) {
-  const { isAuthenticated, loginHref } = usePlayer();
+  const { loginHref } = usePlayerNavigation();
+  const { isAuthenticated } = usePlayerViewer();
 
   if (!isAuthenticated) {
     return (

--- a/packages/player/src/components/completion-milestone-actions.tsx
+++ b/packages/player/src/components/completion-milestone-actions.tsx
@@ -2,29 +2,28 @@
 
 import { buttonVariants } from "@zoonk/ui/components/button";
 import { cn } from "@zoonk/ui/lib/utils";
-import { type Route } from "next";
 import { useExtracted } from "next-intl";
-import Link from "next/link";
-import { usePlayer } from "../player-context";
+import { type PlayerRoute, usePlayerMilestone } from "../player-context";
+import { PlayerLink } from "../player-link";
 import { PrimaryActionLink, SecondaryActionLink } from "./completion-action-link";
 
 function NextButtonLabel() {
   const t = useExtracted();
-  const { isNextChapter } = usePlayer();
+  const milestone = usePlayerMilestone();
 
-  return <span>{isNextChapter ? t("Next Chapter") : t("Next Lesson")}</span>;
+  return <span>{milestone.kind === "chapter" ? t("Next Chapter") : t("Next Lesson")}</span>;
 }
 
 function ReviewLabel() {
   const t = useExtracted();
-  const { isCourseComplete, isNextChapter } = usePlayer();
+  const milestone = usePlayerMilestone();
 
   function getLabel() {
-    if (isCourseComplete) {
+    if (milestone.kind === "course") {
       return t("Review Course");
     }
 
-    if (isNextChapter) {
+    if (milestone.kind === "chapter") {
       return t("Review Chapter");
     }
 
@@ -34,42 +33,46 @@ function ReviewLabel() {
   return <span>{getLabel()}</span>;
 }
 
-function CourseCompleteActions({ lessonHref }: { lessonHref: Route }) {
+function CourseCompleteActions() {
   const t = useExtracted();
-  const { chapterHref, courseHref } = usePlayer();
+  const milestone = usePlayerMilestone();
+
+  if (milestone.kind !== "course") {
+    return null;
+  }
 
   return (
     <>
-      <PrimaryActionLink href={courseHref} shortcut="Enter">
+      <PrimaryActionLink href={milestone.reviewHref} shortcut="Enter">
         {t("Review Course")}
       </PrimaryActionLink>
 
-      <SecondaryActionLink href={chapterHref ?? lessonHref} shortcut="Esc">
+      <SecondaryActionLink href={milestone.secondaryReviewHref} shortcut="Esc">
         {t("Review Chapter")}
       </SecondaryActionLink>
     </>
   );
 }
 
-export function MilestoneActions({ lessonHref }: { lessonHref: Route }) {
-  const { chapterHref, isCourseComplete, isNextChapter, nextChapterHref, nextLessonHref } =
-    usePlayer();
+export function MilestoneActions() {
+  const milestone = usePlayerMilestone();
 
-  if (isCourseComplete) {
-    return <CourseCompleteActions lessonHref={lessonHref} />;
+  if (milestone.kind === "course") {
+    return <CourseCompleteActions />;
   }
 
-  const nextHref = isNextChapter ? nextChapterHref : nextLessonHref;
-  const reviewHref = isNextChapter ? chapterHref : lessonHref;
+  if (milestone.kind === "activity") {
+    return null;
+  }
 
-  if (nextHref) {
+  if (milestone.nextHref) {
     return (
       <>
-        <PrimaryActionLink href={nextHref} shortcut="Enter">
+        <PrimaryActionLink href={milestone.nextHref} shortcut="Enter">
           <NextButtonLabel />
         </PrimaryActionLink>
 
-        <SecondaryActionLink href={reviewHref} shortcut="Esc">
+        <SecondaryActionLink href={milestone.reviewHref} shortcut="Esc">
           <ReviewLabel />
         </SecondaryActionLink>
       </>
@@ -77,30 +80,18 @@ export function MilestoneActions({ lessonHref }: { lessonHref: Route }) {
   }
 
   return (
-    <PrimaryActionLink href={reviewHref} shortcut="Esc">
+    <PrimaryActionLink href={milestone.reviewHref} shortcut="Esc">
       <ReviewLabel />
     </PrimaryActionLink>
   );
 }
 
-export function UnauthenticatedMilestoneActions({
-  lessonHref,
-  loginHref,
-}: {
-  lessonHref: Route;
-  loginHref: Route;
-}) {
+export function UnauthenticatedMilestoneActions({ loginHref }: { loginHref: PlayerRoute }) {
   const t = useExtracted();
-  const { chapterHref, courseHref, isCourseComplete, isNextChapter } = usePlayer();
+  const milestone = usePlayerMilestone();
 
-  function getReviewHref() {
-    if (isCourseComplete) {
-      return courseHref;
-    }
-    if (isNextChapter) {
-      return chapterHref;
-    }
-    return lessonHref;
+  if (milestone.kind === "activity") {
+    return null;
   }
 
   return (
@@ -108,11 +99,11 @@ export function UnauthenticatedMilestoneActions({
       <p className="text-muted-foreground text-sm">{t("Sign up to track your progress")}</p>
 
       <div className="flex w-full flex-col gap-3" data-slot="completion-actions">
-        <Link className={cn(buttonVariants(), "w-full")} href={loginHref}>
+        <PlayerLink className={cn(buttonVariants(), "w-full")} href={loginHref}>
           {t("Login")}
-        </Link>
+        </PlayerLink>
 
-        <SecondaryActionLink href={getReviewHref()} shortcut="Esc">
+        <SecondaryActionLink href={milestone.reviewHref} shortcut="Esc">
           <ReviewLabel />
         </SecondaryActionLink>
       </div>

--- a/packages/player/src/components/completion-screen.tsx
+++ b/packages/player/src/components/completion-screen.tsx
@@ -2,12 +2,11 @@
 
 import { cn } from "@zoonk/ui/lib/utils";
 import { CircleCheck } from "lucide-react";
-import { type Route } from "next";
 import { useExtracted } from "next-intl";
 import { type CompletionResult } from "../completion-input-schema";
 import { computeScore } from "../compute-score";
 import { hasNegativeDimension } from "../dimensions";
-import { usePlayer } from "../player-context";
+import { type PlayerRoute, usePlayerMilestone, usePlayerViewer } from "../player-context";
 import { type DimensionInventory, type StepResult } from "../player-reducer";
 import { ChallengeFailureContent, ChallengeSuccessContent } from "./challenge-completion";
 import { AuthBranch } from "./completion-auth-branch";
@@ -50,14 +49,14 @@ function CompletionSignal() {
 
 function MilestoneHeading() {
   const t = useExtracted();
-  const { isCourseComplete, isNextChapter } = usePlayer();
+  const milestone = usePlayerMilestone();
 
   function getHeading() {
-    if (isCourseComplete) {
+    if (milestone.kind === "course") {
       return t("Course Complete");
     }
 
-    if (isNextChapter) {
+    if (milestone.kind === "chapter") {
       return t("Chapter Complete");
     }
 
@@ -91,13 +90,14 @@ export function CompletionScreenContent({
 }: {
   completionResult: CompletionResult | null;
   dimensions: DimensionInventory;
-  lessonHref: Route;
-  nextActivityHref: Route | null;
+  lessonHref: PlayerRoute;
+  nextActivityHref: PlayerRoute | null;
   onRestart: () => void;
   results: Record<string, StepResult>;
 }) {
   const t = useExtracted();
-  const { completionFooter, isLastInLesson } = usePlayer();
+  const milestone = usePlayerMilestone();
+  const { completionFooter } = usePlayerViewer();
   const isChallenge = Object.keys(dimensions).length > 0;
 
   if (isChallenge && hasNegativeDimension(dimensions)) {
@@ -125,7 +125,7 @@ export function CompletionScreenContent({
     );
   }
 
-  if (isLastInLesson) {
+  if (milestone.kind !== "activity") {
     return (
       <CompletionScreen className="min-h-[60vh] max-w-sm justify-center gap-10 px-6 sm:gap-12">
         <MilestoneHeading />

--- a/packages/player/src/components/in-play-sticky-header.tsx
+++ b/packages/player/src/components/in-play-sticky-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type Route } from "next";
+import { type PlayerRoute } from "../player-context";
 import { type DimensionInventory } from "../player-reducer";
 import { DimensionHeaderStatus } from "./dimension-header-status";
 import { PlayerCloseLink, PlayerHeader, PlayerStepFraction } from "./player-header";
@@ -19,7 +19,7 @@ export function InPlayStickyHeader({
   currentStepIndex: number;
   dimensions: DimensionInventory;
   hasDimensions: boolean;
-  lessonHref: Route;
+  lessonHref: PlayerRoute;
   progressValue: number;
   totalSteps: number;
 }) {

--- a/packages/player/src/components/player-header.tsx
+++ b/packages/player/src/components/player-header.tsx
@@ -3,9 +3,9 @@
 import { buttonVariants } from "@zoonk/ui/components/button";
 import { cn } from "@zoonk/ui/lib/utils";
 import { XIcon } from "lucide-react";
-import { type Route } from "next";
 import { useExtracted } from "next-intl";
-import Link from "next/link";
+import { type PlayerRoute } from "../player-context";
+import { PlayerLink } from "../player-link";
 
 export function PlayerHeader({ className, ...props }: React.ComponentProps<"header">) {
   return (
@@ -20,20 +20,17 @@ export function PlayerHeader({ className, ...props }: React.ComponentProps<"head
   );
 }
 
-export function PlayerCloseLink<T extends string>({
-  className,
-  href,
-}: {
-  className?: string;
-  href: Route<T>;
-}) {
+export function PlayerCloseLink({ className, href }: { className?: string; href: PlayerRoute }) {
   const t = useExtracted();
 
   return (
-    <Link className={cn(buttonVariants({ size: "icon", variant: "ghost" }), className)} href={href}>
+    <PlayerLink
+      className={cn(buttonVariants({ size: "icon", variant: "ghost" }), className)}
+      href={href}
+    >
       <XIcon />
       <span className="sr-only">{t("Close")}</span>
-    </Link>
+    </PlayerLink>
   );
 }
 

--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -1,7 +1,18 @@
 "use client";
 
 import { useExtracted } from "next-intl";
-import { usePlayer } from "../player-context";
+import { usePlayerNavigation, usePlayerRuntime } from "../player-context";
+import {
+  getCanNavigatePrev,
+  getChangedDimensions,
+  getCompletionResult,
+  getCurrentResult,
+  getCurrentStep,
+  getHasAnswer,
+  getIsStaticStep,
+  getProgressValue,
+  getSelectedAnswer,
+} from "../player-selectors";
 import { InPlayStickyHeader } from "./in-play-sticky-header";
 import { PlayerBottomBar, PlayerBottomBarAction, PlayerBottomBarNav } from "./player-bottom-bar";
 import { PlayerCloseLink, PlayerHeader } from "./player-header";
@@ -10,38 +21,23 @@ import { StageContent } from "./stage-content";
 
 export function PlayerShell() {
   const t = useExtracted();
-  const {
-    canNavigatePrev,
-    changedDimensions,
-    check,
-    completionResult,
-    continue: handleContinue,
-    currentResult,
-    currentStep,
-    currentStepIndex,
-    dimensions,
-    hasAnswer,
-    isCompleted,
-    isIntro,
-    isStaticStep,
-    lessonHref,
-    navigateNext,
-    navigatePrev,
-    nextActivityHref,
-    phase,
-    progressValue,
-    restart,
-    results,
-    selectAnswer,
-    selectedAnswer,
-    showBottomBar,
-    showHeader,
-    startChallenge,
-    totalSteps,
-  } = usePlayer();
+  const { actions, state } = usePlayerRuntime();
+  const { lessonHref, nextActivityHref } = usePlayerNavigation();
 
-  const hasDimensions = Object.keys(dimensions).length > 0;
-  const buttonLabel = phase === "feedback" ? t("Continue") : t("Check");
+  const canNavigatePrev = getCanNavigatePrev(state);
+  const changedDimensions = getChangedDimensions(state);
+  const completionResult = getCompletionResult(state);
+  const currentResult = getCurrentResult(state);
+  const currentStep = getCurrentStep(state);
+  const hasAnswer = getHasAnswer(state);
+  const isStaticStep = getIsStaticStep(state);
+  const progressValue = getProgressValue(state);
+  const selectedAnswer = getSelectedAnswer(state);
+
+  const hasDimensions = Object.keys(state.dimensions).length > 0;
+  const isIntro = state.phase === "intro";
+  const showChrome = state.phase === "playing" || state.phase === "feedback";
+  const buttonLabel = state.phase === "feedback" ? t("Continue") : t("Check");
 
   return (
     <main className="flex h-dvh flex-col overflow-hidden">
@@ -53,52 +49,51 @@ export function PlayerShell() {
         </div>
       )}
 
-      {showHeader && (
+      {showChrome && (
         <InPlayStickyHeader
           changedDimensions={changedDimensions}
-          currentStepIndex={currentStepIndex}
-          dimensions={dimensions}
+          currentStepIndex={state.currentStepIndex}
+          dimensions={state.dimensions}
           hasDimensions={hasDimensions}
           lessonHref={lessonHref}
           progressValue={progressValue}
-          totalSteps={totalSteps}
+          totalSteps={state.steps.length}
         />
       )}
 
-      <PlayerStage isStatic={isStaticStep && phase === "playing"} phase={phase}>
+      <PlayerStage isStatic={isStaticStep && state.phase === "playing"} phase={state.phase}>
         <StageContent
           canNavigatePrev={canNavigatePrev}
           completionResult={completionResult}
           currentResult={currentResult}
           currentStep={currentStep}
-          currentStepIndex={currentStepIndex}
-          dimensions={dimensions}
-          isCompleted={isCompleted}
+          currentStepIndex={state.currentStepIndex}
+          dimensions={state.dimensions}
           lessonHref={lessonHref}
           nextActivityHref={nextActivityHref}
-          onNavigateNext={navigateNext}
-          onNavigatePrev={navigatePrev}
-          onRestart={restart}
-          onSelectAnswer={selectAnswer}
-          onStartChallenge={startChallenge}
-          phase={phase}
-          results={results}
+          onNavigateNext={actions.navigateNext}
+          onNavigatePrev={actions.navigatePrev}
+          onRestart={actions.restart}
+          onSelectAnswer={actions.selectAnswer}
+          onStartChallenge={actions.startChallenge}
+          phase={state.phase}
+          results={state.results}
           selectedAnswer={selectedAnswer}
         />
       </PlayerStage>
 
-      {showBottomBar && (
+      {showChrome && (
         <PlayerBottomBar className={isStaticStep ? "lg:hidden" : undefined}>
           {isStaticStep ? (
             <PlayerBottomBarNav
               canNavigatePrev={canNavigatePrev}
-              onNavigateNext={navigateNext}
-              onNavigatePrev={navigatePrev}
+              onNavigateNext={actions.navigateNext}
+              onNavigatePrev={actions.navigatePrev}
             />
           ) : (
             <PlayerBottomBarAction
-              disabled={phase === "playing" && !hasAnswer}
-              onClick={phase === "feedback" ? handleContinue : check}
+              disabled={state.phase === "playing" && !hasAnswer}
+              onClick={state.phase === "feedback" ? actions.continue : actions.check}
             >
               {buttonLabel}
             </PlayerBottomBarAction>

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -1,5 +1,5 @@
-import { type Route } from "next";
 import { type CompletionResult } from "../completion-input-schema";
+import { type PlayerRoute } from "../player-context";
 import {
   type DimensionInventory,
   type PlayerPhase,
@@ -28,7 +28,6 @@ export function StageContent({
   currentStep,
   currentStepIndex,
   dimensions,
-  isCompleted,
   lessonHref,
   nextActivityHref,
   onNavigateNext,
@@ -46,9 +45,8 @@ export function StageContent({
   currentStep: SerializedStep | undefined;
   currentStepIndex: number;
   dimensions: DimensionInventory;
-  isCompleted: boolean;
-  lessonHref: Route;
-  nextActivityHref: Route | null;
+  lessonHref: PlayerRoute;
+  nextActivityHref: PlayerRoute | null;
   onNavigateNext: () => void;
   onNavigatePrev: () => void;
   onRestart: () => void;
@@ -62,7 +60,7 @@ export function StageContent({
     return <ChallengeIntro dimensions={dimensions} onStart={onStartChallenge} />;
   }
 
-  if (isCompleted) {
+  if (phase === "completed") {
     return (
       <CompletionScreenContent
         completionResult={completionResult}

--- a/packages/player/src/player-completion.ts
+++ b/packages/player/src/player-completion.ts
@@ -1,0 +1,45 @@
+import { type CompletionResult } from "./completion-input-schema";
+import { type PlayerState } from "./player-reducer";
+
+export type PlayerCompletionState =
+  | { status: "idle" }
+  | { status: "submitting" }
+  | CompletionResult;
+
+export function createIdleCompletionState(): PlayerCompletionState {
+  return { status: "idle" };
+}
+
+export function handleSubmitCompletion(state: PlayerState, requestId: number): PlayerState {
+  return {
+    ...state,
+    completion: { status: "submitting" },
+    completionRequestId: requestId,
+  };
+}
+
+export function handleResolveCompletion(
+  state: PlayerState,
+  requestId: number,
+  result: CompletionResult,
+): PlayerState {
+  if (requestId !== state.completionRequestId) {
+    return state;
+  }
+
+  return {
+    ...state,
+    completion: result,
+  };
+}
+
+export function handleRejectCompletion(state: PlayerState, requestId: number): PlayerState {
+  if (requestId !== state.completionRequestId) {
+    return state;
+  }
+
+  return {
+    ...state,
+    completion: { status: "error" },
+  };
+}

--- a/packages/player/src/player-context.tsx
+++ b/packages/player/src/player-context.tsx
@@ -1,75 +1,86 @@
 "use client";
 
-import { type Route } from "next";
 import { createContext, useContext } from "react";
-import { type CompletionResult } from "./completion-input-schema";
-import {
-  type DimensionInventory,
-  type PlayerPhase,
-  type SelectedAnswer,
-  type StepResult,
-} from "./player-reducer";
-import { type SerializedStep } from "./prepare-activity-data";
+import { type PlayerState } from "./player-reducer";
+import { type PlayerActions } from "./use-player-actions";
 
-export type PlayerContextValue<Href extends string> = {
-  activityId: string;
-  canNavigatePrev: boolean;
-  completionResult: CompletionResult | null;
-  currentResult: StepResult | undefined;
-  currentStep: SerializedStep | undefined;
-  currentStepIndex: number;
-  changedDimensions: Set<string>;
-  dimensions: DimensionInventory;
-  hasAnswer: boolean;
-  isAuthenticated: boolean;
-  isCompleted: boolean;
-  isCourseComplete: boolean;
-  isGameOver: boolean;
-  isIntro: boolean;
-  isLastInLesson: boolean;
-  isNextChapter: boolean;
-  isStaticStep: boolean;
-  lessonTitle: string;
-  nextLessonTitle: string | null;
-  phase: PlayerPhase;
-  progressValue: number;
-  results: Record<string, StepResult>;
-  selectedAnswer: SelectedAnswer | undefined;
-  showBottomBar: boolean;
-  showHeader: boolean;
-  totalSteps: number;
+export type PlayerRoute = string | URL;
 
-  check: () => void;
-  continue: () => void;
-  escape: () => void;
-  navigateNext: () => void;
-  navigatePrev: () => void;
-  next: () => void;
-  restart: () => void;
-  selectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
-  startChallenge: () => void;
-
-  chapterHref: Route<Href>;
+export type PlayerViewer = {
   completionFooter?: React.ReactNode;
-  courseHref: Route<Href>;
-  lessonHref: Route<Href>;
-  levelHref?: Route<Href>;
-  loginHref?: Route<Href>;
-  nextActivityHref: Route<Href> | null;
-  nextChapterHref: Route<Href> | null;
-  nextLessonHref: Route<Href> | null;
+  isAuthenticated: boolean;
+  userName?: string | null;
 };
 
-const PlayerContext = createContext<PlayerContextValue<string> | null>(null);
+export type PlayerNavigation = {
+  chapterHref: PlayerRoute;
+  courseHref: PlayerRoute;
+  lessonHref: PlayerRoute;
+  levelHref?: PlayerRoute;
+  loginHref?: PlayerRoute;
+  nextActivityHref: PlayerRoute | null;
+};
 
-export function usePlayer<Href extends string = string>(): PlayerContextValue<Href> {
-  const context = useContext(PlayerContext);
+type ReviewMilestone = {
+  kind: "chapter" | "lesson";
+  nextHref: PlayerRoute | null;
+  reviewHref: PlayerRoute;
+};
+
+type CourseMilestone = {
+  kind: "course";
+  reviewHref: PlayerRoute;
+  secondaryReviewHref: PlayerRoute;
+};
+
+export type PlayerMilestone = { kind: "activity" } | ReviewMilestone | CourseMilestone;
+
+type PlayerRuntimeContextValue = {
+  actions: PlayerActions;
+  state: PlayerState;
+};
+
+type PlayerConfigContextValue = {
+  escape: () => void;
+  milestone: PlayerMilestone;
+  navigation: PlayerNavigation;
+  next: () => void;
+  viewer: PlayerViewer;
+};
+
+const PlayerConfigContext = createContext<PlayerConfigContextValue | null>(null);
+const PlayerRuntimeContext = createContext<PlayerRuntimeContextValue | null>(null);
+
+function usePlayerConfig(): PlayerConfigContextValue {
+  const context = useContext(PlayerConfigContext);
 
   if (!context) {
-    throw new Error("usePlayer must be used within a PlayerProvider");
+    throw new Error("usePlayerConfig must be used within a PlayerProvider");
   }
 
-  return context as PlayerContextValue<Href>;
+  return context;
 }
 
-export { PlayerContext };
+export function usePlayerMilestone(): PlayerMilestone {
+  return usePlayerConfig().milestone;
+}
+
+export function usePlayerNavigation(): PlayerNavigation {
+  return usePlayerConfig().navigation;
+}
+
+export function usePlayerRuntime(): PlayerRuntimeContextValue {
+  const context = useContext(PlayerRuntimeContext);
+
+  if (!context) {
+    throw new Error("usePlayerRuntime must be used within a PlayerProvider");
+  }
+
+  return context;
+}
+
+export function usePlayerViewer(): PlayerViewer {
+  return usePlayerConfig().viewer;
+}
+
+export { PlayerConfigContext, PlayerRuntimeContext };

--- a/packages/player/src/player-controller.test.ts
+++ b/packages/player/src/player-controller.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildCompletionInput,
+  getPlayerTransition,
+  getSubmitCompletionRequestId,
+} from "./player-controller";
+import { type PlayerAction, type PlayerState } from "./player-reducer";
+import { type SerializedStep } from "./prepare-activity-data";
+
+function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
+  return {
+    content: { text: "Hello", title: "Intro", variant: "text" as const },
+    fillBlankOptions: [],
+    id: "step-1",
+    kind: "static",
+    matchColumnsRightItems: [],
+    position: 0,
+    sentence: null,
+    sentenceWordOptions: [],
+    sortOrderItems: [],
+    translationOptions: [],
+    vocabularyOptions: [],
+    word: null,
+    wordBankOptions: [],
+    ...overrides,
+  };
+}
+
+function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
+  return {
+    activityId: "activity-1",
+    completion: { status: "idle" },
+    completionRequestId: 0,
+    currentStepIndex: 0,
+    dimensions: {},
+    phase: "playing",
+    previousDimensions: {},
+    results: {},
+    selectedAnswers: {},
+    startedAt: 1000,
+    stepStartedAt: 2000,
+    stepTimings: {},
+    steps: [buildStep()],
+    ...overrides,
+  };
+}
+
+describe(getPlayerTransition, () => {
+  test("marks completion submission when feedback continues into completion", () => {
+    const state = buildState({
+      phase: "feedback",
+      steps: [buildStep()],
+    });
+
+    const transition = getPlayerTransition(state, { type: "CONTINUE" });
+
+    expect(transition.nextState.phase).toBe("completed");
+    expect(transition.shouldSubmitCompletion).toBeTruthy();
+  });
+
+  test("marks completion submission when static navigation reaches the last step", () => {
+    const steps = [buildStep({ id: "step-1" }), buildStep({ id: "step-2", position: 1 })];
+    const state = buildState({
+      currentStepIndex: 1,
+      steps,
+    });
+
+    const transition = getPlayerTransition(state, {
+      direction: "next",
+      type: "NAVIGATE_STEP",
+    });
+
+    expect(transition.nextState.phase).toBe("completed");
+    expect(transition.shouldSubmitCompletion).toBeTruthy();
+  });
+
+  test("does not submit completion for non-terminal actions", () => {
+    const action: PlayerAction = {
+      answer: { kind: "multipleChoice", selectedIndex: 0, selectedText: "A" },
+      stepId: "step-1",
+      type: "SELECT_ANSWER",
+    };
+
+    const transition = getPlayerTransition(buildState(), action);
+
+    expect(transition.shouldSubmitCompletion).toBeFalsy();
+  });
+});
+
+describe(buildCompletionInput, () => {
+  test("builds completion payload from the player state", () => {
+    const answeredAt = new Date("2026-03-18T15:30:00.000Z").getTime();
+    const now = new Date("2026-03-18T18:45:00.000Z");
+    const state = buildState({
+      dimensions: { Courage: 1 },
+      selectedAnswers: {
+        "step-1": { kind: "multipleChoice", selectedIndex: 0, selectedText: "A" },
+      },
+      stepTimings: {
+        "step-1": {
+          answeredAt,
+          dayOfWeek: 3,
+          durationSeconds: 12,
+          hourOfDay: 12,
+        },
+      },
+    });
+
+    expect(buildCompletionInput(state, now)).toEqual({
+      activityId: "activity-1",
+      answers: {
+        "step-1": { kind: "multipleChoice", selectedIndex: 0, selectedText: "A" },
+      },
+      dimensions: { Courage: 1 },
+      localDate: "2026-03-18",
+      startedAt: 1000,
+      stepTimings: {
+        "step-1": {
+          answeredAt,
+          dayOfWeek: 3,
+          durationSeconds: 12,
+          hourOfDay: 12,
+        },
+      },
+    });
+  });
+});
+
+describe(getSubmitCompletionRequestId, () => {
+  test("increments the request id for the next submission", () => {
+    expect(getSubmitCompletionRequestId(buildState({ completionRequestId: 4 }))).toBe(5);
+  });
+});

--- a/packages/player/src/player-controller.ts
+++ b/packages/player/src/player-controller.ts
@@ -1,0 +1,33 @@
+import { type CompletionInput } from "./completion-input-schema";
+import { type PlayerAction, type PlayerState, playerReducer } from "./player-reducer";
+
+function getLocalDate(now: Date): string {
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+}
+
+export function buildCompletionInput(state: PlayerState, now: Date = new Date()): CompletionInput {
+  return {
+    activityId: state.activityId,
+    answers: state.selectedAnswers,
+    dimensions: state.dimensions,
+    localDate: getLocalDate(now),
+    startedAt: state.startedAt,
+    stepTimings: state.stepTimings,
+  };
+}
+
+export function getSubmitCompletionRequestId(state: PlayerState): number {
+  return state.completionRequestId + 1;
+}
+
+export function getPlayerTransition(state: PlayerState, action: PlayerAction) {
+  const nextState = playerReducer(state, action);
+
+  return {
+    nextState,
+    shouldSubmitCompletion:
+      state.phase !== "completed" &&
+      nextState.phase === "completed" &&
+      state.completion.status === "idle",
+  };
+}

--- a/packages/player/src/player-initial-state.ts
+++ b/packages/player/src/player-initial-state.ts
@@ -1,0 +1,70 @@
+import { type ChallengeEffect, parseStepContent } from "@zoonk/core/steps/content-contract";
+import { createIdleCompletionState } from "./player-completion";
+import {
+  type DimensionInventory,
+  type PlayerPhase,
+  type PlayerState,
+  type SelectedAnswer,
+} from "./player-reducer";
+import { type SerializedActivity, type SerializedStep } from "./prepare-activity-data";
+
+function getChallengeEffects(step: SerializedStep): ChallengeEffect[] {
+  if (step.kind !== "multipleChoice") {
+    return [];
+  }
+
+  const content = parseStepContent("multipleChoice", step.content);
+
+  if (content.kind !== "challenge") {
+    return [];
+  }
+
+  return content.options.flatMap((option) => option.effects);
+}
+
+export function collectAllDimensions(steps: SerializedStep[]): DimensionInventory {
+  const effects = steps.flatMap((step) => getChallengeEffects(step));
+
+  return Object.fromEntries(effects.map((effect) => [effect.dimension, 0]));
+}
+
+export function buildInitialAnswers(steps: SerializedStep[]): Record<string, SelectedAnswer> {
+  return Object.fromEntries(
+    steps
+      .filter((step) => step.kind === "sortOrder" && step.sortOrderItems.length > 0)
+      .map((step) => [step.id, { kind: "sortOrder" as const, userOrder: step.sortOrderItems }]),
+  );
+}
+
+function getInitialPhase(steps: SerializedStep[], dimensions: DimensionInventory): PlayerPhase {
+  if (steps.length === 0) {
+    return "completed";
+  }
+
+  if (Object.keys(dimensions).length > 0) {
+    return "intro";
+  }
+
+  return "playing";
+}
+
+export function createInitialState(activity: SerializedActivity): PlayerState {
+  const dimensions = collectAllDimensions(activity.steps);
+  const now = Date.now();
+
+  return {
+    activityId: activity.id,
+    completion: createIdleCompletionState(),
+    completionRequestId: 0,
+    currentStepIndex: 0,
+    dimensions,
+    phase: getInitialPhase(activity.steps, dimensions),
+    previousDimensions: { ...dimensions },
+    results: {},
+    selectedAnswers: buildInitialAnswers(activity.steps),
+    startedAt: now,
+    stepStartedAt: now,
+    stepTimings: {},
+    steps: activity.steps,
+  };
+}

--- a/packages/player/src/player-link.tsx
+++ b/packages/player/src/player-link.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import Link from "next/link";
+import { type ComponentProps } from "react";
+import { type PlayerRoute } from "./player-context";
+
+type PlayerLinkProps = Omit<ComponentProps<typeof Link>, "href"> & {
+  href: PlayerRoute;
+};
+
+export function PlayerLink({ href, ...props }: PlayerLinkProps) {
+  // Concrete route validation happens in the consuming app before href values
+  // cross into the shared player package.
+  return <Link {...props} href={href as ComponentProps<typeof Link>["href"]} />;
+}

--- a/packages/player/src/player-provider.tsx
+++ b/packages/player/src/player-provider.tsx
@@ -1,163 +1,91 @@
 "use client";
 
-import { type Route } from "next";
 import { useCallback, useMemo, useReducer } from "react";
 import { type CompletionInput, type CompletionResult } from "./completion-input-schema";
-import { hasNegativeDimension } from "./dimensions";
-import { PlayerContext, type PlayerContextValue } from "./player-context";
-import { type PlayerState, createInitialState, playerReducer } from "./player-reducer";
+import {
+  PlayerConfigContext,
+  type PlayerMilestone,
+  type PlayerNavigation,
+  PlayerRuntimeContext,
+  type PlayerViewer,
+} from "./player-context";
+import { createInitialState, playerReducer } from "./player-reducer";
+import {
+  getCanNavigatePrev,
+  getHasAnswer,
+  getIsGameOver,
+  getIsStaticStep,
+} from "./player-selectors";
 import { type SerializedActivity } from "./prepare-activity-data";
-import { canNavigatePrev, isStaticNavigationStep } from "./step-navigation";
 import { usePlayerActions } from "./use-player-actions";
 import { usePlayerKeyboard } from "./use-player-keyboard";
 import { UserNameProvider } from "./user-name-context";
 
-function computeProgress(currentIndex: number, total: number): number {
-  if (total === 0) {
-    return 0;
-  }
-
-  return Math.round(((currentIndex + 1) / total) * 100);
-}
-
-function deriveViewState(state: PlayerState) {
-  const currentStep = state.steps[state.currentStepIndex];
-  const isStaticStep = isStaticNavigationStep(currentStep);
-  const isCompleted = state.phase === "completed";
-  const isIntro = state.phase === "intro";
-  const hasDimensions = Object.keys(state.dimensions).length > 0;
-
-  return {
-    canNavigatePrev: canNavigatePrev(state.steps, state.currentStepIndex),
-    currentResult: currentStep ? state.results[currentStep.id] : undefined,
-    currentStep,
-    hasAnswer: currentStep ? Boolean(state.selectedAnswers[currentStep.id]) : false,
-    isCompleted,
-    isGameOver: isCompleted && hasDimensions && hasNegativeDimension(state.dimensions),
-    isIntro,
-    isStaticStep,
-    progressValue: isCompleted ? 100 : computeProgress(state.currentStepIndex, state.steps.length),
-    selectedAnswer: currentStep ? state.selectedAnswers[currentStep.id] : undefined,
-    showBottomBar: !isCompleted && !isIntro,
-    showHeader: !isCompleted && !isIntro,
-    totalSteps: state.steps.length,
-  };
-}
-
-export function PlayerProvider<Href extends string>({
+export function PlayerProvider({
   activity,
   children,
-  chapterHref,
-  completionFooter,
-  courseHref,
-  isAuthenticated,
-  isCourseComplete = false,
-  isLastInLesson = false,
-  isNextChapter = false,
-  lessonHref,
-  lessonTitle = "",
-  levelHref,
-  loginHref,
-  nextActivityHref,
-  nextChapterHref = null,
-  nextLessonHref = null,
-  nextLessonTitle = null,
+  milestone,
+  navigation,
   onComplete,
   onEscape,
   onNext,
-  userName,
+  viewer,
 }: {
   activity: SerializedActivity;
-  chapterHref?: Route<Href>;
   children: React.ReactNode;
-  completionFooter?: React.ReactNode;
-  courseHref?: Route<Href>;
-  isAuthenticated: boolean;
-  isCourseComplete?: boolean;
-  isLastInLesson?: boolean;
-  isNextChapter?: boolean;
-  lessonHref: Route<Href>;
-  lessonTitle?: string;
-  levelHref?: Route<Href>;
-  loginHref?: Route<Href>;
-  nextActivityHref: Route<Href> | null;
-  nextChapterHref?: Route<Href> | null;
-  nextLessonHref?: Route<Href> | null;
-  nextLessonTitle?: string | null;
+  milestone: PlayerMilestone;
+  navigation: PlayerNavigation;
   onComplete: (input: CompletionInput) => Promise<CompletionResult>;
   onEscape: () => void;
   onNext?: () => void;
-  userName?: string | null;
+  viewer: PlayerViewer;
 }) {
   const [state, dispatch] = useReducer(playerReducer, activity, createInitialState);
-  const view = deriveViewState(state);
-  const actions = usePlayerActions(state, dispatch, onComplete, isAuthenticated);
-
-  const changedDimensions = useMemo(() => {
-    const changed = new Set<string>();
-
-    for (const [name, value] of Object.entries(state.dimensions)) {
-      const previous: number | undefined = state.previousDimensions[name];
-
-      if (value !== previous) {
-        changed.add(name);
-      }
-    }
-
-    return changed;
-  }, [state.dimensions, state.previousDimensions]);
+  const actions = usePlayerActions(state, dispatch, onComplete, viewer.isAuthenticated);
 
   const handleNext = useCallback(() => {
     onNext?.();
   }, [onNext]);
 
   usePlayerKeyboard({
-    canNavigatePrev: view.canNavigatePrev,
-    hasAnswer: view.hasAnswer,
-    isStaticStep: view.isStaticStep,
+    canNavigatePrev: getCanNavigatePrev(state),
+    hasAnswer: getHasAnswer(state),
+    isStaticStep: getIsStaticStep(state),
     onCheck: actions.check,
     onContinue: actions.continue,
     onEscape,
     onNavigateNext: actions.navigateNext,
     onNavigatePrev: actions.navigatePrev,
-    onNext: onNext && !view.isGameOver ? handleNext : null,
+    onNext: onNext && !getIsGameOver(state) ? handleNext : null,
     onRestart: actions.restart,
-    onStartChallenge: view.isIntro ? actions.startChallenge : null,
+    onStartChallenge: state.phase === "intro" ? actions.startChallenge : null,
     phase: state.phase,
   });
 
-  const contextValue: PlayerContextValue<Href> = {
-    ...actions,
-    ...view,
-    activityId: state.activityId,
-    changedDimensions,
-    chapterHref: chapterHref ?? lessonHref,
-    completionFooter,
-    completionResult: actions.completionResult,
-    courseHref: courseHref ?? lessonHref,
-    currentStepIndex: state.currentStepIndex,
-    dimensions: state.dimensions,
-    escape: onEscape,
-    isAuthenticated,
-    isCourseComplete,
-    isLastInLesson,
-    isNextChapter,
-    lessonHref,
-    lessonTitle,
-    levelHref,
-    loginHref,
-    next: handleNext,
-    nextActivityHref,
-    nextChapterHref,
-    nextLessonHref,
-    nextLessonTitle,
-    phase: state.phase,
-    results: state.results,
-  };
+  const configValue = useMemo(
+    () => ({
+      escape: onEscape,
+      milestone,
+      navigation,
+      next: handleNext,
+      viewer,
+    }),
+    [handleNext, milestone, navigation, onEscape, viewer],
+  );
+
+  const runtimeValue = useMemo(
+    () => ({
+      actions,
+      state,
+    }),
+    [actions, state],
+  );
 
   return (
-    <PlayerContext value={contextValue}>
-      <UserNameProvider initialName={userName}>{children}</UserNameProvider>
-    </PlayerContext>
+    <PlayerConfigContext value={configValue}>
+      <PlayerRuntimeContext value={runtimeValue}>
+        <UserNameProvider initialName={viewer.userName}>{children}</UserNameProvider>
+      </PlayerRuntimeContext>
+    </PlayerConfigContext>
   );
 }

--- a/packages/player/src/player-reducer.test.ts
+++ b/packages/player/src/player-reducer.test.ts
@@ -57,6 +57,8 @@ function buildActivity(overrides: Partial<SerializedActivity> = {}): SerializedA
 function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
   return {
     activityId: "activity-1",
+    completion: { status: "idle" },
+    completionRequestId: 0,
     currentStepIndex: 0,
     dimensions: {},
     phase: "playing",
@@ -517,6 +519,74 @@ describe("COMPLETE", () => {
     const state = buildState({ phase: "completed" });
     const next = playerReducer(state, { type: "COMPLETE" });
     expect(next).toBe(state);
+  });
+});
+
+describe("completion submission state", () => {
+  test("tracks the current submission request id while submitting", () => {
+    const next = playerReducer(buildState(), {
+      requestId: 7,
+      type: "SUBMIT_COMPLETION",
+    });
+
+    expect(next.completion).toEqual({ status: "submitting" });
+    expect(next.completionRequestId).toBe(7);
+  });
+
+  test("stores the latest resolved completion result", () => {
+    const next = playerReducer(
+      buildState({ completion: { status: "submitting" }, completionRequestId: 2 }),
+      {
+        requestId: 2,
+        result: {
+          belt: {
+            bpPerLevel: 250,
+            bpToNextLevel: 240,
+            color: "white",
+            isMaxLevel: false,
+            level: 1,
+            progressInLevel: 10,
+          },
+          brainPower: 5,
+          energyDelta: 2,
+          newTotalBp: 25,
+          status: "success",
+        },
+        type: "RESOLVE_COMPLETION",
+      },
+    );
+
+    expect(next.completion).toEqual({
+      belt: {
+        bpPerLevel: 250,
+        bpToNextLevel: 240,
+        color: "white",
+        isMaxLevel: false,
+        level: 1,
+        progressInLevel: 10,
+      },
+      brainPower: 5,
+      energyDelta: 2,
+      newTotalBp: 25,
+      status: "success",
+    });
+  });
+
+  test("ignores stale completion responses", () => {
+    const state = buildState({
+      completion: { status: "submitting" },
+      completionRequestId: 3,
+    });
+
+    const resolved = playerReducer(state, {
+      requestId: 2,
+      result: { status: "unauthenticated" },
+      type: "RESOLVE_COMPLETION",
+    });
+    const rejected = playerReducer(state, { requestId: 2, type: "REJECT_COMPLETION" });
+
+    expect(resolved).toBe(state);
+    expect(rejected).toBe(state);
   });
 });
 

--- a/packages/player/src/player-reducer.ts
+++ b/packages/player/src/player-reducer.ts
@@ -1,7 +1,16 @@
-import { type ChallengeEffect, parseStepContent } from "@zoonk/core/steps/content-contract";
+import { type ChallengeEffect } from "@zoonk/core/steps/content-contract";
 import { type AnswerResult } from "./check-answer";
+import { type CompletionResult } from "./completion-input-schema";
 import { IMPACT_DELTA } from "./dimensions";
-import { type SerializedActivity, type SerializedStep } from "./prepare-activity-data";
+import {
+  type PlayerCompletionState,
+  createIdleCompletionState,
+  handleRejectCompletion,
+  handleResolveCompletion,
+  handleSubmitCompletion,
+} from "./player-completion";
+import { buildInitialAnswers, collectAllDimensions } from "./player-initial-state";
+import { type SerializedStep } from "./prepare-activity-data";
 import { canNavigatePrev, isStaticNavigationStep } from "./step-navigation";
 
 export type PlayerPhase = "intro" | "playing" | "feedback" | "completed";
@@ -34,6 +43,8 @@ export type StepTiming = {
 
 export type PlayerState = {
   activityId: string;
+  completion: PlayerCompletionState;
+  completionRequestId: number;
   currentStepIndex: number;
   dimensions: DimensionInventory;
   phase: PlayerPhase;
@@ -46,7 +57,7 @@ export type PlayerState = {
   stepTimings: Record<string, StepTiming>;
 };
 
-type PlayerAction =
+export type PlayerAction =
   | { type: "SELECT_ANSWER"; stepId: string; answer: SelectedAnswer }
   | { type: "CLEAR_ANSWER"; stepId: string }
   | { type: "CHECK_ANSWER"; stepId: string; result: AnswerResult; effects: ChallengeEffect[] }
@@ -54,6 +65,9 @@ type PlayerAction =
   | { type: "COMPLETE" }
   | { type: "NAVIGATE_STEP"; direction: "next" | "prev" }
   | { type: "RESTART" }
+  | { type: "SUBMIT_COMPLETION"; requestId: number }
+  | { type: "RESOLVE_COMPLETION"; requestId: number; result: CompletionResult }
+  | { type: "REJECT_COMPLETION"; requestId: number }
   | { type: "START_CHALLENGE" };
 
 function applyEffects(
@@ -73,64 +87,7 @@ function applyEffects(
   return next;
 }
 
-function getChallengeEffects(step: SerializedStep): ChallengeEffect[] {
-  if (step.kind !== "multipleChoice") {
-    return [];
-  }
-
-  const content = parseStepContent("multipleChoice", step.content);
-
-  if (content.kind !== "challenge") {
-    return [];
-  }
-
-  return content.options.flatMap((option) => option.effects);
-}
-
-function collectAllDimensions(steps: SerializedStep[]): DimensionInventory {
-  const effects = steps.flatMap((step) => getChallengeEffects(step));
-
-  return Object.fromEntries(effects.map((effect) => [effect.dimension, 0]));
-}
-
-function buildInitialAnswers(steps: SerializedStep[]): Record<string, SelectedAnswer> {
-  return Object.fromEntries(
-    steps
-      .filter((step) => step.kind === "sortOrder" && step.sortOrderItems.length > 0)
-      .map((step) => [step.id, { kind: "sortOrder" as const, userOrder: step.sortOrderItems }]),
-  );
-}
-
-function getInitialPhase(steps: SerializedStep[], dimensions: DimensionInventory): PlayerPhase {
-  if (steps.length === 0) {
-    return "completed";
-  }
-
-  if (Object.keys(dimensions).length > 0) {
-    return "intro";
-  }
-
-  return "playing";
-}
-
-export function createInitialState(activity: SerializedActivity): PlayerState {
-  const dimensions = collectAllDimensions(activity.steps);
-  const now = Date.now();
-
-  return {
-    activityId: activity.id,
-    currentStepIndex: 0,
-    dimensions,
-    phase: getInitialPhase(activity.steps, dimensions),
-    previousDimensions: { ...dimensions },
-    results: {},
-    selectedAnswers: buildInitialAnswers(activity.steps),
-    startedAt: now,
-    stepStartedAt: now,
-    stepTimings: {},
-    steps: activity.steps,
-  };
-}
+export { createInitialState } from "./player-initial-state";
 
 function handleSelectAnswer(
   state: PlayerState,
@@ -254,6 +211,8 @@ function handleRestart(state: PlayerState): PlayerState {
 
   return {
     ...state,
+    completion: createIdleCompletionState(),
+    completionRequestId: state.completionRequestId + 1,
     currentStepIndex: 0,
     dimensions,
     phase: "playing",
@@ -304,6 +263,15 @@ export function playerReducer(state: PlayerState, action: PlayerAction): PlayerS
 
     case "RESTART":
       return handleRestart(state);
+
+    case "SUBMIT_COMPLETION":
+      return handleSubmitCompletion(state, action.requestId);
+
+    case "RESOLVE_COMPLETION":
+      return handleResolveCompletion(state, action.requestId, action.result);
+
+    case "REJECT_COMPLETION":
+      return handleRejectCompletion(state, action.requestId);
 
     case "START_CHALLENGE":
       return handleStartChallenge(state);

--- a/packages/player/src/player-selectors.ts
+++ b/packages/player/src/player-selectors.ts
@@ -1,0 +1,86 @@
+import { type CompletionResult } from "./completion-input-schema";
+import { hasNegativeDimension } from "./dimensions";
+import { type PlayerState } from "./player-reducer";
+import { canNavigatePrev, isStaticNavigationStep } from "./step-navigation";
+
+function computeProgress(currentIndex: number, total: number): number {
+  if (total === 0) {
+    return 0;
+  }
+
+  return Math.round(((currentIndex + 1) / total) * 100);
+}
+
+export function getCanNavigatePrev(state: PlayerState): boolean {
+  return canNavigatePrev(state.steps, state.currentStepIndex);
+}
+
+export function getChangedDimensions(state: PlayerState): Set<string> {
+  return new Set(
+    Object.entries(state.dimensions)
+      .filter(([name, value]) => value !== state.previousDimensions[name])
+      .map(([name]) => name),
+  );
+}
+
+export function getCompletionResult(state: PlayerState): CompletionResult | null {
+  if (state.completion.status === "idle" || state.completion.status === "submitting") {
+    return null;
+  }
+
+  return state.completion;
+}
+
+export function getCurrentResult(state: PlayerState) {
+  const currentStep = getCurrentStep(state);
+
+  if (!currentStep) {
+    return;
+  }
+
+  return state.results[currentStep.id];
+}
+
+export function getCurrentStep(state: PlayerState) {
+  return state.steps[state.currentStepIndex];
+}
+
+export function getHasAnswer(state: PlayerState): boolean {
+  const currentStep = getCurrentStep(state);
+
+  if (!currentStep) {
+    return false;
+  }
+
+  return Boolean(state.selectedAnswers[currentStep.id]);
+}
+
+export function getIsGameOver(state: PlayerState): boolean {
+  if (state.phase !== "completed" || Object.keys(state.dimensions).length === 0) {
+    return false;
+  }
+
+  return hasNegativeDimension(state.dimensions);
+}
+
+export function getIsStaticStep(state: PlayerState): boolean {
+  return isStaticNavigationStep(getCurrentStep(state));
+}
+
+export function getProgressValue(state: PlayerState): number {
+  if (state.phase === "completed") {
+    return 100;
+  }
+
+  return computeProgress(state.currentStepIndex, state.steps.length);
+}
+
+export function getSelectedAnswer(state: PlayerState) {
+  const currentStep = getCurrentStep(state);
+
+  if (!currentStep) {
+    return;
+  }
+
+  return state.selectedAnswers[currentStep.id];
+}

--- a/packages/player/src/use-player-actions.ts
+++ b/packages/player/src/use-player-actions.ts
@@ -1,26 +1,34 @@
 "use client";
 
-import { type Dispatch, useCallback, useState } from "react";
+import { type Dispatch, useCallback } from "react";
 import { checkStep } from "./check-step";
 import { type CompletionInput, type CompletionResult } from "./completion-input-schema";
-import { type PlayerState, type SelectedAnswer, playerReducer } from "./player-reducer";
-import { isStaticNavigationStep } from "./step-navigation";
+import {
+  buildCompletionInput,
+  getPlayerTransition,
+  getSubmitCompletionRequestId,
+} from "./player-controller";
+import {
+  type PlayerAction,
+  type PlayerState,
+  type SelectedAnswer,
+  type playerReducer,
+} from "./player-reducer";
 
-function willComplete(state: PlayerState): boolean {
-  if (state.phase === "feedback") {
-    return state.currentStepIndex + 1 >= state.steps.length;
-  }
+type SyncPlayerAction = Exclude<
+  PlayerAction,
+  { type: "REJECT_COMPLETION" | "RESOLVE_COMPLETION" | "SUBMIT_COMPLETION" }
+>;
 
-  if (state.phase === "playing") {
-    const currentStep = state.steps[state.currentStepIndex];
-
-    if (isStaticNavigationStep(currentStep) || currentStep?.kind === "matchColumns") {
-      return state.currentStepIndex + 1 >= state.steps.length;
-    }
-  }
-
-  return false;
-}
+export type PlayerActions = {
+  check: () => void;
+  continue: () => void;
+  navigateNext: () => void;
+  navigatePrev: () => void;
+  restart: () => void;
+  selectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
+  startChallenge: () => void;
+};
 
 export function usePlayerActions(
   state: PlayerState,
@@ -28,41 +36,46 @@ export function usePlayerActions(
   onComplete: (input: CompletionInput) => Promise<CompletionResult>,
   isAuthenticated: boolean,
 ) {
-  const [completionResult, setCompletionResult] = useState<CompletionResult | null>(null);
   const currentStep = state.steps[state.currentStepIndex];
 
-  const fireCompletion = useCallback(
+  const submitCompletion = useCallback(
     (completionState: PlayerState) => {
-      const now = new Date();
-      const localDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+      const requestId = getSubmitCompletionRequestId(state);
+      dispatch({ requestId, type: "SUBMIT_COMPLETION" });
 
-      void onComplete({
-        activityId: completionState.activityId,
-        answers: completionState.selectedAnswers,
-        dimensions: completionState.dimensions,
-        localDate,
-        startedAt: completionState.startedAt,
-        stepTimings: completionState.stepTimings,
-      })
+      void onComplete(buildCompletionInput(completionState))
         .then((result) => {
-          setCompletionResult(result);
+          dispatch({ requestId, result, type: "RESOLVE_COMPLETION" });
         })
         .catch(() => {
-          setCompletionResult({ status: "error" });
+          dispatch({ requestId, type: "REJECT_COMPLETION" });
         });
     },
-    [onComplete],
+    [dispatch, onComplete, state],
+  );
+
+  const dispatchTransition = useCallback(
+    (action: SyncPlayerAction) => {
+      const transition = getPlayerTransition(state, action);
+      dispatch(action);
+
+      if (transition.shouldSubmitCompletion && isAuthenticated) {
+        submitCompletion(transition.nextState);
+      }
+    },
+    [dispatch, isAuthenticated, state, submitCompletion],
   );
 
   const selectAnswer = useCallback(
     (stepId: string, answer: SelectedAnswer | null) => {
       if (answer) {
-        dispatch({ answer, stepId, type: "SELECT_ANSWER" });
-      } else {
-        dispatch({ stepId, type: "CLEAR_ANSWER" });
+        dispatchTransition({ answer, stepId, type: "SELECT_ANSWER" });
+        return;
       }
+
+      dispatchTransition({ stepId, type: "CLEAR_ANSWER" });
     },
-    [dispatch],
+    [dispatchTransition],
   );
 
   const check = useCallback(() => {
@@ -77,50 +90,31 @@ export function usePlayerActions(
     }
 
     const { effects, result } = checkStep(currentStep, answer);
-    const matchColumnsWillComplete = currentStep.kind === "matchColumns" && willComplete(state);
-
-    const action = { effects, result, stepId: currentStep.id, type: "CHECK_ANSWER" as const };
-    dispatch(action);
-
-    if (matchColumnsWillComplete && isAuthenticated) {
-      fireCompletion(playerReducer(state, action));
-    }
-  }, [currentStep, state, dispatch, isAuthenticated, fireCompletion]);
+    dispatchTransition({ effects, result, stepId: currentStep.id, type: "CHECK_ANSWER" });
+  }, [currentStep, dispatchTransition, state.selectedAnswers]);
 
   const handleContinue = useCallback(() => {
-    const completing = willComplete(state);
-    dispatch({ type: "CONTINUE" });
-
-    if (completing && isAuthenticated) {
-      fireCompletion(state);
-    }
-  }, [state, dispatch, isAuthenticated, fireCompletion]);
+    dispatchTransition({ type: "CONTINUE" });
+  }, [dispatchTransition]);
 
   const navigateNext = useCallback(() => {
-    const completing = willComplete(state);
-    dispatch({ direction: "next", type: "NAVIGATE_STEP" });
-
-    if (completing && isAuthenticated) {
-      fireCompletion(state);
-    }
-  }, [state, dispatch, isAuthenticated, fireCompletion]);
+    dispatchTransition({ direction: "next", type: "NAVIGATE_STEP" });
+  }, [dispatchTransition]);
 
   const navigatePrev = useCallback(() => {
-    dispatch({ direction: "prev", type: "NAVIGATE_STEP" });
-  }, [dispatch]);
+    dispatchTransition({ direction: "prev", type: "NAVIGATE_STEP" });
+  }, [dispatchTransition]);
 
   const restart = useCallback(() => {
-    setCompletionResult(null);
-    dispatch({ type: "RESTART" });
-  }, [dispatch]);
+    dispatchTransition({ type: "RESTART" });
+  }, [dispatchTransition]);
 
   const startChallenge = useCallback(() => {
-    dispatch({ type: "START_CHALLENGE" });
-  }, [dispatch]);
+    dispatchTransition({ type: "START_CHALLENGE" });
+  }, [dispatchTransition]);
 
   return {
     check,
-    completionResult,
     continue: handleContinue,
     navigateNext,
     navigatePrev,


### PR DESCRIPTION
## Summary
- refactor the player around explicit state, selectors, and completion/controller helpers
- replace flattened provider booleans with grouped navigation, milestone, viewer, and runtime state
- keep app-specific Next route typing in the app layer and use a shared player link wrapper inside `@zoonk/player`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the player into an explicit, testable state model with clear contexts and selectors, and moves app-specific routing into the app layer. This simplifies the provider API, stabilizes completion submission, and reduces component complexity.

- **Refactors**
  - Added explicit player state with selectors (`player-selectors`) and an initial state builder (`player-initial-state`).
  - Introduced a controller for transitions and completion payloads (`player-controller`) with request IDs to ignore stale responses.
  - Split context into runtime, navigation, milestone, and viewer; new hooks: `usePlayerRuntime`, `usePlayerNavigation`, `usePlayerMilestone`, `usePlayerViewer`.
  - Simplified `PlayerProvider` to accept `milestone`, `navigation`, and `viewer`; removed many booleans and flat href props.
  - Added `PlayerLink` and `PlayerRoute`; components now use `PlayerLink` and accept `PlayerRoute` instead of `Route`.
  - Moved Next route typing to the app; created `buildActivityPlayerModel` to compute navigation/milestones for `@zoonk/player`.
  - Streamlined `PlayerShell` to use selectors and action bundle; reduced prop threading across components.
  - Added tests for the activity model, controller transitions, and reducer completion flow.

- **Migration**
  - Update `PlayerProvider` usage: pass `milestone`, `navigation`, and `viewer` (with `isAuthenticated`, optional `completionFooter`, `userName`).
  - Replace `usePlayer()` with `usePlayerRuntime`, `usePlayerNavigation`, `usePlayerMilestone`, `usePlayerViewer`.
  - Use `PlayerLink` and `PlayerRoute` in `@zoonk/player` components; keep concrete Next `Route` types in the app.
  - Compute navigation/milestones in the app (e.g., via a model like `buildActivityPlayerModel`) and pass them to `PlayerProvider`.

<sup>Written for commit ff39438de27e413e66be8bb8634d97c9e3b1bd5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

