### PR TITLE
fix(main): count all lessons in chapter progress

### DIFF
--- a/apps/main/e2e/course-progress.test.ts
+++ b/apps/main/e2e/course-progress.test.ts
@@ -166,6 +166,60 @@ async function createTestCourseWithChapters(userId: number) {
   };
 }
 
+/**
+ * This creates the exact regression case from the catalog page:
+ * one lesson is fully completed, while another published lesson still has no
+ * activities yet. The course page should keep the chapter in progress and show
+ * a fraction instead of a completed checkmark.
+ */
+async function createCourseWithChapterWaitingOnAnotherLesson(userId: number) {
+  const org = await getAiOrganization();
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-progress-edge-course-${uniqueId}`,
+    title: `E2E Progress Edge Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    description: `Edge chapter ${uniqueId}`,
+    isPublished: true,
+    organizationId: org.id,
+    position: 0,
+    slug: `e2e-progress-edge-ch-${uniqueId}`,
+    title: `E2E Edge Chapter ${uniqueId}`,
+  });
+
+  const [completedLesson] = await Promise.all([
+    lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: org.id,
+      position: 0,
+      title: `Completed Lesson ${uniqueId}`,
+    }),
+    lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: org.id,
+      position: 1,
+      title: `Pending Lesson ${uniqueId}`,
+    }),
+  ]);
+
+  const activity = await activityFixture({
+    isPublished: true,
+    lessonId: completedLesson.id,
+    organizationId: org.id,
+    position: 0,
+  });
+
+  return { activity, chapter, course, userId };
+}
+
 test.describe("Course Progress Indicators", () => {
   test("shows no indicators when user has no progress", async ({
     authenticatedPage,
@@ -327,5 +381,31 @@ test.describe("Course Progress Indicators", () => {
 
     // Chapter 2: partially completed -> fraction
     await expect(authenticatedPage.getByLabel("1 of 2 completed")).toBeVisible();
+  });
+
+  test("keeps a chapter in progress when another published lesson has no activities", async ({
+    authenticatedPage,
+    withProgressUser,
+  }) => {
+    const { activity, chapter, course } = await createCourseWithChapterWaitingOnAnotherLesson(
+      withProgressUser.id,
+    );
+
+    await activityProgressFixture({
+      activityId: activity.id,
+      completedAt: new Date(),
+      durationSeconds: 60,
+      userId: withProgressUser.id,
+    });
+
+    await authenticatedPage.goto(`/b/ai/c/${course.slug}`);
+
+    const chapterLink = authenticatedPage.getByRole("link", {
+      name: new RegExp(chapter.title),
+    });
+
+    await expect(chapterLink).toBeVisible();
+    await expect(chapterLink.getByLabel("1 of 2 completed")).toBeVisible();
+    await expect(chapterLink.getByRole("img", { name: /^completed$/i })).toHaveCount(0);
   });
 });

--- a/packages/core/src/progress/get-chapter-progress.test.ts
+++ b/packages/core/src/progress/get-chapter-progress.test.ts
@@ -297,7 +297,7 @@ describe(getChapterProgress, () => {
     expect(result).toEqual([{ chapterId: chapter.id, completedLessons: 0, totalLessons: 0 }]);
   });
 
-  test("lessons with 0 published activities are excluded from total count", async () => {
+  test("lessons with 0 published activities still count as incomplete lessons", async () => {
     const [user, course] = await Promise.all([
       userFixture(),
       courseFixture({ isPublished: true, organizationId: organization.id }),
@@ -310,7 +310,7 @@ describe(getChapterProgress, () => {
       position: 0,
     });
 
-    // Lesson with no activities
+    // Published lessons still count in chapter progress, even before they have activities.
     await lessonFixture({
       chapterId: chapter.id,
       isPublished: true,
@@ -320,7 +320,54 @@ describe(getChapterProgress, () => {
 
     const headers = await signInAs(user.email, user.password);
     const result = await getChapterProgress({ courseId: course.id, headers });
-    // Lesson has no published activities, so it's excluded from totalLessons
-    expect(result).toEqual([{ chapterId: chapter.id, completedLessons: 0, totalLessons: 0 }]);
+    expect(result).toEqual([{ chapterId: chapter.id, completedLessons: 0, totalLessons: 1 }]);
+  });
+
+  test("a chapter stays in progress when another published lesson has no activities", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const [completedLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    const activity = await activityFixture({
+      isPublished: true,
+      lessonId: completedLesson.id,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    await activityProgressFixture({
+      activityId: activity.id,
+      completedAt: new Date(),
+      durationSeconds: 60,
+      userId: Number(user.id),
+    });
+
+    const headers = await signInAs(user.email, user.password);
+    const result = await getChapterProgress({ courseId: course.id, headers });
+
+    expect(result).toEqual([{ chapterId: chapter.id, completedLessons: 1, totalLessons: 2 }]);
   });
 });

--- a/packages/core/src/progress/get-chapter-progress.ts
+++ b/packages/core/src/progress/get-chapter-progress.ts
@@ -2,6 +2,13 @@ import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { getSession } from "../users/get-user-session";
 
+/**
+ * This query powers the chapter list progress on the course page.
+ * We count every published lesson in a published chapter because the catalog
+ * should only show a chapter as complete once every listed lesson is done.
+ * A lesson with zero published activities is therefore still part of the total,
+ * but it cannot count as completed yet.
+ */
 export async function getChapterProgress({
   courseId,
   headers,
@@ -35,11 +42,11 @@ export async function getChapterProgress({
         SELECT
           l.id AS lesson_id,
           l.chapter_id,
-          COUNT(a.id)::int AS total_activities,
-          COUNT(CASE WHEN ap.completed_at IS NOT NULL THEN 1 END)::int AS completed_activities
+          COUNT(DISTINCT a.id)::int AS total_activities,
+          COUNT(DISTINCT CASE WHEN ap.completed_at IS NOT NULL THEN a.id END)::int AS completed_activities
         FROM lessons l
         JOIN chapters ch ON ch.id = l.chapter_id AND ch.course_id = ${courseId} AND ch.is_published = true
-        JOIN activities a ON a.lesson_id = l.id AND a.is_published = true
+        LEFT JOIN activities a ON a.lesson_id = l.id AND a.is_published = true
         LEFT JOIN activity_progress ap ON ap.activity_id = a.id AND ap.user_id = ${userId}
         WHERE l.is_published = true
         GROUP BY l.id, l.chapter_id
@@ -48,7 +55,7 @@ export async function getChapterProgress({
         ch.id AS "chapterId",
         COUNT(ls.lesson_id)::int AS "totalLessons",
         COUNT(CASE
-          WHEN ls.completed_activities = ls.total_activities THEN 1
+          WHEN ls.total_activities > 0 AND ls.completed_activities = ls.total_activities THEN 1
         END)::int AS "completedLessons"
       FROM chapters ch
       LEFT JOIN lesson_status ls ON ls.chapter_id = ch.id


### PR DESCRIPTION
Count every published lesson toward chapter progress so the course chapter list only shows a completed checkmark when all published lessons are complete.

Add integration and e2e regressions for the case where one lesson is complete and another published lesson still has no activities.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix chapter progress to count every published lesson, so a chapter only shows as complete when all published lessons are done. Handles the case where one lesson is completed and another published lesson has no activities by keeping the chapter in progress and showing "1 of 2 completed".

- **Bug Fixes**
  - Updated `getChapterProgress` to include published lessons with zero activities in `totalLessons` (LEFT JOIN, COUNT DISTINCT) and only mark a lesson complete when it has activities and all are done.
  - Added regression tests in `packages/core/src/progress/get-chapter-progress.test.ts` and an e2e test in `apps/main/e2e/course-progress.test.ts` to ensure the chapter shows a fraction instead of a completed checkmark in the described scenario.

<sup>Written for commit 2cbc88cca106f1b4505bf9ea105097441dabf9ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

