### PR TITLE
feat(ai): add openai tts fallback with alternating retry

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@ai-sdk/gateway": "3.0.79",
+    "@ai-sdk/openai": "3.0.48",
     "@google/genai": "1.47.0",
     "@zoonk/utils": "workspace:*",
     "ai": "6.0.137",

--- a/packages/ai/src/tasks/audio/generate-language-audio.ts
+++ b/packages/ai/src/tasks/audio/generate-language-audio.ts
@@ -1,13 +1,34 @@
 import "server-only";
-import { GoogleGenAI } from "@google/genai";
+import { setTimeout } from "node:timers/promises";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { type TTSVoice, getLanguageName } from "@zoonk/utils/languages";
 import { logError } from "@zoonk/utils/logger";
 import promptTemplate from "./generate-language-audio.prompt.md";
-import { wrapPCMInWAV } from "./wrap-pcm-in-wav";
+import { generateWithGemini } from "./provider-gemini";
+import { generateWithOpenAI } from "./provider-openai";
 
-const DEFAULT_MODEL = "gemini-2.5-flash-preview-tts";
 const DEFAULT_VOICE: TTSVoice = "Kore";
+const MAX_ATTEMPTS_PER_PROVIDER = 3;
+const INITIAL_BACKOFF_MS = 1000;
+
+export type AudioFormat = "opus" | "wav";
+
+export type AudioResult = {
+  audio: Uint8Array;
+  format: AudioFormat;
+};
+
+type AudioProvider = (params: {
+  instructions: string;
+  text: string;
+  voice: TTSVoice;
+}) => Promise<AudioResult>;
+
+type ScheduledAttempt = {
+  backoffMs: number;
+  generate: AudioProvider;
+  name: string;
+};
 
 function buildInstructions(languageCode: string | undefined): string {
   const languageName = languageCode
@@ -18,8 +39,72 @@ function buildInstructions(languageCode: string | undefined): string {
 }
 
 /**
- * Generates audio using the Google GenAI SDK with a Gemini TTS model.
- * Returns WAV audio bytes ready for playback in browsers.
+ * Builds a flat list of retry attempts that alternates between
+ * providers with per-provider exponential backoff.
+ *
+ * Example with 2 providers and 3 attempts each:
+ *   Gemini (0ms) → OpenAI (0ms) → Gemini (1s) → OpenAI (1s) → Gemini (2s) → OpenAI (2s)
+ *
+ * First attempt per provider has no delay. Subsequent retries of the
+ * same provider use exponential backoff (1s, 2s, 4s, ...).
+ */
+function buildAttemptSchedule(
+  providers: readonly { generate: AudioProvider; name: string }[],
+): ScheduledAttempt[] {
+  return Array.from({ length: MAX_ATTEMPTS_PER_PROVIDER }, (_, round) =>
+    providers.map((provider) => ({
+      backoffMs: round === 0 ? 0 : INITIAL_BACKOFF_MS * 2 ** (round - 1),
+      generate: provider.generate,
+      name: provider.name,
+    })),
+  ).flat();
+}
+
+/**
+ * Tries each provider in alternating order with per-provider
+ * exponential backoff. Switching providers immediately after a
+ * failure avoids waiting when a different provider might succeed
+ * right away. Backoff only applies when retrying the same provider.
+ */
+async function generateWithFallback({
+  instructions,
+  text,
+  voice,
+}: {
+  instructions: string;
+  text: string;
+  voice: TTSVoice;
+}): Promise<AudioResult> {
+  const schedule = buildAttemptSchedule([
+    { generate: generateWithGemini, name: "gemini" },
+    { generate: generateWithOpenAI, name: "openai" },
+  ]);
+
+  let lastError: Error | undefined;
+
+  /* oxlint-disable no-await-in-loop -- Sequential retry with backoff is intentional.
+   * We must wait for each attempt to fail before trying the next provider. */
+  for (const attempt of schedule) {
+    if (attempt.backoffMs > 0) {
+      await setTimeout(attempt.backoffMs);
+    }
+
+    try {
+      return await attempt.generate({ instructions, text, voice });
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      logError(`TTS ${attempt.name} failed:`, lastError);
+    }
+  }
+  /* oxlint-enable no-await-in-loop */
+
+  throw lastError ?? new Error("All TTS providers failed");
+}
+
+/**
+ * Generates audio for the given text using Gemini TTS as the primary
+ * provider and OpenAI TTS as a fallback. Alternates between providers
+ * on failure with exponential backoff to handle rate limits.
  */
 export async function generateLanguageAudio({
   language,
@@ -29,43 +114,8 @@ export async function generateLanguageAudio({
   language?: string;
   text: string;
   voice?: TTSVoice;
-}): Promise<
-  SafeReturn<{
-    audio: Uint8Array;
-  }>
-> {
-  const { data, error } = await safeAsync(async () => {
-    const client = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
+}): Promise<SafeReturn<AudioResult>> {
+  const instructions = buildInstructions(language);
 
-    const instructions = buildInstructions(language);
-
-    const response = await client.models.generateContent({
-      config: {
-        responseModalities: ["AUDIO"],
-        speechConfig: {
-          voiceConfig: {
-            prebuiltVoiceConfig: { voiceName: voice },
-          },
-        },
-      },
-      contents: [{ parts: [{ text: `${instructions}\n\n${text}` }] }],
-      model: DEFAULT_MODEL,
-    });
-
-    const audioData = response.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data;
-
-    if (!audioData) {
-      throw new Error("No audio data in Gemini response");
-    }
-
-    const pcmBytes = new Uint8Array(Buffer.from(audioData, "base64"));
-    return { audio: wrapPCMInWAV(pcmBytes) };
-  });
-
-  if (error) {
-    logError("Error generating language audio:", error);
-    return { data: null, error };
-  }
-
-  return { data, error: null };
+  return safeAsync(() => generateWithFallback({ instructions, text, voice }));
 }

--- a/packages/ai/src/tasks/audio/provider-gemini.ts
+++ b/packages/ai/src/tasks/audio/provider-gemini.ts
@@ -1,0 +1,45 @@
+import { GoogleGenAI } from "@google/genai";
+import { type TTSVoice } from "@zoonk/utils/languages";
+import { type AudioResult } from "./generate-language-audio";
+import { wrapPCMInWAV } from "./wrap-pcm-in-wav";
+
+const MODEL = "gemini-2.5-flash-preview-tts";
+
+/**
+ * Generates audio using the Google GenAI SDK with a Gemini TTS model.
+ * Returns WAV audio because Gemini outputs raw PCM which needs
+ * a WAV header for browser playback.
+ */
+export async function generateWithGemini({
+  instructions,
+  text,
+  voice,
+}: {
+  instructions: string;
+  text: string;
+  voice: TTSVoice;
+}): Promise<AudioResult> {
+  const client = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
+
+  const response = await client.models.generateContent({
+    config: {
+      responseModalities: ["AUDIO"],
+      speechConfig: {
+        voiceConfig: {
+          prebuiltVoiceConfig: { voiceName: voice },
+        },
+      },
+    },
+    contents: [{ parts: [{ text: `${instructions}\n\n${text}` }] }],
+    model: MODEL,
+  });
+
+  const audioData = response.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data;
+
+  if (!audioData) {
+    throw new Error("No audio data in Gemini response");
+  }
+
+  const pcmBytes = new Uint8Array(Buffer.from(audioData, "base64"));
+  return { audio: wrapPCMInWAV(pcmBytes), format: "wav" };
+}

--- a/packages/ai/src/tasks/audio/provider-openai.ts
+++ b/packages/ai/src/tasks/audio/provider-openai.ts
@@ -1,0 +1,36 @@
+import { openai } from "@ai-sdk/openai";
+import { type TTSVoice } from "@zoonk/utils/languages";
+import { experimental_generateSpeech as generateSpeech } from "ai";
+import { type AudioResult } from "./generate-language-audio";
+
+const MODEL = openai.speech("gpt-4o-mini-tts");
+
+/**
+ * OpenAI voices don't map 1:1 to Gemini voices.
+ * We pick a reasonable OpenAI default regardless of
+ * the Gemini voice requested since this is a fallback.
+ */
+const OPENAI_VOICE = "marin";
+
+/**
+ * Generates audio using OpenAI's TTS API as a fallback provider.
+ * Returns opus audio directly (no conversion needed).
+ */
+export async function generateWithOpenAI({
+  instructions,
+  text,
+}: {
+  instructions: string;
+  text: string;
+  voice: TTSVoice;
+}): Promise<AudioResult> {
+  const { audio } = await generateSpeech({
+    instructions,
+    model: MODEL,
+    outputFormat: "opus",
+    text,
+    voice: OPENAI_VOICE,
+  });
+
+  return { audio: audio.uint8Array, format: "opus" };
+}

--- a/packages/core/src/audio/generate-language-audio.ts
+++ b/packages/core/src/audio/generate-language-audio.ts
@@ -27,7 +27,7 @@ export async function generateLanguageAudio({
   }
 
   const slug = toSlug(text);
-  const fileName = `audio/${orgSlug ?? "default"}/${slug}.wav`;
+  const fileName = `audio/${orgSlug ?? "default"}/${slug}.${audioResult.format}`;
 
   const { data: url, error: uploadError } = await uploadAudio({
     audio: audioResult.audio,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,6 +461,9 @@ importers:
       '@ai-sdk/gateway':
         specifier: 3.0.79
         version: 3.0.79(zod@4.3.6)
+      '@ai-sdk/openai':
+        specifier: 3.0.48
+        version: 3.0.48(zod@4.3.6)
       '@google/genai':
         specifier: 1.47.0
         version: 1.47.0
@@ -917,6 +920,12 @@ packages:
 
   '@ai-sdk/gateway@3.0.79':
     resolution: {integrity: sha512-Wk2QJpqd0em5YcR49uoMCy9msyANAYgjXdlRcqqRt2fz4rNLnMMrKOlLwAXoFzR1ElR3bj4e/k6hscRfjpzSGA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.48':
+    resolution: {integrity: sha512-ALmj/53EXpcRqMbGpPJPP4UOSWw0q4VGpnDo7YctvsynjkrKDmoneDG/1a7VQnSPYHnJp6tTRMf5ZdxZ5whulg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -7799,6 +7808,12 @@ snapshots:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
       '@vercel/oidc': 3.1.0
+      zod: 4.3.6
+
+  '@ai-sdk/openai@3.0.48(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/provider-utils@4.0.21(zod@4.3.6)':


### PR DESCRIPTION
## Summary

- Add OpenAI TTS as a fallback when Gemini TTS fails
- Providers alternate with per-provider exponential backoff: Gemini → OpenAI → Gemini(1s) → OpenAI(1s) → Gemini(2s) → OpenAI(2s)
- Split providers into separate files for clean separation of concerns
- Return audio format (wav/opus) so upload uses the correct file extension

## Why

Since we're calling Gemini directly instead of through the AI Gateway, we lose automatic fallback/retry. This ensures TTS failures (rate limits, outages) don't block audio generation for language learning content.

## Test plan

- [x] All existing tests pass
- [ ] Test in evals `/audio-test` with valid Gemini key — should return WAV
- [ ] Test with invalid/missing Gemini key — should fall back to OpenAI and return opus

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OpenAI TTS as a fallback when Gemini fails, using alternating retries with per-provider exponential backoff to keep audio generation reliable. Also return the audio format so uploads use the correct file extension.

- **New Features**
  - Fallback to OpenAI TTS when Gemini fails with alternating retry and per-provider exponential backoff (3 attempts each).
  - Return audio format ("wav" for Gemini, "opus" for OpenAI) and use it in the upload filename.

- **Refactors**
  - Split providers into `provider-gemini.ts` and `provider-openai.ts` for clearer separation.

- **Dependencies**
  - Add `@ai-sdk/openai` for the OpenAI TTS fallback.

<sup>Written for commit 543e83e1055db81f2a717b9f34cba03311c4566f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

