### PR TITLE
fix(editor): authorize slug availability checks

### DIFF
--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/slug.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/slug.ts
@@ -18,7 +18,6 @@ export async function checkCourseSlugExists(params: {
 
   return courseSlugExistsForUpdate({
     courseId: params.courseId,
-    language: params.language,
     slug: params.slug,
   });
 }

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/slug.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/slug.ts
@@ -1,26 +1,25 @@
 "use server";
 
-import { courseSlugExists } from "@/data/courses/course-slug";
+import { courseSlugExistsForUpdate } from "@/data/courses/course-slug";
 import { updateCourse } from "@/data/courses/update-course";
 import { getErrorMessage } from "@/lib/error-messages";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
-import { ensureLocaleSuffix, toSlug } from "@zoonk/utils/string";
+import { ensureLocaleSuffix } from "@zoonk/utils/string";
 
 export async function checkCourseSlugExists(params: {
+  courseId?: number;
   language: string;
   orgSlug: string;
   slug: string;
 }): Promise<boolean> {
-  const isAiOrg = params.orgSlug === AI_ORG_SLUG;
+  if (!params.courseId) {
+    return false;
+  }
 
-  const normalizedSlug = isAiOrg
-    ? ensureLocaleSuffix(toSlug(params.slug), params.language)
-    : toSlug(params.slug);
-
-  return courseSlugExists({
+  return courseSlugExistsForUpdate({
+    courseId: params.courseId,
     language: params.language,
-    orgSlug: params.orgSlug,
-    slug: normalizedSlug,
+    slug: params.slug,
   });
 }
 

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/course-slug.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/course-slug.tsx
@@ -18,6 +18,7 @@ export async function CourseSlug({
   return (
     <SlugEditor
       checkFn={checkCourseSlugExists}
+      courseId={course.id}
       entityId={course.id}
       initialSlug={course.slug}
       language={course.language}

--- a/apps/editor/src/app/[orgSlug]/new-course/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/new-course/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { courseSlugExists } from "@/data/courses/course-slug";
+import { courseSlugExistsForCreate } from "@/data/courses/course-slug";
 import { createCourse } from "@/data/courses/create-course";
 import { getErrorMessage } from "@/lib/error-messages";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
@@ -19,14 +19,7 @@ export async function checkSlugExists({
   orgSlug: string;
   slug: string;
 }): Promise<boolean> {
-  if (!slug.trim()) {
-    return false;
-  }
-
-  const isAiOrg = orgSlug === AI_ORG_SLUG;
-  const normalizedSlug = isAiOrg ? ensureLocaleSuffix(toSlug(slug), language) : toSlug(slug);
-
-  return courseSlugExists({ language, orgSlug, slug: normalizedSlug });
+  return courseSlugExistsForCreate({ language, orgSlug, slug });
 }
 
 export async function createCourseAction(formData: CourseFormData, orgSlug: string) {

--- a/apps/editor/src/data/chapters/chapter-slug.test.ts
+++ b/apps/editor/src/data/chapters/chapter-slug.test.ts
@@ -1,16 +1,23 @@
+import { signInAs } from "@zoonk/testing/fixtures/auth";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
-import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { memberFixture, organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { beforeAll, describe, expect, test } from "vitest";
 import { chapterSlugExists } from "./chapter-slug";
 
 describe("chapterSlugExists()", () => {
   let organization: Awaited<ReturnType<typeof organizationFixture>>;
   let course: Awaited<ReturnType<typeof courseFixture>>;
+  let headers: Headers;
 
   beforeAll(async () => {
-    organization = await organizationFixture();
-    course = await courseFixture({ organizationId: organization.id });
+    const fixture = await memberFixture({ role: "admin" });
+    organization = fixture.organization;
+
+    [headers, course] = await Promise.all([
+      signInAs(fixture.user.email, fixture.user.password),
+      courseFixture({ organizationId: fixture.organization.id }),
+    ]);
   });
 
   test("returns true when slug exists in the same course", async () => {
@@ -22,6 +29,7 @@ describe("chapterSlugExists()", () => {
 
     const exists = await chapterSlugExists({
       courseId: course.id,
+      headers,
       slug: chapter.slug,
     });
 
@@ -31,6 +39,7 @@ describe("chapterSlugExists()", () => {
   test("returns false when slug does not exist", async () => {
     const exists = await chapterSlugExists({
       courseId: course.id,
+      headers,
       slug: "non-existent-slug",
     });
 
@@ -50,7 +59,26 @@ describe("chapterSlugExists()", () => {
 
     const exists = await chapterSlugExists({
       courseId: course.id,
+      headers,
       slug: chapter.slug,
+    });
+
+    expect(exists).toBe(false);
+  });
+
+  test("returns false when the user cannot update the target course", async () => {
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+    const otherChapter = await chapterFixture({
+      courseId: otherCourse.id,
+      language: otherCourse.language,
+      organizationId: otherOrg.id,
+    });
+
+    const exists = await chapterSlugExists({
+      courseId: otherCourse.id,
+      headers,
+      slug: otherChapter.slug,
     });
 
     expect(exists).toBe(false);

--- a/apps/editor/src/data/chapters/chapter-slug.ts
+++ b/apps/editor/src/data/chapters/chapter-slug.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
+import { getAuthorizedActiveCourse } from "../courses/get-authorized-course";
 
 const cachedChapterSlugExists = cache(async (courseId: number, slug: string): Promise<boolean> => {
   const { data } = await safeAsync(() =>
@@ -13,6 +14,28 @@ const cachedChapterSlugExists = cache(async (courseId: number, slug: string): Pr
   return data !== null;
 });
 
-export function chapterSlugExists(params: { courseId: number; slug: string }): Promise<boolean> {
-  return cachedChapterSlugExists(params.courseId, params.slug);
+/**
+ * Chapter slug checks receive a course id from the client, so this helper
+ * revalidates the active course and the caller's update permission before it
+ * asks whether that course already owns the candidate slug.
+ */
+export async function chapterSlugExists(params: {
+  courseId: number;
+  headers?: Headers;
+  slug: string;
+}): Promise<boolean> {
+  if (!params.slug.trim()) {
+    return false;
+  }
+
+  const { data: course, error } = await getAuthorizedActiveCourse({
+    courseId: params.courseId,
+    headers: params.headers,
+  });
+
+  if (error) {
+    return false;
+  }
+
+  return cachedChapterSlugExists(course.id, params.slug);
 }

--- a/apps/editor/src/data/chapters/get-authorized-chapter.ts
+++ b/apps/editor/src/data/chapters/get-authorized-chapter.ts
@@ -1,0 +1,51 @@
+import "server-only";
+import { ErrorCode } from "@/lib/app-error";
+import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
+import { type Chapter, getActiveChapterWhere, prisma } from "@zoonk/db";
+import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { cache } from "react";
+
+const cachedGetAuthorizedActiveChapter = cache(
+  async (chapterId: number, headers?: Headers): Promise<SafeReturn<Chapter>> => {
+    const { data: chapter, error: findError } = await safeAsync(() =>
+      prisma.chapter.findFirst({
+        where: getActiveChapterWhere({
+          chapterWhere: { id: chapterId },
+        }),
+      }),
+    );
+
+    if (findError) {
+      return { data: null, error: findError };
+    }
+
+    if (!chapter) {
+      return { data: null, error: new AppError(ErrorCode.chapterNotFound) };
+    }
+
+    const hasPermission = await hasCoursePermission({
+      headers,
+      orgId: chapter.organizationId,
+      permission: "update",
+    });
+
+    if (!hasPermission) {
+      return { data: null, error: new AppError(ErrorCode.forbidden) };
+    }
+
+    return { data: chapter, error: null };
+  },
+);
+
+/**
+ * Lesson slug checks receive a chapter id from the browser, so this helper
+ * resolves the canonical active chapter on the server and confirms the caller
+ * can still update that organization before any follow-up query trusts the id.
+ * React cache deduplicates repeated authorized chapter reads in the same request.
+ */
+export function getAuthorizedActiveChapter(params: {
+  chapterId: number;
+  headers?: Headers;
+}): Promise<SafeReturn<Chapter>> {
+  return cachedGetAuthorizedActiveChapter(params.chapterId, params.headers);
+}

--- a/apps/editor/src/data/courses/course-slug.test.ts
+++ b/apps/editor/src/data/courses/course-slug.test.ts
@@ -172,7 +172,6 @@ describe("courseSlugExistsForUpdate()", () => {
     const exists = await courseSlugExistsForUpdate({
       courseId: course.id,
       headers,
-      language: course.language,
       slug: course.slug,
     });
 
@@ -188,7 +187,6 @@ describe("courseSlugExistsForUpdate()", () => {
     const exists = await courseSlugExistsForUpdate({
       courseId: otherCourse.id,
       headers,
-      language: otherCourse.language,
       slug: otherCourse.slug,
     });
 

--- a/apps/editor/src/data/courses/course-slug.test.ts
+++ b/apps/editor/src/data/courses/course-slug.test.ts
@@ -1,9 +1,10 @@
 import { prisma } from "@zoonk/db";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
 import { courseAlternativeTitleFixture, courseFixture } from "@zoonk/testing/fixtures/courses";
-import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { memberFixture, organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { beforeAll, describe, expect, test } from "vitest";
-import { courseSlugExists } from "./course-slug";
+import { courseSlugExistsForCreate, courseSlugExistsForUpdate } from "./course-slug";
 
 async function getOrCreateAIOrg() {
   return prisma.organization.upsert({
@@ -13,17 +14,21 @@ async function getOrCreateAIOrg() {
   });
 }
 
-describe("courseSlugExists()", () => {
+describe("courseSlugExistsForCreate()", () => {
   let organization: Awaited<ReturnType<typeof organizationFixture>>;
+  let headers: Headers;
 
   beforeAll(async () => {
-    organization = await organizationFixture();
+    const fixture = await memberFixture({ role: "admin" });
+    organization = fixture.organization;
+    headers = await signInAs(fixture.user.email, fixture.user.password);
   });
 
   test("returns true when slug exists for same org", async () => {
     const course = await courseFixture({ organizationId: organization.id });
 
-    const exists = await courseSlugExists({
+    const exists = await courseSlugExistsForCreate({
+      headers,
       language: "en",
       orgSlug: organization.slug,
       slug: course.slug,
@@ -33,7 +38,8 @@ describe("courseSlugExists()", () => {
   });
 
   test("returns false when slug does not exist", async () => {
-    const exists = await courseSlugExists({
+    const exists = await courseSlugExistsForCreate({
+      headers,
       language: "en",
       orgSlug: organization.slug,
       slug: "non-existent-slug",
@@ -48,7 +54,8 @@ describe("courseSlugExists()", () => {
       organizationId: organization.id,
     });
 
-    const exists = await courseSlugExists({
+    const exists = await courseSlugExistsForCreate({
+      headers,
       language: "pt",
       orgSlug: organization.slug,
       slug: course.slug,
@@ -57,11 +64,12 @@ describe("courseSlugExists()", () => {
     expect(exists).toBe(true);
   });
 
-  test("returns false when slug exists but organization differs", async () => {
+  test("returns false when user cannot create courses in the target organization", async () => {
     const otherOrg = await organizationFixture();
     const course = await courseFixture({ organizationId: organization.id });
 
-    const exists = await courseSlugExists({
+    const exists = await courseSlugExistsForCreate({
+      headers,
       language: "en",
       orgSlug: otherOrg.slug,
       slug: course.slug,
@@ -84,8 +92,19 @@ describe("courseSlugExists()", () => {
         language: "pt",
         slug: `alt-title-${course.id}`,
       });
+      const fixture = await memberFixture({ role: "admin" });
+      const aiHeaders = await signInAs(fixture.user.email, fixture.user.password);
 
-      const exists = await courseSlugExists({
+      await prisma.member.create({
+        data: {
+          organizationId: aiOrg.id,
+          role: "admin",
+          userId: fixture.user.id,
+        },
+      });
+
+      const exists = await courseSlugExistsForCreate({
+        headers: aiHeaders,
         language: "pt",
         orgSlug: aiOrg.slug,
         slug: `${altTitle.slug}-pt`,
@@ -96,13 +115,25 @@ describe("courseSlugExists()", () => {
 
     test("returns false when slug matches an alternative title in a different language", async () => {
       const course = await courseFixture({ language: "pt", organizationId: aiOrg.id });
+      const fixture = await memberFixture({ role: "admin" });
+      const aiHeaders = await signInAs(fixture.user.email, fixture.user.password);
+
+      await prisma.member.create({
+        data: {
+          organizationId: aiOrg.id,
+          role: "admin",
+          userId: fixture.user.id,
+        },
+      });
+
       await courseAlternativeTitleFixture({
         courseId: course.id,
         language: "pt",
         slug: `alt-diff-lang-${course.id}`,
       });
 
-      const exists = await courseSlugExists({
+      const exists = await courseSlugExistsForCreate({
+        headers: aiHeaders,
         language: "es",
         orgSlug: aiOrg.slug,
         slug: `alt-diff-lang-${course.id}-es`,
@@ -120,7 +151,8 @@ describe("courseSlugExists()", () => {
         slug: `alt-non-ai-${course.id}`,
       });
 
-      const exists = await courseSlugExists({
+      const exists = await courseSlugExistsForCreate({
+        headers,
         language: "pt",
         orgSlug: nonAiOrg.slug,
         slug: `${altTitle.slug}-pt`,
@@ -128,5 +160,38 @@ describe("courseSlugExists()", () => {
 
       expect(exists).toBe(false);
     });
+  });
+});
+
+describe("courseSlugExistsForUpdate()", () => {
+  test("returns true when the user can update the course organization", async () => {
+    const fixture = await memberFixture({ role: "admin" });
+    const headers = await signInAs(fixture.user.email, fixture.user.password);
+    const course = await courseFixture({ organizationId: fixture.organization.id });
+
+    const exists = await courseSlugExistsForUpdate({
+      courseId: course.id,
+      headers,
+      language: course.language,
+      slug: course.slug,
+    });
+
+    expect(exists).toBe(true);
+  });
+
+  test("returns false when the user cannot update the target course organization", async () => {
+    const fixture = await memberFixture({ role: "admin" });
+    const headers = await signInAs(fixture.user.email, fixture.user.password);
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+
+    const exists = await courseSlugExistsForUpdate({
+      courseId: otherCourse.id,
+      headers,
+      language: otherCourse.language,
+      slug: otherCourse.slug,
+    });
+
+    expect(exists).toBe(false);
   });
 });

--- a/apps/editor/src/data/courses/course-slug.ts
+++ b/apps/editor/src/data/courses/course-slug.ts
@@ -1,9 +1,11 @@
 import "server-only";
+import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
-import { removeLocaleSuffix } from "@zoonk/utils/string";
+import { ensureLocaleSuffix, removeLocaleSuffix, toSlug } from "@zoonk/utils/string";
 import { cache } from "react";
+import { getAuthorizedActiveCourse } from "./get-authorized-course";
 
 const cachedCourseSlugExists = cache(
   async (orgSlug: string, slug: string, language: string): Promise<boolean> => {
@@ -27,10 +29,80 @@ const cachedCourseSlugExists = cache(
   },
 );
 
-export function courseSlugExists(params: {
+/**
+ * AI-managed courses reserve locale-suffixed slugs, while every other
+ * organization stores the plain normalized slug. This helper keeps the editor's
+ * availability checks aligned with the slug that the save path will persist.
+ */
+function normalizeCourseSlug(params: { language: string; orgSlug: string; slug: string }): string {
+  const normalizedSlug = toSlug(params.slug);
+
+  if (params.orgSlug !== AI_ORG_SLUG) {
+    return normalizedSlug;
+  }
+
+  return ensureLocaleSuffix(normalizedSlug, params.language);
+}
+
+/**
+ * Course creation checks receive an org slug before a course exists, so this
+ * helper verifies the caller can create courses in that organization before it
+ * asks whether the normalized slug is already reserved there.
+ */
+export async function courseSlugExistsForCreate(params: {
+  headers?: Headers;
   language: string;
   orgSlug: string;
   slug: string;
 }): Promise<boolean> {
-  return cachedCourseSlugExists(params.orgSlug, params.slug, params.language);
+  if (!params.slug.trim()) {
+    return false;
+  }
+
+  const hasPermission = await hasCoursePermission({
+    headers: params.headers,
+    orgSlug: params.orgSlug,
+    permission: "create",
+  });
+
+  if (!hasPermission) {
+    return false;
+  }
+
+  return cachedCourseSlugExists(params.orgSlug, normalizeCourseSlug(params), params.language);
+}
+
+/**
+ * Course rename checks should not trust a client-provided org slug, so this
+ * helper re-resolves the active course by id and uses the authorized
+ * organization scope for the duplicate lookup.
+ */
+export async function courseSlugExistsForUpdate(params: {
+  courseId: number;
+  headers?: Headers;
+  language: string;
+  slug: string;
+}): Promise<boolean> {
+  if (!params.slug.trim()) {
+    return false;
+  }
+
+  const { data: course, error } = await getAuthorizedActiveCourse({
+    courseId: params.courseId,
+    headers: params.headers,
+  });
+
+  if (error) {
+    return false;
+  }
+
+  return cachedCourseSlugExists(
+    course.organization.slug,
+    normalizeCourseSlug({
+      language: course.language,
+      orgSlug: course.organization.slug,
+      slug: params.slug,
+    }),
+    course.language,
+  );
 }

--- a/apps/editor/src/data/courses/course-slug.ts
+++ b/apps/editor/src/data/courses/course-slug.ts
@@ -80,7 +80,6 @@ export async function courseSlugExistsForCreate(params: {
 export async function courseSlugExistsForUpdate(params: {
   courseId: number;
   headers?: Headers;
-  language: string;
   slug: string;
 }): Promise<boolean> {
   if (!params.slug.trim()) {

--- a/apps/editor/src/data/courses/get-authorized-course.ts
+++ b/apps/editor/src/data/courses/get-authorized-course.ts
@@ -3,6 +3,7 @@ import { ErrorCode } from "@/lib/app-error";
 import { hasCoursePermission } from "@zoonk/core/orgs/permissions";
 import { type CourseGetPayload, getActiveCourseWhere, prisma } from "@zoonk/db";
 import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { cache } from "react";
 
 const courseWithOrganizationSlug = {
   include: {
@@ -62,48 +63,69 @@ async function toAuthorizedCourseResult(params: {
   };
 }
 
+const cachedGetAuthorizedCourse = cache(
+  async (
+    courseId: number,
+    headers?: Headers,
+  ): Promise<SafeReturn<AuthorizedCourseWithOrganization>> => {
+    const { data: course, error } = await safeAsync(() =>
+      prisma.course.findUnique({
+        ...courseWithOrganizationSlug,
+        where: { id: courseId },
+      }),
+    );
+
+    return toAuthorizedCourseResult({
+      course,
+      error,
+      headers,
+    });
+  },
+);
+
 /**
  * Course mutations receive a client-provided course id, so this helper exists to
  * resolve the canonical course record on the server and confirm the caller can
  * still update that course before any mutation or derived path uses its data.
+ * Wrapping the lookup in React cache deduplicates repeated authorization reads
+ * for the same course within a single request.
  */
-export async function getAuthorizedCourse(params: {
+export function getAuthorizedCourse(params: {
   courseId: number;
   headers?: Headers;
 }): Promise<SafeReturn<AuthorizedCourseWithOrganization>> {
-  const { data: course, error } = await safeAsync(() =>
-    prisma.course.findUnique({
-      ...courseWithOrganizationSlug,
-      where: { id: params.courseId },
-    }),
-  );
-
-  return toAuthorizedCourseResult({
-    course,
-    error,
-    headers: params.headers,
-  });
+  return cachedGetAuthorizedCourse(params.courseId, params.headers);
 }
+
+const cachedGetAuthorizedActiveCourse = cache(
+  async (
+    courseId: number,
+    headers?: Headers,
+  ): Promise<SafeReturn<AuthorizedCourseWithOrganization>> => {
+    const { data: course, error } = await safeAsync(() =>
+      prisma.course.findFirst({
+        ...courseWithOrganizationSlug,
+        where: getActiveCourseWhere({ id: courseId }),
+      }),
+    );
+
+    return toAuthorizedCourseResult({
+      course,
+      error,
+      headers,
+    });
+  },
+);
 
 /**
  * Some course write paths should treat archived courses as unavailable, so this
  * helper preserves the shared authorization behavior while enforcing the active
- * course filter those mutations already rely on.
+ * course filter those mutations already rely on. React cache keeps repeated
+ * authorized reads for the same active course from re-running in one request.
  */
-export async function getAuthorizedActiveCourse(params: {
+export function getAuthorizedActiveCourse(params: {
   courseId: number;
   headers?: Headers;
 }): Promise<SafeReturn<AuthorizedCourseWithOrganization>> {
-  const { data: course, error } = await safeAsync(() =>
-    prisma.course.findFirst({
-      ...courseWithOrganizationSlug,
-      where: getActiveCourseWhere({ id: params.courseId }),
-    }),
-  );
-
-  return toAuthorizedCourseResult({
-    course,
-    error,
-    headers: params.headers,
-  });
+  return cachedGetAuthorizedActiveCourse(params.courseId, params.headers);
 }

--- a/apps/editor/src/data/lessons/lesson-slug.test.ts
+++ b/apps/editor/src/data/lessons/lesson-slug.test.ts
@@ -1,22 +1,29 @@
+import { signInAs } from "@zoonk/testing/fixtures/auth";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
-import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { memberFixture, organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { beforeAll, describe, expect, test } from "vitest";
 import { lessonSlugExists } from "./lesson-slug";
 
 describe("lessonSlugExists()", () => {
   let organization: Awaited<ReturnType<typeof organizationFixture>>;
   let chapter: Awaited<ReturnType<typeof chapterFixture>>;
+  let headers: Headers;
 
   beforeAll(async () => {
-    organization = await organizationFixture();
-    const course = await courseFixture({ organizationId: organization.id });
-    chapter = await chapterFixture({
-      courseId: course.id,
-      language: course.language,
-      organizationId: organization.id,
-    });
+    const fixture = await memberFixture({ role: "admin" });
+    organization = fixture.organization;
+
+    const course = await courseFixture({ organizationId: fixture.organization.id });
+    [headers, chapter] = await Promise.all([
+      signInAs(fixture.user.email, fixture.user.password),
+      chapterFixture({
+        courseId: course.id,
+        language: course.language,
+        organizationId: fixture.organization.id,
+      }),
+    ]);
   });
 
   test("returns true when slug exists in same chapter", async () => {
@@ -28,6 +35,7 @@ describe("lessonSlugExists()", () => {
 
     const exists = await lessonSlugExists({
       chapterId: chapter.id,
+      headers,
       slug: lesson.slug,
     });
 
@@ -37,6 +45,7 @@ describe("lessonSlugExists()", () => {
   test("returns false when slug does not exist", async () => {
     const exists = await lessonSlugExists({
       chapterId: chapter.id,
+      headers,
       slug: "non-existent-slug",
     });
 
@@ -66,7 +75,31 @@ describe("lessonSlugExists()", () => {
 
     const exists = await lessonSlugExists({
       chapterId: chapter2.id,
+      headers,
       slug: lesson.slug,
+    });
+
+    expect(exists).toBe(false);
+  });
+
+  test("returns false when the user cannot update the target chapter", async () => {
+    const otherOrg = await organizationFixture();
+    const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+    const otherChapter = await chapterFixture({
+      courseId: otherCourse.id,
+      language: otherCourse.language,
+      organizationId: otherOrg.id,
+    });
+    const otherLesson = await lessonFixture({
+      chapterId: otherChapter.id,
+      language: otherChapter.language,
+      organizationId: otherOrg.id,
+    });
+
+    const exists = await lessonSlugExists({
+      chapterId: otherChapter.id,
+      headers,
+      slug: otherLesson.slug,
     });
 
     expect(exists).toBe(false);

--- a/apps/editor/src/data/lessons/lesson-slug.ts
+++ b/apps/editor/src/data/lessons/lesson-slug.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
+import { getAuthorizedActiveChapter } from "../chapters/get-authorized-chapter";
 
 const cachedLessonSlugExists = cache(async (chapterId: number, slug: string): Promise<boolean> => {
   const { data } = await safeAsync(() =>
@@ -13,6 +14,28 @@ const cachedLessonSlugExists = cache(async (chapterId: number, slug: string): Pr
   return data !== null;
 });
 
-export function lessonSlugExists(params: { chapterId: number; slug: string }): Promise<boolean> {
-  return cachedLessonSlugExists(params.chapterId, params.slug);
+/**
+ * Lesson slug checks are scoped by chapter id, so this helper first resolves
+ * the canonical active chapter the caller can still update before it performs
+ * the existence query inside that chapter.
+ */
+export async function lessonSlugExists(params: {
+  chapterId: number;
+  headers?: Headers;
+  slug: string;
+}): Promise<boolean> {
+  if (!params.slug.trim()) {
+    return false;
+  }
+
+  const { data: chapter, error } = await getAuthorizedActiveChapter({
+    chapterId: params.chapterId,
+    headers: params.headers,
+  });
+
+  if (error) {
+    return false;
+  }
+
+  return cachedLessonSlugExists(chapter.id, params.slug);
 }


### PR DESCRIPTION
Authorize the editor slug-availability checks on the server before querying slug existence.

- re-resolve canonical course and chapter records before scoped slug checks
- cache authorized course and chapter reads with react cache
- add tests for cross-tenant and unauthorized probe attempts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authorize editor slug availability checks on the server to block cross-tenant and unauthorized probes. Revalidate the course/chapter context and permissions before any existence query, and align slug normalization.

- **Bug Fixes**
  - Enforced server-side authorization for course, chapter, and lesson slug checks using authorized active course/chapter reads.
  - Split course checks into `courseSlugExistsForCreate` and `courseSlugExistsForUpdate`; normalize slugs internally (including AI org locale suffixes).
  - Removed the `language` param from `courseSlugExistsForUpdate`; it now resolves course and org on the server.
  - Deduplicated authorized reads with `react` cache.
  - Updated editor actions to pass `courseId` and use the new helpers; short-circuit empty slugs.
  - Expanded tests for cross-tenant and unauthorized probe attempts across courses, chapters, and lessons.

<sup>Written for commit b99237cad72eec8cbfba991348073b3e8ad9dbb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

