### PR TITLE
fix(player): stick bottom nav arrows to screen edges on tablet

### DIFF
--- a/packages/player/src/components/player-bottom-bar.tsx
+++ b/packages/player/src/components/player-bottom-bar.tsx
@@ -4,14 +4,15 @@ import { Button } from "@zoonk/ui/components/button";
 import { cn } from "@zoonk/ui/lib/utils";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useExtracted } from "next-intl";
-import { PlayerContentFrame } from "./step-layouts";
 
 /**
- * Fixed bottom bar for the player's action buttons on mobile.
+ * Fixed bottom bar for the player's action buttons on mobile and tablet.
  *
- * The inner content uses the same shared player frame as the stage content.
- * That keeps mobile actions aligned with the centered step container instead
- * of relying on duplicated width classes.
+ * Only provides the sticky container and safe-area padding. Inner width is
+ * controlled by each mode's content: the action button uses the shared player
+ * frame so it aligns with the centered step container, while the navigation
+ * arrows span the full viewport width so they sit at the screen edges on
+ * tablet — otherwise the frame would cap them at `max-w-2xl` and center them.
  */
 export function PlayerBottomBar({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -21,9 +22,9 @@ export function PlayerBottomBar({ className, ...props }: React.ComponentProps<"d
         "w-full py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]",
         className,
       )}
-    >
-      <PlayerContentFrame data-slot="player-bottom-bar" {...props} />
-    </div>
+      data-slot="player-bottom-bar"
+      {...props}
+    />
   );
 }
 
@@ -39,7 +40,10 @@ export function PlayerBottomBarNav({
   const t = useExtracted();
 
   return (
-    <nav aria-label={t("Step navigation")} className="flex items-center justify-between">
+    <nav
+      aria-label={t("Step navigation")}
+      className="flex w-full items-center justify-between px-4"
+    >
       <Button
         aria-label={t("Previous step")}
         disabled={!canNavigatePrev}

--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -20,12 +20,17 @@ import { StageContent } from "./stage-content";
 import { StatusPill } from "./status-pill";
 import { StepActionButton } from "./step-action-button";
 import { StepImagePreloader } from "./step-image-preloader";
+import { PlayerContentFrame } from "./step-layouts";
 import { StoryMetricsBar } from "./story-metrics-bar";
 
 /**
  * Mobile bottom-bar content switches between arrow navigation and the shared
  * step action button. The screen model decides which mode is active; this
  * component only renders the matching mobile control.
+ *
+ * Navigation arrows span the full viewport so they stick to the screen edges
+ * on tablet. The action button uses the shared player frame so it stays
+ * aligned with the centered step container and doesn't stretch past it.
  */
 function BottomBarContent() {
   const { actions, screen } = usePlayerRuntime();
@@ -40,7 +45,11 @@ function BottomBarContent() {
     );
   }
 
-  return <StepActionButton />;
+  return (
+    <PlayerContentFrame>
+      <StepActionButton />
+    </PlayerContentFrame>
+  );
 }
 
 export function PlayerShell() {


### PR DESCRIPTION
## Summary

On tablet, the static-step navigation arrows in the mobile bottom bar were centered instead of sitting on the viewport edges. `PlayerBottomBar` wrapped its children in `PlayerContentFrame` (`max-w-2xl`), so on viewports wider than that frame the arrows got pulled into the centered container. On mobile the viewport was narrower than the frame, so the bug didn't show up there.

- `PlayerBottomBar` now only provides the sticky container and safe-area padding.
- `PlayerBottomBarNav` spans the full width with `px-4`, placing arrows on the screen edges.
- `StepActionButton` is wrapped in `PlayerContentFrame` inside `player-shell.tsx` so the Continue/Check button stays centered at `max-w-2xl` on tablet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tablet layout so the bottom navigation arrows stick to the screen edges instead of being centered. Keeps the primary action button centered within the content frame.

- **Bug Fixes**
  - `PlayerBottomBar` now only renders the sticky container with safe-area padding.
  - `PlayerBottomBarNav` spans full width with `px-4` so arrows sit on the viewport edges.
  - `StepActionButton` is wrapped in `PlayerContentFrame` in `player-shell.tsx` to stay centered (`max-w-2xl`).

<sup>Written for commit a341dfe78783d5e8e1be72849c9bede5d1e75421. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

