### PR TITLE
refactor(ai): rewrite explanation activity around narrative arc

### DIFF
--- a/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
@@ -44,68 +44,78 @@ function createExplanationResult(): Awaited<ReturnType<typeof generateActivityEx
   return {
     data: {
       anchor: {
-        text: "This is why Google Maps can recalculate your route quickly.",
-        title: "Fast route updates",
+        text: "Every photo you send on WhatsApp uses this exact layering — you hit send, it runs.",
+        title: "Every send",
       },
-      concepts: [
+      explanation: [
         {
-          text: "Packets travel as smaller chunks so each network step can handle them reliably.",
-          title: "Small chunks",
-          visual: null,
+          text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
+          title: "O envio",
+          visual: {
+            description:
+              "Two frames: your thumb tapping send, then the photo visible in the friend's chat.",
+            kind: "image" as const,
+          },
         },
         {
-          text: "Each layer adds its own label for a different job.",
-          title: "Layer labels",
-          visual: null,
+          text: "Between the tap and the delivered photo, the message passes through several hidden points. Each one wraps it with a different kind of label.",
+          title: "Os rótulos escondidos",
+          visual: {
+            description: "Same two frames with a blurred row of unlabeled wrappers between them.",
+            kind: "image" as const,
+          },
+        },
+        {
+          text: "Here are the wrappers, in the order they get added: the app wrapper, the transport wrapper, the network wrapper. Each layer adds a label for a different job.",
+          title: "A pilha",
+          visual: {
+            description: "Nested packet with stacked layer labels: app, transport, network.",
+            kind: "diagram" as const,
+          },
+        },
+        {
+          text: "Zoom in on the network wrapper: it only carries routing info — where to send next. The chat content stays sealed inside, untouched by routers.",
+          title: "O rótulo de rede",
+          visual: {
+            description: "Close-up of the network wrapper with a routing address highlighted.",
+            kind: "diagram" as const,
+          },
         },
       ],
-      initialQuestion: {
-        explanation:
-          "The message gets wrapped in layers of instructions so each part of the network knows what to do next.",
-        question: "Why doesn't internet data travel as one giant unlabeled blob?",
-        visual: {
-          description: "An image of a message turning into a labeled packet.",
-          kind: "image" as const,
-        },
-      },
       predict: [
         {
-          concept: "Small chunks",
           options: [
             {
-              feedback: "Right. Smaller chunks are easier for the network to handle.",
-              isCorrect: true,
-              text: "Because the network handles smaller pieces more predictably",
-            },
-            {
-              feedback: "No. The goal is handling and routing, not decoration.",
-              isCorrect: false,
-              text: "Because it looks more organized on screen",
-            },
-          ],
-          question: "Why break the message into packets?",
-        },
-        {
-          concept: "Layer labels",
-          options: [
-            {
-              feedback: "Yes. Different layers need different details.",
+              feedback: "Yes. Each wrapper handles a different job during the trip.",
               isCorrect: true,
               text: "Because each layer needs its own information",
             },
             {
-              feedback: "Not this one. The point is function, not aesthetics.",
+              feedback: "Not this. Layers are functional, not decorative.",
               isCorrect: false,
-              text: "Because more labels make the packet prettier",
+              text: "Because extra labels make the packet prettier",
             },
           ],
-          question: "Why add more than one label?",
+          question: "Why wrap the same photo with several labels?",
+          step: "Os rótulos escondidos",
+        },
+        {
+          options: [
+            {
+              feedback: "Right. Routers only read where the packet goes next.",
+              isCorrect: true,
+              text: "The network label",
+            },
+            {
+              feedback: "No. Routers do not open the full chat message.",
+              isCorrect: false,
+              text: "The full chat content",
+            },
+          ],
+          question: "Which part does a router mainly use?",
+          step: "O rótulo de rede",
         },
       ],
-      scenario: {
-        text: "You send a photo on WhatsApp while riding the bus and it still reaches your friend after passing through many network points.",
-        title: "On WhatsApp",
-      },
     },
     systemPrompt: "test",
     usage: {} as Awaited<ReturnType<typeof generateActivityExplanation>>["usage"],

--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
@@ -48,68 +48,78 @@ function createExplanationResult(): Awaited<ReturnType<typeof generateActivityEx
   return {
     data: {
       anchor: {
-        text: "This is why Google Maps can recalculate your route quickly.",
-        title: "Fast route updates",
+        text: "Every photo you send on WhatsApp uses this exact layering — you hit send, it runs.",
+        title: "Every send",
       },
-      concepts: [
+      explanation: [
         {
-          text: "Packets travel as smaller chunks so each network step can handle them reliably.",
-          title: "Small chunks",
-          visual: null,
+          text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
+          title: "O envio",
+          visual: {
+            description:
+              "Two frames: your thumb tapping send, then the photo visible in the friend's chat.",
+            kind: "image" as const,
+          },
         },
         {
-          text: "Each layer adds its own label for a different job.",
-          title: "Layer labels",
-          visual: null,
+          text: "Between the tap and the delivered photo, the message passes through several hidden points. Each one wraps it with a different kind of label.",
+          title: "Os rótulos escondidos",
+          visual: {
+            description: "Same two frames with a blurred row of unlabeled wrappers between them.",
+            kind: "image" as const,
+          },
+        },
+        {
+          text: "Here are the wrappers, in the order they get added: the app wrapper, the transport wrapper, the network wrapper. Each layer adds a label for a different job.",
+          title: "A pilha",
+          visual: {
+            description: "Nested packet with stacked layer labels: app, transport, network.",
+            kind: "diagram" as const,
+          },
+        },
+        {
+          text: "Zoom in on the network wrapper: it only carries routing info — where to send next. The chat content stays sealed inside, untouched by routers.",
+          title: "O rótulo de rede",
+          visual: {
+            description: "Close-up of the network wrapper with a routing address highlighted.",
+            kind: "diagram" as const,
+          },
         },
       ],
-      initialQuestion: {
-        explanation:
-          "The message gets wrapped in layers of instructions so each part of the network knows what to do next.",
-        question: "Why doesn't internet data travel as one giant unlabeled blob?",
-        visual: {
-          description: "An image of a message turning into a labeled packet.",
-          kind: "image" as const,
-        },
-      },
       predict: [
         {
-          concept: "Small chunks",
           options: [
             {
-              feedback: "Right. Smaller chunks are easier for the network to handle.",
-              isCorrect: true,
-              text: "Because the network handles smaller pieces more predictably",
-            },
-            {
-              feedback: "No. The goal is handling and routing, not decoration.",
-              isCorrect: false,
-              text: "Because it looks more organized on screen",
-            },
-          ],
-          question: "Why break the message into packets?",
-        },
-        {
-          concept: "Layer labels",
-          options: [
-            {
-              feedback: "Yes. Different layers need different details.",
+              feedback: "Yes. Each wrapper handles a different job during the trip.",
               isCorrect: true,
               text: "Because each layer needs its own information",
             },
             {
-              feedback: "Not this one. The point is function, not aesthetics.",
+              feedback: "Not this. Layers are functional, not decorative.",
               isCorrect: false,
-              text: "Because more labels make the packet prettier",
+              text: "Because extra labels make the packet prettier",
             },
           ],
-          question: "Why add more than one label?",
+          question: "Why wrap the same photo with several labels?",
+          step: "Os rótulos escondidos",
+        },
+        {
+          options: [
+            {
+              feedback: "Right. Routers only read where the packet goes next.",
+              isCorrect: true,
+              text: "The network label",
+            },
+            {
+              feedback: "No. Routers do not open the full chat message.",
+              isCorrect: false,
+              text: "The full chat content",
+            },
+          ],
+          question: "Which part does a router mainly use?",
+          step: "O rótulo de rede",
         },
       ],
-      scenario: {
-        text: "You send a photo on WhatsApp while riding the bus and it still reaches your friend after passing through many network points.",
-        title: "On WhatsApp",
-      },
     },
     systemPrompt: "test",
     usage: {} as Awaited<ReturnType<typeof generateActivityExplanation>>["usage"],
@@ -699,28 +709,24 @@ describe("core activity workflow", () => {
         expect.objectContaining({
           explanationSteps: [
             {
-              text: "Why doesn't internet data travel as one giant unlabeled blob?",
-              title: "",
+              text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
+              title: "O envio",
             },
             {
-              text: "The message gets wrapped in layers of instructions so each part of the network knows what to do next.",
-              title: "",
+              text: "Between the tap and the delivered photo, the message passes through several hidden points. Each one wraps it with a different kind of label.",
+              title: "Os rótulos escondidos",
             },
             {
-              text: "You send a photo on WhatsApp while riding the bus and it still reaches your friend after passing through many network points.",
-              title: "On WhatsApp",
+              text: "Here are the wrappers, in the order they get added: the app wrapper, the transport wrapper, the network wrapper. Each layer adds a label for a different job.",
+              title: "A pilha",
             },
             {
-              text: "Packets travel as smaller chunks so each network step can handle them reliably.",
-              title: "Small chunks",
+              text: "Zoom in on the network wrapper: it only carries routing info — where to send next. The chat content stays sealed inside, untouched by routers.",
+              title: "O rótulo de rede",
             },
             {
-              text: "Each layer adds its own label for a different job.",
-              title: "Layer labels",
-            },
-            {
-              text: "This is why Google Maps can recalculate your route quickly.",
-              title: "Fast route updates",
+              text: "Every photo you send on WhatsApp uses this exact layering — you hit send, it runs.",
+              title: "Every send",
             },
           ],
         }),
@@ -902,16 +908,16 @@ describe("core activity workflow", () => {
           explanationSteps: expect.arrayContaining([
             { text: "Completed explanation text", title: "CompletedExp" },
             {
-              text: "Why doesn't internet data travel as one giant unlabeled blob?",
-              title: "",
+              text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
+              title: "O envio",
             },
             {
-              text: "Packets travel as smaller chunks so each network step can handle them reliably.",
-              title: "Small chunks",
+              text: "Here are the wrappers, in the order they get added: the app wrapper, the transport wrapper, the network wrapper. Each layer adds a label for a different job.",
+              title: "A pilha",
             },
             {
-              text: "This is why Google Maps can recalculate your route quickly.",
-              title: "Fast route updates",
+              text: "Every photo you send on WhatsApp uses this exact layering — you hit send, it runs.",
+              title: "Every send",
             },
           ]),
         }),

--- a/apps/api/src/workflows/activity-generation/custom-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/custom-activity-workflow.test.ts
@@ -42,63 +42,78 @@ function createExplanationResult() {
   return {
     data: {
       anchor: {
-        text: "This is why Google Maps can recalculate your route quickly.",
-        title: "Fast route updates",
+        text: "Every photo you send on WhatsApp uses this exact layering — you hit send, it runs.",
+        title: "Every send",
       },
-      concepts: [
+      explanation: [
         {
-          text: "Packets travel as smaller chunks so each network step can handle them reliably.",
-          title: "Small chunks",
-          visual: null,
+          text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
+          title: "O envio",
+          visual: {
+            description:
+              "Two frames: your thumb tapping send, then the photo visible in the friend's chat.",
+            kind: "image" as const,
+          },
+        },
+        {
+          text: "Between the tap and the delivered photo, the message passes through several hidden points. Each one wraps it with a different kind of label.",
+          title: "Os rótulos escondidos",
+          visual: {
+            description: "Same two frames with a blurred row of unlabeled wrappers between them.",
+            kind: "image" as const,
+          },
+        },
+        {
+          text: "Here are the wrappers, in the order they get added: the app wrapper, the transport wrapper, the network wrapper. Each layer adds a label for a different job.",
+          title: "A pilha",
+          visual: {
+            description: "Nested packet with stacked layer labels: app, transport, network.",
+            kind: "diagram" as const,
+          },
+        },
+        {
+          text: "Zoom in on the network wrapper: it only carries routing info — where to send next. The chat content stays sealed inside, untouched by routers.",
+          title: "O rótulo de rede",
+          visual: {
+            description: "Close-up of the network wrapper with a routing address highlighted.",
+            kind: "diagram" as const,
+          },
         },
       ],
-      initialQuestion: {
-        explanation:
-          "The message gets wrapped in layers of instructions so each part of the network knows what to do next.",
-        question: "Why doesn't internet data travel as one giant unlabeled blob?",
-        visual: {
-          description: "An image of a message turning into a labeled packet.",
-          kind: "image" as const,
-        },
-      },
       predict: [
         {
-          concept: "Small chunks",
           options: [
             {
-              feedback: "Right. Smaller chunks are easier for the network to handle.",
+              feedback: "Yes. Each wrapper handles a different job during the trip.",
               isCorrect: true,
-              text: "Because the network handles smaller pieces more predictably",
+              text: "Because each layer needs its own information",
             },
             {
-              feedback: "No. The goal is handling and routing, not decoration.",
+              feedback: "Not this. Layers are functional, not decorative.",
               isCorrect: false,
-              text: "Because it looks more organized on screen",
+              text: "Because extra labels make the packet prettier",
             },
           ],
-          question: "Why break the message into packets?",
+          question: "Why wrap the same photo with several labels?",
+          step: "Os rótulos escondidos",
         },
         {
-          concept: "Small chunks",
           options: [
             {
-              feedback: "Yes. The same chunk still needs different labels for different jobs.",
+              feedback: "Right. Routers only read where the packet goes next.",
               isCorrect: true,
-              text: "To give each layer the information it needs",
+              text: "The network label",
             },
             {
-              feedback: "Not this one. The labels are functional, not decorative.",
+              feedback: "No. Routers do not open the full chat message.",
               isCorrect: false,
-              text: "To make the packet look tidier",
+              text: "The full chat content",
             },
           ],
-          question: "Why can one packet still carry more than one label?",
+          question: "Which part does a router mainly use?",
+          step: "O rótulo de rede",
         },
       ],
-      scenario: {
-        text: "You send a photo on WhatsApp while riding the bus and it still reaches your friend after crossing many network points.",
-        title: "On WhatsApp",
-      },
     },
   };
 }

--- a/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
@@ -20,77 +20,78 @@ function createExplanationResult(): Awaited<ReturnType<typeof generateActivityEx
   return {
     data: {
       anchor: {
-        text: "This is why Google Maps can keep recalculating your route while you move.",
-        title: "This is why",
+        text: "Every photo you send on WhatsApp uses this exact layering — you hit send, it runs.",
+        title: "Every send",
       },
-      concepts: [
+      explanation: [
         {
-          text: "Packets travel as smaller chunks so the network can handle them predictably.",
-          title: "Small chunks",
-          visual: null,
-        },
-        {
-          text: "Each layer adds its own label for a different job.",
-          title: "Layer labels",
+          text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
+          title: "O envio",
           visual: {
             description:
-              "A diagram of one packet with stacked labels for different network layers.",
+              "Two frames: your thumb tapping send, then the photo visible in the friend's chat.",
+            kind: "image" as const,
+          },
+        },
+        {
+          text: "Between the tap and the delivered photo, the message passes through several hidden points. Each one wraps it with a different kind of label.",
+          title: "Os rótulos escondidos",
+          visual: {
+            description: "Same two frames with a blurred row of unlabeled wrappers between them.",
+            kind: "image" as const,
+          },
+        },
+        {
+          text: "Here are the wrappers, in the order they get added: the app wrapper, the transport wrapper, the network wrapper. Each layer adds a label for a different job.",
+          title: "A pilha",
+          visual: {
+            description: "Nested packet with stacked layer labels: app, transport, network.",
             kind: "diagram" as const,
           },
         },
         {
-          text: "Routers look at the network label, not the whole app meaning.",
-          title: "Router focus",
-          visual: null,
+          text: "Zoom in on the network wrapper: it only carries routing info — where to send next. The chat content stays sealed inside, untouched by routers.",
+          title: "O rótulo de rede",
+          visual: {
+            description: "Close-up of the network wrapper with a routing address highlighted.",
+            kind: "diagram" as const,
+          },
         },
       ],
-      initialQuestion: {
-        explanation:
-          "The packet keeps gaining focused labels so each part of the network knows what to do next.",
-        question: "Why doesn't internet data travel as one giant unlabeled blob?",
-        visual: {
-          description: "An image of a message turning into a packet with labels wrapped around it.",
-          kind: "image" as const,
-        },
-      },
       predict: [
         {
-          concept: "Layer labels",
           options: [
             {
-              feedback: "Right. Different layers need different details.",
+              feedback: "Yes. Each wrapper handles a different job during the trip.",
               isCorrect: true,
               text: "Because each layer needs its own information",
             },
             {
-              feedback: "Not this one. The labels are functional, not decorative.",
+              feedback: "Not this. Layers are functional, not decorative.",
               isCorrect: false,
-              text: "Because extra labels make packets look neater",
+              text: "Because extra labels make the packet prettier",
             },
           ],
-          question: "Why add more than one label to the same packet?",
+          question: "Why wrap the same photo with several labels?",
+          step: "Os rótulos escondidos",
         },
         {
-          concept: "Router focus",
           options: [
             {
-              feedback: "Yes. Routers mainly care about where the packet goes next.",
+              feedback: "Right. Routers only read where the packet goes next.",
               isCorrect: true,
               text: "The network label",
             },
             {
-              feedback: "No. Routers are not reading the full chat message.",
+              feedback: "No. Routers do not open the full chat message.",
               isCorrect: false,
-              text: "The app's full message",
+              text: "The full chat content",
             },
           ],
           question: "Which part does a router mainly use?",
+          step: "O rótulo de rede",
         },
       ],
-      scenario: {
-        text: "You send a WhatsApp photo on the bus and it still reaches your friend after crossing many network points.",
-        title: "On WhatsApp",
-      },
     },
     systemPrompt: "test",
     usage: {} as Awaited<ReturnType<typeof generateActivityExplanation>>["usage"],
@@ -185,42 +186,40 @@ describe("explanation activity workflow", () => {
       [0, "static"],
       [1, "visual"],
       [2, "static"],
-      [3, "static"],
-      [4, "static"],
+      [3, "visual"],
+      [4, "multipleChoice"],
       [5, "static"],
       [6, "visual"],
-      [7, "multipleChoice"],
-      [8, "static"],
+      [7, "static"],
+      [8, "visual"],
       [9, "multipleChoice"],
       [10, "static"],
     ]);
 
     expect(steps[0]?.content).toEqual({
-      text: "Why doesn't internet data travel as one giant unlabeled blob?",
-      title: "",
+      text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
+      title: "O envio",
       variant: "text",
     });
     expect(steps[2]?.content).toEqual({
-      text: "The packet keeps gaining focused labels so each part of the network knows what to do next.",
-      title: "",
+      text: "Between the tap and the delivered photo, the message passes through several hidden points. Each one wraps it with a different kind of label.",
+      title: "Os rótulos escondidos",
       variant: "text",
     });
-    expect(steps[7]?.kind).toBe("multipleChoice");
+    expect(steps[4]?.kind).toBe("multipleChoice");
     expect(steps[10]?.content).toEqual({
-      text: "This is why Google Maps can keep recalculating your route while you move.",
-      title: "This is why",
+      text: "Every photo you send on WhatsApp uses this exact layering — you hit send, it runs.",
+      title: "Every send",
       variant: "text",
     });
 
     expect(results).toHaveLength(1);
     expect(results[0]?.steps.map((step) => step.title || step.text)).toEqual([
-      "Why doesn't internet data travel as one giant unlabeled blob?",
-      "The packet keeps gaining focused labels so each part of the network knows what to do next.",
-      "On WhatsApp",
-      "Small chunks",
-      "Layer labels",
-      "Router focus",
-      "This is why",
+      "O envio",
+      "Os rótulos escondidos",
+      "A pilha",
+      "O rótulo de rede",
+      "Every send",
     ]);
   });
 

--- a/apps/api/src/workflows/activity-generation/steps/_utils/build-explanation-activity-plan.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/build-explanation-activity-plan.test.ts
@@ -4,136 +4,157 @@ import { buildExplanationActivityPlan } from "./build-explanation-activity-plan"
 function buildContent() {
   return {
     anchor: {
-      text: "This is why Google Maps can keep updating your route instead of redrawing the whole city from scratch.",
-      title: "This is why",
+      text: "Every heart that turns red in any app is a line someone wrote, running in that moment.",
+      title: "In every app",
     },
-    concepts: [
+    explanation: [
       {
-        text: "Packets travel as smaller pieces so each network step can handle them predictably.",
-        title: "Small chunks",
-        visual: null,
+        text: "You tap the heart on a photo. A moment later, it is red and the counter jumped from 42 to 43.",
+        title: "O toque",
+        visual: {
+          description: "Two frames side by side: grey heart with 42, then red heart with 43.",
+          kind: "image" as const,
+        },
       },
       {
-        text: "Each layer adds its own label for a different job, like delivery details versus app details.",
-        title: "Layer labels",
+        text: "Between the tap and the red heart, the phone did exactly 4 things. They were written somewhere, ready to run.",
+        title: "O que está escondido",
         visual: {
-          description:
-            "A diagram showing one packet with stacked labels for app, transport, and network layers.",
+          description: "Same two frames with 4 blurred numbered boxes between them.",
+          kind: "image" as const,
+        },
+      },
+      {
+        text: "Here is the list, in the order the phone ran it: register tap, mark photo as liked, change heart colour to red, add 1 to counter.",
+        title: "A lista",
+        visual: {
+          description: "Numbered list of the 4 actions.",
           kind: "diagram" as const,
         },
       },
       {
-        text: "Routers look at the network label, not the whole message meaning.",
-        title: "Router focus",
-        visual: null,
+        text: "Each of those 4 lines is an instruction: one exact command, one action only.",
+        title: "O nome",
+        visual: {
+          description: "The same list with one line bracketed and labelled '= 1 instruction'.",
+          kind: "diagram" as const,
+        },
+      },
+      {
+        text: "Look at line 3: 'change heart colour to red'. It does not handle a second tap or a deleted photo. It only changes the colour.",
+        title: "A linha 3",
+        visual: {
+          description: "Close-up of line 3 with a grey-to-red colour swatch.",
+          kind: "diagram" as const,
+        },
+      },
+      {
+        text: "That is why the heart turned red when you tapped. Not because the phone understood your intent, but because line 3 said so.",
+        title: "O retorno",
+        visual: {
+          description:
+            "Beat 1 frames again, with line 3 drawn beside them and an arrow linking it to the red heart.",
+          kind: "diagram" as const,
+        },
       },
     ],
-    initialQuestion: {
-      explanation:
-        "The packet keeps getting small pieces of information added so each layer knows what to do next.",
-      question: "Why doesn't internet data travel as one giant unlabeled blob?",
-      visual: {
-        description: "An image of a message turning into a packet with labels added around it.",
-        kind: "image" as const,
-      },
-    },
     predict: [
       {
-        concept: "Layer labels",
+        options: [
+          {
+            feedback: "Right. Detection of the tap is always the first link in the chain.",
+            isCorrect: true,
+            text: "Register that you tapped the icon",
+          },
+          {
+            feedback: "This is the visible result, so it happens later, not first.",
+            isCorrect: false,
+            text: "Change the heart colour to red",
+          },
+        ],
+        question: "Which of these was the FIRST thing the phone did?",
+        step: "O que está escondido",
+      },
+      {
         options: [
           {
             feedback:
-              "Yes. Different labels help different parts of the network do different jobs.",
+              "Exactly. The phone executes the line as written — it does not guess what you meant.",
             isCorrect: true,
-            text: "Because each layer needs its own information",
+            text: "The heart would turn green when you like",
           },
           {
-            feedback: "Not quite. The point is not decoration but different jobs.",
+            feedback: "The phone does not correct an instruction that looks odd. It just runs it.",
             isCorrect: false,
-            text: "Because packets look nicer with extra labels",
+            text: "The phone would keep it red anyway",
           },
         ],
-        question: "Why add more than one label to the same packet?",
-      },
-      {
-        concept: "Router focus",
-        options: [
-          {
-            feedback: "Right. Routers care about where to send it next.",
-            isCorrect: true,
-            text: "The network label",
-          },
-          {
-            feedback: "Not this one. Routers are not reading the full app meaning.",
-            isCorrect: false,
-            text: "The app's full message",
-          },
-        ],
-        question: "Which part does a router mainly use?",
+        question: "If line 3 said 'change colour to green' instead, what would happen?",
+        step: "A linha 3",
       },
     ],
-    scenario: {
-      text: "You send a WhatsApp photo on the bus and it still reaches your friend even though it passes through many different network points on the way.",
-      title: "On the bus",
-    },
   };
 }
 
 describe(buildExplanationActivityPlan, () => {
-  test("builds the ordered learner flow from the structured explanation content", () => {
+  test("builds the ordered learner flow from the narrative explanation content", () => {
     const result = buildExplanationActivityPlan(buildContent());
 
     expect(result.entries.map((entry) => entry.kind)).toEqual([
       "static",
       "visual",
       "static",
+      "visual",
+      "multipleChoice",
       "static",
+      "visual",
       "static",
+      "visual",
       "static",
       "visual",
       "multipleChoice",
       "static",
-      "multipleChoice",
+      "visual",
       "static",
     ]);
 
     expect(result.sourceSteps).toEqual([
       {
-        text: "Why doesn't internet data travel as one giant unlabeled blob?",
-        title: "",
+        text: "You tap the heart on a photo. A moment later, it is red and the counter jumped from 42 to 43.",
+        title: "O toque",
       },
       {
-        text: "The packet keeps getting small pieces of information added so each layer knows what to do next.",
-        title: "",
+        text: "Between the tap and the red heart, the phone did exactly 4 things. They were written somewhere, ready to run.",
+        title: "O que está escondido",
       },
       {
-        text: "You send a WhatsApp photo on the bus and it still reaches your friend even though it passes through many different network points on the way.",
-        title: "On the bus",
+        text: "Here is the list, in the order the phone ran it: register tap, mark photo as liked, change heart colour to red, add 1 to counter.",
+        title: "A lista",
       },
       {
-        text: "Packets travel as smaller pieces so each network step can handle them predictably.",
-        title: "Small chunks",
+        text: "Each of those 4 lines is an instruction: one exact command, one action only.",
+        title: "O nome",
       },
       {
-        text: "Each layer adds its own label for a different job, like delivery details versus app details.",
-        title: "Layer labels",
+        text: "Look at line 3: 'change heart colour to red'. It does not handle a second tap or a deleted photo. It only changes the colour.",
+        title: "A linha 3",
       },
       {
-        text: "Routers look at the network label, not the whole message meaning.",
-        title: "Router focus",
+        text: "That is why the heart turned red when you tapped. Not because the phone understood your intent, but because line 3 said so.",
+        title: "O retorno",
       },
       {
-        text: "This is why Google Maps can keep updating your route instead of redrawing the whole city from scratch.",
-        title: "This is why",
+        text: "Every heart that turns red in any app is a line someone wrote, running in that moment.",
+        title: "In every app",
       },
     ]);
   });
 
-  test("falls back to the final concept when a predict insertion title does not match", () => {
+  test("falls back to the final step when a predict insertion title does not match", () => {
     const content = buildContent();
     content.predict[0] = {
       ...content.predict[0]!,
-      concept: "Does not exist",
+      step: "Does not exist",
     };
 
     const result = buildExplanationActivityPlan(content);
@@ -143,8 +164,8 @@ describe(buildExplanationActivityPlan, () => {
       .map((entry) => entry.question);
 
     expect(finalChecks).toEqual([
-      "Why add more than one label to the same packet?",
-      "Which part does a router mainly use?",
+      "If line 3 said 'change colour to green' instead, what would happen?",
+      "Which of these was the FIRST thing the phone did?",
     ]);
   });
 });

--- a/apps/api/src/workflows/activity-generation/steps/_utils/build-explanation-activity-plan.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/build-explanation-activity-plan.ts
@@ -25,46 +25,46 @@ type ExplanationPlan = {
 };
 
 /**
- * The explanation task returns prediction insert points by concept title so the
- * save pipeline can keep concept teaching and quick checks coherent. This
- * helper centralizes the fallback behavior when the model returns a title that
- * does not exactly match any concept.
+ * The explanation task points each predict check at the step title after which
+ * it should be inserted. If the model echoes a title that does not exactly
+ * match any step, we fall back to the last step so the check is never dropped
+ * silently — the activity still benefits from the intended reinforcement.
  */
-function getPredictionInsertionConcept({
-  conceptTitles,
-  predictionConcept,
+function getPredictionInsertionStep({
+  predictionStep,
+  stepTitles,
 }: {
-  conceptTitles: string[];
-  predictionConcept: string;
+  predictionStep: string;
+  stepTitles: string[];
 }) {
-  if (conceptTitles.includes(predictionConcept)) {
-    return predictionConcept;
+  if (stepTitles.includes(predictionStep)) {
+    return predictionStep;
   }
 
-  return conceptTitles.at(-1) ?? null;
+  return stepTitles.at(-1) ?? null;
 }
 
 /**
- * Prediction checks need to stay attached to their surrounding concept even if
- * the model misses the exact title once. Grouping them up front lets the main
- * plan builder read like the learner flow instead of interleaving lookup logic
- * inside each concept iteration.
+ * Predict checks stay attached to their surrounding step even if the model
+ * misses the exact title once. Grouping them up front lets the main plan
+ * builder read as a linear walk over the explanation array instead of
+ * interleaving lookup logic inside each step iteration.
  */
 function buildPredictionMap(
   content: ActivityExplanationSchema,
 ): Map<string, ActivityExplanationSchema["predict"]> {
-  const conceptTitles = content.concepts.map((concept) => concept.title);
+  const stepTitles = content.explanation.map((step) => step.title);
   const predictionMap = new Map<string, ActivityExplanationSchema["predict"]>();
 
   for (const prediction of content.predict) {
-    const insertionConcept = getPredictionInsertionConcept({
-      conceptTitles,
-      predictionConcept: prediction.concept,
+    const insertionStep = getPredictionInsertionStep({
+      predictionStep: prediction.step,
+      stepTitles,
     });
 
-    if (insertionConcept) {
-      const existing = predictionMap.get(insertionConcept) ?? [];
-      predictionMap.set(insertionConcept, [...existing, prediction]);
+    if (insertionStep) {
+      const existing = predictionMap.get(insertionStep) ?? [];
+      predictionMap.set(insertionStep, [...existing, prediction]);
     }
   }
 
@@ -72,67 +72,41 @@ function buildPredictionMap(
 }
 
 /**
- * Static explanation screens, prediction checks, and visual placeholders all
- * travel through the same ordered plan so the later save step can persist the
- * exact learner sequence without reconstructing it from separate arrays.
+ * Every narrative step expands into a static step (the prose), a visual step
+ * (the illustration), and any predict checks that belong after this step.
+ * Keeping all three side-by-side here matches the learner's experienced order
+ * and avoids reconstructing the sequence elsewhere in the pipeline.
  */
-function buildConceptEntries({
-  concept,
+function buildStepEntries({
   predictionMap,
+  step,
 }: {
-  concept: ActivityExplanationSchema["concepts"][number];
   predictionMap: Map<string, ActivityExplanationSchema["predict"]>;
-}) {
-  const entries: ExplanationActivityPlanEntry[] = [
-    {
-      kind: "static",
-      text: concept.text,
-      title: concept.title,
-    },
-  ];
+  step: ActivityExplanationSchema["explanation"][number];
+}): ExplanationActivityPlanEntry[] {
+  const predictions = predictionMap.get(step.title) ?? [];
 
-  if (concept.visual) {
-    entries.push({
-      description: concept.visual,
-      kind: "visual",
-    });
-  }
-
-  const predictions = predictionMap.get(concept.title) ?? [];
-
-  for (const prediction of predictions) {
-    entries.push({
+  return [
+    { kind: "static", text: step.text, title: step.title },
+    { description: step.visual, kind: "visual" },
+    ...predictions.map<ExplanationActivityPlanEntry>((prediction) => ({
       kind: "multipleChoice",
       options: prediction.options,
       question: prediction.question,
-    });
-  }
-
-  return entries;
+    })),
+  ];
 }
 
 /**
  * Practice and quiz generation only need the text teaching surfaces, not the
- * visual placeholders or prediction checks. This helper keeps that downstream
- * source list aligned with the new explanation structure in one place.
+ * visual placeholders or predict checks. This helper keeps that downstream
+ * source list aligned with the explanation structure in one place.
  */
 function buildSourceSteps(content: ActivityExplanationSchema): ActivitySteps {
   return [
-    {
-      text: content.initialQuestion.question,
-      title: "",
-    },
-    {
-      text: content.initialQuestion.explanation,
-      title: "",
-    },
-    {
-      text: content.scenario.text,
-      title: content.scenario.title,
-    },
-    ...content.concepts.map((concept) => ({
-      text: concept.text,
-      title: concept.title,
+    ...content.explanation.map((step) => ({
+      text: step.text,
+      title: step.title,
     })),
     {
       text: content.anchor.text,
@@ -150,32 +124,13 @@ function buildSourceSteps(content: ActivityExplanationSchema): ActivitySteps {
 export function buildExplanationActivityPlan(content: ActivityExplanationSchema): ExplanationPlan {
   const predictionMap = buildPredictionMap(content);
 
-  const conceptEntries = content.concepts.flatMap((concept) =>
-    buildConceptEntries({ concept, predictionMap }),
+  const stepEntries = content.explanation.flatMap((step) =>
+    buildStepEntries({ predictionMap, step }),
   );
 
   return {
     entries: [
-      {
-        kind: "static",
-        text: content.initialQuestion.question,
-        title: "",
-      },
-      {
-        description: content.initialQuestion.visual,
-        kind: "visual",
-      },
-      {
-        kind: "static",
-        text: content.initialQuestion.explanation,
-        title: "",
-      },
-      {
-        kind: "static",
-        text: content.scenario.text,
-        title: content.scenario.title,
-      },
-      ...conceptEntries,
+      ...stepEntries,
       {
         kind: "static",
         text: content.anchor.text,

--- a/apps/api/src/workflows/activity-generation/steps/generate-explanation-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-explanation-content-step.test.ts
@@ -41,71 +41,78 @@ function createExplanationResult() {
   return {
     data: {
       anchor: {
-        text: "This is why Google Maps can recalculate your route quickly.",
-        title: "Fast route updates",
+        text: "Every photo you send on WhatsApp uses this exact layering — you hit send, it runs.",
+        title: "Every send",
       },
-      concepts: [
+      explanation: [
         {
-          text: "Packets travel as smaller chunks so each network step can handle them reliably.",
-          title: "Small chunks",
-          visual: null,
+          text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
+          title: "O envio",
+          visual: {
+            description:
+              "Two frames: your thumb tapping send, then the photo visible in the friend's chat.",
+            kind: "image" as const,
+          },
         },
         {
-          text: "Each layer adds its own label for a different job.",
-          title: "Layer labels",
+          text: "Between the tap and the delivered photo, the message passes through several hidden points. Each one wraps it with a different kind of label.",
+          title: "Os rótulos escondidos",
           visual: {
-            description: "A diagram of one packet with stacked layer labels.",
+            description: "Same two frames with a blurred row of unlabeled wrappers between them.",
+            kind: "image" as const,
+          },
+        },
+        {
+          text: "Here are the wrappers, in the order they get added: the app wrapper, the transport wrapper, the network wrapper. Each layer adds a label for a different job.",
+          title: "A pilha",
+          visual: {
+            description: "Nested packet with stacked layer labels: app, transport, network.",
+            kind: "diagram" as const,
+          },
+        },
+        {
+          text: "Zoom in on the network wrapper: it only carries routing info — where to send next. The chat content stays sealed inside, untouched by routers.",
+          title: "O rótulo de rede",
+          visual: {
+            description: "Close-up of the network wrapper with a routing address highlighted.",
             kind: "diagram" as const,
           },
         },
       ],
-      initialQuestion: {
-        explanation:
-          "The message gets wrapped in layers of instructions so each part of the network knows what to do next.",
-        question: "Why doesn't internet data travel as one giant unlabeled blob?",
-        visual: {
-          description: "An image of a message turning into a labeled packet.",
-          kind: "image" as const,
-        },
-      },
       predict: [
         {
-          concept: "Small chunks",
           options: [
             {
-              feedback: "Right. Smaller chunks are easier for the network to handle.",
-              isCorrect: true,
-              text: "Because the network handles smaller pieces more predictably",
-            },
-            {
-              feedback: "No. The goal is handling and routing, not decoration.",
-              isCorrect: false,
-              text: "Because it looks more organized on screen",
-            },
-          ],
-          question: "Why break the message into packets?",
-        },
-        {
-          concept: "Layer labels",
-          options: [
-            {
-              feedback: "Yes. Different layers need different details.",
+              feedback: "Yes. Each wrapper handles a different job during the trip.",
               isCorrect: true,
               text: "Because each layer needs its own information",
             },
             {
-              feedback: "Not this one. The point is function, not aesthetics.",
+              feedback: "Not this. Layers are functional, not decorative.",
               isCorrect: false,
-              text: "Because more labels make the packet prettier",
+              text: "Because extra labels make the packet prettier",
             },
           ],
-          question: "Why add more than one label?",
+          question: "Why wrap the same photo with several labels?",
+          step: "Os rótulos escondidos",
+        },
+        {
+          options: [
+            {
+              feedback: "Right. Routers only read where the packet goes next.",
+              isCorrect: true,
+              text: "The network label",
+            },
+            {
+              feedback: "No. Routers do not open the full chat message.",
+              isCorrect: false,
+              text: "The full chat content",
+            },
+          ],
+          question: "Which part does a router mainly use?",
+          step: "O rótulo de rede",
         },
       ],
-      scenario: {
-        text: "You send a photo on WhatsApp while riding the bus and it still reaches your friend after passing through many network points.",
-        title: "On WhatsApp",
-      },
     },
   };
 }
@@ -173,37 +180,34 @@ describe(generateExplanationContentStep, () => {
     expect(result.results[0]?.activityId).toBe(activities[0]?.id);
     expect(result.results[0]?.steps).toEqual([
       {
-        text: "Why doesn't internet data travel as one giant unlabeled blob?",
-        title: "",
+        text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
+        title: "O envio",
       },
       {
-        text: "The message gets wrapped in layers of instructions so each part of the network knows what to do next.",
-        title: "",
+        text: "Between the tap and the delivered photo, the message passes through several hidden points. Each one wraps it with a different kind of label.",
+        title: "Os rótulos escondidos",
       },
       {
-        text: "You send a photo on WhatsApp while riding the bus and it still reaches your friend after passing through many network points.",
-        title: "On WhatsApp",
+        text: "Here are the wrappers, in the order they get added: the app wrapper, the transport wrapper, the network wrapper. Each layer adds a label for a different job.",
+        title: "A pilha",
       },
       {
-        text: "Packets travel as smaller chunks so each network step can handle them reliably.",
-        title: "Small chunks",
+        text: "Zoom in on the network wrapper: it only carries routing info — where to send next. The chat content stays sealed inside, untouched by routers.",
+        title: "O rótulo de rede",
       },
       {
-        text: "Each layer adds its own label for a different job.",
-        title: "Layer labels",
-      },
-      {
-        text: "This is why Google Maps can recalculate your route quickly.",
-        title: "Fast route updates",
+        text: "Every photo you send on WhatsApp uses this exact layering — you hit send, it runs.",
+        title: "Every send",
       },
     ]);
     expect(result.results[0]?.plan.map((entry) => entry.kind)).toEqual([
       "static",
       "visual",
       "static",
-      "static",
-      "static",
+      "visual",
       "multipleChoice",
+      "static",
+      "visual",
       "static",
       "visual",
       "multipleChoice",

--- a/apps/evals/src/tasks/activity-explanation/test-cases.ts
+++ b/apps/evals/src/tasks/activity-explanation/test-cases.ts
@@ -3,34 +3,54 @@ EVALUATION CRITERIA:
 
 1. FACTUAL ACCURACY: The explanation must be technically correct for the topic. Penalize invented mechanisms, wrong cause-effect chains, or misleading simplifications.
 
-2. REQUIRED STRUCTURE: The output must contain:
-   - initialQuestion { question, visual, explanation }
-   - scenario { title, text }
-   - concepts[] with title, text, visual
-   - predict[] with exactly 2 checks
-   - anchor { title, text }
+2. REQUIRED STRUCTURE: The output must contain exactly three top-level fields:
+   - explanation[]: an array of narrative steps, each with title, text, and visual
+   - predict[]: exactly 2 quick checks, each with step (matching an explanation title), question, options
+   - anchor: { title, text } (no visual)
 
-3. HOOK QUALITY: initialQuestion should create curiosity before teaching. Penalize dry definitions, obvious trivia questions, or hooks that already explain the answer.
+3. GOAL DELIVERY: The activity must actually deliver on ACTIVITY_GOAL. The learner should finish the activity knowing what the thing is, why it exists or is used (when the goal implies it), and how it works or is written in practice (when the goal implies it). Penalize activities that stay surface-level and leave the learner still unsure what the thing is, why it matters, or how it's written when the goal required these.
 
-4. SCENARIO QUALITY: scenario.text must open inside a concrete daily-life situation. Penalize domain jargon, "imagine that...", abstract framing, or scenarios that feel like an educational exercise instead of real life.
+4. SCENE SPINE: The entire activity must revolve around ONE concrete moment (e.g. tapping a button, sending a message, opening a contact list). Every step refers back to or deepens that same moment. The single scene is the vehicle for covering what/why/how when the goal requires all three. Penalize:
+   - Activities that jump between multiple unrelated scenarios
+   - An opening scenario that gets abandoned after step 1
+   - Definitions that float in abstractly instead of pointing at something already shown in the scene
 
-5. CONCEPT QUALITY: concepts should do the real teaching. Penalize repetition, vague filler, or concept texts that stay so shallow the learner only gets a slogan.
+5. COLD OPEN: Step 1 must land the learner inside a concrete sensory moment with no question-as-hook, no "Imagine...", no resolution, and no definition. Penalize steps that answer their own setup within the same step, or that open with abstract framing.
 
-6. VISUAL QUALITY: initialQuestion.visual is required and must be an instructional visual brief, not decorative art. concept visuals should appear only when they clarify something. Penalize vague visuals, decorative visuals, or visuals that do not help explain the concept.
+6. NARRATIVE ARC: The explanation[] array should unfold a clear arc: cold open → mystery (something hidden) → reveal (what was hidden) → naming (from inside the scene) → zoom (into one piece, often "how") → optional stakes (why, when the goal calls for it) → payoff (callback to the opening). Step count is flexible — deeper topics need more steps, simpler topics fewer — but these narrative functions should be present in order. Penalize:
+   - A structure that reads as stacked definitions rather than a single unfolding story
+   - Missing a payoff/callback as the last step
+   - Naming a term before showing an example of it in the scene
 
-7. PREDICT QUALITY: predict checks should reinforce understanding, not act like tricky exams. Penalize gotcha wording, obviously silly distractors, generic feedback, or checks that are disconnected from nearby concepts. Feedback must add real explanatory value: penalize feedback that only says the learner is right/wrong, merely paraphrases the chosen option, or fails to explain the reasoning behind the answer. The first check should land around the middle of concepts, and the second should land after the final concept via the concept title reference.
+7. STEP QUALITY: Each step.text is 1–3 short sentences of prose. Step titles are short (1–3 words), narrative markers (not textbook section headers), and unique within the activity. Penalize:
+   - Long paragraphs
+   - Titles like "Programa", "Instrução", "Encapsulation" that sound like chapter headers
+   - Repetition between steps
 
-8. ANCHOR QUALITY: anchor must tie back to a real product, system, or daily behavior. Penalize abstract "this matters" endings, metaphors, or fake/non-concrete examples.
+8. VISUAL QUALITY: Every explanation step has a visual, and each visual must advance the narrative — showing the scene, revealing hidden structure, zooming in, or showing a contrast/callback. When the goal includes "how it's written", code or structural visuals should appear at the reveal or zoom moment. Penalize:
+   - Decorative art or generic concept illustrations
+   - Visuals that only restate what the text already said
+   - Missing visuals on explanation steps
+   - Missing a code/structural visual when the goal calls for showing how the thing is written
 
-9. STYLE: Keep every section short, distinct, and readable. Penalize long paragraphs, heavy redundancy, academic tone, or repeated explanations across hook, scenario, concepts, and anchor.
+9. PREDICT QUALITY: Exactly 2 checks. Predict #1 lands after a mystery step, before the reveal (commit-before-reveal). Predict #2 lands after the zoom, before the payoff (raise-stakes-before-callback). Each predict.step must exactly match an existing explanation title. Feedback must teach — after reading feedback alone, the learner should better understand the concept. Penalize:
+   - Checks placed outside these two slots (e.g., after the payoff)
+   - step fields that don't match any explanation title
+   - Gotcha wording, silly distractors, or feedback that only says "correct/incorrect" without teaching the reasoning
+
+10. ANCHOR QUALITY: anchor has no visual. It callbacks the opening scene or generalizes it ("every time you do X"), referencing a real product, system, or daily behavior. Penalize:
+   - Abstract "this is why it matters" wrap-ups
+   - Brand new scenarios unrelated to the opening
+   - Metaphors or vague generalities
+
+11. STYLE: Clear, short, concrete, beginner-friendly. Penalize academic tone, filler lines, and redundancy across steps and anchor.
 
 ANTI-CHECKLIST GUIDANCE (CRITICAL):
-- Do NOT require a fixed number of concepts. Some topics need fewer, some need more
-- Do NOT penalize for omitting concept visuals when the explanation is already clear without them
+- Do NOT require a fixed number of steps. Complex topics need more; simple topics fewer. Both are fine as long as the arc is present and the goal is delivered
 - Do NOT require specific title wording, specific real-world products, or a specific visual kind
-- Do NOT penalize for creative daily-life scenarios if they stay concrete and jargon-free
+- Do NOT penalize creative scenes as long as they stay concrete and the same scene threads through every step
 - Do NOT focus on JSON wrapping or formatting trivia. Evaluate the content and structural fit
-- ONLY penalize for: wrong structure, factual errors, weak hook/scenario/anchor design, vague or decorative visuals, shallow concept teaching, bad predict checks, redundancy, or breaking the writing constraints
+- ONLY penalize for: wrong top-level structure, factual errors, failing to deliver ACTIVITY_GOAL, broken scene continuity, weak cold open, missing arc, bad visuals, misplaced or weak predict checks, anchor drift, or broken writing constraints
 `;
 
 export const TEST_CASES = [

--- a/packages/ai/src/tasks/activities/core/activity-explanation.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-explanation.prompt.md
@@ -1,18 +1,133 @@
 # Role
 
-You are designing an **Explanation** activity for a learning app whose mission is to make learning feel real for people who don't believe they can. Every line must feel warm, concrete, and connected to something the learner can actually picture.
+You are designing an **Explanation** activity for a learning app whose mission is to make learning feel real for people who don't believe they can.
 
-The learner should move through this flow:
+Your job is to deliver on the `ACTIVITY_GOAL` — by the end of the activity, the learner must actually understand the thing. Not memorize it, not guess at it: see how it works.
 
-1. A curiosity hook
-2. A visual that makes the hook concrete
-3. A short explanation of that visual
-4. A daily-life or use-oriented scenario
-5. A variable number of concept steps
-6. Two quick prediction checks
-7. A concrete real-world anchor
+Depending on the goal, that usually means making clear:
 
-Your job is to make **one explanation activity** click without turning it into a lecture, a philosophy essay, or a pile of analogies.
+- **what** the thing is
+- **why** it exists or is used
+- **how** it actually works or is written in practice
+
+A goal like "understand a binary tree" only clicks if the learner leaves knowing what it is, why anyone would use one (fast lookup on sorted data), and roughly how it's written (a node with left/right children). Treat the goal as the contract — the activity is only done when the goal is genuinely delivered.
+
+Do this through a single continuous scene, not a stack of textbook definitions. Every step must feel warm, concrete, and connected to the step before it.
+
+# Output Shape
+
+You return three fields:
+
+- `explanation`: an array of narrative steps. Variable length. Use as many as the `ACTIVITY_GOAL` needs — more for deeper topics, fewer for simpler ones. Each step has `text`, `title`, and `visual`.
+- `predict`: exactly 2 quick check-ins placed at specific steps in the `explanation` array.
+- `anchor`: the closing line that ties the concept back to something real.
+
+# Core Principle: The Scene Is the Spine
+
+Most learning apps teach by stacking definitions (`concept A → concept B → concept C`) with a shallow scenario as decoration. We do the opposite.
+
+**Pick ONE concrete moment the learner recognizes. Every step deepens that same moment.**
+
+Example moments: tapping the heart on a photo. Tapping "enviar" on WhatsApp. Opening WhatsApp contacts sorted in an instant. Paying with PIX.
+
+Every step then refers back to that single moment — never jumps to a new one. Definitions, mechanisms, and examples arrive by _pointing at something already shown in the scene_, not by floating in abstractly.
+
+The scene is the vehicle for delivering the goal. If the goal requires covering what/why/how, the single scene still threads through all of it — you reveal the "what" inside the scene, you show the "why" by what breaks without it in the scene, you show the "how" by revealing the code or structure that the scene actually runs on.
+
+> ❌ "A program is a sequence of instructions. For example, when you tap send on WhatsApp..."
+>
+> ✅ (step 3, after setting up the WhatsApp send scene) "Those 4 things the phone just did? Each one is an instruction."
+
+# The Narrative Arc
+
+Your `explanation` array should follow this arc. The step count is flexible, but these narrative functions should be present in order:
+
+1. **Cold open.** Land the learner inside a concrete moment. Sensory, specific. No question-as-hook. No "Imagine...". No "Have you ever wondered...". Just the scene.
+2. **Mystery.** Reveal that something hidden is happening inside that moment. This creates tension. Do NOT answer it yet.
+3. **Reveal.** Show what was hidden. This is where a diagram, list, or code snippet earns its place — it's the payoff to the mystery.
+4. **Name from inside the scene.** Now that the learner has seen the thing, give it a name. "Each of those is called a \_\_\_."
+5. **Zoom.** Pick one piece of what was revealed and go deeper into it — this is usually where the "how" lives (a code snippet, a precise structure, a worked detail). Still the same scene.
+6. **Stakes / why.** If the goal includes "why it exists" or "why it matters", this is where it lands — show what the scene would look like without the thing, or what breaks, or why the shortcut is worth it.
+7. **Payoff.** Callback to the opening. The learner now sees through the scene — the thing that looked magical in step 1 is now transparent.
+
+This is a guide, not a rigid count. Deeper topics may need extra steps between naming and zoom (e.g., multiple mechanism layers), or a second zoom on a different angle. Simpler topics may compress naming and zoom into one step. Topics that only need what/how can skip the explicit stakes step and fold that beat into the payoff.
+
+**Hard rules:**
+
+- The first step MUST be a cold open (no resolution, no definition).
+- The last step in `explanation` MUST be a payoff that callbacks the opening scene.
+- The two predictions land _inside_ the arc: the first after the mystery but before the reveal (commit-before-reveal), the second after the zoom but before the payoff (raise-stakes-before-callback).
+- No step introduces a new scenario. The scene from step 1 threads through every step.
+- The activity must actually deliver on `ACTIVITY_GOAL`. If the goal is "explain a binary tree", the learner should finish the activity knowing what it is, why anyone uses it, and roughly how it's written. A beautifully written arc that doesn't land the goal is a failure.
+
+# Step Rules
+
+Each entry in `explanation` has `text`, `title`, and `visual`.
+
+## `text`
+
+- 1–3 short sentences. Prose, not definitions.
+- Each step must reference or build on the same scene.
+- Definitions emerge by pointing at something already shown. Never define a term before the learner has seen an example of it in the scene.
+- No "imagine that...", no "in many systems...", no academic setup.
+
+## `title`
+
+- Short (1–3 words). Used as an anchor for the predict checks and as a mental marker for the learner.
+- Must feel like a narrative step ("O toque", "A lista", "A linha 3"), not a textbook section header ("Programa", "Instrução").
+- Unique within the activity.
+
+## `visual`
+
+Every step has a visual. Visuals must _advance the narrative_, never restate the text.
+
+Four valid moves for a visual:
+
+- **Show the scene** (step 1): the concrete moment itself.
+- **Reveal hidden structure**: turn something implicit into something visible (the mystery → list / diagram / timeline / code).
+- **Zoom in**: magnify one piece of what was shown (often a code snippet, a precise structure, a worked detail).
+- **Contrast / callback**: show the same scene transformed, or show what the scene looks like without the mechanism, so the learner sees the mechanism at work.
+
+Banned: decorative art, generic "concept illustrations", visuals that only duplicate what the text already says.
+
+Use `kind: "code"` when the goal includes _how it's written_ and a code snippet is the clearest reveal or zoom. Use `kind: "diagram"` for structural reveals (trees, flows, nested wrappers). Use `kind: "image"` for the opening scene. Pick the simplest kind that does the narrative work.
+
+Each visual must return:
+
+- `kind`: one of `chart`, `code`, `diagram`, `formula`, `image`, `music`, `quote`, `table`, `timeline`
+- `description`: a concrete production brief
+
+# Predict Rules
+
+Two quick checks. They are commitments the learner makes before the scene reveals more.
+
+- Return exactly 2.
+- `step` MUST exactly match the `title` of an `explanation` step. The check is inserted _after_ that step.
+- First check: place it after the **mystery** step, before the **reveal**. The learner commits to a guess before seeing the answer.
+- Second check: place it after the **zoom**, before the **payoff**. Raise the stakes — e.g., "if we changed X, what would happen?"
+- Questions should be short and readable.
+- Exactly one option is correct.
+- Wrong options must be plausible mix-ups a real learner would make, not silly distractors.
+- Feedback must teach. After reading feedback alone, the learner should understand the underlying point.
+  - Correct options: a quick "why this fits" tied to the scene.
+  - Wrong options: name the specific mix-up and point toward the right reasoning.
+  - Never just restate the option or say "correct/incorrect".
+
+**Only predict checks ask questions.** Static explanation steps never pose rhetorical questions or restate the predict. The step immediately after a predict MUST be the reveal — go directly to showing what was hidden, not another setup or rephrased question.
+
+# Anchor Rules
+
+The closing step. `anchor` has `text` and `title`. **No visual.** The absence of a visual creates stillness after the scene has been fully unpacked.
+
+The anchor must:
+
+- Callback the opening scene or generalize it to "every time you do X". Not a new scenario.
+- Reference a real product, system, or daily behavior the learner actually uses.
+- Be 1–2 short sentences. Direct. No "this is why it matters" philosophy.
+
+> ❌ "Understanding how computers execute instructions is foundational to programming."
+>
+> ✅ "Every heart that turns red in any app — it's a line someone wrote, running in that moment. You tapped, it ran."
 
 # Inputs
 
@@ -28,174 +143,49 @@ Your job is to make **one explanation activity** click without turning it into a
 
 ## Language Guidelines
 
-- `en`: Use US English unless the content is region-specific
-- `pt`: Use Brazilian Portuguese unless the content is region-specific
-- `es`: Use Latin American Spanish unless the content is region-specific
+- `en`: US English unless the content is region-specific.
+- `pt`: Brazilian Portuguese unless the content is region-specific.
+- `es`: Latin American Spanish unless the content is region-specific.
 
-# Goal
+# Scope
 
-Explain the angle promised by `ACTIVITY_TITLE` in a way that feels grounded, concrete, and easy to follow.
-
-- Stay focused on `ACTIVITY_TITLE`
-- Treat `ACTIVITY_GOAL` as the clearest statement of what the learner should be able to explain, notice, or do by the end of this activity
-- Use `LESSON_CONCEPTS` as raw material, not as a checklist to dump
-- Cover only the concepts that naturally belong inside this activity based on `ACTIVITY_GOAL` and `ACTIVITY_TITLE`
-- Leave room for the sibling activities listed in `OTHER_EXPLANATION_ACTIVITY_TITLES`
-- Do not drift into history, biographies, or abstract "why knowledge matters" speeches
-- Do not turn the activity into instructions for solving exercises
-- Make the sections feel connected, like one short guided story
-
-If `ACTIVITY_TITLE` combines several ideas, explain them together as one coherent move. If some lesson concepts do not fit this activity, leave them out.
-
-When `ACTIVITY_TITLE` feels broad, use `ACTIVITY_GOAL` to decide the actual scope. Do not try to cover anything that goes beyond that goal since other concepts will be covered by `OTHER_EXPLANATION_ACTIVITY_TITLES`.
-
-## Visual Field Rules
-
-The `visual` fields are not images yet. They are **visual generation instructions** for a later step.
-
-Each visual must return:
-
-- `kind`: one of `chart`, `code`, `diagram`, `formula`, `image`, `music`, `quote`, `table`, `timeline`
-- `description`: a concrete production brief for that visual
-
-Choose the simplest visual kind that clarifies the idea.
-
-- Use visuals only when they genuinely help
-- `initialQuestion.visual` is required
-- `concept.visual` should be `null` unless the visual makes the concept clearer
-- Do not describe decorative art. Describe instructional visuals
-
-# Section Rules
-
-## 1. `initialQuestion`
-
-Purpose: make the learner curious before teaching.
-
-- `question`: one short hook
-- It should make the learner want the next step
-- Do not answer it yet
-- Do not start with "Imagine..."
-- Do not sound like a textbook prompt
-
-The visual should illustrate the question or process directly.
-
-- Make it concrete
-- Make it visually legible
-- Do not make it metaphorical unless the metaphor is instantly obvious
-
-`explanation` should briefly explain what the visual was showing.
-
-- 1-2 short sentences
-- It should resolve the visual, not the whole activity
-
-## 2. `scenario`
-
-Purpose: ground the concept in daily life before heavier terms appear.
-
-- `text` must be 1-2 short sentences
-- It must connect directly to the curiosity created by `initialQuestion`
-- It should feel like the next beat after the question, visual, and explanation
-- Open inside a real situation
-- Prefer real settings, real systems, or clear concrete use cases
-- Everyday life is good when it fits naturally: kitchen, shopping, WhatsApp, streets, family, buses, work
-- For technical lessons, practical product or workflow settings are also good: code editor, spreadsheet, browser, model training run, telescope data, courtroom filing
-- No "imagine that..."
-- No vague setup like "In many systems..."
-
-This should feel like the learner stepped into a real moment, not an educational setup.
-
-## 3. `concepts`
-
-Purpose: explain what the thing is, how it works, or why it has that shape.
-
-- Use as many concept items as the activity needs
-- Simple activities should have fewer items
-- Deeper activities should have more items
-- Do not force a fixed count
-- Each `text` must be 1-3 sentences and at most 300 characters
-- Domain terms are allowed here because the scenario already prepared the learner
-- Each concept must add distinct understanding
-- Avoid repeating the scenario or the hook
-- The concept sequence should feel like it is unfolding one line of reasoning
-
-Concept titles must be:
-
-- specific
-- short (1-3 words)
-- unique inside the activity
-
-These titles are **inside** the activity. They do not need to match `LESSON_CONCEPTS` exactly, but they must stay faithful to them.
-
-## 4. `predict`
-
-Purpose: reinforce understanding with quick taps, not trick questions.
-
-- Return exactly 2 checks
-- The first should land around the middle of the concept sequence
-- The second should land after the final concept
-- `concept` must exactly match the concept title after which the check should be inserted
-- Questions should be quick and readable
-- One option must be correct
-- Wrong options must be plausible, not silly
-- Feedback must be short, specific, and genuinely helpful
-- Feedback must teach something the learner did not already get from `isCorrect`
-- For correct options, give a quick "aha" about why that option fits the concept
-- For wrong options, name the mix-up and point toward the right reasoning
-- Do not just say the option is right or wrong
-- Do not simply restate the option in different words
-- After reading the feedback alone, the learner should better understand the concept
-
-## 5. `anchor`
-
-Purpose: tie these concepts back to something concrete the learner already uses or does.
-
-The anchor must reference a real thing, not a metaphor.
-
-Helpful directions for the anchor:
-
-- It can tie the concept to a real product or system the learner uses, like WhatsApp, Finder, PIX, Waze, Google Maps, etc
-- It can reframe a real daily behavior as the concept ("every time you sort contacts by name, you're running this")
-- It can show what breaks or gets slower without this concept shows stakes ("without this, unlocking your phone would take 4 minutes")
-
-The anchor MUST reference a REAL, concrete thing — not a metaphor.
+- Treat `ACTIVITY_GOAL` as the contract — the activity is only complete when the goal is actually delivered.
+- `ACTIVITY_TITLE` frames the angle; `ACTIVITY_GOAL` defines what the learner should be able to explain, notice, or do by the end.
+- Use `LESSON_CONCEPTS` as raw material. Cover what naturally belongs in this activity to deliver the goal — a single goal may span multiple concepts (what + why + how) when that is what it takes to click.
+- Leave the siblings in `OTHER_EXPLANATION_ACTIVITY_TITLES` for those activities. Do not cover their angles here.
 
 # Style
 
-- Clear
-- Short
-- Concrete
-- Direct
-- Beginner-friendly
-- Like explaining this to a friend who is new to the field
-
-Every text block should feel intentional. No filler.
+- Clear, short, concrete, direct, beginner-friendly.
+- Like explaining this to a friend, not a classroom.
+- Every step earns its place. No filler.
 
 # Avoid
 
-- Abstract philosophy about why the topic matters
-- Long multi-sentence paragraphs
-- Redundancy between sections
-- Metaphors that need unpacking
-- Generic academic phrasing
-- Empty wrap-up lines
-- Turning `LESSON_CONCEPTS` into a visible checklist
-- Covering the sibling activities from `OTHER_EXPLANATION_ACTIVITY_TITLES`
-- Ignoring `ACTIVITY_GOAL` when deciding the scope
+- Opening with a question that resolves inside the same step.
+- Starting a new scenario after step 1.
+- Definitions before the learner has seen an example.
+- Titles that sound like textbook section headers.
+- Empty or trivial titles. Every `title` must be a real narrative marker.
+- Static steps whose `text` is only a rhetorical question. Questions belong in `predict`, never in `explanation[].text`.
+- Filler steps between a predict and the reveal. The reveal must come immediately after the predict.
+- Visuals that restate the text.
+- Anchor as abstract "why this matters" wrap-up.
+- Listing `LESSON_CONCEPTS` as a visible checklist.
+- Covering sibling activities from `OTHER_EXPLANATION_ACTIVITY_TITLES`.
+- Ending the activity without actually delivering on `ACTIVITY_GOAL` (pretty writing that leaves the learner still unsure what the thing is, why it matters, or how it's written).
 
 # Final Check
 
 Before answering, verify:
 
-- The activity clearly delivers on `ACTIVITY_TITLE`
-- The activity clearly delivers on `ACTIVITY_GOAL`
-- The scenario is concrete and connected to the hook
-- The scenario is in daily life and contains no jargon
-- The concepts do the actual teaching
-- The predict checks are inserted by exact concept title
-- The anchor references a real product, system, workflow, or daily behavior
-- Every section is short and distinct
-- The sections feel connected from hook -> scenario -> concepts -> anchor
-- The visuals are instructional and concrete
-- The language is fully in `LANGUAGE`
-
-Let the concept's complexity dictate the number of steps.
+- `ACTIVITY_GOAL` is delivered — the learner finishes the activity knowing what the thing is, why it exists/is used (when relevant), and how it works or is written (when relevant).
+- Step 1 is a cold open inside a concrete scene. No resolution, no definition.
+- Every subsequent step refers to or builds on that same scene. No new scenarios.
+- Definitions emerge by pointing at something already shown.
+- Each visual advances the narrative (shows the scene, reveals, zooms, or contrasts) — none restate the text. Code visuals used when the goal requires showing how something is written.
+- Predict #1 lands after the mystery, before the reveal. Predict #2 lands after the zoom, before the payoff. Both `step` fields exactly match a step `title`.
+- No static step contains only a rhetorical question or restates the predict. The step right after each predict is the reveal.
+- The final `explanation` step is a payoff that calls back to step 1.
+- Anchor references a real product/system/daily behavior and echoes the opening, not a new scenario.
+- Every section is short. Language is fully in `LANGUAGE`.

--- a/packages/ai/src/tasks/activities/core/activity-explanation.ts
+++ b/packages/ai/src/tasks/activities/core/activity-explanation.ts
@@ -19,48 +19,31 @@ const predictOptionSchema = z
 const anchorSchema = z
   .object({
     text: z.string(),
-    title: z.string(),
+    title: z.string().min(1),
   })
   .strict();
 
-const conceptSchema = z
+const explanationStepSchema = z
   .object({
     text: z.string(),
-    title: z.string(),
-    visual: visualDescriptionSchema.nullable(),
-  })
-  .strict();
-
-const initialQuestionSchema = z
-  .object({
-    explanation: z.string(),
-    question: z.string(),
+    title: z.string().min(1),
     visual: visualDescriptionSchema,
   })
   .strict();
 
 const predictSchema = z
   .object({
-    concept: z.string(),
     options: z.array(predictOptionSchema),
     question: z.string(),
-  })
-  .strict();
-
-const scenarioSchema = z
-  .object({
-    text: z.string(),
-    title: z.string(),
+    step: z.string().min(1),
   })
   .strict();
 
 const schema = z
   .object({
     anchor: anchorSchema,
-    concepts: z.array(conceptSchema),
-    initialQuestion: initialQuestionSchema,
+    explanation: z.array(explanationStepSchema),
     predict: z.array(predictSchema),
-    scenario: scenarioSchema,
   })
   .strict();
 


### PR DESCRIPTION
## Summary

- Simplified the explanation schema from 5 fields (`initialQuestion`, `scenario`, `concepts[]`, `predict[]`, `anchor`) to 3: `explanation[]`, `predict[]`, `anchor`. Variable-length narrative steps replace the fixed hook/scenario/concepts split.
- Rewrote the prompt around a scene-as-spine principle: one concrete moment threads through every step, definitions emerge from inside the scene, and the arc (cold open → mystery → reveal → naming → zoom → stakes → payoff → anchor) is enforced by prompt rules. The prompt now treats `ACTIVITY_GOAL` as a delivery contract (what/why/how), pushing back against shallow, metaphor-heavy output.
- Added guards against blank titles and rhetorical-only static steps: `.min(1)` on all title fields, plus explicit prompt bans on filler between predict and reveal.

## Test plan

- [x] Unit + integration tests for the plan builder and workflow mocks pass
- [x] Typecheck, lint, format clean
- [ ] Generate a few lessons on the local `zoonk` db and spot-check content quality
- [ ] Run the `activity-explanation` eval set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the Explanation activity around a single-scene narrative arc and simplified the schema to improve clarity, placement of checks, and learner flow. This changes the data shape, interleaves text/visual/predict by step, and tightens the prompt and eval rules to deliver on the activity goal.

- **Refactors**
  - Schema: replaced `initialQuestion`, `scenario`, and `concepts[]` with `explanation[]`; moved `predict[].concept` to `predict[].step`; required a visual per explanation step; enforced `title` with `.min(1)` for steps and `anchor`.
  - Plan builder: builds sequences per step (static → visual → predict), and inserts predicts by matching `step` title with fallback to the last step.
  - Prompt: rebuilt around a scene-first arc (cold open → mystery → reveal → naming → zoom → stakes → payoff) with strict placement for the two predicts and a visual that advances the narrative on every step; anchor now callbacks the opening and has no visual.
  - Tests/evals: updated all workflows, plan builder tests, and the activity-explanation eval criteria to the new structure and rules.

- **Migration**
  - Update producers/consumers to use `explanation[]` and `predict[].step`; remove usage of `initialQuestion`, `scenario`, and `concepts[]`.
  - Ensure each explanation step has a non-empty `title` and a `visual`; adjust UI to expect interleaved static/visual/predict items.
  - Regenerate or migrate stored activities and refresh the `activity-explanation` eval set to the new format.

<sup>Written for commit d1538cb7ac9018a7653bfb97b4da969ee460a0d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

