### PR TITLE
fix(admin): improve flagged review flow

### DIFF
--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/simple-image-upload.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/simple-image-upload.tsx
@@ -4,7 +4,7 @@ import { Button } from "@zoonk/ui/components/button";
 import { cn } from "@zoonk/ui/lib/utils";
 import { DEFAULT_IMAGE_ACCEPTED_TYPES } from "@zoonk/utils/upload";
 import { ImageIcon, Loader2Icon, UploadIcon } from "lucide-react";
-import { useRef, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 
 type UploadAction = (formData: FormData) => Promise<{ error: string | null }>;
 
@@ -38,6 +38,15 @@ export function SimpleImageUpload({
   const [isPending, startTransition] = useTransition();
   const blobUrlRef = useRef<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(
+    () => () => {
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current);
+      }
+    },
+    [],
+  );
 
   const handleUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/simple-image-upload.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/simple-image-upload.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { Button } from "@zoonk/ui/components/button";
+import { cn } from "@zoonk/ui/lib/utils";
+import { DEFAULT_IMAGE_ACCEPTED_TYPES } from "@zoonk/utils/upload";
+import { ImageIcon, Loader2Icon, UploadIcon } from "lucide-react";
+import { useRef, useState, useTransition } from "react";
+
+type UploadAction = (formData: FormData) => Promise<{ error: string | null }>;
+
+/**
+ * Keeps the admin review image editing flow simple.
+ *
+ * Reviewers only need two things here: a large preview they can actually inspect
+ * and a direct way to replace the file. This component uses a normal image tag
+ * plus a native file input behind one outline button, so the admin app does not
+ * depend on the smaller shared upload widget layout.
+ */
+export function SimpleImageUpload({
+  alt,
+  buttonLabel,
+  imageClassName,
+  imageWrapperClassName,
+  initialImageUrl,
+  placeholderClassName,
+  uploadAction,
+}: {
+  alt: string;
+  buttonLabel: string;
+  imageClassName: string;
+  imageWrapperClassName?: string;
+  initialImageUrl?: string | null;
+  placeholderClassName: string;
+  uploadAction: UploadAction;
+}) {
+  const [currentImageUrl, setCurrentImageUrl] = useState(initialImageUrl ?? null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const blobUrlRef = useRef<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    setError(null);
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    startTransition(async () => {
+      const result = await uploadAction(formData);
+
+      if (result.error) {
+        setError(result.error);
+      } else {
+        if (blobUrlRef.current) {
+          URL.revokeObjectURL(blobUrlRef.current);
+        }
+
+        const nextImageUrl = URL.createObjectURL(file);
+        blobUrlRef.current = nextImageUrl;
+        setCurrentImageUrl(nextImageUrl);
+      }
+
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      {currentImageUrl ? (
+        <div className={cn(imageWrapperClassName)}>
+          {/* oxlint-disable-next-line next/no-img-element -- internal admin preview needs direct blob URL support */}
+          <img alt={alt} className={imageClassName} src={currentImageUrl} />
+        </div>
+      ) : (
+        <div
+          className={cn(
+            "bg-muted text-muted-foreground flex items-center justify-center rounded-md",
+            placeholderClassName,
+          )}
+        >
+          <ImageIcon className="size-8" />
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <label className="w-fit">
+          <input
+            ref={fileInputRef}
+            accept={DEFAULT_IMAGE_ACCEPTED_TYPES.join(",")}
+            className="sr-only"
+            disabled={isPending}
+            onChange={handleUpload}
+            type="file"
+          />
+
+          <Button
+            disabled={isPending}
+            type="button"
+            variant="outline"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            {isPending ? (
+              <Loader2Icon className="size-4 animate-spin" />
+            ) : (
+              <UploadIcon className="size-4" />
+            )}
+            {buttonLabel}
+          </Button>
+        </label>
+
+        {error ? <p className="text-destructive text-sm">{error}</p> : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/step-select-image-edit.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/step-select-image-edit.tsx
@@ -1,19 +1,8 @@
 "use client";
 
 import { Badge } from "@zoonk/ui/components/badge";
-import {
-  ImageUploadActionButton,
-  ImageUploadLoading,
-  ImageUploadOverlay,
-  ImageUploadPlaceholder,
-  ImageUploadProvider,
-  ImageUploadTrigger,
-} from "@zoonk/ui/components/image-upload";
-import { ImageIcon, UploadIcon } from "lucide-react";
-import Image from "next/image";
 import { uploadStepImageAction } from "./_actions/step-image";
-
-const noopRemove = async () => ({ error: null });
+import { SimpleImageUpload } from "./simple-image-upload";
 
 function SelectImageOption({
   option,
@@ -28,43 +17,14 @@ function SelectImageOption({
 
   return (
     <div className="flex flex-col gap-2 rounded-md border p-3">
-      <ImageUploadProvider
-        currentImageUrl={option.url ?? null}
-        onRemove={noopRemove}
-        onUpload={uploadStepImageAction.bind(null, params)}
-      >
-        <ImageUploadTrigger
-          aria-label={
-            option.url
-              ? `Replace image for "${option.prompt}"`
-              : `Upload image for "${option.prompt}"`
-          }
-          className="aspect-square w-full"
-          size={undefined}
-        >
-          {option.url ? (
-            <Image
-              alt={option.prompt}
-              className="object-contain transition-opacity group-hover:opacity-80"
-              fill
-              sizes="300px"
-              src={option.url}
-            />
-          ) : (
-            <ImageUploadPlaceholder>
-              <ImageIcon />
-            </ImageUploadPlaceholder>
-          )}
-
-          <ImageUploadOverlay>
-            <ImageUploadActionButton>
-              <UploadIcon />
-            </ImageUploadActionButton>
-          </ImageUploadOverlay>
-
-          <ImageUploadLoading />
-        </ImageUploadTrigger>
-      </ImageUploadProvider>
+      <SimpleImageUpload
+        alt={option.prompt}
+        buttonLabel="Upload replacement image"
+        imageClassName="aspect-square w-full rounded-md object-contain"
+        initialImageUrl={option.url}
+        placeholderClassName="aspect-square w-full"
+        uploadAction={uploadStepImageAction.bind(null, params)}
+      />
 
       <p className="text-muted-foreground text-sm">{option.prompt}</p>
       <p className="text-muted-foreground text-xs italic">{option.feedback}</p>

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/step-visual-image-edit.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/step-visual-image-edit.tsx
@@ -1,19 +1,8 @@
 "use client";
 
 import { Badge } from "@zoonk/ui/components/badge";
-import {
-  ImageUploadActionButton,
-  ImageUploadLoading,
-  ImageUploadOverlay,
-  ImageUploadPlaceholder,
-  ImageUploadProvider,
-  ImageUploadTrigger,
-} from "@zoonk/ui/components/image-upload";
-import { ImageIcon, UploadIcon } from "lucide-react";
-import Image from "next/image";
 import { uploadStepImageAction } from "./_actions/step-image";
-
-const noopRemove = async () => ({ error: null });
+import { SimpleImageUpload } from "./simple-image-upload";
 
 export function StepVisualImageEdit({
   item,
@@ -35,39 +24,15 @@ export function StepVisualImageEdit({
 
       <p className="text-muted-foreground font-mono text-sm">{item.content.prompt}</p>
 
-      <ImageUploadProvider
-        currentImageUrl={item.content.url ?? null}
-        onRemove={noopRemove}
-        onUpload={uploadStepImageAction.bind(null, params)}
-      >
-        <ImageUploadTrigger
-          aria-label={item.content.url ? "Replace image" : "Upload image"}
-          className="h-96 w-full max-w-150"
-          size={undefined}
-        >
-          {item.content.url ? (
-            <Image
-              alt={item.content.prompt}
-              className="object-contain transition-opacity group-hover:opacity-80"
-              fill
-              sizes="600px"
-              src={item.content.url}
-            />
-          ) : (
-            <ImageUploadPlaceholder>
-              <ImageIcon />
-            </ImageUploadPlaceholder>
-          )}
-
-          <ImageUploadOverlay>
-            <ImageUploadActionButton>
-              <UploadIcon />
-            </ImageUploadActionButton>
-          </ImageUploadOverlay>
-
-          <ImageUploadLoading />
-        </ImageUploadTrigger>
-      </ImageUploadProvider>
+      <SimpleImageUpload
+        alt={item.content.prompt}
+        buttonLabel="Upload replacement image"
+        imageClassName="max-h-96 rounded-md object-contain"
+        imageWrapperClassName="flex justify-center"
+        initialImageUrl={item.content.url}
+        placeholderClassName="h-96 w-full max-w-[600px]"
+        uploadAction={uploadStepImageAction.bind(null, params)}
+      />
     </div>
   );
 }

--- a/apps/admin/src/app/(private)/review/[group]/[task]/unflag-action.ts
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/unflag-action.ts
@@ -1,12 +1,20 @@
 "use server";
 
 import { assertAdmin } from "@/lib/admin-guard";
+import { getTaskPath, isValidTaskType } from "@/lib/review-utils";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
 import { parseBigIntId } from "@zoonk/utils/number";
-import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
 
+/**
+ * Moves a flagged item back into the pending review queue.
+ *
+ * We delete the review row instead of updating its status because pending items
+ * are defined by the absence of a `contentReview` record. The delete must be
+ * idempotent so stale flagged pages or double submissions do not crash.
+ */
 export async function unflagAction(formData: FormData) {
   await assertAdmin();
 
@@ -15,13 +23,13 @@ export async function unflagAction(formData: FormData) {
 
   const entityId = entityIdRaw ? parseBigIntId(entityIdRaw) : null;
 
-  if (!taskType || !entityId) {
+  if (!taskType || !entityId || !isValidTaskType(taskType)) {
     throw new Error("Invalid form data");
   }
 
   const { error } = await safeAsync(() =>
-    prisma.contentReview.delete({
-      where: { taskEntity: { entityId, taskType } },
+    prisma.contentReview.deleteMany({
+      where: { entityId, taskType },
     }),
   );
 
@@ -29,5 +37,5 @@ export async function unflagAction(formData: FormData) {
     throw error;
   }
 
-  revalidatePath("/review");
+  redirect(`${getTaskPath(taskType)}?current=${entityId}`);
 }


### PR DESCRIPTION
## Summary
- make return-to-queue idempotent and redirect reviewers back into the pending queue
- replace the flagged image upload widget with a simple admin-only preview and upload button

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make “return to queue” idempotent and send reviewers back to the pending queue. Replace the shared image upload with a simple admin-only preview + upload, and revoke preview URLs to prevent memory leaks.

- **Bug Fixes**
  - Unflag uses an idempotent delete (`deleteMany`) with task type validation and redirects to the queue (`getTaskPath(taskType)?current=entityId`), preventing stale/double-submit errors.
  - Revokes preview blob URLs on unmount to avoid memory leaks when switching items.

- **Refactors**
  - Added `SimpleImageUpload` with a large preview and a native file input using `DEFAULT_IMAGE_ACCEPTED_TYPES`.
  - Replaced `@zoonk/ui/components/image-upload` in step editors with `SimpleImageUpload` to reduce complexity and improve review UX.

<sup>Written for commit 75686fcf76ea80fe2184550b5551381afd85001c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

