### PR TITLE
feat(admin): add audio review section for words and sentences

### DIFF
--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/upload-audio.ts
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/upload-audio.ts
@@ -1,0 +1,110 @@
+"use server";
+
+import { isAdmin } from "@/lib/admin-guard";
+import { uploadAudio } from "@zoonk/core/audio/upload";
+import { prisma } from "@zoonk/db";
+import { parseBigIntId } from "@zoonk/utils/number";
+import { DEFAULT_AUDIO_ACCEPTED_TYPES, DEFAULT_AUDIO_MAX_SIZE } from "@zoonk/utils/upload";
+import { revalidatePath } from "next/cache";
+
+/**
+ * Validates that the file from FormData is a supported audio format
+ * within the size limit.
+ */
+function validateAudioFile(formData: FormData): { file: File } | { error: string } {
+  const file = formData.get("file");
+
+  if (!(file && file instanceof File)) {
+    return { error: "No file provided" };
+  }
+
+  if (!DEFAULT_AUDIO_ACCEPTED_TYPES.includes(file.type)) {
+    return { error: "Invalid file type. Please upload a WAV, OGG, MP3, or Opus audio file." };
+  }
+
+  if (file.size > DEFAULT_AUDIO_MAX_SIZE) {
+    return { error: "File is too large. Maximum size is 10MB." };
+  }
+
+  return { file };
+}
+
+/**
+ * Shared pipeline for uploading replacement audio: validates admin access,
+ * parses the entity ID, validates the file, uploads to Vercel Blob,
+ * then delegates the DB update to the caller-provided function.
+ */
+async function uploadEntityAudio({
+  entityId,
+  entityType,
+  formData,
+  updateEntity,
+}: {
+  entityId: string;
+  entityType: string;
+  formData: FormData;
+  updateEntity: (audioUrl: string, id: bigint) => Promise<unknown>;
+}): Promise<{ error: string | null }> {
+  if (!(await isAdmin())) {
+    return { error: "Unauthorized" };
+  }
+
+  const id = parseBigIntId(entityId);
+
+  if (!id) {
+    return { error: `Invalid ${entityType} ID` };
+  }
+
+  const validation = validateAudioFile(formData);
+
+  if ("error" in validation) {
+    return { error: validation.error };
+  }
+
+  const buffer = new Uint8Array(await validation.file.arrayBuffer());
+  const extension = validation.file.name.split(".").pop() ?? "wav";
+
+  const { data: audioUrl, error: uploadError } = await uploadAudio({
+    audio: buffer,
+    fileName: `audio/admin-review/${entityType}-${id}.${extension}`,
+  });
+
+  if (uploadError) {
+    return { error: "Failed to upload audio. Please try again." };
+  }
+
+  await updateEntity(audioUrl, id);
+
+  revalidatePath("/review");
+  return { error: null };
+}
+
+/**
+ * Uploads an audio file to replace a flagged word's TTS audio.
+ */
+export async function uploadWordAudioAction(
+  params: { entityId: string },
+  formData: FormData,
+): Promise<{ error: string | null }> {
+  return uploadEntityAudio({
+    entityId: params.entityId,
+    entityType: "word",
+    formData,
+    updateEntity: (audioUrl, id) => prisma.word.update({ data: { audioUrl }, where: { id } }),
+  });
+}
+
+/**
+ * Uploads an audio file to replace a flagged sentence's TTS audio.
+ */
+export async function uploadSentenceAudioAction(
+  params: { entityId: string },
+  formData: FormData,
+): Promise<{ error: string | null }> {
+  return uploadEntityAudio({
+    entityId: params.entityId,
+    entityType: "sentence",
+    formData,
+    updateEntity: (audioUrl, id) => prisma.sentence.update({ data: { audioUrl }, where: { id } }),
+  });
+}

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/audio-edit.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/audio-edit.tsx
@@ -29,11 +29,14 @@ export function AudioEdit({
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [currentAudioUrl, setCurrentAudioUrl] = useState(item.audioUrl);
+  const blobUrlRef = useRef<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    if (!file) {return;}
+    if (!file) {
+      return;
+    }
 
     setError(null);
 
@@ -46,7 +49,13 @@ export function AudioEdit({
       if (result.error) {
         setError(result.error);
       } else {
-        setCurrentAudioUrl(URL.createObjectURL(file));
+        if (blobUrlRef.current) {
+          URL.revokeObjectURL(blobUrlRef.current);
+        }
+
+        const newUrl = URL.createObjectURL(file);
+        blobUrlRef.current = newUrl;
+        setCurrentAudioUrl(newUrl);
       }
 
       if (fileInputRef.current) {

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/audio-edit.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/audio-edit.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { PlayAudioInline } from "@/app/(private)/review/_components/play-audio-inline";
+import { Badge } from "@zoonk/ui/components/badge";
+import { Button } from "@zoonk/ui/components/button";
+import { DEFAULT_AUDIO_ACCEPTED_TYPES } from "@zoonk/utils/upload";
+import { Loader2Icon, UploadIcon } from "lucide-react";
+import { useRef, useState, useTransition } from "react";
+
+type UploadAction = (
+  params: { entityId: string },
+  formData: FormData,
+) => Promise<{ error: string | null }>;
+
+export function AudioEdit({
+  item,
+  uploadAction,
+}: {
+  item: {
+    id: string;
+    text: string;
+    label: string;
+    audioUrl: string | null;
+    targetLanguage: string;
+    romanization: string | null;
+  };
+  uploadAction: UploadAction;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [currentAudioUrl, setCurrentAudioUrl] = useState(item.audioUrl);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {return;}
+
+    setError(null);
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    startTransition(async () => {
+      const result = await uploadAction({ entityId: item.id }, formData);
+
+      if (result.error) {
+        setError(result.error);
+      } else {
+        setCurrentAudioUrl(URL.createObjectURL(file));
+      }
+
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <Badge variant="outline">{item.label}</Badge>
+        <span className="text-muted-foreground text-sm">{item.targetLanguage}</span>
+      </div>
+
+      <p className="text-2xl font-semibold">{item.text}</p>
+
+      {item.romanization && <p className="text-muted-foreground text-sm">{item.romanization}</p>}
+
+      {currentAudioUrl && (
+        <div className="flex justify-center py-4">
+          <PlayAudioInline audioUrl={currentAudioUrl} />
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <label className="relative">
+          <input
+            ref={fileInputRef}
+            accept={DEFAULT_AUDIO_ACCEPTED_TYPES.join(",")}
+            className="sr-only"
+            disabled={isPending}
+            onChange={handleUpload}
+            type="file"
+          />
+
+          <Button
+            disabled={isPending}
+            type="button"
+            variant="outline"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            {isPending ? (
+              <Loader2Icon className="size-4 animate-spin" />
+            ) : (
+              <UploadIcon className="size-4" />
+            )}
+            Upload replacement audio
+          </Button>
+        </label>
+
+        {error && <p className="text-destructive text-sm">{error}</p>}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/flagged-item-content.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/flagged-item-content.tsx
@@ -1,10 +1,61 @@
-import { getCourseSuggestionReview, getStepVisualReview } from "@/data/review/get-review-item";
+import {
+  getCourseSuggestionReview,
+  getSentenceAudioReview,
+  getStepVisualReview,
+  getWordAudioReview,
+} from "@/data/review/get-review-item";
 import { type ReviewTaskType, getVisualKindFromTaskType } from "@/lib/review-utils";
 import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { notFound } from "next/navigation";
+import { uploadSentenceAudioAction, uploadWordAudioAction } from "./_actions/upload-audio";
+import { AudioEdit } from "./audio-edit";
 import { CourseSuggestionEdit } from "./course-suggestion-edit";
 import { StepSelectImageEdit } from "./step-select-image-edit";
 import { StepVisualImageEdit } from "./step-visual-image-edit";
+
+async function renderWordAudio(entityId: bigint) {
+  const item = await getWordAudioReview(entityId);
+
+  if (!item) {
+    notFound();
+  }
+
+  return (
+    <AudioEdit
+      item={{
+        audioUrl: item.audioUrl,
+        id: item.id.toString(),
+        label: "word",
+        romanization: item.romanization,
+        targetLanguage: item.targetLanguage,
+        text: item.word,
+      }}
+      uploadAction={uploadWordAudioAction}
+    />
+  );
+}
+
+async function renderSentenceAudio(entityId: bigint) {
+  const item = await getSentenceAudioReview(entityId);
+
+  if (!item) {
+    notFound();
+  }
+
+  return (
+    <AudioEdit
+      item={{
+        audioUrl: item.audioUrl,
+        id: item.id.toString(),
+        label: "sentence",
+        romanization: item.romanization,
+        targetLanguage: item.targetLanguage,
+        text: item.sentence,
+      }}
+      uploadAction={uploadSentenceAudioAction}
+    />
+  );
+}
 
 export async function FlaggedItemContent({
   taskType,
@@ -56,6 +107,14 @@ export async function FlaggedItemContent({
     }
 
     return <CourseSuggestionEdit item={item} />;
+  }
+
+  if (taskType === "wordAudio") {
+    return renderWordAudio(entityId);
+  }
+
+  if (taskType === "sentenceAudio") {
+    return renderSentenceAudio(entityId);
   }
 
   notFound();

--- a/apps/admin/src/app/(private)/review/[group]/[task]/review-queue.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/review-queue.tsx
@@ -1,8 +1,14 @@
 import { getNextReviewItem } from "@/data/review/get-next-review-item";
-import { getCourseSuggestionReview, getStepVisualReview } from "@/data/review/get-review-item";
+import {
+  getCourseSuggestionReview,
+  getSentenceAudioReview,
+  getStepVisualReview,
+  getWordAudioReview,
+} from "@/data/review/get-review-item";
 import { type ReviewTaskType, getTaskPath, getVisualKindFromTaskType } from "@/lib/review-utils";
 import { parseBigIntId } from "@zoonk/utils/number";
 import { redirect } from "next/navigation";
+import { AudioReview } from "../../_components/content/audio-review";
 import { CourseSuggestionReview } from "../../_components/content/course-suggestion-review";
 import { StepSelectImageReview } from "../../_components/content/step-select-image-review";
 import { StepVisualImageReview } from "../../_components/content/step-visual-image-review";
@@ -32,6 +38,16 @@ async function renderContent(taskType: ReviewTaskType, entityId: bigint) {
       return null;
     }
     return <StepSelectImageReview item={item} />;
+  }
+
+  if (taskType === "wordAudio") {
+    const item = await getWordAudioReview(entityId);
+    return item ? <AudioReview item={{ ...item, label: "word", text: item.word }} /> : null;
+  }
+
+  if (taskType === "sentenceAudio") {
+    const item = await getSentenceAudioReview(entityId);
+    return item ? <AudioReview item={{ ...item, label: "sentence", text: item.sentence }} /> : null;
   }
 
   return null;

--- a/apps/admin/src/app/(private)/review/_components/content/audio-review.tsx
+++ b/apps/admin/src/app/(private)/review/_components/content/audio-review.tsx
@@ -1,0 +1,34 @@
+import { Badge } from "@zoonk/ui/components/badge";
+import { PlayAudioInline } from "../play-audio-inline";
+
+export function AudioReview({
+  item,
+}: {
+  item: {
+    id: bigint;
+    text: string;
+    label: string;
+    audioUrl: string | null;
+    targetLanguage: string;
+    romanization: string | null;
+  };
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <Badge variant="outline">{item.label}</Badge>
+        <span className="text-muted-foreground text-sm">{item.targetLanguage}</span>
+      </div>
+
+      <p className="text-2xl font-semibold">{item.text}</p>
+
+      {item.romanization && <p className="text-muted-foreground text-sm">{item.romanization}</p>}
+
+      {item.audioUrl && (
+        <div className="flex justify-center py-4">
+          <PlayAudioInline audioUrl={item.audioUrl} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/review/_components/play-audio-inline.tsx
+++ b/apps/admin/src/app/(private)/review/_components/play-audio-inline.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { PauseIcon, Volume2Icon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Simple audio playback button for the admin review interface.
+ * Uses native Audio API — no preloading or caching needed since
+ * admin reviews one item at a time.
+ */
+export function PlayAudioInline({ audioUrl }: { audioUrl: string }) {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const getAudio = useCallback(() => {
+    if (!audioRef.current) {
+      const audio = new Audio(audioUrl);
+      audio.addEventListener("ended", () => setIsPlaying(false));
+      audioRef.current = audio;
+    }
+
+    return audioRef.current;
+  }, [audioUrl]);
+
+  useEffect(
+    () => () => {
+      audioRef.current?.pause();
+      audioRef.current = null;
+    },
+    [audioUrl],
+  );
+
+  const handleClick = () => {
+    const audio = getAudio();
+
+    if (isPlaying) {
+      audio.pause();
+      setIsPlaying(false);
+    } else {
+      void audio.play();
+      setIsPlaying(true);
+    }
+  };
+
+  const Icon = isPlaying ? PauseIcon : Volume2Icon;
+  const label = isPlaying ? "Pause audio" : "Play audio";
+
+  return (
+    <button
+      aria-label={label}
+      className="bg-primary text-primary-foreground hover:bg-primary/90 flex size-14 items-center justify-center rounded-full transition-all duration-150 hover:scale-105 active:scale-95"
+      onClick={handleClick}
+      type="button"
+    >
+      <Icon className="size-6" />
+    </button>
+  );
+}

--- a/apps/admin/src/app/(private)/review/_components/play-audio-inline.tsx
+++ b/apps/admin/src/app/(private)/review/_components/play-audio-inline.tsx
@@ -26,6 +26,7 @@ export function PlayAudioInline({ audioUrl }: { audioUrl: string }) {
     () => () => {
       audioRef.current?.pause();
       audioRef.current = null;
+      setIsPlaying(false);
     },
     [audioUrl],
   );

--- a/apps/admin/src/data/review/count-pending-reviews.ts
+++ b/apps/admin/src/data/review/count-pending-reviews.ts
@@ -31,6 +31,26 @@ function countPendingStepVisual(kind: string, excludeIds: bigint[]): Promise<num
   });
 }
 
+function countPendingWordAudio(excludeIds: bigint[]): Promise<number> {
+  return prisma.word.count({
+    where: {
+      NOT: { id: { in: excludeIds } },
+      audioUrl: { not: null },
+      organization: { slug: AI_ORG_SLUG },
+    },
+  });
+}
+
+function countPendingSentenceAudio(excludeIds: bigint[]): Promise<number> {
+  return prisma.sentence.count({
+    where: {
+      NOT: { id: { in: excludeIds } },
+      audioUrl: { not: null },
+      organization: { slug: AI_ORG_SLUG },
+    },
+  });
+}
+
 export const countPendingForTask = cache(async function countPendingForTask(
   taskType: ReviewTaskType,
 ): Promise<number> {
@@ -58,6 +78,14 @@ export const countPendingForTask = cache(async function countPendingForTask(
         kind: "selectImage",
       },
     });
+  }
+
+  if (taskType === "wordAudio") {
+    return countPendingWordAudio(excludeIds);
+  }
+
+  if (taskType === "sentenceAudio") {
+    return countPendingSentenceAudio(excludeIds);
   }
 
   return 0;

--- a/apps/admin/src/data/review/get-next-review-item.ts
+++ b/apps/admin/src/data/review/get-next-review-item.ts
@@ -54,6 +54,40 @@ async function getNextStepVisualByKind(
   return { entityId: next?.id ?? null, remaining };
 }
 
+async function getNextWordAudio(): Promise<ReviewQueueResult> {
+  const excludeIds = await reviewedEntityIds("wordAudio");
+
+  const where = {
+    NOT: { id: { in: excludeIds } },
+    audioUrl: { not: null },
+    organization: { slug: AI_ORG_SLUG },
+  };
+
+  const [next, remaining] = await Promise.all([
+    prisma.word.findFirst({ orderBy: { createdAt: "asc" }, select: { id: true }, where }),
+    prisma.word.count({ where }),
+  ]);
+
+  return { entityId: next?.id ?? null, remaining };
+}
+
+async function getNextSentenceAudio(): Promise<ReviewQueueResult> {
+  const excludeIds = await reviewedEntityIds("sentenceAudio");
+
+  const where = {
+    NOT: { id: { in: excludeIds } },
+    audioUrl: { not: null },
+    organization: { slug: AI_ORG_SLUG },
+  };
+
+  const [next, remaining] = await Promise.all([
+    prisma.sentence.findFirst({ orderBy: { createdAt: "asc" }, select: { id: true }, where }),
+    prisma.sentence.count({ where }),
+  ]);
+
+  return { entityId: next?.id ?? null, remaining };
+}
+
 async function getNextStepSelectImage(): Promise<ReviewQueueResult> {
   const excludeIds = await reviewedEntityIds("stepSelectImage");
 
@@ -90,6 +124,14 @@ export const getNextReviewItem = cache(async function getNextReviewItem(
 
   if (taskType === "stepSelectImage") {
     return getNextStepSelectImage();
+  }
+
+  if (taskType === "wordAudio") {
+    return getNextWordAudio();
+  }
+
+  if (taskType === "sentenceAudio") {
+    return getNextSentenceAudio();
   }
 
   return EMPTY_RESULT;

--- a/apps/admin/src/data/review/get-review-item.ts
+++ b/apps/admin/src/data/review/get-review-item.ts
@@ -31,3 +31,21 @@ export const getStepVisualReview = cache(async function getStepVisualReview(enti
     where: { id: entityId },
   });
 });
+
+export const getWordAudioReview = cache(async function getWordAudioReview(entityId: bigint) {
+  if (!(await isAdmin())) {
+    return null;
+  }
+
+  return prisma.word.findUnique({ where: { id: entityId } });
+});
+
+export const getSentenceAudioReview = cache(async function getSentenceAudioReview(
+  entityId: bigint,
+) {
+  if (!(await isAdmin())) {
+    return null;
+  }
+
+  return prisma.sentence.findUnique({ where: { id: entityId } });
+});

--- a/apps/admin/src/lib/review-utils.ts
+++ b/apps/admin/src/lib/review-utils.ts
@@ -1,12 +1,22 @@
-type ReviewGroup = "text" | "image";
+type ReviewGroup = "text" | "image" | "audio";
 
-type ReviewTaskType = "courseSuggestions" | "stepVisualImage" | "stepSelectImage";
+type ReviewTaskType =
+  | "courseSuggestions"
+  | "sentenceAudio"
+  | "stepSelectImage"
+  | "stepVisualImage"
+  | "wordAudio";
 
 const REVIEW_TASKS: Record<ReviewTaskType, { group: ReviewGroup; label: string; path: string }> = {
   courseSuggestions: {
     group: "text",
     label: "Course Suggestions",
     path: "/review/text/course-suggestions",
+  },
+  sentenceAudio: {
+    group: "audio",
+    label: "Sentence Audio",
+    path: "/review/audio/sentence-audio",
   },
   stepSelectImage: {
     group: "image",
@@ -17,6 +27,11 @@ const REVIEW_TASKS: Record<ReviewTaskType, { group: ReviewGroup; label: string; 
     group: "image",
     label: "Visual Images",
     path: "/review/image/step-visual-image",
+  },
+  wordAudio: {
+    group: "audio",
+    label: "Word Audio",
+    path: "/review/audio/word-audio",
   },
 };
 
@@ -91,6 +106,7 @@ function getVisualKindFromTaskType(taskType: string): string | null {
 const REVIEW_GROUPS: { group: ReviewGroup; label: string }[] = [
   { group: "text", label: "Text" },
   { group: "image", label: "Image" },
+  { group: "audio", label: "Audio" },
 ];
 
 export {

--- a/packages/utils/src/upload.ts
+++ b/packages/utils/src/upload.ts
@@ -4,3 +4,7 @@ const DEFAULT_IMAGE_MAX_SIZE_MB = 5;
 export const DEFAULT_IMAGE_MAX_SIZE = DEFAULT_IMAGE_MAX_SIZE_MB * BYTES_PER_MB;
 export const DEFAULT_IMAGE_QUALITY = 80;
 export const DEFAULT_IMAGE_ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+
+const DEFAULT_AUDIO_MAX_SIZE_MB = 10;
+export const DEFAULT_AUDIO_MAX_SIZE = DEFAULT_AUDIO_MAX_SIZE_MB * BYTES_PER_MB;
+export const DEFAULT_AUDIO_ACCEPTED_TYPES = ["audio/wav", "audio/ogg", "audio/mpeg", "audio/opus"];


### PR DESCRIPTION
## Summary

- Add "Audio" review group with `wordAudio` and `sentenceAudio` task types to the admin content review system
- Admins can play AI-generated TTS audio, approve/reject it, and upload replacement audio files for flagged items
- Unified `AudioReview` and `AudioEdit` components handle both words and sentences via props

## Test plan

- [ ] Navigate to `/review` and verify the new "Audio" section appears with "Word Audio" and "Sentence Audio" categories
- [ ] Open the word audio queue, verify play button works and approve/reject flow functions
- [ ] Flag a word audio item, verify the flagged edit page shows playback and file upload
- [ ] Upload a replacement audio file and verify it updates the playback
- [ ] Repeat for sentence audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Audio review group to the admin review system for words and sentences. Admins can play TTS audio, approve/reject it, and upload replacement files for flagged items; playback state and blob URLs are cleaned up when audio changes.

- **New Features**
  - Added "Audio" group with `wordAudio` and `sentenceAudio` queues in `/review`.
  - Inline playback via a new player button; approve/reject wired into the existing flow.
  - Flagged edit view supports uploading replacement audio; validates type (`wav`, `ogg`, `mp3`, `opus`) and size (≤10MB), uploads via `@zoonk/core/audio/upload`, updates the entity, revalidates `/review`, updates the preview, and revokes old blob URLs.
  - Data layer and utils updated for audio: pending counts, next-item selection, item fetchers, `review-utils` routes/labels, and new defaults in `@zoonk/utils/upload`.

<sup>Written for commit d5a00b849cda5c94370a061aaf30fbeb299f014d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

