### PR TITLE
refactor(player): render action button inline on desktop for better proximity

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -323,31 +323,9 @@ msgid "Activity progress"
 msgstr "Activity progress"
 
 #: ../../packages/player/src/components/player-shell.tsx
-msgctxt "9p9JgX"
-msgid "Start Investigation"
-msgstr "Start Investigation"
-
-#: ../../packages/player/src/components/player-shell.tsx
-#: src/app/(catalog)/(home)/continue-learning-card.tsx
-#: src/components/catalog/continue-activity-link.tsx
-msgctxt "acrOoz"
-msgid "Continue"
-msgstr "Continue"
-
-#: ../../packages/player/src/components/player-shell.tsx
 msgctxt "EqkwlK"
 msgid "evidence"
 msgstr "evidence"
-
-#: ../../packages/player/src/components/player-shell.tsx
-msgctxt "PVe26p"
-msgid "Begin"
-msgstr "Begin"
-
-#: ../../packages/player/src/components/player-shell.tsx
-msgctxt "RDZVQL"
-msgid "Check"
-msgstr "Check"
 
 #: ../../packages/player/src/components/reward-badges.tsx
 #: src/app/(performance)/level/level-stats.tsx
@@ -382,6 +360,28 @@ msgstr "Sort items"
 msgctxt "VA8c/A"
 msgid "Correct order:"
 msgstr "Correct order:"
+
+#: ../../packages/player/src/components/step-action-button.tsx
+msgctxt "9p9JgX"
+msgid "Start Investigation"
+msgstr "Start Investigation"
+
+#: ../../packages/player/src/components/step-action-button.tsx
+#: src/app/(catalog)/(home)/continue-learning-card.tsx
+#: src/components/catalog/continue-activity-link.tsx
+msgctxt "acrOoz"
+msgid "Continue"
+msgstr "Continue"
+
+#: ../../packages/player/src/components/step-action-button.tsx
+msgctxt "PVe26p"
+msgid "Begin"
+msgstr "Begin"
+
+#: ../../packages/player/src/components/step-action-button.tsx
+msgctxt "RDZVQL"
+msgid "Check"
+msgstr "Check"
 
 #: ../../packages/player/src/components/story-feedback-content.tsx
 msgctxt "jSeUY4"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -323,31 +323,9 @@ msgid "Activity progress"
 msgstr "Progreso de actividad"
 
 #: ../../packages/player/src/components/player-shell.tsx
-msgctxt "9p9JgX"
-msgid "Start Investigation"
-msgstr "Iniciar investigación"
-
-#: ../../packages/player/src/components/player-shell.tsx
-#: src/app/(catalog)/(home)/continue-learning-card.tsx
-#: src/components/catalog/continue-activity-link.tsx
-msgctxt "acrOoz"
-msgid "Continue"
-msgstr "Continuar"
-
-#: ../../packages/player/src/components/player-shell.tsx
 msgctxt "EqkwlK"
 msgid "evidence"
 msgstr "evidencias"
-
-#: ../../packages/player/src/components/player-shell.tsx
-msgctxt "PVe26p"
-msgid "Begin"
-msgstr "Comenzar"
-
-#: ../../packages/player/src/components/player-shell.tsx
-msgctxt "RDZVQL"
-msgid "Check"
-msgstr "Revisar"
 
 #: ../../packages/player/src/components/reward-badges.tsx
 #: src/app/(performance)/level/level-stats.tsx
@@ -382,6 +360,28 @@ msgstr "Ordenar elementos"
 msgctxt "VA8c/A"
 msgid "Correct order:"
 msgstr "Orden correcto:"
+
+#: ../../packages/player/src/components/step-action-button.tsx
+msgctxt "9p9JgX"
+msgid "Start Investigation"
+msgstr "Iniciar investigación"
+
+#: ../../packages/player/src/components/step-action-button.tsx
+#: src/app/(catalog)/(home)/continue-learning-card.tsx
+#: src/components/catalog/continue-activity-link.tsx
+msgctxt "acrOoz"
+msgid "Continue"
+msgstr "Continuar"
+
+#: ../../packages/player/src/components/step-action-button.tsx
+msgctxt "PVe26p"
+msgid "Begin"
+msgstr "Comenzar"
+
+#: ../../packages/player/src/components/step-action-button.tsx
+msgctxt "RDZVQL"
+msgid "Check"
+msgstr "Revisar"
 
 #: ../../packages/player/src/components/story-feedback-content.tsx
 msgctxt "jSeUY4"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -323,31 +323,9 @@ msgid "Activity progress"
 msgstr "Progresso da atividade"
 
 #: ../../packages/player/src/components/player-shell.tsx
-msgctxt "9p9JgX"
-msgid "Start Investigation"
-msgstr "Iniciar investigação"
-
-#: ../../packages/player/src/components/player-shell.tsx
-#: src/app/(catalog)/(home)/continue-learning-card.tsx
-#: src/components/catalog/continue-activity-link.tsx
-msgctxt "acrOoz"
-msgid "Continue"
-msgstr "Continuar"
-
-#: ../../packages/player/src/components/player-shell.tsx
 msgctxt "EqkwlK"
 msgid "evidence"
 msgstr "evidências"
-
-#: ../../packages/player/src/components/player-shell.tsx
-msgctxt "PVe26p"
-msgid "Begin"
-msgstr "Começar"
-
-#: ../../packages/player/src/components/player-shell.tsx
-msgctxt "RDZVQL"
-msgid "Check"
-msgstr "Verificar"
 
 #: ../../packages/player/src/components/reward-badges.tsx
 #: src/app/(performance)/level/level-stats.tsx
@@ -382,6 +360,28 @@ msgstr "Ordenar itens"
 msgctxt "VA8c/A"
 msgid "Correct order:"
 msgstr "Ordem correta:"
+
+#: ../../packages/player/src/components/step-action-button.tsx
+msgctxt "9p9JgX"
+msgid "Start Investigation"
+msgstr "Iniciar investigação"
+
+#: ../../packages/player/src/components/step-action-button.tsx
+#: src/app/(catalog)/(home)/continue-learning-card.tsx
+#: src/components/catalog/continue-activity-link.tsx
+msgctxt "acrOoz"
+msgid "Continue"
+msgstr "Continuar"
+
+#: ../../packages/player/src/components/step-action-button.tsx
+msgctxt "PVe26p"
+msgid "Begin"
+msgstr "Começar"
+
+#: ../../packages/player/src/components/step-action-button.tsx
+msgctxt "RDZVQL"
+msgid "Check"
+msgstr "Verificar"
 
 #: ../../packages/player/src/components/story-feedback-content.tsx
 msgctxt "jSeUY4"

--- a/packages/player/src/components/player-bottom-bar.tsx
+++ b/packages/player/src/components/player-bottom-bar.tsx
@@ -48,10 +48,3 @@ export function PlayerBottomBarNav({
     </nav>
   );
 }
-
-export function PlayerBottomBarAction({
-  className,
-  ...props
-}: React.ComponentProps<typeof Button>) {
-  return <Button className={cn("w-full", className)} size="lg" {...props} />;
-}

--- a/packages/player/src/components/player-bottom-bar.tsx
+++ b/packages/player/src/components/player-bottom-bar.tsx
@@ -5,17 +5,25 @@ import { cn } from "@zoonk/ui/lib/utils";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useExtracted } from "next-intl";
 
+/**
+ * Fixed bottom bar for the player's action buttons on mobile.
+ *
+ * Uses px-4 horizontal padding to match PlayerStage's p-4, with
+ * max-w-2xl on the inner content area. This ensures the button
+ * aligns with InteractiveStepLayout's max-w-2xl content above —
+ * both use the same padding-outside-constraint structure.
+ */
 export function PlayerBottomBar({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       className={cn(
         "bg-background/95 sticky bottom-0 z-30 backdrop-blur-sm",
-        "mx-auto w-full max-w-2xl p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]",
+        "w-full px-4 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]",
         className,
       )}
-      data-slot="player-bottom-bar"
-      {...props}
-    />
+    >
+      <div className="mx-auto w-full max-w-2xl" data-slot="player-bottom-bar" {...props} />
+    </div>
   );
 }
 

--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -1,16 +1,12 @@
 "use client";
 
-import { type StoryStaticVariant } from "@zoonk/core/steps/contract/content";
 import { useExtracted } from "next-intl";
 import { usePlayerNavigation, usePlayerRuntime } from "../player-context";
-import { type PlayerPhase } from "../player-reducer";
 import {
   getCanNavigatePrev,
   getCurrentStep,
-  getHasAnswer,
   getInvestigationProgress,
   getInvestigationScenarioData,
-  getIsInvestigationProblem,
   getIsStaticStep,
   getIsStoryActivity,
   getProgressValue,
@@ -22,44 +18,30 @@ import {
 import { type PlayerActions } from "../use-player-actions";
 import { useStoryHaptics } from "../use-story-haptics";
 import { InPlayStickyHeader } from "./in-play-sticky-header";
-import { PlayerBottomBar, PlayerBottomBarAction, PlayerBottomBarNav } from "./player-bottom-bar";
+import { PlayerBottomBar, PlayerBottomBarNav } from "./player-bottom-bar";
 import { PlayerStage } from "./player-stage";
 import { StageContent } from "./stage-content";
 import { StatusPill } from "./status-pill";
+import { StepActionButton } from "./step-action-button";
 import { StepImagePreloader } from "./step-image-preloader";
 import { StoryMetricsBar } from "./story-metrics-bar";
 
+/**
+ * Renders the content inside the bottom bar.
+ *
+ * Static navigation steps (static, visual, vocabulary) show prev/next arrows.
+ * Everything else (story static, interactive, investigation) uses
+ * StepActionButton — the single source of truth for action button logic.
+ */
 function BottomBarContent({
   actions,
   canNavigatePrev,
-  hasAnswer,
-  isInvestigationProblem,
   isStaticStep,
-  phase,
-  storyStaticVariant,
 }: {
   actions: PlayerActions;
   canNavigatePrev: boolean;
-  hasAnswer: boolean;
-  isInvestigationProblem: boolean;
   isStaticStep: boolean;
-  phase: PlayerPhase;
-  storyStaticVariant: StoryStaticVariant | null;
 }) {
-  const t = useExtracted();
-
-  if (storyStaticVariant === "storyIntro") {
-    return (
-      <PlayerBottomBarAction onClick={actions.navigateNext}>{t("Begin")}</PlayerBottomBarAction>
-    );
-  }
-
-  if (storyStaticVariant === "storyOutcome") {
-    return (
-      <PlayerBottomBarAction onClick={actions.navigateNext}>{t("Continue")}</PlayerBottomBarAction>
-    );
-  }
-
   if (isStaticStep) {
     return (
       <PlayerBottomBarNav
@@ -70,27 +52,7 @@ function BottomBarContent({
     );
   }
 
-  /**
-   * The investigation problem step shows "Start Investigation" because
-   * the learner is reading a scenario — "Check" would imply there's
-   * an answer to validate.
-   */
-  if (isInvestigationProblem) {
-    return (
-      <PlayerBottomBarAction onClick={actions.check}>
-        {t("Start Investigation")}
-      </PlayerBottomBarAction>
-    );
-  }
-
-  return (
-    <PlayerBottomBarAction
-      disabled={phase === "playing" && !hasAnswer}
-      onClick={phase === "feedback" ? actions.continue : actions.check}
-    >
-      {phase === "feedback" ? t("Continue") : t("Check")}
-    </PlayerBottomBarAction>
-  );
+  return <StepActionButton />;
 }
 
 export function PlayerShell() {
@@ -100,7 +62,6 @@ export function PlayerShell() {
 
   const canNavigatePrev = getCanNavigatePrev(state);
   const currentStep = getCurrentStep(state);
-  const hasAnswer = getHasAnswer(state);
   const isStaticStep = getIsStaticStep(state);
   const isStoryActivity = getIsStoryActivity(state);
   const progressValue = getProgressValue(state);
@@ -119,7 +80,6 @@ export function PlayerShell() {
     getStoryBriefingText(state) ?? getInvestigationScenarioData(state)?.scenario ?? null;
 
   const investigationProgress = getInvestigationProgress(state);
-  const isInvestigationProblem = getIsInvestigationProblem(state);
   const showChrome = state.phase === "playing" || state.phase === "feedback";
   const showMetricsBar = currentStep?.kind === "story" && showChrome;
 
@@ -153,15 +113,11 @@ export function PlayerShell() {
       </PlayerStage>
 
       {showChrome && (
-        <PlayerBottomBar className={isStaticStep ? "lg:hidden" : undefined}>
+        <PlayerBottomBar className="lg:hidden">
           <BottomBarContent
             actions={actions}
             canNavigatePrev={canNavigatePrev}
-            hasAnswer={hasAnswer}
-            isInvestigationProblem={isInvestigationProblem}
             isStaticStep={isStaticStep}
-            phase={state.phase}
-            storyStaticVariant={storyStaticVariant}
           />
         </PlayerBottomBar>
       )}

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -8,8 +8,10 @@ import {
   getSelectedAnswer,
 } from "../player-selectors";
 import { type SerializedStep } from "../prepare-activity-data";
+import { isStaticNavigationStep } from "../step-navigation";
 import { CompletionScreenContent } from "./completion-screen";
 import { FeedbackScreenContent } from "./feedback-screen";
+import { StepActionButton } from "./step-action-button";
 import { StepRenderer } from "./step-renderer";
 
 /**
@@ -46,6 +48,22 @@ function needsFeedbackScreen(step: SerializedStep): boolean {
   );
 }
 
+/**
+ * Whether the step has an action button (Begin, Check, Continue,
+ * Start Investigation) — as opposed to static navigation arrows
+ * handled by StepSideNav.
+ *
+ * When true, we render the action button inline on large screens
+ * so it sits close to the content instead of fixed at the viewport bottom.
+ */
+function needsInlineAction(step: SerializedStep | undefined): boolean {
+  if (!step) {
+    return false;
+  }
+
+  return !isStaticNavigationStep(step);
+}
+
 export function StageContent() {
   const { actions, state } = usePlayerRuntime();
   const { lessonHref, nextActivityHref } = usePlayerNavigation();
@@ -72,24 +90,42 @@ export function StageContent() {
     currentResult &&
     (!currentStep || needsFeedbackScreen(currentStep))
   ) {
-    return <FeedbackScreenContent result={currentResult} step={currentStep} />;
+    return (
+      <div className="my-auto flex w-full flex-col items-center gap-6">
+        <FeedbackScreenContent result={currentResult} step={currentStep} />
+        <StepActionButton className="hidden max-w-lg lg:inline-flex" />
+      </div>
+    );
   }
 
   if ((state.phase === "playing" || state.phase === "feedback") && currentStep) {
+    const showInlineAction = needsInlineAction(currentStep);
+
+    const stepContent = (
+      <StepRenderer
+        canNavigatePrev={canNavigatePrev}
+        onNavigateNext={actions.navigateNext}
+        onNavigatePrev={actions.navigatePrev}
+        onSelectAnswer={actions.selectAnswer}
+        result={state.phase === "feedback" ? currentResult : undefined}
+        selectedAnswer={selectedAnswer}
+        step={currentStep}
+      />
+    );
+
     return (
       <div
         className="animate-in fade-in flex min-h-0 w-full min-w-0 flex-1 flex-col items-center duration-150 ease-out motion-reduce:animate-none"
         key={`step-${state.currentStepIndex}`}
       >
-        <StepRenderer
-          canNavigatePrev={canNavigatePrev}
-          onNavigateNext={actions.navigateNext}
-          onNavigatePrev={actions.navigatePrev}
-          onSelectAnswer={actions.selectAnswer}
-          result={state.phase === "feedback" ? currentResult : undefined}
-          selectedAnswer={selectedAnswer}
-          step={currentStep}
-        />
+        {showInlineAction ? (
+          <div className="my-auto flex w-full flex-col items-center gap-6">
+            {stepContent}
+            <StepActionButton className="hidden max-w-2xl lg:inline-flex" />
+          </div>
+        ) : (
+          stepContent
+        )}
       </div>
     );
   }

--- a/packages/player/src/components/step-action-button.tsx
+++ b/packages/player/src/components/step-action-button.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Button } from "@zoonk/ui/components/button";
+import { cn } from "@zoonk/ui/lib/utils";
+import { useExtracted } from "next-intl";
+import { usePlayerRuntime } from "../player-context";
+import {
+  getHasAnswer,
+  getIsInvestigationProblem,
+  getStoryStaticVariant,
+} from "../player-selectors";
+
+/**
+ * Single source of truth for the step action button
+ * (Begin, Check, Continue, Start Investigation).
+ *
+ * Handles every non-navigation action: story intro/outcome,
+ * investigation problem, and regular interactive steps.
+ *
+ * Rendered in two places with different visibility:
+ * - Inside the PlayerBottomBar for mobile (visible below lg)
+ * - Inline below step content for desktop (visible at lg+)
+ *
+ * This avoids duplicating button logic across the bottom bar
+ * and the desktop inline slot.
+ */
+export function StepActionButton({
+  className,
+  ...props
+}: Omit<React.ComponentProps<typeof Button>, "children" | "onClick" | "size">) {
+  const t = useExtracted();
+  const { actions, state } = usePlayerRuntime();
+
+  const hasAnswer = getHasAnswer(state);
+  const isInvestigationProblem = getIsInvestigationProblem(state);
+  const storyStaticVariant = getStoryStaticVariant(state);
+
+  if (storyStaticVariant === "storyIntro") {
+    return (
+      <Button
+        className={cn("w-full", className)}
+        onClick={actions.navigateNext}
+        size="lg"
+        {...props}
+      >
+        {t("Begin")}
+      </Button>
+    );
+  }
+
+  if (storyStaticVariant === "storyOutcome") {
+    return (
+      <Button
+        className={cn("w-full", className)}
+        onClick={actions.navigateNext}
+        size="lg"
+        {...props}
+      >
+        {t("Continue")}
+      </Button>
+    );
+  }
+
+  if (isInvestigationProblem) {
+    return (
+      <Button className={cn("w-full", className)} onClick={actions.check} size="lg" {...props}>
+        {t("Start Investigation")}
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      className={cn("w-full", className)}
+      disabled={state.phase === "playing" && !hasAnswer}
+      onClick={state.phase === "feedback" ? actions.continue : actions.check}
+      size="lg"
+      {...props}
+    >
+      {state.phase === "feedback" ? t("Continue") : t("Check")}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary

- On large screens (lg+), the action button (Check/Continue/Begin/Start Investigation) now renders inline below the step content instead of fixed at the viewport bottom
- Extracts `StepActionButton` as the single source of truth for action button logic, used by both the bottom bar (mobile) and the inline slot (desktop)
- Removes `PlayerBottomBarAction` (now unused) and simplifies `BottomBarContent` to just a static-nav-vs-action switch

## Test plan

- [ ] Verify action button appears inline below content on desktop (lg+ screens)
- [ ] Verify bottom bar still shows on mobile/small screens
- [ ] Verify all step types work: multiple choice, fill blank, sort order, match columns, select image, translation, reading, listening, story, investigation (problem/action/call)
- [ ] Verify feedback screen shows inline Continue button on desktop
- [ ] Verify static navigation steps (static, visual, vocabulary) still use StepSideNav on desktop
- [ ] Verify story intro/outcome shows Begin/Continue inline on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render the step action button inline under the content on desktop (lg+) for better proximity; keep the bottom bar on mobile. Unified all action button logic in `StepActionButton` and fixed bottom bar width to align with stage content on tablets.

- **New Features**
  - Inline action button (Begin/Check/Continue/Start Investigation) on lg+ under step and feedback content
  - Mobile keeps the bottom bar with the same actions via `StepActionButton`

- **Bug Fixes**
  - Bottom bar button now matches stage content width on tablets by using outer `px-4` and an inner `max-w-2xl` container

<sup>Written for commit 35cd5e6951500e4f4d0363794fd517e43919415a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

