### PR TITLE
fix(ai): refine practice prompt tone

### DIFF
--- a/apps/evals/src/tasks/activity-practice/test-cases.ts
+++ b/apps/evals/src/tasks/activity-practice/test-cases.ts
@@ -3,9 +3,9 @@ EVALUATION CRITERIA:
 
 1. PRACTICE AUTHENTICITY: Dialogue must be pure conversation between colleagues with no narrator text, no character name prefixes (like "Sarah:"), and no action descriptions. The learner should feel immersed in a real workplace conversation.
 
-2. EDUCATIONAL ALIGNMENT: Every decision point must require applying lesson concepts through reasoning, not memorizing facts. Wrong options should be plausible but flawed for specific conceptual reasons.
+2. EDUCATIONAL ALIGNMENT: Every decision point must require applying lesson concepts through reasoning, not memorizing facts. Wrong options should be plausible but flawed for specific conceptual reasons. Penalize meta-scenarios where the main action is preparing a presentation, poster, cartaz, slogan, summary, or wording about the lesson topic instead of using the concept in a real situation.
 
-3. PLOT COHERENCE: Steps must flow naturally as a continuous practice where each step builds from the previous dialogue. Near the end (within the final 2-3 steps), the practice should introduce a fun, surprising twist that reframes the narrative — the best twists subvert an assumption the practice has been building. The final step must resolve the problem AND reinforce the main learning takeaway. Do NOT penalize for exact twist placement (e.g., 2nd-to-last vs 3rd-to-last) as long as the narrative flow is good.
+3. PLOT COHERENCE: Steps must flow naturally as a continuous practice where each step builds from the previous dialogue. Near the end (within the final 2-3 steps), the practice should introduce a fun, surprising twist that reframes the narrative — the best twists subvert an assumption the practice has been building. A mere escalation or a new requirement from a teacher, boss, or client is not enough to count as a twist. Strong twists usually reinterpret earlier details rather than just adding a late surprise. The final step must resolve the problem AND reinforce the main learning takeaway. Do NOT penalize for exact twist placement (e.g., 2nd-to-last vs 3rd-to-last) as long as the narrative flow is good.
 
 4. FORMAT COMPLIANCE: Verify these constraints:
    - context: Maximum 500 characters of pure dialogue
@@ -20,7 +20,9 @@ EVALUATION CRITERIA:
 
 7. STEP COUNT: Practice must have between 7 and 20 steps. Let problem complexity dictate length.
 
-8. DISTRACTOR QUALITY: All wrong options must be plausible choices someone might consider. Penalize obviously silly or absurd options that no reasonable person would choose.
+8. DISTRACTOR QUALITY: All wrong options must be plausible choices someone might consider. Do not penalize light humor, playful wording, or a mildly funny option if it is still believable in the scene. Penalize distractors that are so silly or absurd that no reasonable person would choose them.
+
+9. DIALOGUE NATURALNESS: Penalize dialogue that sounds like prompt residue, coaching language, polished writing advice, or translated corporate speech instead of something a real person in the scene would say. This includes lines that comment on how a question or sentence sounds rather than moving the scene forward. Examples of suspicious phrasing include things like "great question", "honestly", "without sounding rehearsed", "How do I say that without sounding awkward?", "What wording works better?", or local-language equivalents of that same delivery-focused wording when they feel copied from instructions rather than motivated by the scene. Also penalize dialogue that announces the story structure with labels like "twist", "plot twist", "big reveal", or local-language equivalents instead of letting the surprise happen naturally. Do not penalize light humor, playful exchanges, or a mildly silly twist when they still feel natural for the scene.
 
 ANTI-CHECKLIST GUIDANCE (CRITICAL):
 - Do NOT penalize for specific plot choices, character names, or scenario settings you might expect
@@ -29,6 +31,9 @@ ANTI-CHECKLIST GUIDANCE (CRITICAL):
 - Do NOT penalize for exact twist placement — if the twist occurs anywhere in the final third of the story, that's fine
 - Do NOT penalize for output being wrapped in {"steps": [...]} instead of a raw array
 - Do NOT penalize option text that is 55 characters or fewer — only penalize options clearly exceeding 55 characters
+- Do NOT penalize light humor, a playful tone, or slightly silly moments when they still sound natural and scene-appropriate
+- Do penalize scenes whose main task is choosing wording, polishing phrasing, or presenting the concept instead of using it
+- Do penalize lines that feel like prompt instructions leaking into dialogue, even if grammar and structure are otherwise correct
 - ONLY penalize for: format violations (option text over 55 chars, context over 500 chars, etc.), narrator/description text in dialogue, decisions that test memorization instead of reasoning, complete absence of any twist or surprise, poor distractor quality, or factually incorrect lesson application
 - Different valid practice approaches exist - assess the quality of what IS provided
 `;
@@ -86,9 +91,11 @@ TOPIC-SPECIFIC GUIDANCE:
    - Bool-int subclass relationship is misrepresented
    - Float precision issues are incorrectly described
 
-2. SCENARIO CHECK: The workplace problem should involve realistic Python programming challenges like: debugging unexpected numeric behavior, handling precision in financial calculations, or resolving type coercion surprises.
+2. PORTUGUESE NATURALNESS CHECK: Prefer everyday Brazilian Portuguese. Penalize stiff, translated, or prompt-like phrasing that sounds written instead of spoken, including local-language versions of phrases like "without sounding rehearsed" when they do not fit the scene.
 
-3. CONCEPTUAL FOCUS: Decisions should require reasoning about the structural relationship between bool and int, and about float precision limitations.
+3. SCENARIO CHECK: The workplace problem should involve realistic Python programming challenges like: debugging unexpected numeric behavior, handling precision in financial calculations, or resolving type coercion surprises.
+
+4. CONCEPTUAL FOCUS: Decisions should require reasoning about the structural relationship between bool and int, and about float precision limitations.
 
 ${SHARED_EXPECTATIONS}
     `,
@@ -216,9 +223,11 @@ TOPIC-SPECIFIC GUIDANCE:
    - Audit requirements are misrepresented for the legal context
    - Quality metrics are described without connection to document safety
 
-2. SCENARIO CHECK: The workplace problem should involve realistic legal tech challenges like: investigating a batch of documents with errors, setting up monitoring for a new automation pipeline, or responding to an audit finding.
+2. PORTUGUESE NATURALNESS CHECK: Prefer everyday Brazilian Portuguese. Penalize stiff, translated, or prompt-like phrasing that sounds written instead of spoken, including lines like "foi uma otima pergunta" when they do not fit the scene.
 
-3. CONCEPTUAL FOCUS: Decisions should require reasoning about how metrics and audit trails ensure quality and safety in automated legal document generation.
+3. SCENARIO CHECK: The workplace problem should involve realistic legal tech challenges like: investigating a batch of documents with errors, setting up monitoring for a new automation pipeline, or responding to an audit finding.
+
+4. CONCEPTUAL FOCUS: Decisions should require reasoning about how metrics and audit trails ensure quality and safety in automated legal document generation.
 
 ${SHARED_EXPECTATIONS}
     `,

--- a/packages/ai/src/tasks/activities/core/activity-practice.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-practice.prompt.md
@@ -1,47 +1,19 @@
 # Role
 
-You are an expert interactive story designer creating a **Practice** activity for a learning app. Your mission is to place learners in a first-person dialogue scenario where they work alongside someone to solve a real-world problem using the lesson's concepts.
+You are creating a **Practice** activity for a learning app.
 
-You specialize in crafting immersive, dialogue-driven experiences that make learners feel like they're actually solving problems — not just answering quiz questions.
+Your job is to place the learner inside a first-person dialogue where they work with someone else to solve a real problem using the lesson's concepts.
 
-# The Art of Dialogue-Driven Learning
-
-A great Practice activity doesn't lecture or test recall — it puts learners IN the situation. Think of it like an interactive movie where the learner IS the main character, making real decisions that matter.
-
-## Why Dialogue Scenarios Work
-
-1. **Authentic Context**: When learners apply concepts to solve realistic problems with someone, they see WHY the knowledge matters to them personally.
-
-2. **Active Reasoning**: Making decisions in context requires thinking through principles, not just recognizing memorized facts.
-
-3. **Emotional Investment**: Dialogue creates stakes. The learner cares about the outcome because they're part of the story.
-
-## The Collaborative Problem-Solving Principle
-
-Every great Practice activity creates a sense of partnership:
-
-- **Shared Goal**: You and your partner are tackling something together
-- **Natural Dialogue**: Conversations feel like real exchanges between people solving a problem
-- **Meaningful Choices**: Each decision requires applying what you've learned
-- **Satisfying Resolution**: The problem gets solved and the takeaway sticks
-
-## Why Pure Dialogue Works
-
-Each step should feel like you're eavesdropping on a real conversation — no narrator, no stage directions, just two people working through a problem. Pure dialogue:
-
-- Immerses learners completely in the scenario
-- Makes abstract concepts feel like lived experience
-- Creates natural pacing through back-and-forth exchange
-- Lets context emerge organically from what people say
+The learner should feel like they are inside a real conversation, not reading a script and not taking a quiz in disguise.
 
 # Inputs
 
-- `LESSON_TITLE`: The topic to create a story around
-- `LESSON_DESCRIPTION`: Additional context about what this lesson covers
-- `CHAPTER_TITLE`: The chapter context (for understanding scope)
-- `COURSE_TITLE`: The course context (for understanding audience level)
+- `LESSON_TITLE`: The topic to build the scenario around
+- `LESSON_DESCRIPTION`: Extra context about the lesson
+- `CHAPTER_TITLE`: Chapter context for scope
+- `COURSE_TITLE`: Course context for audience level
 - `LANGUAGE`: Output language
-- `EXPLANATION_STEPS`: Explanation of each concept the story should incorporate. EXPLANATION_STEPS tells you WHAT concepts to weave into the story scenario. Create situations where these concepts are naturally applied.
+- `EXPLANATION_STEPS`: The concepts the scenario must naturally require
 
 ## Language Guidelines
 
@@ -49,271 +21,221 @@ Each step should feel like you're eavesdropping on a real conversation — no na
 - `pt`: Use Brazilian Portuguese unless the content is region-specific
 - `es`: Use Latin American Spanish unless the content is region-specific
 
+## Naturalness Rules
+
+- Write spoken language for the requested locale, not polished written prose.
+- Prefer short, everyday sentences.
+- The dialogue should sound like two people trying to figure something out together.
+- Keep the tone warm and approachable, but grounded.
+- Light humor is welcome when it fits naturally.
+- Playful lines, mild exaggeration, and small funny moments are good when they sound like something a real person in this scene would actually say.
+- Do not force quirky or goofy lines just to make the dialogue feel entertaining.
+- Do not echo the prompt inside the dialogue. Never write lines about sounding natural, not sounding scripted, not sounding rehearsed, or similar meta-writing language.
+- Avoid coaching, therapist, or customer-support phrasing unless the situation truly calls for it.
+- Avoid over-validating the learner with lines like "great question", "excellent point", or "honestly" unless that exact phrasing would sound normal for that character in that moment.
+- Do not write dialogue about how a sentence should sound. Avoid lines like "How do I say that without sounding awkward?", "What wording works better?", "How do I make this not sound boring?", "How do I say this without rambling?", or anything else about polishing wording.
+- More generally: do not make the scene about tone-polishing, phrasing, sounding clearer, sounding better, sounding shorter, sounding less awkward, or local-language equivalents of those same ideas. If the character is worrying about how to package the sentence instead of dealing with the situation itself, rewrite the step.
+- If a line sounds written instead of spoken, rewrite it.
+
+### Extra rule for `pt`
+
+- Use everyday Brazilian Portuguese.
+- Favor direct spoken reactions like "boa", "faz sentido", "isso não bate", "acho que o problema é..." when they fit the scene.
+- Avoid stiff, translated-sounding, or prompt-like phrasing. If the line feels like the speaker is trying to sound natural instead of simply talking, rewrite it as ordinary Brazilian speech.
+- Avoid PT-BR meta-phrasing about delivery itself. If the speaker is talking about how to package the sentence instead of just speaking naturally, rewrite the line.
+
 # Requirements
 
 ## Step Structure
 
 Each step must have:
 
-- **context**: Maximum 500 characters. Pure dialogue only — no narrator, no character name prefixes (like "Sarah:"), no descriptions. This is what the other person says to you, setting up the decision point.
-- **question**: Maximum 100 characters. A short, clear question about what to do next.
-- **options**: Exactly 4 choices, each with:
-  - **text**: The answer choice (max 50 characters)
-  - **isCorrect**: Boolean indicating if this is the correct answer (exactly 1 must be true)
-  - **feedback**: Why this choice is right (with insight) or wrong (and what would be correct) — max 300 characters
+- `context`: Maximum 500 characters. Pure dialogue only. No narrator. No character name prefixes. No action descriptions. This is what the other person says to the learner before the decision.
+- `question`: Maximum 100 characters. A short, clear question about what to do next.
+- `options`: Exactly 4 choices. Each choice must have:
+  - `text`: Maximum 50 characters
+  - `isCorrect`: Boolean. Exactly 1 option must be `true`
+  - `feedback`: Maximum 300 characters
 
-## Writing Great Feedback
+## Feedback Rules
 
-Feedback should feel like the other person's natural reaction to your choice — not a score report.
+Feedback should feel like the other person's immediate response, not a score report.
 
-**For correct answers**: Celebrate the insight and reinforce why it was the right call. Keep the collaborative tone.
-
-**For wrong answers**: The colleague gently redirects — "Good instinct, but..." — and explains why another approach works better.
-
-**Examples of story-appropriate feedback:**
-
-- "Perfect call! That's exactly how we avoid the race condition — check first, then lock."
-- "I get why you'd think that, but that actually makes the deadlock worse. We need [X] to break the cycle."
-- "Close, but that's the symptom, not the cause. The real issue is [X] — once we fix that, everything else falls into place."
+- For correct answers: briefly confirm why the choice works in this situation.
+- For wrong answers: gently redirect and explain what makes another approach better.
+- Keep feedback conversational and specific.
+- A little personality or wit is great when it feels natural.
+- Do not sound like a rubric, a lecture, or praise about how good the learner's question was.
 
 ## Story Arc
 
 Your story must follow this structure:
 
-1. **Opening Step**: Begin "in the middle of the action" — the learner and their partner are already working on something. No preamble or setup exposition.
-2. **Rising Complexity**: Each step builds naturally from the previous dialogue. Decisions compound.
-3. **The Twist**: Near the end (within the final 2-3 steps), introduce a genuine surprise that reframes the story. The best twists subvert an assumption the story has been building — the reader thinks the story is going one direction, then discovers reality is completely different. Think Duolingo-style: fun, a little silly, and genuinely surprising. The twist should make the learner smile and think "I didn't see that coming!"
-4. **Resolution**: The final step resolves the problem AND reinforces the main learning takeaway. The resolution can itself BE the twist if the surprise naturally leads to the conclusion.
+1. **Opening Step**: Start in the middle of the action. No setup exposition.
+2. **Rising Complexity**: Each step builds from the previous one.
+3. **Twist or Reframe**: Near the end, introduce a real surprise or reframing that changes how the learner sees the situation.
+4. **Resolution**: Solve the problem and reinforce the lesson's main takeaway.
+
+Important:
+
+- The twist should happen inside the story. Do not explain that it is a twist.
+- Do not use words like "twist", "plot twist", "big reveal", or similar labels inside the dialogue unless a character would naturally say them for some reason unrelated to the story structure.
+- Let the new fact land on its own and let the characters react to it naturally.
+
+## Building Memorable Twists
+
+The best twists are memorable because they quietly build one strong assumption, then flip it with one concrete new fact.
+
+- Plant one clear assumption early. The learner should think they understand what is happening.
+- Let the middle steps make that assumption feel even more likely.
+- Near the end, reveal one concrete fact that changes the meaning of what came before.
+- The reveal should feel surprising at first and obvious a second later.
+- The reveal should change the situation itself, not just the wording around it.
+- After the reveal, let the characters react naturally and keep moving.
+
+To make the twist stick:
+
+- Build the story around one mistaken frame, not several weak ones.
+- Seed 2-3 earlier details that fit the first interpretation, but make even more sense after the reveal.
+- The reveal should make the learner mentally replay earlier moments and see them differently.
+- Prefer a concrete reveal: identity, source, destination, label, code, role, location, ownership, or point of view.
+- After the reveal, give the learner one last meaningful decision or reaction inside the new frame.
+- If the story still works almost the same after removing the reveal, then it is not a strong twist.
+
+Good twist patterns:
+
+- Perspective flip: everyone thinks an unknown ship is invading, then the final reveal shows the characters are the outsiders landing on someone else's world.
+- Wrong cause: everyone blames one obvious cause, then a late clue shows the real cause was something completely different.
+- Mistaken identity: the feared person, object, or signal turns out to be something familiar seen from the wrong angle.
+- Reversed roles: the person assumed to be helping, chasing, buying, or protecting turns out to be the one being judged, tracked, sold to, or protected from.
+
+Bad twists:
+
+- A teacher, boss, or client simply adds one more requirement.
+- A character literally announces "here comes the twist".
+- The ending just restates the lesson in more dramatic words.
+- The reveal changes the label but not the situation.
+- The reveal arrives with no setup, so it feels random instead of satisfying.
 
 ## Step Count
 
 - Minimum: 7 steps
 - Maximum: 20 steps
-- Let the problem's complexity dictate the length. A simple concept might need 7-10 steps; a complex one might need 15-20.
+- Let the lesson's complexity decide the length
 
-## Tone & Style
+## Tone and Style
 
-- **Pure dialogue**: NO narrator, NO character name prefixes, NO descriptions of actions or settings
-- **Natural conversation**: Write how people actually talk when solving a problem together — casual, collaborative, sometimes humorous
-- **Warm and approachable**: Light, smart humor when appropriate. Never forced or cheesy.
-- **Second-person immersion**: The other person speaks TO the learner. Context emerges from what's said.
-- **Continuous flow**: Each step's dialogue should naturally lead into the next
-- **Helpful without sounding scripted**: The dialogue should feel like a real person talking, not a textbook rewritten as conversation
-- **Accessible to learners outside elite academic or technical circles**: Use everyday language. Short sentences. If a technical term is needed, let the dialogue explain it naturally — like a friend would. Avoid dense, multi-clause sentences in both context and feedback. The learner should never feel like they need a dictionary to follow the story
+- Pure dialogue only
+- No narrator text
+- No character name prefixes
+- No action descriptions
+- Casual, collaborative, everyday speech
+- Friendly, clear, and allowed to be a little playful
+- Short sentences over dense multi-clause explanations
+- Context should emerge naturally from what people say
+- The partner should sound like a real person in the scene, not like a prompt trying to prove it is natural
 
 ## Choosing the Right Scenario
 
-This is a learning and career development platform, so **workplace scenarios are the default** — they show learners what applying this knowledge looks like in a real job. A neuroscience practice might feature lab partners; a music practice might feature bandmates in a rehearsal; a health practice might feature colleagues in a clinic.
+This is a learning and career development platform, so workplace scenarios are the default. They often show most clearly how the lesson applies in real life.
 
-However, not every topic maps best to work. When the concept is more naturally encountered in everyday life, use that setting instead — a friend, a neighbor, a family member.
+However, some topics fit everyday life better. Foundational or broad concepts may work better with a friend, neighbor, family member, or classmate.
 
-**Let the topic's depth guide you.** Foundational topics (introductions, origins, basic concepts) often connect better to everyday situations because the learner is still building intuition — they don't yet know what this job looks like. More advanced or specialized topics naturally call for workplace scenarios because the problems themselves are professional. You can infer this from `LESSON_TITLE`, `CHAPTER_TITLE`, and `COURSE_TITLE`.
+Ask:
 
-The key question is: **"Where would someone at this level most naturally face this problem?"** Use that setting, and pick whoever would naturally be there as the dialogue partner.
+**Where would someone at this level most naturally face this problem?**
 
-## The {{NAME}} Placeholder
+Use that setting and choose the most natural dialogue partner for it.
 
-Use `{{NAME}}` wherever the learner's name should appear in dialogue. For example:
+## The `{{NAME}}` Placeholder
 
-- "{{NAME}}, I think we might have a problem here."
-- "Good catch, {{NAME}}. That's exactly what I was thinking."
+Use `{{NAME}}` wherever the learner's name should appear in dialogue.
 
-This personalizes the experience without requiring actual name input at content creation time.
+Examples:
+
+- "{{NAME}}, I think we missed something."
+- "Boa, {{NAME}}. Será que..."
 
 ## Decision Design
 
 Every decision must:
 
-- **Require reasoning**: Learners must apply principles from the lesson, not recall specific phrases
-- **Feel realistic**: These are choices someone might actually face in this situation
-- **Have plausible distractors**: Wrong options should be tempting but flawed for specific reasons
-- **Avoid "obvious" correct answers**: The right choice should require thought, not be the only non-silly option
+- require reasoning, not recall
+- feel like a real choice someone could face
+- have plausible distractors
+- allow distractors to have some personality or light humor when they are still believable choices
+- avoid an obvious correct answer
 
-### The Core Principle: Content as Tool, Not Subject
+### Core Principle: Use the Concept, Do Not Talk About the Concept
 
-The scenario should never be ABOUT the content (presenting it, explaining it, correcting a description of it, fixing a museum plaque, writing a brochure). The scenario should be about **a real situation where the content is the tool the learner uses to make sense of what's happening.**
+The scenario should not be about presenting, defining, correcting, or summarizing the lesson content.
 
-Ask: **"Is the learner discussing the concept, or using the concept?"**
+The scenario should be about something real happening, where the lesson's concept is the tool the learner uses to understand the situation and decide what to do.
 
-- **Discussing** (BAD): The scenario is about explaining, describing, framing, or presenting the content. The learner picks the best description. This includes fixing museum plaques, correcting slides, writing event texts, helping someone explain a topic, or choosing the right summary.
-- **Using** (GOOD): Something is happening — a system is broken, a person is making a wrong claim, someone needs help — and the learner reaches for the concept as a tool to understand the situation and decide what to do.
+Ask:
 
-**Example — BAD (meta-scenario about the content):**
+**Is the learner talking about the concept, or using the concept?**
 
-> "The museum plaque says ancient medicine was 'almost all magic.' But the Edwin Smith Papyrus complicates that. How would you rewrite the plaque?"
+- BAD: choosing the best explanation, summary, plaque text, brochure copy, slide copy, or definition
+- GOOD: diagnosing, deciding, helping, fixing, interpreting, or responding to a real situation
 
-The learner is choosing the best historical summary. The content is the subject of the conversation.
+Hard rule:
 
-**Example — GOOD (content as invisible tool):**
-
-> "My uncle had a stroke and lost his speech. At a family dinner, my grandma said 'his heart got weak and that's why he can't talk — feelings and speech come from the same place.' I know that's not right, but I don't know how to explain. Where do you start?"
-
-The learner uses historical knowledge (brain vs. heart debate, localization of function) to reason about a real situation. The history is never mentioned directly — it's the lens the learner uses.
-
-**Another BAD example:**
-
-> "The exhibition text says Gall 'proved personality through skull bumps.' How should we correct this?"
-
-The learner picks the right historical framing.
-
-**Another GOOD example:**
-
-> "My aunt is paying R$40/month for an app that 'maps your personality by your skull shape.' I want to help without being rude. What's wrong with this?"
-
-The learner applies what they know about phrenology's failure to evaluate a real modern scam. The concept is a tool, not the topic.
+- Do not build the scene around preparing a presentation, poster, cartaz, slogan, summary, pitch, fair panel, or speech about the lesson topic.
+- Do not make the learner choose how to phrase an idea, how to make it sound better, or how to explain the concept more nicely.
+- If the main action is wording, rewriting, presenting, or polishing the concept, the scenario is wrong. Start over with a real situation where the concept is being used.
 
 ## What to Avoid
 
-- Narrator text ("Meanwhile..." or "You walk into the office...")
-- Character name prefixes ("Sarah:" or "Your colleague says:")
-- Description of actions or settings (except through dialogue itself)
-- Questions that test memorization of facts from earlier activities
-- **Definition-picking questions disguised as dialogue** — "how would you define X?", "which explanation is best?", "what opens the text best?" are all recall, not reasoning. Instead, create a situation where the learner must USE the concept to solve something
-- **Any scenario where the primary action is describing, presenting, or framing the content** — this includes fixing museum plaques, writing brochures, correcting slides, preparing event texts, or helping someone explain a topic. These are meta-scenarios ABOUT the content. Instead, create scenarios where something real is happening and the content is the tool the learner uses to make sense of it: a patient reacting unexpectedly, a relative believing something wrong, a system behaving in ways that require the concept to diagnose
-- Obvious "correct" answers that don't require applying the concept
-- Silly or clearly wrong distractors that no reasonable person would choose
-- Breaking the fourth wall or meta-commentary
-- Starting with "In this activity..." or setup exposition
+- narrator text
+- character name prefixes
+- descriptions of actions or settings outside the dialogue
+- memorization questions disguised as dialogue
+- scenarios about explaining the content instead of using it
+- scenes about choosing wording, fixing phrasing, writing a panel, making a slogan, or deciding how to explain the topic
+- distractors so absurd that nobody in the scene would seriously consider them
+- meta-commentary
+- fourth-wall breaking
+- lines that sound like prompt residue or writing advice
+- lines that describe the quality of the conversation itself, such as whether something sounds natural, honest, polished, clear, or rehearsed
+- lines about how to phrase something better, shorter, clearer, less awkward, or local-language equivalents of those same delivery concerns
+- lines that announce the story structure, such as calling something a "plot twist", "big reveal", or similar label
+- repeated praise that does not move the scene forward
 
 ## Scope
 
-- **Stay focused**: The problem should specifically require THIS lesson's concept to solve
-- **Don't expand**: Other lessons cover related topics — this story tests this lesson
-- **Don't narrow**: If the lesson is broad, the problem should engage multiple aspects of it
-
-# Structure Guide
-
-While every story is unique, most follow this arc (adapt as needed):
-
-1. **The Hook**: Jump straight into the situation. Something needs to be figured out or decided.
-2. **Initial Assessment**: What's the situation? What do we know? First decisions.
-3. **Deepening Complexity**: The problem has layers. Apply the concept more deeply.
-4. **Complications**: Things aren't as simple as they seemed. Adapt your approach.
-5. **The Twist**: A surprise that reframes everything. The best twists flip the story's core assumption — what you thought was the problem turns out to be something else entirely, or the situation is the opposite of what it seemed.
-6. **The Resolution**: Solve the problem AND crystallize the key insight from the lesson.
-
-## Crafting Great Twists
-
-The twist is what makes a story memorable. Think of Duolingo's best stories — they build an assumption throughout the entire narrative, then flip it in a way that's fun, surprising, and a little silly.
-
-**The technique: Plant an assumption, then subvert it.**
-
-The whole story should build toward one interpretation. The learner becomes invested in that version of events. Then the twist reveals reality was completely different — in a delightful way that still teaches the concept.
-
-**Example patterns:**
-
-- **Perspective flip**: "We've been debugging the competitor's system... turns out it's our own system in a staging environment we forgot about."
-- **The real problem**: "The 'critical security breach' was actually our CEO's kid who guessed the password 'password123'."
-- **Ironic reversal**: "After optimizing the algorithm for hours, we discover the slow part was a console.log printing the entire database on every request."
-- **Scale surprise**: "The 'minor data inconsistency' we've been investigating? It's been silently saving the company $50K/month by catching billing errors."
-- **Wrong assumption**: "We spent all day trying to figure out why the server was slow... it was fast. The client's WiFi was connected to the coffee shop next door."
-
-**What makes a great twist:**
-
-- It reframes the ENTIRE story, not just the last step
-- It's fun and a bit silly — makes you smile
-- It's genuinely surprising but makes sense in hindsight
-- It still reinforces the lesson's concept
-- It gives the story a punchline that learners will remember
-
-**What makes a BAD twist:**
-
-- Just adding a new complication near the end (that's not a twist, it's a complication)
-- A twist that's unrelated to the story or lesson
-- Something dark or stressful instead of fun
-- A predictable "the real problem was X" that everyone saw coming
-
-# Dialogue Tone Examples
-
-The following examples show the **tone and style** to aim for — not complete steps, just the kind of dialogue that makes stories feel alive. Adapt freely to your topic.
-
-## Opening Hooks (Jump Into the Action)
-
-> "{{NAME}}, I've been staring at this bug for an hour. The shopping cart total keeps showing yesterday's prices. The database is fine. Something's wrong with how we're storing them."
-
-> "Okay, {{NAME}}, the client just called. Their entire inventory system crashed right before Black Friday. They're panicking. We need to figure this out fast."
-
-> "{{NAME}}, you're not going to believe this. Remember that algorithm we deployed last week? It's been recommending the exact opposite of what users want. Sales are tanking."
-
-> "{{NAME}}, the party is in two hours and this playlist sounds completely wrong. The songs are fine individually but one after the other it's a mess. Something's off with how they flow together."
-
-> "{{NAME}}, my cousin just sent me a video of this rash and wants to know if it's serious. I told him I'm studying this exact topic. Now I actually have to know what I'm talking about."
-
-## Building Tension (Problems Get Deeper)
-
-> "Wait. If this pattern is everywhere in the codebase... inventory counts, user roles, discount percentages... we might have a much bigger problem than I thought."
-
-> "Hold on. The logs show someone accessed the admin panel at 3 AM last night. But nobody on the team was working then. {{NAME}}, who else has those credentials?"
-
-> "The numbers don't add up. We're showing 500 successful transactions, but the bank only received 487. Where did the other 13 go?"
-
-## Plot Twists (The Fun Surprise)
-
-The best twists flip the entire story on its head. They should make the learner smile and think "wait, WHAT?"
-
-> "{{NAME}}... I just figured out why our 'hacker' only attacks during lunch. It's not a hacker. It's the microwave in the break room crashing the server every time someone heats up soup."
-
-> "Wait. I've been running our performance test against the wrong server this whole time. This isn't our production database — it's the intern's Minecraft server. No wonder the query patterns looked weird."
-
-> "{{NAME}}, remember the 'ghost user' who's been editing records at 3 AM? I found them. It's our own automated backup script... and it's been 'correcting' data by reverting everything to last month's values. We've been fighting our own system."
-
-> "{{NAME}}... the reason the song sounded so weird isn't the chord progression. Your guitar has been tuned a half step down this whole time. We've been 'fixing' a song that was already right."
-
-## Humorous Moments (Light Relief)
-
-> "Well, {{NAME}}, the good news is we found the bug. The bad news? It's been there since 2019. The worse news? I wrote it. The even worse news? So did you. We pair-programmed this disaster together."
-
-> "Congratulations, {{NAME}}. We just spent four hours debugging what turned out to be a typo. 'userID' vs 'userId'. Camel case strikes again."
-
-> "{{NAME}}, remember when I said 'this should be a quick fix'? That was three coffees and one existential crisis ago."
-
-## Satisfying Resolutions (Problem Solved + Insight Crystallized)
-
-> "There it is. The fix works. {{NAME}}, I don't think I'll ever forget this — always check if your data source can change while you're holding onto a copy of it."
-
-> "We did it. The system's stable. You know what the real lesson here was? Sometimes the simplest explanation IS the right one. We kept looking for complex bugs when the answer was right in front of us."
-
-> "That's it — problem solved, client happy, crisis averted. {{NAME}}, I think we just learned more about distributed systems in the last hour than in any textbook."
-
-## Unexpected/Funny Endings
-
-> "So let me get this straight. We optimized a million-dollar machine learning pipeline... and the prediction model we built? It's less accurate than the intern's spreadsheet with a VLOOKUP formula. {{NAME}}, we don't tell anyone about this. Ever."
-
-> "Wait — you're saying the 'AI-powered anomaly detection system' that flagged this issue... is just a bash script someone wrote in 2019 that checks if a number is bigger than 1000? And it's been right every single time? I don't know whether to be impressed or terrified."
-
-> "{{NAME}}, the client just called back. They love the fix so much they want us to 'break' three more things so we can dramatically fix those too. I think we've accidentally invented a new business model."
-
-Remember: These are just **tone examples**. Your story should be original, fit the lesson topic, and create its own memorable journey. Mix problem-solving tension with moments of humor or surprise. The best stories make learners think "I didn't see that coming!" while still teaching the concept.
-
-Note: The examples above lean toward tech/workplace scenarios because they're easy to illustrate, but your story should match the topic. A music practice might feature two friends jamming; a biology practice might feature study partners at a park; a cooking practice might feature neighbors preparing for a potluck. Use whatever setting fits the topic most naturally.
+- Stay focused on this lesson's concepts
+- Do not broaden into other lessons
+- If the lesson is broad, let the scenario use multiple parts of it naturally
 
 # Quality Checks
 
 Before finalizing, verify:
 
-- [ ] Is the dialogue pure conversation with NO narrator, NO character prefixes, NO descriptions?
-- [ ] Does every step flow naturally from the previous one (continuous story)?
-- [ ] Do all decisions require applying lesson concepts, not just recalling facts? (For each step, ask: "Is the learner discussing the concept or using the concept?" — if discussing, rewrite it)
-- [ ] Is there a fun, surprising twist near the end (within the final 2-3 steps) that reframes the story?
-- [ ] Does the resolution both solve the problem AND reinforce the main learning?
-- [ ] Is `{{NAME}}` used appropriately to personalize the dialogue?
-- [ ] Are all distractors plausible (not obviously silly)?
-- [ ] Does feedback feel like a natural response from the dialogue partner (not a quiz score)?
-- [ ] Does wrong answer feedback gently guide toward the correct approach?
-- [ ] Does the story feel like a real conversation between people solving a problem, not a quiz in disguise?
-- [ ] Is the scope exactly the lesson topic — not broader or narrower?
-- [ ] Are all constraints met (context ≤500 chars, question ≤100 chars, options ≤50 chars each, feedback ≤300 chars each)?
-- [ ] Is the step count between 7 and 20?
+- [ ] Is every `context` pure dialogue with no narrator, prefixes, or action descriptions?
+- [ ] Does the dialogue sound like real spoken language in the requested locale?
+- [ ] Would a real person in this scene actually say these lines?
+- [ ] Did you avoid prompt-like phrases, coaching language, and over-polished reactions?
+- [ ] Did you avoid scenes about phrasing, rewriting, slogans, panels, presentations, or explaining the concept?
+- [ ] Did you avoid meta phrasing about how a line should sound, including local-language versions of delivery-focused wording?
+- [ ] Did you keep the dialogue warm, lively, and allowed to be funny when the scene supports it?
+- [ ] Does every step flow naturally from the previous step?
+- [ ] Do the decisions require applying the lesson, not recalling definitions?
+- [ ] Is there a real twist or reframe near the end?
+- [ ] Does the twist happen naturally, without the dialogue calling it a twist, big reveal, or similar label?
+- [ ] Does the final step solve the problem and reinforce the key learning?
+- [ ] Is `{{NAME}}` used naturally?
+- [ ] Are all wrong answers plausible?
+- [ ] Does every option have feedback that explains the reasoning?
+- [ ] Are all limits respected?
+- [ ] Is the story between 7 and 20 steps?
 
 # Output Format
 
 Return an array of steps, each with:
 
-- **context**: Pure dialogue from the other person (max 500 chars)
-- **question**: Decision prompt (max 100 chars)
-- **options**: Array of exactly 4 objects, each with:
-  - **text**: The answer choice (max 50 chars)
-  - **isCorrect**: Boolean (exactly 1 must be true, 3 must be false)
-  - **feedback**: Why right (with insight) or wrong (and what would be correct) — max 300 chars
+- `context`
+- `question`
+- `options`: exactly 4 objects with `text`, `isCorrect`, and `feedback`
 
-Use 7-20 steps to tell a complete, engaging story. Let the problem's complexity dictate the length.
+Use 7-20 steps to tell a complete, coherent, natural-feeling story.


### PR DESCRIPTION
Tighten the practice prompt and evaluation guidance to reduce prompt-residue dialogue, improve naturalness, and keep twists more organic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrite the Practice activity prompt to sound like real conversation and avoid prompt-residue. Tighten twist rules and feedback tone, and update eval criteria (incl. PT-BR naturalness) to enforce the new style.

- **Refactors**
  - Overhauled `packages/ai` Practice prompt: adds Naturalness Rules, bans meta phrasing and wording-focused scenes, keeps pure dialogue only, allows light but believable humor, emphasizes using the concept (not explaining it), and clarifies twist design without labeling it a “twist”.
  - Strengthened `apps/evals` criteria: penalizes meta-scenarios (presentations/posters/slogans), distinguishes real twists from simple escalations, permits playful yet plausible distractors, and adds a Dialogue Naturalness check with examples to avoid prompt-like lines.
  - Added PT-BR guidance: prefer everyday Brazilian Portuguese and penalize stiff or translated-sounding phrasing in topic guides.

<sup>Written for commit ebd15edd83137b1bc615cc50333450a1c86a835c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

