### PR TITLE
fix(player): preserve static step nav focus

### DIFF
--- a/apps/main/e2e/static-step.test.ts
+++ b/apps/main/e2e/static-step.test.ts
@@ -509,6 +509,47 @@ test.describe("Static Step Navigation", () => {
     await expect(page.getByRole("status")).toBeVisible();
     await expect(page.getByText(/completed/i)).toBeVisible();
   });
+
+  test("desktop next button keeps focus when navigating between static steps", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { url } = await createStaticActivity({
+      steps: [
+        {
+          content: {
+            text: `Focus 1 body ${uniqueId}`,
+            title: `Focus 1 ${uniqueId}`,
+            variant: "text",
+          },
+          position: 0,
+        },
+        {
+          content: {
+            text: `Focus 2 body ${uniqueId}`,
+            title: `Focus 2 ${uniqueId}`,
+            variant: "text",
+          },
+          position: 1,
+        },
+      ],
+    });
+
+    await page.setViewportSize({ height: 900, width: 1280 });
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const nav = page.getByRole("navigation", { name: /step navigation/i });
+    const nextButton = nav.getByRole("button", { name: /next step/i });
+
+    await nextButton.focus();
+    await expect(nextButton).toBeFocused();
+
+    await page.keyboard.press("Enter");
+
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Focus 2 ${uniqueId}`) }),
+    ).toBeVisible();
+    await expect(nextButton).toBeFocused();
+  });
 });
 
 test.describe("Completion Screen", () => {

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -66,21 +66,16 @@ export function StageContent() {
       />
     );
 
-    return (
-      <div
-        className="animate-in fade-in flex min-h-0 w-full min-w-0 flex-1 flex-col items-center duration-150 ease-out motion-reduce:animate-none"
-        key={`step-${state.currentStepIndex}`}
-      >
-        {showInlineAction ? (
-          <div className="my-auto flex w-full flex-col items-center gap-6">
-            {stepContent}
-            <StepActionButton className="hidden max-w-2xl lg:inline-flex" />
-          </div>
-        ) : (
-          stepContent
-        )}
-      </div>
-    );
+    if (showInlineAction) {
+      return (
+        <div className="my-auto flex w-full flex-col items-center gap-6">
+          {stepContent}
+          <StepActionButton className="hidden max-w-2xl lg:inline-flex" />
+        </div>
+      );
+    }
+
+    return stepContent;
   }
 
   return null;

--- a/packages/player/src/components/step-renderer.tsx
+++ b/packages/player/src/components/step-renderer.tsx
@@ -162,8 +162,17 @@ export function StepRenderer({
     return null;
   }
 
+  const stepContent = (
+    <div
+      className="animate-in fade-in flex min-h-0 w-full min-w-0 flex-1 flex-col items-center duration-150 ease-out motion-reduce:animate-none"
+      key={`step-${step.id}`}
+    >
+      {content}
+    </div>
+  );
+
   if (behavior.layout !== "navigable") {
-    return content;
+    return stepContent;
   }
 
   return (
@@ -173,7 +182,7 @@ export function StepRenderer({
         onNavigateNext={onNavigateNext}
         onNavigatePrev={onNavigatePrev}
       />
-      {content}
+      {stepContent}
     </NavigableStepLayout>
   );
 }


### PR DESCRIPTION
Preserve the desktop static-step navigation container across step changes so the arrow buttons stop flickering and keep focus after navigation.

Includes an E2E regression for focus retention on the `Next step` button.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves focus on the desktop static-step navigation and removes arrow flicker by keeping the nav container mounted across step changes. Adds an E2E test to ensure the Next step button keeps focus after navigating.

- **Bug Fixes**
  - Preserve nav container across steps by keying/animating only step content in `StepRenderer` and removing the keyed wrapper in `StageContent` to prevent remounts.
  - Add E2E regression to verify the desktop “Next step” button retains focus between static steps.

<sup>Written for commit 7910798018b96a94d072194ef70269336ebf3b40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

