### PR TITLE
feat(main): support provider-managed billing

### DIFF
--- a/apps/admin/src/app/(private)/users/[id]/_actions/change-plan.ts
+++ b/apps/admin/src/app/(private)/users/[id]/_actions/change-plan.ts
@@ -24,8 +24,8 @@ export async function changePlanAction(formData: FormData) {
 
   const existing = findUserActiveSubscription(subscriptions);
 
-  if (existing?.stripeSubscriptionId) {
-    throw new Error("Cannot change plan for Stripe-managed subscriptions");
+  if (existing && existing.provider !== "zoonk") {
+    throw new Error("Cannot change plan unless the subscription is Zoonk-managed");
   }
 
   const { error } = await safeAsync(() => {
@@ -41,6 +41,7 @@ export async function changePlanAction(formData: FormData) {
         id: randomUUID(),
         periodStart: new Date(),
         plan,
+        provider: "zoonk",
         referenceId: userId,
         status: "active",
       },

--- a/apps/admin/src/app/(private)/users/[id]/user-subscription.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/user-subscription.tsx
@@ -5,13 +5,14 @@ import { DetailField } from "./detail-field";
 
 export async function UserSubscription({ userId }: { userId: string }) {
   const subscription = await getUserSubscription(userId);
-  const isStripeManaged = Boolean(subscription?.stripeSubscriptionId);
+  const canChangePlan = !subscription || subscription.provider === "zoonk";
+  const providerLabel = subscription ? getSubscriptionProviderLabel(subscription.provider) : "—";
 
   return (
     <section>
       <div className="mb-2 flex items-center justify-between">
         <h3 className="text-sm font-semibold">Subscription</h3>
-        {!isStripeManaged && (
+        {canChangePlan && (
           <ChangePlanDialog userId={userId} currentPlan={subscription?.plan ?? "free"} />
         )}
       </div>
@@ -22,6 +23,8 @@ export async function UserSubscription({ userId }: { userId: string }) {
         <DetailField label="Plan">
           <span className="capitalize">{subscription?.plan ?? "Free"}</span>
         </DetailField>
+
+        <DetailField label="Provider">{providerLabel}</DetailField>
 
         <DetailField label="Status">
           <span className="capitalize">{subscription?.status ?? "—"}</span>
@@ -46,4 +49,24 @@ export async function UserSubscription({ userId }: { userId: string }) {
       </dl>
     </section>
   );
+}
+
+/**
+ * Admin users need readable provider labels so they can tell at a glance
+ * whether a subscription is managed by Stripe, the app stores, or Zoonk.
+ */
+function getSubscriptionProviderLabel(provider: string) {
+  if (provider === "apple") {
+    return "Apple";
+  }
+
+  if (provider === "google") {
+    return "Google";
+  }
+
+  if (provider === "stripe") {
+    return "Stripe";
+  }
+
+  return "Zoonk";
 }

--- a/apps/main/e2e/subscription.test.ts
+++ b/apps/main/e2e/subscription.test.ts
@@ -243,7 +243,7 @@ test.describe("Subscription Page - Provider Managed", () => {
     await expect(page.getByRole("link", { name: /manage in app store/i })).toBeVisible();
     await expect(page.getByRole("link", { name: /manage in app store/i })).toHaveAttribute(
       "href",
-      /support\.apple\.com/,
+      "https://support.apple.com/billing",
     );
     await expect(page.getByRole("link", { name: /contact support/i })).toHaveAttribute(
       "href",

--- a/apps/main/e2e/subscription.test.ts
+++ b/apps/main/e2e/subscription.test.ts
@@ -4,10 +4,16 @@ import { prisma } from "@zoonk/db";
 import { request } from "@zoonk/e2e/fixtures";
 import { expect, test } from "./fixtures";
 
+type TestSubscriptionProvider = "apple" | "google" | "stripe" | "zoonk";
+
+/**
+ * Billing page tests need to create subscriptions owned by different billing
+ * systems so we can verify the page only shows actions that actually work.
+ */
 async function createUserWithSubscription(
   baseURL: string,
   plan: string,
-  options?: { cancelAt?: Date },
+  options?: { cancelAt?: Date; provider?: TestSubscriptionProvider },
 ) {
   const uniqueId = randomUUID().slice(0, 8);
   const email = `e2e-sub-${uniqueId}@zoonk.test`;
@@ -28,10 +34,13 @@ async function createUserWithSubscription(
       cancelAt: options?.cancelAt,
       id: randomUUID(),
       plan,
+      provider: options?.provider ?? "stripe",
       referenceId: user.id,
       status: "active",
-      stripeCustomerId: `cus_test_e2e_${uniqueId}`,
-      stripeSubscriptionId: `sub_test_e2e_${uniqueId}`,
+      ...getStripeSubscriptionFields({
+        provider: options?.provider ?? "stripe",
+        uniqueId,
+      }),
     },
   });
 
@@ -52,6 +61,27 @@ async function createAuthenticatedPage(browser: Browser, baseURL: string, email:
   const page = await browserContext.newPage();
 
   return { browserContext, page };
+}
+
+/**
+ * Only Stripe-backed test subscriptions should carry Stripe identifiers.
+ * Store-managed and Zoonk-managed rows need to look like non-Stripe records.
+ */
+function getStripeSubscriptionFields({
+  provider,
+  uniqueId,
+}: {
+  provider: TestSubscriptionProvider;
+  uniqueId: string;
+}) {
+  if (provider !== "stripe") {
+    return {};
+  }
+
+  return {
+    stripeCustomerId: `cus_test_e2e_${uniqueId}`,
+    stripeSubscriptionId: `sub_test_e2e_${uniqueId}`,
+  };
 }
 
 test.describe("Subscription Page - Unauthenticated", () => {
@@ -194,6 +224,53 @@ test.describe("Subscription Page - With Pro Subscription", () => {
 
     await page.getByRole("radio", { name: /free/i }).click();
     await expect(page.getByRole("button", { name: /cancel/i })).toBeVisible();
+
+    await browserContext.close();
+  });
+});
+
+test.describe("Subscription Page - Provider Managed", () => {
+  test("Apple subscriptions direct users to App Store support instead of Stripe controls", async ({
+    browser,
+    baseURL,
+  }) => {
+    const email = await createUserWithSubscription(baseURL!, "hobby", { provider: "apple" });
+    const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
+
+    await page.goto("/subscription");
+
+    await expect(page.getByText(/managed through the app store/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: /manage in app store/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /manage in app store/i })).toHaveAttribute(
+      "href",
+      /support\.apple\.com/,
+    );
+    await expect(page.getByRole("link", { name: /contact support/i })).toHaveAttribute(
+      "href",
+      "/support",
+    );
+    await expect(page.getByRole("radio", { name: /free/i })).not.toBeVisible();
+    await expect(page.getByRole("button", { name: /manage/i })).not.toBeVisible();
+
+    await browserContext.close();
+  });
+
+  test("Zoonk-managed subscriptions send users to support instead of plan controls", async ({
+    browser,
+    baseURL,
+  }) => {
+    const email = await createUserWithSubscription(baseURL!, "hobby", { provider: "zoonk" });
+    const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
+
+    await page.goto("/subscription");
+
+    await expect(page.getByText(/managed by zoonk/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: /contact support/i })).toHaveAttribute(
+      "href",
+      "/support",
+    );
+    await expect(page.getByRole("radio", { name: /free/i })).not.toBeVisible();
+    await expect(page.getByRole("button", { name: /manage/i })).not.toBeVisible();
 
     await browserContext.close();
   });

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1514,6 +1514,36 @@ msgctxt "yNHZ+a"
 msgid "Your profile has been updated successfully!"
 msgstr "Your profile has been updated successfully!"
 
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "3iCRcP"
+msgid "Manage in App Store"
+msgstr "Manage in App Store"
+
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "5CI3KH"
+msgid "Contact support"
+msgstr "Contact support"
+
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "P0ZHma"
+msgid "This subscription is managed by Zoonk. Contact support if you need help changing or canceling it."
+msgstr "This subscription is managed by Zoonk. Contact support if you need help changing or canceling it."
+
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "tiFovn"
+msgid "Manage in Google Play"
+msgstr "Manage in Google Play"
+
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "Tp4wJB"
+msgid "This subscription is managed through the App Store. To change or cancel it, use Apple's subscription settings."
+msgstr "This subscription is managed through the App Store. To change or cancel it, use Apple's subscription settings."
+
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "unNUPf"
+msgid "This subscription is managed through Google Play. To change or cancel it, use Google Play."
+msgstr "This subscription is managed through Google Play. To change or cancel it, use Google Play."
+
 #: src/app/(settings)/subscription/page.tsx
 msgctxt "NBEnVd"
 msgid "Compare plans and manage your subscription."
@@ -1619,6 +1649,11 @@ msgstr "Pro"
 msgctxt "uNQcTY"
 msgid "Limited lessons with ads"
 msgstr "Limited lessons with ads"
+
+#: src/app/(settings)/subscription/subscription-plans.tsx
+msgctxt "vaN1qz"
+msgid "Current billing period ends on {date}."
+msgstr "Current billing period ends on {date}."
 
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1514,6 +1514,36 @@ msgctxt "yNHZ+a"
 msgid "Your profile has been updated successfully!"
 msgstr "¡Tu perfil se actualizó correctamente!"
 
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "3iCRcP"
+msgid "Manage in App Store"
+msgstr "Gestionar en App Store"
+
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "5CI3KH"
+msgid "Contact support"
+msgstr "Contactar con soporte"
+
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "P0ZHma"
+msgid "This subscription is managed by Zoonk. Contact support if you need help changing or canceling it."
+msgstr "Esta suscripción es gestionada por Zoonk. Contacta con soporte si necesitas ayuda para cambiarla o cancelarla."
+
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "tiFovn"
+msgid "Manage in Google Play"
+msgstr "Gestionar en Google Play"
+
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "Tp4wJB"
+msgid "This subscription is managed through the App Store. To change or cancel it, use Apple's subscription settings."
+msgstr "Esta suscripción se gestiona a través de App Store. Para cambiarla o cancelarla, usa la configuración de suscripciones de Apple."
+
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "unNUPf"
+msgid "This subscription is managed through Google Play. To change or cancel it, use Google Play."
+msgstr "Esta suscripción se gestiona a través de Google Play. Para cambiarla o cancelarla, usa Google Play."
+
 #: src/app/(settings)/subscription/page.tsx
 msgctxt "NBEnVd"
 msgid "Compare plans and manage your subscription."
@@ -1619,6 +1649,11 @@ msgstr "Pro"
 msgctxt "uNQcTY"
 msgid "Limited lessons with ads"
 msgstr "Lecciones limitadas con anuncios"
+
+#: src/app/(settings)/subscription/subscription-plans.tsx
+msgctxt "vaN1qz"
+msgid "Current billing period ends on {date}."
+msgstr "El período de facturación actual termina el {date}."
 
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1514,6 +1514,36 @@ msgctxt "yNHZ+a"
 msgid "Your profile has been updated successfully!"
 msgstr "Seu perfil foi atualizado com sucesso!"
 
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "3iCRcP"
+msgid "Manage in App Store"
+msgstr "Gerenciar na App Store"
+
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "5CI3KH"
+msgid "Contact support"
+msgstr "Entrar em contato com o suporte"
+
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "P0ZHma"
+msgid "This subscription is managed by Zoonk. Contact support if you need help changing or canceling it."
+msgstr "Esta assinatura é gerenciada pelo Zoonk. Entre em contato com o suporte se precisar de ajuda para alterá-la ou cancelá-la."
+
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "tiFovn"
+msgid "Manage in Google Play"
+msgstr "Gerenciar no Google Play"
+
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "Tp4wJB"
+msgid "This subscription is managed through the App Store. To change or cancel it, use Apple's subscription settings."
+msgstr "Esta assinatura é gerenciada pela App Store. Para alterá-la ou cancelá-la, use os ajustes de assinaturas da Apple."
+
+#: src/app/(settings)/subscription/managed-subscription.tsx
+msgctxt "unNUPf"
+msgid "This subscription is managed through Google Play. To change or cancel it, use Google Play."
+msgstr "Esta assinatura é gerenciada pelo Google Play. Para alterá-la ou cancelá-la, use o Google Play."
+
 #: src/app/(settings)/subscription/page.tsx
 msgctxt "NBEnVd"
 msgid "Compare plans and manage your subscription."
@@ -1619,6 +1649,11 @@ msgstr "Pro"
 msgctxt "uNQcTY"
 msgid "Limited lessons with ads"
 msgstr "Aulas limitadas com anúncios"
+
+#: src/app/(settings)/subscription/subscription-plans.tsx
+msgctxt "vaN1qz"
+msgid "Current billing period ends on {date}."
+msgstr "O período de cobrança atual termina em {date}."
 
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx

--- a/apps/main/src/app/(settings)/subscription/managed-subscription.tsx
+++ b/apps/main/src/app/(settings)/subscription/managed-subscription.tsx
@@ -1,0 +1,148 @@
+import { buttonVariants } from "@zoonk/ui/components/button";
+import { cn } from "@zoonk/ui/lib/utils";
+import { type SubscriptionProvider, isStoreSubscriptionProvider } from "@zoonk/utils/subscription";
+import { getExtracted } from "next-intl/server";
+import Link from "next/link";
+
+const APPLE_SUBSCRIPTION_MANAGEMENT_URL = "https://support.apple.com/billing";
+const GOOGLE_SUBSCRIPTION_MANAGEMENT_URL = "https://play.google.com/store/account/subscriptions";
+
+type ManagedSubscriptionProps = {
+  cancelMessage: string | null;
+  periodMessage: string | null;
+  planTitle: string;
+  provider: Exclude<SubscriptionProvider, "stripe">;
+};
+
+export async function ManagedSubscription({
+  cancelMessage,
+  periodMessage,
+  planTitle,
+  provider,
+}: ManagedSubscriptionProps) {
+  const t = await getExtracted();
+  const action = getManagedSubscriptionAction({ provider });
+  const supportVariant = isStoreSubscriptionProvider(provider) ? "outline" : "secondary";
+
+  const actionLabel = getManagedSubscriptionActionLabel({
+    appleLabel: t("Manage in App Store"),
+    googleLabel: t("Manage in Google Play"),
+    provider,
+  });
+
+  const description = getManagedSubscriptionDescription({
+    appleDescription: t(
+      "This subscription is managed through the App Store. To change or cancel it, use Apple's subscription settings.",
+    ),
+    googleDescription: t(
+      "This subscription is managed through Google Play. To change or cancel it, use Google Play.",
+    ),
+    provider,
+    zoonkDescription: t(
+      "This subscription is managed by Zoonk. Contact support if you need help changing or canceling it.",
+    ),
+  });
+
+  return (
+    <div className="flex w-full max-w-2xl flex-col gap-5">
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-medium">{planTitle}</p>
+        <p className="text-muted-foreground text-sm">{description}</p>
+      </div>
+
+      {periodMessage && <p className="text-muted-foreground text-sm">{periodMessage}</p>}
+      {cancelMessage && <p className="text-destructive text-sm">{cancelMessage}</p>}
+
+      <div className="flex flex-wrap gap-3">
+        {action && (
+          <a
+            className={cn(buttonVariants({ variant: "secondary" }), "w-max")}
+            href={action.href}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {actionLabel}
+          </a>
+        )}
+
+        <Link className={cn(buttonVariants({ variant: supportVariant }), "w-max")} href="/support">
+          {t("Contact support")}
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Store-backed subscriptions need a real handoff target, while Zoonk-managed
+ * subscriptions should stay inside the product and go straight to support.
+ */
+function getManagedSubscriptionAction({
+  provider,
+}: {
+  provider: Exclude<SubscriptionProvider, "stripe">;
+}) {
+  if (provider === "apple") {
+    return {
+      href: APPLE_SUBSCRIPTION_MANAGEMENT_URL,
+    };
+  }
+
+  if (provider === "google") {
+    return {
+      href: GOOGLE_SUBSCRIPTION_MANAGEMENT_URL,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Only store-managed subscriptions need an external manage label. Zoonk-managed
+ * subscriptions skip that action and send the user straight to support.
+ */
+function getManagedSubscriptionActionLabel({
+  appleLabel,
+  googleLabel,
+  provider,
+}: {
+  appleLabel: string;
+  googleLabel: string;
+  provider: Exclude<SubscriptionProvider, "stripe">;
+}) {
+  if (provider === "apple") {
+    return appleLabel;
+  }
+
+  if (provider === "google") {
+    return googleLabel;
+  }
+
+  return null;
+}
+
+/**
+ * The billing page needs provider-specific copy so users immediately understand
+ * why web plan controls are hidden and what they should do next.
+ */
+function getManagedSubscriptionDescription({
+  appleDescription,
+  googleDescription,
+  provider,
+  zoonkDescription,
+}: {
+  appleDescription: string;
+  googleDescription: string;
+  provider: Exclude<SubscriptionProvider, "stripe">;
+  zoonkDescription: string;
+}) {
+  if (provider === "apple") {
+    return appleDescription;
+  }
+
+  if (provider === "google") {
+    return googleDescription;
+  }
+
+  return zoonkDescription;
+}

--- a/apps/main/src/app/(settings)/subscription/subscription-plans.tsx
+++ b/apps/main/src/app/(settings)/subscription/subscription-plans.tsx
@@ -1,11 +1,13 @@
 import { getStripePrices } from "@zoonk/core/auth/stripe-prices";
 import { getActiveSubscription } from "@zoonk/core/auth/subscription";
+import { prisma } from "@zoonk/db";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { countryToCurrency } from "@zoonk/utils/currency";
 import { getCountryFromAcceptLanguage } from "@zoonk/utils/locale";
-import { SUBSCRIPTION_PLANS } from "@zoonk/utils/subscription";
+import { SUBSCRIPTION_PLANS, isWebManagedSubscriptionProvider } from "@zoonk/utils/subscription";
 import { getExtracted, getFormatter } from "next-intl/server";
 import { headers } from "next/headers";
+import { ManagedSubscription } from "./managed-subscription";
 import { PlanList } from "./plan-list";
 
 export async function SubscriptionPlans() {
@@ -24,20 +26,47 @@ export async function SubscriptionPlans() {
   );
 
   const [subscription, priceMap] = await Promise.all([
-    getActiveSubscription(requestHeaders),
+    getCurrentSubscription(requestHeaders),
     getStripePrices(lookupKeys, currency),
   ]);
+
+  const titles: Record<string, string> = {
+    free: t("Free"),
+    hobby: t("Hobby"),
+    plus: t("Plus"),
+    pro: t("Pro"),
+  };
+
   const currentPlan = subscription?.plan ?? null;
 
-  const cancelMessage = subscription?.cancelAt
-    ? t("Your subscription will end on {date}.", {
-        date: format.dateTime(new Date(subscription.cancelAt), {
-          day: "numeric",
-          month: "long",
-          year: "numeric",
-        }),
-      })
+  const cancelDate = getSubscriptionDate({
+    date: subscription?.cancelAt ?? null,
+    format,
+  });
+
+  const periodEndDate = getSubscriptionDate({
+    date: subscription?.cancelAt ? null : (subscription?.periodEnd ?? null),
+    format,
+  });
+
+  const cancelMessage = cancelDate
+    ? t("Your subscription will end on {date}.", { date: cancelDate })
     : null;
+
+  const periodMessage = periodEndDate
+    ? t("Current billing period ends on {date}.", { date: periodEndDate })
+    : null;
+
+  if (subscription && !isWebManagedSubscriptionProvider(subscription.provider)) {
+    return (
+      <ManagedSubscription
+        cancelMessage={cancelMessage}
+        periodMessage={periodMessage}
+        planTitle={titles[subscription.plan] ?? subscription.plan}
+        provider={subscription.provider}
+      />
+    );
+  }
 
   const plans = SUBSCRIPTION_PLANS.map((plan) => {
     const monthlyPrice = plan.lookupKey ? (priceMap.get(plan.lookupKey) ?? null) : null;
@@ -52,13 +81,6 @@ export async function SubscriptionPlans() {
       yearlyPrice,
     };
   });
-
-  const titles: Record<string, string> = {
-    free: t("Free"),
-    hobby: t("Hobby"),
-    plus: t("Plus"),
-    pro: t("Pro"),
-  };
 
   const descriptions: Record<string, string> = {
     free: t("Limited lessons with ads"),
@@ -76,6 +98,44 @@ export async function SubscriptionPlans() {
       titles={titles}
     />
   );
+}
+
+/**
+ * Better Auth still decides which row is currently active. Once we know that
+ * row, Prisma can read the extra provider field we added around Better Auth's schema.
+ */
+async function getCurrentSubscription(requestHeaders: Headers) {
+  const activeSubscription = await getActiveSubscription(requestHeaders);
+
+  if (!activeSubscription) {
+    return null;
+  }
+
+  return prisma.subscription.findUnique({
+    where: { id: activeSubscription.id },
+  });
+}
+
+/**
+ * Formatting the subscription date in one place keeps the billing copy focused
+ * on the state change instead of repeating date-shape details in each message.
+ */
+function getSubscriptionDate({
+  date,
+  format,
+}: {
+  date: Date | null;
+  format: Awaited<ReturnType<typeof getFormatter>>;
+}) {
+  if (!date) {
+    return null;
+  }
+
+  return format.dateTime(new Date(date), {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
 }
 
 export function SubscriptionPlansSkeleton() {

--- a/packages/db/src/prisma/enums.prisma
+++ b/packages/db/src/prisma/enums.prisma
@@ -61,3 +61,10 @@ enum ContentManagementMode {
   manual
   pinned
 }
+
+enum SubscriptionProvider {
+  stripe
+  google
+  apple
+  zoonk
+}

--- a/packages/db/src/prisma/migrations/20260416145137_add_subscription_provider/migration.sql
+++ b/packages/db/src/prisma/migrations/20260416145137_add_subscription_provider/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "SubscriptionProvider" AS ENUM ('stripe', 'google', 'apple', 'zoonk');
+
+-- AlterTable
+ALTER TABLE "subscriptions" ADD COLUMN     "provider" "SubscriptionProvider" NOT NULL DEFAULT 'stripe';

--- a/packages/db/src/prisma/models/accounts.prisma
+++ b/packages/db/src/prisma/models/accounts.prisma
@@ -141,23 +141,24 @@ model Invitation {
 }
 
 model Subscription {
-  id                   String    @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  id                   String               @id @default(dbgenerated("uuidv7()")) @db.Uuid
   plan                 String
-  referenceId          String    @map("reference_id") @db.Uuid
-  stripeCustomerId     String?   @map("stripe_customer_id")
-  stripeSubscriptionId String?   @map("stripe_subscription_id")
-  status               String?   @default("incomplete")
-  periodStart          DateTime? @map("period_start")
-  periodEnd            DateTime? @map("period_end")
-  trialStart           DateTime? @map("trial_start")
-  trialEnd             DateTime? @map("trial_end")
-  cancelAtPeriodEnd    Boolean?  @default(false) @map("cancel_at_period_end")
-  cancelAt             DateTime? @map("cancel_at")
-  canceledAt           DateTime? @map("canceled_at")
-  endedAt              DateTime? @map("ended_at")
+  provider             SubscriptionProvider @default(stripe)
+  referenceId          String               @map("reference_id") @db.Uuid
+  stripeCustomerId     String?              @map("stripe_customer_id")
+  stripeSubscriptionId String?              @map("stripe_subscription_id")
+  status               String?              @default("incomplete")
+  periodStart          DateTime?            @map("period_start")
+  periodEnd            DateTime?            @map("period_end")
+  trialStart           DateTime?            @map("trial_start")
+  trialEnd             DateTime?            @map("trial_end")
+  cancelAtPeriodEnd    Boolean?             @default(false) @map("cancel_at_period_end")
+  cancelAt             DateTime?            @map("cancel_at")
+  canceledAt           DateTime?            @map("canceled_at")
+  endedAt              DateTime?            @map("ended_at")
   seats                Int?
-  billingInterval      String?   @map("billing_interval")
-  stripeScheduleId     String?   @map("stripe_schedule_id")
+  billingInterval      String?              @map("billing_interval")
+  stripeScheduleId     String?              @map("stripe_schedule_id")
 
   @@index([referenceId])
   @@index([status])

--- a/packages/db/src/prisma/seed/subscriptions.ts
+++ b/packages/db/src/prisma/seed/subscriptions.ts
@@ -17,6 +17,7 @@ export async function seedSubscriptions(prisma: PrismaClient, users: SeedUsers):
     periodEnd: oneYearFromNow,
     periodStart: now,
     plan: "hobby",
+    provider: "zoonk" as const,
     referenceId: user.id,
     status: "active",
     stripeCustomerId: null,

--- a/packages/utils/src/subscription.ts
+++ b/packages/utils/src/subscription.ts
@@ -1,6 +1,9 @@
 const PLAN_NAMES = ["free", "hobby", "plus", "pro"] as const;
 type PlanName = (typeof PLAN_NAMES)[number];
 
+export const SUBSCRIPTION_PROVIDERS = ["stripe", "google", "apple", "zoonk"] as const;
+export type SubscriptionProvider = (typeof SUBSCRIPTION_PROVIDERS)[number];
+
 const PLAN_LOOKUP_KEYS: Record<Exclude<PlanName, "free">, { monthly: string; yearly: string }> = {
   hobby: { monthly: "hobby_monthly", yearly: "hobby_yearly" },
   plus: { monthly: "plus_monthly", yearly: "plus_yearly" },
@@ -65,4 +68,24 @@ export function getPlanTier(planName: string | null): number {
     return 0;
   }
   return ALL_SUBSCRIPTION_PLANS.find((plan) => plan.name === planName)?.tier ?? 0;
+}
+
+/**
+ * The web billing page should only expose direct plan controls when Stripe owns
+ * the subscription. Every other provider needs a different handoff.
+ */
+export function isWebManagedSubscriptionProvider(
+  provider: SubscriptionProvider | null | undefined,
+): provider is "stripe" {
+  return provider === "stripe";
+}
+
+/**
+ * Apple and Google purchases must be managed in the original store instead of
+ * pretending the web app can cancel or change them.
+ */
+export function isStoreSubscriptionProvider(
+  provider: SubscriptionProvider | null | undefined,
+): provider is "apple" | "google" {
+  return provider === "apple" || provider === "google";
 }


### PR DESCRIPTION
## Summary
- add a required subscription provider field and seed internal subscriptions as `zoonk`
- show provider-specific billing handoff UI for apple, google, and zoonk-managed subscriptions
- update admin subscription controls and add e2e coverage for provider-managed billing states

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add provider-managed billing across web and admin with a required subscription provider and a new managed billing UI. Non-Stripe subscribers now see store/support handoffs and period/cancel messages; admin plan changes are limited to Zoonk-managed accounts.

- **New Features**
  - Add `provider` enum (`stripe`, `google`, `apple`, `zoonk`) to subscriptions and seed internal rows as `zoonk`.
  - Update billing page to show provider handoffs (App Store/Google Play links or Support for Zoonk), display period/cancel messages, and hide plan controls for non-Stripe.
  - Show provider label in Admin and restrict “Change plan” to Zoonk-managed users.
  - Add e2e tests for Apple/Google/Zoonk flows and tighten App Store link assertions; add i18n strings in `en`, `es`, and `pt`.

- **Migration**
  - Run DB migration to add `SubscriptionProvider` and the `subscriptions.provider` column (defaults to `stripe`).

<sup>Written for commit 59ee5d22582855f0b8f8fdb6ad011d2d0d245935. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

