### PR TITLE
refactor(evals): simplify log output

### DIFF
--- a/apps/evals/src/lib/output-generator.ts
+++ b/apps/evals/src/lib/output-generator.ts
@@ -10,11 +10,7 @@ async function generateOutputForTestCase(
   modelId: string,
   runNumber: number,
 ): Promise<OutputEntry> {
-  const inputSummary = Object.entries(testCase.userInput)
-    .map(([key, value]) => `${key}=${String(value)}`)
-    .join(", ");
-
-  logInfo(`Generating output for: ${inputSummary} (run ${runNumber})`);
+  logInfo(`Generating output for: ${testCase.id} (run ${runNumber})`);
 
   const model = getModelById(modelId);
   const gatewayModelId = getGatewayModelId(modelId);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified evals log output by logging the test case ID instead of enumerating `userInput`. This reduces noise and potential PII, and makes runs easier to scan.

<sup>Written for commit ee6f165d5877fa034171a609bb0b2cd086cef7ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

