### PR TITLE
fix(ai): improve story generation prompts and activity classifier

### DIFF
--- a/apps/api/src/workflows/activity-generation/steps/generate-story-debrief-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-debrief-step.ts
@@ -40,6 +40,7 @@ export async function generateStoryDebriefStep({
 
   const { data: result, error } = await safeAsync(() =>
     generateActivityStoryDebrief({
+      concepts: storyActivity.lesson.concepts,
       language: storyActivity.language,
       storySteps,
       topic: storyActivity.lesson.title,

--- a/apps/evals/src/tasks/activity-story-debrief/test-cases.ts
+++ b/apps/evals/src/tasks/activity-story-debrief/test-cases.ts
@@ -37,6 +37,13 @@ ${SHARED_EXPECTATIONS}
     `,
     id: "pt-kanban-origins",
     userInput: {
+      concepts: [
+        "Sistema puxado",
+        "Estoque mínimo",
+        "Fluxo contínuo",
+        "Sinalização visual",
+        "Produção just-in-time",
+      ],
       language: "pt",
       storySteps: {
         intro:
@@ -252,6 +259,7 @@ ${SHARED_EXPECTATIONS}
     expectations: SHARED_EXPECTATIONS,
     id: "en-web-packets-network-paths",
     userInput: {
+      concepts: ["Packet switching", "Routing", "Latency", "Bandwidth", "Network congestion"],
       language: "en",
       storySteps: {
         intro:
@@ -584,6 +592,13 @@ ${SHARED_EXPECTATIONS}
     `,
     id: "pt-python-tipos-numericos-principais",
     userInput: {
+      concepts: [
+        "Inteiros",
+        "Ponto flutuante",
+        "Booleanos",
+        "Números complexos",
+        "Conversão de tipos",
+      ],
       language: "pt",
       storySteps: {
         intro:
@@ -900,6 +915,13 @@ ${SHARED_EXPECTATIONS}
     `,
     id: "es-quimica-formacion-enoles-enolatos",
     userInput: {
+      concepts: [
+        "Tautomería ceto-enólica",
+        "Acidez del hidrógeno alfa",
+        "Enolización",
+        "Bases fuertes y débiles",
+        "Alquilación de enolatos",
+      ],
       language: "es",
       storySteps: {
         intro:
@@ -1248,6 +1270,13 @@ ${SHARED_EXPECTATIONS}
     expectations: SHARED_EXPECTATIONS,
     id: "en-economics-sectoral-comovements",
     userInput: {
+      concepts: [
+        "Business cycle synchronization",
+        "Sectoral spillovers",
+        "Regional disparities",
+        "Leading and lagging indicators",
+        "Aggregate demand shocks",
+      ],
       language: "en",
       storySteps: {
         intro:

--- a/packages/ai/src/tasks/activities/core/activity-story-debrief.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-story-debrief.prompt.md
@@ -4,6 +4,7 @@ You write the outcomes and debrief for a learning story. The story is over — n
 
 - The full story scenario with all steps, choices, and consequences
 - The lesson topic and context
+- **CONCEPTS**: The lesson's core concepts — every one of these MUST appear in the debrief
 
 ## What You Generate
 
@@ -23,12 +24,14 @@ Each outcome has:
 
 IMPORTANT: Even the worst outcome should feel like a learning moment, not a punishment. "Your warehouse is overflowing and deliveries are late — but now you know what happens when you produce without demand." Not "You failed."
 
-### Debrief Concepts (3-5 concepts)
+### Debrief Concepts
+
+One concept for EACH of the lesson's concepts. Every concept provided in the lesson must appear in the debrief — this is the moment you connect what happened in the story back to what the lesson is actually teaching. No concept should be left out.
 
 Each concept has:
 
-- **name**: The actual concept name from the topic (NOW you name it — this is the reveal)
-- **explanation**: 2-3 sentences connecting the concept to the story. This is NOT a label — it must be a full explanation.
+- **name**: The actual concept name from the lesson (NOW you name it — this is the reveal)
+- **explanation**: 2-3 sentences connecting the concept to specific moments in the story. This is NOT a label — it must be a full explanation.
 
 GOOD explanation: "When you chose to only produce what was ordered, you were applying pull-based production. The supermarket shelf worked the same way — replenishing only what was taken."
 

--- a/packages/ai/src/tasks/activities/core/activity-story-debrief.ts
+++ b/packages/ai/src/tasks/activities/core/activity-story-debrief.ts
@@ -27,6 +27,7 @@ const schema = z.object({
 export type ActivityStoryDebriefSchema = z.infer<typeof schema>;
 
 export type ActivityStoryDebriefParams = {
+  concepts: string[];
   storySteps: ActivityStoryStepsSchema;
   topic: string;
   language: string;
@@ -81,6 +82,7 @@ function formatStoryStepsForPrompt(storySteps: ActivityStoryStepsSchema): string
  * This is phase 2 of story generation.
  */
 export async function generateActivityStoryDebrief({
+  concepts,
   storySteps,
   topic,
   language,
@@ -91,6 +93,7 @@ export async function generateActivityStoryDebrief({
   const userPrompt = `
     TOPIC: ${topic}
     LANGUAGE: ${language}
+    CONCEPTS: ${concepts.join(", ")}
     ${formatStoryStepsForPrompt(storySteps)}
   `;
 

--- a/packages/ai/src/tasks/activities/core/activity-story-steps.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-story-steps.prompt.md
@@ -15,7 +15,7 @@ Games teach physics by letting you fall off a cliff, not by explaining gravity. 
 
 ## What You Generate
 
-A scenario with **5 steps** (decision points). Each step has:
+A scenario with **as many steps as needed** to cover ALL the lesson's concepts. Each step has:
 
 - A **situation** (what's happening RIGHT NOW)
 - **3 choices** (actions the learner can take)
@@ -24,6 +24,14 @@ A scenario with **5 steps** (decision points). Each step has:
 - An **alignment** tag for each choice: "strong" (aligns with lesson concepts), "partial" (partially right), or "weak" (goes against concepts)
 
 Plus **3 metrics** that track the world state (e.g., "Production", "Morale", "Cash").
+
+## Step Count
+
+Use as many steps as the story needs — there is no fixed number. The goal is to cover ALL the lesson's concepts while telling a coherent, engaging story. A simple lesson with 3 concepts might need 4 steps. A complex lesson with 8 concepts might need 10.
+
+- **Every concept must be exercised in at least one step.** If a concept never shows up as a force governing any decision, the story is incomplete.
+- **Great steps weave multiple concepts into a single dilemma.** A decision about crop spacing could simultaneously exercise "competition for resources" and "soil nutrient cycling." Don't force one concept per step — that makes stories feel like a checklist. The best steps create situations where several concepts interact and the player must weigh them together.
+- The story must feel like a coherent narrative arc: beginning (drop into the situation), escalation, pivot, and resolution. Don't add steps that feel like padding, and don't cut steps that the story needs for pacing.
 
 ## CRITICAL: Length Constraints
 
@@ -34,21 +42,47 @@ Plus **3 metrics** that track the world state (e.g., "Production", "Morale", "Ca
 | choice text          | 15        | 1             |
 | consequence text     | 30        | 2-3           |
 
+## CRITICAL: No Meta Scenarios
+
+The learner must be INSIDE a situation where the concept governs outcomes — NOT in a contrived scenario ABOUT the concept. The scenario should be something someone in the course's domain would actually face in real life.
+
+**The test**: Is this a real-world problem that exists independently of the concept being taught? Or did you invent this scenario just as a vehicle to discuss/present/teach the concept?
+
+A scenario about "organizing an exhibit on supply and demand" is meta — nobody organizes economics exhibits in real life unless they're a museum curator (and if the course IS about museum curation, then it's fine). A scenario about "running a coffee shop during a festival" is real — shop owners actually face pricing decisions, and supply/demand governs what happens without ever being named.
+
+**The key distinction**: If the scenario only makes sense as an educational exercise about the concept, it's meta. If the scenario describes a real problem someone actually faces — and the concept happens to be the invisible force governing outcomes — it's good.
+
+**Don't force metaphors when the real profession is the right setting.** If the course is about programming, the learner should be a programmer facing a real engineering problem — not a restaurant manager whose decisions are secretly about arrays. If the course is about nursing, the learner should be a nurse — not a lifeguard whose decisions are secretly about triage. Always use the profession where these decisions actually happen.
+
+**Examples**:
+
+| Concept               | Bad scenario                                          | Good scenario                                                                                                      |
+| --------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Supply and demand     | Organizing an economics exhibit                       | Running a coffee shop and setting prices during a festival                                                         |
+| Photosynthesis        | Designing a science fair presentation about plants    | Farming — deciding where to plant, how much shade, when to water                                                   |
+| Newton's third law    | Explaining physics to students                        | Firefighter positioning hoses during a rescue                                                                      |
+| Conflict resolution   | Writing a report on mediation techniques              | Managing a team where two engineers disagree on an architecture decision                                           |
+| Stack implementations | A restaurant tablet managing orders (forced metaphor) | An engineer fixing a crashing production system — recursive calls blowing the stack, undo history corrupting state |
+
 ## Intro Rules
 
 - Drop the learner INTO a moment. Second person ("you"). Sensory detail.
 - Something demands action RIGHT NOW
 - The learner is someone with a role and a real problem
 - NEVER name the lesson's concepts in the intro
+- The scenario must be a real-world situation where the concept governs outcomes, NOT a scenario about the concept itself (see "No Meta Scenarios" above)
+- **Choose roles where decisions have real consequences** — livelihoods, safety, deadlines with real costs, relationships that matter. A farmer whose harvest is at risk is more compelling than a student tending a school garden. A nurse in an ER is more compelling than a volunteer at a first-aid booth. Pick the version of the role where it MATTERS.
 - Example: "You're the new floor manager. Half the warehouse is drowning in parts nobody ordered — the other half can't find what they need. Your phone's already ringing."
 
 ## Step Rules
 
 - Each situation describes what's happening RIGHT NOW — not backstory
-- Situations should ESCALATE: step 1 is a manageable problem, step 5 is a crisis or a breakthrough
+- Situations should ESCALATE: early steps are manageable problems, the final step is a crisis or a breakthrough
 - Introduce SURPRISES: a rush order, an equipment failure, a visitor who changes things
-- Step 3 should be a pivotal moment — something unexpected happens that offers a key insight
+- The middle of the story should have a pivotal moment — something unexpected that offers a key insight
 - Late steps should feel like the pressure is building
+- **Each step must present a fundamentally different kind of problem.** If step 1 is about resource allocation, step 2 should be about people, step 3 about an unexpected crisis, etc. Don't repeat the same dilemma with different surface details — each step should feel like a new challenge, not a variation of the previous one.
+- **Every concept must appear in at least one step.** No concept should be left out of the gameplay. The best steps weave multiple concepts into a single dilemma — don't treat concepts as a checklist where each gets its own isolated step.
 
 ## Choice Rules
 
@@ -60,6 +94,8 @@ Plus **3 metrics** that track the world state (e.g., "Production", "Morale", "Ca
 - One should be a reasonable middle ground ("partial")
 - The "strong" choice should NOT be obvious — it might feel counterintuitive
 - NEVER hint which is correct. All choices should seem reasonable.
+- **CRITICAL: Vary the nature of the strong choice across steps.** If the strong choice in step 1 is "observe carefully before acting," the strong choice in step 2 MUST NOT be another version of "observe carefully." Sometimes the best move is bold action. Sometimes it's restraint. Sometimes it's an unexpected creative approach. Sometimes it's asking for help. If a player can win by always picking "the careful/measured option," your choices are broken.
+- **Vary the weak choice too.** The intuitive-but-wrong approach shouldn't always be the same type (e.g., not always "overreact" or "do the drastic thing"). Sometimes the wrong move is being too cautious, too conventional, or too focused on short-term optics.
 
 ## Consequence Rules
 

--- a/packages/ai/src/tasks/lessons/applied-activity-kind.prompt.md
+++ b/packages/ai/src/tasks/lessons/applied-activity-kind.prompt.md
@@ -1,4 +1,4 @@
-You classify whether a lesson should include an applied activity — a scenario-based experience where learners discover concepts through decisions and consequences rather than direct instruction.
+You choose which applied activity fits a lesson — a hands-on experience where the learner discovers concepts through action, not instruction.
 
 ## Inputs
 
@@ -9,37 +9,37 @@ You classify whether a lesson should include an applied activity — a scenario-
 - **CONCEPTS:** The lesson's core concepts
 - **LANGUAGE:** The content language
 
-## Output
+## Available kinds
 
-Return one of:
+- `"story"` — The learner is dropped into a scenario and makes decisions with consequences. The lesson's concepts are hidden rules governing which choices work and which backfire. Best for topics where understanding shows up in the quality of decisions: trade-offs, cause-and-effect, ethics, systems with interacting forces.
 
-- `"story"` — A decision-based scenario where the learner makes choices with consequences that reveal how concepts work in practice
-- `null` — No applied activity fits this topic
+Return `null` if no kind fits this lesson.
 
-## When to return "story"
+## The One Question
 
-Return `"story"` when the lesson's concepts can be experienced through a scenario where learners make decisions:
+**Can you imagine a real person in a real job where this knowledge governs their decisions or actions?**
 
-- **Decision-making with trade-offs** — management, strategy, resource allocation, policy, leadership
-- **Cause-and-effect reasoning** — economics, engineering decisions, business operations, environmental impact
-- **Ethics or judgment calls** — medical ethics, legal reasoning, professional dilemmas, social responsibility
-- **Systems with interacting forces** — ecology, supply chains, organizational dynamics, market forces
-- **Concepts that work as hidden rules** — the concepts should be discoverable through choices and their consequences (e.g., "supply and demand" becomes a scenario where pricing decisions affect sales and revenue)
-- **Applied knowledge** — any topic where understanding shows up in the quality of decisions, not just recall
+If yes → pick the kind that best fits. If the only scenario you can imagine is someone teaching, presenting, or organizing content about the concept → `null`.
 
-Most educational topics benefit from a story framing. A lesson on "photosynthesis" can become a scenario about managing a greenhouse. A lesson on "memory and learning" can become a scenario about designing a study program. Be creative in seeing how concepts can become decision drivers.
+Don't be fooled by how the lesson description is worded. "Levels of biological organization" sounds like a hierarchy to memorize, but an epidemiologist tracing a disease outbreak must choose which level to investigate — molecular, cellular, population, ecosystem — and choosing wrong wastes time and lives. Most frameworks, hierarchies, and classifications exist because professionals use them to navigate real problems.
+
+## Examples
+
+| Lesson                          | Verdict   | Why                                                                                                                |
+| ------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------ |
+| Supply and demand               | `"story"` | A shop owner sets prices during a festival — economics governs what happens                                        |
+| Dimensions of biodiversity      | `"story"` | A conservation manager allocates limited budget across genetic, species, and ecosystem diversity — real trade-offs |
+| Types of chemical bonds         | `"story"` | A materials engineer picks adhesives for an aircraft — bond properties govern whether it holds                     |
+| Proving the Pythagorean theorem | `null`    | Pure proof with no decision context                                                                                |
+| Gödel's incompleteness theorem  | `null`    | Abstract theory — no practitioner makes decisions governed by it                                                   |
+| Dates of World War I            | `null`    | Pure recall, no decisions to make                                                                                  |
 
 ## When to return null
 
-Return `null` only for topics that genuinely cannot be framed as decisions:
+`null` should be rare. Return it only when:
 
-- **Pure mathematical formulas** with no application context (e.g., "proving the Pythagorean theorem" — but "using geometry in architecture" would be story)
-- **Pure taxonomy or definitions** that exist only as classifications with no decision implications (e.g., "naming the parts of a cell" — but "cell biology in disease" would be story)
-- **Purely procedural content** where there's only one correct sequence and no room for choices (e.g., "syntax of a for loop" — but "choosing the right loop for the job" would be story)
+- The knowledge is purely about recall (arbitrary labels, dates, proofs) with no practical application
+- There is only one correct procedure and no room for meaningful choices
+- You genuinely cannot imagine a scenario where the concepts govern decisions without the scenario being ABOUT the concepts (teaching, presenting, curating, explaining them)
 
-## Decision rules
-
-1. If the concepts can become hidden rules governing good vs. bad decisions in a realistic scenario, return `"story"`
-2. If the topic has any practical application where someone must make choices, return `"story"`
-3. Return `null` only when you genuinely cannot construct a scenario with meaningful choices — this should be rare
-4. When in doubt, return `"story"` — a creative scenario can be built for most topics
+Note: if the course itself is about teaching, event planning, etc., then those activities ARE the real domain — that's not meta.


### PR DESCRIPTION
## Summary

- Prevent meta scenarios in story generation (organizing exhibits, explaining concepts to others). Stories must put the learner inside a real-world situation where concepts are invisible forces governing outcomes
- Require full concept coverage — every lesson concept must appear in at least one story step and in the debrief
- Add choice and step variety rules to prevent repetitive "always pick the careful option" patterns
- Use variable step count (driven by concepts and story needs) instead of fixed 5 steps
- Pass lesson concepts to the debrief generator so it can ensure complete coverage
- Rewrite the applied activity classifier from scratch — one central question ("can you imagine a real person in a real job where this knowledge governs their decisions?"), kind-agnostic for future activity types

## Test plan

- [x] All 441 API integration tests pass
- [x] Typecheck, lint, knip clean
- [ ] Run evals to validate output quality against updated test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves story generation to produce realistic, decision-driven scenarios with full concept coverage, and rewrites the activity classifier around a single practical question for better kind selection.

- **New Features**
  - Variable story step count to cover all lesson concepts.
  - Hard guardrails against meta scenarios; use real roles and problems.
  - Choice and step variety rules to avoid “always pick the careful option”.
  - Debrief now requires one entry per lesson concept, tied to specific story moments.
  - Passes `concepts` into the debrief generator; eval cases updated to include them.

- **Refactors**
  - Rewrote the `applied-activity-kind` prompt: one central question (“can a real person in a real job use this to make decisions?”), kind-agnostic, with clear examples.
  - Tighter criteria for when to return `"story"` vs `null`, reducing misclassification of purely recall/proof lessons.

<sup>Written for commit e87b7ce140e3386e41d7fc190360efa1b756e336. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

