### PR TITLE
fix(main): reconnect SSE stream when connection drops before completion step

### DIFF
--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -426,6 +426,81 @@ test.describe("Generate Chapter Page - With Subscription", () => {
     await userWithoutProgress.waitForURL(/\/b\/ai\/c\//, { timeout: 10_000 });
   });
 
+  test("reconnects and completes when stream is cut off before completion step", async ({
+    userWithoutProgress,
+    noProgressUser,
+  }) => {
+    await createTestSubscription(noProgressUser.id);
+    const { chapter, organizationId } = await createPendingChapter();
+
+    const uniqueId = randomUUID().slice(0, 8);
+    await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId,
+      slug: `e2e-reconnect-lesson-${uniqueId}`,
+      title: `E2E Reconnect Lesson ${uniqueId}`,
+    });
+
+    const partialMessages = [
+      { status: "started", step: "getChapter" },
+      { status: "completed", step: "getChapter" },
+      { status: "started", step: "generateLessons" },
+      { status: "completed", step: "generateLessons" },
+    ];
+
+    const remainingMessages = [
+      { status: "started", step: "setFirstActivityAsCompleted" },
+      { status: "completed", step: "setFirstActivityAsCompleted" },
+    ];
+
+    /**
+     * Simulate a stream cutoff by serving partial messages on the first request
+     * and the remaining messages (including the completion step) on reconnection.
+     * The client uses `startIndex` to resume from where it left off.
+     */
+    let statusRequestCount = 0;
+    await userWithoutProgress.route("**/v1/workflows/chapter-generation/**", async (route) => {
+      const url = route.request().url();
+      const method = route.request().method();
+
+      if (url.includes("/trigger") && method === "POST") {
+        await route.fulfill({
+          body: JSON.stringify({ message: "Workflow started", runId: TEST_RUN_ID }),
+          contentType: "application/json",
+          status: 200,
+        });
+        return;
+      }
+
+      if (url.includes("/status")) {
+        statusRequestCount += 1;
+        const messages = statusRequestCount === 1 ? partialMessages : remainingMessages;
+        await route.fulfill({
+          body: createSSEStream(messages),
+          contentType: "text/event-stream",
+          status: 200,
+        });
+        return;
+      }
+
+      await route.continue();
+    });
+
+    await userWithoutProgress.goto(`/generate/ch/${chapter.id}`);
+
+    await expect(userWithoutProgress.getByText(/your lessons are ready/i)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await prisma.chapter.update({
+      data: { generationStatus: "completed" },
+      where: { id: chapter.id },
+    });
+
+    await userWithoutProgress.waitForURL(/\/b\/ai\/c\//, { timeout: 10_000 });
+  });
+
   test("shows error when stream returns error status", async ({
     userWithoutProgress,
     noProgressUser,

--- a/apps/main/src/lib/workflow/generation-store.test.ts
+++ b/apps/main/src/lib/workflow/generation-store.test.ts
@@ -54,6 +54,33 @@ describe(generationReducer, () => {
     });
   });
 
+  describe("reconnect", () => {
+    it("increments reconnectCount", () => {
+      const state = generationReducer(initialGenerationState({ status: "streaming" }), {
+        type: "reconnect",
+      });
+      expect(state.reconnectCount).toBe(1);
+    });
+
+    it("accumulates across multiple dispatches", () => {
+      const first = generationReducer(initialGenerationState({ status: "streaming" }), {
+        type: "reconnect",
+      });
+      const second = generationReducer(first, { type: "reconnect" });
+      expect(second.reconnectCount).toBe(2);
+    });
+  });
+
+  describe("reset", () => {
+    it("resets reconnectCount to 0", () => {
+      const state = generationReducer(
+        initialGenerationState({ reconnectCount: 3, status: "streaming" }),
+        { type: "reset" },
+      );
+      expect(state.reconnectCount).toBe(0);
+    });
+  });
+
   describe("streamEnded", () => {
     it("does not transition from error state", () => {
       const state = generationReducer(

--- a/apps/main/src/lib/workflow/generation-store.ts
+++ b/apps/main/src/lib/workflow/generation-store.ts
@@ -11,12 +11,14 @@ export type GenerationState<TStep extends string = string> = {
   completedSteps: TStep[];
   currentStep: TStep | null;
   error: string | null;
+  reconnectCount: number;
   runId: string | null;
   startedSteps: TStep[];
   status: GenerationStatus;
 };
 
 export type GenerationAction<TStep extends string = string> =
+  | { type: "reconnect" }
   | { type: "reset" }
   | { type: "setError"; error: string }
   | { type: "stepCompleted"; step: TStep }
@@ -32,6 +34,7 @@ export function initialGenerationState<TStep extends string = string>(
     completedSteps: [] as TStep[],
     currentStep: null,
     error: null,
+    reconnectCount: 0,
     runId: null,
     startedSteps: [] as TStep[],
     status: "idle",
@@ -44,6 +47,8 @@ export function generationReducer<TStep extends string>(
   action: GenerationAction<TStep>,
 ): GenerationState<TStep> {
   switch (action.type) {
+    case "reconnect":
+      return { ...state, reconnectCount: state.reconnectCount + 1 };
     case "reset":
       return initialGenerationState<TStep>();
     case "setError":

--- a/apps/main/src/lib/workflow/use-sse.ts
+++ b/apps/main/src/lib/workflow/use-sse.ts
@@ -62,6 +62,9 @@ export function useSSE<T>(
         }
         /* eslint-enable no-await-in-loop */
 
+        // Flush any bytes the decoder held back while waiting for more chunks
+        parser.feed(decoder.decode());
+
         onCompleteEvent();
       } catch (error) {
         if (error instanceof Error && error.name !== "AbortError") {

--- a/apps/main/src/lib/workflow/use-workflow-generation.ts
+++ b/apps/main/src/lib/workflow/use-workflow-generation.ts
@@ -13,6 +13,8 @@ import {
 } from "./generation-store";
 import { useSSE } from "./use-sse";
 
+const MAX_STREAM_RECONNECTS = 5;
+
 export function useWorkflowGeneration<TStep extends string = string>(config: {
   autoTrigger?: boolean;
   completionStep?: TStep;
@@ -41,22 +43,47 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
     handleStreamMessage(msg, dispatch, completionStep),
   );
 
+  /**
+   * When the SSE stream closes, check whether we received the expected completion
+   * step. If not, the stream was likely cut off (e.g., Vercel function timeout)
+   * while the workflow is still running. In that case, schedule a reconnection
+   * instead of showing an error — the workflow library supports resumable streaming
+   * via `startIndex`, so the next connection picks up where the previous one ended.
+   */
   const handleComplete = useEffectEvent(() => {
-    dispatch({ completionStep, type: "streamEnded" });
+    const isComplete = !completionStep || state.completedSteps.includes(completionStep);
+
+    if (isComplete || state.reconnectCount >= MAX_STREAM_RECONNECTS) {
+      dispatch({ completionStep, type: "streamEnded" });
+      return;
+    }
+
+    setTimeout(() => {
+      dispatch({ type: "reconnect" });
+    }, 1000);
   });
 
   const handleError = useEffectEvent((err: Error) =>
     dispatch({ error: err.message, type: "setError" }),
   );
 
-  const { resetIndex } = useSSE<StreamMessage<TStep>>(
-    state.status === "streaming" && state.runId ? `${statusUrl}?runId=${state.runId}` : null,
-    {
-      onComplete: handleComplete,
-      onError: handleError,
-      onMessage: handleMessage,
-    },
-  );
+  /**
+   * Include `_rc` (reconnect count) in the URL so that when `reconnectCount`
+   * changes, React re-triggers the `useSSE` effect with a fresh connection.
+   * The server ignores this parameter (Zod strips unknown keys).
+   * `indexRef` inside `useSSE` persists across effect cycles, so the new
+   * connection resumes from the last received message index.
+   */
+  const sseUrl =
+    state.status === "streaming" && state.runId
+      ? `${statusUrl}?runId=${state.runId}&_rc=${state.reconnectCount}`
+      : null;
+
+  const { resetIndex } = useSSE<StreamMessage<TStep>>(sseUrl, {
+    onComplete: handleComplete,
+    onError: handleError,
+    onMessage: handleMessage,
+  });
 
   const startTrigger = useEffectEvent(async () => {
     dispatch({ type: "triggerStart" });


### PR DESCRIPTION
## Summary

- Add automatic SSE reconnection when the stream closes before the expected completion step is received
- The workflow status endpoint's HTTP connection can be terminated (e.g., Vercel function timeout) while the workflow is still running — previously this showed "Generation ended unexpectedly" even though everything completed successfully
- Uses React's effect cycle for reconnection: incrementing `reconnectCount` in reducer state changes the URL, re-triggering `useSSE`'s effect with a fresh connection that resumes from the last `startIndex`

## Test plan

- [x] Unit tests for `reconnect` and `reset` reducer actions
- [x] E2E test: mock partial stream (cutoff before completion step), verify client reconnects and completes
- [x] Existing e2e tests pass unchanged (no reconnection when all messages arrive in one request)
- [x] 3 consecutive e2e runs with no flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically reconnect the workflow SSE stream when the connection drops before the completion step, resuming from the last message. This prevents false “Generation ended unexpectedly” errors during timeouts (e.g., Vercel) and lets long runs finish.

- **Bug Fixes**
  - Auto-reconnects SSE if the completion step wasn’t received; resumes via `startIndex`.
  - Triggers fresh connections by appending `_rc` to the status URL; capped at 5 retries with a 1s delay.
  - Flushes the SSE decoder to capture trailing events before close.
  - Adds unit tests for `reconnect`/`reset` and an e2e test for partial streams; existing e2e tests remain unchanged.

<sup>Written for commit 119b91bb87188ddc23b8a926c09c5bf84a9ae998. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

