### PR TITLE
fix(mailer): send contact form as plain text to prevent html injection

### DIFF
--- a/apps/main/src/components/feedback/contact-form-action.ts
+++ b/apps/main/src/components/feedback/contact-form-action.ts
@@ -14,11 +14,7 @@ export async function contactFormAction(_prevState: unknown, formData: FormData)
   const { error } = await sendEmail({
     replyTo: email,
     subject: "Zoonk Request",
-    text: `
-        <p><strong>From:</strong> ${email}</p>
-        <p><strong>Message:</strong></p>
-        <p>${message.replaceAll("\n", "<br>")}</p>
-      `,
+    textBody: `From: ${email}\n\n${message}`,
     to: "hello@zoonk.com",
   });
 

--- a/packages/auth/src/plugins/otp.ts
+++ b/packages/auth/src/plugins/otp.ts
@@ -15,7 +15,7 @@ export const sendVerificationOTP: EmailOTPOptions["sendVerificationOTP"] = async
 
   const subject = t.otpSubject;
 
-  const text = `
+  const htmlBody = `
       <p>${t.otpIntro}</p>
       <h2>${otp}</h2>
       <p>${t.otpExpiry}</p>
@@ -24,8 +24,8 @@ export const sendVerificationOTP: EmailOTPOptions["sendVerificationOTP"] = async
 
   after(() => {
     void sendEmail({
+      htmlBody,
       subject,
-      text,
       to: email,
     });
   });

--- a/packages/mailer/src/client.ts
+++ b/packages/mailer/src/client.ts
@@ -8,17 +8,19 @@ const sendEmailDisabled = !apiKey;
 export async function sendEmail({
   to,
   subject,
-  text,
+  htmlBody,
+  textBody,
   replyTo,
 }: {
   to: string;
   subject: string;
-  text: string;
+  htmlBody?: string;
+  textBody?: string;
   replyTo?: string;
 }): Promise<SafeReturn<Response>> {
   if (sendEmailDisabled) {
     logInfo("Email sending is disabled.");
-    logInfo({ subject, text, to });
+    logInfo({ subject, textBody: textBody ?? htmlBody, to });
     return { data: Response.json({ ok: true }), error: null };
   }
 
@@ -26,7 +28,8 @@ export async function sendEmail({
     const response = await fetch(apiUrl, {
       body: JSON.stringify({
         from: { address: "hello@zoonk.com", name: "Zoonk" },
-        htmlBody: text,
+        ...(htmlBody && { htmlBody }),
+        ...(textBody && { textbody: textBody }),
         ...(replyTo && { reply_to: [{ address: replyTo }] }),
         subject,
         to: [{ email_address: { address: to } }],


### PR DESCRIPTION
## Summary
- Add `textBody` support to the mailer alongside existing `htmlBody`
- Switch contact form to plain text, eliminating HTML injection risk
- OTP emails continue using `htmlBody` for formatted content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send contact form emails as plain text to prevent HTML injection. Added `textBody` to the mailer API and switched the contact form to it; OTP emails continue using `htmlBody` for formatting.

<sup>Written for commit 2200ae6e06aa5e3aed35be1e9cbdba91b1f8578c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

