### PR TITLE
fix(admin): avoid blob urls in review image preview

### DIFF
--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/step-image.ts
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/step-image.ts
@@ -14,22 +14,22 @@ export async function uploadStepImageAction(
     imageTarget: "visual" | number;
   },
   formData: FormData,
-): Promise<{ error: string | null }> {
+): Promise<{ error: string | null; imageUrl: string | null }> {
   if (!(await isAdmin())) {
-    return { error: "Unauthorized" };
+    return { error: "Unauthorized", imageUrl: null };
   }
 
   const stepId = parseBigIntId(params.stepId);
 
   if (!stepId) {
-    return { error: "Invalid step ID" };
+    return { error: "Invalid step ID", imageUrl: null };
   }
 
   const { imageTarget } = params;
   const file = formData.get("file");
 
   if (!(file && file instanceof File)) {
-    return { error: "No file provided" };
+    return { error: "No file provided", imageUrl: null };
   }
 
   const targetLabel = imageTarget === "visual" ? "visual" : `option-${imageTarget}`;
@@ -46,13 +46,13 @@ export async function uploadStepImageAction(
       uploadFailed: "Failed to upload image. Please try again.",
     };
 
-    return { error: errorMessages[uploadError] };
+    return { error: errorMessages[uploadError], imageUrl: null };
   }
 
   const step = await prisma.step.findUnique({ where: { id: stepId } });
 
   if (!step) {
-    return { error: "Step not found" };
+    return { error: "Step not found", imageUrl: null };
   }
 
   const { error: updateError } = await safeAsync(() => {
@@ -76,9 +76,9 @@ export async function uploadStepImageAction(
   });
 
   if (updateError) {
-    return { error: "Failed to update step. Please try again." };
+    return { error: "Failed to update step. Please try again.", imageUrl: null };
   }
 
   revalidatePath("/review");
-  return { error: null };
+  return { error: null, imageUrl };
 }

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/simple-image-upload.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/simple-image-upload.tsx
@@ -4,9 +4,12 @@ import { Button } from "@zoonk/ui/components/button";
 import { cn } from "@zoonk/ui/lib/utils";
 import { DEFAULT_IMAGE_ACCEPTED_TYPES } from "@zoonk/utils/upload";
 import { ImageIcon, Loader2Icon, UploadIcon } from "lucide-react";
-import { useEffect, useRef, useState, useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
 
-type UploadAction = (formData: FormData) => Promise<{ error: string | null }>;
+type UploadAction = (formData: FormData) => Promise<{
+  error: string | null;
+  imageUrl: string | null;
+}>;
 
 /**
  * Keeps the admin review image editing flow simple.
@@ -36,19 +39,15 @@ export function SimpleImageUpload({
   const [currentImageUrl, setCurrentImageUrl] = useState(initialImageUrl ?? null);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
-  const blobUrlRef = useRef<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(
-    () => () => {
-      if (blobUrlRef.current) {
-        URL.revokeObjectURL(blobUrlRef.current);
-      }
-    },
-    [],
-  );
-
-  const handleUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+  /**
+   * Replaces the preview with the URL returned by the server after upload.
+   *
+   * This keeps the admin UI aligned with the optimized asset we actually stored
+   * instead of rendering a local blob URL derived from the raw user-selected file.
+   */
+  function handleUpload(event: React.ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
 
     if (!file) {
@@ -65,27 +64,21 @@ export function SimpleImageUpload({
 
       if (result.error) {
         setError(result.error);
-      } else {
-        if (blobUrlRef.current) {
-          URL.revokeObjectURL(blobUrlRef.current);
-        }
-
-        const nextImageUrl = URL.createObjectURL(file);
-        blobUrlRef.current = nextImageUrl;
-        setCurrentImageUrl(nextImageUrl);
+      } else if (result.imageUrl) {
+        setCurrentImageUrl(result.imageUrl);
       }
 
       if (fileInputRef.current) {
         fileInputRef.current.value = "";
       }
     });
-  };
+  }
 
   return (
     <div className="flex flex-col gap-3">
       {currentImageUrl ? (
         <div className={cn(imageWrapperClassName)}>
-          {/* oxlint-disable-next-line next/no-img-element -- internal admin preview needs direct blob URL support */}
+          {/* oxlint-disable-next-line next/no-img-element -- internal admin review preview does not need next/image optimization */}
           <img alt={alt} className={imageClassName} src={currentImageUrl} />
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- return the persisted image url from the admin review upload action
- render the stored image url in the preview instead of a local blob url

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the stored image URL for admin review previews instead of local blob URLs. This makes the preview match the saved asset and avoids blob URL issues.

- **Bug Fixes**
  - Upload action returns `imageUrl` along with `error`.
  - Preview renders the persisted `imageUrl` instead of `URL.createObjectURL` blobs.
  - Removed blob URL cleanup logic and updated types; input is reset after upload.

<sup>Written for commit bd9ef3fc42a2a356beef8f05e8e243306c8698c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

