### PR TITLE
fix(player): restore formula visual layout

### DIFF
--- a/packages/player/src/_browser-tests/player-visual.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-visual.browser.test.tsx
@@ -64,6 +64,36 @@ function getVerticalSpacing({
 }
 
 /**
+ * Long formulas are allowed to be wider than the visible stage, but the
+ * horizontal scrolling must stay inside the formula renderer. Walking upward
+ * from the math node lets this test verify that behavior without depending on
+ * one exact wrapper element.
+ */
+function findHorizontalScrollContainer({
+  mathElement,
+  stopAt,
+}: {
+  mathElement: HTMLElement;
+  stopAt: HTMLElement;
+}) {
+  let current: HTMLElement | null = mathElement;
+
+  while (current) {
+    if (globalThis.getComputedStyle(current).overflowX === "auto") {
+      return current;
+    }
+
+    if (current === stopAt) {
+      return null;
+    }
+
+    current = current.parentElement;
+  }
+
+  return null;
+}
+
+/**
  * Several layout tests only need a restore callback after conditionally sizing
  * the rendered player root. Using one shared no-op keeps those tests simple and
  * satisfies lint without recreating the same fallback function in each case.
@@ -101,6 +131,8 @@ function setRenderRootSize({ height, width }: { height?: string; width?: string 
     root.style.height = previous.height;
   };
 }
+
+const LONG_FORMULA = String.raw`\text{ocular lens} + \text{body tube} + \text{revolving nosepiece} + \text{low-power objective} + \text{high-power objective} + \text{stage clips} + \text{diaphragm} + \text{condenser} + \text{illuminator}`;
 
 describe("player browser integration: visual steps", () => {
   test("renders quote text and author", async () => {
@@ -604,5 +636,66 @@ describe("player browser integration: visual steps", () => {
     await expect.element(figure).toBeVisible();
     expect(figure.element().querySelector('[role="math"]')).not.toBeNull();
     await expect.element(page.getByText("Pythagorean theorem")).toBeVisible();
+  });
+
+  test("keeps long formula overflow on a nested formula container", async () => {
+    let restoreRenderRootSize = restoreNothing;
+
+    try {
+      renderVisualActivity({
+        steps: [
+          buildVisualStep({
+            content: {
+              description: "Microscope parts formula",
+              formula: LONG_FORMULA,
+              kind: "formula",
+            },
+          }),
+        ],
+      });
+
+      restoreRenderRootSize = setRenderRootSize({ width: "390px" });
+
+      const figure = page.getByRole("figure", {
+        name: "Microscope parts formula",
+      });
+      const visualContent = page.getByRole("region", {
+        name: /visual content/i,
+      });
+
+      await expect.element(figure).toBeVisible();
+
+      const figureElement = figure.element();
+
+      if (!(figureElement instanceof HTMLElement)) {
+        throw new Error("Expected the formula to render inside a figure");
+      }
+
+      const mathElement = figureElement.querySelector('[role="math"]');
+
+      if (!(mathElement instanceof HTMLElement)) {
+        throw new Error("Expected the formula to render a math region");
+      }
+
+      const scrollContainer = findHorizontalScrollContainer({
+        mathElement,
+        stopAt: figureElement,
+      });
+
+      if (!(scrollContainer instanceof HTMLElement)) {
+        throw new Error("Expected the formula to render inside a scroll container");
+      }
+
+      const scrollContainerBox = scrollContainer.getBoundingClientRect();
+      const visualContentBox = visualContent.element().getBoundingClientRect();
+
+      expect(scrollContainer.scrollWidth).toBeGreaterThan(scrollContainer.clientWidth);
+      expect(globalThis.getComputedStyle(scrollContainer).overflowX).toBe("auto");
+      expect(scrollContainerBox.left).toBeGreaterThanOrEqual(visualContentBox.left - 1);
+      expect(scrollContainerBox.right).toBeLessThanOrEqual(visualContentBox.right + 1);
+      expect(globalThis.getComputedStyle(visualContent.element()).overflowX).toBe("hidden");
+    } finally {
+      restoreRenderRootSize();
+    }
   });
 });

--- a/packages/player/src/components/visuals/formula-visual.tsx
+++ b/packages/player/src/components/visuals/formula-visual.tsx
@@ -11,8 +11,13 @@ import { useEffect, useRef } from "react";
  * KaTeX renders math into MathML + HTML, which provides native screen reader
  * support. The description stays visible as a caption for extra context.
  *
- * This renderer stays intentionally simple: formulas should behave like a
- * centered visual, not a nested scroll area or an auto-scaling widget.
+ * Long formulas are allowed to scroll horizontally inside the shared visual
+ * region. That keeps narrow screens usable without reintroducing measurement
+ * logic or scaling the text down until short formulas look undersized. The
+ * caption sits outside the centered flow so the formula itself stays aligned
+ * with the visual stage instead of being offset by the extra caption height.
+ * We also add a tiny desktop-only optical nudge because centered typography
+ * can still look slightly high next to the circular navigation arrows.
  */
 export function FormulaVisual({ content }: { content: FormulaVisualContent }) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -33,15 +38,19 @@ export function FormulaVisual({ content }: { content: FormulaVisualContent }) {
   return (
     <figure
       aria-label={content.description}
-      className="flex w-full max-w-xl flex-col items-center gap-4 px-4 sm:gap-5 sm:px-5"
+      className="relative flex w-full max-w-full min-w-0 flex-col items-center"
     >
-      <div
-        className="text-foreground w-full min-w-0 text-lg sm:text-xl"
-        ref={containerRef}
-        role="math"
-      />
+      <div className="w-full min-w-0 overflow-x-auto overscroll-x-contain">
+        <div className="flex w-max min-w-full justify-center px-4 sm:px-5">
+          <div
+            className="text-foreground shrink-0 text-lg sm:text-xl lg:translate-y-0.5"
+            ref={containerRef}
+            role="math"
+          />
+        </div>
+      </div>
 
-      <figcaption className="text-muted-foreground text-center text-sm">
+      <figcaption className="text-muted-foreground absolute top-full left-1/2 mt-3 w-full max-w-md -translate-x-1/2 px-4 text-center text-sm sm:px-5">
         {content.description}
       </figcaption>
     </figure>


### PR DESCRIPTION
## What changed

- restore nested horizontal overflow for long formulas so they stay visible on narrow screens
- keep the caption out of the centered flow and add a tiny optical nudge so the formula aligns better with the desktop nav arrows
- keep the browser regression focused on the real overflow behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the formula visual layout so long equations scroll within their own container and stay centered. Fixes overflow on narrow screens in the `player`.

- **Bug Fixes**
  - Restored nested horizontal overflow for long formulas: scroll stays inside the formula container, visual region remains clipped, and the caption is positioned outside the centered flow with a small desktop-only nudge for better alignment.
  - Added a browser test to verify overflow stays within the formula container (and not the visual region) to prevent regressions.

<sup>Written for commit 8d33e27881940930e17badb2465b268691105c94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

