### PR TITLE
refactor(api): use CourseGetPayload instead of derived ReturnType for ExistingCourse

### DIFF
--- a/apps/api/src/workflows/course-generation/steps/check-existing-course-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/check-existing-course-step.ts
@@ -1,6 +1,6 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
-import { type CourseSuggestion, prisma } from "@zoonk/db";
+import { type CourseGetPayload, type CourseSuggestion, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { ensureLocaleSuffix, toSlug } from "@zoonk/utils/string";
@@ -15,9 +15,7 @@ const courseInclude = {
   },
 } as const;
 
-export type ExistingCourse = NonNullable<
-  Awaited<ReturnType<typeof prisma.course.findFirst<{ include: typeof courseInclude }>>>
->;
+export type ExistingCourse = CourseGetPayload<{ include: typeof courseInclude }>;
 
 export async function checkExistingCourseStep(
   suggestion: CourseSuggestion,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -43,6 +43,7 @@ export type {
 
 export type { ActivityCreateManyInput } from "./generated/prisma/models/Activity";
 export type { ChapterCreateManyInput } from "./generated/prisma/models/Chapter";
+export type { CourseGetPayload } from "./generated/prisma/models/Course";
 export type { LessonCreateManyInput } from "./generated/prisma/models/Lesson";
 
 export type { BatchPayload } from "./generated/prisma/internal/prismaNamespace";


### PR DESCRIPTION
## Summary
- Replace convoluted `NonNullable<Awaited<ReturnType<typeof prisma.course.findFirst<...>>>>` with Prisma's built-in `CourseGetPayload` utility type for the `ExistingCourse` type
- Export `CourseGetPayload` from `@zoonk/db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the complex ReturnType-based `ExistingCourse` type with Prisma’s `CourseGetPayload` for clearer, safer typing. Also exported `CourseGetPayload` from `@zoonk/db` for reuse across packages.

<sup>Written for commit 967e236c0c886043a4be65aa534839ab055e88e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

