### PR TITLE
refactor(blog): group post list by year and simplify date display

### DIFF
--- a/apps/blog/src/components/post-list.tsx
+++ b/apps/blog/src/components/post-list.tsx
@@ -1,38 +1,41 @@
-import { getPostsByYear } from "@/lib/posts";
+import { formatDateWithoutYear, getPostsByYear } from "@/lib/posts";
 import Link from "next/link";
 
 /**
  * Chronological list of blog posts grouped by year.
- * Displayed on the home page with minimal styling:
- * year label on the left, post title as link, date on the right.
+ * Each year appears as a section header above its posts.
+ * Post rows show the title and a short date (without the year,
+ * since the section header already provides that context).
  */
 export function PostList() {
   const postsByYear = getPostsByYear();
+  const yearGroups = [...postsByYear.entries()];
 
   return (
-    <ul className="text-sm">
-      {[...postsByYear.entries()].map(([year, posts]) => (
-        <li key={year}>
-          {posts.map((post, index) => {
-            const href = `/${post.id}`;
-            const isFirstOfYear = index === 0;
+    <ul>
+      {yearGroups.map(([year, posts], groupIndex) => (
+        <li key={year} className={groupIndex > 0 ? "mt-10" : ""}>
+          <h2 className="text-muted-foreground mb-3 text-sm font-medium">{year}</h2>
 
-            return (
-              <Link key={post.id} href={href} className="group flex items-baseline py-2">
-                <span className="text-muted-foreground w-14 shrink-0 text-xs">
-                  {isFirstOfYear ? year : ""}
-                </span>
+          <ul>
+            {posts.map((post) => {
+              const href = `/${post.id}` as const;
 
-                <span className="grow">
-                  <span className="group-hover:bg-muted rounded-lg px-1.5 py-0.5 transition-colors">
-                    {post.title}
-                  </span>
-                </span>
+              return (
+                <li key={post.id}>
+                  <Link href={href} className="group flex items-baseline py-2 text-sm">
+                    <span className="group-hover:bg-muted -mx-1.5 grow rounded-lg px-1.5 py-0.5 transition-colors">
+                      {post.title}
+                    </span>
 
-                <span className="text-muted-foreground shrink-0 text-xs">{post.date}</span>
-              </Link>
-            );
-          })}
+                    <span className="text-muted-foreground shrink-0 text-xs">
+                      {formatDateWithoutYear(post.date)}
+                    </span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
         </li>
       ))}
     </ul>

--- a/apps/blog/src/lib/posts.ts
+++ b/apps/blog/src/lib/posts.ts
@@ -22,3 +22,11 @@ export function getPostsByYear(): Map<string, Post[]> {
 
   return grouped;
 }
+
+/**
+ * Format a date string as "Month Day" (e.g., "April 6") without the year.
+ * Since posts are grouped by year, displaying the year in each row is redundant.
+ */
+export function formatDateWithoutYear(date: string): string {
+  return new Intl.DateTimeFormat("en-US", { day: "numeric", month: "long" }).format(new Date(date));
+}


### PR DESCRIPTION
## Summary
- Group blog posts by year with year as a section header instead of a column
- Remove year from individual post dates, show only "Month Day" using `Intl.DateTimeFormat`
- Align post titles flush-left with year headers using negative margin on hover background

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grouped blog posts by year with a year header and simplified dates (“Month Day”) to reduce repetition and improve scanability.

- **Refactors**
  - Replaced per-row year column with year section headers in `PostList`.
  - Added `formatDateWithoutYear` using Intl to format dates as “Month Day”.
  - Tweaked hover styling so titles align flush-left with year headers using a small negative margin.

<sup>Written for commit 14b245ef633c41d16df5bda274f3715ee4d5f1be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

