### PR TITLE
feat(player): prefetch player links

### DIFF
--- a/packages/player/src/player-link.tsx
+++ b/packages/player/src/player-link.tsx
@@ -11,5 +11,5 @@ type PlayerLinkProps = Omit<ComponentProps<typeof Link>, "href"> & {
 export function PlayerLink({ href, ...props }: PlayerLinkProps) {
   // Concrete route validation happens in the consuming app before href values
   // cross into the shared player package.
-  return <Link {...props} href={href as ComponentProps<typeof Link>["href"]} />;
+  return <Link prefetch {...props} href={href as ComponentProps<typeof Link>["href"]} />;
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable prefetch on `PlayerLink` so player routes are preloaded and navigation feels faster. This adds the `prefetch` prop to the underlying `Link` in `packages/player/src/player-link.tsx`.

<sup>Written for commit 0e4a14a01ae2eb6110e98bee116da2cad9199b42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

