### PR TITLE
fix(test): stabilize review step e2e

### DIFF
--- a/apps/main/e2e/review-step.test.ts
+++ b/apps/main/e2e/review-step.test.ts
@@ -202,9 +202,13 @@ async function completeReadingStep(page: Page, word1: string, word2: string): Pr
  * keeps the test aligned with the real UI instead of assuming answer controls are
  * always the first stable element to appear.
  */
-async function getVisibleReviewState(
-  page: Page,
-): Promise<"completed" | "pending" | "reading" | "vocab"> {
+async function getVisibleReviewState({
+  completionScoreText,
+  page,
+}: {
+  completionScoreText: string;
+  page: Page;
+}): Promise<"completed" | "pending" | "reading" | "vocab"> {
   if (await page.getByText(/translate this word/i).isVisible()) {
     return "vocab";
   }
@@ -213,7 +217,7 @@ async function getVisibleReviewState(
     return "reading";
   }
 
-  if (await page.getByRole("status").isVisible()) {
+  if (await page.getByText(completionScoreText, { exact: true }).isVisible()) {
     return "completed";
   }
 
@@ -221,18 +225,43 @@ async function getVisibleReviewState(
 }
 
 /**
+ * `expect.poll()` only tells us that a state became visible at least once.
+ * Returning the state from the successful poll avoids a second read that can
+ * land in the middle of the same transition we just waited through.
+ */
+async function waitForVisibleReviewState({
+  completionScoreText,
+  page,
+}: {
+  completionScoreText: string;
+  page: Page;
+}): Promise<"completed" | "reading" | "vocab"> {
+  let reviewState: "completed" | "pending" | "reading" | "vocab" = "pending";
+
+  await expect(async () => {
+    reviewState = await getVisibleReviewState({ completionScoreText, page });
+    expect(reviewState).not.toBe("pending");
+  }).toPass({ timeout: 10_000 });
+
+  if (reviewState === "pending") {
+    throw new Error("Expected review state to be visible");
+  }
+
+  return reviewState;
+}
+
+/**
  * Completes a single step in the review. Steps are shuffled, so we wait for the
  * current visible screen and handle that state directly.
  */
 async function completeAnyStep(
+  completionScoreText: string,
   page: Page,
   translationToWord: Record<string, string>,
   sentenceWord1: string,
   sentenceWord2: string,
 ): Promise<boolean> {
-  await expect.poll(() => getVisibleReviewState(page), { timeout: 10_000 }).not.toBe("pending");
-
-  const reviewState = await getVisibleReviewState(page);
+  const reviewState = await waitForVisibleReviewState({ completionScoreText, page });
 
   if (reviewState === "completed") {
     return false;
@@ -248,7 +277,7 @@ async function completeAnyStep(
     return true;
   }
 
-  throw new Error(`Unexpected review state: ${reviewState}`);
+  throw new Error("Unexpected review state");
 }
 
 /**
@@ -257,12 +286,14 @@ async function completeAnyStep(
  * without relying on an `await` loop.
  */
 async function completeRemainingReviewSteps({
+  completionScoreText,
   page,
   remainingStepCount,
   sentenceWord1,
   sentenceWord2,
   translationToWord,
 }: {
+  completionScoreText: string;
   page: Page;
   remainingStepCount: number;
   sentenceWord1: string;
@@ -274,6 +305,7 @@ async function completeRemainingReviewSteps({
   }
 
   const completedStep = await completeAnyStep(
+    completionScoreText,
     page,
     translationToWord,
     sentenceWord1,
@@ -285,6 +317,7 @@ async function completeRemainingReviewSteps({
   }
 
   await completeRemainingReviewSteps({
+    completionScoreText,
     page,
     remainingStepCount: remainingStepCount - 1,
     sentenceWord1,
@@ -296,6 +329,7 @@ async function completeRemainingReviewSteps({
 test.describe("Review Step", () => {
   test("complete all review steps to reach completion screen", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
+    const completionScoreText = "5/5";
     const sentenceWord1 = `Hola-${uniqueId}`;
     const sentenceWord2 = `amigo-${uniqueId}`;
 
@@ -325,6 +359,7 @@ test.describe("Review Step", () => {
     // Steps are shuffled, so complete each step by detecting its type.
     // 5 total steps: 4 vocabulary + 1 reading
     await completeRemainingReviewSteps({
+      completionScoreText,
       page,
       remainingStepCount: 5,
       sentenceWord1,
@@ -334,7 +369,7 @@ test.describe("Review Step", () => {
 
     // Completion screen
     await expect(page.getByRole("status")).toBeVisible();
-    await expect(page.getByText("5/5")).toBeVisible();
+    await expect(page.getByText(completionScoreText, { exact: true })).toBeVisible();
     await expect(page.getByText(/correct/i)).toBeVisible();
   });
 });

--- a/apps/main/e2e/review-step.test.ts
+++ b/apps/main/e2e/review-step.test.ts
@@ -150,6 +150,7 @@ async function completeVocabStep(
   translationToWord: Record<string, string>,
 ): Promise<void> {
   const radiogroup = page.getByRole("radiogroup", { name: /answer options/i });
+  await expect(radiogroup).toBeVisible();
 
   // Read the displayed translation from the prompt text
   const promptText = await page
@@ -172,7 +173,9 @@ async function completeVocabStep(
       await option.click();
     }
 
-    await expect(option).toHaveAttribute("aria-checked", "true", { timeout: 1000 });
+    await expect(option).toHaveAttribute("aria-checked", "true", {
+      timeout: 1000,
+    });
   }).toPass();
 
   await page.getByRole("button", { name: /check/i }).click();
@@ -194,28 +197,100 @@ async function completeReadingStep(page: Page, word1: string, word2: string): Pr
 }
 
 /**
- * Completes a single step in the review. Steps are shuffled so we detect
- * the type and handle accordingly.
+ * Review screens can briefly be between interactive states while the player swaps
+ * feedback, the next step, and the completion screen. Polling the visible screen
+ * keeps the test aligned with the real UI instead of assuming answer controls are
+ * always the first stable element to appear.
+ */
+async function getVisibleReviewState(
+  page: Page,
+): Promise<"completed" | "pending" | "reading" | "vocab"> {
+  if (await page.getByText(/translate this word/i).isVisible()) {
+    return "vocab";
+  }
+
+  if (await page.getByText(/translate this sentence/i).isVisible()) {
+    return "reading";
+  }
+
+  if (await page.getByRole("status").isVisible()) {
+    return "completed";
+  }
+
+  return "pending";
+}
+
+/**
+ * Completes a single step in the review. Steps are shuffled, so we wait for the
+ * current visible screen and handle that state directly.
  */
 async function completeAnyStep(
   page: Page,
   translationToWord: Record<string, string>,
   sentenceWord1: string,
   sentenceWord2: string,
-): Promise<void> {
-  // Wait for either a radiogroup (vocab) or word bank (reading) to appear
-  const radiogroup = page.getByRole("radiogroup", { name: /answer options/i });
-  const wordBank = page.getByRole("group", { name: /word bank/i });
+): Promise<boolean> {
+  await expect.poll(() => getVisibleReviewState(page), { timeout: 10_000 }).not.toBe("pending");
 
-  await expect(radiogroup.or(wordBank)).toBeVisible();
+  const reviewState = await getVisibleReviewState(page);
 
-  const isVocab = await radiogroup.isVisible();
-
-  if (isVocab) {
-    await completeVocabStep(page, translationToWord);
-  } else {
-    await completeReadingStep(page, sentenceWord1, sentenceWord2);
+  if (reviewState === "completed") {
+    return false;
   }
+
+  if (reviewState === "vocab") {
+    await completeVocabStep(page, translationToWord);
+    return true;
+  }
+
+  if (reviewState === "reading") {
+    await completeReadingStep(page, sentenceWord1, sentenceWord2);
+    return true;
+  }
+
+  throw new Error(`Unexpected review state: ${reviewState}`);
+}
+
+/**
+ * Review steps are sequential: each answer changes which screen appears next.
+ * Recursing through the remaining count keeps that one-at-a-time flow explicit
+ * without relying on an `await` loop.
+ */
+async function completeRemainingReviewSteps({
+  page,
+  remainingStepCount,
+  sentenceWord1,
+  sentenceWord2,
+  translationToWord,
+}: {
+  page: Page;
+  remainingStepCount: number;
+  sentenceWord1: string;
+  sentenceWord2: string;
+  translationToWord: Record<string, string>;
+}): Promise<void> {
+  if (remainingStepCount === 0) {
+    return;
+  }
+
+  const completedStep = await completeAnyStep(
+    page,
+    translationToWord,
+    sentenceWord1,
+    sentenceWord2,
+  );
+
+  if (!completedStep) {
+    return;
+  }
+
+  await completeRemainingReviewSteps({
+    page,
+    remainingStepCount: remainingStepCount - 1,
+    sentenceWord1,
+    sentenceWord2,
+    translationToWord,
+  });
 }
 
 test.describe("Review Step", () => {
@@ -249,13 +324,16 @@ test.describe("Review Step", () => {
 
     // Steps are shuffled, so complete each step by detecting its type.
     // 5 total steps: 4 vocabulary + 1 reading
-    await completeAnyStep(page, translationToWord, sentenceWord1, sentenceWord2);
-    await completeAnyStep(page, translationToWord, sentenceWord1, sentenceWord2);
-    await completeAnyStep(page, translationToWord, sentenceWord1, sentenceWord2);
-    await completeAnyStep(page, translationToWord, sentenceWord1, sentenceWord2);
-    await completeAnyStep(page, translationToWord, sentenceWord1, sentenceWord2);
+    await completeRemainingReviewSteps({
+      page,
+      remainingStepCount: 5,
+      sentenceWord1,
+      sentenceWord2,
+      translationToWord,
+    });
 
     // Completion screen
+    await expect(page.getByRole("status")).toBeVisible();
     await expect(page.getByText("5/5")).toBeVisible();
     await expect(page.getByText(/correct/i)).toBeVisible();
   });


### PR DESCRIPTION
## Summary
- make the review-step E2E helper wait for the visible review screen state instead of assuming answer controls appear first
- handle the completion screen explicitly so the test does not time out between the last continue and the score screen

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the Review Step E2E by waiting on the visible screen state and avoiding state races, and handles the completion screen so the test doesn’t time out. Reduces flakiness during UI transitions.

- **Bug Fixes**
  - Polls for the visible review state (`vocab`, `reading`, `completed`) and uses that polled value to avoid re-read races.
  - Waits for vocab controls before interacting and confirms completion via `role=status` with the exact score text.

- **Refactors**
  - Replaced five explicit calls with a recursive count-based helper that completes remaining steps and exits on `completed`.

<sup>Written for commit 5c4b6eb0450cfca6f3a231c04c9c10471156a477. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

