### PR TITLE
feat(main): add back navigation to generate page gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,7 @@ To accept href in a custom component wrapping next/link, use a generic:
 import type { Route } from "next";
 import Link from "next/link";
 
-function Card<T extends string>({ href }: { href: Route<T> | URL }) {
+function Card<Href extends string>({ href }: { href: Route<Href> | URL }) {
   return (
     <Link href={href}>
       <div>My Card</div>
@@ -187,8 +187,8 @@ You can also type a simple data structure and iterate to render links:
 ```tsx
 import type { Route } from "next";
 
-type NavItem<T extends string = string> = {
-  href: T;
+type NavItem<Href extends string = string> = {
+  href: Href;
   label: string;
 };
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1634,6 +1634,11 @@ msgid "Create Activity"
 msgstr "Create Activity"
 
 #: src/app/generate/a/[id]/generate-activity-content.tsx
+msgctxt "lqM5Zj"
+msgid "Back to lesson"
+msgstr "Back to lesson"
+
+#: src/app/generate/a/[id]/generate-activity-content.tsx
 msgctxt "YQINXG"
 msgid "Create content for this activity"
 msgstr "Create content for this activity"
@@ -1906,6 +1911,11 @@ msgctxt "qNiSDe"
 msgid "Create Chapter"
 msgstr "Create Chapter"
 
+#: src/app/generate/ch/[id]/generate-chapter-content.tsx
+msgctxt "qrEiLa"
+msgid "Back to course"
+msgstr "Back to course"
+
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgctxt "3vY0Zu"
 msgid "This usually takes 1-2 minutes"
@@ -2116,6 +2126,11 @@ msgstr "Writing chapters"
 msgctxt "XxZuJi"
 msgid "Putting it all together..."
 msgstr "Putting it all together..."
+
+#: src/app/generate/l/[id]/generate-lesson-content.tsx
+msgctxt "/N8rYN"
+msgid "Back to chapter"
+msgstr "Back to chapter"
 
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
 msgctxt "kXZ7ZI"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1634,6 +1634,11 @@ msgid "Create Activity"
 msgstr "Crear Actividad"
 
 #: src/app/generate/a/[id]/generate-activity-content.tsx
+msgctxt "lqM5Zj"
+msgid "Back to lesson"
+msgstr "Volver a la lección"
+
+#: src/app/generate/a/[id]/generate-activity-content.tsx
 msgctxt "YQINXG"
 msgid "Create content for this activity"
 msgstr "Crear contenido para esta actividad"
@@ -1906,6 +1911,11 @@ msgctxt "qNiSDe"
 msgid "Create Chapter"
 msgstr "Crear Capítulo"
 
+#: src/app/generate/ch/[id]/generate-chapter-content.tsx
+msgctxt "qrEiLa"
+msgid "Back to course"
+msgstr "Volver al curso"
+
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgctxt "3vY0Zu"
 msgid "This usually takes 1-2 minutes"
@@ -2116,6 +2126,11 @@ msgstr "Escribiendo capítulos"
 msgctxt "XxZuJi"
 msgid "Putting it all together..."
 msgstr "Juntando todo..."
+
+#: src/app/generate/l/[id]/generate-lesson-content.tsx
+msgctxt "/N8rYN"
+msgid "Back to chapter"
+msgstr "Volver al capítulo"
 
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
 msgctxt "kXZ7ZI"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1634,6 +1634,11 @@ msgid "Create Activity"
 msgstr "Criar Atividade"
 
 #: src/app/generate/a/[id]/generate-activity-content.tsx
+msgctxt "lqM5Zj"
+msgid "Back to lesson"
+msgstr "Voltar para a aula"
+
+#: src/app/generate/a/[id]/generate-activity-content.tsx
 msgctxt "YQINXG"
 msgid "Create content for this activity"
 msgstr "Criar conteúdo para esta atividade"
@@ -1906,6 +1911,11 @@ msgctxt "qNiSDe"
 msgid "Create Chapter"
 msgstr "Criar Capítulo"
 
+#: src/app/generate/ch/[id]/generate-chapter-content.tsx
+msgctxt "qrEiLa"
+msgid "Back to course"
+msgstr "Voltar para o curso"
+
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgctxt "3vY0Zu"
 msgid "This usually takes 1-2 minutes"
@@ -2116,6 +2126,11 @@ msgstr "Escrevendo capítulos"
 msgctxt "XxZuJi"
 msgid "Putting it all together..."
 msgstr "Juntando tudo..."
+
+#: src/app/generate/l/[id]/generate-lesson-content.tsx
+msgctxt "/N8rYN"
+msgid "Back to chapter"
+msgstr "Voltar para o capítulo"
 
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
 msgctxt "kXZ7ZI"

--- a/apps/main/src/app/generate/a/[id]/generate-activity-content.tsx
+++ b/apps/main/src/app/generate/a/[id]/generate-activity-content.tsx
@@ -37,8 +37,13 @@ export async function GenerateActivityContent({ params }: { params: Promise<{ id
   const hasStarted = activity.generationStatus !== "pending";
   const t = await getExtracted();
 
+  const backHref =
+    `/b/${AI_ORG_SLUG}/c/${activity.lesson.chapter.course.slug}/ch/${activity.lesson.chapter.slug}/l/${activity.lesson.slug}` as const;
+
+  const backLabel = t("Back to lesson");
+
   if (!session && !hasStarted) {
-    return <LoginRequired title={t("Create Activity")} />;
+    return <LoginRequired backHref={backHref} backLabel={backLabel} title={t("Create Activity")} />;
   }
 
   if (activity.generationStatus === "completed") {
@@ -57,7 +62,7 @@ export async function GenerateActivityContent({ params }: { params: Promise<{ id
       </ContainerHeader>
 
       <ContainerBody>
-        <SubscriptionGate bypass={hasStarted}>
+        <SubscriptionGate backHref={backHref} backLabel={backLabel} bypass={hasStarted}>
           <GenerationClient
             activityKind={activity.kind}
             chapterSlug={activity.lesson.chapter.slug}

--- a/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
@@ -36,8 +36,11 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
   const bypassAuth = isFirstChapter || hasStarted;
   const t = await getExtracted();
 
+  const backHref = `/b/${AI_ORG_SLUG}/c/${chapter.course.slug}` as const;
+  const backLabel = t("Back to course");
+
   if (!session && !bypassAuth) {
-    return <LoginRequired title={t("Create Chapter")} />;
+    return <LoginRequired backHref={backHref} backLabel={backLabel} title={t("Create Chapter")} />;
   }
 
   if (chapter.generationStatus === "completed") {
@@ -56,7 +59,7 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
       </ContainerHeader>
 
       <ContainerBody>
-        <SubscriptionGate bypass={bypassAuth}>
+        <SubscriptionGate backHref={backHref} backLabel={backLabel} bypass={bypassAuth}>
           <GenerationClient
             chapterId={chapterId}
             chapterSlug={chapter.slug}

--- a/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
+++ b/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
@@ -34,8 +34,13 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
   const hasStarted = lesson.generationStatus !== "pending";
   const t = await getExtracted();
 
+  const backHref =
+    `/b/${AI_ORG_SLUG}/c/${lesson.chapter.course.slug}/ch/${lesson.chapter.slug}` as const;
+
+  const backLabel = t("Back to chapter");
+
   if (!session && !hasStarted) {
-    return <LoginRequired title={t("Create Lesson")} />;
+    return <LoginRequired backHref={backHref} backLabel={backLabel} title={t("Create Lesson")} />;
   }
 
   if (lesson.generationStatus === "completed") {
@@ -54,7 +59,7 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
       </ContainerHeader>
 
       <ContainerBody>
-        <SubscriptionGate bypass={hasStarted}>
+        <SubscriptionGate backHref={backHref} backLabel={backLabel} bypass={hasStarted}>
           <GenerationClient
             chapterSlug={lesson.chapter.slug}
             courseSlug={lesson.chapter.course.slug}

--- a/apps/main/src/components/auth/login-required.tsx
+++ b/apps/main/src/components/auth/login-required.tsx
@@ -8,10 +8,19 @@ import {
 } from "@zoonk/ui/components/container";
 import { cn } from "@zoonk/ui/lib/utils";
 import { ProtectedSection } from "@zoonk/ui/patterns/auth/protected";
+import { type Route } from "next";
 import { getExtracted } from "next-intl/server";
 import Link from "next/link";
 
-export async function LoginRequired({ title }: { title: string }) {
+export async function LoginRequired<Href extends string>({
+  backHref,
+  backLabel,
+  title,
+}: {
+  backHref: Route<Href>;
+  backLabel: string;
+  title: string;
+}) {
   const t = await getExtracted();
 
   return (
@@ -25,9 +34,19 @@ export async function LoginRequired({ title }: { title: string }) {
       <ContainerBody>
         <ProtectedSection
           actions={
-            <Link className={cn(buttonVariants(), "w-max")} href="/login">
-              {t("Login")}
-            </Link>
+            <>
+              <Link
+                className={cn(buttonVariants({ variant: "outline" }), "w-max")}
+                href={backHref}
+                prefetch
+              >
+                {backLabel}
+              </Link>
+
+              <Link className={cn(buttonVariants(), "w-max")} href="/login" prefetch>
+                {t("Login")}
+              </Link>
+            </>
           }
           alertTitle={t("You need to be logged in to access this page.")}
           centered

--- a/apps/main/src/components/subscription/subscription-gate.tsx
+++ b/apps/main/src/components/subscription/subscription-gate.tsx
@@ -1,12 +1,17 @@
 import "server-only";
 import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
+import { type Route } from "next";
 import { headers } from "next/headers";
 import { UpgradeCTA } from "./upgrade-cta";
 
-export async function SubscriptionGate({
+export async function SubscriptionGate<Href extends string>({
+  backHref,
+  backLabel,
   bypass,
   children,
 }: {
+  backHref: Route<Href>;
+  backLabel: string;
   bypass?: boolean;
   children: React.ReactNode;
 }) {
@@ -17,7 +22,7 @@ export async function SubscriptionGate({
   const hasSubscription = await hasActiveSubscription(await headers());
 
   if (!hasSubscription) {
-    return <UpgradeCTA />;
+    return <UpgradeCTA backHref={backHref} backLabel={backLabel} />;
   }
 
   return children;

--- a/apps/main/src/components/subscription/upgrade-cta.tsx
+++ b/apps/main/src/components/subscription/upgrade-cta.tsx
@@ -9,10 +9,17 @@ import {
 } from "@zoonk/ui/components/empty";
 import { cn } from "@zoonk/ui/lib/utils";
 import { SparklesIcon } from "lucide-react";
+import { type Route } from "next";
 import { getExtracted } from "next-intl/server";
 import Link from "next/link";
 
-export async function UpgradeCTA() {
+export async function UpgradeCTA<Href extends string>({
+  backHref,
+  backLabel,
+}: {
+  backHref: Route<Href>;
+  backLabel: string;
+}) {
   const t = await getExtracted();
 
   return (
@@ -30,7 +37,15 @@ export async function UpgradeCTA() {
       </EmptyHeader>
 
       <EmptyContent>
-        <Link className={cn(buttonVariants(), "w-max")} href="/subscription">
+        <Link
+          className={cn(buttonVariants({ variant: "outline" }), "w-max")}
+          href={backHref}
+          prefetch
+        >
+          {backLabel}
+        </Link>
+
+        <Link className={cn(buttonVariants(), "w-max")} href="/subscription" prefetch>
           {t("Upgrade")}
         </Link>
       </EmptyContent>

--- a/i18n.lock
+++ b/i18n.lock
@@ -201,7 +201,6 @@ checksums:
     "%7Bitem%7D.%20%7Bresult%7D./singular": 454dd5319c350f361652396801a1c30b
     Position%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: a1b3d3e026bfff43bff3d3e85ccdb952
     Incorrect/singular: a86cfbe7b86f19dc8df14a67df073d22
-    Correct%20answer/singular: b7b440a054a86a05c601276b1a308507
     Word%20bank/singular: ceea720dd5fa3747c7f93ce165f77b2e
     "%7Bcolor%7D%20belt/singular": 5949446c9b4a223c04cc500fa17a1fe0
     Level%20progress/singular: 286f095acd17006787247db0b69270e3
@@ -244,12 +243,12 @@ checksums:
     "%7Bcount%7D%20at%20risk/singular": d0c6a90b2830b7b26e220ef1f7708d08
     View%20scores/singular: 8089ad914ec6636a00fd58ed3c84f07b
     Your%20answer%3A/singular: 663abc310ccb6229c6325f8c857adce2
+    Correct%20answer%3A/singular: a8b8cc0d5d0059cbfeee0ad4721540d5
     "%7Bname%7D%20is%20negative.%20You%20need%20to%20bring%20this%20back%20up%20or%20you%20will%20lose./singular": c893d2d3c1bb15ea45614228ea9ddcac
     Translate%3A/singular: 0a44ccd6c0e1dd4545fd00d059eaf0a5
     Outcome/singular: 4cfc7a40e384ea8b6658e8da6e351bf0
     Close%20call./singular: 7913cf61fc4e2fcd3eaf0d51bd86ba4d
     "%7Bname%7D%20is%20at%20zero.%20One%20more%20drop%20and%20you%20lose./singular": 4e48a2c335f69b412a58e4aef620caf1
-    Correct%20answer%3A/singular: a8b8cc0d5d0059cbfeee0ad4721540d5
     Score%20changes/singular: ddf8ff300115aa23776dc4b3157581de
     Blank%20%7Bposition%7D/singular: 70a4795f65f91685071b6abb1c3a6bad
     Blank%20%7Bposition%7D%3A%20%7Bitem%7D.%20%7Bresult%7D./singular: c64e721cdd1e4cc48eff9f9690f1fc6b
@@ -501,6 +500,7 @@ checksums:
     This%20activity%20hasn't%20been%20created%20yet./singular: c1e71adf6ff4ecd34e0b5ba242110397
     Activity%20not%20available/singular: a76f6331aa0aad825903108429b132a0
     Create%20Activity/singular: ceaf06ac3cbfcfcf824b9e9acf66cfb9
+    Back%20to%20lesson/singular: c393a48d88c80baa6217836b373f908f
     Create%20content%20for%20this%20activity/singular: e48e26e5fc10415a118d5d6c9f6d032e
     Your%20activity%20is%20ready/singular: e7385c4096b843839bb9a96023f0eea9
     Something%20went%20wrong/singular: a3cd2f01c073f1f5ff436d4b132d39cf
@@ -542,6 +542,7 @@ checksums:
     Setting%20things%20up.../singular: 4696c8e1048ec21837f886410864dfe2
     Refining%20the%20details.../singular: eaf7a7ca135f8919dc93f80095040ab0
     Create%20Chapter/singular: eff367b47e651ac3234f8b4655d5a078
+    Back%20to%20course/singular: 605eb294c4cd0dbfee151a369d28fe36
     This%20usually%20takes%201-2%20minutes/singular: bd7260323fa4b3a50a0300ed136fcbd2
     Your%20lessons%20are%20ready/singular: fe8d9df59ba42f451b249fd750813cba
     Taking%20you%20to%20your%20chapter.../singular: fc59b426c3d393ec40f534253309ee9f
@@ -581,6 +582,7 @@ checksums:
     Picking%20the%20right%20look.../singular: 697bdd3a4fa077ddd50c64d57775baf6
     Writing%20chapters/singular: b2e7e149ee761e4e5a45225e37e5441a
     Putting%20it%20all%20together.../singular: 12349256a2104ecf09b213ba1437c636
+    Back%20to%20chapter/singular: ed886de66b9c8ec08ec55860cdebc6a7
     Create%20Lesson/singular: af03c55d9ad5e6063bfad0ce8a35e385
     Your%20lesson%20is%20ready/singular: 3d745fd67b57e47ed10851f1e5404ccc
     Creating%20your%20activities/singular: 6651e663a48e18486f5f873e614cd512
@@ -598,7 +600,6 @@ checksums:
     More%20options/singular: 53d90eae6a9b0243b5bc043b3d9de169
     Start/singular: dbe56303d9a6d3fad1a8d4cbcc97f365
     Review/singular: 299f75db25382980b2895622d7712927
-    All%20activities%20completed/singular: 7a287338649cba271ade32d7008a9231
     Please%20provide%20as%20much%20detail%20as%20possible./singular: 3c8b231283c751d4beae059a6ffc3643
     Failed%20to%20send%20message.%20Please%20try%20again%20or%20email%20us%20directly%20at%20hello%40zoonk.com/singular: 7f36bcd5ba5dad4b9981f85488ff794c
     Email%20address/singular: 3ba3f099b1b9be6c35ad797da660cb9f


### PR DESCRIPTION
## Summary

- Add "Back to course/chapter/lesson" links to `LoginRequired` and `UpgradeCTA` on generate pages
- Links point to the parent entity (course → chapter → lesson) to avoid infinite redirect loops that `router.back()` would cause
- Pure server-rendered `<Link>` with `prefetch` — no client JS needed

## Test plan

- [ ] Visit a generate chapter page without auth → verify "Back to course" link appears and navigates correctly
- [ ] Visit a generate lesson page without auth → verify "Back to chapter" link appears and navigates correctly
- [ ] Visit a generate activity page without auth → verify "Back to lesson" link appears and navigates correctly
- [ ] Visit generate pages without subscription → verify back link appears alongside "Upgrade" button
- [ ] Verify no redirect loops when clicking the back link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Back to course/chapter/lesson” link to generate page gates so users can safely navigate to the parent entity without redirect loops. Links are server-rendered `<Link>`s with prefetch and no client JS.

- **New Features**
  - Show a back link in `LoginRequired` and `UpgradeCTA` on activity, lesson, and chapter generate pages.
  - Pass type-safe `backHref` and `backLabel` from the page to the gates; uses `next/link` with `prefetch`.
  - Replace `router.back()` with explicit parent links to avoid infinite loops.
  - Add new i18n strings in `en`, `es`, and `pt`.

- **Migration**
  - `LoginRequired`, `SubscriptionGate`, and `UpgradeCTA` now require `backHref` and `backLabel` props. Update any other usages to include them.
  - Use a `Route<Href>`-typed path for `backHref` and a localized label for `backLabel`.

<sup>Written for commit 11bf440cb56d6899988b655df9979cf448226dc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

