### PR TITLE
fix(ai): add numbered suffix guidance to all curriculum prompts

### DIFF
--- a/packages/ai/src/tasks/chapters/chapter-lessons.prompt.md
+++ b/packages/ai/src/tasks/chapters/chapter-lessons.prompt.md
@@ -81,6 +81,7 @@ This is the most critical aspect. Each concept must be **one single, specific id
 
 - Describe the thematic group: e.g. "Phases of Mitosis", "DNA Replication Machinery"
 - **NEVER** use words like "learn", "understand", "explore", "introduction to", "basics of"
+- Avoid numbered suffixes like `I`, `II`, `III`, `Part 1`, `Part 2`. If a topic needs multiple lessons, add a specific subtitle that describes what each one covers — e.g., "Cell Division: Mitosis" and "Cell Division: Meiosis" instead of "Cell Division I" and "Cell Division II"
 - Go straight to the point
 
 ### Concept Titles

--- a/packages/ai/src/tasks/chapters/language-chapter-lessons.prompt.md
+++ b/packages/ai/src/tasks/chapters/language-chapter-lessons.prompt.md
@@ -84,6 +84,7 @@ This is the most critical aspect. Each concept must be **one single, specific la
 
 - Describe the thematic group: e.g. "Formal Greetings", "Present Tense: Regular -ar Verbs", "Nasal Vowels"
 - **NEVER** use words like "learn", "understand", "explore", "introduction to", "basics of"
+- Avoid numbered suffixes like `I`, `II`, `III`, `Part 1`, `Part 2`. If a topic needs multiple lessons, add a specific subtitle that describes what each one covers — e.g., "Ser: Singular Conjugation" and "Ser: Plural Conjugation" instead of "Ser I" and "Ser II"
 - Go straight to the point
 
 ### Concept Titles

--- a/packages/ai/src/tasks/courses/course-chapters.prompt.md
+++ b/packages/ai/src/tasks/courses/course-chapters.prompt.md
@@ -258,7 +258,7 @@ That means:
 
 - Short, specific, and concrete
 - Avoid rhetorical or bird's-eye-view titles that talk about the field from outside
-- Avoid numbered suffixes like `I`, `II`, `III`, `Part 1`, `Part 2`
+- Avoid numbered suffixes like `I`, `II`, `III`, `Part 1`, `Part 2`. If a topic needs multiple chapters, add a specific subtitle that describes what each one covers — e.g., "Organic Chemistry: Functional Groups" and "Organic Chemistry: Reaction Mechanisms" instead of "Organic Chemistry I" and "Organic Chemistry II"
 - If a shorter title is clear enough, prefer the shorter title
 
 ## Description

--- a/packages/ai/src/tasks/courses/language-course-chapters.prompt.md
+++ b/packages/ai/src/tasks/courses/language-course-chapters.prompt.md
@@ -81,8 +81,9 @@ Each chapter must include **exactly two fields**:
 Good chapter titles include:
 
 - "Basic Greetings", "Present Tense", "Food & Dining", "Past Tense", "Travel & Directions", "Subjunctive Mood"
-- Just "Present Tense" is better than "Present Tense Conjugation: Regular and Irregular Verbs" (too verbose)
+- Just "Present Tense" is better than "Present Tense Conjugation: Regular and Irregular Verbs" (too verbose — if one chapter covers the whole topic, keep the title simple)
 - "Numbers & Counting" is better than "An Introduction to Numbers and Counting Systems" (too verbose)
+- Avoid numbered suffixes like `I`, `II`, `III`, `Part 1`, `Part 2`. If a topic needs multiple chapters, add a specific subtitle that describes what each one covers — e.g., "Past Tense: Regular Verbs" and "Past Tense: Irregular Verbs" instead of "Past Tense I" and "Past Tense II"
 
 Bad chapter titles:
 


### PR DESCRIPTION
## Summary

- Adds "avoid numbered suffixes" rule to `chapter-lessons`, `language-course-chapters`, and `language-chapter-lessons` prompts (already existed in `course-chapters`)
- All four prompts now include guidance on what to do instead: use descriptive subtitles (e.g., "Organic Chemistry: Functional Groups" instead of "Organic Chemistry I")
- Clarifies verbose-title example in `language-course-chapters` to avoid conflicting with the new subtitle guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized title guidance across all curriculum prompts: avoid numbered suffixes (I, II, Part 1/2) and use descriptive subtitles instead. Updated `course-chapters`, `language-course-chapters`, `chapter-lessons`, and `language-chapter-lessons`, and clarified one verbose-title example to avoid conflicts.

<sup>Written for commit 6dcd8e21a0a990fad262a5ae57624bb34b6ba2c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

