### PR TITLE
feat(ai): add formula visual type and improve visual prompts

### DIFF
--- a/apps/main/e2e/step-visual-content.test.ts
+++ b/apps/main/e2e/step-visual-content.test.ts
@@ -979,4 +979,72 @@ test.describe("Visual Step Content", () => {
 
     await expect(page.getByRole("note")).toContainText(annotationText);
   });
+
+  test("visual step renders formula description and math content", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const description = `Pythagorean theorem ${uniqueId}`;
+    const { url } = await createVisualActivity({
+      steps: [
+        {
+          content: {
+            description,
+            formula: "a^2 + b^2 = c^2",
+            kind: "formula",
+          },
+          kind: "visual",
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(async () => {
+      await expect(page.getByRole("figure", { name: description })).toBeVisible();
+    }).toPass();
+
+    await expect(page.getByText(description)).toBeVisible();
+  });
+
+  test("clicking on a visual step with formula navigates to next step", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const description = `Formula description ${uniqueId}`;
+    const { url } = await createVisualActivity({
+      steps: [
+        {
+          content: {
+            description,
+            formula: "E = mc^2",
+            kind: "formula",
+          },
+          kind: "visual",
+          position: 0,
+        },
+        {
+          content: {
+            text: `Next step body ${uniqueId}`,
+            title: `Formula Next ${uniqueId}`,
+            variant: "text",
+          },
+          position: 1,
+        },
+      ],
+    });
+
+    await page.goto(url);
+
+    await expect(async () => {
+      await expect(page.getByRole("figure", { name: description })).toBeVisible();
+    }).toPass();
+
+    await expect(page.getByText(/1 \/ 2/)).toBeVisible();
+
+    await page.waitForLoadState("networkidle");
+    await page.keyboard.press("ArrowRight");
+
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Formula Next ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(page.getByText(/2 \/ 2/)).toBeVisible();
+  });
 });

--- a/packages/ai/src/tasks/steps/_tools/chart.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/chart.prompt.md
@@ -7,11 +7,7 @@ Use when: The step discusses **real numerical data** — actual statistics, meas
 - **Never invent data.** If the step describes a concept qualitatively (e.g., "rehashing reduces conflicts") but gives no specific numbers, do NOT fabricate values to fill a chart. Use a table or diagram instead.
 - **Never use charts for conceptual comparisons.** "Before vs. after", "fast vs. slow", "good vs. bad" — these are qualitative and belong in a **table** (for structured comparison) or a **diagram** (for showing relationships).
 - **Never use charts when the numbers have no units or meaning.** Every value in a chart must represent something concrete that the reader can interpret (e.g., "milliseconds", "% of capacity", "number of probes"). If you can't explain what the y-axis measures, don't use a chart.
-- **Never chart a tautology.** If the data points simply restate the axis labels in a different format, the chart adds no information. Use a table instead. Common tautologies to avoid:
-  - Plotting y=x to show "linear growth" (e.g., n=1→1, n=2→2, n=3→3 — this is just the identity function)
-  - Plotting a unit conversion (e.g., "200% = 2x factor")
-  - Plotting input size vs. input size with a different label
-  - If every y-value equals its x-value or a trivial multiple of it, it's a tautology
+- **Never chart a trivially obvious relationship.** Before creating a chart, ask: "Could the reader derive every data point in their head instantly?" If yes, the chart adds no insight — use a table or just leave it in the text. A chart should reveal a pattern, trend, or comparison that is **not immediately obvious** from the prose alone.
 
 ## When to use charts
 

--- a/packages/ai/src/tasks/steps/_tools/chart.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/chart.prompt.md
@@ -1,12 +1,26 @@
 Create a data visualization chart.
 
-Use when: The step discusses statistics, comparisons, trends over time, distributions, or any content where numerical data tells the story.
+Use when: The step discusses **real numerical data** — actual statistics, measurements, well-known mathematical relationships, or values derived from established formulas.
 
-Requirements:
+## When NOT to use charts
+
+- **Never invent data.** If the step describes a concept qualitatively (e.g., "rehashing reduces conflicts") but gives no specific numbers, do NOT fabricate values to fill a chart. Use a table or diagram instead.
+- **Never use charts for conceptual comparisons.** "Before vs. after", "fast vs. slow", "good vs. bad" — these are qualitative and belong in a **table** (for structured comparison) or a **diagram** (for showing relationships).
+- **Never use charts when the numbers have no units or meaning.** Every value in a chart must represent something concrete that the reader can interpret (e.g., "milliseconds", "% of capacity", "number of probes"). If you can't explain what the y-axis measures, don't use a chart.
+
+## When to use charts
+
+- The step mentions specific numbers, percentages, or measurements
+- The data comes from a well-known formula or mathematical relationship (e.g., expected probes vs. load factor in hash tables: `1/(1-α)`)
+- The step references real-world statistics or benchmarks
+- The trend or distribution is the main teaching point, not just a side illustration
+
+## Requirements
 
 - Choose chart type based on the data:
-  - bar: comparing categories
-  - line: showing trends over time or continuous data
+  - bar: comparing categories with concrete values
+  - line: showing trends where the x-axis is a continuous or ordered numeric dimension (time, load percentage, input size) — NOT arbitrary categories
   - pie: showing proportions of a whole (parts must sum to 100%)
 - Title max 50 chars
-- Data should be realistic and support the educational content
+- 4-8 data points for optimal clarity
+- Every data point must be grounded in real or mathematically derived values — never arbitrary

--- a/packages/ai/src/tasks/steps/_tools/chart.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/chart.prompt.md
@@ -7,6 +7,7 @@ Use when: The step discusses **real numerical data** — actual statistics, meas
 - **Never invent data.** If the step describes a concept qualitatively (e.g., "rehashing reduces conflicts") but gives no specific numbers, do NOT fabricate values to fill a chart. Use a table or diagram instead.
 - **Never use charts for conceptual comparisons.** "Before vs. after", "fast vs. slow", "good vs. bad" — these are qualitative and belong in a **table** (for structured comparison) or a **diagram** (for showing relationships).
 - **Never use charts when the numbers have no units or meaning.** Every value in a chart must represent something concrete that the reader can interpret (e.g., "milliseconds", "% of capacity", "number of probes"). If you can't explain what the y-axis measures, don't use a chart.
+- **Never chart a tautology.** If the data points simply restate the axis labels in a different format (e.g., plotting "200% enlargement = 2x factor"), the chart adds no information. Use a table instead.
 
 ## When to use charts
 

--- a/packages/ai/src/tasks/steps/_tools/chart.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/chart.prompt.md
@@ -7,7 +7,11 @@ Use when: The step discusses **real numerical data** — actual statistics, meas
 - **Never invent data.** If the step describes a concept qualitatively (e.g., "rehashing reduces conflicts") but gives no specific numbers, do NOT fabricate values to fill a chart. Use a table or diagram instead.
 - **Never use charts for conceptual comparisons.** "Before vs. after", "fast vs. slow", "good vs. bad" — these are qualitative and belong in a **table** (for structured comparison) or a **diagram** (for showing relationships).
 - **Never use charts when the numbers have no units or meaning.** Every value in a chart must represent something concrete that the reader can interpret (e.g., "milliseconds", "% of capacity", "number of probes"). If you can't explain what the y-axis measures, don't use a chart.
-- **Never chart a tautology.** If the data points simply restate the axis labels in a different format (e.g., plotting "200% enlargement = 2x factor"), the chart adds no information. Use a table instead.
+- **Never chart a tautology.** If the data points simply restate the axis labels in a different format, the chart adds no information. Use a table instead. Common tautologies to avoid:
+  - Plotting y=x to show "linear growth" (e.g., n=1→1, n=2→2, n=3→3 — this is just the identity function)
+  - Plotting a unit conversion (e.g., "200% = 2x factor")
+  - Plotting input size vs. input size with a different label
+  - If every y-value equals its x-value or a trivial multiple of it, it's a tautology
 
 ## When to use charts
 

--- a/packages/ai/src/tasks/steps/_tools/code.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/code.prompt.md
@@ -6,6 +6,7 @@ Use when: The step's content describes something that can be concretely demonstr
 
 - **The step talks ABOUT programming conceptually** but doesn't describe specific operations, syntax, or logic. For example, "data structures affect performance" is conceptual — use a table or diagram. But "a hash table resolves collisions by probing the next slot" can be shown in code.
 - **The step is about a non-programming topic.** Design principles, biology, history, etc. should never have code visuals, even if you could technically write a metaphorical program about them.
+- **Never use code for mathematical notation.** If the content is a mathematical expression (derivatives, integrals, equations like `dy/dx`), use the **formula** visual instead. Code visuals are for executable programs, not for displaying math in a monospace font.
 
 ## When to use code
 

--- a/packages/ai/src/tasks/steps/_tools/code.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/code.prompt.md
@@ -10,7 +10,7 @@ Use when: The step's content describes something that can be concretely demonstr
 ## When to use code
 
 - The step explains an algorithm or procedure that has concrete steps (sorting, searching, hashing, traversal)
-- The step describes a data structure operation (insert, delete, lookup) and showing the code makes the mechanics clear
+- The step describes a data structure operation (insert, delete, lookup, push, pop, enqueue, dequeue) and showing the code makes the mechanics clear — **prefer code over a diagram** for these, the concrete implementation is more educational than abstract boxes
 - The step discusses syntax, APIs, or language features
 - The step describes logic (conditionals, loops, recursion) where seeing the code is more precise than prose
 

--- a/packages/ai/src/tasks/steps/_tools/code.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/code.prompt.md
@@ -1,8 +1,20 @@
 Create a code snippet visual with optional line annotations.
 
-Use when: The step explains programming concepts, algorithms, syntax, APIs, or any technical content where code examples clarify understanding.
+Use when: The step's content describes something that can be concretely demonstrated with code — algorithms, data structure operations, syntax, APIs, or logic that becomes clearer when you see it running.
 
-Requirements:
+## When NOT to use code
+
+- **The step talks ABOUT programming conceptually** but doesn't describe specific operations, syntax, or logic. For example, "data structures affect performance" is conceptual — use a table or diagram. But "a hash table resolves collisions by probing the next slot" can be shown in code.
+- **The step is about a non-programming topic.** Design principles, biology, history, etc. should never have code visuals, even if you could technically write a metaphorical program about them.
+
+## When to use code
+
+- The step explains an algorithm or procedure that has concrete steps (sorting, searching, hashing, traversal)
+- The step describes a data structure operation (insert, delete, lookup) and showing the code makes the mechanics clear
+- The step discusses syntax, APIs, or language features
+- The step describes logic (conditionals, loops, recursion) where seeing the code is more precise than prose
+
+## Requirements
 
 - Specify the programming language (python, javascript, typescript, etc.)
 - Code should be concise (max 500 chars) and demonstrate the concept clearly

--- a/packages/ai/src/tasks/steps/_tools/diagram.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/diagram.prompt.md
@@ -15,6 +15,8 @@ Use when: The step explains how components connect, system architecture, process
 - The structure itself is the concept (e.g., tree hierarchies, graph connections, system architecture)
 - Multiple components interact in ways that are hard to follow linearly in text
 
+**Note:** If the step describes a concrete data structure operation (push, pop, enqueue, dequeue, insert, delete) and the lesson is about programming, prefer a **code** snippet over a diagram — the concrete implementation is more educational than abstract boxes.
+
 ## Requirements
 
 - Nodes represent concepts, components, or entities (max 30 chars each)

--- a/packages/ai/src/tasks/steps/_tools/diagram.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/diagram.prompt.md
@@ -1,8 +1,21 @@
 Create a diagram visual showing relationships between concepts.
 
-Use when: The step explains how components connect, system architecture, process flows, hierarchies, or any content where relationships between entities matter.
+Use when: The step explains how components connect, system architecture, process flows, hierarchies, or any content where the **structure of relationships** is the teaching point.
 
-Requirements:
+## When NOT to use diagrams
+
+- **Never restate the text as boxes with arrows.** A diagram must reveal structure that is hard to see from reading alone. If the step says "A leads to B leads to C", turning that into three boxes with arrows adds nothing.
+- **Never use diagrams for simple lists.** If the content is "X involves A, B, C, and D" (a list of items without meaningful relationships between them), use a **table** instead.
+- **Never use diagrams for abstract platitudes.** Nodes like "Performance", "Simplicity", "Importance" connected by generic verbs like "leads to", "includes", "favors" don't help the reader understand anything new. If you can't describe a concrete, non-obvious relationship, use a different visual type.
+
+## When to use diagrams
+
+- The step describes a process with branching, cycles, or feedback loops
+- There are concrete dependencies or causal chains (e.g., "removing this slot breaks the probing chain for items after it")
+- The structure itself is the concept (e.g., tree hierarchies, graph connections, system architecture)
+- Multiple components interact in ways that are hard to follow linearly in text
+
+## Requirements
 
 - Nodes represent concepts, components, or entities (max 30 chars each)
 - Edges show connections with optional labels

--- a/packages/ai/src/tasks/steps/_tools/formula.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/formula.prompt.md
@@ -4,6 +4,8 @@ Use when: The step introduces or explains a **specific formula, equation, or for
 
 ## When NOT to use formula
 
+- **Never use for single values or simple numbers.** "109.5°" or "60°" alone is not a formula — it's just a number that belongs in the text. A formula must contain an actual mathematical expression with operators, variables, or notation that benefits from LaTeX rendering (fractions, subscripts, summations, etc.).
+- **Never use for simple comparisons.** "90° < 109.5°" is a trivial inequality that adds nothing over plain text. Use formula only when the expression has structure that LaTeX makes clearer than prose.
 - **The step discusses a concept without a specific formula.** If the step talks about math or science qualitatively (e.g., "calculus helps us find rates of change") without referencing a concrete equation, use a different visual type.
 - **The step is about code or algorithms.** Even if the step involves a mathematical operation, if the focus is on implementation, use the code visual instead.
 - **The step is about data or statistics.** If the focus is on numerical results or comparisons, use a chart or table.

--- a/packages/ai/src/tasks/steps/_tools/formula.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/formula.prompt.md
@@ -1,0 +1,23 @@
+Create a formula visual using LaTeX notation.
+
+Use when: The step introduces or explains a **specific formula, equation, or formal expression** from any field — math, physics, chemistry, biology, economics, engineering, etc.
+
+## When NOT to use formula
+
+- **The step discusses a concept without a specific formula.** If the step talks about math or science qualitatively (e.g., "calculus helps us find rates of change") without referencing a concrete equation, use a different visual type.
+- **The step is about code or algorithms.** Even if the step involves a mathematical operation, if the focus is on implementation, use the code visual instead.
+- **The step is about data or statistics.** If the focus is on numerical results or comparisons, use a chart or table.
+
+## When to use formula
+
+- The step introduces a named equation (e.g., quadratic formula, Euler's identity, Newton's second law, ideal gas law, Hardy-Weinberg equilibrium)
+- The step derives or transforms a mathematical expression and the formula is the main teaching point
+- The concept becomes significantly clearer when the reader sees formal notation (fractions, subscripts, integrals, Greek letters, chemical notation)
+- The step references a well-known relationship that has a standard formal representation
+
+## Requirements
+
+- Use valid LaTeX syntax
+- Description should explain what the formula represents in plain language (max 100 chars)
+- Keep formulas focused — one main equation, not a full derivation
+- For multi-line equations, use LaTeX `aligned` or `cases` environments

--- a/packages/ai/src/tasks/steps/_tools/formula.ts
+++ b/packages/ai/src/tasks/steps/_tools/formula.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const formulaInputSchema = z.object({
+  description: z.string().describe("Brief plain-text explanation of the formula (max 100 chars)"),
+  formula: z.string().describe("LaTeX math expression"),
+  stepIndex: z.number().describe("The step index (0-based) this visual is for"),
+});

--- a/packages/ai/src/tasks/steps/_tools/image.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/image.prompt.md
@@ -12,4 +12,5 @@ Requirements:
 - Avoid text by default. Only include text when it is necessary to make the image clearer
 - If text is necessary, keep it minimal and spell it exactly in the requested language, with correct accents and other diacritics
 - Write the prompt in the same language specified in the LANGUAGE field
+- **Vary your metaphors.** Don't repeat the same analogy across multiple steps in a lesson (e.g., don't show "people in a line" for 5 different queue steps). Each image should use a distinct visual metaphor or show a different aspect of the concept
 - NEVER reference copyrighted or trademarked characters (e.g., Mickey Mouse, Spider-Man, Mario, Pikachu). If the topic involves such characters, describe the concept abstractly or use generic, original characters instead

--- a/packages/ai/src/tasks/steps/_tools/quote.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/quote.prompt.md
@@ -2,9 +2,15 @@ Create a quote visual with attribution.
 
 Use when: The step references a famous definition, principle stated by an authority, memorable phrase that captures the concept, or foundational text.
 
-Requirements:
+## When NOT to use quote
+
+- **Never invent quotes or attribute them to fake sources.** The quote must be a real statement by a real, named person. Attributions like "Lesson summary", "Common saying", "Traditional wisdom", or any non-specific source are NOT valid.
+- **Never paraphrase and attribute.** If you can't find an exact, verifiable quote that fits, use a different visual type instead.
+
+## Requirements
 
 - Quote should be accurate and properly attributed
+- Author must be a real, identifiable person (e.g., "Alan Turing, 1950", "Marie Curie") — never a generic source
 - Author format: "Name, Year" or just "Name"
 - Quote max 500 chars
 - Only use real, verifiable quotes from recognized sources

--- a/packages/ai/src/tasks/steps/_tools/table.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/table.prompt.md
@@ -1,8 +1,15 @@
 Create a table visual for structured comparisons.
 
-Use when: The step compares multiple items across the same attributes, presents reference data, or shows structured information that benefits from rows and columns.
+Use when: The step compares items, lists examples with attributes, presents reference data, or explains conceptual differences. Tables are one of the most versatile and effective visual types — prefer them over diagrams for comparisons and over charts for qualitative data.
 
-Requirements:
+## Prefer tables over other types when
+
+- The step compares "before vs. after", "approach A vs. approach B", or similar conceptual contrasts — use a table, not a chart (no fabricated numbers) or a diagram (no generic arrows)
+- The step lists concrete examples of a concept (e.g., "caches, indexes, session tables") — a table with columns like "Example", "Why it applies", "What happens" is more informative than a diagram with boxes
+- The step explains differences between related concepts — a table makes the contrast explicit and scannable
+- The content has 2+ attributes per item — tables excel at multi-dimensional comparisons
+
+## Requirements
 
 - Column headers should be clear and concise
 - Caption is optional but helpful for context

--- a/packages/ai/src/tasks/steps/_tools/visual.ts
+++ b/packages/ai/src/tasks/steps/_tools/visual.ts
@@ -6,6 +6,8 @@ import { codeInputSchema } from "./code";
 import codePrompt from "./code.prompt.md";
 import { diagramInputSchema } from "./diagram";
 import diagramPrompt from "./diagram.prompt.md";
+import { formulaInputSchema } from "./formula";
+import formulaPrompt from "./formula.prompt.md";
 import { imageInputSchema } from "./image";
 import imagePrompt from "./image.prompt.md";
 import { quoteInputSchema } from "./quote";
@@ -27,6 +29,10 @@ export const visualTools = {
   diagram: tool({
     description: diagramPrompt,
     inputSchema: diagramInputSchema,
+  }),
+  formula: tool({
+    description: formulaPrompt,
+    inputSchema: formulaInputSchema,
   }),
   image: tool({
     description: imagePrompt,
@@ -58,6 +64,10 @@ export type DiagramVisual = {
   kind: "diagram";
 } & z.infer<typeof diagramInputSchema>;
 
+export type FormulaVisual = {
+  kind: "formula";
+} & z.infer<typeof formulaInputSchema>;
+
 export type ImageVisual = {
   kind: "image";
 } & z.infer<typeof imageInputSchema>;
@@ -78,6 +88,7 @@ export type StepVisualResource =
   | ChartVisual
   | CodeVisual
   | DiagramVisual
+  | FormulaVisual
   | ImageVisual
   | QuoteVisual
   | TableVisual

--- a/packages/ai/src/tasks/steps/step-visual.prompt.md
+++ b/packages/ai/src/tasks/steps/step-visual.prompt.md
@@ -17,23 +17,24 @@ Generate ONE appropriate visual resource for EACH step provided. Each visual sho
 
 Choose the visual type that BEST fits each step's content:
 
-| Visual Type  | When to Use                                                             |
-| ------------ | ----------------------------------------------------------------------- |
-| **timeline** | Historical progression, evolution of concepts, sequence of discoveries  |
-| **diagram**  | System relationships, process flows, component connections, hierarchies |
-| **quote**    | Famous definitions, authoritative statements, foundational principles   |
-| **code**     | Programming concepts, algorithms, syntax examples, API usage            |
-| **chart**    | Statistics, comparisons, trends, numerical distributions                |
-| **table**    | Structured comparisons, reference data, multi-attribute comparisons     |
-| **image**    | DEFAULT fallback when no other type fits the content                    |
+| Visual Type  | When to Use                                                                                |
+| ------------ | ------------------------------------------------------------------------------------------ |
+| **timeline** | Historical progression, evolution of concepts, sequence of discoveries                     |
+| **diagram**  | Concrete structural relationships: processes, dependencies, cycles, hierarchies            |
+| **quote**    | Famous definitions, authoritative statements, foundational principles                      |
+| **code**     | Algorithms, data structure operations, syntax, APIs — only for programming content         |
+| **chart**    | Real statistics, measured data, or values from known formulas — NEVER fabricated numbers   |
+| **table**    | Comparisons, examples with attributes, conceptual contrasts — prefer over generic diagrams |
+| **image**    | DEFAULT fallback when no other type fits the content                                       |
 
 # Rules
 
 1. **One visual per step**: Generate exactly one visual for each step using the stepIndex field. This is mandatory
-2. **Language consistency**: If a visual includes text, every word must match the specified language
-3. **Content accuracy**: Visuals must accurately represent the educational content
-4. **Appropriate selection**: Choose the visual type that genuinely enhances understanding
-5. **Default to image**: When no specialized type fits, use the image tool with a descriptive prompt
+2. **Every visual must add something the text alone cannot easily convey.** Don't restate the text in a different format. A diagram that just puts the same words into boxes, a chart with made-up numbers, or an image that vaguely illustrates the topic is not helpful. Ask: "Would the reader learn something new or see the concept more clearly from this visual?" If not, choose a different visual type that can genuinely add value.
+3. **Language consistency**: If a visual includes text, every word must match the specified language
+4. **Content accuracy**: Visuals must accurately represent the educational content
+5. **Appropriate selection**: Choose the visual type that genuinely enhances understanding
+6. **Default to image**: When no specialized type fits, use the image tool with a descriptive prompt
 
 # Visual Type Guidelines
 
@@ -45,7 +46,8 @@ Choose the visual type that BEST fits each step's content:
 
 ## Diagram
 
-- Use for showing relationships and connections
+- Use for showing **concrete structural relationships** — processes with branching, dependencies, cycles, hierarchies
+- **Don't restate the text as boxes with generic arrows.** If the diagram just mirrors what the text says with nodes like "Concept" → "leads to" → "Result", it adds no value. Use a table instead.
 - Keep focused: 3-7 nodes maximum for clarity
 - Use meaningful node labels (max 30 chars)
 - Do NOT specify positions - layout is computed automatically
@@ -58,19 +60,26 @@ Choose the visual type that BEST fits each step's content:
 
 ## Code
 
+- Use when the step describes something that can be **concretely demonstrated** in code — algorithms, data structure operations, syntax, APIs, logic
+- **Only for programming content.** Don't use code for non-programming topics (design, biology, history, etc.) even as a metaphor
 - Code must be syntactically correct
 - Use annotations to highlight key concepts
 - Keep snippets concise and focused
 
 ## Chart
 
+- **Only use when the step contains or implies real numerical data** — actual measurements, known formulas, or established relationships
+- **Never fabricate data.** If the step explains a concept qualitatively without specific numbers, use a table (for comparisons) or diagram (for relationships) instead
 - Choose chart type based on data nature (bar/line/pie)
+- For line charts, the x-axis must be a continuous or ordered numeric dimension (time, load %, input size) — not arbitrary categories like "Before"/"After"
 - 4-8 data points for optimal clarity
-- Data should be realistic and educational
+- Every value must have a concrete meaning the reader can interpret
 
 ## Table
 
-- Use when comparing items across attributes
+- **Prefer tables for comparisons and structured examples** — they are one of the most effective visual types
+- Use for: conceptual contrasts (before/after, approach A vs. B), lists of examples with attributes, reference data, differences between related concepts
+- When in doubt between a diagram and a table, choose the table — it's more scannable and doesn't risk restating the text as generic boxes
 - Keep columns to 2-5 for readability
 - Headers should be clear and concise
 

--- a/packages/ai/src/tasks/steps/step-visual.prompt.md
+++ b/packages/ai/src/tasks/steps/step-visual.prompt.md
@@ -23,6 +23,7 @@ Choose the visual type that BEST fits each step's content:
 | **diagram**  | Concrete structural relationships: processes, dependencies, cycles, hierarchies            |
 | **quote**    | Famous definitions, authoritative statements, foundational principles                      |
 | **code**     | Algorithms, data structure operations, syntax, APIs — only for programming content         |
+| **formula**  | Specific equations, formulas, or formal expressions from any field (math, physics, etc.)   |
 | **chart**    | Real statistics, measured data, or values from known formulas — NEVER fabricated numbers   |
 | **table**    | Comparisons, examples with attributes, conceptual contrasts — prefer over generic diagrams |
 | **image**    | DEFAULT fallback when no other type fits the content                                       |
@@ -48,6 +49,7 @@ Choose the visual type that BEST fits each step's content:
 
 - Use for showing **concrete structural relationships** — processes with branching, dependencies, cycles, hierarchies
 - **Don't restate the text as boxes with generic arrows.** If the diagram just mirrors what the text says with nodes like "Concept" → "leads to" → "Result", it adds no value. Use a table instead.
+- **Prefer code over diagrams for programming operations.** If the step describes a concrete data structure operation (push, pop, enqueue, dequeue, insert, delete) and the lesson is about programming, a code snippet is more educational than an abstract diagram.
 - Keep focused: 3-7 nodes maximum for clarity
 - Use meaningful node labels (max 30 chars)
 - Do NOT specify positions - layout is computed automatically
@@ -65,6 +67,14 @@ Choose the visual type that BEST fits each step's content:
 - Code must be syntactically correct
 - Use annotations to highlight key concepts
 - Keep snippets concise and focused
+
+## Formula
+
+- Use when the step introduces or explains a **specific equation or formal expression** — from any field (math, physics, chemistry, biology, economics, etc.)
+- Not for code or algorithms (use code visual), not for qualitative discussions without a concrete formula
+- Use valid LaTeX syntax
+- Description should explain what the formula represents in plain language
+- One main equation per visual; use LaTeX `aligned` or `cases` environments for multi-line expressions
 
 ## Chart
 

--- a/packages/core/src/steps/visual-content-contract.test.ts
+++ b/packages/core/src/steps/visual-content-contract.test.ts
@@ -82,6 +82,20 @@ describe("visual content contracts", () => {
     });
   });
 
+  test("parses formula visual content", () => {
+    const content = visualStepContentSchema.parse({
+      description: "Euler's identity",
+      formula: "e^{i\\pi} + 1 = 0",
+      kind: "formula",
+    });
+
+    expect(content).toEqual({
+      description: "Euler's identity",
+      formula: "e^{i\\pi} + 1 = 0",
+      kind: "formula",
+    });
+  });
+
   test("parses image visual content without url", () => {
     const content = visualStepContentSchema.parse({
       kind: "image",
@@ -187,5 +201,7 @@ describe("visual content contracts", () => {
     expect(() => visualStepContentSchema.parse({ code: "x", kind: "code" })).toThrow();
     expect(() => visualStepContentSchema.parse({ chartType: "bar", kind: "chart" })).toThrow();
     expect(() => visualStepContentSchema.parse({ kind: "quote", text: "hi" })).toThrow();
+    expect(() => visualStepContentSchema.parse({ formula: "x^2", kind: "formula" })).toThrow();
+    expect(() => visualStepContentSchema.parse({ description: "desc", kind: "formula" })).toThrow();
   });
 });

--- a/packages/core/src/steps/visual-content-contract.ts
+++ b/packages/core/src/steps/visual-content-contract.ts
@@ -52,6 +52,13 @@ export const diagramVisualContentSchema = z
   })
   .strict();
 
+export const formulaVisualContentSchema = z
+  .object({
+    description: z.string(),
+    formula: z.string(),
+  })
+  .strict();
+
 export const imageVisualContentSchema = z
   .object({
     prompt: z.string(),
@@ -91,6 +98,7 @@ export const timelineVisualContentSchema = z
 const chartVisualStepSchema = chartVisualContentSchema.extend({ kind: z.literal("chart") });
 const codeVisualStepSchema = codeVisualContentSchema.extend({ kind: z.literal("code") });
 const diagramVisualStepSchema = diagramVisualContentSchema.extend({ kind: z.literal("diagram") });
+const formulaVisualStepSchema = formulaVisualContentSchema.extend({ kind: z.literal("formula") });
 const imageVisualStepSchema = imageVisualContentSchema.extend({ kind: z.literal("image") });
 const quoteVisualStepSchema = quoteVisualContentSchema.extend({ kind: z.literal("quote") });
 const tableVisualStepSchema = tableVisualContentSchema.extend({ kind: z.literal("table") });
@@ -102,6 +110,7 @@ export const visualStepContentSchema = z.discriminatedUnion("kind", [
   chartVisualStepSchema,
   codeVisualStepSchema,
   diagramVisualStepSchema,
+  formulaVisualStepSchema,
   imageVisualStepSchema,
   quoteVisualStepSchema,
   tableVisualStepSchema,
@@ -113,6 +122,7 @@ export type VisualStepContent = z.infer<typeof visualStepContentSchema>;
 export type ChartVisualContent = z.infer<typeof chartVisualContentSchema>;
 export type CodeVisualContent = z.infer<typeof codeVisualContentSchema>;
 export type DiagramVisualContent = z.infer<typeof diagramVisualContentSchema>;
+export type FormulaVisualContent = z.infer<typeof formulaVisualContentSchema>;
 export type ImageVisualContent = z.infer<typeof imageVisualContentSchema>;
 export type QuoteVisualContent = z.infer<typeof quoteVisualContentSchema>;
 export type TableVisualContent = z.infer<typeof tableVisualContentSchema>;

--- a/packages/db/src/prisma/seed/steps.ts
+++ b/packages/db/src/prisma/seed/steps.ts
@@ -162,6 +162,24 @@ const stepsData: {
         kind: "visual",
       },
 
+      // --- Formula visual ---
+      {
+        content: {
+          text: "The loss function measures how far the model's predictions are from the actual values. Mean Squared Error is one of the most common choices for regression tasks.",
+          title: "Loss Function",
+          variant: "text",
+        },
+        kind: "static",
+      },
+      {
+        content: {
+          description: "Mean Squared Error (MSE)",
+          formula: "\\text{MSE} = \\frac{1}{n} \\sum_{i=1}^{n} (y_i - \\hat{y}_i)^2",
+          kind: "formula",
+        },
+        kind: "visual",
+      },
+
       // --- Image visual ---
       {
         content: {

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -22,6 +22,7 @@
     "@zoonk/core": "workspace:*",
     "@zoonk/ui": "workspace:*",
     "@zoonk/utils": "workspace:*",
+    "katex": "0.16.40",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/packages/player/src/components/step-visual-renderer.tsx
+++ b/packages/player/src/components/step-visual-renderer.tsx
@@ -4,6 +4,7 @@ import { type VisualStepContent } from "@zoonk/core/steps/visual-content-contrac
 import { ChartVisual } from "./visuals/chart-visual";
 import { CodeVisual } from "./visuals/code-visual";
 import { DiagramVisual } from "./visuals/diagram-visual";
+import { FormulaVisual } from "./visuals/formula-visual";
 import { ImageVisual } from "./visuals/image-visual";
 import { QuoteVisual } from "./visuals/quote-visual";
 import { TableVisual } from "./visuals/table-visual";
@@ -36,6 +37,10 @@ export function StepVisualRenderer({ content }: { content: VisualStepContent }) 
 
   if (content.kind === "diagram") {
     return <DiagramVisual content={content} />;
+  }
+
+  if (content.kind === "formula") {
+    return <FormulaVisual content={content} />;
   }
 
   return null;

--- a/packages/player/src/components/visuals/formula-visual.tsx
+++ b/packages/player/src/components/visuals/formula-visual.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { type FormulaVisualContent } from "@zoonk/core/steps/visual-content-contract";
+import { render } from "katex";
+import "katex/dist/katex.min.css";
+import { useEffect, useRef } from "react";
+
+/**
+ * Renders a LaTeX math expression using KaTeX.
+ *
+ * KaTeX renders math into MathML + HTML, which provides native screen reader
+ * support. The `description` field is shown as a caption for additional context.
+ * We use `useEffect` + `useRef` to imperatively render KaTeX into the DOM,
+ * matching the same pattern used by `code-visual.tsx` with shiki.
+ */
+export function FormulaVisual({ content }: { content: FormulaVisualContent }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) {
+      return;
+    }
+
+    render(content.formula, containerRef.current, {
+      displayMode: true,
+      output: "htmlAndMathml",
+      throwOnError: false,
+      trust: false,
+    });
+  }, [content.formula]);
+
+  return (
+    <figure
+      aria-label={content.description}
+      className="flex w-full max-w-xl flex-col items-center gap-4 px-6 sm:gap-5 sm:px-8"
+    >
+      <div
+        className="text-foreground w-full min-w-0 overflow-x-auto text-2xl sm:text-3xl"
+        ref={containerRef}
+        role="math"
+      />
+
+      <figcaption className="text-muted-foreground text-center text-sm">
+        {content.description}
+      </figcaption>
+    </figure>
+  );
+}

--- a/packages/player/src/css.d.ts
+++ b/packages/player/src/css.d.ts
@@ -1,0 +1,4 @@
+declare module "*.css" {
+  const content: string;
+  export default content;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -765,6 +765,9 @@ importers:
       '@zoonk/utils':
         specifier: workspace:*
         version: link:../utils
+      katex:
+        specifier: 0.16.40
+        version: 0.16.40
       lucide-react:
         specifier: '>=0.400'
         version: 0.577.0(react@19.2.4)
@@ -5849,6 +5852,10 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  katex@0.16.40:
+    resolution: {integrity: sha512-1DJcK/L05k1Y9Gf7wMcyuqFOL6BiY3vY0CFcAM/LPRN04NALxcl6u7lOWNsp3f/bCHWxigzQl6FbR95XJ4R84Q==}
+    hasBin: true
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -12610,6 +12617,10 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  katex@0.16.40:
+    dependencies:
+      commander: 8.3.0
 
   keyv@4.5.4:
     dependencies:


### PR DESCRIPTION
## Summary

- Add new **formula** visual type that renders LaTeX math expressions via KaTeX, covering equations from any scientific field (math, physics, chemistry, biology, economics)
- Improve AI visual prompts based on reviewing 264+ generated visuals:
  - Charts: never fabricate data, never chart tautologies, numbers need units
  - Diagrams: don't restate text as boxes, prefer code for programming operations
  - Tables: elevated as preferred type for comparisons and structured examples
  - Code: prefer over diagrams for data structure operations (push, pop, enqueue, etc.)
  - Images: vary metaphors across steps, don't repeat same analogy

## Test plan

- [x] Unit tests for formula contract schema validation
- [x] E2E tests for formula rendering and navigation
- [x] All 23 visual step E2E tests pass
- [x] All editor and API E2E tests pass
- [ ] Generate new content with updated prompts and review visuals via psql

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `formula` visual type rendered with KaTeX and tightens visual prompt rules to block low-value visuals. Chart guidance is simplified to a reasoning rule so charts show real or formula-based data and avoid trivial relationships.

- **New Features**
  - New `formula` visual: LaTeX validated in core schema and rendered via KaTeX with accessible MathML; added unit/E2E tests, player renderer, and a seed example.
  - Stronger prompt guidance: charts require real/measurable or formula-derived data (units required) and must not show trivially obvious relationships (“can the reader derive every point instantly?”); quotes must be real from a named person; use `formula` for math (not code) and avoid single values/trivial inequalities; prefer tables for comparisons; prefer code over diagrams for data structure operations; avoid diagrams that restate text; vary image metaphors across steps. Updated main step-visual prompt to include `formula`; added E2E coverage for formula rendering and navigation; all visual/editor/API E2E tests pass.

- **Dependencies**
  - Added `katex@0.16.40` to `packages/player`.

<sup>Written for commit c7c41f8ff1a7ce3fea2baa2dd8675aea26324c62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

