### PR TITLE
fix(main): stabilize generation redirects

### DIFF
--- a/apps/main/e2e/generate-activity.test.ts
+++ b/apps/main/e2e/generate-activity.test.ts
@@ -258,6 +258,27 @@ test.describe("Generate Activity Page - No Subscription", () => {
 });
 
 test.describe("Generate Activity Page - With Subscription", () => {
+  test("shows completion UI before redirecting when activity is already ready", async ({
+    page,
+  }) => {
+    const { activity, chapter, course, lesson } = await createPendingActivity();
+
+    await prisma.activity.update({
+      data: { generationStatus: "completed" },
+      where: { id: activity.id },
+    });
+
+    await page.goto(`/generate/a/${activity.id}`);
+
+    await expect(page.getByText(/your activity is ready/i)).toBeVisible();
+    await expect(page.getByText(/taking you to your activity/i)).toBeVisible();
+
+    await page.waitForURL(
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/${activity.position}`,
+      { timeout: 10_000 },
+    );
+  });
+
   test("shows generation UI and completes workflow", async ({
     userWithoutProgress,
     noProgressUser,

--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -5,6 +5,7 @@ import { getAiOrganization } from "@zoonk/e2e/helpers";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
 
@@ -184,6 +185,34 @@ test.describe("Generate Chapter Page - No Subscription", () => {
 });
 
 test.describe("Generate Chapter Page - With Subscription", () => {
+  test("shows completion UI before redirecting when chapter is already ready", async ({ page }) => {
+    const { chapter, course, organizationId } = await createPendingChapter();
+    const uniqueId = randomUUID().slice(0, 8);
+
+    await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        organizationId,
+        slug: `e2e-ready-lesson-${uniqueId}`,
+        title: `E2E Ready Lesson ${uniqueId}`,
+      }),
+      prisma.chapter.update({
+        data: { generationStatus: "completed" },
+        where: { id: chapter.id },
+      }),
+    ]);
+
+    await page.goto(`/generate/ch/${chapter.id}`);
+
+    await expect(page.getByText(/your lessons are ready/i)).toBeVisible();
+    await expect(page.getByText(/taking you to your chapter/i)).toBeVisible();
+
+    await page.waitForURL(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`, {
+      timeout: 10_000,
+    });
+  });
+
   test("shows generation UI and completes workflow", async ({
     userWithoutProgress,
     noProgressUser,

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -6,6 +6,7 @@ import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
 
@@ -194,6 +195,33 @@ test.describe("Generate Lesson Page - No Subscription", () => {
 });
 
 test.describe("Generate Lesson Page - With Subscription", () => {
+  test("shows completion UI before redirecting when lesson is already ready", async ({ page }) => {
+    const { lesson, organizationId } = await createPendingLesson();
+    const uniqueId = randomUUID().slice(0, 8);
+
+    await Promise.all([
+      activityFixture({
+        isPublished: true,
+        lessonId: lesson.id,
+        organizationId,
+        title: `E2E Ready Activity ${uniqueId}`,
+      }),
+      prisma.lesson.update({
+        data: { generationStatus: "completed" },
+        where: { id: lesson.id },
+      }),
+    ]);
+
+    await page.goto(`/generate/l/${lesson.id}`);
+
+    await expect(page.getByText(/your lesson is ready/i)).toBeVisible();
+    await expect(page.getByText(/taking you to your lesson/i)).toBeVisible();
+
+    await page.waitForURL(new RegExp(`/b/${AI_ORG_SLUG}/c/.+/ch/.+/l/${lesson.slug}`), {
+      timeout: 10_000,
+    });
+  });
+
   test("shows generation UI and completes workflow", async ({
     userWithoutProgress,
     noProgressUser,

--- a/apps/main/src/app/generate/a/[id]/generate-activity-content.tsx
+++ b/apps/main/src/app/generate/a/[id]/generate-activity-content.tsx
@@ -1,6 +1,7 @@
 import { LoginRequired } from "@/components/auth/login-required";
 import { SubscriptionGate } from "@/components/subscription/subscription-gate";
 import { getActivityForGeneration } from "@/data/activities/get-activity-for-generation";
+import { getInitialGenerationPageStatus } from "@/lib/workflow/get-initial-generation-page-status";
 import { getSession } from "@zoonk/core/users/session/get";
 import {
   Container,
@@ -14,7 +15,7 @@ import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { parseBigIntId } from "@zoonk/utils/number";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { getExtracted } from "next-intl/server";
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { GenerationClient } from "./generation-client";
 
 export async function GenerateActivityContent({ params }: { params: Promise<{ id: string }> }) {
@@ -42,14 +43,12 @@ export async function GenerateActivityContent({ params }: { params: Promise<{ id
 
   const backLabel = t("Back to lesson");
 
+  const initialStatus = getInitialGenerationPageStatus({
+    generationStatus: activity.generationStatus,
+  });
+
   if (!session && !hasStarted) {
     return <LoginRequired backHref={backHref} backLabel={backLabel} title={t("Create Activity")} />;
-  }
-
-  if (activity.generationStatus === "completed") {
-    redirect(
-      `/b/${AI_ORG_SLUG}/c/${activity.lesson.chapter.course.slug}/ch/${activity.lesson.chapter.slug}/l/${activity.lesson.slug}/a/${activity.position}`,
-    );
   }
 
   return (
@@ -69,7 +68,7 @@ export async function GenerateActivityContent({ params }: { params: Promise<{ id
             chapterSlug={activity.lesson.chapter.slug}
             courseSlug={activity.lesson.chapter.course.slug}
             generationRunId={activity.generationRunId}
-            generationStatus={activity.generationStatus}
+            initialStatus={initialStatus}
             lessonId={activity.lesson.id}
             lessonSlug={activity.lesson.slug}
             position={activity.position}

--- a/apps/main/src/app/generate/a/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/a/[id]/generation-client.tsx
@@ -11,12 +11,13 @@ import {
   GenerationTimelineSubtitle,
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
+import { type GenerationStatus } from "@/lib/workflow/generation-store";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useThinkingMessages } from "@/lib/workflow/use-thinking-messages";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
 import { type ActivityStepName, getActivityCompletionStep } from "@zoonk/core/workflows/steps";
-import { type ActivityKind, type GenerationStatus } from "@zoonk/db";
+import { type ActivityKind } from "@zoonk/db";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { API_URL } from "@zoonk/utils/url";
 import { useExtracted } from "next-intl";
@@ -28,7 +29,7 @@ export function GenerationClient({
   chapterSlug,
   courseSlug,
   generationRunId,
-  generationStatus,
+  initialStatus,
   lessonId,
   lessonSlug,
   position,
@@ -38,7 +39,7 @@ export function GenerationClient({
   chapterSlug: string;
   courseSlug: string;
   generationRunId: string | null;
-  generationStatus: GenerationStatus;
+  initialStatus: GenerationStatus;
   lessonId: number;
   lessonSlug: string;
   position: number;
@@ -51,7 +52,7 @@ export function GenerationClient({
     completionStep,
     entityId: activityId,
     initialRunId: generationRunId,
-    initialStatus: generationStatus === "running" ? "streaming" : "idle",
+    initialStatus,
     statusUrl: `${API_URL}/v1/workflows/activity-generation/status`,
     triggerBody: { lessonId },
     triggerUrl: `${API_URL}/v1/workflows/activity-generation/trigger`,

--- a/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
@@ -1,6 +1,7 @@
 import { LoginRequired } from "@/components/auth/login-required";
 import { SubscriptionGate } from "@/components/subscription/subscription-gate";
 import { getChapterForGeneration } from "@/data/chapters/get-chapter-for-generation";
+import { getInitialGenerationPageStatus } from "@/lib/workflow/get-initial-generation-page-status";
 import { getSession } from "@zoonk/core/users/session/get";
 import {
   Container,
@@ -14,7 +15,7 @@ import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { parseNumericId } from "@zoonk/utils/number";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { getExtracted } from "next-intl/server";
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { GenerationClient } from "./generation-client";
 
 export async function GenerateChapterContent({ params }: { params: Promise<{ id: string }> }) {
@@ -39,20 +40,13 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
   const backHref = `/b/${AI_ORG_SLUG}/c/${chapter.course.slug}` as const;
   const backLabel = t("Back to course");
 
+  const initialStatus = getInitialGenerationPageStatus({
+    generationStatus: chapter.generationStatus,
+    isReadyForRedirect: chapter._count.lessons > 0,
+  });
+
   if (!session && !bypassAuth) {
     return <LoginRequired backHref={backHref} backLabel={backLabel} title={t("Create Chapter")} />;
-  }
-
-  /**
-   * Only redirect when the chapter has actually generated its lessons.
-   * Without the lesson count check, a redirect loop can occur: the chapter
-   * page redirects here when `lessons.length === 0`, and this page redirects
-   * back when `generationStatus === "completed"`. This happens when Next.js
-   * serves a stale prefetched RSC payload for the chapter page that still
-   * shows zero lessons even though they were created in the background.
-   */
-  if (chapter.generationStatus === "completed" && chapter._count.lessons > 0) {
-    redirect(`/b/${AI_ORG_SLUG}/c/${chapter.course.slug}/ch/${chapter.slug}`);
   }
 
   return (
@@ -73,7 +67,7 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
             chapterSlug={chapter.slug}
             courseSlug={chapter.course.slug}
             generationRunId={chapter.generationRunId}
-            generationStatus={chapter.generationStatus}
+            initialStatus={initialStatus}
           />
         </SubscriptionGate>
       </ContainerBody>

--- a/apps/main/src/app/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generation-client.tsx
@@ -11,12 +11,12 @@ import {
   GenerationTimelineSubtitle,
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
+import { type GenerationStatus } from "@/lib/workflow/generation-store";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useThinkingMessages } from "@/lib/workflow/use-thinking-messages";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
 import { CHAPTER_COMPLETION_STEP, type ChapterWorkflowStepName } from "@zoonk/core/workflows/steps";
-import { type GenerationStatus } from "@zoonk/db";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { API_URL } from "@zoonk/utils/url";
 import { useExtracted } from "next-intl";
@@ -27,20 +27,20 @@ export function GenerationClient({
   chapterSlug,
   courseSlug,
   generationRunId,
-  generationStatus,
+  initialStatus,
 }: {
   chapterId: number;
   chapterSlug: string;
   courseSlug: string;
   generationRunId: string | null;
-  generationStatus: GenerationStatus;
+  initialStatus: GenerationStatus;
 }) {
   const t = useExtracted();
 
   const generation = useWorkflowGeneration<ChapterWorkflowStepName>({
     completionStep: CHAPTER_COMPLETION_STEP,
     initialRunId: generationRunId,
-    initialStatus: generationStatus === "running" ? "streaming" : "idle",
+    initialStatus,
     statusUrl: `${API_URL}/v1/workflows/chapter-generation/status`,
     triggerBody: { chapterId },
     triggerUrl: `${API_URL}/v1/workflows/chapter-generation/trigger`,

--- a/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
+++ b/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
@@ -1,6 +1,7 @@
 import { LoginRequired } from "@/components/auth/login-required";
 import { SubscriptionGate } from "@/components/subscription/subscription-gate";
 import { getLessonForGeneration } from "@/data/lessons/get-lesson-for-generation";
+import { getInitialGenerationPageStatus } from "@/lib/workflow/get-initial-generation-page-status";
 import { getSession } from "@zoonk/core/users/session/get";
 import {
   Container,
@@ -14,7 +15,7 @@ import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { parseNumericId } from "@zoonk/utils/number";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { getExtracted } from "next-intl/server";
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { GenerationClient } from "./generation-client";
 
 export async function GenerateLessonContent({ params }: { params: Promise<{ id: string }> }) {
@@ -39,22 +40,13 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
 
   const backLabel = t("Back to chapter");
 
+  const initialStatus = getInitialGenerationPageStatus({
+    generationStatus: lesson.generationStatus,
+    isReadyForRedirect: lesson._count.activities > 0,
+  });
+
   if (!session && !hasStarted) {
     return <LoginRequired backHref={backHref} backLabel={backLabel} title={t("Create Lesson")} />;
-  }
-
-  /**
-   * Only redirect when the lesson has actually generated its activities.
-   * Without the activity count check, a redirect loop can occur: the lesson
-   * page redirects here when `activities.length === 0`, and this page redirects
-   * back when `generationStatus === "completed"`. This happens when Next.js
-   * serves a stale prefetched RSC payload for the lesson page that still
-   * shows zero activities even though they were created in the background.
-   */
-  if (lesson.generationStatus === "completed" && lesson._count.activities > 0) {
-    redirect(
-      `/b/${AI_ORG_SLUG}/c/${lesson.chapter.course.slug}/ch/${lesson.chapter.slug}/l/${lesson.slug}`,
-    );
   }
 
   return (
@@ -72,7 +64,7 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
             chapterSlug={lesson.chapter.slug}
             courseSlug={lesson.chapter.course.slug}
             generationRunId={lesson.generationRunId}
-            generationStatus={lesson.generationStatus}
+            initialStatus={initialStatus}
             lessonId={lessonId}
             lessonSlug={lesson.slug}
           />

--- a/apps/main/src/app/generate/l/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/l/[id]/generation-client.tsx
@@ -11,12 +11,12 @@ import {
   GenerationTimelineSubtitle,
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
+import { type GenerationStatus } from "@/lib/workflow/generation-store";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useThinkingMessages } from "@/lib/workflow/use-thinking-messages";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
 import { LESSON_COMPLETION_STEP, type LessonStepName } from "@zoonk/core/workflows/steps";
-import { type GenerationStatus } from "@zoonk/db";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { API_URL } from "@zoonk/utils/url";
 import { useExtracted } from "next-intl";
@@ -26,14 +26,14 @@ export function GenerationClient({
   chapterSlug,
   courseSlug,
   generationRunId,
-  generationStatus,
+  initialStatus,
   lessonId,
   lessonSlug,
 }: {
   chapterSlug: string;
   courseSlug: string;
   generationRunId: string | null;
-  generationStatus: GenerationStatus;
+  initialStatus: GenerationStatus;
   lessonId: number;
   lessonSlug: string;
 }) {
@@ -42,7 +42,7 @@ export function GenerationClient({
   const generation = useWorkflowGeneration<LessonStepName>({
     completionStep: LESSON_COMPLETION_STEP,
     initialRunId: generationRunId,
-    initialStatus: generationStatus === "running" ? "streaming" : "idle",
+    initialStatus,
     statusUrl: `${API_URL}/v1/workflows/lesson-generation/status`,
     triggerBody: { lessonId },
     triggerUrl: `${API_URL}/v1/workflows/lesson-generation/trigger`,

--- a/apps/main/src/lib/workflow/get-initial-generation-page-status.ts
+++ b/apps/main/src/lib/workflow/get-initial-generation-page-status.ts
@@ -1,0 +1,27 @@
+import { type GenerationStatus as DatabaseGenerationStatus } from "@zoonk/db";
+import { type GenerationStatus as WorkflowGenerationStatus } from "./generation-store";
+
+/**
+ * Generation pages double as a stable waiting room when a workflow finishes
+ * while the user is navigating. In that moment the destination page can still
+ * be served from the router cache with stale child counts, so a server redirect
+ * from `/generate/...` back to the destination can bounce the user forever.
+ *
+ * This helper keeps the page in a client-rendered "completed" state only when
+ * the destination is actually ready. The client can then perform a hard
+ * navigation, which avoids the stale router payload that caused the loop.
+ */
+export function getInitialGenerationPageStatus(params: {
+  generationStatus: DatabaseGenerationStatus;
+  isReadyForRedirect?: boolean;
+}): WorkflowGenerationStatus {
+  if (params.generationStatus === "running") {
+    return "streaming";
+  }
+
+  if (params.generationStatus === "completed" && params.isReadyForRedirect !== false) {
+    return "completed";
+  }
+
+  return "idle";
+}


### PR DESCRIPTION
## Summary
- keep chapter, lesson, and activity generation pages in a stable completion state instead of server redirecting immediately
- reuse the existing client hard navigation after completion to avoid loops caused by stale router cache payloads
- add e2e coverage for generation pages that are already ready when opened

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes redirects for chapter, lesson, and activity generation by showing a completed state first and then performing a client hard navigation to avoid redirect loops. Adds e2e tests for already-ready cases.

- **Bug Fixes**
  - Introduced `getInitialGenerationPageStatus` to derive client `initialStatus` from DB state and only mark as completed when the destination is ready.
  - Removed server redirects from `/generate/*` pages; show completion UI and then hard navigate on the client; updated generation clients to use `initialStatus`.
  - Added e2e tests for activity, lesson, and chapter flows that are already ready, verifying completion UI and final navigation.

<sup>Written for commit 2c80249983b6412cc37f40191c1692f31c0a5096. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

