### PR TITLE
refactor(core): split story outcome and debrief into separate static steps

### DIFF
--- a/apps/api/src/workflows/activity-generation/kinds/story-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/story-workflow.test.ts
@@ -147,8 +147,8 @@ describe("story activity workflow", () => {
       where: { activityId: storyActivity.id },
     });
 
-    // 1 intro + 2 decision steps + 1 debrief = 4
-    expect(steps).toHaveLength(4);
+    // 1 intro + 2 decision steps + 1 outcome + 1 debrief = 5
+    expect(steps).toHaveLength(5);
 
     // Intro step: static with storyIntro variant
     expect(steps[0]?.kind).toBe("static");
@@ -161,10 +161,15 @@ describe("story activity workflow", () => {
     expect(steps[2]?.kind).toBe("story");
     expect(steps[2]?.position).toBe(2);
 
-    // Debrief step: static with storyDebrief variant
+    // Outcome step: static with storyOutcome variant
     expect(steps[3]?.kind).toBe("static");
     expect(steps[3]?.position).toBe(3);
-    expect(getString(steps[3]?.content, "variant")).toBe("storyDebrief");
+    expect(getString(steps[3]?.content, "variant")).toBe("storyOutcome");
+
+    // Debrief step: static with storyDebrief variant
+    expect(steps[4]?.kind).toBe("static");
+    expect(steps[4]?.position).toBe(4);
+    expect(getString(steps[4]?.content, "variant")).toBe("storyDebrief");
 
     for (const step of steps) {
       expect(step.isPublished).toBe(true);

--- a/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.test.ts
@@ -136,8 +136,8 @@ describe(saveStoryActivityStep, () => {
       }),
     ]);
 
-    // 1 intro + 2 decision steps + 1 debrief = 4
-    expect(dbSteps).toHaveLength(4);
+    // 1 intro + 2 decision steps + 1 outcome + 1 debrief = 5
+    expect(dbSteps).toHaveLength(5);
 
     // Intro: static with storyIntro variant at position 0
     expect(dbSteps[0]?.kind).toBe("static");
@@ -150,10 +150,15 @@ describe(saveStoryActivityStep, () => {
     expect(dbSteps[2]?.kind).toBe("story");
     expect(dbSteps[2]?.position).toBe(2);
 
-    // Debrief: static with storyDebrief variant at position 3
+    // Outcome: static with storyOutcome variant at position 3
     expect(dbSteps[3]?.kind).toBe("static");
     expect(dbSteps[3]?.position).toBe(3);
-    expect(getString(dbSteps[3]?.content, "variant")).toBe("storyDebrief");
+    expect(getString(dbSteps[3]?.content, "variant")).toBe("storyOutcome");
+
+    // Debrief: static with storyDebrief variant at position 4
+    expect(dbSteps[4]?.kind).toBe("static");
+    expect(dbSteps[4]?.position).toBe(4);
+    expect(getString(dbSteps[4]?.content, "variant")).toBe("storyDebrief");
 
     // All steps are published
     for (const step of dbSteps) {

--- a/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.ts
@@ -12,7 +12,8 @@ import { handleActivityFailureStep } from "./handle-failure-step";
  *
  * - Position 0: static intro step (scene setup + metric definitions)
  * - Positions 1..N: story decision steps (situation + choices)
- * - Position N+1: static debrief step (outcomes + concept reveals)
+ * - Position N+1: static outcome step (narrative results + final metrics)
+ * - Position N+2: static debrief step (hidden concept reveals)
  */
 function buildStoryStepRecords(
   activityId: number,
@@ -42,26 +43,38 @@ function buildStoryStepRecords(
     position: index + 1,
   }));
 
-  const debriefRecord = {
+  const outcomeRecord = {
     activityId,
     content: assertStepContent("static", {
-      debrief: debriefData.debrief,
+      metrics: storySteps.metrics,
       outcomes: debriefData.outcomes,
-      variant: "storyDebrief" as const,
+      variant: "storyOutcome" as const,
     }),
     isPublished: true,
     kind: "static" as const,
     position: storySteps.steps.length + 1,
   };
 
-  return [introRecord, ...decisionRecords, debriefRecord];
+  const debriefRecord = {
+    activityId,
+    content: assertStepContent("static", {
+      debrief: debriefData.debrief,
+      variant: "storyDebrief" as const,
+    }),
+    isPublished: true,
+    kind: "static" as const,
+    position: storySteps.steps.length + 2,
+  };
+
+  return [introRecord, ...decisionRecords, outcomeRecord, debriefRecord];
 }
 
 /**
  * Persists all generated story data in one transaction:
  * - Static intro step with metrics
  * - Interactive decision steps with choices and consequences
- * - Static debrief step with outcomes and concept reveals
+ * - Static outcome step with narrative results and final metrics
+ * - Static debrief step with hidden concept reveals
  * - Marks the activity as completed
  *
  * This is the single save point for a story entity.

--- a/packages/core/src/steps/content-contract.test.ts
+++ b/packages/core/src/steps/content-contract.test.ts
@@ -330,16 +330,37 @@ describe("step content contracts", () => {
     });
   });
 
+  describe("static storyOutcome", () => {
+    test("parses outcome with metrics", () => {
+      const content = parseStepContent("static", {
+        metrics: ["Production", "Morale"],
+        outcomes: [
+          { minStrongChoices: 4, narrative: "Your factory thrives.", title: "Master Manager" },
+          { minStrongChoices: 0, narrative: "Things fell apart.", title: "Learning Moment" },
+        ],
+        variant: "storyOutcome",
+      });
+
+      expect(content.variant).toBe("storyOutcome");
+    });
+
+    test("rejects negative minStrongChoices", () => {
+      expect(() =>
+        parseStepContent("static", {
+          metrics: ["Production"],
+          outcomes: [{ minStrongChoices: -1, narrative: "Bad.", title: "Bad" }],
+          variant: "storyOutcome",
+        }),
+      ).toThrow();
+    });
+  });
+
   describe("static storyDebrief", () => {
-    test("parses debrief with outcomes", () => {
+    test("parses debrief with concepts", () => {
       const content = parseStepContent("static", {
         debrief: [
           { explanation: "When you chose X, you experienced Y.", name: "Kanban" },
           { explanation: "Pulling work based on demand.", name: "Pull System" },
-        ],
-        outcomes: [
-          { minStrongChoices: 4, narrative: "Your factory thrives.", title: "Master Manager" },
-          { minStrongChoices: 0, narrative: "Things fell apart.", title: "Learning Moment" },
         ],
         variant: "storyDebrief",
       });
@@ -347,11 +368,11 @@ describe("step content contracts", () => {
       expect(content.variant).toBe("storyDebrief");
     });
 
-    test("rejects negative minStrongChoices", () => {
+    test("rejects outcomes in debrief", () => {
       expect(() =>
         parseStepContent("static", {
           debrief: [{ explanation: "Test.", name: "Concept" }],
-          outcomes: [{ minStrongChoices: -1, narrative: "Bad.", title: "Bad" }],
+          outcomes: [{ minStrongChoices: 0, narrative: "Bad.", title: "Bad" }],
           variant: "storyDebrief",
         }),
       ).toThrow();

--- a/packages/core/src/steps/content-contract.ts
+++ b/packages/core/src/steps/content-contract.ts
@@ -127,13 +127,24 @@ const staticStoryIntroContentSchema = z
   .strict();
 
 /**
+ * Outcome screen for a story activity (static step, second-to-last position).
+ * Shows the narrative result of the player's decisions alongside final metric values.
+ */
+const staticStoryOutcomeContentSchema = z
+  .object({
+    metrics: z.array(z.string()).min(1),
+    outcomes: z.array(storyOutcomeSchema).min(1),
+    variant: z.literal("storyOutcome"),
+  })
+  .strict();
+
+/**
  * Debrief screen for a story activity (static step, last position).
- * Reveals hidden concepts and shows outcome based on player's choices.
+ * Reveals the hidden concepts the player practiced through the story.
  */
 const staticStoryDebriefContentSchema = z
   .object({
     debrief: z.array(storyDebriefConceptSchema).min(1),
-    outcomes: z.array(storyOutcomeSchema).min(1),
     variant: z.literal("storyDebrief"),
   })
   .strict();
@@ -143,6 +154,7 @@ const staticContentSchema = z.discriminatedUnion("variant", [
   staticGrammarExampleContentSchema,
   staticGrammarRuleContentSchema,
   staticStoryIntroContentSchema,
+  staticStoryOutcomeContentSchema,
   staticStoryDebriefContentSchema,
 ]);
 

--- a/packages/player/src/components/static-step.tsx
+++ b/packages/player/src/components/static-step.tsx
@@ -69,7 +69,11 @@ function StaticStepContent({ step }: { step: SerializedStep }) {
     return <GrammarRuleVariant ruleName={content.ruleName} ruleSummary={content.ruleSummary} />;
   }
 
-  if (content.variant === "storyIntro" || content.variant === "storyDebrief") {
+  if (
+    content.variant === "storyIntro" ||
+    content.variant === "storyOutcome" ||
+    content.variant === "storyDebrief"
+  ) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

- Add `storyOutcome` static variant with `outcomes` + `metrics` fields
- Narrow `storyDebrief` to only contain `debrief` (concept reveals)
- Split save layer to create separate outcome (N+1) and debrief (N+2) steps

Closes #1181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split story outcome and debrief into two static steps for clearer UX and stricter schemas: new `storyOutcome` (outcomes + metrics) at N+1, and a narrowed `storyDebrief` (concept reveals only) at N+2. Implements the separation requested in #1181.

- New Features
  - Added `storyOutcome` static variant with `outcomes` and `metrics`; enforced in `packages/core` content contract.
  - Narrowed `storyDebrief` to only `debrief`; outcomes are rejected by schema.
  - Updated `apps/api` save step to create intro, decisions, `storyOutcome` (N+1), then `storyDebrief` (N+2); tests updated.
  - `packages/player` recognizes `storyOutcome` and continues to no-op render for static story variants.

- Migration
  - Split any existing `storyDebrief` content that includes `outcomes`: create a new `storyOutcome` step with those outcomes and metrics, and remove outcomes from the debrief step. Regenerate or backfill persisted stories to satisfy the new schema.

<sup>Written for commit ce881789ae9e0cdf810b8fdd3359feaaab0fae03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

