### PR TITLE
fix(main): wait for vocabulary before redirect

### DIFF
--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -289,6 +289,77 @@ test.describe("Generate Chapter Page - With Subscription", () => {
     await userWithoutProgress.waitForURL(/\/b\/ai\/c\//, { timeout: 10_000 });
   });
 
+  test("waits for vocabulary completion before redirecting language chapters", async ({
+    userWithoutProgress,
+    noProgressUser,
+  }) => {
+    await createTestSubscription(noProgressUser.id);
+
+    const org = await getAiOrganization();
+    const uniqueId = randomUUID().slice(0, 8);
+    const courseTitle = `E2E Language Redirect Course ${uniqueId}`;
+    const chapterTitle = `E2E Language Redirect Chapter ${uniqueId}`;
+
+    const course = await courseFixture({
+      isPublished: true,
+      normalizedTitle: normalizeString(courseTitle),
+      organizationId: org.id,
+      slug: `e2e-language-redirect-course-${uniqueId}`,
+      targetLanguage: "es",
+      title: courseTitle,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      generationStatus: "pending",
+      isPublished: true,
+      normalizedTitle: normalizeString(chapterTitle),
+      organizationId: org.id,
+      slug: `e2e-language-redirect-chapter-${uniqueId}`,
+      title: chapterTitle,
+    });
+
+    await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: org.id,
+      slug: `e2e-language-redirect-lesson-${uniqueId}`,
+      title: `E2E Language Redirect Lesson ${uniqueId}`,
+    });
+
+    await setupMockApis(userWithoutProgress, {
+      streamMessages: [
+        { status: "started", step: "getChapter" },
+        { status: "completed", step: "getChapter" },
+        { status: "started", step: "setChapterAsRunning" },
+        { status: "completed", step: "setChapterAsRunning" },
+        { status: "started", step: "generateLessons" },
+        { status: "completed", step: "generateLessons" },
+        { status: "started", step: "addLessons" },
+        { status: "completed", step: "addLessons" },
+        { status: "started", step: "setChapterAsCompleted" },
+        { status: "completed", step: "setChapterAsCompleted" },
+        { status: "started", step: "setLessonAsCompleted" },
+        { status: "completed", step: "setLessonAsCompleted" },
+        { status: "started", step: "setVocabularyAsCompleted" },
+        { status: "completed", step: "setVocabularyAsCompleted" },
+      ],
+    });
+
+    await userWithoutProgress.goto(`/generate/ch/${chapter.id}`);
+
+    await expect(userWithoutProgress.getByText(/your lessons are ready/i)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await prisma.chapter.update({
+      data: { generationStatus: "completed" },
+      where: { id: chapter.id },
+    });
+
+    await userWithoutProgress.waitForURL(/\/b\/ai\/c\//, { timeout: 10_000 });
+  });
+
   test("shows error when stream returns error status", async ({
     userWithoutProgress,
     noProgressUser,

--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -289,7 +289,73 @@ test.describe("Generate Chapter Page - With Subscription", () => {
     await userWithoutProgress.waitForURL(/\/b\/ai\/c\//, { timeout: 10_000 });
   });
 
-  test("waits for vocabulary completion before redirecting language chapters", async ({
+  test("does not redirect language chapters on generic activity completion", async ({
+    userWithoutProgress,
+    noProgressUser,
+  }) => {
+    await createTestSubscription(noProgressUser.id);
+
+    const org = await getAiOrganization();
+    const uniqueId = randomUUID().slice(0, 8);
+    const courseTitle = `E2E Language Redirect Course ${uniqueId}`;
+    const chapterTitle = `E2E Language Redirect Chapter ${uniqueId}`;
+
+    const course = await courseFixture({
+      isPublished: true,
+      normalizedTitle: normalizeString(courseTitle),
+      organizationId: org.id,
+      slug: `e2e-language-redirect-course-${uniqueId}`,
+      targetLanguage: "es",
+      title: courseTitle,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      generationStatus: "pending",
+      isPublished: true,
+      normalizedTitle: normalizeString(chapterTitle),
+      organizationId: org.id,
+      slug: `e2e-language-redirect-chapter-${uniqueId}`,
+      title: chapterTitle,
+    });
+
+    await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: org.id,
+      slug: `e2e-language-redirect-lesson-${uniqueId}`,
+      title: `E2E Language Redirect Lesson ${uniqueId}`,
+    });
+
+    await setupMockApis(userWithoutProgress, {
+      streamMessages: [
+        { status: "started", step: "getChapter" },
+        { status: "completed", step: "getChapter" },
+        { status: "started", step: "setChapterAsRunning" },
+        { status: "completed", step: "setChapterAsRunning" },
+        { status: "started", step: "generateLessons" },
+        { status: "completed", step: "generateLessons" },
+        { status: "started", step: "addLessons" },
+        { status: "completed", step: "addLessons" },
+        { status: "started", step: "setChapterAsCompleted" },
+        { status: "completed", step: "setChapterAsCompleted" },
+        { status: "started", step: "setLessonAsCompleted" },
+        { status: "completed", step: "setLessonAsCompleted" },
+        { status: "started", step: "setActivityAsCompleted" },
+        { status: "completed", step: "setActivityAsCompleted" },
+      ],
+    });
+
+    await userWithoutProgress.goto(`/generate/ch/${chapter.id}`);
+
+    await expect(userWithoutProgress.getByText(/generation ended unexpectedly/i)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await expect(userWithoutProgress).toHaveURL(new RegExp(`/generate/ch/${chapter.id}$`));
+  });
+
+  test("redirects language chapters after vocabulary completion", async ({
     userWithoutProgress,
     noProgressUser,
   }) => {

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -19,7 +19,7 @@ import { expect, test } from "./fixtures";
  * - Shows "Creating your course" while triggering/streaming
  * - Shows current step label + spinner while streaming
  * - Shows completed steps with checkmarks
- * - Workflow completes when the SSE stream ends
+ * - Workflow completes when the configured completion step is received
  * - Redirects to course page when workflow completes
  *
  * NOTE: Some error handling tests (trigger API failures) are not included because
@@ -280,9 +280,62 @@ test.describe("Generate Course Page", () => {
       });
     });
 
-    test("waits for vocabulary completion before redirecting language courses", async ({
-      page,
-    }) => {
+    test("does not redirect language courses on generic activity completion", async ({ page }) => {
+      const slug = `e2e-language-completion-${randomUUID().slice(0, 8)}`;
+      const org = await getAiOrganization();
+
+      const suggestion = await courseSuggestionFixture({
+        generationStatus: "pending",
+        language: "en",
+        slug,
+        targetLanguage: "es",
+        title: "E2E Language Completion Test",
+      });
+
+      await courseFixture({
+        generationStatus: "running",
+        isPublished: true,
+        organizationId: org.id,
+        slug,
+        targetLanguage: "es",
+        title: "E2E Language Completion Test",
+      }).then(async (course) => {
+        const chapter = await chapterFixture({
+          courseId: course.id,
+          isPublished: true,
+          organizationId: org.id,
+        });
+
+        await lessonFixture({
+          chapterId: chapter.id,
+          isPublished: true,
+          organizationId: org.id,
+        });
+      });
+
+      await setupMockApis(page, {
+        streamMessages: [
+          { status: "started", step: "getCourseSuggestion" },
+          { status: "completed", step: "getCourseSuggestion" },
+          { status: "started", step: "addLessons" },
+          { status: "completed", step: "addLessons" },
+          { status: "started", step: "setLessonAsCompleted" },
+          { status: "completed", step: "setLessonAsCompleted" },
+          { status: "started", step: "setActivityAsCompleted" },
+          { status: "completed", step: "setActivityAsCompleted" },
+        ],
+      });
+
+      await page.goto(`/generate/cs/${suggestion.id}`);
+
+      await expect(page.getByText(/generation ended unexpectedly/i)).toBeVisible({
+        timeout: 10_000,
+      });
+
+      await expect(page).toHaveURL(new RegExp(`/generate/cs/${suggestion.id}$`));
+    });
+
+    test("redirects language courses after vocabulary completion", async ({ page }) => {
       const slug = `e2e-language-completion-${randomUUID().slice(0, 8)}`;
       const org = await getAiOrganization();
 

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -279,6 +279,65 @@ test.describe("Generate Course Page", () => {
         timeout: 10_000,
       });
     });
+
+    test("waits for vocabulary completion before redirecting language courses", async ({
+      page,
+    }) => {
+      const slug = `e2e-language-completion-${randomUUID().slice(0, 8)}`;
+      const org = await getAiOrganization();
+
+      const suggestion = await courseSuggestionFixture({
+        generationStatus: "pending",
+        language: "en",
+        slug,
+        targetLanguage: "es",
+        title: "E2E Language Completion Test",
+      });
+
+      await courseFixture({
+        generationStatus: "running",
+        isPublished: true,
+        organizationId: org.id,
+        slug,
+        targetLanguage: "es",
+        title: "E2E Language Completion Test",
+      }).then(async (course) => {
+        const chapter = await chapterFixture({
+          courseId: course.id,
+          isPublished: true,
+          organizationId: org.id,
+        });
+
+        await lessonFixture({
+          chapterId: chapter.id,
+          isPublished: true,
+          organizationId: org.id,
+        });
+      });
+
+      await setupMockApis(page, {
+        streamMessages: [
+          { status: "started", step: "getCourseSuggestion" },
+          { status: "completed", step: "getCourseSuggestion" },
+          { status: "started", step: "addLessons" },
+          { status: "completed", step: "addLessons" },
+          { status: "started", step: "setLessonAsCompleted" },
+          { status: "completed", step: "setLessonAsCompleted" },
+          { status: "started", step: "setVocabularyAsCompleted" },
+          { status: "completed", step: "setVocabularyAsCompleted" },
+        ],
+      });
+
+      await page.goto(`/generate/cs/${suggestion.id}`);
+
+      await expect(page.getByText(/your course is ready/i)).toBeVisible({
+        timeout: 10_000,
+      });
+
+      await page.waitForURL(new RegExp(`/b/ai/c/${slug}`), {
+        timeout: 10_000,
+      });
+    });
   });
 
   test.describe("Error handling", () => {

--- a/apps/main/src/app/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generation-client.tsx
@@ -12,8 +12,8 @@ import {
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
 import {
-  ACTIVITY_GENERATION_COMPLETION_STEP,
   type ChapterWorkflowStepName,
+  getFirstGeneratedActivityCompletionStep,
 } from "@/lib/workflow/config";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
@@ -41,9 +41,10 @@ export function GenerationClient({
   targetLanguage: string | null;
 }) {
   const t = useExtracted();
+  const completionStep = getFirstGeneratedActivityCompletionStep(targetLanguage);
 
   const generation = useWorkflowGeneration<ChapterWorkflowStepName>({
-    completionStep: ACTIVITY_GENERATION_COMPLETION_STEP,
+    completionStep,
     initialRunId: generationRunId,
     initialStatus: generationStatus === "running" ? "streaming" : "idle",
     statusUrl: `${API_URL}/v1/workflows/chapter-generation/status`,

--- a/apps/main/src/app/generate/cs/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generation-client.tsx
@@ -12,8 +12,8 @@ import {
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
 import {
-  ACTIVITY_GENERATION_COMPLETION_STEP,
   type CourseWorkflowStepName,
+  getFirstGeneratedActivityCompletionStep,
 } from "@/lib/workflow/config";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
@@ -39,9 +39,10 @@ export function GenerationClient({
   targetLanguage: string | null;
 }) {
   const t = useExtracted();
+  const completionStep = getFirstGeneratedActivityCompletionStep(targetLanguage);
 
   const generation = useWorkflowGeneration<CourseWorkflowStepName>({
-    completionStep: ACTIVITY_GENERATION_COMPLETION_STEP,
+    completionStep,
     initialRunId: generationRunId,
     initialStatus: generationStatus === "running" ? "streaming" : "idle",
     statusUrl: `${API_URL}/v1/workflows/course-generation/status`,

--- a/apps/main/src/lib/workflow/config.test.ts
+++ b/apps/main/src/lib/workflow/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { getActivityCompletionStep } from "./config";
+import { getActivityCompletionStep, getFirstGeneratedActivityCompletionStep } from "./config";
 
 describe(getActivityCompletionStep, () => {
   test("returns grammar completion step for grammar activity kind", () => {
@@ -12,5 +12,15 @@ describe(getActivityCompletionStep, () => {
 
   test("returns listening completion step for listening activity kind", () => {
     expect(getActivityCompletionStep("listening")).toBe("setListeningAsCompleted");
+  });
+});
+
+describe(getFirstGeneratedActivityCompletionStep, () => {
+  test("waits for vocabulary completion in language lessons", () => {
+    expect(getFirstGeneratedActivityCompletionStep("es")).toBe("setVocabularyAsCompleted");
+  });
+
+  test("uses the generic activity completion step for non-language lessons", () => {
+    expect(getFirstGeneratedActivityCompletionStep(null)).toBe("setActivityAsCompleted");
   });
 });

--- a/apps/main/src/lib/workflow/config.ts
+++ b/apps/main/src/lib/workflow/config.ts
@@ -20,7 +20,7 @@ export const LESSON_STEPS = [
 
 export type LessonStepName = (typeof LESSON_STEPS)[number];
 export const LESSON_COMPLETION_STEP: LessonStepName = "setLessonAsCompleted";
-export const ACTIVITY_GENERATION_COMPLETION_STEP: ActivityStepName = "setActivityAsCompleted";
+const ACTIVITY_GENERATION_COMPLETION_STEP: ActivityStepName = "setActivityAsCompleted";
 
 export const ACTIVITY_STEPS = [
   "getLessonActivities",
@@ -96,6 +96,26 @@ const activityCompletionSteps: Partial<Record<string, ActivityCompletionStep>> =
  */
 export function getActivityCompletionStep(kind: string): ActivityCompletionStep {
   return activityCompletionSteps[kind] ?? "setExplanationAsCompleted";
+}
+
+/**
+ * Course and chapter generation should redirect as soon as the first generated
+ * activity in the first lesson is playable.
+ *
+ * Language lessons always start with a vocabulary activity at position 0.
+ * The generic "setActivityAsCompleted" event is too broad there because
+ * grammar can finish first while vocabulary is still saving pronunciations
+ * and audio. For non-language lessons we keep using the generic event because
+ * the first generated activity kind is not fixed ahead of time.
+ */
+export function getFirstGeneratedActivityCompletionStep(
+  targetLanguage: string | null,
+): ActivityStepName {
+  if (targetLanguage) {
+    return "setVocabularyAsCompleted";
+  }
+
+  return ACTIVITY_GENERATION_COMPLETION_STEP;
 }
 
 export const COURSE_STEPS = [


### PR DESCRIPTION
## Summary

- wait for `setVocabularyAsCompleted` before redirecting language course and chapter generate pages
- keep the generic redirect behavior for non-language generation flows
- add regression coverage for language course and chapter redirects

Related to #1094.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes early redirects in language course and chapter generation by waiting for vocabulary to finish, so users land on playable content. Non‑language flows keep the existing redirect behavior. Related to #1094.

- **Bug Fixes**
  - Use `getFirstGeneratedActivityCompletionStep(targetLanguage)` so language flows wait for `setVocabularyAsCompleted`; non‑language keep `setActivityAsCompleted`.
  - Added unit tests for the helper and E2E tests asserting no redirect on generic completion and redirect after vocabulary for both courses and chapters.

<sup>Written for commit a4d2dac9590dc3076dee78977b2271faf417f907. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

