### PR TITLE
fix(player): show romanization and audio button on translation feedback

### DIFF
--- a/apps/main/e2e/translation-step.test.ts
+++ b/apps/main/e2e/translation-step.test.ts
@@ -15,6 +15,7 @@ import { type Page, expect, test } from "./fixtures";
 async function createTranslationActivity(options: {
   words: {
     alternativeTranslations?: string[];
+    audioUrl?: string | null;
     word: string;
     translation: string;
     pronunciation?: string | null;
@@ -22,6 +23,7 @@ async function createTranslationActivity(options: {
   }[];
   fallbackWords?: {
     alternativeTranslations?: string[];
+    audioUrl?: string | null;
     word: string;
     translation: string;
     pronunciation?: string | null;
@@ -59,6 +61,7 @@ async function createTranslationActivity(options: {
   const createdWords = await Promise.all(
     options.words.map(async (wordData) => {
       const word = await wordFixture({
+        audioUrl: wordData.audioUrl ?? null,
         organizationId: org.id,
         romanization: wordData.romanization ?? null,
         word: wordData.word,
@@ -83,6 +86,7 @@ async function createTranslationActivity(options: {
   await Promise.all(
     (options.fallbackWords ?? []).map(async (wordData) => {
       const word = await wordFixture({
+        audioUrl: wordData.audioUrl ?? null,
         organizationId: org.id,
         romanization: wordData.romanization ?? null,
         word: wordData.word,
@@ -475,5 +479,119 @@ test.describe("Translation Step", () => {
 
     // After selecting, pronunciation should be visible on the selected option
     await expect(page.getByText(new RegExp(pronunciation))).toBeVisible();
+  });
+
+  test("feedback screen shows romanization on correct translation answer", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const correctWord = `こんにちは-${uniqueId}`;
+    const romanization = `konnichiwa-${uniqueId}`;
+
+    const { url } = await createTranslationActivity({
+      words: [
+        { romanization, translation: `hello-${uniqueId}`, word: correctWord },
+        { translation: `goodbye-${uniqueId}`, word: `さようなら-${uniqueId}` },
+        { translation: `thanks-${uniqueId}`, word: `ありがとう-${uniqueId}` },
+        { translation: `please-${uniqueId}`, word: `おねがい-${uniqueId}` },
+      ],
+    });
+
+    await page.goto(url);
+
+    const radiogroup = page.getByRole("radiogroup", { name: /answer options/i });
+    const correctOption = radiogroup.getByRole("radio", { name: new RegExp(correctWord) });
+
+    await expect(async () => {
+      const isChecked = await correctOption.getAttribute("aria-checked");
+
+      if (isChecked !== "true") {
+        await correctOption.click();
+      }
+
+      await expect(correctOption).toHaveAttribute("aria-checked", "true", { timeout: 1000 });
+    }).toPass();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    // Feedback screen should show the romanization below the correct answer
+    await expect(page.getByText(romanization)).toBeVisible();
+  });
+
+  test("feedback screen shows romanization on correct answer line when wrong translation", async ({
+    page,
+  }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const correctWord = `こんにちは-${uniqueId}`;
+    const wrongWord = `さようなら-${uniqueId}`;
+    const romanization = `konnichiwa-${uniqueId}`;
+
+    const { url } = await createTranslationActivity({
+      words: [
+        { romanization, translation: `hello-${uniqueId}`, word: correctWord },
+        { translation: `goodbye-${uniqueId}`, word: wrongWord },
+        { translation: `thanks-${uniqueId}`, word: `ありがとう-${uniqueId}` },
+        { translation: `please-${uniqueId}`, word: `おねがい-${uniqueId}` },
+      ],
+    });
+
+    await page.goto(url);
+
+    const radiogroup = page.getByRole("radiogroup", { name: /answer options/i });
+    const wrongOption = radiogroup.getByRole("radio", { name: new RegExp(wrongWord) });
+
+    await expect(async () => {
+      const isChecked = await wrongOption.getAttribute("aria-checked");
+
+      if (isChecked !== "true") {
+        await wrongOption.click();
+      }
+
+      await expect(wrongOption).toHaveAttribute("aria-checked", "true", { timeout: 1000 });
+    }).toPass();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    // Feedback screen should show the correct answer with romanization
+    await expect(page.getByText(/correct answer/i)).toBeVisible();
+    await expect(page.getByText(correctWord)).toBeVisible();
+    await expect(page.getByText(romanization)).toBeVisible();
+  });
+
+  test("feedback screen shows audio button when word has audioUrl", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const { url } = await createTranslationActivity({
+      words: [
+        {
+          audioUrl: "https://example.com/audio.mp3",
+          translation: `hello-${uniqueId}`,
+          word: `hola-${uniqueId}`,
+        },
+        { translation: `goodbye-${uniqueId}`, word: `adiós-${uniqueId}` },
+        { translation: `thanks-${uniqueId}`, word: `gracias-${uniqueId}` },
+        { translation: `please-${uniqueId}`, word: `por favor-${uniqueId}` },
+      ],
+    });
+
+    await page.goto(url);
+
+    const radiogroup = page.getByRole("radiogroup", { name: /answer options/i });
+    const correctOption = radiogroup.getByRole("radio", {
+      name: new RegExp(`hola-${uniqueId}`),
+    });
+
+    await expect(async () => {
+      const isChecked = await correctOption.getAttribute("aria-checked");
+
+      if (isChecked !== "true") {
+        await correctOption.click();
+      }
+
+      await expect(correctOption).toHaveAttribute("aria-checked", "true", { timeout: 1000 });
+    }).toPass();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    // Feedback screen should show an audio play button
+    await expect(page.getByRole("button", { name: /play pronunciation/i })).toBeVisible();
   });
 });

--- a/packages/player/src/components/_utils/feedback-romanization.test.ts
+++ b/packages/player/src/components/_utils/feedback-romanization.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import { type StepResult } from "../../player-reducer";
+import { type SerializedStep } from "../../prepare-activity-data";
+import { getFeedbackRomanization } from "./feedback-romanization";
+
+/**
+ * Builds a minimal StepResult with the given answer kind.
+ * Only populates the fields that getFeedbackRomanization reads.
+ */
+function buildResult(answer?: StepResult["answer"]): StepResult {
+  return {
+    answer,
+    effects: [],
+    result: { correctAnswer: null, feedback: null, isCorrect: true },
+    stepId: "step-1",
+  };
+}
+
+/**
+ * Builds a minimal SerializedStep with optional word/sentence romanization.
+ * Only populates the fields that getFeedbackRomanization reads.
+ */
+function buildStep({
+  sentenceRomanization,
+  wordRomanization,
+}: {
+  sentenceRomanization?: string | null;
+  wordRomanization?: string | null;
+} = {}): SerializedStep {
+  return {
+    content: {},
+    fillBlankOptions: [],
+    id: "step-1",
+    kind: "translation",
+    matchColumnsRightItems: [],
+    position: 0,
+    sentence:
+      sentenceRomanization === undefined
+        ? null
+        : {
+            alternativeSentences: [],
+            alternativeTranslations: [],
+            audioUrl: null,
+            explanation: null,
+            id: "s-1",
+            romanization: sentenceRomanization,
+            sentence: "test sentence",
+            translation: "test translation",
+          },
+    sentenceWordOptions: [],
+    sortOrderItems: [],
+    translationOptions: [],
+    vocabularyOptions: [],
+    word:
+      wordRomanization === undefined
+        ? null
+        : {
+            alternativeTranslations: [],
+            audioUrl: null,
+            id: "w-1",
+            pronunciation: null,
+            romanization: wordRomanization,
+            translation: "hello",
+            word: "こんにちは",
+          },
+    wordBankOptions: [],
+  };
+}
+
+describe(getFeedbackRomanization, () => {
+  describe("reading answers (sentence romanization)", () => {
+    it("returns sentence romanization on correct reading when it differs from selected text", () => {
+      const result = buildResult({ arrangedWords: ["こんにちは", "世界"], kind: "reading" });
+      const step = buildStep({ sentenceRomanization: "konnichiwa sekai" });
+
+      const rom = getFeedbackRomanization(result, step, "こんにちは 世界", null, null);
+
+      expect(rom.correctReading).toBe("konnichiwa sekai");
+    });
+
+    it("returns null correctReading when romanization matches selected text (dedup)", () => {
+      const result = buildResult({ arrangedWords: ["hello", "world"], kind: "reading" });
+      const step = buildStep({ sentenceRomanization: "hello world" });
+
+      const rom = getFeedbackRomanization(result, step, "hello world", null, null);
+
+      expect(rom.correctReading).toBeNull();
+    });
+
+    it("returns sentence romanization on wrong reading correctAnswer line", () => {
+      const result = buildResult({ arrangedWords: ["世界", "こんにちは"], kind: "reading" });
+      const step = buildStep({ sentenceRomanization: "konnichiwa sekai" });
+
+      const rom = getFeedbackRomanization(result, step, null, "こんにちは 世界", null);
+
+      expect(rom.wrongReading).toBe("konnichiwa sekai");
+    });
+
+    it("returns null wrongReading when romanization matches correct answer (dedup)", () => {
+      const result = buildResult({ arrangedWords: ["world", "hello"], kind: "reading" });
+      const step = buildStep({ sentenceRomanization: "hello world" });
+
+      const rom = getFeedbackRomanization(result, step, null, "hello world", null);
+
+      expect(rom.wrongReading).toBeNull();
+    });
+  });
+
+  describe("translation answers (word romanization)", () => {
+    it("returns word romanization on correct translation answer", () => {
+      const result = buildResult({
+        kind: "translation",
+        questionText: "hello",
+        selectedText: "こんにちは",
+        selectedWordId: "w-1",
+      });
+      const step = buildStep({ wordRomanization: "konnichiwa" });
+
+      const rom = getFeedbackRomanization(result, step, "こんにちは", null, "hello");
+
+      expect(rom.correctReading).toBe("konnichiwa");
+    });
+
+    it("returns null when word romanization matches selected text (dedup)", () => {
+      const result = buildResult({
+        kind: "translation",
+        questionText: "hello",
+        selectedText: "konnichiwa",
+        selectedWordId: "w-1",
+      });
+      const step = buildStep({ wordRomanization: "konnichiwa" });
+
+      const rom = getFeedbackRomanization(result, step, "konnichiwa", null, "hello");
+
+      expect(rom.correctReading).toBeNull();
+    });
+
+    it("returns word romanization on wrong translation's correct answer line", () => {
+      const result = buildResult({
+        kind: "translation",
+        questionText: "hello",
+        selectedText: "さようなら",
+        selectedWordId: "w-2",
+      });
+      const step = buildStep({ wordRomanization: "konnichiwa" });
+
+      const rom = getFeedbackRomanization(result, step, "さようなら", "こんにちは", "hello");
+
+      expect(rom.wrongReading).toBe("konnichiwa");
+    });
+
+    it("returns null wrongReading when word romanization matches correct answer (dedup)", () => {
+      const result = buildResult({
+        kind: "translation",
+        questionText: "hello",
+        selectedText: "wrong",
+        selectedWordId: "w-2",
+      });
+      const step = buildStep({ wordRomanization: "konnichiwa" });
+
+      const rom = getFeedbackRomanization(result, step, "wrong", "konnichiwa", "hello");
+
+      expect(rom.wrongReading).toBeNull();
+    });
+
+    it("returns null for translate field (only used by listening)", () => {
+      const result = buildResult({
+        kind: "translation",
+        questionText: "hello",
+        selectedText: "こんにちは",
+        selectedWordId: "w-1",
+      });
+      const step = buildStep({ wordRomanization: "konnichiwa" });
+
+      const rom = getFeedbackRomanization(result, step, "こんにちは", null, "hello");
+
+      expect(rom.translate).toBeNull();
+    });
+
+    it("returns null when step has no word", () => {
+      const result = buildResult({
+        kind: "translation",
+        questionText: "hello",
+        selectedText: "こんにちは",
+        selectedWordId: "w-1",
+      });
+      const step = buildStep();
+
+      const rom = getFeedbackRomanization(result, step, "こんにちは", null, "hello");
+
+      expect(rom.correctReading).toBeNull();
+      expect(rom.wrongReading).toBeNull();
+    });
+  });
+
+  describe("listening answers", () => {
+    it("returns sentence romanization for translate line", () => {
+      const result = buildResult({ arrangedWords: ["hello", "world"], kind: "listening" });
+      const step = buildStep({ sentenceRomanization: "konnichiwa sekai" });
+
+      const rom = getFeedbackRomanization(result, step, null, null, "こんにちは 世界");
+
+      expect(rom.translate).toBe("konnichiwa sekai");
+    });
+
+    it("returns null translate when romanization matches question text (dedup)", () => {
+      const result = buildResult({ arrangedWords: ["hello"], kind: "listening" });
+      const step = buildStep({ sentenceRomanization: "konnichiwa" });
+
+      const rom = getFeedbackRomanization(result, step, null, null, "konnichiwa");
+
+      expect(rom.translate).toBeNull();
+    });
+
+    it("returns null for correctReading and wrongReading", () => {
+      const result = buildResult({ arrangedWords: ["hello"], kind: "listening" });
+      const step = buildStep({ sentenceRomanization: "konnichiwa" });
+
+      const rom = getFeedbackRomanization(result, step, "hello", "world", "こんにちは");
+
+      expect(rom.correctReading).toBeNull();
+      expect(rom.wrongReading).toBeNull();
+    });
+  });
+
+  describe("multipleChoice answers", () => {
+    it("returns null for all fields", () => {
+      const result = buildResult({
+        kind: "multipleChoice",
+        selectedIndex: 0,
+        selectedText: "option A",
+      });
+      const step = buildStep({ sentenceRomanization: "romaji", wordRomanization: "romaji" });
+
+      const rom = getFeedbackRomanization(result, step, "option A", null, null);
+
+      expect(rom.correctReading).toBeNull();
+      expect(rom.wrongReading).toBeNull();
+      expect(rom.translate).toBeNull();
+    });
+  });
+
+  describe("no answer", () => {
+    it("returns null for all fields when answer is undefined", () => {
+      const result = buildResult();
+      const step = buildStep({ sentenceRomanization: "romaji", wordRomanization: "romaji" });
+
+      const rom = getFeedbackRomanization(result, step, null, null, null);
+
+      expect(rom.correctReading).toBeNull();
+      expect(rom.wrongReading).toBeNull();
+      expect(rom.translate).toBeNull();
+    });
+  });
+});

--- a/packages/player/src/components/_utils/feedback-romanization.ts
+++ b/packages/player/src/components/_utils/feedback-romanization.ts
@@ -1,0 +1,109 @@
+import { type StepResult } from "../../player-reducer";
+import { type SerializedStep } from "../../prepare-activity-data";
+
+/**
+ * Returns romanization only when it differs from the displayed text.
+ * Prevents showing duplicate text when romanization equals the sentence
+ * (bad AI generation data where the original script was copied into
+ * the romanization field instead of the Latin transliteration).
+ */
+function getVisibleRomanization(
+  romanization: string | null | undefined,
+  displayedText: string,
+): string | null {
+  if (!romanization) {
+    return null;
+  }
+
+  if (romanization.trim() === displayedText.trim()) {
+    return null;
+  }
+
+  return romanization;
+}
+
+function getCorrectReadingRomanization(
+  kind: string | undefined,
+  selectedText: string | null,
+  romanizations: {
+    sentenceRomanization: string | null | undefined;
+    wordRomanization: string | null | undefined;
+  },
+): string | null {
+  if (kind === "reading" && selectedText) {
+    return getVisibleRomanization(romanizations.sentenceRomanization, selectedText);
+  }
+
+  if (kind === "translation" && selectedText) {
+    return getVisibleRomanization(romanizations.wordRomanization, selectedText);
+  }
+
+  return null;
+}
+
+function getWrongReadingRomanization(
+  kind: string | undefined,
+  correctAnswer: string | null | undefined,
+  romanizations: {
+    sentenceRomanization: string | null | undefined;
+    wordRomanization: string | null | undefined;
+  },
+): string | null {
+  if (kind === "reading" && correctAnswer) {
+    return getVisibleRomanization(romanizations.sentenceRomanization, correctAnswer);
+  }
+
+  if (kind === "translation" && correctAnswer) {
+    return getVisibleRomanization(romanizations.wordRomanization, correctAnswer);
+  }
+
+  return null;
+}
+
+/**
+ * Resolves which romanization texts to show on the feedback screen
+ * based on the answer kind and dedup rules.
+ *
+ * Translation steps use word-level romanization (step.word.romanization),
+ * while reading/listening steps use sentence-level romanization
+ * (step.sentence.romanization). Both go through the same dedup logic
+ * to prevent showing romanization that matches the displayed text
+ * (bad AI data).
+ */
+export function getFeedbackRomanization(
+  result: StepResult,
+  step: SerializedStep | undefined,
+  selectedText: string | null,
+  correctAnswer: string | null | undefined,
+  questionText: string | null,
+) {
+  const sentenceRomanization = step?.sentence?.romanization;
+  const wordRomanization = step?.word?.romanization;
+  const kind = result.answer?.kind;
+
+  return {
+    /**
+     * Romanization for the "Your answer:" line on correct answers.
+     * Used by both reading (sentence romanization) and translation (word romanization).
+     */
+    correctReading: getCorrectReadingRomanization(kind, selectedText, {
+      sentenceRomanization,
+      wordRomanization,
+    }),
+
+    /** Romanization for the "Translate:" line — only for listening (shows target language sentence). */
+    translate:
+      kind === "listening"
+        ? getVisibleRomanization(sentenceRomanization, questionText ?? "")
+        : null,
+
+    /**
+     * Romanization for the "Correct answer:" line on wrong answers.
+     * Used by both reading (sentence romanization) and translation (word romanization).
+     */
+    wrongReading: getWrongReadingRomanization(kind, correctAnswer, {
+      sentenceRomanization,
+      wordRomanization,
+    }),
+  };
+}

--- a/packages/player/src/components/feedback-answer-blocks.tsx
+++ b/packages/player/src/components/feedback-answer-blocks.tsx
@@ -3,60 +3,7 @@
 import { cn } from "@zoonk/ui/lib/utils";
 import { CircleCheck, CircleX } from "lucide-react";
 import { useExtracted } from "next-intl";
-import { type StepResult } from "../player-reducer";
-import { type SerializedStep } from "../prepare-activity-data";
 import { RomanizationText } from "./romanization-text";
-
-/**
- * Returns romanization only when it differs from the displayed text.
- * Prevents showing duplicate text when romanization equals the sentence
- * (bad AI generation data where the original script was copied into
- * the romanization field instead of the Latin transliteration).
- */
-function getVisibleRomanization(
-  romanization: string | null | undefined,
-  displayedText: string,
-): string | null {
-  if (!romanization) {
-    return null;
-  }
-
-  if (romanization.trim() === displayedText.trim()) {
-    return null;
-  }
-
-  return romanization;
-}
-
-/** Resolves which romanization texts to show based on the answer kind and dedup rules. */
-export function getFeedbackRomanization(
-  result: StepResult,
-  step: SerializedStep | undefined,
-  selectedText: string | null,
-  correctAnswer: string | null | undefined,
-  questionText: string | null,
-) {
-  const romanization = step?.sentence?.romanization;
-  const kind = result.answer?.kind;
-
-  return {
-    /** Romanization for the "Your answer:" line on correct reading answers. */
-    correctReading:
-      kind === "reading" && selectedText
-        ? getVisibleRomanization(romanization, selectedText)
-        : null,
-
-    /** Romanization for the "Translate:" line — only for listening (shows target language sentence). */
-    translate:
-      kind === "listening" ? getVisibleRomanization(romanization, questionText ?? "") : null,
-
-    /** Romanization for the "Correct answer:" line on wrong reading answers. */
-    wrongReading:
-      kind === "reading" && correctAnswer
-        ? getVisibleRomanization(romanization, correctAnswer)
-        : null,
-  };
-}
 
 function AnswerLine({
   children,

--- a/packages/player/src/components/feedback-screen.tsx
+++ b/packages/player/src/components/feedback-screen.tsx
@@ -6,6 +6,7 @@ import { useExtracted } from "next-intl";
 import { type DimensionInventory, type StepResult } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
 import { useReplaceName } from "../user-name-context";
+import { getFeedbackRomanization } from "./_utils/feedback-romanization";
 import {
   type DimensionEntry,
   DimensionList,
@@ -13,11 +14,7 @@ import {
   buildDimensionEntries,
   getWarningDelay,
 } from "./dimension-inventory";
-import {
-  CorrectAnswerBlock,
-  IncorrectAnswerBlock,
-  getFeedbackRomanization,
-} from "./feedback-answer-blocks";
+import { CorrectAnswerBlock, IncorrectAnswerBlock } from "./feedback-answer-blocks";
 import { PlayAudioButton } from "./play-audio-button";
 import { ResultAnnouncement } from "./result-announcement";
 import { RomanizationText } from "./romanization-text";
@@ -166,6 +163,22 @@ function getQuestionText(result: StepResult, step?: SerializedStep): string | nu
   return null;
 }
 
+/**
+ * Returns the audio URL for the feedback screen's pronunciation button.
+ * Reading/listening steps use sentence audio; translation steps use word audio.
+ */
+function getFeedbackAudioUrl(step?: SerializedStep): string | null {
+  if (step?.sentence?.audioUrl) {
+    return step.sentence.audioUrl;
+  }
+
+  if (step?.word?.audioUrl) {
+    return step.word.audioUrl;
+  }
+
+  return null;
+}
+
 function CoreFeedback({ result, step }: { result: StepResult; step?: SerializedStep }) {
   const t = useExtracted();
   const replaceName = useReplaceName();
@@ -177,6 +190,7 @@ function CoreFeedback({ result, step }: { result: StepResult; step?: SerializedS
       : getArrangeWordsSelectedText(result);
   const questionText = getQuestionText(result, step);
   const rom = getFeedbackRomanization(result, step, selectedText, correctAnswer, questionText);
+  const audioUrl = getFeedbackAudioUrl(step);
 
   return (
     <FeedbackScreen>
@@ -203,9 +217,7 @@ function CoreFeedback({ result, step }: { result: StepResult; step?: SerializedS
         )}
       </div>
 
-      {step?.sentence?.audioUrl && (
-        <PlayAudioButton audioUrl={step.sentence.audioUrl} preload={false} variant="text" />
-      )}
+      {audioUrl && <PlayAudioButton audioUrl={audioUrl} preload={false} variant="text" />}
 
       {feedback && <FeedbackMessage>{feedback}</FeedbackMessage>}
 


### PR DESCRIPTION
## Summary

- Extract `getFeedbackRomanization` to `_utils/feedback-romanization.ts` and extend it to support translation answers using word-level romanization
- Add `getFeedbackAudioUrl` to unify audio URL resolution — falls back from sentence audio to word audio so the pronunciation replay button appears on translation feedback
- Add unit tests for the extracted function and e2e tests for romanization display and audio button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes translation feedback to show romanization and a pronunciation play button. Improves feedback clarity by using word-level romanization and falling back to word audio when sentence audio is missing.

- **Bug Fixes**
  - Show word romanization on translation feedback (for correct answers and the “Correct answer” line). Hides it when it matches the displayed text.
  - Display the pronunciation button by resolving audio with `getFeedbackAudioUrl`, falling back from sentence to word audio.

- **Refactors**
  - Extracted `getFeedbackRomanization` to `_utils/feedback-romanization.ts` and extended it to handle translation answers.
  - Added unit and e2e tests for romanization display and the audio button.

<sup>Written for commit 8ea0c7548e4fa150478b161d0d854fc6426048c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

