### PR TITLE
fix(player): handle romanization for multi-word entries

### DIFF
--- a/packages/player/src/build-word-bank-options.test.ts
+++ b/packages/player/src/build-word-bank-options.test.ts
@@ -289,6 +289,70 @@ describe(buildWordBankOptions, () => {
     });
   });
 
+  test("propagates romanization to individual tokens from multi-word distractor entries", () => {
+    const options = buildWordBankOptions(
+      makeReadingStep("안녕하세요."),
+      [
+        makeWordWithMetadata("1", "안녕하세요", "olá", {
+          audioUrl: null,
+          romanization: "annyeonghaseyo",
+        }),
+        makeWordWithMetadata("2", "처음 뵙겠습니다", "prazer em conhecê-lo", {
+          audioUrl: null,
+          romanization: "cheoeum boepgetseumnida",
+        }),
+      ],
+      new Map(),
+    );
+
+    const cheoeum = options.find((option) => option.word === "처음");
+    const boepgetseumnida = options.find((option) => option.word === "뵙겠습니다");
+
+    expect(cheoeum?.romanization).toBe("cheoeum");
+    expect(boepgetseumnida?.romanization).toBe("boepgetseumnida");
+  });
+
+  test("falls back to null romanization when token counts do not match", () => {
+    const options = buildWordBankOptions(
+      makeReadingStep("hello world"),
+      [
+        makeLessonWord("1", "hello", "olá"),
+        makeWordWithMetadata("2", "buenos días amigo", "bom dia amigo", {
+          audioUrl: null,
+          romanization: "only-two",
+        }),
+      ],
+      new Map(),
+    );
+
+    const buenos = options.find((option) => option.word === "buenos");
+
+    expect(buenos?.romanization).toBeNull();
+  });
+
+  test("standalone word metadata overrides sub-token metadata from multi-word entry", () => {
+    const options = buildWordBankOptions(
+      makeReadingStep("hello world"),
+      [
+        makeLessonWord("1", "hello", "olá"),
+        makeWordWithMetadata("2", "처음 뵙겠습니다", "prazer em conhecê-lo", {
+          audioUrl: null,
+          romanization: "cheoeum boepgetseumnida",
+        }),
+        makeWordWithMetadata("3", "처음", "início", {
+          audioUrl: "https://example.com/cheoeum.mp3",
+          romanization: "cheoeum-standalone",
+        }),
+      ],
+      new Map(),
+    );
+
+    const cheoeum = options.find((option) => option.word === "처음");
+
+    expect(cheoeum?.romanization).toBe("cheoeum-standalone");
+    expect(cheoeum?.audioUrl).toBe("https://example.com/cheoeum.mp3");
+  });
+
   test("tops up listening distractors from fallback words until there are four visible distractors", () => {
     const options = buildWordBankOptions(
       makeListeningStep("hello world"),
@@ -335,6 +399,33 @@ describe(buildSentenceWordOptions, () => {
       romanization: "mor-gen",
       translation: "morning (lesson)",
       word: "Morgen!",
+    });
+  });
+
+  test("propagates sub-token romanization from multi-word lesson words", () => {
+    const options = buildSentenceWordOptions(
+      "처음 뵙겠습니다.",
+      [
+        makeWordWithMetadata("1", "처음 뵙겠습니다", "prazer em conhecê-lo", {
+          audioUrl: null,
+          romanization: "cheoeum boepgetseumnida",
+        }),
+      ],
+      new Map(),
+    );
+
+    expect(options[0]).toEqual({
+      audioUrl: null,
+      romanization: "cheoeum",
+      translation: null,
+      word: "처음",
+    });
+
+    expect(options[1]).toEqual({
+      audioUrl: null,
+      romanization: "boepgetseumnida",
+      translation: null,
+      word: "뵙겠습니다.",
     });
   });
 });

--- a/packages/player/src/build-word-bank-options.ts
+++ b/packages/player/src/build-word-bank-options.ts
@@ -21,6 +21,12 @@ type WordDataInput = {
 };
 
 /**
+ * Sub-token entries from multi-word phrases don't correspond to real database records,
+ * so the lookup stores only the metadata subset of WordBankOption (no word field).
+ */
+type WordMetadata = Omit<WordBankOption, "word">;
+
+/**
  * Word-bank matching should ignore punctuation and case so "Morgen" and "Morgen!"
  * resolve to the same metadata. Keeping that rule in one helper prevents the reading
  * options, distractor filtering, and sentence-word lookup from drifting apart.
@@ -30,14 +36,58 @@ function normalizeWordKey(word: string): string {
 }
 
 /**
+ * Multi-word vocabulary entries (e.g., Korean "처음 뵙겠습니다") are stored as a single
+ * phrase, but word-bank distractors are individual tokens. To resolve metadata for each
+ * token, we split both the word and its romanization by spaces and index each token
+ * separately. Romanization systems (romaja, pinyin, romaji, etc.) maintain a 1:1
+ * space-separated correspondence with source tokens, so splitting by spaces is safe.
+ * If the token counts don't match (a data error), tokens get null romanization.
+ *
+ * Sub-token entries are placed before the full-phrase entry so that standalone words
+ * (which come later in the input array) naturally override sub-token entries via
+ * the Map's last-write-wins behavior.
+ */
+function splitMultiWordEntries(lessonWord: SerializedWord): [string, WordMetadata][] {
+  const wordTokens = lessonWord.word.split(" ").filter(Boolean);
+
+  if (wordTokens.length <= 1) {
+    return [];
+  }
+
+  const romanizationTokens = lessonWord.romanization?.split(" ").filter(Boolean) ?? [];
+  const canSlice = romanizationTokens.length === wordTokens.length;
+
+  return wordTokens.map((token, index) => [
+    normalizeWordKey(token),
+    {
+      audioUrl: null,
+      romanization: canSlice ? (romanizationTokens[index] ?? null) : null,
+      translation: null,
+    },
+  ]);
+}
+
+/**
  * Reading word-bank options need fast metadata lookup by normalized token. Building
  * the map once keeps the top-level pipeline declarative and avoids repeated scans.
+ * Multi-word entries are also indexed by their individual tokens so that distractors
+ * segmented from phrases still carry romanization.
  */
-function buildLessonWordLookup(
-  serializedLessonWords: SerializedWord[],
-): Map<string, SerializedWord> {
+function buildLessonWordLookup(serializedLessonWords: SerializedWord[]): Map<string, WordMetadata> {
   return new Map(
-    serializedLessonWords.map((lessonWord) => [normalizeWordKey(lessonWord.word), lessonWord]),
+    serializedLessonWords.flatMap((lessonWord) => {
+      const subTokenEntries = splitMultiWordEntries(lessonWord);
+      const fullEntry: [string, WordMetadata] = [
+        normalizeWordKey(lessonWord.word),
+        {
+          audioUrl: lessonWord.audioUrl,
+          romanization: lessonWord.romanization,
+          translation: lessonWord.translation,
+        },
+      ];
+
+      return [...subTokenEntries, fullEntry];
+    }),
   );
 }
 
@@ -49,7 +99,7 @@ function buildLessonWordLookup(
 function buildWordMetadataLookup(
   serializedLessonWords: SerializedWord[],
   fallbackLessonWords: SerializedWord[],
-): Map<string, SerializedWord> {
+): Map<string, WordMetadata> {
   return buildLessonWordLookup([...fallbackLessonWords, ...serializedLessonWords]);
 }
 
@@ -75,7 +125,7 @@ function buildSentenceWordLookup(
  */
 function getWordMetadata(
   word: string,
-  lessonWordLookup: Map<string, SerializedWord>,
+  lessonWordLookup: Map<string, WordMetadata>,
   sentenceWordLookup: Map<string, WordDataInput>,
 ): Omit<WordBankOption, "word"> {
   const key = normalizeWordKey(word);


### PR DESCRIPTION
Fixes #1148 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes romanization for multi‑word vocabulary so each token gets the right romanization in word‑bank and sentence options. Prevents missing or wrong romanization in distractors and tokenized phrases.

- **Bug Fixes**
  - Index multi‑word phrases by sub‑tokens with per‑token romanization; fall back to null when token counts don’t match.
  - Standalone word metadata (audio, romanization) overrides sub‑token metadata for the same token.
  - Apply the same per‑token romanization handling to sentence word options; added tests for propagation, fallback, and override.

<sup>Written for commit 572aa90bd9a1041237d99366a5fd131ad59ed8f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

