### PR TITLE
fix(test): verify failed status in workflow tests

### DIFF
--- a/apps/api/src/workflows/activity-generation/steps/generate-grammar-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-grammar-content-step.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { fetchLessonActivities } from "@/workflows/_test-utils/fetch-lesson-activities";
 import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { generateActivityGrammarContent } from "@zoonk/ai/tasks/activities/language/grammar-content";
+import { prisma } from "@zoonk/db";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -96,7 +97,7 @@ describe(generateGrammarContentStep, () => {
     );
   });
 
-  test("streams error and returns null when AI fails", async () => {
+  test("marks activity as failed and streams error when AI fails", async () => {
     vi.mocked(generateActivityGrammarContent).mockRejectedValueOnce(new Error("AI error"));
 
     const lesson = await lessonFixture({
@@ -106,7 +107,7 @@ describe(generateGrammarContentStep, () => {
       title: `Grammar Content Fail ${randomUUID()}`,
     });
 
-    await activityFixture({
+    const dbActivity = await activityFixture({
       generationStatus: "pending",
       kind: "grammar",
       language: "en",
@@ -120,6 +121,9 @@ describe(generateGrammarContentStep, () => {
 
     expect(result).toEqual({ generated: false, grammarContent: null });
 
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
+
     const events = getStreamedEvents(writeMock);
 
     expect(events).toContainEqual(
@@ -127,7 +131,7 @@ describe(generateGrammarContentStep, () => {
     );
   });
 
-  test("streams error when grammar content has no exercises", async () => {
+  test("marks activity as failed and streams error when grammar content has no exercises", async () => {
     vi.mocked(generateActivityGrammarContent).mockResolvedValueOnce({
       data: { examples: [{ highlight: "は", sentence: "test" }], exercises: [] },
     } as never);
@@ -139,7 +143,7 @@ describe(generateGrammarContentStep, () => {
       title: `Grammar Content Empty ${randomUUID()}`,
     });
 
-    await activityFixture({
+    const dbActivity = await activityFixture({
       generationStatus: "pending",
       kind: "grammar",
       language: "en",
@@ -152,6 +156,9 @@ describe(generateGrammarContentStep, () => {
     const result = await generateGrammarContentStep(activity!, "workflow-3");
 
     expect(result).toEqual({ generated: false, grammarContent: null });
+
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
 
     const events = getStreamedEvents(writeMock);
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-grammar-romanization-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-grammar-romanization-step.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { fetchLessonActivities } from "@/workflows/_test-utils/fetch-lesson-activities";
 import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { generateActivityRomanization } from "@zoonk/ai/tasks/activities/language/romanization";
+import { prisma } from "@zoonk/db";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -167,7 +168,7 @@ describe(generateGrammarRomanizationStep, () => {
     expect(generateActivityRomanization).not.toHaveBeenCalled();
   });
 
-  test("streams error when AI romanization fails", async () => {
+  test("marks activity as failed and streams error when AI romanization fails", async () => {
     vi.mocked(generateActivityRomanization).mockRejectedValueOnce(new Error("AI error"));
 
     const course = await courseFixture({ organizationId, targetLanguage: "ja" });
@@ -185,7 +186,7 @@ describe(generateGrammarRomanizationStep, () => {
       title: `Grammar Roman Fail ${randomUUID()}`,
     });
 
-    await activityFixture({
+    const dbActivity = await activityFixture({
       generationStatus: "pending",
       kind: "grammar",
       language: "en",
@@ -204,6 +205,9 @@ describe(generateGrammarRomanizationStep, () => {
     const result = await generateGrammarRomanizationStep(activities, grammarContent);
 
     expect(result).toEqual({ romanizations: null });
+
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
 
     const events = getStreamedEvents(writeMock);
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-grammar-user-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-grammar-user-content-step.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { fetchLessonActivities } from "@/workflows/_test-utils/fetch-lesson-activities";
 import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { generateActivityGrammarUserContent } from "@zoonk/ai/tasks/activities/language/grammar-user-content";
+import { prisma } from "@zoonk/db";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -152,7 +153,7 @@ describe(generateGrammarUserContentStep, () => {
     expect(generateActivityGrammarUserContent).not.toHaveBeenCalled();
   });
 
-  test("streams error when AI fails", async () => {
+  test("marks activity as failed and streams error when AI fails", async () => {
     vi.mocked(generateActivityGrammarUserContent).mockRejectedValueOnce(new Error("AI error"));
 
     const lesson = await lessonFixture({
@@ -162,7 +163,7 @@ describe(generateGrammarUserContentStep, () => {
       title: `Grammar UserContent Fail ${randomUUID()}`,
     });
 
-    await activityFixture({
+    const dbActivity = await activityFixture({
       generationStatus: "pending",
       kind: "grammar",
       language: "en",
@@ -182,6 +183,9 @@ describe(generateGrammarUserContentStep, () => {
 
     expect(result).toEqual({ userContent: null });
 
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
+
     const events = getStreamedEvents(writeMock);
 
     expect(events).toContainEqual(
@@ -189,7 +193,7 @@ describe(generateGrammarUserContentStep, () => {
     );
   });
 
-  test("streams error when AI returns empty result", async () => {
+  test("marks activity as failed and streams error when AI returns empty result", async () => {
     vi.mocked(generateActivityGrammarUserContent).mockResolvedValueOnce(null as never);
 
     const lesson = await lessonFixture({
@@ -199,7 +203,7 @@ describe(generateGrammarUserContentStep, () => {
       title: `Grammar UserContent Empty ${randomUUID()}`,
     });
 
-    await activityFixture({
+    const dbActivity = await activityFixture({
       generationStatus: "pending",
       kind: "grammar",
       language: "en",
@@ -218,6 +222,9 @@ describe(generateGrammarUserContentStep, () => {
     const result = await generateGrammarUserContentStep(activities, grammarContent);
 
     expect(result).toEqual({ userContent: null });
+
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
 
     const events = getStreamedEvents(writeMock);
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-practice-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-practice-content-step.test.ts
@@ -229,14 +229,14 @@ describe(generatePracticeContentStep, () => {
     );
   });
 
-  test("streams error event when AI call fails", async () => {
+  test("marks activity as failed and streams error when AI call fails", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
       title: `Practice AI Error ${randomUUID()}`,
     });
 
-    await activityFixture({
+    const dbActivity = await activityFixture({
       generationStatus: "pending",
       kind: "practice",
       language: "en",
@@ -250,7 +250,16 @@ describe(generatePracticeContentStep, () => {
 
     generateActivityPracticeMock.mockRejectedValue(new Error("AI failed"));
 
-    await generatePracticeContentStep(activities, [{ text: "text", title: "title" }], "run-6");
+    const result = await generatePracticeContentStep(
+      activities,
+      [{ text: "text", title: "title" }],
+      "run-6",
+    );
+
+    expect(result).toEqual({ activityId: null, steps: [] });
+
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
 
     const events = getStreamedEvents(writeMock);
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-content-step.test.ts
@@ -229,14 +229,14 @@ describe(generateQuizContentStep, () => {
     );
   });
 
-  test("streams error event when AI call fails", async () => {
+  test("marks activity as failed and streams error when AI call fails", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
       title: `Quiz AI Error ${randomUUID()}`,
     });
 
-    await activityFixture({
+    const dbActivity = await activityFixture({
       generationStatus: "pending",
       kind: "quiz",
       language: "en",
@@ -250,7 +250,16 @@ describe(generateQuizContentStep, () => {
 
     generateActivityQuizMock.mockRejectedValue(new Error("AI failed"));
 
-    await generateQuizContentStep(activities, [{ text: "text", title: "title" }], "run-6");
+    const result = await generateQuizContentStep(
+      activities,
+      [{ text: "text", title: "title" }],
+      "run-6",
+    );
+
+    expect(result).toEqual({ activityId: null, questions: [] });
+
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
 
     const events = getStreamedEvents(writeMock);
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-romanization-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-romanization-step.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { fetchLessonActivities } from "@/workflows/_test-utils/fetch-lesson-activities";
 import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { generateActivityRomanization } from "@zoonk/ai/tasks/activities/language/romanization";
+import { prisma } from "@zoonk/db";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -169,7 +170,7 @@ describe(generateReadingRomanizationStep, () => {
     expect(generateActivityRomanization).not.toHaveBeenCalled();
   });
 
-  test("streams error when AI romanization fails", async () => {
+  test("marks activity as failed and streams error when AI romanization fails", async () => {
     vi.mocked(generateActivityRomanization).mockRejectedValueOnce(new Error("AI error"));
 
     const course = await courseFixture({ organizationId, targetLanguage: "ja" });
@@ -187,7 +188,7 @@ describe(generateReadingRomanizationStep, () => {
       title: `Reading Roman Fail ${randomUUID()}`,
     });
 
-    await activityFixture({
+    const dbActivity = await activityFixture({
       generationStatus: "pending",
       kind: "reading",
       language: "en",
@@ -204,6 +205,9 @@ describe(generateReadingRomanizationStep, () => {
 
     expect(result).toEqual({ romanizations: {} });
 
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
+
     const events = getStreamedEvents(writeMock);
 
     expect(events).toContainEqual(
@@ -211,7 +215,7 @@ describe(generateReadingRomanizationStep, () => {
     );
   });
 
-  test("streams error when some romanizations are missing", async () => {
+  test("marks activity as failed and streams error when some romanizations are missing", async () => {
     vi.mocked(generateActivityRomanization).mockResolvedValueOnce({
       data: { romanizations: ["kore wa neko desu"] },
     } as never);
@@ -231,7 +235,7 @@ describe(generateReadingRomanizationStep, () => {
       title: `Reading Roman Partial ${randomUUID()}`,
     });
 
-    await activityFixture({
+    const dbActivity = await activityFixture({
       generationStatus: "pending",
       kind: "reading",
       language: "en",
@@ -250,6 +254,9 @@ describe(generateReadingRomanizationStep, () => {
     const result = await generateReadingRomanizationStep(activities, sentences);
 
     expect(result.romanizations["これは猫です"]).toBe("kore wa neko desu");
+
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
 
     const events = getStreamedEvents(writeMock);
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-metadata-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-metadata-step.test.ts
@@ -3,6 +3,7 @@ import { fetchLessonActivities } from "@/workflows/_test-utils/fetch-lesson-acti
 import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { generateActivityRomanization } from "@zoonk/ai/tasks/activities/language/romanization";
 import { generateTranslation } from "@zoonk/ai/tasks/activities/language/translation";
+import { prisma } from "@zoonk/db";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -230,7 +231,7 @@ describe(generateSentenceWordMetadataStep, () => {
     expect(generateTranslation).not.toHaveBeenCalled();
   });
 
-  test("streams error when translations are incomplete", async () => {
+  test("marks activity as failed and streams error when translations are incomplete", async () => {
     vi.mocked(generateTranslation).mockRejectedValue(new Error("AI error"));
 
     const course = await courseFixture({ organizationId, targetLanguage: "de" });
@@ -248,7 +249,7 @@ describe(generateSentenceWordMetadataStep, () => {
       title: `SentWord Meta Fail ${randomUUID()}`,
     });
 
-    await activityFixture({
+    const dbActivity = await activityFixture({
       generationStatus: "pending",
       kind: "reading",
       language: "en",
@@ -274,6 +275,9 @@ describe(generateSentenceWordMetadataStep, () => {
     ]);
 
     expect(result.wordMetadata).toBeDefined();
+
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
 
     const events = getStreamedEvents(writeMock);
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.test.ts
@@ -189,9 +189,19 @@ describe(generateStoryContentStep, () => {
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
     expect(updated.generationStatus).toBe("failed");
+
+    const events = getStreamedEvents(writeMock);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        entityId: Number(dbActivity.id),
+        status: "error",
+        step: "generateStoryContent",
+      }),
+    );
   });
 
-  test("marks activity as failed when AI call throws", async () => {
+  test("marks activity as failed and streams error when AI call throws", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -217,6 +227,16 @@ describe(generateStoryContentStep, () => {
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
     expect(updated.generationStatus).toBe("failed");
+
+    const events = getStreamedEvents(writeMock);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        entityId: Number(dbActivity.id),
+        status: "error",
+        step: "generateStoryContent",
+      }),
+    );
   });
 
   test("streams started and completed events on success", async () => {
@@ -256,40 +276,6 @@ describe(generateStoryContentStep, () => {
       expect.objectContaining({
         entityId: storyActivity.id,
         status: "completed",
-        step: "generateStoryContent",
-      }),
-    );
-  });
-
-  test("streams error event when AI call fails", async () => {
-    const lesson = await lessonFixture({
-      chapterId: chapter.id,
-      organizationId,
-      title: `Story Stream Error ${randomUUID()}`,
-    });
-
-    await activityFixture({
-      generationStatus: "pending",
-      kind: "story",
-      language: "en",
-      lessonId: lesson.id,
-      organizationId,
-      title: `Story ${randomUUID()}`,
-    });
-
-    const activities = await fetchLessonActivities(lesson.id);
-    const storyActivity = activities.find((a) => a.kind === "story")!;
-
-    generateActivityStoryStepsMock.mockRejectedValue(new Error("AI failed"));
-
-    await generateStoryContentStep(activities);
-
-    const events = getStreamedEvents(writeMock);
-
-    expect(events).toContainEqual(
-      expect.objectContaining({
-        entityId: storyActivity.id,
-        status: "error",
         step: "generateStoryContent",
       }),
     );

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-debrief-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-debrief-step.test.ts
@@ -176,9 +176,19 @@ describe(generateStoryDebriefStep, () => {
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: storyActivity.id } });
     expect(updated.generationStatus).toBe("failed");
+
+    const events = getStreamedEvents(writeMock);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        entityId: Number(storyActivity.id),
+        status: "error",
+        step: "generateStoryDebrief",
+      }),
+    );
   });
 
-  test("marks activity as failed when AI call throws", async () => {
+  test("marks activity as failed and streams error when AI call throws", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -208,6 +218,16 @@ describe(generateStoryDebriefStep, () => {
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: storyActivity.id } });
     expect(updated.generationStatus).toBe("failed");
+
+    const events = getStreamedEvents(writeMock);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        entityId: Number(storyActivity.id),
+        status: "error",
+        step: "generateStoryDebrief",
+      }),
+    );
   });
 
   test("streams started and completed events on success", async () => {
@@ -250,43 +270,6 @@ describe(generateStoryDebriefStep, () => {
       expect.objectContaining({
         entityId: Number(storyActivity.id),
         status: "completed",
-        step: "generateStoryDebrief",
-      }),
-    );
-  });
-
-  test("streams error event when AI call fails", async () => {
-    const lesson = await lessonFixture({
-      chapterId: chapter.id,
-      organizationId,
-      title: `Debrief Stream Error ${randomUUID()}`,
-    });
-
-    const storyActivity = await activityFixture({
-      generationStatus: "pending",
-      kind: "story",
-      language: "en",
-      lessonId: lesson.id,
-      organizationId,
-      title: `Story ${randomUUID()}`,
-    });
-
-    const activities = await fetchLessonActivities(lesson.id);
-
-    generateActivityStoryDebriefMock.mockRejectedValue(new Error("AI failed"));
-
-    await generateStoryDebriefStep({
-      activitiesToGenerate: activities,
-      activityId: Number(storyActivity.id),
-      storySteps: mockStorySteps,
-    });
-
-    const events = getStreamedEvents(writeMock);
-
-    expect(events).toContainEqual(
-      expect.objectContaining({
-        entityId: Number(storyActivity.id),
-        status: "error",
         step: "generateStoryDebrief",
       }),
     );

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { fetchLessonActivities } from "@/workflows/_test-utils/fetch-lesson-activities";
 import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { generateActivityVocabulary } from "@zoonk/ai/tasks/activities/language/vocabulary";
+import { prisma } from "@zoonk/db";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -99,7 +100,7 @@ describe(generateVocabularyContentStep, () => {
     );
   });
 
-  test("streams error and returns empty words when AI fails", async () => {
+  test("marks activity as failed and streams error when AI fails", async () => {
     vi.mocked(generateActivityVocabulary).mockRejectedValueOnce(new Error("AI error"));
 
     const lesson = await lessonFixture({
@@ -109,7 +110,7 @@ describe(generateVocabularyContentStep, () => {
       title: `Vocab Content Fail ${randomUUID()}`,
     });
 
-    await activityFixture({
+    const dbActivity = await activityFixture({
       generationStatus: "pending",
       kind: "vocabulary",
       language: "en",
@@ -123,6 +124,9 @@ describe(generateVocabularyContentStep, () => {
 
     expect(result).toEqual({ words: [] });
 
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
+
     const events = getStreamedEvents(writeMock);
 
     expect(events).toContainEqual(
@@ -130,7 +134,7 @@ describe(generateVocabularyContentStep, () => {
     );
   });
 
-  test("streams error when AI returns empty words array", async () => {
+  test("marks activity as failed and streams error when AI returns empty words array", async () => {
     vi.mocked(generateActivityVocabulary).mockResolvedValueOnce({
       data: { words: [] },
     } as never);
@@ -142,7 +146,7 @@ describe(generateVocabularyContentStep, () => {
       title: `Vocab Content Empty ${randomUUID()}`,
     });
 
-    await activityFixture({
+    const dbActivity = await activityFixture({
       generationStatus: "pending",
       kind: "vocabulary",
       language: "en",
@@ -155,6 +159,9 @@ describe(generateVocabularyContentStep, () => {
     const result = await generateVocabularyContentStep(activity!, "workflow-3");
 
     expect(result).toEqual({ words: [] });
+
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
 
     const events = getStreamedEvents(writeMock);
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-romanization-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-romanization-step.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { fetchLessonActivities } from "@/workflows/_test-utils/fetch-lesson-activities";
 import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { generateActivityRomanization } from "@zoonk/ai/tasks/activities/language/romanization";
+import { prisma } from "@zoonk/db";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -154,7 +155,7 @@ describe(generateVocabularyRomanizationStep, () => {
     expect(generateActivityRomanization).not.toHaveBeenCalled();
   });
 
-  test("streams error when AI romanization fails", async () => {
+  test("marks activity as failed and streams error when AI romanization fails", async () => {
     vi.mocked(generateActivityRomanization).mockRejectedValueOnce(new Error("AI error"));
 
     const course = await courseFixture({ organizationId, targetLanguage: "ja" });
@@ -172,7 +173,7 @@ describe(generateVocabularyRomanizationStep, () => {
       title: `Vocab Roman Fail ${randomUUID()}`,
     });
 
-    await activityFixture({
+    const dbActivity = await activityFixture({
       generationStatus: "pending",
       kind: "vocabulary",
       language: "en",
@@ -186,6 +187,9 @@ describe(generateVocabularyRomanizationStep, () => {
 
     expect(result).toEqual({ romanizations: {} });
 
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
+
     const events = getStreamedEvents(writeMock);
 
     expect(events).toContainEqual(
@@ -193,7 +197,7 @@ describe(generateVocabularyRomanizationStep, () => {
     );
   });
 
-  test("streams error when some romanizations are missing", async () => {
+  test("marks activity as failed and streams error when some romanizations are missing", async () => {
     vi.mocked(generateActivityRomanization).mockResolvedValueOnce({
       data: { romanizations: ["neko"] },
     } as never);
@@ -213,7 +217,7 @@ describe(generateVocabularyRomanizationStep, () => {
       title: `Vocab Roman Partial ${randomUUID()}`,
     });
 
-    await activityFixture({
+    const dbActivity = await activityFixture({
       generationStatus: "pending",
       kind: "vocabulary",
       language: "en",
@@ -226,6 +230,9 @@ describe(generateVocabularyRomanizationStep, () => {
     const result = await generateVocabularyRomanizationStep(activities, ["猫", "犬"]);
 
     expect(result.romanizations["猫"]).toBe("neko");
+
+    const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
+    expect(updated.generationStatus).toBe("failed");
 
     const events = getStreamedEvents(writeMock);
 


### PR DESCRIPTION
## Summary
- tighten activity-generation step tests to assert persisted `failed` status when existing rows hit error paths
- strengthen AI error-path tests to verify fallback return values, streamed errors, and DB failure state together
- keep destructive save-failure tests focused on stream behavior when the target row no longer exists

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens activity-generation workflow tests to verify activities persist `generationStatus: failed` and stream error events when generation fails or returns invalid data. Also standardizes failure return shapes across steps to avoid regressions.

- **Bug Fixes**
  - Assert persisted `failed` status for grammar, vocabulary, reading, practice, quiz, story content, and debrief steps when AI calls reject or return empty/missing data.
  - Verify error events are streamed with correct step names and entity IDs.
  - Check stable failure payloads: grammar/user content null, words [], romanizations {} or partial map, quiz { activityId: null, questions: [] }, practice { activityId: null, steps: [] }.
  - Use `@zoonk/db` to read back activities and confirm the stored failure state.

- **Refactors**
  - Consolidated story content/debrief error tests to assert both streamed errors and DB failure state, removing redundant stream-only tests.

<sup>Written for commit a339a8311db4254d75112d565e99e12fe8f42004. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

