### PR TITLE
perf(main): show completion metrics instantly via after()

### DIFF
--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
@@ -13,6 +13,7 @@ import {
 import { computeChallengeScore, computeScore } from "@zoonk/player/compute-score";
 import { computeDimensions, hasNegativeDimension } from "@zoonk/player/dimensions";
 import { validateAnswers } from "@zoonk/player/validate-answers";
+import { calculateBeltLevel } from "@zoonk/utils/belt-level";
 import { safeAsync } from "@zoonk/utils/error";
 import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
@@ -46,17 +47,20 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
   const activityId = BigInt(input.activityId);
 
   const { data, error } = await safeAsync(async () => {
-    const activity = await prisma.activity.findUnique({
-      include: {
-        lesson: { include: { chapter: true } },
-        steps: {
-          include: { sentence: true, word: true },
-          orderBy: { position: "asc" },
-          where: { isPublished: true },
+    const [activity, userProgress] = await Promise.all([
+      prisma.activity.findUnique({
+        include: {
+          lesson: { include: { chapter: true } },
+          steps: {
+            include: { sentence: true, word: true },
+            orderBy: { position: "asc" },
+            where: { isPublished: true },
+          },
         },
-      },
-      where: { id: activityId },
-    });
+        where: { id: activityId },
+      }),
+      prisma.userProgress.findUnique({ where: { userId } }),
+    ]);
 
     if (!activity) {
       return null;
@@ -100,27 +104,39 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
       };
     });
 
-    return submitActivityCompletion({
-      activityId: activity.id,
-      courseId: activity.lesson.chapter.courseId,
-      durationSeconds,
-      isChallenge,
-      localDate: input.localDate,
-      organizationId: activity.organizationId,
-      score,
-      startedAt: new Date(input.startedAt),
-      stepResults: mergedStepResults,
-      userId,
+    const newTotalBp = Number(userProgress?.totalBrainPower ?? 0) + score.brainPower;
+
+    // Persist progress in the background so the user sees results instantly
+    // instead of waiting for the DB transaction to complete.
+    after(async () => {
+      await submitActivityCompletion({
+        activityId: activity.id,
+        courseId: activity.lesson.chapter.courseId,
+        durationSeconds,
+        isChallenge,
+        localDate: input.localDate,
+        organizationId: activity.organizationId,
+        score,
+        startedAt: new Date(input.startedAt),
+        stepResults: mergedStepResults,
+        userId,
+      });
+
+      revalidatePath("/");
+      await preloadNextLesson(activityId, reqHeaders.get("cookie") ?? "");
     });
+
+    return {
+      belt: calculateBeltLevel(newTotalBp),
+      brainPower: score.brainPower,
+      energyDelta: score.energyDelta,
+      newTotalBp,
+    };
   });
 
   if (error || !data) {
     return { status: "error" };
   }
-
-  revalidatePath("/");
-
-  after(() => preloadNextLesson(activityId, reqHeaders.get("cookie") ?? ""));
 
   return {
     belt: data.belt,


### PR DESCRIPTION
## Summary

- Move `submitActivityCompletion` DB transaction into `after()` so the server action returns immediately with computed metrics
- Fetch `userProgress.totalBrainPower` in parallel with the activity query to compute belt level without waiting for the write
- Move `revalidatePath` and `preloadNextLesson` into `after()` so cache invalidation happens after data is persisted

Users now see BP, energy, and belt progress instantly on activity completion instead of waiting ~2-3s for skeleton placeholders to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show BP, energy, and belt progress instantly after activity completion by deferring the DB write and cache work with `after()`. Parallelize the activity and `userProgress` fetches to compute metrics immediately.

- **Refactors**
  - Defer `submitActivityCompletion`, `revalidatePath`, and next-lesson preload to `after()` so the action returns immediately.
  - Fetch `activity` and `userProgress` together; compute `newTotalBp` and belt via `@zoonk/utils/belt-level`.

<sup>Written for commit ad2197fa9e3f3cd344a1e3ba5490c612d2836d24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

