### PR TITLE
Revert "fix(auth): don't update name on checkout (#1272)"

### DIFF
--- a/packages/auth/src/stripe/plugin.ts
+++ b/packages/auth/src/stripe/plugin.ts
@@ -20,7 +20,6 @@ export function stripePlugin({ createCustomerOnSignUp = true }: StripePluginOpti
         params: {
           allow_promotion_codes: true,
           billing_address_collection: "required",
-          customer_update: { name: "never" },
           tax_id_collection: { enabled: true },
         },
       }),


### PR DESCRIPTION
This reverts commit dcf5a07d9e8356f36ea3438358281a532a6af779.

`tax_id_collection` requires `customer_update`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the change that blocked name updates in Stripe Checkout by removing `customer_update: { name: "never" }`. This restores compatibility with `tax_id_collection`.

<sup>Written for commit 5e8ec0c6685722be7648bf83a11a7b84fa2e2809. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

