### PR TITLE
fix(player): preload interactive audio

### DIFF
--- a/packages/player/src/components/arrange-words.tsx
+++ b/packages/player/src/components/arrange-words.tsx
@@ -118,7 +118,10 @@ export function ArrangeWordsInteraction({
     return [];
   });
 
-  const { play } = useWordAudio();
+  const { play } = useWordAudio({
+    preloadUrls: wordBankOptions.map((option) => option.audioUrl),
+  });
+
   const maxAnswerLength = Math.max(...acceptedWordLengths, correctWords.length);
 
   const syncSelectedAnswer = useCallback(

--- a/packages/player/src/components/feedback-screen.tsx
+++ b/packages/player/src/components/feedback-screen.tsx
@@ -204,7 +204,7 @@ function CoreFeedback({ result, step }: { result: StepResult; step?: SerializedS
       </div>
 
       {step?.sentence?.audioUrl && (
-        <PlayAudioButton audioUrl={step.sentence.audioUrl} variant="text" />
+        <PlayAudioButton audioUrl={step.sentence.audioUrl} preload={false} variant="text" />
       )}
 
       {feedback && <FeedbackMessage>{feedback}</FeedbackMessage>}

--- a/packages/player/src/components/play-audio-button.tsx
+++ b/packages/player/src/components/play-audio-button.tsx
@@ -8,16 +8,22 @@ import { useWordAudio } from "../use-word-audio";
 
 export function PlayAudioButton({
   audioUrl,
+  preload = true,
   size = "md",
   variant = "filled",
 }: {
   audioUrl: string;
+  preload?: boolean;
   size?: "sm" | "md";
   variant?: "filled" | "text";
 }) {
   const t = useExtracted();
   const [isPlaying, setIsPlaying] = useState(false);
-  const { pause, play } = useWordAudio({ onEnded: () => setIsPlaying(false) });
+
+  const { pause, play } = useWordAudio({
+    onEnded: () => setIsPlaying(false),
+    preloadUrls: preload ? [audioUrl] : undefined,
+  });
 
   const handleClick = () => {
     if (isPlaying) {

--- a/packages/player/src/components/translation-step.tsx
+++ b/packages/player/src/components/translation-step.tsx
@@ -49,10 +49,13 @@ export function TranslationStep({
   step: SerializedStep;
 }) {
   const t = useExtracted();
-  const { play } = useWordAudio();
   const correctWord = step.word;
   const selectedWordId = getSelectedWordId(selectedAnswer);
   const options = step.translationOptions;
+
+  const { play } = useWordAudio({
+    preloadUrls: options.map((word) => word.audioUrl),
+  });
 
   const handleSelect = (index: number) => {
     const word = options[index];

--- a/packages/player/src/use-word-audio.test.ts
+++ b/packages/player/src/use-word-audio.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { useWordAudio } from "./use-word-audio";
+
+class MockAudio {
+  static instances: MockAudio[] = [];
+
+  currentTime = 0;
+  preload = "";
+  readyState = 0;
+  src = "";
+
+  private readonly listeners = new Map<string, (() => void)[]>();
+
+  addEventListener = vi.fn((event: string, handler: () => void) => {
+    const currentHandlers = this.listeners.get(event) ?? [];
+    this.listeners.set(event, [...currentHandlers, handler]);
+  });
+
+  load = vi.fn(() => {
+    this.readyState = 4;
+  });
+
+  pause = vi.fn();
+
+  play = vi.fn(() => Promise.resolve());
+
+  removeAttribute = vi.fn((attribute: string) => {
+    if (attribute === "src") {
+      this.src = "";
+    }
+  });
+
+  constructor() {
+    MockAudio.instances.push(this);
+  }
+
+  dispatch(event: string) {
+    this.listeners.get(event)?.forEach((handler) => handler());
+  }
+}
+
+describe(useWordAudio, () => {
+  beforeEach(() => {
+    MockAudio.instances = [];
+    vi.stubGlobal("Audio", MockAudio as unknown as typeof Audio);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  test("preloads each unique audio url once and reuses it for playback", () => {
+    const urlA = "https://example.com/a.mp3";
+    const urlB = "https://example.com/b.mp3";
+    const { result } = renderHook(() => useWordAudio({ preloadUrls: [urlA, null, urlA, urlB] }));
+
+    expect(MockAudio.instances).toHaveLength(2);
+
+    const [audioA, audioB] = MockAudio.instances;
+
+    expect(audioA?.src).toBe(urlA);
+    expect(audioB?.src).toBe(urlB);
+    expect(audioA?.load).toHaveBeenCalledOnce();
+    expect(audioB?.load).toHaveBeenCalledOnce();
+
+    act(() => {
+      result.current.play(urlA);
+    });
+
+    expect(MockAudio.instances).toHaveLength(2);
+    expect(audioA?.play).toHaveBeenCalledOnce();
+  });
+
+  test("playing a new url stops the previous clip and restarts the next one from the beginning", () => {
+    const urlA = "https://example.com/a.mp3";
+    const urlB = "https://example.com/b.mp3";
+    const { result } = renderHook(() => useWordAudio({ preloadUrls: [urlA, urlB] }));
+    const [audioA, audioB] = MockAudio.instances;
+
+    if (!audioA || !audioB) {
+      throw new Error("Expected preloaded audio instances");
+    }
+
+    audioA.currentTime = 1.2;
+    audioB.currentTime = 2.4;
+
+    act(() => {
+      result.current.play(urlA);
+    });
+
+    act(() => {
+      result.current.play(urlB);
+    });
+
+    expect(audioA.pause).toHaveBeenCalledOnce();
+    expect(audioA.currentTime).toBe(0);
+    expect(audioB.currentTime).toBe(0);
+    expect(audioB.play).toHaveBeenCalledOnce();
+  });
+
+  test("forwards ended events to the caller", () => {
+    const onEnded = vi.fn();
+    const url = "https://example.com/a.mp3";
+    const { result } = renderHook(() => useWordAudio({ onEnded }));
+
+    act(() => {
+      result.current.play(url);
+    });
+
+    const [audio] = MockAudio.instances;
+
+    if (!audio) {
+      throw new Error("Expected a created audio instance");
+    }
+
+    act(() => {
+      audio.dispatch("ended");
+    });
+
+    expect(onEnded).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/player/src/use-word-audio.ts
+++ b/packages/player/src/use-word-audio.ts
@@ -1,42 +1,140 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useEffectEvent, useRef } from "react";
 
-export function useWordAudio(options?: { onEnded?: () => void }): {
+type UseWordAudioOptions = {
+  onEnded?: () => void;
+  preloadUrls?: (string | null)[];
+};
+
+/**
+ * Word banks can repeat the same audio URL or include empty entries. Normalizing the list in one
+ * place keeps the preload effect focused on the small set of files that can actually be played.
+ */
+function getUniqueAudioUrls(urls: (string | null)[] | undefined): string[] {
+  if (!urls) {
+    return [];
+  }
+
+  return [...new Set(urls.filter((url): url is string => Boolean(url)))];
+}
+
+/**
+ * Reusing one audio element per URL avoids paying the fetch and decode cost on every tap. The
+ * element is also configured for eager loading so short vocabulary clips are warm before playback.
+ */
+function createAudioElement(url: string, onEnded: () => void): HTMLAudioElement {
+  const audio = new Audio();
+  audio.preload = "auto";
+  audio.src = url;
+  audio.addEventListener("ended", onEnded);
+  return audio;
+}
+
+/**
+ * Resetting playback to the beginning ensures rapid reselection always restarts the same word from
+ * the start instead of resuming from a partially played clip.
+ */
+function resetAudio(audio: HTMLAudioElement): void {
+  audio.pause();
+  audio.currentTime = 0;
+}
+
+/**
+ * Short language clips need to start as close to instantly as possible. This hook keeps a warm
+ * audio element per URL, optionally preloads likely clips on mount, and exposes simple play/pause
+ * helpers for interaction components.
+ */
+export function useWordAudio(options?: UseWordAudioOptions): {
   pause: () => void;
   play: (url: string | null) => void;
 } {
-  const audioRef = useRef<HTMLAudioElement | null>(null);
-  const onEndedRef = useRef(options?.onEnded);
-  onEndedRef.current = options?.onEnded;
+  const activeAudioRef = useRef<HTMLAudioElement | null>(null);
+  const audioCacheRef = useRef<Map<string, HTMLAudioElement>>(new Map());
+  const preloadKey = getUniqueAudioUrls(options?.preloadUrls).join("\n");
 
-  const play = useCallback((url: string | null) => {
-    if (!url) {
+  const handleEnded = useEffectEvent((audio: HTMLAudioElement) => {
+    if (activeAudioRef.current === audio) {
+      activeAudioRef.current = null;
+    }
+
+    options?.onEnded?.();
+  });
+
+  const getAudio = useCallback((url: string) => {
+    const cachedAudio = audioCacheRef.current.get(url);
+
+    if (cachedAudio) {
+      return cachedAudio;
+    }
+
+    const audio = createAudioElement(url, () => handleEnded(audio));
+
+    audioCacheRef.current.set(url, audio);
+
+    return audio;
+  }, []);
+
+  const play = useCallback(
+    (url: string | null) => {
+      if (!url) {
+        return;
+      }
+
+      const nextAudio = getAudio(url);
+      const currentAudio = activeAudioRef.current;
+
+      if (currentAudio && currentAudio !== nextAudio) {
+        resetAudio(currentAudio);
+      }
+
+      activeAudioRef.current = nextAudio;
+      nextAudio.currentTime = 0;
+
+      if (nextAudio.readyState === 0) {
+        nextAudio.load();
+      }
+
+      // Browser rejects play() when rapid clicks lose the user-gesture association.
+      // oxlint-disable-next-line no-empty-function -- intentional no-op for rejected play()
+      nextAudio.play().catch(() => {});
+    },
+    [getAudio],
+  );
+
+  const pause = useCallback(() => {
+    const activeAudio = activeAudioRef.current;
+
+    if (!activeAudio) {
       return;
     }
 
-    if (!audioRef.current) {
-      audioRef.current = new Audio();
-      audioRef.current.addEventListener("ended", () => {
-        onEndedRef.current?.();
-      });
-    }
-
-    const audio = audioRef.current;
-    audio.pause();
-    audio.src = url;
-    // Browser rejects play() when rapid clicks lose the user-gesture association.
-    // oxlint-disable-next-line no-empty-function -- intentional no-op for rejected play()
-    audio.play().catch(() => {});
+    resetAudio(activeAudio);
+    activeAudioRef.current = null;
   }, []);
 
-  const pause = useCallback(() => {
-    audioRef.current?.pause();
-  }, []);
+  useEffect(() => {
+    const preloadUrls = preloadKey ? preloadKey.split("\n") : [];
+
+    preloadUrls.forEach((url) => {
+      const audio = getAudio(url);
+
+      if (audio.readyState === 0) {
+        audio.load();
+      }
+    });
+  }, [getAudio, preloadKey]);
 
   useEffect(
     () => () => {
-      audioRef.current?.pause();
+      audioCacheRef.current.forEach((audio) => {
+        audio.pause();
+        audio.removeAttribute("src");
+        audio.load();
+      });
+
+      audioCacheRef.current.clear();
+      activeAudioRef.current = null;
     },
     [],
   );


### PR DESCRIPTION
## Summary
- preload interactive audio in player activities by default and opt out on the feedback screen
- cache and reuse audio elements per URL in `useWordAudio`, using `useEffectEvent` for the ended callback
- add hook coverage for audio reuse, switching, and cleanup behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preloads and reuses interactive audio to make playback start faster in player activities. Defaults to preloading during interactions and opts out on the feedback screen.

- **New Features**
  - `useWordAudio` caches one `Audio` element per URL, supports `preloadUrls`, and forwards `onEnded` via `useEffectEvent`.
  - `ArrangeWords` and `TranslationStep` pass candidate URLs to `useWordAudio` for eager loading; `PlayAudioButton` preloads by default and can disable with `preload={false}` (used on the feedback screen).
  - Playback switching resets the previous clip and restarts the next from time 0; preloaded elements call `load()` and are cleaned up on unmount.
  - Added tests for audio reuse, switching behavior, and cleanup.

<sup>Written for commit cb50fcc6c6752b74e1efe9be41149aaac78fd009. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

