### PR TITLE
fix(utils): capitalize first letter after stripping name placeholder

### DIFF
--- a/packages/utils/src/string.test.ts
+++ b/packages/utils/src/string.test.ts
@@ -500,7 +500,17 @@ describe(replaceNamePlaceholder, () => {
   });
 
   test("strips standalone {{NAME}} when name is null", () => {
-    expect(replaceNamePlaceholder("{{NAME}} welcome back", null)).toBe("welcome back");
+    expect(replaceNamePlaceholder("{{NAME}} welcome back", null)).toBe("Welcome back");
+  });
+
+  test("capitalizes first letter after stripping leading {{NAME}} with comma", () => {
+    expect(replaceNamePlaceholder("{{NAME}}, welcome back!", null)).toBe("Welcome back!");
+  });
+
+  test("does not double-capitalize when remainder already starts uppercase", () => {
+    expect(replaceNamePlaceholder("{{NAME}}, I think we have a problem.", null)).toBe(
+      "I think we have a problem.",
+    );
   });
 
   test("returns original text when no placeholder present", () => {

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -243,6 +243,22 @@ export function extractUniqueSentenceWords(sentences: string[]): string[] {
   return [...new Set(words)];
 }
 
+/**
+ * Capitalize the first letter of a string without mutating the rest.
+ * Needed after stripping a leading `{{NAME}}` placeholder so the
+ * remaining sentence still starts with an uppercase letter.
+ */
+function capitalizeFirst(text: string): string {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+/**
+ * Replace `{{NAME}}` placeholders with the user's display name.
+ * When the user is unauthenticated (`name` is null), strip the
+ * placeholder and any surrounding comma-space punctuation, then
+ * capitalize the result so sentences that started with `{{NAME}}`
+ * still begin with an uppercase letter.
+ */
 export function replaceNamePlaceholder(text: string, name: string | null): string {
   if (!text.includes(NAME_PLACEHOLDER)) {
     return text;
@@ -252,9 +268,11 @@ export function replaceNamePlaceholder(text: string, name: string | null): strin
     return text.replaceAll(NAME_PLACEHOLDER, name);
   }
 
-  return text
+  const stripped = text
     .replaceAll(/\{\{NAME\}\},\s*/g, "")
     .replaceAll(/,\s*\{\{NAME\}\}/g, "")
     .replaceAll(NAME_PLACEHOLDER, "")
     .trim();
+
+  return capitalizeFirst(stripped);
 }


### PR DESCRIPTION
## Summary

- When `{{NAME}}` is stripped for unauthenticated users, the remaining text could start with a lowercase letter (e.g. `"{{NAME}} welcome back"` → `"welcome back"`)
- Added `capitalizeFirst` helper applied after stripping, so the result is `"Welcome back"`

## Test plan

- [x] Updated existing test to expect capitalized output
- [x] Added test for leading `{{NAME}},` with comma stripping
- [x] Added test confirming no double-capitalization when remainder is already uppercase
- [x] All 88 string utility tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capitalize the first letter after stripping `{{NAME}}` so messages for unauthenticated users start with proper casing. Handles comma punctuation and avoids double-capitalization.

- **Bug Fixes**
  - Added `capitalizeFirst` in `replaceNamePlaceholder` after removing `{{NAME}}`.
  - Strip surrounding comma and spaces (e.g., `"{{NAME}}, "` and `", {{NAME}}"`).
  - Updated tests for capitalization, comma cases, and no double-capitalization.

<sup>Written for commit adbdb2fd1888ae17c5b031b3533e0b49e6e2adf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

