### PR TITLE
refactor(main): replace floppy disk icon with check circle in generation phases

### DIFF
--- a/apps/main/src/app/generate/ch/[id]/generation-phases.ts
+++ b/apps/main/src/app/generate/ch/[id]/generation-phases.ts
@@ -5,7 +5,7 @@ import {
   getPhaseStatus as getStatus,
 } from "@/lib/generation-phases";
 import { type ChapterStepName, type ChapterWorkflowStepName } from "@zoonk/core/workflows/steps";
-import { BookOpenIcon, type LucideIcon, SaveIcon, SettingsIcon } from "lucide-react";
+import { BookOpenIcon, CheckCircleIcon, type LucideIcon, SettingsIcon } from "lucide-react";
 
 export type PhaseName = "gettingReady" | "preparingLessons" | "savingLessons";
 
@@ -27,7 +27,7 @@ export function getPhaseOrder(): PhaseName[] {
 export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
   gettingReady: SettingsIcon,
   preparingLessons: BookOpenIcon,
-  savingLessons: SaveIcon,
+  savingLessons: CheckCircleIcon,
 };
 
 const PHASE_WEIGHTS: Record<PhaseName, number> = {

--- a/apps/main/src/app/generate/cs/[id]/generation-phases.ts
+++ b/apps/main/src/app/generate/cs/[id]/generation-phases.ts
@@ -6,11 +6,11 @@ import {
 } from "@/lib/generation-phases";
 import { type CourseStepName, type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
 import {
+  CheckCircleIcon,
   ImageIcon,
   LayoutListIcon,
   type LucideIcon,
   PenLineIcon,
-  SaveIcon,
   SettingsIcon,
   TagIcon,
 } from "lucide-react";
@@ -65,7 +65,7 @@ export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
   creatingCoverImage: ImageIcon,
   gettingReady: SettingsIcon,
   outliningChapters: LayoutListIcon,
-  savingCourseInfo: SaveIcon,
+  savingCourseInfo: CheckCircleIcon,
   writingDescription: PenLineIcon,
 };
 

--- a/apps/main/src/lib/generation/activity-generation-phases.ts
+++ b/apps/main/src/lib/generation/activity-generation-phases.ts
@@ -23,7 +23,6 @@ import {
   MicIcon,
   PaletteIcon,
   PenLineIcon,
-  SaveIcon,
   SearchIcon,
   TextIcon,
 } from "lucide-react";
@@ -45,7 +44,7 @@ export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
   recordingVocabularyAudio: AudioLinesIcon,
   recordingWordAudio: AudioLinesIcon,
   saving: CheckCircleIcon,
-  savingPrerequisites: SaveIcon,
+  savingPrerequisites: CheckCircleIcon,
   writingContent: PenLineIcon,
   writingExplanation: PenLineIcon,
 };


### PR DESCRIPTION
## Summary
- Replace `SaveIcon` (floppy disk) with `CheckCircleIcon` in all generation phase configs
- Aligns course and chapter saving phases with the activity generation `saving` phase, which already used `CheckCircleIcon`
- The check circle better communicates "finalizing/completing" for automated persistence steps

## Test plan
- [ ] Verify generation phase icons render correctly on course, chapter, and activity generation pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the floppy disk save icon with a check-circle icon in generation phases to better indicate completion and keep icons consistent across course, chapter, and activity flows. UI-only change; no behavior impact.

- **Refactors**
  - Switched `savingLessons`, `savingCourseInfo`, and `savingPrerequisites` to use CheckCircleIcon from `lucide-react`.
  - Removed obsolete SaveIcon imports and aligned all "saving" phases with the existing activity `saving` phase icon.

<sup>Written for commit c55564095f6a55d3174d030a1d78b3a0cc428eb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

