### PR TITLE
fix(core): handle AbortError in username availability check

### DIFF
--- a/packages/core/src/auth/hooks/use-username-availability.ts
+++ b/packages/core/src/auth/hooks/use-username-availability.ts
@@ -45,23 +45,28 @@ export function useUsernameAvailability(currentUsername?: string | null) {
 
       setStatus("checking");
 
-      const { data, error } = await authClient.isUsernameAvailable({
-        fetchOptions: { signal: controller.signal },
-        username: value,
-      });
+      try {
+        const { data, error } = await authClient.isUsernameAvailable({
+          fetchOptions: { signal: controller.signal },
+          username: value,
+        });
 
-      // Check abort before error — an aborted request surfaces as
-      // an error, and we don't want to show "taken" for a cancelled check.
-      if (controller.signal.aborted) {
-        return;
+        if (error) {
+          setStatus("taken");
+          return;
+        }
+
+        setStatus(data?.available ? "available" : "taken");
+      } catch {
+        // When abort() is called, better-fetch throws an AbortError
+        // instead of returning { error }. Silently ignore it — the
+        // newer request will handle the result.
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setStatus("idle");
       }
-
-      if (error) {
-        setStatus("taken");
-        return;
-      }
-
-      setStatus(data?.available ? "available" : "taken");
     },
     [currentUsername],
   );


### PR DESCRIPTION
## Summary
- Wrap `authClient.isUsernameAvailable()` in a try-catch to handle `AbortError` thrown by `better-fetch` when a request is aborted
- When the user types quickly in the username field, each keystroke aborts the previous availability check — `better-fetch` throws instead of returning `{ error }`, causing an unhandled rejection reported by Sentry
- Fall back to `idle` status for unexpected errors instead of misleadingly showing `taken`

## Test plan
- [x] `pnpm turbo quality:fix` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 576 passed
- [x] `pnpm --filter main e2e` — 424 passed
- [x] `pnpm --filter editor e2e` — 193 passed (1 pre-existing locale-switcher failure)
- [x] `pnpm --filter api e2e` — 56 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle `AbortError` from `better-fetch` in the username availability check to prevent false “taken” states and unhandled rejections when users type quickly. Aborted requests are ignored; unexpected errors now reset the status to idle.

- **Bug Fixes**
  - Wrap `authClient.isUsernameAvailable()` in try/catch and ignore aborts via the request signal.
  - Set status only from real responses; on non-abort errors, fall back to idle to reduce Sentry noise.

<sup>Written for commit ddfe5f3b71d45befdfdd9b0503741eec2497bf47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

