### PR TITLE
refactor(editor): replace isRecord with isJsonObject from utils

### DIFF
--- a/apps/api/src/workflows/_test-utils/parse-stream-events.ts
+++ b/apps/api/src/workflows/_test-utils/parse-stream-events.ts
@@ -1,10 +1,4 @@
-/**
- * Type guard that checks if a value is a non-null object (Record-like).
- * Used to safely narrow `unknown` from JSON.parse into Record<string, unknown>.
- */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
+import { isJsonObject } from "@zoonk/utils/json";
 
 /**
  * Safely parses a JSON string into a Record<string, unknown>.
@@ -12,7 +6,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  */
 function parseEvent(raw: unknown): Record<string, unknown> {
   const parsed: unknown = JSON.parse(String(raw).replace("data: ", "").trim());
-  return isRecord(parsed) ? parsed : {};
+  return isJsonObject(parsed) ? parsed : {};
 }
 
 /**

--- a/apps/editor/src/data/activities/import-activities.ts
+++ b/apps/editor/src/data/activities/import-activities.ts
@@ -2,10 +2,10 @@ import "server-only";
 import { ErrorCode } from "@/lib/app-error";
 import { type ImportMode } from "@/lib/import-mode";
 import { parseJsonFile } from "@/lib/parse-json-file";
-import { isRecord } from "@/lib/validation";
 import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
 import { type Activity, type ActivityKind, type TransactionClient, prisma } from "@zoonk/db";
 import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { isJsonObject } from "@zoonk/utils/json";
 
 const validActivityKinds = new Set<ActivityKind>([
   "custom",
@@ -33,7 +33,7 @@ function isActivityKind(value: string): value is ActivityKind {
 }
 
 function validateActivityData(activity: unknown): activity is ActivityImportData {
-  if (!isRecord(activity)) {
+  if (!isJsonObject(activity)) {
     return false;
   }
 
@@ -45,7 +45,7 @@ function validateActivityData(activity: unknown): activity is ActivityImportData
 function validateImportData(data: unknown): data is {
   activities: ActivityImportData[];
 } {
-  if (!isRecord(data)) {
+  if (!isJsonObject(data)) {
     return false;
   }
 

--- a/apps/editor/src/data/alternative-titles/import-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/import-alternative-titles.ts
@@ -2,9 +2,9 @@ import "server-only";
 import { ErrorCode } from "@/lib/app-error";
 import { type ImportMode } from "@/lib/import-mode";
 import { parseJsonFile } from "@/lib/parse-json-file";
-import { isRecord } from "@/lib/validation";
 import { prisma } from "@zoonk/db";
 import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { isJsonObject } from "@zoonk/utils/json";
 import { toSlug } from "@zoonk/utils/string";
 
 function validateTitleData(title: unknown): title is string {
@@ -14,7 +14,7 @@ function validateTitleData(title: unknown): title is string {
 function validateImportData(data: unknown): data is {
   alternativeTitles: string[];
 } {
-  if (!isRecord(data)) {
+  if (!isJsonObject(data)) {
     return false;
   }
 

--- a/apps/editor/src/data/chapters/import-chapters.ts
+++ b/apps/editor/src/data/chapters/import-chapters.ts
@@ -3,10 +3,10 @@ import { ErrorCode } from "@/lib/app-error";
 import { type ImportMode } from "@/lib/import-mode";
 import { deduplicateImportSlugs, resolveImportSlug } from "@/lib/import-slug";
 import { parseJsonFile } from "@/lib/parse-json-file";
-import { isRecord } from "@/lib/validation";
 import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
 import { type Chapter, type TransactionClient, prisma } from "@zoonk/db";
 import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { isJsonObject } from "@zoonk/utils/json";
 import { normalizeString, toSlug } from "@zoonk/utils/string";
 
 type ChapterImportData = {
@@ -16,7 +16,7 @@ type ChapterImportData = {
 };
 
 function validateChapterData(chapter: unknown): chapter is ChapterImportData {
-  if (!isRecord(chapter)) {
+  if (!isJsonObject(chapter)) {
     return false;
   }
 
@@ -29,7 +29,7 @@ function validateChapterData(chapter: unknown): chapter is ChapterImportData {
 function validateImportData(data: unknown): data is {
   chapters: ChapterImportData[];
 } {
-  if (!isRecord(data)) {
+  if (!isJsonObject(data)) {
     return false;
   }
 

--- a/apps/editor/src/data/lessons/import-lessons.ts
+++ b/apps/editor/src/data/lessons/import-lessons.ts
@@ -4,10 +4,10 @@ import { type ImportMode } from "@/lib/import-mode";
 import { deduplicateImportSlugs, resolveImportSlug } from "@/lib/import-slug";
 import { getLessonKind } from "@/lib/lesson-kind";
 import { parseJsonFile } from "@/lib/parse-json-file";
-import { isRecord } from "@/lib/validation";
 import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
 import { type Lesson, type LessonKind, type TransactionClient, prisma } from "@zoonk/db";
 import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { isJsonObject } from "@zoonk/utils/json";
 import { normalizeString, toSlug } from "@zoonk/utils/string";
 
 type LessonImportData = {
@@ -17,7 +17,7 @@ type LessonImportData = {
 };
 
 function validateLessonData(lesson: unknown): lesson is LessonImportData {
-  if (!isRecord(lesson)) {
+  if (!isJsonObject(lesson)) {
     return false;
   }
 
@@ -30,7 +30,7 @@ function validateLessonData(lesson: unknown): lesson is LessonImportData {
 function validateImportData(data: unknown): data is {
   lessons: LessonImportData[];
 } {
-  if (!isRecord(data)) {
+  if (!isJsonObject(data)) {
     return false;
   }
 

--- a/apps/editor/src/lib/validation.ts
+++ b/apps/editor/src/lib/validation.ts
@@ -1,3 +1,0 @@
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}


### PR DESCRIPTION
## Summary
- Replace duplicate `isRecord` functions with existing `isJsonObject` from `@zoonk/utils/json`
- Delete `apps/editor/src/lib/validation.ts` (only contained `isRecord`)
- Update imports in editor import files and API test utils

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced duplicated isRecord checks with `isJsonObject` from `@zoonk/utils/json` across editor imports and API test utilities. This standardizes JSON validation and removes dead code with no behavior change.

- **Refactors**
  - Swapped isRecord for `isJsonObject` in editor import modules and the SSE test parser.
  - Removed `apps/editor/src/lib/validation.ts` (duplicate helper).

<sup>Written for commit f319832526e64684eabac0f0bd0c3dd3bb212e48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

