### PR TITLE
feat: add tradeoff activity type

### DIFF
--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.ts
@@ -2,6 +2,7 @@ import { settled } from "@zoonk/utils/settled";
 import { explanationActivityWorkflow } from "./kinds/explanation-workflow";
 import { practiceActivityWorkflow } from "./kinds/practice-workflow";
 import { quizActivityWorkflow } from "./kinds/quiz-workflow";
+import { tradeoffActivityWorkflow } from "./kinds/tradeoff-workflow";
 import { findActivitiesByKind } from "./steps/_utils/find-activity-by-kind";
 import { type LessonActivity } from "./steps/get-lesson-activities-step";
 import { getNeighboringConceptsStep } from "./steps/get-neighboring-concepts-step";
@@ -46,6 +47,11 @@ export async function coreActivityWorkflow({
       workflowRunId,
     }),
     quizActivityWorkflow({
+      activitiesToGenerate,
+      explanationResults: results,
+      workflowRunId,
+    }),
+    tradeoffActivityWorkflow({
       activitiesToGenerate,
       explanationResults: results,
       workflowRunId,

--- a/apps/api/src/workflows/activity-generation/kinds/tradeoff-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/tradeoff-workflow.ts
@@ -1,0 +1,43 @@
+import { type ExplanationResult } from "../steps/generate-explanation-content-step";
+import { generateTradeoffContentStep } from "../steps/generate-tradeoff-content-step";
+import { type LessonActivity } from "../steps/get-lesson-activities-step";
+import { saveTradeoffActivityStep } from "../steps/save-tradeoff-activity-step";
+
+/**
+ * Orchestrates tradeoff activity generation.
+ *
+ * Flow: generateContent -> save.
+ * The generate step calls the AI to produce a resource allocation scenario
+ * with multiple rounds. The save step splits the output into individual
+ * step records (intro + N rounds + reflection).
+ *
+ * Only generates for tradeoff activities in the activitiesToGenerate list.
+ */
+export async function tradeoffActivityWorkflow({
+  activitiesToGenerate,
+  explanationResults,
+  workflowRunId,
+}: {
+  activitiesToGenerate: LessonActivity[];
+  explanationResults: ExplanationResult[];
+  workflowRunId: string;
+}): Promise<void> {
+  "use workflow";
+
+  const explanationSteps = explanationResults.flatMap((result) => result.steps);
+  const { activityId, content } = await generateTradeoffContentStep(
+    activitiesToGenerate,
+    explanationSteps,
+    workflowRunId,
+  );
+
+  if (!activityId || !content) {
+    return;
+  }
+
+  await saveTradeoffActivityStep({
+    activityId,
+    content,
+    workflowRunId,
+  });
+}

--- a/apps/api/src/workflows/activity-generation/steps/generate-tradeoff-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-tradeoff-content-step.test.ts
@@ -1,0 +1,286 @@
+import { randomUUID } from "node:crypto";
+import { fetchLessonActivities } from "@/workflows/_test-utils/fetch-lesson-activities";
+import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { generateTradeoffContentStep } from "./generate-tradeoff-content-step";
+
+const writeMock = vi.fn().mockResolvedValue(null);
+
+vi.mock("workflow", () => ({
+  FatalError: class FatalError extends Error {},
+  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
+  getWritable: vi.fn().mockReturnValue({
+    getWriter: () => ({
+      releaseLock: vi.fn(),
+      write: writeMock,
+    }),
+  }),
+  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
+}));
+
+const { generateActivityTradeoffMock } = vi.hoisted(() => ({
+  generateActivityTradeoffMock: vi.fn(),
+}));
+
+vi.mock("@zoonk/ai/tasks/activities/core/tradeoff", () => ({
+  generateActivityTradeoff: generateActivityTradeoffMock,
+}));
+
+function makeTradeoffAIOutput() {
+  return {
+    priorities: [
+      { description: "Study notes", id: "study", name: "Study" },
+      { description: "Exercise", id: "exercise", name: "Exercise" },
+      { description: "Sleep", id: "sleep", name: "Sleep" },
+    ],
+    reflection: { text: "Reflection text", title: "Reflection" },
+    resource: { name: "hours", total: 5 },
+    rounds: [
+      {
+        event: null,
+        outcomes: [
+          {
+            invested: { consequence: "Good" },
+            maintained: { consequence: "OK" },
+            neglected: { consequence: "Bad" },
+            priorityId: "study",
+          },
+        ],
+        stateModifiers: null,
+        tokenOverride: null,
+      },
+      {
+        event: "Event happened",
+        outcomes: [
+          {
+            invested: { consequence: "Great" },
+            maintained: { consequence: "Fine" },
+            neglected: { consequence: "Worse" },
+            priorityId: "study",
+          },
+        ],
+        stateModifiers: [{ delta: -1, priorityId: "sleep" }],
+        tokenOverride: 4,
+      },
+    ],
+    scenario: { text: "Scenario text", title: "Scenario" },
+  };
+}
+
+describe(generateTradeoffContentStep, () => {
+  let organizationId: number;
+  let chapter: Awaited<ReturnType<typeof chapterFixture>>;
+
+  beforeAll(async () => {
+    const organization = await aiOrganizationFixture();
+    organizationId = organization.id;
+    const course = await courseFixture({ organizationId });
+
+    chapter = await chapterFixture({
+      courseId: course.id,
+      organizationId,
+      title: `Gen Tradeoff Chapter ${randomUUID()}`,
+    });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns tradeoff content for a tradeoff activity", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Tradeoff Content ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "tradeoff",
+      language: "pt",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Tradeoff ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+    const aiOutput = makeTradeoffAIOutput();
+
+    generateActivityTradeoffMock.mockResolvedValue({ data: aiOutput });
+
+    const explanationSteps = [{ text: "Explanation text", title: "Explanation title" }];
+
+    const result = await generateTradeoffContentStep(activities, explanationSteps, "run-1");
+
+    expect(result.activityId).toBe(activities.find((act) => act.kind === "tradeoff")?.id);
+    expect(result.content).toEqual(aiOutput);
+  });
+
+  test("returns null when no tradeoff activity exists", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Tradeoff None ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "explanation",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Explanation ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    const result = await generateTradeoffContentStep(
+      activities,
+      [{ text: "text", title: "title" }],
+      "run-2",
+    );
+
+    expect(result).toEqual({ activityId: null, content: null });
+    expect(generateActivityTradeoffMock).not.toHaveBeenCalled();
+  });
+
+  test("marks activity as failed when explanation steps are empty", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Tradeoff Empty Explanation ${randomUUID()}`,
+    });
+
+    const dbActivity = await activityFixture({
+      generationStatus: "pending",
+      kind: "tradeoff",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Tradeoff ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    const result = await generateTradeoffContentStep(activities, [], "run-3");
+
+    expect(result).toEqual({ activityId: null, content: null });
+
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
+  });
+
+  test("marks activity as failed when AI returns empty rounds", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Tradeoff AI Empty ${randomUUID()}`,
+    });
+
+    const dbActivity = await activityFixture({
+      generationStatus: "pending",
+      kind: "tradeoff",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Tradeoff ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    generateActivityTradeoffMock.mockResolvedValue({
+      data: { ...makeTradeoffAIOutput(), rounds: [] },
+    });
+
+    const result = await generateTradeoffContentStep(
+      activities,
+      [{ text: "text", title: "title" }],
+      "run-4",
+    );
+
+    expect(result).toEqual({ activityId: null, content: null });
+
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
+  });
+
+  test("streams started and completed events on success", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Tradeoff Stream ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "tradeoff",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Tradeoff ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+    const tradeoffActivity = activities.find((act) => act.kind === "tradeoff");
+
+    generateActivityTradeoffMock.mockResolvedValue({ data: makeTradeoffAIOutput() });
+
+    await generateTradeoffContentStep(activities, [{ text: "text", title: "title" }], "run-5");
+
+    const events = getStreamedEvents(writeMock);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        entityId: tradeoffActivity?.id,
+        status: "started",
+        step: "generateTradeoffContent",
+      }),
+    );
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        entityId: tradeoffActivity?.id,
+        status: "completed",
+        step: "generateTradeoffContent",
+      }),
+    );
+  });
+
+  test("streams error event when AI call fails", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Tradeoff AI Error ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "tradeoff",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Tradeoff ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    generateActivityTradeoffMock.mockRejectedValue(new Error("AI failed"));
+
+    await generateTradeoffContentStep(activities, [{ text: "text", title: "title" }], "run-6");
+
+    const events = getStreamedEvents(writeMock);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        status: "error",
+        step: "generateTradeoffContent",
+      }),
+    );
+  });
+});

--- a/apps/api/src/workflows/activity-generation/steps/generate-tradeoff-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-tradeoff-content-step.ts
@@ -1,0 +1,66 @@
+import { createEntityStepStream, getAIResultErrorReason } from "@/workflows/_shared/stream-status";
+import {
+  type ActivityTradeoffSchema,
+  generateActivityTradeoff,
+} from "@zoonk/ai/tasks/activities/core/tradeoff";
+import { type ActivityStepName } from "@zoonk/core/workflows/steps";
+import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { findActivitiesByKind } from "./_utils/find-activity-by-kind";
+import { type ActivitySteps } from "./_utils/get-activity-steps";
+import { type LessonActivity } from "./get-lesson-activities-step";
+import { handleActivityFailureStep } from "./handle-failure-step";
+
+/**
+ * Generates a tradeoff scenario from explanation content via AI.
+ *
+ * Returns the full AI output (scenario, priorities, rounds, reflection)
+ * without saving to the database. The save step splits this into
+ * individual step records.
+ *
+ * The AI decides how many rounds to generate (2-4) based on topic
+ * complexity. Simple topics get fewer rounds, complex ones get more.
+ */
+export async function generateTradeoffContentStep(
+  activities: LessonActivity[],
+  explanationSteps: ActivitySteps,
+  _workflowRunId: string,
+): Promise<{ activityId: number | null; content: ActivityTradeoffSchema | null }> {
+  "use step";
+
+  const tradeoffActivity = findActivitiesByKind(activities, "tradeoff")[0];
+
+  if (!tradeoffActivity) {
+    return { activityId: null, content: null };
+  }
+
+  if (explanationSteps.length === 0) {
+    await handleActivityFailureStep({ activityId: tradeoffActivity.id });
+    return { activityId: null, content: null };
+  }
+
+  await using stream = createEntityStepStream<ActivityStepName>(tradeoffActivity.id);
+
+  await stream.status({ status: "started", step: "generateTradeoffContent" });
+
+  const { data: result, error }: SafeReturn<{ data: ActivityTradeoffSchema }> = await safeAsync(
+    () =>
+      generateActivityTradeoff({
+        chapterTitle: tradeoffActivity.lesson.chapter.title,
+        courseTitle: tradeoffActivity.lesson.chapter.course.title,
+        explanationSteps,
+        language: tradeoffActivity.language,
+        lessonDescription: tradeoffActivity.lesson.description ?? "",
+        lessonTitle: tradeoffActivity.lesson.title,
+      }),
+  );
+
+  if (error || !result || result.data.rounds.length === 0) {
+    const reason = getAIResultErrorReason({ error, result });
+    await stream.error({ reason, step: "generateTradeoffContent" });
+    await handleActivityFailureStep({ activityId: tradeoffActivity.id });
+    return { activityId: null, content: null };
+  }
+
+  await stream.status({ status: "completed", step: "generateTradeoffContent" });
+  return { activityId: Number(tradeoffActivity.id), content: result.data };
+}

--- a/apps/api/src/workflows/activity-generation/steps/save-tradeoff-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-tradeoff-activity-step.test.ts
@@ -1,0 +1,232 @@
+import { randomUUID } from "node:crypto";
+import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
+import { type ActivityTradeoffSchema } from "@zoonk/ai/tasks/activities/core/tradeoff";
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { saveTradeoffActivityStep } from "./save-tradeoff-activity-step";
+
+const writeMock = vi.fn().mockResolvedValue(null);
+
+vi.mock("workflow", () => ({
+  FatalError: class FatalError extends Error {},
+  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
+  getWritable: vi.fn().mockReturnValue({
+    getWriter: () => ({
+      releaseLock: vi.fn(),
+      write: writeMock,
+    }),
+  }),
+  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
+}));
+
+function makeTradeoffContent(): ActivityTradeoffSchema {
+  return {
+    priorities: [
+      { description: "Study notes", id: "study", name: "Study" },
+      { description: "Physical activity", id: "exercise", name: "Exercise" },
+      { description: "Rest", id: "sleep", name: "Sleep" },
+    ],
+    reflection: {
+      text: "Learning happens in three stages: encoding, consolidation, retrieval.",
+      title: "Reflection",
+    },
+    resource: { name: "hours", total: 5 },
+    rounds: [
+      {
+        event: null,
+        outcomes: [
+          {
+            invested: { consequence: "Good progress" },
+            maintained: { consequence: "Treading water" },
+            neglected: { consequence: "Fell behind" },
+            priorityId: "study",
+          },
+          {
+            invested: { consequence: "Energized" },
+            maintained: { consequence: "OK" },
+            neglected: { consequence: "Sluggish" },
+            priorityId: "exercise",
+          },
+          {
+            invested: { consequence: "Well rested" },
+            maintained: { consequence: "Fine" },
+            neglected: { consequence: "Exhausted" },
+            priorityId: "sleep",
+          },
+        ],
+        stateModifiers: null,
+        tokenOverride: null,
+      },
+      {
+        event: "The exam was moved to tomorrow!",
+        outcomes: [
+          {
+            invested: { consequence: "Crammed effectively" },
+            maintained: { consequence: "Light review" },
+            neglected: { consequence: "Forgot key concepts" },
+            priorityId: "study",
+          },
+          {
+            invested: { consequence: "Clear mind" },
+            maintained: { consequence: "Some tension" },
+            neglected: { consequence: "High cortisol" },
+            priorityId: "exercise",
+          },
+          {
+            invested: { consequence: "Consolidated memories" },
+            maintained: { consequence: "Partial consolidation" },
+            neglected: { consequence: "No consolidation" },
+            priorityId: "sleep",
+          },
+        ],
+        stateModifiers: [{ delta: -1, priorityId: "sleep" }],
+        tokenOverride: 4,
+      },
+    ],
+    scenario: {
+      text: "You have a big exam in 3 days.",
+      title: "Exam Prep",
+    },
+  };
+}
+
+describe(saveTradeoffActivityStep, () => {
+  let organizationId: number;
+  let chapter: Awaited<ReturnType<typeof chapterFixture>>;
+
+  beforeAll(async () => {
+    const organization = await aiOrganizationFixture();
+    organizationId = organization.id;
+    const course = await courseFixture({ organizationId });
+
+    chapter = await chapterFixture({
+      courseId: course.id,
+      organizationId,
+      title: `Save Tradeoff Chapter ${randomUUID()}`,
+    });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("saves intro + round steps + reflection and marks activity as completed", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Save Tradeoff ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "tradeoff",
+      language: "pt",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Tradeoff ${randomUUID()}`,
+    });
+
+    const content = makeTradeoffContent();
+
+    await saveTradeoffActivityStep({
+      activityId: Number(activity.id),
+      content,
+      workflowRunId: "workflow-1",
+    });
+
+    const [dbSteps, dbActivity] = await Promise.all([
+      prisma.step.findMany({
+        orderBy: { position: "asc" },
+        where: { activityId: activity.id },
+      }),
+      prisma.activity.findUniqueOrThrow({
+        where: { id: activity.id },
+      }),
+    ]);
+
+    // 2 rounds → 1 intro + 2 rounds + 1 reflection = 4 steps
+    expect(dbSteps).toHaveLength(4);
+
+    expect(dbSteps.map((step) => [step.position, step.kind])).toEqual([
+      [0, "static"],
+      [1, "tradeoff"],
+      [2, "tradeoff"],
+      [3, "static"],
+    ]);
+
+    // Verify intro step content
+    const introContent = dbSteps[0]?.content as { title: string; variant: string };
+    expect(introContent.variant).toBe("text");
+    expect(introContent.title).toBe("Exam Prep");
+
+    // Verify reflection step content
+    const reflectionContent = dbSteps[3]?.content as { title: string; variant: string };
+    expect(reflectionContent.variant).toBe("text");
+    expect(reflectionContent.title).toBe("Reflection");
+
+    // Verify round steps have priorities and outcomes
+    const round1Content = dbSteps[1]?.content as { event: string | null; priorities: unknown[] };
+    expect(round1Content.event).toBeNull();
+    expect(round1Content.priorities).toHaveLength(3);
+
+    const round2Content = dbSteps[2]?.content as {
+      event: string | null;
+      stateModifiers: unknown[];
+      tokenOverride: number | null;
+    };
+    expect(round2Content.event).toBe("The exam was moved to tomorrow!");
+    expect(round2Content.tokenOverride).toBe(4);
+    expect(round2Content.stateModifiers).toHaveLength(1);
+
+    expect(dbActivity).toMatchObject({
+      generationRunId: "workflow-1",
+      generationStatus: "completed",
+    });
+
+    const events = getStreamedEvents(writeMock);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({ status: "started", step: "saveTradeoffActivity" }),
+    );
+
+    expect(events).toContainEqual(
+      expect.objectContaining({ status: "completed", step: "saveTradeoffActivity" }),
+    );
+  });
+
+  test("streams error when DB transaction fails", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Save Tradeoff Error ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "tradeoff",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Tradeoff Fail ${randomUUID()}`,
+    });
+
+    await prisma.activity.delete({ where: { id: activity.id } });
+
+    await saveTradeoffActivityStep({
+      activityId: Number(activity.id),
+      content: makeTradeoffContent(),
+      workflowRunId: "workflow-error",
+    });
+
+    const events = getStreamedEvents(writeMock);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({ status: "error", step: "saveTradeoffActivity" }),
+    );
+  });
+});

--- a/apps/api/src/workflows/activity-generation/steps/save-tradeoff-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-tradeoff-activity-step.ts
@@ -1,0 +1,105 @@
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
+import { type ActivityTradeoffSchema } from "@zoonk/ai/tasks/activities/core/tradeoff";
+import { assertStepContent } from "@zoonk/core/steps/content-contract";
+import { type ActivityStepName } from "@zoonk/core/workflows/steps";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { handleActivityFailureStep } from "./handle-failure-step";
+
+/**
+ * Builds step records from the AI-generated tradeoff content.
+ *
+ * Splits the single AI output into 2 + N step records:
+ * - Position 0: static intro (scenario text)
+ * - Positions 1..N: one tradeoff step per round (priorities + outcomes)
+ * - Position N+1: static reflection
+ *
+ * Priorities and resource are copied into each tradeoff step so they're
+ * self-contained — the component doesn't need to look up data from
+ * other steps.
+ */
+function buildTradeoffStepRecords(activityId: number, content: ActivityTradeoffSchema) {
+  const introStep = {
+    activityId,
+    content: assertStepContent("static", {
+      text: content.scenario.text,
+      title: content.scenario.title,
+      variant: "text" as const,
+    }),
+    isPublished: true,
+    kind: "static" as const,
+    position: 0,
+  };
+
+  const roundSteps = content.rounds.map((round, index) => ({
+    activityId,
+    content: assertStepContent("tradeoff", {
+      event: round.event,
+      outcomes: round.outcomes,
+      priorities: content.priorities,
+      resource: content.resource,
+      stateModifiers: round.stateModifiers,
+      tokenOverride: round.tokenOverride,
+    }),
+    isPublished: true,
+    kind: "tradeoff" as const,
+    position: index + 1,
+  }));
+
+  const reflectionStep = {
+    activityId,
+    content: assertStepContent("static", {
+      text: content.reflection.text,
+      title: content.reflection.title,
+      variant: "text" as const,
+    }),
+    isPublished: true,
+    kind: "static" as const,
+    position: content.rounds.length + 1,
+  };
+
+  return [introStep, ...roundSteps, reflectionStep];
+}
+
+/**
+ * Persists all tradeoff step records and marks the activity as completed.
+ *
+ * This is the single save point for a tradeoff entity. The upstream
+ * `generateTradeoffContentStep` produces data only — this step writes
+ * everything and marks the activity done.
+ */
+export async function saveTradeoffActivityStep({
+  activityId,
+  content,
+  workflowRunId,
+}: {
+  activityId: number;
+  content: ActivityTradeoffSchema;
+  workflowRunId: string;
+}): Promise<void> {
+  "use step";
+
+  await using stream = createEntityStepStream<ActivityStepName>(activityId);
+
+  await stream.status({ status: "started", step: "saveTradeoffActivity" });
+
+  const stepRecords = buildTradeoffStepRecords(activityId, content);
+
+  const { error } = await safeAsync(() =>
+    prisma.$transaction([
+      prisma.step.createMany({ data: stepRecords }),
+      prisma.activity.update({
+        data: { generationRunId: workflowRunId, generationStatus: "completed" },
+        where: { id: activityId },
+      }),
+    ]),
+  );
+
+  if (error) {
+    await stream.error({ reason: "dbSaveFailed", step: "saveTradeoffActivity" });
+    await handleActivityFailureStep({ activityId });
+    return;
+  }
+
+  await stream.status({ status: "completed", step: "saveTradeoffActivity" });
+}

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/get-activities-for-kind.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/get-activities-for-kind.test.ts
@@ -6,7 +6,13 @@ describe(getActivitiesForKind, () => {
     test("returns fallback explanation when concepts are empty", () => {
       const result = getActivitiesForKind("core", [], null, []);
 
-      expect(result.map((a) => a.kind)).toEqual(["explanation", "practice", "quiz", "review"]);
+      expect(result.map((a) => a.kind)).toEqual([
+        "explanation",
+        "practice",
+        "quiz",
+        "tradeoff",
+        "review",
+      ]);
       expect(result[0]?.title).toBeNull();
     });
 
@@ -19,9 +25,10 @@ describe(getActivitiesForKind, () => {
         "explanation",
         "practice",
         "quiz",
+        "tradeoff",
         "review",
       ]);
-      expect(result.map((a) => a.title)).toEqual(["A", "B", "C", null, null, null]);
+      expect(result.map((a) => a.title)).toEqual(["A", "B", "C", null, null, null, null]);
     });
 
     test("inserts two practices when there are 4 concepts", () => {
@@ -35,6 +42,7 @@ describe(getActivitiesForKind, () => {
         "explanation",
         "practice",
         "quiz",
+        "tradeoff",
         "review",
       ]);
     });
@@ -51,6 +59,7 @@ describe(getActivitiesForKind, () => {
         "explanation",
         "practice",
         "quiz",
+        "tradeoff",
         "review",
       ]);
       expect(result[0]?.title).toBe("A");
@@ -63,7 +72,13 @@ describe(getActivitiesForKind, () => {
     test("returns single concept with single practice", () => {
       const result = getActivitiesForKind("core", [], null, ["Solo"]);
 
-      expect(result.map((a) => a.kind)).toEqual(["explanation", "practice", "quiz", "review"]);
+      expect(result.map((a) => a.kind)).toEqual([
+        "explanation",
+        "practice",
+        "quiz",
+        "tradeoff",
+        "review",
+      ]);
       expect(result[0]?.title).toBe("Solo");
     });
   });

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/get-activities-for-kind.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/get-activities-for-kind.ts
@@ -44,18 +44,19 @@ function getCoreActivities(concepts: string[]): ActivityEntry[] {
   const practice: ActivityEntry = { description: null, kind: "practice", title: null };
   const review: ActivityEntry = { description: null, kind: "review", title: null };
   const quiz: ActivityEntry = { description: null, kind: "quiz", title: null };
+  const tradeoff: ActivityEntry = { description: null, kind: "tradeoff", title: null };
 
   const minConceptsForTwoPractices = 4;
 
   if (concepts.length < minConceptsForTwoPractices) {
-    return [...allExplanations, practice, quiz, review];
+    return [...allExplanations, practice, quiz, tradeoff, review];
   }
 
   const splitIndex = Math.floor(concepts.length / 2);
   const firstGroup = explanations.slice(0, splitIndex);
   const secondGroup = explanations.slice(splitIndex);
 
-  return [...firstGroup, practice, ...secondGroup, practice, quiz, review];
+  return [...firstGroup, practice, ...secondGroup, practice, quiz, tradeoff, review];
 }
 
 /**

--- a/apps/evals/src/tasks/activity-tradeoff/task.ts
+++ b/apps/evals/src/tasks/activity-tradeoff/task.ts
@@ -1,0 +1,16 @@
+import { type Task } from "@/lib/types";
+import {
+  type ActivityTradeoffParams,
+  type ActivityTradeoffSchema,
+  generateActivityTradeoff,
+} from "@zoonk/ai/tasks/activities/core/tradeoff";
+import { TEST_CASES } from "./test-cases";
+
+export const activityTradeoffTask: Task<ActivityTradeoffParams, ActivityTradeoffSchema> = {
+  description:
+    "Generate a resource allocation scenario with competing priorities, consequences, and a reflection for tradeoff activities",
+  generate: generateActivityTradeoff,
+  id: "activity-tradeoff",
+  name: "Activity Tradeoff",
+  testCases: TEST_CASES,
+};

--- a/apps/evals/src/tasks/activity-tradeoff/test-cases.ts
+++ b/apps/evals/src/tasks/activity-tradeoff/test-cases.ts
@@ -1,0 +1,251 @@
+const SHARED_EXPECTATIONS = `
+EVALUATION CRITERIA:
+
+1. SCENARIO QUALITY: The scenario must be relatable and use {{NAME}} for personalization. Introductory topics should use everyday scenarios (studying, budgeting, health). Advanced topics should use professional/workplace scenarios. Penalize:
+   - Scenarios that feel like a pedagogical setup rather than a real dilemma
+   - Scenarios too abstract or disconnected from the learner's life
+   - Missing {{NAME}} placeholder
+
+2. PRIORITY CONFLICT: Priorities must genuinely conflict — investing in one should make neglecting another WORSE, not just leave it unchanged. Penalize:
+   - Independent priorities where neglecting one has no effect on others
+   - Priorities that are all clearly positive (no tension)
+   - Priorities that are obviously ranked (one is clearly "best")
+
+3. TRAP PRIORITY: At least one priority should sound urgent or important but heavy investment has diminishing returns — 1 token of maintenance is enough. Penalize:
+   - All priorities equally benefiting from heavy investment
+   - No priority where the learner's instinct is suboptimal
+
+4. THREE-TIER DIVERSITY: The "maintained" outcome must feel meaningfully different from both "invested" and "neglected" — not just a medium version. Penalize:
+   - Maintained outcomes that are just softer versions of neglected
+   - Maintained outcomes that are just weaker versions of invested
+   - All three tiers telling essentially the same story with different severity
+
+5. CONSEQUENCE QUALITY: Round 1 consequences should be one short, visceral sentence. Later round consequences can be 1-2 sentences. Consequences should naturally reference lesson concepts as they play out. Penalize:
+   - Round 1 consequences that are too long or academic
+   - Consequences that read like textbook paragraphs
+   - Consequences that don't connect to the lesson's concepts
+   - Generic consequences that could apply to any topic
+
+6. EVENT DRAMA: Round 2+ events must change the strategic landscape — not just add narrative flavor. They should include tokenOverride (fewer resources) or stateModifiers (priority shifts), or ideally both. Penalize:
+   - Events that are purely narrative with null tokenOverride AND null stateModifiers
+   - Events that don't change the learner's calculus
+   - Events that feel like filler between rounds
+
+7. TOKEN TIGHTENING: Resources should generally decrease or demands increase across rounds, forcing harder choices. Penalize:
+   - Same token count every round with no strategic shift
+   - Resources increasing without justification
+
+8. REFLECTION: Must surface the underlying principle from the lesson concepts, not just summarize the scenario. Should explain WHY different strategies lead to different outcomes. Penalize:
+   - Reflections that only describe what happened
+   - Reflections disconnected from the lesson's concepts
+   - Vague platitudes ("balance is important")
+
+STRUCTURAL CHECKS:
+- 3-4 priorities with unique camelCase IDs
+- 4-6 base tokens
+- 2-4 rounds (AI chooses based on complexity)
+- Round 1 event must be null
+- Every round must have one outcome per priority
+- Priority IDs in outcomes must match the priorities array
+- Character limits: scenario ≤200, priority name ≤40, description ≤100, event ≤300, consequence ≤200, reflection ≤500
+
+ANTI-CHECKLIST GUIDANCE:
+- Do NOT penalize for choosing 2 rounds for a simple topic or 4 for a complex one
+- Do NOT require a specific token progression pattern — decreasing is common but not mandatory
+- Do NOT expect consequences to teach the lesson didactically — they should show concepts in action
+- ONLY penalize for: weak priority conflict, missing trap priority, flat three-tier outcomes, narrative-only events, disconnected reflection, or structural violations
+`;
+
+export const TEST_CASES = [
+  {
+    expectations: `
+TOPIC: Introductory neuroscience — how the brain learns and remembers.
+
+SCENARIO GUIDANCE:
+- Should be an everyday scenario (e.g., preparing for an exam, managing study habits)
+- Priorities should relate to brain functions: study, sleep/rest, exercise, social connection
+- The "trap" should be pure study — neuroscience shows sleep and exercise are critical for memory consolidation
+
+CONCEPT APPLICATION:
+- Consequences should reference: memory consolidation during sleep, BDNF from exercise, cortisol effects on hippocampus, forgetting curve
+- The reflection should connect to how learning happens in stages (encoding, consolidation, retrieval)
+
+${SHARED_EXPECTATIONS}
+    `,
+    id: "pt-neuroscience-intro",
+    userInput: {
+      chapterTitle: "O cérebro e a aprendizagem",
+      courseTitle: "Introdução à Neurociência",
+      explanationSteps: [
+        {
+          text: "A neurociência é o estudo do sistema nervoso e do cérebro. Ela nos ajuda a entender como aprendemos, memorizamos e tomamos decisões.",
+          title: "O que é Neurociência",
+        },
+        {
+          text: "O cérebro forma novas conexões entre neurônios quando aprendemos algo novo. Esse processo é chamado de neuroplasticidade e é fortalecido por repetição, sono e exercício físico.",
+          title: "Neuroplasticidade",
+        },
+        {
+          text: "O hipocampo é a região do cérebro responsável por consolidar memórias de curto prazo em memórias de longo prazo. Esse processo acontece principalmente durante o sono profundo.",
+          title: "Consolidação de Memórias",
+        },
+      ],
+      language: "pt",
+      lessonDescription:
+        "Conceitos fundamentais de neurociência: o que é, como o cérebro aprende e como as memórias se formam.",
+      lessonTitle: "O que é Neurociência",
+    },
+  },
+  {
+    expectations: `
+TOPIC: Advanced software engineering — managing technical debt and delivery tradeoffs.
+
+SCENARIO GUIDANCE:
+- Should be a workplace/startup scenario (e.g., startup post-Series A, engineering team lead)
+- Priorities should relate to: code quality/refactoring, feature delivery, team morale/developer experience, system reliability
+- The "trap" could be feature delivery — shipping fast without tests creates compounding debt
+
+CONCEPT APPLICATION:
+- Consequences should reference: technical debt compounding, refactoring ROI, developer burnout, reliability SLAs
+- Events should include realistic disruptions: key person leaving, urgent client demand, production incident
+
+${SHARED_EXPECTATIONS}
+    `,
+    id: "en-software-engineering",
+    userInput: {
+      chapterTitle: "Engineering Leadership",
+      courseTitle: "Software Engineering Management",
+      explanationSteps: [
+        {
+          text: "Technical debt is the accumulated cost of shortcuts taken during development. Like financial debt, it compounds — each shortcut makes future changes harder and more error-prone.",
+          title: "Technical Debt",
+        },
+        {
+          text: "Refactoring improves code structure without changing behavior. The ROI of refactoring is measured in reduced future development time, fewer bugs, and easier onboarding for new team members.",
+          title: "Refactoring ROI",
+        },
+        {
+          text: "Developer experience (DX) directly impacts productivity and retention. Teams with good tooling, clear documentation, and manageable workloads ship more reliably than teams that optimize only for speed.",
+          title: "Developer Experience",
+        },
+      ],
+      language: "en",
+      lessonDescription:
+        "How to balance technical debt, delivery speed, and team health in a growing engineering organization.",
+      lessonTitle: "Managing Technical Debt",
+    },
+  },
+  {
+    expectations: `
+TOPIC: Personal finance basics — budgeting and saving tradeoffs.
+
+SCENARIO GUIDANCE:
+- Should be an everyday scenario (e.g., first job, managing monthly budget)
+- Priorities should relate to: saving/emergency fund, daily expenses/lifestyle, education/skills, debt repayment
+- The "trap" could be lifestyle spending — feels necessary but has the least long-term impact
+
+LANGUAGE REQUIREMENT: All content must be in Latin American Spanish.
+
+${SHARED_EXPECTATIONS}
+    `,
+    id: "es-personal-finance",
+    userInput: {
+      chapterTitle: "Fundamentos de finanzas",
+      courseTitle: "Finanzas Personales",
+      explanationSteps: [
+        {
+          text: "Un presupuesto es un plan para distribuir tus ingresos entre necesidades, deseos y ahorro. La regla 50/30/20 sugiere: 50% necesidades, 30% deseos, 20% ahorro.",
+          title: "Qué es un presupuesto",
+        },
+        {
+          text: "Un fondo de emergencia cubre 3-6 meses de gastos esenciales. Sin él, cualquier imprevisto puede convertirse en deuda — es la base de la estabilidad financiera.",
+          title: "Fondo de emergencia",
+        },
+        {
+          text: "El interés compuesto hace que las deudas crezcan exponencialmente si solo pagas el mínimo. Priorizar el pago de deudas de alto interés ahorra más a largo plazo.",
+          title: "Interés compuesto y deudas",
+        },
+      ],
+      language: "es",
+      lessonDescription:
+        "Conceptos básicos de presupuesto, ahorro y manejo de deudas para tomar mejores decisiones financieras.",
+      lessonTitle: "Presupuesto y Ahorro",
+    },
+  },
+  {
+    expectations: `
+TOPIC: Climate science — environmental policy tradeoffs.
+
+SCENARIO GUIDANCE:
+- Should be a moderate-complexity scenario (e.g., city council member, company sustainability officer)
+- Priorities should relate to: emissions reduction, economic growth, public support, infrastructure investment
+- The "trap" could be public support — sounds politically necessary but doesn't directly reduce emissions
+
+CONCEPT APPLICATION:
+- Consequences should reference: carbon budget, tipping points, green infrastructure ROI, stranded assets
+- This is a complex topic — expect 3-4 rounds
+
+${SHARED_EXPECTATIONS}
+    `,
+    id: "en-climate-policy",
+    userInput: {
+      chapterTitle: "Climate Action",
+      courseTitle: "Environmental Science",
+      explanationSteps: [
+        {
+          text: "The carbon budget is the maximum amount of CO2 that can be emitted while keeping warming below a target. Once the budget is spent, every additional ton of emissions increases the risk of irreversible tipping points.",
+          title: "Carbon Budget",
+        },
+        {
+          text: "Green infrastructure (renewable energy, public transit, building retrofits) requires high upfront investment but pays off through reduced operating costs and avoided climate damages over decades.",
+          title: "Green Infrastructure",
+        },
+        {
+          text: "Stranded assets are investments that lose value due to climate policy changes. Fossil fuel infrastructure built today may become worthless as regulations tighten, creating economic risk alongside environmental risk.",
+          title: "Stranded Assets",
+        },
+      ],
+      language: "en",
+      lessonDescription:
+        "Understanding the tradeoffs between economic growth, emissions reduction, and long-term sustainability in climate policy.",
+      lessonTitle: "Climate Policy Tradeoffs",
+    },
+  },
+  {
+    expectations: `
+TOPIC: Time management basics — productivity tradeoffs.
+
+SCENARIO GUIDANCE:
+- Should be an everyday scenario (e.g., university student, freelancer managing clients)
+- Priorities should relate to: deep work/focus, quick tasks/email, breaks/rest, planning/organization
+- The "trap" could be quick tasks — feels productive but consumes time without meaningful progress
+
+LANGUAGE REQUIREMENT: All content must be in Brazilian Portuguese.
+
+${SHARED_EXPECTATIONS}
+    `,
+    id: "pt-time-management",
+    userInput: {
+      chapterTitle: "Produtividade pessoal",
+      courseTitle: "Gestão do Tempo",
+      explanationSteps: [
+        {
+          text: "Trabalho profundo (deep work) é a capacidade de se concentrar sem distrações em uma tarefa cognitivamente exigente. É nesse estado que produzimos nosso trabalho mais valioso.",
+          title: "Trabalho Profundo",
+        },
+        {
+          text: "A troca de contexto (alternar entre tarefas) tem um custo cognitivo real — cada vez que você muda de tarefa, leva em média 23 minutos para retomar a concentração total.",
+          title: "Custo da troca de contexto",
+        },
+        {
+          text: "A Lei de Parkinson diz que o trabalho se expande para preencher o tempo disponível. Sem prazos claros e planejamento, tarefas simples podem consumir horas desnecessárias.",
+          title: "Lei de Parkinson",
+        },
+      ],
+      language: "pt",
+      lessonDescription:
+        "Como organizar seu tempo para maximizar produtividade sem sacrificar bem-estar.",
+      lessonTitle: "Gestão do Tempo",
+    },
+  },
+];

--- a/apps/evals/src/tasks/index.ts
+++ b/apps/evals/src/tasks/index.ts
@@ -9,6 +9,7 @@ import { activityPronunciationTask } from "./activity-pronunciation/task";
 import { activityQuizTask } from "./activity-quiz/task";
 import { activityRomanizationTask } from "./activity-romanization/task";
 import { activitySentencesTask } from "./activity-sentences/task";
+import { activityTradeoffTask } from "./activity-tradeoff/task";
 import { activityTranslationTask } from "./activity-translation/task";
 import { activityVocabularyTask } from "./activity-vocabulary/task";
 import { alternativeTitlesTask } from "./alternative-titles/task";
@@ -34,6 +35,7 @@ export const TASKS: readonly Task[] = [
   activityTranslationTask,
   activitySentencesTask,
   activityPracticeTask,
+  activityTradeoffTask,
 
   activityRomanizationTask,
   activityVocabularyTask,

--- a/apps/main/e2e/tradeoff-step.test.ts
+++ b/apps/main/e2e/tradeoff-step.test.ts
@@ -1,0 +1,343 @@
+import { randomUUID } from "node:crypto";
+import { getAiOrganization } from "@zoonk/e2e/helpers";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { expect, test } from "./fixtures";
+
+function makeTradeoffContent(
+  uniqueId: string,
+  overrides: {
+    event?: string | null;
+    stateModifiers?: { delta: number; priorityId: string }[] | null;
+    tokenOverride?: number | null;
+  } = {},
+) {
+  return {
+    event: overrides.event ?? null,
+    outcomes: [
+      {
+        invested: { consequence: `Study invested ${uniqueId}` },
+        maintained: { consequence: `Study maintained ${uniqueId}` },
+        neglected: { consequence: `Study neglected ${uniqueId}` },
+        priorityId: "study",
+      },
+      {
+        invested: { consequence: `Exercise invested ${uniqueId}` },
+        maintained: { consequence: `Exercise maintained ${uniqueId}` },
+        neglected: { consequence: `Exercise neglected ${uniqueId}` },
+        priorityId: "exercise",
+      },
+      {
+        invested: { consequence: `Sleep invested ${uniqueId}` },
+        maintained: { consequence: `Sleep maintained ${uniqueId}` },
+        neglected: { consequence: `Sleep neglected ${uniqueId}` },
+        priorityId: "sleep",
+      },
+    ],
+    priorities: [
+      { description: `Study notes ${uniqueId}`, id: "study", name: `Study ${uniqueId}` },
+      {
+        description: `Physical activity ${uniqueId}`,
+        id: "exercise",
+        name: `Exercise ${uniqueId}`,
+      },
+      { description: `Rest and recovery ${uniqueId}`, id: "sleep", name: `Sleep ${uniqueId}` },
+    ],
+    resource: { name: "hours", total: 5 },
+    stateModifiers: overrides.stateModifiers ?? null,
+    tokenOverride: overrides.tokenOverride ?? null,
+  };
+}
+
+async function createTradeoffActivity(options: {
+  rounds: {
+    event?: string | null;
+    stateModifiers?: { delta: number; priorityId: string }[] | null;
+    tokenOverride?: number | null;
+  }[];
+  uniqueId: string;
+}) {
+  const org = await getAiOrganization();
+  const { uniqueId } = options;
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-tf-course-${uniqueId}`,
+    title: `E2E TF Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-tf-chapter-${uniqueId}`,
+    title: `E2E TF Chapter ${uniqueId}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    description: `E2E tradeoff lesson ${uniqueId}`,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-tf-lesson-${uniqueId}`,
+    title: `E2E TF Lesson ${uniqueId}`,
+  });
+
+  const activity = await activityFixture({
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "tradeoff",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 0,
+    title: `E2E TF Activity ${uniqueId}`,
+  });
+
+  // Static intro step at position 0
+  const introStep = stepFixture({
+    activityId: activity.id,
+    content: { text: `Scenario text ${uniqueId}`, title: `Scenario ${uniqueId}`, variant: "text" },
+    isPublished: true,
+    kind: "static",
+    position: 0,
+  });
+
+  // Tradeoff round steps at positions 1..N
+  const roundSteps = options.rounds.map((round, index) =>
+    stepFixture({
+      activityId: activity.id,
+      content: makeTradeoffContent(uniqueId, round),
+      isPublished: true,
+      kind: "tradeoff",
+      position: index + 1,
+    }),
+  );
+
+  // Static reflection step at position N+1
+  const reflectionStep = stepFixture({
+    activityId: activity.id,
+    content: {
+      text: `Reflection text ${uniqueId}`,
+      title: `Reflection ${uniqueId}`,
+      variant: "text",
+    },
+    isPublished: true,
+    kind: "static",
+    position: options.rounds.length + 1,
+  });
+
+  // Second activity so the tested one is not the last in the lesson
+  const dummyActivity = activityFixture({
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "explanation",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 1,
+  });
+
+  await Promise.all([introStep, ...roundSteps, reflectionStep, dummyActivity]);
+
+  const url = `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/0`;
+
+  return { activity, url };
+}
+
+test.describe("Tradeoff Step", () => {
+  test("displays scenario intro, then allocation UI with stepper buttons", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createTradeoffActivity({
+      rounds: [{}],
+      uniqueId,
+    });
+
+    await page.goto(url);
+
+    // Intro static step shows scenario text
+    await expect(page.getByText(new RegExp(`Scenario text ${uniqueId}`))).toBeVisible();
+
+    // Navigate to the tradeoff round
+    await page.getByRole("button", { name: /next/i }).click();
+
+    // Allocation UI shows priority names
+    await expect(page.getByText(new RegExp(`Study ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`Exercise ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`Sleep ${uniqueId}`))).toBeVisible();
+
+    // Stepper buttons are present
+    await expect(
+      page.getByRole("button", { name: new RegExp(`Add to Study ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: new RegExp(`Remove from Study ${uniqueId}`) }),
+    ).toBeVisible();
+
+    // Check button is disabled (no tokens allocated yet)
+    await expect(page.getByRole("button", { name: /check/i })).toBeDisabled();
+  });
+
+  test("enables Check after all tokens are allocated and shows consequences", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createTradeoffActivity({
+      rounds: [{}],
+      uniqueId,
+    });
+
+    await page.goto(url);
+
+    // Skip intro
+    await page.getByRole("button", { name: /next/i }).click();
+
+    // Allocate all 5 tokens: 3 to study, 1 to exercise, 1 to sleep
+    const addStudy = page.getByRole("button", { name: new RegExp(`Add to Study ${uniqueId}`) });
+    const addExercise = page.getByRole("button", {
+      name: new RegExp(`Add to Exercise ${uniqueId}`),
+    });
+    const addSleep = page.getByRole("button", { name: new RegExp(`Add to Sleep ${uniqueId}`) });
+
+    await addStudy.click();
+    await addStudy.click();
+    await addStudy.click();
+    await addExercise.click();
+    await addSleep.click();
+
+    // Check button should now be enabled
+    await expect(page.getByRole("button", { name: /check/i })).toBeEnabled();
+
+    // Click check to see consequences
+    await page.getByRole("button", { name: /check/i }).click();
+
+    // Study got 3 tokens (invested), exercise got 1 (maintained), sleep got 1 (maintained)
+    await expect(page.getByText(new RegExp(`Study invested ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`Exercise maintained ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`Sleep maintained ${uniqueId}`))).toBeVisible();
+  });
+
+  test("full multi-round flow: allocate → consequences → event → allocate → consequences → reflection → completion", async ({
+    page,
+  }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const eventText = `Exam moved to tomorrow ${uniqueId}`;
+    const { url } = await createTradeoffActivity({
+      rounds: [
+        {},
+        {
+          event: eventText,
+          stateModifiers: [{ delta: -1, priorityId: "sleep" }],
+          tokenOverride: 4,
+        },
+      ],
+      uniqueId,
+    });
+
+    await page.goto(url);
+
+    // 1. Skip intro
+    await page.getByRole("button", { name: /next/i }).click();
+
+    // 2. Round 1: allocate 2-2-1
+    const addStudy = page.getByRole("button", { name: new RegExp(`Add to Study ${uniqueId}`) });
+    const addExercise = page.getByRole("button", {
+      name: new RegExp(`Add to Exercise ${uniqueId}`),
+    });
+    const addSleep = page.getByRole("button", { name: new RegExp(`Add to Sleep ${uniqueId}`) });
+
+    await addStudy.click();
+    await addStudy.click();
+    await addExercise.click();
+    await addExercise.click();
+    await addSleep.click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    // Round 1 consequences visible
+    await expect(page.getByText(new RegExp(`Study invested ${uniqueId}`))).toBeVisible();
+
+    // Continue to round 2
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // 3. Round 2: event banner visible
+    await expect(page.getByText(new RegExp(eventText))).toBeVisible();
+
+    // Round 2: allocate 2-1-1 (only 4 tokens available due to tokenOverride)
+    const addStudy2 = page.getByRole("button", { name: new RegExp(`Add to Study ${uniqueId}`) });
+    const addExercise2 = page.getByRole("button", {
+      name: new RegExp(`Add to Exercise ${uniqueId}`),
+    });
+    const addSleep2 = page.getByRole("button", { name: new RegExp(`Add to Sleep ${uniqueId}`) });
+
+    await addStudy2.click();
+    await addStudy2.click();
+    await addExercise2.click();
+    await addSleep2.click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    // Round 2 consequences visible
+    await expect(page.getByText(new RegExp(`Study invested ${uniqueId}`))).toBeVisible();
+
+    // Continue to reflection
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // 4. Reflection step
+    await expect(page.getByText(new RegExp(`Reflection text ${uniqueId}`))).toBeVisible();
+
+    // Navigate to completion
+    await page.getByRole("button", { name: /next/i }).click();
+
+    // 5. Completion screen shows "Completed" (not "X/Y correct")
+    await expect(page.getByText(/completed/i)).toBeVisible();
+  });
+
+  test("shows neglected consequence when 0 tokens allocated to a priority", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createTradeoffActivity({
+      rounds: [{}],
+      uniqueId,
+    });
+
+    await page.goto(url);
+    await page.getByRole("button", { name: /next/i }).click();
+
+    // Allocate all 5 tokens to study, nothing to exercise or sleep
+    const addStudy = page.getByRole("button", { name: new RegExp(`Add to Study ${uniqueId}`) });
+
+    await addStudy.click();
+    await addStudy.click();
+    await addStudy.click();
+    await addStudy.click();
+    await addStudy.click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    // Exercise and sleep got 0 tokens → neglected
+    await expect(page.getByText(new RegExp(`Exercise neglected ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`Sleep neglected ${uniqueId}`))).toBeVisible();
+  });
+
+  test("stepper minus button is disabled at 0 tokens", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createTradeoffActivity({
+      rounds: [{}],
+      uniqueId,
+    });
+
+    await page.goto(url);
+    await page.getByRole("button", { name: /next/i }).click();
+
+    // At 0 tokens, minus should be disabled
+    const removeStudy = page.getByRole("button", {
+      name: new RegExp(`Remove from Study ${uniqueId}`),
+    });
+    await expect(removeStudy).toBeDisabled();
+
+    // After adding, minus should be enabled
+    const addStudy = page.getByRole("button", { name: new RegExp(`Add to Study ${uniqueId}`) });
+    await addStudy.click();
+    await expect(removeStudy).toBeEnabled();
+  });
+});

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -316,6 +316,71 @@ msgctxt "VA8c/A"
 msgid "Correct order:"
 msgstr "Correct order:"
 
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "1nYFVe"
+msgid "All {resource} allocated. Tap Check to see what happens."
+msgstr "All {resource} allocated. Tap Check to see what happens."
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "2kjEYh"
+msgid "{allocated} of {total} {resource} allocated"
+msgstr "{allocated} of {total} {resource} allocated"
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "Fk/yRD"
+msgid "{count} for {priority}"
+msgstr "{count} for {priority}"
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "fQKXig"
+msgid "Remove from {priority}"
+msgstr "Remove from {priority}"
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "fT/Gww"
+msgid "Add to {priority}"
+msgstr "Add to {priority}"
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "xcMVN8"
+msgid "Round {current} of {total}"
+msgstr "Round {current} of {total}"
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-event-banner.tsx
+msgctxt "garskw"
+msgid "You now have {count} {resource}."
+msgstr "You now have {count} {resource}."
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-final-states.tsx
+msgctxt "pomVZp"
+msgid "Final state"
+msgstr "Final state"
+
+#: ../../packages/player/src/components/tradeoff/use-state-tier-label.ts
+msgctxt "/UNyqw"
+msgid "Stable"
+msgstr "Stable"
+
+#: ../../packages/player/src/components/tradeoff/use-state-tier-label.ts
+msgctxt "2pzTGC"
+msgid "Critical"
+msgstr "Critical"
+
+#: ../../packages/player/src/components/tradeoff/use-state-tier-label.ts
+msgctxt "e+SDEH"
+msgid "Stressed"
+msgstr "Stressed"
+
+#: ../../packages/player/src/components/tradeoff/use-state-tier-label.ts
+msgctxt "G9gjpL"
+msgid "Thriving"
+msgstr "Thriving"
+
+#: ../../packages/player/src/components/tradeoff/use-state-tier-label.ts
+msgctxt "TIDNOO"
+msgid "Healthy"
+msgstr "Healthy"
+
 #: ../../packages/player/src/components/translation-step.tsx
 msgctxt "MxLxkr"
 msgid "Translate this word:"
@@ -2481,6 +2546,11 @@ msgid "Test your understanding of {topic} with questions designed to check real 
 msgstr "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
 
 #: src/lib/activities.ts
+msgctxt "k1VNwu"
+msgid "Tradeoff"
+msgstr "Tradeoff"
+
+#: src/lib/activities.ts
 msgctxt "KV+O0y"
 msgid "Practice"
 msgstr "Practice"
@@ -2534,6 +2604,11 @@ msgstr "{activity} - {lesson}"
 msgctxt "XzxpBZ"
 msgid "Improve your {topic} reading comprehension by translating sentences and passages."
 msgstr "Improve your {topic} reading comprehension by translating sentences and passages."
+
+#: src/lib/activities.ts
+msgctxt "y3b5D+"
+msgid "Navigate real-world tradeoffs about {topic} — allocate limited resources across competing priorities and see how your choices play out."
+msgstr "Navigate real-world tradeoffs about {topic} — allocate limited resources across competing priorities and see how your choices play out."
 
 #: src/lib/activities.ts
 msgctxt "YfgUQS"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -316,6 +316,71 @@ msgctxt "VA8c/A"
 msgid "Correct order:"
 msgstr "Orden correcto:"
 
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "1nYFVe"
+msgid "All {resource} allocated. Tap Check to see what happens."
+msgstr "Todo {resource} asignado. Toca Comprobar para ver qué sucede."
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "2kjEYh"
+msgid "{allocated} of {total} {resource} allocated"
+msgstr "Se asignaron {allocated} de {total} {resource}"
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "Fk/yRD"
+msgid "{count} for {priority}"
+msgstr "{count} para {priority}"
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "fQKXig"
+msgid "Remove from {priority}"
+msgstr "Quitar de {priority}"
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "fT/Gww"
+msgid "Add to {priority}"
+msgstr "Añadir a {priority}"
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "xcMVN8"
+msgid "Round {current} of {total}"
+msgstr "Ronda {current} de {total}"
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-event-banner.tsx
+msgctxt "garskw"
+msgid "You now have {count} {resource}."
+msgstr "Ahora tienes {count} {resource}."
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-final-states.tsx
+msgctxt "pomVZp"
+msgid "Final state"
+msgstr "Estado final"
+
+#: ../../packages/player/src/components/tradeoff/use-state-tier-label.ts
+msgctxt "/UNyqw"
+msgid "Stable"
+msgstr "Estable"
+
+#: ../../packages/player/src/components/tradeoff/use-state-tier-label.ts
+msgctxt "2pzTGC"
+msgid "Critical"
+msgstr "Crítico"
+
+#: ../../packages/player/src/components/tradeoff/use-state-tier-label.ts
+msgctxt "e+SDEH"
+msgid "Stressed"
+msgstr "Bajo presión"
+
+#: ../../packages/player/src/components/tradeoff/use-state-tier-label.ts
+msgctxt "G9gjpL"
+msgid "Thriving"
+msgstr "En crecimiento"
+
+#: ../../packages/player/src/components/tradeoff/use-state-tier-label.ts
+msgctxt "TIDNOO"
+msgid "Healthy"
+msgstr "Saludable"
+
 #: ../../packages/player/src/components/translation-step.tsx
 msgctxt "MxLxkr"
 msgid "Translate this word:"
@@ -2481,6 +2546,11 @@ msgid "Test your understanding of {topic} with questions designed to check real 
 msgstr "Pon a prueba tu comprensión de {topic} con preguntas diseñadas para verificar la comprensión real, no solo la memorización."
 
 #: src/lib/activities.ts
+msgctxt "k1VNwu"
+msgid "Tradeoff"
+msgstr "Dilema"
+
+#: src/lib/activities.ts
 msgctxt "KV+O0y"
 msgid "Practice"
 msgstr "Practica"
@@ -2534,6 +2604,11 @@ msgstr "{activity} - {lesson}"
 msgctxt "XzxpBZ"
 msgid "Improve your {topic} reading comprehension by translating sentences and passages."
 msgstr "Mejora tu comprensión de lectura en {topic} traduciendo oraciones y pasajes."
+
+#: src/lib/activities.ts
+msgctxt "y3b5D+"
+msgid "Navigate real-world tradeoffs about {topic} — allocate limited resources across competing priorities and see how your choices play out."
+msgstr "Explora dilemas del mundo real sobre {topic} — asigna recursos limitados entre prioridades en competencia y mira cómo se desarrollan tus decisiones."
 
 #: src/lib/activities.ts
 msgctxt "YfgUQS"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -316,6 +316,71 @@ msgctxt "VA8c/A"
 msgid "Correct order:"
 msgstr "Ordem correta:"
 
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "1nYFVe"
+msgid "All {resource} allocated. Tap Check to see what happens."
+msgstr "Todos os {resource} alocados. Toque em Verificar para ver o que acontece."
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "2kjEYh"
+msgid "{allocated} of {total} {resource} allocated"
+msgstr "{allocated} de {total} {resource} alocados"
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "Fk/yRD"
+msgid "{count} for {priority}"
+msgstr "{count} para {priority}"
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "fQKXig"
+msgid "Remove from {priority}"
+msgstr "Remover de {priority}"
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "fT/Gww"
+msgid "Add to {priority}"
+msgstr "Adicionar a {priority}"
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+msgctxt "xcMVN8"
+msgid "Round {current} of {total}"
+msgstr "Rodada {current} de {total}"
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-event-banner.tsx
+msgctxt "garskw"
+msgid "You now have {count} {resource}."
+msgstr "Agora você tem {count} {resource}."
+
+#: ../../packages/player/src/components/tradeoff/tradeoff-final-states.tsx
+msgctxt "pomVZp"
+msgid "Final state"
+msgstr "Estado final"
+
+#: ../../packages/player/src/components/tradeoff/use-state-tier-label.ts
+msgctxt "/UNyqw"
+msgid "Stable"
+msgstr "Estável"
+
+#: ../../packages/player/src/components/tradeoff/use-state-tier-label.ts
+msgctxt "2pzTGC"
+msgid "Critical"
+msgstr "Crítico"
+
+#: ../../packages/player/src/components/tradeoff/use-state-tier-label.ts
+msgctxt "e+SDEH"
+msgid "Stressed"
+msgstr "Sob pressão"
+
+#: ../../packages/player/src/components/tradeoff/use-state-tier-label.ts
+msgctxt "G9gjpL"
+msgid "Thriving"
+msgstr "Prosperando"
+
+#: ../../packages/player/src/components/tradeoff/use-state-tier-label.ts
+msgctxt "TIDNOO"
+msgid "Healthy"
+msgstr "Saudável"
+
 #: ../../packages/player/src/components/translation-step.tsx
 msgctxt "MxLxkr"
 msgid "Translate this word:"
@@ -2481,6 +2546,11 @@ msgid "Test your understanding of {topic} with questions designed to check real 
 msgstr "Teste sua compreensão de {topic} com perguntas projetadas para verificar compreensão real, não apenas memorização."
 
 #: src/lib/activities.ts
+msgctxt "k1VNwu"
+msgid "Tradeoff"
+msgstr "Dilema"
+
+#: src/lib/activities.ts
 msgctxt "KV+O0y"
 msgid "Practice"
 msgstr "Praticar"
@@ -2534,6 +2604,11 @@ msgstr "{activity} - {lesson}"
 msgctxt "XzxpBZ"
 msgid "Improve your {topic} reading comprehension by translating sentences and passages."
 msgstr "Melhore sua compreensão de leitura em {topic} traduzindo frases e passagens."
+
+#: src/lib/activities.ts
+msgctxt "y3b5D+"
+msgid "Navigate real-world tradeoffs about {topic} — allocate limited resources across competing priorities and see how your choices play out."
+msgstr "Navegue por dilemas reais sobre {topic} — distribua recursos limitados entre prioridades concorrentes e veja como suas escolhas se desenrolam."
 
 #: src/lib/activities.ts
 msgctxt "YfgUQS"

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
@@ -6,7 +6,7 @@ import { submitActivityCompletion } from "@/data/progress/submit-activity-comple
 import { auth } from "@zoonk/core/auth";
 import { type LessonSentence, prisma } from "@zoonk/db";
 import { type CompletionInput, completionInputSchema } from "@zoonk/player/completion-input-schema";
-import { computeScore } from "@zoonk/player/compute-score";
+import { computeScore, computeTradeoffScore } from "@zoonk/player/compute-score";
 import { validateAnswers } from "@zoonk/player/validate-answers";
 import { logError } from "@zoonk/utils/logger";
 import { revalidatePath } from "next/cache";
@@ -113,9 +113,12 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<void>
 
       const stepResults = validateAnswers(stepsForValidation, input.answers);
 
-      const score = computeScore({
-        results: stepResults.map((step) => ({ isCorrect: step.isCorrect })),
-      });
+      const score =
+        activity.kind === "tradeoff"
+          ? computeTradeoffScore()
+          : computeScore({
+              results: stepResults.map((step) => ({ isCorrect: step.isCorrect })),
+            });
 
       const durationSeconds = clampDuration(input.startedAt);
 
@@ -138,6 +141,7 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<void>
         activityId: activity.id,
         courseId: activity.lesson.chapter.courseId,
         durationSeconds,
+        isTradeoff: activity.kind === "tradeoff",
         localDate: input.localDate,
         organizationId: activity.organizationId,
         score,

--- a/apps/main/src/data/progress/submit-activity-completion.test.ts
+++ b/apps/main/src/data/progress/submit-activity-completion.test.ts
@@ -698,4 +698,107 @@ describe(submitActivityCompletion, () => {
     });
     expect(todayRecord?.energyAtEnd).toBeCloseTo(46.2);
   });
+
+  describe("tradeoff activity", () => {
+    test("increments tradeoffCompleted and awards boosted BP + energy", async () => {
+      const user = await userFixture();
+      const userId = Number(user.id);
+
+      const tradeoffActivity = await activityFixture({
+        kind: "tradeoff",
+        lessonId: lesson.id,
+        organizationId: org.id,
+      });
+
+      const tradeoffStep = await stepFixture({
+        activityId: tradeoffActivity.id,
+        content: {
+          event: null,
+          outcomes: [
+            {
+              invested: { consequence: "good" },
+              maintained: { consequence: "ok" },
+              neglected: { consequence: "bad" },
+              priorityId: "study",
+            },
+            {
+              invested: { consequence: "good" },
+              maintained: { consequence: "ok" },
+              neglected: { consequence: "bad" },
+              priorityId: "exercise",
+            },
+            {
+              invested: { consequence: "good" },
+              maintained: { consequence: "ok" },
+              neglected: { consequence: "bad" },
+              priorityId: "sleep",
+            },
+          ],
+          priorities: [
+            { description: "d", id: "study", name: "Study" },
+            { description: "d", id: "exercise", name: "Exercise" },
+            { description: "d", id: "sleep", name: "Sleep" },
+          ],
+          resource: { name: "hours", total: 5 },
+          stateModifiers: null,
+          tokenOverride: null,
+        },
+        kind: "tradeoff",
+      });
+
+      const result = await submitActivityCompletion({
+        activityId: tradeoffActivity.id,
+        courseId: course.id,
+        durationSeconds: 30,
+        isTradeoff: true,
+        localDate: todayLocalDate(),
+        organizationId: org.id,
+        score: { brainPower: 100, correctCount: 0, energyDelta: 5, incorrectCount: 0 },
+        startedAt: new Date(),
+        stepResults: [
+          {
+            answer: {
+              allocations: [
+                { priorityId: "study", tokens: 3 },
+                { priorityId: "exercise", tokens: 1 },
+                { priorityId: "sleep", tokens: 1 },
+              ],
+              kind: "tradeoff",
+            },
+            answeredAt: new Date(),
+            dayOfWeek: 1,
+            durationSeconds: 15,
+            hourOfDay: 14,
+            isCorrect: true,
+            stepId: tradeoffStep.id,
+          },
+        ],
+        userId,
+      });
+
+      expect(result.brainPower).toBe(100);
+      expect(result.energyDelta).toBe(5);
+
+      const userProgress = await prisma.userProgress.findUniqueOrThrow({
+        where: { userId },
+      });
+      expect(Number(userProgress.totalBrainPower)).toBe(100);
+      expect(userProgress.currentEnergy).toBe(5);
+
+      const dailyProgress = await prisma.dailyProgress.findFirst({
+        where: { organizationId: org.id, userId },
+      });
+      expect(dailyProgress?.tradeoffCompleted).toBe(1);
+      expect(dailyProgress?.interactiveCompleted).toBe(0);
+      expect(dailyProgress?.staticCompleted).toBe(0);
+      expect(dailyProgress?.brainPowerEarned).toBe(100);
+
+      // Verify StepAttempt was created for analytics
+      const attempts = await prisma.stepAttempt.findMany({
+        where: { stepId: tradeoffStep.id, userId },
+      });
+      expect(attempts).toHaveLength(1);
+      expect(attempts[0]?.isCorrect).toBe(true);
+    });
+  });
 });

--- a/apps/main/src/data/progress/submit-activity-completion.ts
+++ b/apps/main/src/data/progress/submit-activity-completion.ts
@@ -13,9 +13,16 @@ import {
 
 const MAX_LOCAL_DATE_DRIFT_MS = 2 * MS_PER_DAY;
 
+type CompletionField = "interactiveCompleted" | "staticCompleted" | "tradeoffCompleted";
+
 function getCompletionField(input: {
+  isTradeoff: boolean;
   stepResults: unknown[];
-}): "interactiveCompleted" | "staticCompleted" {
+}): CompletionField {
+  if (input.isTradeoff) {
+    return "tradeoffCompleted";
+  }
+
   if (input.stepResults.length === 0) {
     return "staticCompleted";
   }
@@ -61,7 +68,7 @@ async function upsertDailyProgress(
     date: Date;
     dayOfWeek: number;
     durationSeconds: number;
-    field: "interactiveCompleted" | "staticCompleted";
+    field: CompletionField;
     organizationId: number | null;
     score: ScoreResult;
     userId: number;
@@ -78,6 +85,7 @@ async function upsertDailyProgress(
     organizationId: params.organizationId,
     staticCompleted: params.field === "staticCompleted" ? 1 : 0,
     timeSpentSeconds: params.durationSeconds,
+    tradeoffCompleted: params.field === "tradeoffCompleted" ? 1 : 0,
     userId: params.userId,
   };
 
@@ -130,6 +138,7 @@ export async function submitActivityCompletion(input: {
   activityId: bigint;
   courseId: number;
   durationSeconds: number;
+  isTradeoff?: boolean;
   localDate: string;
   organizationId: number | null;
   score: ScoreResult;
@@ -248,7 +257,10 @@ export async function submitActivityCompletion(input: {
     });
 
     // DailyProgress upsert for today
-    const field = getCompletionField(input);
+    const field = getCompletionField({
+      isTradeoff: input.isTradeoff ?? false,
+      stepResults: input.stepResults,
+    });
 
     await upsertDailyProgress(tx, {
       clampedEnergy,

--- a/apps/main/src/lib/activities.ts
+++ b/apps/main/src/lib/activities.ts
@@ -9,6 +9,7 @@ import {
   LayersIcon,
   type LucideIcon,
   RotateCcwIcon,
+  ScaleIcon,
   SparklesIcon,
   TargetIcon,
 } from "lucide-react";
@@ -26,6 +27,7 @@ export async function getActivityKinds(): Promise<{ key: ActivityKind; label: st
     { key: "grammar", label: t("Grammar") },
     { key: "reading", label: t("Reading") },
     { key: "listening", label: t("Listening") },
+    { key: "tradeoff", label: t("Tradeoff") },
     { key: "review", label: t("Review") },
   ];
 }
@@ -57,6 +59,10 @@ async function getSeoDescription(kind: ActivityKind, topic: string): Promise<str
       { topic },
     ),
     review: t("Review everything you learned about {topic} with a comprehensive quiz.", { topic }),
+    tradeoff: t(
+      "Navigate real-world tradeoffs about {topic} — allocate limited resources across competing priorities and see how your choices play out.",
+      { topic },
+    ),
     translation: t("Test your {topic} vocabulary by translating words you've learned.", { topic }),
     vocabulary: t(
       "Learn new {topic} words with flashcards — see each word, its translation, and pronunciation.",
@@ -120,6 +126,7 @@ const ACTIVITY_ICONS: Record<ActivityKind, LucideIcon> = {
   quiz: CircleHelpIcon,
   reading: BookTextIcon,
   review: RotateCcwIcon,
+  tradeoff: ScaleIcon,
   translation: LanguagesIcon,
   vocabulary: LayersIcon,
 };

--- a/apps/main/src/lib/generation/activity-generation-phase-config.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-config.ts
@@ -15,6 +15,8 @@ import {
   QUIZ_PHASE_STEPS,
   READING_PHASE_ORDER,
   READING_PHASE_STEPS,
+  TRADEOFF_PHASE_ORDER,
+  TRADEOFF_PHASE_STEPS,
   VOCABULARY_PHASE_ORDER,
   VOCABULARY_PHASE_STEPS,
 } from "./activity-generation-phase-kind-steps";
@@ -78,6 +80,7 @@ const PHASE_ORDER_MAP: Record<ActivityKind, PhaseName[]> = {
   quiz: QUIZ_PHASE_ORDER,
   reading: READING_PHASE_ORDER,
   review: EXPLANATION_PHASE_ORDER,
+  tradeoff: TRADEOFF_PHASE_ORDER,
   translation: VOCABULARY_PHASE_ORDER,
   vocabulary: VOCABULARY_PHASE_ORDER,
 };
@@ -130,6 +133,7 @@ const PHASE_STEPS_MAP: Record<ActivityKind, Record<PhaseName, readonly ActivityS
   quiz: toFullPhaseSteps(QUIZ_PHASE_STEPS),
   reading: toFullPhaseSteps(READING_PHASE_STEPS),
   review: toFullPhaseSteps(EXPLANATION_PHASE_STEPS),
+  tradeoff: toFullPhaseSteps(TRADEOFF_PHASE_STEPS),
   translation: toFullPhaseSteps(VOCABULARY_PHASE_STEPS),
   vocabulary: toFullPhaseSteps(VOCABULARY_PHASE_STEPS),
 };

--- a/apps/main/src/lib/generation/activity-generation-phase-kind-steps.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-kind-steps.ts
@@ -306,6 +306,38 @@ export const QUIZ_PHASE_ORDER: PhaseName[] = [
   "saving",
 ];
 
+// -- Tradeoff ---------------------------------------------------------------
+//
+// Tradeoff activities generate a resource allocation scenario with multiple
+// rounds. Like practice, they depend on explanation content for context.
+// Single AI call + save — no images or audio.
+
+type TradeoffSteps =
+  | "getLessonActivities"
+  | "getNeighboringConcepts"
+  | "setActivityAsRunning"
+  | "generateExplanationContent"
+  | "generateTradeoffContent"
+  | "saveTradeoffActivity";
+
+export const TRADEOFF_PHASE_STEPS = {
+  gettingStarted: ["getLessonActivities", "getNeighboringConcepts", "setActivityAsRunning"],
+  saving: ["saveTradeoffActivity"],
+  writingContent: ["generateTradeoffContent"],
+  writingExplanation: ["generateExplanationContent"],
+} as const satisfies Record<string, readonly ActivityStepName[]>;
+
+type _ValidateTradeoff = AssertAllCovered<
+  Exclude<TradeoffSteps, (typeof TRADEOFF_PHASE_STEPS)[keyof typeof TRADEOFF_PHASE_STEPS][number]>
+>;
+
+export const TRADEOFF_PHASE_ORDER: PhaseName[] = [
+  "gettingStarted",
+  "writingExplanation",
+  "writingContent",
+  "saving",
+];
+
 // -- Practice ---------------------------------------------------------------
 
 type PracticeSteps =

--- a/apps/main/src/lib/generation/activity-generation-phase-weights.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-weights.ts
@@ -119,6 +119,16 @@ export function getPhaseWeights(kind: ActivityKind): Record<PhaseName, number> {
     };
   }
 
+  if (kind === "tradeoff") {
+    return {
+      ...ZERO_WEIGHTS,
+      gettingStarted: 5,
+      saving: 5,
+      writingContent: 50,
+      writingExplanation: 40,
+    };
+  }
+
   if (kind === "practice") {
     return {
       ...ZERO_WEIGHTS,

--- a/i18n.lock
+++ b/i18n.lock
@@ -250,6 +250,19 @@ checksums:
     Drag%20items%20into%20the%20correct%20order/singular: 8ccab82ee3ba645ac23da4ca14a0dd2a
     Sort%20items/singular: 3b1072a596203b5acdc5718d38161392
     Correct%20order%3A/singular: df3f446653ec8cde9c29d8d5912636ef
+    All%20%7Bresource%7D%20allocated.%20Tap%20Check%20to%20see%20what%20happens./singular: 7b8d26da1f3b9d3ea7f641f357300284
+    "%7Ballocated%7D%20of%20%7Btotal%7D%20%7Bresource%7D%20allocated/singular": ccc85d4365fd53b39ae075de5af332cb
+    "%7Bcount%7D%20for%20%7Bpriority%7D/singular": 4f3e5315af485baf2aed59bbd8724a5b
+    Remove%20from%20%7Bpriority%7D/singular: d37d557caa6f47775b2895d5f20a8e4d
+    Add%20to%20%7Bpriority%7D/singular: 338f059d76d39fde44745cf3761bfd38
+    Round%20%7Bcurrent%7D%20of%20%7Btotal%7D/singular: be6cb1edf8c1c749fca1c3ac4371d7a7
+    You%20now%20have%20%7Bcount%7D%20%7Bresource%7D./singular: f349005db6bd92aab706320282f8cc31
+    Final%20state/singular: 917efbc42bb73a48b957ebaf4459355d
+    Stable/singular: 28f533f118426f7ae7d274c90d6d3031
+    Critical/singular: eb327cd411b50aee954f8d1d215d003a
+    Stressed/singular: ef49e5b495c5c1bca26897208d0c926a
+    Thriving/singular: 09b11a4ee3607fd466eeb502a7c12d7d
+    Healthy/singular: a16896be3f594e1def8245fae1c9d93c
     Translate%20this%20word%3A/singular: 05fede3c583e9ea39f27ac9fdf17fcc3
     Visual%20content/singular: 38b0261c39ebe4d775867363482225d8
     Legend/singular: 3b588fbd2fe35ded6ca38334e15400c3
@@ -665,6 +678,7 @@ checksums:
     Explanation/singular: f6b595df4ffb1a5b0cbbe1dda5993522
     Sharpen%20your%20%7Btopic%7D%20listening%20skills%20by%20translating%20audio%20sentences./singular: b624ceffbbfc91a29cec43a0037b067f
     Test%20your%20understanding%20of%20%7Btopic%7D%20with%20questions%20designed%20to%20check%20real%20comprehension%2C%20not%20just%20memorization./singular: d9f3e39d19b1c6969b481bc8aec8fc10
+    Tradeoff/singular: 17dd8d0b8a47685bc1e2d6fc4ae6212e
     Practice/singular: ea10afa88a3687e6c40d1bfb3e0f4f20
     "%7Blesson%7D%20%7Bactivity%7D/singular": d959fed1ee77dca493e8cf0a3b3129c0
     Reading/singular: 9d93f1dff4a01a9e1566f23b401b8868
@@ -676,6 +690,7 @@ checksums:
     Practice%20%7Btopic%7D%20grammar%20rules%20with%20exercises%20designed%20to%20help%20you%20remember%20and%20apply%20them./singular: 107adae09992e8b4deb051afa38da3bd
     "%7Bactivity%7D%20-%20%7Blesson%7D/singular": 0aad8d82851f799d79c052a0f2b90d67
     Improve%20your%20%7Btopic%7D%20reading%20comprehension%20by%20translating%20sentences%20and%20passages./singular: 60baac4222f76009cc1eb1b6065b403b
+    Navigate%20real-world%20tradeoffs%20about%20%7Btopic%7D%20%E2%80%94%20allocate%20limited%20resources%20across%20competing%20priorities%20and%20see%20how%20your%20choices%20play%20out./singular: fb4f0bd021e81000b3620253f7f56b55
     Apply%20%7Btopic%7D%20through%20a%20real-world%20dialogue%20scenario./singular: e170c3bd82d42f0972d0f447f10379f0
     "%7Bcategory%7D%20Courses/singular": f82680a650c487992e1025b66f324d4c
     Math/singular: 0a604ffa5ef57408918fe98ef05eb05a

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -8,6 +8,7 @@
     "./tasks/activities/core/explanation": "./src/tasks/activities/core/activity-explanation.ts",
     "./tasks/activities/core/practice": "./src/tasks/activities/core/activity-practice.ts",
     "./tasks/activities/core/quiz": "./src/tasks/activities/core/activity-quiz.ts",
+    "./tasks/activities/core/tradeoff": "./src/tasks/activities/core/activity-tradeoff.ts",
     "./tasks/activities/custom": "./src/tasks/activities/custom/activity-custom.ts",
     "./tasks/activities/language/distractors": "./src/tasks/activities/language/activity-distractors.ts",
     "./tasks/activities/language/grammar-content": "./src/tasks/activities/language/activity-grammar-content.ts",

--- a/packages/ai/src/tasks/activities/core/activity-tradeoff.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-tradeoff.prompt.md
@@ -1,0 +1,125 @@
+# Role
+
+You are an expert scenario designer creating resource allocation games that teach through experience, not instruction. The learner should USE lesson concepts to navigate a real situation — not discuss or recite them.
+
+# What You're Creating
+
+A tradeoff activity where the learner has a limited pool of tokens (e.g., "hours", "sprints", "budget") and must distribute them across 3-4 competing priorities. After each allocation, consequences play out based on a three-tier system:
+
+- **0 tokens → Neglected**: The priority actively declines
+- **1 token → Maintained**: Treading water, no improvement
+- **2+ tokens → Invested**: Real improvement
+
+This means spreading tokens evenly (1 each) keeps everything stable but improves nothing. The learner must concentrate tokens to make progress, which forces genuine tradeoff decisions.
+
+# Core Design Principles
+
+## 1. Application Over Recall
+
+The learner just finished reading explanation steps about the lesson topic. This activity tests whether they can APPLY those concepts, not recall them. The consequence text should naturally reference lesson concepts as they play out — teaching through experience.
+
+## 2. Genuine Tension Through Scarcity
+
+The core tension comes from the constraint: you literally can't have everything. With 5 tokens and 3 priorities, you can invest in at most two while neglecting one. Every choice has real costs.
+
+## 3. No Right Answer
+
+There is no optimal allocation. Different strategies lead to different outcomes, each with genuine pros and cons. The learning comes from experiencing consequences, not from finding the "correct" answer.
+
+## 4. Priorities Must Conflict
+
+Investing in one priority should make neglecting another WORSE, not just leave it unchanged. For example, investing in "Delivery Speed" while neglecting "Code Quality" should result in a worse code quality outcome than just neglecting it passively.
+
+## 5. At Least One Trap Priority
+
+One priority should sound urgent or important but investing heavily in it has diminishing returns — 1 token of maintenance is enough. The learner has to read carefully and apply lesson concepts, not react emotionally to labels.
+
+## 6. The "Safe" Choice Has a Cost
+
+If someone maintains everything (1 token each), the consequences should explicitly communicate that stagnation has a cost: "You kept things stable, but nothing improved while competitors/problems/demands advanced."
+
+# Round Design
+
+## Round Count
+
+Choose the number of rounds based on topic complexity:
+
+- **2 rounds**: Simple, introductory topics with straightforward tradeoffs
+- **3 rounds**: Moderate topics with layered complexity
+- **4 rounds**: Complex, multi-faceted topics where consequences compound
+
+## Round 1 (Setup)
+
+- No event (event: null, stateModifiers: null, tokenOverride: null)
+- Consequences should be SHORT — one visceral sentence each
+- The outcomes should hint at fragility without fully explaining why
+
+## Rounds 2+ (Disruption)
+
+- Each round MUST have an event that changes the situation
+- Events should invalidate the previous round's "obvious" strategy
+- Token count can decrease (tighter choices) or stay the same
+- State modifiers can shift priorities before allocation (e.g., stress drops a priority by -1)
+- Consequences can be 1-2 sentences, longer than round 1
+- Later rounds should create harder, tighter decisions
+
+## Token Progression
+
+Resources should generally tighten across rounds to force harder choices:
+
+- Example: 5 → 4 → 3 (fewer resources each round)
+- Alternative: same tokens but add a 4th priority in round 3
+
+# Scenario Design
+
+- **Introductory topics**: Everyday scenarios (studying for an exam, managing a household budget, planning a trip)
+- **Advanced topics**: Workplace or professional scenarios (managing a startup, leading a team, allocating engineering resources)
+- Use `{{NAME}}` placeholder for personalization in scenario text and events
+- The scenario should feel like a real dilemma, not a pedagogical setup
+
+# Reflection
+
+The reflection should:
+
+- Surface the underlying principle the tradeoff illustrates
+- Connect back to specific lesson concepts
+- Explain WHY different strategies lead to different outcomes
+- Be written as a learning moment, not a grade report
+
+# Language Guidelines
+
+Generate all content in the specified `LANGUAGE`:
+
+- `en`: US English unless content is region-specific
+- `pt`: Brazilian Portuguese unless content is region-specific
+- `es`: Latin American Spanish unless content is region-specific
+
+**Language Purity Rule**: Every word in the output MUST be in the specified LANGUAGE. Never mix languages.
+
+# Constraints
+
+- 3-4 priorities, each with a unique `id` (camelCase, e.g., "codeQuality")
+- 4-6 total tokens for the base resource
+- Priority name: max 40 characters
+- Priority description: max 100 characters
+- Scenario text: max 200 characters
+- Event text: max 300 characters
+- Consequence text: max 200 characters
+- Reflection text: max 500 characters
+- Round 1 event MUST be null
+- Each round must have one outcome per priority
+- Outcomes must reference all priority IDs defined in the priorities array
+
+# Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] Priorities genuinely conflict — investing in one makes neglecting another worse
+- [ ] At least one priority is a "trap" — sounds urgent but maintenance is enough
+- [ ] Maintained outcomes feel distinct from invested and neglected (not just "medium" versions)
+- [ ] Events change the strategic landscape, not just add narrative flavor
+- [ ] Round 1 consequences are short and visceral (one sentence)
+- [ ] The "spread evenly" strategy has explicit drawbacks
+- [ ] Reflection connects to lesson concepts, not just the scenario
+- [ ] All text is in the specified LANGUAGE
+- [ ] All character limits are respected

--- a/packages/ai/src/tasks/activities/core/activity-tradeoff.ts
+++ b/packages/ai/src/tasks/activities/core/activity-tradeoff.ts
@@ -1,0 +1,107 @@
+import "server-only";
+import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { Output, generateText } from "ai";
+import { z } from "zod";
+import systemPrompt from "./activity-tradeoff.prompt.md";
+
+const DEFAULT_MODEL = process.env.AI_MODEL_ACTIVITY_TRADEOFF ?? "openai/gpt-5.4";
+const FALLBACK_MODELS = ["anthropic/claude-opus-4.6"];
+
+const MIN_ROUNDS = 2;
+const MAX_ROUNDS = 4;
+
+const outcomeSchema = z.object({
+  invested: z.object({ consequence: z.string() }),
+  maintained: z.object({ consequence: z.string() }),
+  neglected: z.object({ consequence: z.string() }),
+  priorityId: z.string(),
+});
+
+const stateModifierSchema = z.object({
+  delta: z.number().int(),
+  priorityId: z.string(),
+});
+
+const roundSchema = z.object({
+  event: z.string().nullable(),
+  outcomes: z.array(outcomeSchema),
+  stateModifiers: z.array(stateModifierSchema).nullable(),
+  tokenOverride: z.number().int().nullable(),
+});
+
+const schema = z.object({
+  priorities: z.array(
+    z.object({
+      description: z.string(),
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+  reflection: z.object({
+    text: z.string(),
+    title: z.string(),
+  }),
+  resource: z.object({
+    name: z.string(),
+    total: z.number().int(),
+  }),
+  rounds: z.array(roundSchema).min(MIN_ROUNDS).max(MAX_ROUNDS),
+  scenario: z.object({
+    text: z.string(),
+    title: z.string(),
+  }),
+});
+
+export type ActivityTradeoffSchema = z.infer<typeof schema>;
+
+export type ActivityTradeoffParams = {
+  chapterTitle: string;
+  courseTitle: string;
+  explanationSteps: { title: string; text: string }[];
+  language: string;
+  lessonDescription: string;
+  lessonTitle: string;
+  model?: string;
+  reasoningEffort?: ReasoningEffort;
+  useFallback?: boolean;
+};
+
+export async function generateActivityTradeoff({
+  chapterTitle,
+  courseTitle,
+  explanationSteps,
+  language,
+  lessonDescription,
+  lessonTitle,
+  model = DEFAULT_MODEL,
+  reasoningEffort,
+  useFallback = true,
+}: ActivityTradeoffParams) {
+  const formattedExplanationSteps = explanationSteps
+    .map((step, index) => `${index + 1}. ${step.title}: ${step.text}`)
+    .join("\n");
+
+  const userPrompt = `LESSON_TITLE: ${lessonTitle}
+LESSON_DESCRIPTION: ${lessonDescription}
+CHAPTER_TITLE: ${chapterTitle}
+COURSE_TITLE: ${courseTitle}
+LANGUAGE: ${language}
+EXPLANATION_STEPS:
+${formattedExplanationSteps}`;
+
+  const providerOptions = buildProviderOptions({
+    fallbackModels: FALLBACK_MODELS,
+    reasoningEffort,
+    useFallback,
+  });
+
+  const { output, usage } = await generateText({
+    model,
+    output: Output.object({ schema }),
+    prompt: userPrompt,
+    providerOptions,
+    system: systemPrompt,
+  });
+
+  return { data: output, systemPrompt, usage, userPrompt };
+}

--- a/packages/core/src/steps/content-contract.test.ts
+++ b/packages/core/src/steps/content-contract.test.ts
@@ -237,4 +237,102 @@ describe("step content contracts", () => {
       }),
     ).toThrow();
   });
+
+  describe("tradeoff", () => {
+    const validContent = {
+      event: null,
+      outcomes: [
+        {
+          invested: { consequence: "Great progress" },
+          maintained: { consequence: "Treading water" },
+          neglected: { consequence: "Things got worse" },
+          priorityId: "study",
+        },
+        {
+          invested: { consequence: "Healthy" },
+          maintained: { consequence: "OK" },
+          neglected: { consequence: "Stressed" },
+          priorityId: "exercise",
+        },
+        {
+          invested: { consequence: "Well rested" },
+          maintained: { consequence: "Fine" },
+          neglected: { consequence: "Exhausted" },
+          priorityId: "sleep",
+        },
+      ],
+      priorities: [
+        { description: "Study notes", id: "study", name: "Study" },
+        { description: "Physical activity", id: "exercise", name: "Exercise" },
+        { description: "Rest and recovery", id: "sleep", name: "Sleep" },
+      ],
+      resource: { name: "hours", total: 5 },
+      stateModifiers: null,
+      tokenOverride: null,
+    };
+
+    test("parses valid tradeoff content", () => {
+      const result = parseStepContent("tradeoff", validContent);
+      expect(result.priorities).toHaveLength(3);
+      expect(result.resource.total).toBe(5);
+      expect(result.event).toBeNull();
+    });
+
+    test("parses tradeoff content with event and modifiers", () => {
+      const result = parseStepContent("tradeoff", {
+        ...validContent,
+        event: "The exam was moved to tomorrow",
+        stateModifiers: [{ delta: -1, priorityId: "sleep" }],
+        tokenOverride: 4,
+      });
+      expect(result.event).toBe("The exam was moved to tomorrow");
+      expect(result.stateModifiers).toHaveLength(1);
+      expect(result.tokenOverride).toBe(4);
+    });
+
+    test("rejects tradeoff with fewer than 3 priorities", () => {
+      expect(() =>
+        parseStepContent("tradeoff", {
+          ...validContent,
+          priorities: [
+            { description: "a", id: "a", name: "A" },
+            { description: "b", id: "b", name: "B" },
+          ],
+        }),
+      ).toThrow();
+    });
+
+    test("rejects tradeoff with more than 4 priorities", () => {
+      expect(() =>
+        parseStepContent("tradeoff", {
+          ...validContent,
+          priorities: [
+            { description: "a", id: "a", name: "A" },
+            { description: "b", id: "b", name: "B" },
+            { description: "c", id: "c", name: "C" },
+            { description: "d", id: "d", name: "D" },
+            { description: "e", id: "e", name: "E" },
+          ],
+        }),
+      ).toThrow();
+    });
+
+    test("rejects tradeoff with missing outcomes", () => {
+      expect(() =>
+        parseStepContent("tradeoff", {
+          ...validContent,
+          outcomes: [],
+        }),
+      ).toThrow();
+    });
+
+    test("rejects tradeoff with extra fields", () => {
+      expect(() =>
+        parseStepContent("tradeoff", {
+          ...validContent,
+          extraField: "should fail",
+        }),
+      ).toThrow();
+    });
+  });
 });

--- a/packages/core/src/steps/content-contract.ts
+++ b/packages/core/src/steps/content-contract.ts
@@ -108,6 +108,51 @@ const translationContentSchema = z.object({}).strict();
 const readingContentSchema = z.object({}).strict();
 const listeningContentSchema = z.object({}).strict();
 
+const tradeoffPrioritySchema = z
+  .object({
+    description: z.string(),
+    id: z.string(),
+    name: z.string(),
+  })
+  .strict();
+
+const tradeoffResourceSchema = z
+  .object({
+    name: z.string(),
+    total: z.number().int(),
+  })
+  .strict();
+
+const tradeoffOutcomeSchema = z
+  .object({
+    invested: z.object({ consequence: z.string() }).strict(),
+    maintained: z.object({ consequence: z.string() }).strict(),
+    neglected: z.object({ consequence: z.string() }).strict(),
+    priorityId: z.string(),
+  })
+  .strict();
+
+const tradeoffStateModifierSchema = z
+  .object({
+    delta: z.number().int(),
+    priorityId: z.string(),
+  })
+  .strict();
+
+const MIN_PRIORITIES = 3;
+const MAX_PRIORITIES = 4;
+
+export const tradeoffContentSchema = z
+  .object({
+    event: z.string().nullable(),
+    outcomes: z.array(tradeoffOutcomeSchema).min(1),
+    priorities: z.array(tradeoffPrioritySchema).min(MIN_PRIORITIES).max(MAX_PRIORITIES),
+    resource: tradeoffResourceSchema,
+    stateModifiers: z.array(tradeoffStateModifierSchema).nullable(),
+    tokenOverride: z.number().int().nullable(),
+  })
+  .strict();
+
 const stepContentSchemas = {
   fillBlank: fillBlankContentSchema,
   listening: listeningContentSchema,
@@ -117,6 +162,7 @@ const stepContentSchemas = {
   selectImage: selectImageContentSchema,
   sortOrder: sortOrderContentSchema,
   static: staticContentSchema,
+  tradeoff: tradeoffContentSchema,
   translation: translationContentSchema,
   visual: visualStepContentSchema,
   vocabulary: vocabularyContentSchema,
@@ -136,6 +182,7 @@ export type VocabularyStepContent = z.infer<typeof vocabularyContentSchema>;
 export type TranslationStepContent = z.infer<typeof translationContentSchema>;
 export type ReadingStepContent = z.infer<typeof readingContentSchema>;
 export type ListeningStepContent = z.infer<typeof listeningContentSchema>;
+export type TradeoffStepContent = z.infer<typeof tradeoffContentSchema>;
 
 export type { VisualStepContent };
 
@@ -148,6 +195,7 @@ export type StepContentByKind = {
   selectImage: SelectImageStepContent;
   sortOrder: SortOrderStepContent;
   static: StaticStepContent;
+  tradeoff: TradeoffStepContent;
   translation: TranslationStepContent;
   visual: VisualStepContent;
   vocabulary: VocabularyStepContent;
@@ -168,6 +216,7 @@ export function parseStepContent(kind: "reading", content: unknown): ReadingStep
 export function parseStepContent(kind: "selectImage", content: unknown): SelectImageStepContent;
 export function parseStepContent(kind: "sortOrder", content: unknown): SortOrderStepContent;
 export function parseStepContent(kind: "static", content: unknown): StaticStepContent;
+export function parseStepContent(kind: "tradeoff", content: unknown): TradeoffStepContent;
 export function parseStepContent(kind: "translation", content: unknown): TranslationStepContent;
 export function parseStepContent(kind: "visual", content: unknown): VisualStepContent;
 export function parseStepContent(kind: "vocabulary", content: unknown): VocabularyStepContent;
@@ -190,6 +239,7 @@ export function assertStepContent(kind: "reading", content: unknown): ReadingSte
 export function assertStepContent(kind: "selectImage", content: unknown): SelectImageStepContent;
 export function assertStepContent(kind: "sortOrder", content: unknown): SortOrderStepContent;
 export function assertStepContent(kind: "static", content: unknown): StaticStepContent;
+export function assertStepContent(kind: "tradeoff", content: unknown): TradeoffStepContent;
 export function assertStepContent(kind: "translation", content: unknown): TranslationStepContent;
 export function assertStepContent(kind: "visual", content: unknown): VisualStepContent;
 export function assertStepContent(kind: "vocabulary", content: unknown): VocabularyStepContent;

--- a/packages/core/src/workflows/steps.ts
+++ b/packages/core/src/workflows/steps.ts
@@ -91,6 +91,7 @@ export const ACTIVITY_STEPS = [
   "generateVisuals",
   "generateImages",
   "generateQuizImages",
+  "generateTradeoffContent",
 
   // Listening (copies steps from vocabulary/reading)
   "copyListeningSteps",
@@ -104,6 +105,7 @@ export const ACTIVITY_STEPS = [
   "saveCustomActivity",
   "saveGrammarActivity",
   "saveListeningActivity",
+  "saveTradeoffActivity",
 
   // Error
   "workflowError",
@@ -120,6 +122,7 @@ type ActivityCompletionStep = Extract<
   | "savePracticeActivity"
   | "saveQuizActivity"
   | "saveReadingActivity"
+  | "saveTradeoffActivity"
   | "saveVocabularyActivity"
 >;
 
@@ -131,6 +134,7 @@ const activityCompletionSteps: Partial<Record<string, ActivityCompletionStep>> =
   practice: "savePracticeActivity",
   quiz: "saveQuizActivity",
   reading: "saveReadingActivity",
+  tradeoff: "saveTradeoffActivity",
   translation: "saveVocabularyActivity",
   vocabulary: "saveVocabularyActivity",
 };

--- a/packages/db/src/prisma/enums.prisma
+++ b/packages/db/src/prisma/enums.prisma
@@ -21,6 +21,7 @@ enum ActivityKind {
   reading
   listening
   translation
+  tradeoff
   review
 }
 
@@ -37,6 +38,7 @@ enum StepKind {
   translation
   reading
   listening
+  tradeoff
 }
 
 enum CourseMode {

--- a/packages/db/src/prisma/migrations/20260330183404_add_tradeoff_activity_type/migration.sql
+++ b/packages/db/src/prisma/migrations/20260330183404_add_tradeoff_activity_type/migration.sql
@@ -1,0 +1,8 @@
+-- AlterEnum
+ALTER TYPE "ActivityKind" ADD VALUE 'tradeoff';
+
+-- AlterEnum
+ALTER TYPE "StepKind" ADD VALUE 'tradeoff';
+
+-- AlterTable
+ALTER TABLE "daily_progress" ADD COLUMN     "tradeoff_completed" INTEGER NOT NULL DEFAULT 0;

--- a/packages/db/src/prisma/models/progress.prisma
+++ b/packages/db/src/prisma/models/progress.prisma
@@ -47,6 +47,7 @@ model DailyProgress {
   incorrectAnswers     Int           @default(0) @map("incorrect_answers")
   staticCompleted      Int           @default(0) @map("static_completed")
   interactiveCompleted Int           @default(0) @map("interactive_completed")
+  tradeoffCompleted    Int           @default(0) @map("tradeoff_completed")
   brainPowerEarned     Int           @default(0) @map("brain_power_earned")
   timeSpentSeconds     Int           @default(0) @map("time_spent_seconds")
   energyAtEnd          Float         @default(0) @map("energy_at_end")

--- a/packages/player/src/check-answer.ts
+++ b/packages/player/src/check-answer.ts
@@ -93,6 +93,16 @@ export function checkTranslationAnswer(
   };
 }
 
+/**
+ * Tradeoff steps have no correct or incorrect answer — the learning
+ * comes from experiencing consequences, not from being graded. Always
+ * returns isCorrect: true so the player's CHECK_ANSWER flow proceeds.
+ * The score pipeline excludes tradeoff from accuracy calculations.
+ */
+export function checkTradeoffAnswer(): AnswerResult {
+  return { correctAnswer: null, feedback: null, isCorrect: true };
+}
+
 export function checkArrangeWordsAnswer(
   correctWords: string[][],
   userWords: string[],

--- a/packages/player/src/check-step.test.ts
+++ b/packages/player/src/check-step.test.ts
@@ -399,6 +399,58 @@ describe(checkStep, () => {
     });
   });
 
+  describe("tradeoff", () => {
+    const tradeoffContent = {
+      event: null,
+      outcomes: [
+        {
+          invested: { consequence: "good" },
+          maintained: { consequence: "ok" },
+          neglected: { consequence: "bad" },
+          priorityId: "study",
+        },
+      ],
+      priorities: [
+        { description: "Study notes", id: "study", name: "Study" },
+        { description: "Exercise", id: "exercise", name: "Exercise" },
+        { description: "Sleep", id: "sleep", name: "Sleep" },
+      ],
+      resource: { name: "hours", total: 5 },
+      stateModifiers: null,
+      tokenOverride: null,
+    };
+
+    test("always returns isCorrect: true regardless of allocation", () => {
+      const step = buildStep({ content: tradeoffContent, kind: "tradeoff" });
+      const answer: SelectedAnswer = {
+        allocations: [
+          { priorityId: "study", tokens: 3 },
+          { priorityId: "exercise", tokens: 1 },
+          { priorityId: "sleep", tokens: 1 },
+        ],
+        kind: "tradeoff",
+      };
+      const { result } = checkStep(step, answer);
+      expect(result.isCorrect).toBe(true);
+      expect(result.correctAnswer).toBeNull();
+      expect(result.feedback).toBeNull();
+    });
+
+    test("returns isCorrect: true even with all tokens on one priority", () => {
+      const step = buildStep({ content: tradeoffContent, kind: "tradeoff" });
+      const answer: SelectedAnswer = {
+        allocations: [
+          { priorityId: "study", tokens: 5 },
+          { priorityId: "exercise", tokens: 0 },
+          { priorityId: "sleep", tokens: 0 },
+        ],
+        kind: "tradeoff",
+      };
+      const { result } = checkStep(step, answer);
+      expect(result.isCorrect).toBe(true);
+    });
+  });
+
   describe("mismatched kinds", () => {
     test("multipleChoice step with fillBlank answer returns safe fallback", () => {
       const step = buildStep({

--- a/packages/player/src/check-step.ts
+++ b/packages/player/src/check-step.ts
@@ -9,6 +9,7 @@ import {
   checkMultipleChoiceAnswer,
   checkSelectImageAnswer,
   checkSortOrderAnswer,
+  checkTradeoffAnswer,
   checkTranslationAnswer,
 } from "./check-answer";
 import { type SelectedAnswer } from "./player-reducer";
@@ -154,6 +155,9 @@ export function checkStep(step: SerializedStep, answer: SelectedAnswer): CheckSt
 
     case "listening":
       return checkListeningStep(step, answer);
+
+    case "tradeoff":
+      return { result: checkTradeoffAnswer() };
 
     case "static":
     case "visual":

--- a/packages/player/src/check-step.ts
+++ b/packages/player/src/check-step.ts
@@ -108,6 +108,14 @@ function checkReadingStep(step: SerializedStep, answer: SelectedAnswer): CheckSt
   };
 }
 
+function checkTradeoff(answer: SelectedAnswer): CheckStepResult {
+  if (answer.kind !== "tradeoff") {
+    return MISMATCH_RESULT;
+  }
+
+  return { result: checkTradeoffAnswer() };
+}
+
 function checkListeningStep(step: SerializedStep, answer: SelectedAnswer): CheckStepResult {
   if (answer.kind !== "listening") {
     return MISMATCH_RESULT;
@@ -157,7 +165,7 @@ export function checkStep(step: SerializedStep, answer: SelectedAnswer): CheckSt
       return checkListeningStep(step, answer);
 
     case "tradeoff":
-      return { result: checkTradeoffAnswer() };
+      return checkTradeoff(answer);
 
     case "static":
     case "visual":

--- a/packages/player/src/completion-input-schema.ts
+++ b/packages/player/src/completion-input-schema.ts
@@ -41,6 +41,11 @@ const sortOrderAnswerSchema = z.object({
   userOrder: z.array(z.string()),
 });
 
+const tradeoffAnswerSchema = z.object({
+  allocations: z.array(z.object({ priorityId: z.string(), tokens: z.number() })),
+  kind: z.literal("tradeoff"),
+});
+
 const translationAnswerSchema = z.object({
   kind: z.literal("translation"),
   questionText: z.string(),
@@ -56,6 +61,7 @@ const selectedAnswerSchema = z.discriminatedUnion("kind", [
   readingAnswerSchema,
   selectImageAnswerSchema,
   sortOrderAnswerSchema,
+  tradeoffAnswerSchema,
   translationAnswerSchema,
 ]);
 

--- a/packages/player/src/components/completion-screen.tsx
+++ b/packages/player/src/components/completion-screen.tsx
@@ -5,7 +5,12 @@ import { CircleCheck } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { type CompletionResult } from "../completion-input-schema";
 import { computeScore } from "../compute-score";
-import { type PlayerRoute, usePlayerMilestone, usePlayerViewer } from "../player-context";
+import {
+  type PlayerRoute,
+  usePlayerMilestone,
+  usePlayerRuntime,
+  usePlayerViewer,
+} from "../player-context";
 import { type StepResult } from "../player-reducer";
 import { AuthBranch } from "./completion-auth-branch";
 
@@ -64,18 +69,25 @@ function MilestoneHeading() {
   return <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">{getHeading()}</h2>;
 }
 
-function getCompletionScore(results: Record<string, StepResult>) {
-  const resultList = Object.values(results);
+/**
+ * Computes the score display for the completion screen.
+ *
+ * Tradeoff steps are excluded because they have no correct/incorrect
+ * answer — showing "3/3 correct" would be misleading. When only
+ * tradeoff + static steps exist, returns null so the screen shows
+ * the "Completed" checkmark instead.
+ */
+function getCompletionScore(results: Record<string, StepResult>, tradeoffStepIds: Set<string>) {
+  const scorableResults = Object.entries(results)
+    .filter(([stepId]) => !tradeoffStepIds.has(stepId))
+    .map(([_, stepResult]) => ({ isCorrect: stepResult.result.isCorrect }));
 
-  if (resultList.length === 0) {
+  if (scorableResults.length === 0) {
     return null;
   }
 
-  const score = computeScore({
-    results: resultList.map((stepResult) => ({ isCorrect: stepResult.result.isCorrect })),
-  });
-
-  return { correctCount: score.correctCount, totalCount: resultList.length };
+  const score = computeScore({ results: scorableResults });
+  return { correctCount: score.correctCount, totalCount: scorableResults.length };
 }
 
 export function CompletionScreenContent({
@@ -92,6 +104,7 @@ export function CompletionScreenContent({
   results: Record<string, StepResult>;
 }) {
   const t = useExtracted();
+  const { state } = usePlayerRuntime();
   const milestone = usePlayerMilestone();
   const { completionFooter } = usePlayerViewer();
 
@@ -113,7 +126,10 @@ export function CompletionScreenContent({
     );
   }
 
-  const score = getCompletionScore(results);
+  const tradeoffStepIds = new Set(
+    state.steps.filter((step) => step.kind === "tradeoff").map((step) => step.id),
+  );
+  const score = getCompletionScore(results, tradeoffStepIds);
 
   return (
     <CompletionScreen>

--- a/packages/player/src/components/step-renderer.tsx
+++ b/packages/player/src/components/step-renderer.tsx
@@ -12,6 +12,7 @@ import { SortOrderStep } from "./sort-order-step";
 import { StaticStep } from "./static-step";
 import { NavigableStepLayout } from "./step-layouts";
 import { StepSideNav } from "./step-side-nav";
+import { TradeoffStep } from "./tradeoff/tradeoff-step";
 import { TranslationStep } from "./translation-step";
 import { VisualStep } from "./visual-step";
 import { VocabularyStep } from "./vocabulary-step";
@@ -122,6 +123,17 @@ export function StepRenderer({
         />
         <VocabularyStep step={step} />
       </NavigableStepLayout>
+    );
+  }
+
+  if (step.kind === "tradeoff") {
+    return (
+      <TradeoffStep
+        onSelectAnswer={onSelectAnswer}
+        result={result}
+        selectedAnswer={selectedAnswer}
+        step={step}
+      />
     );
   }
 

--- a/packages/player/src/components/tradeoff/_utils/compute-priority-states.test.ts
+++ b/packages/player/src/components/tradeoff/_utils/compute-priority-states.test.ts
@@ -1,0 +1,240 @@
+import { type TradeoffStepContent } from "@zoonk/core/steps/content-contract";
+import { describe, expect, it } from "vitest";
+import { type SelectedAnswer } from "../../../player-reducer";
+import { type SerializedStep } from "../../../prepare-activity-data";
+import { computePriorityStates, getTradeoffRoundInfo } from "./compute-priority-states";
+
+const PRIORITIES = [
+  { description: "Study notes", id: "study", name: "Study" },
+  { description: "Exercise", id: "exercise", name: "Exercise" },
+  { description: "Sleep", id: "sleep", name: "Sleep" },
+];
+
+const RESOURCE = { name: "hours", total: 5 };
+
+function makeTradeoffContent(overrides: Partial<TradeoffStepContent> = {}): TradeoffStepContent {
+  return {
+    event: null,
+    outcomes: PRIORITIES.map((priority) => ({
+      invested: { consequence: "invested" },
+      maintained: { consequence: "maintained" },
+      neglected: { consequence: "neglected" },
+      priorityId: priority.id,
+    })),
+    priorities: PRIORITIES,
+    resource: RESOURCE,
+    stateModifiers: null,
+    tokenOverride: null,
+    ...overrides,
+  };
+}
+
+function makeStep(id: string, content: TradeoffStepContent, position: number): SerializedStep {
+  return {
+    content,
+    fillBlankOptions: [],
+    id,
+    kind: "tradeoff",
+    matchColumnsRightItems: [],
+    position,
+    sentence: null,
+    sentenceWordOptions: [],
+    sortOrderItems: [],
+    translationOptions: [],
+    vocabularyOptions: [],
+    word: null,
+    wordBankOptions: [],
+  };
+}
+
+function makeStaticStep(id: string, position: number): SerializedStep {
+  return {
+    content: { text: "intro", title: "Intro", variant: "text" as const },
+    fillBlankOptions: [],
+    id,
+    kind: "static",
+    matchColumnsRightItems: [],
+    position,
+    sentence: null,
+    sentenceWordOptions: [],
+    sortOrderItems: [],
+    translationOptions: [],
+    vocabularyOptions: [],
+    word: null,
+    wordBankOptions: [],
+  };
+}
+
+describe(computePriorityStates, () => {
+  it("returns initial states (1 for each priority) when no answers exist", () => {
+    const round1 = makeTradeoffContent();
+    const steps = [makeStep("step-1", round1, 1)];
+
+    const result = computePriorityStates({
+      allSteps: steps,
+      currentStepId: "step-1",
+      includeCurrentRound: false,
+      selectedAnswers: {},
+    });
+
+    expect(result).toEqual({ exercise: 1, sleep: 1, study: 1 });
+  });
+
+  it("applies allocation deltas when includeCurrentRound is true", () => {
+    const round1 = makeTradeoffContent();
+    const steps = [makeStep("step-1", round1, 1)];
+
+    const answers: Record<string, SelectedAnswer> = {
+      "step-1": {
+        allocations: [
+          { priorityId: "study", tokens: 3 },
+          { priorityId: "exercise", tokens: 1 },
+          { priorityId: "sleep", tokens: 0 },
+        ],
+        kind: "tradeoff",
+      },
+    };
+
+    const result = computePriorityStates({
+      allSteps: steps,
+      currentStepId: "step-1",
+      includeCurrentRound: true,
+      selectedAnswers: answers,
+    });
+
+    // study: 1 + 1 (invested) = 2
+    // exercise: 1 + 0 (maintained) = 1
+    // sleep: 1 - 1 (neglected) = 0
+    expect(result).toEqual({ exercise: 1, sleep: 0, study: 2 });
+  });
+
+  it("accumulates states across multiple rounds", () => {
+    const round1 = makeTradeoffContent();
+    const round2 = makeTradeoffContent({ event: "Event happened" });
+    const steps = [makeStep("step-1", round1, 1), makeStep("step-2", round2, 2)];
+
+    const answers: Record<string, SelectedAnswer> = {
+      "step-1": {
+        allocations: [
+          { priorityId: "study", tokens: 2 },
+          { priorityId: "exercise", tokens: 2 },
+          { priorityId: "sleep", tokens: 1 },
+        ],
+        kind: "tradeoff",
+      },
+      "step-2": {
+        allocations: [
+          { priorityId: "study", tokens: 0 },
+          { priorityId: "exercise", tokens: 2 },
+          { priorityId: "sleep", tokens: 2 },
+        ],
+        kind: "tradeoff",
+      },
+    };
+
+    const result = computePriorityStates({
+      allSteps: steps,
+      currentStepId: "step-2",
+      includeCurrentRound: true,
+      selectedAnswers: answers,
+    });
+
+    // study: 1 + 1 (R1 invested) - 1 (R2 neglected) = 1
+    // exercise: 1 + 1 (R1 invested) + 1 (R2 invested) = 3
+    // sleep: 1 + 0 (R1 maintained) + 1 (R2 invested) = 2
+    expect(result).toEqual({ exercise: 3, sleep: 2, study: 1 });
+  });
+
+  it("applies state modifiers from events", () => {
+    const round1 = makeTradeoffContent();
+    const round2 = makeTradeoffContent({
+      event: "Stress hit",
+      stateModifiers: [{ delta: -1, priorityId: "sleep" }],
+    });
+    const steps = [makeStep("step-1", round1, 1), makeStep("step-2", round2, 2)];
+
+    const answers: Record<string, SelectedAnswer> = {
+      "step-1": {
+        allocations: [
+          { priorityId: "study", tokens: 2 },
+          { priorityId: "exercise", tokens: 1 },
+          { priorityId: "sleep", tokens: 2 },
+        ],
+        kind: "tradeoff",
+      },
+    };
+
+    // Before round 2 allocation — includeCurrentRound: false
+    // but state modifiers for current round ARE applied
+    const result = computePriorityStates({
+      allSteps: steps,
+      currentStepId: "step-2",
+      includeCurrentRound: false,
+      selectedAnswers: answers,
+    });
+
+    // study: 1 + 1 (R1 invested) = 2
+    // exercise: 1 + 0 (R1 maintained) = 1
+    // sleep: 1 + 1 (R1 invested) - 1 (R2 modifier) = 1
+    expect(result).toEqual({ exercise: 1, sleep: 1, study: 2 });
+  });
+
+  it("ignores non-tradeoff steps when computing round info", () => {
+    const round1 = makeTradeoffContent();
+    const steps = [makeStaticStep("intro", 0), makeStep("step-1", round1, 1)];
+
+    const result = computePriorityStates({
+      allSteps: steps,
+      currentStepId: "step-1",
+      includeCurrentRound: false,
+      selectedAnswers: {},
+    });
+
+    expect(result).toEqual({ exercise: 1, sleep: 1, study: 1 });
+  });
+
+  it("returns empty object for unknown step ID", () => {
+    const round1 = makeTradeoffContent();
+    const steps = [makeStep("step-1", round1, 1)];
+
+    const result = computePriorityStates({
+      allSteps: steps,
+      currentStepId: "unknown",
+      includeCurrentRound: false,
+      selectedAnswers: {},
+    });
+
+    expect(result).toEqual({});
+  });
+});
+
+describe(getTradeoffRoundInfo, () => {
+  it("returns correct round number and total", () => {
+    const content = makeTradeoffContent();
+    const steps = [
+      makeStaticStep("intro", 0),
+      makeStep("r1", content, 1),
+      makeStep("r2", content, 2),
+      makeStep("r3", content, 3),
+      makeStaticStep("reflection", 4),
+    ];
+
+    expect(getTradeoffRoundInfo(steps, "r1")).toEqual({
+      isLastRound: false,
+      roundNumber: 1,
+      totalRounds: 3,
+    });
+
+    expect(getTradeoffRoundInfo(steps, "r2")).toEqual({
+      isLastRound: false,
+      roundNumber: 2,
+      totalRounds: 3,
+    });
+
+    expect(getTradeoffRoundInfo(steps, "r3")).toEqual({
+      isLastRound: true,
+      roundNumber: 3,
+      totalRounds: 3,
+    });
+  });
+});

--- a/packages/player/src/components/tradeoff/_utils/compute-priority-states.ts
+++ b/packages/player/src/components/tradeoff/_utils/compute-priority-states.ts
@@ -1,0 +1,145 @@
+import { type TradeoffStepContent, parseStepContent } from "@zoonk/core/steps/content-contract";
+import { type SelectedAnswer } from "../../../player-reducer";
+import { type SerializedStep } from "../../../prepare-activity-data";
+import { getConsequenceTier } from "./get-consequence-tier";
+import { CONSEQUENCE_STATE_DELTAS } from "./state-tier";
+
+const INITIAL_STATE = 1;
+
+/** Filters an activity's steps to only tradeoff rounds. */
+function getTradeoffSteps(allSteps: SerializedStep[]): SerializedStep[] {
+  return allSteps.filter((step) => step.kind === "tradeoff");
+}
+
+/**
+ * Applies state modifiers (from events) to a priority state record,
+ * returning a new record without mutating the original.
+ */
+function withStateModifiers(
+  states: Record<string, number>,
+  content: TradeoffStepContent,
+): Record<string, number> {
+  if (!content.stateModifiers) {
+    return states;
+  }
+
+  const result = { ...states };
+
+  for (const modifier of content.stateModifiers) {
+    const current = result[modifier.priorityId];
+
+    if (current !== undefined) {
+      result[modifier.priorityId] = current + modifier.delta;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Applies allocation deltas to a priority state record based on the
+ * learner's token distribution, returning a new record.
+ */
+function withAllocationDeltas(
+  states: Record<string, number>,
+  answer: SelectedAnswer | undefined,
+): Record<string, number> {
+  if (!answer || answer.kind !== "tradeoff") {
+    return states;
+  }
+
+  const result = { ...states };
+
+  for (const allocation of answer.allocations) {
+    const current = result[allocation.priorityId];
+
+    if (current !== undefined) {
+      const tier = getConsequenceTier(allocation.tokens);
+      result[allocation.priorityId] = current + CONSEQUENCE_STATE_DELTAS[tier];
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Computes the accumulated priority states from all tradeoff rounds
+ * up to (and optionally including) the current round.
+ *
+ * Each priority starts at 1 (Stable). Per round:
+ * - Invested (2+ tokens) → +1
+ * - Maintained (1 token) → 0
+ * - Neglected (0 tokens) → -1
+ *
+ * Events between rounds can apply additional state modifiers
+ * (e.g., stress drops Sleep by -1 before the learner allocates).
+ */
+export function computePriorityStates({
+  allSteps,
+  currentStepId,
+  includeCurrentRound,
+  selectedAnswers,
+}: {
+  allSteps: SerializedStep[];
+  currentStepId: string;
+  includeCurrentRound: boolean;
+  selectedAnswers: Record<string, SelectedAnswer>;
+}): Record<string, number> {
+  const tradeoffSteps = getTradeoffSteps(allSteps);
+  const currentIndex = tradeoffSteps.findIndex((step) => step.id === currentStepId);
+
+  if (currentIndex === -1) {
+    return {};
+  }
+
+  const firstStep = tradeoffSteps[0];
+
+  if (!firstStep) {
+    return {};
+  }
+
+  const content = parseStepContent("tradeoff", firstStep.content);
+
+  let states: Record<string, number> = Object.fromEntries(
+    content.priorities.map((priority) => [priority.id, INITIAL_STATE]),
+  );
+
+  const endIndex = includeCurrentRound ? currentIndex + 1 : currentIndex;
+
+  for (let index = 0; index < endIndex; index += 1) {
+    const step = tradeoffSteps[index];
+
+    if (step) {
+      const stepContent = parseStepContent("tradeoff", step.content);
+      states = withStateModifiers(states, stepContent);
+      states = withAllocationDeltas(states, selectedAnswers[step.id]);
+    }
+  }
+
+  if (!includeCurrentRound) {
+    const currentStep = tradeoffSteps[currentIndex];
+
+    if (currentStep) {
+      const currentContent = parseStepContent("tradeoff", currentStep.content);
+      states = withStateModifiers(states, currentContent);
+    }
+  }
+
+  return states;
+}
+
+/**
+ * Returns the round number (1-based) and total rounds for a tradeoff
+ * step by counting tradeoff steps in the activity.
+ */
+export function getTradeoffRoundInfo(
+  allSteps: SerializedStep[],
+  currentStepId: string,
+): { isLastRound: boolean; roundNumber: number; totalRounds: number } {
+  const tradeoffSteps = getTradeoffSteps(allSteps);
+  const index = tradeoffSteps.findIndex((step) => step.id === currentStepId);
+  const roundNumber = index + 1;
+  const totalRounds = tradeoffSteps.length;
+
+  return { isLastRound: roundNumber === totalRounds, roundNumber, totalRounds };
+}

--- a/packages/player/src/components/tradeoff/_utils/get-consequence-tier.test.ts
+++ b/packages/player/src/components/tradeoff/_utils/get-consequence-tier.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { getConsequenceTier } from "./get-consequence-tier";
+
+describe(getConsequenceTier, () => {
+  it("returns 'neglected' for 0 tokens", () => {
+    expect(getConsequenceTier(0)).toBe("neglected");
+  });
+
+  it("returns 'maintained' for 1 token", () => {
+    expect(getConsequenceTier(1)).toBe("maintained");
+  });
+
+  it("returns 'invested' for 2 tokens", () => {
+    expect(getConsequenceTier(2)).toBe("invested");
+  });
+
+  it("returns 'invested' for 3+ tokens", () => {
+    expect(getConsequenceTier(3)).toBe("invested");
+    expect(getConsequenceTier(5)).toBe("invested");
+  });
+});

--- a/packages/player/src/components/tradeoff/_utils/get-consequence-tier.ts
+++ b/packages/player/src/components/tradeoff/_utils/get-consequence-tier.ts
@@ -1,0 +1,27 @@
+export type ConsequenceTier = "invested" | "maintained" | "neglected";
+
+const INVESTED_THRESHOLD = 2;
+
+/**
+ * Maps a token allocation to a consequence tier.
+ *
+ * The three-tier system prevents "spread evenly" as a dominant strategy:
+ * - 0 tokens = neglected (priority declines)
+ * - 1 token = maintained (treading water, no improvement)
+ * - 2+ tokens = invested (real improvement)
+ *
+ * With this system, distributing 1 token to everything keeps things
+ * stable but improves nothing. You must concentrate to make progress,
+ * which forces genuine tradeoff decisions.
+ */
+export function getConsequenceTier(tokens: number): ConsequenceTier {
+  if (tokens >= INVESTED_THRESHOLD) {
+    return "invested";
+  }
+
+  if (tokens >= 1) {
+    return "maintained";
+  }
+
+  return "neglected";
+}

--- a/packages/player/src/components/tradeoff/_utils/state-tier.test.ts
+++ b/packages/player/src/components/tradeoff/_utils/state-tier.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONSEQUENCE_STATE_DELTAS,
+  getEffectiveTokenTotal,
+  getStateDirection,
+  getStateTier,
+} from "./state-tier";
+
+describe(getStateTier, () => {
+  it("returns Critical for negative states", () => {
+    expect(getStateTier(-1)).toMatchObject({
+      colorClass: "text-destructive",
+      dotClass: "bg-destructive",
+      label: "Critical",
+    });
+    expect(getStateTier(-2)).toMatchObject({ label: "Critical" });
+  });
+
+  it("returns Stressed for state 0", () => {
+    expect(getStateTier(0)).toMatchObject({
+      colorClass: "text-warning",
+      dotClass: "bg-warning",
+      label: "Stressed",
+    });
+  });
+
+  it("returns Stable for state 1", () => {
+    expect(getStateTier(1)).toMatchObject({
+      colorClass: "text-muted-foreground",
+      dotClass: "bg-muted-foreground",
+      label: "Stable",
+    });
+  });
+
+  it("returns Healthy for state 2", () => {
+    const tier = getStateTier(2);
+    expect(tier.label).toBe("Healthy");
+    expect(tier.colorClass).toContain("text-sky");
+    expect(tier.dotClass).toContain("bg-sky");
+  });
+
+  it("returns Thriving for state 3+", () => {
+    expect(getStateTier(3)).toMatchObject({
+      colorClass: "text-success",
+      dotClass: "bg-success",
+      label: "Thriving",
+    });
+    expect(getStateTier(5)).toMatchObject({ label: "Thriving" });
+  });
+});
+
+describe(getStateDirection, () => {
+  it("returns ↑ for positive delta", () => {
+    expect(getStateDirection(1)).toBe("↑");
+    expect(getStateDirection(2)).toBe("↑");
+  });
+
+  it("returns ↓ for negative delta", () => {
+    expect(getStateDirection(-1)).toBe("↓");
+    expect(getStateDirection(-2)).toBe("↓");
+  });
+
+  it("returns → for zero delta", () => {
+    expect(getStateDirection(0)).toBe("→");
+  });
+});
+
+describe("CONSEQUENCE_STATE_DELTAS", () => {
+  it("maps invested to +1", () => {
+    expect(CONSEQUENCE_STATE_DELTAS.invested).toBe(1);
+  });
+
+  it("maps maintained to 0", () => {
+    expect(CONSEQUENCE_STATE_DELTAS.maintained).toBe(0);
+  });
+
+  it("maps neglected to -1", () => {
+    expect(CONSEQUENCE_STATE_DELTAS.neglected).toBe(-1);
+  });
+});
+
+describe(getEffectiveTokenTotal, () => {
+  it("returns tokenOverride when set", () => {
+    expect(getEffectiveTokenTotal({ resource: { total: 5 }, tokenOverride: 4 })).toBe(4);
+  });
+
+  it("returns resource.total when tokenOverride is null", () => {
+    expect(getEffectiveTokenTotal({ resource: { total: 5 }, tokenOverride: null })).toBe(5);
+  });
+});

--- a/packages/player/src/components/tradeoff/_utils/state-tier.test.ts
+++ b/packages/player/src/components/tradeoff/_utils/state-tier.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  CONSEQUENCE_STATE_DELTAS,
-  getEffectiveTokenTotal,
-  getStateDirection,
-  getStateTier,
-} from "./state-tier";
+import { getEffectiveTokenTotal, getStateDirection, getStateTier } from "./state-tier";
 
 describe(getStateTier, () => {
   it("returns Critical for negative states", () => {
@@ -62,20 +57,6 @@ describe(getStateDirection, () => {
 
   it("returns → for zero delta", () => {
     expect(getStateDirection(0)).toBe("→");
-  });
-});
-
-describe("CONSEQUENCE_STATE_DELTAS", () => {
-  it("maps invested to +1", () => {
-    expect(CONSEQUENCE_STATE_DELTAS.invested).toBe(1);
-  });
-
-  it("maps maintained to 0", () => {
-    expect(CONSEQUENCE_STATE_DELTAS.maintained).toBe(0);
-  });
-
-  it("maps neglected to -1", () => {
-    expect(CONSEQUENCE_STATE_DELTAS.neglected).toBe(-1);
   });
 });
 

--- a/packages/player/src/components/tradeoff/_utils/state-tier.ts
+++ b/packages/player/src/components/tradeoff/_utils/state-tier.ts
@@ -1,0 +1,92 @@
+import { type ConsequenceTier } from "./get-consequence-tier";
+
+type StateTier = {
+  colorClass: string;
+  dotClass: string;
+  label: string;
+};
+
+/**
+ * Maps a cumulative priority state number to a human-readable label
+ * and color classes for display.
+ *
+ * State numbers accumulate across rounds:
+ * - Invested (+1 per round), Maintained (0), Neglected (-1)
+ * - Events can apply additional state modifiers
+ *
+ * Returns both `colorClass` (for text) and `dotClass` (for the indicator dot)
+ * as literal Tailwind classes — dynamic class construction (e.g., `.replace()`)
+ * breaks Tailwind's static analysis.
+ *
+ * Labels use text + color accent (never color-only) for accessibility.
+ */
+const THRIVING_THRESHOLD = 3;
+
+export function getStateTier(state: number): StateTier {
+  if (state >= THRIVING_THRESHOLD) {
+    return { colorClass: "text-success", dotClass: "bg-success", label: "Thriving" };
+  }
+
+  if (state === 2) {
+    return {
+      colorClass: "text-sky-600 dark:text-sky-400",
+      dotClass: "bg-sky-600 dark:bg-sky-400",
+      label: "Healthy",
+    };
+  }
+
+  if (state === 1) {
+    return {
+      colorClass: "text-muted-foreground",
+      dotClass: "bg-muted-foreground",
+      label: "Stable",
+    };
+  }
+
+  if (state === 0) {
+    return { colorClass: "text-warning", dotClass: "bg-warning", label: "Stressed" };
+  }
+
+  return { colorClass: "text-destructive", dotClass: "bg-destructive", label: "Critical" };
+}
+
+/**
+ * Returns a direction arrow indicating how a priority's state changed
+ * in the current round. Used alongside the state label to communicate
+ * change visually.
+ */
+export function getStateDirection(delta: number): string {
+  if (delta > 0) {
+    return "↑";
+  }
+
+  if (delta < 0) {
+    return "↓";
+  }
+
+  return "→";
+}
+
+/**
+ * Maps a consequence tier to the state delta it applies.
+ *
+ * Shared by both the state computation logic (compute-priority-states)
+ * and the consequence display (tradeoff-consequences) so the business
+ * rule (invested=+1, maintained=0, neglected=-1) lives in one place.
+ */
+export const CONSEQUENCE_STATE_DELTAS: Record<ConsequenceTier, number> = {
+  invested: 1,
+  maintained: 0,
+  neglected: -1,
+};
+
+/**
+ * Returns the effective token count for a round, accounting for
+ * the optional token override from an event.
+ */
+export function getEffectiveTokenTotal(content: {
+  resource: { total: number };
+  tokenOverride: number | null;
+}): number {
+  return content.tokenOverride ?? content.resource.total;
+}

--- a/packages/player/src/components/tradeoff/tradeoff-allocation.tsx
+++ b/packages/player/src/components/tradeoff/tradeoff-allocation.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { type TradeoffStepContent } from "@zoonk/core/steps/content-contract";
+import { Button } from "@zoonk/ui/components/button";
+import { cn } from "@zoonk/ui/lib/utils";
+import { Minus, Plus } from "lucide-react";
+import { useExtracted } from "next-intl";
+import { useCallback, useState } from "react";
+import { type SelectedAnswer } from "../../player-reducer";
+import { useReplaceName } from "../../user-name-context";
+import { QuestionText } from "../question-text";
+import { getEffectiveTokenTotal } from "./_utils/state-tier";
+import { TradeoffEventBanner } from "./tradeoff-event-banner";
+import { TradeoffStateLabel } from "./tradeoff-state-label";
+
+/**
+ * The allocation UI for a single tradeoff round.
+ *
+ * Displays priority rows with +/- stepper buttons for token distribution.
+ * The learner must allocate ALL available tokens before the Check button
+ * becomes enabled (via onSelectAnswer).
+ *
+ * Design: clean rows with subtle dividers, no bordered cards. Token counter
+ * as plain text. Stepper buttons with 44px minimum touch targets.
+ */
+export function TradeoffAllocation({
+  content,
+  onSelectAnswer,
+  priorityStates,
+  roundNumber,
+  stepId,
+  totalRounds,
+}: {
+  content: TradeoffStepContent;
+  onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
+  priorityStates: Record<string, number>;
+  roundNumber: number;
+  stepId: string;
+  totalRounds: number;
+}) {
+  const t = useExtracted();
+  const replaceName = useReplaceName();
+  const effectiveTotal = getEffectiveTokenTotal(content);
+
+  const [allocations, setAllocations] = useState<Record<string, number>>(() =>
+    Object.fromEntries(content.priorities.map((priority) => [priority.id, 0])),
+  );
+
+  const allocated = Object.values(allocations).reduce((sum, value) => sum + value, 0);
+  const remaining = effectiveTotal - allocated;
+  const allSpent = remaining === 0;
+
+  const handleChange = useCallback(
+    (priorityId: string, delta: number) => {
+      const current = allocations[priorityId] ?? 0;
+      const next = current + delta;
+
+      if (next < 0 || allocated + delta > effectiveTotal) {
+        return;
+      }
+
+      const updated = { ...allocations, [priorityId]: next };
+      const updatedTotal = allocated + delta;
+
+      setAllocations(updated);
+
+      if (updatedTotal === effectiveTotal) {
+        onSelectAnswer(stepId, {
+          allocations: content.priorities.map((priority) => ({
+            priorityId: priority.id,
+            tokens: updated[priority.id] ?? 0,
+          })),
+          kind: "tradeoff",
+        });
+      } else {
+        onSelectAnswer(stepId, null);
+      }
+    },
+    [allocated, allocations, content.priorities, effectiveTotal, onSelectAnswer, stepId],
+  );
+
+  const isFirstRound = roundNumber === 1;
+
+  return (
+    <div className="flex w-full flex-col gap-6">
+      {!isFirstRound && <TradeoffEventBanner content={content} previousStates={priorityStates} />}
+
+      {isFirstRound && content.priorities[0] && (
+        <QuestionText>{replaceName(content.priorities[0].description)}</QuestionText>
+      )}
+
+      <div className="flex items-baseline justify-between">
+        <p className="text-muted-foreground text-sm">
+          {t("Round {current} of {total}", {
+            current: String(roundNumber),
+            total: String(totalRounds),
+          })}
+        </p>
+
+        <p className="text-muted-foreground text-sm">
+          {t("{allocated} of {total} {resource} allocated", {
+            allocated: String(allocated),
+            resource: content.resource.name,
+            total: String(effectiveTotal),
+          })}
+        </p>
+      </div>
+
+      <div className="divide-border flex flex-col divide-y" role="group">
+        {content.priorities.map((priority) => {
+          const tokens = allocations[priority.id] ?? 0;
+          const canDecrease = tokens > 0;
+          const canIncrease = remaining > 0;
+          const state = priorityStates[priority.id];
+
+          return (
+            <div className="flex items-center gap-4 py-4" key={priority.id}>
+              <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                <div className="flex items-center gap-2">
+                  <span className="text-base font-medium">{replaceName(priority.name)}</span>
+                  {!isFirstRound && state !== undefined && (
+                    <TradeoffStateLabel className="text-xs" state={state} />
+                  )}
+                </div>
+                <span className="text-muted-foreground text-sm">
+                  {replaceName(priority.description)}
+                </span>
+              </div>
+
+              <div className="flex shrink-0 items-center gap-2">
+                <Button
+                  aria-label={t("Remove from {priority}", {
+                    priority: priority.name,
+                  })}
+                  className="size-10"
+                  disabled={!canDecrease}
+                  onClick={() => handleChange(priority.id, -1)}
+                  size="icon"
+                  variant="outline"
+                >
+                  <Minus className="size-4" />
+                </Button>
+
+                <span
+                  aria-label={t("{count} for {priority}", {
+                    count: String(tokens),
+                    priority: priority.name,
+                  })}
+                  className={cn(
+                    "w-8 text-center text-lg font-semibold tabular-nums",
+                    tokens === 0 && "text-muted-foreground",
+                  )}
+                >
+                  {tokens}
+                </span>
+
+                <Button
+                  aria-label={t("Add to {priority}", {
+                    priority: priority.name,
+                  })}
+                  className="size-10"
+                  disabled={!canIncrease}
+                  onClick={() => handleChange(priority.id, 1)}
+                  size="icon"
+                  variant="outline"
+                >
+                  <Plus className="size-4" />
+                </Button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {allSpent && (
+        <p className="text-muted-foreground animate-in fade-in text-center text-sm duration-150">
+          {t("All {resource} allocated. Tap Check to see what happens.", {
+            resource: content.resource.name,
+          })}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/player/src/components/tradeoff/tradeoff-consequences.tsx
+++ b/packages/player/src/components/tradeoff/tradeoff-consequences.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { type TradeoffStepContent } from "@zoonk/core/steps/content-contract";
+import { type SelectedAnswer } from "../../player-reducer";
+import { useReplaceName } from "../../user-name-context";
+import { getConsequenceTier } from "./_utils/get-consequence-tier";
+import { CONSEQUENCE_STATE_DELTAS } from "./_utils/state-tier";
+import { TradeoffStateLabel } from "./tradeoff-state-label";
+
+const STAGGER_DELAY_MS = 150;
+
+/**
+ * Staggered consequence reveal shown during the feedback phase.
+ *
+ * Each priority's consequence animates in with a 150ms stagger delay,
+ * creating anticipation as the learner watches their choices play out
+ * one by one.
+ *
+ * The component reads the learner's allocation from the answer to
+ * determine which tier (invested/maintained/neglected) to show.
+ */
+export function TradeoffConsequences({
+  answer,
+  content,
+  currentStates,
+}: {
+  answer: SelectedAnswer | undefined;
+  content: TradeoffStepContent;
+  currentStates: Record<string, number>;
+}) {
+  const replaceName = useReplaceName();
+
+  if (!answer || answer.kind !== "tradeoff") {
+    return null;
+  }
+
+  const allocationMap = new Map(
+    answer.allocations.map((allocation) => [allocation.priorityId, allocation.tokens]),
+  );
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      {content.outcomes.map((outcome, index) => {
+        const priority = content.priorities.find(
+          (candidate) => candidate.id === outcome.priorityId,
+        );
+
+        if (!priority) {
+          return null;
+        }
+
+        const tokens = allocationMap.get(outcome.priorityId) ?? 0;
+        const tier = getConsequenceTier(tokens);
+        const delta = CONSEQUENCE_STATE_DELTAS[tier];
+        const state = currentStates[outcome.priorityId] ?? 1;
+
+        return (
+          <div
+            className="animate-in fade-in slide-in-from-bottom-1 fill-mode-backwards flex flex-col gap-1.5 py-3 duration-200 ease-out motion-reduce:animate-none"
+            key={outcome.priorityId}
+            style={{ animationDelay: `${index * STAGGER_DELAY_MS}ms` }}
+          >
+            <div className="flex items-center gap-2">
+              <span className="text-base font-medium">{replaceName(priority.name)}</span>
+              <TradeoffStateLabel delta={delta} state={state} />
+            </div>
+
+            <p className="text-muted-foreground text-sm leading-relaxed">
+              {replaceName(outcome[tier].consequence)}
+            </p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/player/src/components/tradeoff/tradeoff-event-banner.tsx
+++ b/packages/player/src/components/tradeoff/tradeoff-event-banner.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { type TradeoffStepContent } from "@zoonk/core/steps/content-contract";
+import { useExtracted } from "next-intl";
+import { useReplaceName } from "../../user-name-context";
+import { getEffectiveTokenTotal, getStateTier } from "./_utils/state-tier";
+import { useStateTierLabel } from "./use-state-tier-label";
+
+/**
+ * Shown at the top of round 2+ allocation screens. Displays the
+ * narrative event that changes the situation between rounds, along
+ * with any state deltas and token changes.
+ *
+ * The event is the dramatic turn — it should land prominently so
+ * the learner understands why the situation has changed.
+ */
+export function TradeoffEventBanner({
+  content,
+  previousStates,
+}: {
+  content: TradeoffStepContent;
+  previousStates: Record<string, number>;
+}) {
+  const t = useExtracted();
+  const replaceName = useReplaceName();
+  const translateLabel = useStateTierLabel();
+
+  if (!content.event) {
+    return null;
+  }
+
+  const effectiveTotal = getEffectiveTokenTotal(content);
+  const hasTokenChange =
+    content.tokenOverride !== null && content.tokenOverride !== content.resource.total;
+
+  return (
+    <div className="mb-6 flex flex-col gap-3">
+      <p className="text-base leading-relaxed font-medium">{replaceName(content.event)}</p>
+
+      {content.stateModifiers && content.stateModifiers.length > 0 && (
+        <div className="flex flex-col gap-1">
+          {content.stateModifiers.map((modifier) => {
+            const priority = content.priorities.find(
+              (candidate) => candidate.id === modifier.priorityId,
+            );
+
+            if (!priority) {
+              return null;
+            }
+
+            const previousState = previousStates[modifier.priorityId] ?? 1;
+            const previousTier = getStateTier(previousState);
+            const newState = previousState + modifier.delta;
+            const newTier = getStateTier(newState);
+            const sign = modifier.delta > 0 ? "+" : "";
+
+            return (
+              <p className="text-muted-foreground text-sm" key={modifier.priorityId}>
+                {priority.name}:{" "}
+                <span className={previousTier.colorClass}>
+                  {translateLabel(previousTier.label)}
+                </span>
+                {" → "}
+                <span className={newTier.colorClass}>
+                  {translateLabel(newTier.label)} ({sign}
+                  {modifier.delta})
+                </span>
+              </p>
+            );
+          })}
+        </div>
+      )}
+
+      {hasTokenChange && (
+        <p className="text-muted-foreground text-sm">
+          {t("You now have {count} {resource}.", {
+            count: String(effectiveTotal),
+            resource: content.resource.name,
+          })}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/player/src/components/tradeoff/tradeoff-final-states.tsx
+++ b/packages/player/src/components/tradeoff/tradeoff-final-states.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { type TradeoffStepContent } from "@zoonk/core/steps/content-contract";
+import { useExtracted } from "next-intl";
+import { useReplaceName } from "../../user-name-context";
+import { TradeoffStateLabel } from "./tradeoff-state-label";
+
+const STAGGER_BASE_DELAY_MS = 600;
+const STAGGER_DELAY_MS = 100;
+
+/**
+ * Summary of all priority final states, shown in the feedback phase
+ * of the last tradeoff round.
+ *
+ * Uses staggered animation with a base delay so it appears after
+ * the consequence reveal finishes.
+ */
+export function TradeoffFinalStates({
+  content,
+  finalStates,
+}: {
+  content: TradeoffStepContent;
+  finalStates: Record<string, number>;
+}) {
+  const t = useExtracted();
+  const replaceName = useReplaceName();
+
+  return (
+    <div className="mt-4 flex flex-col gap-3">
+      <h3
+        className="animate-in fade-in fill-mode-backwards text-sm font-medium duration-200"
+        style={{ animationDelay: `${STAGGER_BASE_DELAY_MS}ms` }}
+      >
+        {t("Final state")}
+      </h3>
+
+      <div className="divide-border flex flex-col divide-y">
+        {content.priorities.map((priority, index) => {
+          const state = finalStates[priority.id] ?? 1;
+
+          return (
+            <div
+              className="animate-in fade-in slide-in-from-bottom-1 fill-mode-backwards flex items-center justify-between py-3 duration-200 ease-out motion-reduce:animate-none"
+              key={priority.id}
+              style={{
+                animationDelay: `${STAGGER_BASE_DELAY_MS + (index + 1) * STAGGER_DELAY_MS}ms`,
+              }}
+            >
+              <span className="text-base font-medium">{replaceName(priority.name)}</span>
+              <TradeoffStateLabel state={state} />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/player/src/components/tradeoff/tradeoff-state-label.tsx
+++ b/packages/player/src/components/tradeoff/tradeoff-state-label.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { cn } from "@zoonk/ui/lib/utils";
+import { getStateDirection, getStateTier } from "./_utils/state-tier";
+import { useStateTierLabel } from "./use-state-tier-label";
+
+/**
+ * Displays a priority's state as a text label with a subtle colored dot.
+ * Never uses color alone to communicate state — the text label is always
+ * present for accessibility.
+ *
+ * Optionally shows a direction arrow (↑/→/↓) when the state changed.
+ */
+export function TradeoffStateLabel({
+  className,
+  delta,
+  state,
+}: {
+  className?: string;
+  delta?: number;
+  state: number;
+}) {
+  const translateLabel = useStateTierLabel();
+  const tier = getStateTier(state);
+  const direction = delta === undefined ? null : getStateDirection(delta);
+
+  return (
+    <span className={cn("inline-flex items-center gap-1.5 text-sm", className)}>
+      <span aria-hidden className={cn("size-2 rounded-full", tier.dotClass)} />
+      <span className={tier.colorClass}>
+        {translateLabel(tier.label)}
+        {direction && ` ${direction}`}
+      </span>
+    </span>
+  );
+}

--- a/packages/player/src/components/tradeoff/tradeoff-step.tsx
+++ b/packages/player/src/components/tradeoff/tradeoff-step.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
+import { useMemo } from "react";
+import { usePlayerRuntime } from "../../player-context";
+import { type SelectedAnswer, type StepResult } from "../../player-reducer";
+import { type SerializedStep } from "../../prepare-activity-data";
+import { InteractiveStepLayout } from "../step-layouts";
+import { computePriorityStates, getTradeoffRoundInfo } from "./_utils/compute-priority-states";
+import { TradeoffAllocation } from "./tradeoff-allocation";
+import { TradeoffConsequences } from "./tradeoff-consequences";
+import { TradeoffFinalStates } from "./tradeoff-final-states";
+
+/**
+ * Main orchestrator for a single tradeoff round.
+ *
+ * Renders differently based on the player phase:
+ * - **Playing**: allocation UI with stepper buttons (+ event banner for rounds 2+)
+ * - **Feedback**: staggered consequence reveal (+ final state summary for last round)
+ *
+ * Each round is a separate step in the activity. State accumulates across
+ * rounds by reading previous answers from the player state.
+ */
+export function TradeoffStep({
+  onSelectAnswer,
+  result,
+  selectedAnswer,
+  step,
+}: {
+  onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
+  result?: StepResult;
+  selectedAnswer: SelectedAnswer | undefined;
+  step: SerializedStep;
+}) {
+  const { state } = usePlayerRuntime();
+  const content = useMemo(() => parseStepContent("tradeoff", step.content), [step.content]);
+  const { isLastRound, roundNumber, totalRounds } = getTradeoffRoundInfo(state.steps, step.id);
+
+  const hasResult = result !== undefined;
+
+  /**
+   * During allocation (playing phase): states BEFORE this round's allocation,
+   * but AFTER this round's event modifiers — so the learner sees the event's
+   * impact before deciding how to allocate.
+   *
+   * During consequences (feedback phase): states AFTER this round's allocation,
+   * so consequence labels reflect the outcome of the learner's choices.
+   */
+  const priorityStates = useMemo(
+    () =>
+      computePriorityStates({
+        allSteps: state.steps,
+        currentStepId: step.id,
+        includeCurrentRound: hasResult,
+        selectedAnswers: state.selectedAnswers,
+      }),
+    [state.steps, step.id, hasResult, state.selectedAnswers],
+  );
+
+  return (
+    <InteractiveStepLayout>
+      {hasResult ? (
+        <>
+          <TradeoffConsequences
+            answer={selectedAnswer}
+            content={content}
+            currentStates={priorityStates}
+          />
+          {isLastRound && <TradeoffFinalStates content={content} finalStates={priorityStates} />}
+        </>
+      ) : (
+        <TradeoffAllocation
+          content={content}
+          onSelectAnswer={onSelectAnswer}
+          priorityStates={priorityStates}
+          roundNumber={roundNumber}
+          stepId={step.id}
+          totalRounds={totalRounds}
+        />
+      )}
+    </InteractiveStepLayout>
+  );
+}

--- a/packages/player/src/components/tradeoff/use-state-tier-label.ts
+++ b/packages/player/src/components/tradeoff/use-state-tier-label.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useExtracted } from "next-intl";
+import { useCallback } from "react";
+
+/**
+ * Returns a function that translates state tier labels (Thriving, Healthy,
+ * Stable, Stressed, Critical) into the user's language.
+ *
+ * Centralizes all tier label translations so they live in one place
+ * instead of being duplicated across components.
+ */
+export function useStateTierLabel(): (label: string) => string {
+  const t = useExtracted();
+
+  return useCallback(
+    (label: string) => {
+      if (label === "Critical") {
+        return t("Critical");
+      }
+      if (label === "Healthy") {
+        return t("Healthy");
+      }
+      if (label === "Stable") {
+        return t("Stable");
+      }
+      if (label === "Stressed") {
+        return t("Stressed");
+      }
+      if (label === "Thriving") {
+        return t("Thriving");
+      }
+      return label;
+    },
+    [t],
+  );
+}

--- a/packages/player/src/compute-score.test.ts
+++ b/packages/player/src/compute-score.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { computeScore, computeTradeoffScore } from "./compute-score";
+import { computeScore } from "./compute-score";
 
 describe(computeScore, () => {
   test("all correct (5): BP=10, energyDelta=1.0", () => {
@@ -66,19 +66,6 @@ describe(computeScore, () => {
       brainPower: 10,
       correctCount: 0,
       energyDelta: 0.1,
-      incorrectCount: 0,
-    });
-  });
-});
-
-describe(computeTradeoffScore, () => {
-  test("returns 100 BP, 5 energy, 0 correct/incorrect", () => {
-    const result = computeTradeoffScore();
-
-    expect(result).toEqual({
-      brainPower: 100,
-      correctCount: 0,
-      energyDelta: 5,
       incorrectCount: 0,
     });
   });

--- a/packages/player/src/compute-score.test.ts
+++ b/packages/player/src/compute-score.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { computeScore } from "./compute-score";
+import { computeScore, computeTradeoffScore } from "./compute-score";
 
 describe(computeScore, () => {
   test("all correct (5): BP=10, energyDelta=1.0", () => {
@@ -66,6 +66,19 @@ describe(computeScore, () => {
       brainPower: 10,
       correctCount: 0,
       energyDelta: 0.1,
+      incorrectCount: 0,
+    });
+  });
+});
+
+describe(computeTradeoffScore, () => {
+  test("returns 100 BP, 5 energy, 0 correct/incorrect", () => {
+    const result = computeTradeoffScore();
+
+    expect(result).toEqual({
+      brainPower: 100,
+      correctCount: 0,
+      energyDelta: 5,
       incorrectCount: 0,
     });
   });

--- a/packages/player/src/compute-score.ts
+++ b/packages/player/src/compute-score.ts
@@ -1,4 +1,8 @@
-import { BRAIN_POWER_PER_ACTIVITY } from "@zoonk/utils/brain-power";
+import {
+  BRAIN_POWER_PER_ACTIVITY,
+  TRADEOFF_BRAIN_POWER,
+  TRADEOFF_ENERGY,
+} from "@zoonk/utils/brain-power";
 import { ENERGY_PER_CORRECT, ENERGY_PER_INCORRECT, ENERGY_PER_STATIC } from "@zoonk/utils/energy";
 
 type ActivityScoreInput = {
@@ -20,6 +24,20 @@ function calculateEnergyDelta(results: ActivityScoreInput["results"]): number {
   const correctCount = results.filter((result) => result.isCorrect).length;
   const incorrectCount = results.length - correctCount;
   return correctCount * ENERGY_PER_CORRECT + incorrectCount * ENERGY_PER_INCORRECT;
+}
+
+/**
+ * Tradeoff activities have no correct/incorrect answers — they test
+ * judgment, not recall. They award a boosted reward (100 BP + 5 energy)
+ * to reflect the higher engagement and complexity.
+ */
+export function computeTradeoffScore(): ScoreResult {
+  return {
+    brainPower: TRADEOFF_BRAIN_POWER,
+    correctCount: 0,
+    energyDelta: TRADEOFF_ENERGY,
+    incorrectCount: 0,
+  };
 }
 
 export function computeScore(input: ActivityScoreInput): ScoreResult {

--- a/packages/player/src/player-completion.test.ts
+++ b/packages/player/src/player-completion.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "vitest";
+import { computeLocalCompletion } from "./player-completion";
+import { type PlayerState } from "./player-reducer";
+import { type SerializedStep } from "./prepare-activity-data";
+
+function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
+  return {
+    content: { text: "Hello", title: "Intro", variant: "text" as const },
+    fillBlankOptions: [],
+    id: "step-1",
+    kind: "static",
+    matchColumnsRightItems: [],
+    position: 0,
+    sentence: null,
+    sentenceWordOptions: [],
+    sortOrderItems: [],
+    translationOptions: [],
+    vocabularyOptions: [],
+    word: null,
+    wordBankOptions: [],
+    ...overrides,
+  };
+}
+
+function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
+  return {
+    activityId: "activity-1",
+    completion: null,
+    currentStepIndex: 0,
+    phase: "completed",
+    results: {},
+    selectedAnswers: {},
+    startedAt: Date.now(),
+    stepStartedAt: Date.now(),
+    stepTimings: {},
+    steps: [buildStep()],
+    totalBrainPower: 0,
+    ...overrides,
+  };
+}
+
+describe(computeLocalCompletion, () => {
+  test("uses standard scoring for non-tradeoff activities", () => {
+    const state = buildState({
+      results: {
+        "step-1": {
+          answer: { kind: "multipleChoice", selectedIndex: 0, selectedText: "A" },
+          result: { correctAnswer: "A", feedback: null, isCorrect: true },
+          stepId: "step-1",
+        },
+      },
+      steps: [buildStep({ id: "step-1", kind: "multipleChoice" })],
+      totalBrainPower: 50,
+    });
+
+    const result = computeLocalCompletion(state);
+
+    expect(result.brainPower).toBe(10);
+    expect(result.newTotalBp).toBe(60);
+  });
+
+  test("uses boosted scoring (100 BP, 5 energy) for tradeoff activities", () => {
+    const tradeoffContent = {
+      event: null,
+      outcomes: [],
+      priorities: [
+        { description: "d", id: "study", name: "Study" },
+        { description: "d", id: "exercise", name: "Exercise" },
+        { description: "d", id: "sleep", name: "Sleep" },
+      ],
+      resource: { name: "hours", total: 5 },
+      stateModifiers: null,
+      tokenOverride: null,
+    };
+
+    const state = buildState({
+      results: {
+        "step-1": {
+          answer: {
+            allocations: [
+              { priorityId: "study", tokens: 3 },
+              { priorityId: "exercise", tokens: 1 },
+              { priorityId: "sleep", tokens: 1 },
+            ],
+            kind: "tradeoff",
+          },
+          result: { correctAnswer: null, feedback: null, isCorrect: true },
+          stepId: "step-1",
+        },
+      },
+      steps: [
+        buildStep({ id: "intro", kind: "static", position: 0 }),
+        buildStep({ content: tradeoffContent, id: "step-1", kind: "tradeoff", position: 1 }),
+        buildStep({ id: "reflection", kind: "static", position: 2 }),
+      ],
+      totalBrainPower: 200,
+    });
+
+    const result = computeLocalCompletion(state);
+
+    expect(result.brainPower).toBe(100);
+    expect(result.energyDelta).toBe(5);
+    expect(result.newTotalBp).toBe(300);
+  });
+
+  test("detects tradeoff activity even when mixed with static steps", () => {
+    const tradeoffContent = {
+      event: null,
+      outcomes: [],
+      priorities: [
+        { description: "d", id: "study", name: "Study" },
+        { description: "d", id: "exercise", name: "Exercise" },
+        { description: "d", id: "sleep", name: "Sleep" },
+      ],
+      resource: { name: "hours", total: 5 },
+      stateModifiers: null,
+      tokenOverride: null,
+    };
+
+    const state = buildState({
+      steps: [
+        buildStep({ id: "intro", kind: "static", position: 0 }),
+        buildStep({ content: tradeoffContent, id: "r1", kind: "tradeoff", position: 1 }),
+        buildStep({ content: tradeoffContent, id: "r2", kind: "tradeoff", position: 2 }),
+        buildStep({ id: "reflection", kind: "static", position: 3 }),
+      ],
+    });
+
+    const result = computeLocalCompletion(state);
+    expect(result.brainPower).toBe(100);
+  });
+});

--- a/packages/player/src/player-completion.ts
+++ b/packages/player/src/player-completion.ts
@@ -1,7 +1,11 @@
 import { calculateBeltLevel } from "@zoonk/utils/belt-level";
 import { type CompletionResult } from "./completion-input-schema";
-import { computeScore } from "./compute-score";
+import { computeScore, computeTradeoffScore } from "./compute-score";
 import { type PlayerState } from "./player-reducer";
+
+function isTradeoffActivity(state: PlayerState): boolean {
+  return state.steps.some((step) => step.kind === "tradeoff");
+}
 
 /**
  * Computes the completion result from local player state.
@@ -10,13 +14,18 @@ import { type PlayerState } from "./player-reducer";
  * already available on the client, so we can show metrics instantly without
  * waiting for a server round-trip. The server still validates and persists
  * in the background via `after()`.
+ *
+ * Tradeoff activities use boosted scoring (100 BP + 5 energy) because
+ * they require more complex strategic thinking than standard activities.
  */
 export function computeLocalCompletion(state: PlayerState): CompletionResult {
-  const score = computeScore({
-    results: Object.values(state.results).map((stepResult) => ({
-      isCorrect: stepResult.result.isCorrect,
-    })),
-  });
+  const score = isTradeoffActivity(state)
+    ? computeTradeoffScore()
+    : computeScore({
+        results: Object.values(state.results).map((stepResult) => ({
+          isCorrect: stepResult.result.isCorrect,
+        })),
+      });
 
   const newTotalBp = state.totalBrainPower + score.brainPower;
 

--- a/packages/player/src/player-reducer.test.ts
+++ b/packages/player/src/player-reducer.test.ts
@@ -257,6 +257,54 @@ describe("CHECK_ANSWER", () => {
     });
   });
 
+  describe("tradeoff feedback phase", () => {
+    test("enters feedback phase to show consequences (does not auto-advance)", () => {
+      const steps = [
+        buildStep({ id: "t-1", kind: "tradeoff", position: 0 }),
+        buildStep({ id: "t-2", kind: "tradeoff", position: 1 }),
+      ];
+      const state = buildState({ steps });
+      const next = playerReducer(state, {
+        result: { correctAnswer: null, feedback: null, isCorrect: true },
+        stepId: "t-1",
+        type: "CHECK_ANSWER",
+      });
+      expect(next.phase).toBe("feedback");
+      expect(next.currentStepIndex).toBe(0);
+      expect(next.results["t-1"]).toEqual({
+        answer: undefined,
+        result: { correctAnswer: null, feedback: null, isCorrect: true },
+        stepId: "t-1",
+      });
+    });
+
+    test("advances to next step on CONTINUE after feedback", () => {
+      const steps = [
+        buildStep({ id: "t-1", kind: "tradeoff", position: 0 }),
+        buildStep({ id: "t-2", kind: "tradeoff", position: 1 }),
+      ];
+      const feedbackState = buildState({
+        currentStepIndex: 0,
+        phase: "feedback",
+        steps,
+      });
+      const next = playerReducer(feedbackState, { type: "CONTINUE" });
+      expect(next.phase).toBe("playing");
+      expect(next.currentStepIndex).toBe(1);
+    });
+
+    test("completes activity on CONTINUE after last tradeoff round feedback", () => {
+      const steps = [buildStep({ id: "t-1", kind: "tradeoff", position: 0 })];
+      const feedbackState = buildState({
+        currentStepIndex: 0,
+        phase: "feedback",
+        steps,
+      });
+      const next = playerReducer(feedbackState, { type: "CONTINUE" });
+      expect(next.phase).toBe("completed");
+    });
+  });
+
   test("no-ops in feedback phase", () => {
     const state = buildState({ phase: "feedback" });
     const next = playerReducer(state, {

--- a/packages/player/src/player-reducer.ts
+++ b/packages/player/src/player-reducer.ts
@@ -15,6 +15,7 @@ export type SelectedAnswer =
   | { kind: "reading"; arrangedWords: string[] }
   | { kind: "selectImage"; selectedIndex: number }
   | { kind: "sortOrder"; userOrder: string[] }
+  | { kind: "tradeoff"; allocations: { priorityId: string; tokens: number }[] }
   | { kind: "translation"; selectedWordId: string; selectedText: string; questionText: string };
 
 export type StepResult = {

--- a/packages/player/src/validate-answers.test.ts
+++ b/packages/player/src/validate-answers.test.ts
@@ -231,6 +231,69 @@ describe(validateAnswers, () => {
     expect(results[0]?.isCorrect).toBe(true);
   });
 
+  test("tradeoff always validates as correct and creates a StepAttempt record", () => {
+    const steps = [
+      {
+        content: {
+          event: null,
+          outcomes: [],
+          priorities: [
+            { description: "d", id: "study", name: "Study" },
+            { description: "d", id: "exercise", name: "Exercise" },
+            { description: "d", id: "sleep", name: "Sleep" },
+          ],
+          resource: { name: "hours", total: 5 },
+          stateModifiers: null,
+          tokenOverride: null,
+        },
+        id: 20n,
+        kind: "tradeoff",
+      },
+    ];
+
+    const results = validateAnswers(steps, {
+      "20": {
+        allocations: [
+          { priorityId: "study", tokens: 3 },
+          { priorityId: "exercise", tokens: 1 },
+          { priorityId: "sleep", tokens: 1 },
+        ],
+        kind: "tradeoff",
+      },
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.isCorrect).toBe(true);
+    expect(results[0]?.stepId).toBe(20n);
+  });
+
+  test("tradeoff returns null when answer kind does not match", () => {
+    const steps = [
+      {
+        content: {
+          event: null,
+          outcomes: [],
+          priorities: [
+            { description: "d", id: "study", name: "Study" },
+            { description: "d", id: "exercise", name: "Exercise" },
+            { description: "d", id: "sleep", name: "Sleep" },
+          ],
+          resource: { name: "hours", total: 5 },
+          stateModifiers: null,
+          tokenOverride: null,
+        },
+        id: 21n,
+        kind: "tradeoff",
+      },
+    ];
+
+    const results = validateAnswers(steps, {
+      "21": { kind: "multipleChoice", selectedIndex: 0, selectedText: "test" },
+    });
+
+    expect(results).toHaveLength(0);
+  });
+
   test("skips unsupported step kinds", () => {
     const steps = [{ content: {}, id: 7n, kind: "unknownKind" }];
 

--- a/packages/player/src/validate-answers.ts
+++ b/packages/player/src/validate-answers.ts
@@ -22,6 +22,7 @@ type SelectedAnswer =
   | { kind: "reading"; arrangedWords: string[] }
   | { kind: "selectImage"; selectedIndex: number }
   | { kind: "sortOrder"; userOrder: string[] }
+  | { kind: "tradeoff"; allocations: { priorityId: string; tokens: number }[] }
   | { kind: "translation"; selectedWordId: string; selectedText: string; questionText: string };
 
 /**
@@ -135,6 +136,19 @@ function validateReading(step: StepData, answer: SelectedAnswer): ValidatedStepR
   return { answer, isCorrect: result.isCorrect, stepId: step.id };
 }
 
+/**
+ * Tradeoff steps always return isCorrect: true because there is no
+ * right or wrong allocation. We still create a StepAttempt record so
+ * the learner's allocation choices are available for analytics.
+ */
+function validateTradeoff(step: StepData, answer: SelectedAnswer): ValidatedStepResult | null {
+  if (answer.kind !== "tradeoff") {
+    return null;
+  }
+
+  return { answer, isCorrect: true, stepId: step.id };
+}
+
 function validateListening(step: StepData, answer: SelectedAnswer): ValidatedStepResult | null {
   if (answer.kind !== "listening") {
     return null;
@@ -161,6 +175,7 @@ const validators: Record<
   selectImage: validateSelectImage,
   sortOrder: validateSortOrder,
   static: () => null,
+  tradeoff: validateTradeoff,
   translation: validateTranslation,
   visual: () => null,
   vocabulary: () => null,

--- a/packages/utils/src/brain-power.ts
+++ b/packages/utils/src/brain-power.ts
@@ -1,1 +1,9 @@
 export const BRAIN_POWER_PER_ACTIVITY = 10;
+
+/**
+ * Tradeoff activities are more complex and thoughtful than standard
+ * activities — they require multiple rounds of strategic allocation
+ * decisions. The higher reward reflects this increased engagement.
+ */
+export const TRADEOFF_BRAIN_POWER = 100;
+export const TRADEOFF_ENERGY = 5;


### PR DESCRIPTION
## Summary

- Add a new "tradeoff" activity type for core lessons — a resource allocation game where learners distribute limited tokens across competing priorities and see consequences play out over multiple rounds
- Each round is its own step using the standard player flow (allocate → Check → inline consequences → Continue)
- AI generates 2-4 rounds based on topic complexity with three-tier outcomes (neglected/maintained/invested)
- Awards 100 BP + 5 energy (vs standard 10 BP) to reflect the higher engagement
- Excluded from accuracy rate — completion shows "Completed" checkmark, not "X/Y correct"
- StepAttempt records created for allocation analytics

## Test plan

- [ ] Unit tests: content schema validation, check-step, validate-answers, player-reducer feedback flow, compute-score, player-completion scoring, priority state computation, consequence tiers, state tiers
- [ ] Integration tests: save-tradeoff-activity-step (step creation + error handling), generate-tradeoff-content-step (AI mock + failure paths), submit-activity-completion (tradeoff BP/energy/tracking), get-activities-for-kind (tradeoff in core activities)
- [ ] E2E tests: scenario intro display, stepper interaction, token allocation + Check enable, consequence reveal per tier, multi-round flow with events, reflection step, completion screen
- [ ] Eval test cases: 5 scenarios across pt/en/es covering neuroscience, software engineering, personal finance, climate policy, time management

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `tradeoff` core activity: a multi-round resource allocation game that teaches judgment through consequences, not grading. Awards 100 BP + 5 energy, hides accuracy, and logs allocations for analytics; also fixes the player check flow for tradeoff steps.

- **New Features**
  - Activity generation: `tradeoff` workflow and steps; `@zoonk/ai` creates 2–4 rounds with three-tier outcomes (neglected/maintained/invested).
  - Player experience: new tradeoff UI for allocation, events, consequence reveal, and final states; integrated into step renderer; new translations.
  - Scoring: excluded from accuracy; uses `computeTradeoffScore` (100 BP + 5 energy); completion screen hides X/Y correct for `tradeoff`.
  - Progress: tracks `tradeoffCompleted` in daily progress; records `StepAttempt` for allocation analytics.
  - Generation: lesson kinds include `tradeoff`; phase config, steps, and weights added; activity list/SEO updated.
  - Tests/Evals: unit, integration, E2E, and eval task with cross-language cases.
  - Bug fix: player `check-step` now uses an `answer.kind` guard for `tradeoff` and removes brittle snapshot tests.

- **Migration**
  - Database: add `tradeoff` to `ActivityKind`/`StepKind` enums and `daily_progress.tradeoff_completed` via Prisma migration.
  - No backfill needed; new activities use the enums and progress field automatically.

<sup>Written for commit 315979200e22338a674d89e6b6e7b37fdb009f56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

