### PR TITLE
fix(ai): remove no-text instructions from step images

### DIFF
--- a/apps/evals/src/tasks/step-visual/test-cases.ts
+++ b/apps/evals/src/tasks/step-visual/test-cases.ts
@@ -37,25 +37,20 @@ You are evaluating the VISUAL DESCRIPTION stage — the model selects a visual k
    - Formula descriptions lack the actual equation
    - Image descriptions are vague (e.g., "an image about the topic")
 
-5. IMAGE TEXT CONTAMINATION: Image descriptions should describe ONLY the scene, objects, and composition — NOT text to display. PENALIZE if:
-   - An image description asks for labels, captions, signs, annotations, or visible text that isn't strictly necessary to understand the concept
-   - The only way to understand the described image is by reading text within it
-   - Exception: a single word or short phrase is acceptable when the concept genuinely requires it
-
-6. DIAGRAM COMPLEXITY: Diagrams should be focused and reveal non-obvious structure. PENALIZE if:
+5. DIAGRAM COMPLEXITY: Diagrams should be focused and reveal non-obvious structure. PENALIZE if:
    - A diagram description has more than 7 nodes
    - A diagram just restates the text as boxes with arrows
    - A diagram uses abstract platitude nodes connected by generic verbs
    - A diagram is used for a simple list (should be a table)
 
-7. LANGUAGE CONSISTENCY: All text in descriptions — including image descriptions — must match the specified language. PENALIZE any mixed-language content (except JSON field names and enum values like "chart", "table").
+6. LANGUAGE CONSISTENCY: All text in descriptions — including image descriptions — must match the specified language. PENALIZE any mixed-language content (except JSON field names and enum values like "chart", "table").
 
 ANTI-CHECKLIST GUIDANCE (CRITICAL):
 - Do NOT expect specific visual kinds based on topic
 - Do NOT penalize for using "image" as the kind
 - Do NOT penalize for using the same kind multiple times IF each adds unique information
 - Do NOT require variety in kinds
-- ONLY penalize for: redundant information, kind that cannot represent the content, vague descriptions, image text contamination, diagram overcomplexity, language errors, missing steps
+- ONLY penalize for: redundant information, kind that cannot represent the content, vague descriptions, diagram overcomplexity, language errors, missing steps
 `;
 
 export const TEST_CASES = [

--- a/packages/ai/src/tasks/steps/step-visual-descriptions.prompt.md
+++ b/packages/ai/src/tasks/steps/step-visual-descriptions.prompt.md
@@ -40,8 +40,6 @@ Choose the visual type that BEST fits each step's content:
 
 Use as the fallback when no other type fits the content.
 
-**CRITICAL: Descriptions for images must NOT include text.** Describe only the scene, objects, and composition. The image generator handles style. Do not ask for labels, captions, signs, annotations, or any visible text unless the concept genuinely cannot be understood without it. If text is absolutely necessary, keep it to a single word or short phrase and spell it exactly in the requested language with correct accents and diacritics.
-
 **Never generate an image of something another visual type can render directly.** Don't describe images of musical notation, sheet music, or notes on a staff — use the music kind instead. Don't describe images of code — use the code kind. Don't describe images of formulas — use the formula kind.
 
 **Vary your metaphors.** Don't repeat the same analogy across multiple steps (e.g., don't describe "people in a line" for 5 different queue steps). Each image should use a distinct visual metaphor or show a different aspect of the concept.
@@ -184,7 +182,7 @@ In your description, include: key, time signature, specific notes or patterns, a
 - **Formulas**: the actual equation with variable names, what it represents
 - **Music**: key, time signature, specific notes or patterns
 - **Quotes**: the exact quote text and its author
-- **Images**: physical scene details, objects, spatial arrangement. **No text unless absolutely necessary**
+- **Images**: physical scene details, objects, spatial arrangement.
 
 **Invent plausible values when the step is qualitative.** Steps often describe trends or observations without exact numbers. If a step says "values rise then fall," provide illustrative numbers that match the pattern. The visual illustrates the concept — plausible example values are expected.
 
@@ -211,7 +209,6 @@ Before finalizing, verify:
 4. **Self-contained descriptions**: Each description has enough detail for standalone generation
 5. **No redundancy**: No two descriptions repeat the same information
 6. **Language match**: All text content in descriptions matches the requested language
-7. **Image descriptions have no text**: Unless the concept genuinely requires it
-8. **No star-pattern diagrams**: If a diagram has one central node with leaf nodes all sharing the same edge label, replace it with a table
-9. **Diagram edges are unique**: Each edge in a diagram has a different, specific label. If most edges share the same label, it's a list — use a table
-10. **No trivially small diagrams**: A 2-node diagram with 1 edge adds nothing — use a different kind
+7. **No star-pattern diagrams**: If a diagram has one central node with leaf nodes all sharing the same edge label, replace it with a table
+8. **Diagram edges are unique**: Each edge in a diagram has a different, specific label. If most edges share the same label, it's a list — use a table
+9. **No trivially small diagrams**: A 2-node diagram with 1 edge adds nothing — use a different kind

--- a/packages/ai/src/tasks/steps/step-visual-image.prompt.md
+++ b/packages/ai/src/tasks/steps/step-visual-image.prompt.md
@@ -1,12 +1,8 @@
-Generate an educational illustration for a learning step.
+Generate an educational illustration for a learning course.
 
 Style: Modern flat illustration with clean geometric shapes, a refined limited color palette (2-4 harmonious colors with subtle tints and shades), generous white space, crisp edges without heavy outlines, subtle ambient shadows for depth, clean sans-serif typography when text is needed, balanced composition with clear visual hierarchy, educational and professional aesthetic, square format (1:1).
 
 The illustration should clearly communicate the educational concept while being visually engaging and easy to understand.
-
-Do not add labels, captions, signs, annotations, or other visible text unless the concept genuinely needs text to be understood. Prefer communicating the idea through objects, composition, and context.
-
-If text is necessary, use the minimum amount possible and spell it exactly in the requested language, with correct accents and other diacritics.
 
 LANGUAGE: **{{LANGUAGE}}**
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow step images to include text when helpful by removing the “no-text” restriction across prompts and evals. Image descriptions are no longer penalized for including text.

- **Refactors**
  - Removed “no visible text” guidance from `packages/ai/src/tasks/steps/step-visual-descriptions.prompt.md` and `packages/ai/src/tasks/steps/step-visual-image.prompt.md`
  - Updated `apps/evals/src/tasks/step-visual/test-cases.ts` to drop the IMAGE TEXT CONTAMINATION rule and renumber checks
  - Kept language consistency checks; evaluators and generators can now allow minimal text when the concept needs it

<sup>Written for commit 5d905d0dca6e2b31ecb46909ba0445603af8f005. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

