### PR TITLE
fix(api): restrict ai generation to ai org

### DIFF
--- a/apps/api/e2e/workflows-activity-generation.test.ts
+++ b/apps/api/e2e/workflows-activity-generation.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { request } from "@playwright/test";
 import { prisma } from "@zoonk/db";
 import { expect, test } from "@zoonk/e2e/fixtures";
-import { getAiOrganization } from "@zoonk/e2e/helpers";
+import { createOrganization, getAiOrganization } from "@zoonk/e2e/helpers";
 import { normalizeString } from "@zoonk/utils/string";
 
 test.describe("Activity Generation Workflow API", () => {
@@ -154,6 +154,60 @@ test.describe("Activity Generation Workflow API", () => {
 
     expect(body.error).toBeDefined();
     expect(body.error.code).toBe("VALIDATION_ERROR");
+
+    await apiContext.dispose();
+  });
+
+  test("returns 404 for lessons outside the AI organization", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const org = await createOrganization();
+
+    const course = await prisma.course.create({
+      data: {
+        description: "Non-AI course should not allow activity generation",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString(`Non AI Activity Test ${uniqueId}`),
+        organizationId: org.id,
+        slug: `non-ai-activity-test-${uniqueId}`,
+        title: `Non AI Activity Test ${uniqueId}`,
+      },
+    });
+
+    const chapter = await prisma.chapter.create({
+      data: {
+        courseId: course.id,
+        description: "Non-AI chapter",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString("Non AI Activity Chapter"),
+        organizationId: org.id,
+        position: 0,
+        slug: `non-ai-activity-chapter-${uniqueId}`,
+        title: "Non AI Activity Chapter",
+      },
+    });
+
+    const lesson = await prisma.lesson.create({
+      data: {
+        chapterId: chapter.id,
+        description: "Non-AI lesson",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString("Non AI Activity Lesson"),
+        organizationId: org.id,
+        position: 0,
+        slug: `non-ai-activity-lesson-${uniqueId}`,
+        title: "Non AI Activity Lesson",
+      },
+    });
+
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.post("/v1/workflows/activity-generation/trigger", {
+      data: { lessonId: lesson.id },
+    });
+
+    expect(response.status()).toBe(404);
 
     await apiContext.dispose();
   });

--- a/apps/api/e2e/workflows-chapter-generation.test.ts
+++ b/apps/api/e2e/workflows-chapter-generation.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { request } from "@playwright/test";
 import { prisma } from "@zoonk/db";
 import { expect, test } from "@zoonk/e2e/fixtures";
-import { getAiOrganization } from "@zoonk/e2e/helpers";
+import { createOrganization, getAiOrganization } from "@zoonk/e2e/helpers";
 import { normalizeString } from "@zoonk/utils/string";
 
 test.describe("Chapter Generation Workflow API", () => {
@@ -160,6 +160,46 @@ test.describe("Chapter Generation Workflow API", () => {
 
     expect(body.message).toBe("Workflow started");
     expect(body.runId).toBeDefined();
+
+    await apiContext.dispose();
+  });
+
+  test("returns 404 for chapters outside the AI organization", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const org = await createOrganization();
+
+    const course = await prisma.course.create({
+      data: {
+        description: "Non-AI course should not allow chapter generation",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString(`Non AI Chapter Test ${uniqueId}`),
+        organizationId: org.id,
+        slug: `non-ai-chapter-test-${uniqueId}`,
+        title: `Non AI Chapter Test ${uniqueId}`,
+      },
+    });
+
+    const chapter = await prisma.chapter.create({
+      data: {
+        courseId: course.id,
+        description: "Non-AI first chapter",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString("Non AI First Chapter"),
+        organizationId: org.id,
+        position: 0,
+        slug: `non-ai-first-chapter-${uniqueId}`,
+        title: "Non AI First Chapter",
+      },
+    });
+
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.post("/v1/workflows/chapter-generation/trigger", {
+      data: { chapterId: chapter.id },
+    });
+
+    expect(response.status()).toBe(404);
 
     await apiContext.dispose();
   });

--- a/apps/api/e2e/workflows-lesson-generation.test.ts
+++ b/apps/api/e2e/workflows-lesson-generation.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { request } from "@playwright/test";
 import { prisma } from "@zoonk/db";
 import { expect, test } from "@zoonk/e2e/fixtures";
-import { getAiOrganization } from "@zoonk/e2e/helpers";
+import { createOrganization, getAiOrganization } from "@zoonk/e2e/helpers";
 import { normalizeString } from "@zoonk/utils/string";
 
 test.describe("Lesson Generation Workflow API", () => {
@@ -141,6 +141,60 @@ test.describe("Lesson Generation Workflow API", () => {
 
     expect(body.error).toBeDefined();
     expect(body.error.code).toBe("VALIDATION_ERROR");
+
+    await apiContext.dispose();
+  });
+
+  test("returns 404 for lessons outside the AI organization", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const org = await createOrganization();
+
+    const course = await prisma.course.create({
+      data: {
+        description: "Non-AI course should not allow lesson generation",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString(`Non AI Lesson Test ${uniqueId}`),
+        organizationId: org.id,
+        slug: `non-ai-lesson-test-${uniqueId}`,
+        title: `Non AI Lesson Test ${uniqueId}`,
+      },
+    });
+
+    const chapter = await prisma.chapter.create({
+      data: {
+        courseId: course.id,
+        description: "Non-AI chapter",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString("Non AI Chapter"),
+        organizationId: org.id,
+        position: 0,
+        slug: `non-ai-lesson-chapter-${uniqueId}`,
+        title: "Non AI Chapter",
+      },
+    });
+
+    const lesson = await prisma.lesson.create({
+      data: {
+        chapterId: chapter.id,
+        description: "Non-AI lesson",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString("Non AI Lesson"),
+        organizationId: org.id,
+        position: 0,
+        slug: `non-ai-lesson-${uniqueId}`,
+        title: "Non AI Lesson",
+      },
+    });
+
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
+      data: { lessonId: lesson.id },
+    });
+
+    expect(response.status()).toBe(404);
 
     await apiContext.dispose();
   });

--- a/apps/api/src/app/v1/workflows/activity-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/activity-generation/trigger/route.ts
@@ -3,6 +3,7 @@ import { parseBody } from "@/lib/body-parser";
 import { activityGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
 import { activityGenerationWorkflow } from "@/workflows/activity-generation/activity-generation-workflow";
 import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
+import { getAiGenerationLessonWhere, prisma } from "@zoonk/db";
 import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 
@@ -11,6 +12,17 @@ export async function POST(request: NextRequest) {
 
   if (!parsed.success) {
     return errors.validation(parsed.error);
+  }
+
+  const lesson = await prisma.lesson.findFirst({
+    select: { id: true },
+    where: getAiGenerationLessonWhere({
+      lessonWhere: { id: parsed.data.lessonId },
+    }),
+  });
+
+  if (!lesson) {
+    return errors.notFound();
   }
 
   const hasSubscription = await hasActiveSubscription(request.headers);

--- a/apps/api/src/app/v1/workflows/chapter-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/chapter-generation/trigger/route.ts
@@ -3,14 +3,20 @@ import { parseBody } from "@/lib/body-parser";
 import { chapterGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
 import { chapterGenerationWorkflow } from "@/workflows/chapter-generation/chapter-generation-workflow";
 import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
-import { prisma } from "@zoonk/db";
+import { getAiGenerationChapterWhere, prisma } from "@zoonk/db";
 import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 
+/**
+ * The first-chapter free path is intentionally public, so this lookup must
+ * also prove the chapter belongs to the AI curriculum before we skip auth.
+ */
 async function getChapterPosition(chapterId: number) {
-  const chapter = await prisma.chapter.findUnique({
+  const chapter = await prisma.chapter.findFirst({
     select: { position: true },
-    where: { id: chapterId },
+    where: getAiGenerationChapterWhere({
+      chapterWhere: { id: chapterId },
+    }),
   });
   return chapter;
 }

--- a/apps/api/src/app/v1/workflows/lesson-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/lesson-generation/trigger/route.ts
@@ -3,6 +3,7 @@ import { parseBody } from "@/lib/body-parser";
 import { lessonGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
 import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
 import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
+import { getAiGenerationLessonWhere, prisma } from "@zoonk/db";
 import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 
@@ -11,6 +12,17 @@ export async function POST(request: NextRequest) {
 
   if (!parsed.success) {
     return errors.validation(parsed.error);
+  }
+
+  const lesson = await prisma.lesson.findFirst({
+    select: { id: true },
+    where: getAiGenerationLessonWhere({
+      lessonWhere: { id: parsed.data.lessonId },
+    }),
+  });
+
+  if (!lesson) {
+    return errors.notFound();
   }
 
   const hasSubscription = await hasActiveSubscription(request.headers);

--- a/apps/api/src/app/v1/workflows/lesson-preload/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/lesson-preload/trigger/route.ts
@@ -3,6 +3,7 @@ import { parseBody } from "@/lib/body-parser";
 import { lessonPreloadTriggerSchema } from "@/lib/openapi/schemas/workflows";
 import { lessonPreloadWorkflow } from "@/workflows/lesson-preload/lesson-preload-workflow";
 import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
+import { getAiGenerationLessonWhere, prisma } from "@zoonk/db";
 import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 
@@ -11,6 +12,17 @@ export async function POST(request: NextRequest) {
 
   if (!parsed.success) {
     return errors.validation(parsed.error);
+  }
+
+  const lesson = await prisma.lesson.findFirst({
+    select: { id: true },
+    where: getAiGenerationLessonWhere({
+      lessonWhere: { id: parsed.data.lessonId },
+    }),
+  });
+
+  if (!lesson) {
+    return errors.notFound();
   }
 
   const hasSubscription = await hasActiveSubscription(request.headers);

--- a/apps/api/src/workflows/activity-generation/steps/_utils/fetch-lesson-activities.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/fetch-lesson-activities.ts
@@ -1,4 +1,4 @@
-import { getActiveActivityWhere, prisma } from "@zoonk/db";
+import { getAiGenerationActivityWhere, prisma } from "@zoonk/db";
 
 /**
  * Workflow steps and workflow test helpers both need the same "current lesson
@@ -49,7 +49,7 @@ async function fetchActivitiesForLesson(input: {
       },
     },
     orderBy: { position: "asc" },
-    where: getActiveActivityWhere({
+    where: getAiGenerationActivityWhere({
       activityWhere: input.replacementActivities
         ? {
             isPublished: false,

--- a/apps/api/src/workflows/activity-generation/steps/get-lesson-activities-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/get-lesson-activities-step.test.ts
@@ -4,7 +4,7 @@ import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
-import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { aiOrganizationFixture, organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { beforeAll, beforeEach, describe, expect, expectTypeOf, test, vi } from "vitest";
 import { getLessonActivitiesStep } from "./get-lesson-activities-step";
 
@@ -197,5 +197,34 @@ describe(getLessonActivitiesStep, () => {
     expect(result[0]?.isPublished).toBe(false);
     expect(result[0]?.kind).toBe("reading");
     expect(result[0]?.archivedAt).toBeNull();
+  });
+
+  test("throws FatalError when the lesson is outside the AI organization", async () => {
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+    const otherChapter = await chapterFixture({
+      courseId: otherCourse.id,
+      organizationId: otherOrg.id,
+      title: `Manual Activities Chapter ${randomUUID()}`,
+    });
+    const lesson = await lessonFixture({
+      chapterId: otherChapter.id,
+      kind: "language",
+      organizationId: otherOrg.id,
+      title: `Manual Activities Lesson ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "vocabulary",
+      lessonId: lesson.id,
+      organizationId: otherOrg.id,
+      position: 0,
+      title: `Manual Activity ${randomUUID()}`,
+    });
+
+    await expect(getLessonActivitiesStep({ lessonId: lesson.id })).rejects.toThrow(
+      "No activities found for lesson",
+    );
   });
 });

--- a/apps/api/src/workflows/chapter-generation/steps/get-chapter-step.test.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/get-chapter-step.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
-import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { aiOrganizationFixture, organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { getChapterStep } from "./get-chapter-step";
 
@@ -147,6 +147,19 @@ describe(getChapterStep, () => {
       organizationId,
       position: 0,
       title: `Archived Chapter ${randomUUID()}`,
+    });
+
+    await expect(getChapterStep(chapter.id)).rejects.toThrow("Chapter not found");
+  });
+
+  test("throws FatalError when chapter is outside the AI organization", async () => {
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+    const chapter = await chapterFixture({
+      courseId: otherCourse.id,
+      organizationId: otherOrg.id,
+      position: 0,
+      title: `Manual Chapter ${randomUUID()}`,
     });
 
     await expect(getChapterStep(chapter.id)).rejects.toThrow("Chapter not found");

--- a/apps/api/src/workflows/chapter-generation/steps/get-chapter-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/get-chapter-step.ts
@@ -1,6 +1,6 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type ChapterStepName } from "@zoonk/core/workflows/steps";
-import { getActiveChapterWhere, prisma } from "@zoonk/db";
+import { getAiGenerationChapterWhere, prisma } from "@zoonk/db";
 import { FatalError } from "workflow";
 
 async function getChapterForGeneration(chapterId: number) {
@@ -9,7 +9,7 @@ async function getChapterForGeneration(chapterId: number) {
       _count: { select: { lessons: true } },
       course: true,
     },
-    where: getActiveChapterWhere({
+    where: getAiGenerationChapterWhere({
       chapterWhere: { id: chapterId },
     }),
   });
@@ -21,7 +21,7 @@ async function getNeighboringChapters(courseId: number, position: number) {
   return prisma.chapter.findMany({
     orderBy: { position: "asc" },
     select: { description: true, title: true },
-    where: getActiveChapterWhere({
+    where: getAiGenerationChapterWhere({
       chapterWhere: {
         courseId,
         position: {

--- a/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.test.ts
@@ -3,7 +3,7 @@ import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
-import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { aiOrganizationFixture, organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { getLessonStep } from "./get-lesson-step";
 
@@ -84,6 +84,24 @@ describe(getLessonStep, () => {
       kind: "language",
       organizationId,
       title: `Archived Lesson ${randomUUID()}`,
+    });
+
+    await expect(getLessonStep(lesson.id)).rejects.toThrow("Lesson not found");
+  });
+
+  test("throws FatalError when lesson is outside the AI organization", async () => {
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+    const otherChapter = await chapterFixture({
+      courseId: otherCourse.id,
+      organizationId: otherOrg.id,
+      title: `Manual Lesson Chapter ${randomUUID()}`,
+    });
+    const lesson = await lessonFixture({
+      chapterId: otherChapter.id,
+      kind: "language",
+      organizationId: otherOrg.id,
+      title: `Manual Lesson ${randomUUID()}`,
     });
 
     await expect(getLessonStep(lesson.id)).rejects.toThrow("Lesson not found");

--- a/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.ts
@@ -1,6 +1,6 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type LessonStepName } from "@zoonk/core/workflows/steps";
-import { getActiveLessonWhere, prisma } from "@zoonk/db";
+import { getAiGenerationLessonWhere, prisma } from "@zoonk/db";
 import { FatalError } from "workflow";
 
 async function getLessonForGeneration(lessonId: number) {
@@ -9,7 +9,7 @@ async function getLessonForGeneration(lessonId: number) {
       _count: { select: { activities: true } },
       chapter: { include: { course: true } },
     },
-    where: getActiveLessonWhere({
+    where: getAiGenerationLessonWhere({
       lessonWhere: { id: lessonId },
     }),
   });

--- a/apps/main/e2e/activity-detail.test.ts
+++ b/apps/main/e2e/activity-detail.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { getAiOrganization } from "@zoonk/e2e/helpers";
+import { createOrganization, getAiOrganization } from "@zoonk/e2e/helpers";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -111,6 +111,44 @@ test.describe("Activity Detail Page", () => {
     await expect(generateLink).toBeVisible();
     await expect(generateLink).toHaveAttribute("href", new RegExp(`/generate/a/${activity.id}`));
     await expect(generateLink).toHaveAttribute("rel", "nofollow");
+  });
+
+  test("pending non-AI activities do not show a generate link", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const org = await createOrganization();
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: org.id,
+      slug: `non-ai-activity-course-${uniqueId}`,
+      title: `Non AI Activity Course ${uniqueId}`,
+    });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: org.id,
+      slug: `non-ai-activity-chapter-${uniqueId}`,
+      title: `Non AI Activity Chapter ${uniqueId}`,
+    });
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: org.id,
+      slug: `non-ai-activity-lesson-${uniqueId}`,
+      title: `Non AI Activity Lesson ${uniqueId}`,
+    });
+    await activityFixture({
+      generationStatus: "pending",
+      isPublished: true,
+      lessonId: lesson.id,
+      organizationId: org.id,
+      position: 0,
+      title: `Non AI Activity ${uniqueId}`,
+    });
+
+    await page.goto(`/b/${org.slug}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}/a/0`);
+
+    await expect(page.getByText(/activity not available/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: /create activity/i })).not.toBeVisible();
   });
 
   test("pressing escape navigates to lesson page", async ({ page }) => {

--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { getAiOrganization } from "@zoonk/e2e/helpers";
+import { createOrganization, getAiOrganization } from "@zoonk/e2e/helpers";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
@@ -273,5 +273,35 @@ test.describe("Chapter - No Lessons", () => {
     await page.goto(noLessonsChapterUrl);
 
     await page.waitForURL(new RegExp(`/generate/ch/${noLessonsChapterId}`));
+  });
+
+  test("non-AI chapters with no lessons stay on the chapter page", async ({ page }) => {
+    const nonAiUniqueId = randomUUID().slice(0, 8);
+    const org = await createOrganization();
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: org.id,
+      slug: `non-ai-chapter-course-${nonAiUniqueId}`,
+      title: `Non AI Chapter Course ${nonAiUniqueId}`,
+    });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      description: `Non AI chapter ${nonAiUniqueId}`,
+      isPublished: true,
+      organizationId: org.id,
+      slug: `non-ai-chapter-${nonAiUniqueId}`,
+      title: `Non AI Chapter ${nonAiUniqueId}`,
+    });
+    const url = `/b/${org.slug}/c/${course.slug}/ch/${chapter.slug}`;
+
+    await page.goto(url);
+
+    await expect(page).toHaveURL(url);
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: `Non AI Chapter ${nonAiUniqueId}`,
+      }),
+    ).toBeVisible();
   });
 });

--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -303,5 +303,6 @@ test.describe("Chapter - No Lessons", () => {
         name: `Non AI Chapter ${nonAiUniqueId}`,
       }),
     ).toBeVisible();
+    await expect(page.getByRole("link", { name: /^start$/i })).not.toBeVisible();
   });
 });

--- a/apps/main/e2e/course-detail.test.ts
+++ b/apps/main/e2e/course-detail.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { type Route } from "@playwright/test";
-import { getAiOrganization, setLocale } from "@zoonk/e2e/helpers";
+import { createOrganization, getAiOrganization, setLocale } from "@zoonk/e2e/helpers";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseSuggestionFixture } from "@zoonk/testing/fixtures/course-suggestions";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -178,6 +178,28 @@ test.describe("Course Detail Page", () => {
     await expect(page.getByText(/creating your course/i)).toBeVisible({
       timeout: 10_000,
     });
+  });
+
+  test("non-AI courses with no chapters stay on the course page", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, UUID_SHORT_LENGTH);
+    const org = await createOrganization();
+    const course = await courseFixture({
+      isPublished: true,
+      language: "en",
+      normalizedTitle: normalizeString(`Non AI Empty Course ${uniqueId}`),
+      organizationId: org.id,
+      slug: `non-ai-empty-course-${uniqueId}`,
+      title: `Non AI Empty Course ${uniqueId}`,
+    });
+    const url = `/b/${org.slug}/c/${course.slug}`;
+
+    await page.goto(url);
+
+    await expect(page).toHaveURL(url);
+    await expect(
+      page.getByRole("heading", { level: 1, name: `Non AI Empty Course ${uniqueId}` }),
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: /^start$/i })).not.toBeVisible();
   });
 
   test("shows fallback icon when course has no image", async ({ page }) => {

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -285,6 +285,7 @@ test.describe("Lesson Detail Page", () => {
         name: `Non AI Lesson ${uniqueId}`,
       }),
     ).toBeVisible();
+    await expect(page.getByRole("link", { name: /^start$/i })).not.toBeVisible();
   });
 
   test("shows not-completed indicators for unauthenticated user", async ({ page }) => {

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { getAiOrganization } from "@zoonk/e2e/helpers";
+import { createOrganization, getAiOrganization } from "@zoonk/e2e/helpers";
 import { activityFixture, activityProgressFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -249,6 +249,42 @@ test.describe("Lesson Detail Page", () => {
     await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
     await page.waitForURL(new RegExp(`/generate/l/${lesson.id}`));
+  });
+
+  test("non-AI lessons without activities stay on the lesson page", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const org = await createOrganization();
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: org.id,
+      slug: `non-ai-lesson-course-${uniqueId}`,
+      title: `Non AI Lesson Course ${uniqueId}`,
+    });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: org.id,
+      slug: `non-ai-lesson-chapter-${uniqueId}`,
+      title: `Non AI Lesson Chapter ${uniqueId}`,
+    });
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: org.id,
+      slug: `non-ai-lesson-${uniqueId}`,
+      title: `Non AI Lesson ${uniqueId}`,
+    });
+    const url = `/b/${org.slug}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`;
+
+    await page.goto(url);
+
+    await expect(page).toHaveURL(url);
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: `Non AI Lesson ${uniqueId}`,
+      }),
+    ).toBeVisible();
   });
 
   test("shows not-completed indicators for unauthenticated user", async ({ page }) => {

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -72,6 +72,10 @@ export default async function LessonPage({
     ? (`/b/${nextSibling.brandSlug}/c/${nextSibling.courseSlug}/ch/${nextSibling.chapterSlug}/l/${nextSibling.lessonSlug}` as const)
     : undefined;
 
+  const fallbackHref = activities[0]
+    ? (`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}/a/${activities[0].position}` as const)
+    : undefined;
+
   return (
     <main className="flex flex-1 flex-col">
       <LessonHeader
@@ -86,7 +90,7 @@ export default async function LessonPage({
           <Suspense fallback={<ContinueActivityLinkSkeleton />}>
             <ContinueActivityLink
               completedHref={completedHref}
-              fallbackHref={`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}/a/${activities[0]?.position}`}
+              fallbackHref={fallbackHref}
               lessonId={lesson.id}
             />
           </Suspense>

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -9,6 +9,7 @@ import { getLesson } from "@/data/lessons/get-lesson";
 import { getNextSibling } from "@zoonk/core/player/queries/get-next-sibling";
 import { listLessonActivities } from "@zoonk/core/player/queries/list-lesson-activities";
 import { getSession } from "@zoonk/core/users/session/get";
+import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { type Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import { Suspense } from "react";
@@ -63,7 +64,7 @@ export default async function LessonPage({
     }),
   ]);
 
-  if (activities.length === 0) {
+  if (brandSlug === AI_ORG_SLUG && activities.length === 0) {
     redirect(`/generate/l/${lesson.id}`);
   }
 

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -68,6 +68,10 @@ export default async function ChapterPage({
     ? (`/b/${nextSibling.brandSlug}/c/${nextSibling.courseSlug}/ch/${nextSibling.chapterSlug}` as const)
     : undefined;
 
+  const fallbackHref = lessons[0]
+    ? (`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessons[0].slug}` as const)
+    : undefined;
+
   return (
     <main className="flex flex-1 flex-col">
       <ChapterHeader brandSlug={brandSlug} chapter={chapter} courseSlug={courseSlug} />
@@ -78,7 +82,7 @@ export default async function ChapterPage({
             <ContinueActivityLink
               chapterId={chapter.id}
               completedHref={completedHref}
-              fallbackHref={`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessons[0]?.slug}`}
+              fallbackHref={fallbackHref}
             />
           </Suspense>
           <CatalogActions

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -9,6 +9,7 @@ import { getChapter } from "@/data/chapters/get-chapter";
 import { listChapterLessons } from "@/data/lessons/list-chapter-lessons";
 import { getNextSibling } from "@zoonk/core/player/queries/get-next-sibling";
 import { getSession } from "@zoonk/core/users/session/get";
+import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { type Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import { Suspense } from "react";
@@ -59,7 +60,7 @@ export default async function ChapterPage({
     }),
   ]);
 
-  if (lessons.length === 0) {
+  if (brandSlug === AI_ORG_SLUG && lessons.length === 0) {
     redirect(`/generate/ch/${chapter.id}`);
   }
 

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
@@ -55,6 +55,10 @@ export default async function CoursePage({ params }: PageProps<"/b/[brandSlug]/c
     redirect(`/generate/c/${course.slug}`);
   }
 
+  const fallbackHref = chapters[0]
+    ? (`/b/${brandSlug}/c/${courseSlug}/ch/${chapters[0].slug}` as const)
+    : undefined;
+
   return (
     <main className="flex flex-1 flex-col">
       <CourseHeader brandSlug={brandSlug} course={course} />
@@ -62,10 +66,7 @@ export default async function CoursePage({ params }: PageProps<"/b/[brandSlug]/c
       <CatalogContainer>
         <CatalogToolbar>
           <Suspense fallback={<ContinueActivityLinkSkeleton />}>
-            <ContinueActivityLink
-              courseId={course.id}
-              fallbackHref={`/b/${brandSlug}/c/${courseSlug}/ch/${chapters[0]?.slug}`}
-            />
+            <ContinueActivityLink courseId={course.id} fallbackHref={fallbackHref} />
           </Suspense>
           <CatalogActions contentId={courseSlug} defaultEmail={session?.user.email} kind="course" />
         </CatalogToolbar>

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
@@ -8,6 +8,7 @@ import {
 import { listCourseChapters } from "@/data/chapters/list-course-chapters";
 import { getCourse } from "@/data/courses/get-course";
 import { getSession } from "@zoonk/core/users/session/get";
+import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { type Metadata } from "next";
 import { getExtracted } from "next-intl/server";
 import { notFound, redirect } from "next/navigation";
@@ -50,7 +51,7 @@ export default async function CoursePage({ params }: PageProps<"/b/[brandSlug]/c
 
   const chapters = await listCourseChapters({ courseId: course.id });
 
-  if (chapters.length === 0) {
+  if (brandSlug === AI_ORG_SLUG && chapters.length === 0) {
     redirect(`/generate/c/${course.slug}`);
   }
 

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-not-generated.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-not-generated.tsx
@@ -7,12 +7,20 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@zoonk/ui/components/empty";
+import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { SparklesIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
 import Link from "next/link";
 
-export async function ActivityNotGenerated({ activityId }: { activityId: bigint }) {
+export async function ActivityNotGenerated({
+  activityId,
+  brandSlug,
+}: {
+  activityId: bigint;
+  brandSlug: string;
+}) {
   const t = await getExtracted();
+  const canGenerateActivity = brandSlug === AI_ORG_SLUG;
 
   return (
     <Empty className="border-0">
@@ -26,17 +34,19 @@ export async function ActivityNotGenerated({ activityId }: { activityId: bigint 
         <EmptyDescription>{t("This activity hasn't been created yet.")}</EmptyDescription>
       </EmptyHeader>
 
-      <EmptyContent>
-        <Link
-          className={buttonVariants({ variant: "outline" })}
-          href={`/generate/a/${activityId}`}
-          prefetch={false}
-          rel="nofollow"
-        >
-          <SparklesIcon data-icon="inline-start" />
-          {t("Create activity")}
-        </Link>
-      </EmptyContent>
+      {canGenerateActivity && (
+        <EmptyContent>
+          <Link
+            className={buttonVariants({ variant: "outline" })}
+            href={`/generate/a/${activityId}`}
+            prefetch={false}
+            rel="nofollow"
+          >
+            <SparklesIcon data-icon="inline-start" />
+            {t("Create activity")}
+          </Link>
+        </EmptyContent>
+      )}
     </Empty>
   );
 }

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/page.tsx
@@ -97,7 +97,7 @@ export default async function ActivityPage({ params }: Props) {
   if (activity.generationStatus !== "completed") {
     return (
       <main className="flex min-h-[calc(100vh-8rem)] flex-col items-center justify-center p-4">
-        <ActivityNotGenerated activityId={activity.id} />
+        <ActivityNotGenerated activityId={activity.id} brandSlug={brandSlug} />
       </main>
     );
   }

--- a/apps/main/src/components/catalog/continue-activity-link.tsx
+++ b/apps/main/src/components/catalog/continue-activity-link.tsx
@@ -33,7 +33,7 @@ export async function ContinueActivityLink<Href extends string, CompletedHref ex
   chapterId?: number;
   completedHref?: Route<CompletedHref>;
   courseId?: number;
-  fallbackHref: Route<Href>;
+  fallbackHref?: Route<Href>;
   lessonId?: number;
 }) {
   const t = await getExtracted();
@@ -42,18 +42,31 @@ export async function ContinueActivityLink<Href extends string, CompletedHref ex
   const className = cn(buttonVariants(), "min-w-0 flex-1 gap-2");
 
   /**
+   * Some catalog pages can compute a safe first-child route, while others may
+   * legitimately have no child route at all. Centralizing the fallback render
+   * keeps that "render nothing when no safe fallback exists" rule in one place.
+   */
+  function renderFallback({ label }: { label: string }) {
+    if (!fallbackHref) {
+      return null;
+    }
+
+    return (
+      <Link className={className} href={fallbackHref} prefetch={false}>
+        {label}
+        <ChevronRightIcon aria-hidden="true" />
+      </Link>
+    );
+  }
+
+  /**
    * When we cannot compute a next activity at all, the parent page already has
    * the safest fallback for its own level: first chapter, first lesson, or
    * first activity. Reusing that fallback avoids duplicating page-specific
    * routing rules here.
    */
   if (!data) {
-    return (
-      <Link className={className} href={fallbackHref} prefetch={false}>
-        {t("Start")}
-        <ChevronRightIcon aria-hidden="true" />
-      </Link>
-    );
+    return renderFallback({ label: t("Start") });
   }
 
   const getLabel = () => {
@@ -90,12 +103,7 @@ export async function ContinueActivityLink<Href extends string, CompletedHref ex
    * already knows is valid.
    */
   if (!data.brandSlug) {
-    return (
-      <Link className={className} href={fallbackHref} prefetch={false}>
-        {label}
-        <ChevronRightIcon aria-hidden="true" />
-      </Link>
-    );
+    return renderFallback({ label });
   }
 
   /**
@@ -121,12 +129,7 @@ export async function ContinueActivityLink<Href extends string, CompletedHref ex
    * self-link that happens when the first activity exists but is still pending.
    */
   if (lessonId) {
-    return (
-      <Link className={className} href={fallbackHref} prefetch={false}>
-        {label}
-        <ChevronRightIcon aria-hidden="true" />
-      </Link>
-    );
+    return renderFallback({ label });
   }
 
   /**

--- a/apps/main/src/data/activities/get-activity-for-generation.test.ts
+++ b/apps/main/src/data/activities/get-activity-for-generation.test.ts
@@ -2,7 +2,7 @@ import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
-import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { aiOrganizationFixture, organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { beforeAll, describe, expect, expectTypeOf, test } from "vitest";
 import { getActivityForGeneration } from "./get-activity-for-generation";
 
@@ -14,7 +14,7 @@ describe(getActivityForGeneration, () => {
   let activity: Awaited<ReturnType<typeof activityFixture>>;
 
   beforeAll(async () => {
-    org = await organizationFixture({ kind: "brand" });
+    org = await aiOrganizationFixture();
 
     course = await courseFixture({
       isPublished: true,
@@ -102,5 +102,33 @@ describe(getActivityForGeneration, () => {
     if (lessonData) {
       expectTypeOf(lessonData.id).toBeNumber();
     }
+  });
+
+  test("returns null for activities outside the AI organization", async () => {
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({
+      isPublished: true,
+      organizationId: otherOrg.id,
+    });
+    const otherChapter = await chapterFixture({
+      courseId: otherCourse.id,
+      isPublished: true,
+      organizationId: otherOrg.id,
+    });
+    const otherLesson = await lessonFixture({
+      chapterId: otherChapter.id,
+      isPublished: true,
+      organizationId: otherOrg.id,
+    });
+    const otherActivity = await activityFixture({
+      isPublished: true,
+      lessonId: otherLesson.id,
+      organizationId: otherOrg.id,
+      position: 0,
+    });
+
+    const result = await getActivityForGeneration(otherActivity.id);
+
+    expect(result).toBeNull();
   });
 });

--- a/apps/main/src/data/activities/get-activity-for-generation.ts
+++ b/apps/main/src/data/activities/get-activity-for-generation.ts
@@ -1,8 +1,8 @@
 import "server-only";
-import { prisma } from "@zoonk/db";
+import { getAiGenerationActivityWhere, prisma } from "@zoonk/db";
 
 export async function getActivityForGeneration(activityId: bigint) {
-  return prisma.activity.findUnique({
+  return prisma.activity.findFirst({
     include: {
       lesson: {
         include: {
@@ -12,6 +12,8 @@ export async function getActivityForGeneration(activityId: bigint) {
         },
       },
     },
-    where: { id: activityId },
+    where: getAiGenerationActivityWhere({
+      activityWhere: { id: activityId },
+    }),
   });
 }

--- a/apps/main/src/data/chapters/get-chapter-for-generation.test.ts
+++ b/apps/main/src/data/chapters/get-chapter-for-generation.test.ts
@@ -1,7 +1,7 @@
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
-import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { aiOrganizationFixture, organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { beforeAll, describe, expect, test } from "vitest";
 import { getChapterForGeneration } from "./get-chapter-for-generation";
 
@@ -66,6 +66,19 @@ describe(getChapterForGeneration, () => {
 
   test("returns null for non-existent chapter", async () => {
     const result = await getChapterForGeneration(999_999);
+    expect(result).toBeNull();
+  });
+
+  test("returns null for chapters outside the AI organization", async () => {
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+    const otherChapter = await chapterFixture({
+      courseId: otherCourse.id,
+      organizationId: otherOrg.id,
+    });
+
+    const result = await getChapterForGeneration(otherChapter.id);
+
     expect(result).toBeNull();
   });
 });

--- a/apps/main/src/data/chapters/get-chapter-for-generation.ts
+++ b/apps/main/src/data/chapters/get-chapter-for-generation.ts
@@ -1,12 +1,14 @@
 import "server-only";
-import { prisma } from "@zoonk/db";
+import { getAiGenerationChapterWhere, prisma } from "@zoonk/db";
 
 export async function getChapterForGeneration(chapterId: number) {
-  return prisma.chapter.findUnique({
+  return prisma.chapter.findFirst({
     include: {
       _count: { select: { lessons: true } },
       course: true,
     },
-    where: { id: chapterId },
+    where: getAiGenerationChapterWhere({
+      chapterWhere: { id: chapterId },
+    }),
   });
 }

--- a/apps/main/src/data/lessons/get-lesson-for-generation.test.ts
+++ b/apps/main/src/data/lessons/get-lesson-for-generation.test.ts
@@ -1,0 +1,77 @@
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { aiOrganizationFixture, organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { beforeAll, describe, expect, test } from "vitest";
+import { getLessonForGeneration } from "./get-lesson-for-generation";
+
+describe(getLessonForGeneration, () => {
+  let organizationId: number;
+  let course: Awaited<ReturnType<typeof courseFixture>>;
+  let chapter: Awaited<ReturnType<typeof chapterFixture>>;
+
+  beforeAll(async () => {
+    const org = await aiOrganizationFixture();
+    organizationId = org.id;
+    course = await courseFixture({ organizationId });
+    chapter = await chapterFixture({
+      courseId: course.id,
+      organizationId,
+    });
+  });
+
+  test("returns lesson with chapter and course info", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+    });
+
+    const result = await getLessonForGeneration(lesson.id);
+
+    expect(result).toMatchObject({
+      _count: {
+        activities: 0,
+      },
+      chapter: {
+        course: {
+          slug: course.slug,
+          title: course.title,
+        },
+        slug: chapter.slug,
+        title: chapter.title,
+      },
+      description: lesson.description,
+      generationRunId: lesson.generationRunId,
+      generationStatus: lesson.generationStatus,
+      id: lesson.id,
+      language: lesson.language,
+      organizationId: lesson.organizationId,
+      position: lesson.position,
+      slug: lesson.slug,
+      title: lesson.title,
+    });
+  });
+
+  test("returns null for non-existent lessons", async () => {
+    const result = await getLessonForGeneration(999_999);
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null for lessons outside the AI organization", async () => {
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+    const otherChapter = await chapterFixture({
+      courseId: otherCourse.id,
+      organizationId: otherOrg.id,
+    });
+    const otherLesson = await lessonFixture({
+      chapterId: otherChapter.id,
+      organizationId: otherOrg.id,
+    });
+
+    const result = await getLessonForGeneration(otherLesson.id);
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/main/src/data/lessons/get-lesson-for-generation.ts
+++ b/apps/main/src/data/lessons/get-lesson-for-generation.ts
@@ -1,14 +1,16 @@
 import "server-only";
-import { prisma } from "@zoonk/db";
+import { getAiGenerationLessonWhere, prisma } from "@zoonk/db";
 
 export async function getLessonForGeneration(lessonId: number) {
-  return prisma.lesson.findUnique({
+  return prisma.lesson.findFirst({
     include: {
       _count: { select: { activities: true } },
       chapter: {
         include: { course: true },
       },
     },
-    where: { id: lessonId },
+    where: getAiGenerationLessonWhere({
+      lessonWhere: { id: lessonId },
+    }),
   });
 }

--- a/knip.json
+++ b/knip.json
@@ -43,7 +43,6 @@
     "packages/db": {
       "entry": ["prisma.config.ts"],
       "ignore": ["src/prisma/seed.ts", "src/prisma/seed/**"],
-      "ignoreDependencies": ["@zoonk/utils"],
       "prisma": false
     },
     "packages/player": {

--- a/packages/db/src/curriculum-filters.ts
+++ b/packages/db/src/curriculum-filters.ts
@@ -1,3 +1,4 @@
+import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { type Prisma } from "./generated/prisma/client";
 
 type CourseWhere = Omit<Prisma.CourseWhereInput, "archivedAt">;
@@ -5,6 +6,18 @@ type ChapterWhere = Omit<Prisma.ChapterWhereInput, "archivedAt" | "course">;
 type LessonWhere = Omit<Prisma.LessonWhereInput, "archivedAt" | "chapter">;
 type ActivityWhere = Omit<Prisma.ActivityWhereInput, "archivedAt" | "lesson">;
 type StepWhere = Omit<Prisma.StepWhereInput, "archivedAt" | "activity">;
+
+/**
+ * Generation entry points are only supposed to operate on the public AI
+ * curriculum. Centralizing that constraint here keeps route handlers, server
+ * pages, and workflow steps aligned when they load raw ids for generation.
+ */
+function getAiCourseWhere(where: CourseWhere = {}): Prisma.CourseWhereInput {
+  return {
+    ...where,
+    organization: { slug: AI_ORG_SLUG },
+  };
+}
 
 /**
  * A course stops being part of the active curriculum as soon as it is archived.
@@ -50,6 +63,24 @@ export function getActiveChapterWhere({
 }
 
 /**
+ * Raw-id generation routes must only load chapters that belong to the public
+ * AI organization. Without this helper, any active chapter id could be treated
+ * as eligible for lesson generation just because the row exists.
+ */
+export function getAiGenerationChapterWhere({
+  chapterWhere = {},
+  courseWhere = {},
+}: {
+  chapterWhere?: ChapterWhere;
+  courseWhere?: CourseWhere;
+} = {}): Prisma.ChapterWhereInput {
+  return getActiveChapterWhere({
+    chapterWhere,
+    courseWhere: getAiCourseWhere(courseWhere),
+  });
+}
+
+/**
  * Public chapter reads should only see chapters that are still visible in the
  * live catalog, which means both the chapter and its parent course must remain
  * published and unarchived.
@@ -91,6 +122,27 @@ export function getActiveLessonWhere({
       courseWhere,
     }),
   };
+}
+
+/**
+ * Lesson generation is also keyed by raw ids, so every entry point needs one
+ * shared definition of "AI-owned lesson". Tying the org check to the full
+ * ancestor chain avoids route-level drift when lessons are loaded indirectly.
+ */
+export function getAiGenerationLessonWhere({
+  chapterWhere = {},
+  courseWhere = {},
+  lessonWhere = {},
+}: {
+  chapterWhere?: ChapterWhere;
+  courseWhere?: CourseWhere;
+  lessonWhere?: LessonWhere;
+} = {}): Prisma.LessonWhereInput {
+  return getActiveLessonWhere({
+    chapterWhere,
+    courseWhere: getAiCourseWhere(courseWhere),
+    lessonWhere,
+  });
 }
 
 /**
@@ -141,6 +193,30 @@ export function getActiveActivityWhere({
       lessonWhere,
     }),
   };
+}
+
+/**
+ * Activity generation loads activities from a lesson id rather than a branded
+ * URL. This helper ensures those background reads only see activity rows that
+ * live under the public AI curriculum branch.
+ */
+export function getAiGenerationActivityWhere({
+  activityWhere = {},
+  chapterWhere = {},
+  courseWhere = {},
+  lessonWhere = {},
+}: {
+  activityWhere?: ActivityWhere;
+  chapterWhere?: ChapterWhere;
+  courseWhere?: CourseWhere;
+  lessonWhere?: LessonWhere;
+} = {}): Prisma.ActivityWhereInput {
+  return getActiveActivityWhere({
+    activityWhere,
+    chapterWhere,
+    courseWhere: getAiCourseWhere(courseWhere),
+    lessonWhere,
+  });
 }
 
 /**

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -61,6 +61,9 @@ export type Sql = Prisma.Sql;
 export type TransactionClient = Parameters<Parameters<typeof prisma.$transaction>[0]>[0];
 
 export {
+  getAiGenerationActivityWhere,
+  getAiGenerationChapterWhere,
+  getAiGenerationLessonWhere,
   getActiveActivityWhere,
   getActiveChapterWhere,
   getActiveCourseWhere,

--- a/packages/e2e/src/helpers.ts
+++ b/packages/e2e/src/helpers.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { type Locator, type Page, expect, request } from "@playwright/test";
-import { prisma } from "@zoonk/db";
+import { type Organization, prisma } from "@zoonk/db";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -40,6 +40,26 @@ export async function getAiOrganization() {
     create: { kind: "brand", name: "Zoonk AI", slug: AI_ORG_SLUG },
     update: {},
     where: { slug: AI_ORG_SLUG },
+  });
+}
+
+/**
+ * Create a non-AI organization for Playwright tests without importing auth fixtures.
+ * Some browser tests only need a second org to verify routing and authorization rules.
+ * Using Prisma directly keeps the e2e environment isolated from better-auth and Next.js
+ * server-only imports that are not available in the Playwright runtime.
+ */
+export async function createOrganization(
+  attrs?: Partial<Pick<Organization, "kind" | "name" | "slug">>,
+) {
+  const uniqueId = randomUUID().slice(0, UUID_SHORT_LENGTH);
+
+  return prisma.organization.create({
+    data: {
+      kind: attrs?.kind ?? "brand",
+      name: attrs?.name ?? `E2E Organization ${uniqueId}`,
+      slug: attrs?.slug ?? `e2e-org-${uniqueId}`,
+    },
   });
 }
 

--- a/packages/testing/src/fixtures/orgs.ts
+++ b/packages/testing/src/fixtures/orgs.ts
@@ -30,6 +30,12 @@ export async function organizationFixture(attrs?: Partial<Organization>) {
   return org;
 }
 
+/**
+ * Create a member when a test needs both a user and an organization.
+ * Many permission tests operate at the membership level, so this fixture keeps
+ * user, organization, and member creation in one place instead of repeating the
+ * same setup in every test.
+ */
 export async function memberFixture(
   attrs?: {
     orgKind?: Organization["kind"];

--- a/packages/testing/src/fixtures/users.ts
+++ b/packages/testing/src/fixtures/users.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { auth } from "@zoonk/auth/testing";
+import { prisma } from "@zoonk/db";
 
 type UserAttrs = {
   email: string;
@@ -18,9 +18,31 @@ function userAttrs(attrs?: Partial<UserAttrs>): UserAttrs {
   };
 }
 
+/**
+ * Create a credential user directly with Prisma for tests.
+ * Tests need a user row plus a credential account row so `signInAs()` can
+ * authenticate through Better Auth. Writing the same database shape directly
+ * keeps this fixture fast and avoids pulling the auth runtime into callers
+ * that only need seeded data. We still return `id` as a string for backwards
+ * compatibility because many existing tests expect Better Auth's session/user
+ * shape instead of Prisma's numeric id shape.
+ */
 export async function userFixture(attrs?: Partial<UserAttrs>) {
   const params = userAttrs(attrs);
-  const result = await auth.api.createUser({ body: params });
+  const user = await prisma.user.create({
+    data: {
+      accounts: {
+        create: {
+          accountId: params.email,
+          password: params.password,
+          providerId: "credential",
+        },
+      },
+      email: params.email,
+      name: params.name,
+      role: params.role,
+    },
+  });
 
-  return { ...result.user, password: params.password };
+  return { ...user, id: String(user.id), password: params.password };
 }


### PR DESCRIPTION
Restrict chapter, lesson, and activity generation to AI org content.

Adds backend guards, prevents non-AI catalog redirects into generation flows, and updates e2e/test coverage for the new restriction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts chapter, lesson, and activity generation to the AI org. Non-AI content no longer redirects into generation flows, APIs return 404 for non-AI ids, and empty catalog pages avoid broken “Start” links.

- New Features
  - Guarded generation triggers for chapters, lessons, activities, and lesson preload to require AI org ownership (404 otherwise).
  - Catalog: only redirect to generate pages when `brandSlug === AI_ORG_SLUG`; hide “Create activity” for non-AI; omit “Start” when no safe child exists.

- Refactors
  - Added `getAiGenerationChapterWhere`, `getAiGenerationLessonWhere`, and `getAiGenerationActivityWhere` in `@zoonk/db` and applied across API routes, workflow steps, and server data loaders.
  - Updated tests and e2e helpers (added `createOrganization`) to cover non-AI scenarios.

<sup>Written for commit f6cd95a1427007551c6d9eb6c6a70d3e9e031931. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

