### PR TITLE
fix(editor): reauthorize alternative title actions

### DIFF
--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/alternative-titles.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/alternative-titles.ts
@@ -1,11 +1,11 @@
 "use server";
 
+import { addAlternativeTitles } from "@/data/alternative-titles/add-alternative-titles";
 import { deleteAlternativeTitles } from "@/data/alternative-titles/delete-alternative-titles";
 import { exportAlternativeTitles } from "@/data/alternative-titles/export-alternative-titles";
 import { importAlternativeTitles } from "@/data/alternative-titles/import-alternative-titles";
 import { getErrorMessage } from "@/lib/error-messages";
 import { isImportMode } from "@/lib/import-mode";
-import { addAlternativeTitles } from "@zoonk/core/alternative-titles/add";
 import { getExtracted } from "next-intl/server";
 import { revalidatePath } from "next/cache";
 
@@ -47,10 +47,14 @@ export async function deleteAlternativeTitleAction(
 ): Promise<{ error: string | null }> {
   const { courseId, courseSlug, orgSlug } = params;
 
-  await deleteAlternativeTitles({
+  const { error } = await deleteAlternativeTitles({
     courseId,
     titles: [slug],
   });
+
+  if (error) {
+    return { error: await getErrorMessage(error) };
+  }
 
   revalidatePath(`/${orgSlug}/c/${courseSlug}`);
   return { error: null };

--- a/apps/editor/src/data/alternative-titles/add-alternative-titles.test.ts
+++ b/apps/editor/src/data/alternative-titles/add-alternative-titles.test.ts
@@ -1,0 +1,86 @@
+import { randomUUID } from "node:crypto";
+import { ErrorCode } from "@/lib/app-error";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { memberFixture, organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, describe, expect, test } from "vitest";
+import { addAlternativeTitles } from "./add-alternative-titles";
+
+describe("unauthenticated users", () => {
+  test("returns Forbidden", async () => {
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    const result = await addAlternativeTitles({
+      courseId: course.id,
+      headers: new Headers(),
+      language: "en",
+      titles: ["test-title"],
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("members", () => {
+  test("returns Forbidden", async () => {
+    const { organization, user } = await memberFixture({ role: "member" });
+
+    const [headers, course] = await Promise.all([
+      signInAs(user.email, user.password),
+      courseFixture({ organizationId: organization.id }),
+    ]);
+
+    const result = await addAlternativeTitles({
+      courseId: course.id,
+      headers,
+      language: "en",
+      titles: ["test-title"],
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("admins", () => {
+  let organization: Awaited<ReturnType<typeof memberFixture>>["organization"];
+  let headers: Headers;
+
+  beforeAll(async () => {
+    const fixture = await memberFixture({ role: "admin" });
+    organization = fixture.organization;
+    headers = await signInAs(fixture.user.email, fixture.user.password);
+  });
+
+  test("adds alternative titles successfully", async () => {
+    const course = await courseFixture({ organizationId: organization.id });
+    const suffix = randomUUID().slice(0, 8);
+
+    const result = await addAlternativeTitles({
+      courseId: course.id,
+      headers,
+      language: "en",
+      titles: [`Test Title ${suffix}`],
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.count).toBe(1);
+  });
+
+  test("returns Forbidden for course in different organization", async () => {
+    const otherOrg = await organizationFixture();
+    const course = await courseFixture({ organizationId: otherOrg.id });
+
+    const result = await addAlternativeTitles({
+      courseId: course.id,
+      headers,
+      language: "en",
+      titles: ["test-title"],
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+});

--- a/apps/editor/src/data/alternative-titles/add-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/add-alternative-titles.ts
@@ -1,0 +1,31 @@
+import "server-only";
+import { addAlternativeTitles as createAlternativeTitles } from "@zoonk/core/alternative-titles/add";
+import { type BatchPayload } from "@zoonk/db";
+import { type SafeReturn } from "@zoonk/utils/error";
+import { getAuthorizedAlternativeTitleCourse } from "./get-authorized-course";
+
+/**
+ * The editor needs an authenticated wrapper around the shared alternative-title
+ * insert helper so every mutation reuses the same org-level permission check.
+ */
+export async function addAlternativeTitles(params: {
+  courseId: number;
+  headers?: Headers;
+  language: string;
+  titles: string[];
+}): Promise<SafeReturn<BatchPayload | null>> {
+  const { error } = await getAuthorizedAlternativeTitleCourse({
+    courseId: params.courseId,
+    headers: params.headers,
+  });
+
+  if (error) {
+    return { data: null, error };
+  }
+
+  return createAlternativeTitles({
+    courseId: params.courseId,
+    language: params.language,
+    titles: params.titles,
+  });
+}

--- a/apps/editor/src/data/alternative-titles/delete-alternative-titles.test.ts
+++ b/apps/editor/src/data/alternative-titles/delete-alternative-titles.test.ts
@@ -1,15 +1,51 @@
 import { randomUUID } from "node:crypto";
+import { ErrorCode } from "@/lib/app-error";
 import { addAlternativeTitles } from "@zoonk/core/alternative-titles/add";
 import { prisma } from "@zoonk/db";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
-import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { memberFixture, organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { describe, expect, test } from "vitest";
 import { deleteAlternativeTitles } from "./delete-alternative-titles";
 
 describe(deleteAlternativeTitles, () => {
+  test("returns Forbidden for unauthenticated users", async () => {
+    const org = await organizationFixture();
+    const course = await courseFixture({ organizationId: org.id });
+
+    const result = await deleteAlternativeTitles({
+      courseId: course.id,
+      headers: new Headers(),
+      titles: ["frontend-development"],
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+
+  test("returns Forbidden for org members", async () => {
+    const { organization, user } = await memberFixture({ role: "member" });
+
+    const [headers, course] = await Promise.all([
+      signInAs(user.email, user.password),
+      courseFixture({ organizationId: organization.id }),
+    ]);
+
+    const result = await deleteAlternativeTitles({
+      courseId: course.id,
+      headers,
+      titles: ["frontend-development"],
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+
   test("deletes specific alternative titles from a course", async () => {
     const org = await organizationFixture();
     const course = await courseFixture({ organizationId: org.id });
+    const { user } = await memberFixture({ organizationId: org.id, role: "admin" });
+    const headers = await signInAs(user.email, user.password);
 
     const suffix = randomUUID().slice(0, 8);
     const title1 = `frontend-development-${suffix}`;
@@ -22,10 +58,13 @@ describe(deleteAlternativeTitles, () => {
       titles: [title1, title2, title3],
     });
 
-    await deleteAlternativeTitles({
+    const result = await deleteAlternativeTitles({
       courseId: course.id,
+      headers,
       titles: [title1],
     });
+
+    expect(result.error).toBeNull();
 
     const remaining = await prisma.courseAlternativeTitle.findMany({
       orderBy: { slug: "asc" },
@@ -39,6 +78,8 @@ describe(deleteAlternativeTitles, () => {
   test("deletes multiple titles at once", async () => {
     const org = await organizationFixture();
     const course = await courseFixture({ organizationId: org.id });
+    const { user } = await memberFixture({ organizationId: org.id, role: "admin" });
+    const headers = await signInAs(user.email, user.password);
 
     const suffix = randomUUID().slice(0, 8);
 
@@ -48,10 +89,13 @@ describe(deleteAlternativeTitles, () => {
       titles: [`react-${suffix}`, `vue-${suffix}`, `angular-${suffix}`],
     });
 
-    await deleteAlternativeTitles({
+    const result = await deleteAlternativeTitles({
       courseId: course.id,
+      headers,
       titles: [`react-${suffix}`, `angular-${suffix}`],
     });
+
+    expect(result.error).toBeNull();
 
     const remaining = await prisma.courseAlternativeTitle.findMany({
       select: { slug: true },
@@ -64,6 +108,8 @@ describe(deleteAlternativeTitles, () => {
   test("handles deleting non-existent titles gracefully", async () => {
     const org = await organizationFixture();
     const course = await courseFixture({ organizationId: org.id });
+    const { user } = await memberFixture({ organizationId: org.id, role: "admin" });
+    const headers = await signInAs(user.email, user.password);
 
     const suffix = randomUUID().slice(0, 8);
 
@@ -73,10 +119,13 @@ describe(deleteAlternativeTitles, () => {
       titles: [`python-${suffix}`],
     });
 
-    await deleteAlternativeTitles({
+    const result = await deleteAlternativeTitles({
       courseId: course.id,
+      headers,
       titles: ["nonexistent-title"],
     });
+
+    expect(result.error).toBeNull();
 
     const remaining = await prisma.courseAlternativeTitle.findMany({
       select: { slug: true },
@@ -89,6 +138,8 @@ describe(deleteAlternativeTitles, () => {
   test("does nothing when titles array is empty", async () => {
     const org = await organizationFixture();
     const course = await courseFixture({ organizationId: org.id });
+    const { user } = await memberFixture({ organizationId: org.id, role: "admin" });
+    const headers = await signInAs(user.email, user.password);
 
     const suffix = randomUUID().slice(0, 8);
 
@@ -98,10 +149,13 @@ describe(deleteAlternativeTitles, () => {
       titles: [`javascript-${suffix}`],
     });
 
-    await deleteAlternativeTitles({
+    const result = await deleteAlternativeTitles({
       courseId: course.id,
+      headers,
       titles: [],
     });
+
+    expect(result.error).toBeNull();
 
     const remaining = await prisma.courseAlternativeTitle.findMany({
       select: { slug: true },
@@ -115,6 +169,8 @@ describe(deleteAlternativeTitles, () => {
     const org = await organizationFixture();
     const course1 = await courseFixture({ organizationId: org.id });
     const course2 = await courseFixture({ organizationId: org.id });
+    const { user } = await memberFixture({ organizationId: org.id, role: "admin" });
+    const headers = await signInAs(user.email, user.password);
 
     const suffix = randomUUID().slice(0, 8);
 
@@ -130,10 +186,13 @@ describe(deleteAlternativeTitles, () => {
       titles: [`go-programming-${suffix}`],
     });
 
-    await deleteAlternativeTitles({
+    const result = await deleteAlternativeTitles({
       courseId: course1.id,
+      headers,
       titles: [`typescript-${suffix}`, `go-programming-${suffix}`],
     });
+
+    expect(result.error).toBeNull();
 
     const course1Titles = await prisma.courseAlternativeTitle.findMany({
       where: { courseId: course1.id },
@@ -146,5 +205,21 @@ describe(deleteAlternativeTitles, () => {
 
     expect(course1Titles).toEqual([]);
     expect(course2Titles).toEqual([{ slug: `go-programming-${suffix}` }]);
+  });
+
+  test("returns Forbidden for courses in a different organization", async () => {
+    const { user } = await memberFixture({ role: "admin" });
+    const headers = await signInAs(user.email, user.password);
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+
+    const result = await deleteAlternativeTitles({
+      courseId: otherCourse.id,
+      headers,
+      titles: ["frontend-development"],
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
   });
 });

--- a/apps/editor/src/data/alternative-titles/delete-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/delete-alternative-titles.ts
@@ -1,21 +1,45 @@
 import "server-only";
 import { prisma } from "@zoonk/db";
+import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { toSlug } from "@zoonk/utils/string";
+import { getAuthorizedAlternativeTitleCourse } from "./get-authorized-course";
 
+/**
+ * Deleting alternative titles changes duplicate-detection data, so this helper
+ * exists to enforce course update permission before removing any stored slugs.
+ */
 export async function deleteAlternativeTitles(params: {
   courseId: number;
+  headers?: Headers;
   titles: string[];
-}): Promise<void> {
+}): Promise<SafeReturn<null>> {
+  const { error: courseError } = await getAuthorizedAlternativeTitleCourse({
+    courseId: params.courseId,
+    headers: params.headers,
+  });
+
+  if (courseError) {
+    return { data: null, error: courseError };
+  }
+
   const slugs = params.titles.map((title) => toSlug(title));
 
   if (slugs.length === 0) {
-    return;
+    return { data: null, error: null };
   }
 
-  await prisma.courseAlternativeTitle.deleteMany({
-    where: {
-      courseId: params.courseId,
-      slug: { in: slugs },
-    },
-  });
+  const { error } = await safeAsync(() =>
+    prisma.courseAlternativeTitle.deleteMany({
+      where: {
+        courseId: params.courseId,
+        slug: { in: slugs },
+      },
+    }),
+  );
+
+  if (error) {
+    return { data: null, error };
+  }
+
+  return { data: null, error: null };
 }

--- a/apps/editor/src/data/alternative-titles/export-alternative-titles.test.ts
+++ b/apps/editor/src/data/alternative-titles/export-alternative-titles.test.ts
@@ -1,15 +1,50 @@
 import { randomUUID } from "node:crypto";
 import { ErrorCode } from "@/lib/app-error";
 import { prisma } from "@zoonk/db";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
-import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { memberFixture, organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { describe, expect, test } from "vitest";
 import { exportAlternativeTitles } from "./export-alternative-titles";
 
 describe(exportAlternativeTitles, () => {
+  test("returns Forbidden for unauthenticated users", async () => {
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    const result = await exportAlternativeTitles({
+      courseId: course.id,
+      headers: new Headers(),
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+
+  test("returns Forbidden for org members", async () => {
+    const { organization, user } = await memberFixture({ role: "member" });
+
+    const [headers, course] = await Promise.all([
+      signInAs(user.email, user.password),
+      courseFixture({ organizationId: organization.id }),
+    ]);
+
+    const result = await exportAlternativeTitles({
+      courseId: course.id,
+      headers,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+
   test("returns courseNotFound for non-existent course", async () => {
+    const { user } = await memberFixture({ role: "admin" });
+    const headers = await signInAs(user.email, user.password);
+
     const result = await exportAlternativeTitles({
       courseId: 999_999,
+      headers,
     });
 
     expect(result.error?.message).toBe(ErrorCode.courseNotFound);
@@ -20,6 +55,8 @@ describe(exportAlternativeTitles, () => {
     const suffix = randomUUID().slice(0, 8);
     const organization = await organizationFixture();
     const course = await courseFixture({ organizationId: organization.id });
+    const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+    const headers = await signInAs(user.email, user.password);
 
     await prisma.courseAlternativeTitle.createMany({
       data: [
@@ -34,6 +71,7 @@ describe(exportAlternativeTitles, () => {
 
     const result = await exportAlternativeTitles({
       courseId: course.id,
+      headers,
     });
 
     expect(result.error).toBeNull();
@@ -46,9 +84,12 @@ describe(exportAlternativeTitles, () => {
   test("exports empty array when no titles exist", async () => {
     const organization = await organizationFixture();
     const course = await courseFixture({ organizationId: organization.id });
+    const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+    const headers = await signInAs(user.email, user.password);
 
     const result = await exportAlternativeTitles({
       courseId: course.id,
+      headers,
     });
 
     expect(result.error).toBeNull();
@@ -59,6 +100,8 @@ describe(exportAlternativeTitles, () => {
     const suffix = randomUUID().slice(0, 8);
     const organization = await organizationFixture();
     const course = await courseFixture({ organizationId: organization.id });
+    const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+    const headers = await signInAs(user.email, user.password);
 
     await prisma.courseAlternativeTitle.createMany({
       data: [
@@ -78,6 +121,7 @@ describe(exportAlternativeTitles, () => {
 
     const result = await exportAlternativeTitles({
       courseId: course.id,
+      headers,
     });
 
     expect(result.error).toBeNull();
@@ -86,5 +130,20 @@ describe(exportAlternativeTitles, () => {
       `beta-training-${suffix}`,
       `zebra-learning-${suffix}`,
     ]);
+  });
+
+  test("returns Forbidden for courses in a different organization", async () => {
+    const { user } = await memberFixture({ role: "admin" });
+    const headers = await signInAs(user.email, user.password);
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+
+    const result = await exportAlternativeTitles({
+      courseId: otherCourse.id,
+      headers,
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
   });
 });

--- a/apps/editor/src/data/alternative-titles/export-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/export-alternative-titles.ts
@@ -1,27 +1,29 @@
 import "server-only";
-import { ErrorCode } from "@/lib/app-error";
 import { prisma } from "@zoonk/db";
-import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { getAuthorizedAlternativeTitleCourse } from "./get-authorized-course";
 
-export async function exportAlternativeTitles(params: { courseId: number }): Promise<
+/**
+ * Export needs the same authorization boundary as mutations because the action
+ * can be replayed directly and exposes internal duplicate-detection data.
+ */
+export async function exportAlternativeTitles(params: {
+  courseId: number;
+  headers?: Headers;
+}): Promise<
   SafeReturn<{
     alternativeTitles: string[];
     exportedAt: string;
     version: number;
   }>
 > {
-  const { data: course, error: findError } = await safeAsync(() =>
-    prisma.course.findUnique({
-      where: { id: params.courseId },
-    }),
-  );
+  const { error: courseError } = await getAuthorizedAlternativeTitleCourse({
+    courseId: params.courseId,
+    headers: params.headers,
+  });
 
-  if (findError) {
-    return { data: null, error: findError };
-  }
-
-  if (!course) {
-    return { data: null, error: new AppError(ErrorCode.courseNotFound) };
+  if (courseError) {
+    return { data: null, error: courseError };
   }
 
   const { data: titles, error: titlesError } = await safeAsync(() =>

--- a/apps/editor/src/data/alternative-titles/get-authorized-course.ts
+++ b/apps/editor/src/data/alternative-titles/get-authorized-course.ts
@@ -1,0 +1,42 @@
+import "server-only";
+import { ErrorCode } from "@/lib/app-error";
+import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
+import { type Course, prisma } from "@zoonk/db";
+import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+
+/**
+ * Alternative-title mutations use `courseId` from the client, so this helper
+ * exists to resolve the real course record on the server and re-check that the
+ * caller still has update access to that course's organization before any read
+ * or write happens.
+ */
+export async function getAuthorizedAlternativeTitleCourse(params: {
+  courseId: number;
+  headers?: Headers;
+}): Promise<SafeReturn<Course>> {
+  const { data: course, error: findError } = await safeAsync(() =>
+    prisma.course.findUnique({
+      where: { id: params.courseId },
+    }),
+  );
+
+  if (findError) {
+    return { data: null, error: findError };
+  }
+
+  if (!course) {
+    return { data: null, error: new AppError(ErrorCode.courseNotFound) };
+  }
+
+  const hasPermission = await hasCoursePermission({
+    headers: params.headers,
+    orgId: course.organizationId,
+    permission: "update",
+  });
+
+  if (!hasPermission) {
+    return { data: null, error: new AppError(ErrorCode.forbidden) };
+  }
+
+  return { data: course, error: null };
+}

--- a/apps/editor/src/data/alternative-titles/import-alternative-titles.test.ts
+++ b/apps/editor/src/data/alternative-titles/import-alternative-titles.test.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { ErrorCode } from "@/lib/app-error";
 import { prisma } from "@zoonk/db";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
-import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { memberFixture, organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { describe, expect, test } from "vitest";
 import { importAlternativeTitles } from "./import-alternative-titles";
 
@@ -19,16 +20,55 @@ function createImportFile(alternativeTitles: string[]): File {
 }
 
 describe(importAlternativeTitles, () => {
+  test("returns Forbidden for unauthenticated users", async () => {
+    const file = createImportFile(["Test Title"]);
+    const organization = await organizationFixture();
+    const course = await courseFixture({ organizationId: organization.id });
+
+    const result = await importAlternativeTitles({
+      courseId: course.id,
+      file,
+      headers: new Headers(),
+      language: "en",
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+
+  test("returns Forbidden for org members", async () => {
+    const file = createImportFile(["Test Title"]);
+    const { organization, user } = await memberFixture({ role: "member" });
+
+    const [headers, course] = await Promise.all([
+      signInAs(user.email, user.password),
+      courseFixture({ organizationId: organization.id }),
+    ]);
+
+    const result = await importAlternativeTitles({
+      courseId: course.id,
+      file,
+      headers,
+      language: "en",
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
+  });
+
   test("imports titles successfully", async () => {
     const suffix = randomUUID().slice(0, 8);
     const organization = await organizationFixture();
     const course = await courseFixture({ organizationId: organization.id });
+    const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+    const headers = await signInAs(user.email, user.password);
 
     const file = createImportFile([`Machine Learning ${suffix}`, `ML Basics ${suffix}`]);
 
     const result = await importAlternativeTitles({
       courseId: course.id,
       file,
+      headers,
       language: "en",
     });
 
@@ -49,10 +89,13 @@ describe(importAlternativeTitles, () => {
   test("returns courseNotFound for non-existent course", async () => {
     const suffix = randomUUID().slice(0, 8);
     const file = createImportFile([`Test Title ${suffix}`]);
+    const { user } = await memberFixture({ role: "admin" });
+    const headers = await signInAs(user.email, user.password);
 
     const result = await importAlternativeTitles({
       courseId: 999_999,
       file,
+      headers,
       language: "en",
     });
 
@@ -64,6 +107,8 @@ describe(importAlternativeTitles, () => {
     const suffix = randomUUID().slice(0, 8);
     const organization = await organizationFixture();
     const course = await courseFixture({ organizationId: organization.id });
+    const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+    const headers = await signInAs(user.email, user.password);
 
     await prisma.courseAlternativeTitle.create({
       data: {
@@ -78,6 +123,7 @@ describe(importAlternativeTitles, () => {
     const result = await importAlternativeTitles({
       courseId: course.id,
       file,
+      headers,
       language: "en",
     });
 
@@ -98,6 +144,8 @@ describe(importAlternativeTitles, () => {
     const suffix = randomUUID().slice(0, 8);
     const organization = await organizationFixture();
     const course = await courseFixture({ organizationId: organization.id });
+    const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+    const headers = await signInAs(user.email, user.password);
 
     await prisma.courseAlternativeTitle.create({
       data: {
@@ -112,6 +160,7 @@ describe(importAlternativeTitles, () => {
     const result = await importAlternativeTitles({
       courseId: course.id,
       file,
+      headers,
       language: "en",
       mode: "replace",
     });
@@ -131,6 +180,8 @@ describe(importAlternativeTitles, () => {
     const suffix = randomUUID().slice(0, 8);
     const organization = await organizationFixture();
     const course = await courseFixture({ organizationId: organization.id });
+    const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+    const headers = await signInAs(user.email, user.password);
 
     await prisma.courseAlternativeTitle.createMany({
       data: [
@@ -152,6 +203,7 @@ describe(importAlternativeTitles, () => {
     const result = await importAlternativeTitles({
       courseId: course.id,
       file,
+      headers,
       language: "en",
       mode: "replace",
     });
@@ -181,6 +233,8 @@ describe(importAlternativeTitles, () => {
     const suffix = randomUUID().slice(0, 8);
     const organization = await organizationFixture();
     const course = await courseFixture({ organizationId: organization.id });
+    const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+    const headers = await signInAs(user.email, user.password);
 
     const file = createImportFile([
       `Same Title ${suffix}`,
@@ -192,6 +246,7 @@ describe(importAlternativeTitles, () => {
     const result = await importAlternativeTitles({
       courseId: course.id,
       file,
+      headers,
       language: "en",
     });
 
@@ -209,12 +264,15 @@ describe(importAlternativeTitles, () => {
   test("returns empty array when all titles are empty", async () => {
     const organization = await organizationFixture();
     const course = await courseFixture({ organizationId: organization.id });
+    const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+    const headers = await signInAs(user.email, user.password);
 
     const file = createMockFile(JSON.stringify({ alternativeTitles: [] }));
 
     const result = await importAlternativeTitles({
       courseId: course.id,
       file,
+      headers,
       language: "en",
     });
 
@@ -226,6 +284,8 @@ describe(importAlternativeTitles, () => {
     test("rejects file larger than 5MB", async () => {
       const organization = await organizationFixture();
       const course = await courseFixture({ organizationId: organization.id });
+      const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+      const headers = await signInAs(user.email, user.password);
 
       const largeContent = "x".repeat(6 * 1024 * 1024);
       const file = createMockFile(largeContent);
@@ -233,6 +293,7 @@ describe(importAlternativeTitles, () => {
       const result = await importAlternativeTitles({
         courseId: course.id,
         file,
+        headers,
         language: "en",
       });
 
@@ -242,6 +303,8 @@ describe(importAlternativeTitles, () => {
     test("rejects non-JSON file", async () => {
       const organization = await organizationFixture();
       const course = await courseFixture({ organizationId: organization.id });
+      const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+      const headers = await signInAs(user.email, user.password);
 
       const file = new File(["test content"], "titles.txt", {
         type: "text/plain",
@@ -250,6 +313,7 @@ describe(importAlternativeTitles, () => {
       const result = await importAlternativeTitles({
         courseId: course.id,
         file,
+        headers,
         language: "en",
       });
 
@@ -259,12 +323,15 @@ describe(importAlternativeTitles, () => {
     test("rejects invalid JSON", async () => {
       const organization = await organizationFixture();
       const course = await courseFixture({ organizationId: organization.id });
+      const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+      const headers = await signInAs(user.email, user.password);
 
       const file = createMockFile("{ invalid json }");
 
       const result = await importAlternativeTitles({
         courseId: course.id,
         file,
+        headers,
         language: "en",
       });
 
@@ -274,12 +341,15 @@ describe(importAlternativeTitles, () => {
     test("rejects JSON without alternativeTitles array", async () => {
       const organization = await organizationFixture();
       const course = await courseFixture({ organizationId: organization.id });
+      const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+      const headers = await signInAs(user.email, user.password);
 
       const file = createMockFile(JSON.stringify({ foo: "bar" }));
 
       const result = await importAlternativeTitles({
         courseId: course.id,
         file,
+        headers,
         language: "en",
       });
 
@@ -289,6 +359,8 @@ describe(importAlternativeTitles, () => {
     test("rejects non-string titles", async () => {
       const organization = await organizationFixture();
       const course = await courseFixture({ organizationId: organization.id });
+      const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+      const headers = await signInAs(user.email, user.password);
 
       const file = createMockFile(
         JSON.stringify({
@@ -299,6 +371,7 @@ describe(importAlternativeTitles, () => {
       const result = await importAlternativeTitles({
         courseId: course.id,
         file,
+        headers,
         language: "en",
       });
 
@@ -308,6 +381,8 @@ describe(importAlternativeTitles, () => {
     test("rejects empty string titles", async () => {
       const organization = await organizationFixture();
       const course = await courseFixture({ organizationId: organization.id });
+      const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+      const headers = await signInAs(user.email, user.password);
 
       const file = createMockFile(
         JSON.stringify({
@@ -318,6 +393,7 @@ describe(importAlternativeTitles, () => {
       const result = await importAlternativeTitles({
         courseId: course.id,
         file,
+        headers,
         language: "en",
       });
 
@@ -327,6 +403,8 @@ describe(importAlternativeTitles, () => {
     test("rejects whitespace-only titles", async () => {
       const organization = await organizationFixture();
       const course = await courseFixture({ organizationId: organization.id });
+      const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+      const headers = await signInAs(user.email, user.password);
 
       const file = createMockFile(
         JSON.stringify({
@@ -337,6 +415,7 @@ describe(importAlternativeTitles, () => {
       const result = await importAlternativeTitles({
         courseId: course.id,
         file,
+        headers,
         language: "en",
       });
 
@@ -347,6 +426,8 @@ describe(importAlternativeTitles, () => {
       const suffix = randomUUID().slice(0, 8);
       const organization = await organizationFixture();
       const course = await courseFixture({ organizationId: organization.id });
+      const { user } = await memberFixture({ organizationId: organization.id, role: "admin" });
+      const headers = await signInAs(user.email, user.password);
 
       const file = new File(
         [JSON.stringify({ alternativeTitles: [`Test Title ${suffix}`] })],
@@ -357,11 +438,30 @@ describe(importAlternativeTitles, () => {
       const result = await importAlternativeTitles({
         courseId: course.id,
         file,
+        headers,
         language: "en",
       });
 
       expect(result.error).toBeNull();
       expect(result.data).toHaveLength(1);
     });
+  });
+
+  test("returns Forbidden for courses in a different organization", async () => {
+    const { user } = await memberFixture({ role: "admin" });
+    const headers = await signInAs(user.email, user.password);
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+    const file = createImportFile(["Test Title"]);
+
+    const result = await importAlternativeTitles({
+      courseId: otherCourse.id,
+      file,
+      headers,
+      language: "en",
+    });
+
+    expect(result.error?.message).toBe(ErrorCode.forbidden);
+    expect(result.data).toBeNull();
   });
 });

--- a/apps/editor/src/data/alternative-titles/import-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/import-alternative-titles.ts
@@ -3,9 +3,10 @@ import { ErrorCode } from "@/lib/app-error";
 import { type ImportMode } from "@/lib/import-mode";
 import { parseJsonFile } from "@/lib/parse-json-file";
 import { prisma } from "@zoonk/db";
-import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { isJsonObject } from "@zoonk/utils/json";
 import { toSlug } from "@zoonk/utils/string";
+import { getAuthorizedAlternativeTitleCourse } from "./get-authorized-course";
 
 function validateTitleData(title: unknown): title is string {
   return typeof title === "string" && title.trim().length > 0;
@@ -28,6 +29,7 @@ function validateImportData(data: unknown): data is {
 export async function importAlternativeTitles(params: {
   courseId: number;
   file: File;
+  headers?: Headers;
   language: string;
   mode?: ImportMode;
 }): Promise<SafeReturn<string[]>> {
@@ -43,18 +45,13 @@ export async function importAlternativeTitles(params: {
     return { data: null, error: parseError };
   }
 
-  const { data: course, error: findError } = await safeAsync(() =>
-    prisma.course.findUnique({
-      where: { id: params.courseId },
-    }),
-  );
+  const { error: courseError } = await getAuthorizedAlternativeTitleCourse({
+    courseId: params.courseId,
+    headers: params.headers,
+  });
 
-  if (findError) {
-    return { data: null, error: findError };
-  }
-
-  if (!course) {
-    return { data: null, error: new AppError(ErrorCode.courseNotFound) };
+  if (courseError) {
+    return { data: null, error: courseError };
   }
 
   const uniqueSlugs = [


### PR DESCRIPTION
## Summary
- reauthorize alternative title add, delete, import, and export in the editor DAL
- add regression tests for unauthenticated, member, admin, and wrong-org access


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reauthorized editor alternative title actions (add, delete, import, export) to enforce org-level update permissions and consistent error handling. Adds coverage to block unauthenticated, member, and cross-org access.

- **Bug Fixes**
  - Added `getAuthorizedAlternativeTitleCourse` to resolve the course and check `update` permission via `hasCoursePermission` (`@zoonk/core/orgs/permissions`).
  - Wrapped actions with authenticated DAL helpers that accept `headers` and return `SafeReturn` (`@zoonk/utils/error`), using `@zoonk/db` for lookups.
  - Updated import/export to use the common authorization path, returning `forbidden` or `courseNotFound` when applicable.
  - Improved server action to surface errors and only revalidate on success.
  - Added regression tests for unauthenticated, member, admin, and wrong-org scenarios.

<sup>Written for commit 223855829a0c72e676f7a0ebc36657dc7aad37f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

