### PR TITLE
refactor(test): share workflow test mocks

### DIFF
--- a/apps/api/mocks/workflow.ts
+++ b/apps/api/mocks/workflow.ts
@@ -1,0 +1,55 @@
+import { vi } from "vitest";
+
+type WorkflowMetadata = {
+  workflowRunId: string;
+};
+
+const defaultWorkflowMetadata: WorkflowMetadata = {
+  workflowRunId: "test-run-id",
+};
+
+let workflowMetadata = { ...defaultWorkflowMetadata };
+
+export const workflowReleaseLockMock = vi.fn();
+export const workflowWriteMock = vi.fn().mockResolvedValue(null);
+
+/**
+ * Builds the writable shape that our workflow helpers expect.
+ * Tests do not need a real stream implementation here — they only need
+ * a stable place to capture writes so stream assertions can inspect them.
+ */
+function createWritable() {
+  return {
+    getWriter: () => ({
+      releaseLock: workflowReleaseLockMock,
+      write: workflowWriteMock,
+    }),
+  };
+}
+
+export class FatalError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = "FatalError";
+  }
+}
+
+export const getWorkflowMetadata = vi.fn(() => workflowMetadata);
+export const getWritable = vi.fn().mockReturnValue(createWritable());
+export const workflowStep = vi.fn((_name: string, fn: unknown) => fn);
+
+/**
+ * Restores the shared workflow mock to the default state before each test.
+ * This exists because many workflow tests only clear call history globally,
+ * but they also rely on the default run id and stream writer being recreated
+ * consistently after a test changes the mock behavior.
+ */
+export function resetWorkflowMockState(): void {
+  workflowMetadata = { ...defaultWorkflowMetadata };
+
+  workflowReleaseLockMock.mockReset();
+  workflowWriteMock.mockReset().mockResolvedValue(null);
+  getWorkflowMetadata.mockReset().mockImplementation(() => workflowMetadata);
+  getWritable.mockReset().mockReturnValue(createWritable());
+  workflowStep.mockReset().mockImplementation((_name: string, fn: unknown) => fn);
+}

--- a/apps/api/setup-tests.ts
+++ b/apps/api/setup-tests.ts
@@ -1,7 +1,9 @@
 import { beforeEach, vi } from "vitest";
+import { resetWorkflowMockState } from "./mocks/workflow";
 
 vi.mock("server-only");
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetWorkflowMockState();
 });

--- a/apps/api/src/workflows/_test-utils/parse-stream-events.ts
+++ b/apps/api/src/workflows/_test-utils/parse-stream-events.ts
@@ -1,4 +1,5 @@
 import { isJsonObject } from "@zoonk/utils/json";
+import { getWorkflowWriteMock } from "./workflow-mock";
 
 /**
  * Safely parses a JSON string into a Record<string, unknown>.
@@ -14,8 +15,10 @@ function parseEvent(raw: unknown): Record<string, unknown> {
  * Each write call contains a string like `data: {"status":"started","step":"..."}\n\n`.
  * This parses them into objects for easy assertion.
  */
-export function getStreamedEvents(writeMock: {
-  mock: { calls: unknown[][] };
-}): Record<string, unknown>[] {
+export function getStreamedEvents(
+  writeMock: {
+    mock: { calls: unknown[][] };
+  } = getWorkflowWriteMock(),
+): Record<string, unknown>[] {
   return writeMock.mock.calls.map(([raw]) => parseEvent(raw));
 }

--- a/apps/api/src/workflows/_test-utils/workflow-mock.ts
+++ b/apps/api/src/workflows/_test-utils/workflow-mock.ts
@@ -1,0 +1,10 @@
+import { workflowWriteMock } from "../../../mocks/workflow";
+
+/**
+ * Returns the shared stream writer mock used by workflow tests.
+ * Keeping this behind a helper means individual test files do not need to
+ * own local `writeMock` variables just to inspect emitted stream events.
+ */
+export function getWorkflowWriteMock() {
+  return workflowWriteMock;
+}

--- a/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { generateActivityExplanation } from "@zoonk/ai/tasks/activities/core/explanation";
 import { generateActivityCustom } from "@zoonk/ai/tasks/activities/custom";
 import { type generateStepVisualDescriptions } from "@zoonk/ai/tasks/steps/visual-descriptions";
@@ -8,7 +9,7 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import { activityGenerationWorkflow } from "./activity-generation-workflow";
 import { type dispatchVisualContent } from "./steps/_utils/dispatch-visual-content";
 
@@ -38,20 +39,6 @@ function createDispatchResult(
       : { annotations: null, code: "const x = 1;", kind: "code", language: "typescript" },
   );
 }
-
-const writeMock = vi.fn().mockResolvedValue(null);
-
-vi.mock("workflow", () => ({
-  FatalError: class FatalError extends Error {},
-  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
-  getWritable: vi.fn().mockReturnValue({
-    getWriter: () => ({
-      releaseLock: vi.fn(),
-      write: writeMock,
-    }),
-  }),
-  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
-}));
 
 vi.mock("@zoonk/ai/tasks/activities/core/explanation", () => ({
   generateActivityExplanation: vi.fn().mockResolvedValue({
@@ -158,10 +145,6 @@ describe(activityGenerationWorkflow, () => {
       organizationId,
       title: `Test Chapter ${randomUUID()}`,
     });
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
   });
 
   describe("lesson validation", () => {
@@ -341,12 +324,10 @@ describe(activityGenerationWorkflow, () => {
       expect(generateActivityExplanation).not.toHaveBeenCalled();
       expect(generateActivityCustom).not.toHaveBeenCalled();
 
-      const completionCall = writeMock.mock.calls.find(
-        (call: string[]) =>
-          call[0]?.includes('"step":"saveExplanationActivity"') &&
-          call[0]?.includes('"status":"completed"'),
+      const completionEvent = getStreamedEvents().find(
+        (event) => event.step === "saveExplanationActivity" && event.status === "completed",
       );
-      expect(completionCall).toBeDefined();
+      expect(completionEvent).toBeDefined();
     });
 
     test("returns early without streaming completion when activities are completed or running", async () => {
@@ -379,12 +360,10 @@ describe(activityGenerationWorkflow, () => {
       expect(generateActivityExplanation).not.toHaveBeenCalled();
       expect(generateActivityCustom).not.toHaveBeenCalled();
 
-      const completionCall = writeMock.mock.calls.find(
-        (call: string[]) =>
-          call[0]?.includes('"step":"saveExplanationActivity"') &&
-          call[0]?.includes('"status":"completed"'),
+      const completionEvent = getStreamedEvents().find(
+        (event) => event.step === "saveExplanationActivity" && event.status === "completed",
       );
-      expect(completionCall).toBeUndefined();
+      expect(completionEvent).toBeUndefined();
     });
 
     test("does not skip when some activities are pending", async () => {

--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
@@ -13,7 +13,7 @@ import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { getString } from "@zoonk/utils/json";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import { activityGenerationWorkflow } from "./activity-generation-workflow";
 import { dispatchVisualContent } from "./steps/_utils/dispatch-visual-content";
 import { getNeighboringConceptsStep } from "./steps/get-neighboring-concepts-step";
@@ -21,8 +21,6 @@ import { getNeighboringConceptsStep } from "./steps/get-neighboring-concepts-ste
 vi.mock("./steps/get-neighboring-concepts-step", () => ({
   getNeighboringConceptsStep: vi.fn().mockResolvedValue([]),
 }));
-
-const mockStreamWrite = vi.hoisted(() => vi.fn().mockResolvedValue(null));
 
 function createDescriptionsResult(
   steps: { title: string; text: string }[],
@@ -50,18 +48,6 @@ function createDispatchResult(
       : { annotations: null, code: "const x = 1;", kind: "code", language: "typescript" },
   );
 }
-
-vi.mock("workflow", () => ({
-  FatalError: class FatalError extends Error {},
-  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
-  getWritable: vi.fn().mockReturnValue({
-    getWriter: () => ({
-      releaseLock: vi.fn(),
-      write: mockStreamWrite,
-    }),
-  }),
-  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
-}));
 
 vi.mock("@zoonk/ai/tasks/activities/core/explanation", () => ({
   generateActivityExplanation: vi.fn().mockResolvedValue({
@@ -210,10 +196,6 @@ describe("core activity workflow", () => {
       organizationId,
       title: `Test Chapter ${randomUUID()}`,
     });
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
   });
 
   describe("resumption", () => {

--- a/apps/api/src/workflows/activity-generation/custom-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/custom-activity-workflow.test.ts
@@ -7,7 +7,7 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import { activityGenerationWorkflow } from "./activity-generation-workflow";
 import { type dispatchVisualContent } from "./steps/_utils/dispatch-visual-content";
 
@@ -37,18 +37,6 @@ function createDispatchResult(
       : { annotations: null, code: "const x = 1;", kind: "code", language: "typescript" },
   );
 }
-
-vi.mock("workflow", () => ({
-  FatalError: class FatalError extends Error {},
-  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
-  getWritable: vi.fn().mockReturnValue({
-    getWriter: () => ({
-      releaseLock: vi.fn(),
-      write: vi.fn().mockResolvedValue(null),
-    }),
-  }),
-  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
-}));
 
 vi.mock("@zoonk/ai/tasks/activities/core/explanation", () => ({
   generateActivityExplanation: vi.fn().mockResolvedValue({
@@ -113,10 +101,6 @@ describe("custom activity workflow", () => {
       organizationId,
       title: `Test Chapter ${randomUUID()}`,
     });
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
   });
 
   test("one custom activity fails while others still complete", async () => {

--- a/apps/api/src/workflows/activity-generation/kinds/custom-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/custom-workflow.test.ts
@@ -7,7 +7,7 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import { type dispatchVisualContent } from "../steps/_utils/dispatch-visual-content";
 import { type LessonActivity } from "../steps/get-lesson-activities-step";
 import { customActivityWorkflow } from "./custom-workflow";
@@ -38,18 +38,6 @@ function createDispatchResult(
       : { annotations: null, code: "const x = 1;", kind: "code", language: "typescript" },
   );
 }
-
-vi.mock("workflow", () => ({
-  FatalError: class FatalError extends Error {},
-  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
-  getWritable: vi.fn().mockReturnValue({
-    getWriter: () => ({
-      releaseLock: vi.fn(),
-      write: vi.fn().mockResolvedValue(null),
-    }),
-  }),
-  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
-}));
 
 vi.mock("@zoonk/ai/tasks/activities/custom", () => ({
   generateActivityCustom: vi.fn().mockResolvedValue({
@@ -114,10 +102,6 @@ describe(customActivityWorkflow, () => {
       organizationId,
       title: `Custom Chapter ${randomUUID()}`,
     });
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
   });
 
   test("creates steps with visuals and images for custom activity", async () => {

--- a/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { generateActivityExplanation } from "@zoonk/ai/tasks/activities/core/explanation";
 import { generateStepVisualDescriptions } from "@zoonk/ai/tasks/steps/visual-descriptions";
 import { prisma } from "@zoonk/db";
@@ -9,12 +10,10 @@ import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { getString } from "@zoonk/utils/json";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import { dispatchVisualContent } from "../steps/_utils/dispatch-visual-content";
 import { getLessonActivitiesStep } from "../steps/get-lesson-activities-step";
 import { explanationActivityWorkflow } from "./explanation-workflow";
-
-const mockStreamWrite = vi.hoisted(() => vi.fn().mockResolvedValue(null));
 
 function createDescriptionsResult(
   steps: { title: string; text: string }[],
@@ -48,22 +47,8 @@ function createDispatchResult(
 }
 
 function getStreamedMessages(): Record<string, string>[] {
-  return mockStreamWrite.mock.calls.map(
-    (call: string[]) => JSON.parse(call[0]!.replace("data: ", "").trim()) as Record<string, string>,
-  );
+  return getStreamedEvents() as Record<string, string>[];
 }
-
-vi.mock("workflow", () => ({
-  FatalError: class FatalError extends Error {},
-  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
-  getWritable: vi.fn().mockReturnValue({
-    getWriter: () => ({
-      releaseLock: vi.fn(),
-      write: mockStreamWrite,
-    }),
-  }),
-  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
-}));
 
 vi.mock("@zoonk/ai/tasks/activities/core/explanation", () => ({
   generateActivityExplanation: vi.fn().mockResolvedValue({
@@ -112,10 +97,6 @@ describe("explanation activity workflow", () => {
       organizationId,
       title: `Exp WF Chapter ${randomUUID()}`,
     });
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
   });
 
   test("creates explanation steps in database for each concept", async () => {

--- a/apps/api/src/workflows/activity-generation/kinds/grammar-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/grammar-workflow.test.ts
@@ -7,21 +7,9 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import { type LessonActivity } from "../steps/get-lesson-activities-step";
 import { grammarActivityWorkflow } from "./grammar-workflow";
-
-vi.mock("workflow", () => ({
-  FatalError: class FatalError extends Error {},
-  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
-  getWritable: vi.fn().mockReturnValue({
-    getWriter: () => ({
-      releaseLock: vi.fn(),
-      write: vi.fn().mockResolvedValue(null),
-    }),
-  }),
-  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
-}));
 
 vi.mock("@zoonk/ai/tasks/activities/language/grammar-content", () => ({
   generateActivityGrammarContent: vi.fn().mockResolvedValue({
@@ -105,10 +93,6 @@ describe(grammarActivityWorkflow, () => {
       organizationId,
       title: `Grammar Chapter ${randomUUID()}`,
     });
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
   });
 
   test("creates grammar steps in correct order (examples, discovery, rule, exercises)", async () => {

--- a/apps/api/src/workflows/activity-generation/kinds/investigation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/investigation-workflow.test.ts
@@ -10,22 +10,10 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { getString } from "@zoonk/utils/json";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import { getArray } from "../../_test-utils/json-helpers";
 import { getLessonActivitiesStep } from "../steps/get-lesson-activities-step";
 import { investigationActivityWorkflow } from "./investigation-workflow";
-
-vi.mock("workflow", () => ({
-  FatalError: class FatalError extends Error {},
-  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
-  getWritable: vi.fn().mockReturnValue({
-    getWriter: () => ({
-      releaseLock: vi.fn(),
-      write: vi.fn().mockResolvedValue(null),
-    }),
-  }),
-  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
-}));
 
 const { mockScenario, mockAccuracy, mockActions, mockFindings } = vi.hoisted(() => ({
   mockAccuracy: {
@@ -89,10 +77,6 @@ describe("investigation activity workflow", () => {
       organizationId,
       title: `Inv WF Chapter ${randomUUID()}`,
     });
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
   });
 
   test("creates investigation steps with correct structure", async () => {

--- a/apps/api/src/workflows/activity-generation/kinds/listening-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/listening-workflow.test.ts
@@ -8,21 +8,9 @@ import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { sentenceFixture } from "@zoonk/testing/fixtures/sentences";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test } from "vitest";
 import { type LessonActivity } from "../steps/get-lesson-activities-step";
 import { listeningActivityWorkflow } from "./listening-workflow";
-
-vi.mock("workflow", () => ({
-  FatalError: class FatalError extends Error {},
-  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
-  getWritable: vi.fn().mockReturnValue({
-    getWriter: () => ({
-      releaseLock: vi.fn(),
-      write: vi.fn().mockResolvedValue(null),
-    }),
-  }),
-  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
-}));
 
 async function fetchLessonActivities(lessonId: number): Promise<LessonActivity[]> {
   const activities = await prisma.activity.findMany({
@@ -59,10 +47,6 @@ describe(listeningActivityWorkflow, () => {
       organizationId,
       title: `Listening Chapter ${randomUUID()}`,
     });
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
   });
 
   test("copies reading steps to listening activity", async () => {

--- a/apps/api/src/workflows/activity-generation/kinds/practice-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/practice-workflow.test.ts
@@ -7,22 +7,10 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import { type ExplanationResult } from "../steps/generate-explanation-content-step";
 import { getLessonActivitiesStep } from "../steps/get-lesson-activities-step";
 import { practiceActivityWorkflow } from "./practice-workflow";
-
-vi.mock("workflow", () => ({
-  FatalError: class FatalError extends Error {},
-  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
-  getWritable: vi.fn().mockReturnValue({
-    getWriter: () => ({
-      releaseLock: vi.fn(),
-      write: vi.fn().mockResolvedValue(null),
-    }),
-  }),
-  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
-}));
 
 vi.mock("@zoonk/ai/tasks/activities/core/practice", () => ({
   generateActivityPractice: vi.fn().mockResolvedValue({
@@ -70,10 +58,6 @@ describe("practice activity workflow", () => {
       organizationId,
       title: `Practice WF Chapter ${randomUUID()}`,
     });
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
   });
 
   test("creates practice steps with multipleChoice kind", async () => {

--- a/apps/api/src/workflows/activity-generation/kinds/quiz-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/quiz-workflow.test.ts
@@ -7,22 +7,10 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import { type ExplanationResult } from "../steps/generate-explanation-content-step";
 import { getLessonActivitiesStep } from "../steps/get-lesson-activities-step";
 import { quizActivityWorkflow } from "./quiz-workflow";
-
-vi.mock("workflow", () => ({
-  FatalError: class FatalError extends Error {},
-  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
-  getWritable: vi.fn().mockReturnValue({
-    getWriter: () => ({
-      releaseLock: vi.fn(),
-      write: vi.fn().mockResolvedValue(null),
-    }),
-  }),
-  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
-}));
 
 vi.mock("@zoonk/ai/tasks/activities/core/quiz", () => ({
   generateActivityQuiz: vi.fn().mockResolvedValue({
@@ -84,10 +72,6 @@ describe("quiz activity workflow", () => {
       organizationId,
       title: `Quiz WF Chapter ${randomUUID()}`,
     });
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
   });
 
   test("creates quiz steps from explanation results", async () => {

--- a/apps/api/src/workflows/activity-generation/kinds/story-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/story-workflow.test.ts
@@ -8,21 +8,9 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { getString } from "@zoonk/utils/json";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import { getLessonActivitiesStep } from "../steps/get-lesson-activities-step";
 import { storyActivityWorkflow } from "./story-workflow";
-
-vi.mock("workflow", () => ({
-  FatalError: class FatalError extends Error {},
-  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
-  getWritable: vi.fn().mockReturnValue({
-    getWriter: () => ({
-      releaseLock: vi.fn(),
-      write: vi.fn().mockResolvedValue(null),
-    }),
-  }),
-  workflowStep: vi.fn().mockImplementation((_name: string, fn: unknown) => fn),
-}));
 
 const { mockStorySteps, mockDebriefData } = vi.hoisted(() => ({
   mockDebriefData: {
@@ -113,10 +101,6 @@ describe("story activity workflow", () => {
       organizationId,
       title: `Story WF Chapter ${randomUUID()}`,
     });
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
   });
 
   test("creates story steps with intro, decisions, and debrief", async () => {

--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { activityGenerationWorkflow } from "@/workflows/activity-generation/activity-generation-workflow";
 import { generateChapterLessons } from "@zoonk/ai/tasks/chapters/lessons";
 import { CHAPTER_COMPLETION_STEP } from "@zoonk/core/workflows/steps";
@@ -7,21 +8,8 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import { chapterGenerationWorkflow } from "./chapter-generation-workflow";
-
-const writeMock = vi.fn().mockResolvedValue(null);
-
-vi.mock("workflow", () => ({
-  FatalError: class FatalError extends Error {},
-  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
-  getWritable: vi.fn().mockReturnValue({
-    getWriter: () => ({
-      releaseLock: vi.fn(),
-      write: writeMock,
-    }),
-  }),
-}));
 
 vi.mock("@zoonk/ai/tasks/chapters/lessons", () => ({
   generateChapterLessons: vi.fn().mockResolvedValue({
@@ -71,10 +59,6 @@ describe(chapterGenerationWorkflow, () => {
     course = await courseFixture({ organizationId });
   });
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   describe("early returns", () => {
     test("returns early when generationStatus is 'running' without streaming completion", async () => {
       const chapter = await chapterFixture({
@@ -93,12 +77,10 @@ describe(chapterGenerationWorkflow, () => {
       expect(dbChapter?.generationStatus).toBe("running");
       expect(generateChapterLessons).not.toHaveBeenCalled();
 
-      const completionCall = writeMock.mock.calls.find(
-        (call: string[]) =>
-          call[0]?.includes(`"step":"${CHAPTER_COMPLETION_STEP}"`) &&
-          call[0]?.includes('"status":"completed"'),
+      const completionEvent = getStreamedEvents().find(
+        (event) => event.step === CHAPTER_COMPLETION_STEP && event.status === "completed",
       );
-      expect(completionCall).toBeUndefined();
+      expect(completionEvent).toBeUndefined();
     });
 
     test("streams completion when generationStatus is 'completed'", async () => {
@@ -118,12 +100,10 @@ describe(chapterGenerationWorkflow, () => {
       expect(dbChapter?.generationStatus).toBe("completed");
       expect(generateChapterLessons).not.toHaveBeenCalled();
 
-      const completionCall = writeMock.mock.calls.find(
-        (call: string[]) =>
-          call[0]?.includes(`"step":"${CHAPTER_COMPLETION_STEP}"`) &&
-          call[0]?.includes('"status":"completed"'),
+      const completionEvent = getStreamedEvents().find(
+        (event) => event.step === CHAPTER_COMPLETION_STEP && event.status === "completed",
       );
-      expect(completionCall).toBeDefined();
+      expect(completionEvent).toBeDefined();
     });
 
     test("sets as completed and returns when chapter has existing lessons", async () => {
@@ -263,11 +243,10 @@ describe(chapterGenerationWorkflow, () => {
       expect(dbChapter?.generationStatus).toBe("failed");
       expect(dbChapter?.generationRunId).toBeNull();
 
-      const errorCall = writeMock.mock.calls.find(
-        (call: string[]) =>
-          call[0]?.includes('"status":"error"') && call[0]?.includes('"step":"workflowError"'),
+      const errorEvent = getStreamedEvents().find(
+        (event) => event.status === "error" && event.step === "workflowError",
       );
-      expect(errorCall).toBeDefined();
+      expect(errorEvent).toBeDefined();
     });
 
     test("throws FatalError when chapter not found", async () => {

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { generateChapterLessons } from "@zoonk/ai/tasks/chapters/lessons";
 import { generateAlternativeTitles } from "@zoonk/ai/tasks/courses/alternative-titles";
 import { generateCourseCategories } from "@zoonk/ai/tasks/courses/categories";
@@ -16,22 +17,9 @@ import {
 } from "@zoonk/testing/fixtures/courses";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { toSlug } from "@zoonk/utils/string";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import { getOrCreateCourse } from "./_internal/get-or-create-course";
 import { courseGenerationWorkflow } from "./course-generation-workflow";
-
-const writeMock = vi.fn().mockResolvedValue(null);
-
-vi.mock("workflow", () => ({
-  FatalError: class FatalError extends Error {},
-  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
-  getWritable: vi.fn().mockReturnValue({
-    getWriter: () => ({
-      releaseLock: vi.fn(),
-      write: writeMock,
-    }),
-  }),
-}));
 
 vi.mock("@zoonk/ai/tasks/courses/description", () => ({
   generateCourseDescription: vi.fn().mockResolvedValue({
@@ -133,10 +121,6 @@ describe(courseGenerationWorkflow, () => {
     organizationId = org.id;
   });
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   describe("early returns", () => {
     test("returns when suggestion not found", async () => {
       const nonExistentId = 999_999_999;
@@ -163,12 +147,10 @@ describe(courseGenerationWorkflow, () => {
       expect(dbSuggestion?.generationStatus).toBe("running");
       expect(generateCourseDescription).not.toHaveBeenCalled();
 
-      const completionCall = writeMock.mock.calls.find(
-        (call: string[]) =>
-          call[0]?.includes(`"step":"${COURSE_COMPLETION_STEP}"`) &&
-          call[0]?.includes('"status":"completed"'),
+      const completionEvent = getStreamedEvents().find(
+        (event) => event.step === COURSE_COMPLETION_STEP && event.status === "completed",
       );
-      expect(completionCall).toBeUndefined();
+      expect(completionEvent).toBeUndefined();
     });
 
     test("streams completion when suggestion status is 'completed'", async () => {
@@ -186,12 +168,10 @@ describe(courseGenerationWorkflow, () => {
       expect(dbSuggestion?.generationStatus).toBe("completed");
       expect(generateCourseDescription).not.toHaveBeenCalled();
 
-      const completionCall = writeMock.mock.calls.find(
-        (call: string[]) =>
-          call[0]?.includes(`"step":"${COURSE_COMPLETION_STEP}"`) &&
-          call[0]?.includes('"status":"completed"'),
+      const completionEvent = getStreamedEvents().find(
+        (event) => event.step === COURSE_COMPLETION_STEP && event.status === "completed",
       );
-      expect(completionCall).toBeDefined();
+      expect(completionEvent).toBeDefined();
     });
 
     test("returns when existing course status is 'running' without streaming completion", async () => {
@@ -220,12 +200,10 @@ describe(courseGenerationWorkflow, () => {
       expect(dbSuggestion?.generationStatus).toBe("pending");
       expect(generateCourseDescription).not.toHaveBeenCalled();
 
-      const completionCall = writeMock.mock.calls.find(
-        (call: string[]) =>
-          call[0]?.includes(`"step":"${COURSE_COMPLETION_STEP}"`) &&
-          call[0]?.includes('"status":"completed"'),
+      const completionEvent = getStreamedEvents().find(
+        (event) => event.step === COURSE_COMPLETION_STEP && event.status === "completed",
       );
-      expect(completionCall).toBeUndefined();
+      expect(completionEvent).toBeUndefined();
     });
 
     test("streams completion when existing course status is 'completed'", async () => {
@@ -254,12 +232,10 @@ describe(courseGenerationWorkflow, () => {
       expect(dbSuggestion?.generationStatus).toBe("pending");
       expect(generateCourseDescription).not.toHaveBeenCalled();
 
-      const completionCall = writeMock.mock.calls.find(
-        (call: string[]) =>
-          call[0]?.includes(`"step":"${COURSE_COMPLETION_STEP}"`) &&
-          call[0]?.includes('"status":"completed"'),
+      const completionEvent = getStreamedEvents().find(
+        (event) => event.step === COURSE_COMPLETION_STEP && event.status === "completed",
       );
-      expect(completionCall).toBeDefined();
+      expect(completionEvent).toBeDefined();
     });
   });
 
@@ -408,11 +384,10 @@ describe(courseGenerationWorkflow, () => {
       expect(dbSuggestion?.generationStatus).toBe("failed");
       expect(dbSuggestion?.generationRunId).toBeNull();
 
-      const errorCall = writeMock.mock.calls.find(
-        (call: string[]) =>
-          call[0]?.includes('"status":"error"') && call[0]?.includes('"step":"workflowError"'),
+      const errorEvent = getStreamedEvents().find(
+        (event) => event.status === "error" && event.step === "workflowError",
       );
-      expect(errorCall).toBeDefined();
+      expect(errorEvent).toBeDefined();
     });
 
     test("marks suggestion as 'failed' when getOrCreateCourse fails", async () => {
@@ -435,11 +410,10 @@ describe(courseGenerationWorkflow, () => {
 
       expect(dbSuggestion?.generationStatus).toBe("failed");
 
-      const errorCall = writeMock.mock.calls.find(
-        (call: string[]) =>
-          call[0]?.includes('"status":"error"') && call[0]?.includes('"step":"workflowError"'),
+      const errorEvent = getStreamedEvents().find(
+        (event) => event.status === "error" && event.step === "workflowError",
       );
-      expect(errorCall).toBeDefined();
+      expect(errorEvent).toBeDefined();
     });
 
     test("chapter generation errors don't mark course as failed", async () => {

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { generateLessonActivities } from "@zoonk/ai/tasks/lessons/activities";
 import { generateAppliedActivityKind } from "@zoonk/ai/tasks/lessons/applied-activity-kind";
 import { generateLessonKind } from "@zoonk/ai/tasks/lessons/kind";
@@ -8,21 +9,8 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import { lessonGenerationWorkflow } from "./lesson-generation-workflow";
-
-const writeMock = vi.fn().mockResolvedValue(null);
-
-vi.mock("workflow", () => ({
-  FatalError: class FatalError extends Error {},
-  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
-  getWritable: vi.fn().mockReturnValue({
-    getWriter: () => ({
-      releaseLock: vi.fn(),
-      write: writeMock,
-    }),
-  }),
-}));
 
 vi.mock("@zoonk/ai/tasks/lessons/kind", () => ({
   generateLessonKind: vi.fn().mockResolvedValue({
@@ -61,10 +49,6 @@ describe(lessonGenerationWorkflow, () => {
       organizationId,
       title: `Test Chapter ${randomUUID()}`,
     });
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
   });
 
   describe("early returns", () => {
@@ -109,12 +93,10 @@ describe(lessonGenerationWorkflow, () => {
       expect(dbLesson?.generationStatus).toBe("completed");
       expect(generateLessonKind).not.toHaveBeenCalled();
 
-      const completionCall = writeMock.mock.calls.find(
-        (call: string[]) =>
-          call[0]?.includes('"step":"setLessonAsCompleted"') &&
-          call[0]?.includes('"status":"completed"'),
+      const completionEvent = getStreamedEvents().find(
+        (event) => event.step === "setLessonAsCompleted" && event.status === "completed",
       );
-      expect(completionCall).toBeDefined();
+      expect(completionEvent).toBeDefined();
     });
 
     test("sets as completed and returns when lesson has existing activities but status not completed", async () => {
@@ -207,11 +189,10 @@ describe(lessonGenerationWorkflow, () => {
       expect(dbLesson?.generationStatus).toBe("failed");
       expect(dbLesson?.generationRunId).toBe("test-run-id");
 
-      const errorCall = writeMock.mock.calls.find(
-        (call: string[]) =>
-          call[0]?.includes('"status":"error"') && call[0]?.includes('"step":"workflowError"'),
+      const errorEvent = getStreamedEvents().find(
+        (event) => event.status === "error" && event.step === "workflowError",
       );
-      expect(errorCall).toBeDefined();
+      expect(errorEvent).toBeDefined();
     });
 
     test("marks lesson as 'failed' when custom activities generation throws", async () => {

--- a/apps/api/src/workflows/lesson-regeneration/lesson-regeneration-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-regeneration/lesson-regeneration-workflow.test.ts
@@ -11,19 +11,6 @@ import { userFixture } from "@zoonk/testing/fixtures/users";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { lessonRegenerationWorkflow } from "./lesson-regeneration-workflow";
 
-const writeMock = vi.fn().mockResolvedValue(null);
-
-vi.mock("workflow", () => ({
-  FatalError: class FatalError extends Error {},
-  getWorkflowMetadata: vi.fn().mockReturnValue({ workflowRunId: "test-run-id" }),
-  getWritable: vi.fn().mockReturnValue({
-    getWriter: () => ({
-      releaseLock: vi.fn(),
-      write: writeMock,
-    }),
-  }),
-}));
-
 const { activityGenerationWorkflowMock } = vi.hoisted(() => ({
   activityGenerationWorkflowMock: vi.fn(),
 }));

--- a/apps/api/vitest.config.mts
+++ b/apps/api/vitest.config.mts
@@ -11,6 +11,11 @@ export default defineConfig({
         replacement: resolve(import.meta.dirname, "../../packages/auth/src/testing.ts"),
       },
       {
+        // Provide one shared workflow mock so workflow integration tests can reuse the same plumbing.
+        find: /^workflow$/,
+        replacement: resolve(import.meta.dirname, "./mocks/workflow.ts"),
+      },
+      {
         // Mock server-only module
         find: /^server-only$/,
         replacement: resolve(import.meta.dirname, "./mocks/server-only.ts"),


### PR DESCRIPTION
## Summary
- add a shared workflow mock to the api vitest harness
- default workflow stream event helpers to the shared writer
- remove duplicated workflow mock setup from api workflow tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized workflow test mocks to remove duplication and make stream event assertions consistent across API tests.

- **Refactors**
  - Added shared workflow mock and writer helpers in `apps/api/mocks/workflow.ts` and `_test-utils/`.
  - Mapped `workflow` to the shared mock in `apps/api/vitest.config.mts`.
  - Auto-reset mock state in `apps/api/setup-tests.ts` before each test.
  - Updated `getStreamedEvents` to default to the shared writer; removed per-test `workflow` mocks and switched assertions to `getStreamedEvents()`.

<sup>Written for commit 57b2c97888019e4af7cfc1cc9a10d22fb3bdbbf5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

