### PR TITLE
feat(ai): improve sentence explanations with cross-language contrasts

### DIFF
--- a/apps/api/src/workflows/activity-generation/kinds/reading-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/reading-workflow.test.ts
@@ -13,7 +13,7 @@ vi.mock("../steps/generate-reading-content-step", () => ({
   generateReadingContentStep: vi.fn().mockResolvedValue({
     sentences: [
       {
-        explanation: null,
+        explanation: "test explanation",
         sentence: "Guten Morgen, Lara.",
         translation: "Bom dia, Lara.",
       },
@@ -111,7 +111,7 @@ describe(readingActivityWorkflow, () => {
     );
     expect(generateSentenceDistractorsStep).toHaveBeenCalledWith(activities, [
       {
-        explanation: null,
+        explanation: "test explanation",
         sentence: "Guten Morgen, Lara.",
         translation: "Bom dia, Lara.",
       },
@@ -120,7 +120,7 @@ describe(readingActivityWorkflow, () => {
       activities,
       [
         {
-          explanation: null,
+          explanation: "test explanation",
           sentence: "Guten Morgen, Lara.",
           translation: "Bom dia, Lara.",
         },
@@ -155,7 +155,7 @@ describe(readingActivityWorkflow, () => {
       sentenceRomanizations: { "Guten Morgen, Lara.": null },
       sentences: [
         {
-          explanation: null,
+          explanation: "test explanation",
           sentence: "Guten Morgen, Lara.",
           translation: "Bom dia, Lara.",
         },

--- a/apps/api/src/workflows/activity-generation/steps/_utils/save-reading-target-words.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/save-reading-target-words.test.ts
@@ -61,7 +61,7 @@ describe(saveReadingTargetWords, () => {
       lessonId: lesson.id,
       organizationId: organization.id,
       pronunciations: {},
-      sentences: [{ explanation: null, sentence: "... !!!", translation: "" }],
+      sentences: [{ explanation: "test explanation", sentence: "... !!!", translation: "" }],
       targetLanguage: "de",
       userLanguage: "en",
       wordAudioUrls: {},
@@ -185,7 +185,7 @@ describe(saveReadingTargetWords, () => {
       pronunciations: {},
       sentences: [
         {
-          explanation: null,
+          explanation: "test explanation",
           sentence: `${translatedWord} ${untranslatedWord}`,
           translation: "pretty cat",
         },
@@ -219,7 +219,7 @@ describe(saveReadingTargetWords, () => {
       pronunciations: {
         [canonicalWord]: `${canonicalWord}-pron`,
       },
-      sentences: [{ explanation: null, sentence: canonicalWord, translation: "cat" }],
+      sentences: [{ explanation: "test explanation", sentence: canonicalWord, translation: "cat" }],
       targetLanguage: "de",
       userLanguage: "en",
       wordAudioUrls: {
@@ -287,7 +287,9 @@ describe(saveReadingTargetWords, () => {
       lessonId: lesson.id,
       organizationId: organization.id,
       pronunciations: {},
-      sentences: [{ explanation: null, sentence: canonicalWord, translation: "hello" }],
+      sentences: [
+        { explanation: "test explanation", sentence: canonicalWord, translation: "hello" },
+      ],
       targetLanguage: "de",
       userLanguage: "en",
       wordAudioUrls: {},
@@ -360,7 +362,7 @@ describe(saveReadingTargetWords, () => {
       pronunciations: {
         [lowercaseWord]: `${lowercaseWord}-pron`,
       },
-      sentences: [{ explanation: null, sentence: lowercaseWord, translation: "cat" }],
+      sentences: [{ explanation: "test explanation", sentence: lowercaseWord, translation: "cat" }],
       targetLanguage: "de",
       userLanguage: "en",
       wordAudioUrls: {},
@@ -415,7 +417,9 @@ describe(saveReadingTargetWords, () => {
       pronunciations: {
         [lowercaseDistractor]: `${lowercaseDistractor}-pron`,
       },
-      sentences: [{ explanation: null, sentence: canonicalWord, translation: "hello" }],
+      sentences: [
+        { explanation: "test explanation", sentence: canonicalWord, translation: "hello" },
+      ],
       targetLanguage: "de",
       userLanguage: "en",
       wordAudioUrls: {},
@@ -481,7 +485,9 @@ describe(saveReadingTargetWords, () => {
       lessonId: lesson.id,
       organizationId: organization.id,
       pronunciations: {},
-      sentences: [{ explanation: null, sentence: canonicalWord, translation: "hello" }],
+      sentences: [
+        { explanation: "test explanation", sentence: canonicalWord, translation: "hello" },
+      ],
       targetLanguage: "de",
       userLanguage: "en",
       wordAudioUrls: {},

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.test.ts
@@ -70,7 +70,11 @@ describe(generateReadingAudioStep, () => {
     const id = randomUUID().slice(0, 8);
 
     const sentences = [
-      { explanation: null, sentence: `Guten Morgen ${id}`, translation: `Good morning ${id}` },
+      {
+        explanation: "test explanation",
+        sentence: `Guten Morgen ${id}`,
+        translation: `Good morning ${id}`,
+      },
     ];
 
     const result = await generateReadingAudioStep(activities, sentences);
@@ -125,7 +129,9 @@ describe(generateReadingAudioStep, () => {
 
     const activities = await fetchLessonActivities(lesson.id);
 
-    const sentences = [{ explanation: null, sentence: sentenceText, translation: "Good day" }];
+    const sentences = [
+      { explanation: "test explanation", sentence: sentenceText, translation: "Good day" },
+    ];
 
     const result = await generateReadingAudioStep(activities, sentences);
 
@@ -160,7 +166,7 @@ describe(generateReadingAudioStep, () => {
     const activities = await fetchLessonActivities(lesson.id);
 
     const result = await generateReadingAudioStep(activities, [
-      { explanation: null, sentence: "test", translation: "test" },
+      { explanation: "test explanation", sentence: "test", translation: "test" },
     ]);
 
     expect(result).toEqual({ sentenceAudioUrls: {} });
@@ -228,8 +234,16 @@ describe(generateReadingAudioStep, () => {
     const id = randomUUID().slice(0, 8);
 
     const sentences = [
-      { explanation: null, sentence: `Guten Morgen ${id}`, translation: `Good morning ${id}` },
-      { explanation: null, sentence: `Gute Nacht ${id}`, translation: `Good night ${id}` },
+      {
+        explanation: "test explanation",
+        sentence: `Guten Morgen ${id}`,
+        translation: `Good morning ${id}`,
+      },
+      {
+        explanation: "test explanation",
+        sentence: `Gute Nacht ${id}`,
+        translation: `Good night ${id}`,
+      },
     ];
 
     vi.mocked(generateLanguageAudio)
@@ -270,7 +284,7 @@ describe(generateReadingAudioStep, () => {
     const activities = await fetchLessonActivities(lesson.id);
 
     const result = await generateReadingAudioStep(activities, [
-      { explanation: null, sentence: "test", translation: "test" },
+      { explanation: "test explanation", sentence: "test", translation: "test" },
     ]);
 
     expect(result).toEqual({ sentenceAudioUrls: {} });

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-content-step.test.ts
@@ -28,7 +28,7 @@ vi.mock("@zoonk/ai/tasks/activities/language/sentences", () => ({
     data: {
       sentences: [
         {
-          explanation: null,
+          explanation: "test explanation",
           sentence: "Guten Morgen",
           translation: "Good morning",
         },
@@ -93,7 +93,7 @@ describe(generateReadingContentStep, () => {
 
     expect(result.sentences).toEqual([
       {
-        explanation: null,
+        explanation: "test explanation",
         sentence: "Guten Morgen",
         translation: "Good morning",
       },

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-romanization-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-romanization-step.test.ts
@@ -70,7 +70,11 @@ describe(generateReadingRomanizationStep, () => {
     const id = randomUUID().slice(0, 8);
 
     const sentences = [
-      { explanation: null, sentence: `これは猫です-${id}`, translation: `This is a cat ${id}` },
+      {
+        explanation: "test explanation",
+        sentence: `これは猫です-${id}`,
+        translation: `This is a cat ${id}`,
+      },
     ];
 
     const result = await generateReadingRomanizationStep(activities, sentences);
@@ -123,7 +127,7 @@ describe(generateReadingRomanizationStep, () => {
     const activities = await fetchLessonActivities(lesson.id);
 
     const result = await generateReadingRomanizationStep(activities, [
-      { explanation: null, sentence: "Guten Morgen", translation: "Good morning" },
+      { explanation: "test explanation", sentence: "Guten Morgen", translation: "Good morning" },
     ]);
 
     expect(result).toEqual({ romanizations: {} });
@@ -158,7 +162,7 @@ describe(generateReadingRomanizationStep, () => {
     const activities = await fetchLessonActivities(lesson.id);
 
     const result = await generateReadingRomanizationStep(activities, [
-      { explanation: null, sentence: "これは猫です", translation: "This is a cat" },
+      { explanation: "test explanation", sentence: "これは猫です", translation: "This is a cat" },
     ]);
 
     expect(result).toEqual({ romanizations: {} });
@@ -195,7 +199,7 @@ describe(generateReadingRomanizationStep, () => {
     const activities = await fetchLessonActivities(lesson.id);
 
     const result = await generateReadingRomanizationStep(activities, [
-      { explanation: null, sentence: "これは猫です", translation: "This is a cat" },
+      { explanation: "test explanation", sentence: "これは猫です", translation: "This is a cat" },
     ]);
 
     expect(result).toEqual({ romanizations: {} });
@@ -239,8 +243,8 @@ describe(generateReadingRomanizationStep, () => {
     const activities = await fetchLessonActivities(lesson.id);
 
     const sentences = [
-      { explanation: null, sentence: "これは猫です", translation: "This is a cat" },
-      { explanation: null, sentence: "あれは犬です", translation: "That is a dog" },
+      { explanation: "test explanation", sentence: "これは猫です", translation: "This is a cat" },
+      { explanation: "test explanation", sentence: "あれは犬です", translation: "That is a dog" },
     ];
 
     const result = await generateReadingRomanizationStep(activities, sentences);

--- a/apps/api/src/workflows/activity-generation/steps/generate-sentence-distractors-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-sentence-distractors-step.test.ts
@@ -70,7 +70,11 @@ describe(generateSentenceDistractorsStep, () => {
     const id = randomUUID().slice(0, 8);
 
     const sentences = [
-      { explanation: null, sentence: `Guten Morgen ${id}`, translation: `Good morning ${id}` },
+      {
+        explanation: "test explanation",
+        sentence: `Guten Morgen ${id}`,
+        translation: `Good morning ${id}`,
+      },
     ];
 
     const result = await generateSentenceDistractorsStep(activities, sentences);
@@ -115,7 +119,7 @@ describe(generateSentenceDistractorsStep, () => {
     const activities = await fetchLessonActivities(lesson.id);
 
     const result = await generateSentenceDistractorsStep(activities, [
-      { explanation: null, sentence: "test", translation: "test" },
+      { explanation: "test explanation", sentence: "test", translation: "test" },
     ]);
 
     expect(result).toEqual({ distractors: {}, translationDistractors: {} });
@@ -143,7 +147,11 @@ describe(generateSentenceDistractorsStep, () => {
     const id = randomUUID().slice(0, 8);
 
     const sentences = [
-      { explanation: null, sentence: `Guten Morgen ${id}`, translation: `Good morning ${id}` },
+      {
+        explanation: "test explanation",
+        sentence: `Guten Morgen ${id}`,
+        translation: `Good morning ${id}`,
+      },
     ];
 
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test mock doesn't need full AI SDK return shape

--- a/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-metadata-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-metadata-step.test.ts
@@ -79,7 +79,11 @@ describe(generateSentenceWordMetadataStep, () => {
     const id = randomUUID().slice(0, 8);
 
     const sentences = [
-      { explanation: null, sentence: `Guten${id} Morgen${id}`, translation: "Good morning" },
+      {
+        explanation: "test explanation",
+        sentence: `Guten${id} Morgen${id}`,
+        translation: "Good morning",
+      },
     ];
 
     const targetWords = [`guten${id}`, `morgen${id}`];
@@ -132,7 +136,9 @@ describe(generateSentenceWordMetadataStep, () => {
     const activities = await fetchLessonActivities(lesson.id);
     const id = randomUUID().slice(0, 8);
 
-    const sentences = [{ explanation: null, sentence: `猫${id} 犬${id}`, translation: "Cat dog" }];
+    const sentences = [
+      { explanation: "test explanation", sentence: `猫${id} 犬${id}`, translation: "Cat dog" },
+    ];
 
     const targetWords = [`猫${id}`, `犬${id}`];
 
@@ -184,7 +190,7 @@ describe(generateSentenceWordMetadataStep, () => {
 
     const result = await generateSentenceWordMetadataStep(
       activities,
-      [{ explanation: null, sentence: "Hallo", translation: "Hello" }],
+      [{ explanation: "test explanation", sentence: "Hallo", translation: "Hello" }],
       ["hallo"],
     );
 
@@ -255,7 +261,11 @@ describe(generateSentenceWordMetadataStep, () => {
     const id = randomUUID().slice(0, 8);
 
     const sentences = [
-      { explanation: null, sentence: `Hallo${id} Welt${id}`, translation: "Hello World" },
+      {
+        explanation: "test explanation",
+        sentence: `Hallo${id} Welt${id}`,
+        translation: "Hello World",
+      },
     ];
 
     const result = await generateSentenceWordMetadataStep(activities, sentences, [

--- a/apps/api/src/workflows/activity-generation/steps/save-reading-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-reading-activity-step.test.ts
@@ -235,7 +235,7 @@ describe(saveReadingActivityStep, () => {
       sentenceRomanizations: {},
       sentences: [
         {
-          explanation: null,
+          explanation: "test explanation",
           sentence: `${translatedWord} ${untranslatedWord}`,
           translation: "pretty cat",
         },
@@ -296,7 +296,7 @@ describe(saveReadingActivityStep, () => {
       sentenceRomanizations: {},
       sentences: [
         {
-          explanation: null,
+          explanation: "test explanation",
           sentence: lowercaseWord,
           translation: "cat",
         },

--- a/packages/ai/src/tasks/activities/language/activity-sentences.prompt.md
+++ b/packages/ai/src/tasks/activities/language/activity-sentences.prompt.md
@@ -101,11 +101,36 @@ For languages with grammatical gender, ensure all agreement is correct throughou
 
 # Explanation
 
-For each sentence, provide a brief explanation (1-2 sentences) of the key grammar or word-order pattern demonstrated. Write the explanation in USER_LANGUAGE (the learner's native language).
+Every sentence MUST have an explanation. Never set it to `null` or leave it empty.
 
-- Focus on patterns that differ from the user's native language (e.g., adjective placement, verb conjugation rules, word order differences)
-- Set to `null` for very simple sentences where the structure is obvious (e.g., single-word greetings, basic "Hello!" sentences)
-- Keep explanations concise and practical — highlight the one thing a learner should notice
+Write the explanation in USER_LANGUAGE (the learner's native language). The explanation should help the learner understand **why this sentence is written this way in the target language** by comparing it with how they would express the same idea in their own language.
+
+## What to Explain
+
+The core question the explanation answers is: **"Why is this sentence structured this way, and how does it differ from what I'd say in my language?"**
+
+Focus on contrasts and potential confusion points between TARGET_LANGUAGE and USER_LANGUAGE:
+
+- **Word order differences**: If the target language places the verb at the end, the adjective after the noun, or the question word in a different position than USER_LANGUAGE, explain why. E.g., "In German, the verb goes to the end in subordinate clauses — unlike in Portuguese, where the verb stays near the subject."
+- **Word choice surprises**: When the target language uses a different word, structure, or concept than the learner would expect. E.g., "German uses 'Wie geht's?' (literally 'How goes it?') — unlike Portuguese, which asks 'Como vai?' (How do you go?)."
+- **Grammar patterns that don't exist in USER_LANGUAGE**: Articles, cases, gendered nouns, verb conjugations, particles, or other structures the learner's language lacks. E.g., "German has formal ('Sie') and informal ('du') versions of 'you' — if you'd use 'você' in Portuguese, use 'Sie' in German for the same level of politeness."
+- **False friends and misleading similarities**: Words that look or sound similar between languages but mean different things or are used differently. E.g., "'Hallo' looks like 'alô' in Portuguese, but 'alô' is only used on the phone — 'Hallo' is a general greeting."
+- **Why this word and not another**: When multiple words could seemingly fit, explain why this specific one is used. E.g., "'Guten Morgen' uses 'Guten' (accusative) because German greetings use an implied 'I wish you a...' construction — you wouldn't say 'Guter Morgen'."
+
+## Romanization in Explanations
+
+When TARGET_LANGUAGE uses a non-Latin script (Japanese, Korean, Chinese, Arabic, Thai, Hindi, Russian, Greek, etc.), **always include romanization** next to any target-language word or phrase mentioned in the explanation. Learners — especially beginners — cannot yet read the script fluently, so bare characters are unhelpful.
+
+Format: `characters (romanization)`. E.g., "こんばんは (konbanwa) is the greeting used at night" — NOT "こんばんは is the greeting used at night".
+
+This applies to every target-language word or phrase in the explanation, not just the first mention.
+
+## Explanation Style
+
+- Keep explanations concise (1-3 sentences) but always informative
+- Be specific to THIS sentence — don't give generic grammar lectures
+- Use concrete comparisons: "In TARGET_LANGUAGE you say X, but in USER_LANGUAGE you'd say Y, because..."
+- Make the learner feel like they understand the logic, not just memorizing
 
 ## Explanation Accuracy (CRITICAL)
 
@@ -121,7 +146,7 @@ Many grammar elements have multiple functions. Picking the wrong one teaches inc
 - **German prepositions**: Many take different cases depending on meaning (e.g., "in" + accusative for direction vs "in" + dative for location). Identify the correct case and meaning for the sentence.
 - **Korean particles**: 을/를 (object), 이/가 (subject), 은/는 (topic) serve distinct roles. Do not conflate them.
 
-**General principle**: If a grammar element has multiple functions, identify which function applies in this specific sentence. A wrong explanation is worse than no explanation — set the field to `null` if you are unsure.
+**General principle**: If a grammar element has multiple functions, identify which function applies in this specific sentence. A wrong explanation is worse than a vague one — but every sentence must still have an explanation. If unsure about a specific grammar detail, focus the explanation on word order or vocabulary contrasts instead.
 
 # Output Format
 
@@ -129,45 +154,7 @@ Return an object with a `sentences` array. Each sentence object must include:
 
 - `sentence`: The complete sentence in the target language
 - `translation`: The translation in the native language
-- `explanation`: Brief grammar/structure explanation in USER_LANGUAGE, or `null` for trivially simple sentences
-
-**Example for Spanish:**
-
-```json
-{
-  "sentences": [
-    {
-      "sentence": "Mi hermana trabaja en un hospital.",
-      "translation": "My sister works at a hospital.",
-      "explanation": "In Spanish, possessive adjectives like 'mi' (my) come before the noun, just like in English."
-    },
-    {
-      "sentence": "¿Dónde está la estación de tren?",
-      "translation": "Where is the train station?",
-      "explanation": "'Estar' is used for location. Questions in Spanish are framed with ¿...? and the verb often comes before the subject."
-    }
-  ]
-}
-```
-
-**Example for Japanese:**
-
-```json
-{
-  "sentences": [
-    {
-      "sentence": "私の姉は病院で働いています。",
-      "translation": "My older sister works at a hospital.",
-      "explanation": "Japanese uses the particle 'de' (で) to indicate where an action takes place, similar to 'at' or 'in' in English."
-    },
-    {
-      "sentence": "駅はどこですか？",
-      "translation": "Where is the station?",
-      "explanation": "In Japanese, the question word 'doko' (where) comes after the topic, and 'ka' at the end marks it as a question."
-    }
-  ]
-}
-```
+- `explanation`: Explanation in USER_LANGUAGE comparing the target-language structure with the learner's language (always required, never `null`)
 
 # Quality Requirements
 

--- a/packages/ai/src/tasks/activities/language/activity-sentences.ts
+++ b/packages/ai/src/tasks/activities/language/activity-sentences.ts
@@ -12,7 +12,7 @@ const FALLBACK_MODELS = ["google/gemini-3.1-pro-preview", "anthropic/claude-opus
 const schema = z.object({
   sentences: z.array(
     z.object({
-      explanation: z.string().nullable(),
+      explanation: z.string(),
       sentence: z.string(),
       translation: z.string(),
     }),


### PR DESCRIPTION
## Summary

- Sentence explanations are now always required (never `null`), including for simple beginner sentences
- Prompt rewritten to focus on cross-language contrasts: word order differences, grammar patterns absent in the learner's language, false friends, and word choice reasoning
- Non-Latin script explanations must include romanization (e.g., `こんばんは (konbanwa)`)
- Made `explanation` non-nullable in the zod schema

## Test plan

- [x] All existing tests updated and passing
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved sentence explanations to always contrast target and learner languages, and made `explanation` a required string with romanization for non‑Latin scripts. This clarifies learning points and standardizes the API.

- **New Features**
  - Rewrote `@zoonk/ai` `activity-sentences` prompt to focus on cross-language contrasts: word order, missing grammar patterns, false friends, and word choice.
  - `explanation` is now always present (never `null`) and written in the learner’s language.
  - Explanations for non‑Latin scripts must include romanization, e.g., `こんばんは (konbanwa)`.
  - Updated zod schema and tests to enforce the non-null `explanation`.

<sup>Written for commit 4915fbaff1eef57b121bfa35f49a0af3d1657881. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

