### PR TITLE
refactor(player): read player state from context in stage content

### DIFF
--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -6,14 +6,11 @@ import { usePlayerNavigation, usePlayerRuntime } from "../player-context";
 import { type PlayerPhase } from "../player-reducer";
 import {
   getCanNavigatePrev,
-  getCompletionResult,
-  getCurrentResult,
   getCurrentStep,
   getHasAnswer,
   getIsStaticStep,
   getIsStoryActivity,
   getProgressValue,
-  getSelectedAnswer,
   getStoryBriefingText,
   getStoryMetrics,
   getStoryStaticVariant,
@@ -82,17 +79,14 @@ function BottomBarContent({
 export function PlayerShell() {
   const t = useExtracted();
   const { actions, state } = usePlayerRuntime();
-  const { lessonHref, nextActivityHref } = usePlayerNavigation();
+  const { lessonHref } = usePlayerNavigation();
 
   const canNavigatePrev = getCanNavigatePrev(state);
-  const completionResult = getCompletionResult(state);
-  const currentResult = getCurrentResult(state);
   const currentStep = getCurrentStep(state);
   const hasAnswer = getHasAnswer(state);
   const isStaticStep = getIsStaticStep(state);
   const isStoryActivity = getIsStoryActivity(state);
   const progressValue = getProgressValue(state);
-  const selectedAnswer = getSelectedAnswer(state);
   const storyBriefing = getStoryBriefingText(state);
   const storyMetrics = getStoryMetrics(state);
   const storyStaticVariant = getStoryStaticVariant(state);
@@ -124,22 +118,7 @@ export function PlayerShell() {
       {showMetricsBar && <StoryMetricsBar metrics={storyMetrics} />}
 
       <PlayerStage isStatic={isStaticStep && state.phase === "playing"} phase={state.phase}>
-        <StageContent
-          canNavigatePrev={canNavigatePrev}
-          completionResult={completionResult}
-          currentResult={currentResult}
-          currentStep={currentStep}
-          currentStepIndex={state.currentStepIndex}
-          lessonHref={lessonHref}
-          nextActivityHref={nextActivityHref}
-          onNavigateNext={actions.navigateNext}
-          onNavigatePrev={actions.navigatePrev}
-          onRestart={actions.restart}
-          onSelectAnswer={actions.selectAnswer}
-          phase={state.phase}
-          results={state.results}
-          selectedAnswer={selectedAnswer}
-        />
+        <StageContent />
       </PlayerStage>
 
       {showChrome && (

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -1,6 +1,11 @@
-import { type CompletionResult } from "../completion-input-schema";
-import { type PlayerRoute } from "../player-context";
-import { type PlayerPhase, type SelectedAnswer, type StepResult } from "../player-reducer";
+import { usePlayerNavigation, usePlayerRuntime } from "../player-context";
+import {
+  getCanNavigatePrev,
+  getCompletionResult,
+  getCurrentResult,
+  getCurrentStep,
+  getSelectedAnswer,
+} from "../player-selectors";
 import { type SerializedStep } from "../prepare-activity-data";
 import { CompletionScreenContent } from "./completion-screen";
 import { FeedbackScreenContent } from "./feedback-screen";
@@ -16,65 +21,48 @@ function needsFeedbackScreen(step: SerializedStep): boolean {
   );
 }
 
-export function StageContent({
-  canNavigatePrev,
-  completionResult,
-  currentResult,
-  currentStep,
-  currentStepIndex,
-  lessonHref,
-  nextActivityHref,
-  onNavigateNext,
-  onNavigatePrev,
-  onRestart,
-  onSelectAnswer,
-  results,
-  phase,
-  selectedAnswer,
-}: {
-  canNavigatePrev: boolean;
-  completionResult: CompletionResult | null;
-  currentResult: StepResult | undefined;
-  currentStep: SerializedStep | undefined;
-  currentStepIndex: number;
-  lessonHref: PlayerRoute;
-  nextActivityHref: PlayerRoute | null;
-  onNavigateNext: () => void;
-  onNavigatePrev: () => void;
-  onRestart: () => void;
-  onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
-  results: Record<string, StepResult>;
-  phase: PlayerPhase;
-  selectedAnswer: SelectedAnswer | undefined;
-}) {
-  if (phase === "completed") {
+export function StageContent() {
+  const { actions, state } = usePlayerRuntime();
+  const { lessonHref, nextActivityHref } = usePlayerNavigation();
+
+  const canNavigatePrev = getCanNavigatePrev(state);
+  const completionResult = getCompletionResult(state);
+  const currentResult = getCurrentResult(state);
+  const currentStep = getCurrentStep(state);
+  const selectedAnswer = getSelectedAnswer(state);
+
+  if (state.phase === "completed") {
     return (
       <CompletionScreenContent
         completionResult={completionResult}
         lessonHref={lessonHref}
         nextActivityHref={nextActivityHref}
-        onRestart={onRestart}
-        results={results}
+        onRestart={actions.restart}
+        results={state.results}
       />
     );
   }
 
-  if (phase === "feedback" && currentResult && (!currentStep || needsFeedbackScreen(currentStep))) {
+  if (
+    state.phase === "feedback" &&
+    currentResult &&
+    (!currentStep || needsFeedbackScreen(currentStep))
+  ) {
     return <FeedbackScreenContent result={currentResult} step={currentStep} />;
   }
 
-  if ((phase === "playing" || phase === "feedback") && currentStep) {
+  if ((state.phase === "playing" || state.phase === "feedback") && currentStep) {
     return (
       <div
         className="animate-in fade-in flex min-h-0 w-full min-w-0 flex-1 flex-col items-center duration-150 ease-out motion-reduce:animate-none"
-        key={`step-${currentStepIndex}`}
+        key={`step-${state.currentStepIndex}`}
       >
         <StepRenderer
           canNavigatePrev={canNavigatePrev}
-          onNavigateNext={onNavigateNext}
-          onNavigatePrev={onNavigatePrev}
-          onSelectAnswer={onSelectAnswer}
-          result={phase === "feedback" ? currentResult : undefined}
+          onNavigateNext={actions.navigateNext}
+          onNavigatePrev={actions.navigatePrev}
+          onSelectAnswer={actions.selectAnswer}
+          result={state.phase === "feedback" ? currentResult : undefined}
           selectedAnswer={selectedAnswer}
           step={currentStep}
         />


### PR DESCRIPTION
## Summary
- `StageContent` now reads state and actions from `usePlayerRuntime()` and `usePlayerNavigation()` instead of receiving 14 props
- Removed pass-through selector calls from `PlayerShell` that were only used by `StageContent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `StageContent` to read player state and actions from context instead of props, simplifying the component tree and reducing coupling. No user-visible changes.

- **Refactors**
  - `StageContent` now uses `usePlayerRuntime()` and `usePlayerNavigation()` and computes needed values via selectors.
  - Removed 14 props and pass-through selector calls from `PlayerShell` (including `nextActivityHref` plumbing).
  - Navigation, restart, and select-answer now call context actions; keys use `state.currentStepIndex`, and completion screen reads `state.results`.

<sup>Written for commit 31a890a50ddf8a6e688c7fbba0b1c3c153180a39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

