### PR TITLE
fix(main): redirect only after first activity (position 0) completes

### DIFF
--- a/apps/api/src/workflows/activity-generation/steps/complete-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/complete-activity-step.ts
@@ -69,4 +69,10 @@ export async function completeActivityStep(
 
   await streamStatus({ status, step: stepName });
   await streamStatus({ status, step: "setActivityAsCompleted" });
+
+  const hasFirstActivity = matchingActivities.some((a) => a.position === 0);
+
+  if (hasFirstActivity) {
+    await streamStatus({ status, step: "setFirstActivityAsCompleted" });
+  }
 }

--- a/apps/api/src/workflows/activity-generation/steps/save-custom-activities-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-custom-activities-step.ts
@@ -37,12 +37,23 @@ export async function saveCustomActivitiesStep(
     customActivities.map((act) => saveActivity(act, workflowRunId)),
   );
 
+  const hasFirstActivity = customActivities.some((a) => a.position === 0);
+
   if (rejected(results)) {
     await streamError({ reason: "dbSaveFailed", step: "setCustomAsCompleted" });
     await streamStatus({ status: "error", step: "setActivityAsCompleted" });
+
+    if (hasFirstActivity) {
+      await streamStatus({ status: "error", step: "setFirstActivityAsCompleted" });
+    }
+
     return;
   }
 
   await streamStatus({ status: "completed", step: "setCustomAsCompleted" });
   await streamStatus({ status: "completed", step: "setActivityAsCompleted" });
+
+  if (hasFirstActivity) {
+    await streamStatus({ status: "completed", step: "setFirstActivityAsCompleted" });
+  }
 }

--- a/apps/api/src/workflows/config.ts
+++ b/apps/api/src/workflows/config.ts
@@ -59,6 +59,7 @@ const ACTIVITY_STEPS = [
   "setReadingAsCompleted",
   "setListeningAsCompleted",
   "setActivityAsCompleted",
+  "setFirstActivityAsCompleted",
   "workflowError",
 ] as const;
 

--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -265,8 +265,8 @@ test.describe("Generate Chapter Page - With Subscription", () => {
         { status: "completed", step: "setChapterAsCompleted" },
         { status: "started", step: "setLessonAsCompleted" },
         { status: "completed", step: "setLessonAsCompleted" },
-        { status: "started", step: "setActivityAsCompleted" },
-        { status: "completed", step: "setActivityAsCompleted" },
+        { status: "started", step: "setFirstActivityAsCompleted" },
+        { status: "completed", step: "setFirstActivityAsCompleted" },
       ],
     });
 
@@ -355,7 +355,7 @@ test.describe("Generate Chapter Page - With Subscription", () => {
     await expect(userWithoutProgress).toHaveURL(new RegExp(`/generate/ch/${chapter.id}$`));
   });
 
-  test("redirects language chapters after vocabulary completion", async ({
+  test("redirects after first activity completion", async ({
     userWithoutProgress,
     noProgressUser,
   }) => {
@@ -407,8 +407,8 @@ test.describe("Generate Chapter Page - With Subscription", () => {
         { status: "completed", step: "setChapterAsCompleted" },
         { status: "started", step: "setLessonAsCompleted" },
         { status: "completed", step: "setLessonAsCompleted" },
-        { status: "started", step: "setVocabularyAsCompleted" },
-        { status: "completed", step: "setVocabularyAsCompleted" },
+        { status: "started", step: "setFirstActivityAsCompleted" },
+        { status: "completed", step: "setFirstActivityAsCompleted" },
       ],
     });
 

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -213,8 +213,8 @@ test.describe("Generate Course Page", () => {
           { status: "completed", step: "addLessons" },
           { status: "started", step: "setLessonAsCompleted" },
           { status: "completed", step: "setLessonAsCompleted" },
-          { status: "started", step: "setActivityAsCompleted" },
-          { status: "completed", step: "setActivityAsCompleted" },
+          { status: "started", step: "setFirstActivityAsCompleted" },
+          { status: "completed", step: "setFirstActivityAsCompleted" },
         ],
       });
 
@@ -267,8 +267,8 @@ test.describe("Generate Course Page", () => {
           { status: "completed", step: "addLessons" },
           { status: "started", step: "setLessonAsCompleted" },
           { status: "completed", step: "setLessonAsCompleted" },
-          { status: "started", step: "setActivityAsCompleted" },
-          { status: "completed", step: "setActivityAsCompleted" },
+          { status: "started", step: "setFirstActivityAsCompleted" },
+          { status: "completed", step: "setFirstActivityAsCompleted" },
         ],
       });
 
@@ -335,7 +335,7 @@ test.describe("Generate Course Page", () => {
       await expect(page).toHaveURL(new RegExp(`/generate/cs/${suggestion.id}$`));
     });
 
-    test("redirects language courses after vocabulary completion", async ({ page }) => {
+    test("redirects language courses after first activity completion", async ({ page }) => {
       const slug = `e2e-language-completion-${randomUUID().slice(0, 8)}`;
       const org = await getAiOrganization();
 
@@ -376,8 +376,8 @@ test.describe("Generate Course Page", () => {
           { status: "completed", step: "addLessons" },
           { status: "started", step: "setLessonAsCompleted" },
           { status: "completed", step: "setLessonAsCompleted" },
-          { status: "started", step: "setVocabularyAsCompleted" },
-          { status: "completed", step: "setVocabularyAsCompleted" },
+          { status: "started", step: "setFirstActivityAsCompleted" },
+          { status: "completed", step: "setFirstActivityAsCompleted" },
         ],
       });
 

--- a/apps/main/src/app/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generation-client.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/generation/generation-progress";
 import {
   type ChapterWorkflowStepName,
-  getFirstGeneratedActivityCompletionStep,
+  FIRST_ACTIVITY_COMPLETION_STEP,
 } from "@/lib/workflow/config";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
@@ -41,10 +41,9 @@ export function GenerationClient({
   targetLanguage: string | null;
 }) {
   const t = useExtracted();
-  const completionStep = getFirstGeneratedActivityCompletionStep(targetLanguage);
 
   const generation = useWorkflowGeneration<ChapterWorkflowStepName>({
-    completionStep,
+    completionStep: FIRST_ACTIVITY_COMPLETION_STEP,
     initialRunId: generationRunId,
     initialStatus: generationStatus === "running" ? "streaming" : "idle",
     statusUrl: `${API_URL}/v1/workflows/chapter-generation/status`,

--- a/apps/main/src/app/generate/cs/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generation-client.tsx
@@ -11,10 +11,7 @@ import {
   GenerationTimelineSubtitle,
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
-import {
-  type CourseWorkflowStepName,
-  getFirstGeneratedActivityCompletionStep,
-} from "@/lib/workflow/config";
+import { type CourseWorkflowStepName, FIRST_ACTIVITY_COMPLETION_STEP } from "@/lib/workflow/config";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useThinkingMessages } from "@/lib/workflow/use-thinking-messages";
@@ -39,10 +36,9 @@ export function GenerationClient({
   targetLanguage: string | null;
 }) {
   const t = useExtracted();
-  const completionStep = getFirstGeneratedActivityCompletionStep(targetLanguage);
 
   const generation = useWorkflowGeneration<CourseWorkflowStepName>({
-    completionStep,
+    completionStep: FIRST_ACTIVITY_COMPLETION_STEP,
     initialRunId: generationRunId,
     initialStatus: generationStatus === "running" ? "streaming" : "idle",
     statusUrl: `${API_URL}/v1/workflows/course-generation/status`,

--- a/apps/main/src/lib/generation/activity-generation-phase-step-groups.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-step-groups.ts
@@ -37,6 +37,7 @@ const ALL_COMPLETION_STEPS: ActivityStepName[] = [
   "setReadingAsCompleted",
   "setListeningAsCompleted",
   "setActivityAsCompleted",
+  "setFirstActivityAsCompleted",
 ];
 
 export const EXPLANATION_DEPS: ActivityStepName[] = [

--- a/apps/main/src/lib/workflow/config.test.ts
+++ b/apps/main/src/lib/workflow/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { getActivityCompletionStep, getFirstGeneratedActivityCompletionStep } from "./config";
+import { getActivityCompletionStep } from "./config";
 
 describe(getActivityCompletionStep, () => {
   test("returns grammar completion step for grammar activity kind", () => {
@@ -12,15 +12,5 @@ describe(getActivityCompletionStep, () => {
 
   test("returns listening completion step for listening activity kind", () => {
     expect(getActivityCompletionStep("listening")).toBe("setListeningAsCompleted");
-  });
-});
-
-describe(getFirstGeneratedActivityCompletionStep, () => {
-  test("waits for vocabulary completion in language lessons", () => {
-    expect(getFirstGeneratedActivityCompletionStep("es")).toBe("setVocabularyAsCompleted");
-  });
-
-  test("uses the generic activity completion step for non-language lessons", () => {
-    expect(getFirstGeneratedActivityCompletionStep(null)).toBe("setActivityAsCompleted");
   });
 });

--- a/apps/main/src/lib/workflow/config.ts
+++ b/apps/main/src/lib/workflow/config.ts
@@ -20,7 +20,6 @@ export const LESSON_STEPS = [
 
 export type LessonStepName = (typeof LESSON_STEPS)[number];
 export const LESSON_COMPLETION_STEP: LessonStepName = "setLessonAsCompleted";
-const ACTIVITY_GENERATION_COMPLETION_STEP: ActivityStepName = "setActivityAsCompleted";
 
 export const ACTIVITY_STEPS = [
   "getLessonActivities",
@@ -56,6 +55,7 @@ export const ACTIVITY_STEPS = [
   "setReadingAsCompleted",
   "setListeningAsCompleted",
   "setActivityAsCompleted",
+  "setFirstActivityAsCompleted",
   "workflowError",
 ] as const;
 
@@ -99,24 +99,11 @@ export function getActivityCompletionStep(kind: string): ActivityCompletionStep 
 }
 
 /**
- * Course and chapter generation should redirect as soon as the first generated
- * activity in the first lesson is playable.
- *
- * Language lessons always start with a vocabulary activity at position 0.
- * The generic "setActivityAsCompleted" event is too broad there because
- * grammar can finish first while vocabulary is still saving pronunciations
- * and audio. For non-language lessons we keep using the generic event because
- * the first generated activity kind is not fixed ahead of time.
+ * The step the frontend listens for to trigger redirect during course/chapter
+ * generation. The API emits this only when the activity at position 0 finishes,
+ * so it works universally for all lesson kinds without language-specific checks.
  */
-export function getFirstGeneratedActivityCompletionStep(
-  targetLanguage: string | null,
-): ActivityStepName {
-  if (targetLanguage) {
-    return "setVocabularyAsCompleted";
-  }
-
-  return ACTIVITY_GENERATION_COMPLETION_STEP;
-}
+export const FIRST_ACTIVITY_COMPLETION_STEP: ActivityStepName = "setFirstActivityAsCompleted";
 
 export const COURSE_STEPS = [
   "getCourseSuggestion",


### PR DESCRIPTION
## Summary

- Adds `setFirstActivityAsCompleted` SSE event that only fires when an activity at position 0 finishes generation
- Replaces the language-specific `getFirstGeneratedActivityCompletionStep()` function with a universal `FIRST_ACTIVITY_COMPLETION_STEP` constant
- Frontend now listens for `setFirstActivityAsCompleted` instead of `setVocabularyAsCompleted` (language) or `setActivityAsCompleted` (generic)

Closes #1094

## Test plan

- [x] Unit tests pass (`pnpm test`)
- [x] E2E generate tests pass 3x with zero flakiness
- [x] Full E2E suites pass for all apps (main, editor, api)
- [x] `pnpm knip --production` — no unused exports
- [x] All apps build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect now waits for the first generated activity (position 0) to finish before navigating during course/chapter generation. Adds a new SSE event and a single frontend completion constant to prevent early redirects, especially in language lessons. Closes #1094.

- **Bug Fixes**
  - API emits `setFirstActivityAsCompleted` only when the activity at position 0 completes (covers success and error paths).
  - Frontend uses `FIRST_ACTIVITY_COMPLETION_STEP` and listens for `setFirstActivityAsCompleted` instead of language-specific steps; E2E tests updated.

<sup>Written for commit 2116201346c148e6acea4792274b00637875e25a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

