### PR TITLE
feat(ai): gate gateway reporting tags

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -44,9 +44,10 @@ APPLE_PRIVATE_KEY=
 
 # AI Services
 AI_GATEWAY_API_KEY=
+# Opt in to paid Gateway request tags for admin cost reporting
+ENABLE_AI_GATEWAY_TAGS=
 GEMINI_API_KEY=
 OPENAI_API_KEY=
-
 
 # Sentry monitoring
 NEXT_PUBLIC_SENTRY_DSN=

--- a/apps/evals/.env.example
+++ b/apps/evals/.env.example
@@ -1,6 +1,9 @@
 # Running evals using Vercel AI Gateway
 AI_GATEWAY_API_KEY=
 
+# Opt in to paid Gateway request tags for admin cost reporting
+ENABLE_AI_GATEWAY_TAGS=
+
 # Image generation and other OpenAI services
 OPENAI_API_KEY=
 

--- a/apps/main/.env.example
+++ b/apps/main/.env.example
@@ -33,6 +33,8 @@ BLOB_READ_WRITE_TOKEN=
 AI_GATEWAY_API_KEY=
 OPENAI_API_KEY=
 
+# Opt in to paid Gateway request tags for admin cost reporting
+ENABLE_AI_GATEWAY_TAGS=
 
 # Sentry monitoring
 NEXT_PUBLIC_SENTRY_DSN=

--- a/packages/ai/src/provider-options.test.ts
+++ b/packages/ai/src/provider-options.test.ts
@@ -1,8 +1,32 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { buildImageProviderOptions, buildProviderOptions } from "./provider-options";
 
 describe(buildProviderOptions, () => {
-  test("adds provider order, default-model tags, and reasoning effort for fallback-enabled openai models", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("skips reporting tags by default even for fallback-enabled models", () => {
+    expect(
+      buildProviderOptions({
+        fallbackModels: ["google/gemini-3-flash", "anthropic/claude-haiku-4.5"],
+        model: "openai/gpt-5.4",
+        reasoningEffort: "high",
+        taskName: "activity-explanation",
+        useFallback: true,
+      }),
+    ).toEqual({
+      gateway: {
+        models: ["google/gemini-3-flash", "anthropic/claude-haiku-4.5"],
+        order: ["openai", "azure", "google", "anthropic", "vertex"],
+      },
+      openai: { reasoningEffort: "high" },
+    });
+  });
+
+  test("adds provider order, default-model tags, and reasoning effort when gateway tags are enabled", () => {
+    vi.stubEnv("ENABLE_AI_GATEWAY_TAGS", "true");
+
     expect(
       buildProviderOptions({
         fallbackModels: ["google/gemini-3-flash", "anthropic/claude-haiku-4.5"],
@@ -38,6 +62,8 @@ describe(buildProviderOptions, () => {
   });
 
   test("adds the anthropic provider order for anthropic models", () => {
+    vi.stubEnv("ENABLE_AI_GATEWAY_TAGS", "true");
+
     expect(
       buildProviderOptions({
         fallbackModels: ["openai/gpt-5.4-mini"],
@@ -55,6 +81,8 @@ describe(buildProviderOptions, () => {
   });
 
   test("leaves provider order unset for unsupported model prefixes", () => {
+    vi.stubEnv("ENABLE_AI_GATEWAY_TAGS", "true");
+
     expect(
       buildProviderOptions({
         fallbackModels: ["openai/gpt-5.4-mini"],
@@ -71,6 +99,8 @@ describe(buildProviderOptions, () => {
   });
 
   test("still adds reporting tags when fallback tracking is enabled without fallback models", () => {
+    vi.stubEnv("ENABLE_AI_GATEWAY_TAGS", "true");
+
     expect(
       buildProviderOptions({
         fallbackModels: [],
@@ -89,7 +119,29 @@ describe(buildProviderOptions, () => {
 });
 
 describe(buildImageProviderOptions, () => {
-  test("adds gateway reporting tags while preserving the openai image settings", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("skips gateway reporting tags by default while preserving the openai image settings", () => {
+    expect(
+      buildImageProviderOptions({
+        model: "openai/gpt-image-1.5",
+        quality: "low",
+        taskName: "course-thumbnail",
+      }),
+    ).toEqual({
+      gateway: {},
+      openai: {
+        output_format: "webp",
+        quality: "low",
+      },
+    });
+  });
+
+  test("adds gateway reporting tags for image tasks when enabled", () => {
+    vi.stubEnv("ENABLE_AI_GATEWAY_TAGS", "true");
+
     expect(
       buildImageProviderOptions({
         model: "openai/gpt-image-1.5",

--- a/packages/ai/src/provider-options.ts
+++ b/packages/ai/src/provider-options.ts
@@ -117,10 +117,12 @@ export function buildImageProviderOptions({
   quality: ImageGenerationQuality;
   taskName: string;
 }): ImageProviderOptionsResult {
+  const tags = isGatewayTaggingEnabled()
+    ? buildGatewayTags({ model: getImageReportingModel(model), taskName })
+    : undefined;
+
   return {
-    gateway: {
-      tags: buildGatewayTags({ model: getImageReportingModel(model), taskName }),
-    },
+    gateway: tags ? { tags } : {},
     openai: {
       output_format: "webp",
       quality,
@@ -129,12 +131,22 @@ export function buildImageProviderOptions({
 }
 
 /**
+ * Gateway request tags power our cost reporting, but tagged Gateway requests
+ * cost money. We keep this behind an explicit env opt-in so environments that
+ * do not need reporting can avoid the extra charge by default.
+ */
+function isGatewayTaggingEnabled(): boolean {
+  return process.env.ENABLE_AI_GATEWAY_TAGS === "true";
+}
+
+/**
  * We only want analytics for tasks that actually participate in fallback
- * routing. This keeps eval runs out of Gateway reports while still tracking the
- * normal task path, even for tasks whose fallback list is currently empty.
+ * routing, and only in environments that explicitly opted into paid Gateway
+ * tags. This keeps eval runs out of Gateway reports while still letting opted-
+ * in fallback flows report against the normal task path.
  */
 function shouldAddGatewayTags(useFallback: boolean): boolean {
-  return useFallback;
+  return useFallback && isGatewayTaggingEnabled();
 }
 
 /**


### PR DESCRIPTION
## Summary
- gate Vercel AI Gateway request tags behind `ENABLE_AI_GATEWAY_TAGS`
- keep Gateway tags disabled by default for both text and image requests
- update focused provider option tests and app env examples

## Why
Tagged Gateway requests cost money, so admin cost reporting should only be enabled in environments that explicitly opt in.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate Vercel AI Gateway reporting tags behind `ENABLE_AI_GATEWAY_TAGS`. Tags are off by default for both text (fallback flows) and image requests to avoid extra charges unless you opt in.

- **Migration**
  - Set `ENABLE_AI_GATEWAY_TAGS=true` in environments that need admin cost reporting.
  - Applies to text fallback tasks and image generation; when unset, no tags are sent.
  - See updated `.env.example` files in `apps/api`, `apps/main`, and `apps/evals`.

<sup>Written for commit c682b850e86ff7745994176741868c8934c35a47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

