### PR TITLE
fix(player): remove tooltip from word bank tiles

### DIFF
--- a/packages/player/src/components/arrange-words.tsx
+++ b/packages/player/src/components/arrange-words.tsx
@@ -2,7 +2,6 @@
 
 import { type DragEndEvent } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@zoonk/ui/components/tooltip";
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { useCallback, useRef, useState } from "react";
@@ -32,33 +31,15 @@ function BankTile({
   onPlace: () => void;
   option: WordBankOption;
 }) {
-  const buttonClassName = cn(
-    "border-border flex min-h-11 flex-col items-center rounded-lg border px-4 py-2.5 transition-all duration-150",
-    isUsed
-      ? "pointer-events-none opacity-30"
-      : "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]",
-  );
-
-  if (option.translation) {
-    return (
-      <Tooltip>
-        <TooltipTrigger
-          aria-disabled={isUsed}
-          className={buttonClassName}
-          onClick={onPlace}
-          tabIndex={isUsed ? -1 : 0}
-        >
-          <BankTileContent option={option} />
-        </TooltipTrigger>
-        <TooltipContent>{option.translation}</TooltipContent>
-      </Tooltip>
-    );
-  }
-
   return (
     <button
       aria-disabled={isUsed}
-      className={buttonClassName}
+      className={cn(
+        "border-border flex min-h-11 flex-col items-center rounded-lg border px-4 py-2.5 transition-all duration-150",
+        isUsed
+          ? "pointer-events-none opacity-30"
+          : "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]",
+      )}
       onClick={onPlace}
       tabIndex={isUsed ? -1 : 0}
       type="button"


### PR DESCRIPTION
## Summary
- Remove tooltip from word bank tiles in arrange words steps — buggy behavior on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the translation tooltip from word bank tiles in the Arrange Words step to fix buggy hover/long-press behavior on mobile. Tiles are now plain buttons without `Tooltip` from `@zoonk/ui/components/tooltip`, improving tap reliability; translation text is no longer shown as a tooltip.

<sup>Written for commit 96df2e7fa7faf62e9e28a38f350a78dc1394adf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

