### PR TITLE
fix(main): use dynamic drift ceiling for generation progress bar

### DIFF
--- a/apps/main/src/app/generate/a/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/a/[id]/generation-client.tsx
@@ -58,15 +58,16 @@ export function GenerationClient({
     triggerUrl: `${API_URL}/v1/workflows/activity-generation/trigger`,
   });
 
-  const { activePhaseNames, phases, progress, thinkingGenerators } = useGenerationPhases(
-    generation.completedSteps,
-    generation.currentStep,
-    activityKind,
-    generation.startedSteps,
-  );
+  const { activePhaseNames, phases, progress, targetProgress, thinkingGenerators } =
+    useGenerationPhases(
+      generation.completedSteps,
+      generation.currentStep,
+      activityKind,
+      generation.startedSteps,
+    );
 
   const isActive = generation.status === "triggering" || generation.status === "streaming";
-  const displayProgress = useAnimatedProgress(progress, isActive);
+  const displayProgress = useAnimatedProgress({ isActive, realProgress: progress, targetProgress });
   const thinkingMessages = useThinkingMessages(
     thinkingGenerators,
     isActive ? activePhaseNames : [],

--- a/apps/main/src/app/generate/a/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/a/[id]/use-generation-phases.ts
@@ -4,6 +4,7 @@ import { type PhaseStatus, enforcePhaseProgression } from "@/lib/generation-phas
 import { type PhaseName, getPhaseOrder } from "@/lib/generation/activity-generation-phase-config";
 import {
   PHASE_ICONS,
+  calculateTargetProgress,
   calculateWeightedProgress,
   getPhaseStatus,
 } from "@/lib/generation/activity-generation-phases";
@@ -42,11 +43,18 @@ export function useGenerationPhases(
     startedSteps,
   );
 
+  const targetProgress = calculateTargetProgress(
+    completedSteps,
+    currentStep,
+    activityKind,
+    startedSteps,
+  );
+
   const activePhaseNames = phases
     .filter((phase) => phase.status === "active")
     .map((phase) => phase.name);
 
   const thinkingGenerators = usePhaseThinkingGenerators();
 
-  return { activePhaseNames, phases, progress, thinkingGenerators };
+  return { activePhaseNames, phases, progress, targetProgress, thinkingGenerators };
 }

--- a/apps/main/src/app/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generation-client.tsx
@@ -46,14 +46,11 @@ export function GenerationClient({
     triggerUrl: `${API_URL}/v1/workflows/chapter-generation/trigger`,
   });
 
-  const { activePhaseNames, phases, progress, thinkingGenerators } = useGenerationPhases(
-    generation.completedSteps,
-    generation.currentStep,
-    generation.startedSteps,
-  );
+  const { activePhaseNames, phases, progress, targetProgress, thinkingGenerators } =
+    useGenerationPhases(generation.completedSteps, generation.currentStep, generation.startedSteps);
 
   const isActive = generation.status === "triggering" || generation.status === "streaming";
-  const displayProgress = useAnimatedProgress(progress, isActive);
+  const displayProgress = useAnimatedProgress({ isActive, realProgress: progress, targetProgress });
   const thinkingMessages = useThinkingMessages(
     thinkingGenerators,
     isActive ? activePhaseNames : [],

--- a/apps/main/src/app/generate/ch/[id]/generation-phases.ts
+++ b/apps/main/src/app/generate/ch/[id]/generation-phases.ts
@@ -2,6 +2,7 @@ import {
   type AssertAllCovered,
   type PhaseStatus,
   calculateWeightedProgress as calculateProgress,
+  calculateTargetProgress as calculateTarget,
   getPhaseStatus as getStatus,
 } from "@/lib/generation-phases";
 import { type ChapterStepName, type ChapterWorkflowStepName } from "@zoonk/core/workflows/steps";
@@ -45,15 +46,24 @@ export function getPhaseStatus(
   return getStatus(phase, completedSteps, currentStep, PHASE_STEPS, startedSteps);
 }
 
+const PROGRESS_CONFIG = {
+  phaseOrder: PHASE_ORDER,
+  phaseSteps: PHASE_STEPS,
+  phaseWeights: PHASE_WEIGHTS,
+};
+
 export function calculateWeightedProgress(
   completedSteps: ChapterWorkflowStepName[],
   currentStep: ChapterWorkflowStepName | null,
   startedSteps?: ChapterWorkflowStepName[],
 ): number {
-  return calculateProgress(completedSteps, currentStep, {
-    phaseOrder: PHASE_ORDER,
-    phaseSteps: PHASE_STEPS,
-    phaseWeights: PHASE_WEIGHTS,
-    startedSteps,
-  });
+  return calculateProgress(completedSteps, currentStep, { ...PROGRESS_CONFIG, startedSteps });
+}
+
+export function calculateTargetProgress(
+  completedSteps: ChapterWorkflowStepName[],
+  currentStep: ChapterWorkflowStepName | null,
+  startedSteps?: ChapterWorkflowStepName[],
+): number {
+  return calculateTarget(completedSteps, currentStep, { ...PROGRESS_CONFIG, startedSteps });
 }

--- a/apps/main/src/app/generate/ch/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/ch/[id]/use-generation-phases.ts
@@ -11,6 +11,7 @@ import { useExtracted } from "next-intl";
 import {
   PHASE_ICONS,
   type PhaseName,
+  calculateTargetProgress,
   calculateWeightedProgress,
   getPhaseOrder,
   getPhaseStatus,
@@ -46,6 +47,7 @@ export function useGenerationPhases(
   const phases = enforcePhaseProgression(rawPhases);
 
   const progress = calculateWeightedProgress(completedSteps, currentStep, startedSteps);
+  const targetProgress = calculateTargetProgress(completedSteps, currentStep, startedSteps);
 
   const activePhaseNames = phases
     .filter((phase) => phase.status === "active")
@@ -63,5 +65,5 @@ export function useGenerationPhases(
       cycleMessage([t("Saving your progress..."), t("Putting it all together...")], index),
   };
 
-  return { activePhaseNames, phases, progress, thinkingGenerators };
+  return { activePhaseNames, phases, progress, targetProgress, thinkingGenerators };
 }

--- a/apps/main/src/app/generate/cs/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generation-client.tsx
@@ -44,14 +44,11 @@ export function GenerationClient({
     triggerUrl: `${API_URL}/v1/workflows/course-generation/trigger`,
   });
 
-  const { activePhaseNames, phases, progress, thinkingGenerators } = useGenerationPhases(
-    generation.completedSteps,
-    generation.currentStep,
-    generation.startedSteps,
-  );
+  const { activePhaseNames, phases, progress, targetProgress, thinkingGenerators } =
+    useGenerationPhases(generation.completedSteps, generation.currentStep, generation.startedSteps);
 
   const isActive = generation.status === "triggering" || generation.status === "streaming";
-  const displayProgress = useAnimatedProgress(progress, isActive);
+  const displayProgress = useAnimatedProgress({ isActive, realProgress: progress, targetProgress });
   const thinkingMessages = useThinkingMessages(
     thinkingGenerators,
     isActive ? activePhaseNames : [],

--- a/apps/main/src/app/generate/cs/[id]/generation-phases.ts
+++ b/apps/main/src/app/generate/cs/[id]/generation-phases.ts
@@ -2,6 +2,7 @@ import {
   type AssertAllCovered,
   type PhaseStatus,
   calculateWeightedProgress as calculateProgress,
+  calculateTargetProgress as calculateTarget,
   getPhaseStatus as getStatus,
 } from "@/lib/generation-phases";
 import { type CourseStepName, type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
@@ -87,15 +88,24 @@ export function getPhaseStatus(
   return getStatus(phase, completedSteps, currentStep, PHASE_STEPS, startedSteps);
 }
 
+const PROGRESS_CONFIG = {
+  phaseOrder: PHASE_ORDER,
+  phaseSteps: PHASE_STEPS,
+  phaseWeights: PHASE_WEIGHTS,
+};
+
 export function calculateWeightedProgress(
   completedSteps: CourseWorkflowStepName[],
   currentStep: CourseWorkflowStepName | null,
   startedSteps?: CourseWorkflowStepName[],
 ): number {
-  return calculateProgress(completedSteps, currentStep, {
-    phaseOrder: PHASE_ORDER,
-    phaseSteps: PHASE_STEPS,
-    phaseWeights: PHASE_WEIGHTS,
-    startedSteps,
-  });
+  return calculateProgress(completedSteps, currentStep, { ...PROGRESS_CONFIG, startedSteps });
+}
+
+export function calculateTargetProgress(
+  completedSteps: CourseWorkflowStepName[],
+  currentStep: CourseWorkflowStepName | null,
+  startedSteps?: CourseWorkflowStepName[],
+): number {
+  return calculateTarget(completedSteps, currentStep, { ...PROGRESS_CONFIG, startedSteps });
 }

--- a/apps/main/src/app/generate/cs/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/cs/[id]/use-generation-phases.ts
@@ -11,6 +11,7 @@ import { useExtracted } from "next-intl";
 import {
   PHASE_ICONS,
   type PhaseName,
+  calculateTargetProgress,
   calculateWeightedProgress,
   getPhaseOrder,
   getPhaseStatus,
@@ -49,6 +50,7 @@ export function useGenerationPhases(
   const phases = enforcePhaseProgression(rawPhases);
 
   const progress = calculateWeightedProgress(completedSteps, currentStep, startedSteps);
+  const targetProgress = calculateTargetProgress(completedSteps, currentStep, startedSteps);
 
   const activePhaseNames = phases
     .filter((phase) => phase.status === "active")
@@ -79,5 +81,5 @@ export function useGenerationPhases(
       cycleMessage([t("Summarizing what you'll learn..."), t("Writing the overview...")], index),
   };
 
-  return { activePhaseNames, phases, progress, thinkingGenerators };
+  return { activePhaseNames, phases, progress, targetProgress, thinkingGenerators };
 }

--- a/apps/main/src/app/generate/l/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/l/[id]/generation-client.tsx
@@ -48,14 +48,11 @@ export function GenerationClient({
     triggerUrl: `${API_URL}/v1/workflows/lesson-generation/trigger`,
   });
 
-  const { activePhaseNames, phases, progress, thinkingGenerators } = useGenerationPhases(
-    generation.completedSteps,
-    generation.currentStep,
-    generation.startedSteps,
-  );
+  const { activePhaseNames, phases, progress, targetProgress, thinkingGenerators } =
+    useGenerationPhases(generation.completedSteps, generation.currentStep, generation.startedSteps);
 
   const isActive = generation.status === "triggering" || generation.status === "streaming";
-  const displayProgress = useAnimatedProgress(progress, isActive);
+  const displayProgress = useAnimatedProgress({ isActive, realProgress: progress, targetProgress });
   const thinkingMessages = useThinkingMessages(
     thinkingGenerators,
     isActive ? activePhaseNames : [],

--- a/apps/main/src/app/generate/l/[id]/generation-phases.ts
+++ b/apps/main/src/app/generate/l/[id]/generation-phases.ts
@@ -2,6 +2,7 @@ import {
   type AssertAllCovered,
   type PhaseStatus,
   calculateWeightedProgress as calculateProgress,
+  calculateTargetProgress as calculateTarget,
   getPhaseStatus as getStatus,
 } from "@/lib/generation-phases";
 import { type LessonStepName } from "@zoonk/core/workflows/steps";
@@ -66,15 +67,24 @@ export function getPhaseStatus(
   return getStatus(phase, completedSteps, currentStep, PHASE_STEPS, startedSteps);
 }
 
+const PROGRESS_CONFIG = {
+  phaseOrder: PHASE_ORDER,
+  phaseSteps: PHASE_STEPS,
+  phaseWeights: PHASE_WEIGHTS,
+};
+
 export function calculateWeightedProgress(
   completedSteps: LessonStepName[],
   currentStep: LessonStepName | null,
   startedSteps?: LessonStepName[],
 ): number {
-  return calculateProgress(completedSteps, currentStep, {
-    phaseOrder: PHASE_ORDER,
-    phaseSteps: PHASE_STEPS,
-    phaseWeights: PHASE_WEIGHTS,
-    startedSteps,
-  });
+  return calculateProgress(completedSteps, currentStep, { ...PROGRESS_CONFIG, startedSteps });
+}
+
+export function calculateTargetProgress(
+  completedSteps: LessonStepName[],
+  currentStep: LessonStepName | null,
+  startedSteps?: LessonStepName[],
+): number {
+  return calculateTarget(completedSteps, currentStep, { ...PROGRESS_CONFIG, startedSteps });
 }

--- a/apps/main/src/app/generate/l/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/l/[id]/use-generation-phases.ts
@@ -8,6 +8,7 @@ import {
   PHASE_ICONS,
   PHASE_ORDER,
   type PhaseName,
+  calculateTargetProgress,
   calculateWeightedProgress,
   getPhaseStatus,
 } from "./generation-phases";
@@ -42,6 +43,7 @@ export function useGenerationPhases(
   const phases = enforcePhaseProgression(rawPhases);
 
   const progress = calculateWeightedProgress(completedSteps, currentStep, startedSteps);
+  const targetProgress = calculateTargetProgress(completedSteps, currentStep, startedSteps);
 
   const activePhaseNames = phases
     .filter((phase) => phase.status === "active")
@@ -62,5 +64,5 @@ export function useGenerationPhases(
       cycleMessage([t("Designing practice exercises..."), t("Making it interactive...")], index),
   };
 
-  return { activePhaseNames, phases, progress, thinkingGenerators };
+  return { activePhaseNames, phases, progress, targetProgress, thinkingGenerators };
 }

--- a/apps/main/src/lib/generation-phases.test.ts
+++ b/apps/main/src/lib/generation-phases.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   type PhaseStatus,
+  calculateTargetProgress,
   calculateWeightedProgress,
   enforcePhaseProgression,
   getPhaseStatus,
@@ -129,6 +130,62 @@ describe(calculateWeightedProgress, () => {
     // start: completed (20), middle: pending (0), finishing: clamped to pending (0)
     // 20/60 * 100 = 33
     expect(progress).toBe(33);
+  });
+});
+
+describe(calculateTargetProgress, () => {
+  it("returns 0 when no steps completed and no active phases", () => {
+    expect(calculateTargetProgress([], null, testConfig)).toBe(0);
+  });
+
+  it("returns 100 when all steps completed", () => {
+    const allSteps: TestStep[] = ["stepA", "stepB", "stepC", "stepD", "stepE"];
+    expect(calculateTargetProgress(allSteps, null, testConfig)).toBe(100);
+  });
+
+  it("includes full weight of active phase in target", () => {
+    // phase1: stepA completed (active, 1/2 steps done)
+    // real progress = 10 (half of phase1's weight 20)
+    // target = 20 (full weight of phase1, since it's active)
+    expect(calculateTargetProgress(["stepA"], null, testConfig)).toBe(20);
+  });
+
+  it("includes full weight of current-step phase", () => {
+    // No steps completed, but currentStep is in phase2
+    // phase1: pending (0), phase2: active via currentStep (target = full 30)
+    // But enforcePhaseProgression doesn't promote phase2 since phase1 isn't completed.
+    // phase2 becomes active because currentStep is in it.
+    // Target should include phase2's full weight = 30
+    expect(calculateTargetProgress([], "stepC", testConfig)).toBe(30);
+  });
+
+  it("includes weights of all completed phases plus active phase", () => {
+    // phase1 complete (20) + phase2 active via currentStep (full weight 30) = 50
+    expect(calculateTargetProgress(["stepA", "stepB"], "stepC", testConfig)).toBe(50);
+  });
+
+  it("handles multiple active phases in parallel", () => {
+    // phase1: stepA started (active via startedSteps)
+    // phase2: stepC is currentStep (active)
+    // Both are active, target should include both full weights = 20 + 30 = 50
+    const config = { ...testConfig, startedSteps: ["stepA" as TestStep] };
+    expect(calculateTargetProgress([], "stepC", config)).toBe(50);
+  });
+
+  it("equals real progress when no phases are active", () => {
+    // phase1 complete (20), phase2 and phase3 pending
+    // enforcePhaseProgression promotes phase2 to active
+    // so target = 20 (completed) + 30 (active phase2) = 50
+    const progress = calculateWeightedProgress(["stepA", "stepB"], null, testConfig);
+    const target = calculateTargetProgress(["stepA", "stepB"], null, testConfig);
+    expect(target).toBeGreaterThanOrEqual(progress);
+  });
+
+  it("is always >= real progress", () => {
+    const steps: TestStep[] = ["stepA"];
+    const progress = calculateWeightedProgress(steps, null, testConfig);
+    const target = calculateTargetProgress(steps, null, testConfig);
+    expect(target).toBeGreaterThanOrEqual(progress);
   });
 });
 

--- a/apps/main/src/lib/generation-phases.ts
+++ b/apps/main/src/lib/generation-phases.ts
@@ -95,22 +95,20 @@ function getPhaseWeightContribution<TPhase extends string, TStep extends string>
   return (completedCount / steps.length) * weight;
 }
 
-export function calculateWeightedProgress<TPhase extends string, TStep extends string>(
+/**
+ * Resolves phase statuses from step data, applying enforcement rules.
+ * Shared by both progress and target-progress calculations to avoid
+ * duplicating the status resolution logic.
+ */
+function resolvePhaseStatuses<TPhase extends string, TStep extends string>(
   completedSteps: TStep[],
   currentStep: TStep | null,
   config: {
     phaseSteps: Record<TPhase, readonly TStep[]>;
     phaseOrder: readonly TPhase[];
-    phaseWeights: Record<TPhase, number>;
     startedSteps?: TStep[];
   },
-): number {
-  const totalWeight = sumOf(config.phaseOrder.map((phase) => config.phaseWeights[phase]));
-
-  if (totalWeight === 0) {
-    return 0;
-  }
-
+): { phase: TPhase; status: PhaseStatus }[] {
   const rawStatuses = config.phaseOrder.map((phase) => ({
     phase,
     status: getPhaseStatus(
@@ -122,12 +120,68 @@ export function calculateWeightedProgress<TPhase extends string, TStep extends s
     ),
   }));
 
-  const enforced = enforcePhaseProgression(rawStatuses);
+  return enforcePhaseProgression(rawStatuses);
+}
+
+type ProgressConfig<TPhase extends string, TStep extends string> = {
+  phaseSteps: Record<TPhase, readonly TStep[]>;
+  phaseOrder: readonly TPhase[];
+  phaseWeights: Record<TPhase, number>;
+  startedSteps?: TStep[];
+};
+
+export function calculateWeightedProgress<TPhase extends string, TStep extends string>(
+  completedSteps: TStep[],
+  currentStep: TStep | null,
+  config: ProgressConfig<TPhase, TStep>,
+): number {
+  const totalWeight = sumOf(config.phaseOrder.map((phase) => config.phaseWeights[phase]));
+
+  if (totalWeight === 0) {
+    return 0;
+  }
+
+  const enforced = resolvePhaseStatuses(completedSteps, currentStep, config);
 
   const weightedSum = sumOf(
     enforced.map(({ phase, status }) =>
       getPhaseWeightContribution(phase, status, completedSteps, config),
     ),
+  );
+
+  return Math.round((weightedSum / totalWeight) * 100);
+}
+
+/**
+ * Computes the progress value that would be reached if all currently
+ * active phases completed right now. This gives `useAnimatedProgress`
+ * a meaningful ceiling to drift toward instead of a fixed constant.
+ *
+ * With parallel phases (e.g. listening runs vocab + grammar simultaneously),
+ * multiple phases can be active at once — their combined remaining weight
+ * is included in the target.
+ */
+export function calculateTargetProgress<TPhase extends string, TStep extends string>(
+  completedSteps: TStep[],
+  currentStep: TStep | null,
+  config: ProgressConfig<TPhase, TStep>,
+): number {
+  const totalWeight = sumOf(config.phaseOrder.map((phase) => config.phaseWeights[phase]));
+
+  if (totalWeight === 0) {
+    return 0;
+  }
+
+  const enforced = resolvePhaseStatuses(completedSteps, currentStep, config);
+
+  const weightedSum = sumOf(
+    enforced.map(({ phase, status }) => {
+      if (status === "active") {
+        return config.phaseWeights[phase];
+      }
+
+      return getPhaseWeightContribution(phase, status, completedSteps, config);
+    }),
   );
 
   return Math.round((weightedSum / totalWeight) * 100);

--- a/apps/main/src/lib/generation/activity-generation-phases.ts
+++ b/apps/main/src/lib/generation/activity-generation-phases.ts
@@ -1,6 +1,7 @@
 import {
   type PhaseStatus,
   calculateWeightedProgress as calculateProgress,
+  calculateTargetProgress as calculateTarget,
   getPhaseStatus as getStatus,
 } from "@/lib/generation-phases";
 import {
@@ -63,16 +64,37 @@ export function getPhaseStatus(
   return getStatus(phase, completedSteps, currentStep, getPhaseSteps(activityKind), startedSteps);
 }
 
+function getProgressConfig(activityKind: ActivityKind, startedSteps?: ActivityStepName[]) {
+  return {
+    phaseOrder: getPhaseOrder(activityKind),
+    phaseSteps: getPhaseSteps(activityKind),
+    phaseWeights: getPhaseWeights(activityKind),
+    startedSteps,
+  };
+}
+
 export function calculateWeightedProgress(
   completedSteps: ActivityStepName[],
   currentStep: ActivityStepName | null,
   activityKind: ActivityKind,
   startedSteps?: ActivityStepName[],
 ): number {
-  return calculateProgress(completedSteps, currentStep, {
-    phaseOrder: getPhaseOrder(activityKind),
-    phaseSteps: getPhaseSteps(activityKind),
-    phaseWeights: getPhaseWeights(activityKind),
-    startedSteps,
-  });
+  return calculateProgress(
+    completedSteps,
+    currentStep,
+    getProgressConfig(activityKind, startedSteps),
+  );
+}
+
+export function calculateTargetProgress(
+  completedSteps: ActivityStepName[],
+  currentStep: ActivityStepName | null,
+  activityKind: ActivityKind,
+  startedSteps?: ActivityStepName[],
+): number {
+  return calculateTarget(
+    completedSteps,
+    currentStep,
+    getProgressConfig(activityKind, startedSteps),
+  );
 }

--- a/apps/main/src/lib/workflow/use-animated-progress.test.ts
+++ b/apps/main/src/lib/workflow/use-animated-progress.test.ts
@@ -13,17 +13,25 @@ describe(useAnimatedProgress, () => {
   });
 
   it("returns realProgress when not active", () => {
-    const { result } = renderHook(() => useAnimatedProgress(42, false));
+    const { result } = renderHook(() =>
+      useAnimatedProgress({ isActive: false, realProgress: 42, targetProgress: 42 }),
+    );
+
     expect(result.current).toBe(42);
   });
 
   it("returns realProgress initially when active", () => {
-    const { result } = renderHook(() => useAnimatedProgress(10, true));
+    const { result } = renderHook(() =>
+      useAnimatedProgress({ isActive: true, realProgress: 10, targetProgress: 50 }),
+    );
+
     expect(result.current).toBe(10);
   });
 
   it("drifts forward when active and stalled", () => {
-    const { result } = renderHook(() => useAnimatedProgress(10, true));
+    const { result } = renderHook(() =>
+      useAnimatedProgress({ isActive: true, realProgress: 10, targetProgress: 50 }),
+    );
 
     act(() => {
       vi.advanceTimersByTime(15_000);
@@ -32,18 +40,40 @@ describe(useAnimatedProgress, () => {
     expect(result.current).toBeGreaterThan(10);
   });
 
-  it("never exceeds realProgress + MAX_DRIFT (8)", () => {
-    const { result } = renderHook(() => useAnimatedProgress(10, true));
+  it("drifts proportionally to the gap between real and target", () => {
+    // Small gap (target 15, real 10) — drift should be modest
+    const { result: small } = renderHook(() =>
+      useAnimatedProgress({ isActive: true, realProgress: 10, targetProgress: 15 }),
+    );
+
+    // Large gap (target 90, real 10) — drift should be much larger
+    const { result: large } = renderHook(() =>
+      useAnimatedProgress({ isActive: true, realProgress: 10, targetProgress: 90 }),
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+
+    expect(large.current).toBeGreaterThan(small.current);
+  });
+
+  it("never exceeds targetProgress", () => {
+    const { result } = renderHook(() =>
+      useAnimatedProgress({ isActive: true, realProgress: 10, targetProgress: 30 }),
+    );
 
     act(() => {
       vi.advanceTimersByTime(300_000);
     });
 
-    expect(result.current).toBeLessThanOrEqual(18);
+    expect(result.current).toBeLessThanOrEqual(30);
   });
 
   it("never exceeds CAP (97)", () => {
-    const { result } = renderHook(() => useAnimatedProgress(90, true));
+    const { result } = renderHook(() =>
+      useAnimatedProgress({ isActive: true, realProgress: 90, targetProgress: 100 }),
+    );
 
     act(() => {
       vi.advanceTimersByTime(300_000);
@@ -53,10 +83,9 @@ describe(useAnimatedProgress, () => {
   });
 
   it("snaps to real progress when it updates", () => {
-    const { result, rerender } = renderHook(
-      ({ progress, active }) => useAnimatedProgress(progress, active),
-      { initialProps: { active: true, progress: 10 } },
-    );
+    const { result, rerender } = renderHook((props) => useAnimatedProgress(props), {
+      initialProps: { isActive: true, realProgress: 10, targetProgress: 30 },
+    });
 
     act(() => {
       vi.advanceTimersByTime(8000);
@@ -65,7 +94,7 @@ describe(useAnimatedProgress, () => {
     const driftedValue = result.current;
     expect(driftedValue).toBeGreaterThan(10);
 
-    rerender({ active: true, progress: 50 });
+    rerender({ isActive: true, realProgress: 50, targetProgress: 80 });
 
     act(() => {
       vi.advanceTimersByTime(100);
@@ -75,10 +104,9 @@ describe(useAnimatedProgress, () => {
   });
 
   it("never decreases when realProgress drops", () => {
-    const { result, rerender } = renderHook(
-      ({ progress, active }) => useAnimatedProgress(progress, active),
-      { initialProps: { active: true, progress: 10 } },
-    );
+    const { result, rerender } = renderHook((props) => useAnimatedProgress(props), {
+      initialProps: { isActive: true, realProgress: 10, targetProgress: 50 },
+    });
 
     act(() => {
       vi.advanceTimersByTime(15_000);
@@ -87,7 +115,7 @@ describe(useAnimatedProgress, () => {
     const driftedValue = result.current;
     expect(driftedValue).toBeGreaterThan(10);
 
-    rerender({ active: true, progress: 5 });
+    rerender({ isActive: true, realProgress: 5, targetProgress: 50 });
 
     act(() => {
       vi.advanceTimersByTime(100);
@@ -97,10 +125,9 @@ describe(useAnimatedProgress, () => {
   });
 
   it("continues drifting when realProgress stays below high water mark", () => {
-    const { result, rerender } = renderHook(
-      ({ progress, active }) => useAnimatedProgress(progress, active),
-      { initialProps: { active: true, progress: 20 } },
-    );
+    const { result, rerender } = renderHook((props) => useAnimatedProgress(props), {
+      initialProps: { isActive: true, realProgress: 20, targetProgress: 60 },
+    });
 
     act(() => {
       vi.advanceTimersByTime(10_000);
@@ -109,7 +136,7 @@ describe(useAnimatedProgress, () => {
     const firstDrift = result.current;
     expect(firstDrift).toBeGreaterThan(20);
 
-    rerender({ active: true, progress: 15 });
+    rerender({ isActive: true, realProgress: 15, targetProgress: 60 });
 
     act(() => {
       vi.advanceTimersByTime(5000);
@@ -119,23 +146,36 @@ describe(useAnimatedProgress, () => {
   });
 
   it("stops drifting when active becomes false", () => {
-    const { result, rerender } = renderHook(
-      ({ progress, active }) => useAnimatedProgress(progress, active),
-      { initialProps: { active: true, progress: 30 } },
-    );
+    const { result, rerender } = renderHook((props) => useAnimatedProgress(props), {
+      initialProps: { isActive: true, realProgress: 30, targetProgress: 70 },
+    });
 
     act(() => {
       vi.advanceTimersByTime(10_000);
     });
 
-    rerender({ active: false, progress: 30 });
+    rerender({ isActive: false, realProgress: 30, targetProgress: 70 });
 
     expect(result.current).toBe(30);
   });
 
+  it("does not drift when target equals real progress", () => {
+    const { result } = renderHook(() =>
+      useAnimatedProgress({ isActive: true, realProgress: 50, targetProgress: 50 }),
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(result.current).toBe(50);
+  });
+
   it("cleans up animation frame on unmount", () => {
     const cancelSpy = vi.spyOn(globalThis, "cancelAnimationFrame");
-    const { unmount } = renderHook(() => useAnimatedProgress(10, true));
+    const { unmount } = renderHook(() =>
+      useAnimatedProgress({ isActive: true, realProgress: 10, targetProgress: 50 }),
+    );
 
     act(() => {
       vi.advanceTimersByTime(1000);

--- a/apps/main/src/lib/workflow/use-animated-progress.ts
+++ b/apps/main/src/lib/workflow/use-animated-progress.ts
@@ -2,8 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
-const MAX_DRIFT = 8;
-const HALF_LIFE = 15_000;
+const HALF_LIFE = 12_000;
 const CAP = 97;
 
 /**
@@ -11,10 +10,26 @@ const CAP = 97;
  * while streaming is active, creating the illusion of movement
  * during long-running backend steps.
  *
+ * The drift ceiling is dynamic: instead of a fixed constant,
+ * it uses `targetProgress` (the value progress will reach when
+ * all currently active phases complete). This makes the drift
+ * proportional to the actual work remaining in the active phase(s),
+ * so a heavy phase like "recording audio" (weight 50) gets a wide
+ * drift range while a light phase like "saving" (weight 2) gets
+ * a narrow one.
+ *
  * Uses a high-water mark to ensure the displayed value never decreases,
  * preventing visual "snap-back" when real progress drops after drift inflation.
  */
-export function useAnimatedProgress(realProgress: number, active: boolean): number {
+export function useAnimatedProgress({
+  isActive,
+  realProgress,
+  targetProgress,
+}: {
+  isActive: boolean;
+  realProgress: number;
+  targetProgress: number;
+}): number {
   const [display, setDisplay] = useState(realProgress);
   const rafRef = useRef<number>(0);
   const startTimeRef = useRef<number>(0);
@@ -32,7 +47,7 @@ export function useAnimatedProgress(realProgress: number, active: boolean): numb
   }, [realProgress]);
 
   useEffect(() => {
-    if (!active) {
+    if (!isActive) {
       setDisplay(realProgress);
       highWaterRef.current = realProgress;
       cancelAnimationFrame(rafRef.current);
@@ -40,8 +55,9 @@ export function useAnimatedProgress(realProgress: number, active: boolean): numb
     }
 
     function tick() {
+      const gap = Math.max(0, targetProgress - baseRef.current);
       const elapsed = performance.now() - startTimeRef.current;
-      const drift = MAX_DRIFT * (1 - 1 / (1 + elapsed / HALF_LIFE));
+      const drift = gap * (1 - Math.exp(-elapsed / HALF_LIFE));
       const animated = baseRef.current + drift;
       const capped = Math.min(animated, CAP);
       const monotonic = Math.max(capped, highWaterRef.current);
@@ -61,7 +77,7 @@ export function useAnimatedProgress(realProgress: number, active: boolean): numb
     return () => {
       cancelAnimationFrame(rafRef.current);
     };
-  }, [active, realProgress]);
+  }, [isActive, realProgress, targetProgress]);
 
   return display;
 }


### PR DESCRIPTION
## Summary

- Replace fixed `MAX_DRIFT = 8` in `useAnimatedProgress` with a dynamic ceiling based on `targetProgress - realProgress`, so the drift fills proportionally to the active phase's weight
- Add `calculateTargetProgress` that computes progress as if all currently active phases completed (handles parallel phases like listening)
- Switch drift curve from hyperbolic to exponential decay for faster gap coverage (~95% in 36s)

## Test plan

- [x] Unit tests for `calculateTargetProgress` (single active, multiple parallel, invariant `target >= progress`)
- [x] Unit tests for `useAnimatedProgress` (proportional drift, never exceeds target, monotonicity, zero-gap)
- [x] All existing tests pass (386/386)
- [x] Typecheck, lint, knip, build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the generation progress bar drift toward a dynamic ceiling based on target progress, so movement matches the weight of the active phase and prevents big jumps. This makes heavy phases feel responsive and light phases stay subtle.

- **Bug Fixes**
  - Drift ceiling is now `targetProgress - realProgress`; display never exceeds target or the 97% cap.
  - Switched to exponential decay for faster, smoother catch-up (~95% of the gap in ~36s).

- **Refactors**
  - Added `calculateTargetProgress` and a shared status resolver; supports parallel phases and is used across activity/chapter/course/lesson flows.
  - `useGenerationPhases` now returns `targetProgress`, and `useAnimatedProgress` accepts `{ isActive, realProgress, targetProgress }`; tests updated and expanded.

<sup>Written for commit 9f2a09f18246dbb00fc485bff40274292b4e345a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

