### PR TITLE
fix(ai): improve curriculum generation prompts

### DIFF
--- a/packages/ai/src/tasks/chapters/chapter-lessons.prompt.md
+++ b/packages/ai/src/tasks/chapters/chapter-lessons.prompt.md
@@ -124,6 +124,29 @@ When a concept title is a single generic word, add just enough context to make i
 - **NEVER** start with words like "introduces", "presents", "shows", "teaches", "covers", "explains"
 - Go straight to the content: e.g. "How the if, else, and elif keywords control which code block runs." not "Introduces the main conditional keywords in Python."
 
+## No Meta or Methodology Lessons
+
+Every lesson must teach **concrete, subject-specific content** — things the learner will actually use or apply. Do NOT generate lessons that describe or overview the field, its subfields, its methodology, or its nature.
+
+**BAD lessons** (meta — talk ABOUT the field):
+
+- ❌ "Biology as the Study of Life"
+- ❌ "Crosscutting Themes in Biology"
+- ❌ "Biological Inquiry and Experimental Logic"
+- ❌ "Natureza da Ciência da Computação"
+- ❌ "Subcampos centrais da área"
+- ❌ "Dimensões de atuação na computação"
+- ❌ "Scientific Knowledge in Chemistry"
+
+**GOOD lessons** (concrete — teach actual content):
+
+- ✅ "Mitosis"
+- ✅ "The if Statement"
+- ✅ "Atomic Number"
+- ✅ "Arrays dinâmicos"
+
+**The test**: "Will the learner use this specific knowledge to solve problems, build things, or understand the subject more deeply?" If the answer is "no, it's just context about the field itself," remove it.
+
 ## Progression & Structure
 
 - Build a logical progression from basic to advanced concepts
@@ -175,6 +198,7 @@ Before finalizing, verify:
 4. **Complete coverage**: Have you covered EVERYTHING from the chapter description?
 5. **Chapter scope**: Did you stay within the chapter's scope?
 6. **No neighboring overlap**: For each concept, if you moved it to a neighboring chapter's list, would it fit naturally there? If yes, remove it — it belongs there, not here.
+7. **No meta lessons**: Does any lesson describe the field, its subfields, or its methodology rather than teaching concrete content? If yes, remove it.
 
 # Output Format
 

--- a/packages/ai/src/tasks/courses/course-chapters.prompt.md
+++ b/packages/ai/src/tasks/courses/course-chapters.prompt.md
@@ -35,6 +35,7 @@ The curriculum should make the learner highly capable in the subject itself. For
 - Avoid generic cross-disciplinary chapters that are not specific to the course title, such as "Scientific Thinking", "Academic Writing", "Literature Review", "Communication Skills", or "Career Development".
 - If supporting topics like research methods, statistics, ethics, regulation, tools, or career paths are truly important, scope them explicitly to `COURSE_TITLE` in both the title and description.
 - For broad academic subjects such as biology, chemistry, economics, history, or psychology, primarily teach the field itself rather than how academics study the field.
+- **No overlapping chapters.** Each chapter must cover a distinct domain. If two chapter titles could reasonably share the same lessons, merge them or sharpen their scopes so they don't overlap. For example, a course should NOT have both "Cells" and "Cell and Tissue Biology" — the second clearly overlaps with the first.
 - Write **clear, concise** text in the specified `LANGUAGE` input.
 - Avoid fluff/fillers/unnecessary words.
 - Keep the curriculum **modern and relevant**, but do not sacrifice canonical foundations for trends.
@@ -42,6 +43,27 @@ The curriculum should make the learner highly capable in the subject itself. For
 - For hobbies, pop culture, or non-professional topics, you don't need to focus on job readiness. Instead, focus on comprehensive coverage of the topic.
 - Career chapters are optional. Include them only when they are genuinely useful and can be clearly specific to `COURSE_TITLE`.
 - Don't mention prompt instructions such as "mastery" in the chapter titles or descriptions.
+
+## Foundations Must Be Concrete
+
+The first chapters are where learners decide if they can do this. Many learners come from backgrounds where they don't believe they can become engineers or scientists — the opening chapters must prove them wrong by being **concrete, achievable, and immediately engaging**.
+
+The first chapter must dive straight into the subject's core content — the actual things people learn this subject TO learn. Do NOT start with meta-chapters that describe the field, its history, its methodology, or its subfields. Those are academic lectures, not learning.
+
+**BAD first chapters** (meta — describe the field instead of teaching it):
+
+- ❌ "Foundations of Biology" with lessons like "Biology as the Study of Life", "Crosscutting Themes"
+- ❌ "Fundamentos da Ciência da Computação" with lessons like "Natureza da Ciência da Computação", "Subcampos da área"
+- ❌ "What is Chemistry" or "The Nature of Chemistry"
+
+**GOOD first chapters** (concrete — teach the actual subject):
+
+- ✅ A Biology course starting with "Cells" or "Biological Chemistry"
+- ✅ A Computer Science course starting with "Representation of Information" or "Programming"
+- ✅ A Chemistry course starting with "Atoms and Elements" or "Chemical Bonding"
+- ✅ A Python course starting with "Getting Started with Python" (practical setup + first code)
+
+If foundational concepts like measurement, notation, or terminology are genuinely needed before diving into the subject, keep them minimal and concrete — teach them as tools the learner needs, not as a lecture about the field.
 
 ## Hobbies, Pop Culture, Non-Professional Topics
 
@@ -94,6 +116,11 @@ Good chapter titles include:
 
 Avoid generic titles that could belong to many unrelated courses unless they are explicitly the course subject. For example, "Scientific Thinking", "Academic Communication", or "Career Development" are usually too generic for a course about biology, chemistry, or psychology.
 
+**NEVER use numbered suffixes** like "I", "II", "III" (or "Part 1", "Part 2") in chapter titles. This is a university catalog convention that tells the learner nothing about what's inside. Instead, use specific titles that describe the actual content of each chapter.
+
+- ❌ "Organic Chemistry I", "Organic Chemistry II" → ✅ "Organic Structure and Reactivity", "Organic Reactions and Synthesis"
+- ❌ "Calculus I", "Calculus II" → ✅ "Calculus of One Variable", "Multivariable Calculus"
+
 **TIP:** Go straight to the point. Avoid verbose titles. If necessary, add details in the description instead.
 
 ### Description
@@ -115,5 +142,7 @@ Before finishing this course, review the entire content and ask yourself:
 - "Am I adding generic chapters that could fit many unrelated courses unchanged?" If the answer is "yes," remove them or scope them specifically to `COURSE_TITLE`.
 - "Am I missing any important chapters or topics?" If the answer is "yes," add them.
 - "Does this curriculum have enough depth for real mastery of the subject?" If the answer is "no," add more depth to the chapters or add new chapters as needed.
+- "Does the first chapter dive into concrete subject content, or does it describe/overview the field?" If it describes the field, replace it with a chapter that teaches actual content.
+- "Do any two chapters overlap significantly in scope?" If the answer is "yes," merge them or sharpen their scopes so each chapter covers a distinct domain.
 
 Make sure this is a focused, complete, and high-quality curriculum for this subject.


### PR DESCRIPTION
## Summary

- First chapters must dive into concrete subject content, not meta overviews ("What is Biology?", "Nature of Computer Science")
- Lessons that describe/overview the field are rejected — every lesson must teach concrete, usable knowledge
- Chapters with overlapping scopes are flagged (e.g., "Cells" + "Cell and Tissue Biology")
- Numbered suffixes (I, II, III) banned in chapter titles — use descriptive titles instead

## Test plan

- [x] Verified with freshly generated courses (Computer Science, Economics, Physics) — no meta first chapters, no overlapping chapters, no numbered suffixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens `packages/ai` course and lesson prompts to produce concrete, immediately useful curricula with clearer chapter structure. Prevents meta content in early chapters, stops scope overlaps, and bans numbered chapter titles.

- **New Features**
  - First chapters must teach concrete subject content; no field overviews.
  - Reject meta/methodology lessons; require actionable lessons.
  - Enforce distinct, non-overlapping chapter scopes.
  - Ban numbered suffixes (I/II/III, Part 1/2); use descriptive titles.

<sup>Written for commit 9c642b59bf8e2dae9a3acf6a9548150de50b5c7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

