### PR TITLE
fix(api): stream completion events on workflow early returns

### DIFF
--- a/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
@@ -34,13 +34,15 @@ function createStepVisualsResult(
   };
 }
 
+const writeMock = vi.fn().mockResolvedValue(null);
+
 vi.mock("workflow", () => ({
   FatalError: class FatalError extends Error {},
   getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
   getWritable: vi.fn().mockReturnValue({
     getWriter: () => ({
       releaseLock: vi.fn(),
-      write: vi.fn().mockResolvedValue(null),
+      write: writeMock,
     }),
   }),
   workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
@@ -270,7 +272,7 @@ describe(activityGenerationWorkflow, () => {
       expect(generateActivityCustom).not.toHaveBeenCalled();
     });
 
-    test("returns early when all activities are completed", async () => {
+    test("streams completion events when all activities are completed", async () => {
       const testLesson = await lessonFixture({
         chapterId: chapter.id,
         kind: "core",
@@ -284,6 +286,7 @@ describe(activityGenerationWorkflow, () => {
           kind: "explanation",
           lessonId: testLesson.id,
           organizationId,
+          position: 0,
           title: `Completed Explanation ${randomUUID()}`,
         }),
         activityFixture({
@@ -291,6 +294,7 @@ describe(activityGenerationWorkflow, () => {
           kind: "quiz",
           lessonId: testLesson.id,
           organizationId,
+          position: 1,
           title: `Completed Quiz ${randomUUID()}`,
         }),
       ]);
@@ -299,9 +303,16 @@ describe(activityGenerationWorkflow, () => {
 
       expect(generateActivityExplanation).not.toHaveBeenCalled();
       expect(generateActivityCustom).not.toHaveBeenCalled();
+
+      const completionCall = writeMock.mock.calls.find(
+        (call: string[]) =>
+          call[0]?.includes('"step":"setActivityAsCompleted"') &&
+          call[0]?.includes('"status":"completed"'),
+      );
+      expect(completionCall).toBeDefined();
     });
 
-    test("returns early when all activities are completed or running", async () => {
+    test("returns early without streaming completion when activities are completed or running", async () => {
       const testLesson = await lessonFixture({
         chapterId: chapter.id,
         kind: "core",
@@ -330,6 +341,13 @@ describe(activityGenerationWorkflow, () => {
 
       expect(generateActivityExplanation).not.toHaveBeenCalled();
       expect(generateActivityCustom).not.toHaveBeenCalled();
+
+      const completionCall = writeMock.mock.calls.find(
+        (call: string[]) =>
+          call[0]?.includes('"step":"setActivityAsCompleted"') &&
+          call[0]?.includes('"status":"completed"'),
+      );
+      expect(completionCall).toBeUndefined();
     });
 
     test("does not skip when some activities are pending", async () => {

--- a/apps/api/src/workflows/activity-generation/activity-generation-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/activity-generation-workflow.ts
@@ -1,7 +1,9 @@
+import { type ActivityKind } from "@zoonk/db";
 import { FatalError, getWorkflowMetadata } from "workflow";
 import { coreActivityWorkflow } from "./core-activity-workflow";
 import { customActivityWorkflow } from "./custom-activity-workflow";
 import { languageActivityWorkflow } from "./language-activity-workflow";
+import { completeActivityStep } from "./steps/complete-activity-step";
 import { getLessonActivitiesStep } from "./steps/get-lesson-activities-step";
 import { handleWorkflowFailureStep } from "./steps/handle-workflow-failure-step";
 
@@ -23,17 +25,32 @@ export async function activityGenerationWorkflow(lessonId: number): Promise<void
       throw new FatalError("No activities found for lesson");
     }
 
+    const allCompleted = activities.every((a) => a.generationStatus === "completed");
+
     /**
-     * Skip the entire workflow when every activity is already handled.
-     * "completed" means generation finished; "running" means another workflow
-     * run is actively generating it. We only need to proceed when at least
-     * one activity is "pending" or "failed".
+     * All activities are already completed — stream the completion events
+     * so the client can detect this and redirect to the activity page.
      */
-    const allDone = activities.every(
+    if (allCompleted) {
+      const uniqueKinds = [...new Set(activities.map((a) => a.kind))] as ActivityKind[];
+
+      await Promise.allSettled(
+        uniqueKinds.map((kind) => completeActivityStep(activities, workflowRunId, kind)),
+      );
+
+      return;
+    }
+
+    /**
+     * Skip if all remaining activities are either completed or actively running.
+     * "running" means another workflow instance is generating them — we skip
+     * to avoid conflicts. We only proceed when at least one is "pending" or "failed".
+     */
+    const allHandled = activities.every(
       (a) => a.generationStatus === "completed" || a.generationStatus === "running",
     );
 
-    if (allDone) {
+    if (allHandled) {
       return;
     }
 

--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
@@ -76,7 +76,7 @@ describe(chapterGenerationWorkflow, () => {
   });
 
   describe("early returns", () => {
-    test("returns early when generationStatus is 'running'", async () => {
+    test("returns early when generationStatus is 'running' without streaming completion", async () => {
       const chapter = await chapterFixture({
         courseId: course.id,
         generationStatus: "running",
@@ -92,9 +92,16 @@ describe(chapterGenerationWorkflow, () => {
 
       expect(dbChapter?.generationStatus).toBe("running");
       expect(generateChapterLessons).not.toHaveBeenCalled();
+
+      const completionCall = writeMock.mock.calls.find(
+        (call: string[]) =>
+          call[0]?.includes('"step":"setFirstActivityAsCompleted"') &&
+          call[0]?.includes('"status":"completed"'),
+      );
+      expect(completionCall).toBeUndefined();
     });
 
-    test("returns early when generationStatus is 'completed'", async () => {
+    test("streams completion when generationStatus is 'completed'", async () => {
       const chapter = await chapterFixture({
         courseId: course.id,
         generationStatus: "completed",
@@ -110,6 +117,13 @@ describe(chapterGenerationWorkflow, () => {
 
       expect(dbChapter?.generationStatus).toBe("completed");
       expect(generateChapterLessons).not.toHaveBeenCalled();
+
+      const completionCall = writeMock.mock.calls.find(
+        (call: string[]) =>
+          call[0]?.includes('"step":"setFirstActivityAsCompleted"') &&
+          call[0]?.includes('"status":"completed"'),
+      );
+      expect(completionCall).toBeDefined();
     });
 
     test("sets as completed and returns when chapter has existing lessons", async () => {

--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.ts
@@ -1,3 +1,4 @@
+import { streamStatus as sharedStreamStatus } from "@/workflows/_shared/stream-status";
 import { activityGenerationWorkflow } from "@/workflows/activity-generation/activity-generation-workflow";
 import { handleChapterFailureStep } from "@/workflows/course-generation/steps/handle-failure-step";
 import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
@@ -21,8 +22,14 @@ export async function chapterGenerationWorkflow(chapterId: number): Promise<void
   // Fetch chapter data (throws FatalError if not found)
   const context = await getChapterStep(chapterId);
 
-  // Skip if already running or completed
-  if (context.generationStatus === "running" || context.generationStatus === "completed") {
+  // Skip if actively running to avoid conflicts with another workflow instance.
+  if (context.generationStatus === "running") {
+    return;
+  }
+
+  // Already completed — stream the completion step so the client can redirect.
+  if (context.generationStatus === "completed") {
+    await sharedStreamStatus({ status: "completed", step: "setFirstActivityAsCompleted" });
     return;
   }
 

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -149,7 +149,7 @@ describe(courseGenerationWorkflow, () => {
       expect(generateCourseDescription).not.toHaveBeenCalled();
     });
 
-    test("returns when suggestion status is 'running'", async () => {
+    test("returns when suggestion status is 'running' without streaming completion", async () => {
       const suggestion = await courseSuggestionFixture({
         generationStatus: "running",
         title: `Running Suggestion ${randomUUID()}`,
@@ -163,9 +163,16 @@ describe(courseGenerationWorkflow, () => {
 
       expect(dbSuggestion?.generationStatus).toBe("running");
       expect(generateCourseDescription).not.toHaveBeenCalled();
+
+      const completionCall = writeMock.mock.calls.find(
+        (call: string[]) =>
+          call[0]?.includes('"step":"setFirstActivityAsCompleted"') &&
+          call[0]?.includes('"status":"completed"'),
+      );
+      expect(completionCall).toBeUndefined();
     });
 
-    test("returns when suggestion status is 'completed'", async () => {
+    test("streams completion when suggestion status is 'completed'", async () => {
       const suggestion = await courseSuggestionFixture({
         generationStatus: "completed",
         title: `Completed Suggestion ${randomUUID()}`,
@@ -179,9 +186,16 @@ describe(courseGenerationWorkflow, () => {
 
       expect(dbSuggestion?.generationStatus).toBe("completed");
       expect(generateCourseDescription).not.toHaveBeenCalled();
+
+      const completionCall = writeMock.mock.calls.find(
+        (call: string[]) =>
+          call[0]?.includes('"step":"setFirstActivityAsCompleted"') &&
+          call[0]?.includes('"status":"completed"'),
+      );
+      expect(completionCall).toBeDefined();
     });
 
-    test("returns when existing course status is 'running'", async () => {
+    test("returns when existing course status is 'running' without streaming completion", async () => {
       const title = `Existing Running Course ${randomUUID()}`;
       const slug = toSlug(title);
 
@@ -206,9 +220,16 @@ describe(courseGenerationWorkflow, () => {
 
       expect(dbSuggestion?.generationStatus).toBe("pending");
       expect(generateCourseDescription).not.toHaveBeenCalled();
+
+      const completionCall = writeMock.mock.calls.find(
+        (call: string[]) =>
+          call[0]?.includes('"step":"setFirstActivityAsCompleted"') &&
+          call[0]?.includes('"status":"completed"'),
+      );
+      expect(completionCall).toBeUndefined();
     });
 
-    test("returns when existing course status is 'completed'", async () => {
+    test("streams completion when existing course status is 'completed'", async () => {
       const title = `Existing Completed Course ${randomUUID()}`;
       const slug = toSlug(title);
 
@@ -233,6 +254,13 @@ describe(courseGenerationWorkflow, () => {
 
       expect(dbSuggestion?.generationStatus).toBe("pending");
       expect(generateCourseDescription).not.toHaveBeenCalled();
+
+      const completionCall = writeMock.mock.calls.find(
+        (call: string[]) =>
+          call[0]?.includes('"step":"setFirstActivityAsCompleted"') &&
+          call[0]?.includes('"status":"completed"'),
+      );
+      expect(completionCall).toBeDefined();
     });
   });
 

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.ts
@@ -6,6 +6,7 @@ import { setupCourse } from "./_internal/setup-course";
 import { checkExistingCourseStep } from "./steps/check-existing-course-step";
 import { getCourseSuggestionStep } from "./steps/get-course-suggestion-step";
 import { handleCourseFailureStep } from "./steps/handle-failure-step";
+import { streamStatus } from "./stream-status";
 
 export async function courseGenerationWorkflow(courseSuggestionId: number): Promise<void> {
   "use workflow";
@@ -14,17 +15,27 @@ export async function courseGenerationWorkflow(courseSuggestionId: number): Prom
 
   const suggestion = await getCourseSuggestionStep(courseSuggestionId);
 
-  if (!suggestion) {
+  // Skip if actively running to avoid conflicts with another workflow instance.
+  if (suggestion.generationStatus === "running") {
+    return;
+  }
+
+  // Already completed — stream the completion step so the client can redirect.
+  if (suggestion.generationStatus === "completed") {
+    await streamStatus({ status: "completed", step: "setFirstActivityAsCompleted" });
     return;
   }
 
   const existingCourse = await checkExistingCourseStep(suggestion);
 
-  // Skip completed courses (nothing to do) and running courses (avoid conflicts)
-  if (
-    existingCourse?.generationStatus === "completed" ||
-    existingCourse?.generationStatus === "running"
-  ) {
+  // Skip running courses to avoid conflicts with another workflow instance.
+  if (existingCourse?.generationStatus === "running") {
+    return;
+  }
+
+  // Already completed — stream the completion step so the client can redirect.
+  if (existingCourse?.generationStatus === "completed") {
+    await streamStatus({ status: "completed", step: "setFirstActivityAsCompleted" });
     return;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/get-course-suggestion-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/get-course-suggestion-step.ts
@@ -2,9 +2,14 @@ import { type CourseSuggestion, prisma } from "@zoonk/db";
 import { FatalError } from "workflow";
 import { streamError, streamStatus } from "../stream-status";
 
+/**
+ * Fetches the course suggestion from the database.
+ * Always returns the suggestion so the workflow can decide what to do
+ * based on the generation status (e.g., skip if running, stream completion if completed).
+ */
 export async function getCourseSuggestionStep(
   courseSuggestionId: number,
-): Promise<CourseSuggestion | null> {
+): Promise<CourseSuggestion> {
   "use step";
 
   await streamStatus({ status: "started", step: "getCourseSuggestion" });
@@ -16,13 +21,6 @@ export async function getCourseSuggestionStep(
   if (!suggestion) {
     await streamError({ reason: "notFound", step: "getCourseSuggestion" });
     throw new FatalError("Course suggestion not found");
-  }
-
-  // When the generation is running or already completed, we return null to skip the workflow,
-  // Avoiding this running multiple times for the same course suggestion.
-  if (suggestion.generationStatus === "running" || suggestion.generationStatus === "completed") {
-    await streamStatus({ status: "completed", step: "getCourseSuggestion" });
-    return null;
   }
 
   await streamStatus({ status: "completed", step: "getCourseSuggestion" });

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
@@ -79,7 +79,7 @@ describe(lessonGenerationWorkflow, () => {
       expect(generateLessonKind).not.toHaveBeenCalled();
     });
 
-    test("returns early when generationStatus is 'completed' and has activities", async () => {
+    test("streams completion when generationStatus is 'completed' and has activities", async () => {
       const lesson = await lessonFixture({
         chapterId: chapter.id,
         generationStatus: "completed",
@@ -101,6 +101,13 @@ describe(lessonGenerationWorkflow, () => {
 
       expect(dbLesson?.generationStatus).toBe("completed");
       expect(generateLessonKind).not.toHaveBeenCalled();
+
+      const completionCall = writeMock.mock.calls.find(
+        (call: string[]) =>
+          call[0]?.includes('"step":"setLessonAsCompleted"') &&
+          call[0]?.includes('"status":"completed"'),
+      );
+      expect(completionCall).toBeDefined();
     });
 
     test("sets as completed and returns when lesson has existing activities but status not completed", async () => {

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
@@ -58,11 +58,14 @@ export async function lessonGenerationWorkflow(lessonId: number): Promise<void> 
   const { workflowRunId } = getWorkflowMetadata();
   const context = await getLessonStep(lessonId);
 
+  // Skip if actively running to avoid conflicts with another workflow instance.
   if (context.generationStatus === "running") {
     return;
   }
 
+  // Already completed with activities — stream the completion step so the client can redirect.
   if (context.generationStatus === "completed" && context._count.activities > 0) {
+    await streamStatus({ status: "completed", step: "setLessonAsCompleted" });
     return;
   }
 


### PR DESCRIPTION
## Summary

- When a workflow retries after an error, the backend detects the resource is already completed and returns early — but without streaming the completion step the client expects, leaving the UI stuck
- Now each workflow (course, chapter, lesson, activity) streams the appropriate completion event when the resource is truly `"completed"`, while still returning silently for `"running"` to avoid conflicts
- Changed `getCourseSuggestionStep` to always return the suggestion so the workflow can distinguish between `"running"` and `"completed"` statuses

## Test plan

- [x] Updated course generation workflow tests (running = no completion stream, completed = streams `setFirstActivityAsCompleted`)
- [x] Updated chapter generation workflow tests (same pattern)
- [x] Updated lesson generation workflow tests (completed = streams `setLessonAsCompleted`)
- [x] Updated activity generation workflow tests (all completed = streams completion events, some running = silent return)
- [x] All 589 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the UI getting stuck on workflow retries by streaming the expected completion events when a resource is already completed. Workflows still return silently when status is "running" to avoid conflicts.

- **Bug Fixes**
  - Stream completion on early returns across course, chapter, lesson, and activity workflows; skip streaming for "running".
  - Activity workflow: when all activities are completed, stream per-kind completion via `completeActivityStep`; skip when all are completed or running.
  - `getCourseSuggestionStep` now always returns the suggestion so workflows can decide to stream completion or skip.
  - Tests updated to assert streaming behavior (`setFirstActivityAsCompleted`, `setLessonAsCompleted`, `setActivityAsCompleted`); all pass.

<sup>Written for commit 0eeec063c7980d9e759db5ddc02f04f6215d7109. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

