### PR TITLE
fix(main): prevent redirect loop between generation and catalog pages

### DIFF
--- a/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
@@ -43,7 +43,15 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
     return <LoginRequired backHref={backHref} backLabel={backLabel} title={t("Create Chapter")} />;
   }
 
-  if (chapter.generationStatus === "completed") {
+  /**
+   * Only redirect when the chapter has actually generated its lessons.
+   * Without the lesson count check, a redirect loop can occur: the chapter
+   * page redirects here when `lessons.length === 0`, and this page redirects
+   * back when `generationStatus === "completed"`. This happens when Next.js
+   * serves a stale prefetched RSC payload for the chapter page that still
+   * shows zero lessons even though they were created in the background.
+   */
+  if (chapter.generationStatus === "completed" && chapter._count.lessons > 0) {
     redirect(`/b/${AI_ORG_SLUG}/c/${chapter.course.slug}/ch/${chapter.slug}`);
   }
 

--- a/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
+++ b/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
@@ -43,7 +43,15 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
     return <LoginRequired backHref={backHref} backLabel={backLabel} title={t("Create Lesson")} />;
   }
 
-  if (lesson.generationStatus === "completed") {
+  /**
+   * Only redirect when the lesson has actually generated its activities.
+   * Without the activity count check, a redirect loop can occur: the lesson
+   * page redirects here when `activities.length === 0`, and this page redirects
+   * back when `generationStatus === "completed"`. This happens when Next.js
+   * serves a stale prefetched RSC payload for the lesson page that still
+   * shows zero activities even though they were created in the background.
+   */
+  if (lesson.generationStatus === "completed" && lesson._count.activities > 0) {
     redirect(
       `/b/${AI_ORG_SLUG}/c/${lesson.chapter.course.slug}/ch/${lesson.chapter.slug}/l/${lesson.slug}`,
     );

--- a/apps/main/src/components/catalog/continue-activity-link.tsx
+++ b/apps/main/src/components/catalog/continue-activity-link.tsx
@@ -49,7 +49,7 @@ export async function ContinueActivityLink<Href extends string, CompletedHref ex
    */
   if (!data) {
     return (
-      <Link className={className} href={fallbackHref} prefetch>
+      <Link className={className} href={fallbackHref} prefetch={false}>
         {t("Start")}
         <ChevronRightIcon aria-hidden="true" />
       </Link>

--- a/apps/main/src/data/lessons/get-lesson-for-generation.ts
+++ b/apps/main/src/data/lessons/get-lesson-for-generation.ts
@@ -4,6 +4,7 @@ import { prisma } from "@zoonk/db";
 export async function getLessonForGeneration(lessonId: number) {
   return prisma.lesson.findUnique({
     include: {
+      _count: { select: { activities: true } },
       chapter: {
         include: { course: true },
       },


### PR DESCRIPTION
## Summary

- Disable prefetch on the "Start" fallback link in `ContinueActivityLink` — when there's no progress data, the destination may still be generating, so prefetching caches a stale redirect response
- Add child count checks to generation page redirects: chapter generation checks `_count.lessons > 0` and lesson generation checks `_count.activities > 0` before redirecting back to the catalog page
- Add `_count.activities` to `getLessonForGeneration` query

Fixes a redirect loop (`history.replaceState > 100 times/10s`) between `/generate/ch/:id` and the chapter page caused by stale prefetched RSC payloads.

## Test plan

- [ ] Generate a new course, wait to be redirected to the course page
- [ ] Click "Start" before chapter generation finishes — should navigate to generation page without looping
- [ ] Click "Start" after chapter generation finishes — should navigate directly to the chapter page
- [ ] Verify no `SecurityError` in browser console


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix redirect loops between generation pages and the catalog by only redirecting after child content exists and disabling prefetch on the fallback "Start" link to avoid stale RSC payloads.

- **Bug Fixes**
  - Chapter generation redirects only when `generationStatus === "completed"` and `_count.lessons > 0`.
  - Lesson generation redirects only when `generationStatus === "completed"` and `_count.activities > 0`.
  - Disable `prefetch` on the `ContinueActivityLink` fallback "Start" to prevent caching stale redirect responses.
  - Include `_count.activities` in `getLessonForGeneration` to support the new check.

<sup>Written for commit 62feb7c6cf10b20affbd1b8acf8de05d0118cd2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

