### PR TITLE
chore(main): update course meta title and description

### DIFF
--- a/apps/api/src/i18n/request.ts
+++ b/apps/api/src/i18n/request.ts
@@ -2,13 +2,14 @@ import { LOCALE_COOKIE, getLocaleFromHeaders } from "@zoonk/utils/locale";
 import { getRequestConfig } from "next-intl/server";
 import { cookies, headers } from "next/headers";
 
-export default getRequestConfig(async () => {
+export default getRequestConfig(async ({ locale: overrideLocale }) => {
   const store = await cookies();
   const headerStore = await headers();
 
   const cookieLocale = store.get(LOCALE_COOKIE)?.value;
 
-  const locale = cookieLocale || getLocaleFromHeaders(headerStore.get("accept-language"));
+  const locale =
+    overrideLocale || cookieLocale || getLocaleFromHeaders(headerStore.get("accept-language"));
 
   const translations = await import(`../../messages/${locale}.po`);
 

--- a/apps/editor/src/i18n/request.ts
+++ b/apps/editor/src/i18n/request.ts
@@ -2,13 +2,14 @@ import { LOCALE_COOKIE, getLocaleFromHeaders } from "@zoonk/utils/locale";
 import { getRequestConfig } from "next-intl/server";
 import { cookies, headers } from "next/headers";
 
-export default getRequestConfig(async () => {
+export default getRequestConfig(async ({ locale: overrideLocale }) => {
   const store = await cookies();
   const headerStore = await headers();
 
   const cookieLocale = store.get(LOCALE_COOKIE)?.value;
 
-  const locale = cookieLocale || getLocaleFromHeaders(headerStore.get("accept-language"));
+  const locale =
+    overrideLocale || cookieLocale || getLocaleFromHeaders(headerStore.get("accept-language"));
 
   const translations = await import(`../../messages/${locale}.po`);
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -865,6 +865,16 @@ msgctxt "8udPa+"
 msgid "No chapters found"
 msgstr "No chapters found"
 
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+msgctxt "gyGolN"
+msgid "Learn {course}"
+msgstr "Learn {course}"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+msgctxt "wPdQ13"
+msgid "Online and interactive course on {course}. Learn everything about {course} using real-life examples and everyday language. {description}"
+msgstr "Online and interactive course on {course}. Learn everything about {course} using real-life examples and everyday language. {description}"
+
 #: src/app/(catalog)/courses/category-pills.tsx
 msgctxt "tuZsq+"
 msgid "Course categories"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -865,6 +865,16 @@ msgctxt "8udPa+"
 msgid "No chapters found"
 msgstr "No se encontraron capítulos"
 
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+msgctxt "gyGolN"
+msgid "Learn {course}"
+msgstr "Aprende {course}"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+msgctxt "wPdQ13"
+msgid "Online and interactive course on {course}. Learn everything about {course} using real-life examples and everyday language. {description}"
+msgstr "Curso en línea e interactivo sobre {course}. Aprende todo sobre {course} usando ejemplos de la vida real y lenguaje cotidiano. {description}"
+
 #: src/app/(catalog)/courses/category-pills.tsx
 msgctxt "tuZsq+"
 msgid "Course categories"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -865,6 +865,16 @@ msgctxt "8udPa+"
 msgid "No chapters found"
 msgstr "Nenhum capítulo encontrado"
 
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+msgctxt "gyGolN"
+msgid "Learn {course}"
+msgstr "Aprenda {course}"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+msgctxt "wPdQ13"
+msgid "Online and interactive course on {course}. Learn everything about {course} using real-life examples and everyday language. {description}"
+msgstr "Curso online e interativo sobre {course}. Aprenda tudo sobre {course} usando exemplos da vida real e linguagem do dia a dia. {description}"
+
 #: src/app/(catalog)/courses/category-pills.tsx
 msgctxt "tuZsq+"
 msgid "Course categories"

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
@@ -9,6 +9,7 @@ import { listCourseChapters } from "@/data/chapters/list-course-chapters";
 import { getCourse } from "@/data/courses/get-course";
 import { getSession } from "@zoonk/core/users/session/get";
 import { type Metadata } from "next";
+import { getExtracted } from "next-intl/server";
 import { notFound, redirect } from "next/navigation";
 import { Suspense } from "react";
 import { ChapterList } from "./chapter-list";
@@ -24,9 +25,17 @@ export async function generateMetadata({
     return {};
   }
 
+  const t = await getExtracted({ locale: course.language });
+
   return {
-    description: course.description,
-    title: course.title,
+    description: t(
+      "Online and interactive course on {course}. Learn everything about {course} using real-life examples and everyday language. {description}",
+      {
+        course: course.title,
+        description: course.description ?? "",
+      },
+    ),
+    title: t("Learn {course}", { course: course.title }),
   };
 }
 

--- a/apps/main/src/i18n/request.ts
+++ b/apps/main/src/i18n/request.ts
@@ -2,13 +2,14 @@ import { LOCALE_COOKIE, getLocaleFromHeaders } from "@zoonk/utils/locale";
 import { getRequestConfig } from "next-intl/server";
 import { cookies, headers } from "next/headers";
 
-export default getRequestConfig(async () => {
+export default getRequestConfig(async ({ locale: overrideLocale }) => {
   const store = await cookies();
   const headerStore = await headers();
 
   const cookieLocale = store.get(LOCALE_COOKIE)?.value;
 
-  const locale = cookieLocale || getLocaleFromHeaders(headerStore.get("accept-language"));
+  const locale =
+    overrideLocale || cookieLocale || getLocaleFromHeaders(headerStore.get("accept-language"));
 
   const translations = await import(`../../messages/${locale}.po`);
 

--- a/i18n.lock
+++ b/i18n.lock
@@ -349,6 +349,8 @@ checksums:
     Search%20lessons.../singular: fad37eaa75cdc3a12e9d13b4974c91d7
     Search%20chapters.../singular: 6ffe1deeaba59c7a7883c416c1aff611
     No%20chapters%20found/singular: df124bf6f027ecb93afa5941531a3f39
+    Learn%20%7Bcourse%7D/singular: 8b3af50b27d75cf539e30431f47b8238
+    Online%20and%20interactive%20course%20on%20%7Bcourse%7D.%20Learn%20everything%20about%20%7Bcourse%7D%20using%20real-life%20examples%20and%20everyday%20language.%20%7Bdescription%7D/singular: 16ed8ab615b447169268358ac6fe5ca7
     Course%20categories/singular: 3c86af7c305be0c0f5b65077fb06708d
     All/singular: 5e2e93f8e2a5f315b6fecdd0a0e6f55f
     Loading%20more%20courses%E2%80%A6/singular: 290733f8b53c88f64b385ba9dd320acf


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds localized SEO metadata for course pages. The title is now “Learn {course}” and the description is richer and translated. Also allows overriding the locale when resolving translations.

- **New Features**
  - Generate course page metadata with `getExtracted` from `next-intl/server`, using the course’s language.
  - Added messages for the new title/description in `en.po`, `es.po`, and `pt.po` and updated `i18n.lock`.
  - Updated `getRequestConfig` in `apps/api`, `apps/editor`, and `apps/main` to prefer an override locale over cookie/header.

<sup>Written for commit d2e4b577a071569f8701883ff79e68f299f08421. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

