### PR TITLE
refactor(db): remove org scope from learner progress

### DIFF
--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
@@ -165,7 +165,6 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<void>
         activityId: activity.id,
         durationSeconds,
         localDate: input.localDate,
-        organizationId: activity.organizationId,
         score,
         startedAt: new Date(input.startedAt),
         stepResults: [...mergedStepResults, ...investigationActionResults],

--- a/apps/main/src/data/progress/_utils/daily-progress.test.ts
+++ b/apps/main/src/data/progress/_utils/daily-progress.test.ts
@@ -1,0 +1,63 @@
+import { prisma } from "@zoonk/db";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { describe, expect, test } from "vitest";
+import { fillDecayGaps } from "./daily-progress";
+
+describe(fillDecayGaps, () => {
+  test("keeps one daily progress row per user and day", async () => {
+    const user = await userFixture();
+    const userId = Number(user.id);
+    const date = new Date(Date.UTC(2026, 0, 2));
+
+    await prisma.dailyProgress.create({
+      data: {
+        date,
+        dayOfWeek: date.getUTCDay(),
+        energyAtEnd: 49,
+        userId,
+      },
+    });
+
+    await expect(
+      prisma.dailyProgress.create({
+        data: {
+          date,
+          dayOfWeek: date.getUTCDay(),
+          energyAtEnd: 48,
+          userId,
+        },
+      }),
+    ).rejects.toHaveProperty("code", "P2002");
+  });
+
+  test("skips decay rows for days that already have progress", async () => {
+    const user = await userFixture();
+    const userId = Number(user.id);
+    const gapDate = new Date(Date.UTC(2026, 0, 2));
+
+    await prisma.dailyProgress.create({
+      data: {
+        date: gapDate,
+        dayOfWeek: gapDate.getUTCDay(),
+        energyAtEnd: 49,
+        userId,
+      },
+    });
+
+    await prisma.$transaction((tx) =>
+      fillDecayGaps({
+        currentEnergy: 50,
+        lastActiveDate: new Date(Date.UTC(2026, 0, 1)),
+        todayDate: new Date(Date.UTC(2026, 0, 3)),
+        tx,
+        userId,
+      }),
+    );
+
+    const rows = await prisma.dailyProgress.findMany({
+      where: { date: gapDate, userId },
+    });
+
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/apps/main/src/data/progress/_utils/daily-progress.ts
+++ b/apps/main/src/data/progress/_utils/daily-progress.ts
@@ -46,7 +46,6 @@ export async function fillDecayGaps(params: {
       date,
       dayOfWeek: date.getUTCDay(),
       energyAtEnd: decayedEnergy,
-      organizationId: null as number | null,
       userId: params.userId,
     };
   });
@@ -55,10 +54,9 @@ export async function fillDecayGaps(params: {
 }
 
 /**
- * Daily progress rows use a nullable organization id, which means the regular
- * compound unique only works for organization-scoped records. This helper keeps
- * the two write paths aligned so completion writes do not have to repeat that
- * null-handling branch every time.
+ * Daily progress is a global learner timeline, so there is exactly one row per
+ * user and day. Keeping the upsert logic here prevents every completion write
+ * from rebuilding the same counter and energy updates inline.
  */
 export async function upsertDailyProgress(
   tx: TransactionClient,
@@ -68,7 +66,6 @@ export async function upsertDailyProgress(
     dayOfWeek: number;
     durationSeconds: number;
     field: "interactiveCompleted" | "staticCompleted";
-    organizationId: number | null;
     score: ScoreResult;
     userId: number;
   },
@@ -81,7 +78,6 @@ export async function upsertDailyProgress(
     energyAtEnd: params.clampedEnergy,
     incorrectAnswers: params.score.incorrectCount,
     interactiveCompleted: params.field === "interactiveCompleted" ? 1 : 0,
-    organizationId: params.organizationId,
     staticCompleted: params.field === "staticCompleted" ? 1 : 0,
     timeSpentSeconds: params.durationSeconds,
     userId: params.userId,
@@ -96,38 +92,14 @@ export async function upsertDailyProgress(
     [params.field]: { increment: 1 },
   };
 
-  if (params.organizationId) {
-    await tx.dailyProgress.upsert({
-      create: createData,
-      update: updateData,
-      where: {
-        userDateOrg: {
-          date: params.date,
-          organizationId: params.organizationId,
-          userId: params.userId,
-        },
-      },
-    });
-
-    return;
-  }
-
-  const existing = await tx.dailyProgress.findFirst({
+  await tx.dailyProgress.upsert({
+    create: createData,
+    update: updateData,
     where: {
-      date: params.date,
-      organizationId: null,
-      userId: params.userId,
+      userDate: {
+        date: params.date,
+        userId: params.userId,
+      },
     },
   });
-
-  if (existing) {
-    await tx.dailyProgress.update({
-      data: updateData,
-      where: { id: existing.id },
-    });
-
-    return;
-  }
-
-  await tx.dailyProgress.create({ data: createData });
 }

--- a/apps/main/src/data/progress/get-best-day.test.ts
+++ b/apps/main/src/data/progress/get-best-day.test.ts
@@ -1,6 +1,5 @@
 import { prisma } from "@zoonk/db";
 import { signInAs } from "@zoonk/testing/fixtures/auth";
-import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { describe, expect, test } from "vitest";
 import { getBestDay } from "./get-best-day";
@@ -24,7 +23,6 @@ describe("authenticated users", () => {
   test("returns best day when user has data for multiple days", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);
-    const org = await organizationFixture();
 
     await prisma.dailyProgress.createMany({
       data: [
@@ -33,7 +31,6 @@ describe("authenticated users", () => {
           date: new Date("2025-01-05T12:00:00Z"),
           dayOfWeek: 0, // Sunday
           incorrectAnswers: 2,
-          organizationId: org.id,
           userId: Number(user.id),
         },
         {
@@ -41,7 +38,6 @@ describe("authenticated users", () => {
           date: new Date("2025-01-06T12:00:00Z"),
           dayOfWeek: 1, // Monday
           incorrectAnswers: 5,
-          organizationId: org.id,
           userId: Number(user.id),
         },
       ],
@@ -60,7 +56,6 @@ describe("authenticated users", () => {
   test("excludes records older than 90 days", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);
-    const org = await organizationFixture();
 
     const today = new Date();
     const oldDate = new Date(today);
@@ -73,7 +68,6 @@ describe("authenticated users", () => {
           date: today,
           dayOfWeek: today.getDay(),
           incorrectAnswers: 2,
-          organizationId: org.id,
           userId: Number(user.id),
         },
         {
@@ -81,7 +75,6 @@ describe("authenticated users", () => {
           date: oldDate,
           dayOfWeek: oldDate.getDay(),
           incorrectAnswers: 0,
-          organizationId: org.id,
           userId: Number(user.id),
         },
       ],
@@ -96,7 +89,6 @@ describe("authenticated users", () => {
   test("uses day with most answers as tiebreaker", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);
-    const org = await organizationFixture();
 
     await prisma.dailyProgress.createMany({
       data: [
@@ -105,7 +97,6 @@ describe("authenticated users", () => {
           date: new Date("2025-01-05T12:00:00Z"),
           dayOfWeek: 0, // Sunday
           incorrectAnswers: 1,
-          organizationId: org.id,
           userId: Number(user.id),
         },
         {
@@ -113,7 +104,6 @@ describe("authenticated users", () => {
           date: new Date("2025-01-12T12:00:00Z"),
           dayOfWeek: 0, // Next Sunday
           incorrectAnswers: 1,
-          organizationId: org.id,
           userId: Number(user.id),
         },
         {
@@ -121,7 +111,6 @@ describe("authenticated users", () => {
           date: new Date("2025-01-06T12:00:00Z"),
           dayOfWeek: 1, // Monday
           incorrectAnswers: 2,
-          organizationId: org.id,
           userId: Number(user.id),
         },
       ],
@@ -140,7 +129,6 @@ describe("authenticated users", () => {
   test("returns correct score calculation", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);
-    const org = await organizationFixture();
 
     const today = new Date();
 
@@ -150,7 +138,6 @@ describe("authenticated users", () => {
         date: today,
         dayOfWeek: today.getDay(),
         incorrectAnswers: 3,
-        organizationId: org.id,
         userId: Number(user.id),
       },
     });

--- a/apps/main/src/data/progress/get-best-time.test.ts
+++ b/apps/main/src/data/progress/get-best-time.test.ts
@@ -13,7 +13,6 @@ type StepAttemptParams = {
   answeredAt?: Date;
   hourOfDay: number;
   isCorrect: boolean;
-  orgId: number;
   stepId: bigint;
   userId: number;
 };
@@ -27,7 +26,6 @@ function buildStepAttemptData(params: StepAttemptParams) {
     durationSeconds: 15,
     hourOfDay: params.hourOfDay,
     isCorrect: params.isCorrect,
-    organizationId: params.orgId,
     stepId: params.stepId,
     userId: params.userId,
   };
@@ -104,14 +102,13 @@ describe("authenticated users", () => {
     ]);
 
     const userId = Number(user.id);
-    const orgId = org.id;
     const stepId = step.id;
 
     await Promise.all([
       // Morning (hour 9): 9 correct, 1 incorrect = 90%
-      createStepAttempts({ hourOfDay: 9, orgId, stepId, userId }, 9, 1),
+      createStepAttempts({ hourOfDay: 9, stepId, userId }, 9, 1),
       // Afternoon (hour 15): 8 correct, 2 incorrect = 80%
-      createStepAttempts({ hourOfDay: 15, orgId, stepId, userId }, 8, 2),
+      createStepAttempts({ hourOfDay: 15, stepId, userId }, 8, 2),
     ]);
 
     const result = await getBestTime({ headers });
@@ -133,14 +130,13 @@ describe("authenticated users", () => {
     oldDate.setDate(oldDate.getDate() - 91);
 
     const userId = Number(user.id);
-    const orgId = org.id;
     const stepId = step.id;
 
     await Promise.all([
       // Recent Morning attempts: 80%
-      createStepAttempts({ answeredAt: now, hourOfDay: 9, orgId, stepId, userId }, 8, 2),
+      createStepAttempts({ answeredAt: now, hourOfDay: 9, stepId, userId }, 8, 2),
       // Old Afternoon attempts: 100% (should be excluded)
-      createStepAttempts({ answeredAt: oldDate, hourOfDay: 15, orgId, stepId, userId }, 10, 0),
+      createStepAttempts({ answeredAt: oldDate, hourOfDay: 15, stepId, userId }, 10, 0),
     ]);
 
     const result = await getBestTime({ headers });
@@ -158,14 +154,13 @@ describe("authenticated users", () => {
     ]);
 
     const userId = Number(user.id);
-    const orgId = org.id;
     const stepId = step.id;
 
     await Promise.all([
       // Morning (hour 9): 9 correct, 1 incorrect = 90%
-      createStepAttempts({ hourOfDay: 9, orgId, stepId, userId }, 9, 1),
+      createStepAttempts({ hourOfDay: 9, stepId, userId }, 9, 1),
       // Afternoon (hour 15): 18 correct, 2 incorrect = 90% (more answers)
-      createStepAttempts({ hourOfDay: 15, orgId, stepId, userId }, 18, 2),
+      createStepAttempts({ hourOfDay: 15, stepId, userId }, 18, 2),
     ]);
 
     const result = await getBestTime({ headers });
@@ -183,11 +178,10 @@ describe("authenticated users", () => {
     ]);
 
     const userId = Number(user.id);
-    const orgId = org.id;
     const stepId = step.id;
 
     // 17 correct, 3 incorrect = 85%
-    await createStepAttempts({ hourOfDay: 21, orgId, stepId, userId }, 17, 3);
+    await createStepAttempts({ hourOfDay: 21, stepId, userId }, 17, 3);
 
     const result = await getBestTime({ headers });
 
@@ -204,11 +198,10 @@ describe("authenticated users", () => {
     ]);
 
     const userId = Number(user.id);
-    const orgId = org.id;
     const stepId = step.id;
 
     // Night (hour 3): 100%
-    await createStepAttempts({ hourOfDay: 3, orgId, stepId, userId }, 1, 0);
+    await createStepAttempts({ hourOfDay: 3, stepId, userId }, 1, 0);
 
     const result = await getBestTime({ headers });
 
@@ -231,14 +224,13 @@ describe("authenticated users", () => {
     twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
 
     const userId = Number(user.id);
-    const orgId = org.id;
     const stepId = step.id;
 
     await Promise.all([
       // Recent Morning attempts: 80%
-      createStepAttempts({ answeredAt: now, hourOfDay: 9, orgId, stepId, userId }, 8, 2),
+      createStepAttempts({ answeredAt: now, hourOfDay: 9, stepId, userId }, 8, 2),
       // Older Afternoon attempts: 100% (should be excluded with custom range)
-      createStepAttempts({ answeredAt: twoWeeksAgo, hourOfDay: 15, orgId, stepId, userId }, 10, 0),
+      createStepAttempts({ answeredAt: twoWeeksAgo, hourOfDay: 15, stepId, userId }, 10, 0),
     ]);
 
     // Filter to only include data from the past week

--- a/apps/main/src/data/progress/get-bp-history.test.ts
+++ b/apps/main/src/data/progress/get-bp-history.test.ts
@@ -1,7 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { signInAs } from "@zoonk/testing/fixtures/auth";
 import { createSafeDate } from "@zoonk/testing/fixtures/dates";
-import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { describe, expect, test } from "vitest";
 import { getBpHistory } from "./get-bp-history";
@@ -27,7 +26,7 @@ describe("authenticated users", () => {
 
   describe("month period", () => {
     test("returns daily data points with BP values", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const today = createSafeDate(0);
@@ -39,14 +38,12 @@ describe("authenticated users", () => {
             brainPowerEarned: 100,
             date: today,
             dayOfWeek: today.getDay(),
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             brainPowerEarned: 50,
             date: yesterday,
             dayOfWeek: yesterday.getDay(),
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -60,7 +57,7 @@ describe("authenticated users", () => {
     });
 
     test("calculates period total correctly", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const today = createSafeDate(0);
@@ -72,14 +69,12 @@ describe("authenticated users", () => {
             brainPowerEarned: 200,
             date: today,
             dayOfWeek: today.getDay(),
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             brainPowerEarned: 300,
             date: yesterday,
             dayOfWeek: yesterday.getDay(),
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -92,7 +87,7 @@ describe("authenticated users", () => {
     });
 
     test("includes current belt level", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       await prisma.userProgress.upsert({
@@ -112,7 +107,6 @@ describe("authenticated users", () => {
           brainPowerEarned: 100,
           date,
           dayOfWeek: date.getDay(),
-          organizationId: org.id,
           userId: Number(user.id),
         },
       });
@@ -125,7 +119,7 @@ describe("authenticated users", () => {
     });
 
     test("calculates comparison with previous month", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const currentMonth = createSafeDate(0);
@@ -137,14 +131,12 @@ describe("authenticated users", () => {
             brainPowerEarned: 200,
             date: currentMonth,
             dayOfWeek: currentMonth.getDay(),
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             brainPowerEarned: 100,
             date: lastMonth,
             dayOfWeek: lastMonth.getDay(),
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -158,7 +150,7 @@ describe("authenticated users", () => {
     });
 
     test("navigates to previous month with offset", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const currentMonth = createSafeDate(0);
@@ -170,14 +162,12 @@ describe("authenticated users", () => {
             brainPowerEarned: 300,
             date: currentMonth,
             dayOfWeek: currentMonth.getDay(),
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             brainPowerEarned: 150,
             date: lastMonth,
             dayOfWeek: lastMonth.getDay(),
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -197,7 +187,7 @@ describe("authenticated users", () => {
 
   describe("6months period", () => {
     test("returns weekly aggregated data points", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const today = createSafeDate(0);
@@ -209,14 +199,12 @@ describe("authenticated users", () => {
             brainPowerEarned: 100,
             date: today,
             dayOfWeek: today.getDay(),
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             brainPowerEarned: 80,
             date: oneWeekAgo,
             dayOfWeek: oneWeekAgo.getDay(),
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -232,7 +220,7 @@ describe("authenticated users", () => {
 
   describe("year period", () => {
     test("returns monthly aggregated data points", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const today = createSafeDate(0);
@@ -244,14 +232,12 @@ describe("authenticated users", () => {
             brainPowerEarned: 250,
             date: today,
             dayOfWeek: today.getDay(),
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             brainPowerEarned: 150,
             date: yesterday,
             dayOfWeek: yesterday.getDay(),
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -267,7 +253,7 @@ describe("authenticated users", () => {
 
   describe("all period", () => {
     test("returns yearly aggregated data points", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const today = createSafeDate(0);
@@ -277,7 +263,6 @@ describe("authenticated users", () => {
           brainPowerEarned: 200,
           date: today,
           dayOfWeek: today.getDay(),
-          organizationId: org.id,
           userId: Number(user.id),
         },
       });
@@ -292,7 +277,7 @@ describe("authenticated users", () => {
 
   describe("navigation flags", () => {
     test("hasPreviousPeriod is true when historical data exists", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const currentMonth = createSafeDate(0);
@@ -304,14 +289,12 @@ describe("authenticated users", () => {
             brainPowerEarned: 100,
             date: currentMonth,
             dayOfWeek: currentMonth.getDay(),
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             brainPowerEarned: 50,
             date: twoMonthsAgo,
             dayOfWeek: twoMonthsAgo.getDay(),
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -324,7 +307,7 @@ describe("authenticated users", () => {
     });
 
     test("hasNextPeriod is false when on current period (offset=0)", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const date = createSafeDate(0);
@@ -333,7 +316,6 @@ describe("authenticated users", () => {
           brainPowerEarned: 100,
           date,
           dayOfWeek: date.getDay(),
-          organizationId: org.id,
           userId: Number(user.id),
         },
       });
@@ -345,7 +327,7 @@ describe("authenticated users", () => {
     });
 
     test("hasNextPeriod is true when offset > 0", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const lastMonth = createSafeDate(1);
@@ -355,7 +337,6 @@ describe("authenticated users", () => {
           brainPowerEarned: 75,
           date: lastMonth,
           dayOfWeek: lastMonth.getDay(),
-          organizationId: org.id,
           userId: Number(user.id),
         },
       });

--- a/apps/main/src/data/progress/get-energy-history.test.ts
+++ b/apps/main/src/data/progress/get-energy-history.test.ts
@@ -1,7 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { signInAs } from "@zoonk/testing/fixtures/auth";
 import { createSafeDate, createSameWeekDates } from "@zoonk/testing/fixtures/dates";
-import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { describe, expect, test } from "vitest";
 import { getEnergyHistory } from "./get-energy-history";
@@ -27,7 +26,7 @@ describe("authenticated users", () => {
 
   describe("month period", () => {
     test("returns daily data points for current month", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       // Use createSafeDate to avoid month boundary issues (always mid-month)
@@ -40,14 +39,12 @@ describe("authenticated users", () => {
             date: today,
             dayOfWeek: today.getDay(),
             energyAtEnd: 85.5,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             date: yesterday,
             dayOfWeek: yesterday.getDay(),
             energyAtEnd: 80,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -61,7 +58,7 @@ describe("authenticated users", () => {
     });
 
     test("calculates average correctly", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       // Use createSafeDate to avoid month boundary issues
@@ -74,14 +71,12 @@ describe("authenticated users", () => {
             date: today,
             dayOfWeek: today.getDay(),
             energyAtEnd: 100,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             date: yesterday,
             dayOfWeek: yesterday.getDay(),
             energyAtEnd: 50,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -94,7 +89,7 @@ describe("authenticated users", () => {
     });
 
     test("calculates comparison with previous month", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const currentMonth = createSafeDate(0);
@@ -106,14 +101,12 @@ describe("authenticated users", () => {
             date: currentMonth,
             dayOfWeek: currentMonth.getDay(),
             energyAtEnd: 80,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             date: lastMonth,
             dayOfWeek: lastMonth.getDay(),
             energyAtEnd: 60,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -127,7 +120,7 @@ describe("authenticated users", () => {
     });
 
     test("navigates to previous month with offset", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const currentMonth = createSafeDate(0);
@@ -139,14 +132,12 @@ describe("authenticated users", () => {
             date: currentMonth,
             dayOfWeek: currentMonth.getDay(),
             energyAtEnd: 80,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             date: lastMonth,
             dayOfWeek: lastMonth.getDay(),
             energyAtEnd: 60,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -166,7 +157,7 @@ describe("authenticated users", () => {
 
   describe("6months period", () => {
     test("returns weekly aggregated data points", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       // Use createSafeDate for stable dates within the period
@@ -179,14 +170,12 @@ describe("authenticated users", () => {
             date: today,
             dayOfWeek: today.getDay(),
             energyAtEnd: 80,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             date: oneWeekAgo,
             dayOfWeek: oneWeekAgo.getDay(),
             energyAtEnd: 70,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -201,7 +190,7 @@ describe("authenticated users", () => {
 
   describe("year period", () => {
     test("returns monthly aggregated data points", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const currentMonth = createSafeDate(0);
@@ -213,14 +202,12 @@ describe("authenticated users", () => {
             date: currentMonth,
             dayOfWeek: currentMonth.getDay(),
             energyAtEnd: 85,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             date: lastMonth,
             dayOfWeek: lastMonth.getDay(),
             energyAtEnd: 75,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -235,7 +222,7 @@ describe("authenticated users", () => {
 
   describe("all period", () => {
     test("returns yearly aggregated data points", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const today = createSafeDate(0);
@@ -245,7 +232,6 @@ describe("authenticated users", () => {
           date: today,
           dayOfWeek: today.getDay(),
           energyAtEnd: 85,
-          organizationId: org.id,
           userId: Number(user.id),
         },
       });
@@ -260,7 +246,7 @@ describe("authenticated users", () => {
 
   describe("navigation flags", () => {
     test("hasPreviousPeriod is true when historical data exists", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const currentMonth = createSafeDate(0);
@@ -272,14 +258,12 @@ describe("authenticated users", () => {
             date: currentMonth,
             dayOfWeek: currentMonth.getDay(),
             energyAtEnd: 80,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             date: twoMonthsAgo,
             dayOfWeek: twoMonthsAgo.getDay(),
             energyAtEnd: 60,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -292,7 +276,7 @@ describe("authenticated users", () => {
     });
 
     test("hasNextPeriod is false when on current period (offset=0)", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const today = createSafeDate(0);
@@ -302,7 +286,6 @@ describe("authenticated users", () => {
           date: today,
           dayOfWeek: today.getDay(),
           energyAtEnd: 80,
-          organizationId: org.id,
           userId: Number(user.id),
         },
       });
@@ -314,7 +297,7 @@ describe("authenticated users", () => {
     });
 
     test("hasNextPeriod is true when offset > 0", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const lastMonth = createSafeDate(1);
@@ -324,7 +307,6 @@ describe("authenticated users", () => {
           date: lastMonth,
           dayOfWeek: lastMonth.getDay(),
           energyAtEnd: 70,
-          organizationId: org.id,
           userId: Number(user.id),
         },
       });
@@ -342,7 +324,7 @@ describe("authenticated users", () => {
 
   describe("daily decay for month period", () => {
     test("fills gaps between data points with -1 decay per day", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
 
       const headers = await signInAs(user.email, user.password);
 
@@ -357,14 +339,12 @@ describe("authenticated users", () => {
             date: day1,
             dayOfWeek: day1.getDay(),
             energyAtEnd: 75,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             date: day5,
             dayOfWeek: day5.getDay(),
             energyAtEnd: 76,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -391,7 +371,7 @@ describe("authenticated users", () => {
     });
 
     test("decay never goes below 0", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
 
       const headers = await signInAs(user.email, user.password);
 
@@ -406,14 +386,12 @@ describe("authenticated users", () => {
             date: day1,
             dayOfWeek: day1.getDay(),
             energyAtEnd: 3,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             date: day6,
             dayOfWeek: day6.getDay(),
             energyAtEnd: 50,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -438,7 +416,7 @@ describe("authenticated users", () => {
     });
 
     test("average includes decayed values", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
 
       const headers = await signInAs(user.email, user.password);
 
@@ -453,14 +431,12 @@ describe("authenticated users", () => {
             date: day1,
             dayOfWeek: day1.getDay(),
             energyAtEnd: 90,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             date: day3,
             dayOfWeek: day3.getDay(),
             energyAtEnd: 95,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -475,7 +451,7 @@ describe("authenticated users", () => {
     });
 
     test("applies decay and aggregates by week for 6months period", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       // Use createSameWeekDates to guarantee both dates are in the same Mon-Sun week
@@ -487,14 +463,12 @@ describe("authenticated users", () => {
             date: day1,
             dayOfWeek: day1.getDay(),
             energyAtEnd: 80,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             date: day3,
             dayOfWeek: day3.getDay(),
             energyAtEnd: 90,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -511,7 +485,7 @@ describe("authenticated users", () => {
     });
 
     test("applies decay and aggregates by month for year period", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
 
       const headers = await signInAs(user.email, user.password);
 
@@ -526,14 +500,12 @@ describe("authenticated users", () => {
             date: day1,
             dayOfWeek: day1.getDay(),
             energyAtEnd: 100,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
             date: day4,
             dayOfWeek: day4.getDay(),
             energyAtEnd: 100,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],

--- a/apps/main/src/data/progress/get-score-history.test.ts
+++ b/apps/main/src/data/progress/get-score-history.test.ts
@@ -1,7 +1,6 @@
 import { prisma } from "@zoonk/db";
 import { signInAs } from "@zoonk/testing/fixtures/auth";
 import { createSafeDate } from "@zoonk/testing/fixtures/dates";
-import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { describe, expect, test } from "vitest";
 import { getScoreHistory } from "./get-score-history";
@@ -26,7 +25,7 @@ describe("authenticated users", () => {
   });
 
   test("returns null when user has records but no answers", async () => {
-    const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+    const user = await userFixture();
     const headers = await signInAs(user.email, user.password);
 
     const date = new Date();
@@ -36,7 +35,6 @@ describe("authenticated users", () => {
         date,
         dayOfWeek: date.getDay(),
         incorrectAnswers: 0,
-        organizationId: org.id,
         userId: Number(user.id),
       },
     });
@@ -47,7 +45,7 @@ describe("authenticated users", () => {
 
   describe("month period", () => {
     test("returns daily data points for current month", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const today = createSafeDate(0, 0);
@@ -61,7 +59,6 @@ describe("authenticated users", () => {
             dayOfWeek: today.getDay(),
 
             incorrectAnswers: 2,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
@@ -70,7 +67,6 @@ describe("authenticated users", () => {
             dayOfWeek: yesterday.getDay(),
 
             incorrectAnswers: 4,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -85,7 +81,7 @@ describe("authenticated users", () => {
     });
 
     test("calculates score as percentage correctly", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const today = new Date();
@@ -96,7 +92,6 @@ describe("authenticated users", () => {
           date: today,
           dayOfWeek: today.getDay(),
           incorrectAnswers: 3,
-          organizationId: org.id,
           userId: Number(user.id),
         },
       });
@@ -109,7 +104,7 @@ describe("authenticated users", () => {
     });
 
     test("calculates comparison with previous month", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const currentMonth = createSafeDate(0);
@@ -122,7 +117,6 @@ describe("authenticated users", () => {
             date: currentMonth,
             dayOfWeek: currentMonth.getDay(),
             incorrectAnswers: 1,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
@@ -130,7 +124,6 @@ describe("authenticated users", () => {
             date: lastMonth,
             dayOfWeek: lastMonth.getDay(),
             incorrectAnswers: 3,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -144,7 +137,7 @@ describe("authenticated users", () => {
     });
 
     test("navigates to previous month with offset", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const currentMonth = createSafeDate(0);
@@ -157,7 +150,6 @@ describe("authenticated users", () => {
             date: currentMonth,
             dayOfWeek: currentMonth.getDay(),
             incorrectAnswers: 1,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
@@ -165,7 +157,6 @@ describe("authenticated users", () => {
             date: lastMonth,
             dayOfWeek: lastMonth.getDay(),
             incorrectAnswers: 4,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -185,7 +176,7 @@ describe("authenticated users", () => {
 
   describe("6months period", () => {
     test("returns weekly aggregated data points", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const today = new Date();
@@ -199,7 +190,6 @@ describe("authenticated users", () => {
             date: today,
             dayOfWeek: today.getDay(),
             incorrectAnswers: 2,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
@@ -207,7 +197,6 @@ describe("authenticated users", () => {
             date: oneWeekAgo,
             dayOfWeek: oneWeekAgo.getDay(),
             incorrectAnswers: 3,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -220,7 +209,7 @@ describe("authenticated users", () => {
     });
 
     test("aggregates weekly scores correctly", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       // Two days in the same week
@@ -235,7 +224,6 @@ describe("authenticated users", () => {
             date: day1,
             dayOfWeek: day1.getDay(),
             incorrectAnswers: 2,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
@@ -243,7 +231,6 @@ describe("authenticated users", () => {
             date: day2,
             dayOfWeek: day2.getDay(),
             incorrectAnswers: 4,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -259,7 +246,7 @@ describe("authenticated users", () => {
 
   describe("year period", () => {
     test("returns monthly aggregated data points", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const currentMonth = createSafeDate(0);
@@ -272,7 +259,6 @@ describe("authenticated users", () => {
             date: currentMonth,
             dayOfWeek: currentMonth.getDay(),
             incorrectAnswers: 1,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
@@ -280,7 +266,6 @@ describe("authenticated users", () => {
             date: lastMonth,
             dayOfWeek: lastMonth.getDay(),
             incorrectAnswers: 2,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -295,7 +280,7 @@ describe("authenticated users", () => {
 
   describe("all period", () => {
     test("returns yearly aggregated data points", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const today = createSafeDate(0);
@@ -306,7 +291,6 @@ describe("authenticated users", () => {
           date: today,
           dayOfWeek: today.getDay(),
           incorrectAnswers: 1,
-          organizationId: org.id,
           userId: Number(user.id),
         },
       });
@@ -321,7 +305,7 @@ describe("authenticated users", () => {
 
   describe("navigation flags", () => {
     test("hasPreviousPeriod is true when historical data exists", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const currentMonth = createSafeDate(0);
@@ -334,7 +318,6 @@ describe("authenticated users", () => {
             date: currentMonth,
             dayOfWeek: currentMonth.getDay(),
             incorrectAnswers: 2,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
@@ -342,7 +325,6 @@ describe("authenticated users", () => {
             date: twoMonthsAgo,
             dayOfWeek: twoMonthsAgo.getDay(),
             incorrectAnswers: 4,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],
@@ -355,7 +337,7 @@ describe("authenticated users", () => {
     });
 
     test("hasNextPeriod is false when on current period (offset=0)", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       await prisma.dailyProgress.create({
@@ -364,7 +346,6 @@ describe("authenticated users", () => {
           date: new Date(),
           dayOfWeek: new Date().getDay(),
           incorrectAnswers: 2,
-          organizationId: org.id,
           userId: Number(user.id),
         },
       });
@@ -376,7 +357,7 @@ describe("authenticated users", () => {
     });
 
     test("hasNextPeriod is true when offset > 0", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const lastMonth = createSafeDate(1);
@@ -387,7 +368,6 @@ describe("authenticated users", () => {
           date: lastMonth,
           dayOfWeek: lastMonth.getDay(),
           incorrectAnswers: 3,
-          organizationId: org.id,
           userId: Number(user.id),
         },
       });
@@ -405,7 +385,7 @@ describe("authenticated users", () => {
 
   describe("days with no answers", () => {
     test("excludes days with zero answers from calculations", async () => {
-      const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+      const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
       const today = createSafeDate(0, 0);
@@ -418,7 +398,6 @@ describe("authenticated users", () => {
             date: today,
             dayOfWeek: today.getDay(),
             incorrectAnswers: 0,
-            organizationId: org.id,
             userId: Number(user.id),
           },
           {
@@ -426,7 +405,6 @@ describe("authenticated users", () => {
             date: yesterday,
             dayOfWeek: yesterday.getDay(),
             incorrectAnswers: 0,
-            organizationId: org.id,
             userId: Number(user.id),
           },
         ],

--- a/apps/main/src/data/progress/get-score.test.ts
+++ b/apps/main/src/data/progress/get-score.test.ts
@@ -1,6 +1,5 @@
 import { prisma } from "@zoonk/db";
 import { signInAs } from "@zoonk/testing/fixtures/auth";
-import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { describe, expect, test } from "vitest";
 import { getScore } from "./get-score";
@@ -24,7 +23,6 @@ describe("authenticated users", () => {
   test("returns score when user has DailyProgress records", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);
-    const org = await organizationFixture();
 
     const today = new Date();
     const yesterday = new Date(today);
@@ -37,7 +35,6 @@ describe("authenticated users", () => {
           date: today,
           dayOfWeek: today.getDay(),
           incorrectAnswers: 3,
-          organizationId: org.id,
           userId: Number(user.id),
         },
         {
@@ -45,7 +42,6 @@ describe("authenticated users", () => {
           date: yesterday,
           dayOfWeek: yesterday.getDay(),
           incorrectAnswers: 2,
-          organizationId: org.id,
           userId: Number(user.id),
         },
       ],
@@ -61,7 +57,6 @@ describe("authenticated users", () => {
   test("excludes records older than 3 months", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);
-    const org = await organizationFixture();
 
     const today = new Date();
     const oldDate = new Date(today);
@@ -74,7 +69,6 @@ describe("authenticated users", () => {
           date: today,
           dayOfWeek: today.getDay(),
           incorrectAnswers: 0,
-          organizationId: org.id,
           userId: Number(user.id),
         },
         {
@@ -82,7 +76,6 @@ describe("authenticated users", () => {
           date: oldDate,
           dayOfWeek: oldDate.getDay(),
           incorrectAnswers: 100,
-          organizationId: org.id,
           userId: Number(user.id),
         },
       ],
@@ -98,7 +91,6 @@ describe("authenticated users", () => {
   test("filters by custom date range when startDate and endDate are provided", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);
-    const org = await organizationFixture();
 
     const now = new Date();
     const oneWeekAgo = new Date(now);
@@ -113,7 +105,6 @@ describe("authenticated users", () => {
           date: now,
           dayOfWeek: now.getDay(),
           incorrectAnswers: 0,
-          organizationId: org.id,
           userId: Number(user.id),
         },
         {
@@ -121,7 +112,6 @@ describe("authenticated users", () => {
           date: oneWeekAgo,
           dayOfWeek: oneWeekAgo.getDay(),
           incorrectAnswers: 5,
-          organizationId: org.id,
           userId: Number(user.id),
         },
         {
@@ -129,7 +119,6 @@ describe("authenticated users", () => {
           date: twoWeeksAgo,
           dayOfWeek: twoWeeksAgo.getDay(),
           incorrectAnswers: 10,
-          organizationId: org.id,
           userId: Number(user.id),
         },
       ],

--- a/apps/main/src/data/progress/submit-activity-completion.test.ts
+++ b/apps/main/src/data/progress/submit-activity-completion.test.ts
@@ -70,7 +70,6 @@ describe(submitActivityCompletion, () => {
       durationSeconds: 10,
 
       localDate: todayLocalDate(),
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
       stepResults: [stepResult(true)],
@@ -97,7 +96,6 @@ describe(submitActivityCompletion, () => {
       durationSeconds: 15,
 
       localDate: todayLocalDate(),
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 15_000),
       stepResults: [stepResult(true)],
@@ -176,7 +174,6 @@ describe(submitActivityCompletion, () => {
       activityId: secondActivity.id,
       durationSeconds: 15,
       localDate: todayLocalDate(),
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 15_000),
       stepResults: [stepResult(true)],
@@ -209,7 +206,6 @@ describe(submitActivityCompletion, () => {
       durationSeconds: 10,
 
       localDate: todayLocalDate(),
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
       stepResults: [stepResult(true)],
@@ -232,7 +228,6 @@ describe(submitActivityCompletion, () => {
       durationSeconds: 10,
 
       localDate: todayLocalDate(),
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 3, energyDelta: 0.4, incorrectCount: 2 },
       startedAt: new Date(Date.now() - 10_000),
       stepResults: [stepResult(true)],
@@ -240,7 +235,7 @@ describe(submitActivityCompletion, () => {
     });
 
     const daily = await prisma.dailyProgress.findFirst({
-      where: { organizationId: org.id, userId },
+      where: { userId },
     });
 
     expect(daily).not.toBeNull();
@@ -262,7 +257,6 @@ describe(submitActivityCompletion, () => {
       durationSeconds: 10,
 
       localDate: todayLocalDate(),
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 5, energyDelta: 1, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
       stepResults: [stepResult(true)],
@@ -284,7 +278,6 @@ describe(submitActivityCompletion, () => {
       durationSeconds: 10,
 
       localDate: todayLocalDate(),
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 0, energyDelta: -0.5, incorrectCount: 5 },
       startedAt: new Date(Date.now() - 10_000),
       stepResults: [stepResult(false)],
@@ -304,7 +297,6 @@ describe(submitActivityCompletion, () => {
       durationSeconds: 10,
 
       localDate: todayLocalDate(),
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
       stepResults: [stepResult(true)],
@@ -338,7 +330,6 @@ describe(submitActivityCompletion, () => {
       durationSeconds: 5,
 
       localDate: todayLocalDate(),
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 0, energyDelta: 0.1, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 5000),
       stepResults: [],
@@ -346,7 +337,7 @@ describe(submitActivityCompletion, () => {
     });
 
     const daily = await prisma.dailyProgress.findFirst({
-      where: { organizationId: org.id, userId },
+      where: { userId },
     });
 
     expect(daily).not.toBeNull();
@@ -363,7 +354,6 @@ describe(submitActivityCompletion, () => {
       durationSeconds: 10,
 
       localDate: todayLocalDate(),
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
       stepResults: [stepResult(true)],
@@ -373,86 +363,6 @@ describe(submitActivityCompletion, () => {
     expect(result.belt.color).toBe("white");
     expect(result.belt.level).toBe(1);
     expect(result.newTotalBp).toBe(10);
-  });
-
-  test("null organizationId: creates DailyProgress without org", async () => {
-    const user = await userFixture();
-    const userId = Number(user.id);
-
-    await submitActivityCompletion({
-      activityId: activity.id,
-      durationSeconds: 10,
-
-      localDate: todayLocalDate(),
-      organizationId: null,
-      score: { brainPower: 10, correctCount: 2, energyDelta: 0.3, incorrectCount: 1 },
-      startedAt: new Date(Date.now() - 10_000),
-      stepResults: [stepResult(true)],
-      userId,
-    });
-
-    const daily = await prisma.dailyProgress.findFirst({
-      where: { organizationId: null, userId },
-    });
-
-    expect(daily).not.toBeNull();
-    expect(daily?.correctAnswers).toBe(2);
-    expect(daily?.incorrectAnswers).toBe(1);
-    expect(daily?.brainPowerEarned).toBe(10);
-    expect(daily?.interactiveCompleted).toBe(1);
-  });
-
-  test("null organizationId: increments existing DailyProgress on second completion", async () => {
-    const user = await userFixture();
-    const userId = Number(user.id);
-
-    const baseInput = {
-      activityId: activity.id,
-      durationSeconds: 10,
-
-      localDate: todayLocalDate(),
-      organizationId: null as number | null,
-      score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
-      startedAt: new Date(Date.now() - 10_000),
-      stepResults: [stepResult(true)],
-      userId,
-    };
-
-    await submitActivityCompletion(baseInput);
-    await submitActivityCompletion(baseInput);
-
-    const dailyRecords = await prisma.dailyProgress.findMany({
-      where: { organizationId: null, userId },
-    });
-
-    expect(dailyRecords).toHaveLength(1);
-    expect(dailyRecords[0]?.brainPowerEarned).toBe(20);
-    expect(dailyRecords[0]?.correctAnswers).toBe(2);
-    expect(dailyRecords[0]?.interactiveCompleted).toBe(2);
-  });
-
-  test("null organizationId: creates StepAttempt without org", async () => {
-    const user = await userFixture();
-    const userId = Number(user.id);
-
-    await submitActivityCompletion({
-      activityId: activity.id,
-      durationSeconds: 10,
-
-      localDate: todayLocalDate(),
-      organizationId: null,
-      score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
-      startedAt: new Date(Date.now() - 10_000),
-      stepResults: [stepResult(true)],
-      userId,
-    });
-
-    const attempts = await prisma.stepAttempt.findMany({
-      where: { organizationId: null, stepId: step.id, userId },
-    });
-
-    expect(attempts).toHaveLength(1);
-    expect(attempts[0]?.organizationId).toBeNull();
   });
 
   test("creates CourseUser and increments userCount on first activity completion", async () => {
@@ -466,7 +376,6 @@ describe(submitActivityCompletion, () => {
       durationSeconds: 10,
 
       localDate: todayLocalDate(),
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
       stepResults: [stepResult(true)],
@@ -491,7 +400,6 @@ describe(submitActivityCompletion, () => {
       durationSeconds: 10,
 
       localDate: todayLocalDate(),
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
       stepResults: [stepResult(true)],
@@ -536,7 +444,6 @@ describe(submitActivityCompletion, () => {
       durationSeconds: 10,
 
       localDate: todayLocalDate(),
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
       stepResults: [stepResult(true)],
@@ -546,11 +453,13 @@ describe(submitActivityCompletion, () => {
     const userProgress = await prisma.userProgress.findUnique({ where: { userId } });
     expect(userProgress?.currentEnergy).toBeCloseTo(50.2);
 
-    // No decay gap records should exist (only today's org-scoped record)
-    const decayRecords = await prisma.dailyProgress.findMany({
-      where: { organizationId: null, userId },
+    const dailyRecords = await prisma.dailyProgress.findMany({
+      orderBy: { date: "asc" },
+      where: { userId },
     });
-    expect(decayRecords).toHaveLength(0);
+    expect(dailyRecords).toHaveLength(1);
+    expect(dailyRecords[0]?.date).toEqual(parseLocalDate(todayLocalDate()));
+    expect(dailyRecords[0]?.energyAtEnd).toBeCloseTo(50.2);
   });
 
   test("completes a pre-started record: sets completedAt and durationSeconds, preserves startedAt", async () => {
@@ -573,7 +482,6 @@ describe(submitActivityCompletion, () => {
       durationSeconds: 20,
 
       localDate: todayLocalDate(),
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 20_000),
       stepResults: [stepResult(true)],
@@ -606,7 +514,6 @@ describe(submitActivityCompletion, () => {
       durationSeconds: 10,
 
       localDate,
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
       stepResults: [stepResult(true)],
@@ -614,7 +521,7 @@ describe(submitActivityCompletion, () => {
     });
 
     const daily = await prisma.dailyProgress.findFirst({
-      where: { organizationId: org.id, userId },
+      where: { userId },
     });
 
     expect(daily).not.toBeNull();
@@ -635,7 +542,6 @@ describe(submitActivityCompletion, () => {
         durationSeconds: 10,
 
         localDate: "9999-12-31",
-        organizationId: org.id,
         score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
         startedAt: new Date(Date.now() - 10_000),
         stepResults: [stepResult(true)],
@@ -654,7 +560,6 @@ describe(submitActivityCompletion, () => {
         durationSeconds: 10,
 
         localDate: "2020-01-01",
-        organizationId: org.id,
         score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
         startedAt: new Date(Date.now() - 10_000),
         stepResults: [stepResult(true)],
@@ -682,7 +587,6 @@ describe(submitActivityCompletion, () => {
       durationSeconds: 10,
 
       localDate,
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
       stepResults: [stepResult(true)],
@@ -693,23 +597,16 @@ describe(submitActivityCompletion, () => {
     const userProgress = await prisma.userProgress.findUnique({ where: { userId } });
     expect(userProgress?.currentEnergy).toBeCloseTo(46.2);
 
-    // 4 gap records (one per inactive day)
-    const gapRecords = await prisma.dailyProgress.findMany({
+    const dailyRecords = await prisma.dailyProgress.findMany({
       orderBy: { date: "asc" },
-      where: { organizationId: null, userId },
+      where: { userId },
     });
 
-    expect(gapRecords).toHaveLength(4);
-    expect(gapRecords[0]?.energyAtEnd).toBe(49);
-    expect(gapRecords[3]?.energyAtEnd).toBe(46);
-
-    // Today's record uses localDate
-    const todayRecord = await prisma.dailyProgress.findFirst({
-      where: { organizationId: org.id, userId },
-    });
-
-    expect(todayRecord?.date).toEqual(parseLocalDate(localDate));
-    expect(todayRecord?.energyAtEnd).toBeCloseTo(46.2);
+    expect(dailyRecords).toHaveLength(5);
+    expect(dailyRecords[0]?.energyAtEnd).toBe(49);
+    expect(dailyRecords[3]?.energyAtEnd).toBe(46);
+    expect(dailyRecords[4]?.date).toEqual(parseLocalDate(localDate));
+    expect(dailyRecords[4]?.energyAtEnd).toBeCloseTo(46.2);
   });
 
   test("applies decay and fills DailyProgress gaps for inactive days", async () => {
@@ -733,7 +630,6 @@ describe(submitActivityCompletion, () => {
       durationSeconds: 10,
 
       localDate: todayLocalDate(),
-      organizationId: org.id,
       score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
       startedAt: new Date(Date.now() - 10_000),
       stepResults: [stepResult(true)],
@@ -744,24 +640,19 @@ describe(submitActivityCompletion, () => {
     const userProgress = await prisma.userProgress.findUnique({ where: { userId } });
     expect(userProgress?.currentEnergy).toBeCloseTo(46.2);
 
-    // Should have 4 decay DailyProgress records (one per inactive day) + 1 for today
     const dailyRecords = await prisma.dailyProgress.findMany({
       orderBy: { date: "asc" },
-      where: { organizationId: null, userId },
+      where: { userId },
     });
 
-    expect(dailyRecords).toHaveLength(4);
+    expect(dailyRecords).toHaveLength(5);
 
     // Decay records: energy decreases by 1 each day
     expect(dailyRecords[0]?.energyAtEnd).toBe(49);
     expect(dailyRecords[1]?.energyAtEnd).toBe(48);
     expect(dailyRecords[2]?.energyAtEnd).toBe(47);
     expect(dailyRecords[3]?.energyAtEnd).toBe(46);
-
-    // Today's record is in the org-scoped DailyProgress
-    const todayRecord = await prisma.dailyProgress.findFirst({
-      where: { organizationId: org.id, userId },
-    });
-    expect(todayRecord?.energyAtEnd).toBeCloseTo(46.2);
+    expect(dailyRecords[4]?.date).toEqual(parseLocalDate(todayLocalDate()));
+    expect(dailyRecords[4]?.energyAtEnd).toBeCloseTo(46.2);
   });
 });

--- a/apps/main/src/data/progress/submit-activity-completion.ts
+++ b/apps/main/src/data/progress/submit-activity-completion.ts
@@ -13,7 +13,6 @@ export async function submitActivityCompletion(input: {
   activityId: bigint;
   durationSeconds: number;
   localDate: string;
-  organizationId: number | null;
   score: ScoreResult;
   startedAt: Date;
   stepResults: {
@@ -53,7 +52,6 @@ export async function submitActivityCompletion(input: {
           durationSeconds: step.durationSeconds,
           hourOfDay: step.hourOfDay,
           isCorrect: step.isCorrect,
-          organizationId: input.organizationId,
           stepId: step.stepId,
           userId: input.userId,
         })),
@@ -149,7 +147,6 @@ export async function submitActivityCompletion(input: {
       dayOfWeek: today.getUTCDay(),
       durationSeconds: input.durationSeconds,
       field,
-      organizationId: input.organizationId,
       score: input.score,
       userId: input.userId,
     });

--- a/packages/core/src/content/lifecycle.test.ts
+++ b/packages/core/src/content/lifecycle.test.ts
@@ -79,7 +79,6 @@ describe("content lifecycle", () => {
       durationSeconds: 30,
       hourOfDay: 9,
       isCorrect: true,
-      organizationId,
       stepId: step.id,
       userId: Number(user.id),
     });
@@ -212,7 +211,6 @@ describe("content lifecycle", () => {
       durationSeconds: 22,
       hourOfDay: 13,
       isCorrect: false,
-      organizationId,
       stepId: step.id,
       userId: Number(user.id),
     });

--- a/packages/db/src/prisma/migrations/20260412124352_remove_progress_organization_scope/migration.sql
+++ b/packages/db/src/prisma/migrations/20260412124352_remove_progress_organization_scope/migration.sql
@@ -1,0 +1,26 @@
+-- DropForeignKey
+ALTER TABLE "daily_progress" DROP CONSTRAINT "daily_progress_organization_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "step_attempts" DROP CONSTRAINT "step_attempts_organization_id_fkey";
+
+-- DropIndex
+DROP INDEX "daily_progress_organization_id_idx";
+
+-- DropIndex
+DROP INDEX "daily_progress_user_id_date_organization_id_key";
+
+-- DropIndex
+DROP INDEX "step_attempts_organization_id_idx";
+
+-- DropIndex
+DROP INDEX "step_attempts_user_id_organization_id_idx";
+
+-- AlterTable
+ALTER TABLE "daily_progress" DROP COLUMN "organization_id";
+
+-- AlterTable
+ALTER TABLE "step_attempts" DROP COLUMN "organization_id";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "daily_progress_user_id_date_key" ON "daily_progress"("user_id", "date");

--- a/packages/db/src/prisma/models/accounts.prisma
+++ b/packages/db/src/prisma/models/accounts.prisma
@@ -88,22 +88,20 @@ model Verification {
 }
 
 model Organization {
-  id               Int             @id @default(autoincrement())
+  id               Int          @id @default(autoincrement())
   name             String
   slug             String
   logo             String?
-  createdAt        DateTime        @default(now()) @map("created_at")
+  createdAt        DateTime     @default(now()) @map("created_at")
   metadata         String?
-  kind             String          @default("brand")
+  kind             String       @default("brand")
   members          Member[]
   invitations      Invitation[]
   courses          Course[]
   chapters         Chapter[]
   lessons          Lesson[]
   activities       Activity[]
-  stepAttempts     StepAttempt[]
-  dailyProgress    DailyProgress[]
-  stripeCustomerId String?         @map("stripe_customer_id")
+  stripeCustomerId String?      @map("stripe_customer_id")
   words            Word[]
   sentences        Sentence[]
 

--- a/packages/db/src/prisma/models/progress.prisma
+++ b/packages/db/src/prisma/models/progress.prisma
@@ -58,25 +58,21 @@ model CourseCompletion {
 }
 
 model StepAttempt {
-  id              BigInt        @id @default(autoincrement())
-  userId          Int           @map("user_id")
-  user            User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  stepId          BigInt        @map("step_id")
-  step            Step          @relation(fields: [stepId], references: [id], onDelete: Cascade)
-  organizationId  Int?          @map("organization_id")
-  organization    Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  isCorrect       Boolean       @map("is_correct")
+  id              BigInt   @id @default(autoincrement())
+  userId          Int      @map("user_id")
+  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  stepId          BigInt   @map("step_id")
+  step            Step     @relation(fields: [stepId], references: [id], onDelete: Cascade)
+  isCorrect       Boolean  @map("is_correct")
   answer          Json
   effects         Json?
-  durationSeconds Int           @map("duration_seconds")
-  answeredAt      DateTime      @default(now()) @map("answered_at")
-  hourOfDay       Int           @map("hour_of_day") @db.SmallInt
-  dayOfWeek       Int           @map("day_of_week") @db.SmallInt
+  durationSeconds Int      @map("duration_seconds")
+  answeredAt      DateTime @default(now()) @map("answered_at")
+  hourOfDay       Int      @map("hour_of_day") @db.SmallInt
+  dayOfWeek       Int      @map("day_of_week") @db.SmallInt
 
   @@index([userId, answeredAt])
   @@index([stepId])
-  @@index([organizationId])
-  @@index([userId, organizationId])
   @@index([userId, dayOfWeek])
   @@index([userId, hourOfDay])
   @@index([answeredAt])
@@ -95,24 +91,21 @@ model UserProgress {
 }
 
 model DailyProgress {
-  id                   BigInt        @id @default(autoincrement())
-  userId               Int           @map("user_id")
-  user                 User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  date                 DateTime      @db.Date
-  dayOfWeek            Int           @map("day_of_week") @db.SmallInt
-  organizationId       Int?          @map("organization_id")
-  organization         Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  correctAnswers       Int           @default(0) @map("correct_answers")
-  incorrectAnswers     Int           @default(0) @map("incorrect_answers")
-  staticCompleted      Int           @default(0) @map("static_completed")
-  interactiveCompleted Int           @default(0) @map("interactive_completed")
-  brainPowerEarned     Int           @default(0) @map("brain_power_earned")
-  timeSpentSeconds     Int           @default(0) @map("time_spent_seconds")
-  energyAtEnd          Float         @default(0) @map("energy_at_end")
+  id                   BigInt   @id @default(autoincrement())
+  userId               Int      @map("user_id")
+  user                 User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  date                 DateTime @db.Date
+  dayOfWeek            Int      @map("day_of_week") @db.SmallInt
+  correctAnswers       Int      @default(0) @map("correct_answers")
+  incorrectAnswers     Int      @default(0) @map("incorrect_answers")
+  staticCompleted      Int      @default(0) @map("static_completed")
+  interactiveCompleted Int      @default(0) @map("interactive_completed")
+  brainPowerEarned     Int      @default(0) @map("brain_power_earned")
+  timeSpentSeconds     Int      @default(0) @map("time_spent_seconds")
+  energyAtEnd          Float    @default(0) @map("energy_at_end")
 
-  @@unique([userId, date, organizationId], name: "userDateOrg")
+  @@unique([userId, date], name: "userDate")
   @@index([userId, dayOfWeek])
-  @@index([organizationId])
   @@index([date])
   @@map("daily_progress")
 }

--- a/packages/db/src/prisma/seed/progress.ts
+++ b/packages/db/src/prisma/seed/progress.ts
@@ -9,7 +9,6 @@ function seededRandom(seed: number) {
 
 function buildOwnerDailyProgress(
   today: Date,
-  orgId: number,
   userId: number,
 ): {
   brainPowerEarned: number;
@@ -19,7 +18,6 @@ function buildOwnerDailyProgress(
   energyAtEnd: number;
   incorrectAnswers: number;
   interactiveCompleted: number;
-  organizationId: number;
   staticCompleted: number;
   timeSpentSeconds: number;
   userId: number;
@@ -47,7 +45,6 @@ function buildOwnerDailyProgress(
         energyAtEnd: Math.max(20, Math.min(95, baseEnergy + energyVariation)),
         incorrectAnswers: 1 + Math.floor(seededRandom(seed + 5) * 6),
         interactiveCompleted: 6 + Math.floor(seededRandom(seed + 6) * 12),
-        organizationId: orgId,
         staticCompleted: 3 + Math.floor(seededRandom(seed + 7) * 10),
         timeSpentSeconds: 900 + Math.floor(seededRandom(seed + 8) * 2100),
         userId,
@@ -138,7 +135,6 @@ async function seedStepAttempts(
     durationSeconds: 15 + Math.floor(Math.random() * 30),
     hourOfDay: now.getHours(),
     isCorrect: index !== 1,
-    organizationId: org.id,
     stepId: step.id,
     userId: users.owner.id,
   }));
@@ -175,7 +171,7 @@ export async function seedProgress(
 
   await seedUserProgress(prisma, users, now);
 
-  const dailyProgressData = buildOwnerDailyProgress(today, org.id, users.owner.id);
+  const dailyProgressData = buildOwnerDailyProgress(today, users.owner.id);
 
   await Promise.all(
     dailyProgressData.map((data) =>
@@ -183,9 +179,8 @@ export async function seedProgress(
         create: data,
         update: {},
         where: {
-          userDateOrg: {
+          userDate: {
             date: data.date,
-            organizationId: data.organizationId,
             userId: data.userId,
           },
         },

--- a/packages/e2e/src/helpers.ts
+++ b/packages/e2e/src/helpers.ts
@@ -205,7 +205,7 @@ function buildGroupDates(today: Date, range: { start: Date; end: Date }, isCurre
   }).filter((entry): entry is NonNullable<typeof entry> => entry !== null);
 }
 
-function buildDailyProgressInputs(today: Date, orgId: number, userId: number) {
+function buildDailyProgressInputs(today: Date, userId: number) {
   const dateEntries = ALL_PERIODS.flatMap((period) => {
     const { current, previous } = calculateDateRanges(period, 0);
     return [...buildGroupDates(today, current, true), ...buildGroupDates(today, previous, false)];
@@ -221,15 +221,10 @@ function buildDailyProgressInputs(today: Date, orgId: number, userId: number) {
       seen.add(key);
       return true;
     })
-    .map((entry) => ({ ...entry, organizationId: orgId, userId }));
+    .map((entry) => ({ ...entry, userId }));
 }
 
-async function createStepAttempts(
-  stepId: bigint,
-  orgId: number,
-  userId: number,
-  now: Date,
-): Promise<void> {
+async function createStepAttempts(stepId: bigint, userId: number, now: Date): Promise<void> {
   const configs = [
     { correct: 9, hourOfDay: 9, incorrect: 1 },
     { correct: 8, hourOfDay: 15, incorrect: 2 },
@@ -244,7 +239,6 @@ async function createStepAttempts(
       durationSeconds: 15,
       hourOfDay: config.hourOfDay,
       isCorrect: true,
-      organizationId: orgId,
       stepId,
       userId,
     })),
@@ -255,7 +249,6 @@ async function createStepAttempts(
       durationSeconds: 15,
       hourOfDay: config.hourOfDay,
       isCorrect: false,
-      organizationId: orgId,
       stepId,
       userId,
     })),
@@ -331,9 +324,9 @@ async function createE2EProgressData(userId: number): Promise<void> {
     userId,
   });
 
-  await dailyProgressFixtureMany(buildDailyProgressInputs(today, org.id, userId));
+  await dailyProgressFixtureMany(buildDailyProgressInputs(today, userId));
 
-  await createStepAttempts(step.id, org.id, userId, now);
+  await createStepAttempts(step.id, userId, now);
 
   const activityDurationSeconds = 120;
   const activityStartOffsetSeconds = 180;

--- a/packages/testing/src/fixtures/progress.ts
+++ b/packages/testing/src/fixtures/progress.ts
@@ -7,7 +7,6 @@ export async function dailyProgressFixtureMany(
     date: Date;
     energyAtEnd?: number;
     incorrectAnswers?: number;
-    organizationId: number;
     userId: number;
   }[],
 ) {
@@ -19,7 +18,6 @@ export async function dailyProgressFixtureMany(
       dayOfWeek: input.date.getDay(),
       energyAtEnd: input.energyAtEnd ?? 0,
       incorrectAnswers: input.incorrectAnswers ?? 0,
-      organizationId: input.organizationId,
       userId: input.userId,
     })),
   });

--- a/packages/testing/src/fixtures/step-attempts.ts
+++ b/packages/testing/src/fixtures/step-attempts.ts
@@ -8,7 +8,6 @@ export async function stepAttemptFixture(attrs: {
   effects?: object;
   hourOfDay: number;
   isCorrect: boolean;
-  organizationId?: number;
   stepId: bigint;
   userId: number;
 }) {
@@ -21,7 +20,6 @@ export async function stepAttemptFixture(attrs: {
       effects: attrs.effects,
       hourOfDay: attrs.hourOfDay,
       isCorrect: attrs.isCorrect,
-      organizationId: attrs.organizationId,
       stepId: attrs.stepId,
       userId: attrs.userId,
     },


### PR DESCRIPTION
## Summary
- remove organization scoping from `DailyProgress` and `StepAttempt`
- make daily progress global per user/day and update the completion write path
- update fixtures, seeds, tests, and the Prisma migration for the new schema

Closes #1246

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed organization scoping from `DailyProgress` and `StepAttempt` to make learner progress global per user/day. This simplifies completion writes, enforces a single daily row, and resolves the null-org progress issue (#1246).

- **Refactors**
  - Simplified `upsertDailyProgress` to upsert by `userDate` only; removed org-specific branches.
  - Updated completion write path to stop passing `organizationId`; `StepAttempt` no longer stores org.
  - Updated tests, fixtures, seeds, and e2e helpers for global progress; added decay-gap coverage.

- **Migration**
  - Prisma migration in `packages/db` drops `organization_id` from `daily_progress` and `step_attempts`, and creates unique index `daily_progress(user_id, date)`.
  - Remove `organizationId` from any calls to `submitActivityCompletion` and step attempt fixtures.
  - Re-run seeds to populate global daily progress.

<sup>Written for commit 883c8e747d0f63e8b614db9cd823bd635e6a6170. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

