### PR TITLE
fix(next): add public security headers

### DIFF
--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { withSentryConfig } from "@sentry/nextjs";
+import { getPublicAppSecurityHeaders } from "@zoonk/next/security/headers";
 import { withBotId } from "botid/next/config";
 import { type NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
@@ -20,6 +21,7 @@ const nextConfig: NextConfig = {
     authInterrupts: true,
     typedEnv: true,
   },
+  headers: getPublicAppSecurityHeaders,
   reactCompiler: true,
   turbopack: {
     resolveAlias: { ...e2eAliases },

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { withSentryConfig } from "@sentry/nextjs";
+import { getPublicAppSecurityHeaders } from "@zoonk/next/security/headers";
 import { type NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
@@ -39,6 +40,7 @@ const nextConfig: NextConfig = {
     ],
   },
   reactCompiler: true,
+  headers: getPublicAppSecurityHeaders,
   turbopack: {
     resolveAlias: {
       ...e2eAliases,

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -30,6 +30,7 @@ const nextConfig: NextConfig = {
     },
     typedEnv: true,
   },
+  headers: getPublicAppSecurityHeaders,
   images: {
     minimumCacheTTL: 60 * 60 * 24 * CACHE_IMAGE_DAYS,
     remotePatterns: [
@@ -40,7 +41,6 @@ const nextConfig: NextConfig = {
     ],
   },
   reactCompiler: true,
-  headers: getPublicAppSecurityHeaders,
   turbopack: {
     resolveAlias: {
       ...e2eAliases,

--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -4,6 +4,7 @@ import { withSentryConfig } from "@sentry/nextjs";
 import { withBotId } from "botid/next/config";
 import { type NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
+import { getPublicAppSecurityHeaders } from "@zoonk/next/security/headers";
 
 const CACHE_IMAGE_DAYS = 30;
 
@@ -38,6 +39,7 @@ const nextConfig: NextConfig = {
   logging: {
     browserToTerminal: true,
   },
+  headers: getPublicAppSecurityHeaders,
   pageExtensions: ["js", "jsx", "mdx", "ts", "tsx"],
   reactCompiler: true,
   turbopack: {

--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -1,10 +1,10 @@
 import path from "node:path";
 import createMDX from "@next/mdx";
 import { withSentryConfig } from "@sentry/nextjs";
+import { getPublicAppSecurityHeaders } from "@zoonk/next/security/headers";
 import { withBotId } from "botid/next/config";
 import { type NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
-import { getPublicAppSecurityHeaders } from "@zoonk/next/security/headers";
 
 const CACHE_IMAGE_DAYS = 30;
 
@@ -27,6 +27,7 @@ const nextConfig: NextConfig = {
     },
     typedEnv: true,
   },
+  headers: getPublicAppSecurityHeaders,
   images: {
     minimumCacheTTL: 60 * 60 * 24 * CACHE_IMAGE_DAYS,
     remotePatterns: [
@@ -39,7 +40,6 @@ const nextConfig: NextConfig = {
   logging: {
     browserToTerminal: true,
   },
-  headers: getPublicAppSecurityHeaders,
   pageExtensions: ["js", "jsx", "mdx", "ts", "tsx"],
   reactCompiler: true,
   turbopack: {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     "./i18n/codec": "./src/i18n/next-intl-codec.ts",
-    "./navigation/external-redirect": "./src/navigation/external-redirect.ts"
+    "./navigation/external-redirect": "./src/navigation/external-redirect.ts",
+    "./security/headers": "./src/security/headers.ts"
   },
   "scripts": {
     "typecheck": "tsgo --noEmit"

--- a/packages/next/src/security/headers.ts
+++ b/packages/next/src/security/headers.ts
@@ -1,0 +1,59 @@
+type ResponseHeader = {
+  key: string;
+  value: string;
+};
+
+type RouteHeaders = {
+  headers: ResponseHeader[];
+  source: string;
+};
+
+const PUBLIC_APP_PERMISSIONS_POLICY = [
+  "camera=()",
+  "microphone=()",
+  "geolocation=()",
+  "payment=()",
+  "usb=()",
+  "serial=()",
+  "hid=()",
+  "bluetooth=()",
+  "accelerometer=()",
+  "gyroscope=()",
+  "magnetometer=()",
+  "browsing-topics=()",
+].join(", ");
+
+const PUBLIC_APP_SECURITY_HEADERS = [
+  {
+    headers: [
+      {
+        key: "Strict-Transport-Security",
+        value: "max-age=63072000",
+      },
+      {
+        key: "X-Frame-Options",
+        value: "DENY",
+      },
+      {
+        key: "X-Content-Type-Options",
+        value: "nosniff",
+      },
+      {
+        key: "Permissions-Policy",
+        value: PUBLIC_APP_PERMISSIONS_POLICY,
+      },
+    ],
+    source: "/:path*",
+  },
+] satisfies RouteHeaders[];
+
+/**
+ * Keeps the baseline security headers for our public apps in one place so the
+ * policy stays consistent across `main`, `api`, and `editor`. The list is
+ * intentionally limited to low-risk headers while CSP is handled separately.
+ */
+export async function getPublicAppSecurityHeaders() {
+  return PUBLIC_APP_SECURITY_HEADERS;
+}
+
+export { PUBLIC_APP_PERMISSIONS_POLICY };

--- a/packages/next/src/security/headers.ts
+++ b/packages/next/src/security/headers.ts
@@ -51,9 +51,9 @@ const PUBLIC_APP_SECURITY_HEADERS = [
  * Keeps the baseline security headers for our public apps in one place so the
  * policy stays consistent across `main`, `api`, and `editor`. The list is
  * intentionally limited to low-risk headers while CSP is handled separately.
+ *
+ * @public
  */
 export async function getPublicAppSecurityHeaders() {
   return PUBLIC_APP_SECURITY_HEADERS;
 }
-
-export { PUBLIC_APP_PERMISSIONS_POLICY };


### PR DESCRIPTION
## Summary
- add a shared `@zoonk/next` helper for the public app security headers
- apply the shared headers in `main`, `api`, and `editor`
- export the helper from `@zoonk/next`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add shared security headers for public apps and apply them to `main`, `api`, and `editor`. Centralizes a consistent baseline (HSTS, X-Frame-Options, nosniff, restrictive Permissions-Policy) in `@zoonk/next`; fixes Next.js config lint and knip warnings; CSP stays separate.

- **New Features**
  - Added `getPublicAppSecurityHeaders` in `@zoonk/next/security/headers` and exported it from `@zoonk/next`.
  - Set Next.js `headers` to this helper in `apps/main`, `apps/api`, and `apps/editor`.
  - Policy disables risky features via Permissions-Policy (camera, microphone, geolocation, Bluetooth, sensors, etc.).

<sup>Written for commit 57c68843a0e42d5027f7c58f695dcb7a38688dc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

