### PR TITLE
fix(api): disable auto complete on auth setup

### DIFF
--- a/apps/api/src/app/auth/setup/setup-form.tsx
+++ b/apps/api/src/app/auth/setup/setup-form.tsx
@@ -78,7 +78,7 @@ export function SetupProfileForm({
       <SetupField>
         <SetupLabel htmlFor="name">{t("Name")}</SetupLabel>
         <SetupInput
-          autoComplete="name"
+          autoComplete="off"
           defaultValue={defaultName}
           id="name"
           name="name"
@@ -93,7 +93,7 @@ export function SetupProfileForm({
 
           <InputGroupInput
             autoCapitalize="none"
-            autoComplete="username"
+            autoComplete="off"
             autoCorrect="off"
             id="username"
             maxLength={USERNAME_MAX_LENGTH}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Turned off browser autocomplete on the auth setup screen. Applies to the Name and Username fields to avoid unwanted autofill and improve privacy.

<sup>Written for commit 5c19a81edd1712f5e399300c637fa43763bc6a99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

