### PR TITLE
fix(api): log errors in handleActivityFailureStep

### DIFF
--- a/apps/api/src/workflows/activity-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/handle-failure-step.ts
@@ -1,10 +1,13 @@
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
+import { logError } from "@zoonk/utils/logger";
 
 export async function handleActivityFailureStep(input: {
   activityId: bigint | number;
 }): Promise<void> {
   "use step";
+
+  logError("[Activity Failure]", `activityId: ${input.activityId}`);
 
   await safeAsync(() =>
     prisma.activity.update({


### PR DESCRIPTION
## Summary
- Add `logError` call to `handleActivityFailureStep` so activity failures are always logged with the `activityId` for context
- Previously, only callers that also called `stream.error` would log errors — 10 call sites were silently swallowing failures

## Test plan
- [ ] Verify `logError` is called when an activity fails during generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)