### PR TITLE
feat(admin): reduce ai stats reporting cost

### DIFF
--- a/apps/admin/src/app/(private)/stats/ai/[task]/ai-task-report-sections.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/[task]/ai-task-report-sections.tsx
@@ -1,0 +1,198 @@
+import { type AiTaskOverview } from "@/data/stats/ai/get-ai-task-overview";
+import { type getAiTaskReport } from "@/data/stats/ai/get-ai-task-report";
+import { buttonVariants } from "@zoonk/ui/components/button";
+import Link from "next/link";
+import { AdminMetricCard } from "../../_components/admin-metric-card";
+import { formatAiCost, formatAiStatsDate } from "../format-ai-cost";
+import { AiTaskModelTable } from "./ai-task-model-table";
+
+type AiTaskDetailReport = Awaited<ReturnType<typeof getAiTaskReport>>;
+
+type AiTaskRange = {
+  endInput: string;
+  startInput: string;
+};
+
+/**
+ * The overview stays visible whether or not the admin opens the detailed model
+ * report, so this section owns the shared summary cards and helper copy.
+ */
+export function AiTaskSummarySection({
+  breakdownHref,
+  range,
+  report,
+  runCount,
+  showBreakdown,
+  summary,
+}: {
+  breakdownHref: string;
+  range: AiTaskRange;
+  report: AiTaskDetailReport | null;
+  runCount: number;
+  showBreakdown: boolean;
+  summary: AiTaskOverview;
+}) {
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-muted-foreground text-sm">
+        Overview from {formatAiStatsDate(range.startInput)} to {formatAiStatsDate(range.endInput)}.
+      </p>
+
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 xl:grid-cols-4">
+        <AdminMetricCard
+          description="Gateway-tagged runs for this task in the selected range."
+          title="Requests"
+          value={summary.totalRequests.toLocaleString()}
+        />
+        <AdminMetricCard
+          description="Historical market spend captured for the task tag."
+          title="Total Market Cost"
+          value={formatAiCost(summary.totalMarketCost)}
+        />
+        <AdminMetricCard
+          description="The average used for quick planning and comparison."
+          title="Avg Market Cost / Request"
+          value={formatAiCost(summary.averageMarketCostPerRequest)}
+        />
+        <AdminMetricCard
+          description="Projected from the current average market cost."
+          title={`Est. ${runCount.toLocaleString()} Runs`}
+          value={formatAiCost(summary.estimatedMarketCost)}
+        />
+      </div>
+
+      <AiTaskFallbackSummary summary={summary} />
+      <AiTaskStatusMessage
+        breakdownHref={breakdownHref}
+        report={report}
+        showBreakdown={showBreakdown}
+        totalRequests={summary.totalRequests}
+      />
+    </div>
+  );
+}
+
+/**
+ * Default-model tags are the only fallback metadata we have on the cheap
+ * overview path, so this helper keeps that explanation separate from the cards.
+ */
+function AiTaskFallbackSummary({ summary }: { summary: AiTaskOverview }) {
+  if (!summary.hasFallbackTracking) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        No default-model tags were reported for this time range yet, so fallback requests cannot be
+        identified for this period.
+      </p>
+    );
+  }
+
+  return (
+    <p className="text-muted-foreground text-sm">
+      Default model{summary.defaultModels.length === 1 ? "" : "s"}:{" "}
+      <span className="text-foreground font-medium">{summary.defaultModels.join(", ")}</span>.
+    </p>
+  );
+}
+
+/**
+ * The small paragraph under the cards changes based on whether the task had
+ * traffic and whether the admin already opened the model breakdown.
+ */
+function AiTaskStatusMessage({
+  breakdownHref,
+  report,
+  showBreakdown,
+  totalRequests,
+}: {
+  breakdownHref: string;
+  report: AiTaskDetailReport | null;
+  showBreakdown: boolean;
+  totalRequests: number;
+}) {
+  if (totalRequests <= 0) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        No gateway requests were reported for this task in the selected range.
+      </p>
+    );
+  }
+
+  if (showBreakdown && report) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        {report.models.length.toLocaleString()} model{report.models.length === 1 ? "" : "s"} in the
+        breakdown. Fallback requests in this range:{" "}
+        <span className="text-foreground font-medium tabular-nums">
+          {report.fallbackRequestCount.toLocaleString()}
+        </span>
+        .
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <p className="text-muted-foreground text-sm">
+        Load the model breakdown only when you need fallback counts or per-model pricing.
+      </p>
+
+      <Link className={buttonVariants({ variant: "outline" })} href={breakdownHref}>
+        Load Model Breakdown
+      </Link>
+    </div>
+  );
+}
+
+/**
+ * The detailed model table is useful, but it should stay visually separate from
+ * the cheaper overview so admins can tell when they have opted into the heavier
+ * report path.
+ */
+export function AiTaskBreakdownSection({
+  overviewHref,
+  report,
+  showBreakdown,
+}: {
+  overviewHref: string;
+  report: AiTaskDetailReport | null;
+  showBreakdown: boolean;
+}) {
+  if (!showBreakdown || !report) {
+    return (
+      <section className="flex flex-col gap-1">
+        <h2 className="text-base font-semibold tracking-tight">Model Breakdown</h2>
+        <p className="text-muted-foreground text-sm">
+          Keep this closed until you need the detailed per-model report. The overview above is the
+          cheaper default.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-base font-semibold tracking-tight">Model Breakdown</h2>
+          <p className="text-muted-foreground text-sm">
+            Per-model request counts and pricing for the selected range.
+          </p>
+        </div>
+
+        <Link className={buttonVariants({ variant: "ghost" })} href={overviewHref}>
+          Hide Breakdown
+        </Link>
+      </div>
+
+      {report.models.length > 0 ? (
+        <div className="rounded-lg border">
+          <AiTaskModelTable models={report.models} />
+        </div>
+      ) : (
+        <p className="text-muted-foreground text-sm">
+          No gateway requests were reported for this task in the selected range.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/ai/[task]/ai-task-report.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/[task]/ai-task-report.tsx
@@ -1,3 +1,4 @@
+import { buildAiTaskReportHref } from "@/data/stats/ai/ai-task-hrefs";
 import {
   getAiTaskHref,
   getSingleSearchParamValue,
@@ -5,12 +6,34 @@ import {
   resolveAiTaskDateRange,
   resolveEstimateRunCount,
 } from "@/data/stats/ai/ai-task-stats";
+import { type AiTaskOverview, getAiTaskOverview } from "@/data/stats/ai/get-ai-task-overview";
 import { getAiTaskReport } from "@/data/stats/ai/get-ai-task-report";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { notFound } from "next/navigation";
 import { AiStatsFilters } from "../ai-stats-filters";
-import { formatAiCost, formatAiStatsDate } from "../format-ai-cost";
-import { AiTaskModelTable } from "./ai-task-model-table";
+import { AiTaskBreakdownSection, AiTaskSummarySection } from "./ai-task-report-sections";
+
+type AiTaskDetailSearchParams = Promise<{
+  from?: string | string[];
+  runs?: string | string[];
+  to?: string | string[];
+  view?: string | string[];
+}>;
+
+type AiTaskDetailReport = Awaited<ReturnType<typeof getAiTaskReport>>;
+
+type AiTaskReportState = {
+  breakdownHref: string;
+  overviewHref: string;
+  range: {
+    endInput: string;
+    startInput: string;
+  };
+  report: AiTaskDetailReport | null;
+  runCount: number;
+  showBreakdown: boolean;
+  summary: AiTaskOverview;
+};
 
 /**
  * The task detail view resolves the URL filters, loads the grouped gateway
@@ -21,29 +44,15 @@ export async function AiTaskReport({
   searchParams,
   taskName,
 }: {
-  searchParams: Promise<{
-    from?: string | string[];
-    runs?: string | string[];
-    to?: string | string[];
-  }>;
+  searchParams: AiTaskDetailSearchParams;
   taskName: string;
 }) {
   if (!isAiTaskName(taskName)) {
     notFound();
   }
 
-  const resolvedSearchParams = await searchParams;
-  const range = resolveAiTaskDateRange({
-    from: getSingleSearchParamValue(resolvedSearchParams.from),
-    to: getSingleSearchParamValue(resolvedSearchParams.to),
-  });
-  const runCount = resolveEstimateRunCount(getSingleSearchParamValue(resolvedSearchParams.runs));
-  const report = await getAiTaskReport({
-    endDate: range.endInput,
-    runCount,
-    startDate: range.startInput,
-    taskName,
-  });
+  const { breakdownHref, overviewHref, range, report, runCount, showBreakdown, summary } =
+    await getAiTaskReportState({ searchParams, taskName });
 
   return (
     <div className="flex flex-col gap-8">
@@ -54,54 +63,91 @@ export async function AiTaskReport({
         startDate={range.startInput}
       />
 
-      <div className="flex flex-col gap-2">
-        <p className="text-muted-foreground text-sm">
-          {report.totalRequests.toLocaleString()} requests from{" "}
-          {formatAiStatsDate(range.startInput)} to {formatAiStatsDate(range.endInput)} across{" "}
-          {report.models.length.toLocaleString()} models.
-        </p>
+      <AiTaskSummarySection
+        breakdownHref={breakdownHref}
+        range={range}
+        report={report}
+        runCount={runCount}
+        showBreakdown={showBreakdown}
+        summary={summary}
+      />
 
-        {report.hasFallbackTracking ? (
-          <p className="text-muted-foreground text-sm">
-            Default model{report.defaultModels.length === 1 ? "" : "s"}:{" "}
-            <span className="text-foreground font-medium">{report.defaultModels.join(", ")}</span>.{" "}
-            Fallback requests in this range:{" "}
-            <span className="text-foreground font-medium tabular-nums">
-              {report.fallbackRequestCount.toLocaleString()}
-            </span>
-            .
-          </p>
-        ) : (
-          <p className="text-muted-foreground text-sm">
-            No default-model tags were reported for this time range yet, so fallback rows cannot be
-            identified here.
-          </p>
-        )}
-
-        <p className="text-muted-foreground text-sm">
-          Based on the current average market cost of{" "}
-          <span className="text-foreground font-medium tabular-nums">
-            {formatAiCost(report.averageMarketCostPerRequest)}
-          </span>{" "}
-          per request, {runCount.toLocaleString()} runs would cost about{" "}
-          <span className="text-foreground font-medium tabular-nums">
-            {formatAiCost(report.estimatedMarketCost)}
-          </span>
-          .
-        </p>
-      </div>
-
-      {report.models.length > 0 ? (
-        <div className="rounded-lg border">
-          <AiTaskModelTable models={report.models} />
-        </div>
-      ) : (
-        <p className="text-muted-foreground text-sm">
-          No gateway requests were reported for this task in the selected range.
-        </p>
-      )}
+      <AiTaskBreakdownSection
+        overviewHref={overviewHref}
+        report={report}
+        showBreakdown={showBreakdown}
+      />
     </div>
   );
+}
+
+/**
+ * The detail page has a few moving parts in the query string. Resolving them in
+ * one place keeps the main component short and makes the on-demand breakdown
+ * flow explicit.
+ */
+async function getAiTaskReportState({
+  searchParams,
+  taskName,
+}: {
+  searchParams: AiTaskDetailSearchParams;
+  taskName: string;
+}): Promise<AiTaskReportState> {
+  const resolvedSearchParams = await searchParams;
+  const range = resolveAiTaskDateRange({
+    from: getSingleSearchParamValue(resolvedSearchParams.from),
+    to: getSingleSearchParamValue(resolvedSearchParams.to),
+  });
+  const runCount = resolveEstimateRunCount(getSingleSearchParamValue(resolvedSearchParams.runs));
+  const showBreakdown = shouldShowAiTaskBreakdown(
+    getSingleSearchParamValue(resolvedSearchParams.view),
+  );
+  const overviewHref = buildAiTaskReportHref({
+    endDate: range.endInput,
+    runCount,
+    startDate: range.startInput,
+    taskName,
+  });
+  const breakdownHref = buildAiTaskReportHref({
+    endDate: range.endInput,
+    runCount,
+    startDate: range.startInput,
+    taskName,
+    view: "breakdown",
+  });
+  const report = showBreakdown
+    ? await getAiTaskReport({
+        endDate: range.endInput,
+        runCount,
+        startDate: range.startInput,
+        taskName,
+      })
+    : null;
+
+  return {
+    breakdownHref,
+    overviewHref,
+    range,
+    report,
+    runCount,
+    showBreakdown,
+    summary:
+      report ??
+      (await getAiTaskOverview({
+        endDate: range.endInput,
+        runCount,
+        startDate: range.startInput,
+        taskName,
+      })),
+  };
+}
+
+/**
+ * The task detail page now distinguishes the cheap overview from the more
+ * expensive model drill-down with an explicit `view` flag in the URL.
+ */
+function shouldShowAiTaskBreakdown(view?: string) {
+  return view === "breakdown";
 }
 
 /**
@@ -119,7 +165,13 @@ export function AiTaskReportSkeleton() {
       </div>
       <div className="flex flex-col gap-2">
         <Skeleton className="h-4 w-80" />
-        <Skeleton className="h-4 w-lg" />
+        <Skeleton className="h-4 w-96" />
+      </div>
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 xl:grid-cols-4">
+        <Skeleton className="h-28 w-full rounded-lg" />
+        <Skeleton className="h-28 w-full rounded-lg" />
+        <Skeleton className="h-28 w-full rounded-lg" />
+        <Skeleton className="h-28 w-full rounded-lg" />
       </div>
       <Skeleton className="h-72 w-full rounded-lg" />
     </div>

--- a/apps/admin/src/app/(private)/stats/ai/ai-estimate-filters.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/ai-estimate-filters.tsx
@@ -1,8 +1,8 @@
 import { type AiCourseEstimateInputs } from "@/data/stats/ai/get-ai-cost-estimates";
 import { Button, buttonVariants } from "@zoonk/ui/components/button";
 import { Input } from "@zoonk/ui/components/input";
-import { Label } from "@zoonk/ui/components/label";
 import Link from "next/link";
+import { AiFilterField } from "./ai-filter-field";
 
 /**
  * Course estimates need both the reporting window and the planned course shape.
@@ -34,13 +34,13 @@ export function AiEstimateFilters({
 
       <form action={actionHref} className="flex flex-col gap-6">
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          <FilterField htmlFor="from" label="From">
+          <AiFilterField htmlFor="from" label="From">
             <Input defaultValue={startDate} id="from" name="from" type="date" />
-          </FilterField>
+          </AiFilterField>
 
-          <FilterField htmlFor="to" label="To">
+          <AiFilterField htmlFor="to" label="To">
             <Input defaultValue={endDate} id="to" name="to" type="date" />
-          </FilterField>
+          </AiFilterField>
         </div>
 
         <div className="grid gap-6 lg:grid-cols-2">
@@ -65,28 +65,6 @@ export function AiEstimateFilters({
         </div>
       </form>
     </section>
-  );
-}
-
-/**
- * The estimate form repeats the same label-plus-input structure across both
- * course types. This wrapper keeps the layout readable and ensures each field
- * stays properly labeled for semantic queries and keyboard users.
- */
-function FilterField({
-  children,
-  htmlFor,
-  label,
-}: {
-  children: React.ReactNode;
-  htmlFor: string;
-  label: string;
-}) {
-  return (
-    <div className="flex min-w-32 flex-col gap-1.5">
-      <Label htmlFor={htmlFor}>{label}</Label>
-      {children}
-    </div>
   );
 }
 
@@ -208,8 +186,8 @@ function EstimateNumberField({
   value: number;
 }) {
   return (
-    <FilterField htmlFor={htmlFor} label={label}>
+    <AiFilterField htmlFor={htmlFor} label={label}>
       <Input defaultValue={String(value)} id={htmlFor} min={min} name={name} type="number" />
-    </FilterField>
+    </AiFilterField>
   );
 }

--- a/apps/admin/src/app/(private)/stats/ai/ai-fallback-task-list.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/ai-fallback-task-list.tsx
@@ -1,0 +1,190 @@
+import { buildAiTaskReportHref } from "@/data/stats/ai/ai-task-hrefs";
+import {
+  type AiFallbackTaskSummary,
+  getAiFallbackTaskSummaries,
+} from "@/data/stats/ai/get-ai-fallback-task-summaries";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@zoonk/ui/components/table";
+import Link from "next/link";
+import { AdminMetricCard } from "../_components/admin-metric-card";
+import { formatAiStatsDate } from "./format-ai-cost";
+
+/**
+ * The fallback report answers one focused question: which tasks actually missed
+ * their configured default model in the selected period. It stays on-demand so
+ * the admin only pays for this cross-task report when it is useful.
+ */
+export async function AiFallbackTaskList({
+  endDate,
+  startDate,
+}: {
+  endDate: string;
+  startDate: string;
+}) {
+  const report = await getAiFallbackTaskSummaries({ endDate, startDate });
+
+  return (
+    <section className="flex flex-col gap-6">
+      <div className="flex max-w-3xl flex-col gap-1">
+        <h2 className="text-base font-semibold tracking-tight">Fallback Tasks</h2>
+        <p className="text-muted-foreground text-sm">
+          Exact fallback counts from {formatAiStatsDate(startDate)} to {formatAiStatsDate(endDate)}.
+          This summary reuses the task totals and then checks one grouped report per active default
+          model, which is much cheaper than loading every task breakdown.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 xl:grid-cols-3">
+        <AdminMetricCard
+          description={
+            report.activeTaskCount > 0
+              ? `${report.tasks.length.toLocaleString()} of ${report.activeTaskCount.toLocaleString()} active fallback-capable tasks.`
+              : "No active fallback-capable tasks in this period."
+          }
+          title="Tasks With Fallbacks"
+          value={report.tasks.length.toLocaleString()}
+        />
+        <AdminMetricCard
+          description="Requests that were served by a model other than the configured default."
+          title="Fallback Requests"
+          value={report.fallbackRequestCount.toLocaleString()}
+        />
+        <AdminMetricCard
+          description="Share of traffic across active fallback-capable tasks."
+          title="Fallback Rate"
+          value={formatAiFallbackRate(report.fallbackRate)}
+        />
+      </div>
+
+      {report.tasks.length > 0 ? (
+        <div className="rounded-lg border">
+          <AiFallbackTaskTable endDate={endDate} startDate={startDate} tasks={report.tasks} />
+        </div>
+      ) : (
+        <p className="text-muted-foreground text-sm">
+          No tasks used fallback models in the selected range.
+        </p>
+      )}
+    </section>
+  );
+}
+
+/**
+ * The fallback summary is still backed by live Gateway data, so the placeholder
+ * mirrors the cards and table footprint while the report resolves.
+ */
+export function AiFallbackTaskListSkeleton() {
+  return (
+    <section className="flex flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <Skeleton className="h-5 w-32" />
+        <Skeleton className="h-4 w-[36rem]" />
+      </div>
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 xl:grid-cols-3">
+        <Skeleton className="h-28 w-full rounded-lg" />
+        <Skeleton className="h-28 w-full rounded-lg" />
+        <Skeleton className="h-28 w-full rounded-lg" />
+      </div>
+      <Skeleton className="h-72 w-full rounded-lg" />
+    </section>
+  );
+}
+
+/**
+ * A plain table is still the clearest way to compare fallback-heavy tasks,
+ * especially when the only action users need is drilling into the exact task
+ * breakdown for the same date range.
+ */
+function AiFallbackTaskTable({
+  endDate,
+  startDate,
+  tasks,
+}: {
+  endDate: string;
+  startDate: string;
+  tasks: AiFallbackTaskSummary[];
+}) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Task</TableHead>
+          <TableHead>Configured Default</TableHead>
+          <TableHead className="text-right">Fallback Requests</TableHead>
+          <TableHead className="text-right">Fallback Rate</TableHead>
+          <TableHead className="text-right">Total Requests</TableHead>
+        </TableRow>
+      </TableHeader>
+
+      <TableBody>
+        {tasks.map((task) => (
+          <AiFallbackTaskRow
+            endDate={endDate}
+            key={task.taskName}
+            startDate={startDate}
+            task={task}
+          />
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+/**
+ * Every row links straight to the exact task breakdown view so the admin can go
+ * from cross-task triage to the full model table in one click.
+ */
+function AiFallbackTaskRow({
+  endDate,
+  startDate,
+  task,
+}: {
+  endDate: string;
+  startDate: string;
+  task: AiFallbackTaskSummary;
+}) {
+  const href = buildAiTaskReportHref({
+    endDate,
+    startDate,
+    taskName: task.taskName,
+    view: "breakdown",
+  });
+
+  return (
+    <TableRow>
+      <TableCell className="font-medium">
+        <Link className="hover:underline" href={href}>
+          {task.taskLabel}
+        </Link>
+      </TableCell>
+      <TableCell className="font-mono text-xs sm:text-sm">{task.defaultModel}</TableCell>
+      <TableCell className="text-right tabular-nums">
+        {task.fallbackRequestCount.toLocaleString()}
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {formatAiFallbackRate(task.fallbackRate)}
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {task.requestCount.toLocaleString()}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+/**
+ * Rates are easiest to scan as percentages with one decimal place because many
+ * fallback issues sit in the low single-digit range.
+ */
+function formatAiFallbackRate(value: number) {
+  return new Intl.NumberFormat("en", {
+    maximumFractionDigits: 1,
+    style: "percent",
+  }).format(value);
+}

--- a/apps/admin/src/app/(private)/stats/ai/ai-filter-field.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/ai-filter-field.tsx
@@ -1,0 +1,23 @@
+import { Label } from "@zoonk/ui/components/label";
+
+/**
+ * The AI stats pages repeat the same label-plus-input structure across several
+ * server-rendered forms. Keeping that wrapper in one file makes the filters
+ * consistent without pushing form layout details into every page component.
+ */
+export function AiFilterField({
+  children,
+  htmlFor,
+  label,
+}: {
+  children: React.ReactNode;
+  htmlFor: string;
+  label: string;
+}) {
+  return (
+    <div className="flex min-w-32 flex-col gap-1.5">
+      <Label htmlFor={htmlFor}>{label}</Label>
+      {children}
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/ai/ai-stats-filters.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/ai-stats-filters.tsx
@@ -1,7 +1,7 @@
 import { Button, buttonVariants } from "@zoonk/ui/components/button";
 import { Input } from "@zoonk/ui/components/input";
-import { Label } from "@zoonk/ui/components/label";
 import Link from "next/link";
+import { AiFilterField } from "./ai-filter-field";
 
 /**
  * The AI stats pages are fully server-rendered, so the filters use a plain GET
@@ -21,18 +21,18 @@ export function AiStatsFilters({
 }) {
   return (
     <form action={actionHref} className="flex flex-wrap items-end gap-3">
-      <FilterField htmlFor="from" label="From">
+      <AiFilterField htmlFor="from" label="From">
         <Input defaultValue={startDate} id="from" name="from" type="date" />
-      </FilterField>
+      </AiFilterField>
 
-      <FilterField htmlFor="to" label="To">
+      <AiFilterField htmlFor="to" label="To">
         <Input defaultValue={endDate} id="to" name="to" type="date" />
-      </FilterField>
+      </AiFilterField>
 
       {runCount === undefined ? null : (
-        <FilterField htmlFor="runs" label="Estimate Runs">
+        <AiFilterField htmlFor="runs" label="Estimate Runs">
           <Input defaultValue={String(runCount)} id="runs" min={1} name="runs" type="number" />
-        </FilterField>
+        </AiFilterField>
       )}
 
       <div className="flex items-center gap-2">
@@ -45,27 +45,5 @@ export function AiStatsFilters({
         </Link>
       </div>
     </form>
-  );
-}
-
-/**
- * The date range and optional run-count controls repeat the same label-plus-
- * input structure. This wrapper keeps the form readable and ensures each input
- * stays properly labeled for semantic queries and keyboard users.
- */
-function FilterField({
-  children,
-  htmlFor,
-  label,
-}: {
-  children: React.ReactNode;
-  htmlFor: string;
-  label: string;
-}) {
-  return (
-    <div className="flex min-w-32 flex-col gap-1.5">
-      <Label htmlFor={htmlFor}>{label}</Label>
-      {children}
-    </div>
   );
 }

--- a/apps/admin/src/app/(private)/stats/ai/ai-task-directory-controls.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/ai-task-directory-controls.tsx
@@ -1,0 +1,83 @@
+import { buildAiEstimateHref, buildAiTaskIndexHref } from "@/data/stats/ai/ai-task-hrefs";
+import { Button, buttonVariants } from "@zoonk/ui/components/button";
+import { Input } from "@zoonk/ui/components/input";
+import Link from "next/link";
+import { AiFilterField } from "./ai-filter-field";
+
+type AiTaskPageView = "fallbacks" | "summary";
+
+/**
+ * The task index should stay passive until the admin explicitly asks for a
+ * billed Custom Reporting snapshot. This header explains that behavior and
+ * keeps the date-range controls close to the two actions users actually need.
+ */
+export function AiTaskDirectoryControls({
+  activeView,
+  endDate,
+  startDate,
+}: {
+  activeView?: AiTaskPageView;
+  endDate: string;
+  startDate: string;
+}) {
+  const estimateHref = buildAiEstimateHref({ endDate, startDate });
+  const hideReportHref = buildAiTaskIndexHref({ endDate, startDate });
+  const resetHref = "/stats/ai";
+  const showHideReport = activeView !== undefined;
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex max-w-3xl flex-col gap-2">
+        <p className="text-sm font-medium tracking-tight">
+          Open a task when you need its report. We only run the expensive Vercel queries after you
+          explicitly ask for a summary.
+        </p>
+        <p className="text-muted-foreground text-sm">
+          The directory below stays lightweight, keeps the page easier to scan, and still preserves
+          your selected date range when you jump into a task or the estimates view.
+        </p>
+      </div>
+
+      <form action="/stats/ai" className="flex flex-wrap items-end gap-3">
+        <AiFilterField htmlFor="from" label="From">
+          <Input defaultValue={startDate} id="from" name="from" type="date" />
+        </AiFilterField>
+
+        <AiFilterField htmlFor="to" label="To">
+          <Input defaultValue={endDate} id="to" name="to" type="date" />
+        </AiFilterField>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            name="view"
+            type="submit"
+            value="summary"
+            variant={activeView === "summary" ? "secondary" : "outline"}
+          >
+            Load Live Summary
+          </Button>
+
+          <Button
+            name="view"
+            type="submit"
+            value="fallbacks"
+            variant={activeView === "fallbacks" ? "secondary" : "outline"}
+          >
+            Load Fallback Tasks
+          </Button>
+
+          <Link className={buttonVariants({ variant: "outline" })} href={estimateHref}>
+            Cost Estimates
+          </Link>
+
+          <Link
+            className={buttonVariants({ variant: "ghost" })}
+            href={showHideReport ? hideReportHref : resetHref}
+          >
+            {showHideReport ? "Hide Report" : "Reset"}
+          </Link>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/ai/ai-task-directory.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/ai-task-directory.tsx
@@ -1,0 +1,73 @@
+import { AI_TASK_CATALOG } from "@/data/stats/ai/ai-task-catalog";
+import { buildAiTaskReportHref } from "@/data/stats/ai/ai-task-hrefs";
+import { buttonVariants } from "@zoonk/ui/components/button";
+import { Separator } from "@zoonk/ui/components/separator";
+import Link from "next/link";
+import { Fragment } from "react";
+
+/**
+ * The task page is now a directory first. Grouping the known AI tasks by the
+ * part of the product they support gives admins a calmer starting point than a
+ * giant always-live table while still keeping one-click access to each report.
+ */
+export function AiTaskDirectory({ endDate, startDate }: { endDate: string; startDate: string }) {
+  return (
+    <section className="flex flex-col gap-5">
+      <header className="flex max-w-3xl flex-col gap-1">
+        <h2 className="text-base font-semibold tracking-tight">Task Directory</h2>
+        <p className="text-muted-foreground text-sm">
+          Each link opens the selected task with the date range above, so you can go straight to the
+          one report you need instead of loading everything up front.
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-6">
+        {AI_TASK_CATALOG.map((group, index) => (
+          <Fragment key={group.title}>
+            {index === 0 ? null : <Separator />}
+            <AiTaskDirectoryGroup endDate={endDate} group={group} startDate={startDate} />
+          </Fragment>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Each group combines a short explanation with direct links so admins can scan
+ * the catalog quickly without expanding nested menus or accordion state.
+ */
+function AiTaskDirectoryGroup({
+  endDate,
+  group,
+  startDate,
+}: {
+  endDate: string;
+  group: (typeof AI_TASK_CATALOG)[number];
+  startDate: string;
+}) {
+  return (
+    <section className="grid gap-4 lg:grid-cols-[16rem_1fr] lg:gap-6">
+      <div className="flex flex-col gap-1">
+        <h3 className="text-sm font-semibold tracking-tight">{group.title}</h3>
+        <p className="text-muted-foreground text-sm">{group.description}</p>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {group.tasks.map((task) => (
+          <Link
+            className={buttonVariants({ size: "sm", variant: "outline" })}
+            href={buildAiTaskReportHref({
+              endDate,
+              startDate,
+              taskName: task.taskName,
+            })}
+            key={task.taskName}
+          >
+            {task.taskLabel}
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/ai/ai-task-list.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/ai-task-list.tsx
@@ -1,7 +1,5 @@
 import { getAiTaskSummaries } from "@/data/stats/ai/get-ai-task-summaries";
-import { buttonVariants } from "@zoonk/ui/components/button";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
-import Link from "next/link";
 import { AiTaskTable } from "./ai-task-table";
 import { formatAiStatsDate } from "./format-ai-cost";
 
@@ -14,29 +12,34 @@ export async function AiTaskList({ endDate, startDate }: { endDate: string; star
   const tasks = await getAiTaskSummaries({ endDate, startDate });
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <p className="text-muted-foreground max-w-3xl text-sm">
-          Request counts and fallback usage for gateway-tagged AI tasks from{" "}
-          {formatAiStatsDate(startDate)} to {formatAiStatsDate(endDate)}.
+    <section className="flex flex-col gap-6">
+      <div className="flex max-w-3xl flex-col gap-1">
+        <h2 className="text-base font-semibold tracking-tight">Live Summary</h2>
+        <p className="text-muted-foreground text-sm">
+          One on-demand snapshot of gateway-tagged task traffic from {formatAiStatsDate(startDate)}{" "}
+          to {formatAiStatsDate(endDate)}. Open a task for model-level breakdowns only when you need
+          them.
         </p>
-
-        <Link
-          className={buttonVariants({ variant: "outline" })}
-          href={buildEstimateHref({ endDate, startDate })}
-        >
-          Cost Estimates
-        </Link>
       </div>
 
       {tasks.length > 0 ? (
-        <div className="rounded-lg border">
-          <AiTaskTable endDate={endDate} startDate={startDate} tasks={tasks} />
-        </div>
+        <>
+          <p className="text-muted-foreground text-sm">
+            {tasks.length.toLocaleString()} active task{tasks.length === 1 ? "" : "s"} reported in
+            this range.
+          </p>
+
+          <div className="rounded-lg border">
+            <AiTaskTable endDate={endDate} startDate={startDate} tasks={tasks} />
+          </div>
+        </>
       ) : (
-        <p className="text-muted-foreground text-sm">No AI task requests were reported yet.</p>
+        <p className="text-muted-foreground text-sm">
+          No AI task requests were reported from {formatAiStatsDate(startDate)} to{" "}
+          {formatAiStatsDate(endDate)}.
+        </p>
       )}
-    </div>
+    </section>
   );
 }
 
@@ -46,21 +49,13 @@ export async function AiTaskList({ endDate, startDate }: { endDate: string; star
  */
 export function AiTaskListSkeleton() {
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-wrap items-start justify-between gap-3">
+    <section className="flex flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <Skeleton className="h-5 w-32" />
         <Skeleton className="h-4 w-96" />
-        <Skeleton className="h-10 w-36 rounded-full" />
       </div>
+      <Skeleton className="h-4 w-40" />
       <Skeleton className="h-64 w-full rounded-lg" />
-    </div>
+    </section>
   );
-}
-
-/**
- * The estimates page reads its period from the query string. Building the href
- * in one place keeps the task page link aligned with that route contract.
- */
-function buildEstimateHref({ endDate, startDate }: { endDate: string; startDate: string }) {
-  const searchParams = new URLSearchParams({ from: startDate, to: endDate });
-  return `/stats/ai/estimates?${searchParams.toString()}`;
 }

--- a/apps/admin/src/app/(private)/stats/ai/ai-task-table.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/ai-task-table.tsx
@@ -1,6 +1,5 @@
-import { getAiTaskHref } from "@/data/stats/ai/ai-task-stats";
+import { buildAiTaskReportHref } from "@/data/stats/ai/ai-task-hrefs";
 import { type AiTaskSummary } from "@/data/stats/ai/get-ai-task-summaries";
-import { Badge } from "@zoonk/ui/components/badge";
 import {
   Table,
   TableBody,
@@ -10,6 +9,7 @@ import {
   TableRow,
 } from "@zoonk/ui/components/table";
 import Link from "next/link";
+import { formatAiCost } from "./format-ai-cost";
 
 /**
  * The index page only needs a compact, scan-friendly task list. A plain table is
@@ -31,7 +31,8 @@ export function AiTaskTable({
         <TableRow>
           <TableHead>Task</TableHead>
           <TableHead className="text-right">Requests</TableHead>
-          <TableHead className="text-right">Fallback Requests</TableHead>
+          <TableHead className="text-right">Total Market Cost</TableHead>
+          <TableHead className="text-right">Avg Market Cost / Request</TableHead>
         </TableRow>
       </TableHeader>
 
@@ -58,7 +59,7 @@ function AiTaskRow({
   startDate: string;
   task: AiTaskSummary;
 }) {
-  const href = buildTaskHref({ endDate, startDate, taskName: task.taskName });
+  const href = buildAiTaskReportHref({ endDate, startDate, taskName: task.taskName });
 
   return (
     <TableRow>
@@ -70,44 +71,12 @@ function AiTaskRow({
       <TableCell className="text-right tabular-nums">
         {task.requestCount.toLocaleString()}
       </TableCell>
-      <TableCell className="text-right">
-        <FallbackCount task={task} />
+      <TableCell className="text-right tabular-nums">
+        {formatAiCost(task.totalMarketCost)}
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {formatAiCost(task.averageMarketCostPerRequest)}
       </TableCell>
     </TableRow>
   );
-}
-
-/**
- * Older reporting data may exist from before default-model tags were added.
- * This keeps the list honest by distinguishing "no fallback requests" from
- * "no fallback metadata available for this time range".
- */
-function FallbackCount({ task }: { task: AiTaskSummary }) {
-  if (!task.hasFallbackTracking) {
-    return <span className="text-muted-foreground">—</span>;
-  }
-
-  if (task.fallbackRequestCount > 0) {
-    return <Badge variant="secondary">{task.fallbackRequestCount.toLocaleString()}</Badge>;
-  }
-
-  return <span className="tabular-nums">{task.fallbackRequestCount.toLocaleString()}</span>;
-}
-
-/**
- * The detail page reads its filters from the query string. Building the href in
- * one place keeps the index links aligned with that contract and avoids hand-
- * written query strings drifting across call sites.
- */
-function buildTaskHref({
-  endDate,
-  startDate,
-  taskName,
-}: {
-  endDate: string;
-  startDate: string;
-  taskName: string;
-}): string {
-  const searchParams = new URLSearchParams({ from: startDate, to: endDate });
-  return `${getAiTaskHref(taskName)}?${searchParams.toString()}`;
 }

--- a/apps/admin/src/app/(private)/stats/ai/page.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/page.tsx
@@ -2,7 +2,9 @@ import { getSingleSearchParamValue, resolveAiTaskDateRange } from "@/data/stats/
 import { type Metadata } from "next";
 import { Suspense } from "react";
 import { StatsPageLayout } from "../_components/stats-page-layout";
-import { AiStatsFilters } from "./ai-stats-filters";
+import { AiFallbackTaskList, AiFallbackTaskListSkeleton } from "./ai-fallback-task-list";
+import { AiTaskDirectory } from "./ai-task-directory";
+import { AiTaskDirectoryControls } from "./ai-task-directory-controls";
 import { AiTaskList, AiTaskListSkeleton } from "./ai-task-list";
 
 export const metadata: Metadata = {
@@ -10,9 +12,9 @@ export const metadata: Metadata = {
 };
 
 /**
- * The AI stats index is its own stats subsection, so it reuses the shared stats
- * shell and streams the selected-period task list once the Gateway report has
- * loaded.
+ * The AI stats index keeps its default render lightweight, then streams only the
+ * specific on-demand report the admin asked for while keeping the task directory
+ * visible underneath.
  */
 export default async function AiTasksPage({ searchParams }: PageProps<"/stats/ai">) {
   const resolvedSearchParams = await searchParams;
@@ -20,22 +22,42 @@ export default async function AiTasksPage({ searchParams }: PageProps<"/stats/ai
     from: getSingleSearchParamValue(resolvedSearchParams.from),
     to: getSingleSearchParamValue(resolvedSearchParams.to),
   });
+  const activeView = resolveAiTaskPageView(getSingleSearchParamValue(resolvedSearchParams.view));
 
   return (
-    <StatsPageLayout
-      navigation={
-        <AiStatsFilters
-          actionHref="/stats/ai"
+    <StatsPageLayout showPeriodTabs={false} title="AI Tasks">
+      <div className="flex flex-col gap-10">
+        <AiTaskDirectoryControls
+          activeView={activeView}
           endDate={range.endInput}
           startDate={range.startInput}
         />
-      }
-      showPeriodTabs={false}
-      title="AI Tasks"
-    >
-      <Suspense fallback={<AiTaskListSkeleton />}>
-        <AiTaskList endDate={range.endInput} startDate={range.startInput} />
-      </Suspense>
+
+        {activeView === "summary" ? (
+          <Suspense fallback={<AiTaskListSkeleton />}>
+            <AiTaskList endDate={range.endInput} startDate={range.startInput} />
+          </Suspense>
+        ) : null}
+
+        {activeView === "fallbacks" ? (
+          <Suspense fallback={<AiFallbackTaskListSkeleton />}>
+            <AiFallbackTaskList endDate={range.endInput} startDate={range.startInput} />
+          </Suspense>
+        ) : null}
+
+        <AiTaskDirectory endDate={range.endInput} startDate={range.startInput} />
+      </div>
     </StatsPageLayout>
   );
+}
+
+/**
+ * The index exposes a small set of on-demand report views. Narrowing the raw
+ * query string to those known values keeps the page logic explicit and ignores
+ * any unsupported value without throwing.
+ */
+function resolveAiTaskPageView(value?: string) {
+  if (value === "summary" || value === "fallbacks") {
+    return value;
+  }
 }

--- a/apps/admin/src/data/stats/ai/ai-task-catalog.ts
+++ b/apps/admin/src/data/stats/ai/ai-task-catalog.ts
@@ -1,0 +1,309 @@
+import { formatAiTaskLabel } from "./ai-task-stats";
+
+type AiTaskMetadata = {
+  defaultModel: string;
+  supportsFallbackReporting: boolean;
+};
+
+type AiTaskCatalogGroupDefinition = {
+  description: string;
+  taskNames: AiTaskName[];
+  title: string;
+};
+
+const AI_TASK_METADATA = {
+  "activity-custom": {
+    defaultModel: "google/gemini-3-flash",
+    supportsFallbackReporting: true,
+  },
+  "activity-distractors": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "activity-explanation": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "activity-grammar-content": {
+    defaultModel: "google/gemini-3.1-pro-preview",
+    supportsFallbackReporting: true,
+  },
+  "activity-grammar-user-content": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "activity-investigation-accuracy": {
+    defaultModel: "openai/gpt-5.4-mini",
+    supportsFallbackReporting: true,
+  },
+  "activity-investigation-actions": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "activity-investigation-findings": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "activity-investigation-scenario": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "activity-practice": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "activity-pronunciation": {
+    defaultModel: "google/gemini-3-flash",
+    supportsFallbackReporting: true,
+  },
+  "activity-quiz": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "activity-romanization": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "activity-sentences": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "activity-story-debrief": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "activity-story-steps": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: false,
+  },
+  "activity-translation": {
+    defaultModel: "openai/gpt-5.4-mini",
+    supportsFallbackReporting: true,
+  },
+  "activity-vocabulary": {
+    defaultModel: "google/gemini-3-flash",
+    supportsFallbackReporting: true,
+  },
+  "alternative-titles": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "applied-activity-kind": {
+    defaultModel: "google/gemini-3.1-flash-lite-preview",
+    supportsFallbackReporting: true,
+  },
+  "chapter-lessons": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "course-categories": {
+    defaultModel: "google/gemini-3.1-flash-lite-preview",
+    supportsFallbackReporting: true,
+  },
+  "course-chapters": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "course-description": {
+    defaultModel: "openai/gpt-5.4-nano",
+    supportsFallbackReporting: true,
+  },
+  "course-suggestions": {
+    defaultModel: "openai/gpt-5.4-mini",
+    supportsFallbackReporting: true,
+  },
+  "course-thumbnail": {
+    defaultModel: "openai/gpt-image-1.5",
+    supportsFallbackReporting: false,
+  },
+  "language-chapter-lessons": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "language-course-chapters": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "lesson-activities": {
+    defaultModel: "google/gemini-3-flash",
+    supportsFallbackReporting: true,
+  },
+  "lesson-kind": {
+    defaultModel: "openai/gpt-5.4-nano",
+    supportsFallbackReporting: true,
+  },
+  "step-select-image": {
+    defaultModel: "openai/gpt-image-1-mini",
+    supportsFallbackReporting: false,
+  },
+  "step-visual-descriptions": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "step-visual-image": {
+    defaultModel: "openai/gpt-image-1.5",
+    supportsFallbackReporting: false,
+  },
+  "visual-chart": {
+    defaultModel: "google/gemini-3.1-flash-lite-preview",
+    supportsFallbackReporting: true,
+  },
+  "visual-code": {
+    defaultModel: "openai/gpt-5.4",
+    supportsFallbackReporting: true,
+  },
+  "visual-diagram": {
+    defaultModel: "google/gemini-3.1-flash-lite-preview",
+    supportsFallbackReporting: true,
+  },
+  "visual-formula": {
+    defaultModel: "openai/gpt-5.4-mini",
+    supportsFallbackReporting: true,
+  },
+  "visual-music": {
+    defaultModel: "google/gemini-3.1-pro-preview",
+    supportsFallbackReporting: true,
+  },
+  "visual-quote": {
+    defaultModel: "google/gemini-3.1-pro-preview",
+    supportsFallbackReporting: true,
+  },
+  "visual-table": {
+    defaultModel: "google/gemini-3.1-flash-lite-preview",
+    supportsFallbackReporting: true,
+  },
+  "visual-timeline": {
+    defaultModel: "openai/gpt-5.4-mini",
+    supportsFallbackReporting: true,
+  },
+} satisfies Record<string, AiTaskMetadata>;
+
+export type AiTaskName = keyof typeof AI_TASK_METADATA;
+
+export type AiTaskCatalogTask = {
+  defaultModel: string;
+  supportsFallbackReporting: boolean;
+  taskLabel: string;
+  taskName: AiTaskName;
+};
+
+type AiTaskCatalogGroup = {
+  description: string;
+  tasks: AiTaskCatalogTask[];
+  title: string;
+};
+
+const AI_TASK_CATALOG_GROUP_DEFINITIONS = [
+  {
+    description: "Top-level course creation, positioning, and presentation tasks.",
+    taskNames: [
+      "course-suggestions",
+      "alternative-titles",
+      "course-categories",
+      "course-description",
+      "course-thumbnail",
+      "course-chapters",
+      "language-course-chapters",
+    ],
+    title: "Course Planning",
+  },
+  {
+    description: "Chapter-level planning tasks that decide which lessons should exist next.",
+    taskNames: ["chapter-lessons", "language-chapter-lessons"],
+    title: "Chapter Planning",
+  },
+  {
+    description:
+      "Lesson scaffolding tasks that shape the structure before activity generation starts.",
+    taskNames: ["lesson-kind", "lesson-activities", "applied-activity-kind"],
+    title: "Lesson Flow",
+  },
+  {
+    description:
+      "Core lesson activities, including explanations, practice, quiz, and investigation flows.",
+    taskNames: [
+      "activity-explanation",
+      "activity-practice",
+      "activity-quiz",
+      "activity-story-steps",
+      "activity-story-debrief",
+      "activity-investigation-scenario",
+      "activity-investigation-accuracy",
+      "activity-investigation-actions",
+      "activity-investigation-findings",
+      "activity-custom",
+    ],
+    title: "Core Activities",
+  },
+  {
+    description:
+      "Language-specific tasks for vocabulary, grammar, pronunciation, and translation work.",
+    taskNames: [
+      "activity-vocabulary",
+      "activity-translation",
+      "activity-grammar-content",
+      "activity-grammar-user-content",
+      "activity-distractors",
+      "activity-pronunciation",
+      "activity-sentences",
+      "activity-romanization",
+    ],
+    title: "Language Activities",
+  },
+  {
+    description: "Image-selection and visual-description tasks used inside lesson steps.",
+    taskNames: ["step-select-image", "step-visual-descriptions", "step-visual-image"],
+    title: "Step Media",
+  },
+  {
+    description:
+      "Standalone visual generation tasks for charts, diagrams, code, tables, and other assets.",
+    taskNames: [
+      "visual-chart",
+      "visual-code",
+      "visual-diagram",
+      "visual-formula",
+      "visual-music",
+      "visual-quote",
+      "visual-table",
+      "visual-timeline",
+    ],
+    title: "Visual Assets",
+  },
+] satisfies AiTaskCatalogGroupDefinition[];
+
+/**
+ * The AI task index now acts as a lightweight directory instead of a live
+ * dashboard. This catalog keeps the admin-specific grouping, labels, and
+ * configured default models in one place so the fallback summary can reuse the
+ * same task definitions as the directory.
+ */
+export const AI_TASK_CATALOG = AI_TASK_CATALOG_GROUP_DEFINITIONS.map((group) => ({
+  description: group.description,
+  tasks: group.taskNames.map((taskName) => buildAiTaskCatalogTask({ taskName })),
+  title: group.title,
+})) satisfies AiTaskCatalogGroup[];
+
+/**
+ * The fallback summary needs a flat task list so it can group active tasks by
+ * configured default model without caring which section they appear under in the
+ * directory UI.
+ */
+export function listAiTaskCatalogTasks() {
+  return AI_TASK_CATALOG.flatMap((group) => group.tasks);
+}
+
+/**
+ * Building task objects through one helper keeps labels and metadata aligned
+ * wherever the admin UI needs to render or analyze a task.
+ */
+function buildAiTaskCatalogTask({ taskName }: { taskName: AiTaskName }): AiTaskCatalogTask {
+  const metadata = AI_TASK_METADATA[taskName];
+
+  return {
+    defaultModel: metadata.defaultModel,
+    supportsFallbackReporting: metadata.supportsFallbackReporting,
+    taskLabel: formatAiTaskLabel(taskName),
+    taskName,
+  };
+}

--- a/apps/admin/src/data/stats/ai/ai-task-hrefs.ts
+++ b/apps/admin/src/data/stats/ai/ai-task-hrefs.ts
@@ -1,0 +1,125 @@
+import { getAiTaskHref } from "./ai-task-stats";
+
+/**
+ * The AI stats routes share the same date-range query contract. Building those
+ * search params in one place keeps the index, detail, and estimates links aligned
+ * as the on-demand reporting flow grows.
+ */
+function buildAiTaskSearchParams({
+  endDate,
+  runCount,
+  startDate,
+  view,
+}: {
+  endDate: string;
+  runCount?: number;
+  startDate: string;
+  view?: string;
+}) {
+  return new URLSearchParams(getAiTaskSearchEntries({ endDate, runCount, startDate, view }));
+}
+
+/**
+ * `URLSearchParams` expects an iterable of `[key, value]` pairs. Returning the
+ * full entry list from one helper keeps the tuple typing intact and avoids
+ * hand-built query arrays drifting across routes.
+ */
+function getAiTaskSearchEntries({
+  endDate,
+  runCount,
+  startDate,
+  view,
+}: {
+  endDate: string;
+  runCount?: number;
+  startDate: string;
+  view?: string;
+}): [string, string][] {
+  return [
+    buildAiTaskSearchEntry({ key: "from", value: startDate }),
+    buildAiTaskSearchEntry({ key: "to", value: endDate }),
+    ...getOptionalAiTaskSearchEntries({ runCount, view }),
+  ];
+}
+
+/**
+ * Building entries through a tiny helper keeps TypeScript from widening the
+ * tuple shape to `string[]`, which `URLSearchParams` does not accept here.
+ */
+function buildAiTaskSearchEntry({ key, value }: { key: string; value: string }): [string, string] {
+  return [key, value];
+}
+
+/**
+ * Optional AI stats fields should only appear in the URL when the user actually
+ * asked for that view. Keeping those entries in a helper avoids ad hoc query
+ * string building across the admin pages.
+ */
+function getOptionalAiTaskSearchEntries({
+  runCount,
+  view,
+}: {
+  runCount?: number;
+  view?: string;
+}): [string, string][] {
+  return [
+    ...(runCount === undefined
+      ? []
+      : [buildAiTaskSearchEntry({ key: "runs", value: String(runCount) })]),
+    ...(view ? [buildAiTaskSearchEntry({ key: "view", value: view })] : []),
+  ];
+}
+
+/**
+ * The AI stats index can now stay passive by default and only opt into live
+ * reporting when the user requests a specific summary view.
+ */
+export function buildAiTaskIndexHref({
+  endDate,
+  startDate,
+  view,
+}: {
+  endDate: string;
+  startDate: string;
+  view?: string;
+}) {
+  const searchParams = buildAiTaskSearchParams({ endDate, startDate, view });
+  return `/stats/ai?${searchParams.toString()}` as const;
+}
+
+/**
+ * Task detail links preserve the active date range and any optional drill-down
+ * state so admins can move between overview and breakdown views without losing
+ * the context they selected on the index page.
+ */
+export function buildAiTaskReportHref({
+  endDate,
+  runCount,
+  startDate,
+  taskName,
+  view,
+}: {
+  endDate: string;
+  runCount?: number;
+  startDate: string;
+  taskName: string;
+  view?: string;
+}) {
+  const searchParams = buildAiTaskSearchParams({ endDate, runCount, startDate, view });
+  return `${getAiTaskHref(taskName)}?${searchParams.toString()}`;
+}
+
+/**
+ * The estimates route reads the same shared date range as the task pages. This
+ * helper keeps the cross-link from the index consistent with that contract.
+ */
+export function buildAiEstimateHref({
+  endDate,
+  startDate,
+}: {
+  endDate: string;
+  startDate: string;
+}) {
+  const searchParams = buildAiTaskSearchParams({ endDate, startDate });
+  return `/stats/ai/estimates?${searchParams.toString()}` as const;
+}

--- a/apps/admin/src/data/stats/ai/ai-task-stats.ts
+++ b/apps/admin/src/data/stats/ai/ai-task-stats.ts
@@ -8,7 +8,7 @@ import { MS_PER_DAY, parseLocalDate } from "@zoonk/utils/date";
 const AI_TASK_NAME_PATTERN = /^[a-z0-9-]+$/;
 const AI_MODEL_ID_PATTERN = /^[a-z0-9.-]+\/[a-z0-9.-]+$/;
 const DATE_INPUT_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
-const DEFAULT_LOOKBACK_DAYS = 30;
+const DEFAULT_LOOKBACK_DAYS = 1;
 const DEFAULT_ESTIMATE_RUN_COUNT = 1000;
 const DEFAULT_WORD_AUDIO_SECONDS = 0.75;
 const AVERAGE_SPOKEN_WORDS_PER_SECOND = 2.5;
@@ -111,7 +111,7 @@ export function isFallbackModel({
 }
 
 /**
- * The AI stats pages default to the last 30 calendar days, including today.
+ * The AI stats pages default to the current calendar day.
  * When the user supplies only one side of the range, we keep the experience
  * predictable by filling the missing side instead of dropping back to an empty
  * or invalid query.
@@ -277,7 +277,7 @@ export function getAiTaskHref(taskName: string): `/stats/ai/${string}` {
 }
 
 /**
- * The default task list and task detail pages share the same last-30-days window.
+ * The default task list and task detail pages share the same single-day window.
  * This helper keeps that convention centralized so those pages do not drift.
  */
 function getDefaultAiTaskDateRange(now: Date): AiTaskDateRange {

--- a/apps/admin/src/data/stats/ai/get-ai-fallback-task-summaries.ts
+++ b/apps/admin/src/data/stats/ai/get-ai-fallback-task-summaries.ts
@@ -1,0 +1,328 @@
+import "server-only";
+import { zoonkGateway } from "@zoonk/core/ai";
+import { safeAsync } from "@zoonk/utils/error";
+import { type AiTaskCatalogTask, listAiTaskCatalogTasks } from "./ai-task-catalog";
+import { extractAiTaskName } from "./ai-task-stats";
+import { getAiTaskUsageMap } from "./get-ai-task-usage-map";
+
+type ActiveFallbackTask = AiTaskCatalogTask & {
+  requestCount: number;
+};
+
+export type AiFallbackTaskSummary = {
+  defaultModel: string;
+  fallbackRate: number;
+  fallbackRequestCount: number;
+  requestCount: number;
+  taskLabel: string;
+  taskName: string;
+};
+
+type AiFallbackTaskSummaryReport = {
+  activeTaskCount: number;
+  fallbackRate: number;
+  fallbackRequestCount: number;
+  tasks: AiFallbackTaskSummary[];
+  totalRequestCount: number;
+};
+
+/**
+ * The cheapest exact cross-task fallback summary we can build with Gateway's
+ * current reporting API is one task-usage query plus one grouped-tag query per
+ * active default model. That lets us compare each task's total requests against
+ * the subset that actually ran on its configured default model.
+ */
+export async function getAiFallbackTaskSummaries({
+  endDate,
+  startDate,
+}: {
+  endDate: string;
+  startDate: string;
+}): Promise<AiFallbackTaskSummaryReport> {
+  const usageByTask = await getAiTaskUsageMap({ endDate, startDate });
+  const activeTasks = getActiveFallbackTasks({ usageByTask });
+
+  if (activeTasks.length <= 0) {
+    return {
+      activeTaskCount: 0,
+      fallbackRate: 0,
+      fallbackRequestCount: 0,
+      tasks: [],
+      totalRequestCount: 0,
+    };
+  }
+
+  const defaultModelRequestCounts = await getDefaultModelRequestCounts({
+    activeTasks,
+    endDate,
+    startDate,
+  });
+  const tasks = activeTasks
+    .map((task) =>
+      buildAiFallbackTaskSummary({
+        defaultModelRequestCount: defaultModelRequestCounts.get(task.taskName) ?? 0,
+        task,
+      }),
+    )
+    .filter((task) => hasFallbackRequests(task))
+    .toSorted(compareAiFallbackTaskSummaries);
+  const fallbackRequestCount = sumFallbackRequestCounts(tasks);
+  const totalRequestCount = sumActiveTaskRequestCounts(activeTasks);
+
+  return {
+    activeTaskCount: activeTasks.length,
+    fallbackRate: calculateFallbackRate({
+      fallbackRequestCount,
+      requestCount: totalRequestCount,
+    }),
+    fallbackRequestCount,
+    tasks,
+    totalRequestCount,
+  };
+}
+
+/**
+ * Tasks without fallback routing or without any traffic in the selected period
+ * cannot contribute to this report, so we drop them before issuing any model-
+ * filtered Gateway queries.
+ */
+function getActiveFallbackTasks({
+  usageByTask,
+}: {
+  usageByTask: Awaited<ReturnType<typeof getAiTaskUsageMap>>;
+}) {
+  return listAiTaskCatalogTasks().flatMap((task) =>
+    getActiveFallbackTaskEntries({ task, usageByTask }),
+  );
+}
+
+/**
+ * Returning either one enriched task or nothing keeps the parent pipeline
+ * linear and makes the inclusion rules explicit in one place.
+ */
+function getActiveFallbackTaskEntries({
+  task,
+  usageByTask,
+}: {
+  task: AiTaskCatalogTask;
+  usageByTask: Awaited<ReturnType<typeof getAiTaskUsageMap>>;
+}): ActiveFallbackTask[] {
+  const usage = usageByTask[task.taskName];
+
+  if (!task.supportsFallbackReporting || !usage || usage.requestCount <= 0) {
+    return [];
+  }
+
+  return [{ ...task, requestCount: usage.requestCount }];
+}
+
+/**
+ * Gateway can filter by actual served model while still grouping by tag. Grouping
+ * active tasks by configured default model lets one query cover every task that
+ * shares that default, which is much cheaper than opening one query per task.
+ */
+async function getDefaultModelRequestCounts({
+  activeTasks,
+  endDate,
+  startDate,
+}: {
+  activeTasks: ActiveFallbackTask[];
+  endDate: string;
+  startDate: string;
+}) {
+  const tasksByDefaultModel = groupTasksByDefaultModel({ activeTasks });
+  const defaultModelRequestCountMaps = await Promise.all(
+    [...tasksByDefaultModel.entries()].map(([defaultModel, tasks]) =>
+      getDefaultModelRequestCountMapForTaskGroup({
+        defaultModel,
+        endDate,
+        startDate,
+        tasks,
+      }),
+    ),
+  );
+
+  return mergeDefaultModelRequestCounts({ requestCountMaps: defaultModelRequestCountMaps });
+}
+
+/**
+ * Tasks that share the same configured default model can reuse the same Gateway
+ * query because we only need to know which of those tasks actually ran on that
+ * model in the selected period.
+ */
+function groupTasksByDefaultModel({ activeTasks }: { activeTasks: ActiveFallbackTask[] }) {
+  const groups = new Map<string, ActiveFallbackTask[]>();
+
+  for (const task of activeTasks) {
+    const existingTasks = groups.get(task.defaultModel) ?? [];
+    groups.set(task.defaultModel, [...existingTasks, task]);
+  }
+
+  return groups;
+}
+
+/**
+ * Filtering the report by the configured default model yields the subset of
+ * requests that stayed on their default path. Subtracting those counts from the
+ * per-task totals gives us the fallback counts without a task-by-task drill-down.
+ */
+async function getDefaultModelRequestCountMapForTaskGroup({
+  defaultModel,
+  endDate,
+  startDate,
+  tasks,
+}: {
+  defaultModel: string;
+  endDate: string;
+  startDate: string;
+  tasks: ActiveFallbackTask[];
+}) {
+  const { data, error } = await safeAsync(() =>
+    zoonkGateway.getSpendReport({
+      endDate,
+      groupBy: "tag",
+      model: defaultModel,
+      startDate,
+    }),
+  );
+
+  if (error) {
+    throw new Error(`Failed to load default-model usage for ${defaultModel}`, { cause: error });
+  }
+
+  return buildDefaultModelRequestCountMap({
+    rows: data.results,
+    taskNames: tasks.map((task) => task.taskName),
+  });
+}
+
+/**
+ * The model-filtered tag report still includes non-task tags. We keep only the
+ * task rows we care about for the current default-model group.
+ */
+function buildDefaultModelRequestCountMap({
+  rows,
+  taskNames,
+}: {
+  rows: Awaited<ReturnType<typeof zoonkGateway.getSpendReport>>["results"];
+  taskNames: string[];
+}) {
+  const taskNameSet = new Set(taskNames);
+  const requestCounts = new Map<string, number>();
+
+  for (const row of rows) {
+    const taskName = extractAiTaskName(row.tag);
+
+    if (taskName && taskNameSet.has(taskName)) {
+      requestCounts.set(taskName, row.requestCount ?? 0);
+    }
+  }
+
+  return requestCounts;
+}
+
+/**
+ * Each default-model query returns a map for the tasks that share that model.
+ * Merging those maps once here keeps the main loader linear and avoids unsafe
+ * casts around `Object.assign`.
+ */
+function mergeDefaultModelRequestCounts({
+  requestCountMaps,
+}: {
+  requestCountMaps: Map<string, number>[];
+}) {
+  const requestCounts = new Map<string, number>();
+
+  for (const requestCountMap of requestCountMaps) {
+    for (const [taskName, requestCount] of requestCountMap.entries()) {
+      requestCounts.set(taskName, requestCount);
+    }
+  }
+
+  return requestCounts;
+}
+
+/**
+ * The fallback summary is centered on how many requests missed the configured
+ * default model for a task, plus the share of traffic that represents.
+ */
+function buildAiFallbackTaskSummary({
+  defaultModelRequestCount,
+  task,
+}: {
+  defaultModelRequestCount: number;
+  task: ActiveFallbackTask;
+}) {
+  const defaultRequestCount = Math.min(defaultModelRequestCount, task.requestCount);
+  const fallbackRequestCount = Math.max(task.requestCount - defaultRequestCount, 0);
+
+  return {
+    defaultModel: task.defaultModel,
+    fallbackRate: calculateFallbackRate({
+      fallbackRequestCount,
+      requestCount: task.requestCount,
+    }),
+    fallbackRequestCount,
+    requestCount: task.requestCount,
+    taskLabel: task.taskLabel,
+    taskName: task.taskName,
+  } satisfies AiFallbackTaskSummary;
+}
+
+/**
+ * Rows with zero fallback requests are not helpful on the summary page, so we
+ * drop them and keep the report focused on the tasks that actually fell back.
+ */
+function hasFallbackRequests(task: AiFallbackTaskSummary) {
+  return task.fallbackRequestCount > 0;
+}
+
+/**
+ * The most important tasks are the ones with the largest fallback volume. When
+ * counts tie, the report falls back to rate and then to a stable label order.
+ */
+function compareAiFallbackTaskSummaries(left: AiFallbackTaskSummary, right: AiFallbackTaskSummary) {
+  if (right.fallbackRequestCount !== left.fallbackRequestCount) {
+    return right.fallbackRequestCount - left.fallbackRequestCount;
+  }
+
+  if (right.fallbackRate !== left.fallbackRate) {
+    return right.fallbackRate - left.fallbackRate;
+  }
+
+  return left.taskLabel.localeCompare(right.taskLabel);
+}
+
+/**
+ * The top-level cards need the report-wide fallback volume, so we sum the task
+ * rows once here instead of recalculating it inside the component tree.
+ */
+function sumFallbackRequestCounts(tasks: AiFallbackTaskSummary[]) {
+  return tasks.reduce((sum, task) => sum + task.fallbackRequestCount, 0);
+}
+
+/**
+ * We compare fallback volume against the total traffic for active fallback-
+ * capable tasks in the period, not against the whole task catalog.
+ */
+function sumActiveTaskRequestCounts(tasks: ActiveFallbackTask[]) {
+  return tasks.reduce((sum, task) => sum + task.requestCount, 0);
+}
+
+/**
+ * Both the per-task rows and the report summary need the same normalized rate.
+ * Returning zero for empty totals keeps the UI stable for quiet periods.
+ */
+function calculateFallbackRate({
+  fallbackRequestCount,
+  requestCount,
+}: {
+  fallbackRequestCount: number;
+  requestCount: number;
+}) {
+  if (requestCount <= 0) {
+    return 0;
+  }
+
+  return fallbackRequestCount / requestCount;
+}

--- a/apps/admin/src/data/stats/ai/get-ai-task-overview.ts
+++ b/apps/admin/src/data/stats/ai/get-ai-task-overview.ts
@@ -1,0 +1,113 @@
+import "server-only";
+import { zoonkGateway } from "@zoonk/core/ai";
+import { safeAsync } from "@zoonk/utils/error";
+import {
+  buildAiTaskTag,
+  calculateAverageMarketCostPerRequest,
+  calculateEstimatedMarketCost,
+  extractAiDefaultModel,
+  formatAiTaskLabel,
+} from "./ai-task-stats";
+
+type SpendReportTagRow = {
+  marketCost?: number | null;
+  requestCount?: number | null;
+  tag?: string | null;
+};
+
+export type AiTaskOverview = {
+  averageMarketCostPerRequest: number;
+  defaultModels: string[];
+  estimatedMarketCost: number;
+  hasFallbackTracking: boolean;
+  taskLabel: string;
+  taskName: string;
+  totalMarketCost: number;
+  totalRequests: number;
+};
+
+/**
+ * The task detail page now opens with a lightweight overview instead of the
+ * full model table. A single grouped tag report is enough to show totals,
+ * estimates, and which default-model tags were configured for that period.
+ */
+export async function getAiTaskOverview({
+  endDate,
+  runCount,
+  startDate,
+  taskName,
+}: {
+  endDate: string;
+  runCount: number;
+  startDate: string;
+  taskName: string;
+}): Promise<AiTaskOverview> {
+  const taskTag = buildAiTaskTag(taskName);
+  const { data, error } = await safeAsync(() =>
+    zoonkGateway.getSpendReport({
+      endDate,
+      groupBy: "tag",
+      startDate,
+      tags: [taskTag],
+    }),
+  );
+
+  if (error) {
+    throw new Error(`Failed to load AI task overview for ${taskName}`, { cause: error });
+  }
+
+  const totals = getAiTaskTotals({ rows: data.results, taskTag });
+  const averageMarketCostPerRequest = calculateAverageMarketCostPerRequest({
+    marketCost: totals.totalMarketCost,
+    requestCount: totals.totalRequests,
+  });
+  const defaultModels = getAiTaskDefaultModels(data.results);
+
+  return {
+    averageMarketCostPerRequest,
+    defaultModels,
+    estimatedMarketCost: calculateEstimatedMarketCost({
+      averageMarketCostPerRequest,
+      runCount,
+    }),
+    hasFallbackTracking: defaultModels.length > 0,
+    taskLabel: formatAiTaskLabel(taskName),
+    taskName,
+    totalMarketCost: totals.totalMarketCost,
+    totalRequests: totals.totalRequests,
+  };
+}
+
+/**
+ * The grouped tag response contains one row for the task tag itself plus any
+ * default-model tags that were attached to those requests. Only the task-tag row
+ * represents the total traffic for the task, so we isolate it here.
+ */
+function getAiTaskTotals({ rows, taskTag }: { rows: SpendReportTagRow[]; taskTag: string }) {
+  const taskRow = rows.find((row) => row.tag === taskTag);
+
+  return {
+    totalMarketCost: taskRow?.marketCost ?? 0,
+    totalRequests: taskRow?.requestCount ?? 0,
+  };
+}
+
+/**
+ * Default-model tags tell the admin which model configuration was active for
+ * the task during the selected period, even when we have not loaded the full
+ * per-model breakdown yet.
+ */
+function getAiTaskDefaultModels(rows: SpendReportTagRow[]) {
+  return [
+    ...new Set(rows.flatMap((row) => getAiTaskDefaultModelTags(row.tag ?? undefined))),
+  ].toSorted();
+}
+
+/**
+ * The reporting API returns raw tag strings. This helper keeps the flattening
+ * logic readable while ignoring unrelated tag dimensions that may appear later.
+ */
+function getAiTaskDefaultModelTags(tag?: string) {
+  const defaultModel = extractAiDefaultModel(tag);
+  return defaultModel ? [defaultModel] : [];
+}

--- a/apps/admin/src/data/stats/ai/get-ai-task-summaries.ts
+++ b/apps/admin/src/data/stats/ai/get-ai-task-summaries.ts
@@ -1,21 +1,19 @@
 import "server-only";
-import { zoonkGateway } from "@zoonk/core/ai";
-import { safeAsync } from "@zoonk/utils/error";
-import { extractAiTaskName, formatAiTaskLabel } from "./ai-task-stats";
-import { getAiTaskModelUsage } from "./get-ai-task-model-usage";
+import { formatAiTaskLabel } from "./ai-task-stats";
+import { getAiTaskUsageMap } from "./get-ai-task-usage-map";
 
 export type AiTaskSummary = {
-  fallbackRequestCount: number;
-  hasFallbackTracking: boolean;
+  averageMarketCostPerRequest: number;
   requestCount: number;
   taskLabel: string;
   taskName: string;
+  totalMarketCost: number;
 };
 
 /**
- * The stats index groups spend-report rows by tag so admins can see which AI
- * tasks ran most often in the last 30 days. We filter the response down to our
- * `task:*` tags and sort by request volume so the busiest tasks appear first.
+ * The index summary should be one billed reporting query, not one query plus a
+ * follow-up for every task. This loader reuses the shared task-usage map and
+ * only formats the active tasks for the selected date range.
  */
 export async function getAiTaskSummaries({
   endDate,
@@ -24,60 +22,28 @@ export async function getAiTaskSummaries({
   endDate: string;
   startDate: string;
 }): Promise<AiTaskSummary[]> {
-  const { data, error } = await safeAsync(() =>
-    zoonkGateway.getSpendReport({
-      endDate,
-      groupBy: "tag",
-      startDate,
-    }),
-  );
+  const usageByTask = await getAiTaskUsageMap({ endDate, startDate });
 
-  if (error) {
-    throw new Error("Failed to load AI task summaries", { cause: error });
+  return Object.values(usageByTask)
+    .map((task) => ({
+      averageMarketCostPerRequest: task.averageMarketCostPerRequest,
+      requestCount: task.requestCount,
+      taskLabel: formatAiTaskLabel(task.taskName),
+      taskName: task.taskName,
+      totalMarketCost: task.totalMarketCost,
+    }))
+    .toSorted(compareAiTaskSummaries);
+}
+
+/**
+ * Request volume is the fastest way to see which tasks mattered most in the
+ * selected period, so the summary stays sorted by traffic before falling back
+ * to a stable alphabetical label order.
+ */
+function compareAiTaskSummaries(left: AiTaskSummary, right: AiTaskSummary) {
+  if (right.requestCount !== left.requestCount) {
+    return right.requestCount - left.requestCount;
   }
 
-  const summariesByTask = new Map<string, AiTaskSummary>();
-
-  for (const row of data.results) {
-    const taskName = extractAiTaskName(row.tag);
-
-    if (taskName) {
-      const existingSummary = summariesByTask.get(taskName);
-      const requestCount = row.requestCount ?? 0;
-
-      summariesByTask.set(taskName, {
-        fallbackRequestCount: existingSummary?.fallbackRequestCount ?? 0,
-        hasFallbackTracking: existingSummary?.hasFallbackTracking ?? false,
-        requestCount: (existingSummary?.requestCount ?? 0) + requestCount,
-        taskLabel: existingSummary?.taskLabel ?? formatAiTaskLabel(taskName),
-        taskName,
-      });
-    }
-  }
-
-  const tasks = [...summariesByTask.values()].toSorted((left, right) => {
-    if (right.requestCount !== left.requestCount) {
-      return right.requestCount - left.requestCount;
-    }
-
-    return left.taskLabel.localeCompare(right.taskLabel);
-  });
-
-  const enrichedTasks = await Promise.all(
-    tasks.map(async (task) => {
-      const usage = await getAiTaskModelUsage({
-        endDate,
-        startDate,
-        taskName: task.taskName,
-      });
-
-      return {
-        ...task,
-        fallbackRequestCount: usage.fallbackRequestCount,
-        hasFallbackTracking: usage.hasFallbackTracking,
-      } satisfies AiTaskSummary;
-    }),
-  );
-
-  return enrichedTasks;
+  return left.taskLabel.localeCompare(right.taskLabel);
 }


### PR DESCRIPTION
## Summary
- make the admin ai stats index directory-first and load live summaries or fallback-task reports only on demand
- add a cheaper task overview flow and only load the detailed model breakdown when requested
- default the shared ai stats date range to the current day and extract shared catalog, href, and filter helpers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the AI stats pages directory‑first and load expensive reports only when requested, cutting reporting cost and speeding up the index. Adds a cheaper cross‑task fallback summary and defaults the date range to today.

- New Features
  - Directory page with grouped task links and controls to “Load Live Summary” or “Load Fallback Tasks” without auto‑querying.
  - Task detail shows a lightweight overview (totals, avg cost, est. runs, default models) and only loads the model breakdown when `view=breakdown`.
  - New fallback‑task report that summarizes where defaults were missed using one usage map plus grouped default‑model queries.
  - Index table now shows Requests, Total Market Cost, and Avg Market Cost/Request.

- Refactors
  - Default reporting window is now the current day.
  - Shared helpers: `ai-task-hrefs` for consistent query params, `ai-task-catalog` for labels/defaults/grouping, and `AiFilterField` for forms.
  - Reworked summaries to reuse a single usage map instead of per‑task breakdown queries.

<sup>Written for commit d61b457ec4ef64d19a5a0a93421712070b1ee1b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

