### PR TITLE
refactor(main): remove unnecessary `route` helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,57 @@ page.getByLabel(/email/i);
 - When using `render` prop with base-ui components (e.g., `useRender`), use `ClientLink` instead of `Link` since the render prop requires a client component
 - i18n functions like `getExtracted` can't be called inside `Promise.all`
 
+## Next.js links
+
+We're using Next.js `typedRoutes` feature. Next.js can statically type links to prevent typos and other errors when using `next/link`. These types are generated when we run `pnpm typecheck` or `pnpm build`.
+
+This works out of the box if you pass a string literal to `href`. However, for variables, you may need to use `as const` to preserve literal types. **NEVER** cast them as `Route` because this defeats the purpose of type safety:
+
+```tsx
+// BAD - casting as Route defeats type safety
+const lessonHref = `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}` as Route;
+
+// ALSO BAD - Creating wrapper functions instead of using `as const`
+function route<Href extends string>(href: Route<Href>): Route<Href> {
+  return href;
+}
+
+// GOOD - string literal as const
+const lessonHref = `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}` as const;
+```
+
+To accept href in a custom component wrapping next/link, use a generic:
+
+```tsx
+import type { Route } from "next";
+import Link from "next/link";
+
+function Card<T extends string>({ href }: { href: Route<T> | URL }) {
+  return (
+    <Link href={href}>
+      <div>My Card</div>
+    </Link>
+  );
+}
+```
+
+You can also type a simple data structure and iterate to render links:
+
+```tsx
+import type { Route } from "next";
+
+type NavItem<T extends string = string> = {
+  href: T;
+  label: string;
+};
+
+export const navItems: NavItem<Route>[] = [
+  { href: "/", label: "Home" },
+  { href: "/about", label: "About" },
+  { href: "/blog", label: "Blog" },
+];
+```
+
 ## Plan Mode
 
 - Before completing your plan, make sure you identified which tests need to be added or updated. A plan without tests is incomplete.
@@ -159,3 +210,7 @@ page.getByLabel(/email/i);
 Before any Next.js work, find and read the relevant doc in `apps/{app}/node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
 
 <!-- END:nextjs-agent-rules -->
+
+```
+
+```

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-player-model.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-player-model.ts
@@ -1,5 +1,3 @@
-import { type Route } from "next";
-
 type NextActivity = {
   activityPosition: number;
   chapterSlug: string;
@@ -14,10 +12,6 @@ type NextSibling = {
   lessonSlug: string;
   lessonTitle: string;
 };
-
-function route<Href extends string>(href: Route<Href>): Route<Href> {
-  return href;
-}
 
 export function buildActivityPlayerModel({
   brandSlug,
@@ -34,14 +28,12 @@ export function buildActivityPlayerModel({
   nextActivity: NextActivity | null;
   nextSibling: NextSibling | null;
 }) {
-  const lessonHref = route(`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`);
-  const chapterHref = route(`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}`);
-  const courseHref = route(`/b/${brandSlug}/c/${courseSlug}`);
+  const lessonHref = `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}` as const;
+  const chapterHref = `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}`;
+  const courseHref = `/b/${brandSlug}/c/${courseSlug}`;
 
   const nextActivityHref = nextActivity
-    ? route(
-        `/b/${brandSlug}/c/${courseSlug}/ch/${nextActivity.chapterSlug}/l/${nextActivity.lessonSlug}/a/${String(nextActivity.activityPosition)}`,
-      )
+    ? (`/b/${brandSlug}/c/${courseSlug}/ch/${nextActivity.chapterSlug}/l/${nextActivity.lessonSlug}/a/${String(nextActivity.activityPosition)}` as const)
     : null;
 
   const isLastInLesson =
@@ -55,15 +47,11 @@ export function buildActivityPlayerModel({
     }
 
     if (nextActivity) {
-      return route(
-        `/b/${brandSlug}/c/${courseSlug}/ch/${nextActivity.chapterSlug}/l/${nextActivity.lessonSlug}`,
-      );
+      return `/b/${brandSlug}/c/${courseSlug}/ch/${nextActivity.chapterSlug}/l/${nextActivity.lessonSlug}` as const;
     }
 
     if (nextSibling) {
-      return route(
-        `/b/${nextSibling.brandSlug}/c/${nextSibling.courseSlug}/ch/${nextSibling.chapterSlug}/l/${nextSibling.lessonSlug}`,
-      );
+      return `/b/${nextSibling.brandSlug}/c/${nextSibling.courseSlug}/ch/${nextSibling.chapterSlug}/l/${nextSibling.lessonSlug}` as const;
     }
 
     return null;
@@ -71,13 +59,11 @@ export function buildActivityPlayerModel({
 
   const nextChapterHref = (() => {
     if (nextActivity && nextActivity.chapterSlug !== chapterSlug) {
-      return route(`/b/${brandSlug}/c/${courseSlug}/ch/${nextActivity.chapterSlug}`);
+      return `/b/${brandSlug}/c/${courseSlug}/ch/${nextActivity.chapterSlug}`;
     }
 
     if (nextSibling && nextSibling.chapterSlug !== chapterSlug) {
-      return route(
-        `/b/${nextSibling.brandSlug}/c/${nextSibling.courseSlug}/ch/${nextSibling.chapterSlug}`,
-      );
+      return `/b/${nextSibling.brandSlug}/c/${nextSibling.courseSlug}/ch/${nextSibling.chapterSlug}`;
     }
 
     return null;
@@ -117,8 +103,8 @@ export function buildActivityPlayerModel({
       chapterHref,
       courseHref,
       lessonHref,
-      levelHref: route("/level"),
-      loginHref: route("/login"),
+      levelHref: "/level",
+      loginHref: "/login",
       nextActivityHref,
     },
     onNextHref: nextActivityHref ?? nextLessonHref,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove the unnecessary route() helper and use typed hrefs directly with Next.js. This simplifies link building and improves type safety for `next/link`.

- **Refactors**
  - Deleted `route<Href>()` and the `Route` import from `next`.
  - Replaced helper calls in `activity-player-model.ts` with literal paths; added `as const` where needed; simplified `levelHref`/`loginHref`.
  - Added “Next.js links” guidance to `AGENTS.md`: prefer `as const`, don’t cast to `Route`, avoid wrapper helpers, and use generics for custom `next/link` wrappers.

<sup>Written for commit d312fbe094cd49e867a1f8811fc594d78cd3b4bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

