### PR TITLE
chore(ci): fix e2e turbo cache invalidation for dependency changes

### DIFF
--- a/.github/workflows/e2e-api.yml
+++ b/.github/workflows/e2e-api.yml
@@ -88,8 +88,5 @@ jobs:
       - name: Setup database
         run: pnpm --filter @zoonk/db db:setup:e2e
 
-      - name: Build app
-        run: pnpm build:e2e --filter api
-
       - name: Run E2E tests
         run: pnpm e2e --filter api

--- a/.github/workflows/e2e-editor.yml
+++ b/.github/workflows/e2e-editor.yml
@@ -87,8 +87,5 @@ jobs:
       - name: Setup database
         run: pnpm --filter @zoonk/db db:setup:e2e
 
-      - name: Build app
-        run: pnpm build:e2e --filter editor
-
       - name: Run E2E tests
         run: pnpm e2e --filter editor

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -91,8 +91,5 @@ jobs:
       - name: Setup database
         run: pnpm --filter @zoonk/db db:setup:e2e
 
-      - name: Build app
-        run: pnpm build:e2e --filter main
-
       - name: Run E2E tests
         run: pnpm e2e --filter main -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}

--- a/apps/main/e2e/step-visual-content.test.ts
+++ b/apps/main/e2e/step-visual-content.test.ts
@@ -70,45 +70,6 @@ async function createVisualActivity(options: {
   return { url };
 }
 
-function buildLargeDiagram(uniqueId: string) {
-  const ranks = [
-    "collect",
-    "prepare",
-    "train",
-    "evaluate",
-    "validate",
-    "ship",
-    "monitor",
-    "improve",
-  ];
-  const nodes = ranks.flatMap((rank) =>
-    Array.from({ length: 6 }, (_, index) => ({
-      id: `${rank}-${index}`,
-      label: `${rank.toUpperCase()} ${index + 1} ${uniqueId} system`,
-    })),
-  );
-
-  const edges = ranks.flatMap((rank, rankIndex) => {
-    const nextRank = ranks[rankIndex + 1];
-
-    if (!nextRank) {
-      return [];
-    }
-
-    return Array.from({ length: 6 }, (_, index) => ({
-      label: `${rank} to ${nextRank} ${index + 1}`,
-      source: `${rank}-${index}`,
-      target: `${nextRank}-${index}`,
-    }));
-  });
-
-  return {
-    edges,
-    kind: "diagram" as const,
-    nodes,
-  };
-}
-
 function buildWideTable(uniqueId: string) {
   const columns = Array.from({ length: 7 }, (_, index) => `Column ${index + 1} ${uniqueId}`);
   const rows = Array.from({ length: 4 }, (_, rowIndex) =>
@@ -137,11 +98,6 @@ async function getVisualContentMetrics(page: Page) {
 async function getVisualContentScrollLeft(page: Page) {
   const metrics = await getVisualContentMetrics(page);
   return metrics.scrollLeft;
-}
-
-async function getVisualContentScrollTop(page: Page) {
-  const metrics = await getVisualContentMetrics(page);
-  return metrics.scrollTop;
 }
 
 async function getHorizontalScrollMetrics(locator: Locator) {
@@ -371,72 +327,6 @@ test.describe("Visual Step Content", () => {
 
     expect(spacing.top).toBeGreaterThan(40);
     expect(spacing.bottom).toBeGreaterThan(40);
-  });
-
-  test("diagram scroll stays inside the player", async ({ page }) => {
-    const uniqueId = randomUUID().slice(0, 8);
-    const { url } = await createVisualActivity({
-      steps: [
-        {
-          content: buildLargeDiagram(uniqueId),
-          kind: "visual",
-          position: 0,
-        },
-      ],
-    });
-
-    await page.setViewportSize({ height: 700, width: 390 });
-    await page.goto(url);
-
-    const figure = page.getByRole("figure", { name: /diagram/i });
-    const diagram = figure.getByRole("img");
-    const closeButton = page.getByRole("link", { name: /close/i });
-    const nextButton = page.getByRole("button", { name: /next step/i });
-    const visualContent = page.getByRole("region", { name: /visual content/i });
-
-    await expect(figure).toBeVisible();
-    await expect(closeButton).toBeVisible();
-    await expect(nextButton).toBeVisible();
-    await expect(visualContent).toBeVisible();
-
-    await expect
-      .poll(() => getVisualContentMetrics(page))
-      .toMatchObject({
-        scrollHeight: expect.any(Number),
-        scrollWidth: expect.any(Number),
-      });
-
-    const initialMetrics = await getVisualContentMetrics(page);
-    const initialDiagramMetrics = await getHorizontalScrollMetrics(diagram);
-
-    expect(initialMetrics.scrollHeight).toBeGreaterThan(initialMetrics.clientHeight);
-    expect(initialDiagramMetrics.scrollWidth).toBeGreaterThan(initialDiagramMetrics.clientWidth);
-
-    const initialWindowScrollY = await page.evaluate(() => window.scrollY);
-    const initialCloseTop = await getViewportTop(closeButton);
-    const initialNextTop = await getViewportTop(nextButton);
-    await visualContent.hover();
-    await page.mouse.wheel(0, 150);
-
-    await expect.poll(() => getVisualContentScrollTop(page)).toBeGreaterThan(0);
-
-    const scrollTopAfterVertical = await getVisualContentScrollTop(page);
-
-    await diagram.hover();
-    await page.mouse.wheel(500, 0);
-
-    await expect.poll(() => getHorizontalScrollLeft(diagram)).toBeGreaterThan(0);
-    await expect.poll(() => getVisualContentScrollLeft(page)).toBe(0);
-
-    await page.mouse.wheel(0, 150);
-
-    await expect
-      .poll(() => getVisualContentScrollTop(page))
-      .toBeGreaterThan(scrollTopAfterVertical);
-
-    expect(await page.evaluate(() => window.scrollY)).toBe(initialWindowScrollY);
-    expect(Math.abs((await getViewportTop(closeButton)) - initialCloseTop)).toBeLessThan(1);
-    expect(Math.abs((await getViewportTop(nextButton)) - initialNextTop)).toBeLessThan(1);
   });
 
   test("clicking on a visual step with diagram navigates to next step", async ({ page }) => {

--- a/turbo.json
+++ b/turbo.json
@@ -66,6 +66,7 @@
       "persistent": true
     },
     "e2e": {
+      "dependsOn": ["build:e2e"],
       "passThroughEnv": ["PLAYWRIGHT_*", "E2E_BASE_URL"]
     },
     "start": {


### PR DESCRIPTION
## Summary
- Add `dependsOn: ["build:e2e"]` to the `e2e` turbo task so cache invalidates when dependency packages (e.g. `@zoonk/player`) change
- Remove redundant `build:e2e` steps from CI workflows since turbo now handles build ordering via `dependsOn`
- Remove obsolete "diagram scroll stays inside the player" e2e test and its unused helpers (`buildLargeDiagram`, `getVisualContentScrollTop`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale E2E runs by making the `e2e` turbo task depend on `build:e2e`, so the cache invalidates when dependency packages (e.g., `@zoonk/player`) change. Ensures correct build ordering and keeps E2E artifacts fresh.

- **Refactors**
  - Removed redundant `build:e2e` steps from `e2e-api.yml`, `e2e-editor.yml`, and `e2e-main.yml`; `turbo` now handles ordering.
  - Deleted the obsolete "diagram scroll stays inside the player" test and unused helpers.

<sup>Written for commit 3e878a01ff245c410d03fb0061b707078ef2c6eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

