### PR TITLE
fix(main): avoid lesson self-link for pending activity

### DIFF
--- a/apps/main/e2e/continue-activity-link.test.ts
+++ b/apps/main/e2e/continue-activity-link.test.ts
@@ -92,6 +92,48 @@ async function createTestCourseWithoutPublishedActivities() {
   return { chapter, course, lesson };
 }
 
+async function createTestCourseWithPendingFirstActivity() {
+  const org = await getAiOrganization();
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-cal-pending-course-${uniqueId}`,
+    title: `E2E CAL Pending Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    position: 0,
+    slug: `e2e-cal-pending-ch-${uniqueId}`,
+    title: `E2E CAL Pending Chapter ${uniqueId}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    isPublished: true,
+    organizationId: org.id,
+    position: 0,
+    slug: `e2e-cal-pending-l-${uniqueId}`,
+    title: `E2E CAL Pending Lesson ${uniqueId}`,
+  });
+
+  await activityFixture({
+    generationStatus: "pending",
+    isPublished: true,
+    kind: "explanation",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 0,
+    title: `E2E CAL Pending Activity ${uniqueId}`,
+  });
+
+  return { chapter, course, lesson };
+}
+
 test.describe("Continue Activity Link", () => {
   test("course page shows Start link for unauthenticated user", async ({ page }) => {
     const { course } = await createTestCourseWithActivity();
@@ -130,6 +172,25 @@ test.describe("Continue Activity Link", () => {
 
     const startLink = page.getByRole("link", { name: /^start$/i });
     await expect(startLink).toBeVisible();
+  });
+
+  test("lesson page Start link opens the pending activity instead of self-linking", async ({
+    page,
+  }) => {
+    const { chapter, course, lesson } = await createTestCourseWithPendingFirstActivity();
+
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+
+    const startLink = page.getByRole("link", { name: /^start$/i });
+
+    await expect(startLink).toHaveAttribute(
+      "href",
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/0`,
+    );
+
+    await startLink.click();
+
+    await expect(page.getByRole("link", { name: /create activity/i })).toBeVisible();
   });
 
   test("course page falls back to first chapter when no activity data", async ({ page }) => {

--- a/apps/main/src/components/catalog/continue-activity-link.tsx
+++ b/apps/main/src/components/catalog/continue-activity-link.tsx
@@ -39,10 +39,17 @@ export async function ContinueActivityLink<Href extends string, CompletedHref ex
   const t = await getExtracted();
   const scope = getScope({ chapterId, courseId, lessonId });
   const data = await getNextActivity({ scope });
+  const className = cn(buttonVariants(), "min-w-0 flex-1 gap-2");
 
+  /**
+   * When we cannot compute a next activity at all, the parent page already has
+   * the safest fallback for its own level: first chapter, first lesson, or
+   * first activity. Reusing that fallback avoids duplicating page-specific
+   * routing rules here.
+   */
   if (!data) {
     return (
-      <Link className={cn(buttonVariants(), "min-w-0 flex-1 gap-2")} href={fallbackHref} prefetch>
+      <Link className={className} href={fallbackHref} prefetch>
         {t("Start")}
         <ChevronRightIcon aria-hidden="true" />
       </Link>
@@ -61,26 +68,78 @@ export async function ContinueActivityLink<Href extends string, CompletedHref ex
     return t("Start");
   };
 
+  const label = getLabel();
+
+  /**
+   * Once the current scope is fully completed, the parent can provide the next
+   * lesson/chapter route. We prefer that explicit sibling destination over
+   * sending users back into a finished activity.
+   */
   if (data.completed && completedHref) {
     return (
-      <Link className={cn(buttonVariants(), "min-w-0 flex-1 gap-2")} href={completedHref}>
-        {getLabel()}
+      <Link className={className} href={completedHref}>
+        {label}
         <ChevronRightIcon aria-hidden="true" />
       </Link>
     );
   }
 
+  /**
+   * Catalog pages always live under a brand URL. If progress data cannot give
+   * us that slug, the safest option is to stay with the route the parent page
+   * already knows is valid.
+   */
+  if (!data.brandSlug) {
+    return (
+      <Link className={className} href={fallbackHref} prefetch={false}>
+        {label}
+        <ChevronRightIcon aria-hidden="true" />
+      </Link>
+    );
+  }
+
+  /**
+   * Generated activities are safe to deep-link to directly, so we send users
+   * straight into the activity route and allow prefetching.
+   */
+  if (data.canPrefetch) {
+    return (
+      <Link
+        className={className}
+        href={`/b/${data.brandSlug}/c/${data.courseSlug}/ch/${data.chapterSlug}/l/${data.lessonSlug}/a/${data.activityPosition}`}
+        prefetch
+      >
+        {label}
+        <ChevronRightIcon aria-hidden="true" />
+      </Link>
+    );
+  }
+
+  /**
+   * Lesson pages already loaded the activity list and passed a concrete first
+   * activity href as the fallback. Reusing that href avoids the no-op
+   * self-link that happens when the first activity exists but is still pending.
+   */
+  if (lessonId) {
+    return (
+      <Link className={className} href={fallbackHref} prefetch={false}>
+        {label}
+        <ChevronRightIcon aria-hidden="true" />
+      </Link>
+    );
+  }
+
+  /**
+   * Course and chapter pages may only know the lesson-level destination when
+   * the activity is still pending, so we fall back to the lesson shell there.
+   */
   return (
     <Link
-      className={cn(buttonVariants(), "min-w-0 flex-1 gap-2")}
-      href={
-        data.canPrefetch
-          ? `/b/${data.brandSlug}/c/${data.courseSlug}/ch/${data.chapterSlug}/l/${data.lessonSlug}/a/${data.activityPosition}`
-          : `/b/${data.brandSlug}/c/${data.courseSlug}/ch/${data.chapterSlug}/l/${data.lessonSlug}`
-      }
-      prefetch={data.canPrefetch}
+      className={className}
+      href={`/b/${data.brandSlug}/c/${data.courseSlug}/ch/${data.chapterSlug}/l/${data.lessonSlug}`}
+      prefetch={false}
     >
-      {getLabel()}
+      {label}
       <ChevronRightIcon aria-hidden="true" />
     </Link>
   );


### PR DESCRIPTION
## Summary
- route lesson-level continue/start links to the first activity href when that first activity exists but is still pending
- add a Playwright regression covering the pending-activity lesson case
- document the continue-link routing branches so the fallback behavior is explicit


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lesson Start/Continue links when the first activity exists but is pending by routing to the first activity URL instead of self-linking the lesson. Also clarifies routing and prefetch behavior across catalog pages.

- **Bug Fixes**
  - Lesson Start/Continue uses the first-activity href when the first activity is pending; no more no-op self-link.
  - Prefer `completedHref` when the current scope is finished to avoid re-entering a completed activity.
  - Safer fallbacks and prefetch: use parent `fallbackHref` when no data or no brand slug; prefetch only for generated activities; course/chapter pending case falls back to the lesson shell.

- **Tests**
  - Added a Playwright regression for the pending-first-activity lesson case that asserts the Start link targets `/a/0` and loads the create-activity UI.

<sup>Written for commit ec14cf6eddb917a9453c4871234511caf451de19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

