### PR TITLE
feat(player): add story activity schema, content types, and player logic

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -2516,6 +2516,11 @@ msgid "Learn about {topic} through an interactive activity."
 msgstr "Learn about {topic} through an interactive activity."
 
 #: src/lib/activities.ts
+msgctxt "SJvUFW"
+msgid "Experience {topic} through an interactive story where your decisions shape the outcome."
+msgstr "Experience {topic} through an interactive story where your decisions shape the outcome."
+
+#: src/lib/activities.ts
 msgctxt "THPcKi"
 msgid "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies."
 msgstr "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies."

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -2516,6 +2516,11 @@ msgid "Learn about {topic} through an interactive activity."
 msgstr "Aprende sobre {topic} a través de una actividad interactiva."
 
 #: src/lib/activities.ts
+msgctxt "SJvUFW"
+msgid "Experience {topic} through an interactive story where your decisions shape the outcome."
+msgstr "Vive {topic} a través de una historia interactiva donde tus decisiones moldean el resultado."
+
+#: src/lib/activities.ts
 msgctxt "THPcKi"
 msgid "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies."
 msgstr "Entiende qué es {topic}: conceptos centrales y definiciones explicados con metáforas y analogías claras."

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -2516,6 +2516,11 @@ msgid "Learn about {topic} through an interactive activity."
 msgstr "Aprenda sobre {topic} através de uma atividade interativa."
 
 #: src/lib/activities.ts
+msgctxt "SJvUFW"
+msgid "Experience {topic} through an interactive story where your decisions shape the outcome."
+msgstr "Vivencie {topic} por meio de uma história interativa em que suas decisões moldam o resultado."
+
+#: src/lib/activities.ts
 msgctxt "THPcKi"
 msgid "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies."
 msgstr "Entenda o que é {topic} — conceitos centrais e definições explicados com metáforas e analogias claras."

--- a/apps/main/src/lib/activities.ts
+++ b/apps/main/src/lib/activities.ts
@@ -57,6 +57,10 @@ async function getSeoDescription(kind: ActivityKind, topic: string): Promise<str
       { topic },
     ),
     review: t("Review everything you learned about {topic} with a comprehensive quiz.", { topic }),
+    story: t(
+      "Experience {topic} through an interactive story where your decisions shape the outcome.",
+      { topic },
+    ),
     translation: t("Test your {topic} vocabulary by translating words you've learned.", { topic }),
     vocabulary: t(
       "Learn new {topic} words with flashcards — see each word, its translation, and pronunciation.",
@@ -120,6 +124,7 @@ const ACTIVITY_ICONS: Record<ActivityKind, LucideIcon> = {
   quiz: CircleHelpIcon,
   reading: BookTextIcon,
   review: RotateCcwIcon,
+  story: BookOpenIcon,
   translation: LanguagesIcon,
   vocabulary: LayersIcon,
 };

--- a/apps/main/src/lib/generation/activity-generation-phase-config.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-config.ts
@@ -78,6 +78,7 @@ const PHASE_ORDER_MAP: Record<ActivityKind, PhaseName[]> = {
   quiz: QUIZ_PHASE_ORDER,
   reading: READING_PHASE_ORDER,
   review: EXPLANATION_PHASE_ORDER,
+  story: EXPLANATION_PHASE_ORDER,
   translation: VOCABULARY_PHASE_ORDER,
   vocabulary: VOCABULARY_PHASE_ORDER,
 };
@@ -130,6 +131,7 @@ const PHASE_STEPS_MAP: Record<ActivityKind, Record<PhaseName, readonly ActivityS
   quiz: toFullPhaseSteps(QUIZ_PHASE_STEPS),
   reading: toFullPhaseSteps(READING_PHASE_STEPS),
   review: toFullPhaseSteps(EXPLANATION_PHASE_STEPS),
+  story: toFullPhaseSteps(EXPLANATION_PHASE_STEPS),
   translation: toFullPhaseSteps(VOCABULARY_PHASE_STEPS),
   vocabulary: toFullPhaseSteps(VOCABULARY_PHASE_STEPS),
 };

--- a/i18n.lock
+++ b/i18n.lock
@@ -672,6 +672,7 @@ checksums:
     Test%20your%20%7Btopic%7D%20vocabulary%20by%20translating%20words%20you've%20learned./singular: d81da859633df4dd0b03711f48cc1cdd
     Grammar/singular: 1d97aca351a45df1d6eb27adbee04832
     Learn%20about%20%7Btopic%7D%20through%20an%20interactive%20activity./singular: 94f8ca153ea2ee6b539f507266548201
+    Experience%20%7Btopic%7D%20through%20an%20interactive%20story%20where%20your%20decisions%20shape%20the%20outcome./singular: 56069dcd1f836d241ab23c4a19d7d208
     Understand%20what%20%7Btopic%7D%20is%20%E2%80%94%20core%20concepts%20and%20definitions%20explained%20with%20clear%20metaphors%20and%20analogies./singular: ec3b49a710ebac5f592523bdaa68ceff
     Practice%20%7Btopic%7D%20grammar%20rules%20with%20exercises%20designed%20to%20help%20you%20remember%20and%20apply%20them./singular: 107adae09992e8b4deb051afa38da3bd
     "%7Bactivity%7D%20-%20%7Blesson%7D/singular": 0aad8d82851f799d79c052a0f2b90d67

--- a/packages/core/src/steps/content-contract.test.ts
+++ b/packages/core/src/steps/content-contract.test.ts
@@ -247,7 +247,7 @@ describe("step content contracts", () => {
       text: "Do the right thing",
     };
 
-    test("parses middle step with situation and choices only", () => {
+    test("parses step with situation and choices", () => {
       const content = parseStepContent("story", {
         choices: [baseChoice, { ...baseChoice, alignment: "weak", id: "1b" }],
         situation: "You face a decision.",
@@ -255,44 +255,6 @@ describe("step content contracts", () => {
 
       expect(content.situation).toBe("You face a decision.");
       expect(content.choices).toHaveLength(2);
-      expect(content.intro).toBeUndefined();
-      expect(content.metrics).toBeUndefined();
-      expect(content.outcomes).toBeUndefined();
-      expect(content.debrief).toBeUndefined();
-    });
-
-    test("parses first step with intro and metrics", () => {
-      const content = parseStepContent("story", {
-        choices: [baseChoice, { ...baseChoice, alignment: "partial", id: "1b" }],
-        intro: "You are a factory manager in 1950.",
-        metrics: [
-          { id: "production", initial: 50, label: "Production" },
-          { id: "morale", initial: 45, label: "Morale" },
-          { id: "cash", initial: 40, label: "Cash" },
-        ],
-        situation: "The factory floor is chaotic.",
-      });
-
-      expect(content.intro).toBe("You are a factory manager in 1950.");
-      expect(content.metrics).toHaveLength(3);
-    });
-
-    test("parses last step with outcomes and debrief", () => {
-      const content = parseStepContent("story", {
-        choices: [baseChoice, { ...baseChoice, alignment: "weak", id: "1b" }],
-        debrief: [
-          { explanation: "When you chose X, you experienced Y.", name: "Kanban" },
-          { explanation: "Pulling work based on demand.", name: "Pull System" },
-        ],
-        outcomes: [
-          { minStrongChoices: 4, narrative: "Your factory thrives.", title: "Master Manager" },
-          { minStrongChoices: 0, narrative: "Things fell apart.", title: "Learning Moment" },
-        ],
-        situation: "The director visits.",
-      });
-
-      expect(content.outcomes).toHaveLength(2);
-      expect(content.debrief).toHaveLength(2);
     });
 
     test("accepts more than 4 choices", () => {
@@ -318,6 +280,16 @@ describe("step content contracts", () => {
       ).toThrow();
     });
 
+    test("rejects extra fields on step content", () => {
+      expect(() =>
+        parseStepContent("story", {
+          choices: [baseChoice, { ...baseChoice, id: "1b" }],
+          intro: "Not allowed here.",
+          situation: "Test.",
+        }),
+      ).toThrow();
+    });
+
     test("rejects extra fields on choice", () => {
       expect(() =>
         parseStepContent("story", {
@@ -334,13 +306,57 @@ describe("step content contracts", () => {
         }),
       ).toThrow();
     });
+  });
+
+  describe("static storyIntro", () => {
+    test("parses intro with metrics", () => {
+      const content = parseStepContent("static", {
+        intro: "You are a factory manager in 1950.",
+        metrics: [
+          { id: "production", initial: 50, label: "Production" },
+          { id: "morale", initial: 45, label: "Morale" },
+          { id: "cash", initial: 40, label: "Cash" },
+        ],
+        variant: "storyIntro",
+      });
+
+      expect(content.variant).toBe("storyIntro");
+    });
+
+    test("rejects empty metrics", () => {
+      expect(() =>
+        parseStepContent("static", {
+          intro: "You are a factory manager.",
+          metrics: [],
+          variant: "storyIntro",
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe("static storyDebrief", () => {
+    test("parses debrief with outcomes", () => {
+      const content = parseStepContent("static", {
+        debrief: [
+          { explanation: "When you chose X, you experienced Y.", name: "Kanban" },
+          { explanation: "Pulling work based on demand.", name: "Pull System" },
+        ],
+        outcomes: [
+          { minStrongChoices: 4, narrative: "Your factory thrives.", title: "Master Manager" },
+          { minStrongChoices: 0, narrative: "Things fell apart.", title: "Learning Moment" },
+        ],
+        variant: "storyDebrief",
+      });
+
+      expect(content.variant).toBe("storyDebrief");
+    });
 
     test("rejects negative minStrongChoices", () => {
       expect(() =>
-        parseStepContent("story", {
-          choices: [baseChoice, { ...baseChoice, id: "1b" }],
+        parseStepContent("static", {
+          debrief: [{ explanation: "Test.", name: "Concept" }],
           outcomes: [{ minStrongChoices: -1, narrative: "Bad.", title: "Bad" }],
-          situation: "Test.",
+          variant: "storyDebrief",
         }),
       ).toThrow();
     });

--- a/packages/core/src/steps/content-contract.test.ts
+++ b/packages/core/src/steps/content-contract.test.ts
@@ -237,4 +237,112 @@ describe("step content contracts", () => {
       }),
     ).toThrow();
   });
+
+  describe("story", () => {
+    const baseChoice = {
+      alignment: "strong" as const,
+      consequence: "Things improve.",
+      id: "1a",
+      metricChanges: { production: 10 },
+      text: "Do the right thing",
+    };
+
+    test("parses middle step with situation and choices only", () => {
+      const content = parseStepContent("story", {
+        choices: [baseChoice, { ...baseChoice, alignment: "weak", id: "1b" }],
+        situation: "You face a decision.",
+      });
+
+      expect(content.situation).toBe("You face a decision.");
+      expect(content.choices).toHaveLength(2);
+      expect(content.intro).toBeUndefined();
+      expect(content.metrics).toBeUndefined();
+      expect(content.outcomes).toBeUndefined();
+      expect(content.debrief).toBeUndefined();
+    });
+
+    test("parses first step with intro and metrics", () => {
+      const content = parseStepContent("story", {
+        choices: [baseChoice, { ...baseChoice, alignment: "partial", id: "1b" }],
+        intro: "You are a factory manager in 1950.",
+        metrics: [
+          { id: "production", initial: 50, label: "Production" },
+          { id: "morale", initial: 45, label: "Morale" },
+          { id: "cash", initial: 40, label: "Cash" },
+        ],
+        situation: "The factory floor is chaotic.",
+      });
+
+      expect(content.intro).toBe("You are a factory manager in 1950.");
+      expect(content.metrics).toHaveLength(3);
+    });
+
+    test("parses last step with outcomes and debrief", () => {
+      const content = parseStepContent("story", {
+        choices: [baseChoice, { ...baseChoice, alignment: "weak", id: "1b" }],
+        debrief: [
+          { explanation: "When you chose X, you experienced Y.", name: "Kanban" },
+          { explanation: "Pulling work based on demand.", name: "Pull System" },
+        ],
+        outcomes: [
+          { minStrongChoices: 4, narrative: "Your factory thrives.", title: "Master Manager" },
+          { minStrongChoices: 0, narrative: "Things fell apart.", title: "Learning Moment" },
+        ],
+        situation: "The director visits.",
+      });
+
+      expect(content.outcomes).toHaveLength(2);
+      expect(content.debrief).toHaveLength(2);
+    });
+
+    test("accepts more than 4 choices", () => {
+      const choices = Array.from({ length: 5 }, (_, i) => ({
+        ...baseChoice,
+        id: `choice-${i}`,
+      }));
+
+      const content = parseStepContent("story", {
+        choices,
+        situation: "Many options available.",
+      });
+
+      expect(content.choices).toHaveLength(5);
+    });
+
+    test("rejects fewer than 2 choices", () => {
+      expect(() =>
+        parseStepContent("story", {
+          choices: [baseChoice],
+          situation: "Only one option.",
+        }),
+      ).toThrow();
+    });
+
+    test("rejects extra fields on choice", () => {
+      expect(() =>
+        parseStepContent("story", {
+          choices: [{ ...baseChoice, extra: "field" }],
+          situation: "Test.",
+        }),
+      ).toThrow();
+    });
+
+    test("rejects missing situation", () => {
+      expect(() =>
+        parseStepContent("story", {
+          choices: [baseChoice, { ...baseChoice, id: "1b" }],
+        }),
+      ).toThrow();
+    });
+
+    test("rejects negative minStrongChoices", () => {
+      expect(() =>
+        parseStepContent("story", {
+          choices: [baseChoice, { ...baseChoice, id: "1b" }],
+          outcomes: [{ minStrongChoices: -1, narrative: "Bad.", title: "Bad" }],
+          situation: "Test.",
+        }),
+      ).toThrow();
+    });
+  });
 });

--- a/packages/core/src/steps/content-contract.ts
+++ b/packages/core/src/steps/content-contract.ts
@@ -97,29 +97,11 @@ const staticGrammarRuleContentSchema = z
   })
   .strict();
 
-const staticContentSchema = z.discriminatedUnion("variant", [
-  staticTextContentSchema,
-  staticGrammarExampleContentSchema,
-  staticGrammarRuleContentSchema,
-]);
-
 const storyMetricSchema = z
   .object({
     id: z.string(),
     initial: z.number(),
     label: z.string(),
-  })
-  .strict();
-
-const storyAlignmentSchema = z.enum(["strong", "partial", "weak"]);
-
-const storyChoiceSchema = z
-  .object({
-    alignment: storyAlignmentSchema,
-    consequence: z.string(),
-    id: z.string(),
-    metricChanges: z.record(z.string(), z.number()),
-    text: z.string(),
   })
   .strict();
 
@@ -139,21 +121,53 @@ const storyDebriefConceptSchema = z
   .strict();
 
 /**
- * Schema for a story step's content.
- *
- * Every step has a situation and choices. The first step also carries
- * story-level intro/metrics, and the last step carries outcomes/debrief.
- * Position-based requirements are enforced at the save layer, not here.
+ * Intro screen for a story activity (static step, first position).
+ * Sets the scene and defines the metrics the player will track.
  */
+const staticStoryIntroContentSchema = z
+  .object({
+    intro: z.string(),
+    metrics: z.array(storyMetricSchema).min(1),
+    variant: z.literal("storyIntro"),
+  })
+  .strict();
+
+/**
+ * Debrief screen for a story activity (static step, last position).
+ * Reveals hidden concepts and shows outcome based on player's choices.
+ */
+const staticStoryDebriefContentSchema = z
+  .object({
+    debrief: z.array(storyDebriefConceptSchema).min(1),
+    outcomes: z.array(storyOutcomeSchema).min(1),
+    variant: z.literal("storyDebrief"),
+  })
+  .strict();
+
+const staticContentSchema = z.discriminatedUnion("variant", [
+  staticTextContentSchema,
+  staticGrammarExampleContentSchema,
+  staticGrammarRuleContentSchema,
+  staticStoryIntroContentSchema,
+  staticStoryDebriefContentSchema,
+]);
+
+const storyAlignmentSchema = z.enum(["strong", "partial", "weak"]);
+
+const storyChoiceSchema = z
+  .object({
+    alignment: storyAlignmentSchema,
+    consequence: z.string(),
+    id: z.string(),
+    metricChanges: z.record(z.string(), z.number()),
+    text: z.string(),
+  })
+  .strict();
+
+/** Schema for a story decision step's content (situation + choices). */
 const storyContentSchema = z
   .object({
     choices: z.array(storyChoiceSchema).min(2),
-    // Story-level data on last step.
-    debrief: z.array(storyDebriefConceptSchema).min(1).optional(),
-    // Story-level data on first step.
-    intro: z.string().optional(),
-    metrics: z.array(storyMetricSchema).min(1).optional(),
-    outcomes: z.array(storyOutcomeSchema).min(1).optional(),
     situation: z.string(),
   })
   .strict();

--- a/packages/core/src/steps/content-contract.ts
+++ b/packages/core/src/steps/content-contract.ts
@@ -103,6 +103,61 @@ const staticContentSchema = z.discriminatedUnion("variant", [
   staticGrammarRuleContentSchema,
 ]);
 
+const storyMetricSchema = z
+  .object({
+    id: z.string(),
+    initial: z.number(),
+    label: z.string(),
+  })
+  .strict();
+
+const storyAlignmentSchema = z.enum(["strong", "partial", "weak"]);
+
+const storyChoiceSchema = z
+  .object({
+    alignment: storyAlignmentSchema,
+    consequence: z.string(),
+    id: z.string(),
+    metricChanges: z.record(z.string(), z.number()),
+    text: z.string(),
+  })
+  .strict();
+
+const storyOutcomeSchema = z
+  .object({
+    minStrongChoices: z.number().int().min(0),
+    narrative: z.string(),
+    title: z.string(),
+  })
+  .strict();
+
+const storyDebriefConceptSchema = z
+  .object({
+    explanation: z.string(),
+    name: z.string(),
+  })
+  .strict();
+
+/**
+ * Schema for a story step's content.
+ *
+ * Every step has a situation and choices. The first step also carries
+ * story-level intro/metrics, and the last step carries outcomes/debrief.
+ * Position-based requirements are enforced at the save layer, not here.
+ */
+const storyContentSchema = z
+  .object({
+    choices: z.array(storyChoiceSchema).min(2),
+    // Story-level data on last step.
+    debrief: z.array(storyDebriefConceptSchema).min(1).optional(),
+    // Story-level data on first step.
+    intro: z.string().optional(),
+    metrics: z.array(storyMetricSchema).min(1).optional(),
+    outcomes: z.array(storyOutcomeSchema).min(1).optional(),
+    situation: z.string(),
+  })
+  .strict();
+
 const vocabularyContentSchema = z.object({}).strict();
 const translationContentSchema = z.object({}).strict();
 const readingContentSchema = z.object({}).strict();
@@ -117,6 +172,7 @@ const stepContentSchemas = {
   selectImage: selectImageContentSchema,
   sortOrder: sortOrderContentSchema,
   static: staticContentSchema,
+  story: storyContentSchema,
   translation: translationContentSchema,
   visual: visualStepContentSchema,
   vocabulary: vocabularyContentSchema,
@@ -132,6 +188,8 @@ export type MatchColumnsStepContent = z.infer<typeof matchColumnsContentSchema>;
 export type SortOrderStepContent = z.infer<typeof sortOrderContentSchema>;
 export type SelectImageStepContent = z.infer<typeof selectImageContentSchema>;
 export type StaticStepContent = z.infer<typeof staticContentSchema>;
+export type StoryAlignment = z.infer<typeof storyAlignmentSchema>;
+export type StoryStepContent = z.infer<typeof storyContentSchema>;
 export type VocabularyStepContent = z.infer<typeof vocabularyContentSchema>;
 export type TranslationStepContent = z.infer<typeof translationContentSchema>;
 export type ReadingStepContent = z.infer<typeof readingContentSchema>;
@@ -148,6 +206,7 @@ export type StepContentByKind = {
   selectImage: SelectImageStepContent;
   sortOrder: SortOrderStepContent;
   static: StaticStepContent;
+  story: StoryStepContent;
   translation: TranslationStepContent;
   visual: VisualStepContent;
   vocabulary: VocabularyStepContent;
@@ -168,6 +227,7 @@ export function parseStepContent(kind: "reading", content: unknown): ReadingStep
 export function parseStepContent(kind: "selectImage", content: unknown): SelectImageStepContent;
 export function parseStepContent(kind: "sortOrder", content: unknown): SortOrderStepContent;
 export function parseStepContent(kind: "static", content: unknown): StaticStepContent;
+export function parseStepContent(kind: "story", content: unknown): StoryStepContent;
 export function parseStepContent(kind: "translation", content: unknown): TranslationStepContent;
 export function parseStepContent(kind: "visual", content: unknown): VisualStepContent;
 export function parseStepContent(kind: "vocabulary", content: unknown): VocabularyStepContent;
@@ -190,6 +250,7 @@ export function assertStepContent(kind: "reading", content: unknown): ReadingSte
 export function assertStepContent(kind: "selectImage", content: unknown): SelectImageStepContent;
 export function assertStepContent(kind: "sortOrder", content: unknown): SortOrderStepContent;
 export function assertStepContent(kind: "static", content: unknown): StaticStepContent;
+export function assertStepContent(kind: "story", content: unknown): StoryStepContent;
 export function assertStepContent(kind: "translation", content: unknown): TranslationStepContent;
 export function assertStepContent(kind: "visual", content: unknown): VisualStepContent;
 export function assertStepContent(kind: "vocabulary", content: unknown): VocabularyStepContent;

--- a/packages/db/src/prisma/enums.prisma
+++ b/packages/db/src/prisma/enums.prisma
@@ -22,6 +22,7 @@ enum ActivityKind {
   listening
   translation
   review
+  story
 }
 
 enum StepKind {
@@ -37,6 +38,7 @@ enum StepKind {
   translation
   reading
   listening
+  story
 }
 
 enum CourseMode {

--- a/packages/db/src/prisma/migrations/20260331094505_add_story_kind/migration.sql
+++ b/packages/db/src/prisma/migrations/20260331094505_add_story_kind/migration.sql
@@ -1,0 +1,5 @@
+-- AlterEnum
+ALTER TYPE "ActivityKind" ADD VALUE 'story';
+
+-- AlterEnum
+ALTER TYPE "StepKind" ADD VALUE 'story';

--- a/packages/player/src/check-answer.test.ts
+++ b/packages/player/src/check-answer.test.ts
@@ -14,6 +14,7 @@ import {
   checkSelectImageAnswer,
   checkSingleMatchPair,
   checkSortOrderAnswer,
+  checkStoryAnswer,
   checkTranslationAnswer,
 } from "./check-answer";
 
@@ -269,6 +270,67 @@ describe(checkTranslationAnswer, () => {
 
   test("returns incorrect for non-matching IDs", () => {
     expect(checkTranslationAnswer("word-1", "word-2")).toEqual({
+      correctAnswer: null,
+      feedback: null,
+      isCorrect: false,
+    });
+  });
+});
+
+describe(checkStoryAnswer, () => {
+  const content = {
+    choices: [
+      {
+        alignment: "strong" as const,
+        consequence: "Things improve.",
+        id: "1a",
+        metricChanges: { production: 10 },
+        text: "Strong choice",
+      },
+      {
+        alignment: "partial" as const,
+        consequence: "Mixed results.",
+        id: "1b",
+        metricChanges: { production: 5 },
+        text: "Partial choice",
+      },
+      {
+        alignment: "weak" as const,
+        consequence: "Things get worse.",
+        id: "1c",
+        metricChanges: { production: -10 },
+        text: "Weak choice",
+      },
+    ],
+    situation: "You face a decision.",
+  };
+
+  test("strong alignment is correct with consequence as feedback", () => {
+    expect(checkStoryAnswer(content, "1a")).toEqual({
+      correctAnswer: null,
+      feedback: "Things improve.",
+      isCorrect: true,
+    });
+  });
+
+  test("partial alignment is correct with consequence as feedback", () => {
+    expect(checkStoryAnswer(content, "1b")).toEqual({
+      correctAnswer: null,
+      feedback: "Mixed results.",
+      isCorrect: true,
+    });
+  });
+
+  test("weak alignment is incorrect with consequence as feedback", () => {
+    expect(checkStoryAnswer(content, "1c")).toEqual({
+      correctAnswer: null,
+      feedback: "Things get worse.",
+      isCorrect: false,
+    });
+  });
+
+  test("unknown choice ID is incorrect with null feedback", () => {
+    expect(checkStoryAnswer(content, "unknown")).toEqual({
       correctAnswer: null,
       feedback: null,
       isCorrect: false,

--- a/packages/player/src/check-answer.ts
+++ b/packages/player/src/check-answer.ts
@@ -4,6 +4,7 @@ import {
   type MultipleChoiceStepContent,
   type SelectImageStepContent,
   type SortOrderStepContent,
+  type StoryStepContent,
 } from "@zoonk/core/steps/content-contract";
 import { matchesAcceptedArrangeWords } from "./arrange-words-answers";
 
@@ -91,6 +92,23 @@ export function checkTranslationAnswer(
     feedback: null,
     isCorrect: correctWordId === selectedWordId,
   };
+}
+
+/**
+ * Check a story answer by looking up the selected choice's alignment.
+ *
+ * Alignment is hidden from the player during play, but determines correctness
+ * for analytics/metrics: strong and partial count as correct, weak as incorrect.
+ * The choice's consequence text is returned as feedback for display on the
+ * feedback screen — it describes what happens as a result of the player's decision.
+ */
+export function checkStoryAnswer(
+  content: StoryStepContent,
+  selectedChoiceId: string,
+): AnswerResult {
+  const choice = content.choices.find((option) => option.id === selectedChoiceId);
+  const isCorrect = choice ? choice.alignment !== "weak" : false;
+  return { correctAnswer: null, feedback: choice?.consequence ?? null, isCorrect };
 }
 
 export function checkArrangeWordsAnswer(

--- a/packages/player/src/check-step.test.ts
+++ b/packages/player/src/check-step.test.ts
@@ -399,6 +399,60 @@ describe(checkStep, () => {
     });
   });
 
+  describe("story", () => {
+    const step = buildStep({
+      content: {
+        choices: [
+          {
+            alignment: "strong",
+            consequence: "Things improve.",
+            id: "1a",
+            metricChanges: { production: 10 },
+            text: "Do the right thing",
+          },
+          {
+            alignment: "weak",
+            consequence: "Things get worse.",
+            id: "1b",
+            metricChanges: { production: -10 },
+            text: "Do the wrong thing",
+          },
+        ],
+        situation: "You face a decision.",
+      },
+      id: "story-1",
+      kind: "story",
+    });
+
+    test("strong alignment returns isCorrect true", () => {
+      const answer: SelectedAnswer = {
+        kind: "story",
+        selectedChoiceId: "1a",
+        selectedText: "Do the right thing",
+      };
+
+      const { result } = checkStep(step, answer);
+      expect(result.isCorrect).toBe(true);
+    });
+
+    test("weak alignment returns isCorrect false", () => {
+      const answer: SelectedAnswer = {
+        kind: "story",
+        selectedChoiceId: "1b",
+        selectedText: "Do the wrong thing",
+      };
+
+      const { result } = checkStep(step, answer);
+      expect(result.isCorrect).toBe(false);
+    });
+
+    test("returns mismatch for wrong answer kind", () => {
+      const answer: SelectedAnswer = { kind: "multipleChoice", selectedIndex: 0, selectedText: "" };
+      const { result } = checkStep(step, answer);
+      expect(result.isCorrect).toBe(false);
+    });
+  });
+
   describe("mismatched kinds", () => {
     test("multipleChoice step with fillBlank answer returns safe fallback", () => {
       const step = buildStep({

--- a/packages/player/src/check-step.ts
+++ b/packages/player/src/check-step.ts
@@ -9,6 +9,7 @@ import {
   checkMultipleChoiceAnswer,
   checkSelectImageAnswer,
   checkSortOrderAnswer,
+  checkStoryAnswer,
   checkTranslationAnswer,
 } from "./check-answer";
 import { type SelectedAnswer } from "./player-reducer";
@@ -129,6 +130,16 @@ function checkListeningStep(step: SerializedStep, answer: SelectedAnswer): Check
   };
 }
 
+function checkStory(step: SerializedStep, answer: SelectedAnswer): CheckStepResult {
+  if (answer.kind !== "story") {
+    return MISMATCH_RESULT;
+  }
+
+  const content = parseStepContent("story", step.content);
+
+  return { result: checkStoryAnswer(content, answer.selectedChoiceId) };
+}
+
 export function checkStep(step: SerializedStep, answer: SelectedAnswer): CheckStepResult {
   switch (step.kind) {
     case "multipleChoice":
@@ -154,6 +165,9 @@ export function checkStep(step: SerializedStep, answer: SelectedAnswer): CheckSt
 
     case "listening":
       return checkListeningStep(step, answer);
+
+    case "story":
+      return checkStory(step, answer);
 
     case "static":
     case "visual":

--- a/packages/player/src/completion-input-schema.ts
+++ b/packages/player/src/completion-input-schema.ts
@@ -41,6 +41,12 @@ const sortOrderAnswerSchema = z.object({
   userOrder: z.array(z.string()),
 });
 
+const storyAnswerSchema = z.object({
+  kind: z.literal("story"),
+  selectedChoiceId: z.string(),
+  selectedText: z.string(),
+});
+
 const translationAnswerSchema = z.object({
   kind: z.literal("translation"),
   questionText: z.string(),
@@ -56,6 +62,7 @@ const selectedAnswerSchema = z.discriminatedUnion("kind", [
   readingAnswerSchema,
   selectImageAnswerSchema,
   sortOrderAnswerSchema,
+  storyAnswerSchema,
   translationAnswerSchema,
 ]);
 

--- a/packages/player/src/components/static-step.tsx
+++ b/packages/player/src/components/static-step.tsx
@@ -69,6 +69,10 @@ function StaticStepContent({ step }: { step: SerializedStep }) {
     return <GrammarRuleVariant ruleName={content.ruleName} ruleSummary={content.ruleSummary} />;
   }
 
+  if (content.variant === "storyIntro" || content.variant === "storyDebrief") {
+    return null;
+  }
+
   return <TextVariant text={content.text} title={content.title} />;
 }
 

--- a/packages/player/src/compute-score.test.ts
+++ b/packages/player/src/compute-score.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { computeScore } from "./compute-score";
+import { computeScore, computeStoryScore } from "./compute-score";
 
 describe(computeScore, () => {
   test("all correct (5): BP=10, energyDelta=1.0", () => {
@@ -66,6 +66,71 @@ describe(computeScore, () => {
       brainPower: 10,
       correctCount: 0,
       energyDelta: 0.1,
+      incorrectCount: 0,
+    });
+  });
+});
+
+describe(computeStoryScore, () => {
+  test("all strong: BP=100, energy=15, 5 correct", () => {
+    const result = computeStoryScore({
+      alignments: ["strong", "strong", "strong", "strong", "strong"],
+    });
+
+    expect(result).toEqual({
+      brainPower: 100,
+      correctCount: 5,
+      energyDelta: 15,
+      incorrectCount: 0,
+    });
+  });
+
+  test("all weak: BP=100, energy=0, 0 correct", () => {
+    const result = computeStoryScore({
+      alignments: ["weak", "weak", "weak", "weak", "weak"],
+    });
+
+    expect(result).toEqual({
+      brainPower: 100,
+      correctCount: 0,
+      energyDelta: 0,
+      incorrectCount: 5,
+    });
+  });
+
+  test("all partial: BP=100, energy=5, 5 correct", () => {
+    const result = computeStoryScore({
+      alignments: ["partial", "partial", "partial", "partial", "partial"],
+    });
+
+    expect(result).toEqual({
+      brainPower: 100,
+      correctCount: 5,
+      energyDelta: 5,
+      incorrectCount: 0,
+    });
+  });
+
+  test("mixed alignments: energy sums per choice", () => {
+    const result = computeStoryScore({
+      alignments: ["strong", "weak", "partial", "strong", "weak"],
+    });
+
+    expect(result).toEqual({
+      brainPower: 100,
+      correctCount: 3,
+      energyDelta: 7,
+      incorrectCount: 2,
+    });
+  });
+
+  test("empty alignments: BP=100, energy=0", () => {
+    const result = computeStoryScore({ alignments: [] });
+
+    expect(result).toEqual({
+      brainPower: 100,
+      correctCount: 0,
+      energyDelta: 0,
       incorrectCount: 0,
     });
   });

--- a/packages/player/src/compute-score.ts
+++ b/packages/player/src/compute-score.ts
@@ -1,4 +1,5 @@
-import { BRAIN_POWER_PER_ACTIVITY } from "@zoonk/utils/brain-power";
+import { type StoryAlignment } from "@zoonk/core/steps/content-contract";
+import { BRAIN_POWER_PER_ACTIVITY, STORY_BRAIN_POWER } from "@zoonk/utils/brain-power";
 import { ENERGY_PER_CORRECT, ENERGY_PER_INCORRECT, ENERGY_PER_STATIC } from "@zoonk/utils/energy";
 
 type ActivityScoreInput = {
@@ -20,6 +21,35 @@ function calculateEnergyDelta(results: ActivityScoreInput["results"]): number {
   const correctCount = results.filter((result) => result.isCorrect).length;
   const incorrectCount = results.length - correctCount;
   return correctCount * ENERGY_PER_CORRECT + incorrectCount * ENERGY_PER_INCORRECT;
+}
+
+const STORY_ENERGY_BY_ALIGNMENT: Record<StoryAlignment, number> = {
+  partial: 1,
+  strong: 3,
+  weak: 0,
+};
+
+/**
+ * Compute score for a story activity based on choice alignments.
+ *
+ * Stories earn 100 BP on completion (vs 10 for standard activities).
+ * Energy is alignment-based: strong (+3), partial (+1), weak (0).
+ * Strong/partial count as correct; weak counts as incorrect for analytics.
+ */
+export function computeStoryScore({ alignments }: { alignments: StoryAlignment[] }): ScoreResult {
+  const energyDelta = alignments.reduce(
+    (sum, alignment) => sum + STORY_ENERGY_BY_ALIGNMENT[alignment],
+    0,
+  );
+
+  const correctCount = alignments.filter((alignment) => alignment !== "weak").length;
+
+  return {
+    brainPower: STORY_BRAIN_POWER,
+    correctCount,
+    energyDelta,
+    incorrectCount: alignments.length - correctCount,
+  };
 }
 
 export function computeScore(input: ActivityScoreInput): ScoreResult {

--- a/packages/player/src/player-completion.test.ts
+++ b/packages/player/src/player-completion.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "vitest";
+import { computeLocalCompletion } from "./player-completion";
+import { type PlayerState, type StepResult } from "./player-reducer";
+import { type SerializedStep } from "./prepare-activity-data";
+
+function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
+  return {
+    content: { text: "Hello", title: "Intro", variant: "text" as const },
+    fillBlankOptions: [],
+    id: "step-1",
+    kind: "static",
+    matchColumnsRightItems: [],
+    position: 0,
+    sentence: null,
+    sentenceWordOptions: [],
+    sortOrderItems: [],
+    translationOptions: [],
+    vocabularyOptions: [],
+    word: null,
+    wordBankOptions: [],
+    ...overrides,
+  };
+}
+
+function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
+  return {
+    activityId: "activity-1",
+    completion: null,
+    currentStepIndex: 0,
+    phase: "completed",
+    results: {},
+    selectedAnswers: {},
+    startedAt: 1000,
+    stepStartedAt: 1000,
+    stepTimings: {},
+    steps: [buildStep()],
+    totalBrainPower: 0,
+    ...overrides,
+  };
+}
+
+const storyStepContent = {
+  choices: [
+    {
+      alignment: "strong" as const,
+      consequence: "Things improve.",
+      id: "1a",
+      metricChanges: { production: 10 },
+      text: "Strong choice",
+    },
+    {
+      alignment: "partial" as const,
+      consequence: "Mixed results.",
+      id: "1b",
+      metricChanges: { production: 5 },
+      text: "Partial choice",
+    },
+    {
+      alignment: "weak" as const,
+      consequence: "Things get worse.",
+      id: "1c",
+      metricChanges: { production: -10 },
+      text: "Weak choice",
+    },
+  ],
+  situation: "You face a decision.",
+};
+
+function buildStoryStep(id: string, position: number): SerializedStep {
+  return buildStep({ content: storyStepContent, id, kind: "story", position });
+}
+
+function buildStoryResult(stepId: string, selectedChoiceId: string): StepResult {
+  return {
+    answer: { kind: "story", selectedChoiceId, selectedText: "choice" },
+    result: { correctAnswer: null, feedback: null, isCorrect: selectedChoiceId !== "1c" },
+    stepId,
+  };
+}
+
+describe(computeLocalCompletion, () => {
+  describe("standard activities", () => {
+    test("uses standard scoring for non-story steps", () => {
+      const steps = [
+        buildStep({
+          content: {
+            kind: "core" as const,
+            options: [{ feedback: "Yes", isCorrect: true, text: "A" }],
+          },
+          id: "mc-1",
+          kind: "multipleChoice",
+        }),
+      ];
+
+      const results: Record<string, StepResult> = {
+        "mc-1": {
+          answer: { kind: "multipleChoice", selectedIndex: 0, selectedText: "A" },
+          result: { correctAnswer: null, feedback: "Yes", isCorrect: true },
+          stepId: "mc-1",
+        },
+      };
+
+      const completion = computeLocalCompletion(buildState({ results, steps }));
+      expect(completion.brainPower).toBe(10);
+    });
+  });
+
+  describe("story activities", () => {
+    test("uses story scoring with 100 BP", () => {
+      const steps = [buildStoryStep("s1", 0), buildStoryStep("s2", 1)];
+      const results: Record<string, StepResult> = {
+        s1: buildStoryResult("s1", "1a"),
+        s2: buildStoryResult("s2", "1a"),
+      };
+
+      const completion = computeLocalCompletion(buildState({ results, steps }));
+      expect(completion.brainPower).toBe(100);
+    });
+
+    test("computes energy from alignments: all strong = 6 for 2 steps", () => {
+      const steps = [buildStoryStep("s1", 0), buildStoryStep("s2", 1)];
+      const results: Record<string, StepResult> = {
+        s1: buildStoryResult("s1", "1a"),
+        s2: buildStoryResult("s2", "1a"),
+      };
+
+      const completion = computeLocalCompletion(buildState({ results, steps }));
+      expect(completion.energyDelta).toBe(6);
+    });
+
+    test("computes energy from mixed alignments", () => {
+      const steps = [buildStoryStep("s1", 0), buildStoryStep("s2", 1), buildStoryStep("s3", 2)];
+      const results: Record<string, StepResult> = {
+        s1: buildStoryResult("s1", "1a"), // strong = 3
+        s2: buildStoryResult("s2", "1b"), // partial = 1
+        s3: buildStoryResult("s3", "1c"), // weak = 0
+      };
+
+      const completion = computeLocalCompletion(buildState({ results, steps }));
+      expect(completion.energyDelta).toBe(4);
+    });
+
+    test("skips steps without results", () => {
+      const steps = [buildStoryStep("s1", 0), buildStoryStep("s2", 1)];
+      const results: Record<string, StepResult> = {
+        s1: buildStoryResult("s1", "1a"), // strong = 3
+      };
+
+      const completion = computeLocalCompletion(buildState({ results, steps }));
+      expect(completion.energyDelta).toBe(3);
+    });
+
+    test("adds story BP to existing totalBrainPower", () => {
+      const steps = [buildStoryStep("s1", 0)];
+      const results: Record<string, StepResult> = {
+        s1: buildStoryResult("s1", "1a"),
+      };
+
+      const completion = computeLocalCompletion(
+        buildState({ results, steps, totalBrainPower: 500 }),
+      );
+      expect(completion.newTotalBp).toBe(600);
+    });
+  });
+});

--- a/packages/player/src/player-completion.ts
+++ b/packages/player/src/player-completion.ts
@@ -1,7 +1,31 @@
+import { type StoryAlignment, parseStepContent } from "@zoonk/core/steps/content-contract";
 import { calculateBeltLevel } from "@zoonk/utils/belt-level";
 import { type CompletionResult } from "./completion-input-schema";
-import { computeScore } from "./compute-score";
+import { computeScore, computeStoryScore } from "./compute-score";
 import { type PlayerState } from "./player-reducer";
+
+/**
+ * Extract the alignment of each selected choice from story step results.
+ *
+ * Looks up each answer's selectedChoiceId in the step content to find
+ * the alignment tag. Used to compute story-specific scoring (energy by
+ * alignment instead of correct/incorrect counts).
+ */
+function getStoryAlignments(state: PlayerState): StoryAlignment[] {
+  return state.steps.flatMap((step) => {
+    const result = state.results[step.id];
+
+    if (!result?.answer || result.answer.kind !== "story") {
+      return [];
+    }
+
+    const { selectedChoiceId } = result.answer;
+    const content = parseStepContent("story", step.content);
+    const choice = content.choices.find((option) => option.id === selectedChoiceId);
+
+    return choice ? [choice.alignment] : [];
+  });
+}
 
 /**
  * Computes the completion result from local player state.
@@ -12,11 +36,15 @@ import { type PlayerState } from "./player-reducer";
  * in the background via `after()`.
  */
 export function computeLocalCompletion(state: PlayerState): CompletionResult {
-  const score = computeScore({
-    results: Object.values(state.results).map((stepResult) => ({
-      isCorrect: stepResult.result.isCorrect,
-    })),
-  });
+  const isStory = state.steps[0]?.kind === "story";
+
+  const score = isStory
+    ? computeStoryScore({ alignments: getStoryAlignments(state) })
+    : computeScore({
+        results: Object.values(state.results).map((stepResult) => ({
+          isCorrect: stepResult.result.isCorrect,
+        })),
+      });
 
   const newTotalBp = state.totalBrainPower + score.brainPower;
 

--- a/packages/player/src/player-reducer.test.ts
+++ b/packages/player/src/player-reducer.test.ts
@@ -257,6 +257,44 @@ describe("CHECK_ANSWER", () => {
     });
   });
 
+  test("story step enters feedback phase instead of auto-continuing", () => {
+    const storyContent = {
+      choices: [
+        {
+          alignment: "strong" as const,
+          consequence: "Things improve.",
+          id: "1a",
+          metricChanges: { production: 10 },
+          text: "Do the right thing",
+        },
+        {
+          alignment: "weak" as const,
+          consequence: "Things get worse.",
+          id: "1b",
+          metricChanges: { production: -10 },
+          text: "Do the wrong thing",
+        },
+      ],
+      situation: "You face a decision.",
+    };
+
+    const steps = [
+      buildStep({ content: storyContent, id: "story-1", kind: "story", position: 0 }),
+      buildStep({ content: storyContent, id: "story-2", kind: "story", position: 1 }),
+    ];
+
+    const state = buildState({ steps });
+
+    const next = playerReducer(state, {
+      result: { correctAnswer: null, feedback: null, isCorrect: true },
+      stepId: "story-1",
+      type: "CHECK_ANSWER",
+    });
+
+    expect(next.phase).toBe("feedback");
+    expect(next.currentStepIndex).toBe(0);
+  });
+
   test("no-ops in feedback phase", () => {
     const state = buildState({ phase: "feedback" });
     const next = playerReducer(state, {

--- a/packages/player/src/player-reducer.ts
+++ b/packages/player/src/player-reducer.ts
@@ -15,6 +15,7 @@ export type SelectedAnswer =
   | { kind: "reading"; arrangedWords: string[] }
   | { kind: "selectImage"; selectedIndex: number }
   | { kind: "sortOrder"; userOrder: string[] }
+  | { kind: "story"; selectedChoiceId: string; selectedText: string }
   | { kind: "translation"; selectedWordId: string; selectedText: string; questionText: string };
 
 export type StepResult = {

--- a/packages/player/src/validate-answers.test.ts
+++ b/packages/player/src/validate-answers.test.ts
@@ -231,6 +231,98 @@ describe(validateAnswers, () => {
     expect(results[0]?.isCorrect).toBe(true);
   });
 
+  test("validates story strong choice as correct", () => {
+    const storyContent = {
+      choices: [
+        {
+          alignment: "strong",
+          consequence: "Things improve.",
+          id: "1a",
+          metricChanges: { production: 10 },
+          text: "Do the right thing",
+        },
+        {
+          alignment: "weak",
+          consequence: "Things get worse.",
+          id: "1b",
+          metricChanges: { production: -10 },
+          text: "Do the wrong thing",
+        },
+      ],
+      situation: "You face a decision.",
+    };
+
+    const steps = [{ content: storyContent, id: 8n, kind: "story" }];
+
+    const results = validateAnswers(steps, {
+      "8": { kind: "story", selectedChoiceId: "1a", selectedText: "Do the right thing" },
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.isCorrect).toBe(true);
+  });
+
+  test("validates story weak choice as incorrect", () => {
+    const storyContent = {
+      choices: [
+        {
+          alignment: "strong",
+          consequence: "Things improve.",
+          id: "1a",
+          metricChanges: { production: 10 },
+          text: "Do the right thing",
+        },
+        {
+          alignment: "weak",
+          consequence: "Things get worse.",
+          id: "1b",
+          metricChanges: { production: -10 },
+          text: "Do the wrong thing",
+        },
+      ],
+      situation: "You face a decision.",
+    };
+
+    const steps = [{ content: storyContent, id: 8n, kind: "story" }];
+
+    const results = validateAnswers(steps, {
+      "8": { kind: "story", selectedChoiceId: "1b", selectedText: "Do the wrong thing" },
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.isCorrect).toBe(false);
+  });
+
+  test("story validator returns empty for wrong answer kind", () => {
+    const storyContent = {
+      choices: [
+        {
+          alignment: "strong",
+          consequence: "Things improve.",
+          id: "1a",
+          metricChanges: { production: 10 },
+          text: "Do the right thing",
+        },
+        {
+          alignment: "weak",
+          consequence: "Things get worse.",
+          id: "1b",
+          metricChanges: { production: -10 },
+          text: "Do the wrong thing",
+        },
+      ],
+      situation: "You face a decision.",
+    };
+
+    const steps = [{ content: storyContent, id: 9n, kind: "story" }];
+
+    const results = validateAnswers(steps, {
+      "9": { kind: "multipleChoice", selectedIndex: 0, selectedText: "Option A" },
+    });
+
+    expect(results).toHaveLength(0);
+  });
+
   test("skips unsupported step kinds", () => {
     const steps = [{ content: {}, id: 7n, kind: "unknownKind" }];
 

--- a/packages/player/src/validate-answers.ts
+++ b/packages/player/src/validate-answers.ts
@@ -11,6 +11,7 @@ import {
   checkMultipleChoiceAnswer,
   checkSelectImageAnswer,
   checkSortOrderAnswer,
+  checkStoryAnswer,
   checkTranslationAnswer,
 } from "./check-answer";
 
@@ -22,6 +23,7 @@ type SelectedAnswer =
   | { kind: "reading"; arrangedWords: string[] }
   | { kind: "selectImage"; selectedIndex: number }
   | { kind: "sortOrder"; userOrder: string[] }
+  | { kind: "story"; selectedChoiceId: string; selectedText: string }
   | { kind: "translation"; selectedWordId: string; selectedText: string; questionText: string };
 
 /**
@@ -149,6 +151,17 @@ function validateListening(step: StepData, answer: SelectedAnswer): ValidatedSte
   return { answer, isCorrect: result.isCorrect, stepId: step.id };
 }
 
+function validateStory(step: StepData, answer: SelectedAnswer): ValidatedStepResult | null {
+  if (answer.kind !== "story") {
+    return null;
+  }
+
+  const content = parseStepContent("story", step.content);
+  const result = checkStoryAnswer(content, answer.selectedChoiceId);
+
+  return { answer, isCorrect: result.isCorrect, stepId: step.id };
+}
+
 const validators: Record<
   SupportedStepKind,
   (step: StepData, answer: SelectedAnswer) => ValidatedStepResult | null
@@ -161,6 +174,7 @@ const validators: Record<
   selectImage: validateSelectImage,
   sortOrder: validateSortOrder,
   static: () => null,
+  story: validateStory,
   translation: validateTranslation,
   visual: () => null,
   vocabulary: () => null,

--- a/packages/utils/src/brain-power.ts
+++ b/packages/utils/src/brain-power.ts
@@ -1,1 +1,2 @@
 export const BRAIN_POWER_PER_ACTIVITY = 10;
+export const STORY_BRAIN_POWER = 100;


### PR DESCRIPTION
## Summary

- Add `story` to `ActivityKind` and `StepKind` Prisma enums with migration
- Add story content schema (situation, choices with alignment/consequence/metricChanges, plus optional intro/metrics on first step and outcomes/debrief on last step)
- Add story answer type to `SelectedAnswer` union and completion input schema
- Add `checkStoryAnswer` — strong/partial = correct, weak = incorrect; consequence text returned as feedback
- Add story case to `checkStep`, `validateAnswers`, and `computeStoryScore` (100 BP; energy: strong +3, partial +1, weak 0)
- Add `StoryAlignment` type derived from schema, used across player package
- Add placeholder entries in `Record<ActivityKind>` maps to keep builds green
- Tests for all new logic (content contract, check-answer, check-step, validate-answers, player-reducer, compute-score)

Closes #1169

## Test plan

- [x] `pnpm test` — all 409 tests pass
- [x] `pnpm typecheck` — all packages pass (main app has pre-existing debug page issue)
- [x] `pnpm lint:fix` — clean
- [x] `pnpm --filter main build` / `editor build` / `api build` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `story` activity with consequence-driven choices, player feedback, and story-specific scoring (100 BP + energy by alignment). Also refactors story intro and debrief into dedicated `static` variants for a cleaner schema.

- **New Features**
  - DB: added `story` to `ActivityKind`/`StepKind` via Prisma migration.
  - Core: `story` decision schema (`situation`, `choices` with `alignment`/`metricChanges`); exports `StoryStepContent` and `StoryAlignment`.
  - Player: `checkStoryAnswer` (strong/partial = correct; weak = incorrect) wired into `checkStep`/`validateAnswers`; story steps enter a feedback phase.
  - Scoring: `computeStoryScore` with `STORY_BRAIN_POWER = 100`; integrated into `computeLocalCompletion`.
  - UI: SEO copy and `BookOpenIcon` for `story`; basic generation phase config added.
  - Tests: coverage for schema validation, answer checking, step validation, reducer behavior, scoring, and completion.

- **Refactors**
  - Moved story-wide `intro`/`metrics` and `outcomes`/`debrief` into `static` step variants (`storyIntro`, `storyDebrief`); story steps now only define `situation` and `choices`. Updated validation and the `StaticStep` renderer to handle these variants.

<sup>Written for commit bb1317104dd98cc93a7a3c5cdb4a5881ca1422b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

