### PR TITLE
fix(i18n): update activity page title for pt/es

### DIFF
--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -2787,7 +2787,7 @@ msgstr "Investiga {topic} reuniendo evidencia, evaluando hallazgos y sacando tus
 #: src/lib/activities.ts
 msgctxt "MfGqY2"
 msgid "{lesson} {activity}"
-msgstr "{lesson} {activity}"
+msgstr "{activity}: {lesson}"
 
 #: src/lib/activities.ts
 msgctxt "MOK/yK"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -2787,7 +2787,7 @@ msgstr "Investigue {topic} reunindo evidências, avaliando os resultados e tiran
 #: src/lib/activities.ts
 msgctxt "MfGqY2"
 msgid "{lesson} {activity}"
-msgstr "{lesson} {activity}"
+msgstr "{activity}: {lesson}"
 
 #: src/lib/activities.ts
 msgctxt "MOK/yK"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the activity page title in Spanish and Portuguese by changing the order to "{activity}: {lesson}". This aligns with the expected title format and improves readability.

<sup>Written for commit 812f48aaedab5c5c232ef0d66f4d3b679172032a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

