### PR TITLE
feat(player): add story player UI components and catalog integration

### DIFF
--- a/apps/api/src/workflows/activity-generation/kinds/story-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/story-workflow.test.ts
@@ -147,8 +147,8 @@ describe("story activity workflow", () => {
       where: { activityId: storyActivity.id },
     });
 
-    // 1 intro + 2 decision steps + 1 outcome + 1 debrief = 5
-    expect(steps).toHaveLength(5);
+    // 1 intro + 2 decision steps + 1 outcome + 2 debrief concepts = 6
+    expect(steps).toHaveLength(6);
 
     // Intro step: static with storyIntro variant
     expect(steps[0]?.kind).toBe("static");
@@ -166,10 +166,16 @@ describe("story activity workflow", () => {
     expect(steps[3]?.position).toBe(3);
     expect(getString(steps[3]?.content, "variant")).toBe("storyOutcome");
 
-    // Debrief step: static with storyDebrief variant
+    // Debrief concepts: individual text steps
     expect(steps[4]?.kind).toBe("static");
     expect(steps[4]?.position).toBe(4);
-    expect(getString(steps[4]?.content, "variant")).toBe("storyDebrief");
+    expect(getString(steps[4]?.content, "variant")).toBe("text");
+    expect(getString(steps[4]?.content, "title")).toBe("Crisis Communication");
+
+    expect(steps[5]?.kind).toBe("static");
+    expect(steps[5]?.position).toBe(5);
+    expect(getString(steps[5]?.content, "variant")).toBe("text");
+    expect(getString(steps[5]?.content, "title")).toBe("Supply Chain Resilience");
 
     for (const step of steps) {
       expect(step.isPublished).toBe(true);

--- a/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.test.ts
@@ -136,8 +136,8 @@ describe(saveStoryActivityStep, () => {
       }),
     ]);
 
-    // 1 intro + 2 decision steps + 1 outcome + 1 debrief = 5
-    expect(dbSteps).toHaveLength(5);
+    // 1 intro + 2 decision steps + 1 outcome + 2 debrief concepts = 6
+    expect(dbSteps).toHaveLength(6);
 
     // Intro: static with storyIntro variant at position 0
     expect(dbSteps[0]?.kind).toBe("static");
@@ -155,10 +155,16 @@ describe(saveStoryActivityStep, () => {
     expect(dbSteps[3]?.position).toBe(3);
     expect(getString(dbSteps[3]?.content, "variant")).toBe("storyOutcome");
 
-    // Debrief: static with storyDebrief variant at position 4
+    // Debrief concepts: individual text steps at positions 4 and 5
     expect(dbSteps[4]?.kind).toBe("static");
     expect(dbSteps[4]?.position).toBe(4);
-    expect(getString(dbSteps[4]?.content, "variant")).toBe("storyDebrief");
+    expect(getString(dbSteps[4]?.content, "variant")).toBe("text");
+    expect(getString(dbSteps[4]?.content, "title")).toBe("Crisis Communication");
+
+    expect(dbSteps[5]?.kind).toBe("static");
+    expect(dbSteps[5]?.position).toBe(5);
+    expect(getString(dbSteps[5]?.content, "variant")).toBe("text");
+    expect(getString(dbSteps[5]?.content, "title")).toBe("Supply Chain Resilience");
 
     // All steps are published
     for (const step of dbSteps) {

--- a/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.ts
@@ -13,7 +13,7 @@ import { handleActivityFailureStep } from "./handle-failure-step";
  * - Position 0: static intro step (scene setup + metric definitions)
  * - Positions 1..N: story decision steps (situation + choices)
  * - Position N+1: static outcome step (narrative results + final metrics)
- * - Position N+2: static debrief step (hidden concept reveals)
+ * - Positions N+2..N+2+M: static text steps, one per debrief concept
  */
 function buildStoryStepRecords(
   activityId: number,
@@ -55,18 +55,19 @@ function buildStoryStepRecords(
     position: storySteps.steps.length + 1,
   };
 
-  const debriefRecord = {
+  const debriefRecords = debriefData.debrief.map((concept, index) => ({
     activityId,
     content: assertStepContent("static", {
-      debrief: debriefData.debrief,
-      variant: "storyDebrief" as const,
+      text: concept.explanation,
+      title: concept.name,
+      variant: "text" as const,
     }),
     isPublished: true,
     kind: "static" as const,
-    position: storySteps.steps.length + 2,
-  };
+    position: storySteps.steps.length + 2 + index,
+  }));
 
-  return [introRecord, ...decisionRecords, outcomeRecord, debriefRecord];
+  return [introRecord, ...decisionRecords, outcomeRecord, ...debriefRecords];
 }
 
 /**
@@ -74,7 +75,7 @@ function buildStoryStepRecords(
  * - Static intro step with metrics
  * - Interactive decision steps with choices and consequences
  * - Static outcome step with narrative results and final metrics
- * - Static debrief step with hidden concept reveals
+ * - Static text steps for each debrief concept (one per concept)
  * - Marks the activity as completed
  *
  * This is the single save point for a story entity.

--- a/apps/main/e2e/multiple-choice-step.test.ts
+++ b/apps/main/e2e/multiple-choice-step.test.ts
@@ -380,6 +380,39 @@ test.describe("Interaction Mechanics", () => {
     );
   });
 
+  test("clicking a selected option unselects it", async ({ page }) => {
+    const { url } = await createMultipleChoiceActivity({
+      steps: [
+        {
+          content: {
+            kind: "core",
+            options: [
+              { feedback: "No", isCorrect: false, text: "Toggle A" },
+              { feedback: "Yes", isCorrect: true, text: "Toggle B" },
+            ],
+            question: "Toggle test",
+          },
+          position: 0,
+        },
+      ],
+    });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const option = page.getByRole("radio", { name: /toggle a/i });
+
+    // Select the option
+    await option.click();
+    await expect(option).toHaveAttribute("aria-checked", "true");
+    await expect(page.getByRole("button", { name: /check/i })).toBeEnabled();
+
+    // Click again to unselect
+    await option.click();
+    await expect(option).toHaveAttribute("aria-checked", "false");
+    await expect(page.getByRole("button", { name: /check/i })).toBeDisabled();
+  });
+
   test("feedback screen replaces step after checking", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const { url } = await createMultipleChoiceActivity({

--- a/apps/main/e2e/story-step.test.ts
+++ b/apps/main/e2e/story-step.test.ts
@@ -1,0 +1,416 @@
+import { randomUUID } from "node:crypto";
+import { getAiOrganization } from "@zoonk/e2e/helpers";
+import { activityFixture } from "@zoonk/testing/fixtures/activities";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { expect, test } from "./fixtures";
+
+function buildStoryContent(uniqueId: string) {
+  return {
+    debriefConcepts: [
+      {
+        content: {
+          text: `Training investment builds capacity ${uniqueId}`,
+          title: `Resource Allocation ${uniqueId}`,
+          variant: "text" as const,
+        },
+        kind: "static" as const,
+      },
+    ],
+    decisions: [
+      {
+        content: {
+          choices: [
+            {
+              alignment: "strong" as const,
+              consequence: `Production surges ${uniqueId}`,
+              id: `choice-1a-${uniqueId}`,
+              metricEffects: [
+                { effect: "positive" as const, metric: "Production" },
+                { effect: "positive" as const, metric: "Morale" },
+              ],
+              text: `Invest in training ${uniqueId}`,
+            },
+            {
+              alignment: "partial" as const,
+              consequence: `Mixed results ${uniqueId}`,
+              id: `choice-1b-${uniqueId}`,
+              metricEffects: [
+                { effect: "neutral" as const, metric: "Production" },
+                { effect: "positive" as const, metric: "Morale" },
+              ],
+              text: `Hire consultants ${uniqueId}`,
+            },
+            {
+              alignment: "weak" as const,
+              consequence: `Morale drops ${uniqueId}`,
+              id: `choice-1c-${uniqueId}`,
+              metricEffects: [
+                { effect: "negative" as const, metric: "Production" },
+                { effect: "negative" as const, metric: "Morale" },
+              ],
+              text: `Cut costs ${uniqueId}`,
+            },
+          ],
+          situation: `A crisis hits the factory floor ${uniqueId}`,
+        },
+        kind: "story" as const,
+      },
+    ],
+    intro: {
+      content: {
+        intro: `You are a factory manager ${uniqueId}. Your decisions shape the outcome.`,
+        metrics: ["Production", "Morale"],
+        variant: "storyIntro" as const,
+      },
+      kind: "static" as const,
+    },
+    outcome: {
+      content: {
+        metrics: ["Production", "Morale"],
+        outcomes: [
+          {
+            minStrongChoices: 1,
+            narrative: `Excellent leadership ${uniqueId}`,
+            title: `Great Manager ${uniqueId}`,
+          },
+          {
+            minStrongChoices: 0,
+            narrative: `Room for improvement ${uniqueId}`,
+            title: `Average Manager ${uniqueId}`,
+          },
+        ],
+        variant: "storyOutcome" as const,
+      },
+      kind: "static" as const,
+    },
+  };
+}
+
+async function createStoryActivity() {
+  const org = await getAiOrganization();
+  const uniqueId = randomUUID().slice(0, 8);
+  const storyContent = buildStoryContent(uniqueId);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-story-course-${uniqueId}`,
+    title: `E2E Story Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-story-chapter-${uniqueId}`,
+    title: `E2E Story Chapter ${uniqueId}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    description: `E2E story lesson ${uniqueId}`,
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-story-lesson-${uniqueId}`,
+    title: `E2E Story Lesson ${uniqueId}`,
+  });
+
+  const activity = await activityFixture({
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "story",
+    lessonId: lesson.id,
+    organizationId: org.id,
+    position: 0,
+    title: `E2E Story Activity ${uniqueId}`,
+  });
+
+  await Promise.all([
+    stepFixture({
+      activityId: activity.id,
+      content: storyContent.intro.content,
+      isPublished: true,
+      kind: storyContent.intro.kind,
+      position: 0,
+    }),
+    ...storyContent.decisions.map((decision, index) =>
+      stepFixture({
+        activityId: activity.id,
+        content: decision.content,
+        isPublished: true,
+        kind: decision.kind,
+        position: index + 1,
+      }),
+    ),
+    stepFixture({
+      activityId: activity.id,
+      content: storyContent.outcome.content,
+      isPublished: true,
+      kind: storyContent.outcome.kind,
+      position: storyContent.decisions.length + 1,
+    }),
+    ...storyContent.debriefConcepts.map((concept, index) =>
+      stepFixture({
+        activityId: activity.id,
+        content: concept.content,
+        isPublished: true,
+        kind: concept.kind,
+        position: storyContent.decisions.length + 2 + index,
+      }),
+    ),
+    activityFixture({
+      generationStatus: "completed",
+      isPublished: true,
+      kind: "explanation",
+      lessonId: lesson.id,
+      organizationId: org.id,
+      position: 1,
+    }),
+  ]);
+
+  const url = `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/0`;
+
+  return { uniqueId, url };
+}
+
+test.describe("Story Intro Screen", () => {
+  test("renders intro text and Begin button", async ({ page }) => {
+    const { uniqueId, url } = await createStoryActivity();
+
+    await page.goto(url);
+
+    await expect(page.getByText(new RegExp(`You are a factory manager ${uniqueId}`))).toBeVisible();
+
+    await expect(page.getByRole("button", { name: /begin/i })).toBeVisible();
+
+    // Metric labels and starting values visible
+    await expect(page.getByText("Production")).toBeVisible();
+    await expect(page.getByText("Morale")).toBeVisible();
+  });
+
+  test("Begin button advances to first decision step", async ({ page }) => {
+    const { uniqueId, url } = await createStoryActivity();
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("button", { name: /begin/i }).click();
+
+    await expect(
+      page.getByText(new RegExp(`A crisis hits the factory floor ${uniqueId}`)),
+    ).toBeVisible();
+  });
+
+  test("Enter key advances from intro to decision step", async ({ page }) => {
+    const { uniqueId, url } = await createStoryActivity();
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    await page.keyboard.press("Enter");
+
+    await expect(
+      page.getByText(new RegExp(`A crisis hits the factory floor ${uniqueId}`)),
+    ).toBeVisible();
+  });
+});
+
+test.describe("Story Decision Step", () => {
+  test("renders situation text and choice cards", async ({ page }) => {
+    const { uniqueId, url } = await createStoryActivity();
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    // Navigate past intro
+    await page.getByRole("button", { name: /begin/i }).click();
+
+    // Situation text visible
+    await expect(
+      page.getByText(new RegExp(`A crisis hits the factory floor ${uniqueId}`)),
+    ).toBeVisible();
+
+    // Choice cards visible as radio buttons
+    const radiogroup = page.getByRole("radiogroup", { name: /answer options/i });
+    await expect(radiogroup).toBeVisible();
+
+    await expect(
+      radiogroup.getByRole("radio", { name: new RegExp(`Invest in training ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(
+      radiogroup.getByRole("radio", { name: new RegExp(`Hire consultants ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(
+      radiogroup.getByRole("radio", { name: new RegExp(`Cut costs ${uniqueId}`) }),
+    ).toBeVisible();
+  });
+
+  test("briefing popover shows intro text on decision steps", async ({ page }) => {
+    const { uniqueId, url } = await createStoryActivity();
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    // Briefing icon not visible on intro screen (only on decision steps)
+    await expect(page.getByRole("button", { name: /briefing/i })).not.toBeVisible();
+
+    // Navigate to decision step
+    await page.getByRole("button", { name: /begin/i }).click();
+
+    // Briefing icon now visible
+    const briefingButton = page.getByRole("button", { name: /briefing/i });
+    await expect(briefingButton).toBeVisible();
+
+    // Click to open popover
+    await briefingButton.click();
+
+    // Popover shows intro text
+    await expect(page.getByText(new RegExp(`You are a factory manager ${uniqueId}`))).toBeVisible();
+  });
+
+  test("number key shortcuts select choices", async ({ page }) => {
+    const { url } = await createStoryActivity();
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("button", { name: /begin/i }).click();
+    await page.waitForLoadState("networkidle");
+
+    // Press 1 to select first choice
+    await page.keyboard.press("1");
+
+    // Check button should be enabled
+    await expect(page.getByRole("button", { name: /check/i })).toBeEnabled();
+  });
+
+  test("clicking a selected choice unselects it", async ({ page }) => {
+    const { uniqueId, url } = await createStoryActivity();
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("button", { name: /begin/i }).click();
+
+    const choice = page.getByRole("radio", {
+      name: new RegExp(`Invest in training ${uniqueId}`, "i"),
+    });
+
+    // Select the choice
+    await choice.click();
+    await expect(choice).toHaveAttribute("aria-checked", "true");
+    await expect(page.getByRole("button", { name: /check/i })).toBeEnabled();
+
+    // Click again to unselect
+    await choice.click();
+    await expect(choice).toHaveAttribute("aria-checked", "false");
+    await expect(page.getByRole("button", { name: /check/i })).toBeDisabled();
+  });
+});
+
+test.describe("Story Consequence Feedback", () => {
+  test("shows consequence text without correct/incorrect framing", async ({ page }) => {
+    const { uniqueId, url } = await createStoryActivity();
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    // Navigate to decision step
+    await page.getByRole("button", { name: /begin/i }).click();
+    await page.waitForLoadState("networkidle");
+
+    // Select first choice and check
+    await page
+      .getByRole("radio", { name: new RegExp(`Invest in training ${uniqueId}`, "i") })
+      .click();
+    await page.getByRole("button", { name: /check/i }).click();
+
+    // Consequence text visible
+    await expect(page.getByText(new RegExp(`Production surges ${uniqueId}`))).toBeVisible();
+
+    // No correct/incorrect framing
+    await expect(page.getByText(/your answer/i)).not.toBeVisible();
+    await expect(page.getByText(/correct answer/i)).not.toBeVisible();
+  });
+});
+
+test.describe("Full Story Flow", () => {
+  test("intro -> decision -> feedback -> outcome -> debrief -> completion", async ({ page }) => {
+    const { uniqueId, url } = await createStoryActivity();
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    // Step 1: Intro
+    await expect(page.getByText(new RegExp(`You are a factory manager ${uniqueId}`))).toBeVisible();
+    await page.getByRole("button", { name: /begin/i }).click();
+
+    // Step 2: Decision
+    await expect(
+      page.getByText(new RegExp(`A crisis hits the factory floor ${uniqueId}`)),
+    ).toBeVisible();
+
+    // Select a choice and check
+    await page
+      .getByRole("radio", { name: new RegExp(`Invest in training ${uniqueId}`, "i") })
+      .click();
+    await page.getByRole("button", { name: /check/i }).click();
+
+    // Step 3: Consequence feedback
+    await expect(page.getByText(new RegExp(`Production surges ${uniqueId}`))).toBeVisible();
+
+    // Continue to outcome
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 4: Outcome
+    await expect(page.getByText(new RegExp(`Great Manager ${uniqueId}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`Excellent leadership ${uniqueId}`))).toBeVisible();
+
+    // Continue to debrief concept (now a regular text step)
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 5: Debrief concept rendered as text step (title = concept name, body = explanation)
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Resource Allocation ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(new RegExp(`Training investment builds capacity ${uniqueId}`)),
+    ).toBeVisible();
+
+    // Navigate past the last step to completion
+    await page.keyboard.press("ArrowRight");
+
+    // Step 6: Completion screen
+    await expect(page.getByRole("status")).toBeVisible();
+  });
+});
+
+test.describe("Story Debrief", () => {
+  test("debrief concepts render as individual text steps", async ({ page }) => {
+    const { uniqueId, url } = await createStoryActivity();
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    // Navigate through story to debrief
+    await page.getByRole("button", { name: /begin/i }).click();
+
+    await page
+      .getByRole("radio", { name: new RegExp(`Invest in training ${uniqueId}`, "i") })
+      .click();
+    await page.getByRole("button", { name: /check/i }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Debrief concept shows as regular text step with title and body
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Resource Allocation ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(new RegExp(`Training investment builds capacity ${uniqueId}`)),
+    ).toBeVisible();
+  });
+});

--- a/apps/main/e2e/story-step.test.ts
+++ b/apps/main/e2e/story-step.test.ts
@@ -337,6 +337,43 @@ test.describe("Story Consequence Feedback", () => {
   });
 });
 
+test.describe("Story Metrics Bar", () => {
+  test("metrics bar visible only on decision and feedback steps", async ({ page }) => {
+    const { uniqueId, url } = await createStoryActivity();
+    const metricsBar = page.getByRole("status", { name: /current status/i });
+
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    // Intro: no metrics bar
+    await expect(page.getByRole("button", { name: /begin/i })).toBeVisible();
+    await expect(metricsBar).not.toBeVisible();
+
+    // Decision step: metrics bar visible
+    await page.getByRole("button", { name: /begin/i }).click();
+    await expect(metricsBar).toBeVisible();
+
+    // Check answer → feedback: metrics bar still visible
+    await page
+      .getByRole("radio", { name: new RegExp(`Invest in training ${uniqueId}`, "i") })
+      .click();
+    await page.getByRole("button", { name: /check/i }).click();
+    await expect(metricsBar).toBeVisible();
+
+    // Continue to outcome: no metrics bar
+    await page.getByRole("button", { name: /continue/i }).click();
+    await expect(page.getByText(new RegExp(`Great Manager ${uniqueId}`))).toBeVisible();
+    await expect(metricsBar).not.toBeVisible();
+
+    // Continue to debrief text step: no metrics bar
+    await page.getByRole("button", { name: /continue/i }).click();
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Resource Allocation ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(metricsBar).not.toBeVisible();
+  });
+});
+
 test.describe("Full Story Flow", () => {
   test("intro -> decision -> feedback -> outcome -> debrief -> completion", async ({ page }) => {
     const { uniqueId, url } = await createStoryActivity();

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -70,6 +70,12 @@ msgctxt "xiSVL4"
 msgid "{color} Belt — Level {level}"
 msgstr "{color} Belt — Level {level}"
 
+#: ../../packages/player/src/components/choice-step-layout.tsx
+#: ../../packages/player/src/components/translation-step.tsx
+msgctxt "akd+cv"
+msgid "Answer options"
+msgstr "Answer options"
+
 #: ../../packages/player/src/components/completion-auth-branch.tsx
 msgctxt "9+Ddtu"
 msgid "Next"
@@ -226,12 +232,6 @@ msgctxt "ja1JDt"
 msgid "All pairs matched. Press Check to continue."
 msgstr "All pairs matched. Press Check to continue."
 
-#: ../../packages/player/src/components/multiple-choice-step.tsx
-#: ../../packages/player/src/components/translation-step.tsx
-msgctxt "akd+cv"
-msgid "Answer options"
-msgstr "Answer options"
-
 #: ../../packages/player/src/components/play-audio-button.tsx
 msgctxt "lYWSeP"
 msgid "Play pronunciation"
@@ -278,6 +278,11 @@ msgid "Continue"
 msgstr "Continue"
 
 #: ../../packages/player/src/components/player-shell.tsx
+msgctxt "PVe26p"
+msgid "Begin"
+msgstr "Begin"
+
+#: ../../packages/player/src/components/player-shell.tsx
 msgctxt "RDZVQL"
 msgid "Check"
 msgstr "Check"
@@ -315,6 +320,26 @@ msgstr "Sort items"
 msgctxt "VA8c/A"
 msgid "Correct order:"
 msgstr "Correct order:"
+
+#: ../../packages/player/src/components/story-briefing-popover.tsx
+msgctxt "XyeasA"
+msgid "Briefing"
+msgstr "Briefing"
+
+#: ../../packages/player/src/components/story-feedback-content.tsx
+msgctxt "jSeUY4"
+msgid "Metric changes"
+msgstr "Metric changes"
+
+#: ../../packages/player/src/components/story-intro-content.tsx
+msgctxt "pFm27r"
+msgid "Current status"
+msgstr "Current status"
+
+#: ../../packages/player/src/components/story-outcome-content.tsx
+msgctxt "ZJ5JQC"
+msgid "Final status"
+msgstr "Final status"
 
 #: ../../packages/player/src/components/translation-step.tsx
 msgctxt "MxLxkr"
@@ -2524,6 +2549,11 @@ msgstr "Listening"
 msgctxt "3198Ew"
 msgid "Learn new {topic} words with flashcards — see each word, its translation, and pronunciation."
 msgstr "Learn new {topic} words with flashcards — see each word, its translation, and pronunciation."
+
+#: src/lib/activities.ts
+msgctxt "Bfq+7w"
+msgid "Story"
+msgstr "Story"
 
 #: src/lib/activities.ts
 msgctxt "bzFQEy"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -332,6 +332,7 @@ msgid "Metric changes"
 msgstr "Metric changes"
 
 #: ../../packages/player/src/components/story-intro-content.tsx
+#: ../../packages/player/src/components/story-metrics-bar.tsx
 msgctxt "pFm27r"
 msgid "Current status"
 msgstr "Current status"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -70,6 +70,12 @@ msgctxt "xiSVL4"
 msgid "{color} Belt — Level {level}"
 msgstr "Cinturón {color} — Nivel {level}"
 
+#: ../../packages/player/src/components/choice-step-layout.tsx
+#: ../../packages/player/src/components/translation-step.tsx
+msgctxt "akd+cv"
+msgid "Answer options"
+msgstr "Opciones de respuesta"
+
 #: ../../packages/player/src/components/completion-auth-branch.tsx
 msgctxt "9+Ddtu"
 msgid "Next"
@@ -226,12 +232,6 @@ msgctxt "ja1JDt"
 msgid "All pairs matched. Press Check to continue."
 msgstr "Todos los pares coinciden. Presiona Verificar para continuar."
 
-#: ../../packages/player/src/components/multiple-choice-step.tsx
-#: ../../packages/player/src/components/translation-step.tsx
-msgctxt "akd+cv"
-msgid "Answer options"
-msgstr "Opciones de respuesta"
-
 #: ../../packages/player/src/components/play-audio-button.tsx
 msgctxt "lYWSeP"
 msgid "Play pronunciation"
@@ -278,6 +278,11 @@ msgid "Continue"
 msgstr "Continuar"
 
 #: ../../packages/player/src/components/player-shell.tsx
+msgctxt "PVe26p"
+msgid "Begin"
+msgstr "Comenzar"
+
+#: ../../packages/player/src/components/player-shell.tsx
 msgctxt "RDZVQL"
 msgid "Check"
 msgstr "Verificación"
@@ -315,6 +320,26 @@ msgstr "Ordenar elementos"
 msgctxt "VA8c/A"
 msgid "Correct order:"
 msgstr "Orden correcto:"
+
+#: ../../packages/player/src/components/story-briefing-popover.tsx
+msgctxt "XyeasA"
+msgid "Briefing"
+msgstr "Informe previo"
+
+#: ../../packages/player/src/components/story-feedback-content.tsx
+msgctxt "jSeUY4"
+msgid "Metric changes"
+msgstr "Cambios en las métricas"
+
+#: ../../packages/player/src/components/story-intro-content.tsx
+msgctxt "pFm27r"
+msgid "Current status"
+msgstr "Estado actual"
+
+#: ../../packages/player/src/components/story-outcome-content.tsx
+msgctxt "ZJ5JQC"
+msgid "Final status"
+msgstr "Estado final"
 
 #: ../../packages/player/src/components/translation-step.tsx
 msgctxt "MxLxkr"
@@ -2524,6 +2549,11 @@ msgstr "Escucha"
 msgctxt "3198Ew"
 msgid "Learn new {topic} words with flashcards — see each word, its translation, and pronunciation."
 msgstr "Aprende nuevas palabras de {topic} con tarjetas didácticas — ve cada palabra, su traducción y pronunciación."
+
+#: src/lib/activities.ts
+msgctxt "Bfq+7w"
+msgid "Story"
+msgstr "Historia"
 
 #: src/lib/activities.ts
 msgctxt "bzFQEy"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -332,6 +332,7 @@ msgid "Metric changes"
 msgstr "Cambios en las métricas"
 
 #: ../../packages/player/src/components/story-intro-content.tsx
+#: ../../packages/player/src/components/story-metrics-bar.tsx
 msgctxt "pFm27r"
 msgid "Current status"
 msgstr "Estado actual"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -332,6 +332,7 @@ msgid "Metric changes"
 msgstr "Mudanças nas métricas"
 
 #: ../../packages/player/src/components/story-intro-content.tsx
+#: ../../packages/player/src/components/story-metrics-bar.tsx
 msgctxt "pFm27r"
 msgid "Current status"
 msgstr "Status atual"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -70,6 +70,12 @@ msgctxt "xiSVL4"
 msgid "{color} Belt — Level {level}"
 msgstr "Faixa {color} — Nível {level}"
 
+#: ../../packages/player/src/components/choice-step-layout.tsx
+#: ../../packages/player/src/components/translation-step.tsx
+msgctxt "akd+cv"
+msgid "Answer options"
+msgstr "Opções de resposta"
+
 #: ../../packages/player/src/components/completion-auth-branch.tsx
 msgctxt "9+Ddtu"
 msgid "Next"
@@ -226,12 +232,6 @@ msgctxt "ja1JDt"
 msgid "All pairs matched. Press Check to continue."
 msgstr "Todos os pares combinados. Pressione Verificar para continuar."
 
-#: ../../packages/player/src/components/multiple-choice-step.tsx
-#: ../../packages/player/src/components/translation-step.tsx
-msgctxt "akd+cv"
-msgid "Answer options"
-msgstr "Opções de resposta"
-
 #: ../../packages/player/src/components/play-audio-button.tsx
 msgctxt "lYWSeP"
 msgid "Play pronunciation"
@@ -278,6 +278,11 @@ msgid "Continue"
 msgstr "Continuar"
 
 #: ../../packages/player/src/components/player-shell.tsx
+msgctxt "PVe26p"
+msgid "Begin"
+msgstr "Começar"
+
+#: ../../packages/player/src/components/player-shell.tsx
 msgctxt "RDZVQL"
 msgid "Check"
 msgstr "Verificar"
@@ -315,6 +320,26 @@ msgstr "Ordenar itens"
 msgctxt "VA8c/A"
 msgid "Correct order:"
 msgstr "Ordem correta:"
+
+#: ../../packages/player/src/components/story-briefing-popover.tsx
+msgctxt "XyeasA"
+msgid "Briefing"
+msgstr "Resumo"
+
+#: ../../packages/player/src/components/story-feedback-content.tsx
+msgctxt "jSeUY4"
+msgid "Metric changes"
+msgstr "Mudanças nas métricas"
+
+#: ../../packages/player/src/components/story-intro-content.tsx
+msgctxt "pFm27r"
+msgid "Current status"
+msgstr "Status atual"
+
+#: ../../packages/player/src/components/story-outcome-content.tsx
+msgctxt "ZJ5JQC"
+msgid "Final status"
+msgstr "Status final"
 
 #: ../../packages/player/src/components/translation-step.tsx
 msgctxt "MxLxkr"
@@ -2524,6 +2549,11 @@ msgstr "Escuta"
 msgctxt "3198Ew"
 msgid "Learn new {topic} words with flashcards — see each word, its translation, and pronunciation."
 msgstr "Aprenda novas palavras de {topic} com flashcards — veja cada palavra, sua tradução e pronúncia."
+
+#: src/lib/activities.ts
+msgctxt "Bfq+7w"
+msgid "Story"
+msgstr "História"
 
 #: src/lib/activities.ts
 msgctxt "bzFQEy"

--- a/apps/main/src/lib/activities.ts
+++ b/apps/main/src/lib/activities.ts
@@ -4,6 +4,7 @@ import {
   BookTextIcon,
   BracesIcon,
   CircleHelpIcon,
+  DramaIcon,
   HeadphonesIcon,
   LanguagesIcon,
   LayersIcon,
@@ -27,6 +28,7 @@ export async function getActivityKinds(): Promise<{ key: ActivityKind; label: st
     { key: "reading", label: t("Reading") },
     { key: "listening", label: t("Listening") },
     { key: "review", label: t("Review") },
+    { key: "story", label: t("Story") },
   ];
 }
 
@@ -124,7 +126,7 @@ const ACTIVITY_ICONS: Record<ActivityKind, LucideIcon> = {
   quiz: CircleHelpIcon,
   reading: BookTextIcon,
   review: RotateCcwIcon,
-  story: BookOpenIcon,
+  story: DramaIcon,
   translation: LanguagesIcon,
   vocabulary: LayersIcon,
 };

--- a/i18n.lock
+++ b/i18n.lock
@@ -206,6 +206,7 @@ checksums:
     Level%20progress/singular: 286f095acd17006787247db0b69270e3
     "%7Bvalue%7D%20BP%20to%20level%20up/singular": 755c2fe6e435645cb35b57bf92af09d3
     "%7Bcolor%7D%20Belt%20%E2%80%94%20Level%20%7Blevel%7D/singular": 367f2e902d39199c8507aaad09e8907a
+    Answer%20options/singular: acb0b378cefcb8a8d50a7c43ce77ae39
     Next/singular: 89ddbcf710eba274963494f312bdc8a9
     Login/singular: f4f219abeb5a465ecb1c7efaf50246de
     All%20Activities/singular: 9eee26b7ca58444c6d0db6bcd7ea7eda
@@ -234,7 +235,6 @@ checksums:
     Translate%20this%20sentence%3A/singular: f69b2eec827b3a74bafca50e9058716f
     What%20do%20you%20hear%3F/singular: 9527d094d65c550a40108673bc67744f
     All%20pairs%20matched.%20Press%20Check%20to%20continue./singular: 0663e33ba7db53b298c5f50a2f3c7ae8
-    Answer%20options/singular: acb0b378cefcb8a8d50a7c43ce77ae39
     Play%20pronunciation/singular: 623289cc3217c5404e3d48a78dd0456f
     Pause%20pronunciation/singular: e24b23e108f8efb6f2eea709e5f540e9
     Previous%20step/singular: 96b31ec6dab003c2bbfbbca10a8a9826
@@ -243,6 +243,7 @@ checksums:
     Close/singular: 2c2e22f8424a1031de89063bd0022e16
     Activity%20progress/singular: 8ff2fb7372b8a2525f2955c851c4fa42
     Continue/singular: 3cfba90b4600131e82fc4260c568d044
+    Begin/singular: cc2a17a662cb60dd2d8335a2e8440997
     Check/singular: 023cc2ba432775c38e3efc004ad7b9ef
     BP/singular: 842ed01b3a4d0efa6fe96ae8c595726c
     Energy/singular: 958809db5050650b97519e0f1f3e1951
@@ -250,6 +251,10 @@ checksums:
     Drag%20items%20into%20the%20correct%20order/singular: 8ccab82ee3ba645ac23da4ca14a0dd2a
     Sort%20items/singular: 3b1072a596203b5acdc5718d38161392
     Correct%20order%3A/singular: df3f446653ec8cde9c29d8d5912636ef
+    Briefing/singular: 557fdc15cf73ec0d6d9eb4041340498a
+    Metric%20changes/singular: b47eb6ffcf56070345e7783cb048b563
+    Current%20status/singular: b9c587d6cd7ee919b59e75066fa4675f
+    Final%20status/singular: 62c3befb232a9d290e74b84d6ddbf22c
     Translate%20this%20word%3A/singular: 05fede3c583e9ea39f27ac9fdf17fcc3
     Visual%20content/singular: 38b0261c39ebe4d775867363482225d8
     Legend/singular: 3b588fbd2fe35ded6ca38334e15400c3
@@ -674,6 +679,7 @@ checksums:
     Translation/singular: 9276816e7bc1a6ff00f388faa0863986
     Listening/singular: 9e680c44cd88a178b953349ed8881ef2
     Learn%20new%20%7Btopic%7D%20words%20with%20flashcards%20%E2%80%94%20see%20each%20word%2C%20its%20translation%2C%20and%20pronunciation./singular: 923933ba274d61fc2ffb279cf64aceba
+    Story/singular: fabac3f62af801d429e2cd7115bf14c9
     Review%20everything%20you%20learned%20about%20%7Btopic%7D%20with%20a%20comprehensive%20quiz./singular: 8acf9006cabdcbaac217c7565943f068
     Explanation/singular: f6b595df4ffb1a5b0cbbe1dda5993522
     Sharpen%20your%20%7Btopic%7D%20listening%20skills%20by%20translating%20audio%20sentences./singular: b624ceffbbfc91a29cec43a0037b067f

--- a/packages/core/src/steps/content-contract.test.ts
+++ b/packages/core/src/steps/content-contract.test.ts
@@ -354,28 +354,4 @@ describe("step content contracts", () => {
       ).toThrow();
     });
   });
-
-  describe("static storyDebrief", () => {
-    test("parses debrief with concepts", () => {
-      const content = parseStepContent("static", {
-        debrief: [
-          { explanation: "When you chose X, you experienced Y.", name: "Kanban" },
-          { explanation: "Pulling work based on demand.", name: "Pull System" },
-        ],
-        variant: "storyDebrief",
-      });
-
-      expect(content.variant).toBe("storyDebrief");
-    });
-
-    test("rejects outcomes in debrief", () => {
-      expect(() =>
-        parseStepContent("static", {
-          debrief: [{ explanation: "Test.", name: "Concept" }],
-          outcomes: [{ minStrongChoices: 0, narrative: "Bad.", title: "Bad" }],
-          variant: "storyDebrief",
-        }),
-      ).toThrow();
-    });
-  });
 });

--- a/packages/core/src/steps/content-contract.ts
+++ b/packages/core/src/steps/content-contract.ts
@@ -107,13 +107,6 @@ const storyOutcomeSchema = z
   })
   .strict();
 
-const storyDebriefConceptSchema = z
-  .object({
-    explanation: z.string(),
-    name: z.string(),
-  })
-  .strict();
-
 /**
  * Intro screen for a story activity (static step, first position).
  * Sets the scene and defines the metrics the player will track.
@@ -138,24 +131,12 @@ const staticStoryOutcomeContentSchema = z
   })
   .strict();
 
-/**
- * Debrief screen for a story activity (static step, last position).
- * Reveals the hidden concepts the player practiced through the story.
- */
-const staticStoryDebriefContentSchema = z
-  .object({
-    debrief: z.array(storyDebriefConceptSchema).min(1),
-    variant: z.literal("storyDebrief"),
-  })
-  .strict();
-
 const staticContentSchema = z.discriminatedUnion("variant", [
   staticTextContentSchema,
   staticGrammarExampleContentSchema,
   staticGrammarRuleContentSchema,
   staticStoryIntroContentSchema,
   staticStoryOutcomeContentSchema,
-  staticStoryDebriefContentSchema,
 ]);
 
 const storyAlignmentSchema = z.enum(["strong", "partial", "weak"]);
@@ -208,8 +189,6 @@ const stepContentSchemas = {
 } as const;
 
 export type SupportedStepKind = keyof typeof stepContentSchemas;
-
-export type CoreMultipleChoiceContent = z.infer<typeof coreMultipleChoiceContentSchema>;
 
 export type MultipleChoiceStepContent = z.infer<typeof multipleChoiceContentSchema>;
 export type FillBlankStepContent = z.infer<typeof fillBlankContentSchema>;

--- a/packages/core/src/steps/content-contract.ts
+++ b/packages/core/src/steps/content-contract.ts
@@ -197,6 +197,9 @@ export type SortOrderStepContent = z.infer<typeof sortOrderContentSchema>;
 export type SelectImageStepContent = z.infer<typeof selectImageContentSchema>;
 export type StaticStepContent = z.infer<typeof staticContentSchema>;
 export type StoryAlignment = z.infer<typeof storyAlignmentSchema>;
+export type StoryStaticVariant =
+  | z.infer<typeof staticStoryIntroContentSchema>["variant"]
+  | z.infer<typeof staticStoryOutcomeContentSchema>["variant"];
 export type StoryStepContent = z.infer<typeof storyContentSchema>;
 export type VocabularyStepContent = z.infer<typeof vocabularyContentSchema>;
 export type TranslationStepContent = z.infer<typeof translationContentSchema>;

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -26,7 +26,8 @@
     "@zoonk/utils": "workspace:*",
     "abcjs": "6.6.2",
     "katex": "0.16.40",
-    "shiki": "4.0.2"
+    "shiki": "4.0.2",
+    "web-haptics": "0.0.6"
   },
   "devDependencies": {
     "@testing-library/react": "16.3.2",

--- a/packages/player/src/components/choice-step-layout.tsx
+++ b/packages/player/src/components/choice-step-layout.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useExtracted } from "next-intl";
+import { useOptionKeyboard } from "../use-option-keyboard";
+import { useReplaceName } from "../user-name-context";
+import { OptionCard } from "./option-card";
+import { ContextText, QuestionText } from "./question-text";
+import { InteractiveStepLayout } from "./step-layouts";
+
+/**
+ * Shared layout for choice-based steps (multiple choice, story decisions).
+ *
+ * Owns all rendering and interaction: text display, option list with dimming,
+ * keyboard shortcuts (1/2/3), and toggle-to-unselect. Each step kind provides
+ * a thin wrapper that parses its content and builds the answer shape.
+ */
+export function ChoiceStepLayout({
+  context,
+  keyboardEnabled,
+  onSelect,
+  options,
+  question,
+  selectedIndex,
+}: {
+  context?: string | null;
+  keyboardEnabled: boolean;
+  onSelect: (index: number) => void;
+  options: readonly { key: string; text: string }[];
+  question?: string | null;
+  selectedIndex: number | null;
+}) {
+  const t = useExtracted();
+  const replaceName = useReplaceName();
+  const hasSelection = selectedIndex !== null;
+
+  useOptionKeyboard({
+    enabled: keyboardEnabled,
+    onSelect,
+    optionCount: options.length,
+  });
+
+  return (
+    <InteractiveStepLayout>
+      {(context || question) && (
+        <div className="flex flex-col gap-2 sm:gap-6">
+          {context && <ContextText>{replaceName(context)}</ContextText>}
+          {question && <QuestionText>{replaceName(question)}</QuestionText>}
+        </div>
+      )}
+
+      <div aria-label={t("Answer options")} className="flex flex-col gap-3" role="radiogroup">
+        {options.map((option, index) => (
+          <OptionCard
+            index={index}
+            isDimmed={hasSelection && selectedIndex !== index}
+            isSelected={selectedIndex === index}
+            key={option.key}
+            onSelect={() => onSelect(index)}
+          >
+            <span className="text-base leading-6">{option.text}</span>
+          </OptionCard>
+        ))}
+      </div>
+    </InteractiveStepLayout>
+  );
+}

--- a/packages/player/src/components/choice-step-layout.tsx
+++ b/packages/player/src/components/choice-step-layout.tsx
@@ -16,14 +16,12 @@ import { InteractiveStepLayout } from "./step-layouts";
  */
 export function ChoiceStepLayout({
   context,
-  keyboardEnabled,
   onSelect,
   options,
   question,
   selectedIndex,
 }: {
   context?: string | null;
-  keyboardEnabled: boolean;
   onSelect: (index: number) => void;
   options: readonly { key: string; text: string }[];
   question?: string | null;
@@ -34,7 +32,7 @@ export function ChoiceStepLayout({
   const hasSelection = selectedIndex !== null;
 
   useOptionKeyboard({
-    enabled: keyboardEnabled,
+    enabled: true,
     onSelect,
     optionCount: options.length,
   });

--- a/packages/player/src/components/feedback-screen.tsx
+++ b/packages/player/src/components/feedback-screen.tsx
@@ -10,6 +10,7 @@ import { CorrectAnswerBlock, IncorrectAnswerBlock } from "./feedback-answer-bloc
 import { PlayAudioButton } from "./play-audio-button";
 import { ResultAnnouncement } from "./result-announcement";
 import { RomanizationText } from "./romanization-text";
+import { StoryFeedbackContent } from "./story-feedback-content";
 
 function FeedbackScreen({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -76,13 +77,7 @@ function getFeedbackAudioUrl(step?: SerializedStep): string | null {
   return null;
 }
 
-export function FeedbackScreenContent({
-  result,
-  step,
-}: {
-  result: StepResult;
-  step?: SerializedStep;
-}) {
+function StandardFeedbackContent({ result, step }: { result: StepResult; step?: SerializedStep }) {
   const t = useExtracted();
   const replaceName = useReplaceName();
   const { isCorrect, feedback: rawFeedback, correctAnswer } = result.result;
@@ -127,4 +122,18 @@ export function FeedbackScreenContent({
       <ResultAnnouncement isCorrect={isCorrect} />
     </FeedbackScreen>
   );
+}
+
+export function FeedbackScreenContent({
+  result,
+  step,
+}: {
+  result: StepResult;
+  step?: SerializedStep;
+}) {
+  if (result.answer?.kind === "story") {
+    return <StoryFeedbackContent result={result} step={step} />;
+  }
+
+  return <StandardFeedbackContent result={result} step={step} />;
 }

--- a/packages/player/src/components/in-play-sticky-header.tsx
+++ b/packages/player/src/components/in-play-sticky-header.tsx
@@ -3,16 +3,19 @@
 import { type PlayerRoute } from "../player-context";
 import { PlayerCloseLink, PlayerHeader, PlayerStepFraction } from "./player-header";
 import { PlayerProgressBar } from "./player-progress-bar";
+import { StoryBriefingPopover } from "./story-briefing-popover";
 
 export function InPlayStickyHeader({
   currentStepIndex,
   lessonHref,
   progressValue,
+  storyBriefing,
   totalSteps,
 }: {
   currentStepIndex: number;
   lessonHref: PlayerRoute;
   progressValue: number;
+  storyBriefing: string | null;
   totalSteps: number;
 }) {
   return (
@@ -27,6 +30,12 @@ export function InPlayStickyHeader({
             </PlayerStepFraction>
           </div>
         </div>
+
+        {storyBriefing ? (
+          <StoryBriefingPopover intro={storyBriefing} />
+        ) : (
+          <div className="size-9" />
+        )}
       </PlayerHeader>
 
       <PlayerProgressBar value={progressValue} />

--- a/packages/player/src/components/in-play-sticky-header.tsx
+++ b/packages/player/src/components/in-play-sticky-header.tsx
@@ -31,11 +31,7 @@ export function InPlayStickyHeader({
           </div>
         </div>
 
-        {storyBriefing ? (
-          <StoryBriefingPopover intro={storyBriefing} />
-        ) : (
-          <div className="size-9" />
-        )}
+        {storyBriefing && <StoryBriefingPopover intro={storyBriefing} />}
       </PlayerHeader>
 
       <PlayerProgressBar value={progressValue} />

--- a/packages/player/src/components/multiple-choice-step.tsx
+++ b/packages/player/src/components/multiple-choice-step.tsx
@@ -38,7 +38,6 @@ export function MultipleChoiceStep({
   return (
     <ChoiceStepLayout
       context={content.context}
-      keyboardEnabled={selectedAnswer === undefined || selectedAnswer.kind === "multipleChoice"}
       onSelect={handleSelect}
       options={content.options.map((option) => ({ key: option.text, text: option.text }))}
       question={content.question}

--- a/packages/player/src/components/multiple-choice-step.tsx
+++ b/packages/player/src/components/multiple-choice-step.tsx
@@ -1,17 +1,9 @@
 "use client";
 
-import {
-  type CoreMultipleChoiceContent,
-  parseStepContent,
-} from "@zoonk/core/steps/content-contract";
-import { useExtracted } from "next-intl";
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { type SelectedAnswer } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
-import { useOptionKeyboard } from "../use-option-keyboard";
-import { useReplaceName } from "../user-name-context";
-import { OptionCard } from "./option-card";
-import { ContextText, QuestionText } from "./question-text";
-import { InteractiveStepLayout } from "./step-layouts";
+import { ChoiceStepLayout } from "./choice-step-layout";
 
 function getSelectedIndex(selectedAnswer: SelectedAnswer | undefined): number | null {
   if (selectedAnswer?.kind !== "multipleChoice") {
@@ -21,66 +13,12 @@ function getSelectedIndex(selectedAnswer: SelectedAnswer | undefined): number | 
   return selectedAnswer.selectedIndex;
 }
 
-function StepTextGroup({ children }: { children: React.ReactNode }) {
-  return <div className="flex flex-col gap-2 sm:gap-6">{children}</div>;
-}
-
-function OptionList({
-  onSelect,
-  options,
-  selectedIndex,
-}: {
-  onSelect: (index: number) => void;
-  options: readonly { text: string }[];
-  selectedIndex: number | null;
-}) {
-  const t = useExtracted();
-
-  return (
-    <div aria-label={t("Answer options")} className="flex flex-col gap-3" role="radiogroup">
-      {options.map((option, index) => (
-        <OptionCard
-          index={index}
-          isSelected={selectedIndex === index}
-          key={option.text}
-          onSelect={() => onSelect(index)}
-        >
-          <span className="text-base leading-6">{option.text}</span>
-        </OptionCard>
-      ))}
-    </div>
-  );
-}
-
-function CoreVariant({
-  content,
-  onSelect,
-  selectedIndex,
-}: {
-  content: CoreMultipleChoiceContent;
-  onSelect: (index: number) => void;
-  selectedIndex: number | null;
-}) {
-  const replaceName = useReplaceName();
-
-  return (
-    <>
-      <StepTextGroup>
-        {content.context && <ContextText>{replaceName(content.context)}</ContextText>}
-        {content.question && <QuestionText>{replaceName(content.question)}</QuestionText>}
-      </StepTextGroup>
-
-      <OptionList onSelect={onSelect} options={content.options} selectedIndex={selectedIndex} />
-    </>
-  );
-}
-
 export function MultipleChoiceStep({
   onSelectAnswer,
   selectedAnswer,
   step,
 }: {
-  onSelectAnswer: (stepId: string, answer: SelectedAnswer) => void;
+  onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
   selectedAnswer: SelectedAnswer | undefined;
   step: SerializedStep;
 }) {
@@ -88,19 +26,23 @@ export function MultipleChoiceStep({
   const selectedIndex = getSelectedIndex(selectedAnswer);
 
   const handleSelect = (index: number) => {
+    if (selectedIndex === index) {
+      onSelectAnswer(step.id, null);
+      return;
+    }
+
     const selectedText = content.options[index]?.text ?? "";
     onSelectAnswer(step.id, { kind: "multipleChoice", selectedIndex: index, selectedText });
   };
 
-  useOptionKeyboard({
-    enabled: selectedAnswer === undefined || selectedAnswer.kind === "multipleChoice",
-    onSelect: handleSelect,
-    optionCount: content.options.length,
-  });
-
   return (
-    <InteractiveStepLayout>
-      <CoreVariant content={content} onSelect={handleSelect} selectedIndex={selectedIndex} />
-    </InteractiveStepLayout>
+    <ChoiceStepLayout
+      context={content.context}
+      keyboardEnabled={selectedAnswer === undefined || selectedAnswer.kind === "multipleChoice"}
+      onSelect={handleSelect}
+      options={content.options.map((option) => ({ key: option.text, text: option.text }))}
+      question={content.question}
+      selectedIndex={selectedIndex}
+    />
   );
 }

--- a/packages/player/src/components/option-card.tsx
+++ b/packages/player/src/components/option-card.tsx
@@ -22,11 +22,11 @@ export function OptionCard({
     <button
       aria-checked={isSelected}
       className={cn(
-        "focus-visible:border-ring focus-visible:ring-ring/50 flex w-full items-center gap-3 rounded-xl border px-4 py-3.5 text-left transition-colors duration-150 outline-none focus-visible:ring-[3px]",
+        "focus-visible:border-ring focus-visible:ring-ring/50 flex w-full items-center gap-3 rounded-xl border px-4 py-3.5 text-left transition-all duration-150 outline-none focus-visible:ring-[3px]",
         !disabled && !isSelected && "border-border hover:bg-accent",
         !disabled && isSelected && "border-primary bg-primary/5",
         disabled && "pointer-events-none",
-        isDimmed && "opacity-40",
+        isDimmed && "opacity-50",
         resultState === "correct" && "bg-success/5 text-success border-transparent opacity-75",
         resultState === "incorrect" &&
           "bg-destructive/5 text-destructive border-transparent opacity-75",

--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -2,22 +2,82 @@
 
 import { useExtracted } from "next-intl";
 import { usePlayerNavigation, usePlayerRuntime } from "../player-context";
+import { type PlayerPhase } from "../player-reducer";
 import {
+  type StoryStaticVariant,
   getCanNavigatePrev,
   getCompletionResult,
   getCurrentResult,
   getCurrentStep,
   getHasAnswer,
   getIsStaticStep,
+  getIsStoryActivity,
   getProgressValue,
   getSelectedAnswer,
+  getStoryBriefingText,
+  getStoryMetrics,
+  getStoryStaticVariant,
   getUpcomingImages,
 } from "../player-selectors";
+import { type PlayerActions } from "../use-player-actions";
+import { useStoryHaptics } from "../use-story-haptics";
 import { InPlayStickyHeader } from "./in-play-sticky-header";
 import { PlayerBottomBar, PlayerBottomBarAction, PlayerBottomBarNav } from "./player-bottom-bar";
 import { PlayerStage } from "./player-stage";
 import { StageContent } from "./stage-content";
 import { StepImagePreloader } from "./step-image-preloader";
+import { StoryMetricsBar } from "./story-metrics-bar";
+
+function BottomBarContent({
+  actions,
+  buttonLabel,
+  canNavigatePrev,
+  hasAnswer,
+  isStaticStep,
+  phase,
+  storyStaticVariant,
+}: {
+  actions: PlayerActions;
+  buttonLabel: string;
+  canNavigatePrev: boolean;
+  hasAnswer: boolean;
+  isStaticStep: boolean;
+  phase: PlayerPhase;
+  storyStaticVariant: StoryStaticVariant | null;
+}) {
+  const t = useExtracted();
+
+  if (storyStaticVariant === "storyIntro") {
+    return (
+      <PlayerBottomBarAction onClick={actions.navigateNext}>{t("Begin")}</PlayerBottomBarAction>
+    );
+  }
+
+  if (storyStaticVariant === "storyOutcome") {
+    return (
+      <PlayerBottomBarAction onClick={actions.navigateNext}>{t("Continue")}</PlayerBottomBarAction>
+    );
+  }
+
+  if (isStaticStep) {
+    return (
+      <PlayerBottomBarNav
+        canNavigatePrev={canNavigatePrev}
+        onNavigateNext={actions.navigateNext}
+        onNavigatePrev={actions.navigatePrev}
+      />
+    );
+  }
+
+  return (
+    <PlayerBottomBarAction
+      disabled={phase === "playing" && !hasAnswer}
+      onClick={phase === "feedback" ? actions.continue : actions.check}
+    >
+      {buttonLabel}
+    </PlayerBottomBarAction>
+  );
+}
 
 export function PlayerShell() {
   const t = useExtracted();
@@ -30,11 +90,23 @@ export function PlayerShell() {
   const currentStep = getCurrentStep(state);
   const hasAnswer = getHasAnswer(state);
   const isStaticStep = getIsStaticStep(state);
+  const isStoryActivity = getIsStoryActivity(state);
   const progressValue = getProgressValue(state);
   const selectedAnswer = getSelectedAnswer(state);
+  const storyBriefing = getStoryBriefingText(state);
+  const storyMetrics = getStoryMetrics(state);
+  const storyStaticVariant = getStoryStaticVariant(state);
   const upcomingImages = getUpcomingImages(state);
 
+  useStoryHaptics({
+    isStoryActivity,
+    metrics: storyMetrics,
+    phase: state.phase,
+    storyStaticVariant,
+  });
+
   const showChrome = state.phase === "playing" || state.phase === "feedback";
+  const showMetricsBar = isStoryActivity && showChrome && storyStaticVariant !== "storyIntro";
   const buttonLabel = state.phase === "feedback" ? t("Continue") : t("Check");
 
   return (
@@ -44,9 +116,12 @@ export function PlayerShell() {
           currentStepIndex={state.currentStepIndex}
           lessonHref={lessonHref}
           progressValue={progressValue}
+          storyBriefing={storyBriefing}
           totalSteps={state.steps.length}
         />
       )}
+
+      {showMetricsBar && <StoryMetricsBar metrics={storyMetrics} />}
 
       <PlayerStage isStatic={isStaticStep && state.phase === "playing"} phase={state.phase}>
         <StageContent
@@ -69,20 +144,15 @@ export function PlayerShell() {
 
       {showChrome && (
         <PlayerBottomBar className={isStaticStep ? "lg:hidden" : undefined}>
-          {isStaticStep ? (
-            <PlayerBottomBarNav
-              canNavigatePrev={canNavigatePrev}
-              onNavigateNext={actions.navigateNext}
-              onNavigatePrev={actions.navigatePrev}
-            />
-          ) : (
-            <PlayerBottomBarAction
-              disabled={state.phase === "playing" && !hasAnswer}
-              onClick={state.phase === "feedback" ? actions.continue : actions.check}
-            >
-              {buttonLabel}
-            </PlayerBottomBarAction>
-          )}
+          <BottomBarContent
+            actions={actions}
+            buttonLabel={buttonLabel}
+            canNavigatePrev={canNavigatePrev}
+            hasAnswer={hasAnswer}
+            isStaticStep={isStaticStep}
+            phase={state.phase}
+            storyStaticVariant={storyStaticVariant}
+          />
         </PlayerBottomBar>
       )}
 

--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import { type StoryStaticVariant } from "@zoonk/core/steps/content-contract";
 import { useExtracted } from "next-intl";
 import { usePlayerNavigation, usePlayerRuntime } from "../player-context";
 import { type PlayerPhase } from "../player-reducer";
 import {
-  type StoryStaticVariant,
   getCanNavigatePrev,
   getCompletionResult,
   getCurrentResult,

--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -106,7 +106,7 @@ export function PlayerShell() {
   });
 
   const showChrome = state.phase === "playing" || state.phase === "feedback";
-  const showMetricsBar = isStoryActivity && showChrome && storyStaticVariant !== "storyIntro";
+  const showMetricsBar = currentStep?.kind === "story" && showChrome;
   const buttonLabel = state.phase === "feedback" ? t("Continue") : t("Check");
 
   return (

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -11,7 +11,8 @@ function needsFeedbackScreen(step: SerializedStep): boolean {
     step.kind === "multipleChoice" ||
     step.kind === "translation" ||
     step.kind === "reading" ||
-    step.kind === "listening"
+    step.kind === "listening" ||
+    step.kind === "story"
   );
 }
 

--- a/packages/player/src/components/static-step.tsx
+++ b/packages/player/src/components/static-step.tsx
@@ -6,6 +6,8 @@ import { useReplaceName } from "../user-name-context";
 import { HighlightText } from "./highlight-text";
 import { ContextText, QuestionText } from "./question-text";
 import { RomanizationText } from "./romanization-text";
+import { StoryIntroContent } from "./story-intro-content";
+import { StoryOutcomeContent } from "./story-outcome-content";
 
 function TextVariant({ title, text }: { title: string; text: string }) {
   const replaceName = useReplaceName();
@@ -69,12 +71,12 @@ function StaticStepContent({ step }: { step: SerializedStep }) {
     return <GrammarRuleVariant ruleName={content.ruleName} ruleSummary={content.ruleSummary} />;
   }
 
-  if (
-    content.variant === "storyIntro" ||
-    content.variant === "storyOutcome" ||
-    content.variant === "storyDebrief"
-  ) {
-    return null;
+  if (content.variant === "storyIntro") {
+    return <StoryIntroContent intro={content.intro} metrics={content.metrics} />;
+  }
+
+  if (content.variant === "storyOutcome") {
+    return <StoryOutcomeContent metrics={content.metrics} outcomes={content.outcomes} />;
   }
 
   return <TextVariant text={content.text} title={content.title} />;

--- a/packages/player/src/components/static-step.tsx
+++ b/packages/player/src/components/static-step.tsx
@@ -76,7 +76,7 @@ function StaticStepContent({ step }: { step: SerializedStep }) {
   }
 
   if (content.variant === "storyOutcome") {
-    return <StoryOutcomeContent metrics={content.metrics} outcomes={content.outcomes} />;
+    return <StoryOutcomeContent outcomes={content.outcomes} />;
   }
 
   return <TextVariant text={content.text} title={content.title} />;

--- a/packages/player/src/components/step-renderer.tsx
+++ b/packages/player/src/components/step-renderer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
 import { FillBlankStep } from "./fill-blank-step";
@@ -12,6 +13,7 @@ import { SortOrderStep } from "./sort-order-step";
 import { StaticStep } from "./static-step";
 import { NavigableStepLayout } from "./step-layouts";
 import { StepSideNav } from "./step-side-nav";
+import { StoryStep } from "./story-step";
 import { TranslationStep } from "./translation-step";
 import { VisualStep } from "./visual-step";
 import { VocabularyStep } from "./vocabulary-step";
@@ -34,6 +36,14 @@ export function StepRenderer({
   step: SerializedStep;
 }) {
   if (step.kind === "static") {
+    const staticContent = parseStepContent("static", step.content);
+    const isStoryStatic =
+      staticContent.variant === "storyIntro" || staticContent.variant === "storyOutcome";
+
+    if (isStoryStatic) {
+      return <StaticStep step={step} />;
+    }
+
     return (
       <NavigableStepLayout>
         <StepSideNav
@@ -154,6 +164,12 @@ export function StepRenderer({
         selectedAnswer={selectedAnswer}
         step={step}
       />
+    );
+  }
+
+  if (step.kind === "story") {
+    return (
+      <StoryStep onSelectAnswer={onSelectAnswer} selectedAnswer={selectedAnswer} step={step} />
     );
   }
 

--- a/packages/player/src/components/story-briefing-popover.tsx
+++ b/packages/player/src/components/story-briefing-popover.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { buttonVariants } from "@zoonk/ui/components/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverTrigger,
+} from "@zoonk/ui/components/popover";
+import { ScrollTextIcon } from "lucide-react";
+import { useExtracted } from "next-intl";
+
+/**
+ * A small icon button in the sticky header that opens a popover with the
+ * story premise.
+ *
+ * Placed on the right side of the header (symmetrical with the close button
+ * on the left) so players can recall the briefing during decision steps
+ * without layout shift or navigating back.
+ */
+export function StoryBriefingPopover({ intro }: { intro: string }) {
+  const t = useExtracted();
+
+  return (
+    <Popover>
+      <PopoverTrigger className={buttonVariants({ size: "icon", variant: "ghost" })}>
+        <ScrollTextIcon className="size-4" />
+        <span className="sr-only">{t("Briefing")}</span>
+      </PopoverTrigger>
+
+      <PopoverContent align="end" side="bottom" sideOffset={8}>
+        <PopoverDescription>{intro}</PopoverDescription>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/player/src/components/story-feedback-content.tsx
+++ b/packages/player/src/components/story-feedback-content.tsx
@@ -6,18 +6,13 @@ import { ArrowDown, ArrowUp } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { type StepResult } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
+import { EFFECT_DELTA_MAP } from "../story";
 import { useReplaceName } from "../user-name-context";
 
 type MetricDelta = {
   delta: number;
   metric: string;
 };
-
-const EFFECT_DELTA_MAP = {
-  negative: -15,
-  neutral: 0,
-  positive: 15,
-} as const;
 
 /**
  * Finds the selected choice from the story step content and computes

--- a/packages/player/src/components/story-feedback-content.tsx
+++ b/packages/player/src/components/story-feedback-content.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { type StoryStepContent, parseStepContent } from "@zoonk/core/steps/content-contract";
+import { cn } from "@zoonk/ui/lib/utils";
+import { ArrowDown, ArrowUp } from "lucide-react";
+import { useExtracted } from "next-intl";
+import { type StepResult } from "../player-reducer";
+import { type SerializedStep } from "../prepare-activity-data";
+import { useReplaceName } from "../user-name-context";
+
+type MetricDelta = {
+  delta: number;
+  metric: string;
+};
+
+const EFFECT_DELTA_MAP = {
+  negative: -15,
+  neutral: 0,
+  positive: 15,
+} as const;
+
+/**
+ * Finds the selected choice from the story step content and computes
+ * metric deltas to display as colored badges on the feedback screen.
+ */
+function getMetricDeltas(content: StoryStepContent, selectedChoiceId: string): MetricDelta[] {
+  const choice = content.choices.find((option) => option.id === selectedChoiceId);
+
+  if (!choice) {
+    return [];
+  }
+
+  return choice.metricEffects
+    .map((effect) => ({
+      delta: EFFECT_DELTA_MAP[effect.effect],
+      metric: effect.metric,
+    }))
+    .filter((entry) => entry.delta !== 0);
+}
+
+function MetricDeltaBadge({ delta, metric }: MetricDelta) {
+  const isPositive = delta > 0;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 text-sm font-medium",
+        isPositive ? "text-success" : "text-destructive",
+      )}
+    >
+      {isPositive ? <ArrowUp className="size-3.5" /> : <ArrowDown className="size-3.5" />}
+      {metric} {isPositive ? `+${delta}` : delta}
+    </span>
+  );
+}
+
+/**
+ * Story-specific feedback screen showing the consequence narrative and
+ * metric deltas.
+ *
+ * Intentionally omits correct/incorrect framing — in stories, the
+ * consequence IS the feedback. There are no "Your answer" / "Correct answer"
+ * blocks, no green check or red X.
+ */
+export function StoryFeedbackContent({
+  result,
+  step,
+}: {
+  result: StepResult;
+  step?: SerializedStep;
+}) {
+  const t = useExtracted();
+  const replaceName = useReplaceName();
+
+  const consequence = result.result.feedback;
+  const selectedChoiceId = result.answer?.kind === "story" ? result.answer.selectedChoiceId : null;
+
+  const metricDeltas =
+    step && selectedChoiceId
+      ? getMetricDeltas(parseStepContent("story", step.content), selectedChoiceId)
+      : [];
+
+  return (
+    <div
+      aria-live="polite"
+      className="animate-in fade-in slide-in-from-bottom-1 mx-auto my-auto flex w-full max-w-lg flex-col gap-6 duration-200 ease-out motion-reduce:animate-none"
+      role="status"
+    >
+      {consequence && (
+        <p className="text-foreground text-lg leading-relaxed">{replaceName(consequence)}</p>
+      )}
+
+      {metricDeltas.length > 0 && (
+        <div aria-label={t("Metric changes")} className="flex flex-wrap gap-4">
+          {metricDeltas.map((entry) => (
+            <MetricDeltaBadge delta={entry.delta} key={entry.metric} metric={entry.metric} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/player/src/components/story-intro-content.tsx
+++ b/packages/player/src/components/story-intro-content.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useExtracted } from "next-intl";
+import { METRIC_AVERAGE_THRESHOLD } from "../story";
 import { StoryMetricPill } from "./story-metric-pill";
-
-const STARTING_VALUE = 50;
 
 /**
  * Intro screen for a story activity.
@@ -34,7 +33,7 @@ export function StoryIntroContent({ intro, metrics }: { intro: string; metrics: 
 
           <div className="-ml-1 flex flex-wrap gap-2">
             {metrics.map((metric) => (
-              <StoryMetricPill key={metric} metric={metric} value={STARTING_VALUE} />
+              <StoryMetricPill key={metric} metric={metric} value={METRIC_AVERAGE_THRESHOLD} />
             ))}
           </div>
         </div>

--- a/packages/player/src/components/story-intro-content.tsx
+++ b/packages/player/src/components/story-intro-content.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useExtracted } from "next-intl";
+import { StoryMetricPill } from "./story-metric-pill";
+
+const STARTING_VALUE = 50;
+
+/**
+ * Intro screen for a story activity.
+ *
+ * Sets the scene with narrative text and shows the initial metric values
+ * using the same pill components as the in-game metrics bar.
+ * Typography-forward design — the writing IS the visual. No emoji, no images.
+ *
+ * Layout hierarchy:
+ * 1. Narrative text (hero) — large, confident, draws you in
+ * 2. Thin divider — clean visual break between story and game state
+ * 3. Metrics pills — same style as the persistent bar during gameplay
+ */
+export function StoryIntroContent({ intro, metrics }: { intro: string; metrics: string[] }) {
+  const t = useExtracted();
+
+  return (
+    <div className="flex flex-col gap-10">
+      <p className="text-xl leading-relaxed sm:text-2xl sm:leading-relaxed">{intro}</p>
+
+      <div className="flex flex-col gap-4">
+        <div className="bg-border h-px" />
+
+        <div className="flex flex-col gap-3">
+          <p className="text-muted-foreground text-xs font-medium tracking-widest uppercase">
+            {t("Current status")}
+          </p>
+
+          <div className="-ml-1 flex flex-wrap gap-2">
+            {metrics.map((metric) => (
+              <StoryMetricPill key={metric} metric={metric} value={STARTING_VALUE} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/player/src/components/story-metric-pill.tsx
+++ b/packages/player/src/components/story-metric-pill.tsx
@@ -1,0 +1,53 @@
+import { cn } from "@zoonk/ui/lib/utils";
+
+const CRITICAL_THRESHOLD = 25;
+const AVERAGE_THRESHOLD = 50;
+const GOOD_THRESHOLD = 60;
+
+/**
+ * Returns the Tailwind color class for a metric value based on threshold bands.
+ * <25: critical (destructive + bold), 25-49: bad (destructive),
+ * 50-59: average (warning), 60+: good (success).
+ */
+export function getMetricColor(value: number): string {
+  if (value < CRITICAL_THRESHOLD) {
+    return "text-destructive font-bold";
+  }
+
+  if (value < AVERAGE_THRESHOLD) {
+    return "text-destructive";
+  }
+
+  if (value < GOOD_THRESHOLD) {
+    return "text-warning";
+  }
+
+  return "text-success";
+}
+
+/**
+ * A compact pill showing a metric label and its color-coded value inline
+ * (e.g., "Morale 72").
+ *
+ * Reused across the story metrics bar, intro screen, and outcome screen
+ * to ensure consistent metric presentation. The pill pulses on value
+ * change via a CSS animation triggered by a key remount.
+ */
+export function StoryMetricPill({ metric, value }: { metric: string; value: number }) {
+  return (
+    <span
+      key={value}
+      className="animate-pulse-scale bg-muted/50 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 motion-reduce:animate-none"
+    >
+      <span className="text-muted-foreground text-xs">{metric}</span>
+      <span
+        className={cn(
+          "text-xs font-semibold tabular-nums transition-colors duration-500",
+          getMetricColor(value),
+        )}
+      >
+        {value}
+      </span>
+    </span>
+  );
+}

--- a/packages/player/src/components/story-metric-pill.tsx
+++ b/packages/player/src/components/story-metric-pill.tsx
@@ -9,7 +9,7 @@ const GOOD_THRESHOLD = 60;
  * <25: critical (destructive + bold), 25-49: bad (destructive),
  * 50-59: average (warning), 60+: good (success).
  */
-export function getMetricColor(value: number): string {
+function getMetricColor(value: number): string {
   if (value < CRITICAL_THRESHOLD) {
     return "text-destructive font-bold";
   }

--- a/packages/player/src/components/story-metric-pill.tsx
+++ b/packages/player/src/components/story-metric-pill.tsx
@@ -1,24 +1,26 @@
 import { cn } from "@zoonk/ui/lib/utils";
+import {
+  METRIC_AVERAGE_THRESHOLD,
+  METRIC_CRITICAL_THRESHOLD,
+  METRIC_DANGER_THRESHOLD,
+  METRIC_GOOD_THRESHOLD,
+} from "../story";
 
-const CRITICAL_THRESHOLD = 25;
-const AVERAGE_THRESHOLD = 50;
-const GOOD_THRESHOLD = 60;
-
-/**
- * Returns the Tailwind color class for a metric value based on threshold bands.
- * <25: critical (destructive + bold), 25-49: bad (destructive),
- * 50-59: average (warning), 60+: good (success).
- */
+/** Returns the Tailwind color class for a metric value based on threshold bands. */
 function getMetricColor(value: number): string {
-  if (value < CRITICAL_THRESHOLD) {
+  if (value < METRIC_CRITICAL_THRESHOLD) {
+    return "text-destructive font-bold animate-pulse";
+  }
+
+  if (value < METRIC_DANGER_THRESHOLD) {
     return "text-destructive font-bold";
   }
 
-  if (value < AVERAGE_THRESHOLD) {
+  if (value < METRIC_AVERAGE_THRESHOLD) {
     return "text-destructive";
   }
 
-  if (value < GOOD_THRESHOLD) {
+  if (value < METRIC_GOOD_THRESHOLD) {
     return "text-warning";
   }
 

--- a/packages/player/src/components/story-metrics-bar.tsx
+++ b/packages/player/src/components/story-metrics-bar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useExtracted } from "next-intl";
 import { type StoryMetric } from "../player-selectors";
 import { StoryMetricPill } from "./story-metric-pill";
 
@@ -10,14 +11,17 @@ import { StoryMetricPill } from "./story-metric-pill";
  * sticky header and the story content.
  */
 export function StoryMetricsBar({ metrics }: { metrics: StoryMetric[] }) {
+  const t = useExtracted();
+
   if (metrics.length === 0) {
     return null;
   }
 
   return (
     <div
+      aria-label={t("Current status")}
       className="mx-auto flex w-full max-w-2xl flex-wrap items-center justify-center gap-2 p-4"
-      data-slot="story-metrics-bar"
+      role="status"
     >
       {metrics.map((metric) => (
         <StoryMetricPill key={metric.metric} metric={metric.metric} value={metric.value} />

--- a/packages/player/src/components/story-metrics-bar.tsx
+++ b/packages/player/src/components/story-metrics-bar.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { type StoryMetric } from "../player-selectors";
+import { StoryMetricPill } from "./story-metric-pill";
+
+/**
+ * Persistent horizontal bar showing story metrics during gameplay.
+ *
+ * Renders metrics as compact centered pills that sit between the
+ * sticky header and the story content.
+ */
+export function StoryMetricsBar({ metrics }: { metrics: StoryMetric[] }) {
+  if (metrics.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="mx-auto flex w-full max-w-2xl flex-wrap items-center justify-center gap-2 p-4"
+      data-slot="story-metrics-bar"
+    >
+      {metrics.map((metric) => (
+        <StoryMetricPill key={metric.metric} metric={metric.metric} value={metric.value} />
+      ))}
+    </div>
+  );
+}

--- a/packages/player/src/components/story-outcome-content.tsx
+++ b/packages/player/src/components/story-outcome-content.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { usePlayerRuntime } from "../player-context";
-import { getStoryMetrics } from "../player-selectors";
+import { findSelectedChoice, getStoryMetrics } from "../player-selectors";
 import { type SerializedStep } from "../prepare-activity-data";
 import { StoryMetricPill } from "./story-metric-pill";
 
@@ -15,21 +14,26 @@ type StoryOutcome = {
 };
 
 /**
+ * A ranked outcome includes its position in the sorted list so we can
+ * determine the tier color without re-sorting.
+ */
+type RankedOutcome = {
+  index: number;
+  outcome: StoryOutcome;
+  total: number;
+};
+
+/**
  * Checks whether a story step result has a "strong" alignment choice.
  */
-function isStrongChoice(
-  step: SerializedStep,
-  results: Record<string, { answer?: { kind: string; selectedChoiceId?: string } }>,
-): boolean {
-  const result = results[step.id];
-
-  if (!result?.answer || result.answer.kind !== "story" || !result.answer.selectedChoiceId) {
-    return false;
-  }
-
-  const content = parseStepContent("story", step.content);
-  const choice = content.choices.find((option) => option.id === result.answer?.selectedChoiceId);
-
+function isStrongChoice({
+  results,
+  step,
+}: {
+  results: Record<string, { answer?: { kind: string; selectedChoiceId?: string } }>;
+  step: SerializedStep;
+}): boolean {
+  const choice = findSelectedChoice({ results, step });
   return choice?.alignment === "strong";
 }
 
@@ -37,47 +41,58 @@ function isStrongChoice(
  * Counts how many "strong" alignment choices the player made across all
  * story decision steps.
  */
-function countStrongChoices(state: {
+function countStrongChoices({
+  results,
+  steps,
+}: {
   results: Record<string, { answer?: { kind: string; selectedChoiceId?: string } }>;
   steps: SerializedStep[];
 }): number {
-  return state.steps
-    .filter((step) => step.kind === "story")
-    .filter((step) => isStrongChoice(step, state.results)).length;
+  return steps.filter((step) => isStrongChoice({ results, step })).length;
 }
 
 /**
- * Selects the best-matching outcome based on the player's strong choice count.
+ * Sorts outcomes by minStrongChoices descending (best first, worst last)
+ * and selects the first one where the player's count meets or exceeds
+ * the threshold. Falls back to the last outcome if none match.
  *
- * Sorts outcomes by minStrongChoices descending and picks the first one
- * where the player's count meets or exceeds the threshold. Falls back to
- * the last outcome (lowest threshold) if none match.
+ * Returns the matched outcome along with its tier index and total count
+ * so the caller can determine the color without re-sorting.
  */
-function selectOutcome(outcomes: StoryOutcome[], strongCount: number): StoryOutcome | undefined {
+function selectOutcome({
+  outcomes,
+  strongCount,
+}: {
+  outcomes: StoryOutcome[];
+  strongCount: number;
+}): RankedOutcome | null {
   const sorted = [...outcomes].toSorted(
     (left, right) => right.minStrongChoices - left.minStrongChoices,
   );
 
-  return sorted.find((outcome) => strongCount >= outcome.minStrongChoices) ?? sorted.at(-1);
+  const index = sorted.findIndex((entry) => strongCount >= entry.minStrongChoices);
+  const resolvedIndex = index === -1 ? sorted.length - 1 : index;
+  const outcome = sorted[resolvedIndex];
+
+  if (!outcome) {
+    return null;
+  }
+
+  return { index: resolvedIndex, outcome, total: sorted.length };
 }
 
 /**
- * Returns the color class for the outcome title based on its tier.
+ * Returns the color class for the outcome title based on its position
+ * in the ranked list.
  *
- * The best outcome (highest threshold) is green, the worst (lowest) is
- * destructive, and everything in between is warning.
+ * First (best) = green, last (worst) = destructive, middle = warning.
  */
-function getOutcomeTierColor(outcome: StoryOutcome, allOutcomes: StoryOutcome[]): string {
-  const sorted = [...allOutcomes].toSorted(
-    (left, right) => right.minStrongChoices - left.minStrongChoices,
-  );
-  const index = sorted.indexOf(outcome);
-
+function getOutcomeTierColor({ index, total }: RankedOutcome): string {
   if (index === 0) {
     return "text-success";
   }
 
-  if (index === sorted.length - 1) {
+  if (index === total - 1) {
     return "text-destructive";
   }
 
@@ -90,39 +105,39 @@ function getOutcomeTierColor(outcome: StoryOutcome, allOutcomes: StoryOutcome[])
  * Displays the narrative result of the player's decisions with a
  * color-coded title reflecting how well they did.
  */
-export function StoryOutcomeContent({ outcomes }: { metrics: string[]; outcomes: StoryOutcome[] }) {
+export function StoryOutcomeContent({ outcomes }: { outcomes: StoryOutcome[] }) {
   const t = useExtracted();
   const { state } = usePlayerRuntime();
   const strongCount = countStrongChoices(state);
-  const outcome = selectOutcome(outcomes, strongCount);
+  const ranked = selectOutcome({ outcomes, strongCount });
   const storyMetrics = getStoryMetrics(state);
 
-  if (!outcome) {
+  if (!ranked) {
     return null;
   }
 
-  const titleColor = getOutcomeTierColor(outcome, outcomes);
+  const titleColor = getOutcomeTierColor(ranked);
 
   return (
     <div className="flex flex-col gap-6">
-      <h2 className={cn("text-2xl font-semibold tracking-tight", titleColor)}>{outcome.title}</h2>
+      <h2 className={cn("text-2xl font-semibold tracking-tight", titleColor)}>
+        {ranked.outcome.title}
+      </h2>
 
-      <p className="text-lg leading-relaxed">{outcome.narrative}</p>
+      <p className="text-lg leading-relaxed">{ranked.outcome.narrative}</p>
 
       {storyMetrics.length > 0 && (
         <div className="flex flex-col gap-3">
           <div className="bg-border h-px" />
 
-          <div className="flex flex-col gap-3">
-            <p className="text-muted-foreground text-xs font-medium tracking-widest uppercase">
-              {t("Final status")}
-            </p>
+          <p className="text-muted-foreground text-xs font-medium tracking-widest uppercase">
+            {t("Final status")}
+          </p>
 
-            <div className="-ml-1 flex flex-wrap gap-2">
-              {storyMetrics.map((entry) => (
-                <StoryMetricPill key={entry.metric} metric={entry.metric} value={entry.value} />
-              ))}
-            </div>
+          <div className="-ml-1 flex flex-wrap gap-2">
+            {storyMetrics.map((entry) => (
+              <StoryMetricPill key={entry.metric} metric={entry.metric} value={entry.value} />
+            ))}
           </div>
         </div>
       )}

--- a/packages/player/src/components/story-outcome-content.tsx
+++ b/packages/player/src/components/story-outcome-content.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
+import { cn } from "@zoonk/ui/lib/utils";
+import { useExtracted } from "next-intl";
+import { usePlayerRuntime } from "../player-context";
+import { getStoryMetrics } from "../player-selectors";
+import { type SerializedStep } from "../prepare-activity-data";
+import { StoryMetricPill } from "./story-metric-pill";
+
+type StoryOutcome = {
+  minStrongChoices: number;
+  narrative: string;
+  title: string;
+};
+
+/**
+ * Checks whether a story step result has a "strong" alignment choice.
+ */
+function isStrongChoice(
+  step: SerializedStep,
+  results: Record<string, { answer?: { kind: string; selectedChoiceId?: string } }>,
+): boolean {
+  const result = results[step.id];
+
+  if (!result?.answer || result.answer.kind !== "story" || !result.answer.selectedChoiceId) {
+    return false;
+  }
+
+  const content = parseStepContent("story", step.content);
+  const choice = content.choices.find((option) => option.id === result.answer?.selectedChoiceId);
+
+  return choice?.alignment === "strong";
+}
+
+/**
+ * Counts how many "strong" alignment choices the player made across all
+ * story decision steps.
+ */
+function countStrongChoices(state: {
+  results: Record<string, { answer?: { kind: string; selectedChoiceId?: string } }>;
+  steps: SerializedStep[];
+}): number {
+  return state.steps
+    .filter((step) => step.kind === "story")
+    .filter((step) => isStrongChoice(step, state.results)).length;
+}
+
+/**
+ * Selects the best-matching outcome based on the player's strong choice count.
+ *
+ * Sorts outcomes by minStrongChoices descending and picks the first one
+ * where the player's count meets or exceeds the threshold. Falls back to
+ * the last outcome (lowest threshold) if none match.
+ */
+function selectOutcome(outcomes: StoryOutcome[], strongCount: number): StoryOutcome | undefined {
+  const sorted = [...outcomes].toSorted(
+    (left, right) => right.minStrongChoices - left.minStrongChoices,
+  );
+
+  return sorted.find((outcome) => strongCount >= outcome.minStrongChoices) ?? sorted.at(-1);
+}
+
+/**
+ * Returns the color class for the outcome title based on its tier.
+ *
+ * The best outcome (highest threshold) is green, the worst (lowest) is
+ * destructive, and everything in between is warning.
+ */
+function getOutcomeTierColor(outcome: StoryOutcome, allOutcomes: StoryOutcome[]): string {
+  const sorted = [...allOutcomes].toSorted(
+    (left, right) => right.minStrongChoices - left.minStrongChoices,
+  );
+  const index = sorted.indexOf(outcome);
+
+  if (index === 0) {
+    return "text-success";
+  }
+
+  if (index === sorted.length - 1) {
+    return "text-destructive";
+  }
+
+  return "text-warning";
+}
+
+/**
+ * Outcome screen shown after the final decision step's consequence.
+ *
+ * Displays the narrative result of the player's decisions with a
+ * color-coded title reflecting how well they did.
+ */
+export function StoryOutcomeContent({ outcomes }: { metrics: string[]; outcomes: StoryOutcome[] }) {
+  const t = useExtracted();
+  const { state } = usePlayerRuntime();
+  const strongCount = countStrongChoices(state);
+  const outcome = selectOutcome(outcomes, strongCount);
+  const storyMetrics = getStoryMetrics(state);
+
+  if (!outcome) {
+    return null;
+  }
+
+  const titleColor = getOutcomeTierColor(outcome, outcomes);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <h2 className={cn("text-2xl font-semibold tracking-tight", titleColor)}>{outcome.title}</h2>
+
+      <p className="text-lg leading-relaxed">{outcome.narrative}</p>
+
+      {storyMetrics.length > 0 && (
+        <div className="flex flex-col gap-3">
+          <div className="bg-border h-px" />
+
+          <div className="flex flex-col gap-3">
+            <p className="text-muted-foreground text-xs font-medium tracking-widest uppercase">
+              {t("Final status")}
+            </p>
+
+            <div className="-ml-1 flex flex-wrap gap-2">
+              {storyMetrics.map((entry) => (
+                <StoryMetricPill key={entry.metric} metric={entry.metric} value={entry.value} />
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/player/src/components/story-outcome-content.tsx
+++ b/packages/player/src/components/story-outcome-content.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { usePlayerRuntime } from "../player-context";
+import { type PlayerState } from "../player-reducer";
 import { findSelectedChoice, getStoryMetrics } from "../player-selectors";
 import { type SerializedStep } from "../prepare-activity-data";
 import { StoryMetricPill } from "./story-metric-pill";
@@ -30,7 +31,7 @@ function isStrongChoice({
   results,
   step,
 }: {
-  results: Record<string, { answer?: { kind: string; selectedChoiceId?: string } }>;
+  results: PlayerState["results"];
   step: SerializedStep;
 }): boolean {
   const choice = findSelectedChoice({ results, step });
@@ -45,7 +46,7 @@ function countStrongChoices({
   results,
   steps,
 }: {
-  results: Record<string, { answer?: { kind: string; selectedChoiceId?: string } }>;
+  results: PlayerState["results"];
   steps: SerializedStep[];
 }): number {
   return steps.filter((step) => isStrongChoice({ results, step })).length;

--- a/packages/player/src/components/story-step.tsx
+++ b/packages/player/src/components/story-step.tsx
@@ -56,7 +56,6 @@ export function StoryStep({
   return (
     <ChoiceStepLayout
       context={content.situation}
-      keyboardEnabled={selectedAnswer === undefined || selectedAnswer.kind === "story"}
       onSelect={handleSelect}
       options={content.choices.map((choice) => ({ key: choice.id, text: choice.text }))}
       selectedIndex={selectedIndex}

--- a/packages/player/src/components/story-step.tsx
+++ b/packages/player/src/components/story-step.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
+import { type SelectedAnswer } from "../player-reducer";
+import { type SerializedStep } from "../prepare-activity-data";
+import { ChoiceStepLayout } from "./choice-step-layout";
+
+function getSelectedIndex(
+  selectedAnswer: SelectedAnswer | undefined,
+  choices: { id: string }[],
+): number | null {
+  if (selectedAnswer?.kind !== "story") {
+    return null;
+  }
+
+  const index = choices.findIndex((choice) => choice.id === selectedAnswer.selectedChoiceId);
+
+  if (index === -1) {
+    return null;
+  }
+
+  return index;
+}
+
+export function StoryStep({
+  onSelectAnswer,
+  selectedAnswer,
+  step,
+}: {
+  onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
+  selectedAnswer: SelectedAnswer | undefined;
+  step: SerializedStep;
+}) {
+  const content = parseStepContent("story", step.content);
+  const selectedIndex = getSelectedIndex(selectedAnswer, content.choices);
+
+  const handleSelect = (index: number) => {
+    const choice = content.choices[index];
+
+    if (!choice) {
+      return;
+    }
+
+    if (selectedIndex === index) {
+      onSelectAnswer(step.id, null);
+      return;
+    }
+
+    onSelectAnswer(step.id, {
+      kind: "story",
+      selectedChoiceId: choice.id,
+      selectedText: choice.text,
+    });
+  };
+
+  return (
+    <ChoiceStepLayout
+      context={content.situation}
+      keyboardEnabled={selectedAnswer === undefined || selectedAnswer.kind === "story"}
+      onSelect={handleSelect}
+      options={content.choices.map((choice) => ({ key: choice.id, text: choice.text }))}
+      selectedIndex={selectedIndex}
+    />
+  );
+}

--- a/packages/player/src/player-completion.test.ts
+++ b/packages/player/src/player-completion.test.ts
@@ -150,6 +150,31 @@ describe(computeLocalCompletion, () => {
       expect(completion.energyDelta).toBe(3);
     });
 
+    test("detects story activity when story steps are preceded by static intro", () => {
+      const steps = [
+        buildStep({
+          content: {
+            intro: "You are a manager.",
+            metrics: ["Production", "Morale"],
+            variant: "storyIntro" as const,
+          },
+          id: "intro",
+          kind: "static",
+          position: 0,
+        }),
+        buildStoryStep("s1", 1),
+        buildStoryStep("s2", 2),
+      ];
+
+      const results: Record<string, StepResult> = {
+        s1: buildStoryResult("s1", "1a"),
+        s2: buildStoryResult("s2", "1b"),
+      };
+
+      const completion = computeLocalCompletion(buildState({ results, steps }));
+      expect(completion.brainPower).toBe(100);
+    });
+
     test("adds story BP to existing totalBrainPower", () => {
       const steps = [buildStoryStep("s1", 0)];
       const results: Record<string, StepResult> = {

--- a/packages/player/src/player-completion.ts
+++ b/packages/player/src/player-completion.ts
@@ -36,7 +36,7 @@ function getStoryAlignments(state: PlayerState): StoryAlignment[] {
  * in the background via `after()`.
  */
 export function computeLocalCompletion(state: PlayerState): CompletionResult {
-  const isStory = state.steps[0]?.kind === "story";
+  const isStory = state.steps.some((step) => step.kind === "story");
 
   const score = isStory
     ? computeStoryScore({ alignments: getStoryAlignments(state) })

--- a/packages/player/src/player-provider.tsx
+++ b/packages/player/src/player-provider.tsx
@@ -11,7 +11,12 @@ import {
 } from "./player-context";
 import { type InitialStateInput } from "./player-initial-state";
 import { createInitialState, playerReducer } from "./player-reducer";
-import { getCanNavigatePrev, getHasAnswer, getIsStaticStep } from "./player-selectors";
+import {
+  getCanNavigatePrev,
+  getHasAnswer,
+  getIsStaticStep,
+  getStoryStaticVariant,
+} from "./player-selectors";
 import { type SerializedActivity } from "./prepare-activity-data";
 import { usePlayerActions } from "./use-player-actions";
 import { usePlayerKeyboard } from "./use-player-keyboard";
@@ -61,6 +66,7 @@ export function PlayerProvider({
     onNext: onNext ? handleNext : null,
     onRestart: actions.restart,
     phase: state.phase,
+    storyStaticVariant: getStoryStaticVariant(state),
   });
 
   const configValue = useMemo(

--- a/packages/player/src/player-reducer.test.ts
+++ b/packages/player/src/player-reducer.test.ts
@@ -411,6 +411,93 @@ describe("NAVIGATE_STEP", () => {
     const next = playerReducer(state, { direction: "next", type: "NAVIGATE_STEP" });
     expect(next).toBe(state);
   });
+
+  describe("story static steps", () => {
+    const storyIntroContent = {
+      intro: "You are a factory manager.",
+      metrics: ["Production", "Morale"],
+      variant: "storyIntro" as const,
+    };
+
+    const storyOutcomeContent = {
+      metrics: ["Production"],
+      outcomes: [{ minStrongChoices: 0, narrative: "Result.", title: "Outcome" }],
+      variant: "storyOutcome" as const,
+    };
+
+    function buildStoryIntroStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
+      return buildStep({ content: storyIntroContent, id: "intro", kind: "static", ...overrides });
+    }
+
+    function buildStoryOutcomeStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
+      return buildStep({
+        content: storyOutcomeContent,
+        id: "outcome",
+        kind: "static",
+        ...overrides,
+      });
+    }
+
+    test("next advances on storyIntro step", () => {
+      const steps = [
+        buildStoryIntroStep({ position: 0 }),
+        buildStep({ id: "s2", kind: "static", position: 1 }),
+      ];
+      const state = buildState({ steps });
+      const next = playerReducer(state, { direction: "next", type: "NAVIGATE_STEP" });
+      expect(next.currentStepIndex).toBe(1);
+    });
+
+    test("next advances on storyOutcome step", () => {
+      const steps = [
+        buildStoryOutcomeStep({ position: 0 }),
+        buildStep({ id: "s2", kind: "static", position: 1 }),
+      ];
+      const state = buildState({ steps });
+      const next = playerReducer(state, { direction: "next", type: "NAVIGATE_STEP" });
+      expect(next.currentStepIndex).toBe(1);
+    });
+
+    test("next on last storyIntro step transitions to completed", () => {
+      const steps = [buildStoryIntroStep()];
+      const state = buildState({ currentStepIndex: 0, steps, totalBrainPower: 50 });
+      const next = playerReducer(state, { direction: "next", type: "NAVIGATE_STEP" });
+      expect(next.phase).toBe("completed");
+      expect(next.completion).not.toBeNull();
+    });
+
+    test("prev no-ops on story static step (forward-only)", () => {
+      const steps = [
+        buildStoryIntroStep({ position: 0 }),
+        buildStoryOutcomeStep({ id: "outcome", position: 1 }),
+      ];
+      const state = buildState({ currentStepIndex: 1, steps });
+      const next = playerReducer(state, { direction: "prev", type: "NAVIGATE_STEP" });
+      expect(next).toBe(state);
+    });
+
+    test("next resets stepStartedAt on story static step", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-03-15T10:00:00"));
+
+      const steps = [
+        buildStoryIntroStep({ position: 0 }),
+        buildStep({ id: "s2", kind: "static", position: 1 }),
+      ];
+      const state = buildState({ stepStartedAt: 1000, steps });
+      const next = playerReducer(state, { direction: "next", type: "NAVIGATE_STEP" });
+      expect(next.stepStartedAt).toBe(Date.now());
+
+      vi.useRealTimers();
+    });
+
+    test("no-ops in feedback phase", () => {
+      const steps = [buildStoryIntroStep()];
+      const state = buildState({ phase: "feedback", steps });
+      const next = playerReducer(state, { direction: "next", type: "NAVIGATE_STEP" });
+      expect(next).toBe(state);
+    });
+  });
 });
 
 describe("COMPLETE", () => {

--- a/packages/player/src/player-reducer.ts
+++ b/packages/player/src/player-reducer.ts
@@ -1,3 +1,4 @@
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { type AnswerResult } from "./check-answer";
 import { type CompletionResult } from "./completion-input-schema";
 import { computeLocalCompletion } from "./player-completion";
@@ -145,6 +146,21 @@ function handleContinue(state: PlayerState): PlayerState {
   };
 }
 
+/**
+ * Checks whether the current step is a story static variant (intro, outcome,
+ * debrief). These steps allow forward-only navigation via the "Begin" /
+ * "Continue" buttons but not arrow-key navigation.
+ */
+function isStoryStaticStep(step: SerializedStep | undefined): boolean {
+  if (!step || step.kind !== "static") {
+    return false;
+  }
+
+  const content = parseStepContent("static", step.content);
+
+  return content.variant === "storyIntro" || content.variant === "storyOutcome";
+}
+
 function handleNavigateStep(
   state: PlayerState,
   action: Extract<PlayerAction, { type: "NAVIGATE_STEP" }>,
@@ -154,6 +170,21 @@ function handleNavigateStep(
   }
 
   const currentStep = state.steps[state.currentStepIndex];
+
+  /**
+   * Story static steps (intro, outcome, debrief) allow forward-only
+   * navigation via the bottom bar action buttons. They don't participate
+   * in arrow-key navigation handled by `isStaticNavigationStep`.
+   */
+  if (isStoryStaticStep(currentStep) && action.direction === "next") {
+    const nextIndex = state.currentStepIndex + 1;
+
+    if (nextIndex >= state.steps.length) {
+      return completeWith(state);
+    }
+
+    return { ...state, currentStepIndex: nextIndex, stepStartedAt: Date.now() };
+  }
 
   if (!isStaticNavigationStep(currentStep)) {
     return state;

--- a/packages/player/src/player-reducer.ts
+++ b/packages/player/src/player-reducer.ts
@@ -1,10 +1,10 @@
-import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { type AnswerResult } from "./check-answer";
 import { type CompletionResult } from "./completion-input-schema";
 import { computeLocalCompletion } from "./player-completion";
 import { buildInitialAnswers } from "./player-initial-state";
 import { type SerializedStep } from "./prepare-activity-data";
 import { canNavigatePrev, isStaticNavigationStep } from "./step-navigation";
+import { isStoryStaticVariant } from "./story";
 
 export type PlayerPhase = "playing" | "feedback" | "completed";
 
@@ -147,18 +147,18 @@ function handleContinue(state: PlayerState): PlayerState {
 }
 
 /**
- * Checks whether the current step is a story static variant (intro, outcome,
- * debrief). These steps allow forward-only navigation via the "Begin" /
- * "Continue" buttons but not arrow-key navigation.
+ * Moves the player to the next step, or completes the activity if there
+ * are no more steps. Shared by both story-static and regular-static
+ * forward navigation to avoid duplicating the advance-or-complete logic.
  */
-function isStoryStaticStep(step: SerializedStep | undefined): boolean {
-  if (!step || step.kind !== "static") {
-    return false;
+function advanceForward(state: PlayerState): PlayerState {
+  const nextIndex = state.currentStepIndex + 1;
+
+  if (nextIndex >= state.steps.length) {
+    return completeWith(state);
   }
 
-  const content = parseStepContent("static", step.content);
-
-  return content.variant === "storyIntro" || content.variant === "storyOutcome";
+  return { ...state, currentStepIndex: nextIndex, stepStartedAt: Date.now() };
 }
 
 function handleNavigateStep(
@@ -176,14 +176,8 @@ function handleNavigateStep(
    * navigation via the bottom bar action buttons. They don't participate
    * in arrow-key navigation handled by `isStaticNavigationStep`.
    */
-  if (isStoryStaticStep(currentStep) && action.direction === "next") {
-    const nextIndex = state.currentStepIndex + 1;
-
-    if (nextIndex >= state.steps.length) {
-      return completeWith(state);
-    }
-
-    return { ...state, currentStepIndex: nextIndex, stepStartedAt: Date.now() };
+  if (currentStep && isStoryStaticVariant(currentStep) && action.direction === "next") {
+    return advanceForward(state);
   }
 
   if (!isStaticNavigationStep(currentStep)) {
@@ -200,13 +194,7 @@ function handleNavigateStep(
     return { ...state, currentStepIndex: prevIndex, stepStartedAt: Date.now() };
   }
 
-  const nextIndex = state.currentStepIndex + 1;
-
-  if (nextIndex >= state.steps.length) {
-    return completeWith(state);
-  }
-
-  return { ...state, currentStepIndex: nextIndex, stepStartedAt: Date.now() };
+  return advanceForward(state);
 }
 
 function handleRestart(state: PlayerState): PlayerState {

--- a/packages/player/src/player-selectors.test.ts
+++ b/packages/player/src/player-selectors.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "vitest";
 import { type PlayerState, type StepResult } from "./player-reducer";
 import {
+  findSelectedChoice,
   getIsStoryActivity,
+  getStoryBriefingText,
   getStoryMetrics,
   getStoryStaticVariant,
   getUpcomingImages,
@@ -160,6 +162,129 @@ describe(getStoryStaticVariant, () => {
     });
 
     expect(getStoryStaticVariant(state)).toBeNull();
+  });
+});
+
+describe(getStoryBriefingText, () => {
+  test("returns intro text when current step is a story decision step", () => {
+    const state = buildState({
+      currentStepIndex: 1,
+      steps: [buildStoryIntroStep(), buildStoryStep("s1", 1)],
+    });
+
+    expect(getStoryBriefingText(state)).toBe("You are a factory manager.");
+  });
+
+  test("returns null when current step is a static step", () => {
+    const state = buildState({
+      currentStepIndex: 0,
+      steps: [buildStoryIntroStep(), buildStoryStep("s1", 1)],
+    });
+
+    expect(getStoryBriefingText(state)).toBeNull();
+  });
+
+  test("returns null when current step is not a story step", () => {
+    const state = buildState({
+      steps: [buildStep({ id: "s1" })],
+    });
+
+    expect(getStoryBriefingText(state)).toBeNull();
+  });
+
+  test("returns null when there is no intro step", () => {
+    const state = buildState({
+      steps: [buildStoryStep("s1", 0)],
+    });
+
+    expect(getStoryBriefingText(state)).toBeNull();
+  });
+
+  test("finds intro even when a non-intro static step comes first", () => {
+    const state = buildState({
+      currentStepIndex: 2,
+      steps: [
+        buildStep({
+          content: { text: "Welcome", title: "Preamble", variant: "text" as const },
+          id: "text-static",
+          kind: "static",
+          position: 0,
+        }),
+        buildStoryIntroStep(),
+        buildStoryStep("s1", 2),
+      ],
+    });
+
+    expect(getStoryBriefingText(state)).toBe("You are a factory manager.");
+  });
+});
+
+describe(findSelectedChoice, () => {
+  test("returns the matching choice when a story answer exists", () => {
+    const step = buildStoryStep("s1", 0);
+    const results = { s1: buildStoryResult("s1", "c1") };
+
+    const choice = findSelectedChoice({ results, step });
+
+    expect(choice).toEqual(
+      expect.objectContaining({ alignment: "strong", id: "c1", text: "Strong choice" }),
+    );
+  });
+
+  test("returns null when the step has no result", () => {
+    const step = buildStoryStep("s1", 0);
+
+    expect(findSelectedChoice({ results: {}, step })).toBeNull();
+  });
+
+  test("returns null when the answer is not a story kind", () => {
+    const step = buildStoryStep("s1", 0);
+    const results = {
+      s1: {
+        answer: { kind: "multipleChoice" as const, selectedIndex: 0, selectedText: "A" },
+        result: { correctAnswer: null, feedback: null, isCorrect: true },
+        stepId: "s1",
+      },
+    };
+
+    expect(findSelectedChoice({ results, step })).toBeNull();
+  });
+
+  test("returns null when the choice ID does not match any option", () => {
+    const step = buildStoryStep("s1", 0);
+    const results = {
+      s1: buildStoryResult("s1", "nonexistent"),
+    };
+
+    expect(findSelectedChoice({ results, step })).toBeNull();
+  });
+});
+
+describe("findStoryIntroContent (via getStoryMetrics)", () => {
+  test("finds storyIntro even when a non-intro static step comes first", () => {
+    const state = buildState({
+      steps: [
+        buildStep({
+          content: { text: "Welcome", title: "Preamble", variant: "text" as const },
+          id: "text-static",
+          kind: "static",
+          position: 0,
+        }),
+        buildStep({
+          content: {
+            intro: "You are a factory manager.",
+            metrics: ["Production"],
+            variant: "storyIntro" as const,
+          },
+          id: "intro",
+          kind: "static",
+          position: 1,
+        }),
+        buildStoryStep("s1", 2),
+      ],
+    });
+
+    expect(getStoryMetrics(state)).toEqual([{ metric: "Production", value: 50 }]);
   });
 });
 

--- a/packages/player/src/player-selectors.test.ts
+++ b/packages/player/src/player-selectors.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "vitest";
-import { type PlayerState } from "./player-reducer";
-import { getUpcomingImages } from "./player-selectors";
+import { type PlayerState, type StepResult } from "./player-reducer";
+import {
+  getIsStoryActivity,
+  getStoryMetrics,
+  getStoryStaticVariant,
+  getUpcomingImages,
+} from "./player-selectors";
 import { type SerializedStep } from "./prepare-activity-data";
 
 function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
@@ -38,6 +43,199 @@ function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
     ...overrides,
   };
 }
+
+const storyStepContent = {
+  choices: [
+    {
+      alignment: "strong" as const,
+      consequence: "Things improve.",
+      id: "c1",
+      metricEffects: [{ effect: "positive" as const, metric: "Production" }],
+      text: "Strong choice",
+    },
+    {
+      alignment: "partial" as const,
+      consequence: "Mixed results.",
+      id: "c2",
+      metricEffects: [{ effect: "neutral" as const, metric: "Production" }],
+      text: "Partial choice",
+    },
+    {
+      alignment: "weak" as const,
+      consequence: "Things get worse.",
+      id: "c3",
+      metricEffects: [
+        { effect: "negative" as const, metric: "Production" },
+        { effect: "negative" as const, metric: "Morale" },
+      ],
+      text: "Weak choice",
+    },
+  ],
+  situation: "You face a decision.",
+};
+
+function buildStoryStep(id: string, position: number): SerializedStep {
+  return buildStep({ content: storyStepContent, id, kind: "story", position });
+}
+
+function buildStoryIntroStep(): SerializedStep {
+  return buildStep({
+    content: {
+      intro: "You are a factory manager.",
+      metrics: ["Production", "Morale"],
+      variant: "storyIntro" as const,
+    },
+    id: "intro",
+    kind: "static",
+    position: 0,
+  });
+}
+
+function buildStoryResult(stepId: string, selectedChoiceId: string): StepResult {
+  return {
+    answer: { kind: "story", selectedChoiceId, selectedText: "choice" },
+    result: { correctAnswer: null, feedback: null, isCorrect: selectedChoiceId !== "c3" },
+    stepId,
+  };
+}
+
+describe(getIsStoryActivity, () => {
+  test("returns true when activity has story steps", () => {
+    const state = buildState({
+      steps: [buildStoryIntroStep(), buildStoryStep("s1", 1)],
+    });
+
+    expect(getIsStoryActivity(state)).toBe(true);
+  });
+
+  test("returns false when activity has no story steps", () => {
+    const state = buildState({
+      steps: [buildStep({ id: "s1" }), buildStep({ id: "s2", position: 1 })],
+    });
+
+    expect(getIsStoryActivity(state)).toBe(false);
+  });
+});
+
+describe(getStoryStaticVariant, () => {
+  test("returns storyIntro when current step is a story intro", () => {
+    const state = buildState({
+      currentStepIndex: 0,
+      steps: [buildStoryIntroStep(), buildStoryStep("s1", 1)],
+    });
+
+    expect(getStoryStaticVariant(state)).toBe("storyIntro");
+  });
+
+  test("returns storyOutcome when current step is a story outcome", () => {
+    const state = buildState({
+      currentStepIndex: 0,
+      steps: [
+        buildStep({
+          content: {
+            metrics: ["Production"],
+            outcomes: [{ minStrongChoices: 0, narrative: "Result.", title: "Outcome" }],
+            variant: "storyOutcome" as const,
+          },
+          id: "outcome",
+          kind: "static",
+        }),
+      ],
+    });
+
+    expect(getStoryStaticVariant(state)).toBe("storyOutcome");
+  });
+
+  test("returns null when current step is a regular static step", () => {
+    const state = buildState({
+      steps: [buildStep({ content: { text: "Hello", title: "Intro", variant: "text" as const } })],
+    });
+
+    expect(getStoryStaticVariant(state)).toBeNull();
+  });
+
+  test("returns null when current step is a story decision step", () => {
+    const state = buildState({
+      steps: [buildStoryStep("s1", 0)],
+    });
+
+    expect(getStoryStaticVariant(state)).toBeNull();
+  });
+});
+
+describe(getStoryMetrics, () => {
+  test("returns initial values when no story steps are answered", () => {
+    const state = buildState({
+      steps: [buildStoryIntroStep(), buildStoryStep("s1", 1)],
+    });
+
+    expect(getStoryMetrics(state)).toEqual([
+      { metric: "Production", value: 50 },
+      { metric: "Morale", value: 50 },
+    ]);
+  });
+
+  test("accumulates positive effects (+15)", () => {
+    const state = buildState({
+      results: { s1: buildStoryResult("s1", "c1") },
+      steps: [buildStoryIntroStep(), buildStoryStep("s1", 1)],
+    });
+
+    expect(getStoryMetrics(state)).toEqual([
+      { metric: "Production", value: 65 },
+      { metric: "Morale", value: 50 },
+    ]);
+  });
+
+  test("accumulates negative effects (-15)", () => {
+    const state = buildState({
+      results: { s1: buildStoryResult("s1", "c3") },
+      steps: [buildStoryIntroStep(), buildStoryStep("s1", 1)],
+    });
+
+    expect(getStoryMetrics(state)).toEqual([
+      { metric: "Production", value: 35 },
+      { metric: "Morale", value: 35 },
+    ]);
+  });
+
+  test("neutral effects leave value unchanged", () => {
+    const state = buildState({
+      results: { s1: buildStoryResult("s1", "c2") },
+      steps: [buildStoryIntroStep(), buildStoryStep("s1", 1)],
+    });
+
+    expect(getStoryMetrics(state)).toEqual([
+      { metric: "Production", value: 50 },
+      { metric: "Morale", value: 50 },
+    ]);
+  });
+
+  test("accumulates effects across multiple steps", () => {
+    const state = buildState({
+      results: {
+        s1: buildStoryResult("s1", "c1"),
+        s2: buildStoryResult("s2", "c3"),
+      },
+      steps: [buildStoryIntroStep(), buildStoryStep("s1", 1), buildStoryStep("s2", 2)],
+    });
+
+    // Production: 50 + 15 (c1) - 15 (c3) = 50
+    // Morale: 50 + 0 (c1) - 15 (c3) = 35
+    expect(getStoryMetrics(state)).toEqual([
+      { metric: "Production", value: 50 },
+      { metric: "Morale", value: 35 },
+    ]);
+  });
+
+  test("returns empty array when there is no intro step", () => {
+    const state = buildState({
+      steps: [buildStoryStep("s1", 0)],
+    });
+
+    expect(getStoryMetrics(state)).toEqual([]);
+  });
+});
 
 describe(getUpcomingImages, () => {
   test("returns empty array when no upcoming steps have images", () => {

--- a/packages/player/src/player-selectors.ts
+++ b/packages/player/src/player-selectors.ts
@@ -3,7 +3,7 @@ import { type CompletionResult } from "./completion-input-schema";
 import { type PlayerState } from "./player-reducer";
 import { type SerializedStep } from "./prepare-activity-data";
 import { canNavigatePrev, isStaticNavigationStep } from "./step-navigation";
-import { EFFECT_DELTA_MAP } from "./story";
+import { EFFECT_DELTA_MAP, METRIC_AVERAGE_THRESHOLD } from "./story";
 
 function computeProgress(currentIndex: number, total: number): number {
   if (total === 0) {
@@ -123,8 +123,6 @@ export type StoryMetric = {
   value: number;
 };
 
-const METRIC_STARTING_VALUE = 50;
-
 /**
  * Finds the storyIntro step and returns its parsed content, or null if
  * no intro step exists. Shared by getStoryMetrics (needs metrics) and
@@ -216,7 +214,7 @@ export function getStoryMetrics(state: PlayerState): StoryMetric[] {
     metric: name,
     value: storySteps.reduce(
       (sum, step) => sum + getStepMetricDelta({ metric: name, results: state.results, step }),
-      METRIC_STARTING_VALUE,
+      METRIC_AVERAGE_THRESHOLD,
     ),
   }));
 }

--- a/packages/player/src/player-selectors.ts
+++ b/packages/player/src/player-selectors.ts
@@ -1,4 +1,4 @@
-import { parseStepContent } from "@zoonk/core/steps/content-contract";
+import { type StoryStaticVariant, parseStepContent } from "@zoonk/core/steps/content-contract";
 import { type CompletionResult } from "./completion-input-schema";
 import { type PlayerState } from "./player-reducer";
 import { type SerializedStep } from "./prepare-activity-data";
@@ -66,8 +66,6 @@ export function getSelectedAnswer(state: PlayerState) {
 
   return state.selectedAnswers[currentStep.id];
 }
-
-export type StoryStaticVariant = "storyIntro" | "storyOutcome";
 
 /** Returns true when the activity contains at least one story decision step. */
 export function getIsStoryActivity(state: PlayerState): boolean {

--- a/packages/player/src/player-selectors.ts
+++ b/packages/player/src/player-selectors.ts
@@ -66,6 +66,178 @@ export function getSelectedAnswer(state: PlayerState) {
   return state.selectedAnswers[currentStep.id];
 }
 
+export type StoryStaticVariant = "storyIntro" | "storyOutcome";
+
+/** Returns true when the activity contains at least one story decision step. */
+export function getIsStoryActivity(state: PlayerState): boolean {
+  return state.steps.some((step) => step.kind === "story");
+}
+
+/**
+ * Returns the intro text from the storyIntro step, or null if the current
+ * step is not a story decision step.
+ *
+ * Used by the sticky header to show a briefing popover only during
+ * decision-making, so players can recall the premise without navigating back.
+ */
+export function getStoryBriefingText(state: PlayerState): string | null {
+  const currentStep = getCurrentStep(state);
+
+  if (!currentStep || currentStep.kind !== "story") {
+    return null;
+  }
+
+  const introStep = state.steps.find((step) => step.kind === "static");
+
+  if (!introStep) {
+    return null;
+  }
+
+  const content = parseStepContent("static", introStep.content);
+
+  if (content.variant !== "storyIntro") {
+    return null;
+  }
+
+  return content.intro;
+}
+
+/**
+ * Returns the story-specific static variant of the current step, or null
+ * if the current step is not a story static screen.
+ *
+ * Used by PlayerShell to pick the correct bottom bar (Begin, Continue)
+ * and by keyboard handlers for Enter key behavior.
+ */
+export function getStoryStaticVariant(state: PlayerState): StoryStaticVariant | null {
+  const step = getCurrentStep(state);
+
+  if (!step || step.kind !== "static") {
+    return null;
+  }
+
+  const content = parseStepContent("static", step.content);
+
+  if (content.variant === "storyIntro" || content.variant === "storyOutcome") {
+    return content.variant;
+  }
+
+  return null;
+}
+
+export type StoryMetric = {
+  metric: string;
+  value: number;
+};
+
+const METRIC_STARTING_VALUE = 50;
+const METRIC_POSITIVE_DELTA = 15;
+const METRIC_NEGATIVE_DELTA = -15;
+
+/**
+ * Computes the current value of each story metric by walking all completed
+ * story step results.
+ *
+ * Reads metric names from the storyIntro step (first step), then for each
+ * answered story step, looks up the selected choice's metricEffects and
+ * accumulates deltas (positive = +15, neutral = 0, negative = -15) starting
+ * from 50.
+ */
+/**
+ * Finds the storyIntro step and returns its metric names, or null if
+ * no intro step exists.
+ */
+function findIntroMetricNames(steps: SerializedStep[]): string[] | null {
+  const introStep = steps.find((step) => step.kind === "static");
+
+  if (!introStep) {
+    return null;
+  }
+
+  const content = parseStepContent("static", introStep.content);
+
+  if (content.variant !== "storyIntro") {
+    return null;
+  }
+
+  return content.metrics;
+}
+
+/**
+ * Extracts the selected choice from a story step result, if available.
+ * Returns null when the step has no result or the choice ID doesn't match.
+ */
+function findSelectedChoice(
+  step: SerializedStep,
+  results: Record<string, { answer?: { kind: string; selectedChoiceId?: string } }>,
+) {
+  const result = results[step.id];
+  const answer = result?.answer;
+
+  if (!answer || answer.kind !== "story" || !answer.selectedChoiceId) {
+    return null;
+  }
+
+  const choiceId = answer.selectedChoiceId;
+  const content = parseStepContent("story", step.content);
+
+  return content.choices.find((option) => option.id === choiceId) ?? null;
+}
+
+/**
+ * Applies a single story step's metric effects to the running totals.
+ */
+function applyMetricEffects(
+  metricValues: Map<string, number>,
+  step: SerializedStep,
+  results: Record<string, { answer?: { kind: string; selectedChoiceId?: string } }>,
+): void {
+  const choice = findSelectedChoice(step, results);
+
+  if (!choice) {
+    return;
+  }
+
+  for (const effect of choice.metricEffects) {
+    const current = metricValues.get(effect.metric) ?? METRIC_STARTING_VALUE;
+    const delta = getMetricDelta(effect.effect);
+    metricValues.set(effect.metric, current + delta);
+  }
+}
+
+export function getStoryMetrics(state: PlayerState): StoryMetric[] {
+  const metricNames = findIntroMetricNames(state.steps);
+
+  if (!metricNames) {
+    return [];
+  }
+
+  const metricValues = new Map(metricNames.map((name) => [name, METRIC_STARTING_VALUE]));
+
+  const storySteps = state.steps.filter((step) => step.kind === "story");
+
+  for (const step of storySteps) {
+    applyMetricEffects(metricValues, step, state.results);
+  }
+
+  return metricNames.map((name) => ({
+    metric: name,
+    value: metricValues.get(name) ?? METRIC_STARTING_VALUE,
+  }));
+}
+
+function getMetricDelta(effect: "negative" | "neutral" | "positive"): number {
+  if (effect === "positive") {
+    return METRIC_POSITIVE_DELTA;
+  }
+
+  if (effect === "negative") {
+    return METRIC_NEGATIVE_DELTA;
+  }
+
+  return 0;
+}
+
 export type PreloadableImage = {
   kind: "selectImage" | "visual";
   url: string;

--- a/packages/player/src/player-selectors.ts
+++ b/packages/player/src/player-selectors.ts
@@ -147,8 +147,11 @@ function findStoryIntroContent(steps: SerializedStep[]) {
 /**
  * Extracts the selected choice from a story step result, if available.
  * Returns null when the step has no result or the choice ID doesn't match.
+ *
+ * Also used by the outcome screen to determine choice alignment
+ * without duplicating the lookup logic.
  */
-function findSelectedChoice({
+export function findSelectedChoice({
   step,
   results,
 }: {

--- a/packages/player/src/player-selectors.ts
+++ b/packages/player/src/player-selectors.ts
@@ -3,8 +3,9 @@ import { type CompletionResult } from "./completion-input-schema";
 import { type PlayerState } from "./player-reducer";
 import { type SerializedStep } from "./prepare-activity-data";
 import { canNavigatePrev, isStaticNavigationStep } from "./step-navigation";
-import { EFFECT_DELTA_MAP, METRIC_AVERAGE_THRESHOLD } from "./story";
+import { EFFECT_DELTA_MAP, METRIC_AVERAGE_THRESHOLD, getStepStoryVariant } from "./story";
 
+/** Converts a 0-based step index to a 1-based percentage (0–100). */
 function computeProgress(currentIndex: number, total: number): number {
   if (total === 0) {
     return 0;
@@ -13,14 +14,17 @@ function computeProgress(currentIndex: number, total: number): number {
   return Math.round(((currentIndex + 1) / total) * 100);
 }
 
+/** Whether the player can navigate to the previous step. */
 export function getCanNavigatePrev(state: PlayerState): boolean {
   return canNavigatePrev(state.steps, state.currentStepIndex);
 }
 
+/** Returns the completion payload once the activity is finished, or null while still playing. */
 export function getCompletionResult(state: PlayerState): CompletionResult | null {
   return state.completion;
 }
 
+/** Returns the checked result for the current step, or undefined if not yet checked. */
 export function getCurrentResult(state: PlayerState) {
   const currentStep = getCurrentStep(state);
 
@@ -31,10 +35,12 @@ export function getCurrentResult(state: PlayerState) {
   return state.results[currentStep.id];
 }
 
+/** Returns the step at the current index. */
 export function getCurrentStep(state: PlayerState) {
   return state.steps[state.currentStepIndex];
 }
 
+/** Whether the player has selected an answer for the current step. */
 export function getHasAnswer(state: PlayerState): boolean {
   const currentStep = getCurrentStep(state);
 
@@ -45,10 +51,12 @@ export function getHasAnswer(state: PlayerState): boolean {
   return Boolean(state.selectedAnswers[currentStep.id]);
 }
 
+/** Whether the current step uses static (auto-advance) navigation. */
 export function getIsStaticStep(state: PlayerState): boolean {
   return isStaticNavigationStep(getCurrentStep(state));
 }
 
+/** Returns the progress percentage (0–100), snapping to 100 when completed. */
 export function getProgressValue(state: PlayerState): number {
   if (state.phase === "completed") {
     return 100;
@@ -57,6 +65,7 @@ export function getProgressValue(state: PlayerState): number {
   return computeProgress(state.currentStepIndex, state.steps.length);
 }
 
+/** Returns the selected answer for the current step, or undefined if none selected. */
 export function getSelectedAnswer(state: PlayerState) {
   const currentStep = getCurrentStep(state);
 
@@ -103,19 +112,7 @@ export function getStoryBriefingText(state: PlayerState): string | null {
  * and by keyboard handlers for Enter key behavior.
  */
 export function getStoryStaticVariant(state: PlayerState): StoryStaticVariant | null {
-  const step = getCurrentStep(state);
-
-  if (!step || step.kind !== "static") {
-    return null;
-  }
-
-  const content = parseStepContent("static", step.content);
-
-  if (content.variant === "storyIntro" || content.variant === "storyOutcome") {
-    return content.variant;
-  }
-
-  return null;
+  return getStepStoryVariant(getCurrentStep(state));
 }
 
 export type StoryMetric = {
@@ -127,21 +124,22 @@ export type StoryMetric = {
  * Finds the storyIntro step and returns its parsed content, or null if
  * no intro step exists. Shared by getStoryMetrics (needs metrics) and
  * getStoryBriefingText (needs intro text).
+ *
+ * Scans all static steps (not just the first one) because a non-intro
+ * static step could appear earlier in the list.
  */
 function findStoryIntroContent(steps: SerializedStep[]) {
-  const introStep = steps.find((step) => step.kind === "static");
+  for (const step of steps) {
+    if (step.kind === "static") {
+      const content = parseStepContent("static", step.content);
 
-  if (!introStep) {
-    return null;
+      if (content.variant === "storyIntro") {
+        return content;
+      }
+    }
   }
 
-  const content = parseStepContent("static", introStep.content);
-
-  if (content.variant !== "storyIntro") {
-    return null;
-  }
-
-  return content;
+  return null;
 }
 
 /**
@@ -156,7 +154,7 @@ export function findSelectedChoice({
   results,
 }: {
   step: SerializedStep;
-  results: Record<string, { answer?: { kind: string; selectedChoiceId?: string } }>;
+  results: PlayerState["results"];
 }) {
   const result = results[step.id];
   const answer = result?.answer;
@@ -182,7 +180,7 @@ function getStepMetricDelta({
   step,
 }: {
   metric: string;
-  results: Record<string, { answer?: { kind: string; selectedChoiceId?: string } }>;
+  results: PlayerState["results"];
   step: SerializedStep;
 }): number {
   const choice = findSelectedChoice({ results, step });

--- a/packages/player/src/player-selectors.ts
+++ b/packages/player/src/player-selectors.ts
@@ -86,19 +86,13 @@ export function getStoryBriefingText(state: PlayerState): string | null {
     return null;
   }
 
-  const introStep = state.steps.find((step) => step.kind === "static");
+  const introContent = findStoryIntroContent(state.steps);
 
-  if (!introStep) {
+  if (!introContent) {
     return null;
   }
 
-  const content = parseStepContent("static", introStep.content);
-
-  if (content.variant !== "storyIntro") {
-    return null;
-  }
-
-  return content.intro;
+  return introContent.intro;
 }
 
 /**
@@ -132,19 +126,11 @@ export type StoryMetric = {
 const METRIC_STARTING_VALUE = 50;
 
 /**
- * Computes the current value of each story metric by walking all completed
- * story step results.
- *
- * Reads metric names from the storyIntro step (first step), then for each
- * answered story step, looks up the selected choice's metricEffects and
- * accumulates deltas (positive = +15, neutral = 0, negative = -15) starting
- * from 50.
+ * Finds the storyIntro step and returns its parsed content, or null if
+ * no intro step exists. Shared by getStoryMetrics (needs metrics) and
+ * getStoryBriefingText (needs intro text).
  */
-/**
- * Finds the storyIntro step and returns its metric names, or null if
- * no intro step exists.
- */
-function findIntroMetricNames(steps: SerializedStep[]): string[] | null {
+function findStoryIntroContent(steps: SerializedStep[]) {
   const introStep = steps.find((step) => step.kind === "static");
 
   if (!introStep) {
@@ -157,17 +143,20 @@ function findIntroMetricNames(steps: SerializedStep[]): string[] | null {
     return null;
   }
 
-  return content.metrics;
+  return content;
 }
 
 /**
  * Extracts the selected choice from a story step result, if available.
  * Returns null when the step has no result or the choice ID doesn't match.
  */
-function findSelectedChoice(
-  step: SerializedStep,
-  results: Record<string, { answer?: { kind: string; selectedChoiceId?: string } }>,
-) {
+function findSelectedChoice({
+  step,
+  results,
+}: {
+  step: SerializedStep;
+  results: Record<string, { answer?: { kind: string; selectedChoiceId?: string } }>;
+}) {
   const result = results[step.id];
   const answer = result?.answer;
 
@@ -182,43 +171,53 @@ function findSelectedChoice(
 }
 
 /**
- * Applies a single story step's metric effects to the running totals.
+ * Returns the delta a single step contributes to a specific metric.
+ * Returns 0 when the step has no result or the choice doesn't affect
+ * the given metric.
  */
-function applyMetricEffects(
-  metricValues: Map<string, number>,
-  step: SerializedStep,
-  results: Record<string, { answer?: { kind: string; selectedChoiceId?: string } }>,
-): void {
-  const choice = findSelectedChoice(step, results);
+function getStepMetricDelta({
+  metric,
+  results,
+  step,
+}: {
+  metric: string;
+  results: Record<string, { answer?: { kind: string; selectedChoiceId?: string } }>;
+  step: SerializedStep;
+}): number {
+  const choice = findSelectedChoice({ results, step });
 
   if (!choice) {
-    return;
+    return 0;
   }
 
-  for (const effect of choice.metricEffects) {
-    const current = metricValues.get(effect.metric) ?? METRIC_STARTING_VALUE;
-    metricValues.set(effect.metric, current + EFFECT_DELTA_MAP[effect.effect]);
-  }
+  const effect = choice.metricEffects.find((entry) => entry.metric === metric);
+  return effect ? EFFECT_DELTA_MAP[effect.effect] : 0;
 }
 
+/**
+ * Computes the current value of each story metric by summing deltas
+ * from all completed story steps.
+ *
+ * Reads metric names from the storyIntro step (first step), then for each
+ * answered story step, looks up the selected choice's metricEffects and
+ * accumulates deltas (positive = +15, neutral = 0, negative = -15) starting
+ * from 50.
+ */
 export function getStoryMetrics(state: PlayerState): StoryMetric[] {
-  const metricNames = findIntroMetricNames(state.steps);
+  const introContent = findStoryIntroContent(state.steps);
 
-  if (!metricNames) {
+  if (!introContent) {
     return [];
   }
 
-  const metricValues = new Map(metricNames.map((name) => [name, METRIC_STARTING_VALUE]));
-
   const storySteps = state.steps.filter((step) => step.kind === "story");
 
-  for (const step of storySteps) {
-    applyMetricEffects(metricValues, step, state.results);
-  }
-
-  return metricNames.map((name) => ({
+  return introContent.metrics.map((name) => ({
     metric: name,
-    value: metricValues.get(name) ?? METRIC_STARTING_VALUE,
+    value: storySteps.reduce(
+      (sum, step) => sum + getStepMetricDelta({ metric: name, results: state.results, step }),
+      METRIC_STARTING_VALUE,
+    ),
   }));
 }
 

--- a/packages/player/src/player-selectors.ts
+++ b/packages/player/src/player-selectors.ts
@@ -3,6 +3,7 @@ import { type CompletionResult } from "./completion-input-schema";
 import { type PlayerState } from "./player-reducer";
 import { type SerializedStep } from "./prepare-activity-data";
 import { canNavigatePrev, isStaticNavigationStep } from "./step-navigation";
+import { EFFECT_DELTA_MAP } from "./story";
 
 function computeProgress(currentIndex: number, total: number): number {
   if (total === 0) {
@@ -131,8 +132,6 @@ export type StoryMetric = {
 };
 
 const METRIC_STARTING_VALUE = 50;
-const METRIC_POSITIVE_DELTA = 15;
-const METRIC_NEGATIVE_DELTA = -15;
 
 /**
  * Computes the current value of each story metric by walking all completed
@@ -200,8 +199,7 @@ function applyMetricEffects(
 
   for (const effect of choice.metricEffects) {
     const current = metricValues.get(effect.metric) ?? METRIC_STARTING_VALUE;
-    const delta = getMetricDelta(effect.effect);
-    metricValues.set(effect.metric, current + delta);
+    metricValues.set(effect.metric, current + EFFECT_DELTA_MAP[effect.effect]);
   }
 }
 
@@ -224,18 +222,6 @@ export function getStoryMetrics(state: PlayerState): StoryMetric[] {
     metric: name,
     value: metricValues.get(name) ?? METRIC_STARTING_VALUE,
   }));
-}
-
-function getMetricDelta(effect: "negative" | "neutral" | "positive"): number {
-  if (effect === "positive") {
-    return METRIC_POSITIVE_DELTA;
-  }
-
-  if (effect === "negative") {
-    return METRIC_NEGATIVE_DELTA;
-  }
-
-  return 0;
 }
 
 export type PreloadableImage = {

--- a/packages/player/src/step-navigation.ts
+++ b/packages/player/src/step-navigation.ts
@@ -1,21 +1,5 @@
-import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { type SerializedStep } from "./prepare-activity-data";
-
-/**
- * Checks whether the step's content has a story-specific static variant.
- *
- * Story static steps (intro, outcome, debrief) need action buttons instead
- * of arrow navigation, so they must be excluded from `isStaticNavigationStep`.
- */
-function isStoryStaticVariant(step: SerializedStep): boolean {
-  if (step.kind !== "static") {
-    return false;
-  }
-
-  const content = parseStepContent("static", step.content);
-
-  return content.variant === "storyIntro" || content.variant === "storyOutcome";
-}
+import { isStoryStaticVariant } from "./story";
 
 export function isStaticNavigationStep(step: SerializedStep | undefined): boolean {
   if (!step) {

--- a/packages/player/src/step-navigation.ts
+++ b/packages/player/src/step-navigation.ts
@@ -1,7 +1,32 @@
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
 import { type SerializedStep } from "./prepare-activity-data";
 
+/**
+ * Checks whether the step's content has a story-specific static variant.
+ *
+ * Story static steps (intro, outcome, debrief) need action buttons instead
+ * of arrow navigation, so they must be excluded from `isStaticNavigationStep`.
+ */
+function isStoryStaticVariant(step: SerializedStep): boolean {
+  if (step.kind !== "static") {
+    return false;
+  }
+
+  const content = parseStepContent("static", step.content);
+
+  return content.variant === "storyIntro" || content.variant === "storyOutcome";
+}
+
 export function isStaticNavigationStep(step: SerializedStep | undefined): boolean {
-  return step?.kind === "static" || step?.kind === "visual" || step?.kind === "vocabulary";
+  if (!step) {
+    return false;
+  }
+
+  if (isStoryStaticVariant(step)) {
+    return false;
+  }
+
+  return step.kind === "static" || step.kind === "visual" || step.kind === "vocabulary";
 }
 
 export function canNavigatePrev(steps: SerializedStep[], currentStepIndex: number): boolean {

--- a/packages/player/src/story.ts
+++ b/packages/player/src/story.ts
@@ -1,5 +1,26 @@
-import { parseStepContent } from "@zoonk/core/steps/content-contract";
+import { type StoryStaticVariant, parseStepContent } from "@zoonk/core/steps/content-contract";
 import { type SerializedStep } from "./prepare-activity-data";
+
+/**
+ * Returns the story-specific static variant ("storyIntro" or "storyOutcome")
+ * of a step, or null if the step is not a story static screen.
+ *
+ * Shared by `isStoryStaticVariant` (boolean gate for reducer/navigation)
+ * and `getStoryStaticVariant` (selector that lifts this to PlayerState level).
+ */
+export function getStepStoryVariant(step: SerializedStep | undefined): StoryStaticVariant | null {
+  if (!step || step.kind !== "static") {
+    return null;
+  }
+
+  const content = parseStepContent("static", step.content);
+
+  if (content.variant === "storyIntro" || content.variant === "storyOutcome") {
+    return content.variant;
+  }
+
+  return null;
+}
 
 /**
  * Checks whether a step is a story-specific static variant (storyIntro
@@ -8,13 +29,7 @@ import { type SerializedStep } from "./prepare-activity-data";
  * reducer and navigation guards.
  */
 export function isStoryStaticVariant(step: SerializedStep): boolean {
-  if (step.kind !== "static") {
-    return false;
-  }
-
-  const content = parseStepContent("static", step.content);
-
-  return content.variant === "storyIntro" || content.variant === "storyOutcome";
+  return getStepStoryVariant(step) !== null;
 }
 
 /**

--- a/packages/player/src/story.ts
+++ b/packages/player/src/story.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared threshold values for story metric feedback.
+ *
+ * Used by both visual (pill color) and tactile (haptics) feedback
+ * to ensure consistent severity bands across the player.
+ */
+export const METRIC_CRITICAL_THRESHOLD = 15;
+export const METRIC_DANGER_THRESHOLD = 25;
+export const METRIC_AVERAGE_THRESHOLD = 50;
+export const METRIC_GOOD_THRESHOLD = 60;

--- a/packages/player/src/story.ts
+++ b/packages/player/src/story.ts
@@ -8,3 +8,14 @@ export const METRIC_CRITICAL_THRESHOLD = 15;
 export const METRIC_DANGER_THRESHOLD = 25;
 export const METRIC_AVERAGE_THRESHOLD = 50;
 export const METRIC_GOOD_THRESHOLD = 60;
+
+/**
+ * Fixed delta applied to a metric when a story choice has a positive,
+ * neutral, or negative effect. Used by both the metrics bar (cumulative
+ * totals) and the feedback screen (per-choice badges).
+ */
+export const EFFECT_DELTA_MAP = {
+  negative: -15,
+  neutral: 0,
+  positive: 15,
+} as const;

--- a/packages/player/src/story.ts
+++ b/packages/player/src/story.ts
@@ -1,3 +1,22 @@
+import { parseStepContent } from "@zoonk/core/steps/content-contract";
+import { type SerializedStep } from "./prepare-activity-data";
+
+/**
+ * Checks whether a step is a story-specific static variant (storyIntro
+ * or storyOutcome). These steps use action buttons for forward-only
+ * navigation instead of arrow keys, and need special handling in the
+ * reducer and navigation guards.
+ */
+export function isStoryStaticVariant(step: SerializedStep): boolean {
+  if (step.kind !== "static") {
+    return false;
+  }
+
+  const content = parseStepContent("static", step.content);
+
+  return content.variant === "storyIntro" || content.variant === "storyOutcome";
+}
+
 /**
  * Shared threshold values for story metric feedback.
  *

--- a/packages/player/src/use-player-keyboard.test.ts
+++ b/packages/player/src/use-player-keyboard.test.ts
@@ -17,6 +17,7 @@ function buildOptions(overrides: Partial<Parameters<typeof usePlayerKeyboard>[0]
     onNext: null as (() => void) | null,
     onRestart: vi.fn(),
     phase: "playing" as PlayerPhase,
+    storyStaticVariant: null as Parameters<typeof usePlayerKeyboard>[0]["storyStaticVariant"],
     ...overrides,
   };
 }
@@ -80,6 +81,27 @@ describe(usePlayerKeyboard, () => {
       expect(opts.onEscape).toHaveBeenCalledOnce();
       expect(opts.onCheck).not.toHaveBeenCalled();
       expect(opts.onContinue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Enter key — story static variants", () => {
+    test("calls onNavigateNext on story intro", () => {
+      const opts = buildOptions({ phase: "playing", storyStaticVariant: "storyIntro" });
+      renderHook(() => usePlayerKeyboard(opts));
+
+      fireKey("Enter");
+
+      expect(opts.onNavigateNext).toHaveBeenCalledOnce();
+      expect(opts.onCheck).not.toHaveBeenCalled();
+    });
+
+    test("calls onNavigateNext on story outcome", () => {
+      const opts = buildOptions({ phase: "playing", storyStaticVariant: "storyOutcome" });
+      renderHook(() => usePlayerKeyboard(opts));
+
+      fireKey("Enter");
+
+      expect(opts.onNavigateNext).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/player/src/use-player-keyboard.ts
+++ b/packages/player/src/use-player-keyboard.ts
@@ -39,11 +39,7 @@ function getEnterAction({
   | "phase"
   | "storyStaticVariant"
 >): (() => void) | null {
-  if (phase === "playing" && storyStaticVariant === "storyIntro") {
-    return onNavigateNext;
-  }
-
-  if (phase === "playing" && storyStaticVariant === "storyOutcome") {
+  if (phase === "playing" && storyStaticVariant) {
     return onNavigateNext;
   }
 

--- a/packages/player/src/use-player-keyboard.ts
+++ b/packages/player/src/use-player-keyboard.ts
@@ -2,6 +2,7 @@
 
 import { useKeyboardCallback } from "@zoonk/ui/hooks/keyboard";
 import { type PlayerPhase } from "./player-reducer";
+import { type StoryStaticVariant } from "./player-selectors";
 
 type PlayerKeyboardParams = {
   canNavigatePrev: boolean;
@@ -15,6 +16,7 @@ type PlayerKeyboardParams = {
   onNext: (() => void) | null;
   onRestart: () => void;
   phase: PlayerPhase;
+  storyStaticVariant: StoryStaticVariant | null;
 };
 
 function getEnterAction({
@@ -22,12 +24,29 @@ function getEnterAction({
   onCheck,
   onContinue,
   onEscape,
+  onNavigateNext,
   onNext,
   phase,
+  storyStaticVariant,
 }: Pick<
   PlayerKeyboardParams,
-  "hasAnswer" | "onCheck" | "onContinue" | "onEscape" | "onNext" | "phase"
+  | "hasAnswer"
+  | "onCheck"
+  | "onContinue"
+  | "onEscape"
+  | "onNavigateNext"
+  | "onNext"
+  | "phase"
+  | "storyStaticVariant"
 >): (() => void) | null {
+  if (phase === "playing" && storyStaticVariant === "storyIntro") {
+    return onNavigateNext;
+  }
+
+  if (phase === "playing" && storyStaticVariant === "storyOutcome") {
+    return onNavigateNext;
+  }
+
   if (phase === "playing" && hasAnswer) {
     return onCheck;
   }
@@ -55,6 +74,7 @@ export function usePlayerKeyboard({
   onNext,
   onRestart,
   phase,
+  storyStaticVariant,
 }: PlayerKeyboardParams) {
   useKeyboardCallback(
     "Enter",
@@ -64,8 +84,10 @@ export function usePlayerKeyboard({
         onCheck,
         onContinue,
         onEscape,
+        onNavigateNext,
         onNext,
         phase,
+        storyStaticVariant,
       });
 
       if (!action) {

--- a/packages/player/src/use-player-keyboard.ts
+++ b/packages/player/src/use-player-keyboard.ts
@@ -1,8 +1,8 @@
 "use client";
 
+import { type StoryStaticVariant } from "@zoonk/core/steps/content-contract";
 import { useKeyboardCallback } from "@zoonk/ui/hooks/keyboard";
 import { type PlayerPhase } from "./player-reducer";
-import { type StoryStaticVariant } from "./player-selectors";
 
 type PlayerKeyboardParams = {
   canNavigatePrev: boolean;

--- a/packages/player/src/use-story-haptics.ts
+++ b/packages/player/src/use-story-haptics.ts
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useWebHaptics } from "web-haptics/react";
+import { type PlayerPhase } from "./player-reducer";
+import { type StoryMetric } from "./player-selectors";
+
+type HapticState = {
+  metrics: StoryMetric[];
+  phase: PlayerPhase;
+};
+
+/**
+ * Determines the haptic pattern for consequence feedback based on metric deltas.
+ *
+ * Compares previous and current metric values to categorize the consequence:
+ * - All positive or unchanged → "success" (short double-tap)
+ * - All negative or all decreased → "error" (three sharp taps)
+ * - Mixed changes → "nudge" (light tap)
+ */
+function getConsequenceHaptic(
+  prevMetrics: StoryMetric[],
+  currentMetrics: StoryMetric[],
+): string | null {
+  if (prevMetrics.length === 0 || currentMetrics.length === 0) {
+    return null;
+  }
+
+  const hasPositive = currentMetrics.some((current) => {
+    const previous = prevMetrics.find((entry) => entry.metric === current.metric);
+    return previous && current.value > previous.value;
+  });
+
+  const hasNegative = currentMetrics.some((current) => {
+    const previous = prevMetrics.find((entry) => entry.metric === current.metric);
+    return previous && current.value < previous.value;
+  });
+
+  if (hasNegative && !hasPositive) {
+    return "error";
+  }
+
+  if (hasPositive && !hasNegative) {
+    return "success";
+  }
+
+  if (hasPositive && hasNegative) {
+    return "nudge";
+  }
+
+  return null;
+}
+
+const DANGER_THRESHOLD = 25;
+const CRITICAL_THRESHOLD = 15;
+const CRITICAL_VIBRATE_SHORT = 50;
+const CRITICAL_VIBRATE_LONG = 100;
+const CRITICAL_PATTERN = [CRITICAL_VIBRATE_SHORT, CRITICAL_VIBRATE_SHORT, CRITICAL_VIBRATE_LONG];
+
+/**
+ * Checks if any metric just crossed into a danger or critical zone and
+ * fires the appropriate haptic feedback.
+ */
+function checkMetricThresholds(
+  currentMetrics: StoryMetric[],
+  previousMetrics: StoryMetric[],
+  trigger: (input: number | number[] | string) => void,
+): void {
+  const crossedCritical = currentMetrics.some((current) => {
+    const previous = previousMetrics.find((entry) => entry.metric === current.metric);
+    return previous && current.value < CRITICAL_THRESHOLD && previous.value >= CRITICAL_THRESHOLD;
+  });
+
+  if (crossedCritical) {
+    trigger(CRITICAL_PATTERN);
+    return;
+  }
+
+  const crossedDanger = currentMetrics.some((current) => {
+    const previous = previousMetrics.find((entry) => entry.metric === current.metric);
+    return previous && current.value < DANGER_THRESHOLD && previous.value >= DANGER_THRESHOLD;
+  });
+
+  if (crossedDanger) {
+    trigger("error");
+  }
+}
+
+/**
+ * Centralized haptic feedback hook for story activities.
+ *
+ * Watches player state transitions and fires haptic patterns at key moments:
+ * - Consequence reveal (playing→feedback): pattern based on metric changes
+ * - Metric entering danger zone (<25): warning tap
+ * - Metric entering critical zone (<15): double-tap pattern
+ * - Outcome screen reveal: medium nudge
+ * - Debrief concept reveals: soft tap
+ *
+ * No-ops when the activity is not a story or on devices that don't support
+ * the Vibration API.
+ */
+export function useStoryHaptics({
+  isStoryActivity,
+  metrics,
+  phase,
+  storyStaticVariant,
+}: {
+  isStoryActivity: boolean;
+  metrics: StoryMetric[];
+  phase: PlayerPhase;
+  storyStaticVariant: string | null;
+}) {
+  const { trigger } = useWebHaptics();
+  const prevRef = useRef<HapticState>({ metrics, phase });
+
+  useEffect(() => {
+    if (!isStoryActivity) {
+      return;
+    }
+
+    const previous = prevRef.current;
+    prevRef.current = { metrics, phase };
+
+    // Consequence reveal: playing → feedback
+    if (previous.phase === "playing" && phase === "feedback") {
+      const haptic = getConsequenceHaptic(previous.metrics, metrics);
+
+      if (haptic) {
+        void trigger(haptic);
+      }
+    }
+
+    // Outcome screen reveal
+    if (
+      phase === "playing" &&
+      storyStaticVariant === "storyOutcome" &&
+      previous.phase === "feedback"
+    ) {
+      void trigger("nudge");
+    }
+
+    // Check for metrics entering danger/critical zones
+    checkMetricThresholds(metrics, previous.metrics, (input) => {
+      void trigger(input);
+    });
+  }, [isStoryActivity, metrics, phase, storyStaticVariant, trigger]);
+}

--- a/packages/player/src/use-story-haptics.ts
+++ b/packages/player/src/use-story-haptics.ts
@@ -4,97 +4,121 @@ import { useEffect, useRef } from "react";
 import { useWebHaptics } from "web-haptics/react";
 import { type PlayerPhase } from "./player-reducer";
 import { type StoryMetric } from "./player-selectors";
+import { METRIC_CRITICAL_THRESHOLD, METRIC_DANGER_THRESHOLD } from "./story";
 
 type HapticState = {
   metrics: StoryMetric[];
   phase: PlayerPhase;
 };
 
+type ConsequenceHaptic = "error" | "nudge" | "success";
+
+/** Builds a metric-name to value lookup from a metrics array. */
+function toMetricMap(metrics: StoryMetric[]): Map<string, number> {
+  return new Map(metrics.map((entry) => [entry.metric, entry.value]));
+}
+
 /**
  * Determines the haptic pattern for consequence feedback based on metric deltas.
  *
  * Compares previous and current metric values to categorize the consequence:
- * - All positive or unchanged → "success" (short double-tap)
- * - All negative or all decreased → "error" (three sharp taps)
- * - Mixed changes → "nudge" (light tap)
+ * - All positive or unchanged -> "success" (short double-tap)
+ * - All negative or all decreased -> "error" (three sharp taps)
+ * - Mixed changes -> "nudge" (light tap)
  */
-function getConsequenceHaptic(
-  prevMetrics: StoryMetric[],
-  currentMetrics: StoryMetric[],
-): string | null {
-  if (prevMetrics.length === 0 || currentMetrics.length === 0) {
+function getConsequenceHaptic({
+  previousMetrics,
+  currentMetrics,
+}: {
+  previousMetrics: StoryMetric[];
+  currentMetrics: StoryMetric[];
+}): ConsequenceHaptic | null {
+  if (previousMetrics.length === 0 || currentMetrics.length === 0) {
     return null;
   }
 
+  const previousValues = toMetricMap(previousMetrics);
+
   const hasPositive = currentMetrics.some((current) => {
-    const previous = prevMetrics.find((entry) => entry.metric === current.metric);
-    return previous && current.value > previous.value;
+    const previousValue = previousValues.get(current.metric);
+    return previousValue !== undefined && current.value > previousValue;
   });
 
   const hasNegative = currentMetrics.some((current) => {
-    const previous = prevMetrics.find((entry) => entry.metric === current.metric);
-    return previous && current.value < previous.value;
+    const previousValue = previousValues.get(current.metric);
+    return previousValue !== undefined && current.value < previousValue;
   });
 
-  if (hasNegative && !hasPositive) {
-    return "error";
-  }
-
-  if (hasPositive && !hasNegative) {
-    return "success";
+  if (!hasPositive && !hasNegative) {
+    return null;
   }
 
   if (hasPositive && hasNegative) {
     return "nudge";
   }
 
-  return null;
+  return hasPositive ? "success" : "error";
 }
 
-const DANGER_THRESHOLD = 25;
-const CRITICAL_THRESHOLD = 15;
 const CRITICAL_VIBRATE_SHORT = 50;
 const CRITICAL_VIBRATE_LONG = 100;
 const CRITICAL_PATTERN = [CRITICAL_VIBRATE_SHORT, CRITICAL_VIBRATE_SHORT, CRITICAL_VIBRATE_LONG];
 
+type ThresholdHaptic = typeof CRITICAL_PATTERN | "error";
+
 /**
- * Checks if any metric just crossed into a danger or critical zone and
- * fires the appropriate haptic feedback.
+ * Returns a haptic pattern if any metric just crossed into a danger or
+ * critical zone, or null if no threshold was crossed.
+ *
+ * Critical takes priority over danger because it represents a more
+ * urgent state that requires stronger tactile feedback.
  */
-function checkMetricThresholds(
-  currentMetrics: StoryMetric[],
-  previousMetrics: StoryMetric[],
-  trigger: (input: number | number[] | string) => void,
-): void {
+function getThresholdHaptic({
+  previousMetrics,
+  currentMetrics,
+}: {
+  previousMetrics: StoryMetric[];
+  currentMetrics: StoryMetric[];
+}): ThresholdHaptic | null {
+  const previousValues = toMetricMap(previousMetrics);
+
   const crossedCritical = currentMetrics.some((current) => {
-    const previous = previousMetrics.find((entry) => entry.metric === current.metric);
-    return previous && current.value < CRITICAL_THRESHOLD && previous.value >= CRITICAL_THRESHOLD;
+    const previousValue = previousValues.get(current.metric);
+    return (
+      previousValue !== undefined &&
+      current.value < METRIC_CRITICAL_THRESHOLD &&
+      previousValue >= METRIC_CRITICAL_THRESHOLD
+    );
   });
 
   if (crossedCritical) {
-    trigger(CRITICAL_PATTERN);
-    return;
+    return CRITICAL_PATTERN;
   }
 
   const crossedDanger = currentMetrics.some((current) => {
-    const previous = previousMetrics.find((entry) => entry.metric === current.metric);
-    return previous && current.value < DANGER_THRESHOLD && previous.value >= DANGER_THRESHOLD;
+    const previousValue = previousValues.get(current.metric);
+    return (
+      previousValue !== undefined &&
+      current.value < METRIC_DANGER_THRESHOLD &&
+      previousValue >= METRIC_DANGER_THRESHOLD
+    );
   });
 
   if (crossedDanger) {
-    trigger("error");
+    return "error";
   }
+
+  return null;
 }
 
 /**
  * Centralized haptic feedback hook for story activities.
  *
  * Watches player state transitions and fires haptic patterns at key moments:
- * - Consequence reveal (playing→feedback): pattern based on metric changes
- * - Metric entering danger zone (<25): warning tap
- * - Metric entering critical zone (<15): double-tap pattern
+ * - Consequence reveal (playing->feedback): pattern based on metric changes
+ * - Metric entering danger zone: warning tap
+ * - Metric entering critical zone: double-tap pattern
  * - Outcome screen reveal: medium nudge
- * - Debrief concept reveals: soft tap
  *
  * No-ops when the activity is not a story or on devices that don't support
  * the Vibration API.
@@ -121,27 +145,36 @@ export function useStoryHaptics({
     const previous = prevRef.current;
     prevRef.current = { metrics, phase };
 
-    // Consequence reveal: playing → feedback
+    // Consequence reveal: playing -> feedback
     if (previous.phase === "playing" && phase === "feedback") {
-      const haptic = getConsequenceHaptic(previous.metrics, metrics);
+      const haptic = getConsequenceHaptic({
+        currentMetrics: metrics,
+        previousMetrics: previous.metrics,
+      });
 
       if (haptic) {
         void trigger(haptic);
       }
     }
 
-    // Outcome screen reveal
+    // Outcome screen reveal: storyStaticVariant reflects the current step
+    // after CONTINUE advances the index, so we check the previous phase.
     if (
+      previous.phase === "feedback" &&
       phase === "playing" &&
-      storyStaticVariant === "storyOutcome" &&
-      previous.phase === "feedback"
+      storyStaticVariant === "storyOutcome"
     ) {
       void trigger("nudge");
     }
 
-    // Check for metrics entering danger/critical zones
-    checkMetricThresholds(metrics, previous.metrics, (input) => {
-      void trigger(input);
+    // Metric entering danger or critical zone
+    const thresholdHaptic = getThresholdHaptic({
+      currentMetrics: metrics,
+      previousMetrics: previous.metrics,
     });
+
+    if (thresholdHaptic) {
+      void trigger(thresholdHaptic);
+    }
   }, [isStoryActivity, metrics, phase, storyStaticVariant, trigger]);
 }

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -65,6 +65,7 @@
   --animate-dot-pulse: dot-pulse 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
   --animate-shimmer-text: shimmer-text 3s ease-in-out infinite;
   --animate-placeholder-cycle: placeholder-cycle 64s both infinite;
+  --animate-pulse-scale: pulse-scale 300ms ease-out;
 }
 
 :root {
@@ -315,6 +316,18 @@
   }
   80% {
     transform: translateX(3px);
+  }
+}
+
+@keyframes pulse-scale {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.15);
+  }
+  100% {
+    transform: scale(1);
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -765,6 +765,9 @@ importers:
       shiki:
         specifier: 4.0.2
         version: 4.0.2
+      web-haptics:
+        specifier: 0.0.6
+        version: 0.0.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       zod:
         specifier: '>=4'
         version: 4.3.6
@@ -7650,6 +7653,23 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-haptics@0.0.6:
+    resolution: {integrity: sha512-eCzcf1LDi20+Fr0x9V3OkX92k0gxEQXaHajmhXHitsnk6SxPeshv8TBtBRqxyst8HI1uf2FyFVE7QS3jo1gkrw==}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+      svelte: '>=4'
+      vue: '>=3'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -14794,6 +14814,11 @@ snapshots:
     dependencies:
       defaults: 1.0.4
     optional: true
+
+  web-haptics@0.0.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   web-streams-polyfill@3.3.3: {}
 


### PR DESCRIPTION
## Summary

Closes #1171

- Add story player UI: intro screen, decision steps, consequence feedback, outcome screen, and debrief as individual text steps
- Add persistent metrics bar with animated pills showing color-coded values during gameplay
- Add briefing popover in sticky header for quick premise recall on decision steps
- Add haptic feedback via `web-haptics` for key story moments (consequences, metric changes)
- Add `DramaIcon` and "Story" label to activity catalog
- Add shared `ChoiceStepLayout` to unify story and multiple-choice step rendering
- Add toggle-to-unselect and dimming for both story and multiple-choice option cards
- Add `usePulseOnChange` hook to `@zoonk/ui` for reusable value-change animations
- Fix `computeLocalCompletion` story detection bug (checked step 0 instead of any step)
- Remove `storyDebrief` variant — debrief concepts are now individual static text steps

## Test plan

- [ ] E2E: story intro renders with Begin button, Enter key advances
- [ ] E2E: decision step shows choices with keyboard shortcuts, toggle-to-unselect works
- [ ] E2E: consequence feedback shows narrative without correct/incorrect framing
- [ ] E2E: full flow (intro → decisions → feedback → outcome → debrief → completion)
- [ ] E2E: briefing popover appears on decision steps, not on intro
- [ ] E2E: multiple-choice toggle-to-unselect works
- [ ] Unit: story metrics selector accumulates effects correctly
- [ ] Unit: story static variant detection
- [ ] Unit: keyboard Enter key for story intro/outcome
- [ ] Unit: computeLocalCompletion with mixed step arrays
- [ ] Run e2e for all apps (main, editor, api)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the full story player flow with metrics, briefing, haptics, and adds Story to the catalog. Deduplicates story static variant parsing, fixes intro lookup for the briefing, and makes intro/outcome forward‑only with Enter mapped to Begin/Continue (Linear #1171).

- **New Features**
  - Story flow: intro and outcome static screens; decision steps with consequence‑only feedback and metric delta badges; outcome title color‑coded by performance; debrief as individual `text` steps.
  - Metrics: animated pills; bar visible only on story decision/feedback; outcome shows final status; critical tier styling; shared thresholds, starting value, and effect deltas; selectors compute cumulative metrics.
  - Briefing: sticky‑header popover shows the intro on decision steps; intro lookup now scans all static steps so briefing appears reliably.
  - Controls/keyboard: shared `ChoiceStepLayout` for story and multiple‑choice with 1/2/3 shortcuts and toggle‑to‑unselect; bottom bar shows Begin/Continue and maps Enter on story intro/outcome using a single `getStepStoryVariant` helper; story static screens are forward‑only.
  - Feedback: consequence narrative with metric change badges; no correct/incorrect framing.
  - Haptics: consequence, threshold‑crossing, and outcome patterns via `web-haptics`, aligned to shared metric bands.
  - Catalog/i18n/tests: `DramaIcon` and "Story" label in the catalog; new i18n strings (Begin, Briefing, Current/Final status, Metric changes); e2e for full story flow and multiple‑choice unselect; fixed `computeLocalCompletion` to detect any story step; unified story static variant detection in `story.ts`; tests for briefing text and selected choice; `StoryStaticVariant` derived from Zod schemas in `@zoonk/core`.

- **Migration**
  - Replace the `storyDebrief` static variant with individual `text` steps (one per concept). Story generation now saves multiple static text steps for debrief concepts.

<sup>Written for commit 04373922ae15773891e18ff3e372f54982e86d31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

