### PR TITLE
fix(ai): use z.union instead of z.discriminatedUnion for quiz schema

### DIFF
--- a/packages/ai/src/tasks/activities/core/activity-quiz.ts
+++ b/packages/ai/src/tasks/activities/core/activity-quiz.ts
@@ -59,7 +59,7 @@ const selectImageSchema = z.object({
   question: z.string(),
 });
 
-const quizQuestionSchema = z.discriminatedUnion("format", [
+const quizQuestionSchema = z.union([
   multipleChoiceSchema,
   fillBlankSchema,
   matchColumnsSchema,


### PR DESCRIPTION
## Summary
- Replace `z.discriminatedUnion` with `z.union` in quiz question schema
- `discriminatedUnion` compiles to `oneOf` in JSON Schema, which OpenAI's structured output API rejects
- `z.union` compiles to `anyOf`, which is supported

## Test plan
- [ ] Run activity quiz generation and verify no schema errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch quiz question schema to `z.union` so it compiles to `anyOf` instead of `oneOf`, which OpenAI’s structured output supports. This prevents schema rejection and restores activity quiz generation.

<sup>Written for commit 4fea5d1bfa831039716065aea5e6bc886f3ca78b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

