### PR TITLE
feat(ai): add investigation interpretations task

### DIFF
--- a/apps/evals/src/tasks/activity-investigation-interpretations/task.ts
+++ b/apps/evals/src/tasks/activity-investigation-interpretations/task.ts
@@ -1,0 +1,19 @@
+import { type Task } from "@/lib/types";
+import {
+  type ActivityInvestigationInterpretationsParams,
+  type ActivityInvestigationInterpretationsSchema,
+  generateActivityInvestigationInterpretations,
+} from "@zoonk/ai/tasks/activities/core/investigation-interpretations";
+import { TEST_CASES } from "./test-cases";
+
+export const activityInvestigationInterpretationsTask: Task<
+  ActivityInvestigationInterpretationsParams,
+  ActivityInvestigationInterpretationsSchema
+> = {
+  description:
+    "Generate interpretation statements for each finding from one explanation's perspective",
+  generate: generateActivityInvestigationInterpretations,
+  id: "activity-investigation-interpretations",
+  name: "Activity Investigation Interpretations",
+  testCases: TEST_CASES,
+};

--- a/apps/evals/src/tasks/activity-investigation-interpretations/test-cases.ts
+++ b/apps/evals/src/tasks/activity-investigation-interpretations/test-cases.ts
@@ -1,0 +1,41 @@
+export const TEST_CASES = [
+  {
+    expectations: `
+EVALUATION CRITERIA:
+
+1. INTERPRETATION COUNT: Exactly one interpretation set per finding (3 statements + 1 feedback each).
+
+2. QUALITY TIERS: Each set must have exactly one "best", one "overclaims", and one "dismissive" statement. The "best" should acknowledge both what the evidence shows and its limits. "overclaims" should read too much into it. "dismissive" should dismiss relevant evidence.
+
+3. PERSPECTIVE CONSISTENCY: All interpretations must be written from the perspective of someone who believes the given explanation. They should make sense for that specific hunch.
+
+4. SIMILAR LENGTH AND TONE: All 3 statements for a finding must be similar in length. The quality difference should be in the reasoning, not in how carefully each one is written. The "best" should NOT be obviously best by being longer or more detailed.
+
+5. FEEDBACK QUALITY: Feedback should explain why the best reading is best — not just restate the statement.
+
+6. LANGUAGE: All content must be in the specified language. Only JSON field names and enum values should be in English.
+    `,
+    id: "en-web-packets-network-paths",
+    userInput: {
+      explanationIndex: 0,
+      findings: {
+        findings: [
+          "The trace shows 14 stops between the office and your server, compared to 6 from headquarters; however, a few of those extra stops appear in traces to unrelated sites as well.",
+          "Server logs show all requests arriving intact with correct formatting; however, response times for the affected office are three times longer than for other locations.",
+          "Both offices measure similar download speeds on a general speed test; however, the affected office shows noticeably higher variation when loading pages with many small embedded resources.",
+        ],
+      },
+      language: "en",
+      scenario: {
+        explanations: [
+          "A device between your office and the app is sending requests along a bad route, so some messages never reach the server and others come back late.",
+          "The app update changed what each message contains, and the server is rejecting certain requests because important information is missing or malformed.",
+          "A machine on the local network is using the wrong identity details, so replies are being sent to the wrong place even though the requests leave successfully.",
+          "The slowdown is coming from one overloaded link in the chain, where traffic is piling up and causing timeouts before the full exchange can finish.",
+        ],
+        scenario:
+          "Your team pushes a small update to your web app, and now users in one office say pages load halfway then stall. You can reach the app from headquarters, but the problem gets worse the farther users are from the server.",
+      },
+    },
+  },
+];

--- a/apps/evals/src/tasks/index.ts
+++ b/apps/evals/src/tasks/index.ts
@@ -8,6 +8,7 @@ import { activityInvestigationAccuracyTask } from "./activity-investigation-accu
 import { activityInvestigationActionsTask } from "./activity-investigation-actions/task";
 import { activityInvestigationDebriefTask } from "./activity-investigation-debrief/task";
 import { activityInvestigationFindingsTask } from "./activity-investigation-findings/task";
+import { activityInvestigationInterpretationsTask } from "./activity-investigation-interpretations/task";
 import { activityInvestigationScenarioTask } from "./activity-investigation-scenario/task";
 import { activityInvestigationVisualsTask } from "./activity-investigation-visuals/task";
 import { activityPracticeTask } from "./activity-practice/task";
@@ -48,6 +49,7 @@ export const TASKS: readonly Task[] = [
   activityInvestigationActionsTask,
   activityInvestigationDebriefTask,
   activityInvestigationFindingsTask,
+  activityInvestigationInterpretationsTask,
   activityInvestigationScenarioTask,
   activityInvestigationVisualsTask,
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -13,6 +13,7 @@
     "./tasks/activities/core/investigation-actions": "./src/tasks/activities/core/activity-investigation-actions.ts",
     "./tasks/activities/core/investigation-debrief": "./src/tasks/activities/core/activity-investigation-debrief.ts",
     "./tasks/activities/core/investigation-findings": "./src/tasks/activities/core/activity-investigation-findings.ts",
+    "./tasks/activities/core/investigation-interpretations": "./src/tasks/activities/core/activity-investigation-interpretations.ts",
     "./tasks/activities/core/investigation-scenario": "./src/tasks/activities/core/activity-investigation-scenario.ts",
     "./tasks/activities/core/investigation-visuals": "./src/tasks/activities/core/activity-investigation-visuals.ts",
     "./tasks/activities/core/story-steps": "./src/tasks/activities/core/activity-story-steps.ts",

--- a/packages/ai/src/tasks/activities/core/activity-investigation-interpretations.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-investigation-interpretations.prompt.md
@@ -1,0 +1,50 @@
+You write interpretation statements for a learning game investigation. Given a mystery scenario and investigation findings, you write how a learner would interpret each piece of evidence if they believe a specific explanation is correct.
+
+## Philosophy
+
+The learner has picked a hunch (one of the explanations) and is now reviewing evidence. For each finding, they choose from 3 interpretation statements — one careful and nuanced, one that reads too much into it, and one that dismisses it. Your job is to write those 3 options from the perspective of someone who believes the given explanation.
+
+## Inputs
+
+- **SCENARIO**: The mystery scenario text
+- **EXPLANATION**: The specific explanation this task writes interpretations for (the learner's hunch)
+- **FINDINGS**: The evidence findings from investigation (numbered)
+- **LANGUAGE**: The content language
+
+## What You Generate
+
+For each finding, exactly 3 interpretation statements and 1 feedback string.
+
+## Interpretation Statements
+
+Each finding gets 3 statements with quality tiers:
+
+- `best`: A careful, nuanced reading. Acknowledges what the evidence shows AND its limitations relative to the hunch. Doesn't jump to conclusions but doesn't dismiss relevant information either.
+- `overclaims`: Reads too much into the evidence. Treats it as stronger proof than it is, ignores the complicating factor or alternative explanations.
+- `dismissive`: Dismisses the evidence as irrelevant or unimportant. Doesn't engage with what it actually shows.
+
+## Feedback
+
+One feedback string per finding (1-2 sentences). Explains why the `best` reading is the best — what makes it more careful than the overclaiming one and more engaged than the dismissive one. Should help the learner understand evidence interpretation, not just whether they picked correctly.
+
+## Rules
+
+- Write from the perspective of someone who believes the given EXPLANATION. The interpretations should make sense for that specific hunch.
+- Each statement should be one sentence. Concise but clear.
+- The `best` statement should NOT be obviously best. It might feel less satisfying than the confident overclaiming one — that's intentional.
+- All 3 statements for a finding must be similar in length and tone. The quality difference should be in the reasoning, not in how carefully it's written.
+- Generate exactly one interpretation set per finding, in the same order as the input.
+
+## Voice
+
+- Write in the specified LANGUAGE.
+- Use casual, conversational register.
+- NO jargon from the topic. Use everyday language.
+
+## Language
+
+Generate ALL content in the specified LANGUAGE. Never mix languages. The only English in the output should be the JSON field names and enum values (like "best", "overclaims", "dismissive").
+
+- `en`: US English
+- `pt`: Brazilian Portuguese
+- `es`: Latin American Spanish

--- a/packages/ai/src/tasks/activities/core/activity-investigation-interpretations.ts
+++ b/packages/ai/src/tasks/activities/core/activity-investigation-interpretations.ts
@@ -1,0 +1,99 @@
+import "server-only";
+import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { Output, generateText } from "ai";
+import { z } from "zod";
+import { type ActivityInvestigationFindingsSchema } from "./activity-investigation-findings";
+import systemPrompt from "./activity-investigation-interpretations.prompt.md";
+import { type ActivityInvestigationScenarioSchema } from "./activity-investigation-scenario";
+
+const DEFAULT_MODEL =
+  process.env.AI_MODEL_ACTIVITY_INVESTIGATION_INTERPRETATIONS ?? "openai/gpt-5.4";
+const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"];
+
+const schema = z.object({
+  interpretations: z.array(
+    z.object({
+      feedback: z.string(),
+      statements: z.array(
+        z.object({
+          quality: z.enum(["best", "overclaims", "dismissive"]),
+          text: z.string(),
+        }),
+      ),
+    }),
+  ),
+});
+
+export type ActivityInvestigationInterpretationsSchema = z.infer<typeof schema>;
+
+export type ActivityInvestigationInterpretationsParams = {
+  scenario: ActivityInvestigationScenarioSchema;
+  findings: ActivityInvestigationFindingsSchema;
+  explanationIndex: number;
+  language: string;
+  model?: string;
+  useFallback?: boolean;
+  reasoningEffort?: ReasoningEffort;
+};
+
+/**
+ * Formats the scenario, specific explanation, and findings into a
+ * readable prompt block so the AI can write interpretations from
+ * one explanation's perspective.
+ */
+function formatInputsForPrompt({
+  scenario,
+  findings,
+  explanationIndex,
+}: Pick<
+  ActivityInvestigationInterpretationsParams,
+  "scenario" | "findings" | "explanationIndex"
+>): string {
+  const findingList = findings.findings.map((finding, i) => `${i}. ${finding}`).join("\n");
+
+  return `
+    SCENARIO: ${scenario.scenario}
+    EXPLANATION: ${scenario.explanations[explanationIndex]}
+    FINDINGS: ${findingList}
+  `;
+}
+
+/**
+ * Generates interpretation statements for each finding from one
+ * explanation's perspective. Produces 3 statements (best/overclaims/
+ * dismissive) + feedback per finding.
+ *
+ * One instance of this task runs per explanation, all in parallel.
+ * This keeps each call small and lets the AI deeply inhabit one
+ * perspective rather than switching between explanations.
+ */
+export async function generateActivityInvestigationInterpretations({
+  scenario,
+  findings,
+  explanationIndex,
+  language,
+  model = DEFAULT_MODEL,
+  useFallback = true,
+  reasoningEffort,
+}: ActivityInvestigationInterpretationsParams) {
+  const userPrompt = `
+    ${formatInputsForPrompt({ explanationIndex, findings, scenario })}
+    LANGUAGE: ${language}
+  `;
+
+  const providerOptions = buildProviderOptions({
+    fallbackModels: FALLBACK_MODELS,
+    reasoningEffort,
+    useFallback,
+  });
+
+  const { output, usage } = await generateText({
+    model,
+    output: Output.object({ schema }),
+    prompt: userPrompt,
+    providerOptions,
+    system: systemPrompt,
+  });
+
+  return { data: output, systemPrompt, usage, userPrompt };
+}


### PR DESCRIPTION
## Summary
- Add per-explanation interpretation AI task with prompt and schema
- Each instance generates 3 reading statements (best/overclaims/dismissive) + feedback per finding from one explanation's perspective
- Add eval task with one test case
- Register in evals index and package.json exports

## Test plan
- [ ] Run evals for `activity-investigation-interpretations` task
- [ ] Verify outputs have correct structure (3 statements + feedback per finding)
- [ ] Check that interpretations are written from the given explanation's perspective

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-explanation investigation interpretations task that generates three statements (best, overclaims, dismissive) plus feedback for each finding. Registers the task in evals and exports it from `@zoonk/ai`.

- **New Features**
  - New `activity-investigation-interpretations` task with prompt, schema, and generator; runs once per explanation for focused perspective.
  - Structured output per finding: three statements with `quality` enums and one `feedback` string.
  - Evals: added test case and task registration in `apps/evals` and `TASKS` index.
  - Exported via `@zoonk/ai` at `./tasks/activities/core/investigation-interpretations`.

<sup>Written for commit e2cfb1c51e07ca9505ac0fdd97319d9ee1fa1267. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

