### PR TITLE
refactor(player): centralize step and screen models

### DIFF
--- a/packages/player/src/check-step.ts
+++ b/packages/player/src/check-step.ts
@@ -5,7 +5,7 @@ import {
   type AnswerResult,
   checkArrangeWordsAnswer,
   checkFillBlankAnswer,
-  checkInvestigationAction,
+  checkInvestigationAction as checkInvestigationActionAnswer,
   checkInvestigationCall,
   checkMatchColumnsAnswer,
   checkMultipleChoiceAnswer,
@@ -15,6 +15,7 @@ import {
   checkTranslationAnswer,
 } from "./check-answer";
 import { type SelectedAnswer } from "./player-reducer";
+import { type PlayerCheckBehavior, getPlayerCheckBehavior } from "./player-step-behavior";
 import { type SerializedStep } from "./prepare-activity-data";
 
 type CheckStepResult = {
@@ -139,30 +140,53 @@ function checkListeningStep(step: SerializedStep, answer: SelectedAnswer): Check
  * - Action: correct unless weak quality (critical/useful = correct, weak = incorrect)
  * - Call: checks if the selected explanation has "best" accuracy
  */
-function checkInvestigation(step: SerializedStep, answer: SelectedAnswer): CheckStepResult {
+function checkInvestigationProblem(step: SerializedStep, answer: SelectedAnswer): CheckStepResult {
+  if (answer.kind !== "investigation" || answer.variant !== "problem") {
+    return MISMATCH_RESULT;
+  }
+
+  const content = parseStepContent("investigation", step.content);
+
+  if (content.variant !== "problem") {
+    return MISMATCH_RESULT;
+  }
+
+  return { result: { correctAnswer: null, feedback: null, isCorrect: true } };
+}
+
+function checkInvestigationActionStep(
+  step: SerializedStep,
+  answer: SelectedAnswer,
+): CheckStepResult {
   if (answer.kind !== "investigation") {
     return MISMATCH_RESULT;
   }
 
   const content = parseStepContent("investigation", step.content);
 
-  if (content.variant === "problem") {
-    return { result: { correctAnswer: null, feedback: null, isCorrect: true } };
+  if (content.variant !== "action" || answer.variant !== "action") {
+    return MISMATCH_RESULT;
   }
 
-  if (content.variant === "action" && answer.variant === "action") {
-    return {
-      result: checkInvestigationAction(content, answer.selectedActionId),
-    };
+  return {
+    result: checkInvestigationActionAnswer(content, answer.selectedActionId),
+  };
+}
+
+function checkInvestigationCallStep(step: SerializedStep, answer: SelectedAnswer): CheckStepResult {
+  if (answer.kind !== "investigation") {
+    return MISMATCH_RESULT;
   }
 
-  if (content.variant === "call" && answer.variant === "call") {
-    return {
-      result: checkInvestigationCall(content, answer.selectedExplanationId),
-    };
+  const content = parseStepContent("investigation", step.content);
+
+  if (content.variant !== "call" || answer.variant !== "call") {
+    return MISMATCH_RESULT;
   }
 
-  return MISMATCH_RESULT;
+  return {
+    result: checkInvestigationCall(content, answer.selectedExplanationId),
+  };
 }
 
 function checkStory(step: SerializedStep, answer: SelectedAnswer): CheckStepResult {
@@ -175,44 +199,26 @@ function checkStory(step: SerializedStep, answer: SelectedAnswer): CheckStepResu
   return { result: checkStoryAnswer(content, answer.selectedChoiceId) };
 }
 
+const CHECKERS: Record<
+  PlayerCheckBehavior,
+  (step: SerializedStep, answer: SelectedAnswer) => CheckStepResult
+> = {
+  fillBlank: checkFillBlank,
+  investigationAction: checkInvestigationActionStep,
+  investigationCall: checkInvestigationCallStep,
+  investigationProblem: checkInvestigationProblem,
+  listening: checkListeningStep,
+  matchColumns: checkMatchColumns,
+  multipleChoice: checkMultipleChoice,
+  none: () => MISMATCH_RESULT,
+  reading: checkReadingStep,
+  selectImage: checkSelectImage,
+  sortOrder: checkSortOrder,
+  story: checkStory,
+  translation: checkTranslationStep,
+};
+
 export function checkStep(step: SerializedStep, answer: SelectedAnswer): CheckStepResult {
-  switch (step.kind) {
-    case "multipleChoice":
-      return checkMultipleChoice(step, answer);
-
-    case "fillBlank":
-      return checkFillBlank(step, answer);
-
-    case "matchColumns":
-      return checkMatchColumns(step, answer);
-
-    case "sortOrder":
-      return checkSortOrder(step, answer);
-
-    case "selectImage":
-      return checkSelectImage(step, answer);
-
-    case "translation":
-      return checkTranslationStep(step, answer);
-
-    case "reading":
-      return checkReadingStep(step, answer);
-
-    case "listening":
-      return checkListeningStep(step, answer);
-
-    case "story":
-      return checkStory(step, answer);
-
-    case "investigation":
-      return checkInvestigation(step, answer);
-
-    case "static":
-    case "visual":
-    case "vocabulary":
-      return MISMATCH_RESULT;
-
-    default:
-      return MISMATCH_RESULT;
-  }
+  const behavior = getPlayerCheckBehavior(step) ?? "none";
+  return CHECKERS[behavior](step, answer);
 }

--- a/packages/player/src/components/investigation-step.tsx
+++ b/packages/player/src/components/investigation-step.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { parseStepContent } from "@zoonk/core/steps/contract/content";
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
+import { describePlayerStep } from "../player-step";
 import { type SerializedStep } from "../prepare-activity-data";
 import { InvestigationActionVariant } from "./investigation-action-variant";
 import { InvestigationCallVariant } from "./investigation-call-variant";
@@ -25,16 +25,16 @@ export function InvestigationStep({
   selectedAnswer: SelectedAnswer | undefined;
   step: SerializedStep;
 }) {
-  const content = parseStepContent("investigation", step.content);
+  const descriptor = describePlayerStep(step);
 
-  if (content.variant === "problem") {
-    return <InvestigationProblemVariant content={content} />;
+  if (descriptor?.kind === "investigationProblem") {
+    return <InvestigationProblemVariant content={descriptor.content} />;
   }
 
-  if (content.variant === "action") {
+  if (descriptor?.kind === "investigationAction") {
     return (
       <InvestigationActionVariant
-        content={content}
+        content={descriptor.content}
         onSelectAnswer={onSelectAnswer}
         result={result}
         selectedAnswer={selectedAnswer}
@@ -43,10 +43,10 @@ export function InvestigationStep({
     );
   }
 
-  if (content.variant === "call") {
+  if (descriptor?.kind === "investigationCall") {
     return (
       <InvestigationCallVariant
-        content={content}
+        content={descriptor.content}
         onSelectAnswer={onSelectAnswer}
         result={result}
         selectedAnswer={selectedAnswer}

--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -3,19 +3,14 @@
 import { useExtracted } from "next-intl";
 import { usePlayerNavigation, usePlayerRuntime } from "../player-context";
 import {
-  getCanNavigatePrev,
-  getCurrentStep,
   getInvestigationProgress,
   getInvestigationScenarioData,
-  getIsStaticStep,
   getIsStoryActivity,
   getProgressValue,
   getStoryBriefingText,
   getStoryMetrics,
-  getStoryStaticVariant,
   getUpcomingImages,
 } from "../player-selectors";
-import { type PlayerActions } from "../use-player-actions";
 import { useStoryHaptics } from "../use-story-haptics";
 import { InPlayStickyHeader } from "./in-play-sticky-header";
 import { PlayerBottomBar, PlayerBottomBarNav } from "./player-bottom-bar";
@@ -27,25 +22,17 @@ import { StepImagePreloader } from "./step-image-preloader";
 import { StoryMetricsBar } from "./story-metrics-bar";
 
 /**
- * Renders the content inside the bottom bar.
- *
- * Static navigation steps (static, visual, vocabulary) show prev/next arrows.
- * Everything else (story static, interactive, investigation) uses
- * StepActionButton — the single source of truth for action button logic.
+ * Mobile bottom-bar content switches between arrow navigation and the shared
+ * step action button. The screen model decides which mode is active; this
+ * component only renders the matching mobile control.
  */
-function BottomBarContent({
-  actions,
-  canNavigatePrev,
-  isStaticStep,
-}: {
-  actions: PlayerActions;
-  canNavigatePrev: boolean;
-  isStaticStep: boolean;
-}) {
-  if (isStaticStep) {
+function BottomBarContent() {
+  const { actions, screen } = usePlayerRuntime();
+
+  if (screen.bottomBar?.kind === "navigation") {
     return (
       <PlayerBottomBarNav
-        canNavigatePrev={canNavigatePrev}
+        canNavigatePrev={screen.bottomBar.canNavigatePrev}
         onNavigateNext={actions.navigateNext}
         onNavigatePrev={actions.navigatePrev}
       />
@@ -57,31 +44,25 @@ function BottomBarContent({
 
 export function PlayerShell() {
   const t = useExtracted();
-  const { actions, state } = usePlayerRuntime();
+  const { screen, state } = usePlayerRuntime();
   const { lessonHref } = usePlayerNavigation();
 
-  const canNavigatePrev = getCanNavigatePrev(state);
-  const currentStep = getCurrentStep(state);
-  const isStaticStep = getIsStaticStep(state);
   const isStoryActivity = getIsStoryActivity(state);
   const progressValue = getProgressValue(state);
   const storyMetrics = getStoryMetrics(state);
-  const storyStaticVariant = getStoryStaticVariant(state);
   const upcomingImages = getUpcomingImages(state);
 
   useStoryHaptics({
     isStoryActivity,
     metrics: storyMetrics,
     phase: state.phase,
-    storyStaticVariant,
+    storyStaticVariant: screen.storyStaticVariant,
   });
 
   const contextRecall =
     getStoryBriefingText(state) ?? getInvestigationScenarioData(state)?.scenario ?? null;
 
   const investigationProgress = getInvestigationProgress(state);
-  const showChrome = state.phase === "playing" || state.phase === "feedback";
-  const showMetricsBar = currentStep?.kind === "story" && showChrome;
 
   const evidencePill = investigationProgress ? (
     <StatusPill animationKey={investigationProgress.collected}>
@@ -95,7 +76,7 @@ export function PlayerShell() {
 
   return (
     <main className="flex h-dvh flex-col overflow-hidden">
-      {showChrome && (
+      {screen.showChrome && (
         <InPlayStickyHeader
           centerContent={evidencePill}
           contextRecall={contextRecall}
@@ -106,19 +87,15 @@ export function PlayerShell() {
         />
       )}
 
-      {showMetricsBar && <StoryMetricsBar metrics={storyMetrics} />}
+      {screen.showMetricsBar && <StoryMetricsBar metrics={storyMetrics} />}
 
-      <PlayerStage isStatic={isStaticStep && state.phase === "playing"} phase={state.phase}>
+      <PlayerStage isStatic={screen.stageIsStatic} phase={state.phase}>
         <StageContent />
       </PlayerStage>
 
-      {showChrome && (
+      {screen.showChrome && screen.bottomBar && (
         <PlayerBottomBar className="lg:hidden">
-          <BottomBarContent
-            actions={actions}
-            canNavigatePrev={canNavigatePrev}
-            isStaticStep={isStaticStep}
-          />
+          <BottomBarContent />
         </PlayerBottomBar>
       )}
 

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -1,52 +1,14 @@
-import { parseStepContent } from "@zoonk/core/steps/contract/content";
 import { usePlayerNavigation, usePlayerRuntime } from "../player-context";
 import {
-  getCanNavigatePrev,
   getCompletionResult,
   getCurrentResult,
   getCurrentStep,
   getSelectedAnswer,
 } from "../player-selectors";
-import { type SerializedStep } from "../prepare-activity-data";
-import { isStaticNavigationStep } from "../step-navigation";
 import { CompletionScreenContent } from "./completion-screen";
 import { FeedbackScreenContent } from "./feedback-screen";
 import { StepActionButton } from "./step-action-button";
 import { StepRenderer } from "./step-renderer";
-
-/**
- * Investigation action steps show feedback inline (the finding reveal
- * is brief and contextual), but the call step uses the dedicated
- * feedback screen because its debrief explanation is long-form text
- * that benefits from a focused reading experience.
- */
-function isInvestigationCallStep(step: SerializedStep): boolean {
-  if (step.kind !== "investigation") {
-    return false;
-  }
-
-  const content = parseStepContent("investigation", step.content);
-  return content.variant === "call";
-}
-
-/**
- * Determines whether a step should use the full-screen feedback view
- * after the answer is checked.
- *
- * Investigation action steps handle feedback inline (brief finding
- * reveal), but investigation call steps use the feedback screen
- * for their long-form debrief explanation.
- */
-function needsFeedbackScreen(step: SerializedStep): boolean {
-  return (
-    step.kind === "multipleChoice" ||
-    step.kind === "translation" ||
-    step.kind === "reading" ||
-    step.kind === "listening" ||
-    step.kind === "story" ||
-    isInvestigationCallStep(step)
-  );
-}
 
 /**
  * Whether the step has an action button (Begin, Check, Continue,
@@ -56,25 +18,20 @@ function needsFeedbackScreen(step: SerializedStep): boolean {
  * When true, we render the action button inline on large screens
  * so it sits close to the content instead of fixed at the viewport bottom.
  */
-function needsInlineAction(step: SerializedStep | undefined): boolean {
-  if (!step) {
-    return false;
-  }
-
-  return !isStaticNavigationStep(step);
+function needsInlineAction(screen: ReturnType<typeof usePlayerRuntime>["screen"]) {
+  return screen.kind === "step" && screen.bottomBar.kind === "primaryAction";
 }
 
 export function StageContent() {
-  const { actions, state } = usePlayerRuntime();
+  const { actions, screen, state } = usePlayerRuntime();
   const { lessonHref, nextActivityHref } = usePlayerNavigation();
 
-  const canNavigatePrev = getCanNavigatePrev(state);
   const completionResult = getCompletionResult(state);
   const currentResult = getCurrentResult(state);
   const currentStep = getCurrentStep(state);
   const selectedAnswer = getSelectedAnswer(state);
 
-  if (state.phase === "completed") {
+  if (screen.kind === "completed") {
     return (
       <CompletionScreenContent
         completionResult={completionResult}
@@ -85,11 +42,7 @@ export function StageContent() {
     );
   }
 
-  if (
-    state.phase === "feedback" &&
-    currentResult &&
-    (!currentStep || needsFeedbackScreen(currentStep))
-  ) {
+  if (screen.kind === "feedbackScreen" && currentResult) {
     return (
       <div className="my-auto flex w-full flex-col items-center gap-6">
         <FeedbackScreenContent result={currentResult} step={currentStep} />
@@ -98,12 +51,12 @@ export function StageContent() {
     );
   }
 
-  if ((state.phase === "playing" || state.phase === "feedback") && currentStep) {
-    const showInlineAction = needsInlineAction(currentStep);
+  if (screen.kind === "step" && currentStep) {
+    const showInlineAction = needsInlineAction(screen);
 
     const stepContent = (
       <StepRenderer
-        canNavigatePrev={canNavigatePrev}
+        canNavigatePrev={screen.canNavigatePrev}
         onNavigateNext={actions.navigateNext}
         onNavigatePrev={actions.navigatePrev}
         onSelectAnswer={actions.selectAnswer}

--- a/packages/player/src/components/static-step.tsx
+++ b/packages/player/src/components/static-step.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { parseStepContent } from "@zoonk/core/steps/contract/content";
+import { describePlayerStep } from "../player-step";
 import { type SerializedStep } from "../prepare-activity-data";
 import { useReplaceName } from "../user-name-context";
 import { HighlightText } from "./highlight-text";
@@ -54,32 +54,47 @@ function GrammarRuleVariant({ ruleName, ruleSummary }: { ruleName: string; ruleS
 }
 
 function StaticStepContent({ step }: { step: SerializedStep }) {
-  const content = parseStepContent("static", step.content);
+  const descriptor = describePlayerStep(step);
 
-  if (content.variant === "grammarExample") {
+  if (!descriptor) {
+    return null;
+  }
+
+  if (descriptor.kind === "staticGrammarExample") {
     return (
       <GrammarExampleVariant
-        highlight={content.highlight}
-        romanization={content.romanization}
-        sentence={content.sentence}
-        translation={content.translation}
+        highlight={descriptor.content.highlight}
+        romanization={descriptor.content.romanization}
+        sentence={descriptor.content.sentence}
+        translation={descriptor.content.translation}
       />
     );
   }
 
-  if (content.variant === "grammarRule") {
-    return <GrammarRuleVariant ruleName={content.ruleName} ruleSummary={content.ruleSummary} />;
+  if (descriptor.kind === "staticGrammarRule") {
+    return (
+      <GrammarRuleVariant
+        ruleName={descriptor.content.ruleName}
+        ruleSummary={descriptor.content.ruleSummary}
+      />
+    );
   }
 
-  if (content.variant === "storyIntro") {
-    return <StoryIntroContent intro={content.intro} metrics={content.metrics} />;
+  if (descriptor.kind === "storyIntro") {
+    return (
+      <StoryIntroContent intro={descriptor.content.intro} metrics={descriptor.content.metrics} />
+    );
   }
 
-  if (content.variant === "storyOutcome") {
-    return <StoryOutcomeContent outcomes={content.outcomes} />;
+  if (descriptor.kind === "storyOutcome") {
+    return <StoryOutcomeContent outcomes={descriptor.content.outcomes} />;
   }
 
-  return <TextVariant text={content.text} title={content.title} />;
+  if (descriptor.kind !== "staticText") {
+    return null;
+  }
+
+  return <TextVariant text={descriptor.content.text} title={descriptor.content.title} />;
 }
 
 export function StaticStep({ step }: { step: SerializedStep }) {

--- a/packages/player/src/components/step-action-button.tsx
+++ b/packages/player/src/components/step-action-button.tsx
@@ -4,11 +4,6 @@ import { Button } from "@zoonk/ui/components/button";
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { usePlayerRuntime } from "../player-context";
-import {
-  getHasAnswer,
-  getIsInvestigationProblem,
-  getStoryStaticVariant,
-} from "../player-selectors";
 
 /**
  * Single source of truth for the step action button
@@ -29,55 +24,33 @@ export function StepActionButton({
   ...props
 }: Omit<React.ComponentProps<typeof Button>, "children" | "onClick" | "size">) {
   const t = useExtracted();
-  const { actions, state } = usePlayerRuntime();
+  const { actions, screen } = usePlayerRuntime();
+  const model = screen.bottomBar;
 
-  const hasAnswer = getHasAnswer(state);
-  const isInvestigationProblem = getIsInvestigationProblem(state);
-  const storyStaticVariant = getStoryStaticVariant(state);
-
-  if (storyStaticVariant === "storyIntro") {
-    return (
-      <Button
-        className={cn("w-full", className)}
-        onClick={actions.navigateNext}
-        size="lg"
-        {...props}
-      >
-        {t("Begin")}
-      </Button>
-    );
+  if (!model || model.kind === "navigation") {
+    return null;
   }
 
-  if (storyStaticVariant === "storyOutcome") {
-    return (
-      <Button
-        className={cn("w-full", className)}
-        onClick={actions.navigateNext}
-        size="lg"
-        {...props}
-      >
-        {t("Continue")}
-      </Button>
-    );
-  }
+  const actionByRun = {
+    check: actions.check,
+    continue: actions.continue,
+    navigateNext: actions.navigateNext,
+  } as const;
 
-  if (isInvestigationProblem) {
-    return (
-      <Button className={cn("w-full", className)} onClick={actions.check} size="lg" {...props}>
-        {t("Start Investigation")}
-      </Button>
-    );
-  }
+  const labelByButton = {
+    begin: t("Begin"),
+    check: t("Check"),
+    continue: t("Continue"),
+    startInvestigation: t("Start Investigation"),
+  } as const;
 
-  return (
-    <Button
-      className={cn("w-full", className)}
-      disabled={state.phase === "playing" && !hasAnswer}
-      onClick={state.phase === "feedback" ? actions.continue : actions.check}
-      size="lg"
-      {...props}
-    >
-      {state.phase === "feedback" ? t("Continue") : t("Check")}
-    </Button>
-  );
+  const buttonProps = {
+    ...props,
+    className: cn("w-full", className),
+    disabled: model.disabled,
+    onClick: actionByRun[model.run],
+    size: "lg" as const,
+  };
+
+  return <Button {...buttonProps}>{labelByButton[model.button]}</Button>;
 }

--- a/packages/player/src/components/step-renderer.tsx
+++ b/packages/player/src/components/step-renderer.tsx
@@ -1,8 +1,8 @@
 /* oxlint-disable max-lines-per-function, max-statements */
 "use client";
 
-import { parseStepContent } from "@zoonk/core/steps/contract/content";
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
+import { describePlayerStep } from "../player-step";
 import { type SerializedStep } from "../prepare-activity-data";
 import { FillBlankStep } from "./fill-blank-step";
 import { InvestigationStep } from "./investigation-step";
@@ -37,12 +37,10 @@ export function StepRenderer({
   selectedAnswer: SelectedAnswer | undefined;
   step: SerializedStep;
 }) {
-  if (step.kind === "static") {
-    const staticContent = parseStepContent("static", step.content);
-    const isStoryStatic =
-      staticContent.variant === "storyIntro" || staticContent.variant === "storyOutcome";
+  const descriptor = describePlayerStep(step);
 
-    if (isStoryStatic) {
+  if (step.kind === "static") {
+    if (descriptor?.kind === "storyIntro" || descriptor?.kind === "storyOutcome") {
       return <StaticStep step={step} />;
     }
 

--- a/packages/player/src/components/step-renderer.tsx
+++ b/packages/player/src/components/step-renderer.tsx
@@ -3,6 +3,7 @@
 
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
 import { describePlayerStep } from "../player-step";
+import { type PlayerRenderBehavior, getPlayerStepBehavior } from "../player-step-behavior";
 import { type SerializedStep } from "../prepare-activity-data";
 import { FillBlankStep } from "./fill-blank-step";
 import { InvestigationStep } from "./investigation-step";
@@ -20,6 +21,119 @@ import { TranslationStep } from "./translation-step";
 import { VisualStep } from "./visual-step";
 import { VocabularyStep } from "./vocabulary-step";
 
+type StepRendererProps = {
+  canNavigatePrev: boolean;
+  onNavigateNext: () => void;
+  onNavigatePrev: () => void;
+  onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
+  result?: StepResult;
+  selectedAnswer: SelectedAnswer | undefined;
+  step: SerializedStep;
+};
+
+function renderStepContent({
+  render,
+  onSelectAnswer,
+  result,
+  selectedAnswer,
+  step,
+}: Pick<StepRendererProps, "onSelectAnswer" | "result" | "selectedAnswer" | "step"> & {
+  render: PlayerRenderBehavior;
+}) {
+  switch (render) {
+    case "fillBlank":
+      return (
+        <FillBlankStep
+          onSelectAnswer={onSelectAnswer}
+          result={result}
+          selectedAnswer={selectedAnswer}
+          step={step}
+        />
+      );
+    case "investigation":
+      return (
+        <InvestigationStep
+          onSelectAnswer={onSelectAnswer}
+          result={result}
+          selectedAnswer={selectedAnswer}
+          step={step}
+        />
+      );
+    case "listening":
+      return (
+        <ListeningStep
+          onSelectAnswer={onSelectAnswer}
+          result={result}
+          selectedAnswer={selectedAnswer}
+          step={step}
+        />
+      );
+    case "matchColumns":
+      return (
+        <MatchColumnsStep
+          onSelectAnswer={onSelectAnswer}
+          selectedAnswer={selectedAnswer}
+          step={step}
+        />
+      );
+    case "multipleChoice":
+      return (
+        <MultipleChoiceStep
+          onSelectAnswer={onSelectAnswer}
+          selectedAnswer={selectedAnswer}
+          step={step}
+        />
+      );
+    case "reading":
+      return (
+        <ReadingStep
+          onSelectAnswer={onSelectAnswer}
+          result={result}
+          selectedAnswer={selectedAnswer}
+          step={step}
+        />
+      );
+    case "selectImage":
+      return (
+        <SelectImageStep
+          onSelectAnswer={onSelectAnswer}
+          result={result}
+          selectedAnswer={selectedAnswer}
+          step={step}
+        />
+      );
+    case "sortOrder":
+      return (
+        <SortOrderStep
+          onSelectAnswer={onSelectAnswer}
+          result={result}
+          selectedAnswer={selectedAnswer}
+          step={step}
+        />
+      );
+    case "static":
+      return <StaticStep step={step} />;
+    case "story":
+      return (
+        <StoryStep onSelectAnswer={onSelectAnswer} selectedAnswer={selectedAnswer} step={step} />
+      );
+    case "translation":
+      return (
+        <TranslationStep
+          onSelectAnswer={onSelectAnswer}
+          selectedAnswer={selectedAnswer}
+          step={step}
+        />
+      );
+    case "visual":
+      return <VisualStep step={step} />;
+    case "vocabulary":
+      return <VocabularyStep step={step} />;
+    default:
+      return null;
+  }
+}
+
 export function StepRenderer({
   canNavigatePrev,
   onNavigateNext,
@@ -28,161 +142,38 @@ export function StepRenderer({
   result,
   selectedAnswer,
   step,
-}: {
-  canNavigatePrev: boolean;
-  onNavigateNext: () => void;
-  onNavigatePrev: () => void;
-  onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
-  result?: StepResult;
-  selectedAnswer: SelectedAnswer | undefined;
-  step: SerializedStep;
-}) {
+}: StepRendererProps) {
   const descriptor = describePlayerStep(step);
+  const behavior = getPlayerStepBehavior(descriptor);
 
-  if (step.kind === "static") {
-    if (descriptor?.kind === "storyIntro" || descriptor?.kind === "storyOutcome") {
-      return <StaticStep step={step} />;
-    }
-
-    return (
-      <NavigableStepLayout>
-        <StepSideNav
-          canNavigatePrev={canNavigatePrev}
-          onNavigateNext={onNavigateNext}
-          onNavigatePrev={onNavigatePrev}
-        />
-        <StaticStep step={step} />
-      </NavigableStepLayout>
-    );
+  if (!behavior) {
+    return null;
   }
 
-  if (step.kind === "visual") {
-    return (
-      <NavigableStepLayout>
-        <StepSideNav
-          canNavigatePrev={canNavigatePrev}
-          onNavigateNext={onNavigateNext}
-          onNavigatePrev={onNavigatePrev}
-        />
-        <VisualStep step={step} />
-      </NavigableStepLayout>
-    );
+  const content = renderStepContent({
+    onSelectAnswer,
+    render: behavior.render,
+    result,
+    selectedAnswer,
+    step,
+  });
+
+  if (!content) {
+    return null;
   }
 
-  if (step.kind === "multipleChoice") {
-    return (
-      <MultipleChoiceStep
-        onSelectAnswer={onSelectAnswer}
-        selectedAnswer={selectedAnswer}
-        step={step}
+  if (behavior.layout !== "navigable") {
+    return content;
+  }
+
+  return (
+    <NavigableStepLayout>
+      <StepSideNav
+        canNavigatePrev={canNavigatePrev}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrev={onNavigatePrev}
       />
-    );
-  }
-
-  if (step.kind === "fillBlank") {
-    return (
-      <FillBlankStep
-        onSelectAnswer={onSelectAnswer}
-        result={result}
-        selectedAnswer={selectedAnswer}
-        step={step}
-      />
-    );
-  }
-
-  if (step.kind === "matchColumns") {
-    return (
-      <MatchColumnsStep
-        onSelectAnswer={onSelectAnswer}
-        selectedAnswer={selectedAnswer}
-        step={step}
-      />
-    );
-  }
-
-  if (step.kind === "selectImage") {
-    return (
-      <SelectImageStep
-        onSelectAnswer={onSelectAnswer}
-        result={result}
-        selectedAnswer={selectedAnswer}
-        step={step}
-      />
-    );
-  }
-
-  if (step.kind === "sortOrder") {
-    return (
-      <SortOrderStep
-        onSelectAnswer={onSelectAnswer}
-        result={result}
-        selectedAnswer={selectedAnswer}
-        step={step}
-      />
-    );
-  }
-
-  if (step.kind === "vocabulary") {
-    return (
-      <NavigableStepLayout>
-        <StepSideNav
-          canNavigatePrev={canNavigatePrev}
-          onNavigateNext={onNavigateNext}
-          onNavigatePrev={onNavigatePrev}
-        />
-        <VocabularyStep step={step} />
-      </NavigableStepLayout>
-    );
-  }
-
-  if (step.kind === "translation") {
-    return (
-      <TranslationStep
-        onSelectAnswer={onSelectAnswer}
-        selectedAnswer={selectedAnswer}
-        step={step}
-      />
-    );
-  }
-
-  if (step.kind === "reading") {
-    return (
-      <ReadingStep
-        onSelectAnswer={onSelectAnswer}
-        result={result}
-        selectedAnswer={selectedAnswer}
-        step={step}
-      />
-    );
-  }
-
-  if (step.kind === "listening") {
-    return (
-      <ListeningStep
-        onSelectAnswer={onSelectAnswer}
-        result={result}
-        selectedAnswer={selectedAnswer}
-        step={step}
-      />
-    );
-  }
-
-  if (step.kind === "story") {
-    return (
-      <StoryStep onSelectAnswer={onSelectAnswer} selectedAnswer={selectedAnswer} step={step} />
-    );
-  }
-
-  if (step.kind === "investigation") {
-    return (
-      <InvestigationStep
-        onSelectAnswer={onSelectAnswer}
-        result={result}
-        selectedAnswer={selectedAnswer}
-        step={step}
-      />
-    );
-  }
-
-  return null;
+      {content}
+    </NavigableStepLayout>
+  );
 }

--- a/packages/player/src/investigation-reducer.ts
+++ b/packages/player/src/investigation-reducer.ts
@@ -1,4 +1,3 @@
-import { parseStepContent } from "@zoonk/core/steps/contract/content";
 import { INVESTIGATION_EXPERIMENT_COUNT } from "@zoonk/utils/activities";
 import {
   type ActionTiming,
@@ -6,20 +5,6 @@ import {
   getInvestigationStepByVariant,
 } from "./investigation";
 import { type PlayerState, type SelectedAnswer } from "./player-reducer";
-import { type SerializedStep } from "./prepare-activity-data";
-
-/**
- * Returns the investigation variant of the current step, or null
- * if the step is not an investigation step.
- */
-export function getInvestigationVariant(step: SerializedStep | undefined) {
-  if (!step || step.kind !== "investigation") {
-    return null;
-  }
-
-  const content = parseStepContent("investigation", step.content);
-  return content.variant;
-}
 
 /**
  * Initializes the investigation loop state when the problem step

--- a/packages/player/src/investigation.ts
+++ b/packages/player/src/investigation.ts
@@ -1,9 +1,9 @@
 import {
   type InvestigationActionQuality,
   type InvestigationStepContent,
-  parseStepContent,
 } from "@zoonk/core/steps/contract/content";
 import { type PlayerState } from "./player-reducer";
+import { describePlayerStep } from "./player-step";
 import { type SerializedStep } from "./prepare-activity-data";
 
 export type ActionTiming = {
@@ -34,12 +34,21 @@ export function getInvestigationStepByVariant(
   variant: InvestigationVariant,
 ): SerializedStep | undefined {
   return steps.find((step) => {
-    if (step.kind !== "investigation") {
-      return false;
+    const descriptor = describePlayerStep(step);
+
+    if (descriptor?.kind === "investigationAction") {
+      return variant === "action";
     }
 
-    const content = parseStepContent("investigation", step.content);
-    return content.variant === variant;
+    if (descriptor?.kind === "investigationCall") {
+      return variant === "call";
+    }
+
+    if (descriptor?.kind === "investigationProblem") {
+      return variant === "problem";
+    }
+
+    return false;
   });
 }
 
@@ -71,29 +80,26 @@ export function getAvailableActions(
 export function getInvestigationScenario(state: PlayerState): {
   scenario: string;
 } | null {
-  const currentStep = state.steps[state.currentStepIndex];
+  const descriptor = describePlayerStep(state.steps[state.currentStepIndex]);
 
-  if (!currentStep || currentStep.kind !== "investigation") {
+  if (
+    descriptor?.kind !== "investigationAction" &&
+    descriptor?.kind !== "investigationCall" &&
+    descriptor?.kind !== "investigationProblem"
+  ) {
     return null;
   }
 
-  const currentContent = parseStepContent("investigation", currentStep.content);
-
-  if (currentContent.variant === "problem") {
+  if (descriptor.kind === "investigationProblem") {
     return null;
   }
 
   const problemStep = getInvestigationStepByVariant(state.steps, "problem");
+  const problemDescriptor = describePlayerStep(problemStep);
 
-  if (!problemStep) {
+  if (problemDescriptor?.kind !== "investigationProblem") {
     return null;
   }
 
-  const problemContent = parseStepContent("investigation", problemStep.content);
-
-  if (problemContent.variant !== "problem") {
-    return null;
-  }
-
-  return { scenario: problemContent.scenario };
+  return { scenario: problemDescriptor.content.scenario };
 }

--- a/packages/player/src/player-context.tsx
+++ b/packages/player/src/player-context.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext } from "react";
 import { type PlayerState } from "./player-reducer";
+import { type PlayerScreenModel } from "./player-screen";
 import { type PlayerActions } from "./use-player-actions";
 
 export type PlayerRoute = string | URL;
@@ -37,6 +38,7 @@ export type PlayerMilestone = { kind: "activity" } | ReviewMilestone | CourseMil
 
 type PlayerRuntimeContextValue = {
   actions: PlayerActions;
+  screen: PlayerScreenModel;
   state: PlayerState;
 };
 

--- a/packages/player/src/player-initial-state.ts
+++ b/packages/player/src/player-initial-state.ts
@@ -1,21 +1,5 @@
-import { parseStepContent } from "@zoonk/core/steps/contract/content";
 import { type PlayerPhase, type PlayerState, type SelectedAnswer } from "./player-reducer";
 import { type SerializedActivity, type SerializedStep } from "./prepare-activity-data";
-
-/**
- * Returns true if the step is an investigation problem step.
- *
- * Problem steps are read-only (no user selection), so they need
- * a pre-set answer to enable the "Investigate" button in the bottom bar.
- */
-function isInvestigationProblemStep(step: SerializedStep): boolean {
-  if (step.kind !== "investigation") {
-    return false;
-  }
-
-  const content = parseStepContent("investigation", step.content);
-  return content.variant === "problem";
-}
 
 export function buildInitialAnswers(steps: SerializedStep[]): Record<string, SelectedAnswer> {
   const entries: [string, SelectedAnswer][] = [];
@@ -23,10 +7,6 @@ export function buildInitialAnswers(steps: SerializedStep[]): Record<string, Sel
   for (const step of steps) {
     if (step.kind === "sortOrder" && step.sortOrderItems.length > 0) {
       entries.push([step.id, { kind: "sortOrder", userOrder: step.sortOrderItems }]);
-    }
-
-    if (isInvestigationProblemStep(step)) {
-      entries.push([step.id, { kind: "investigation", variant: "problem" }]);
     }
   }
 

--- a/packages/player/src/player-provider.tsx
+++ b/packages/player/src/player-provider.tsx
@@ -11,12 +11,7 @@ import {
 } from "./player-context";
 import { type InitialStateInput } from "./player-initial-state";
 import { createInitialState, playerReducer } from "./player-reducer";
-import {
-  getCanNavigatePrev,
-  getHasAnswer,
-  getIsStaticStep,
-  getStoryStaticVariant,
-} from "./player-selectors";
+import { getPlayerScreenModel } from "./player-screen";
 import { type SerializedActivity } from "./prepare-activity-data";
 import { usePlayerActions } from "./use-player-actions";
 import { usePlayerKeyboard } from "./use-player-keyboard";
@@ -49,16 +44,14 @@ export function PlayerProvider({
   );
   const [state, dispatch] = useReducer(playerReducer, initInput, createInitialState);
   const actions = usePlayerActions(state, dispatch, onComplete, viewer.isAuthenticated);
+  const screen = useMemo(() => getPlayerScreenModel(state), [state]);
 
   const handleNext = useCallback(() => {
     onNext?.();
   }, [onNext]);
 
   usePlayerKeyboard({
-    canNavigatePrev: getCanNavigatePrev(state),
-    hasAnswer: getHasAnswer(state),
-
-    isStaticStep: getIsStaticStep(state),
+    keyboard: screen.keyboard,
     onCheck: actions.check,
     onContinue: actions.continue,
     onEscape,
@@ -66,8 +59,6 @@ export function PlayerProvider({
     onNavigatePrev: actions.navigatePrev,
     onNext: onNext ? handleNext : null,
     onRestart: actions.restart,
-    phase: state.phase,
-    storyStaticVariant: getStoryStaticVariant(state),
   });
 
   const configValue = useMemo(
@@ -84,9 +75,10 @@ export function PlayerProvider({
   const runtimeValue = useMemo(
     () => ({
       actions,
+      screen,
       state,
     }),
-    [actions, state],
+    [actions, screen, state],
   );
 
   return (

--- a/packages/player/src/player-reducer.ts
+++ b/packages/player/src/player-reducer.ts
@@ -4,14 +4,13 @@ import { type InvestigationLoopState } from "./investigation";
 import {
   continueFromAction,
   continueFromProblem,
-  getInvestigationVariant,
   recordActionInLoop,
 } from "./investigation-reducer";
 import { computeLocalCompletion } from "./player-completion";
 import { buildInitialAnswers } from "./player-initial-state";
+import { getInvestigationVariant, getStoryStaticVariant } from "./player-step";
 import { type SerializedStep } from "./prepare-activity-data";
 import { canNavigatePrev, isStaticNavigationStep } from "./step-navigation";
-import { isStoryStaticVariant } from "./story";
 
 export type PlayerPhase = "playing" | "feedback" | "completed";
 
@@ -273,7 +272,7 @@ function handleNavigateStep(
    * navigation via the bottom bar action buttons. They don't participate
    * in arrow-key navigation handled by `isStaticNavigationStep`.
    */
-  if (currentStep && isStoryStaticVariant(currentStep) && action.direction === "next") {
+  if (currentStep && getStoryStaticVariant(currentStep) && action.direction === "next") {
     return advanceForward(state);
   }
 

--- a/packages/player/src/player-screen.test.ts
+++ b/packages/player/src/player-screen.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "vitest";
+import { type PlayerState } from "./player-reducer";
+import { getPlayerScreenModel } from "./player-screen";
+import { type SerializedStep } from "./prepare-activity-data";
+
+function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
+  return {
+    content: { text: "Hello", title: "Intro", variant: "text" as const },
+    fillBlankOptions: [],
+    id: "step-1",
+    kind: "static",
+    matchColumnsRightItems: [],
+    position: 0,
+    sentence: null,
+    sentenceWordOptions: [],
+    sortOrderItems: [],
+    translationOptions: [],
+    vocabularyOptions: [],
+    word: null,
+    wordBankOptions: [],
+    ...overrides,
+  };
+}
+
+function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
+  return {
+    activityId: "activity-1",
+    completion: null,
+    currentStepIndex: 0,
+    investigationLoop: null,
+    phase: "playing",
+    results: {},
+    selectedAnswers: {},
+    startedAt: 1000,
+    stepStartedAt: 1000,
+    stepTimings: {},
+    steps: [buildStep()],
+    totalBrainPower: 0,
+    ...overrides,
+  };
+}
+
+describe(getPlayerScreenModel, () => {
+  test("uses navigation mode for regular static steps", () => {
+    const screen = getPlayerScreenModel(buildState());
+
+    expect(screen.kind).toBe("step");
+    expect(screen.bottomBar).toEqual({ canNavigatePrev: false, kind: "navigation" });
+    expect(screen.keyboard.enterAction).toBeNull();
+    expect(screen.keyboard.rightAction).toBe("navigateNext");
+    expect(screen.stageIsStatic).toBe(true);
+  });
+
+  test("uses primary action mode for story intro", () => {
+    const screen = getPlayerScreenModel(
+      buildState({
+        steps: [
+          buildStep({
+            content: {
+              intro: "Welcome",
+              metrics: ["Morale"],
+              variant: "storyIntro" as const,
+            },
+          }),
+        ],
+      }),
+    );
+
+    expect(screen.kind).toBe("step");
+    expect(screen.bottomBar).toEqual({
+      button: "begin",
+      disabled: false,
+      kind: "primaryAction",
+      run: "navigateNext",
+    });
+    expect(screen.keyboard.enterAction).toBe("navigateNext");
+    expect(screen.storyStaticVariant).toBe("storyIntro");
+  });
+
+  test("supports investigation problem without a synthetic answer", () => {
+    const screen = getPlayerScreenModel(
+      buildState({
+        steps: [
+          buildStep({
+            content: { scenario: "A mystery occurred.", variant: "problem" as const },
+            kind: "investigation",
+          }),
+        ],
+      }),
+    );
+
+    expect(screen.kind).toBe("step");
+    expect(screen.bottomBar).toEqual({
+      button: "startInvestigation",
+      disabled: false,
+      kind: "primaryAction",
+      run: "check",
+    });
+    expect(screen.keyboard.enterAction).toBe("check");
+  });
+
+  test("keeps unanswered interactive steps disabled", () => {
+    const screen = getPlayerScreenModel(
+      buildState({
+        steps: [
+          buildStep({
+            content: {
+              kind: "core" as const,
+              options: [{ feedback: "Correct", isCorrect: true, text: "A" }],
+              question: "Choose",
+            },
+            kind: "multipleChoice",
+          }),
+        ],
+      }),
+    );
+
+    expect(screen.kind).toBe("step");
+    expect(screen.bottomBar).toEqual({
+      button: "check",
+      disabled: true,
+      kind: "primaryAction",
+      run: "check",
+    });
+    expect(screen.keyboard.enterAction).toBeNull();
+  });
+
+  test("routes story feedback to the dedicated feedback screen", () => {
+    const screen = getPlayerScreenModel(
+      buildState({
+        phase: "feedback",
+        steps: [
+          buildStep({
+            content: {
+              choices: [
+                {
+                  alignment: "strong" as const,
+                  consequence: "Good call",
+                  id: "choice-1",
+                  metricEffects: [],
+                  text: "Option A",
+                },
+              ],
+              situation: "Choose",
+            },
+            kind: "story",
+          }),
+        ],
+      }),
+    );
+
+    expect(screen.kind).toBe("feedbackScreen");
+    expect(screen.bottomBar).toEqual({
+      button: "continue",
+      disabled: false,
+      kind: "primaryAction",
+      run: "continue",
+    });
+    expect(screen.keyboard.enterAction).toBe("continue");
+    expect(screen.showMetricsBar).toBe(true);
+  });
+
+  test("keeps completed state in completion mode", () => {
+    const screen = getPlayerScreenModel(
+      buildState({
+        phase: "completed",
+      }),
+    );
+
+    expect(screen.kind).toBe("completed");
+    expect(screen.bottomBar).toBeNull();
+    expect(screen.keyboard.enterAction).toBe("nextOrEscape");
+    expect(screen.keyboard.canRestart).toBe(true);
+  });
+});

--- a/packages/player/src/player-screen.ts
+++ b/packages/player/src/player-screen.ts
@@ -1,0 +1,260 @@
+import { type StoryStaticVariant } from "@zoonk/core/steps/contract/content";
+import { type PlayerState } from "./player-reducer";
+import {
+  type PlayerStepDescriptor,
+  describePlayerStep,
+  usesFeedbackScreen,
+  usesStaticNavigation,
+} from "./player-step";
+import { canNavigatePrev as getCanNavigatePrev } from "./step-navigation";
+
+type PlayerPrimaryActionKind = "begin" | "check" | "continue" | "startInvestigation";
+type PlayerPrimaryActionRun = "check" | "continue" | "navigateNext";
+
+type PlayerBottomBarModel =
+  | {
+      canNavigatePrev: boolean;
+      kind: "navigation";
+    }
+  | {
+      button: PlayerPrimaryActionKind;
+      disabled: boolean;
+      kind: "primaryAction";
+      run: PlayerPrimaryActionRun;
+    };
+
+export type PlayerKeyboardModel = {
+  canRestart: boolean;
+  enterAction: "check" | "continue" | "navigateNext" | "nextOrEscape" | null;
+  leftAction: "navigatePrev" | null;
+  rightAction: "navigateNext" | null;
+};
+
+type InPlayScreenModel = {
+  bottomBar: PlayerBottomBarModel;
+  canNavigatePrev: boolean;
+  keyboard: PlayerKeyboardModel;
+  showChrome: true;
+  showMetricsBar: boolean;
+  stageIsStatic: boolean;
+  step: PlayerStepDescriptor;
+  storyStaticVariant: StoryStaticVariant | null;
+};
+
+export type PlayerCompletedScreenModel = {
+  bottomBar: null;
+  keyboard: PlayerKeyboardModel;
+  kind: "completed";
+  showChrome: false;
+  showMetricsBar: false;
+  stageIsStatic: false;
+  storyStaticVariant: null;
+};
+
+export type PlayerFeedbackScreenModel = InPlayScreenModel & {
+  kind: "feedbackScreen";
+};
+
+export type PlayerStepScreenModel = InPlayScreenModel & {
+  kind: "step";
+};
+
+export type PlayerScreenModel =
+  | PlayerCompletedScreenModel
+  | PlayerFeedbackScreenModel
+  | PlayerStepScreenModel;
+
+/**
+ * A completed player only exposes completion controls. Keeping this in a
+ * helper lets the main screen model focus on active play and gives the
+ * keyboard hook a consistent shape even when there is no current step.
+ */
+function getCompletedScreenModel(): PlayerCompletedScreenModel {
+  return {
+    bottomBar: null,
+    keyboard: {
+      canRestart: true,
+      enterAction: "nextOrEscape",
+      leftAction: null,
+      rightAction: null,
+    },
+    kind: "completed",
+    showChrome: false,
+    showMetricsBar: false,
+    stageIsStatic: false,
+    storyStaticVariant: null,
+  };
+}
+
+/**
+ * The bottom bar is the clearest description of the player's current control
+ * mode. Building it in one place prevents shell and keyboard code from
+ * independently re-deriving which action should be active.
+ */
+function getBottomBarModel({
+  canMovePrev,
+  hasAnswer,
+  phase,
+  step,
+}: {
+  canMovePrev: boolean;
+  hasAnswer: boolean;
+  phase: PlayerState["phase"];
+  step: PlayerStepDescriptor;
+}): PlayerBottomBarModel {
+  if (phase === "feedback") {
+    return {
+      button: "continue",
+      disabled: false,
+      kind: "primaryAction",
+      run: "continue",
+    };
+  }
+
+  if (step.kind === "storyIntro") {
+    return {
+      button: "begin",
+      disabled: false,
+      kind: "primaryAction",
+      run: "navigateNext",
+    };
+  }
+
+  if (step.kind === "storyOutcome") {
+    return {
+      button: "continue",
+      disabled: false,
+      kind: "primaryAction",
+      run: "navigateNext",
+    };
+  }
+
+  if (usesStaticNavigation(step)) {
+    return { canNavigatePrev: canMovePrev, kind: "navigation" };
+  }
+
+  if (step.kind === "investigationProblem") {
+    return {
+      button: "startInvestigation",
+      disabled: false,
+      kind: "primaryAction",
+      run: "check",
+    };
+  }
+
+  return {
+    button: "check",
+    disabled: !hasAnswer,
+    kind: "primaryAction",
+    run: "check",
+  };
+}
+
+/**
+ * Keyboard shortcuts should mirror the same control mode shown in the bottom
+ * bar. Deriving them from the screen model avoids subtle drift where the UI
+ * shows one action but Enter or arrow keys trigger another.
+ */
+function getKeyboardModel({
+  bottomBar,
+  canMovePrev,
+  phase,
+  step,
+}: {
+  bottomBar: PlayerBottomBarModel;
+  canMovePrev: boolean;
+  phase: PlayerState["phase"];
+  step: PlayerStepDescriptor;
+}): PlayerKeyboardModel {
+  if (phase === "completed") {
+    return {
+      canRestart: true,
+      enterAction: "nextOrEscape",
+      leftAction: null,
+      rightAction: null,
+    };
+  }
+
+  const enterAction =
+    bottomBar.kind === "primaryAction" && !bottomBar.disabled ? bottomBar.run : null;
+
+  return {
+    canRestart: false,
+    enterAction,
+    leftAction: phase === "playing" && canMovePrev ? "navigatePrev" : null,
+    rightAction: phase === "playing" && usesStaticNavigation(step) ? "navigateNext" : null,
+  };
+}
+
+/**
+ * Story intro and outcome are the only step descriptors that need a dedicated
+ * story-static signal. The haptics layer consumes this when feedback advances
+ * into the outcome screen.
+ */
+function getStoryStaticVariant(step: PlayerStepDescriptor): StoryStaticVariant | null {
+  if (step.kind === "storyIntro") {
+    return "storyIntro";
+  }
+
+  if (step.kind === "storyOutcome") {
+    return "storyOutcome";
+  }
+
+  return null;
+}
+
+/**
+ * Returns the player's canonical screen model from raw reducer state.
+ *
+ * This is the shared UI/control source of truth for shell layout, keyboard
+ * shortcuts, and stage routing. Callers should prefer this over rebuilding
+ * screen mode from scattered booleans.
+ */
+export function getPlayerScreenModel(state: PlayerState): PlayerScreenModel {
+  if (state.phase === "completed") {
+    return getCompletedScreenModel();
+  }
+
+  const currentStep = state.steps[state.currentStepIndex];
+
+  if (!currentStep) {
+    return getCompletedScreenModel();
+  }
+
+  const step = describePlayerStep(currentStep);
+
+  if (!step) {
+    return getCompletedScreenModel();
+  }
+
+  const hasAnswer = Boolean(state.selectedAnswers[currentStep.id]);
+  const canMovePrev = getCanNavigatePrev(state.steps, state.currentStepIndex);
+  const bottomBar = getBottomBarModel({
+    canMovePrev,
+    hasAnswer,
+    phase: state.phase,
+    step,
+  });
+  const keyboard = getKeyboardModel({
+    bottomBar,
+    canMovePrev,
+    phase: state.phase,
+    step,
+  });
+  const model = {
+    bottomBar,
+    canNavigatePrev: canMovePrev,
+    keyboard,
+    showChrome: true as const,
+    showMetricsBar: step.kind === "storyDecision",
+    stageIsStatic: state.phase === "playing" && usesStaticNavigation(step),
+    step,
+    storyStaticVariant: getStoryStaticVariant(step),
+  };
+
+  if (state.phase === "feedback" && usesFeedbackScreen(step)) {
+    return { ...model, kind: "feedbackScreen" };
+  }
+
+  return { ...model, kind: "step" };
+}

--- a/packages/player/src/player-screen.ts
+++ b/packages/player/src/player-screen.ts
@@ -1,11 +1,11 @@
 import { type StoryStaticVariant } from "@zoonk/core/steps/contract/content";
 import { type PlayerState } from "./player-reducer";
+import { type PlayerStepDescriptor, describePlayerStep } from "./player-step";
 import {
-  type PlayerStepDescriptor,
-  describePlayerStep,
+  getPlayerStepBehavior,
   usesFeedbackScreen,
   usesStaticNavigation,
-} from "./player-step";
+} from "./player-step-behavior";
 import { canNavigatePrev as getCanNavigatePrev } from "./step-navigation";
 
 type PlayerPrimaryActionKind = "begin" | "check" | "continue" | "startInvestigation";
@@ -102,6 +102,12 @@ function getBottomBarModel({
   phase: PlayerState["phase"];
   step: PlayerStepDescriptor;
 }): PlayerBottomBarModel {
+  const behavior = getPlayerStepBehavior(step);
+
+  if (!behavior) {
+    return { canNavigatePrev: canMovePrev, kind: "navigation" };
+  }
+
   if (phase === "feedback") {
     return {
       button: "continue",
@@ -129,7 +135,7 @@ function getBottomBarModel({
     };
   }
 
-  if (usesStaticNavigation(step)) {
+  if (behavior.layout === "navigable") {
     return { canNavigatePrev: canMovePrev, kind: "navigation" };
   }
 
@@ -177,12 +183,13 @@ function getKeyboardModel({
 
   const enterAction =
     bottomBar.kind === "primaryAction" && !bottomBar.disabled ? bottomBar.run : null;
+  const behavior = getPlayerStepBehavior(step);
 
   return {
     canRestart: false,
     enterAction,
     leftAction: phase === "playing" && canMovePrev ? "navigatePrev" : null,
-    rightAction: phase === "playing" && usesStaticNavigation(step) ? "navigateNext" : null,
+    rightAction: phase === "playing" && behavior?.layout === "navigable" ? "navigateNext" : null,
   };
 }
 

--- a/packages/player/src/player-selectors.test.ts
+++ b/packages/player/src/player-selectors.test.ts
@@ -6,7 +6,6 @@ import {
   getIsStoryActivity,
   getStoryBriefingText,
   getStoryMetrics,
-  getStoryStaticVariant,
   getUpcomingImages,
 } from "./player-selectors";
 import { type SerializedStep } from "./prepare-activity-data";
@@ -118,52 +117,6 @@ describe(getIsStoryActivity, () => {
     });
 
     expect(getIsStoryActivity(state)).toBe(false);
-  });
-});
-
-describe(getStoryStaticVariant, () => {
-  test("returns storyIntro when current step is a story intro", () => {
-    const state = buildState({
-      currentStepIndex: 0,
-      steps: [buildStoryIntroStep(), buildStoryStep("s1", 1)],
-    });
-
-    expect(getStoryStaticVariant(state)).toBe("storyIntro");
-  });
-
-  test("returns storyOutcome when current step is a story outcome", () => {
-    const state = buildState({
-      currentStepIndex: 0,
-      steps: [
-        buildStep({
-          content: {
-            metrics: ["Production"],
-            outcomes: [{ minStrongChoices: 0, narrative: "Result.", title: "Outcome" }],
-            variant: "storyOutcome" as const,
-          },
-          id: "outcome",
-          kind: "static",
-        }),
-      ],
-    });
-
-    expect(getStoryStaticVariant(state)).toBe("storyOutcome");
-  });
-
-  test("returns null when current step is a regular static step", () => {
-    const state = buildState({
-      steps: [buildStep({ content: { text: "Hello", title: "Intro", variant: "text" as const } })],
-    });
-
-    expect(getStoryStaticVariant(state)).toBeNull();
-  });
-
-  test("returns null when current step is a story decision step", () => {
-    const state = buildState({
-      steps: [buildStoryStep("s1", 0)],
-    });
-
-    expect(getStoryStaticVariant(state)).toBeNull();
   });
 });
 

--- a/packages/player/src/player-selectors.ts
+++ b/packages/player/src/player-selectors.ts
@@ -1,12 +1,10 @@
-import { type StoryStaticVariant, parseStepContent } from "@zoonk/core/steps/contract/content";
 import { INVESTIGATION_EXPERIMENT_COUNT } from "@zoonk/utils/activities";
 import { type CompletionResult } from "./completion-input-schema";
 import { getInvestigationScenario } from "./investigation";
-import { getInvestigationVariant } from "./investigation-reducer";
 import { type PlayerState } from "./player-reducer";
+import { describePlayerStep, getInvestigationVariant } from "./player-step";
 import { type SerializedStep } from "./prepare-activity-data";
-import { canNavigatePrev, isStaticNavigationStep } from "./step-navigation";
-import { EFFECT_DELTA_MAP, METRIC_AVERAGE_THRESHOLD, getStepStoryVariant } from "./story";
+import { EFFECT_DELTA_MAP, METRIC_AVERAGE_THRESHOLD } from "./story";
 
 /** Converts a 0-based step index to a 1-based percentage (0–100). */
 function computeProgress(currentIndex: number, total: number): number {
@@ -15,11 +13,6 @@ function computeProgress(currentIndex: number, total: number): number {
   }
 
   return Math.round(((currentIndex + 1) / total) * 100);
-}
-
-/** Whether the player can navigate to the previous step. */
-export function getCanNavigatePrev(state: PlayerState): boolean {
-  return canNavigatePrev(state.steps, state.currentStepIndex);
 }
 
 /** Returns the completion payload once the activity is finished, or null while still playing. */
@@ -41,40 +34,6 @@ export function getCurrentResult(state: PlayerState) {
 /** Returns the step at the current index. */
 export function getCurrentStep(state: PlayerState) {
   return state.steps[state.currentStepIndex];
-}
-
-/** Whether the player has selected an answer for the current step. */
-export function getHasAnswer(state: PlayerState): boolean {
-  const currentStep = getCurrentStep(state);
-
-  if (!currentStep) {
-    return false;
-  }
-
-  return Boolean(state.selectedAnswers[currentStep.id]);
-}
-
-/** Whether the current step uses static (auto-advance) navigation. */
-export function getIsStaticStep(state: PlayerState): boolean {
-  return isStaticNavigationStep(getCurrentStep(state));
-}
-
-/**
- * Whether the current step is an investigation problem step.
- *
- * The problem step is read-only (the learner just reads the scenario),
- * so the bottom bar should show "Investigate" instead of "Check"
- * to describe the action the learner is about to take.
- */
-export function getIsInvestigationProblem(state: PlayerState): boolean {
-  const step = getCurrentStep(state);
-
-  if (!step || step.kind !== "investigation") {
-    return false;
-  }
-
-  const content = parseStepContent("investigation", step.content);
-  return content.variant === "problem";
 }
 
 type InvestigationProgress = {
@@ -145,9 +104,9 @@ export function getInvestigationScenarioData(state: PlayerState) {
  * decision-making, so players can recall the premise without navigating back.
  */
 export function getStoryBriefingText(state: PlayerState): string | null {
-  const currentStep = getCurrentStep(state);
+  const currentDescriptor = describePlayerStep(getCurrentStep(state));
 
-  if (!currentStep || currentStep.kind !== "story") {
+  if (currentDescriptor?.kind !== "storyDecision") {
     return null;
   }
 
@@ -158,17 +117,6 @@ export function getStoryBriefingText(state: PlayerState): string | null {
   }
 
   return introContent.intro;
-}
-
-/**
- * Returns the story-specific static variant of the current step, or null
- * if the current step is not a story static screen.
- *
- * Used by PlayerShell to pick the correct bottom bar (Begin, Continue)
- * and by keyboard handlers for Enter key behavior.
- */
-export function getStoryStaticVariant(state: PlayerState): StoryStaticVariant | null {
-  return getStepStoryVariant(getCurrentStep(state));
 }
 
 export type StoryMetric = {
@@ -186,12 +134,10 @@ export type StoryMetric = {
  */
 function findStoryIntroContent(steps: SerializedStep[]) {
   for (const step of steps) {
-    if (step.kind === "static") {
-      const content = parseStepContent("static", step.content);
+    const descriptor = describePlayerStep(step);
 
-      if (content.variant === "storyIntro") {
-        return content;
-      }
+    if (descriptor?.kind === "storyIntro") {
+      return descriptor.content;
     }
   }
 
@@ -212,17 +158,20 @@ export function findSelectedChoice({
   step: SerializedStep;
   results: PlayerState["results"];
 }) {
+  const descriptor = describePlayerStep(step);
   const result = results[step.id];
   const answer = result?.answer;
 
-  if (!answer || answer.kind !== "story" || !answer.selectedChoiceId) {
+  if (
+    descriptor?.kind !== "storyDecision" ||
+    !answer ||
+    answer.kind !== "story" ||
+    !answer.selectedChoiceId
+  ) {
     return null;
   }
 
-  const choiceId = answer.selectedChoiceId;
-  const content = parseStepContent("story", step.content);
-
-  return content.choices.find((option) => option.id === choiceId) ?? null;
+  return descriptor.content.choices.find((option) => option.id === answer.selectedChoiceId) ?? null;
 }
 
 /**
@@ -289,20 +238,18 @@ const DEFAULT_LOOKAHEAD = 3;
  * have one URL per option.
  */
 function getStepImages(step: SerializedStep): PreloadableImage[] {
-  if (step.kind === "visual") {
-    const content = parseStepContent("visual", step.content);
+  const descriptor = describePlayerStep(step);
 
-    if (content.kind !== "image" || !content.url) {
+  if (descriptor?.kind === "visual") {
+    if (descriptor.content.kind !== "image" || !descriptor.content.url) {
       return [];
     }
 
-    return [{ kind: "visual", url: content.url }];
+    return [{ kind: "visual", url: descriptor.content.url }];
   }
 
-  if (step.kind === "selectImage") {
-    const content = parseStepContent("selectImage", step.content);
-
-    return content.options.flatMap((option) =>
+  if (descriptor?.kind === "selectImage") {
+    return descriptor.content.options.flatMap((option) =>
       option.url ? [{ kind: "selectImage" as const, url: option.url }] : [],
     );
   }

--- a/packages/player/src/player-step-behavior.test.ts
+++ b/packages/player/src/player-step-behavior.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "vitest";
+import { describePlayerStep } from "./player-step";
+import {
+  getPlayerStepBehavior,
+  getPlayerValidationBehavior,
+  usesFeedbackScreen,
+  usesStaticNavigation,
+} from "./player-step-behavior";
+import { type SerializedStep } from "./prepare-activity-data";
+
+function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
+  return {
+    content: { text: "Hello", title: "Intro", variant: "text" as const },
+    fillBlankOptions: [],
+    id: "step-1",
+    kind: "static",
+    matchColumnsRightItems: [],
+    position: 0,
+    sentence: null,
+    sentenceWordOptions: [],
+    sortOrderItems: [],
+    translationOptions: [],
+    vocabularyOptions: [],
+    word: null,
+    wordBankOptions: [],
+    ...overrides,
+  };
+}
+
+describe(getPlayerStepBehavior, () => {
+  test("keeps regular static text in navigable static mode", () => {
+    const descriptor = describePlayerStep(buildStep());
+    const behavior = getPlayerStepBehavior(descriptor);
+
+    expect(behavior).toMatchObject({
+      check: "none",
+      feedback: "none",
+      layout: "navigable",
+      render: "static",
+      validation: "none",
+    });
+    expect(descriptor && usesStaticNavigation(descriptor)).toBe(true);
+    expect(descriptor && usesFeedbackScreen(descriptor)).toBe(false);
+  });
+
+  test("marks story intro as a primary-action static screen", () => {
+    const descriptor = describePlayerStep(
+      buildStep({
+        content: {
+          intro: "Welcome",
+          metrics: ["Morale"],
+          variant: "storyIntro" as const,
+        },
+      }),
+    );
+    const behavior = getPlayerStepBehavior(descriptor);
+
+    expect(behavior).toMatchObject({
+      check: "none",
+      feedback: "none",
+      layout: "default",
+      render: "static",
+      validation: "none",
+    });
+    expect(descriptor && usesStaticNavigation(descriptor)).toBe(false);
+  });
+
+  test("routes investigation call through shared feedback and validation behavior", () => {
+    const step = buildStep({
+      content: {
+        explanations: [
+          {
+            accuracy: "best" as const,
+            feedback: "Correct",
+            id: "exp-1",
+            text: "It was DNS",
+          },
+        ],
+        variant: "call" as const,
+      },
+      kind: "investigation",
+    });
+    const descriptor = describePlayerStep(step);
+    const behavior = getPlayerStepBehavior(descriptor);
+
+    expect(behavior).toMatchObject({
+      check: "investigationCall",
+      feedback: "screen",
+      layout: "default",
+      render: "investigation",
+      validation: "investigationCall",
+    });
+    expect(descriptor && usesFeedbackScreen(descriptor)).toBe(true);
+    expect(getPlayerValidationBehavior({ content: step.content, kind: step.kind })).toBe(
+      "investigationCall",
+    );
+  });
+
+  test("skips validation for investigation action while keeping its check behavior", () => {
+    const step = buildStep({
+      content: {
+        actions: [
+          {
+            finding: "A clue",
+            id: "action-1",
+            label: "Inspect the logs",
+            quality: "critical" as const,
+          },
+          {
+            finding: "Another clue",
+            id: "action-2",
+            label: "Interview the witness",
+            quality: "useful" as const,
+          },
+        ],
+        variant: "action" as const,
+      },
+      kind: "investigation",
+    });
+    const descriptor = describePlayerStep(step);
+    const behavior = getPlayerStepBehavior(descriptor);
+
+    expect(behavior).toMatchObject({
+      check: "investigationAction",
+      feedback: "inline",
+      render: "investigation",
+      validation: "none",
+    });
+    expect(getPlayerValidationBehavior({ content: step.content, kind: step.kind })).toBe("none");
+  });
+});

--- a/packages/player/src/player-step-behavior.ts
+++ b/packages/player/src/player-step-behavior.ts
@@ -1,0 +1,265 @@
+import { isSupportedStepKind } from "@zoonk/core/steps/contract/content";
+import {
+  type PlayerStepDescriptor,
+  type PlayerStepKind,
+  describePlayerStep,
+  parsePlayerStepKind,
+} from "./player-step";
+import { type SerializedStep } from "./prepare-activity-data";
+
+export type PlayerCheckBehavior =
+  | "fillBlank"
+  | "investigationAction"
+  | "investigationCall"
+  | "investigationProblem"
+  | "listening"
+  | "matchColumns"
+  | "multipleChoice"
+  | "none"
+  | "reading"
+  | "selectImage"
+  | "sortOrder"
+  | "story"
+  | "translation";
+
+type PlayerFeedbackBehavior = "inline" | "none" | "screen";
+type PlayerLayoutBehavior = "default" | "navigable";
+
+export type PlayerRenderBehavior =
+  | "fillBlank"
+  | "investigation"
+  | "listening"
+  | "matchColumns"
+  | "multipleChoice"
+  | "reading"
+  | "selectImage"
+  | "sortOrder"
+  | "static"
+  | "story"
+  | "translation"
+  | "visual"
+  | "vocabulary";
+
+export type PlayerValidationBehavior =
+  | "fillBlank"
+  | "investigationCall"
+  | "listening"
+  | "matchColumns"
+  | "multipleChoice"
+  | "none"
+  | "reading"
+  | "selectImage"
+  | "sortOrder"
+  | "story"
+  | "translation";
+
+type PlayerStepBehavior = {
+  check: PlayerCheckBehavior;
+  feedback: PlayerFeedbackBehavior;
+  layout: PlayerLayoutBehavior;
+  render: PlayerRenderBehavior;
+  validation: PlayerValidationBehavior;
+};
+
+const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
+  fillBlank: {
+    check: "fillBlank",
+    feedback: "inline",
+    layout: "default",
+    render: "fillBlank",
+    validation: "fillBlank",
+  },
+  investigationAction: {
+    check: "investigationAction",
+    feedback: "inline",
+    layout: "default",
+    render: "investigation",
+    validation: "none",
+  },
+  investigationCall: {
+    check: "investigationCall",
+    feedback: "screen",
+    layout: "default",
+    render: "investigation",
+    validation: "investigationCall",
+  },
+  investigationProblem: {
+    check: "investigationProblem",
+    feedback: "none",
+    layout: "default",
+    render: "investigation",
+    validation: "none",
+  },
+  listening: {
+    check: "listening",
+    feedback: "screen",
+    layout: "default",
+    render: "listening",
+    validation: "listening",
+  },
+  matchColumns: {
+    check: "matchColumns",
+    feedback: "inline",
+    layout: "default",
+    render: "matchColumns",
+    validation: "matchColumns",
+  },
+  multipleChoice: {
+    check: "multipleChoice",
+    feedback: "screen",
+    layout: "default",
+    render: "multipleChoice",
+    validation: "multipleChoice",
+  },
+  reading: {
+    check: "reading",
+    feedback: "screen",
+    layout: "default",
+    render: "reading",
+    validation: "reading",
+  },
+  selectImage: {
+    check: "selectImage",
+    feedback: "inline",
+    layout: "default",
+    render: "selectImage",
+    validation: "selectImage",
+  },
+  sortOrder: {
+    check: "sortOrder",
+    feedback: "inline",
+    layout: "default",
+    render: "sortOrder",
+    validation: "sortOrder",
+  },
+  staticGrammarExample: {
+    check: "none",
+    feedback: "none",
+    layout: "navigable",
+    render: "static",
+    validation: "none",
+  },
+  staticGrammarRule: {
+    check: "none",
+    feedback: "none",
+    layout: "navigable",
+    render: "static",
+    validation: "none",
+  },
+  staticText: {
+    check: "none",
+    feedback: "none",
+    layout: "navigable",
+    render: "static",
+    validation: "none",
+  },
+  storyDecision: {
+    check: "story",
+    feedback: "screen",
+    layout: "default",
+    render: "story",
+    validation: "story",
+  },
+  storyIntro: {
+    check: "none",
+    feedback: "none",
+    layout: "default",
+    render: "static",
+    validation: "none",
+  },
+  storyOutcome: {
+    check: "none",
+    feedback: "none",
+    layout: "default",
+    render: "static",
+    validation: "none",
+  },
+  translation: {
+    check: "translation",
+    feedback: "screen",
+    layout: "default",
+    render: "translation",
+    validation: "translation",
+  },
+  visual: {
+    check: "none",
+    feedback: "none",
+    layout: "navigable",
+    render: "visual",
+    validation: "none",
+  },
+  vocabulary: {
+    check: "none",
+    feedback: "none",
+    layout: "navigable",
+    render: "vocabulary",
+    validation: "none",
+  },
+};
+
+/**
+ * The player has one semantic step descriptor, but multiple subsystems need to
+ * ask behavior questions about it: render routing, feedback mode, navigation,
+ * client-side checking, and server-side validation. This module keeps those
+ * answers in one place so new step kinds become additive instead of scattered.
+ */
+export function getPlayerStepBehavior(
+  descriptor: PlayerStepDescriptor | null | undefined,
+): PlayerStepBehavior | null {
+  if (!descriptor) {
+    return null;
+  }
+
+  return STEP_BEHAVIOR_BY_KIND[descriptor.kind];
+}
+
+/**
+ * Keyboard and shell layout both need to know whether a step participates in
+ * left/right static navigation. Deriving that from the shared behavior keeps
+ * the layout contract aligned with render routing.
+ */
+export function usesStaticNavigation(descriptor: PlayerStepDescriptor | null | undefined): boolean {
+  return getPlayerStepBehavior(descriptor)?.layout === "navigable";
+}
+
+/**
+ * Some steps swap to a dedicated feedback screen while others keep feedback
+ * inline. The screen model should ask the behavior layer this question rather
+ * than re-encoding a list of step kinds.
+ */
+export function usesFeedbackScreen(descriptor: PlayerStepDescriptor | null | undefined): boolean {
+  return getPlayerStepBehavior(descriptor)?.feedback === "screen";
+}
+
+/**
+ * Client-side checking runs against fully typed serialized steps, so it can
+ * reuse the canonical descriptor directly and then dispatch to the matching
+ * check strategy.
+ */
+export function getPlayerCheckBehavior(
+  step: SerializedStep | null | undefined,
+): PlayerCheckBehavior | null {
+  return getPlayerStepBehavior(describePlayerStep(step))?.check ?? null;
+}
+
+/**
+ * Server-side validation only has raw `{ kind, content }` rows. Reusing the
+ * canonical parsed step kind keeps validation policy in sync with the client
+ * behavior table even when step variants share one physical kind.
+ */
+export function getPlayerValidationBehavior(step: {
+  content: unknown;
+  kind: string;
+}): PlayerValidationBehavior | null {
+  if (!isSupportedStepKind(step.kind)) {
+    return null;
+  }
+
+  const stepKind = parsePlayerStepKind(step);
+
+  if (!stepKind) {
+    return null;
+  }
+
+  return STEP_BEHAVIOR_BY_KIND[stepKind].validation;
+}

--- a/packages/player/src/player-step.test.ts
+++ b/packages/player/src/player-step.test.ts
@@ -3,8 +3,7 @@ import {
   describePlayerStep,
   getInvestigationVariant,
   getStoryStaticVariant,
-  usesFeedbackScreen,
-  usesStaticNavigation,
+  parsePlayerStepKind,
 } from "./player-step";
 import { type SerializedStep } from "./prepare-activity-data";
 
@@ -40,11 +39,10 @@ describe(describePlayerStep, () => {
     );
 
     expect(descriptor?.kind).toBe("storyIntro");
-    expect(descriptor && usesStaticNavigation(descriptor)).toBe(false);
     expect(getStoryStaticVariant(descriptor?.step)).toBe("storyIntro");
   });
 
-  test("describes investigation call and marks it as feedback-screen content", () => {
+  test("describes investigation call and preserves its investigation variant", () => {
     const descriptor = describePlayerStep(
       buildStep({
         content: {
@@ -63,15 +61,31 @@ describe(describePlayerStep, () => {
     );
 
     expect(descriptor?.kind).toBe("investigationCall");
-    expect(descriptor && usesFeedbackScreen(descriptor)).toBe(true);
     expect(getInvestigationVariant(descriptor?.step)).toBe("call");
   });
 
-  test("keeps regular static text in static navigation mode", () => {
+  test("keeps regular static text as the canonical staticText kind", () => {
     const descriptor = describePlayerStep(buildStep());
 
     expect(descriptor?.kind).toBe("staticText");
-    expect(descriptor && usesStaticNavigation(descriptor)).toBe(true);
-    expect(descriptor && usesFeedbackScreen(descriptor)).toBe(false);
+  });
+
+  test("parses raw server step data into the same canonical step kind", () => {
+    expect(
+      parsePlayerStepKind({
+        content: {
+          explanations: [
+            {
+              accuracy: "best" as const,
+              feedback: "Correct",
+              id: "exp-1",
+              text: "It was DNS",
+            },
+          ],
+          variant: "call" as const,
+        },
+        kind: "investigation",
+      }),
+    ).toBe("investigationCall");
   });
 });

--- a/packages/player/src/player-step.test.ts
+++ b/packages/player/src/player-step.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "vitest";
+import {
+  describePlayerStep,
+  getInvestigationVariant,
+  getStoryStaticVariant,
+  usesFeedbackScreen,
+  usesStaticNavigation,
+} from "./player-step";
+import { type SerializedStep } from "./prepare-activity-data";
+
+function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
+  return {
+    content: { text: "Hello", title: "Intro", variant: "text" as const },
+    fillBlankOptions: [],
+    id: "step-1",
+    kind: "static",
+    matchColumnsRightItems: [],
+    position: 0,
+    sentence: null,
+    sentenceWordOptions: [],
+    sortOrderItems: [],
+    translationOptions: [],
+    vocabularyOptions: [],
+    word: null,
+    wordBankOptions: [],
+    ...overrides,
+  };
+}
+
+describe(describePlayerStep, () => {
+  test("describes story intro as its own canonical step", () => {
+    const descriptor = describePlayerStep(
+      buildStep({
+        content: {
+          intro: "Welcome",
+          metrics: ["Morale"],
+          variant: "storyIntro" as const,
+        },
+      }),
+    );
+
+    expect(descriptor?.kind).toBe("storyIntro");
+    expect(descriptor && usesStaticNavigation(descriptor)).toBe(false);
+    expect(getStoryStaticVariant(descriptor?.step)).toBe("storyIntro");
+  });
+
+  test("describes investigation call and marks it as feedback-screen content", () => {
+    const descriptor = describePlayerStep(
+      buildStep({
+        content: {
+          explanations: [
+            {
+              accuracy: "best" as const,
+              feedback: "Correct",
+              id: "exp-1",
+              text: "It was DNS",
+            },
+          ],
+          variant: "call" as const,
+        },
+        kind: "investigation",
+      }),
+    );
+
+    expect(descriptor?.kind).toBe("investigationCall");
+    expect(descriptor && usesFeedbackScreen(descriptor)).toBe(true);
+    expect(getInvestigationVariant(descriptor?.step)).toBe("call");
+  });
+
+  test("keeps regular static text in static navigation mode", () => {
+    const descriptor = describePlayerStep(buildStep());
+
+    expect(descriptor?.kind).toBe("staticText");
+    expect(descriptor && usesStaticNavigation(descriptor)).toBe(true);
+    expect(descriptor && usesFeedbackScreen(descriptor)).toBe(false);
+  });
+});

--- a/packages/player/src/player-step.ts
+++ b/packages/player/src/player-step.ts
@@ -1,0 +1,280 @@
+import {
+  type InvestigationStepContent,
+  type StoryStaticVariant,
+} from "@zoonk/core/steps/contract/content";
+import { type SerializedStep } from "./prepare-activity-data";
+
+type StepDescriptorBase<Kind extends SerializedStep["kind"], Name extends string> = {
+  content: SerializedStep<Kind>["content"];
+  kind: Name;
+  step: SerializedStep<Kind>;
+};
+
+type StaticTextStepDescriptor = StepDescriptorBase<"static", "staticText"> & {
+  content: Extract<SerializedStep<"static">["content"], { variant: "text" }>;
+};
+
+type StaticGrammarExampleStepDescriptor = StepDescriptorBase<"static", "staticGrammarExample"> & {
+  content: Extract<SerializedStep<"static">["content"], { variant: "grammarExample" }>;
+};
+
+type StaticGrammarRuleStepDescriptor = StepDescriptorBase<"static", "staticGrammarRule"> & {
+  content: Extract<SerializedStep<"static">["content"], { variant: "grammarRule" }>;
+};
+
+type StoryIntroStepDescriptor = StepDescriptorBase<"static", "storyIntro"> & {
+  content: Extract<SerializedStep<"static">["content"], { variant: "storyIntro" }>;
+};
+
+type StoryOutcomeStepDescriptor = StepDescriptorBase<"static", "storyOutcome"> & {
+  content: Extract<SerializedStep<"static">["content"], { variant: "storyOutcome" }>;
+};
+
+type InvestigationProblemStepDescriptor = StepDescriptorBase<
+  "investigation",
+  "investigationProblem"
+> & {
+  content: Extract<SerializedStep<"investigation">["content"], { variant: "problem" }>;
+};
+
+type InvestigationActionStepDescriptor = StepDescriptorBase<
+  "investigation",
+  "investigationAction"
+> & {
+  content: Extract<SerializedStep<"investigation">["content"], { variant: "action" }>;
+};
+
+type InvestigationCallStepDescriptor = StepDescriptorBase<"investigation", "investigationCall"> & {
+  content: Extract<SerializedStep<"investigation">["content"], { variant: "call" }>;
+};
+
+export type PlayerStepDescriptor =
+  | StepDescriptorBase<"fillBlank", "fillBlank">
+  | InvestigationActionStepDescriptor
+  | InvestigationCallStepDescriptor
+  | InvestigationProblemStepDescriptor
+  | StepDescriptorBase<"listening", "listening">
+  | StepDescriptorBase<"matchColumns", "matchColumns">
+  | StepDescriptorBase<"multipleChoice", "multipleChoice">
+  | StepDescriptorBase<"reading", "reading">
+  | StepDescriptorBase<"selectImage", "selectImage">
+  | StepDescriptorBase<"sortOrder", "sortOrder">
+  | StaticGrammarExampleStepDescriptor
+  | StaticGrammarRuleStepDescriptor
+  | StaticTextStepDescriptor
+  | StepDescriptorBase<"story", "storyDecision">
+  | StoryIntroStepDescriptor
+  | StoryOutcomeStepDescriptor
+  | StepDescriptorBase<"translation", "translation">
+  | StepDescriptorBase<"visual", "visual">
+  | StepDescriptorBase<"vocabulary", "vocabulary">;
+
+/**
+ * `SerializedStep` loses some of its `kind` to `content` correlation once it
+ * moves through arrays and reducer state. This guard restores that link so the
+ * descriptor layer can narrow safely without unsafe assertions.
+ */
+function hasStepKind<Kind extends SerializedStep["kind"]>(
+  step: SerializedStep,
+  kind: Kind,
+): step is SerializedStep<Kind> {
+  return step.kind === kind;
+}
+
+/**
+ * Static steps share the same physical kind, but they behave differently
+ * depending on their content variant. This helper names those variants once
+ * so the rest of the player can switch on a canonical descriptor instead of
+ * repeating `step.kind` plus `content.variant` checks.
+ */
+function describeStaticStep(step: SerializedStep<"static">): PlayerStepDescriptor {
+  const content = step.content;
+
+  switch (content.variant) {
+    case "grammarExample":
+      return { content, kind: "staticGrammarExample", step };
+    case "grammarRule":
+      return { content, kind: "staticGrammarRule", step };
+    case "storyIntro":
+      return { content, kind: "storyIntro", step };
+    case "storyOutcome":
+      return { content, kind: "storyOutcome", step };
+    case "text":
+      return { content, kind: "staticText", step };
+    default:
+      return { content, kind: "staticText", step };
+  }
+}
+
+/**
+ * Investigation steps also share one physical kind while representing three
+ * distinct phases of the investigation flow. A canonical descriptor lets the
+ * reducer, shell, and renderers talk about those phases with one vocabulary.
+ */
+function describeInvestigationStep(step: SerializedStep<"investigation">): PlayerStepDescriptor {
+  const content = step.content;
+
+  switch (content.variant) {
+    case "action":
+      return { content, kind: "investigationAction", step };
+    case "call":
+      return { content, kind: "investigationCall", step };
+    case "problem":
+      return { content, kind: "investigationProblem", step };
+    default:
+      return { content, kind: "investigationProblem", step };
+  }
+}
+
+/**
+ * Returns the canonical player step descriptor for a serialized step.
+ *
+ * This exists so the player package can classify steps once and reuse that
+ * meaning everywhere else, instead of rebuilding the same `kind` and `variant`
+ * decisions in each UI and reducer file.
+ */
+export function describePlayerStep(
+  step: SerializedStep | null | undefined,
+): PlayerStepDescriptor | null {
+  if (!step) {
+    return null;
+  }
+
+  if (hasStepKind(step, "fillBlank")) {
+    return { content: step.content, kind: "fillBlank", step };
+  }
+
+  if (hasStepKind(step, "investigation")) {
+    return describeInvestigationStep(step);
+  }
+
+  if (hasStepKind(step, "listening")) {
+    return { content: step.content, kind: "listening", step };
+  }
+
+  if (hasStepKind(step, "matchColumns")) {
+    return { content: step.content, kind: "matchColumns", step };
+  }
+
+  if (hasStepKind(step, "multipleChoice")) {
+    return { content: step.content, kind: "multipleChoice", step };
+  }
+
+  if (hasStepKind(step, "reading")) {
+    return { content: step.content, kind: "reading", step };
+  }
+
+  if (hasStepKind(step, "selectImage")) {
+    return { content: step.content, kind: "selectImage", step };
+  }
+
+  if (hasStepKind(step, "sortOrder")) {
+    return { content: step.content, kind: "sortOrder", step };
+  }
+
+  if (hasStepKind(step, "static")) {
+    return describeStaticStep(step);
+  }
+
+  if (hasStepKind(step, "story")) {
+    return { content: step.content, kind: "storyDecision", step };
+  }
+
+  if (hasStepKind(step, "translation")) {
+    return { content: step.content, kind: "translation", step };
+  }
+
+  if (hasStepKind(step, "visual")) {
+    return { content: step.content, kind: "visual", step };
+  }
+
+  if (hasStepKind(step, "vocabulary")) {
+    return { content: step.content, kind: "vocabulary", step };
+  }
+
+  return null;
+}
+
+/**
+ * Story intro and outcome screens are the only static variants that replace
+ * side-navigation with a primary action button. Keeping that distinction here
+ * prevents the rest of the package from repeating story-specific checks.
+ */
+export function getStoryStaticVariant(
+  step: SerializedStep | null | undefined,
+): StoryStaticVariant | null {
+  const descriptor = describePlayerStep(step);
+
+  if (descriptor?.kind === "storyIntro") {
+    return "storyIntro";
+  }
+
+  if (descriptor?.kind === "storyOutcome") {
+    return "storyOutcome";
+  }
+
+  return null;
+}
+
+/**
+ * Investigation variants drive special reducer transitions, sticky-header
+ * recall, and button labeling. This helper exposes the current investigation
+ * phase without making each caller know how investigation content is shaped.
+ */
+export function getInvestigationVariant(
+  step: SerializedStep | null | undefined,
+): InvestigationStepContent["variant"] | null {
+  const descriptor = describePlayerStep(step);
+
+  if (descriptor?.kind === "investigationAction") {
+    return "action";
+  }
+
+  if (descriptor?.kind === "investigationCall") {
+    return "call";
+  }
+
+  if (descriptor?.kind === "investigationProblem") {
+    return "problem";
+  }
+
+  return null;
+}
+
+/**
+ * Only a subset of steps participate in side-navigation. Centralizing that
+ * rule keeps navigation, layout, and keyboard handling aligned as new step
+ * variants are added later.
+ */
+export function usesStaticNavigation(descriptor: PlayerStepDescriptor | null): boolean {
+  if (!descriptor) {
+    return false;
+  }
+
+  return (
+    descriptor.kind === "staticText" ||
+    descriptor.kind === "staticGrammarExample" ||
+    descriptor.kind === "staticGrammarRule" ||
+    descriptor.kind === "visual" ||
+    descriptor.kind === "vocabulary"
+  );
+}
+
+/**
+ * Some steps keep feedback inline, while others swap to a dedicated feedback
+ * screen. This helper gives the screen model one place to ask that question.
+ */
+export function usesFeedbackScreen(descriptor: PlayerStepDescriptor | null): boolean {
+  if (!descriptor) {
+    return false;
+  }
+
+  return (
+    descriptor.kind === "investigationCall" ||
+    descriptor.kind === "listening" ||
+    descriptor.kind === "multipleChoice" ||
+    descriptor.kind === "reading" ||
+    descriptor.kind === "storyDecision" ||
+    descriptor.kind === "translation"
+  );
+}

--- a/packages/player/src/player-step.ts
+++ b/packages/player/src/player-step.ts
@@ -1,6 +1,7 @@
 import {
   type InvestigationStepContent,
   type StoryStaticVariant,
+  parseStepContent,
 } from "@zoonk/core/steps/contract/content";
 import { type SerializedStep } from "./prepare-activity-data";
 
@@ -69,6 +70,25 @@ export type PlayerStepDescriptor =
   | StepDescriptorBase<"visual", "visual">
   | StepDescriptorBase<"vocabulary", "vocabulary">;
 
+export type PlayerStepKind = PlayerStepDescriptor["kind"];
+
+const IDENTITY_PLAYER_STEP_KINDS = [
+  "fillBlank",
+  "listening",
+  "matchColumns",
+  "multipleChoice",
+  "reading",
+  "selectImage",
+  "sortOrder",
+  "translation",
+  "visual",
+  "vocabulary",
+] as const satisfies readonly PlayerStepKind[];
+
+const IDENTITY_PLAYER_STEP_KIND_SET: ReadonlySet<string> = new Set(IDENTITY_PLAYER_STEP_KINDS);
+
+type IdentityPlayerStepKind = (typeof IDENTITY_PLAYER_STEP_KINDS)[number];
+
 /**
  * `SerializedStep` loses some of its `kind` to `content` correlation once it
  * moves through arrays and reducer state. This guard restores that link so the
@@ -87,22 +107,20 @@ function hasStepKind<Kind extends SerializedStep["kind"]>(
  * so the rest of the player can switch on a canonical descriptor instead of
  * repeating `step.kind` plus `content.variant` checks.
  */
-function describeStaticStep(step: SerializedStep<"static">): PlayerStepDescriptor {
-  const content = step.content;
-
+function getStaticStepKind(content: SerializedStep<"static">["content"]): PlayerStepKind {
   switch (content.variant) {
     case "grammarExample":
-      return { content, kind: "staticGrammarExample", step };
+      return "staticGrammarExample";
     case "grammarRule":
-      return { content, kind: "staticGrammarRule", step };
+      return "staticGrammarRule";
     case "storyIntro":
-      return { content, kind: "storyIntro", step };
+      return "storyIntro";
     case "storyOutcome":
-      return { content, kind: "storyOutcome", step };
+      return "storyOutcome";
     case "text":
-      return { content, kind: "staticText", step };
+      return "staticText";
     default:
-      return { content, kind: "staticText", step };
+      return "staticText";
   }
 }
 
@@ -111,19 +129,96 @@ function describeStaticStep(step: SerializedStep<"static">): PlayerStepDescripto
  * distinct phases of the investigation flow. A canonical descriptor lets the
  * reducer, shell, and renderers talk about those phases with one vocabulary.
  */
+function getInvestigationStepKind(
+  content: SerializedStep<"investigation">["content"],
+): PlayerStepKind {
+  switch (content.variant) {
+    case "action":
+      return "investigationAction";
+    case "call":
+      return "investigationCall";
+    case "problem":
+      return "investigationProblem";
+    default:
+      return "investigationProblem";
+  }
+}
+
+/**
+ * Most raw server step kinds already match the canonical player step kind.
+ * This helper isolates that identity mapping so parsePlayerStepKind only
+ * needs to special-case the variants that truly diverge (`static`,
+ * `investigation`, and `story`).
+ */
+function isIdentityPlayerStepKind(kind: string): kind is IdentityPlayerStepKind {
+  return IDENTITY_PLAYER_STEP_KIND_SET.has(kind);
+}
+
+function describeStaticStep(step: SerializedStep<"static">): PlayerStepDescriptor {
+  const content = step.content;
+
+  if (content.variant === "grammarExample") {
+    return { content, kind: "staticGrammarExample", step };
+  }
+
+  if (content.variant === "grammarRule") {
+    return { content, kind: "staticGrammarRule", step };
+  }
+
+  if (content.variant === "storyIntro") {
+    return { content, kind: "storyIntro", step };
+  }
+
+  if (content.variant === "storyOutcome") {
+    return { content, kind: "storyOutcome", step };
+  }
+
+  return { content, kind: "staticText", step };
+}
+
 function describeInvestigationStep(step: SerializedStep<"investigation">): PlayerStepDescriptor {
   const content = step.content;
 
-  switch (content.variant) {
-    case "action":
-      return { content, kind: "investigationAction", step };
-    case "call":
-      return { content, kind: "investigationCall", step };
-    case "problem":
-      return { content, kind: "investigationProblem", step };
-    default:
-      return { content, kind: "investigationProblem", step };
+  if (content.variant === "action") {
+    return { content, kind: "investigationAction", step };
   }
+
+  if (content.variant === "call") {
+    return { content, kind: "investigationCall", step };
+  }
+
+  return { content, kind: "investigationProblem", step };
+}
+
+/**
+ * Some server-side callers only have raw `{ kind, content }` data instead of a
+ * fully typed `SerializedStep`. This parser keeps those callers on the same
+ * canonical step-kind vocabulary as the client descriptor layer.
+ */
+export function parsePlayerStepKind(
+  step: { content: unknown; kind: string } | null | undefined,
+): PlayerStepKind | null {
+  if (!step) {
+    return null;
+  }
+
+  if (step.kind === "investigation") {
+    return getInvestigationStepKind(parseStepContent("investigation", step.content));
+  }
+
+  if (step.kind === "static") {
+    return getStaticStepKind(parseStepContent("static", step.content));
+  }
+
+  if (step.kind === "story") {
+    return "storyDecision";
+  }
+
+  if (isIdentityPlayerStepKind(step.kind)) {
+    return step.kind;
+  }
+
+  return null;
 }
 
 /**
@@ -239,42 +334,4 @@ export function getInvestigationVariant(
   }
 
   return null;
-}
-
-/**
- * Only a subset of steps participate in side-navigation. Centralizing that
- * rule keeps navigation, layout, and keyboard handling aligned as new step
- * variants are added later.
- */
-export function usesStaticNavigation(descriptor: PlayerStepDescriptor | null): boolean {
-  if (!descriptor) {
-    return false;
-  }
-
-  return (
-    descriptor.kind === "staticText" ||
-    descriptor.kind === "staticGrammarExample" ||
-    descriptor.kind === "staticGrammarRule" ||
-    descriptor.kind === "visual" ||
-    descriptor.kind === "vocabulary"
-  );
-}
-
-/**
- * Some steps keep feedback inline, while others swap to a dedicated feedback
- * screen. This helper gives the screen model one place to ask that question.
- */
-export function usesFeedbackScreen(descriptor: PlayerStepDescriptor | null): boolean {
-  if (!descriptor) {
-    return false;
-  }
-
-  return (
-    descriptor.kind === "investigationCall" ||
-    descriptor.kind === "listening" ||
-    descriptor.kind === "multipleChoice" ||
-    descriptor.kind === "reading" ||
-    descriptor.kind === "storyDecision" ||
-    descriptor.kind === "translation"
-  );
 }

--- a/packages/player/src/step-navigation.ts
+++ b/packages/player/src/step-navigation.ts
@@ -1,4 +1,5 @@
-import { describePlayerStep, usesStaticNavigation } from "./player-step";
+import { describePlayerStep } from "./player-step";
+import { usesStaticNavigation } from "./player-step-behavior";
 import { type SerializedStep } from "./prepare-activity-data";
 
 /**

--- a/packages/player/src/step-navigation.ts
+++ b/packages/player/src/step-navigation.ts
@@ -1,18 +1,20 @@
+import { describePlayerStep, usesStaticNavigation } from "./player-step";
 import { type SerializedStep } from "./prepare-activity-data";
-import { isStoryStaticVariant } from "./story";
 
+/**
+ * Navigation chrome, layout, and keyboard shortcuts all need the same answer
+ * to "does this step behave like a navigable static screen?" Routing that
+ * question through the canonical step descriptor keeps those behaviors aligned.
+ */
 export function isStaticNavigationStep(step: SerializedStep | undefined): boolean {
-  if (!step) {
-    return false;
-  }
-
-  if (isStoryStaticVariant(step)) {
-    return false;
-  }
-
-  return step.kind === "static" || step.kind === "visual" || step.kind === "vocabulary";
+  return usesStaticNavigation(describePlayerStep(step));
 }
 
+/**
+ * Previous-step navigation is only available when both the current step and
+ * the previous step participate in static navigation. This prevents arrow-key
+ * backtracking into interactive steps with incompatible affordances.
+ */
 export function canNavigatePrev(steps: SerializedStep[], currentStepIndex: number): boolean {
   return (
     isStaticNavigationStep(steps[currentStepIndex]) &&

--- a/packages/player/src/story.ts
+++ b/packages/player/src/story.ts
@@ -1,37 +1,3 @@
-import { type StoryStaticVariant, parseStepContent } from "@zoonk/core/steps/contract/content";
-import { type SerializedStep } from "./prepare-activity-data";
-
-/**
- * Returns the story-specific static variant ("storyIntro" or "storyOutcome")
- * of a step, or null if the step is not a story static screen.
- *
- * Shared by `isStoryStaticVariant` (boolean gate for reducer/navigation)
- * and `getStoryStaticVariant` (selector that lifts this to PlayerState level).
- */
-export function getStepStoryVariant(step: SerializedStep | undefined): StoryStaticVariant | null {
-  if (!step || step.kind !== "static") {
-    return null;
-  }
-
-  const content = parseStepContent("static", step.content);
-
-  if (content.variant === "storyIntro" || content.variant === "storyOutcome") {
-    return content.variant;
-  }
-
-  return null;
-}
-
-/**
- * Checks whether a step is a story-specific static variant (storyIntro
- * or storyOutcome). These steps use action buttons for forward-only
- * navigation instead of arrow keys, and need special handling in the
- * reducer and navigation guards.
- */
-export function isStoryStaticVariant(step: SerializedStep): boolean {
-  return getStepStoryVariant(step) !== null;
-}
-
 /**
  * Shared threshold values for story metric feedback.
  *

--- a/packages/player/src/use-player-actions.test.tsx
+++ b/packages/player/src/use-player-actions.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { type PlayerState } from "./player-reducer";
+import { type SerializedStep } from "./prepare-activity-data";
+import { usePlayerActions } from "./use-player-actions";
+
+function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
+  return {
+    content: { text: "Hello", title: "Intro", variant: "text" as const },
+    fillBlankOptions: [],
+    id: "step-1",
+    kind: "static",
+    matchColumnsRightItems: [],
+    position: 0,
+    sentence: null,
+    sentenceWordOptions: [],
+    sortOrderItems: [],
+    translationOptions: [],
+    vocabularyOptions: [],
+    word: null,
+    wordBankOptions: [],
+    ...overrides,
+  };
+}
+
+function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
+  return {
+    activityId: "activity-1",
+    completion: null,
+    currentStepIndex: 0,
+    investigationLoop: null,
+    phase: "playing",
+    results: {},
+    selectedAnswers: {},
+    startedAt: 1000,
+    stepStartedAt: 1000,
+    stepTimings: {},
+    steps: [buildStep()],
+    totalBrainPower: 0,
+    ...overrides,
+  };
+}
+
+describe(usePlayerActions, () => {
+  test("check dispatches the investigation problem transition without a stored answer", () => {
+    const dispatch = vi.fn();
+    const onComplete = vi.fn();
+    const state = buildState({
+      steps: [
+        buildStep({
+          content: { scenario: "A mystery occurred.", variant: "problem" as const },
+          kind: "investigation",
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() => usePlayerActions(state, dispatch, onComplete, false));
+
+    act(() => {
+      result.current.check();
+    });
+
+    expect(dispatch).toHaveBeenCalledWith({
+      result: { correctAnswer: null, feedback: null, isCorrect: true },
+      stepId: "step-1",
+      type: "CHECK_ANSWER",
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  test("check still no-ops for unanswered interactive steps", () => {
+    const dispatch = vi.fn();
+    const onComplete = vi.fn();
+    const state = buildState({
+      steps: [
+        buildStep({
+          content: {
+            kind: "core" as const,
+            options: [{ feedback: "Correct", isCorrect: true, text: "A" }],
+            question: "Choose",
+          },
+          kind: "multipleChoice",
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() => usePlayerActions(state, dispatch, onComplete, false));
+
+    act(() => {
+      result.current.check();
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/player/src/use-player-actions.ts
+++ b/packages/player/src/use-player-actions.ts
@@ -10,7 +10,7 @@ import {
   type SelectedAnswer,
   type playerReducer,
 } from "./player-reducer";
-import { describePlayerStep } from "./player-step";
+import { getPlayerCheckBehavior } from "./player-step-behavior";
 
 export type PlayerActions = {
   check: () => void;
@@ -62,7 +62,7 @@ export function usePlayerActions(
       return;
     }
 
-    if (describePlayerStep(currentStep)?.kind === "investigationProblem") {
+    if (getPlayerCheckBehavior(currentStep) === "investigationProblem") {
       dispatchTransition({
         result: READ_ONLY_CHECK_RESULT.result,
         stepId: currentStep.id,

--- a/packages/player/src/use-player-actions.ts
+++ b/packages/player/src/use-player-actions.ts
@@ -10,6 +10,7 @@ import {
   type SelectedAnswer,
   type playerReducer,
 } from "./player-reducer";
+import { describePlayerStep } from "./player-step";
 
 export type PlayerActions = {
   check: () => void;
@@ -19,6 +20,10 @@ export type PlayerActions = {
   restart: () => void;
   selectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
 };
+
+const READ_ONLY_CHECK_RESULT = {
+  result: { correctAnswer: null, feedback: null, isCorrect: true },
+} as const;
 
 export function usePlayerActions(
   state: PlayerState,
@@ -54,6 +59,15 @@ export function usePlayerActions(
 
   const check = useCallback(() => {
     if (!currentStep) {
+      return;
+    }
+
+    if (describePlayerStep(currentStep)?.kind === "investigationProblem") {
+      dispatchTransition({
+        result: READ_ONLY_CHECK_RESULT.result,
+        stepId: currentStep.id,
+        type: "CHECK_ANSWER",
+      });
       return;
     }
 

--- a/packages/player/src/use-player-keyboard.test.ts
+++ b/packages/player/src/use-player-keyboard.test.ts
@@ -1,15 +1,17 @@
 // @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { type PlayerPhase } from "./player-reducer";
+import { type PlayerKeyboardModel } from "./player-screen";
 import { usePlayerKeyboard } from "./use-player-keyboard";
 
 function buildOptions(overrides: Partial<Parameters<typeof usePlayerKeyboard>[0]> = {}) {
   return {
-    canNavigatePrev: false,
-    hasAnswer: false,
-    isInvestigationScore: false,
-    isStaticStep: false,
+    keyboard: {
+      canRestart: false,
+      enterAction: null,
+      leftAction: null,
+      rightAction: null,
+    } as PlayerKeyboardModel,
     onCheck: vi.fn(),
     onContinue: vi.fn(),
     onEscape: vi.fn(),
@@ -17,8 +19,6 @@ function buildOptions(overrides: Partial<Parameters<typeof usePlayerKeyboard>[0]
     onNavigatePrev: vi.fn(),
     onNext: null as (() => void) | null,
     onRestart: vi.fn(),
-    phase: "playing" as PlayerPhase,
-    storyStaticVariant: null as Parameters<typeof usePlayerKeyboard>[0]["storyStaticVariant"],
     ...overrides,
   };
 }
@@ -34,8 +34,15 @@ describe(usePlayerKeyboard, () => {
   });
 
   describe("Enter key", () => {
-    test("calls onCheck when playing and hasAnswer", () => {
-      const opts = buildOptions({ hasAnswer: true, phase: "playing" });
+    test("calls onCheck when the screen model exposes a check action", () => {
+      const opts = buildOptions({
+        keyboard: {
+          canRestart: false,
+          enterAction: "check",
+          leftAction: null,
+          rightAction: null,
+        },
+      });
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter");
@@ -43,8 +50,15 @@ describe(usePlayerKeyboard, () => {
       expect(opts.onCheck).toHaveBeenCalledOnce();
     });
 
-    test("calls onContinue when feedback", () => {
-      const opts = buildOptions({ phase: "feedback" });
+    test("calls onContinue when the screen model exposes a continue action", () => {
+      const opts = buildOptions({
+        keyboard: {
+          canRestart: false,
+          enterAction: "continue",
+          leftAction: null,
+          rightAction: null,
+        },
+      });
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter");
@@ -52,8 +66,8 @@ describe(usePlayerKeyboard, () => {
       expect(opts.onContinue).toHaveBeenCalledOnce();
     });
 
-    test("no-op when playing and no answer", () => {
-      const opts = buildOptions({ hasAnswer: false, phase: "playing" });
+    test("no-op when Enter has no mapped action", () => {
+      const opts = buildOptions();
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter");
@@ -62,9 +76,17 @@ describe(usePlayerKeyboard, () => {
       expect(opts.onContinue).not.toHaveBeenCalled();
     });
 
-    test("calls onNext when completed and onNext is provided", () => {
+    test("calls onNext when completion Enter action prefers next", () => {
       const onNext = vi.fn();
-      const opts = buildOptions({ onNext, phase: "completed" });
+      const opts = buildOptions({
+        keyboard: {
+          canRestart: true,
+          enterAction: "nextOrEscape",
+          leftAction: null,
+          rightAction: null,
+        },
+        onNext,
+      });
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter");
@@ -73,8 +95,16 @@ describe(usePlayerKeyboard, () => {
       expect(opts.onEscape).not.toHaveBeenCalled();
     });
 
-    test("calls onEscape when completed and onNext is null", () => {
-      const opts = buildOptions({ onNext: null, phase: "completed" });
+    test("calls onEscape when completion Enter action has no next callback", () => {
+      const opts = buildOptions({
+        keyboard: {
+          canRestart: true,
+          enterAction: "nextOrEscape",
+          leftAction: null,
+          rightAction: null,
+        },
+        onNext: null,
+      });
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter");
@@ -85,30 +115,16 @@ describe(usePlayerKeyboard, () => {
     });
   });
 
-  describe("Enter key — story static variants", () => {
-    test("calls onNavigateNext on story intro", () => {
-      const opts = buildOptions({ phase: "playing", storyStaticVariant: "storyIntro" });
-      renderHook(() => usePlayerKeyboard(opts));
-
-      fireKey("Enter");
-
-      expect(opts.onNavigateNext).toHaveBeenCalledOnce();
-      expect(opts.onCheck).not.toHaveBeenCalled();
-    });
-
-    test("calls onNavigateNext on story outcome", () => {
-      const opts = buildOptions({ phase: "playing", storyStaticVariant: "storyOutcome" });
-      renderHook(() => usePlayerKeyboard(opts));
-
-      fireKey("Enter");
-
-      expect(opts.onNavigateNext).toHaveBeenCalledOnce();
-    });
-  });
-
-  describe("Arrow keys", () => {
-    test("ArrowRight calls onNavigateNext when playing and static step", () => {
-      const opts = buildOptions({ isStaticStep: true, phase: "playing" });
+  describe("Navigation keys", () => {
+    test("ArrowRight calls onNavigateNext when the screen model enables it", () => {
+      const opts = buildOptions({
+        keyboard: {
+          canRestart: false,
+          enterAction: null,
+          leftAction: null,
+          rightAction: "navigateNext",
+        },
+      });
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("ArrowRight");
@@ -116,8 +132,15 @@ describe(usePlayerKeyboard, () => {
       expect(opts.onNavigateNext).toHaveBeenCalledOnce();
     });
 
-    test("ArrowLeft calls onNavigatePrev when playing and static step", () => {
-      const opts = buildOptions({ canNavigatePrev: true, isStaticStep: true, phase: "playing" });
+    test("ArrowLeft calls onNavigatePrev when the screen model enables it", () => {
+      const opts = buildOptions({
+        keyboard: {
+          canRestart: false,
+          enterAction: null,
+          leftAction: "navigatePrev",
+          rightAction: null,
+        },
+      });
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("ArrowLeft");
@@ -125,8 +148,8 @@ describe(usePlayerKeyboard, () => {
       expect(opts.onNavigatePrev).toHaveBeenCalledOnce();
     });
 
-    test("ArrowLeft no-ops when previous step is not navigable", () => {
-      const opts = buildOptions({ canNavigatePrev: false, isStaticStep: true, phase: "playing" });
+    test("ArrowLeft no-ops when no previous action is mapped", () => {
+      const opts = buildOptions();
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("ArrowLeft");
@@ -134,41 +157,19 @@ describe(usePlayerKeyboard, () => {
       expect(opts.onNavigatePrev).not.toHaveBeenCalled();
     });
 
-    test("no-op for non-static steps", () => {
-      const opts = buildOptions({ isStaticStep: false, phase: "playing" });
+    test("ArrowRight no-ops when no next action is mapped", () => {
+      const opts = buildOptions();
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("ArrowRight");
-      fireKey("ArrowLeft");
 
       expect(opts.onNavigateNext).not.toHaveBeenCalled();
-      expect(opts.onNavigatePrev).not.toHaveBeenCalled();
-    });
-
-    test("no-op during feedback", () => {
-      const opts = buildOptions({ isStaticStep: true, phase: "feedback" });
-      renderHook(() => usePlayerKeyboard(opts));
-
-      fireKey("ArrowRight");
-      fireKey("ArrowLeft");
-
-      expect(opts.onNavigateNext).not.toHaveBeenCalled();
-      expect(opts.onNavigatePrev).not.toHaveBeenCalled();
     });
   });
 
   describe("Escape key", () => {
-    test("calls onEscape during playing phase", () => {
-      const opts = buildOptions({ phase: "playing" });
-      renderHook(() => usePlayerKeyboard(opts));
-
-      fireKey("Escape");
-
-      expect(opts.onEscape).toHaveBeenCalledOnce();
-    });
-
-    test("calls onEscape during feedback phase", () => {
-      const opts = buildOptions({ phase: "feedback" });
+    test("calls onEscape regardless of screen mode", () => {
+      const opts = buildOptions();
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Escape");
@@ -178,8 +179,15 @@ describe(usePlayerKeyboard, () => {
   });
 
   describe("R key", () => {
-    test("calls onRestart when completed", () => {
-      const opts = buildOptions({ phase: "completed" });
+    test("calls onRestart when restart is enabled", () => {
+      const opts = buildOptions({
+        keyboard: {
+          canRestart: true,
+          enterAction: "nextOrEscape",
+          leftAction: null,
+          rightAction: null,
+        },
+      });
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("r");
@@ -187,17 +195,8 @@ describe(usePlayerKeyboard, () => {
       expect(opts.onRestart).toHaveBeenCalledOnce();
     });
 
-    test("no-op when playing", () => {
-      const opts = buildOptions({ phase: "playing" });
-      renderHook(() => usePlayerKeyboard(opts));
-
-      fireKey("r");
-
-      expect(opts.onRestart).not.toHaveBeenCalled();
-    });
-
-    test("no-op when feedback", () => {
-      const opts = buildOptions({ phase: "feedback" });
+    test("no-op when restart is disabled", () => {
+      const opts = buildOptions();
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("r");
@@ -206,7 +205,14 @@ describe(usePlayerKeyboard, () => {
     });
 
     test("no-op when target is an input element", () => {
-      const opts = buildOptions({ phase: "completed" });
+      const opts = buildOptions({
+        keyboard: {
+          canRestart: true,
+          enterAction: "nextOrEscape",
+          leftAction: null,
+          rightAction: null,
+        },
+      });
       renderHook(() => usePlayerKeyboard(opts));
 
       const input = document.createElement("input");
@@ -222,7 +228,14 @@ describe(usePlayerKeyboard, () => {
 
   describe("modifier keys", () => {
     test("all keys are no-op with metaKey", () => {
-      const opts = buildOptions({ hasAnswer: true, isStaticStep: true, phase: "playing" });
+      const opts = buildOptions({
+        keyboard: {
+          canRestart: false,
+          enterAction: "check",
+          leftAction: null,
+          rightAction: "navigateNext",
+        },
+      });
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter", { metaKey: true });
@@ -233,7 +246,14 @@ describe(usePlayerKeyboard, () => {
     });
 
     test("all keys are no-op with ctrlKey", () => {
-      const opts = buildOptions({ hasAnswer: true, isStaticStep: true, phase: "playing" });
+      const opts = buildOptions({
+        keyboard: {
+          canRestart: false,
+          enterAction: "check",
+          leftAction: null,
+          rightAction: null,
+        },
+      });
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter", { ctrlKey: true });
@@ -242,7 +262,14 @@ describe(usePlayerKeyboard, () => {
     });
 
     test("all keys are no-op with shiftKey", () => {
-      const opts = buildOptions({ hasAnswer: true, isStaticStep: true, phase: "playing" });
+      const opts = buildOptions({
+        keyboard: {
+          canRestart: false,
+          enterAction: "check",
+          leftAction: null,
+          rightAction: null,
+        },
+      });
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter", { shiftKey: true });
@@ -251,7 +278,14 @@ describe(usePlayerKeyboard, () => {
     });
 
     test("all keys are no-op with altKey", () => {
-      const opts = buildOptions({ hasAnswer: true, isStaticStep: true, phase: "playing" });
+      const opts = buildOptions({
+        keyboard: {
+          canRestart: false,
+          enterAction: "check",
+          leftAction: null,
+          rightAction: null,
+        },
+      });
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter", { altKey: true });
@@ -261,7 +295,14 @@ describe(usePlayerKeyboard, () => {
   });
 
   test("cleans up listener on unmount", () => {
-    const opts = buildOptions({ hasAnswer: true, phase: "playing" });
+    const opts = buildOptions({
+      keyboard: {
+        canRestart: false,
+        enterAction: "check",
+        leftAction: null,
+        rightAction: null,
+      },
+    });
     const { unmount } = renderHook(() => usePlayerKeyboard(opts));
 
     unmount();

--- a/packages/player/src/use-player-keyboard.ts
+++ b/packages/player/src/use-player-keyboard.ts
@@ -1,13 +1,10 @@
 "use client";
 
-import { type StoryStaticVariant } from "@zoonk/core/steps/contract/content";
 import { useKeyboardCallback } from "@zoonk/ui/hooks/keyboard";
-import { type PlayerPhase } from "./player-reducer";
+import { type PlayerKeyboardModel } from "./player-screen";
 
 type PlayerKeyboardParams = {
-  canNavigatePrev: boolean;
-  hasAnswer: boolean;
-  isStaticStep: boolean;
+  keyboard: PlayerKeyboardModel;
   onCheck: () => void;
   onContinue: () => void;
   onEscape: () => void;
@@ -15,53 +12,57 @@ type PlayerKeyboardParams = {
   onNavigatePrev: () => void;
   onNext: (() => void) | null;
   onRestart: () => void;
-  phase: PlayerPhase;
-  storyStaticVariant: StoryStaticVariant | null;
 };
 
-function getEnterAction({
-  hasAnswer,
+/**
+ * Keyboard behavior is derived from the shared screen model. This helper maps
+ * those declarative action identifiers back to the live callbacks exposed by
+ * the provider so Enter and arrow keys stay aligned with the current screen.
+ */
+function runKeyboardAction({
+  action,
   onCheck,
   onContinue,
   onEscape,
   onNavigateNext,
+  onNavigatePrev,
   onNext,
-  phase,
-  storyStaticVariant,
-}: Pick<
+}: {
+  action:
+    | PlayerKeyboardModel["enterAction"]
+    | PlayerKeyboardModel["leftAction"]
+    | PlayerKeyboardModel["rightAction"];
+} & Pick<
   PlayerKeyboardParams,
-  | "hasAnswer"
-  | "onCheck"
-  | "onContinue"
-  | "onEscape"
-  | "onNavigateNext"
-  | "onNext"
-  | "phase"
-  | "storyStaticVariant"
->): (() => void) | null {
-  if (phase === "playing" && storyStaticVariant) {
-    return onNavigateNext;
+  "onCheck" | "onContinue" | "onEscape" | "onNavigateNext" | "onNavigatePrev" | "onNext"
+>) {
+  if (!action) {
+    return false;
   }
 
-  if (phase === "playing" && hasAnswer) {
-    return onCheck;
+  switch (action) {
+    case "check":
+      onCheck();
+      return;
+    case "continue":
+      onContinue();
+      return;
+    case "navigateNext":
+      onNavigateNext();
+      return;
+    case "navigatePrev":
+      onNavigatePrev();
+      return;
+    case "nextOrEscape":
+      (onNext ?? onEscape)();
+      return;
+    default:
+      return false;
   }
-
-  if (phase === "feedback") {
-    return onContinue;
-  }
-
-  if (phase === "completed") {
-    return onNext ?? onEscape;
-  }
-
-  return null;
 }
 
 export function usePlayerKeyboard({
-  canNavigatePrev,
-  hasAnswer,
-  isStaticStep,
+  keyboard,
   onCheck,
   onContinue,
   onEscape,
@@ -69,37 +70,29 @@ export function usePlayerKeyboard({
   onNavigatePrev,
   onNext,
   onRestart,
-  phase,
-  storyStaticVariant,
 }: PlayerKeyboardParams) {
   useKeyboardCallback(
     "Enter",
-    () => {
-      const action = getEnterAction({
-        hasAnswer,
+    () =>
+      runKeyboardAction({
+        action: keyboard.enterAction,
         onCheck,
         onContinue,
         onEscape,
         onNavigateNext,
+        onNavigatePrev,
         onNext,
-        phase,
-        storyStaticVariant,
-      });
-
-      if (!action) {
-        return false;
-      }
-      action();
-    },
+      }),
     { mode: "none" },
   );
 
   useKeyboardCallback(
     "r",
     () => {
-      if (phase !== "completed") {
+      if (!keyboard.canRestart) {
         return false;
       }
+
       onRestart();
     },
     { ignoreEditable: true, mode: "none" },
@@ -107,23 +100,31 @@ export function usePlayerKeyboard({
 
   useKeyboardCallback(
     "ArrowRight",
-    () => {
-      if (phase !== "playing" || !isStaticStep) {
-        return false;
-      }
-      onNavigateNext();
-    },
+    () =>
+      runKeyboardAction({
+        action: keyboard.rightAction,
+        onCheck,
+        onContinue,
+        onEscape,
+        onNavigateNext,
+        onNavigatePrev,
+        onNext,
+      }),
     { mode: "none" },
   );
 
   useKeyboardCallback(
     "ArrowLeft",
-    () => {
-      if (phase !== "playing" || !canNavigatePrev) {
-        return false;
-      }
-      onNavigatePrev();
-    },
+    () =>
+      runKeyboardAction({
+        action: keyboard.leftAction,
+        onCheck,
+        onContinue,
+        onEscape,
+        onNavigateNext,
+        onNavigatePrev,
+        onNext,
+      }),
     { mode: "none" },
   );
 

--- a/packages/player/src/validate-answers.test.ts
+++ b/packages/player/src/validate-answers.test.ts
@@ -429,4 +429,28 @@ describe(validateAnswers, () => {
     expect(results).toHaveLength(1);
     expect(results[0]?.isCorrect).toBe(false);
   });
+
+  test("skips malformed unanswered static steps instead of throwing", () => {
+    const steps = [{ content: { text: "Legacy static step" }, id: 16n, kind: "static" }];
+
+    const runValidation = () => validateAnswers(steps, {});
+
+    expect(runValidation).not.toThrow();
+    expect(runValidation()).toEqual([]);
+  });
+
+  test("skips malformed unanswered investigation steps instead of throwing", () => {
+    const steps = [
+      {
+        content: { scenario: "Legacy investigation step" },
+        id: 17n,
+        kind: "investigation",
+      },
+    ];
+
+    const runValidation = () => validateAnswers(steps, {});
+
+    expect(runValidation).not.toThrow();
+    expect(runValidation()).toEqual([]);
+  });
 });

--- a/packages/player/src/validate-answers.ts
+++ b/packages/player/src/validate-answers.ts
@@ -201,9 +201,14 @@ export function validateAnswers(
 ): ValidatedStepResult[] {
   return steps.flatMap((step) => {
     const answer = clientAnswers[String(step.id)];
+
+    if (!answer) {
+      return [];
+    }
+
     const behavior = getPlayerValidationBehavior(step);
 
-    if (!answer || !behavior || behavior === "none") {
+    if (!behavior || behavior === "none") {
       return [];
     }
 

--- a/packages/player/src/validate-answers.ts
+++ b/packages/player/src/validate-answers.ts
@@ -1,8 +1,4 @@
-import {
-  type SupportedStepKind,
-  isSupportedStepKind,
-  parseStepContent,
-} from "@zoonk/core/steps/contract/content";
+import { parseStepContent } from "@zoonk/core/steps/contract/content";
 import { buildAcceptedArrangeWordSequences } from "./arrange-words-answers";
 import {
   checkArrangeWordsAnswer,
@@ -16,6 +12,7 @@ import {
   checkTranslationAnswer,
 } from "./check-answer";
 import { type SelectedAnswer } from "./player-reducer";
+import { type PlayerValidationBehavior, getPlayerValidationBehavior } from "./player-step-behavior";
 
 /**
  * Step data for server-side validation. Translations live directly
@@ -182,22 +179,20 @@ function validateStory(step: StepData, answer: SelectedAnswer): ValidatedStepRes
 }
 
 const validators: Record<
-  SupportedStepKind,
+  PlayerValidationBehavior,
   (step: StepData, answer: SelectedAnswer) => ValidatedStepResult | null
 > = {
   fillBlank: validateFillBlank,
-  investigation: validateInvestigation,
+  investigationCall: validateInvestigation,
   listening: validateListening,
   matchColumns: validateMatchColumns,
   multipleChoice: validateMultipleChoice,
+  none: () => null,
   reading: validateReading,
   selectImage: validateSelectImage,
   sortOrder: validateSortOrder,
-  static: () => null,
   story: validateStory,
   translation: validateTranslation,
-  visual: () => null,
-  vocabulary: () => null,
 };
 
 export function validateAnswers(
@@ -206,12 +201,13 @@ export function validateAnswers(
 ): ValidatedStepResult[] {
   return steps.flatMap((step) => {
     const answer = clientAnswers[String(step.id)];
+    const behavior = getPlayerValidationBehavior(step);
 
-    if (!answer || !isSupportedStepKind(step.kind)) {
+    if (!answer || !behavior || behavior === "none") {
       return [];
     }
 
-    const validator = validators[step.kind];
+    const validator = validators[behavior];
     const result = validator(step, answer);
     return result ? [result] : [];
   });


### PR DESCRIPTION
## Summary
- add a canonical player step descriptor for kind and variant semantics
- add a canonical player screen model for shell, stage, and keyboard behavior
- remove the synthetic investigation problem answer and route button behavior through the shared screen model
- keep phase 3 behavior-module work on this same PR before it is marked ready

Closes #1218

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes player step semantics, behavior, and the screen model to simplify UI flow, align keyboard and bottom bar actions, and remove ad‑hoc state flags. Also guards validation to skip malformed unanswered steps and prevent crashes; addresses Linear #1218 and removes the synthetic investigation problem answer.

- **Refactors**
  - Added `player-step.ts`: `describePlayerStep`, `getInvestigationVariant`, `getStoryStaticVariant`, `parsePlayerStepKind`.
  - Added `player-step-behavior.ts`: canonical behavior for render, check, validation, layout/feedback (`getPlayerStepBehavior`, `getPlayerCheckBehavior`, `getPlayerValidationBehavior`, `usesStaticNavigation`, `usesFeedbackScreen`).
  - Added `player-screen.ts`: single screen model for bottom bar, keyboard map, metrics bar, stage static state, and story static variant.
  - Components now use `runtime.screen` and descriptors: `PlayerShell`, `StageContent`, `StaticStep`, `InvestigationStep`, `StepRenderer`, `StepActionButton`.
  - `StepRenderer` routes by `getPlayerStepBehavior`; `check-step`/`validate-answers` route by behavior maps.
  - Keyboard derives from the screen model; `use-player-keyboard` consumes `keyboard`.
  - Actions: `use-player-actions` treats investigation problem as a read‑only CHECK (no pre‑seeded answer).
  - Navigation: `step-navigation` uses `usesStaticNavigation(describePlayerStep(step))`.
  - Provider: computes `screen` via `getPlayerScreenModel(state)` and passes it through context.
  - Removed story/static helpers and scattered `parseStepContent` calls; selectors simplified. Tests added for step, behavior, screen, keyboard, actions.
  - Validation: guard before behavior lookup and skip malformed unanswered static/investigation steps.

- **Migration**
  - Use `describePlayerStep(step)` in UI instead of `parseStepContent`.
  - Read UI/controls from `runtime.screen` (e.g., `screen.bottomBar`, `screen.keyboard`, `screen.showMetricsBar`, `screen.stageIsStatic`).
  - Update keyboard usage: `usePlayerKeyboard({ keyboard, ...handlers })`.
  - Do not seed an investigation problem answer in initial state; the Start Investigation flow is handled by `check`.

<sup>Written for commit f75004061f99ac2e05cb71077eb5b7381921d307. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

