### PR TITLE
fix(player): add audio, romanization, and dedup to feedback screen

### DIFF
--- a/apps/main/e2e/listening-step.test.ts
+++ b/apps/main/e2e/listening-step.test.ts
@@ -16,6 +16,7 @@ async function createListeningActivity(options: {
     audioUrl?: string | null;
     alternativeSentences?: string[];
     alternativeTranslations?: string[];
+    romanization?: string | null;
     sentence: string;
     translation: string;
   }[];
@@ -77,6 +78,7 @@ async function createListeningActivity(options: {
         alternativeSentences: sentenceData.alternativeSentences ?? [],
         alternativeTranslations: sentenceData.alternativeTranslations ?? [],
         organizationId: org.id,
+        romanization: sentenceData.romanization ?? null,
         sentence: sentenceData.sentence,
         sentenceAudioId,
         translation: sentenceData.translation,
@@ -308,6 +310,121 @@ test.describe("Listening Step", () => {
     await expect(wordBank.getByRole("button", { exact: true, name: noite })).toBeVisible();
     await expect(wordBank.getByRole("button", { exact: true, name: bom })).toHaveCount(0);
     await expect(wordBank.getByRole("button", { exact: true, name: dia })).toHaveCount(0);
+  });
+
+  test("romanization shows on 'Translate:' line when correct", async ({ page }) => {
+    const uniqueId = randomUUID().replaceAll("-", "").slice(0, 8);
+    const transWord1 = `hello${uniqueId}`;
+    const transWord2 = `world${uniqueId}`;
+    const sentence = `konnichiwa${uniqueId} sekai${uniqueId}`;
+    const romanization = `romaji${uniqueId} test${uniqueId}`;
+
+    const { url } = await createListeningActivity({
+      sentences: [
+        {
+          audioUrl: "https://example.com/audio.mp3",
+          romanization,
+          sentence,
+          translation: `${transWord1} ${transWord2}`,
+        },
+      ],
+      words: [{ translation: `cat${uniqueId}`, word: `neko${uniqueId}` }],
+    });
+
+    await page.goto(url);
+
+    const wordBank = page.getByRole("group", { name: /word bank/i });
+
+    await expect(async () => {
+      await wordBank.getByRole("button", { exact: true, name: transWord1 }).click();
+      await expect(
+        page
+          .getByRole("group", { name: /your answer/i })
+          .getByRole("button", { name: new RegExp(transWord1) }),
+      ).toBeVisible({ timeout: 1000 });
+    }).toPass();
+
+    await wordBank.getByRole("button", { exact: true, name: transWord2 }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByText(romanization)).toBeVisible();
+  });
+
+  test("romanization shows on 'Translate:' line when incorrect", async ({ page }) => {
+    const uniqueId = randomUUID().replaceAll("-", "").slice(0, 8);
+    const transWord1 = `hello${uniqueId}`;
+    const transWord2 = `world${uniqueId}`;
+    const sentence = `konnichiwa${uniqueId} sekai${uniqueId}`;
+    const romanization = `romaji${uniqueId} test${uniqueId}`;
+
+    const { url } = await createListeningActivity({
+      sentences: [
+        {
+          audioUrl: "https://example.com/audio.mp3",
+          romanization,
+          sentence,
+          translation: `${transWord1} ${transWord2}`,
+        },
+      ],
+      words: [{ translation: `cat${uniqueId}`, word: `neko${uniqueId}` }],
+    });
+
+    await page.goto(url);
+
+    const wordBank = page.getByRole("group", { name: /word bank/i });
+
+    // Arrange in wrong order
+    await expect(async () => {
+      await wordBank.getByRole("button", { exact: true, name: transWord2 }).click();
+      await expect(
+        page
+          .getByRole("group", { name: /your answer/i })
+          .getByRole("button", { name: new RegExp(transWord2) }),
+      ).toBeVisible({ timeout: 1000 });
+    }).toPass();
+
+    await wordBank.getByRole("button", { exact: true, name: transWord1 }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByText(romanization)).toBeVisible();
+  });
+
+  test("audio button shows on listening feedback", async ({ page }) => {
+    const uniqueId = randomUUID().replaceAll("-", "").slice(0, 8);
+    const transWord1 = `hello${uniqueId}`;
+    const transWord2 = `world${uniqueId}`;
+
+    const { url } = await createListeningActivity({
+      sentences: [
+        {
+          audioUrl: "https://example.com/audio.mp3",
+          sentence: `hola${uniqueId} mundo${uniqueId}`,
+          translation: `${transWord1} ${transWord2}`,
+        },
+      ],
+      words: [{ translation: `cat${uniqueId}`, word: `gato${uniqueId}` }],
+    });
+
+    await page.goto(url);
+
+    const wordBank = page.getByRole("group", { name: /word bank/i });
+
+    await expect(async () => {
+      await wordBank.getByRole("button", { exact: true, name: transWord1 }).click();
+      await expect(
+        page
+          .getByRole("group", { name: /your answer/i })
+          .getByRole("button", { name: new RegExp(transWord1) }),
+      ).toBeVisible({ timeout: 1000 });
+    }).toPass();
+
+    await wordBank.getByRole("button", { exact: true, name: transWord2 }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByRole("button", { name: /play pronunciation/i })).toBeVisible();
   });
 
   test("full flow: complete all listening steps to completion screen", async ({ page }) => {

--- a/apps/main/e2e/reading-step.test.ts
+++ b/apps/main/e2e/reading-step.test.ts
@@ -462,6 +462,161 @@ test.describe("Reading Step", () => {
     await expect(answerArea.getByText(/tap words to build your answer/i)).toBeVisible();
   });
 
+  test("romanization shows on correct answer feedback", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const word1 = `Konnichiwa-${uniqueId}`;
+    const word2 = `sekai-${uniqueId}`;
+    const romanization = `romaji-${uniqueId} test-${uniqueId}`;
+
+    const { url } = await createReadingActivity({
+      sentences: [
+        {
+          romanization,
+          sentence: `${word1} ${word2}`,
+          translation: `Hello-${uniqueId} world-${uniqueId}`,
+        },
+      ],
+      words: [{ translation: `cat-${uniqueId}`, word: `neko-${uniqueId}` }],
+    });
+
+    await page.goto(url);
+
+    const wordBank = page.getByRole("group", { name: /word bank/i });
+
+    await expect(async () => {
+      await wordBank.getByRole("button", { exact: true, name: word1 }).click();
+      await expect(
+        page
+          .getByRole("group", { name: /your answer/i })
+          .getByRole("button", { name: new RegExp(word1) }),
+      ).toBeVisible({ timeout: 1000 });
+    }).toPass();
+
+    await wordBank.getByRole("button", { exact: true, name: word2 }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByText(romanization)).toBeVisible();
+  });
+
+  test("romanization shows on incorrect answer feedback", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const word1 = `Konnichiwa-${uniqueId}`;
+    const word2 = `sekai-${uniqueId}`;
+    const romanization = `romaji-${uniqueId} test-${uniqueId}`;
+
+    const { url } = await createReadingActivity({
+      sentences: [
+        {
+          romanization,
+          sentence: `${word1} ${word2}`,
+          translation: `Hello-${uniqueId} world-${uniqueId}`,
+        },
+      ],
+      words: [{ translation: `cat-${uniqueId}`, word: `neko-${uniqueId}` }],
+    });
+
+    await page.goto(url);
+
+    const wordBank = page.getByRole("group", { name: /word bank/i });
+
+    // Arrange in wrong order
+    await expect(async () => {
+      await wordBank.getByRole("button", { exact: true, name: word2 }).click();
+      await expect(
+        page
+          .getByRole("group", { name: /your answer/i })
+          .getByRole("button", { name: new RegExp(word2) }),
+      ).toBeVisible({ timeout: 1000 });
+    }).toPass();
+
+    await wordBank.getByRole("button", { exact: true, name: word1 }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByText(romanization)).toBeVisible();
+  });
+
+  test("audio button shows when audioUrl exists", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const word1 = `Buenos-${uniqueId}`;
+    const word2 = `dias-${uniqueId}`;
+
+    const { url } = await createReadingActivity({
+      sentences: [
+        {
+          audioUrl: "https://example.com/audio.mp3",
+          sentence: `${word1} ${word2}`,
+          translation: `Good-${uniqueId} morning-${uniqueId}`,
+        },
+      ],
+      words: [{ translation: `night-${uniqueId}`, word: `noche-${uniqueId}` }],
+    });
+
+    await page.goto(url);
+
+    const wordBank = page.getByRole("group", { name: /word bank/i });
+
+    await expect(async () => {
+      await wordBank.getByRole("button", { exact: true, name: word1 }).click();
+      await expect(
+        page
+          .getByRole("group", { name: /your answer/i })
+          .getByRole("button", { name: new RegExp(word1) }),
+      ).toBeVisible({ timeout: 1000 });
+    }).toPass();
+
+    await wordBank.getByRole("button", { exact: true, name: word2 }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect(page.getByRole("button", { name: /play pronunciation/i })).toBeVisible();
+  });
+
+  test("romanization dedup: not shown when equals sentence", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const word1 = `Buenos-${uniqueId}`;
+    const word2 = `dias-${uniqueId}`;
+    const sentence = `${word1} ${word2}`;
+
+    const { url } = await createReadingActivity({
+      sentences: [
+        {
+          // Simulate bad AI data: romanization equals the sentence
+          romanization: sentence,
+          sentence,
+          translation: `Good-${uniqueId} morning-${uniqueId}`,
+        },
+      ],
+      words: [{ translation: `night-${uniqueId}`, word: `noche-${uniqueId}` }],
+    });
+
+    await page.goto(url);
+
+    const wordBank = page.getByRole("group", { name: /word bank/i });
+
+    await expect(async () => {
+      await wordBank.getByRole("button", { exact: true, name: word1 }).click();
+      await expect(
+        page
+          .getByRole("group", { name: /your answer/i })
+          .getByRole("button", { name: new RegExp(word1) }),
+      ).toBeVisible({ timeout: 1000 });
+    }).toPass();
+
+    await wordBank.getByRole("button", { exact: true, name: word2 }).click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    // Feedback shows "Your answer:" with the sentence text
+    await expect(page.getByText(/your answer/i)).toBeVisible();
+    await expect(page.getByText(sentence)).toBeVisible();
+
+    // Romanization should NOT appear as a separate element since it equals the sentence.
+    // The sentence text appears once in the answer, not duplicated as romanization below it.
+    await expect(page.getByText(sentence, { exact: true })).toHaveCount(1);
+  });
+
   test("full flow: complete all reading steps to completion screen", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const word1a = `Hola-${uniqueId}`;

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -269,10 +269,15 @@ msgctxt "qymjuq"
 msgid "View scores"
 msgstr "View scores"
 
-#: ../../packages/player/src/components/feedback-screen.tsx
+#: ../../packages/player/src/components/feedback-answer-blocks.tsx
 msgctxt "3nOd8f"
 msgid "Your answer:"
 msgstr "Your answer:"
+
+#: ../../packages/player/src/components/feedback-answer-blocks.tsx
+msgctxt "QAJ/Tl"
+msgid "Correct answer:"
+msgstr "Correct answer:"
 
 #: ../../packages/player/src/components/feedback-screen.tsx
 msgctxt "eBxz+u"
@@ -298,11 +303,6 @@ msgstr "Close call."
 msgctxt "ld7zgc"
 msgid "{name} is at zero. One more drop and you lose."
 msgstr "{name} is at zero. One more drop and you lose."
-
-#: ../../packages/player/src/components/feedback-screen.tsx
-msgctxt "QAJ/Tl"
-msgid "Correct answer:"
-msgstr "Correct answer:"
 
 #: ../../packages/player/src/components/feedback-screen.tsx
 msgctxt "vhpTgv"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -269,10 +269,15 @@ msgctxt "qymjuq"
 msgid "View scores"
 msgstr "Ver puntuaciones"
 
-#: ../../packages/player/src/components/feedback-screen.tsx
+#: ../../packages/player/src/components/feedback-answer-blocks.tsx
 msgctxt "3nOd8f"
 msgid "Your answer:"
 msgstr "Tu respuesta:"
+
+#: ../../packages/player/src/components/feedback-answer-blocks.tsx
+msgctxt "QAJ/Tl"
+msgid "Correct answer:"
+msgstr "Respuesta correcta:"
 
 #: ../../packages/player/src/components/feedback-screen.tsx
 msgctxt "eBxz+u"
@@ -298,11 +303,6 @@ msgstr "Estuvo cerca."
 msgctxt "ld7zgc"
 msgid "{name} is at zero. One more drop and you lose."
 msgstr "{name} está en cero. Una caída más y pierdes."
-
-#: ../../packages/player/src/components/feedback-screen.tsx
-msgctxt "QAJ/Tl"
-msgid "Correct answer:"
-msgstr "Respuesta correcta:"
 
 #: ../../packages/player/src/components/feedback-screen.tsx
 msgctxt "vhpTgv"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -269,10 +269,15 @@ msgctxt "qymjuq"
 msgid "View scores"
 msgstr "Ver pontuações"
 
-#: ../../packages/player/src/components/feedback-screen.tsx
+#: ../../packages/player/src/components/feedback-answer-blocks.tsx
 msgctxt "3nOd8f"
 msgid "Your answer:"
 msgstr "Sua resposta:"
+
+#: ../../packages/player/src/components/feedback-answer-blocks.tsx
+msgctxt "QAJ/Tl"
+msgid "Correct answer:"
+msgstr "Resposta correta:"
 
 #: ../../packages/player/src/components/feedback-screen.tsx
 msgctxt "eBxz+u"
@@ -298,11 +303,6 @@ msgstr "Por pouco."
 msgctxt "ld7zgc"
 msgid "{name} is at zero. One more drop and you lose."
 msgstr "{name} está em zero. Mais uma queda e você perde."
-
-#: ../../packages/player/src/components/feedback-screen.tsx
-msgctxt "QAJ/Tl"
-msgid "Correct answer:"
-msgstr "Resposta correta:"
 
 #: ../../packages/player/src/components/feedback-screen.tsx
 msgctxt "vhpTgv"

--- a/packages/ai/src/tasks/activities/language/activity-grammar.prompt.md
+++ b/packages/ai/src/tasks/activities/language/activity-grammar.prompt.md
@@ -190,6 +190,8 @@ Use the standard romanization system for each language:
 
 **For languages using Roman letters** (Spanish, French, German, Portuguese, Italian, etc.), set `romanization` to `null`.
 
+**IMPORTANT**: The `romanization` field must ONLY contain Roman/Latin letters — never characters from the original script. If the sentence is "私は学生です。", the romanization must be "watashi wa gakusei desu." — never the original Japanese text.
+
 # Linguistic Accuracy Requirements
 
 ## Factual Correctness in Explanations

--- a/packages/ai/src/tasks/activities/language/activity-sentences.prompt.md
+++ b/packages/ai/src/tasks/activities/language/activity-sentences.prompt.md
@@ -110,6 +110,8 @@ Use the standard romanization system for each language:
 
 **For languages using Roman letters** (Spanish, French, German, Portuguese, Italian, etc.), set `romanization` to `null`.
 
+**IMPORTANT**: The `romanization` field must ONLY contain Roman/Latin letters — never characters from the original script. If the sentence is "先生、おはようございます。", the romanization must be "Sensei, ohayō gozaimasu." — never the original Japanese text.
+
 # Explanation
 
 For each sentence, provide a brief explanation (1-2 sentences) of the key grammar or word-order pattern demonstrated. Write the explanation in USER_LANGUAGE (the learner's native language).

--- a/packages/ai/src/tasks/activities/language/activity-vocabulary.prompt.md
+++ b/packages/ai/src/tasks/activities/language/activity-vocabulary.prompt.md
@@ -131,6 +131,8 @@ Use the standard romanization system for each language:
 
 **For languages using Roman letters** (Spanish, French, German, Portuguese, Italian, etc.), set `romanization` to `null`.
 
+**IMPORTANT**: The `romanization` field must ONLY contain Roman/Latin letters — never characters from the original script. If the word is "猫", the romanization must be "neko" — never the original Japanese text.
+
 # Output Format
 
 Return an object with a `words` array. Each word object must include:

--- a/packages/player/src/components/feedback-answer-blocks.tsx
+++ b/packages/player/src/components/feedback-answer-blocks.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { cn } from "@zoonk/ui/lib/utils";
+import { CircleCheck, CircleX } from "lucide-react";
+import { useExtracted } from "next-intl";
+import { type StepResult } from "../player-reducer";
+import { type SerializedStep } from "../prepare-activity-data";
+import { RomanizationText } from "./romanization-text";
+
+/**
+ * Returns romanization only when it differs from the displayed text.
+ * Prevents showing duplicate text when romanization equals the sentence
+ * (bad AI generation data where the original script was copied into
+ * the romanization field instead of the Latin transliteration).
+ */
+function getVisibleRomanization(
+  romanization: string | null | undefined,
+  displayedText: string,
+): string | null {
+  if (!romanization) {
+    return null;
+  }
+
+  if (romanization.trim() === displayedText.trim()) {
+    return null;
+  }
+
+  return romanization;
+}
+
+/** Resolves which romanization texts to show based on the answer kind and dedup rules. */
+export function getFeedbackRomanization(
+  result: StepResult,
+  step: SerializedStep | undefined,
+  selectedText: string | null,
+  correctAnswer: string | null | undefined,
+  questionText: string | null,
+) {
+  const romanization = step?.sentence?.romanization;
+  const kind = result.answer?.kind;
+
+  return {
+    /** Romanization for the "Your answer:" line on correct reading answers. */
+    correctReading:
+      kind === "reading" && selectedText
+        ? getVisibleRomanization(romanization, selectedText)
+        : null,
+
+    /** Romanization for the "Translate:" line — only for listening (shows target language sentence). */
+    translate:
+      kind === "listening" ? getVisibleRomanization(romanization, questionText ?? "") : null,
+
+    /** Romanization for the "Correct answer:" line on wrong reading answers. */
+    wrongReading:
+      kind === "reading" && correctAnswer
+        ? getVisibleRomanization(romanization, correctAnswer)
+        : null,
+  };
+}
+
+function AnswerLine({
+  children,
+  icon,
+  label,
+  variant,
+}: {
+  children: React.ReactNode;
+  icon: React.ReactNode;
+  label: string;
+  variant: "correct" | "incorrect";
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2 rounded-lg px-3 py-2 text-sm",
+        variant === "correct" ? "bg-success/10" : "bg-destructive/10",
+      )}
+    >
+      <span
+        className={cn(
+          "mt-0.5 shrink-0",
+          variant === "correct" ? "text-success" : "text-destructive",
+        )}
+      >
+        {icon}
+      </span>
+      <div>
+        <span className="text-muted-foreground">{label}</span>{" "}
+        <span className="font-medium">{children}</span>
+      </div>
+    </div>
+  );
+}
+
+export function CorrectAnswerBlock({
+  romanization,
+  selectedText,
+}: {
+  romanization: string | null;
+  selectedText: string;
+}) {
+  const t = useExtracted();
+
+  return (
+    <AnswerLine
+      icon={<CircleCheck aria-hidden="true" className="size-4" />}
+      label={t("Your answer:")}
+      variant="correct"
+    >
+      <span className="flex flex-col">
+        <span>{selectedText}</span>
+        <RomanizationText>{romanization}</RomanizationText>
+      </span>
+    </AnswerLine>
+  );
+}
+
+export function IncorrectAnswerBlock({
+  correctAnswer,
+  romanization,
+  selectedText,
+}: {
+  correctAnswer: string | null | undefined;
+  romanization: string | null;
+  selectedText: string | null;
+}) {
+  const t = useExtracted();
+
+  return (
+    <>
+      {selectedText && (
+        <AnswerLine
+          icon={<CircleX aria-hidden="true" className="size-4" />}
+          label={t("Your answer:")}
+          variant="incorrect"
+        >
+          {selectedText}
+        </AnswerLine>
+      )}
+      {correctAnswer && (
+        <AnswerLine
+          icon={<CircleCheck aria-hidden="true" className="size-4" />}
+          label={t("Correct answer:")}
+          variant="correct"
+        >
+          <span className="flex flex-col">
+            <span>{correctAnswer}</span>
+            <RomanizationText>{romanization}</RomanizationText>
+          </span>
+        </AnswerLine>
+      )}
+    </>
+  );
+}

--- a/packages/player/src/components/feedback-screen.tsx
+++ b/packages/player/src/components/feedback-screen.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@zoonk/ui/lib/utils";
-import { CircleAlert, CircleCheck, CircleX, TriangleAlert } from "lucide-react";
+import { CircleAlert, TriangleAlert } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { type DimensionInventory, type StepResult } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
@@ -13,7 +13,14 @@ import {
   buildDimensionEntries,
   getWarningDelay,
 } from "./dimension-inventory";
+import {
+  CorrectAnswerBlock,
+  IncorrectAnswerBlock,
+  getFeedbackRomanization,
+} from "./feedback-answer-blocks";
+import { PlayAudioButton } from "./play-audio-button";
 import { ResultAnnouncement } from "./result-announcement";
+import { RomanizationText } from "./romanization-text";
 
 function FeedbackScreen({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -47,40 +54,6 @@ function FeedbackMessage({ className, ...props }: React.ComponentProps<"p">) {
       data-slot="feedback-message"
       {...props}
     />
-  );
-}
-
-function AnswerLine({
-  children,
-  icon,
-  label,
-  variant,
-}: {
-  children: React.ReactNode;
-  icon: React.ReactNode;
-  label: string;
-  variant: "correct" | "incorrect";
-}) {
-  return (
-    <div
-      className={cn(
-        "flex items-start gap-2 rounded-lg px-3 py-2 text-sm",
-        variant === "correct" ? "bg-success/10" : "bg-destructive/10",
-      )}
-    >
-      <span
-        className={cn(
-          "mt-0.5 shrink-0",
-          variant === "correct" ? "text-success" : "text-destructive",
-        )}
-      >
-        {icon}
-      </span>
-      <div>
-        <span className="text-muted-foreground">{label}</span>{" "}
-        <span className="font-medium">{children}</span>
-      </div>
-    </div>
   );
 }
 
@@ -203,56 +176,36 @@ function CoreFeedback({ result, step }: { result: StepResult; step?: SerializedS
       ? result.answer.selectedText
       : getArrangeWordsSelectedText(result);
   const questionText = getQuestionText(result, step);
+  const rom = getFeedbackRomanization(result, step, selectedText, correctAnswer, questionText);
 
   return (
     <FeedbackScreen>
       <div className="flex flex-col gap-2">
         {questionText && (
-          <p className="text-muted-foreground text-sm">
-            {t("Translate:")} <span className="text-foreground font-medium">{questionText}</span>
-          </p>
+          <div className="text-muted-foreground text-sm">
+            <p>
+              {t("Translate:")} <span className="text-foreground font-medium">{questionText}</span>
+            </p>
+            <RomanizationText>{rom.translate}</RomanizationText>
+          </div>
         )}
 
         {isCorrect ? (
           selectedText && (
-            <AnswerLine
-              icon={<CircleCheck aria-hidden="true" className="size-4" />}
-              label={t("Your answer:")}
-              variant="correct"
-            >
-              {selectedText}
-            </AnswerLine>
+            <CorrectAnswerBlock romanization={rom.correctReading} selectedText={selectedText} />
           )
         ) : (
-          <>
-            {selectedText && (
-              <AnswerLine
-                icon={<CircleX aria-hidden="true" className="size-4" />}
-                label={t("Your answer:")}
-                variant="incorrect"
-              >
-                {selectedText}
-              </AnswerLine>
-            )}
-            {correctAnswer && (
-              <AnswerLine
-                icon={<CircleCheck aria-hidden="true" className="size-4" />}
-                label={t("Correct answer:")}
-                variant="correct"
-              >
-                <span className="flex flex-col">
-                  <span>{correctAnswer}</span>
-                  {step?.sentence?.romanization && (
-                    <span className="text-muted-foreground text-xs font-normal">
-                      {step.sentence.romanization}
-                    </span>
-                  )}
-                </span>
-              </AnswerLine>
-            )}
-          </>
+          <IncorrectAnswerBlock
+            correctAnswer={correctAnswer}
+            romanization={rom.wrongReading}
+            selectedText={selectedText}
+          />
         )}
       </div>
+
+      {step?.sentence?.audioUrl && (
+        <PlayAudioButton audioUrl={step.sentence.audioUrl} variant="text" />
+      )}
 
       {feedback && <FeedbackMessage>{feedback}</FeedbackMessage>}
 

--- a/packages/player/src/components/play-audio-button.tsx
+++ b/packages/player/src/components/play-audio-button.tsx
@@ -9,9 +9,11 @@ import { useWordAudio } from "../use-word-audio";
 export function PlayAudioButton({
   audioUrl,
   size = "md",
+  variant = "filled",
 }: {
   audioUrl: string;
   size?: "sm" | "md";
+  variant?: "filled" | "text";
 }) {
   const t = useExtracted();
   const [isPlaying, setIsPlaying] = useState(false);
@@ -29,6 +31,19 @@ export function PlayAudioButton({
 
   const Icon = isPlaying ? PauseIcon : Volume2Icon;
   const label = isPlaying ? t("Pause pronunciation") : t("Play pronunciation");
+
+  if (variant === "text") {
+    return (
+      <button
+        className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 text-sm transition-colors"
+        onClick={handleClick}
+        type="button"
+      >
+        <Icon aria-hidden className="size-4" />
+        {label}
+      </button>
+    );
+  }
 
   return (
     <button


### PR DESCRIPTION
## Summary

- Add audio play button (`text` variant) on feedback screen when sentence has `audioUrl`
- Show romanization on "Translate:" line for listening activities
- Show romanization on correct/incorrect answer lines for reading activities
- Add dedup check so romanization is suppressed when it equals the displayed sentence (bad AI data)
- Strengthen AI prompts to enforce Latin-only characters in `romanization` field
- Extract answer block components from `feedback-screen.tsx` to stay under max-lines lint rule

## Test plan

- [x] E2E: romanization on correct reading feedback
- [x] E2E: romanization on incorrect reading feedback
- [x] E2E: audio button on reading feedback
- [x] E2E: romanization dedup (not shown when equals sentence)
- [x] E2E: romanization on listening "Translate:" line (correct + incorrect)
- [x] E2E: audio button on listening feedback
- [x] All 417 main, 194 editor, 56 API e2e tests pass
- [x] 3x flakiness check on new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a text-style “Play pronunciation” button and show romanization on the feedback screen to make answers clearer, with a dedup rule to avoid duplicate text. Also tightened prompts to enforce Latin-only romanization and simplified the feedback code.

- **New Features**
  - Show a “Play pronunciation” button on feedback when `audioUrl` exists.
  - Display romanization on the “Translate:” line for listening activities.
  - Display romanization on “Your answer” (correct reading) and “Correct answer” (incorrect reading).
  - Suppress romanization when it matches the displayed sentence; enforce Latin-only output in `activity-*` prompts.

- **Refactors**
  - Extracted answer blocks to `feedback-answer-blocks.tsx` to reduce `feedback-screen.tsx` size and moved related i18n strings; added e2e tests for audio and romanization.

<sup>Written for commit 440734bbd0864e42da94d08d2f2911fcafb0689c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

