### PR TITLE
chore(utils): enforce no-console rule and use logger utility

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -33,7 +33,6 @@
     ],
     "eslint/max-params": "off",
     "eslint/max-statements": ["error", { "ignoreTopLevelFunctions": true, "max": 30 }],
-    "eslint/no-console": ["error", { "allow": ["error", "info"] }],
     "eslint/no-inline-comments": "off",
     "eslint/no-magic-numbers": [
       "error",

--- a/apps/evals/src/app/audio-test/actions.ts
+++ b/apps/evals/src/app/audio-test/actions.ts
@@ -3,6 +3,7 @@
 import { generateLanguageAudio } from "@zoonk/core/audio/generate";
 import { parseFormField } from "@zoonk/utils/form";
 import { type TTSVoice } from "@zoonk/utils/languages";
+import { logError } from "@zoonk/utils/logger";
 
 export async function generateAudioAction(formData: FormData) {
   const text = parseFormField(formData, "text");
@@ -21,7 +22,7 @@ export async function generateAudioAction(formData: FormData) {
   });
 
   if (error) {
-    console.error("Error generating audio:", error);
+    logError("Error generating audio:", error);
     return { error: error.message };
   }
 

--- a/apps/evals/src/app/image-test/actions.ts
+++ b/apps/evals/src/app/image-test/actions.ts
@@ -2,6 +2,7 @@
 
 import { generateCourseImage } from "@zoonk/core/courses/image";
 import { parseFormField } from "@zoonk/utils/form";
+import { logError } from "@zoonk/utils/logger";
 
 export async function generateThumbnailAction(formData: FormData) {
   const title = parseFormField(formData, "title");
@@ -16,7 +17,7 @@ export async function generateThumbnailAction(formData: FormData) {
   });
 
   if (error) {
-    console.error("Error generating thumbnail:", error);
+    logError("Error generating thumbnail:", error);
     return { error: error.message };
   }
 

--- a/apps/evals/src/app/select-image-test/actions.ts
+++ b/apps/evals/src/app/select-image-test/actions.ts
@@ -2,6 +2,7 @@
 
 import { generateStepImage } from "@zoonk/core/steps/image";
 import { parseFormField } from "@zoonk/utils/form";
+import { logError } from "@zoonk/utils/logger";
 
 export async function generateSelectImageAction(formData: FormData) {
   const prompt = parseFormField(formData, "prompt");
@@ -17,7 +18,7 @@ export async function generateSelectImageAction(formData: FormData) {
   });
 
   if (error) {
-    console.error("Error generating select image:", error);
+    logError("Error generating select image:", error);
     return { error: error.message };
   }
 

--- a/apps/evals/src/app/tasks/[taskId]/[modelId]/actions.ts
+++ b/apps/evals/src/app/tasks/[taskId]/[modelId]/actions.ts
@@ -4,6 +4,7 @@ import { runEval } from "@/lib/eval-runner";
 import { generateOutputs } from "@/lib/output-generator";
 import { TASKS } from "@/tasks";
 import { parseFormField } from "@zoonk/utils/form";
+import { logError } from "@zoonk/utils/logger";
 import { revalidatePath } from "next/cache";
 
 export async function generateOutputsAction(formData: FormData) {
@@ -25,7 +26,7 @@ export async function generateOutputsAction(formData: FormData) {
     revalidatePath(`/tasks/${taskId}/${modelId}`);
     revalidatePath(`/tasks/${taskId}`);
   } catch (error) {
-    console.error("Error generating outputs:", error);
+    logError("Error generating outputs:", error);
   }
 }
 
@@ -47,6 +48,6 @@ export async function runEvalAction(formData: FormData) {
     await runEval(task, modelId);
     revalidatePath(`/tasks/${taskId}/${modelId}`);
   } catch (error) {
-    console.error("Error running eval:", error);
+    logError("Error running eval:", error);
   }
 }

--- a/apps/evals/src/app/tasks/[taskId]/actions.ts
+++ b/apps/evals/src/app/tasks/[taskId]/actions.ts
@@ -3,6 +3,7 @@
 import { runBattleMode } from "@/lib/battle-runner";
 import { TASKS } from "@/tasks";
 import { parseFormField } from "@zoonk/utils/form";
+import { logError } from "@zoonk/utils/logger";
 import { revalidatePath } from "next/cache";
 
 export async function runBattleModeAction(formData: FormData) {
@@ -18,7 +19,7 @@ export async function runBattleModeAction(formData: FormData) {
     await runBattleMode(task);
     revalidatePath(`/tasks/${taskId}`);
   } catch (error) {
-    console.error("Error running battle mode:", error);
+    logError("Error running battle mode:", error);
     throw error;
   }
 }

--- a/apps/evals/src/app/visual-image-test/actions.ts
+++ b/apps/evals/src/app/visual-image-test/actions.ts
@@ -2,6 +2,7 @@
 
 import { generateVisualStepImage } from "@zoonk/core/steps/visual-image";
 import { parseFormField } from "@zoonk/utils/form";
+import { logError } from "@zoonk/utils/logger";
 
 export async function generateVisualImageAction(formData: FormData) {
   const prompt = parseFormField(formData, "prompt");
@@ -17,7 +18,7 @@ export async function generateVisualImageAction(formData: FormData) {
   });
 
   if (error) {
-    console.error("Error generating visual image:", error);
+    logError("Error generating visual image:", error);
     return { error: error.message };
   }
 

--- a/apps/evals/src/lib/battle-runner.ts
+++ b/apps/evals/src/lib/battle-runner.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { logInfo } from "@zoonk/utils/logger";
 import { getBattleLeaderboard } from "./battle-loader";
 import { generateBattleRankings } from "./battle-score";
 import {
@@ -198,7 +199,7 @@ async function runBattleForTestCase(
   const currentModelIds = modelOutputs.map((item) => item.modelId);
   const newModelsDetected = existingMatchup && hasNewModels(existingMatchup, currentModelIds);
   if (newModelsDetected) {
-    console.info(`New models detected for ${testCaseId}, re-running all judges`);
+    logInfo(`New models detected for ${testCaseId}, re-running all judges`);
   }
 
   const effectiveExisting = newModelsDetected ? null : existingMatchup;
@@ -236,7 +237,7 @@ async function runBattleForTestCase(
 }
 
 export async function runBattleMode(task: Task): Promise<void> {
-  console.info(`\n=== Starting Battle Mode for task: ${task.name} ===\n`);
+  logInfo(`\n=== Starting Battle Mode for task: ${task.name} ===\n`);
 
   const totalTestCases = task.testCases.length;
 
@@ -249,7 +250,7 @@ export async function runBattleMode(task: Task): Promise<void> {
     );
   }
 
-  console.info(`Found ${completeModels.length} models with complete outputs`);
+  logInfo(`Found ${completeModels.length} models with complete outputs`);
 
   // Load all outputs
   const allOutputs = await getAllOutputsForTask(task.id);
@@ -275,7 +276,7 @@ export async function runBattleMode(task: Task): Promise<void> {
 
       completedBattles += 1;
       const remaining = totalBattles - completedBattles;
-      console.info(`Battle complete for ${testCaseId}, ${remaining} remaining`);
+      logInfo(`Battle complete for ${testCaseId}, ${remaining} remaining`);
 
       return result;
     }),
@@ -283,9 +284,9 @@ export async function runBattleMode(task: Task): Promise<void> {
 
   const leaderboard = await getBattleLeaderboard(task.id);
 
-  console.info("\n=== Battle Mode Complete ===");
-  console.info("Top 3 models:");
+  logInfo("\n=== Battle Mode Complete ===");
+  logInfo("Top 3 models:");
   leaderboard.slice(0, 3).forEach((entry, i) => {
-    console.info(`  ${i + 1}. ${entry.modelName}: ${entry.totalScore} points`);
+    logInfo(`  ${i + 1}. ${entry.modelName}: ${entry.totalScore} points`);
   });
 }

--- a/apps/evals/src/lib/eval-runner.ts
+++ b/apps/evals/src/lib/eval-runner.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { logError, logInfo } from "@zoonk/utils/logger";
 import { cache } from "react";
 import { loadModelOutputs } from "./output-loader";
 import { generateScore } from "./score";
@@ -57,7 +58,7 @@ function findTestCaseForOutput(task: Task, testCaseId: string): TestCase | undef
 }
 
 async function scoreOutput(output: OutputEntry, testCase: TestCase): Promise<ScoredResult> {
-  console.info(`Scoring output: ${output.testCaseId}`);
+  logInfo(`Scoring output: ${output.testCaseId}`);
 
   const scoreResult = await generateScore({
     expectations: testCase.expectations,
@@ -66,7 +67,7 @@ async function scoreOutput(output: OutputEntry, testCase: TestCase): Promise<Sco
     system: output.systemPrompt,
   });
 
-  console.info(`Score: ${scoreResult.score}`);
+  logInfo(`Score: ${scoreResult.score}`);
 
   const testCaseWithRun: TestCase = {
     ...testCase,
@@ -86,7 +87,7 @@ function isAlreadyScored(existingResults: ScoredResult[], testCaseId: string): b
 export async function runEval(task: Task, modelId: string): Promise<TaskEvalResults> {
   const safeModelId = String(modelId).replaceAll(/[\r\n]/g, "");
 
-  console.info(`\nStarting eval for task: ${task.name}, model: [${safeModelId}]`);
+  logInfo(`\nStarting eval for task: ${task.name}, model: [${safeModelId}]`);
 
   // Load pre-generated outputs
   const modelOutputs = await loadModelOutputs(task.id, modelId);
@@ -94,21 +95,21 @@ export async function runEval(task: Task, modelId: string): Promise<TaskEvalResu
     throw new Error(`No outputs found for model ${modelId}. Generate outputs first.`);
   }
 
-  console.info(`Found ${modelOutputs.outputs.length} outputs to score`);
+  logInfo(`Found ${modelOutputs.outputs.length} outputs to score`);
 
   // Load existing scored results
   const existingResults = await loadExistingScoredResults(task.id, modelId);
-  console.info(`Found ${existingResults.length} existing scored results`);
+  logInfo(`Found ${existingResults.length} existing scored results`);
 
   // Find outputs that haven't been scored yet
   const outputsToScore = modelOutputs.outputs.filter(
     (output) => !isAlreadyScored(existingResults, output.testCaseId),
   );
 
-  console.info(`Scoring ${outputsToScore.length} outputs`);
+  logInfo(`Scoring ${outputsToScore.length} outputs`);
 
   if (outputsToScore.length === 0) {
-    console.info("All outputs already scored");
+    logInfo("All outputs already scored");
     return combineOutputsAndResults(task.id, modelId, modelOutputs.outputs, existingResults);
   }
 
@@ -127,7 +128,7 @@ export async function runEval(task: Task, modelId: string): Promise<TaskEvalResu
       return [result.value];
     }
 
-    console.error(
+    logError(
       `Error scoring output: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`,
     );
 
@@ -137,7 +138,7 @@ export async function runEval(task: Task, modelId: string): Promise<TaskEvalResu
   const allScoredResults = [...existingResults, ...newResults];
 
   await saveScoredResults(task.id, modelId, allScoredResults);
-  console.info(`Saved ${allScoredResults.length} total scored results`);
+  logInfo(`Saved ${allScoredResults.length} total scored results`);
 
   return combineOutputsAndResults(task.id, modelId, modelOutputs.outputs, allScoredResults);
 }

--- a/apps/evals/src/lib/output-generator.ts
+++ b/apps/evals/src/lib/output-generator.ts
@@ -1,4 +1,5 @@
 import { RUNS_PER_TEST_CASE } from "@/tasks";
+import { logError, logInfo } from "@zoonk/utils/logger";
 import { getGatewayModelId, getModelById } from "./models";
 import { loadModelOutputs, saveModelOutputs } from "./output-loader";
 import { type ModelOutputs, type OutputEntry, type Task, type TestCase } from "./types";
@@ -13,7 +14,7 @@ async function generateOutputForTestCase(
     .map(([key, value]) => `${key}=${String(value)}`)
     .join(", ");
 
-  console.info(`Generating output for: ${inputSummary} (run ${runNumber})`);
+  logInfo(`Generating output for: ${inputSummary} (run ${runNumber})`);
 
   const model = getModelById(modelId);
   const gatewayModelId = getGatewayModelId(modelId);
@@ -68,7 +69,7 @@ function extractSuccessfulOutputs(results: PromiseSettledResult<OutputEntry>[]):
       return [result.value];
     }
 
-    console.error(
+    logError(
       `Error generating output: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`,
     );
 
@@ -82,20 +83,20 @@ function createModelOutputs(taskId: string, modelId: string, outputs: OutputEntr
 
 export async function generateOutputs(task: Task, modelId: string): Promise<ModelOutputs> {
   const safeModelId = String(modelId).replaceAll(/[\r\n]/g, "");
-  console.info(`\nGenerating outputs for task: ${task.name}, model: [${safeModelId}]`);
-  console.info(
+  logInfo(`\nGenerating outputs for task: ${task.name}, model: [${safeModelId}]`);
+  logInfo(
     `Total test cases: ${task.testCases.length} (${task.testCases.length * RUNS_PER_TEST_CASE} runs)`,
   );
 
   const existingOutputs = await loadModelOutputs(task.id, modelId);
   const existingEntries = existingOutputs?.outputs ?? [];
-  console.info(`Found ${existingEntries.length} existing outputs`);
+  logInfo(`Found ${existingEntries.length} existing outputs`);
 
   const runsToExecute = collectTestCaseRuns(task.testCases, existingEntries);
-  console.info(`Generating ${runsToExecute.length} new outputs`);
+  logInfo(`Generating ${runsToExecute.length} new outputs`);
 
   if (runsToExecute.length === 0) {
-    console.info("All outputs already generated");
+    logInfo("All outputs already generated");
     return existingOutputs ?? createModelOutputs(task.id, modelId, []);
   }
 
@@ -109,7 +110,7 @@ export async function generateOutputs(task: Task, modelId: string): Promise<Mode
   const modelOutputs = createModelOutputs(task.id, modelId, allOutputs);
 
   await saveModelOutputs(task.id, modelId, modelOutputs);
-  console.info(`Saved ${allOutputs.length} total outputs`);
+  logInfo(`Saved ${allOutputs.length} total outputs`);
 
   return modelOutputs;
 }

--- a/packages/db/src/prisma/seed.ts
+++ b/packages/db/src/prisma/seed.ts
@@ -1,3 +1,4 @@
+import { logError } from "@zoonk/utils/logger";
 import { prisma } from "../index";
 import { seedAccounts } from "./seed/accounts";
 import { seedActivities } from "./seed/activities";
@@ -41,7 +42,7 @@ main()
     process.exit(0);
   })
   .catch(async (error: unknown) => {
-    console.error(error);
+    logError(error);
     await prisma.$disconnect();
     process.exit(1);
   });

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -4,12 +4,14 @@ function isTestEnvironment(): boolean {
 
 export function logError(...args: unknown[]): void {
   if (!isTestEnvironment()) {
+    // eslint-disable-next-line no-console
     console.error(...args);
   }
 }
 
 export function logInfo(...args: unknown[]): void {
   if (!isTestEnvironment()) {
+    // eslint-disable-next-line no-console
     console.info(...args);
   }
 }


### PR DESCRIPTION
## Summary
- Removed `no-console` allow list from `.oxlintrc.json` (the `restriction` category already enforces it by default)
- Replaced all `console.error`/`console.info` calls with `logError`/`logInfo` from `@zoonk/utils/logger`
- Added inline `eslint-disable-next-line no-console` in `logger.ts` where `console` is legitimately needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the `no-console` rule and routes all logging through `@zoonk/utils/logger`. This standardizes logs and keeps tests quiet.

- **Refactors**
  - Removed allow list for `eslint/no-console` in `.oxlintrc.json`.
  - Replaced `console.error`/`console.info` with `logError`/`logInfo` from `@zoonk/utils/logger` across eval actions, runners, output generator, and Prisma seed.
  - Added inline `eslint-disable-next-line no-console` in `packages/utils/src/logger.ts` where console is required.

<sup>Written for commit 1e55a9ce8ee3f3c298361ba8d62013c448126974. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

