### PR TITLE
fix(auth): don't update name on checkout

### DIFF
--- a/packages/auth/src/stripe/plugin.ts
+++ b/packages/auth/src/stripe/plugin.ts
@@ -20,6 +20,7 @@ export function stripePlugin({ createCustomerOnSignUp = true }: StripePluginOpti
         params: {
           allow_promotion_codes: true,
           billing_address_collection: "required",
+          customer_update: { name: "never" },
           tax_id_collection: { enabled: true },
         },
       }),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent Stripe Checkout from updating the customer's name so the auth profile stays unchanged. Sets `customer_update: { name: 'never' }` in the checkout session params in `packages/auth/src/stripe/plugin.ts`.

<sup>Written for commit e034910aa0ba008c3f29f14d4042ea057ecf21ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

