### PR TITLE
fix(main): rename support labels to "Feedback & Support" for clarity

### DIFF
--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -107,12 +107,12 @@ test.describe("Command Palette - Unauthenticated", () => {
     await expect(dialog.getByText(/manage subscription/i)).not.toBeVisible();
   });
 
-  test("shows Contact us group with Help and support", async ({ page }) => {
+  test("shows Help group with Feedback & Support", async ({ page }) => {
     await openCommandPalette(page);
 
     const dialog = page.getByRole("dialog");
-    await expect(dialog.getByText("Contact us")).toBeVisible();
-    await expect(dialog.getByText(/help and support/i)).toBeVisible();
+    await expect(dialog.getByText("Help")).toBeVisible();
+    await expect(dialog.getByText(/feedback & support/i)).toBeVisible();
   });
 
   test("selecting Home shows home content", async ({ page }) => {

--- a/apps/main/e2e/navbar.test.ts
+++ b/apps/main/e2e/navbar.test.ts
@@ -107,7 +107,7 @@ test.describe("Navbar - Authenticated", () => {
     await authenticatedPage.getByRole("menuitem", { name: /support/i }).click();
 
     await expect(
-      authenticatedPage.getByRole("heading", { level: 1, name: /help.*support/i }),
+      authenticatedPage.getByRole("heading", { level: 1, name: /feedback & support/i }),
     ).toBeVisible();
   });
 });

--- a/apps/main/e2e/settings-navbar.test.ts
+++ b/apps/main/e2e/settings-navbar.test.ts
@@ -42,7 +42,9 @@ test.describe("Settings Navbar", () => {
     await page.goto("/subscription");
     await page.getByRole("link", { name: /support/i }).click();
 
-    await expect(page.getByRole("heading", { level: 1, name: /help.*support/i })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { level: 1, name: /feedback & support/i }),
+    ).toBeVisible();
   });
 
   test("logout button logs user out", async ({ logoutPage }) => {

--- a/apps/main/e2e/support.test.ts
+++ b/apps/main/e2e/support.test.ts
@@ -5,7 +5,7 @@ test.describe("Support page", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/support");
 
-    await expect(page.getByRole("heading", { name: /help & support/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /feedback & support/i })).toBeVisible();
   });
 
   test("shows page content with support options", async ({ page }) => {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -559,9 +559,13 @@ msgid "My account"
 msgstr "My account"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgctxt "h7uoBs"
-msgid "Help and support"
-msgstr "Help and support"
+#: src/app/(catalog)/_components/user-dropdown-menu.tsx
+#: src/app/(settings)/_components/settings-pills.tsx
+#: src/app/(settings)/support/page.tsx
+#: src/app/(settings)/support/support-content.tsx
+msgctxt "fFZ0Wd"
+msgid "Feedback & Support"
+msgstr "Feedback & Support"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgctxt "HC7Mi4"
@@ -608,17 +612,17 @@ msgid "Courses"
 msgstr "Courses"
 
 #: src/app/(catalog)/_components/command-palette.tsx
+msgctxt "SENRqu"
+msgid "Help"
+msgstr "Help"
+
+#: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/navbar-links.tsx
 #: src/app/(performance)/_components/performance-navbar.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
 msgctxt "U3l+Q9"
 msgid "Home page"
 msgstr "Home page"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgctxt "WnQ/AZ"
-msgid "Contact us"
-msgstr "Contact us"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgctxt "xmcVZ0"
@@ -642,12 +646,6 @@ msgstr "Learn"
 msgctxt "6b2CRH"
 msgid "User menu"
 msgstr "User menu"
-
-#: src/app/(catalog)/_components/user-dropdown-menu.tsx
-#: src/app/(settings)/_components/settings-pills.tsx
-msgctxt "HqRNN8"
-msgid "Support"
-msgstr "Support"
 
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
@@ -1588,15 +1586,9 @@ msgstr "Limited lessons with ads"
 
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
-msgctxt "63m0Wt"
-msgid "Get help with your account, courses, or any technical issues. Our support team is here to assist you."
-msgstr "Get help with your account, courses, or any technical issues. Our support team is here to assist you."
-
-#: src/app/(settings)/support/page.tsx
-#: src/app/(settings)/support/support-content.tsx
-msgctxt "Uf3+S6"
-msgid "Help & Support"
-msgstr "Help & Support"
+msgctxt "B5MLC7"
+msgid "Share feedback, ask questions, or get help with your account and courses."
+msgstr "Share feedback, ask questions, or get help with your account and courses."
 
 #: src/app/(settings)/support/support-content.tsx
 msgctxt "7h49qt"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -559,9 +559,13 @@ msgid "My account"
 msgstr "Mi cuenta"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgctxt "h7uoBs"
-msgid "Help and support"
-msgstr "Ayuda y soporte"
+#: src/app/(catalog)/_components/user-dropdown-menu.tsx
+#: src/app/(settings)/_components/settings-pills.tsx
+#: src/app/(settings)/support/page.tsx
+#: src/app/(settings)/support/support-content.tsx
+msgctxt "fFZ0Wd"
+msgid "Feedback & Support"
+msgstr "Opiniones y Soporte"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgctxt "HC7Mi4"
@@ -608,17 +612,17 @@ msgid "Courses"
 msgstr "Cursos"
 
 #: src/app/(catalog)/_components/command-palette.tsx
+msgctxt "SENRqu"
+msgid "Help"
+msgstr "Ayuda"
+
+#: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/navbar-links.tsx
 #: src/app/(performance)/_components/performance-navbar.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
 msgctxt "U3l+Q9"
 msgid "Home page"
 msgstr "Página de inicio"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgctxt "WnQ/AZ"
-msgid "Contact us"
-msgstr "Contáctanos"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgctxt "xmcVZ0"
@@ -642,12 +646,6 @@ msgstr "Aprender"
 msgctxt "6b2CRH"
 msgid "User menu"
 msgstr "Menú de usuario"
-
-#: src/app/(catalog)/_components/user-dropdown-menu.tsx
-#: src/app/(settings)/_components/settings-pills.tsx
-msgctxt "HqRNN8"
-msgid "Support"
-msgstr "Soporte"
 
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
@@ -1588,15 +1586,9 @@ msgstr "Lecciones limitadas con anuncios"
 
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
-msgctxt "63m0Wt"
-msgid "Get help with your account, courses, or any technical issues. Our support team is here to assist you."
-msgstr "Obtén ayuda con tu cuenta, cursos o cualquier problema técnico. Nuestro equipo de soporte está aquí para ayudarte."
-
-#: src/app/(settings)/support/page.tsx
-#: src/app/(settings)/support/support-content.tsx
-msgctxt "Uf3+S6"
-msgid "Help & Support"
-msgstr "Ayuda y soporte"
+msgctxt "B5MLC7"
+msgid "Share feedback, ask questions, or get help with your account and courses."
+msgstr "Comparte opiniones, haz preguntas o recibe ayuda con tu cuenta y cursos."
 
 #: src/app/(settings)/support/support-content.tsx
 msgctxt "7h49qt"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -559,9 +559,13 @@ msgid "My account"
 msgstr "Minha conta"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgctxt "h7uoBs"
-msgid "Help and support"
-msgstr "Ajuda e suporte"
+#: src/app/(catalog)/_components/user-dropdown-menu.tsx
+#: src/app/(settings)/_components/settings-pills.tsx
+#: src/app/(settings)/support/page.tsx
+#: src/app/(settings)/support/support-content.tsx
+msgctxt "fFZ0Wd"
+msgid "Feedback & Support"
+msgstr "Sugestões e Suporte"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgctxt "HC7Mi4"
@@ -608,17 +612,17 @@ msgid "Courses"
 msgstr "Cursos"
 
 #: src/app/(catalog)/_components/command-palette.tsx
+msgctxt "SENRqu"
+msgid "Help"
+msgstr "Ajuda"
+
+#: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/navbar-links.tsx
 #: src/app/(performance)/_components/performance-navbar.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
 msgctxt "U3l+Q9"
 msgid "Home page"
 msgstr "Página inicial"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgctxt "WnQ/AZ"
-msgid "Contact us"
-msgstr "Contacte-nos"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgctxt "xmcVZ0"
@@ -642,12 +646,6 @@ msgstr "Aprender"
 msgctxt "6b2CRH"
 msgid "User menu"
 msgstr "Menu do usuário"
-
-#: src/app/(catalog)/_components/user-dropdown-menu.tsx
-#: src/app/(settings)/_components/settings-pills.tsx
-msgctxt "HqRNN8"
-msgid "Support"
-msgstr "Suporte"
 
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
@@ -1588,15 +1586,9 @@ msgstr "Aulas limitadas com anúncios"
 
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
-msgctxt "63m0Wt"
-msgid "Get help with your account, courses, or any technical issues. Our support team is here to assist you."
-msgstr "Receba ajuda com sua conta, cursos ou qualquer problema técnico. Nossa equipe de suporte está aqui para ajudar você."
-
-#: src/app/(settings)/support/page.tsx
-#: src/app/(settings)/support/support-content.tsx
-msgctxt "Uf3+S6"
-msgid "Help & Support"
-msgstr "Ajuda e suporte"
+msgctxt "B5MLC7"
+msgid "Share feedback, ask questions, or get help with your account and courses."
+msgstr "Compartilhe sugestões, tire dúvidas ou receba ajuda com sua conta e cursos."
 
 #: src/app/(settings)/support/support-content.tsx
 msgctxt "7h49qt"

--- a/apps/main/src/app/(catalog)/_components/command-palette.tsx
+++ b/apps/main/src/app/(catalog)/_components/command-palette.tsx
@@ -66,7 +66,7 @@ export function CommandPalette({ isLoggedIn }: { isLoggedIn: boolean }) {
     { key: t("Update profile"), ...getMenu("profile") },
   ];
 
-  const contactUs = [{ key: t("Help and support"), ...getMenu("support") }];
+  const contactUs = [{ key: t("Feedback & Support"), ...getMenu("support") }];
 
   const hasCourses = courses.length > 0;
 
@@ -133,7 +133,7 @@ export function CommandPalette({ isLoggedIn }: { isLoggedIn: boolean }) {
             )}
           </CommandGroup>
 
-          <CommandGroup heading={t("Contact us")}>
+          <CommandGroup heading={t("Help")}>
             {contactUs.map((item) => (
               <CommandItem key={item.key} onSelect={() => handleSelect(item.url)}>
                 <item.icon aria-hidden="true" />

--- a/apps/main/src/app/(catalog)/_components/user-dropdown-menu.tsx
+++ b/apps/main/src/app/(catalog)/_components/user-dropdown-menu.tsx
@@ -18,7 +18,7 @@ export async function UserDropdownMenu() {
   const accountMenu = [
     { key: t("Profile"), ...getMenu("profile") },
     { key: t("Subscription"), ...getMenu("subscription") },
-    { key: t("Support"), ...getMenu("support") },
+    { key: t("Feedback & Support"), ...getMenu("support") },
   ];
 
   return (

--- a/apps/main/src/app/(settings)/_components/settings-pills.tsx
+++ b/apps/main/src/app/(settings)/_components/settings-pills.tsx
@@ -14,7 +14,7 @@ export function SettingsPillLinks() {
     { label: t("Profile"), segment: "profile", ...getMenu("profile") },
     { label: t("Subscription"), segment: "subscription", ...getMenu("subscription") },
     { label: t("Language"), segment: "language", ...getMenu("language") },
-    { label: t("Support"), segment: "support", ...getMenu("support") },
+    { label: t("Feedback & Support"), segment: "support", ...getMenu("support") },
   ];
 
   return items.map((item) => (

--- a/apps/main/src/app/(settings)/support/page.tsx
+++ b/apps/main/src/app/(settings)/support/page.tsx
@@ -6,10 +6,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted();
 
   return {
-    description: t(
-      "Get help with your account, courses, or any technical issues. Our support team is here to assist you.",
-    ),
-    title: t("Help & Support"),
+    description: t("Share feedback, ask questions, or get help with your account and courses."),
+    title: t("Feedback & Support"),
   };
 }
 

--- a/apps/main/src/app/(settings)/support/support-content.tsx
+++ b/apps/main/src/app/(settings)/support/support-content.tsx
@@ -32,11 +32,9 @@ export async function SupportContent() {
     <Container>
       <ContainerHeader>
         <ContainerHeaderGroup>
-          <ContainerTitle>{t("Help & Support")}</ContainerTitle>
+          <ContainerTitle>{t("Feedback & Support")}</ContainerTitle>
           <ContainerDescription>
-            {t(
-              "Get help with your account, courses, or any technical issues. Our support team is here to assist you.",
-            )}
+            {t("Share feedback, ask questions, or get help with your account and courses.")}
           </ContainerDescription>
         </ContainerHeaderGroup>
       </ContainerHeader>


### PR DESCRIPTION
## Summary

- Renamed all support/help labels to "Feedback & Support" for consistency across dropdown menu, command palette, settings pills, and support page
- Changed command palette group heading from "Contact us" to "Help"
- Updated page description to lead with feedback: "Share feedback, ask questions, or get help with your account and courses."
- Added pt/es translations using accessible, native-language terms (pt: "Sugestões e Suporte", es: "Opiniones y Soporte")
- Updated e2e tests to match new labels

## Test plan

- [ ] Verify dropdown menu shows "Feedback & Support"
- [ ] Verify command palette shows "Help" group with "Feedback & Support" item
- [ ] Verify settings pills show "Feedback & Support"
- [ ] Verify support page title and description updated
- [ ] Run e2e tests for command palette and support page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized support copy to “Feedback & Support” across the app and translations, and renamed the command palette group to “Help” for clearer navigation. Updated the support page title and description, and aligned e2e tests.

- **Refactors**
  - Replaced “Support”/“Help and support” with “Feedback & Support” in the user dropdown, settings pills, command palette item, and support page.
  - Renamed command palette group header from “Contact us” to “Help”.
  - Updated support page title and description to lead with feedback.
  - Added `pt`/`es` translations and updated `en` strings; adjusted e2e tests to match.

<sup>Written for commit 3bff45002360b520f0cc51c131736f8c476b0d3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

