### PR TITLE
fix(api): use shared completion step constants for course and chapter workflows

### DIFF
--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { activityGenerationWorkflow } from "@/workflows/activity-generation/activity-generation-workflow";
 import { generateLanguageChapterLessons } from "@zoonk/ai/tasks/chapters/language-lessons";
 import { generateChapterLessons } from "@zoonk/ai/tasks/chapters/lessons";
+import { CHAPTER_COMPLETION_STEP } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -95,7 +96,7 @@ describe(chapterGenerationWorkflow, () => {
 
       const completionCall = writeMock.mock.calls.find(
         (call: string[]) =>
-          call[0]?.includes('"step":"setFirstActivityAsCompleted"') &&
+          call[0]?.includes(`"step":"${CHAPTER_COMPLETION_STEP}"`) &&
           call[0]?.includes('"status":"completed"'),
       );
       expect(completionCall).toBeUndefined();
@@ -120,7 +121,7 @@ describe(chapterGenerationWorkflow, () => {
 
       const completionCall = writeMock.mock.calls.find(
         (call: string[]) =>
-          call[0]?.includes('"step":"setFirstActivityAsCompleted"') &&
+          call[0]?.includes(`"step":"${CHAPTER_COMPLETION_STEP}"`) &&
           call[0]?.includes('"status":"completed"'),
       );
       expect(completionCall).toBeDefined();

--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.ts
@@ -2,6 +2,7 @@ import { streamSkipStep } from "@/workflows/_shared/stream-skip-step";
 import { activityGenerationWorkflow } from "@/workflows/activity-generation/activity-generation-workflow";
 import { handleChapterFailureStep } from "@/workflows/course-generation/steps/handle-failure-step";
 import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
+import { CHAPTER_COMPLETION_STEP } from "@zoonk/core/workflows/steps";
 import { getWorkflowMetadata } from "workflow";
 import { addLessonsStep } from "./steps/add-lessons-step";
 import { generateLessonsStep } from "./steps/generate-lessons-step";
@@ -29,7 +30,7 @@ export async function chapterGenerationWorkflow(chapterId: number): Promise<void
 
   // Already completed — stream the completion step so the client can redirect.
   if (context.generationStatus === "completed") {
-    await streamSkipStep("setFirstActivityAsCompleted");
+    await streamSkipStep(CHAPTER_COMPLETION_STEP);
     return;
   }
 

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -7,6 +7,7 @@ import { generateCourseDescription } from "@zoonk/ai/tasks/courses/description";
 import { generateLanguageCourseChapters } from "@zoonk/ai/tasks/courses/language-chapters";
 import { generateLessonKind } from "@zoonk/ai/tasks/lessons/kind";
 import { generateCourseImage } from "@zoonk/core/courses/image";
+import { COURSE_COMPLETION_STEP } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseSuggestionFixture } from "@zoonk/testing/fixtures/course-suggestions";
@@ -166,7 +167,7 @@ describe(courseGenerationWorkflow, () => {
 
       const completionCall = writeMock.mock.calls.find(
         (call: string[]) =>
-          call[0]?.includes('"step":"setFirstActivityAsCompleted"') &&
+          call[0]?.includes(`"step":"${COURSE_COMPLETION_STEP}"`) &&
           call[0]?.includes('"status":"completed"'),
       );
       expect(completionCall).toBeUndefined();
@@ -189,7 +190,7 @@ describe(courseGenerationWorkflow, () => {
 
       const completionCall = writeMock.mock.calls.find(
         (call: string[]) =>
-          call[0]?.includes('"step":"setFirstActivityAsCompleted"') &&
+          call[0]?.includes(`"step":"${COURSE_COMPLETION_STEP}"`) &&
           call[0]?.includes('"status":"completed"'),
       );
       expect(completionCall).toBeDefined();
@@ -223,7 +224,7 @@ describe(courseGenerationWorkflow, () => {
 
       const completionCall = writeMock.mock.calls.find(
         (call: string[]) =>
-          call[0]?.includes('"step":"setFirstActivityAsCompleted"') &&
+          call[0]?.includes(`"step":"${COURSE_COMPLETION_STEP}"`) &&
           call[0]?.includes('"status":"completed"'),
       );
       expect(completionCall).toBeUndefined();
@@ -257,7 +258,7 @@ describe(courseGenerationWorkflow, () => {
 
       const completionCall = writeMock.mock.calls.find(
         (call: string[]) =>
-          call[0]?.includes('"step":"setFirstActivityAsCompleted"') &&
+          call[0]?.includes(`"step":"${COURSE_COMPLETION_STEP}"`) &&
           call[0]?.includes('"status":"completed"'),
       );
       expect(completionCall).toBeDefined();

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.ts
@@ -1,5 +1,6 @@
 import { streamSkipStep } from "@/workflows/_shared/stream-skip-step";
 import { chapterGenerationWorkflow } from "@/workflows/chapter-generation/chapter-generation-workflow";
+import { COURSE_COMPLETION_STEP } from "@zoonk/core/workflows/steps";
 import { logError } from "@zoonk/utils/logger";
 import { FatalError, getWorkflowMetadata } from "workflow";
 import { getOrCreateCourse } from "./_internal/get-or-create-course";
@@ -22,7 +23,7 @@ export async function courseGenerationWorkflow(courseSuggestionId: number): Prom
 
   // Already completed — stream the completion step so the client can redirect.
   if (suggestion.generationStatus === "completed") {
-    await streamSkipStep("setFirstActivityAsCompleted");
+    await streamSkipStep(COURSE_COMPLETION_STEP);
     return;
   }
 
@@ -35,7 +36,7 @@ export async function courseGenerationWorkflow(courseSuggestionId: number): Prom
 
   // Already completed — stream the completion step so the client can redirect.
   if (existingCourse?.generationStatus === "completed") {
-    await streamSkipStep("setFirstActivityAsCompleted");
+    await streamSkipStep(COURSE_COMPLETION_STEP);
     return;
   }
 

--- a/apps/main/src/app/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generation-client.tsx
@@ -15,7 +15,7 @@ import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useThinkingMessages } from "@/lib/workflow/use-thinking-messages";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
-import { type ChapterWorkflowStepName } from "@zoonk/core/workflows/steps";
+import { CHAPTER_COMPLETION_STEP, type ChapterWorkflowStepName } from "@zoonk/core/workflows/steps";
 import { type GenerationStatus } from "@zoonk/db";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { API_URL } from "@zoonk/utils/url";
@@ -38,7 +38,7 @@ export function GenerationClient({
   const t = useExtracted();
 
   const generation = useWorkflowGeneration<ChapterWorkflowStepName>({
-    completionStep: "setChapterAsCompleted",
+    completionStep: CHAPTER_COMPLETION_STEP,
     initialRunId: generationRunId,
     initialStatus: generationStatus === "running" ? "streaming" : "idle",
     statusUrl: `${API_URL}/v1/workflows/chapter-generation/status`,

--- a/apps/main/src/app/generate/cs/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generation-client.tsx
@@ -15,7 +15,7 @@ import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useThinkingMessages } from "@/lib/workflow/use-thinking-messages";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
-import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
+import { COURSE_COMPLETION_STEP, type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
 import { type GenerationStatus } from "@zoonk/db";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { API_URL } from "@zoonk/utils/url";
@@ -36,7 +36,7 @@ export function GenerationClient({
   const t = useExtracted();
 
   const generation = useWorkflowGeneration<CourseWorkflowStepName>({
-    completionStep: "completeCourseSetup",
+    completionStep: COURSE_COMPLETION_STEP,
     initialRunId: generationRunId,
     initialStatus: generationStatus === "running" ? "streaming" : "idle",
     statusUrl: `${API_URL}/v1/workflows/course-generation/status`,

--- a/packages/core/src/workflows/steps.ts
+++ b/packages/core/src/workflows/steps.ts
@@ -45,6 +45,8 @@ export const CHAPTER_STEPS = [
 
 export type ChapterStepName = (typeof CHAPTER_STEPS)[number];
 
+export const CHAPTER_COMPLETION_STEP: ChapterStepName = "setChapterAsCompleted";
+
 export const LESSON_STEPS = [
   "getLesson",
   "setLessonAsRunning",
@@ -165,6 +167,8 @@ export const COURSE_STEPS = [
 ] as const;
 
 export type CourseStepName = (typeof COURSE_STEPS)[number];
+
+export const COURSE_COMPLETION_STEP: CourseStepName = "completeCourseSetup";
 
 /**
  * All step names the SSE stream can emit during chapter generation.


### PR DESCRIPTION
## Summary

- Course and chapter workflows were streaming `setFirstActivityAsCompleted` for already-completed generations, but the frontend now listens for `completeCourseSetup` and `setChapterAsCompleted` (changed in 17b2db9a). This caused "Generation ended unexpectedly" errors when revisiting completed generation pages.
- Added `COURSE_COMPLETION_STEP` and `CHAPTER_COMPLETION_STEP` shared constants (matching existing `LESSON_COMPLETION_STEP` pattern) so API and frontend reference the same source of truth, preventing future drift.

## Test plan

- [x] Integration tests updated to use shared constants
- [x] All 200 workflow tests pass
- [x] Typecheck passes
- [x] Quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mismatched completion steps between API and frontend for course and chapter generation. Streams the correct completion steps using shared constants to prevent "Generation ended unexpectedly" when revisiting completed runs.

- **Bug Fixes**
  - Added `COURSE_COMPLETION_STEP` and `CHAPTER_COMPLETION_STEP` in `@zoonk/core/workflows/steps`.
  - API workflows stream these steps when a run is already completed.
  - Frontend generation clients use the same constants for `completionStep`.

<sup>Written for commit 7db5d6446949f056c2bc4595926e0d15a931964e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

