### PR TITLE
chore(agents): update zoonk-commit skill

### DIFF
--- a/.agents/skills/zoonk-commit/SKILL.md
+++ b/.agents/skills/zoonk-commit/SKILL.md
@@ -30,22 +30,20 @@ Use the owning app or package name as scope when working in this monorepo.
 
 1. If the change is fully owned by one app in `apps/<name>`, use that app name.
 2. If the change is fully owned by one package in `packages/<name>`, use that package name.
-3. Only use an inferred scope like `deps`, `data`, `ci`, or `agents` when the change truly spans multiple workspaces or does not belong to a single app/package.
-4. Do not pick a scope based on the kind of code changed (`data`, `ui`, styling, tests, etc.) when the files clearly belong to one app/package. The workspace owner wins.
+3. Only use an inferred scope like `deps`, `ci`, or `agents` when the change truly spans multiple workspaces or does not belong to a single app/package.
+4. Do not pick a scope based on the kind of code changed (eg `data`) when the files clearly belong to one app/package. The workspace owner wins.
 
 **Inferred scopes** (when change doesn't fit an app/package):
 
 - `agents` - CLAUDE.md, AGENTS.md, `.claude/` folder
 - `ci` - GitHub workflows, CI/CD configuration
 - `deps` - dependency updates across multiple packages
-- `data` - data layer changes spanning multiple packages
 
 ### Good Scope Choices
 
 - `fix(player): improve belt progress contrast` for changes in `packages/player/...`
 - `fix(main): correct level page copy` for changes in `apps/main/...`
 - `fix(api): handle null response in auth` for changes in `apps/api/...`
-- `fix(data): normalize progress query` only when the data-layer change spans multiple apps/packages
 
 ### Avoid These Mistakes
 
@@ -72,8 +70,10 @@ fix(ci): update node version in workflow
 - Keep message under 72 characters
 - Use imperative mood ("add" not "added")
 
-# PR Descriptions
+# PR Titles
 
 Use the same `type(scope): short message` format as the commit title.
+
+# PR Descriptions
 
 Keep descriptions brief. Focus on what changed. No need to list verification commands run.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified commit scope rules in `zoonk-commit`: removed `data` as an inferred scope, and emphasized choosing the owning app/package over code type. Added a new “PR Titles” section that uses the same `type(scope): short message` format.

<sup>Written for commit 689e5d8e9cc6744c736573869ad6ad98236886db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

