### PR TITLE
refactor(player): unify player scenes and layout

### DIFF
--- a/apps/main/e2e/_utils/layout-contracts.ts
+++ b/apps/main/e2e/_utils/layout-contracts.ts
@@ -1,0 +1,96 @@
+import { type Locator, expect } from "@playwright/test";
+
+const WIDTH_ALIGNMENT_TOLERANCE = 2;
+const MINIMUM_VERTICAL_GAP = 8;
+
+/**
+ * Reads a locator's rendered box so layout assertions can compare what users
+ * actually see instead of coupling tests to class names or wrapper markup.
+ */
+async function getBoundingBox({ description, locator }: { description: string; locator: Locator }) {
+  const box = await locator.boundingBox();
+
+  if (!box) {
+    throw new Error(`Expected ${description} to have a bounding box`);
+  }
+
+  return box;
+}
+
+/**
+ * Returns an element's rendered width for cross-scene layout checks.
+ *
+ * These tests protect the player's shared width contract by comparing visible
+ * elements from different scene families rather than asserting exact pixels.
+ */
+export async function getRenderedWidth({
+  description,
+  locator,
+}: {
+  description: string;
+  locator: Locator;
+}) {
+  const box = await getBoundingBox({ description, locator });
+  return box.width;
+}
+
+/**
+ * Verifies that a visible element matches a previously recorded reference
+ * width within a small tolerance.
+ *
+ * The tolerance absorbs sub-pixel rounding while still failing if one scene
+ * drifts away from the shared player frame.
+ */
+export async function expectWidthToMatch({
+  description,
+  expectedDescription,
+  expectedWidth,
+  locator,
+  tolerance = WIDTH_ALIGNMENT_TOLERANCE,
+}: {
+  description: string;
+  expectedDescription: string;
+  expectedWidth: number;
+  locator: Locator;
+  tolerance?: number;
+}) {
+  const actualWidth = await getRenderedWidth({ description, locator });
+
+  expect(
+    Math.abs(actualWidth - expectedWidth),
+    `${description} should match ${expectedDescription}`,
+  ).toBeLessThanOrEqual(tolerance);
+}
+
+/**
+ * Ensures sticky chrome leaves visible breathing room above the next content
+ * block on small screens.
+ *
+ * This guards against mobile regressions where the shared header and the first
+ * question block visually collide after scene refactors.
+ */
+export async function expectMinimumVerticalGap({
+  lowerDescription,
+  lowerLocator,
+  minimumGap = MINIMUM_VERTICAL_GAP,
+  upperDescription,
+  upperLocator,
+}: {
+  lowerDescription: string;
+  lowerLocator: Locator;
+  minimumGap?: number;
+  upperDescription: string;
+  upperLocator: Locator;
+}) {
+  const [upperBox, lowerBox] = await Promise.all([
+    getBoundingBox({ description: upperDescription, locator: upperLocator }),
+    getBoundingBox({ description: lowerDescription, locator: lowerLocator }),
+  ]);
+
+  const gap = lowerBox.y - (upperBox.y + upperBox.height);
+
+  expect(
+    gap,
+    `${lowerDescription} should leave space below ${upperDescription}`,
+  ).toBeGreaterThanOrEqual(minimumGap);
+}

--- a/apps/main/e2e/investigation-step.test.ts
+++ b/apps/main/e2e/investigation-step.test.ts
@@ -5,6 +5,7 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { expectMinimumVerticalGap } from "./_utils/layout-contracts";
 import { expect, test } from "./fixtures";
 
 function buildInvestigationContent(uniqueId: string) {
@@ -203,6 +204,49 @@ test.describe("Investigation Action Step", () => {
     await expect(
       page.getByText(new RegExp(`Finding 0.*unusual pattern.*${uniqueId}`)),
     ).toBeVisible();
+  });
+
+  test("mobile choice screens keep breathing room below the sticky header", async ({ page }) => {
+    const { url } = await createInvestigationActivity();
+
+    await page.setViewportSize({ height: 844, width: 390 });
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const progressBar = page.getByRole("progressbar", { name: /activity progress/i });
+    await expect(progressBar).toBeVisible();
+
+    await page.getByRole("button", { name: /start investigation/i }).click();
+
+    const actionQuestion = page.getByRole("heading", {
+      name: /what do you want to investigate first/i,
+    });
+    await expect(actionQuestion).toBeVisible();
+
+    await expectMinimumVerticalGap({
+      lowerDescription: "investigation action question",
+      lowerLocator: actionQuestion,
+      upperDescription: "mobile activity progress bar",
+      upperLocator: progressBar,
+    });
+
+    await page.getByRole("radiogroup").getByRole("radio").first().click();
+    await page.getByRole("button", { name: /check/i }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await page.getByRole("radiogroup").getByRole("radio").first().click();
+    await page.getByRole("button", { name: /check/i }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    const callQuestion = page.getByRole("heading", { name: /what do you think happened/i });
+    await expect(callQuestion).toBeVisible();
+
+    await expectMinimumVerticalGap({
+      lowerDescription: "investigation call question",
+      lowerLocator: callQuestion,
+      upperDescription: "mobile activity progress bar",
+      upperLocator: progressBar,
+    });
   });
 });
 

--- a/apps/main/e2e/story-step.test.ts
+++ b/apps/main/e2e/story-step.test.ts
@@ -5,6 +5,7 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { expectWidthToMatch, getRenderedWidth } from "./_utils/layout-contracts";
 import { expect, test } from "./fixtures";
 
 function buildStoryContent(uniqueId: string) {
@@ -215,6 +216,56 @@ test.describe("Story Intro Screen", () => {
     await expect(
       page.getByText(new RegExp(`A crisis hits the factory floor ${uniqueId}`)),
     ).toBeVisible();
+  });
+
+  test("reuses the same mobile content width across intro, decision, and outcome", async ({
+    page,
+  }) => {
+    const { uniqueId, url } = await createStoryActivity();
+
+    await page.setViewportSize({ height: 844, width: 390 });
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+
+    const beginButton = page.getByRole("button", { name: /begin/i });
+    await expect(beginButton).toBeVisible();
+
+    const introActionWidth = await getRenderedWidth({
+      description: "story intro action button",
+      locator: beginButton,
+    });
+
+    await beginButton.click();
+
+    const answerOptions = page.getByRole("radiogroup", { name: /answer options/i });
+    await expect(answerOptions).toBeVisible();
+
+    const decisionWidth = await getRenderedWidth({
+      description: "story decision options",
+      locator: answerOptions,
+    });
+
+    await expectWidthToMatch({
+      description: "story decision options",
+      expectedDescription: "story intro action button",
+      expectedWidth: introActionWidth,
+      locator: answerOptions,
+    });
+
+    await page.getByRole("radio", { name: new RegExp(`Invest in training ${uniqueId}`) }).click();
+    await page.getByRole("button", { name: /check/i }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Great Manager ${uniqueId}`) }),
+    ).toBeVisible();
+
+    await expectWidthToMatch({
+      description: "story outcome action button",
+      expectedDescription: "story decision options",
+      expectedWidth: decisionWidth,
+      locator: page.getByRole("button", { name: /continue/i }),
+    });
   });
 });
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -68,13 +68,6 @@ msgctxt "xiSVL4"
 msgid "{color} Belt — Level {level}"
 msgstr "{color} Belt — Level {level}"
 
-#: ../../packages/player/src/components/choice-step-layout.tsx
-#: ../../packages/player/src/components/investigation-call-variant.tsx
-#: ../../packages/player/src/components/translation-step.tsx
-msgctxt "akd+cv"
-msgid "Answer options"
-msgstr "Answer options"
-
 #: ../../packages/player/src/components/completion-auth-branch.tsx
 msgctxt "9+Ddtu"
 msgid "Next"
@@ -311,6 +304,11 @@ msgstr "Next step"
 msgctxt "kXUK98"
 msgid "Step navigation"
 msgstr "Step navigation"
+
+#: ../../packages/player/src/components/player-choice-scene.tsx
+msgctxt "akd+cv"
+msgid "Answer options"
+msgstr "Answer options"
 
 #: ../../packages/player/src/components/player-header.tsx
 msgctxt "rbrahO"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -68,13 +68,6 @@ msgctxt "xiSVL4"
 msgid "{color} Belt — Level {level}"
 msgstr "Cinturón {color} — Nivel {level}"
 
-#: ../../packages/player/src/components/choice-step-layout.tsx
-#: ../../packages/player/src/components/investigation-call-variant.tsx
-#: ../../packages/player/src/components/translation-step.tsx
-msgctxt "akd+cv"
-msgid "Answer options"
-msgstr "Opciones de respuesta"
-
 #: ../../packages/player/src/components/completion-auth-branch.tsx
 msgctxt "9+Ddtu"
 msgid "Next"
@@ -311,6 +304,11 @@ msgstr "Siguiente paso"
 msgctxt "kXUK98"
 msgid "Step navigation"
 msgstr "Navegación de pasos"
+
+#: ../../packages/player/src/components/player-choice-scene.tsx
+msgctxt "akd+cv"
+msgid "Answer options"
+msgstr "Opciones de respuesta"
 
 #: ../../packages/player/src/components/player-header.tsx
 msgctxt "rbrahO"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -68,13 +68,6 @@ msgctxt "xiSVL4"
 msgid "{color} Belt — Level {level}"
 msgstr "Faixa {color} — Nível {level}"
 
-#: ../../packages/player/src/components/choice-step-layout.tsx
-#: ../../packages/player/src/components/investigation-call-variant.tsx
-#: ../../packages/player/src/components/translation-step.tsx
-msgctxt "akd+cv"
-msgid "Answer options"
-msgstr "Opções de resposta"
-
 #: ../../packages/player/src/components/completion-auth-branch.tsx
 msgctxt "9+Ddtu"
 msgid "Next"
@@ -311,6 +304,11 @@ msgstr "Próximo passo"
 msgctxt "kXUK98"
 msgid "Step navigation"
 msgstr "Navegação de etapas"
+
+#: ../../packages/player/src/components/player-choice-scene.tsx
+msgctxt "akd+cv"
+msgid "Answer options"
+msgstr "Opções de resposta"
 
 #: ../../packages/player/src/components/player-header.tsx
 msgctxt "rbrahO"

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -1,0 +1,48 @@
+# Player
+
+The player separates domain step kinds from UI scenes.
+
+Domain step kinds still matter for validation, scoring, and analytics. The UI
+layer maps those kinds into a smaller set of shared scene families so layout
+and interaction rules stay consistent as the player grows.
+
+## Scene Model
+
+The player shell thinks in a few broad scenes:
+
+- `read`
+- `choice`
+- `feedback`
+- `completion`
+
+Each scene family has shared primitives that own its layout and baseline
+typography. Step-specific components should mainly adapt data into those
+primitives instead of redefining the scene themselves.
+
+## Ownership
+
+As a rule:
+
+- shared scene primitives own layout, spacing, and baseline scene typography
+- step adapters own domain-specific content and data mapping
+- the screen model decides which scene the shell renders
+
+If a new screen needs a variation of an existing shared pattern, prefer adding
+a semantic variant to the shared primitive instead of introducing local
+one-off styling in the adapter.
+
+## Local Styling
+
+Local styling is still appropriate for content that is genuinely unique to a
+feature and not part of the shared scene language.
+
+Examples include:
+
+- vocabulary word display
+- grammar highlighting
+- metric pills
+- evidence drawer rows
+- visual-step content
+
+When in doubt, ask whether a style belongs to the shared player language or to
+content inside that language. Shared language belongs in the shared primitive.

--- a/packages/player/src/components/choice-step-layout.tsx
+++ b/packages/player/src/components/choice-step-layout.tsx
@@ -3,6 +3,7 @@
 import {
   PlayerChoiceScene,
   PlayerChoiceSceneContext,
+  PlayerChoiceSceneOptionText,
   PlayerChoiceSceneOptions,
   PlayerChoiceScenePrompt,
   PlayerChoiceSceneQuestion,
@@ -42,7 +43,7 @@ export function ChoiceStepLayout({
       <PlayerChoiceSceneOptions
         onSelect={onSelect}
         options={options.map((option, index) => ({
-          content: <span className="text-base leading-6">{option.text}</span>,
+          content: <PlayerChoiceSceneOptionText>{option.text}</PlayerChoiceSceneOptionText>,
           isDimmed: hasSelection && selectedIndex !== index,
           isSelected: selectedIndex === index,
           key: option.key,

--- a/packages/player/src/components/choice-step-layout.tsx
+++ b/packages/player/src/components/choice-step-layout.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useExtracted } from "next-intl";
-import { useOptionKeyboard } from "../use-option-keyboard";
-import { useReplaceName } from "../user-name-context";
-import { OptionCard } from "./option-card";
-import { ContextText, QuestionText } from "./question-text";
-import { InteractiveStepLayout } from "./step-layouts";
+import {
+  PlayerChoiceScene,
+  PlayerChoiceSceneContext,
+  PlayerChoiceSceneOptions,
+  PlayerChoiceScenePrompt,
+  PlayerChoiceSceneQuestion,
+} from "./player-choice-scene";
 
 /**
  * Shared layout for choice-based steps (multiple choice, story decisions).
@@ -27,38 +28,26 @@ export function ChoiceStepLayout({
   question?: string | null;
   selectedIndex: number | null;
 }) {
-  const t = useExtracted();
-  const replaceName = useReplaceName();
   const hasSelection = selectedIndex !== null;
 
-  useOptionKeyboard({
-    enabled: true,
-    onSelect,
-    optionCount: options.length,
-  });
-
   return (
-    <InteractiveStepLayout>
+    <PlayerChoiceScene>
       {(context || question) && (
-        <div className="flex flex-col gap-2 sm:gap-6">
-          {context && <ContextText>{replaceName(context)}</ContextText>}
-          {question && <QuestionText>{replaceName(question)}</QuestionText>}
-        </div>
+        <PlayerChoiceScenePrompt>
+          <PlayerChoiceSceneContext>{context}</PlayerChoiceSceneContext>
+          <PlayerChoiceSceneQuestion>{question}</PlayerChoiceSceneQuestion>
+        </PlayerChoiceScenePrompt>
       )}
 
-      <div aria-label={t("Answer options")} className="flex flex-col gap-3" role="radiogroup">
-        {options.map((option, index) => (
-          <OptionCard
-            index={index}
-            isDimmed={hasSelection && selectedIndex !== index}
-            isSelected={selectedIndex === index}
-            key={option.key}
-            onSelect={() => onSelect(index)}
-          >
-            <span className="text-base leading-6">{option.text}</span>
-          </OptionCard>
-        ))}
-      </div>
-    </InteractiveStepLayout>
+      <PlayerChoiceSceneOptions
+        onSelect={onSelect}
+        options={options.map((option, index) => ({
+          content: <span className="text-base leading-6">{option.text}</span>,
+          isDimmed: hasSelection && selectedIndex !== index,
+          isSelected: selectedIndex === index,
+          key: option.key,
+        }))}
+      />
+    </PlayerChoiceScene>
   );
 }

--- a/packages/player/src/components/completion-screen.tsx
+++ b/packages/player/src/components/completion-screen.tsx
@@ -6,6 +6,7 @@ import { useExtracted } from "next-intl";
 import { type CompletionResult } from "../completion-input-schema";
 import { type PlayerRoute, usePlayerMilestone, usePlayerViewer } from "../player-context";
 import { AuthBranch } from "./completion-auth-branch";
+import { PlayerSupportingText } from "./player-supporting-text";
 import { PlayerContentFrame } from "./step-layouts";
 
 /**
@@ -108,7 +109,7 @@ export function CompletionScreenContent({
           <p className="text-5xl font-bold tracking-tight tabular-nums">
             {completionResult.correctCount}/{totalCount}
           </p>
-          <p className="text-muted-foreground text-sm">{t("correct")}</p>
+          <PlayerSupportingText>{t("correct")}</PlayerSupportingText>
         </CompletionScore>
       ) : (
         <CompletionSignal />

--- a/packages/player/src/components/completion-screen.tsx
+++ b/packages/player/src/components/completion-screen.tsx
@@ -6,15 +6,17 @@ import { useExtracted } from "next-intl";
 import { type CompletionResult } from "../completion-input-schema";
 import { type PlayerRoute, usePlayerMilestone, usePlayerViewer } from "../player-context";
 import { AuthBranch } from "./completion-auth-branch";
+import { PlayerContentFrame } from "./step-layouts";
 
+/**
+ * Completion lives on the same centered frame as the rest of the player so
+ * score summaries and follow-up actions don't introduce another width system.
+ */
 function CompletionScreen({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <div
+    <PlayerContentFrame
       aria-live="polite"
-      className={cn(
-        "animate-in fade-in mx-auto my-auto flex w-full max-w-lg flex-col items-center gap-6 duration-200 ease-out motion-reduce:animate-none",
-        className,
-      )}
+      className={cn("my-auto flex flex-col items-center gap-6", className)}
       data-slot="completion-screen"
       role="status"
       {...props}
@@ -79,7 +81,7 @@ export function CompletionScreenContent({
 
   if (milestone.kind !== "activity") {
     return (
-      <CompletionScreen className="min-h-[60vh] max-w-sm justify-center gap-10 px-6 sm:gap-12">
+      <CompletionScreen className="min-h-[60vh] justify-center gap-10 sm:gap-12">
         <MilestoneHeading />
 
         <div className="flex w-full flex-col gap-3">

--- a/packages/player/src/components/feedback-screen.tsx
+++ b/packages/player/src/components/feedback-screen.tsx
@@ -9,6 +9,7 @@ import { CorrectAnswerBlock, IncorrectAnswerBlock } from "./feedback-answer-bloc
 import { InvestigationCallFeedbackContent } from "./investigation-call-feedback";
 import { PlayAudioButton } from "./play-audio-button";
 import { PlayerFeedbackScene, PlayerFeedbackSceneMessage } from "./player-feedback-scene";
+import { PlayerSupportingText } from "./player-supporting-text";
 import { RomanizationText } from "./romanization-text";
 import { StoryFeedbackContent } from "./story-feedback-content";
 
@@ -69,10 +70,10 @@ function StandardFeedbackContent({ result, step }: { result: StepResult; step?: 
     <PlayerFeedbackScene>
       <div className="flex flex-col gap-2">
         {questionText && (
-          <div className="text-muted-foreground text-sm">
-            <p>
+          <div className="flex flex-col gap-1">
+            <PlayerSupportingText>
               {t("Translate:")} <span className="text-foreground font-medium">{questionText}</span>
-            </p>
+            </PlayerSupportingText>
             <RomanizationText>{rom.translate}</RomanizationText>
           </div>
         )}
@@ -92,11 +93,7 @@ function StandardFeedbackContent({ result, step }: { result: StepResult; step?: 
 
       {audioUrl && <PlayAudioButton audioUrl={audioUrl} preload={false} variant="text" />}
 
-      {feedback && (
-        <PlayerFeedbackSceneMessage data-slot="feedback-message">
-          {feedback}
-        </PlayerFeedbackSceneMessage>
-      )}
+      {feedback && <PlayerFeedbackSceneMessage>{feedback}</PlayerFeedbackSceneMessage>}
     </PlayerFeedbackScene>
   );
 }

--- a/packages/player/src/components/feedback-screen.tsx
+++ b/packages/player/src/components/feedback-screen.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { type StepResult } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
@@ -9,33 +8,9 @@ import { getFeedbackRomanization } from "./_utils/feedback-romanization";
 import { CorrectAnswerBlock, IncorrectAnswerBlock } from "./feedback-answer-blocks";
 import { InvestigationCallFeedbackContent } from "./investigation-call-feedback";
 import { PlayAudioButton } from "./play-audio-button";
+import { PlayerFeedbackScene, PlayerFeedbackSceneMessage } from "./player-feedback-scene";
 import { RomanizationText } from "./romanization-text";
 import { StoryFeedbackContent } from "./story-feedback-content";
-
-function FeedbackScreen({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      aria-live="polite"
-      className={cn(
-        "animate-in fade-in slide-in-from-bottom-1 mx-auto my-auto flex w-full max-w-lg flex-col gap-6 duration-200 ease-out motion-reduce:animate-none",
-        className,
-      )}
-      data-slot="feedback-screen"
-      role="status"
-      {...props}
-    />
-  );
-}
-
-function FeedbackMessage({ className, ...props }: React.ComponentProps<"p">) {
-  return (
-    <p
-      className={cn("text-foreground max-w-md text-lg leading-relaxed", className)}
-      data-slot="feedback-message"
-      {...props}
-    />
-  );
-}
 
 function getArrangeWordsSelectedText(result: StepResult): string | null {
   if (result.answer?.kind === "reading" || result.answer?.kind === "listening") {
@@ -91,7 +66,7 @@ function StandardFeedbackContent({ result, step }: { result: StepResult; step?: 
   const audioUrl = getFeedbackAudioUrl(step);
 
   return (
-    <FeedbackScreen>
+    <PlayerFeedbackScene>
       <div className="flex flex-col gap-2">
         {questionText && (
           <div className="text-muted-foreground text-sm">
@@ -117,8 +92,12 @@ function StandardFeedbackContent({ result, step }: { result: StepResult; step?: 
 
       {audioUrl && <PlayAudioButton audioUrl={audioUrl} preload={false} variant="text" />}
 
-      {feedback && <FeedbackMessage>{feedback}</FeedbackMessage>}
-    </FeedbackScreen>
+      {feedback && (
+        <PlayerFeedbackSceneMessage data-slot="feedback-message">
+          {feedback}
+        </PlayerFeedbackSceneMessage>
+      )}
+    </PlayerFeedbackScene>
   );
 }
 

--- a/packages/player/src/components/investigation-action-variant.tsx
+++ b/packages/player/src/components/investigation-action-variant.tsx
@@ -10,10 +10,13 @@ import { getAvailableActions } from "../investigation";
 import { usePlayerRuntime } from "../player-context";
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
-import { useOptionKeyboard } from "../use-option-keyboard";
-import { OptionCard } from "./option-card";
-import { ContextText, QuestionText } from "./question-text";
-import { InteractiveStepLayout } from "./step-layouts";
+import {
+  PlayerChoiceScene,
+  PlayerChoiceSceneOptions,
+  PlayerChoiceScenePrompt,
+  PlayerChoiceSceneQuestion,
+} from "./player-choice-scene";
+import { PlayerReadScene, PlayerReadSceneBody } from "./player-read-scene";
 
 type ActionContent = Extract<InvestigationStepContent, { variant: "action" }>;
 
@@ -73,17 +76,17 @@ function ActionFeedback({
   const quality = useQualityLabel(action.quality);
 
   return (
-    <InteractiveStepLayout>
+    <PlayerReadScene>
       <p className={`text-lg font-semibold ${quality.className}`}>{quality.label}</p>
 
-      <ContextText>{action.finding}</ContextText>
+      <PlayerReadSceneBody>{action.finding}</PlayerReadSceneBody>
 
       {isLastExperiment && (
         <p className="text-muted-foreground text-sm">
           {t("Evidence complete — time to make your call.")}
         </p>
       )}
-    </InteractiveStepLayout>
+    </PlayerReadScene>
   );
 }
 
@@ -147,12 +150,6 @@ export function InvestigationActionVariant({
     });
   };
 
-  useOptionKeyboard({
-    enabled: !hasFeedback,
-    onSelect: handleSelect,
-    optionCount: availableActions.length,
-  });
-
   const selectedAction =
     selectedActionId === null
       ? null
@@ -168,22 +165,22 @@ export function InvestigationActionVariant({
   }
 
   return (
-    <InteractiveStepLayout>
-      <QuestionText>{questionText}</QuestionText>
+    <PlayerChoiceScene>
+      <PlayerChoiceScenePrompt>
+        <PlayerChoiceSceneQuestion>{questionText}</PlayerChoiceSceneQuestion>
+      </PlayerChoiceScenePrompt>
 
-      <div aria-label={questionText} className="flex flex-col gap-3" role="radiogroup">
-        {availableActions.map((action, index) => (
-          <OptionCard
-            index={index}
-            isDimmed={hasSelection && selectedActionId !== action.id}
-            isSelected={selectedActionId === action.id}
-            key={action.id}
-            onSelect={() => handleSelect(index)}
-          >
-            <span className="text-base leading-6">{action.label}</span>
-          </OptionCard>
-        ))}
-      </div>
-    </InteractiveStepLayout>
+      <PlayerChoiceSceneOptions
+        ariaLabel={questionText}
+        keyboardEnabled={!hasFeedback}
+        onSelect={handleSelect}
+        options={availableActions.map((action) => ({
+          content: <span className="text-base leading-6">{action.label}</span>,
+          isDimmed: hasSelection && selectedActionId !== action.id,
+          isSelected: selectedActionId === action.id,
+          key: action.id,
+        }))}
+      />
+    </PlayerChoiceScene>
   );
 }

--- a/packages/player/src/components/investigation-action-variant.tsx
+++ b/packages/player/src/components/investigation-action-variant.tsx
@@ -12,6 +12,7 @@ import { type SelectedAnswer, type StepResult } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
 import {
   PlayerChoiceScene,
+  PlayerChoiceSceneOptionText,
   PlayerChoiceSceneOptions,
   PlayerChoiceScenePrompt,
   PlayerChoiceSceneQuestion,
@@ -175,7 +176,7 @@ export function InvestigationActionVariant({
         keyboardEnabled={!hasFeedback}
         onSelect={handleSelect}
         options={availableActions.map((action) => ({
-          content: <span className="text-base leading-6">{action.label}</span>,
+          content: <PlayerChoiceSceneOptionText>{action.label}</PlayerChoiceSceneOptionText>,
           isDimmed: hasSelection && selectedActionId !== action.id,
           isSelected: selectedActionId === action.id,
           key: action.id,

--- a/packages/player/src/components/investigation-action-variant.tsx
+++ b/packages/player/src/components/investigation-action-variant.tsx
@@ -18,6 +18,7 @@ import {
   PlayerChoiceSceneQuestion,
 } from "./player-choice-scene";
 import { PlayerReadScene, PlayerReadSceneBody } from "./player-read-scene";
+import { PlayerSupportingText } from "./player-supporting-text";
 
 type ActionContent = Extract<InvestigationStepContent, { variant: "action" }>;
 
@@ -83,9 +84,9 @@ function ActionFeedback({
       <PlayerReadSceneBody>{action.finding}</PlayerReadSceneBody>
 
       {isLastExperiment && (
-        <p className="text-muted-foreground text-sm">
+        <PlayerSupportingText>
           {t("Evidence complete — time to make your call.")}
-        </p>
+        </PlayerSupportingText>
       )}
     </PlayerReadScene>
   );

--- a/packages/player/src/components/investigation-action-variant.tsx
+++ b/packages/player/src/components/investigation-action-variant.tsx
@@ -17,7 +17,12 @@ import {
   PlayerChoiceScenePrompt,
   PlayerChoiceSceneQuestion,
 } from "./player-choice-scene";
-import { PlayerReadScene, PlayerReadSceneBody } from "./player-read-scene";
+import {
+  PlayerReadScene,
+  PlayerReadSceneBody,
+  PlayerReadSceneTitle,
+  type PlayerReadSceneTitleTone,
+} from "./player-read-scene";
 import { PlayerSupportingText } from "./player-supporting-text";
 
 type ActionContent = Extract<InvestigationStepContent, { variant: "action" }>;
@@ -27,20 +32,20 @@ type ActionContent = Extract<InvestigationStepContent, { variant: "action" }>;
  * Shown as a quality indicator in the evidence feedback after checking.
  */
 function useQualityLabel(quality: InvestigationActionQuality): {
-  className: string;
   label: string;
+  tone: PlayerReadSceneTitleTone;
 } {
   const t = useExtracted();
 
   if (quality === "critical") {
-    return { className: "text-success", label: t("Strong lead") };
+    return { label: t("Strong lead"), tone: "success" };
   }
 
   if (quality === "useful") {
-    return { className: "text-foreground", label: t("Useful clue") };
+    return { label: t("Useful clue"), tone: "foreground" };
   }
 
-  return { className: "text-muted-foreground", label: t("Weak signal") };
+  return { label: t("Weak signal"), tone: "muted" };
 }
 
 /**
@@ -79,7 +84,7 @@ function ActionFeedback({
 
   return (
     <PlayerReadScene>
-      <p className={`text-lg font-semibold ${quality.className}`}>{quality.label}</p>
+      <PlayerReadSceneTitle tone={quality.tone}>{quality.label}</PlayerReadSceneTitle>
 
       <PlayerReadSceneBody>{action.finding}</PlayerReadSceneBody>
 

--- a/packages/player/src/components/investigation-call-feedback.tsx
+++ b/packages/player/src/components/investigation-call-feedback.tsx
@@ -3,6 +3,7 @@
 import { getInvestigationCallVerdict } from "../investigation-call-verdict";
 import { type StepResult } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
+import { PlayerFeedbackScene, PlayerFeedbackSceneMessage } from "./player-feedback-scene";
 import { type Verdict, VerdictLabel } from "./verdict-label";
 
 /** Maps investigation call accuracy to the shared UI verdict vocabulary. */
@@ -41,14 +42,10 @@ export function InvestigationCallFeedbackContent({
   const verdict = getCallVerdict({ result, step });
 
   return (
-    <div
-      aria-live="polite"
-      className="animate-in fade-in slide-in-from-bottom-1 mx-auto my-auto flex w-full max-w-lg flex-col gap-6 duration-200 ease-out motion-reduce:animate-none"
-      role="status"
-    >
+    <PlayerFeedbackScene>
       <VerdictLabel verdict={verdict} />
 
-      {feedback && <p className="text-foreground text-lg leading-relaxed">{feedback}</p>}
-    </div>
+      {feedback && <PlayerFeedbackSceneMessage>{feedback}</PlayerFeedbackSceneMessage>}
+    </PlayerFeedbackScene>
   );
 }

--- a/packages/player/src/components/investigation-call-variant.tsx
+++ b/packages/player/src/components/investigation-call-variant.tsx
@@ -21,10 +21,12 @@ import { getInvestigationStepByVariant } from "../investigation";
 import { usePlayerRuntime } from "../player-context";
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
-import { useOptionKeyboard } from "../use-option-keyboard";
-import { OptionCard } from "./option-card";
-import { QuestionText } from "./question-text";
-import { InteractiveStepLayout } from "./step-layouts";
+import {
+  PlayerChoiceScene,
+  PlayerChoiceSceneOptions,
+  PlayerChoiceScenePrompt,
+  PlayerChoiceSceneQuestion,
+} from "./player-choice-scene";
 
 type CallContent = Extract<InvestigationStepContent, { variant: "call" }>;
 
@@ -220,38 +222,31 @@ export function InvestigationCallVariant({
     });
   };
 
-  useOptionKeyboard({
-    enabled: !hasFeedback,
-    onSelect: handleSelect,
-    optionCount: explanations.length,
-  });
-
   return (
-    <InteractiveStepLayout>
+    <PlayerChoiceScene>
       <EvidenceDrawer evidence={evidence} />
 
-      <QuestionText>{t("What do you think happened?")}</QuestionText>
+      <PlayerChoiceScenePrompt>
+        <PlayerChoiceSceneQuestion>{t("What do you think happened?")}</PlayerChoiceSceneQuestion>
+      </PlayerChoiceScenePrompt>
 
-      <div aria-label={t("Answer options")} className="flex flex-col gap-3" role="radiogroup">
-        {explanations.map((explanation, index) => (
-          <OptionCard
-            disabled={hasFeedback}
-            index={index}
-            isDimmed={hasSelection && selectedId !== explanation.id}
-            isSelected={selectedId === explanation.id}
-            key={explanation.id}
-            onSelect={() => handleSelect(index)}
-            resultState={getResultState({
-              accuracy: explanation.accuracy,
-              hasFeedback,
-              id: explanation.id,
-              selectedId,
-            })}
-          >
-            <span className="text-base leading-6">{explanation.text}</span>
-          </OptionCard>
-        ))}
-      </div>
-    </InteractiveStepLayout>
+      <PlayerChoiceSceneOptions
+        keyboardEnabled={!hasFeedback}
+        onSelect={handleSelect}
+        options={explanations.map((explanation) => ({
+          content: <span className="text-base leading-6">{explanation.text}</span>,
+          disabled: hasFeedback,
+          isDimmed: hasSelection && selectedId !== explanation.id,
+          isSelected: selectedId === explanation.id,
+          key: explanation.id,
+          resultState: getResultState({
+            accuracy: explanation.accuracy,
+            hasFeedback,
+            id: explanation.id,
+            selectedId,
+          }),
+        }))}
+      />
+    </PlayerChoiceScene>
   );
 }

--- a/packages/player/src/components/investigation-call-variant.tsx
+++ b/packages/player/src/components/investigation-call-variant.tsx
@@ -23,6 +23,7 @@ import { type SelectedAnswer, type StepResult } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
 import {
   PlayerChoiceScene,
+  PlayerChoiceSceneOptionText,
   PlayerChoiceSceneOptions,
   PlayerChoiceScenePrompt,
   PlayerChoiceSceneQuestion,
@@ -234,7 +235,7 @@ export function InvestigationCallVariant({
         keyboardEnabled={!hasFeedback}
         onSelect={handleSelect}
         options={explanations.map((explanation) => ({
-          content: <span className="text-base leading-6">{explanation.text}</span>,
+          content: <PlayerChoiceSceneOptionText>{explanation.text}</PlayerChoiceSceneOptionText>,
           disabled: hasFeedback,
           isDimmed: hasSelection && selectedId !== explanation.id,
           isSelected: selectedId === explanation.id,

--- a/packages/player/src/components/investigation-problem-variant.tsx
+++ b/packages/player/src/components/investigation-problem-variant.tsx
@@ -2,9 +2,12 @@
 
 import { type InvestigationStepContent } from "@zoonk/core/steps/contract/content";
 import { useExtracted } from "next-intl";
-import { ContextText } from "./question-text";
-import { SectionLabel } from "./section-label";
-import { InteractiveStepLayout } from "./step-layouts";
+import {
+  PlayerReadScene,
+  PlayerReadSceneBody,
+  PlayerReadSceneEyebrow,
+  PlayerReadSceneStack,
+} from "./player-read-scene";
 
 type ProblemContent = Extract<InvestigationStepContent, { variant: "problem" }>;
 
@@ -20,12 +23,13 @@ export function InvestigationProblemVariant({ content }: { content: ProblemConte
   const t = useExtracted();
 
   return (
-    <InteractiveStepLayout>
-      <SectionLabel>{t("The Case")}</SectionLabel>
-
-      <ContextText>{content.scenario}</ContextText>
+    <PlayerReadScene>
+      <PlayerReadSceneStack>
+        <PlayerReadSceneEyebrow>{t("The Case")}</PlayerReadSceneEyebrow>
+        <PlayerReadSceneBody>{content.scenario}</PlayerReadSceneBody>
+      </PlayerReadSceneStack>
 
       <p className="text-muted-foreground text-sm">{t("Collect 2 leads. Then make your call.")}</p>
-    </InteractiveStepLayout>
+    </PlayerReadScene>
   );
 }

--- a/packages/player/src/components/investigation-problem-variant.tsx
+++ b/packages/player/src/components/investigation-problem-variant.tsx
@@ -8,6 +8,7 @@ import {
   PlayerReadSceneEyebrow,
   PlayerReadSceneStack,
 } from "./player-read-scene";
+import { PlayerSupportingText } from "./player-supporting-text";
 
 type ProblemContent = Extract<InvestigationStepContent, { variant: "problem" }>;
 
@@ -29,7 +30,7 @@ export function InvestigationProblemVariant({ content }: { content: ProblemConte
         <PlayerReadSceneBody>{content.scenario}</PlayerReadSceneBody>
       </PlayerReadSceneStack>
 
-      <p className="text-muted-foreground text-sm">{t("Collect 2 leads. Then make your call.")}</p>
+      <PlayerSupportingText>{t("Collect 2 leads. Then make your call.")}</PlayerSupportingText>
     </PlayerReadScene>
   );
 }

--- a/packages/player/src/components/player-bottom-bar.tsx
+++ b/packages/player/src/components/player-bottom-bar.tsx
@@ -4,25 +4,25 @@ import { Button } from "@zoonk/ui/components/button";
 import { cn } from "@zoonk/ui/lib/utils";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useExtracted } from "next-intl";
+import { PlayerContentFrame } from "./step-layouts";
 
 /**
  * Fixed bottom bar for the player's action buttons on mobile.
  *
- * Uses px-4 horizontal padding to match PlayerStage's p-4, with
- * max-w-2xl on the inner content area. This ensures the button
- * aligns with InteractiveStepLayout's max-w-2xl content above —
- * both use the same padding-outside-constraint structure.
+ * The inner content uses the same shared player frame as the stage content.
+ * That keeps mobile actions aligned with the centered step container instead
+ * of relying on duplicated width classes.
  */
 export function PlayerBottomBar({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       className={cn(
         "bg-background/95 sticky bottom-0 z-30 backdrop-blur-sm",
-        "w-full px-4 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]",
+        "w-full py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]",
         className,
       )}
     >
-      <div className="mx-auto w-full max-w-2xl" data-slot="player-bottom-bar" {...props} />
+      <PlayerContentFrame data-slot="player-bottom-bar" {...props} />
     </div>
   );
 }

--- a/packages/player/src/components/player-choice-scene.tsx
+++ b/packages/player/src/components/player-choice-scene.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { useOptionKeyboard } from "../use-option-keyboard";
 import { useReplaceName } from "../user-name-context";
@@ -83,6 +84,31 @@ export function PlayerChoiceSceneQuestion({ children }: { children?: string | nu
   }
 
   return <QuestionText>{replaceName(children)}</QuestionText>;
+}
+
+/**
+ * Keeps the primary option copy consistent across all choice scenes.
+ *
+ * Multiple choice, story decisions, translation, and investigation choices
+ * all present one tappable answer label. Centralizing that text treatment
+ * here prevents each adapter from quietly diverging when option typography
+ * changes in the future.
+ */
+export function PlayerChoiceSceneOptionText({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn("text-base leading-6", className)}
+      data-slot="player-choice-scene-option-text"
+    >
+      {children}
+    </span>
+  );
 }
 
 /**

--- a/packages/player/src/components/player-choice-scene.tsx
+++ b/packages/player/src/components/player-choice-scene.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { useOptionKeyboard } from "../use-option-keyboard";
 import { useReplaceName } from "../user-name-context";
@@ -94,18 +93,9 @@ export function PlayerChoiceSceneQuestion({ children }: { children?: string | nu
  * here prevents each adapter from quietly diverging when option typography
  * changes in the future.
  */
-export function PlayerChoiceSceneOptionText({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
+export function PlayerChoiceSceneOptionText({ children }: { children: React.ReactNode }) {
   return (
-    <span
-      className={cn("text-base leading-6", className)}
-      data-slot="player-choice-scene-option-text"
-    >
+    <span className="text-base leading-6" data-slot="player-choice-scene-option-text">
       {children}
     </span>
   );

--- a/packages/player/src/components/player-choice-scene.tsx
+++ b/packages/player/src/components/player-choice-scene.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useExtracted } from "next-intl";
+import { useOptionKeyboard } from "../use-option-keyboard";
+import { useReplaceName } from "../user-name-context";
+import { OptionCard } from "./option-card";
+import { ContextText, QuestionText } from "./question-text";
+import { SectionLabel } from "./section-label";
+import { InteractiveStepLayout } from "./step-layouts";
+
+type PlayerChoiceOptionResultState = "correct" | "incorrect";
+
+type PlayerChoiceSceneOption = {
+  content: React.ReactNode;
+  disabled?: boolean;
+  isDimmed?: boolean;
+  isSelected: boolean;
+  key: string;
+  resultState?: PlayerChoiceOptionResultState;
+};
+
+/**
+ * Provides the shared shell for all choice-based scenes.
+ *
+ * Multiple choice, story decisions, translation, and investigation choices all
+ * need the same centered layout, spacing, and action placement. Keeping that
+ * shell here means future layout changes land once for the whole family.
+ */
+export function PlayerChoiceScene({ children }: { children: React.ReactNode }) {
+  return <InteractiveStepLayout data-slot="player-choice-scene">{children}</InteractiveStepLayout>;
+}
+
+/**
+ * Keeps prompt copy grouped consistently above the option list.
+ *
+ * Some scenes show an eyebrow, some show context, some show only a question.
+ * This wrapper gives all of them the same vertical rhythm.
+ */
+export function PlayerChoiceScenePrompt({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-2 sm:gap-6" data-slot="player-choice-scene-prompt">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Reuses the shared eyebrow styling for choice scenes that need a short label
+ * above the question.
+ */
+export function PlayerChoiceSceneEyebrow({ children }: { children: React.ReactNode }) {
+  return <SectionLabel>{children}</SectionLabel>;
+}
+
+/**
+ * Replaces the player-name placeholder before rendering contextual copy.
+ *
+ * Choice scenes often reuse authored text that may contain the learner's name,
+ * so the replacement logic needs to stay in the shared scene layer rather than
+ * being repeated in every adapter component.
+ */
+export function PlayerChoiceSceneContext({ children }: { children?: string | null }) {
+  const replaceName = useReplaceName();
+
+  if (!children) {
+    return null;
+  }
+
+  return <ContextText>{replaceName(children)}</ContextText>;
+}
+
+/**
+ * Replaces the player-name placeholder before rendering the main question.
+ *
+ * This keeps story, multiple-choice, and investigation prompts aligned on the
+ * same copy treatment even though they come from different step kinds.
+ */
+export function PlayerChoiceSceneQuestion({ children }: { children?: string | null }) {
+  const replaceName = useReplaceName();
+
+  if (!children) {
+    return null;
+  }
+
+  return <QuestionText>{replaceName(children)}</QuestionText>;
+}
+
+/**
+ * Renders the shared option list and owns the numeric keyboard shortcuts.
+ *
+ * This exists so the option-card layout, radiogroup semantics, and keyboard
+ * interaction cannot drift between multiple-choice, story, translation, and
+ * investigation adapters.
+ */
+export function PlayerChoiceSceneOptions({
+  ariaLabel,
+  keyboardEnabled = true,
+  onSelect,
+  options,
+}: {
+  ariaLabel?: string;
+  keyboardEnabled?: boolean;
+  onSelect: (index: number) => void;
+  options: readonly PlayerChoiceSceneOption[];
+}) {
+  const t = useExtracted();
+
+  useOptionKeyboard({
+    enabled: keyboardEnabled,
+    onSelect,
+    optionCount: options.length,
+  });
+
+  return (
+    <div
+      aria-label={ariaLabel ?? t("Answer options")}
+      className="flex flex-col gap-3"
+      data-slot="player-choice-scene-options"
+      role="radiogroup"
+    >
+      {options.map((option, index) => (
+        <OptionCard
+          disabled={option.disabled}
+          index={index}
+          isDimmed={option.isDimmed}
+          isSelected={option.isSelected}
+          key={option.key}
+          onSelect={() => onSelect(index)}
+          resultState={option.resultState}
+        >
+          {option.content}
+        </OptionCard>
+      ))}
+    </div>
+  );
+}

--- a/packages/player/src/components/player-feedback-scene.tsx
+++ b/packages/player/src/components/player-feedback-scene.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { cn } from "@zoonk/ui/lib/utils";
+import { PlayerContentFrame } from "./step-layouts";
+
+/**
+ * Shared shell for dedicated feedback screens.
+ *
+ * Standard answer feedback, story consequences, and investigation call
+ * verdicts all replace the underlying step with a centered status scene.
+ * Keeping that shell here prevents those feedback variants from drifting.
+ */
+export function PlayerFeedbackScene({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <PlayerContentFrame
+      aria-live="polite"
+      className={cn("my-auto flex flex-col gap-6 py-4 sm:py-6", className)}
+      data-slot="player-feedback-scene"
+      role="status"
+    >
+      {children}
+    </PlayerContentFrame>
+  );
+}
+
+/**
+ * Shared feedback copy styling so all dedicated feedback scenes speak with the
+ * same visual voice even when their inner content differs.
+ */
+export function PlayerFeedbackSceneMessage({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      className={cn("text-foreground text-lg leading-relaxed", className)}
+      data-slot="player-feedback-scene-message"
+      {...props}
+    >
+      {children}
+    </p>
+  );
+}

--- a/packages/player/src/components/player-feedback-scene.tsx
+++ b/packages/player/src/components/player-feedback-scene.tsx
@@ -35,12 +35,11 @@ export function PlayerFeedbackScene({
  */
 export function PlayerFeedbackSceneMessage({
   children,
-  className,
   ...props
-}: React.ComponentProps<"p">) {
+}: Omit<React.ComponentProps<"p">, "className">) {
   return (
     <p
-      className={cn("text-foreground text-lg leading-relaxed", className)}
+      className="text-foreground text-lg leading-relaxed"
       data-slot="player-feedback-scene-message"
       {...props}
     >

--- a/packages/player/src/components/player-read-scene.tsx
+++ b/packages/player/src/components/player-read-scene.tsx
@@ -61,6 +61,24 @@ export function PlayerReadSceneEyebrow({ children }: { children: React.ReactNode
 }
 
 /**
+ * Gives read scenes one shared visual treatment for small section labels.
+ *
+ * Story intro and outcome both show a short uppercase label above metrics.
+ * Keeping that copy style here prevents those static/read screens from
+ * quietly drifting apart when spacing or typography changes later.
+ */
+export function PlayerReadSceneMetaLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p
+      className="text-muted-foreground text-xs font-medium tracking-widest uppercase"
+      data-slot="player-read-scene-meta-label"
+    >
+      {children}
+    </p>
+  );
+}
+
+/**
  * Shared read-scene title styling.
  *
  * Static text, investigation setup, and story outcomes all need a readable

--- a/packages/player/src/components/player-read-scene.tsx
+++ b/packages/player/src/components/player-read-scene.tsx
@@ -2,6 +2,21 @@ import { cn } from "@zoonk/ui/lib/utils";
 import { SectionLabel } from "./section-label";
 import { PlayerContentFrame } from "./step-layouts";
 
+export type PlayerReadSceneTitleTone =
+  | "destructive"
+  | "foreground"
+  | "muted"
+  | "success"
+  | "warning";
+
+const PLAYER_READ_SCENE_TITLE_TONE_CLASS: Record<PlayerReadSceneTitleTone, string> = {
+  destructive: "text-destructive",
+  foreground: "text-foreground",
+  muted: "text-muted-foreground",
+  success: "text-success",
+  warning: "text-warning",
+};
+
 /**
  * Shared read-only scene shell for centered player content.
  *
@@ -86,16 +101,16 @@ export function PlayerReadSceneMetaLabel({ children }: { children: React.ReactNo
  */
 export function PlayerReadSceneTitle({
   children,
-  className,
+  tone = "muted",
 }: {
   children: React.ReactNode;
-  className?: string;
+  tone?: PlayerReadSceneTitleTone;
 }) {
   return (
     <h2
       className={cn(
-        "text-muted-foreground text-lg font-semibold tracking-tight sm:text-xl",
-        className,
+        "text-lg font-semibold tracking-tight sm:text-xl",
+        PLAYER_READ_SCENE_TITLE_TONE_CLASS[tone],
       )}
       data-slot="player-read-scene-title"
     >
@@ -110,16 +125,10 @@ export function PlayerReadSceneTitle({
  * Story narrative, static explanations, and investigation setup copy should
  * stay visually aligned, so the baseline body typography lives here.
  */
-export function PlayerReadSceneBody({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
+export function PlayerReadSceneBody({ children }: { children: React.ReactNode }) {
   return (
     <p
-      className={cn("text-lg leading-relaxed sm:text-xl sm:leading-relaxed", className)}
+      className="text-lg leading-relaxed sm:text-xl sm:leading-relaxed"
       data-slot="player-read-scene-body"
     >
       {children}

--- a/packages/player/src/components/player-read-scene.tsx
+++ b/packages/player/src/components/player-read-scene.tsx
@@ -1,0 +1,120 @@
+import { cn } from "@zoonk/ui/lib/utils";
+import { SectionLabel } from "./section-label";
+import { PlayerContentFrame } from "./step-layouts";
+
+/**
+ * Shared read-only scene shell for centered player content.
+ *
+ * Static lesson copy, story intro/outcome, investigation setup, and
+ * vocabulary all live in the same visual family: read something, then move
+ * forward. This component keeps that family on one layout contract.
+ */
+export function PlayerReadScene({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <PlayerContentFrame
+      className={cn(
+        "relative my-auto flex flex-col items-start justify-center gap-3 py-4 sm:gap-6 sm:py-6",
+        className,
+      )}
+      data-slot="player-read-scene"
+    >
+      {children}
+    </PlayerContentFrame>
+  );
+}
+
+/**
+ * Groups related read-scene content into a consistent vertical stack.
+ *
+ * This prevents static and story screens from each inventing their own local
+ * spacing rules for the same title/body pattern.
+ */
+export function PlayerReadSceneStack({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn("flex flex-col gap-3 sm:gap-4", className)}
+      data-slot="player-read-scene-stack"
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Reuses the small uppercase label style for read scenes that need an eyebrow
+ * before the main body copy.
+ */
+export function PlayerReadSceneEyebrow({ children }: { children: React.ReactNode }) {
+  return <SectionLabel>{children}</SectionLabel>;
+}
+
+/**
+ * Shared read-scene title styling.
+ *
+ * Static text, investigation setup, and story outcomes all need a readable
+ * headline treatment. Keeping it here makes title changes fan out once.
+ */
+export function PlayerReadSceneTitle({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <h2
+      className={cn(
+        "text-muted-foreground text-lg font-semibold tracking-tight sm:text-xl",
+        className,
+      )}
+      data-slot="player-read-scene-title"
+    >
+      {children}
+    </h2>
+  );
+}
+
+/**
+ * Shared body copy styling for read scenes.
+ *
+ * Story narrative, static explanations, and investigation setup copy should
+ * stay visually aligned, so the baseline body typography lives here.
+ */
+export function PlayerReadSceneBody({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <p
+      className={cn("text-lg leading-relaxed sm:text-xl sm:leading-relaxed", className)}
+      data-slot="player-read-scene-body"
+    >
+      {children}
+    </p>
+  );
+}
+
+/**
+ * Standard divider used by read scenes to separate narrative copy from
+ * secondary metadata such as metrics.
+ */
+export function PlayerReadSceneDivider({ className }: { className?: string }) {
+  return (
+    <div className={cn("bg-border h-px w-full", className)} data-slot="player-read-scene-divider" />
+  );
+}

--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -96,7 +96,7 @@ export function PlayerShell() {
 
       {screen.showMetricsBar && <StoryMetricsBar metrics={storyMetrics} />}
 
-      <PlayerStage isStatic={screen.stageIsStatic} phase={state.phase}>
+      <PlayerStage isStatic={screen.stageIsStatic} phase={state.phase} scene={screen.scene}>
         <StageContent />
       </PlayerStage>
 

--- a/packages/player/src/components/player-stage.tsx
+++ b/packages/player/src/components/player-stage.tsx
@@ -5,19 +5,22 @@ export function PlayerStage({
   className,
   isStatic,
   phase,
+  scene,
   ...props
 }: React.ComponentProps<"section"> & {
   isStatic?: boolean;
   phase: PlayerPhase;
+  scene?: string;
 }) {
   return (
     <section
       className={cn(
-        "flex min-h-0 min-w-0 flex-1 flex-col items-center overflow-y-auto",
-        isStatic ? "overflow-hidden p-0" : "p-4",
+        "flex min-h-0 min-w-0 flex-1 flex-col items-center",
+        isStatic ? "overflow-hidden" : "overflow-y-auto",
         className,
       )}
       data-phase={phase}
+      data-scene={scene}
       data-slot="player-stage"
       {...props}
     />

--- a/packages/player/src/components/player-supporting-text.tsx
+++ b/packages/player/src/components/player-supporting-text.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@zoonk/ui/lib/utils";
+
+/**
+ * Provides one shared style for short, muted helper copy across the player.
+ *
+ * Investigation notes, completion summaries, and other small supporting lines
+ * were repeating the same text classes in multiple components. Centralizing
+ * that treatment here reduces drift without forcing unrelated scenes to share
+ * larger layout primitives.
+ */
+export function PlayerSupportingText({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <p
+      className={cn("text-muted-foreground text-sm", className)}
+      data-slot="player-supporting-text"
+    >
+      {children}
+    </p>
+  );
+}

--- a/packages/player/src/components/player-supporting-text.tsx
+++ b/packages/player/src/components/player-supporting-text.tsx
@@ -1,5 +1,3 @@
-import { cn } from "@zoonk/ui/lib/utils";
-
 /**
  * Provides one shared style for short, muted helper copy across the player.
  *
@@ -8,18 +6,9 @@ import { cn } from "@zoonk/ui/lib/utils";
  * that treatment here reduces drift without forcing unrelated scenes to share
  * larger layout primitives.
  */
-export function PlayerSupportingText({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
+export function PlayerSupportingText({ children }: { children: React.ReactNode }) {
   return (
-    <p
-      className={cn("text-muted-foreground text-sm", className)}
-      data-slot="player-supporting-text"
-    >
+    <p className="text-muted-foreground text-sm" data-slot="player-supporting-text">
       {children}
     </p>
   );

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -8,18 +8,31 @@ import {
 import { CompletionScreenContent } from "./completion-screen";
 import { FeedbackScreenContent } from "./feedback-screen";
 import { StepActionButton } from "./step-action-button";
+import { PlayerContentFrame } from "./step-layouts";
 import { StepRenderer } from "./step-renderer";
 
 /**
- * Whether the step has an action button (Begin, Check, Continue,
- * Start Investigation) — as opposed to static navigation arrows
- * handled by StepSideNav.
+ * Renders the desktop inline action inside the shared player frame so the
+ * button stays aligned with the step content instead of growing to the full
+ * stage width.
  *
- * When true, we render the action button inline on large screens
- * so it sits close to the content instead of fixed at the viewport bottom.
+ * Mobile still uses the sticky bottom bar. Large screens keep the same action
+ * close to the content, but now both placements share one width source.
  */
-function needsInlineAction(screen: ReturnType<typeof usePlayerRuntime>["screen"]) {
-  return screen.kind === "step" && screen.bottomBar.kind === "primaryAction";
+function DesktopInlineAction() {
+  return (
+    <PlayerContentFrame className="hidden lg:flex">
+      <StepActionButton />
+    </PlayerContentFrame>
+  );
+}
+
+/**
+ * Primary-action screens render the shared action inline on desktop, while
+ * navigable screens rely on side arrows or the mobile bottom bar.
+ */
+function usesDesktopInlineAction(screen: ReturnType<typeof usePlayerRuntime>["screen"]) {
+  return screen.kind !== "completed" && screen.bottomBar?.kind === "primaryAction";
 }
 
 export function StageContent() {
@@ -44,15 +57,15 @@ export function StageContent() {
 
   if (screen.kind === "feedbackScreen" && currentResult) {
     return (
-      <div className="my-auto flex w-full flex-col items-center gap-6">
+      <div className="my-auto flex w-full flex-col gap-6">
         <FeedbackScreenContent result={currentResult} step={currentStep} />
-        <StepActionButton className="hidden max-w-lg lg:inline-flex" />
+        <DesktopInlineAction />
       </div>
     );
   }
 
   if (screen.kind === "step" && currentStep) {
-    const showInlineAction = needsInlineAction(screen);
+    const showInlineAction = usesDesktopInlineAction(screen);
 
     const stepContent = (
       <StepRenderer
@@ -68,9 +81,9 @@ export function StageContent() {
 
     if (showInlineAction) {
       return (
-        <div className="my-auto flex w-full flex-col items-center gap-6">
+        <div className="my-auto flex w-full flex-col gap-6">
           {stepContent}
-          <StepActionButton className="hidden max-w-2xl lg:inline-flex" />
+          <DesktopInlineAction />
         </div>
       );
     }

--- a/packages/player/src/components/static-step.tsx
+++ b/packages/player/src/components/static-step.tsx
@@ -4,7 +4,12 @@ import { describePlayerStep } from "../player-step";
 import { type SerializedStep } from "../prepare-activity-data";
 import { useReplaceName } from "../user-name-context";
 import { HighlightText } from "./highlight-text";
-import { ContextText, QuestionText } from "./question-text";
+import {
+  PlayerReadScene,
+  PlayerReadSceneBody,
+  PlayerReadSceneStack,
+  PlayerReadSceneTitle,
+} from "./player-read-scene";
 import { RomanizationText } from "./romanization-text";
 import { StoryIntroContent } from "./story-intro-content";
 import { StoryOutcomeContent } from "./story-outcome-content";
@@ -13,10 +18,10 @@ function TextVariant({ title, text }: { title: string; text: string }) {
   const replaceName = useReplaceName();
 
   return (
-    <>
-      <QuestionText>{replaceName(title)}</QuestionText>
-      <ContextText>{replaceName(text)}</ContextText>
-    </>
+    <PlayerReadSceneStack>
+      <PlayerReadSceneTitle>{replaceName(title)}</PlayerReadSceneTitle>
+      <PlayerReadSceneBody>{replaceName(text)}</PlayerReadSceneBody>
+    </PlayerReadSceneStack>
   );
 }
 
@@ -32,24 +37,24 @@ function GrammarExampleVariant({
   translation: string;
 }) {
   return (
-    <>
+    <PlayerReadSceneStack>
       <p className="text-xl font-medium sm:text-2xl">
         <HighlightText highlight={highlight} text={sentence} />
       </p>
 
       <RomanizationText>{romanization}</RomanizationText>
 
-      <ContextText>{translation}</ContextText>
-    </>
+      <PlayerReadSceneBody>{translation}</PlayerReadSceneBody>
+    </PlayerReadSceneStack>
   );
 }
 
 function GrammarRuleVariant({ ruleName, ruleSummary }: { ruleName: string; ruleSummary: string }) {
   return (
-    <>
-      <QuestionText>{ruleName}</QuestionText>
-      <ContextText>{ruleSummary}</ContextText>
-    </>
+    <PlayerReadSceneStack>
+      <PlayerReadSceneTitle>{ruleName}</PlayerReadSceneTitle>
+      <PlayerReadSceneBody>{ruleSummary}</PlayerReadSceneBody>
+    </PlayerReadSceneStack>
   );
 }
 
@@ -99,8 +104,8 @@ function StaticStepContent({ step }: { step: SerializedStep }) {
 
 export function StaticStep({ step }: { step: SerializedStep }) {
   return (
-    <div className="relative flex min-h-0 w-full max-w-2xl flex-1 flex-col items-start justify-center gap-3 px-8 sm:px-10">
+    <PlayerReadScene>
       <StaticStepContent step={step} />
-    </div>
+    </PlayerReadScene>
   );
 }

--- a/packages/player/src/components/step-layouts.tsx
+++ b/packages/player/src/components/step-layouts.tsx
@@ -1,5 +1,24 @@
 import { cn } from "@zoonk/ui/lib/utils";
 
+/**
+ * Centers player content inside one shared width contract.
+ *
+ * The player used to repeat `max-w-*` and padding classes across static
+ * screens, feedback screens, and the mobile bottom bar. That made story
+ * intro/outcome drift away from the primary action button. This frame is the
+ * single source of truth for every centered screen that should align with that
+ * button.
+ */
+export function PlayerContentFrame({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("mx-auto w-full max-w-2xl px-4", className)}
+      data-slot="player-content-frame"
+      {...props}
+    />
+  );
+}
+
 export function NavigableStepLayout({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -13,10 +32,14 @@ export function NavigableStepLayout({ className, ...props }: React.ComponentProp
   );
 }
 
+/**
+ * Wraps every centered interactive screen in the shared player frame so answer
+ * content and primary actions always use the same width.
+ */
 export function InteractiveStepLayout({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <div
-      className={cn("my-auto flex w-full max-w-2xl flex-col gap-4 sm:gap-6", className)}
+    <PlayerContentFrame
+      className={cn("my-auto flex flex-col gap-4 py-4 sm:gap-6 sm:py-6", className)}
       data-slot="interactive-step-layout"
       {...props}
     />

--- a/packages/player/src/components/step-renderer.tsx
+++ b/packages/player/src/components/step-renderer.tsx
@@ -164,7 +164,7 @@ export function StepRenderer({
 
   const stepContent = (
     <div
-      className="animate-in fade-in flex min-h-0 w-full min-w-0 flex-1 flex-col items-center duration-150 ease-out motion-reduce:animate-none"
+      className="flex min-h-0 w-full min-w-0 flex-1 flex-col items-center"
       key={`step-${step.id}`}
     >
       {content}

--- a/packages/player/src/components/story-feedback-content.tsx
+++ b/packages/player/src/components/story-feedback-content.tsx
@@ -8,6 +8,7 @@ import { type StepResult } from "../player-reducer";
 import { type SerializedStep } from "../prepare-activity-data";
 import { EFFECT_DELTA_MAP } from "../story";
 import { useReplaceName } from "../user-name-context";
+import { PlayerFeedbackScene, PlayerFeedbackSceneMessage } from "./player-feedback-scene";
 
 type MetricDelta = {
   delta: number;
@@ -76,13 +77,9 @@ export function StoryFeedbackContent({
       : [];
 
   return (
-    <div
-      aria-live="polite"
-      className="animate-in fade-in slide-in-from-bottom-1 mx-auto my-auto flex w-full max-w-lg flex-col gap-6 duration-200 ease-out motion-reduce:animate-none"
-      role="status"
-    >
+    <PlayerFeedbackScene>
       {consequence && (
-        <p className="text-foreground text-lg leading-relaxed">{replaceName(consequence)}</p>
+        <PlayerFeedbackSceneMessage>{replaceName(consequence)}</PlayerFeedbackSceneMessage>
       )}
 
       {metricDeltas.length > 0 && (
@@ -92,6 +89,6 @@ export function StoryFeedbackContent({
           ))}
         </div>
       )}
-    </div>
+    </PlayerFeedbackScene>
   );
 }

--- a/packages/player/src/components/story-intro-content.tsx
+++ b/packages/player/src/components/story-intro-content.tsx
@@ -2,6 +2,11 @@
 
 import { useExtracted } from "next-intl";
 import { METRIC_AVERAGE_THRESHOLD } from "../story";
+import {
+  PlayerReadSceneBody,
+  PlayerReadSceneDivider,
+  PlayerReadSceneStack,
+} from "./player-read-scene";
 import { StoryMetricPill } from "./story-metric-pill";
 
 /**
@@ -21,10 +26,10 @@ export function StoryIntroContent({ intro, metrics }: { intro: string; metrics: 
 
   return (
     <div className="flex flex-col gap-10">
-      <p className="text-xl leading-relaxed sm:text-2xl sm:leading-relaxed">{intro}</p>
+      <PlayerReadSceneBody>{intro}</PlayerReadSceneBody>
 
-      <div className="flex flex-col gap-4">
-        <div className="bg-border h-px" />
+      <PlayerReadSceneStack className="gap-4">
+        <PlayerReadSceneDivider />
 
         <div className="flex flex-col gap-3">
           <p className="text-muted-foreground text-xs font-medium tracking-widest uppercase">
@@ -37,7 +42,7 @@ export function StoryIntroContent({ intro, metrics }: { intro: string; metrics: 
             ))}
           </div>
         </div>
-      </div>
+      </PlayerReadSceneStack>
     </div>
   );
 }

--- a/packages/player/src/components/story-intro-content.tsx
+++ b/packages/player/src/components/story-intro-content.tsx
@@ -5,6 +5,7 @@ import { METRIC_AVERAGE_THRESHOLD } from "../story";
 import {
   PlayerReadSceneBody,
   PlayerReadSceneDivider,
+  PlayerReadSceneMetaLabel,
   PlayerReadSceneStack,
 } from "./player-read-scene";
 import { StoryMetricPill } from "./story-metric-pill";
@@ -32,9 +33,7 @@ export function StoryIntroContent({ intro, metrics }: { intro: string; metrics: 
         <PlayerReadSceneDivider />
 
         <div className="flex flex-col gap-3">
-          <p className="text-muted-foreground text-xs font-medium tracking-widest uppercase">
-            {t("Current status")}
-          </p>
+          <PlayerReadSceneMetaLabel>{t("Current status")}</PlayerReadSceneMetaLabel>
 
           <div className="-ml-1 flex flex-wrap gap-2">
             {metrics.map((metric) => (

--- a/packages/player/src/components/story-metrics-bar.tsx
+++ b/packages/player/src/components/story-metrics-bar.tsx
@@ -2,6 +2,7 @@
 
 import { useExtracted } from "next-intl";
 import { type StoryMetric } from "../player-selectors";
+import { PlayerContentFrame } from "./step-layouts";
 import { StoryMetricPill } from "./story-metric-pill";
 
 /**
@@ -18,14 +19,14 @@ export function StoryMetricsBar({ metrics }: { metrics: StoryMetric[] }) {
   }
 
   return (
-    <div
+    <PlayerContentFrame
       aria-label={t("Current status")}
-      className="mx-auto flex w-full max-w-2xl flex-wrap items-center justify-center gap-2 p-4"
+      className="flex flex-wrap items-center justify-center gap-2 py-4"
       role="status"
     >
       {metrics.map((metric) => (
         <StoryMetricPill key={metric.metric} metric={metric.metric} value={metric.value} />
       ))}
-    </div>
+    </PlayerContentFrame>
   );
 }

--- a/packages/player/src/components/story-outcome-content.tsx
+++ b/packages/player/src/components/story-outcome-content.tsx
@@ -11,6 +11,7 @@ import {
   PlayerReadSceneMetaLabel,
   PlayerReadSceneStack,
   PlayerReadSceneTitle,
+  type PlayerReadSceneTitleTone,
 } from "./player-read-scene";
 import { StoryMetricPill } from "./story-metric-pill";
 
@@ -89,28 +90,28 @@ function selectOutcome({
 }
 
 /**
- * Returns the color class for the outcome title based on its position
+ * Returns the semantic title tone for the outcome based on its position
  * in the ranked list.
  *
  * First (best) = green, last (worst) = destructive, middle = warning.
  */
-function getOutcomeTierColor({ index, total }: RankedOutcome): string {
+function getOutcomeTierTone({ index, total }: RankedOutcome): PlayerReadSceneTitleTone {
   if (index === 0) {
-    return "text-success";
+    return "success";
   }
 
   if (index === total - 1) {
-    return "text-destructive";
+    return "destructive";
   }
 
-  return "text-warning";
+  return "warning";
 }
 
 /**
  * Outcome screen shown after the final decision step's consequence.
  *
  * Displays the narrative result of the player's decisions with a
- * color-coded title reflecting how well they did.
+ * tone-coded title reflecting how well they did.
  */
 export function StoryOutcomeContent({ outcomes }: { outcomes: StoryOutcome[] }) {
   const t = useExtracted();
@@ -123,11 +124,11 @@ export function StoryOutcomeContent({ outcomes }: { outcomes: StoryOutcome[] }) 
     return null;
   }
 
-  const titleColor = getOutcomeTierColor(ranked);
+  const titleTone = getOutcomeTierTone(ranked);
 
   return (
     <div className="flex flex-col gap-6">
-      <PlayerReadSceneTitle className={titleColor}>{ranked.outcome.title}</PlayerReadSceneTitle>
+      <PlayerReadSceneTitle tone={titleTone}>{ranked.outcome.title}</PlayerReadSceneTitle>
 
       <PlayerReadSceneBody>{ranked.outcome.narrative}</PlayerReadSceneBody>
 

--- a/packages/player/src/components/story-outcome-content.tsx
+++ b/packages/player/src/components/story-outcome-content.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { usePlayerRuntime } from "../player-context";
 import { type PlayerState } from "../player-reducer";
@@ -127,9 +126,7 @@ export function StoryOutcomeContent({ outcomes }: { outcomes: StoryOutcome[] }) 
 
   return (
     <div className="flex flex-col gap-6">
-      <PlayerReadSceneTitle className={cn("text-2xl font-semibold", titleColor)}>
-        {ranked.outcome.title}
-      </PlayerReadSceneTitle>
+      <PlayerReadSceneTitle className={titleColor}>{ranked.outcome.title}</PlayerReadSceneTitle>
 
       <PlayerReadSceneBody>{ranked.outcome.narrative}</PlayerReadSceneBody>
 

--- a/packages/player/src/components/story-outcome-content.tsx
+++ b/packages/player/src/components/story-outcome-content.tsx
@@ -6,6 +6,12 @@ import { usePlayerRuntime } from "../player-context";
 import { type PlayerState } from "../player-reducer";
 import { findSelectedChoice, getStoryMetrics } from "../player-selectors";
 import { type SerializedStep } from "../prepare-activity-data";
+import {
+  PlayerReadSceneBody,
+  PlayerReadSceneDivider,
+  PlayerReadSceneStack,
+  PlayerReadSceneTitle,
+} from "./player-read-scene";
 import { StoryMetricPill } from "./story-metric-pill";
 
 type StoryOutcome = {
@@ -121,15 +127,15 @@ export function StoryOutcomeContent({ outcomes }: { outcomes: StoryOutcome[] }) 
 
   return (
     <div className="flex flex-col gap-6">
-      <h2 className={cn("text-2xl font-semibold tracking-tight", titleColor)}>
+      <PlayerReadSceneTitle className={cn("text-2xl font-semibold", titleColor)}>
         {ranked.outcome.title}
-      </h2>
+      </PlayerReadSceneTitle>
 
-      <p className="text-lg leading-relaxed">{ranked.outcome.narrative}</p>
+      <PlayerReadSceneBody>{ranked.outcome.narrative}</PlayerReadSceneBody>
 
       {storyMetrics.length > 0 && (
-        <div className="flex flex-col gap-3">
-          <div className="bg-border h-px" />
+        <PlayerReadSceneStack className="gap-3">
+          <PlayerReadSceneDivider />
 
           <p className="text-muted-foreground text-xs font-medium tracking-widest uppercase">
             {t("Final status")}
@@ -140,7 +146,7 @@ export function StoryOutcomeContent({ outcomes }: { outcomes: StoryOutcome[] }) 
               <StoryMetricPill key={entry.metric} metric={entry.metric} value={entry.value} />
             ))}
           </div>
-        </div>
+        </PlayerReadSceneStack>
       )}
     </div>
   );

--- a/packages/player/src/components/story-outcome-content.tsx
+++ b/packages/player/src/components/story-outcome-content.tsx
@@ -8,6 +8,7 @@ import { type SerializedStep } from "../prepare-activity-data";
 import {
   PlayerReadSceneBody,
   PlayerReadSceneDivider,
+  PlayerReadSceneMetaLabel,
   PlayerReadSceneStack,
   PlayerReadSceneTitle,
 } from "./player-read-scene";
@@ -134,9 +135,7 @@ export function StoryOutcomeContent({ outcomes }: { outcomes: StoryOutcome[] }) 
         <PlayerReadSceneStack className="gap-3">
           <PlayerReadSceneDivider />
 
-          <p className="text-muted-foreground text-xs font-medium tracking-widest uppercase">
-            {t("Final status")}
-          </p>
+          <PlayerReadSceneMetaLabel>{t("Final status")}</PlayerReadSceneMetaLabel>
 
           <div className="-ml-1 flex flex-wrap gap-2">
             {storyMetrics.map((entry) => (

--- a/packages/player/src/components/translation-step.tsx
+++ b/packages/player/src/components/translation-step.tsx
@@ -7,6 +7,7 @@ import { useWordAudio } from "../use-word-audio";
 import {
   PlayerChoiceScene,
   PlayerChoiceSceneEyebrow,
+  PlayerChoiceSceneOptionText,
   PlayerChoiceSceneOptions,
   PlayerChoiceScenePrompt,
   PlayerChoiceSceneQuestion,
@@ -30,7 +31,7 @@ function TranslationOptionContent({
 }) {
   return (
     <>
-      <span className="text-base leading-6">{word.word}</span>
+      <PlayerChoiceSceneOptionText>{word.word}</PlayerChoiceSceneOptionText>
 
       <RomanizationText>{word.romanization}</RomanizationText>
 

--- a/packages/player/src/components/translation-step.tsx
+++ b/packages/player/src/components/translation-step.tsx
@@ -3,13 +3,15 @@
 import { useExtracted } from "next-intl";
 import { type SelectedAnswer } from "../player-reducer";
 import { type SerializedStep, type TranslationOption } from "../prepare-activity-data";
-import { useOptionKeyboard } from "../use-option-keyboard";
 import { useWordAudio } from "../use-word-audio";
-import { OptionCard } from "./option-card";
-import { QuestionText } from "./question-text";
+import {
+  PlayerChoiceScene,
+  PlayerChoiceSceneEyebrow,
+  PlayerChoiceSceneOptions,
+  PlayerChoiceScenePrompt,
+  PlayerChoiceSceneQuestion,
+} from "./player-choice-scene";
 import { RomanizationText } from "./romanization-text";
-import { SectionLabel } from "./section-label";
-import { InteractiveStepLayout } from "./step-layouts";
 
 function getSelectedWordId(selectedAnswer: SelectedAnswer | undefined): string | null {
   if (selectedAnswer?.kind !== "translation") {
@@ -73,35 +75,26 @@ export function TranslationStep({
     });
   };
 
-  useOptionKeyboard({
-    enabled: !selectedAnswer || selectedAnswer.kind === "translation",
-    onSelect: handleSelect,
-    optionCount: options.length,
-  });
-
   if (!correctWord) {
     return null;
   }
 
   return (
-    <InteractiveStepLayout>
-      <div className="flex flex-col gap-2">
-        <SectionLabel>{t("Translate this word:")}</SectionLabel>
-        <QuestionText>{correctWord.translation}</QuestionText>
-      </div>
+    <PlayerChoiceScene>
+      <PlayerChoiceScenePrompt>
+        <PlayerChoiceSceneEyebrow>{t("Translate this word:")}</PlayerChoiceSceneEyebrow>
+        <PlayerChoiceSceneQuestion>{correctWord.translation}</PlayerChoiceSceneQuestion>
+      </PlayerChoiceScenePrompt>
 
-      <div aria-label={t("Answer options")} className="flex flex-col gap-3" role="radiogroup">
-        {options.map((word, index) => (
-          <OptionCard
-            index={index}
-            isSelected={selectedWordId === word.id}
-            key={word.id}
-            onSelect={() => handleSelect(index)}
-          >
-            <TranslationOptionContent isSelected={selectedWordId === word.id} word={word} />
-          </OptionCard>
-        ))}
-      </div>
-    </InteractiveStepLayout>
+      <PlayerChoiceSceneOptions
+        keyboardEnabled={!selectedAnswer || selectedAnswer.kind === "translation"}
+        onSelect={handleSelect}
+        options={options.map((word) => ({
+          content: <TranslationOptionContent isSelected={selectedWordId === word.id} word={word} />,
+          isSelected: selectedWordId === word.id,
+          key: word.id,
+        }))}
+      />
+    </PlayerChoiceScene>
   );
 }

--- a/packages/player/src/components/vocabulary-step.tsx
+++ b/packages/player/src/components/vocabulary-step.tsx
@@ -3,7 +3,7 @@
 import { useExtracted } from "next-intl";
 import { type SerializedStep } from "../prepare-activity-data";
 import { PlayAudioButton } from "./play-audio-button";
-import { ContextText } from "./question-text";
+import { PlayerReadScene, PlayerReadSceneBody, PlayerReadSceneStack } from "./player-read-scene";
 import { RomanizationText } from "./romanization-text";
 
 export function VocabularyStep({ step }: { step: SerializedStep }) {
@@ -15,15 +15,15 @@ export function VocabularyStep({ step }: { step: SerializedStep }) {
   }
 
   return (
-    <div
-      aria-label={`${t("Vocabulary")}: ${word.word}`}
-      className="flex w-full max-w-2xl flex-1 flex-col items-start justify-center px-8 sm:px-10"
-      role="region"
-    >
-      <div className="flex flex-col gap-6">
+    <PlayerReadScene>
+      <div
+        aria-label={`${t("Vocabulary")}: ${word.word}`}
+        role="region"
+        className="flex flex-col gap-6"
+      >
         {word.audioUrl && <PlayAudioButton audioUrl={word.audioUrl} size="sm" />}
 
-        <div className="flex flex-col gap-2">
+        <PlayerReadSceneStack className="gap-2">
           <p className="text-4xl font-bold tracking-tight sm:text-5xl">{word.word}</p>
 
           <RomanizationText>{word.romanization}</RomanizationText>
@@ -31,10 +31,10 @@ export function VocabularyStep({ step }: { step: SerializedStep }) {
           {word.pronunciation && (
             <p className="text-muted-foreground text-sm">{word.pronunciation}</p>
           )}
-        </div>
+        </PlayerReadSceneStack>
 
-        <ContextText>{word.translation}</ContextText>
+        <PlayerReadSceneBody>{word.translation}</PlayerReadSceneBody>
       </div>
-    </div>
+    </PlayerReadScene>
   );
 }

--- a/packages/player/src/player-screen.ts
+++ b/packages/player/src/player-screen.ts
@@ -3,6 +3,7 @@ import { type PlayerState } from "./player-reducer";
 import { type PlayerStepDescriptor, describePlayerStep } from "./player-step";
 import {
   getPlayerStepBehavior,
+  getPlayerStepScene,
   usesFeedbackScreen,
   usesStaticNavigation,
 } from "./player-step-behavior";
@@ -10,6 +11,7 @@ import { canNavigatePrev as getCanNavigatePrev } from "./step-navigation";
 
 type PlayerPrimaryActionKind = "begin" | "check" | "continue" | "startInvestigation";
 type PlayerPrimaryActionRun = "check" | "continue" | "navigateNext";
+type InPlayScreenScene = "choice" | "feedback" | "read" | "visual";
 
 type PlayerBottomBarModel =
   | {
@@ -34,6 +36,7 @@ type InPlayScreenModel = {
   bottomBar: PlayerBottomBarModel;
   canNavigatePrev: boolean;
   keyboard: PlayerKeyboardModel;
+  scene: InPlayScreenScene;
   showChrome: true;
   showMetricsBar: boolean;
   stageIsStatic: boolean;
@@ -45,6 +48,7 @@ export type PlayerCompletedScreenModel = {
   bottomBar: null;
   keyboard: PlayerKeyboardModel;
   kind: "completed";
+  scene: "completion";
   showChrome: false;
   showMetricsBar: false;
   stageIsStatic: false;
@@ -53,6 +57,7 @@ export type PlayerCompletedScreenModel = {
 
 export type PlayerFeedbackScreenModel = InPlayScreenModel & {
   kind: "feedbackScreen";
+  scene: "feedback";
 };
 
 export type PlayerStepScreenModel = InPlayScreenModel & {
@@ -79,6 +84,7 @@ function getCompletedScreenModel(): PlayerCompletedScreenModel {
       rightAction: null,
     },
     kind: "completed",
+    scene: "completion",
     showChrome: false,
     showMetricsBar: false,
     stageIsStatic: false,
@@ -211,6 +217,27 @@ function getStoryStaticVariant(step: PlayerStepDescriptor): StoryStaticVariant |
 }
 
 /**
+ * Reduces the player's screen routing to a small set of UI scenes.
+ *
+ * This lets the shell think in broad layouts like read, choice, feedback, and
+ * completion without erasing the domain-specific step kinds that scoring and
+ * validation still need.
+ */
+function getPlayerScreenScene({
+  phase,
+  step,
+}: {
+  phase: PlayerState["phase"];
+  step: PlayerStepDescriptor;
+}): InPlayScreenScene {
+  if (phase === "feedback") {
+    return "feedback";
+  }
+
+  return getPlayerStepScene(step) ?? "read";
+}
+
+/**
  * Returns the player's canonical screen model from raw reducer state.
  *
  * This is the shared UI/control source of truth for shell layout, keyboard
@@ -248,10 +275,12 @@ export function getPlayerScreenModel(state: PlayerState): PlayerScreenModel {
     phase: state.phase,
     step,
   });
+  const scene = getPlayerScreenScene({ phase: state.phase, step });
   const model = {
     bottomBar,
     canNavigatePrev: canMovePrev,
     keyboard,
+    scene,
     showChrome: true as const,
     showMetricsBar: step.kind === "storyDecision",
     stageIsStatic: state.phase === "playing" && usesStaticNavigation(step),
@@ -260,7 +289,7 @@ export function getPlayerScreenModel(state: PlayerState): PlayerScreenModel {
   };
 
   if (state.phase === "feedback" && usesFeedbackScreen(step)) {
-    return { ...model, kind: "feedbackScreen" };
+    return { ...model, kind: "feedbackScreen", scene: "feedback" };
   }
 
   return { ...model, kind: "step" };

--- a/packages/player/src/player-step-behavior.ts
+++ b/packages/player/src/player-step-behavior.ts
@@ -24,6 +24,7 @@ export type PlayerCheckBehavior =
 
 type PlayerFeedbackBehavior = "inline" | "none" | "screen";
 type PlayerLayoutBehavior = "default" | "navigable";
+type PlayerSceneBehavior = "choice" | "read" | "visual";
 
 export type PlayerRenderBehavior =
   | "fillBlank"
@@ -58,6 +59,7 @@ type PlayerStepBehavior = {
   feedback: PlayerFeedbackBehavior;
   layout: PlayerLayoutBehavior;
   render: PlayerRenderBehavior;
+  scene: PlayerSceneBehavior;
   validation: PlayerValidationBehavior;
 };
 
@@ -67,6 +69,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "inline",
     layout: "default",
     render: "fillBlank",
+    scene: "choice",
     validation: "fillBlank",
   },
   investigationAction: {
@@ -74,6 +77,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "inline",
     layout: "default",
     render: "investigation",
+    scene: "choice",
     validation: "none",
   },
   investigationCall: {
@@ -81,6 +85,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "screen",
     layout: "default",
     render: "investigation",
+    scene: "choice",
     validation: "investigationCall",
   },
   investigationProblem: {
@@ -88,6 +93,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "none",
     layout: "default",
     render: "investigation",
+    scene: "read",
     validation: "none",
   },
   listening: {
@@ -95,6 +101,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "screen",
     layout: "default",
     render: "listening",
+    scene: "choice",
     validation: "listening",
   },
   matchColumns: {
@@ -102,6 +109,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "inline",
     layout: "default",
     render: "matchColumns",
+    scene: "choice",
     validation: "matchColumns",
   },
   multipleChoice: {
@@ -109,6 +117,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "screen",
     layout: "default",
     render: "multipleChoice",
+    scene: "choice",
     validation: "multipleChoice",
   },
   reading: {
@@ -116,6 +125,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "screen",
     layout: "default",
     render: "reading",
+    scene: "choice",
     validation: "reading",
   },
   selectImage: {
@@ -123,6 +133,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "inline",
     layout: "default",
     render: "selectImage",
+    scene: "choice",
     validation: "selectImage",
   },
   sortOrder: {
@@ -130,6 +141,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "inline",
     layout: "default",
     render: "sortOrder",
+    scene: "choice",
     validation: "sortOrder",
   },
   staticGrammarExample: {
@@ -137,6 +149,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "none",
     layout: "navigable",
     render: "static",
+    scene: "read",
     validation: "none",
   },
   staticGrammarRule: {
@@ -144,6 +157,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "none",
     layout: "navigable",
     render: "static",
+    scene: "read",
     validation: "none",
   },
   staticText: {
@@ -151,6 +165,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "none",
     layout: "navigable",
     render: "static",
+    scene: "read",
     validation: "none",
   },
   storyDecision: {
@@ -158,6 +173,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "screen",
     layout: "default",
     render: "story",
+    scene: "choice",
     validation: "story",
   },
   storyIntro: {
@@ -165,6 +181,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "none",
     layout: "default",
     render: "static",
+    scene: "read",
     validation: "none",
   },
   storyOutcome: {
@@ -172,6 +189,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "none",
     layout: "default",
     render: "static",
+    scene: "read",
     validation: "none",
   },
   translation: {
@@ -179,6 +197,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "screen",
     layout: "default",
     render: "translation",
+    scene: "choice",
     validation: "translation",
   },
   visual: {
@@ -186,6 +205,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "none",
     layout: "navigable",
     render: "visual",
+    scene: "visual",
     validation: "none",
   },
   vocabulary: {
@@ -193,6 +213,7 @@ const STEP_BEHAVIOR_BY_KIND: Record<PlayerStepKind, PlayerStepBehavior> = {
     feedback: "none",
     layout: "navigable",
     render: "vocabulary",
+    scene: "read",
     validation: "none",
   },
 };
@@ -229,6 +250,19 @@ export function usesStaticNavigation(descriptor: PlayerStepDescriptor | null | u
  */
 export function usesFeedbackScreen(descriptor: PlayerStepDescriptor | null | undefined): boolean {
   return getPlayerStepBehavior(descriptor)?.feedback === "screen";
+}
+
+/**
+ * Groups the player's many step kinds into a smaller set of UI scenes.
+ *
+ * Story and investigation still keep their domain-specific step kinds for
+ * scoring and validation, but the shell can now reason about a simpler
+ * family of screens: read, choice, or visual.
+ */
+export function getPlayerStepScene(
+  descriptor: PlayerStepDescriptor | null | undefined,
+): PlayerSceneBehavior | null {
+  return getPlayerStepBehavior(descriptor)?.scene ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- refactor the player around shared read, choice, and feedback scene primitives
- make story, investigation, static, and completion screens share one width and motion contract
- add targeted main-app e2e coverage for the mobile width and spacing guarantees

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the player around shared read, choice, and feedback scenes with one centered content frame so mobile and desktop stay aligned and styles don’t drift. Adds targeted e2e checks to lock in shared width and breathing room below the sticky header on mobile.

- **Refactors**
  - Added `PlayerReadScene`, `PlayerChoiceScene`, `PlayerFeedbackScene`, and `PlayerContentFrame`; updated story, investigation, static, translation, vocabulary, completion, and metrics to use them.
  - Centralized option keyboard/semantics and text via `PlayerChoiceSceneOptions`/`PlayerChoiceSceneOptionText`; moved the "Answer options" i18n key into the choice scene.
  - Introduced a `scene` field to screen routing (`player-screen`, `player-step-behavior`); tagged `PlayerStage` with `data-scene`; desktop inline actions and the mobile bottom bar now use the same content frame.
  - Extracted shared read-scene primitives (`PlayerReadSceneMetaLabel`, `PlayerReadSceneDivider`, `PlayerReadSceneStack`, `PlayerSupportingText`), tightened scene APIs, and moved remaining adapter styling into semantic primitives; added an architecture overview in `packages/player/README.md`.

- **New Features**
  - Added e2e layout helpers to assert shared content width and a minimum header-to-content gap on mobile.
  - Extended story and investigation tests to verify width reuse across intro/decision/outcome and spacing below the sticky progress bar.

<sup>Written for commit db5203cee0afd7774fdb5a5ad0bcf2aec682bd2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

