### PR TITLE
feat(ai): redesign image-led practice activities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 - Always prefer the **simplest solution**. If something feels complex, refactor
 - **Simplicity ≠ laziness.** Creating a reusable component for repeated patterns IS the simple solution—it maintains consistency and quality. Leaving duplication "because it's only N files" leads to inconsistency (bugs). DRY is about having a single source of truth, not just reducing typing. When you see the same pattern repeated, extract it
 - Favor **clarity and minimalism** in both code and UI
+- **Do not create formatting-only diffs.** Preserve existing formatting unless a line needs a semantic change. Formatting is handled by `oxfmt`, so never manually reflow unrelated code, expand one-line calls/types/objects into multiline, or collapse multiline code into one line unless that exact code is being changed for behavior.
 - Follow design inspirations from Apple, Linear, Vercel
 - Code must be modular, following SOLID and DRY principles
 - Avoid nested conditionals and complex logic

--- a/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
@@ -128,16 +128,8 @@ vi.mock("@zoonk/ai/tasks/activities/core/quiz", () => ({
         {
           format: "selectImage",
           options: [
-            {
-              feedback: "This is correct",
-              isCorrect: true,
-              prompt: "A cat sitting",
-            },
-            {
-              feedback: "This is incorrect",
-              isCorrect: false,
-              prompt: "A dog running",
-            },
+            { feedback: "This is correct", isCorrect: true, prompt: "A cat sitting" },
+            { feedback: "This is incorrect", isCorrect: false, prompt: "A dog running" },
           ],
           question: "Which image shows a cat?",
         },
@@ -312,15 +304,9 @@ describe(activityGenerationWorkflow, () => {
         updatedReplacementActivity,
         updatedArchivedReplacementActivity,
       ] = await Promise.all([
-        prisma.activity.findUniqueOrThrow({
-          where: { id: publishedActivity.id },
-        }),
-        prisma.activity.findUniqueOrThrow({
-          where: { id: replacementActivity.id },
-        }),
-        prisma.activity.findUniqueOrThrow({
-          where: { id: archivedReplacementActivity.id },
-        }),
+        prisma.activity.findUniqueOrThrow({ where: { id: publishedActivity.id } }),
+        prisma.activity.findUniqueOrThrow({ where: { id: replacementActivity.id } }),
+        prisma.activity.findUniqueOrThrow({ where: { id: archivedReplacementActivity.id } }),
       ]);
 
       expect(generateActivityExplanation).toHaveBeenCalledOnce();

--- a/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/activity-generation-workflow.test.ts
@@ -89,12 +89,15 @@ vi.mock("@zoonk/ai/tasks/activities/core/practice", () => ({
   generateActivityPractice: vi.fn().mockResolvedValue({
     data: {
       scenario: {
+        imagePrompt: "Opening support desk scene with Maya and a refund dashboard",
         text: "I'm closing the support queue with Maya, and one customer report still does not line up with the refund totals.",
         title: "Night shift",
       },
       steps: [
         {
           context: "Your colleague turns to you during a meeting...",
+          imagePrompt:
+            "A refund dashboard filtered to discounted orders with one outlier row highlighted",
           options: [
             { feedback: "Great choice!", isCorrect: true, text: "Option A" },
             { feedback: "Not quite.", isCorrect: false, text: "Option B" },
@@ -125,8 +128,16 @@ vi.mock("@zoonk/ai/tasks/activities/core/quiz", () => ({
         {
           format: "selectImage",
           options: [
-            { feedback: "This is correct", isCorrect: true, prompt: "A cat sitting" },
-            { feedback: "This is incorrect", isCorrect: false, prompt: "A dog running" },
+            {
+              feedback: "This is correct",
+              isCorrect: true,
+              prompt: "A cat sitting",
+            },
+            {
+              feedback: "This is incorrect",
+              isCorrect: false,
+              prompt: "A dog running",
+            },
           ],
           question: "Which image shows a cat?",
         },
@@ -301,9 +312,15 @@ describe(activityGenerationWorkflow, () => {
         updatedReplacementActivity,
         updatedArchivedReplacementActivity,
       ] = await Promise.all([
-        prisma.activity.findUniqueOrThrow({ where: { id: publishedActivity.id } }),
-        prisma.activity.findUniqueOrThrow({ where: { id: replacementActivity.id } }),
-        prisma.activity.findUniqueOrThrow({ where: { id: archivedReplacementActivity.id } }),
+        prisma.activity.findUniqueOrThrow({
+          where: { id: publishedActivity.id },
+        }),
+        prisma.activity.findUniqueOrThrow({
+          where: { id: replacementActivity.id },
+        }),
+        prisma.activity.findUniqueOrThrow({
+          where: { id: archivedReplacementActivity.id },
+        }),
       ]);
 
       expect(generateActivityExplanation).toHaveBeenCalledOnce();

--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
@@ -132,16 +132,8 @@ vi.mock("@zoonk/ai/tasks/activities/core/quiz", () => ({
         {
           format: "selectImage",
           options: [
-            {
-              feedback: "This is correct",
-              isCorrect: true,
-              prompt: "A cat sitting",
-            },
-            {
-              feedback: "This is incorrect",
-              isCorrect: false,
-              prompt: "A dog running",
-            },
+            { feedback: "This is correct", isCorrect: true, prompt: "A cat sitting" },
+            { feedback: "This is incorrect", isCorrect: false, prompt: "A dog running" },
           ],
           question: "Which image shows a cat?",
         },
@@ -275,11 +267,7 @@ describe("core activity workflow", () => {
 
       await stepFixture({
         activityId: explanationActivity.id,
-        content: {
-          text: "Existing Exp text",
-          title: "Existing Exp",
-          variant: "text",
-        },
+        content: { text: "Existing Exp text", title: "Existing Exp", variant: "text" },
         position: 0,
       });
 
@@ -315,10 +303,7 @@ describe("core activity workflow", () => {
       await stepFixture({
         activityId: explanationActivity.id,
         content: {
-          image: {
-            prompt: "A prompt",
-            url: "https://example.com/existing.webp",
-          },
+          image: { prompt: "A prompt", url: "https://example.com/existing.webp" },
           text: "Step text",
           title: "Step",
           variant: "text",
@@ -350,10 +335,7 @@ describe("core activity workflow", () => {
       await stepFixture({
         activityId: explanationActivity.id,
         content: {
-          image: {
-            prompt: "A prompt",
-            url: "https://example.com/existing.webp",
-          },
+          image: { prompt: "A prompt", url: "https://example.com/existing.webp" },
           text: "Step text",
           title: "Step",
           variant: "text",
@@ -429,11 +411,7 @@ describe("core activity workflow", () => {
 
       await stepFixture({
         activityId: explanationActivity.id,
-        content: {
-          text: "Explanation content",
-          title: "Explanation",
-          variant: "text",
-        },
+        content: { text: "Explanation content", title: "Explanation", variant: "text" },
         position: 0,
       });
 

--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
@@ -93,12 +93,15 @@ vi.mock("@zoonk/ai/tasks/activities/core/practice", () => ({
   generateActivityPractice: vi.fn().mockResolvedValue({
     data: {
       scenario: {
+        imagePrompt: "Opening support desk scene with Maya and a refund dashboard",
         text: "I'm closing the support queue with Maya, and one customer report still does not line up with the refund totals.",
         title: "Night shift",
       },
       steps: [
         {
           context: "Your colleague turns to you during a meeting...",
+          imagePrompt:
+            "A refund dashboard filtered to discounted orders with one outlier row highlighted",
           options: [
             { feedback: "Great choice!", isCorrect: true, text: "Option A" },
             { feedback: "Not quite.", isCorrect: false, text: "Option B" },
@@ -129,8 +132,16 @@ vi.mock("@zoonk/ai/tasks/activities/core/quiz", () => ({
         {
           format: "selectImage",
           options: [
-            { feedback: "This is correct", isCorrect: true, prompt: "A cat sitting" },
-            { feedback: "This is incorrect", isCorrect: false, prompt: "A dog running" },
+            {
+              feedback: "This is correct",
+              isCorrect: true,
+              prompt: "A cat sitting",
+            },
+            {
+              feedback: "This is incorrect",
+              isCorrect: false,
+              prompt: "A dog running",
+            },
           ],
           question: "Which image shows a cat?",
         },
@@ -264,7 +275,11 @@ describe("core activity workflow", () => {
 
       await stepFixture({
         activityId: explanationActivity.id,
-        content: { text: "Existing Exp text", title: "Existing Exp", variant: "text" },
+        content: {
+          text: "Existing Exp text",
+          title: "Existing Exp",
+          variant: "text",
+        },
         position: 0,
       });
 
@@ -300,7 +315,10 @@ describe("core activity workflow", () => {
       await stepFixture({
         activityId: explanationActivity.id,
         content: {
-          image: { prompt: "A prompt", url: "https://example.com/existing.webp" },
+          image: {
+            prompt: "A prompt",
+            url: "https://example.com/existing.webp",
+          },
           text: "Step text",
           title: "Step",
           variant: "text",
@@ -332,7 +350,10 @@ describe("core activity workflow", () => {
       await stepFixture({
         activityId: explanationActivity.id,
         content: {
-          image: { prompt: "A prompt", url: "https://example.com/existing.webp" },
+          image: {
+            prompt: "A prompt",
+            url: "https://example.com/existing.webp",
+          },
           text: "Step text",
           title: "Step",
           variant: "text",
@@ -408,7 +429,11 @@ describe("core activity workflow", () => {
 
       await stepFixture({
         activityId: explanationActivity.id,
-        content: { text: "Explanation content", title: "Explanation", variant: "text" },
+        content: {
+          text: "Explanation content",
+          title: "Explanation",
+          variant: "text",
+        },
         position: 0,
       });
 

--- a/apps/api/src/workflows/activity-generation/custom-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/custom-activity-workflow.test.ts
@@ -68,6 +68,7 @@ vi.mock("@zoonk/ai/tasks/activities/core/practice", () => ({
   generateActivityPractice: vi.fn().mockResolvedValue({
     data: {
       scenario: {
+        imagePrompt: "Opening support desk scene with Maya and a refund dashboard",
         text: "I'm closing the support queue with Maya, and one customer report still does not line up with the refund totals.",
         title: "Night shift",
       },

--- a/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
@@ -215,6 +215,7 @@ describe("explanation activity workflow", () => {
     expect(vi.mocked(generateStepImages)).toHaveBeenCalledWith({
       language: activity.language,
       orgSlug: activities[0]?.lesson.chapter.course.organization?.slug,
+      preset: "illustration",
       prompts: [
         "A lesson illustration for O envio",
         "A lesson illustration for Os rótulos escondidos",

--- a/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.ts
@@ -1,12 +1,12 @@
 import { getExistingContentSteps } from "../steps/_utils/content-step-helpers";
 import { findActivitiesByKind } from "../steps/_utils/find-activity-by-kind";
+import { generateActivityStepImagesStep } from "../steps/generate-activity-step-images-step";
 import {
   type ExplanationResult,
   type GeneratedExplanationResult,
   generateExplanationContentStep,
 } from "../steps/generate-explanation-content-step";
 import { generateExplanationImagePromptsStep } from "../steps/generate-explanation-image-prompts-step";
-import { generateExplanationStepImagesStep } from "../steps/generate-explanation-step-images-step";
 import { type LessonActivity } from "../steps/get-lesson-activities-step";
 import { handleActivityFailureStep } from "../steps/handle-failure-step";
 import { saveExplanationActivityStep } from "../steps/save-explanation-activity-step";
@@ -114,7 +114,7 @@ export async function explanationActivityWorkflow({
 
       try {
         const { prompts } = await generateExplanationImagePromptsStep(activity, result.steps);
-        const { images } = await generateExplanationStepImagesStep(activity, prompts);
+        const { images } = await generateActivityStepImagesStep(activity, prompts);
 
         await saveExplanationActivityStep({
           activityId: result.activityId,

--- a/apps/api/src/workflows/activity-generation/kinds/practice-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/practice-workflow.test.ts
@@ -8,20 +8,31 @@ import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { beforeAll, describe, expect, test, vi } from "vitest";
+import { generateStepImages } from "../steps/_utils/generate-step-images";
 import { type ExplanationResult } from "../steps/generate-explanation-content-step";
 import { getLessonActivitiesStep } from "../steps/get-lesson-activities-step";
 import { practiceActivityWorkflow } from "./practice-workflow";
+
+function createImageResult(prompts: string[]) {
+  return prompts.map((prompt, index) => ({
+    prompt,
+    url: `https://example.com/practice-step-image-${index}.webp`,
+  }));
+}
 
 vi.mock("@zoonk/ai/tasks/activities/core/practice", () => ({
   generateActivityPractice: vi.fn().mockResolvedValue({
     data: {
       scenario: {
+        imagePrompt: "Opening support desk scene with Maya and a refund dashboard",
         text: "I'm closing the support queue with Maya, and one customer report still does not line up with the refund totals.",
         title: "Night shift",
       },
       steps: [
         {
           context: "Your colleague turns to you during a meeting...",
+          imagePrompt:
+            "A refund dashboard filtered to discounted orders with one outlier row highlighted",
           options: [
             { feedback: "Great choice!", isCorrect: true, text: "Option A" },
             { feedback: "Not quite.", isCorrect: false, text: "Option B" },
@@ -34,6 +45,14 @@ vi.mock("@zoonk/ai/tasks/activities/core/practice", () => ({
       title: "The game store signup mix-up",
     },
   }),
+}));
+
+vi.mock("../steps/_utils/generate-step-images", () => ({
+  generateStepImages: vi
+    .fn()
+    .mockImplementation(({ prompts }: { prompts: string[] }) =>
+      Promise.resolve(createImageResult(prompts)),
+    ),
 }));
 
 function buildExplanationResults(activityId: string): ExplanationResult[] {
@@ -89,7 +108,9 @@ describe("practice activity workflow", () => {
       title: `Practice ${randomUUID()}`,
     });
 
-    const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
+    const activities = await getLessonActivitiesStep({
+      lessonId: testLesson.id,
+    });
     const explanationResults = buildExplanationResults(expActivity.id);
 
     await practiceActivityWorkflow({
@@ -109,6 +130,10 @@ describe("practice activity workflow", () => {
     expect(steps[0]?.isPublished).toBe(true);
     expect(steps[0]?.kind).toBe("static");
     expect(steps[0]?.content).toEqual({
+      image: {
+        prompt: "Opening support desk scene with Maya and a refund dashboard",
+        url: "https://example.com/practice-step-image-0.webp",
+      },
       text: "I'm closing the support queue with Maya, and one customer report still does not line up with the refund totals.",
       title: "Night shift",
       variant: "text",
@@ -116,6 +141,10 @@ describe("practice activity workflow", () => {
     expect(steps[1]?.kind).toBe("multipleChoice");
     expect(steps[1]?.content).toEqual({
       context: "Your colleague turns to you during a meeting...",
+      image: {
+        prompt: "A refund dashboard filtered to discounted orders with one outlier row highlighted",
+        url: "https://example.com/practice-step-image-1.webp",
+      },
       kind: "core",
       options: [
         { feedback: "Great choice!", isCorrect: true, text: "Option A" },
@@ -151,7 +180,9 @@ describe("practice activity workflow", () => {
       title: `Practice ${randomUUID()}`,
     });
 
-    const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
+    const activities = await getLessonActivitiesStep({
+      lessonId: testLesson.id,
+    });
     const explanationResults = buildExplanationResults(expActivity.id);
 
     await practiceActivityWorkflow({
@@ -198,13 +229,59 @@ describe("practice activity workflow", () => {
       title: `Practice ${randomUUID()}`,
     });
 
-    const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
+    const activities = await getLessonActivitiesStep({
+      lessonId: testLesson.id,
+    });
     const explanationResults = buildExplanationResults(expActivity.id);
 
     await practiceActivityWorkflow({
       activitiesToGenerate: activities,
       allActivities: activities,
       explanationResults,
+      totalPractices: 1,
+      workflowRunId: "test-run-id",
+    });
+
+    const dbPractice = await prisma.activity.findFirst({
+      where: { kind: "practice", lessonId: testLesson.id },
+    });
+    expect(dbPractice?.generationStatus).toBe("failed");
+  });
+
+  test("sets practice status to 'failed' when step image generation throws", async () => {
+    vi.mocked(generateStepImages).mockRejectedValueOnce(new Error("Practice images failed"));
+
+    const testLesson = await lessonFixture({
+      chapterId: chapter.id,
+      concepts: ["Test Concept"],
+      organizationId,
+      title: `Practice Image Failure Lesson ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "completed",
+      kind: "explanation",
+      lessonId: testLesson.id,
+      organizationId,
+      title: "Test Concept",
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "practice",
+      lessonId: testLesson.id,
+      organizationId,
+      title: `Practice ${randomUUID()}`,
+    });
+
+    const activities = await getLessonActivitiesStep({
+      lessonId: testLesson.id,
+    });
+
+    await practiceActivityWorkflow({
+      activitiesToGenerate: activities,
+      allActivities: activities,
+      explanationResults: buildExplanationResults("unused"),
       totalPractices: 1,
       workflowRunId: "test-run-id",
     });
@@ -231,7 +308,9 @@ describe("practice activity workflow", () => {
       title: `Practice ${randomUUID()}`,
     });
 
-    const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
+    const activities = await getLessonActivitiesStep({
+      lessonId: testLesson.id,
+    });
 
     await practiceActivityWorkflow({
       activitiesToGenerate: activities,
@@ -283,7 +362,9 @@ describe("practice activity workflow", () => {
       position: 0,
     });
 
-    const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
+    const activities = await getLessonActivitiesStep({
+      lessonId: testLesson.id,
+    });
     const explanationResults = buildExplanationResults(expActivity.id);
 
     await practiceActivityWorkflow({
@@ -360,12 +441,30 @@ describe("practice activity workflow", () => {
         }),
       ]);
 
-      const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
+      const activities = await getLessonActivitiesStep({
+        lessonId: testLesson.id,
+      });
       const explanationResults: ExplanationResult[] = [
-        { activityId: expS1.id, concept: "S1", steps: [{ text: "S1 text", title: "S1" }] },
-        { activityId: expS2.id, concept: "S2", steps: [{ text: "S2 text", title: "S2" }] },
-        { activityId: expS3.id, concept: "S3", steps: [{ text: "S3 text", title: "S3" }] },
-        { activityId: expS4.id, concept: "S4", steps: [{ text: "S4 text", title: "S4" }] },
+        {
+          activityId: expS1.id,
+          concept: "S1",
+          steps: [{ text: "S1 text", title: "S1" }],
+        },
+        {
+          activityId: expS2.id,
+          concept: "S2",
+          steps: [{ text: "S2 text", title: "S2" }],
+        },
+        {
+          activityId: expS3.id,
+          concept: "S3",
+          steps: [{ text: "S3 text", title: "S3" }],
+        },
+        {
+          activityId: expS4.id,
+          concept: "S4",
+          steps: [{ text: "S4 text", title: "S4" }],
+        },
       ];
 
       await practiceActivityWorkflow({
@@ -441,7 +540,9 @@ describe("practice activity workflow", () => {
         }),
       ]);
 
-      const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
+      const activities = await getLessonActivitiesStep({
+        lessonId: testLesson.id,
+      });
       const explanationResults: ExplanationResult[] = [
         {
           activityId: expH1A.id,
@@ -532,7 +633,9 @@ describe("practice activity workflow", () => {
         title: `Single Practice ${randomUUID()}`,
       });
 
-      const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
+      const activities = await getLessonActivitiesStep({
+        lessonId: testLesson.id,
+      });
       const explanationResults: ExplanationResult[] = [
         {
           activityId: expSA.id,
@@ -626,7 +729,9 @@ describe("practice activity workflow", () => {
         }),
       ]);
 
-      const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
+      const activities = await getLessonActivitiesStep({
+        lessonId: testLesson.id,
+      });
       const explanationResults: ExplanationResult[] = [
         {
           activityId: expSC1.id,
@@ -730,7 +835,9 @@ describe("practice activity workflow", () => {
       ]);
 
       // practice0 is completed → only practice1 in activitiesToGenerate
-      const allActivities = await getLessonActivitiesStep({ lessonId: testLesson.id });
+      const allActivities = await getLessonActivitiesStep({
+        lessonId: testLesson.id,
+      });
       const activitiesToGenerate = allActivities.filter((a) => a.id === practice1.id);
 
       const explanationResults: ExplanationResult[] = [
@@ -820,7 +927,9 @@ describe("practice activity workflow", () => {
         }),
       ]);
 
-      const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
+      const activities = await getLessonActivitiesStep({
+        lessonId: testLesson.id,
+      });
       const explanationResults: ExplanationResult[] = [
         {
           activityId: expOnly.id,

--- a/apps/api/src/workflows/activity-generation/kinds/practice-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/practice-workflow.test.ts
@@ -108,9 +108,7 @@ describe("practice activity workflow", () => {
       title: `Practice ${randomUUID()}`,
     });
 
-    const activities = await getLessonActivitiesStep({
-      lessonId: testLesson.id,
-    });
+    const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
     const explanationResults = buildExplanationResults(expActivity.id);
 
     await practiceActivityWorkflow({
@@ -180,9 +178,7 @@ describe("practice activity workflow", () => {
       title: `Practice ${randomUUID()}`,
     });
 
-    const activities = await getLessonActivitiesStep({
-      lessonId: testLesson.id,
-    });
+    const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
     const explanationResults = buildExplanationResults(expActivity.id);
 
     await practiceActivityWorkflow({
@@ -229,9 +225,7 @@ describe("practice activity workflow", () => {
       title: `Practice ${randomUUID()}`,
     });
 
-    const activities = await getLessonActivitiesStep({
-      lessonId: testLesson.id,
-    });
+    const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
     const explanationResults = buildExplanationResults(expActivity.id);
 
     await practiceActivityWorkflow({
@@ -274,9 +268,7 @@ describe("practice activity workflow", () => {
       title: `Practice ${randomUUID()}`,
     });
 
-    const activities = await getLessonActivitiesStep({
-      lessonId: testLesson.id,
-    });
+    const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
 
     await practiceActivityWorkflow({
       activitiesToGenerate: activities,
@@ -308,9 +300,7 @@ describe("practice activity workflow", () => {
       title: `Practice ${randomUUID()}`,
     });
 
-    const activities = await getLessonActivitiesStep({
-      lessonId: testLesson.id,
-    });
+    const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
 
     await practiceActivityWorkflow({
       activitiesToGenerate: activities,
@@ -362,9 +352,7 @@ describe("practice activity workflow", () => {
       position: 0,
     });
 
-    const activities = await getLessonActivitiesStep({
-      lessonId: testLesson.id,
-    });
+    const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
     const explanationResults = buildExplanationResults(expActivity.id);
 
     await practiceActivityWorkflow({
@@ -441,30 +429,12 @@ describe("practice activity workflow", () => {
         }),
       ]);
 
-      const activities = await getLessonActivitiesStep({
-        lessonId: testLesson.id,
-      });
+      const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
       const explanationResults: ExplanationResult[] = [
-        {
-          activityId: expS1.id,
-          concept: "S1",
-          steps: [{ text: "S1 text", title: "S1" }],
-        },
-        {
-          activityId: expS2.id,
-          concept: "S2",
-          steps: [{ text: "S2 text", title: "S2" }],
-        },
-        {
-          activityId: expS3.id,
-          concept: "S3",
-          steps: [{ text: "S3 text", title: "S3" }],
-        },
-        {
-          activityId: expS4.id,
-          concept: "S4",
-          steps: [{ text: "S4 text", title: "S4" }],
-        },
+        { activityId: expS1.id, concept: "S1", steps: [{ text: "S1 text", title: "S1" }] },
+        { activityId: expS2.id, concept: "S2", steps: [{ text: "S2 text", title: "S2" }] },
+        { activityId: expS3.id, concept: "S3", steps: [{ text: "S3 text", title: "S3" }] },
+        { activityId: expS4.id, concept: "S4", steps: [{ text: "S4 text", title: "S4" }] },
       ];
 
       await practiceActivityWorkflow({
@@ -540,9 +510,7 @@ describe("practice activity workflow", () => {
         }),
       ]);
 
-      const activities = await getLessonActivitiesStep({
-        lessonId: testLesson.id,
-      });
+      const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
       const explanationResults: ExplanationResult[] = [
         {
           activityId: expH1A.id,
@@ -633,9 +601,7 @@ describe("practice activity workflow", () => {
         title: `Single Practice ${randomUUID()}`,
       });
 
-      const activities = await getLessonActivitiesStep({
-        lessonId: testLesson.id,
-      });
+      const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
       const explanationResults: ExplanationResult[] = [
         {
           activityId: expSA.id,
@@ -729,9 +695,7 @@ describe("practice activity workflow", () => {
         }),
       ]);
 
-      const activities = await getLessonActivitiesStep({
-        lessonId: testLesson.id,
-      });
+      const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
       const explanationResults: ExplanationResult[] = [
         {
           activityId: expSC1.id,
@@ -835,9 +799,7 @@ describe("practice activity workflow", () => {
       ]);
 
       // practice0 is completed → only practice1 in activitiesToGenerate
-      const allActivities = await getLessonActivitiesStep({
-        lessonId: testLesson.id,
-      });
+      const allActivities = await getLessonActivitiesStep({ lessonId: testLesson.id });
       const activitiesToGenerate = allActivities.filter((a) => a.id === practice1.id);
 
       const explanationResults: ExplanationResult[] = [
@@ -927,9 +889,7 @@ describe("practice activity workflow", () => {
         }),
       ]);
 
-      const activities = await getLessonActivitiesStep({
-        lessonId: testLesson.id,
-      });
+      const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
       const explanationResults: ExplanationResult[] = [
         {
           activityId: expOnly.id,

--- a/apps/api/src/workflows/activity-generation/kinds/practice-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/practice-workflow.ts
@@ -1,16 +1,20 @@
 import { findActivitiesByKind } from "../steps/_utils/find-activity-by-kind";
 import { getExplanationStepsForPractice } from "../steps/_utils/get-explanation-steps-for-practice";
+import { getPracticeImagePrompts } from "../steps/_utils/get-practice-image-prompts";
+import { generateActivityStepImagesStep } from "../steps/generate-activity-step-images-step";
 import { type ExplanationResult } from "../steps/generate-explanation-content-step";
 import { generatePracticeContentStep } from "../steps/generate-practice-content-step";
 import { type LessonActivity } from "../steps/get-lesson-activities-step";
+import { handleActivityFailureStep } from "../steps/handle-failure-step";
 import { savePracticeActivityStep } from "../steps/save-practice-activity-step";
 
 /**
  * Orchestrates practice activity generation.
  *
- * Flow per practice: generateContent -> save.
+ * Flow per practice: generateContent -> generateStepImages -> save.
  * Each practice is independent — if one fails, others continue.
- * The save step writes steps and marks the activity as completed.
+ * The save step writes the image-led scenario/question steps and marks the
+ * activity as completed.
  *
  * Iterates over ALL practice activities (from allActivities) to compute
  * the correct explanation slice per practice index. Only generates content
@@ -41,24 +45,34 @@ export async function practiceActivityWorkflow({
         return;
       }
 
-      const { activityId, scenario, steps, title } = await generatePracticeContentStep(
-        allActivities,
-        getExplanationStepsForPractice(explanationResults, practiceIndex, totalPractices),
-        workflowRunId,
-        practiceIndex,
-      );
+      try {
+        const { activityId, scenario, steps, title } = await generatePracticeContentStep(
+          allActivities,
+          getExplanationStepsForPractice(explanationResults, practiceIndex, totalPractices),
+          workflowRunId,
+          practiceIndex,
+        );
 
-      if (!activityId || !scenario || steps.length === 0 || !title) {
-        return;
+        if (!activityId || !scenario || steps.length === 0 || !title) {
+          return;
+        }
+
+        const { images } = await generateActivityStepImagesStep(
+          practice,
+          getPracticeImagePrompts({ scenario, steps }),
+        );
+
+        await savePracticeActivityStep({
+          activityId,
+          images,
+          scenario,
+          steps,
+          title,
+          workflowRunId,
+        });
+      } catch {
+        await handleActivityFailureStep({ activityId: practice.id });
       }
-
-      await savePracticeActivityStep({
-        activityId,
-        scenario,
-        steps,
-        title,
-        workflowRunId,
-      });
     }),
   );
 }

--- a/apps/api/src/workflows/activity-generation/steps/_utils/generate-step-images.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/generate-step-images.test.ts
@@ -70,4 +70,24 @@ describe(generateStepImages, () => {
       }),
     ).rejects.toThrow("Image generation returned no URL for prompt: Missing URL prompt");
   });
+
+  test("passes the requested image preset through to the generator", async () => {
+    generateContentStepImageMock.mockResolvedValueOnce({
+      data: "https://example.com/practice-step.webp",
+      error: null,
+    });
+
+    await generateStepImages({
+      language: "en",
+      preset: "practice",
+      prompts: ["Practice prompt"],
+    });
+
+    expect(generateContentStepImageMock).toHaveBeenCalledWith({
+      language: "en",
+      orgSlug: undefined,
+      preset: "practice",
+      prompt: "Practice prompt",
+    });
+  });
 });

--- a/apps/api/src/workflows/activity-generation/steps/_utils/generate-step-images.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/generate-step-images.ts
@@ -1,4 +1,7 @@
-import { generateContentStepImage } from "@zoonk/core/steps/content-image";
+import {
+  type StepContentImagePreset,
+  generateContentStepImage,
+} from "@zoonk/core/steps/content-image";
 import { type StepImage } from "@zoonk/core/steps/contract/image";
 
 function getImageUrlOrThrow({
@@ -29,10 +32,12 @@ function getImageUrlOrThrow({
 export async function generateStepImages({
   language,
   orgSlug,
+  preset,
   prompts,
 }: {
   language: string;
   orgSlug?: string;
+  preset?: StepContentImagePreset;
   prompts: string[];
 }): Promise<StepImage[]> {
   return Promise.all(
@@ -40,6 +45,7 @@ export async function generateStepImages({
       const { data: url, error } = await generateContentStepImage({
         language,
         orgSlug,
+        preset,
         prompt,
       });
 

--- a/apps/api/src/workflows/activity-generation/steps/_utils/get-practice-image-prompts.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/get-practice-image-prompts.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, test } from "vitest";
 import { getPracticeImagePrompts } from "./get-practice-image-prompts";
 
 describe(getPracticeImagePrompts, () => {
-  test("returns authored prompts in visible practice order", () => {
+  test("returns trimmed authored prompts in visible practice order", () => {
     const prompts = getPracticeImagePrompts({
       scenario: {
-        imagePrompt: "Opening support desk scene with Maya and a refund dashboard",
+        imagePrompt: "  Opening support desk scene with Maya and a refund dashboard  ",
         text: "I'm closing the support queue with Maya, and one refund total still looks wrong.",
         title: "Night shift",
       },
@@ -13,7 +13,7 @@ describe(getPracticeImagePrompts, () => {
         {
           context: "The discounted orders are the only ones acting weird.",
           imagePrompt:
-            "A refund dashboard filtered to discounted orders with one outlier row highlighted",
+            "  A refund dashboard filtered to discounted orders with one outlier row highlighted  ",
           options: [
             { feedback: "Yes", isCorrect: true, text: "Check discounts" },
             { feedback: "No", isCorrect: false, text: "Ignore it" },
@@ -29,32 +29,39 @@ describe(getPracticeImagePrompts, () => {
     ]);
   });
 
-  test("fills blank prompts with concrete fallbacks", () => {
-    const prompts = getPracticeImagePrompts({
-      scenario: {
-        imagePrompt: "   ",
-        text: "I'm checking one last shipping issue with Leo before the warehouse closes.",
-        title: "Late label",
-      },
-      steps: [
-        {
-          context: "These two labels look almost the same, but the destination scan disagrees.",
-          imagePrompt: "",
-          options: [
-            { feedback: "Yes", isCorrect: true, text: "Match labels" },
-            { feedback: "No", isCorrect: false, text: "Guess city" },
-          ],
-          question: "What should we compare?",
+  test("throws when the scenario image prompt is blank", () => {
+    expect(() =>
+      getPracticeImagePrompts({
+        scenario: {
+          imagePrompt: "   ",
+          text: "I'm checking one last shipping issue with Leo before the warehouse closes.",
+          title: "Late label",
         },
-      ],
-    });
+        steps: [],
+      }),
+    ).toThrow("Missing practice image prompt for scenario");
+  });
 
-    expect(prompts[0]).toContain("Short scene label: Late label.");
-    expect(prompts[0]).toContain(
-      "Situation: I'm checking one last shipping issue with Leo before the warehouse closes.",
-    );
-    expect(prompts[1]).toContain("Dialogue: These two labels look almost the same");
-    expect(prompts[1]).toContain("Question: What should we compare?");
-    expect(prompts[1]).toContain("Possible actions: Match labels, Guess city.");
+  test("throws when a step image prompt is blank", () => {
+    expect(() =>
+      getPracticeImagePrompts({
+        scenario: {
+          imagePrompt: "Opening shipping desk scene",
+          text: "I'm checking one last shipping issue with Leo before the warehouse closes.",
+          title: "Late label",
+        },
+        steps: [
+          {
+            context: "These two labels look almost the same, but the destination scan disagrees.",
+            imagePrompt: "",
+            options: [
+              { feedback: "Yes", isCorrect: true, text: "Match labels" },
+              { feedback: "No", isCorrect: false, text: "Guess city" },
+            ],
+            question: "What should we compare?",
+          },
+        ],
+      }),
+    ).toThrow("Missing practice image prompt for step 1");
   });
 });

--- a/apps/api/src/workflows/activity-generation/steps/_utils/get-practice-image-prompts.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/get-practice-image-prompts.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+import { getPracticeImagePrompts } from "./get-practice-image-prompts";
+
+describe(getPracticeImagePrompts, () => {
+  test("returns authored prompts in visible practice order", () => {
+    const prompts = getPracticeImagePrompts({
+      scenario: {
+        imagePrompt: "Opening support desk scene with Maya and a refund dashboard",
+        text: "I'm closing the support queue with Maya, and one refund total still looks wrong.",
+        title: "Night shift",
+      },
+      steps: [
+        {
+          context: "The discounted orders are the only ones acting weird.",
+          imagePrompt:
+            "A refund dashboard filtered to discounted orders with one outlier row highlighted",
+          options: [
+            { feedback: "Yes", isCorrect: true, text: "Check discounts" },
+            { feedback: "No", isCorrect: false, text: "Ignore it" },
+          ],
+          question: "Where do we start?",
+        },
+      ],
+    });
+
+    expect(prompts).toEqual([
+      "Opening support desk scene with Maya and a refund dashboard",
+      "A refund dashboard filtered to discounted orders with one outlier row highlighted",
+    ]);
+  });
+
+  test("fills blank prompts with concrete fallbacks", () => {
+    const prompts = getPracticeImagePrompts({
+      scenario: {
+        imagePrompt: "   ",
+        text: "I'm checking one last shipping issue with Leo before the warehouse closes.",
+        title: "Late label",
+      },
+      steps: [
+        {
+          context: "These two labels look almost the same, but the destination scan disagrees.",
+          imagePrompt: "",
+          options: [
+            { feedback: "Yes", isCorrect: true, text: "Match labels" },
+            { feedback: "No", isCorrect: false, text: "Guess city" },
+          ],
+          question: "What should we compare?",
+        },
+      ],
+    });
+
+    expect(prompts[0]).toContain("Short scene label: Late label.");
+    expect(prompts[0]).toContain(
+      "Situation: I'm checking one last shipping issue with Leo before the warehouse closes.",
+    );
+    expect(prompts[1]).toContain("Dialogue: These two labels look almost the same");
+    expect(prompts[1]).toContain("Question: What should we compare?");
+    expect(prompts[1]).toContain("Possible actions: Match labels, Guess city.");
+  });
+});

--- a/apps/api/src/workflows/activity-generation/steps/_utils/get-practice-image-prompts.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/get-practice-image-prompts.ts
@@ -1,0 +1,97 @@
+import { type PracticeScenario, type PracticeStep } from "../generate-practice-content-step";
+
+/**
+ * Practice is now image-led, so every scenario and decision step needs an
+ * image prompt. The AI should author these directly, but this helper fills in
+ * a concrete fallback when one prompt comes back blank so we can still render
+ * a usable scene instead of failing on a soft-authoring miss.
+ */
+function getPromptOrFallback({ fallback, prompt }: { fallback: string; prompt: string }) {
+  const trimmedPrompt = prompt.trim();
+
+  if (trimmedPrompt) {
+    return trimmedPrompt;
+  }
+
+  return fallback;
+}
+
+/**
+ * Fallback prompts read better when reused learner copy becomes a clean
+ * sentence. This keeps punctuation from stacking when the authored text
+ * already ends with `.`, `?`, or `!`.
+ */
+function toSentence(value: string) {
+  const trimmedValue = value.trim();
+
+  if (!trimmedValue) {
+    return trimmedValue;
+  }
+
+  if (/[.!?]$/.test(trimmedValue)) {
+    return trimmedValue;
+  }
+
+  return `${trimmedValue}.`;
+}
+
+/**
+ * The opening scenario image should establish the place, the recurring partner,
+ * and the problem the learner is stepping into before the first decision.
+ */
+function getScenarioFallbackPrompt({ scenario }: { scenario: PracticeScenario }) {
+  return [
+    "Show the opening scene for a visual-first practice activity.",
+    `Short scene label: ${toSentence(scenario.title)}`,
+    `Situation: ${toSentence(scenario.text)}`,
+    "Make the main person, the setting, and the practical problem immediately visible.",
+  ].join(" ");
+}
+
+/**
+ * Practice question images should carry the clue, artifact, or state change
+ * the learner needs to inspect. The fallback prompt keeps that evidence tied
+ * to the dialogue, question, and candidate actions when the authored prompt
+ * is missing.
+ */
+function getStepFallbackPrompt({ step }: { step: PracticeStep }) {
+  const optionSummary = step.options
+    .map((option) => option.text.trim())
+    .filter(Boolean)
+    .join(", ");
+
+  return [
+    "Show the key evidence for this practice decision.",
+    step.context ? `Dialogue: ${toSentence(step.context)}` : "",
+    `Question: ${toSentence(step.question)}`,
+    optionSummary ? `Possible actions: ${toSentence(optionSummary)}` : "",
+    "Use a concrete artifact, screen, document, diagram, label, or scene clue the learner can inspect.",
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+/**
+ * Returns one image prompt per persisted practice step: scenario first, then
+ * one prompt for each question step in visible order.
+ */
+export function getPracticeImagePrompts({
+  scenario,
+  steps,
+}: {
+  scenario: PracticeScenario;
+  steps: PracticeStep[];
+}) {
+  return [
+    getPromptOrFallback({
+      fallback: getScenarioFallbackPrompt({ scenario }),
+      prompt: scenario.imagePrompt,
+    }),
+    ...steps.map((step) =>
+      getPromptOrFallback({
+        fallback: getStepFallbackPrompt({ step }),
+        prompt: step.imagePrompt,
+      }),
+    ),
+  ];
+}

--- a/apps/api/src/workflows/activity-generation/steps/_utils/get-practice-image-prompts.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/get-practice-image-prompts.ts
@@ -1,74 +1,18 @@
 import { type PracticeScenario, type PracticeStep } from "../generate-practice-content-step";
 
 /**
- * Practice is now image-led, so every scenario and decision step needs an
- * image prompt. The AI should author these directly, but this helper fills in
- * a concrete fallback when one prompt comes back blank so we can still render
- * a usable scene instead of failing on a soft-authoring miss.
+ * Practice image prompts are required AI output. This helper only preserves
+ * the persisted step order and trims whitespace; it fails fast when a prompt
+ * is missing so the workflow does not invent fallback scenes prelaunch.
  */
-function getPromptOrFallback({ fallback, prompt }: { fallback: string; prompt: string }) {
+function getRequiredPrompt({ label, prompt }: { label: string; prompt: string }) {
   const trimmedPrompt = prompt.trim();
 
-  if (trimmedPrompt) {
-    return trimmedPrompt;
+  if (!trimmedPrompt) {
+    throw new Error(`Missing practice image prompt for ${label}`);
   }
 
-  return fallback;
-}
-
-/**
- * Fallback prompts read better when reused learner copy becomes a clean
- * sentence. This keeps punctuation from stacking when the authored text
- * already ends with `.`, `?`, or `!`.
- */
-function toSentence(value: string) {
-  const trimmedValue = value.trim();
-
-  if (!trimmedValue) {
-    return trimmedValue;
-  }
-
-  if (/[.!?]$/.test(trimmedValue)) {
-    return trimmedValue;
-  }
-
-  return `${trimmedValue}.`;
-}
-
-/**
- * The opening scenario image should establish the place, the recurring partner,
- * and the problem the learner is stepping into before the first decision.
- */
-function getScenarioFallbackPrompt({ scenario }: { scenario: PracticeScenario }) {
-  return [
-    "Show the opening scene for a visual-first practice activity.",
-    `Short scene label: ${toSentence(scenario.title)}`,
-    `Situation: ${toSentence(scenario.text)}`,
-    "Make the main person, the setting, and the practical problem immediately visible.",
-  ].join(" ");
-}
-
-/**
- * Practice question images should carry the clue, artifact, or state change
- * the learner needs to inspect. The fallback prompt keeps that evidence tied
- * to the dialogue, question, and candidate actions when the authored prompt
- * is missing.
- */
-function getStepFallbackPrompt({ step }: { step: PracticeStep }) {
-  const optionSummary = step.options
-    .map((option) => option.text.trim())
-    .filter(Boolean)
-    .join(", ");
-
-  return [
-    "Show the key evidence for this practice decision.",
-    step.context ? `Dialogue: ${toSentence(step.context)}` : "",
-    `Question: ${toSentence(step.question)}`,
-    optionSummary ? `Possible actions: ${toSentence(optionSummary)}` : "",
-    "Use a concrete artifact, screen, document, diagram, label, or scene clue the learner can inspect.",
-  ]
-    .filter(Boolean)
-    .join(" ");
+  return trimmedPrompt;
 }
 
 /**
@@ -83,13 +27,13 @@ export function getPracticeImagePrompts({
   steps: PracticeStep[];
 }) {
   return [
-    getPromptOrFallback({
-      fallback: getScenarioFallbackPrompt({ scenario }),
+    getRequiredPrompt({
+      label: "scenario",
       prompt: scenario.imagePrompt,
     }),
-    ...steps.map((step) =>
-      getPromptOrFallback({
-        fallback: getStepFallbackPrompt({ step }),
+    ...steps.map((step, index) =>
+      getRequiredPrompt({
+        label: `step ${index + 1}`,
         prompt: step.imagePrompt,
       }),
     ),

--- a/apps/api/src/workflows/activity-generation/steps/generate-activity-step-images-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-activity-step-images-step.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test, vi } from "vitest";
+import { generateActivityStepImagesStep } from "./generate-activity-step-images-step";
+import { type LessonActivity } from "./get-lesson-activities-step";
+
+const { generateStepImagesMock, statusMock } = vi.hoisted(() => ({
+  generateStepImagesMock: vi.fn(),
+  statusMock: vi.fn().mockImplementation(async () => {}),
+}));
+
+vi.mock("@/workflows/_shared/stream-status", () => ({
+  createEntityStepStream: vi.fn().mockImplementation(() => ({
+    [Symbol.asyncDispose]: vi.fn().mockImplementation(async () => {}),
+    error: vi.fn().mockImplementation(async () => {}),
+    status: statusMock,
+  })),
+}));
+
+vi.mock("./_utils/generate-step-images", () => ({
+  generateStepImages: generateStepImagesMock,
+}));
+
+function makeActivity(kind: LessonActivity["kind"]): LessonActivity {
+  return {
+    id: "activity-1",
+    kind,
+    language: "pt",
+    lesson: {
+      chapter: {
+        course: {
+          organization: {
+            slug: "ai-org",
+          },
+        },
+      },
+    },
+  } as LessonActivity;
+}
+
+describe(generateActivityStepImagesStep, () => {
+  test("uses the practice image preset for practice activities", async () => {
+    generateStepImagesMock.mockResolvedValueOnce([
+      { prompt: "Prompt 1", url: "https://example.com/practice.webp" },
+    ]);
+
+    const result = await generateActivityStepImagesStep(makeActivity("practice"), ["Prompt 1"]);
+
+    expect(result).toEqual({
+      images: [{ prompt: "Prompt 1", url: "https://example.com/practice.webp" }],
+    });
+    expect(generateStepImagesMock).toHaveBeenCalledWith({
+      language: "pt",
+      orgSlug: "ai-org",
+      preset: "practice",
+      prompts: ["Prompt 1"],
+    });
+  });
+
+  test("uses the illustration preset for non-practice activities", async () => {
+    generateStepImagesMock.mockResolvedValueOnce([
+      { prompt: "Prompt 1", url: "https://example.com/illustration.webp" },
+    ]);
+
+    await generateActivityStepImagesStep(makeActivity("explanation"), ["Prompt 1"]);
+
+    expect(generateStepImagesMock).toHaveBeenCalledWith({
+      language: "pt",
+      orgSlug: "ai-org",
+      preset: "illustration",
+      prompts: ["Prompt 1"],
+    });
+  });
+});

--- a/apps/api/src/workflows/activity-generation/steps/generate-activity-step-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-activity-step-images-step.ts
@@ -1,15 +1,26 @@
 import { createEntityStepStream } from "@/workflows/_shared/stream-status";
+import { type StepContentImagePreset } from "@zoonk/core/steps/content-image";
 import { type StepImage } from "@zoonk/core/steps/contract/image";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { generateStepImages } from "./_utils/generate-step-images";
 import { type LessonActivity } from "./get-lesson-activities-step";
 
 /**
- * Explanation activities create one uploaded illustration per readable step.
- * This workflow step keeps the per-entity stream around the expensive image
- * generation work.
+ * Several activity kinds now persist one uploaded image per learner-visible
+ * step. This shared workflow step keeps the expensive image generation work in
+ * one place so explanation and practice activities stream the same progress
+ * events and use the same upload pipeline while still choosing the right
+ * image-generation preset for each activity kind.
  */
-export async function generateExplanationStepImagesStep(
+function getImagePresetForActivity(activity: LessonActivity): StepContentImagePreset {
+  if (activity.kind === "practice") {
+    return "practice";
+  }
+
+  return "illustration";
+}
+
+export async function generateActivityStepImagesStep(
   activity: LessonActivity,
   prompts: string[],
 ): Promise<{ images: StepImage[] }> {
@@ -26,6 +37,7 @@ export async function generateExplanationStepImagesStep(
   const images = await generateStepImages({
     language: activity.language,
     orgSlug: activity.lesson.chapter.course.organization?.slug,
+    preset: getImagePresetForActivity(activity),
     prompts,
   });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-practice-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-practice-content-step.test.ts
@@ -33,6 +33,7 @@ vi.mock("@zoonk/ai/tasks/activities/core/practice", () => ({
 }));
 
 const practiceScenario = {
+  imagePrompt: "Opening support desk scene with Maya and a refund dashboard",
   text: "I'm closing the support queue with Maya, and one customer report still does not line up with the refund totals.",
   title: "Night shift",
 };
@@ -78,6 +79,8 @@ describe(generatePracticeContentStep, () => {
     const practiceSteps = [
       {
         context: "Context 1",
+        imagePrompt:
+          "A refund dashboard filtered to discounted orders with one outlier row highlighted",
         options: [
           { feedback: "Correct!", isCorrect: true, text: "A" },
           { feedback: "Wrong", isCorrect: false, text: "B" },
@@ -240,6 +243,7 @@ describe(generatePracticeContentStep, () => {
         steps: [
           {
             context: "ctx",
+            imagePrompt: "A support dashboard with one suspicious refund highlighted",
             options: [{ feedback: "f", isCorrect: true, text: "t" }],
             question: "q",
           },

--- a/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.test.ts
@@ -25,6 +25,7 @@ vi.mock("workflow", () => ({
 }));
 
 const practiceScenario = {
+  imagePrompt: "Opening support desk scene with Maya and a refund dashboard",
   text: "I'm closing the support queue with Maya, and one customer report still does not line up with the refund totals.",
   title: "Night shift",
 };
@@ -49,6 +50,21 @@ describe(savePracticeActivityStep, () => {
     vi.clearAllMocks();
   });
 
+  const practiceImages = [
+    {
+      prompt: "Opening support desk scene with Maya and a refund dashboard",
+      url: "https://example.com/practice-scenario.webp",
+    },
+    {
+      prompt: "A refund dashboard filtered to discounted orders with one outlier row highlighted",
+      url: "https://example.com/practice-step-1.webp",
+    },
+    {
+      prompt: "A spreadsheet comparing manual discounts against refund totals",
+      url: "https://example.com/practice-step-2.webp",
+    },
+  ];
+
   test("saves multipleChoice steps and marks activity as completed", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
@@ -68,6 +84,8 @@ describe(savePracticeActivityStep, () => {
     const steps: PracticeStep[] = [
       {
         context: "Context for question 1",
+        imagePrompt:
+          "A refund dashboard filtered to discounted orders with one outlier row highlighted",
         options: [
           { feedback: "Correct!", isCorrect: true, text: "Option A" },
           { feedback: "Incorrect.", isCorrect: false, text: "Option B" },
@@ -78,6 +96,7 @@ describe(savePracticeActivityStep, () => {
       },
       {
         context: "Context for question 2",
+        imagePrompt: "A spreadsheet comparing manual discounts against refund totals",
         options: [
           { feedback: "Incorrect.", isCorrect: false, text: "Option A" },
           { feedback: "Correct!", isCorrect: true, text: "Option B" },
@@ -90,6 +109,7 @@ describe(savePracticeActivityStep, () => {
 
     await savePracticeActivityStep({
       activityId: activity.id,
+      images: practiceImages,
       scenario: practiceScenario,
       steps,
       title: "The game store signup mix-up",
@@ -115,9 +135,36 @@ describe(savePracticeActivityStep, () => {
     ]);
 
     expect(dbSteps[0]?.content).toEqual({
+      image: practiceImages[0],
       text: practiceScenario.text,
       title: practiceScenario.title,
       variant: "text",
+    });
+
+    expect(dbSteps[1]?.content).toEqual({
+      context: "Context for question 1",
+      image: practiceImages[1],
+      kind: "core",
+      options: [
+        { feedback: "Correct!", isCorrect: true, text: "Option A" },
+        { feedback: "Incorrect.", isCorrect: false, text: "Option B" },
+        { feedback: "Incorrect.", isCorrect: false, text: "Option C" },
+        { feedback: "Incorrect.", isCorrect: false, text: "Option D" },
+      ],
+      question: steps[0]?.question,
+    });
+
+    expect(dbSteps[2]?.content).toEqual({
+      context: "Context for question 2",
+      image: practiceImages[2],
+      kind: "core",
+      options: [
+        { feedback: "Incorrect.", isCorrect: false, text: "Option A" },
+        { feedback: "Correct!", isCorrect: true, text: "Option B" },
+        { feedback: "Incorrect.", isCorrect: false, text: "Option C" },
+        { feedback: "Incorrect.", isCorrect: false, text: "Option D" },
+      ],
+      question: steps[1]?.question,
     });
 
     expect(dbActivity).toMatchObject({
@@ -129,11 +176,17 @@ describe(savePracticeActivityStep, () => {
     const events = getStreamedEvents(writeMock);
 
     expect(events).toContainEqual(
-      expect.objectContaining({ status: "started", step: "savePracticeActivity" }),
+      expect.objectContaining({
+        status: "started",
+        step: "savePracticeActivity",
+      }),
     );
 
     expect(events).toContainEqual(
-      expect.objectContaining({ status: "completed", step: "savePracticeActivity" }),
+      expect.objectContaining({
+        status: "completed",
+        step: "savePracticeActivity",
+      }),
     );
   });
 
@@ -159,6 +212,7 @@ describe(savePracticeActivityStep, () => {
     const steps: PracticeStep[] = [
       {
         context: "Context",
+        imagePrompt: "A dashboard with one highlighted mismatch",
         options: [
           { feedback: "Correct!", isCorrect: true, text: "Option A" },
           { feedback: "Incorrect.", isCorrect: false, text: "Option B" },
@@ -171,6 +225,7 @@ describe(savePracticeActivityStep, () => {
 
     await savePracticeActivityStep({
       activityId: activity.id,
+      images: practiceImages.slice(0, 2),
       scenario: practiceScenario,
       steps,
       title: "The game store signup mix-up",
@@ -180,7 +235,10 @@ describe(savePracticeActivityStep, () => {
     const events = getStreamedEvents(writeMock);
 
     expect(events).toContainEqual(
-      expect.objectContaining({ status: "error", step: "savePracticeActivity" }),
+      expect.objectContaining({
+        status: "error",
+        step: "savePracticeActivity",
+      }),
     );
   });
 });

--- a/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.test.ts
@@ -176,17 +176,11 @@ describe(savePracticeActivityStep, () => {
     const events = getStreamedEvents(writeMock);
 
     expect(events).toContainEqual(
-      expect.objectContaining({
-        status: "started",
-        step: "savePracticeActivity",
-      }),
+      expect.objectContaining({ status: "started", step: "savePracticeActivity" }),
     );
 
     expect(events).toContainEqual(
-      expect.objectContaining({
-        status: "completed",
-        step: "savePracticeActivity",
-      }),
+      expect.objectContaining({ status: "completed", step: "savePracticeActivity" }),
     );
   });
 
@@ -235,10 +229,7 @@ describe(savePracticeActivityStep, () => {
     const events = getStreamedEvents(writeMock);
 
     expect(events).toContainEqual(
-      expect.objectContaining({
-        status: "error",
-        step: "savePracticeActivity",
-      }),
+      expect.objectContaining({ status: "error", step: "savePracticeActivity" }),
     );
   });
 });

--- a/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.ts
@@ -179,21 +179,14 @@ export async function savePracticeActivityStep({
     prisma.$transaction([
       prisma.step.createMany({ data: stepRecords }),
       prisma.activity.update({
-        data: {
-          generationRunId: workflowRunId,
-          generationStatus: "completed",
-          title,
-        },
+        data: { generationRunId: workflowRunId, generationStatus: "completed", title },
         where: { id: activityId },
       }),
     ]),
   );
 
   if (error) {
-    await stream.error({
-      reason: "dbSaveFailed",
-      step: "savePracticeActivity",
-    });
+    await stream.error({ reason: "dbSaveFailed", step: "savePracticeActivity" });
     await handleActivityFailureStep({ activityId });
     return;
   }

--- a/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.ts
@@ -1,5 +1,6 @@
 import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { assertStepContent } from "@zoonk/core/steps/contract/content";
+import { type StepImage } from "@zoonk/core/steps/contract/image";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
@@ -7,20 +8,52 @@ import { type PracticeScenario, type PracticeStep } from "./generate-practice-co
 import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
+ * Practice now saves one image for the opening scenario plus one image for
+ * each multiple-choice question. Keeping that split explicit makes it obvious
+ * which uploaded file belongs to which persisted step and fails early if the
+ * workflow generated the wrong number of images.
+ */
+function splitPracticeImages({
+  images,
+  questionCount,
+}: {
+  images: StepImage[];
+  questionCount: number;
+}) {
+  const expectedImageCount = questionCount + 1;
+
+  if (images.length !== expectedImageCount) {
+    throw new Error("Generated image count does not match practice step count");
+  }
+
+  const [scenarioImage, ...questionImages] = images;
+
+  if (!scenarioImage) {
+    throw new Error("Practice scenario image is missing");
+  }
+
+  return { questionImages, scenarioImage };
+}
+
+/**
  * Practice activities now open with a static scenario screen so the player can
  * reuse the generic static-step renderer instead of learning a practice-only
- * intro shape.
+ * intro shape. That intro also carries the first generated scene image so the
+ * learner starts with a visual setup instead of a text wall.
  */
 function buildPracticeScenarioRecord({
   activityId,
+  image,
   scenario,
 }: {
   activityId: string;
+  image: StepImage;
   scenario: PracticeScenario;
 }) {
   return {
     activityId,
     content: assertStepContent("static", {
+      image,
       text: scenario.text,
       title: scenario.title,
       variant: "text" as const,
@@ -34,18 +67,28 @@ function buildPracticeScenarioRecord({
 /**
  * Practice questions stay as the existing `multipleChoice` core steps. Their
  * positions start after the static scenario so navigation and completion stay
- * aligned with the visible player order.
+ * aligned with the visible player order, while each question owns its own
+ * artifact image inside the same step content.
  */
 function buildPracticeQuestionRecords({
   activityId,
+  images,
   steps,
 }: {
   activityId: string;
+  images: StepImage[];
   steps: PracticeStep[];
 }) {
   return steps.map((step, index) => {
+    const image = images[index];
+
+    if (!image) {
+      throw new Error("Practice question image is missing");
+    }
+
     const content = assertStepContent("multipleChoice", {
       context: step.context,
+      image,
       kind: "core",
       options: step.options,
       question: step.question,
@@ -68,16 +111,27 @@ function buildPracticeQuestionRecords({
  */
 function buildPracticeStepRecords({
   activityId,
+  images,
   scenario,
   steps,
 }: {
   activityId: string;
+  images: StepImage[];
   scenario: PracticeScenario;
   steps: PracticeStep[];
 }) {
+  const { questionImages, scenarioImage } = splitPracticeImages({
+    images,
+    questionCount: steps.length,
+  });
+
   return [
-    buildPracticeScenarioRecord({ activityId, scenario }),
-    ...buildPracticeQuestionRecords({ activityId, steps }),
+    buildPracticeScenarioRecord({ activityId, image: scenarioImage, scenario }),
+    ...buildPracticeQuestionRecords({
+      activityId,
+      images: questionImages,
+      steps,
+    }),
   ];
 }
 
@@ -89,12 +143,14 @@ function buildPracticeStepRecords({
  */
 export async function savePracticeActivityStep({
   activityId,
+  images,
   scenario,
   steps,
   title,
   workflowRunId,
 }: {
   activityId: string;
+  images: StepImage[];
   scenario: PracticeScenario;
   steps: PracticeStep[];
   title: string;
@@ -106,20 +162,38 @@ export async function savePracticeActivityStep({
 
   await stream.status({ status: "started", step: "savePracticeActivity" });
 
-  const stepRecords = buildPracticeStepRecords({ activityId, scenario, steps });
+  const { data: stepRecords, error: buildError } = await safeAsync(async () =>
+    buildPracticeStepRecords({ activityId, images, scenario, steps }),
+  );
+
+  if (buildError || !stepRecords) {
+    await stream.error({
+      reason: "dbSaveFailed",
+      step: "savePracticeActivity",
+    });
+    await handleActivityFailureStep({ activityId });
+    return;
+  }
 
   const { error } = await safeAsync(() =>
     prisma.$transaction([
       prisma.step.createMany({ data: stepRecords }),
       prisma.activity.update({
-        data: { generationRunId: workflowRunId, generationStatus: "completed", title },
+        data: {
+          generationRunId: workflowRunId,
+          generationStatus: "completed",
+          title,
+        },
         where: { id: activityId },
       }),
     ]),
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "savePracticeActivity" });
+    await stream.error({
+      reason: "dbSaveFailed",
+      step: "savePracticeActivity",
+    });
     await handleActivityFailureStep({ activityId });
     return;
   }

--- a/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.ts
@@ -167,10 +167,7 @@ export async function savePracticeActivityStep({
   );
 
   if (buildError || !stepRecords) {
-    await stream.error({
-      reason: "dbSaveFailed",
-      step: "savePracticeActivity",
-    });
+    await stream.error({ reason: "dbSaveFailed", step: "savePracticeActivity" });
     await handleActivityFailureStep({ activityId });
     return;
   }

--- a/apps/evals/src/tasks/activity-practice/task.ts
+++ b/apps/evals/src/tasks/activity-practice/task.ts
@@ -8,7 +8,7 @@ import { TEST_CASES } from "./test-cases";
 
 export const activityPracticeTask: Task<ActivityPracticeParams, ActivityPracticeSchema> = {
   description:
-    "Generate a practice activity where learners solve problems through dialogue with a colleague",
+    "Generate a visual-first practice activity where learners solve real problems with a colleague",
   generate: generateActivityPractice,
   id: "activity-practice",
   name: "Activity Practice",

--- a/apps/evals/src/tasks/activity-practice/test-cases.ts
+++ b/apps/evals/src/tasks/activity-practice/test-cases.ts
@@ -3,29 +3,32 @@ EVALUATION CRITERIA:
 
 1. PRACTICE AUTHENTICITY: Dialogue must be pure conversation between colleagues with no narrator text, no character name prefixes (like "Sarah:"), and no action descriptions. The learner should feel immersed in a real workplace conversation.
 
-2. EDUCATIONAL ALIGNMENT: Every decision point must require applying lesson concepts through reasoning, not memorizing facts. Wrong options should be plausible but flawed for specific conceptual reasons. Penalize meta-scenarios where the main action is preparing a presentation, poster, cartaz, slogan, summary, or wording about the lesson topic instead of using the concept in a real situation.
+2. VISUAL GROUNDING: Every scenario and every step should include an imagePrompt that gives useful evidence, not decoration. The image should help the learner reason about the decision through an artifact, screen, diagram, label, table, document, or concrete scene clue. Penalize generic image prompts that add no value.
 
-3. PLOT COHERENCE: Steps must flow naturally as a continuous practice where each step builds from the previous dialogue. Near the end (within the final 2-3 steps), the practice should introduce a fun, surprising twist that reframes the narrative — the best twists subvert an assumption the practice has been building. A mere escalation or a new requirement from a teacher, boss, or client is not enough to count as a twist. Strong twists usually reinterpret earlier details rather than just adding a late surprise. The final step must resolve the problem AND reinforce the main learning takeaway. Do NOT penalize for exact twist placement (e.g., 2nd-to-last vs 3rd-to-last) as long as the narrative flow is good.
+3. EDUCATIONAL ALIGNMENT: Every decision point must require applying lesson concepts through reasoning, not memorizing facts. Wrong options should be plausible but flawed for specific conceptual reasons. Penalize meta-scenarios where the main action is preparing a presentation, poster, cartaz, slogan, summary, or wording about the lesson topic instead of using the concept in a real situation.
 
-4. FORMAT COMPLIANCE: Verify these constraints:
-   - scenario.title: 1-3 words
-   - scenario.text: Maximum 300 characters, one short paragraph, first person
-   - context: Maximum 500 characters of pure dialogue
-   - question: Maximum 100 characters
-   - options: Exactly 4 objects, each with: text (max 50 chars, allow up to 55 without penalty), isCorrect (boolean), feedback (max 300 chars)
-   - Exactly 1 option must have isCorrect: true, the other 3 must have isCorrect: false
+4. PLOT COHERENCE: Steps must flow naturally as a continuous practice where each step builds from the previous dialogue. Near the end (within the final 2-3 steps), the practice should introduce a fun, surprising twist that reframes the narrative — the best twists subvert an assumption the practice has been building. A mere escalation or a new requirement from a teacher, boss, or client is not enough to count as a twist. Strong twists usually reinterpret earlier details rather than just adding a late surprise. The final step must resolve the problem AND reinforce the main learning takeaway. Do NOT penalize for exact twist placement (e.g., 2nd-to-last vs 3rd-to-last) as long as the narrative flow is good.
+
+5. FORMAT COMPLIANCE: Verify these constraints:
+   - scenario has: title, text, imagePrompt
+   - every step has: imagePrompt, context, question, options
+   - scenario.text is first person and short
+   - context is pure dialogue and should stay short enough to scan quickly
+   - question should be short and direct
+   - option text should usually be short and action-like
+   - Exactly 1 option must have isCorrect: true
    - The recurring person or situation introduced in scenario.text should stay consistent across the dialogue unless the story deliberately reveals a reason for the change
    - Do NOT penalize for output being wrapped in {"steps": [...]} vs a raw array — both are valid formats
 
-5. PERSONALIZATION: The {{NAME}} placeholder must be used appropriately in dialogue to personalize the experience.
+6. PERSONALIZATION: The {{NAME}} placeholder must be used appropriately in dialogue to personalize the experience.
 
-6. FEEDBACK QUALITY: Each option must have feedback explaining WHY it's right (with insight) or WHY it's wrong (and what would be correct). Feedback should help learners understand the reasoning, not just state correctness.
+7. FEEDBACK QUALITY: Each option must have feedback explaining WHY it's right (with insight) or WHY it's wrong (and what would be correct). Feedback should help learners understand the reasoning, not just state correctness.
 
-7. STEP COUNT: Practice must have between 7 and 20 steps. Let problem complexity dictate length.
+8. STEP COUNT: Practice should usually have between 7 and 20 steps. Let problem complexity dictate length. Do not over-penalize a small miss if the activity is otherwise strong.
 
-8. DISTRACTOR QUALITY: All wrong options must be plausible choices someone might consider. Do not penalize light humor, playful wording, or a mildly funny option if it is still believable in the scene. Penalize distractors that are so silly or absurd that no reasonable person would choose them.
+9. DISTRACTOR QUALITY: All wrong options must be plausible choices someone might consider. Do not penalize light humor, playful wording, or a mildly funny option if it is still believable in the scene. Penalize distractors that are so silly or absurd that no reasonable person would choose them.
 
-9. DIALOGUE NATURALNESS: Penalize dialogue that sounds like prompt residue, coaching language, polished writing advice, or translated corporate speech instead of something a real person in the scene would say. This includes lines that comment on how a question or sentence sounds rather than moving the scene forward. Examples of suspicious phrasing include things like "great question", "honestly", "without sounding rehearsed", "How do I say that without sounding awkward?", "What wording works better?", or local-language equivalents of that same delivery-focused wording when they feel copied from instructions rather than motivated by the scene. Also penalize dialogue that announces the story structure with labels like "twist", "plot twist", "big reveal", or local-language equivalents instead of letting the surprise happen naturally. Do not penalize light humor, playful exchanges, or a mildly silly twist when they still feel natural for the scene.
+10. DIALOGUE NATURALNESS: Penalize dialogue that sounds like prompt residue, coaching language, polished writing advice, or translated corporate speech instead of something a real person in the scene would say. This includes lines that comment on how a question or sentence sounds rather than moving the scene forward. Examples of suspicious phrasing include things like "great question", "honestly", "without sounding rehearsed", "How do I say that without sounding awkward?", "What wording works better?", or local-language equivalents of that same delivery-focused wording when they feel copied from instructions rather than motivated by the scene. Also penalize dialogue that announces the story structure with labels like "twist", "plot twist", "big reveal", or local-language equivalents instead of letting the surprise happen naturally. Do not penalize light humor, playful exchanges, or a mildly silly twist when they still feel natural for the scene.
 
 ANTI-CHECKLIST GUIDANCE (CRITICAL):
 - Do NOT penalize for specific plot choices, character names, or scenario settings you might expect
@@ -33,11 +36,13 @@ ANTI-CHECKLIST GUIDANCE (CRITICAL):
 - Do NOT check against an imagined "ideal" practice structure
 - Do NOT penalize for exact twist placement — if the twist occurs anywhere in the final third of the story, that's fine
 - Do NOT penalize for output being wrapped in {"steps": [...]} instead of a raw array
-- Do NOT penalize option text that is 55 characters or fewer — only penalize options clearly exceeding 55 characters
+- Do NOT penalize a small overrun on text length if the step is still fast and readable
+- Do NOT penalize 3-5 options if the step quality stays high and there is no filler
 - Do NOT penalize light humor, a playful tone, or slightly silly moments when they still sound natural and scene-appropriate
 - Do penalize scenes whose main task is choosing wording, polishing phrasing, or presenting the concept instead of using it
+- Do penalize image prompts that are generic decoration instead of useful evidence
 - Do penalize lines that feel like prompt instructions leaking into dialogue, even if grammar and structure are otherwise correct
-- ONLY penalize for: format violations (option text over 55 chars, context over 500 chars, etc.), narrator/description text in dialogue, decisions that test memorization instead of reasoning, complete absence of any twist or surprise, poor distractor quality, or factually incorrect lesson application
+- ONLY penalize for: major format violations, missing or low-value image prompts, narrator/description text in dialogue, decisions that test memorization instead of reasoning, complete absence of any twist or surprise, poor distractor quality, or factually incorrect lesson application
 - Different valid practice approaches exist - assess the quality of what IS provided
 `;
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -2827,14 +2827,14 @@ msgid "{activity} - {lesson}"
 msgstr "{activity} - {lesson}"
 
 #: src/lib/activities.ts
+msgctxt "wHBT6R"
+msgid "Apply {topic} through a visual real-world problem with short decisions."
+msgstr "Apply {topic} through a visual real-world problem with short decisions."
+
+#: src/lib/activities.ts
 msgctxt "XzxpBZ"
 msgid "Improve your {topic} reading comprehension by translating sentences and passages."
 msgstr "Improve your {topic} reading comprehension by translating sentences and passages."
-
-#: src/lib/activities.ts
-msgctxt "YfgUQS"
-msgid "Apply {topic} through a real-world dialogue scenario."
-msgstr "Apply {topic} through a real-world dialogue scenario."
 
 #: src/lib/categories/category.ts
 msgctxt "4HKnmB"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -2827,14 +2827,14 @@ msgid "{activity} - {lesson}"
 msgstr "{activity} - {lesson}"
 
 #: src/lib/activities.ts
+msgctxt "wHBT6R"
+msgid "Apply {topic} through a visual real-world problem with short decisions."
+msgstr "Aplica {topic} mediante un problema visual del mundo real con decisiones cortas."
+
+#: src/lib/activities.ts
 msgctxt "XzxpBZ"
 msgid "Improve your {topic} reading comprehension by translating sentences and passages."
 msgstr "Mejora tu comprensión de lectura en {topic} traduciendo oraciones y pasajes."
-
-#: src/lib/activities.ts
-msgctxt "YfgUQS"
-msgid "Apply {topic} through a real-world dialogue scenario."
-msgstr "Aplica {topic} a través de un escenario de diálogo del mundo real."
 
 #: src/lib/categories/category.ts
 msgctxt "4HKnmB"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -2827,14 +2827,14 @@ msgid "{activity} - {lesson}"
 msgstr "{activity} - {lesson}"
 
 #: src/lib/activities.ts
+msgctxt "wHBT6R"
+msgid "Apply {topic} through a visual real-world problem with short decisions."
+msgstr "Aplique {topic} por meio de um problema visual do mundo real com decisões curtas."
+
+#: src/lib/activities.ts
 msgctxt "XzxpBZ"
 msgid "Improve your {topic} reading comprehension by translating sentences and passages."
 msgstr "Melhore sua compreensão de leitura em {topic} traduzindo frases e passagens."
-
-#: src/lib/activities.ts
-msgctxt "YfgUQS"
-msgid "Apply {topic} through a real-world dialogue scenario."
-msgstr "Aplique {topic} através de um cenário de diálogo do mundo real."
 
 #: src/lib/categories/category.ts
 msgctxt "4HKnmB"

--- a/apps/main/src/lib/activities.ts
+++ b/apps/main/src/lib/activities.ts
@@ -38,7 +38,9 @@ async function getSeoDescription(kind: ActivityKind, topic: string): Promise<str
   const t = await getExtracted();
 
   const descriptions: Record<ActivityKind, string> = {
-    custom: t("Learn about {topic} through an interactive activity.", { topic }),
+    custom: t("Learn about {topic} through an interactive activity.", {
+      topic,
+    }),
     explanation: t(
       "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies.",
       { topic },
@@ -54,7 +56,9 @@ async function getSeoDescription(kind: ActivityKind, topic: string): Promise<str
     listening: t("Sharpen your {topic} listening skills by translating audio sentences.", {
       topic,
     }),
-    practice: t("Apply {topic} through a real-world dialogue scenario.", { topic }),
+    practice: t("Apply {topic} through a visual real-world problem with short decisions.", {
+      topic,
+    }),
     quiz: t(
       "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization.",
       { topic },
@@ -79,7 +83,11 @@ async function getSeoDescription(kind: ActivityKind, topic: string): Promise<str
 }
 
 export async function getActivitySeoMeta(
-  activity: { kind: ActivityKind; title: string | null; description: string | null },
+  activity: {
+    kind: ActivityKind;
+    title: string | null;
+    description: string | null;
+  },
   lessonTitle: string,
 ): Promise<{ title: string; description: string }> {
   const [title, description] = await Promise.all([
@@ -97,14 +105,20 @@ async function getSeoTitle(
   const t = await getExtracted();
 
   if (activity.title) {
-    return t("{activity} - {lesson}", { activity: activity.title, lesson: lessonTitle });
+    return t("{activity} - {lesson}", {
+      activity: activity.title,
+      lesson: lessonTitle,
+    });
   }
 
   const kinds = await getActivityKinds();
   const kindInfo = kinds.find((kind) => kind.key === activity.kind);
 
   if (kindInfo) {
-    return t("{lesson} {activity}", { activity: kindInfo.label, lesson: lessonTitle });
+    return t("{lesson} {activity}", {
+      activity: kindInfo.label,
+      lesson: lessonTitle,
+    });
   }
 
   return lessonTitle;

--- a/apps/main/src/lib/activities.ts
+++ b/apps/main/src/lib/activities.ts
@@ -38,9 +38,7 @@ async function getSeoDescription(kind: ActivityKind, topic: string): Promise<str
   const t = await getExtracted();
 
   const descriptions: Record<ActivityKind, string> = {
-    custom: t("Learn about {topic} through an interactive activity.", {
-      topic,
-    }),
+    custom: t("Learn about {topic} through an interactive activity.", { topic }),
     explanation: t(
       "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies.",
       { topic },
@@ -83,11 +81,7 @@ async function getSeoDescription(kind: ActivityKind, topic: string): Promise<str
 }
 
 export async function getActivitySeoMeta(
-  activity: {
-    kind: ActivityKind;
-    title: string | null;
-    description: string | null;
-  },
+  activity: { kind: ActivityKind; title: string | null; description: string | null },
   lessonTitle: string,
 ): Promise<{ title: string; description: string }> {
   const [title, description] = await Promise.all([
@@ -105,20 +99,14 @@ async function getSeoTitle(
   const t = await getExtracted();
 
   if (activity.title) {
-    return t("{activity} - {lesson}", {
-      activity: activity.title,
-      lesson: lessonTitle,
-    });
+    return t("{activity} - {lesson}", { activity: activity.title, lesson: lessonTitle });
   }
 
   const kinds = await getActivityKinds();
   const kindInfo = kinds.find((kind) => kind.key === activity.kind);
 
   if (kindInfo) {
-    return t("{lesson} {activity}", {
-      activity: kindInfo.label,
-      lesson: lessonTitle,
-    });
+    return t("{lesson} {activity}", { activity: kindInfo.label, lesson: lessonTitle });
   }
 
   return lessonTitle;

--- a/apps/main/src/lib/generation/activity-generation-phase-weights.ts
+++ b/apps/main/src/lib/generation/activity-generation-phase-weights.ts
@@ -128,10 +128,11 @@ export function getPhaseWeights(kind: ActivityKind): Record<PhaseName, number> {
   if (kind === "practice") {
     return {
       ...ZERO_WEIGHTS,
+      creatingImages: 25,
       gettingStarted: 5,
       saving: 5,
-      writingContent: 50,
-      writingExplanation: 40,
+      writingContent: 35,
+      writingExplanation: 30,
     };
   }
 

--- a/apps/main/src/lib/generation/phase-kind-steps/practice.ts
+++ b/apps/main/src/lib/generation/phase-kind-steps/practice.ts
@@ -7,9 +7,11 @@ type PracticeSteps =
   | "setActivityAsRunning"
   | "generateExplanationContent"
   | "generatePracticeContent"
+  | "generateStepImages"
   | "savePracticeActivity";
 
 export const PRACTICE_PHASE_STEPS = {
+  creatingImages: ["generateStepImages"],
   gettingStarted: ["getLessonActivities", "setActivityAsRunning"],
   saving: ["savePracticeActivity"],
   writingContent: ["generatePracticeContent"],
@@ -24,5 +26,6 @@ export const PRACTICE_PHASE_ORDER: PhaseName[] = [
   "gettingStarted",
   "writingExplanation",
   "writingContent",
+  "creatingImages",
   "saving",
 ];

--- a/i18n.lock
+++ b/i18n.lock
@@ -247,9 +247,6 @@ checksums:
     All%20pairs%20matched.%20Press%20Check%20to%20continue./singular: 0663e33ba7db53b298c5f50a2f3c7ae8
     Play%20pronunciation/singular: 623289cc3217c5404e3d48a78dd0456f
     Pause%20pronunciation/singular: e24b23e108f8efb6f2eea709e5f540e9
-    Previous%20step/singular: 96b31ec6dab003c2bbfbbca10a8a9826
-    Next%20step/singular: 712c63650b5180cbc14d6246b5d558c2
-    Step%20navigation/singular: ec328f28051577e1c0aab044c89b138c
     Answer%20options/singular: acb0b378cefcb8a8d50a7c43ce77ae39
     Close/singular: 2c2e22f8424a1031de89063bd0022e16
     Activity%20progress/singular: 8ff2fb7372b8a2525f2955c851c4fa42
@@ -735,8 +732,8 @@ checksums:
     Understand%20what%20%7Btopic%7D%20is%20%E2%80%94%20core%20concepts%20and%20definitions%20explained%20with%20clear%20metaphors%20and%20analogies./singular: ec3b49a710ebac5f592523bdaa68ceff
     Practice%20%7Btopic%7D%20grammar%20rules%20with%20exercises%20designed%20to%20help%20you%20remember%20and%20apply%20them./singular: 107adae09992e8b4deb051afa38da3bd
     "%7Bactivity%7D%20-%20%7Blesson%7D/singular": 0aad8d82851f799d79c052a0f2b90d67
+    Apply%20%7Btopic%7D%20through%20a%20visual%20real-world%20problem%20with%20short%20decisions./singular: 999716355d473c7ee9a000c81633da05
     Improve%20your%20%7Btopic%7D%20reading%20comprehension%20by%20translating%20sentences%20and%20passages./singular: 60baac4222f76009cc1eb1b6065b403b
-    Apply%20%7Btopic%7D%20through%20a%20real-world%20dialogue%20scenario./singular: e170c3bd82d42f0972d0f447f10379f0
     "%7Bcategory%7D%20Courses/singular": f82680a650c487992e1025b66f324d4c
     Math/singular: 0a604ffa5ef57408918fe98ef05eb05a
     Explore%20all%20%7Bcategory%7D%20courses/singular: b1f2775c67b4a61b3d92b4345b8b852e

--- a/packages/ai/src/tasks/activities/config.ts
+++ b/packages/ai/src/tasks/activities/config.ts
@@ -1,5 +1,3 @@
-export const ACTIVITY_OPTIONS_COUNT = 4;
-
 export function formatConceptLines(concepts: string[], neighboringConcepts: string[]) {
   return `CONCEPTS: ${concepts.join(", ")}
 NEIGHBORING_CONCEPTS: ${neighboringConcepts.join(", ")}`;

--- a/packages/ai/src/tasks/activities/core/activity-practice.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-practice.prompt.md
@@ -2,9 +2,19 @@
 
 You are creating a **Practice** activity for a learning app.
 
-Your job is to place the learner inside a first-person dialogue where they work with someone else to solve a real problem using the lesson's concepts.
+Your job is to place the learner inside a short, visual-first problem they solve with someone else.
 
-The learner should feel like they are inside a real conversation, not reading a script and not taking a quiz in disguise.
+The activity should feel:
+
+- practical
+- story-driven
+- fast to read
+- lightly playful
+- grounded in a real workplace or real-life situation
+
+The learner should mostly inspect the image, notice what matters, and decide what to do next.
+
+This should feel closer to a great Duolingo story beat than to a quiz with long paragraphs.
 
 # Inputs
 
@@ -20,29 +30,102 @@ The learner should feel like they are inside a real conversation, not reading a 
 - `en`: Use US English unless the content is region-specific
 - `pt`: Use Brazilian Portuguese unless the content is region-specific
 - `es`: Use Latin American Spanish unless the content is region-specific
+- Use English for instruction examples in this prompt unless a non-English example is necessary to show a locale-specific edge case.
 
 ## Naturalness Rules
 
 - Write spoken language for the requested locale, not polished written prose.
 - Prefer short, everyday sentences.
-- The dialogue should sound like two people trying to figure something out together.
-- Keep the tone warm and approachable, but grounded.
+- The partner should sound like a real person trying to solve a real problem with the learner.
+- Keep the concrete details that make the scene feel alive: a messy artifact, a mild annoyance, a recurring quirk, or a useful oddity.
 - Light humor is welcome when it fits naturally.
-- Playful lines, mild exaggeration, and small funny moments are good when they sound like something a real person in this scene would actually say.
-- Do not force quirky or goofy lines just to make the dialogue feel entertaining.
-- Do not echo the prompt inside the dialogue. Never write lines about sounding natural, not sounding scripted, not sounding rehearsed, or similar meta-writing language.
-- Avoid coaching, therapist, or customer-support phrasing unless the situation truly calls for it.
-- Avoid over-validating the learner with lines like "great question", "excellent point", or "honestly" unless that exact phrasing would sound normal for that character in that moment.
-- Do not write dialogue about how a sentence should sound. Avoid lines like "How do I say that without sounding awkward?", "What wording works better?", "How do I make this not sound boring?", "How do I say this without rambling?", or anything else about polishing wording.
-- More generally: do not make the scene about tone-polishing, phrasing, sounding clearer, sounding better, sounding shorter, sounding less awkward, or local-language equivalents of those same ideas. If the character is worrying about how to package the sentence instead of dealing with the situation itself, rewrite the step.
+- Mild absurdity is welcome when it still feels grounded in the scene.
+- Do not force quirky or goofy lines just to sound entertaining.
+- Do not compress the dialogue until it turns generic. Short is good. Skeletal is not.
+- Avoid coaching, therapist, or customer-support phrasing unless the scene truly calls for it.
+- Avoid over-validating lines like "great question", "excellent point", or "honestly" unless that exact phrasing would sound normal for that character.
+- Do not write dialogue about how something should sound.
 - If a line sounds written instead of spoken, rewrite it.
 
 ### Extra rule for `pt`
 
 - Use everyday Brazilian Portuguese.
 - Favor direct spoken reactions like "boa", "faz sentido", "isso não bate", "acho que o problema é..." when they fit the scene.
-- Avoid stiff, translated-sounding, or prompt-like phrasing. If the line feels like the speaker is trying to sound natural instead of simply talking, rewrite it as ordinary Brazilian speech.
-- Avoid PT-BR meta-phrasing about delivery itself. If the speaker is talking about how to package the sentence instead of just speaking naturally, rewrite the line.
+- Avoid stiff, translated-sounding, or prompt-like phrasing.
+
+# Core Goal
+
+The learner should use the lesson concept to solve a real situation.
+
+Do not make the learner explain the concept.
+Do not make the learner polish wording about the concept.
+Do not make the learner prepare a presentation, poster, or summary about the concept.
+
+The concept is the tool.
+The situation is the point.
+
+# Visual-First Format
+
+Every scenario and every question step must include an `imagePrompt`.
+
+The image is the main source of context and evidence.
+The text should guide attention, not carry the whole scene.
+
+Good practice images include:
+
+- dashboards
+- receipts
+- labels
+- tables
+- maps
+- diagrams
+- timelines
+- code screens
+- terminal output
+- schedules
+- packaging
+- signs
+- whiteboards
+- forms
+- annotated photos
+- simple infographics
+- realistic workplace or everyday scenes with a few readable clues
+
+Image rules:
+
+- Describe exactly what should be visible.
+- Prefer concrete evidence over decorative metaphor art.
+- Each step image should usually have one primary clue, contrast, or state change that helps answer that step's question.
+- Show only the evidence needed for this step. Do not keep unrelated cards, labels, widgets, people, or side details just to make the image feel busy or realistic.
+- When the artifact is complex, zoom in or crop to the relevant section instead of showing the entire room, board, app, or document.
+- Prefer a few readable clues over many competing ones. It is better to show 2 useful labels clearly than 12 labels at once.
+- Background details are optional. Include them only when they help orient the learner or support the story.
+- If text is needed inside the image, keep it short and legible.
+- Use labels, totals, column names, timestamps, badges, short notes, or short dialogue bubbles when useful.
+- Do not rely on dense paragraphs, tiny unreadable text, or walls of copy inside the image.
+- Do not overload the frame with extra information that does not change the decision.
+- Do not spend the prompt on art-style instructions. Focus on content, objects, clues, and relationships.
+- Reuse the same setting, people, and artifacts across steps when that makes the story feel more coherent.
+- Every `imagePrompt` must stand on its own. The image model sees each prompt in isolation.
+- Do not write references like "same laptop", "same terminal", "same person as before", "continue the previous scene", or "again" unless you also restate what that recurring thing looks like.
+- If continuity matters, explicitly restate the recurring person, device, room, document, or artifact inside the current prompt.
+- Let later images reveal changed states, new evidence, or the twist when possible.
+
+Bad standalone prompt:
+
+- Same laptop and same dark terminal.
+
+Good standalone prompt:
+
+- Dark laptop open to a black terminal with green text. Visible text: `Hi! What is your name?`. A blinking cursor sits on an empty line. Beside it, a simple Python file is open in the editor.
+
+Bad cluttered step prompt:
+
+- Meeting room with the whole Kanban wall, six columns, many colorful cards, people around the table, laptops, mugs, sticky notes, window, plant, and side whiteboard full of notes.
+
+Better focused step prompt:
+
+- Close view of the Kanban wall section that matters. Three cards are visible in `Ready`, including one client bug, one admin reminder, and one sticky note that says `buy coffee`. The mixed card types should be easy to read at a glance.
 
 # Requirements
 
@@ -50,42 +133,79 @@ The learner should feel like they are inside a real conversation, not reading a 
 
 Also generate a `scenario` object that sets up the practice before the dialogue starts.
 
-- `scenario.title`: 1-3 words
-- `scenario.text`: Maximum 300 characters
+- `scenario.title`: A short label. Soft target: 1-3 words.
+- `scenario.text`: A short first-person setup paragraph. Soft target: around 300 characters or less.
+- `scenario.imagePrompt`: The opening image for the situation.
 
 Scenario rules:
 
 - Write `scenario.text` in first person.
-- Make it one short paragraph.
+- Keep it short and vivid.
+- Return plain text only. Do not wrap `scenario.text` in quotation marks.
 - Set up one realistic situation where the lesson concepts matter.
+- Surface the concrete tension, confusion, or annoyance that makes the learner lean in.
 - Introduce the colleague, friend, client, or other recurring person here when useful.
-- Keep that same person and situation consistent across ALL dialogue steps.
-- This is setup only. The actual `steps` should continue inside the same situation instead of restarting with a different scene.
+- Keep that same person and situation consistent across all later steps unless the story deliberately reveals why the frame changed.
+- This is setup only. The actual `steps` should continue the same situation instead of restarting with a new scene.
 
 ## Step Structure
 
 Each step must have:
 
-- `context`: Maximum 500 characters. Pure dialogue only. No narrator. No character name prefixes. No action descriptions. This is what the other person says to the learner before the decision.
-- `question`: Maximum 100 characters. A short, clear question about what to do next.
-- `options`: Exactly 4 choices. Each choice must have:
-  - `text`: Maximum 50 characters
-  - `isCorrect`: Boolean. Exactly 1 option must be `true`
-  - `feedback`: Maximum 300 characters
+- `imagePrompt`
+- `context`
+- `question`
+- `options`
+
+Soft targets:
+
+- `context`: Usually 2-4 short spoken sentences. Give enough detail to carry the concrete situation, the person's reaction, and why this decision matters. Pure dialogue only.
+- `question`: short and direct, usually under 70 characters.
+- `options`: usually 4 choices. Prefer 2-4 words. Using 5 words is fine when clarity needs it.
+- `feedback`: short, conversational, specific, and helpful. It should explain the decision, not just react to it.
+
+Important:
+
+- The learner should often need the image to answer well.
+- The image should show the clue, artifact, mismatch, or state change that matters.
+- For question steps, the image should usually be tighter and more selective than the opening scenario image.
+- Each `imagePrompt` must be self-contained and understandable without seeing any earlier image.
+- Return `context` as plain dialogue text, not as a quoted string. Do not add surrounding quotation marks.
+- `context` should be short enough that the learner is not reading a wall of dialogue before every choice, but rich enough that the scene still feels understandable and alive.
+- `context` should usually mention one specific clue, mismatch, consequence, or oddly human detail from this exact scene instead of generic filler.
+- Keep the dialogue lean, but do not strip out the useful setup, tension, or personality that makes the moment feel real.
+- If the scene feels flat after shortening, add one more concrete spoken sentence instead of turning the image into the only source of meaning.
+- Options should feel like real actions or interpretations someone in the scene might suggest.
+
+Good option styles:
+
+- Check totals
+- Trace route
+- Ask Maya
+- Match labels
+- Filter refunds
+- Open raw logs
+- Compare timestamps
+
+Bad generic context:
+
+- {{NAME}}, look at this. Where do we even start?
+
+Better context:
+
+- {{NAME}}, this board has bugs, client requests, and someone's "buy coffee" note in the same lane. If all of that counts as one flow, how are we supposed to know what belongs here?
 
 ## Activity Title
 
 Also generate a `title` for the whole activity.
 
 - This is the activity title, not the `scenario.title`.
-- `scenario.title` is a tiny label for the opening static setup step.
+- `scenario.title` is the tiny label for the opening setup step.
 - `title` is the memorable name shown in the activity list.
 
-- It must be a short, memorable title based on the specific scenario/dialogue you created.
-- It should feel like a practical case, incident, or real situation, not a textbook heading.
-- Do NOT use generic titles like "Practice", "Applying the lesson", "Conversation practice", or the lesson title copied back unchanged.
-- The title should be specific enough that, if someone sees it in an activity list, they can picture the situation immediately.
-- Write the title in the requested `LANGUAGE`, even though the examples below are in English.
+- It must be a short, memorable title based on the specific scenario you created.
+- It should feel like a practical case, incident, or situation, not a textbook heading.
+- Do NOT use generic titles like "Practice", "Applying the lesson", or the lesson title copied back unchanged.
 
 Good example styles:
 
@@ -97,95 +217,73 @@ Good example styles:
 
 ## Feedback Rules
 
-Feedback should feel like the other person's immediate response, not a score report.
+Feedback should feel like the other person's immediate reaction, not a score report.
 
-- For correct answers: briefly confirm why the choice works in this situation.
-- For wrong answers: gently redirect and explain what makes another approach better.
+- For correct answers: briefly confirm why the choice works here.
+- For wrong answers: explain why the chosen option is wrong in this exact scene, then point to the better option and why it fits better.
 - Keep feedback conversational and specific.
-- A little personality or wit is great when it feels natural.
-- Do not sound like a rubric, a lecture, or praise about how good the learner's question was.
+- Light personality is great when it feels natural.
+- Do not sound like a rubric, lecture, or generic praise message.
+- Every feedback line should answer the learner's implicit question: "Why is this right or wrong here?"
+- Wrong-answer feedback should do two jobs:
+  - say what is misleading, missing, or mistaken about the chosen option
+  - say what the better move, interpretation, or clue is instead
+- Do not stop at "not quite" or "that helps later." Finish the thought.
+
+Bad wrong-answer feedback:
+
+- That helps later, but not yet.
+
+Better wrong-answer feedback:
+
+- Counting cards might tell us volume, but the problem here is that the board does not show what belongs in the flow. Defining the board's scope comes first, because otherwise we are counting a mixed pile.
 
 ## Story Arc
 
 Your story must follow this structure:
 
-1. **Opening Step**: Start in the middle of the action. The setup already lives in `scenario`, so do not spend the first dialogue step re-explaining it.
+1. **Opening Step**: Start in the middle of the problem. The setup already lives in `scenario`.
 2. **Rising Complexity**: Each step builds from the previous one.
-3. **Twist or Reframe**: Near the end, introduce a real surprise or reframing that changes how the learner sees the situation.
+3. **Reveal or Reframe**: Near the end, reveal one concrete fact that changes how earlier clues should be understood.
 4. **Resolution**: Solve the problem and reinforce the lesson's main takeaway.
 
-Important:
+The best reveals:
 
-- The twist should happen inside the story. Do not explain that it is a twist.
-- Do not use words like "twist", "plot twist", "big reveal", or similar labels inside the dialogue unless a character would naturally say them for some reason unrelated to the story structure.
-- Let the new fact land on its own and let the characters react to it naturally.
+- build one strong assumption
+- quietly reinforce it for several steps
+- then flip it with one concrete fact
+- make earlier clues feel different in hindsight
 
-## Building Memorable Twists
+The reveal should change the situation itself, not just add one more requirement.
 
-The best twists are memorable because they quietly build one strong assumption, then flip it with one concrete new fact.
+Whenever possible, let the reveal land through the image, or through the mismatch between what the image shows and what the characters assumed.
 
-- Plant one clear assumption early. The learner should think they understand what is happening.
-- Let the middle steps make that assumption feel even more likely.
-- Near the end, reveal one concrete fact that changes the meaning of what came before.
-- The reveal should feel surprising at first and obvious a second later.
-- The reveal should change the situation itself, not just the wording around it.
-- After the reveal, let the characters react naturally and keep moving.
+## Fun and Personality
 
-To make the twist stick:
-
-- Build the story around one mistaken frame, not several weak ones.
-- Seed 2-3 earlier details that fit the first interpretation, but make even more sense after the reveal.
-- The reveal should make the learner mentally replay earlier moments and see them differently.
-- Prefer a concrete reveal: identity, source, destination, label, code, role, location, ownership, or point of view.
-- After the reveal, give the learner one last meaningful decision or reaction inside the new frame.
-- If the story still works almost the same after removing the reveal, then it is not a strong twist.
-
-Good twist patterns:
-
-- Perspective flip: everyone thinks an unknown ship is invading, then the final reveal shows the characters are the outsiders landing on someone else's world.
-- Wrong cause: everyone blames one obvious cause, then a late clue shows the real cause was something completely different.
-- Mistaken identity: the feared person, object, or signal turns out to be something familiar seen from the wrong angle.
-- Reversed roles: the person assumed to be helping, chasing, buying, or protecting turns out to be the one being judged, tracked, sold to, or protected from.
-
-Bad twists:
-
-- A teacher, boss, or client simply adds one more requirement.
-- A character literally announces "here comes the twist".
-- The ending just restates the lesson in more dramatic words.
-- The reveal changes the label but not the situation.
-- The reveal arrives with no setup, so it feels random instead of satisfying.
+- Give the activity at least one small human detail, running assumption, mildly funny mismatch, or workplace oddity that makes the story feel alive.
+- Let the humor come from the situation, the artifact, or the colleague dynamic, not from random jokes pasted on top.
+- Not every step needs a joke, but the full activity should feel engaging, not sterile.
+- The reveal can feel wry, satisfying, or lightly funny in hindsight when it fits the scene.
+- A dry but correct case study is not enough. The learner should want to see what happens next.
 
 ## Step Count
 
-- Minimum: 7 steps
-- Maximum: 20 steps
+- Soft target: 7-20 steps
 - Let the lesson's complexity decide the length
-
-## Tone and Style
-
-- Pure dialogue only
-- No narrator text
-- No character name prefixes
-- No action descriptions
-- Casual, collaborative, everyday speech
-- Friendly, clear, and allowed to be a little playful
-- Short sentences over dense multi-clause explanations
-- Context should emerge naturally from what people say
-- The partner should sound like a real person in the scene, not like a prompt trying to prove it is natural
 
 ## Choosing the Right Scenario
 
-This is a learning and career development platform, so workplace scenarios are the default. They often show most clearly how the lesson applies in real life.
+This is a learning and career development platform, so workplace scenarios are the default.
 
-However, some topics fit everyday life better. Foundational or broad concepts may work better with a friend, neighbor, family member, or classmate.
+The learner should usually be solving a real job-shaped problem with a colleague, teammate, client, or partner.
+
+However, if the topic fits everyday life better, use the most natural setting for that level.
 
 Ask:
 
 **Where would someone at this level most naturally face this problem?**
 
-Use that setting and choose the most natural dialogue partner for it.
-
-If you name a colleague, friend, client, or partner in `scenario.text`, keep that same person present throughout the dialogue unless the story explicitly reveals a reason for the shift.
+Use that setting.
 
 ## The `{{NAME}}` Placeholder
 
@@ -193,8 +291,8 @@ Use `{{NAME}}` wherever the learner's name should appear in dialogue.
 
 Examples:
 
-- "{{NAME}}, I think we missed something."
-- "Boa, {{NAME}}. Será que..."
+- {{NAME}}, I think we missed something.
+- Nice catch, {{NAME}}. That explains the timestamp.
 
 ## Decision Design
 
@@ -202,73 +300,65 @@ Every decision must:
 
 - require reasoning, not recall
 - feel like a real choice someone could face
+- depend on the lesson concept being used inside the situation
+- usually depend on the image plus the short dialogue
 - have plausible distractors
-- allow distractors to have some personality or light humor when they are still believable choices
-- avoid an obvious correct answer
-- **write all options at the same level of specificity and confidence** — if the correct option is detailed and thoughtful while the others are vague or cartoonish, it's a giveaway. A learner should NOT be able to pick the right choice just by comparing how carefully each one is worded
-- **length must not signal quality** — if the correct answer is consistently the longest, learners stop reading and just pick it. Wrong options must be equally developed — a wrong answer is a fully argued bad take, not a lazy short one
-- **vary sentence structure across options** — if all correct answers follow the same template (e.g., more hedging, more nuance) while wrong answers share a different template (e.g., shorter, more blunt), learners pick by pattern instead of reasoning
+- keep all options at the same level of specificity and confidence
+- avoid making the correct answer the obvious longest or most polished one
+- allow mild humor, as long as the option still feels believable in the scene
 
-### Core Principle: Use the Concept, Do Not Talk About the Concept
+## Tone and Style
 
-The scenario should not be about presenting, defining, correcting, or summarizing the lesson content.
-
-The scenario should be about something real happening, where the lesson's concept is the tool the learner uses to understand the situation and decide what to do.
-
-Ask:
-
-**Is the learner talking about the concept, or using the concept?**
-
-- BAD: choosing the best explanation, summary, plaque text, brochure copy, slide copy, or definition
-- GOOD: diagnosing, deciding, helping, fixing, interpreting, or responding to a real situation
-
-Hard rule:
-
-- Do not build the scene around preparing a presentation, poster, cartaz, slogan, summary, pitch, fair panel, or speech about the lesson topic.
-- Do not make the learner choose how to phrase an idea, how to make it sound better, or how to explain the concept more nicely.
-- If the main action is wording, rewriting, presenting, or polishing the concept, the scenario is wrong. Start over with a real situation where the concept is being used.
+- Pure dialogue only in `context`
+- No surrounding quotation marks in `scenario.text` or `context`
+- No narrator text
+- No character name prefixes
+- No action descriptions in `context`
+- Fast pacing
+- Short sentences
+- Specific, not generic
+- Friendly and clear
+- Light humor welcome
+- Practical, not academic
+- Enough situational detail to feel real
+- Short does not mean stripped of personality
+- More "real problem with a colleague" than "content review disguised as dialogue"
 
 ## What to Avoid
 
 - narrator text
+- surrounding quotation marks around `scenario.text` or `context`
 - character name prefixes
-- descriptions of actions or settings outside the dialogue
+- action descriptions inside `context`
 - memorization questions disguised as dialogue
-- scenarios about explaining the content instead of using it
-- scenes about choosing wording, fixing phrasing, writing a panel, making a slogan, or deciding how to explain the topic
-- distractors so absurd that nobody in the scene would seriously consider them
+- scenarios about explaining the concept instead of using it
+- images that only decorate and do not help with the decision
+- giant blocks of tiny text inside the image
+- generic stock-scene prompts with no useful clues
+- options so long they turn back into mini-sentences unless absolutely necessary
+- distractors so absurd that nobody in the scene would consider them
 - meta-commentary
 - fourth-wall breaking
-- lines that sound like prompt residue or writing advice
-- lines that describe the quality of the conversation itself, such as whether something sounds natural, honest, polished, clear, or rehearsed
-- lines about how to phrase something better, shorter, clearer, less awkward, or local-language equivalents of those same delivery concerns
-- lines that announce the story structure, such as calling something a "plot twist", "big reveal", or similar label
-- repeated praise that does not move the scene forward
-
-## Scope
-
-- Stay focused on this lesson's concepts
-- Do not broaden into other lessons
-- If the lesson is broad, let the scenario use multiple parts of it naturally
+- dialogue about how to phrase something better
+- lines that announce the story structure with labels like "twist" or "big reveal"
+- dialogue so compressed that the learner loses the useful context or the human voice
+- bland filler lines like "look at this", "what now?", or "that's weird" when they could mention the actual clue
+- workplace dialogue that is technically correct but emotionally flat, generic, or humorless
 
 # Quality Checks
 
 Before finalizing, verify:
 
+- [ ] Does every `scenario` and every step include an `imagePrompt`?
+- [ ] Is every `imagePrompt` fully standalone, with no unexplained references to earlier images?
+- [ ] Does each question image focus on the evidence needed for that exact decision instead of showing extra clutter?
 - [ ] Is every `context` pure dialogue with no narrator, prefixes, or action descriptions?
+- [ ] Are `scenario.text` and `context` plain text, with no surrounding quotation marks?
 - [ ] Does the dialogue sound like real spoken language in the requested locale?
 - [ ] Would a real person in this scene actually say these lines?
-- [ ] Did you avoid prompt-like phrases, coaching language, and over-polished reactions?
-- [ ] Did you avoid scenes about phrasing, rewriting, slogans, panels, presentations, or explaining the concept?
-- [ ] Did you avoid meta phrasing about how a line should sound, including local-language versions of delivery-focused wording?
-- [ ] Did you keep the dialogue warm, lively, and allowed to be funny when the scene supports it?
-- [ ] Does every step flow naturally from the previous step?
-- [ ] Do the decisions require applying the lesson, not recalling definitions?
-- [ ] Is there a real twist or reframe near the end?
-- [ ] Does the twist happen naturally, without the dialogue calling it a twist, big reveal, or similar label?
-- [ ] Does the final step solve the problem and reinforce the key learning?
-- [ ] Is `{{NAME}}` used naturally?
-- [ ] Are all wrong answers plausible?
-- [ ] Does every option have feedback that explains the reasoning?
-- [ ] Are all limits respected?
-- [ ] Is the story between 7 and 20 steps?
+- [ ] Would the learner get useful evidence from the image, not just decoration?
+- [ ] Does each `context` include enough concrete detail to make the decision feel motivated?
+- [ ] Are the options short, action-like, and easy to scan?
+- [ ] Does the late reveal reframe earlier clues instead of adding a random surprise?
+- [ ] Did the story keep at least one small human or lightly funny detail instead of flattening into dry prompts?
+- [ ] Does the whole activity feel practical, fun, and grounded in a real situation?

--- a/packages/ai/src/tasks/activities/core/activity-practice.ts
+++ b/packages/ai/src/tasks/activities/core/activity-practice.ts
@@ -8,26 +8,26 @@ import systemPrompt from "./activity-practice.prompt.md";
 const DEFAULT_MODEL = "openai/gpt-5.4";
 const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"];
 
+const practiceOptionSchema = z.object({
+  feedback: z.string(),
+  isCorrect: z.boolean(),
+  text: z.string(),
+});
+
+const practiceStepSchema = z.object({
+  context: z.string(),
+  imagePrompt: z.string(),
+  options: z.array(practiceOptionSchema).min(1),
+  question: z.string(),
+});
+
 const schema = z.object({
   scenario: z.object({
     imagePrompt: z.string(),
     text: z.string(),
     title: z.string(),
   }),
-  steps: z.array(
-    z.object({
-      context: z.string(),
-      imagePrompt: z.string(),
-      options: z.array(
-        z.object({
-          feedback: z.string(),
-          isCorrect: z.boolean(),
-          text: z.string(),
-        }),
-      ),
-      question: z.string(),
-    }),
-  ),
+  steps: z.array(practiceStepSchema),
   title: z.string(),
 });
 

--- a/packages/ai/src/tasks/activities/core/activity-practice.ts
+++ b/packages/ai/src/tasks/activities/core/activity-practice.ts
@@ -2,7 +2,6 @@ import "server-only";
 import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { ACTIVITY_OPTIONS_COUNT } from "../config";
 import { formatExplanationStepsForPrompt } from "./_utils/format-explanation-steps";
 import systemPrompt from "./activity-practice.prompt.md";
 
@@ -11,25 +10,25 @@ const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-pre
 
 const schema = z.object({
   scenario: z.object({
+    imagePrompt: z.string(),
     text: z.string(),
     title: z.string(),
   }),
   steps: z.array(
     z.object({
       context: z.string(),
-      options: z
-        .array(
-          z.object({
-            feedback: z.string(),
-            isCorrect: z.boolean(),
-            text: z.string(),
-          }),
-        )
-        .length(ACTIVITY_OPTIONS_COUNT),
+      imagePrompt: z.string(),
+      options: z.array(
+        z.object({
+          feedback: z.string(),
+          isCorrect: z.boolean(),
+          text: z.string(),
+        }),
+      ),
       question: z.string(),
     }),
   ),
-  title: z.string().min(1),
+  title: z.string(),
 });
 
 export type ActivityPracticeSchema = z.infer<typeof schema>;

--- a/packages/ai/src/tasks/steps/step-content-image.prompt.md
+++ b/packages/ai/src/tasks/steps/step-content-image.prompt.md
@@ -1,8 +1,17 @@
-Generate an educational illustration for a learning step.
+Generate an educational illustration for a modern learning app.
 
-Style: Modern flat illustration with clean geometric shapes, a refined limited color palette (2-4 harmonious colors with subtle tints and shades), generous white space, crisp edges without heavy outlines, subtle ambient shadows for depth, clean sans-serif typography when text is needed, balanced composition with clear visual hierarchy, educational and professional aesthetic, portrait-friendly vertical format with enough room for explanatory diagrams and annotations. Avoid putting too much information in the illustration; focus on clarity and simplicity to enhance understanding of the concept.
+Style: Modern flat illustration with clean geometric shapes, a refined limited color palette (2-4 harmonious colors with soft tints and shades), generous white space, crisp edges without heavy outlines, subtle ambient shadows for depth, clean sans-serif typography when text is needed, balanced composition, and clear visual hierarchy. Keep the overall look polished, minimal, and educational.
 
-The illustration should clearly communicate the educational concept while being visually engaging and easy to understand.
+Art direction:
+
+- Prefer off-white, warm gray, or other soft neutral backgrounds.
+- Keep colors restrained and tasteful.
+- When the content needs a table, dashboard, form, label, diagram, or screen, render it in this same clean visual system.
+- If text appears in the image, keep it short, legible, and useful.
+- Avoid dense paragraphs, tiny unreadable text, photorealism, glossy 3D, neon gradients, generic screenshot aesthetics, and loud saturated backdrops.
+- Especially avoid heavy blue or purple background fills unless the prompt truly requires them.
+
+The illustration should clearly communicate the educational idea while staying easy to inspect and understand.
 
 LANGUAGE: **{{LANGUAGE}}**
 

--- a/packages/ai/src/tasks/steps/step-content-image.ts
+++ b/packages/ai/src/tasks/steps/step-content-image.ts
@@ -2,40 +2,69 @@ import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { logError } from "@zoonk/utils/logger";
 import { type GeneratedFile, type ImageModel, generateImage } from "ai";
 import { type ImageGenerationQuality, buildImageProviderOptions } from "../../provider-options";
-import promptTemplate from "./step-content-image.prompt.md";
+import illustrationPromptTemplate from "./step-content-image.prompt.md";
+import practicePromptTemplate from "./step-content-practice-image.prompt.md";
 
 const DEFAULT_MODEL = "openai/gpt-image-2";
 const DEFAULT_QUALITY = "low";
-const STEP_CONTENT_IMAGE_SIZE = "1024x1280";
+const STEP_CONTENT_IMAGE_PRESETS = {
+  illustration: {
+    promptTemplate: illustrationPromptTemplate,
+    size: "1024x1280",
+    taskName: "step-content-image",
+  },
+  practice: {
+    promptTemplate: practicePromptTemplate,
+    size: "1024x1024",
+    taskName: "practice-step-image",
+  },
+} as const;
 
-function getStepContentImagePrompt(prompt: string, language: string) {
-  return promptTemplate.replace("{{PROMPT}}", () => prompt).replace("{{LANGUAGE}}", () => language);
+export type StepContentImagePreset = keyof typeof STEP_CONTENT_IMAGE_PRESETS;
+
+const DEFAULT_PRESET: StepContentImagePreset = "illustration";
+
+function getStepContentImagePrompt({
+  language,
+  preset,
+  prompt,
+}: {
+  language: string;
+  preset: StepContentImagePreset;
+  prompt: string;
+}) {
+  return STEP_CONTENT_IMAGE_PRESETS[preset].promptTemplate
+    .replace("{{PROMPT}}", () => prompt)
+    .replace("{{LANGUAGE}}", () => language);
 }
 
 export type StepContentImageParams = {
-  prompt: string;
   language: string;
   model?: ImageModel;
+  preset?: StepContentImagePreset;
+  prompt: string;
   quality?: ImageGenerationQuality;
 };
 
 export async function generateStepContentImage({
-  prompt,
   language,
   model = DEFAULT_MODEL,
+  preset = DEFAULT_PRESET,
+  prompt,
   quality = DEFAULT_QUALITY,
 }: StepContentImageParams): Promise<SafeReturn<GeneratedFile>> {
+  const imagePreset = STEP_CONTENT_IMAGE_PRESETS[preset];
   const { data, error } = await safeAsync(() =>
     generateImage({
       maxImagesPerCall: 1,
       model,
-      prompt: getStepContentImagePrompt(prompt, language),
+      prompt: getStepContentImagePrompt({ language, preset, prompt }),
       providerOptions: buildImageProviderOptions({
         model,
         quality,
-        taskName: "step-content-image",
+        taskName: imagePreset.taskName,
       }),
-      size: STEP_CONTENT_IMAGE_SIZE,
+      size: imagePreset.size,
     }),
   );
 

--- a/packages/ai/src/tasks/steps/step-content-practice-image.prompt.md
+++ b/packages/ai/src/tasks/steps/step-content-practice-image.prompt.md
@@ -1,0 +1,24 @@
+Generate a realistic image for an interactive practice activity in a modern learning app.
+
+Style: Grounded, believable realism with clean composition, readable details, and practical visual evidence. The image should feel like a real screen, document, device, workspace, object, or situation the learner could inspect to solve a problem. Keep it polished and clear, not decorative.
+
+Art direction:
+
+- Prefer realistic artifacts or realistic scenes over flat illustration.
+- When the prompt involves a terminal, editor, dashboard, receipt, form, diagram, schedule, label, table, or document, make that artifact large and easy to inspect.
+- Use a tight, selective composition. Make the main clue large and obvious enough to notice without hunting through the frame.
+- If the scene contains a complex board, screen, document, or workspace, simplify it to the minimum readable surface needed for the clue.
+- Prefer close crops and clear hierarchy over wide shots with many competing details.
+- Leave out unrelated widgets, cards, labels, windows, desk objects, or background business unless they are needed to understand the scene.
+- Keep backgrounds neutral and unobtrusive.
+- If people appear, keep them natural and grounded in a real task, but do not let them distract from the artifact or evidence.
+- If text appears in the image, keep it short, legible, and useful.
+- Avoid dense paragraphs, tiny unreadable text, cluttered frames, overfilled dashboards or boards, surreal fantasy, glossy 3D, cartoon styling, stock-photo posing, dramatic cinematic lighting, and loud saturated backdrops.
+- Aim for clean, believable realism, not generic decorative concept art.
+
+The image should clearly communicate the clue, evidence, or changed state the learner needs to notice.
+Favor clarity over completeness. It is better to show fewer things clearly than many things weakly.
+
+LANGUAGE: **{{LANGUAGE}}**
+
+CONTENT TO SHOW: **{{PROMPT}}**

--- a/packages/core/src/steps/contract/content.test.ts
+++ b/packages/core/src/steps/contract/content.test.ts
@@ -186,26 +186,12 @@ describe("step content contracts", () => {
 
   test("parses selectImage", () => {
     const content = parseStepContent("selectImage", {
-      options: [
-        {
-          feedback: "Correct",
-          isCorrect: true,
-          prompt: "A cat",
-          url: "https://a.co/x",
-        },
-      ],
+      options: [{ feedback: "Correct", isCorrect: true, prompt: "A cat", url: "https://a.co/x" }],
       question: "Which image shows a cat?",
     });
 
     expect(content).toEqual({
-      options: [
-        {
-          feedback: "Correct",
-          isCorrect: true,
-          prompt: "A cat",
-          url: "https://a.co/x",
-        },
-      ],
+      options: [{ feedback: "Correct", isCorrect: true, prompt: "A cat", url: "https://a.co/x" }],
       question: "Which image shows a cat?",
     });
   });
@@ -357,16 +343,8 @@ describe("step content contracts", () => {
       const content = parseStepContent("static", {
         metrics: ["Production", "Morale"],
         outcomes: [
-          {
-            minStrongChoices: 4,
-            narrative: "Your factory thrives.",
-            title: "Master Manager",
-          },
-          {
-            minStrongChoices: 0,
-            narrative: "Things fell apart.",
-            title: "Learning Moment",
-          },
+          { minStrongChoices: 4, narrative: "Your factory thrives.", title: "Master Manager" },
+          { minStrongChoices: 0, narrative: "Things fell apart.", title: "Learning Moment" },
         ],
         variant: "storyOutcome",
       });
@@ -420,12 +398,7 @@ describe("step content contracts", () => {
             label: "Interview the gardener",
             quality: "useful",
           },
-          {
-            finding: "No clues here.",
-            id: "a3",
-            label: "Check the attic",
-            quality: "weak",
-          },
+          { finding: "No clues here.", id: "a3", label: "Check the attic", quality: "weak" },
         ],
         variant: "action",
       });
@@ -437,24 +410,9 @@ describe("step content contracts", () => {
       expect(() =>
         parseStepContent("investigation", {
           actions: [
-            {
-              finding: "Something",
-              id: "a1",
-              label: "Do something",
-              quality: "excellent",
-            },
-            {
-              finding: "Something",
-              id: "a2",
-              label: "Do more",
-              quality: "critical",
-            },
-            {
-              finding: "Something",
-              id: "a3",
-              label: "Do other",
-              quality: "useful",
-            },
+            { finding: "Something", id: "a1", label: "Do something", quality: "excellent" },
+            { finding: "Something", id: "a2", label: "Do more", quality: "critical" },
+            { finding: "Something", id: "a3", label: "Do other", quality: "useful" },
           ],
           variant: "action",
         }),
@@ -494,12 +452,7 @@ describe("step content contracts", () => {
         parseStepContent("investigation", {
           correctExplanationIndex: 0,
           explanations: [
-            {
-              accuracy: "best",
-              feedback: "Correct.",
-              id: "e1",
-              text: "Explanation.",
-            },
+            { accuracy: "best", feedback: "Correct.", id: "e1", text: "Explanation." },
           ],
           variant: "call",
         }),

--- a/packages/core/src/steps/contract/content.test.ts
+++ b/packages/core/src/steps/contract/content.test.ts
@@ -17,6 +17,10 @@ describe("step content contracts", () => {
   test("parses core multipleChoice with all fields", () => {
     const content = parseStepContent("multipleChoice", {
       context: "Some context",
+      image: {
+        prompt: "A refund dashboard with one outlier row",
+        url: "https://example.com/refund.webp",
+      },
       kind: "core",
       options: [
         { feedback: "Correct!", isCorrect: true, text: "A" },
@@ -27,6 +31,10 @@ describe("step content contracts", () => {
 
     expect(content).toEqual({
       context: "Some context",
+      image: {
+        prompt: "A refund dashboard with one outlier row",
+        url: "https://example.com/refund.webp",
+      },
       kind: "core",
       options: [
         { feedback: "Correct!", isCorrect: true, text: "A" },
@@ -178,12 +186,26 @@ describe("step content contracts", () => {
 
   test("parses selectImage", () => {
     const content = parseStepContent("selectImage", {
-      options: [{ feedback: "Correct", isCorrect: true, prompt: "A cat", url: "https://a.co/x" }],
+      options: [
+        {
+          feedback: "Correct",
+          isCorrect: true,
+          prompt: "A cat",
+          url: "https://a.co/x",
+        },
+      ],
       question: "Which image shows a cat?",
     });
 
     expect(content).toEqual({
-      options: [{ feedback: "Correct", isCorrect: true, prompt: "A cat", url: "https://a.co/x" }],
+      options: [
+        {
+          feedback: "Correct",
+          isCorrect: true,
+          prompt: "A cat",
+          url: "https://a.co/x",
+        },
+      ],
       question: "Which image shows a cat?",
     });
   });
@@ -335,8 +357,16 @@ describe("step content contracts", () => {
       const content = parseStepContent("static", {
         metrics: ["Production", "Morale"],
         outcomes: [
-          { minStrongChoices: 4, narrative: "Your factory thrives.", title: "Master Manager" },
-          { minStrongChoices: 0, narrative: "Things fell apart.", title: "Learning Moment" },
+          {
+            minStrongChoices: 4,
+            narrative: "Your factory thrives.",
+            title: "Master Manager",
+          },
+          {
+            minStrongChoices: 0,
+            narrative: "Things fell apart.",
+            title: "Learning Moment",
+          },
         ],
         variant: "storyOutcome",
       });
@@ -390,7 +420,12 @@ describe("step content contracts", () => {
             label: "Interview the gardener",
             quality: "useful",
           },
-          { finding: "No clues here.", id: "a3", label: "Check the attic", quality: "weak" },
+          {
+            finding: "No clues here.",
+            id: "a3",
+            label: "Check the attic",
+            quality: "weak",
+          },
         ],
         variant: "action",
       });
@@ -402,9 +437,24 @@ describe("step content contracts", () => {
       expect(() =>
         parseStepContent("investigation", {
           actions: [
-            { finding: "Something", id: "a1", label: "Do something", quality: "excellent" },
-            { finding: "Something", id: "a2", label: "Do more", quality: "critical" },
-            { finding: "Something", id: "a3", label: "Do other", quality: "useful" },
+            {
+              finding: "Something",
+              id: "a1",
+              label: "Do something",
+              quality: "excellent",
+            },
+            {
+              finding: "Something",
+              id: "a2",
+              label: "Do more",
+              quality: "critical",
+            },
+            {
+              finding: "Something",
+              id: "a3",
+              label: "Do other",
+              quality: "useful",
+            },
           ],
           variant: "action",
         }),
@@ -444,7 +494,12 @@ describe("step content contracts", () => {
         parseStepContent("investigation", {
           correctExplanationIndex: 0,
           explanations: [
-            { accuracy: "best", feedback: "Correct.", id: "e1", text: "Explanation." },
+            {
+              accuracy: "best",
+              feedback: "Correct.",
+              id: "e1",
+              text: "Explanation.",
+            },
           ],
           variant: "call",
         }),

--- a/packages/core/src/steps/contract/exercise.ts
+++ b/packages/core/src/steps/contract/exercise.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { stepImageSchema } from "./image";
 
 const coreOptionSchema = z
   .object({
@@ -11,6 +12,7 @@ const coreOptionSchema = z
 const coreMultipleChoiceContentSchema = z
   .object({
     context: z.string().optional(),
+    image: stepImageSchema.optional(),
     kind: z.literal("core"),
     options: z.array(coreOptionSchema).min(1),
     question: z.string().optional(),

--- a/packages/core/src/steps/step-content-image.ts
+++ b/packages/core/src/steps/step-content-image.ts
@@ -1,5 +1,6 @@
 import {
   type StepContentImageParams,
+  type StepContentImagePreset,
   generateStepContentImage,
 } from "@zoonk/ai/tasks/steps/content-image";
 import { type SafeReturn } from "@zoonk/utils/error";
@@ -9,10 +10,10 @@ import { optimizeImage } from "../images/optimize-image";
 import { uploadImage } from "../images/upload-image";
 
 /**
- * Content-step illustrations share the same upload pipeline as quiz images,
- * but they use a different prompt template tuned for explanatory artwork.
- * Keeping that wrapper separate avoids mixing quiz-style prompts with lesson
- * illustration prompts.
+ * Step images share the same optimize-and-upload pipeline, but not every
+ * learner-visible image wants the same generation preset. Explanation steps
+ * use the illustration preset, while practice steps can opt into a more
+ * realistic preset without forking the storage flow.
  */
 export async function generateContentStepImage({
   orgSlug,
@@ -53,3 +54,5 @@ export async function generateContentStepImage({
 
   return { data: url, error: null };
 }
+
+export type { StepContentImagePreset };

--- a/packages/player/src/_browser-tests/player-practice.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-practice.browser.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
 import { page } from "vitest/browser";
+import { buildInlineImageUrl } from "../_test-utils/build-inline-image-url";
 import { buildSerializedActivity, buildSerializedStep } from "../_test-utils/player-test-data";
 import { buildAuthenticatedViewer } from "../_test-utils/player-test-viewer";
 import { buildNavigation, renderPlayer } from "../_test-utils/render-player";
@@ -22,6 +23,14 @@ describe("player browser integration: practice activities", () => {
           buildSerializedStep({
             content: {
               context: "Maya says the mismatch only appears on orders with manual discounts.",
+              image: {
+                prompt:
+                  "A refund dashboard filtered to discounted orders with one outlier row highlighted",
+                url: buildInlineImageUrl({
+                  label:
+                    "A refund dashboard filtered to discounted orders with one outlier row highlighted",
+                }),
+              },
               kind: "core" as const,
               options: [
                 {
@@ -60,6 +69,9 @@ describe("player browser integration: practice activities", () => {
 
     await expect
       .element(page.getByRole("heading", { name: "What should I check first?" }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByAltText(/refund dashboard filtered to discounted orders/i))
       .toBeInTheDocument();
 
     await page.getByRole("radio", { name: "Check the discounted orders first" }).click();

--- a/packages/player/src/components/_utils/strip-wrapping-quotes.test.ts
+++ b/packages/player/src/components/_utils/strip-wrapping-quotes.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "vitest";
+import { stripWrappingQuotes } from "./strip-wrapping-quotes";
+
+describe(stripWrappingQuotes, () => {
+  test("removes one outer pair of matching quotes", () => {
+    expect(stripWrappingQuotes('  "hello there"  ')).toBe("hello there");
+    expect(stripWrappingQuotes("“hello there”")).toBe("hello there");
+    expect(stripWrappingQuotes("‘hello there’")).toBe("hello there");
+  });
+
+  test("leaves unmatched or inner quotes alone", () => {
+    expect(stripWrappingQuotes('"hello there')).toBe('"hello there');
+    expect(stripWrappingQuotes('He said "wait" and left.')).toBe('He said "wait" and left.');
+  });
+});

--- a/packages/player/src/components/_utils/strip-wrapping-quotes.test.ts
+++ b/packages/player/src/components/_utils/strip-wrapping-quotes.test.ts
@@ -19,12 +19,23 @@ describe(stripWrappingQuotes, () => {
     expect(stripWrappingQuotes('  "  ')).toBe('  "  ');
   });
 
+  test("strips outer single quotes when the inner text only has apostrophes", () => {
+    expect(stripWrappingQuotes("'It's ready'")).toBe("It's ready");
+    expect(stripWrappingQuotes("‘It’s ready’")).toBe("It’s ready");
+  });
+
   test("preserves quotes around the first and last words", () => {
     expect(stripWrappingQuotes('"this" should preserve quotes in the first and last "words"')).toBe(
       '"this" should preserve quotes in the first and last "words"',
     );
     expect(stripWrappingQuotes("“this” should preserve quotes in the first and last “words”")).toBe(
       "“this” should preserve quotes in the first and last “words”",
+    );
+    expect(stripWrappingQuotes("'this' should preserve quotes in the first and last 'words'")).toBe(
+      "'this' should preserve quotes in the first and last 'words'",
+    );
+    expect(stripWrappingQuotes("‘this’ should preserve quotes in the first and last ‘words’")).toBe(
+      "‘this’ should preserve quotes in the first and last ‘words’",
     );
   });
 });

--- a/packages/player/src/components/_utils/strip-wrapping-quotes.test.ts
+++ b/packages/player/src/components/_utils/strip-wrapping-quotes.test.ts
@@ -12,4 +12,19 @@ describe(stripWrappingQuotes, () => {
     expect(stripWrappingQuotes('"hello there')).toBe('"hello there');
     expect(stripWrappingQuotes('He said "wait" and left.')).toBe('He said "wait" and left.');
   });
+
+  test("leaves lone quote characters alone", () => {
+    expect(stripWrappingQuotes('"')).toBe('"');
+    expect(stripWrappingQuotes("'")).toBe("'");
+    expect(stripWrappingQuotes('  "  ')).toBe('  "  ');
+  });
+
+  test("preserves quotes around the first and last words", () => {
+    expect(stripWrappingQuotes('"this" should preserve quotes in the first and last "words"')).toBe(
+      '"this" should preserve quotes in the first and last "words"',
+    );
+    expect(stripWrappingQuotes("“this” should preserve quotes in the first and last “words”")).toBe(
+      "“this” should preserve quotes in the first and last “words”",
+    );
+  });
 });

--- a/packages/player/src/components/_utils/strip-wrapping-quotes.ts
+++ b/packages/player/src/components/_utils/strip-wrapping-quotes.ts
@@ -1,0 +1,26 @@
+const WRAPPING_QUOTE_PAIRS = [
+  ['"', '"'],
+  ["'", "'"],
+  ["“", "”"],
+  ["‘", "’"],
+] as const;
+
+/**
+ * AI-authored copy sometimes arrives wrapped in one unnecessary outer quote
+ * pair. Strip only that wrapper so scenario and dialogue text render as plain
+ * app copy, while leaving inner quoted phrases untouched.
+ */
+export function stripWrappingQuotes(value: string): string {
+  const trimmedValue = value.trim();
+  const matchingPair = WRAPPING_QUOTE_PAIRS.find(
+    ([openingQuote, closingQuote]) =>
+      trimmedValue.startsWith(openingQuote) && trimmedValue.endsWith(closingQuote),
+  );
+
+  if (!matchingPair) {
+    return value;
+  }
+
+  const [openingQuote, closingQuote] = matchingPair;
+  return trimmedValue.slice(openingQuote.length, trimmedValue.length - closingQuote.length).trim();
+}

--- a/packages/player/src/components/_utils/strip-wrapping-quotes.ts
+++ b/packages/player/src/components/_utils/strip-wrapping-quotes.ts
@@ -1,25 +1,17 @@
-const WRAPPING_QUOTE_PAIRS = [
-  ['"', '"'],
-  ["'", "'"],
-  ["“", "”"],
-  ["‘", "’"],
-] as const;
+const QUOTE_PAIRS: Record<string, string> = {
+  '"': '"',
+  "'": "'",
+  "‘": "’",
+  "“": "”",
+};
 
-function hasInnerQuotePair({
-  closingQuote,
-  innerValue,
-  openingQuote,
-}: {
-  closingQuote: string;
-  innerValue: string;
-  openingQuote: string;
-}) {
-  if (openingQuote === closingQuote) {
-    return innerValue.includes(openingQuote);
-  }
-
-  return innerValue.includes(openingQuote) || innerValue.includes(closingQuote);
-}
+/**
+ * Matches any quote character that has at least one non-word neighbor (or sits
+ * at a string edge). This is how we detect an intentional inner quote while
+ * ignoring apostrophes inside words like "it's", where both neighbors are
+ * letters.
+ */
+const NESTED_QUOTE_PATTERN = /(?<![\p{L}\p{N}])['"‘’“”]|['"‘’“”](?![\p{L}\p{N}])/u;
 
 /**
  * AI-authored copy sometimes arrives wrapped in one unnecessary outer quote
@@ -27,29 +19,14 @@ function hasInnerQuotePair({
  * app copy, while leaving inner quoted phrases untouched.
  */
 export function stripWrappingQuotes(value: string): string {
-  const trimmedValue = value.trim();
+  const trimmed = value.trim();
+  const opener = trimmed[0];
+  const closer = opener && QUOTE_PAIRS[opener];
 
-  const matchingPair = WRAPPING_QUOTE_PAIRS.find(
-    ([openingQuote, closingQuote]) =>
-      trimmedValue.length >= openingQuote.length + closingQuote.length &&
-      trimmedValue.startsWith(openingQuote) &&
-      trimmedValue.endsWith(closingQuote),
-  );
-
-  if (!matchingPair) {
+  if (!closer || trimmed.length < 2 || !trimmed.endsWith(closer)) {
     return value;
   }
 
-  const [openingQuote, closingQuote] = matchingPair;
-
-  const innerValue = trimmedValue.slice(
-    openingQuote.length,
-    trimmedValue.length - closingQuote.length,
-  );
-
-  if (hasInnerQuotePair({ closingQuote, innerValue, openingQuote })) {
-    return value;
-  }
-
-  return innerValue.trim();
+  const inner = trimmed.slice(1, -1);
+  return NESTED_QUOTE_PATTERN.test(inner) ? value : inner.trim();
 }

--- a/packages/player/src/components/_utils/strip-wrapping-quotes.ts
+++ b/packages/player/src/components/_utils/strip-wrapping-quotes.ts
@@ -5,6 +5,22 @@ const WRAPPING_QUOTE_PAIRS = [
   ["‘", "’"],
 ] as const;
 
+function hasInnerQuotePair({
+  closingQuote,
+  innerValue,
+  openingQuote,
+}: {
+  closingQuote: string;
+  innerValue: string;
+  openingQuote: string;
+}) {
+  if (openingQuote === closingQuote) {
+    return innerValue.includes(openingQuote);
+  }
+
+  return innerValue.includes(openingQuote) || innerValue.includes(closingQuote);
+}
+
 /**
  * AI-authored copy sometimes arrives wrapped in one unnecessary outer quote
  * pair. Strip only that wrapper so scenario and dialogue text render as plain
@@ -12,9 +28,12 @@ const WRAPPING_QUOTE_PAIRS = [
  */
 export function stripWrappingQuotes(value: string): string {
   const trimmedValue = value.trim();
+
   const matchingPair = WRAPPING_QUOTE_PAIRS.find(
     ([openingQuote, closingQuote]) =>
-      trimmedValue.startsWith(openingQuote) && trimmedValue.endsWith(closingQuote),
+      trimmedValue.length >= openingQuote.length + closingQuote.length &&
+      trimmedValue.startsWith(openingQuote) &&
+      trimmedValue.endsWith(closingQuote),
   );
 
   if (!matchingPair) {
@@ -22,5 +41,15 @@ export function stripWrappingQuotes(value: string): string {
   }
 
   const [openingQuote, closingQuote] = matchingPair;
-  return trimmedValue.slice(openingQuote.length, trimmedValue.length - closingQuote.length).trim();
+
+  const innerValue = trimmedValue.slice(
+    openingQuote.length,
+    trimmedValue.length - closingQuote.length,
+  );
+
+  if (hasInnerQuotePair({ closingQuote, innerValue, openingQuote })) {
+    return value;
+  }
+
+  return innerValue.trim();
 }

--- a/packages/player/src/components/choice-step-layout.tsx
+++ b/packages/player/src/components/choice-step-layout.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type StepImage } from "@zoonk/core/steps/contract/image";
 import {
   PlayerChoiceScene,
   PlayerChoiceSceneContext,
@@ -8,15 +9,15 @@ import {
   PlayerChoiceScenePrompt,
   PlayerChoiceSceneQuestion,
 } from "./player-choice-scene";
+import { StepActionButton } from "./step-action-button";
+import { StepImageView } from "./step-image";
 
 /**
- * Shared layout for choice-based steps (multiple choice, story decisions).
- *
- * Owns all rendering and interaction: text display, option list with dimming,
- * keyboard shortcuts (1/2/3), and toggle-to-unselect. Each step kind provides
- * a thin wrapper that parses its content and builds the answer shape.
+ * The prompt and option list are the reusable heart of every choice scene.
+ * Keeping them separate from the outer layout lets the same content render in
+ * the classic text-only shell or the newer image-led split layout.
  */
-export function ChoiceStepLayout({
+function ChoiceStepLayoutContent({
   context,
   onSelect,
   options,
@@ -32,7 +33,7 @@ export function ChoiceStepLayout({
   const hasSelection = selectedIndex !== null;
 
   return (
-    <PlayerChoiceScene>
+    <>
       {(context || question) && (
         <PlayerChoiceScenePrompt>
           <PlayerChoiceSceneContext>{context}</PlayerChoiceSceneContext>
@@ -49,6 +50,110 @@ export function ChoiceStepLayout({
           key: option.key,
         }))}
       />
-    </PlayerChoiceScene>
+    </>
   );
+}
+
+/**
+ * Choice steps need a different image composition than read-only steps.
+ *
+ * Practice questions need the artifact visible before the learner scans the
+ * options on mobile, but large screens have enough room to sit the evidence
+ * beside the decision. Keeping that responsive image stage here avoids making
+ * the rest of the choice layout care about viewport-specific composition.
+ */
+function ChoiceStepImageStage({ image }: { image: StepImage }) {
+  return (
+    <div
+      className="w-full lg:ml-auto lg:max-w-md xl:max-w-120"
+      data-slot="choice-step-image-stage-shell"
+    >
+      <div
+        className="relative aspect-square w-full [&_img]:object-top"
+        data-slot="choice-step-image-stage"
+      >
+        <StepImageView image={image} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Image-led choice steps need their desktop action button inside the same
+ * reading column as the prompt and options. Keeping that button local to the
+ * step lets the right column stay visually self-contained while mobile still
+ * uses the shared sticky bottom bar.
+ */
+function ChoiceStepDesktopAction() {
+  return <StepActionButton className="hidden lg:flex" />;
+}
+
+/**
+ * Visual practice questions need a wider stage than text-only choice scenes.
+ *
+ * The centered text frame is correct for normal multiple-choice questions, but
+ * image-led steps need the same kind of horizontal space as static media steps
+ * so the artifact can stay large while the prompt, options, and desktop action
+ * remain grouped in one compact column.
+ */
+function ChoiceStepMediaLayout({
+  children,
+  image,
+}: {
+  children: React.ReactNode;
+  image: StepImage;
+}) {
+  return (
+    <div
+      className="mx-auto my-auto w-full max-w-5xl px-4 py-4 sm:px-6 sm:py-6"
+      data-slot="choice-step-media-layout"
+    >
+      <div className="flex flex-col gap-4 sm:gap-6 lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(22rem,25rem)] lg:items-start lg:gap-8 xl:gap-10">
+        <ChoiceStepImageStage image={image} />
+        <div className="flex min-w-0 flex-col gap-4 sm:gap-6">
+          {children}
+          <ChoiceStepDesktopAction />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Shared layout for choice-based steps (multiple choice, story decisions).
+ *
+ * Owns all rendering and interaction: text display, option list with dimming,
+ * numeric keyboard shortcuts, and toggle-to-unselect. Each step kind provides
+ * a thin wrapper that parses its content and builds the answer shape.
+ */
+export function ChoiceStepLayout({
+  context,
+  image,
+  onSelect,
+  options,
+  question,
+  selectedIndex,
+}: {
+  context?: string | null;
+  image?: StepImage | null;
+  onSelect: (index: number) => void;
+  options: readonly { key: string; text: string }[];
+  question?: string | null;
+  selectedIndex: number | null;
+}) {
+  const content = (
+    <ChoiceStepLayoutContent
+      context={context}
+      onSelect={onSelect}
+      options={options}
+      question={question}
+      selectedIndex={selectedIndex}
+    />
+  );
+
+  if (!image) {
+    return <PlayerChoiceScene>{content}</PlayerChoiceScene>;
+  }
+
+  return <ChoiceStepMediaLayout image={image}>{content}</ChoiceStepMediaLayout>;
 }

--- a/packages/player/src/components/multiple-choice-step.tsx
+++ b/packages/player/src/components/multiple-choice-step.tsx
@@ -32,11 +32,7 @@ export function MultipleChoiceStep({
     }
 
     const selectedText = content.options[index]?.text ?? "";
-    onSelectAnswer(step.id, {
-      kind: "multipleChoice",
-      selectedIndex: index,
-      selectedText,
-    });
+    onSelectAnswer(step.id, { kind: "multipleChoice", selectedIndex: index, selectedText });
   };
 
   return (
@@ -44,10 +40,7 @@ export function MultipleChoiceStep({
       context={content.context}
       image={content.image}
       onSelect={handleSelect}
-      options={content.options.map((option) => ({
-        key: option.text,
-        text: option.text,
-      }))}
+      options={content.options.map((option) => ({ key: option.text, text: option.text }))}
       question={content.question}
       selectedIndex={selectedIndex}
     />

--- a/packages/player/src/components/multiple-choice-step.tsx
+++ b/packages/player/src/components/multiple-choice-step.tsx
@@ -32,14 +32,22 @@ export function MultipleChoiceStep({
     }
 
     const selectedText = content.options[index]?.text ?? "";
-    onSelectAnswer(step.id, { kind: "multipleChoice", selectedIndex: index, selectedText });
+    onSelectAnswer(step.id, {
+      kind: "multipleChoice",
+      selectedIndex: index,
+      selectedText,
+    });
   };
 
   return (
     <ChoiceStepLayout
       context={content.context}
+      image={content.image}
       onSelect={handleSelect}
-      options={content.options.map((option) => ({ key: option.text, text: option.text }))}
+      options={content.options.map((option) => ({
+        key: option.text,
+        text: option.text,
+      }))}
       question={content.question}
       selectedIndex={selectedIndex}
     />

--- a/packages/player/src/components/player-read-scene.tsx
+++ b/packages/player/src/components/player-read-scene.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@zoonk/ui/lib/utils";
+import { stripWrappingQuotes } from "./_utils/strip-wrapping-quotes";
 import { SectionLabel } from "./section-label";
 import { PlayerContentFrame } from "./step-layouts";
 
@@ -126,12 +127,14 @@ export function PlayerReadSceneTitle({
  * stay visually aligned, so the baseline body typography lives here.
  */
 export function PlayerReadSceneBody({ children }: { children: React.ReactNode }) {
+  const content = typeof children === "string" ? stripWrappingQuotes(children) : children;
+
   return (
     <p
       className="text-lg leading-relaxed sm:text-xl sm:leading-relaxed"
       data-slot="player-read-scene-body"
     >
-      {children}
+      {content}
     </p>
   );
 }

--- a/packages/player/src/components/question-text.tsx
+++ b/packages/player/src/components/question-text.tsx
@@ -1,5 +1,9 @@
+import { stripWrappingQuotes } from "./_utils/strip-wrapping-quotes";
+
 export function ContextText({ children }: { children: React.ReactNode }) {
-  return <p className="text-lg leading-relaxed sm:text-xl sm:leading-relaxed">{children}</p>;
+  const content = typeof children === "string" ? stripWrappingQuotes(children) : children;
+
+  return <p className="text-lg leading-relaxed sm:text-xl sm:leading-relaxed">{content}</p>;
 }
 
 export function QuestionText({ children }: { children: React.ReactNode }) {

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -5,6 +5,7 @@ import {
   getCurrentStep,
   getSelectedAnswer,
 } from "../player-selectors";
+import { describePlayerStep } from "../player-step";
 import { CompletionScreenContent } from "./completion-screen";
 import { FeedbackScreenContent } from "./feedback-screen";
 import { StepActionButton } from "./step-action-button";
@@ -33,6 +34,19 @@ function DesktopInlineAction() {
  */
 function usesDesktopInlineAction(screen: ReturnType<typeof usePlayerRuntime>["screen"]) {
   return screen.kind !== "completed" && screen.bottomBar?.kind === "primaryAction";
+}
+
+/**
+ * Image-led multiple-choice practice steps own their desktop action placement.
+ *
+ * Those scenes need the button inside the right-hand decision column so the
+ * artifact, question, options, and action read as one compact unit. The global
+ * desktop action slot still serves every other primary-action screen.
+ */
+function usesEmbeddedDesktopAction(step: ReturnType<typeof getCurrentStep>) {
+  const descriptor = describePlayerStep(step);
+
+  return descriptor?.kind === "multipleChoice" && Boolean(descriptor.content.image);
 }
 
 export function StageContent() {
@@ -65,7 +79,8 @@ export function StageContent() {
   }
 
   if (screen.kind === "step" && currentStep) {
-    const showInlineAction = usesDesktopInlineAction(screen);
+    const showInlineAction =
+      usesDesktopInlineAction(screen) && !usesEmbeddedDesktopAction(currentStep);
 
     const stepContent = (
       <StepRenderer

--- a/packages/player/src/components/static-step-layout.tsx
+++ b/packages/player/src/components/static-step-layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type StepImage } from "@zoonk/core/steps/contract/image";
-import { StepImageView } from "./step-image";
+import { StepMediaLayout } from "./step-media-layout";
 
 /**
  * Static explanation steps now combine the illustration and copy in one screen.
@@ -16,25 +16,10 @@ export function StaticStepLayout({
   image: StepImage;
 }) {
   return (
-    <div
-      className="flex h-full min-h-0 w-full flex-col lg:grid lg:grid-cols-2"
-      data-slot="static-step-layout"
-    >
-      <div className="flex min-h-0 flex-1 px-4 pt-4 sm:px-6 sm:pt-6 lg:h-full lg:px-6 lg:py-6">
-        <div
-          className="relative h-full min-h-0 w-full overflow-hidden lg:rounded-[2rem]"
-          data-slot="static-step-media-stage"
-        >
-          <StepImageView image={image} />
-        </div>
-      </div>
-
-      <div
-        className="min-h-0 overflow-y-auto overscroll-contain px-4 pt-3 pb-4 sm:px-6 sm:pb-6 lg:flex lg:items-center lg:px-10 lg:py-6"
-        data-slot="static-step-copy"
-      >
+    <StepMediaLayout image={image}>
+      <div className="w-full" data-slot="static-step-copy">
         <div className="mx-auto w-full max-w-2xl">{children}</div>
       </div>
-    </div>
+    </StepMediaLayout>
   );
 }

--- a/packages/player/src/components/step-action-button.tsx
+++ b/packages/player/src/components/step-action-button.tsx
@@ -14,10 +14,10 @@ import { usePlayerRuntime } from "../player-context";
  *
  * Rendered in two places with different visibility:
  * - Inside the PlayerBottomBar for mobile (visible below lg)
- * - Inline below step content for desktop (visible at lg+)
+ * - Inline on desktop, either below the step or inside a media choice column
  *
  * This avoids duplicating button logic across the bottom bar
- * and the desktop inline slot.
+ * and the desktop action slots.
  */
 export function StepActionButton({
   className,

--- a/packages/player/src/components/step-media-layout.tsx
+++ b/packages/player/src/components/step-media-layout.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { type StepImage } from "@zoonk/core/steps/contract/image";
+import { StepImageView } from "./step-image";
+
+/**
+ * Image-led learning steps share the same media shell: one stage for the
+ * generated artifact and one scrollable copy pane beside or below it. Keeping
+ * that split in one component prevents practice questions and static reading
+ * steps from drifting into different image layouts over time.
+ */
+export function StepMediaLayout({
+  children,
+  image,
+}: {
+  children: React.ReactNode;
+  image: StepImage;
+}) {
+  return (
+    <div
+      className="flex h-full min-h-0 w-full flex-col lg:grid lg:grid-cols-2 lg:content-center lg:items-start"
+      data-slot="step-media-layout"
+    >
+      <div className="flex min-h-0 flex-1 px-4 pt-4 sm:px-6 sm:pt-6 lg:px-6 lg:py-6">
+        <div
+          className="relative h-full min-h-0 w-full overflow-hidden lg:ml-auto lg:h-[min(70vh,40rem)] lg:max-w-xl lg:[&_img]:object-top"
+          data-slot="step-media-stage"
+        >
+          <StepImageView image={image} />
+        </div>
+      </div>
+
+      <div
+        className="min-h-0 overflow-y-auto overscroll-contain px-4 pt-3 pb-4 sm:px-6 sm:pb-6 lg:flex lg:max-h-[min(70vh,40rem)] lg:items-start lg:px-10 lg:py-6"
+        data-slot="step-media-copy"
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/player/src/player-selectors.test.ts
+++ b/packages/player/src/player-selectors.test.ts
@@ -96,7 +96,11 @@ function buildStoryIntroStep(): SerializedStep {
 function buildStoryResult(stepId: string, selectedChoiceId: string): StepResult {
   return {
     answer: { kind: "story", selectedChoiceId, selectedText: "choice" },
-    result: { correctAnswer: null, feedback: null, isCorrect: selectedChoiceId !== "c3" },
+    result: {
+      correctAnswer: null,
+      feedback: null,
+      isCorrect: selectedChoiceId !== "c3",
+    },
     stepId,
   };
 }
@@ -141,7 +145,11 @@ describe(getStoryBriefingText, () => {
       currentStepIndex: 2,
       steps: [
         buildStep({
-          content: { text: "Welcome", title: "Preamble", variant: "text" as const },
+          content: {
+            text: "Welcome",
+            title: "Preamble",
+            variant: "text" as const,
+          },
           id: "text-static",
           kind: "static",
           position: 0,
@@ -163,7 +171,11 @@ describe(findSelectedChoice, () => {
     const choice = findSelectedChoice({ results, step });
 
     expect(choice).toEqual(
-      expect.objectContaining({ alignment: "strong", id: "c1", text: "Strong choice" }),
+      expect.objectContaining({
+        alignment: "strong",
+        id: "c1",
+        text: "Strong choice",
+      }),
     );
   });
 
@@ -177,7 +189,11 @@ describe(findSelectedChoice, () => {
     const step = buildStoryStep("s1", 0);
     const results = {
       s1: {
-        answer: { kind: "multipleChoice" as const, selectedIndex: 0, selectedText: "A" },
+        answer: {
+          kind: "multipleChoice" as const,
+          selectedIndex: 0,
+          selectedText: "A",
+        },
         result: { correctAnswer: null, feedback: null, isCorrect: true },
         stepId: "s1",
       },
@@ -201,7 +217,11 @@ describe("findStoryIntroContent (via getStoryMetrics)", () => {
     const state = buildState({
       steps: [
         buildStep({
-          content: { text: "Welcome", title: "Preamble", variant: "text" as const },
+          content: {
+            text: "Welcome",
+            title: "Preamble",
+            variant: "text" as const,
+          },
           id: "text-static",
           kind: "static",
           position: 0,
@@ -302,9 +322,24 @@ function buildInvestigationActionStep(): SerializedStep {
   return buildStep({
     content: {
       actions: [
-        { finding: "Clue A", id: "a1", label: "Check logs", quality: "critical" as const },
-        { finding: "Clue B", id: "a2", label: "Ask witness", quality: "useful" as const },
-        { finding: "Clue C", id: "a3", label: "Check camera", quality: "weak" as const },
+        {
+          finding: "Clue A",
+          id: "a1",
+          label: "Check logs",
+          quality: "critical" as const,
+        },
+        {
+          finding: "Clue B",
+          id: "a2",
+          label: "Ask witness",
+          quality: "useful" as const,
+        },
+        {
+          finding: "Clue C",
+          id: "a3",
+          label: "Check camera",
+          quality: "weak" as const,
+        },
       ],
       variant: "action" as const,
     },
@@ -350,7 +385,10 @@ describe(getInvestigationProgress, () => {
       currentStepIndex: 0,
       steps: [
         buildStep({
-          content: { scenario: "A mystery occurred.", variant: "problem" as const },
+          content: {
+            scenario: "A mystery occurred.",
+            variant: "problem" as const,
+          },
           id: "problem-step",
           kind: "investigation",
         }),
@@ -437,6 +475,33 @@ describe(getUpcomingImages, () => {
 
     expect(getUpcomingImages(state)).toEqual([
       { kind: "step", url: "https://example.com/cat.jpg" },
+    ]);
+  });
+
+  test("extracts URL from a multipleChoice step image", () => {
+    const state = buildState({
+      steps: [
+        buildStep({ id: "s1" }),
+        buildStep({
+          content: {
+            context: "Maya points at the refund dashboard.",
+            image: {
+              prompt: "A refund dashboard with one mismatched total highlighted",
+              url: "https://example.com/refund-dashboard.jpg",
+            },
+            kind: "core",
+            options: [{ feedback: "Yes", isCorrect: true, text: "Check totals" }],
+            question: "What should we inspect?",
+          },
+          id: "s2",
+          kind: "multipleChoice",
+          position: 1,
+        }),
+      ],
+    });
+
+    expect(getUpcomingImages(state)).toEqual([
+      { kind: "step", url: "https://example.com/refund-dashboard.jpg" },
     ]);
   });
 

--- a/packages/player/src/player-selectors.test.ts
+++ b/packages/player/src/player-selectors.test.ts
@@ -96,11 +96,7 @@ function buildStoryIntroStep(): SerializedStep {
 function buildStoryResult(stepId: string, selectedChoiceId: string): StepResult {
   return {
     answer: { kind: "story", selectedChoiceId, selectedText: "choice" },
-    result: {
-      correctAnswer: null,
-      feedback: null,
-      isCorrect: selectedChoiceId !== "c3",
-    },
+    result: { correctAnswer: null, feedback: null, isCorrect: selectedChoiceId !== "c3" },
     stepId,
   };
 }
@@ -145,11 +141,7 @@ describe(getStoryBriefingText, () => {
       currentStepIndex: 2,
       steps: [
         buildStep({
-          content: {
-            text: "Welcome",
-            title: "Preamble",
-            variant: "text" as const,
-          },
+          content: { text: "Welcome", title: "Preamble", variant: "text" as const },
           id: "text-static",
           kind: "static",
           position: 0,
@@ -171,11 +163,7 @@ describe(findSelectedChoice, () => {
     const choice = findSelectedChoice({ results, step });
 
     expect(choice).toEqual(
-      expect.objectContaining({
-        alignment: "strong",
-        id: "c1",
-        text: "Strong choice",
-      }),
+      expect.objectContaining({ alignment: "strong", id: "c1", text: "Strong choice" }),
     );
   });
 
@@ -189,11 +177,7 @@ describe(findSelectedChoice, () => {
     const step = buildStoryStep("s1", 0);
     const results = {
       s1: {
-        answer: {
-          kind: "multipleChoice" as const,
-          selectedIndex: 0,
-          selectedText: "A",
-        },
+        answer: { kind: "multipleChoice" as const, selectedIndex: 0, selectedText: "A" },
         result: { correctAnswer: null, feedback: null, isCorrect: true },
         stepId: "s1",
       },
@@ -217,11 +201,7 @@ describe("findStoryIntroContent (via getStoryMetrics)", () => {
     const state = buildState({
       steps: [
         buildStep({
-          content: {
-            text: "Welcome",
-            title: "Preamble",
-            variant: "text" as const,
-          },
+          content: { text: "Welcome", title: "Preamble", variant: "text" as const },
           id: "text-static",
           kind: "static",
           position: 0,
@@ -322,24 +302,9 @@ function buildInvestigationActionStep(): SerializedStep {
   return buildStep({
     content: {
       actions: [
-        {
-          finding: "Clue A",
-          id: "a1",
-          label: "Check logs",
-          quality: "critical" as const,
-        },
-        {
-          finding: "Clue B",
-          id: "a2",
-          label: "Ask witness",
-          quality: "useful" as const,
-        },
-        {
-          finding: "Clue C",
-          id: "a3",
-          label: "Check camera",
-          quality: "weak" as const,
-        },
+        { finding: "Clue A", id: "a1", label: "Check logs", quality: "critical" as const },
+        { finding: "Clue B", id: "a2", label: "Ask witness", quality: "useful" as const },
+        { finding: "Clue C", id: "a3", label: "Check camera", quality: "weak" as const },
       ],
       variant: "action" as const,
     },
@@ -385,10 +350,7 @@ describe(getInvestigationProgress, () => {
       currentStepIndex: 0,
       steps: [
         buildStep({
-          content: {
-            scenario: "A mystery occurred.",
-            variant: "problem" as const,
-          },
+          content: { scenario: "A mystery occurred.", variant: "problem" as const },
           id: "problem-step",
           kind: "investigation",
         }),

--- a/packages/player/src/player-selectors.ts
+++ b/packages/player/src/player-selectors.ts
@@ -229,8 +229,9 @@ const DEFAULT_LOOKAHEAD = 3;
 
 /**
  * Extracts image URLs from a step so they can be preloaded before the user
- * navigates to it. Readable steps can carry one embedded illustration, and
- * selectImage steps can carry one URL per option.
+ * navigates to it. Readable steps can carry one embedded illustration,
+ * image-led practice questions can own one artifact image, and selectImage
+ * steps can carry one URL per option.
  */
 function getStepImages(step: SerializedStep): PreloadableImage[] {
   const descriptor = describePlayerStep(step);
@@ -242,6 +243,12 @@ function getStepImages(step: SerializedStep): PreloadableImage[] {
     descriptor?.kind === "storyIntro" ||
     descriptor?.kind === "storyOutcome"
   ) {
+    return descriptor.content.image?.url
+      ? [{ kind: "step", url: descriptor.content.image.url }]
+      : [];
+  }
+
+  if (descriptor?.kind === "multipleChoice") {
     return descriptor.content.image?.url
       ? [{ kind: "step", url: descriptor.content.image.url }]
       : [];


### PR DESCRIPTION
## Summary
- redesign practice generation around image-led scenarios with richer dialogue, stronger feedback guidance, and tighter image prompts
- add dedicated practice image generation presets plus workflow support for per-step practice images
- update the player to render image-led practice steps with the new layout and copy normalization behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make practice activities visual-first. Each scenario and decision step now gets a generated image, and the player uses a split media + decisions layout for faster, scene-led choices.

- **New Features**
  - Practice generation now authors `imagePrompt` for the scenario and each step, then creates images using a new `practice` preset; explanation uses the `illustration` preset via the shared `generate-activity-step-images-step` with progress streaming (`packages/ai`, `apps/api`).
  - Practice workflow generates and saves one scenario image plus one per question, with strict prompt validation and order preserved via `get-practice-image-prompts` (`apps/api`).
  - Player supports image-led multiple choice: new media layout, embedded desktop action on desktop, image preloading for question images, and cleaner copy via wrapping-quote stripping (`packages/player`).
  - Core multiple-choice content now supports an optional `image` in the contract (`packages/core`).
  - Updated copy and SEO: practice is described as a “visual real-world problem” (i18n and `apps/main`).

- **Bug Fixes**
  - Removed fallback image prompt creation and restored the minimum options requirement in practice output; ensured the image `preset` is passed through to the generator (`apps/api`, `packages/ai`).
  - Simplified and hardened quote stripping to remove only outer wrappers and preserve inner quotes (`packages/player`).

<sup>Written for commit dd7360f8cca6d14a1967138cdad13b316144cd42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

