### PR TITLE
refactor(player): type activity kind instead of using plain string

### DIFF
--- a/packages/core/src/steps/content-contract.ts
+++ b/packages/core/src/steps/content-contract.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import { type VisualStepContent, visualStepContentSchema } from "./visual-content-contract";
 
+export type { ActivityKind } from "@zoonk/db";
+
 const coreOptionSchema = z
   .object({
     feedback: z.string(),

--- a/packages/player/src/player-reducer.test.ts
+++ b/packages/player/src/player-reducer.test.ts
@@ -43,7 +43,7 @@ function buildActivity(overrides: Partial<SerializedActivity> = {}): SerializedA
   return {
     description: null,
     id: "activity-1",
-    kind: "core",
+    kind: "quiz",
     language: "en",
     lessonSentences: [],
     lessonWords: [],

--- a/packages/player/src/prepare-activity-data.test.ts
+++ b/packages/player/src/prepare-activity-data.test.ts
@@ -120,7 +120,7 @@ function makeActivity(steps: RawStep[], overrides: Partial<ActivityInput> = {}):
   return {
     description: null,
     id: 1n,
-    kind: "lesson",
+    kind: "quiz",
     language: "en",
     organizationId: 1,
     steps,

--- a/packages/player/src/prepare-activity-data.ts
+++ b/packages/player/src/prepare-activity-data.ts
@@ -1,4 +1,5 @@
 import {
+  type ActivityKind,
   type MultipleChoiceStepContent,
   type StepContentByKind,
   type SupportedStepKind,
@@ -77,7 +78,7 @@ export type SerializedStep<Kind extends SupportedStepKind = SupportedStepKind> =
 
 export type SerializedActivity = {
   id: string;
-  kind: string;
+  kind: ActivityKind;
   title: string | null;
   description: string | null;
   language: string;
@@ -90,7 +91,7 @@ export type SerializedActivity = {
 type PrepareLessonActivitySource = {
   description: string | null;
   id: bigint;
-  kind: string;
+  kind: ActivityKind;
   language: string;
   organizationId: number | null;
   steps: ActivityStepInput[];
@@ -225,7 +226,7 @@ function serializeStep(step: StepDataInput): SerializedStep | null {
 function prepareActivityData(
   activity: {
     id: bigint;
-    kind: string;
+    kind: ActivityKind;
     title: string | null;
     description: string | null;
     language: string;

--- a/packages/player/src/validate-answers.ts
+++ b/packages/player/src/validate-answers.ts
@@ -14,17 +14,7 @@ import {
   checkStoryAnswer,
   checkTranslationAnswer,
 } from "./check-answer";
-
-type SelectedAnswer =
-  | { kind: "fillBlank"; userAnswers: string[] }
-  | { kind: "listening"; arrangedWords: string[] }
-  | { kind: "matchColumns"; userPairs: { left: string; right: string }[]; mistakes: number }
-  | { kind: "multipleChoice"; selectedIndex: number; selectedText: string }
-  | { kind: "reading"; arrangedWords: string[] }
-  | { kind: "selectImage"; selectedIndex: number }
-  | { kind: "sortOrder"; userOrder: string[] }
-  | { kind: "story"; selectedChoiceId: string; selectedText: string }
-  | { kind: "translation"; selectedWordId: string; selectedText: string; questionText: string };
+import { type SelectedAnswer } from "./player-reducer";
 
 /**
  * Step data for server-side validation. Translations live directly


### PR DESCRIPTION
## Summary

- Export `ActivityKind` from `@zoonk/core` so the player package gets type safety without depending on `@zoonk/db`
- Narrow `SerializedActivity.kind` and related types from `string` to `ActivityKind`
- Remove duplicate `SelectedAnswer` type from `validate-answers.ts` (import from `player-reducer.ts` instead)
- Fix invalid activity kind values in tests (`"core"` and `"lesson"` replaced with `"quiz"`)

## Test plan

- [x] `pnpm --filter @zoonk/player typecheck` passes
- [x] `pnpm --filter @zoonk/core typecheck` passes
- [x] `pnpm --filter @zoonk/player test` — all 268 tests pass
- [x] `pnpm lint:fix` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed activity kind across the player by replacing plain strings with `ActivityKind` to improve type safety. `@zoonk/player` now uses `ActivityKind` re-exported from `@zoonk/core` without depending on `@zoonk/db`.

- **Refactors**
  - Exported `ActivityKind` from `@zoonk/core` (re-export from `@zoonk/db`).
  - Narrowed `SerializedActivity.kind` and related inputs to `ActivityKind`.
  - Removed duplicate `SelectedAnswer` in `validate-answers.ts` (import from `player-reducer.ts`).
  - Fixed tests to use valid kinds (`"quiz"` instead of `"core"`/`"lesson"`).

<sup>Written for commit 23e627eb9a69caf86ad4170ac8333f79eca090ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

