### PR TITLE
chore(auth): disable tax and address collection

### DIFF
--- a/packages/auth/src/stripe/plugin.ts
+++ b/packages/auth/src/stripe/plugin.ts
@@ -19,9 +19,6 @@ export function stripePlugin({ createCustomerOnSignUp = true }: StripePluginOpti
       getCheckoutSessionParams: () => ({
         params: {
           allow_promotion_codes: true,
-          billing_address_collection: "required",
-          customer_update: { name: "never" },
-          tax_id_collection: { enabled: true },
         },
       }),
       plans: PAID_PLANS.map((plan) => ({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable tax ID and billing address collection in Stripe Checkout for the `packages/auth` Stripe plugin to reduce checkout friction.
Removed `billing_address_collection`, `tax_id_collection`, and the `customer_update: { name: 'never' }` override to use Stripe defaults.

<sup>Written for commit 896bd124d6ee37a8eea98dad00fcce712d4da0e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

