### PR TITLE
refactor(ai): use gpt-image-2

### DIFF
--- a/apps/admin/src/data/stats/ai/ai-task-catalog.ts
+++ b/apps/admin/src/data/stats/ai/ai-task-catalog.ts
@@ -113,7 +113,7 @@ const AI_TASK_METADATA = {
     supportsFallbackReporting: true,
   },
   "course-thumbnail": {
-    defaultModel: "openai/gpt-image-1.5",
+    defaultModel: "openai/gpt-image-2",
     supportsFallbackReporting: false,
   },
   "language-chapter-lessons": {
@@ -145,7 +145,7 @@ const AI_TASK_METADATA = {
     supportsFallbackReporting: true,
   },
   "step-select-image": {
-    defaultModel: "openai/gpt-image-1-mini",
+    defaultModel: "openai/gpt-image-2",
     supportsFallbackReporting: false,
   },
 } satisfies Record<string, AiTaskMetadata>;

--- a/packages/ai/src/provider-options.test.ts
+++ b/packages/ai/src/provider-options.test.ts
@@ -126,7 +126,7 @@ describe(buildImageProviderOptions, () => {
   test("skips gateway reporting tags by default while preserving the openai image settings", () => {
     expect(
       buildImageProviderOptions({
-        model: "openai/gpt-image-1.5",
+        model: "openai/gpt-image-2",
         quality: "low",
         taskName: "course-thumbnail",
       }),
@@ -144,13 +144,13 @@ describe(buildImageProviderOptions, () => {
 
     expect(
       buildImageProviderOptions({
-        model: "openai/gpt-image-1.5",
+        model: "openai/gpt-image-2",
         quality: "low",
         taskName: "course-thumbnail",
       }),
     ).toEqual({
       gateway: {
-        tags: ["task:course-thumbnail", "default-model:openai/gpt-image-1.5"],
+        tags: ["task:course-thumbnail", "default-model:openai/gpt-image-2"],
       },
       openai: {
         output_format: "webp",

--- a/packages/ai/src/tasks/courses/course-thumbnail.ts
+++ b/packages/ai/src/tasks/courses/course-thumbnail.ts
@@ -4,7 +4,7 @@ import { type GeneratedFile, type ImageModel, generateImage } from "ai";
 import { type ImageGenerationQuality, buildImageProviderOptions } from "../../provider-options";
 import promptTemplate from "./course-thumbnail.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-image-1.5";
+const DEFAULT_MODEL = "openai/gpt-image-2";
 const DEFAULT_QUALITY = "low";
 
 function getCourseThumbnailPrompt(title: string) {

--- a/packages/ai/src/tasks/steps/step-select-image.ts
+++ b/packages/ai/src/tasks/steps/step-select-image.ts
@@ -4,7 +4,7 @@ import { type GeneratedFile, type ImageModel, generateImage } from "ai";
 import { type ImageGenerationQuality, buildImageProviderOptions } from "../../provider-options";
 import promptTemplate from "./step-select-image.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-image-1-mini";
+const DEFAULT_MODEL = "openai/gpt-image-2";
 const DEFAULT_QUALITY = "low";
 
 function getSelectImageStepPrompt(prompt: string, language: string) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches the default image generation model to `openai/gpt-image-2` for course thumbnails and step image selection. Updates metadata and tests to match the new model and gateway tag.

- **Refactors**
  - Set default model to `openai/gpt-image-2` for `course-thumbnail` and `step-select-image`.
  - Updated `AI_TASK_METADATA` defaults and `buildImageProviderOptions` tests (including expected `default-model` gateway tag).

<sup>Written for commit f5ef832e1382923393ae49068b8adeeda128793b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

