### PR TITLE
chore(knip): remove unnecessary ignore config

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/knip/schema.json",
-  "ignore": ["**/*.d.**.ts", "**/codec.ts", ".agents/**", ".claude/**"],
+  "ignore": ["**/*.d.**.ts", "**/codec.ts"],
   "ignoreWorkspaces": ["packages/e2e!", "packages/testing!"],
   "ignoreBinaries": ["stripe", "build-and-start", "turbo!"],
   "ignoreDependencies": [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleaned up `knip` config by removing unnecessary ignore entries for `.agents/**` and `.claude/**`. These folders are now analyzed, reducing blind spots and keeping unused-code checks accurate.

<sup>Written for commit e7d6631e708f096ff004763fb2777d543b386e45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

