### PR TITLE
refactor(db): make word/sentence canonical with separate translation tables

### DIFF
--- a/apps/api/src/workflows/activity-generation/kinds/reading-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/reading-workflow.test.ts
@@ -168,7 +168,6 @@ describe(readingActivityWorkflow, () => {
         organizationId,
         steps: { some: { activityId: activity.id } },
         targetLanguage: "es",
-        userLanguage: "en",
       },
     });
 
@@ -234,19 +233,22 @@ describe(readingActivityWorkflow, () => {
     await readingActivityWorkflow(activities, "test-run-id", words, [], []);
 
     const savedSentence = await prisma.sentence.findFirst({
+      include: { translations: true },
       where: {
         organizationId,
         sentence: sentenceText,
         targetLanguage: "es",
-        translation: translationText,
-        userLanguage: "en",
       },
     });
 
     expect(savedSentence).toMatchObject({
       alternativeSentences: [alternativeSentence],
-      alternativeTranslations: [alternativeTranslation],
       sentence: sentenceText,
+    });
+
+    const translation = savedSentence?.translations.find((t) => t.userLanguage === "en");
+    expect(translation).toMatchObject({
+      alternativeTranslations: [alternativeTranslation],
       translation: translationText,
     });
   });
@@ -321,12 +323,12 @@ describe(readingActivityWorkflow, () => {
     await readingActivityWorkflow(activities, "test-run-id", greetingWords, [], []);
 
     const savedSentences = await prisma.sentence.findMany({
+      include: { translations: true },
       orderBy: { sentence: "asc" },
       where: {
         organizationId,
         steps: { some: { activity: { lessonId: lesson.id } } },
         targetLanguage: "es",
-        userLanguage: "pt",
       },
     });
 
@@ -335,12 +337,16 @@ describe(readingActivityWorkflow, () => {
         expect.objectContaining({
           alternativeSentences: ["Guten Abend, Mama."],
           sentence: "Gute Nacht, Mama.",
-          translation: "Boa noite, mãe.",
+          translations: expect.arrayContaining([
+            expect.objectContaining({ translation: "Boa noite, mãe.", userLanguage: "pt" }),
+          ]) as unknown,
         }),
         expect.objectContaining({
           alternativeSentences: ["Guten Tag, Anna!"],
           sentence: "Guten Morgen, Anna!",
-          translation: "Bom dia, Anna!",
+          translations: expect.arrayContaining([
+            expect.objectContaining({ translation: "Bom dia, Anna!", userLanguage: "pt" }),
+          ]) as unknown,
         }),
       ]),
     );
@@ -393,21 +399,22 @@ describe(readingActivityWorkflow, () => {
     await readingActivityWorkflow(activities, "test-run-id", greetingWords, [], []);
 
     const savedSentence = await prisma.sentence.findFirst({
+      include: { translations: true },
       where: {
         organizationId,
         sentence: "Guten Morgen, Anna!",
         steps: { some: { activity: { lessonId: lesson.id } } },
         targetLanguage: "es",
-        translation: "Bom dia, Anna!",
-        userLanguage: "pt",
       },
     });
 
     expect(savedSentence).toMatchObject({
       alternativeSentences: ["Guten Tag, Anna!"],
       sentence: "Guten Morgen, Anna!",
-      translation: "Bom dia, Anna!",
     });
+
+    const translation = savedSentence?.translations.find((t) => t.userLanguage === "pt");
+    expect(translation).toMatchObject({ translation: "Bom dia, Anna!" });
   });
 
   test("keeps AI sentence variants even when they introduce a different lesson phrase", async () => {
@@ -468,21 +475,22 @@ describe(readingActivityWorkflow, () => {
     await readingActivityWorkflow(activities, "test-run-id", greetingWords, [], []);
 
     const savedSentence = await prisma.sentence.findFirst({
+      include: { translations: true },
       where: {
         organizationId,
         sentence: "Guten Tag, Herr Weber.",
         steps: { some: { activity: { lessonId: lesson.id } } },
         targetLanguage: "es",
-        translation: "Boa tarde, senhor Weber.",
-        userLanguage: "pt",
       },
     });
 
     expect(savedSentence).toMatchObject({
       alternativeSentences: ["Guten Morgen, Herr Weber."],
       sentence: "Guten Tag, Herr Weber.",
-      translation: "Boa tarde, senhor Weber.",
     });
+
+    const translation = savedSentence?.translations.find((t) => t.userLanguage === "pt");
+    expect(translation).toMatchObject({ translation: "Boa tarde, senhor Weber." });
   });
 
   test("sets reading status to 'completed' after full pipeline", async () => {
@@ -534,7 +542,6 @@ describe(readingActivityWorkflow, () => {
       where: {
         organizationId,
         targetLanguage: "es",
-        userLanguage: "en",
         word: { in: ["yo", "veo", "un", "gato", "hola", "como", "estas"] },
       },
     });
@@ -644,15 +651,18 @@ describe(readingActivityWorkflow, () => {
     await readingActivityWorkflow(activities, "test-run-id", words, [], []);
 
     const failWordInDb = await prisma.word.findMany({
+      include: { translations: true },
       where: {
         organizationId,
         targetLanguage: "es",
-        userLanguage: "en",
         word: failWord,
       },
     });
 
-    const emptyTranslationWords = failWordInDb.filter((word) => word.translation === "");
+    // Either no Word record at all, or no translation with empty string
+    const emptyTranslationWords = failWordInDb.filter((word) =>
+      word.translations.some((t) => t.translation === ""),
+    );
     expect(emptyTranslationWords).toHaveLength(0);
   });
 
@@ -661,14 +671,20 @@ describe(readingActivityWorkflow, () => {
     const capitalizedWord = `Zcap${id}`;
     const lowercaseWord = capitalizedWord.toLowerCase();
 
-    await prisma.word.create({
+    const existingWord = await prisma.word.create({
       data: {
         organizationId,
         romanization: "existing-rom",
         targetLanguage: "es",
+        word: capitalizedWord,
+      },
+    });
+
+    await prisma.wordTranslation.create({
+      data: {
         translation: "existing-translation",
         userLanguage: "en",
-        word: capitalizedWord,
+        wordId: existingWord.id,
       },
     });
 
@@ -711,7 +727,6 @@ describe(readingActivityWorkflow, () => {
       where: {
         organizationId,
         targetLanguage: "es",
-        userLanguage: "en",
         word: { in: [capitalizedWord, lowercaseWord] },
       },
     });
@@ -759,7 +774,6 @@ describe(readingActivityWorkflow, () => {
       where: {
         organizationId,
         targetLanguage: "es",
-        userLanguage: "en",
         word: testWord,
       },
     });
@@ -835,7 +849,6 @@ describe(readingActivityWorkflow, () => {
       where: {
         organizationId,
         targetLanguage: "ja",
-        userLanguage: "en",
         word: { in: [word1, word2] },
       },
     });
@@ -847,28 +860,17 @@ describe(readingActivityWorkflow, () => {
     }
   });
 
-  test("skips TTS for sentence words that already have a WordAudio record", async () => {
+  test("skips TTS for sentence words that already have an audioUrl", async () => {
     const id = randomUUID().replaceAll("-", "").slice(0, 8);
     const existingWord = `zexist${id}`;
     const newWord = `znew${id}`;
 
-    const wordAudio = await prisma.wordAudio.create({
+    await prisma.word.create({
       data: {
         audioUrl: "https://example.com/existing-audio.mp3",
         organizationId,
         targetLanguage: "es",
         word: existingWord,
-      },
-    });
-
-    await prisma.word.create({
-      data: {
-        organizationId,
-        targetLanguage: "es",
-        translation: "existing",
-        userLanguage: "en",
-        word: existingWord,
-        wordAudioId: wordAudio.id,
       },
     });
 

--- a/apps/api/src/workflows/activity-generation/kinds/reading-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/reading-workflow.ts
@@ -36,10 +36,10 @@ export async function readingActivityWorkflow(
     generateReadingRomanizationStep(activities, savedSentences),
   ]);
 
-  const { sentenceAudioIds } = settled(audioResult, { sentenceAudioIds: {} });
+  const { sentenceAudioUrls } = settled(audioResult, { sentenceAudioUrls: {} });
   const { romanizations } = settled(romanizationResult, { romanizations: {} });
 
-  await updateReadingEnrichmentsStep(activities, savedSentences, sentenceAudioIds, romanizations);
+  await updateReadingEnrichmentsStep(activities, savedSentences, sentenceAudioUrls, romanizations);
 
   const { wordMetadata } = await generateSentenceWordMetadataStep(activities, savedSentences);
 
@@ -49,8 +49,8 @@ export async function readingActivityWorkflow(
     wordMetadata,
   );
 
-  const { wordAudioIds } = await generateSentenceWordAudioStep(activities, savedSentenceWords);
-  await updateSentenceWordEnrichmentsStep(activities, savedSentenceWords, wordAudioIds);
+  const { wordAudioUrls } = await generateSentenceWordAudioStep(activities, savedSentenceWords);
+  await updateSentenceWordEnrichmentsStep(activities, savedSentenceWords, wordAudioUrls);
 
   await completeActivityStep(activities, workflowRunId, "reading");
 }

--- a/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.test.ts
@@ -120,7 +120,6 @@ describe(vocabularyActivityWorkflow, () => {
         organizationId,
         steps: { some: { activityId: activity.id } },
         targetLanguage: "es",
-        userLanguage: "en",
       },
     });
 
@@ -349,28 +348,17 @@ describe(vocabularyActivityWorkflow, () => {
     expect(result.words).toHaveLength(0);
   });
 
-  test("preserves existing wordAudioId when audio step fails but pronunciation succeeds", async () => {
+  test("preserves existing audioUrl when audio step fails but pronunciation succeeds", async () => {
     const id = randomUUID().replaceAll("-", "").slice(0, 8);
     const existingWord = `zkeep${id}`;
     const newWord = `znew${id}`;
 
-    const wordAudio = await prisma.wordAudio.create({
+    await prisma.word.create({
       data: {
         audioUrl: "https://example.com/keep-audio.mp3",
         organizationId,
         targetLanguage: "es",
         word: existingWord,
-      },
-    });
-
-    await prisma.word.create({
-      data: {
-        organizationId,
-        targetLanguage: "es",
-        translation: "existing",
-        userLanguage: "en",
-        word: existingWord,
-        wordAudioId: wordAudio.id,
       },
     });
 
@@ -413,30 +401,19 @@ describe(vocabularyActivityWorkflow, () => {
       where: { organizationId, targetLanguage: "es", word: existingWord },
     });
 
-    expect(updatedWord?.wordAudioId).toBe(wordAudio.id);
+    expect(updatedWord?.audioUrl).toBe("https://example.com/keep-audio.mp3");
   });
 
   test("reuses existing Word record when casing differs", async () => {
     const id = randomUUID().replaceAll("-", "").slice(0, 8);
     const existingWord = `Hola${id}`;
 
-    const wordAudio = await prisma.wordAudio.create({
+    const existingRecord = await prisma.word.create({
       data: {
         audioUrl: "https://example.com/hola-audio.mp3",
         organizationId,
         targetLanguage: "es",
         word: existingWord,
-      },
-    });
-
-    const existingRecord = await prisma.word.create({
-      data: {
-        organizationId,
-        targetLanguage: "es",
-        translation: "hello",
-        userLanguage: "en",
-        word: existingWord,
-        wordAudioId: wordAudio.id,
       },
     });
 
@@ -476,7 +453,6 @@ describe(vocabularyActivityWorkflow, () => {
       where: {
         organizationId,
         targetLanguage: "es",
-        userLanguage: "en",
         word: { in: [existingWord, existingWord.toLowerCase()], mode: "insensitive" },
       },
     });
@@ -487,11 +463,11 @@ describe(vocabularyActivityWorkflow, () => {
     expect(words[0]!.id).toBe(existingRecord.id);
   });
 
-  test("reuses existing WordAudio when casing differs", async () => {
+  test("reuses existing audio when casing differs", async () => {
     const id = randomUUID().replaceAll("-", "").slice(0, 8);
     const existingWord = `Gato${id}`;
 
-    const wordAudio = await prisma.wordAudio.create({
+    await prisma.word.create({
       data: {
         audioUrl: "https://example.com/gato-audio.mp3",
         organizationId,
@@ -531,23 +507,23 @@ describe(vocabularyActivityWorkflow, () => {
     const activities = await fetchLessonActivities(lesson.id);
     await vocabularyActivityWorkflow(activities, "test-run-id", [], []);
 
-    // Should not call TTS since WordAudio for "Gato..." already exists
+    // Should not call TTS since audio for "Gato..." already exists on the Word record
     expect(generateLanguageAudio).not.toHaveBeenCalled();
 
-    // The Word record should be linked to the existing WordAudio
+    // The Word record should have the existing audioUrl preserved
     const word = await prisma.word.findFirst({
-      where: { organizationId, targetLanguage: "es", word: existingWord.toLowerCase() },
+      where: { organizationId, targetLanguage: "es", word: existingWord },
     });
 
-    expect(word?.wordAudioId).toBe(wordAudio.id);
+    expect(word?.audioUrl).toBe("https://example.com/gato-audio.mp3");
   });
 
-  test("skips TTS for vocabulary words that already have a WordAudio record", async () => {
+  test("skips TTS for vocabulary words that already have an audioUrl", async () => {
     const id = randomUUID().replaceAll("-", "").slice(0, 8);
     const existingWord = `zexist${id}`;
     const newWord = `znew${id}`;
 
-    await prisma.wordAudio.create({
+    await prisma.word.create({
       data: {
         audioUrl: "https://example.com/existing-audio.mp3",
         organizationId,

--- a/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.ts
@@ -34,14 +34,14 @@ export async function vocabularyActivityWorkflow(
 
   const { savedWords } = settled(saveWordsResult, { savedWords: [] });
   const { pronunciations } = settled(pronunciationResult, { pronunciations: {} });
-  const { wordAudioIds } = settled(audioResult, { wordAudioIds: {} });
+  const { wordAudioUrls } = settled(audioResult, { wordAudioUrls: {} });
   const { romanizations } = settled(romanizationResult, { romanizations: {} });
 
   await updateVocabularyEnrichmentsStep(
     activities,
     savedWords,
     pronunciations,
-    wordAudioIds,
+    wordAudioUrls,
     romanizations,
   );
   await completeActivityStep(activities, workflowRunId, "vocabulary");

--- a/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.ts
@@ -24,15 +24,14 @@ export async function vocabularyActivityWorkflow(
     neighboringConcepts,
   );
 
-  const [saveWordsResult, pronunciationResult, audioResult, romanizationResult] =
-    await Promise.allSettled([
-      saveVocabularyWordsStep(activities, words, workflowRunId),
-      generateVocabularyPronunciationStep(activities, words),
-      generateVocabularyAudioStep(activities, words),
-      generateVocabularyRomanizationStep(activities, words),
-    ]);
+  const { savedWords } = await saveVocabularyWordsStep(activities, words, workflowRunId);
 
-  const { savedWords } = settled(saveWordsResult, { savedWords: [] });
+  const [pronunciationResult, audioResult, romanizationResult] = await Promise.allSettled([
+    generateVocabularyPronunciationStep(activities, words),
+    generateVocabularyAudioStep(activities, words),
+    generateVocabularyRomanizationStep(activities, words),
+  ]);
+
   const { pronunciations } = settled(pronunciationResult, { pronunciations: {} });
   const { wordAudioUrls } = settled(audioResult, { wordAudioUrls: {} });
   const { romanizations } = settled(romanizationResult, { romanizations: {} });

--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
@@ -220,9 +220,15 @@ describe("language activity generation", () => {
         organizationId,
         romanization: "ga-to",
         targetLanguage,
+        word: `gato-${randomUUID().slice(0, 8)}`,
+      },
+    });
+
+    await prisma.wordTranslation.create({
+      data: {
         translation: "cat",
         userLanguage,
-        word: `gato-${randomUUID().slice(0, 8)}`,
+        wordId: word1.id,
       },
     });
 
@@ -231,9 +237,15 @@ describe("language activity generation", () => {
         organizationId,
         romanization: "o-la",
         targetLanguage,
+        word: `hola-${randomUUID().slice(0, 8)}`,
+      },
+    });
+
+    await prisma.wordTranslation.create({
+      data: {
         translation: "hello",
         userLanguage,
-        word: `hola-${randomUUID().slice(0, 8)}`,
+        wordId: word2.id,
       },
     });
 
@@ -600,6 +612,12 @@ describe("language activity generation", () => {
         organizationId,
         sentence: `pre-complete-sentence-1-${randomUUID().slice(0, 8)}`,
         targetLanguage: "es",
+      },
+    });
+
+    await prisma.sentenceTranslation.create({
+      data: {
+        sentenceId: sentence1.id,
         translation: "Pre-complete sentence 1",
         userLanguage: "en",
       },
@@ -610,6 +628,12 @@ describe("language activity generation", () => {
         organizationId,
         sentence: `pre-complete-sentence-2-${randomUUID().slice(0, 8)}`,
         targetLanguage: "es",
+      },
+    });
+
+    await prisma.sentenceTranslation.create({
+      data: {
+        sentenceId: sentence2.id,
         translation: "Pre-complete sentence 2",
         userLanguage: "en",
       },

--- a/apps/api/src/workflows/activity-generation/steps/_utils/fetch-existing-word-casing.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/fetch-existing-word-casing.ts
@@ -3,7 +3,6 @@ import { prisma } from "@zoonk/db";
 export async function fetchExistingWordCasing(params: {
   organizationId: number;
   targetLanguage: string;
-  userLanguage: string;
   words: string[];
 }): Promise<Record<string, string>> {
   const existing = await prisma.word.findMany({
@@ -11,7 +10,6 @@ export async function fetchExistingWordCasing(params: {
     where: {
       organizationId: params.organizationId,
       targetLanguage: params.targetLanguage,
-      userLanguage: params.userLanguage,
       word: { in: params.words, mode: "insensitive" },
     },
   });

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.ts
@@ -11,13 +11,13 @@ import { type SavedSentence } from "./save-reading-sentences-step";
 export async function generateReadingAudioStep(
   activities: LessonActivity[],
   savedSentences: SavedSentence[],
-): Promise<{ sentenceAudioIds: Record<string, bigint> }> {
+): Promise<{ sentenceAudioUrls: Record<string, string> }> {
   "use step";
 
   const activity = findActivityByKind(activities, "reading");
 
   if (!activity || savedSentences.length === 0) {
-    return { sentenceAudioIds: {} };
+    return { sentenceAudioUrls: {} };
   }
 
   const course = activity.lesson.chapter.course;
@@ -29,25 +29,30 @@ export async function generateReadingAudioStep(
 
   if (!isTTSSupportedLanguage(targetLanguage) || !course.organization) {
     await stream.status({ status: "completed", step: "generateAudio" });
-    return { sentenceAudioIds: {} };
+    return { sentenceAudioUrls: {} };
   }
 
   const organizationId = course.organization.id;
 
-  const existingAudios = await prisma.sentenceAudio.findMany({
-    select: { id: true, sentence: true },
+  const existingAudios = await prisma.sentence.findMany({
+    select: { audioUrl: true, sentence: true },
     where: {
+      audioUrl: { not: null },
       organizationId,
       sentence: { in: savedSentences.map((saved) => saved.sentence) },
       targetLanguage,
     },
   });
 
-  const existingAudioIds: Record<string, bigint> = Object.fromEntries(
-    existingAudios.map((record) => [record.sentence, record.id]),
+  const existingAudioUrls: Record<string, string> = Object.fromEntries(
+    existingAudios.flatMap((record) =>
+      record.audioUrl ? [[record.sentence, record.audioUrl]] : [],
+    ),
   );
 
-  const sentencesNeedingAudio = savedSentences.filter((saved) => !existingAudioIds[saved.sentence]);
+  const sentencesNeedingAudio = savedSentences.filter(
+    (saved) => !existingAudioUrls[saved.sentence],
+  );
 
   const results = await Promise.all(
     sentencesNeedingAudio.map((saved) =>
@@ -59,33 +64,31 @@ export async function generateReadingAudioStep(
 
   const newAudioRecords = await Promise.all(
     fulfilled.map((result) =>
-      prisma.sentenceAudio.upsert({
-        create: {
-          audioUrl: result.audioUrl,
-          organizationId,
-          sentence: result.text,
-          targetLanguage,
-        },
-        select: { id: true, sentence: true },
-        update: { audioUrl: result.audioUrl },
+      prisma.sentence.update({
+        data: { audioUrl: result.audioUrl },
+        select: { audioUrl: true, sentence: true },
         where: {
-          orgSentenceAudio: { organizationId, sentence: result.text, targetLanguage },
+          orgSentence: { organizationId, sentence: result.text, targetLanguage },
         },
       }),
     ),
   );
 
-  const sentenceAudioIds: Record<string, bigint> = {
-    ...existingAudioIds,
-    ...Object.fromEntries(newAudioRecords.map((record) => [record.sentence, record.id])),
+  const sentenceAudioUrls: Record<string, string> = {
+    ...existingAudioUrls,
+    ...Object.fromEntries(
+      newAudioRecords.flatMap((record) =>
+        record.audioUrl ? [[record.sentence, record.audioUrl]] : [],
+      ),
+    ),
   };
 
   if (fulfilled.length < sentencesNeedingAudio.length) {
     await stream.error({ reason: "enrichmentFailed", step: "generateAudio" });
     await handleActivityFailureStep({ activityId: activity.id });
-    return { sentenceAudioIds };
+    return { sentenceAudioUrls };
   }
 
   await stream.status({ status: "completed", step: "generateAudio" });
-  return { sentenceAudioIds };
+  return { sentenceAudioUrls };
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-content-step.ts
@@ -31,6 +31,11 @@ export type ReadingSentence = GeneratedReadingSentence & {
   alternativeTranslations: string[];
 };
 
+/**
+ * Fetches lesson words with their translation for the given user language.
+ * Used as a fallback when the current vocabulary workflow run produced no words,
+ * so that the reading workflow can still generate sentences from existing data.
+ */
 async function getFallbackLessonWords(params: {
   lessonId: number;
   organizationId: number | null;
@@ -46,9 +51,13 @@ async function getFallbackLessonWords(params: {
     select: {
       word: {
         select: {
-          alternativeTranslations: true,
-          romanization: true,
-          translation: true,
+          translations: {
+            select: {
+              alternativeTranslations: true,
+              translation: true,
+            },
+            where: { userLanguage: params.userLanguage },
+          },
           word: true,
         },
       },
@@ -58,12 +67,25 @@ async function getFallbackLessonWords(params: {
       word: {
         organizationId: params.organizationId,
         targetLanguage: params.targetLanguage,
-        userLanguage: params.userLanguage,
       },
     },
   });
 
-  return words.map((record) => record.word);
+  return words.flatMap((record) => {
+    const translation = record.word.translations[0];
+
+    if (!translation) {
+      return [];
+    }
+
+    return [
+      {
+        alternativeTranslations: translation.alternativeTranslations,
+        translation: translation.translation,
+        word: record.word.word,
+      },
+    ];
+  });
 }
 
 function hasValidSentences(sentences: ReadingSentence[]): boolean {

--- a/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-audio-step.ts
@@ -11,13 +11,13 @@ import { type SavedSentenceWord } from "./save-sentence-words-step";
 export async function generateSentenceWordAudioStep(
   activities: LessonActivity[],
   savedSentenceWords: SavedSentenceWord[],
-): Promise<{ wordAudioIds: Record<string, bigint> }> {
+): Promise<{ wordAudioUrls: Record<string, string> }> {
   "use step";
 
   const activity = findActivityByKind(activities, "reading");
 
   if (!activity || savedSentenceWords.length === 0) {
-    return { wordAudioIds: {} };
+    return { wordAudioUrls: {} };
   }
 
   const course = activity.lesson.chapter.course;
@@ -29,27 +29,28 @@ export async function generateSentenceWordAudioStep(
 
   if (!isTTSSupportedLanguage(targetLanguage) || !course.organization) {
     await stream.status({ status: "completed", step: "generateSentenceWordAudio" });
-    return { wordAudioIds: {} };
+    return { wordAudioUrls: {} };
   }
 
   const orgSlug = course.organization.slug;
   const organizationId = course.organization.id;
 
-  const existingAudios = await prisma.wordAudio.findMany({
-    select: { id: true, word: true },
+  const existingAudios = await prisma.word.findMany({
+    select: { audioUrl: true, word: true },
     where: {
+      audioUrl: { not: null },
       organizationId,
       targetLanguage,
       word: { in: savedSentenceWords.map((saved) => saved.word) },
     },
   });
 
-  const existingAudioIds: Record<string, bigint> = Object.fromEntries(
-    existingAudios.map((record) => [record.word, record.id]),
+  const existingAudioUrls: Record<string, string> = Object.fromEntries(
+    existingAudios.flatMap((record) => (record.audioUrl ? [[record.word, record.audioUrl]] : [])),
   );
 
   const wordsNeedingAudio = savedSentenceWords.filter(
-    (saved) => !saved.wordAudioId && !existingAudioIds[saved.word],
+    (saved) => !saved.wordAudioUrl && !existingAudioUrls[saved.word],
   );
 
   const results = await Promise.all(
@@ -60,36 +61,34 @@ export async function generateSentenceWordAudioStep(
 
   const newAudioRecords = await Promise.all(
     fulfilled.map((result) =>
-      prisma.wordAudio.upsert({
-        create: {
-          audioUrl: result.audioUrl,
-          organizationId,
-          targetLanguage,
-          word: result.text,
-        },
-        select: { id: true, word: true },
-        update: { audioUrl: result.audioUrl },
-        where: { orgWordAudio: { organizationId, targetLanguage, word: result.text } },
+      prisma.word.update({
+        data: { audioUrl: result.audioUrl },
+        select: { audioUrl: true, word: true },
+        where: { orgWord: { organizationId, targetLanguage, word: result.text } },
       }),
     ),
   );
 
-  const wordAudioIds: Record<string, bigint> = {
-    ...existingAudioIds,
+  const wordAudioUrls: Record<string, string> = {
+    ...existingAudioUrls,
     ...Object.fromEntries(
       savedSentenceWords.flatMap((saved) =>
-        saved.wordAudioId ? [[saved.word, saved.wordAudioId]] : [],
+        saved.wordAudioUrl ? [[saved.word, saved.wordAudioUrl]] : [],
       ),
     ),
-    ...Object.fromEntries(newAudioRecords.map((record) => [record.word, record.id])),
+    ...Object.fromEntries(
+      newAudioRecords.flatMap((record) =>
+        record.audioUrl ? [[record.word, record.audioUrl]] : [],
+      ),
+    ),
   };
 
   if (fulfilled.length < wordsNeedingAudio.length) {
     await stream.error({ reason: "enrichmentFailed", step: "generateSentenceWordAudio" });
     await handleActivityFailureStep({ activityId: activity.id });
-    return { wordAudioIds };
+    return { wordAudioUrls };
   }
 
   await stream.status({ status: "completed", step: "generateSentenceWordAudio" });
-  return { wordAudioIds };
+  return { wordAudioUrls };
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-metadata-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-metadata-step.ts
@@ -16,6 +16,10 @@ type WordMetadataEntry = {
   translation: string;
 };
 
+/**
+ * Fetches existing word metadata by joining Word and WordTranslation tables.
+ * Translations now live in WordTranslation, while romanization stays on Word.
+ */
 async function fetchExistingWordMetadata(params: {
   organizationId: number;
   targetLanguage: string;
@@ -23,20 +27,27 @@ async function fetchExistingWordMetadata(params: {
   words: string[];
 }): Promise<Record<string, WordMetadataEntry>> {
   const existing = await prisma.word.findMany({
+    include: {
+      translations: {
+        where: { userLanguage: params.userLanguage },
+      },
+    },
     where: {
       organizationId: params.organizationId,
       targetLanguage: params.targetLanguage,
-      userLanguage: params.userLanguage,
       word: { in: params.words, mode: "insensitive" },
     },
   });
 
   return Object.fromEntries(
     existing
-      .filter((record) => record.translation)
+      .filter((record) => record.translations[0]?.translation)
       .map((record) => [
         record.word.toLowerCase(),
-        { romanization: record.romanization, translation: record.translation },
+        {
+          romanization: record.romanization,
+          translation: record.translations[0]?.translation ?? "",
+        },
       ]),
   );
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
@@ -11,13 +11,13 @@ import { handleActivityFailureStep } from "./handle-failure-step";
 export async function generateVocabularyAudioStep(
   activities: LessonActivity[],
   words: VocabularyWord[],
-): Promise<{ wordAudioIds: Record<string, bigint> }> {
+): Promise<{ wordAudioUrls: Record<string, string> }> {
   "use step";
 
   const activity = findActivityByKind(activities, "vocabulary");
 
   if (!activity || words.length === 0) {
-    return { wordAudioIds: {} };
+    return { wordAudioUrls: {} };
   }
 
   const course = activity.lesson.chapter.course;
@@ -29,29 +29,32 @@ export async function generateVocabularyAudioStep(
 
   if (!isTTSSupportedLanguage(targetLanguage) || !course.organization) {
     await stream.status({ status: "completed", step: "generateVocabularyAudio" });
-    return { wordAudioIds: {} };
+    return { wordAudioUrls: {} };
   }
 
   const orgSlug = course.organization.slug;
   const organizationId = course.organization.id;
 
-  const existingAudios = await prisma.wordAudio.findMany({
-    select: { id: true, word: true },
+  const existingAudios = await prisma.word.findMany({
+    select: { audioUrl: true, word: true },
     where: {
+      audioUrl: { not: null },
       organizationId,
       targetLanguage,
       word: { in: words.map((vocab) => vocab.word), mode: "insensitive" },
     },
   });
 
-  const existingAudioByLower: Record<string, bigint> = Object.fromEntries(
-    existingAudios.map((record) => [record.word.toLowerCase(), record.id]),
+  const existingAudioByLower: Record<string, string> = Object.fromEntries(
+    existingAudios.flatMap((record) =>
+      record.audioUrl ? [[record.word.toLowerCase(), record.audioUrl]] : [],
+    ),
   );
 
-  const existingAudioIds: Record<string, bigint> = Object.fromEntries(
+  const existingAudioUrls: Record<string, string> = Object.fromEntries(
     words.flatMap((vocab) => {
-      const audioId = existingAudioByLower[vocab.word.toLowerCase()];
-      return audioId ? [[vocab.word, audioId]] : [];
+      const audioUrl = existingAudioByLower[vocab.word.toLowerCase()];
+      return audioUrl ? [[vocab.word, audioUrl]] : [];
     }),
   );
 
@@ -69,31 +72,29 @@ export async function generateVocabularyAudioStep(
 
   const newAudioRecords = await Promise.all(
     fulfilled.map((result) =>
-      prisma.wordAudio.upsert({
-        create: {
-          audioUrl: result.audioUrl,
-          organizationId,
-          targetLanguage,
-          word: result.text,
-        },
-        select: { id: true, word: true },
-        update: { audioUrl: result.audioUrl },
-        where: { orgWordAudio: { organizationId, targetLanguage, word: result.text } },
+      prisma.word.update({
+        data: { audioUrl: result.audioUrl },
+        select: { audioUrl: true, word: true },
+        where: { orgWord: { organizationId, targetLanguage, word: result.text } },
       }),
     ),
   );
 
-  const wordAudioIds: Record<string, bigint> = {
-    ...existingAudioIds,
-    ...Object.fromEntries(newAudioRecords.map((record) => [record.word, record.id])),
+  const wordAudioUrls: Record<string, string> = {
+    ...existingAudioUrls,
+    ...Object.fromEntries(
+      newAudioRecords.flatMap((record) =>
+        record.audioUrl ? [[record.word, record.audioUrl]] : [],
+      ),
+    ),
   };
 
   if (fulfilled.length < wordsNeedingAudio.length) {
     await stream.error({ reason: "enrichmentFailed", step: "generateVocabularyAudio" });
     await handleActivityFailureStep({ activityId: activity.id });
-    return { wordAudioIds };
+    return { wordAudioUrls };
   }
 
   await stream.status({ status: "completed", step: "generateVocabularyAudio" });
-  return { wordAudioIds };
+  return { wordAudioUrls };
 }

--- a/apps/api/src/workflows/activity-generation/steps/save-reading-sentences-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-reading-sentences-step.ts
@@ -56,31 +56,41 @@ function buildSaveOneSentence(params: {
     const record = await prisma.sentence.upsert({
       create: {
         alternativeSentences,
-        alternativeTranslations,
-        explanation: emptyToNull(readingSentence.explanation),
         organizationId,
         sentence,
         targetLanguage,
-        translation,
-        userLanguage,
       },
       update: {
         alternativeSentences,
-        alternativeTranslations,
-        explanation: emptyToNull(readingSentence.explanation),
-        translation,
       },
       where: {
         orgSentence: {
           organizationId,
           sentence,
           targetLanguage,
-          userLanguage,
         },
       },
     });
 
     const sentenceId = record.id;
+
+    await prisma.sentenceTranslation.upsert({
+      create: {
+        alternativeTranslations,
+        explanation: emptyToNull(readingSentence.explanation),
+        sentenceId,
+        translation,
+        userLanguage,
+      },
+      update: {
+        alternativeTranslations,
+        explanation: emptyToNull(readingSentence.explanation),
+        translation,
+      },
+      where: {
+        sentenceTranslation: { sentenceId, userLanguage },
+      },
+    });
 
     await prisma.lessonSentence.upsert({
       create: { lessonId, sentenceId },

--- a/apps/api/src/workflows/activity-generation/steps/save-sentence-words-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-sentence-words-step.ts
@@ -11,7 +11,7 @@ import { type SavedSentence } from "./save-reading-sentences-step";
 
 export type SavedSentenceWord = {
   word: string;
-  wordAudioId: bigint | null;
+  wordAudioUrl: string | null;
   wordId: number;
 };
 
@@ -40,20 +40,31 @@ function buildSaveOneWord(params: {
         organizationId,
         romanization,
         targetLanguage,
-        translation,
-        userLanguage,
         word: dbWord,
       },
       update: {
         romanization,
-        translation,
       },
       where: {
-        orgWord: { organizationId, targetLanguage, userLanguage, word: dbWord },
+        orgWord: { organizationId, targetLanguage, word: dbWord },
       },
     });
 
-    return { word, wordAudioId: record.wordAudioId, wordId: Number(record.id) };
+    await prisma.wordTranslation.upsert({
+      create: {
+        translation,
+        userLanguage,
+        wordId: record.id,
+      },
+      update: {
+        translation,
+      },
+      where: {
+        wordTranslation: { userLanguage, wordId: record.id },
+      },
+    });
+
+    return { word: dbWord, wordAudioUrl: record.audioUrl, wordId: Number(record.id) };
   };
 }
 
@@ -96,7 +107,6 @@ export async function saveSentenceWordsStep(
   const existingCasing = await fetchExistingWordCasing({
     organizationId,
     targetLanguage,
-    userLanguage,
     words: uniqueWords,
   });
 

--- a/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-vocabulary-words-step.ts
@@ -41,23 +41,33 @@ function buildSaveOneWord(params: {
 
     const record = await prisma.word.upsert({
       create: {
-        alternativeTranslations: vocabWord.alternativeTranslations,
         organizationId,
         targetLanguage,
+        word: dbWord,
+      },
+      update: {},
+      where: {
+        orgWord: { organizationId, targetLanguage, word: dbWord },
+      },
+    });
+
+    const wordId = record.id;
+
+    await prisma.wordTranslation.upsert({
+      create: {
+        alternativeTranslations: vocabWord.alternativeTranslations,
         translation,
         userLanguage,
-        word: dbWord,
+        wordId,
       },
       update: {
         alternativeTranslations: vocabWord.alternativeTranslations,
         translation,
       },
       where: {
-        orgWord: { organizationId, targetLanguage, userLanguage, word: dbWord },
+        wordTranslation: { userLanguage, wordId },
       },
     });
-
-    const wordId = record.id;
 
     await prisma.lessonWord.upsert({
       create: { lessonId, wordId },
@@ -131,7 +141,6 @@ export async function saveVocabularyWordsStep(
   const existingCasing = await fetchExistingWordCasing({
     organizationId,
     targetLanguage,
-    userLanguage,
     words: words.map((vocab) => vocab.word),
   });
 

--- a/apps/api/src/workflows/activity-generation/steps/update-reading-enrichments-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/update-reading-enrichments-step.ts
@@ -10,7 +10,7 @@ import { type SavedSentence } from "./save-reading-sentences-step";
 export async function updateReadingEnrichmentsStep(
   activities: LessonActivity[],
   savedSentences: SavedSentence[],
-  sentenceAudioIds: Record<string, bigint>,
+  sentenceAudioUrls: Record<string, string>,
   romanizations: Record<string, string>,
 ): Promise<void> {
   "use step";
@@ -26,12 +26,12 @@ export async function updateReadingEnrichmentsStep(
   await stream.status({ status: "started", step: "updateSentenceEnrichments" });
 
   const updates = savedSentences
-    .filter((saved) => sentenceAudioIds[saved.sentence] || romanizations[saved.sentence])
+    .filter((saved) => sentenceAudioUrls[saved.sentence] || romanizations[saved.sentence])
     .map((saved) =>
       prisma.sentence.update({
         data: {
+          audioUrl: sentenceAudioUrls[saved.sentence],
           romanization: romanizations[saved.sentence],
-          sentenceAudioId: sentenceAudioIds[saved.sentence],
         },
         where: { id: saved.sentenceId },
       }),

--- a/apps/api/src/workflows/activity-generation/steps/update-sentence-word-enrichments-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/update-sentence-word-enrichments-step.ts
@@ -10,7 +10,7 @@ import { type SavedSentenceWord } from "./save-sentence-words-step";
 export async function updateSentenceWordEnrichmentsStep(
   activities: LessonActivity[],
   savedSentenceWords: SavedSentenceWord[],
-  wordAudioIds: Record<string, bigint>,
+  wordAudioUrls: Record<string, string>,
 ): Promise<void> {
   "use step";
 
@@ -25,10 +25,10 @@ export async function updateSentenceWordEnrichmentsStep(
   await stream.status({ status: "started", step: "updateSentenceWordEnrichments" });
 
   const updates = savedSentenceWords
-    .filter((saved) => wordAudioIds[saved.word])
+    .filter((saved) => wordAudioUrls[saved.word])
     .map((saved) =>
       prisma.word.update({
-        data: { wordAudioId: wordAudioIds[saved.word] },
+        data: { audioUrl: wordAudioUrls[saved.word] },
         where: { id: saved.wordId },
       }),
     );

--- a/apps/api/src/workflows/activity-generation/steps/update-vocabulary-enrichments-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/update-vocabulary-enrichments-step.ts
@@ -11,7 +11,7 @@ export async function updateVocabularyEnrichmentsStep(
   activities: LessonActivity[],
   savedWords: SavedWord[],
   pronunciations: Record<string, string>,
-  wordAudioIds: Record<string, bigint>,
+  wordAudioUrls: Record<string, string>,
   romanizations: Record<string, string>,
 ): Promise<void> {
   "use step";
@@ -26,23 +26,32 @@ export async function updateVocabularyEnrichmentsStep(
 
   await stream.status({ status: "started", step: "updateVocabularyEnrichments" });
 
-  const updates = savedWords
-    .filter(
-      (saved) =>
-        pronunciations[saved.word] || wordAudioIds[saved.word] || romanizations[saved.word],
-    )
+  const userLanguage = activity.language;
+
+  const wordUpdates = savedWords
+    .filter((saved) => wordAudioUrls[saved.word] || romanizations[saved.word])
     .map((saved) =>
       prisma.word.update({
         data: {
-          pronunciation: pronunciations[saved.word],
+          audioUrl: wordAudioUrls[saved.word],
           romanization: romanizations[saved.word],
-          wordAudioId: wordAudioIds[saved.word],
         },
         where: { id: saved.wordId },
       }),
     );
 
-  const { error } = await safeAsync(() => prisma.$transaction(updates));
+  const translationUpdates = savedWords
+    .filter((saved) => pronunciations[saved.word])
+    .map((saved) =>
+      prisma.wordTranslation.update({
+        data: { pronunciation: pronunciations[saved.word] },
+        where: { wordTranslation: { userLanguage, wordId: BigInt(saved.wordId) } },
+      }),
+    );
+
+  const { error } = await safeAsync(() =>
+    prisma.$transaction([...wordUpdates, ...translationUpdates]),
+  );
 
   if (error) {
     await stream.error({ reason: "dbSaveFailed", step: "updateVocabularyEnrichments" });

--- a/apps/main/e2e/activity-completion.test.ts
+++ b/apps/main/e2e/activity-completion.test.ts
@@ -10,7 +10,7 @@ import { lessonWordFixture } from "@zoonk/testing/fixtures/lesson-words";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { userProgressFixture } from "@zoonk/testing/fixtures/progress";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
-import { wordFixture } from "@zoonk/testing/fixtures/words";
+import { wordFixture, wordTranslationFixture } from "@zoonk/testing/fixtures/words";
 import { expect, test } from "./fixtures";
 
 async function createUniqueUser(baseURL: string) {
@@ -388,8 +388,12 @@ test.describe("Activity Completion", () => {
 
     const word = await wordFixture({
       organizationId: org.id,
-      translation: `cat-${uniqueId}`,
       word: `gato-${uniqueId}`,
+    });
+
+    await wordTranslationFixture({
+      translation: `cat-${uniqueId}`,
+      wordId: word.id,
     });
 
     await lessonWordFixture({ lessonId: lesson.id, wordId: word.id });

--- a/apps/main/e2e/listening-step.test.ts
+++ b/apps/main/e2e/listening-step.test.ts
@@ -6,9 +6,9 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonSentenceFixture } from "@zoonk/testing/fixtures/lesson-sentences";
 import { lessonWordFixture } from "@zoonk/testing/fixtures/lesson-words";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
-import { sentenceAudioFixture, sentenceFixture } from "@zoonk/testing/fixtures/sentences";
+import { sentenceFixture, sentenceTranslationFixture } from "@zoonk/testing/fixtures/sentences";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
-import { wordFixture } from "@zoonk/testing/fixtures/words";
+import { wordFixture, wordTranslationFixture } from "@zoonk/testing/fixtures/words";
 import { type Page, expect, test } from "./fixtures";
 
 async function createListeningActivity(options: {
@@ -52,37 +52,39 @@ async function createListeningActivity(options: {
   });
 
   const createdWords = await Promise.all(
-    options.words.map((wordData) =>
-      wordFixture({
-        alternativeTranslations: wordData.alternativeTranslations ?? [],
+    options.words.map(async (wordData) => {
+      const word = await wordFixture({
         organizationId: org.id,
-        translation: wordData.translation,
         word: wordData.word,
-      }),
-    ),
+      });
+
+      await wordTranslationFixture({
+        alternativeTranslations: wordData.alternativeTranslations ?? [],
+        translation: wordData.translation,
+        wordId: word.id,
+      });
+
+      return word;
+    }),
   );
 
   const createdSentences = await Promise.all(
     options.sentences.map(async (sentenceData) => {
-      let sentenceAudioId: bigint | null = null;
-
-      if (sentenceData.audioUrl) {
-        const audio = await sentenceAudioFixture({
-          audioUrl: sentenceData.audioUrl,
-          organizationId: org.id,
-        });
-        sentenceAudioId = audio.id;
-      }
-
-      return sentenceFixture({
+      const sentence = await sentenceFixture({
         alternativeSentences: sentenceData.alternativeSentences ?? [],
-        alternativeTranslations: sentenceData.alternativeTranslations ?? [],
+        audioUrl: sentenceData.audioUrl ?? null,
         organizationId: org.id,
         romanization: sentenceData.romanization ?? null,
         sentence: sentenceData.sentence,
-        sentenceAudioId,
+      });
+
+      await sentenceTranslationFixture({
+        alternativeTranslations: sentenceData.alternativeTranslations ?? [],
+        sentenceId: sentence.id,
         translation: sentenceData.translation,
       });
+
+      return sentence;
     }),
   );
 
@@ -96,14 +98,20 @@ async function createListeningActivity(options: {
   // Create sentence word records for target-language enrichment in feedback
   if (options.sentenceWords) {
     await Promise.all(
-      options.sentenceWords.map((sw) =>
-        wordFixture({
+      options.sentenceWords.map(async (sw) => {
+        const word = await wordFixture({
           organizationId: org.id,
           romanization: sw.romanization ?? null,
-          translation: sw.translation,
           word: sw.word,
-        }),
-      ),
+        });
+
+        await wordTranslationFixture({
+          translation: sw.translation,
+          wordId: word.id,
+        });
+
+        return word;
+      }),
     );
   }
 

--- a/apps/main/e2e/reading-step.test.ts
+++ b/apps/main/e2e/reading-step.test.ts
@@ -6,9 +6,9 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonSentenceFixture } from "@zoonk/testing/fixtures/lesson-sentences";
 import { lessonWordFixture } from "@zoonk/testing/fixtures/lesson-words";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
-import { sentenceAudioFixture, sentenceFixture } from "@zoonk/testing/fixtures/sentences";
+import { sentenceFixture, sentenceTranslationFixture } from "@zoonk/testing/fixtures/sentences";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
-import { wordFixture } from "@zoonk/testing/fixtures/words";
+import { wordFixture, wordTranslationFixture } from "@zoonk/testing/fixtures/words";
 import { type Page, expect, test } from "./fixtures";
 
 async function createReadingActivity(options: {
@@ -62,50 +62,58 @@ async function createReadingActivity(options: {
   });
 
   const createdWords = await Promise.all(
-    options.words.map((wordData) =>
-      wordFixture({
-        alternativeTranslations: wordData.alternativeTranslations ?? [],
+    options.words.map(async (wordData) => {
+      const word = await wordFixture({
         organizationId: org.id,
         romanization: wordData.romanization ?? null,
-        translation: wordData.translation,
         word: wordData.word,
-      }),
-    ),
+      });
+
+      await wordTranslationFixture({
+        alternativeTranslations: wordData.alternativeTranslations ?? [],
+        translation: wordData.translation,
+        wordId: word.id,
+      });
+
+      return word;
+    }),
   );
 
   await Promise.all(
-    (options.fallbackWords ?? []).map((wordData) =>
-      wordFixture({
-        alternativeTranslations: wordData.alternativeTranslations ?? [],
+    (options.fallbackWords ?? []).map(async (wordData) => {
+      const word = await wordFixture({
         organizationId: org.id,
         romanization: wordData.romanization ?? null,
-        translation: wordData.translation,
         word: wordData.word,
-      }),
-    ),
+      });
+
+      await wordTranslationFixture({
+        alternativeTranslations: wordData.alternativeTranslations ?? [],
+        translation: wordData.translation,
+        wordId: word.id,
+      });
+
+      return word;
+    }),
   );
 
   const createdSentences = await Promise.all(
     options.sentences.map(async (sentenceData) => {
-      let sentenceAudioId: bigint | null = null;
-
-      if (sentenceData.audioUrl) {
-        const audio = await sentenceAudioFixture({
-          audioUrl: sentenceData.audioUrl,
-          organizationId: org.id,
-        });
-        sentenceAudioId = audio.id;
-      }
-
-      return sentenceFixture({
+      const sentence = await sentenceFixture({
         alternativeSentences: sentenceData.alternativeSentences ?? [],
-        alternativeTranslations: sentenceData.alternativeTranslations ?? [],
+        audioUrl: sentenceData.audioUrl ?? null,
         organizationId: org.id,
         romanization: sentenceData.romanization ?? null,
         sentence: sentenceData.sentence,
-        sentenceAudioId,
+      });
+
+      await sentenceTranslationFixture({
+        alternativeTranslations: sentenceData.alternativeTranslations ?? [],
+        sentenceId: sentence.id,
         translation: sentenceData.translation,
       });
+
+      return sentence;
     }),
   );
 

--- a/apps/main/e2e/review-step.test.ts
+++ b/apps/main/e2e/review-step.test.ts
@@ -7,9 +7,9 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonSentenceFixture } from "@zoonk/testing/fixtures/lesson-sentences";
 import { lessonWordFixture } from "@zoonk/testing/fixtures/lesson-words";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
-import { sentenceFixture } from "@zoonk/testing/fixtures/sentences";
+import { sentenceFixture, sentenceTranslationFixture } from "@zoonk/testing/fixtures/sentences";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
-import { wordFixture } from "@zoonk/testing/fixtures/words";
+import { wordFixture, wordTranslationFixture } from "@zoonk/testing/fixtures/words";
 import { expect, test } from "./fixtures";
 
 async function createReviewActivity(options: {
@@ -46,22 +46,34 @@ async function createReviewActivity(options: {
 
   const [createdWords, createdSentences] = await Promise.all([
     Promise.all(
-      options.words.map((wordData) =>
-        wordFixture({
+      options.words.map(async (wordData) => {
+        const word = await wordFixture({
           organizationId: org.id,
-          translation: wordData.translation,
           word: wordData.word,
-        }),
-      ),
+        });
+
+        await wordTranslationFixture({
+          translation: wordData.translation,
+          wordId: word.id,
+        });
+
+        return word;
+      }),
     ),
     Promise.all(
-      options.sentences.map((sentenceData) =>
-        sentenceFixture({
+      options.sentences.map(async (sentenceData) => {
+        const sentence = await sentenceFixture({
           organizationId: org.id,
           sentence: sentenceData.sentence,
+        });
+
+        await sentenceTranslationFixture({
+          sentenceId: sentence.id,
           translation: sentenceData.translation,
-        }),
-      ),
+        });
+
+        return sentence;
+      }),
     ),
   ]);
 

--- a/apps/main/e2e/translation-step.test.ts
+++ b/apps/main/e2e/translation-step.test.ts
@@ -6,7 +6,7 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonWordFixture } from "@zoonk/testing/fixtures/lesson-words";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
-import { wordFixture } from "@zoonk/testing/fixtures/words";
+import { wordFixture, wordTranslationFixture } from "@zoonk/testing/fixtures/words";
 import { type Page, expect, test } from "./fixtures";
 
 async function createTranslationActivity(options: {
@@ -54,29 +54,41 @@ async function createTranslationActivity(options: {
   });
 
   const createdWords = await Promise.all(
-    options.words.map((wordData) =>
-      wordFixture({
-        alternativeTranslations: wordData.alternativeTranslations ?? [],
+    options.words.map(async (wordData) => {
+      const word = await wordFixture({
         organizationId: org.id,
-        pronunciation: wordData.pronunciation ?? null,
         romanization: wordData.romanization ?? null,
-        translation: wordData.translation,
         word: wordData.word,
-      }),
-    ),
+      });
+
+      await wordTranslationFixture({
+        alternativeTranslations: wordData.alternativeTranslations ?? [],
+        pronunciation: wordData.pronunciation ?? null,
+        translation: wordData.translation,
+        wordId: word.id,
+      });
+
+      return word;
+    }),
   );
 
   await Promise.all(
-    (options.fallbackWords ?? []).map((wordData) =>
-      wordFixture({
-        alternativeTranslations: wordData.alternativeTranslations ?? [],
+    (options.fallbackWords ?? []).map(async (wordData) => {
+      const word = await wordFixture({
         organizationId: org.id,
-        pronunciation: wordData.pronunciation ?? null,
         romanization: wordData.romanization ?? null,
-        translation: wordData.translation,
         word: wordData.word,
-      }),
-    ),
+      });
+
+      await wordTranslationFixture({
+        alternativeTranslations: wordData.alternativeTranslations ?? [],
+        pronunciation: wordData.pronunciation ?? null,
+        translation: wordData.translation,
+        wordId: word.id,
+      });
+
+      return word;
+    }),
   );
 
   await Promise.all(

--- a/apps/main/e2e/vocabulary-flashcard-step.test.ts
+++ b/apps/main/e2e/vocabulary-flashcard-step.test.ts
@@ -6,7 +6,7 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonWordFixture } from "@zoonk/testing/fixtures/lesson-words";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
-import { wordFixture } from "@zoonk/testing/fixtures/words";
+import { wordFixture, wordTranslationFixture } from "@zoonk/testing/fixtures/words";
 import { expect, test } from "./fixtures";
 
 async function createFlashcardActivity(options: {
@@ -45,14 +45,20 @@ async function createFlashcardActivity(options: {
   });
 
   const createdWords = await Promise.all(
-    options.words.map((wordData) =>
-      wordFixture({
+    options.words.map(async (wordData) => {
+      const word = await wordFixture({
         organizationId: org.id,
         romanization: wordData.romanization ?? null,
-        translation: wordData.translation,
         word: wordData.word,
-      }),
-    ),
+      });
+
+      await wordTranslationFixture({
+        translation: wordData.translation,
+        wordId: word.id,
+      });
+
+      return word;
+    }),
   );
 
   await Promise.all(

--- a/apps/main/src/data/activities/get-activity.test.ts
+++ b/apps/main/src/data/activities/get-activity.test.ts
@@ -3,9 +3,9 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { sentenceAudioFixture, sentenceFixture } from "@zoonk/testing/fixtures/sentences";
+import { sentenceFixture, sentenceTranslationFixture } from "@zoonk/testing/fixtures/sentences";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
-import { wordAudioFixture, wordFixture } from "@zoonk/testing/fixtures/words";
+import { wordFixture, wordTranslationFixture } from "@zoonk/testing/fixtures/words";
 import { beforeAll, describe, expect, test } from "vitest";
 import { getActivity } from "./get-activity";
 
@@ -144,11 +144,6 @@ describe(getActivity, () => {
       organizationId: org.id,
     });
 
-    const wordAudio = await wordAudioFixture({
-      audioUrl: "https://example.com/audio.mp3",
-      organizationId: org.id,
-    });
-
     const [wordActivity, word] = await Promise.all([
       activityFixture({
         generationStatus: "completed",
@@ -160,14 +155,20 @@ describe(getActivity, () => {
         position: 0,
       }),
       wordFixture({
+        audioUrl: "https://example.com/audio.mp3",
         organizationId: org.id,
-        pronunciation: "test-pron",
         romanization: "test-roman",
-        translation: "test-translation",
         word: `test-word-${crypto.randomUUID()}`,
-        wordAudioId: wordAudio.id,
       }),
     ]);
+
+    await wordTranslationFixture({
+      alternativeTranslations: [],
+      pronunciation: "test-pron",
+      translation: "test-translation",
+      userLanguage: "en",
+      wordId: word.id,
+    });
 
     await stepFixture({
       activityId: wordActivity.id,
@@ -179,13 +180,17 @@ describe(getActivity, () => {
     const result = await getActivity({ lessonId: wordLesson.id, position: 0 });
 
     expect(result?.steps[0]?.word).toMatchObject({
-      alternativeTranslations: [],
+      audioUrl: "https://example.com/audio.mp3",
       id: word.id,
-      pronunciation: "test-pron",
       romanization: "test-roman",
-      translation: "test-translation",
+      translations: expect.arrayContaining([
+        expect.objectContaining({
+          alternativeTranslations: [],
+          pronunciation: "test-pron",
+          translation: "test-translation",
+        }),
+      ]) as unknown,
       word: word.word,
-      wordAudio: { audioUrl: "https://example.com/audio.mp3" },
     });
   });
 
@@ -194,11 +199,6 @@ describe(getActivity, () => {
       chapterId: chapter.id,
       isPublished: true,
       language: "en",
-      organizationId: org.id,
-    });
-
-    const sentAudio = await sentenceAudioFixture({
-      audioUrl: "https://example.com/sent-audio.mp3",
       organizationId: org.id,
     });
 
@@ -214,14 +214,19 @@ describe(getActivity, () => {
       }),
       sentenceFixture({
         alternativeSentences: ["test-sentence-alt"],
-        alternativeTranslations: ["test-sent-translation-alt"],
+        audioUrl: "https://example.com/sent-audio.mp3",
         organizationId: org.id,
         romanization: "test-sent-roman",
         sentence: `test-sentence-${crypto.randomUUID()}`,
-        sentenceAudioId: sentAudio.id,
-        translation: "test-sent-translation",
       }),
     ]);
+
+    await sentenceTranslationFixture({
+      alternativeTranslations: ["test-sent-translation-alt"],
+      sentenceId: sentence.id,
+      translation: "test-sent-translation",
+      userLanguage: "en",
+    });
 
     await stepFixture({
       activityId: sentActivity.id,
@@ -234,12 +239,16 @@ describe(getActivity, () => {
 
     expect(result?.steps[0]?.sentence).toMatchObject({
       alternativeSentences: ["test-sentence-alt"],
-      alternativeTranslations: ["test-sent-translation-alt"],
+      audioUrl: "https://example.com/sent-audio.mp3",
       id: sentence.id,
       romanization: "test-sent-roman",
       sentence: sentence.sentence,
-      sentenceAudio: { audioUrl: "https://example.com/sent-audio.mp3" },
-      translation: "test-sent-translation",
+      translations: expect.arrayContaining([
+        expect.objectContaining({
+          alternativeTranslations: ["test-sent-translation-alt"],
+          translation: "test-sent-translation",
+        }),
+      ]) as unknown,
     });
   });
 

--- a/apps/main/src/data/activities/get-activity.ts
+++ b/apps/main/src/data/activities/get-activity.ts
@@ -7,8 +7,8 @@ const cachedGetActivity = cache(async (lessonId: number, position: number) =>
     include: {
       steps: {
         include: {
-          sentence: { include: { sentenceAudio: true } },
-          word: { include: { wordAudio: true } },
+          sentence: { include: { translations: true } },
+          word: { include: { translations: true } },
         },
         orderBy: { position: "asc" },
         where: { isPublished: true },

--- a/apps/main/src/data/activities/get-fallback-distractor-words.test.ts
+++ b/apps/main/src/data/activities/get-fallback-distractor-words.test.ts
@@ -38,8 +38,6 @@ describe(getFallbackDistractorWords, () => {
     const lessonWord = await wordFixture({
       organizationId: org.id,
       targetLanguage: "es",
-      translation: `hello-${crypto.randomUUID()}`,
-      userLanguage: "en",
       word: `hola-${crypto.randomUUID()}`,
     });
     await lessonWordFixture({ lessonId: lesson.id, wordId: lessonWord.id });
@@ -49,8 +47,6 @@ describe(getFallbackDistractorWords, () => {
         wordFixture({
           organizationId: org.id,
           targetLanguage: "es",
-          translation: `extra-${index}-${crypto.randomUUID()}`,
-          userLanguage: "en",
           word: `word-${index}-${crypto.randomUUID()}`,
         }),
       ),
@@ -60,8 +56,6 @@ describe(getFallbackDistractorWords, () => {
     await wordFixture({
       organizationId: otherOrg.id,
       targetLanguage: "es",
-      translation: `other-org-${crypto.randomUUID()}`,
-      userLanguage: "en",
       word: `otro-${crypto.randomUUID()}`,
     });
 
@@ -84,24 +78,18 @@ describe(getFallbackDistractorWords, () => {
       organizationId: org.id,
       sentence: `hola-${crypto.randomUUID()} mundo-${crypto.randomUUID()}`,
       targetLanguage: "es",
-      translation: `hello-${crypto.randomUUID()} world-${crypto.randomUUID()}`,
-      userLanguage: "en",
     });
     await lessonSentenceFixture({ lessonId: lesson.id, sentenceId: sentence.id });
 
     const scopedWord = await wordFixture({
       organizationId: org.id,
       targetLanguage: "es",
-      translation: `cat-${crypto.randomUUID()}`,
-      userLanguage: "en",
       word: `gato-${crypto.randomUUID()}`,
     });
 
     await wordFixture({
       organizationId: org.id,
       targetLanguage: "fr",
-      translation: `cat-${crypto.randomUUID()}`,
-      userLanguage: "en",
       word: `chat-${crypto.randomUUID()}`,
     });
 

--- a/apps/main/src/data/activities/get-fallback-distractor-words.ts
+++ b/apps/main/src/data/activities/get-fallback-distractor-words.ts
@@ -6,17 +6,9 @@ import { getLessonWords } from "./get-lesson-words";
 
 const FALLBACK_DISTRACTOR_WORD_LIMIT = 4;
 
-type LessonWordScope = {
-  id: bigint;
+type LanguageScope = {
   organizationId: number;
   targetLanguage: string;
-  userLanguage: string;
-};
-
-type LessonSentenceScope = {
-  organizationId: number;
-  targetLanguage: string;
-  userLanguage: string;
 };
 
 /**
@@ -24,9 +16,9 @@ type LessonSentenceScope = {
  * the player can fill rare underflow cases without building a larger scope system.
  */
 function getFallbackWordScope(
-  lessonWords: LessonWordScope[],
-  lessonSentences: LessonSentenceScope[],
-): LessonSentenceScope | LessonWordScope | null {
+  lessonWords: LanguageScope[],
+  lessonSentences: LanguageScope[],
+): LanguageScope | null {
   return lessonWords[0] ?? lessonSentences[0] ?? null;
 }
 
@@ -49,14 +41,13 @@ const cachedGetFallbackDistractorWords = cache(async (lessonId: number, limit: n
   }
 
   return prisma.word.findMany({
-    include: { wordAudio: true },
+    include: { translations: true },
     orderBy: { id: "desc" },
     take: limit,
     where: {
       id: { notIn: lessonWords.map((word) => word.id) },
       organizationId: scope.organizationId,
       targetLanguage: scope.targetLanguage,
-      userLanguage: scope.userLanguage,
     },
   });
 });

--- a/apps/main/src/data/activities/get-lesson-sentences.test.ts
+++ b/apps/main/src/data/activities/get-lesson-sentences.test.ts
@@ -3,7 +3,7 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonSentenceFixture } from "@zoonk/testing/fixtures/lesson-sentences";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { sentenceAudioFixture, sentenceFixture } from "@zoonk/testing/fixtures/sentences";
+import { sentenceFixture, sentenceTranslationFixture } from "@zoonk/testing/fixtures/sentences";
 import { beforeAll, describe, expect, test } from "vitest";
 import { getLessonSentences } from "./get-lesson-sentences";
 
@@ -43,13 +43,11 @@ describe(getLessonSentences, () => {
         organizationId: org.id,
         sentence: `Hola mundo ${crypto.randomUUID()}`,
         targetLanguage: "es",
-        translation: "Hello world",
       }),
       sentenceFixture({
         organizationId: org.id,
         sentence: `Buenos días ${crypto.randomUUID()}`,
         targetLanguage: "es",
-        translation: "Good morning",
       }),
     ]);
 
@@ -75,21 +73,20 @@ describe(getLessonSentences, () => {
       organizationId: org.id,
     });
 
-    const sentAudio = await sentenceAudioFixture({
-      audioUrl: "https://example.com/megusta.mp3",
-      organizationId: org.id,
-      targetLanguage: "es",
-    });
-
     const sentence = await sentenceFixture({
       alternativeSentences: ["Adoro"],
-      alternativeTranslations: ["I enjoy"],
+      audioUrl: "https://example.com/megusta.mp3",
       organizationId: org.id,
       romanization: null,
       sentence: `Me gusta ${crypto.randomUUID()}`,
-      sentenceAudioId: sentAudio.id,
       targetLanguage: "es",
+    });
+
+    await sentenceTranslationFixture({
+      alternativeTranslations: ["I enjoy"],
+      sentenceId: sentence.id,
       translation: "I like",
+      userLanguage: "en",
     });
 
     await lessonSentenceFixture({ lessonId: newLesson.id, sentenceId: sentence.id });
@@ -99,12 +96,16 @@ describe(getLessonSentences, () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       alternativeSentences: ["Adoro"],
-      alternativeTranslations: ["I enjoy"],
+      audioUrl: "https://example.com/megusta.mp3",
       id: sentence.id,
       romanization: null,
       sentence: sentence.sentence,
-      sentenceAudio: { audioUrl: "https://example.com/megusta.mp3" },
-      translation: "I like",
+      translations: expect.arrayContaining([
+        expect.objectContaining({
+          alternativeTranslations: ["I enjoy"],
+          translation: "I like",
+        }),
+      ]) as unknown,
     });
   });
 

--- a/apps/main/src/data/activities/get-lesson-sentences.ts
+++ b/apps/main/src/data/activities/get-lesson-sentences.ts
@@ -4,7 +4,7 @@ import { cache } from "react";
 
 const cachedGetLessonSentences = cache(async (lessonId: number) => {
   const lessonSentences = await prisma.lessonSentence.findMany({
-    include: { sentence: { include: { sentenceAudio: true } } },
+    include: { sentence: { include: { translations: true } } },
     where: { lessonId },
   });
 

--- a/apps/main/src/data/activities/get-lesson-words.test.ts
+++ b/apps/main/src/data/activities/get-lesson-words.test.ts
@@ -3,7 +3,7 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonWordFixture } from "@zoonk/testing/fixtures/lesson-words";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { wordAudioFixture, wordFixture } from "@zoonk/testing/fixtures/words";
+import { wordFixture, wordTranslationFixture } from "@zoonk/testing/fixtures/words";
 import { beforeAll, describe, expect, test } from "vitest";
 import { getLessonWords } from "./get-lesson-words";
 
@@ -41,16 +41,12 @@ describe(getLessonWords, () => {
     const [word1, word2] = await Promise.all([
       wordFixture({
         organizationId: org.id,
-        pronunciation: "oh-lah",
         targetLanguage: "es",
-        translation: "hello",
         word: `hola-${crypto.randomUUID()}`,
       }),
       wordFixture({
         organizationId: org.id,
-        pronunciation: "grah-see-ahs",
         targetLanguage: "es",
-        translation: "thank you",
         word: `gracias-${crypto.randomUUID()}`,
       }),
     ]);
@@ -77,20 +73,20 @@ describe(getLessonWords, () => {
       organizationId: org.id,
     });
 
-    const wordAudio = await wordAudioFixture({
+    const word = await wordFixture({
       audioUrl: "https://example.com/perro.mp3",
       organizationId: org.id,
-      targetLanguage: "es",
-    });
-
-    const word = await wordFixture({
-      organizationId: org.id,
-      pronunciation: "peh-roh",
       romanization: null,
       targetLanguage: "es",
-      translation: "dog",
       word: `perro-${crypto.randomUUID()}`,
-      wordAudioId: wordAudio.id,
+    });
+
+    await wordTranslationFixture({
+      alternativeTranslations: [],
+      pronunciation: "peh-roh",
+      translation: "dog",
+      userLanguage: "en",
+      wordId: word.id,
     });
 
     await lessonWordFixture({ lessonId: newLesson.id, wordId: word.id });
@@ -99,13 +95,17 @@ describe(getLessonWords, () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
-      alternativeTranslations: [],
+      audioUrl: "https://example.com/perro.mp3",
       id: word.id,
-      pronunciation: "peh-roh",
       romanization: null,
-      translation: "dog",
+      translations: expect.arrayContaining([
+        expect.objectContaining({
+          alternativeTranslations: [],
+          pronunciation: "peh-roh",
+          translation: "dog",
+        }),
+      ]) as unknown,
       word: word.word,
-      wordAudio: { audioUrl: "https://example.com/perro.mp3" },
     });
   });
 

--- a/apps/main/src/data/activities/get-lesson-words.ts
+++ b/apps/main/src/data/activities/get-lesson-words.ts
@@ -4,7 +4,7 @@ import { cache } from "react";
 
 const cachedGetLessonWords = cache(async (lessonId: number) => {
   const lessonWords = await prisma.lessonWord.findMany({
-    include: { word: { include: { wordAudio: true } } },
+    include: { word: { include: { translations: true } } },
     where: { lessonId },
   });
 

--- a/apps/main/src/data/activities/get-review-steps.test.ts
+++ b/apps/main/src/data/activities/get-review-steps.test.ts
@@ -3,7 +3,7 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { sentenceFixture } from "@zoonk/testing/fixtures/sentences";
+import { sentenceFixture, sentenceTranslationFixture } from "@zoonk/testing/fixtures/sentences";
 import { stepAttemptFixture } from "@zoonk/testing/fixtures/step-attempts";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { userFixture } from "@zoonk/testing/fixtures/users";
@@ -728,8 +728,14 @@ describe(getReviewValidationSteps, () => {
   test("includes sentence variants for review validation", async () => {
     const sentence = await sentenceFixture({
       alternativeSentences: ["Guten Morgen, ich bin Lara."],
-      alternativeTranslations: ["Good morning, I am Lara."],
       organizationId,
+    });
+
+    await sentenceTranslationFixture({
+      alternativeTranslations: ["Good morning, I am Lara."],
+      sentenceId: sentence.id,
+      translation: "Hello, I am Lara.",
+      userLanguage: "en",
     });
 
     const readingActivity = await activityFixture({
@@ -750,9 +756,13 @@ describe(getReviewValidationSteps, () => {
 
     expect(steps[0]?.sentence).toMatchObject({
       alternativeSentences: ["Guten Morgen, ich bin Lara."],
-      alternativeTranslations: ["Good morning, I am Lara."],
       sentence: sentence.sentence,
-      translation: sentence.translation,
+      translations: expect.arrayContaining([
+        expect.objectContaining({
+          alternativeTranslations: ["Good morning, I am Lara."],
+          translation: "Hello, I am Lara.",
+        }),
+      ]) as unknown,
     });
   });
 });

--- a/apps/main/src/data/activities/get-review-steps.ts
+++ b/apps/main/src/data/activities/get-review-steps.ts
@@ -38,8 +38,8 @@ export async function getReviewSteps({
   if (!userId) {
     const allSteps = await prisma.step.findMany({
       include: {
-        sentence: { include: { sentenceAudio: true } },
-        word: { include: { wordAudio: true } },
+        sentence: { include: { translations: true } },
+        word: { include: { translations: true } },
       },
       where: lessonStepFilter,
     });
@@ -53,8 +53,8 @@ export async function getReviewSteps({
   const [allSteps, incorrectAttempts, correctAttempts] = await Promise.all([
     prisma.step.findMany({
       include: {
-        sentence: { include: { sentenceAudio: true } },
-        word: { include: { wordAudio: true } },
+        sentence: { include: { translations: true } },
+        word: { include: { translations: true } },
       },
       where: lessonStepFilter,
     }),
@@ -102,8 +102,8 @@ export async function getReviewSteps({
 export async function getReviewValidationSteps(lessonId: number, stepIds: bigint[]) {
   return prisma.step.findMany({
     include: {
-      sentence: { include: { sentenceAudio: true } },
-      word: { include: { wordAudio: true } },
+      sentence: { include: { translations: true } },
+      word: { include: { translations: true } },
     },
     where: { ...reviewableStepFilter(lessonId), id: { in: stepIds } },
   });

--- a/apps/main/src/data/activities/get-sentence-words.test.ts
+++ b/apps/main/src/data/activities/get-sentence-words.test.ts
@@ -4,7 +4,7 @@ import { lessonSentenceFixture } from "@zoonk/testing/fixtures/lesson-sentences"
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { sentenceFixture } from "@zoonk/testing/fixtures/sentences";
-import { wordFixture } from "@zoonk/testing/fixtures/words";
+import { wordFixture, wordTranslationFixture } from "@zoonk/testing/fixtures/words";
 import { beforeAll, describe, expect, test } from "vitest";
 import { getSentenceWords } from "./get-sentence-words";
 
@@ -46,18 +46,15 @@ describe(getSentenceWords, () => {
         organizationId: org.id,
         sentence: `${wordText1} ${wordText2}`,
         targetLanguage: "es",
-        translation: "hello world",
       }),
       wordFixture({
         organizationId: org.id,
         targetLanguage: "es",
-        translation: "hello",
         word: wordText1,
       }),
       wordFixture({
         organizationId: org.id,
         targetLanguage: "es",
-        translation: "world",
         word: wordText2,
       }),
     ]);
@@ -103,7 +100,6 @@ describe(getSentenceWords, () => {
       organizationId: org.id,
       sentence: `noexiste${uniqueId} tampoco${uniqueId}`,
       targetLanguage: "es",
-      translation: "doesn't exist either",
     });
 
     await lessonSentenceFixture({ lessonId: newLesson.id, sentenceId: sentence.id });
@@ -127,12 +123,10 @@ describe(getSentenceWords, () => {
         organizationId: org.id,
         sentence: `${wordText}?`,
         targetLanguage: "es",
-        translation: "you know?",
       }),
       wordFixture({
         organizationId: org.id,
         targetLanguage: "es",
-        translation: "you know",
         word: wordText,
       }),
     ]);
@@ -156,21 +150,24 @@ describe(getSentenceWords, () => {
 
     const wordText = `Hola${uniqueId}`;
 
-    const [sentence] = await Promise.all([
+    const [sentence, word] = await Promise.all([
       sentenceFixture({
         organizationId: org.id,
         sentence: `${wordText} mundo`,
         targetLanguage: "es",
-        translation: "hello world",
       }),
-      // Word stored with uppercase (as AI might generate)
       wordFixture({
         organizationId: org.id,
         targetLanguage: "es",
-        translation: "hello",
         word: wordText,
       }),
     ]);
+
+    await wordTranslationFixture({
+      translation: "hello",
+      userLanguage: "en",
+      wordId: word.id,
+    });
 
     await lessonSentenceFixture({ lessonId: newLesson.id, sentenceId: sentence.id });
 
@@ -179,7 +176,8 @@ describe(getSentenceWords, () => {
 
     const match = result.find((item) => item.word.toLowerCase() === wordText.toLowerCase());
     expect(match).toBeDefined();
-    expect(match?.translation).toBe("hello");
+    const matchTranslation = match?.translations.find((t) => t.userLanguage === "en");
+    expect(matchTranslation?.translation).toBe("hello");
   });
 
   test("deduplicates words across multiple sentences", async () => {
@@ -197,18 +195,15 @@ describe(getSentenceWords, () => {
         organizationId: org.id,
         sentence: `${wordText} bonito`,
         targetLanguage: "es",
-        translation: "pretty cat",
       }),
       sentenceFixture({
         organizationId: org.id,
         sentence: `${wordText} grande`,
         targetLanguage: "es",
-        translation: "big cat",
       }),
       wordFixture({
         organizationId: org.id,
         targetLanguage: "es",
-        translation: "cat",
         word: wordText,
       }),
     ]);

--- a/apps/main/src/data/activities/get-sentence-words.ts
+++ b/apps/main/src/data/activities/get-sentence-words.ts
@@ -26,14 +26,13 @@ const cachedGetSentenceWords = cache(async (lessonId: number) => {
     return [];
   }
 
-  const { organizationId, targetLanguage, userLanguage } = firstSentence;
+  const { organizationId, targetLanguage } = firstSentence;
 
   return prisma.word.findMany({
-    include: { wordAudio: true },
+    include: { translations: true },
     where: {
       organizationId,
       targetLanguage,
-      userLanguage,
       word: { in: uniqueWords, mode: "insensitive" },
     },
   });

--- a/apps/main/src/data/activities/prepare-activity-data.test.ts
+++ b/apps/main/src/data/activities/prepare-activity-data.test.ts
@@ -6,9 +6,9 @@ import { lessonSentenceFixture } from "@zoonk/testing/fixtures/lesson-sentences"
 import { lessonWordFixture } from "@zoonk/testing/fixtures/lesson-words";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { sentenceAudioFixture, sentenceFixture } from "@zoonk/testing/fixtures/sentences";
+import { sentenceFixture, sentenceTranslationFixture } from "@zoonk/testing/fixtures/sentences";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
-import { wordAudioFixture, wordFixture } from "@zoonk/testing/fixtures/words";
+import { wordFixture, wordTranslationFixture } from "@zoonk/testing/fixtures/words";
 import { beforeAll, describe, expect, expectTypeOf, test } from "vitest";
 import { getActivity } from "./get-activity";
 
@@ -104,19 +104,12 @@ describe(prepareActivityData, () => {
   });
 
   test("serializes word data on steps with word relations", async () => {
-    const wordAudio = await wordAudioFixture({
-      audioUrl: "https://example.com/word.mp3",
-      organizationId: org.id,
-    });
-
     const [word, activity] = await Promise.all([
       wordFixture({
+        audioUrl: "https://example.com/word.mp3",
         organizationId: org.id,
-        pronunciation: "hola",
         romanization: null,
-        translation: "hello",
         word: `hola-${crypto.randomUUID()}`,
-        wordAudioId: wordAudio.id,
       }),
       activityFixture({
         generationStatus: "completed",
@@ -128,6 +121,14 @@ describe(prepareActivityData, () => {
         position: 104,
       }),
     ]);
+
+    await wordTranslationFixture({
+      alternativeTranslations: [],
+      pronunciation: "hola",
+      translation: "hello",
+      userLanguage: "en",
+      wordId: word.id,
+    });
 
     await stepFixture({
       activityId: activity.id,
@@ -153,20 +154,13 @@ describe(prepareActivityData, () => {
   });
 
   test("serializes sentence data on steps with sentence relations", async () => {
-    const sentAudio = await sentenceAudioFixture({
-      audioUrl: "https://example.com/sent.mp3",
-      organizationId: org.id,
-    });
-
     const [sentence, activity] = await Promise.all([
       sentenceFixture({
         alternativeSentences: ["ohayo"],
-        alternativeTranslations: ["hi"],
+        audioUrl: "https://example.com/sent.mp3",
         organizationId: org.id,
         romanization: "konnichiwa",
         sentence: `konnichiwa-${crypto.randomUUID()}`,
-        sentenceAudioId: sentAudio.id,
-        translation: "hello",
       }),
       activityFixture({
         generationStatus: "completed",
@@ -178,6 +172,14 @@ describe(prepareActivityData, () => {
         position: 105,
       }),
     ]);
+
+    await sentenceTranslationFixture({
+      alternativeTranslations: ["hi"],
+      explanation: null,
+      sentenceId: sentence.id,
+      translation: "hello",
+      userLanguage: "en",
+    });
 
     await stepFixture({
       activityId: activity.id,
@@ -253,35 +255,29 @@ describe(prepareActivityData, () => {
 
     const lessonWords = [
       {
-        alternativeTranslations: word1.alternativeTranslations,
+        audioUrl: word1.audioUrl,
         id: word1.id,
-        pronunciation: word1.pronunciation,
         romanization: word1.romanization,
-        translation: word1.translation,
+        translations: [],
         word: word1.word,
-        wordAudio: word1.wordAudio,
       },
       {
-        alternativeTranslations: word2.alternativeTranslations,
+        audioUrl: word2.audioUrl,
         id: word2.id,
-        pronunciation: word2.pronunciation,
         romanization: word2.romanization,
-        translation: word2.translation,
+        translations: [],
         word: word2.word,
-        wordAudio: word2.wordAudio,
       },
     ];
 
     const lessonSentences = [
       {
         alternativeSentences: sentence1.alternativeSentences,
-        alternativeTranslations: sentence1.alternativeTranslations,
-        explanation: sentence1.explanation,
+        audioUrl: sentence1.audioUrl,
         id: sentence1.id,
         romanization: sentence1.romanization,
         sentence: sentence1.sentence,
-        sentenceAudio: sentence1.sentenceAudio,
-        translation: sentence1.translation,
+        translations: [],
       },
     ];
 
@@ -361,23 +357,33 @@ describe(prepareActivityData, () => {
 
   test("copies alternativeTranslations arrays for translation options", () => {
     const stepWord = {
-      alternativeTranslations: ["hello"],
+      audioUrl: null,
       id: BigInt(1),
-      pronunciation: null,
       romanization: null,
-      translation: "hello",
+      translations: [
+        {
+          alternativeTranslations: ["hello"],
+          pronunciation: null,
+          translation: "hello",
+          userLanguage: "en",
+        },
+      ],
       word: "hola",
-      wordAudio: null,
     };
 
     const lessonWord = {
-      alternativeTranslations: ["cat"],
+      audioUrl: null,
       id: BigInt(2),
-      pronunciation: null,
       romanization: null,
-      translation: "cat",
+      translations: [
+        {
+          alternativeTranslations: ["cat"],
+          pronunciation: null,
+          translation: "cat",
+          userLanguage: "en",
+        },
+      ],
       word: "gato",
-      wordAudio: null,
     };
 
     const activity = {
@@ -408,65 +414,89 @@ describe(prepareActivityData, () => {
     const translationOptions = translationStep?.translationOptions ?? [];
     const serializedStepWord = translationOptions.find((word) => word.id === String(stepWord.id));
 
+    const inputAlternatives = stepWord.translations[0]!.alternativeTranslations;
     expect(serializedStepWord).toBeDefined();
-    expect(serializedStepWord?.alternativeTranslations).toEqual(stepWord.alternativeTranslations);
-    expect(serializedStepWord?.alternativeTranslations).not.toBe(stepWord.alternativeTranslations);
-    expect(result.lessonWords[0]?.alternativeTranslations).not.toBe(
-      stepWord.alternativeTranslations,
-    );
+    expect(serializedStepWord?.alternativeTranslations).toEqual(inputAlternatives);
+    expect(serializedStepWord?.alternativeTranslations).not.toBe(inputAlternatives);
+    expect(result.lessonWords[0]?.alternativeTranslations).not.toBe(inputAlternatives);
   });
 
   test("translation options use fallback words without leaking them into lessonWords", () => {
     const stepWord = {
-      alternativeTranslations: ["hi"],
+      audioUrl: null,
       id: BigInt(11),
-      pronunciation: null,
       romanization: null,
-      translation: "hello",
+      translations: [
+        {
+          alternativeTranslations: ["hi"],
+          pronunciation: null,
+          translation: "hello",
+          userLanguage: "en",
+        },
+      ],
       word: "hola",
-      wordAudio: null,
     };
 
     const lessonWords = [
       stepWord,
       {
-        alternativeTranslations: ["hello"],
+        audioUrl: null,
         id: BigInt(12),
-        pronunciation: null,
         romanization: null,
-        translation: "hi",
+        translations: [
+          {
+            alternativeTranslations: ["hello"],
+            pronunciation: null,
+            translation: "hi",
+            userLanguage: "en",
+          },
+        ],
         word: "oi",
-        wordAudio: null,
       },
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(13),
-        pronunciation: null,
         romanization: null,
-        translation: "cat",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "cat",
+            userLanguage: "en",
+          },
+        ],
         word: "gato",
-        wordAudio: null,
       },
     ];
 
     const fallbackWords = [
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(14),
-        pronunciation: null,
         romanization: null,
-        translation: "dog",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "dog",
+            userLanguage: "en",
+          },
+        ],
         word: "perro",
-        wordAudio: null,
       },
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(15),
-        pronunciation: null,
         romanization: null,
-        translation: "bird",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "bird",
+            userLanguage: "en",
+          },
+        ],
         word: "pajaro",
-        wordAudio: null,
       },
     ];
 
@@ -507,61 +537,91 @@ describe(prepareActivityData, () => {
   test("reading word bank uses fallback words to reach four visible distractors without leaking them into lessonWords", () => {
     const lessonWords = [
       {
-        alternativeTranslations: ["hi"],
+        audioUrl: null,
         id: BigInt(18),
-        pronunciation: null,
         romanization: null,
-        translation: "hello",
+        translations: [
+          {
+            alternativeTranslations: ["hi"],
+            pronunciation: null,
+            translation: "hello",
+            userLanguage: "en",
+          },
+        ],
         word: "Hola",
-        wordAudio: null,
       },
       {
-        alternativeTranslations: ["hello"],
+        audioUrl: null,
         id: BigInt(19),
-        pronunciation: null,
         romanization: null,
-        translation: "hi",
+        translations: [
+          {
+            alternativeTranslations: ["hello"],
+            pronunciation: null,
+            translation: "hi",
+            userLanguage: "en",
+          },
+        ],
         word: "Salut",
-        wordAudio: null,
       },
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(20),
-        pronunciation: null,
         romanization: null,
-        translation: "cat",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "cat",
+            userLanguage: "en",
+          },
+        ],
         word: "gato",
-        wordAudio: null,
       },
     ];
 
     const fallbackWords = [
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(21),
-        pronunciation: null,
         romanization: null,
-        translation: "dog",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "dog",
+            userLanguage: "en",
+          },
+        ],
         word: "perro",
-        wordAudio: null,
       },
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(22),
-        pronunciation: null,
         romanization: null,
-        translation: "bird",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "bird",
+            userLanguage: "en",
+          },
+        ],
         word: "pajaro",
-        wordAudio: null,
       },
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(23),
-        pronunciation: null,
         romanization: null,
-        translation: "fish",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "fish",
+            userLanguage: "en",
+          },
+        ],
         word: "pez",
-        wordAudio: null,
       },
     ];
 
@@ -582,13 +642,18 @@ describe(prepareActivityData, () => {
           position: 0,
           sentence: {
             alternativeSentences: [],
-            alternativeTranslations: [],
-            explanation: null,
+            audioUrl: null,
             id: BigInt(26),
             romanization: null,
             sentence: "Hola mundo",
-            sentenceAudio: null,
-            translation: "Hello world",
+            translations: [
+              {
+                alternativeTranslations: [],
+                explanation: null,
+                translation: "Hello world",
+                userLanguage: "en",
+              },
+            ],
           },
           word: null,
         },
@@ -615,16 +680,13 @@ describe(prepareActivityData, () => {
       sentenceFixture({
         organizationId: org.id,
         sentence: sentenceText,
-        translation: `Hello world ${uniqueId}`,
       }),
       wordFixture({
         organizationId: org.id,
-        translation: `cat-${uniqueId}`,
         word: `gato-${uniqueId}`,
       }),
       wordFixture({
         organizationId: org.id,
-        translation: `dog-${uniqueId}`,
         word: `perro-${uniqueId}`,
       }),
       activityFixture({
@@ -635,6 +697,24 @@ describe(prepareActivityData, () => {
         lessonId: lesson.id,
         organizationId: org.id,
         position: 110,
+      }),
+    ]);
+
+    await Promise.all([
+      sentenceTranslationFixture({
+        sentenceId: sentence.id,
+        translation: `Hello world ${uniqueId}`,
+        userLanguage: "en",
+      }),
+      wordTranslationFixture({
+        translation: `cat-${uniqueId}`,
+        userLanguage: "en",
+        wordId: word1.id,
+      }),
+      wordTranslationFixture({
+        translation: `dog-${uniqueId}`,
+        userLanguage: "en",
+        wordId: word2.id,
       }),
     ]);
 
@@ -649,22 +729,32 @@ describe(prepareActivityData, () => {
 
     const lessonWords = [
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: word1.id,
-        pronunciation: null,
         romanization: null,
-        translation: word1.translation,
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: `cat-${uniqueId}`,
+            userLanguage: "en",
+          },
+        ],
         word: word1.word,
-        wordAudio: null,
       },
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: word2.id,
-        pronunciation: null,
         romanization: null,
-        translation: word2.translation,
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: `dog-${uniqueId}`,
+            userLanguage: "en",
+          },
+        ],
         word: word2.word,
-        wordAudio: null,
       },
     ];
 
@@ -689,16 +779,13 @@ describe(prepareActivityData, () => {
       sentenceFixture({
         organizationId: org.id,
         sentence: `Hola mundo ${uniqueId}`,
-        translation: translationText,
       }),
       wordFixture({
         organizationId: org.id,
-        translation: `cat-${uniqueId}`,
         word: `gato-${uniqueId}`,
       }),
       wordFixture({
         organizationId: org.id,
-        translation: `dog-${uniqueId}`,
         word: `perro-${uniqueId}`,
       }),
       activityFixture({
@@ -709,6 +796,24 @@ describe(prepareActivityData, () => {
         lessonId: lesson.id,
         organizationId: org.id,
         position: 111,
+      }),
+    ]);
+
+    await Promise.all([
+      sentenceTranslationFixture({
+        sentenceId: sentence.id,
+        translation: translationText,
+        userLanguage: "en",
+      }),
+      wordTranslationFixture({
+        translation: `cat-${uniqueId}`,
+        userLanguage: "en",
+        wordId: word1.id,
+      }),
+      wordTranslationFixture({
+        translation: `dog-${uniqueId}`,
+        userLanguage: "en",
+        wordId: word2.id,
       }),
     ]);
 
@@ -723,22 +828,32 @@ describe(prepareActivityData, () => {
 
     const lessonWords = [
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: word1.id,
-        pronunciation: null,
         romanization: null,
-        translation: word1.translation,
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: `cat-${uniqueId}`,
+            userLanguage: "en",
+          },
+        ],
         word: word1.word,
-        wordAudio: null,
       },
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: word2.id,
-        pronunciation: null,
         romanization: null,
-        translation: word2.translation,
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: `dog-${uniqueId}`,
+            userLanguage: "en",
+          },
+        ],
         word: word2.word,
-        wordAudio: null,
       },
     ];
 
@@ -774,13 +889,18 @@ describe(prepareActivityData, () => {
           position: 0,
           sentence: {
             alternativeSentences: [],
-            alternativeTranslations: [],
-            explanation: null,
+            audioUrl: null,
             id: BigInt(72),
             romanization: null,
             sentence: "gato bonito",
-            sentenceAudio: null,
-            translation: "pretty cat",
+            translations: [
+              {
+                alternativeTranslations: [],
+                explanation: null,
+                translation: "pretty cat",
+                userLanguage: "en",
+              },
+            ],
           },
           word: null,
         },
@@ -790,13 +910,18 @@ describe(prepareActivityData, () => {
 
     const lessonWords = [
       {
-        alternativeTranslations: [],
+        audioUrl: "https://example.com/gato.mp3",
         id: BigInt(73),
-        pronunciation: null,
         romanization: "ga-to",
-        translation: "cat",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "cat",
+            userLanguage: "en",
+          },
+        ],
         word: "gato",
-        wordAudio: { audioUrl: "https://example.com/gato.mp3" },
       },
     ];
 
@@ -829,13 +954,18 @@ describe(prepareActivityData, () => {
           position: 0,
           sentence: {
             alternativeSentences: [],
-            alternativeTranslations: [],
-            explanation: null,
+            audioUrl: null,
             id: BigInt(76),
             romanization: null,
             sentence: "gato bonito",
-            sentenceAudio: null,
-            translation: "pretty cat",
+            translations: [
+              {
+                alternativeTranslations: [],
+                explanation: null,
+                translation: "pretty cat",
+                userLanguage: "en",
+              },
+            ],
           },
           word: null,
         },
@@ -845,25 +975,35 @@ describe(prepareActivityData, () => {
 
     const lessonWords = [
       {
-        alternativeTranslations: [],
+        audioUrl: "https://example.com/lesson-gato.mp3",
         id: BigInt(77),
-        pronunciation: null,
         romanization: null,
-        translation: "cat (lesson)",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "cat (lesson)",
+            userLanguage: "en",
+          },
+        ],
         word: "gato",
-        wordAudio: { audioUrl: "https://example.com/lesson-gato.mp3" },
       },
     ];
 
     const sentenceWords = [
       {
-        alternativeTranslations: [],
+        audioUrl: "https://example.com/sentence-gato.mp3",
         id: BigInt(78),
-        pronunciation: null,
         romanization: "ga-to",
-        translation: "cat (sentence)",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "cat (sentence)",
+            userLanguage: "en",
+          },
+        ],
         word: "gato",
-        wordAudio: { audioUrl: "https://example.com/sentence-gato.mp3" },
       },
     ];
 
@@ -872,7 +1012,8 @@ describe(prepareActivityData, () => {
 
     const gatoOption = wordBank.find((option) => option.word === "gato");
     expect(gatoOption).toBeDefined();
-    expect(gatoOption?.translation).toBe("cat (sentence)");
+    // Translation comes from lessonWords (flat serialized), audioUrl/romanization from sentenceWords
+    expect(gatoOption?.translation).toBe("cat (lesson)");
     expect(gatoOption?.audioUrl).toBe("https://example.com/sentence-gato.mp3");
     expect(gatoOption?.romanization).toBe("ga-to");
   });
@@ -895,13 +1036,18 @@ describe(prepareActivityData, () => {
           position: 0,
           sentence: {
             alternativeSentences: [],
-            alternativeTranslations: [],
-            explanation: null,
+            audioUrl: null,
             id: BigInt(22),
             romanization: null,
             sentence: "Hola mundo",
-            sentenceAudio: null,
-            translation: "Hello world",
+            translations: [
+              {
+                alternativeTranslations: [],
+                explanation: null,
+                translation: "Hello world",
+                userLanguage: "en",
+              },
+            ],
           },
           word: null,
         },
@@ -912,22 +1058,32 @@ describe(prepareActivityData, () => {
     // Distractor word "hola" overlaps with correct word "Hola" (case-insensitive)
     const lessonWords = [
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(23),
-        pronunciation: null,
         romanization: null,
-        translation: "hello",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "hello",
+            userLanguage: "en",
+          },
+        ],
         word: "hola",
-        wordAudio: null,
       },
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(24),
-        pronunciation: null,
         romanization: null,
-        translation: "cat",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "cat",
+            userLanguage: "en",
+          },
+        ],
         word: "gato",
-        wordAudio: null,
       },
     ];
 
@@ -957,13 +1113,18 @@ describe(prepareActivityData, () => {
           position: 0,
           sentence: {
             alternativeSentences: ["Guten Morgen Lara"],
-            alternativeTranslations: [],
-            explanation: null,
+            audioUrl: null,
             id: BigInt(27),
             romanization: null,
             sentence: "Guten Tag Lara",
-            sentenceAudio: null,
-            translation: "Good day Lara",
+            translations: [
+              {
+                alternativeTranslations: [],
+                explanation: null,
+                translation: "Good day Lara",
+                userLanguage: "en",
+              },
+            ],
           },
           word: null,
         },
@@ -973,22 +1134,32 @@ describe(prepareActivityData, () => {
 
     const lessonWords = [
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(28),
-        pronunciation: null,
         romanization: null,
-        translation: "morning",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "morning",
+            userLanguage: "en",
+          },
+        ],
         word: "Morgen",
-        wordAudio: null,
       },
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(29),
-        pronunciation: null,
         romanization: null,
-        translation: "evening",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "evening",
+            userLanguage: "en",
+          },
+        ],
         word: "Abend",
-        wordAudio: null,
       },
     ];
 
@@ -1019,13 +1190,18 @@ describe(prepareActivityData, () => {
           position: 0,
           sentence: {
             alternativeSentences: [],
-            alternativeTranslations: ["Good morning I am Lara"],
-            explanation: null,
+            audioUrl: null,
             id: BigInt(37),
             romanization: null,
             sentence: "Bom dia eu sou Lara",
-            sentenceAudio: null,
-            translation: "Good day I am Lara",
+            translations: [
+              {
+                alternativeTranslations: ["Good morning I am Lara"],
+                explanation: null,
+                translation: "Good day I am Lara",
+                userLanguage: "en",
+              },
+            ],
           },
           word: null,
         },
@@ -1035,31 +1211,46 @@ describe(prepareActivityData, () => {
 
     const lessonWords = [
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(38),
-        pronunciation: null,
         romanization: null,
-        translation: "morning",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "morning",
+            userLanguage: "en",
+          },
+        ],
         word: "Morgen",
-        wordAudio: null,
       },
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(39),
-        pronunciation: null,
         romanization: null,
-        translation: "morning",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "morning",
+            userLanguage: "en",
+          },
+        ],
         word: "morning",
-        wordAudio: null,
       },
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(40),
-        pronunciation: null,
         romanization: null,
-        translation: "evening",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "evening",
+            userLanguage: "en",
+          },
+        ],
         word: "evening",
-        wordAudio: null,
       },
     ];
 
@@ -1090,13 +1281,18 @@ describe(prepareActivityData, () => {
           position: 0,
           sentence: {
             alternativeSentences: [],
-            alternativeTranslations: [],
-            explanation: null,
+            audioUrl: null,
             id: BigInt(32),
             romanization: null,
             sentence: "Sabes you?",
-            sentenceAudio: null,
-            translation: "Know you?",
+            translations: [
+              {
+                alternativeTranslations: [],
+                explanation: null,
+                translation: "Know you?",
+                userLanguage: "en",
+              },
+            ],
           },
           word: null,
         },
@@ -1107,22 +1303,32 @@ describe(prepareActivityData, () => {
     // Distractor "you" (from .word) overlaps with correct word "you?" after stripping punctuation
     const lessonWords = [
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(33),
-        pronunciation: null,
         romanization: null,
-        translation: "you",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "you",
+            userLanguage: "en",
+          },
+        ],
         word: "you",
-        wordAudio: null,
       },
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(34),
-        pronunciation: null,
         romanization: null,
-        translation: "cat",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "cat",
+            userLanguage: "en",
+          },
+        ],
         word: "gato",
-        wordAudio: null,
       },
     ];
 
@@ -1152,13 +1358,18 @@ describe(prepareActivityData, () => {
           position: 0,
           sentence: {
             alternativeSentences: [],
-            alternativeTranslations: [],
-            explanation: null,
+            audioUrl: null,
             id: BigInt(42),
             romanization: null,
             sentence: "Hola amigos",
-            sentenceAudio: null,
-            translation: "Hello friends",
+            translations: [
+              {
+                alternativeTranslations: [],
+                explanation: null,
+                translation: "Hello friends",
+                userLanguage: "en",
+              },
+            ],
           },
           word: null,
         },
@@ -1169,22 +1380,32 @@ describe(prepareActivityData, () => {
     // Two lesson words produce distractors "tu" and "tu?" after splitting
     const lessonWords = [
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(43),
-        pronunciation: null,
         romanization: null,
-        translation: "you",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "you",
+            userLanguage: "en",
+          },
+        ],
         word: "tu",
-        wordAudio: null,
       },
       {
-        alternativeTranslations: [],
+        audioUrl: null,
         id: BigInt(44),
-        pronunciation: null,
         romanization: null,
-        translation: "you?",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "you?",
+            userLanguage: "en",
+          },
+        ],
         word: "tu?",
-        wordAudio: null,
       },
     ];
 
@@ -1242,13 +1463,18 @@ describe(prepareActivityData, () => {
           position: 0,
           sentence: {
             alternativeSentences: [],
-            alternativeTranslations: [],
-            explanation: null,
+            audioUrl: null,
             id: BigInt(92),
             romanization: null,
             sentence: "gato bonito",
-            sentenceAudio: null,
-            translation: "pretty cat",
+            translations: [
+              {
+                alternativeTranslations: [],
+                explanation: null,
+                translation: "pretty cat",
+                userLanguage: "en",
+              },
+            ],
           },
           word: null,
         },
@@ -1258,13 +1484,18 @@ describe(prepareActivityData, () => {
 
     const lessonWords = [
       {
-        alternativeTranslations: [],
+        audioUrl: "https://example.com/gato.mp3",
         id: BigInt(93),
-        pronunciation: null,
         romanization: "ga-to",
-        translation: "cat",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "cat",
+            userLanguage: "en",
+          },
+        ],
         word: "gato",
-        wordAudio: { audioUrl: "https://example.com/gato.mp3" },
       },
     ];
 
@@ -1304,13 +1535,18 @@ describe(prepareActivityData, () => {
           position: 0,
           sentence: {
             alternativeSentences: [],
-            alternativeTranslations: [],
-            explanation: null,
+            audioUrl: null,
             id: BigInt(96),
             romanization: null,
             sentence: "gato bonito",
-            sentenceAudio: null,
-            translation: "pretty cat",
+            translations: [
+              {
+                alternativeTranslations: [],
+                explanation: null,
+                translation: "pretty cat",
+                userLanguage: "en",
+              },
+            ],
           },
           word: null,
         },
@@ -1320,13 +1556,18 @@ describe(prepareActivityData, () => {
 
     const sentenceWords = [
       {
-        alternativeTranslations: [],
+        audioUrl: "https://example.com/sw-gato.mp3",
         id: BigInt(97),
-        pronunciation: null,
         romanization: "ga-to-sw",
-        translation: "cat (sw)",
+        translations: [
+          {
+            alternativeTranslations: [],
+            pronunciation: null,
+            translation: "cat (sw)",
+            userLanguage: "en",
+          },
+        ],
         word: "gato",
-        wordAudio: { audioUrl: "https://example.com/sw-gato.mp3" },
       },
     ];
 
@@ -1337,7 +1578,7 @@ describe(prepareActivityData, () => {
     expect(sentenceWordOptions[0]).toEqual({
       audioUrl: "https://example.com/sw-gato.mp3",
       romanization: "ga-to-sw",
-      translation: "cat (sw)",
+      translation: null,
       word: "gato",
     });
     expect(sentenceWordOptions[1]).toEqual({

--- a/packages/db/src/prisma/migrations/20260325000000_canonical_vocabulary_schema/migration.sql
+++ b/packages/db/src/prisma/migrations/20260325000000_canonical_vocabulary_schema/migration.sql
@@ -1,0 +1,230 @@
+-- Phase 1: Create new translation tables
+
+CREATE TABLE "word_translations" (
+    "id" BIGSERIAL NOT NULL,
+    "word_id" BIGINT NOT NULL,
+    "user_language" VARCHAR(10) NOT NULL,
+    "translation" TEXT NOT NULL,
+    "alternative_translations" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "pronunciation" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "word_translations_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "sentence_translations" (
+    "id" BIGSERIAL NOT NULL,
+    "sentence_id" BIGINT NOT NULL,
+    "user_language" VARCHAR(10) NOT NULL,
+    "translation" TEXT NOT NULL,
+    "alternative_translations" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "explanation" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "sentence_translations_pkey" PRIMARY KEY ("id")
+);
+
+-- Phase 2: Add audio_url columns to words and sentences
+
+ALTER TABLE "words" ADD COLUMN "audio_url" TEXT;
+ALTER TABLE "sentences" ADD COLUMN "audio_url" TEXT;
+
+-- Phase 3: Populate audio_url from audio tables
+
+UPDATE "words" w
+SET "audio_url" = wa."audio_url"
+FROM "word_audio" wa
+WHERE w."word_audio_id" = wa."id";
+
+UPDATE "sentences" s
+SET "audio_url" = sa."audio_url"
+FROM "sentence_audio" sa
+WHERE s."sentence_audio_id" = sa."id";
+
+-- Phase 4: Deduplicate words
+-- For each (organization_id, target_language, word) group, keep the row with the lowest id as canonical.
+
+-- 4a: Build a mapping from every word row to its canonical row
+CREATE TEMP TABLE word_canonical_map AS
+SELECT w."id" AS old_id, canonical."id" AS canonical_id
+FROM "words" w
+JOIN (
+    SELECT MIN("id") AS "id", "organization_id", "target_language", "word"
+    FROM "words"
+    GROUP BY "organization_id", "target_language", "word"
+) canonical
+ON w."organization_id" = canonical."organization_id"
+AND w."target_language" = canonical."target_language"
+AND w."word" = canonical."word";
+
+-- 4b: Populate word_translations from all word rows (including duplicates)
+INSERT INTO "word_translations" ("word_id", "user_language", "translation", "alternative_translations", "pronunciation", "created_at", "updated_at")
+SELECT DISTINCT ON (wcm.canonical_id, w."user_language")
+    wcm.canonical_id,
+    w."user_language",
+    w."translation",
+    w."alternative_translations",
+    w."pronunciation",
+    w."created_at",
+    w."updated_at"
+FROM "words" w
+JOIN word_canonical_map wcm ON wcm.old_id = w."id"
+ORDER BY wcm.canonical_id, w."user_language", w."updated_at" DESC;
+
+-- 4c: Repoint steps.word_id to canonical
+UPDATE "steps" s
+SET "word_id" = wcm.canonical_id
+FROM word_canonical_map wcm
+WHERE s."word_id" = wcm.old_id
+AND wcm.old_id != wcm.canonical_id;
+
+-- 4d: Repoint lesson_words.word_id to canonical
+-- First delete any duplicates that would violate the unique constraint after repointing
+DELETE FROM "lesson_words" lw
+WHERE EXISTS (
+    SELECT 1 FROM word_canonical_map wcm
+    WHERE lw."word_id" = wcm.old_id
+    AND wcm.old_id != wcm.canonical_id
+    AND EXISTS (
+        SELECT 1 FROM "lesson_words" lw2
+        JOIN word_canonical_map wcm2 ON lw2."word_id" = wcm2.old_id
+        WHERE lw2."lesson_id" = lw."lesson_id"
+        AND wcm2.canonical_id = wcm.canonical_id
+        AND lw2."id" < lw."id"
+    )
+);
+
+UPDATE "lesson_words" lw
+SET "word_id" = wcm.canonical_id
+FROM word_canonical_map wcm
+WHERE lw."word_id" = wcm.old_id
+AND wcm.old_id != wcm.canonical_id;
+
+-- 4e: Delete non-canonical word rows
+DELETE FROM "words" w
+WHERE EXISTS (
+    SELECT 1 FROM word_canonical_map wcm
+    WHERE wcm.old_id = w."id"
+    AND wcm.old_id != wcm.canonical_id
+);
+
+DROP TABLE word_canonical_map;
+
+-- Phase 5: Deduplicate sentences (same pattern)
+
+CREATE TEMP TABLE sentence_canonical_map AS
+SELECT s."id" AS old_id, canonical."id" AS canonical_id
+FROM "sentences" s
+JOIN (
+    SELECT MIN("id") AS "id", "organization_id", "target_language", "sentence"
+    FROM "sentences"
+    GROUP BY "organization_id", "target_language", "sentence"
+) canonical
+ON s."organization_id" = canonical."organization_id"
+AND s."target_language" = canonical."target_language"
+AND s."sentence" = canonical."sentence";
+
+-- 5b: Populate sentence_translations
+INSERT INTO "sentence_translations" ("sentence_id", "user_language", "translation", "alternative_translations", "explanation", "created_at", "updated_at")
+SELECT DISTINCT ON (scm.canonical_id, s."user_language")
+    scm.canonical_id,
+    s."user_language",
+    s."translation",
+    s."alternative_translations",
+    s."explanation",
+    s."created_at",
+    s."updated_at"
+FROM "sentences" s
+JOIN sentence_canonical_map scm ON scm.old_id = s."id"
+ORDER BY scm.canonical_id, s."user_language", s."updated_at" DESC;
+
+-- 5c: Repoint steps.sentence_id to canonical
+UPDATE "steps" s
+SET "sentence_id" = scm.canonical_id
+FROM sentence_canonical_map scm
+WHERE s."sentence_id" = scm.old_id
+AND scm.old_id != scm.canonical_id;
+
+-- 5d: Repoint lesson_sentences to canonical (handle duplicates)
+DELETE FROM "lesson_sentences" ls
+WHERE EXISTS (
+    SELECT 1 FROM sentence_canonical_map scm
+    WHERE ls."sentence_id" = scm.old_id
+    AND scm.old_id != scm.canonical_id
+    AND EXISTS (
+        SELECT 1 FROM "lesson_sentences" ls2
+        JOIN sentence_canonical_map scm2 ON ls2."sentence_id" = scm2.old_id
+        WHERE ls2."lesson_id" = ls."lesson_id"
+        AND scm2.canonical_id = scm.canonical_id
+        AND ls2."id" < ls."id"
+    )
+);
+
+UPDATE "lesson_sentences" ls
+SET "sentence_id" = scm.canonical_id
+FROM sentence_canonical_map scm
+WHERE ls."sentence_id" = scm.old_id
+AND scm.old_id != scm.canonical_id;
+
+-- 5e: Delete non-canonical sentence rows
+DELETE FROM "sentences" s
+WHERE EXISTS (
+    SELECT 1 FROM sentence_canonical_map scm
+    WHERE scm.old_id = s."id"
+    AND scm.old_id != scm.canonical_id
+);
+
+DROP TABLE sentence_canonical_map;
+
+-- Phase 6: Drop old columns and constraints
+
+-- Drop foreign key constraints first
+ALTER TABLE "words" DROP CONSTRAINT IF EXISTS "words_word_audio_id_fkey";
+ALTER TABLE "sentences" DROP CONSTRAINT IF EXISTS "sentences_sentence_audio_id_fkey";
+
+-- Drop old unique constraints
+ALTER TABLE "words" DROP CONSTRAINT IF EXISTS "words_organization_id_target_language_user_language_word_key";
+ALTER TABLE "sentences" DROP CONSTRAINT IF EXISTS "sentences_organization_id_target_language_user_language_sentence_key";
+
+-- Drop old indexes
+DROP INDEX IF EXISTS "words_organization_id_target_language_user_language_idx";
+DROP INDEX IF EXISTS "sentences_organization_id_target_language_user_language_idx";
+
+-- Drop old columns from words
+ALTER TABLE "words" DROP COLUMN "user_language";
+ALTER TABLE "words" DROP COLUMN "translation";
+ALTER TABLE "words" DROP COLUMN "alternative_translations";
+ALTER TABLE "words" DROP COLUMN "pronunciation";
+ALTER TABLE "words" DROP COLUMN "word_audio_id";
+
+-- Drop old columns from sentences
+ALTER TABLE "sentences" DROP COLUMN "user_language";
+ALTER TABLE "sentences" DROP COLUMN "translation";
+ALTER TABLE "sentences" DROP COLUMN "alternative_translations";
+ALTER TABLE "sentences" DROP COLUMN "explanation";
+ALTER TABLE "sentences" DROP COLUMN "sentence_audio_id";
+
+-- Phase 7: Drop audio tables
+
+DROP TABLE "word_audio";
+DROP TABLE "sentence_audio";
+
+-- Phase 8: Add new constraints and indexes
+
+-- New unique constraints for canonical records
+CREATE UNIQUE INDEX "words_organization_id_target_language_word_key" ON "words"("organization_id", "target_language", "word");
+CREATE UNIQUE INDEX "sentence_translations_sentence_id_user_language_key" ON "sentence_translations"("sentence_id", "user_language");
+CREATE UNIQUE INDEX "word_translations_word_id_user_language_key" ON "word_translations"("word_id", "user_language");
+CREATE UNIQUE INDEX "sentences_organization_id_target_language_sentence_key" ON "sentences"("organization_id", "target_language", "sentence");
+
+-- New indexes
+CREATE INDEX "words_organization_id_target_language_idx" ON "words"("organization_id", "target_language");
+CREATE INDEX "sentences_organization_id_target_language_idx" ON "sentences"("organization_id", "target_language");
+CREATE INDEX "word_translations_word_id_idx" ON "word_translations"("word_id");
+CREATE INDEX "sentence_translations_sentence_id_idx" ON "sentence_translations"("sentence_id");
+
+-- Foreign keys for translation tables
+ALTER TABLE "word_translations" ADD CONSTRAINT "word_translations_word_id_fkey" FOREIGN KEY ("word_id") REFERENCES "words"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "sentence_translations" ADD CONSTRAINT "sentence_translations_sentence_id_fkey" FOREIGN KEY ("sentence_id") REFERENCES "sentences"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/src/prisma/models/accounts.prisma
+++ b/packages/db/src/prisma/models/accounts.prisma
@@ -102,9 +102,7 @@ model Organization {
   dailyProgress    DailyProgress[]
   stripeCustomerId String?         @map("stripe_customer_id")
   words            Word[]
-  wordAudios       WordAudio[]
   sentences        Sentence[]
-  sentenceAudios   SentenceAudio[]
 
   @@unique([slug])
   @@map("organizations")

--- a/packages/db/src/prisma/models/vocabulary.prisma
+++ b/packages/db/src/prisma/models/vocabulary.prisma
@@ -1,76 +1,72 @@
-model WordAudio {
-  id             BigInt       @id @default(autoincrement())
-  organizationId Int          @map("organization_id")
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  targetLanguage String       @map("target_language") @db.VarChar(10)
-  word           String
-  audioUrl       String       @map("audio_url")
-  createdAt      DateTime     @default(now()) @map("created_at")
-  words          Word[]
-
-  @@unique([organizationId, targetLanguage, word], name: "orgWordAudio")
-  @@map("word_audio")
-}
-
-model SentenceAudio {
-  id             BigInt       @id @default(autoincrement())
-  organizationId Int          @map("organization_id")
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  targetLanguage String       @map("target_language") @db.VarChar(10)
-  sentence       String
-  audioUrl       String       @map("audio_url")
-  createdAt      DateTime     @default(now()) @map("created_at")
-  sentences      Sentence[]
-
-  @@unique([organizationId, targetLanguage, sentence], name: "orgSentenceAudio")
-  @@map("sentence_audio")
-}
-
 model Word {
-  id                      BigInt       @id @default(autoincrement())
-  organizationId          Int          @map("organization_id")
-  organization            Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  targetLanguage          String       @map("target_language") @db.VarChar(10)
-  userLanguage            String       @map("user_language") @db.VarChar(10)
-  word                    String
-  translation             String
-  alternativeTranslations String[]     @default([]) @map("alternative_translations")
-  pronunciation           String?
-  romanization            String?
-  wordAudioId             BigInt?      @map("word_audio_id")
-  wordAudio               WordAudio?   @relation(fields: [wordAudioId], references: [id], onDelete: SetNull)
-  createdAt               DateTime     @default(now()) @map("created_at")
-  updatedAt               DateTime     @default(now()) @updatedAt @map("updated_at")
-  lessons                 LessonWord[]
-  steps                   Step[]
+  id             BigInt            @id @default(autoincrement())
+  organizationId Int               @map("organization_id")
+  organization   Organization      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  targetLanguage String            @map("target_language") @db.VarChar(10)
+  word           String
+  romanization   String?
+  audioUrl       String?           @map("audio_url")
+  createdAt      DateTime          @default(now()) @map("created_at")
+  updatedAt      DateTime          @default(now()) @updatedAt @map("updated_at")
+  translations   WordTranslation[]
+  lessons        LessonWord[]
+  steps          Step[]
 
-  @@unique([organizationId, targetLanguage, userLanguage, word], name: "orgWord")
-  @@index([organizationId, targetLanguage, userLanguage])
+  @@unique([organizationId, targetLanguage, word], name: "orgWord")
+  @@index([organizationId, targetLanguage])
   @@map("words")
 }
 
-model Sentence {
-  id                      BigInt           @id @default(autoincrement())
-  organizationId          Int              @map("organization_id")
-  organization            Organization     @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  targetLanguage          String           @map("target_language") @db.VarChar(10)
-  userLanguage            String           @map("user_language") @db.VarChar(10)
-  sentence                String
-  alternativeSentences    String[]         @default([]) @map("alternative_sentences")
+model WordTranslation {
+  id                      BigInt   @id @default(autoincrement())
+  wordId                  BigInt   @map("word_id")
+  word                    Word     @relation(fields: [wordId], references: [id], onDelete: Cascade)
+  userLanguage            String   @map("user_language") @db.VarChar(10)
   translation             String
-  alternativeTranslations String[]         @default([]) @map("alternative_translations")
-  romanization            String?
-  explanation             String?
-  sentenceAudioId         BigInt?          @map("sentence_audio_id")
-  sentenceAudio           SentenceAudio?   @relation(fields: [sentenceAudioId], references: [id], onDelete: SetNull)
-  createdAt               DateTime         @default(now()) @map("created_at")
-  updatedAt               DateTime         @default(now()) @updatedAt @map("updated_at")
-  lessons                 LessonSentence[]
-  steps                   Step[]
+  alternativeTranslations String[] @default([]) @map("alternative_translations")
+  pronunciation           String?
+  createdAt               DateTime @default(now()) @map("created_at")
+  updatedAt               DateTime @default(now()) @updatedAt @map("updated_at")
 
-  @@unique([organizationId, targetLanguage, userLanguage, sentence], name: "orgSentence")
-  @@index([organizationId, targetLanguage, userLanguage])
+  @@unique([wordId, userLanguage], name: "wordTranslation")
+  @@index([wordId])
+  @@map("word_translations")
+}
+
+model Sentence {
+  id                   BigInt                @id @default(autoincrement())
+  organizationId       Int                   @map("organization_id")
+  organization         Organization          @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  targetLanguage       String                @map("target_language") @db.VarChar(10)
+  sentence             String
+  alternativeSentences String[]              @default([]) @map("alternative_sentences")
+  romanization         String?
+  audioUrl             String?               @map("audio_url")
+  createdAt            DateTime              @default(now()) @map("created_at")
+  updatedAt            DateTime              @default(now()) @updatedAt @map("updated_at")
+  translations         SentenceTranslation[]
+  lessons              LessonSentence[]
+  steps                Step[]
+
+  @@unique([organizationId, targetLanguage, sentence], name: "orgSentence")
+  @@index([organizationId, targetLanguage])
   @@map("sentences")
+}
+
+model SentenceTranslation {
+  id                      BigInt   @id @default(autoincrement())
+  sentenceId              BigInt   @map("sentence_id")
+  sentence                Sentence @relation(fields: [sentenceId], references: [id], onDelete: Cascade)
+  userLanguage            String   @map("user_language") @db.VarChar(10)
+  translation             String
+  alternativeTranslations String[] @default([]) @map("alternative_translations")
+  explanation             String?
+  createdAt               DateTime @default(now()) @map("created_at")
+  updatedAt               DateTime @default(now()) @updatedAt @map("updated_at")
+
+  @@unique([sentenceId, userLanguage], name: "sentenceTranslation")
+  @@index([sentenceId])
+  @@map("sentence_translations")
 }
 
 model LessonWord {

--- a/packages/db/src/prisma/seed/sentences.ts
+++ b/packages/db/src/prisma/seed/sentences.ts
@@ -58,8 +58,6 @@ async function seedSentence(
       romanization: data.romanization,
       sentence: data.sentence,
       targetLanguage: data.targetLanguage,
-      translation: data.translation,
-      userLanguage: data.userLanguage,
     },
     update: {},
     where: {
@@ -67,6 +65,20 @@ async function seedSentence(
         organizationId: org.id,
         sentence: data.sentence,
         targetLanguage: data.targetLanguage,
+      },
+    },
+  });
+
+  await prisma.sentenceTranslation.upsert({
+    create: {
+      sentenceId: sentence.id,
+      translation: data.translation,
+      userLanguage: data.userLanguage,
+    },
+    update: {},
+    where: {
+      sentenceTranslation: {
+        sentenceId: sentence.id,
         userLanguage: data.userLanguage,
       },
     },

--- a/packages/db/src/prisma/seed/words.ts
+++ b/packages/db/src/prisma/seed/words.ts
@@ -61,11 +61,8 @@ async function seedWord(
   const word = await prisma.word.upsert({
     create: {
       organizationId: org.id,
-      pronunciation: data.pronunciation,
       romanization: data.romanization,
       targetLanguage: data.targetLanguage,
-      translation: data.translation,
-      userLanguage: data.userLanguage,
       word: data.word,
     },
     update: {},
@@ -73,8 +70,23 @@ async function seedWord(
       orgWord: {
         organizationId: org.id,
         targetLanguage: data.targetLanguage,
-        userLanguage: data.userLanguage,
         word: data.word,
+      },
+    },
+  });
+
+  await prisma.wordTranslation.upsert({
+    create: {
+      pronunciation: data.pronunciation,
+      translation: data.translation,
+      userLanguage: data.userLanguage,
+      wordId: word.id,
+    },
+    update: {},
+    where: {
+      wordTranslation: {
+        userLanguage: data.userLanguage,
+        wordId: word.id,
       },
     },
   });

--- a/packages/player/src/build-word-bank-options.test.ts
+++ b/packages/player/src/build-word-bank-options.test.ts
@@ -322,10 +322,9 @@ describe(buildSentenceWordOptions, () => {
         [
           "morgen",
           {
+            audioUrl: "https://example.com/morgen.mp3",
             romanization: "mor-gen",
-            translation: "morning (sentence)",
             word: "morgen",
-            wordAudio: { audioUrl: "https://example.com/morgen.mp3" },
           },
         ],
       ]),
@@ -334,7 +333,7 @@ describe(buildSentenceWordOptions, () => {
     expect(options[1]).toEqual({
       audioUrl: "https://example.com/morgen.mp3",
       romanization: "mor-gen",
-      translation: "morning (sentence)",
+      translation: "morning (lesson)",
       word: "Morgen!",
     });
   });

--- a/packages/player/src/build-word-bank-options.ts
+++ b/packages/player/src/build-word-bank-options.ts
@@ -16,9 +16,8 @@ const WORD_BANK_DISTRACTOR_COUNT = 8;
 
 type WordDataInput = {
   romanization: string | null;
-  translation: string;
+  audioUrl: string | null;
   word: string;
-  wordAudio: { audioUrl: string } | null;
 };
 
 /**
@@ -84,9 +83,9 @@ function getWordMetadata(
   const lessonWord = lessonWordLookup.get(key);
 
   return {
-    audioUrl: sentenceWord?.wordAudio?.audioUrl ?? lessonWord?.audioUrl ?? null,
+    audioUrl: sentenceWord?.audioUrl ?? lessonWord?.audioUrl ?? null,
     romanization: sentenceWord?.romanization ?? lessonWord?.romanization ?? null,
-    translation: sentenceWord?.translation ?? lessonWord?.translation ?? null,
+    translation: lessonWord?.translation ?? null,
   };
 }
 

--- a/packages/player/src/prepare-activity-data.ts
+++ b/packages/player/src/prepare-activity-data.ts
@@ -67,6 +67,20 @@ export type SerializedActivity = {
   lessonSentences: SerializedSentence[];
 };
 
+type WordTranslationInput = {
+  userLanguage: string;
+  translation: string;
+  alternativeTranslations: string[];
+  pronunciation: string | null;
+};
+
+type SentenceTranslationInput = {
+  userLanguage: string;
+  translation: string;
+  alternativeTranslations: string[];
+  explanation: string | null;
+};
+
 type StepDataInput = {
   id: bigint;
   content: unknown;
@@ -79,32 +93,53 @@ type StepDataInput = {
 type WordDataInput = {
   id: bigint;
   word: string;
-  translation: string;
-  alternativeTranslations: string[];
-  pronunciation: string | null;
   romanization: string | null;
-  wordAudio: { audioUrl: string } | null;
+  audioUrl: string | null;
+  translations: WordTranslationInput[];
 };
 
 type SentenceDataInput = {
   id: bigint;
   sentence: string;
   alternativeSentences: string[];
-  translation: string;
-  alternativeTranslations: string[];
   romanization: string | null;
-  explanation: string | null;
-  sentenceAudio: { audioUrl: string } | null;
+  audioUrl: string | null;
+  translations: SentenceTranslationInput[];
 };
 
-function serializeWord(word: WordDataInput): SerializedWord {
+/**
+ * Finds the translation matching the user's language from the translations array.
+ * Falls back to the first translation if no exact match exists, because a word
+ * always has at least one translation in practice.
+ */
+function findWordTranslation(
+  translations: WordTranslationInput[],
+  userLanguage: string,
+): WordTranslationInput | undefined {
+  return translations.find((t) => t.userLanguage === userLanguage) ?? translations[0];
+}
+
+/**
+ * Same as findWordTranslation but for sentence translations which carry
+ * explanation instead of pronunciation.
+ */
+function findSentenceTranslation(
+  translations: SentenceTranslationInput[],
+  userLanguage: string,
+): SentenceTranslationInput | undefined {
+  return translations.find((t) => t.userLanguage === userLanguage) ?? translations[0];
+}
+
+function serializeWord(word: WordDataInput, userLanguage: string): SerializedWord {
+  const translation = findWordTranslation(word.translations, userLanguage);
+
   return {
-    alternativeTranslations: [...word.alternativeTranslations],
-    audioUrl: word.wordAudio?.audioUrl ?? null,
+    alternativeTranslations: translation ? [...translation.alternativeTranslations] : [],
+    audioUrl: word.audioUrl,
     id: String(word.id),
-    pronunciation: word.pronunciation,
+    pronunciation: translation?.pronunciation ?? null,
     romanization: word.romanization,
-    translation: word.translation,
+    translation: translation?.translation ?? "",
     word: word.word,
   };
 }
@@ -113,20 +148,22 @@ function serializeWord(word: WordDataInput): SerializedWord {
  * The player consumes serialized words from multiple sources, so this helper keeps
  * lesson words and fallback distractor words aligned on one serialization rule.
  */
-function serializeWords(words: WordDataInput[]): SerializedWord[] {
-  return words.map((word) => serializeWord(word));
+function serializeWords(words: WordDataInput[], userLanguage: string): SerializedWord[] {
+  return words.map((word) => serializeWord(word, userLanguage));
 }
 
-function serializeSentence(sentence: SentenceDataInput): SerializedSentence {
+function serializeSentence(sentence: SentenceDataInput, userLanguage: string): SerializedSentence {
+  const translation = findSentenceTranslation(sentence.translations, userLanguage);
+
   return {
     alternativeSentences: [...sentence.alternativeSentences],
-    alternativeTranslations: [...sentence.alternativeTranslations],
-    audioUrl: sentence.sentenceAudio?.audioUrl ?? null,
-    explanation: sentence.explanation,
+    alternativeTranslations: translation ? [...translation.alternativeTranslations] : [],
+    audioUrl: sentence.audioUrl,
+    explanation: translation?.explanation ?? null,
     id: String(sentence.id),
     romanization: sentence.romanization,
     sentence: sentence.sentence,
-    translation: sentence.translation,
+    translation: translation?.translation ?? "",
   };
 }
 
@@ -198,7 +235,7 @@ function buildMatchColumnsRightItems(step: SerializedStep): string[] {
   return shuffle(content.pairs.map((pair) => pair.right));
 }
 
-function serializeStep(step: StepDataInput): SerializedStep | null {
+function serializeStep(step: StepDataInput, userLanguage: string): SerializedStep | null {
   if (!isSupportedStepKind(step.kind)) {
     return null;
   }
@@ -216,12 +253,12 @@ function serializeStep(step: StepDataInput): SerializedStep | null {
       kind: step.kind,
       matchColumnsRightItems: [],
       position: step.position,
-      sentence: step.sentence ? serializeSentence(step.sentence) : null,
+      sentence: step.sentence ? serializeSentence(step.sentence, userLanguage) : null,
       sentenceWordOptions: [],
       sortOrderItems: [],
       translationOptions: [],
       vocabularyOptions: [],
-      word: step.word ? serializeWord(step.word) : null,
+      word: step.word ? serializeWord(step.word, userLanguage) : null,
       wordBankOptions: [],
     };
   } catch {
@@ -244,13 +281,14 @@ export function prepareActivityData(
   sentenceWords: WordDataInput[] = [],
   fallbackDistractorWords: WordDataInput[] = [],
 ): SerializedActivity {
-  const serializedLessonWords = serializeWords(lessonWords);
-  const serializedFallbackWords = serializeWords(fallbackDistractorWords);
+  const userLanguage = activity.language;
+  const serializedLessonWords = serializeWords(lessonWords, userLanguage);
+  const serializedFallbackWords = serializeWords(fallbackDistractorWords, userLanguage);
 
   const sentenceWordMap = new Map(sentenceWords.map((sw) => [sw.word.toLowerCase(), sw]));
 
   const steps = activity.steps.flatMap((raw) => {
-    const step = serializeStep(raw);
+    const step = serializeStep(raw, userLanguage);
 
     if (!step) {
       return [];
@@ -285,16 +323,7 @@ export function prepareActivityData(
     id: String(activity.id),
     kind: activity.kind,
     language: activity.language,
-    lessonSentences: lessonSentences.map((sentence) => ({
-      alternativeSentences: [...sentence.alternativeSentences],
-      alternativeTranslations: [...sentence.alternativeTranslations],
-      audioUrl: sentence.sentenceAudio?.audioUrl ?? null,
-      explanation: sentence.explanation,
-      id: String(sentence.id),
-      romanization: sentence.romanization,
-      sentence: sentence.sentence,
-      translation: sentence.translation,
-    })),
+    lessonSentences: lessonSentences.map((sentence) => serializeSentence(sentence, userLanguage)),
     lessonWords: serializedLessonWords,
     organizationId: activity.organizationId,
     steps,

--- a/packages/player/src/validate-answers.test.ts
+++ b/packages/player/src/validate-answers.test.ts
@@ -172,10 +172,9 @@ describe(validateAnswers, () => {
         kind: "reading",
         sentence: {
           alternativeSentences: [],
-          alternativeTranslations: [],
           id: 1n,
           sentence: "hello world",
-          translation: "olá mundo",
+          translations: [{ alternativeTranslations: [], translation: "olá mundo" }],
         },
       },
     ];
@@ -196,10 +195,9 @@ describe(validateAnswers, () => {
         kind: "listening",
         sentence: {
           alternativeSentences: [],
-          alternativeTranslations: [],
           id: 1n,
           sentence: "hello world",
-          translation: "olá mundo",
+          translations: [{ alternativeTranslations: [], translation: "olá mundo" }],
         },
       },
     ];
@@ -220,10 +218,9 @@ describe(validateAnswers, () => {
         kind: "reading",
         sentence: {
           alternativeSentences: ["guten morgen lara"],
-          alternativeTranslations: [],
           id: 1n,
           sentence: "guten tag lara",
-          translation: "bom dia lara",
+          translations: [{ alternativeTranslations: [], translation: "bom dia lara" }],
         },
       },
     ];
@@ -244,10 +241,9 @@ describe(validateAnswers, () => {
         kind: "listening",
         sentence: {
           alternativeSentences: [],
-          alternativeTranslations: [],
           id: 1n,
           sentence: "hello lara",
-          translation: "bom dia, lara!",
+          translations: [{ alternativeTranslations: [], translation: "bom dia, lara!" }],
         },
       },
     ];

--- a/packages/player/src/validate-answers.ts
+++ b/packages/player/src/validate-answers.ts
@@ -25,6 +25,16 @@ type SelectedAnswer =
   | { kind: "sortOrder"; userOrder: string[] }
   | { kind: "translation"; selectedWordId: string; selectedText: string; questionText: string };
 
+type SentenceTranslationData = {
+  translation: string;
+  alternativeTranslations?: string[];
+};
+
+/**
+ * Step data for server-side validation. Sentences now carry translations in a
+ * separate array rather than flat on the model, so we accept both the raw DB
+ * shape (translations[]) and let a helper extract the first match.
+ */
 type StepData = {
   id: bigint;
   kind: string;
@@ -34,10 +44,25 @@ type StepData = {
     id: bigint;
     sentence: string;
     alternativeSentences?: string[];
-    translation: string;
-    alternativeTranslations?: string[];
+    translations?: SentenceTranslationData[];
   } | null;
 };
+
+/**
+ * Extracts the first translation entry from a sentence's translations array.
+ * Falls back to an empty translation when the array is missing or empty so
+ * callers always get a safe object.
+ */
+function getSentenceTranslation(sentence: NonNullable<StepData["sentence"]>): {
+  translation: string;
+  alternativeTranslations: string[];
+} {
+  const first = sentence.translations?.[0];
+  return {
+    alternativeTranslations: first?.alternativeTranslations ?? [],
+    translation: first?.translation ?? "",
+  };
+}
 
 type ValidatedStepResult = {
   answer: object;
@@ -146,9 +171,10 @@ function validateListening(step: StepData, answer: SelectedAnswer): ValidatedSte
     return null;
   }
 
+  const { alternativeTranslations, translation } = getSentenceTranslation(step.sentence);
   const acceptedWordSequences = buildAcceptedArrangeWordSequences(
-    step.sentence.translation,
-    step.sentence.alternativeTranslations ?? [],
+    translation,
+    alternativeTranslations,
   );
   const result = checkArrangeWordsAnswer(acceptedWordSequences, answer.arrangedWords);
   return { answer, effects: [], isCorrect: result.isCorrect, stepId: step.id };

--- a/packages/testing/src/fixtures/sentences.ts
+++ b/packages/testing/src/fixtures/sentences.ts
@@ -1,44 +1,39 @@
 import { prisma } from "@zoonk/db";
 
-export async function sentenceAudioFixture(attrs: {
+export async function sentenceFixture(attrs: {
   organizationId: number;
-  targetLanguage?: string;
   sentence?: string;
-  audioUrl?: string;
+  targetLanguage?: string;
+  alternativeSentences?: string[];
+  romanization?: string | null;
+  audioUrl?: string | null;
 }) {
-  return prisma.sentenceAudio.create({
+  return prisma.sentence.create({
     data: {
-      audioUrl: attrs.audioUrl ?? `https://example.com/${crypto.randomUUID()}.mp3`,
+      alternativeSentences: attrs.alternativeSentences ?? [],
+      audioUrl: attrs.audioUrl ?? null,
       organizationId: attrs.organizationId,
+      romanization: attrs.romanization ?? null,
       sentence: attrs.sentence ?? `sentence-${crypto.randomUUID()}`,
       targetLanguage: attrs.targetLanguage ?? "es",
     },
   });
 }
 
-export async function sentenceFixture(attrs: {
-  alternativeSentences?: string[];
-  alternativeTranslations?: string[];
-  organizationId: number;
-  sentence?: string;
-  translation?: string;
-  targetLanguage?: string;
+export async function sentenceTranslationFixture(attrs: {
+  sentenceId: bigint;
   userLanguage?: string;
-  romanization?: string | null;
-  sentenceAudioId?: bigint | null;
+  translation?: string;
+  alternativeTranslations?: string[];
+  explanation?: string | null;
 }) {
-  return prisma.sentence.create({
+  return prisma.sentenceTranslation.create({
     data: {
-      alternativeSentences: attrs.alternativeSentences ?? [],
       alternativeTranslations: attrs.alternativeTranslations ?? [],
-      organizationId: attrs.organizationId,
-      romanization: attrs.romanization ?? null,
-      sentence: attrs.sentence ?? `sentence-${crypto.randomUUID()}`,
-      sentenceAudioId: attrs.sentenceAudioId ?? null,
-      targetLanguage: attrs.targetLanguage ?? "es",
+      explanation: attrs.explanation ?? null,
+      sentenceId: attrs.sentenceId,
       translation: attrs.translation ?? `translation-${crypto.randomUUID()}`,
       userLanguage: attrs.userLanguage ?? "en",
     },
-    include: { sentenceAudio: true },
   });
 }

--- a/packages/testing/src/fixtures/words.ts
+++ b/packages/testing/src/fixtures/words.ts
@@ -1,44 +1,37 @@
 import { prisma } from "@zoonk/db";
 
-export async function wordAudioFixture(attrs: {
+export async function wordFixture(attrs: {
   organizationId: number;
-  targetLanguage?: string;
   word?: string;
-  audioUrl?: string;
+  targetLanguage?: string;
+  romanization?: string | null;
+  audioUrl?: string | null;
 }) {
-  return prisma.wordAudio.create({
+  return prisma.word.create({
     data: {
-      audioUrl: attrs.audioUrl ?? `https://example.com/${crypto.randomUUID()}.mp3`,
+      audioUrl: attrs.audioUrl ?? null,
       organizationId: attrs.organizationId,
+      romanization: attrs.romanization ?? null,
       targetLanguage: attrs.targetLanguage ?? "es",
       word: attrs.word ?? `word-${crypto.randomUUID()}`,
     },
   });
 }
 
-export async function wordFixture(attrs: {
-  alternativeTranslations?: string[];
-  organizationId: number;
-  word?: string;
-  translation?: string;
-  targetLanguage?: string;
+export async function wordTranslationFixture(attrs: {
+  wordId: bigint;
   userLanguage?: string;
+  translation?: string;
+  alternativeTranslations?: string[];
   pronunciation?: string | null;
-  romanization?: string | null;
-  wordAudioId?: bigint | null;
 }) {
-  return prisma.word.create({
+  return prisma.wordTranslation.create({
     data: {
       alternativeTranslations: attrs.alternativeTranslations ?? [],
-      organizationId: attrs.organizationId,
       pronunciation: attrs.pronunciation ?? "test-pronunciation",
-      romanization: attrs.romanization ?? null,
-      targetLanguage: attrs.targetLanguage ?? "es",
       translation: attrs.translation ?? `translation-${crypto.randomUUID()}`,
       userLanguage: attrs.userLanguage ?? "en",
-      word: attrs.word ?? `word-${crypto.randomUUID()}`,
-      wordAudioId: attrs.wordAudioId ?? null,
+      wordId: attrs.wordId,
     },
-    include: { wordAudio: true },
   });
 }


### PR DESCRIPTION
## Summary

- Word/Sentence become canonical records keyed by `(org, targetLang, text)` instead of `(org, targetLang, userLang, text)`, eliminating duplication across user languages
- Translations moved to new `WordTranslation`/`SentenceTranslation` tables with `(entityId, userLanguage)` unique constraint
- Audio folded back into `Word.audioUrl`/`Sentence.audioUrl` directly — `WordAudio`/`SentenceAudio` tables dropped since they became 1:1 after dedup reason removed
- Pronunciation moved to `WordTranslation` (user-language-dependent), explanation moved to `SentenceTranslation`

## Test plan

- [x] `pnpm turbo quality:fix` — 0 warnings, 0 errors
- [x] `pnpm typecheck` — 16/16 packages pass
- [x] `pnpm knip --production` — clean
- [x] `pnpm test` — 415 tests pass
- [x] All 3 apps build successfully
- [x] E2E: main 422 passed, api 56 passed, editor 194 passed
- [x] Main E2E run twice consecutively with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalized vocabulary schema to make Words and Sentences canonical per `(org, targetLang, text)` and moved translations to `WordTranslation`/`SentenceTranslation`. Audio is now stored on the canonical records via `audioUrl`, removing `WordAudio`/`SentenceAudio` and cutting duplication across user languages.

- **Refactors**
  - Added `WordTranslation` and `SentenceTranslation` with unique `(entityId, userLanguage)` constraints.
  - Moved pronunciation to `WordTranslation` and sentence explanation to `SentenceTranslation`.
  - Inlined `audioUrl` on `Word` and `Sentence`; replaced `wordAudioId`/`sentenceAudioId` plumbing with URLs end-to-end.
  - Updated `apps/api` workflows to join translations and handle audio URLs; saved vocabulary words before running enrichment steps to avoid update races.
  - Updated `apps/main` data loaders to `include: { translations: true }` and removed `userLanguage` from canonical lookups.
  - Updated `packages/player` serialization, validation, and word bank logic to read from `translations[]` and `audioUrl`.
  - Reworked fixtures and tests in `packages/testing`, `apps/main`, and `apps/api` to use translation tables.

- **Migration**
  - Run Prisma migrate in `packages/db` to create new tables and constraints.
  - Ensure any downstream code reads translations from `translations[]` and audio from `audioUrl`.
  - Remove usage of dropped `WordAudio`/`SentenceAudio` and any `(org, targetLang, userLang, text)` word/sentence keys.

<sup>Written for commit 4b2a354dd3b5aff51e019fe6d1a249b4e3f15d19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

