### PR TITLE
fix(player): center word tile content vertically

### DIFF
--- a/packages/player/src/components/arrange-words-answer-area.tsx
+++ b/packages/player/src/components/arrange-words-answer-area.tsx
@@ -69,7 +69,7 @@ function PlacedWordTile({
       {...listeners}
       aria-label={ariaLabel}
       className={cn(
-        "border-border flex min-h-11 flex-col items-center rounded-lg border px-4 py-2.5 text-base transition-all duration-150",
+        "border-border flex min-h-11 flex-col items-center justify-center rounded-lg border px-4 py-2.5 text-base transition-all duration-150",
         hasResult && "pointer-events-none",
         !hasResult &&
           "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]",
@@ -97,7 +97,7 @@ function PlacedWordTile({
 
 function DragOverlayWord({ option }: { option: WordBankOption }) {
   return (
-    <div className="bg-background border-border flex min-h-11 flex-col items-center rounded-lg border px-4 py-2.5 text-base shadow-md">
+    <div className="bg-background border-border flex min-h-11 flex-col items-center justify-center rounded-lg border px-4 py-2.5 text-base shadow-md">
       <span>{option.word}</span>
       <RomanizationText>{option.romanization}</RomanizationText>
     </div>

--- a/packages/player/src/components/arrange-words.tsx
+++ b/packages/player/src/components/arrange-words.tsx
@@ -35,7 +35,7 @@ function BankTile({
     <button
       aria-disabled={isUsed}
       className={cn(
-        "border-border flex min-h-11 flex-col items-center rounded-lg border px-4 py-2.5 transition-all duration-150",
+        "border-border flex min-h-11 flex-col items-center justify-center rounded-lg border px-4 py-2.5 transition-all duration-150",
         isUsed
           ? "pointer-events-none opacity-30"
           : "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]",


### PR DESCRIPTION
## Summary
- Add `justify-center` to word bank tiles, placed word tiles, and drag overlay so text is vertically centered when romanization is absent

## Test plan
- [ ] Open an arrange words activity in a non-CJK language (e.g. German)
- [ ] Verify word bank tiles have no extra space below the text
- [ ] Verify placed words in the answer area are vertically centered
- [ ] Open an arrange words activity in a CJK language (e.g. Japanese) and verify romanization still displays correctly below the word

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers word tile content vertically in arrange-words to remove extra bottom space when romanization is missing. Non-CJK tiles align correctly; CJK tiles still show romanization below.

- **Bug Fixes**
  - Added `justify-center` to word bank tiles in `packages/player/src/components/arrange-words.tsx`.
  - Added `justify-center` to placed tiles and the drag overlay in `packages/player/src/components/arrange-words-answer-area.tsx`.

<sup>Written for commit 0c52be2021078029739984172f367154de1e25de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

