### PR TITLE
refactor(player): compute completion metrics client-side for instant display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ i18n.cache
 # AI
 debug.log
 .claude/agent-memory
+.claude/plans
 
 # Tasks for AI agents
 /tasks/

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-player-client.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-player-client.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { ContentFeedback } from "@/components/feedback/content-feedback";
+import { type CompletionInput } from "@zoonk/player/completion-input-schema";
 import { type SerializedActivity } from "@zoonk/player/prepare-activity-data";
 import { PlayerProvider } from "@zoonk/player/provider";
 import { PlayerShell } from "@zoonk/player/shell";
 import { useRouter } from "next/navigation";
+import { useCallback } from "react";
 import { buildActivityPlayerModel } from "./activity-player-model";
 import { submitCompletion } from "./submit-completion-action";
 
@@ -17,6 +19,7 @@ export function ActivityPlayerClient({
   lessonSlug,
   nextActivity,
   nextSibling,
+  totalBrainPower,
   userEmail,
   userName,
 }: {
@@ -39,6 +42,7 @@ export function ActivityPlayerClient({
     lessonSlug: string;
     lessonTitle: string;
   } | null;
+  totalBrainPower: number;
   userEmail?: string;
   userName: string | null;
 }) {
@@ -54,14 +58,20 @@ export function ActivityPlayerClient({
   const onNextHref = model.onNextHref;
   const handleNext = onNextHref ? () => router.push(onNextHref) : undefined;
 
+  /** Fire-and-forget: the server validates and persists via `after()`. */
+  const handleComplete = useCallback((input: CompletionInput) => {
+    void submitCompletion(input);
+  }, []);
+
   return (
     <PlayerProvider
       activity={activity}
       milestone={model.milestone}
       navigation={model.navigation}
-      onComplete={submitCompletion}
+      onComplete={handleComplete}
       onEscape={() => router.push(model.navigation.lessonHref)}
       onNext={handleNext}
+      totalBrainPower={totalBrainPower}
       viewer={{
         completionFooter: (
           <ContentFeedback

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
@@ -4,6 +4,7 @@ import { getLessonSentences } from "@/data/activities/get-lesson-sentences";
 import { getLessonWords } from "@/data/activities/get-lesson-words";
 import { getSentenceWords } from "@/data/activities/get-sentence-words";
 import { getLesson } from "@/data/lessons/get-lesson";
+import { getTotalBrainPower } from "@/data/progress/get-total-brain-power";
 import { startActivity } from "@/data/progress/start-activity";
 import { getActivitySeoMeta } from "@/lib/activities";
 import { getNextActivityInCourse } from "@zoonk/core/activities/next-in-course";
@@ -68,6 +69,7 @@ export default async function ActivityPage({ params }: Props) {
     session,
     reviewSteps,
     nextSibling,
+    totalBrainPower,
   ] = await Promise.all([
     getActivity({ lessonId: lesson.id, position: activityPosition }),
     getLessonWords({ lessonId: lesson.id }),
@@ -85,6 +87,7 @@ export default async function ActivityPage({ params }: Props) {
     getSession(),
     fetchReviewSteps(lesson.id, activityPosition),
     fetchNextSibling(lesson.id, activityPosition, lessonSlug, lesson.chapter, lesson.position),
+    getTotalBrainPower(),
   ]);
 
   if (!activity) {
@@ -121,6 +124,7 @@ export default async function ActivityPage({ params }: Props) {
       lessonSlug={lessonSlug}
       nextActivity={nextActivity}
       nextSibling={nextSibling}
+      totalBrainPower={totalBrainPower}
       userEmail={session?.user.email}
       userName={session?.user.name ?? null}
     />

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
@@ -5,16 +5,11 @@ import { preloadNextLesson } from "@/data/progress/preload-next-lesson";
 import { submitActivityCompletion } from "@/data/progress/submit-activity-completion";
 import { auth } from "@zoonk/core/auth";
 import { prisma } from "@zoonk/db";
-import {
-  type CompletionInput,
-  type CompletionResult,
-  completionInputSchema,
-} from "@zoonk/player/completion-input-schema";
+import { type CompletionInput, completionInputSchema } from "@zoonk/player/completion-input-schema";
 import { computeChallengeScore, computeScore } from "@zoonk/player/compute-score";
 import { computeDimensions, hasNegativeDimension } from "@zoonk/player/dimensions";
 import { validateAnswers } from "@zoonk/player/validate-answers";
-import { calculateBeltLevel } from "@zoonk/utils/belt-level";
-import { safeAsync } from "@zoonk/utils/error";
+import { logError } from "@zoonk/utils/logger";
 import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 import { after } from "next/server";
@@ -26,11 +21,18 @@ function clampDuration(startedAt: number): number {
   return Math.max(0, Math.min(raw, MAX_DURATION_SECONDS));
 }
 
-export async function submitCompletion(rawInput: CompletionInput): Promise<CompletionResult> {
+/**
+ * Validates and persists an activity completion in the background.
+ *
+ * The client computes metrics (BP, energy, belt) locally for instant display.
+ * This server action handles the authoritative validation and DB persistence
+ * via `after()`, so the response returns immediately after the auth check.
+ */
+export async function submitCompletion(rawInput: CompletionInput): Promise<void> {
   const parsed = completionInputSchema.safeParse(rawInput);
 
   if (!parsed.success) {
-    return { status: "error" };
+    return;
   }
 
   const input = parsed.data;
@@ -39,16 +41,15 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
   const session = await auth.api.getSession({ headers: reqHeaders });
 
   if (!session) {
-    return { status: "unauthenticated" };
+    return;
   }
 
   const userId = Number(session.user.id);
-
   const activityId = BigInt(input.activityId);
 
-  const { data, error } = await safeAsync(async () => {
-    const [activity, userProgress] = await Promise.all([
-      prisma.activity.findUnique({
+  after(async () => {
+    try {
+      const activity = await prisma.activity.findUnique({
         include: {
           lesson: { include: { chapter: true } },
           steps: {
@@ -58,57 +59,54 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
           },
         },
         where: { id: activityId },
-      }),
-      prisma.userProgress.findUnique({ where: { userId } }),
-    ]);
+      });
 
-    if (!activity) {
-      return null;
-    }
+      if (!activity) {
+        logError(`[submitCompletion] Activity ${activityId} not found`);
+        return;
+      }
 
-    const stepsForValidation =
-      activity.kind === "review"
-        ? await getReviewValidationSteps(activity.lessonId, Object.keys(input.answers).map(BigInt))
-        : activity.steps;
+      const stepsForValidation =
+        activity.kind === "review"
+          ? await getReviewValidationSteps(
+              activity.lessonId,
+              Object.keys(input.answers).map(BigInt),
+            )
+          : activity.steps;
 
-    const stepResults = validateAnswers(stepsForValidation, input.answers);
-    const isChallenge = activity.kind === "challenge";
+      const stepResults = validateAnswers(stepsForValidation, input.answers);
+      const isChallenge = activity.kind === "challenge";
 
-    const dimensions = isChallenge
-      ? computeDimensions(stepResults.map((result) => result.effects))
-      : {};
+      const dimensions = isChallenge
+        ? computeDimensions(stepResults.map((result) => result.effects))
+        : {};
 
-    const isSuccessful = !hasNegativeDimension(dimensions);
+      const isSuccessful = !hasNegativeDimension(dimensions);
 
-    const score = isChallenge
-      ? computeChallengeScore({ dimensions, isSuccessful })
-      : computeScore({
-          results: stepResults.map((step) => ({ isCorrect: step.isCorrect })),
-        });
+      const score = isChallenge
+        ? computeChallengeScore({ dimensions, isSuccessful })
+        : computeScore({
+            results: stepResults.map((step) => ({ isCorrect: step.isCorrect })),
+          });
 
-    const durationSeconds = clampDuration(input.startedAt);
+      const durationSeconds = clampDuration(input.startedAt);
 
-    const mergedStepResults = stepResults.map((validated) => {
-      const stepId = String(validated.stepId);
-      const timing = input.stepTimings[stepId];
+      const mergedStepResults = stepResults.map((validated) => {
+        const stepId = String(validated.stepId);
+        const timing = input.stepTimings[stepId];
 
-      return {
-        answer: validated.answer,
-        answeredAt: timing ? new Date(timing.answeredAt) : new Date(),
-        dayOfWeek: timing?.dayOfWeek ?? new Date().getDay(),
-        durationSeconds: timing?.durationSeconds ?? 0,
-        effects: validated.effects,
-        hourOfDay: timing?.hourOfDay ?? new Date().getHours(),
-        isCorrect: validated.isCorrect,
-        stepId: validated.stepId,
-      };
-    });
+        return {
+          answer: validated.answer,
+          answeredAt: timing ? new Date(timing.answeredAt) : new Date(),
+          dayOfWeek: timing?.dayOfWeek ?? new Date().getDay(),
+          durationSeconds: timing?.durationSeconds ?? 0,
+          effects: validated.effects,
+          hourOfDay: timing?.hourOfDay ?? new Date().getHours(),
+          isCorrect: validated.isCorrect,
+          stepId: validated.stepId,
+        };
+      });
 
-    const newTotalBp = Number(userProgress?.totalBrainPower ?? 0) + score.brainPower;
-
-    // Persist progress in the background so the user sees results instantly
-    // instead of waiting for the DB transaction to complete.
-    after(async () => {
       await submitActivityCompletion({
         activityId: activity.id,
         courseId: activity.lesson.chapter.courseId,
@@ -124,25 +122,8 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<Compl
 
       revalidatePath("/");
       await preloadNextLesson(activityId, reqHeaders.get("cookie") ?? "");
-    });
-
-    return {
-      belt: calculateBeltLevel(newTotalBp),
-      brainPower: score.brainPower,
-      energyDelta: score.energyDelta,
-      newTotalBp,
-    };
+    } catch (error) {
+      logError("[submitCompletion] Failed to persist activity completion:", error);
+    }
   });
-
-  if (error || !data) {
-    return { status: "error" };
-  }
-
-  return {
-    belt: data.belt,
-    brainPower: data.brainPower,
-    energyDelta: data.energyDelta,
-    newTotalBp: data.newTotalBp,
-    status: "success",
-  };
 }

--- a/apps/main/src/data/progress/get-total-brain-power.test.ts
+++ b/apps/main/src/data/progress/get-total-brain-power.test.ts
@@ -1,0 +1,40 @@
+import { prisma } from "@zoonk/db";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { beforeAll, describe, expect, test } from "vitest";
+import { getTotalBrainPower } from "./get-total-brain-power";
+
+describe("unauthenticated users", () => {
+  test("returns 0", async () => {
+    const result = await getTotalBrainPower(new Headers());
+    expect(result).toBe(0);
+  });
+});
+
+describe("authenticated users", () => {
+  let headers: Headers;
+  let userId: number;
+
+  beforeAll(async () => {
+    const user = await userFixture();
+    headers = await signInAs(user.email, user.password);
+    userId = Number(user.id);
+  });
+
+  test("returns 0 when user has no progress record", async () => {
+    const result = await getTotalBrainPower(headers);
+    expect(result).toBe(0);
+  });
+
+  test("returns total brain power from progress record", async () => {
+    await prisma.userProgress.create({
+      data: {
+        totalBrainPower: BigInt(2500),
+        userId,
+      },
+    });
+
+    const result = await getTotalBrainPower(headers);
+    expect(result).toBe(2500);
+  });
+});

--- a/apps/main/src/data/progress/get-total-brain-power.ts
+++ b/apps/main/src/data/progress/get-total-brain-power.ts
@@ -1,0 +1,26 @@
+import "server-only";
+import { getSession } from "@zoonk/core/users/session/get";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+/**
+ * Returns the total brain power accumulated by the current user.
+ *
+ * Used at activity page load to pass to the player, which computes
+ * completion metrics (belt level, BP to next level) client-side for
+ * instant display without waiting for a server round-trip.
+ */
+export const getTotalBrainPower = cache(async (headers?: Headers): Promise<number> => {
+  const session = await getSession(headers);
+
+  if (!session) {
+    return 0;
+  }
+
+  const progress = await prisma.userProgress.findUnique({
+    select: { totalBrainPower: true },
+    where: { userId: Number(session.user.id) },
+  });
+
+  return Number(progress?.totalBrainPower ?? 0);
+});

--- a/packages/player/src/completion-input-schema.ts
+++ b/packages/player/src/completion-input-schema.ts
@@ -77,13 +77,9 @@ export const completionInputSchema = z.object({
 
 export type CompletionInput = z.infer<typeof completionInputSchema>;
 
-export type CompletionResult =
-  | {
-      status: "success";
-      belt: BeltLevelResult;
-      brainPower: number;
-      energyDelta: number;
-      newTotalBp: number;
-    }
-  | { status: "error" }
-  | { status: "unauthenticated" };
+export type CompletionResult = {
+  belt: BeltLevelResult;
+  brainPower: number;
+  energyDelta: number;
+  newTotalBp: number;
+};

--- a/packages/player/src/components/belt-progress.tsx
+++ b/packages/player/src/components/belt-progress.tsx
@@ -2,7 +2,6 @@
 
 import { BeltIndicator, beltColorClasses } from "@zoonk/ui/components/belt-indicator";
 import { ProgressIndicator, ProgressRoot, ProgressTrack } from "@zoonk/ui/components/progress";
-import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { cn } from "@zoonk/ui/lib/utils";
 import { calculateBeltLevel, getBeltProgressPercent } from "@zoonk/utils/belt-level";
 import { useExtracted } from "next-intl";
@@ -121,18 +120,5 @@ export function BeltProgressHint({
         {t("{value} BP to level up", { value: String(currentBelt.bpToNextLevel) })}
       </span>
     </PlayerLink>
-  );
-}
-
-export function BeltProgressSkeleton() {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex items-center gap-1.5">
-        <Skeleton className="size-3 rounded-full" />
-        <Skeleton className="h-4 w-36" />
-      </div>
-      <Skeleton className="h-1.5 w-full rounded-4xl" />
-      <Skeleton className="h-3 w-16" />
-    </div>
   );
 }

--- a/packages/player/src/components/challenge-completion.tsx
+++ b/packages/player/src/components/challenge-completion.tsx
@@ -6,10 +6,10 @@ import { useExtracted } from "next-intl";
 import { type CompletionResult } from "../completion-input-schema";
 import { type PlayerRoute, usePlayerViewer } from "../player-context";
 import { type DimensionInventory } from "../player-reducer";
-import { BeltProgressHint, BeltProgressSkeleton } from "./belt-progress";
+import { BeltProgressHint } from "./belt-progress";
 import { PrimaryKbd, SecondaryActionLink } from "./completion-action-link";
 import { DimensionList, buildDimensionEntries } from "./dimension-inventory";
-import { RewardBadges, RewardBadgesSkeleton } from "./reward-badges";
+import { RewardBadges } from "./reward-badges";
 
 function ChallengeScreen({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -33,39 +33,6 @@ function ChallengeActions({ className, ...props }: React.ComponentProps<"div">) 
       data-slot="completion-actions"
       {...props}
     />
-  );
-}
-
-function ChallengeRewardBadges({
-  completionResult,
-  isSuccess,
-}: {
-  completionResult: CompletionResult | null;
-  isSuccess: boolean;
-}) {
-  if (!completionResult || completionResult.status !== "success") {
-    return (
-      <>
-        <RewardBadgesSkeleton />
-        {isSuccess && <BeltProgressSkeleton />}
-      </>
-    );
-  }
-
-  return (
-    <>
-      <RewardBadges
-        brainPower={completionResult.brainPower}
-        energyDelta={completionResult.energyDelta}
-        isChallenge={isSuccess}
-      />
-      {isSuccess && (
-        <BeltProgressHint
-          brainPower={completionResult.brainPower}
-          newTotalBp={completionResult.newTotalBp}
-        />
-      )}
-    </>
   );
 }
 
@@ -121,7 +88,19 @@ export function ChallengeSuccessContent({
 
       <DimensionList aria-label={t("Final scores")} entries={entries} variant="success" />
 
-      {isAuthenticated && <ChallengeRewardBadges completionResult={completionResult} isSuccess />}
+      {isAuthenticated && completionResult && (
+        <>
+          <RewardBadges
+            brainPower={completionResult.brainPower}
+            energyDelta={completionResult.energyDelta}
+            isChallenge
+          />
+          <BeltProgressHint
+            brainPower={completionResult.brainPower}
+            newTotalBp={completionResult.newTotalBp}
+          />
+        </>
+      )}
 
       {children}
 
@@ -159,8 +138,12 @@ export function ChallengeFailureContent({
 
       <DimensionList aria-label={t("Final scores")} entries={entries} variant="failure" />
 
-      {isAuthenticated && (
-        <ChallengeRewardBadges completionResult={completionResult} isSuccess={false} />
+      {isAuthenticated && completionResult && (
+        <RewardBadges
+          brainPower={completionResult.brainPower}
+          energyDelta={completionResult.energyDelta}
+          isChallenge={false}
+        />
       )}
 
       <ChallengeActions>

--- a/packages/player/src/components/completion-auth-branch.tsx
+++ b/packages/player/src/components/completion-auth-branch.tsx
@@ -11,10 +11,10 @@ import {
   usePlayerViewer,
 } from "../player-context";
 import { PlayerLink } from "../player-link";
-import { BeltProgressHint, BeltProgressSkeleton } from "./belt-progress";
+import { BeltProgressHint } from "./belt-progress";
 import { PrimaryActionLink, PrimaryKbd, SecondaryKbd } from "./completion-action-link";
 import { MilestoneActions, UnauthenticatedMilestoneActions } from "./completion-milestone-actions";
-import { RewardBadges, RewardBadgesSkeleton } from "./reward-badges";
+import { RewardBadges } from "./reward-badges";
 
 function CompletionActions({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -100,8 +100,6 @@ function AuthenticatedContent({
   const t = useExtracted();
   const milestone = usePlayerMilestone();
 
-  const isLoading = !completionResult || completionResult.status !== "success";
-
   if (milestone.kind !== "activity") {
     return (
       <CompletionActions>
@@ -112,25 +110,19 @@ function AuthenticatedContent({
 
   return (
     <>
-      {showRewards &&
-        (isLoading ? (
-          <>
-            <RewardBadgesSkeleton />
-            <BeltProgressSkeleton />
-          </>
-        ) : (
-          <>
-            <RewardBadges
-              brainPower={completionResult.brainPower}
-              energyDelta={completionResult.energyDelta}
-              isChallenge={false}
-            />
-            <BeltProgressHint
-              brainPower={completionResult.brainPower}
-              newTotalBp={completionResult.newTotalBp}
-            />
-          </>
-        ))}
+      {showRewards && completionResult && (
+        <>
+          <RewardBadges
+            brainPower={completionResult.brainPower}
+            energyDelta={completionResult.energyDelta}
+            isChallenge={false}
+          />
+          <BeltProgressHint
+            brainPower={completionResult.brainPower}
+            newTotalBp={completionResult.newTotalBp}
+          />
+        </>
+      )}
 
       <CompletionActions>
         {nextActivityHref ? (

--- a/packages/player/src/components/reward-badges.tsx
+++ b/packages/player/src/components/reward-badges.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Badge } from "@zoonk/ui/components/badge";
-import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { cn } from "@zoonk/ui/lib/utils";
 import { BrainIcon, ZapIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
@@ -40,15 +39,6 @@ export function RewardBadges({
         </span>
         <span className="sr-only">{t("Energy")}</span>
       </Badge>
-    </div>
-  );
-}
-
-export function RewardBadgesSkeleton() {
-  return (
-    <div className="flex gap-2">
-      <Skeleton className="h-5 w-20" />
-      <Skeleton className="h-5 w-16" />
     </div>
   );
 }

--- a/packages/player/src/player-completion.ts
+++ b/packages/player/src/player-completion.ts
@@ -1,45 +1,35 @@
+import { calculateBeltLevel } from "@zoonk/utils/belt-level";
 import { type CompletionResult } from "./completion-input-schema";
+import { computeChallengeScore, computeScore } from "./compute-score";
+import { hasNegativeDimension } from "./dimensions";
 import { type PlayerState } from "./player-reducer";
 
-export type PlayerCompletionState =
-  | { status: "idle" }
-  | { status: "submitting" }
-  | CompletionResult;
+/**
+ * Computes the completion result from local player state.
+ *
+ * All inputs (correct/incorrect answers, dimensions, totalBrainPower) are
+ * already available on the client, so we can show metrics instantly without
+ * waiting for a server round-trip. The server still validates and persists
+ * in the background via `after()`.
+ */
+export function computeLocalCompletion(state: PlayerState): CompletionResult {
+  const isChallenge = Object.keys(state.dimensions).length > 0;
+  const isSuccessful = !hasNegativeDimension(state.dimensions);
 
-export function createIdleCompletionState(): PlayerCompletionState {
-  return { status: "idle" };
-}
+  const score = isChallenge
+    ? computeChallengeScore({ dimensions: state.dimensions, isSuccessful })
+    : computeScore({
+        results: Object.values(state.results).map((stepResult) => ({
+          isCorrect: stepResult.result.isCorrect,
+        })),
+      });
 
-export function handleSubmitCompletion(state: PlayerState, requestId: number): PlayerState {
-  return {
-    ...state,
-    completion: { status: "submitting" },
-    completionRequestId: requestId,
-  };
-}
-
-export function handleResolveCompletion(
-  state: PlayerState,
-  requestId: number,
-  result: CompletionResult,
-): PlayerState {
-  if (requestId !== state.completionRequestId) {
-    return state;
-  }
+  const newTotalBp = state.totalBrainPower + score.brainPower;
 
   return {
-    ...state,
-    completion: result,
-  };
-}
-
-export function handleRejectCompletion(state: PlayerState, requestId: number): PlayerState {
-  if (requestId !== state.completionRequestId) {
-    return state;
-  }
-
-  return {
-    ...state,
-    completion: { status: "error" },
+    belt: calculateBeltLevel(newTotalBp),
+    brainPower: score.brainPower,
+    energyDelta: score.energyDelta,
+    newTotalBp,
   };
 }

--- a/packages/player/src/player-controller.test.ts
+++ b/packages/player/src/player-controller.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, test } from "vitest";
-import {
-  buildCompletionInput,
-  getPlayerTransition,
-  getSubmitCompletionRequestId,
-} from "./player-controller";
+import { buildCompletionInput, getPlayerTransition } from "./player-controller";
 import { type PlayerAction, type PlayerState } from "./player-reducer";
 import { type SerializedStep } from "./prepare-activity-data";
 
@@ -29,8 +25,7 @@ function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
 function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
   return {
     activityId: "activity-1",
-    completion: { status: "idle" },
-    completionRequestId: 0,
+    completion: null,
     currentStepIndex: 0,
     dimensions: {},
     phase: "playing",
@@ -41,12 +36,13 @@ function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
     stepStartedAt: 2000,
     stepTimings: {},
     steps: [buildStep()],
+    totalBrainPower: 0,
     ...overrides,
   };
 }
 
 describe(getPlayerTransition, () => {
-  test("marks completion submission when feedback continues into completion", () => {
+  test("marks persistence when feedback continues into completion", () => {
     const state = buildState({
       phase: "feedback",
       steps: [buildStep()],
@@ -55,10 +51,10 @@ describe(getPlayerTransition, () => {
     const transition = getPlayerTransition(state, { type: "CONTINUE" });
 
     expect(transition.nextState.phase).toBe("completed");
-    expect(transition.shouldSubmitCompletion).toBe(true);
+    expect(transition.shouldPersistCompletion).toBe(true);
   });
 
-  test("marks completion submission when static navigation reaches the last step", () => {
+  test("marks persistence when static navigation reaches the last step", () => {
     const steps = [buildStep({ id: "step-1" }), buildStep({ id: "step-2", position: 1 })];
     const state = buildState({
       currentStepIndex: 1,
@@ -71,10 +67,10 @@ describe(getPlayerTransition, () => {
     });
 
     expect(transition.nextState.phase).toBe("completed");
-    expect(transition.shouldSubmitCompletion).toBe(true);
+    expect(transition.shouldPersistCompletion).toBe(true);
   });
 
-  test("does not submit completion for non-terminal actions", () => {
+  test("does not persist completion for non-terminal actions", () => {
     const action: PlayerAction = {
       answer: { kind: "multipleChoice", selectedIndex: 0, selectedText: "A" },
       stepId: "step-1",
@@ -83,7 +79,7 @@ describe(getPlayerTransition, () => {
 
     const transition = getPlayerTransition(buildState(), action);
 
-    expect(transition.shouldSubmitCompletion).toBe(false);
+    expect(transition.shouldPersistCompletion).toBe(false);
   });
 });
 
@@ -123,11 +119,5 @@ describe(buildCompletionInput, () => {
         },
       },
     });
-  });
-});
-
-describe(getSubmitCompletionRequestId, () => {
-  test("increments the request id for the next submission", () => {
-    expect(getSubmitCompletionRequestId(buildState({ completionRequestId: 4 }))).toBe(5);
   });
 });

--- a/packages/player/src/player-controller.ts
+++ b/packages/player/src/player-controller.ts
@@ -16,18 +16,11 @@ export function buildCompletionInput(state: PlayerState, now: Date = new Date())
   };
 }
 
-export function getSubmitCompletionRequestId(state: PlayerState): number {
-  return state.completionRequestId + 1;
-}
-
 export function getPlayerTransition(state: PlayerState, action: PlayerAction) {
   const nextState = playerReducer(state, action);
 
   return {
     nextState,
-    shouldSubmitCompletion:
-      state.phase !== "completed" &&
-      nextState.phase === "completed" &&
-      state.completion.status === "idle",
+    shouldPersistCompletion: state.phase !== "completed" && nextState.phase === "completed",
   };
 }

--- a/packages/player/src/player-initial-state.ts
+++ b/packages/player/src/player-initial-state.ts
@@ -1,5 +1,4 @@
 import { type ChallengeEffect, parseStepContent } from "@zoonk/core/steps/content-contract";
-import { createIdleCompletionState } from "./player-completion";
 import {
   type DimensionInventory,
   type PlayerPhase,
@@ -48,14 +47,18 @@ function getInitialPhase(steps: SerializedStep[], dimensions: DimensionInventory
   return "playing";
 }
 
-export function createInitialState(activity: SerializedActivity): PlayerState {
+export type InitialStateInput = {
+  activity: SerializedActivity;
+  totalBrainPower: number;
+};
+
+export function createInitialState({ activity, totalBrainPower }: InitialStateInput): PlayerState {
   const dimensions = collectAllDimensions(activity.steps);
   const now = Date.now();
 
   return {
     activityId: activity.id,
-    completion: createIdleCompletionState(),
-    completionRequestId: 0,
+    completion: null,
     currentStepIndex: 0,
     dimensions,
     phase: getInitialPhase(activity.steps, dimensions),
@@ -66,5 +69,6 @@ export function createInitialState(activity: SerializedActivity): PlayerState {
     stepStartedAt: now,
     stepTimings: {},
     steps: activity.steps,
+    totalBrainPower,
   };
 }

--- a/packages/player/src/player-provider.tsx
+++ b/packages/player/src/player-provider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useReducer } from "react";
-import { type CompletionInput, type CompletionResult } from "./completion-input-schema";
+import { type CompletionInput } from "./completion-input-schema";
 import {
   PlayerConfigContext,
   type PlayerMilestone,
@@ -9,6 +9,7 @@ import {
   PlayerRuntimeContext,
   type PlayerViewer,
 } from "./player-context";
+import { type InitialStateInput } from "./player-initial-state";
 import { createInitialState, playerReducer } from "./player-reducer";
 import {
   getCanNavigatePrev,
@@ -29,18 +30,24 @@ export function PlayerProvider({
   onComplete,
   onEscape,
   onNext,
+  totalBrainPower,
   viewer,
 }: {
   activity: SerializedActivity;
   children: React.ReactNode;
   milestone: PlayerMilestone;
   navigation: PlayerNavigation;
-  onComplete: (input: CompletionInput) => Promise<CompletionResult>;
+  onComplete: (input: CompletionInput) => void;
   onEscape: () => void;
   onNext?: () => void;
+  totalBrainPower: number;
   viewer: PlayerViewer;
 }) {
-  const [state, dispatch] = useReducer(playerReducer, activity, createInitialState);
+  const initInput: InitialStateInput = useMemo(
+    () => ({ activity, totalBrainPower }),
+    [activity, totalBrainPower],
+  );
+  const [state, dispatch] = useReducer(playerReducer, initInput, createInitialState);
   const actions = usePlayerActions(state, dispatch, onComplete, viewer.isAuthenticated);
 
   const handleNext = useCallback(() => {

--- a/packages/player/src/player-reducer.test.ts
+++ b/packages/player/src/player-reducer.test.ts
@@ -57,8 +57,7 @@ function buildActivity(overrides: Partial<SerializedActivity> = {}): SerializedA
 function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
   return {
     activityId: "activity-1",
-    completion: { status: "idle" },
-    completionRequestId: 0,
+    completion: null,
     currentStepIndex: 0,
     dimensions: {},
     phase: "playing",
@@ -69,6 +68,7 @@ function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
     stepStartedAt: 1000,
     stepTimings: {},
     steps: [buildStep()],
+    totalBrainPower: 0,
     ...overrides,
   };
 }
@@ -109,40 +109,45 @@ function buildChallengeActivity(): SerializedActivity {
 describe(createInitialState, () => {
   test("sets phase to playing and index to 0 for non-challenge", () => {
     const activity = buildActivity();
-    const state = createInitialState(activity);
+    const state = createInitialState({ activity, totalBrainPower: 0 });
     expect(state.phase).toBe("playing");
     expect(state.currentStepIndex).toBe(0);
   });
 
   test("sets phase to intro for challenge activity", () => {
-    const state = createInitialState(buildChallengeActivity());
+    const state = createInitialState({ activity: buildChallengeActivity(), totalBrainPower: 0 });
     expect(state.phase).toBe("intro");
   });
 
   test("copies activityId and steps", () => {
     const steps = [buildStep({ id: "s1" }), buildStep({ id: "s2", position: 1 })];
     const activity = buildActivity({ steps });
-    const state = createInitialState(activity);
+    const state = createInitialState({ activity, totalBrainPower: 0 });
     expect(state.activityId).toBe("activity-1");
     expect(state.steps).toEqual(steps);
   });
 
   test("initializes empty maps for non-challenge activity", () => {
-    const state = createInitialState(buildActivity());
+    const state = createInitialState({ activity: buildActivity(), totalBrainPower: 0 });
     expect(state.selectedAnswers).toEqual({});
     expect(state.results).toEqual({});
     expect(state.dimensions).toEqual({});
   });
 
   test("collects all dimensions from challenge steps at init", () => {
-    const state = createInitialState(buildChallengeActivity());
+    const state = createInitialState({ activity: buildChallengeActivity(), totalBrainPower: 0 });
     expect(state.dimensions).toEqual({ Courage: 0, Diplomacy: 0 });
+  });
+
+  test("stores totalBrainPower from input", () => {
+    const state = createInitialState({ activity: buildActivity(), totalBrainPower: 500 });
+    expect(state.totalBrainPower).toBe(500);
   });
 
   test("pre-populates selectedAnswers for sortOrder steps", () => {
     const sortItems = ["Banana", "Apple", "Cherry"];
     const steps = [buildStep({ id: "sort-1", kind: "sortOrder", sortOrderItems: sortItems })];
-    const state = createInitialState(buildActivity({ steps }));
+    const state = createInitialState({ activity: buildActivity({ steps }), totalBrainPower: 0 });
     expect(state.selectedAnswers["sort-1"]).toEqual({
       kind: "sortOrder",
       userOrder: sortItems,
@@ -154,7 +159,7 @@ describe(createInitialState, () => {
       buildStep({ id: "s1", kind: "static" }),
       buildMultipleChoiceStep({ id: "mc-1" }),
     ];
-    const state = createInitialState(buildActivity({ steps }));
+    const state = createInitialState({ activity: buildActivity({ steps }), totalBrainPower: 0 });
     expect(state.selectedAnswers).toEqual({});
   });
 });
@@ -522,71 +527,110 @@ describe("COMPLETE", () => {
   });
 });
 
-describe("completion submission state", () => {
-  test("tracks the current submission request id while submitting", () => {
-    const next = playerReducer(buildState(), {
-      requestId: 7,
-      type: "SUBMIT_COMPLETION",
-    });
-
-    expect(next.completion).toEqual({ status: "submitting" });
-    expect(next.completionRequestId).toBe(7);
-  });
-
-  test("stores the latest resolved completion result", () => {
-    const next = playerReducer(
-      buildState({ completion: { status: "submitting" }, completionRequestId: 2 }),
-      {
-        requestId: 2,
-        result: {
-          belt: {
-            bpPerLevel: 250,
-            bpToNextLevel: 240,
-            color: "white",
-            isMaxLevel: false,
-            level: 1,
-            progressInLevel: 10,
-          },
-          brainPower: 5,
-          energyDelta: 2,
-          newTotalBp: 25,
-          status: "success",
-        },
-        type: "RESOLVE_COMPLETION",
-      },
-    );
-
-    expect(next.completion).toEqual({
-      belt: {
-        bpPerLevel: 250,
-        bpToNextLevel: 240,
-        color: "white",
-        isMaxLevel: false,
-        level: 1,
-        progressInLevel: 10,
-      },
-      brainPower: 5,
-      energyDelta: 2,
-      newTotalBp: 25,
-      status: "success",
-    });
-  });
-
-  test("ignores stale completion responses", () => {
+describe("local completion computation", () => {
+  test("computes completion result when CONTINUE transitions to completed", () => {
     const state = buildState({
-      completion: { status: "submitting" },
-      completionRequestId: 3,
+      currentStepIndex: 0,
+      phase: "feedback",
+      results: {
+        "step-1": {
+          answer: multipleChoiceAnswer,
+          effects: [],
+          result: { correctAnswer: null, feedback: "Yes", isCorrect: true },
+          stepId: "step-1",
+        },
+      },
+      steps: [buildMultipleChoiceStep()],
+      totalBrainPower: 100,
     });
 
-    const resolved = playerReducer(state, {
-      requestId: 2,
-      result: { status: "unauthenticated" },
-      type: "RESOLVE_COMPLETION",
-    });
-    const rejected = playerReducer(state, { requestId: 2, type: "REJECT_COMPLETION" });
+    const next = playerReducer(state, { type: "CONTINUE" });
 
-    expect(resolved).toBe(state);
-    expect(rejected).toBe(state);
+    expect(next.phase).toBe("completed");
+    expect(next.completion).not.toBeNull();
+    expect(next.completion?.brainPower).toBe(10);
+    expect(next.completion?.newTotalBp).toBe(110);
+    expect(next.completion?.belt).toBeDefined();
+  });
+
+  test("computes completion result when NAVIGATE_STEP passes last step", () => {
+    const steps = [buildStep({ id: "s1", kind: "static" })];
+    const state = buildState({ currentStepIndex: 0, steps, totalBrainPower: 50 });
+
+    const next = playerReducer(state, { direction: "next", type: "NAVIGATE_STEP" });
+
+    expect(next.phase).toBe("completed");
+    expect(next.completion).not.toBeNull();
+    expect(next.completion?.brainPower).toBe(10);
+    expect(next.completion?.newTotalBp).toBe(60);
+  });
+
+  test("computes challenge completion with 100 BP for successful challenge", () => {
+    const state = buildState({
+      currentStepIndex: 0,
+      dimensions: { Courage: 2 },
+      phase: "feedback",
+      results: {
+        "step-1": {
+          answer: multipleChoiceAnswer,
+          effects: [{ dimension: "Courage", impact: "positive" }],
+          result: { correctAnswer: null, feedback: null, isCorrect: true },
+          stepId: "step-1",
+        },
+      },
+      steps: [buildMultipleChoiceStep()],
+      totalBrainPower: 0,
+    });
+
+    const next = playerReducer(state, { type: "CONTINUE" });
+
+    expect(next.completion?.brainPower).toBe(100);
+    expect(next.completion?.newTotalBp).toBe(100);
+  });
+
+  test("computes challenge completion with 10 BP for failed challenge", () => {
+    const state = buildState({
+      currentStepIndex: 0,
+      dimensions: { Courage: -1 },
+      phase: "feedback",
+      results: {
+        "step-1": {
+          answer: multipleChoiceAnswer,
+          effects: [{ dimension: "Courage", impact: "negative" }],
+          result: { correctAnswer: null, feedback: null, isCorrect: false },
+          stepId: "step-1",
+        },
+      },
+      steps: [buildMultipleChoiceStep()],
+      totalBrainPower: 0,
+    });
+
+    const next = playerReducer(state, { type: "CONTINUE" });
+
+    expect(next.completion?.brainPower).toBe(10);
+  });
+
+  test("resets completion to null on RESTART", () => {
+    const state = buildState({
+      completion: {
+        belt: {
+          bpPerLevel: 250,
+          bpToNextLevel: 240,
+          color: "white",
+          isMaxLevel: false,
+          level: 1,
+          progressInLevel: 10,
+        },
+        brainPower: 10,
+        energyDelta: 0.2,
+        newTotalBp: 10,
+      },
+      phase: "completed",
+    });
+
+    const next = playerReducer(state, { type: "RESTART" });
+
+    expect(next.completion).toBeNull();
   });
 });
 
@@ -732,7 +776,7 @@ describe("timing", () => {
 
   test("createInitialState sets startedAt and stepStartedAt", () => {
     vi.setSystemTime(new Date("2026-03-15T10:00:00"));
-    const state = createInitialState(buildActivity());
+    const state = createInitialState({ activity: buildActivity(), totalBrainPower: 0 });
     expect(state.startedAt).toBe(Date.now());
     expect(state.stepStartedAt).toBe(Date.now());
     expect(state.stepTimings).toEqual({});
@@ -840,7 +884,7 @@ describe("edge cases", () => {
 
   test("empty steps array sets phase to completed", () => {
     const activity = buildActivity({ steps: [] });
-    const state = createInitialState(activity);
+    const state = createInitialState({ activity, totalBrainPower: 0 });
     expect(state.steps).toEqual([]);
     expect(state.currentStepIndex).toBe(0);
     expect(state.phase).toBe("completed");

--- a/packages/player/src/player-reducer.ts
+++ b/packages/player/src/player-reducer.ts
@@ -2,13 +2,7 @@ import { type ChallengeEffect } from "@zoonk/core/steps/content-contract";
 import { type AnswerResult } from "./check-answer";
 import { type CompletionResult } from "./completion-input-schema";
 import { IMPACT_DELTA } from "./dimensions";
-import {
-  type PlayerCompletionState,
-  createIdleCompletionState,
-  handleRejectCompletion,
-  handleResolveCompletion,
-  handleSubmitCompletion,
-} from "./player-completion";
+import { computeLocalCompletion } from "./player-completion";
 import { buildInitialAnswers, collectAllDimensions } from "./player-initial-state";
 import { type SerializedStep } from "./prepare-activity-data";
 import { canNavigatePrev, isStaticNavigationStep } from "./step-navigation";
@@ -43,8 +37,7 @@ export type StepTiming = {
 
 export type PlayerState = {
   activityId: string;
-  completion: PlayerCompletionState;
-  completionRequestId: number;
+  completion: CompletionResult | null;
   currentStepIndex: number;
   dimensions: DimensionInventory;
   phase: PlayerPhase;
@@ -55,6 +48,7 @@ export type PlayerState = {
   stepStartedAt: number;
   steps: SerializedStep[];
   stepTimings: Record<string, StepTiming>;
+  totalBrainPower: number;
 };
 
 export type PlayerAction =
@@ -65,9 +59,6 @@ export type PlayerAction =
   | { type: "COMPLETE" }
   | { type: "NAVIGATE_STEP"; direction: "next" | "prev" }
   | { type: "RESTART" }
-  | { type: "SUBMIT_COMPLETION"; requestId: number }
-  | { type: "RESOLVE_COMPLETION"; requestId: number; result: CompletionResult }
-  | { type: "REJECT_COMPLETION"; requestId: number }
   | { type: "START_CHALLENGE" };
 
 function applyEffects(
@@ -156,6 +147,11 @@ function handleCheckAnswer(
   return checked;
 }
 
+function completeWith(state: PlayerState): PlayerState {
+  const completed: PlayerState = { ...state, phase: "completed" };
+  return { ...completed, completion: computeLocalCompletion(completed) };
+}
+
 function handleContinue(state: PlayerState): PlayerState {
   if (state.phase !== "feedback") {
     return state;
@@ -164,11 +160,15 @@ function handleContinue(state: PlayerState): PlayerState {
   const nextIndex = state.currentStepIndex + 1;
   const isLast = nextIndex >= state.steps.length;
 
+  if (isLast) {
+    return completeWith(state);
+  }
+
   return {
     ...state,
-    currentStepIndex: isLast ? state.currentStepIndex : nextIndex,
-    phase: isLast ? "completed" : "playing",
-    stepStartedAt: isLast ? state.stepStartedAt : Date.now(),
+    currentStepIndex: nextIndex,
+    phase: "playing",
+    stepStartedAt: Date.now(),
   };
 }
 
@@ -199,7 +199,7 @@ function handleNavigateStep(
   const nextIndex = state.currentStepIndex + 1;
 
   if (nextIndex >= state.steps.length) {
-    return { ...state, phase: "completed" };
+    return completeWith(state);
   }
 
   return { ...state, currentStepIndex: nextIndex, stepStartedAt: Date.now() };
@@ -211,8 +211,7 @@ function handleRestart(state: PlayerState): PlayerState {
 
   return {
     ...state,
-    completion: createIdleCompletionState(),
-    completionRequestId: state.completionRequestId + 1,
+    completion: null,
     currentStepIndex: 0,
     dimensions,
     phase: "playing",
@@ -238,7 +237,7 @@ function handleComplete(state: PlayerState): PlayerState {
     return state;
   }
 
-  return { ...state, phase: "completed" };
+  return completeWith(state);
 }
 
 export function playerReducer(state: PlayerState, action: PlayerAction): PlayerState {
@@ -263,15 +262,6 @@ export function playerReducer(state: PlayerState, action: PlayerAction): PlayerS
 
     case "RESTART":
       return handleRestart(state);
-
-    case "SUBMIT_COMPLETION":
-      return handleSubmitCompletion(state, action.requestId);
-
-    case "RESOLVE_COMPLETION":
-      return handleResolveCompletion(state, action.requestId, action.result);
-
-    case "REJECT_COMPLETION":
-      return handleRejectCompletion(state, action.requestId);
 
     case "START_CHALLENGE":
       return handleStartChallenge(state);

--- a/packages/player/src/player-selectors.test.ts
+++ b/packages/player/src/player-selectors.test.ts
@@ -25,8 +25,7 @@ function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
 function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
   return {
     activityId: "activity-1",
-    completion: { status: "idle" },
-    completionRequestId: 0,
+    completion: null,
     currentStepIndex: 0,
     dimensions: {},
     phase: "playing",
@@ -37,6 +36,7 @@ function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
     stepStartedAt: 1000,
     stepTimings: {},
     steps: [buildStep()],
+    totalBrainPower: 0,
     ...overrides,
   };
 }

--- a/packages/player/src/player-selectors.ts
+++ b/packages/player/src/player-selectors.ts
@@ -26,10 +26,6 @@ export function getChangedDimensions(state: PlayerState): Set<string> {
 }
 
 export function getCompletionResult(state: PlayerState): CompletionResult | null {
-  if (state.completion.status === "idle" || state.completion.status === "submitting") {
-    return null;
-  }
-
   return state.completion;
 }
 

--- a/packages/player/src/use-player-actions.ts
+++ b/packages/player/src/use-player-actions.ts
@@ -2,23 +2,14 @@
 
 import { type Dispatch, useCallback } from "react";
 import { checkStep } from "./check-step";
-import { type CompletionInput, type CompletionResult } from "./completion-input-schema";
-import {
-  buildCompletionInput,
-  getPlayerTransition,
-  getSubmitCompletionRequestId,
-} from "./player-controller";
+import { type CompletionInput } from "./completion-input-schema";
+import { buildCompletionInput, getPlayerTransition } from "./player-controller";
 import {
   type PlayerAction,
   type PlayerState,
   type SelectedAnswer,
   type playerReducer,
 } from "./player-reducer";
-
-type SyncPlayerAction = Exclude<
-  PlayerAction,
-  { type: "REJECT_COMPLETION" | "RESOLVE_COMPLETION" | "SUBMIT_COMPLETION" }
->;
 
 export type PlayerActions = {
   check: () => void;
@@ -33,37 +24,21 @@ export type PlayerActions = {
 export function usePlayerActions(
   state: PlayerState,
   dispatch: Dispatch<Parameters<typeof playerReducer>[1]>,
-  onComplete: (input: CompletionInput) => Promise<CompletionResult>,
+  onComplete: (input: CompletionInput) => void,
   isAuthenticated: boolean,
 ) {
   const currentStep = state.steps[state.currentStepIndex];
 
-  const submitCompletion = useCallback(
-    (completionState: PlayerState) => {
-      const requestId = getSubmitCompletionRequestId(state);
-      dispatch({ requestId, type: "SUBMIT_COMPLETION" });
-
-      void onComplete(buildCompletionInput(completionState))
-        .then((result) => {
-          dispatch({ requestId, result, type: "RESOLVE_COMPLETION" });
-        })
-        .catch(() => {
-          dispatch({ requestId, type: "REJECT_COMPLETION" });
-        });
-    },
-    [dispatch, onComplete, state],
-  );
-
   const dispatchTransition = useCallback(
-    (action: SyncPlayerAction) => {
+    (action: PlayerAction) => {
       const transition = getPlayerTransition(state, action);
       dispatch(action);
 
-      if (transition.shouldSubmitCompletion && isAuthenticated) {
-        submitCompletion(transition.nextState);
+      if (transition.shouldPersistCompletion && isAuthenticated) {
+        onComplete(buildCompletionInput(transition.nextState));
       }
     },
-    [dispatch, isAuthenticated, state, submitCompletion],
+    [dispatch, isAuthenticated, onComplete, state],
   );
 
   const selectAnswer = useCallback(


### PR DESCRIPTION
## Summary

- Compute completion metrics (BP, energy, belt level) client-side in the reducer when phase transitions to "completed", eliminating the 1-2s skeleton wait
- Fire the server action as fire-and-forget — it validates and persists via `after()` in the background
- Remove the submission state machine (`SUBMIT_COMPLETION`/`RESOLVE_COMPLETION`/`REJECT_COMPLETION`) and skeleton components (`RewardBadgesSkeleton`, `BeltProgressSkeleton`)
- Pass `totalBrainPower` from server at page load (the only missing piece for client-side computation)
- Add `getTotalBrainPower` data function with integration tests

## Test plan

- [x] Unit tests updated (local completion computation, state shape changes)
- [x] Integration tests added for `getTotalBrainPower`
- [x] E2E activity completion tests pass (all 6 scenarios)
- [x] Full e2e suites pass (main: 426, editor: 194, api: 56)
- [ ] Manual test: complete an activity as authenticated user — metrics appear instantly with no skeleton flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compute completion metrics (brain power, energy, belt) on the client when an activity completes for instant display. Persist progress on the server in the background to remove the 1–2s skeleton flash and simplify the player flow.

- **Refactors**
  - Compute metrics in the reducer on transition to "completed" (`computeLocalCompletion`); removed the submission state machine and request IDs.
  - `submitCompletion` now validates and persists via `after()` and returns `void`; errors simply log.
  - Load `totalBrainPower` on page render with `getTotalBrainPower` and pass it to `PlayerProvider`.
  - `PlayerProvider` now accepts `totalBrainPower`; `onComplete` is fire-and-forget (no return value).
  - Removed `RewardBadgesSkeleton` and `BeltProgressSkeleton`; components render immediately using local `completion`.
  - Updated challenge/auth completion UIs to use local `completion`; selectors/tests adjusted.

- **Migration**
  - Pass `totalBrainPower` into `PlayerProvider` and through your page/client props.
  - Change `onComplete` to return `void` and call the server action without awaiting a result.
  - Remove uses of completion skeletons; conditionally render based on `completion` presence.
  - If you depend on `submitCompletion` response data/status, remove that logic (the action no longer returns a payload).

<sup>Written for commit 9a44c7219ad87ad3d89cd0a578887b4c35d2671a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

