### PR TITLE
fix(ai): restore explanation visual pipeline

### DIFF
--- a/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
@@ -51,35 +51,18 @@ function createExplanationResult(): Awaited<ReturnType<typeof generateActivityEx
         {
           text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
           title: "O envio",
-          visual: {
-            description:
-              "Two frames: your thumb tapping send, then the photo visible in the friend's chat.",
-            kind: "image" as const,
-          },
         },
         {
           text: "Between the tap and the delivered photo, the message passes through several hidden points. Each one wraps it with a different kind of label.",
           title: "Os rótulos escondidos",
-          visual: {
-            description: "Same two frames with a blurred row of unlabeled wrappers between them.",
-            kind: "image" as const,
-          },
         },
         {
           text: "Here are the wrappers, in the order they get added: the app wrapper, the transport wrapper, the network wrapper. Each layer adds a label for a different job.",
           title: "A pilha",
-          visual: {
-            description: "Nested packet with stacked layer labels: app, transport, network.",
-            kind: "diagram" as const,
-          },
         },
         {
           text: "Zoom in on the network wrapper: it only carries routing info — where to send next. The chat content stays sealed inside, untouched by routers.",
           title: "O rótulo de rede",
-          visual: {
-            description: "Close-up of the network wrapper with a routing address highlighted.",
-            kind: "diagram" as const,
-          },
         },
       ],
       predict: [

--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
@@ -55,35 +55,18 @@ function createExplanationResult(): Awaited<ReturnType<typeof generateActivityEx
         {
           text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
           title: "O envio",
-          visual: {
-            description:
-              "Two frames: your thumb tapping send, then the photo visible in the friend's chat.",
-            kind: "image" as const,
-          },
         },
         {
           text: "Between the tap and the delivered photo, the message passes through several hidden points. Each one wraps it with a different kind of label.",
           title: "Os rótulos escondidos",
-          visual: {
-            description: "Same two frames with a blurred row of unlabeled wrappers between them.",
-            kind: "image" as const,
-          },
         },
         {
           text: "Here are the wrappers, in the order they get added: the app wrapper, the transport wrapper, the network wrapper. Each layer adds a label for a different job.",
           title: "A pilha",
-          visual: {
-            description: "Nested packet with stacked layer labels: app, transport, network.",
-            kind: "diagram" as const,
-          },
         },
         {
           text: "Zoom in on the network wrapper: it only carries routing info — where to send next. The chat content stays sealed inside, untouched by routers.",
           title: "O rótulo de rede",
-          visual: {
-            description: "Close-up of the network wrapper with a routing address highlighted.",
-            kind: "diagram" as const,
-          },
         },
       ],
       predict: [

--- a/apps/api/src/workflows/activity-generation/custom-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/custom-activity-workflow.test.ts
@@ -49,35 +49,18 @@ function createExplanationResult() {
         {
           text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
           title: "O envio",
-          visual: {
-            description:
-              "Two frames: your thumb tapping send, then the photo visible in the friend's chat.",
-            kind: "image" as const,
-          },
         },
         {
           text: "Between the tap and the delivered photo, the message passes through several hidden points. Each one wraps it with a different kind of label.",
           title: "Os rótulos escondidos",
-          visual: {
-            description: "Same two frames with a blurred row of unlabeled wrappers between them.",
-            kind: "image" as const,
-          },
         },
         {
           text: "Here are the wrappers, in the order they get added: the app wrapper, the transport wrapper, the network wrapper. Each layer adds a label for a different job.",
           title: "A pilha",
-          visual: {
-            description: "Nested packet with stacked layer labels: app, transport, network.",
-            kind: "diagram" as const,
-          },
         },
         {
           text: "Zoom in on the network wrapper: it only carries routing info — where to send next. The chat content stays sealed inside, untouched by routers.",
           title: "O rótulo de rede",
-          visual: {
-            description: "Close-up of the network wrapper with a routing address highlighted.",
-            kind: "diagram" as const,
-          },
         },
       ],
       predict: [

--- a/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { generateActivityExplanation } from "@zoonk/ai/tasks/activities/core/explanation";
+import { generateStepVisualDescriptions } from "@zoonk/ai/tasks/steps/visual-descriptions";
 import { prisma } from "@zoonk/db";
 import { activityFixture } from "@zoonk/testing/fixtures/activities";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
@@ -16,6 +17,23 @@ function getStreamedMessages(): Record<string, string>[] {
   return getStreamedEvents() as Record<string, string>[];
 }
 
+function createDescriptionsResult(
+  steps: { title: string; text: string }[],
+): Awaited<ReturnType<typeof generateStepVisualDescriptions>> {
+  return {
+    data: {
+      descriptions: steps.map((step, index) =>
+        index === 0
+          ? { description: `A visual prompt for ${step.title}`, kind: "image" as const }
+          : { description: `A diagram for ${step.title}`, kind: "diagram" as const },
+      ),
+    },
+    systemPrompt: "test",
+    usage: {} as Awaited<ReturnType<typeof generateStepVisualDescriptions>>["usage"],
+    userPrompt: "test",
+  };
+}
+
 function createExplanationResult(): Awaited<ReturnType<typeof generateActivityExplanation>> {
   return {
     data: {
@@ -27,35 +45,18 @@ function createExplanationResult(): Awaited<ReturnType<typeof generateActivityEx
         {
           text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
           title: "O envio",
-          visual: {
-            description:
-              "Two frames: your thumb tapping send, then the photo visible in the friend's chat.",
-            kind: "image" as const,
-          },
         },
         {
           text: "Between the tap and the delivered photo, the message passes through several hidden points. Each one wraps it with a different kind of label.",
           title: "Os rótulos escondidos",
-          visual: {
-            description: "Same two frames with a blurred row of unlabeled wrappers between them.",
-            kind: "image" as const,
-          },
         },
         {
           text: "Here are the wrappers, in the order they get added: the app wrapper, the transport wrapper, the network wrapper. Each layer adds a label for a different job.",
           title: "A pilha",
-          visual: {
-            description: "Nested packet with stacked layer labels: app, transport, network.",
-            kind: "diagram" as const,
-          },
         },
         {
           text: "Zoom in on the network wrapper: it only carries routing info — where to send next. The chat content stays sealed inside, untouched by routers.",
           title: "O rótulo de rede",
-          visual: {
-            description: "Close-up of the network wrapper with a routing address highlighted.",
-            kind: "diagram" as const,
-          },
         },
       ],
       predict: [
@@ -101,6 +102,14 @@ function createExplanationResult(): Awaited<ReturnType<typeof generateActivityEx
 
 vi.mock("@zoonk/ai/tasks/activities/core/explanation", () => ({
   generateActivityExplanation: vi.fn().mockResolvedValue(createExplanationResult()),
+}));
+
+vi.mock("@zoonk/ai/tasks/steps/visual-descriptions", () => ({
+  generateStepVisualDescriptions: vi
+    .fn()
+    .mockImplementation(({ steps }: { steps: { title: string; text: string }[] }) =>
+      Promise.resolve(createDescriptionsResult(steps)),
+    ),
 }));
 
 vi.mock("../steps/_utils/dispatch-visual-content", () => ({
@@ -221,6 +230,38 @@ describe("explanation activity workflow", () => {
       "O rótulo de rede",
       "Every send",
     ]);
+    expect(vi.mocked(generateStepVisualDescriptions)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        steps: [
+          {
+            text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
+            title: "O envio",
+          },
+          {
+            text: "Between the tap and the delivered photo, the message passes through several hidden points. Each one wraps it with a different kind of label.",
+            title: "Os rótulos escondidos",
+          },
+          {
+            text: "Here are the wrappers, in the order they get added: the app wrapper, the transport wrapper, the network wrapper. Each layer adds a label for a different job.",
+            title: "A pilha",
+          },
+          {
+            text: "Zoom in on the network wrapper: it only carries routing info — where to send next. The chat content stays sealed inside, untouched by routers.",
+            title: "O rótulo de rede",
+          },
+        ],
+      }),
+    );
+    expect(vi.mocked(dispatchVisualContent)).toHaveBeenCalledWith({
+      descriptions: [
+        { description: "A visual prompt for O envio", kind: "image" },
+        { description: "A diagram for Os rótulos escondidos", kind: "diagram" },
+        { description: "A diagram for A pilha", kind: "diagram" },
+        { description: "A diagram for O rótulo de rede", kind: "diagram" },
+      ],
+      language: activity.language,
+      orgSlug: activities[0]?.lesson.chapter.course.organization?.slug,
+    });
   });
 
   test("returns existing static explanation steps for already completed activities", async () => {
@@ -445,7 +486,11 @@ describe("explanation activity workflow", () => {
     const streamedMessages = getStreamedMessages();
     const activityIds = new Set([firstActivity.id, secondActivity.id]);
 
-    for (const stepName of ["generateVisualContent", "saveExplanationActivity"]) {
+    for (const stepName of [
+      "generateVisualDescriptions",
+      "generateVisualContent",
+      "saveExplanationActivity",
+    ]) {
       const stepMessages = streamedMessages.filter((message) => message.step === stepName);
       expect(stepMessages.length).toBeGreaterThan(0);
 

--- a/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.ts
@@ -6,18 +6,10 @@ import {
   generateExplanationContentStep,
 } from "../steps/generate-explanation-content-step";
 import { generateExplanationVisualContentStep } from "../steps/generate-explanation-visual-content-step";
+import { generateExplanationVisualDescriptionsStep } from "../steps/generate-explanation-visual-descriptions-step";
 import { type LessonActivity } from "../steps/get-lesson-activities-step";
 import { handleActivityFailureStep } from "../steps/handle-failure-step";
 import { saveExplanationActivityStep } from "../steps/save-explanation-activity-step";
-
-/**
- * Explanation visuals now come inline from the explanation task. Pulling the
- * visual briefs out of the ordered plan keeps the rest of the workflow focused
- * on execution instead of re-deriving where visuals belong.
- */
-function getVisualDescriptions(result: GeneratedExplanationResult) {
-  return result.plan.flatMap((entry) => (entry.kind === "visual" ? [entry.description] : []));
-}
 
 /**
  * Marks explanation activities as failed when the content generation step
@@ -70,11 +62,10 @@ async function getResultsFromCompletedActivities(
  * Orchestrates explanation activity generation with per-entity save.
  *
  * Flow per entity:
- *   generateContent -> generateVisualContent -> save.
+ *   generateContent -> generateVisualDescriptions -> generateVisualContent -> save.
  *
- * The main explanation task now writes the visual briefs inline with the rest
- * of the activity structure, so the workflow only needs a separate execution
- * step for producing the final visual payloads.
+ * The explanation task produces the ordered learner flow, while the shared
+ * visual-description task decides what to illustrate for each explanation step.
  *
  * Each entity is independent — if one fails, others continue.
  * The save step writes all data (content + visuals) at once
@@ -122,10 +113,12 @@ export async function explanationActivityWorkflow({
       }
 
       try {
-        const { visuals } = await generateExplanationVisualContentStep(
+        const { descriptions } = await generateExplanationVisualDescriptionsStep(
           activity,
-          getVisualDescriptions(result),
+          result.visualSteps,
         );
+
+        const { visuals } = await generateExplanationVisualContentStep(activity, descriptions);
 
         await saveExplanationActivityStep({
           activityId: result.activityId,

--- a/apps/api/src/workflows/activity-generation/steps/_utils/build-explanation-activity-plan.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/build-explanation-activity-plan.test.ts
@@ -11,51 +11,26 @@ function buildContent() {
       {
         text: "You tap the heart on a photo. A moment later, it is red and the counter jumped from 42 to 43.",
         title: "O toque",
-        visual: {
-          description: "Two frames side by side: grey heart with 42, then red heart with 43.",
-          kind: "image" as const,
-        },
       },
       {
         text: "Between the tap and the red heart, the phone did exactly 4 things. They were written somewhere, ready to run.",
         title: "O que está escondido",
-        visual: {
-          description: "Same two frames with 4 blurred numbered boxes between them.",
-          kind: "image" as const,
-        },
       },
       {
         text: "Here is the list, in the order the phone ran it: register tap, mark photo as liked, change heart colour to red, add 1 to counter.",
         title: "A lista",
-        visual: {
-          description: "Numbered list of the 4 actions.",
-          kind: "diagram" as const,
-        },
       },
       {
         text: "Each of those 4 lines is an instruction: one exact command, one action only.",
         title: "O nome",
-        visual: {
-          description: "The same list with one line bracketed and labelled '= 1 instruction'.",
-          kind: "diagram" as const,
-        },
       },
       {
         text: "Look at line 3: 'change heart colour to red'. It does not handle a second tap or a deleted photo. It only changes the colour.",
         title: "A linha 3",
-        visual: {
-          description: "Close-up of line 3 with a grey-to-red colour swatch.",
-          kind: "diagram" as const,
-        },
       },
       {
         text: "That is why the heart turned red when you tapped. Not because the phone understood your intent, but because line 3 said so.",
         title: "O retorno",
-        visual: {
-          description:
-            "Beat 1 frames again, with line 3 drawn beside them and an arrow linking it to the red heart.",
-          kind: "diagram" as const,
-        },
       },
     ],
     predict: [

--- a/apps/api/src/workflows/activity-generation/steps/_utils/build-explanation-activity-plan.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/build-explanation-activity-plan.ts
@@ -1,5 +1,4 @@
 import { type ActivityExplanationSchema } from "@zoonk/ai/tasks/activities/core/explanation";
-import { type VisualDescription } from "@zoonk/ai/tasks/steps/visual-descriptions";
 import { type MultipleChoiceStepContent } from "@zoonk/core/steps/contract/content";
 import { type ActivitySteps } from "./get-activity-steps";
 
@@ -14,14 +13,12 @@ export type ExplanationActivityPlanEntry =
       text: string;
       title: string;
     }
-  | {
-      description: VisualDescription;
-      kind: "visual";
-    };
+  | { kind: "visual" };
 
 type ExplanationPlan = {
   entries: ExplanationActivityPlanEntry[];
   sourceSteps: ActivitySteps;
+  visualSteps: ActivitySteps;
 };
 
 /**
@@ -88,7 +85,7 @@ function buildStepEntries({
 
   return [
     { kind: "static", text: step.text, title: step.title },
-    { description: step.visual, kind: "visual" },
+    { kind: "visual" },
     ...predictions.map<ExplanationActivityPlanEntry>((prediction) => ({
       kind: "multipleChoice",
       options: prediction.options,
@@ -98,9 +95,20 @@ function buildStepEntries({
 }
 
 /**
- * Practice and quiz generation only need the text teaching surfaces, not the
- * visual placeholders or predict checks. This helper keeps that downstream
- * source list aligned with the explanation structure in one place.
+ * The shared visual-description generator should only see explanation prose
+ * steps. Predict checks and the closing anchor do not need visuals.
+ */
+function buildVisualSteps(content: ActivityExplanationSchema): ActivitySteps {
+  return content.explanation.map((step) => ({
+    text: step.text,
+    title: step.title,
+  }));
+}
+
+/**
+ * Practice and quiz generation need the explanation prose plus the anchor, but
+ * not the visual placeholders or predict checks. This helper keeps that
+ * downstream source list aligned with the explanation structure in one place.
  */
 function buildSourceSteps(content: ActivityExplanationSchema): ActivitySteps {
   return [
@@ -138,5 +146,6 @@ export function buildExplanationActivityPlan(content: ActivityExplanationSchema)
       },
     ],
     sourceSteps: buildSourceSteps(content),
+    visualSteps: buildVisualSteps(content),
   };
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-explanation-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-explanation-content-step.test.ts
@@ -48,35 +48,18 @@ function createExplanationResult() {
         {
           text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
           title: "O envio",
-          visual: {
-            description:
-              "Two frames: your thumb tapping send, then the photo visible in the friend's chat.",
-            kind: "image" as const,
-          },
         },
         {
           text: "Between the tap and the delivered photo, the message passes through several hidden points. Each one wraps it with a different kind of label.",
           title: "Os rótulos escondidos",
-          visual: {
-            description: "Same two frames with a blurred row of unlabeled wrappers between them.",
-            kind: "image" as const,
-          },
         },
         {
           text: "Here are the wrappers, in the order they get added: the app wrapper, the transport wrapper, the network wrapper. Each layer adds a label for a different job.",
           title: "A pilha",
-          visual: {
-            description: "Nested packet with stacked layer labels: app, transport, network.",
-            kind: "diagram" as const,
-          },
         },
         {
           text: "Zoom in on the network wrapper: it only carries routing info — where to send next. The chat content stays sealed inside, untouched by routers.",
           title: "O rótulo de rede",
-          visual: {
-            description: "Close-up of the network wrapper with a routing address highlighted.",
-            kind: "diagram" as const,
-          },
         },
       ],
       predict: [
@@ -212,6 +195,24 @@ describe(generateExplanationContentStep, () => {
       "visual",
       "multipleChoice",
       "static",
+    ]);
+    expect(result.results[0]?.visualSteps).toEqual([
+      {
+        text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
+        title: "O envio",
+      },
+      {
+        text: "Between the tap and the delivered photo, the message passes through several hidden points. Each one wraps it with a different kind of label.",
+        title: "Os rótulos escondidos",
+      },
+      {
+        text: "Here are the wrappers, in the order they get added: the app wrapper, the transport wrapper, the network wrapper. Each layer adds a label for a different job.",
+        title: "A pilha",
+      },
+      {
+        text: "Zoom in on the network wrapper: it only carries routing info — where to send next. The chat content stays sealed inside, untouched by routers.",
+        title: "O rótulo de rede",
+      },
     ]);
     expect(result.results[1]?.activityId).toBe(activities[1]?.id);
     expect(generateActivityExplanationMock).toHaveBeenNthCalledWith(

--- a/apps/api/src/workflows/activity-generation/steps/generate-explanation-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-explanation-content-step.ts
@@ -17,6 +17,7 @@ export type ExplanationResult = {
 
 export type GeneratedExplanationResult = ExplanationResult & {
   plan: ExplanationActivityPlanEntry[];
+  visualSteps: ActivitySteps;
 };
 
 /**
@@ -64,6 +65,7 @@ async function generateSingleExplanation({
     concept: activityTitle,
     plan: plan.entries,
     steps: plan.sourceSteps,
+    visualSteps: plan.visualSteps,
   };
 }
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-explanation-visual-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-explanation-visual-content-step.ts
@@ -5,10 +5,10 @@ import { dispatchVisualContent } from "./_utils/dispatch-visual-content";
 import { type LessonActivity } from "./get-lesson-activities-step";
 
 /**
- * Explanation activities choose their visual briefs during the main content
- * generation step. This workflow step only turns those stored briefs into real
- * visual payloads and keeps the per-entity streaming and retry behavior around
- * the expensive visual generation work.
+ * Explanation activities reuse the shared visual-description task before this
+ * step runs. This workflow step turns those chosen briefs into real visual
+ * payloads and keeps the per-entity streaming and retry behavior around the
+ * expensive visual generation work.
  */
 export async function generateExplanationVisualContentStep(
   activity: LessonActivity,

--- a/apps/api/src/workflows/activity-generation/steps/generate-explanation-visual-descriptions-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-explanation-visual-descriptions-step.ts
@@ -1,0 +1,48 @@
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
+import {
+  type VisualDescription,
+  generateStepVisualDescriptions,
+} from "@zoonk/ai/tasks/steps/visual-descriptions";
+import { type ActivityStepName } from "@zoonk/core/workflows/steps";
+import { type ActivitySteps } from "./_utils/get-activity-steps";
+import { type LessonActivity } from "./get-lesson-activities-step";
+
+/**
+ * Explanation activities still use the shared visual-description task so the
+ * visual-planning logic stays consistent with custom activities. We only pass
+ * the explanation prose steps here because predict checks and the closing
+ * anchor do not need visuals.
+ */
+export async function generateExplanationVisualDescriptionsStep(
+  activity: LessonActivity,
+  steps: ActivitySteps,
+): Promise<{ descriptions: VisualDescription[] }> {
+  "use step";
+
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
+  await stream.status({ status: "started", step: "generateVisualDescriptions" });
+
+  if (steps.length === 0) {
+    await stream.status({ status: "completed", step: "generateVisualDescriptions" });
+    return { descriptions: [] };
+  }
+
+  await stream.status({ status: "started", step: "generateVisualDescriptions" });
+
+  const result = await generateStepVisualDescriptions({
+    chapterTitle: activity.lesson.chapter.title,
+    courseTitle: activity.lesson.chapter.course.title,
+    language: activity.language,
+    lessonDescription: activity.lesson.description ?? "",
+    lessonTitle: activity.lesson.title,
+    steps,
+  });
+
+  if (!result) {
+    throw new Error("Empty AI result for visual description generation");
+  }
+
+  await stream.status({ status: "completed", step: "generateVisualDescriptions" });
+
+  return { descriptions: result.data.descriptions };
+}

--- a/apps/api/src/workflows/activity-generation/steps/generate-explanation-visual-descriptions-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-explanation-visual-descriptions-step.ts
@@ -27,8 +27,6 @@ export async function generateExplanationVisualDescriptionsStep(
     return { descriptions: [] };
   }
 
-  await stream.status({ status: "started", step: "generateVisualDescriptions" });
-
   const result = await generateStepVisualDescriptions({
     chapterTitle: activity.lesson.chapter.title,
     courseTitle: activity.lesson.chapter.course.title,

--- a/apps/evals/src/tasks/activity-explanation/test-cases.ts
+++ b/apps/evals/src/tasks/activity-explanation/test-cases.ts
@@ -4,7 +4,7 @@ EVALUATION CRITERIA:
 1. FACTUAL ACCURACY: The explanation must be technically correct for the topic. Penalize invented mechanisms, wrong cause-effect chains, or misleading simplifications.
 
 2. REQUIRED STRUCTURE: The output must contain exactly three top-level fields:
-   - explanation[]: an array of narrative steps, each with title, text, and visual
+   - explanation[]: an array of narrative steps, each with title and text
    - predict[]: exactly 2 quick checks, each with step (matching an explanation title), question, options
    - anchor: { title, text } (no visual)
 
@@ -27,11 +27,10 @@ EVALUATION CRITERIA:
    - Titles like "Programa", "Instrução", "Encapsulation" that sound like chapter headers
    - Repetition between steps
 
-8. VISUAL QUALITY: Every explanation step has a visual, and each visual must advance the narrative — showing the scene, revealing hidden structure, zooming in, or showing a contrast/callback. When the goal includes "how it's written", code or structural visuals should appear at the reveal or zoom moment. Penalize:
-   - Decorative art or generic concept illustrations
-   - Visuals that only restate what the text already said
-   - Missing visuals on explanation steps
-   - Missing a code/structural visual when the goal calls for showing how the thing is written
+8. STEP CONCRETENESS: The explanation steps must be specific enough that a downstream visual-planning task could clearly infer what should be shown. Penalize:
+   - Vague prose that never makes the scene or reveal concrete
+   - Mechanism steps that stay too abstract to picture
+   - "How it's written" goals that never describe the structure or code detail clearly enough to visualize
 
 9. PREDICT QUALITY: Exactly 2 checks. Predict #1 lands after a mystery step, before the reveal (commit-before-reveal). Predict #2 lands after the zoom, before the payoff (raise-stakes-before-callback). Each predict.step must exactly match an existing explanation title. Feedback must teach — after reading feedback alone, the learner should better understand the concept. Penalize:
    - Checks placed outside these two slots (e.g., after the payoff)

--- a/apps/main/src/lib/generation/activity-generation-phase-weights.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-weights.ts
@@ -107,10 +107,11 @@ export function getPhaseWeights(kind: ActivityKind): Record<PhaseName, number> {
   if (kind === "explanation") {
     return {
       ...ZERO_WEIGHTS,
-      creatingVisuals: 35,
+      creatingVisuals: 33,
       gettingStarted: 3,
+      preparingVisuals: 40,
       saving: 4,
-      writingContent: 58,
+      writingContent: 20,
     };
   }
 

--- a/apps/main/src/lib/generation/phase-kind-steps/explanation.ts
+++ b/apps/main/src/lib/generation/phase-kind-steps/explanation.ts
@@ -6,12 +6,14 @@ type ExplanationSteps =
   | "getLessonActivities"
   | "setActivityAsRunning"
   | "generateExplanationContent"
+  | "generateVisualDescriptions"
   | "generateVisualContent"
   | "saveExplanationActivity";
 
 export const EXPLANATION_PHASE_STEPS = {
   creatingVisuals: ["generateVisualContent"],
   gettingStarted: ["getLessonActivities", "setActivityAsRunning"],
+  preparingVisuals: ["generateVisualDescriptions"],
   saving: ["saveExplanationActivity"],
   writingContent: ["generateExplanationContent"],
 } as const satisfies Record<string, readonly ActivityStepName[]>;
@@ -26,6 +28,7 @@ type _ValidateExplanation = AssertAllCovered<
 export const EXPLANATION_PHASE_ORDER: PhaseName[] = [
   "gettingStarted",
   "writingContent",
+  "preparingVisuals",
   "creatingVisuals",
   "saving",
 ];

--- a/packages/ai/src/tasks/activities/core/activity-explanation.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-explanation.prompt.md
@@ -18,7 +18,7 @@ Do this through a single continuous scene, not a stack of textbook definitions. 
 
 You return three fields:
 
-- `explanation`: an array of narrative steps. Variable length. Use as many as the `ACTIVITY_GOAL` needs — more for deeper topics, fewer for simpler ones. Each step has `text`, `title`, and `visual`.
+- `explanation`: an array of narrative steps. Variable length. Use as many as the `ACTIVITY_GOAL` needs — more for deeper topics, fewer for simpler ones. Each step has `text` and `title`.
 - `predict`: exactly 2 quick check-ins placed at specific steps in the `explanation` array.
 - `anchor`: the closing line that ties the concept back to something real.
 
@@ -62,7 +62,7 @@ This is a guide, not a rigid count. Deeper topics may need extra steps between n
 
 # Step Rules
 
-Each entry in `explanation` has `text`, `title`, and `visual`.
+Each entry in `explanation` has `text` and `title`.
 
 ## `text`
 
@@ -77,25 +77,10 @@ Each entry in `explanation` has `text`, `title`, and `visual`.
 - Must feel like a narrative step ("O toque", "A lista", "A linha 3"), not a textbook section header ("Programa", "Instrução").
 - Unique within the activity.
 
-## `visual`
-
-Every step has a visual. Visuals must _advance the narrative_, never restate the text.
-
-Four valid moves for a visual:
-
-- **Show the scene** (step 1): the concrete moment itself.
-- **Reveal hidden structure**: turn something implicit into something visible (the mystery → list / diagram / timeline / code).
-- **Zoom in**: magnify one piece of what was shown (often a code snippet, a precise structure, a worked detail).
-- **Contrast / callback**: show the same scene transformed, or show what the scene looks like without the mechanism, so the learner sees the mechanism at work.
-
-Banned: decorative art, generic "concept illustrations", visuals that only duplicate what the text already says.
-
-Use `kind: "code"` when the goal includes _how it's written_ and a code snippet is the clearest reveal or zoom. Use `kind: "diagram"` for structural reveals (trees, flows, nested wrappers). Use `kind: "image"` for the opening scene. Pick the simplest kind that does the narrative work.
-
-Each visual must return:
-
-- `kind`: one of `chart`, `code`, `diagram`, `formula`, `image`, `music`, `quote`, `table`, `timeline`
-- `description`: a concrete production brief
+Do not generate visuals in this task. A downstream workflow will create one
+visual per explanation step from the narrative you write here. That means the
+scene, reveals, zooms, and payoff still need to be concrete enough that another
+task can clearly infer what should be illustrated.
 
 # Predict Rules
 
@@ -169,7 +154,6 @@ The anchor must:
 - Empty or trivial titles. Every `title` must be a real narrative marker.
 - Static steps whose `text` is only a rhetorical question. Questions belong in `predict`, never in `explanation[].text`.
 - Filler steps between a predict and the reveal. The reveal must come immediately after the predict.
-- Visuals that restate the text.
 - Anchor as abstract "why this matters" wrap-up.
 - Listing `LESSON_CONCEPTS` as a visible checklist.
 - Covering sibling activities from `OTHER_EXPLANATION_ACTIVITY_TITLES`.
@@ -183,7 +167,7 @@ Before answering, verify:
 - Step 1 is a cold open inside a concrete scene. No resolution, no definition.
 - Every subsequent step refers to or builds on that same scene. No new scenarios.
 - Definitions emerge by pointing at something already shown.
-- Each visual advances the narrative (shows the scene, reveals, zooms, or contrasts) — none restate the text. Code visuals used when the goal requires showing how something is written.
+- The narrative is concrete enough that a downstream visual-planning task can infer what to show at each explanation step.
 - Predict #1 lands after the mystery, before the reveal. Predict #2 lands after the zoom, before the payoff. Both `step` fields exactly match a step `title`.
 - No static step contains only a rhetorical question or restates the predict. The step right after each predict is the reveal.
 - The final `explanation` step is a payoff that calls back to step 1.

--- a/packages/ai/src/tasks/activities/core/activity-explanation.ts
+++ b/packages/ai/src/tasks/activities/core/activity-explanation.ts
@@ -2,7 +2,6 @@ import "server-only";
 import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { visualDescriptionSchema } from "../../steps/step-visual-descriptions";
 import systemPrompt from "./activity-explanation.prompt.md";
 
 const DEFAULT_MODEL = "openai/gpt-5.4";
@@ -27,7 +26,6 @@ const explanationStepSchema = z
   .object({
     text: z.string(),
     title: z.string().min(1),
-    visual: visualDescriptionSchema,
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- restore explanation visuals to use `generateStepVisualDescriptions` again instead of inline briefs from the explanation task
- only generate visuals for `explanation` steps, not `predict` checks or the `anchor`
- restore the explanation visual-preparation phase in the main generation flow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the two-stage visual pipeline for explanation activities: generate step briefs with `generateStepVisualDescriptions`, then render visuals. Visuals are only created for explanation steps, not `predict` checks or the anchor.

- **Refactors**
  - Added `generateExplanationVisualDescriptionsStep` and run it before visual rendering.
  - Switched to `@zoonk/ai/tasks/steps/visual-descriptions`; pass only explanation prose steps.
  - Removed inline `visual` from the explanation schema and prompt; evals now check step concreteness.
  - Introduced `preparingVisuals` phase, added `generateVisualDescriptions` to streamed steps, and adjusted weights.
  - Updated the plan builder to include `visualSteps`; tests mock/verify description generation and dispatched visuals.

- **Bug Fixes**
  - Removed a duplicate “started” stream event for the visual-descriptions step.

<sup>Written for commit 46b04ae91183c033a3053bc481f7259a6c4e9771. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

