### PR TITLE
feat(player): preload images for upcoming steps

### DIFF
--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -12,12 +12,14 @@ import {
   getIsStaticStep,
   getProgressValue,
   getSelectedAnswer,
+  getUpcomingImages,
 } from "../player-selectors";
 import { InPlayStickyHeader } from "./in-play-sticky-header";
 import { PlayerBottomBar, PlayerBottomBarAction, PlayerBottomBarNav } from "./player-bottom-bar";
 import { PlayerCloseLink, PlayerHeader } from "./player-header";
 import { PlayerStage } from "./player-stage";
 import { StageContent } from "./stage-content";
+import { StepImagePreloader } from "./step-image-preloader";
 
 export function PlayerShell() {
   const t = useExtracted();
@@ -33,6 +35,7 @@ export function PlayerShell() {
   const isStaticStep = getIsStaticStep(state);
   const progressValue = getProgressValue(state);
   const selectedAnswer = getSelectedAnswer(state);
+  const upcomingImages = getUpcomingImages(state);
 
   const hasDimensions = Object.keys(state.dimensions).length > 0;
   const isIntro = state.phase === "intro";
@@ -100,6 +103,8 @@ export function PlayerShell() {
           )}
         </PlayerBottomBar>
       )}
+
+      <StepImagePreloader images={upcomingImages} />
     </main>
   );
 }

--- a/packages/player/src/components/select-image-step.tsx
+++ b/packages/player/src/components/select-image-step.tsx
@@ -5,6 +5,7 @@ import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import Image from "next/image";
 import { useState } from "react";
+import { SELECT_IMAGE_PROPS } from "../image-config";
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
 import { useOptionKeyboard } from "../use-option-keyboard";
@@ -51,12 +52,10 @@ function ImageWithFallback({ alt, url }: { alt: string; url: string | undefined 
     <Image
       alt={alt}
       className="aspect-square object-cover"
-      height={336}
       loading="eager"
       onError={() => setHasError(true)}
-      sizes="(max-width: 672px) 50vw, 336px"
       src={url}
-      width={336}
+      {...SELECT_IMAGE_PROPS}
     />
   );
 }

--- a/packages/player/src/components/step-image-preloader.tsx
+++ b/packages/player/src/components/step-image-preloader.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Image from "next/image";
+import { Activity } from "react";
+import { SELECT_IMAGE_PROPS, VISUAL_IMAGE_PROPS } from "../image-config";
+import { type PreloadableImage } from "../player-selectors";
+
+/**
+ * Renders hidden Next.js `<Image>` components for upcoming steps so the browser
+ * fetches the optimized `/_next/image` URLs before the user navigates to them.
+ * When the real step mounts with the same props, the browser serves the image
+ * from its HTTP cache — making it appear instantly.
+ *
+ * Uses React's `<Activity mode="hidden">` to render at lower priority
+ * (doesn't compete with the current step) while keeping DOM nodes alive
+ * so `loading="eager"` can trigger the fetch.
+ */
+export function StepImagePreloader({ images }: { images: PreloadableImage[] }) {
+  if (images.length === 0) {
+    return null;
+  }
+
+  return (
+    <Activity mode="hidden">
+      {images.map((image) => {
+        const props = image.kind === "visual" ? VISUAL_IMAGE_PROPS : SELECT_IMAGE_PROPS;
+        return <Image alt="" key={image.url} loading="eager" src={image.url} {...props} />;
+      })}
+    </Activity>
+  );
+}

--- a/packages/player/src/components/visuals/image-visual.tsx
+++ b/packages/player/src/components/visuals/image-visual.tsx
@@ -3,6 +3,7 @@
 import { type ImageVisualContent } from "@zoonk/core/steps/visual-content-contract";
 import Image from "next/image";
 import { useState } from "react";
+import { VISUAL_IMAGE_PROPS } from "../../image-config";
 
 function ImageFallback({ prompt }: { prompt: string }) {
   return (
@@ -23,12 +24,10 @@ export function ImageVisual({ content }: { content: ImageVisualContent }) {
     <Image
       alt={content.prompt}
       className="aspect-square w-full max-w-md rounded-2xl object-cover"
-      height={1024}
       loading="eager"
       onError={() => setErrorUrl(content.url ?? null)}
-      sizes="(max-width: 640px) calc(100vw - 2rem), 448px"
       src={content.url}
-      width={1024}
+      {...VISUAL_IMAGE_PROPS}
     />
   );
 }

--- a/packages/player/src/image-config.ts
+++ b/packages/player/src/image-config.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared image dimension constants for step images. Used by both the rendering
+ * components and the preloader to ensure the browser fetches the exact same
+ * optimized `/_next/image` URL — guaranteeing a cache hit when the step mounts.
+ */
+export const VISUAL_IMAGE_PROPS = {
+  height: 1024,
+  sizes: "(max-width: 640px) calc(100vw - 2rem), 448px",
+  width: 1024,
+} as const;
+
+export const SELECT_IMAGE_PROPS = {
+  height: 336,
+  sizes: "(max-width: 672px) 50vw, 336px",
+  width: 336,
+} as const;

--- a/packages/player/src/player-selectors.test.ts
+++ b/packages/player/src/player-selectors.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, test } from "vitest";
+import { type PlayerState } from "./player-reducer";
+import { getUpcomingImages } from "./player-selectors";
+import { type SerializedStep } from "./prepare-activity-data";
+
+function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
+  return {
+    content: { text: "Hello", title: "Intro", variant: "text" as const },
+    fillBlankOptions: [],
+    id: "step-1",
+    kind: "static",
+    matchColumnsRightItems: [],
+    position: 0,
+    sentence: null,
+    sentenceWordOptions: [],
+    sortOrderItems: [],
+    translationOptions: [],
+    vocabularyOptions: [],
+    word: null,
+    wordBankOptions: [],
+    ...overrides,
+  };
+}
+
+function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
+  return {
+    activityId: "activity-1",
+    completion: { status: "idle" },
+    completionRequestId: 0,
+    currentStepIndex: 0,
+    dimensions: {},
+    phase: "playing",
+    previousDimensions: {},
+    results: {},
+    selectedAnswers: {},
+    startedAt: 1000,
+    stepStartedAt: 1000,
+    stepTimings: {},
+    steps: [buildStep()],
+    ...overrides,
+  };
+}
+
+describe(getUpcomingImages, () => {
+  test("returns empty array when no upcoming steps have images", () => {
+    const state = buildState({
+      steps: [
+        buildStep({ id: "s1" }),
+        buildStep({ id: "s2", position: 1 }),
+        buildStep({ id: "s3", position: 2 }),
+      ],
+    });
+
+    expect(getUpcomingImages(state)).toEqual([]);
+  });
+
+  test("extracts URL from a visual image step", () => {
+    const state = buildState({
+      steps: [
+        buildStep({ id: "s1" }),
+        buildStep({
+          content: { kind: "image", prompt: "A cat", url: "https://example.com/cat.jpg" },
+          id: "s2",
+          kind: "visual",
+          position: 1,
+        }),
+      ],
+    });
+
+    expect(getUpcomingImages(state)).toEqual([
+      { kind: "visual", url: "https://example.com/cat.jpg" },
+    ]);
+  });
+
+  test("extracts URLs from a selectImage step", () => {
+    const state = buildState({
+      steps: [
+        buildStep({ id: "s1" }),
+        buildStep({
+          content: {
+            options: [
+              {
+                feedback: "Yes",
+                isCorrect: true,
+                prompt: "Cat",
+                url: "https://example.com/cat.jpg",
+              },
+              {
+                feedback: "No",
+                isCorrect: false,
+                prompt: "Dog",
+                url: "https://example.com/dog.jpg",
+              },
+            ],
+            question: "Pick the cat",
+          },
+          id: "s2",
+          kind: "selectImage",
+          position: 1,
+        }),
+      ],
+    });
+
+    expect(getUpcomingImages(state)).toEqual([
+      { kind: "selectImage", url: "https://example.com/cat.jpg" },
+      { kind: "selectImage", url: "https://example.com/dog.jpg" },
+    ]);
+  });
+
+  test("respects default lookahead of 3 steps", () => {
+    const state = buildState({
+      steps: [
+        buildStep({ id: "s1" }),
+        buildStep({
+          content: { kind: "image", prompt: "One", url: "https://example.com/1.jpg" },
+          id: "s2",
+          kind: "visual",
+          position: 1,
+        }),
+        buildStep({
+          content: { kind: "image", prompt: "Two", url: "https://example.com/2.jpg" },
+          id: "s3",
+          kind: "visual",
+          position: 2,
+        }),
+        buildStep({
+          content: { kind: "image", prompt: "Three", url: "https://example.com/3.jpg" },
+          id: "s4",
+          kind: "visual",
+          position: 3,
+        }),
+        buildStep({
+          content: { kind: "image", prompt: "Four", url: "https://example.com/4.jpg" },
+          id: "s5",
+          kind: "visual",
+          position: 4,
+        }),
+      ],
+    });
+
+    const result = getUpcomingImages(state);
+    expect(result).toHaveLength(3);
+    expect(result).toEqual([
+      { kind: "visual", url: "https://example.com/1.jpg" },
+      { kind: "visual", url: "https://example.com/2.jpg" },
+      { kind: "visual", url: "https://example.com/3.jpg" },
+    ]);
+  });
+
+  test("only looks ahead from current step, not behind", () => {
+    const state = buildState({
+      currentStepIndex: 2,
+      steps: [
+        buildStep({
+          content: { kind: "image", prompt: "Behind", url: "https://example.com/behind.jpg" },
+          id: "s1",
+          kind: "visual",
+        }),
+        buildStep({
+          content: {
+            kind: "image",
+            prompt: "Also behind",
+            url: "https://example.com/also-behind.jpg",
+          },
+          id: "s2",
+          kind: "visual",
+          position: 1,
+        }),
+        buildStep({ id: "s3", position: 2 }),
+        buildStep({
+          content: { kind: "image", prompt: "Ahead", url: "https://example.com/ahead.jpg" },
+          id: "s4",
+          kind: "visual",
+          position: 3,
+        }),
+      ],
+    });
+
+    expect(getUpcomingImages(state)).toEqual([
+      { kind: "visual", url: "https://example.com/ahead.jpg" },
+    ]);
+  });
+
+  test("skips visual steps that are not image kind", () => {
+    const state = buildState({
+      steps: [
+        buildStep({ id: "s1" }),
+        buildStep({
+          content: { code: "console.log('hi')", kind: "code", language: "javascript" },
+          id: "s2",
+          kind: "visual",
+          position: 1,
+        }),
+        buildStep({
+          content: { author: "Author", kind: "quote", text: "Quote" },
+          id: "s3",
+          kind: "visual",
+          position: 2,
+        }),
+      ],
+    });
+
+    expect(getUpcomingImages(state)).toEqual([]);
+  });
+
+  test("skips steps with missing or undefined URLs", () => {
+    const state = buildState({
+      steps: [
+        buildStep({ id: "s1" }),
+        buildStep({
+          content: { kind: "image", prompt: "No URL" },
+          id: "s2",
+          kind: "visual",
+          position: 1,
+        }),
+        buildStep({
+          content: {
+            options: [
+              { feedback: "Yes", isCorrect: true, prompt: "No URL" },
+              {
+                feedback: "No",
+                isCorrect: false,
+                prompt: "Has URL",
+                url: "https://example.com/img.jpg",
+              },
+            ],
+            question: "Pick one",
+          },
+          id: "s3",
+          kind: "selectImage",
+          position: 2,
+        }),
+      ],
+    });
+
+    expect(getUpcomingImages(state)).toEqual([
+      { kind: "selectImage", url: "https://example.com/img.jpg" },
+    ]);
+  });
+
+  test("handles end-of-list with fewer than 3 steps remaining", () => {
+    const state = buildState({
+      currentStepIndex: 3,
+      steps: [
+        buildStep({ id: "s1" }),
+        buildStep({ id: "s2", position: 1 }),
+        buildStep({ id: "s3", position: 2 }),
+        buildStep({ id: "s4", position: 3 }),
+        buildStep({
+          content: { kind: "image", prompt: "Last", url: "https://example.com/last.jpg" },
+          id: "s5",
+          kind: "visual",
+          position: 4,
+        }),
+      ],
+    });
+
+    expect(getUpcomingImages(state)).toEqual([
+      { kind: "visual", url: "https://example.com/last.jpg" },
+    ]);
+  });
+});

--- a/packages/player/src/player-selectors.ts
+++ b/packages/player/src/player-selectors.ts
@@ -1,6 +1,8 @@
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { type CompletionResult } from "./completion-input-schema";
 import { hasNegativeDimension } from "./dimensions";
 import { type PlayerState } from "./player-reducer";
+import { type SerializedStep } from "./prepare-activity-data";
 import { canNavigatePrev, isStaticNavigationStep } from "./step-navigation";
 
 function computeProgress(currentIndex: number, total: number): number {
@@ -83,4 +85,52 @@ export function getSelectedAnswer(state: PlayerState) {
   }
 
   return state.selectedAnswers[currentStep.id];
+}
+
+export type PreloadableImage = {
+  kind: "selectImage" | "visual";
+  url: string;
+};
+
+const DEFAULT_LOOKAHEAD = 3;
+
+/**
+ * Extracts image URLs from a step so they can be preloaded before the user
+ * navigates to it. Visual image steps have a single URL; selectImage steps
+ * have one URL per option.
+ */
+function getStepImages(step: SerializedStep): PreloadableImage[] {
+  if (step.kind === "visual") {
+    const content = parseStepContent("visual", step.content);
+
+    if (content.kind !== "image" || !content.url) {
+      return [];
+    }
+
+    return [{ kind: "visual", url: content.url }];
+  }
+
+  if (step.kind === "selectImage") {
+    const content = parseStepContent("selectImage", step.content);
+
+    return content.options.flatMap((option) =>
+      option.url ? [{ kind: "selectImage" as const, url: option.url }] : [],
+    );
+  }
+
+  return [];
+}
+
+/**
+ * Collects image URLs from the next few steps so they can be preloaded in the
+ * background. This eliminates the 1-2 second delay users experience when
+ * navigating to steps that contain images.
+ */
+export function getUpcomingImages(
+  state: PlayerState,
+  lookahead = DEFAULT_LOOKAHEAD,
+): PreloadableImage[] {
+  const start = state.currentStepIndex + 1;
+  const upcoming = state.steps.slice(start, start + lookahead);
+  return upcoming.flatMap((step) => getStepImages(step));
 }


### PR DESCRIPTION
## Summary

- Preload images for the next 3 steps using hidden Next.js `<Image>` components inside React's `<Activity mode="hidden">`
- Extract shared image dimension constants so the preloader and rendering components use the same props (guaranteeing a browser cache hit)
- Add `getUpcomingImages` selector to extract image URLs from upcoming visual and selectImage steps

## Test plan

- [ ] Open the player on an activity with image steps
- [ ] Check the Network tab — optimized image URLs should appear before navigating to the image step
- [ ] Navigate to the image step — image should appear instantly (no 1-2s delay)
- [ ] Verify selectImage steps also preload all option images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preloads images for the next 3 steps so image steps render instantly, removing the 1–2s delay. Uses hidden `next/image` within React `Activity` and shared dimensions to guarantee cache hits.

- **New Features**
  - Added `StepImagePreloader` to render hidden, eager `next/image` for upcoming steps (lookahead: 3), integrated in `PlayerShell`.
  - Added `getUpcomingImages` selector to collect image URLs from `visual` (image) and `selectImage` steps.

- **Refactors**
  - Extracted shared image sizing in `image-config.ts`, used by preloader and step components to produce identical `/_next/image` URLs.
  - Updated `select-image-step` and `image-visual` to use shared props.

<sup>Written for commit d90064af52faa2284a58478614bb68495832a409. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

