### PR TITLE
fix(player): avoid duplicate visual keys

### DIFF
--- a/packages/player/src/_browser-tests/player-visual.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-visual.browser.test.tsx
@@ -1,5 +1,5 @@
 import { type VisualStepContent } from "@zoonk/core/steps/contract/visual";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { page } from "vitest/browser";
 import { buildSerializedActivity, buildSerializedStep } from "../_test-utils/player-test-data";
 import { buildAuthenticatedViewer } from "../_test-utils/player-test-viewer";
@@ -273,6 +273,112 @@ describe("player browser integration: visual steps", () => {
     await expect.element(page.getByText("1956")).toBeVisible();
     await expect.element(page.getByText("Dartmouth Conference")).toBeVisible();
     await expect.element(page.getByText(/deep blue defeats kasparov/i)).toBeVisible();
+  });
+
+  test("renders repeated timeline labels without duplicate-key warnings", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      renderVisualActivity({
+        steps: [
+          buildVisualStep({
+            content: {
+              events: [
+                {
+                  date: "Ao longo do tempo",
+                  description: "Primeiro marco dessa ideia.",
+                  title: "Primeiro momento",
+                },
+                {
+                  date: "Ao longo do tempo",
+                  description: "Segundo marco dessa ideia.",
+                  title: "Segundo momento",
+                },
+              ],
+              kind: "timeline",
+            },
+          }),
+        ],
+      });
+
+      await expect.element(page.getByRole("figure", { name: /timeline/i })).toBeVisible();
+      await expect.element(page.getByText(/primeiro marco dessa ideia/i)).toBeVisible();
+      await expect.element(page.getByText(/segundo marco dessa ideia/i)).toBeVisible();
+
+      const duplicateKeyWarnings = consoleErrorSpy.mock.calls.filter((args: unknown[]) =>
+        String(args[0]).includes("Encountered two children with the same key"),
+      );
+
+      expect(duplicateKeyWarnings).toStrictEqual([]);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  test("renders duplicate chart legend labels without duplicate-key warnings", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      renderVisualActivity({
+        steps: [
+          buildVisualStep({
+            content: {
+              chartType: "pie",
+              data: [
+                { name: "Ao longo do tempo", value: 60 },
+                { name: "Ao longo do tempo", value: 40 },
+              ],
+              kind: "chart",
+              title: "Repeated legend labels",
+            },
+          }),
+        ],
+      });
+
+      await expect
+        .element(page.getByRole("figure", { name: /repeated legend labels/i }))
+        .toBeVisible();
+
+      const duplicateKeyWarnings = consoleErrorSpy.mock.calls.filter((args: unknown[]) =>
+        String(args[0]).includes("Encountered two children with the same key"),
+      );
+
+      expect(duplicateKeyWarnings).toStrictEqual([]);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  test("renders duplicate table rows without duplicate-key warnings", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      renderVisualActivity({
+        steps: [
+          buildVisualStep({
+            content: {
+              caption: "Duplicate rows",
+              columns: ["Column A", "Column B"],
+              kind: "table",
+              rows: [
+                ["Same", "Row"],
+                ["Same", "Row"],
+              ],
+            },
+          }),
+        ],
+      });
+
+      await expect.element(page.getByRole("figure", { name: /duplicate rows/i })).toBeVisible();
+
+      const duplicateKeyWarnings = consoleErrorSpy.mock.calls.filter((args: unknown[]) =>
+        String(args[0]).includes("Encountered two children with the same key"),
+      );
+
+      expect(duplicateKeyWarnings).toStrictEqual([]);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   test("renders bar, line, and pie charts through the shared chart renderer", async () => {

--- a/packages/player/src/components/visuals/chart-visual.tsx
+++ b/packages/player/src/components/visuals/chart-visual.tsx
@@ -146,8 +146,12 @@ function PieChartVisual({ data }: { data: ChartDataPoint[] }) {
       </ResponsiveContainer>
 
       <ul aria-label={t("Legend")} className="mt-3 flex flex-wrap justify-center gap-x-4 gap-y-1">
-        {coloredData.map((entry) => (
-          <li className="flex items-center gap-1.5 text-sm" key={entry.name}>
+        {coloredData.map((entry, index) => (
+          <li
+            className="flex items-center gap-1.5 text-sm"
+            // oxlint-disable-next-line react/no-array-index-key -- pie-chart legends can intentionally repeat the same generated label
+            key={index}
+          >
             <span
               aria-hidden="true"
               className="size-2 shrink-0 rounded-full"

--- a/packages/player/src/components/visuals/table-visual.tsx
+++ b/packages/player/src/components/visuals/table-visual.tsx
@@ -26,8 +26,9 @@ export function TableVisual({ content }: { content: TableVisualContent }) {
         </TableHeader>
 
         <TableBody>
-          {content.rows.map((row) => (
-            <TableRow key={row.join("-")}>
+          {content.rows.map((row, rowIndex) => (
+            // oxlint-disable-next-line react/no-array-index-key -- AI-generated tables can intentionally repeat the same row values
+            <TableRow key={rowIndex}>
               {content.columns.map((column, columnIndex) => (
                 // oxlint-disable-next-line react/no-array-index-key -- AI-generated columns can have duplicate names
                 <TableCell className="whitespace-normal" key={columnIndex}>

--- a/packages/player/src/components/visuals/timeline-visual.tsx
+++ b/packages/player/src/components/visuals/timeline-visual.tsx
@@ -45,7 +45,8 @@ export function TimelineVisual({ content }: { content: TimelineVisualContent }) 
             date={event.date}
             description={event.description}
             hasLine={hasMultipleEvents && index < content.events.length - 1}
-            key={event.date}
+            // oxlint-disable-next-line react/no-array-index-key -- timeline events can intentionally reuse the same generated date label
+            key={index}
             title={event.title}
           />
         ))}


### PR DESCRIPTION
## Summary
- use non-colliding keys in the timeline, chart, and table visual renderers
- add browser regressions for duplicate generated labels in visual steps

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate React key warnings in player visuals by using stable index-based keys where labels may repeat. Adds browser tests to prevent regressions in timeline, pie chart legends, and table rows.

- Bug Fixes
  - Use index keys for timeline events, pie chart legend items, and table rows/columns to avoid key collisions when labels repeat.
  - Add browser tests that render visuals with duplicate labels and assert no “Encountered two children with the same key” warnings.

<sup>Written for commit 602000ee6d0f601b07d2cac54530b671c840f766. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

