### PR TITLE
feat(main,editor): add missing page title metadata

### DIFF
--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[activityId]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[activityId]/page.tsx
@@ -2,6 +2,7 @@ import { BackLink, BackLinkSkeleton } from "@/components/back-link";
 import { getLesson } from "@/data/lessons/get-lesson";
 import { Container, ContainerBody } from "@zoonk/ui/components/container";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { type Metadata } from "next";
 import { getExtracted } from "next-intl/server";
 import { Suspense } from "react";
 
@@ -43,6 +44,17 @@ function ActivityPlaceholderSkeleton() {
       <Skeleton className="mx-auto h-5 w-48" />
     </div>
   );
+}
+
+export async function generateMetadata({ params }: ActivityPageProps): Promise<Metadata> {
+  const { chapterSlug, courseSlug, lessonSlug, orgSlug } = await params;
+  const { data: lesson } = await getLesson({ chapterSlug, courseSlug, lessonSlug, orgSlug });
+
+  if (!lesson) {
+    return {};
+  }
+
+  return { title: lesson.title };
 }
 
 export default function ActivityPage(props: ActivityPageProps) {

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -2,12 +2,27 @@ import { BackLinkSkeleton } from "@/components/back-link";
 import { ContentEditorSkeleton } from "@/components/content-editor";
 import { EditorListSkeleton } from "@/components/editor-list";
 import { SlugEditorSkeleton } from "@/components/slug-editor";
+import { getLesson } from "@/data/lessons/get-lesson";
 import { Container, ContainerBody } from "@zoonk/ui/components/container";
+import { type Metadata } from "next";
 import { Suspense } from "react";
 import { ActivityList } from "./activity-list";
 import { LessonBackLink } from "./lesson-back-link";
 import { LessonContent } from "./lesson-content";
 import { LessonSlug } from "./lesson-slug";
+
+export async function generateMetadata({
+  params,
+}: PageProps<"/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]">): Promise<Metadata> {
+  const { chapterSlug, courseSlug, lessonSlug, orgSlug } = await params;
+  const { data: lesson } = await getLesson({ chapterSlug, courseSlug, lessonSlug, orgSlug });
+
+  if (!lesson) {
+    return {};
+  }
+
+  return { title: lesson.title };
+}
 
 export default function LessonPage(
   props: PageProps<"/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]">,

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -2,12 +2,27 @@ import { BackLinkSkeleton } from "@/components/back-link";
 import { ContentEditorSkeleton } from "@/components/content-editor";
 import { EditorListSkeleton } from "@/components/editor-list";
 import { SlugEditorSkeleton } from "@/components/slug-editor";
+import { getChapter } from "@/data/chapters/get-chapter";
 import { Container, ContainerBody } from "@zoonk/ui/components/container";
+import { type Metadata } from "next";
 import { Suspense } from "react";
 import { ChapterBackLink } from "./chapter-back-link";
 import { ChapterContent } from "./chapter-content";
 import { ChapterSlug } from "./chapter-slug";
 import { LessonList } from "./lesson-list";
+
+export async function generateMetadata({
+  params,
+}: PageProps<"/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]">): Promise<Metadata> {
+  const { chapterSlug, courseSlug, orgSlug } = await params;
+  const { data: chapter } = await getChapter({ chapterSlug, courseSlug, orgSlug });
+
+  if (!chapter) {
+    return {};
+  }
+
+  return { title: chapter.title };
+}
 
 export default function ChapterPage(
   props: PageProps<"/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]">,

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/page.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/page.tsx
@@ -3,8 +3,10 @@ import { CategoryEditorSkeleton } from "@/components/category/category-editor";
 import { ContentEditorSkeleton } from "@/components/content-editor";
 import { EditorListSkeleton } from "@/components/editor-list";
 import { SlugEditorSkeleton } from "@/components/slug-editor";
+import { getCourse } from "@/data/courses/get-course";
 import { Container, ContainerBody } from "@zoonk/ui/components/container";
 import { ImageUploadSkeleton } from "@zoonk/ui/components/image-upload";
+import { type Metadata } from "next";
 import { Suspense } from "react";
 import { ChapterList } from "./chapter-list";
 import { CourseAlternativeTitles } from "./course-alternative-titles";
@@ -12,6 +14,19 @@ import { CourseCategories } from "./course-categories";
 import { CourseContent } from "./course-content";
 import { CourseImage } from "./course-image";
 import { CourseSlug } from "./course-slug";
+
+export async function generateMetadata({
+  params,
+}: PageProps<"/[orgSlug]/c/[courseSlug]">): Promise<Metadata> {
+  const { courseSlug, orgSlug } = await params;
+  const { data: course } = await getCourse({ courseSlug, orgSlug });
+
+  if (!course) {
+    return {};
+  }
+
+  return { title: course.title };
+}
 
 export default function CoursePage(props: PageProps<"/[orgSlug]/c/[courseSlug]">) {
   return (

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -2157,6 +2157,11 @@ msgctxt "THvPMp"
 msgid "This usually takes a few seconds"
 msgstr "This usually takes a few seconds"
 
+#: src/app/generate/layout.tsx
+msgctxt "/tq5fR"
+msgid "Creating content"
+msgstr "Creating content"
+
 #: src/app/privacy/page.tsx
 msgctxt "iql85X"
 msgid "Read Zoonk's privacy policy to understand how we collect, use, and protect your personal information."

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -2157,6 +2157,11 @@ msgctxt "THvPMp"
 msgid "This usually takes a few seconds"
 msgstr "Esto generalmente toma unos segundos"
 
+#: src/app/generate/layout.tsx
+msgctxt "/tq5fR"
+msgid "Creating content"
+msgstr "Creando contenido"
+
 #: src/app/privacy/page.tsx
 msgctxt "iql85X"
 msgid "Read Zoonk's privacy policy to understand how we collect, use, and protect your personal information."

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -2157,6 +2157,11 @@ msgctxt "THvPMp"
 msgid "This usually takes a few seconds"
 msgstr "Isso geralmente leva alguns segundos"
 
+#: src/app/generate/layout.tsx
+msgctxt "/tq5fR"
+msgid "Creating content"
+msgstr "Criando conteúdo"
+
 #: src/app/privacy/page.tsx
 msgctxt "iql85X"
 msgid "Read Zoonk's privacy policy to understand how we collect, use, and protect your personal information."

--- a/apps/main/src/app/generate/layout.tsx
+++ b/apps/main/src/app/generate/layout.tsx
@@ -1,0 +1,11 @@
+import { type Metadata } from "next";
+import { getExtracted } from "next-intl/server";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getExtracted();
+  return { title: t("Creating content") };
+}
+
+export default function GenerateLayout({ children }: LayoutProps<"/generate">) {
+  return children;
+}

--- a/apps/main/src/app/layout.tsx
+++ b/apps/main/src/app/layout.tsx
@@ -11,7 +11,7 @@ import "@zoonk/ui/globals.css";
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: {
-    default: "",
+    default: "Zoonk",
     template: "%s | Zoonk",
   },
 };

--- a/i18n.lock
+++ b/i18n.lock
@@ -588,6 +588,7 @@ checksums:
     Creating%20your%20activities/singular: 6651e663a48e18486f5f873e614cd512
     Taking%20you%20to%20your%20lesson.../singular: 7a47c8664a900646ef51c9f27e2886e0
     This%20usually%20takes%20a%20few%20seconds/singular: d95f1b6378326c1aeb3792bd9cd643e7
+    Creating%20content/singular: ec70a8b5ffb94c0d5b83409d03d5b77b
     Read%20Zoonk's%20privacy%20policy%20to%20understand%20how%20we%20collect%2C%20use%2C%20and%20protect%20your%20personal%20information./singular: 044f3586abe7d9915820a6629cef08e4
     Privacy%20Policy/singular: 7459744a63ef8af4e517a09024bd7c08
     Read%20Zoonk's%20terms%20of%20use%20to%20understand%20the%20rules%20and%20conditions%20for%20using%20our%20platform%20and%20services/singular: 4b82898d60691839a1999e4a17199895


### PR DESCRIPTION
## Summary

- Set main app root layout default title to "Zoonk" (was empty string)
- Add `generate/layout.tsx` with "Creating content" title for all generate pages
- Add `generateMetadata` to editor course, chapter, lesson, and activity pages

## Test plan

- [ ] Open a generate page and verify browser tab shows "Creating content | Zoonk"
- [ ] Open editor course/chapter/lesson pages and verify tab shows entity title
- [ ] Verify pages that already had metadata are unaffected


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing page titles across main and editor to improve tab labels and SEO. Sets a default "Zoonk" title and adds dynamic titles for generate and editor pages.

- **New Features**
  - Main app: default title set to "Zoonk" with template "%s | Zoonk".
  - Generate pages: new layout adds "Creating content" title using `next-intl`.
  - Editor: `generateMetadata` added to course, chapter, lesson, and activity pages to use the entity title.
  - i18n: added "Creating content" string in `en`, `es`, and `pt`.

<sup>Written for commit ddb792ea35214f44390fa0e72097cbd889f5cf80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

