### PR TITLE
feat(api): add story generation workflow and applied activity classifier

### DIFF
--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
@@ -2,6 +2,8 @@ import { randomUUID } from "node:crypto";
 import { generateActivityExplanation } from "@zoonk/ai/tasks/activities/core/explanation";
 import { generateActivityPractice } from "@zoonk/ai/tasks/activities/core/practice";
 import { generateActivityQuiz } from "@zoonk/ai/tasks/activities/core/quiz";
+import { generateActivityStoryDebrief } from "@zoonk/ai/tasks/activities/core/story-debrief";
+import { generateActivityStorySteps } from "@zoonk/ai/tasks/activities/core/story-steps";
 import { generateStepVisuals } from "@zoonk/ai/tasks/steps/visual";
 import { generateVisualStepImage } from "@zoonk/core/steps/visual-image";
 import { prisma } from "@zoonk/db";
@@ -123,6 +125,48 @@ vi.mock("@zoonk/ai/tasks/activities/core/quiz", () => ({
           ],
           question: "Which image shows a cat?",
         },
+      ],
+    },
+  }),
+}));
+
+vi.mock("@zoonk/ai/tasks/activities/core/story-steps", () => ({
+  generateActivityStorySteps: vi.fn().mockResolvedValue({
+    data: {
+      intro: "You are a factory manager.",
+      metrics: ["Production", "Morale"],
+      steps: [
+        {
+          choices: [
+            {
+              alignment: "strong",
+              consequence: "Workers rally.",
+              id: "c1",
+              metricEffects: [{ effect: "positive", metric: "Morale" }],
+              text: "Address the team",
+            },
+            {
+              alignment: "weak",
+              consequence: "Rumors spread.",
+              id: "c2",
+              metricEffects: [{ effect: "negative", metric: "Morale" }],
+              text: "Send an email",
+            },
+          ],
+          situation: "Your supplier went bankrupt.",
+        },
+      ],
+    },
+  }),
+}));
+
+vi.mock("@zoonk/ai/tasks/activities/core/story-debrief", () => ({
+  generateActivityStoryDebrief: vi.fn().mockResolvedValue({
+    data: {
+      debrief: [{ explanation: "Communication matters.", name: "Crisis Communication" }],
+      outcomes: [
+        { minStrongChoices: 1, narrative: "Well done.", title: "Great" },
+        { minStrongChoices: 0, narrative: "Needs work.", title: "Okay" },
       ],
     },
   }),
@@ -796,6 +840,93 @@ describe("core activity workflow", () => {
         where: { id: practiceActivity.id },
       });
       expect(dbPractice?.generationStatus).toBe("completed");
+    });
+  });
+
+  describe("story isolation", () => {
+    test("story failure does not affect explanation or practice completion", async () => {
+      vi.mocked(generateActivityStorySteps).mockRejectedValueOnce(new Error("Story failed"));
+
+      const testLesson = await lessonFixture({
+        chapterId: chapter.id,
+        concepts: ["Test Concept"],
+        organizationId,
+        title: `Story Isolation Lesson ${randomUUID()}`,
+      });
+
+      const [expActivity, practiceActivity, storyActivity] = await Promise.all([
+        activityFixture({
+          generationStatus: "pending",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          title: `Explanation ${randomUUID()}`,
+        }),
+        activityFixture({
+          generationStatus: "pending",
+          kind: "practice",
+          lessonId: testLesson.id,
+          organizationId,
+          title: `Practice ${randomUUID()}`,
+        }),
+        activityFixture({
+          generationStatus: "pending",
+          kind: "story",
+          lessonId: testLesson.id,
+          organizationId,
+          title: `Story ${randomUUID()}`,
+        }),
+      ]);
+
+      await activityGenerationWorkflow(testLesson.id);
+
+      const [dbExp, dbPractice, dbStory] = await Promise.all([
+        prisma.activity.findUnique({ where: { id: expActivity.id } }),
+        prisma.activity.findUnique({ where: { id: practiceActivity.id } }),
+        prisma.activity.findUnique({ where: { id: storyActivity.id } }),
+      ]);
+
+      expect(dbExp?.generationStatus).toBe("completed");
+      expect(dbPractice?.generationStatus).toBe("completed");
+      expect(dbStory?.generationStatus).toBe("failed");
+    });
+
+    test("generates story alongside explanation in wave 1", async () => {
+      const testLesson = await lessonFixture({
+        chapterId: chapter.id,
+        concepts: ["Test Concept"],
+        organizationId,
+        title: `Story Wave 1 Lesson ${randomUUID()}`,
+      });
+
+      const [expActivity, storyActivity] = await Promise.all([
+        activityFixture({
+          generationStatus: "pending",
+          kind: "explanation",
+          lessonId: testLesson.id,
+          organizationId,
+          title: `Explanation ${randomUUID()}`,
+        }),
+        activityFixture({
+          generationStatus: "pending",
+          kind: "story",
+          lessonId: testLesson.id,
+          organizationId,
+          title: `Story ${randomUUID()}`,
+        }),
+      ]);
+
+      await activityGenerationWorkflow(testLesson.id);
+
+      const [dbExp, dbStory] = await Promise.all([
+        prisma.activity.findUnique({ where: { id: expActivity.id } }),
+        prisma.activity.findUnique({ where: { id: storyActivity.id } }),
+      ]);
+
+      expect(dbExp?.generationStatus).toBe("completed");
+      expect(dbStory?.generationStatus).toBe("completed");
+      expect(generateActivityStorySteps).toHaveBeenCalled();
+      expect(generateActivityStoryDebrief).toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.ts
@@ -2,12 +2,18 @@ import { settled } from "@zoonk/utils/settled";
 import { explanationActivityWorkflow } from "./kinds/explanation-workflow";
 import { practiceActivityWorkflow } from "./kinds/practice-workflow";
 import { quizActivityWorkflow } from "./kinds/quiz-workflow";
+import { storyActivityWorkflow } from "./kinds/story-workflow";
 import { findActivitiesByKind } from "./steps/_utils/find-activity-by-kind";
 import { type LessonActivity } from "./steps/get-lesson-activities-step";
 import { getNeighboringConceptsStep } from "./steps/get-neighboring-concepts-step";
 
 /**
- * Orchestrates core activity generation (explanation, practice, quiz).
+ * Orchestrates core activity generation (explanation, practice, quiz, story).
+ *
+ * Wave 1 (parallel): explanation + story — story uses lesson concepts directly
+ * and is independent of explanation results.
+ * Wave 2 (parallel): practice + quiz — both depend on explanation results.
+ *
  * Receives both the full activity list and the subset that needs generation.
  * Generate steps only receive activities that need generation.
  * Completed activities are used to fetch existing data for downstream dependencies.
@@ -31,6 +37,10 @@ export async function coreActivityWorkflow({
       allActivities,
       concepts,
       neighboringConcepts,
+      workflowRunId,
+    }),
+    storyActivityWorkflow({
+      activitiesToGenerate,
       workflowRunId,
     }),
   ]);

--- a/apps/api/src/workflows/activity-generation/kinds/story-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/story-workflow.test.ts
@@ -1,0 +1,298 @@
+import { randomUUID } from "node:crypto";
+import { generateActivityStoryDebrief } from "@zoonk/ai/tasks/activities/core/story-debrief";
+import { generateActivityStorySteps } from "@zoonk/ai/tasks/activities/core/story-steps";
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { getString } from "@zoonk/utils/json";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { getLessonActivitiesStep } from "../steps/get-lesson-activities-step";
+import { storyActivityWorkflow } from "./story-workflow";
+
+vi.mock("workflow", () => ({
+  FatalError: class FatalError extends Error {},
+  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
+  getWritable: vi.fn().mockReturnValue({
+    getWriter: () => ({
+      releaseLock: vi.fn(),
+      write: vi.fn().mockResolvedValue(null),
+    }),
+  }),
+  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
+}));
+
+const { mockStorySteps, mockDebriefData } = vi.hoisted(() => ({
+  mockDebriefData: {
+    debrief: [
+      {
+        explanation: "Direct communication builds trust during crises.",
+        name: "Crisis Communication",
+      },
+      {
+        explanation: "Constraints can drive innovation when embraced.",
+        name: "Supply Chain Resilience",
+      },
+    ],
+    outcomes: [
+      { minStrongChoices: 2, narrative: "You turned crisis into opportunity.", title: "Excellent" },
+      { minStrongChoices: 1, narrative: "You navigated the crisis reasonably.", title: "Good" },
+      { minStrongChoices: 0, narrative: "The crisis overwhelmed you.", title: "Needs work" },
+    ],
+  },
+  mockStorySteps: {
+    intro: "You are a factory manager facing a supply chain crisis.",
+    metrics: ["Production", "Morale", "Cash"],
+    steps: [
+      {
+        choices: [
+          {
+            alignment: "strong",
+            consequence: "Workers rally behind you.",
+            id: "c1a",
+            metricEffects: [{ effect: "positive", metric: "Morale" }],
+            text: "Address the team directly",
+          },
+          {
+            alignment: "weak",
+            consequence: "Rumors spread unchecked.",
+            id: "c1b",
+            metricEffects: [{ effect: "negative", metric: "Morale" }],
+            text: "Send an email instead",
+          },
+        ],
+        situation: "Your main supplier just went bankrupt.",
+      },
+      {
+        choices: [
+          {
+            alignment: "partial",
+            consequence: "You find a reasonable alternative.",
+            id: "c2a",
+            metricEffects: [{ effect: "positive", metric: "Production" }],
+            text: "Contact backup suppliers",
+          },
+          {
+            alignment: "strong",
+            consequence: "Innovation emerges from constraint.",
+            id: "c2b",
+            metricEffects: [
+              { effect: "positive", metric: "Production" },
+              { effect: "positive", metric: "Cash" },
+            ],
+            text: "Redesign the product to use different materials",
+          },
+        ],
+        situation: "Production is halted without parts.",
+      },
+    ],
+  },
+}));
+
+vi.mock("@zoonk/ai/tasks/activities/core/story-steps", () => ({
+  generateActivityStorySteps: vi.fn().mockResolvedValue({ data: mockStorySteps }),
+}));
+
+vi.mock("@zoonk/ai/tasks/activities/core/story-debrief", () => ({
+  generateActivityStoryDebrief: vi.fn().mockResolvedValue({ data: mockDebriefData }),
+}));
+
+describe("story activity workflow", () => {
+  let organizationId: number;
+  let course: Awaited<ReturnType<typeof courseFixture>>;
+  let chapter: Awaited<ReturnType<typeof chapterFixture>>;
+
+  beforeAll(async () => {
+    const org = await aiOrganizationFixture();
+    organizationId = org.id;
+    course = await courseFixture({ organizationId });
+    chapter = await chapterFixture({
+      courseId: course.id,
+      organizationId,
+      title: `Story WF Chapter ${randomUUID()}`,
+    });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("creates story steps with intro, decisions, and debrief", async () => {
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      concepts: ["Supply Chain Management", "Crisis Communication"],
+      organizationId,
+      title: `Story Full Pipeline ${randomUUID()}`,
+    });
+
+    const storyActivity = await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Story ${randomUUID()}`,
+    });
+
+    const activities = await getLessonActivitiesStep(testLesson.id);
+
+    await storyActivityWorkflow({
+      activitiesToGenerate: activities,
+      workflowRunId: "test-run-id",
+    });
+
+    const steps = await prisma.step.findMany({
+      orderBy: { position: "asc" },
+      where: { activityId: storyActivity.id },
+    });
+
+    // 1 intro + 2 decision steps + 1 debrief = 4
+    expect(steps).toHaveLength(4);
+
+    // Intro step: static with storyIntro variant
+    expect(steps[0]?.kind).toBe("static");
+    expect(steps[0]?.position).toBe(0);
+    expect(getString(steps[0]?.content, "variant")).toBe("storyIntro");
+
+    // Decision steps: story kind
+    expect(steps[1]?.kind).toBe("story");
+    expect(steps[1]?.position).toBe(1);
+    expect(steps[2]?.kind).toBe("story");
+    expect(steps[2]?.position).toBe(2);
+
+    // Debrief step: static with storyDebrief variant
+    expect(steps[3]?.kind).toBe("static");
+    expect(steps[3]?.position).toBe(3);
+    expect(getString(steps[3]?.content, "variant")).toBe("storyDebrief");
+
+    for (const step of steps) {
+      expect(step.isPublished).toBe(true);
+    }
+  });
+
+  test("marks story as completed with generationRunId", async () => {
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      concepts: ["Test Concept"],
+      organizationId,
+      title: `Story Completed ${randomUUID()}`,
+    });
+
+    const storyActivity = await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Story ${randomUUID()}`,
+    });
+
+    const activities = await getLessonActivitiesStep(testLesson.id);
+
+    await storyActivityWorkflow({
+      activitiesToGenerate: activities,
+      workflowRunId: "test-run-id",
+    });
+
+    const dbActivity = await prisma.activity.findUnique({
+      where: { id: storyActivity.id },
+    });
+
+    expect(dbActivity?.generationStatus).toBe("completed");
+    expect(dbActivity?.generationRunId).toBe("test-run-id");
+  });
+
+  test("skips when no story activity exists", async () => {
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      concepts: ["Test Concept"],
+      organizationId,
+      title: `Story Skip ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "explanation",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Explanation ${randomUUID()}`,
+    });
+
+    const activities = await getLessonActivitiesStep(testLesson.id);
+
+    await storyActivityWorkflow({
+      activitiesToGenerate: activities,
+      workflowRunId: "test-run-id",
+    });
+
+    expect(generateActivityStorySteps).not.toHaveBeenCalled();
+    expect(generateActivityStoryDebrief).not.toHaveBeenCalled();
+  });
+
+  test("marks story as failed when content generation throws", async () => {
+    vi.mocked(generateActivityStorySteps).mockRejectedValueOnce(new Error("AI failed"));
+
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      concepts: ["Test Concept"],
+      organizationId,
+      title: `Story Content Fail ${randomUUID()}`,
+    });
+
+    const storyActivity = await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Story ${randomUUID()}`,
+    });
+
+    const activities = await getLessonActivitiesStep(testLesson.id);
+
+    await storyActivityWorkflow({
+      activitiesToGenerate: activities,
+      workflowRunId: "test-run-id",
+    });
+
+    const dbActivity = await prisma.activity.findUnique({
+      where: { id: storyActivity.id },
+    });
+
+    expect(dbActivity?.generationStatus).toBe("failed");
+    expect(generateActivityStoryDebrief).not.toHaveBeenCalled();
+  });
+
+  test("marks story as failed when debrief generation throws", async () => {
+    vi.mocked(generateActivityStoryDebrief).mockRejectedValueOnce(new Error("Debrief failed"));
+
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      concepts: ["Test Concept"],
+      organizationId,
+      title: `Story Debrief Fail ${randomUUID()}`,
+    });
+
+    const storyActivity = await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Story ${randomUUID()}`,
+    });
+
+    const activities = await getLessonActivitiesStep(testLesson.id);
+
+    await storyActivityWorkflow({
+      activitiesToGenerate: activities,
+      workflowRunId: "test-run-id",
+    });
+
+    const dbActivity = await prisma.activity.findUnique({
+      where: { id: storyActivity.id },
+    });
+
+    expect(dbActivity?.generationStatus).toBe("failed");
+    expect(generateActivityStorySteps).toHaveBeenCalled();
+    expect(generateActivityStoryDebrief).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/workflows/activity-generation/kinds/story-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/story-workflow.ts
@@ -1,0 +1,44 @@
+import { generateStoryContentStep } from "../steps/generate-story-content-step";
+import { generateStoryDebriefStep } from "../steps/generate-story-debrief-step";
+import { type LessonActivity } from "../steps/get-lesson-activities-step";
+import { saveStoryActivityStep } from "../steps/save-story-activity-step";
+
+/**
+ * Orchestrates story activity generation.
+ *
+ * Flow: generateContent -> generateDebrief -> save.
+ * The two generate steps are sequential because the debrief
+ * needs the full story steps output to reference specific
+ * moments. The save step writes everything at once.
+ *
+ * Uses lesson concepts directly — story generation is
+ * independent of explanation results, so it runs in wave 1
+ * alongside explanations.
+ */
+export async function storyActivityWorkflow({
+  activitiesToGenerate,
+  workflowRunId,
+}: {
+  activitiesToGenerate: LessonActivity[];
+  workflowRunId: string;
+}): Promise<void> {
+  "use workflow";
+
+  const { activityId, storySteps } = await generateStoryContentStep(activitiesToGenerate);
+
+  if (!activityId || !storySteps) {
+    return;
+  }
+
+  const debriefData = await generateStoryDebriefStep({
+    activitiesToGenerate,
+    activityId,
+    storySteps,
+  });
+
+  if (!debriefData) {
+    return;
+  }
+
+  await saveStoryActivityStep({ activityId, debriefData, storySteps, workflowRunId });
+}

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.test.ts
@@ -1,0 +1,297 @@
+import { randomUUID } from "node:crypto";
+import { fetchLessonActivities } from "@/workflows/_test-utils/fetch-lesson-activities";
+import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { generateStoryContentStep } from "./generate-story-content-step";
+
+const writeMock = vi.fn().mockResolvedValue(null);
+
+vi.mock("workflow", () => ({
+  FatalError: class FatalError extends Error {},
+  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
+  getWritable: vi.fn().mockReturnValue({
+    getWriter: () => ({
+      releaseLock: vi.fn(),
+      write: writeMock,
+    }),
+  }),
+  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
+}));
+
+const { generateActivityStoryStepsMock } = vi.hoisted(() => ({
+  generateActivityStoryStepsMock: vi.fn(),
+}));
+
+vi.mock("@zoonk/ai/tasks/activities/core/story-steps", () => ({
+  generateActivityStorySteps: generateActivityStoryStepsMock,
+}));
+
+const mockStoryData = {
+  intro: "You are a factory manager.",
+  metrics: ["Production", "Morale"],
+  steps: [
+    {
+      choices: [
+        {
+          alignment: "strong",
+          consequence: "Workers rally.",
+          id: "c1",
+          metricEffects: [{ effect: "positive", metric: "Morale" }],
+          text: "Address the team",
+        },
+        {
+          alignment: "weak",
+          consequence: "Rumors spread.",
+          id: "c2",
+          metricEffects: [{ effect: "negative", metric: "Morale" }],
+          text: "Send an email",
+        },
+      ],
+      situation: "Your supplier went bankrupt.",
+    },
+  ],
+};
+
+describe(generateStoryContentStep, () => {
+  let organizationId: number;
+  let chapter: Awaited<ReturnType<typeof chapterFixture>>;
+
+  beforeAll(async () => {
+    const organization = await aiOrganizationFixture();
+    organizationId = organization.id;
+    const course = await courseFixture({ organizationId });
+
+    chapter = await chapterFixture({
+      courseId: course.id,
+      organizationId,
+      title: `Gen Story Chapter ${randomUUID()}`,
+    });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns story steps data for a story activity", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      concepts: ["Supply Chain", "Communication"],
+      organizationId,
+      title: `Story Content ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Story ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    generateActivityStoryStepsMock.mockResolvedValue({ data: mockStoryData });
+
+    const result = await generateStoryContentStep(activities);
+
+    expect(result.activityId).toBe(activities.find((a) => a.kind === "story")?.id);
+    expect(result.storySteps).toEqual(mockStoryData);
+  });
+
+  test("passes lesson concepts and context to the AI task", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      concepts: ["Concept A", "Concept B"],
+      organizationId,
+      title: `Story Concepts ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Story ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    generateActivityStoryStepsMock.mockResolvedValue({ data: mockStoryData });
+
+    await generateStoryContentStep(activities);
+
+    expect(generateActivityStoryStepsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        concepts: ["Concept A", "Concept B"],
+        language: "en",
+        topic: lesson.title,
+      }),
+    );
+  });
+
+  test("returns null activityId when no story activity exists", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Story None ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "explanation",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Explanation ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    const result = await generateStoryContentStep(activities);
+
+    expect(result).toEqual({ activityId: null, storySteps: null });
+    expect(generateActivityStoryStepsMock).not.toHaveBeenCalled();
+  });
+
+  test("marks activity as failed when AI returns empty steps", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Story AI Empty ${randomUUID()}`,
+    });
+
+    const dbActivity = await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Story ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    generateActivityStoryStepsMock.mockResolvedValue({
+      data: { intro: "Intro", metrics: ["M"], steps: [] },
+    });
+
+    const result = await generateStoryContentStep(activities);
+
+    expect(result).toEqual({ activityId: null, storySteps: null });
+
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
+  });
+
+  test("marks activity as failed when AI call throws", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Story AI Error ${randomUUID()}`,
+    });
+
+    const dbActivity = await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Story ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    generateActivityStoryStepsMock.mockRejectedValue(new Error("AI failed"));
+
+    const result = await generateStoryContentStep(activities);
+
+    expect(result).toEqual({ activityId: null, storySteps: null });
+
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
+  });
+
+  test("streams started and completed events on success", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Story Stream ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Story ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+    const storyActivity = activities.find((a) => a.kind === "story")!;
+
+    generateActivityStoryStepsMock.mockResolvedValue({ data: mockStoryData });
+
+    await generateStoryContentStep(activities);
+
+    const events = getStreamedEvents(writeMock);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        entityId: storyActivity.id,
+        status: "started",
+        step: "generateStoryContent",
+      }),
+    );
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        entityId: storyActivity.id,
+        status: "completed",
+        step: "generateStoryContent",
+      }),
+    );
+  });
+
+  test("streams error event when AI call fails", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Story Stream Error ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Story ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+    const storyActivity = activities.find((a) => a.kind === "story")!;
+
+    generateActivityStoryStepsMock.mockRejectedValue(new Error("AI failed"));
+
+    await generateStoryContentStep(activities);
+
+    const events = getStreamedEvents(writeMock);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        entityId: storyActivity.id,
+        status: "error",
+        step: "generateStoryContent",
+      }),
+    );
+  });
+});

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.ts
@@ -1,0 +1,67 @@
+import { createEntityStepStream, getAIResultErrorReason } from "@/workflows/_shared/stream-status";
+import {
+  type ActivityStoryStepsSchema,
+  generateActivityStorySteps,
+} from "@zoonk/ai/tasks/activities/core/story-steps";
+import { type ActivityStepName } from "@zoonk/core/workflows/steps";
+import { safeAsync } from "@zoonk/utils/error";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
+import { type LessonActivity } from "./get-lesson-activities-step";
+import { handleActivityFailureStep } from "./handle-failure-step";
+
+type StoryContentResult = {
+  activityId: number | null;
+  storySteps: ActivityStoryStepsSchema | null;
+};
+
+/**
+ * Generates the interactive story steps (intro, metrics, decision steps)
+ * via AI. Returns the raw data without saving to the database.
+ * The output is passed to `generateStoryDebriefStep` (which needs the
+ * full steps context) and then to `saveStoryActivityStep` for persistence.
+ *
+ * Uses lesson concepts directly — story generation is independent of
+ * explanation results.
+ */
+export async function generateStoryContentStep(
+  activities: LessonActivity[],
+): Promise<StoryContentResult> {
+  "use step";
+
+  const storyActivity = findActivityByKind(activities, "story");
+
+  if (!storyActivity) {
+    return { activityId: null, storySteps: null };
+  }
+
+  await using stream = createEntityStepStream<ActivityStepName>(storyActivity.id);
+
+  await stream.status({ status: "started", step: "generateStoryContent" });
+
+  const lesson = storyActivity.lesson;
+  const concepts = lesson.concepts;
+
+  const { data: result, error } = await safeAsync(() =>
+    generateActivityStorySteps({
+      chapterTitle: lesson.chapter.title,
+      concepts,
+      courseTitle: lesson.chapter.course.title,
+      language: storyActivity.language,
+      lessonDescription: lesson.description,
+      topic: lesson.title,
+    }),
+  );
+
+  if (error || !result || result.data.steps.length === 0) {
+    const reason = getAIResultErrorReason({ error, result });
+
+    await stream.error({ reason, step: "generateStoryContent" });
+    await handleActivityFailureStep({ activityId: storyActivity.id });
+
+    return { activityId: null, storySteps: null };
+  }
+
+  await stream.status({ status: "completed", step: "generateStoryContent" });
+
+  return { activityId: Number(storyActivity.id), storySteps: result.data };
+}

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-debrief-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-debrief-step.test.ts
@@ -1,0 +1,294 @@
+import { randomUUID } from "node:crypto";
+import { fetchLessonActivities } from "@/workflows/_test-utils/fetch-lesson-activities";
+import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { generateStoryDebriefStep } from "./generate-story-debrief-step";
+
+const writeMock = vi.fn().mockResolvedValue(null);
+
+vi.mock("workflow", () => ({
+  FatalError: class FatalError extends Error {},
+  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
+  getWritable: vi.fn().mockReturnValue({
+    getWriter: () => ({
+      releaseLock: vi.fn(),
+      write: writeMock,
+    }),
+  }),
+  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
+}));
+
+const { generateActivityStoryDebriefMock } = vi.hoisted(() => ({
+  generateActivityStoryDebriefMock: vi.fn(),
+}));
+
+vi.mock("@zoonk/ai/tasks/activities/core/story-debrief", () => ({
+  generateActivityStoryDebrief: generateActivityStoryDebriefMock,
+}));
+
+const mockStorySteps = {
+  intro: "You are a factory manager.",
+  metrics: ["Production", "Morale"],
+  steps: [
+    {
+      choices: [
+        {
+          alignment: "strong" as const,
+          consequence: "Workers rally.",
+          id: "c1",
+          metricEffects: [{ effect: "positive" as const, metric: "Morale" }],
+          text: "Address the team",
+        },
+      ],
+      situation: "Your supplier went bankrupt.",
+    },
+  ],
+};
+
+const mockDebriefData = {
+  debrief: [{ explanation: "Communication matters.", name: "Crisis Communication" }],
+  outcomes: [
+    { minStrongChoices: 1, narrative: "Well done.", title: "Great" },
+    { minStrongChoices: 0, narrative: "Needs work.", title: "Okay" },
+  ],
+};
+
+describe(generateStoryDebriefStep, () => {
+  let organizationId: number;
+  let chapter: Awaited<ReturnType<typeof chapterFixture>>;
+
+  beforeAll(async () => {
+    const organization = await aiOrganizationFixture();
+    organizationId = organization.id;
+    const course = await courseFixture({ organizationId });
+
+    chapter = await chapterFixture({
+      courseId: course.id,
+      organizationId,
+      title: `Gen Debrief Chapter ${randomUUID()}`,
+    });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns debrief data from story steps output", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Debrief Content ${randomUUID()}`,
+    });
+
+    const storyActivity = await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Story ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    generateActivityStoryDebriefMock.mockResolvedValue({ data: mockDebriefData });
+
+    const result = await generateStoryDebriefStep({
+      activitiesToGenerate: activities,
+      activityId: Number(storyActivity.id),
+      storySteps: mockStorySteps,
+    });
+
+    expect(result).toEqual(mockDebriefData);
+
+    expect(generateActivityStoryDebriefMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        language: "en",
+        storySteps: mockStorySteps,
+        topic: lesson.title,
+      }),
+    );
+  });
+
+  test("returns null when no story activity exists", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Debrief None ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "explanation",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Explanation ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    const result = await generateStoryDebriefStep({
+      activitiesToGenerate: activities,
+      activityId: 999,
+      storySteps: mockStorySteps,
+    });
+
+    expect(result).toBeNull();
+    expect(generateActivityStoryDebriefMock).not.toHaveBeenCalled();
+  });
+
+  test("marks activity as failed when AI returns empty outcomes", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Debrief Empty ${randomUUID()}`,
+    });
+
+    const storyActivity = await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Story ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    generateActivityStoryDebriefMock.mockResolvedValue({
+      data: { debrief: [{ explanation: "x", name: "x" }], outcomes: [] },
+    });
+
+    const result = await generateStoryDebriefStep({
+      activitiesToGenerate: activities,
+      activityId: Number(storyActivity.id),
+      storySteps: mockStorySteps,
+    });
+
+    expect(result).toBeNull();
+
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: storyActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
+  });
+
+  test("marks activity as failed when AI call throws", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Debrief AI Error ${randomUUID()}`,
+    });
+
+    const storyActivity = await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Story ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    generateActivityStoryDebriefMock.mockRejectedValue(new Error("Debrief failed"));
+
+    const result = await generateStoryDebriefStep({
+      activitiesToGenerate: activities,
+      activityId: Number(storyActivity.id),
+      storySteps: mockStorySteps,
+    });
+
+    expect(result).toBeNull();
+
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: storyActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
+  });
+
+  test("streams started and completed events on success", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Debrief Stream ${randomUUID()}`,
+    });
+
+    const storyActivity = await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Story ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    generateActivityStoryDebriefMock.mockResolvedValue({ data: mockDebriefData });
+
+    await generateStoryDebriefStep({
+      activitiesToGenerate: activities,
+      activityId: Number(storyActivity.id),
+      storySteps: mockStorySteps,
+    });
+
+    const events = getStreamedEvents(writeMock);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        entityId: Number(storyActivity.id),
+        status: "started",
+        step: "generateStoryDebrief",
+      }),
+    );
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        entityId: Number(storyActivity.id),
+        status: "completed",
+        step: "generateStoryDebrief",
+      }),
+    );
+  });
+
+  test("streams error event when AI call fails", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Debrief Stream Error ${randomUUID()}`,
+    });
+
+    const storyActivity = await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Story ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    generateActivityStoryDebriefMock.mockRejectedValue(new Error("AI failed"));
+
+    await generateStoryDebriefStep({
+      activitiesToGenerate: activities,
+      activityId: Number(storyActivity.id),
+      storySteps: mockStorySteps,
+    });
+
+    const events = getStreamedEvents(writeMock);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        entityId: Number(storyActivity.id),
+        status: "error",
+        step: "generateStoryDebrief",
+      }),
+    );
+  });
+});

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-debrief-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-debrief-step.ts
@@ -1,0 +1,61 @@
+import { createEntityStepStream, getAIResultErrorReason } from "@/workflows/_shared/stream-status";
+import {
+  type ActivityStoryDebriefSchema,
+  generateActivityStoryDebrief,
+} from "@zoonk/ai/tasks/activities/core/story-debrief";
+import { type ActivityStoryStepsSchema } from "@zoonk/ai/tasks/activities/core/story-steps";
+import { type ActivityStepName } from "@zoonk/core/workflows/steps";
+import { safeAsync } from "@zoonk/utils/error";
+import { findActivityByKind } from "./_utils/find-activity-by-kind";
+import { type LessonActivity } from "./get-lesson-activities-step";
+import { handleActivityFailureStep } from "./handle-failure-step";
+
+/**
+ * Generates outcomes and debrief concepts for a story activity via AI.
+ * Takes the full steps output from `generateStoryContentStep` as input
+ * so the debrief can reference specific story moments.
+ *
+ * Returns the debrief data or null if generation fails.
+ */
+export async function generateStoryDebriefStep({
+  activityId,
+  activitiesToGenerate,
+  storySteps,
+}: {
+  activityId: number;
+  activitiesToGenerate: LessonActivity[];
+  storySteps: ActivityStoryStepsSchema;
+}): Promise<ActivityStoryDebriefSchema | null> {
+  "use step";
+
+  const storyActivity = findActivityByKind(activitiesToGenerate, "story");
+
+  if (!storyActivity) {
+    return null;
+  }
+
+  await using stream = createEntityStepStream<ActivityStepName>(activityId);
+
+  await stream.status({ status: "started", step: "generateStoryDebrief" });
+
+  const { data: result, error } = await safeAsync(() =>
+    generateActivityStoryDebrief({
+      language: storyActivity.language,
+      storySteps,
+      topic: storyActivity.lesson.title,
+    }),
+  );
+
+  if (error || !result || result.data.outcomes.length === 0) {
+    const reason = getAIResultErrorReason({ error, result });
+
+    await stream.error({ reason, step: "generateStoryDebrief" });
+    await handleActivityFailureStep({ activityId });
+
+    return null;
+  }
+
+  await stream.status({ status: "completed", step: "generateStoryDebrief" });
+
+  return result.data;
+}

--- a/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.test.ts
@@ -1,0 +1,212 @@
+import { randomUUID } from "node:crypto";
+import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
+import { prisma } from "@zoonk/db";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { getString } from "@zoonk/utils/json";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { saveStoryActivityStep } from "./save-story-activity-step";
+
+const writeMock = vi.fn().mockResolvedValue(null);
+
+vi.mock("workflow", () => ({
+  FatalError: class FatalError extends Error {},
+  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
+  getWritable: vi.fn().mockReturnValue({
+    getWriter: () => ({
+      releaseLock: vi.fn(),
+      write: writeMock,
+    }),
+  }),
+  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
+}));
+
+const storySteps = {
+  intro: "You are a factory manager facing a crisis.",
+  metrics: ["Production", "Morale", "Cash"],
+  steps: [
+    {
+      choices: [
+        {
+          alignment: "strong" as const,
+          consequence: "Workers rally behind you.",
+          id: "c1a",
+          metricEffects: [{ effect: "positive" as const, metric: "Morale" }],
+          text: "Address the team directly",
+        },
+        {
+          alignment: "weak" as const,
+          consequence: "Rumors spread.",
+          id: "c1b",
+          metricEffects: [{ effect: "negative" as const, metric: "Morale" }],
+          text: "Send an email",
+        },
+      ],
+      situation: "Your supplier went bankrupt.",
+    },
+    {
+      choices: [
+        {
+          alignment: "partial" as const,
+          consequence: "Reasonable alternative found.",
+          id: "c2a",
+          metricEffects: [{ effect: "positive" as const, metric: "Production" }],
+          text: "Contact backup suppliers",
+        },
+        {
+          alignment: "strong" as const,
+          consequence: "Innovation emerges.",
+          id: "c2b",
+          metricEffects: [
+            { effect: "positive" as const, metric: "Production" },
+            { effect: "positive" as const, metric: "Cash" },
+          ],
+          text: "Redesign the product",
+        },
+      ],
+      situation: "Production is halted.",
+    },
+  ],
+};
+
+const debriefData = {
+  debrief: [
+    { explanation: "Communication builds trust.", name: "Crisis Communication" },
+    { explanation: "Constraints drive innovation.", name: "Supply Chain Resilience" },
+  ],
+  outcomes: [
+    { minStrongChoices: 2, narrative: "You turned crisis into opportunity.", title: "Excellent" },
+    { minStrongChoices: 0, narrative: "The crisis overwhelmed you.", title: "Needs work" },
+  ],
+};
+
+describe(saveStoryActivityStep, () => {
+  let organizationId: number;
+  let chapter: Awaited<ReturnType<typeof chapterFixture>>;
+
+  beforeAll(async () => {
+    const organization = await aiOrganizationFixture();
+    organizationId = organization.id;
+    const course = await courseFixture({ organizationId });
+
+    chapter = await chapterFixture({
+      courseId: course.id,
+      organizationId,
+      title: `Save Story Chapter ${randomUUID()}`,
+    });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("saves intro, decision steps, and debrief with correct kinds and positions", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Save Story ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Story ${randomUUID()}`,
+    });
+
+    await saveStoryActivityStep({
+      activityId: Number(activity.id),
+      debriefData,
+      storySteps,
+      workflowRunId: "workflow-1",
+    });
+
+    const [dbSteps, dbActivity] = await Promise.all([
+      prisma.step.findMany({
+        orderBy: { position: "asc" },
+        where: { activityId: activity.id },
+      }),
+      prisma.activity.findUniqueOrThrow({
+        where: { id: activity.id },
+      }),
+    ]);
+
+    // 1 intro + 2 decision steps + 1 debrief = 4
+    expect(dbSteps).toHaveLength(4);
+
+    // Intro: static with storyIntro variant at position 0
+    expect(dbSteps[0]?.kind).toBe("static");
+    expect(dbSteps[0]?.position).toBe(0);
+    expect(getString(dbSteps[0]?.content, "variant")).toBe("storyIntro");
+
+    // Decision steps: story kind at positions 1 and 2
+    expect(dbSteps[1]?.kind).toBe("story");
+    expect(dbSteps[1]?.position).toBe(1);
+    expect(dbSteps[2]?.kind).toBe("story");
+    expect(dbSteps[2]?.position).toBe(2);
+
+    // Debrief: static with storyDebrief variant at position 3
+    expect(dbSteps[3]?.kind).toBe("static");
+    expect(dbSteps[3]?.position).toBe(3);
+    expect(getString(dbSteps[3]?.content, "variant")).toBe("storyDebrief");
+
+    // All steps are published
+    for (const step of dbSteps) {
+      expect(step.isPublished).toBe(true);
+    }
+
+    // Activity marked as completed with generationRunId
+    expect(dbActivity).toMatchObject({
+      generationRunId: "workflow-1",
+      generationStatus: "completed",
+    });
+
+    const events = getStreamedEvents(writeMock);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({ status: "started", step: "saveStoryActivity" }),
+    );
+
+    expect(events).toContainEqual(
+      expect.objectContaining({ status: "completed", step: "saveStoryActivity" }),
+    );
+  });
+
+  test("streams error and marks failed when DB transaction fails", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Save Story Error ${randomUUID()}`,
+    });
+
+    const activity = await activityFixture({
+      generationStatus: "pending",
+      kind: "story",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Story Fail ${randomUUID()}`,
+    });
+
+    // Delete the activity so the prisma.activity.update inside the transaction fails
+    await prisma.activity.delete({ where: { id: activity.id } });
+
+    await saveStoryActivityStep({
+      activityId: Number(activity.id),
+      debriefData,
+      storySteps,
+      workflowRunId: "workflow-error",
+    });
+
+    const events = getStreamedEvents(writeMock);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({ status: "error", step: "saveStoryActivity" }),
+    );
+  });
+});

--- a/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.ts
@@ -1,0 +1,107 @@
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
+import { type ActivityStoryDebriefSchema } from "@zoonk/ai/tasks/activities/core/story-debrief";
+import { type ActivityStoryStepsSchema } from "@zoonk/ai/tasks/activities/core/story-steps";
+import { assertStepContent } from "@zoonk/core/steps/content-contract";
+import { type ActivityStepName } from "@zoonk/core/workflows/steps";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { handleActivityFailureStep } from "./handle-failure-step";
+
+/**
+ * Builds step records for a story activity from the AI outputs.
+ *
+ * - Position 0: static intro step (scene setup + metric definitions)
+ * - Positions 1..N: story decision steps (situation + choices)
+ * - Position N+1: static debrief step (outcomes + concept reveals)
+ */
+function buildStoryStepRecords(
+  activityId: number,
+  storySteps: ActivityStoryStepsSchema,
+  debriefData: ActivityStoryDebriefSchema,
+) {
+  const introRecord = {
+    activityId,
+    content: assertStepContent("static", {
+      intro: storySteps.intro,
+      metrics: storySteps.metrics,
+      variant: "storyIntro" as const,
+    }),
+    isPublished: true,
+    kind: "static" as const,
+    position: 0,
+  };
+
+  const decisionRecords = storySteps.steps.map((step, index) => ({
+    activityId,
+    content: assertStepContent("story", {
+      choices: step.choices,
+      situation: step.situation,
+    }),
+    isPublished: true,
+    kind: "story" as const,
+    position: index + 1,
+  }));
+
+  const debriefRecord = {
+    activityId,
+    content: assertStepContent("static", {
+      debrief: debriefData.debrief,
+      outcomes: debriefData.outcomes,
+      variant: "storyDebrief" as const,
+    }),
+    isPublished: true,
+    kind: "static" as const,
+    position: storySteps.steps.length + 1,
+  };
+
+  return [introRecord, ...decisionRecords, debriefRecord];
+}
+
+/**
+ * Persists all generated story data in one transaction:
+ * - Static intro step with metrics
+ * - Interactive decision steps with choices and consequences
+ * - Static debrief step with outcomes and concept reveals
+ * - Marks the activity as completed
+ *
+ * This is the single save point for a story entity.
+ * Upstream generate steps (content, debrief) produce data only;
+ * this step writes everything to the database at once.
+ */
+export async function saveStoryActivityStep({
+  activityId,
+  debriefData,
+  storySteps,
+  workflowRunId,
+}: {
+  activityId: number;
+  debriefData: ActivityStoryDebriefSchema;
+  storySteps: ActivityStoryStepsSchema;
+  workflowRunId: string;
+}): Promise<void> {
+  "use step";
+
+  await using stream = createEntityStepStream<ActivityStepName>(activityId);
+
+  await stream.status({ status: "started", step: "saveStoryActivity" });
+
+  const stepRecords = buildStoryStepRecords(activityId, storySteps, debriefData);
+
+  const { error } = await safeAsync(() =>
+    prisma.$transaction([
+      prisma.step.createMany({ data: stepRecords }),
+      prisma.activity.update({
+        data: { generationRunId: workflowRunId, generationStatus: "completed" },
+        where: { id: activityId },
+      }),
+    ]),
+  );
+
+  if (error) {
+    await stream.error({ reason: "dbSaveFailed", step: "saveStoryActivity" });
+    await handleActivityFailureStep({ activityId });
+    return;
+  }
+
+  await stream.status({ status: "completed", step: "saveStoryActivity" });
+}

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { generateLessonActivities } from "@zoonk/ai/tasks/lessons/activities";
+import { generateAppliedActivityKind } from "@zoonk/ai/tasks/lessons/applied-activity-kind";
 import { generateLessonKind } from "@zoonk/ai/tasks/lessons/kind";
 import { prisma } from "@zoonk/db";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
@@ -26,6 +27,12 @@ vi.mock("workflow", () => ({
 vi.mock("@zoonk/ai/tasks/lessons/kind", () => ({
   generateLessonKind: vi.fn().mockResolvedValue({
     data: { kind: "core" },
+  }),
+}));
+
+vi.mock("@zoonk/ai/tasks/lessons/applied-activity-kind", () => ({
+  generateAppliedActivityKind: vi.fn().mockResolvedValue({
+    data: { appliedActivityKind: "story" },
   }),
 }));
 
@@ -225,6 +232,84 @@ describe(lessonGenerationWorkflow, () => {
       });
       expect(finalLesson?.generationStatus).toBe("completed");
       expect(finalLesson?.generationRunId).toBe("test-run-id");
+    });
+  });
+
+  describe("applied activity classifier", () => {
+    test("calls classifier for core lessons and includes story activity", async () => {
+      vi.mocked(generateLessonKind).mockResolvedValueOnce({
+        data: { kind: "core" },
+      } as Awaited<ReturnType<typeof generateLessonKind>>);
+
+      const lesson = await lessonFixture({
+        chapterId: chapter.id,
+        concepts: ["Test Concept"],
+        generationStatus: "pending",
+        organizationId,
+        title: `Applied Core Lesson ${randomUUID()}`,
+      });
+
+      await lessonGenerationWorkflow(lesson.id);
+
+      expect(generateAppliedActivityKind).toHaveBeenCalled();
+
+      const activities = await prisma.activity.findMany({
+        orderBy: { position: "asc" },
+        where: { lessonId: lesson.id },
+      });
+
+      expect(activities.some((a) => a.kind === "story")).toBe(true);
+    });
+
+    test("skips classifier for language lessons", async () => {
+      vi.mocked(generateLessonKind).mockResolvedValueOnce({
+        data: { kind: "language" },
+      } as Awaited<ReturnType<typeof generateLessonKind>>);
+
+      const languageCourse = await courseFixture({
+        organizationId,
+        targetLanguage: "es",
+      });
+
+      const languageChapter = await chapterFixture({
+        courseId: languageCourse.id,
+        organizationId,
+        title: `Language Chapter ${randomUUID()}`,
+      });
+
+      const lesson = await lessonFixture({
+        chapterId: languageChapter.id,
+        generationStatus: "pending",
+        organizationId,
+        title: `Applied Language Lesson ${randomUUID()}`,
+      });
+
+      await lessonGenerationWorkflow(lesson.id);
+
+      expect(generateAppliedActivityKind).not.toHaveBeenCalled();
+
+      const activities = await prisma.activity.findMany({
+        where: { lessonId: lesson.id },
+      });
+
+      expect(activities.some((a) => a.kind === "story")).toBe(false);
+    });
+
+    test("skips classifier for custom lessons", async () => {
+      vi.mocked(generateLessonKind).mockResolvedValueOnce({
+        data: { kind: "custom" },
+      } as Awaited<ReturnType<typeof generateLessonKind>>);
+
+      const lesson = await lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "pending",
+        organizationId,
+        title: `Applied Custom Lesson ${randomUUID()}`,
+      });
+
+      await lessonGenerationWorkflow(lesson.id);
+
+      expect(generateAppliedActivityKind).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
@@ -1,6 +1,7 @@
 import { streamSkipStep } from "@/workflows/_shared/stream-skip-step";
 import { getWorkflowMetadata } from "workflow";
 import { addActivitiesStep } from "./steps/add-activities-step";
+import { determineAppliedActivityStep } from "./steps/determine-applied-activity-step";
 import { determineLessonKindStep } from "./steps/determine-lesson-kind-step";
 import { generateCustomActivitiesStep } from "./steps/generate-custom-activities-step";
 import { getLessonStep } from "./steps/get-lesson-step";
@@ -31,6 +32,14 @@ async function generateActivities(
   lessonId: number,
 ): Promise<"filtered" | "completed"> {
   const lessonKind = await determineLessonKindStep(context);
+
+  const appliedActivityKind =
+    lessonKind === "core" ? await determineAppliedActivityStep(context) : null;
+
+  if (lessonKind !== "core") {
+    await streamSkipStep("determineAppliedActivity");
+  }
+
   await updateLessonKindStep({ kind: lessonKind, lessonId });
 
   // The AI sometimes classifies a language-course lesson as "core" or "custom"
@@ -41,7 +50,9 @@ async function generateActivities(
   }
 
   const customActivities = await getCustomActivities(context, lessonKind);
+
   await addActivitiesStep({
+    appliedActivityKind,
     concepts: context.concepts,
     context,
     customActivities,

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/get-activities-for-kind.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/get-activities-for-kind.test.ts
@@ -103,6 +103,82 @@ describe(getActivitiesForKind, () => {
     });
   });
 
+  describe("applied activity", () => {
+    test("inserts story after quiz before review with 3 concepts", () => {
+      const result = getActivitiesForKind("core", [], null, ["A", "B", "C"], "story");
+
+      expect(result.map((a) => a.kind)).toEqual([
+        "explanation",
+        "explanation",
+        "explanation",
+        "practice",
+        "quiz",
+        "story",
+        "review",
+      ]);
+    });
+
+    test("inserts story after quiz before review with 5 concepts", () => {
+      const result = getActivitiesForKind("core", [], null, ["A", "B", "C", "D", "E"], "story");
+
+      expect(result.map((a) => a.kind)).toEqual([
+        "explanation",
+        "explanation",
+        "practice",
+        "explanation",
+        "explanation",
+        "explanation",
+        "practice",
+        "quiz",
+        "story",
+        "review",
+      ]);
+    });
+
+    test("inserts story with 0 concepts", () => {
+      const result = getActivitiesForKind("core", [], null, [], "story");
+
+      expect(result.map((a) => a.kind)).toEqual([
+        "explanation",
+        "practice",
+        "quiz",
+        "story",
+        "review",
+      ]);
+    });
+
+    test("inserts story with 1 concept", () => {
+      const result = getActivitiesForKind("core", [], null, ["Solo"], "story");
+
+      expect(result.map((a) => a.kind)).toEqual([
+        "explanation",
+        "practice",
+        "quiz",
+        "story",
+        "review",
+      ]);
+    });
+
+    test("does not insert story when appliedActivityKind is null", () => {
+      const result = getActivitiesForKind("core", [], null, ["A", "B", "C"], null);
+
+      expect(result.map((a) => a.kind)).toEqual([
+        "explanation",
+        "explanation",
+        "explanation",
+        "practice",
+        "quiz",
+        "review",
+      ]);
+    });
+
+    test("defaults to no applied activity when parameter is omitted", () => {
+      const result = getActivitiesForKind("core", [], null, ["A", "B", "C"]);
+
+      expect(result.map((a) => a.kind)).not.toContain("story");
+    });
+  });
+
   describe("custom lessons", () => {
     test("returns custom activities from AI-generated definitions", () => {
       const customActivities = [

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/get-activities-for-kind.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/get-activities-for-kind.ts
@@ -1,4 +1,5 @@
 import { type GeneratedActivity } from "@zoonk/ai/tasks/lessons/activities";
+import { type AppliedActivityKind } from "@zoonk/core/workflows/steps";
 import { type ActivityKind, type LessonKind } from "@zoonk/db";
 import { isTTSSupportedLanguage } from "@zoonk/utils/languages";
 
@@ -26,10 +27,16 @@ const LANGUAGE_ACTIVITY_KINDS: ActivityKind[] = [
  * activities are inserted — one after the first half of explanations
  * and another after the second half — to break up long sequences.
  *
- * Example with 5 concepts:
+ * Example with 5 concepts (no applied activity):
  *   [exp1, exp2, practice, exp3, exp4, exp5, practice, quiz, review]
+ *
+ * Example with 5 concepts and story:
+ *   [exp1, exp2, practice, exp3, exp4, exp5, practice, quiz, story, review]
  */
-function getCoreActivities(concepts: string[]): ActivityEntry[] {
+function getCoreActivities(
+  concepts: string[],
+  appliedActivityKind: AppliedActivityKind,
+): ActivityEntry[] {
   const explanations: ActivityEntry[] = concepts.map((concept) => ({
     description: null,
     kind: "explanation",
@@ -45,17 +52,21 @@ function getCoreActivities(concepts: string[]): ActivityEntry[] {
   const review: ActivityEntry = { description: null, kind: "review", title: null };
   const quiz: ActivityEntry = { description: null, kind: "quiz", title: null };
 
+  const appliedActivities: ActivityEntry[] = appliedActivityKind
+    ? [{ description: null, kind: appliedActivityKind, title: null }]
+    : [];
+
   const minConceptsForTwoPractices = 4;
 
   if (concepts.length < minConceptsForTwoPractices) {
-    return [...allExplanations, practice, quiz, review];
+    return [...allExplanations, practice, quiz, ...appliedActivities, review];
   }
 
   const splitIndex = Math.floor(concepts.length / 2);
   const firstGroup = explanations.slice(0, splitIndex);
   const secondGroup = explanations.slice(splitIndex);
 
-  return [...firstGroup, practice, ...secondGroup, practice, quiz, review];
+  return [...firstGroup, practice, ...secondGroup, practice, quiz, ...appliedActivities, review];
 }
 
 /**
@@ -85,9 +96,10 @@ export function getActivitiesForKind(
   customActivities: GeneratedActivity[],
   targetLanguage: string | null,
   concepts: string[],
+  appliedActivityKind: AppliedActivityKind = null,
 ): ActivityEntry[] {
   if (lessonKind === "core") {
-    return getCoreActivities(concepts);
+    return getCoreActivities(concepts, appliedActivityKind);
   }
 
   if (lessonKind === "language") {

--- a/apps/api/src/workflows/lesson-generation/steps/add-activities-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/add-activities-step.test.ts
@@ -70,6 +70,7 @@ describe(addActivitiesStep, () => {
     };
 
     await addActivitiesStep({
+      appliedActivityKind: null,
       concepts: [],
       context: lessonContext,
       customActivities: [],
@@ -114,6 +115,7 @@ describe(addActivitiesStep, () => {
     };
 
     await addActivitiesStep({
+      appliedActivityKind: null,
       concepts: ["Concept A", "Concept B"],
       context: lessonContext,
       customActivities: [],
@@ -141,6 +143,7 @@ describe(addActivitiesStep, () => {
 
     await expect(
       addActivitiesStep({
+        appliedActivityKind: null,
         concepts: [],
         context: brokenContext,
         customActivities: [],
@@ -171,6 +174,7 @@ describe(addActivitiesStep, () => {
     };
 
     await addActivitiesStep({
+      appliedActivityKind: null,
       concepts: [],
       context: lessonContext,
       customActivities: [],

--- a/apps/api/src/workflows/lesson-generation/steps/add-activities-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/add-activities-step.ts
@@ -1,12 +1,13 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type GeneratedActivity } from "@zoonk/ai/tasks/lessons/activities";
-import { type LessonStepName } from "@zoonk/core/workflows/steps";
+import { type AppliedActivityKind, type LessonStepName } from "@zoonk/core/workflows/steps";
 import { type ActivityCreateManyInput, type LessonKind, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { getActivitiesForKind } from "./_utils/get-activities-for-kind";
 import { type LessonContext } from "./get-lesson-step";
 
 export async function addActivitiesStep(input: {
+  appliedActivityKind: AppliedActivityKind;
   concepts: string[];
   context: LessonContext;
   lessonKind: LessonKind;
@@ -24,6 +25,7 @@ export async function addActivitiesStep(input: {
     input.customActivities,
     input.targetLanguage,
     input.concepts,
+    input.appliedActivityKind,
   );
 
   const activitiesData: ActivityCreateManyInput[] = activitiesToCreate.map((activity, index) => ({

--- a/apps/api/src/workflows/lesson-generation/steps/determine-applied-activity-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/determine-applied-activity-step.test.ts
@@ -1,0 +1,121 @@
+import { randomUUID } from "node:crypto";
+import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { determineAppliedActivityStep } from "./determine-applied-activity-step";
+import { type LessonContext } from "./get-lesson-step";
+
+const writeMock = vi.fn().mockResolvedValue(null);
+
+vi.mock("workflow", () => ({
+  FatalError: class FatalError extends Error {},
+  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
+  getWritable: vi.fn().mockReturnValue({
+    getWriter: () => ({
+      releaseLock: vi.fn(),
+      write: writeMock,
+    }),
+  }),
+  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
+}));
+
+const { generateAppliedActivityKindMock } = vi.hoisted(() => ({
+  generateAppliedActivityKindMock: vi.fn(),
+}));
+
+vi.mock("@zoonk/ai/tasks/lessons/applied-activity-kind", () => ({
+  generateAppliedActivityKind: generateAppliedActivityKindMock,
+}));
+
+describe(determineAppliedActivityStep, () => {
+  let context: LessonContext;
+
+  beforeAll(async () => {
+    const organization = await aiOrganizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      organizationId: organization.id,
+      title: `Applied Activity Chapter ${randomUUID()}`,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      concepts: ["Supply Chain", "Communication"],
+      organizationId: organization.id,
+      title: `Applied Activity Lesson ${randomUUID()}`,
+    });
+
+    context = {
+      ...lesson,
+      _count: { activities: 0 },
+      chapter: { ...chapter, course },
+    };
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns the applied activity kind from AI generation", async () => {
+    generateAppliedActivityKindMock.mockResolvedValue({
+      data: { appliedActivityKind: "story" },
+    });
+
+    const result = await determineAppliedActivityStep(context);
+
+    expect(result).toBe("story");
+
+    expect(generateAppliedActivityKindMock).toHaveBeenCalledWith({
+      chapterTitle: context.chapter.title,
+      concepts: context.concepts,
+      courseTitle: context.chapter.course.title,
+      language: context.language,
+      lessonDescription: context.description ?? "",
+      lessonTitle: context.title,
+    });
+
+    const events = getStreamedEvents(writeMock);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({ status: "started", step: "determineAppliedActivity" }),
+    );
+
+    expect(events).toContainEqual(
+      expect.objectContaining({ status: "completed", step: "determineAppliedActivity" }),
+    );
+  });
+
+  test("returns null when AI classifies as no applied activity", async () => {
+    generateAppliedActivityKindMock.mockResolvedValue({
+      data: { appliedActivityKind: null },
+    });
+
+    const result = await determineAppliedActivityStep(context);
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null when AI generation fails (non-fatal)", async () => {
+    generateAppliedActivityKindMock.mockRejectedValue(new Error("AI failure"));
+
+    const result = await determineAppliedActivityStep(context);
+
+    expect(result).toBeNull();
+
+    const events = getStreamedEvents(writeMock);
+
+    // Should still stream completed (not error) since failure is non-fatal
+    expect(events).toContainEqual(
+      expect.objectContaining({ status: "completed", step: "determineAppliedActivity" }),
+    );
+
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ status: "error", step: "determineAppliedActivity" }),
+    );
+  });
+});

--- a/apps/api/src/workflows/lesson-generation/steps/determine-applied-activity-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/determine-applied-activity-step.ts
@@ -1,0 +1,42 @@
+import { createStepStream } from "@/workflows/_shared/stream-status";
+import { generateAppliedActivityKind } from "@zoonk/ai/tasks/lessons/applied-activity-kind";
+import { type AppliedActivityKind, type LessonStepName } from "@zoonk/core/workflows/steps";
+import { safeAsync } from "@zoonk/utils/error";
+import { type LessonContext } from "./get-lesson-step";
+
+/**
+ * Classifies whether this core lesson should include an applied activity
+ * (story, investigation, etc).
+ *
+ * Non-fatal: if the classifier fails, the lesson proceeds without an
+ * applied activity. This is an optional enhancement, not a structural
+ * requirement.
+ */
+export async function determineAppliedActivityStep(
+  context: LessonContext,
+): Promise<AppliedActivityKind> {
+  "use step";
+
+  await using stream = createStepStream<LessonStepName>();
+
+  await stream.status({ status: "started", step: "determineAppliedActivity" });
+
+  const { data: result, error } = await safeAsync(() =>
+    generateAppliedActivityKind({
+      chapterTitle: context.chapter.title,
+      concepts: context.concepts,
+      courseTitle: context.chapter.course.title,
+      language: context.language,
+      lessonDescription: context.description ?? "",
+      lessonTitle: context.title,
+    }),
+  );
+
+  await stream.status({ status: "completed", step: "determineAppliedActivity" });
+
+  if (error) {
+    return null;
+  }
+
+  return result.data.appliedActivityKind;
+}

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1609,6 +1609,16 @@ msgid "Recording word audio"
 msgstr "Recording word audio"
 
 #: src/app/generate/a/[id]/use-phase-labels.ts
+msgctxt "jN8cMX"
+msgid "Creating the story"
+msgstr "Creating the story"
+
+#: src/app/generate/a/[id]/use-phase-labels.ts
+msgctxt "kVV8P0"
+msgid "Preparing the wrap-up"
+msgstr "Preparing the wrap-up"
+
+#: src/app/generate/a/[id]/use-phase-labels.ts
 msgctxt "mIpv67"
 msgid "Creating sentences"
 msgstr "Creating sentences"
@@ -1664,9 +1674,19 @@ msgid "Finding the right sounds..."
 msgstr "Finding the right sounds..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "+6mDjl"
+msgid "Designing the choices..."
+msgstr "Designing the choices..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "+QrqeN"
 msgid "Writing the explanation first..."
 msgstr "Writing the explanation first..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "+r6Z9x"
+msgid "Preparing the wrap-up..."
+msgstr "Preparing the wrap-up..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "+wV822"
@@ -1702,6 +1722,11 @@ msgstr "Recording vocabulary audio..."
 msgctxt "2e5abC"
 msgid "Wrapping things up..."
 msgstr "Wrapping things up..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "2Qq4mP"
+msgid "Connecting choices to concepts..."
+msgstr "Connecting choices to concepts..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "4wkMNX"
@@ -1798,6 +1823,11 @@ msgid "Making each word listenable..."
 msgstr "Making each word listenable..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "C30MSR"
+msgid "Setting the scene..."
+msgstr "Setting the scene..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "Ch9BcP"
 msgid "Converting vocabulary to Latin script..."
 msgstr "Converting vocabulary to Latin script..."
@@ -1821,6 +1851,11 @@ msgstr "Choosing the right style..."
 msgctxt "EAqAX/"
 msgid "Thinking about what to illustrate..."
 msgstr "Thinking about what to illustrate..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "eh88d1"
+msgid "Adding consequences..."
+msgstr "Adding consequences..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "epxxAx"
@@ -1898,6 +1933,11 @@ msgid "Writing the explanation..."
 msgstr "Writing the explanation..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "k+mDX9"
+msgid "Creating your story..."
+msgstr "Creating your story..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "k0Q/Ph"
 msgid "Looking up each term..."
 msgstr "Looking up each term..."
@@ -1968,6 +2008,11 @@ msgid "Researching the topic..."
 msgstr "Researching the topic..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "rMBa9K"
+msgid "Crafting the outcomes..."
+msgstr "Crafting the outcomes..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "SC0o7J"
 msgid "Building the vocabulary guide..."
 msgstr "Building the vocabulary guide..."
@@ -2034,6 +2079,11 @@ msgstr "Finishing the artwork..."
 msgctxt "xrLiIe"
 msgid "Setting things up..."
 msgstr "Setting things up..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "XU3/xf"
+msgid "Writing the debrief..."
+msgstr "Writing the debrief..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "YgG70c"
@@ -2264,6 +2314,11 @@ msgid "Thinking about how to teach this..."
 msgstr "Thinking about how to teach this..."
 
 #: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "HwkHAi"
+msgid "Personalizing the lesson"
+msgstr "Personalizing the lesson"
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "HYmCaW"
 msgid "Almost done"
 msgstr "Almost done"
@@ -2272,6 +2327,11 @@ msgstr "Almost done"
 msgctxt "igBmpz"
 msgid "Making it interactive..."
 msgstr "Making it interactive..."
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "jtFSH4"
+msgid "Tailoring the experience..."
+msgstr "Tailoring the experience..."
 
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "MNQpiA"
@@ -2292,6 +2352,11 @@ msgstr "Figuring out the best approach"
 msgctxt "Nhva19"
 msgid "Choosing the right approach..."
 msgstr "Choosing the right approach..."
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "OV0vGb"
+msgid "Personalizing the lesson..."
+msgstr "Personalizing the lesson..."
 
 #: src/app/generate/layout.tsx
 msgctxt "/tq5fR"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1609,6 +1609,16 @@ msgid "Recording word audio"
 msgstr "Grabando audio de palabras"
 
 #: src/app/generate/a/[id]/use-phase-labels.ts
+msgctxt "jN8cMX"
+msgid "Creating the story"
+msgstr "Creando la historia"
+
+#: src/app/generate/a/[id]/use-phase-labels.ts
+msgctxt "kVV8P0"
+msgid "Preparing the wrap-up"
+msgstr "Preparando el cierre"
+
+#: src/app/generate/a/[id]/use-phase-labels.ts
 msgctxt "mIpv67"
 msgid "Creating sentences"
 msgstr "Creando oraciones"
@@ -1664,9 +1674,19 @@ msgid "Finding the right sounds..."
 msgstr "Buscando los sonidos correctos..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "+6mDjl"
+msgid "Designing the choices..."
+msgstr "Diseñando las opciones..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "+QrqeN"
 msgid "Writing the explanation first..."
 msgstr "Escribiendo primero la explicación..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "+r6Z9x"
+msgid "Preparing the wrap-up..."
+msgstr "Preparando el cierre..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "+wV822"
@@ -1702,6 +1722,11 @@ msgstr "Grabando audio de vocabulario..."
 msgctxt "2e5abC"
 msgid "Wrapping things up..."
 msgstr "Terminando los detalles..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "2Qq4mP"
+msgid "Connecting choices to concepts..."
+msgstr "Conectando las opciones con los conceptos..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "4wkMNX"
@@ -1798,6 +1823,11 @@ msgid "Making each word listenable..."
 msgstr "Haciendo que cada palabra sea escuchable..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "C30MSR"
+msgid "Setting the scene..."
+msgstr "Preparando el escenario..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "Ch9BcP"
 msgid "Converting vocabulary to Latin script..."
 msgstr "Convirtiendo el vocabulario a escritura latina..."
@@ -1821,6 +1851,11 @@ msgstr "Eligiendo el estilo correcto..."
 msgctxt "EAqAX/"
 msgid "Thinking about what to illustrate..."
 msgstr "Pensando qué ilustrar..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "eh88d1"
+msgid "Adding consequences..."
+msgstr "Añadiendo consecuencias..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "epxxAx"
@@ -1898,6 +1933,11 @@ msgid "Writing the explanation..."
 msgstr "Escribiendo la explicación..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "k+mDX9"
+msgid "Creating your story..."
+msgstr "Creando tu historia..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "k0Q/Ph"
 msgid "Looking up each term..."
 msgstr "Buscando cada término..."
@@ -1968,6 +2008,11 @@ msgid "Researching the topic..."
 msgstr "Investigando el tema..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "rMBa9K"
+msgid "Crafting the outcomes..."
+msgstr "Dando forma a los resultados..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "SC0o7J"
 msgid "Building the vocabulary guide..."
 msgstr "Construyendo la guía de vocabulario..."
@@ -2034,6 +2079,11 @@ msgstr "Terminando las ilustraciones..."
 msgctxt "xrLiIe"
 msgid "Setting things up..."
 msgstr "Configurando todo..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "XU3/xf"
+msgid "Writing the debrief..."
+msgstr "Escribiendo el resumen..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "YgG70c"
@@ -2264,6 +2314,11 @@ msgid "Thinking about how to teach this..."
 msgstr "Pensando cómo enseñar esto..."
 
 #: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "HwkHAi"
+msgid "Personalizing the lesson"
+msgstr "Personalizando la lección"
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "HYmCaW"
 msgid "Almost done"
 msgstr "Casi listo"
@@ -2272,6 +2327,11 @@ msgstr "Casi listo"
 msgctxt "igBmpz"
 msgid "Making it interactive..."
 msgstr "Haciéndolo interactivo..."
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "jtFSH4"
+msgid "Tailoring the experience..."
+msgstr "Adaptando la experiencia..."
 
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "MNQpiA"
@@ -2292,6 +2352,11 @@ msgstr "Determinando el mejor enfoque"
 msgctxt "Nhva19"
 msgid "Choosing the right approach..."
 msgstr "Eligiendo el enfoque correcto..."
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "OV0vGb"
+msgid "Personalizing the lesson..."
+msgstr "Personalizando la lección..."
 
 #: src/app/generate/layout.tsx
 msgctxt "/tq5fR"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1609,6 +1609,16 @@ msgid "Recording word audio"
 msgstr "Gravando áudio das palavras"
 
 #: src/app/generate/a/[id]/use-phase-labels.ts
+msgctxt "jN8cMX"
+msgid "Creating the story"
+msgstr "Criando a história"
+
+#: src/app/generate/a/[id]/use-phase-labels.ts
+msgctxt "kVV8P0"
+msgid "Preparing the wrap-up"
+msgstr "Preparando o encerramento"
+
+#: src/app/generate/a/[id]/use-phase-labels.ts
 msgctxt "mIpv67"
 msgid "Creating sentences"
 msgstr "Criando frases"
@@ -1664,9 +1674,19 @@ msgid "Finding the right sounds..."
 msgstr "Encontrando os sons certos..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "+6mDjl"
+msgid "Designing the choices..."
+msgstr "Criando as alternativas..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "+QrqeN"
 msgid "Writing the explanation first..."
 msgstr "Escrevendo a explicação primeiro..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "+r6Z9x"
+msgid "Preparing the wrap-up..."
+msgstr "Preparando o encerramento..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "+wV822"
@@ -1702,6 +1722,11 @@ msgstr "Gravando áudio do vocabulário..."
 msgctxt "2e5abC"
 msgid "Wrapping things up..."
 msgstr "Finalizando as coisas..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "2Qq4mP"
+msgid "Connecting choices to concepts..."
+msgstr "Conectando as alternativas aos conceitos..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "4wkMNX"
@@ -1798,6 +1823,11 @@ msgid "Making each word listenable..."
 msgstr "Deixando cada palavra audível..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "C30MSR"
+msgid "Setting the scene..."
+msgstr "Montando o cenário..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "Ch9BcP"
 msgid "Converting vocabulary to Latin script..."
 msgstr "Convertendo vocabulário para escrita latina..."
@@ -1821,6 +1851,11 @@ msgstr "Escolhendo o estilo certo..."
 msgctxt "EAqAX/"
 msgid "Thinking about what to illustrate..."
 msgstr "Pensando no que ilustrar..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "eh88d1"
+msgid "Adding consequences..."
+msgstr "Adicionando consequências..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "epxxAx"
@@ -1898,6 +1933,11 @@ msgid "Writing the explanation..."
 msgstr "Escrevendo a explicação..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "k+mDX9"
+msgid "Creating your story..."
+msgstr "Criando sua história..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "k0Q/Ph"
 msgid "Looking up each term..."
 msgstr "Pesquisando cada termo..."
@@ -1968,6 +2008,11 @@ msgid "Researching the topic..."
 msgstr "Pesquisando o tópico..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "rMBa9K"
+msgid "Crafting the outcomes..."
+msgstr "Criando os resultados..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "SC0o7J"
 msgid "Building the vocabulary guide..."
 msgstr "Montando o guia de vocabulário..."
@@ -2034,6 +2079,11 @@ msgstr "Finalizando a arte..."
 msgctxt "xrLiIe"
 msgid "Setting things up..."
 msgstr "Configurando as coisas..."
+
+#: src/app/generate/a/[id]/use-phase-thinking-generators.ts
+msgctxt "XU3/xf"
+msgid "Writing the debrief..."
+msgstr "Escrevendo o resumo..."
 
 #: src/app/generate/a/[id]/use-phase-thinking-generators.ts
 msgctxt "YgG70c"
@@ -2264,6 +2314,11 @@ msgid "Thinking about how to teach this..."
 msgstr "Pensando em como ensinar isso..."
 
 #: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "HwkHAi"
+msgid "Personalizing the lesson"
+msgstr "Personalizando a aula"
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "HYmCaW"
 msgid "Almost done"
 msgstr "Quase pronto"
@@ -2272,6 +2327,11 @@ msgstr "Quase pronto"
 msgctxt "igBmpz"
 msgid "Making it interactive..."
 msgstr "Tornando interativo..."
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "jtFSH4"
+msgid "Tailoring the experience..."
+msgstr "Adaptando a experiência..."
 
 #: src/app/generate/l/[id]/use-generation-phases.ts
 msgctxt "MNQpiA"
@@ -2292,6 +2352,11 @@ msgstr "Descobrindo a melhor abordagem"
 msgctxt "Nhva19"
 msgid "Choosing the right approach..."
 msgstr "Escolhendo a abordagem certa..."
+
+#: src/app/generate/l/[id]/use-generation-phases.ts
+msgctxt "OV0vGb"
+msgid "Personalizing the lesson..."
+msgstr "Personalizando a aula..."
 
 #: src/app/generate/layout.tsx
 msgctxt "/tq5fR"

--- a/apps/main/src/app/generate/a/[id]/use-phase-labels.ts
+++ b/apps/main/src/app/generate/a/[id]/use-phase-labels.ts
@@ -13,6 +13,7 @@ export function usePhaseLabels(): Record<PhaseName, string> {
     addingRomanization: t("Adding romanization"),
     addingVocabularyRomanization: t("Adding vocabulary romanization"),
     addingWordPronunciation: t("Adding word pronunciation"),
+    buildingScenario: t("Creating the story"),
     buildingWordList: t("Building word list"),
     creatingAnswerOptions: t("Preparing options"),
     creatingExercises: t("Creating exercises"),
@@ -27,6 +28,7 @@ export function usePhaseLabels(): Record<PhaseName, string> {
     saving: t("Saving your activity"),
     savingPrerequisites: t("Saving earlier activities"),
     writingContent: t("Writing the content"),
+    writingDebrief: t("Preparing the wrap-up"),
     writingExplanation: t("Writing the explanation"),
   };
 }

--- a/apps/main/src/app/generate/a/[id]/use-phase-thinking-generators.ts
+++ b/apps/main/src/app/generate/a/[id]/use-phase-thinking-generators.ts
@@ -115,6 +115,16 @@ function useContentPhaseGenerators(): Partial<Record<PhaseName, ThinkingMessageG
   const t = useExtracted();
 
   return {
+    buildingScenario: (index) =>
+      cycleMessage(
+        [
+          t("Creating your story..."),
+          t("Setting the scene..."),
+          t("Designing the choices..."),
+          t("Adding consequences..."),
+        ],
+        index,
+      ),
     creatingAnswerOptions: (index) =>
       cycleMessage(
         [
@@ -203,6 +213,16 @@ function useContentPhaseGenerators(): Partial<Record<PhaseName, ThinkingMessageG
           t("Making it clear..."),
           t("Putting together the lesson..."),
           t("Crafting the content..."),
+        ],
+        index,
+      ),
+    writingDebrief: (index) =>
+      cycleMessage(
+        [
+          t("Preparing the wrap-up..."),
+          t("Connecting choices to concepts..."),
+          t("Crafting the outcomes..."),
+          t("Writing the debrief..."),
         ],
         index,
       ),

--- a/apps/main/src/app/generate/l/[id]/generation-phases.ts
+++ b/apps/main/src/app/generate/l/[id]/generation-phases.ts
@@ -16,6 +16,7 @@ import {
 export type PhaseName =
   | "gettingStarted"
   | "figuringOutApproach"
+  | "personalizingLesson"
   | "settingUpActivities"
   | "finishing";
 
@@ -23,6 +24,7 @@ const PHASE_STEPS = {
   figuringOutApproach: ["determineLessonKind", "updateLessonKind", "removeNonLanguageLesson"],
   finishing: ["setLessonAsCompleted"],
   gettingStarted: ["getLesson", "setLessonAsRunning"],
+  personalizingLesson: ["determineAppliedActivity"],
   settingUpActivities: ["generateCustomActivities", "addActivities"],
 } as const satisfies Record<PhaseName, readonly LessonStepName[]>;
 
@@ -34,6 +36,7 @@ type _ValidateLesson = AssertAllCovered<
 export const PHASE_ORDER: PhaseName[] = [
   "gettingStarted",
   "figuringOutApproach",
+  "personalizingLesson",
   "settingUpActivities",
   "finishing",
 ];
@@ -42,14 +45,16 @@ export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
   figuringOutApproach: SearchIcon,
   finishing: CheckCircleIcon,
   gettingStarted: BookOpenIcon,
+  personalizingLesson: SparklesIcon,
   settingUpActivities: SparklesIcon,
 };
 
 const PHASE_WEIGHTS: Record<PhaseName, number> = {
-  figuringOutApproach: 25,
+  figuringOutApproach: 20,
   finishing: 5,
   gettingStarted: 5,
-  settingUpActivities: 65,
+  personalizingLesson: 20,
+  settingUpActivities: 50,
 };
 
 export function getPhaseStatus(

--- a/apps/main/src/app/generate/l/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/l/[id]/use-generation-phases.ts
@@ -23,6 +23,7 @@ export function useGenerationPhases(
     figuringOutApproach: t("Figuring out the best approach"),
     finishing: t("Almost done"),
     gettingStarted: t("Getting started"),
+    personalizingLesson: t("Personalizing the lesson"),
     settingUpActivities: t("Setting up activities"),
   };
 
@@ -55,6 +56,8 @@ export function useGenerationPhases(
     finishing: (index) => cycleMessage([t("Wrapping up..."), t("Almost there...")], index),
     gettingStarted: (index) =>
       cycleMessage([t("Getting everything ready..."), t("Setting things up...")], index),
+    personalizingLesson: (index) =>
+      cycleMessage([t("Personalizing the lesson..."), t("Tailoring the experience...")], index),
     settingUpActivities: (index) =>
       cycleMessage([t("Designing practice exercises..."), t("Making it interactive...")], index),
   };

--- a/apps/main/src/data/activities/get-review-steps.test.ts
+++ b/apps/main/src/data/activities/get-review-steps.test.ts
@@ -15,27 +15,19 @@ const REVIEW_TARGET_COUNT = 10;
 describe(getReviewSteps, () => {
   let lesson: Awaited<ReturnType<typeof lessonFixture>>;
   let org: Awaited<ReturnType<typeof organizationFixture>>;
-  let user: Awaited<ReturnType<typeof userFixture>>;
-
-  let reviewStepId: bigint;
   let unpublishedStepId: bigint;
 
   beforeAll(async () => {
     org = await organizationFixture({ kind: "brand" });
 
-    const [courseResult, userResult] = await Promise.all([
-      courseFixture({
-        isPublished: true,
-        language: "en",
-        organizationId: org.id,
-      }),
-      userFixture(),
-    ]);
-
-    user = userResult;
+    const course = await courseFixture({
+      isPublished: true,
+      language: "en",
+      organizationId: org.id,
+    });
 
     const chapter = await chapterFixture({
-      courseId: courseResult.id,
+      courseId: course.id,
       isPublished: true,
       language: "en",
       organizationId: org.id,
@@ -48,7 +40,7 @@ describe(getReviewSteps, () => {
       organizationId: org.id,
     });
 
-    // Create a source activity with 12 interactive steps + 1 static step
+    // Create a source activity with 12 interactive steps
     const sourceActivity = await activityFixture({
       generationStatus: "completed",
       isPublished: true,
@@ -69,38 +61,6 @@ describe(getReviewSteps, () => {
       }),
     );
 
-    // Also create a static step (should be excluded from reviews)
-    stepPromises.push(
-      stepFixture({
-        activityId: sourceActivity.id,
-        content: { text: "Static content", title: "Static" },
-        isPublished: true,
-        kind: "static",
-        position: 12,
-      }),
-    );
-
-    // Also create a review activity (its steps should be excluded)
-    const reviewActivity = await activityFixture({
-      generationStatus: "completed",
-      isPublished: true,
-      kind: "review",
-      language: "en",
-      lessonId: lesson.id,
-      organizationId: org.id,
-      position: 1,
-    });
-
-    const reviewStep = await stepFixture({
-      activityId: reviewActivity.id,
-      content: { kind: "core", options: [], question: "Review Q", text: "Review step" },
-      isPublished: true,
-      kind: "multipleChoice",
-      position: 0,
-    });
-
-    reviewStepId = reviewStep.id;
-
     // Also create an unpublished step (should be excluded)
     stepPromises.push(
       stepFixture({
@@ -113,7 +73,7 @@ describe(getReviewSteps, () => {
     );
 
     const allSteps = await Promise.all(stepPromises);
-    unpublishedStepId = allSteps[13]!.id;
+    unpublishedStepId = allSteps[12]!.id;
   });
 
   test("returns steps where user only has incorrect attempts (tier 1)", async () => {
@@ -354,37 +314,77 @@ describe(getReviewSteps, () => {
     expect(occurrences).toHaveLength(1);
   });
 
+  /**
+   * Each exclusion test uses an isolated lesson with fewer steps than
+   * REVIEW_TARGET_COUNT so ALL eligible steps are returned. This makes
+   * the assertion deterministic: if the filter is broken, the excluded
+   * step will always appear in the result.
+   */
+
   test("excludes review activity steps", async () => {
-    const result = await getReviewSteps({
-      lessonId: lesson.id,
-      userId: Number(user.id),
+    const isolated = await createLessonWithSteps(org.id, 3);
+
+    const reviewActivity = await activityFixture({
+      generationStatus: "completed",
+      isPublished: true,
+      kind: "review",
+      language: "en",
+      lessonId: isolated.lesson.id,
+      organizationId: org.id,
     });
 
+    const reviewStep = await stepFixture({
+      activityId: reviewActivity.id,
+      content: { kind: "core", options: [], question: "Review Q" },
+      isPublished: true,
+      kind: "multipleChoice",
+      position: 0,
+    });
+
+    const result = await getReviewSteps({
+      lessonId: isolated.lesson.id,
+      userId: null,
+    });
+
+    expect(result).toHaveLength(3);
+
     const resultIds = result.map((step) => step.id);
-    expect(resultIds).not.toContain(reviewStepId);
+    expect(resultIds).not.toContain(reviewStep.id);
   });
 
   test("excludes static steps", async () => {
-    const result = await getReviewSteps({
-      lessonId: lesson.id,
-      userId: Number(user.id),
+    const isolated = await createLessonWithSteps(org.id, 3);
+
+    await stepFixture({
+      activityId: isolated.activity.id,
+      content: { text: "Static content", title: "Static" },
+      isPublished: true,
+      kind: "static",
+      position: 10,
     });
 
-    // No static steps should be in results
+    const result = await getReviewSteps({
+      lessonId: isolated.lesson.id,
+      userId: null,
+    });
+
+    expect(result).toHaveLength(3);
+
     for (const step of result) {
       expect(step.kind).not.toBe("static");
     }
   });
 
   test("excludes story steps", async () => {
+    const isolated = await createLessonWithSteps(org.id, 3);
+
     const storyActivity = await activityFixture({
       generationStatus: "completed",
       isPublished: true,
       kind: "story",
       language: "en",
-      lessonId: lesson.id,
+      lessonId: isolated.lesson.id,
       organizationId: org.id,
-      position: 2,
     });
 
     await stepFixture({
@@ -407,9 +407,11 @@ describe(getReviewSteps, () => {
     });
 
     const result = await getReviewSteps({
-      lessonId: lesson.id,
-      userId: Number(user.id),
+      lessonId: isolated.lesson.id,
+      userId: null,
     });
+
+    expect(result).toHaveLength(3);
 
     for (const step of result) {
       expect(step.kind).not.toBe("story");

--- a/apps/main/src/data/activities/get-review-steps.test.ts
+++ b/apps/main/src/data/activities/get-review-steps.test.ts
@@ -376,6 +376,46 @@ describe(getReviewSteps, () => {
     }
   });
 
+  test("excludes story steps", async () => {
+    const storyActivity = await activityFixture({
+      generationStatus: "completed",
+      isPublished: true,
+      kind: "story",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId: org.id,
+      position: 2,
+    });
+
+    await stepFixture({
+      activityId: storyActivity.id,
+      content: {
+        choices: [
+          {
+            alignment: "strong",
+            consequence: "Good outcome",
+            id: "c1",
+            metricEffects: [{ effect: "positive", metric: "Score" }],
+            text: "Choice A",
+          },
+        ],
+        situation: "A scenario",
+      },
+      isPublished: true,
+      kind: "story",
+      position: 0,
+    });
+
+    const result = await getReviewSteps({
+      lessonId: lesson.id,
+      userId: Number(user.id),
+    });
+
+    for (const step of result) {
+      expect(step.kind).not.toBe("story");
+    }
+  });
+
   test("fills with random steps when total mistakes < 10", async () => {
     const newLesson = await createLessonWithSteps(org.id, 12);
     const newUser = await userFixture();

--- a/apps/main/src/data/activities/get-review-steps.ts
+++ b/apps/main/src/data/activities/get-review-steps.ts
@@ -4,7 +4,7 @@ import { shuffle } from "@zoonk/utils/shuffle";
 
 const REVIEW_TARGET_COUNT = 10;
 const EXCLUDED_ACTIVITY_KINDS: ActivityKind[] = ["review"];
-const NON_REVIEWABLE_STEP_KINDS: StepKind[] = ["static", "visual"];
+const NON_REVIEWABLE_STEP_KINDS: StepKind[] = ["static", "story", "visual"];
 
 function reviewableStepFilter(lessonId: number) {
   return {

--- a/apps/main/src/lib/generation/activity-generation-phase-config.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-config.ts
@@ -15,6 +15,8 @@ import {
   QUIZ_PHASE_STEPS,
   READING_PHASE_ORDER,
   READING_PHASE_STEPS,
+  STORY_PHASE_ORDER,
+  STORY_PHASE_STEPS,
   VOCABULARY_PHASE_ORDER,
   VOCABULARY_PHASE_STEPS,
 } from "./activity-generation-phase-kind-steps";
@@ -50,6 +52,7 @@ export { getPhaseWeights } from "./activity-generation-phase-weights";
 export type PhaseName =
   | "gettingStarted"
   | "buildingWordList"
+  | "buildingScenario"
   | "addingPronunciation"
   | "addingRomanization"
   | "addingVocabularyRomanization"
@@ -57,6 +60,7 @@ export type PhaseName =
   | "recordingAudio"
   | "recordingVocabularyAudio"
   | "writingContent"
+  | "writingDebrief"
   | "creatingExercises"
   | "creatingAnswerOptions"
   | "creatingSentences"
@@ -78,7 +82,7 @@ const PHASE_ORDER_MAP: Record<ActivityKind, PhaseName[]> = {
   quiz: QUIZ_PHASE_ORDER,
   reading: READING_PHASE_ORDER,
   review: EXPLANATION_PHASE_ORDER,
-  story: EXPLANATION_PHASE_ORDER,
+  story: STORY_PHASE_ORDER,
   translation: VOCABULARY_PHASE_ORDER,
   vocabulary: VOCABULARY_PHASE_ORDER,
 };
@@ -103,6 +107,7 @@ function toFullPhaseSteps(
     addingRomanization: EMPTY,
     addingVocabularyRomanization: EMPTY,
     addingWordPronunciation: EMPTY,
+    buildingScenario: EMPTY,
     buildingWordList: EMPTY,
     creatingAnswerOptions: EMPTY,
     creatingExercises: EMPTY,
@@ -117,6 +122,7 @@ function toFullPhaseSteps(
     saving: EMPTY,
     savingPrerequisites: EMPTY,
     writingContent: EMPTY,
+    writingDebrief: EMPTY,
     writingExplanation: EMPTY,
     ...partial,
   };
@@ -131,7 +137,7 @@ const PHASE_STEPS_MAP: Record<ActivityKind, Record<PhaseName, readonly ActivityS
   quiz: toFullPhaseSteps(QUIZ_PHASE_STEPS),
   reading: toFullPhaseSteps(READING_PHASE_STEPS),
   review: toFullPhaseSteps(EXPLANATION_PHASE_STEPS),
-  story: toFullPhaseSteps(EXPLANATION_PHASE_STEPS),
+  story: toFullPhaseSteps(STORY_PHASE_STEPS),
   translation: toFullPhaseSteps(VOCABULARY_PHASE_STEPS),
   vocabulary: toFullPhaseSteps(VOCABULARY_PHASE_STEPS),
 };

--- a/apps/main/src/lib/generation/activity-generation-phase-kind-steps.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-kind-steps.ts
@@ -333,3 +333,30 @@ export const PRACTICE_PHASE_ORDER: PhaseName[] = [
   "writingContent",
   "saving",
 ];
+
+// -- Story ------------------------------------------------------------------
+
+type StorySteps =
+  | "getLessonActivities"
+  | "setActivityAsRunning"
+  | "generateStoryContent"
+  | "generateStoryDebrief"
+  | "saveStoryActivity";
+
+export const STORY_PHASE_STEPS = {
+  buildingScenario: ["generateStoryContent"],
+  gettingStarted: ["getLessonActivities", "setActivityAsRunning"],
+  saving: ["saveStoryActivity"],
+  writingDebrief: ["generateStoryDebrief"],
+} as const satisfies Record<string, readonly ActivityStepName[]>;
+
+type _ValidateStory = AssertAllCovered<
+  Exclude<StorySteps, (typeof STORY_PHASE_STEPS)[keyof typeof STORY_PHASE_STEPS][number]>
+>;
+
+export const STORY_PHASE_ORDER: PhaseName[] = [
+  "gettingStarted",
+  "buildingScenario",
+  "writingDebrief",
+  "saving",
+];

--- a/apps/main/src/lib/generation/activity-generation-phase-weights.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-weights.ts
@@ -8,6 +8,7 @@ const ZERO_WEIGHTS: Record<PhaseName, number> = {
   addingRomanization: 0,
   addingVocabularyRomanization: 0,
   addingWordPronunciation: 0,
+  buildingScenario: 0,
   buildingWordList: 0,
   creatingAnswerOptions: 0,
   creatingExercises: 0,
@@ -22,6 +23,7 @@ const ZERO_WEIGHTS: Record<PhaseName, number> = {
   saving: 0,
   savingPrerequisites: 0,
   writingContent: 0,
+  writingDebrief: 0,
   writingExplanation: 0,
 };
 
@@ -126,6 +128,16 @@ export function getPhaseWeights(kind: ActivityKind): Record<PhaseName, number> {
       saving: 5,
       writingContent: 50,
       writingExplanation: 40,
+    };
+  }
+
+  if (kind === "story") {
+    return {
+      ...ZERO_WEIGHTS,
+      buildingScenario: 55,
+      gettingStarted: 5,
+      saving: 10,
+      writingDebrief: 30,
     };
   }
 

--- a/apps/main/src/lib/generation/activity-generation-phases.ts
+++ b/apps/main/src/lib/generation/activity-generation-phases.ts
@@ -34,6 +34,7 @@ export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
   addingRomanization: LanguagesIcon,
   addingVocabularyRomanization: LanguagesIcon,
   addingWordPronunciation: MicIcon,
+  buildingScenario: BookOpenIcon,
   buildingWordList: BookTextIcon,
   creatingAnswerOptions: ListChecksIcon,
   creatingExercises: GraduationCapIcon,
@@ -48,6 +49,7 @@ export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
   saving: CheckCircleIcon,
   savingPrerequisites: CheckCircleIcon,
   writingContent: PenLineIcon,
+  writingDebrief: PenLineIcon,
   writingExplanation: PenLineIcon,
 };
 

--- a/i18n.lock
+++ b/i18n.lock
@@ -493,6 +493,8 @@ checksums:
     Adding%20vocabulary%20romanization/singular: 4fe1e590bba583a7bcea4f7fbb1a113a
     Saving%20earlier%20activities/singular: 4a5c7258994f11d2152bb7d65e7c963a
     Recording%20word%20audio/singular: 89a018a75830ff5590ed158f01b1809e
+    Creating%20the%20story/singular: a063029253c8262e769d0ca1f949de73
+    Preparing%20the%20wrap-up/singular: 28cfda9388f052a4391705ec7ad01511
     Creating%20sentences/singular: a9f832408dd259bd6458708c84b34ff0
     Building%20word%20list/singular: 9a9b5271981383a36db347f286054e02
     Preparing%20illustrations/singular: ebb0d8d739dd029c1ac7327ab6adf8b7
@@ -504,7 +506,9 @@ checksums:
     Preparing%20options/singular: 62f984059e903150a341e8775f897d84
     Writing%20the%20explanation/singular: 9019a6d759ed0983454bc40f281e6c45
     Finding%20the%20right%20sounds.../singular: e98992b78e94cf880db6a82e2d9dea71
+    Designing%20the%20choices.../singular: 8aec77b9ca385431c902bd9fcbeee368
     Writing%20the%20explanation%20first.../singular: 77cc0507a1013d90c5b9a0ae9f543236
+    Preparing%20the%20wrap-up.../singular: c27ba5f2b8aade84ad77a5a90291e185
     Saving%20your%20activity.../singular: 7faac2f9e34b347881e7074bae7a8313
     Explaining%20the%20topic.../singular: 1e2968adf3ec2b589dd754982830840a
     Putting%20words%20in%20context.../singular: 3b63ddc4157c48ac1c1f8797fa0dc2fb
@@ -512,6 +516,7 @@ checksums:
     Making%20vocabulary%20easier%20to%20read.../singular: c335046b2e76760b03f473562eda5443
     Recording%20vocabulary%20audio.../singular: 2e70abbf9fcc50d1058b663854d16cf9
     Wrapping%20things%20up.../singular: c6343ae3437b730bc961c2a319a617e7
+    Connecting%20choices%20to%20concepts.../singular: 671d2ecd83a2a4d11730f2d8ff6e2015
     Getting%20answer%20options%20ready.../singular: d37e6efe3c82d8ddee1e3b1f537ed4f5
     Getting%20the%20pronunciation%20right.../singular: a809bb5d01620f015cae9a4f0eeede13
     Recording%20the%20audio.../singular: e6e8da2d75c102373fec6056189d54ba
@@ -530,11 +535,13 @@ checksums:
     Adding%20reading%20aids.../singular: c2a09bc7ea6dc5fad494cd5bcd33bdbc
     Building%20interactive%20tasks.../singular: cd08796577042526d8ac1ef9608480a7
     Making%20each%20word%20listenable.../singular: 867c55b5eb4038eaff47657d2ef1c3c1
+    Setting%20the%20scene.../singular: 1d1dafcdd21594e1cbaac7f7e7973bad
     Converting%20vocabulary%20to%20Latin%20script.../singular: bee78842a0524d9beb3ecf2cbd0e9fc5
     Preparing%20options.../singular: c4fcd4a9e3b72550c86c62e79d7e9408
     Converting%20to%20Latin%20script.../singular: 6052e7545ae1927e02e42b9238091b9e
     Choosing%20the%20right%20style.../singular: 7c273483546943a1553fbc762646c079
     Thinking%20about%20what%20to%20illustrate.../singular: fe3a341a8fba909f02f4a26fb4510637
+    Adding%20consequences.../singular: 1ab324dbe6d4d9b2bd3e846b6a990756
     Building%20the%20foundation.../singular: b8101b6b421f014348465a4842ed718e
     Preparing%20vocabulary%20audio.../singular: a981ba3b51ad33dd23b54006e1ca8565
     Converting%20grammar%20text%20to%20Latin%20script.../singular: 22e7aeb66fdd90905fdd239c307184bc
@@ -550,6 +557,7 @@ checksums:
     Finishing%20up.../singular: 6bcdd72fd5aa845ae0f32f41f3e5f26d
     Getting%20the%20sound%20for%20each%20word.../singular: d449f3e06926833803a2e4d213a68e81
     Writing%20the%20explanation.../singular: cb3b01d1dc07a25447ee138dde5bfdde
+    Creating%20your%20story.../singular: 234c96be1ed372c81ea7d27817f30a9a
     Looking%20up%20each%20term.../singular: 9d0357c0da11eaf709f71945a65b3852
     Writing%20fill-in-the-blanks.../singular: b3d5f34c982c68c1bfac3e03acfda523
     Adding%20romanization%20for%20grammar.../singular: 114d35a8c97da77df790b1e767422da5
@@ -564,6 +572,7 @@ checksums:
     Preparing%20word-by-word%20audio.../singular: 8dfc633c922918272408507108c3d270
     Getting%20the%20audio%20for%20each%20term.../singular: 97dd8fda4b4011ace74b6d43a7967d67
     Researching%20the%20topic.../singular: 54c9981da59b1efccfbba3c40bb1fdd5
+    Crafting%20the%20outcomes.../singular: b009f6b2355e6fbe991570e478675c82
     Building%20the%20vocabulary%20guide.../singular: d91fca805f4e6523b60d86c3998227e1
     Making%20it%20sound%20natural.../singular: 1c95405cf7277ee02e760b48a8e0e45f
     Creating%20reading%20passages.../singular: 1f4ecba76f3c5421292dfb8e2bafbea9
@@ -577,6 +586,7 @@ checksums:
     Preparing%20the%20word%20bank.../singular: 87c5f53472bbc0e5120e338f491087ff
     Finishing%20the%20artwork.../singular: 0943b62bd602abbacf8bba3c3865f36e
     Setting%20things%20up.../singular: 4696c8e1048ec21837f886410864dfe2
+    Writing%20the%20debrief.../singular: 4c6f5256333e59e811621acfaf5066c4
     Selecting%20important%20terms.../singular: 74d7c5283c1071c3a5906260b01c72d4
     Refining%20the%20details.../singular: eaf7a7ca135f8919dc93f80095040ab0
     Detailing%20the%20word%20sounds.../singular: 75e4509b4a016e935d3bb7729aa932b2
@@ -622,12 +632,15 @@ checksums:
     This%20usually%20takes%20a%20few%20seconds/singular: d95f1b6378326c1aeb3792bd9cd643e7
     Wrapping%20up.../singular: f53e2507f652df36db205a5201fe5008
     Thinking%20about%20how%20to%20teach%20this.../singular: e71e60276db8c3d5ddb63542b0c7251e
+    Personalizing%20the%20lesson/singular: a01eae5e4ede2a5cc5fcffe98b653e75
     Almost%20done/singular: fa5f270ea4b185be8dd47cfb91b87810
     Making%20it%20interactive.../singular: 1379852e804db4736e71c068cd50982e
+    Tailoring%20the%20experience.../singular: a95d87d1a44b1f716adf7aba86c86c97
     Almost%20there.../singular: decd6d1e84363cf4c89e5446eab55dc9
     Setting%20up%20activities/singular: a644864fddf71801feef8c789333456a
     Figuring%20out%20the%20best%20approach/singular: 0cbd8e2d3c43eb874e25dd6b30fff474
     Choosing%20the%20right%20approach.../singular: 2ed5698b6fd002b38e10035a29a815dc
+    Personalizing%20the%20lesson.../singular: 4d4cbcecaa25a9650c0da5f77a6d45ad
     Creating%20content/singular: ec70a8b5ffb94c0d5b83409d03d5b77b
     Read%20Zoonk's%20privacy%20policy%20to%20understand%20how%20we%20collect%2C%20use%2C%20and%20protect%20your%20personal%20information./singular: 044f3586abe7d9915820a6629cef08e4
     Privacy%20Policy/singular: 7459744a63ef8af4e517a09024bd7c08

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -30,6 +30,7 @@
     "./tasks/courses/suggestions": "./src/tasks/courses/course-suggestions.ts",
     "./tasks/courses/thumbnail": "./src/tasks/courses/course-thumbnail.ts",
     "./tasks/lessons/activities": "./src/tasks/lessons/lesson-activities.ts",
+    "./tasks/lessons/applied-activity-kind": "./src/tasks/lessons/applied-activity-kind.ts",
     "./tasks/lessons/kind": "./src/tasks/lessons/lesson-kind.ts",
     "./tasks/steps/select-image": "./src/tasks/steps/step-select-image.ts",
     "./tasks/steps/visual-image": "./src/tasks/steps/step-visual-image.ts",

--- a/packages/ai/src/tasks/lessons/applied-activity-kind.prompt.md
+++ b/packages/ai/src/tasks/lessons/applied-activity-kind.prompt.md
@@ -1,0 +1,45 @@
+You classify whether a lesson should include an applied activity — a scenario-based experience where learners discover concepts through decisions and consequences rather than direct instruction.
+
+## Inputs
+
+- **LESSON_TITLE:** The lesson title
+- **LESSON_DESCRIPTION:** The lesson description
+- **CHAPTER_TITLE:** The chapter context
+- **COURSE_TITLE:** The course context
+- **CONCEPTS:** The lesson's core concepts
+- **LANGUAGE:** The content language
+
+## Output
+
+Return one of:
+
+- `"story"` — A decision-based scenario where the learner makes choices with consequences that reveal how concepts work in practice
+- `null` — No applied activity fits this topic
+
+## When to return "story"
+
+Return `"story"` when the lesson's concepts can be experienced through a scenario where learners make decisions:
+
+- **Decision-making with trade-offs** — management, strategy, resource allocation, policy, leadership
+- **Cause-and-effect reasoning** — economics, engineering decisions, business operations, environmental impact
+- **Ethics or judgment calls** — medical ethics, legal reasoning, professional dilemmas, social responsibility
+- **Systems with interacting forces** — ecology, supply chains, organizational dynamics, market forces
+- **Concepts that work as hidden rules** — the concepts should be discoverable through choices and their consequences (e.g., "supply and demand" becomes a scenario where pricing decisions affect sales and revenue)
+- **Applied knowledge** — any topic where understanding shows up in the quality of decisions, not just recall
+
+Most educational topics benefit from a story framing. A lesson on "photosynthesis" can become a scenario about managing a greenhouse. A lesson on "memory and learning" can become a scenario about designing a study program. Be creative in seeing how concepts can become decision drivers.
+
+## When to return null
+
+Return `null` only for topics that genuinely cannot be framed as decisions:
+
+- **Pure mathematical formulas** with no application context (e.g., "proving the Pythagorean theorem" — but "using geometry in architecture" would be story)
+- **Pure taxonomy or definitions** that exist only as classifications with no decision implications (e.g., "naming the parts of a cell" — but "cell biology in disease" would be story)
+- **Purely procedural content** where there's only one correct sequence and no room for choices (e.g., "syntax of a for loop" — but "choosing the right loop for the job" would be story)
+
+## Decision rules
+
+1. If the concepts can become hidden rules governing good vs. bad decisions in a realistic scenario, return `"story"`
+2. If the topic has any practical application where someone must make choices, return `"story"`
+3. Return `null` only when you genuinely cannot construct a scenario with meaningful choices — this should be rare
+4. When in doubt, return `"story"` — a creative scenario can be built for most topics

--- a/packages/ai/src/tasks/lessons/applied-activity-kind.ts
+++ b/packages/ai/src/tasks/lessons/applied-activity-kind.ts
@@ -1,0 +1,65 @@
+import "server-only";
+import { Output, generateText } from "ai";
+import { z } from "zod";
+import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import systemPrompt from "./applied-activity-kind.prompt.md";
+
+const DEFAULT_MODEL = process.env.AI_MODEL_APPLIED_ACTIVITY_KIND ?? "openai/gpt-5.4-nano";
+const FALLBACK_MODELS = ["google/gemini-3.1-flash-lite-preview", "anthropic/claude-haiku-4.5"];
+
+const schema = z.object({
+  appliedActivityKind: z.enum(["story"]).nullable(),
+});
+
+type AppliedActivityKindParams = {
+  lessonTitle: string;
+  lessonDescription: string;
+  chapterTitle: string;
+  courseTitle: string;
+  concepts: string[];
+  language: string;
+  model?: string;
+  useFallback?: boolean;
+  reasoningEffort?: ReasoningEffort;
+};
+
+/**
+ * Classifies whether a core lesson should include an applied activity
+ * (`story`, `investigation`, etc).
+ */
+export async function generateAppliedActivityKind({
+  lessonTitle,
+  lessonDescription,
+  chapterTitle,
+  courseTitle,
+  concepts,
+  language,
+  model = DEFAULT_MODEL,
+  useFallback = true,
+  reasoningEffort,
+}: AppliedActivityKindParams) {
+  const userPrompt = `
+    LESSON_TITLE: ${lessonTitle}
+    LESSON_DESCRIPTION: ${lessonDescription}
+    CHAPTER_TITLE: ${chapterTitle}
+    COURSE_TITLE: ${courseTitle}
+    CONCEPTS: ${concepts.join(", ")}
+    LANGUAGE: ${language}
+  `;
+
+  const providerOptions = buildProviderOptions({
+    fallbackModels: FALLBACK_MODELS,
+    reasoningEffort,
+    useFallback,
+  });
+
+  const { output, usage } = await generateText({
+    model,
+    output: Output.object({ schema }),
+    prompt: userPrompt,
+    providerOptions,
+    system: systemPrompt,
+  });
+
+  return { data: output, systemPrompt, usage, userPrompt };
+}

--- a/packages/core/src/workflows/steps.ts
+++ b/packages/core/src/workflows/steps.ts
@@ -51,6 +51,7 @@ export const LESSON_STEPS = [
   "getLesson",
   "setLessonAsRunning",
   "determineLessonKind",
+  "determineAppliedActivity",
   "updateLessonKind",
   "removeNonLanguageLesson",
   "generateCustomActivities",
@@ -73,6 +74,8 @@ export const ACTIVITY_STEPS = [
   "generateExplanationContent",
   "generateQuizContent",
   "generatePracticeContent",
+  "generateStoryContent",
+  "generateStoryDebrief",
   "generateGrammarContent",
   "generateGrammarUserContent",
   "generateGrammarRomanization",
@@ -100,6 +103,7 @@ export const ACTIVITY_STEPS = [
   "saveReadingActivity",
   "saveQuizActivity",
   "savePracticeActivity",
+  "saveStoryActivity",
   "saveExplanationActivity",
   "saveCustomActivity",
   "saveGrammarActivity",
@@ -120,6 +124,7 @@ type ActivityCompletionStep = Extract<
   | "savePracticeActivity"
   | "saveQuizActivity"
   | "saveReadingActivity"
+  | "saveStoryActivity"
   | "saveVocabularyActivity"
 >;
 
@@ -131,6 +136,7 @@ const activityCompletionSteps: Partial<Record<string, ActivityCompletionStep>> =
   practice: "savePracticeActivity",
   quiz: "saveQuizActivity",
   reading: "saveReadingActivity",
+  story: "saveStoryActivity",
   translation: "saveVocabularyActivity",
   vocabulary: "saveVocabularyActivity",
 };
@@ -181,3 +187,10 @@ export type ChapterWorkflowStepName = ChapterStepName | LessonStepName | Activit
  * so the stream includes all downstream step events.
  */
 export type CourseWorkflowStepName = CourseStepName | ChapterWorkflowStepName;
+
+/**
+ * The applied activity kind assigned to a core lesson by the AI classifier.
+ * Applied activities are scenario-based experiences (story, investigation, etc.)
+ * added on top of the standard explanation/practice/quiz set.
+ */
+export type AppliedActivityKind = "story" | null;


### PR DESCRIPTION
## Summary

- Add story generation workflow: two sequential AI calls (story steps + debrief) followed by an atomic save, running in wave 1 alongside explanations
- Add "applied activity" AI classifier (`determineAppliedActivityStep`) that decides whether a core lesson should include a story activity
- Wire story into lesson pipeline: classifier runs during lesson generation, story activity inserted after quiz before review
- Add `AppliedActivityKind` type to core package as single source of truth
- Exclude story steps from review (they depend on activity-scoped context)
- Replace placeholder phase config with proper story phases (`buildingScenario`, `writingDebrief`)
- Add `personalizingLesson` phase for the applied activity classifier (separate from `figuringOutApproach` per one-AI-call-per-phase rule)

## Test plan

- [x] Story workflow test: full pipeline, no story activity skip, content failure, debrief failure
- [x] Generate story content step test: happy path, no activity, empty steps, AI throws, stream events
- [x] Generate story debrief step test: happy path, no activity, empty outcomes, AI throws, stream events
- [x] Save story activity step test: correct kinds/positions/content, completion marking
- [x] Determine applied activity step test: returns story, returns null, non-fatal failure
- [x] Core activity workflow test: story isolation from other activities, wave 1 generation
- [x] Get activities for kind test: story insertion with various concept counts, null/omitted param
- [x] Lesson generation workflow test: classifier called for core, skipped for language/custom
- [x] Add activities step test: updated for new `appliedActivityKind` param
- [x] Review steps test: story steps excluded
- [ ] Save story step DB failure test: need to verify activity marked as failed (pending approach decision)

Closes #1172, closes #1173

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a story-based applied activity and a classifier that decides when to include it in core lessons. Integrates the story workflow into generation (wave 1) with new phases and UI updates; also makes review exclusion tests deterministic to ensure story steps are filtered out. Closes #1172 and #1173.

- **New Features**
  - Story workflow: generate steps → debrief → atomic save; runs alongside explanations in wave 1.
  - Applied activity classifier for core lessons (`story` or `null`): `determineAppliedActivityStep` using `generateAppliedActivityKind`; adds a new “personalizingLesson” phase.
  - Activity planning: insert `story` after `quiz` and before `review`; story steps are excluded from review.
  - Phases/UI: add `buildingScenario` and `writingDebrief` with labels, icons, weights, and thinking messages (i18n updated).
  - Core/types and steps: add `AppliedActivityKind` and new step names (`generateStoryContent`, `generateStoryDebrief`, `saveStoryActivity`).
  - AI package: expose `./tasks/lessons/applied-activity-kind` in `@zoonk/ai`.

- **Bug Fixes**
  - Review: make tests deterministic and explicitly exclude `review`, `static`, and `story` steps from selection.

<sup>Written for commit f8daf05a81ce53d24c3e8ad21c0749c711604baa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

