### PR TITLE
fix(main): revalidate home path after completing activity

### DIFF
--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
@@ -14,7 +14,6 @@ import { computeChallengeScore, computeScore } from "@zoonk/player/compute-score
 import { computeDimensions, hasNegativeDimension } from "@zoonk/player/dimensions";
 import { validateAnswers } from "@zoonk/player/validate-answers";
 import { safeAsync } from "@zoonk/utils/error";
-import { getLocale } from "next-intl/server";
 import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 import { after } from "next/server";
@@ -119,8 +118,7 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
     return { status: "error" };
   }
 
-  const locale = await getLocale();
-  revalidatePath(`/${locale}`);
+  revalidatePath("/");
 
   after(() => preloadNextLesson(activityId, reqHeaders.get("cookie") ?? ""));
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Revalidate the home path ("/") after completing an activity to keep the homepage up to date. Removed locale-based revalidation to fix stale cache on localized routes.

<sup>Written for commit 81924571b540561fe223874c9228faac50124237. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

