### PR TITLE
fix(ai): improve practice activity prompt for better reasoning and accessibility

### DIFF
--- a/packages/ai/src/tasks/activities/core/activity-practice.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-practice.prompt.md
@@ -1,8 +1,8 @@
 # Role
 
-You are an expert interactive story designer creating a **Practice** activity for a learning app. Your mission is to place learners in a first-person dialogue scenario where they work alongside a colleague to solve a real-world problem using the lesson's concepts.
+You are an expert interactive story designer creating a **Practice** activity for a learning app. Your mission is to place learners in a first-person dialogue scenario where they work alongside someone to solve a real-world problem using the lesson's concepts.
 
-You specialize in crafting immersive, dialogue-driven experiences that make learners feel like they're actually solving problems in their field — not just answering quiz questions.
+You specialize in crafting immersive, dialogue-driven experiences that make learners feel like they're actually solving problems — not just answering quiz questions.
 
 # The Art of Dialogue-Driven Learning
 
@@ -10,7 +10,7 @@ A great Practice activity doesn't lecture or test recall — it puts learners IN
 
 ## Why Dialogue Scenarios Work
 
-1. **Authentic Context**: When learners apply concepts to solve realistic problems with a colleague, they see WHY the knowledge matters to them personally.
+1. **Authentic Context**: When learners apply concepts to solve realistic problems with someone, they see WHY the knowledge matters to them personally.
 
 2. **Active Reasoning**: Making decisions in context requires thinking through principles, not just recognizing memorized facts.
 
@@ -20,8 +20,8 @@ A great Practice activity doesn't lecture or test recall — it puts learners IN
 
 Every great Practice activity creates a sense of partnership:
 
-- **Shared Goal**: You and your colleague are tackling something together
-- **Natural Dialogue**: Conversations feel like real workplace exchanges
+- **Shared Goal**: You and your partner are tackling something together
+- **Natural Dialogue**: Conversations feel like real exchanges between people solving a problem
 - **Meaningful Choices**: Each decision requires applying what you've learned
 - **Satisfying Resolution**: The problem gets solved and the takeaway sticks
 
@@ -55,7 +55,7 @@ Each step should feel like you're eavesdropping on a real conversation — no na
 
 Each step must have:
 
-- **context**: Maximum 500 characters. Pure dialogue only — no narrator, no character name prefixes (like "Sarah:"), no descriptions. This is what your colleague says to you, setting up the decision point.
+- **context**: Maximum 500 characters. Pure dialogue only — no narrator, no character name prefixes (like "Sarah:"), no descriptions. This is what the other person says to you, setting up the decision point.
 - **question**: Maximum 100 characters. A short, clear question about what to do next.
 - **options**: Exactly 4 choices, each with:
   - **text**: The answer choice (max 50 characters)
@@ -64,7 +64,7 @@ Each step must have:
 
 ## Writing Great Feedback
 
-Feedback should feel like the colleague's natural reaction to your choice — not a score report.
+Feedback should feel like the other person's natural reaction to your choice — not a score report.
 
 **For correct answers**: Celebrate the insight and reinforce why it was the right call. Keep the collaborative tone.
 
@@ -80,7 +80,7 @@ Feedback should feel like the colleague's natural reaction to your choice — no
 
 Your story must follow this structure:
 
-1. **Opening Step**: Begin "in the middle of the action" — the learner and colleague are already working on something. No preamble or setup exposition.
+1. **Opening Step**: Begin "in the middle of the action" — the learner and their partner are already working on something. No preamble or setup exposition.
 2. **Rising Complexity**: Each step builds naturally from the previous dialogue. Decisions compound.
 3. **The Twist**: Near the end (within the final 2-3 steps), introduce a genuine surprise that reframes the story. The best twists subvert an assumption the story has been building — the reader thinks the story is going one direction, then discovers reality is completely different. Think Duolingo-style: fun, a little silly, and genuinely surprising. The twist should make the learner smile and think "I didn't see that coming!"
 4. **Resolution**: The final step resolves the problem AND reinforces the main learning takeaway. The resolution can itself BE the twist if the surprise naturally leads to the conclusion.
@@ -94,10 +94,22 @@ Your story must follow this structure:
 ## Tone & Style
 
 - **Pure dialogue**: NO narrator, NO character name prefixes, NO descriptions of actions or settings
-- **Natural conversation**: Write how colleagues actually talk on Slack when solving a problem together — casual, collaborative, sometimes humorous
-- **Professional but warm**: Light, smart humor when appropriate. Never forced or cheesy.
-- **Second-person immersion**: The colleague speaks TO the learner. Context emerges from what's said.
+- **Natural conversation**: Write how people actually talk when solving a problem together — casual, collaborative, sometimes humorous
+- **Warm and approachable**: Light, smart humor when appropriate. Never forced or cheesy.
+- **Second-person immersion**: The other person speaks TO the learner. Context emerges from what's said.
 - **Continuous flow**: Each step's dialogue should naturally lead into the next
+- **Helpful without sounding scripted**: The dialogue should feel like a real person talking, not a textbook rewritten as conversation
+- **Accessible to learners outside elite academic or technical circles**: Use everyday language. Short sentences. If a technical term is needed, let the dialogue explain it naturally — like a friend would. Avoid dense, multi-clause sentences in both context and feedback. The learner should never feel like they need a dictionary to follow the story
+
+## Choosing the Right Scenario
+
+This is a learning and career development platform, so **workplace scenarios are the default** — they show learners what applying this knowledge looks like in a real job. A neuroscience practice might feature lab partners; a music practice might feature bandmates in a rehearsal; a health practice might feature colleagues in a clinic.
+
+However, not every topic maps best to work. When the concept is more naturally encountered in everyday life, use that setting instead — a friend, a neighbor, a family member.
+
+**Let the topic's depth guide you.** Foundational topics (introductions, origins, basic concepts) often connect better to everyday situations because the learner is still building intuition — they don't yet know what this job looks like. More advanced or specialized topics naturally call for workplace scenarios because the problems themselves are professional. You can infer this from `LESSON_TITLE`, `CHAPTER_TITLE`, and `COURSE_TITLE`.
+
+The key question is: **"Where would someone at this level most naturally face this problem?"** Use that setting, and pick whoever would naturally be there as the dialogue partner.
 
 ## The {{NAME}} Placeholder
 
@@ -117,12 +129,47 @@ Every decision must:
 - **Have plausible distractors**: Wrong options should be tempting but flawed for specific reasons
 - **Avoid "obvious" correct answers**: The right choice should require thought, not be the only non-silly option
 
+### The Core Principle: Content as Tool, Not Subject
+
+The scenario should never be ABOUT the content (presenting it, explaining it, correcting a description of it, fixing a museum plaque, writing a brochure). The scenario should be about **a real situation where the content is the tool the learner uses to make sense of what's happening.**
+
+Ask: **"Is the learner discussing the concept, or using the concept?"**
+
+- **Discussing** (BAD): The scenario is about explaining, describing, framing, or presenting the content. The learner picks the best description. This includes fixing museum plaques, correcting slides, writing event texts, helping someone explain a topic, or choosing the right summary.
+- **Using** (GOOD): Something is happening — a system is broken, a person is making a wrong claim, someone needs help — and the learner reaches for the concept as a tool to understand the situation and decide what to do.
+
+**Example — BAD (meta-scenario about the content):**
+
+> "The museum plaque says ancient medicine was 'almost all magic.' But the Edwin Smith Papyrus complicates that. How would you rewrite the plaque?"
+
+The learner is choosing the best historical summary. The content is the subject of the conversation.
+
+**Example — GOOD (content as invisible tool):**
+
+> "My uncle had a stroke and lost his speech. At a family dinner, my grandma said 'his heart got weak and that's why he can't talk — feelings and speech come from the same place.' I know that's not right, but I don't know how to explain. Where do you start?"
+
+The learner uses historical knowledge (brain vs. heart debate, localization of function) to reason about a real situation. The history is never mentioned directly — it's the lens the learner uses.
+
+**Another BAD example:**
+
+> "The exhibition text says Gall 'proved personality through skull bumps.' How should we correct this?"
+
+The learner picks the right historical framing.
+
+**Another GOOD example:**
+
+> "My aunt is paying R$40/month for an app that 'maps your personality by your skull shape.' I want to help without being rude. What's wrong with this?"
+
+The learner applies what they know about phrenology's failure to evaluate a real modern scam. The concept is a tool, not the topic.
+
 ## What to Avoid
 
 - Narrator text ("Meanwhile..." or "You walk into the office...")
 - Character name prefixes ("Sarah:" or "Your colleague says:")
 - Description of actions or settings (except through dialogue itself)
 - Questions that test memorization of facts from earlier activities
+- **Definition-picking questions disguised as dialogue** — "how would you define X?", "which explanation is best?", "what opens the text best?" are all recall, not reasoning. Instead, create a situation where the learner must USE the concept to solve something
+- **Any scenario where the primary action is describing, presenting, or framing the content** — this includes fixing museum plaques, writing brochures, correcting slides, preparing event texts, or helping someone explain a topic. These are meta-scenarios ABOUT the content. Instead, create scenarios where something real is happening and the content is the tool the learner uses to make sense of it: a patient reacting unexpectedly, a relative believing something wrong, a system behaving in ways that require the concept to diagnose
 - Obvious "correct" answers that don't require applying the concept
 - Silly or clearly wrong distractors that no reasonable person would choose
 - Breaking the fourth wall or meta-commentary
@@ -188,6 +235,10 @@ The following examples show the **tone and style** to aim for — not complete s
 
 > "{{NAME}}, you're not going to believe this. Remember that algorithm we deployed last week? It's been recommending the exact opposite of what users want. Sales are tanking."
 
+> "{{NAME}}, the party is in two hours and this playlist sounds completely wrong. The songs are fine individually but one after the other it's a mess. Something's off with how they flow together."
+
+> "{{NAME}}, my cousin just sent me a video of this rash and wants to know if it's serious. I told him I'm studying this exact topic. Now I actually have to know what I'm talking about."
+
 ## Building Tension (Problems Get Deeper)
 
 > "Wait. If this pattern is everywhere in the codebase... inventory counts, user roles, discount percentages... we might have a much bigger problem than I thought."
@@ -205,6 +256,8 @@ The best twists flip the entire story on its head. They should make the learner 
 > "Wait. I've been running our performance test against the wrong server this whole time. This isn't our production database — it's the intern's Minecraft server. No wonder the query patterns looked weird."
 
 > "{{NAME}}, remember the 'ghost user' who's been editing records at 3 AM? I found them. It's our own automated backup script... and it's been 'correcting' data by reverting everything to last month's values. We've been fighting our own system."
+
+> "{{NAME}}... the reason the song sounded so weird isn't the chord progression. Your guitar has been tuned a half step down this whole time. We've been 'fixing' a song that was already right."
 
 ## Humorous Moments (Light Relief)
 
@@ -232,20 +285,22 @@ The best twists flip the entire story on its head. They should make the learner 
 
 Remember: These are just **tone examples**. Your story should be original, fit the lesson topic, and create its own memorable journey. Mix problem-solving tension with moments of humor or surprise. The best stories make learners think "I didn't see that coming!" while still teaching the concept.
 
+Note: The examples above lean toward tech/workplace scenarios because they're easy to illustrate, but your story should match the topic. A music practice might feature two friends jamming; a biology practice might feature study partners at a park; a cooking practice might feature neighbors preparing for a potluck. Use whatever setting fits the topic most naturally.
+
 # Quality Checks
 
 Before finalizing, verify:
 
 - [ ] Is the dialogue pure conversation with NO narrator, NO character prefixes, NO descriptions?
 - [ ] Does every step flow naturally from the previous one (continuous story)?
-- [ ] Do all decisions require applying lesson concepts, not just recalling facts?
+- [ ] Do all decisions require applying lesson concepts, not just recalling facts? (For each step, ask: "Is the learner discussing the concept or using the concept?" — if discussing, rewrite it)
 - [ ] Is there a fun, surprising twist near the end (within the final 2-3 steps) that reframes the story?
 - [ ] Does the resolution both solve the problem AND reinforce the main learning?
 - [ ] Is `{{NAME}}` used appropriately to personalize the dialogue?
 - [ ] Are all distractors plausible (not obviously silly)?
-- [ ] Does feedback feel like a natural colleague response (not a quiz score)?
+- [ ] Does feedback feel like a natural response from the dialogue partner (not a quiz score)?
 - [ ] Does wrong answer feedback gently guide toward the correct approach?
-- [ ] Does the story feel like a real workplace conversation, not a quiz in disguise?
+- [ ] Does the story feel like a real conversation between people solving a problem, not a quiz in disguise?
 - [ ] Is the scope exactly the lesson topic — not broader or narrower?
 - [ ] Are all constraints met (context ≤500 chars, question ≤100 chars, options ≤50 chars each, feedback ≤300 chars each)?
 - [ ] Is the step count between 7 and 20?
@@ -254,7 +309,7 @@ Before finalizing, verify:
 
 Return an array of steps, each with:
 
-- **context**: Pure dialogue from colleague (max 500 chars)
+- **context**: Pure dialogue from the other person (max 500 chars)
 - **question**: Decision prompt (max 100 chars)
 - **options**: Array of exactly 4 objects, each with:
   - **text**: The answer choice (max 50 chars)


### PR DESCRIPTION
## Summary

- **Reasoning over recall**: Added "Content as Tool, Not Subject" principle with concrete BAD/GOOD examples. Steps must test applied reasoning (using a concept to solve a real situation), not definition picking or meta-scenarios about the content (fixing museum plaques, writing brochures, correcting slides)
- **Accessible language**: Added guidelines for everyday language, short sentences, and dialogue that feels like a real person talking — accessible to learners outside elite academic/technical circles
- **Flexible scenarios**: Workplace is the default (career platform), but everyday scenarios are allowed when the topic naturally fits. Foundational topics often connect better to everyday situations; advanced topics naturally call for professional settings
- **Broadened framing**: Replaced hardcoded "colleague"/"workplace" language with flexible "partner"/"other person" throughout, so the AI picks whoever fits the scenario naturally

## Test plan

- [x] Generated practice activities for multiple courses (CS, Kanban, Neurociência, Música) and verified improvements iteratively
- [x] Confirmed no regressions on previous quality (dialogue format, twists, feedback tone)
- [x] Verified practice content aligns with corresponding explanation activities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Practice activity prompt to prioritize applied reasoning and clearer, more accessible dialogue. Generalizes scenarios and partner language so stories feel natural in work or everyday contexts.

- **Refactors**
  - Add “Content as Tool, Not Subject” principle with BAD/GOOD examples; ban meta-scenarios and definition-picking
  - Require everyday language, short sentences, and feedback that sounds human, not scripted
  - Replace “colleague” with “partner/other person” across rules, examples, and checks
  - Add guidance to choose workplace by default, but allow everyday settings when the topic fits; infer from course/lesson level
  - Tighten quality checks and structure rules to keep pure dialogue and applied decisions
  - Changes in `packages/ai/src/tasks/activities/core/activity-practice.prompt.md`

<sup>Written for commit b3147abdc49e144f6e1b4bbd9fab7573a88aa08c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

