### PR TITLE
feat(player): show activity title and lesson info in player header

### DIFF
--- a/apps/main/e2e/activity-detail.test.ts
+++ b/apps/main/e2e/activity-detail.test.ts
@@ -136,7 +136,7 @@ test.describe("Activity Detail Page", () => {
     await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/0`);
 
     await expect(page.getByRole("link", { name: /close/i })).toBeVisible();
-    await expect(page.getByText(/1 \/ 1/)).toBeVisible();
+    await expect(page.getByRole("button", { name: /lesson info/i })).toBeVisible();
 
     const progressbar = page.getByRole("progressbar", { name: /activity progress/i });
     await expect(progressbar).toBeVisible();

--- a/apps/main/e2e/step-visual-content.test.ts
+++ b/apps/main/e2e/step-visual-content.test.ts
@@ -403,7 +403,7 @@ test.describe("Visual Step Content", () => {
       await expect(page.getByRole("figure", { name: /diagram/i })).toBeVisible();
     }).toPass();
 
-    await expect(page.getByText(/1 \/ 2/)).toBeVisible();
+    await expect(page.getByRole("button", { name: /lesson info/i })).toBeVisible();
 
     await page.waitForLoadState("networkidle");
 
@@ -413,8 +413,6 @@ test.describe("Visual Step Content", () => {
         page.getByRole("heading", { name: new RegExp(`Diagram Step2 ${uniqueId}`) }),
       ).toBeVisible();
     }).toPass();
-
-    await expect(page.getByText(/2 \/ 2/)).toBeVisible();
   });
 
   test("visual step renders code and language label", async ({ page }) => {
@@ -474,7 +472,7 @@ test.describe("Visual Step Content", () => {
       await expect(page.getByRole("figure", { name: /typescript/i })).toBeVisible();
     }).toPass();
 
-    await expect(page.getByText(/1 \/ 2/)).toBeVisible();
+    await expect(page.getByRole("button", { name: /lesson info/i })).toBeVisible();
 
     await page.waitForLoadState("networkidle");
 
@@ -484,8 +482,6 @@ test.describe("Visual Step Content", () => {
         page.getByRole("heading", { name: new RegExp(`Code Step2 ${uniqueId}`) }),
       ).toBeVisible();
     }).toPass();
-
-    await expect(page.getByText(/2 \/ 2/)).toBeVisible();
   });
 
   test("visual step renders table headers and cell data", async ({ page }) => {
@@ -679,7 +675,7 @@ test.describe("Visual Step Content", () => {
     await expect(
       page.getByRole("columnheader", { name: new RegExp(`Col A ${uniqueId}`) }),
     ).toBeVisible();
-    await expect(page.getByText(/1 \/ 2/)).toBeVisible();
+    await expect(page.getByRole("button", { name: /lesson info/i })).toBeVisible();
 
     await page.waitForLoadState("networkidle");
 
@@ -689,8 +685,6 @@ test.describe("Visual Step Content", () => {
         page.getByRole("heading", { name: new RegExp(`Table Step2 ${uniqueId}`) }),
       ).toBeVisible();
     }).toPass();
-
-    await expect(page.getByText(/2 \/ 2/)).toBeVisible();
   });
 
   test("visual step renders timeline event dates, titles, and descriptions", async ({ page }) => {
@@ -782,7 +776,7 @@ test.describe("Visual Step Content", () => {
     await page.goto(url);
 
     await expect(page.getByRole("figure", { name: /timeline/i })).toBeVisible();
-    await expect(page.getByText(/1 \/ 2/)).toBeVisible();
+    await expect(page.getByRole("button", { name: /lesson info/i })).toBeVisible();
 
     await page.waitForLoadState("networkidle");
 
@@ -792,8 +786,6 @@ test.describe("Visual Step Content", () => {
         page.getByRole("heading", { name: new RegExp(`Timeline Step2 ${uniqueId}`) }),
       ).toBeVisible();
     }).toPass();
-
-    await expect(page.getByText(/2 \/ 2/)).toBeVisible();
   });
 
   test("visual step renders bar chart title and category labels", async ({ page }) => {
@@ -937,7 +929,7 @@ test.describe("Visual Step Content", () => {
       await expect(page.getByRole("figure", { name: chartTitle })).toBeVisible();
     }).toPass();
 
-    await expect(page.getByText(/1 \/ 2/)).toBeVisible();
+    await expect(page.getByRole("button", { name: /lesson info/i })).toBeVisible();
 
     await page.waitForLoadState("networkidle");
 
@@ -947,8 +939,6 @@ test.describe("Visual Step Content", () => {
         page.getByRole("heading", { name: new RegExp(`Chart Step2 ${uniqueId}`) }),
       ).toBeVisible();
     }).toPass();
-
-    await expect(page.getByText(/2 \/ 2/)).toBeVisible();
   });
 
   test("visual step renders code annotations", async ({ page }) => {
@@ -1035,7 +1025,7 @@ test.describe("Visual Step Content", () => {
       await expect(page.getByRole("figure", { name: description })).toBeVisible();
     }).toPass();
 
-    await expect(page.getByText(/1 \/ 2/)).toBeVisible();
+    await expect(page.getByRole("button", { name: /lesson info/i })).toBeVisible();
 
     await page.waitForLoadState("networkidle");
 
@@ -1045,7 +1035,5 @@ test.describe("Visual Step Content", () => {
         page.getByRole("heading", { name: new RegExp(`Formula Next ${uniqueId}`) }),
       ).toBeVisible();
     }).toPass();
-
-    await expect(page.getByText(/2 \/ 2/)).toBeVisible();
   });
 });

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -261,6 +261,11 @@ msgctxt "kW2sOl"
 msgid "Collect 2 leads. Then make your call."
 msgstr "Collect 2 leads. Then make your call."
 
+#: ../../packages/player/src/components/lesson-info-popover.tsx
+msgctxt "RwePAQ"
+msgid "Lesson info"
+msgstr "Lesson info"
+
 #: ../../packages/player/src/components/listening-step.tsx
 #: ../../packages/player/src/components/reading-step.tsx
 msgctxt "19nXyC"
@@ -438,10 +443,79 @@ msgid "Timeline"
 msgstr "Timeline"
 
 #: ../../packages/player/src/components/vocabulary-step.tsx
+#: ../../packages/player/src/use-activity-kind-label.ts
 #: src/lib/activities.ts
 msgctxt "lqtP+R"
 msgid "Vocabulary"
 msgstr "Vocabulary"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "/vCXIP"
+msgid "Translation"
+msgstr "Translation"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "1TOMnj"
+msgid "Listening"
+msgstr "Listening"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "Bfq+7w"
+msgid "Story"
+msgstr "Story"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "E1bF/X"
+msgid "Explanation"
+msgstr "Explanation"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "KV+O0y"
+msgid "Practice"
+msgstr "Practice"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "MOK/yK"
+msgid "Reading"
+msgstr "Reading"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "OuR/Ij"
+msgid "Quiz"
+msgstr "Quiz"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "QzTY8x"
+msgid "Grammar"
+msgstr "Grammar"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/components/catalog/continue-activity-link.tsx
+#: src/lib/activities.ts
+msgctxt "R+J5ox"
+msgid "Review"
+msgstr "Review"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "tNseQe"
+msgid "Investigation"
+msgstr "Investigation"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/app/(catalog)/(home)/continue-learning-card.tsx
+#: src/app/generate/a/[id]/generate-activity-content.tsx
+msgctxt "ZmlNQ3"
+msgid "Activity"
+msgstr "Activity"
 
 #: ../../packages/player/src/use-belt-color-label.ts
 #: src/lib/belt-colors.ts
@@ -688,12 +762,6 @@ msgstr "{period} with {value}%"
 msgctxt "TyANVg"
 msgid "Next: {activity}"
 msgstr "Next: {activity}"
-
-#: src/app/(catalog)/(home)/continue-learning-card.tsx
-#: src/app/generate/a/[id]/generate-activity-content.tsx
-msgctxt "ZmlNQ3"
-msgid "Activity"
-msgstr "Activity"
 
 #: src/app/(catalog)/(home)/continue-learning.tsx
 msgctxt "0X+xfW"
@@ -2641,12 +2709,6 @@ msgctxt "mOFG3K"
 msgid "Start"
 msgstr "Start"
 
-#: src/components/catalog/continue-activity-link.tsx
-#: src/lib/activities.ts
-msgctxt "R+J5ox"
-msgid "Review"
-msgstr "Review"
-
 #: src/components/feedback/contact-form.tsx
 msgctxt "+5vOOu"
 msgid "Please provide as much detail as possible."
@@ -2733,34 +2795,14 @@ msgid "Creating content with AI requires an active subscription."
 msgstr "Creating content with AI requires an active subscription."
 
 #: src/lib/activities.ts
-msgctxt "/vCXIP"
-msgid "Translation"
-msgstr "Translation"
-
-#: src/lib/activities.ts
-msgctxt "1TOMnj"
-msgid "Listening"
-msgstr "Listening"
-
-#: src/lib/activities.ts
 msgctxt "3198Ew"
 msgid "Learn new {topic} words with flashcards — see each word, its translation, and pronunciation."
 msgstr "Learn new {topic} words with flashcards — see each word, its translation, and pronunciation."
 
 #: src/lib/activities.ts
-msgctxt "Bfq+7w"
-msgid "Story"
-msgstr "Story"
-
-#: src/lib/activities.ts
 msgctxt "bzFQEy"
 msgid "Review everything you learned about {topic} with a comprehensive quiz."
 msgstr "Review everything you learned about {topic} with a comprehensive quiz."
-
-#: src/lib/activities.ts
-msgctxt "E1bF/X"
-msgid "Explanation"
-msgstr "Explanation"
 
 #: src/lib/activities.ts
 msgctxt "gAYlHX"
@@ -2773,11 +2815,6 @@ msgid "Test your understanding of {topic} with questions designed to check real 
 msgstr "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
 
 #: src/lib/activities.ts
-msgctxt "KV+O0y"
-msgid "Practice"
-msgstr "Practice"
-
-#: src/lib/activities.ts
 msgctxt "lLtcKR"
 msgid "Investigate {topic} by gathering evidence, evaluating findings, and drawing your own conclusions."
 msgstr "Investigate {topic} by gathering evidence, evaluating findings, and drawing your own conclusions."
@@ -2788,24 +2825,9 @@ msgid "{lesson} {activity}"
 msgstr "{lesson} {activity}"
 
 #: src/lib/activities.ts
-msgctxt "MOK/yK"
-msgid "Reading"
-msgstr "Reading"
-
-#: src/lib/activities.ts
-msgctxt "OuR/Ij"
-msgid "Quiz"
-msgstr "Quiz"
-
-#: src/lib/activities.ts
 msgctxt "pDtxFt"
 msgid "Test your {topic} vocabulary by translating words you've learned."
 msgstr "Test your {topic} vocabulary by translating words you've learned."
-
-#: src/lib/activities.ts
-msgctxt "QzTY8x"
-msgid "Grammar"
-msgstr "Grammar"
 
 #: src/lib/activities.ts
 msgctxt "RtjVBh"
@@ -2826,11 +2848,6 @@ msgstr "Understand what {topic} is — core concepts and definitions explained w
 msgctxt "tlgfSZ"
 msgid "Practice {topic} grammar rules with exercises designed to help you remember and apply them."
 msgstr "Practice {topic} grammar rules with exercises designed to help you remember and apply them."
-
-#: src/lib/activities.ts
-msgctxt "tNseQe"
-msgid "Investigation"
-msgstr "Investigation"
 
 #: src/lib/activities.ts
 msgctxt "UDijXW"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -261,6 +261,11 @@ msgctxt "kW2sOl"
 msgid "Collect 2 leads. Then make your call."
 msgstr "Consigue 2 evidencias y luego toma tu decisión."
 
+#: ../../packages/player/src/components/lesson-info-popover.tsx
+msgctxt "RwePAQ"
+msgid "Lesson info"
+msgstr "Información de la lección"
+
 #: ../../packages/player/src/components/listening-step.tsx
 #: ../../packages/player/src/components/reading-step.tsx
 msgctxt "19nXyC"
@@ -438,10 +443,79 @@ msgid "Timeline"
 msgstr "Línea de tiempo"
 
 #: ../../packages/player/src/components/vocabulary-step.tsx
+#: ../../packages/player/src/use-activity-kind-label.ts
 #: src/lib/activities.ts
 msgctxt "lqtP+R"
 msgid "Vocabulary"
 msgstr "Vocabulario"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "/vCXIP"
+msgid "Translation"
+msgstr "Traducción"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "1TOMnj"
+msgid "Listening"
+msgstr "Escucha"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "Bfq+7w"
+msgid "Story"
+msgstr "Historia"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "E1bF/X"
+msgid "Explanation"
+msgstr "Explicación"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "KV+O0y"
+msgid "Practice"
+msgstr "Practica"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "MOK/yK"
+msgid "Reading"
+msgstr "Lectura"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "OuR/Ij"
+msgid "Quiz"
+msgstr "Cuestionario"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "QzTY8x"
+msgid "Grammar"
+msgstr "Gramática"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/components/catalog/continue-activity-link.tsx
+#: src/lib/activities.ts
+msgctxt "R+J5ox"
+msgid "Review"
+msgstr "Repaso"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "tNseQe"
+msgid "Investigation"
+msgstr "Investigación"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/app/(catalog)/(home)/continue-learning-card.tsx
+#: src/app/generate/a/[id]/generate-activity-content.tsx
+msgctxt "ZmlNQ3"
+msgid "Activity"
+msgstr "Actividad"
 
 #: ../../packages/player/src/use-belt-color-label.ts
 #: src/lib/belt-colors.ts
@@ -688,12 +762,6 @@ msgstr "{period} con {value}%"
 msgctxt "TyANVg"
 msgid "Next: {activity}"
 msgstr "Siguiente: {activity}"
-
-#: src/app/(catalog)/(home)/continue-learning-card.tsx
-#: src/app/generate/a/[id]/generate-activity-content.tsx
-msgctxt "ZmlNQ3"
-msgid "Activity"
-msgstr "Actividad"
 
 #: src/app/(catalog)/(home)/continue-learning.tsx
 msgctxt "0X+xfW"
@@ -2641,12 +2709,6 @@ msgctxt "mOFG3K"
 msgid "Start"
 msgstr "Comenzar"
 
-#: src/components/catalog/continue-activity-link.tsx
-#: src/lib/activities.ts
-msgctxt "R+J5ox"
-msgid "Review"
-msgstr "Repaso"
-
 #: src/components/feedback/contact-form.tsx
 msgctxt "+5vOOu"
 msgid "Please provide as much detail as possible."
@@ -2733,34 +2795,14 @@ msgid "Creating content with AI requires an active subscription."
 msgstr "Crear contenido con IA requiere una suscripción activa."
 
 #: src/lib/activities.ts
-msgctxt "/vCXIP"
-msgid "Translation"
-msgstr "Traducción"
-
-#: src/lib/activities.ts
-msgctxt "1TOMnj"
-msgid "Listening"
-msgstr "Escucha"
-
-#: src/lib/activities.ts
 msgctxt "3198Ew"
 msgid "Learn new {topic} words with flashcards — see each word, its translation, and pronunciation."
 msgstr "Aprende nuevas palabras de {topic} con tarjetas didácticas — ve cada palabra, su traducción y pronunciación."
 
 #: src/lib/activities.ts
-msgctxt "Bfq+7w"
-msgid "Story"
-msgstr "Historia"
-
-#: src/lib/activities.ts
 msgctxt "bzFQEy"
 msgid "Review everything you learned about {topic} with a comprehensive quiz."
 msgstr "Repasa todo lo que aprendiste sobre {topic} con un cuestionario completo."
-
-#: src/lib/activities.ts
-msgctxt "E1bF/X"
-msgid "Explanation"
-msgstr "Explicación"
 
 #: src/lib/activities.ts
 msgctxt "gAYlHX"
@@ -2773,11 +2815,6 @@ msgid "Test your understanding of {topic} with questions designed to check real 
 msgstr "Pon a prueba tu comprensión de {topic} con preguntas diseñadas para verificar la comprensión real, no solo la memorización."
 
 #: src/lib/activities.ts
-msgctxt "KV+O0y"
-msgid "Practice"
-msgstr "Practica"
-
-#: src/lib/activities.ts
 msgctxt "lLtcKR"
 msgid "Investigate {topic} by gathering evidence, evaluating findings, and drawing your own conclusions."
 msgstr "Investiga {topic} reuniendo evidencia, evaluando hallazgos y sacando tus propias conclusiones."
@@ -2788,24 +2825,9 @@ msgid "{lesson} {activity}"
 msgstr "{activity}: {lesson}"
 
 #: src/lib/activities.ts
-msgctxt "MOK/yK"
-msgid "Reading"
-msgstr "Lectura"
-
-#: src/lib/activities.ts
-msgctxt "OuR/Ij"
-msgid "Quiz"
-msgstr "Cuestionario"
-
-#: src/lib/activities.ts
 msgctxt "pDtxFt"
 msgid "Test your {topic} vocabulary by translating words you've learned."
 msgstr "Pon a prueba tu vocabulario de {topic} traduciendo las palabras que aprendiste."
-
-#: src/lib/activities.ts
-msgctxt "QzTY8x"
-msgid "Grammar"
-msgstr "Gramática"
 
 #: src/lib/activities.ts
 msgctxt "RtjVBh"
@@ -2826,11 +2848,6 @@ msgstr "Entiende qué es {topic}: conceptos centrales y definiciones explicados 
 msgctxt "tlgfSZ"
 msgid "Practice {topic} grammar rules with exercises designed to help you remember and apply them."
 msgstr "Practica las reglas gramaticales de {topic} con ejercicios diseñados para ayudarte a recordarlas y aplicarlas."
-
-#: src/lib/activities.ts
-msgctxt "tNseQe"
-msgid "Investigation"
-msgstr "Investigación"
 
 #: src/lib/activities.ts
 msgctxt "UDijXW"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -261,6 +261,11 @@ msgctxt "kW2sOl"
 msgid "Collect 2 leads. Then make your call."
 msgstr "Colete duas evidências e tire sua conclusão."
 
+#: ../../packages/player/src/components/lesson-info-popover.tsx
+msgctxt "RwePAQ"
+msgid "Lesson info"
+msgstr "Informações da aula"
+
 #: ../../packages/player/src/components/listening-step.tsx
 #: ../../packages/player/src/components/reading-step.tsx
 msgctxt "19nXyC"
@@ -438,10 +443,79 @@ msgid "Timeline"
 msgstr "Linha do tempo"
 
 #: ../../packages/player/src/components/vocabulary-step.tsx
+#: ../../packages/player/src/use-activity-kind-label.ts
 #: src/lib/activities.ts
 msgctxt "lqtP+R"
 msgid "Vocabulary"
 msgstr "Vocabulário"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "/vCXIP"
+msgid "Translation"
+msgstr "Tradução"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "1TOMnj"
+msgid "Listening"
+msgstr "Escuta"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "Bfq+7w"
+msgid "Story"
+msgstr "História"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "E1bF/X"
+msgid "Explanation"
+msgstr "Explicação"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "KV+O0y"
+msgid "Practice"
+msgstr "Praticar"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "MOK/yK"
+msgid "Reading"
+msgstr "Leitura"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "OuR/Ij"
+msgid "Quiz"
+msgstr "Quiz"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "QzTY8x"
+msgid "Grammar"
+msgstr "Gramática"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/components/catalog/continue-activity-link.tsx
+#: src/lib/activities.ts
+msgctxt "R+J5ox"
+msgid "Review"
+msgstr "Revisão"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/lib/activities.ts
+msgctxt "tNseQe"
+msgid "Investigation"
+msgstr "Investigação"
+
+#: ../../packages/player/src/use-activity-kind-label.ts
+#: src/app/(catalog)/(home)/continue-learning-card.tsx
+#: src/app/generate/a/[id]/generate-activity-content.tsx
+msgctxt "ZmlNQ3"
+msgid "Activity"
+msgstr "Atividade"
 
 #: ../../packages/player/src/use-belt-color-label.ts
 #: src/lib/belt-colors.ts
@@ -688,12 +762,6 @@ msgstr "{period} com {value}%"
 msgctxt "TyANVg"
 msgid "Next: {activity}"
 msgstr "Próximo: {activity}"
-
-#: src/app/(catalog)/(home)/continue-learning-card.tsx
-#: src/app/generate/a/[id]/generate-activity-content.tsx
-msgctxt "ZmlNQ3"
-msgid "Activity"
-msgstr "Atividade"
 
 #: src/app/(catalog)/(home)/continue-learning.tsx
 msgctxt "0X+xfW"
@@ -2641,12 +2709,6 @@ msgctxt "mOFG3K"
 msgid "Start"
 msgstr "Começar"
 
-#: src/components/catalog/continue-activity-link.tsx
-#: src/lib/activities.ts
-msgctxt "R+J5ox"
-msgid "Review"
-msgstr "Revisão"
-
 #: src/components/feedback/contact-form.tsx
 msgctxt "+5vOOu"
 msgid "Please provide as much detail as possible."
@@ -2733,34 +2795,14 @@ msgid "Creating content with AI requires an active subscription."
 msgstr "Criar conteúdo com IA requer uma assinatura ativa."
 
 #: src/lib/activities.ts
-msgctxt "/vCXIP"
-msgid "Translation"
-msgstr "Tradução"
-
-#: src/lib/activities.ts
-msgctxt "1TOMnj"
-msgid "Listening"
-msgstr "Escuta"
-
-#: src/lib/activities.ts
 msgctxt "3198Ew"
 msgid "Learn new {topic} words with flashcards — see each word, its translation, and pronunciation."
 msgstr "Aprenda novas palavras de {topic} com flashcards — veja cada palavra, sua tradução e pronúncia."
 
 #: src/lib/activities.ts
-msgctxt "Bfq+7w"
-msgid "Story"
-msgstr "História"
-
-#: src/lib/activities.ts
 msgctxt "bzFQEy"
 msgid "Review everything you learned about {topic} with a comprehensive quiz."
 msgstr "Revise tudo que você aprendeu sobre {topic} com um quiz abrangente."
-
-#: src/lib/activities.ts
-msgctxt "E1bF/X"
-msgid "Explanation"
-msgstr "Explicação"
 
 #: src/lib/activities.ts
 msgctxt "gAYlHX"
@@ -2773,11 +2815,6 @@ msgid "Test your understanding of {topic} with questions designed to check real 
 msgstr "Teste sua compreensão de {topic} com perguntas projetadas para verificar compreensão real, não apenas memorização."
 
 #: src/lib/activities.ts
-msgctxt "KV+O0y"
-msgid "Practice"
-msgstr "Praticar"
-
-#: src/lib/activities.ts
 msgctxt "lLtcKR"
 msgid "Investigate {topic} by gathering evidence, evaluating findings, and drawing your own conclusions."
 msgstr "Investigue {topic} reunindo evidências, avaliando os resultados e tirando suas próprias conclusões."
@@ -2788,24 +2825,9 @@ msgid "{lesson} {activity}"
 msgstr "{activity}: {lesson}"
 
 #: src/lib/activities.ts
-msgctxt "MOK/yK"
-msgid "Reading"
-msgstr "Leitura"
-
-#: src/lib/activities.ts
-msgctxt "OuR/Ij"
-msgid "Quiz"
-msgstr "Quiz"
-
-#: src/lib/activities.ts
 msgctxt "pDtxFt"
 msgid "Test your {topic} vocabulary by translating words you've learned."
 msgstr "Teste seu vocabulário de {topic} traduzindo palavras que você aprendeu."
-
-#: src/lib/activities.ts
-msgctxt "QzTY8x"
-msgid "Grammar"
-msgstr "Gramática"
 
 #: src/lib/activities.ts
 msgctxt "RtjVBh"
@@ -2826,11 +2848,6 @@ msgstr "Entenda o que é {topic} — conceitos centrais e definições explicado
 msgctxt "tlgfSZ"
 msgid "Practice {topic} grammar rules with exercises designed to help you remember and apply them."
 msgstr "Pratique regras gramaticais de {topic} com exercícios projetados pra te ajudar a lembrar e aplicar elas."
-
-#: src/lib/activities.ts
-msgctxt "tNseQe"
-msgid "Investigation"
-msgstr "Investigação"
 
 #: src/lib/activities.ts
 msgctxt "UDijXW"

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-player-client.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-player-client.tsx
@@ -13,10 +13,13 @@ import { submitCompletion } from "./submit-completion-action";
 export function ActivityPlayerClient({
   activity,
   brandSlug,
+  chapterTitle,
   courseSlug,
   chapterSlug,
   isAuthenticated,
+  lessonDescription,
   lessonSlug,
+  lessonTitle,
   nextActivity,
   nextSibling,
   totalBrainPower,
@@ -25,10 +28,13 @@ export function ActivityPlayerClient({
 }: {
   activity: SerializedActivity;
   brandSlug: string;
+  chapterTitle: string;
   courseSlug: string;
   chapterSlug: string;
   isAuthenticated: boolean;
+  lessonDescription: string;
   lessonSlug: string;
+  lessonTitle: string;
   nextActivity: {
     chapterSlug: string;
     lessonSlug: string;
@@ -66,6 +72,9 @@ export function ActivityPlayerClient({
   return (
     <PlayerProvider
       activity={activity}
+      chapterTitle={chapterTitle}
+      lessonDescription={lessonDescription}
+      lessonTitle={lessonTitle}
       milestone={model.milestone}
       navigation={model.navigation}
       onComplete={handleComplete}

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/loading.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/loading.tsx
@@ -5,7 +5,7 @@ export default function ActivityPlayerLoading() {
     <main className="flex min-h-dvh flex-col">
       <header className="flex items-center justify-between px-3 py-1.5 sm:p-4">
         <Skeleton className="size-9 rounded-full" />
-        <Skeleton className="h-4 w-12" />
+        <Skeleton className="h-4 w-24" />
       </header>
 
       <Skeleton className="h-0.5 w-full rounded-none" />

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
@@ -119,10 +119,13 @@ export default async function ActivityPage({ params }: Props) {
     <ActivityPlayerClient
       activity={serialized}
       brandSlug={brandSlug}
+      chapterTitle={lesson.chapter.title}
       courseSlug={courseSlug}
       chapterSlug={chapterSlug}
       isAuthenticated={Boolean(session)}
+      lessonDescription={lesson.description}
       lessonSlug={lessonSlug}
+      lessonTitle={lesson.title}
       nextActivity={nextActivity}
       nextSibling={nextSibling}
       totalBrainPower={totalBrainPower}

--- a/i18n.lock
+++ b/i18n.lock
@@ -206,7 +206,6 @@ checksums:
     Level%20progress/singular: 286f095acd17006787247db0b69270e3
     "%7Bvalue%7D%20BP%20to%20level%20up/singular": 755c2fe6e435645cb35b57bf92af09d3
     "%7Bcolor%7D%20Belt%20%E2%80%94%20Level%20%7Blevel%7D/singular": 367f2e902d39199c8507aaad09e8907a
-    Answer%20options/singular: acb0b378cefcb8a8d50a7c43ce77ae39
     Next/singular: 89ddbcf710eba274963494f312bdc8a9
     Login/singular: f4f219abeb5a465ecb1c7efaf50246de
     All%20Activities/singular: 9eee26b7ca58444c6d0db6bcd7ea7eda
@@ -230,10 +229,21 @@ checksums:
     Blank%20%7Bposition%7D%3A%20%7Bitem%7D.%20%7Bresult%7D./singular: c64e721cdd1e4cc48eff9f9690f1fc6b
     Blank%20%7Bposition%7D%3A%20%7Bitem%7D.%20Tap%20to%20remove./singular: d7ab9b86256fae5fbb5187fe718afe0b
     Correct%20answer%3A%20%7Banswer%7D/singular: 7745b2664e841dffff4568203ee443b2
+    Translation/singular: 9276816e7bc1a6ff00f388faa0863986
+    Listening/singular: 9e680c44cd88a178b953349ed8881ef2
+    Story/singular: fabac3f62af801d429e2cd7115bf14c9
+    Explanation/singular: f6b595df4ffb1a5b0cbbe1dda5993522
+    Practice/singular: ea10afa88a3687e6c40d1bfb3e0f4f20
+    Vocabulary/singular: 2c8127af4c194fa05463e82d5e414c62
+    Reading/singular: 9d93f1dff4a01a9e1566f23b401b8868
+    Quiz/singular: 22bce287f7a90d3b41b418108eaab43b
+    Grammar/singular: 1d97aca351a45df1d6eb27adbee04832
+    Review/singular: 299f75db25382980b2895622d7712927
+    Investigation/singular: 89bc005c971ce9ded2848561258095d8
+    Activity/singular: 1948763de8e531483a798b68195e297e
     Answer%20feedback/singular: 9ec80a1e5b591c3d6c790b8d43266c0f
     Evidence%20complete%20%E2%80%94%20time%20to%20make%20your%20call./singular: 6f1a545162b4f3799dab45247dfc5f35
     Weak%20signal/singular: 19b95e7dfa1cb1c1f257f1812720859f
-    What%20do%20you%20want%20to%20investigate%20next%3F/singular: 9ddcec8a58615e2d5c501f12c091c1dc
     One%20more%20lead%20to%20follow/singular: 8f719bae5f33676aa045aed39b080f46
     Useful%20clue/singular: 9ae26309bb851fc48999bc8455ed8f88
     What%20do%20you%20want%20to%20investigate%20first%3F/singular: 84bfc285b668f4dc31f58cb56a7d7978
@@ -242,6 +252,8 @@ checksums:
     What%20do%20you%20think%20happened%3F/singular: 5fcc4c51ba3f52e459f316ef4b5fc756
     Review%20evidence/singular: 7edeeb02b39b1ebd65fe36986bd63407
     The%20Case/singular: da25531981c47e8d30f64ac4e5f954d8
+    Collect%202%20leads.%20Then%20make%20your%20call./singular: bf64acfc31f90c0cdfbb4e9593af265d
+    Lesson%20info/singular: fa3040672119e9b5babd1a8d54bd7d17
     Translate%20this%20sentence%3A/singular: f69b2eec827b3a74bafca50e9058716f
     What%20do%20you%20hear%3F/singular: 9527d094d65c550a40108673bc67744f
     All%20pairs%20matched.%20Press%20Check%20to%20continue./singular: 0663e33ba7db53b298c5f50a2f3c7ae8
@@ -250,19 +262,20 @@ checksums:
     Previous%20step/singular: 96b31ec6dab003c2bbfbbca10a8a9826
     Next%20step/singular: 712c63650b5180cbc14d6246b5d558c2
     Step%20navigation/singular: ec328f28051577e1c0aab044c89b138c
+    Answer%20options/singular: acb0b378cefcb8a8d50a7c43ce77ae39
     Close/singular: 2c2e22f8424a1031de89063bd0022e16
     Activity%20progress/singular: 8ff2fb7372b8a2525f2955c851c4fa42
-    Start%20Investigation/singular: 597f9ca357f5bfb78aa995ce49660ca9
-    Continue/singular: 3cfba90b4600131e82fc4260c568d044
     evidence/singular: e79d4526b88aca84fbc283178ed61264
-    Begin/singular: cc2a17a662cb60dd2d8335a2e8440997
-    Check/singular: 023cc2ba432775c38e3efc004ad7b9ef
     BP/singular: 842ed01b3a4d0efa6fe96ae8c595726c
     Energy/singular: 958809db5050650b97519e0f1f3e1951
     Image%20options/singular: 64a1aee44b26dbaff851cb846eb4274d
     Drag%20items%20into%20the%20correct%20order/singular: 8ccab82ee3ba645ac23da4ca14a0dd2a
     Sort%20items/singular: 3b1072a596203b5acdc5718d38161392
     Correct%20order%3A/singular: df3f446653ec8cde9c29d8d5912636ef
+    Start%20Investigation/singular: 597f9ca357f5bfb78aa995ce49660ca9
+    Continue/singular: 3cfba90b4600131e82fc4260c568d044
+    Begin/singular: cc2a17a662cb60dd2d8335a2e8440997
+    Check/singular: 023cc2ba432775c38e3efc004ad7b9ef
     Metric%20changes/singular: b47eb6ffcf56070345e7783cb048b563
     Current%20status/singular: b9c587d6cd7ee919b59e75066fa4675f
     Final%20status/singular: 62c3befb232a9d290e74b84d6ddbf22c
@@ -274,7 +287,6 @@ checksums:
     Legend/singular: 3b588fbd2fe35ded6ca38334e15400c3
     Diagram/singular: e0bc1ef7782cb0d749c9582da6775175
     Timeline/singular: 342b1e646f0634e47112092db1a24f49
-    Vocabulary/singular: 2c8127af4c194fa05463e82d5e414c62
     Green/singular: 482ff383a4258357ba404f283682471d
     Yellow/singular: 15d533755d35af887dfa584975549fda
     Red/singular: bace0083b78cdb188523bc4abc7b55c6
@@ -316,7 +328,6 @@ checksums:
     Evening/singular: d401caa89963f8017a148bcdd1749c2d
     "%7Bperiod%7D%20with%20%7Bvalue%7D%25/singular": 958bc2c65d9a6823edee6f2585fd6501
     Next%3A%20%7Bactivity%7D/singular: 9208679843466247d2161793249e5eda
-    Activity/singular: 1948763de8e531483a798b68195e297e
     Continue%20learning/singular: ff5ff528cbacf657af36fb9b711431d6
     Your%20energy%20is%20%7Bvalue%7D%25/singular: d5ae9aecd778267fbc44c9e681c91637
     Keep%20learning%20to%20increase%20it/singular: a3c3f15ac29089d9448b0971126cabf7
@@ -697,7 +708,6 @@ checksums:
     Send%20feedback/singular: 9631cc08d49da04475b30a0d320ce97c
     More%20options/singular: 53d90eae6a9b0243b5bc043b3d9de169
     Start/singular: dbe56303d9a6d3fad1a8d4cbcc97f365
-    Review/singular: 299f75db25382980b2895622d7712927
     Please%20provide%20as%20much%20detail%20as%20possible./singular: 3c8b231283c751d4beae059a6ffc3643
     Failed%20to%20send%20message.%20Please%20try%20again%20or%20email%20us%20directly%20at%20hello%40zoonk.com/singular: 7f36bcd5ba5dad4b9981f85488ff794c
     Email%20address/singular: 3ba3f099b1b9be6c35ad797da660cb9f
@@ -715,26 +725,17 @@ checksums:
     Upgrade/singular: 63c3b52882e0d779859307d672c178c2
     Upgrade%20to%20create/singular: d8be0e2d204b5a7601612cc44cca5cd5
     Creating%20content%20with%20AI%20requires%20an%20active%20subscription./singular: 7a1e2747c5271495f525ae7360db6fe0
-    Translation/singular: 9276816e7bc1a6ff00f388faa0863986
-    Listening/singular: 9e680c44cd88a178b953349ed8881ef2
     Learn%20new%20%7Btopic%7D%20words%20with%20flashcards%20%E2%80%94%20see%20each%20word%2C%20its%20translation%2C%20and%20pronunciation./singular: 923933ba274d61fc2ffb279cf64aceba
-    Story/singular: fabac3f62af801d429e2cd7115bf14c9
     Review%20everything%20you%20learned%20about%20%7Btopic%7D%20with%20a%20comprehensive%20quiz./singular: 8acf9006cabdcbaac217c7565943f068
-    Explanation/singular: f6b595df4ffb1a5b0cbbe1dda5993522
     Sharpen%20your%20%7Btopic%7D%20listening%20skills%20by%20translating%20audio%20sentences./singular: b624ceffbbfc91a29cec43a0037b067f
     Test%20your%20understanding%20of%20%7Btopic%7D%20with%20questions%20designed%20to%20check%20real%20comprehension%2C%20not%20just%20memorization./singular: d9f3e39d19b1c6969b481bc8aec8fc10
-    Practice/singular: ea10afa88a3687e6c40d1bfb3e0f4f20
     Investigate%20%7Btopic%7D%20by%20gathering%20evidence%2C%20evaluating%20findings%2C%20and%20drawing%20your%20own%20conclusions./singular: 00493764f0b0552779c71e990ec3be5c
     "%7Blesson%7D%20%7Bactivity%7D/singular": d959fed1ee77dca493e8cf0a3b3129c0
-    Reading/singular: 9d93f1dff4a01a9e1566f23b401b8868
-    Quiz/singular: 22bce287f7a90d3b41b418108eaab43b
     Test%20your%20%7Btopic%7D%20vocabulary%20by%20translating%20words%20you've%20learned./singular: d81da859633df4dd0b03711f48cc1cdd
-    Grammar/singular: 1d97aca351a45df1d6eb27adbee04832
     Learn%20about%20%7Btopic%7D%20through%20an%20interactive%20activity./singular: 94f8ca153ea2ee6b539f507266548201
     Experience%20%7Btopic%7D%20through%20an%20interactive%20story%20where%20your%20decisions%20shape%20the%20outcome./singular: 56069dcd1f836d241ab23c4a19d7d208
     Understand%20what%20%7Btopic%7D%20is%20%E2%80%94%20core%20concepts%20and%20definitions%20explained%20with%20clear%20metaphors%20and%20analogies./singular: ec3b49a710ebac5f592523bdaa68ceff
     Practice%20%7Btopic%7D%20grammar%20rules%20with%20exercises%20designed%20to%20help%20you%20remember%20and%20apply%20them./singular: 107adae09992e8b4deb051afa38da3bd
-    Investigation/singular: 89bc005c971ce9ded2848561258095d8
     "%7Bactivity%7D%20-%20%7Blesson%7D/singular": 0aad8d82851f799d79c052a0f2b90d67
     Improve%20your%20%7Btopic%7D%20reading%20comprehension%20by%20translating%20sentences%20and%20passages./singular: 60baac4222f76009cc1eb1b6065b403b
     Apply%20%7Btopic%7D%20through%20a%20real-world%20dialogue%20scenario./singular: e170c3bd82d42f0972d0f447f10379f0

--- a/packages/player/src/_browser-tests/player-header-info.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-header-info.browser.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import { page } from "vitest/browser";
+import { buildSerializedActivity } from "../_test-utils/player-test-data";
+import { buildAuthenticatedViewer } from "../_test-utils/player-test-viewer";
+import { renderPlayer } from "../_test-utils/render-player";
+
+describe("player header: activity title and lesson info", () => {
+  test("shows the activity title in the header", async () => {
+    renderPlayer({
+      activity: buildSerializedActivity({ title: "Basic Greetings" }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await expect.element(page.getByText("Basic Greetings")).toBeInTheDocument();
+  });
+
+  test("shows the activity kind label when title is null", async () => {
+    renderPlayer({
+      activity: buildSerializedActivity({ kind: "vocabulary", title: null }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await expect.element(page.getByText("Vocabulary")).toBeInTheDocument();
+  });
+
+  test("lesson info popover shows lesson and chapter details", async () => {
+    renderPlayer({
+      activity: buildSerializedActivity(),
+      chapterTitle: "Verb Fundamentals",
+      lessonDescription: "Learn present tense conjugation patterns.",
+      lessonTitle: "Present Tense",
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await page.getByRole("button", { name: /lesson info/i }).click();
+
+    await expect.element(page.getByRole("heading", { name: "Present Tense" })).toBeInTheDocument();
+    await expect
+      .element(page.getByText("Learn present tense conjugation patterns."))
+      .toBeInTheDocument();
+    await expect.element(page.getByText("Verb Fundamentals")).toBeInTheDocument();
+  });
+});

--- a/packages/player/src/_test-utils/render-player.tsx
+++ b/packages/player/src/_test-utils/render-player.tsx
@@ -16,6 +16,9 @@ const noop = () => null;
  */
 export function renderPlayer({
   activity,
+  chapterTitle = "Test Chapter",
+  lessonDescription = "Test lesson description",
+  lessonTitle = "Test Lesson",
   milestone = { kind: "activity" },
   navigation = buildNavigation(),
   onComplete = noop,
@@ -25,6 +28,9 @@ export function renderPlayer({
   viewer = { isAuthenticated: false, userName: null },
 }: {
   activity: SerializedActivity;
+  chapterTitle?: string;
+  lessonDescription?: string;
+  lessonTitle?: string;
   milestone?: PlayerMilestone;
   navigation?: PlayerNavigation;
   onComplete?: (input: CompletionInput) => void;
@@ -36,6 +42,9 @@ export function renderPlayer({
   return render(
     <PlayerProvider
       activity={activity}
+      chapterTitle={chapterTitle}
+      lessonDescription={lessonDescription}
+      lessonTitle={lessonTitle}
       milestone={milestone}
       navigation={navigation}
       onComplete={onComplete}

--- a/packages/player/src/components/in-play-sticky-header.tsx
+++ b/packages/player/src/components/in-play-sticky-header.tsx
@@ -1,41 +1,44 @@
 "use client";
 
-import { type PlayerRoute } from "../player-context";
+import { usePlayerActivityMeta, usePlayerNavigation } from "../player-context";
+import { useActivityKindLabel } from "../use-activity-kind-label";
 import { ContextRecallPopover } from "./context-recall-popover";
-import { PlayerCloseLink, PlayerHeader, PlayerStepFraction } from "./player-header";
+import { LessonInfoPopover } from "./lesson-info-popover";
+import { PlayerCloseLink, PlayerHeader } from "./player-header";
 import { PlayerProgressBar } from "./player-progress-bar";
 
 export function InPlayStickyHeader({
   centerContent,
   contextRecall,
-  currentStepIndex,
-  lessonHref,
   progressValue,
-  totalSteps,
 }: {
   centerContent?: React.ReactNode;
   contextRecall: string | null;
-  currentStepIndex: number;
-  lessonHref: PlayerRoute;
   progressValue: number;
-  totalSteps: number;
 }) {
+  const { kind, title } = usePlayerActivityMeta();
+  const { lessonHref } = usePlayerNavigation();
+  const kindLabel = useActivityKindLabel(kind);
+  const displayTitle = title ?? kindLabel;
+
   return (
     <div className="bg-background/95 sticky top-0 z-30 backdrop-blur-sm">
       <PlayerHeader>
         <PlayerCloseLink href={lessonHref} />
 
         <div className="pointer-events-none absolute inset-x-0 flex justify-center">
-          <div className="pointer-events-auto">
+          <div className="pointer-events-auto max-w-50 sm:max-w-75">
             {centerContent ?? (
-              <PlayerStepFraction>
-                {currentStepIndex + 1} / {totalSteps}
-              </PlayerStepFraction>
+              <span className="text-muted-foreground truncate text-sm">{displayTitle}</span>
             )}
           </div>
         </div>
 
-        {contextRecall && <ContextRecallPopover content={contextRecall} />}
+        <div className="flex items-center gap-1">
+          {contextRecall && <ContextRecallPopover content={contextRecall} />}
+
+          <LessonInfoPopover />
+        </div>
       </PlayerHeader>
 
       <PlayerProgressBar value={progressValue} />

--- a/packages/player/src/components/lesson-info-popover.tsx
+++ b/packages/player/src/components/lesson-info-popover.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { buttonVariants } from "@zoonk/ui/components/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@zoonk/ui/components/popover";
+import { Separator } from "@zoonk/ui/components/separator";
+import { InfoIcon } from "lucide-react";
+import { useExtracted } from "next-intl";
+import { usePlayerActivityMeta } from "../player-context";
+
+/**
+ * A small info button in the player header that opens a popover with
+ * contextual details about the current lesson and chapter.
+ *
+ * Helps learners orient themselves when they enter an activity directly
+ * (e.g., via "Continue" links) without going through the lesson page first.
+ */
+export function LessonInfoPopover() {
+  const t = useExtracted();
+  const { chapterTitle, lessonDescription, lessonTitle } = usePlayerActivityMeta();
+
+  return (
+    <Popover>
+      <PopoverTrigger className={buttonVariants({ size: "icon", variant: "ghost" })}>
+        <InfoIcon className="size-4" />
+        <span className="sr-only">{t("Lesson info")}</span>
+      </PopoverTrigger>
+
+      <PopoverContent align="end" side="bottom" sideOffset={8}>
+        <PopoverHeader>
+          <PopoverTitle>{lessonTitle}</PopoverTitle>
+          <PopoverDescription>{lessonDescription}</PopoverDescription>
+        </PopoverHeader>
+
+        <Separator />
+
+        <p className="text-muted-foreground text-xs">{chapterTitle}</p>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/player/src/components/player-header.tsx
+++ b/packages/player/src/components/player-header.tsx
@@ -33,13 +33,3 @@ export function PlayerCloseLink({ className, href }: { className?: string; href:
     </PlayerLink>
   );
 }
-
-export function PlayerStepFraction({ className, ...props }: React.ComponentProps<"span">) {
-  return (
-    <span
-      className={cn("text-muted-foreground text-sm tabular-nums", className)}
-      data-slot="player-step-fraction"
-      {...props}
-    />
-  );
-}

--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useExtracted } from "next-intl";
-import { usePlayerMilestone, usePlayerNavigation, usePlayerRuntime } from "../player-context";
+import { usePlayerMilestone, usePlayerRuntime } from "../player-context";
 import {
   getCurrentResult,
   getCurrentStep,
@@ -46,7 +46,6 @@ function BottomBarContent() {
 export function PlayerShell() {
   const t = useExtracted();
   const { screen, state } = usePlayerRuntime();
-  const { lessonHref } = usePlayerNavigation();
   const milestone = usePlayerMilestone();
 
   const currentResult = getCurrentResult(state);
@@ -87,10 +86,7 @@ export function PlayerShell() {
         <InPlayStickyHeader
           centerContent={evidencePill}
           contextRecall={contextRecall}
-          currentStepIndex={state.currentStepIndex}
-          lessonHref={lessonHref}
           progressValue={progressValue}
-          totalSteps={state.steps.length}
         />
       )}
 

--- a/packages/player/src/player-context.tsx
+++ b/packages/player/src/player-context.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type ActivityKind } from "@zoonk/core/steps/contract/content";
 import { createContext, useContext } from "react";
 import { type PlayerState } from "./player-reducer";
 import { type PlayerScreenModel } from "./player-screen";
@@ -42,7 +43,16 @@ type PlayerRuntimeContextValue = {
   state: PlayerState;
 };
 
+type PlayerActivityMeta = {
+  chapterTitle: string;
+  kind: ActivityKind;
+  lessonDescription: string;
+  lessonTitle: string;
+  title: string | null;
+};
+
 type PlayerConfigContextValue = {
+  activityMeta: PlayerActivityMeta;
   escape: () => void;
   milestone: PlayerMilestone;
   navigation: PlayerNavigation;
@@ -61,6 +71,10 @@ function usePlayerConfig(): PlayerConfigContextValue {
   }
 
   return context;
+}
+
+export function usePlayerActivityMeta(): PlayerActivityMeta {
+  return usePlayerConfig().activityMeta;
 }
 
 export function usePlayerMilestone(): PlayerMilestone {

--- a/packages/player/src/player-provider.tsx
+++ b/packages/player/src/player-provider.tsx
@@ -19,7 +19,10 @@ import { UserNameProvider } from "./user-name-context";
 
 export function PlayerProvider({
   activity,
+  chapterTitle,
   children,
+  lessonDescription,
+  lessonTitle,
   milestone,
   navigation,
   onComplete,
@@ -29,7 +32,10 @@ export function PlayerProvider({
   viewer,
 }: {
   activity: SerializedActivity;
+  chapterTitle: string;
   children: React.ReactNode;
+  lessonDescription: string;
+  lessonTitle: string;
   milestone: PlayerMilestone;
   navigation: PlayerNavigation;
   onComplete: (input: CompletionInput) => void;
@@ -63,13 +69,31 @@ export function PlayerProvider({
 
   const configValue = useMemo(
     () => ({
+      activityMeta: {
+        chapterTitle,
+        kind: activity.kind,
+        lessonDescription,
+        lessonTitle,
+        title: activity.title,
+      },
       escape: onEscape,
       milestone,
       navigation,
       next: handleNext,
       viewer,
     }),
-    [handleNext, milestone, navigation, onEscape, viewer],
+    [
+      activity.kind,
+      activity.title,
+      chapterTitle,
+      handleNext,
+      lessonDescription,
+      lessonTitle,
+      milestone,
+      navigation,
+      onEscape,
+      viewer,
+    ],
   );
 
   const runtimeValue = useMemo(

--- a/packages/player/src/use-activity-kind-label.ts
+++ b/packages/player/src/use-activity-kind-label.ts
@@ -1,0 +1,28 @@
+import { type ActivityKind } from "@zoonk/core/steps/contract/content";
+import { useExtracted } from "next-intl";
+
+/**
+ * Map an activity kind to a human-readable label. Used as fallback when
+ * the activity has no custom title, matching how the activity list displays
+ * activity kinds throughout the app.
+ */
+export function useActivityKindLabel(kind: ActivityKind): string {
+  const t = useExtracted();
+
+  const labels: Record<ActivityKind, string> = {
+    custom: t("Activity"),
+    explanation: t("Explanation"),
+    grammar: t("Grammar"),
+    investigation: t("Investigation"),
+    listening: t("Listening"),
+    practice: t("Practice"),
+    quiz: t("Quiz"),
+    reading: t("Reading"),
+    review: t("Review"),
+    story: t("Story"),
+    translation: t("Translation"),
+    vocabulary: t("Vocabulary"),
+  };
+
+  return labels[kind];
+}

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -57,7 +57,7 @@ function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
 function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
   return (
     <PopoverPrimitive.Title
-      className={cn("text-base font-medium", className)}
+      className={cn("text-sm font-medium", className)}
       data-slot="popover-title"
       {...props}
     />


### PR DESCRIPTION
## Summary

- Replace the step fraction ("1 / 5") with the activity title in the player header center. Falls back to the activity kind label (e.g., "Vocabulary") when no title is set
- Add a lesson info popover (info icon) on the right side showing lesson title, description, and chapter title
- Change `PopoverTitle` default from `text-base` to `text-sm`

## Test plan

- [x] 295 player package tests pass (3 new browser tests for header title and info popover)
- [x] 303 e2e tests pass (7 updated from step fraction to lesson info button assertions)
- [ ] Verify activity title displays correctly in the player header
- [ ] Verify kind label fallback works when activity has no title
- [ ] Verify lesson info popover shows correct lesson/chapter details
- [ ] Verify context recall popover still works for story/investigation activities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the step fraction in the player header with the activity title and added a lesson info popover to help learners orient themselves. Falls back to the activity kind label when no title is set.

- **New Features**
  - Header shows the activity title; falls back to the kind label (e.g., Vocabulary).
  - Added a “Lesson info” button that reveals lesson title, description, and chapter.

- **Refactors**
  - Removed the “1 / N” step fraction from the header; the progress bar already conveys progress.
  - Set `PopoverTitle` default size to `text-sm` and adjusted header loading skeleton width.

<sup>Written for commit 64265e83f1ba1fa16f28c6e922a08dc4f3d34937. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

