### PR TITLE
fix(player): prevent tall step content from hiding behind navbar

### DIFF
--- a/packages/player/src/components/challenge-completion.tsx
+++ b/packages/player/src/components/challenge-completion.tsx
@@ -16,7 +16,7 @@ function ChallengeScreen({ className, ...props }: React.ComponentProps<"div">) {
     <div
       aria-live="polite"
       className={cn(
-        "animate-in fade-in mx-auto flex w-full max-w-lg flex-col items-center gap-6 duration-200 ease-out motion-reduce:animate-none",
+        "animate-in fade-in mx-auto my-auto flex w-full max-w-lg flex-col items-center gap-6 duration-200 ease-out motion-reduce:animate-none",
         className,
       )}
       data-slot="completion-screen"

--- a/packages/player/src/components/challenge-intro.tsx
+++ b/packages/player/src/components/challenge-intro.tsx
@@ -17,7 +17,7 @@ export function ChallengeIntro({
   const entries = buildDimensionEntries(dimensions, []);
 
   return (
-    <div className="mx-auto flex w-full max-w-lg flex-col gap-6 text-left">
+    <div className="mx-auto my-auto flex w-full max-w-lg flex-col gap-6 text-left">
       <div className="flex flex-col gap-4">
         <SectionLabel>{t("Challenge")}</SectionLabel>
 

--- a/packages/player/src/components/completion-screen.tsx
+++ b/packages/player/src/components/completion-screen.tsx
@@ -16,7 +16,7 @@ function CompletionScreen({ className, ...props }: React.ComponentProps<"div">) 
     <div
       aria-live="polite"
       className={cn(
-        "animate-in fade-in mx-auto flex w-full max-w-lg flex-col items-center gap-6 duration-200 ease-out motion-reduce:animate-none",
+        "animate-in fade-in mx-auto my-auto flex w-full max-w-lg flex-col items-center gap-6 duration-200 ease-out motion-reduce:animate-none",
         className,
       )}
       data-slot="completion-screen"

--- a/packages/player/src/components/feedback-screen.tsx
+++ b/packages/player/src/components/feedback-screen.tsx
@@ -27,7 +27,7 @@ function FeedbackScreen({ className, ...props }: React.ComponentProps<"div">) {
     <div
       aria-live="polite"
       className={cn(
-        "animate-in fade-in slide-in-from-bottom-1 mx-auto flex w-full max-w-lg flex-col gap-6 duration-200 ease-out motion-reduce:animate-none",
+        "animate-in fade-in slide-in-from-bottom-1 mx-auto my-auto flex w-full max-w-lg flex-col gap-6 duration-200 ease-out motion-reduce:animate-none",
         className,
       )}
       data-slot="feedback-screen"

--- a/packages/player/src/components/player-stage.tsx
+++ b/packages/player/src/components/player-stage.tsx
@@ -14,7 +14,7 @@ export function PlayerStage({
     <section
       className={cn(
         "flex min-h-0 min-w-0 flex-1 flex-col items-center overflow-y-auto",
-        isStatic ? "overflow-hidden p-0" : "justify-center p-4",
+        isStatic ? "overflow-hidden p-0" : "p-4",
         className,
       )}
       data-phase={phase}

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -82,7 +82,7 @@ export function StageContent({
   if ((phase === "playing" || phase === "feedback") && currentStep) {
     return (
       <div
-        className="animate-in fade-in flex min-h-0 w-full min-w-0 flex-1 flex-col items-center justify-center duration-150 ease-out motion-reduce:animate-none"
+        className="animate-in fade-in flex min-h-0 w-full min-w-0 flex-1 flex-col items-center duration-150 ease-out motion-reduce:animate-none"
         key={`step-${currentStepIndex}`}
       >
         <StepRenderer

--- a/packages/player/src/components/step-layouts.tsx
+++ b/packages/player/src/components/step-layouts.tsx
@@ -16,7 +16,7 @@ export function NavigableStepLayout({ className, ...props }: React.ComponentProp
 export function InteractiveStepLayout({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("flex w-full max-w-2xl flex-col gap-4 sm:gap-6", className)}
+      className={cn("my-auto flex w-full max-w-2xl flex-col gap-4 sm:gap-6", className)}
       data-slot="interactive-step-layout"
       {...props}
     />


### PR DESCRIPTION
## Summary
- Replaced `justify-center` with `my-auto` for vertical centering in player step containers
- `justify-center` on scrollable flex containers pushes overflowing content above the scroll viewport, making the top inaccessible (e.g. multiple choice steps with many options)
- `my-auto` centers content when it fits but resolves to zero margin on overflow, allowing proper top-aligned scrolling

## Test plan
- [ ] Open a multiple choice step with many/long options that exceeds viewport height
- [ ] Verify the top of the content is visible and scrollable
- [ ] Verify shorter steps are still vertically centered
- [ ] Check completion, feedback, challenge intro, and challenge completion screens remain centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents tall step content in the player from being hidden behind the navbar by removing justify-based centering on scrollable containers and using my-auto for vertical centering. Short screens stay centered; long screens now scroll from the top.

- **Bug Fixes**
  - Updated `player-stage`, `stage-content`, `challenge-intro`, `feedback-screen`, `completion-screen`, `challenge-completion`, and `step-layouts` in `packages/player`.
  - Replaced `justify-center` with `my-auto` so overflow no longer starts above the viewport while preserving centering when content fits.

<sup>Written for commit 58bf6b4345ffd2ceb91e235e02dab56718f5b5eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

