### PR TITLE
fix(player): show correct belt level on completion screen after level-up

### DIFF
--- a/apps/main/e2e/activity-completion.test.ts
+++ b/apps/main/e2e/activity-completion.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { type Browser } from "@playwright/test";
+import { prisma } from "@zoonk/db";
 import { request } from "@zoonk/e2e/fixtures";
 import { getAiOrganization } from "@zoonk/e2e/helpers";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
@@ -7,6 +8,7 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonWordFixture } from "@zoonk/testing/fixtures/lesson-words";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { userProgressFixture } from "@zoonk/testing/fixtures/progress";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { wordFixture } from "@zoonk/testing/fixtures/words";
 import { expect, test } from "./fixtures";
@@ -325,6 +327,55 @@ test.describe("Activity Completion", () => {
     await expect(page.getByText(/sign up to track your progress/i)).toBeVisible();
     await expect(page.getByRole("progressbar", { name: /level progress/i })).not.toBeVisible();
     await expect(page.getByText(/\+\d+ BP/)).not.toBeVisible();
+  });
+
+  test("completion screen shows updated belt level after level-up", async ({
+    baseURL,
+    browser,
+  }) => {
+    const email = await createUniqueUser(baseURL!);
+    const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
+    const { buildUrl, lesson, org, uniqueId } = await createTestHierarchy("lvlup");
+
+    // Set user to 240 BP (White Belt Level 1). Completing a quiz earns 10 BP,
+    // reaching 250 BP which crosses into White Belt Level 2.
+    const user = await prisma.user.findUniqueOrThrow({ where: { email } });
+    await userProgressFixture({ totalBrainPower: 240n, userId: user.id });
+
+    const activity = await activityFixture({
+      generationStatus: "completed",
+      isPublished: true,
+      kind: "quiz",
+      lessonId: lesson.id,
+      organizationId: org.id,
+      position: 0,
+    });
+
+    await stepFixture({
+      activityId: activity.id,
+      content: {
+        kind: "core",
+        options: [
+          { feedback: "Correct!", isCorrect: true, text: `Right ${uniqueId}` },
+          { feedback: "Wrong", isCorrect: false, text: `Wrong ${uniqueId}` },
+        ],
+        question: `Level up Q ${uniqueId}`,
+      },
+      isPublished: true,
+      kind: "multipleChoice",
+    });
+
+    await page.goto(buildUrl());
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("radio", { name: new RegExp(`Right ${uniqueId}`) }).click();
+    await page.getByRole("button", { name: /check/i }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await expect(page.getByText(/White Belt — Level 2/i)).toBeVisible();
+    await expect(page.getByRole("progressbar", { name: /level progress/i })).toBeVisible();
+
+    await browserContext.close();
   });
 
   test("authenticated user sees BP and belt progress on flashcard vocabulary completion", async ({

--- a/packages/player/src/components/belt-progress.tsx
+++ b/packages/player/src/components/belt-progress.tsx
@@ -5,35 +5,9 @@ import { ProgressIndicator, ProgressRoot, ProgressTrack } from "@zoonk/ui/compon
 import { cn } from "@zoonk/ui/lib/utils";
 import { calculateBeltLevel, getBeltProgressPercent } from "@zoonk/utils/belt-level";
 import { useExtracted } from "next-intl";
-import { useEffect, useState } from "react";
 import { usePlayerNavigation } from "../player-context";
 import { PlayerLink } from "../player-link";
 import { useBeltColorLabel } from "../use-belt-color-label";
-
-type LevelUpPhase = "filling" | "resetting" | "done";
-
-/**
- * Triggers animation start after first paint.
- *
- * This is a legitimate useEffect: we need the browser to paint the
- * initial state (previousPercent) before transitioning to the target.
- * No event handler exists for "component finished painting."
- */
-function useAnimationStarted(): boolean {
-  const [started, setStarted] = useState(false);
-  useEffect(() => setStarted(true), []);
-  return started;
-}
-
-function getDisplayPercent(phase: LevelUpPhase, currentPercent: number): number {
-  if (phase === "filling") {
-    return 100;
-  }
-  if (phase === "resetting") {
-    return 0;
-  }
-  return currentPercent;
-}
 
 export function BeltProgressHint({
   brainPower,
@@ -48,38 +22,8 @@ export function BeltProgressHint({
   const previousBelt = calculateBeltLevel(newTotalBp - brainPower);
   const didLevelUp =
     currentBelt.color !== previousBelt.color || currentBelt.level !== previousBelt.level;
-  const currentColorLabel = useBeltColorLabel(currentBelt.color);
-  const previousColorLabel = useBeltColorLabel(previousBelt.color);
-
+  const colorLabel = useBeltColorLabel(currentBelt.color);
   const currentPercent = getBeltProgressPercent(currentBelt);
-  const previousPercent = getBeltProgressPercent(previousBelt);
-
-  const animationStarted = useAnimationStarted();
-  const [levelUpPhase, setLevelUpPhase] = useState<LevelUpPhase>("filling");
-
-  const showCurrentBelt = !didLevelUp || levelUpPhase !== "filling";
-  const displayColor = showCurrentBelt ? currentBelt.color : previousBelt.color;
-  const displayLabel = showCurrentBelt ? currentColorLabel : previousColorLabel;
-  const displayLevel = showCurrentBelt ? currentBelt.level : previousBelt.level;
-
-  const displayPercent = getDisplayPercent(
-    animationStarted && didLevelUp ? levelUpPhase : "done",
-    currentPercent,
-  );
-
-  const skipTransition = levelUpPhase === "resetting";
-
-  function handleTransitionEnd() {
-    if (!didLevelUp || levelUpPhase !== "filling") {
-      return;
-    }
-    // Two-frame sequence: first frame paints 0% with no transition,
-    // second frame starts the transition to currentPercent.
-    setLevelUpPhase("resetting");
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => setLevelUpPhase("done"));
-    });
-  }
 
   if (currentBelt.isMaxLevel || !levelHref) {
     return null;
@@ -90,29 +34,28 @@ export function BeltProgressHint({
       <div className="flex items-center gap-1.5">
         <BeltIndicator
           className={didLevelUp ? "animate-dot-pulse motion-reduce:animate-none" : undefined}
-          color={displayColor}
-          label={t("{color} belt", { color: displayLabel })}
+          color={currentBelt.color}
+          label={t("{color} belt", { color: colorLabel })}
           size="sm"
         />
         <span className="text-foreground text-sm font-medium">
-          {t("{color} Belt — Level {level}", { color: displayLabel, level: String(displayLevel) })}
+          {t("{color} Belt — Level {level}", {
+            color: colorLabel,
+            level: String(currentBelt.level),
+          })}
         </span>
       </div>
-      <ProgressRoot
-        aria-label={t("Level progress")}
-        value={animationStarted ? displayPercent : previousPercent}
-      >
+      <ProgressRoot aria-label={t("Level progress")} value={currentPercent}>
         <ProgressTrack className="h-1.5 overflow-hidden">
           <ProgressIndicator
             className={cn(
-              beltColorClasses[displayColor],
+              beltColorClasses[currentBelt.color],
               "rounded-full",
-              displayColor === "white" && "ring-1 ring-black/10 ring-inset dark:ring-0",
-              displayColor === "black" && "dark:ring-1 dark:ring-white/10 dark:ring-inset",
-              skipTransition ? "duration-0" : "duration-600 ease-out",
+              currentBelt.color === "white" && "ring-1 ring-black/10 ring-inset dark:ring-0",
+              currentBelt.color === "black" && "dark:ring-1 dark:ring-white/10 dark:ring-inset",
+              "duration-600 ease-out",
               "motion-reduce:duration-0",
             )}
-            onTransitionEnd={handleTransitionEnd}
           />
         </ProgressTrack>
       </ProgressRoot>


### PR DESCRIPTION
## Summary

- The `BeltProgressHint` text was stuck on the previous level after a level-up because the display depended on a CSS `onTransitionEnd` event that could fail to fire
- Removed the animation state machine (`useAnimationStarted`, `levelUpPhase`, `onTransitionEnd`) and always render the current belt info directly
- Added e2e test that sets a user to 240 BP, completes a quiz (+10 BP = 250 BP), and asserts "White Belt — Level 2" is shown

## Test plan

- [x] Existing unit tests pass (415/415)
- [x] New e2e test passes and is not flaky (3/3 runs)
- [x] All main app e2e tests pass (421 passed)
- [x] Editor e2e tests pass (194 passed)
- [x] API e2e tests pass (56 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the completion screen showing the previous belt level after a level-up. We now render the current belt and progress directly so the text and progress bar are always correct.

- **Bug Fixes**
  - Removed the animation state machine and `onTransitionEnd`; always use the current belt color, label, level, and percent.
  - Kept smooth fill via CSS timing only; no dependency on transition events.
  - Added an e2e that levels from 240 BP to 250 BP and asserts "White Belt — Level 2" and the level progress bar are visible.

<sup>Written for commit 115aacfa78126f9de938705e2ea62f72e1978f84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

