### PR TITLE
fix(admin): count only real ai runs in cost estimates

### DIFF
--- a/apps/admin/src/data/stats/ai/_utils/get-ai-cost-estimate-structure.ts
+++ b/apps/admin/src/data/stats/ai/_utils/get-ai-cost-estimate-structure.ts
@@ -206,7 +206,7 @@ async function getVisualUsageRows({
         AND s.archived_at IS NULL
         AND a.archived_at IS NULL
         AND l.archived_at IS NULL
-        AND l.management_mode = 'ai'
+        AND l.generation_run_id IS NOT NULL
         AND l.generation_status = 'completed'
         AND l.created_at >= ${dateWindow.startAt}
         AND l.created_at < ${dateWindow.endExclusive}
@@ -242,7 +242,7 @@ async function getLanguageAudioUsage({
         JOIN courses c ON c.id = ch.course_id
         WHERE l.kind = 'language'
           AND l.archived_at IS NULL
-          AND l.management_mode = 'ai'
+          AND l.generation_run_id IS NOT NULL
           AND l.generation_status = 'completed'
           AND l.created_at >= ${dateWindow.startAt}
           AND l.created_at < ${dateWindow.endExclusive}
@@ -310,6 +310,7 @@ function countActivities({
   return prisma.activity.count({
     where: {
       archivedAt: null,
+      generationRunId: { not: null },
       generationStatus: "completed",
       kind: activityKind,
       lesson: { ...where, kind: lessonKind },
@@ -317,12 +318,21 @@ function countActivities({
   });
 }
 
+/**
+ * A row counts as "AI-generated" only when it carries a workflow run id. That
+ * id is written when the generation workflow marks the entity as running, so
+ * it cleanly excludes seed data, fixtures, and manually-added content — all of
+ * which can share the same `management_mode` or `generation_status` values but
+ * never flow through a workflow. Pairing the run id with `generation_status =
+ * 'completed'` narrows further to runs that finished successfully, which is
+ * the only shape the cost-per-unit math can divide against honestly.
+ */
 function buildCompletedLessonWhere({ dateWindow }: { dateWindow: DateWindow }) {
   return {
     archivedAt: null,
     createdAt: { gte: dateWindow.startAt, lt: dateWindow.endExclusive },
+    generationRunId: { not: null },
     generationStatus: "completed" as const,
-    managementMode: "ai" as const,
   };
 }
 
@@ -336,8 +346,8 @@ function buildCompletedCourseWhere({
   return {
     archivedAt: null,
     createdAt: { gte: dateWindow.startAt, lt: dateWindow.endExclusive },
+    generationRunId: { not: null },
     generationStatus: "completed" as const,
-    managementMode: "ai" as const,
     targetLanguage,
   };
 }
@@ -346,7 +356,7 @@ function buildChapterShellWhere({ dateWindow }: { dateWindow: DateWindow }) {
   return {
     archivedAt: null,
     createdAt: { gte: dateWindow.startAt, lt: dateWindow.endExclusive },
-    managementMode: "ai" as const,
+    generationRunId: { not: null },
   };
 }
 


### PR DESCRIPTION
## Summary

- The AI cost estimator filtered lessons/chapters/courses by `management_mode=ai + generation_status=completed`, which includes seed data, fixtures, and manually-added content. That inflated the denominator in the per-unit cost math (locally, we saw "10 completed core lessons" when only 1 real workflow run existed).
- Switch every structure query to `generation_run_id IS NOT NULL + generation_status = completed` — the run id is only written when the workflow marks the entity as running, so it strictly excludes non-workflow content while still only counting runs that finished.
- Applied the same filter to the raw SQL queries for visual and language audio usage, and to the activity counts that feed the per-lesson averages.

## Test plan

- [ ] Open the AI stats page with recent data and confirm lesson/chapter/course sample counts now reflect only real AI-generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes admin cost estimates by counting only workflow-backed generations. We now require a non-null run id and completed status to avoid seed/fixture/manual content inflating per-unit costs.

- **Bug Fixes**
  - Switched lesson/chapter/course filters to `generation_run_id IS NOT NULL` + `generation_status = 'completed'`.
  - Applied the same filter in raw SQL for visual usage and language audio usage.
  - Updated activity counts and completed-where builders to use the run id filter.

<sup>Written for commit 3acddbfe1f1142df66aa59877625e032444767e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

