### PR TITLE
fix(api): add entityId to per-entity step SSE events

### DIFF
--- a/apps/api/src/workflows/_shared/stream-status.ts
+++ b/apps/api/src/workflows/_shared/stream-status.ts
@@ -23,15 +23,26 @@ export type StepStream<T extends string> = {
   [Symbol.asyncDispose]: () => Promise<void>;
 };
 
+/** Writes an SSE event to the workflow stream. */
+async function writeSSE(
+  writer: WritableStreamDefaultWriter<string>,
+  data: Record<string, unknown>,
+): Promise<void> {
+  await writer.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
 /**
  * Creates a stream writer for emitting SSE status events from within a step.
+ * Use this for batch/shared steps that process all activities at once.
+ * For per-entity steps (steps that run once per activity), use createEntityStepStream instead.
+ *
  * Acquires the workflow stream writer once. The lock is released automatically
  * when the enclosing scope exits via `await using` — on return, throw, or
  * early return.
  *
  * Usage:
  * ```ts
- * async function myStep() {
+ * async function myBatchStep() {
  *   "use step";
  *   await using stream = createStepStream<MyStepName>();
  *   await stream.status({ step: "myStep", status: "started" });
@@ -51,11 +62,53 @@ export function createStepStream<T extends string>(): StepStream<T> {
 
     async error(params: { reason: WorkflowErrorReason; step: T }) {
       logError("[Workflow Error]", JSON.stringify(params));
-      await writer.write(`data: ${JSON.stringify({ ...params, status: "error" })}\n\n`);
+      await writeSSE(writer, { ...params, status: "error" });
     },
 
     async status(params: StepStreamMessage<T>) {
-      await writer.write(`data: ${JSON.stringify(params)}\n\n`);
+      await writeSSE(writer, params);
+    },
+  };
+}
+
+/**
+ * Creates a stream writer that automatically includes entityId in every event.
+ * Use this in per-entity steps (steps that run once per activity).
+ * For batch/shared steps that process all activities at once, use `createStepStream` instead.
+ *
+ * `entityId` is injected into both status and error events, so callers never
+ * need to pass it manually. This prevents the bug where per-entity steps
+ * forgot to include `entityId`, causing the frontend to show phases as
+ * completed for the wrong entity.
+ *
+ * ### Usage
+ *
+ * ```ts
+ * async function myPerEntityStep(activity: LessonActivity) {
+ *   "use step";
+ *   await using stream = createEntityStepStream<MyStepName>(activity.id);
+ *   await stream.status({ step: "myStep", status: "started" });
+ *   // ... do work ...
+ *   await stream.status({ step: "myStep", status: "completed" });
+ *   // writer.releaseLock() called automatically here
+ * }
+ * ```
+ */
+export function createEntityStepStream<T extends string>(entityId: number): StepStream<T> {
+  const writer = getWritable<string>().getWriter();
+
+  return {
+    async [Symbol.asyncDispose]() {
+      writer.releaseLock();
+    },
+
+    async error(params: { reason: WorkflowErrorReason; step: T }) {
+      logError("[Workflow Error]", JSON.stringify({ ...params, entityId }));
+      await writeSSE(writer, { ...params, entityId, status: "error" });
+    },
+
+    async status(params: Omit<StepStreamMessage<T>, "entityId">) {
+      await writeSSE(writer, { ...params, entityId });
     },
   };
 }

--- a/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
@@ -554,6 +554,71 @@ describe("explanation activity workflow", () => {
       );
     });
 
+    test("per-entity step events include entityId, batch step events do not", async () => {
+      const testLesson = await lessonFixture({
+        chapterId: chapter.id,
+        concepts: ["Entity A", "Entity B"],
+        organizationId,
+        title: `EntityId SSE Lesson ${randomUUID()}`,
+      });
+
+      const [expA, expB] = await Promise.all([
+        activityFixture({
+          generationStatus: "pending",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 1,
+          title: "Entity A",
+        }),
+        activityFixture({
+          generationStatus: "pending",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          position: 2,
+          title: "Entity B",
+        }),
+      ]);
+
+      const activities = await getLessonActivitiesStep(testLesson.id);
+      const concepts = activities[0]?.lesson?.concepts ?? [];
+
+      await explanationActivityWorkflow({
+        activitiesToGenerate: activities,
+        allActivities: activities,
+        concepts,
+        neighboringConcepts: [],
+        workflowRunId: "test-run-id",
+      });
+
+      const streamedMessages = getStreamedMessages();
+      const activityIds = new Set([Number(expA.id), Number(expB.id)]);
+
+      // Per-entity steps must include entityId matching one of the activity IDs
+      const perEntitySteps = ["generateVisuals", "generateImages", "saveExplanationActivity"];
+
+      for (const stepName of perEntitySteps) {
+        const stepMessages = streamedMessages.filter((msg) => msg.step === stepName);
+        expect(stepMessages.length).toBeGreaterThan(0);
+
+        for (const msg of stepMessages) {
+          expect(msg.entityId).toBeDefined();
+          expect(activityIds.has(Number(msg.entityId))).toBe(true);
+        }
+      }
+
+      // Batch step (generateExplanationContent) should NOT have entityId
+      const batchMessages = streamedMessages.filter(
+        (msg) => msg.step === "generateExplanationContent",
+      );
+      expect(batchMessages.length).toBeGreaterThan(0);
+
+      for (const msg of batchMessages) {
+        expect(msg.entityId).toBeUndefined();
+      }
+    });
+
     test("one explanation failure doesn't block others", async () => {
       vi.mocked(generateActivityExplanation).mockImplementation(async (params) => {
         if (params.concept === "Fail Concept") {

--- a/apps/api/src/workflows/activity-generation/steps/generate-challenge-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-challenge-content-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream, getAIResultErrorReason } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream, getAIResultErrorReason } from "@/workflows/_shared/stream-status";
 import {
   type ActivityChallengeSchema,
   generateActivityChallenge,
@@ -28,7 +28,7 @@ export async function generateChallengeContentStep(
     return { activityId: null, data: null };
   }
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({ status: "started", step: "generateChallengeContent" });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-grammar-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-grammar-content-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream, getAIResultErrorReason } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream, getAIResultErrorReason } from "@/workflows/_shared/stream-status";
 import {
   type ActivityGrammarContentSchema,
   generateActivityGrammarContent,
@@ -39,7 +39,7 @@ export async function generateGrammarContentStep(
 ): Promise<{ generated: boolean; grammarContent: ActivityGrammarContentSchema | null }> {
   "use step";
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({ status: "started", step: "generateGrammarContent" });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-grammar-romanization-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-grammar-romanization-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { type ActivityGrammarContentSchema } from "@zoonk/ai/tasks/activities/language/grammar-content";
 import { generateActivityRomanization } from "@zoonk/ai/tasks/activities/language/romanization";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
@@ -58,7 +58,7 @@ export async function generateGrammarRomanizationStep(
     return { romanizations: null };
   }
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({ status: "started", step: "generateGrammarRomanization" });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-grammar-user-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-grammar-user-content-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { type ActivityGrammarContentSchema } from "@zoonk/ai/tasks/activities/language/grammar-content";
 import {
   type ActivityGrammarUserContentSchema,
@@ -27,7 +27,7 @@ export async function generateGrammarUserContentStep(
     return { userContent: null };
   }
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({ status: "started", step: "generateGrammarUserContent" });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-images-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { generateVisualStepImage } from "@zoonk/core/steps/visual-image";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { rejected } from "@zoonk/utils/settled";
@@ -109,7 +109,7 @@ export async function generateImagesForActivityStep(
 ): Promise<{ completedRows: VisualRow[]; visuals: StepVisualWithUrl[] }> {
   "use step";
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   if (visuals.length === 0 || visualRows.length === 0) {
     await stream.status({ status: "started", step: "generateImages" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-practice-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-practice-content-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream, getAIResultErrorReason } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream, getAIResultErrorReason } from "@/workflows/_shared/stream-status";
 import {
   type ActivityPracticeSchema,
   generateActivityPractice,
@@ -40,7 +40,7 @@ export async function generatePracticeContentStep(
     return { activityId: null, steps: [] };
   }
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(practiceActivity.id);
 
   await stream.status({ status: "started", step: "generatePracticeContent" });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-content-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream, getAIResultErrorReason } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream, getAIResultErrorReason } from "@/workflows/_shared/stream-status";
 import {
   type ActivityQuizSchema,
   type QuizQuestion,
@@ -41,7 +41,7 @@ export async function generateQuizContentStep(
     return { activityId: null, questions: [] };
   }
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(quizActivity.id);
 
   await stream.status({ status: "started", step: "generateQuizContent" });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { type QuizQuestion, type SelectImageQuestion } from "@zoonk/ai/tasks/activities/core/quiz";
 import { generateStepImage } from "@zoonk/core/steps/image";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
@@ -69,7 +69,7 @@ export async function generateQuizImagesStep(
     return [];
   }
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   const selectImageQuestions = questions.filter((question) => isSelectImageQuestion(question));
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { isTTSSupportedLanguage } from "@zoonk/utils/languages";
@@ -28,7 +28,7 @@ export async function generateReadingAudioStep(
   const course = activity.lesson.chapter.course;
   const targetLanguage = course.targetLanguage;
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({ status: "started", step: "generateAudio" });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-content-step.ts
@@ -1,6 +1,6 @@
 import {
   type StepStream,
-  createStepStream,
+  createEntityStepStream,
   getAIResultErrorReason,
 } from "@/workflows/_shared/stream-status";
 import {
@@ -176,7 +176,7 @@ export async function generateReadingContentStep(
 
   const course = activity.lesson.chapter.course;
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({ status: "started", step: "generateSentences" });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-romanization-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-romanization-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { generateActivityRomanization } from "@zoonk/ai/tasks/activities/language/romanization";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { safeAsync } from "@zoonk/utils/error";
@@ -33,7 +33,7 @@ export async function generateReadingRomanizationStep(
     return { romanizations: {} };
   }
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({ status: "started", step: "generateReadingRomanization" });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-sentence-pronunciation-and-alternatives-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-sentence-pronunciation-and-alternatives-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { generateWordPronunciationAndAlternatives } from "./_utils/generate-word-pronunciation-and-alternatives";
@@ -38,7 +38,7 @@ export async function generateSentencePronunciationAndAlternativesStep(
     return { alternatives: {}, pronunciations: {} };
   }
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({
     status: "started",

--- a/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-audio-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { isTTSSupportedLanguage } from "@zoonk/utils/languages";
@@ -27,7 +27,7 @@ export async function generateSentenceWordAudioStep(
   const course = activity.lesson.chapter.course;
   const targetLanguage = course.targetLanguage;
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({ status: "started", step: "generateSentenceWordAudio" });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-metadata-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-metadata-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { generateActivityRomanization } from "@zoonk/ai/tasks/activities/language/romanization";
 import { generateTranslation } from "@zoonk/ai/tasks/activities/language/translation";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
@@ -187,7 +187,7 @@ export async function generateSentenceWordMetadataStep(
     return { wordMetadata: {} };
   }
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({ status: "started", step: "generateSentenceWordMetadata" });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-visuals-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-visuals-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { type StepVisualSchema, generateStepVisuals } from "@zoonk/ai/tasks/steps/visual";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { type ActivitySteps } from "./_utils/get-activity-steps";
@@ -37,7 +37,7 @@ export async function generateVisualsForActivityStep(
 ): Promise<{ visuals: StepVisual[]; visualRows: VisualRow[] }> {
   "use step";
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   if (steps.length === 0) {
     await stream.status({ status: "started", step: "generateVisuals" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { type VocabularyWord } from "@zoonk/ai/tasks/activities/language/vocabulary";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
@@ -28,7 +28,7 @@ export async function generateVocabularyAudioStep(
   const course = activity.lesson.chapter.course;
   const targetLanguage = course.targetLanguage;
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({ status: "started", step: "generateVocabularyAudio" });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import {
   type VocabularyWord,
   generateActivityVocabulary,
@@ -21,7 +21,7 @@ export async function generateVocabularyContentStep(
 ): Promise<{ words: VocabularyWord[] }> {
   "use step";
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({ status: "started", step: "generateVocabularyContent" });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-pronunciation-and-alternatives-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-pronunciation-and-alternatives-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { type VocabularyWord } from "@zoonk/ai/tasks/activities/language/vocabulary";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
@@ -39,7 +39,7 @@ export async function generateVocabularyPronunciationAndAlternativesStep(
     return { alternatives: {}, pronunciations: {} };
   }
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({
     status: "started",

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-romanization-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-romanization-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { generateActivityRomanization } from "@zoonk/ai/tasks/activities/language/romanization";
 import { type VocabularyWord } from "@zoonk/ai/tasks/activities/language/vocabulary";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
@@ -33,7 +33,7 @@ export async function generateVocabularyRomanizationStep(
     return { romanizations: {} };
   }
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({ status: "started", step: "generateVocabularyRomanization" });
 

--- a/apps/api/src/workflows/activity-generation/steps/save-challenge-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-challenge-activity-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { type ActivityChallengeSchema } from "@zoonk/ai/tasks/activities/core/challenge";
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
@@ -62,9 +62,9 @@ export async function saveChallengeActivityStep({
 }): Promise<void> {
   "use step";
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activityId);
 
-  await stream.status({ entityId: activityId, status: "started", step: "saveChallengeActivity" });
+  await stream.status({ status: "started", step: "saveChallengeActivity" });
 
   const stepRecords = buildChallengeStepRecords(activityId, data);
 
@@ -84,5 +84,5 @@ export async function saveChallengeActivityStep({
     return;
   }
 
-  await stream.status({ entityId: activityId, status: "completed", step: "saveChallengeActivity" });
+  await stream.status({ status: "completed", step: "saveChallengeActivity" });
 }

--- a/apps/api/src/workflows/activity-generation/steps/save-custom-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-custom-activity-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
@@ -49,9 +49,9 @@ export async function saveCustomActivityStep({
 }): Promise<void> {
   "use step";
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activityId);
 
-  await stream.status({ entityId: activityId, status: "started", step: "saveCustomActivity" });
+  await stream.status({ status: "started", step: "saveCustomActivity" });
 
   const staticRecords = buildStaticStepRecords(activityId, contentSteps);
   const allStepRecords = [...staticRecords, ...completedRows];
@@ -72,5 +72,5 @@ export async function saveCustomActivityStep({
     return;
   }
 
-  await stream.status({ entityId: activityId, status: "completed", step: "saveCustomActivity" });
+  await stream.status({ status: "completed", step: "saveCustomActivity" });
 }

--- a/apps/api/src/workflows/activity-generation/steps/save-explanation-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-explanation-activity-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
@@ -49,9 +49,9 @@ export async function saveExplanationActivityStep({
 }): Promise<void> {
   "use step";
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activityId);
 
-  await stream.status({ entityId: activityId, status: "started", step: "saveExplanationActivity" });
+  await stream.status({ status: "started", step: "saveExplanationActivity" });
 
   const staticRecords = buildStaticStepRecords(activityId, contentSteps);
   const allStepRecords = [...staticRecords, ...completedRows];
@@ -72,9 +72,5 @@ export async function saveExplanationActivityStep({
     return;
   }
 
-  await stream.status({
-    entityId: activityId,
-    status: "completed",
-    step: "saveExplanationActivity",
-  });
+  await stream.status({ status: "completed", step: "saveExplanationActivity" });
 }

--- a/apps/api/src/workflows/activity-generation/steps/save-grammar-steps-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-grammar-steps-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { type ActivityGrammarContentSchema } from "@zoonk/ai/tasks/activities/language/grammar-content";
 import { type ActivityGrammarUserContentSchema } from "@zoonk/ai/tasks/activities/language/grammar-user-content";
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
@@ -137,9 +137,9 @@ export async function saveGrammarActivityStep(
     return;
   }
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
-  await stream.status({ entityId: activity.id, status: "started", step: "saveGrammarActivity" });
+  await stream.status({ status: "started", step: "saveGrammarActivity" });
 
   const steps = buildGrammarSteps(activity.id, content, userContent, romanizations);
 
@@ -159,5 +159,5 @@ export async function saveGrammarActivityStep(
     return;
   }
 
-  await stream.status({ entityId: activity.id, status: "completed", step: "saveGrammarActivity" });
+  await stream.status({ status: "completed", step: "saveGrammarActivity" });
 }

--- a/apps/api/src/workflows/activity-generation/steps/save-listening-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-listening-activity-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
@@ -96,7 +96,7 @@ export async function saveListeningActivityStep(
     return;
   }
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(listening.id);
 
   const current = await prisma.activity.findUnique({
     where: { id: listening.id },
@@ -114,7 +114,7 @@ export async function saveListeningActivityStep(
     return;
   }
 
-  await stream.status({ entityId: listening.id, status: "started", step: "saveListeningActivity" });
+  await stream.status({ status: "started", step: "saveListeningActivity" });
 
   const success = await createListeningStepsAndComplete({
     listeningId: listening.id,
@@ -128,9 +128,5 @@ export async function saveListeningActivityStep(
     return;
   }
 
-  await stream.status({
-    entityId: listening.id,
-    status: "completed",
-    step: "saveListeningActivity",
-  });
+  await stream.status({ status: "completed", step: "saveListeningActivity" });
 }

--- a/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
@@ -46,9 +46,9 @@ export async function savePracticeActivityStep({
 }): Promise<void> {
   "use step";
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activityId);
 
-  await stream.status({ entityId: activityId, status: "started", step: "savePracticeActivity" });
+  await stream.status({ status: "started", step: "savePracticeActivity" });
 
   const stepRecords = buildPracticeStepRecords(activityId, steps);
 
@@ -68,5 +68,5 @@ export async function savePracticeActivityStep({
     return;
   }
 
-  await stream.status({ entityId: activityId, status: "completed", step: "savePracticeActivity" });
+  await stream.status({ status: "completed", step: "savePracticeActivity" });
 }

--- a/apps/api/src/workflows/activity-generation/steps/save-quiz-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-quiz-activity-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { type QuizQuestion } from "@zoonk/ai/tasks/activities/core/quiz";
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
@@ -52,9 +52,9 @@ export async function saveQuizActivityStep({
 }): Promise<void> {
   "use step";
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activityId);
 
-  await stream.status({ entityId: activityId, status: "started", step: "saveQuizActivity" });
+  await stream.status({ status: "started", step: "saveQuizActivity" });
 
   const stepRecords = buildQuizStepRecords(activityId, questions);
 
@@ -74,5 +74,5 @@ export async function saveQuizActivityStep({
     return;
   }
 
-  await stream.status({ entityId: activityId, status: "completed", step: "saveQuizActivity" });
+  await stream.status({ status: "completed", step: "saveQuizActivity" });
 }

--- a/apps/api/src/workflows/activity-generation/steps/save-reading-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-reading-activity-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
@@ -70,9 +70,9 @@ export async function saveReadingActivityStep(params: {
     return;
   }
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
-  await stream.status({ entityId: activity.id, status: "started", step: "saveReadingActivity" });
+  await stream.status({ status: "started", step: "saveReadingActivity" });
 
   const targetLanguage = course.targetLanguage ?? "";
   const userLanguage = activity.language;
@@ -140,7 +140,7 @@ export async function saveReadingActivityStep(params: {
 
   await markActivityAsCompleted(activity.id, workflowRunId);
 
-  await stream.status({ entityId: activity.id, status: "completed", step: "saveReadingActivity" });
+  await stream.status({ status: "completed", step: "saveReadingActivity" });
 }
 
 /**

--- a/apps/api/src/workflows/activity-generation/steps/save-translation-from-existing-vocabulary-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-translation-from-existing-vocabulary-step.ts
@@ -1,4 +1,4 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { assertStepContent } from "@zoonk/core/steps/content-contract";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
@@ -36,13 +36,9 @@ export async function saveTranslationFromExistingVocabularyStep({
     return;
   }
 
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(translationActivity.id);
 
-  await stream.status({
-    entityId: translationActivity.id,
-    status: "started",
-    step: "saveVocabularyActivity",
-  });
+  await stream.status({ status: "started", step: "saveVocabularyActivity" });
 
   const vocabularySteps = await prisma.step.findMany({
     orderBy: { position: "asc" },
@@ -80,9 +76,5 @@ export async function saveTranslationFromExistingVocabularyStep({
     return;
   }
 
-  await stream.status({
-    entityId: translationActivity.id,
-    status: "completed",
-    step: "saveVocabularyActivity",
-  });
+  await stream.status({ status: "completed", step: "saveVocabularyActivity" });
 }

--- a/apps/main/src/lib/workflow/generation-store.test.ts
+++ b/apps/main/src/lib/workflow/generation-store.test.ts
@@ -208,6 +208,106 @@ describe(handleStepStreamMessage, () => {
     expect(state.status).toBe("streaming");
   });
 
+  describe("entity filtering", () => {
+    it("does NOT track stepCompleted when message entityId doesn't match viewer", () => {
+      const actions: GenerationAction[] = [];
+
+      handleStepStreamMessage({
+        dispatch: (a) => actions.push(a),
+        entityId: 235,
+        message: { entityId: 238, status: "completed", step: "generateVisuals" },
+      });
+
+      const state = applyActions(actions, initialGenerationState());
+
+      expect(state.completedSteps).toEqual([]);
+    });
+
+    it("tracks stepCompleted when message entityId matches viewer", () => {
+      const actions: GenerationAction[] = [];
+
+      handleStepStreamMessage({
+        dispatch: (a) => actions.push(a),
+        entityId: 235,
+        message: { entityId: 235, status: "completed", step: "generateVisuals" },
+      });
+
+      const state = applyActions(actions, initialGenerationState());
+
+      expect(state.completedSteps).toEqual(["generateVisuals"]);
+    });
+
+    it("tracks stepCompleted when message has no entityId (shared/batch step)", () => {
+      const actions: GenerationAction[] = [];
+
+      handleStepStreamMessage({
+        dispatch: (a) => actions.push(a),
+        entityId: 235,
+        message: { status: "completed", step: "generateExplanationContent" },
+      });
+
+      const state = applyActions(actions, initialGenerationState());
+
+      expect(state.completedSteps).toEqual(["generateExplanationContent"]);
+    });
+
+    it("tracks stepCompleted when viewer has no entityId (non-activity workflow)", () => {
+      const actions: GenerationAction[] = [];
+
+      handleStepStreamMessage({
+        dispatch: (a) => actions.push(a),
+        message: { entityId: 99, status: "completed", step: "stepA" },
+      });
+
+      const state = applyActions(actions, initialGenerationState());
+
+      expect(state.completedSteps).toEqual(["stepA"]);
+    });
+
+    it("does NOT track stepStarted when message entityId doesn't match viewer", () => {
+      const actions: GenerationAction[] = [];
+
+      handleStepStreamMessage({
+        dispatch: (a) => actions.push(a),
+        entityId: 235,
+        message: { entityId: 238, status: "started", step: "generateVisuals" },
+      });
+
+      const state = applyActions(actions, initialGenerationState());
+
+      expect(state.currentStep).toBeNull();
+      expect(state.startedSteps).toEqual([]);
+    });
+
+    it("tracks stepStarted when message entityId matches viewer", () => {
+      const actions: GenerationAction[] = [];
+
+      handleStepStreamMessage({
+        dispatch: (a) => actions.push(a),
+        entityId: 235,
+        message: { entityId: 235, status: "started", step: "generateVisuals" },
+      });
+
+      const state = applyActions(actions, initialGenerationState());
+
+      expect(state.currentStep).toBe("generateVisuals");
+    });
+
+    it("tracks stepStarted when message has no entityId (shared/batch step)", () => {
+      const actions: GenerationAction[] = [];
+
+      handleStepStreamMessage({
+        dispatch: (a) => actions.push(a),
+        entityId: 235,
+        message: { status: "started", step: "getLessonActivities" },
+      });
+
+      const state = applyActions(actions, initialGenerationState());
+
+      expect(state.currentStep).toBe("getLessonActivities");
+    });
+  });
+
   it("routes 'error' to setError with step name", () => {
     const state = applyMessage({ status: "error", step: "stepA" });
     expect(state.status).toBe("error");

--- a/apps/main/src/lib/workflow/generation-store.test.ts
+++ b/apps/main/src/lib/workflow/generation-store.test.ts
@@ -319,4 +319,52 @@ describe(handleStepStreamMessage, () => {
     expect(state.status).toBe("error");
     expect(state.error).toBe("stepA: aiGenerationFailed");
   });
+
+  it("does NOT set error when error entityId doesn't match viewer", () => {
+    const actions: GenerationAction[] = [];
+    handleStepStreamMessage({
+      dispatch: (a) => actions.push(a),
+      entityId: 100,
+      message: {
+        entityId: 200,
+        reason: "aiGenerationFailed",
+        status: "error",
+        step: "generateVisuals",
+      },
+    });
+    const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
+    expect(state.status).toBe("streaming");
+    expect(state.error).toBeNull();
+  });
+
+  it("sets error when error entityId matches viewer", () => {
+    const actions: GenerationAction[] = [];
+    handleStepStreamMessage({
+      dispatch: (a) => actions.push(a),
+      entityId: 100,
+      message: {
+        entityId: 100,
+        reason: "aiGenerationFailed",
+        status: "error",
+        step: "generateVisuals",
+      },
+    });
+    const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
+    expect(state.status).toBe("error");
+  });
+
+  it("sets error when error has no entityId (shared/batch step failure)", () => {
+    const actions: GenerationAction[] = [];
+    handleStepStreamMessage({
+      dispatch: (a) => actions.push(a),
+      entityId: 100,
+      message: {
+        reason: "aiGenerationFailed",
+        status: "error",
+        step: "generateExplanationContent",
+      },
+    });
+    const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
+    expect(state.status).toBe("error");
+  });
 });

--- a/apps/main/src/lib/workflow/generation-store.ts
+++ b/apps/main/src/lib/workflow/generation-store.ts
@@ -88,6 +88,26 @@ export function generationReducer<TStep extends string>(
   }
 }
 
+/**
+ * Checks if an SSE event is relevant to the entity the viewer is tracking.
+ * Events without entityId are shared/batch events that apply to all entities.
+ * When the viewer has no entityId (non-activity workflows), everything matches.
+ */
+function isEventRelevantToViewer(
+  messageEntityId: number | undefined,
+  viewerEntityId: number | undefined,
+): boolean {
+  if (messageEntityId === undefined) {
+    return true;
+  }
+
+  if (viewerEntityId === undefined) {
+    return true;
+  }
+
+  return messageEntityId === viewerEntityId;
+}
+
 export function handleStepStreamMessage<TStep extends string>(params: {
   completionStep?: TStep;
   dispatch: (action: GenerationAction<TStep>) => void;
@@ -98,18 +118,28 @@ export function handleStepStreamMessage<TStep extends string>(params: {
 
   switch (message.status) {
     case "started":
-      dispatch({ step: message.step, type: "stepStarted" });
-      break;
-    case "completed":
-      dispatch({ step: message.step, type: "stepCompleted" });
-      if (completionStep && message.step === completionStep) {
-        const entityMatches = entityId === undefined || message.entityId === entityId;
-
-        if (entityMatches) {
-          dispatch({ completionStep, type: "streamEnded" });
-        }
+      if (isEventRelevantToViewer(message.entityId, entityId)) {
+        dispatch({ step: message.step, type: "stepStarted" });
       }
       break;
+    case "completed": {
+      if (isEventRelevantToViewer(message.entityId, entityId)) {
+        dispatch({ step: message.step, type: "stepCompleted" });
+      }
+
+      // streamEnded uses DIFFERENT semantics: undefined message entityId does NOT match
+      // a specific viewer entityId. This prevents batch steps from prematurely ending
+      // a stream that's waiting for a specific entity's save step.
+      const isCompletionForThisEntity =
+        completionStep &&
+        message.step === completionStep &&
+        (entityId === undefined || message.entityId === entityId);
+
+      if (isCompletionForThisEntity) {
+        dispatch({ completionStep, type: "streamEnded" });
+      }
+      break;
+    }
     case "error": {
       const errorMessage = message.reason
         ? `${message.step}: ${message.reason}`

--- a/apps/main/src/lib/workflow/generation-store.ts
+++ b/apps/main/src/lib/workflow/generation-store.ts
@@ -140,13 +140,16 @@ export function handleStepStreamMessage<TStep extends string>(params: {
       }
       break;
     }
-    case "error": {
-      const errorMessage = message.reason
-        ? `${message.step}: ${message.reason}`
-        : `Step "${message.step}" failed`;
-      dispatch({ error: errorMessage, type: "setError" });
+    case "error":
+      if (isEventRelevantToViewer(message.entityId, entityId)) {
+        const errorMessage = message.reason
+          ? `${message.step}: ${message.reason}`
+          : `Step "${message.step}" failed`;
+
+        dispatch({ error: errorMessage, type: "setError" });
+      }
       break;
-    }
+
     default: {
       const exhaustiveCheck: never = message.status;
       throw new Error(`Unexpected status: ${String(exhaustiveCheck)}`);


### PR DESCRIPTION
## Summary

- Add `createEntityStepStream(entityId)` helper that automatically injects entityId into every SSE status and error event, preventing future omissions
- Switch all 19 per-entity generate steps and 9 save steps to use `createEntityStepStream` instead of `createStepStream`
- Add frontend entity filtering in `handleStepStreamMessage` so each viewer only tracks events matching its own entityId (shared/batch events without entityId are still tracked by all viewers)

Closes #1143

## Test plan

- [x] 8 new frontend unit tests for entity filtering (match, mismatch, shared step, no viewer entityId)
- [x] 1 new backend integration test asserting per-entity events include correct entityId and batch events don't
- [x] All existing tests pass (412 main, 201 api)
- [x] E2e pass for all apps (main, editor, api)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect step progress and cross-entity errors when a lesson has multiple activities by adding entityId to per-entity SSE events and filtering on the client. Closes #1143.

- **Bug Fixes**
  - Added `createEntityStepStream` to inject `entityId` into all status/error events; switched all per-entity generate/save steps to use it. Batch/shared steps still use `createStepStream`.
  - Frontend now filters `stepStarted`/`stepCompleted`/`error` by `entityId` in `handleStepStreamMessage`; `streamEnded` only fires when the completion event matches the viewer’s entity.
  - Added tests to confirm per-entity events include `entityId`, batch events do not, client filtering works for match/mismatch/shared steps, and errors are entity-scoped.

<sup>Written for commit f718e862d6f36746480880a735106cdcef0fef42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

