### PR TITLE
chore(db): add reset:test script

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,6 +12,7 @@
     "db:migrate": "prisma migrate dev",
     "db:reset": "prisma migrate reset",
     "db:reset:e2e": "env $(cat .env.e2e | xargs) prisma migrate reset",
+    "db:reset:test": "env $(cat .env.test | xargs) prisma migrate reset",
     "db:seed": "prisma db seed",
     "db:seed:e2e": "env $(cat .env.e2e | xargs) prisma db seed",
     "db:setup:e2e": "env $(cat .env.e2e | xargs) prisma migrate deploy",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `db:reset:test` to reset the test database using `.env.test` via `prisma migrate reset`. This makes test DB resets consistent with existing dev and e2e scripts.

<sup>Written for commit 75c0a7d8cb3f11a1d667af2b373a6a439105c330. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

