### PR TITLE
fix(test): fix flaky locale-switcher e2e test

### DIFF
--- a/apps/editor/e2e/locale-switcher.test.ts
+++ b/apps/editor/e2e/locale-switcher.test.ts
@@ -1,22 +1,37 @@
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { type Page, expect, test } from "./fixtures";
 
+/**
+ * Retry-click the org dropdown trigger until the menu appears.
+ * The first click can be lost if it lands before React hydration
+ * attaches the event handler (same pattern as openDialog in e2e helpers).
+ */
 async function openOrgDropdown(page: Page) {
-  await page.getByRole("button", { name: /organizations|ai/i }).click();
+  const trigger = page.getByRole("button", { name: /organizations|ai/i });
+  const menu = page.getByRole("menu");
+
+  await expect(async () => {
+    if (!(await menu.isVisible())) {
+      await trigger.click();
+    }
+
+    await expect(menu).toBeVisible({ timeout: 1000 });
+  }).toPass();
 }
 
 async function openLanguageSubmenu(page: Page) {
   await openOrgDropdown(page);
 
   const languageMenuItem = page.getByRole("menuitem", { name: /language/i });
-  const englishMenuItem = page.getByRole("menuitem", { name: "English" });
 
-  // Use keyboard navigation to open submenu reliably.
-  // Arrow keys work consistently with Base UI menus.
-  await languageMenuItem.focus();
-  await page.keyboard.press("ArrowRight");
+  // Wait for the dropdown to fully render before interacting
+  await expect(languageMenuItem).toBeVisible();
+
+  // Hover to open submenu — Base UI opens submenus on pointer enter
+  await languageMenuItem.hover();
 
   // Wait for submenu to appear
+  const englishMenuItem = page.getByRole("menuitem", { name: "English" });
   await expect(englishMenuItem).toBeVisible();
 }
 


### PR DESCRIPTION
## Summary
- Fix flaky `marks currently selected locale with aria-current` test that failed with "Target page, context or browser has been closed"
- Root cause: dropdown click lost when landing before React hydration — menu never opened, `focus()` timed out, browser context torn down
- Apply retry-click pattern (same as `openDialog` helper) to `openOrgDropdown` so clicks are retried until the menu appears
- Replace `focus()` + `ArrowRight` with `hover()` for opening the language submenu (natural Base UI pointer-enter behavior)

## Test plan
- [x] Locale-switcher tests pass 5/5 runs with zero failures
- [x] Full editor e2e suite passes (194 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky locale-switcher e2e test by making the org dropdown open reliably and using hover to open the language submenu, eliminating hydration timing failures and teardown errors.

- **Bug Fixes**
  - Added retry-click logic to `openOrgDropdown` to keep clicking until the menu is visible, preventing lost clicks before React hydration.
  - Switched submenu opening from `focus()` + ArrowRight to `hover()` to match Base UI pointer-enter behavior and avoid timeouts.
  - Locale-switcher tests pass 5/5; full editor e2e suite passes.

<sup>Written for commit d1fc9f0828e4db114e541b0ce7d255b434242f4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

