### PR TITLE
chore: disable sentry PII

### DIFF
--- a/apps/api/sentry.edge.config.ts
+++ b/apps/api/sentry.edge.config.ts
@@ -9,7 +9,7 @@ if (process.env.NODE_ENV === "production") {
   init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     enableLogs: true,
-    sendDefaultPii: true,
+    sendDefaultPii: false,
     tracesSampleRate: 0.1,
   });
 }

--- a/apps/api/sentry.server.config.ts
+++ b/apps/api/sentry.server.config.ts
@@ -8,7 +8,7 @@ if (process.env.NODE_ENV === "production") {
   init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     enableLogs: true,
-    sendDefaultPii: true,
+    sendDefaultPii: false,
     tracesSampleRate: 0.1,
   });
 }

--- a/apps/api/src/instrumentation-client.ts
+++ b/apps/api/src/instrumentation-client.ts
@@ -5,7 +5,7 @@ if (process.env.NODE_ENV === "production") {
   init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     enableLogs: true,
-    sendDefaultPii: true,
+    sendDefaultPii: false,
     tracesSampleRate: 0.1,
   });
 }

--- a/apps/editor/sentry.edge.config.ts
+++ b/apps/editor/sentry.edge.config.ts
@@ -9,7 +9,7 @@ if (process.env.NODE_ENV === "production") {
   init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     enableLogs: true,
-    sendDefaultPii: true,
+    sendDefaultPii: false,
     tracesSampleRate: 0.1,
   });
 }

--- a/apps/editor/sentry.server.config.ts
+++ b/apps/editor/sentry.server.config.ts
@@ -8,7 +8,7 @@ if (process.env.NODE_ENV === "production") {
   init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     enableLogs: true,
-    sendDefaultPii: true,
+    sendDefaultPii: false,
     tracesSampleRate: 0.1,
   });
 }

--- a/apps/editor/src/instrumentation-client.ts
+++ b/apps/editor/src/instrumentation-client.ts
@@ -4,7 +4,7 @@ if (process.env.NODE_ENV === "production") {
   init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     enableLogs: true,
-    sendDefaultPii: true,
+    sendDefaultPii: false,
     tracesSampleRate: 0.1,
   });
 }

--- a/apps/main/sentry.edge.config.ts
+++ b/apps/main/sentry.edge.config.ts
@@ -9,7 +9,7 @@ if (process.env.NODE_ENV === "production") {
   init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     enableLogs: true,
-    sendDefaultPii: true,
+    sendDefaultPii: false,
     tracesSampleRate: 0.1,
   });
 }

--- a/apps/main/sentry.server.config.ts
+++ b/apps/main/sentry.server.config.ts
@@ -8,7 +8,7 @@ if (process.env.NODE_ENV === "production") {
   init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     enableLogs: true,
-    sendDefaultPii: true,
+    sendDefaultPii: false,
     tracesSampleRate: 0.1,
   });
 }

--- a/apps/main/src/instrumentation-client.ts
+++ b/apps/main/src/instrumentation-client.ts
@@ -5,7 +5,7 @@ if (process.env.NODE_ENV === "production") {
   init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     enableLogs: true,
-    sendDefaultPii: true,
+    sendDefaultPii: false,
     tracesSampleRate: 0.1,
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disabled Sentry’s default PII collection in production across API, Editor, and Main (server, edge, and instrumentation) by setting sendDefaultPii=false. This stops sending user identifiers and other personal data to Sentry and improves privacy compliance.

<sup>Written for commit e9588bdc26cafe210ee25c727022aaf32364490a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

