### PR TITLE
fix(ai): improve challenge activity prompt for better scenarios and dimensions

### DIFF
--- a/packages/ai/src/tasks/activities/core/activity-challenge.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-challenge.prompt.md
@@ -41,11 +41,11 @@ The `intro` field sets the scene (max 500 characters). It should:
 
 ## Steps
 
-Create 4-6 steps. Each step presents a decision point with 3-4 options.
+Create 4-6 steps. Each step presents a decision point with 3-4 options. **Vary the structure** — don't always default to 5 steps with 3 options each. Some challenges work better with 4 tight steps and 4 options per step; others need 6 steps with a mix of 3 and 4 options. Let the scenario's natural shape guide you.
 
 ### Step Structure
 
-- **context**: Maximum 500 characters. Pure dialogue from a colleague setting up the decision. Conversational, no narrator.
+- **context**: Maximum 500 characters. Pure dialogue from the other person setting up the decision. Conversational, no narrator.
 - **question**: Maximum 100 characters. What needs to be decided.
 - **options**: 3-4 choices, each with:
   - **text**: The choice (max 80 characters)
@@ -62,9 +62,26 @@ This is a core game mechanic: dimensions accumulate across the entire challenge 
 
 **How to choose dimensions:**
 
-1. Pick 2-4 aspects of the lesson that naturally create tension (e.g., for "Technical Debt": Code Quality vs. Delivery Speed vs. Team Morale)
-2. Write ALL steps using ONLY those dimensions
-3. Ensure every dimension appears in multiple steps so learners can recover
+1. Pick 2-4 aspects of the lesson that naturally create tension
+2. **Use the subject's own vocabulary** — dimensions should sound like terms a practitioner in that field would use, not generic project-management categories
+3. Write ALL steps using ONLY those dimensions
+4. Ensure every dimension appears in multiple steps so learners can recover
+
+**BAD — generic dimensions that could apply to any topic (DON'T DO THIS):**
+
+- "Clareza", "Engajamento", "Viabilidade"
+- "Clarity", "Engagement", "Feasibility"
+
+These are project-management categories, not domain knowledge. They teach nothing about the subject itself. The same dimensions could appear in a music challenge, a neuroscience challenge, or a cooking challenge — that's a red flag.
+
+**GOOD — domain-specific dimensions that teach the subject's real tensions (DO THIS):**
+
+- For "General Anesthesia": Hypnosis vs. Analgesia vs. Immobility (the actual clinical pillars)
+- For "Technical Debt": Code Quality vs. Delivery Speed vs. Team Morale
+- For "Beat and Tempo" in music: Rhythmic Precision vs. Musical Expression vs. Ensemble Cohesion
+- For "Kanban WIP Limits": Throughput vs. Lead Time vs. Team Focus
+
+The dimensions themselves should be educational — a learner who sees "Hypnosis vs. Analgesia vs. Immobility" is already learning that anesthesia has three distinct components.
 
 **BAD — different dimensions per step (DON'T DO THIS):**
 
@@ -101,12 +118,58 @@ The `reflection` field (max 500 characters) provides closing insight after all s
 - Connect the experience back to the lesson's key principles
 - Help learners understand how the concepts apply in practice
 
+## Choosing the Right Scenario
+
+### Content as Tool, Not Subject
+
+The scenario should never be ABOUT the content (presenting it, explaining it, planning how to teach it, organizing an event around it). The scenario should be about **a real situation where the content is the tool the learner uses to navigate trade-offs.**
+
+Ask: **"Is the learner discussing the concept, or using the concept?"**
+
+- **Discussing** (BAD): The scenario is about explaining, presenting, planning, or framing the content. The learner decides how to teach, communicate, or organize around the topic. This includes planning outreach events, designing teaching exercises, writing lab proposals, or presenting a method's history to a team.
+- **Using** (GOOD): Something real is happening — a system needs to be designed, a patient needs treatment, a performance needs to go well — and the learner reaches for the concept as a tool to navigate the trade-offs.
+
+**Example — BAD (meta-scenario about the content):**
+
+> "We need to design an activity that shows freshmen what Computer Science is. Should we start with machines or with symbols?"
+
+The learner is planning how to teach CS. The content is the subject of the conversation.
+
+**Example — GOOD (content as invisible tool):**
+
+> "The client wants us to automate their invoice workflow. We need to decide how to represent the data before we can process it. What structure do we use?"
+
+The learner uses CS concepts (representation, processing, automation) to solve a real problem. The concepts are tools, not the topic.
+
+**Another BAD example:**
+
+> "We need to present Kanban's origins to the team. Should we start with manufacturing history or the visual board everyone knows?"
+
+The learner is deciding how to teach Kanban.
+
+**Another GOOD example:**
+
+> "Our sprint board is a mess — 47 cards in 'In Progress' and nobody knows what's blocked. We need to fix this flow. Where do we start?"
+
+The learner uses Kanban concepts (WIP limits, flow, pull signals) to solve a real workflow problem.
+
+### Workplace vs. Everyday Scenarios
+
+This is a learning and career development platform, so **workplace scenarios are the default** — they show learners what applying this knowledge looks like in a real job. A neuroscience challenge might feature a clinical team managing a patient; a music challenge might feature bandmates preparing for a gig; a CS challenge might feature engineers designing a system.
+
+However, not every topic maps best to work. When the concept is more naturally encountered in everyday life, use that setting instead — a friend, a neighbor, a family member.
+
+**Let the topic's depth guide you.** Foundational topics (introductions, origins, basic concepts) often connect better to everyday situations because the learner is still building intuition — they don't yet know what this job looks like. More advanced or specialized topics naturally call for workplace scenarios because the problems themselves are professional. You can infer this from `LESSON_TITLE`, `CHAPTER_TITLE`, and `COURSE_TITLE`.
+
+The key question is: **"Where would someone at this level most naturally face this problem?"** Use that setting, and pick whoever would naturally be there as the dialogue partner.
+
 ## Tone & Style
 
 - **Pure dialogue**: NO narrator, NO character prefixes, NO action descriptions
-- **Natural conversation**: Colleagues working through a problem together
-- **Professional but warm**: Light humor when appropriate
-- **Second-person immersion**: The colleague speaks TO the learner
+- **Natural conversation**: People working through a problem together — casual, collaborative, sometimes humorous
+- **Warm and approachable**: Light humor when appropriate. Never forced or cheesy
+- **Second-person immersion**: The other person speaks TO the learner. Context emerges from what's said
+- **Accessible to learners outside elite academic or technical circles**: Use everyday language. Short sentences. If a technical term is needed, let the dialogue explain it naturally — like a friend would
 - **Use `{{NAME}}`** to personalize dialogue
 
 ## What to Avoid
@@ -117,6 +180,8 @@ The `reflection` field (max 500 characters) provides closing insight after all s
 - **Disconnected consequences**: Consequences should relate to lesson concepts
 - **Too many dimensions**: If you have more than 4 unique dimension names across ALL steps, you have too many. Go back and consolidate. Every dimension must appear in at least 2 steps
 - **Step-specific dimensions**: Never introduce a dimension that only appears in one step — it removes the learner's ability to recover
+- **Meta-scenarios about the content**: Never create scenarios where the learner is planning how to teach, present, or explain the topic. The learner should be USING the concepts to navigate a real situation, not discussing them. This includes planning outreach events, designing teaching exercises, writing proposals about the topic, or deciding how to present a method's history
+- **Generic dimensions**: Avoid catch-all categories like "Clarity", "Engagement", "Feasibility", or "Applicability" that could apply to any topic. Dimensions must be specific to the subject matter
 
 # Example
 
@@ -162,14 +227,16 @@ For a lesson on "Technical Debt":
 Before finalizing, verify:
 
 - [ ] Does the intro establish a clear, engaging scenario?
+- [ ] Is the learner USING the concepts to navigate a real situation (not discussing, teaching, or presenting them)?
 - [ ] Does every option have a meaningful consequence?
 - [ ] Are consequences connected to lesson principles?
 - [ ] Is there no obviously "best" option in each step?
 - [ ] Do options affect multiple dimensions where realistic?
 - [ ] Did you define exactly 2-4 dimensions BEFORE writing steps?
+- [ ] Are dimensions domain-specific (not generic categories like "Clarity" or "Engagement")?
 - [ ] Does every dimension appear in at least 2 different steps?
 - [ ] Are there ZERO dimensions that only appear in a single step?
-- [ ] Are dimension names identical across all effects (same spelling, same casing)?
+- [ ] **Dimension typo check**: Collect every dimension string from every effect in every step. Count the unique strings. If that count is higher than the number of dimensions you intended (2-4), you may have a typo somewhere — find it and fix it before continuing
 - [ ] Is `{{NAME}}` used appropriately?
 - [ ] Is all dialogue pure conversation (no narrator)?
 - [ ] Does the reflection tie the experience back to the lesson?


### PR DESCRIPTION
## Summary

- Require practitioner scenarios where the learner USES concepts to navigate trade-offs, not meta-scenarios about teaching/presenting the topic
- Require domain-specific dimensions (e.g., "Hypnosis vs. Analgesia vs. Immobility") instead of generic categories (e.g., "Clarity", "Engagement", "Feasibility")
- Encourage structural variety in step count (4-6) and option count (3-4) instead of always defaulting to 5×3
- Add workplace vs. everyday scenario guidance matching the practice prompt approach
- Improve dimension typo check with a concrete counting verification step
- Update tone/style for accessibility and inclusive language

## Test plan

- [x] Verified improved output by generating new challenges for 3 lessons and comparing with previous batch
- [ ] Re-run evals to confirm no regressions in challenge quality scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the challenge activity prompt in `packages/ai` to produce practitioner-first scenarios with domain-specific dimensions, varied step structures, and clearer, more accessible tone. Results in more realistic challenges and fewer generic outputs.

- **Refactors**
  - Require scenarios where learners use the concept to navigate trade‑offs; ban meta‑scenarios about teaching/presenting; add guidance for choosing workplace vs. everyday settings.
  - Enforce domain‑specific dimensions (with good/bad examples); require reuse across steps; forbid generic categories like “Clarity/Engagement/Feasibility.”
  - Encourage structural variety: 4–6 steps with 3–4 options; avoid defaulting to 5×3.
  - Improve validation: add a concrete dimension typo check by counting unique dimension strings; update the checklist accordingly.
  - Update tone/style: pure dialogue from “the other person,” inclusive and accessible language, professional but warm.

<sup>Written for commit 8fa6deb285e974546246b33aba946aa8a09b366c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

