### PR TITLE
fix(player): prevent duplicate keys in diagram edges

### DIFF
--- a/packages/player/src/components/visuals/diagram-visual.tsx
+++ b/packages/player/src/components/visuals/diagram-visual.tsx
@@ -102,8 +102,9 @@ function DiagramEdgeLabel({ edge }: { edge: PositionedEdge }) {
 function DiagramEdges({ edges, markerId }: { edges: PositionedEdge[]; markerId: string }) {
   return (
     <g>
-      {edges.map((edge) => (
-        <g key={`${edge.source}-${edge.target}`}>
+      {edges.map((edge, index) => (
+        // oxlint-disable-next-line react/no-array-index-key -- Multiple edges can share the same source-target pair, no unique ID on edges
+        <g key={`${edge.source}-${edge.target}-${index}`}>
           <DiagramEdgeLine edge={edge} markerId={markerId} />
           <DiagramEdgeLabel edge={edge} />
         </g>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent duplicate React keys for diagram edges by appending the array index to the `source-target` key, eliminating warnings when multiple edges connect the same nodes.

<sup>Written for commit 57913458c4953f00e708eeb178e1eee59e675196. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

