### PR TITLE
fix(player): show next activity to guests

### DIFF
--- a/packages/player/src/_browser-tests/player-completion.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-completion.browser.test.tsx
@@ -130,7 +130,7 @@ describe("player browser integration: completion", () => {
   test("shows guest activity completion login prompt without rewards and falls back to /login", async () => {
     renderPlayer({
       activity: buildCompletionQuizActivity(),
-      navigation: buildNavigation({ loginHref: undefined }),
+      navigation: buildNavigation({ loginHref: undefined, nextActivityHref: "/lesson/a/2" }),
       viewer: { isAuthenticated: false, userName: null },
     });
 
@@ -138,11 +138,14 @@ describe("player browser integration: completion", () => {
 
     const completionScreen = page.getByRole("status");
     const loginLink = completionScreen.getByRole("link", { name: /login/i });
+    const nextLink = completionScreen.getByRole("link", { name: "Next" });
 
     await expect.element(completionScreen.getByText("1/1")).toBeInTheDocument();
     await expect
       .element(completionScreen.getByText(/sign up to track your progress/i))
       .toBeInTheDocument();
+    await expect.element(nextLink).toBeInTheDocument();
+    await expect.element(nextLink).toHaveAttribute("href", "/lesson/a/2");
     await expect.element(loginLink).toBeInTheDocument();
     await expect.element(loginLink).toHaveAttribute("href", "/login");
     await expect

--- a/packages/player/src/components/completion-auth-branch.tsx
+++ b/packages/player/src/components/completion-auth-branch.tsx
@@ -143,10 +143,12 @@ function AuthenticatedContent({
 function UnauthenticatedContent({
   lessonHref,
   loginHref,
+  nextActivityHref,
   onRestart,
 }: {
   lessonHref: PlayerRoute;
   loginHref: PlayerRoute;
+  nextActivityHref: PlayerRoute | null;
   onRestart: () => void;
 }) {
   const t = useExtracted();
@@ -161,9 +163,21 @@ function UnauthenticatedContent({
       <p className="text-muted-foreground text-sm">{t("Sign up to track your progress")}</p>
 
       <CompletionActions>
-        <PlayerLink className={cn(buttonVariants(), "w-full")} href={loginHref}>
+        <PlayerLink
+          className={cn(
+            buttonVariants({ variant: nextActivityHref ? "outline" : undefined }),
+            "w-full",
+          )}
+          href={loginHref}
+        >
           {t("Login")}
         </PlayerLink>
+
+        {nextActivityHref && (
+          <PrimaryActionLink href={nextActivityHref} shortcut="Enter">
+            {t("Next")}
+          </PrimaryActionLink>
+        )}
 
         <SecondaryActions lessonHref={lessonHref} onRestart={onRestart} variant="inline" />
       </CompletionActions>
@@ -192,6 +206,7 @@ export function AuthBranch({
       <UnauthenticatedContent
         lessonHref={lessonHref}
         loginHref={loginHref ?? "/login"}
+        nextActivityHref={nextActivityHref}
         onRestart={onRestart}
       />
     );


### PR DESCRIPTION
## Summary
- keep the next activity link visible on the player completion screen for unauthenticated users
- keep login as the first guest action while preserving the signed-in completion flow
- cover the guest completion path in the shared player browser test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the “Next” activity link on the player completion screen for guests while keeping Login as the first action. Restores guest navigation without changing the signed-in flow.

- **Bug Fixes**
  - Always render “Next” for guests when `nextActivityHref` is provided in `packages/player`.
  - Make Login primary and Next outlined; default `loginHref` to `/login` if missing.
  - Added a browser test for the guest completion path, asserting Next visibility and href.

<sup>Written for commit d7be1698aaa94834ced4576a4c985181bd75dfe8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

