### PR TITLE
feat(main): redirect earlier from course and chapter generation pages

### DIFF
--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -184,56 +184,6 @@ test.describe("Generate Chapter Page - No Subscription", () => {
 });
 
 test.describe("Generate Chapter Page - With Subscription", () => {
-  test("shows vocabulary-specific activity phases for language courses", async ({
-    userWithoutProgress,
-    noProgressUser,
-  }) => {
-    await createTestSubscription(noProgressUser.id);
-
-    const org = await getAiOrganization();
-
-    const uniqueId = randomUUID().slice(0, 8);
-    const courseTitle = `E2E Language Chapter Course ${uniqueId}`;
-    const chapterTitle = `E2E Language Chapter ${uniqueId}`;
-
-    const course = await courseFixture({
-      isPublished: true,
-      normalizedTitle: normalizeString(courseTitle),
-      organizationId: org.id,
-      slug: `e2e-language-ch-course-${uniqueId}`,
-      targetLanguage: "es",
-      title: courseTitle,
-    });
-
-    const chapter = await chapterFixture({
-      courseId: course.id,
-      generationStatus: "pending",
-      isPublished: true,
-      normalizedTitle: normalizeString(chapterTitle),
-      organizationId: org.id,
-      slug: `e2e-language-chapter-${uniqueId}`,
-      title: chapterTitle,
-    });
-
-    await setupMockApis(userWithoutProgress, {
-      statusDelayMs: 2500,
-      streamMessages: [{ status: "started", step: "getChapter" }],
-    });
-
-    await userWithoutProgress.goto(`/generate/ch/${chapter.id}`);
-
-    await expect(userWithoutProgress.getByText(/preparing practice content/i)).toBeVisible({
-      timeout: 10_000,
-    });
-
-    await expect(userWithoutProgress.getByText(/this usually takes 1-2 minutes/i)).toBeVisible();
-    await expect(userWithoutProgress.getByText(/adding pronunciation/i)).toBeVisible();
-    await expect(userWithoutProgress.getByText(/recording audio/i)).toBeVisible();
-    await expect(userWithoutProgress.getByText(/writing the content/i)).toHaveCount(0);
-    await expect(userWithoutProgress.getByText(/preparing illustrations/i)).toHaveCount(0);
-    await expect(userWithoutProgress.getByText(/creating images/i)).toHaveCount(0);
-  });
-
   test("shows generation UI and completes workflow", async ({
     userWithoutProgress,
     noProgressUser,
@@ -263,10 +213,6 @@ test.describe("Generate Chapter Page - With Subscription", () => {
         { status: "completed", step: "addLessons" },
         { status: "started", step: "setChapterAsCompleted" },
         { status: "completed", step: "setChapterAsCompleted" },
-        { status: "started", step: "setLessonAsCompleted" },
-        { status: "completed", step: "setLessonAsCompleted" },
-        { status: "started", step: "setFirstActivityAsCompleted" },
-        { status: "completed", step: "setFirstActivityAsCompleted" },
       ],
     });
 
@@ -286,143 +232,6 @@ test.describe("Generate Chapter Page - With Subscription", () => {
     });
 
     // Should redirect to chapter page
-    await userWithoutProgress.waitForURL(/\/b\/ai\/c\//, { timeout: 10_000 });
-  });
-
-  test("does not redirect language chapters on generic activity completion", async ({
-    userWithoutProgress,
-    noProgressUser,
-  }) => {
-    await createTestSubscription(noProgressUser.id);
-
-    const org = await getAiOrganization();
-    const uniqueId = randomUUID().slice(0, 8);
-    const courseTitle = `E2E Language Redirect Course ${uniqueId}`;
-    const chapterTitle = `E2E Language Redirect Chapter ${uniqueId}`;
-
-    const course = await courseFixture({
-      isPublished: true,
-      normalizedTitle: normalizeString(courseTitle),
-      organizationId: org.id,
-      slug: `e2e-language-redirect-course-${uniqueId}`,
-      targetLanguage: "es",
-      title: courseTitle,
-    });
-
-    const chapter = await chapterFixture({
-      courseId: course.id,
-      generationStatus: "pending",
-      isPublished: true,
-      normalizedTitle: normalizeString(chapterTitle),
-      organizationId: org.id,
-      slug: `e2e-language-redirect-chapter-${uniqueId}`,
-      title: chapterTitle,
-    });
-
-    await lessonFixture({
-      chapterId: chapter.id,
-      isPublished: true,
-      organizationId: org.id,
-      slug: `e2e-language-redirect-lesson-${uniqueId}`,
-      title: `E2E Language Redirect Lesson ${uniqueId}`,
-    });
-
-    await setupMockApis(userWithoutProgress, {
-      streamMessages: [
-        { status: "started", step: "getChapter" },
-        { status: "completed", step: "getChapter" },
-        { status: "started", step: "setChapterAsRunning" },
-        { status: "completed", step: "setChapterAsRunning" },
-        { status: "started", step: "generateLessons" },
-        { status: "completed", step: "generateLessons" },
-        { status: "started", step: "addLessons" },
-        { status: "completed", step: "addLessons" },
-        { status: "started", step: "setChapterAsCompleted" },
-        { status: "completed", step: "setChapterAsCompleted" },
-        { status: "started", step: "setLessonAsCompleted" },
-        { status: "completed", step: "setLessonAsCompleted" },
-        { status: "started", step: "setActivityAsCompleted" },
-        { status: "completed", step: "setActivityAsCompleted" },
-      ],
-    });
-
-    await userWithoutProgress.goto(`/generate/ch/${chapter.id}`);
-
-    await expect(userWithoutProgress.getByText(/generation ended unexpectedly/i)).toBeVisible({
-      timeout: 10_000,
-    });
-
-    await expect(userWithoutProgress).toHaveURL(new RegExp(`/generate/ch/${chapter.id}$`));
-  });
-
-  test("redirects after first activity completion", async ({
-    userWithoutProgress,
-    noProgressUser,
-  }) => {
-    await createTestSubscription(noProgressUser.id);
-
-    const org = await getAiOrganization();
-    const uniqueId = randomUUID().slice(0, 8);
-    const courseTitle = `E2E Language Redirect Course ${uniqueId}`;
-    const chapterTitle = `E2E Language Redirect Chapter ${uniqueId}`;
-
-    const course = await courseFixture({
-      isPublished: true,
-      normalizedTitle: normalizeString(courseTitle),
-      organizationId: org.id,
-      slug: `e2e-language-redirect-course-${uniqueId}`,
-      targetLanguage: "es",
-      title: courseTitle,
-    });
-
-    const chapter = await chapterFixture({
-      courseId: course.id,
-      generationStatus: "pending",
-      isPublished: true,
-      normalizedTitle: normalizeString(chapterTitle),
-      organizationId: org.id,
-      slug: `e2e-language-redirect-chapter-${uniqueId}`,
-      title: chapterTitle,
-    });
-
-    await lessonFixture({
-      chapterId: chapter.id,
-      isPublished: true,
-      organizationId: org.id,
-      slug: `e2e-language-redirect-lesson-${uniqueId}`,
-      title: `E2E Language Redirect Lesson ${uniqueId}`,
-    });
-
-    await setupMockApis(userWithoutProgress, {
-      streamMessages: [
-        { status: "started", step: "getChapter" },
-        { status: "completed", step: "getChapter" },
-        { status: "started", step: "setChapterAsRunning" },
-        { status: "completed", step: "setChapterAsRunning" },
-        { status: "started", step: "generateLessons" },
-        { status: "completed", step: "generateLessons" },
-        { status: "started", step: "addLessons" },
-        { status: "completed", step: "addLessons" },
-        { status: "started", step: "setChapterAsCompleted" },
-        { status: "completed", step: "setChapterAsCompleted" },
-        { status: "started", step: "setLessonAsCompleted" },
-        { status: "completed", step: "setLessonAsCompleted" },
-        { status: "started", step: "setFirstActivityAsCompleted" },
-        { status: "completed", step: "setFirstActivityAsCompleted" },
-      ],
-    });
-
-    await userWithoutProgress.goto(`/generate/ch/${chapter.id}`);
-
-    await expect(userWithoutProgress.getByText(/your lessons are ready/i)).toBeVisible({
-      timeout: 10_000,
-    });
-
-    await prisma.chapter.update({
-      data: { generationStatus: "completed" },
-      where: { id: chapter.id },
-    });
-
     await userWithoutProgress.waitForURL(/\/b\/ai\/c\//, { timeout: 10_000 });
   });
 
@@ -450,8 +259,8 @@ test.describe("Generate Chapter Page - With Subscription", () => {
     ];
 
     const remainingMessages = [
-      { status: "started", step: "setFirstActivityAsCompleted" },
-      { status: "completed", step: "setFirstActivityAsCompleted" },
+      { status: "started", step: "setChapterAsCompleted" },
+      { status: "completed", step: "setChapterAsCompleted" },
     ];
 
     /**

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -141,35 +141,7 @@ test.describe("Generate Course Page", () => {
         timeout: 10_000,
       });
 
-      await expect(page.getByText(/this usually takes 1-3 minutes/i)).toBeVisible();
-    });
-
-    test("shows vocabulary-specific activity phases for language courses", async ({ page }) => {
-      const slug = `e2e-language-status-${randomUUID().slice(0, 8)}`;
-      const suggestion = await courseSuggestionFixture({
-        generationStatus: "running",
-        language: "en",
-        slug,
-        targetLanguage: "es",
-        title: "E2E Language Course Status",
-      });
-
-      await setupMockApis(page, {
-        statusDelayMs: 2500,
-        streamMessages: [{ status: "started", step: "getCourseSuggestion" }],
-      });
-
-      await page.goto(`/generate/cs/${suggestion.id}`);
-
-      await expect(page.getByText(/preparing practice content/i)).toBeVisible({
-        timeout: 10_000,
-      });
-
-      await expect(page.getByText(/adding pronunciation/i)).toBeVisible();
-      await expect(page.getByText(/recording audio/i)).toBeVisible();
-      await expect(page.getByText(/writing the lesson content/i)).toHaveCount(0);
-      await expect(page.getByText(/preparing illustrations/i)).toHaveCount(0);
-      await expect(page.getByText(/creating images/i)).toHaveCount(0);
+      await expect(page.getByText(/this usually takes about a minute/i)).toBeVisible();
     });
   });
 
@@ -209,12 +181,8 @@ test.describe("Generate Course Page", () => {
         streamMessages: [
           { status: "started", step: "getCourseSuggestion" },
           { status: "completed", step: "getCourseSuggestion" },
-          { status: "started", step: "addLessons" },
-          { status: "completed", step: "addLessons" },
-          { status: "started", step: "setLessonAsCompleted" },
-          { status: "completed", step: "setLessonAsCompleted" },
-          { status: "started", step: "setFirstActivityAsCompleted" },
-          { status: "completed", step: "setFirstActivityAsCompleted" },
+          { status: "started", step: "completeCourseSetup" },
+          { status: "completed", step: "completeCourseSetup" },
         ],
       });
 
@@ -263,12 +231,8 @@ test.describe("Generate Course Page", () => {
         streamMessages: [
           { status: "started", step: "getCourseSuggestion" },
           { status: "completed", step: "getCourseSuggestion" },
-          { status: "started", step: "addLessons" },
-          { status: "completed", step: "addLessons" },
-          { status: "started", step: "setLessonAsCompleted" },
-          { status: "completed", step: "setLessonAsCompleted" },
-          { status: "started", step: "setFirstActivityAsCompleted" },
-          { status: "completed", step: "setFirstActivityAsCompleted" },
+          { status: "started", step: "completeCourseSetup" },
+          { status: "completed", step: "completeCourseSetup" },
         ],
       });
 
@@ -276,118 +240,6 @@ test.describe("Generate Course Page", () => {
 
       // Should redirect to the suffixed slug, not the raw suggestion slug
       await page.waitForURL(new RegExp(`/b/ai/c/${suffixedSlug}`), {
-        timeout: 10_000,
-      });
-    });
-
-    test("does not redirect language courses on generic activity completion", async ({ page }) => {
-      const slug = `e2e-language-completion-${randomUUID().slice(0, 8)}`;
-      const org = await getAiOrganization();
-
-      const suggestion = await courseSuggestionFixture({
-        generationStatus: "pending",
-        language: "en",
-        slug,
-        targetLanguage: "es",
-        title: "E2E Language Completion Test",
-      });
-
-      await courseFixture({
-        generationStatus: "running",
-        isPublished: true,
-        organizationId: org.id,
-        slug,
-        targetLanguage: "es",
-        title: "E2E Language Completion Test",
-      }).then(async (course) => {
-        const chapter = await chapterFixture({
-          courseId: course.id,
-          isPublished: true,
-          organizationId: org.id,
-        });
-
-        await lessonFixture({
-          chapterId: chapter.id,
-          isPublished: true,
-          organizationId: org.id,
-        });
-      });
-
-      await setupMockApis(page, {
-        streamMessages: [
-          { status: "started", step: "getCourseSuggestion" },
-          { status: "completed", step: "getCourseSuggestion" },
-          { status: "started", step: "addLessons" },
-          { status: "completed", step: "addLessons" },
-          { status: "started", step: "setLessonAsCompleted" },
-          { status: "completed", step: "setLessonAsCompleted" },
-          { status: "started", step: "setActivityAsCompleted" },
-          { status: "completed", step: "setActivityAsCompleted" },
-        ],
-      });
-
-      await page.goto(`/generate/cs/${suggestion.id}`);
-
-      await expect(page.getByText(/generation ended unexpectedly/i)).toBeVisible({
-        timeout: 10_000,
-      });
-
-      await expect(page).toHaveURL(new RegExp(`/generate/cs/${suggestion.id}$`));
-    });
-
-    test("redirects language courses after first activity completion", async ({ page }) => {
-      const slug = `e2e-language-completion-${randomUUID().slice(0, 8)}`;
-      const org = await getAiOrganization();
-
-      const suggestion = await courseSuggestionFixture({
-        generationStatus: "pending",
-        language: "en",
-        slug,
-        targetLanguage: "es",
-        title: "E2E Language Completion Test",
-      });
-
-      await courseFixture({
-        generationStatus: "running",
-        isPublished: true,
-        organizationId: org.id,
-        slug,
-        targetLanguage: "es",
-        title: "E2E Language Completion Test",
-      }).then(async (course) => {
-        const chapter = await chapterFixture({
-          courseId: course.id,
-          isPublished: true,
-          organizationId: org.id,
-        });
-
-        await lessonFixture({
-          chapterId: chapter.id,
-          isPublished: true,
-          organizationId: org.id,
-        });
-      });
-
-      await setupMockApis(page, {
-        streamMessages: [
-          { status: "started", step: "getCourseSuggestion" },
-          { status: "completed", step: "getCourseSuggestion" },
-          { status: "started", step: "addLessons" },
-          { status: "completed", step: "addLessons" },
-          { status: "started", step: "setLessonAsCompleted" },
-          { status: "completed", step: "setLessonAsCompleted" },
-          { status: "started", step: "setFirstActivityAsCompleted" },
-          { status: "completed", step: "setFirstActivityAsCompleted" },
-        ],
-      });
-
-      await page.goto(`/generate/cs/${suggestion.id}`);
-
-      await expect(page.getByText(/your course is ready/i)).toBeVisible({
-        timeout: 10_000,
-      });
-
-      await page.waitForURL(new RegExp(`/b/ai/c/${slug}`), {
         timeout: 10_000,
       });
     });

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1657,6 +1657,8 @@ msgid "Something went wrong"
 msgstr "Something went wrong"
 
 #: src/app/generate/a/[id]/generation-client.tsx
+#: src/app/generate/ch/[id]/generation-client.tsx
+#: src/app/generate/cs/[id]/generation-client.tsx
 msgctxt "kiZUDf"
 msgid "This usually takes about a minute"
 msgstr "This usually takes about a minute"
@@ -1688,27 +1690,22 @@ msgid "Something went wrong. Please try again."
 msgstr "Something went wrong. Please try again."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "19fPwV"
 msgid "Making it clear..."
 msgstr "Making it clear..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "4xvh9e"
 msgid "Getting the pronunciation right..."
 msgstr "Getting the pronunciation right..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "5InW8H"
 msgid "Recording the audio..."
 msgstr "Recording the audio..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
+#: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "5nJVpw"
@@ -1716,51 +1713,37 @@ msgid "Getting everything ready..."
 msgstr "Getting everything ready..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "8lInA7"
 msgid "Sketching out ideas..."
 msgstr "Sketching out ideas..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "abtOR3"
 msgid "Planning the layout..."
 msgstr "Planning the layout..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "aeeXxf"
 msgid "Wrapping up..."
 msgstr "Wrapping up..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "aKNA/b"
 msgid "Creating images"
 msgstr "Creating images"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "bJVUNz"
 msgid "Adding some color..."
 msgstr "Adding some color..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "dQnsCW"
 msgid "Choosing the right style..."
 msgstr "Choosing the right style..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "EAqAX/"
 msgid "Thinking about what to illustrate..."
 msgstr "Thinking about what to illustrate..."
@@ -1772,8 +1755,6 @@ msgid "Getting started"
 msgstr "Getting started"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "fbHa1D"
 msgid "Preparing practice content"
 msgstr "Preparing practice content"
@@ -1784,23 +1765,17 @@ msgid "Reviewing earlier activities..."
 msgstr "Reviewing earlier activities..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "HYmCaW"
 msgid "Almost done"
 msgstr "Almost done"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "i+rNdh"
 msgid "Picking the key vocabulary..."
 msgstr "Picking the key vocabulary..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "IdWf9/"
 msgid "Choosing words to practice..."
 msgstr "Choosing words to practice..."
@@ -1811,37 +1786,27 @@ msgid "Connecting the pieces..."
 msgstr "Connecting the pieces..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "JGNN92"
 msgid "Drawing an illustration..."
 msgstr "Drawing an illustration..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "K/JznZ"
 msgid "Writing the explanation..."
 msgstr "Writing the explanation..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "MNQpiA"
 msgid "Almost there..."
 msgstr "Almost there..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "O8xr9p"
 msgid "Working on the visuals..."
 msgstr "Working on the visuals..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "r8xznK"
 msgid "Researching the topic..."
 msgstr "Researching the topic..."
@@ -1852,47 +1817,37 @@ msgid "Processing earlier activities"
 msgstr "Processing earlier activities"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "sLBFa0"
 msgid "Preparing illustrations"
 msgstr "Preparing illustrations"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "T00GEW"
 msgid "Recording audio"
 msgstr "Recording audio"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "TlrPFF"
 msgid "Adding pronunciation"
 msgstr "Adding pronunciation"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
 msgctxt "v4iFHN"
 msgid "Writing the content"
 msgstr "Writing the content"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "VADOBa"
 msgid "Looking up how each word sounds..."
 msgstr "Looking up how each word sounds..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "WnqJeL"
 msgid "Mapping out the pronunciation..."
 msgstr "Mapping out the pronunciation..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
+#: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "xrLiIe"
@@ -1900,8 +1855,6 @@ msgid "Setting things up..."
 msgstr "Setting things up..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "Yoev2R"
 msgid "Refining the details..."
 msgstr "Refining the details..."
@@ -1915,11 +1868,6 @@ msgstr "Create Chapter"
 msgctxt "qrEiLa"
 msgid "Back to course"
 msgstr "Back to course"
-
-#: src/app/generate/ch/[id]/generation-client.tsx
-msgctxt "3vY0Zu"
-msgid "This usually takes 1-2 minutes"
-msgstr "This usually takes 1-2 minutes"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgctxt "45uo73"
@@ -1938,54 +1886,21 @@ msgstr "Creating your lessons"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "6xEJTk"
-msgid "Designing practice exercises..."
-msgstr "Designing practice exercises..."
+msgctxt "aJev/w"
+msgid "Getting things ready"
+msgstr "Getting things ready"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "GTTucy"
-msgid "Thinking about how to teach this..."
-msgstr "Thinking about how to teach this..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "HWSnYS"
 msgid "Reviewing the flow so far..."
 msgstr "Reviewing the flow so far..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "igBmpz"
-msgid "Making it interactive..."
-msgstr "Making it interactive..."
+msgctxt "L7nQzn"
+msgid "Saving your lessons"
+msgstr "Saving your lessons"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "NcACsR"
-msgid "Setting up activities"
-msgstr "Setting up activities"
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "Nh4M9g"
-msgid "Figuring out the best approach"
-msgstr "Figuring out the best approach"
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "Nhva19"
-msgid "Choosing the right approach..."
-msgstr "Choosing the right approach..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "nwGJ65"
 msgid "Exploring your topic..."
 msgstr "Exploring your topic..."
@@ -1997,12 +1912,22 @@ msgstr "Preparing lessons"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
+msgctxt "txvxwS"
+msgid "Saving your progress..."
+msgstr "Saving your progress..."
+
+#: src/app/generate/ch/[id]/use-generation-phases.ts
 msgctxt "VKFa/t"
 msgid "Mapping out the learning path..."
 msgstr "Mapping out the learning path..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
+msgctxt "XxZuJi"
+msgid "Putting it all together..."
+msgstr "Putting it all together..."
+
+#: src/app/generate/ch/[id]/use-generation-phases.ts
 msgctxt "zQWv1/"
 msgid "Writing lesson {number}..."
 msgstr "Writing lesson {number}..."
@@ -2021,16 +1946,6 @@ msgstr "Your course is ready"
 msgctxt "DFlapX"
 msgid "Creating your course"
 msgstr "Creating your course"
-
-#: src/app/generate/cs/[id]/generation-client.tsx
-msgctxt "wj9q4k"
-msgid "This usually takes 1-3 minutes"
-msgstr "This usually takes 1-3 minutes"
-
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-msgctxt "4uQ1Ek"
-msgid "Writing the lesson content"
-msgstr "Writing the lesson content"
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "9r/4zz"
@@ -2053,19 +1968,9 @@ msgid "Figuring out the right categories..."
 msgstr "Figuring out the right categories..."
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
-msgctxt "aJev/w"
-msgid "Getting things ready"
-msgstr "Getting things ready"
-
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "At4rk1"
 msgid "Adding finishing touches..."
 msgstr "Adding finishing touches..."
-
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-msgctxt "bkPdBd"
-msgid "Planning your first lesson"
-msgstr "Planning your first lesson"
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "CFWOGF"
@@ -2108,11 +2013,6 @@ msgid "Reviewing the overall flow..."
 msgstr "Reviewing the overall flow..."
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
-msgctxt "txvxwS"
-msgid "Saving your progress..."
-msgstr "Saving your progress..."
-
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "W8n2i3"
 msgid "Picking the right look..."
 msgstr "Picking the right look..."
@@ -2121,11 +2021,6 @@ msgstr "Picking the right look..."
 msgctxt "WZpB8D"
 msgid "Writing chapters"
 msgstr "Writing chapters"
-
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-msgctxt "XxZuJi"
-msgid "Putting it all together..."
-msgstr "Putting it all together..."
 
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
 msgctxt "/N8rYN"
@@ -2156,6 +2051,36 @@ msgstr "Taking you to your lesson..."
 msgctxt "THvPMp"
 msgid "This usually takes a few seconds"
 msgstr "This usually takes a few seconds"
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "6xEJTk"
+msgid "Designing practice exercises..."
+msgstr "Designing practice exercises..."
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "GTTucy"
+msgid "Thinking about how to teach this..."
+msgstr "Thinking about how to teach this..."
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "igBmpz"
+msgid "Making it interactive..."
+msgstr "Making it interactive..."
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "NcACsR"
+msgid "Setting up activities"
+msgstr "Setting up activities"
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "Nh4M9g"
+msgid "Figuring out the best approach"
+msgstr "Figuring out the best approach"
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "Nhva19"
+msgid "Choosing the right approach..."
+msgstr "Choosing the right approach..."
 
 #: src/app/generate/layout.tsx
 msgctxt "/tq5fR"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1657,6 +1657,8 @@ msgid "Something went wrong"
 msgstr "Algo salió mal"
 
 #: src/app/generate/a/[id]/generation-client.tsx
+#: src/app/generate/ch/[id]/generation-client.tsx
+#: src/app/generate/cs/[id]/generation-client.tsx
 msgctxt "kiZUDf"
 msgid "This usually takes about a minute"
 msgstr "Esto suele tomar alrededor de un minuto"
@@ -1688,27 +1690,22 @@ msgid "Something went wrong. Please try again."
 msgstr "Algo salió mal. Por favor, intenta de nuevo."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "19fPwV"
 msgid "Making it clear..."
 msgstr "Dejándolo claro..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "4xvh9e"
 msgid "Getting the pronunciation right..."
 msgstr "Ajustando la pronunciación..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "5InW8H"
 msgid "Recording the audio..."
 msgstr "Grabando el audio..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
+#: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "5nJVpw"
@@ -1716,51 +1713,37 @@ msgid "Getting everything ready..."
 msgstr "Preparando todo..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "8lInA7"
 msgid "Sketching out ideas..."
 msgstr "Esbozando ideas..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "abtOR3"
 msgid "Planning the layout..."
 msgstr "Planificando el diseño..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "aeeXxf"
 msgid "Wrapping up..."
 msgstr "Terminando..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "aKNA/b"
 msgid "Creating images"
 msgstr "Creando imágenes"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "bJVUNz"
 msgid "Adding some color..."
 msgstr "Agregando algo de color..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "dQnsCW"
 msgid "Choosing the right style..."
 msgstr "Eligiendo el estilo correcto..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "EAqAX/"
 msgid "Thinking about what to illustrate..."
 msgstr "Pensando qué ilustrar..."
@@ -1772,8 +1755,6 @@ msgid "Getting started"
 msgstr "Comenzando"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "fbHa1D"
 msgid "Preparing practice content"
 msgstr "Preparando contenido de práctica"
@@ -1784,23 +1765,17 @@ msgid "Reviewing earlier activities..."
 msgstr "Revisando actividades anteriores..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "HYmCaW"
 msgid "Almost done"
 msgstr "Casi listo"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "i+rNdh"
 msgid "Picking the key vocabulary..."
 msgstr "Seleccionando el vocabulario clave..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "IdWf9/"
 msgid "Choosing words to practice..."
 msgstr "Eligiendo palabras para practicar..."
@@ -1811,37 +1786,27 @@ msgid "Connecting the pieces..."
 msgstr "Conectando las piezas..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "JGNN92"
 msgid "Drawing an illustration..."
 msgstr "Dibujando una ilustración..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "K/JznZ"
 msgid "Writing the explanation..."
 msgstr "Escribiendo la explicación..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "MNQpiA"
 msgid "Almost there..."
 msgstr "Casi listo..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "O8xr9p"
 msgid "Working on the visuals..."
 msgstr "Trabajando en las imágenes..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "r8xznK"
 msgid "Researching the topic..."
 msgstr "Investigando el tema..."
@@ -1852,47 +1817,37 @@ msgid "Processing earlier activities"
 msgstr "Procesando actividades anteriores"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "sLBFa0"
 msgid "Preparing illustrations"
 msgstr "Preparando ilustraciones"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "T00GEW"
 msgid "Recording audio"
 msgstr "Grabando audio"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "TlrPFF"
 msgid "Adding pronunciation"
 msgstr "Agregando pronunciación"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
 msgctxt "v4iFHN"
 msgid "Writing the content"
 msgstr "Escribiendo el contenido"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "VADOBa"
 msgid "Looking up how each word sounds..."
 msgstr "Buscando cómo suena cada palabra..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "WnqJeL"
 msgid "Mapping out the pronunciation..."
 msgstr "Mapeando la pronunciación..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
+#: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "xrLiIe"
@@ -1900,8 +1855,6 @@ msgid "Setting things up..."
 msgstr "Configurando todo..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "Yoev2R"
 msgid "Refining the details..."
 msgstr "Refinando los detalles..."
@@ -1915,11 +1868,6 @@ msgstr "Crear Capítulo"
 msgctxt "qrEiLa"
 msgid "Back to course"
 msgstr "Volver al curso"
-
-#: src/app/generate/ch/[id]/generation-client.tsx
-msgctxt "3vY0Zu"
-msgid "This usually takes 1-2 minutes"
-msgstr "Esto suele tomar 1-2 minutos"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgctxt "45uo73"
@@ -1938,54 +1886,21 @@ msgstr "Creando tus lecciones"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "6xEJTk"
-msgid "Designing practice exercises..."
-msgstr "Diseñando ejercicios de práctica..."
+msgctxt "aJev/w"
+msgid "Getting things ready"
+msgstr "Preparando todo"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "GTTucy"
-msgid "Thinking about how to teach this..."
-msgstr "Pensando cómo enseñar esto..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "HWSnYS"
 msgid "Reviewing the flow so far..."
 msgstr "Revisando el flujo hasta ahora..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "igBmpz"
-msgid "Making it interactive..."
-msgstr "Haciéndolo interactivo..."
+msgctxt "L7nQzn"
+msgid "Saving your lessons"
+msgstr "Guardando tus clases"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "NcACsR"
-msgid "Setting up activities"
-msgstr "Configurando actividades"
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "Nh4M9g"
-msgid "Figuring out the best approach"
-msgstr "Determinando el mejor enfoque"
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "Nhva19"
-msgid "Choosing the right approach..."
-msgstr "Eligiendo el enfoque correcto..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "nwGJ65"
 msgid "Exploring your topic..."
 msgstr "Explorando tu tema..."
@@ -1997,12 +1912,22 @@ msgstr "Preparando lecciones"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
+msgctxt "txvxwS"
+msgid "Saving your progress..."
+msgstr "Guardando tu progreso..."
+
+#: src/app/generate/ch/[id]/use-generation-phases.ts
 msgctxt "VKFa/t"
 msgid "Mapping out the learning path..."
 msgstr "Trazando el camino de aprendizaje..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
+msgctxt "XxZuJi"
+msgid "Putting it all together..."
+msgstr "Juntando todo..."
+
+#: src/app/generate/ch/[id]/use-generation-phases.ts
 msgctxt "zQWv1/"
 msgid "Writing lesson {number}..."
 msgstr "Escribiendo la lección {number}..."
@@ -2021,16 +1946,6 @@ msgstr "Tu curso está listo"
 msgctxt "DFlapX"
 msgid "Creating your course"
 msgstr "Creando tu curso"
-
-#: src/app/generate/cs/[id]/generation-client.tsx
-msgctxt "wj9q4k"
-msgid "This usually takes 1-3 minutes"
-msgstr "Esto generalmente toma de 1 a 3 minutos"
-
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-msgctxt "4uQ1Ek"
-msgid "Writing the lesson content"
-msgstr "Escribiendo el contenido de la lección"
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "9r/4zz"
@@ -2053,19 +1968,9 @@ msgid "Figuring out the right categories..."
 msgstr "Determinando las categorías correctas..."
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
-msgctxt "aJev/w"
-msgid "Getting things ready"
-msgstr "Preparando todo"
-
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "At4rk1"
 msgid "Adding finishing touches..."
 msgstr "Agregando toques finales..."
-
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-msgctxt "bkPdBd"
-msgid "Planning your first lesson"
-msgstr "Planeando tu primera lección"
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "CFWOGF"
@@ -2108,11 +2013,6 @@ msgid "Reviewing the overall flow..."
 msgstr "Revisando el flujo general..."
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
-msgctxt "txvxwS"
-msgid "Saving your progress..."
-msgstr "Guardando tu progreso..."
-
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "W8n2i3"
 msgid "Picking the right look..."
 msgstr "Eligiendo la apariencia correcta..."
@@ -2121,11 +2021,6 @@ msgstr "Eligiendo la apariencia correcta..."
 msgctxt "WZpB8D"
 msgid "Writing chapters"
 msgstr "Escribiendo capítulos"
-
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-msgctxt "XxZuJi"
-msgid "Putting it all together..."
-msgstr "Juntando todo..."
 
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
 msgctxt "/N8rYN"
@@ -2156,6 +2051,36 @@ msgstr "Llevándote a tu lección..."
 msgctxt "THvPMp"
 msgid "This usually takes a few seconds"
 msgstr "Esto generalmente toma unos segundos"
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "6xEJTk"
+msgid "Designing practice exercises..."
+msgstr "Diseñando ejercicios de práctica..."
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "GTTucy"
+msgid "Thinking about how to teach this..."
+msgstr "Pensando cómo enseñar esto..."
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "igBmpz"
+msgid "Making it interactive..."
+msgstr "Haciéndolo interactivo..."
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "NcACsR"
+msgid "Setting up activities"
+msgstr "Configurando actividades"
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "Nh4M9g"
+msgid "Figuring out the best approach"
+msgstr "Determinando el mejor enfoque"
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "Nhva19"
+msgid "Choosing the right approach..."
+msgstr "Eligiendo el enfoque correcto..."
 
 #: src/app/generate/layout.tsx
 msgctxt "/tq5fR"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1657,6 +1657,8 @@ msgid "Something went wrong"
 msgstr "Algo deu errado"
 
 #: src/app/generate/a/[id]/generation-client.tsx
+#: src/app/generate/ch/[id]/generation-client.tsx
+#: src/app/generate/cs/[id]/generation-client.tsx
 msgctxt "kiZUDf"
 msgid "This usually takes about a minute"
 msgstr "Isso geralmente leva cerca de um minuto"
@@ -1688,27 +1690,22 @@ msgid "Something went wrong. Please try again."
 msgstr "Algo deu errado. Por favor, tente novamente."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "19fPwV"
 msgid "Making it clear..."
 msgstr "Esclarecendo..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "4xvh9e"
 msgid "Getting the pronunciation right..."
 msgstr "Acertando a pronúncia..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "5InW8H"
 msgid "Recording the audio..."
 msgstr "Gravando o áudio..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
+#: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "5nJVpw"
@@ -1716,51 +1713,37 @@ msgid "Getting everything ready..."
 msgstr "Preparando tudo..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "8lInA7"
 msgid "Sketching out ideas..."
 msgstr "Esboçando ideias..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "abtOR3"
 msgid "Planning the layout..."
 msgstr "Planejando a estrutura..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "aeeXxf"
 msgid "Wrapping up..."
 msgstr "Finalizando..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "aKNA/b"
 msgid "Creating images"
 msgstr "Criando imagens"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "bJVUNz"
 msgid "Adding some color..."
 msgstr "Adicionando um pouco de cor..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "dQnsCW"
 msgid "Choosing the right style..."
 msgstr "Escolhendo o estilo certo..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "EAqAX/"
 msgid "Thinking about what to illustrate..."
 msgstr "Pensando no que ilustrar..."
@@ -1772,8 +1755,6 @@ msgid "Getting started"
 msgstr "Começando"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "fbHa1D"
 msgid "Preparing practice content"
 msgstr "Preparando conteúdo para prática"
@@ -1784,23 +1765,17 @@ msgid "Reviewing earlier activities..."
 msgstr "Revisando atividades anteriores..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "HYmCaW"
 msgid "Almost done"
 msgstr "Quase pronto"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "i+rNdh"
 msgid "Picking the key vocabulary..."
 msgstr "Escolhendo o vocabulário principal..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "IdWf9/"
 msgid "Choosing words to practice..."
 msgstr "Escolhendo palavras pra praticar..."
@@ -1811,37 +1786,27 @@ msgid "Connecting the pieces..."
 msgstr "Conectando as peças..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "JGNN92"
 msgid "Drawing an illustration..."
 msgstr "Desenhando uma ilustração..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "K/JznZ"
 msgid "Writing the explanation..."
 msgstr "Escrevendo a explicação..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "MNQpiA"
 msgid "Almost there..."
 msgstr "Quase lá..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "O8xr9p"
 msgid "Working on the visuals..."
 msgstr "Trabalhando nos visuais..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "r8xznK"
 msgid "Researching the topic..."
 msgstr "Pesquisando o tópico..."
@@ -1852,47 +1817,37 @@ msgid "Processing earlier activities"
 msgstr "Processando atividades anteriores"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "sLBFa0"
 msgid "Preparing illustrations"
 msgstr "Preparando ilustrações"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "T00GEW"
 msgid "Recording audio"
 msgstr "Gravando áudio"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "TlrPFF"
 msgid "Adding pronunciation"
 msgstr "Adicionando pronúncia"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
 msgctxt "v4iFHN"
 msgid "Writing the content"
 msgstr "Escrevendo o conteúdo"
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "VADOBa"
 msgid "Looking up how each word sounds..."
 msgstr "Procurando como cada palavra soa..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "WnqJeL"
 msgid "Mapping out the pronunciation..."
 msgstr "Mapeando a pronúncia..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
+#: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "xrLiIe"
@@ -1900,8 +1855,6 @@ msgid "Setting things up..."
 msgstr "Configurando as coisas..."
 
 #: src/app/generate/a/[id]/use-generation-phases.ts
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "Yoev2R"
 msgid "Refining the details..."
 msgstr "Refinando os detalhes..."
@@ -1915,11 +1868,6 @@ msgstr "Criar Capítulo"
 msgctxt "qrEiLa"
 msgid "Back to course"
 msgstr "Voltar para o curso"
-
-#: src/app/generate/ch/[id]/generation-client.tsx
-msgctxt "3vY0Zu"
-msgid "This usually takes 1-2 minutes"
-msgstr "Isso geralmente leva 1-2 minutos"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgctxt "45uo73"
@@ -1938,54 +1886,21 @@ msgstr "Criando suas aulas"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "6xEJTk"
-msgid "Designing practice exercises..."
-msgstr "Criando exercícios de prática..."
+msgctxt "aJev/w"
+msgid "Getting things ready"
+msgstr "Preparando as coisas"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "GTTucy"
-msgid "Thinking about how to teach this..."
-msgstr "Pensando em como ensinar isso..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "HWSnYS"
 msgid "Reviewing the flow so far..."
 msgstr "Revisando o fluxo até agora..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "igBmpz"
-msgid "Making it interactive..."
-msgstr "Tornando interativo..."
+msgctxt "L7nQzn"
+msgid "Saving your lessons"
+msgstr "Salvando suas aulas"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "NcACsR"
-msgid "Setting up activities"
-msgstr "Configurando atividades"
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "Nh4M9g"
-msgid "Figuring out the best approach"
-msgstr "Descobrindo a melhor abordagem"
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/use-generation-phases.ts
-msgctxt "Nhva19"
-msgid "Choosing the right approach..."
-msgstr "Escolhendo a abordagem certa..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "nwGJ65"
 msgid "Exploring your topic..."
 msgstr "Explorando seu tópico..."
@@ -1997,12 +1912,22 @@ msgstr "Preparando aulas"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
+msgctxt "txvxwS"
+msgid "Saving your progress..."
+msgstr "Salvando seu progresso..."
+
+#: src/app/generate/ch/[id]/use-generation-phases.ts
 msgctxt "VKFa/t"
 msgid "Mapping out the learning path..."
 msgstr "Mapeando o caminho de aprendizado..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
+msgctxt "XxZuJi"
+msgid "Putting it all together..."
+msgstr "Juntando tudo..."
+
+#: src/app/generate/ch/[id]/use-generation-phases.ts
 msgctxt "zQWv1/"
 msgid "Writing lesson {number}..."
 msgstr "Escrevendo a aula {number}..."
@@ -2021,16 +1946,6 @@ msgstr "Seu curso está pronto"
 msgctxt "DFlapX"
 msgid "Creating your course"
 msgstr "Criando seu curso"
-
-#: src/app/generate/cs/[id]/generation-client.tsx
-msgctxt "wj9q4k"
-msgid "This usually takes 1-3 minutes"
-msgstr "Isso geralmente leva de 1 a 3 minutos"
-
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-msgctxt "4uQ1Ek"
-msgid "Writing the lesson content"
-msgstr "Escrevendo o conteúdo da aula"
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "9r/4zz"
@@ -2053,19 +1968,9 @@ msgid "Figuring out the right categories..."
 msgstr "Descobrindo as categorias certas..."
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
-msgctxt "aJev/w"
-msgid "Getting things ready"
-msgstr "Preparando as coisas"
-
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "At4rk1"
 msgid "Adding finishing touches..."
 msgstr "Adicionando os toques finais..."
-
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-msgctxt "bkPdBd"
-msgid "Planning your first lesson"
-msgstr "Planejando sua primeira aula"
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "CFWOGF"
@@ -2108,11 +2013,6 @@ msgid "Reviewing the overall flow..."
 msgstr "Revisando o fluxo geral..."
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
-msgctxt "txvxwS"
-msgid "Saving your progress..."
-msgstr "Salvando seu progresso..."
-
-#: src/app/generate/cs/[id]/use-generation-phases.ts
 msgctxt "W8n2i3"
 msgid "Picking the right look..."
 msgstr "Escolhendo a aparência certa..."
@@ -2121,11 +2021,6 @@ msgstr "Escolhendo a aparência certa..."
 msgctxt "WZpB8D"
 msgid "Writing chapters"
 msgstr "Escrevendo capítulos"
-
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-msgctxt "XxZuJi"
-msgid "Putting it all together..."
-msgstr "Juntando tudo..."
 
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
 msgctxt "/N8rYN"
@@ -2156,6 +2051,36 @@ msgstr "Levando você para sua aula..."
 msgctxt "THvPMp"
 msgid "This usually takes a few seconds"
 msgstr "Isso geralmente leva alguns segundos"
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "6xEJTk"
+msgid "Designing practice exercises..."
+msgstr "Criando exercícios de prática..."
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "GTTucy"
+msgid "Thinking about how to teach this..."
+msgstr "Pensando em como ensinar isso..."
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "igBmpz"
+msgid "Making it interactive..."
+msgstr "Tornando interativo..."
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "NcACsR"
+msgid "Setting up activities"
+msgstr "Configurando atividades"
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "Nh4M9g"
+msgid "Figuring out the best approach"
+msgstr "Descobrindo a melhor abordagem"
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "Nhva19"
+msgid "Choosing the right approach..."
+msgstr "Escolhendo a abordagem certa..."
 
 #: src/app/generate/layout.tsx
 msgctxt "/tq5fR"

--- a/apps/main/src/app/generate/a/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/a/[id]/use-generation-phases.ts
@@ -1,11 +1,10 @@
 "use client";
 
 import { type PhaseStatus, enforcePhaseProgression } from "@/lib/generation-phases";
+import { type PhaseName, getPhaseOrder } from "@/lib/generation/activity-generation-phase-config";
 import {
   PHASE_ICONS,
-  type PhaseName,
   calculateWeightedProgress,
-  getPhaseOrder,
   getPhaseStatus,
 } from "@/lib/generation/activity-generation-phases";
 import { type ActivityStepName } from "@/lib/workflow/config";

--- a/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
@@ -66,7 +66,6 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
             courseSlug={chapter.course.slug}
             generationRunId={chapter.generationRunId}
             generationStatus={chapter.generationStatus}
-            targetLanguage={chapter.course.targetLanguage}
           />
         </SubscriptionGate>
       </ContainerBody>

--- a/apps/main/src/app/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generation-client.tsx
@@ -11,10 +11,7 @@ import {
   GenerationTimelineSubtitle,
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
-import {
-  type ChapterWorkflowStepName,
-  FIRST_ACTIVITY_COMPLETION_STEP,
-} from "@/lib/workflow/config";
+import { type ChapterWorkflowStepName } from "@/lib/workflow/config";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useThinkingMessages } from "@/lib/workflow/use-thinking-messages";
@@ -31,19 +28,17 @@ export function GenerationClient({
   courseSlug,
   generationRunId,
   generationStatus,
-  targetLanguage,
 }: {
   chapterId: number;
   chapterSlug: string;
   courseSlug: string;
   generationRunId: string | null;
   generationStatus: GenerationStatus;
-  targetLanguage: string | null;
 }) {
   const t = useExtracted();
 
   const generation = useWorkflowGeneration<ChapterWorkflowStepName>({
-    completionStep: FIRST_ACTIVITY_COMPLETION_STEP,
+    completionStep: "setChapterAsCompleted",
     initialRunId: generationRunId,
     initialStatus: generationStatus === "running" ? "streaming" : "idle",
     statusUrl: `${API_URL}/v1/workflows/chapter-generation/status`,
@@ -54,7 +49,6 @@ export function GenerationClient({
   const { activePhaseNames, phases, progress, thinkingGenerators } = useGenerationPhases(
     generation.completedSteps,
     generation.currentStep,
-    targetLanguage,
     generation.startedSteps,
   );
 
@@ -76,7 +70,7 @@ export function GenerationClient({
         <GenerationTimelineHeader>
           <GenerationTimelineTitle>{t("Creating your lessons")}</GenerationTimelineTitle>
           <GenerationTimelineSubtitle>
-            {t("This usually takes 1-2 minutes")}
+            {t("This usually takes about a minute")}
           </GenerationTimelineSubtitle>
           <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
         </GenerationTimelineHeader>

--- a/apps/main/src/app/generate/ch/[id]/generation-phases.test.ts
+++ b/apps/main/src/app/generate/ch/[id]/generation-phases.test.ts
@@ -1,45 +1,59 @@
 import { describe, expect, test } from "vitest";
-import { getPhaseOrder, getPhaseStatus } from "./generation-phases";
+import { calculateWeightedProgress, getPhaseOrder, getPhaseStatus } from "./generation-phases";
 
 describe("chapter generation phases", () => {
-  test("uses vocabulary-specific tail phases for language courses", () => {
-    const phases = getPhaseOrder({
-      completedSteps: ["getLessonActivities"],
-      currentStep: "generateVocabularyContent",
-      targetLanguage: "fr",
-    });
+  test("returns all 3 chapter phases in order", () => {
+    const phases = getPhaseOrder();
 
-    expect(phases).toContain("buildingWordList");
-    expect(phases).toContain("addingPronunciation");
-    expect(phases).toContain("recordingAudio");
-    expect(phases).not.toContain("writingContent");
-    expect(phases).not.toContain("preparingVisuals");
-    expect(phases).not.toContain("creatingImages");
+    expect(phases).toEqual(["gettingReady", "preparingLessons", "savingLessons"]);
   });
 
-  test("keeps non-language tail phases for regular chapters", () => {
-    const phases = getPhaseOrder({
-      completedSteps: ["getLessonActivities"],
-      currentStep: "generateExplanationContent",
-      targetLanguage: null,
-    });
-
-    expect(phases).toContain("writingContent");
-    expect(phases).toContain("preparingVisuals");
-    expect(phases).toContain("creatingImages");
-    expect(phases).not.toContain("buildingWordList");
-    expect(phases).not.toContain("addingPronunciation");
-    expect(phases).not.toContain("recordingAudio");
+  test("marks gettingReady as active when its step is the current step", () => {
+    const status = getPhaseStatus("gettingReady", [], "getChapter");
+    expect(status).toBe("active");
   });
 
-  test("marks buildingWordList as active for vocabulary steps", () => {
+  test("marks preparingLessons as active when generateLessons is in progress", () => {
     const status = getPhaseStatus(
-      "buildingWordList",
-      ["setActivityAsRunning"],
-      "generateVocabularyContent",
-      "fr",
+      "preparingLessons",
+      ["getChapter", "setChapterAsRunning"],
+      "generateLessons",
     );
 
     expect(status).toBe("active");
+  });
+
+  test("marks savingLessons as completed when all its steps are done", () => {
+    const status = getPhaseStatus(
+      "savingLessons",
+      [
+        "getChapter",
+        "setChapterAsRunning",
+        "generateLessons",
+        "addLessons",
+        "setChapterAsCompleted",
+      ],
+      null,
+    );
+
+    expect(status).toBe("completed");
+  });
+
+  test("returns 0 progress at start", () => {
+    const progress = calculateWeightedProgress([], null);
+    expect(progress).toBe(0);
+  });
+
+  test("returns 100 progress when all steps are complete", () => {
+    const allSteps = [
+      "getChapter",
+      "setChapterAsRunning",
+      "generateLessons",
+      "addLessons",
+      "setChapterAsCompleted",
+    ] as const;
+
+    const progress = calculateWeightedProgress([...allSteps], null);
+    expect(progress).toBe(100);
   });
 });

--- a/apps/main/src/app/generate/ch/[id]/generation-phases.ts
+++ b/apps/main/src/app/generate/ch/[id]/generation-phases.ts
@@ -4,204 +4,56 @@ import {
   calculateWeightedProgress as calculateProgress,
   getPhaseStatus as getStatus,
 } from "@/lib/generation-phases";
-import {
-  PHASE_ICONS as ACTIVITY_PHASE_ICONS,
-  type PhaseName as ActivityPhaseName,
-  type FirstActivityKind,
-  getPhaseSteps as getActivityPhaseSteps,
-  inferFirstActivityKind,
-} from "@/lib/generation/activity-generation-phases";
-import {
-  type ActivityStepName,
-  type ChapterStepName,
-  type ChapterWorkflowStepName,
-  type LessonStepName,
-} from "@/lib/workflow/config";
-import {
-  BookOpenIcon,
-  CheckCircleIcon,
-  CompassIcon,
-  ImageIcon,
-  LayoutListIcon,
-  type LucideIcon,
-  PaletteIcon,
-  PenLineIcon,
-} from "lucide-react";
+import { type ChapterStepName, type ChapterWorkflowStepName } from "@/lib/workflow/config";
+import { BookOpenIcon, type LucideIcon, SaveIcon, SettingsIcon } from "lucide-react";
 
-type BasePhaseName = "preparingLessons" | "figuringOutApproach" | "settingUpActivities";
+export type PhaseName = "gettingReady" | "preparingLessons" | "savingLessons";
 
-type ActivityTailPhaseName = Exclude<
-  ActivityPhaseName,
-  "gettingStarted" | "processingDependencies"
->;
+const PHASE_STEPS = {
+  gettingReady: ["getChapter", "setChapterAsRunning"],
+  preparingLessons: ["generateLessons"],
+  savingLessons: ["addLessons", "setChapterAsCompleted"],
+} as const satisfies Record<PhaseName, readonly ChapterStepName[]>;
 
-export type PhaseName = BasePhaseName | ActivityTailPhaseName;
-
-const BASE_PHASE_STEPS = {
-  figuringOutApproach: [
-    "getLesson",
-    "setLessonAsRunning",
-    "determineLessonKind",
-    "updateLessonKind",
-  ],
-  preparingLessons: [
-    "getChapter",
-    "setChapterAsRunning",
-    "generateLessons",
-    "addLessons",
-    "setChapterAsCompleted",
-  ],
-  settingUpActivities: [
-    "generateCustomActivities",
-    "addActivities",
-    "setLessonAsCompleted",
-    "getLessonActivities",
-  ],
-} as const satisfies Record<BasePhaseName, readonly ChapterWorkflowStepName[]>;
-
-type AssignedSteps = (typeof BASE_PHASE_STEPS)[BasePhaseName][number] | ActivityStepName;
-
+type AssignedSteps = (typeof PHASE_STEPS)[PhaseName][number];
 type _ValidateChapter = AssertAllCovered<Exclude<ChapterStepName, AssignedSteps>>;
-type _ValidateLesson = AssertAllCovered<Exclude<LessonStepName, AssignedSteps>>;
-type _ValidateActivity = AssertAllCovered<
-  Exclude<ActivityStepName, AssignedSteps | "workflowError">
->;
 
-const BASE_PHASE_ORDER: BasePhaseName[] = [
-  "preparingLessons",
-  "figuringOutApproach",
-  "settingUpActivities",
-];
+const PHASE_ORDER: PhaseName[] = ["gettingReady", "preparingLessons", "savingLessons"];
 
-const NON_LANGUAGE_ACTIVITY_TAIL_ORDER: ActivityTailPhaseName[] = [
-  "writingContent",
-  "preparingVisuals",
-  "creatingImages",
-  "finishing",
-];
-
-const LANGUAGE_ACTIVITY_TAIL_ORDER: ActivityTailPhaseName[] = [
-  "buildingWordList",
-  "addingPronunciation",
-  "recordingAudio",
-  "finishing",
-];
-
-function getInferredFirstActivityKind(
-  completedSteps: ChapterWorkflowStepName[],
-  currentStep: ChapterWorkflowStepName | null,
-  targetLanguage: string | null,
-): FirstActivityKind {
-  return inferFirstActivityKind({ completedSteps, currentStep, targetLanguage });
-}
-
-function getActivityTailPhaseOrder(kind: FirstActivityKind): ActivityTailPhaseName[] {
-  if (kind === "vocabulary") {
-    return LANGUAGE_ACTIVITY_TAIL_ORDER;
-  }
-
-  return NON_LANGUAGE_ACTIVITY_TAIL_ORDER;
-}
-
-function getPhaseSteps(
-  kind: FirstActivityKind,
-): Record<PhaseName, readonly ChapterWorkflowStepName[]> {
-  const activitySteps = getActivityPhaseSteps(kind);
-
-  return {
-    ...BASE_PHASE_STEPS,
-    addingPronunciation: activitySteps.addingPronunciation,
-    buildingWordList: activitySteps.buildingWordList,
-    creatingImages: activitySteps.creatingImages,
-    finishing: activitySteps.finishing,
-    preparingVisuals: activitySteps.preparingVisuals,
-    recordingAudio: activitySteps.recordingAudio,
-    writingContent: activitySteps.writingContent,
-  };
-}
-
-export function getPhaseOrder(params: {
-  completedSteps: ChapterWorkflowStepName[];
-  currentStep: ChapterWorkflowStepName | null;
-  targetLanguage: string | null;
-}): PhaseName[] {
-  const kind = getInferredFirstActivityKind(
-    params.completedSteps,
-    params.currentStep,
-    params.targetLanguage,
-  );
-
-  return [...BASE_PHASE_ORDER, ...getActivityTailPhaseOrder(kind)];
+export function getPhaseOrder(): PhaseName[] {
+  return PHASE_ORDER;
 }
 
 export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
-  addingPronunciation: ACTIVITY_PHASE_ICONS.addingPronunciation,
-  buildingWordList: ACTIVITY_PHASE_ICONS.buildingWordList,
-  creatingImages: ImageIcon,
-  figuringOutApproach: CompassIcon,
-  finishing: CheckCircleIcon,
+  gettingReady: SettingsIcon,
   preparingLessons: BookOpenIcon,
-  preparingVisuals: PaletteIcon,
-  recordingAudio: ACTIVITY_PHASE_ICONS.recordingAudio,
-  settingUpActivities: LayoutListIcon,
-  writingContent: PenLineIcon,
+  savingLessons: SaveIcon,
 };
 
-const BASE_PHASE_WEIGHTS: Record<BasePhaseName, number> = {
-  figuringOutApproach: 2,
-  preparingLessons: 24,
-  settingUpActivities: 4,
+const PHASE_WEIGHTS: Record<PhaseName, number> = {
+  gettingReady: 5,
+  preparingLessons: 85,
+  savingLessons: 10,
 };
-
-function getPhaseWeights(kind: FirstActivityKind): Record<PhaseName, number> {
-  if (kind === "vocabulary") {
-    return {
-      ...BASE_PHASE_WEIGHTS,
-      addingPronunciation: 18,
-      buildingWordList: 14,
-      creatingImages: 0,
-      finishing: 7,
-      preparingVisuals: 0,
-      recordingAudio: 31,
-      writingContent: 0,
-    };
-  }
-
-  return {
-    ...BASE_PHASE_WEIGHTS,
-    addingPronunciation: 0,
-    buildingWordList: 0,
-    creatingImages: 24,
-    finishing: 2,
-    preparingVisuals: 11,
-    recordingAudio: 0,
-    writingContent: 33,
-  };
-}
 
 export function getPhaseStatus(
   phase: PhaseName,
   completedSteps: ChapterWorkflowStepName[],
   currentStep: ChapterWorkflowStepName | null,
-  targetLanguage: string | null,
   startedSteps?: ChapterWorkflowStepName[],
 ): PhaseStatus {
-  const kind = getInferredFirstActivityKind(completedSteps, currentStep, targetLanguage);
-  return getStatus(phase, completedSteps, currentStep, getPhaseSteps(kind), startedSteps);
+  return getStatus(phase, completedSteps, currentStep, PHASE_STEPS, startedSteps);
 }
 
 export function calculateWeightedProgress(
   completedSteps: ChapterWorkflowStepName[],
   currentStep: ChapterWorkflowStepName | null,
-  targetLanguage: string | null,
   startedSteps?: ChapterWorkflowStepName[],
 ): number {
-  const kind = getInferredFirstActivityKind(completedSteps, currentStep, targetLanguage);
-
   return calculateProgress(completedSteps, currentStep, {
-    phaseOrder: getPhaseOrder({ completedSteps, currentStep, targetLanguage }),
-    phaseSteps: getPhaseSteps(kind),
-    phaseWeights: getPhaseWeights(kind),
+    phaseOrder: PHASE_ORDER,
+    phaseSteps: PHASE_STEPS,
+    phaseWeights: PHASE_WEIGHTS,
     startedSteps,
   });
 }

--- a/apps/main/src/app/generate/ch/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/ch/[id]/use-generation-phases.ts
@@ -19,25 +19,17 @@ import {
 export function useGenerationPhases(
   completedSteps: ChapterWorkflowStepName[],
   currentStep: ChapterWorkflowStepName | null,
-  targetLanguage: string | null,
   startedSteps?: ChapterWorkflowStepName[],
 ) {
   const t = useExtracted();
 
   const labels: Record<PhaseName, string> = {
-    addingPronunciation: t("Adding pronunciation"),
-    buildingWordList: t("Preparing practice content"),
-    creatingImages: t("Creating images"),
-    figuringOutApproach: t("Figuring out the best approach"),
-    finishing: t("Almost done"),
+    gettingReady: t("Getting things ready"),
     preparingLessons: t("Preparing lessons"),
-    preparingVisuals: t("Preparing illustrations"),
-    recordingAudio: t("Recording audio"),
-    settingUpActivities: t("Setting up activities"),
-    writingContent: t("Writing the content"),
+    savingLessons: t("Saving your lessons"),
   };
 
-  const phaseOrder = getPhaseOrder({ completedSteps, currentStep, targetLanguage });
+  const phaseOrder = getPhaseOrder();
 
   const rawPhases: {
     name: PhaseName;
@@ -48,70 +40,27 @@ export function useGenerationPhases(
     icon: PHASE_ICONS[phase],
     label: labels[phase],
     name: phase,
-    status: getPhaseStatus(phase, completedSteps, currentStep, targetLanguage, startedSteps),
+    status: getPhaseStatus(phase, completedSteps, currentStep, startedSteps),
   }));
 
   const phases = enforcePhaseProgression(rawPhases);
 
-  const progress = calculateWeightedProgress(
-    completedSteps,
-    currentStep,
-    targetLanguage,
-    startedSteps,
-  );
+  const progress = calculateWeightedProgress(completedSteps, currentStep, startedSteps);
 
   const activePhaseNames = phases
     .filter((phase) => phase.status === "active")
     .map((phase) => phase.name);
 
   const thinkingGenerators: Record<PhaseName, ThinkingMessageGenerator> = {
-    addingPronunciation: (index) =>
-      cycleMessage(
-        [t("Looking up how each word sounds..."), t("Mapping out the pronunciation...")],
-        index,
-      ),
-    buildingWordList: (index) =>
-      cycleMessage([t("Picking the key vocabulary..."), t("Choosing words to practice...")], index),
-    creatingImages: (index) =>
-      cycleMessage(
-        [
-          t("Drawing an illustration..."),
-          t("Working on the visuals..."),
-          t("Adding some color..."),
-          t("Refining the details..."),
-        ],
-        index,
-      ),
-    figuringOutApproach: (index) =>
-      cycleMessage(
-        [t("Thinking about how to teach this..."), t("Choosing the right approach...")],
-        index,
-      ),
-    finishing: (index) => cycleMessage([t("Wrapping up..."), t("Almost there...")], index),
+    gettingReady: (index) =>
+      cycleMessage([t("Setting things up..."), t("Getting everything ready...")], index),
     preparingLessons: createCountingGenerator({
       intro: [t("Exploring your topic..."), t("Mapping out the learning path...")],
       itemTemplate: (num) => t("Writing lesson {number}...", { number: String(num) }),
       reviewMessage: t("Reviewing the flow so far..."),
     }),
-    preparingVisuals: (index) =>
-      cycleMessage(
-        [
-          t("Thinking about what to illustrate..."),
-          t("Sketching out ideas..."),
-          t("Choosing the right style..."),
-          t("Planning the layout..."),
-        ],
-        index,
-      ),
-    recordingAudio: (index) =>
-      cycleMessage([t("Recording the audio..."), t("Getting the pronunciation right...")], index),
-    settingUpActivities: (index) =>
-      cycleMessage([t("Designing practice exercises..."), t("Making it interactive...")], index),
-    writingContent: (index) =>
-      cycleMessage(
-        [t("Researching the topic..."), t("Writing the explanation..."), t("Making it clear...")],
-        index,
-      ),
+    savingLessons: (index) =>
+      cycleMessage([t("Saving your progress..."), t("Putting it all together...")], index),
   };
 
   return { activePhaseNames, phases, progress, thinkingGenerators };

--- a/apps/main/src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
@@ -58,7 +58,6 @@ export async function GenerateCourseSuggestionContent({
           generationRunId={suggestion.generationRunId}
           generationStatus={suggestion.generationStatus}
           suggestionId={suggestionId}
-          targetLanguage={suggestion.targetLanguage}
         />
       </ContainerBody>
     </Container>

--- a/apps/main/src/app/generate/cs/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generation-client.tsx
@@ -11,7 +11,7 @@ import {
   GenerationTimelineSubtitle,
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
-import { type CourseWorkflowStepName, FIRST_ACTIVITY_COMPLETION_STEP } from "@/lib/workflow/config";
+import { type CourseWorkflowStepName } from "@/lib/workflow/config";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useThinkingMessages } from "@/lib/workflow/use-thinking-messages";
@@ -27,18 +27,16 @@ export function GenerationClient({
   generationRunId,
   generationStatus,
   suggestionId,
-  targetLanguage,
 }: {
   courseSlug: string;
   generationRunId: string | null;
   generationStatus: GenerationStatus;
   suggestionId: number;
-  targetLanguage: string | null;
 }) {
   const t = useExtracted();
 
   const generation = useWorkflowGeneration<CourseWorkflowStepName>({
-    completionStep: FIRST_ACTIVITY_COMPLETION_STEP,
+    completionStep: "completeCourseSetup",
     initialRunId: generationRunId,
     initialStatus: generationStatus === "running" ? "streaming" : "idle",
     statusUrl: `${API_URL}/v1/workflows/course-generation/status`,
@@ -49,7 +47,6 @@ export function GenerationClient({
   const { activePhaseNames, phases, progress, thinkingGenerators } = useGenerationPhases(
     generation.completedSteps,
     generation.currentStep,
-    targetLanguage,
     generation.startedSteps,
   );
 
@@ -71,7 +68,7 @@ export function GenerationClient({
         <GenerationTimelineHeader>
           <GenerationTimelineTitle>{t("Creating your course")}</GenerationTimelineTitle>
           <GenerationTimelineSubtitle>
-            {t("This usually takes 1-3 minutes")}
+            {t("This usually takes about a minute")}
           </GenerationTimelineSubtitle>
           <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
         </GenerationTimelineHeader>

--- a/apps/main/src/app/generate/cs/[id]/generation-phases.test.ts
+++ b/apps/main/src/app/generate/cs/[id]/generation-phases.test.ts
@@ -1,45 +1,65 @@
 import { describe, expect, test } from "vitest";
-import { getPhaseOrder, getPhaseStatus } from "./generation-phases";
+import { calculateWeightedProgress, getPhaseOrder, getPhaseStatus } from "./generation-phases";
 
 describe("course generation phases", () => {
-  test("uses vocabulary-specific tail phases for language courses", () => {
-    const phases = getPhaseOrder({
-      completedSteps: ["getLessonActivities"],
-      currentStep: "generateVocabularyContent",
-      targetLanguage: "es",
-    });
+  test("returns all 6 course phases in order", () => {
+    const phases = getPhaseOrder();
 
-    expect(phases).toContain("buildingWordList");
-    expect(phases).toContain("addingPronunciation");
-    expect(phases).toContain("recordingAudio");
-    expect(phases).not.toContain("writingContent");
-    expect(phases).not.toContain("preparingVisuals");
-    expect(phases).not.toContain("creatingImages");
+    expect(phases).toEqual([
+      "gettingReady",
+      "writingDescription",
+      "creatingCoverImage",
+      "categorizingCourse",
+      "outliningChapters",
+      "savingCourseInfo",
+    ]);
   });
 
-  test("keeps non-language tail phases for regular courses", () => {
-    const phases = getPhaseOrder({
-      completedSteps: ["getLessonActivities"],
-      currentStep: "generateExplanationContent",
-      targetLanguage: null,
-    });
-
-    expect(phases).toContain("writingContent");
-    expect(phases).toContain("preparingVisuals");
-    expect(phases).toContain("creatingImages");
-    expect(phases).not.toContain("buildingWordList");
-    expect(phases).not.toContain("addingPronunciation");
-    expect(phases).not.toContain("recordingAudio");
+  test("marks phase as active when its step is the current step", () => {
+    const status = getPhaseStatus("writingDescription", [], "generateDescription");
+    expect(status).toBe("active");
   });
 
-  test("marks buildingWordList as active for vocabulary steps", () => {
+  test("marks phase as completed when all its steps are completed", () => {
     const status = getPhaseStatus(
-      "buildingWordList",
-      ["setActivityAsRunning"],
-      "generateVocabularyContent",
-      "es",
+      "gettingReady",
+      ["getCourseSuggestion", "checkExistingCourse", "initializeCourse", "setCourseAsRunning"],
+      null,
     );
 
-    expect(status).toBe("active");
+    expect(status).toBe("completed");
+  });
+
+  test("marks phase as pending when no steps have started", () => {
+    const status = getPhaseStatus("outliningChapters", [], null);
+    expect(status).toBe("pending");
+  });
+
+  test("returns 0 progress at start", () => {
+    const progress = calculateWeightedProgress([], null);
+    expect(progress).toBe(0);
+  });
+
+  test("returns 100 progress when all steps are complete", () => {
+    const allSteps = [
+      "getCourseSuggestion",
+      "checkExistingCourse",
+      "initializeCourse",
+      "setCourseAsRunning",
+      "generateDescription",
+      "generateImage",
+      "generateAlternativeTitles",
+      "generateCategories",
+      "generateChapters",
+      "getExistingChapters",
+      "updateCourse",
+      "addAlternativeTitles",
+      "addCategories",
+      "addChapters",
+      "completeCourseSetup",
+    ] as const;
+
+    const progress = calculateWeightedProgress([...allSteps], null);
+    expect(progress).toBe(100);
   });
 });

--- a/apps/main/src/app/generate/cs/[id]/generation-phases.ts
+++ b/apps/main/src/app/generate/cs/[id]/generation-phases.ts
@@ -4,62 +4,28 @@ import {
   calculateWeightedProgress as calculateProgress,
   getPhaseStatus as getStatus,
 } from "@/lib/generation-phases";
+import { type CourseStepName, type CourseWorkflowStepName } from "@/lib/workflow/config";
 import {
-  PHASE_ICONS as ACTIVITY_PHASE_ICONS,
-  type PhaseName as ActivityPhaseName,
-  type FirstActivityKind,
-  getPhaseSteps as getActivityPhaseSteps,
-  inferFirstActivityKind,
-} from "@/lib/generation/activity-generation-phases";
-import {
-  type ActivityStepName,
-  type ChapterStepName,
-  type CourseStepName,
-  type CourseWorkflowStepName,
-  type LessonStepName,
-} from "@/lib/workflow/config";
-import {
-  BookOpenIcon,
-  CheckCircleIcon,
-  CompassIcon,
   ImageIcon,
   LayoutListIcon,
   type LucideIcon,
-  PaletteIcon,
   PenLineIcon,
   SaveIcon,
   SettingsIcon,
-  SparklesIcon,
   TagIcon,
 } from "lucide-react";
 
-type BasePhaseName =
+export type PhaseName =
   | "gettingReady"
   | "writingDescription"
   | "creatingCoverImage"
   | "categorizingCourse"
   | "outliningChapters"
-  | "savingCourseInfo"
-  | "planningLessons"
-  | "figuringOutApproach"
-  | "settingUpActivities";
+  | "savingCourseInfo";
 
-type ActivityTailPhaseName = Exclude<
-  ActivityPhaseName,
-  "gettingStarted" | "processingDependencies"
->;
-
-export type PhaseName = BasePhaseName | ActivityTailPhaseName;
-
-const BASE_PHASE_STEPS = {
+const PHASE_STEPS = {
   categorizingCourse: ["generateAlternativeTitles", "generateCategories"],
   creatingCoverImage: ["generateImage"],
-  figuringOutApproach: [
-    "getLesson",
-    "setLessonAsRunning",
-    "determineLessonKind",
-    "updateLessonKind",
-  ],
   gettingReady: [
     "getCourseSuggestion",
     "checkExistingCourse",
@@ -67,13 +33,6 @@ const BASE_PHASE_STEPS = {
     "setCourseAsRunning",
   ],
   outliningChapters: ["generateChapters"],
-  planningLessons: [
-    "getChapter",
-    "setChapterAsRunning",
-    "generateLessons",
-    "addLessons",
-    "setChapterAsCompleted",
-  ],
   savingCourseInfo: [
     "getExistingChapters",
     "updateCourse",
@@ -82,177 +41,61 @@ const BASE_PHASE_STEPS = {
     "addChapters",
     "completeCourseSetup",
   ],
-  settingUpActivities: [
-    "generateCustomActivities",
-    "addActivities",
-    "setLessonAsCompleted",
-    "getLessonActivities",
-  ],
   writingDescription: ["generateDescription"],
-} as const satisfies Record<BasePhaseName, readonly CourseWorkflowStepName[]>;
+} as const satisfies Record<PhaseName, readonly CourseStepName[]>;
 
-type AssignedSteps = (typeof BASE_PHASE_STEPS)[BasePhaseName][number] | ActivityStepName;
-
+type AssignedSteps = (typeof PHASE_STEPS)[PhaseName][number];
 type _ValidateCourse = AssertAllCovered<Exclude<CourseStepName, AssignedSteps>>;
-type _ValidateChapter = AssertAllCovered<Exclude<ChapterStepName, AssignedSteps>>;
-type _ValidateLesson = AssertAllCovered<Exclude<LessonStepName, AssignedSteps>>;
-type _ValidateActivity = AssertAllCovered<
-  Exclude<ActivityStepName, AssignedSteps | "workflowError">
->;
 
-const BASE_PHASE_ORDER: BasePhaseName[] = [
+const PHASE_ORDER: PhaseName[] = [
   "gettingReady",
   "writingDescription",
   "creatingCoverImage",
   "categorizingCourse",
   "outliningChapters",
   "savingCourseInfo",
-  "planningLessons",
-  "figuringOutApproach",
-  "settingUpActivities",
 ];
 
-const NON_LANGUAGE_ACTIVITY_TAIL_ORDER: ActivityTailPhaseName[] = [
-  "writingContent",
-  "preparingVisuals",
-  "creatingImages",
-  "finishing",
-];
-
-const LANGUAGE_ACTIVITY_TAIL_ORDER: ActivityTailPhaseName[] = [
-  "buildingWordList",
-  "addingPronunciation",
-  "recordingAudio",
-  "finishing",
-];
-
-function getInferredFirstActivityKind(
-  completedSteps: CourseWorkflowStepName[],
-  currentStep: CourseWorkflowStepName | null,
-  targetLanguage: string | null,
-): FirstActivityKind {
-  return inferFirstActivityKind({ completedSteps, currentStep, targetLanguage });
-}
-
-function getActivityTailPhaseOrder(kind: FirstActivityKind): ActivityTailPhaseName[] {
-  if (kind === "vocabulary") {
-    return LANGUAGE_ACTIVITY_TAIL_ORDER;
-  }
-
-  return NON_LANGUAGE_ACTIVITY_TAIL_ORDER;
-}
-
-function getPhaseSteps(
-  kind: FirstActivityKind,
-): Record<PhaseName, readonly CourseWorkflowStepName[]> {
-  const activitySteps = getActivityPhaseSteps(kind);
-
-  return {
-    ...BASE_PHASE_STEPS,
-    addingPronunciation: activitySteps.addingPronunciation,
-    buildingWordList: activitySteps.buildingWordList,
-    creatingImages: activitySteps.creatingImages,
-    finishing: activitySteps.finishing,
-    preparingVisuals: activitySteps.preparingVisuals,
-    recordingAudio: activitySteps.recordingAudio,
-    writingContent: activitySteps.writingContent,
-  };
-}
-
-export function getPhaseOrder(params: {
-  completedSteps: CourseWorkflowStepName[];
-  currentStep: CourseWorkflowStepName | null;
-  targetLanguage: string | null;
-}): PhaseName[] {
-  const kind = getInferredFirstActivityKind(
-    params.completedSteps,
-    params.currentStep,
-    params.targetLanguage,
-  );
-
-  return [...BASE_PHASE_ORDER, ...getActivityTailPhaseOrder(kind)];
+export function getPhaseOrder(): PhaseName[] {
+  return PHASE_ORDER;
 }
 
 export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
-  addingPronunciation: ACTIVITY_PHASE_ICONS.addingPronunciation,
-  buildingWordList: ACTIVITY_PHASE_ICONS.buildingWordList,
   categorizingCourse: TagIcon,
   creatingCoverImage: ImageIcon,
-  creatingImages: ImageIcon,
-  figuringOutApproach: CompassIcon,
-  finishing: CheckCircleIcon,
   gettingReady: SettingsIcon,
   outliningChapters: LayoutListIcon,
-  planningLessons: BookOpenIcon,
-  preparingVisuals: PaletteIcon,
-  recordingAudio: ACTIVITY_PHASE_ICONS.recordingAudio,
   savingCourseInfo: SaveIcon,
-  settingUpActivities: LayoutListIcon,
-  writingContent: SparklesIcon,
   writingDescription: PenLineIcon,
 };
 
-const BASE_PHASE_WEIGHTS: Record<BasePhaseName, number> = {
+const PHASE_WEIGHTS: Record<PhaseName, number> = {
   categorizingCourse: 3,
   creatingCoverImage: 7,
-  figuringOutApproach: 1,
   gettingReady: 1,
   outliningChapters: 19,
-  planningLessons: 16,
   savingCourseInfo: 1,
-  settingUpActivities: 3,
   writingDescription: 3,
 };
-
-function getPhaseWeights(kind: FirstActivityKind): Record<PhaseName, number> {
-  if (kind === "vocabulary") {
-    return {
-      ...BASE_PHASE_WEIGHTS,
-      addingPronunciation: 12,
-      buildingWordList: 10,
-      creatingImages: 0,
-      finishing: 4,
-      preparingVisuals: 0,
-      recordingAudio: 20,
-      writingContent: 0,
-    };
-  }
-
-  return {
-    ...BASE_PHASE_WEIGHTS,
-    addingPronunciation: 0,
-    buildingWordList: 0,
-    creatingImages: 16,
-    finishing: 1,
-    preparingVisuals: 8,
-    recordingAudio: 0,
-    writingContent: 21,
-  };
-}
 
 export function getPhaseStatus(
   phase: PhaseName,
   completedSteps: CourseWorkflowStepName[],
   currentStep: CourseWorkflowStepName | null,
-  targetLanguage: string | null,
   startedSteps?: CourseWorkflowStepName[],
 ): PhaseStatus {
-  const kind = getInferredFirstActivityKind(completedSteps, currentStep, targetLanguage);
-  return getStatus(phase, completedSteps, currentStep, getPhaseSteps(kind), startedSteps);
+  return getStatus(phase, completedSteps, currentStep, PHASE_STEPS, startedSteps);
 }
 
 export function calculateWeightedProgress(
   completedSteps: CourseWorkflowStepName[],
   currentStep: CourseWorkflowStepName | null,
-  targetLanguage: string | null,
   startedSteps?: CourseWorkflowStepName[],
 ): number {
-  const kind = getInferredFirstActivityKind(completedSteps, currentStep, targetLanguage);
-
   return calculateProgress(completedSteps, currentStep, {
-    phaseOrder: getPhaseOrder({ completedSteps, currentStep, targetLanguage }),
-    phaseSteps: getPhaseSteps(kind),
-    phaseWeights: getPhaseWeights(kind),
+    phaseOrder: PHASE_ORDER,
+    phaseSteps: PHASE_STEPS,
+    phaseWeights: PHASE_WEIGHTS,
     startedSteps,
   });
 }

--- a/apps/main/src/app/generate/cs/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/cs/[id]/use-generation-phases.ts
@@ -19,31 +19,20 @@ import {
 export function useGenerationPhases(
   completedSteps: CourseWorkflowStepName[],
   currentStep: CourseWorkflowStepName | null,
-  targetLanguage: string | null,
   startedSteps?: CourseWorkflowStepName[],
 ) {
   const t = useExtracted();
 
   const labels: Record<PhaseName, string> = {
-    addingPronunciation: t("Adding pronunciation"),
-    buildingWordList: t("Preparing practice content"),
     categorizingCourse: t("Categorizing your course"),
     creatingCoverImage: t("Creating the cover image"),
-    creatingImages: t("Creating images"),
-    figuringOutApproach: t("Figuring out the best approach"),
-    finishing: t("Almost done"),
     gettingReady: t("Getting things ready"),
     outliningChapters: t("Writing chapters"),
-    planningLessons: t("Planning your first lesson"),
-    preparingVisuals: t("Preparing illustrations"),
-    recordingAudio: t("Recording audio"),
     savingCourseInfo: t("Saving your course"),
-    settingUpActivities: t("Setting up activities"),
-    writingContent: t("Writing the lesson content"),
     writingDescription: t("Writing your course description"),
   };
 
-  const phaseOrder = getPhaseOrder({ completedSteps, currentStep, targetLanguage });
+  const phaseOrder = getPhaseOrder();
 
   const rawPhases: {
     name: PhaseName;
@@ -54,30 +43,18 @@ export function useGenerationPhases(
     icon: PHASE_ICONS[phase],
     label: labels[phase],
     name: phase,
-    status: getPhaseStatus(phase, completedSteps, currentStep, targetLanguage, startedSteps),
+    status: getPhaseStatus(phase, completedSteps, currentStep, startedSteps),
   }));
 
   const phases = enforcePhaseProgression(rawPhases);
 
-  const progress = calculateWeightedProgress(
-    completedSteps,
-    currentStep,
-    targetLanguage,
-    startedSteps,
-  );
+  const progress = calculateWeightedProgress(completedSteps, currentStep, startedSteps);
 
   const activePhaseNames = phases
     .filter((phase) => phase.status === "active")
     .map((phase) => phase.name);
 
   const thinkingGenerators: Record<PhaseName, ThinkingMessageGenerator> = {
-    addingPronunciation: (index) =>
-      cycleMessage(
-        [t("Looking up how each word sounds..."), t("Mapping out the pronunciation...")],
-        index,
-      ),
-    buildingWordList: (index) =>
-      cycleMessage([t("Picking the key vocabulary..."), t("Choosing words to practice...")], index),
     categorizingCourse: (index) =>
       cycleMessage([t("Figuring out the right categories..."), t("Tagging your course...")], index),
     creatingCoverImage: (index) =>
@@ -89,22 +66,6 @@ export function useGenerationPhases(
         ],
         index,
       ),
-    creatingImages: (index) =>
-      cycleMessage(
-        [
-          t("Drawing an illustration..."),
-          t("Working on the visuals..."),
-          t("Adding some color..."),
-          t("Refining the details..."),
-        ],
-        index,
-      ),
-    figuringOutApproach: (index) =>
-      cycleMessage(
-        [t("Thinking about how to teach this..."), t("Choosing the right approach...")],
-        index,
-      ),
-    finishing: (index) => cycleMessage([t("Wrapping up..."), t("Almost there...")], index),
     gettingReady: (index) =>
       cycleMessage([t("Setting things up..."), t("Getting everything ready...")], index),
     outliningChapters: createCountingGenerator({
@@ -112,32 +73,8 @@ export function useGenerationPhases(
       itemTemplate: (num) => t("Writing chapter {number}...", { number: String(num) }),
       reviewMessage: t("Reviewing the overall flow..."),
     }),
-    planningLessons: createCountingGenerator({
-      intro: [t("Exploring your topic..."), t("Mapping out the learning path...")],
-      itemTemplate: (num) => t("Writing lesson {number}...", { number: String(num) }),
-      reviewMessage: t("Reviewing the flow so far..."),
-    }),
-    preparingVisuals: (index) =>
-      cycleMessage(
-        [
-          t("Thinking about what to illustrate..."),
-          t("Sketching out ideas..."),
-          t("Choosing the right style..."),
-          t("Planning the layout..."),
-        ],
-        index,
-      ),
-    recordingAudio: (index) =>
-      cycleMessage([t("Recording the audio..."), t("Getting the pronunciation right...")], index),
     savingCourseInfo: (index) =>
       cycleMessage([t("Saving your progress..."), t("Putting it all together...")], index),
-    settingUpActivities: (index) =>
-      cycleMessage([t("Designing practice exercises..."), t("Making it interactive...")], index),
-    writingContent: (index) =>
-      cycleMessage(
-        [t("Researching the topic..."), t("Writing the explanation..."), t("Making it clear...")],
-        index,
-      ),
     writingDescription: (index) =>
       cycleMessage([t("Summarizing what you'll learn..."), t("Writing the overview...")], index),
   };

--- a/apps/main/src/lib/generation/activity-generation-phase-config.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-config.ts
@@ -20,30 +20,6 @@ export type PhaseName =
   | "recordingAudio"
   | "finishing";
 
-export type FirstActivityKind = "explanation" | "custom" | "vocabulary";
-
-const CUSTOM_INFERENCE_STEPS = new Set(["generateCustomContent", "setCustomAsCompleted"]);
-
-export function inferFirstActivityKind(params: {
-  completedSteps: readonly string[];
-  currentStep: string | null;
-  targetLanguage: string | null;
-}): FirstActivityKind {
-  if (params.targetLanguage !== null) {
-    return "vocabulary";
-  }
-
-  const seenSteps = params.currentStep
-    ? [...params.completedSteps, params.currentStep]
-    : params.completedSteps;
-
-  if (seenSteps.some((step) => CUSTOM_INFERENCE_STEPS.has(step))) {
-    return "custom";
-  }
-
-  return "explanation";
-}
-
 export function getPhaseOrder(kind: ActivityKind): PhaseName[] {
   if (kind === "vocabulary" || kind === "translation") {
     return [

--- a/apps/main/src/lib/generation/activity-generation-phases.test.ts
+++ b/apps/main/src/lib/generation/activity-generation-phases.test.ts
@@ -1,43 +1,7 @@
 import { enforcePhaseProgression } from "@/lib/generation-phases";
+import { getPhaseOrder } from "@/lib/generation/activity-generation-phase-config";
 import { describe, expect, test } from "vitest";
-import {
-  calculateWeightedProgress,
-  getPhaseOrder,
-  getPhaseStatus,
-  inferFirstActivityKind,
-} from "./activity-generation-phases";
-
-describe(inferFirstActivityKind, () => {
-  test("returns vocabulary when targetLanguage exists", () => {
-    const kind = inferFirstActivityKind({
-      completedSteps: ["generateCustomContent"],
-      currentStep: null,
-      targetLanguage: "es",
-    });
-
-    expect(kind).toBe("vocabulary");
-  });
-
-  test("returns custom when custom steps are observed", () => {
-    const kind = inferFirstActivityKind({
-      completedSteps: ["generateCustomContent"],
-      currentStep: null,
-      targetLanguage: null,
-    });
-
-    expect(kind).toBe("custom");
-  });
-
-  test("falls back to explanation", () => {
-    const kind = inferFirstActivityKind({
-      completedSteps: ["getLessonActivities"],
-      currentStep: "setActivityAsRunning",
-      targetLanguage: null,
-    });
-
-    expect(kind).toBe("explanation");
-  });
-});
+import { calculateWeightedProgress, getPhaseStatus } from "./activity-generation-phases";
 
 describe(getPhaseOrder, () => {
   test("uses vocabulary-first order for vocabulary activities", () => {

--- a/apps/main/src/lib/generation/activity-generation-phases.ts
+++ b/apps/main/src/lib/generation/activity-generation-phases.ts
@@ -4,12 +4,10 @@ import {
   getPhaseStatus as getStatus,
 } from "@/lib/generation-phases";
 import {
-  type FirstActivityKind,
   type PhaseName,
   getPhaseOrder,
   getPhaseSteps,
   getPhaseWeights,
-  inferFirstActivityKind,
 } from "@/lib/generation/activity-generation-phase-config";
 import { type ActivityStepName } from "@/lib/workflow/config";
 import { type ActivityKind } from "@zoonk/db";
@@ -25,9 +23,6 @@ import {
   PaletteIcon,
   PenLineIcon,
 } from "lucide-react";
-
-export type { FirstActivityKind, PhaseName };
-export { getPhaseOrder, getPhaseSteps, inferFirstActivityKind };
 
 export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
   addingPronunciation: MicIcon,

--- a/apps/main/src/lib/workflow/config.ts
+++ b/apps/main/src/lib/workflow/config.ts
@@ -103,13 +103,6 @@ export function getActivityCompletionStep(kind: string): ActivityCompletionStep 
   return activityCompletionSteps[kind] ?? "setExplanationAsCompleted";
 }
 
-/**
- * The step the frontend listens for to trigger redirect during course/chapter
- * generation. The API emits this only when the activity at position 0 finishes,
- * so it works universally for all lesson kinds without language-specific checks.
- */
-export const FIRST_ACTIVITY_COMPLETION_STEP: ActivityStepName = "setFirstActivityAsCompleted";
-
 export const COURSE_STEPS = [
   "getCourseSuggestion",
   "checkExistingCourse",
@@ -130,9 +123,16 @@ export const COURSE_STEPS = [
 
 export type CourseStepName = (typeof COURSE_STEPS)[number];
 
-// Chapter workflow includes lesson steps since we generate the first lesson
+/**
+ * All step names the SSE stream can emit during chapter generation.
+ * The chapter workflow also generates the first lesson and activity,
+ * so the stream includes lesson and activity step events.
+ */
 export type ChapterWorkflowStepName = ChapterStepName | LessonStepName | ActivityStepName;
 
-// We also generate the first chapter as part of the course workflow
-// So the course generation is only complete after chapter and lesson workflow is done
+/**
+ * All step names the SSE stream can emit during course generation.
+ * The course workflow also generates the first chapter, lesson, and activity,
+ * so the stream includes all downstream step events.
+ */
 export type CourseWorkflowStepName = CourseStepName | ChapterWorkflowStepName;

--- a/i18n.lock
+++ b/i18n.lock
@@ -543,33 +543,26 @@ checksums:
     Refining%20the%20details.../singular: eaf7a7ca135f8919dc93f80095040ab0
     Create%20Chapter/singular: eff367b47e651ac3234f8b4655d5a078
     Back%20to%20course/singular: 605eb294c4cd0dbfee151a369d28fe36
-    This%20usually%20takes%201-2%20minutes/singular: bd7260323fa4b3a50a0300ed136fcbd2
     Your%20lessons%20are%20ready/singular: fe8d9df59ba42f451b249fd750813cba
     Taking%20you%20to%20your%20chapter.../singular: fc59b426c3d393ec40f534253309ee9f
     Creating%20your%20lessons/singular: 93571965dc04dcef0bf92f212b3b34d3
-    Designing%20practice%20exercises.../singular: 9f1ddddd3324e1586eb427a2c96ee399
-    Thinking%20about%20how%20to%20teach%20this.../singular: e71e60276db8c3d5ddb63542b0c7251e
+    Getting%20things%20ready/singular: eeb67bd061dfaf280e6971c00e7b7999
     Reviewing%20the%20flow%20so%20far.../singular: 4412a2800906a2b7ea847a9493cd5ac4
-    Making%20it%20interactive.../singular: 1379852e804db4736e71c068cd50982e
-    Setting%20up%20activities/singular: a644864fddf71801feef8c789333456a
-    Figuring%20out%20the%20best%20approach/singular: 0cbd8e2d3c43eb874e25dd6b30fff474
-    Choosing%20the%20right%20approach.../singular: 2ed5698b6fd002b38e10035a29a815dc
+    Saving%20your%20lessons/singular: 78908c0b6045f07d935152a3471399ea
     Exploring%20your%20topic.../singular: 01c8bbcee210a5270bd7629f2fe35e4b
     Preparing%20lessons/singular: efa9d3dc1167beadeae4a660574c8696
+    Saving%20your%20progress.../singular: 15fd06dcc4a2ae41403787c26babdc83
     Mapping%20out%20the%20learning%20path.../singular: 92e90eda50e4c4dea6701f916ef2e853
+    Putting%20it%20all%20together.../singular: 12349256a2104ecf09b213ba1437c636
     Writing%20lesson%20%7Bnumber%7D.../singular: 9a81f245c815438ea4e925777f711894
     Taking%20you%20to%20your%20course.../singular: f1522561681357abdaad3936d36fdfe7
     Your%20course%20is%20ready/singular: b54659084218a9b9bcf7b5f1cfcf3fbf
     Creating%20your%20course/singular: 02c33db1106e7478e5cbd00fa5f20532
-    This%20usually%20takes%201-3%20minutes/singular: a68f9814da3adf4933de2ceee3b1f0fc
-    Writing%20the%20lesson%20content/singular: 2b3243b19b65a83cfe355bef089b7ce8
     Writing%20the%20overview.../singular: 14d71db32539c19803e72da8a4553a0f
     Summarizing%20what%20you'll%20learn.../singular: bb6b58ff4b46ee6e8c59789464e9bced
     Planning%20the%20course%20structure.../singular: 752a256e319aa780a5116e8981d4dffb
     Figuring%20out%20the%20right%20categories.../singular: 6ba5a3ad0241d1b53ad3df38af600d96
-    Getting%20things%20ready/singular: eeb67bd061dfaf280e6971c00e7b7999
     Adding%20finishing%20touches.../singular: 071e61c7a9adfabf2ea37b921bcd7a6d
-    Planning%20your%20first%20lesson/singular: 7f427574ea313b46b889fdef3253d5c6
     Saving%20your%20course/singular: 52dd36a207730a97e851bd6571fffd85
     Tagging%20your%20course.../singular: 3e5051038112611e998fe0787b804c20
     Creating%20the%20cover%20image/singular: f58c3380093e8204ad6ade3b6a0a2691
@@ -578,16 +571,20 @@ checksums:
     Designing%20the%20cover.../singular: 1a65a35fdfdc5c38c17b7c03054f6c33
     Writing%20chapter%20%7Bnumber%7D.../singular: 1634bab54867d26fb32455bfe4e2a98f
     Reviewing%20the%20overall%20flow.../singular: 35a915dd127d3ebd503cfc6b8a3e5082
-    Saving%20your%20progress.../singular: 15fd06dcc4a2ae41403787c26babdc83
     Picking%20the%20right%20look.../singular: 697bdd3a4fa077ddd50c64d57775baf6
     Writing%20chapters/singular: b2e7e149ee761e4e5a45225e37e5441a
-    Putting%20it%20all%20together.../singular: 12349256a2104ecf09b213ba1437c636
     Back%20to%20chapter/singular: ed886de66b9c8ec08ec55860cdebc6a7
     Create%20Lesson/singular: af03c55d9ad5e6063bfad0ce8a35e385
     Your%20lesson%20is%20ready/singular: 3d745fd67b57e47ed10851f1e5404ccc
     Creating%20your%20activities/singular: 6651e663a48e18486f5f873e614cd512
     Taking%20you%20to%20your%20lesson.../singular: 7a47c8664a900646ef51c9f27e2886e0
     This%20usually%20takes%20a%20few%20seconds/singular: d95f1b6378326c1aeb3792bd9cd643e7
+    Designing%20practice%20exercises.../singular: 9f1ddddd3324e1586eb427a2c96ee399
+    Thinking%20about%20how%20to%20teach%20this.../singular: e71e60276db8c3d5ddb63542b0c7251e
+    Making%20it%20interactive.../singular: 1379852e804db4736e71c068cd50982e
+    Setting%20up%20activities/singular: a644864fddf71801feef8c789333456a
+    Figuring%20out%20the%20best%20approach/singular: 0cbd8e2d3c43eb874e25dd6b30fff474
+    Choosing%20the%20right%20approach.../singular: 2ed5698b6fd002b38e10035a29a815dc
     Creating%20content/singular: ec70a8b5ffb94c0d5b83409d03d5b77b
     Read%20Zoonk's%20privacy%20policy%20to%20understand%20how%20we%20collect%2C%20use%2C%20and%20protect%20your%20personal%20information./singular: 044f3586abe7d9915820a6629cef08e4
     Privacy%20Policy/singular: 7459744a63ef8af4e517a09024bd7c08


### PR DESCRIPTION
## Summary

- Redirect from course generation page on `completeCourseSetup` instead of `setFirstActivityAsCompleted` — users see their course as soon as chapters are stored
- Redirect from chapter generation page on `setChapterAsCompleted` instead of `setFirstActivityAsCompleted` — users see lessons as soon as they're stored
- Remove activity/lesson phases from course and chapter generation timelines (no longer relevant since we redirect before those phases)
- Update time estimates from "1-3 minutes" / "1-2 minutes" to "about a minute"
- Split chapter generation into 3 phases (gettingReady, preparingLessons, savingLessons) for better progress feedback
- Clean up unused `FIRST_ACTIVITY_COMPLETION_STEP`, `inferFirstActivityKind`, and re-exports

## Test plan

- [x] Unit tests rewritten for new phase structures
- [x] E2E tests updated with new completion steps and time estimates
- [x] Removed language-specific phase tests (no longer applicable)
- [x] All 421 main e2e tests pass (3 consecutive runs)
- [x] All 56 API e2e tests pass
- [x] All 194 editor e2e tests pass
- [x] knip --production clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect users earlier from course and chapter generation so they land on the new course or chapter as soon as chapters/lessons are saved. This improves perceived speed and simplifies the progress UI while workflows continue in the background.

- **New Features**
  - Course: redirect on `completeCourseSetup` (was `setFirstActivityAsCompleted`).
  - Chapter: redirect on `setChapterAsCompleted` (was `setFirstActivityAsCompleted`).
  - Chapter progress now has 3 phases: `gettingReady`, `preparingLessons`, `savingLessons`.
  - Updated time estimate copy to “about a minute”.

- **Refactors**
  - Removed activity/lesson phases from course and chapter timelines.
  - Deleted unused `FIRST_ACTIVITY_COMPLETION_STEP`, `inferFirstActivityKind`, and related re-exports.
  - Updated unit/E2E tests and i18n strings for the new phase structure; removed language-specific phase tests.

<sup>Written for commit 550d9f60df9674e5a7c08d52414a06cd2b55f6a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

