### PR TITLE
fix(player): center arrange-word steps and left-align listening prompt

### DIFF
--- a/packages/player/src/components/listening-step.tsx
+++ b/packages/player/src/components/listening-step.tsx
@@ -16,7 +16,7 @@ function AudioPrompt({ audioUrl }: { audioUrl: string }) {
   const t = useExtracted();
 
   return (
-    <div className="flex flex-col items-center gap-3">
+    <div className="flex flex-col gap-3">
       <SectionLabel>{t("What do you hear?")}</SectionLabel>
       <PlayAudioButton audioUrl={audioUrl} />
     </div>

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@zoonk/ui/lib/utils";
 import { type CompletionResult } from "../completion-input-schema";
 import { type PlayerRoute } from "../player-context";
 import {
@@ -19,6 +20,16 @@ function needsFeedbackScreen(step: SerializedStep): boolean {
     step.kind === "reading" ||
     step.kind === "listening"
   );
+}
+
+/**
+ * Arrange-word steps (reading/listening) have compact content
+ * that looks better centered on the screen, while other
+ * interactive steps (e.g. multiple choice) work better
+ * top-aligned.
+ */
+function shouldCenterStep(step: SerializedStep): boolean {
+  return step.kind === "reading" || step.kind === "listening";
 }
 
 export function StageContent({
@@ -82,7 +93,10 @@ export function StageContent({
   if ((phase === "playing" || phase === "feedback") && currentStep) {
     return (
       <div
-        className="animate-in fade-in flex min-h-0 w-full min-w-0 flex-1 flex-col items-center duration-150 ease-out motion-reduce:animate-none sm:justify-center"
+        className={cn(
+          "animate-in fade-in flex min-h-0 w-full min-w-0 flex-1 flex-col items-center duration-150 ease-out motion-reduce:animate-none",
+          shouldCenterStep(currentStep) && "justify-center",
+        )}
         key={`step-${currentStepIndex}`}
       >
         <StepRenderer


### PR DESCRIPTION
## Summary
- Center reading/listening (arrange-word) steps vertically on screen instead of top-aligning them like other interactive steps
- Left-align the listening audio prompt label and play button for consistency with other left-aligned labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers arrange-word steps (reading and listening) vertically while keeping other step types top-aligned. Also left-aligns the listening prompt label and play button for consistency.

- **Bug Fixes**
  - Conditionally apply `justify-center` for `reading`/`listening` in `StageContent`; other steps remain top-aligned.
  - Remove `items-center` from the listening prompt container to left-align the label and `PlayAudioButton`.

<sup>Written for commit 9d1b8d8042f6145ffdc60030376759cb791d5f05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

