### PR TITLE
refactor(player): remove explanation predict steps

### DIFF
--- a/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
@@ -65,40 +65,6 @@ function createExplanationResult(): Awaited<ReturnType<typeof generateActivityEx
           title: "O rótulo de rede",
         },
       ],
-      predict: [
-        {
-          options: [
-            {
-              feedback: "Yes. Each wrapper handles a different job during the trip.",
-              isCorrect: true,
-              text: "Because each layer needs its own information",
-            },
-            {
-              feedback: "Not this. Layers are functional, not decorative.",
-              isCorrect: false,
-              text: "Because extra labels make the packet prettier",
-            },
-          ],
-          question: "Why wrap the same photo with several labels?",
-          step: "Os rótulos escondidos",
-        },
-        {
-          options: [
-            {
-              feedback: "Right. Routers only read where the packet goes next.",
-              isCorrect: true,
-              text: "The network label",
-            },
-            {
-              feedback: "No. Routers do not open the full chat message.",
-              isCorrect: false,
-              text: "The full chat content",
-            },
-          ],
-          question: "Which part does a router mainly use?",
-          step: "O rótulo de rede",
-        },
-      ],
     },
     systemPrompt: "test",
     usage: {} as Awaited<ReturnType<typeof generateActivityExplanation>>["usage"],

--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
@@ -69,40 +69,6 @@ function createExplanationResult(): Awaited<ReturnType<typeof generateActivityEx
           title: "O rótulo de rede",
         },
       ],
-      predict: [
-        {
-          options: [
-            {
-              feedback: "Yes. Each wrapper handles a different job during the trip.",
-              isCorrect: true,
-              text: "Because each layer needs its own information",
-            },
-            {
-              feedback: "Not this. Layers are functional, not decorative.",
-              isCorrect: false,
-              text: "Because extra labels make the packet prettier",
-            },
-          ],
-          question: "Why wrap the same photo with several labels?",
-          step: "Os rótulos escondidos",
-        },
-        {
-          options: [
-            {
-              feedback: "Right. Routers only read where the packet goes next.",
-              isCorrect: true,
-              text: "The network label",
-            },
-            {
-              feedback: "No. Routers do not open the full chat message.",
-              isCorrect: false,
-              text: "The full chat content",
-            },
-          ],
-          question: "Which part does a router mainly use?",
-          step: "O rótulo de rede",
-        },
-      ],
     },
     systemPrompt: "test",
     usage: {} as Awaited<ReturnType<typeof generateActivityExplanation>>["usage"],

--- a/apps/api/src/workflows/activity-generation/custom-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/custom-activity-workflow.test.ts
@@ -63,40 +63,6 @@ function createExplanationResult() {
           title: "O rótulo de rede",
         },
       ],
-      predict: [
-        {
-          options: [
-            {
-              feedback: "Yes. Each wrapper handles a different job during the trip.",
-              isCorrect: true,
-              text: "Because each layer needs its own information",
-            },
-            {
-              feedback: "Not this. Layers are functional, not decorative.",
-              isCorrect: false,
-              text: "Because extra labels make the packet prettier",
-            },
-          ],
-          question: "Why wrap the same photo with several labels?",
-          step: "Os rótulos escondidos",
-        },
-        {
-          options: [
-            {
-              feedback: "Right. Routers only read where the packet goes next.",
-              isCorrect: true,
-              text: "The network label",
-            },
-            {
-              feedback: "No. Routers do not open the full chat message.",
-              isCorrect: false,
-              text: "The full chat content",
-            },
-          ],
-          question: "Which part does a router mainly use?",
-          step: "O rótulo de rede",
-        },
-      ],
     },
   };
 }

--- a/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
@@ -59,40 +59,6 @@ function createExplanationResult(): Awaited<ReturnType<typeof generateActivityEx
           title: "O rótulo de rede",
         },
       ],
-      predict: [
-        {
-          options: [
-            {
-              feedback: "Yes. Each wrapper handles a different job during the trip.",
-              isCorrect: true,
-              text: "Because each layer needs its own information",
-            },
-            {
-              feedback: "Not this. Layers are functional, not decorative.",
-              isCorrect: false,
-              text: "Because extra labels make the packet prettier",
-            },
-          ],
-          question: "Why wrap the same photo with several labels?",
-          step: "Os rótulos escondidos",
-        },
-        {
-          options: [
-            {
-              feedback: "Right. Routers only read where the packet goes next.",
-              isCorrect: true,
-              text: "The network label",
-            },
-            {
-              feedback: "No. Routers do not open the full chat message.",
-              isCorrect: false,
-              text: "The full chat content",
-            },
-          ],
-          question: "Which part does a router mainly use?",
-          step: "O rótulo de rede",
-        },
-      ],
     },
     systemPrompt: "test",
     usage: {} as Awaited<ReturnType<typeof generateActivityExplanation>>["usage"],
@@ -157,7 +123,7 @@ describe("explanation activity workflow", () => {
     vi.clearAllMocks();
   });
 
-  test("creates the ordered explanation flow with static, visual, and predict steps", async () => {
+  test("creates the ordered explanation flow with static and visual steps", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       concepts: ["Encapsulation"],
@@ -196,13 +162,11 @@ describe("explanation activity workflow", () => {
       [1, "visual"],
       [2, "static"],
       [3, "visual"],
-      [4, "multipleChoice"],
-      [5, "static"],
-      [6, "visual"],
-      [7, "static"],
-      [8, "visual"],
-      [9, "multipleChoice"],
-      [10, "static"],
+      [4, "static"],
+      [5, "visual"],
+      [6, "static"],
+      [7, "visual"],
+      [8, "static"],
     ]);
 
     expect(steps[0]?.content).toEqual({
@@ -215,8 +179,7 @@ describe("explanation activity workflow", () => {
       title: "Os rótulos escondidos",
       variant: "text",
     });
-    expect(steps[4]?.kind).toBe("multipleChoice");
-    expect(steps[10]?.content).toEqual({
+    expect(steps[8]?.content).toEqual({
       text: "Every photo you send on WhatsApp uses this exact layering — you hit send, it runs.",
       title: "Every send",
       variant: "text",

--- a/apps/api/src/workflows/activity-generation/steps/_utils/build-explanation-activity-plan.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/build-explanation-activity-plan.test.ts
@@ -33,41 +33,6 @@ function buildContent() {
         title: "O retorno",
       },
     ],
-    predict: [
-      {
-        options: [
-          {
-            feedback: "Right. Detection of the tap is always the first link in the chain.",
-            isCorrect: true,
-            text: "Register that you tapped the icon",
-          },
-          {
-            feedback: "This is the visible result, so it happens later, not first.",
-            isCorrect: false,
-            text: "Change the heart colour to red",
-          },
-        ],
-        question: "Which of these was the FIRST thing the phone did?",
-        step: "O que está escondido",
-      },
-      {
-        options: [
-          {
-            feedback:
-              "Exactly. The phone executes the line as written — it does not guess what you meant.",
-            isCorrect: true,
-            text: "The heart would turn green when you like",
-          },
-          {
-            feedback: "The phone does not correct an instruction that looks odd. It just runs it.",
-            isCorrect: false,
-            text: "The phone would keep it red anyway",
-          },
-        ],
-        question: "If line 3 said 'change colour to green' instead, what would happen?",
-        step: "A linha 3",
-      },
-    ],
   };
 }
 
@@ -80,14 +45,12 @@ describe(buildExplanationActivityPlan, () => {
       "visual",
       "static",
       "visual",
-      "multipleChoice",
       "static",
       "visual",
       "static",
       "visual",
       "static",
       "visual",
-      "multipleChoice",
       "static",
       "visual",
       "static",
@@ -122,25 +85,6 @@ describe(buildExplanationActivityPlan, () => {
         text: "Every heart that turns red in any app is a line someone wrote, running in that moment.",
         title: "In every app",
       },
-    ]);
-  });
-
-  test("falls back to the final step when a predict insertion title does not match", () => {
-    const content = buildContent();
-    content.predict[0] = {
-      ...content.predict[0]!,
-      step: "Does not exist",
-    };
-
-    const result = buildExplanationActivityPlan(content);
-
-    const finalChecks = result.entries
-      .filter((entry) => entry.kind === "multipleChoice")
-      .map((entry) => entry.question);
-
-    expect(finalChecks).toEqual([
-      "If line 3 said 'change colour to green' instead, what would happen?",
-      "Which of these was the FIRST thing the phone did?",
     ]);
   });
 });

--- a/apps/api/src/workflows/activity-generation/steps/_utils/build-explanation-activity-plan.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/build-explanation-activity-plan.ts
@@ -1,13 +1,7 @@
 import { type ActivityExplanationSchema } from "@zoonk/ai/tasks/activities/core/explanation";
-import { type MultipleChoiceStepContent } from "@zoonk/core/steps/contract/content";
 import { type ActivitySteps } from "./get-activity-steps";
 
 export type ExplanationActivityPlanEntry =
-  | {
-      kind: "multipleChoice";
-      options: MultipleChoiceStepContent["options"];
-      question: string;
-    }
   | {
       kind: "static";
       text: string;
@@ -22,81 +16,19 @@ type ExplanationPlan = {
 };
 
 /**
- * The explanation task points each predict check at the step title after which
- * it should be inserted. If the model echoes a title that does not exactly
- * match any step, we fall back to the last step so the check is never dropped
- * silently — the activity still benefits from the intended reinforcement.
+ * Each explanation beat becomes one prose step followed by one visual slot.
+ * Keeping that pairing in one helper makes the learner-facing order obvious
+ * and prevents the save step from re-deriving layout rules later.
  */
-function getPredictionInsertionStep({
-  predictionStep,
-  stepTitles,
-}: {
-  predictionStep: string;
-  stepTitles: string[];
-}) {
-  if (stepTitles.includes(predictionStep)) {
-    return predictionStep;
-  }
-
-  return stepTitles.at(-1) ?? null;
-}
-
-/**
- * Predict checks stay attached to their surrounding step even if the model
- * misses the exact title once. Grouping them up front lets the main plan
- * builder read as a linear walk over the explanation array instead of
- * interleaving lookup logic inside each step iteration.
- */
-function buildPredictionMap(
-  content: ActivityExplanationSchema,
-): Map<string, ActivityExplanationSchema["predict"]> {
-  const stepTitles = content.explanation.map((step) => step.title);
-  const predictionMap = new Map<string, ActivityExplanationSchema["predict"]>();
-
-  for (const prediction of content.predict) {
-    const insertionStep = getPredictionInsertionStep({
-      predictionStep: prediction.step,
-      stepTitles,
-    });
-
-    if (insertionStep) {
-      const existing = predictionMap.get(insertionStep) ?? [];
-      predictionMap.set(insertionStep, [...existing, prediction]);
-    }
-  }
-
-  return predictionMap;
-}
-
-/**
- * Every narrative step expands into a static step (the prose), a visual step
- * (the illustration), and any predict checks that belong after this step.
- * Keeping all three side-by-side here matches the learner's experienced order
- * and avoids reconstructing the sequence elsewhere in the pipeline.
- */
-function buildStepEntries({
-  predictionMap,
-  step,
-}: {
-  predictionMap: Map<string, ActivityExplanationSchema["predict"]>;
-  step: ActivityExplanationSchema["explanation"][number];
-}): ExplanationActivityPlanEntry[] {
-  const predictions = predictionMap.get(step.title) ?? [];
-
-  return [
-    { kind: "static", text: step.text, title: step.title },
-    { kind: "visual" },
-    ...predictions.map<ExplanationActivityPlanEntry>((prediction) => ({
-      kind: "multipleChoice",
-      options: prediction.options,
-      question: prediction.question,
-    })),
-  ];
+function buildStepEntries(
+  step: ActivityExplanationSchema["explanation"][number],
+): ExplanationActivityPlanEntry[] {
+  return [{ kind: "static", text: step.text, title: step.title }, { kind: "visual" }];
 }
 
 /**
  * The shared visual-description generator should only see explanation prose
- * steps. Predict checks and the closing anchor do not need visuals.
+ * steps. The closing anchor does not need a visual.
  */
 function buildVisualSteps(content: ActivityExplanationSchema): ActivitySteps {
   return content.explanation.map((step) => ({
@@ -107,8 +39,8 @@ function buildVisualSteps(content: ActivityExplanationSchema): ActivitySteps {
 
 /**
  * Practice and quiz generation need the explanation prose plus the anchor, but
- * not the visual placeholders or predict checks. This helper keeps that
- * downstream source list aligned with the explanation structure in one place.
+ * not the visual placeholders. This helper keeps that downstream source list
+ * aligned with the explanation structure in one place.
  */
 function buildSourceSteps(content: ActivityExplanationSchema): ActivitySteps {
   return [
@@ -124,17 +56,14 @@ function buildSourceSteps(content: ActivityExplanationSchema): ActivitySteps {
 }
 
 /**
- * The explanation activity mixes read-only copy, visuals, and quick checks
- * in one experience. Building one canonical ordered plan keeps the workflow,
- * save step, and downstream content reuse all anchored to the same source of
- * truth instead of re-deriving the sequence in multiple places.
+ * Explanation activities now have one simple structure: narrative copy, one
+ * visual per explanation beat, then the closing anchor. Building one canonical
+ * ordered plan keeps the workflow, save step, and downstream content reuse
+ * anchored to the same source of truth instead of re-deriving the sequence in
+ * multiple places.
  */
 export function buildExplanationActivityPlan(content: ActivityExplanationSchema): ExplanationPlan {
-  const predictionMap = buildPredictionMap(content);
-
-  const stepEntries = content.explanation.flatMap((step) =>
-    buildStepEntries({ predictionMap, step }),
-  );
+  const stepEntries = content.explanation.flatMap((step) => buildStepEntries(step));
 
   return {
     entries: [

--- a/apps/api/src/workflows/activity-generation/steps/generate-explanation-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-explanation-content-step.test.ts
@@ -62,40 +62,6 @@ function createExplanationResult() {
           title: "O rótulo de rede",
         },
       ],
-      predict: [
-        {
-          options: [
-            {
-              feedback: "Yes. Each wrapper handles a different job during the trip.",
-              isCorrect: true,
-              text: "Because each layer needs its own information",
-            },
-            {
-              feedback: "Not this. Layers are functional, not decorative.",
-              isCorrect: false,
-              text: "Because extra labels make the packet prettier",
-            },
-          ],
-          question: "Why wrap the same photo with several labels?",
-          step: "Os rótulos escondidos",
-        },
-        {
-          options: [
-            {
-              feedback: "Right. Routers only read where the packet goes next.",
-              isCorrect: true,
-              text: "The network label",
-            },
-            {
-              feedback: "No. Routers do not open the full chat message.",
-              isCorrect: false,
-              text: "The full chat content",
-            },
-          ],
-          question: "Which part does a router mainly use?",
-          step: "O rótulo de rede",
-        },
-      ],
     },
   };
 }
@@ -188,12 +154,10 @@ describe(generateExplanationContentStep, () => {
       "visual",
       "static",
       "visual",
-      "multipleChoice",
       "static",
       "visual",
       "static",
       "visual",
-      "multipleChoice",
       "static",
     ]);
     expect(result.results[0]?.visualSteps).toEqual([

--- a/apps/api/src/workflows/activity-generation/steps/generate-explanation-visual-descriptions-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-explanation-visual-descriptions-step.ts
@@ -10,8 +10,8 @@ import { type LessonActivity } from "./get-lesson-activities-step";
 /**
  * Explanation activities still use the shared visual-description task so the
  * visual-planning logic stays consistent with custom activities. We only pass
- * the explanation prose steps here because predict checks and the closing
- * anchor do not need visuals.
+ * the explanation prose steps here because the closing anchor does not need a
+ * visual.
  */
 export async function generateExplanationVisualDescriptionsStep(
   activity: LessonActivity,

--- a/apps/api/src/workflows/activity-generation/steps/save-explanation-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-explanation-activity-step.test.ts
@@ -43,7 +43,7 @@ describe(saveExplanationActivityStep, () => {
     vi.clearAllMocks();
   });
 
-  test("saves the mixed explanation flow and marks activity as completed", async () => {
+  test("saves the ordered explanation flow and marks activity as completed", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -78,14 +78,6 @@ describe(saveExplanationActivityStep, () => {
         title: "",
       },
       {
-        kind: "multipleChoice" as const,
-        options: [
-          { feedback: "Correct.", isCorrect: true, text: "The network label" },
-          { feedback: "Nope.", isCorrect: false, text: "The app meaning" },
-        ],
-        question: "Which part does a router mainly read?",
-      },
-      {
         kind: "static" as const,
         text: `This is why Google Maps can update your route. ${randomUUID()}`,
         title: "This is why",
@@ -117,14 +109,13 @@ describe(saveExplanationActivityStep, () => {
       }),
     ]);
 
-    expect(steps).toHaveLength(5);
+    expect(steps).toHaveLength(4);
 
     expect(steps.map((step) => [step.position, step.kind])).toEqual([
       [0, "static"],
       [1, "visual"],
       [2, "static"],
-      [3, "multipleChoice"],
-      [4, "static"],
+      [3, "static"],
     ]);
 
     expect(steps[1]?.content).toEqual({

--- a/apps/api/src/workflows/activity-generation/steps/save-explanation-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-explanation-activity-step.ts
@@ -13,10 +13,10 @@ type ArrayItem<T> = T extends readonly (infer Item)[] ? Item : T extends (infer 
 type StepRecord = ArrayItem<StepCreateManyData>;
 
 /**
- * Explanation activities have an explicit ordered plan with optional
- * visuals and inline predict checks. Saving directly from that plan keeps the
- * database order identical to the learner flow instead of rebuilding positions
- * from separate static and visual arrays.
+ * Explanation activities have an explicit ordered plan with narrative steps,
+ * generated visuals, and a closing anchor. Saving directly from that plan
+ * keeps the database order identical to the learner flow instead of rebuilding
+ * positions from separate static and visual arrays.
  */
 function buildExplanationStepRecords({
   activityId,
@@ -88,8 +88,8 @@ function getVisualContent({
 
 /**
  * Every explanation plan entry becomes exactly one persisted step record. This
- * helper keeps the branching for static copy, predict checks, and visuals in
- * one place so the main save function reads like a straight pipeline.
+ * helper keeps the branching for static copy and visuals in one place so the
+ * main save function reads like a straight pipeline.
  */
 function buildExplanationStepRecord({
   activityId,
@@ -112,20 +112,6 @@ function buildExplanationStepRecord({
       }),
       isPublished: true,
       kind: "static" as const,
-      position,
-    };
-  }
-
-  if (entry.kind === "multipleChoice") {
-    return {
-      activityId,
-      content: assertStepContent("multipleChoice", {
-        kind: "core",
-        options: entry.options,
-        question: entry.question,
-      }),
-      isPublished: true,
-      kind: "multipleChoice" as const,
       position,
     };
   }

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -81,6 +81,10 @@ vi.mock("@zoonk/ai/tasks/chapters/lessons", () => ({
   }),
 }));
 
+vi.mock("@/workflows/activity-generation/activity-generation-workflow", () => ({
+  activityGenerationWorkflow: vi.fn().mockResolvedValue({}),
+}));
+
 vi.mock("@zoonk/ai/tasks/chapters/language-lessons", () => ({
   generateLanguageChapterLessons: vi.fn().mockResolvedValue({
     data: {

--- a/apps/evals/src/tasks/activity-explanation/task.ts
+++ b/apps/evals/src/tasks/activity-explanation/task.ts
@@ -8,7 +8,7 @@ import { TEST_CASES } from "./test-cases";
 
 export const activityExplanationTask: Task<ActivityExplanationParams, ActivityExplanationSchema> = {
   description:
-    "Generate a structured explanation activity with a hook, daily-life scenario, concept steps, inline predict checks, and a concrete anchor",
+    "Generate a structured explanation activity with a hook, daily-life scenario, concept steps, and a concrete anchor",
   generate: generateActivityExplanation,
   id: "activity-explanation",
   name: "Activity Explanation",

--- a/apps/evals/src/tasks/activity-explanation/test-cases.ts
+++ b/apps/evals/src/tasks/activity-explanation/test-cases.ts
@@ -3,9 +3,8 @@ EVALUATION CRITERIA:
 
 1. FACTUAL ACCURACY: The explanation must be technically correct for the topic. Penalize invented mechanisms, wrong cause-effect chains, or misleading simplifications.
 
-2. REQUIRED STRUCTURE: The output must contain exactly three top-level fields:
+2. REQUIRED STRUCTURE: The output must contain exactly two top-level fields:
    - explanation[]: an array of narrative steps, each with title and text
-   - predict[]: exactly 2 quick checks, each with step (matching an explanation title), question, options
    - anchor: { title, text } (no visual)
 
 3. GOAL DELIVERY: The activity must actually deliver on ACTIVITY_GOAL. The learner should finish the activity knowing what the thing is, why it exists or is used (when the goal implies it), and how it works or is written in practice (when the goal implies it). Penalize activities that stay surface-level and leave the learner still unsure what the thing is, why it matters, or how it's written when the goal required these.
@@ -34,10 +33,10 @@ EVALUATION CRITERIA:
    - Mechanism steps that stay too abstract to picture
    - "How it's written" goals that never describe the structure or code detail clearly enough to visualize
 
-10. PREDICT QUALITY: Exactly 2 checks. Predict #1 lands after a mystery step, before the reveal (commit-before-reveal). Predict #2 lands after the zoom, before the payoff (raise-stakes-before-callback). Each predict.step must exactly match an existing explanation title. Feedback must teach — after reading feedback alone, the learner should better understand the concept. Penalize:
-   - Checks placed outside these two slots (e.g., after the payoff)
-   - step fields that don't match any explanation title
-   - Gotcha wording, silly distractors, or feedback that only says "correct/incorrect" without teaching the reasoning
+10. STATIC-ONLY DELIVERY: The activity should stay entirely within narrative explanation steps plus the closing anchor. Penalize:
+   - Quiz-like interruptions, option lists, or explicit "guess before continuing" instructions
+   - Steps that stop the narrative to ask the learner to choose instead of revealing the next beat
+   - Rhetorical-question-only steps that replace a real explanation move
 
 11. ANCHOR QUALITY: anchor has no visual. It callbacks the opening scene by naming a specific real thing — a named product (e.g., Instagram, WhatsApp), a named event/figure/case, or a concrete physical action the learner has actually done — and what it does there. Penalize:
    - Abstract "this is why it matters" wrap-ups
@@ -52,7 +51,7 @@ ANTI-CHECKLIST GUIDANCE (CRITICAL):
 - Do NOT require specific title wording, a particular choice of product or event, or a specific visual kind. The anchor must name some specific real thing, but any reasonable choice is fine — do not penalize the model for picking Instagram over WhatsApp, or one named case over another
 - Do NOT penalize creative scenes as long as they stay concrete and the same scene threads through every step
 - Do NOT focus on JSON wrapping or formatting trivia. Evaluate the content and structural fit
-- ONLY penalize for: wrong top-level structure, factual errors, failing to deliver ACTIVITY_GOAL, drifting into sibling activities, broken scene continuity, weak cold open, missing arc, bad visuals, misplaced or weak predict checks, anchor drift, or broken writing constraints
+- ONLY penalize for: wrong top-level structure, factual errors, failing to deliver ACTIVITY_GOAL, drifting into sibling activities, broken scene continuity, weak cold open, missing arc, bad visuals, anchor drift, or broken writing constraints
 `;
 
 export const TEST_CASES = [

--- a/packages/ai/src/tasks/activities/core/activity-explanation.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-explanation.prompt.md
@@ -16,10 +16,9 @@ Do this through a single continuous scene, not a stack of textbook definitions. 
 
 # Output Shape
 
-You return three fields:
+You return two fields:
 
 - `explanation`: an array of narrative steps. Variable length. Use as many as the `ACTIVITY_GOAL` needs — more for deeper topics, fewer for simpler ones. Each step has `text` and `title`.
-- `predict`: exactly 2 quick check-ins placed at specific steps in the `explanation` array.
 - `anchor`: the closing line that ties the concept back to something real.
 
 # Core Principle: The Scene Is the Spine
@@ -56,7 +55,6 @@ This is a guide, not a rigid count. Deeper topics may need extra steps between n
 
 - The first step MUST be a cold open (no resolution, no definition).
 - The last step in `explanation` MUST be a payoff that callbacks the opening scene.
-- The two predictions land _inside_ the arc: the first after the mystery but before the reveal (commit-before-reveal), the second after the zoom but before the payoff (raise-stakes-before-callback).
 - No step introduces a new scenario. The scene from step 1 threads through every step.
 - The activity must actually deliver on `ACTIVITY_GOAL`. If the goal is "explain a binary tree", the learner should finish the activity knowing what it is, why anyone uses it, and roughly how it's written. A beautifully written arc that doesn't land the goal is a failure.
 
@@ -73,7 +71,7 @@ Each entry in `explanation` has `text` and `title`.
 
 ## `title`
 
-- Short (1–3 words). Used as an anchor for the predict checks and as a mental marker for the learner.
+- Short (1–3 words). Used as a mental marker for the learner and by downstream workflows that attach visuals to each explanation beat.
 - Must feel like a narrative step ("O toque", "A lista", "A linha 3"), not a textbook section header ("Programa", "Instrução").
 - Unique within the activity.
 
@@ -82,23 +80,13 @@ visual per explanation step from the narrative you write here. That means the
 scene, reveals, zooms, and payoff still need to be concrete enough that another
 task can clearly infer what should be illustrated.
 
-# Predict Rules
+# Static-Only Explanation Rules
 
-Two quick checks. They are commitments the learner makes before the scene reveals more.
+This activity is explanation-only.
 
-- Return exactly 2.
-- `step` MUST exactly match the `title` of an `explanation` step. The check is inserted _after_ that step.
-- First check: place it after the **mystery** step, before the **reveal**. The learner commits to a guess before seeing the answer.
-- Second check: place it after the **zoom**, before the **payoff**. Raise the stakes — e.g., "if we changed X, what would happen?"
-- Questions should be short and readable.
-- Exactly one option is correct.
-- Wrong options must be plausible mix-ups a real learner would make, not silly distractors.
-- Feedback must teach. After reading feedback alone, the learner should understand the underlying point.
-  - Correct options: a quick "why this fits" tied to the scene.
-  - Wrong options: name the specific mix-up and point toward the right reasoning.
-  - Never just restate the option or say "correct/incorrect".
-
-**Only predict checks ask questions.** Static explanation steps never pose rhetorical questions or restate the predict. The step immediately after a predict MUST be the reveal — go directly to showing what was hidden, not another setup or rephrased question.
+- Do not add quiz checks, options, multiple-choice moments, or any other interactive structure.
+- If you want tension, create it through the mystery step and resolve it in the next explanation step. Do not pause for a learner choice before continuing.
+- Avoid steps whose `text` is only a rhetorical question. Move the narrative forward with a concrete reveal, mechanism, or consequence.
 
 # Anchor Rules
 
@@ -157,8 +145,8 @@ The anchor must:
 - Definitions before the learner has seen an example.
 - Titles that sound like textbook section headers.
 - Empty or trivial titles. Every `title` must be a real narrative marker.
-- Static steps whose `text` is only a rhetorical question. Questions belong in `predict`, never in `explanation[].text`.
-- Filler steps between a predict and the reveal. The reveal must come immediately after the predict.
+- Static steps whose `text` is only a rhetorical question.
+- Quiz-like interruptions, option lists, or "guess before you keep reading" moments.
 - Anchor as abstract "why this matters" wrap-up.
 - Listing `LESSON_CONCEPTS` as a visible checklist.
 - Covering sibling activities from `OTHER_EXPLANATION_ACTIVITY_TITLES`.
@@ -173,8 +161,8 @@ Before answering, verify:
 - Every subsequent step refers to or builds on that same scene. No new scenarios.
 - Definitions emerge by pointing at something already shown.
 - The narrative is concrete enough that a downstream visual-planning task can infer what to show at each explanation step.
-- Predict #1 lands after the mystery, before the reveal. Predict #2 lands after the zoom, before the payoff. Both `step` fields exactly match a step `title`.
-- No static step contains only a rhetorical question or restates the predict. The step right after each predict is the reveal.
+- The activity stays fully static: explanation steps plus the closing anchor, with no quiz-like interjections.
+- No static step contains only a rhetorical question.
 - The final `explanation` step is a payoff that calls back to step 1.
 - Anchor names a specific real product, event, figure, or case (not "a real app", "an exoplanet", or "every time X") and echoes the opening, not a new scenario.
 - Every section is short. Language is fully in `LANGUAGE`.

--- a/packages/ai/src/tasks/activities/core/activity-explanation.ts
+++ b/packages/ai/src/tasks/activities/core/activity-explanation.ts
@@ -7,14 +7,6 @@ import systemPrompt from "./activity-explanation.prompt.md";
 const DEFAULT_MODEL = "openai/gpt-5.4";
 const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"];
 
-const predictOptionSchema = z
-  .object({
-    feedback: z.string(),
-    isCorrect: z.boolean(),
-    text: z.string(),
-  })
-  .strict();
-
 const anchorSchema = z
   .object({
     text: z.string(),
@@ -29,19 +21,10 @@ const explanationStepSchema = z
   })
   .strict();
 
-const predictSchema = z
-  .object({
-    options: z.array(predictOptionSchema),
-    question: z.string(),
-    step: z.string().min(1),
-  })
-  .strict();
-
 const schema = z
   .object({
     anchor: anchorSchema,
     explanation: z.array(explanationStepSchema),
-    predict: z.array(predictSchema),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- remove inline `predict` checks from the explanation activity contract and prompt
- simplify explanation planning and saving to static plus visual steps with updated evals/tests
- keep course-generation workflow tests scoped by mocking nested activity generation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove inline predict checks from explanation activities and drop multiple-choice steps. The flow is now static narrative beats with paired visuals plus the closing anchor, simplifying planning, saving, prompts, schema, and tests.

- **Refactors**
  - Removed `predict` from `ActivityExplanationSchema` in `@zoonk/ai`.
  - Rewrote plan builder to emit only `static` + `visual` pairs and the anchor; deleted prediction mapping logic.
  - Simplified save step; removed `multipleChoice` handling.
  - Kept visual-description generation scoped to prose steps; updated copy to reflect no predict checks.
  - Updated prompt and eval criteria in `packages/ai` and `apps/evals` for static-only delivery.
  - Pruned tests accordingly; mocked nested activity generation in course-generation tests to keep scope tight.

- **Migration**
  - Stop reading/writing `predict` in explanation activity payloads.
  - Update UIs to render only `static` and `visual` steps for explanation activities; no `multipleChoice`.
  - Refresh fixtures/evals to the new two-field output: `explanation[]` and `anchor`.

<sup>Written for commit 97b62fa7136b3b157b70383438fd05aef2e4ad61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

