### PR TITLE
refactor(db): migrate ids to uuid v7

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       db:
-        image: postgres:17-alpine
+        image: postgres:18-alpine
         ports: ["5432:5432"]
         env:
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/e2e-api.yml
+++ b/.github/workflows/e2e-api.yml
@@ -35,7 +35,7 @@ jobs:
 
     services:
       db:
-        image: postgres:17-alpine
+        image: postgres:18-alpine
         ports: ["5432:5432"]
         env:
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/e2e-editor.yml
+++ b/.github/workflows/e2e-editor.yml
@@ -34,7 +34,7 @@ jobs:
 
     services:
       db:
-        image: postgres:17-alpine
+        image: postgres:18-alpine
         ports: ["5432:5432"]
         env:
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -38,7 +38,7 @@ jobs:
 
     services:
       db:
-        image: postgres:17-alpine
+        image: postgres:18-alpine
         ports: ["5432:5432"]
         env:
           POSTGRES_PASSWORD: postgres

--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
   - [Local Development](#local-development)
-- [Overview](#overview)
-  - [Apps](#apps)
-  - [Packages](#packages)
 - [Translations](#translations)
 - [Remote Caching](#remote-caching)
 - [Supporters](#supporters)
@@ -52,7 +49,7 @@
 
 - Node.js v24
 - pnpm v10
-- PostgreSQL v17
+- PostgreSQL v18
 
 We recommend using [mise](https://mise.jdx.dev/) to manage your Node.js and pnpm versions.
 
@@ -71,31 +68,6 @@ We recommend using [mise](https://mise.jdx.dev/) to manage your Node.js and pnpm
 - `pnpm knip --production` to check for unused code
 - `pnpm test` to run tests with Vitest
 - `pnpm e2e` to run end-to-end tests with Playwright
-
-## Overview
-
-### Apps
-
-- [main](./apps/main): Public web app (`zoonk.com`)
-- [admin](./apps/admin): Dashboard for managing users and organizations (`admin.zoonk.com`)
-- [api](./apps/api): Centralized API and authentication UI (`api.zoonk.com`)
-- [editor](./apps/editor): Visual editor for building courses and activities (`editor.zoonk.com`)
-- [evals](./apps/evals): Local-only tool for evaluating AI-generated content
-
-### Packages
-
-- [ai](./packages/ai): AI prompts, tasks, and helpers for content generation
-- [auth](./packages/auth): Shared Better Auth setup and plugins
-- [core](./packages/core): Shared server utilities
-- [db](./packages/db): Prisma schema and client
-- [e2e](./packages/e2e): Shared Playwright config and test fixtures
-- [oxlint-plugin](./packages/oxlint-plugin): Custom oxlint rules
-- [mailer](./packages/mailer): Email-sending utilities
-- [next](./packages/next): Shared Next.js utilities
-- [testing](./packages/testing): Shared testing utilities
-- [tsconfig](./packages/tsconfig): Shared TypeScript config
-- [ui](./packages/ui): Shared React components, patterns, hooks, and styles
-- [utils](./packages/utils): Shared utilities and helpers
 
 ## i18n
 

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/approve-flagged.ts
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/approve-flagged.ts
@@ -4,20 +4,13 @@ import { assertAdmin } from "@/lib/admin-guard";
 import { type ReviewTaskType, getTaskPath, isValidTaskType } from "@/lib/review-utils";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { parseBigIntId } from "@zoonk/utils/number";
 import { redirect } from "next/navigation";
 
-export async function approveFlaggedAction(taskType: ReviewTaskType, rawEntityId: string) {
+export async function approveFlaggedAction(taskType: ReviewTaskType, entityId: string) {
   const session = await assertAdmin();
 
   if (!isValidTaskType(taskType)) {
     throw new Error("Invalid task type");
-  }
-
-  const entityId = parseBigIntId(rawEntityId);
-
-  if (!entityId) {
-    throw new Error("Invalid entity ID");
   }
 
   const userId = session.user.id;

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/course-suggestion.ts
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/course-suggestion.ts
@@ -10,15 +10,13 @@ import { revalidatePath } from "next/cache";
 export async function updateCourseSuggestionAction(formData: FormData) {
   await assertAdmin();
 
-  const suggestionIdRaw = parseFormField(formData, "suggestionId");
+  const suggestionId = parseFormField(formData, "suggestionId");
   const title = parseFormField(formData, "title");
   const description = parseFormField(formData, "description");
 
-  if (!suggestionIdRaw || !title || !description) {
+  if (!suggestionId || !title || !description) {
     throw new Error("Invalid form data");
   }
-
-  const suggestionId = Number(suggestionIdRaw);
 
   const { error } = await safeAsync(() =>
     prisma.courseSuggestion.update({
@@ -37,15 +35,12 @@ export async function updateCourseSuggestionAction(formData: FormData) {
 export async function removeCourseSuggestionAction(formData: FormData) {
   await assertAdmin();
 
-  const searchPromptIdRaw = parseFormField(formData, "searchPromptId");
-  const courseSuggestionIdRaw = parseFormField(formData, "courseSuggestionId");
+  const searchPromptId = parseFormField(formData, "searchPromptId");
+  const courseSuggestionId = parseFormField(formData, "courseSuggestionId");
 
-  if (!searchPromptIdRaw || !courseSuggestionIdRaw) {
+  if (!searchPromptId || !courseSuggestionId) {
     throw new Error("Invalid form data");
   }
-
-  const searchPromptId = Number(searchPromptIdRaw);
-  const courseSuggestionId = Number(courseSuggestionIdRaw);
 
   const { error } = await safeAsync(() =>
     prisma.searchPromptSuggestion.delete({
@@ -63,13 +58,11 @@ export async function removeCourseSuggestionAction(formData: FormData) {
 export async function addCourseSuggestionAction(formData: FormData) {
   await assertAdmin();
 
-  const searchPromptIdRaw = parseFormField(formData, "searchPromptId");
+  const searchPromptId = parseFormField(formData, "searchPromptId");
   const title = parseFormField(formData, "title");
   const description = parseFormField(formData, "description");
   const language = parseFormField(formData, "language");
   const targetLanguage = parseFormField(formData, "targetLanguage");
-
-  const searchPromptId = searchPromptIdRaw ? Number(searchPromptIdRaw) : null;
 
   if (!searchPromptId || !title || !description || !language) {
     throw new Error("Invalid form data");

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/step-image.ts
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/step-image.ts
@@ -5,7 +5,6 @@ import { processAndUploadImage } from "@zoonk/core/images/process-and-upload";
 import { parseStepContent } from "@zoonk/core/steps/contract/content";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { parseBigIntId } from "@zoonk/utils/number";
 import { revalidatePath } from "next/cache";
 
 export async function uploadStepImageAction(
@@ -19,11 +18,7 @@ export async function uploadStepImageAction(
     return { error: "Unauthorized", imageUrl: null };
   }
 
-  const stepId = parseBigIntId(params.stepId);
-
-  if (!stepId) {
-    return { error: "Invalid step ID", imageUrl: null };
-  }
+  const stepId = params.stepId;
 
   const { imageTarget } = params;
   const file = formData.get("file");

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/upload-audio.ts
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/upload-audio.ts
@@ -3,7 +3,6 @@
 import { isAdmin } from "@/lib/admin-guard";
 import { uploadAudio } from "@zoonk/core/audio/upload";
 import { prisma } from "@zoonk/db";
-import { parseBigIntId } from "@zoonk/utils/number";
 import { DEFAULT_AUDIO_ACCEPTED_TYPES, DEFAULT_AUDIO_MAX_SIZE } from "@zoonk/utils/upload";
 import { revalidatePath } from "next/cache";
 
@@ -43,16 +42,10 @@ async function uploadEntityAudio({
   entityId: string;
   entityType: string;
   formData: FormData;
-  updateEntity: (audioUrl: string, id: bigint) => Promise<unknown>;
+  updateEntity: (audioUrl: string, id: string) => Promise<unknown>;
 }): Promise<{ error: string | null }> {
   if (!(await isAdmin())) {
     return { error: "Unauthorized" };
-  }
-
-  const id = parseBigIntId(entityId);
-
-  if (!id) {
-    return { error: `Invalid ${entityType} ID` };
   }
 
   const validation = validateAudioFile(formData);
@@ -66,14 +59,14 @@ async function uploadEntityAudio({
 
   const { data: audioUrl, error: uploadError } = await uploadAudio({
     audio: buffer,
-    fileName: `audio/admin-review/${entityType}-${id}.${extension}`,
+    fileName: `audio/admin-review/${entityType}-${entityId}.${extension}`,
   });
 
   if (uploadError) {
     return { error: "Failed to upload audio. Please try again." };
   }
 
-  await updateEntity(audioUrl, id);
+  await updateEntity(audioUrl, entityId);
 
   revalidatePath("/review");
   return { error: null };

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/course-suggestion-edit.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/course-suggestion-edit.tsx
@@ -18,7 +18,7 @@ function SuggestionForm({
   searchPromptId,
 }: {
   suggestion: CourseSuggestionReviewData["suggestions"][number]["courseSuggestion"];
-  searchPromptId: number;
+  searchPromptId: string;
 }) {
   return (
     <div className="flex flex-col gap-3 border-b pb-4 last:border-b-0">
@@ -51,7 +51,7 @@ function AddSuggestionForm({
   searchPromptId,
   language,
 }: {
-  searchPromptId: number;
+  searchPromptId: string;
   language: string;
 }) {
   return (

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/flagged-item-content.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/flagged-item-content.tsx
@@ -13,7 +13,7 @@ import { CourseSuggestionEdit } from "./course-suggestion-edit";
 import { StepSelectImageEdit } from "./step-select-image-edit";
 import { StepVisualImageEdit } from "./step-visual-image-edit";
 
-async function renderWordAudio(entityId: bigint) {
+async function renderWordAudio(entityId: string) {
   const item = await getWordAudioReview(entityId);
 
   if (!item) {
@@ -24,7 +24,7 @@ async function renderWordAudio(entityId: bigint) {
     <AudioEdit
       item={{
         audioUrl: item.audioUrl,
-        id: item.id.toString(),
+        id: item.id,
         label: "word",
         romanization: item.romanization,
         targetLanguage: item.targetLanguage,
@@ -35,7 +35,7 @@ async function renderWordAudio(entityId: bigint) {
   );
 }
 
-async function renderSentenceAudio(entityId: bigint) {
+async function renderSentenceAudio(entityId: string) {
   const item = await getSentenceAudioReview(entityId);
 
   if (!item) {
@@ -46,7 +46,7 @@ async function renderSentenceAudio(entityId: bigint) {
     <AudioEdit
       item={{
         audioUrl: item.audioUrl,
-        id: item.id.toString(),
+        id: item.id,
         label: "sentence",
         romanization: item.romanization,
         targetLanguage: item.targetLanguage,
@@ -62,7 +62,7 @@ export async function FlaggedItemContent({
   entityId,
 }: {
   taskType: ReviewTaskType;
-  entityId: bigint;
+  entityId: string;
 }) {
   const visualKind = getVisualKindFromTaskType(taskType);
 
@@ -79,11 +79,7 @@ export async function FlaggedItemContent({
       notFound();
     }
 
-    return (
-      <StepVisualImageEdit
-        item={{ activity: step.activity, content: visual, id: step.id.toString() }}
-      />
-    );
+    return <StepVisualImageEdit item={{ activity: step.activity, content: visual, id: step.id }} />;
   }
 
   if (taskType === "stepSelectImage") {
@@ -94,9 +90,7 @@ export async function FlaggedItemContent({
     }
 
     const content = parseStepContent("selectImage", step.content);
-    return (
-      <StepSelectImageEdit item={{ activity: step.activity, content, id: step.id.toString() }} />
-    );
+    return <StepSelectImageEdit item={{ activity: step.activity, content, id: step.id }} />;
   }
 
   if (taskType === "courseSuggestions") {

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/page.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/page.tsx
@@ -19,7 +19,6 @@ import {
   ContainerHeaderGroup,
 } from "@zoonk/ui/components/container";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
-import { parseBigIntId } from "@zoonk/utils/number";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
@@ -66,16 +65,10 @@ function ContentSkeleton() {
 export default async function FlaggedItemPage({
   params,
 }: PageProps<"/review/[group]/[task]/[entityId]">) {
-  const { group, task, entityId: rawEntityId } = await params;
+  const { group, task, entityId } = await params;
   const taskType = resolveTaskType(group, task);
 
   if (!taskType) {
-    notFound();
-  }
-
-  const entityId = parseBigIntId(rawEntityId);
-
-  if (!entityId) {
     notFound();
   }
 
@@ -83,7 +76,7 @@ export default async function FlaggedItemPage({
     <Container>
       <ContainerHeader variant="sidebar">
         <ContainerHeaderGroup>
-          <FlaggedItemBreadcrumb taskType={taskType} entityId={entityId.toString()} />
+          <FlaggedItemBreadcrumb taskType={taskType} entityId={entityId} />
         </ContainerHeaderGroup>
       </ContainerHeader>
 
@@ -92,7 +85,7 @@ export default async function FlaggedItemPage({
           <FlaggedItemContent taskType={taskType} entityId={entityId} />
         </Suspense>
 
-        <FlaggedItemActions taskType={taskType} entityId={entityId.toString()} />
+        <FlaggedItemActions taskType={taskType} entityId={entityId} />
       </ContainerBody>
     </Container>
   );

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/remove-suggestion-button.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/remove-suggestion-button.tsx
@@ -19,16 +19,16 @@ export function RemoveSuggestionButton({
   searchPromptId,
   courseSuggestionId,
 }: {
-  searchPromptId: number;
-  courseSuggestionId: number;
+  searchPromptId: string;
+  courseSuggestionId: string;
 }) {
   const [pending, startTransition] = useTransition();
 
   function handleRemove() {
     startTransition(async () => {
       const formData = new FormData();
-      formData.append("searchPromptId", String(searchPromptId));
-      formData.append("courseSuggestionId", String(courseSuggestionId));
+      formData.append("searchPromptId", searchPromptId);
+      formData.append("courseSuggestionId", courseSuggestionId);
       await removeCourseSuggestionAction(formData);
     });
   }

--- a/apps/admin/src/app/(private)/review/[group]/[task]/flagged-list.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/flagged-list.tsx
@@ -73,8 +73,8 @@ export async function FlaggedList({
           <TableBody>
             {items.map((item) => (
               <FlaggedRow
-                key={item.id.toString()}
-                entityId={item.entityId.toString()}
+                key={item.id}
+                entityId={item.entityId}
                 flaggedBy={item.user.name}
                 flaggedAt={item.reviewedAt.toLocaleDateString()}
                 taskPath={taskPath}

--- a/apps/admin/src/app/(private)/review/[group]/[task]/review-queue.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/review-queue.tsx
@@ -6,7 +6,6 @@ import {
   getWordAudioReview,
 } from "@/data/review/get-review-item";
 import { type ReviewTaskType, getTaskPath, getVisualKindFromTaskType } from "@/lib/review-utils";
-import { parseBigIntId } from "@zoonk/utils/number";
 import { redirect } from "next/navigation";
 import { AudioReview } from "../../_components/content/audio-review";
 import { CourseSuggestionReview } from "../../_components/content/course-suggestion-review";
@@ -16,7 +15,7 @@ import { ReviewActions } from "../../_components/review-actions";
 import { ReviewEmpty } from "../../_components/review-empty";
 import { ReviewProgress } from "../../_components/review-progress";
 
-async function renderContent(taskType: ReviewTaskType, entityId: bigint) {
+async function renderContent(taskType: ReviewTaskType, entityId: string) {
   const visualKind = getVisualKindFromTaskType(taskType);
 
   if (visualKind) {
@@ -61,7 +60,7 @@ export async function ReviewQueue({
   currentId: string | undefined;
 }) {
   const queue = await getNextReviewItem(taskType);
-  const entityId = (currentId ? parseBigIntId(currentId) : null) ?? queue.entityId;
+  const entityId = currentId ?? queue.entityId;
 
   if (!entityId) {
     return <ReviewEmpty />;
@@ -79,7 +78,7 @@ export async function ReviewQueue({
 
       {content}
 
-      <ReviewActions taskType={taskType} entityId={entityId.toString()} />
+      <ReviewActions taskType={taskType} entityId={entityId} />
     </div>
   );
 }

--- a/apps/admin/src/app/(private)/review/[group]/[task]/unflag-action.ts
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/unflag-action.ts
@@ -5,7 +5,6 @@ import { getTaskPath, isValidTaskType } from "@/lib/review-utils";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
-import { parseBigIntId } from "@zoonk/utils/number";
 import { redirect } from "next/navigation";
 
 /**
@@ -19,9 +18,7 @@ export async function unflagAction(formData: FormData) {
   await assertAdmin();
 
   const taskType = parseFormField(formData, "taskType");
-  const entityIdRaw = parseFormField(formData, "entityId");
-
-  const entityId = entityIdRaw ? parseBigIntId(entityIdRaw) : null;
+  const entityId = parseFormField(formData, "entityId");
 
   if (!taskType || !entityId || !isValidTaskType(taskType)) {
     throw new Error("Invalid form data");

--- a/apps/admin/src/app/(private)/review/_actions/mark-needs-changes.ts
+++ b/apps/admin/src/app/(private)/review/_actions/mark-needs-changes.ts
@@ -6,16 +6,13 @@ import { getTaskPath, isValidTaskType } from "@/lib/review-utils";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
-import { parseBigIntId } from "@zoonk/utils/number";
 import { redirect } from "next/navigation";
 
 export async function markNeedsChangesAction(formData: FormData) {
   const session = await assertAdmin();
 
   const taskType = parseFormField(formData, "taskType");
-  const entityIdRaw = parseFormField(formData, "entityId");
-
-  const entityId = entityIdRaw ? parseBigIntId(entityIdRaw) : null;
+  const entityId = parseFormField(formData, "entityId");
 
   if (!taskType || !entityId || !isValidTaskType(taskType)) {
     throw new Error("Invalid form data");

--- a/apps/admin/src/app/(private)/review/_actions/mark-reviewed.ts
+++ b/apps/admin/src/app/(private)/review/_actions/mark-reviewed.ts
@@ -6,16 +6,13 @@ import { getTaskPath, isValidTaskType } from "@/lib/review-utils";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
-import { parseBigIntId } from "@zoonk/utils/number";
 import { redirect } from "next/navigation";
 
 export async function markReviewedAction(formData: FormData) {
   const session = await assertAdmin();
 
   const taskType = parseFormField(formData, "taskType");
-  const entityIdRaw = parseFormField(formData, "entityId");
-
-  const entityId = entityIdRaw ? parseBigIntId(entityIdRaw) : null;
+  const entityId = parseFormField(formData, "entityId");
 
   if (!taskType || !entityId || !isValidTaskType(taskType)) {
     throw new Error("Invalid form data");

--- a/apps/admin/src/app/(private)/review/_components/content/audio-review.tsx
+++ b/apps/admin/src/app/(private)/review/_components/content/audio-review.tsx
@@ -5,7 +5,7 @@ export function AudioReview({
   item,
 }: {
   item: {
-    id: bigint;
+    id: string;
     text: string;
     label: string;
     audioUrl: string | null;

--- a/apps/admin/src/app/(private)/review/_components/content/step-select-image-review.tsx
+++ b/apps/admin/src/app/(private)/review/_components/content/step-select-image-review.tsx
@@ -6,7 +6,7 @@ export function StepSelectImageReview({
   item,
 }: {
   item: {
-    id: bigint;
+    id: string;
     content: unknown;
     activity: { title: string | null };
   };

--- a/apps/admin/src/app/(private)/review/_components/content/step-visual-image-review.tsx
+++ b/apps/admin/src/app/(private)/review/_components/content/step-visual-image-review.tsx
@@ -15,7 +15,7 @@ export function StepVisualImageReview({
   item,
 }: {
   item: {
-    id: bigint;
+    id: string;
     content: unknown;
     activity: { title: string | null };
   };

--- a/apps/admin/src/data/review/count-pending-reviews.ts
+++ b/apps/admin/src/data/review/count-pending-reviews.ts
@@ -11,7 +11,7 @@ import { cache } from "react";
 
 export const reviewedEntityIds = cache(async function reviewedEntityIds(
   taskType: ReviewTaskType,
-): Promise<bigint[]> {
+): Promise<string[]> {
   const reviews = await prisma.contentReview.findMany({
     select: { entityId: true },
     where: { taskType },
@@ -20,7 +20,7 @@ export const reviewedEntityIds = cache(async function reviewedEntityIds(
   return reviews.map((review) => review.entityId);
 });
 
-function countPendingStepVisual(kind: string, excludeIds: bigint[]): Promise<number> {
+function countPendingStepVisual(kind: string, excludeIds: string[]): Promise<number> {
   return prisma.step.count({
     where: {
       NOT: { id: { in: excludeIds } },
@@ -31,7 +31,7 @@ function countPendingStepVisual(kind: string, excludeIds: bigint[]): Promise<num
   });
 }
 
-function countPendingWordAudio(excludeIds: bigint[]): Promise<number> {
+function countPendingWordAudio(excludeIds: string[]): Promise<number> {
   return prisma.word.count({
     where: {
       NOT: { id: { in: excludeIds } },
@@ -41,7 +41,7 @@ function countPendingWordAudio(excludeIds: bigint[]): Promise<number> {
   });
 }
 
-function countPendingSentenceAudio(excludeIds: bigint[]): Promise<number> {
+function countPendingSentenceAudio(excludeIds: string[]): Promise<number> {
   return prisma.sentence.count({
     where: {
       NOT: { id: { in: excludeIds } },
@@ -64,7 +64,7 @@ export const countPendingForTask = cache(async function countPendingForTask(
   if (taskType === "courseSuggestions") {
     return prisma.searchPrompt.count({
       where: {
-        NOT: { id: { in: excludeIds.map(Number) } },
+        NOT: { id: { in: excludeIds } },
         suggestions: { some: {} },
       },
     });

--- a/apps/admin/src/data/review/get-next-review-item.ts
+++ b/apps/admin/src/data/review/get-next-review-item.ts
@@ -7,7 +7,7 @@ import { cache } from "react";
 import { reviewedEntityIds } from "./count-pending-reviews";
 
 type ReviewQueueResult = {
-  entityId: bigint | null;
+  entityId: string | null;
   remaining: number;
 };
 
@@ -17,7 +17,7 @@ async function getNextCourseSuggestion(): Promise<ReviewQueueResult> {
   const excludeIds = await reviewedEntityIds("courseSuggestions");
 
   const where = {
-    NOT: { id: { in: excludeIds.map(Number) } },
+    NOT: { id: { in: excludeIds } },
     suggestions: { some: {} },
   };
 
@@ -30,7 +30,7 @@ async function getNextCourseSuggestion(): Promise<ReviewQueueResult> {
     prisma.searchPrompt.count({ where }),
   ]);
 
-  return { entityId: next ? BigInt(next.id) : null, remaining };
+  return { entityId: next?.id ?? null, remaining };
 }
 
 async function getNextStepVisualByKind(

--- a/apps/admin/src/data/review/get-review-item.ts
+++ b/apps/admin/src/data/review/get-review-item.ts
@@ -4,7 +4,7 @@ import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
 export const getCourseSuggestionReview = cache(async function getCourseSuggestionReview(
-  entityId: bigint,
+  entityId: string,
 ) {
   if (!(await isAdmin())) {
     return null;
@@ -17,11 +17,11 @@ export const getCourseSuggestionReview = cache(async function getCourseSuggestio
         orderBy: { position: "asc" },
       },
     },
-    where: { id: Number(entityId) },
+    where: { id: entityId },
   });
 });
 
-export const getStepVisualReview = cache(async function getStepVisualReview(entityId: bigint) {
+export const getStepVisualReview = cache(async function getStepVisualReview(entityId: string) {
   if (!(await isAdmin())) {
     return null;
   }
@@ -32,7 +32,7 @@ export const getStepVisualReview = cache(async function getStepVisualReview(enti
   });
 });
 
-export const getWordAudioReview = cache(async function getWordAudioReview(entityId: bigint) {
+export const getWordAudioReview = cache(async function getWordAudioReview(entityId: string) {
   if (!(await isAdmin())) {
     return null;
   }
@@ -41,7 +41,7 @@ export const getWordAudioReview = cache(async function getWordAudioReview(entity
 });
 
 export const getSentenceAudioReview = cache(async function getSentenceAudioReview(
-  entityId: bigint,
+  entityId: string,
 ) {
   if (!(await isAdmin())) {
     return null;

--- a/apps/api/src/app/v1/courses/search/route.ts
+++ b/apps/api/src/app/v1/courses/search/route.ts
@@ -8,14 +8,14 @@ import { NextResponse } from "next/server";
 export async function GET(request: Request): Promise<
   | NextResponse<
       PaginatedResponse<{
-        id: number;
+        id: string;
         slug: string;
         title: string;
         description: string | null;
         imageUrl: string | null;
         language: string;
         organization: {
-          id: number;
+          id: string;
           slug: string;
           name: string;
           logo: string | null;

--- a/apps/api/src/app/v1/progress/next-activity/route.ts
+++ b/apps/api/src/app/v1/progress/next-activity/route.ts
@@ -6,9 +6,9 @@ import { getNextActivity } from "@zoonk/core/progress/next-activity";
 import { NextResponse } from "next/server";
 
 function getScope(params: {
-  chapterId?: number;
-  courseId?: number;
-  lessonId?: number;
+  chapterId?: string;
+  courseId?: string;
+  lessonId?: string;
 }): ActivityScope {
   if (params.courseId) {
     return { courseId: params.courseId };
@@ -18,7 +18,7 @@ function getScope(params: {
     return { chapterId: params.chapterId };
   }
 
-  return { lessonId: params.lessonId ?? 0 };
+  return { lessonId: params.lessonId ?? "" };
 }
 
 export async function GET(request: Request) {

--- a/apps/api/src/app/v1/workflows/chapter-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/chapter-generation/trigger/route.ts
@@ -11,7 +11,7 @@ import { start } from "workflow/api";
  * The first-chapter free path is intentionally public, so this lookup must
  * also prove the chapter belongs to the AI curriculum before we skip auth.
  */
-async function getChapterPosition(chapterId: number) {
+async function getChapterPosition(chapterId: string) {
   const chapter = await prisma.chapter.findFirst({
     select: { position: true },
     where: getAiGenerationChapterWhere({

--- a/apps/api/src/lib/openapi/schemas/progress.ts
+++ b/apps/api/src/lib/openapi/schemas/progress.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
 
+const uuidQuery = (description: string) => z.uuid().meta({ description });
+
 export const activityCompletionQuerySchema = z
   .object({
-    lessonId: z.coerce.number().int().positive().meta({ description: "Lesson ID" }),
+    lessonId: uuidQuery("Lesson ID"),
   })
   .meta({ id: "ActivityCompletionQuery" });
 
@@ -16,7 +18,7 @@ export const activityCompletionResponseSchema = z
 
 export const courseCompletionQuerySchema = z
   .object({
-    courseId: z.coerce.number().int().positive().meta({ description: "Course ID" }),
+    courseId: uuidQuery("Course ID"),
   })
   .meta({ id: "CourseCompletionQuery" });
 
@@ -25,7 +27,7 @@ export const courseCompletionResponseSchema = z
     chapters: z
       .array(
         z.object({
-          chapterId: z.number().meta({ description: "Chapter ID" }),
+          chapterId: z.string().meta({ description: "Chapter ID" }),
           completedLessons: z.number().meta({ description: "Number of completed lessons" }),
           totalLessons: z.number().meta({ description: "Total number of lessons" }),
         }),
@@ -36,7 +38,7 @@ export const courseCompletionResponseSchema = z
 
 export const chapterCompletionQuerySchema = z
   .object({
-    chapterId: z.coerce.number().int().positive().meta({ description: "Chapter ID" }),
+    chapterId: uuidQuery("Chapter ID"),
   })
   .meta({ id: "ChapterCompletionQuery" });
 
@@ -46,7 +48,7 @@ export const chapterCompletionResponseSchema = z
       .array(
         z.object({
           completedActivities: z.number().meta({ description: "Number of completed activities" }),
-          lessonId: z.number().meta({ description: "Lesson ID" }),
+          lessonId: z.string().meta({ description: "Lesson ID" }),
           totalActivities: z.number().meta({ description: "Total number of activities" }),
         }),
       )
@@ -56,9 +58,9 @@ export const chapterCompletionResponseSchema = z
 
 export const nextActivityQuerySchema = z
   .object({
-    chapterId: z.coerce.number().int().positive().optional().meta({ description: "Chapter ID" }),
-    courseId: z.coerce.number().int().positive().optional().meta({ description: "Course ID" }),
-    lessonId: z.coerce.number().int().positive().optional().meta({ description: "Lesson ID" }),
+    chapterId: uuidQuery("Chapter ID").optional(),
+    courseId: uuidQuery("Course ID").optional(),
+    lessonId: uuidQuery("Lesson ID").optional(),
   })
   .refine(
     (data) => {

--- a/apps/api/src/lib/openapi/schemas/workflows.ts
+++ b/apps/api/src/lib/openapi/schemas/workflows.ts
@@ -1,48 +1,34 @@
 import { z } from "zod";
 
+const uuidParam = (description: string) => z.uuid().meta({ description });
+
 export const courseGenerationTriggerSchema = z
   .object({
-    courseSuggestionId: z
-      .number()
-      .int()
-      .positive()
-      .meta({ description: "Course suggestion ID to generate from" }),
+    courseSuggestionId: uuidParam("Course suggestion ID to generate from"),
   })
   .meta({ id: "CourseGenerationTrigger" });
 
 export const chapterGenerationTriggerSchema = z
   .object({
-    chapterId: z
-      .number()
-      .int()
-      .positive()
-      .meta({ description: "Chapter ID to generate content for" }),
+    chapterId: uuidParam("Chapter ID to generate content for"),
   })
   .meta({ id: "ChapterGenerationTrigger" });
 
 export const lessonGenerationTriggerSchema = z
   .object({
-    lessonId: z
-      .number()
-      .int()
-      .positive()
-      .meta({ description: "Lesson ID to generate activities for" }),
+    lessonId: uuidParam("Lesson ID to generate activities for"),
   })
   .meta({ id: "LessonGenerationTrigger" });
 
 export const activityGenerationTriggerSchema = z
   .object({
-    lessonId: z
-      .number()
-      .int()
-      .positive()
-      .meta({ description: "Lesson ID to generate activities for" }),
+    lessonId: uuidParam("Lesson ID to generate activities for"),
   })
   .meta({ id: "ActivityGenerationTrigger" });
 
 export const lessonPreloadTriggerSchema = z
   .object({
-    lessonId: z.number().int().positive().meta({ description: "Lesson ID to preload content for" }),
+    lessonId: uuidParam("Lesson ID to preload content for"),
   })
   .meta({ id: "LessonPreloadTrigger" });
 

--- a/apps/api/src/workflows/_shared/stream-status.ts
+++ b/apps/api/src/workflows/_shared/stream-status.ts
@@ -97,7 +97,7 @@ export function createStepStream<T extends string>(): StepStream<T> {
  * }
  * ```
  */
-export function createEntityStepStream<T extends string>(entityId: number): StepStream<T> {
+export function createEntityStepStream<T extends string>(entityId: string): StepStream<T> {
   const writer = getWritable<string>().getWriter();
 
   return {

--- a/apps/api/src/workflows/activity-generation/activity-generation-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/activity-generation-workflow.ts
@@ -15,7 +15,7 @@ import { streamCompletionEventsStep } from "./steps/stream-completion-events-ste
  * already completed, so downstream generate steps never check generationStatus.
  */
 export async function activityGenerationWorkflow(
-  lessonId: number,
+  lessonId: string,
   options: {
     regeneration?: boolean;
   } = {},

--- a/apps/api/src/workflows/activity-generation/kinds/custom-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/custom-workflow.test.ts
@@ -67,7 +67,7 @@ vi.mock("../steps/_utils/dispatch-visual-content", () => ({
     ),
 }));
 
-async function fetchLessonActivities(lessonId: number): Promise<LessonActivity[]> {
+async function fetchLessonActivities(lessonId: string): Promise<LessonActivity[]> {
   const activities = await prisma.activity.findMany({
     include: {
       _count: { select: { steps: true } },
@@ -85,7 +85,7 @@ async function fetchLessonActivities(lessonId: number): Promise<LessonActivity[]
     where: { lessonId },
   });
 
-  return activities.map((activity) => ({ ...activity, id: Number(activity.id) }));
+  return activities.map((activity) => ({ ...activity, id: activity.id }));
 }
 
 describe(customActivityWorkflow, () => {

--- a/apps/api/src/workflows/activity-generation/kinds/custom-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/custom-workflow.ts
@@ -13,7 +13,7 @@ import { saveCustomActivityStep } from "../steps/save-custom-activity-step";
  */
 async function markDroppedCustomActivitiesAsFailed(
   activitiesToGenerate: LessonActivity[],
-  contentResults: { activityId: number }[],
+  contentResults: { activityId: string }[],
 ): Promise<void> {
   const customActivitiesToGenerate = activitiesToGenerate.filter((a) => a.kind === "custom");
   const resultActivityIds = new Set(contentResults.map((result) => result.activityId));

--- a/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
@@ -564,7 +564,7 @@ describe("explanation activity workflow", () => {
       });
 
       const streamedMessages = getStreamedMessages();
-      const activityIds = new Set([Number(expA.id), Number(expB.id)]);
+      const activityIds = new Set([expA.id, expB.id]);
 
       // Per-entity steps must include entityId matching one of the activity IDs
       const perEntitySteps = [
@@ -579,7 +579,7 @@ describe("explanation activity workflow", () => {
 
         for (const msg of stepMessages) {
           expect(msg.entityId).toBeDefined();
-          expect(activityIds.has(Number(msg.entityId))).toBe(true);
+          expect(activityIds.has(msg.entityId!)).toBe(true);
         }
       }
 
@@ -919,7 +919,7 @@ describe("explanation activity workflow", () => {
       const constraintName = `prevent_completion_${randomUUID().replaceAll("-", "")}`;
 
       await prisma.$executeRawUnsafe(
-        `ALTER TABLE activities ADD CONSTRAINT ${constraintName} CHECK (NOT (id = ${String(activity.id)} AND generation_status = 'completed'))`,
+        `ALTER TABLE activities ADD CONSTRAINT ${constraintName} CHECK (NOT (id = '${activity.id}' AND generation_status = 'completed'))`,
       );
 
       try {

--- a/apps/api/src/workflows/activity-generation/kinds/grammar-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/grammar-workflow.test.ts
@@ -58,7 +58,7 @@ vi.mock("@zoonk/ai/tasks/activities/language/romanization", () => ({
   }),
 }));
 
-async function fetchLessonActivities(lessonId: number): Promise<LessonActivity[]> {
+async function fetchLessonActivities(lessonId: string): Promise<LessonActivity[]> {
   const activities = await prisma.activity.findMany({
     include: {
       _count: { select: { steps: true } },
@@ -76,7 +76,7 @@ async function fetchLessonActivities(lessonId: number): Promise<LessonActivity[]
     where: { lessonId },
   });
 
-  return activities.map((activity) => ({ ...activity, id: Number(activity.id) }));
+  return activities.map((activity) => ({ ...activity, id: activity.id }));
 }
 
 describe(grammarActivityWorkflow, () => {

--- a/apps/api/src/workflows/activity-generation/kinds/listening-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/listening-workflow.test.ts
@@ -12,7 +12,7 @@ import { beforeAll, describe, expect, test } from "vitest";
 import { type LessonActivity } from "../steps/get-lesson-activities-step";
 import { listeningActivityWorkflow } from "./listening-workflow";
 
-async function fetchLessonActivities(lessonId: number): Promise<LessonActivity[]> {
+async function fetchLessonActivities(lessonId: string): Promise<LessonActivity[]> {
   const activities = await prisma.activity.findMany({
     include: {
       _count: { select: { steps: true } },
@@ -30,7 +30,7 @@ async function fetchLessonActivities(lessonId: number): Promise<LessonActivity[]
     where: { lessonId },
   });
 
-  return activities.map((activity) => ({ ...activity, id: Number(activity.id) }));
+  return activities.map((activity) => ({ ...activity, id: activity.id }));
 }
 
 describe(listeningActivityWorkflow, () => {

--- a/apps/api/src/workflows/activity-generation/kinds/practice-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/practice-workflow.test.ts
@@ -31,7 +31,7 @@ vi.mock("@zoonk/ai/tasks/activities/core/practice", () => ({
   }),
 }));
 
-function buildExplanationResults(activityId: number): ExplanationResult[] {
+function buildExplanationResults(activityId: string): ExplanationResult[] {
   return [
     {
       activityId,
@@ -85,7 +85,7 @@ describe("practice activity workflow", () => {
     });
 
     const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
-    const explanationResults = buildExplanationResults(Number(expActivity.id));
+    const explanationResults = buildExplanationResults(expActivity.id);
 
     await practiceActivityWorkflow({
       activitiesToGenerate: activities,
@@ -141,7 +141,7 @@ describe("practice activity workflow", () => {
     });
 
     const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
-    const explanationResults = buildExplanationResults(Number(expActivity.id));
+    const explanationResults = buildExplanationResults(expActivity.id);
 
     await practiceActivityWorkflow({
       activitiesToGenerate: activities,
@@ -187,7 +187,7 @@ describe("practice activity workflow", () => {
     });
 
     const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
-    const explanationResults = buildExplanationResults(Number(expActivity.id));
+    const explanationResults = buildExplanationResults(expActivity.id);
 
     await practiceActivityWorkflow({
       activitiesToGenerate: activities,
@@ -272,7 +272,7 @@ describe("practice activity workflow", () => {
     });
 
     const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
-    const explanationResults = buildExplanationResults(Number(expActivity.id));
+    const explanationResults = buildExplanationResults(expActivity.id);
 
     await practiceActivityWorkflow({
       activitiesToGenerate: [],
@@ -350,10 +350,10 @@ describe("practice activity workflow", () => {
 
       const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
       const explanationResults: ExplanationResult[] = [
-        { activityId: Number(expS1.id), concept: "S1", steps: [{ text: "S1 text", title: "S1" }] },
-        { activityId: Number(expS2.id), concept: "S2", steps: [{ text: "S2 text", title: "S2" }] },
-        { activityId: Number(expS3.id), concept: "S3", steps: [{ text: "S3 text", title: "S3" }] },
-        { activityId: Number(expS4.id), concept: "S4", steps: [{ text: "S4 text", title: "S4" }] },
+        { activityId: expS1.id, concept: "S1", steps: [{ text: "S1 text", title: "S1" }] },
+        { activityId: expS2.id, concept: "S2", steps: [{ text: "S2 text", title: "S2" }] },
+        { activityId: expS3.id, concept: "S3", steps: [{ text: "S3 text", title: "S3" }] },
+        { activityId: expS4.id, concept: "S4", steps: [{ text: "S4 text", title: "S4" }] },
       ];
 
       await practiceActivityWorkflow({
@@ -432,22 +432,22 @@ describe("practice activity workflow", () => {
       const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
       const explanationResults: ExplanationResult[] = [
         {
-          activityId: Number(expH1A.id),
+          activityId: expH1A.id,
           concept: "Half1A",
           steps: [{ text: "H1A text", title: "H1A" }],
         },
         {
-          activityId: Number(expH1B.id),
+          activityId: expH1B.id,
           concept: "Half1B",
           steps: [{ text: "H1B text", title: "H1B" }],
         },
         {
-          activityId: Number(expH2A.id),
+          activityId: expH2A.id,
           concept: "Half2A",
           steps: [{ text: "H2A text", title: "H2A" }],
         },
         {
-          activityId: Number(expH2B.id),
+          activityId: expH2B.id,
           concept: "Half2B",
           steps: [{ text: "H2B text", title: "H2B" }],
         },
@@ -523,12 +523,12 @@ describe("practice activity workflow", () => {
       const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
       const explanationResults: ExplanationResult[] = [
         {
-          activityId: Number(expSA.id),
+          activityId: expSA.id,
           concept: "Single A",
           steps: [{ text: "SA text", title: "SA" }],
         },
         {
-          activityId: Number(expSB.id),
+          activityId: expSB.id,
           concept: "Single B",
           steps: [{ text: "SB text", title: "SB" }],
         },
@@ -617,22 +617,22 @@ describe("practice activity workflow", () => {
       const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
       const explanationResults: ExplanationResult[] = [
         {
-          activityId: Number(expSC1.id),
+          activityId: expSC1.id,
           concept: "SC1",
           steps: [{ text: "SC1 text", title: "SC1" }],
         },
         {
-          activityId: Number(expSC2.id),
+          activityId: expSC2.id,
           concept: "SC2",
           steps: [{ text: "SC2 text", title: "SC2" }],
         },
         {
-          activityId: Number(expSC3.id),
+          activityId: expSC3.id,
           concept: "SC3",
           steps: [{ text: "SC3 text", title: "SC3" }],
         },
         {
-          activityId: Number(expSC4.id),
+          activityId: expSC4.id,
           concept: "SC4",
           steps: [{ text: "SC4 text", title: "SC4" }],
         },
@@ -719,26 +719,26 @@ describe("practice activity workflow", () => {
 
       // practice0 is completed → only practice1 in activitiesToGenerate
       const allActivities = await getLessonActivitiesStep({ lessonId: testLesson.id });
-      const activitiesToGenerate = allActivities.filter((a) => a.id === Number(practice1.id));
+      const activitiesToGenerate = allActivities.filter((a) => a.id === practice1.id);
 
       const explanationResults: ExplanationResult[] = [
         {
-          activityId: Number(expIdxA.id),
+          activityId: expIdxA.id,
           concept: "IdxA",
           steps: [{ text: "IdxA text", title: "IdxA" }],
         },
         {
-          activityId: Number(expIdxB.id),
+          activityId: expIdxB.id,
           concept: "IdxB",
           steps: [{ text: "IdxB text", title: "IdxB" }],
         },
         {
-          activityId: Number(expIdxC.id),
+          activityId: expIdxC.id,
           concept: "IdxC",
           steps: [{ text: "IdxC text", title: "IdxC" }],
         },
         {
-          activityId: Number(expIdxD.id),
+          activityId: expIdxD.id,
           concept: "IdxD",
           steps: [{ text: "IdxD text", title: "IdxD" }],
         },
@@ -811,7 +811,7 @@ describe("practice activity workflow", () => {
       const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
       const explanationResults: ExplanationResult[] = [
         {
-          activityId: Number(expOnly.id),
+          activityId: expOnly.id,
           concept: "OnlyConcept",
           steps: [{ text: "Only text", title: "Only" }],
         },

--- a/apps/api/src/workflows/activity-generation/kinds/quiz-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/quiz-workflow.test.ts
@@ -45,7 +45,7 @@ vi.mock("@zoonk/core/steps/image", () => ({
   }),
 }));
 
-function buildExplanationResults(activityId: number): ExplanationResult[] {
+function buildExplanationResults(activityId: string): ExplanationResult[] {
   return [
     {
       activityId,
@@ -100,7 +100,7 @@ describe("quiz activity workflow", () => {
     ]);
 
     const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
-    const explanationResults = buildExplanationResults(Number(explanationActivity.id));
+    const explanationResults = buildExplanationResults(explanationActivity.id);
 
     await quizActivityWorkflow({
       activitiesToGenerate: activities,
@@ -149,7 +149,7 @@ describe("quiz activity workflow", () => {
     ]);
 
     const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
-    const explanationResults = buildExplanationResults(Number(explanationActivity.id));
+    const explanationResults = buildExplanationResults(explanationActivity.id);
 
     await quizActivityWorkflow({
       activitiesToGenerate: activities,
@@ -192,7 +192,7 @@ describe("quiz activity workflow", () => {
     ]);
 
     const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
-    const explanationResults = buildExplanationResults(Number(explanationActivity.id));
+    const explanationResults = buildExplanationResults(explanationActivity.id);
 
     await quizActivityWorkflow({
       activitiesToGenerate: activities,
@@ -262,7 +262,7 @@ describe("quiz activity workflow", () => {
     ]);
 
     const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
-    const explanationResults = buildExplanationResults(Number(explanationActivity.id));
+    const explanationResults = buildExplanationResults(explanationActivity.id);
 
     await quizActivityWorkflow({
       activitiesToGenerate: activities,
@@ -320,7 +320,7 @@ describe("quiz activity workflow", () => {
       position: 0,
     });
 
-    const explanationResults = buildExplanationResults(Number(explanationActivity.id));
+    const explanationResults = buildExplanationResults(explanationActivity.id);
 
     await quizActivityWorkflow({
       activitiesToGenerate: [],

--- a/apps/api/src/workflows/activity-generation/steps/_utils/content-step-helpers.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/content-step-helpers.test.ts
@@ -22,7 +22,7 @@ vi.mock("workflow", () => ({
 
 describe(getExistingContentSteps, () => {
   let organizationId: string;
-  let chapterId: number;
+  let chapterId: string;
 
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();

--- a/apps/api/src/workflows/activity-generation/steps/_utils/content-step-helpers.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/content-step-helpers.ts
@@ -8,7 +8,7 @@ import { type ActivitySteps, parseActivitySteps } from "./get-activity-steps";
  * (e.g., practice/quiz need explanation steps). Instead of re-generating,
  * we read what was already persisted.
  */
-export async function getExistingContentSteps(activityId: bigint | number): Promise<ActivitySteps> {
+export async function getExistingContentSteps(activityId: string): Promise<ActivitySteps> {
   "use step";
   const { data: existingSteps } = await safeAsync(() =>
     prisma.step.findMany({

--- a/apps/api/src/workflows/activity-generation/steps/_utils/fetch-lesson-activities.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/fetch-lesson-activities.ts
@@ -6,7 +6,7 @@ import { getAiGenerationActivityWhere, prisma } from "@zoonk/db";
  * activities or archived ancestors from leaking back into generation context
  * when one caller gets updated and the other does not.
  */
-export async function fetchLessonActivities(lessonId: number) {
+export async function fetchLessonActivities(lessonId: string) {
   return fetchActivitiesForLesson({
     lessonId,
     replacementActivities: false,
@@ -18,7 +18,7 @@ export async function fetchLessonActivities(lessonId: number) {
  * This helper loads only that unpublished set so the background workflow can
  * regenerate activities without touching the published learner-facing ones.
  */
-export async function fetchReplacementLessonActivities(input: { lessonId: number }) {
+export async function fetchReplacementLessonActivities(input: { lessonId: string }) {
   return fetchActivitiesForLesson({
     lessonId: input.lessonId,
     replacementActivities: true,
@@ -32,7 +32,7 @@ export async function fetchReplacementLessonActivities(input: { lessonId: number
  * replacement set used during regeneration.
  */
 async function fetchActivitiesForLesson(input: {
-  lessonId: number;
+  lessonId: string;
   replacementActivities: boolean;
 }) {
   const activities = await prisma.activity.findMany({
@@ -61,5 +61,5 @@ async function fetchActivitiesForLesson(input: {
     }),
   });
 
-  return activities.map((activity) => ({ ...activity, id: Number(activity.id) }));
+  return activities;
 }

--- a/apps/api/src/workflows/activity-generation/steps/_utils/find-activity-by-kind.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/find-activity-by-kind.test.ts
@@ -3,28 +3,28 @@ import { type LessonActivity } from "../get-lesson-activities-step";
 import { findActivitiesByKind } from "./find-activity-by-kind";
 
 function makeMockActivity(overrides: Partial<LessonActivity>): LessonActivity {
-  return { id: 1, kind: "explanation", ...overrides } as LessonActivity;
+  return { id: "1", kind: "explanation", ...overrides } as LessonActivity;
 }
 
 describe(findActivitiesByKind, () => {
   test("returns all activities matching the given kind", () => {
     const activities = [
-      makeMockActivity({ id: 1, kind: "explanation" }),
-      makeMockActivity({ id: 2, kind: "quiz" }),
-      makeMockActivity({ id: 3, kind: "explanation" }),
+      makeMockActivity({ id: "1", kind: "explanation" }),
+      makeMockActivity({ id: "2", kind: "quiz" }),
+      makeMockActivity({ id: "3", kind: "explanation" }),
     ];
 
     const result = findActivitiesByKind(activities, "explanation");
 
     expect(result).toHaveLength(2);
-    expect(result[0]?.id).toBe(1);
-    expect(result[1]?.id).toBe(3);
+    expect(result[0]?.id).toBe("1");
+    expect(result[1]?.id).toBe("3");
   });
 
   test("returns empty array when no activities match", () => {
     const activities = [
-      makeMockActivity({ id: 1, kind: "quiz" }),
-      makeMockActivity({ id: 2, kind: "practice" }),
+      makeMockActivity({ id: "1", kind: "quiz" }),
+      makeMockActivity({ id: "2", kind: "practice" }),
     ];
 
     const result = findActivitiesByKind(activities, "explanation");
@@ -34,15 +34,15 @@ describe(findActivitiesByKind, () => {
 
   test("maintains original order", () => {
     const activities = [
-      makeMockActivity({ id: 10, kind: "quiz" }),
-      makeMockActivity({ id: 5, kind: "explanation" }),
-      makeMockActivity({ id: 20, kind: "quiz" }),
-      makeMockActivity({ id: 3, kind: "quiz" }),
+      makeMockActivity({ id: "10", kind: "quiz" }),
+      makeMockActivity({ id: "5", kind: "explanation" }),
+      makeMockActivity({ id: "20", kind: "quiz" }),
+      makeMockActivity({ id: "3", kind: "quiz" }),
     ];
 
     const result = findActivitiesByKind(activities, "quiz");
 
     expect(result).toHaveLength(3);
-    expect(result.map((a) => a.id)).toEqual([10, 20, 3]);
+    expect(result.map((a) => a.id)).toEqual(["10", "20", "3"]);
   });
 });

--- a/apps/api/src/workflows/activity-generation/steps/_utils/get-explanation-steps-for-practice.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/get-explanation-steps-for-practice.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { type ExplanationResult } from "../generate-explanation-content-step";
 import { getExplanationStepsForPractice } from "./get-explanation-steps-for-practice";
 
-function makeResult(activityId: number, steps: string[]): ExplanationResult {
+function makeResult(activityId: string, steps: string[]): ExplanationResult {
   return {
     activityId,
     concept: `concept-${activityId}`,
@@ -12,7 +12,7 @@ function makeResult(activityId: number, steps: string[]): ExplanationResult {
 
 describe(getExplanationStepsForPractice, () => {
   test("returns all steps when there is only one practice", () => {
-    const results = [makeResult(1, ["a", "b"]), makeResult(2, ["c", "d"])];
+    const results = [makeResult("1", ["a", "b"]), makeResult("2", ["c", "d"])];
     const steps = getExplanationStepsForPractice(results, 0, 1);
 
     expect(steps.map((step) => step.text)).toEqual(["a", "b", "c", "d"]);
@@ -20,10 +20,10 @@ describe(getExplanationStepsForPractice, () => {
 
   test("returns first half for practice index 0 when there are two practices", () => {
     const results = [
-      makeResult(1, ["a"]),
-      makeResult(2, ["b"]),
-      makeResult(3, ["c"]),
-      makeResult(4, ["d"]),
+      makeResult("1", ["a"]),
+      makeResult("2", ["b"]),
+      makeResult("3", ["c"]),
+      makeResult("4", ["d"]),
     ];
 
     const steps = getExplanationStepsForPractice(results, 0, 2);
@@ -33,10 +33,10 @@ describe(getExplanationStepsForPractice, () => {
 
   test("returns second half for practice index 1 when there are two practices", () => {
     const results = [
-      makeResult(1, ["a"]),
-      makeResult(2, ["b"]),
-      makeResult(3, ["c"]),
-      makeResult(4, ["d"]),
+      makeResult("1", ["a"]),
+      makeResult("2", ["b"]),
+      makeResult("3", ["c"]),
+      makeResult("4", ["d"]),
     ];
 
     const steps = getExplanationStepsForPractice(results, 1, 2);
@@ -46,11 +46,11 @@ describe(getExplanationStepsForPractice, () => {
 
   test("splits 5 results into groups of 2 and 3", () => {
     const results = [
-      makeResult(1, ["a"]),
-      makeResult(2, ["b"]),
-      makeResult(3, ["c"]),
-      makeResult(4, ["d"]),
-      makeResult(5, ["e"]),
+      makeResult("1", ["a"]),
+      makeResult("2", ["b"]),
+      makeResult("3", ["c"]),
+      makeResult("4", ["d"]),
+      makeResult("5", ["e"]),
     ];
 
     const first = getExplanationStepsForPractice(results, 0, 2);
@@ -66,7 +66,7 @@ describe(getExplanationStepsForPractice, () => {
   });
 
   test("ensures split index is at least 1 for two practices with single result", () => {
-    const results = [makeResult(1, ["a", "b"])];
+    const results = [makeResult("1", ["a", "b"])];
 
     const first = getExplanationStepsForPractice(results, 0, 2);
     const second = getExplanationStepsForPractice(results, 1, 2);

--- a/apps/api/src/workflows/activity-generation/steps/_utils/save-reading-target-words.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/save-reading-target-words.test.ts
@@ -38,7 +38,7 @@ async function createLessonContext() {
  * Lesson words are the observable output for canonical sentence tokens, so most tests
  * assert against this joined query instead of lower-level individual rows.
  */
-async function getLessonWordsWithWords(lessonId: number) {
+async function getLessonWordsWithWords(lessonId: string) {
   return prisma.lessonWord.findMany({
     include: { word: true },
     orderBy: { word: { word: "asc" } },

--- a/apps/api/src/workflows/activity-generation/steps/_utils/save-reading-target-words.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/save-reading-target-words.ts
@@ -23,7 +23,7 @@ export type WordMetadataEntry = {
  */
 export async function saveReadingTargetWords(params: {
   distractors: Record<string, string[]>;
-  lessonId: number;
+  lessonId: string;
   organizationId: string;
   pronunciations: Record<string, string>;
   sentences: ReadingSentence[];
@@ -139,7 +139,7 @@ function getRomanizationUpdate(metadata: WordMetadataEntry | undefined): {
  */
 async function saveCanonicalSentenceWord(params: {
   existingCasing: Record<string, string>;
-  lessonId: number;
+  lessonId: string;
   organizationId: string;
   pronunciations: Record<string, string>;
   targetLanguage: string;

--- a/apps/api/src/workflows/activity-generation/steps/_utils/upsert-word-with-pronunciation.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/upsert-word-with-pronunciation.ts
@@ -23,7 +23,7 @@ export async function upsertWordWithPronunciation(params: {
   targetLanguage: string;
   userLanguage: string;
   word: string;
-}): Promise<bigint> {
+}): Promise<string> {
   const {
     audioUrl,
     organizationId,

--- a/apps/api/src/workflows/activity-generation/steps/_utils/visual-rows.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/visual-rows.test.ts
@@ -3,7 +3,7 @@ import { buildVisualStepRows } from "./visual-rows";
 
 describe(buildVisualStepRows, () => {
   test("returns empty array when visuals are empty", () => {
-    const result = buildVisualStepRows({ activityId: 1, visuals: [] });
+    const result = buildVisualStepRows({ activityId: "1", visuals: [] });
 
     expect(result).toEqual([]);
   });
@@ -14,12 +14,12 @@ describe(buildVisualStepRows, () => {
       { kind: "image", prompt: "A visual", url: "https://example.com/image.webp" },
     ];
 
-    const result = buildVisualStepRows({ activityId: 42, visuals });
+    const result = buildVisualStepRows({ activityId: "42", visuals });
 
     expect(result).toHaveLength(2);
 
     expect(result[0]).toMatchObject({
-      activityId: 42,
+      activityId: "42",
       content: { code: "const x = 1;", kind: "code", language: "typescript" },
       isPublished: true,
       kind: "visual",
@@ -27,7 +27,7 @@ describe(buildVisualStepRows, () => {
     });
 
     expect(result[1]).toMatchObject({
-      activityId: 42,
+      activityId: "42",
       content: { kind: "image", prompt: "A visual", url: "https://example.com/image.webp" },
       isPublished: true,
       kind: "visual",
@@ -38,7 +38,7 @@ describe(buildVisualStepRows, () => {
   test("places visual steps at odd positions (content + 1)", () => {
     const visuals = [{ kind: "chart" }, { kind: "table" }, { kind: "diagram" }];
 
-    const result = buildVisualStepRows({ activityId: 1, visuals });
+    const result = buildVisualStepRows({ activityId: "1", visuals });
 
     expect(result.map((row) => row.position)).toEqual([1, 3, 5]);
   });

--- a/apps/api/src/workflows/activity-generation/steps/_utils/visual-rows.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/visual-rows.ts
@@ -7,7 +7,7 @@ type VisualWithStepIndex = { stepIndex: number };
  * (without stepIndex) and the computed position for database insertion.
  */
 type VisualRow<TVisual extends VisualWithStepIndex> = {
-  activityId: bigint | number;
+  activityId: string;
   content: Omit<TVisual, "stepIndex">;
   isPublished: true;
   kind: "visual";
@@ -22,7 +22,7 @@ type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string
  * it's stored as JSON in the database.
  */
 export type VisualStepRow = {
-  activityId: bigint | number;
+  activityId: string;
   content: Record<string, JsonValue>;
   isPublished: true;
   kind: "visual";
@@ -97,7 +97,7 @@ export function buildVisualStepRows({
   activityId,
   visuals,
 }: {
-  activityId: bigint | number;
+  activityId: string;
   visuals: Record<string, unknown>[];
 }): VisualStepRow[] {
   const visualsWithIndex = visuals.map((visual, index) => ({ ...visual, stepIndex: index }));
@@ -117,7 +117,7 @@ function buildVisualRows<TVisual extends VisualWithStepIndex>({
   dbSteps,
   visuals,
 }: {
-  activityId: bigint | number;
+  activityId: string;
   dbSteps: DbStep[];
   visuals: TVisual[];
 }): VisualRow<TVisual>[] | null {

--- a/apps/api/src/workflows/activity-generation/steps/generate-custom-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-custom-content-step.ts
@@ -5,7 +5,7 @@ import { rejected, settledValues } from "@zoonk/utils/settled";
 import { type ActivitySteps } from "./_utils/get-activity-steps";
 import { type LessonActivity } from "./get-lesson-activities-step";
 
-export type CustomContentResult = { activityId: number; steps: ActivitySteps };
+export type CustomContentResult = { activityId: string; steps: ActivitySteps };
 
 /**
  * Calls AI to generate custom activity content.

--- a/apps/api/src/workflows/activity-generation/steps/generate-custom-visual-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-custom-visual-content-step.ts
@@ -7,7 +7,7 @@ import { type CustomVisualDescriptionResult } from "./generate-custom-visuals-st
 import { type LessonActivity } from "./get-lesson-activities-step";
 
 type CustomVisualContentResult = {
-  activityId: number;
+  activityId: string;
   completedRows: VisualStepRow[];
 };
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-custom-visuals-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-custom-visuals-step.ts
@@ -9,7 +9,7 @@ import { type CustomContentResult } from "./generate-custom-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
 
 export type CustomVisualDescriptionResult = {
-  activityId: number;
+  activityId: string;
   descriptions: VisualDescription[];
 };
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-explanation-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-explanation-content-step.ts
@@ -6,7 +6,7 @@ import { type ActivitySteps } from "./_utils/get-activity-steps";
 import { type LessonActivity } from "./get-lesson-activities-step";
 
 export type ExplanationResult = {
-  activityId: number;
+  activityId: string;
   concept: string;
   steps: ActivitySteps;
 };

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-accuracy-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-accuracy-step.test.ts
@@ -91,13 +91,13 @@ describe(generateInvestigationAccuracyStep, () => {
       where: { id: dbActivity.id },
     });
 
-    const activityWithNumericId = { ...activity, id: Number(activity.id) };
+    const activityWithNumericId = { ...activity, id: activity.id };
 
     generateActivityInvestigationAccuracyMock.mockResolvedValue({ data: mockAccuracyData });
 
     const result = await generateInvestigationAccuracyStep({
       activity: activityWithNumericId,
-      activityId: Number(dbActivity.id),
+      activityId: dbActivity.id,
       scenario: mockScenario,
     });
 
@@ -131,13 +131,13 @@ describe(generateInvestigationAccuracyStep, () => {
       where: { id: dbActivity.id },
     });
 
-    const activityWithNumericId = { ...activity, id: Number(activity.id) };
+    const activityWithNumericId = { ...activity, id: activity.id };
 
     generateActivityInvestigationAccuracyMock.mockResolvedValue({ data: mockAccuracyData });
 
     await generateInvestigationAccuracyStep({
       activity: activityWithNumericId,
-      activityId: Number(dbActivity.id),
+      activityId: dbActivity.id,
       scenario: mockScenario,
     });
 
@@ -177,13 +177,13 @@ describe(generateInvestigationAccuracyStep, () => {
       where: { id: dbActivity.id },
     });
 
-    const activityWithNumericId = { ...activity, id: Number(activity.id) };
+    const activityWithNumericId = { ...activity, id: activity.id };
 
     generateActivityInvestigationAccuracyMock.mockRejectedValue(new Error("AI failed"));
 
     const result = await generateInvestigationAccuracyStep({
       activity: activityWithNumericId,
-      activityId: Number(dbActivity.id),
+      activityId: dbActivity.id,
       scenario: mockScenario,
     });
 
@@ -196,7 +196,7 @@ describe(generateInvestigationAccuracyStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(dbActivity.id),
+        entityId: dbActivity.id,
         status: "error",
         step: "generateInvestigationAccuracy",
       }),
@@ -229,13 +229,13 @@ describe(generateInvestigationAccuracyStep, () => {
       where: { id: dbActivity.id },
     });
 
-    const activityWithNumericId = { ...activity, id: Number(activity.id) };
+    const activityWithNumericId = { ...activity, id: activity.id };
 
     generateActivityInvestigationAccuracyMock.mockResolvedValue({ data: mockAccuracyData });
 
     await generateInvestigationAccuracyStep({
       activity: activityWithNumericId,
-      activityId: Number(dbActivity.id),
+      activityId: dbActivity.id,
       scenario: mockScenario,
     });
 
@@ -243,7 +243,7 @@ describe(generateInvestigationAccuracyStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(dbActivity.id),
+        entityId: dbActivity.id,
         status: "started",
         step: "generateInvestigationAccuracy",
       }),
@@ -251,7 +251,7 @@ describe(generateInvestigationAccuracyStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(dbActivity.id),
+        entityId: dbActivity.id,
         status: "completed",
         step: "generateInvestigationAccuracy",
       }),

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-accuracy-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-accuracy-step.ts
@@ -22,7 +22,7 @@ export async function generateInvestigationAccuracyStep({
   activity,
   scenario,
 }: {
-  activityId: number;
+  activityId: string;
   activity: LessonActivity;
   scenario: ActivityInvestigationScenarioSchema;
 }): Promise<ActivityInvestigationAccuracySchema | null> {

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-actions-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-actions-step.test.ts
@@ -92,7 +92,7 @@ describe(generateInvestigationActionsStep, () => {
 
     const result = await generateInvestigationActionsStep({
       accuracy: mockAccuracy,
-      activityId: Number(dbActivity.id),
+      activityId: dbActivity.id,
       language: "en",
       scenario: mockScenario,
     });
@@ -120,7 +120,7 @@ describe(generateInvestigationActionsStep, () => {
 
     await generateInvestigationActionsStep({
       accuracy: mockAccuracy,
-      activityId: Number(dbActivity.id),
+      activityId: dbActivity.id,
       language: "pt",
       scenario: mockScenario,
     });
@@ -156,7 +156,7 @@ describe(generateInvestigationActionsStep, () => {
 
     const result = await generateInvestigationActionsStep({
       accuracy: mockAccuracy,
-      activityId: Number(dbActivity.id),
+      activityId: dbActivity.id,
       language: "en",
       scenario: mockScenario,
     });
@@ -170,7 +170,7 @@ describe(generateInvestigationActionsStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(dbActivity.id),
+        entityId: dbActivity.id,
         status: "error",
         step: "generateInvestigationActions",
       }),
@@ -197,7 +197,7 @@ describe(generateInvestigationActionsStep, () => {
 
     const result = await generateInvestigationActionsStep({
       accuracy: mockAccuracy,
-      activityId: Number(dbActivity.id),
+      activityId: dbActivity.id,
       language: "en",
       scenario: mockScenario,
     });
@@ -211,7 +211,7 @@ describe(generateInvestigationActionsStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(dbActivity.id),
+        entityId: dbActivity.id,
         status: "error",
         step: "generateInvestigationActions",
       }),
@@ -238,7 +238,7 @@ describe(generateInvestigationActionsStep, () => {
 
     await generateInvestigationActionsStep({
       accuracy: mockAccuracy,
-      activityId: Number(dbActivity.id),
+      activityId: dbActivity.id,
       language: "en",
       scenario: mockScenario,
     });
@@ -247,7 +247,7 @@ describe(generateInvestigationActionsStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(dbActivity.id),
+        entityId: dbActivity.id,
         status: "started",
         step: "generateInvestigationActions",
       }),
@@ -255,7 +255,7 @@ describe(generateInvestigationActionsStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(dbActivity.id),
+        entityId: dbActivity.id,
         status: "completed",
         step: "generateInvestigationActions",
       }),

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-actions-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-actions-step.ts
@@ -21,7 +21,7 @@ export async function generateInvestigationActionsStep({
   language,
   scenario,
 }: {
-  activityId: number;
+  activityId: string;
   accuracy: ActivityInvestigationAccuracySchema;
   language: string;
   scenario: ActivityInvestigationScenarioSchema;

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-findings-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-findings-step.test.ts
@@ -99,7 +99,7 @@ describe(generateInvestigationFindingsStep, () => {
     const result = await generateInvestigationFindingsStep({
       accuracy: mockAccuracy,
       actions: mockActions,
-      activityId: Number(dbActivity.id),
+      activityId: dbActivity.id,
       language: "en",
       scenario: mockScenario,
     });
@@ -128,7 +128,7 @@ describe(generateInvestigationFindingsStep, () => {
     await generateInvestigationFindingsStep({
       accuracy: mockAccuracy,
       actions: mockActions,
-      activityId: Number(dbActivity.id),
+      activityId: dbActivity.id,
       language: "pt",
       scenario: mockScenario,
     });
@@ -166,7 +166,7 @@ describe(generateInvestigationFindingsStep, () => {
     const result = await generateInvestigationFindingsStep({
       accuracy: mockAccuracy,
       actions: mockActions,
-      activityId: Number(dbActivity.id),
+      activityId: dbActivity.id,
       language: "en",
       scenario: mockScenario,
     });
@@ -180,7 +180,7 @@ describe(generateInvestigationFindingsStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(dbActivity.id),
+        entityId: dbActivity.id,
         status: "error",
         step: "generateInvestigationFindings",
       }),
@@ -208,7 +208,7 @@ describe(generateInvestigationFindingsStep, () => {
     const result = await generateInvestigationFindingsStep({
       accuracy: mockAccuracy,
       actions: mockActions,
-      activityId: Number(dbActivity.id),
+      activityId: dbActivity.id,
       language: "en",
       scenario: mockScenario,
     });
@@ -222,7 +222,7 @@ describe(generateInvestigationFindingsStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(dbActivity.id),
+        entityId: dbActivity.id,
         status: "error",
         step: "generateInvestigationFindings",
       }),
@@ -250,7 +250,7 @@ describe(generateInvestigationFindingsStep, () => {
     await generateInvestigationFindingsStep({
       accuracy: mockAccuracy,
       actions: mockActions,
-      activityId: Number(dbActivity.id),
+      activityId: dbActivity.id,
       language: "en",
       scenario: mockScenario,
     });
@@ -259,7 +259,7 @@ describe(generateInvestigationFindingsStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(dbActivity.id),
+        entityId: dbActivity.id,
         status: "started",
         step: "generateInvestigationFindings",
       }),
@@ -267,7 +267,7 @@ describe(generateInvestigationFindingsStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(dbActivity.id),
+        entityId: dbActivity.id,
         status: "completed",
         step: "generateInvestigationFindings",
       }),

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-findings-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-findings-step.ts
@@ -23,7 +23,7 @@ export async function generateInvestigationFindingsStep({
   language,
   scenario,
 }: {
-  activityId: number;
+  activityId: string;
   accuracy: ActivityInvestigationAccuracySchema;
   actions: ActivityInvestigationActionsSchema;
   language: string;

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-scenario-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-scenario-step.test.ts
@@ -181,7 +181,7 @@ describe(generateInvestigationScenarioStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(dbActivity.id),
+        entityId: dbActivity.id,
         status: "error",
         step: "generateInvestigationScenario",
       }),
@@ -219,7 +219,7 @@ describe(generateInvestigationScenarioStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(dbActivity.id),
+        entityId: dbActivity.id,
         status: "error",
         step: "generateInvestigationScenario",
       }),

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-scenario-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-scenario-step.ts
@@ -10,7 +10,7 @@ import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
 
 type InvestigationScenarioResult = {
-  activityId: number | null;
+  activityId: string | null;
   scenario: ActivityInvestigationScenarioSchema | null;
 };
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-practice-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-practice-content-step.ts
@@ -26,7 +26,7 @@ export async function generatePracticeContentStep(
   explanationSteps: ActivitySteps,
   workflowRunId: string,
   practiceIndex = 0,
-): Promise<{ activityId: number | null; steps: PracticeStep[] }> {
+): Promise<{ activityId: string | null; steps: PracticeStep[] }> {
   "use step";
 
   const practiceActivity = findActivitiesByKind(activities, "practice")[practiceIndex];

--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-content-step.ts
@@ -27,7 +27,7 @@ export async function generateQuizContentStep(
   explanationSteps: ActivitySteps,
   workflowRunId: string,
   quizIndex = 0,
-): Promise<{ activityId: number | null; questions: QuizQuestion[] }> {
+): Promise<{ activityId: string | null; questions: QuizQuestion[] }> {
   "use step";
 
   const quizActivity = findActivitiesByKind(activities, "quiz")[quizIndex];

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-content-step.ts
@@ -24,7 +24,7 @@ export type ReadingSentence = ActivitySentencesSchema["sentences"][number];
  * workflow resumable without reintroducing any distractor-specific coupling.
  */
 async function getLessonWords(params: {
-  lessonId: number;
+  lessonId: string;
   organizationId: string | null;
   targetLanguage: string;
 }): Promise<SourceWord[]> {
@@ -68,7 +68,7 @@ function hasValidSentences(sentences: ReadingSentence[]): boolean {
  */
 async function resolveSourceWords(input: {
   currentRunWords: SourceWord[];
-  lessonId: number;
+  lessonId: string;
   organizationId: string | null;
   targetLanguage: string;
 }): Promise<{ error: Error; words: [] } | { error: null; words: SourceWord[] }> {
@@ -97,7 +97,7 @@ async function resolveSourceWords(input: {
  */
 async function handleReadingGenerationFailure(
   stream: StepStream<ActivityStepName>,
-  activityId: number,
+  activityId: string,
   reason: WorkflowErrorReason,
 ): Promise<{ sentences: ReadingSentence[] }> {
   await stream.error({ reason, step: "generateSentences" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.test.ts
@@ -194,7 +194,7 @@ describe(generateStoryContentStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(dbActivity.id),
+        entityId: dbActivity.id,
         status: "error",
         step: "generateStoryContent",
       }),
@@ -232,7 +232,7 @@ describe(generateStoryContentStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(dbActivity.id),
+        entityId: dbActivity.id,
         status: "error",
         step: "generateStoryContent",
       }),

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.ts
@@ -10,7 +10,7 @@ import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
 
 type StoryContentResult = {
-  activityId: number | null;
+  activityId: string | null;
   storySteps: ActivityStoryStepsSchema | null;
 };
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-debrief-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-debrief-step.test.ts
@@ -101,7 +101,7 @@ describe(generateStoryDebriefStep, () => {
 
     const result = await generateStoryDebriefStep({
       activitiesToGenerate: activities,
-      activityId: Number(storyActivity.id),
+      activityId: storyActivity.id,
       storySteps: mockStorySteps,
     });
 
@@ -136,7 +136,7 @@ describe(generateStoryDebriefStep, () => {
 
     const result = await generateStoryDebriefStep({
       activitiesToGenerate: activities,
-      activityId: 999,
+      activityId: "999",
       storySteps: mockStorySteps,
     });
 
@@ -168,7 +168,7 @@ describe(generateStoryDebriefStep, () => {
 
     const result = await generateStoryDebriefStep({
       activitiesToGenerate: activities,
-      activityId: Number(storyActivity.id),
+      activityId: storyActivity.id,
       storySteps: mockStorySteps,
     });
 
@@ -181,7 +181,7 @@ describe(generateStoryDebriefStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(storyActivity.id),
+        entityId: storyActivity.id,
         status: "error",
         step: "generateStoryDebrief",
       }),
@@ -210,7 +210,7 @@ describe(generateStoryDebriefStep, () => {
 
     const result = await generateStoryDebriefStep({
       activitiesToGenerate: activities,
-      activityId: Number(storyActivity.id),
+      activityId: storyActivity.id,
       storySteps: mockStorySteps,
     });
 
@@ -223,7 +223,7 @@ describe(generateStoryDebriefStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(storyActivity.id),
+        entityId: storyActivity.id,
         status: "error",
         step: "generateStoryDebrief",
       }),
@@ -252,7 +252,7 @@ describe(generateStoryDebriefStep, () => {
 
     await generateStoryDebriefStep({
       activitiesToGenerate: activities,
-      activityId: Number(storyActivity.id),
+      activityId: storyActivity.id,
       storySteps: mockStorySteps,
     });
 
@@ -260,7 +260,7 @@ describe(generateStoryDebriefStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(storyActivity.id),
+        entityId: storyActivity.id,
         status: "started",
         step: "generateStoryDebrief",
       }),
@@ -268,7 +268,7 @@ describe(generateStoryDebriefStep, () => {
 
     expect(events).toContainEqual(
       expect.objectContaining({
-        entityId: Number(storyActivity.id),
+        entityId: storyActivity.id,
         status: "completed",
         step: "generateStoryDebrief",
       }),

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-debrief-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-debrief-step.ts
@@ -22,7 +22,7 @@ export async function generateStoryDebriefStep({
   activitiesToGenerate,
   storySteps,
 }: {
-  activityId: number;
+  activityId: string;
   activitiesToGenerate: LessonActivity[];
   storySteps: ActivityStoryStepsSchema;
 }): Promise<ActivityStoryDebriefSchema | null> {

--- a/apps/api/src/workflows/activity-generation/steps/get-lesson-activities-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/get-lesson-activities-step.test.ts
@@ -24,8 +24,8 @@ vi.mock("workflow", () => ({
 
 describe(getLessonActivitiesStep, () => {
   let organizationId: string;
-  let chapterId: number;
-  let courseId: number;
+  let chapterId: string;
+  let courseId: string;
 
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();
@@ -78,7 +78,7 @@ describe(getLessonActivitiesStep, () => {
     expect(result[0]!.lesson.chapter.id).toBe(chapterId);
     expect(result[0]!.lesson.chapter.course.id).toBe(courseId);
     expect(result[0]!.lesson.chapter.course.organization!.id).toBe(organizationId);
-    expectTypeOf(result[0]!.id).toBeNumber();
+    expectTypeOf(result[0]!.id).toBeString();
     expect(result[0]!.position).toBe(0);
     expect(result[1]!.position).toBe(1);
 

--- a/apps/api/src/workflows/activity-generation/steps/get-lesson-activities-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/get-lesson-activities-step.ts
@@ -21,7 +21,7 @@ export type LessonActivity = Awaited<ReturnType<typeof fetchReplacementLessonAct
  * lesson id and others passed extra flags.
  */
 export async function getLessonActivitiesStep(input: {
-  lessonId: number;
+  lessonId: string;
   regeneration?: boolean;
 }): Promise<LessonActivity[]> {
   "use step";

--- a/apps/api/src/workflows/activity-generation/steps/get-neighboring-concepts-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/get-neighboring-concepts-step.test.ts
@@ -22,7 +22,7 @@ vi.mock("workflow", () => ({
 
 describe(getNeighboringConceptsStep, () => {
   let organizationId: string;
-  let chapterId: number;
+  let chapterId: string;
 
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();

--- a/apps/api/src/workflows/activity-generation/steps/get-neighboring-concepts-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/get-neighboring-concepts-step.ts
@@ -6,7 +6,7 @@ import { type LessonActivity } from "./get-lesson-activities-step";
 
 const NEIGHBOR_RANGE = 3;
 
-async function getNeighboringConcepts(chapterId: number, position: number): Promise<string[]> {
+async function getNeighboringConcepts(chapterId: string, position: number): Promise<string[]> {
   const neighbors = await prisma.lesson.findMany({
     orderBy: { position: "asc" },
     select: { concepts: true },

--- a/apps/api/src/workflows/activity-generation/steps/handle-failure-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/handle-failure-step.test.ts
@@ -22,7 +22,7 @@ vi.mock("workflow", () => ({
 
 describe(handleActivityFailureStep, () => {
   let organizationId: string;
-  let chapterId: number;
+  let chapterId: string;
 
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();

--- a/apps/api/src/workflows/activity-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/handle-failure-step.ts
@@ -2,9 +2,7 @@ import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { logError } from "@zoonk/utils/logger";
 
-export async function handleActivityFailureStep(input: {
-  activityId: bigint | number;
-}): Promise<void> {
+export async function handleActivityFailureStep(input: { activityId: string }): Promise<void> {
   "use step";
 
   logError("[Activity Failure]", `activityId: ${input.activityId}`);

--- a/apps/api/src/workflows/activity-generation/steps/handle-workflow-failure-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/handle-workflow-failure-step.test.ts
@@ -25,7 +25,7 @@ vi.mock("workflow", () => ({
 
 describe(handleWorkflowFailureStep, () => {
   let organizationId: string;
-  let chapterId: number;
+  let chapterId: string;
 
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();

--- a/apps/api/src/workflows/activity-generation/steps/handle-workflow-failure-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/handle-workflow-failure-step.ts
@@ -12,7 +12,7 @@ import { safeAsync } from "@zoonk/utils/error";
  * that temporary replacement set on failure instead of keeping failed rows
  * around.
  */
-export async function handleWorkflowFailureStep(input: { lessonId: number }): Promise<void> {
+export async function handleWorkflowFailureStep(input: { lessonId: string }): Promise<void> {
   "use step";
 
   await safeAsync(() =>

--- a/apps/api/src/workflows/activity-generation/steps/mark-all-activities-as-running-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/mark-all-activities-as-running-step.test.ts
@@ -27,7 +27,7 @@ vi.mock("workflow", () => ({
 
 describe(markAllActivitiesAsRunningStep, () => {
   let organizationId: string;
-  let chapterId: number;
+  let chapterId: string;
 
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();

--- a/apps/api/src/workflows/activity-generation/steps/save-custom-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-custom-activity-step.test.ts
@@ -62,7 +62,7 @@ describe(saveCustomActivityStep, () => {
       title: `Custom ${randomUUID()}`,
     });
 
-    const activityId = Number(customActivity.id);
+    const activityId = customActivity.id;
 
     const contentSteps = [
       { text: `First step text ${id}`, title: `First title ${id}` },
@@ -126,7 +126,7 @@ describe(saveCustomActivityStep, () => {
   });
 
   test("streams error when DB transaction fails", async () => {
-    const invalidActivityId = 999_999_999;
+    const invalidActivityId = randomUUID();
 
     await saveCustomActivityStep({
       activityId: invalidActivityId,

--- a/apps/api/src/workflows/activity-generation/steps/save-custom-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-custom-activity-step.ts
@@ -12,7 +12,7 @@ import { handleActivityFailureStep } from "./handle-failure-step";
  * Static steps are placed at even positions (index * 2)
  * to leave room for visual steps at odd positions.
  */
-function buildStaticStepRecords(activityId: number, steps: ActivitySteps) {
+function buildStaticStepRecords(activityId: string, steps: ActivitySteps) {
   return steps.map((step, index) => ({
     activityId,
     content: assertStepContent("static", {
@@ -42,7 +42,7 @@ export async function saveCustomActivityStep({
   contentSteps,
   workflowRunId,
 }: {
-  activityId: number;
+  activityId: string;
   completedRows: VisualStepRow[];
   contentSteps: ActivitySteps;
   workflowRunId: string;

--- a/apps/api/src/workflows/activity-generation/steps/save-explanation-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-explanation-activity-step.test.ts
@@ -66,7 +66,7 @@ describe(saveExplanationActivityStep, () => {
     ];
 
     await saveExplanationActivityStep({
-      activityId: Number(activity.id),
+      activityId: activity.id,
       completedRows: [],
       contentSteps,
       workflowRunId: "workflow-1",
@@ -107,7 +107,7 @@ describe(saveExplanationActivityStep, () => {
   });
 
   test("streams error when DB transaction fails", async () => {
-    const invalidActivityId = 999_999_999;
+    const invalidActivityId = randomUUID();
 
     await saveExplanationActivityStep({
       activityId: invalidActivityId,

--- a/apps/api/src/workflows/activity-generation/steps/save-explanation-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-explanation-activity-step.ts
@@ -12,7 +12,7 @@ import { handleActivityFailureStep } from "./handle-failure-step";
  * Static steps are placed at even positions (index * 2)
  * to leave room for visual steps at odd positions.
  */
-function buildStaticStepRecords(activityId: number, steps: ActivitySteps) {
+function buildStaticStepRecords(activityId: string, steps: ActivitySteps) {
   return steps.map((step, index) => ({
     activityId,
     content: assertStepContent("static", {
@@ -42,7 +42,7 @@ export async function saveExplanationActivityStep({
   contentSteps,
   workflowRunId,
 }: {
-  activityId: number;
+  activityId: string;
   completedRows: VisualStepRow[];
   contentSteps: ActivitySteps;
   workflowRunId: string;

--- a/apps/api/src/workflows/activity-generation/steps/save-grammar-steps-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-grammar-steps-step.ts
@@ -45,7 +45,7 @@ function buildOptionRomanizations(
  * matching the learner flow of "see pattern → test intuition → learn rule → practice."
  */
 function buildGrammarSteps(
-  activityId: bigint | number,
+  activityId: string,
   content: ActivityGrammarContentSchema,
   userContent: ActivityGrammarUserContentSchema,
   romanizations: Record<string, string> | null,

--- a/apps/api/src/workflows/activity-generation/steps/save-investigation-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-investigation-activity-step.test.ts
@@ -91,7 +91,7 @@ describe(saveInvestigationActivityStep, () => {
     await saveInvestigationActivityStep({
       accuracy: mockAccuracy,
       actions: mockActions,
-      activityId: Number(activity.id),
+      activityId: activity.id,
       findings: mockFindings,
       scenario: mockScenario,
       workflowRunId: "workflow-1",
@@ -183,7 +183,7 @@ describe(saveInvestigationActivityStep, () => {
     await saveInvestigationActivityStep({
       accuracy: mockAccuracy,
       actions: mockActions,
-      activityId: Number(activity.id),
+      activityId: activity.id,
       findings: mockFindings,
       scenario: mockScenario,
       workflowRunId: "workflow-completed",
@@ -219,7 +219,7 @@ describe(saveInvestigationActivityStep, () => {
     await saveInvestigationActivityStep({
       accuracy: mockAccuracy,
       actions: mockActions,
-      activityId: Number(activity.id),
+      activityId: activity.id,
       findings: mockFindings,
       scenario: mockScenario,
       workflowRunId: "workflow-error",

--- a/apps/api/src/workflows/activity-generation/steps/save-investigation-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-investigation-activity-step.ts
@@ -43,7 +43,7 @@ function buildInvestigationStepRecords({
   scenario,
 }: {
   accuracy: ActivityInvestigationAccuracySchema;
-  activityId: number;
+  activityId: string;
   actions: ActivityInvestigationActionsSchema;
   findings: ActivityInvestigationFindingsSchema;
   scenario: ActivityInvestigationScenarioSchema;
@@ -111,7 +111,7 @@ export async function saveInvestigationActivityStep({
   workflowRunId,
 }: {
   accuracy: ActivityInvestigationAccuracySchema;
-  activityId: number;
+  activityId: string;
   actions: ActivityInvestigationActionsSchema;
   findings: ActivityInvestigationFindingsSchema;
   scenario: ActivityInvestigationScenarioSchema;

--- a/apps/api/src/workflows/activity-generation/steps/save-listening-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-listening-activity-step.ts
@@ -14,7 +14,7 @@ import { handleActivityFailureStep } from "./handle-failure-step";
  */
 async function fetchReadingSourceSteps(
   activities: LessonActivity[],
-): Promise<{ position: number; sentenceId: bigint | null }[] | null> {
+): Promise<{ position: number; sentenceId: string | null }[] | null> {
   const reading = findActivityByKind(activities, "reading");
 
   if (!reading) {
@@ -49,8 +49,8 @@ async function fetchReadingSourceSteps(
  * Returns true on success, false on failure.
  */
 async function createListeningStepsAndComplete(params: {
-  listeningId: number;
-  readingSteps: { position: number; sentenceId: bigint | null }[];
+  listeningId: string;
+  readingSteps: { position: number; sentenceId: string | null }[];
   workflowRunId: string;
 }): Promise<boolean> {
   const { error } = await safeAsync(() =>

--- a/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.test.ts
@@ -84,7 +84,7 @@ describe(savePracticeActivityStep, () => {
     ];
 
     await savePracticeActivityStep({
-      activityId: Number(activity.id),
+      activityId: activity.id,
       steps,
       workflowRunId: "workflow-1",
     });
@@ -155,7 +155,7 @@ describe(savePracticeActivityStep, () => {
     ];
 
     await savePracticeActivityStep({
-      activityId: Number(activity.id),
+      activityId: activity.id,
       steps,
       workflowRunId: "workflow-error",
     });

--- a/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.ts
@@ -10,7 +10,7 @@ import { handleActivityFailureStep } from "./handle-failure-step";
  * Builds multipleChoice step records from practice steps.
  * Each practice step becomes a multipleChoice step with `kind: "core"`.
  */
-function buildPracticeStepRecords(activityId: number, steps: PracticeStep[]) {
+function buildPracticeStepRecords(activityId: string, steps: PracticeStep[]) {
   return steps.map((step, index) => {
     const content = assertStepContent("multipleChoice", {
       context: step.context,
@@ -40,7 +40,7 @@ export async function savePracticeActivityStep({
   steps,
   workflowRunId,
 }: {
-  activityId: number;
+  activityId: string;
   steps: PracticeStep[];
   workflowRunId: string;
 }): Promise<void> {

--- a/apps/api/src/workflows/activity-generation/steps/save-quiz-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-quiz-activity-step.test.ts
@@ -83,7 +83,7 @@ describe(saveQuizActivityStep, () => {
     ];
 
     await saveQuizActivityStep({
-      activityId: Number(activity.id),
+      activityId: activity.id,
       questions,
       workflowRunId: "workflow-1",
     });
@@ -153,7 +153,7 @@ describe(saveQuizActivityStep, () => {
     ];
 
     await saveQuizActivityStep({
-      activityId: Number(activity.id),
+      activityId: activity.id,
       questions,
       workflowRunId: "workflow-error",
     });

--- a/apps/api/src/workflows/activity-generation/steps/save-quiz-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-quiz-activity-step.ts
@@ -13,7 +13,7 @@ import { handleActivityFailureStep } from "./handle-failure-step";
  * The `format` field from AI output maps to the step `kind` in the DB.
  */
 function buildQuizStepRecords(
-  activityId: number,
+  activityId: string,
   questions: (QuizQuestion | QuizQuestionWithUrls)[],
 ) {
   return questions.map((question, index) => {
@@ -46,7 +46,7 @@ export async function saveQuizActivityStep({
   questions,
   workflowRunId,
 }: {
-  activityId: number;
+  activityId: string;
   questions: (QuizQuestion | QuizQuestionWithUrls)[];
   workflowRunId: string;
 }): Promise<void> {

--- a/apps/api/src/workflows/activity-generation/steps/save-reading-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-reading-activity-step.ts
@@ -126,9 +126,9 @@ export async function saveReadingActivityStep(params: {
  * lesson-scoped exercise data.
  */
 async function saveOneSentence(params: {
-  activityId: number;
+  activityId: string;
   distractors: Record<string, string[]>;
-  lessonId: number;
+  lessonId: string;
   organizationId: string;
   position: number;
   readingSentence: ReadingSentence;
@@ -224,7 +224,7 @@ async function saveOneSentence(params: {
  * Uses updateMany so "no matching row" (already completed) returns count=0
  * instead of throwing. Real DB errors still propagate to the caller.
  */
-async function markActivityAsCompleted(activityId: number, workflowRunId: string): Promise<void> {
+async function markActivityAsCompleted(activityId: string, workflowRunId: string): Promise<void> {
   await prisma.activity.updateMany({
     data: { generationRunId: workflowRunId, generationStatus: "completed" },
     where: { generationStatus: { not: "completed" }, id: activityId },

--- a/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.test.ts
@@ -120,7 +120,7 @@ describe(saveStoryActivityStep, () => {
     });
 
     await saveStoryActivityStep({
-      activityId: Number(activity.id),
+      activityId: activity.id,
       debriefData,
       storySteps,
       workflowRunId: "workflow-1",
@@ -208,7 +208,7 @@ describe(saveStoryActivityStep, () => {
     await prisma.activity.delete({ where: { id: activity.id } });
 
     await saveStoryActivityStep({
-      activityId: Number(activity.id),
+      activityId: activity.id,
       debriefData,
       storySteps,
       workflowRunId: "workflow-error",

--- a/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.ts
@@ -16,7 +16,7 @@ import { handleActivityFailureStep } from "./handle-failure-step";
  * - Positions N+2..N+2+M: static text steps, one per debrief concept
  */
 function buildStoryStepRecords(
-  activityId: number,
+  activityId: string,
   storySteps: ActivityStoryStepsSchema,
   debriefData: ActivityStoryDebriefSchema,
 ) {
@@ -88,7 +88,7 @@ export async function saveStoryActivityStep({
   storySteps,
   workflowRunId,
 }: {
-  activityId: number;
+  activityId: string;
   debriefData: ActivityStoryDebriefSchema;
   storySteps: ActivityStoryStepsSchema;
   workflowRunId: string;

--- a/apps/api/src/workflows/activity-generation/steps/save-vocabulary-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-vocabulary-activity-step.ts
@@ -164,16 +164,16 @@ export async function saveVocabularyActivityStep(params: {
 async function saveOneVocabularyWord(params: {
   distractors: Record<string, string[]>;
   existingCasing: Record<string, string>;
-  lessonId: number;
+  lessonId: string;
   organizationId: string;
   position: number;
   pronunciations: Record<string, string>;
   romanizations: Record<string, string>;
   targetLanguage: string;
-  translationActivityId: number | null;
+  translationActivityId: string | null;
   userLanguage: string;
   vocabWord: VocabularyWord;
-  vocabularyActivityId: number;
+  vocabularyActivityId: string;
   wordAudioUrls: Record<string, string>;
 }): Promise<void> {
   const {
@@ -257,7 +257,7 @@ async function saveOneVocabularyWord(params: {
  * Uses updateMany so "no matching row" (already completed) returns count=0
  * instead of throwing. Real DB errors still propagate to the caller.
  */
-async function markActivityAsCompleted(activityId: number, workflowRunId: string): Promise<void> {
+async function markActivityAsCompleted(activityId: string, workflowRunId: string): Promise<void> {
   await prisma.activity.updateMany({
     data: { generationRunId: workflowRunId, generationStatus: "completed" },
     where: { generationStatus: { not: "completed" }, id: activityId },

--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
@@ -250,7 +250,7 @@ describe(chapterGenerationWorkflow, () => {
     });
 
     test("throws FatalError when chapter not found", async () => {
-      const nonExistentId = 999_999_999;
+      const nonExistentId = randomUUID();
 
       await expect(chapterGenerationWorkflow(nonExistentId)).rejects.toThrow("Chapter not found");
     });

--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.ts
@@ -15,7 +15,7 @@ async function generateAndAddLessons(context: Awaited<ReturnType<typeof getChapt
   return addLessonsStep({ context, lessons });
 }
 
-export async function chapterGenerationWorkflow(chapterId: number): Promise<void> {
+export async function chapterGenerationWorkflow(chapterId: string): Promise<void> {
   "use workflow";
 
   const { workflowRunId } = getWorkflowMetadata();

--- a/apps/api/src/workflows/chapter-generation/steps/add-lessons-step.test.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/add-lessons-step.test.ts
@@ -52,7 +52,7 @@ describe(addLessonsStep, () => {
   test("streams error and throws when DB save fails", async () => {
     const brokenContext: ChapterContext = {
       ...context,
-      id: 999_999_999,
+      id: randomUUID(),
     };
 
     const lessons = [{ concepts: ["A"], description: "Desc", title: `Lesson ${randomUUID()}` }];

--- a/apps/api/src/workflows/chapter-generation/steps/get-chapter-step.test.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/get-chapter-step.test.ts
@@ -22,7 +22,7 @@ vi.mock("workflow", () => ({
 
 describe(getChapterStep, () => {
   let organizationId: string;
-  let courseId: number;
+  let courseId: string;
 
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();
@@ -133,7 +133,7 @@ describe(getChapterStep, () => {
   });
 
   test("throws FatalError when chapter does not exist", async () => {
-    await expect(getChapterStep(999_999_999)).rejects.toThrow("Chapter not found");
+    await expect(getChapterStep(randomUUID())).rejects.toThrow("Chapter not found");
 
     const events = getStreamedEvents(writeMock);
 

--- a/apps/api/src/workflows/chapter-generation/steps/get-chapter-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/get-chapter-step.ts
@@ -3,7 +3,7 @@ import { type ChapterStepName } from "@zoonk/core/workflows/steps";
 import { getAiGenerationChapterWhere, prisma } from "@zoonk/db";
 import { FatalError } from "workflow";
 
-async function getChapterForGeneration(chapterId: number) {
+async function getChapterForGeneration(chapterId: string) {
   return prisma.chapter.findFirst({
     include: {
       _count: { select: { lessons: true } },
@@ -17,7 +17,7 @@ async function getChapterForGeneration(chapterId: number) {
 
 const NEIGHBOR_RANGE = 3;
 
-async function getNeighboringChapters(courseId: number, position: number) {
+async function getNeighboringChapters(courseId: string, position: number) {
   return prisma.chapter.findMany({
     orderBy: { position: "asc" },
     select: { description: true, title: true },
@@ -38,7 +38,7 @@ export type ChapterContext = NonNullable<Awaited<ReturnType<typeof getChapterFor
   neighboringChapters: { description: string; title: string }[];
 };
 
-export async function getChapterStep(chapterId: number): Promise<ChapterContext> {
+export async function getChapterStep(chapterId: string): Promise<ChapterContext> {
   "use step";
 
   await using stream = createStepStream<ChapterStepName>();

--- a/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-completed-step.test.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-completed-step.test.ts
@@ -37,9 +37,19 @@ describe(setChapterAsCompletedStep, () => {
   });
 
   test("streams error and throws when chapter does not exist", async () => {
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      organizationId,
+      title: `Broken Chapter ${randomUUID()}`,
+    });
+
     const brokenContext: ChapterContext = {
-      id: 999_999_999,
-    } as ChapterContext;
+      ...chapter,
+      _count: { lessons: 0 },
+      course,
+      id: randomUUID(),
+      neighboringChapters: [],
+    };
 
     await expect(
       setChapterAsCompletedStep({ context: brokenContext, workflowRunId: "run-id" }),

--- a/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-running-step.test.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-running-step.test.ts
@@ -23,7 +23,7 @@ vi.mock("workflow", () => ({
 
 describe(setChapterAsRunningStep, () => {
   let organizationId: string;
-  let courseId: number;
+  let courseId: string;
 
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();
@@ -38,7 +38,7 @@ describe(setChapterAsRunningStep, () => {
 
   test("streams error and throws when chapter does not exist", async () => {
     await expect(
-      setChapterAsRunningStep({ chapterId: 999_999_999, workflowRunId: "run-id" }),
+      setChapterAsRunningStep({ chapterId: randomUUID(), workflowRunId: "run-id" }),
     ).rejects.toThrow();
 
     const events = getStreamedEvents(writeMock);

--- a/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-running-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-running-step.ts
@@ -4,7 +4,7 @@ import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 
 export async function setChapterAsRunningStep(input: {
-  chapterId: number;
+  chapterId: string;
   workflowRunId: string;
 }): Promise<void> {
   "use step";

--- a/apps/api/src/workflows/course-generation/_internal/generate-missing-content.test.ts
+++ b/apps/api/src/workflows/course-generation/_internal/generate-missing-content.test.ts
@@ -59,7 +59,7 @@ vi.mock("@zoonk/ai/tasks/courses/language-chapters", () => ({
 }));
 
 const course: CourseContext = {
-  courseId: 1,
+  courseId: "1",
   courseSlug: "test-course",
   courseTitle: "Test Course",
   language: "en",

--- a/apps/api/src/workflows/course-generation/_internal/get-or-create-course.test.ts
+++ b/apps/api/src/workflows/course-generation/_internal/get-or-create-course.test.ts
@@ -43,7 +43,7 @@ describe(getOrCreateCourse, () => {
     const result = await getOrCreateCourse(null, suggestion, suggestion.id, workflowRunId);
 
     expect(result.course.courseTitle).toBe(suggestion.title);
-    expect(result.course.courseId).toBeGreaterThan(0);
+    expect(result.course.courseId).toEqual(expect.any(String));
 
     expect(result.existing).toEqual({
       description: null,

--- a/apps/api/src/workflows/course-generation/_internal/get-or-create-course.ts
+++ b/apps/api/src/workflows/course-generation/_internal/get-or-create-course.ts
@@ -24,7 +24,7 @@ const DEFAULT_EXISTING_CONTENT: ExistingCourseContent = {
 export async function getOrCreateCourse(
   existingCourse: ExistingCourse | null,
   suggestion: CourseSuggestion,
-  courseSuggestionId: number,
+  courseSuggestionId: string,
   workflowRunId: string,
 ): Promise<{
   course: CourseContext;

--- a/apps/api/src/workflows/course-generation/_internal/setup-course.ts
+++ b/apps/api/src/workflows/course-generation/_internal/setup-course.ts
@@ -8,7 +8,7 @@ import { type ExistingCourseContent } from "./get-or-create-course";
 import { persistGeneratedContent } from "./persist-generated-content";
 
 async function getChapters(
-  courseId: number,
+  courseId: string,
   createdChapters: Chapter[],
   hasChapters: boolean,
 ): Promise<Chapter[]> {
@@ -22,7 +22,7 @@ async function getChapters(
 
 export async function setupCourse(
   course: CourseContext,
-  courseSuggestionId: number,
+  courseSuggestionId: string,
   existing: ExistingCourseContent,
 ): Promise<Chapter[]> {
   const content = await generateMissingContent(course, existing);

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -123,7 +123,7 @@ describe(courseGenerationWorkflow, () => {
 
   describe("early returns", () => {
     test("returns when suggestion not found", async () => {
-      const nonExistentId = 999_999_999;
+      const nonExistentId = randomUUID();
 
       await expect(courseGenerationWorkflow(nonExistentId)).rejects.toThrow(
         "Course suggestion not found",

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.ts
@@ -9,7 +9,7 @@ import { checkExistingCourseStep } from "./steps/check-existing-course-step";
 import { getCourseSuggestionStep } from "./steps/get-course-suggestion-step";
 import { handleCourseFailureStep } from "./steps/handle-failure-step";
 
-export async function courseGenerationWorkflow(courseSuggestionId: number): Promise<void> {
+export async function courseGenerationWorkflow(courseSuggestionId: string): Promise<void> {
   "use workflow";
 
   const { workflowRunId } = getWorkflowMetadata();

--- a/apps/api/src/workflows/course-generation/steps/add-alternative-titles-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/add-alternative-titles-step.test.ts
@@ -35,7 +35,7 @@ describe(addAlternativeTitlesStep, () => {
 
   test("streams error and throws when DB save fails", async () => {
     const brokenContext: CourseContext = {
-      courseId: 999_999_999,
+      courseId: randomUUID(),
       courseSlug: "broken",
       courseTitle: "Broken",
       language: "en",

--- a/apps/api/src/workflows/course-generation/steps/add-chapters-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/add-chapters-step.test.ts
@@ -47,7 +47,7 @@ describe(addChaptersStep, () => {
   test("streams error and throws when DB save fails", async () => {
     const brokenContext: CourseContext = {
       ...courseContext,
-      courseId: 999_999_999,
+      courseId: randomUUID(),
     };
 
     const chapters = [{ description: "Desc", title: `Chapter ${randomUUID()}` }];

--- a/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.test.ts
@@ -36,8 +36,8 @@ describe(completeCourseSetupStep, () => {
   test("streams error and throws when DB save fails", async () => {
     await expect(
       completeCourseSetupStep({
-        courseId: 999_999_999,
-        courseSuggestionId: 999_999_999,
+        courseId: randomUUID(),
+        courseSuggestionId: randomUUID(),
       }),
     ).rejects.toThrow("DB save failed in completeCourseSetup");
 

--- a/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.ts
@@ -4,8 +4,8 @@ import { prisma } from "@zoonk/db";
 import { rejected } from "@zoonk/utils/settled";
 
 export async function completeCourseSetupStep(input: {
-  courseSuggestionId: number;
-  courseId: number;
+  courseSuggestionId: string;
+  courseId: string;
 }): Promise<void> {
   "use step";
 

--- a/apps/api/src/workflows/course-generation/steps/generate-alternative-titles-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-alternative-titles-step.test.ts
@@ -26,7 +26,7 @@ vi.mock("@zoonk/ai/tasks/courses/alternative-titles", () => ({
 }));
 
 const course: CourseContext = {
-  courseId: 1,
+  courseId: "1",
   courseSlug: "test-course",
   courseTitle: "Test Course",
   language: "en",

--- a/apps/api/src/workflows/course-generation/steps/generate-categories-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-categories-step.test.ts
@@ -26,7 +26,7 @@ vi.mock("@zoonk/ai/tasks/courses/categories", () => ({
 }));
 
 const course: CourseContext = {
-  courseId: 1,
+  courseId: "1",
   courseSlug: "test-course",
   courseTitle: "Test Course",
   language: "en",

--- a/apps/api/src/workflows/course-generation/steps/generate-chapters-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-chapters-step.test.ts
@@ -31,7 +31,7 @@ vi.mock("@zoonk/ai/tasks/courses/language-chapters", () => ({
 }));
 
 const baseCourse: CourseContext = {
-  courseId: 1,
+  courseId: "1",
   courseSlug: "test-course",
   courseTitle: "Test Course",
   language: "en",

--- a/apps/api/src/workflows/course-generation/steps/generate-description-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-description-step.test.ts
@@ -26,7 +26,7 @@ vi.mock("@zoonk/ai/tasks/courses/description", () => ({
 }));
 
 const course: CourseContext = {
-  courseId: 1,
+  courseId: "1",
   courseSlug: "test-course",
   courseTitle: "Test Course",
   language: "en",

--- a/apps/api/src/workflows/course-generation/steps/generate-image-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-image-step.test.ts
@@ -26,7 +26,7 @@ vi.mock("@zoonk/core/courses/image", () => ({
 }));
 
 const course: CourseContext = {
-  courseId: 1,
+  courseId: "1",
   courseSlug: "test-course",
   courseTitle: "Test Course",
   language: "en",

--- a/apps/api/src/workflows/course-generation/steps/get-course-chapters-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/get-course-chapters-step.ts
@@ -3,7 +3,7 @@ import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
 import { type Chapter, getActiveChapterWhere, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 
-export async function getCourseChaptersStep(courseId: number): Promise<Chapter[]> {
+export async function getCourseChaptersStep(courseId: string): Promise<Chapter[]> {
   "use step";
 
   await using stream = createStepStream<CourseWorkflowStepName>();

--- a/apps/api/src/workflows/course-generation/steps/get-course-suggestion-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/get-course-suggestion-step.test.ts
@@ -45,7 +45,7 @@ describe(getCourseSuggestionStep, () => {
   });
 
   test("throws FatalError when suggestion does not exist", async () => {
-    await expect(getCourseSuggestionStep(999_999_999)).rejects.toThrow(
+    await expect(getCourseSuggestionStep(randomUUID())).rejects.toThrow(
       "Course suggestion not found",
     );
 

--- a/apps/api/src/workflows/course-generation/steps/get-course-suggestion-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/get-course-suggestion-step.ts
@@ -9,7 +9,7 @@ import { FatalError } from "workflow";
  * based on the generation status (e.g., skip if running, stream completion if completed).
  */
 export async function getCourseSuggestionStep(
-  courseSuggestionId: number,
+  courseSuggestionId: string,
 ): Promise<CourseSuggestion> {
   "use step";
 

--- a/apps/api/src/workflows/course-generation/steps/handle-failure-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/handle-failure-step.test.ts
@@ -94,7 +94,7 @@ describe(handleCourseFailureStep, () => {
 
 describe(handleChapterFailureStep, () => {
   let organizationId: string;
-  let courseId: number;
+  let courseId: string;
 
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();

--- a/apps/api/src/workflows/course-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/handle-failure-step.ts
@@ -4,8 +4,8 @@ import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 
 export async function handleCourseFailureStep(input: {
-  courseId: number | null;
-  courseSuggestionId: number;
+  courseId: string | null;
+  courseSuggestionId: string;
 }): Promise<void> {
   "use step";
 
@@ -33,7 +33,7 @@ export async function handleCourseFailureStep(input: {
   await stream.error({ reason: "aiGenerationFailed", step: "workflowError" });
 }
 
-export async function handleChapterFailureStep(input: { chapterId: number }): Promise<void> {
+export async function handleChapterFailureStep(input: { chapterId: string }): Promise<void> {
   "use step";
 
   await safeAsync(() =>

--- a/apps/api/src/workflows/course-generation/steps/initialize-course-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/initialize-course-step.test.ts
@@ -30,13 +30,16 @@ describe(initializeCourseStep, () => {
   });
 
   test("streams error and throws when suggestion update fails", async () => {
+    const suggestion = await courseSuggestionFixture({
+      title: `Missing Suggestion ${randomUUID()}`,
+    });
+
     const fakeSuggestion = {
-      id: 999_999_999,
-      language: "en",
-      slug: "nonexistent",
-      targetLanguage: null,
+      ...suggestion,
+      id: randomUUID(),
+      slug: `nonexistent-${randomUUID()}`,
       title: "Nonexistent",
-    } as Awaited<ReturnType<typeof courseSuggestionFixture>>;
+    };
 
     await expect(
       initializeCourseStep({ suggestion: fakeSuggestion, workflowRunId: "run-id" }),
@@ -60,7 +63,7 @@ describe(initializeCourseStep, () => {
 
     expect(result.courseTitle).toBe(suggestion.title);
     expect(result.language).toBe(suggestion.language);
-    expect(result.courseId).toBeGreaterThan(0);
+    expect(result.courseId).toEqual(expect.any(String));
 
     const [updatedSuggestion, createdCourse] = await Promise.all([
       prisma.courseSuggestion.findUniqueOrThrow({ where: { id: suggestion.id } }),

--- a/apps/api/src/workflows/course-generation/steps/initialize-course-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/initialize-course-step.ts
@@ -6,7 +6,7 @@ import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { ensureLocaleSuffix, normalizeString, toSlug } from "@zoonk/utils/string";
 
 export type CourseContext = {
-  courseId: number;
+  courseId: string;
   courseSlug: string;
   courseTitle: string;
   language: string;
@@ -27,7 +27,7 @@ async function updateCourseSuggestionToRunning({
   stream: {
     error: (params: { reason: WorkflowErrorReason; step: CourseWorkflowStepName }) => Promise<void>;
   };
-  suggestionId: number;
+  suggestionId: string;
   workflowRunId: string;
 }): Promise<{ error: Error | null }> {
   const { error } = await safeAsync(() =>

--- a/apps/api/src/workflows/course-generation/steps/set-course-as-running-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/set-course-as-running-step.test.ts
@@ -36,8 +36,8 @@ describe(setCourseAsRunningStep, () => {
   test("streams error and throws when DB save fails", async () => {
     await expect(
       setCourseAsRunningStep({
-        courseId: 999_999_999,
-        courseSuggestionId: 999_999_999,
+        courseId: randomUUID(),
+        courseSuggestionId: randomUUID(),
         workflowRunId: "run-id",
       }),
     ).rejects.toThrow("DB save failed in setCourseAsRunning");

--- a/apps/api/src/workflows/course-generation/steps/set-course-as-running-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/set-course-as-running-step.ts
@@ -4,8 +4,8 @@ import { prisma } from "@zoonk/db";
 import { rejected } from "@zoonk/utils/settled";
 
 export async function setCourseAsRunningStep(input: {
-  courseId: number;
-  courseSuggestionId: number;
+  courseId: string;
+  courseSuggestionId: string;
   workflowRunId: string;
 }): Promise<void> {
   "use step";

--- a/apps/api/src/workflows/course-generation/steps/update-course-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/update-course-step.test.ts
@@ -35,7 +35,7 @@ describe(updateCourseStep, () => {
 
   test("streams error and throws when course does not exist", async () => {
     const brokenContext: CourseContext = {
-      courseId: 999_999_999,
+      courseId: randomUUID(),
       courseSlug: "broken",
       courseTitle: "Broken",
       language: "en",

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
@@ -224,7 +224,7 @@ describe(lessonGenerationWorkflow, () => {
     });
 
     test("throws FatalError when lesson not found", async () => {
-      const nonExistentId = 999_999_999;
+      const nonExistentId = randomUUID();
 
       await expect(lessonGenerationWorkflow(nonExistentId)).rejects.toThrow("Lesson not found");
     });

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
@@ -123,7 +123,7 @@ async function getLessonKindForRegeneration(context: LessonGenerationContext): P
  * generated activity set that was just created.
  */
 async function syncLessonKindForInitialGeneration(input: {
-  lessonId: number;
+  lessonId: string;
   lessonKind: LessonKind;
 }): Promise<void> {
   await updateLessonKindStep({
@@ -146,7 +146,7 @@ async function skipLessonKindSyncForRegeneration(): Promise<void> {
  * actually a language lesson. In that case we delete the lesson instead of
  * saving an invalid activity set under it.
  */
-async function handleFilteredInitialLesson(input: { lessonId: number }): Promise<"filtered"> {
+async function handleFilteredInitialLesson(input: { lessonId: string }): Promise<"filtered"> {
   await removeNonLanguageLessonStep({ lessonId: input.lessonId });
   return "filtered";
 }
@@ -194,7 +194,7 @@ async function addGeneratedActivities(input: {
  */
 async function runInitialLessonGeneration(input: {
   context: LessonGenerationContext;
-  lessonId: number;
+  lessonId: string;
   workflowRunId: string;
 }): Promise<LessonGenerationResult> {
   if (shouldSkipRunningInitialGeneration(input.context)) {
@@ -263,7 +263,7 @@ async function runInitialLessonGeneration(input: {
 async function runLessonRegeneration(input: {
   context: LessonGenerationContext;
   generationRunId: string;
-  lessonId: number;
+  lessonId: string;
 }): Promise<LessonGenerationResult> {
   const lessonKind = await getLessonKindForRegeneration(input.context);
 
@@ -290,7 +290,7 @@ async function runLessonRegeneration(input: {
 }
 
 export async function lessonGenerationWorkflow(
-  lessonId: number,
+  lessonId: string,
   options: LessonGenerationOptions = {},
 ): Promise<LessonGenerationResult> {
   "use workflow";

--- a/apps/api/src/workflows/lesson-generation/steps/add-activities-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/add-activities-step.test.ts
@@ -143,7 +143,7 @@ describe(addActivitiesStep, () => {
   test("streams error and throws when DB save fails", async () => {
     const brokenContext: LessonContext = {
       ...context,
-      id: 999_999_999,
+      id: randomUUID(),
     };
 
     await expect(

--- a/apps/api/src/workflows/lesson-generation/steps/determine-applied-activity-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/determine-applied-activity-step.test.ts
@@ -34,7 +34,7 @@ vi.mock("@zoonk/ai/tasks/lessons/applied-activity-kind", () => ({
 describe(determineAppliedActivityStep, () => {
   let context: LessonContext;
   let organizationId: string;
-  let chapterId: number;
+  let chapterId: string;
 
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();

--- a/apps/api/src/workflows/lesson-generation/steps/determine-applied-activity-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/determine-applied-activity-step.ts
@@ -14,7 +14,7 @@ const MAX_RECENT_KINDS = 5;
  * so it can avoid repeating the same kind when the topic is ambiguous.
  */
 async function getRecentAppliedKinds(
-  chapterId: number,
+  chapterId: string,
   currentPosition: number,
 ): Promise<string[]> {
   const previousActivities = await prisma.activity.findMany({

--- a/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.test.ts
@@ -23,8 +23,8 @@ vi.mock("workflow", () => ({
 
 describe(getLessonStep, () => {
   let organizationId: string;
-  let chapterId: number;
-  let courseId: number;
+  let chapterId: string;
+  let courseId: string;
 
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();
@@ -70,7 +70,7 @@ describe(getLessonStep, () => {
   });
 
   test("throws FatalError when lesson does not exist", async () => {
-    await expect(getLessonStep(999_999_999)).rejects.toThrow("Lesson not found");
+    await expect(getLessonStep(randomUUID())).rejects.toThrow("Lesson not found");
 
     const events = getStreamedEvents(writeMock);
 

--- a/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.ts
@@ -3,7 +3,7 @@ import { type LessonStepName } from "@zoonk/core/workflows/steps";
 import { getAiGenerationLessonWhere, prisma } from "@zoonk/db";
 import { FatalError } from "workflow";
 
-async function getLessonForGeneration(lessonId: number) {
+async function getLessonForGeneration(lessonId: string) {
   return prisma.lesson.findFirst({
     include: {
       _count: { select: { activities: true } },
@@ -17,7 +17,7 @@ async function getLessonForGeneration(lessonId: number) {
 
 export type LessonContext = NonNullable<Awaited<ReturnType<typeof getLessonForGeneration>>>;
 
-export async function getLessonStep(lessonId: number): Promise<LessonContext> {
+export async function getLessonStep(lessonId: string): Promise<LessonContext> {
   "use step";
 
   await using stream = createStepStream<LessonStepName>();

--- a/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.test.ts
@@ -24,7 +24,7 @@ vi.mock("workflow", () => ({
 
 describe(handleLessonFailureStep, () => {
   let organizationId: string;
-  let chapterId: number;
+  let chapterId: string;
 
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();

--- a/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.ts
@@ -2,7 +2,7 @@ import { createStepStream } from "@/workflows/_shared/stream-status";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 
-export async function handleLessonFailureStep(input: { lessonId: number }): Promise<void> {
+export async function handleLessonFailureStep(input: { lessonId: string }): Promise<void> {
   "use step";
 
   await using stream = createStepStream();

--- a/apps/api/src/workflows/lesson-generation/steps/remove-non-language-lesson-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/remove-non-language-lesson-step.test.ts
@@ -24,7 +24,7 @@ vi.mock("workflow", () => ({
 
 describe(removeNonLanguageLessonStep, () => {
   let organizationId: string;
-  let chapterId: number;
+  let chapterId: string;
 
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();
@@ -43,7 +43,7 @@ describe(removeNonLanguageLessonStep, () => {
   });
 
   test("streams error and throws when lesson does not exist", async () => {
-    await expect(removeNonLanguageLessonStep({ lessonId: 999_999_999 })).rejects.toThrow();
+    await expect(removeNonLanguageLessonStep({ lessonId: randomUUID() })).rejects.toThrow();
 
     const events = getStreamedEvents(writeMock);
 

--- a/apps/api/src/workflows/lesson-generation/steps/remove-non-language-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/remove-non-language-lesson-step.ts
@@ -3,7 +3,7 @@ import { type LessonStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 
-export async function removeNonLanguageLessonStep(input: { lessonId: number }): Promise<void> {
+export async function removeNonLanguageLessonStep(input: { lessonId: string }): Promise<void> {
   "use step";
 
   await using stream = createStepStream<LessonStepName>();

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-completed-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-completed-step.test.ts
@@ -26,7 +26,7 @@ vi.mock("workflow", () => ({
 
 describe(setLessonAsCompletedStep, () => {
   let organizationId: string;
-  let chapterId: number;
+  let chapterId: string;
   let course: Awaited<ReturnType<typeof courseFixture>>;
   let chapter: Awaited<ReturnType<typeof chapterFixture>>;
 
@@ -47,9 +47,18 @@ describe(setLessonAsCompletedStep, () => {
   });
 
   test("streams error and throws when lesson does not exist", async () => {
+    const lesson = await lessonFixture({
+      chapterId,
+      organizationId,
+      title: `Broken Lesson ${randomUUID()}`,
+    });
+
     const context: LessonContext = {
-      id: 999_999_999,
-    } as LessonContext;
+      ...lesson,
+      _count: { activities: 0 },
+      chapter: { ...chapter, course },
+      id: randomUUID(),
+    };
 
     await expect(
       setLessonAsCompletedStep({

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.test.ts
@@ -24,7 +24,7 @@ vi.mock("workflow", () => ({
 
 describe(setLessonAsRunningStep, () => {
   let organizationId: string;
-  let chapterId: number;
+  let chapterId: string;
 
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();
@@ -44,7 +44,7 @@ describe(setLessonAsRunningStep, () => {
 
   test("streams error and throws when lesson does not exist", async () => {
     await expect(
-      setLessonAsRunningStep({ lessonId: 999_999_999, workflowRunId: "run-id" }),
+      setLessonAsRunningStep({ lessonId: randomUUID(), workflowRunId: "run-id" }),
     ).rejects.toThrow();
 
     const events = getStreamedEvents(writeMock);

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.ts
@@ -4,7 +4,7 @@ import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 
 export async function setLessonAsRunningStep(input: {
-  lessonId: number;
+  lessonId: string;
   workflowRunId: string;
 }): Promise<void> {
   "use step";

--- a/apps/api/src/workflows/lesson-generation/steps/update-lesson-kind-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/update-lesson-kind-step.test.ts
@@ -24,7 +24,7 @@ vi.mock("workflow", () => ({
 
 describe(updateLessonKindStep, () => {
   let organizationId: string;
-  let chapterId: number;
+  let chapterId: string;
 
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();
@@ -44,7 +44,7 @@ describe(updateLessonKindStep, () => {
 
   test("streams error and throws when lesson does not exist", async () => {
     await expect(
-      updateLessonKindStep({ kind: "language", lessonId: 999_999_999 }),
+      updateLessonKindStep({ kind: "language", lessonId: randomUUID() }),
     ).rejects.toThrow();
 
     const events = getStreamedEvents(writeMock);

--- a/apps/api/src/workflows/lesson-generation/steps/update-lesson-kind-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/update-lesson-kind-step.ts
@@ -4,7 +4,7 @@ import { type LessonKind, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 
 export async function updateLessonKindStep(input: {
-  lessonId: number;
+  lessonId: string;
   kind: LessonKind;
 }): Promise<void> {
   "use step";

--- a/apps/api/src/workflows/lesson-preload/lesson-preload-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-preload/lesson-preload-workflow.test.ts
@@ -29,7 +29,7 @@ vi.mock("../lesson-regeneration/lesson-regeneration-workflow", () => ({
 describe(lessonPreloadWorkflow, () => {
   const initialLesson = {
     generationVersion: null,
-    id: 42,
+    id: "42",
     managementMode: "ai",
   };
   const outdatedLesson = {
@@ -114,14 +114,14 @@ describe(lessonPreloadWorkflow, () => {
   test("propagates errors from lessonGenerationWorkflow", async () => {
     vi.mocked(lessonGenerationWorkflow).mockRejectedValueOnce(new Error("lesson gen failed"));
 
-    await expect(lessonPreloadWorkflow(1)).rejects.toThrow("lesson gen failed");
+    await expect(lessonPreloadWorkflow(initialLesson.id)).rejects.toThrow("lesson gen failed");
     expect(activityGenerationWorkflow).not.toHaveBeenCalled();
   });
 
   test("propagates errors from activityGenerationWorkflow", async () => {
     vi.mocked(activityGenerationWorkflow).mockRejectedValueOnce(new Error("activity gen failed"));
 
-    await expect(lessonPreloadWorkflow(1)).rejects.toThrow("activity gen failed");
-    expect(lessonGenerationWorkflow).toHaveBeenCalledWith(1);
+    await expect(lessonPreloadWorkflow(initialLesson.id)).rejects.toThrow("activity gen failed");
+    expect(lessonGenerationWorkflow).toHaveBeenCalledWith(initialLesson.id);
   });
 });

--- a/apps/api/src/workflows/lesson-preload/lesson-preload-workflow.ts
+++ b/apps/api/src/workflows/lesson-preload/lesson-preload-workflow.ts
@@ -23,7 +23,7 @@ function usesRegenerationPath(input: {
   );
 }
 
-export async function lessonPreloadWorkflow(lessonId: number): Promise<void> {
+export async function lessonPreloadWorkflow(lessonId: string): Promise<void> {
   "use workflow";
 
   const lesson = await getLessonStep(lessonId);

--- a/apps/api/src/workflows/lesson-regeneration/lesson-regeneration-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-regeneration/lesson-regeneration-workflow.test.ts
@@ -32,7 +32,7 @@ vi.mock("../lesson-generation/lesson-generation-workflow", () => ({
  * use the same query shape so promotion and cleanup assertions run against the
  * exact data contract the workflow consumes in production.
  */
-async function getLessonContext(lessonId: number): Promise<LessonContext> {
+async function getLessonContext(lessonId: string): Promise<LessonContext> {
   return prisma.lesson.findUniqueOrThrow({
     include: {
       _count: { select: { activities: true } },
@@ -43,7 +43,7 @@ async function getLessonContext(lessonId: number): Promise<LessonContext> {
 }
 
 describe(lessonRegenerationWorkflow, () => {
-  let chapterId: number;
+  let chapterId: string;
   let organizationId: string;
 
   beforeAll(async () => {
@@ -62,7 +62,7 @@ describe(lessonRegenerationWorkflow, () => {
     vi.clearAllMocks();
     lessonGenerationWorkflowMock.mockImplementation(
       async (
-        lessonId: number,
+        lessonId: string,
         options?: {
           generationRunId?: string;
           regeneration?: boolean;
@@ -82,7 +82,7 @@ describe(lessonRegenerationWorkflow, () => {
         return "ready";
       },
     );
-    activityGenerationWorkflowMock.mockImplementation(async (lessonId: number) => {
+    activityGenerationWorkflowMock.mockImplementation(async (lessonId: string) => {
       await prisma.activity.updateMany({
         data: { generationStatus: "completed" },
         where: {
@@ -234,7 +234,7 @@ describe(lessonRegenerationWorkflow, () => {
   test("publishes regenerated activities with fresh zero-based positions", async () => {
     lessonGenerationWorkflowMock.mockImplementationOnce(
       async (
-        lessonId: number,
+        lessonId: string,
         options?: {
           generationRunId?: string;
           regeneration?: boolean;
@@ -276,7 +276,7 @@ describe(lessonRegenerationWorkflow, () => {
         return "ready";
       },
     );
-    activityGenerationWorkflowMock.mockImplementationOnce(async (lessonId: number) => {
+    activityGenerationWorkflowMock.mockImplementationOnce(async (lessonId: string) => {
       await prisma.activity.updateMany({
         data: { generationStatus: "completed" },
         where: {
@@ -393,7 +393,7 @@ describe(lessonRegenerationWorkflow, () => {
   });
 
   test("deletes hidden replacement activities when activity regeneration fails", async () => {
-    activityGenerationWorkflowMock.mockImplementationOnce(async (lessonId: number) => {
+    activityGenerationWorkflowMock.mockImplementationOnce(async (lessonId: string) => {
       await prisma.activity.updateMany({
         data: { generationStatus: "running" },
         where: {

--- a/apps/api/src/workflows/lesson-regeneration/steps/claim-live-lesson-regeneration-step.test.ts
+++ b/apps/api/src/workflows/lesson-regeneration/steps/claim-live-lesson-regeneration-step.test.ts
@@ -13,7 +13,7 @@ import { claimLiveLessonRegenerationStep } from "./claim-live-lesson-regeneratio
  * passes in after loading the live lesson. Keeping that query in the test
  * avoids inventing a partial object that would diverge from production.
  */
-async function getLessonContext(lessonId: number): Promise<LessonContext> {
+async function getLessonContext(lessonId: string): Promise<LessonContext> {
   return prisma.lesson.findUniqueOrThrow({
     include: {
       _count: { select: { activities: true } },
@@ -24,7 +24,7 @@ async function getLessonContext(lessonId: number): Promise<LessonContext> {
 }
 
 describe(claimLiveLessonRegenerationStep, () => {
-  let chapterId: number;
+  let chapterId: string;
   let organizationId: string;
 
   beforeAll(async () => {

--- a/apps/api/src/workflows/lesson-regeneration/steps/cleanup-regenerated-activities-step.test.ts
+++ b/apps/api/src/workflows/lesson-regeneration/steps/cleanup-regenerated-activities-step.test.ts
@@ -9,7 +9,7 @@ import { beforeAll, describe, expect, test } from "vitest";
 import { cleanupRegeneratedActivitiesStep } from "./cleanup-regenerated-activities-step";
 
 describe(cleanupRegeneratedActivitiesStep, () => {
-  let chapterId: number;
+  let chapterId: string;
   let organizationId: string;
 
   beforeAll(async () => {

--- a/apps/api/src/workflows/lesson-regeneration/steps/cleanup-regenerated-activities-step.ts
+++ b/apps/api/src/workflows/lesson-regeneration/steps/cleanup-regenerated-activities-step.ts
@@ -7,7 +7,7 @@ import { prisma } from "@zoonk/db";
  * the published learner-facing activities untouched. Regeneration is already
  * serialized at the lesson level, so we do not need a workflow run id here.
  */
-export async function cleanupRegeneratedActivitiesStep(input: { lessonId: number }): Promise<void> {
+export async function cleanupRegeneratedActivitiesStep(input: { lessonId: string }): Promise<void> {
   "use step";
 
   await prisma.activity.deleteMany({

--- a/apps/api/src/workflows/lesson-regeneration/steps/release-live-lesson-regeneration-step.test.ts
+++ b/apps/api/src/workflows/lesson-regeneration/steps/release-live-lesson-regeneration-step.test.ts
@@ -8,7 +8,7 @@ import { beforeAll, describe, expect, test } from "vitest";
 import { releaseLiveLessonRegenerationStep } from "./release-live-lesson-regeneration-step";
 
 describe(releaseLiveLessonRegenerationStep, () => {
-  let chapterId: number;
+  let chapterId: string;
   let organizationId: string;
 
   beforeAll(async () => {

--- a/apps/api/src/workflows/lesson-regeneration/steps/release-live-lesson-regeneration-step.ts
+++ b/apps/api/src/workflows/lesson-regeneration/steps/release-live-lesson-regeneration-step.ts
@@ -8,7 +8,7 @@ import { prisma } from "@zoonk/db";
  * content as current.
  */
 export async function releaseLiveLessonRegenerationStep(input: {
-  lessonId: number;
+  lessonId: string;
 }): Promise<void> {
   "use step";
 

--- a/apps/editor/e2e/alternative-titles.test.ts
+++ b/apps/editor/e2e/alternative-titles.test.ts
@@ -34,7 +34,7 @@ async function openAlternativeTitles(page: Page) {
   await page.getByRole("button", { name: /alternative titles/i }).click();
 }
 
-async function createAlternativeTitleFixture(courseId: number, baseSlug: string) {
+async function createAlternativeTitleFixture(courseId: string, baseSlug: string) {
   const slug = `${baseSlug}-${randomUUID().slice(0, 8)}`;
   await prisma.courseAlternativeTitle.create({
     data: { courseId, language: "en", slug },
@@ -42,7 +42,7 @@ async function createAlternativeTitleFixture(courseId: number, baseSlug: string)
   return slug;
 }
 
-async function createManyAlternativeTitleFixtures(courseId: number, count: number) {
+async function createManyAlternativeTitleFixtures(courseId: string, count: number) {
   const prefix = randomUUID().slice(0, 8);
   const slugs = Array.from(
     { length: count },

--- a/apps/editor/e2e/chapter-delete.test.ts
+++ b/apps/editor/e2e/chapter-delete.test.ts
@@ -57,12 +57,12 @@ async function confirmDelete(page: Page) {
   await getConfirmDeleteButton(page).click();
 }
 
-async function verifyChapterDeleted(chapterId: number) {
+async function verifyChapterDeleted(chapterId: string) {
   const chapter = await prisma.chapter.findUnique({ where: { id: chapterId } });
   expect(chapter).toBeNull();
 }
 
-async function verifyChapterExists(chapterId: number) {
+async function verifyChapterExists(chapterId: string) {
   const chapter = await prisma.chapter.findUnique({ where: { id: chapterId } });
   expect(chapter).not.toBeNull();
 }

--- a/apps/editor/e2e/course-categories.test.ts
+++ b/apps/editor/e2e/course-categories.test.ts
@@ -31,7 +31,7 @@ function getCategoryOption(page: Page, name: RegExp) {
   return dialog.getByText(name);
 }
 
-async function expectCategoryInDB(courseId: number, category: string) {
+async function expectCategoryInDB(courseId: string, category: string) {
   await expect(async () => {
     const record = await prisma.courseCategory.findUnique({
       where: { courseCategory: { category, courseId } },
@@ -40,7 +40,7 @@ async function expectCategoryInDB(courseId: number, category: string) {
   }).toPass({ timeout: 10_000 });
 }
 
-async function expectCategoryNotInDB(courseId: number, category: string) {
+async function expectCategoryNotInDB(courseId: string, category: string) {
   await expect(async () => {
     const record = await prisma.courseCategory.findUnique({
       where: { courseCategory: { category, courseId } },

--- a/apps/editor/e2e/course-delete.test.ts
+++ b/apps/editor/e2e/course-delete.test.ts
@@ -87,17 +87,17 @@ async function confirmDelete(page: Page) {
   await getConfirmDeleteButton(page).click();
 }
 
-async function verifyCourseDeleted(courseId: number) {
+async function verifyCourseDeleted(courseId: string) {
   const course = await prisma.course.findUnique({ where: { id: courseId } });
   expect(course).toBeNull();
 }
 
-async function verifyCourseExists(courseId: number) {
+async function verifyCourseExists(courseId: string) {
   const course = await prisma.course.findUnique({ where: { id: courseId } });
   expect(course).not.toBeNull();
 }
 
-async function verifyCourseArchived(courseId: number) {
+async function verifyCourseArchived(courseId: string) {
   const course = await prisma.course.findUnique({ where: { id: courseId } });
   expect(course).not.toBeNull();
   expect(course?.archivedAt).not.toBeNull();

--- a/apps/editor/e2e/lesson-delete.test.ts
+++ b/apps/editor/e2e/lesson-delete.test.ts
@@ -71,12 +71,12 @@ async function confirmDelete(page: Page) {
   await getConfirmDeleteButton(page).click();
 }
 
-async function verifyLessonDeleted(lessonId: number) {
+async function verifyLessonDeleted(lessonId: string) {
   const lesson = await prisma.lesson.findUnique({ where: { id: lessonId } });
   expect(lesson).toBeNull();
 }
 
-async function verifyLessonExists(lessonId: number) {
+async function verifyLessonExists(lessonId: string) {
   const lesson = await prisma.lesson.findUnique({ where: { id: lessonId } });
   expect(lesson).not.toBeNull();
 }

--- a/apps/editor/src/app/[orgSlug]/@navbarActions/c/[courseSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/@navbarActions/c/[courseSlug]/actions.ts
@@ -8,7 +8,7 @@ import { redirect } from "next/navigation";
 
 export async function togglePublishAction(
   params: {
-    courseId: number;
+    courseId: string;
     courseUrl: string;
   },
   isPublished: boolean,
@@ -31,7 +31,7 @@ export async function togglePublishAction(
 
 export async function deleteCourseAction(
   orgSlug: string,
-  courseId: number,
+  courseId: string,
 ): Promise<{ error: string | null }> {
   const { error } = await deleteCourse({ courseId });
 

--- a/apps/editor/src/app/[orgSlug]/@navbarActions/c/[courseSlug]/ch/[chapterSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/@navbarActions/c/[courseSlug]/ch/[chapterSlug]/actions.ts
@@ -8,7 +8,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 export async function togglePublishAction(
-  params: { chapterId: number; chapterUrl: string },
+  params: { chapterId: string; chapterUrl: string },
   isPublished: boolean,
 ): Promise<{ error: string | null }> {
   const { chapterId, chapterUrl } = params;
@@ -28,7 +28,7 @@ export async function togglePublishAction(
 }
 
 export async function deleteChapterAction(
-  chapterId: number,
+  chapterId: string,
   courseUrl: Route,
 ): Promise<{ error: string | null }> {
   const { error } = await deleteChapter({ chapterId });

--- a/apps/editor/src/app/[orgSlug]/@navbarActions/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/@navbarActions/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/actions.ts
@@ -9,7 +9,7 @@ import { redirect } from "next/navigation";
 
 export async function togglePublishAction(
   lessonUrl: string,
-  lessonId: number,
+  lessonId: string,
   isPublished: boolean,
 ): Promise<{ error: string | null }> {
   const { error } = await toggleLessonPublished({
@@ -27,7 +27,7 @@ export async function togglePublishAction(
 }
 
 export async function deleteLessonAction(
-  lessonId: number,
+  lessonId: string,
   chapterUrl: Route,
 ): Promise<{ error: string | null }> {
   const { error } = await deleteLesson({ lessonId });

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/alternative-titles.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/alternative-titles.ts
@@ -11,7 +11,7 @@ import { getExtracted } from "next-intl/server";
 import { revalidatePath } from "next/cache";
 
 type CourseActionParams = {
-  courseId: number;
+  courseId: string;
   language: string;
 };
 
@@ -111,7 +111,7 @@ export async function importAlternativeTitlesAction(
   return { error: null };
 }
 
-export async function exportAlternativeTitlesAction(courseId: number): Promise<{
+export async function exportAlternativeTitlesAction(courseId: string): Promise<{
   data: object | null;
   error: Error | null;
 }> {

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/categories.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/categories.ts
@@ -7,7 +7,7 @@ import { getErrorMessage } from "@/lib/error-messages";
 import { revalidatePath } from "next/cache";
 
 type CourseActionParams = {
-  courseId: number;
+  courseId: string;
 };
 
 export async function addCourseCategoryAction(

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/chapters.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/chapters.ts
@@ -12,7 +12,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 async function createChapterAction(
-  courseId: number,
+  courseId: string,
   position: number,
 ): Promise<{ error: string | null; slug?: string }> {
   const t = await getExtracted();
@@ -36,7 +36,7 @@ async function createChapterAction(
 }
 
 async function importChaptersAction(
-  courseId: number,
+  courseId: string,
   formData: FormData,
 ): Promise<{ error: string | null }> {
   const file = formData.get("file");
@@ -61,7 +61,7 @@ async function importChaptersAction(
   return { error: null };
 }
 
-export async function exportChaptersAction(courseId: number): Promise<{
+export async function exportChaptersAction(courseId: string): Promise<{
   data: object | null;
   error: Error | null;
 }> {
@@ -75,7 +75,7 @@ export async function exportChaptersAction(courseId: number): Promise<{
 }
 
 type CourseActionParams = {
-  courseId: number;
+  courseId: string;
 };
 
 /**
@@ -83,7 +83,7 @@ type CourseActionParams = {
  * this helper resolves the canonical route on the server before we revalidate or
  * redirect instead of trusting route params captured at render time.
  */
-async function getAuthorizedCoursePagePath(courseId: number): Promise<
+async function getAuthorizedCoursePagePath(courseId: string): Promise<
   | {
       error: string;
       path: null;
@@ -164,7 +164,7 @@ export async function handleImportChaptersAction(
 
 export async function reorderChaptersAction(
   params: CourseActionParams,
-  chapters: { id: number; position: number }[],
+  chapters: { id: string; position: number }[],
 ): Promise<{ error: string | null }> {
   const { courseId } = params;
   const coursePage = await getAuthorizedCoursePagePath(courseId);

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/content.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/content.ts
@@ -4,7 +4,7 @@ import { updateCourse } from "@/data/courses/update-course";
 import { getErrorMessage } from "@/lib/error-messages";
 
 export async function updateCourseTitleAction(
-  courseId: number,
+  courseId: string,
   data: { title: string },
 ): Promise<{ error: string | null }> {
   const { error } = await updateCourse({
@@ -20,7 +20,7 @@ export async function updateCourseTitleAction(
 }
 
 export async function updateCourseDescriptionAction(
-  courseId: number,
+  courseId: string,
   data: { description: string },
 ): Promise<{ error: string | null }> {
   const { error } = await updateCourse({

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/image.test.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/image.test.ts
@@ -53,10 +53,10 @@ describe(uploadCourseImageAction, () => {
       error: new Error("forbidden"),
     });
 
-    const result = await uploadCourseImageAction({ courseId: 42 }, createFormData());
+    const result = await uploadCourseImageAction({ courseId: "course-42" }, createFormData());
 
     expect(result).toEqual({ error: "Forbidden" });
-    expect(mocks.getAuthorizedCourse).toHaveBeenCalledWith({ courseId: 42 });
+    expect(mocks.getAuthorizedCourse).toHaveBeenCalledWith({ courseId: "course-42" });
     expect(mocks.processAndUploadImage).not.toHaveBeenCalled();
     expect(mocks.updateCourse).not.toHaveBeenCalled();
     expect(mocks.revalidatePath).not.toHaveBeenCalled();
@@ -65,7 +65,7 @@ describe(uploadCourseImageAction, () => {
   test("derives the upload path from the authorized course record", async () => {
     mocks.getAuthorizedCourse.mockResolvedValue({
       data: {
-        id: 42,
+        id: "course-42",
         organization: { slug: "real-org" },
         slug: "real-course",
       },
@@ -76,11 +76,11 @@ describe(uploadCourseImageAction, () => {
       error: null,
     });
     mocks.updateCourse.mockResolvedValue({
-      data: { id: 42, imageUrl: "https://example.com/course.webp" },
+      data: { id: "course-42", imageUrl: "https://example.com/course.webp" },
       error: null,
     });
 
-    const result = await uploadCourseImageAction({ courseId: 42 }, createFormData());
+    const result = await uploadCourseImageAction({ courseId: "course-42" }, createFormData());
 
     expect(result).toEqual({ error: null });
     expect(mocks.processAndUploadImage).toHaveBeenCalledWith({
@@ -88,7 +88,7 @@ describe(uploadCourseImageAction, () => {
       fileName: "courses/real-org/real-course.webp",
     });
     expect(mocks.updateCourse).toHaveBeenCalledWith({
-      courseId: 42,
+      courseId: "course-42",
       imageUrl: "https://example.com/course.webp",
     });
     expect(mocks.revalidatePath).toHaveBeenCalledWith("/real-org/c/real-course");

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/image.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/image.ts
@@ -8,7 +8,7 @@ import { getExtracted } from "next-intl/server";
 import { revalidatePath } from "next/cache";
 
 type CourseActionParams = {
-  courseId: number;
+  courseId: string;
 };
 
 export async function uploadCourseImageAction(

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/slug.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/_actions/slug.ts
@@ -7,7 +7,7 @@ import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { ensureLocaleSuffix } from "@zoonk/utils/string";
 
 export async function checkCourseSlugExists(params: {
-  courseId?: number;
+  courseId?: string;
   language: string;
   orgSlug: string;
   slug: string;
@@ -26,7 +26,7 @@ export async function updateCourseSlugAction(
   currentSlug: string,
   language: string,
   orgSlug: string,
-  courseId: number,
+  courseId: string,
   data: { slug: string },
 ): Promise<{ error: string | null; newSlug?: string }> {
   const isAiOrg = orgSlug === AI_ORG_SLUG;

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/actions.ts
@@ -13,7 +13,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 export async function checkChapterSlugExists(params: {
-  courseId?: number;
+  courseId?: string;
   language: string;
   orgSlug: string;
   slug: string;
@@ -26,7 +26,7 @@ export async function checkChapterSlugExists(params: {
 
 export async function updateChapterTitleAction(
   slugs: { courseSlug: string; orgSlug: string },
-  chapterId: number,
+  chapterId: string,
   data: { title: string },
 ): Promise<{ error: string | null }> {
   const { courseSlug, orgSlug } = slugs;
@@ -46,7 +46,7 @@ export async function updateChapterTitleAction(
 
 export async function updateChapterDescriptionAction(
   slugs: { courseSlug: string; orgSlug: string },
-  chapterId: number,
+  chapterId: string,
   data: { description: string },
 ): Promise<{ error: string | null }> {
   const { courseSlug, orgSlug } = slugs;
@@ -65,7 +65,7 @@ export async function updateChapterDescriptionAction(
 }
 
 export async function updateChapterSlugAction(
-  chapterId: number,
+  chapterId: string,
   data: { slug: string },
 ): Promise<{ error: string | null; newSlug?: string }> {
   const { data: chapter, error } = await updateChapter({
@@ -81,7 +81,7 @@ export async function updateChapterSlugAction(
 }
 
 async function createLessonAction(
-  chapterId: number,
+  chapterId: string,
   position: number,
 ): Promise<{ error: string | null; slug?: string }> {
   const t = await getExtracted();
@@ -105,7 +105,7 @@ async function createLessonAction(
 }
 
 async function importLessonsAction(
-  chapterId: number,
+  chapterId: string,
   formData: FormData,
 ): Promise<{ error: string | null }> {
   const file = formData.get("file");
@@ -130,7 +130,7 @@ async function importLessonsAction(
   return { error: null };
 }
 
-export async function exportLessonsAction(chapterId: number): Promise<{
+export async function exportLessonsAction(chapterId: string): Promise<{
   data: object | null;
   error: Error | null;
 }> {
@@ -144,7 +144,7 @@ export async function exportLessonsAction(chapterId: number): Promise<{
 }
 
 type LessonRouteParams = {
-  chapterId: number;
+  chapterId: string;
   chapterSlug: string;
   courseSlug: string;
   orgSlug: string;
@@ -184,7 +184,7 @@ export async function handleImportLessonsAction(
 
 export async function reorderLessonsAction(
   params: LessonRouteParams,
-  lessons: { id: number; position: number }[],
+  lessons: { id: string; position: number }[],
 ): Promise<{ error: string | null }> {
   const { chapterId, chapterSlug, courseSlug, orgSlug } = params;
 

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/actions.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/actions.ts
@@ -6,7 +6,7 @@ import { getErrorMessage } from "@/lib/error-messages";
 import { revalidatePath } from "next/cache";
 
 export async function checkLessonSlugExists(params: {
-  chapterId?: number;
+  chapterId?: string;
   slug: string;
 }): Promise<boolean> {
   if (!params.chapterId) {
@@ -18,7 +18,7 @@ export async function checkLessonSlugExists(params: {
 
 export async function updateLessonTitleAction(
   slugs: { chapterSlug: string; courseSlug: string; orgSlug: string },
-  lessonId: number,
+  lessonId: string,
   data: { title: string },
 ): Promise<{ error: string | null }> {
   const { chapterSlug, courseSlug, orgSlug } = slugs;
@@ -38,7 +38,7 @@ export async function updateLessonTitleAction(
 
 export async function updateLessonDescriptionAction(
   slugs: { chapterSlug: string; courseSlug: string; orgSlug: string },
-  lessonId: number,
+  lessonId: string,
   data: { description: string },
 ): Promise<{ error: string | null }> {
   const { chapterSlug, courseSlug, orgSlug } = slugs;
@@ -58,7 +58,7 @@ export async function updateLessonDescriptionAction(
 
 export async function updateLessonSlugAction(
   slugs: { lessonSlug: string; chapterSlug: string; courseSlug: string },
-  lessonId: number,
+  lessonId: string,
   data: { slug: string },
 ): Promise<{ error: string | null; newSlug?: string }> {
   const { data: lesson, error } = await updateLesson({

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-actions.ts
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-actions.ts
@@ -12,9 +12,9 @@ import { redirect } from "next/navigation";
 
 async function createActivityAction(
   lessonSlug: string,
-  lessonId: number,
+  lessonId: string,
   position: number,
-): Promise<{ activityId: bigint | null; error: string | null }> {
+): Promise<{ activityId: string | null; error: string | null }> {
   const t = await getExtracted();
   const title = t("Untitled activity");
   const description = t("Add a description…");
@@ -36,7 +36,7 @@ async function createActivityAction(
 
 async function importActivitiesAction(
   lessonSlug: string,
-  lessonId: number,
+  lessonId: string,
   formData: FormData,
 ): Promise<{ error: string | null }> {
   const file = formData.get("file");
@@ -61,7 +61,7 @@ async function importActivitiesAction(
   return { error: null };
 }
 
-export async function exportActivitiesAction(lessonId: number): Promise<{
+export async function exportActivitiesAction(lessonId: string): Promise<{
   data: object | null;
   error: Error | null;
 }> {
@@ -77,7 +77,7 @@ export async function exportActivitiesAction(lessonId: number): Promise<{
 type ActivityRouteParams = {
   chapterSlug: string;
   courseSlug: string;
-  lessonId: number;
+  lessonId: string;
   lessonSlug: string;
   orgSlug: string;
 };
@@ -116,13 +116,13 @@ export async function handleImportActivitiesAction(
 
 export async function reorderActivitiesAction(
   params: ActivityRouteParams,
-  activities: { id: number; position: number }[],
+  activities: { id: string; position: number }[],
 ): Promise<{ error: string | null }> {
   const { chapterSlug, courseSlug, lessonId, lessonSlug, orgSlug } = params;
 
   const { error } = await reorderActivities({
     activities: activities.map((a) => ({
-      activityId: BigInt(a.id),
+      activityId: a.id,
       position: a.position,
     })),
     lessonId,

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list-item-link.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list-item-link.tsx
@@ -18,7 +18,7 @@ export function ActivityListItemLink({
   orgSlug,
   title,
 }: {
-  activityId: bigint;
+  activityId: string;
   chapterSlug: string;
   courseSlug: string;
   description: string | null;

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list-row.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list-row.tsx
@@ -17,7 +17,7 @@ export async function ActivityListRow({
   orgSlug,
 }: {
   activity: {
-    id: bigint;
+    id: string;
     kind: string;
     title: string | null;
     description: string | null;
@@ -31,7 +31,7 @@ export async function ActivityListRow({
   const t = await getExtracted();
 
   return (
-    <EditorSortableItem id={Number(activity.id)} key={String(activity.id)}>
+    <EditorSortableItem id={activity.id} key={activity.id}>
       <EditorListItem>
         <EditorSortableItemRow>
           <EditorDragHandle aria-label={t("Drag to reorder")}>{index + 1}</EditorDragHandle>

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
@@ -93,7 +93,7 @@ export async function ActivityList({
 
       {activities.length > 0 && (
         <EditorSortableList
-          items={activities.map((a) => ({ ...a, id: Number(a.id) }))}
+          items={activities}
           onReorder={reorderActivitiesAction.bind(null, routeParams)}
         >
           <EditorListContent>
@@ -103,7 +103,7 @@ export async function ActivityList({
                 chapterSlug={chapterSlug}
                 courseSlug={courseSlug}
                 index={index}
-                key={String(activity.id)}
+                key={activity.id}
                 lessonSlug={lessonSlug}
                 orgSlug={orgSlug}
               />

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-row.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-row.tsx
@@ -18,7 +18,7 @@ export async function LessonListRow({
   chapterSlug: string;
   courseSlug: string;
   index: number;
-  lesson: { id: number; slug: string; title: string; description: string | null };
+  lesson: { id: string; slug: string; title: string; description: string | null };
   orgSlug: string;
 }) {
   const t = await getExtracted();

--- a/apps/editor/src/app/[orgSlug]/c/[courseSlug]/chapter-list-row.tsx
+++ b/apps/editor/src/app/[orgSlug]/c/[courseSlug]/chapter-list-row.tsx
@@ -14,7 +14,7 @@ export async function ChapterListRow({
   index,
   orgSlug,
 }: {
-  chapter: { id: number; slug: string; title: string; description: string | null };
+  chapter: { id: string; slug: string; title: string; description: string | null };
   courseSlug: string;
   index: number;
   orgSlug: string;

--- a/apps/editor/src/components/content-editor.tsx
+++ b/apps/editor/src/components/content-editor.tsx
@@ -30,12 +30,12 @@ export function ContentEditor({
   titleLabel,
   descriptionLabel,
 }: {
-  entityId: number;
+  entityId: string;
   initialTitle: string;
   initialDescription: string;
-  onSaveTitle: (id: number, data: { title: string }) => Promise<{ error: string | null }>;
+  onSaveTitle: (id: string, data: { title: string }) => Promise<{ error: string | null }>;
   onSaveDescription: (
-    id: number,
+    id: string,
     data: { description: string },
   ) => Promise<{ error: string | null }>;
   titlePlaceholder: string;

--- a/apps/editor/src/components/editor-list/editor-sortable-context.ts
+++ b/apps/editor/src/components/editor-list/editor-sortable-context.ts
@@ -3,12 +3,12 @@
 import { createContext } from "react";
 
 export type SortableItem = {
-  id: number;
+  id: string;
   position: number;
 };
 
 export type EditorSortableContextValue = {
-  activeId: number | null;
+  activeId: string | null;
   isDragging: boolean;
 };
 

--- a/apps/editor/src/components/editor-list/editor-sortable-item.tsx
+++ b/apps/editor/src/components/editor-list/editor-sortable-item.tsx
@@ -9,7 +9,7 @@ import {
   type SortableItemContextValue,
 } from "./editor-sortable-item-context";
 
-export function EditorSortableItem({ children, id }: { children: React.ReactNode; id: number }) {
+export function EditorSortableItem({ children, id }: { children: React.ReactNode; id: string }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id,
   });

--- a/apps/editor/src/components/editor-list/editor-sortable-list.tsx
+++ b/apps/editor/src/components/editor-list/editor-sortable-list.tsx
@@ -35,11 +35,11 @@ export function EditorSortableList<T extends SortableItem>({
 }: {
   children: React.ReactNode;
   items: T[];
-  onReorder: (items: { id: number; position: number }[]) => Promise<{ error: string | null }>;
+  onReorder: (items: { id: string; position: number }[]) => Promise<{ error: string | null }>;
   renderOverlay?: (activeItem: T) => React.ReactNode;
 }) {
   const dndId = useId();
-  const [activeId, setActiveId] = useState<number | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
   const [optimisticItems, setOptimisticItems] = useOptimistic(initialItems);
   const [pending, startTransition] = useTransition();
 
@@ -64,7 +64,7 @@ export function EditorSortableList<T extends SortableItem>({
     if (typeof navigator !== "undefined" && navigator.vibrate) {
       navigator.vibrate(10);
     }
-    setActiveId(Number(event.active.id));
+    setActiveId(String(event.active.id));
   }, []);
 
   const handleDragEnd = useCallback(
@@ -106,7 +106,8 @@ export function EditorSortableList<T extends SortableItem>({
     setActiveId(null);
   }, []);
 
-  const activeItem = activeId ? optimisticItems.find((item) => item.id === activeId) : null;
+  const activeItem =
+    activeId === null ? null : optimisticItems.find((item) => item.id === activeId);
 
   const contextValue = useMemo<EditorSortableContextValue>(
     () => ({

--- a/apps/editor/src/components/navbar/command-palette.tsx
+++ b/apps/editor/src/components/navbar/command-palette.tsx
@@ -237,7 +237,7 @@ function PositionedItem({
 }: {
   description: string | null;
   icon: LucideIcon;
-  id: number;
+  id: string;
   onSelect: () => void;
   position: number;
   title: string;

--- a/apps/editor/src/components/slug-editor.tsx
+++ b/apps/editor/src/components/slug-editor.tsx
@@ -26,20 +26,20 @@ export function SlugEditor({
   redirectPrefix,
   redirectSuffix = "",
 }: {
-  chapterId?: number;
+  chapterId?: string;
   checkFn: (params: {
-    chapterId?: number;
-    courseId?: number;
+    chapterId?: string;
+    courseId?: string;
     language: string;
     orgSlug: string;
     slug: string;
   }) => Promise<boolean>;
-  courseId?: number;
-  entityId: number;
+  courseId?: string;
+  entityId: string;
   initialSlug: string;
   language: string;
   onSave: (
-    id: number,
+    id: string,
     data: { slug: string },
   ) => Promise<{ error: string | null; newSlug?: string }>;
   orgSlug: string;

--- a/apps/editor/src/data/activities/create-activity.test.ts
+++ b/apps/editor/src/data/activities/create-activity.test.ts
@@ -130,7 +130,7 @@ describe("admins", () => {
     const result = await createActivity({
       headers,
       kind: "custom",
-      lessonId: 999_999,
+      lessonId: "00000000-0000-7000-8000-000000000001",
       position: 0,
     });
 

--- a/apps/editor/src/data/activities/create-activity.ts
+++ b/apps/editor/src/data/activities/create-activity.ts
@@ -9,7 +9,7 @@ export async function createActivity(params: {
   description?: string;
   headers?: Headers;
   kind: ActivityKind;
-  lessonId: number;
+  lessonId: string;
   position: number;
   title?: string;
 }): Promise<SafeReturn<Activity>> {

--- a/apps/editor/src/data/activities/export-activities.test.ts
+++ b/apps/editor/src/data/activities/export-activities.test.ts
@@ -152,7 +152,7 @@ describe("admins", () => {
   test("returns Lesson not found for non-existent lesson", async () => {
     const result = await exportActivities({
       headers,
-      lessonId: 999_999,
+      lessonId: "00000000-0000-7000-8000-000000000001",
     });
 
     expect(result.error?.message).toBe(ErrorCode.lessonNotFound);

--- a/apps/editor/src/data/activities/export-activities.ts
+++ b/apps/editor/src/data/activities/export-activities.ts
@@ -11,7 +11,7 @@ type ExportedActivity = {
   title: string | null;
 };
 
-export async function exportActivities(params: { lessonId: number; headers?: Headers }): Promise<
+export async function exportActivities(params: { lessonId: string; headers?: Headers }): Promise<
   SafeReturn<{
     activities: ExportedActivity[];
     exportedAt: string;

--- a/apps/editor/src/data/activities/import-activities.test.ts
+++ b/apps/editor/src/data/activities/import-activities.test.ts
@@ -208,7 +208,7 @@ describe("admins", () => {
     const result = await importActivities({
       file,
       headers,
-      lessonId: 999_999,
+      lessonId: randomUUID(),
     });
 
     expect(result.error?.message).toBe(ErrorCode.lessonNotFound);

--- a/apps/editor/src/data/activities/import-activities.ts
+++ b/apps/editor/src/data/activities/import-activities.ts
@@ -66,7 +66,7 @@ function validateImportData(data: unknown): data is {
 export async function importActivities(params: {
   file: File;
   headers?: Headers;
-  lessonId: number;
+  lessonId: string;
   mode?: ImportMode;
 }): Promise<SafeReturn<Activity[]>> {
   const mode = params.mode ?? "merge";

--- a/apps/editor/src/data/activities/list-lesson-activities.test.ts
+++ b/apps/editor/src/data/activities/list-lesson-activities.test.ts
@@ -153,7 +153,7 @@ describe("admins", () => {
   test("returns empty array when lessonId does not exist", async () => {
     const result = await listLessonActivities({
       headers,
-      lessonId: 999_999_999,
+      lessonId: "00000000-0000-7000-8000-000000000001",
       orgId: organization.id,
     });
 

--- a/apps/editor/src/data/activities/list-lesson-activities.ts
+++ b/apps/editor/src/data/activities/list-lesson-activities.ts
@@ -7,7 +7,7 @@ import { cache } from "react";
 
 const cachedListLessonActivities = cache(
   async (
-    lessonId: number,
+    lessonId: string,
     orgId: string | null,
     headers?: Headers,
   ): Promise<{ data: Activity[]; error: Error | null }> => {
@@ -47,7 +47,7 @@ const cachedListLessonActivities = cache(
 
 export function listLessonActivities(params: {
   headers?: Headers;
-  lessonId: number;
+  lessonId: string;
   orgId: string | null;
 }): Promise<{ data: Activity[]; error: Error | null }> {
   return cachedListLessonActivities(params.lessonId, params.orgId, params.headers);

--- a/apps/editor/src/data/activities/reorder-activities.test.ts
+++ b/apps/editor/src/data/activities/reorder-activities.test.ts
@@ -157,7 +157,7 @@ describe("admins", () => {
     const result = await reorderActivities({
       activities: [],
       headers,
-      lessonId: 999_999,
+      lessonId: "00000000-0000-7000-8000-000000000001",
     });
 
     expect(result.error?.message).toBe(ErrorCode.lessonNotFound);
@@ -248,7 +248,7 @@ describe("admins", () => {
     const result = await reorderActivities({
       activities: [
         { activityId: activity.id, position: expectedPosition },
-        { activityId: BigInt(999_999), position: 0 },
+        { activityId: "00000000-0000-7000-8000-000000000001", position: 0 },
       ],
       headers,
       lessonId: newLesson.id,

--- a/apps/editor/src/data/activities/reorder-activities.ts
+++ b/apps/editor/src/data/activities/reorder-activities.ts
@@ -6,10 +6,10 @@ import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
 
 export async function reorderActivities(params: {
   activities: {
-    activityId: bigint;
+    activityId: string;
     position: number;
   }[];
-  lessonId: number;
+  lessonId: string;
   headers?: Headers;
 }): Promise<SafeReturn<{ updated: number }>> {
   const { data: lesson, error: findError } = await safeAsync(() =>

--- a/apps/editor/src/data/alternative-titles/add-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/add-alternative-titles.ts
@@ -9,7 +9,7 @@ import { getAuthorizedCourse } from "../courses/get-authorized-course";
  * insert helper so every mutation reuses the same org-level permission check.
  */
 export async function addAlternativeTitles(params: {
-  courseId: number;
+  courseId: string;
   headers?: Headers;
   language: string;
   titles: string[];

--- a/apps/editor/src/data/alternative-titles/delete-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/delete-alternative-titles.ts
@@ -9,7 +9,7 @@ import { getAuthorizedCourse } from "../courses/get-authorized-course";
  * exists to enforce course update permission before removing any stored slugs.
  */
 export async function deleteAlternativeTitles(params: {
-  courseId: number;
+  courseId: string;
   headers?: Headers;
   titles: string[];
 }): Promise<SafeReturn<null>> {

--- a/apps/editor/src/data/alternative-titles/export-alternative-titles.test.ts
+++ b/apps/editor/src/data/alternative-titles/export-alternative-titles.test.ts
@@ -43,7 +43,7 @@ describe(exportAlternativeTitles, () => {
     const headers = await signInAs(user.email, user.password);
 
     const result = await exportAlternativeTitles({
-      courseId: 999_999,
+      courseId: "00000000-0000-7000-8000-000000000001",
       headers,
     });
 

--- a/apps/editor/src/data/alternative-titles/export-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/export-alternative-titles.ts
@@ -8,7 +8,7 @@ import { getAuthorizedCourse } from "../courses/get-authorized-course";
  * can be replayed directly and exposes internal duplicate-detection data.
  */
 export async function exportAlternativeTitles(params: {
-  courseId: number;
+  courseId: string;
   headers?: Headers;
 }): Promise<
   SafeReturn<{

--- a/apps/editor/src/data/alternative-titles/import-alternative-titles.test.ts
+++ b/apps/editor/src/data/alternative-titles/import-alternative-titles.test.ts
@@ -93,7 +93,7 @@ describe(importAlternativeTitles, () => {
     const headers = await signInAs(user.email, user.password);
 
     const result = await importAlternativeTitles({
-      courseId: 999_999,
+      courseId: "00000000-0000-7000-8000-000000000001",
       file,
       headers,
       language: "en",

--- a/apps/editor/src/data/alternative-titles/import-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/import-alternative-titles.ts
@@ -27,7 +27,7 @@ function validateImportData(data: unknown): data is {
 }
 
 export async function importAlternativeTitles(params: {
-  courseId: number;
+  courseId: string;
   file: File;
   headers?: Headers;
   language: string;

--- a/apps/editor/src/data/alternative-titles/list-alternative-titles.ts
+++ b/apps/editor/src/data/alternative-titles/list-alternative-titles.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
-const cachedListAlternativeTitlesById = cache(async (courseId: number): Promise<string[]> => {
+const cachedListAlternativeTitlesById = cache(async (courseId: string): Promise<string[]> => {
   const results = await prisma.courseAlternativeTitle.findMany({
     orderBy: { slug: "asc" },
     where: { courseId },
@@ -21,7 +21,7 @@ const cachedListAlternativeTitlesBySlug = cache(async (courseSlug: string): Prom
 });
 
 export function listAlternativeTitles(
-  params: { courseId: number } | { courseSlug: string },
+  params: { courseId: string } | { courseSlug: string },
 ): Promise<string[]> {
   if ("courseId" in params) {
     return cachedListAlternativeTitlesById(params.courseId);

--- a/apps/editor/src/data/categories/add-category-to-course.test.ts
+++ b/apps/editor/src/data/categories/add-category-to-course.test.ts
@@ -113,7 +113,7 @@ describe("admins", () => {
   test("returns Course not found", async () => {
     const result = await addCategoryToCourse({
       category: "tech",
-      courseId: 999_999,
+      courseId: "00000000-0000-7000-8000-000000000001",
       headers,
     });
 

--- a/apps/editor/src/data/categories/add-category-to-course.ts
+++ b/apps/editor/src/data/categories/add-category-to-course.ts
@@ -8,7 +8,7 @@ import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
 
 export async function addCategoryToCourse(params: {
   category: string;
-  courseId: number;
+  courseId: string;
   headers?: Headers;
 }): Promise<SafeReturn<CourseCategory>> {
   if (!isValidCategory(params.category)) {

--- a/apps/editor/src/data/categories/list-course-categories.ts
+++ b/apps/editor/src/data/categories/list-course-categories.ts
@@ -4,7 +4,7 @@ import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 
 const cachedListCourseCategories = cache(
-  async (courseId: number): Promise<SafeReturn<CourseCategory[]>> => {
+  async (courseId: string): Promise<SafeReturn<CourseCategory[]>> => {
     const { data, error } = await safeAsync(() =>
       prisma.courseCategory.findMany({
         orderBy: { category: "asc" },
@@ -21,7 +21,7 @@ const cachedListCourseCategories = cache(
 );
 
 export function listCourseCategories(params: {
-  courseId: number;
+  courseId: string;
 }): Promise<SafeReturn<CourseCategory[]>> {
   return cachedListCourseCategories(params.courseId);
 }

--- a/apps/editor/src/data/categories/remove-category-from-course.ts
+++ b/apps/editor/src/data/categories/remove-category-from-course.ts
@@ -6,7 +6,7 @@ import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
 
 export async function removeCategoryFromCourse(params: {
   category: string;
-  courseId: number;
+  courseId: string;
   headers?: Headers;
 }): Promise<SafeReturn<CourseCategory>> {
   const { data: courseCategory, error: findError } = await safeAsync(() =>

--- a/apps/editor/src/data/chapters/chapter-slug.ts
+++ b/apps/editor/src/data/chapters/chapter-slug.ts
@@ -4,7 +4,7 @@ import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 import { getAuthorizedActiveCourse } from "../courses/get-authorized-course";
 
-const cachedChapterSlugExists = cache(async (courseId: number, slug: string): Promise<boolean> => {
+const cachedChapterSlugExists = cache(async (courseId: string, slug: string): Promise<boolean> => {
   const { data } = await safeAsync(() =>
     prisma.chapter.findFirst({
       where: { courseId, slug },
@@ -20,7 +20,7 @@ const cachedChapterSlugExists = cache(async (courseId: number, slug: string): Pr
  * asks whether that course already owns the candidate slug.
  */
 export async function chapterSlugExists(params: {
-  courseId: number;
+  courseId: string;
   headers?: Headers;
   slug: string;
 }): Promise<boolean> {

--- a/apps/editor/src/data/chapters/create-chapter.test.ts
+++ b/apps/editor/src/data/chapters/create-chapter.test.ts
@@ -121,10 +121,10 @@ describe("admins", () => {
   test("returns Course not found", async () => {
     const result = await createChapter({
       ...chapterAttrs({
-        courseId: 999_999,
+        courseId: "00000000-0000-7000-8000-000000000001",
         organizationId: organization.id,
       }),
-      courseId: 999_999,
+      courseId: "00000000-0000-7000-8000-000000000001",
       headers,
       position: 0,
     });

--- a/apps/editor/src/data/chapters/create-chapter.ts
+++ b/apps/editor/src/data/chapters/create-chapter.ts
@@ -6,7 +6,7 @@ import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { normalizeString, toSlug } from "@zoonk/utils/string";
 
 export async function createChapter(params: {
-  courseId: number;
+  courseId: string;
   description: string;
   headers?: Headers;
   position: number;

--- a/apps/editor/src/data/chapters/delete-chapter.test.ts
+++ b/apps/editor/src/data/chapters/delete-chapter.test.ts
@@ -179,7 +179,7 @@ describe("owners", () => {
 
   test("returns Chapter not found", async () => {
     const result = await deleteChapter({
-      chapterId: 999_999,
+      chapterId: "00000000-0000-7000-8000-000000000001",
       headers,
     });
 

--- a/apps/editor/src/data/chapters/delete-chapter.ts
+++ b/apps/editor/src/data/chapters/delete-chapter.ts
@@ -10,7 +10,7 @@ import { getArchivedSlug, getCurriculumDeletePlan } from "../curriculum-delete";
  * exists under them so the delete action no longer cascades through that history.
  */
 export async function deleteChapter(params: {
-  chapterId: number;
+  chapterId: string;
   headers?: Headers;
 }): Promise<SafeReturn<Chapter>> {
   const { data: chapter, error: findError } = await safeAsync(() =>

--- a/apps/editor/src/data/chapters/export-chapters.test.ts
+++ b/apps/editor/src/data/chapters/export-chapters.test.ts
@@ -103,7 +103,7 @@ describe("admins", () => {
 
   test("returns Course not found for non-existent course", async () => {
     const result = await exportChapters({
-      courseId: 999_999,
+      courseId: "00000000-0000-7000-8000-000000000001",
       headers,
     });
 

--- a/apps/editor/src/data/chapters/export-chapters.ts
+++ b/apps/editor/src/data/chapters/export-chapters.ts
@@ -10,7 +10,7 @@ type ExportedChapter = {
   title: string;
 };
 
-export async function exportChapters(params: { courseId: number; headers?: Headers }): Promise<
+export async function exportChapters(params: { courseId: string; headers?: Headers }): Promise<
   SafeReturn<{
     chapters: ExportedChapter[];
     exportedAt: string;

--- a/apps/editor/src/data/chapters/get-authorized-chapter.ts
+++ b/apps/editor/src/data/chapters/get-authorized-chapter.ts
@@ -6,7 +6,7 @@ import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 
 const cachedGetAuthorizedActiveChapter = cache(
-  async (chapterId: number, headers?: Headers): Promise<SafeReturn<Chapter>> => {
+  async (chapterId: string, headers?: Headers): Promise<SafeReturn<Chapter>> => {
     const { data: chapter, error: findError } = await safeAsync(() =>
       prisma.chapter.findFirst({
         where: getActiveChapterWhere({
@@ -44,7 +44,7 @@ const cachedGetAuthorizedActiveChapter = cache(
  * React cache deduplicates repeated authorized chapter reads in the same request.
  */
 export function getAuthorizedActiveChapter(params: {
-  chapterId: number;
+  chapterId: string;
   headers?: Headers;
 }): Promise<SafeReturn<Chapter>> {
   return cachedGetAuthorizedActiveChapter(params.chapterId, params.headers);

--- a/apps/editor/src/data/chapters/import-chapters.test.ts
+++ b/apps/editor/src/data/chapters/import-chapters.test.ts
@@ -108,7 +108,7 @@ describe("admins", () => {
     const file = createImportFile([{ description: "Desc", title: "Test" }]);
 
     const result = await importChapters({
-      courseId: 999_999,
+      courseId: "00000000-0000-7000-8000-000000000001",
       file,
       headers,
     });

--- a/apps/editor/src/data/chapters/import-chapters.ts
+++ b/apps/editor/src/data/chapters/import-chapters.ts
@@ -51,7 +51,7 @@ function validateImportData(data: unknown): data is {
 async function resolveChapter(
   tx: TransactionClient,
   params: {
-    courseId: number;
+    courseId: string;
     courseIsPublished: boolean;
     description: string;
     existingChapter: Chapter | undefined;
@@ -106,7 +106,7 @@ async function resolveChapter(
 }
 
 export async function importChapters(params: {
-  courseId: number;
+  courseId: string;
   file: File;
   headers?: Headers;
   mode?: ImportMode;

--- a/apps/editor/src/data/chapters/list-course-chapters.ts
+++ b/apps/editor/src/data/chapters/list-course-chapters.ts
@@ -7,7 +7,7 @@ import { cache } from "react";
 
 const cachedListCourseChapters = cache(
   async (
-    courseId: number,
+    courseId: string,
     orgId: string | null,
     headers?: Headers,
   ): Promise<{ data: Chapter[]; error: Error | null }> => {
@@ -42,7 +42,7 @@ const cachedListCourseChapters = cache(
 );
 
 export function listCourseChapters(params: {
-  courseId: number;
+  courseId: string;
   headers?: Headers;
   orgId: string | null;
 }): Promise<{ data: Chapter[]; error: Error | null }> {

--- a/apps/editor/src/data/chapters/publish-chapter.test.ts
+++ b/apps/editor/src/data/chapters/publish-chapter.test.ts
@@ -102,7 +102,7 @@ describe("admins", () => {
 
   test("returns Chapter not found", async () => {
     const result = await toggleChapterPublished({
-      chapterId: 999_999,
+      chapterId: "00000000-0000-7000-8000-000000000001",
       headers,
       isPublished: true,
     });

--- a/apps/editor/src/data/chapters/publish-chapter.ts
+++ b/apps/editor/src/data/chapters/publish-chapter.ts
@@ -5,7 +5,7 @@ import { type Chapter, getActiveChapterWhere, prisma } from "@zoonk/db";
 import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
 
 export async function toggleChapterPublished(params: {
-  chapterId: number;
+  chapterId: string;
   headers?: Headers;
   isPublished: boolean;
 }): Promise<SafeReturn<Chapter>> {

--- a/apps/editor/src/data/chapters/reorder-chapters.test.ts
+++ b/apps/editor/src/data/chapters/reorder-chapters.test.ts
@@ -108,7 +108,7 @@ describe("admins", () => {
   test("returns Course not found", async () => {
     const result = await reorderChapters({
       chapters: [],
-      courseId: 999_999,
+      courseId: "00000000-0000-7000-8000-000000000001",
       headers,
     });
 
@@ -172,7 +172,7 @@ describe("admins", () => {
     const result = await reorderChapters({
       chapters: [
         { chapterId: chapter.id, position: expectedPosition },
-        { chapterId: 999_999, position: 0 },
+        { chapterId: "00000000-0000-7000-8000-000000000001", position: 0 },
       ],
       courseId: newCourse.id,
       headers,

--- a/apps/editor/src/data/chapters/reorder-chapters.ts
+++ b/apps/editor/src/data/chapters/reorder-chapters.ts
@@ -5,10 +5,10 @@ import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 
 export async function reorderChapters(params: {
   chapters: {
-    chapterId: number;
+    chapterId: string;
     position: number;
   }[];
-  courseId: number;
+  courseId: string;
   headers?: Headers;
 }): Promise<SafeReturn<{ updated: number }>> {
   const { data: course, error: courseError } = await getAuthorizedActiveCourse({

--- a/apps/editor/src/data/chapters/update-chapter.test.ts
+++ b/apps/editor/src/data/chapters/update-chapter.test.ts
@@ -147,7 +147,7 @@ describe("admins", () => {
 
   test("returns Chapter not found", async () => {
     const result = await updateChapter({
-      chapterId: 999_999,
+      chapterId: "00000000-0000-7000-8000-000000000001",
       headers,
       title: "Updated Title",
     });

--- a/apps/editor/src/data/chapters/update-chapter.ts
+++ b/apps/editor/src/data/chapters/update-chapter.ts
@@ -6,7 +6,7 @@ import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { normalizeString, toSlug } from "@zoonk/utils/string";
 
 export async function updateChapter(params: {
-  chapterId: number;
+  chapterId: string;
   description?: string;
   headers?: Headers;
   slug?: string;

--- a/apps/editor/src/data/courses/course-slug.ts
+++ b/apps/editor/src/data/courses/course-slug.ts
@@ -78,7 +78,7 @@ export async function courseSlugExistsForCreate(params: {
  * organization scope for the duplicate lookup.
  */
 export async function courseSlugExistsForUpdate(params: {
-  courseId: number;
+  courseId: string;
   headers?: Headers;
   slug: string;
 }): Promise<boolean> {

--- a/apps/editor/src/data/courses/delete-course.test.ts
+++ b/apps/editor/src/data/courses/delete-course.test.ts
@@ -165,7 +165,7 @@ describe("owners", () => {
 
   test("returns Course not found", async () => {
     const result = await deleteCourse({
-      courseId: 999_999,
+      courseId: "00000000-0000-7000-8000-000000000001",
       headers,
     });
 

--- a/apps/editor/src/data/courses/delete-course.ts
+++ b/apps/editor/src/data/courses/delete-course.ts
@@ -10,7 +10,7 @@ import { getArchivedSlug, getCurriculumDeletePlan } from "../curriculum-delete";
  * significant courses instead so we do not cascade away learner facts.
  */
 export async function deleteCourse(params: {
-  courseId: number;
+  courseId: string;
   headers?: Headers;
 }): Promise<SafeReturn<Course>> {
   const { data: course, error: findError } = await safeAsync(() =>

--- a/apps/editor/src/data/courses/get-authorized-course.ts
+++ b/apps/editor/src/data/courses/get-authorized-course.ts
@@ -65,7 +65,7 @@ async function toAuthorizedCourseResult(params: {
 
 const cachedGetAuthorizedCourse = cache(
   async (
-    courseId: number,
+    courseId: string,
     headers?: Headers,
   ): Promise<SafeReturn<AuthorizedCourseWithOrganization>> => {
     const { data: course, error } = await safeAsync(() =>
@@ -91,7 +91,7 @@ const cachedGetAuthorizedCourse = cache(
  * for the same course within a single request.
  */
 export function getAuthorizedCourse(params: {
-  courseId: number;
+  courseId: string;
   headers?: Headers;
 }): Promise<SafeReturn<AuthorizedCourseWithOrganization>> {
   return cachedGetAuthorizedCourse(params.courseId, params.headers);
@@ -99,7 +99,7 @@ export function getAuthorizedCourse(params: {
 
 const cachedGetAuthorizedActiveCourse = cache(
   async (
-    courseId: number,
+    courseId: string,
     headers?: Headers,
   ): Promise<SafeReturn<AuthorizedCourseWithOrganization>> => {
     const { data: course, error } = await safeAsync(() =>
@@ -124,7 +124,7 @@ const cachedGetAuthorizedActiveCourse = cache(
  * authorized reads for the same active course from re-running in one request.
  */
 export function getAuthorizedActiveCourse(params: {
-  courseId: number;
+  courseId: string;
   headers?: Headers;
 }): Promise<SafeReturn<AuthorizedCourseWithOrganization>> {
   return cachedGetAuthorizedActiveCourse(params.courseId, params.headers);

--- a/apps/editor/src/data/courses/publish-course.test.ts
+++ b/apps/editor/src/data/courses/publish-course.test.ts
@@ -61,7 +61,7 @@ describe("admins", () => {
 
   test("returns Course not found", async () => {
     const result = await toggleCoursePublished({
-      courseId: 999_999,
+      courseId: "00000000-0000-7000-8000-000000000001",
       headers,
       isPublished: true,
     });

--- a/apps/editor/src/data/courses/publish-course.ts
+++ b/apps/editor/src/data/courses/publish-course.ts
@@ -4,7 +4,7 @@ import { type Course, prisma } from "@zoonk/db";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 
 export async function toggleCoursePublished(params: {
-  courseId: number;
+  courseId: string;
   headers?: Headers;
   isPublished: boolean;
 }): Promise<SafeReturn<Course>> {

--- a/apps/editor/src/data/courses/update-course.test.ts
+++ b/apps/editor/src/data/courses/update-course.test.ts
@@ -144,7 +144,7 @@ describe("admins", () => {
 
   test("returns Course not found", async () => {
     const result = await updateCourse({
-      courseId: 999_999,
+      courseId: "00000000-0000-7000-8000-000000000001",
       headers,
       title: "Updated Title",
     });

--- a/apps/editor/src/data/courses/update-course.ts
+++ b/apps/editor/src/data/courses/update-course.ts
@@ -5,7 +5,7 @@ import { normalizeString, toSlug } from "@zoonk/utils/string";
 import { getAuthorizedCourse } from "./get-authorized-course";
 
 export async function updateCourse(params: {
-  courseId: number;
+  courseId: string;
   description?: string;
   headers?: Headers;
   imageUrl?: string | null;

--- a/apps/editor/src/data/curriculum-delete.ts
+++ b/apps/editor/src/data/curriculum-delete.ts
@@ -36,7 +36,7 @@ export async function getCurriculumDeletePlan({
  * create new active curriculum with the original slug without changing DB
  * uniqueness rules.
  */
-export function getArchivedSlug({ id, slug }: { id: number; slug: string }) {
+export function getArchivedSlug({ id, slug }: { id: string; slug: string }) {
   return `${slug}--archived-${id}`;
 }
 

--- a/apps/editor/src/data/curriculum-replace.ts
+++ b/apps/editor/src/data/curriculum-replace.ts
@@ -46,7 +46,7 @@ async function getReplaceDecisions<Item>({
  * per-record lifecycle work. This keeps replace-mode imports efficient while
  * still letting archive paths do the extra slug rewrite work they need.
  */
-async function deleteChapters({ chapterIds, tx }: { chapterIds: number[]; tx: TransactionClient }) {
+async function deleteChapters({ chapterIds, tx }: { chapterIds: string[]; tx: TransactionClient }) {
   if (chapterIds.length === 0) {
     return;
   }
@@ -87,7 +87,7 @@ async function archiveChapters({ chapters, tx }: { chapters: Chapter[]; tx: Tran
  * Lesson replace imports follow the same historical-integrity rule as chapter
  * imports, including slug release for archived rows.
  */
-async function deleteLessons({ lessonIds, tx }: { lessonIds: number[]; tx: TransactionClient }) {
+async function deleteLessons({ lessonIds, tx }: { lessonIds: string[]; tx: TransactionClient }) {
   if (lessonIds.length === 0) {
     return;
   }
@@ -134,7 +134,7 @@ async function deleteActivities({
   activityIds,
   tx,
 }: {
-  activityIds: bigint[];
+  activityIds: string[];
   tx: TransactionClient;
 }) {
   if (activityIds.length === 0) {
@@ -177,7 +177,7 @@ export async function replaceCourseChapters({
   courseId,
   tx,
 }: {
-  courseId: number;
+  courseId: string;
   tx: TransactionClient;
 }) {
   const chapters = await tx.chapter.findMany({
@@ -212,7 +212,7 @@ export async function replaceChapterLessons({
   chapterId,
   tx,
 }: {
-  chapterId: number;
+  chapterId: string;
   tx: TransactionClient;
 }) {
   const lessons = await tx.lesson.findMany({
@@ -248,7 +248,7 @@ export async function replaceLessonActivities({
   lessonId,
   tx,
 }: {
-  lessonId: number;
+  lessonId: string;
   tx: TransactionClient;
 }) {
   const activities = await tx.activity.findMany({

--- a/apps/editor/src/data/lessons/create-lesson.test.ts
+++ b/apps/editor/src/data/lessons/create-lesson.test.ts
@@ -276,10 +276,10 @@ describe("admins", () => {
   test("returns Chapter not found", async () => {
     const result = await createLesson({
       ...lessonAttrs({
-        chapterId: 999_999,
+        chapterId: randomUUID(),
         organizationId: organization.id,
       }),
-      chapterId: 999_999,
+      chapterId: randomUUID(),
       headers,
       position: 0,
     });

--- a/apps/editor/src/data/lessons/create-lesson.ts
+++ b/apps/editor/src/data/lessons/create-lesson.ts
@@ -8,7 +8,7 @@ import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { normalizeString, toSlug } from "@zoonk/utils/string";
 
 export async function createLesson(params: {
-  chapterId: number;
+  chapterId: string;
   description: string;
   headers?: Headers;
   position: number;

--- a/apps/editor/src/data/lessons/delete-lesson.test.ts
+++ b/apps/editor/src/data/lessons/delete-lesson.test.ts
@@ -200,7 +200,7 @@ describe("owners", () => {
   test("returns Lesson not found", async () => {
     const result = await deleteLesson({
       headers,
-      lessonId: 999_999,
+      lessonId: "00000000-0000-7000-8000-000000000001",
     });
 
     expect(result.error?.message).toBe(ErrorCode.lessonNotFound);

--- a/apps/editor/src/data/lessons/delete-lesson.ts
+++ b/apps/editor/src/data/lessons/delete-lesson.ts
@@ -10,7 +10,7 @@ import { getArchivedSlug, getCurriculumDeletePlan } from "../curriculum-delete";
  * activity and attempt data are not removed by cascading lesson deletes.
  */
 export async function deleteLesson(params: {
-  lessonId: number;
+  lessonId: string;
   headers?: Headers;
 }): Promise<SafeReturn<Lesson>> {
   const { data: lesson, error: findError } = await safeAsync(() =>

--- a/apps/editor/src/data/lessons/export-lessons.test.ts
+++ b/apps/editor/src/data/lessons/export-lessons.test.ts
@@ -126,7 +126,7 @@ describe("admins", () => {
 
   test("returns Chapter not found for non-existent chapter", async () => {
     const result = await exportLessons({
-      chapterId: 999_999,
+      chapterId: "00000000-0000-7000-8000-000000000001",
       headers,
     });
 

--- a/apps/editor/src/data/lessons/export-lessons.ts
+++ b/apps/editor/src/data/lessons/export-lessons.ts
@@ -11,7 +11,7 @@ type ExportedLesson = {
   title: string;
 };
 
-export async function exportLessons(params: { chapterId: number; headers?: Headers }): Promise<
+export async function exportLessons(params: { chapterId: string; headers?: Headers }): Promise<
   SafeReturn<{
     lessons: ExportedLesson[];
     exportedAt: string;

--- a/apps/editor/src/data/lessons/import-lessons.test.ts
+++ b/apps/editor/src/data/lessons/import-lessons.test.ts
@@ -133,7 +133,7 @@ describe("admins", () => {
     const file = createImportFile([{ description: "Desc", title: "Test" }]);
 
     const result = await importLessons({
-      chapterId: 999_999,
+      chapterId: randomUUID(),
       file,
       headers,
     });

--- a/apps/editor/src/data/lessons/import-lessons.ts
+++ b/apps/editor/src/data/lessons/import-lessons.ts
@@ -54,7 +54,7 @@ function validateImportData(data: unknown): data is {
 async function resolveLesson(
   tx: TransactionClient,
   params: {
-    chapterId: number;
+    chapterId: string;
     chapterIsPublished: boolean;
     description: string;
     existingLesson: Lesson | undefined;
@@ -106,7 +106,7 @@ async function resolveLesson(
 }
 
 export async function importLessons(params: {
-  chapterId: number;
+  chapterId: string;
   file: File;
   headers?: Headers;
   mode?: ImportMode;

--- a/apps/editor/src/data/lessons/lesson-slug.ts
+++ b/apps/editor/src/data/lessons/lesson-slug.ts
@@ -4,7 +4,7 @@ import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 import { getAuthorizedActiveChapter } from "../chapters/get-authorized-chapter";
 
-const cachedLessonSlugExists = cache(async (chapterId: number, slug: string): Promise<boolean> => {
+const cachedLessonSlugExists = cache(async (chapterId: string, slug: string): Promise<boolean> => {
   const { data } = await safeAsync(() =>
     prisma.lesson.findFirst({
       where: { chapterId, slug },
@@ -20,7 +20,7 @@ const cachedLessonSlugExists = cache(async (chapterId: number, slug: string): Pr
  * the existence query inside that chapter.
  */
 export async function lessonSlugExists(params: {
-  chapterId: number;
+  chapterId: string;
   headers?: Headers;
   slug: string;
 }): Promise<boolean> {

--- a/apps/editor/src/data/lessons/list-chapter-lessons.test.ts
+++ b/apps/editor/src/data/lessons/list-chapter-lessons.test.ts
@@ -131,7 +131,7 @@ describe("admins", () => {
 
   test("returns empty array when chapterId does not exist", async () => {
     const result = await listChapterLessons({
-      chapterId: 999_999_999,
+      chapterId: "00000000-0000-7000-8000-000000000001",
       headers,
       orgId: organization.id,
     });

--- a/apps/editor/src/data/lessons/list-chapter-lessons.ts
+++ b/apps/editor/src/data/lessons/list-chapter-lessons.ts
@@ -7,7 +7,7 @@ import { cache } from "react";
 
 const cachedListChapterLessons = cache(
   async (
-    chapterId: number,
+    chapterId: string,
     orgId: string | null,
     headers?: Headers,
   ): Promise<{ data: Lesson[]; error: Error | null }> => {
@@ -46,7 +46,7 @@ const cachedListChapterLessons = cache(
 );
 
 export function listChapterLessons(params: {
-  chapterId: number;
+  chapterId: string;
   headers?: Headers;
   orgId: string | null;
 }): Promise<{ data: Lesson[]; error: Error | null }> {

--- a/apps/editor/src/data/lessons/publish-lesson.test.ts
+++ b/apps/editor/src/data/lessons/publish-lesson.test.ts
@@ -121,7 +121,7 @@ describe("admins", () => {
     const result = await toggleLessonPublished({
       headers,
       isPublished: true,
-      lessonId: 999_999,
+      lessonId: "00000000-0000-7000-8000-000000000001",
     });
 
     expect(result.error?.message).toBe(ErrorCode.lessonNotFound);

--- a/apps/editor/src/data/lessons/publish-lesson.ts
+++ b/apps/editor/src/data/lessons/publish-lesson.ts
@@ -5,7 +5,7 @@ import { type Lesson, getActiveLessonWhere, prisma } from "@zoonk/db";
 import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
 
 export async function toggleLessonPublished(params: {
-  lessonId: number;
+  lessonId: string;
   headers?: Headers;
   isPublished: boolean;
 }): Promise<SafeReturn<Lesson>> {

--- a/apps/editor/src/data/lessons/reorder-lessons.test.ts
+++ b/apps/editor/src/data/lessons/reorder-lessons.test.ts
@@ -130,7 +130,7 @@ describe("admins", () => {
 
   test("returns Chapter not found", async () => {
     const result = await reorderLessons({
-      chapterId: 999_999,
+      chapterId: "00000000-0000-7000-8000-000000000001",
       headers,
       lessons: [],
     });
@@ -210,7 +210,7 @@ describe("admins", () => {
       headers,
       lessons: [
         { lessonId: lesson.id, position: expectedPosition },
-        { lessonId: 999_999, position: 0 },
+        { lessonId: "00000000-0000-7000-8000-000000000001", position: 0 },
       ],
     });
 

--- a/apps/editor/src/data/lessons/reorder-lessons.ts
+++ b/apps/editor/src/data/lessons/reorder-lessons.ts
@@ -6,10 +6,10 @@ import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
 
 export async function reorderLessons(params: {
   lessons: {
-    lessonId: number;
+    lessonId: string;
     position: number;
   }[];
-  chapterId: number;
+  chapterId: string;
   headers?: Headers;
 }): Promise<SafeReturn<{ updated: number }>> {
   const { data: chapter, error: findError } = await safeAsync(() =>

--- a/apps/editor/src/data/lessons/update-lesson.test.ts
+++ b/apps/editor/src/data/lessons/update-lesson.test.ts
@@ -164,7 +164,7 @@ describe("admins", () => {
   test("returns Lesson not found", async () => {
     const result = await updateLesson({
       headers,
-      lessonId: 999_999,
+      lessonId: "00000000-0000-7000-8000-000000000001",
       title: "Updated Title",
     });
 

--- a/apps/editor/src/data/lessons/update-lesson.ts
+++ b/apps/editor/src/data/lessons/update-lesson.ts
@@ -6,7 +6,7 @@ import { AppError, type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { normalizeString, toSlug } from "@zoonk/utils/string";
 
 export async function updateLesson(params: {
-  lessonId: number;
+  lessonId: string;
   description?: string;
   headers?: Headers;
   slug?: string;

--- a/apps/editor/src/data/search-content.ts
+++ b/apps/editor/src/data/search-content.ts
@@ -7,7 +7,7 @@ import { headers } from "next/headers";
 import { cache } from "react";
 
 export type ResultWithImage = {
-  id: number;
+  id: string;
   type: "course";
   title: string;
   description: string | null;
@@ -16,7 +16,7 @@ export type ResultWithImage = {
 };
 
 export type ResultWithPosition = {
-  id: number;
+  id: string;
   type: "chapter" | "lesson";
   title: string;
   description: string | null;

--- a/apps/editor/src/lib/import-slug.test.ts
+++ b/apps/editor/src/lib/import-slug.test.ts
@@ -6,7 +6,7 @@ vi.mock("server-only", () => ({}));
 describe(resolveImportSlug, () => {
   it("preserves explicit slugs even when a record exists", () => {
     const result = resolveImportSlug({
-      existingRecord: { id: 1 },
+      existingRecord: { id: "1" },
       hasExplicitSlug: true,
       index: 0,
       slug: "my-slug",
@@ -30,7 +30,7 @@ describe(resolveImportSlug, () => {
     vi.spyOn(Date, "now").mockReturnValue(1_234_567_890);
 
     const result = resolveImportSlug({
-      existingRecord: { id: 1 },
+      existingRecord: { id: "1" },
       hasExplicitSlug: false,
       index: 3,
       slug: "my-slug",

--- a/apps/editor/src/lib/use-slug-check.ts
+++ b/apps/editor/src/lib/use-slug-check.ts
@@ -4,8 +4,8 @@ import { useDebounce } from "@zoonk/ui/hooks/debounce";
 import { useEffect, useEffectEvent, useState, useTransition } from "react";
 
 type SlugCheckParams = {
-  chapterId?: number;
-  courseId?: number;
+  chapterId?: string;
+  courseId?: string;
   language: string;
   orgSlug: string;
   slug: string;

--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -14,7 +14,7 @@ let courseSlug: string;
 let courseTitle: string;
 let chapterTitle: string;
 let unpublishedChapterSlug: string;
-let noLessonsChapterId: number;
+let noLessonsChapterId: string;
 let noLessonsChapterUrl: string;
 let lessonNames: { first: string; second: string };
 let lessonSlugs: { first: string; second: string };

--- a/apps/main/e2e/lesson-completion.test.ts
+++ b/apps/main/e2e/lesson-completion.test.ts
@@ -41,7 +41,7 @@ async function createAuthenticatedPage(browser: Browser, baseURL: string, email:
   return { browserContext, page };
 }
 
-async function createQuizActivity(lessonId: number, orgId: string, uniqueId: string) {
+async function createQuizActivity(lessonId: string, orgId: string, uniqueId: string) {
   const activity = await activityFixture({
     generationStatus: "completed",
     isPublished: true,

--- a/apps/main/src/app/(catalog)/_components/search-courses-action.ts
+++ b/apps/main/src/app/(catalog)/_components/search-courses-action.ts
@@ -3,7 +3,7 @@
 import { searchCourses } from "@zoonk/core/courses/search";
 
 export type CourseSearchResult = {
-  id: number;
+  id: string;
   title: string;
   description: string | null;
   slug: string;

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-list.tsx
@@ -25,7 +25,7 @@ export async function ActivityList({
   brandSlug: string;
   chapterSlug: string;
   courseSlug: string;
-  lessonId: number;
+  lessonId: string;
   lessonSlug: string;
 }) {
   if (activities.length === 0) {
@@ -39,13 +39,13 @@ export async function ActivityList({
     <CatalogList>
       <CatalogListContent aria-label={t("Activities")}>
         {activities.map((activity) => {
-          const completed = completedIds.includes(String(activity.id));
+          const completed = completedIds.includes(activity.id);
 
           return (
             <CatalogListItem
               href={`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}/a/${activity.position}`}
               id={activity.id}
-              key={String(activity.id)}
+              key={activity.id}
               prefetch={activity.generationStatus === "completed"}
             >
               <CatalogListItemPosition>{formatPosition(activity.position)}</CatalogListItemPosition>

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-path.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/activity-path.tsx
@@ -18,7 +18,7 @@ export async function ActivityPath({
   brandSlug: string;
   chapterSlug: string;
   courseSlug: string;
-  lessonId: number;
+  lessonId: string;
   lessonSlug: string;
 }) {
   if (activities.length === 0) {
@@ -38,12 +38,12 @@ export async function ActivityPath({
       {activities.map((activity, index) => {
         const meta = kindMeta.get(activity.kind);
         const Icon = getActivityIcon(activity.kind);
-        const completed = completedIds.includes(String(activity.id));
+        const completed = completedIds.includes(activity.id);
         const isLast = index === activities.length - 1;
         const title = activity.title ?? meta?.label;
 
         return (
-          <li key={String(activity.id)}>
+          <li key={activity.id}>
             <Link
               className="hover:bg-muted/30 -mx-3 flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors"
               href={`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}/a/${activity.position}`}

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -23,7 +23,7 @@ export async function LessonList({
   lessons,
 }: {
   brandSlug: string;
-  chapterId: number;
+  chapterId: string;
   chapterSlug: string;
   courseSlug: string;
   lessons: Lesson[];

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -23,7 +23,7 @@ export async function ChapterList({
 }: {
   brandSlug: string;
   chapters: Chapter[];
-  courseId: number;
+  courseId: string;
   courseSlug: string;
 }) {
   if (chapters.length === 0) {

--- a/apps/main/src/app/(catalog)/courses/actions.ts
+++ b/apps/main/src/app/(catalog)/courses/actions.ts
@@ -5,7 +5,7 @@ import { type CourseCategory } from "@zoonk/utils/categories";
 
 export async function loadMoreCourses(params: {
   category?: CourseCategory;
-  cursor: number;
+  cursor: string;
   language: string;
 }) {
   const courses = await listCourses({

--- a/apps/main/src/app/(catalog)/courses/course-list-client.tsx
+++ b/apps/main/src/app/(catalog)/courses/course-list-client.tsx
@@ -43,7 +43,7 @@ export function CourseListClient({
     isLoading,
     sentryRef,
   } = useInfiniteList<CourseWithOrg>({
-    fetchMore: (cursor) => loadMoreCourses({ category, cursor: Number(cursor), language }),
+    fetchMore: (cursor) => loadMoreCourses({ category, cursor: String(cursor), language }),
     getKey: (course) => course.id,
     initialItems: initialCourses,
     limit,

--- a/apps/main/src/app/(catalog)/learn/[prompt]/course-suggestion-item.tsx
+++ b/apps/main/src/app/(catalog)/learn/[prompt]/course-suggestion-item.tsx
@@ -15,7 +15,7 @@ export async function CourseSuggestionItem({
   course,
   isLast,
 }: {
-  course: { id: number; title: string; description: string };
+  course: { id: string; title: string; description: string };
   isLast: boolean;
 }) {
   const t = await getExtracted();

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-data-loaders.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-data-loaders.ts
@@ -4,7 +4,7 @@ import { getNextSibling } from "@zoonk/core/player/queries/get-next-sibling";
 import { getReviewSteps } from "@zoonk/core/player/queries/get-review-steps";
 import { getSession } from "@zoonk/core/users/session/get";
 
-export async function fetchReviewSteps(lessonId: number, activityPosition: number) {
+export async function fetchReviewSteps(lessonId: string, activityPosition: number) {
   const activity = await getActivity({ lessonId, position: activityPosition });
 
   if (activity?.kind !== "review") {
@@ -20,10 +20,10 @@ export async function fetchReviewSteps(lessonId: number, activityPosition: numbe
 }
 
 export async function fetchNextSibling(
-  lessonId: number,
+  lessonId: string,
   activityPosition: number,
   lessonSlug: string,
-  chapter: { id: number; position: number; course: { id: number } },
+  chapter: { id: string; position: number; course: { id: string } },
   lessonPosition: number,
 ) {
   const nextActivity = await getNextActivityInCourse({

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-not-generated.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/activity-not-generated.tsx
@@ -16,7 +16,7 @@ export async function ActivityNotGenerated({
   activityId,
   brandSlug,
 }: {
-  activityId: bigint;
+  activityId: string;
   brandSlug: string;
 }) {
   const t = await getExtracted();

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/a/[position]/submit-completion-action.ts
@@ -36,7 +36,7 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<void>
   }
 
   const userId = session.user.id;
-  const activityId = BigInt(input.activityId);
+  const activityId = input.activityId;
 
   // Revalidate outside after() so the signal is included in the RSC response.
   // This tells the client Router Cache to purge "/", ensuring the next

--- a/apps/main/src/app/generate/a/[id]/generate-activity-content.tsx
+++ b/apps/main/src/app/generate/a/[id]/generate-activity-content.tsx
@@ -12,7 +12,6 @@ import {
   ContainerTitle,
 } from "@zoonk/ui/components/container";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
-import { parseBigIntId } from "@zoonk/utils/number";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { getExtracted } from "next-intl/server";
 import { notFound } from "next/navigation";
@@ -20,16 +19,8 @@ import { GenerationClient } from "./generation-client";
 
 export async function GenerateActivityContent({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const activityId = parseBigIntId(id);
 
-  if (activityId === null) {
-    notFound();
-  }
-
-  const [session, activity] = await Promise.all([
-    getSession(),
-    getActivityForGeneration(activityId),
-  ]);
+  const [session, activity] = await Promise.all([getSession(), getActivityForGeneration(id)]);
 
   if (!activity || !activity.lesson) {
     notFound();
@@ -63,7 +54,7 @@ export async function GenerateActivityContent({ params }: { params: Promise<{ id
       <ContainerBody>
         <SubscriptionGate backHref={backHref} backLabel={backLabel} bypass={hasStarted}>
           <GenerationClient
-            activityId={Number(activityId)}
+            activityId={id}
             activityKind={activity.kind}
             chapterSlug={activity.lesson.chapter.slug}
             courseSlug={activity.lesson.chapter.course.slug}

--- a/apps/main/src/app/generate/a/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/a/[id]/generation-client.tsx
@@ -34,13 +34,13 @@ export function GenerationClient({
   lessonSlug,
   position,
 }: {
-  activityId: number;
+  activityId: string;
   activityKind: ActivityKind;
   chapterSlug: string;
   courseSlug: string;
   generationRunId: string | null;
   initialStatus: GenerationStatus;
-  lessonId: number;
+  lessonId: string;
   lessonSlug: string;
   position: number;
 }) {

--- a/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
@@ -12,7 +12,6 @@ import {
   ContainerTitle,
 } from "@zoonk/ui/components/container";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
-import { parseNumericId } from "@zoonk/utils/number";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { getExtracted } from "next-intl/server";
 import { notFound } from "next/navigation";
@@ -20,13 +19,7 @@ import { GenerationClient } from "./generation-client";
 
 export async function GenerateChapterContent({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const chapterId = parseNumericId(id);
-
-  if (chapterId === null) {
-    notFound();
-  }
-
-  const [session, chapter] = await Promise.all([getSession(), getChapterForGeneration(chapterId)]);
+  const [session, chapter] = await Promise.all([getSession(), getChapterForGeneration(id)]);
 
   if (!chapter) {
     notFound();
@@ -63,7 +56,7 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
       <ContainerBody>
         <SubscriptionGate backHref={backHref} backLabel={backLabel} bypass={bypassAuth}>
           <GenerationClient
-            chapterId={chapterId}
+            chapterId={id}
             chapterSlug={chapter.slug}
             courseSlug={chapter.course.slug}
             generationRunId={chapter.generationRunId}

--- a/apps/main/src/app/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generation-client.tsx
@@ -29,7 +29,7 @@ export function GenerationClient({
   generationRunId,
   initialStatus,
 }: {
-  chapterId: number;
+  chapterId: string;
   chapterSlug: string;
   courseSlug: string;
   generationRunId: string | null;

--- a/apps/main/src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
@@ -10,7 +10,6 @@ import {
 } from "@zoonk/ui/components/container";
 import { Empty, EmptyContent, EmptyHeader } from "@zoonk/ui/components/empty";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
-import { parseNumericId } from "@zoonk/utils/number";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { ensureLocaleSuffix } from "@zoonk/utils/string";
 import { notFound, redirect } from "next/navigation";
@@ -22,13 +21,7 @@ export async function GenerateCourseSuggestionContent({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const suggestionId = parseNumericId(id);
-
-  if (suggestionId === null) {
-    notFound();
-  }
-
-  const suggestion = await getCourseSuggestionById(suggestionId);
+  const suggestion = await getCourseSuggestionById(id);
 
   if (!suggestion) {
     notFound();
@@ -57,7 +50,7 @@ export async function GenerateCourseSuggestionContent({
           courseSlug={ensureLocaleSuffix(suggestion.slug, suggestion.language)}
           generationRunId={suggestion.generationRunId}
           generationStatus={suggestion.generationStatus}
-          suggestionId={suggestionId}
+          suggestionId={id}
         />
       </ContainerBody>
     </Container>

--- a/apps/main/src/app/generate/cs/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generation-client.tsx
@@ -31,7 +31,7 @@ export function GenerationClient({
   courseSlug: string;
   generationRunId: string | null;
   generationStatus: GenerationStatus;
-  suggestionId: number;
+  suggestionId: string;
 }) {
   const t = useExtracted();
 

--- a/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
+++ b/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
@@ -12,7 +12,6 @@ import {
   ContainerTitle,
 } from "@zoonk/ui/components/container";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
-import { parseNumericId } from "@zoonk/utils/number";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { getExtracted } from "next-intl/server";
 import { notFound } from "next/navigation";
@@ -20,13 +19,7 @@ import { GenerationClient } from "./generation-client";
 
 export async function GenerateLessonContent({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const lessonId = parseNumericId(id);
-
-  if (lessonId === null) {
-    notFound();
-  }
-
-  const [session, lesson] = await Promise.all([getSession(), getLessonForGeneration(lessonId)]);
+  const [session, lesson] = await Promise.all([getSession(), getLessonForGeneration(id)]);
 
   if (!lesson) {
     notFound();
@@ -65,7 +58,7 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
             courseSlug={lesson.chapter.course.slug}
             generationRunId={lesson.generationRunId}
             initialStatus={initialStatus}
-            lessonId={lessonId}
+            lessonId={id}
             lessonSlug={lesson.slug}
           />
         </SubscriptionGate>

--- a/apps/main/src/app/generate/l/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/l/[id]/generation-client.tsx
@@ -34,7 +34,7 @@ export function GenerationClient({
   courseSlug: string;
   generationRunId: string | null;
   initialStatus: GenerationStatus;
-  lessonId: number;
+  lessonId: string;
   lessonSlug: string;
 }) {
   const t = useExtracted();

--- a/apps/main/src/components/catalog/continue-activity-link.tsx
+++ b/apps/main/src/components/catalog/continue-activity-link.tsx
@@ -8,9 +8,9 @@ import { getExtracted } from "next-intl/server";
 import Link from "next/link";
 
 function getScope(props: {
-  chapterId?: number;
-  courseId?: number;
-  lessonId?: number;
+  chapterId?: string;
+  courseId?: string;
+  lessonId?: string;
 }): ActivityScope {
   if (props.courseId) {
     return { courseId: props.courseId };
@@ -20,7 +20,11 @@ function getScope(props: {
     return { chapterId: props.chapterId };
   }
 
-  return { lessonId: props.lessonId ?? 0 };
+  if (props.lessonId) {
+    return { lessonId: props.lessonId };
+  }
+
+  throw new Error("ContinueActivityLink requires a course, chapter, or lesson id.");
 }
 
 export async function ContinueActivityLink<Href extends string, CompletedHref extends string>({
@@ -30,11 +34,11 @@ export async function ContinueActivityLink<Href extends string, CompletedHref ex
   fallbackHref,
   lessonId,
 }: {
-  chapterId?: number;
+  chapterId?: string;
   completedHref?: Route<CompletedHref>;
-  courseId?: number;
+  courseId?: string;
   fallbackHref?: Route<Href>;
-  lessonId?: number;
+  lessonId?: string;
 }) {
   const t = await getExtracted();
   const scope = getScope({ chapterId, courseId, lessonId });

--- a/apps/main/src/data/activities/get-activity-for-generation.test.ts
+++ b/apps/main/src/data/activities/get-activity-for-generation.test.ts
@@ -72,8 +72,12 @@ describe(getActivityForGeneration, () => {
   });
 
   test("returns null for non-existent activity", async () => {
-    const result = await getActivityForGeneration(BigInt(999_999_999));
+    const result = await getActivityForGeneration("00000000-0000-7000-8000-000000000001");
+    expect(result).toBeNull();
+  });
 
+  test("returns null for malformed activity ids", async () => {
+    const result = await getActivityForGeneration("invalid-id");
     expect(result).toBeNull();
   });
 
@@ -100,7 +104,7 @@ describe(getActivityForGeneration, () => {
     const lessonData = result?.lesson;
     expect(lessonData?.id).toBe(lesson.id);
     if (lessonData) {
-      expectTypeOf(lessonData.id).toBeNumber();
+      expectTypeOf(lessonData.id).toBeString();
     }
   });
 

--- a/apps/main/src/data/activities/get-activity-for-generation.ts
+++ b/apps/main/src/data/activities/get-activity-for-generation.ts
@@ -1,7 +1,17 @@
 import "server-only";
 import { getAiGenerationActivityWhere, prisma } from "@zoonk/db";
+import { isUuid } from "@zoonk/utils/uuid";
 
-export async function getActivityForGeneration(activityId: bigint) {
+/**
+ * Generate routes turn missing activities into a 404. Returning `null` for
+ * malformed ids keeps invalid route params on that path instead of letting
+ * Prisma raise a UUID parsing error.
+ */
+export async function getActivityForGeneration(activityId: string) {
+  if (!isUuid(activityId)) {
+    return null;
+  }
+
   return prisma.activity.findFirst({
     include: {
       lesson: {

--- a/apps/main/src/data/chapters/get-chapter-for-generation.test.ts
+++ b/apps/main/src/data/chapters/get-chapter-for-generation.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
@@ -65,7 +66,12 @@ describe(getChapterForGeneration, () => {
   });
 
   test("returns null for non-existent chapter", async () => {
-    const result = await getChapterForGeneration(999_999);
+    const result = await getChapterForGeneration(randomUUID());
+    expect(result).toBeNull();
+  });
+
+  test("returns null for malformed chapter ids", async () => {
+    const result = await getChapterForGeneration("invalid-id");
     expect(result).toBeNull();
   });
 

--- a/apps/main/src/data/chapters/get-chapter-for-generation.ts
+++ b/apps/main/src/data/chapters/get-chapter-for-generation.ts
@@ -1,7 +1,17 @@
 import "server-only";
 import { getAiGenerationChapterWhere, prisma } from "@zoonk/db";
+import { isUuid } from "@zoonk/utils/uuid";
 
-export async function getChapterForGeneration(chapterId: number) {
+/**
+ * Generate routes expect missing chapters to resolve to a 404. Returning `null`
+ * for malformed ids preserves that behavior instead of surfacing a Prisma UUID
+ * parsing error from the URL.
+ */
+export async function getChapterForGeneration(chapterId: string) {
+  if (!isUuid(chapterId)) {
+    return null;
+  }
+
   return prisma.chapter.findFirst({
     include: {
       _count: { select: { lessons: true } },

--- a/apps/main/src/data/chapters/list-course-chapters.ts
+++ b/apps/main/src/data/chapters/list-course-chapters.ts
@@ -3,7 +3,7 @@ import { type Chapter, getPublishedChapterWhere, prisma } from "@zoonk/db";
 import { cache } from "react";
 
 const cachedListCourseChapters = cache(
-  async (courseId: number): Promise<Chapter[]> =>
+  async (courseId: string): Promise<Chapter[]> =>
     prisma.chapter.findMany({
       orderBy: { position: "asc" },
       where: getPublishedChapterWhere({
@@ -12,6 +12,6 @@ const cachedListCourseChapters = cache(
     }),
 );
 
-export function listCourseChapters(params: { courseId: number }): Promise<Chapter[]> {
+export function listCourseChapters(params: { courseId: string }): Promise<Chapter[]> {
   return cachedListCourseChapters(params.courseId);
 }

--- a/apps/main/src/data/courses/_utils/continue-learning-candidates.ts
+++ b/apps/main/src/data/courses/_utils/continue-learning-candidates.ts
@@ -16,13 +16,13 @@ export type ContinueLearningCandidate = {
 };
 
 type BlockedSequentialTargetIds = {
-  chapterIds: Set<number>;
-  lessonIds: Set<number>;
+  chapterIds: Set<string>;
+  lessonIds: Set<string>;
 };
 
 type SequentialTargetIds = {
-  chapterIds: number[];
-  lessonIds: number[];
+  chapterIds: string[];
+  lessonIds: string[];
 };
 
 /**
@@ -198,7 +198,7 @@ function hasNoSequentialTargetIds({ targetIds }: { targetIds: SequentialTargetId
  * inline object literals inside the main query helper.
  */
 function getEmptyBlockedSequentialTargetIds(): BlockedSequentialTargetIds {
-  return { chapterIds: new Set<number>(), lessonIds: new Set<number>() };
+  return { chapterIds: new Set<string>(), lessonIds: new Set<string>() };
 }
 
 /**
@@ -209,7 +209,7 @@ async function listBlockedSequentialChapterIds({
   chapterIds,
   userId,
 }: {
-  chapterIds: number[];
+  chapterIds: string[];
   userId: string;
 }) {
   if (chapterIds.length === 0) {
@@ -232,7 +232,7 @@ async function listBlockedSequentialLessonIds({
   lessonIds,
   userId,
 }: {
-  lessonIds: number[];
+  lessonIds: string[];
   userId: string;
 }) {
   if (lessonIds.length === 0) {
@@ -254,7 +254,7 @@ async function listBlockedSequentialLessonIds({
 function toBlockedChapterIdSet({
   chapterCompletions,
 }: {
-  chapterCompletions: { chapterId: number }[];
+  chapterCompletions: { chapterId: string }[];
 }) {
   return new Set(chapterCompletions.map((completion) => completion.chapterId));
 }
@@ -266,7 +266,7 @@ function toBlockedChapterIdSet({
 function toBlockedLessonIdSet({
   lessonCompletions,
 }: {
-  lessonCompletions: { lessonId: number }[];
+  lessonCompletions: { lessonId: string }[];
 }) {
   return new Set(lessonCompletions.map((completion) => completion.lessonId));
 }

--- a/apps/main/src/data/courses/_utils/continue-learning-queries.ts
+++ b/apps/main/src/data/courses/_utils/continue-learning-queries.ts
@@ -8,13 +8,13 @@ import { safeAsync } from "@zoonk/utils/error";
  */
 export type ContinueLearningRow = {
   activityPosition: number;
-  chapterId: number;
+  chapterId: string;
   chapterPosition: number;
-  courseId: number;
+  courseId: string;
   courseImageUrl: string | null;
   courseSlug: string;
   courseTitle: string;
-  lessonId: number;
+  lessonId: string;
   lessonPosition: number;
   orgSlug: string | null;
 };

--- a/apps/main/src/data/courses/course-suggestions.test.ts
+++ b/apps/main/src/data/courses/course-suggestions.test.ts
@@ -68,7 +68,7 @@ describe("course-suggestions", () => {
 
     expect(result.suggestions).toHaveLength(1);
     expect(result.suggestions[0]?.title).toBe("Vitest");
-    expect(result.suggestions[0]?.id).toBeTypeOf("number");
+    expect(result.suggestions[0]?.id).toBeTypeOf("string");
     expect(spy).toHaveBeenCalledOnce();
 
     // Verify item was created in database
@@ -227,7 +227,13 @@ describe("course-suggestions", () => {
   });
 
   test("getCourseSuggestionById returns null for non-existent id", async () => {
-    const result = await getCourseSuggestionById(999_999);
+    const result = await getCourseSuggestionById(randomUUID());
+    expect(result).toBeNull();
+  });
+
+  test("getCourseSuggestionById returns null for malformed ids", async () => {
+    const result = await getCourseSuggestionById("invalid-id");
+
     expect(result).toBeNull();
   });
 

--- a/apps/main/src/data/courses/course-suggestions.ts
+++ b/apps/main/src/data/courses/course-suggestions.ts
@@ -3,6 +3,7 @@ import { generateCourseSuggestions as generateTask } from "@zoonk/ai/tasks/cours
 import { type CourseSuggestion, prisma } from "@zoonk/db";
 import { getLanguageName } from "@zoonk/utils/languages";
 import { normalizeString, removeLocaleSuffix, toSlug } from "@zoonk/utils/string";
+import { isUuid } from "@zoonk/utils/uuid";
 
 type SuggestionResult = Pick<CourseSuggestion, "id" | "title" | "description" | "targetLanguage">;
 
@@ -31,7 +32,7 @@ async function upsertSearchPromptWithSuggestions(input: {
   language: string;
   prompt: string;
   suggestions: SuggestionInput[];
-}): Promise<{ id: number; suggestions: SuggestionResult[] }> {
+}): Promise<{ id: string; suggestions: SuggestionResult[] }> {
   const { language, prompt: rawPrompt, suggestions } = input;
   const prompt = normalizeString(rawPrompt);
 
@@ -129,7 +130,7 @@ export async function generateCourseSuggestions({
 }: {
   language: string;
   prompt: string;
-}): Promise<{ id: number; suggestions: SuggestionResult[] }> {
+}): Promise<{ id: string; suggestions: SuggestionResult[] }> {
   const record = await findSearchPrompt({ language, prompt });
 
   if (record && record.suggestions.length > 0) {
@@ -156,7 +157,16 @@ export async function generateCourseSuggestions({
   });
 }
 
-export async function getCourseSuggestionById(id: number): Promise<CourseSuggestion | null> {
+/**
+ * Course suggestion pages render a 404 when the suggestion lookup returns
+ * `null`. Returning `null` for malformed ids preserves that behavior for bad
+ * route params instead of surfacing a Prisma UUID parsing error.
+ */
+export async function getCourseSuggestionById(id: string): Promise<CourseSuggestion | null> {
+  if (!isUuid(id)) {
+    return null;
+  }
+
   return prisma.courseSuggestion.findUnique({
     where: { id },
   });

--- a/apps/main/src/data/courses/get-continue-learning.ts
+++ b/apps/main/src/data/courses/get-continue-learning.ts
@@ -24,7 +24,7 @@ export const MAX_CONTINUE_LEARNING_ITEMS = 4;
 type ContinueLearningResolvedState = NonNullable<ContinueLearningState>;
 
 type PrefetchableContinueLearningState = ContinueLearningResolvedState & {
-  activityId: bigint;
+  activityId: string;
   activityKind: NonNullable<ContinueLearningResolvedState["activityKind"]>;
 };
 

--- a/apps/main/src/data/courses/list-courses.ts
+++ b/apps/main/src/data/courses/list-courses.ts
@@ -1,22 +1,13 @@
 import "server-only";
-import { type Course, getPublishedCourseWhere, prisma } from "@zoonk/db";
+import { getPublishedCourseWhere, prisma } from "@zoonk/db";
 import { clampQueryItems } from "@zoonk/db/utils";
 import { type CourseCategory } from "@zoonk/utils/categories";
 import { cache } from "react";
 
 export const LIST_COURSES_LIMIT = 20;
 
-export type CourseWithOrg = Course & {
-  organization: { slug: string } | null;
-};
-
 const cachedListCourses = cache(
-  async (
-    language: string,
-    limit: number,
-    category?: CourseCategory,
-    cursor?: number,
-  ): Promise<CourseWithOrg[]> => {
+  async (language: string, limit: number, category?: CourseCategory, cursor?: string) => {
     const courses = await prisma.course.findMany({
       include: {
         organization: {
@@ -39,9 +30,11 @@ const cachedListCourses = cache(
   },
 );
 
+export type CourseWithOrg = Awaited<ReturnType<typeof cachedListCourses>>[number];
+
 export function listCourses(params: {
   category?: CourseCategory;
-  cursor?: number;
+  cursor?: string;
   language: string;
   limit?: number;
 }): Promise<CourseWithOrg[]> {

--- a/apps/main/src/data/lessons/get-lesson-for-generation.test.ts
+++ b/apps/main/src/data/lessons/get-lesson-for-generation.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
@@ -53,8 +54,12 @@ describe(getLessonForGeneration, () => {
   });
 
   test("returns null for non-existent lessons", async () => {
-    const result = await getLessonForGeneration(999_999);
+    const result = await getLessonForGeneration(randomUUID());
+    expect(result).toBeNull();
+  });
 
+  test("returns null for malformed lesson ids", async () => {
+    const result = await getLessonForGeneration("invalid-id");
     expect(result).toBeNull();
   });
 

--- a/apps/main/src/data/lessons/get-lesson-for-generation.ts
+++ b/apps/main/src/data/lessons/get-lesson-for-generation.ts
@@ -1,7 +1,17 @@
 import "server-only";
 import { getAiGenerationLessonWhere, prisma } from "@zoonk/db";
+import { isUuid } from "@zoonk/utils/uuid";
 
-export async function getLessonForGeneration(lessonId: number) {
+/**
+ * Generate routes call `notFound()` when this lookup returns `null`. We treat
+ * malformed ids the same way so bad route params do not bubble up as Prisma
+ * UUID parsing errors.
+ */
+export async function getLessonForGeneration(lessonId: string) {
+  if (!isUuid(lessonId)) {
+    return null;
+  }
+
   return prisma.lesson.findFirst({
     include: {
       _count: { select: { activities: true } },

--- a/apps/main/src/data/lessons/list-chapter-lessons.test.ts
+++ b/apps/main/src/data/lessons/list-chapter-lessons.test.ts
@@ -100,7 +100,7 @@ describe(listChapterLessons, () => {
   });
 
   test("returns empty array for non-existent chapter", async () => {
-    const result = await listChapterLessons({ chapterId: 999_999 });
+    const result = await listChapterLessons({ chapterId: "00000000-0000-7000-8000-000000000001" });
 
     expect(result).toEqual([]);
   });

--- a/apps/main/src/data/lessons/list-chapter-lessons.ts
+++ b/apps/main/src/data/lessons/list-chapter-lessons.ts
@@ -3,7 +3,7 @@ import { type Lesson, getPublishedLessonWhere, prisma } from "@zoonk/db";
 import { cache } from "react";
 
 const cachedListChapterLessons = cache(
-  async (chapterId: number): Promise<Lesson[]> =>
+  async (chapterId: string): Promise<Lesson[]> =>
     prisma.lesson.findMany({
       orderBy: { position: "asc" },
       where: getPublishedLessonWhere({
@@ -12,6 +12,6 @@ const cachedListChapterLessons = cache(
     }),
 );
 
-export function listChapterLessons(params: { chapterId: number }): Promise<Lesson[]> {
+export function listChapterLessons(params: { chapterId: string }): Promise<Lesson[]> {
   return cachedListChapterLessons(params.chapterId);
 }

--- a/apps/main/src/data/progress/get-best-time.test.ts
+++ b/apps/main/src/data/progress/get-best-time.test.ts
@@ -13,7 +13,7 @@ type StepAttemptParams = {
   answeredAt?: Date;
   hourOfDay: number;
   isCorrect: boolean;
-  stepId: bigint;
+  stepId: string;
   userId: string;
 };
 

--- a/apps/main/src/data/progress/trigger-lesson-preload.ts
+++ b/apps/main/src/data/progress/trigger-lesson-preload.ts
@@ -9,7 +9,7 @@ import { API_URL } from "@zoonk/utils/url";
  */
 export async function triggerLessonPreload(input: {
   cookieHeader: string;
-  lessonId: number;
+  lessonId: string;
 }): Promise<void> {
   const response = await fetch(`${API_URL}/v1/workflows/lesson-preload/trigger`, {
     body: JSON.stringify({ lessonId: input.lessonId }),

--- a/apps/main/src/lib/workflow/generation-store.test.ts
+++ b/apps/main/src/lib/workflow/generation-store.test.ts
@@ -167,8 +167,8 @@ describe(handleStepStreamMessage, () => {
     handleStepStreamMessage({
       completionStep: "done",
       dispatch: (a) => actions.push(a),
-      entityId: 42,
-      message: { entityId: 42, status: "completed", step: "done" },
+      entityId: "42",
+      message: { entityId: "42", status: "completed", step: "done" },
     });
     const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
     expect(state.status).toBe("completed");
@@ -179,8 +179,8 @@ describe(handleStepStreamMessage, () => {
     handleStepStreamMessage({
       completionStep: "done",
       dispatch: (a) => actions.push(a),
-      entityId: 42,
-      message: { entityId: 99, status: "completed", step: "done" },
+      entityId: "42",
+      message: { entityId: "99", status: "completed", step: "done" },
     });
     const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
     expect(state.status).toBe("streaming");
@@ -191,7 +191,7 @@ describe(handleStepStreamMessage, () => {
     handleStepStreamMessage({
       completionStep: "done",
       dispatch: (a) => actions.push(a),
-      message: { entityId: 99, status: "completed", step: "done" },
+      message: { entityId: "99", status: "completed", step: "done" },
     });
     const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
     expect(state.status).toBe("completed");
@@ -214,8 +214,8 @@ describe(handleStepStreamMessage, () => {
 
       handleStepStreamMessage({
         dispatch: (a) => actions.push(a),
-        entityId: 235,
-        message: { entityId: 238, status: "completed", step: "generateVisuals" },
+        entityId: "235",
+        message: { entityId: "238", status: "completed", step: "generateVisuals" },
       });
 
       const state = applyActions(actions, initialGenerationState());
@@ -228,8 +228,8 @@ describe(handleStepStreamMessage, () => {
 
       handleStepStreamMessage({
         dispatch: (a) => actions.push(a),
-        entityId: 235,
-        message: { entityId: 235, status: "completed", step: "generateVisuals" },
+        entityId: "235",
+        message: { entityId: "235", status: "completed", step: "generateVisuals" },
       });
 
       const state = applyActions(actions, initialGenerationState());
@@ -242,7 +242,7 @@ describe(handleStepStreamMessage, () => {
 
       handleStepStreamMessage({
         dispatch: (a) => actions.push(a),
-        entityId: 235,
+        entityId: "235",
         message: { status: "completed", step: "generateExplanationContent" },
       });
 
@@ -256,7 +256,7 @@ describe(handleStepStreamMessage, () => {
 
       handleStepStreamMessage({
         dispatch: (a) => actions.push(a),
-        message: { entityId: 99, status: "completed", step: "stepA" },
+        message: { entityId: "99", status: "completed", step: "stepA" },
       });
 
       const state = applyActions(actions, initialGenerationState());
@@ -269,8 +269,8 @@ describe(handleStepStreamMessage, () => {
 
       handleStepStreamMessage({
         dispatch: (a) => actions.push(a),
-        entityId: 235,
-        message: { entityId: 238, status: "started", step: "generateVisuals" },
+        entityId: "235",
+        message: { entityId: "238", status: "started", step: "generateVisuals" },
       });
 
       const state = applyActions(actions, initialGenerationState());
@@ -284,8 +284,8 @@ describe(handleStepStreamMessage, () => {
 
       handleStepStreamMessage({
         dispatch: (a) => actions.push(a),
-        entityId: 235,
-        message: { entityId: 235, status: "started", step: "generateVisuals" },
+        entityId: "235",
+        message: { entityId: "235", status: "started", step: "generateVisuals" },
       });
 
       const state = applyActions(actions, initialGenerationState());
@@ -298,7 +298,7 @@ describe(handleStepStreamMessage, () => {
 
       handleStepStreamMessage({
         dispatch: (a) => actions.push(a),
-        entityId: 235,
+        entityId: "235",
         message: { status: "started", step: "getLessonActivities" },
       });
 
@@ -324,9 +324,9 @@ describe(handleStepStreamMessage, () => {
     const actions: GenerationAction[] = [];
     handleStepStreamMessage({
       dispatch: (a) => actions.push(a),
-      entityId: 100,
+      entityId: "100",
       message: {
-        entityId: 200,
+        entityId: "200",
         reason: "aiGenerationFailed",
         status: "error",
         step: "generateVisuals",
@@ -341,9 +341,9 @@ describe(handleStepStreamMessage, () => {
     const actions: GenerationAction[] = [];
     handleStepStreamMessage({
       dispatch: (a) => actions.push(a),
-      entityId: 100,
+      entityId: "100",
       message: {
-        entityId: 100,
+        entityId: "100",
         reason: "aiGenerationFailed",
         status: "error",
         step: "generateVisuals",
@@ -357,7 +357,7 @@ describe(handleStepStreamMessage, () => {
     const actions: GenerationAction[] = [];
     handleStepStreamMessage({
       dispatch: (a) => actions.push(a),
-      entityId: 100,
+      entityId: "100",
       message: {
         reason: "aiGenerationFailed",
         status: "error",

--- a/apps/main/src/lib/workflow/generation-store.ts
+++ b/apps/main/src/lib/workflow/generation-store.ts
@@ -94,8 +94,8 @@ export function generationReducer<TStep extends string>(
  * When the viewer has no entityId (non-activity workflows), everything matches.
  */
 function isEventRelevantToViewer(
-  messageEntityId: number | undefined,
-  viewerEntityId: number | undefined,
+  messageEntityId: string | undefined,
+  viewerEntityId: string | undefined,
 ): boolean {
   if (messageEntityId === undefined) {
     return true;
@@ -111,7 +111,7 @@ function isEventRelevantToViewer(
 export function handleStepStreamMessage<TStep extends string>(params: {
   completionStep?: TStep;
   dispatch: (action: GenerationAction<TStep>) => void;
-  entityId?: number;
+  entityId?: string;
   message: StepStreamMessage<TStep>;
 }) {
   const { completionStep, dispatch, entityId, message } = params;

--- a/apps/main/src/lib/workflow/use-workflow-generation.ts
+++ b/apps/main/src/lib/workflow/use-workflow-generation.ts
@@ -18,7 +18,7 @@ const MAX_STREAM_RECONNECTS = 5;
 export function useWorkflowGeneration<TStep extends string = string>(config: {
   autoTrigger?: boolean;
   completionStep?: TStep;
-  entityId?: number;
+  entityId?: string;
   initialRunId?: string | null;
   initialStatus?: GenerationStatus;
   statusUrl: string;

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -37,6 +37,9 @@ export const baseAuthConfig: Omit<BetterAuthOptions, "rateLimit"> = {
   account: {
     accountLinking: { enabled: true },
   },
+  advanced: {
+    database: { generateId: "uuid" },
+  },
   appName: "Zoonk",
   basePath: BETTER_AUTH_BASE_PATH,
   baseURL: {

--- a/packages/core/src/activities/find-last-completed.test.ts
+++ b/packages/core/src/activities/find-last-completed.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { activityFixture, activityProgressFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -707,7 +708,7 @@ describe(findLastCompleted, () => {
   });
 
   test("returns null for non-existent course", async () => {
-    const result = await findLastCompleted(userId, { courseId: 999_999 });
+    const result = await findLastCompleted(userId, { courseId: randomUUID() });
 
     expect(result).toBeNull();
   });

--- a/packages/core/src/activities/find-last-completed.ts
+++ b/packages/core/src/activities/find-last-completed.ts
@@ -2,16 +2,16 @@ import "server-only";
 import { getPublishedActivityWhere, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 
-export type ActivityScope = { courseId: number } | { chapterId: number } | { lessonId: number };
+export type ActivityScope = { courseId: string } | { chapterId: string } | { lessonId: string };
 
 type LastCompletedActivity = {
   activityPosition: number;
-  chapterId: number;
+  chapterId: string;
   chapterPosition: number;
   chapterSlug: string;
-  courseId: number;
+  courseId: string;
   courseSlug: string;
-  lessonId: number;
+  lessonId: string;
   lessonPosition: number;
   lessonSlug: string;
   orgSlug: string | null;

--- a/packages/core/src/activities/get-next-activity-in-course.test.ts
+++ b/packages/core/src/activities/get-next-activity-in-course.test.ts
@@ -7,24 +7,24 @@ import { beforeAll, describe, expect, test } from "vitest";
 import { getNextActivityInCourse } from "./get-next-activity-in-course";
 
 describe(getNextActivityInCourse, () => {
-  let courseId: number;
+  let courseId: string;
   let orgId: string;
 
-  let chapter1Id: number;
+  let chapter1Id: string;
   let chapter1Slug: string;
-  let chapter2Id: number;
+  let chapter2Id: string;
   let chapter2Slug: string;
 
-  let lesson1Id: number;
+  let lesson1Id: string;
   let lesson1Slug: string;
-  let lesson2Id: number;
+  let lesson2Id: string;
   let lesson2Slug: string;
-  let lesson3Id: number;
+  let lesson3Id: string;
   let lesson3Slug: string;
 
-  let activity2Id: bigint;
-  let activity3Id: bigint;
-  let activity4Id: bigint;
+  let activity2Id: string;
+  let activity3Id: string;
+  let activity4Id: string;
 
   beforeAll(async () => {
     const org = await organizationFixture({ kind: "brand" });
@@ -205,7 +205,7 @@ describe(getNextActivityInCourse, () => {
       activityPosition: 0,
       chapterId: chapter1Id,
       chapterPosition: 0,
-      courseId: 999_999,
+      courseId: "missing-course-id",
       lessonId: lesson1Id,
       lessonPosition: 0,
     });

--- a/packages/core/src/activities/get-next-activity-in-course.ts
+++ b/packages/core/src/activities/get-next-activity-in-course.ts
@@ -4,14 +4,14 @@ import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 
 export type NextActivityInCourse = {
-  activityId: bigint;
+  activityId: string;
   activityKind: ActivityKind;
   activityPosition: number;
   activityTitle: string | null;
-  chapterId: number;
+  chapterId: string;
   chapterSlug: string;
   lessonDescription: string;
-  lessonId: number;
+  lessonId: string;
   lessonSlug: string;
   lessonTitle: string;
 };
@@ -19,10 +19,10 @@ export type NextActivityInCourse = {
 const cachedGetNextActivity = cache(
   async (
     activityPosition: number,
-    chapterId: number,
+    chapterId: string,
     chapterPosition: number,
-    courseId: number,
-    lessonId: number,
+    courseId: string,
+    lessonId: string,
     lessonPosition: number,
   ): Promise<NextActivityInCourse | null> => {
     const { data: activity, error } = await safeAsync(() =>
@@ -91,10 +91,10 @@ const cachedGetNextActivity = cache(
  */
 export function getNextActivityInCourse(params: {
   activityPosition: number;
-  chapterId: number;
+  chapterId: string;
   chapterPosition: number;
-  courseId: number;
-  lessonId: number;
+  courseId: string;
+  lessonId: string;
   lessonPosition: number;
 }): Promise<NextActivityInCourse | null> {
   return cachedGetNextActivity(

--- a/packages/core/src/alternative-titles/add-alternative-titles.ts
+++ b/packages/core/src/alternative-titles/add-alternative-titles.ts
@@ -4,7 +4,7 @@ import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { toSlug } from "@zoonk/utils/string";
 
 export async function addAlternativeTitles(params: {
-  courseId: number;
+  courseId: string;
   titles: string[];
   language: string;
 }): Promise<SafeReturn<BatchPayload | null>> {

--- a/packages/core/src/content/lifecycle.ts
+++ b/packages/core/src/content/lifecycle.ts
@@ -101,7 +101,7 @@ async function hasLearnerDataConstraint(target: ContentDeleteTarget): Promise<bo
  * completion or step attempt exists, because those rows are the historical facts
  * later analytics and performance pages need to preserve.
  */
-async function hasLearnerDataInCourse({ courseId }: { courseId: number }) {
+async function hasLearnerDataInCourse({ courseId }: { courseId: string }) {
   const [activityProgressCount, stepAttemptCount] = await Promise.all([
     prisma.activityProgress.count({
       where: { activity: { lesson: { chapter: { courseId } } } },
@@ -118,7 +118,7 @@ async function hasLearnerDataInCourse({ courseId }: { courseId: number }) {
  * Chapters share the same learner-history rule as courses, but their scope is
  * limited to activities and steps nested under that chapter.
  */
-async function hasLearnerDataInChapter({ chapterId }: { chapterId: number }) {
+async function hasLearnerDataInChapter({ chapterId }: { chapterId: string }) {
   const [activityProgressCount, stepAttemptCount] = await Promise.all([
     prisma.activityProgress.count({
       where: { activity: { lesson: { chapterId } } },
@@ -135,7 +135,7 @@ async function hasLearnerDataInChapter({ chapterId }: { chapterId: number }) {
  * Lessons need the same protection as higher levels because a later archive or
  * regeneration must not erase attempts and completions tied to that lesson.
  */
-async function hasLearnerDataInLesson({ lessonId }: { lessonId: number }) {
+async function hasLearnerDataInLesson({ lessonId }: { lessonId: string }) {
   const [activityProgressCount, stepAttemptCount] = await Promise.all([
     prisma.activityProgress.count({ where: { activity: { lessonId } } }),
     prisma.stepAttempt.count({ where: { step: { activity: { lessonId } } } }),
@@ -148,7 +148,7 @@ async function hasLearnerDataInLesson({ lessonId }: { lessonId: number }) {
  * Activities can accumulate two kinds of learner history today: direct activity
  * completions and step-level attempts. Either one is enough to block hard delete.
  */
-async function hasLearnerDataInActivity({ activityId }: { activityId: bigint }) {
+async function hasLearnerDataInActivity({ activityId }: { activityId: string }) {
   const [activityProgressCount, stepAttemptCount] = await Promise.all([
     prisma.activityProgress.count({ where: { activityId } }),
     prisma.stepAttempt.count({ where: { step: { activityId } } }),

--- a/packages/core/src/player/commands/_utils/durable-curriculum-completion-queries.ts
+++ b/packages/core/src/player/commands/_utils/durable-curriculum-completion-queries.ts
@@ -1,15 +1,15 @@
 import { type TransactionClient } from "@zoonk/db";
 
 type ActivityCurriculumContext = {
-  chapterId: number;
-  courseId: number;
-  lessonId: number;
+  chapterId: string;
+  courseId: string;
+  lessonId: string;
 };
 
 export type PublishedLessonCompletionRow = {
-  chapterId: number;
+  chapterId: string;
   completedActivities: number;
-  lessonId: number;
+  lessonId: string;
   totalActivities: number;
 };
 
@@ -23,7 +23,7 @@ export async function getActivityCurriculumContext({
   activityId,
   tx,
 }: {
-  activityId: bigint;
+  activityId: string;
   tx: TransactionClient;
 }): Promise<ActivityCurriculumContext> {
   const activity = await tx.activity.findUnique({
@@ -65,7 +65,7 @@ export async function listPublishedCourseLessonCompletionRows({
   tx,
   userId,
 }: {
-  courseId: number;
+  courseId: string;
   tx: TransactionClient;
   userId: string;
 }): Promise<PublishedLessonCompletionRow[]> {
@@ -104,7 +104,7 @@ export async function listPublishedCourseChapters({
   courseId,
   tx,
 }: {
-  courseId: number;
+  courseId: string;
   tx: TransactionClient;
 }) {
   return tx.chapter.findMany({
@@ -127,10 +127,10 @@ export async function listDurableCourseLessonIds({
   tx,
   userId,
 }: {
-  courseId: number;
+  courseId: string;
   tx: TransactionClient;
   userId: string;
-}): Promise<Set<number>> {
+}): Promise<Set<string>> {
   const rows = await tx.lessonCompletion.findMany({
     where: {
       lesson: {
@@ -159,10 +159,10 @@ export async function listDurableCourseChapterIds({
   tx,
   userId,
 }: {
-  courseId: number;
+  courseId: string;
   tx: TransactionClient;
   userId: string;
-}): Promise<Set<number>> {
+}): Promise<Set<string>> {
   const rows = await tx.chapterCompletion.findMany({
     where: {
       chapter: {

--- a/packages/core/src/player/commands/_utils/durable-curriculum-completion-rules.test.ts
+++ b/packages/core/src/player/commands/_utils/durable-curriculum-completion-rules.test.ts
@@ -10,6 +10,10 @@ import {
   isCurrentLessonCompleted,
 } from "./durable-curriculum-completion-rules";
 
+function createTestUuid(id: number): string {
+  return `00000000-0000-7000-8000-${String(id).padStart(12, "0")}`;
+}
+
 /**
  * These rule tests only care about lesson/chapter completion counts, so this
  * helper builds the smallest row shape that still exercises the pure logic.
@@ -18,9 +22,9 @@ function createRow(
   overrides: Partial<PublishedLessonCompletionRow> = {},
 ): PublishedLessonCompletionRow {
   return {
-    chapterId: 1,
+    chapterId: createTestUuid(1),
     completedActivities: 0,
-    lessonId: 1,
+    lessonId: createTestUuid(101),
     totalActivities: 1,
     ...overrides,
   };
@@ -31,10 +35,10 @@ function createRow(
  * Returning the full inferred type keeps the tests aligned with the real
  * function signature without needing database fixtures.
  */
-function createChapters(ids: number[]): Parameters<typeof isCurrentCourseCompleted>[0]["chapters"] {
-  return ids.map((id) => ({
+function createChapters(ids: string[]): Parameters<typeof isCurrentCourseCompleted>[0]["chapters"] {
+  return ids.map((id, index) => ({
     archivedAt: null,
-    courseId: 1,
+    courseId: createTestUuid(900),
     createdAt: new Date(),
     description: `Description ${id}`,
     generationRunId: null,
@@ -45,8 +49,8 @@ function createChapters(ids: number[]): Parameters<typeof isCurrentCourseComplet
     language: "en",
     managementMode: "manual" as const,
     normalizedTitle: `chapter ${id}`,
-    organizationId: `org-${id}`,
-    position: id - 1,
+    organizationId: createTestUuid(901),
+    position: index,
     slug: `chapter-${id}`,
     title: `Chapter ${id}`,
     updatedAt: new Date(),
@@ -73,62 +77,94 @@ describe("durable curriculum completion rules", () => {
   });
 
   test("groupRowsByChapter groups rows by chapter id", () => {
+    const chapter1 = createTestUuid(1);
+    const chapter2 = createTestUuid(2);
+    const lesson10 = createTestUuid(10);
+    const lesson11 = createTestUuid(11);
+    const lesson20 = createTestUuid(20);
     const rows = [
-      createRow({ chapterId: 1, lessonId: 10 }),
-      createRow({ chapterId: 1, lessonId: 11 }),
-      createRow({ chapterId: 2, lessonId: 20 }),
+      createRow({ chapterId: chapter1, lessonId: lesson10 }),
+      createRow({ chapterId: chapter1, lessonId: lesson11 }),
+      createRow({ chapterId: chapter2, lessonId: lesson20 }),
     ];
 
     const grouped = groupRowsByChapter({ rows });
 
-    expect(grouped.get(1)?.map((row) => row.lessonId)).toEqual([10, 11]);
-    expect(grouped.get(2)?.map((row) => row.lessonId)).toEqual([20]);
+    expect(grouped.get(chapter1)?.map((row) => row.lessonId)).toEqual([lesson10, lesson11]);
+    expect(grouped.get(chapter2)?.map((row) => row.lessonId)).toEqual([lesson20]);
   });
 
   test("getLessonRow returns the matching lesson or null", () => {
-    const rows = [createRow({ lessonId: 10 }), createRow({ lessonId: 11 })];
+    const lesson10 = createTestUuid(10);
+    const lesson11 = createTestUuid(11);
+    const missingLesson = createTestUuid(99);
+    const rows = [createRow({ lessonId: lesson10 }), createRow({ lessonId: lesson11 })];
 
-    expect(getLessonRow({ lessonId: 11, rows })?.lessonId).toBe(11);
-    expect(getLessonRow({ lessonId: 99, rows })).toBeNull();
+    expect(getLessonRow({ lessonId: lesson11, rows })?.lessonId).toBe(lesson11);
+    expect(getLessonRow({ lessonId: missingLesson, rows })).toBeNull();
   });
 
   test("getEffectiveDurableLessonIds adds the current lesson only when it is complete", () => {
-    const durableLessonIds = new Set([3]);
+    const durableLessonId = createTestUuid(3);
+    const currentLessonId = createTestUuid(9);
+    const durableLessonIds = new Set([durableLessonId]);
 
     expect(
       getEffectiveDurableLessonIds({
         durableLessonIds,
-        lessonRow: createRow({ completedActivities: 1, lessonId: 9, totalActivities: 1 }),
+        lessonRow: createRow({
+          completedActivities: 1,
+          lessonId: currentLessonId,
+          totalActivities: 1,
+        }),
       }),
-    ).toEqual(new Set([3, 9]));
+    ).toEqual(new Set([durableLessonId, currentLessonId]));
 
     expect(
       getEffectiveDurableLessonIds({
         durableLessonIds,
-        lessonRow: createRow({ completedActivities: 0, lessonId: 9, totalActivities: 1 }),
+        lessonRow: createRow({
+          completedActivities: 0,
+          lessonId: currentLessonId,
+          totalActivities: 1,
+        }),
       }),
     ).toBe(durableLessonIds);
   });
 
   test("isCurrentChapterCompleted accepts direct or durable lesson completion but rejects empty chapters", () => {
+    const chapterId = createTestUuid(1);
+    const lesson10 = createTestUuid(10);
+    const lesson11 = createTestUuid(11);
+    const missingChapterId = createTestUuid(99);
     const rowsByChapter = groupRowsByChapter({
       rows: [
-        createRow({ chapterId: 1, completedActivities: 1, lessonId: 10, totalActivities: 1 }),
-        createRow({ chapterId: 1, completedActivities: 0, lessonId: 11, totalActivities: 2 }),
+        createRow({
+          chapterId,
+          completedActivities: 1,
+          lessonId: lesson10,
+          totalActivities: 1,
+        }),
+        createRow({
+          chapterId,
+          completedActivities: 0,
+          lessonId: lesson11,
+          totalActivities: 2,
+        }),
       ],
     });
 
     expect(
       isCurrentChapterCompleted({
-        chapterId: 1,
-        durableLessonIds: new Set([11]),
+        chapterId,
+        durableLessonIds: new Set([lesson11]),
         rowsByChapter,
       }),
     ).toBe(true);
 
     expect(
       isCurrentChapterCompleted({
-        chapterId: 1,
+        chapterId,
         durableLessonIds: new Set(),
         rowsByChapter,
       }),
@@ -136,7 +172,7 @@ describe("durable curriculum completion rules", () => {
 
     expect(
       isCurrentChapterCompleted({
-        chapterId: 99,
+        chapterId: missingChapterId,
         durableLessonIds: new Set(),
         rowsByChapter,
       }),
@@ -144,19 +180,21 @@ describe("durable curriculum completion rules", () => {
   });
 
   test("getEffectiveDurableChapterIds adds the current chapter only when it is complete", () => {
-    const durableChapterIds = new Set([2]);
+    const durableChapterId = createTestUuid(2);
+    const currentChapterId = createTestUuid(5);
+    const durableChapterIds = new Set([durableChapterId]);
 
     expect(
       getEffectiveDurableChapterIds({
-        chapterId: 5,
+        chapterId: currentChapterId,
         durableChapterIds,
         isChapterCompleted: true,
       }),
-    ).toEqual(new Set([2, 5]));
+    ).toEqual(new Set([durableChapterId, currentChapterId]));
 
     expect(
       getEffectiveDurableChapterIds({
-        chapterId: 5,
+        chapterId: currentChapterId,
         durableChapterIds,
         isChapterCompleted: false,
       }),
@@ -164,17 +202,32 @@ describe("durable curriculum completion rules", () => {
   });
 
   test("isCurrentCourseCompleted requires every chapter to be covered by durable or effective completion", () => {
+    const chapter1 = createTestUuid(1);
+    const chapter2 = createTestUuid(2);
+    const chapter3 = createTestUuid(3);
+    const lesson10 = createTestUuid(10);
+    const lesson20 = createTestUuid(20);
     const rowsByChapter = groupRowsByChapter({
       rows: [
-        createRow({ chapterId: 1, completedActivities: 1, lessonId: 10, totalActivities: 1 }),
-        createRow({ chapterId: 2, completedActivities: 0, lessonId: 20, totalActivities: 2 }),
+        createRow({
+          chapterId: chapter1,
+          completedActivities: 1,
+          lessonId: lesson10,
+          totalActivities: 1,
+        }),
+        createRow({
+          chapterId: chapter2,
+          completedActivities: 0,
+          lessonId: lesson20,
+          totalActivities: 2,
+        }),
       ],
     });
 
     expect(
       isCurrentCourseCompleted({
-        chapters: createChapters([1, 2]),
-        durableChapterIds: new Set([2]),
+        chapters: createChapters([chapter1, chapter2]),
+        durableChapterIds: new Set([chapter2]),
         durableLessonIds: new Set(),
         rowsByChapter,
       }),
@@ -182,8 +235,8 @@ describe("durable curriculum completion rules", () => {
 
     expect(
       isCurrentCourseCompleted({
-        chapters: createChapters([1, 2, 3]),
-        durableChapterIds: new Set([2]),
+        chapters: createChapters([chapter1, chapter2, chapter3]),
+        durableChapterIds: new Set([chapter2]),
         durableLessonIds: new Set(),
         rowsByChapter,
       }),
@@ -200,18 +253,32 @@ describe("durable curriculum completion rules", () => {
   });
 
   test("isCurrentCourseCompleted can finish a course through durable lessons without a chapter badge yet", () => {
+    const chapter1 = createTestUuid(1);
+    const chapter2 = createTestUuid(2);
+    const lesson10 = createTestUuid(10);
+    const lesson20 = createTestUuid(20);
     const rowsByChapter = groupRowsByChapter({
       rows: [
-        createRow({ chapterId: 1, completedActivities: 1, lessonId: 10, totalActivities: 1 }),
-        createRow({ chapterId: 2, completedActivities: 0, lessonId: 20, totalActivities: 2 }),
+        createRow({
+          chapterId: chapter1,
+          completedActivities: 1,
+          lessonId: lesson10,
+          totalActivities: 1,
+        }),
+        createRow({
+          chapterId: chapter2,
+          completedActivities: 0,
+          lessonId: lesson20,
+          totalActivities: 2,
+        }),
       ],
     });
 
     expect(
       isCurrentCourseCompleted({
-        chapters: createChapters([1, 2]),
+        chapters: createChapters([chapter1, chapter2]),
         durableChapterIds: new Set(),
-        durableLessonIds: new Set([20]),
+        durableLessonIds: new Set([lesson20]),
         rowsByChapter,
       }),
     ).toBe(true);

--- a/packages/core/src/player/commands/_utils/durable-curriculum-completion-rules.ts
+++ b/packages/core/src/player/commands/_utils/durable-curriculum-completion-rules.ts
@@ -21,7 +21,7 @@ function isEffectivelyCompleted({
   durableLessonIds,
   row,
 }: {
-  durableLessonIds: Set<number>;
+  durableLessonIds: Set<string>;
   row: PublishedLessonCompletionRow;
 }) {
   return durableLessonIds.has(row.lessonId) || isCurrentLessonCompleted({ row });
@@ -33,7 +33,7 @@ function isEffectivelyCompleted({
  * avoids embedding grouping logic inside later predicates.
  */
 export function groupRowsByChapter({ rows }: { rows: PublishedLessonCompletionRow[] }) {
-  const grouped = new Map<number, PublishedLessonCompletionRow[]>();
+  const grouped = new Map<string, PublishedLessonCompletionRow[]>();
 
   for (const row of rows) {
     const chapterRows = grouped.get(row.chapterId) ?? [];
@@ -53,7 +53,7 @@ export function getLessonRow({
   lessonId,
   rows,
 }: {
-  lessonId: number;
+  lessonId: string;
   rows: PublishedLessonCompletionRow[];
 }) {
   return rows.find((row) => row.lessonId === lessonId) ?? null;
@@ -68,7 +68,7 @@ export function getEffectiveDurableLessonIds({
   durableLessonIds,
   lessonRow,
 }: {
-  durableLessonIds: Set<number>;
+  durableLessonIds: Set<string>;
   lessonRow: PublishedLessonCompletionRow | null;
 }) {
   if (!lessonRow || !isCurrentLessonCompleted({ row: lessonRow })) {
@@ -88,9 +88,9 @@ export function isCurrentChapterCompleted({
   durableLessonIds,
   rowsByChapter,
 }: {
-  chapterId: number;
-  durableLessonIds: Set<number>;
-  rowsByChapter: Map<number, PublishedLessonCompletionRow[]>;
+  chapterId: string;
+  durableLessonIds: Set<string>;
+  rowsByChapter: Map<string, PublishedLessonCompletionRow[]>;
 }) {
   const chapterRows = rowsByChapter.get(chapterId) ?? [];
 
@@ -110,8 +110,8 @@ export function getEffectiveDurableChapterIds({
   durableChapterIds,
   isChapterCompleted,
 }: {
-  chapterId: number;
-  durableChapterIds: Set<number>;
+  chapterId: string;
+  durableChapterIds: Set<string>;
   isChapterCompleted: boolean;
 }) {
   if (!isChapterCompleted) {
@@ -134,9 +134,9 @@ export function isCurrentCourseCompleted({
   rowsByChapter,
 }: {
   chapters: Awaited<ReturnType<typeof listPublishedCourseChapters>>;
-  durableChapterIds: Set<number>;
-  durableLessonIds: Set<number>;
-  rowsByChapter: Map<number, PublishedLessonCompletionRow[]>;
+  durableChapterIds: Set<string>;
+  durableLessonIds: Set<string>;
+  rowsByChapter: Map<string, PublishedLessonCompletionRow[]>;
 }) {
   if (chapters.length === 0) {
     return false;

--- a/packages/core/src/player/commands/_utils/durable-curriculum-completion.ts
+++ b/packages/core/src/player/commands/_utils/durable-curriculum-completion.ts
@@ -25,10 +25,10 @@ import {
 export async function syncDurableCurriculumCompletion(
   tx: TransactionClient,
   params: {
-    activityId: bigint;
+    activityId: string;
     userId: string;
   },
-): Promise<{ courseId: number }> {
+): Promise<{ courseId: string }> {
   const context = await getActivityCurriculumContext({ activityId: params.activityId, tx });
 
   const [chapters, rows, durableLessonIds, durableChapterIds] = await Promise.all([
@@ -109,8 +109,8 @@ function getDurableCompletionWrites({
   chapterCompleted: boolean;
   context: Awaited<ReturnType<typeof getActivityCurriculumContext>>;
   courseCompleted: boolean;
-  durableChapterIds: Set<number>;
-  durableLessonIds: Set<number>;
+  durableChapterIds: Set<string>;
+  durableLessonIds: Set<string>;
   lessonRow: NonNullable<ReturnType<typeof getLessonRow>>;
   tx: TransactionClient;
   userId: string;

--- a/packages/core/src/player/commands/start-activity.ts
+++ b/packages/core/src/player/commands/start-activity.ts
@@ -7,7 +7,7 @@ import { prisma } from "@zoonk/db";
  * upsert keeps repeated page visits idempotent and preserves any existing
  * completion metadata instead of resetting progress.
  */
-export async function startActivity(params: { activityId: bigint; userId: string }): Promise<void> {
+export async function startActivity(params: { activityId: string; userId: string }): Promise<void> {
   await prisma.activityProgress.upsert({
     create: { activityId: params.activityId, userId: params.userId },
     update: {},

--- a/packages/core/src/player/commands/submit-activity-completion.ts
+++ b/packages/core/src/player/commands/submit-activity-completion.ts
@@ -10,7 +10,7 @@ import { syncDurableCurriculumCompletion } from "./_utils/durable-curriculum-com
 const MAX_LOCAL_DATE_DRIFT_MS = 2 * MS_PER_DAY;
 
 export async function submitActivityCompletion(input: {
-  activityId: bigint;
+  activityId: string;
   durationSeconds: number;
   localDate: string;
   score: ScoreResult;
@@ -22,7 +22,7 @@ export async function submitActivityCompletion(input: {
     durationSeconds: number;
     hourOfDay: number;
     isCorrect: boolean;
-    stepId: bigint;
+    stepId: string;
   }[];
   userId: string;
 }): Promise<{

--- a/packages/core/src/player/commands/submit-player-completion.test.ts
+++ b/packages/core/src/player/commands/submit-player-completion.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { prisma } from "@zoonk/db";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
@@ -47,7 +48,7 @@ async function createPublishedChapterContext() {
  * follow-up effect planning without dragging in unrelated player variants.
  */
 async function createMultipleChoiceActivity(params: {
-  lessonId: number;
+  lessonId: string;
   organizationId: string;
   position?: number;
 }) {
@@ -81,17 +82,17 @@ async function createMultipleChoiceActivity(params: {
  * validation path for a multiple-choice step.
  */
 function buildCompletionInput(params: {
-  activityId: bigint | string;
+  activityId: string;
   selectedIndex?: number;
   selectedText?: string;
   startedAt?: number;
-  stepId: bigint | string;
+  stepId: string;
 }): CompletionInput {
   const startedAt = params.startedAt ?? Date.now() - 10_000;
-  const stepId = String(params.stepId);
+  const stepId = params.stepId;
 
   return {
-    activityId: String(params.activityId),
+    activityId: params.activityId,
     answers: {
       [stepId]: {
         kind: "multipleChoice",
@@ -116,8 +117,8 @@ describe(submitPlayerCompletion, () => {
   test("returns null when the submitted activity no longer exists", async () => {
     const result = await submitPlayerCompletion({
       input: buildCompletionInput({
-        activityId: "999999999",
-        stepId: "999999999",
+        activityId: randomUUID(),
+        stepId: randomUUID(),
       }),
       userId: "missing-user-id",
     });
@@ -174,7 +175,7 @@ describe(submitPlayerCompletion, () => {
       }),
     ]);
 
-    expect(nextLesson.id).toBeGreaterThan(currentLesson.id);
+    expect(nextLesson.position).toBeGreaterThan(currentLesson.position);
     expect(result).toEqual({
       preloadLessonId: nextLesson.id,
       regenerateLessonId: null,

--- a/packages/core/src/player/commands/submit-player-completion.ts
+++ b/packages/core/src/player/commands/submit-player-completion.ts
@@ -17,16 +17,16 @@ function clampDuration(startedAt: number): number {
 }
 
 type StepWithSentence = {
-  id: bigint;
+  id: string;
   kind: string;
   content: unknown;
-  word: { id: bigint } | null;
-  sentence: { id: bigint; sentence: string } | null;
+  word: { id: string } | null;
+  sentence: { id: string; sentence: string } | null;
 };
 
 type PlayerCompletionEffects = {
-  preloadLessonId: number | null;
-  regenerateLessonId: number | null;
+  preloadLessonId: string | null;
+  regenerateLessonId: string | null;
 };
 
 /**
@@ -62,7 +62,7 @@ export async function submitPlayerCompletion(params: {
   input: CompletionInput;
   userId: string;
 }): Promise<PlayerCompletionEffects | null> {
-  const activityId = BigInt(params.input.activityId);
+  const activityId = params.input.activityId;
   const activity = await prisma.activity.findUnique({
     include: {
       lesson: { include: { chapter: true } },
@@ -88,7 +88,7 @@ export async function submitPlayerCompletion(params: {
       ? attachSentenceTranslationsToSteps(
           await getReviewValidationSteps({
             lessonId: activity.lessonId,
-            stepIds: Object.keys(params.input.answers).map(BigInt),
+            stepIds: Object.keys(params.input.answers),
           }),
           lessonSentences,
         )
@@ -104,7 +104,7 @@ export async function submitPlayerCompletion(params: {
       stepResults: stepResults.map((step) => ({ isCorrect: step.isCorrect })),
       steps: activity.steps.map((step) => ({
         content: step.content,
-        id: String(step.id),
+        id: step.id,
         kind: step.kind,
       })),
     }),
@@ -113,7 +113,7 @@ export async function submitPlayerCompletion(params: {
   const durationSeconds = clampDuration(params.input.startedAt);
 
   const mergedStepResults = stepResults.map((validated) => {
-    const stepId = String(validated.stepId);
+    const stepId = validated.stepId;
     const timing = params.input.stepTimings[stepId];
 
     return {

--- a/packages/core/src/player/contracts/_utils/activity-data-mappers.test.ts
+++ b/packages/core/src/player/contracts/_utils/activity-data-mappers.test.ts
@@ -13,7 +13,7 @@ function makeLessonWord(overrides: Record<string, unknown> = {}) {
     translation: "translation",
     word: {
       audioUrl: null,
-      id: 1n,
+      id: "1",
       pronunciations: [],
       romanization: null,
       word: "word",
@@ -28,7 +28,7 @@ function makeLessonSentence(overrides: Record<string, unknown> = {}) {
     explanation: null,
     sentence: {
       audioUrl: null,
-      id: 1n,
+      id: "1",
       romanization: null,
       sentence: "sentence",
     },
@@ -46,7 +46,7 @@ describe(toLessonWordInputs, () => {
         translation: "good evening",
         word: {
           audioUrl: "/audio/boa-noite.mp3",
-          id: 1n,
+          id: "1",
           pronunciations: [{ pronunciation: "boa noite" }],
           romanization: null,
           word: "boa noite",
@@ -58,7 +58,7 @@ describe(toLessonWordInputs, () => {
       {
         audioUrl: "/audio/boa-noite.mp3",
         distractors: ["boa tarde"],
-        id: 1n,
+        id: "1",
         pronunciation: "boa noite",
         romanization: null,
         translation: "good evening",
@@ -76,7 +76,7 @@ describe(toLessonSentenceInputs, () => {
         explanation: "Greeting sentence",
         sentence: {
           audioUrl: "/audio/sentence.mp3",
-          id: 2n,
+          id: "2",
           romanization: null,
           sentence: "Guten Morgen",
         },
@@ -90,7 +90,7 @@ describe(toLessonSentenceInputs, () => {
         audioUrl: "/audio/sentence.mp3",
         distractors: ["abend"],
         explanation: "Greeting sentence",
-        id: 2n,
+        id: "2",
         romanization: null,
         sentence: "Guten Morgen",
         translation: "Good morning",
@@ -107,7 +107,7 @@ describe(toSentenceWordInputs, () => {
         translation: "cat",
         word: {
           audioUrl: null,
-          id: 3n,
+          id: "3",
           pronunciations: [{ pronunciation: "katze" }],
           romanization: null,
           word: "Katze",
@@ -128,7 +128,7 @@ describe(toDistractorWordInputs, () => {
     const result = toDistractorWordInputs([
       {
         audioUrl: "/audio/abend.mp3",
-        id: 4n,
+        id: "4",
         pronunciations: [{ pronunciation: "abend" }],
         romanization: null,
         word: "Abend",
@@ -138,7 +138,7 @@ describe(toDistractorWordInputs, () => {
     expect(result).toEqual([
       {
         audioUrl: "/audio/abend.mp3",
-        id: 4n,
+        id: "4",
         pronunciation: "abend",
         romanization: null,
         word: "Abend",
@@ -153,25 +153,25 @@ describe(attachTranslationsToSteps, () => {
       [
         {
           content: {},
-          id: 1n,
+          id: "1",
           kind: "translation",
           position: 0,
           sentence: null,
           word: {
             audioUrl: "/audio/boa-noite.mp3",
-            id: 1n,
+            id: "1",
             romanization: null,
             word: "boa noite",
           },
         },
         {
           content: {},
-          id: 2n,
+          id: "2",
           kind: "reading",
           position: 1,
           sentence: {
             audioUrl: "/audio/sentence.mp3",
-            id: 2n,
+            id: "2",
             romanization: null,
             sentence: "Guten Morgen",
           },
@@ -184,7 +184,7 @@ describe(attachTranslationsToSteps, () => {
           translation: "good evening",
           word: {
             audioUrl: "/audio/boa-noite.mp3",
-            id: 1n,
+            id: "1",
             pronunciations: [{ pronunciation: "boa noite" }],
             romanization: null,
             word: "boa noite",
@@ -197,7 +197,7 @@ describe(attachTranslationsToSteps, () => {
           explanation: "Greeting sentence",
           sentence: {
             audioUrl: "/audio/sentence.mp3",
-            id: 2n,
+            id: "2",
             romanization: null,
             sentence: "Guten Morgen",
           },
@@ -210,14 +210,14 @@ describe(attachTranslationsToSteps, () => {
     expect(result).toEqual([
       {
         content: {},
-        id: 1n,
+        id: "1",
         kind: "translation",
         position: 0,
         sentence: null,
         word: {
           audioUrl: "/audio/boa-noite.mp3",
           distractors: ["boa tarde"],
-          id: 1n,
+          id: "1",
           pronunciation: "boa noite",
           romanization: null,
           translation: "good evening",
@@ -226,14 +226,14 @@ describe(attachTranslationsToSteps, () => {
       },
       {
         content: {},
-        id: 2n,
+        id: "2",
         kind: "reading",
         position: 1,
         sentence: {
           audioUrl: "/audio/sentence.mp3",
           distractors: ["abend"],
           explanation: "Greeting sentence",
-          id: 2n,
+          id: "2",
           romanization: null,
           sentence: "Guten Morgen",
           translation: "Good morning",
@@ -249,25 +249,25 @@ describe(attachTranslationsToSteps, () => {
       [
         {
           content: {},
-          id: 1n,
+          id: "1",
           kind: "translation",
           position: 0,
           sentence: null,
           word: {
             audioUrl: null,
-            id: 1n,
+            id: "1",
             romanization: null,
             word: "hola",
           },
         },
         {
           content: {},
-          id: 2n,
+          id: "2",
           kind: "reading",
           position: 1,
           sentence: {
             audioUrl: null,
-            id: 2n,
+            id: "2",
             romanization: null,
             sentence: "hola mundo",
           },
@@ -281,14 +281,14 @@ describe(attachTranslationsToSteps, () => {
     expect(result).toEqual([
       {
         content: {},
-        id: 1n,
+        id: "1",
         kind: "translation",
         position: 0,
         sentence: null,
         word: {
           audioUrl: null,
           distractors: [],
-          id: 1n,
+          id: "1",
           pronunciation: null,
           romanization: null,
           translation: "",
@@ -297,14 +297,14 @@ describe(attachTranslationsToSteps, () => {
       },
       {
         content: {},
-        id: 2n,
+        id: "2",
         kind: "reading",
         position: 1,
         sentence: {
           audioUrl: null,
           distractors: [],
           explanation: null,
-          id: 2n,
+          id: "2",
           romanization: null,
           sentence: "hola mundo",
           translation: "",

--- a/packages/core/src/player/contracts/_utils/activity-data-mappers.ts
+++ b/packages/core/src/player/contracts/_utils/activity-data-mappers.ts
@@ -3,7 +3,7 @@ export type ActivityPronunciationInput = {
 };
 
 export type ActivityWordInput = {
-  id: bigint;
+  id: string;
   word: string;
   romanization: string | null;
   audioUrl: string | null;
@@ -11,7 +11,7 @@ export type ActivityWordInput = {
 };
 
 export type ActivitySentenceInput = {
-  id: bigint;
+  id: string;
   sentence: string;
   romanization: string | null;
   audioUrl: string | null;
@@ -34,7 +34,7 @@ export type LessonSentenceInput = {
 export type ActivityDistractorWordInput = ActivityWordInput;
 
 export type WordDataInput = {
-  id: bigint;
+  id: string;
   word: string;
   romanization: string | null;
   audioUrl: string | null;
@@ -44,7 +44,7 @@ export type WordDataInput = {
 };
 
 export type SentenceDataInput = {
-  id: bigint;
+  id: string;
   sentence: string;
   distractors: string[];
   romanization: string | null;
@@ -55,7 +55,7 @@ export type SentenceDataInput = {
 };
 
 export type DistractorWordDataInput = {
-  id: bigint;
+  id: string;
   word: string;
   romanization: string | null;
   audioUrl: string | null;
@@ -63,7 +63,7 @@ export type DistractorWordDataInput = {
 };
 
 export type StepDataInput = {
-  id: bigint;
+  id: string;
   content: unknown;
   kind: string;
   position: number;
@@ -72,7 +72,7 @@ export type StepDataInput = {
 };
 
 export type ActivityStepInput = {
-  id: bigint;
+  id: string;
   content: unknown;
   kind: string;
   position: number;
@@ -202,7 +202,7 @@ export function attachTranslationsToSteps(
  */
 function mergeWordWithTranslation(
   word: Omit<ActivityWordInput, "pronunciations">,
-  wordMap: Map<bigint, LessonWordInput>,
+  wordMap: Map<string, LessonWordInput>,
 ): WordDataInput {
   const lessonWord = wordMap.get(word.id);
 
@@ -222,7 +222,7 @@ function mergeWordWithTranslation(
  */
 function mergeSentenceWithTranslation(
   sentence: ActivitySentenceInput,
-  sentenceMap: Map<bigint, LessonSentenceInput>,
+  sentenceMap: Map<string, LessonSentenceInput>,
 ): SentenceDataInput {
   const lessonSentence = sentenceMap.get(sentence.id);
 

--- a/packages/core/src/player/contracts/build-investigation-action-results.test.ts
+++ b/packages/core/src/player/contracts/build-investigation-action-results.test.ts
@@ -24,7 +24,7 @@ describe(buildInvestigationActionResults, () => {
         actionTimings: [baseTiming, baseTiming],
         usedActionIds: ["a1", "a3"],
       },
-      steps: [{ content: actionContent, id: 100n, kind: "investigation" }],
+      steps: [{ content: actionContent, id: "100", kind: "investigation" }],
     });
 
     expect(results).toHaveLength(2);
@@ -38,10 +38,10 @@ describe(buildInvestigationActionResults, () => {
         actionTimings: [baseTiming, baseTiming],
         usedActionIds: ["a1", "a2"],
       },
-      steps: [{ content: actionContent, id: 42n, kind: "investigation" }],
+      steps: [{ content: actionContent, id: "42", kind: "investigation" }],
     });
 
-    expect(results.every((result) => result.stepId === 42n)).toBe(true);
+    expect(results.every((result) => result.stepId === "42")).toBe(true);
   });
 
   test("uses per-experiment timing from actionTimings", () => {
@@ -55,7 +55,7 @@ describe(buildInvestigationActionResults, () => {
         actionTimings: timings,
         usedActionIds: ["a1", "a2"],
       },
-      steps: [{ content: actionContent, id: 1n, kind: "investigation" }],
+      steps: [{ content: actionContent, id: "1", kind: "investigation" }],
     });
 
     expect(results[0]?.durationSeconds).toBe(5);
@@ -68,7 +68,7 @@ describe(buildInvestigationActionResults, () => {
         actionTimings: [baseTiming, baseTiming],
         usedActionIds: ["a3", "a1"],
       },
-      steps: [{ content: actionContent, id: 1n, kind: "investigation" }],
+      steps: [{ content: actionContent, id: "1", kind: "investigation" }],
     });
 
     expect(results[0]?.answer).toEqual({
@@ -86,7 +86,7 @@ describe(buildInvestigationActionResults, () => {
   test("returns empty array when investigationLoop is undefined", () => {
     const results = buildInvestigationActionResults({
       investigationLoop: undefined,
-      steps: [{ content: actionContent, id: 1n, kind: "investigation" }],
+      steps: [{ content: actionContent, id: "1", kind: "investigation" }],
     });
 
     expect(results).toEqual([]);
@@ -101,7 +101,7 @@ describe(buildInvestigationActionResults, () => {
       steps: [
         {
           content: { scenario: "A mystery", variant: "problem" as const },
-          id: 1n,
+          id: "1",
           kind: "investigation",
         },
       ],
@@ -116,7 +116,7 @@ describe(buildInvestigationActionResults, () => {
         actionTimings: [baseTiming], // Only 1 timing
         usedActionIds: ["a1", "a2", "a3"], // 3 IDs
       },
-      steps: [{ content: actionContent, id: 1n, kind: "investigation" }],
+      steps: [{ content: actionContent, id: "1", kind: "investigation" }],
     });
 
     expect(results).toHaveLength(1);
@@ -129,7 +129,7 @@ describe(buildInvestigationActionResults, () => {
         actionTimings: [],
         usedActionIds: [],
       },
-      steps: [{ content: actionContent, id: 1n, kind: "investigation" }],
+      steps: [{ content: actionContent, id: "1", kind: "investigation" }],
     });
 
     expect(results).toEqual([]);

--- a/packages/core/src/player/contracts/build-investigation-action-results.ts
+++ b/packages/core/src/player/contracts/build-investigation-action-results.ts
@@ -8,7 +8,7 @@ type ActionStepResult = {
   durationSeconds: number;
   hourOfDay: number;
   isCorrect: boolean;
-  stepId: bigint;
+  stepId: string;
 };
 
 /**
@@ -27,7 +27,7 @@ export function buildInvestigationActionResults({
   steps,
 }: {
   investigationLoop: InvestigationLoopState | undefined;
-  steps: { id: bigint; kind: string; content: unknown }[];
+  steps: { id: string; kind: string; content: unknown }[];
 }): ActionStepResult[] {
   if (!investigationLoop) {
     return [];

--- a/packages/core/src/player/contracts/prepare-activity-data.test.ts
+++ b/packages/core/src/player/contracts/prepare-activity-data.test.ts
@@ -18,7 +18,7 @@ type DistractorWord = NonNullable<PrepareLessonActivityInput["distractorWords"]>
 function makeWordRecord(overrides: Partial<LessonWord["word"]> = {}): LessonWord["word"] {
   return {
     audioUrl: null,
-    id: 1n,
+    id: "1",
     pronunciations: [],
     romanization: null,
     word: "word",
@@ -31,7 +31,7 @@ function makeSentenceRecord(
 ): LessonSentence["sentence"] {
   return {
     audioUrl: null,
-    id: 1n,
+    id: "1",
     romanization: null,
     sentence: "sentence",
     ...overrides,
@@ -41,7 +41,7 @@ function makeSentenceRecord(
 function makeStepWord(overrides: Partial<RawStepWord> = {}): RawStepWord {
   return {
     audioUrl: null,
-    id: 1n,
+    id: "1",
     romanization: null,
     word: "word",
     ...overrides,
@@ -51,7 +51,7 @@ function makeStepWord(overrides: Partial<RawStepWord> = {}): RawStepWord {
 function makeStepSentence(overrides: Partial<RawStepSentence> = {}): RawStepSentence {
   return {
     audioUrl: null,
-    id: 1n,
+    id: "1",
     romanization: null,
     sentence: "sentence",
     ...overrides,
@@ -96,7 +96,7 @@ function makeSentenceWord(overrides: Partial<SentenceWord> = {}): SentenceWord {
 function makeDistractorWord(overrides: Partial<DistractorWord> = {}): DistractorWord {
   return {
     audioUrl: null,
-    id: 1n,
+    id: "1",
     pronunciations: [],
     romanization: null,
     word: "word",
@@ -107,7 +107,7 @@ function makeDistractorWord(overrides: Partial<DistractorWord> = {}): Distractor
 function makeStep(overrides: Partial<RawStep> = {}): RawStep {
   return {
     content: {},
-    id: 1n,
+    id: "1",
     kind: "static",
     position: 0,
     sentence: null,
@@ -119,7 +119,7 @@ function makeStep(overrides: Partial<RawStep> = {}): RawStep {
 function makeActivity(steps: RawStep[], overrides: Partial<ActivityInput> = {}): ActivityInput {
   return {
     description: null,
-    id: 1n,
+    id: "1",
     kind: "quiz",
     language: "en",
     organizationId: "org-1",
@@ -147,10 +147,10 @@ describe(prepareLessonActivityData, () => {
         [
           makeStep({
             content: { text: "Hello world", title: "Intro", variant: "text" },
-            id: 42n,
+            id: "42",
           }),
         ],
-        { id: 99n },
+        { id: "99" },
       ),
     });
 
@@ -164,7 +164,7 @@ describe(prepareLessonActivityData, () => {
       translation: "good evening",
       word: makeWordRecord({
         audioUrl: "/audio/boa-noite.mp3",
-        id: 10n,
+        id: "10",
         pronunciations: [{ pronunciation: "boa noite" }],
         word: "boa noite",
       }),
@@ -174,7 +174,7 @@ describe(prepareLessonActivityData, () => {
       explanation: "Greeting",
       sentence: makeSentenceRecord({
         audioUrl: "/audio/guten-morgen.mp3",
-        id: 20n,
+        id: "20",
         romanization: "guten morgen",
         sentence: "Guten Morgen",
       }),
@@ -187,7 +187,7 @@ describe(prepareLessonActivityData, () => {
         [makeStep({ content: { text: "Hello world", title: "Intro", variant: "text" } })],
         {
           description: "Description",
-          id: 99n,
+          id: "99",
           kind: "review",
           organizationId: "org-42",
         },
@@ -235,7 +235,7 @@ describe(prepareLessonActivityData, () => {
           content: { text: "Hello world", title: "Intro", variant: "text" },
           kind: "static",
         }),
-        makeStep({ id: 2n, kind: "not-supported" }),
+        makeStep({ id: "2", kind: "not-supported" }),
       ]),
     });
 
@@ -256,7 +256,7 @@ describe(prepareLessonActivityData, () => {
             items: ["first", "second", "third"],
             question: "Sort these",
           },
-          id: 1n,
+          id: "1",
           kind: "sortOrder",
         }),
         makeStep({
@@ -267,7 +267,7 @@ describe(prepareLessonActivityData, () => {
             romanizations: { ground: "ground-rom" },
             template: "The ___ is blue",
           },
-          id: 2n,
+          id: "2",
           kind: "fillBlank",
         }),
         makeStep({
@@ -278,7 +278,7 @@ describe(prepareLessonActivityData, () => {
             ],
             question: "Match the pairs",
           },
-          id: 3n,
+          id: "3",
           kind: "matchColumns",
         }),
       ]),
@@ -306,11 +306,11 @@ describe(prepareLessonActivityData, () => {
     const word = makeLessonWord({
       distractors: ["boa tarde", "bom dia"],
       translation: "good evening",
-      word: makeWordRecord({ id: 10n, word: "boa noite" }),
+      word: makeWordRecord({ id: "10", word: "boa noite" }),
     });
     const sentence = makeLessonSentence({
       distractors: ["Abend", "Fenster"],
-      sentence: makeSentenceRecord({ id: 20n, sentence: "Guten Morgen, Lara." }),
+      sentence: makeSentenceRecord({ id: "20", sentence: "Guten Morgen, Lara." }),
       translation: "Bom dia, Lara.",
       translationDistractors: ["tchau", "logo"],
     });
@@ -318,14 +318,14 @@ describe(prepareLessonActivityData, () => {
     const result = prepare({
       activity: makeActivity([
         makeStep({
-          id: 11n,
+          id: "11",
           kind: "translation",
-          word: makeStepWord({ id: 10n, word: "boa noite" }),
+          word: makeStepWord({ id: "10", word: "boa noite" }),
         }),
         makeStep({
-          id: 12n,
+          id: "12",
           kind: "reading",
-          sentence: makeStepSentence({ id: 20n, sentence: "Guten Morgen, Lara." }),
+          sentence: makeStepSentence({ id: "20", sentence: "Guten Morgen, Lara." }),
         }),
       ]),
       lessonSentences: [sentence],
@@ -344,7 +344,7 @@ describe(prepareLessonActivityData, () => {
       distractors: ["boa tarde", "bom dia", "até logo"],
       translation: "good evening",
       word: makeWordRecord({
-        id: 10n,
+        id: "10",
         pronunciations: [{ pronunciation: "boa noite" }],
         word: "boa noite",
       }),
@@ -353,21 +353,21 @@ describe(prepareLessonActivityData, () => {
     const result = prepare({
       activity: makeActivity([
         makeStep({
-          id: 11n,
+          id: "11",
           kind: "translation",
-          word: makeStepWord({ id: 10n, word: "boa noite" }),
+          word: makeStepWord({ id: "10", word: "boa noite" }),
         }),
       ]),
       distractorWords: [
         makeDistractorWord({
           audioUrl: "/audio/boa-tarde.mp3",
-          id: 101n,
+          id: "101",
           pronunciations: [{ pronunciation: "boa tarde" }],
           word: "boa tarde",
         }),
         makeDistractorWord({
           audioUrl: "/audio/bom-dia.mp3",
-          id: 102n,
+          id: "102",
           pronunciations: [{ pronunciation: "bom dia" }],
           word: "bom dia",
         }),
@@ -410,10 +410,10 @@ describe(prepareLessonActivityData, () => {
   test("drops supported steps whose content does not match the content contract", () => {
     const result = prepare({
       activity: makeActivity([
-        makeStep({ content: {}, id: 1n, kind: "static" }),
+        makeStep({ content: {}, id: "1", kind: "static" }),
         makeStep({
           content: { text: "Hello world", title: "Intro", variant: "text" },
-          id: 2n,
+          id: "2",
           kind: "static",
         }),
       ]),
@@ -435,7 +435,7 @@ describe(prepareLessonActivityData, () => {
             ],
             question: "Pick one",
           },
-          id: 30n,
+          id: "30",
           kind: "multipleChoice",
         }),
       ]),
@@ -454,7 +454,7 @@ describe(prepareLessonActivityData, () => {
   test("builds reading and listening word banks from stored distractors only", () => {
     const sentence = makeLessonSentence({
       distractors: ["Abend", "Fenster", "Guten Tag"],
-      sentence: makeSentenceRecord({ id: 20n, sentence: "Guten Morgen, Lara." }),
+      sentence: makeSentenceRecord({ id: "20", sentence: "Guten Morgen, Lara." }),
       translation: "Bom dia, Lara.",
       translationDistractors: ["tchau", "boa noite"],
     });
@@ -462,20 +462,20 @@ describe(prepareLessonActivityData, () => {
     const result = prepare({
       activity: makeActivity([
         makeStep({
-          id: 12n,
+          id: "12",
           kind: "reading",
-          sentence: makeStepSentence({ id: 20n, sentence: "Guten Morgen, Lara." }),
+          sentence: makeStepSentence({ id: "20", sentence: "Guten Morgen, Lara." }),
         }),
         makeStep({
-          id: 13n,
+          id: "13",
           kind: "listening",
-          sentence: makeStepSentence({ id: 20n, sentence: "Guten Morgen, Lara." }),
+          sentence: makeStepSentence({ id: "20", sentence: "Guten Morgen, Lara." }),
         }),
       ]),
       distractorWords: [
         makeDistractorWord({
           audioUrl: "/audio/abend.mp3",
-          id: 201n,
+          id: "201",
           pronunciations: [{ pronunciation: "abend" }],
           romanization: "abend",
           word: "Abend",
@@ -547,16 +547,16 @@ describe(prepareLessonActivityData, () => {
 
   test("populates sentenceWordOptions from canonical sentence tokens", () => {
     const sentence = makeLessonSentence({
-      sentence: makeSentenceRecord({ id: 20n, sentence: "Guten Morgen" }),
+      sentence: makeSentenceRecord({ id: "20", sentence: "Guten Morgen" }),
       translation: "Good morning",
     });
 
     const result = prepare({
       activity: makeActivity([
         makeStep({
-          id: 12n,
+          id: "12",
           kind: "reading",
-          sentence: makeStepSentence({ id: 20n, sentence: "Guten Morgen" }),
+          sentence: makeStepSentence({ id: "20", sentence: "Guten Morgen" }),
         }),
       ]),
       lessonSentences: [sentence],
@@ -564,7 +564,7 @@ describe(prepareLessonActivityData, () => {
         makeLessonWord({
           translation: "good morning",
           word: makeWordRecord({
-            id: 10n,
+            id: "10",
             romanization: "guten morgen",
             word: "Guten Morgen",
           }),
@@ -590,16 +590,16 @@ describe(prepareLessonActivityData, () => {
 
   test("keeps sentence word metadata from sentence words when available", () => {
     const sentence = makeLessonSentence({
-      sentence: makeSentenceRecord({ id: 20n, sentence: "gato bonito" }),
+      sentence: makeSentenceRecord({ id: "20", sentence: "gato bonito" }),
       translation: "pretty cat",
     });
 
     const result = prepare({
       activity: makeActivity([
         makeStep({
-          id: 40n,
+          id: "40",
           kind: "reading",
-          sentence: makeStepSentence({ id: 20n, sentence: "gato bonito" }),
+          sentence: makeStepSentence({ id: "20", sentence: "gato bonito" }),
         }),
       ]),
       lessonSentences: [sentence],
@@ -608,7 +608,7 @@ describe(prepareLessonActivityData, () => {
           translation: "cat (lesson)",
           word: makeWordRecord({
             audioUrl: "/audio/lesson-gato.mp3",
-            id: 10n,
+            id: "10",
             word: "gato",
           }),
         }),
@@ -618,7 +618,7 @@ describe(prepareLessonActivityData, () => {
           translation: "cat (sentence)",
           word: makeWordRecord({
             audioUrl: "/audio/sentence-gato.mp3",
-            id: 11n,
+            id: "11",
             romanization: "ga-to",
             word: "gato",
           }),
@@ -679,16 +679,16 @@ describe(prepareLessonActivityData, () => {
   test("allows sanitation underflow without fallback top-up", () => {
     const sentence = makeLessonSentence({
       distractors: ["Hola", "Buenos dias"],
-      sentence: makeSentenceRecord({ id: 20n, sentence: "Hola mundo" }),
+      sentence: makeSentenceRecord({ id: "20", sentence: "Hola mundo" }),
       translation: "Hello world",
     });
 
     const result = prepare({
       activity: makeActivity([
         makeStep({
-          id: 12n,
+          id: "12",
           kind: "reading",
-          sentence: makeStepSentence({ id: 20n, sentence: "Hola mundo" }),
+          sentence: makeStepSentence({ id: "20", sentence: "Hola mundo" }),
         }),
       ]),
       lessonSentences: [sentence],
@@ -716,16 +716,16 @@ describe(prepareLessonActivityData, () => {
         [
           makeStep({
             content: { text: "from activity", title: "Ignored", variant: "text" },
-            id: 10n,
+            id: "10",
             kind: "static",
           }),
         ],
-        { id: 99n },
+        { id: "99" },
       ),
       steps: [
         makeStep({
           content: { text: "from override", title: "Used", variant: "text" },
-          id: 11n,
+          id: "11",
           kind: "static",
         }),
       ],

--- a/packages/core/src/player/contracts/prepare-activity-data.ts
+++ b/packages/core/src/player/contracts/prepare-activity-data.ts
@@ -91,7 +91,7 @@ export type SerializedActivity = {
 
 type PrepareLessonActivitySource = {
   description: string | null;
-  id: bigint;
+  id: string;
   kind: ActivityKind;
   language: string;
   organizationId: string | null;
@@ -110,13 +110,13 @@ type PrepareLessonActivityInput = {
 
 /**
  * Canonical lesson words travel through the player with lesson-scoped translations and
- * distractor arrays. This serializer converts bigint IDs and copies arrays defensively.
+ * distractor arrays. This serializer keeps string IDs stable and copies arrays defensively.
  */
 function serializeWord(word: WordDataInput): SerializedWord {
   return {
     audioUrl: word.audioUrl,
     distractors: [...word.distractors],
-    id: String(word.id),
+    id: word.id,
     pronunciation: word.pronunciation,
     romanization: word.romanization,
     translation: word.translation,
@@ -141,7 +141,7 @@ function serializeSentence(sentence: SentenceDataInput): SerializedSentence {
     audioUrl: sentence.audioUrl,
     distractors: [...sentence.distractors],
     explanation: sentence.explanation,
-    id: String(sentence.id),
+    id: sentence.id,
     romanization: sentence.romanization,
     sentence: sentence.sentence,
     translation: sentence.translation,
@@ -233,7 +233,7 @@ function serializeStep(step: StepDataInput): SerializedStep | null {
     return {
       content,
       fillBlankOptions: [],
-      id: String(step.id),
+      id: step.id,
       kind: step.kind,
       matchColumnsRightItems: [],
       position: step.position,
@@ -252,7 +252,7 @@ function serializeStep(step: StepDataInput): SerializedStep | null {
 
 function prepareActivityData(
   activity: {
-    id: bigint;
+    id: string;
     kind: ActivityKind;
     title: string | null;
     description: string | null;
@@ -312,7 +312,7 @@ function prepareActivityData(
 
   return {
     description: activity.description,
-    id: String(activity.id),
+    id: activity.id,
     kind: activity.kind,
     language: activity.language,
     lessonSentences: serializedLessonSentences,
@@ -326,7 +326,7 @@ function prepareActivityData(
 /**
  * The app should only fetch the raw lesson activity inputs. This helper keeps the entire
  * preparation pipeline inside the shared player contract so apps do not need to know about
- * serialization, shuffling, or derived option building.
+ * serialization, shuffling, or derived option building after ids were standardized to UUIDs.
  */
 export function prepareLessonActivityData(params: PrepareLessonActivityInput): SerializedActivity {
   const steps = params.steps ?? params.activity.steps;

--- a/packages/core/src/player/contracts/translation-options.ts
+++ b/packages/core/src/player/contracts/translation-options.ts
@@ -32,7 +32,7 @@ type TranslationSourceWord = {
  * Direct distractor words do not need lesson translations, only render metadata.
  */
 export function serializeDistractorWord(word: {
-  id: bigint;
+  id: string;
   word: string;
   pronunciation: string | null;
   romanization: string | null;
@@ -40,7 +40,7 @@ export function serializeDistractorWord(word: {
 }): DistractorWord {
   return {
     audioUrl: word.audioUrl,
-    id: String(word.id),
+    id: word.id,
     pronunciation: word.pronunciation,
     romanization: word.romanization,
     word: word.word,

--- a/packages/core/src/player/contracts/validate-answers.test.ts
+++ b/packages/core/src/player/contracts/validate-answers.test.ts
@@ -18,7 +18,7 @@ const fillBlankContent = {
 
 describe(validateAnswers, () => {
   test("validates correct multipleChoice answer server-side", () => {
-    const steps = [{ content: coreMultipleChoiceContent, id: 1n, kind: "multipleChoice" }];
+    const steps = [{ content: coreMultipleChoiceContent, id: "1", kind: "multipleChoice" }];
 
     const results = validateAnswers(steps, {
       "1": { kind: "multipleChoice", selectedIndex: 0, selectedText: "Option A" },
@@ -26,11 +26,11 @@ describe(validateAnswers, () => {
 
     expect(results).toHaveLength(1);
     expect(results[0]?.isCorrect).toBe(true);
-    expect(results[0]?.stepId).toBe(1n);
+    expect(results[0]?.stepId).toBe("1");
   });
 
   test("validates incorrect multipleChoice answer", () => {
-    const steps = [{ content: coreMultipleChoiceContent, id: 1n, kind: "multipleChoice" }];
+    const steps = [{ content: coreMultipleChoiceContent, id: "1", kind: "multipleChoice" }];
 
     const results = validateAnswers(steps, {
       "1": { kind: "multipleChoice", selectedIndex: 1, selectedText: "Option B" },
@@ -41,7 +41,7 @@ describe(validateAnswers, () => {
   });
 
   test("validates fillBlank answer", () => {
-    const steps = [{ content: fillBlankContent, id: 2n, kind: "fillBlank" }];
+    const steps = [{ content: fillBlankContent, id: "2", kind: "fillBlank" }];
 
     const results = validateAnswers(steps, {
       "2": { kind: "fillBlank", userAnswers: ["dog"] },
@@ -53,8 +53,8 @@ describe(validateAnswers, () => {
 
   test("skips steps with no client answer", () => {
     const steps = [
-      { content: coreMultipleChoiceContent, id: 1n, kind: "multipleChoice" },
-      { content: { text: "Hello", title: "Intro", variant: "text" }, id: 2n, kind: "static" },
+      { content: coreMultipleChoiceContent, id: "1", kind: "multipleChoice" },
+      { content: { text: "Hello", title: "Intro", variant: "text" }, id: "2", kind: "static" },
     ];
 
     const results = validateAnswers(steps, {
@@ -62,16 +62,16 @@ describe(validateAnswers, () => {
     });
 
     expect(results).toHaveLength(1);
-    expect(results[0]?.stepId).toBe(1n);
+    expect(results[0]?.stepId).toBe("1");
   });
 
   test("validates translation answer against word ID", () => {
     const steps = [
       {
         content: {},
-        id: 4n,
+        id: "4",
         kind: "translation",
-        word: { id: 100n },
+        word: { id: "100" },
       },
     ];
 
@@ -92,9 +92,9 @@ describe(validateAnswers, () => {
     const steps = [
       {
         content: {},
-        id: 4n,
+        id: "4",
         kind: "translation",
-        word: { id: 100n },
+        word: { id: "100" },
       },
     ];
 
@@ -115,11 +115,11 @@ describe(validateAnswers, () => {
     const steps = [
       {
         content: {},
-        id: 5n,
+        id: "5",
         kind: "reading",
         sentence: {
           distractors: [],
-          id: 1n,
+          id: "1",
           sentence: "hello world",
           translation: "olá mundo",
           translationDistractors: [],
@@ -139,11 +139,11 @@ describe(validateAnswers, () => {
     const steps = [
       {
         content: {},
-        id: 6n,
+        id: "6",
         kind: "listening",
         sentence: {
           distractors: [],
-          id: 1n,
+          id: "1",
           sentence: "hello world",
           translation: "olá mundo",
           translationDistractors: [],
@@ -163,11 +163,11 @@ describe(validateAnswers, () => {
     const steps = [
       {
         content: {},
-        id: 7n,
+        id: "7",
         kind: "reading",
         sentence: {
           distractors: ["morgen"],
-          id: 1n,
+          id: "1",
           sentence: "guten tag lara",
           translation: "bom dia lara",
           translationDistractors: [],
@@ -187,11 +187,11 @@ describe(validateAnswers, () => {
     const steps = [
       {
         content: {},
-        id: 10n,
+        id: "10",
         kind: "listening",
         sentence: {
           distractors: [],
-          id: 1n,
+          id: "1",
           sentence: "guten tag lara",
           translation: "boa tarde lara",
           translationDistractors: ["bom"],
@@ -211,11 +211,11 @@ describe(validateAnswers, () => {
     const steps = [
       {
         content: {},
-        id: 8n,
+        id: "8",
         kind: "listening",
         sentence: {
           distractors: [],
-          id: 1n,
+          id: "1",
           sentence: "hello lara",
           translation: "bom dia, lara!",
           translationDistractors: [],
@@ -252,7 +252,7 @@ describe(validateAnswers, () => {
       situation: "You face a decision.",
     };
 
-    const steps = [{ content: storyContent, id: 8n, kind: "story" }];
+    const steps = [{ content: storyContent, id: "8", kind: "story" }];
 
     const results = validateAnswers(steps, {
       "8": { kind: "story", selectedChoiceId: "1a", selectedText: "Do the right thing" },
@@ -283,7 +283,7 @@ describe(validateAnswers, () => {
       situation: "You face a decision.",
     };
 
-    const steps = [{ content: storyContent, id: 8n, kind: "story" }];
+    const steps = [{ content: storyContent, id: "8", kind: "story" }];
 
     const results = validateAnswers(steps, {
       "8": { kind: "story", selectedChoiceId: "1b", selectedText: "Do the wrong thing" },
@@ -314,7 +314,7 @@ describe(validateAnswers, () => {
       situation: "You face a decision.",
     };
 
-    const steps = [{ content: storyContent, id: 9n, kind: "story" }];
+    const steps = [{ content: storyContent, id: "9", kind: "story" }];
 
     const results = validateAnswers(steps, {
       "9": { kind: "multipleChoice", selectedIndex: 0, selectedText: "Option A" },
@@ -324,7 +324,7 @@ describe(validateAnswers, () => {
   });
 
   test("skips unsupported step kinds", () => {
-    const steps = [{ content: {}, id: 7n, kind: "unknownKind" }];
+    const steps = [{ content: {}, id: "7", kind: "unknownKind" }];
 
     const results = validateAnswers(steps, {
       "7": { kind: "multipleChoice", selectedIndex: 0, selectedText: "Option A" },
@@ -340,7 +340,7 @@ describe(validateAnswers, () => {
           scenario: "test",
           variant: "problem",
         },
-        id: 10n,
+        id: "10",
         kind: "investigation",
       },
     ];
@@ -368,7 +368,7 @@ describe(validateAnswers, () => {
           ],
           variant: "action",
         },
-        id: 11n,
+        id: "11",
         kind: "investigation",
       },
     ];
@@ -394,7 +394,7 @@ describe(validateAnswers, () => {
           ],
           variant: "call",
         },
-        id: 14n,
+        id: "14",
         kind: "investigation",
       },
     ];
@@ -417,7 +417,7 @@ describe(validateAnswers, () => {
           ],
           variant: "call",
         },
-        id: 15n,
+        id: "15",
         kind: "investigation",
       },
     ];
@@ -431,7 +431,7 @@ describe(validateAnswers, () => {
   });
 
   test("skips malformed unanswered static steps instead of throwing", () => {
-    const steps = [{ content: { text: "Legacy static step" }, id: 16n, kind: "static" }];
+    const steps = [{ content: { text: "Legacy static step" }, id: "16", kind: "static" }];
 
     const runValidation = () => validateAnswers(steps, {});
 
@@ -443,7 +443,7 @@ describe(validateAnswers, () => {
     const steps = [
       {
         content: { scenario: "Legacy investigation step" },
-        id: 17n,
+        id: "17",
         kind: "investigation",
       },
     ];

--- a/packages/core/src/player/contracts/validate-answers.ts
+++ b/packages/core/src/player/contracts/validate-answers.ts
@@ -20,12 +20,12 @@ import { type SelectedAnswer } from "./completion-input-schema";
  * by listening validation.
  */
 type StepData = {
-  id: bigint;
+  id: string;
   kind: string;
   content: unknown;
-  word?: { id: bigint } | null;
+  word?: { id: string } | null;
   sentence?: {
-    id: bigint;
+    id: string;
     sentence: string;
     translation: string;
   } | null;
@@ -34,7 +34,7 @@ type StepData = {
 type ValidatedStepResult = {
   answer: object;
   isCorrect: boolean;
-  stepId: bigint;
+  stepId: string;
 };
 
 type ServerValidationBehavior =
@@ -154,7 +154,7 @@ function validateTranslation(step: StepData, answer: SelectedAnswer): ValidatedS
     return null;
   }
 
-  const result = checkTranslationAnswer(String(step.word.id), answer.selectedWordId);
+  const result = checkTranslationAnswer(step.word.id, answer.selectedWordId);
   return { answer, isCorrect: result.isCorrect, stepId: step.id };
 }
 
@@ -247,7 +247,7 @@ export function validateAnswers(
   clientAnswers: Record<string, SelectedAnswer>,
 ): ValidatedStepResult[] {
   return steps.flatMap((step) => {
-    const answer = clientAnswers[String(step.id)];
+    const answer = clientAnswers[step.id];
 
     if (!answer) {
       return [];

--- a/packages/core/src/player/queries/get-activity-distractor-words.ts
+++ b/packages/core/src/player/queries/get-activity-distractor-words.ts
@@ -5,7 +5,7 @@ import { cache } from "react";
 import { getLessonSentences } from "./get-lesson-sentences";
 import { getLessonWords } from "./get-lesson-words";
 
-const cachedGetActivityDistractorWords = cache(async (lessonId: number) => {
+const cachedGetActivityDistractorWords = cache(async (lessonId: string) => {
   const [lessonWords, lessonSentences] = await Promise.all([
     getLessonWords({ lessonId }),
     getLessonSentences({ lessonId }),
@@ -52,6 +52,6 @@ const cachedGetActivityDistractorWords = cache(async (lessonId: number) => {
  * matching `Word` records for that lesson's language pair. Listening-side
  * `translationDistractors` are intentionally ignored because they stay plain strings.
  */
-export function getActivityDistractorWords(params: { lessonId: number }) {
+export function getActivityDistractorWords(params: { lessonId: string }) {
   return cachedGetActivityDistractorWords(params.lessonId);
 }

--- a/packages/core/src/player/queries/get-activity.test.ts
+++ b/packages/core/src/player/queries/get-activity.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { prisma } from "@zoonk/db";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
@@ -118,7 +119,7 @@ describe(getActivity, () => {
   });
 
   test("returns null for non-existent lesson", async () => {
-    const result = await getActivity({ lessonId: 999_999, position: 0 });
+    const result = await getActivity({ lessonId: randomUUID(), position: 0 });
 
     expect(result).toBeNull();
   });

--- a/packages/core/src/player/queries/get-activity.ts
+++ b/packages/core/src/player/queries/get-activity.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { getPublishedActivityWhere, getPublishedStepWhere, prisma } from "@zoonk/db";
 import { cache } from "react";
 
-const cachedGetActivity = cache(async (lessonId: number, position: number) =>
+const cachedGetActivity = cache(async (lessonId: string, position: number) =>
   prisma.activity.findFirst({
     include: {
       steps: {
@@ -18,6 +18,6 @@ const cachedGetActivity = cache(async (lessonId: number, position: number) =>
   }),
 );
 
-export function getActivity(params: { lessonId: number; position: number }) {
+export function getActivity(params: { lessonId: string; position: number }) {
   return cachedGetActivity(params.lessonId, params.position);
 }

--- a/packages/core/src/player/queries/get-lesson-sentences.test.ts
+++ b/packages/core/src/player/queries/get-lesson-sentences.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
@@ -119,7 +120,7 @@ describe(getLessonSentences, () => {
   });
 
   test("returns empty array for non-existent lesson", async () => {
-    const result = await getLessonSentences({ lessonId: 999_999 });
+    const result = await getLessonSentences({ lessonId: randomUUID() });
     expect(result).toEqual([]);
   });
 });

--- a/packages/core/src/player/queries/get-lesson-sentences.ts
+++ b/packages/core/src/player/queries/get-lesson-sentences.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
-const cachedGetLessonSentences = cache(async (lessonId: number) =>
+const cachedGetLessonSentences = cache(async (lessonId: string) =>
   prisma.lessonSentence.findMany({
     include: { sentence: true },
     where: { lessonId },
@@ -13,6 +13,6 @@ const cachedGetLessonSentences = cache(async (lessonId: number) =>
  * Returns all `LessonSentence` records for a lesson, each including
  * the canonical sentence row used for audio and romanization.
  */
-export function getLessonSentences(params: { lessonId: number }) {
+export function getLessonSentences(params: { lessonId: string }) {
   return cachedGetLessonSentences(params.lessonId);
 }

--- a/packages/core/src/player/queries/get-lesson-words.test.ts
+++ b/packages/core/src/player/queries/get-lesson-words.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
@@ -130,7 +131,7 @@ describe(getLessonWords, () => {
   });
 
   test("returns empty array for non-existent lesson", async () => {
-    const result = await getLessonWords({ lessonId: 999_999 });
+    const result = await getLessonWords({ lessonId: randomUUID() });
     expect(result).toEqual([]);
   });
 

--- a/packages/core/src/player/queries/get-lesson-words.ts
+++ b/packages/core/src/player/queries/get-lesson-words.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
-const cachedGetLessonWords = cache(async (lessonId: number) => {
+const cachedGetLessonWords = cache(async (lessonId: string) => {
   const firstLesson = await prisma.lessonWord.findFirst({
     select: { userLanguage: true },
     where: { lessonId },
@@ -31,6 +31,6 @@ const cachedGetLessonWords = cache(async (lessonId: number) => {
  * separate `WordTranslation` table, so the caller gets translation +
  * word surface form in one object.
  */
-export function getLessonWords(params: { lessonId: number }) {
+export function getLessonWords(params: { lessonId: string }) {
   return cachedGetLessonWords(params.lessonId);
 }

--- a/packages/core/src/player/queries/get-next-lesson.test.ts
+++ b/packages/core/src/player/queries/get-next-lesson.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -8,18 +9,18 @@ import { getNextLesson } from "./get-next-lesson";
 
 describe(getNextLesson, () => {
   let orgId: string;
-  let courseId: number;
+  let courseId: string;
 
-  let chapter1Id: number;
-  let chapter2Id: number;
+  let chapter1Id: string;
+  let chapter2Id: string;
 
-  let lesson1Id: number;
-  let lesson2Id: number;
-  let lesson3Id: number;
+  let lesson1Id: string;
+  let lesson2Id: string;
+  let lesson3Id: string;
 
-  let activity1Id: bigint;
-  let activity2Id: bigint;
-  let activity3Id: bigint;
+  let activity1Id: string;
+  let activity2Id: string;
+  let activity3Id: string;
 
   beforeAll(async () => {
     const org = await organizationFixture({ kind: "brand" });
@@ -105,7 +106,7 @@ describe(getNextLesson, () => {
   });
 
   test("returns null for non-existent activity", async () => {
-    const result = await getNextLesson(BigInt(999_999_999));
+    const result = await getNextLesson(randomUUID());
     expect(result).toBeNull();
   });
 

--- a/packages/core/src/player/queries/get-next-lesson.ts
+++ b/packages/core/src/player/queries/get-next-lesson.ts
@@ -3,7 +3,7 @@ import { getLessonGenerationState } from "@zoonk/core/content/management";
 import { getPublishedLessonWhere, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 
-type NextLesson = { id: number; needsGeneration: boolean };
+type NextLesson = { id: string; needsGeneration: boolean };
 
 /**
  * Given an activityId, finds the next lesson in course order.
@@ -14,7 +14,7 @@ type NextLesson = { id: number; needsGeneration: boolean };
  * generation work, has descendant activities still generating, or is an
  * outdated AI-managed lesson that can be safely regenerated now.
  */
-export async function getNextLesson(activityId: bigint): Promise<NextLesson | null> {
+export async function getNextLesson(activityId: string): Promise<NextLesson | null> {
   const { data: activity, error } = await safeAsync(() =>
     prisma.activity.findFirst({
       include: {

--- a/packages/core/src/player/queries/get-next-sibling.test.ts
+++ b/packages/core/src/player/queries/get-next-sibling.test.ts
@@ -7,12 +7,12 @@ import { getNextSibling } from "./get-next-sibling";
 
 describe("getNextSibling - lesson level", () => {
   let orgSlug: string;
-  let courseId: number;
+  let courseId: string;
   let courseSlug: string;
 
-  let chapter1Id: number;
+  let chapter1Id: string;
   let chapter1Position: number;
-  let chapter2Id: number;
+  let chapter2Id: string;
   let chapter2Position: number;
   let chapter2Slug: string;
 
@@ -169,7 +169,7 @@ describe("getNextSibling - lesson level", () => {
 
 describe("getNextSibling - chapter level", () => {
   let orgSlug: string;
-  let courseId: number;
+  let courseId: string;
   let courseSlug: string;
   let chapter2Slug: string;
 

--- a/packages/core/src/player/queries/get-next-sibling.ts
+++ b/packages/core/src/player/queries/get-next-sibling.ts
@@ -3,33 +3,33 @@ import { getPublishedChapterWhere, getPublishedLessonWhere, prisma } from "@zoon
 import { safeAsync } from "@zoonk/utils/error";
 
 type LessonScope = {
-  chapterId: number;
+  chapterId: string;
   chapterPosition: number;
-  courseId: number;
+  courseId: string;
   lessonPosition: number;
   level: "lesson";
 };
 
 type ChapterScope = {
   chapterPosition: number;
-  courseId: number;
+  courseId: string;
   level: "chapter";
 };
 
 type LessonResult = {
   brandSlug: string;
-  chapterId: number;
+  chapterId: string;
   chapterSlug: string;
   courseSlug: string;
   lessonDescription: string;
-  lessonId: number;
+  lessonId: string;
   lessonSlug: string;
   lessonTitle: string;
 };
 
 type ChapterResult = {
   brandSlug: string;
-  chapterId: number;
+  chapterId: string;
   chapterSlug: string;
   courseSlug: string;
 };

--- a/packages/core/src/player/queries/get-review-steps.test.ts
+++ b/packages/core/src/player/queries/get-review-steps.test.ts
@@ -16,7 +16,7 @@ const REVIEW_TARGET_COUNT = 10;
 describe(getReviewSteps, () => {
   let lesson: Awaited<ReturnType<typeof lessonFixture>>;
   let org: Awaited<ReturnType<typeof organizationFixture>>;
-  let unpublishedStepId: bigint;
+  let unpublishedStepId: string;
 
   beforeAll(async () => {
     org = await organizationFixture({ kind: "brand" });

--- a/packages/core/src/player/queries/get-review-steps.ts
+++ b/packages/core/src/player/queries/get-review-steps.ts
@@ -6,7 +6,7 @@ const REVIEW_TARGET_COUNT = 10;
 const EXCLUDED_ACTIVITY_KINDS: ActivityKind[] = ["review"];
 const NON_REVIEWABLE_STEP_KINDS: StepKind[] = ["investigation", "static", "story", "visual"];
 
-function reviewableStepFilter(lessonId: number) {
+function reviewableStepFilter(lessonId: string) {
   return getPublishedStepWhere({
     activityWhere: { kind: { notIn: EXCLUDED_ACTIVITY_KINDS } },
     lessonWhere: { id: lessonId },
@@ -30,7 +30,7 @@ export async function getReviewSteps({
   lessonId,
   userId,
 }: {
-  lessonId: number;
+  lessonId: string;
   userId: string | null;
 }) {
   const lessonStepFilter = reviewableStepFilter(lessonId);
@@ -93,7 +93,7 @@ export async function getReviewSteps({
  * Only returns steps that are eligible for review — excludes
  * steps from review activities and static steps.
  */
-export async function getReviewValidationSteps(params: { lessonId: number; stepIds: bigint[] }) {
+export async function getReviewValidationSteps(params: { lessonId: string; stepIds: string[] }) {
   return prisma.step.findMany({
     include: { sentence: true, word: true },
     where: { ...reviewableStepFilter(params.lessonId), id: { in: params.stepIds } },

--- a/packages/core/src/player/queries/get-sentence-words.test.ts
+++ b/packages/core/src/player/queries/get-sentence-words.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
@@ -86,7 +87,7 @@ describe(getSentenceWords, () => {
   });
 
   test("returns empty array for non-existent lesson", async () => {
-    const result = await getSentenceWords({ lessonId: 999_999 });
+    const result = await getSentenceWords({ lessonId: randomUUID() });
     expect(result).toEqual([]);
   });
 

--- a/packages/core/src/player/queries/get-sentence-words.ts
+++ b/packages/core/src/player/queries/get-sentence-words.ts
@@ -3,7 +3,7 @@ import { prisma } from "@zoonk/db";
 import { extractUniqueSentenceWords } from "@zoonk/utils/string";
 import { cache } from "react";
 
-const cachedGetSentenceWords = cache(async (lessonId: number) => {
+const cachedGetSentenceWords = cache(async (lessonId: string) => {
   const lessonSentences = await prisma.lessonSentence.findMany({
     include: { sentence: true },
     where: { lessonId },
@@ -46,6 +46,6 @@ const cachedGetSentenceWords = cache(async (lessonId: number) => {
  * Word table with text matching. This keeps the return type consistent
  * with getLessonWords, which prepareActivityData also consumes.
  */
-export function getSentenceWords(params: { lessonId: number }) {
+export function getSentenceWords(params: { lessonId: string }) {
   return cachedGetSentenceWords(params.lessonId);
 }

--- a/packages/core/src/player/queries/list-lesson-activities.test.ts
+++ b/packages/core/src/player/queries/list-lesson-activities.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -127,7 +128,7 @@ describe(listLessonActivities, () => {
   });
 
   test("returns empty array for non-existent lesson", async () => {
-    const result = await listLessonActivities({ lessonId: 999_999 });
+    const result = await listLessonActivities({ lessonId: randomUUID() });
 
     expect(result).toEqual([]);
   });

--- a/packages/core/src/player/queries/list-lesson-activities.ts
+++ b/packages/core/src/player/queries/list-lesson-activities.ts
@@ -3,7 +3,7 @@ import { type Activity, getPublishedActivityWhere, prisma } from "@zoonk/db";
 import { cache } from "react";
 
 const cachedListLessonActivities = cache(
-  async (lessonId: number): Promise<Activity[]> =>
+  async (lessonId: string): Promise<Activity[]> =>
     prisma.activity.findMany({
       orderBy: { position: "asc" },
       where: getPublishedActivityWhere({
@@ -12,6 +12,6 @@ const cachedListLessonActivities = cache(
     }),
 );
 
-export function listLessonActivities(params: { lessonId: number }): Promise<Activity[]> {
+export function listLessonActivities(params: { lessonId: string }): Promise<Activity[]> {
   return cachedListLessonActivities(params.lessonId);
 }

--- a/packages/core/src/progress/_utils/durable-completion-queries.ts
+++ b/packages/core/src/progress/_utils/durable-completion-queries.ts
@@ -11,10 +11,10 @@ export async function listDurableLessonCompletionIds({
   lessonIds,
   userId,
 }: {
-  lessonIds: number[];
-  userId: string;
-}): Promise<Set<number>> {
-  if (lessonIds.length === 0) {
+  lessonIds: string[];
+  userId?: string;
+}): Promise<Set<string>> {
+  if (lessonIds.length === 0 || !userId) {
     return new Set();
   }
 
@@ -39,10 +39,10 @@ export async function listDurableChapterCompletionIds({
   chapterIds,
   userId,
 }: {
-  chapterIds: number[];
-  userId: string;
-}): Promise<Set<number>> {
-  if (chapterIds.length === 0) {
+  chapterIds: string[];
+  userId?: string;
+}): Promise<Set<string>> {
+  if (chapterIds.length === 0 || !userId) {
     return new Set();
   }
 
@@ -67,9 +67,13 @@ export async function hasDurableCourseCompletion({
   courseId,
   userId,
 }: {
-  courseId: number;
-  userId: string;
+  courseId: string;
+  userId?: string;
 }): Promise<boolean> {
+  if (!userId) {
+    return false;
+  }
+
   const { data } = await safeAsync(() =>
     prisma.courseCompletion.findUnique({
       where: { userCourseCompletion: { courseId, userId } },

--- a/packages/core/src/progress/_utils/next-activity-state-helpers.ts
+++ b/packages/core/src/progress/_utils/next-activity-state-helpers.ts
@@ -5,7 +5,7 @@ import {
 
 export type NextActivityStateAnchor = {
   chapterPosition: number;
-  lessonId: number;
+  lessonId: string;
   lessonPosition: number;
 };
 
@@ -20,7 +20,7 @@ export function getHasStartedState({
   rows,
 }: {
   courseCompleted: boolean;
-  durableChapterIds: Set<number>;
+  durableChapterIds: Set<string>;
   rows: EffectiveLessonProgressRow[];
 }) {
   return (
@@ -42,7 +42,7 @@ export function isScopeCompleted({
   scope,
 }: {
   courseCompleted: boolean;
-  durableChapterIds: Set<number>;
+  durableChapterIds: Set<string>;
   rows: EffectiveLessonProgressRow[];
   scope: PublishedLessonProgressScope;
 }) {
@@ -81,7 +81,7 @@ export function getScopeDurablyCompleted({
   scope,
 }: {
   courseCompleted: boolean;
-  durableChapterIds: Set<number>;
+  durableChapterIds: Set<string>;
   rows: EffectiveLessonProgressRow[];
   scope: PublishedLessonProgressScope;
 }) {
@@ -107,7 +107,7 @@ export function getFirstIncompleteLesson({
   rows,
 }: {
   courseCompleted: boolean;
-  durableChapterIds: Set<number>;
+  durableChapterIds: Set<string>;
   rows: EffectiveLessonProgressRow[];
 }) {
   if (courseCompleted) {
@@ -132,7 +132,7 @@ export function getForwardLesson({
 }: {
   after: NextActivityStateAnchor;
   courseCompleted: boolean;
-  durableChapterIds: Set<number>;
+  durableChapterIds: Set<string>;
   rows: EffectiveLessonProgressRow[];
 }) {
   if (courseCompleted) {
@@ -194,7 +194,7 @@ export function hasPendingLessonContent({ row }: { row: EffectiveLessonProgressR
  * a durably completed chapter from a chapter that still has open lessons now.
  */
 function groupRowsByChapter({ rows }: { rows: EffectiveLessonProgressRow[] }) {
-  const grouped = new Map<number, { chapterId: number; rows: EffectiveLessonProgressRow[] }>();
+  const grouped = new Map<string, { chapterId: string; rows: EffectiveLessonProgressRow[] }>();
 
   for (const row of rows) {
     const current = grouped.get(row.chapterId);
@@ -249,7 +249,7 @@ function isForwardLessonOpen({
   durableChapterIds,
   row,
 }: {
-  durableChapterIds: Set<number>;
+  durableChapterIds: Set<string>;
   row: EffectiveLessonProgressRow;
 }) {
   return !durableChapterIds.has(row.chapterId) && !row.isEffectivelyCompleted;
@@ -263,7 +263,7 @@ function getLessonById({
   lessonId,
   rows,
 }: {
-  lessonId: number;
+  lessonId: string;
   rows: EffectiveLessonProgressRow[];
 }) {
   return rows.find((row) => row.lessonId === lessonId) ?? null;

--- a/packages/core/src/progress/_utils/published-lesson-progress-queries.ts
+++ b/packages/core/src/progress/_utils/published-lesson-progress-queries.ts
@@ -16,7 +16,7 @@ export async function listPublishedLessonProgressRows({
   userId,
 }: {
   scope: PublishedLessonProgressScope;
-  userId: string;
+  userId?: string;
 }): Promise<PublishedLessonProgressRow[]> {
   return queryPublishedLessonProgressRows({
     scope,
@@ -31,8 +31,8 @@ export async function listPublishedLessonProgressRows({
 export async function listPublishedChaptersForCourse({
   courseId,
 }: {
-  courseId: number;
-}): Promise<{ chapterId: number }[]> {
+  courseId: string;
+}): Promise<{ chapterId: string }[]> {
   const { data } = await safeAsync(() =>
     prisma.chapter.findMany({
       orderBy: { position: "asc" },
@@ -59,9 +59,11 @@ async function queryPublishedLessonProgressRows({
   userId,
 }: {
   scope: PublishedLessonProgressScope;
-  userId: string;
+  userId?: string;
 }) {
   const scopeFilter = getPublishedLessonProgressScopeFilter({ scope });
+  const progressUserFilter = userId ? sql`ap.user_id = ${userId}` : sql`FALSE`;
+
   const { data } = await safeAsync(
     () =>
       prisma.$queryRaw<PublishedLessonProgressRow[]>`
@@ -97,7 +99,7 @@ async function queryPublishedLessonProgressRows({
           AND a.archived_at IS NULL
         LEFT JOIN activity_progress ap
           ON ap.activity_id = a.id
-          AND ap.user_id = ${userId}
+          AND ${progressUserFilter}
           AND ap.completed_at IS NOT NULL
         WHERE l.is_published = true
           AND l.archived_at IS NULL

--- a/packages/core/src/progress/_utils/published-lesson-progress.ts
+++ b/packages/core/src/progress/_utils/published-lesson-progress.ts
@@ -1,19 +1,19 @@
 export type PublishedLessonProgressScope =
-  | { chapterId: number }
-  | { courseId: number }
-  | { lessonId: number };
+  | { chapterId: string }
+  | { courseId: string }
+  | { lessonId: string };
 
 export type PublishedLessonProgressRow = {
   brandSlug: string | null;
-  chapterId: number;
+  chapterId: string;
   chapterPosition: number;
   chapterSlug: string;
   completedActivities: number;
-  courseId: number;
+  courseId: string;
   courseSlug: string;
   lessonDescription: string;
   lessonGenerationStatus: "completed" | "failed" | "pending" | "running";
-  lessonId: number;
+  lessonId: string;
   lessonPosition: number;
   lessonSlug: string;
   lessonTitle: string;
@@ -35,7 +35,7 @@ export function toEffectiveLessonProgressRows({
   durablyCompletedLessonIds,
   rows,
 }: {
-  durablyCompletedLessonIds: Set<number>;
+  durablyCompletedLessonIds: Set<string>;
   rows: PublishedLessonProgressRow[];
 }): EffectiveLessonProgressRow[] {
   return rows.map((row) => {

--- a/packages/core/src/progress/get-activity-progress.test.ts
+++ b/packages/core/src/progress/get-activity-progress.test.ts
@@ -127,7 +127,7 @@ describe(getActivityProgress, () => {
 
     const headers = await signInAs(user.email, user.password);
     const result = await getActivityProgress({ headers, lessonId: lesson.id });
-    expect(result).toEqual(expect.arrayContaining([String(activity1.id), String(activity2.id)]));
+    expect(result).toEqual(expect.arrayContaining([activity1.id, activity2.id]));
     expect(result).toHaveLength(2);
   });
 
@@ -182,7 +182,7 @@ describe(getActivityProgress, () => {
 
     const headers = await signInAs(user.email, user.password);
     const result = await getActivityProgress({ headers, lessonId: lesson.id });
-    expect(result).toEqual([String(completedActivity.id)]);
+    expect(result).toEqual([completedActivity.id]);
   });
 
   test("only returns activities for the specified lesson", async () => {
@@ -245,7 +245,7 @@ describe(getActivityProgress, () => {
 
     const headers = await signInAs(user.email, user.password);
     const result = await getActivityProgress({ headers, lessonId: lesson1.id });
-    expect(result).toEqual([String(activityInLesson1.id)]);
+    expect(result).toEqual([activityInLesson1.id]);
   });
 
   test("returns all current activities when the learner durably completed the lesson", async () => {
@@ -308,6 +308,6 @@ describe(getActivityProgress, () => {
     const headers = await signInAs(user.email, user.password);
     const result = await getActivityProgress({ headers, lessonId: currentLesson.id });
 
-    expect(result).toEqual([String(currentActivity1.id), String(currentActivity2.id)]);
+    expect(result).toEqual([currentActivity1.id, currentActivity2.id]);
   });
 });

--- a/packages/core/src/progress/get-activity-progress.ts
+++ b/packages/core/src/progress/get-activity-progress.ts
@@ -6,7 +6,7 @@ export async function getActivityProgress({
   lessonId,
   headers,
 }: {
-  lessonId: number;
+  lessonId: string;
   headers?: Headers;
 }): Promise<string[]> {
   const session = await getSession(headers);
@@ -37,7 +37,7 @@ export async function getActivityProgress({
       }),
     );
 
-    return (activities ?? []).map((activity) => String(activity.id));
+    return (activities ?? []).map((activity) => activity.id);
   }
 
   const { data, error } = await safeAsync(() =>
@@ -56,5 +56,5 @@ export async function getActivityProgress({
     return [];
   }
 
-  return data.map((row) => String(row.activityId));
+  return data.map((row) => row.activityId);
 }

--- a/packages/core/src/progress/get-chapter-progress.ts
+++ b/packages/core/src/progress/get-chapter-progress.ts
@@ -20,11 +20,11 @@ function getChapterProgressRows({
   durableChapterIds,
   rows,
 }: {
-  chapterIds: { chapterId: number }[];
-  durableChapterIds: Set<number>;
+  chapterIds: { chapterId: string }[];
+  durableChapterIds: Set<string>;
   rows: ReturnType<typeof toEffectiveLessonProgressRows>;
 }) {
-  const rowsByChapter = new Map<number, typeof rows>();
+  const rowsByChapter = new Map<string, typeof rows>();
 
   for (const row of rows) {
     const chapterRows = rowsByChapter.get(row.chapterId) ?? [];
@@ -63,11 +63,11 @@ export async function getChapterProgress({
   courseId,
   headers,
 }: {
-  courseId: number;
+  courseId: string;
   headers?: Headers;
 }): Promise<
   {
-    chapterId: number;
+    chapterId: string;
     completedLessons: number;
     totalLessons: number;
   }[]

--- a/packages/core/src/progress/get-lesson-progress.ts
+++ b/packages/core/src/progress/get-lesson-progress.ts
@@ -7,12 +7,12 @@ export async function getLessonProgress({
   chapterId,
   headers,
 }: {
-  chapterId: number;
+  chapterId: string;
   headers?: Headers;
 }): Promise<
   {
     completedActivities: number;
-    lessonId: number;
+    lessonId: string;
     totalActivities: number;
   }[]
 > {

--- a/packages/core/src/progress/get-next-activity-state.ts
+++ b/packages/core/src/progress/get-next-activity-state.ts
@@ -24,20 +24,20 @@ import {
 import { listPublishedLessonProgressRows } from "./_utils/published-lesson-progress-queries";
 
 export type NextActivityState = {
-  activityId: bigint | null;
+  activityId: string | null;
   activityKind: ActivityKind | null;
   activityPosition: number;
   activityTitle: string | null;
   brandSlug: string | null;
   canPrefetch: boolean;
-  chapterId: number;
+  chapterId: string;
   chapterSlug: string;
   completed: boolean;
-  courseId: number;
+  courseId: string;
   courseSlug: string;
   hasStarted: boolean;
   lessonDescription: string;
-  lessonId: number;
+  lessonId: string;
   lessonHasPendingContent: boolean;
   lessonSlug: string;
   lessonTitle: string;
@@ -56,7 +56,7 @@ export async function getNextActivityStateForUser({
 }: {
   after?: NextActivityStateAnchor;
   scope: PublishedLessonProgressScope;
-  userId: string;
+  userId?: string;
 }): Promise<NextActivityState | null> {
   const rows = await listPublishedLessonProgressRows({ scope, userId });
 
@@ -204,7 +204,7 @@ async function buildOpenLessonState({
 }: {
   hasStarted: boolean;
   lesson: EffectiveLessonProgressRow;
-  userId: string;
+  userId?: string;
 }) {
   if (hasPendingLessonContent({ row: lesson })) {
     return toLessonShellState({
@@ -302,20 +302,26 @@ async function findFirstIncompleteActivity({
   lessonId,
   userId,
 }: {
-  lessonId: number;
-  userId: string;
+  lessonId: string;
+  userId?: string;
 }) {
-  return prisma.activity.findFirst({
-    orderBy: { position: "asc" },
-    where: getPublishedActivityWhere({
-      activityWhere: {
-        generationStatus: "completed",
+  const progressFilter = userId
+    ? {
         progress: {
           none: {
             completedAt: { not: null },
             userId,
           },
         },
+      }
+    : {};
+
+  return prisma.activity.findFirst({
+    orderBy: { position: "asc" },
+    where: getPublishedActivityWhere({
+      activityWhere: {
+        generationStatus: "completed",
+        ...progressFilter,
       },
       lessonWhere: { id: lessonId },
     }),

--- a/packages/core/src/progress/get-next-activity.ts
+++ b/packages/core/src/progress/get-next-activity.ts
@@ -19,7 +19,7 @@ export async function getNextActivity({
   lessonSlug: string;
 } | null> {
   const session = await getSession(headers);
-  const userId = session?.user.id ?? "";
+  const userId = session?.user.id;
   const lastCompleted = userId ? await findLastCompleted(userId, scope) : null;
 
   const state = await getNextActivityStateForUser({

--- a/packages/core/src/workflows/steps.ts
+++ b/packages/core/src/workflows/steps.ts
@@ -17,7 +17,7 @@ export type WorkflowErrorReason =
  * This is the contract between the workflow streaming layer and the client.
  */
 export type StepStreamMessage<TStep extends string = string> = {
-  entityId?: number;
+  entityId?: string;
   reason?: WorkflowErrorReason;
   status: StepStatus;
   step: TStep;

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -4,11 +4,17 @@ This package contains all schemas the DB client for interacting with our databas
 
 ### PostgreSQL Setup
 
-For macOS users, you can install PostgreSQL using Homebrew:
+For macOS users, install PostgreSQL 18 using Homebrew:
 
 ```bash
-brew install postgresql
-brew services start postgresql
+brew install postgresql@18
+brew services start postgresql@18
+```
+
+If `createdb` or `psql` are not available after installation, add PostgreSQL 18 to your shell `PATH`:
+
+```bash
+export PATH="$(brew --prefix postgresql@18)/bin:$PATH"
 ```
 
 Then, create a new database:

--- a/packages/db/src/prisma/migrations/20260416024906_use_uuid_v7_auth_ids/migration.sql
+++ b/packages/db/src/prisma/migrations/20260416024906_use_uuid_v7_auth_ids/migration.sql
@@ -1,0 +1,875 @@
+/*
+  Warnings:
+
+  - The primary key for the `accounts` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `accounts` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `activities` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `activities` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `organization_id` column on the `activities` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `activity_progress` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `activity_progress` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `chapter_completions` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `chapter_completions` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `chapters` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `chapters` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `organization_id` column on the `chapters` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `content_reviews` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `content_reviews` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `course_alternative_titles` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `course_alternative_titles` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `course_categories` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `course_categories` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `course_completions` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `course_completions` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `course_suggestions` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `course_suggestions` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `course_users` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `course_users` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `courses` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `courses` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `organization_id` column on the `courses` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `user_id` column on the `courses` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `daily_progress` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `daily_progress` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `invitations` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `invitations` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `jwks` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `jwks` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `lesson_completions` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `lesson_completions` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `lesson_sentences` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `lesson_sentences` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `lesson_words` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `lesson_words` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `lessons` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `lessons` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `organization_id` column on the `lessons` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `members` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `members` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `organizations` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `organizations` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `rate_limits` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `rate_limits` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `search_prompt_suggestions` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `search_prompt_suggestions` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `search_prompts` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `search_prompts` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `sentences` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `sentences` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `sessions` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `sessions` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `impersonated_by` column on the `sessions` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `active_organization_id` column on the `sessions` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `step_attempts` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `step_attempts` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `steps` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `steps` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `sentence_id` column on the `steps` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `word_id` column on the `steps` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `subscriptions` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `subscriptions` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `user_learning_profiles` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `user_learning_profiles` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `user_progress` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `user_progress` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `users` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `users` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `verifications` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `verifications` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `word_pronunciations` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `word_pronunciations` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `words` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `words` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - Changed the type of `user_id` on the `accounts` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `lesson_id` on the `activities` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `activity_progress` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `activity_id` on the `activity_progress` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `chapter_completions` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `chapter_id` on the `chapter_completions` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `course_id` on the `chapters` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `entity_id` on the `content_reviews` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `content_reviews` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `course_id` on the `course_alternative_titles` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `course_id` on the `course_categories` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `course_completions` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `course_id` on the `course_completions` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `course_id` on the `course_users` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `course_users` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `daily_progress` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `organization_id` on the `invitations` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `inviter_id` on the `invitations` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `lesson_completions` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `lesson_id` on the `lesson_completions` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `lesson_id` on the `lesson_sentences` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `sentence_id` on the `lesson_sentences` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `lesson_id` on the `lesson_words` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `word_id` on the `lesson_words` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `chapter_id` on the `lessons` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `organization_id` on the `members` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `members` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `search_prompt_id` on the `search_prompt_suggestions` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `course_suggestion_id` on the `search_prompt_suggestions` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `organization_id` on the `sentences` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `sessions` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `step_attempts` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `step_id` on the `step_attempts` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `activity_id` on the `steps` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `reference_id` on the `subscriptions` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `user_learning_profiles` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `user_progress` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `word_id` on the `word_pronunciations` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `organization_id` on the `words` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- DropForeignKey
+ALTER TABLE "accounts" DROP CONSTRAINT "accounts_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "activities" DROP CONSTRAINT "activities_lesson_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "activities" DROP CONSTRAINT "activities_organization_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "activity_progress" DROP CONSTRAINT "activity_progress_activity_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "activity_progress" DROP CONSTRAINT "activity_progress_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "chapter_completions" DROP CONSTRAINT "chapter_completions_chapter_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "chapter_completions" DROP CONSTRAINT "chapter_completions_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "chapters" DROP CONSTRAINT "chapters_course_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "chapters" DROP CONSTRAINT "chapters_organization_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "content_reviews" DROP CONSTRAINT "content_reviews_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "course_alternative_titles" DROP CONSTRAINT "course_alternative_titles_course_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "course_categories" DROP CONSTRAINT "course_categories_course_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "course_completions" DROP CONSTRAINT "course_completions_course_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "course_completions" DROP CONSTRAINT "course_completions_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "course_users" DROP CONSTRAINT "course_users_course_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "course_users" DROP CONSTRAINT "course_users_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "courses" DROP CONSTRAINT "courses_organization_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "courses" DROP CONSTRAINT "courses_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "daily_progress" DROP CONSTRAINT "daily_progress_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "invitations" DROP CONSTRAINT "invitations_inviter_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "invitations" DROP CONSTRAINT "invitations_organization_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "lesson_completions" DROP CONSTRAINT "lesson_completions_lesson_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "lesson_completions" DROP CONSTRAINT "lesson_completions_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "lesson_sentences" DROP CONSTRAINT "lesson_sentences_lesson_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "lesson_sentences" DROP CONSTRAINT "lesson_sentences_sentence_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "lesson_words" DROP CONSTRAINT "lesson_words_lesson_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "lesson_words" DROP CONSTRAINT "lesson_words_word_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "lessons" DROP CONSTRAINT "lessons_chapter_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "lessons" DROP CONSTRAINT "lessons_organization_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "members" DROP CONSTRAINT "members_organization_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "members" DROP CONSTRAINT "members_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "search_prompt_suggestions" DROP CONSTRAINT "search_prompt_suggestions_course_suggestion_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "search_prompt_suggestions" DROP CONSTRAINT "search_prompt_suggestions_search_prompt_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "sentences" DROP CONSTRAINT "sentences_organization_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "sessions" DROP CONSTRAINT "sessions_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "step_attempts" DROP CONSTRAINT "step_attempts_step_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "step_attempts" DROP CONSTRAINT "step_attempts_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "steps" DROP CONSTRAINT "steps_activity_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "steps" DROP CONSTRAINT "steps_sentence_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "steps" DROP CONSTRAINT "steps_word_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "user_learning_profiles" DROP CONSTRAINT "user_learning_profiles_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "user_progress" DROP CONSTRAINT "user_progress_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "word_pronunciations" DROP CONSTRAINT "word_pronunciations_word_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "words" DROP CONSTRAINT "words_organization_id_fkey";
+
+-- AlterTable
+ALTER TABLE "accounts" DROP CONSTRAINT "accounts_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID NOT NULL,
+ADD CONSTRAINT "accounts_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "activities" DROP CONSTRAINT "activities_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "organization_id",
+ADD COLUMN     "organization_id" UUID,
+DROP COLUMN "lesson_id",
+ADD COLUMN     "lesson_id" UUID NOT NULL,
+ADD CONSTRAINT "activities_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "activity_progress" DROP CONSTRAINT "activity_progress_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID NOT NULL,
+DROP COLUMN "activity_id",
+ADD COLUMN     "activity_id" UUID NOT NULL,
+ADD CONSTRAINT "activity_progress_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "chapter_completions" DROP CONSTRAINT "chapter_completions_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID NOT NULL,
+DROP COLUMN "chapter_id",
+ADD COLUMN     "chapter_id" UUID NOT NULL,
+ADD CONSTRAINT "chapter_completions_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "chapters" DROP CONSTRAINT "chapters_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "organization_id",
+ADD COLUMN     "organization_id" UUID,
+DROP COLUMN "course_id",
+ADD COLUMN     "course_id" UUID NOT NULL,
+ADD CONSTRAINT "chapters_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "content_reviews" DROP CONSTRAINT "content_reviews_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "entity_id",
+ADD COLUMN     "entity_id" UUID NOT NULL,
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID NOT NULL,
+ADD CONSTRAINT "content_reviews_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "course_alternative_titles" DROP CONSTRAINT "course_alternative_titles_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "course_id",
+ADD COLUMN     "course_id" UUID NOT NULL,
+ADD CONSTRAINT "course_alternative_titles_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "course_categories" DROP CONSTRAINT "course_categories_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "course_id",
+ADD COLUMN     "course_id" UUID NOT NULL,
+ADD CONSTRAINT "course_categories_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "course_completions" DROP CONSTRAINT "course_completions_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID NOT NULL,
+DROP COLUMN "course_id",
+ADD COLUMN     "course_id" UUID NOT NULL,
+ADD CONSTRAINT "course_completions_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "course_suggestions" DROP CONSTRAINT "course_suggestions_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+ADD CONSTRAINT "course_suggestions_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "course_users" DROP CONSTRAINT "course_users_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "course_id",
+ADD COLUMN     "course_id" UUID NOT NULL,
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID NOT NULL,
+ADD CONSTRAINT "course_users_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "courses" DROP CONSTRAINT "courses_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "organization_id",
+ADD COLUMN     "organization_id" UUID,
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID,
+ADD CONSTRAINT "courses_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "daily_progress" DROP CONSTRAINT "daily_progress_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID NOT NULL,
+ADD CONSTRAINT "daily_progress_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "invitations" DROP CONSTRAINT "invitations_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "organization_id",
+ADD COLUMN     "organization_id" UUID NOT NULL,
+DROP COLUMN "inviter_id",
+ADD COLUMN     "inviter_id" UUID NOT NULL,
+ADD CONSTRAINT "invitations_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "jwks" DROP CONSTRAINT "jwks_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+ADD CONSTRAINT "jwks_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "lesson_completions" DROP CONSTRAINT "lesson_completions_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID NOT NULL,
+DROP COLUMN "lesson_id",
+ADD COLUMN     "lesson_id" UUID NOT NULL,
+ADD CONSTRAINT "lesson_completions_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "lesson_sentences" DROP CONSTRAINT "lesson_sentences_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "lesson_id",
+ADD COLUMN     "lesson_id" UUID NOT NULL,
+DROP COLUMN "sentence_id",
+ADD COLUMN     "sentence_id" UUID NOT NULL,
+ADD CONSTRAINT "lesson_sentences_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "lesson_words" DROP CONSTRAINT "lesson_words_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "lesson_id",
+ADD COLUMN     "lesson_id" UUID NOT NULL,
+DROP COLUMN "word_id",
+ADD COLUMN     "word_id" UUID NOT NULL,
+ADD CONSTRAINT "lesson_words_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "lessons" DROP CONSTRAINT "lessons_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "organization_id",
+ADD COLUMN     "organization_id" UUID,
+DROP COLUMN "chapter_id",
+ADD COLUMN     "chapter_id" UUID NOT NULL,
+ADD CONSTRAINT "lessons_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "members" DROP CONSTRAINT "members_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "organization_id",
+ADD COLUMN     "organization_id" UUID NOT NULL,
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID NOT NULL,
+ADD CONSTRAINT "members_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "organizations" DROP CONSTRAINT "organizations_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+ADD CONSTRAINT "organizations_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "rate_limits" DROP CONSTRAINT "rate_limits_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+ADD CONSTRAINT "rate_limits_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "search_prompt_suggestions" DROP CONSTRAINT "search_prompt_suggestions_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "search_prompt_id",
+ADD COLUMN     "search_prompt_id" UUID NOT NULL,
+DROP COLUMN "course_suggestion_id",
+ADD COLUMN     "course_suggestion_id" UUID NOT NULL,
+ADD CONSTRAINT "search_prompt_suggestions_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "search_prompts" DROP CONSTRAINT "search_prompts_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+ADD CONSTRAINT "search_prompts_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "sentences" DROP CONSTRAINT "sentences_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "organization_id",
+ADD COLUMN     "organization_id" UUID NOT NULL,
+ADD CONSTRAINT "sentences_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "sessions" DROP CONSTRAINT "sessions_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID NOT NULL,
+DROP COLUMN "impersonated_by",
+ADD COLUMN     "impersonated_by" UUID,
+DROP COLUMN "active_organization_id",
+ADD COLUMN     "active_organization_id" UUID,
+ADD CONSTRAINT "sessions_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "step_attempts" DROP CONSTRAINT "step_attempts_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID NOT NULL,
+DROP COLUMN "step_id",
+ADD COLUMN     "step_id" UUID NOT NULL,
+ADD CONSTRAINT "step_attempts_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "steps" DROP CONSTRAINT "steps_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "activity_id",
+ADD COLUMN     "activity_id" UUID NOT NULL,
+DROP COLUMN "sentence_id",
+ADD COLUMN     "sentence_id" UUID,
+DROP COLUMN "word_id",
+ADD COLUMN     "word_id" UUID,
+ADD CONSTRAINT "steps_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "subscriptions" DROP CONSTRAINT "subscriptions_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "reference_id",
+ADD COLUMN     "reference_id" UUID NOT NULL,
+ADD CONSTRAINT "subscriptions_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "user_learning_profiles" DROP CONSTRAINT "user_learning_profiles_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID NOT NULL,
+ADD CONSTRAINT "user_learning_profiles_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "user_progress" DROP CONSTRAINT "user_progress_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID NOT NULL,
+ADD CONSTRAINT "user_progress_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "users" DROP CONSTRAINT "users_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+ADD CONSTRAINT "users_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "verifications" DROP CONSTRAINT "verifications_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+ADD CONSTRAINT "verifications_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "word_pronunciations" DROP CONSTRAINT "word_pronunciations_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "word_id",
+ADD COLUMN     "word_id" UUID NOT NULL,
+ADD CONSTRAINT "word_pronunciations_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "words" DROP CONSTRAINT "words_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuidv7(),
+DROP COLUMN "organization_id",
+ADD COLUMN     "organization_id" UUID NOT NULL,
+ADD CONSTRAINT "words_pkey" PRIMARY KEY ("id");
+
+-- CreateIndex
+CREATE INDEX "accounts_user_id_idx" ON "accounts"("user_id");
+
+-- CreateIndex
+CREATE INDEX "activities_lesson_id_archived_at_position_idx" ON "activities"("lesson_id", "archived_at", "position");
+
+-- CreateIndex
+CREATE INDEX "activities_lesson_id_archived_at_generation_status_idx" ON "activities"("lesson_id", "archived_at", "generation_status");
+
+-- CreateIndex
+CREATE INDEX "activities_organization_id_kind_idx" ON "activities"("organization_id", "kind");
+
+-- CreateIndex
+CREATE INDEX "activity_progress_activity_id_idx" ON "activity_progress"("activity_id");
+
+-- CreateIndex
+CREATE INDEX "activity_progress_user_id_completed_at_idx" ON "activity_progress"("user_id", "completed_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "activity_progress_user_id_activity_id_key" ON "activity_progress"("user_id", "activity_id");
+
+-- CreateIndex
+CREATE INDEX "chapter_completions_chapter_id_idx" ON "chapter_completions"("chapter_id");
+
+-- CreateIndex
+CREATE INDEX "chapter_completions_user_id_completed_at_idx" ON "chapter_completions"("user_id", "completed_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "chapter_completions_user_id_chapter_id_key" ON "chapter_completions"("user_id", "chapter_id");
+
+-- CreateIndex
+CREATE INDEX "chapters_organization_id_archived_at_normalized_title_idx" ON "chapters"("organization_id", "archived_at", "normalized_title");
+
+-- CreateIndex
+CREATE INDEX "chapters_course_id_archived_at_position_idx" ON "chapters"("course_id", "archived_at", "position");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "chapters_course_id_slug_key" ON "chapters"("course_id", "slug");
+
+-- CreateIndex
+CREATE INDEX "content_reviews_user_id_idx" ON "content_reviews"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "content_reviews_task_type_entity_id_key" ON "content_reviews"("task_type", "entity_id");
+
+-- CreateIndex
+CREATE INDEX "course_alternative_titles_course_id_idx" ON "course_alternative_titles"("course_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "course_categories_course_id_category_key" ON "course_categories"("course_id", "category");
+
+-- CreateIndex
+CREATE INDEX "course_completions_course_id_idx" ON "course_completions"("course_id");
+
+-- CreateIndex
+CREATE INDEX "course_completions_user_id_completed_at_idx" ON "course_completions"("user_id", "completed_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "course_completions_user_id_course_id_key" ON "course_completions"("user_id", "course_id");
+
+-- CreateIndex
+CREATE INDEX "course_users_user_id_idx" ON "course_users"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "course_users_course_id_user_id_key" ON "course_users"("course_id", "user_id");
+
+-- CreateIndex
+CREATE INDEX "courses_organization_id_archived_at_normalized_title_idx" ON "courses"("organization_id", "archived_at", "normalized_title");
+
+-- CreateIndex
+CREATE INDEX "courses_organization_id_is_published_archived_at_created_at_idx" ON "courses"("organization_id", "is_published", "archived_at", "created_at");
+
+-- CreateIndex
+CREATE INDEX "courses_is_published_archived_at_language_user_count_id_idx" ON "courses"("is_published", "archived_at", "language", "user_count", "id");
+
+-- CreateIndex
+CREATE INDEX "courses_user_id_mode_idx" ON "courses"("user_id", "mode");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "courses_organization_id_slug_key" ON "courses"("organization_id", "slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "courses_user_id_slug_key" ON "courses"("user_id", "slug");
+
+-- CreateIndex
+CREATE INDEX "daily_progress_user_id_day_of_week_idx" ON "daily_progress"("user_id", "day_of_week");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "daily_progress_user_id_date_key" ON "daily_progress"("user_id", "date");
+
+-- CreateIndex
+CREATE INDEX "invitations_organization_id_idx" ON "invitations"("organization_id");
+
+-- CreateIndex
+CREATE INDEX "lesson_completions_lesson_id_idx" ON "lesson_completions"("lesson_id");
+
+-- CreateIndex
+CREATE INDEX "lesson_completions_user_id_completed_at_idx" ON "lesson_completions"("user_id", "completed_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "lesson_completions_user_id_lesson_id_key" ON "lesson_completions"("user_id", "lesson_id");
+
+-- CreateIndex
+CREATE INDEX "lesson_sentences_sentence_id_idx" ON "lesson_sentences"("sentence_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "lesson_sentences_lesson_id_sentence_id_key" ON "lesson_sentences"("lesson_id", "sentence_id");
+
+-- CreateIndex
+CREATE INDEX "lesson_words_word_id_idx" ON "lesson_words"("word_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "lesson_words_lesson_id_word_id_key" ON "lesson_words"("lesson_id", "word_id");
+
+-- CreateIndex
+CREATE INDEX "lessons_organization_id_archived_at_normalized_title_idx" ON "lessons"("organization_id", "archived_at", "normalized_title");
+
+-- CreateIndex
+CREATE INDEX "lessons_chapter_id_archived_at_position_idx" ON "lessons"("chapter_id", "archived_at", "position");
+
+-- CreateIndex
+CREATE INDEX "lessons_organization_id_kind_idx" ON "lessons"("organization_id", "kind");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "lessons_chapter_id_slug_key" ON "lessons"("chapter_id", "slug");
+
+-- CreateIndex
+CREATE INDEX "members_organization_id_idx" ON "members"("organization_id");
+
+-- CreateIndex
+CREATE INDEX "members_user_id_idx" ON "members"("user_id");
+
+-- CreateIndex
+CREATE INDEX "search_prompt_suggestions_course_suggestion_id_idx" ON "search_prompt_suggestions"("course_suggestion_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "search_prompt_suggestions_search_prompt_id_course_suggestio_key" ON "search_prompt_suggestions"("search_prompt_id", "course_suggestion_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sentences_organization_id_target_language_sentence_key" ON "sentences"("organization_id", "target_language", "sentence");
+
+-- CreateIndex
+CREATE INDEX "sessions_user_id_idx" ON "sessions"("user_id");
+
+-- CreateIndex
+CREATE INDEX "step_attempts_user_id_answered_at_idx" ON "step_attempts"("user_id", "answered_at");
+
+-- CreateIndex
+CREATE INDEX "step_attempts_step_id_idx" ON "step_attempts"("step_id");
+
+-- CreateIndex
+CREATE INDEX "step_attempts_user_id_day_of_week_idx" ON "step_attempts"("user_id", "day_of_week");
+
+-- CreateIndex
+CREATE INDEX "step_attempts_user_id_hour_of_day_idx" ON "step_attempts"("user_id", "hour_of_day");
+
+-- CreateIndex
+CREATE INDEX "steps_activity_id_archived_at_position_idx" ON "steps"("activity_id", "archived_at", "position");
+
+-- CreateIndex
+CREATE INDEX "steps_activity_id_kind_archived_at_position_idx" ON "steps"("activity_id", "kind", "archived_at", "position");
+
+-- CreateIndex
+CREATE INDEX "steps_word_id_idx" ON "steps"("word_id");
+
+-- CreateIndex
+CREATE INDEX "steps_sentence_id_idx" ON "steps"("sentence_id");
+
+-- CreateIndex
+CREATE INDEX "subscriptions_reference_id_idx" ON "subscriptions"("reference_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_learning_profiles_user_id_key" ON "user_learning_profiles"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_progress_user_id_key" ON "user_progress"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "word_pronunciations_word_id_user_language_key" ON "word_pronunciations"("word_id", "user_language");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "words_organization_id_target_language_word_key" ON "words"("organization_id", "target_language", "word");
+
+-- AddForeignKey
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "members" ADD CONSTRAINT "members_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "members" ADD CONSTRAINT "members_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "invitations" ADD CONSTRAINT "invitations_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "invitations" ADD CONSTRAINT "invitations_inviter_id_fkey" FOREIGN KEY ("inviter_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "chapters" ADD CONSTRAINT "chapters_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "chapters" ADD CONSTRAINT "chapters_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "courses"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "content_reviews" ADD CONSTRAINT "content_reviews_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "search_prompt_suggestions" ADD CONSTRAINT "search_prompt_suggestions_search_prompt_id_fkey" FOREIGN KEY ("search_prompt_id") REFERENCES "search_prompts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "search_prompt_suggestions" ADD CONSTRAINT "search_prompt_suggestions_course_suggestion_id_fkey" FOREIGN KEY ("course_suggestion_id") REFERENCES "course_suggestions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "courses" ADD CONSTRAINT "courses_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "courses" ADD CONSTRAINT "courses_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "course_alternative_titles" ADD CONSTRAINT "course_alternative_titles_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "courses"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "course_categories" ADD CONSTRAINT "course_categories_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "courses"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "course_users" ADD CONSTRAINT "course_users_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "courses"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "course_users" ADD CONSTRAINT "course_users_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "lessons" ADD CONSTRAINT "lessons_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "lessons" ADD CONSTRAINT "lessons_chapter_id_fkey" FOREIGN KEY ("chapter_id") REFERENCES "chapters"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activities" ADD CONSTRAINT "activities_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activities" ADD CONSTRAINT "activities_lesson_id_fkey" FOREIGN KEY ("lesson_id") REFERENCES "lessons"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "steps" ADD CONSTRAINT "steps_activity_id_fkey" FOREIGN KEY ("activity_id") REFERENCES "activities"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "steps" ADD CONSTRAINT "steps_word_id_fkey" FOREIGN KEY ("word_id") REFERENCES "words"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "steps" ADD CONSTRAINT "steps_sentence_id_fkey" FOREIGN KEY ("sentence_id") REFERENCES "sentences"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_progress" ADD CONSTRAINT "activity_progress_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_progress" ADD CONSTRAINT "activity_progress_activity_id_fkey" FOREIGN KEY ("activity_id") REFERENCES "activities"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "lesson_completions" ADD CONSTRAINT "lesson_completions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "lesson_completions" ADD CONSTRAINT "lesson_completions_lesson_id_fkey" FOREIGN KEY ("lesson_id") REFERENCES "lessons"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "chapter_completions" ADD CONSTRAINT "chapter_completions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "chapter_completions" ADD CONSTRAINT "chapter_completions_chapter_id_fkey" FOREIGN KEY ("chapter_id") REFERENCES "chapters"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "course_completions" ADD CONSTRAINT "course_completions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "course_completions" ADD CONSTRAINT "course_completions_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "courses"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "step_attempts" ADD CONSTRAINT "step_attempts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "step_attempts" ADD CONSTRAINT "step_attempts_step_id_fkey" FOREIGN KEY ("step_id") REFERENCES "steps"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_progress" ADD CONSTRAINT "user_progress_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "daily_progress" ADD CONSTRAINT "daily_progress_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_learning_profiles" ADD CONSTRAINT "user_learning_profiles_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "words" ADD CONSTRAINT "words_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "word_pronunciations" ADD CONSTRAINT "word_pronunciations_word_id_fkey" FOREIGN KEY ("word_id") REFERENCES "words"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sentences" ADD CONSTRAINT "sentences_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "lesson_words" ADD CONSTRAINT "lesson_words_lesson_id_fkey" FOREIGN KEY ("lesson_id") REFERENCES "lessons"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "lesson_words" ADD CONSTRAINT "lesson_words_word_id_fkey" FOREIGN KEY ("word_id") REFERENCES "words"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "lesson_sentences" ADD CONSTRAINT "lesson_sentences_lesson_id_fkey" FOREIGN KEY ("lesson_id") REFERENCES "lessons"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "lesson_sentences" ADD CONSTRAINT "lesson_sentences_sentence_id_fkey" FOREIGN KEY ("sentence_id") REFERENCES "sentences"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/src/prisma/models/accounts.prisma
+++ b/packages/db/src/prisma/models/accounts.prisma
@@ -1,7 +1,7 @@
 // Better Auth models for Prisma
 
 model User {
-  id                 String               @id
+  id                 String               @id @default(dbgenerated("uuidv7()")) @db.Uuid
   name               String
   email              String
   emailVerified      Boolean              @default(false) @map("email_verified")
@@ -38,17 +38,17 @@ model User {
 }
 
 model Session {
-  id                   String   @id
+  id                   String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
   expiresAt            DateTime @map("expires_at")
   token                String
   createdAt            DateTime @default(now()) @map("created_at")
   updatedAt            DateTime @updatedAt @map("updated_at")
   ipAddress            String?  @map("ip_address")
   userAgent            String?  @map("user_agent")
-  userId               String   @map("user_id")
+  userId               String   @map("user_id") @db.Uuid
   user                 User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  impersonatedBy       String?  @map("impersonated_by")
-  activeOrganizationId String?  @map("active_organization_id")
+  impersonatedBy       String?  @map("impersonated_by") @db.Uuid
+  activeOrganizationId String?  @map("active_organization_id") @db.Uuid
 
   @@unique([token])
   @@index([userId])
@@ -56,10 +56,10 @@ model Session {
 }
 
 model Account {
-  id                    String    @id
+  id                    String    @id @default(dbgenerated("uuidv7()")) @db.Uuid
   accountId             String    @map("account_id")
   providerId            String    @map("provider_id")
-  userId                String    @map("user_id")
+  userId                String    @map("user_id") @db.Uuid
   user                  User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   accessToken           String?   @map("access_token")
   refreshToken          String?   @map("refresh_token")
@@ -76,7 +76,7 @@ model Account {
 }
 
 model Verification {
-  id         String   @id
+  id         String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
   identifier String
   value      String
   expiresAt  DateTime @map("expires_at")
@@ -88,7 +88,7 @@ model Verification {
 }
 
 model Organization {
-  id               String       @id
+  id               String       @id @default(dbgenerated("uuidv7()")) @db.Uuid
   name             String
   slug             String
   logo             String?
@@ -110,10 +110,10 @@ model Organization {
 }
 
 model Member {
-  id             String       @id
-  organizationId String       @map("organization_id")
+  id             String       @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  organizationId String       @map("organization_id") @db.Uuid
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  userId         String       @map("user_id")
+  userId         String       @map("user_id") @db.Uuid
   user           User         @relation(fields: [userId], references: [id], onDelete: Cascade)
   role           String       @default("member")
   createdAt      DateTime     @default(now()) @map("created_at")
@@ -124,15 +124,15 @@ model Member {
 }
 
 model Invitation {
-  id             String       @id
-  organizationId String       @map("organization_id")
+  id             String       @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  organizationId String       @map("organization_id") @db.Uuid
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   email          String
   role           String?
   status         String       @default("pending")
   expiresAt      DateTime     @map("expires_at")
   createdAt      DateTime     @default(now()) @map("created_at")
-  inviterId      String       @map("inviter_id")
+  inviterId      String       @map("inviter_id") @db.Uuid
   user           User         @relation(fields: [inviterId], references: [id], onDelete: Cascade)
 
   @@index([organizationId])
@@ -141,9 +141,9 @@ model Invitation {
 }
 
 model Subscription {
-  id                   String    @id
+  id                   String    @id @default(dbgenerated("uuidv7()")) @db.Uuid
   plan                 String
-  referenceId          String    @map("reference_id")
+  referenceId          String    @map("reference_id") @db.Uuid
   stripeCustomerId     String?   @map("stripe_customer_id")
   stripeSubscriptionId String?   @map("stripe_subscription_id")
   status               String?   @default("incomplete")
@@ -165,7 +165,7 @@ model Subscription {
 }
 
 model RateLimit {
-  id          String  @id
+  id          String  @id @default(dbgenerated("uuidv7()")) @db.Uuid
   key         String?
   count       Int?
   lastRequest BigInt? @map("last_request")
@@ -175,7 +175,7 @@ model RateLimit {
 }
 
 model Jwks {
-  id         String    @id
+  id         String    @id @default(dbgenerated("uuidv7()")) @db.Uuid
   publicKey  String    @map("public_key")
   privateKey String    @map("private_key")
   createdAt  DateTime  @default(now()) @map("created_at")

--- a/packages/db/src/prisma/models/chapters.prisma
+++ b/packages/db/src/prisma/models/chapters.prisma
@@ -1,8 +1,8 @@
 model Chapter {
-  id               Int                   @id @default(autoincrement())
-  organizationId   String?               @map("organization_id")
+  id               String                @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  organizationId   String?               @map("organization_id") @db.Uuid
   organization     Organization?         @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  courseId         Int                   @map("course_id")
+  courseId         String                @map("course_id") @db.Uuid
   course           Course                @relation(fields: [courseId], references: [id], onDelete: Cascade)
   isLocked         Boolean               @default(false) @map("is_locked")
   isPublished      Boolean               @default(false) @map("is_published")

--- a/packages/db/src/prisma/models/content-review.prisma
+++ b/packages/db/src/prisma/models/content-review.prisma
@@ -1,10 +1,10 @@
 model ContentReview {
-  id         BigInt   @id @default(autoincrement())
+  id         String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
   taskType   String   @map("task_type")
-  entityId   BigInt   @map("entity_id")
+  entityId   String   @map("entity_id") @db.Uuid
   status     String   @default("approved") @map("status")
   reviewedAt DateTime @default(now()) @map("reviewed_at")
-  userId     String   @map("user_id")
+  userId     String   @map("user_id") @db.Uuid
   user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([taskType, entityId], name: "taskEntity")

--- a/packages/db/src/prisma/models/courses.prisma
+++ b/packages/db/src/prisma/models/courses.prisma
@@ -1,5 +1,5 @@
 model SearchPrompt {
-  id          Int                      @id @default(autoincrement())
+  id          String                   @id @default(dbgenerated("uuidv7()")) @db.Uuid
   language    String                   @db.VarChar(10)
   prompt      String
   suggestions SearchPromptSuggestion[]
@@ -11,7 +11,7 @@ model SearchPrompt {
 }
 
 model CourseSuggestion {
-  id               Int                      @id @default(autoincrement())
+  id               String                   @id @default(dbgenerated("uuidv7()")) @db.Uuid
   language         String                   @db.VarChar(10)
   slug             String
   title            String
@@ -28,10 +28,10 @@ model CourseSuggestion {
 }
 
 model SearchPromptSuggestion {
-  id                 Int              @id @default(autoincrement())
-  searchPromptId     Int              @map("search_prompt_id")
+  id                 String           @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  searchPromptId     String           @map("search_prompt_id") @db.Uuid
   searchPrompt       SearchPrompt     @relation(fields: [searchPromptId], references: [id], onDelete: Cascade)
-  courseSuggestionId Int              @map("course_suggestion_id")
+  courseSuggestionId String           @map("course_suggestion_id") @db.Uuid
   courseSuggestion   CourseSuggestion @relation(fields: [courseSuggestionId], references: [id], onDelete: Cascade)
   position           Int              @default(0)
   createdAt          DateTime         @default(now()) @map("created_at")
@@ -42,10 +42,10 @@ model SearchPromptSuggestion {
 }
 
 model Course {
-  id                Int                      @id @default(autoincrement())
-  organizationId    String?                  @map("organization_id")
+  id                String                   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  organizationId    String?                  @map("organization_id") @db.Uuid
   organization      Organization?            @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  userId            String?                  @map("user_id")
+  userId            String?                  @map("user_id") @db.Uuid
   user              User?                    @relation(fields: [userId], references: [id], onDelete: Cascade)
   mode              CourseMode               @default(full)
   completedAt       DateTime?                @map("completed_at")
@@ -81,8 +81,8 @@ model Course {
 }
 
 model CourseAlternativeTitle {
-  id        Int      @id @default(autoincrement())
-  courseId  Int      @map("course_id")
+  id        String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  courseId  String   @map("course_id") @db.Uuid
   course    Course   @relation(fields: [courseId], references: [id], onDelete: Cascade)
   slug      String
   language  String   @db.VarChar(10)
@@ -94,8 +94,8 @@ model CourseAlternativeTitle {
 }
 
 model CourseCategory {
-  id        Int      @id @default(autoincrement())
-  courseId  Int      @map("course_id")
+  id        String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  courseId  String   @map("course_id") @db.Uuid
   course    Course   @relation(fields: [courseId], references: [id], onDelete: Cascade)
   category  String   @db.VarChar(50)
   createdAt DateTime @default(now()) @map("created_at")
@@ -106,10 +106,10 @@ model CourseCategory {
 }
 
 model CourseUser {
-  id        Int      @id @default(autoincrement())
-  courseId  Int      @map("course_id")
+  id        String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  courseId  String   @map("course_id") @db.Uuid
   course    Course   @relation(fields: [courseId], references: [id], onDelete: Cascade)
-  userId    String   @map("user_id")
+  userId    String   @map("user_id") @db.Uuid
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   startedAt DateTime @default(now()) @map("started_at")
 

--- a/packages/db/src/prisma/models/lessons.prisma
+++ b/packages/db/src/prisma/models/lessons.prisma
@@ -1,8 +1,8 @@
 model Lesson {
-  id                Int                   @id @default(autoincrement())
-  organizationId    String?               @map("organization_id")
+  id                String                @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  organizationId    String?               @map("organization_id") @db.Uuid
   organization      Organization?         @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  chapterId         Int                   @map("chapter_id")
+  chapterId         String                @map("chapter_id") @db.Uuid
   chapter           Chapter               @relation(fields: [chapterId], references: [id], onDelete: Cascade)
   isLocked          Boolean               @default(false) @map("is_locked")
   isPublished       Boolean               @default(false) @map("is_published")
@@ -35,10 +35,10 @@ model Lesson {
 }
 
 model Activity {
-  id               BigInt                @id @default(autoincrement())
-  organizationId   String?               @map("organization_id")
+  id               String                @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  organizationId   String?               @map("organization_id") @db.Uuid
   organization     Organization?         @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  lessonId         Int                   @map("lesson_id")
+  lessonId         String                @map("lesson_id") @db.Uuid
   lesson           Lesson                @relation(fields: [lessonId], references: [id], onDelete: Cascade)
   isPublished      Boolean               @default(false) @map("is_published")
   language         String                @db.VarChar(10)
@@ -62,12 +62,12 @@ model Activity {
 }
 
 model Step {
-  id          BigInt        @id @default(autoincrement())
-  activityId  BigInt        @map("activity_id")
+  id          String        @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  activityId  String        @map("activity_id") @db.Uuid
   activity    Activity      @relation(fields: [activityId], references: [id], onDelete: Cascade)
-  wordId      BigInt?       @map("word_id")
+  wordId      String?       @map("word_id") @db.Uuid
   word        Word?         @relation(fields: [wordId], references: [id], onDelete: Cascade)
-  sentenceId  BigInt?       @map("sentence_id")
+  sentenceId  String?       @map("sentence_id") @db.Uuid
   sentence    Sentence?     @relation(fields: [sentenceId], references: [id], onDelete: Cascade)
   kind        StepKind
   position    Int

--- a/packages/db/src/prisma/models/progress.prisma
+++ b/packages/db/src/prisma/models/progress.prisma
@@ -1,8 +1,8 @@
 model ActivityProgress {
-  id              BigInt    @id @default(autoincrement())
-  userId          String    @map("user_id")
+  id              String    @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  userId          String    @map("user_id") @db.Uuid
   user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  activityId      BigInt    @map("activity_id")
+  activityId      String    @map("activity_id") @db.Uuid
   activity        Activity  @relation(fields: [activityId], references: [id], onDelete: Cascade)
   startedAt       DateTime  @default(now()) @map("started_at")
   completedAt     DateTime? @map("completed_at")
@@ -16,10 +16,10 @@ model ActivityProgress {
 }
 
 model LessonCompletion {
-  id          BigInt   @id @default(autoincrement())
-  userId      String   @map("user_id")
+  id          String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  userId      String   @map("user_id") @db.Uuid
   user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  lessonId    Int      @map("lesson_id")
+  lessonId    String   @map("lesson_id") @db.Uuid
   lesson      Lesson   @relation(fields: [lessonId], references: [id], onDelete: Cascade)
   completedAt DateTime @default(now()) @map("completed_at")
 
@@ -30,10 +30,10 @@ model LessonCompletion {
 }
 
 model ChapterCompletion {
-  id          BigInt   @id @default(autoincrement())
-  userId      String   @map("user_id")
+  id          String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  userId      String   @map("user_id") @db.Uuid
   user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  chapterId   Int      @map("chapter_id")
+  chapterId   String   @map("chapter_id") @db.Uuid
   chapter     Chapter  @relation(fields: [chapterId], references: [id], onDelete: Cascade)
   completedAt DateTime @default(now()) @map("completed_at")
 
@@ -44,10 +44,10 @@ model ChapterCompletion {
 }
 
 model CourseCompletion {
-  id          BigInt   @id @default(autoincrement())
-  userId      String   @map("user_id")
+  id          String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  userId      String   @map("user_id") @db.Uuid
   user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  courseId    Int      @map("course_id")
+  courseId    String   @map("course_id") @db.Uuid
   course      Course   @relation(fields: [courseId], references: [id], onDelete: Cascade)
   completedAt DateTime @default(now()) @map("completed_at")
 
@@ -58,10 +58,10 @@ model CourseCompletion {
 }
 
 model StepAttempt {
-  id              BigInt   @id @default(autoincrement())
-  userId          String   @map("user_id")
+  id              String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  userId          String   @map("user_id") @db.Uuid
   user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  stepId          BigInt   @map("step_id")
+  stepId          String   @map("step_id") @db.Uuid
   step            Step     @relation(fields: [stepId], references: [id], onDelete: Cascade)
   isCorrect       Boolean  @map("is_correct")
   answer          Json
@@ -80,8 +80,8 @@ model StepAttempt {
 }
 
 model UserProgress {
-  id              Int      @id @default(autoincrement())
-  userId          String   @unique @map("user_id")
+  id              String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  userId          String   @unique @map("user_id") @db.Uuid
   user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   currentEnergy   Float    @default(0) @map("current_energy")
   totalBrainPower BigInt   @default(0) @map("total_brain_power")
@@ -91,8 +91,8 @@ model UserProgress {
 }
 
 model DailyProgress {
-  id                   BigInt   @id @default(autoincrement())
-  userId               String   @map("user_id")
+  id                   String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  userId               String   @map("user_id") @db.Uuid
   user                 User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   date                 DateTime @db.Date
   dayOfWeek            Int      @map("day_of_week") @db.SmallInt

--- a/packages/db/src/prisma/models/user-learning-profiles.prisma
+++ b/packages/db/src/prisma/models/user-learning-profiles.prisma
@@ -1,6 +1,6 @@
 model UserLearningProfile {
-  id           Int      @id @default(autoincrement())
-  userId       String   @unique @map("user_id")
+  id           String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  userId       String   @unique @map("user_id") @db.Uuid
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   interests    Json?
   preferences  Json?

--- a/packages/db/src/prisma/models/vocabulary.prisma
+++ b/packages/db/src/prisma/models/vocabulary.prisma
@@ -1,6 +1,6 @@
 model Word {
-  id             BigInt              @id @default(autoincrement())
-  organizationId String              @map("organization_id")
+  id             String              @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  organizationId String              @map("organization_id") @db.Uuid
   organization   Organization        @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   targetLanguage String              @map("target_language") @db.VarChar(10)
   word           String
@@ -25,8 +25,8 @@ model Word {
 /// (wordId, userLanguage) rather than on `Word` (no user language)
 /// or `LessonWord` (would duplicate the same value across lessons).
 model WordPronunciation {
-  id            BigInt   @id @default(autoincrement())
-  wordId        BigInt   @map("word_id")
+  id            String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  wordId        String   @map("word_id") @db.Uuid
   word          Word     @relation(fields: [wordId], references: [id], onDelete: Cascade)
   userLanguage  String   @map("user_language") @db.VarChar(10)
   pronunciation String
@@ -37,8 +37,8 @@ model WordPronunciation {
 }
 
 model Sentence {
-  id             BigInt           @id @default(autoincrement())
-  organizationId String           @map("organization_id")
+  id             String           @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  organizationId String           @map("organization_id") @db.Uuid
   organization   Organization     @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   targetLanguage String           @map("target_language") @db.VarChar(10)
   sentence       String
@@ -60,10 +60,10 @@ model Sentence {
 /// furniture lesson. A global translation would be overwritten by whichever
 /// lesson saved last.
 model LessonWord {
-  id           BigInt   @id @default(autoincrement())
-  lessonId     Int      @map("lesson_id")
+  id           String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  lessonId     String   @map("lesson_id") @db.Uuid
   lesson       Lesson   @relation(fields: [lessonId], references: [id], onDelete: Cascade)
-  wordId       BigInt   @map("word_id")
+  wordId       String   @map("word_id") @db.Uuid
   word         Word     @relation(fields: [wordId], references: [id], onDelete: Cascade)
   userLanguage String   @map("user_language") @db.VarChar(10)
   translation  String   @default("")
@@ -87,10 +87,10 @@ model LessonWord {
 /// vocabulary lesson), and fixing the schema pre-launch is far cheaper
 /// than migrating production data later.
 model LessonSentence {
-  id                     BigInt   @id @default(autoincrement())
-  lessonId               Int      @map("lesson_id")
+  id                     String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  lessonId               String   @map("lesson_id") @db.Uuid
   lesson                 Lesson   @relation(fields: [lessonId], references: [id], onDelete: Cascade)
-  sentenceId             BigInt   @map("sentence_id")
+  sentenceId             String   @map("sentence_id") @db.Uuid
   sentence               Sentence @relation(fields: [sentenceId], references: [id], onDelete: Cascade)
   userLanguage           String   @map("user_language") @db.VarChar(10)
   translation            String   @default("")

--- a/packages/db/src/prisma/seed/accounts.ts
+++ b/packages/db/src/prisma/seed/accounts.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { type PrismaClient } from "../../generated/prisma/client";
 import { type SeedUsers } from "./users";
 
@@ -7,7 +6,6 @@ const TEST_PASSWORD = "password123";
 export async function seedAccounts(prisma: PrismaClient, users: SeedUsers): Promise<void> {
   const accountData = Object.values(users).map((user) => ({
     accountId: user.email,
-    id: randomUUID(),
     password: TEST_PASSWORD,
     providerId: "credential",
     userId: user.id,

--- a/packages/db/src/prisma/seed/orgs.ts
+++ b/packages/db/src/prisma/seed/orgs.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { type Organization, type PrismaClient } from "../../generated/prisma/client";
 import { type SeedUsers } from "./users";
@@ -15,13 +14,12 @@ export async function seedOrganizations(
   const [ai, testOrg] = await Promise.all([
     prisma.organization.upsert({
       create: {
-        id: randomUUID(),
         members: {
           create: [
-            { id: randomUUID(), role: "owner", userId: users.owner.id },
-            { id: randomUUID(), role: "admin", userId: users.admin.id },
-            { id: randomUUID(), role: "member", userId: users.member.id },
-            { id: randomUUID(), role: "admin", userId: users.multiOrg.id },
+            { role: "owner", userId: users.owner.id },
+            { role: "admin", userId: users.admin.id },
+            { role: "member", userId: users.member.id },
+            { role: "admin", userId: users.multiOrg.id },
           ],
         },
         name: "Zoonk AI",
@@ -32,9 +30,8 @@ export async function seedOrganizations(
     }),
     prisma.organization.upsert({
       create: {
-        id: randomUUID(),
         members: {
-          create: [{ id: randomUUID(), role: "owner", userId: users.multiOrg.id }],
+          create: [{ role: "owner", userId: users.multiOrg.id }],
         },
         name: "Test Org",
         slug: "test-org",

--- a/packages/db/src/prisma/seed/subscriptions.ts
+++ b/packages/db/src/prisma/seed/subscriptions.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { type PrismaClient } from "../../generated/prisma/client";
 import { type SeedUsers } from "./users";
 
@@ -15,7 +14,6 @@ export async function seedSubscriptions(prisma: PrismaClient, users: SeedUsers):
   oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1);
 
   const subscriptionData = allUsers.map((user) => ({
-    id: randomUUID(),
     periodEnd: oneYearFromNow,
     periodStart: now,
     plan: "hobby",

--- a/packages/db/src/prisma/seed/users.ts
+++ b/packages/db/src/prisma/seed/users.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { type PrismaClient, type User } from "../../generated/prisma/client";
 
 export type SeedUsers = {
@@ -14,7 +13,6 @@ export async function seedUsers(prisma: PrismaClient): Promise<SeedUsers> {
     create: {
       email: "owner@zoonk.test",
       emailVerified: true,
-      id: randomUUID(),
       name: "Owner User",
       role: "admin",
       username: "owner_user",
@@ -27,7 +25,6 @@ export async function seedUsers(prisma: PrismaClient): Promise<SeedUsers> {
     create: {
       email: "admin@zoonk.test",
       emailVerified: true,
-      id: randomUUID(),
       name: "Admin User",
       role: "admin",
       username: "admin_user",
@@ -40,7 +37,6 @@ export async function seedUsers(prisma: PrismaClient): Promise<SeedUsers> {
     create: {
       email: "member@zoonk.test",
       emailVerified: true,
-      id: randomUUID(),
       name: "Member User",
       role: "member",
       username: "member_user",
@@ -53,7 +49,6 @@ export async function seedUsers(prisma: PrismaClient): Promise<SeedUsers> {
     create: {
       email: "logout-test@zoonk.test",
       emailVerified: true,
-      id: randomUUID(),
       name: "Logout Test User",
       role: "member",
       username: "logout_test",
@@ -66,7 +61,6 @@ export async function seedUsers(prisma: PrismaClient): Promise<SeedUsers> {
     create: {
       email: "multi-org@zoonk.test",
       emailVerified: true,
-      id: randomUUID(),
       name: "Multi Org User",
       role: "admin",
       username: "multi_org",

--- a/packages/e2e/src/fixtures/progress.ts
+++ b/packages/e2e/src/fixtures/progress.ts
@@ -84,7 +84,7 @@ function buildDailyProgressInputs(today: Date, userId: string) {
  * The progress summaries depend on answer counts and hour-of-day buckets, so
  * this helper creates that coverage once instead of repeating it in browser setup.
  */
-async function createStepAttempts(stepId: bigint, userId: string, now: Date) {
+async function createStepAttempts(stepId: string, userId: string, now: Date) {
   const configs = [
     { correct: 9, hourOfDay: 9, incorrect: 1 },
     { correct: 8, hourOfDay: 15, incorrect: 2 },

--- a/packages/testing/src/fixtures/activities.ts
+++ b/packages/testing/src/fixtures/activities.ts
@@ -11,7 +11,7 @@ function activityAttrs(
     isPublished: false,
     kind: "explanation",
     language: "en",
-    lessonId: 0,
+    lessonId: "",
     managementMode: "manual",
     organizationId: null,
     position: 0,

--- a/packages/testing/src/fixtures/chapters.ts
+++ b/packages/testing/src/fixtures/chapters.ts
@@ -10,7 +10,7 @@ export function chapterAttrs(
 
   return {
     archivedAt: null,
-    courseId: 0,
+    courseId: "",
     description: "Test chapter description",
     generationRunId: null,
     generationStatus: "completed",

--- a/packages/testing/src/fixtures/lessons.ts
+++ b/packages/testing/src/fixtures/lessons.ts
@@ -10,7 +10,7 @@ export function lessonAttrs(
 
   return {
     archivedAt: null,
-    chapterId: 0,
+    chapterId: "",
     concepts: [],
     description: "Test lesson description",
     generationRunId: null,

--- a/packages/testing/src/fixtures/sentences.ts
+++ b/packages/testing/src/fixtures/sentences.ts
@@ -19,8 +19,8 @@ export async function sentenceFixture(attrs: {
 }
 
 export async function lessonSentenceFixture(attrs: {
-  lessonId: number;
-  sentenceId: bigint;
+  lessonId: string;
+  sentenceId: string;
   userLanguage?: string;
   translation?: string;
   distractors?: string[];

--- a/packages/testing/src/fixtures/step-attempts.ts
+++ b/packages/testing/src/fixtures/step-attempts.ts
@@ -8,7 +8,7 @@ export async function stepAttemptFixture(attrs: {
   effects?: object;
   hourOfDay: number;
   isCorrect: boolean;
-  stepId: bigint;
+  stepId: string;
   userId: string;
 }) {
   return prisma.stepAttempt.create({

--- a/packages/testing/src/fixtures/steps.ts
+++ b/packages/testing/src/fixtures/steps.ts
@@ -1,13 +1,13 @@
 import { type StepKind, prisma } from "@zoonk/db";
 
 export async function stepFixture(attrs: {
-  activityId: bigint;
+  activityId: string;
   content?: object;
   isPublished?: boolean;
   kind?: StepKind;
   position?: number;
-  sentenceId?: bigint;
-  wordId?: bigint;
+  sentenceId?: string;
+  wordId?: string;
 }) {
   const step = await prisma.step.create({
     data: {

--- a/packages/testing/src/fixtures/words.ts
+++ b/packages/testing/src/fixtures/words.ts
@@ -19,7 +19,7 @@ export async function wordFixture(attrs: {
 }
 
 export async function wordPronunciationFixture(attrs: {
-  wordId: bigint;
+  wordId: string;
   userLanguage?: string;
   pronunciation?: string;
 }) {
@@ -33,8 +33,8 @@ export async function wordPronunciationFixture(attrs: {
 }
 
 export async function lessonWordFixture(attrs: {
-  lessonId: number;
-  wordId: bigint;
+  lessonId: string;
+  wordId: string;
   userLanguage?: string;
   translation?: string;
   distractors?: string[];

--- a/packages/ui/src/patterns/courses/course-list.tsx
+++ b/packages/ui/src/patterns/courses/course-list.tsx
@@ -13,7 +13,7 @@ import { cn } from "@zoonk/ui/lib/utils";
 import { ChevronRightIcon, NotebookPenIcon } from "lucide-react";
 
 export type CourseListItem = {
-  id: number;
+  id: string;
   description: string | null;
   imageUrl: string | null;
   slug: string;

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -32,6 +32,7 @@
     "./string": "./src/string.ts",
     "./subscription": "./src/subscription.ts",
     "./upload": "./src/upload.ts",
+    "./uuid": "./src/uuid.ts",
     "./url": "./src/url.ts"
   },
   "scripts": {

--- a/packages/utils/src/number.test.ts
+++ b/packages/utils/src/number.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { formatPosition, parseBigIntId, parseNumericId, validateOffset } from "./number";
+import { formatPosition, parseNumericId, validateOffset } from "./number";
 
 describe(validateOffset, () => {
   test("parses valid positive integer", () => {
@@ -77,44 +77,6 @@ describe(parseNumericId, () => {
     expect(parseNumericId(3.7)).toBeNull();
     expect(parseNumericId(null)).toBeNull();
     expect(parseNumericId()).toBeNull();
-  });
-});
-
-describe(parseBigIntId, () => {
-  test("parses valid numeric strings as BigInt", () => {
-    expect(parseBigIntId("123")).toBe(BigInt(123));
-    expect(parseBigIntId("0")).toBe(BigInt(0));
-    expect(parseBigIntId("999999")).toBe(BigInt(999_999));
-  });
-
-  test("parses large numbers that exceed Number.MAX_SAFE_INTEGER", () => {
-    const largeNum = "9007199254740993";
-    expect(parseBigIntId(largeNum)).toBe(BigInt(largeNum));
-  });
-
-  test("returns null for strings with letters", () => {
-    expect(parseBigIntId("123abc")).toBeNull();
-    expect(parseBigIntId("abc123")).toBeNull();
-    expect(parseBigIntId("1a2b3c")).toBeNull();
-  });
-
-  test("returns null for strings with special characters", () => {
-    expect(parseBigIntId("123.45")).toBeNull();
-    expect(parseBigIntId("123-45")).toBeNull();
-    expect(parseBigIntId("123_45")).toBeNull();
-    expect(parseBigIntId("+123")).toBeNull();
-    expect(parseBigIntId("-123")).toBeNull();
-  });
-
-  test("returns null for strings with whitespace", () => {
-    expect(parseBigIntId(" 123")).toBeNull();
-    expect(parseBigIntId("123 ")).toBeNull();
-    expect(parseBigIntId(" 123 ")).toBeNull();
-    expect(parseBigIntId("12 34")).toBeNull();
-  });
-
-  test("returns null for empty string", () => {
-    expect(parseBigIntId("")).toBeNull();
   });
 });
 

--- a/packages/utils/src/number.ts
+++ b/packages/utils/src/number.ts
@@ -25,13 +25,6 @@ export function parseNumericId(value?: number | string | null): number | null {
   return Number.parseInt(normalizedValue, 10);
 }
 
-export function parseBigIntId(value: string): bigint | null {
-  if (!NUMERIC_ID_PATTERN.test(value)) {
-    return null;
-  }
-  return BigInt(value);
-}
-
 /**
  * Formats a 0-indexed position as a 2-digit display string.
  * @example formatPosition(0) // "01"

--- a/packages/utils/src/uuid.test.ts
+++ b/packages/utils/src/uuid.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+import { isUuid } from "./uuid";
+
+describe(isUuid, () => {
+  test("returns true for valid UUID strings", () => {
+    expect(isUuid("018f5c3e-a9f8-7cc9-88d4-31e5c7286210")).toBe(true);
+    expect(isUuid("A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11")).toBe(true);
+  });
+
+  test("returns false for malformed values", () => {
+    expect(isUuid("invalid-id")).toBe(false);
+    expect(isUuid("999999")).toBe(false);
+    expect(isUuid("")).toBe(false);
+    expect(isUuid(null)).toBe(false);
+  });
+});

--- a/packages/utils/src/uuid.ts
+++ b/packages/utils/src/uuid.ts
@@ -1,0 +1,15 @@
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Prisma throws when a malformed id reaches a UUID column. This guard lets route
+ * and form boundaries reject bad input early so callers can return `null` or
+ * `notFound()` instead of crashing into a database error.
+ *
+ * @example isUuid("018f5c3e-a9f8-7cc9-88d4-31e5c7286210") // true
+ * @example isUuid("invalid-id") // false
+ */
+export function isUuid(value: unknown): value is string {
+  const normalizedValue = typeof value === "string" ? value.trim() : "";
+
+  return UUID_PATTERN.test(normalizedValue);
+}


### PR DESCRIPTION
## Summary
- migrate Prisma ids to UUIDv7 and update Postgres references to 18
- update auth, API, admin, editor, main, core, and testing code for string UUID ids
- fix follow-up typecheck, lint, test, knip, and e2e regressions from the id migration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated all database IDs to UUIDv7 (strings) and updated the app, API, workflows, and tests to use string IDs. Upgraded Postgres to v18 in CI and docs.

- **Refactors**
  - Switched ID types from number/bigint to string UUIDs across `@zoonk/db`, admin review flows, API workflows, and tests.
  - Removed numeric ID parsing (e.g., `parseBigIntId`); routes and actions now pass raw UUIDs.
  - Updated OpenAPI schemas (`zod`) and responses to accept and return UUIDs for course/chapter/lesson.
  - Stream utilities now emit `entityId` as a string.

- **Dependencies**
  - CI services moved to `postgres:18-alpine`; README updated to require PostgreSQL v18.

<sup>Written for commit 2407ae8ed27866fc1fc0c811fcd9dc3e9c6e710f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

