### PR TITLE
fix(player): top up safe language distractors

### DIFF
--- a/apps/main/e2e/reading-step.test.ts
+++ b/apps/main/e2e/reading-step.test.ts
@@ -12,6 +12,12 @@ import { wordFixture } from "@zoonk/testing/fixtures/words";
 import { type Page, expect, test } from "./fixtures";
 
 async function createReadingActivity(options: {
+  fallbackWords?: {
+    alternativeTranslations?: string[];
+    romanization?: string | null;
+    translation: string;
+    word: string;
+  }[];
   sentences: {
     audioUrl?: string | null;
     alternativeSentences?: string[];
@@ -57,6 +63,18 @@ async function createReadingActivity(options: {
 
   const createdWords = await Promise.all(
     options.words.map((wordData) =>
+      wordFixture({
+        alternativeTranslations: wordData.alternativeTranslations ?? [],
+        organizationId: org.id,
+        romanization: wordData.romanization ?? null,
+        translation: wordData.translation,
+        word: wordData.word,
+      }),
+    ),
+  );
+
+  await Promise.all(
+    (options.fallbackWords ?? []).map((wordData) =>
       wordFixture({
         alternativeTranslations: wordData.alternativeTranslations ?? [],
         organizationId: org.id,
@@ -183,6 +201,54 @@ test.describe("Reading Step", () => {
     await expect(
       wordBank.getByRole("button", { exact: true, name: `perro-${uniqueId}` }),
     ).toBeVisible();
+  });
+
+  test("uses fallback words to keep four visible distractors for short reading steps", async ({
+    page,
+  }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const helloWord = `Hola-${uniqueId}`;
+    const ambiguousWord = `Salut-${uniqueId}`;
+    const worldWord = `mundo-${uniqueId}`;
+
+    const { url } = await createReadingActivity({
+      fallbackWords: [
+        { translation: `dog-${uniqueId}`, word: `perro-${uniqueId}` },
+        { translation: `bird-${uniqueId}`, word: `pajaro-${uniqueId}` },
+        { translation: `fish-${uniqueId}`, word: `pez-${uniqueId}` },
+      ],
+      sentences: [
+        {
+          sentence: `${helloWord} ${worldWord}`,
+          translation: `hello-${uniqueId} world-${uniqueId}`,
+        },
+      ],
+      words: [
+        {
+          alternativeTranslations: [`hi-${uniqueId}`],
+          translation: `hello-${uniqueId}`,
+          word: helloWord,
+        },
+        {
+          alternativeTranslations: [`hello-${uniqueId}`],
+          translation: `hi-${uniqueId}`,
+          word: ambiguousWord,
+        },
+        { translation: `cat-${uniqueId}`, word: `gato-${uniqueId}` },
+      ],
+    });
+
+    await page.goto(url);
+
+    const wordBank = page.getByRole("group", { name: /word bank/i });
+
+    await expect(wordBank.getByRole("button")).toHaveCount(6);
+    await expect(wordBank.getByRole("button", { exact: true, name: helloWord })).toBeVisible();
+    await expect(wordBank.getByRole("button", { exact: true, name: worldWord })).toBeVisible();
+    await expect(
+      wordBank.getByRole("button", { exact: true, name: `gato-${uniqueId}` }),
+    ).toBeVisible();
+    await expect(wordBank.getByRole("button", { exact: true, name: ambiguousWord })).toHaveCount(0);
   });
 
   test("tapping words adds them to the answer area in order", async ({ page }) => {

--- a/apps/main/e2e/translation-step.test.ts
+++ b/apps/main/e2e/translation-step.test.ts
@@ -11,6 +11,14 @@ import { type Page, expect, test } from "./fixtures";
 
 async function createTranslationActivity(options: {
   words: {
+    alternativeTranslations?: string[];
+    word: string;
+    translation: string;
+    pronunciation?: string | null;
+    romanization?: string | null;
+  }[];
+  fallbackWords?: {
+    alternativeTranslations?: string[];
     word: string;
     translation: string;
     pronunciation?: string | null;
@@ -48,6 +56,20 @@ async function createTranslationActivity(options: {
   const createdWords = await Promise.all(
     options.words.map((wordData) =>
       wordFixture({
+        alternativeTranslations: wordData.alternativeTranslations ?? [],
+        organizationId: org.id,
+        pronunciation: wordData.pronunciation ?? null,
+        romanization: wordData.romanization ?? null,
+        translation: wordData.translation,
+        word: wordData.word,
+      }),
+    ),
+  );
+
+  await Promise.all(
+    (options.fallbackWords ?? []).map((wordData) =>
+      wordFixture({
+        alternativeTranslations: wordData.alternativeTranslations ?? [],
         organizationId: org.id,
         pronunciation: wordData.pronunciation ?? null,
         romanization: wordData.romanization ?? null,
@@ -145,6 +167,43 @@ test.describe("Translation Step", () => {
     await expect(radiogroup).toBeVisible();
     await expect(radiogroup.getByRole("radio")).toHaveCount(4);
     await expect(radiogroup.getByRole("radio", { name: new RegExp(word) })).toBeVisible();
+  });
+
+  test("uses fallback words to keep four safe options when lesson words overlap in meaning", async ({
+    page,
+  }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const correctWord = `hola-${uniqueId}`;
+    const ambiguousWord = `oi-${uniqueId}`;
+
+    const { url } = await createTranslationActivity({
+      fallbackWords: [
+        { translation: `dog-${uniqueId}`, word: `perro-${uniqueId}` },
+        { translation: `bird-${uniqueId}`, word: `pajaro-${uniqueId}` },
+      ],
+      words: [
+        {
+          alternativeTranslations: [`hi-${uniqueId}`],
+          translation: `hello-${uniqueId}`,
+          word: correctWord,
+        },
+        {
+          alternativeTranslations: [`hello-${uniqueId}`],
+          translation: `hi-${uniqueId}`,
+          word: ambiguousWord,
+        },
+        { translation: `cat-${uniqueId}`, word: `gato-${uniqueId}` },
+      ],
+    });
+
+    await page.goto(url);
+
+    const radiogroup = page.getByRole("radiogroup", { name: /answer options/i });
+
+    await expect(radiogroup.getByRole("radio")).toHaveCount(4);
+    await expect(radiogroup.getByRole("radio", { name: correctWord })).toBeVisible();
+    await expect(radiogroup.getByRole("radio", { name: `gato-${uniqueId}` })).toBeVisible();
+    await expect(radiogroup.getByRole("radio", { name: ambiguousWord })).toHaveCount(0);
   });
 
   test("select correct option and check shows feedback with translate context and answer", async ({

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
@@ -1,4 +1,5 @@
 import { getActivity } from "@/data/activities/get-activity";
+import { getFallbackDistractorWords } from "@/data/activities/get-fallback-distractor-words";
 import { getLessonSentences } from "@/data/activities/get-lesson-sentences";
 import { getLessonWords } from "@/data/activities/get-lesson-words";
 import { getSentenceWords } from "@/data/activities/get-sentence-words";
@@ -62,6 +63,7 @@ export default async function ActivityPage({ params }: Props) {
     lessonWords,
     lessonSentences,
     sentenceWords,
+    fallbackDistractorWords,
     nextActivity,
     session,
     reviewSteps,
@@ -71,6 +73,7 @@ export default async function ActivityPage({ params }: Props) {
     getLessonWords({ lessonId: lesson.id }),
     getLessonSentences({ lessonId: lesson.id }),
     getSentenceWords({ lessonId: lesson.id }),
+    getFallbackDistractorWords({ lessonId: lesson.id }),
     getNextActivityInCourse({
       activityPosition,
       chapterId: lesson.chapter.id,
@@ -101,6 +104,7 @@ export default async function ActivityPage({ params }: Props) {
     lessonWords,
     lessonSentences,
     sentenceWords,
+    fallbackDistractorWords,
   );
 
   if (session) {

--- a/apps/main/src/data/activities/get-fallback-distractor-words.test.ts
+++ b/apps/main/src/data/activities/get-fallback-distractor-words.test.ts
@@ -1,0 +1,123 @@
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonSentenceFixture } from "@zoonk/testing/fixtures/lesson-sentences";
+import { lessonWordFixture } from "@zoonk/testing/fixtures/lesson-words";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { sentenceFixture } from "@zoonk/testing/fixtures/sentences";
+import { wordFixture } from "@zoonk/testing/fixtures/words";
+import { beforeAll, describe, expect, test } from "vitest";
+import { getFallbackDistractorWords } from "./get-fallback-distractor-words";
+
+describe(getFallbackDistractorWords, () => {
+  let chapter: Awaited<ReturnType<typeof chapterFixture>>;
+  let org: Awaited<ReturnType<typeof organizationFixture>>;
+
+  beforeAll(async () => {
+    org = await organizationFixture({ kind: "brand" });
+
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: org.id,
+      targetLanguage: "es",
+    });
+
+    chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: org.id,
+    });
+  });
+
+  test("returns up to four extra words and excludes lesson word ids", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: org.id,
+    });
+    const lessonWord = await wordFixture({
+      organizationId: org.id,
+      targetLanguage: "es",
+      translation: `hello-${crypto.randomUUID()}`,
+      userLanguage: "en",
+      word: `hola-${crypto.randomUUID()}`,
+    });
+    await lessonWordFixture({ lessonId: lesson.id, wordId: lessonWord.id });
+
+    const extraWords = await Promise.all(
+      Array.from({ length: 6 }, (_, index) =>
+        wordFixture({
+          organizationId: org.id,
+          targetLanguage: "es",
+          translation: `extra-${index}-${crypto.randomUUID()}`,
+          userLanguage: "en",
+          word: `word-${index}-${crypto.randomUUID()}`,
+        }),
+      ),
+    );
+
+    const otherOrg = await organizationFixture({ kind: "brand" });
+    await wordFixture({
+      organizationId: otherOrg.id,
+      targetLanguage: "es",
+      translation: `other-org-${crypto.randomUUID()}`,
+      userLanguage: "en",
+      word: `otro-${crypto.randomUUID()}`,
+    });
+
+    const result = await getFallbackDistractorWords({ lessonId: lesson.id });
+
+    expect(result).toHaveLength(4);
+    expect(result.map((word) => word.id)).not.toContain(lessonWord.id);
+    expect(
+      result.every((word) => extraWords.some((extraWord) => extraWord.id === word.id)),
+    ).toBeTruthy();
+  });
+
+  test("uses sentence language scope when there are no lesson words", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: org.id,
+    });
+    const sentence = await sentenceFixture({
+      organizationId: org.id,
+      sentence: `hola-${crypto.randomUUID()} mundo-${crypto.randomUUID()}`,
+      targetLanguage: "es",
+      translation: `hello-${crypto.randomUUID()} world-${crypto.randomUUID()}`,
+      userLanguage: "en",
+    });
+    await lessonSentenceFixture({ lessonId: lesson.id, sentenceId: sentence.id });
+
+    const scopedWord = await wordFixture({
+      organizationId: org.id,
+      targetLanguage: "es",
+      translation: `cat-${crypto.randomUUID()}`,
+      userLanguage: "en",
+      word: `gato-${crypto.randomUUID()}`,
+    });
+
+    await wordFixture({
+      organizationId: org.id,
+      targetLanguage: "fr",
+      translation: `cat-${crypto.randomUUID()}`,
+      userLanguage: "en",
+      word: `chat-${crypto.randomUUID()}`,
+    });
+
+    const result = await getFallbackDistractorWords({ lessonId: lesson.id, limit: 10 });
+
+    expect(result.map((word) => word.id)).toContain(scopedWord.id);
+  });
+
+  test("returns empty array when there is no lesson scope to derive fallback words from", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: org.id,
+    });
+    const result = await getFallbackDistractorWords({ lessonId: lesson.id });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/main/src/data/activities/get-fallback-distractor-words.ts
+++ b/apps/main/src/data/activities/get-fallback-distractor-words.ts
@@ -1,0 +1,69 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+import { getLessonSentences } from "./get-lesson-sentences";
+import { getLessonWords } from "./get-lesson-words";
+
+const FALLBACK_DISTRACTOR_WORD_LIMIT = 4;
+
+type LessonWordScope = {
+  id: bigint;
+  organizationId: number;
+  targetLanguage: string;
+  userLanguage: string;
+};
+
+type LessonSentenceScope = {
+  organizationId: number;
+  targetLanguage: string;
+  userLanguage: string;
+};
+
+/**
+ * We fetch fallback distractors from the same language context as the lesson so
+ * the player can fill rare underflow cases without building a larger scope system.
+ */
+function getFallbackWordScope(
+  lessonWords: LessonWordScope[],
+  lessonSentences: LessonSentenceScope[],
+): LessonSentenceScope | LessonWordScope | null {
+  return lessonWords[0] ?? lessonSentences[0] ?? null;
+}
+
+/**
+ * Fallback distractors depend on lesson words for excluded ids and on lesson
+ * sentences for a sentence-only language scope, so this helper runs the whole
+ * lookup in one cached function. That keeps the API small and makes the cache
+ * key match the only public inputs: lesson id and limit.
+ */
+const cachedGetFallbackDistractorWords = cache(async (lessonId: number, limit: number) => {
+  const [lessonWords, lessonSentences] = await Promise.all([
+    getLessonWords({ lessonId }),
+    getLessonSentences({ lessonId }),
+  ]);
+
+  const scope = getFallbackWordScope(lessonWords, lessonSentences);
+
+  if (!scope) {
+    return [];
+  }
+
+  return prisma.word.findMany({
+    include: { wordAudio: true },
+    orderBy: { id: "desc" },
+    take: limit,
+    where: {
+      id: { notIn: lessonWords.map((word) => word.id) },
+      organizationId: scope.organizationId,
+      targetLanguage: scope.targetLanguage,
+      userLanguage: scope.userLanguage,
+    },
+  });
+});
+
+export function getFallbackDistractorWords(params: { lessonId: number; limit?: number }) {
+  return cachedGetFallbackDistractorWords(
+    params.lessonId,
+    params.limit ?? FALLBACK_DISTRACTOR_WORD_LIMIT,
+  );
+}

--- a/apps/main/src/data/activities/prepare-activity-data.test.ts
+++ b/apps/main/src/data/activities/prepare-activity-data.test.ts
@@ -416,6 +416,198 @@ describe(prepareActivityData, () => {
     );
   });
 
+  test("translation options use fallback words without leaking them into lessonWords", () => {
+    const stepWord = {
+      alternativeTranslations: ["hi"],
+      id: BigInt(11),
+      pronunciation: null,
+      romanization: null,
+      translation: "hello",
+      word: "hola",
+      wordAudio: null,
+    };
+
+    const lessonWords = [
+      stepWord,
+      {
+        alternativeTranslations: ["hello"],
+        id: BigInt(12),
+        pronunciation: null,
+        romanization: null,
+        translation: "hi",
+        word: "oi",
+        wordAudio: null,
+      },
+      {
+        alternativeTranslations: [],
+        id: BigInt(13),
+        pronunciation: null,
+        romanization: null,
+        translation: "cat",
+        word: "gato",
+        wordAudio: null,
+      },
+    ];
+
+    const fallbackWords = [
+      {
+        alternativeTranslations: [],
+        id: BigInt(14),
+        pronunciation: null,
+        romanization: null,
+        translation: "dog",
+        word: "perro",
+        wordAudio: null,
+      },
+      {
+        alternativeTranslations: [],
+        id: BigInt(15),
+        pronunciation: null,
+        romanization: null,
+        translation: "bird",
+        word: "pajaro",
+        wordAudio: null,
+      },
+    ];
+
+    const activity = {
+      description: null,
+      generationRunId: null,
+      generationStatus: "completed",
+      id: BigInt(16),
+      kind: "translation",
+      language: "en",
+      organizationId: 1,
+      position: 0,
+      steps: [
+        {
+          content: {},
+          id: BigInt(17),
+          kind: "translation",
+          position: 0,
+          sentence: null,
+          word: stepWord,
+        },
+      ],
+      title: "Translation Fallback",
+    };
+
+    const result = prepareActivityData(activity, lessonWords, [], [], fallbackWords);
+    const translationOptions = result.steps[0]?.translationOptions ?? [];
+
+    expect(translationOptions.map((word) => word.word).toSorted()).toEqual([
+      "gato",
+      "hola",
+      "pajaro",
+      "perro",
+    ]);
+    expect(result.lessonWords.map((word) => word.word).toSorted()).toEqual(["gato", "hola", "oi"]);
+  });
+
+  test("reading word bank uses fallback words to reach four visible distractors without leaking them into lessonWords", () => {
+    const lessonWords = [
+      {
+        alternativeTranslations: ["hi"],
+        id: BigInt(18),
+        pronunciation: null,
+        romanization: null,
+        translation: "hello",
+        word: "Hola",
+        wordAudio: null,
+      },
+      {
+        alternativeTranslations: ["hello"],
+        id: BigInt(19),
+        pronunciation: null,
+        romanization: null,
+        translation: "hi",
+        word: "Salut",
+        wordAudio: null,
+      },
+      {
+        alternativeTranslations: [],
+        id: BigInt(20),
+        pronunciation: null,
+        romanization: null,
+        translation: "cat",
+        word: "gato",
+        wordAudio: null,
+      },
+    ];
+
+    const fallbackWords = [
+      {
+        alternativeTranslations: [],
+        id: BigInt(21),
+        pronunciation: null,
+        romanization: null,
+        translation: "dog",
+        word: "perro",
+        wordAudio: null,
+      },
+      {
+        alternativeTranslations: [],
+        id: BigInt(22),
+        pronunciation: null,
+        romanization: null,
+        translation: "bird",
+        word: "pajaro",
+        wordAudio: null,
+      },
+      {
+        alternativeTranslations: [],
+        id: BigInt(23),
+        pronunciation: null,
+        romanization: null,
+        translation: "fish",
+        word: "pez",
+        wordAudio: null,
+      },
+    ];
+
+    const activity = {
+      description: null,
+      generationRunId: null,
+      generationStatus: "completed",
+      id: BigInt(24),
+      kind: "reading",
+      language: "en",
+      organizationId: 1,
+      position: 0,
+      steps: [
+        {
+          content: {},
+          id: BigInt(25),
+          kind: "reading",
+          position: 0,
+          sentence: {
+            alternativeSentences: [],
+            alternativeTranslations: [],
+            explanation: null,
+            id: BigInt(26),
+            romanization: null,
+            sentence: "Hola mundo",
+            sentenceAudio: null,
+            translation: "Hello world",
+          },
+          word: null,
+        },
+      ],
+      title: "Reading Fallback",
+    };
+
+    const result = prepareActivityData(activity, lessonWords, [], [], fallbackWords);
+    const wordBankWords = (result.steps[0]?.wordBankOptions ?? []).map((option) => option.word);
+
+    expect(wordBankWords).toHaveLength(6);
+    expect(wordBankWords.toSorted()).toEqual(["Hola", "gato", "mundo", "pajaro", "perro", "pez"]);
+    expect(result.lessonWords.map((word) => word.word).toSorted()).toEqual([
+      "Hola",
+      "Salut",
+      "gato",
+    ]);
+  });
+
   test("reading step gets word bank with sentence words and distractors from lesson word fields", async () => {
     const uniqueId = crypto.randomUUID().slice(0, 8);
     const sentenceText = `Hola mundo ${uniqueId}`;

--- a/packages/player/src/build-word-bank-options.test.ts
+++ b/packages/player/src/build-word-bank-options.test.ts
@@ -219,6 +219,52 @@ describe(buildWordBankOptions, () => {
     expect(words).not.toContain("gato");
     expect(words).not.toContain("prueba");
   });
+
+  test("tops up reading distractors from fallback words until there are four visible distractors", () => {
+    const options = buildWordBankOptions(
+      makeReadingStep("Hola mundo"),
+      [
+        makeLessonWord("1", "Hola", "hello", ["hi"]),
+        makeLessonWord("2", "Salut", "hi", ["hello"]),
+        makeLessonWord("3", "gato", "cat"),
+      ],
+      new Map(),
+      [
+        makeLessonWord("4", "perro", "dog"),
+        makeLessonWord("5", "pajaro", "bird"),
+        makeLessonWord("6", "pez", "fish"),
+      ],
+    );
+
+    const words = options.map((option) => option.word);
+
+    expect(words).toHaveLength(6);
+    expect(words).toEqual(["Hola", "mundo", "gato", "perro", "pajaro", "pez"]);
+    expect(words).not.toContain("Salut");
+  });
+
+  test("tops up listening distractors from fallback words until there are four visible distractors", () => {
+    const options = buildWordBankOptions(
+      makeListeningStep("hello world"),
+      [
+        makeLessonWord("1", "bonjour", "hello", ["hi"]),
+        makeLessonWord("2", "salut", "hi", ["hello"]),
+        makeLessonWord("3", "chat", "cat"),
+      ],
+      new Map(),
+      [
+        makeLessonWord("4", "chien", "dog"),
+        makeLessonWord("5", "oiseau", "bird"),
+        makeLessonWord("6", "poisson", "fish"),
+      ],
+    );
+
+    const words = options.map((option) => option.word);
+
+    expect(words).toHaveLength(6);
+    expect(words).toEqual(["hello", "world", "cat", "dog", "bird", "fish"]);
+    expect(words).not.toContain("hi");
+  });
 });
 
 describe(buildSentenceWordOptions, () => {

--- a/packages/player/src/build-word-bank-options.test.ts
+++ b/packages/player/src/build-word-bank-options.test.ts
@@ -23,6 +23,27 @@ function makeLessonWord(
   };
 }
 
+function makeWordWithMetadata(
+  id: string,
+  word: string,
+  translation: string,
+  metadata: {
+    audioUrl: string | null;
+    romanization: string | null;
+  },
+  alternativeTranslations: string[] = [],
+): SerializedWord {
+  return {
+    alternativeTranslations,
+    audioUrl: metadata.audioUrl,
+    id,
+    pronunciation: null,
+    romanization: metadata.romanization,
+    translation,
+    word,
+  };
+}
+
 function makeReadingStep(sentence: string): SerializedStep<"reading"> {
   return {
     content: {},
@@ -241,6 +262,31 @@ describe(buildWordBankOptions, () => {
     expect(words).toHaveLength(6);
     expect(words).toEqual(["Hola", "mundo", "gato", "perro", "pajaro", "pez"]);
     expect(words).not.toContain("Salut");
+  });
+
+  test("preserves metadata for fallback reading distractors", () => {
+    const options = buildWordBankOptions(
+      makeReadingStep("Hola mundo"),
+      [
+        makeLessonWord("1", "Hola", "hello", ["hi"]),
+        makeLessonWord("2", "Salut", "hi", ["hello"]),
+        makeLessonWord("3", "gato", "cat"),
+      ],
+      new Map(),
+      [
+        makeWordWithMetadata("4", "perro", "dog", {
+          audioUrl: "https://example.com/perro.mp3",
+          romanization: "pe-rro",
+        }),
+      ],
+    );
+
+    expect(options).toContainEqual({
+      audioUrl: "https://example.com/perro.mp3",
+      romanization: "pe-rro",
+      translation: "dog",
+      word: "perro",
+    });
   });
 
   test("tops up listening distractors from fallback words until there are four visible distractors", () => {

--- a/packages/player/src/build-word-bank-options.ts
+++ b/packages/player/src/build-word-bank-options.ts
@@ -43,6 +43,18 @@ function buildLessonWordLookup(
 }
 
 /**
+ * Fallback distractors should render with the same metadata as lesson distractors.
+ * We merge both sources into one lookup and keep lesson words last so the visible
+ * lesson payload stays the source of truth if both pools contain the same token.
+ */
+function buildWordMetadataLookup(
+  serializedLessonWords: SerializedWord[],
+  fallbackLessonWords: SerializedWord[],
+): Map<string, SerializedWord> {
+  return buildLessonWordLookup([...fallbackLessonWords, ...serializedLessonWords]);
+}
+
+/**
  * The incoming map can be keyed with raw words, but the player resolves options with
  * normalized tokens. Re-key the values here so callers do not need to care which form
  * the original map used.
@@ -84,9 +96,10 @@ function getWordMetadata(
  */
 function createEnrichedWordOptionBuilder(
   serializedLessonWords: SerializedWord[],
+  fallbackLessonWords: SerializedWord[],
   sentenceWordMap: Map<string, WordDataInput>,
 ): (word: string) => WordBankOption {
-  const lessonWordLookup = buildLessonWordLookup(serializedLessonWords);
+  const lessonWordLookup = buildWordMetadataLookup(serializedLessonWords, fallbackLessonWords);
   const sentenceWordLookup = buildSentenceWordLookup(sentenceWordMap);
 
   return (word) => ({
@@ -222,7 +235,7 @@ export function buildSentenceWordOptions(
   serializedLessonWords: SerializedWord[],
   sentenceWordMap: Map<string, WordDataInput>,
 ): WordBankOption[] {
-  const buildOption = createEnrichedWordOptionBuilder(serializedLessonWords, sentenceWordMap);
+  const buildOption = createEnrichedWordOptionBuilder(serializedLessonWords, [], sentenceWordMap);
 
   return segmentWords(sentence).map((word) => buildOption(word));
 }
@@ -296,12 +309,17 @@ function createWordBankOptionBuilder(
   stepKind: SerializedStep["kind"],
   serializedLessonWords: SerializedWord[],
   sentenceWordMap: Map<string, WordDataInput>,
+  fallbackLessonWords: SerializedWord[],
 ): (word: string) => WordBankOption {
   if (stepKind !== "reading") {
     return emptyWordOption;
   }
 
-  return createEnrichedWordOptionBuilder(serializedLessonWords, sentenceWordMap);
+  return createEnrichedWordOptionBuilder(
+    serializedLessonWords,
+    fallbackLessonWords,
+    sentenceWordMap,
+  );
 }
 
 export function buildWordBankOptions(
@@ -322,6 +340,7 @@ export function buildWordBankOptions(
     step.kind,
     serializedLessonWords,
     sentenceWordMap,
+    fallbackLessonWords,
   );
 
   const acceptedWordSet = getAcceptedArrangeWordSet(acceptedWordSequences);

--- a/packages/player/src/build-word-bank-options.ts
+++ b/packages/player/src/build-word-bank-options.ts
@@ -11,6 +11,7 @@ import {
   type WordBankOption,
 } from "./prepare-activity-data";
 
+const MIN_WORD_BANK_DISTRACTOR_COUNT = 4;
 const WORD_BANK_DISTRACTOR_COUNT = 8;
 
 type WordDataInput = {
@@ -195,22 +196,19 @@ function isEquivalentToAcceptedLessonWord(
   );
 }
 
+/**
+ * We compare every distractor candidate against the lesson words that appear in
+ * accepted answers so fallback pools follow the same ambiguity rules as lesson words.
+ */
 function filterEquivalentLessonWords(
-  serializedLessonWords: SerializedWord[],
-  acceptedTexts: string[],
-  distractorField: "word" | "translation",
+  candidateLessonWords: SerializedWord[],
+  acceptedLessonWords: SerializedWord[],
 ): SerializedWord[] {
-  const acceptedLessonWords = getAcceptedLessonWords(
-    serializedLessonWords,
-    acceptedTexts,
-    distractorField,
-  );
-
   if (acceptedLessonWords.length === 0) {
-    return serializedLessonWords;
+    return candidateLessonWords;
   }
 
-  return serializedLessonWords.filter(
+  return candidateLessonWords.filter(
     (lessonWord) => !isEquivalentToAcceptedLessonWord(lessonWord, acceptedLessonWords),
   );
 }
@@ -238,6 +236,7 @@ function getUniqueDistractorWords(
   lessonWords: SerializedWord[],
   distractorField: "word" | "translation",
   acceptedWordSet: Set<string>,
+  excludedWordKeys = new Set<string>(),
 ): string[] {
   return [
     ...new Map(
@@ -246,10 +245,47 @@ function getUniqueDistractorWords(
         .flatMap((word) => {
           const key = normalizeWordKey(word);
 
-          return key.length > 0 && !acceptedWordSet.has(key) ? [[key, word] as const] : [];
+          return key.length > 0 && !acceptedWordSet.has(key) && !excludedWordKeys.has(key)
+            ? [[key, word] as const]
+            : [];
         }),
     ).values(),
   ];
+}
+
+/**
+ * Lesson distractors should stay primary, while fallback words only fill genuine
+ * gaps when semantic filtering leaves fewer than four visible distractors.
+ */
+function buildDistractorWords(
+  lessonWords: SerializedWord[],
+  fallbackLessonWords: SerializedWord[],
+  acceptedLessonWords: SerializedWord[],
+  acceptedWordSet: Set<string>,
+  distractorField: "word" | "translation",
+): string[] {
+  const lessonDistractorWords = shuffle(
+    getUniqueDistractorWords(
+      filterEquivalentLessonWords(lessonWords, acceptedLessonWords),
+      distractorField,
+      acceptedWordSet,
+    ),
+  ).slice(0, WORD_BANK_DISTRACTOR_COUNT);
+
+  if (lessonDistractorWords.length >= MIN_WORD_BANK_DISTRACTOR_COUNT) {
+    return lessonDistractorWords;
+  }
+
+  const fallbackDistractorWords = shuffle(
+    getUniqueDistractorWords(
+      filterEquivalentLessonWords(fallbackLessonWords, acceptedLessonWords),
+      distractorField,
+      acceptedWordSet,
+      new Set(lessonDistractorWords.map((word) => normalizeWordKey(word))),
+    ),
+  ).slice(0, MIN_WORD_BANK_DISTRACTOR_COUNT - lessonDistractorWords.length);
+
+  return [...lessonDistractorWords, ...fallbackDistractorWords];
 }
 
 /**
@@ -272,6 +308,7 @@ export function buildWordBankOptions(
   step: SerializedStep,
   serializedLessonWords: SerializedWord[],
   sentenceWordMap: Map<string, WordDataInput>,
+  fallbackLessonWords: SerializedWord[] = [],
 ): WordBankOption[] {
   const config = getWordBankConfig(step);
 
@@ -288,18 +325,19 @@ export function buildWordBankOptions(
   );
 
   const acceptedWordSet = getAcceptedArrangeWordSet(acceptedWordSequences);
-
-  const distractorLessonWords = filterEquivalentLessonWords(
+  const acceptedLessonWords = getAcceptedLessonWords(
     serializedLessonWords,
     acceptedTexts,
     distractorField,
   );
   const correctOptions = segmentWords(primaryText).map((word) => buildOption(word));
-  const distractorOptions = shuffle(
-    getUniqueDistractorWords(distractorLessonWords, distractorField, acceptedWordSet),
-  )
-    .slice(0, WORD_BANK_DISTRACTOR_COUNT)
-    .map((word) => buildOption(word));
+  const distractorOptions = buildDistractorWords(
+    serializedLessonWords,
+    fallbackLessonWords,
+    acceptedLessonWords,
+    acceptedWordSet,
+    distractorField,
+  ).map((word) => buildOption(word));
 
   return shuffle([...correctOptions, ...distractorOptions]);
 }

--- a/packages/player/src/get-distractor-words.test.ts
+++ b/packages/player/src/get-distractor-words.test.ts
@@ -92,6 +92,26 @@ describe(getDistractorWords, () => {
     expect(result).toHaveLength(0);
   });
 
+  test("uses fallback words when lesson words cannot reach the requested count", () => {
+    const correct = makeWord("1", "hello", ["hi"], "hola");
+    const words = [correct, makeWord("2", "hi", [], "oi"), makeWord("3", "cat", [], "gato")];
+    const fallbackWords = [makeWord("4", "dog", [], "perro"), makeWord("5", "bird", [], "pajaro")];
+    const result = getDistractorWords(correct, words, 3, fallbackWords);
+
+    expect(result).toHaveLength(3);
+    expect(result.map((word) => word.id).toSorted()).toEqual(["3", "4", "5"]);
+  });
+
+  test("keeps only safe distractors when fallback words still cannot satisfy the count", () => {
+    const correct = makeWord("1", "hello", ["hi"], "hola");
+    const words = [correct, makeWord("2", "cat", [], "gato")];
+    const fallbackWords = [makeWord("3", "hi", [], "oi"), makeWord("4", "dog", [], "perro")];
+    const result = getDistractorWords(correct, words, 3, fallbackWords);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((word) => word.id).toSorted()).toEqual(["2", "4"]);
+  });
+
   test("returns empty array when all words are alternatives", () => {
     const correct = makeWord("1", "hello", ["hi", "hey"]);
     const words = [correct, makeWord("2", "hello"), makeWord("3", "hi"), makeWord("4", "hey")];

--- a/packages/player/src/get-distractor-words.ts
+++ b/packages/player/src/get-distractor-words.ts
@@ -14,6 +14,44 @@ function normalizeWordText(text: string): string {
     .trim();
 }
 
+/**
+ * Vocabulary distractors must stay unambiguous for the learner, so this helper
+ * centralizes the rule for when a word is safe to show as a wrong answer.
+ */
+function isValidDistractor<T extends DistractorWord>(correctWord: T, candidate: T): boolean {
+  const correctNormalized = normalizeWordText(correctWord.word);
+
+  return (
+    candidate.id !== correctWord.id &&
+    !isSemanticMatch(correctWord, candidate) &&
+    normalizeWordText(candidate.word) !== correctNormalized
+  );
+}
+
+/**
+ * We deduplicate on normalized word text so punctuation variants such as
+ * "ca va." and "ca va?" never consume multiple answer slots.
+ */
+function getUniqueDistractors<T extends DistractorWord>(
+  correctWord: T,
+  lessonWords: T[],
+  excludedWordKeys = new Set<string>(),
+): T[] {
+  return [
+    ...new Map(
+      lessonWords.flatMap((word) => {
+        const normalizedWord = normalizeWordText(word.word);
+
+        if (excludedWordKeys.has(normalizedWord) || !isValidDistractor(correctWord, word)) {
+          return [];
+        }
+
+        return [[normalizedWord, word] as const];
+      }),
+    ).values(),
+  ];
+}
+
 export function isSemanticMatch(correctWord: DistractorWord, candidate: DistractorWord): boolean {
   const correctTranslation = correctWord.translation.toLowerCase();
   const candidateTranslation = candidate.translation.toLowerCase();
@@ -47,26 +85,28 @@ export function isSemanticMatch(correctWord: DistractorWord, candidate: Distract
 
 /**
  * Filters lesson words to produce valid distractors for vocabulary exercises.
- * Excludes semantically equivalent words (same translation, alternative translations)
- * and returns a shuffled subset of the requested count.
+ * Excludes semantically equivalent words first from the lesson pool, then uses a
+ * small fallback pool only when the lesson does not have enough safe options.
  */
 export function getDistractorWords<T extends DistractorWord>(
   correctWord: T,
   lessonWords: T[],
   count: number,
+  fallbackWords: T[] = [],
 ): T[] {
-  const correctNormalized = normalizeWordText(correctWord.word);
+  const lessonDistractors = shuffle(getUniqueDistractors(correctWord, lessonWords)).slice(0, count);
 
-  const validDistractors = lessonWords.filter(
-    (word) =>
-      word.id !== correctWord.id &&
-      !isSemanticMatch(correctWord, word) &&
-      normalizeWordText(word.word) !== correctNormalized,
-  );
+  if (lessonDistractors.length >= count || fallbackWords.length === 0) {
+    return lessonDistractors;
+  }
 
-  const uniqueDistractors = [
-    ...new Map(validDistractors.map((word) => [normalizeWordText(word.word), word])).values(),
-  ];
+  const fallbackDistractors = shuffle(
+    getUniqueDistractors(
+      correctWord,
+      fallbackWords,
+      new Set(lessonDistractors.map((word) => normalizeWordText(word.word))),
+    ),
+  ).slice(0, count - lessonDistractors.length);
 
-  return shuffle(uniqueDistractors).slice(0, count);
+  return [...lessonDistractors, ...fallbackDistractors];
 }

--- a/packages/player/src/prepare-activity-data.ts
+++ b/packages/player/src/prepare-activity-data.ts
@@ -109,6 +109,14 @@ function serializeWord(word: WordDataInput): SerializedWord {
   };
 }
 
+/**
+ * The player consumes serialized words from multiple sources, so this helper keeps
+ * lesson words and fallback distractor words aligned on one serialization rule.
+ */
+function serializeWords(words: WordDataInput[]): SerializedWord[] {
+  return words.map((word) => serializeWord(word));
+}
+
 function serializeSentence(sentence: SentenceDataInput): SerializedSentence {
   return {
     alternativeSentences: [...sentence.alternativeSentences],
@@ -138,6 +146,7 @@ function shuffleMultipleChoiceContent(
 function buildTranslationOptions(
   step: SerializedStep,
   serializedLessonWords: SerializedWord[],
+  serializedFallbackWords: SerializedWord[],
 ): SerializedWord[] {
   if (step.kind !== "translation" || !step.word) {
     return [];
@@ -147,6 +156,7 @@ function buildTranslationOptions(
     step.word,
     serializedLessonWords,
     VOCABULARY_DISTRACTOR_COUNT,
+    serializedFallbackWords,
   );
   return shuffle([step.word, ...distractors]).map((word) => ({
     ...word,
@@ -225,16 +235,10 @@ export function prepareActivityData(
   lessonWords: WordDataInput[],
   lessonSentences: SentenceDataInput[],
   sentenceWords: WordDataInput[] = [],
+  fallbackDistractorWords: WordDataInput[] = [],
 ): SerializedActivity {
-  const serializedLessonWords = lessonWords.map((word) => ({
-    alternativeTranslations: [...word.alternativeTranslations],
-    audioUrl: word.wordAudio?.audioUrl ?? null,
-    id: String(word.id),
-    pronunciation: word.pronunciation,
-    romanization: word.romanization,
-    translation: word.translation,
-    word: word.word,
-  }));
+  const serializedLessonWords = serializeWords(lessonWords);
+  const serializedFallbackWords = serializeWords(fallbackDistractorWords);
 
   const sentenceWordMap = new Map(sentenceWords.map((sw) => [sw.word.toLowerCase(), sw]));
 
@@ -254,8 +258,17 @@ export function prepareActivityData(
           ? buildSentenceWordOptions(step.sentence.sentence, serializedLessonWords, sentenceWordMap)
           : [],
         sortOrderItems: buildSortOrderItems(step),
-        translationOptions: buildTranslationOptions(step, serializedLessonWords),
-        wordBankOptions: buildWordBankOptions(step, serializedLessonWords, sentenceWordMap),
+        translationOptions: buildTranslationOptions(
+          step,
+          serializedLessonWords,
+          serializedFallbackWords,
+        ),
+        wordBankOptions: buildWordBankOptions(
+          step,
+          serializedLessonWords,
+          sentenceWordMap,
+          serializedFallbackWords,
+        ),
       },
     ];
   });


### PR DESCRIPTION
## Summary
- keep translation activities at 4 visible options when safe distractors exist by topping up from a small fallback word pool
- keep reading and listening arrange-words activities at a minimum of 4 visible distractors while preserving the same semantic safety rules
- fetch fallback distractors from the same lesson language scope without leaking fallback words into the serialized lesson words payload

## Tests
- add unit coverage for translation fallback distractors and arrange-words fallback distractors
- add integration coverage for fallback word loading and prepare-activity-data
- add e2e regressions for translation and reading underfilled distractor cases

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarantees at least four safe, non-ambiguous distractors in translation, reading, and listening by topping up from a small fallback word pool scoped to the lesson’s languages. Preserves audio and romanization for fallback reading distractors without adding fallback words to the lesson payload.

- **New Features**
  - Translation: always show 4 safe options by supplementing with scoped fallback words when lesson words are ambiguous.
  - Reading/Listening: keep word banks at 4 visible distractors with the same semantic safety rules; for reading, carry over audio/romanization for fallback words.
  - Data: added a cached `getFallbackDistractorWords` loader that fetches up to 4 words in the same org/language scope (from lesson words or sentences), excludes lesson word IDs, and passes them separately into `prepare-activity-data`.

<sup>Written for commit abc5afe55bc480ea83a7a5bf1befc621b66bb8b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

