### PR TITLE
fix(api): retry failed visual image dispatches

### DIFF
--- a/apps/api/src/workflows/activity-generation/steps/_utils/dispatch-visual-content.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/dispatch-visual-content.test.ts
@@ -95,6 +95,22 @@ describe(dispatchVisualContent, () => {
     });
   });
 
+  test("throws when image generation returns an error", async () => {
+    const { generateVisualStepImage } = await import("@zoonk/core/steps/visual-image");
+
+    vi.mocked(generateVisualStepImage).mockResolvedValueOnce({
+      data: null,
+      error: new Error("Image generation failed"),
+    });
+
+    await expect(
+      dispatchVisualContent({
+        descriptions: [{ description: "A broken image", kind: "image" }],
+        language: "en",
+      }),
+    ).rejects.toThrow("Image generation failed");
+  });
+
   test("returns results in same order as input descriptions", async () => {
     const results = await dispatchVisualContent({
       descriptions: [

--- a/apps/api/src/workflows/activity-generation/steps/_utils/dispatch-visual-content.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/dispatch-visual-content.ts
@@ -8,6 +8,7 @@ import { generateVisualQuote } from "@zoonk/ai/tasks/visuals/quote";
 import { generateVisualTable } from "@zoonk/ai/tasks/visuals/table";
 import { generateVisualTimeline } from "@zoonk/ai/tasks/visuals/timeline";
 import { generateVisualStepImage } from "@zoonk/core/steps/visual-image";
+import { toError } from "@zoonk/utils/error";
 import { logError } from "@zoonk/utils/logger";
 
 /**
@@ -40,6 +41,79 @@ const structuredGenerators: Record<
   timeline: generateVisualTimeline,
 };
 
+type DispatchFailure = {
+  description: VisualDescription;
+  error: Error;
+};
+
+/**
+ * Image visuals must return a real uploaded URL.
+ * Throwing here is intentional: storing `{ kind: "image", url: null }` looks like
+ * success to the workflow layer, which prevents the step runtime from retrying
+ * transient gateway and network failures.
+ */
+function getImageUrlOrThrow({ error, url }: { error: Error | null; url: string | null }): string {
+  if (error) {
+    throw error;
+  }
+
+  if (!url) {
+    throw new Error("Image generation returned no URL");
+  }
+
+  return url;
+}
+
+/**
+ * Finds the first rejected image dispatch so the caller can abort the whole
+ * step and let Workflow's built-in retries handle transient image failures.
+ * Structured visuals still fall back to prompt-only images because they do not
+ * depend on an external uploaded asset being present.
+ */
+function getImageDispatchFailure({
+  descriptions,
+  results,
+}: {
+  descriptions: VisualDescription[];
+  results: PromiseSettledResult<DispatchedVisual | null>[];
+}): DispatchFailure | null {
+  for (const [index, description] of descriptions.entries()) {
+    const result = results[index];
+
+    if (description.kind === "image" && result?.status === "rejected") {
+      return { description, error: toError(result.reason) };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Re-throws image dispatch failures so the surrounding `"use step"` function
+ * fails loudly. Workflow retries only happen when the step throws, so this
+ * guard preserves retries for transient image-generation outages.
+ */
+function throwIfImageDispatchFailed({
+  descriptions,
+  results,
+}: {
+  descriptions: VisualDescription[];
+  results: PromiseSettledResult<DispatchedVisual | null>[];
+}): void {
+  const failure = getImageDispatchFailure({ descriptions, results });
+
+  if (!failure) {
+    return;
+  }
+
+  logError("Image visual dispatch failed, rethrowing to allow workflow retry", {
+    description: failure.description.description,
+    kind: failure.description.kind,
+  });
+
+  throw failure.error;
+}
+
 /**
  * Generates structured visual content for a single description by
  * calling the appropriate per-kind task. For image kinds, generates
@@ -55,12 +129,17 @@ async function dispatchSingle({
   orgSlug?: string;
 }): Promise<DispatchedVisual | null> {
   if (description.kind === "image") {
-    const { data: url } = await generateVisualStepImage({
+    const { data: url, error } = await generateVisualStepImage({
       language,
       orgSlug,
       prompt: description.description,
     });
-    return { kind: "image", prompt: description.description, url };
+
+    return {
+      kind: "image",
+      prompt: description.description,
+      url: getImageUrlOrThrow({ error, url }),
+    };
   }
 
   const generator = structuredGenerators[description.kind];
@@ -96,6 +175,8 @@ export async function dispatchVisualContent({
   const results = await Promise.allSettled(
     descriptions.map((description) => dispatchSingle({ description, language, orgSlug })),
   );
+
+  throwIfImageDispatchFailed({ descriptions, results });
 
   return results.map((result, index) => {
     if (result.status === "fulfilled" && result.value) {

--- a/apps/api/src/workflows/activity-generation/steps/generate-visual-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-visual-content-step.test.ts
@@ -204,4 +204,50 @@ describe(generateVisualContentForActivityStep, () => {
       }),
     );
   });
+
+  test("rethrows dispatcher failures so workflow retries can run", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Visual Content Retry ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "explanation",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Explanation ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+    const activity = activities[0]!;
+
+    dispatchVisualContentMock.mockRejectedValueOnce(new Error("Dispatch failed"));
+
+    await expect(
+      generateVisualContentForActivityStep(activity, [
+        { description: "A failing image", kind: "image" as const },
+      ]),
+    ).rejects.toThrow("Dispatch failed");
+
+    const events = getStreamedEvents(writeMock);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        entityId: activity.id,
+        status: "started",
+        step: "generateVisualContent",
+      }),
+    );
+
+    expect(events).not.toContainEqual(
+      expect.objectContaining({
+        entityId: activity.id,
+        status: "completed",
+        step: "generateVisualContent",
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- rethrow image visual dispatch failures so workflow retries can handle transient gateway and network errors
- keep the existing structured visual fallbacks unchanged
- add tests for image dispatch rejection and visual-content step propagation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure failed image visual dispatches are rethrown so the workflow can retry transient gateway/network errors. Structured visuals keep their fallbacks; images now require a real uploaded URL.

- **Bug Fixes**
  - Re-throw image dispatch failures after `Promise.allSettled` to trigger step retries.
  - Enforce real image URLs via a guard to prevent false “success” with `url: null`.
  - Added tests for image rejection, dispatcher rethrow in the step, and result ordering.

<sup>Written for commit 173508556ae6b13a2f4d0c9e4253390f52316083. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

