### PR TITLE
fix(ai): only log tts errors after all retry attempts fail

### DIFF
--- a/packages/ai/src/tasks/audio/generate-language-audio.ts
+++ b/packages/ai/src/tasks/audio/generate-language-audio.ts
@@ -93,11 +93,11 @@ async function generateWithFallback({
       return await attempt.generate({ instructions, text, voice });
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
-      logError(`TTS ${attempt.name} failed:`, lastError);
     }
   }
   /* oxlint-enable no-await-in-loop */
 
+  logError("All TTS providers failed after retries:", lastError);
   throw lastError ?? new Error("All TTS providers failed");
 }
 


### PR DESCRIPTION
## Summary

- Move `logError` from inside the TTS retry loop to after all attempts are exhausted
- Intermediate failures (e.g., rate limits) are expected and recoverable — logging each one polluted logs/Sentry with noise
- Now we only log once when all providers and retries fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move TTS error logging so we only log once after all retries and provider fallbacks fail. This reduces noise from expected transient failures (like rate limits) in logs and Sentry.

<sup>Written for commit 8a644005cf788dabe427b0fb2c3c481fb0634768. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

