### PR TITLE
feat(ai): save custom core activity titles

### DIFF
--- a/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
@@ -149,6 +149,7 @@ vi.mock("@zoonk/ai/tasks/activities/core/practice", () => ({
           question: "What should you do?",
         },
       ],
+      title: "The game store signup mix-up",
     },
   }),
 }));

--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
@@ -153,6 +153,7 @@ vi.mock("@zoonk/ai/tasks/activities/core/practice", () => ({
           question: "What should you do?",
         },
       ],
+      title: "The game store signup mix-up",
     },
   }),
 }));
@@ -209,6 +210,7 @@ vi.mock("@zoonk/ai/tasks/activities/core/story-steps", () => ({
           situation: "Your supplier went bankrupt.",
         },
       ],
+      title: "The night the labels got swapped",
     },
   }),
 }));

--- a/apps/api/src/workflows/activity-generation/custom-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/custom-activity-workflow.test.ts
@@ -108,7 +108,9 @@ vi.mock("@zoonk/ai/tasks/activities/core/explanation", () => ({
 }));
 
 vi.mock("@zoonk/ai/tasks/activities/core/practice", () => ({
-  generateActivityPractice: vi.fn().mockResolvedValue({ data: { steps: [] } }),
+  generateActivityPractice: vi.fn().mockResolvedValue({
+    data: { steps: [], title: "The game store signup mix-up" },
+  }),
 }));
 
 vi.mock("@zoonk/ai/tasks/activities/core/quiz", () => ({

--- a/apps/api/src/workflows/activity-generation/kinds/investigation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/investigation-workflow.test.ts
@@ -44,6 +44,7 @@ const { mockScenario, mockAccuracy, mockActions, mockFindings } = vi.hoisted(() 
       "Explanation C is wrong",
     ],
     scenario: "A mysterious event happened in a factory.",
+    title: "Who froze the payment queue?",
   },
 }));
 
@@ -153,6 +154,7 @@ describe("investigation activity workflow", () => {
 
     expect(dbActivity?.generationStatus).toBe("completed");
     expect(dbActivity?.generationRunId).toBe("test-run-id");
+    expect(dbActivity?.title).toBe(mockScenario.title);
   });
 
   test("saves correct problem step content", async () => {

--- a/apps/api/src/workflows/activity-generation/kinds/investigation-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/investigation-workflow.ts
@@ -27,9 +27,10 @@ export async function investigationActivityWorkflow({
 }): Promise<void> {
   "use workflow";
 
-  const { activityId, scenario } = await generateInvestigationScenarioStep(activitiesToGenerate);
+  const { activityId, scenario, title } =
+    await generateInvestigationScenarioStep(activitiesToGenerate);
 
-  if (!activityId || !scenario) {
+  if (!activityId || !scenario || !title) {
     return;
   }
 
@@ -78,6 +79,7 @@ export async function investigationActivityWorkflow({
     activityId,
     findings,
     scenario,
+    title,
     workflowRunId,
   });
 }

--- a/apps/api/src/workflows/activity-generation/kinds/practice-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/practice-workflow.test.ts
@@ -27,6 +27,7 @@ vi.mock("@zoonk/ai/tasks/activities/core/practice", () => ({
           question: "What should you do?",
         },
       ],
+      title: "The game store signup mix-up",
     },
   }),
 }));
@@ -156,6 +157,7 @@ describe("practice activity workflow", () => {
     });
     expect(dbActivity?.generationStatus).toBe("completed");
     expect(dbActivity?.generationRunId).toBe("test-run-id");
+    expect(dbActivity?.title).toBe("The game store signup mix-up");
   });
 
   test("sets practice status to 'failed' when AI throws", async () => {

--- a/apps/api/src/workflows/activity-generation/kinds/practice-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/practice-workflow.ts
@@ -41,20 +41,21 @@ export async function practiceActivityWorkflow({
         return;
       }
 
-      const { activityId, steps } = await generatePracticeContentStep(
+      const { activityId, steps, title } = await generatePracticeContentStep(
         allActivities,
         getExplanationStepsForPractice(explanationResults, practiceIndex, totalPractices),
         workflowRunId,
         practiceIndex,
       );
 
-      if (!activityId || steps.length === 0) {
+      if (!activityId || steps.length === 0 || !title) {
         return;
       }
 
       await savePracticeActivityStep({
         activityId,
         steps,
+        title,
         workflowRunId,
       });
     }),

--- a/apps/api/src/workflows/activity-generation/kinds/story-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/story-workflow.test.ts
@@ -76,6 +76,7 @@ const { mockStorySteps, mockDebriefData } = vi.hoisted(() => ({
         situation: "Production is halted without parts.",
       },
     ],
+    title: "The night the labels got swapped",
   },
 }));
 
@@ -195,6 +196,7 @@ describe("story activity workflow", () => {
 
     expect(dbActivity?.generationStatus).toBe("completed");
     expect(dbActivity?.generationRunId).toBe("test-run-id");
+    expect(dbActivity?.title).toBe(mockStorySteps.title);
   });
 
   test("skips when no story activity exists", async () => {

--- a/apps/api/src/workflows/activity-generation/kinds/story-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/story-workflow.ts
@@ -24,9 +24,9 @@ export async function storyActivityWorkflow({
 }): Promise<void> {
   "use workflow";
 
-  const { activityId, storySteps } = await generateStoryContentStep(activitiesToGenerate);
+  const { activityId, storySteps, title } = await generateStoryContentStep(activitiesToGenerate);
 
-  if (!activityId || !storySteps) {
+  if (!activityId || !storySteps || !title) {
     return;
   }
 
@@ -40,5 +40,5 @@ export async function storyActivityWorkflow({
     return;
   }
 
-  await saveStoryActivityStep({ activityId, debriefData, storySteps, workflowRunId });
+  await saveStoryActivityStep({ activityId, debriefData, storySteps, title, workflowRunId });
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-accuracy-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-accuracy-step.test.ts
@@ -34,6 +34,7 @@ vi.mock("@zoonk/ai/tasks/activities/core/investigation-accuracy", () => ({
 const mockScenario = {
   explanations: ["Best explanation", "Partial explanation", "Wrong explanation"],
   scenario: "A mysterious drop in website traffic occurred overnight.",
+  title: "Who froze the payment queue?",
 };
 
 const mockAccuracyData = {

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-actions-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-actions-step.test.ts
@@ -34,6 +34,7 @@ vi.mock("@zoonk/ai/tasks/activities/core/investigation-actions", () => ({
 const mockScenario = {
   explanations: ["Best explanation", "Partial explanation", "Wrong explanation"],
   scenario: "A mysterious drop in website traffic occurred overnight.",
+  title: "Who froze the payment queue?",
 };
 
 const mockAccuracy = {

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-findings-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-findings-step.test.ts
@@ -34,6 +34,7 @@ vi.mock("@zoonk/ai/tasks/activities/core/investigation-findings", () => ({
 const mockScenario = {
   explanations: ["Best explanation", "Partial explanation", "Wrong explanation"],
   scenario: "A mysterious drop in website traffic occurred overnight.",
+  title: "Who froze the payment queue?",
 };
 
 const mockAccuracy = {

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-scenario-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-scenario-step.test.ts
@@ -39,6 +39,7 @@ const mockScenarioData = {
     "Explanation C is wrong",
   ],
   scenario: "A mysterious drop in website traffic occurred overnight.",
+  title: "Who froze the payment queue?",
 };
 
 describe(generateInvestigationScenarioStep, () => {
@@ -87,6 +88,7 @@ describe(generateInvestigationScenarioStep, () => {
 
     expect(result.activityId).toBe(activities.find((a) => a.kind === "investigation")?.id);
     expect(result.scenario).toEqual(mockScenarioData);
+    expect(result.title).toBe("Who froze the payment queue?");
   });
 
   test("passes lesson context to AI task", async () => {
@@ -144,7 +146,7 @@ describe(generateInvestigationScenarioStep, () => {
 
     const result = await generateInvestigationScenarioStep(activities);
 
-    expect(result).toEqual({ activityId: null, scenario: null });
+    expect(result).toEqual({ activityId: null, scenario: null, title: null });
     expect(generateActivityInvestigationScenarioMock).not.toHaveBeenCalled();
   });
 
@@ -167,12 +169,12 @@ describe(generateInvestigationScenarioStep, () => {
     const activities = await fetchLessonActivities(lesson.id);
 
     generateActivityInvestigationScenarioMock.mockResolvedValue({
-      data: { explanations: [], scenario: "A scenario" },
+      data: { explanations: [], scenario: "A scenario", title: "Who froze the payment queue?" },
     });
 
     const result = await generateInvestigationScenarioStep(activities);
 
-    expect(result).toEqual({ activityId: null, scenario: null });
+    expect(result).toEqual({ activityId: null, scenario: null, title: null });
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
     expect(updated.generationStatus).toBe("failed");
@@ -210,7 +212,7 @@ describe(generateInvestigationScenarioStep, () => {
 
     const result = await generateInvestigationScenarioStep(activities);
 
-    expect(result).toEqual({ activityId: null, scenario: null });
+    expect(result).toEqual({ activityId: null, scenario: null, title: null });
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
     expect(updated.generationStatus).toBe("failed");

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-scenario-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-scenario-step.ts
@@ -12,6 +12,7 @@ import { handleActivityFailureStep } from "./handle-failure-step";
 type InvestigationScenarioResult = {
   activityId: string | null;
   scenario: ActivityInvestigationScenarioSchema | null;
+  title: string | null;
 };
 
 /**
@@ -30,7 +31,7 @@ export async function generateInvestigationScenarioStep(
   const investigationActivity = findActivityByKind(activities, "investigation");
 
   if (!investigationActivity) {
-    return { activityId: null, scenario: null };
+    return { activityId: null, scenario: null, title: null };
   }
 
   await using stream = createEntityStepStream<ActivityStepName>(investigationActivity.id);
@@ -56,10 +57,14 @@ export async function generateInvestigationScenarioStep(
     await stream.error({ reason, step: "generateInvestigationScenario" });
     await handleActivityFailureStep({ activityId: investigationActivity.id });
 
-    return { activityId: null, scenario: null };
+    return { activityId: null, scenario: null, title: null };
   }
 
   await stream.status({ status: "completed", step: "generateInvestigationScenario" });
 
-  return { activityId: investigationActivity.id, scenario: result.data };
+  return {
+    activityId: investigationActivity.id,
+    scenario: result.data,
+    title: result.data.title,
+  };
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-practice-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-practice-content-step.test.ts
@@ -81,7 +81,12 @@ describe(generatePracticeContentStep, () => {
       },
     ];
 
-    generateActivityPracticeMock.mockResolvedValue({ data: { steps: practiceSteps } });
+    generateActivityPracticeMock.mockResolvedValue({
+      data: {
+        steps: practiceSteps,
+        title: "The game store signup mix-up",
+      },
+    });
 
     const explanationSteps = [{ text: "Explanation text", title: "Explanation title" }];
 
@@ -89,6 +94,7 @@ describe(generatePracticeContentStep, () => {
 
     expect(result.activityId).toBe(activities.find((a) => a.kind === "practice")?.id);
     expect(result.steps).toEqual(practiceSteps);
+    expect(result.title).toBe("The game store signup mix-up");
   });
 
   test("returns null activityId when no practice activity exists", async () => {
@@ -115,7 +121,7 @@ describe(generatePracticeContentStep, () => {
       "run-2",
     );
 
-    expect(result).toEqual({ activityId: null, steps: [] });
+    expect(result).toEqual({ activityId: null, steps: [], title: null });
     expect(generateActivityPracticeMock).not.toHaveBeenCalled();
   });
 
@@ -139,7 +145,7 @@ describe(generatePracticeContentStep, () => {
 
     const result = await generatePracticeContentStep(activities, [], "run-3");
 
-    expect(result).toEqual({ activityId: null, steps: [] });
+    expect(result).toEqual({ activityId: null, steps: [], title: null });
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
     expect(updated.generationStatus).toBe("failed");
@@ -163,7 +169,9 @@ describe(generatePracticeContentStep, () => {
 
     const activities = await fetchLessonActivities(lesson.id);
 
-    generateActivityPracticeMock.mockResolvedValue({ data: { steps: [] } });
+    generateActivityPracticeMock.mockResolvedValue({
+      data: { steps: [], title: "The game store signup mix-up" },
+    });
 
     const result = await generatePracticeContentStep(
       activities,
@@ -171,7 +179,7 @@ describe(generatePracticeContentStep, () => {
       "run-4",
     );
 
-    expect(result).toEqual({ activityId: null, steps: [] });
+    expect(result).toEqual({ activityId: null, steps: [], title: null });
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
     expect(updated.generationStatus).toBe("failed");
@@ -205,6 +213,7 @@ describe(generatePracticeContentStep, () => {
             question: "q",
           },
         ],
+        title: "The game store signup mix-up",
       },
     });
 
@@ -256,7 +265,7 @@ describe(generatePracticeContentStep, () => {
       "run-6",
     );
 
-    expect(result).toEqual({ activityId: null, steps: [] });
+    expect(result).toEqual({ activityId: null, steps: [], title: null });
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
     expect(updated.generationStatus).toBe("failed");

--- a/apps/api/src/workflows/activity-generation/steps/generate-practice-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-practice-content-step.ts
@@ -26,18 +26,18 @@ export async function generatePracticeContentStep(
   explanationSteps: ActivitySteps,
   workflowRunId: string,
   practiceIndex = 0,
-): Promise<{ activityId: string | null; steps: PracticeStep[] }> {
+): Promise<{ activityId: string | null; steps: PracticeStep[]; title: string | null }> {
   "use step";
 
   const practiceActivity = findActivitiesByKind(activities, "practice")[practiceIndex];
 
   if (!practiceActivity) {
-    return { activityId: null, steps: [] };
+    return { activityId: null, steps: [], title: null };
   }
 
   if (explanationSteps.length === 0) {
     await handleActivityFailureStep({ activityId: practiceActivity.id });
-    return { activityId: null, steps: [] };
+    return { activityId: null, steps: [], title: null };
   }
 
   await using stream = createEntityStepStream<ActivityStepName>(practiceActivity.id);
@@ -60,9 +60,13 @@ export async function generatePracticeContentStep(
     const reason = getAIResultErrorReason({ error, result });
     await stream.error({ reason, step: "generatePracticeContent" });
     await handleActivityFailureStep({ activityId: practiceActivity.id });
-    return { activityId: null, steps: [] };
+    return { activityId: null, steps: [], title: null };
   }
 
   await stream.status({ status: "completed", step: "generatePracticeContent" });
-  return { activityId: practiceActivity.id, steps: result.data.steps };
+  return {
+    activityId: practiceActivity.id,
+    steps: result.data.steps,
+    title: result.data.title,
+  };
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.test.ts
@@ -56,6 +56,7 @@ const mockStoryData = {
       situation: "Your supplier went bankrupt.",
     },
   ],
+  title: "The night the labels got swapped",
 };
 
 describe(generateStoryContentStep, () => {
@@ -103,6 +104,7 @@ describe(generateStoryContentStep, () => {
 
     expect(result.activityId).toBe(activities.find((a) => a.kind === "story")?.id);
     expect(result.storySteps).toEqual(mockStoryData);
+    expect(result.title).toBe("The night the labels got swapped");
   });
 
   test("passes lesson concepts and context to the AI task", async () => {
@@ -157,7 +159,7 @@ describe(generateStoryContentStep, () => {
 
     const result = await generateStoryContentStep(activities);
 
-    expect(result).toEqual({ activityId: null, storySteps: null });
+    expect(result).toEqual({ activityId: null, storySteps: null, title: null });
     expect(generateActivityStoryStepsMock).not.toHaveBeenCalled();
   });
 
@@ -180,12 +182,17 @@ describe(generateStoryContentStep, () => {
     const activities = await fetchLessonActivities(lesson.id);
 
     generateActivityStoryStepsMock.mockResolvedValue({
-      data: { intro: "Intro", metrics: ["M"], steps: [] },
+      data: {
+        intro: "Intro",
+        metrics: ["M"],
+        steps: [],
+        title: "The night the labels got swapped",
+      },
     });
 
     const result = await generateStoryContentStep(activities);
 
-    expect(result).toEqual({ activityId: null, storySteps: null });
+    expect(result).toEqual({ activityId: null, storySteps: null, title: null });
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
     expect(updated.generationStatus).toBe("failed");
@@ -223,7 +230,7 @@ describe(generateStoryContentStep, () => {
 
     const result = await generateStoryContentStep(activities);
 
-    expect(result).toEqual({ activityId: null, storySteps: null });
+    expect(result).toEqual({ activityId: null, storySteps: null, title: null });
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
     expect(updated.generationStatus).toBe("failed");

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.ts
@@ -12,6 +12,7 @@ import { handleActivityFailureStep } from "./handle-failure-step";
 type StoryContentResult = {
   activityId: string | null;
   storySteps: ActivityStoryStepsSchema | null;
+  title: string | null;
 };
 
 /**
@@ -31,7 +32,7 @@ export async function generateStoryContentStep(
   const storyActivity = findActivityByKind(activities, "story");
 
   if (!storyActivity) {
-    return { activityId: null, storySteps: null };
+    return { activityId: null, storySteps: null, title: null };
   }
 
   await using stream = createEntityStepStream<ActivityStepName>(storyActivity.id);
@@ -58,10 +59,10 @@ export async function generateStoryContentStep(
     await stream.error({ reason, step: "generateStoryContent" });
     await handleActivityFailureStep({ activityId: storyActivity.id });
 
-    return { activityId: null, storySteps: null };
+    return { activityId: null, storySteps: null, title: null };
   }
 
   await stream.status({ status: "completed", step: "generateStoryContent" });
 
-  return { activityId: storyActivity.id, storySteps: result.data };
+  return { activityId: storyActivity.id, storySteps: result.data, title: result.data.title };
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-debrief-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-debrief-step.test.ts
@@ -49,6 +49,7 @@ const mockStorySteps = {
       situation: "Your supplier went bankrupt.",
     },
   ],
+  title: "The night the labels got swapped",
 };
 
 const mockDebriefData = {

--- a/apps/api/src/workflows/activity-generation/steps/save-investigation-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-investigation-activity-step.test.ts
@@ -27,6 +27,7 @@ vi.mock("workflow", () => ({
 const mockScenario = {
   explanations: ["Best explanation text", "Wrong explanation text"],
   scenario: "A mysterious drop in website traffic occurred overnight.",
+  title: "Who froze the payment queue?",
 };
 
 const mockAccuracy = {
@@ -85,7 +86,7 @@ describe(saveInvestigationActivityStep, () => {
       language: "en",
       lessonId: lesson.id,
       organizationId,
-      title: `Investigation ${randomUUID()}`,
+      title: null,
     });
 
     await saveInvestigationActivityStep({
@@ -94,6 +95,7 @@ describe(saveInvestigationActivityStep, () => {
       activityId: activity.id,
       findings: mockFindings,
       scenario: mockScenario,
+      title: mockScenario.title,
       workflowRunId: "workflow-1",
     });
 
@@ -151,6 +153,7 @@ describe(saveInvestigationActivityStep, () => {
     expect(dbActivity).toMatchObject({
       generationRunId: "workflow-1",
       generationStatus: "completed",
+      title: mockScenario.title,
     });
 
     const events = getStreamedEvents(writeMock);
@@ -186,6 +189,7 @@ describe(saveInvestigationActivityStep, () => {
       activityId: activity.id,
       findings: mockFindings,
       scenario: mockScenario,
+      title: mockScenario.title,
       workflowRunId: "workflow-completed",
     });
 
@@ -195,6 +199,7 @@ describe(saveInvestigationActivityStep, () => {
 
     expect(dbActivity.generationRunId).toBe("workflow-completed");
     expect(dbActivity.generationStatus).toBe("completed");
+    expect(dbActivity.title).toBe(mockScenario.title);
   });
 
   test("streams error when DB transaction fails", async () => {
@@ -222,6 +227,7 @@ describe(saveInvestigationActivityStep, () => {
       activityId: activity.id,
       findings: mockFindings,
       scenario: mockScenario,
+      title: mockScenario.title,
       workflowRunId: "workflow-error",
     });
 

--- a/apps/api/src/workflows/activity-generation/steps/save-investigation-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-investigation-activity-step.ts
@@ -108,6 +108,7 @@ export async function saveInvestigationActivityStep({
   actions,
   findings,
   scenario,
+  title,
   workflowRunId,
 }: {
   accuracy: ActivityInvestigationAccuracySchema;
@@ -115,6 +116,7 @@ export async function saveInvestigationActivityStep({
   actions: ActivityInvestigationActionsSchema;
   findings: ActivityInvestigationFindingsSchema;
   scenario: ActivityInvestigationScenarioSchema;
+  title: string;
   workflowRunId: string;
 }): Promise<void> {
   "use step";
@@ -135,7 +137,7 @@ export async function saveInvestigationActivityStep({
     prisma.$transaction([
       prisma.step.createMany({ data: stepRecords }),
       prisma.activity.update({
-        data: { generationRunId: workflowRunId, generationStatus: "completed" },
+        data: { generationRunId: workflowRunId, generationStatus: "completed", title },
         where: { id: activityId },
       }),
     ]),

--- a/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.test.ts
@@ -57,7 +57,7 @@ describe(savePracticeActivityStep, () => {
       language: "en",
       lessonId: lesson.id,
       organizationId,
-      title: `Practice ${randomUUID()}`,
+      title: null,
     });
 
     const steps: PracticeStep[] = [
@@ -86,6 +86,7 @@ describe(savePracticeActivityStep, () => {
     await savePracticeActivityStep({
       activityId: activity.id,
       steps,
+      title: "The game store signup mix-up",
       workflowRunId: "workflow-1",
     });
 
@@ -109,6 +110,7 @@ describe(savePracticeActivityStep, () => {
     expect(dbActivity).toMatchObject({
       generationRunId: "workflow-1",
       generationStatus: "completed",
+      title: "The game store signup mix-up",
     });
 
     const events = getStreamedEvents(writeMock);
@@ -157,6 +159,7 @@ describe(savePracticeActivityStep, () => {
     await savePracticeActivityStep({
       activityId: activity.id,
       steps,
+      title: "The game store signup mix-up",
       workflowRunId: "workflow-error",
     });
 

--- a/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.ts
@@ -38,10 +38,12 @@ function buildPracticeStepRecords(activityId: string, steps: PracticeStep[]) {
 export async function savePracticeActivityStep({
   activityId,
   steps,
+  title,
   workflowRunId,
 }: {
   activityId: string;
   steps: PracticeStep[];
+  title: string;
   workflowRunId: string;
 }): Promise<void> {
   "use step";
@@ -56,7 +58,7 @@ export async function savePracticeActivityStep({
     prisma.$transaction([
       prisma.step.createMany({ data: stepRecords }),
       prisma.activity.update({
-        data: { generationRunId: workflowRunId, generationStatus: "completed" },
+        data: { generationRunId: workflowRunId, generationStatus: "completed", title },
         where: { id: activityId },
       }),
     ]),

--- a/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.test.ts
@@ -70,6 +70,7 @@ const storySteps = {
       situation: "Production is halted.",
     },
   ],
+  title: "The night the labels got swapped",
 };
 
 const debriefData = {
@@ -116,13 +117,14 @@ describe(saveStoryActivityStep, () => {
       language: "en",
       lessonId: lesson.id,
       organizationId,
-      title: `Story ${randomUUID()}`,
+      title: null,
     });
 
     await saveStoryActivityStep({
       activityId: activity.id,
       debriefData,
       storySteps,
+      title: storySteps.title,
       workflowRunId: "workflow-1",
     });
 
@@ -175,6 +177,7 @@ describe(saveStoryActivityStep, () => {
     expect(dbActivity).toMatchObject({
       generationRunId: "workflow-1",
       generationStatus: "completed",
+      title: storySteps.title,
     });
 
     const events = getStreamedEvents(writeMock);
@@ -211,6 +214,7 @@ describe(saveStoryActivityStep, () => {
       activityId: activity.id,
       debriefData,
       storySteps,
+      title: storySteps.title,
       workflowRunId: "workflow-error",
     });
 

--- a/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.ts
@@ -86,11 +86,13 @@ export async function saveStoryActivityStep({
   activityId,
   debriefData,
   storySteps,
+  title,
   workflowRunId,
 }: {
   activityId: string;
   debriefData: ActivityStoryDebriefSchema;
   storySteps: ActivityStoryStepsSchema;
+  title: string;
   workflowRunId: string;
 }): Promise<void> {
   "use step";
@@ -105,7 +107,7 @@ export async function saveStoryActivityStep({
     prisma.$transaction([
       prisma.step.createMany({ data: stepRecords }),
       prisma.activity.update({
-        data: { generationRunId: workflowRunId, generationStatus: "completed" },
+        data: { generationRunId: workflowRunId, generationStatus: "completed", title },
         where: { id: activityId },
       }),
     ]),

--- a/packages/ai/src/tasks/activities/core/activity-investigation-scenario.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-investigation-scenario.prompt.md
@@ -17,8 +17,25 @@ Investigation teaches evidence interpretation by giving you ambiguous findings. 
 
 A scenario frame for an investigation:
 
-1. **Scenario**: A single problem/mystery (2-3 short sentences)
-2. **Explanations**: 3-4 competing hypotheses that could explain what happened in that ONE scenario
+1. **Title**: A short case-like title for the investigation
+2. **Scenario**: A single problem/mystery (2-3 short sentences)
+3. **Explanations**: 3-4 competing hypotheses that could explain what happened in that ONE scenario
+
+## Activity Title Rules
+
+- The title must be specific to this exact mystery.
+- It should feel like the name of a real case or incident, not a lesson heading.
+- Do NOT use generic titles like "Investigation", "Mystery", "Finding the cause", or the lesson title copied back unchanged.
+- Prefer concrete people, places, objects, or the central symptom.
+- Write the title in the requested `LANGUAGE`, even though the examples below are in English.
+
+Good example styles:
+
+- The greenhouse that kept fogging up
+- Who tampered with the strawberry beds?
+- The science fair sensor that lied
+- Why the checkout totals broke
+- The game shop signup mystery
 
 ## CRITICAL: No Meta Scenarios
 

--- a/packages/ai/src/tasks/activities/core/activity-investigation-scenario.ts
+++ b/packages/ai/src/tasks/activities/core/activity-investigation-scenario.ts
@@ -10,6 +10,7 @@ const FALLBACK_MODELS = ["anthropic/claude-sonnet-4.6"];
 const schema = z.object({
   explanations: z.array(z.string()),
   scenario: z.string(),
+  title: z.string().min(1),
 });
 
 export type ActivityInvestigationScenarioSchema = z.infer<typeof schema>;

--- a/packages/ai/src/tasks/activities/core/activity-practice.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-practice.prompt.md
@@ -57,6 +57,24 @@ Each step must have:
   - `isCorrect`: Boolean. Exactly 1 option must be `true`
   - `feedback`: Maximum 300 characters
 
+## Activity Title
+
+Also generate a `title` for the whole activity.
+
+- It must be a short, memorable title based on the specific scenario/dialogue you created.
+- It should feel like a practical case, incident, or real situation, not a textbook heading.
+- Do NOT use generic titles like "Practice", "Applying the lesson", "Conversation practice", or the lesson title copied back unchanged.
+- The title should be specific enough that, if someone sees it in an activity list, they can picture the situation immediately.
+- Write the title in the requested `LANGUAGE`, even though the examples below are in English.
+
+Good example styles:
+
+- The checkout line that stopped moving
+- Maya's last-minute inventory problem
+- Why the refund numbers do not match
+- The game store signup mix-up
+- Who changed the shipping labels?
+
 ## Feedback Rules
 
 Feedback should feel like the other person's immediate response, not a score report.
@@ -235,10 +253,12 @@ Before finalizing, verify:
 
 # Output Format
 
-Return an array of steps, each with:
+Return one object with:
 
-- `context`
-- `question`
-- `options`: exactly 4 objects with `text`, `isCorrect`, and `feedback`
+- `title`
+- `steps`: an array of steps, each with:
+  - `context`
+  - `question`
+  - `options`: exactly 4 objects with `text`, `isCorrect`, and `feedback`
 
 Use 7-20 steps to tell a complete, coherent, natural-feeling story.

--- a/packages/ai/src/tasks/activities/core/activity-practice.ts
+++ b/packages/ai/src/tasks/activities/core/activity-practice.ts
@@ -25,6 +25,7 @@ const schema = z.object({
       question: z.string(),
     }),
   ),
+  title: z.string().min(1),
 });
 
 export type ActivityPracticeSchema = z.infer<typeof schema>;

--- a/packages/ai/src/tasks/activities/core/activity-story-steps.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-story-steps.prompt.md
@@ -17,6 +17,7 @@ Games teach physics by letting you fall off a cliff, not by explaining gravity. 
 
 A scenario with **as many steps as needed** to cover ALL the lesson's concepts. Each step has:
 
+- A **title** for the whole activity: short, vivid, and based on the specific scenario
 - A **situation** (what's happening RIGHT NOW)
 - **3 choices** (actions the learner can take)
 - A **consequence** for each choice (what happens as a result)
@@ -24,6 +25,21 @@ A scenario with **as many steps as needed** to cover ALL the lesson's concepts. 
 - An **alignment** tag for each choice: "strong" (aligns with lesson concepts), "partial" (partially right), or "weak" (goes against concepts)
 
 Plus **3 metrics** that track the world state (e.g., "Production", "Morale", "Cash").
+
+## Activity Title Rules
+
+- The title must feel like a real case, situation, or incident inside the story.
+- It must NOT sound like a lesson heading, textbook chapter, or generic label like "Story", "Scenario", or "Decision practice".
+- Prefer concrete nouns, people, places, or the central problem.
+- Write the title in the requested `LANGUAGE`, even though the examples below are in English.
+
+Good example styles:
+
+- The night the labels got swapped
+- Yara and the missing test results
+- Who froze the payment queue?
+- The strawberry patch mystery
+- Why the totals suddenly broke
 
 ## Step Count
 

--- a/packages/ai/src/tasks/activities/core/activity-story-steps.ts
+++ b/packages/ai/src/tasks/activities/core/activity-story-steps.ts
@@ -31,6 +31,7 @@ const schema = z.object({
   intro: z.string(),
   metrics: z.array(z.string()).min(1),
   steps: z.array(storyStepSchema).min(1),
+  title: z.string().min(1),
 });
 
 export type ActivityStoryStepsSchema = z.infer<typeof schema>;


### PR DESCRIPTION
## Summary
- generate scenario-based titles for practice, story, and investigation activities
- persist those titles when activity generation completes so existing activity lists can render them
- update prompts and workflow tests for the new title contract

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scenario-based titles to practice, story, and investigation activities and saves them on the activity record so lists show meaningful names. Updates prompts, schemas, and workflows to generate, validate, and persist titles.

- **New Features**
  - Add title generation to `activity-practice`, `activity-story-steps`, and `activity-investigation-scenario` tasks with clear title rules and required schema fields.
  - Pass `title` through generation steps and workflows; fail gracefully when missing.
  - Persist `title` on the `activity` row in save steps.
  - Update tests and mocks to cover the new title contract end-to-end.

<sup>Written for commit 0eaf4a4cbdf918409aea74cec85efbce72f54972. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

