### PR TITLE
fix(player): truncate activity title and use full header width

### DIFF
--- a/packages/player/src/components/in-play-sticky-header.tsx
+++ b/packages/player/src/components/in-play-sticky-header.tsx
@@ -26,12 +26,10 @@ export function InPlayStickyHeader({
       <PlayerHeader>
         <PlayerCloseLink href={lessonHref} />
 
-        <div className="pointer-events-none absolute inset-x-0 flex justify-center">
-          <div className="pointer-events-auto max-w-50 sm:max-w-75">
-            {centerContent ?? (
-              <span className="text-muted-foreground truncate text-sm">{displayTitle}</span>
-            )}
-          </div>
+        <div className="min-w-0 flex-1 text-center">
+          {centerContent ?? (
+            <p className="text-muted-foreground truncate text-sm">{displayTitle}</p>
+          )}
         </div>
 
         <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- Replace the absolute-positioned, width-capped title with a flex-1 wrapper so the activity title fills all space between the header icons and truncates cleanly when too long
- Drop the `max-w-50 sm:max-w-75` cap and the `pointer-events` workaround that were needed for the absolute layout
- Switch the title from `<span>` to `<p>` so `truncate` engages reliably as a flex child

## Test plan
- [ ] Verify short titles are centered between the close icon and info icons
- [ ] Verify long titles truncate with ellipsis instead of overflowing into the right-side icons
- [ ] Verify the evidence pill (`centerContent`) still renders correctly in investigation activities
- [ ] Check both mobile and desktop viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Truncates long activity titles in the player header and lets the title use the full space between icons. Replaces the absolute-centered layout with a flex-based wrapper to prevent overlap.

- **Bug Fixes**
  - Switched center area to `flex-1 min-w-0 text-center` so titles expand and ellipsize cleanly.
  - Removed `max-w-50 sm:max-w-75` and the `pointer-events` workaround.
  - Changed title element to `<p>` to ensure `truncate` works as a flex child.

<sup>Written for commit fd24b7d3f43be448f22dfd038b81ba656d2f8494. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

