### PR TITLE
fix(ai): add gateway tags to image tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@
 - Never cut corners or do hacks. Aim for maintainable, clean code
 - Think about the big picture—how your changes fit into the overall architecture and future growth
 - **Think from first principles.** Don't accept patterns just because they're common. For every piece of code, ask: "What is this actually doing? Is there a simpler, more declarative way?" For every test, ask: "Am I testing my business logic or just testing that React/the browser works?" Before finishing any change, review everything again: "Is this the best way to implement this? Is this the best way to test this? Am I missing anything?" Think like a top 0.1% engineer who deeply cares about quality and details, not just getting things working. Think like the best engineer in the world
+- Preserve behavior, not implementation details
+- For compatibility issues, test simpler equivalent shapes before building workarounds
 - **Verify before fixing.** When evaluating review comments (AI or human), trace the actual code path to determine if the reported issue can happen in practice. Answer "can this actually happen?" before "should we fix it?" Distinguish real bugs from theoretical issues from code style — and say which one it is upfront. Don't default to agreement; apply the same rigor you'd apply to your own code
 - **Treat specs and GitHub issues as guidance, not truth.** If the ticket pushes the code toward a worse design or a wrong assumption, call it out and propose the better approach instead of implementing it blindly.
 

--- a/apps/admin/src/app/(private)/stats/ai/ai-task-list.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/ai-task-list.tsx
@@ -15,7 +15,7 @@ export async function AiTaskList() {
   return (
     <div className="flex flex-col gap-4">
       <p className="text-muted-foreground text-sm">
-        Request counts and fallback usage for gateway-tagged AI text tasks in the last 30 days.
+        Request counts and fallback usage for gateway-tagged AI tasks in the last 30 days.
       </p>
 
       {tasks.length > 0 ? (

--- a/packages/ai/src/provider-options.test.ts
+++ b/packages/ai/src/provider-options.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { buildProviderOptions } from "./provider-options";
+import { buildImageProviderOptions, buildProviderOptions } from "./provider-options";
 
 describe(buildProviderOptions, () => {
   test("adds provider order, default-model tags, and reasoning effort for fallback-enabled openai models", () => {
@@ -83,6 +83,26 @@ describe(buildProviderOptions, () => {
         models: [],
         order: ["openai", "azure", "google", "anthropic", "vertex"],
         tags: ["task:activity-story-steps", "default-model:openai/gpt-5.4"],
+      },
+    });
+  });
+});
+
+describe(buildImageProviderOptions, () => {
+  test("adds gateway reporting tags while preserving the openai image settings", () => {
+    expect(
+      buildImageProviderOptions({
+        model: "openai/gpt-image-1.5",
+        quality: "low",
+        taskName: "course-thumbnail",
+      }),
+    ).toEqual({
+      gateway: {
+        tags: ["task:course-thumbnail", "default-model:openai/gpt-image-1.5"],
+      },
+      openai: {
+        output_format: "webp",
+        quality: "low",
       },
     });
   });

--- a/packages/ai/src/provider-options.ts
+++ b/packages/ai/src/provider-options.ts
@@ -1,8 +1,10 @@
 import { type GatewayProviderOptions } from "@ai-sdk/gateway";
 import { type OpenAILanguageModelResponsesOptions } from "@ai-sdk/openai";
+import { type ImageModel } from "ai";
 import { buildGatewayReportingTags } from "./reporting-tags";
 
 export type ReasoningEffort = "auto" | "low" | "medium" | "high";
+export type ImageGenerationQuality = "auto" | "low" | "medium" | "high";
 
 const providerOrderByModelPrefix = {
   anthropic: ["anthropic", "vertex", "openai", "azure", "google"],
@@ -15,6 +17,14 @@ type SupportedModelPrefix = keyof typeof providerOrderByModelPrefix;
 type ProviderOptionsResult = {
   gateway: Pick<GatewayProviderOptions, "models" | "order" | "tags">;
   openai?: Pick<OpenAILanguageModelResponsesOptions, "reasoningEffort">;
+};
+
+type ImageProviderOptionsResult = {
+  gateway: Pick<GatewayProviderOptions, "tags">;
+  openai: {
+    output_format: "webp";
+    quality: ImageGenerationQuality;
+  };
 };
 
 /**
@@ -77,6 +87,45 @@ function isSupportedModelPrefix(value: string): value is SupportedModelPrefix {
  */
 function buildGatewayTags({ model, taskName }: { model: string; taskName: string }): string[] {
   return buildGatewayReportingTags({ model, taskName });
+}
+
+/**
+ * Image tasks accept either a plain `provider/model` string or a provider model
+ * instance. Custom Reporting needs a stable string tag, so this helper converts
+ * either shape into the same `provider/model` identifier before we build tags.
+ */
+function getImageReportingModel(model: ImageModel): string {
+  if (typeof model === "string") {
+    return model;
+  }
+
+  return model.modelId.includes("/") ? model.modelId : `${model.provider}/${model.modelId}`;
+}
+
+/**
+ * Builds the provider options shared by image-generation tasks.
+ * Image requests do not use the text fallback helper, so they need their own
+ * small wrapper to keep Custom Reporting tags and the OpenAI image output
+ * format in one place instead of drifting across each task entry point.
+ */
+export function buildImageProviderOptions({
+  model,
+  quality,
+  taskName,
+}: {
+  model: ImageModel;
+  quality: ImageGenerationQuality;
+  taskName: string;
+}): ImageProviderOptionsResult {
+  return {
+    gateway: {
+      tags: buildGatewayTags({ model: getImageReportingModel(model), taskName }),
+    },
+    openai: {
+      output_format: "webp",
+      quality,
+    },
+  };
 }
 
 /**

--- a/packages/ai/src/tasks/courses/course-thumbnail.ts
+++ b/packages/ai/src/tasks/courses/course-thumbnail.ts
@@ -1,6 +1,7 @@
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { logError } from "@zoonk/utils/logger";
 import { type GeneratedFile, type ImageModel, generateImage } from "ai";
+import { type ImageGenerationQuality, buildImageProviderOptions } from "../../provider-options";
 import promptTemplate from "./course-thumbnail.prompt.md";
 
 const DEFAULT_MODEL = "openai/gpt-image-1.5";
@@ -13,7 +14,7 @@ function getCourseThumbnailPrompt(title: string) {
 export type CourseThumbnailParams = {
   title: string;
   model?: ImageModel;
-  quality?: "auto" | "low" | "medium" | "high";
+  quality?: ImageGenerationQuality;
 };
 
 export async function generateCourseThumbnail({
@@ -26,9 +27,11 @@ export async function generateCourseThumbnail({
       maxImagesPerCall: 1,
       model,
       prompt: getCourseThumbnailPrompt(title),
-      providerOptions: {
-        openai: { output_format: "webp", quality },
-      },
+      providerOptions: buildImageProviderOptions({
+        model,
+        quality,
+        taskName: "course-thumbnail",
+      }),
       size: "1024x1024",
     }),
   );

--- a/packages/ai/src/tasks/steps/step-select-image.ts
+++ b/packages/ai/src/tasks/steps/step-select-image.ts
@@ -1,6 +1,7 @@
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { logError } from "@zoonk/utils/logger";
 import { type GeneratedFile, type ImageModel, generateImage } from "ai";
+import { type ImageGenerationQuality, buildImageProviderOptions } from "../../provider-options";
 import promptTemplate from "./step-select-image.prompt.md";
 
 const DEFAULT_MODEL = "openai/gpt-image-1-mini";
@@ -14,7 +15,7 @@ export type SelectImageStepParams = {
   prompt: string;
   language: string;
   model?: ImageModel;
-  quality?: "auto" | "low" | "medium" | "high";
+  quality?: ImageGenerationQuality;
 };
 
 export async function generateSelectImageStep({
@@ -28,9 +29,11 @@ export async function generateSelectImageStep({
       maxImagesPerCall: 1,
       model,
       prompt: getSelectImageStepPrompt(prompt, language),
-      providerOptions: {
-        openai: { output_format: "webp", quality },
-      },
+      providerOptions: buildImageProviderOptions({
+        model,
+        quality,
+        taskName: "step-select-image",
+      }),
       size: "1024x1024",
     }),
   );

--- a/packages/ai/src/tasks/steps/step-visual-image.ts
+++ b/packages/ai/src/tasks/steps/step-visual-image.ts
@@ -1,6 +1,7 @@
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { logError } from "@zoonk/utils/logger";
 import { type GeneratedFile, type ImageModel, generateImage } from "ai";
+import { type ImageGenerationQuality, buildImageProviderOptions } from "../../provider-options";
 import promptTemplate from "./step-visual-image.prompt.md";
 
 const DEFAULT_MODEL = "openai/gpt-image-1.5";
@@ -14,7 +15,7 @@ export type StepVisualImageParams = {
   prompt: string;
   language: string;
   model?: ImageModel;
-  quality?: "auto" | "low" | "medium" | "high";
+  quality?: ImageGenerationQuality;
 };
 
 export async function generateStepVisualImage({
@@ -28,9 +29,11 @@ export async function generateStepVisualImage({
       maxImagesPerCall: 1,
       model,
       prompt: getStepVisualImagePrompt(prompt, language),
-      providerOptions: {
-        openai: { output_format: "webp", quality },
-      },
+      providerOptions: buildImageProviderOptions({
+        model,
+        quality,
+        taskName: "step-visual-image",
+      }),
       size: "1024x1024",
     }),
   );


### PR DESCRIPTION
Add gateway reporting tags to the image generation tasks so `course-thumbnail`, `step-select-image`, and `step-visual-image` appear in the admin AI task reports.

This also updates the admin AI task list copy to reflect that the report covers AI tasks broadly, and includes the earlier `AGENTS.md` update already on this branch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add gateway reporting tags to image generation tasks so `course-thumbnail`, `step-select-image`, and `step-visual-image` appear in the admin task reports. Centralizes image provider options to add tags consistently while preserving `openai` image settings.

- **Bug Fixes**
  - Tagged all image tasks via `buildImageProviderOptions`, adding `gateway.tags` and keeping `output_format: webp` and `quality`.
  - Normalized model identifiers (string or instance) for stable reporting tags.
  - Updated admin stats copy to “AI tasks”; added tests for `buildImageProviderOptions`; small doc update in `AGENTS.md`.

<sup>Written for commit 25ee0ca55fb55462e38f80886d6caf58050381f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

