### PR TITLE
feat(admin): add ai generation cost estimates

### DIFF
--- a/apps/admin/src/app/(private)/stats/ai/[task]/ai-task-report.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/[task]/ai-task-report.tsx
@@ -1,4 +1,6 @@
 import {
+  getAiTaskHref,
+  getSingleSearchParamValue,
   isAiTaskName,
   resolveAiTaskDateRange,
   resolveEstimateRunCount,
@@ -6,8 +8,8 @@ import {
 import { getAiTaskReport } from "@/data/stats/ai/get-ai-task-report";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { notFound } from "next/navigation";
+import { AiStatsFilters } from "../ai-stats-filters";
 import { formatAiCost, formatAiStatsDate } from "../format-ai-cost";
-import { AiTaskFilters } from "./ai-task-filters";
 import { AiTaskModelTable } from "./ai-task-model-table";
 
 /**
@@ -32,10 +34,10 @@ export async function AiTaskReport({
 
   const resolvedSearchParams = await searchParams;
   const range = resolveAiTaskDateRange({
-    from: getSingleSearchParam(resolvedSearchParams.from),
-    to: getSingleSearchParam(resolvedSearchParams.to),
+    from: getSingleSearchParamValue(resolvedSearchParams.from),
+    to: getSingleSearchParamValue(resolvedSearchParams.to),
   });
-  const runCount = resolveEstimateRunCount(getSingleSearchParam(resolvedSearchParams.runs));
+  const runCount = resolveEstimateRunCount(getSingleSearchParamValue(resolvedSearchParams.runs));
   const report = await getAiTaskReport({
     endDate: range.endInput,
     runCount,
@@ -45,11 +47,11 @@ export async function AiTaskReport({
 
   return (
     <div className="flex flex-col gap-8">
-      <AiTaskFilters
+      <AiStatsFilters
+        actionHref={getAiTaskHref(taskName)}
         endDate={range.endInput}
         runCount={runCount}
         startDate={range.startInput}
-        taskName={taskName}
       />
 
       <div className="flex flex-col gap-2">
@@ -122,13 +124,4 @@ export function AiTaskReportSkeleton() {
       <Skeleton className="h-72 w-full rounded-lg" />
     </div>
   );
-}
-
-/**
- * Next search params can arrive as `string | string[] | undefined`. The AI stats
- * view only supports one value per filter, so this helper safely narrows those
- * fields before the date and run-count validators consume them.
- */
-function getSingleSearchParam(value?: string | string[]): string | undefined {
-  return typeof value === "string" ? value : undefined;
 }

--- a/apps/admin/src/app/(private)/stats/ai/ai-estimate-breakdown.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/ai-estimate-breakdown.tsx
@@ -1,0 +1,172 @@
+import {
+  type AiGenerationCostEstimate,
+  type EstimateLineItem,
+} from "@/data/stats/ai/get-ai-cost-estimates";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@zoonk/ui/components/accordion";
+import { Badge } from "@zoonk/ui/components/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@zoonk/ui/components/table";
+import { formatAiCost } from "./format-ai-cost";
+
+/**
+ * The top estimate cards answer the big questions quickly, but admins still
+ * need a way to inspect the math behind each total before trusting it.
+ */
+export function AiEstimateBreakdown({
+  estimates,
+  summaries,
+}: {
+  estimates: AiGenerationCostEstimate[];
+  summaries: Record<string, string>;
+}) {
+  return (
+    <section className="flex flex-col gap-4">
+      <header className="flex flex-col gap-0.5">
+        <h2 className="text-base font-semibold tracking-tight">Estimate Breakdown</h2>
+        <p className="text-muted-foreground/70 text-sm">
+          Each estimate shows the average requests per workflow, the historical average cost per
+          request, and any inferred cost that sits outside Gateway reporting.
+        </p>
+      </header>
+
+      <Accordion multiple variant="default">
+        {estimates.map((estimate) => (
+          <AccordionItem key={estimate.kind} value={estimate.kind}>
+            <AccordionTrigger>
+              <EstimateSummary estimate={estimate} summary={summaries[estimate.kind] ?? ""} />
+            </AccordionTrigger>
+            <AccordionContent className="flex flex-col gap-4">
+              <div className="overflow-hidden rounded-xl border">
+                <EstimateLineItemTable items={estimate.lineItems} />
+              </div>
+
+              {estimate.notes.length > 0 ? (
+                <ul className="text-muted-foreground flex list-disc flex-col gap-1 pl-5 text-sm">
+                  {estimate.notes.map((note) => (
+                    <li key={note}>{note}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </section>
+  );
+}
+
+/**
+ * Accordion headers need to summarize both the workflow name and the current
+ * total so admins can scan the full section without opening every item.
+ */
+function EstimateSummary({
+  estimate,
+  summary,
+}: {
+  estimate: AiGenerationCostEstimate;
+  summary: string;
+}) {
+  return (
+    <div className="flex w-full flex-wrap items-start justify-between gap-4">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="text-foreground text-sm font-medium">{estimate.title}</span>
+        <span className="text-muted-foreground text-sm">{estimate.description}</span>
+      </div>
+
+      <div className="flex flex-col items-end gap-1 text-right">
+        <span className="text-foreground text-base font-medium tabular-nums">
+          {formatAiCost(estimate.totalEstimatedCost)}
+        </span>
+        <span className="text-muted-foreground text-sm">{summary}</span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The estimate details are easiest to compare as a table because admins often
+ * need to see which task dominates the total and whether a row is inferred or
+ * missing direct cost data.
+ */
+function EstimateLineItemTable({ items }: { items: EstimateLineItem[] }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Component</TableHead>
+          <TableHead className="text-right">Avg Requests / Run</TableHead>
+          <TableHead className="text-right">Avg Cost / Request</TableHead>
+          <TableHead className="text-right">Estimated Cost</TableHead>
+          <TableHead className="text-right">Source</TableHead>
+        </TableRow>
+      </TableHeader>
+
+      <TableBody>
+        {items.map((item) => (
+          <TableRow key={item.taskName ?? item.label}>
+            <TableCell className="align-top">
+              <div className="flex flex-col gap-1">
+                <span className="font-medium">{item.label}</span>
+                {item.note ? (
+                  <span className="text-muted-foreground text-sm">{item.note}</span>
+                ) : null}
+              </div>
+            </TableCell>
+            <TableCell className="text-right align-top tabular-nums">
+              {formatEstimateRatio(item.averageRequestsPerRun)}
+            </TableCell>
+            <TableCell className="text-right align-top tabular-nums">
+              {item.averageCostPerRequest > 0 ? formatAiCost(item.averageCostPerRequest) : "—"}
+            </TableCell>
+            <TableCell className="text-right align-top tabular-nums">
+              {formatAiCost(item.estimatedCost)}
+            </TableCell>
+            <TableCell className="align-top">
+              <LineItemSource item={item} />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+/**
+ * Gateway-backed rows and inferred rows should be distinguishable at a glance,
+ * and missing cost coverage should stand out because it directly affects how
+ * complete the total estimate is.
+ */
+function LineItemSource({ item }: { item: EstimateLineItem }) {
+  return (
+    <div className="flex justify-end gap-2">
+      <Badge variant={item.isInferred ? "outline" : "secondary"}>
+        {item.isInferred ? "Inferred" : "Gateway"}
+      </Badge>
+
+      {item.hasUsageData ? null : <Badge variant="outline">No cost data</Badge>}
+    </div>
+  );
+}
+
+/**
+ * Request counts can be fractional once we average them across many lessons or
+ * courses. This formatter keeps the numbers compact without hiding smaller
+ * differences in workflow shape.
+ */
+function formatEstimateRatio(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: value > 0 && value < 1 ? 2 : 0,
+  }).format(value);
+}

--- a/apps/admin/src/app/(private)/stats/ai/ai-estimate-dashboard.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/ai-estimate-dashboard.tsx
@@ -1,0 +1,176 @@
+import { StatsSection, StatsSectionSkeleton } from "@/components/stats-section";
+import {
+  type AiCourseEstimateInputOverrides,
+  type AiCourseEstimateInputs,
+  type AiGenerationCostEstimate,
+  getAiCostEstimates,
+} from "@/data/stats/ai/get-ai-cost-estimates";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { AdminMetricCard } from "../_components/admin-metric-card";
+import { AiEstimateBreakdown } from "./ai-estimate-breakdown";
+import { AiEstimateFilters } from "./ai-estimate-filters";
+import { formatAiCost, formatAiStatsDate } from "./format-ai-cost";
+
+/**
+ * The estimates page focuses on workflow costs rather than raw task activity.
+ * It loads the selected-period lesson averages, resolves the editable course
+ * structure inputs, and renders the resulting lesson and course totals.
+ */
+export async function AiEstimateDashboard({
+  courseInputOverrides,
+  endDate,
+  startDate,
+}: {
+  courseInputOverrides: AiCourseEstimateInputOverrides;
+  endDate: string;
+  startDate: string;
+}) {
+  const report = await getAiCostEstimates({ courseInputOverrides, endDate, startDate });
+  const lessonEstimates = report.estimates.filter((estimate) => isLessonEstimate(estimate));
+  const courseEstimates = report.estimates.filter((estimate) => isCourseEstimate(estimate));
+  const summaries = Object.fromEntries(
+    report.estimates.map((estimate) => [
+      estimate.kind,
+      getEstimateSummary({ courseInputs: report.courseInputs, estimate }),
+    ]),
+  );
+
+  return (
+    <div className="flex flex-col gap-10">
+      <div className="flex flex-col gap-2">
+        <p className="text-muted-foreground text-sm">
+          Lesson estimates use average task cost from {formatAiStatsDate(startDate)} to{" "}
+          {formatAiStatsDate(endDate)}.
+        </p>
+        <p className="text-muted-foreground text-sm">
+          Language audio is inferred from newly created word and sentence audio because those TTS
+          calls do not appear in the Vercel Custom Reporting API.
+        </p>
+      </div>
+
+      <AiEstimateFilters
+        actionHref="/stats/ai/estimates"
+        courseInputs={report.courseInputs}
+        defaultCourseInputs={report.defaultCourseInputs}
+        endDate={endDate}
+        startDate={startDate}
+      />
+
+      <StatsSection
+        subtitle="Each total combines the average task cost with the average number of task runs needed to finish one lesson in this period."
+        title="Estimated Lesson Cost"
+      >
+        {lessonEstimates.map((estimate) => (
+          <AdminMetricCard
+            description={summaries[estimate.kind]}
+            key={estimate.kind}
+            title={estimate.title}
+            value={formatAiCost(estimate.totalEstimatedCost)}
+          />
+        ))}
+      </StatsSection>
+
+      <StatsSection
+        subtitle="These totals use the chapter and lesson counts entered above instead of waiting for fully generated courses to exist."
+        title="Estimated Course Cost"
+      >
+        {courseEstimates.map((estimate) => (
+          <AdminMetricCard
+            description={summaries[estimate.kind]}
+            key={estimate.kind}
+            title={estimate.title}
+            value={formatAiCost(estimate.totalEstimatedCost)}
+          />
+        ))}
+      </StatsSection>
+
+      <AiEstimateBreakdown estimates={report.estimates} summaries={summaries} />
+    </div>
+  );
+}
+
+/**
+ * The estimates page mixes Gateway reports and database aggregates, so this
+ * placeholder keeps the layout stable while those server queries resolve after
+ * navigation or filter changes.
+ */
+export function AiEstimateDashboardSkeleton() {
+  return (
+    <div className="flex flex-col gap-10">
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-4 w-72" />
+        <Skeleton className="h-4 w-96" />
+      </div>
+
+      <section className="flex flex-col gap-4">
+        <header className="flex flex-col gap-1">
+          <Skeleton className="h-5 w-36" />
+          <Skeleton className="h-4 w-96" />
+        </header>
+        <Skeleton className="h-72 w-full rounded-lg" />
+      </section>
+
+      <StatsSectionSkeleton items={3} />
+      <StatsSectionSkeleton items={2} />
+
+      <section className="flex flex-col gap-4">
+        <header className="flex flex-col gap-0.5">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-4 w-96" />
+        </header>
+        <Skeleton className="h-80 w-full rounded-lg" />
+      </section>
+    </div>
+  );
+}
+
+/**
+ * Lesson estimates should surface how much historical lesson data exists in the
+ * selected period, while course estimates should echo the explicit course shape
+ * the admin entered above.
+ */
+function getEstimateSummary({
+  courseInputs,
+  estimate,
+}: {
+  courseInputs: AiCourseEstimateInputs;
+  estimate: AiGenerationCostEstimate;
+}) {
+  if (estimate.kind === "regularCourse") {
+    return `${courseInputs.regularChapterCount.toLocaleString()} chapters, ${courseInputs.regularCoreLessonsPerChapter.toLocaleString()} core/chapter, ${courseInputs.regularCustomLessonsPerChapter.toLocaleString()} custom/chapter.`;
+  }
+
+  if (estimate.kind === "languageCourse") {
+    return `${courseInputs.languageChapterCount.toLocaleString()} chapters, ${courseInputs.languageLessonsPerChapter.toLocaleString()} language/chapter.`;
+  }
+
+  if (estimate.sampleCount <= 0) {
+    return `No ${estimate.runLabel} in this period.`;
+  }
+
+  return `Based on ${estimate.sampleCount.toLocaleString()} ${estimate.runLabel}.`;
+}
+
+/**
+ * Lesson and course estimates are rendered in separate card groups so the page
+ * answers the user's questions in the same buckets they asked for.
+ */
+function isLessonEstimate(
+  estimate: AiGenerationCostEstimate,
+): estimate is AiGenerationCostEstimate {
+  return (
+    estimate.kind === "coreLesson" ||
+    estimate.kind === "customLesson" ||
+    estimate.kind === "languageLesson"
+  );
+}
+
+/**
+ * Course totals use a different mental model than lesson totals because they
+ * are driven by explicit chapter and lesson counts entered on the page.
+ */
+function isCourseEstimate(
+  estimate: AiGenerationCostEstimate,
+): estimate is AiGenerationCostEstimate {
+  return estimate.kind === "regularCourse" || estimate.kind === "languageCourse";
+}

--- a/apps/admin/src/app/(private)/stats/ai/ai-estimate-filters.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/ai-estimate-filters.tsx
@@ -1,0 +1,215 @@
+import { type AiCourseEstimateInputs } from "@/data/stats/ai/get-ai-cost-estimates";
+import { Button, buttonVariants } from "@zoonk/ui/components/button";
+import { Input } from "@zoonk/ui/components/input";
+import { Label } from "@zoonk/ui/components/label";
+import Link from "next/link";
+
+/**
+ * Course estimates need both the reporting window and the planned course shape.
+ * A single GET form keeps those assumptions shareable in the URL and avoids any
+ * client-side state for what is purely server-rendered analytics.
+ */
+export function AiEstimateFilters({
+  actionHref,
+  courseInputs,
+  defaultCourseInputs,
+  endDate,
+  startDate,
+}: {
+  actionHref: string;
+  courseInputs: AiCourseEstimateInputs;
+  defaultCourseInputs: AiCourseEstimateInputs;
+  endDate: string;
+  startDate: string;
+}) {
+  return (
+    <section className="flex flex-col gap-4">
+      <header className="flex flex-col gap-1">
+        <h2 className="text-base font-semibold tracking-tight">Estimate Inputs</h2>
+        <p className="text-muted-foreground text-sm">
+          Defaults come from the selected period when we have enough data. Override them to model a
+          planned course before it exists end to end.
+        </p>
+      </header>
+
+      <form action={actionHref} className="flex flex-col gap-6">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <FilterField htmlFor="from" label="From">
+            <Input defaultValue={startDate} id="from" name="from" type="date" />
+          </FilterField>
+
+          <FilterField htmlFor="to" label="To">
+            <Input defaultValue={endDate} id="to" name="to" type="date" />
+          </FilterField>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          <RegularCourseFieldset
+            courseInputs={courseInputs}
+            defaultCourseInputs={defaultCourseInputs}
+          />
+          <LanguageCourseFieldset
+            courseInputs={courseInputs}
+            defaultCourseInputs={defaultCourseInputs}
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button type="submit" variant="outline">
+            Apply
+          </Button>
+
+          <Link className={buttonVariants({ variant: "ghost" })} href={actionHref}>
+            Reset
+          </Link>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+/**
+ * The estimate form repeats the same label-plus-input structure across both
+ * course types. This wrapper keeps the layout readable and ensures each field
+ * stays properly labeled for semantic queries and keyboard users.
+ */
+function FilterField({
+  children,
+  htmlFor,
+  label,
+}: {
+  children: React.ReactNode;
+  htmlFor: string;
+  label: string;
+}) {
+  return (
+    <div className="flex min-w-32 flex-col gap-1.5">
+      <Label htmlFor={htmlFor}>{label}</Label>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Regular-course defaults include both core and custom lesson counts, so the
+ * helper copy should surface all three assumptions in one compact sentence.
+ */
+function describeRegularDefaults(courseInputs: AiCourseEstimateInputs) {
+  return `${courseInputs.regularChapterCount.toLocaleString()} chapters, ${courseInputs.regularCoreLessonsPerChapter.toLocaleString()} core per chapter, ${courseInputs.regularCustomLessonsPerChapter.toLocaleString()} custom per chapter.`;
+}
+
+/**
+ * Language-course defaults only need one lesson count per chapter, so the copy
+ * can stay shorter while still making the assumption explicit.
+ */
+function describeLanguageDefaults(courseInputs: AiCourseEstimateInputs) {
+  return `${courseInputs.languageChapterCount.toLocaleString()} chapters, ${courseInputs.languageLessonsPerChapter.toLocaleString()} language lessons per chapter.`;
+}
+
+/**
+ * Regular-course planning needs three numeric inputs, so this fieldset keeps
+ * that group isolated from the rest of the form and avoids excessive JSX
+ * nesting in the parent component.
+ */
+function RegularCourseFieldset({
+  courseInputs,
+  defaultCourseInputs,
+}: {
+  courseInputs: AiCourseEstimateInputs;
+  defaultCourseInputs: AiCourseEstimateInputs;
+}) {
+  return (
+    <fieldset className="flex flex-col gap-3">
+      <legend className="text-sm font-medium">Regular Course Shape</legend>
+      <p className="text-muted-foreground text-sm">
+        Default: {describeRegularDefaults(defaultCourseInputs)}
+      </p>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <EstimateNumberField
+          htmlFor="regularChapterCount"
+          label="Chapters"
+          min={1}
+          name="regularChapterCount"
+          value={courseInputs.regularChapterCount}
+        />
+        <EstimateNumberField
+          htmlFor="regularCoreLessonsPerChapter"
+          label="Core / Chapter"
+          min={1}
+          name="regularCoreLessonsPerChapter"
+          value={courseInputs.regularCoreLessonsPerChapter}
+        />
+        <EstimateNumberField
+          htmlFor="regularCustomLessonsPerChapter"
+          label="Custom / Chapter"
+          min={0}
+          name="regularCustomLessonsPerChapter"
+          value={courseInputs.regularCustomLessonsPerChapter}
+        />
+      </div>
+    </fieldset>
+  );
+}
+
+/**
+ * Language-course planning only needs the chapter count and the number of
+ * language lessons per chapter, so its fieldset can stay compact.
+ */
+function LanguageCourseFieldset({
+  courseInputs,
+  defaultCourseInputs,
+}: {
+  courseInputs: AiCourseEstimateInputs;
+  defaultCourseInputs: AiCourseEstimateInputs;
+}) {
+  return (
+    <fieldset className="flex flex-col gap-3">
+      <legend className="text-sm font-medium">Language Course Shape</legend>
+      <p className="text-muted-foreground text-sm">
+        Default: {describeLanguageDefaults(defaultCourseInputs)}
+      </p>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <EstimateNumberField
+          htmlFor="languageChapterCount"
+          label="Chapters"
+          min={1}
+          name="languageChapterCount"
+          value={courseInputs.languageChapterCount}
+        />
+        <EstimateNumberField
+          htmlFor="languageLessonsPerChapter"
+          label="Language / Chapter"
+          min={1}
+          name="languageLessonsPerChapter"
+          value={courseInputs.languageLessonsPerChapter}
+        />
+      </div>
+    </fieldset>
+  );
+}
+
+/**
+ * Every course-shape input is the same labeled number field. This helper keeps
+ * the estimate form consistent and removes repeated JSX from the fieldsets.
+ */
+function EstimateNumberField({
+  htmlFor,
+  label,
+  min,
+  name,
+  value,
+}: {
+  htmlFor: string;
+  label: string;
+  min: number;
+  name: string;
+  value: number;
+}) {
+  return (
+    <FilterField htmlFor={htmlFor} label={label}>
+      <Input defaultValue={String(value)} id={htmlFor} min={min} name={name} type="number" />
+    </FilterField>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/ai/ai-stats-filters.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/ai-stats-filters.tsx
@@ -1,29 +1,26 @@
-import { getAiTaskHref } from "@/data/stats/ai/ai-task-stats";
 import { Button, buttonVariants } from "@zoonk/ui/components/button";
 import { Input } from "@zoonk/ui/components/input";
 import { Label } from "@zoonk/ui/components/label";
 import Link from "next/link";
 
 /**
- * The detail page is fully server-rendered, so the filters use a plain GET form.
- * That keeps date filtering and cost-estimate inputs shareable in the URL
- * without adding client-side state just to update analytics parameters.
+ * The AI stats pages are fully server-rendered, so the filters use a plain GET
+ * form. That keeps the selected reporting window shareable in the URL without
+ * introducing client-side state just to update analytics parameters.
  */
-export function AiTaskFilters({
+export function AiStatsFilters({
+  actionHref,
   endDate,
   runCount,
   startDate,
-  taskName,
 }: {
+  actionHref: string;
   endDate: string;
-  runCount: number;
+  runCount?: number;
   startDate: string;
-  taskName: string;
 }) {
-  const resetHref = getAiTaskHref(taskName);
-
   return (
-    <form action={resetHref} className="flex flex-wrap items-end gap-3">
+    <form action={actionHref} className="flex flex-wrap items-end gap-3">
       <FilterField htmlFor="from" label="From">
         <Input defaultValue={startDate} id="from" name="from" type="date" />
       </FilterField>
@@ -32,16 +29,18 @@ export function AiTaskFilters({
         <Input defaultValue={endDate} id="to" name="to" type="date" />
       </FilterField>
 
-      <FilterField htmlFor="runs" label="Estimate Runs">
-        <Input defaultValue={String(runCount)} id="runs" min={1} name="runs" type="number" />
-      </FilterField>
+      {runCount === undefined ? null : (
+        <FilterField htmlFor="runs" label="Estimate Runs">
+          <Input defaultValue={String(runCount)} id="runs" min={1} name="runs" type="number" />
+        </FilterField>
+      )}
 
       <div className="flex items-center gap-2">
         <Button type="submit" variant="outline">
           Apply
         </Button>
 
-        <Link className={buttonVariants({ variant: "ghost" })} href={resetHref}>
+        <Link className={buttonVariants({ variant: "ghost" })} href={actionHref}>
           Reset
         </Link>
       </div>
@@ -50,9 +49,9 @@ export function AiTaskFilters({
 }
 
 /**
- * The filter controls repeat the same label-plus-input structure three times.
- * This small wrapper keeps the form readable and ensures each input stays
- * properly labeled for semantic queries and keyboard users.
+ * The date range and optional run-count controls repeat the same label-plus-
+ * input structure. This wrapper keeps the form readable and ensures each input
+ * stays properly labeled for semantic queries and keyboard users.
  */
 function FilterField({
   children,

--- a/apps/admin/src/app/(private)/stats/ai/ai-task-list.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/ai-task-list.tsx
@@ -1,26 +1,37 @@
-import { resolveAiTaskDateRange } from "@/data/stats/ai/ai-task-stats";
 import { getAiTaskSummaries } from "@/data/stats/ai/get-ai-task-summaries";
+import { buttonVariants } from "@zoonk/ui/components/button";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
+import Link from "next/link";
 import { AiTaskTable } from "./ai-task-table";
+import { formatAiStatsDate } from "./format-ai-cost";
 
 /**
- * This server component owns the fixed last-30-days task index. Keeping the
- * date-range resolution and gateway query here lets the page component stay
- * focused on layout and suspense only.
+ * The task index should stay focused on raw Gateway activity. This server
+ * component loads the selected-period task summaries and links out to the
+ * dedicated estimates page for workflow-level cost modeling.
  */
-export async function AiTaskList() {
-  const { endInput, startInput } = resolveAiTaskDateRange({});
-  const tasks = await getAiTaskSummaries({ endDate: endInput, startDate: startInput });
+export async function AiTaskList({ endDate, startDate }: { endDate: string; startDate: string }) {
+  const tasks = await getAiTaskSummaries({ endDate, startDate });
 
   return (
-    <div className="flex flex-col gap-4">
-      <p className="text-muted-foreground text-sm">
-        Request counts and fallback usage for gateway-tagged AI tasks in the last 30 days.
-      </p>
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <p className="text-muted-foreground max-w-3xl text-sm">
+          Request counts and fallback usage for gateway-tagged AI tasks from{" "}
+          {formatAiStatsDate(startDate)} to {formatAiStatsDate(endDate)}.
+        </p>
+
+        <Link
+          className={buttonVariants({ variant: "outline" })}
+          href={buildEstimateHref({ endDate, startDate })}
+        >
+          Cost Estimates
+        </Link>
+      </div>
 
       {tasks.length > 0 ? (
         <div className="rounded-lg border">
-          <AiTaskTable tasks={tasks} />
+          <AiTaskTable endDate={endDate} startDate={startDate} tasks={tasks} />
         </div>
       ) : (
         <p className="text-muted-foreground text-sm">No AI task requests were reported yet.</p>
@@ -30,14 +41,26 @@ export async function AiTaskList() {
 }
 
 /**
- * The task list is gateway-backed runtime data, so the page needs a lightweight
- * placeholder while the report request resolves on navigation.
+ * The task list is backed by runtime Gateway data, so the page keeps a light
+ * placeholder while the server report resolves on navigation.
  */
 export function AiTaskListSkeleton() {
   return (
-    <div className="flex flex-col gap-4">
-      <Skeleton className="h-4 w-72" />
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <Skeleton className="h-4 w-96" />
+        <Skeleton className="h-10 w-36 rounded-full" />
+      </div>
       <Skeleton className="h-64 w-full rounded-lg" />
     </div>
   );
+}
+
+/**
+ * The estimates page reads its period from the query string. Building the href
+ * in one place keeps the task page link aligned with that route contract.
+ */
+function buildEstimateHref({ endDate, startDate }: { endDate: string; startDate: string }) {
+  const searchParams = new URLSearchParams({ from: startDate, to: endDate });
+  return `/stats/ai/estimates?${searchParams.toString()}`;
 }

--- a/apps/admin/src/app/(private)/stats/ai/ai-task-table.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/ai-task-table.tsx
@@ -16,7 +16,15 @@ import Link from "next/link";
  * the clearest way to compare request counts and gives each task a predictable
  * link target into its detail view.
  */
-export function AiTaskTable({ tasks }: { tasks: AiTaskSummary[] }) {
+export function AiTaskTable({
+  endDate,
+  startDate,
+  tasks,
+}: {
+  endDate: string;
+  startDate: string;
+  tasks: AiTaskSummary[];
+}) {
   return (
     <Table>
       <TableHeader>
@@ -29,7 +37,7 @@ export function AiTaskTable({ tasks }: { tasks: AiTaskSummary[] }) {
 
       <TableBody>
         {tasks.map((task) => (
-          <AiTaskRow key={task.taskName} task={task} />
+          <AiTaskRow endDate={endDate} key={task.taskName} startDate={startDate} task={task} />
         ))}
       </TableBody>
     </Table>
@@ -37,12 +45,20 @@ export function AiTaskTable({ tasks }: { tasks: AiTaskSummary[] }) {
 }
 
 /**
- * Each summary row links to the task detail view while preserving the 30-day
- * window shown on the index page. That way the detail view opens in the same
- * context the admin just inspected.
+ * Each summary row links to the task detail view while preserving the selected
+ * report range. That way the detail page opens in the same context the admin
+ * just inspected on the index view.
  */
-function AiTaskRow({ task }: { task: AiTaskSummary }) {
-  const href = getAiTaskHref(task.taskName);
+function AiTaskRow({
+  endDate,
+  startDate,
+  task,
+}: {
+  endDate: string;
+  startDate: string;
+  task: AiTaskSummary;
+}) {
+  const href = buildTaskHref({ endDate, startDate, taskName: task.taskName });
 
   return (
     <TableRow>
@@ -76,4 +92,22 @@ function FallbackCount({ task }: { task: AiTaskSummary }) {
   }
 
   return <span className="tabular-nums">{task.fallbackRequestCount.toLocaleString()}</span>;
+}
+
+/**
+ * The detail page reads its filters from the query string. Building the href in
+ * one place keeps the index links aligned with that contract and avoids hand-
+ * written query strings drifting across call sites.
+ */
+function buildTaskHref({
+  endDate,
+  startDate,
+  taskName,
+}: {
+  endDate: string;
+  startDate: string;
+  taskName: string;
+}): string {
+  const searchParams = new URLSearchParams({ from: startDate, to: endDate });
+  return `${getAiTaskHref(taskName)}?${searchParams.toString()}`;
 }

--- a/apps/admin/src/app/(private)/stats/ai/estimates/page.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/estimates/page.tsx
@@ -1,0 +1,51 @@
+import { getSingleSearchParamValue, resolveAiTaskDateRange } from "@/data/stats/ai/ai-task-stats";
+import { type Metadata } from "next";
+import { Suspense } from "react";
+import { StatsPageLayout } from "../../_components/stats-page-layout";
+import { AiEstimateDashboard, AiEstimateDashboardSkeleton } from "../ai-estimate-dashboard";
+
+export const metadata: Metadata = {
+  title: "AI Cost Estimates",
+};
+
+/**
+ * Workflow cost modeling lives on its own page so the task index can stay
+ * focused on raw Gateway activity while this route concentrates on lesson and
+ * course cost estimation.
+ */
+export default async function AiEstimatesPage({ searchParams }: PageProps<"/stats/ai/estimates">) {
+  const resolvedSearchParams = await searchParams;
+  const range = resolveAiTaskDateRange({
+    from: getSingleSearchParamValue(resolvedSearchParams.from),
+    to: getSingleSearchParamValue(resolvedSearchParams.to),
+  });
+  const courseInputOverrides = {
+    languageChapterCount: getSingleSearchParamValue(resolvedSearchParams.languageChapterCount),
+    languageLessonsPerChapter: getSingleSearchParamValue(
+      resolvedSearchParams.languageLessonsPerChapter,
+    ),
+    regularChapterCount: getSingleSearchParamValue(resolvedSearchParams.regularChapterCount),
+    regularCoreLessonsPerChapter: getSingleSearchParamValue(
+      resolvedSearchParams.regularCoreLessonsPerChapter,
+    ),
+    regularCustomLessonsPerChapter: getSingleSearchParamValue(
+      resolvedSearchParams.regularCustomLessonsPerChapter,
+    ),
+  };
+
+  return (
+    <StatsPageLayout
+      breadcrumbItems={[{ href: "/stats/ai", label: "AI Tasks" }, { label: "Estimates" }]}
+      showPeriodTabs={false}
+      title="AI Cost Estimates"
+    >
+      <Suspense fallback={<AiEstimateDashboardSkeleton />}>
+        <AiEstimateDashboard
+          courseInputOverrides={courseInputOverrides}
+          endDate={range.endInput}
+          startDate={range.startInput}
+        />
+      </Suspense>
+    </StatsPageLayout>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/ai/page.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/page.tsx
@@ -1,6 +1,8 @@
+import { getSingleSearchParamValue, resolveAiTaskDateRange } from "@/data/stats/ai/ai-task-stats";
 import { type Metadata } from "next";
 import { Suspense } from "react";
 import { StatsPageLayout } from "../_components/stats-page-layout";
+import { AiStatsFilters } from "./ai-stats-filters";
 import { AiTaskList, AiTaskListSkeleton } from "./ai-task-list";
 
 export const metadata: Metadata = {
@@ -9,13 +11,30 @@ export const metadata: Metadata = {
 
 /**
  * The AI stats index is its own stats subsection, so it reuses the shared stats
- * shell and streams the task table once the gateway report has loaded.
+ * shell and streams the selected-period task list once the Gateway report has
+ * loaded.
  */
-export default function AiTasksPage() {
+export default async function AiTasksPage({ searchParams }: PageProps<"/stats/ai">) {
+  const resolvedSearchParams = await searchParams;
+  const range = resolveAiTaskDateRange({
+    from: getSingleSearchParamValue(resolvedSearchParams.from),
+    to: getSingleSearchParamValue(resolvedSearchParams.to),
+  });
+
   return (
-    <StatsPageLayout showPeriodTabs={false} title="AI Tasks">
+    <StatsPageLayout
+      navigation={
+        <AiStatsFilters
+          actionHref="/stats/ai"
+          endDate={range.endInput}
+          startDate={range.startInput}
+        />
+      }
+      showPeriodTabs={false}
+      title="AI Tasks"
+    >
       <Suspense fallback={<AiTaskListSkeleton />}>
-        <AiTaskList />
+        <AiTaskList endDate={range.endInput} startDate={range.startInput} />
       </Suspense>
     </StatsPageLayout>
   );

--- a/apps/admin/src/data/stats/ai/_utils/ai-cost-estimate-constants.ts
+++ b/apps/admin/src/data/stats/ai/_utils/ai-cost-estimate-constants.ts
@@ -1,0 +1,34 @@
+export const REGULAR_COURSE_ESTIMATE_NOTE =
+  "Assumes the course suggestion already exists and estimates the full curriculum, not only the first generated chapter.";
+
+export const COURSE_INPUT_ESTIMATE_NOTE =
+  "Course totals use the lesson and chapter counts entered on this page instead of relying on completed-course history.";
+
+export const LANGUAGE_TTS_ESTIMATE_NOTE =
+  "TTS is inferred from newly created word and sentence audio assets because Gateway does not report those calls.";
+
+export const LANGUAGE_TTS_HEURISTIC_NOTE =
+  "Audio cost assumes Gemini TTS pricing for all clips, about 70 words per 100 text tokens, 32 audio tokens per second, and a 0.75s minimum for single-word clips.";
+
+export const VISUAL_TASK_BY_KIND = {
+  chart: "visual-chart",
+  code: "visual-code",
+  diagram: "visual-diagram",
+  formula: "visual-formula",
+  image: "step-visual-image",
+  music: "visual-music",
+  quote: "visual-quote",
+  table: "visual-table",
+  timeline: "visual-timeline",
+} as const satisfies Record<string, string>;
+
+export const LANGUAGE_GATEWAY_TASKS = [
+  "activity-vocabulary",
+  "activity-distractors",
+  "activity-pronunciation",
+  "activity-romanization",
+  "activity-translation",
+  "activity-sentences",
+  "activity-grammar-content",
+  "activity-grammar-user-content",
+] as const;

--- a/apps/admin/src/data/stats/ai/_utils/ai-cost-estimate-helpers.ts
+++ b/apps/admin/src/data/stats/ai/_utils/ai-cost-estimate-helpers.ts
@@ -1,0 +1,225 @@
+import {
+  type TaskUsageByName,
+  calculateAverageRequestsPerEntity,
+  estimateGeminiTtsCost,
+  formatAiTaskLabel,
+} from "../ai-task-stats";
+import { LANGUAGE_TTS_HEURISTIC_NOTE, VISUAL_TASK_BY_KIND } from "./ai-cost-estimate-constants";
+import {
+  type EstimateLineItem,
+  type StructureStats,
+  type VisualUsageRow,
+} from "./ai-cost-estimate-types";
+
+/**
+ * The UI cards show one total, but the totals should still be explainable. Each
+ * Gateway line item keeps the original task name, the per-request cost, and the
+ * normalized number of requests we expect for one lesson or course.
+ */
+export function buildGatewayLineItem({
+  averageRequestsPerRun,
+  taskName,
+  usageByTask,
+}: {
+  averageRequestsPerRun: number;
+  taskName: string;
+  usageByTask: TaskUsageByName;
+}): EstimateLineItem | null {
+  if (averageRequestsPerRun <= 0) {
+    return null;
+  }
+
+  const usage = usageByTask[taskName];
+  const averageCostPerRequest = usage?.averageMarketCostPerRequest ?? 0;
+
+  return {
+    averageCostPerRequest,
+    averageRequestsPerRun,
+    estimatedCost: averageRequestsPerRun * averageCostPerRequest,
+    hasUsageData: Boolean(usage && usage.requestCount > 0),
+    isInferred: false,
+    label: formatAiTaskLabel(taskName),
+    taskName,
+  };
+}
+
+/**
+ * Some costs do not map to a single Gateway task. Aggregate line items keep
+ * those costs visible in the breakdown without pretending there was one
+ * underlying task row.
+ */
+export function buildAggregateLineItem({
+  averageRequestsPerRun,
+  estimatedCost,
+  label,
+  note,
+}: {
+  averageRequestsPerRun: number;
+  estimatedCost: number;
+  label: string;
+  note?: string;
+}): EstimateLineItem | null {
+  if (averageRequestsPerRun <= 0 || estimatedCost <= 0) {
+    return null;
+  }
+
+  return {
+    averageCostPerRequest: estimatedCost / averageRequestsPerRun,
+    averageRequestsPerRun,
+    estimatedCost,
+    hasUsageData: true,
+    isInferred: true,
+    label,
+    note,
+  };
+}
+
+/**
+ * Language audio clips sit outside Gateway. Surfacing the TTS estimate as its
+ * own line item makes that approximation explicit instead of burying it inside
+ * the lesson total.
+ */
+export function buildTtsLineItem({
+  totalAudioSeconds,
+  totalInputWordCount,
+}: {
+  totalAudioSeconds: number;
+  totalInputWordCount: number;
+}): EstimateLineItem | null {
+  if (totalAudioSeconds <= 0 || totalInputWordCount <= 0) {
+    return null;
+  }
+
+  return {
+    averageCostPerRequest: 0,
+    averageRequestsPerRun: totalAudioSeconds,
+    estimatedCost: estimateGeminiTtsCost({ totalAudioSeconds, totalInputWordCount }),
+    hasUsageData: true,
+    isInferred: true,
+    label: "Estimated TTS audio",
+    note: LANGUAGE_TTS_HEURISTIC_NOTE,
+  };
+}
+
+/**
+ * Visual dispatch requests map one-to-one to persisted visual rows, so the
+ * database is the most reliable way to attribute those shared tasks back to
+ * core explanations versus custom activities.
+ */
+export function buildVisualLineItems({
+  activityKind,
+  entityCount,
+  structureStats,
+  usageByTask,
+}: {
+  activityKind: "custom" | "explanation";
+  entityCount: number;
+  structureStats: StructureStats;
+  usageByTask: TaskUsageByName;
+}): EstimateLineItem[] {
+  return Object.entries(VISUAL_TASK_BY_KIND)
+    .map(([visualKind, taskName]) =>
+      buildGatewayLineItem({
+        averageRequestsPerRun: calculateAverageRequestsPerEntity({
+          entityCount,
+          requestCount: structureStats.visualCountsByKey[`${activityKind}:${visualKind}`] ?? 0,
+        }),
+        taskName,
+        usageByTask,
+      }),
+    )
+    .filter((item): item is EstimateLineItem => item !== null);
+}
+
+/**
+ * The workflow guarantees one applied activity slot in core lessons, but
+ * historical data can still be sparse or messy. Normalizing the
+ * story/investigation mix back to one slot keeps the estimate aligned with the
+ * product rule the admin cares about.
+ */
+export function getAppliedActivityShares({
+  investigationCount,
+  storyCount,
+}: {
+  investigationCount: number;
+  storyCount: number;
+}): { investigationShare: number; storyShare: number } {
+  const totalAppliedActivities = storyCount + investigationCount;
+
+  if (totalAppliedActivities <= 0) {
+    return { investigationShare: 0.5, storyShare: 0.5 };
+  }
+
+  return {
+    investigationShare: investigationCount / totalAppliedActivities,
+    storyShare: storyCount / totalAppliedActivities,
+  };
+}
+
+/**
+ * Some workflows use historical task counts directly instead of persisted
+ * content records. This helper centralizes the "requests per entity" math so
+ * the builders all normalize task usage the same way.
+ */
+export function getAverageTaskRequestsPerRun({
+  entityCount,
+  taskName,
+  usageByTask,
+}: {
+  entityCount: number;
+  taskName: string;
+  usageByTask: TaskUsageByName;
+}): number {
+  return calculateAverageRequestsPerEntity({
+    entityCount,
+    requestCount: usageByTask[taskName]?.requestCount ?? 0,
+  });
+}
+
+/**
+ * Every estimate ultimately rolls up into one currency number, so this helper
+ * keeps the final sum consistent across lesson and course builders.
+ */
+export function sumLineItems(items: EstimateLineItem[]): number {
+  return items.reduce((sum, item) => sum + item.estimatedCost, 0);
+}
+
+/**
+ * Most estimate builders assemble arrays with optional line items. This keeps
+ * those builders readable while still giving TypeScript a concrete
+ * `EstimateLineItem[]` before totals are calculated.
+ */
+export function isEstimateLineItem(item: EstimateLineItem | null): item is EstimateLineItem {
+  return item !== null;
+}
+
+/**
+ * The SQL visual query returns one row per activity-kind and visual-kind pair.
+ * Flattening that into a predictable key-value map keeps the estimate builders
+ * free from row-scanning logic and makes missing combinations naturally fall
+ * back to zero.
+ */
+export function buildVisualCountMap(rows: VisualUsageRow[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+
+  for (const row of rows) {
+    const visualKind = row.visualKind ?? "image";
+    const key = `${row.activityKind}:${visualKind}`;
+    counts[key] = toNumber(row.count);
+  }
+
+  return counts;
+}
+
+/**
+ * The raw SQL helpers return bigint counts from Postgres. Converting them in one
+ * place keeps the structure loader focused on domain values instead of database
+ * transport types.
+ */
+export function toNumber(value: bigint | number | null | undefined): number {
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+
+  return value ?? 0;
+}

--- a/apps/admin/src/data/stats/ai/_utils/ai-cost-estimate-types.ts
+++ b/apps/admin/src/data/stats/ai/_utils/ai-cost-estimate-types.ts
@@ -1,0 +1,81 @@
+export type EstimateKind =
+  | "coreLesson"
+  | "customLesson"
+  | "languageLesson"
+  | "regularCourse"
+  | "languageCourse";
+
+export type EstimateLineItem = {
+  averageCostPerRequest: number;
+  averageRequestsPerRun: number;
+  estimatedCost: number;
+  hasUsageData: boolean;
+  isInferred: boolean;
+  label: string;
+  note?: string;
+  taskName?: string;
+};
+
+export type AiGenerationCostEstimate = {
+  description: string;
+  kind: EstimateKind;
+  lineItems: EstimateLineItem[];
+  notes: string[];
+  runLabel: string;
+  sampleCount: number;
+  title: string;
+  totalEstimatedCost: number;
+};
+
+export type AiCourseEstimateInputs = {
+  languageChapterCount: number;
+  languageLessonsPerChapter: number;
+  regularChapterCount: number;
+  regularCoreLessonsPerChapter: number;
+  regularCustomLessonsPerChapter: number;
+};
+
+export type AiCourseEstimateInputOverrides = Partial<
+  Record<keyof AiCourseEstimateInputs, number | string | undefined>
+>;
+
+export type AiCostEstimateReport = {
+  courseInputs: AiCourseEstimateInputs;
+  defaultCourseInputs: AiCourseEstimateInputs;
+  estimates: AiGenerationCostEstimate[];
+};
+
+export type VisualUsageRow = {
+  activityKind: "custom" | "explanation";
+  count: bigint;
+  visualKind: string | null;
+};
+
+export type LanguageAudioUsageRow = {
+  sentenceWordCount: bigint | null;
+  wordClipCount: bigint | null;
+};
+
+export type StructureStats = {
+  completedLanguageChapterCount: number;
+  completedRegularChapterCount: number;
+  coreLessonCount: number;
+  coreLessonExplanationCount: number;
+  coreLessonInvestigationCount: number;
+  coreLessonPracticeCount: number;
+  coreLessonQuizCount: number;
+  coreLessonStoryCount: number;
+  customActivityCount: number;
+  customLessonCount: number;
+  languageAudioSentenceWordCount: number;
+  languageAudioWordClipCount: number;
+  languageCourseChapterCount: number;
+  languageCourseCount: number;
+  languageLessonCount: number;
+  languageLessonCountInCourses: number;
+  regularCoreLessonCountInCourses: number;
+  regularCourseChapterCount: number;
+  regularCourseCount: number;
+  regularCustomLessonCountInCourses: number;
+  visualCountsByKey: Record<string, number>;
+};

--- a/apps/admin/src/data/stats/ai/_utils/ai-course-estimate-inputs.ts
+++ b/apps/admin/src/data/stats/ai/_utils/ai-course-estimate-inputs.ts
@@ -1,0 +1,138 @@
+import { calculateAverageRequestsPerEntity } from "../ai-task-stats";
+import { type AiCourseEstimateInputs, type StructureStats } from "./ai-cost-estimate-types";
+
+type CourseInputOverride = number | string | undefined;
+
+/**
+ * Course totals should be editable because course generation is on-demand and
+ * we often do not have many fully generated courses to average from. These
+ * defaults seed the form with the nearest observed structure from the selected
+ * period when data exists.
+ */
+export function buildDefaultCourseEstimateInputs({
+  structureStats,
+}: {
+  structureStats: StructureStats;
+}): AiCourseEstimateInputs {
+  return {
+    languageChapterCount: normalizeInteger({
+      fallback: 1,
+      minimum: 1,
+      value: roundAverage({
+        entityCount: structureStats.languageCourseCount,
+        totalCount: structureStats.languageCourseChapterCount,
+      }),
+    }),
+    languageLessonsPerChapter: normalizeInteger({
+      fallback: 1,
+      minimum: 1,
+      value: roundAverage({
+        entityCount: structureStats.completedLanguageChapterCount,
+        totalCount: structureStats.languageLessonCountInCourses,
+      }),
+    }),
+    regularChapterCount: normalizeInteger({
+      fallback: 1,
+      minimum: 1,
+      value: roundAverage({
+        entityCount: structureStats.regularCourseCount,
+        totalCount: structureStats.regularCourseChapterCount,
+      }),
+    }),
+    regularCoreLessonsPerChapter: normalizeInteger({
+      fallback: 1,
+      minimum: 1,
+      value: roundAverage({
+        entityCount: structureStats.completedRegularChapterCount,
+        totalCount: structureStats.regularCoreLessonCountInCourses,
+      }),
+    }),
+    regularCustomLessonsPerChapter: normalizeInteger({
+      fallback: 0,
+      minimum: 0,
+      value: roundAverage({
+        entityCount: structureStats.completedRegularChapterCount,
+        totalCount: structureStats.regularCustomLessonCountInCourses,
+      }),
+    }),
+  };
+}
+
+/**
+ * Search params are free-form strings. This resolver clamps them to safe whole
+ * numbers while preserving the selected-period defaults when the input is
+ * missing or invalid.
+ */
+export function resolveCourseEstimateInputs({
+  defaults,
+  overrides,
+}: {
+  defaults: AiCourseEstimateInputs;
+  overrides?: Partial<Record<keyof AiCourseEstimateInputs, CourseInputOverride>>;
+}): AiCourseEstimateInputs {
+  return {
+    languageChapterCount: normalizeInteger({
+      fallback: defaults.languageChapterCount,
+      minimum: 1,
+      value: overrides?.languageChapterCount,
+    }),
+    languageLessonsPerChapter: normalizeInteger({
+      fallback: defaults.languageLessonsPerChapter,
+      minimum: 1,
+      value: overrides?.languageLessonsPerChapter,
+    }),
+    regularChapterCount: normalizeInteger({
+      fallback: defaults.regularChapterCount,
+      minimum: 1,
+      value: overrides?.regularChapterCount,
+    }),
+    regularCoreLessonsPerChapter: normalizeInteger({
+      fallback: defaults.regularCoreLessonsPerChapter,
+      minimum: 1,
+      value: overrides?.regularCoreLessonsPerChapter,
+    }),
+    regularCustomLessonsPerChapter: normalizeInteger({
+      fallback: defaults.regularCustomLessonsPerChapter,
+      minimum: 0,
+      value: overrides?.regularCustomLessonsPerChapter,
+    }),
+  };
+}
+
+/**
+ * Course defaults only need whole-number suggestions for the form, so the
+ * selected-period averages get rounded here before any min/fallback rules
+ * apply.
+ */
+function roundAverage({
+  entityCount,
+  totalCount,
+}: {
+  entityCount: number;
+  totalCount: number;
+}): number {
+  return Math.round(calculateAverageRequestsPerEntity({ entityCount, requestCount: totalCount }));
+}
+
+/**
+ * Course planning inputs represent counts, not arbitrary numeric weights. This
+ * helper keeps those values as non-negative integers and falls back cleanly when
+ * the URL contains anything unexpected.
+ */
+function normalizeInteger({
+  fallback,
+  minimum,
+  value,
+}: {
+  fallback: number;
+  minimum: number;
+  value: CourseInputOverride;
+}) {
+  const parsedValue = typeof value === "number" ? value : Number.parseInt(value ?? "", 10);
+
+  if (!Number.isInteger(parsedValue) || parsedValue < minimum) {
+    return fallback;
+  }
+
+  return parsedValue;
+}

--- a/apps/admin/src/data/stats/ai/_utils/ai-course-estimate-inputs.ts
+++ b/apps/admin/src/data/stats/ai/_utils/ai-course-estimate-inputs.ts
@@ -1,3 +1,4 @@
+import { parseNumericId } from "@zoonk/utils/number";
 import { calculateAverageRequestsPerEntity } from "../ai-task-stats";
 import { type AiCourseEstimateInputs, type StructureStats } from "./ai-cost-estimate-types";
 
@@ -128,9 +129,9 @@ function normalizeInteger({
   minimum: number;
   value: CourseInputOverride;
 }) {
-  const parsedValue = typeof value === "number" ? value : Number.parseInt(value ?? "", 10);
+  const parsedValue = parseNumericId(value);
 
-  if (!Number.isInteger(parsedValue) || parsedValue < minimum) {
+  if (parsedValue === null || parsedValue < minimum) {
     return fallback;
   }
 

--- a/apps/admin/src/data/stats/ai/_utils/build-ai-course-cost-estimates.ts
+++ b/apps/admin/src/data/stats/ai/_utils/build-ai-course-cost-estimates.ts
@@ -1,0 +1,147 @@
+import { type TaskUsageByName } from "../ai-task-stats";
+import {
+  COURSE_INPUT_ESTIMATE_NOTE,
+  LANGUAGE_TTS_ESTIMATE_NOTE,
+  REGULAR_COURSE_ESTIMATE_NOTE,
+} from "./ai-cost-estimate-constants";
+import {
+  buildAggregateLineItem,
+  buildGatewayLineItem,
+  isEstimateLineItem,
+  sumLineItems,
+} from "./ai-cost-estimate-helpers";
+import {
+  type AiCourseEstimateInputs,
+  type AiGenerationCostEstimate,
+} from "./ai-cost-estimate-types";
+
+/**
+ * Regular-course estimates combine the course shell tasks with the weighted
+ * lesson totals and the explicit chapter/lesson counts the admin entered for a
+ * planned non-language course.
+ */
+export function buildRegularCourseEstimate({
+  courseInputs,
+  coreLessonEstimate,
+  customLessonEstimate,
+  usageByTask,
+}: {
+  courseInputs: AiCourseEstimateInputs;
+  coreLessonEstimate: AiGenerationCostEstimate;
+  customLessonEstimate: AiGenerationCostEstimate;
+  usageByTask: TaskUsageByName;
+}): AiGenerationCostEstimate {
+  const totalLessonCount =
+    courseInputs.regularChapterCount *
+    (courseInputs.regularCoreLessonsPerChapter + courseInputs.regularCustomLessonsPerChapter);
+  const totalLessonCost =
+    courseInputs.regularChapterCount *
+    (courseInputs.regularCoreLessonsPerChapter * coreLessonEstimate.totalEstimatedCost +
+      courseInputs.regularCustomLessonsPerChapter * customLessonEstimate.totalEstimatedCost);
+  const lineItems = [
+    buildGatewayLineItem({ averageRequestsPerRun: 1, taskName: "course-description", usageByTask }),
+    buildGatewayLineItem({ averageRequestsPerRun: 1, taskName: "course-thumbnail", usageByTask }),
+    buildGatewayLineItem({ averageRequestsPerRun: 1, taskName: "alternative-titles", usageByTask }),
+    buildGatewayLineItem({ averageRequestsPerRun: 1, taskName: "course-categories", usageByTask }),
+    buildGatewayLineItem({ averageRequestsPerRun: 1, taskName: "course-chapters", usageByTask }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: courseInputs.regularChapterCount,
+      taskName: "chapter-lessons",
+      usageByTask,
+    }),
+    buildAggregateLineItem({
+      averageRequestsPerRun: totalLessonCount,
+      estimatedCost: totalLessonCost,
+      label: "Lesson generation across the full course",
+      note: buildRegularCourseInputNote({ courseInputs }),
+    }),
+  ].filter((item): item is NonNullable<typeof item> => isEstimateLineItem(item));
+
+  return {
+    description:
+      "Course setup plus the full chapter, lesson, and activity workload for a typical non-language AI course.",
+    kind: "regularCourse",
+    lineItems,
+    notes: [
+      COURSE_INPUT_ESTIMATE_NOTE,
+      REGULAR_COURSE_ESTIMATE_NOTE,
+      buildRegularCourseInputNote({ courseInputs }),
+    ],
+    runLabel: "selected regular course structures",
+    sampleCount: courseInputs.regularChapterCount,
+    title: "Full Regular Course",
+    totalEstimatedCost: sumLineItems(lineItems),
+  };
+}
+
+/**
+ * Language-course estimates use the same course-shell idea as regular courses,
+ * but they roll up the language-lesson estimate so the inferred TTS component
+ * is included in the full-course total.
+ */
+export function buildLanguageCourseEstimate({
+  courseInputs,
+  languageLessonEstimate,
+  usageByTask,
+}: {
+  courseInputs: AiCourseEstimateInputs;
+  languageLessonEstimate: AiGenerationCostEstimate;
+  usageByTask: TaskUsageByName;
+}): AiGenerationCostEstimate {
+  const totalLessonCount =
+    courseInputs.languageChapterCount * courseInputs.languageLessonsPerChapter;
+  const lineItems = [
+    buildGatewayLineItem({ averageRequestsPerRun: 1, taskName: "course-description", usageByTask }),
+    buildGatewayLineItem({ averageRequestsPerRun: 1, taskName: "course-thumbnail", usageByTask }),
+    buildGatewayLineItem({ averageRequestsPerRun: 1, taskName: "alternative-titles", usageByTask }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: 1,
+      taskName: "language-course-chapters",
+      usageByTask,
+    }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: courseInputs.languageChapterCount,
+      taskName: "language-chapter-lessons",
+      usageByTask,
+    }),
+    buildAggregateLineItem({
+      averageRequestsPerRun: totalLessonCount,
+      estimatedCost: totalLessonCount * languageLessonEstimate.totalEstimatedCost,
+      label: "Lesson generation across the full course",
+      note: buildLanguageCourseInputNote({ courseInputs }),
+    }),
+  ].filter((item): item is NonNullable<typeof item> => isEstimateLineItem(item));
+
+  return {
+    description:
+      "Course setup plus the full chapter, lesson, activity, and inferred TTS workload for a typical language course.",
+    kind: "languageCourse",
+    lineItems,
+    notes: [
+      COURSE_INPUT_ESTIMATE_NOTE,
+      REGULAR_COURSE_ESTIMATE_NOTE,
+      LANGUAGE_TTS_ESTIMATE_NOTE,
+      buildLanguageCourseInputNote({ courseInputs }),
+    ],
+    runLabel: "selected language course structures",
+    sampleCount: courseInputs.languageChapterCount,
+    title: "Full Language Course",
+    totalEstimatedCost: sumLineItems(lineItems),
+  };
+}
+
+/**
+ * Regular courses need both the chapter count and the per-chapter lesson mix in
+ * plain language so the admin can confirm the input assumptions at a glance.
+ */
+function buildRegularCourseInputNote({ courseInputs }: { courseInputs: AiCourseEstimateInputs }) {
+  return `Uses ${courseInputs.regularChapterCount.toLocaleString()} chapters with ${courseInputs.regularCoreLessonsPerChapter.toLocaleString()} core lessons and ${courseInputs.regularCustomLessonsPerChapter.toLocaleString()} custom lessons per chapter.`;
+}
+
+/**
+ * Language courses only need one lesson-count input per chapter, so their
+ * summary can stay shorter while still making the selected structure explicit.
+ */
+function buildLanguageCourseInputNote({ courseInputs }: { courseInputs: AiCourseEstimateInputs }) {
+  return `Uses ${courseInputs.languageChapterCount.toLocaleString()} chapters with ${courseInputs.languageLessonsPerChapter.toLocaleString()} language lessons per chapter.`;
+}

--- a/apps/admin/src/data/stats/ai/_utils/build-ai-lesson-cost-estimates.ts
+++ b/apps/admin/src/data/stats/ai/_utils/build-ai-lesson-cost-estimates.ts
@@ -1,0 +1,256 @@
+import {
+  type TaskUsageByName,
+  calculateAverageRequestsPerEntity,
+  estimateSentenceAudioSeconds,
+  estimateWordAudioSeconds,
+} from "../ai-task-stats";
+import {
+  LANGUAGE_GATEWAY_TASKS,
+  LANGUAGE_TTS_ESTIMATE_NOTE,
+  LANGUAGE_TTS_HEURISTIC_NOTE,
+} from "./ai-cost-estimate-constants";
+import {
+  buildGatewayLineItem,
+  buildTtsLineItem,
+  buildVisualLineItems,
+  getAppliedActivityShares,
+  getAverageTaskRequestsPerRun,
+  isEstimateLineItem,
+  sumLineItems,
+} from "./ai-cost-estimate-helpers";
+import { type AiGenerationCostEstimate, type StructureStats } from "./ai-cost-estimate-types";
+
+/**
+ * Core lessons combine lesson classification, a fixed explanation/practice/quiz
+ * pipeline, explanation-specific visuals, and exactly one applied activity slot.
+ */
+export function buildCoreLessonEstimate({
+  structureStats,
+  usageByTask,
+}: {
+  structureStats: StructureStats;
+  usageByTask: TaskUsageByName;
+}): AiGenerationCostEstimate {
+  const coreLessonCount = structureStats.coreLessonCount;
+  const appliedShares = getAppliedActivityShares({
+    investigationCount: structureStats.coreLessonInvestigationCount,
+    storyCount: structureStats.coreLessonStoryCount,
+  });
+  const lineItems = [
+    buildGatewayLineItem({ averageRequestsPerRun: 1, taskName: "lesson-kind", usageByTask }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: 1,
+      taskName: "applied-activity-kind",
+      usageByTask,
+    }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: getAverageActivityCount({
+        entityCount: coreLessonCount,
+        totalCount: structureStats.coreLessonExplanationCount,
+      }),
+      taskName: "activity-explanation",
+      usageByTask,
+    }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: getAverageActivityCount({
+        entityCount: coreLessonCount,
+        totalCount: structureStats.coreLessonPracticeCount,
+      }),
+      taskName: "activity-practice",
+      usageByTask,
+    }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: getAverageActivityCount({
+        entityCount: coreLessonCount,
+        totalCount: structureStats.coreLessonQuizCount,
+      }),
+      taskName: "activity-quiz",
+      usageByTask,
+    }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: getAverageActivityCount({
+        entityCount: coreLessonCount,
+        totalCount: structureStats.coreLessonExplanationCount,
+      }),
+      taskName: "step-visual-descriptions",
+      usageByTask,
+    }),
+    ...buildVisualLineItems({
+      activityKind: "explanation",
+      entityCount: coreLessonCount,
+      structureStats,
+      usageByTask,
+    }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: getAverageTaskRequestsPerRun({
+        entityCount: coreLessonCount,
+        taskName: "step-select-image",
+        usageByTask,
+      }),
+      taskName: "step-select-image",
+      usageByTask,
+    }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: appliedShares.storyShare,
+      taskName: "activity-story-steps",
+      usageByTask,
+    }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: appliedShares.storyShare,
+      taskName: "activity-story-debrief",
+      usageByTask,
+    }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: appliedShares.investigationShare,
+      taskName: "activity-investigation-scenario",
+      usageByTask,
+    }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: appliedShares.investigationShare,
+      taskName: "activity-investigation-accuracy",
+      usageByTask,
+    }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: appliedShares.investigationShare,
+      taskName: "activity-investigation-actions",
+      usageByTask,
+    }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: appliedShares.investigationShare,
+      taskName: "activity-investigation-findings",
+      usageByTask,
+    }),
+  ].filter((item): item is NonNullable<typeof item> => isEstimateLineItem(item));
+
+  return {
+    description:
+      "Lesson classification, explanation/practice/quiz generation, explanation visuals, quiz image generation, and one weighted applied activity.",
+    kind: "coreLesson",
+    lineItems,
+    notes: [],
+    runLabel: "completed core lessons",
+    sampleCount: coreLessonCount,
+    title: "Full Core Lesson",
+    totalEstimatedCost: sumLineItems(lineItems),
+  };
+}
+
+/**
+ * Custom lessons use a simpler workflow: classify the lesson, plan the custom
+ * activities, generate each activity, then run the visual pass for those
+ * activities.
+ */
+export function buildCustomLessonEstimate({
+  structureStats,
+  usageByTask,
+}: {
+  structureStats: StructureStats;
+  usageByTask: TaskUsageByName;
+}): AiGenerationCostEstimate {
+  const customLessonCount = structureStats.customLessonCount;
+  const averageCustomActivities = getAverageActivityCount({
+    entityCount: customLessonCount,
+    totalCount: structureStats.customActivityCount,
+  });
+  const lineItems = [
+    buildGatewayLineItem({ averageRequestsPerRun: 1, taskName: "lesson-kind", usageByTask }),
+    buildGatewayLineItem({ averageRequestsPerRun: 1, taskName: "lesson-activities", usageByTask }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: averageCustomActivities,
+      taskName: "activity-custom",
+      usageByTask,
+    }),
+    buildGatewayLineItem({
+      averageRequestsPerRun: averageCustomActivities,
+      taskName: "step-visual-descriptions",
+      usageByTask,
+    }),
+    ...buildVisualLineItems({
+      activityKind: "custom",
+      entityCount: customLessonCount,
+      structureStats,
+      usageByTask,
+    }),
+  ].filter((item): item is NonNullable<typeof item> => isEstimateLineItem(item));
+
+  return {
+    description:
+      "Lesson classification, custom activity planning, custom activity generation, and the visual pass for those activities.",
+    kind: "customLesson",
+    lineItems,
+    notes: [],
+    runLabel: "completed custom lessons",
+    sampleCount: customLessonCount,
+    title: "Full Custom Lesson",
+    totalEstimatedCost: sumLineItems(lineItems),
+  };
+}
+
+/**
+ * Language lessons rely on Gateway-tracked text tasks plus a separate inferred
+ * TTS cost because the audio generation calls bypass AI Gateway reporting.
+ */
+export function buildLanguageLessonEstimate({
+  structureStats,
+  usageByTask,
+}: {
+  structureStats: StructureStats;
+  usageByTask: TaskUsageByName;
+}): AiGenerationCostEstimate {
+  const languageLessonCount = structureStats.languageLessonCount;
+  const averageWordClipCount = getAverageActivityCount({
+    entityCount: languageLessonCount,
+    totalCount: structureStats.languageAudioWordClipCount,
+  });
+  const averageSentenceWordCount = getAverageActivityCount({
+    entityCount: languageLessonCount,
+    totalCount: structureStats.languageAudioSentenceWordCount,
+  });
+  const totalAudioSeconds =
+    estimateWordAudioSeconds(averageWordClipCount) +
+    estimateSentenceAudioSeconds(averageSentenceWordCount);
+  const lineItems = [
+    buildGatewayLineItem({ averageRequestsPerRun: 1, taskName: "lesson-kind", usageByTask }),
+    ...LANGUAGE_GATEWAY_TASKS.map((taskName) =>
+      buildGatewayLineItem({
+        averageRequestsPerRun: getAverageTaskRequestsPerRun({
+          entityCount: languageLessonCount,
+          taskName,
+          usageByTask,
+        }),
+        taskName,
+        usageByTask,
+      }),
+    ).filter((item): item is NonNullable<typeof item> => isEstimateLineItem(item)),
+    buildTtsLineItem({
+      totalAudioSeconds,
+      totalInputWordCount: averageWordClipCount + averageSentenceWordCount,
+    }),
+  ].filter((item): item is NonNullable<typeof item> => isEstimateLineItem(item));
+
+  return {
+    description:
+      "Vocabulary, grammar, reading, translation/romanization/pronunciation helpers, and a separate inferred TTS cost for generated audio.",
+    kind: "languageLesson",
+    lineItems,
+    notes: [LANGUAGE_TTS_ESTIMATE_NOTE, LANGUAGE_TTS_HEURISTIC_NOTE],
+    runLabel: "completed language lessons",
+    sampleCount: languageLessonCount,
+    title: "Full Language Lesson",
+    totalEstimatedCost: sumLineItems(lineItems),
+  };
+}
+
+/**
+ * Lesson-level builders repeatedly need the same normalization from raw counts
+ * into "average generated items per lesson" ratios.
+ */
+function getAverageActivityCount({
+  entityCount,
+  totalCount,
+}: {
+  entityCount: number;
+  totalCount: number;
+}) {
+  return calculateAverageRequestsPerEntity({ entityCount, requestCount: totalCount });
+}

--- a/apps/admin/src/data/stats/ai/_utils/get-ai-cost-estimate-structure.ts
+++ b/apps/admin/src/data/stats/ai/_utils/get-ai-cost-estimate-structure.ts
@@ -1,0 +1,358 @@
+import { prisma, sql } from "@zoonk/db";
+import { MS_PER_DAY, parseLocalDate } from "@zoonk/utils/date";
+import { safeAsync } from "@zoonk/utils/error";
+import { buildVisualCountMap, toNumber } from "./ai-cost-estimate-helpers";
+import {
+  type LanguageAudioUsageRow,
+  type StructureStats,
+  type VisualUsageRow,
+} from "./ai-cost-estimate-types";
+
+type DateWindow = {
+  endExclusive: Date;
+  startAt: Date;
+};
+
+/**
+ * The workflow estimates depend on a handful of aggregate counts. This loader
+ * gathers the persisted content shape for the selected period so the cost math
+ * can stay focused on translating those averages into workflow estimates.
+ */
+export async function getStructureStats({
+  endDate,
+  startDate,
+}: {
+  endDate: string;
+  startDate: string;
+}): Promise<StructureStats> {
+  const dateWindow = buildDateWindow({ endDate, startDate });
+  const [lessonAndActivityCounts, courseShapeCounts, visualRows, languageAudioUsage] =
+    await Promise.all([
+      getLessonAndActivityCounts({ dateWindow }),
+      getCourseShapeCounts({ dateWindow }),
+      getVisualUsageRows({ dateWindow }),
+      getLanguageAudioUsage({ dateWindow }),
+    ]);
+
+  return {
+    ...lessonAndActivityCounts,
+    ...courseShapeCounts,
+    languageAudioSentenceWordCount: toNumber(languageAudioUsage.sentenceWordCount),
+    languageAudioWordClipCount: toNumber(languageAudioUsage.wordClipCount),
+    visualCountsByKey: buildVisualCountMap(visualRows),
+  };
+}
+
+/**
+ * Content records use full timestamps while the AI stats filters work with
+ * whole UTC dates. Converting the selected day range into an inclusive start
+ * and exclusive end keeps the database queries aligned with the Gateway report
+ * window.
+ */
+function buildDateWindow({
+  endDate,
+  startDate,
+}: {
+  endDate: string;
+  startDate: string;
+}): DateWindow {
+  const startAt = parseLocalDate(startDate);
+  const endExclusive = new Date(parseLocalDate(endDate).getTime() + MS_PER_DAY);
+
+  return { endExclusive, startAt };
+}
+
+/**
+ * Lesson-level estimates care about how many activities of each kind actually
+ * got created inside completed AI-managed lessons during the selected period.
+ */
+async function getLessonAndActivityCounts({ dateWindow }: { dateWindow: DateWindow }) {
+  const completedLessonWhere = buildCompletedLessonWhere({ dateWindow });
+
+  const [
+    coreLessonCount,
+    customLessonCount,
+    languageLessonCount,
+    coreLessonExplanationCount,
+    coreLessonPracticeCount,
+    coreLessonQuizCount,
+    coreLessonStoryCount,
+    coreLessonInvestigationCount,
+    customActivityCount,
+  ] = await Promise.all([
+    prisma.lesson.count({ where: { ...completedLessonWhere, kind: "core" } }),
+    prisma.lesson.count({ where: { ...completedLessonWhere, kind: "custom" } }),
+    prisma.lesson.count({ where: { ...completedLessonWhere, kind: "language" } }),
+    countActivities({
+      activityKind: "explanation",
+      lessonKind: "core",
+      where: completedLessonWhere,
+    }),
+    countActivities({ activityKind: "practice", lessonKind: "core", where: completedLessonWhere }),
+    countActivities({ activityKind: "quiz", lessonKind: "core", where: completedLessonWhere }),
+    countActivities({ activityKind: "story", lessonKind: "core", where: completedLessonWhere }),
+    countActivities({
+      activityKind: "investigation",
+      lessonKind: "core",
+      where: completedLessonWhere,
+    }),
+    countActivities({ activityKind: "custom", lessonKind: "custom", where: completedLessonWhere }),
+  ]);
+
+  return {
+    coreLessonCount,
+    coreLessonExplanationCount,
+    coreLessonInvestigationCount,
+    coreLessonPracticeCount,
+    coreLessonQuizCount,
+    coreLessonStoryCount,
+    customActivityCount,
+    customLessonCount,
+    languageLessonCount,
+  };
+}
+
+/**
+ * Course estimates need both the course shell counts and the generated
+ * curriculum shape beneath them so full-course totals can extend beyond the
+ * first chapter that the workflow creates immediately.
+ */
+async function getCourseShapeCounts({ dateWindow }: { dateWindow: DateWindow }) {
+  const completedLessonWhere = buildCompletedLessonWhere({ dateWindow });
+  const regularCourseWhere = buildCompletedCourseWhere({ dateWindow, targetLanguage: null });
+  const languageCourseWhere = buildCompletedCourseWhere({
+    dateWindow,
+    targetLanguage: { not: null },
+  });
+  const chapterShellWhere = buildChapterShellWhere({ dateWindow });
+  const completedChapterWhere = buildCompletedChapterWhere({ dateWindow });
+
+  const [
+    regularCourseCount,
+    languageCourseCount,
+    regularCourseChapterCount,
+    languageCourseChapterCount,
+    completedRegularChapterCount,
+    completedLanguageChapterCount,
+    regularCoreLessonCountInCourses,
+    regularCustomLessonCountInCourses,
+    languageLessonCountInCourses,
+  ] = await Promise.all([
+    prisma.course.count({ where: regularCourseWhere }),
+    prisma.course.count({ where: languageCourseWhere }),
+    prisma.chapter.count({ where: { ...chapterShellWhere, course: regularCourseWhere } }),
+    prisma.chapter.count({ where: { ...chapterShellWhere, course: languageCourseWhere } }),
+    prisma.chapter.count({ where: { ...completedChapterWhere, course: { targetLanguage: null } } }),
+    prisma.chapter.count({
+      where: { ...completedChapterWhere, course: { targetLanguage: { not: null } } },
+    }),
+    prisma.lesson.count({
+      where: {
+        ...completedLessonWhere,
+        chapter: { course: { targetLanguage: null } },
+        kind: "core",
+      },
+    }),
+    prisma.lesson.count({
+      where: {
+        ...completedLessonWhere,
+        chapter: { course: { targetLanguage: null } },
+        kind: "custom",
+      },
+    }),
+    prisma.lesson.count({
+      where: {
+        ...completedLessonWhere,
+        chapter: { course: { targetLanguage: { not: null } } },
+        kind: "language",
+      },
+    }),
+  ]);
+
+  return {
+    completedLanguageChapterCount,
+    completedRegularChapterCount,
+    languageCourseChapterCount,
+    languageCourseCount,
+    languageLessonCountInCourses,
+    regularCoreLessonCountInCourses,
+    regularCourseChapterCount,
+    regularCourseCount,
+    regularCustomLessonCountInCourses,
+  };
+}
+
+/**
+ * Explanation and custom activities share the same visual task family, so
+ * Gateway counts alone cannot tell us which workflow those requests belonged
+ * to. Grouping the persisted visual steps by parent activity kind lets each
+ * lesson estimate claim only its own visual workload.
+ */
+async function getVisualUsageRows({
+  dateWindow,
+}: {
+  dateWindow: DateWindow;
+}): Promise<VisualUsageRow[]> {
+  const { data, error } = await safeAsync(() =>
+    prisma.$queryRaw<VisualUsageRow[]>(sql`
+      SELECT
+        a.kind AS "activityKind",
+        COALESCE(s.content->>'kind', 'image') AS "visualKind",
+        COUNT(*)::bigint AS "count"
+      FROM steps s
+      JOIN activities a ON a.id = s.activity_id
+      JOIN lessons l ON l.id = a.lesson_id
+      WHERE s.kind = 'visual'
+        AND s.archived_at IS NULL
+        AND a.archived_at IS NULL
+        AND l.archived_at IS NULL
+        AND l.management_mode = 'ai'
+        AND l.generation_status = 'completed'
+        AND l.created_at >= ${dateWindow.startAt}
+        AND l.created_at < ${dateWindow.endExclusive}
+        AND a.kind IN ('explanation', 'custom')
+      GROUP BY a.kind, COALESCE(s.content->>'kind', 'image')
+    `),
+  );
+
+  if (error) {
+    throw new Error("Failed to load visual usage for AI estimates", { cause: error });
+  }
+
+  return data;
+}
+
+/**
+ * Language audio is stored outside Gateway reporting, and the workflow reuses
+ * any existing word or sentence audio it can find. Counting only newly created
+ * audio assets linked to selected-period lessons keeps the TTS estimate closer
+ * to the spend that actually happened.
+ */
+async function getLanguageAudioUsage({
+  dateWindow,
+}: {
+  dateWindow: DateWindow;
+}): Promise<LanguageAudioUsageRow> {
+  const { data, error } = await safeAsync(() =>
+    prisma.$queryRaw<LanguageAudioUsageRow[]>(sql`
+      WITH language_lessons AS (
+        SELECT l.id
+        FROM lessons l
+        JOIN chapters ch ON ch.id = l.chapter_id
+        JOIN courses c ON c.id = ch.course_id
+        WHERE l.kind = 'language'
+          AND l.archived_at IS NULL
+          AND l.management_mode = 'ai'
+          AND l.generation_status = 'completed'
+          AND l.created_at >= ${dateWindow.startAt}
+          AND l.created_at < ${dateWindow.endExclusive}
+          AND c.target_language IS NOT NULL
+      ),
+      generated_word_audio AS (
+        SELECT DISTINCT w.id
+        FROM lesson_words lw
+        JOIN words w ON w.id = lw.word_id
+        WHERE lw.lesson_id IN (SELECT id FROM language_lessons)
+          AND w.audio_url IS NOT NULL
+          AND w.created_at >= ${dateWindow.startAt}
+          AND w.created_at < ${dateWindow.endExclusive}
+      ),
+      generated_sentence_audio AS (
+        SELECT DISTINCT s.id, s.sentence
+        FROM lesson_sentences ls
+        JOIN sentences s ON s.id = ls.sentence_id
+        WHERE ls.lesson_id IN (SELECT id FROM language_lessons)
+          AND s.audio_url IS NOT NULL
+          AND s.created_at >= ${dateWindow.startAt}
+          AND s.created_at < ${dateWindow.endExclusive}
+      ),
+      sentence_audio AS (
+        SELECT
+          COALESCE(
+            SUM(
+              GREATEST(
+                COALESCE(array_length(regexp_split_to_array(TRIM(generated_sentence_audio.sentence), E'\\s+'), 1), 0),
+                1
+              )
+            ),
+            0
+          )::bigint AS "sentenceWordCount"
+        FROM generated_sentence_audio
+      )
+      SELECT
+        (SELECT COUNT(*)::bigint FROM generated_word_audio) AS "wordClipCount",
+        sentence_audio."sentenceWordCount" AS "sentenceWordCount"
+      FROM sentence_audio
+    `),
+  );
+
+  if (error) {
+    throw new Error("Failed to load language audio usage for AI estimates", { cause: error });
+  }
+
+  return data[0] ?? { sentenceWordCount: 0n, wordClipCount: 0n };
+}
+
+/**
+ * Activity counts all follow the same "completed generated activity inside a
+ * completed generated lesson" rule. Centralizing it keeps the main aggregate
+ * query readable.
+ */
+function countActivities({
+  activityKind,
+  lessonKind,
+  where,
+}: {
+  activityKind: "custom" | "explanation" | "investigation" | "practice" | "quiz" | "story";
+  lessonKind: "core" | "custom";
+  where: ReturnType<typeof buildCompletedLessonWhere>;
+}) {
+  return prisma.activity.count({
+    where: {
+      archivedAt: null,
+      generationStatus: "completed",
+      kind: activityKind,
+      lesson: { ...where, kind: lessonKind },
+    },
+  });
+}
+
+function buildCompletedLessonWhere({ dateWindow }: { dateWindow: DateWindow }) {
+  return {
+    archivedAt: null,
+    createdAt: { gte: dateWindow.startAt, lt: dateWindow.endExclusive },
+    generationStatus: "completed" as const,
+    managementMode: "ai" as const,
+  };
+}
+
+function buildCompletedCourseWhere({
+  dateWindow,
+  targetLanguage,
+}: {
+  dateWindow: DateWindow;
+  targetLanguage: null | { not: null };
+}) {
+  return {
+    archivedAt: null,
+    createdAt: { gte: dateWindow.startAt, lt: dateWindow.endExclusive },
+    generationStatus: "completed" as const,
+    managementMode: "ai" as const,
+    targetLanguage,
+  };
+}
+
+function buildChapterShellWhere({ dateWindow }: { dateWindow: DateWindow }) {
+  return {
+    archivedAt: null,
+    createdAt: { gte: dateWindow.startAt, lt: dateWindow.endExclusive },
+    managementMode: "ai" as const,
+  };
+}
+
+function buildCompletedChapterWhere({ dateWindow }: { dateWindow: DateWindow }) {
+  return {
+    ...buildChapterShellWhere({ dateWindow }),
+    generationStatus: "completed" as const,
+  };
+}

--- a/apps/admin/src/data/stats/ai/ai-task-stats.ts
+++ b/apps/admin/src/data/stats/ai/ai-task-stats.ts
@@ -10,6 +10,13 @@ const AI_MODEL_ID_PATTERN = /^[a-z0-9.-]+\/[a-z0-9.-]+$/;
 const DATE_INPUT_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const DEFAULT_LOOKBACK_DAYS = 30;
 const DEFAULT_ESTIMATE_RUN_COUNT = 1000;
+const DEFAULT_WORD_AUDIO_SECONDS = 0.75;
+const AVERAGE_SPOKEN_WORDS_PER_SECOND = 2.5;
+const AVERAGE_WORDS_PER_100_TEXT_TOKENS = 70;
+const GEMINI_TTS_AUDIO_TOKENS_PER_SECOND = 32;
+const GEMINI_TTS_INPUT_COST_PER_1M_TOKENS = 0.5;
+const GEMINI_TTS_OUTPUT_COST_PER_1M_TOKENS = 10;
+const ONE_MILLION_TOKENS = 1_000_000;
 
 type AiTaskDateRange = {
   end: Date;
@@ -17,6 +24,15 @@ type AiTaskDateRange = {
   start: Date;
   startInput: string;
 };
+
+export type TaskUsageSummary = {
+  averageMarketCostPerRequest: number;
+  requestCount: number;
+  taskName: string;
+  totalMarketCost: number;
+};
+
+export type TaskUsageByName = Record<string, TaskUsageSummary>;
 
 /**
  * AI Gateway reporting groups tagged generations under a raw `task:*` string.
@@ -137,6 +153,15 @@ export function resolveEstimateRunCount(value?: string): number {
 }
 
 /**
+ * App Router search params can be missing or repeated. The AI stats views only
+ * support one value per field, so this helper safely narrows those values
+ * before the date-range and run-count parsers consume them.
+ */
+export function getSingleSearchParamValue(value?: string | string[]): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
  * Gateway reporting returns accumulated market cost and request counts. The
  * calculator and per-model table both need the normalized per-request cost.
  */
@@ -166,6 +191,69 @@ export function calculateEstimatedMarketCost({
   runCount: number;
 }): number {
   return averageMarketCostPerRequest * runCount;
+}
+
+/**
+ * Some lesson and course estimates need a normalized "requests per entity" ratio.
+ * Returning zero when the denominator is missing keeps those estimates partial
+ * instead of throwing on empty ranges.
+ */
+export function calculateAverageRequestsPerEntity({
+  entityCount,
+  requestCount,
+}: {
+  entityCount: number;
+  requestCount: number;
+}): number {
+  if (entityCount <= 0) {
+    return 0;
+  }
+
+  return requestCount / entityCount;
+}
+
+/**
+ * The language audio estimate uses a speech-duration heuristic because Gateway does
+ * not report TTS usage. Single-word clips are usually longer than a naive words-per-
+ * second formula would suggest, so we keep a small minimum duration per clip.
+ */
+export function estimateWordAudioSeconds(itemCount: number): number {
+  return itemCount * DEFAULT_WORD_AUDIO_SECONDS;
+}
+
+/**
+ * Sentence clips scale better with spoken word count than with raw character count.
+ * A steady words-per-second heuristic keeps the estimate simple and stable while
+ * still responding to longer or shorter generated reading sentences.
+ */
+export function estimateSentenceAudioSeconds(totalWordCount: number): number {
+  if (totalWordCount <= 0) {
+    return 0;
+  }
+
+  return totalWordCount / AVERAGE_SPOKEN_WORDS_PER_SECOND;
+}
+
+/**
+ * Gemini bills TTS on both text input tokens and audio output tokens. We only
+ * have persisted words and generated audio assets, so this helper converts the
+ * observed word count into approximate text tokens and the estimated duration
+ * into audio tokens using Google's published tokenization rates.
+ */
+export function estimateGeminiTtsCost({
+  totalAudioSeconds,
+  totalInputWordCount,
+}: {
+  totalAudioSeconds: number;
+  totalInputWordCount: number;
+}): number {
+  const estimatedInputTokenCount = estimateTextTokenCountFromWords(totalInputWordCount);
+  const estimatedAudioTokenCount = totalAudioSeconds * GEMINI_TTS_AUDIO_TOKENS_PER_SECOND;
+
+  return (
+    (estimatedInputTokenCount / ONE_MILLION_TOKENS) * GEMINI_TTS_INPUT_COST_PER_1M_TOKENS +
+    (estimatedAudioTokenCount / ONE_MILLION_TOKENS) * GEMINI_TTS_OUTPUT_COST_PER_1M_TOKENS
+  );
 }
 
 /**
@@ -249,4 +337,17 @@ function buildAiTaskDateRange({ end, start }: { end: Date; start: Date }): AiTas
  */
 function capitalizeWord(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+/**
+ * Google's token guide only gives an English text range of 60-80 words per 100
+ * tokens. Using the midpoint keeps the TTS input-side estimate simple while
+ * still accounting for the fact that speech requests pay for prompt text too.
+ */
+function estimateTextTokenCountFromWords(totalWordCount: number): number {
+  if (totalWordCount <= 0) {
+    return 0;
+  }
+
+  return (totalWordCount / AVERAGE_WORDS_PER_100_TEXT_TOKENS) * 100;
 }

--- a/apps/admin/src/data/stats/ai/get-ai-cost-estimates.ts
+++ b/apps/admin/src/data/stats/ai/get-ai-cost-estimates.ts
@@ -1,0 +1,76 @@
+import "server-only";
+import {
+  type AiCostEstimateReport,
+  type AiCourseEstimateInputOverrides,
+} from "./_utils/ai-cost-estimate-types";
+import {
+  buildDefaultCourseEstimateInputs,
+  resolveCourseEstimateInputs,
+} from "./_utils/ai-course-estimate-inputs";
+import {
+  buildLanguageCourseEstimate,
+  buildRegularCourseEstimate,
+} from "./_utils/build-ai-course-cost-estimates";
+import {
+  buildCoreLessonEstimate,
+  buildCustomLessonEstimate,
+  buildLanguageLessonEstimate,
+} from "./_utils/build-ai-lesson-cost-estimates";
+import { getStructureStats } from "./_utils/get-ai-cost-estimate-structure";
+import { getAiTaskUsageMap } from "./get-ai-task-usage-map";
+
+export type {
+  AiCourseEstimateInputOverrides,
+  AiCourseEstimateInputs,
+  AiGenerationCostEstimate,
+  EstimateLineItem,
+} from "./_utils/ai-cost-estimate-types";
+
+/**
+ * The AI stats index needs workflow-level answers, not raw task rows. This
+ * loader combines Gateway cost averages with the content-shape averages we can
+ * derive from the database for the same date range.
+ */
+export async function getAiCostEstimates({
+  courseInputOverrides,
+  endDate,
+  startDate,
+}: {
+  courseInputOverrides?: AiCourseEstimateInputOverrides;
+  endDate: string;
+  startDate: string;
+}): Promise<AiCostEstimateReport> {
+  const [usageByTask, structureStats] = await Promise.all([
+    getAiTaskUsageMap({ endDate, startDate }),
+    getStructureStats({ endDate, startDate }),
+  ]);
+  const defaultCourseInputs = buildDefaultCourseEstimateInputs({ structureStats });
+  const courseInputs = resolveCourseEstimateInputs({
+    defaults: defaultCourseInputs,
+    overrides: courseInputOverrides,
+  });
+  const coreLessonEstimate = buildCoreLessonEstimate({ structureStats, usageByTask });
+  const customLessonEstimate = buildCustomLessonEstimate({ structureStats, usageByTask });
+  const languageLessonEstimate = buildLanguageLessonEstimate({ structureStats, usageByTask });
+
+  return {
+    courseInputs,
+    defaultCourseInputs,
+    estimates: [
+      coreLessonEstimate,
+      customLessonEstimate,
+      languageLessonEstimate,
+      buildRegularCourseEstimate({
+        coreLessonEstimate,
+        courseInputs,
+        customLessonEstimate,
+        usageByTask,
+      }),
+      buildLanguageCourseEstimate({
+        courseInputs,
+        languageLessonEstimate,
+        usageByTask,
+      }),
+    ],
+  };
+}

--- a/apps/admin/src/data/stats/ai/get-ai-task-usage-map.ts
+++ b/apps/admin/src/data/stats/ai/get-ai-task-usage-map.ts
@@ -1,0 +1,65 @@
+import "server-only";
+import { zoonkGateway } from "@zoonk/core/ai";
+import { safeAsync } from "@zoonk/utils/error";
+import {
+  type TaskUsageByName,
+  calculateAverageMarketCostPerRequest,
+  extractAiTaskName,
+} from "./ai-task-stats";
+
+type SpendReportTagRow = {
+  marketCost?: number | null;
+  requestCount?: number | null;
+  tag?: string | null;
+};
+
+/**
+ * The estimate views and the task index both need one normalized aggregate per task.
+ * Loading the grouped tag report once here keeps the parsing rules in one place and
+ * prevents every caller from re-implementing the same `task:*` filtering logic.
+ */
+export async function getAiTaskUsageMap({
+  endDate,
+  startDate,
+}: {
+  endDate: string;
+  startDate: string;
+}): Promise<TaskUsageByName> {
+  const { data, error } = await safeAsync(() =>
+    zoonkGateway.getSpendReport({
+      endDate,
+      groupBy: "tag",
+      startDate,
+    }),
+  );
+
+  if (error) {
+    throw new Error("Failed to load AI task usage", { cause: error });
+  }
+
+  const usageByTask: TaskUsageByName = {};
+
+  for (const row of data.results) {
+    const taskName = extractAiTaskName((row satisfies SpendReportTagRow).tag ?? undefined);
+
+    if (taskName) {
+      const requestCount = row.requestCount ?? 0;
+      const totalMarketCost = row.marketCost ?? 0;
+      const current = usageByTask[taskName];
+      const nextRequestCount = (current?.requestCount ?? 0) + requestCount;
+      const nextTotalMarketCost = (current?.totalMarketCost ?? 0) + totalMarketCost;
+
+      usageByTask[taskName] = {
+        averageMarketCostPerRequest: calculateAverageMarketCostPerRequest({
+          marketCost: nextTotalMarketCost,
+          requestCount: nextRequestCount,
+        }),
+        requestCount: nextRequestCount,
+        taskName,
+        totalMarketCost: nextTotalMarketCost,
+      };
+    }
+  }
+
+  return usageByTask;
+}

--- a/packages/utils/src/number.test.ts
+++ b/packages/utils/src/number.test.ts
@@ -42,6 +42,17 @@ describe(parseNumericId, () => {
     expect(parseNumericId("999999")).toBe(999_999);
   });
 
+  test("parses numeric strings with surrounding whitespace", () => {
+    expect(parseNumericId(" 123")).toBe(123);
+    expect(parseNumericId("123 ")).toBe(123);
+    expect(parseNumericId(" 123 ")).toBe(123);
+  });
+
+  test("parses valid integer numbers directly", () => {
+    expect(parseNumericId(123)).toBe(123);
+    expect(parseNumericId(0)).toBe(0);
+  });
+
   test("returns null for strings with letters", () => {
     expect(parseNumericId("123abc")).toBeNull();
     expect(parseNumericId("abc123")).toBeNull();
@@ -56,15 +67,16 @@ describe(parseNumericId, () => {
     expect(parseNumericId("-123")).toBeNull();
   });
 
-  test("returns null for strings with whitespace", () => {
-    expect(parseNumericId(" 123")).toBeNull();
-    expect(parseNumericId("123 ")).toBeNull();
-    expect(parseNumericId(" 123 ")).toBeNull();
+  test("returns null for malformed whitespace-delimited strings", () => {
     expect(parseNumericId("12 34")).toBeNull();
   });
 
-  test("returns null for empty string", () => {
+  test("returns null for empty or unsupported values", () => {
     expect(parseNumericId("")).toBeNull();
+    expect(parseNumericId("   ")).toBeNull();
+    expect(parseNumericId(3.7)).toBeNull();
+    expect(parseNumericId(null)).toBeNull();
+    expect(parseNumericId()).toBeNull();
   });
 });
 

--- a/packages/utils/src/number.ts
+++ b/packages/utils/src/number.ts
@@ -5,11 +5,24 @@ export function validateOffset(value?: unknown): number {
   return Number.isFinite(parsed) ? Math.max(0, Math.trunc(parsed)) : 0;
 }
 
-export function parseNumericId(value: string): number | null {
-  if (!NUMERIC_ID_PATTERN.test(value)) {
+/**
+ * Route params and form values often arrive as strings, while some call sites
+ * already have an integer in hand. This parser accepts both shapes so callers
+ * can ask for a numeric id directly instead of reimplementing trim/validation
+ * branches around it.
+ */
+export function parseNumericId(value?: number | string | null): number | null {
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value >= 0 ? value : null;
+  }
+
+  const normalizedValue = value?.trim();
+
+  if (!normalizedValue || !NUMERIC_ID_PATTERN.test(normalizedValue)) {
     return null;
   }
-  return Number.parseInt(value, 10);
+
+  return Number.parseInt(normalizedValue, 10);
 }
 
 export function parseBigIntId(value: string): bigint | null {


### PR DESCRIPTION
## Summary
- split AI task activity and workflow cost modeling into separate admin pages
- add lesson cost estimates based on selected-period Gateway and database averages
- add parameterized course cost estimates, including inferred TTS costs for language flows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an estimates dashboard that models AI lesson and course generation costs from recent Gateway spend and database averages, including inferred TTS for language content. Splits AI stats into a task activity view and a new, parameterized estimates page with shareable filters.

- New Features
  - New estimates page at /stats/ai/estimates with cards for core/custom/language lessons and full regular/language courses.
  - Per-estimate breakdown accordion with line items (avg requests/run, avg cost/request, inferred items) and notes.
  - GET-based filters for date range and course shape; defaults derived from the selected period.
  - Server builders aggregate Gateway task costs with DB structure; language TTS cost inferred via Gemini token rates and audio duration heuristics.
  - Task index now accepts a date range, shows filters, and links to the estimates page preserving the period.

- Refactors
  - Introduced `AiStatsFilters` and updated task report/list to use it; replaced ad-hoc search param parsing with `getSingleSearchParamValue`.
  - Added `get-ai-task-usage-map` for grouped Gateway cost averages and new estimate utilities under `data/stats/ai/_utils`.
  - Adjusted task table links to carry the selected period and cleaned up minor UI copy/structure.
  - Simplified `parseNumericId` to accept integers and trimmed strings; fixes dropped course input overrides and adds tests.

<sup>Written for commit 3e53973b5234e5e74918665b132b82a8870349af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

