### PR TITLE
fix(player): stabilize diagram layout and scrolling

### DIFF
--- a/apps/main/e2e/step-visual-content.test.ts
+++ b/apps/main/e2e/step-visual-content.test.ts
@@ -84,6 +84,47 @@ function buildWideTable(uniqueId: string) {
   };
 }
 
+function buildWideDiagram(uniqueId: string) {
+  return {
+    edges: [
+      {
+        label: `routes requests ${uniqueId}`,
+        source: "incoming",
+        target: "queue",
+      },
+      {
+        label: `overloads approvals ${uniqueId}`,
+        source: "urgent",
+        target: "queue",
+      },
+      {
+        label: `delivers updates ${uniqueId}`,
+        source: "queue",
+        target: "delivery",
+      },
+    ],
+    kind: "diagram" as const,
+    nodes: [
+      {
+        id: "incoming",
+        label: `Incoming enterprise procurement requests ${uniqueId}`,
+      },
+      {
+        id: "urgent",
+        label: `High-priority compliance escalations ${uniqueId}`,
+      },
+      {
+        id: "queue",
+        label: `Awaiting approval from operations ${uniqueId}`,
+      },
+      {
+        id: "delivery",
+        label: `Delivery to the requesting team ${uniqueId}`,
+      },
+    ],
+  };
+}
+
 async function getVisualContentMetrics(page: Page) {
   return page.getByRole("region", { name: /visual content/i }).evaluate((element) => ({
     clientHeight: element.clientHeight,
@@ -526,6 +567,58 @@ test.describe("Visual Step Content", () => {
     await page.mouse.wheel(500, 0);
 
     await expect.poll(() => getHorizontalScrollLeft(table)).toBeGreaterThan(0);
+    await expect.poll(() => getVisualContentScrollLeft(page)).toBe(0);
+
+    expect(await page.evaluate(() => window.scrollY)).toBe(initialWindowScrollY);
+    expect(Math.abs((await getViewportTop(closeButton)) - initialCloseTop)).toBeLessThan(1);
+    expect(Math.abs((await getViewportTop(nextButton)) - initialNextTop)).toBeLessThan(1);
+  });
+
+  test("wide diagrams keep horizontal scroll on the diagram", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createVisualActivity({
+      steps: [
+        {
+          content: buildWideDiagram(uniqueId),
+          kind: "visual",
+          position: 0,
+        },
+        {
+          content: {
+            text: `Next step body ${uniqueId}`,
+            title: `Wide Diagram Step2 ${uniqueId}`,
+            variant: "text",
+          },
+          position: 1,
+        },
+      ],
+    });
+
+    await page.setViewportSize({ height: 700, width: 390 });
+    await page.goto(url);
+
+    const closeButton = page.getByRole("link", { name: /close/i });
+    const nextButton = page.getByRole("button", { name: /next step/i });
+    const figure = page.getByRole("figure", { name: /diagram/i });
+    const diagram = figure.getByRole("img");
+    const visualContent = page.getByRole("region", { name: /visual content/i });
+
+    await expect(figure).toBeVisible();
+    await expect(visualContent).toBeVisible();
+    await expect(nextButton).toBeVisible();
+
+    const initialDiagramMetrics = await getHorizontalScrollMetrics(diagram);
+
+    expect(initialDiagramMetrics.scrollWidth).toBeGreaterThan(initialDiagramMetrics.clientWidth);
+
+    const initialWindowScrollY = await page.evaluate(() => window.scrollY);
+    const initialCloseTop = await getViewportTop(closeButton);
+    const initialNextTop = await getViewportTop(nextButton);
+
+    await diagram.hover();
+    await page.mouse.wheel(500, 0);
+
+    await expect.poll(() => getHorizontalScrollLeft(diagram)).toBeGreaterThan(0);
     await expect.poll(() => getVisualContentScrollLeft(page)).toBe(0);
 
     expect(await page.evaluate(() => window.scrollY)).toBe(initialWindowScrollY);

--- a/packages/player/src/components/visuals/diagram-visual.tsx
+++ b/packages/player/src/components/visuals/diagram-visual.tsx
@@ -166,10 +166,11 @@ function buildAccessibleDescription(content: DiagramVisualContent): string {
 function DiagramSvg({ layout, markerId }: { layout: DiagramLayout; markerId: string }) {
   return (
     <svg
-      className="block h-auto max-w-full"
+      className="block flex-none"
       height={layout.height}
       preserveAspectRatio="xMidYMid meet"
       role="img"
+      style={{ height: layout.height, width: layout.width }}
       viewBox={layout.viewBox}
       width={layout.width}
     >
@@ -183,18 +184,18 @@ function DiagramSvg({ layout, markerId }: { layout: DiagramLayout; markerId: str
 export function DiagramVisual({ content }: { content: DiagramVisualContent }) {
   const t = useExtracted();
   const markerId = useId();
-
   const layout = useMemo(
     () => computeDiagramLayout(content.nodes, content.edges),
     [content.nodes, content.edges],
   );
-
-  const description = useMemo(() => buildAccessibleDescription(content), [content]);
+  const description = buildAccessibleDescription(content);
 
   return (
     <figure aria-label={t("Diagram")} className="w-full max-w-full min-w-0">
-      <div className="flex w-full justify-center">
-        <DiagramSvg layout={layout} markerId={markerId} />
+      <div className="w-full overflow-x-auto overscroll-x-contain">
+        <div className="flex w-max min-w-full justify-center">
+          <DiagramSvg layout={layout} markerId={markerId} />
+        </div>
       </div>
 
       <figcaption className="sr-only">{description}</figcaption>

--- a/packages/player/src/diagram-layout.test.ts
+++ b/packages/player/src/diagram-layout.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { computeDiagramLayout } from "./diagram-layout";
 
 function parseViewBox(viewBox: string) {
@@ -216,5 +216,50 @@ describe(computeDiagramLayout, () => {
     expect(edge!.label).toBeUndefined();
     expect(edge!.labelX).toBeUndefined();
     expect(edge!.labelY).toBeUndefined();
+  });
+
+  it("returns the same layout when browser canvas APIs are available", async () => {
+    const nodes = [
+      { id: "incoming", label: "Pedidos recebidos" },
+      { id: "urgent", label: "Muitas solicitações urgentes" },
+      { id: "queue", label: "Aguardando aprovação" },
+    ];
+    const edges = [
+      { label: "inicia", source: "incoming", target: "queue" },
+      { label: "sobrecarrega", source: "urgent", target: "queue" },
+    ];
+
+    try {
+      vi.stubGlobal("OffscreenCanvas", {});
+      vi.resetModules();
+
+      const { computeDiagramLayout: computeLayoutWithoutCanvas } = await import("./diagram-layout");
+      const fallbackLayout = computeLayoutWithoutCanvas(nodes, edges);
+
+      vi.stubGlobal(
+        "OffscreenCanvas",
+        class {
+          context = {
+            font: "",
+            measureText(text: string) {
+              return { width: text.length * 3 };
+            },
+          };
+
+          getContext() {
+            return this.context;
+          }
+        },
+      );
+      vi.resetModules();
+
+      const { computeDiagramLayout: computeLayoutWithCanvas } = await import("./diagram-layout");
+      const canvasLayout = computeLayoutWithCanvas(nodes, edges);
+
+      expect(canvasLayout).toEqual(fallbackLayout);
+    } finally {
+      vi.unstubAllGlobals();
+      vi.resetModules();
+    }
   });
 });

--- a/packages/player/src/diagram-layout.ts
+++ b/packages/player/src/diagram-layout.ts
@@ -28,6 +28,17 @@ export type DiagramLayout = {
   width: number;
 };
 
+type DiagramNodeInput = {
+  id: string;
+  label: string;
+};
+
+type DiagramEdgeInput = {
+  label?: string;
+  source: string;
+  target: string;
+};
+
 const MIN_NODE_WIDTH = 100;
 const NODE_HEIGHT = 40;
 const NODE_PADDING = 32;
@@ -40,47 +51,20 @@ const EDGE_LABEL_PADDING_Y = 3;
 const EDGE_LABEL_HEIGHT = EDGE_LABEL_FONT_SIZE + EDGE_LABEL_PADDING_Y * 2;
 
 const NODE_FONT_SIZE = 14;
-const NODE_FONT_WEIGHT = 500;
-const NODE_FONT = `${NODE_FONT_WEIGHT} ${NODE_FONT_SIZE}px Inter, system-ui, sans-serif`;
-const EDGE_FONT = `${EDGE_LABEL_FONT_SIZE}px Inter, system-ui, sans-serif`;
 
 /**
- * Cached OffscreenCanvas context for text measurement.
- * `undefined` = not yet initialized, `null` = unavailable
- * (e.g. test environments without canvas support).
+ * Estimates text width without consulting browser-only APIs.
+ *
+ * The diagram layout is part of the prerendered HTML for a Client Component,
+ * so server and client must compute the same numbers during hydration.
+ * Using `OffscreenCanvas` in the browser but not on the server causes the SVG
+ * geometry to diverge, which React correctly reports as a hydration mismatch.
+ *
+ * A small deterministic estimate is enough here because dagre only needs
+ * stable relative widths to avoid overlaps; it does not require pixel-perfect
+ * typography metrics.
  */
-let canvasCtx: OffscreenCanvasRenderingContext2D | null | undefined;
-
-function getCanvasContext(): OffscreenCanvasRenderingContext2D | null {
-  if (canvasCtx !== undefined) {
-    return canvasCtx;
-  }
-
-  if (typeof OffscreenCanvas === "undefined") {
-    canvasCtx = null;
-    return null;
-  }
-
-  const canvas = new OffscreenCanvas(1, 1);
-  canvasCtx = canvas.getContext("2d");
-  return canvasCtx;
-}
-
-/**
- * Measures text width using OffscreenCanvas when available (browser),
- * falling back to a character-count heuristic in environments without
- * canvas support (e.g. jsdom in tests). Using actual measurement
- * produces accurate node sizing for proportional fonts, mixed-width
- * characters, and non-Latin scripts.
- */
-function measureText(text: string, font: string, fontSize: number): number {
-  const ctx = getCanvasContext();
-
-  if (ctx) {
-    ctx.font = font;
-    return ctx.measureText(text).width;
-  }
-
+function estimateTextWidth({ fontSize, text }: { fontSize: number; text: string }): number {
   // Fallback: average character width for proportional
   // sans-serif fonts like Inter is ~55% of the font size.
   const averageCharWidthRatio = 0.55;
@@ -88,11 +72,42 @@ function measureText(text: string, font: string, fontSize: number): number {
 }
 
 function measureNodeWidth(label: string): number {
-  return Math.max(MIN_NODE_WIDTH, measureText(label, NODE_FONT, NODE_FONT_SIZE) + NODE_PADDING);
+  return Math.max(
+    MIN_NODE_WIDTH,
+    estimateTextWidth({ fontSize: NODE_FONT_SIZE, text: label }) + NODE_PADDING,
+  );
 }
 
 function measureEdgeLabelWidth(label: string): number {
-  return measureText(label, EDGE_FONT, EDGE_LABEL_FONT_SIZE) + EDGE_LABEL_PADDING_X * 2;
+  return (
+    estimateTextWidth({ fontSize: EDGE_LABEL_FONT_SIZE, text: label }) + EDGE_LABEL_PADDING_X * 2
+  );
+}
+
+/**
+ * Precomputes node widths once so dagre layout and the rendered SVG use the
+ * same dimensions. This avoids duplicated sizing logic drifting over time.
+ */
+function sizeNode(node: DiagramNodeInput): DiagramNodeInput & { width: number } {
+  return {
+    ...node,
+    width: measureNodeWidth(node.label),
+  };
+}
+
+/**
+ * Precomputes edge label dimensions once so dagre reserves space for the same
+ * label box that the SVG later renders.
+ */
+function sizeEdge(edge: DiagramEdgeInput): DiagramEdgeInput & {
+  labelHeight?: number;
+  labelWidth?: number;
+} {
+  return {
+    ...edge,
+    labelHeight: edge.label ? EDGE_LABEL_HEIGHT : undefined,
+    labelWidth: edge.label ? measureEdgeLabelWidth(edge.label) : undefined,
+  };
 }
 
 function readNodePosition(
@@ -180,59 +195,44 @@ function computeViewBox({ edges, nodes }: { edges: PositionedEdge[]; nodes: Posi
 }
 
 export function computeDiagramLayout(
-  nodes: {
-    id: string;
-    label: string;
-  }[],
-  edges: {
-    label?: string;
-    source: string;
-    target: string;
-  }[],
+  nodes: DiagramNodeInput[],
+  edges: DiagramEdgeInput[],
 ): DiagramLayout {
   const graph = new Graph<GraphLabel, NodeLabel, EdgeLabel>();
+  const sizedNodes = nodes.map((node) => sizeNode(node));
+  const sizedEdges = edges.map((edge) => sizeEdge(edge));
 
   graph.setGraph({ nodesep: NODE_SEP, rankdir: "TB", ranksep: RANK_SEP });
   graph.setDefaultEdgeLabel(() => ({}));
 
-  for (const node of nodes) {
+  for (const node of sizedNodes) {
     graph.setNode(node.id, {
       height: NODE_HEIGHT,
       label: node.label,
-      width: measureNodeWidth(node.label),
+      width: node.width,
     });
   }
 
-  for (const edge of edges) {
+  for (const edge of sizedEdges) {
     graph.setEdge(edge.source, edge.target, {
-      height: edge.label ? EDGE_LABEL_HEIGHT : 0,
+      height: edge.labelHeight ?? 0,
       label: edge.label,
-      width: edge.label ? measureEdgeLabelWidth(edge.label) : 0,
+      width: edge.labelWidth ?? 0,
     });
   }
 
   layout(graph);
 
-  const positionedNodes = nodes.map((node) => ({
+  const positionedNodes = sizedNodes.map((node) => ({
     ...readNodePosition(graph, node.id),
     id: node.id,
     label: node.label,
   }));
 
-  const positionedEdges = edges.map((edge) => {
-    const edgeData = readEdge(graph, edge.source, edge.target);
-
-    return {
-      label: edge.label,
-      labelHeight: edge.label ? EDGE_LABEL_HEIGHT : undefined,
-      labelWidth: edge.label ? measureEdgeLabelWidth(edge.label) : undefined,
-      labelX: edgeData.labelX,
-      labelY: edgeData.labelY,
-      points: edgeData.points,
-      source: edge.source,
-      target: edge.target,
-    };
-  });
+  const positionedEdges = sizedEdges.map((edge) => ({
+    ...edge,
+    ...readEdge(graph, edge.source, edge.target),
+  }));
 
   const { height, viewBox, width } = computeViewBox({
     edges: positionedEdges,


### PR DESCRIPTION
- make diagram sizing deterministic across server and client and reuse the same precomputed node and edge dimensions
- keep small diagrams centered while allowing wide diagrams to scroll horizontally on narrow screens
- add regression coverage for canvas-independent layout and mobile diagram scrolling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes diagram layout so server and client render identical SVG sizes, and keeps horizontal scrolling inside the diagram to prevent page scroll jumps. Addresses the hydration error investigation by making layout deterministic.

- **Bug Fixes**
  - Replaced canvas-based text measurement with a deterministic estimator and precomputed node/edge dimensions so dagre and the SVG use the same sizes, avoiding hydration mismatches.
  - Updated `packages/player` diagram wrappers to center small diagrams and allow wide diagrams to scroll horizontally within the figure only; added unit and e2e tests for canvas-independent layout and mobile scrolling behavior.

<sup>Written for commit 1e90ffd83b7b1fc28d918afa0053f39cebfcc6e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

