### PR TITLE
feat(ai): add music visual type using ABC notation

### DIFF
--- a/apps/evals/src/tasks/step-visual/task.ts
+++ b/apps/evals/src/tasks/step-visual/task.ts
@@ -8,7 +8,7 @@ import { TEST_CASES } from "./test-cases";
 
 export const stepVisualTask: Task<StepVisualParams, StepVisualSchema> = {
   description:
-    "Generate visual resources (timelines, diagrams, quotes, code, charts, tables, images) for learning steps",
+    "Generate visual resources (timelines, diagrams, quotes, code, charts, tables, images, formulas, music) for learning steps",
   generate: generateStepVisuals,
   id: "step-visual",
   name: "Step Visual Resources",

--- a/apps/evals/src/tasks/step-visual/test-cases.ts
+++ b/apps/evals/src/tasks/step-visual/test-cases.ts
@@ -256,6 +256,7 @@ REDUNDANCY CHECKS - PENALIZE if:
 
 VISUAL-CONTENT FIT - PENALIZE if:
 - Code visual is used (no programming content)
+- Music visual is used (no musical notation content)
 - Timeline is used (mindfulness is not a historical topic)
 - Chart is used without meaningful data (IMPORTANT: Step 2 "Benefits of Practice" contains ONLY qualitative descriptions like "reduce stress" and "improve focus" with NO numerical data. If a chart is used for this step, the model MUST fabricate numbers to populate it. This is ALWAYS a MAJOR error because it presents made-up statistics as educational facts. Score it under majorErrors, not minorErrors.)
 
@@ -286,6 +287,61 @@ ${SHARED_EXPECTATIONS}
         {
           text: "Regular mindfulness practice has been shown to reduce stress, improve focus, and help people respond rather than react to difficult situations.",
           title: "Benefits of Practice",
+        },
+      ],
+    },
+  },
+  {
+    expectations: `
+TOPIC-SPECIFIC GUIDANCE:
+
+This test covers music theory - the major scale pattern.
+
+ACCURACY CHECKS - PENALIZE if:
+- ABC notation has syntax errors (missing required headers like X:, K:, M:, L:)
+- Musical content is incorrect (wrong notes in scales, wrong key signatures)
+- Notation doesn't match the described concept (e.g., shows a minor scale when the text describes a major scale)
+
+REDUNDANCY CHECKS - PENALIZE if:
+- Multiple visuals show the same scale or pattern
+- The same notes appear across different visuals without adding new information
+
+VISUAL-CONTENT FIT:
+- Music visual is the ideal type for steps with specific scales, intervals, or melodies
+- Table is acceptable for comparing scale degrees or intervals
+- Image is acceptable as fallback
+
+PENALIZE if:
+- Code visual is used (no programming content)
+- Chart is used without numerical data
+- Timeline is used (not a historical topic)
+
+Do NOT PENALIZE if:
+- Not all steps use music visuals (table or image can supplement)
+- Music visual is used for all steps (if each shows distinct notation)
+
+${SHARED_EXPECTATIONS}
+    `,
+    id: "en-music-major-scale",
+    userInput: {
+      chapterTitle: "Scales and Keys",
+      courseTitle: "Music Theory Fundamentals",
+      language: "en",
+      lessonDescription:
+        "Understanding the major scale pattern and how it forms the foundation of Western music",
+      lessonTitle: "The Major Scale",
+      steps: [
+        {
+          text: "The major scale follows a specific pattern of whole and half steps: W-W-H-W-W-W-H. Starting from C, this gives us C-D-E-F-G-A-B-C with no sharps or flats.",
+          title: "The Pattern",
+        },
+        {
+          text: "When we start the same whole-half pattern from G, we need one sharp (F#) to maintain the intervals. This gives us the G major scale: G-A-B-C-D-E-F#-G.",
+          title: "Transposing to G",
+        },
+        {
+          text: "The distance between any two adjacent notes is called an interval. In a major scale, the interval from the first to the fifth note (like C to G) is called a perfect fifth.",
+          title: "Intervals in the Scale",
         },
       ],
     },

--- a/packages/ai/src/tasks/steps/_tools/music.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/music.prompt.md
@@ -1,0 +1,28 @@
+Create a music visual using ABC notation.
+
+Use when: The step introduces or explains a **specific musical concept that can be written as standard music notation** — scales, intervals, chords, rhythms, melodies, key signatures, time signatures.
+
+## When NOT to use music
+
+- **Never use for non-music content.** If the step is not about music, never use this visual type — even if music is mentioned as a metaphor or analogy (e.g., "programming is like composing music"). Use the visual type appropriate for the actual topic.
+- **Never use for conceptual music discussions without specific notation.** If the step talks about music qualitatively (e.g., "music improves memory", "Mozart was a genius", "jazz originated in New Orleans") without a concrete musical passage, scale, or pattern to show, use image, quote, or timeline instead.
+- **Never use for music production, audio engineering, or sound design.** These topics don't involve standard music notation. Use image or diagram instead.
+- **Never use for sound, acoustics, or audio waveforms.** Use image, diagram, or formula instead.
+- **Only use when there are specific notes to notate.** If the step doesn't describe a concrete musical passage, scale, chord, rhythm, or pattern that can be written in standard notation, don't use music.
+
+## When to use music
+
+- The step introduces a scale, chord, interval, or musical pattern with specific notes
+- The step explains rhythm, time signatures, or note values with concrete examples
+- The step shows a melody or motif as a teaching point
+- The step compares musical structures (e.g., major vs. minor scale) and the comparison is clearer as notation
+
+## Requirements
+
+- Use valid ABC notation with required headers (`X:1`, `M:`, `L:`, `K:`)
+- Keep notation short and focused — 1 to 4 lines of notes
+- Single voice only (no `V:` multi-voice)
+- No lyrics lines (`w:`)
+- No layout directives (`%%`)
+- No MIDI directives
+- Description should explain what the notation demonstrates in plain language (max 100 chars)

--- a/packages/ai/src/tasks/steps/_tools/music.prompt.md
+++ b/packages/ai/src/tasks/steps/_tools/music.prompt.md
@@ -16,6 +16,8 @@ Use when: The step introduces or explains a **specific musical concept that can 
 - The step explains rhythm, time signatures, or note values with concrete examples
 - The step shows a melody or motif as a teaching point
 - The step compares musical structures (e.g., major vs. minor scale) and the comparison is clearer as notation
+- **The step introduces or describes a specific musical figure or note value** (e.g., whole note, half note, quarter note, eighth note, sixteenth note). Real rendered notation is always better than an AI-generated image of notation. If a step says "the half note has an open note head and a stem", show an actual half note in ABC notation — don't generate an image of one
+- The step describes what a note, rest, or rhythmic figure looks like on a staff — use music notation to show the real thing
 
 ## Requirements
 

--- a/packages/ai/src/tasks/steps/_tools/music.ts
+++ b/packages/ai/src/tasks/steps/_tools/music.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const musicInputSchema = z.object({
+  abc: z.string().describe("ABC notation string including headers (X:, M:, L:, K:) and notes"),
+  description: z.string().describe("Brief plain-text explanation of the notation (max 100 chars)"),
+  stepIndex: z.number().describe("The step index (0-based) this visual is for"),
+});

--- a/packages/ai/src/tasks/steps/_tools/visual.ts
+++ b/packages/ai/src/tasks/steps/_tools/visual.ts
@@ -10,6 +10,8 @@ import { formulaInputSchema } from "./formula";
 import formulaPrompt from "./formula.prompt.md";
 import { imageInputSchema } from "./image";
 import imagePrompt from "./image.prompt.md";
+import { musicInputSchema } from "./music";
+import musicPrompt from "./music.prompt.md";
 import { quoteInputSchema } from "./quote";
 import quotePrompt from "./quote.prompt.md";
 import { tableInputSchema } from "./table";
@@ -37,6 +39,10 @@ export const visualTools = {
   image: tool({
     description: imagePrompt,
     inputSchema: imageInputSchema,
+  }),
+  music: tool({
+    description: musicPrompt,
+    inputSchema: musicInputSchema,
   }),
   quote: tool({
     description: quotePrompt,
@@ -72,6 +78,10 @@ export type ImageVisual = {
   kind: "image";
 } & z.infer<typeof imageInputSchema>;
 
+export type MusicVisual = {
+  kind: "music";
+} & z.infer<typeof musicInputSchema>;
+
 export type QuoteVisual = {
   kind: "quote";
 } & z.infer<typeof quoteInputSchema>;
@@ -90,6 +100,7 @@ export type StepVisualResource =
   | DiagramVisual
   | FormulaVisual
   | ImageVisual
+  | MusicVisual
   | QuoteVisual
   | TableVisual
   | TimelineVisual;

--- a/packages/ai/src/tasks/steps/step-visual.prompt.md
+++ b/packages/ai/src/tasks/steps/step-visual.prompt.md
@@ -17,16 +17,17 @@ Generate ONE appropriate visual resource for EACH step provided. Each visual sho
 
 Choose the visual type that BEST fits each step's content:
 
-| Visual Type  | When to Use                                                                                |
-| ------------ | ------------------------------------------------------------------------------------------ |
-| **timeline** | Historical progression, evolution of concepts, sequence of discoveries                     |
-| **diagram**  | Concrete structural relationships: processes, dependencies, cycles, hierarchies            |
-| **quote**    | Famous definitions, authoritative statements, foundational principles                      |
-| **code**     | Algorithms, data structure operations, syntax, APIs — only for programming content         |
-| **formula**  | Specific equations, formulas, or formal expressions from any field (math, physics, etc.)   |
-| **chart**    | Real statistics, measured data, or values from known formulas — NEVER fabricated numbers   |
-| **table**    | Comparisons, examples with attributes, conceptual contrasts — prefer over generic diagrams |
-| **image**    | DEFAULT fallback when no other type fits the content                                       |
+| Visual Type  | When to Use                                                                                 |
+| ------------ | ------------------------------------------------------------------------------------------- |
+| **timeline** | Historical progression, evolution of concepts, sequence of discoveries                      |
+| **diagram**  | Concrete structural relationships: processes, dependencies, cycles, hierarchies             |
+| **quote**    | Famous definitions, authoritative statements, foundational principles                       |
+| **code**     | Algorithms, data structure operations, syntax, APIs — only for programming content          |
+| **formula**  | Specific equations, formulas, or formal expressions from any field (math, physics, etc.)    |
+| **music**    | Scales, chords, intervals, rhythms, melodies — only when there are specific notes to notate |
+| **chart**    | Real statistics, measured data, or values from known formulas — NEVER fabricated numbers    |
+| **table**    | Comparisons, examples with attributes, conceptual contrasts — prefer over generic diagrams  |
+| **image**    | DEFAULT fallback when no other type fits the content                                        |
 
 # Rules
 
@@ -75,6 +76,15 @@ Choose the visual type that BEST fits each step's content:
 - Use valid LaTeX syntax
 - Description should explain what the formula represents in plain language
 - One main equation per visual; use LaTeX `aligned` or `cases` environments for multi-line expressions
+
+## Music
+
+- Use when the step introduces or explains a **specific musical element** that is clearer as notation than as text — scales, intervals, chords, rhythms, melodies, key signatures, time signatures
+- **Only for content with specific notes to notate.** Never use music for steps that merely mention music as a metaphor, analogy, or historical context without actual notation to show
+- Not for music production, sound design, audio engineering, acoustics, or audio waveforms
+- Not for conceptual music discussions without a concrete passage or pattern (e.g., "music helps with memory" or "jazz originated in New Orleans" — use image or timeline instead)
+- Use valid ABC notation with required headers (`X:1`, `M:`, `L:`, `K:`)
+- Keep notation concise (1-4 lines of notes), single voice only
 
 ## Chart
 

--- a/packages/ai/src/tasks/steps/step-visual.prompt.md
+++ b/packages/ai/src/tasks/steps/step-visual.prompt.md
@@ -80,6 +80,7 @@ Choose the visual type that BEST fits each step's content:
 ## Music
 
 - Use when the step introduces or explains a **specific musical element** that is clearer as notation than as text — scales, intervals, chords, rhythms, melodies, key signatures, time signatures
+- **Prefer music over image for anything that belongs on a staff.** If a step introduces a note value (whole note, half note, quarter note, etc.), a rhythmic figure, a rest, or any musical symbol — show it as real rendered notation, not as an AI-generated image of notation. Real notation is always more accurate and educational than a picture of notation
 - **Only for content with specific notes to notate.** Never use music for steps that merely mention music as a metaphor, analogy, or historical context without actual notation to show
 - Not for music production, sound design, audio engineering, acoustics, or audio waveforms
 - Not for conceptual music discussions without a concrete passage or pattern (e.g., "music helps with memory" or "jazz originated in New Orleans" — use image or timeline instead)
@@ -106,6 +107,7 @@ Choose the visual type that BEST fits each step's content:
 ## Image
 
 - Use as fallback when no other type fits
+- **Never generate an image of something another visual type can render directly.** Don't generate images of musical notation, sheet music, or notes on a staff — use the music visual instead. Don't generate images of code — use the code visual. Don't generate images of formulas — use the formula visual
 - Describe content only, not style
 - Be specific enough to convey the concept
 - Avoid text by default. Only include text in image visuals when it materially improves clarity

--- a/packages/core/src/steps/visual-content-contract.test.ts
+++ b/packages/core/src/steps/visual-content-contract.test.ts
@@ -96,6 +96,20 @@ describe("visual content contracts", () => {
     });
   });
 
+  test("parses music visual content", () => {
+    const content = visualStepContentSchema.parse({
+      abc: "X:1\nM:4/4\nL:1/4\nK:C\nC D E F | G A B c |",
+      description: "C major scale ascending over one octave",
+      kind: "music",
+    });
+
+    expect(content).toEqual({
+      abc: "X:1\nM:4/4\nL:1/4\nK:C\nC D E F | G A B c |",
+      description: "C major scale ascending over one octave",
+      kind: "music",
+    });
+  });
+
   test("parses image visual content without url", () => {
     const content = visualStepContentSchema.parse({
       kind: "image",
@@ -203,5 +217,9 @@ describe("visual content contracts", () => {
     expect(() => visualStepContentSchema.parse({ kind: "quote", text: "hi" })).toThrow();
     expect(() => visualStepContentSchema.parse({ formula: "x^2", kind: "formula" })).toThrow();
     expect(() => visualStepContentSchema.parse({ description: "desc", kind: "formula" })).toThrow();
+    expect(() =>
+      visualStepContentSchema.parse({ abc: "X:1\nK:C\nC D E", kind: "music" }),
+    ).toThrow();
+    expect(() => visualStepContentSchema.parse({ description: "scale", kind: "music" })).toThrow();
   });
 });

--- a/packages/core/src/steps/visual-content-contract.ts
+++ b/packages/core/src/steps/visual-content-contract.ts
@@ -59,6 +59,13 @@ export const formulaVisualContentSchema = z
   })
   .strict();
 
+export const musicVisualContentSchema = z
+  .object({
+    abc: z.string(),
+    description: z.string(),
+  })
+  .strict();
+
 export const imageVisualContentSchema = z
   .object({
     prompt: z.string(),
@@ -99,6 +106,7 @@ const chartVisualStepSchema = chartVisualContentSchema.extend({ kind: z.literal(
 const codeVisualStepSchema = codeVisualContentSchema.extend({ kind: z.literal("code") });
 const diagramVisualStepSchema = diagramVisualContentSchema.extend({ kind: z.literal("diagram") });
 const formulaVisualStepSchema = formulaVisualContentSchema.extend({ kind: z.literal("formula") });
+const musicVisualStepSchema = musicVisualContentSchema.extend({ kind: z.literal("music") });
 const imageVisualStepSchema = imageVisualContentSchema.extend({ kind: z.literal("image") });
 const quoteVisualStepSchema = quoteVisualContentSchema.extend({ kind: z.literal("quote") });
 const tableVisualStepSchema = tableVisualContentSchema.extend({ kind: z.literal("table") });
@@ -112,6 +120,7 @@ export const visualStepContentSchema = z.discriminatedUnion("kind", [
   diagramVisualStepSchema,
   formulaVisualStepSchema,
   imageVisualStepSchema,
+  musicVisualStepSchema,
   quoteVisualStepSchema,
   tableVisualStepSchema,
   timelineVisualStepSchema,
@@ -124,6 +133,7 @@ export type CodeVisualContent = z.infer<typeof codeVisualContentSchema>;
 export type DiagramVisualContent = z.infer<typeof diagramVisualContentSchema>;
 export type FormulaVisualContent = z.infer<typeof formulaVisualContentSchema>;
 export type ImageVisualContent = z.infer<typeof imageVisualContentSchema>;
+export type MusicVisualContent = z.infer<typeof musicVisualContentSchema>;
 export type QuoteVisualContent = z.infer<typeof quoteVisualContentSchema>;
 export type TableVisualContent = z.infer<typeof tableVisualContentSchema>;
 export type TimelineVisualContent = z.infer<typeof timelineVisualContentSchema>;

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -22,6 +22,7 @@
     "@zoonk/core": "workspace:*",
     "@zoonk/ui": "workspace:*",
     "@zoonk/utils": "workspace:*",
+    "abcjs": "6.6.2",
     "katex": "0.16.40",
     "zod": "4.3.6"
   },

--- a/packages/player/src/components/step-visual-renderer.tsx
+++ b/packages/player/src/components/step-visual-renderer.tsx
@@ -6,6 +6,7 @@ import { CodeVisual } from "./visuals/code-visual";
 import { DiagramVisual } from "./visuals/diagram-visual";
 import { FormulaVisual } from "./visuals/formula-visual";
 import { ImageVisual } from "./visuals/image-visual";
+import { MusicVisual } from "./visuals/music-visual";
 import { QuoteVisual } from "./visuals/quote-visual";
 import { TableVisual } from "./visuals/table-visual";
 import { TimelineVisual } from "./visuals/timeline-visual";
@@ -41,6 +42,10 @@ export function StepVisualRenderer({ content }: { content: VisualStepContent }) 
 
   if (content.kind === "formula") {
     return <FormulaVisual content={content} />;
+  }
+
+  if (content.kind === "music") {
+    return <MusicVisual content={content} />;
   }
 
   return null;

--- a/packages/player/src/components/visuals/music-visual.tsx
+++ b/packages/player/src/components/visuals/music-visual.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { type MusicVisualContent } from "@zoonk/core/steps/visual-content-contract";
+import abcjs from "abcjs";
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Renders ABC music notation as SVG using ABCJS.
+ *
+ * ABCJS imperatively renders SVG into the target DOM element, matching
+ * the same useEffect + useRef pattern used by formula-visual.tsx (KaTeX)
+ * and code-visual.tsx (shiki). The `description` field provides both an
+ * aria-label for screen readers and a visible caption explaining the notation.
+ *
+ * We use `responsive: "resize"` so ABCJS reflows measures to new lines
+ * when the container is narrow (e.g., on mobile), rather than requiring
+ * horizontal scrolling which breaks the spatial relationship between notes.
+ *
+ * Dark mode is handled by reading the current foreground color from CSS
+ * and passing it to ABCJS as `foregroundColor`, so the SVG renders with
+ * the correct theme color from the start.
+ */
+export function MusicVisual({ content }: { content: MusicVisualContent }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [rendered, setRendered] = useState(false);
+
+  useEffect(() => {
+    if (!containerRef.current) {
+      return;
+    }
+
+    const foreground = getComputedStyle(containerRef.current).getPropertyValue("color");
+
+    abcjs.renderAbc(containerRef.current, content.abc, {
+      foregroundColor: foreground,
+      responsive: "resize",
+    });
+
+    setRendered(true);
+  }, [content.abc]);
+
+  return (
+    <figure
+      aria-label={content.description}
+      className="flex w-full min-w-0 flex-col items-center gap-4 sm:gap-5"
+    >
+      <div
+        className={`text-foreground w-full min-w-0 transition-opacity duration-300 ${rendered ? "opacity-100" : "opacity-0"}`}
+        ref={containerRef}
+        role="img"
+      />
+
+      <figcaption className="text-muted-foreground text-center text-sm">
+        {content.description}
+      </figcaption>
+    </figure>
+  );
+}

--- a/packages/player/src/components/visuals/music-visual.tsx
+++ b/packages/player/src/components/visuals/music-visual.tsx
@@ -2,27 +2,26 @@
 
 import { type MusicVisualContent } from "@zoonk/core/steps/visual-content-contract";
 import abcjs from "abcjs";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 
 /**
  * Renders ABC music notation as SVG using ABCJS.
  *
- * ABCJS imperatively renders SVG into the target DOM element, matching
- * the same useEffect + useRef pattern used by formula-visual.tsx (KaTeX)
- * and code-visual.tsx (shiki). The `description` field provides both an
- * aria-label for screen readers and a visible caption explaining the notation.
+ * `staffwidth` controls how wide ABCJS draws the staff and spaces
+ * notes within it. `responsive: "resize"` then scales the SVG to
+ * fill the container. With larger staffwidth values (e.g., 200+),
+ * short phrases only use a fraction of the staff, leaving empty
+ * space on the right that makes the notation look left-aligned.
+ * A small staffwidth (50) forces ABCJS to pack notes tightly so
+ * they fill the staff, and responsive scaling enlarges everything
+ * to fit the container — keeping notation centered and properly
+ * sized regardless of how many notes there are.
  *
- * We use `responsive: "resize"` so ABCJS reflows measures to new lines
- * when the container is narrow (e.g., on mobile), rather than requiring
- * horizontal scrolling which breaks the spatial relationship between notes.
- *
- * Dark mode is handled by reading the current foreground color from CSS
- * and passing it to ABCJS as `foregroundColor`, so the SVG renders with
- * the correct theme color from the start.
+ * Dark mode is handled by reading the current foreground
+ * color from CSS and passing it to ABCJS as `foregroundColor`.
  */
 export function MusicVisual({ content }: { content: MusicVisualContent }) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [rendered, setRendered] = useState(false);
 
   useEffect(() => {
     if (!containerRef.current) {
@@ -34,18 +33,17 @@ export function MusicVisual({ content }: { content: MusicVisualContent }) {
     abcjs.renderAbc(containerRef.current, content.abc, {
       foregroundColor: foreground,
       responsive: "resize",
+      staffwidth: 50,
     });
-
-    setRendered(true);
   }, [content.abc]);
 
   return (
     <figure
       aria-label={content.description}
-      className="flex w-full min-w-0 flex-col items-center gap-4 sm:gap-5"
+      className="flex w-full max-w-xl flex-col items-center gap-4 px-6 sm:gap-5 sm:px-8"
     >
       <div
-        className={`text-foreground w-full min-w-0 transition-opacity duration-300 ${rendered ? "opacity-100" : "opacity-0"}`}
+        className="text-foreground w-full min-w-0 overflow-x-auto"
         ref={containerRef}
         role="img"
       />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -765,6 +765,9 @@ importers:
       '@zoonk/utils':
         specifier: workspace:*
         version: link:../utils
+      abcjs:
+        specifier: 6.6.2
+        version: 6.6.2
       katex:
         specifier: 0.16.40
         version: 0.16.40
@@ -4497,6 +4500,9 @@ packages:
 
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
+  abcjs@6.6.2:
+    resolution: {integrity: sha512-YLbp5lYUq0uOywWZx9EuTdm0TcflKZi7hOzz366A/LFl3qoAXSYIjznJQmr/VeHg8NcLxZYoN8dLi7PqCpxKEA==}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -11266,6 +11272,8 @@ snapshots:
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
+
+  abcjs@6.6.2: {}
 
   accepts@1.3.8:
     dependencies:


### PR DESCRIPTION
## Summary

- Add `music` visual kind with ABC notation schema (`abc` + `description` fields)
- Render notation as SVG using ABCJS with responsive reflow, dark mode support, and fade-in animation
- Strong AI prompt guardrails to prevent misuse on non-music content
- Add music theory eval test case and penalize music misuse in existing non-music test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `music` visual type that renders ABC notation to SVG using `abcjs`, so steps can show real notation for scales, chords, intervals, rhythms, and melodies. Prompts prefer notation over images, and the player centers notation for better readability.

- **New Features**
  - Added `music` kind to the core visual contract and types.
  - Player renders ABC to SVG with responsive reflow, dark mode, and centered notation.
  - Music tool input schema and prompt; enabled `music` in visual tools and task description.
  - Added a music theory eval (major scale); schema tests validate `music`.

- **Bug Fixes**
  - Prompts now prefer real music notation over images for note values and figures.
  - Image guardrail: never generate images of notation, code, or formulas when dedicated visuals exist.
  - Evals penalize using `music` on non-musical steps.

<sup>Written for commit 95da5aab3dfedcbf33ed9dd9fc4f0cc9a1db6320. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

