### PR TITLE
refactor: simplify absence types

### DIFF
--- a/apps/admin/src/app/(private)/review/[group]/[task]/review-queue.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/review-queue.tsx
@@ -63,7 +63,7 @@ export async function ReviewQueue({
   currentId,
 }: {
   taskType: ReviewTaskType;
-  currentId: string | undefined;
+  currentId?: string;
 }) {
   const queue = await getNextReviewItem(taskType);
   const entityId = currentId ?? queue.entityId;

--- a/apps/admin/src/app/(private)/review/[group]/[task]/review-tabs.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/review-tabs.tsx
@@ -26,13 +26,7 @@ function TabLink({
   );
 }
 
-export async function ReviewTabs({
-  taskType,
-  view,
-}: {
-  taskType: ReviewTaskType;
-  view: string | undefined;
-}) {
+export async function ReviewTabs({ taskType, view }: { taskType: ReviewTaskType; view?: string }) {
   const counts = await countReviewStatuses(taskType);
   const basePath = getTaskPath(taskType);
   const isFlagged = view === "flagged";

--- a/apps/admin/src/app/(private)/stats/ai/[task]/ai-task-report.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/[task]/ai-task-report.tsx
@@ -146,7 +146,7 @@ async function getAiTaskReportState({
  * The task detail page now distinguishes the cheap overview from the more
  * expensive model drill-down with an explicit `view` flag in the URL.
  */
-function shouldShowAiTaskBreakdown(view?: string) {
+function shouldShowAiTaskBreakdown(view: string | null) {
   return view === "breakdown";
 }
 

--- a/apps/admin/src/app/(private)/stats/ai/page.tsx
+++ b/apps/admin/src/app/(private)/stats/ai/page.tsx
@@ -56,7 +56,7 @@ export default async function AiTasksPage({ searchParams }: PageProps<"/stats/ai
  * query string to those known values keeps the page logic explicit and ignores
  * any unsupported value without throwing.
  */
-function resolveAiTaskPageView(value?: string) {
+function resolveAiTaskPageView(value: string | null) {
   if (value === "summary" || value === "fallbacks") {
     return value;
   }

--- a/apps/admin/src/data/courses/list-courses.ts
+++ b/apps/admin/src/data/courses/list-courses.ts
@@ -6,7 +6,7 @@ import { cache } from "react";
 const cachedListCourses = cache(async function cachedListCourses(
   limit: number,
   offset: number,
-  search: string | undefined,
+  search?: string,
 ) {
   if (!(await isAdmin())) {
     return { courses: [], total: 0 };

--- a/apps/admin/src/data/stats/ai/_utils/ai-cost-estimate-helpers.ts
+++ b/apps/admin/src/data/stats/ai/_utils/ai-cost-estimate-helpers.ts
@@ -210,7 +210,7 @@ export function buildStepImageCountMap(rows: StepImageUsageRow[]): Record<string
  * place keeps the structure loader focused on domain values instead of database
  * transport types.
  */
-export function toNumber(value: bigint | number | null | undefined): number {
+export function toNumber(value?: bigint | number | null): number {
   if (typeof value === "bigint") {
     return Number(value);
   }

--- a/apps/admin/src/data/stats/ai/_utils/ai-cost-estimate-types.ts
+++ b/apps/admin/src/data/stats/ai/_utils/ai-cost-estimate-types.ts
@@ -36,7 +36,7 @@ export type AiCourseEstimateInputs = {
 };
 
 export type AiCourseEstimateInputOverrides = Partial<
-  Record<keyof AiCourseEstimateInputs, number | string | undefined>
+  Record<keyof AiCourseEstimateInputs, number | string | null>
 >;
 
 export type AiCostEstimateReport = {

--- a/apps/admin/src/data/stats/ai/_utils/ai-course-estimate-inputs.ts
+++ b/apps/admin/src/data/stats/ai/_utils/ai-course-estimate-inputs.ts
@@ -2,7 +2,7 @@ import { parseNumericId } from "@zoonk/utils/number";
 import { calculateAverageRequestsPerEntity } from "../ai-task-stats";
 import { type AiCourseEstimateInputs, type StructureStats } from "./ai-cost-estimate-types";
 
-type CourseInputOverride = number | string | undefined;
+type CourseInputOverride = number | string | null;
 
 /**
  * Course totals should be editable because course generation is on-demand and
@@ -127,7 +127,7 @@ function normalizeInteger({
 }: {
   fallback: number;
   minimum: number;
-  value: CourseInputOverride;
+  value?: CourseInputOverride;
 }) {
   const parsedValue = parseNumericId(value);
 

--- a/apps/admin/src/data/stats/ai/ai-task-stats.ts
+++ b/apps/admin/src/data/stats/ai/ai-task-stats.ts
@@ -79,7 +79,7 @@ export function buildAiTaskTag(taskName: string): string {
  * The task detail route receives a free-form path segment. We validate it before
  * sending it to the gateway so malformed values cannot become reporting filters.
  */
-export function isAiTaskName(value: string | null | undefined): value is string {
+export function isAiTaskName(value?: string | null): value is string {
   return value !== null && value !== undefined && AI_TASK_NAME_PATTERN.test(value);
 }
 
@@ -88,7 +88,7 @@ export function isAiTaskName(value: string | null | undefined): value is string 
  * `/`. This small validator is enough for reporting tags without pulling in a
  * broader schema dependency into the admin package.
  */
-function isAiModelId(value: string | null | undefined): value is string {
+function isAiModelId(value?: string | null): value is string {
   return value !== null && value !== undefined && AI_MODEL_ID_PATTERN.test(value);
 }
 
@@ -121,9 +121,9 @@ export function resolveAiTaskDateRange({
   now = new Date(),
   to,
 }: {
-  from?: string;
+  from?: string | null;
   now?: Date;
-  to?: string;
+  to?: string | null;
 }): AiTaskDateRange {
   const defaultRange = getDefaultAiTaskDateRange(now);
   const parsedEnd = parseDateInput(to);
@@ -145,7 +145,7 @@ export function resolveAiTaskDateRange({
  * whole numbers and fall back to a friendly default so the page can render an
  * estimate immediately without client-side state.
  */
-export function resolveEstimateRunCount(value?: string): number {
+export function resolveEstimateRunCount(value?: string | null): number {
   const parsedValue = Number.parseInt(value ?? "", 10);
   return Number.isInteger(parsedValue) && parsedValue > 0
     ? parsedValue
@@ -157,8 +157,8 @@ export function resolveEstimateRunCount(value?: string): number {
  * support one value per field, so this helper safely narrows those values
  * before the date-range and run-count parsers consume them.
  */
-export function getSingleSearchParamValue(value?: string | string[]): string | undefined {
-  return typeof value === "string" ? value : undefined;
+export function getSingleSearchParamValue(value?: string | string[]): string | null {
+  return typeof value === "string" ? value : null;
 }
 
 /**
@@ -300,7 +300,7 @@ function getUtcCalendarDay(date: Date): Date {
  * format. We add a round-trip check here so impossible values like `2026-02-31`
  * do not silently roll over to another month in the admin filters.
  */
-function parseDateInput(value?: string): Date | null {
+function parseDateInput(value?: string | null): Date | null {
   if (!value || !DATE_INPUT_PATTERN.test(value)) {
     return null;
   }

--- a/apps/admin/src/data/users/find-active-subscription.ts
+++ b/apps/admin/src/data/users/find-active-subscription.ts
@@ -12,9 +12,9 @@ type ActiveSubscriptionCandidate = {
  */
 export function findUserActiveSubscription<T extends ActiveSubscriptionCandidate>(
   subscriptions: T[],
-): T | undefined {
+): T | null {
   const sortedSubscriptions = subscriptions.toSorted(compareSubscriptionsByStartDate);
-  return sortedSubscriptions.find((subscription) => isActiveSubscription(subscription));
+  return sortedSubscriptions.find((subscription) => isActiveSubscription(subscription)) ?? null;
 }
 
 /**

--- a/apps/admin/src/data/users/list-users.ts
+++ b/apps/admin/src/data/users/list-users.ts
@@ -7,7 +7,7 @@ import { cache } from "react";
 const cachedListUsers = cache(async function cachedListUsers(
   limit: number,
   offset: number,
-  search: string | undefined,
+  search?: string,
 ) {
   if (!(await isAdmin())) {
     return { total: 0, users: [] };

--- a/apps/admin/src/lib/parse-search-params.ts
+++ b/apps/admin/src/lib/parse-search-params.ts
@@ -1,10 +1,10 @@
 const DEFAULT_PAGE_SIZE = 50;
 
-export function parseSearchParams(params: Record<string, string | string[] | undefined>): {
+export function parseSearchParams(params: Partial<Record<string, string | string[]>>): {
   page: number;
   limit: number;
   offset: number;
-  search: string | undefined;
+  search?: string;
 } {
   const page = Number(params.page) || 1;
   const limit = Number(params.limit) || DEFAULT_PAGE_SIZE;

--- a/apps/api/src/workflows/activity-generation/steps/_utils/save-reading-target-words.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/save-reading-target-words.ts
@@ -122,7 +122,7 @@ function removeCanonicalWords(canonicalWords: string[], distractorWords: string[
  * word. Preserve the existing DB value in that case, but still allow explicit `null` or
  * empty strings to clear stale romanization when the metadata entry is present.
  */
-function getRomanizationUpdate(metadata: WordMetadataEntry | undefined): {
+function getRomanizationUpdate(metadata?: WordMetadataEntry): {
   romanization?: string | null;
 } {
   if (metadata === undefined) {

--- a/apps/api/src/workflows/activity-generation/steps/save-grammar-steps-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-grammar-steps-step.ts
@@ -9,9 +9,9 @@ import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
 import { handleActivityFailureStep } from "./handle-failure-step";
 
-function nullableNonEmpty(value: string | null | undefined): string | undefined {
+function nullableNonEmpty(value?: string | null): string | null {
   if (!value || value.trim().length === 0) {
-    return undefined;
+    return null;
   }
 
   return value;

--- a/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.ts
@@ -47,13 +47,7 @@ function buildStoryChoices({
  * turns a missing array entry into a clear save-time failure instead of a
  * silently degraded step.
  */
-function getRequiredStoryImage({
-  image,
-  label,
-}: {
-  image: StepImage | undefined;
-  label: string;
-}): StepImage {
+function getRequiredStoryImage({ image, label }: { image?: StepImage; label: string }): StepImage {
   if (!image) {
     throw new Error(`Story image is missing for ${label}`);
   }

--- a/apps/blog/src/lib/authors.ts
+++ b/apps/blog/src/lib/authors.ts
@@ -35,6 +35,6 @@ const AUTHORS: Record<string, Author> = {
 };
 
 /** Look up an author by their ID. */
-export function getAuthor(authorId: string): Author | undefined {
-  return AUTHORS[authorId];
+export function getAuthor(authorId: string): Author | null {
+  return AUTHORS[authorId] ?? null;
 }

--- a/apps/editor/src/data/chapters/import-chapters.ts
+++ b/apps/editor/src/data/chapters/import-chapters.ts
@@ -54,7 +54,7 @@ async function resolveChapter(
     courseId: string;
     courseIsPublished: boolean;
     description: string;
-    existingChapter: Chapter | undefined;
+    existingChapter?: Chapter;
     hasExplicitSlug: boolean;
     index: number;
     language: string;

--- a/apps/editor/src/data/lessons/import-lessons.ts
+++ b/apps/editor/src/data/lessons/import-lessons.ts
@@ -57,7 +57,7 @@ async function resolveLesson(
     chapterId: string;
     chapterIsPublished: boolean;
     description: string;
-    existingLesson: Lesson | undefined;
+    existingLesson?: Lesson;
     hasExplicitSlug: boolean;
     index: number;
     kind: LessonKind;

--- a/apps/evals/src/lib/battle-loader.ts
+++ b/apps/evals/src/lib/battle-loader.ts
@@ -83,10 +83,13 @@ function aggregateScoresFromMatchups(matchups: BattleMatchup[]): {
   return { modelScores, totalJudgments };
 }
 
-function calculateModelMetrics(
-  outputs: ModelOutputs | undefined,
-  model: ModelConfig,
-): { averageDuration: number; averageCost: number } {
+function calculateModelMetrics({
+  model,
+  outputs,
+}: {
+  model: ModelConfig;
+  outputs?: ModelOutputs;
+}): { averageDuration: number; averageCost: number } {
   const numOutputs = outputs?.outputs.length ?? 0;
 
   if (numOutputs === 0 || !outputs) {
@@ -123,7 +126,7 @@ function buildLeaderboardEntry(
   }
 
   const outputs = allOutputs.get(modelId);
-  const { averageCost, averageDuration } = calculateModelMetrics(outputs, model);
+  const { averageCost, averageDuration } = calculateModelMetrics({ model, outputs });
 
   return {
     averageCost,

--- a/apps/evals/src/lib/eval-runner.ts
+++ b/apps/evals/src/lib/eval-runner.ts
@@ -50,11 +50,11 @@ async function saveScoredResults(taskId: string, modelId: string, results: Score
   await fs.writeFile(filePath, JSON.stringify(taskResults, null, 2));
 }
 
-function findTestCaseForOutput(task: Task, testCaseId: string): TestCase | undefined {
+function findTestCaseForOutput(task: Task, testCaseId: string): TestCase | null {
   // TestCaseId format is "{baseId}-{runNumber}"
   const lastDashIndex = testCaseId.lastIndexOf("-");
   const baseId = testCaseId.slice(0, lastDashIndex);
-  return task.testCases.find((testCase) => testCase.id === baseId);
+  return task.testCases.find((testCase) => testCase.id === baseId) ?? null;
 }
 
 async function scoreOutput(output: OutputEntry, testCase: TestCase): Promise<ScoredResult> {

--- a/apps/evals/src/lib/models.ts
+++ b/apps/evals/src/lib/models.ts
@@ -72,8 +72,8 @@ export function getModelDisplayName(model: ModelConfig): string {
   return model.name;
 }
 
-export function getModelById(modelId: string): ModelConfig | undefined {
-  return EVAL_MODELS.find((model) => model.id === modelId);
+export function getModelById(modelId: string): ModelConfig | null {
+  return EVAL_MODELS.find((model) => model.id === modelId) ?? null;
 }
 
 /**

--- a/apps/evals/src/lib/output-loader.ts
+++ b/apps/evals/src/lib/output-loader.ts
@@ -108,6 +108,6 @@ export async function getModelsWithCompleteOutputs(
 export function getOutputForTestCase(
   outputs: ModelOutputs,
   testCaseId: string,
-): OutputEntry | undefined {
-  return outputs.outputs.find((output) => output.testCaseId === testCaseId);
+): OutputEntry | null {
+  return outputs.outputs.find((output) => output.testCaseId === testCaseId) ?? null;
 }

--- a/apps/evals/src/tasks/index.ts
+++ b/apps/evals/src/tasks/index.ts
@@ -66,8 +66,8 @@ export const TASKS: readonly Task[] = [
 // Number of times each test case should be run for more reliable results
 export const RUNS_PER_TEST_CASE = 1;
 
-export function getTaskById(taskId: string): Task | undefined {
-  return TASKS.find((t) => t.id === taskId);
+export function getTaskById(taskId: string): Task | null {
+  return TASKS.find((t) => t.id === taskId) ?? null;
 }
 
 export function getTotalTestCases(taskId: string): number {

--- a/apps/main/src/data/progress/get-best-day.ts
+++ b/apps/main/src/data/progress/get-best-day.ts
@@ -11,7 +11,7 @@ type BestDayData = {
 };
 
 const cachedGetBestDay = cache(
-  async (startDateIso: string | undefined, headers?: Headers): Promise<BestDayData | null> => {
+  async (startDateIso?: string, headers?: Headers): Promise<BestDayData | null> => {
     const session = await getSession(headers);
     if (!session) {
       return null;

--- a/apps/main/src/data/progress/get-best-time.ts
+++ b/apps/main/src/data/progress/get-best-time.ts
@@ -12,7 +12,7 @@ type BestTimeData = {
 };
 
 const cachedGetBestTime = cache(
-  async (startDateIso: string | undefined, headers?: Headers): Promise<BestTimeData | null> => {
+  async (startDateIso?: string, headers?: Headers): Promise<BestTimeData | null> => {
     const session = await getSession(headers);
     if (!session) {
       return null;

--- a/apps/main/src/data/progress/get-score.ts
+++ b/apps/main/src/data/progress/get-score.ts
@@ -10,8 +10,8 @@ type ScoreData = {
 };
 
 function getDateRange(
-  startDateIso: string | undefined,
-  endDateIso: string | undefined,
+  startDateIso?: string,
+  endDateIso?: string,
 ): { startDate: Date; endDate: Date } {
   if (startDateIso && endDateIso) {
     return { endDate: new Date(endDateIso), startDate: new Date(startDateIso) };
@@ -32,8 +32,8 @@ function calculateScoreFromTotals(correct: number, incorrect: number): number | 
 
 const cachedGetScore = cache(
   async (
-    startDateIso: string | undefined,
-    endDateIso: string | undefined,
+    startDateIso?: string,
+    endDateIso?: string,
     headers?: Headers,
   ): Promise<ScoreData | null> => {
     const session = await getSession(headers);

--- a/apps/main/src/lib/workflow/generation-store.ts
+++ b/apps/main/src/lib/workflow/generation-store.ts
@@ -93,10 +93,7 @@ export function generationReducer<TStep extends string>(
  * Events without entityId are shared/batch events that apply to all entities.
  * When the viewer has no entityId (non-activity workflows), everything matches.
  */
-function isEventRelevantToViewer(
-  messageEntityId: string | undefined,
-  viewerEntityId: string | undefined,
-): boolean {
+function isEventRelevantToViewer(messageEntityId?: string, viewerEntityId?: string): boolean {
   if (messageEntityId === undefined) {
     return true;
   }

--- a/packages/ai/src/tasks/audio/generate-language-audio.ts
+++ b/packages/ai/src/tasks/audio/generate-language-audio.ts
@@ -30,7 +30,7 @@ type ScheduledAttempt = {
   name: string;
 };
 
-function buildInstructions(languageCode: string | undefined): string {
+function buildInstructions(languageCode?: string): string {
   const languageName = languageCode
     ? getLanguageName({ targetLanguage: languageCode, userLanguage: "en" })
     : "English";

--- a/packages/auth/src/stripe/subscription.ts
+++ b/packages/auth/src/stripe/subscription.ts
@@ -5,7 +5,7 @@ function isActiveSubscription<T extends SubscriptionStatus>(sub: T): boolean {
 }
 
 export function findActiveSubscription<T extends SubscriptionStatus>(
-  subscriptions: T[] | null | undefined,
-): T | undefined {
-  return subscriptions?.find((sub) => isActiveSubscription(sub));
+  subscriptions?: T[] | null,
+): T | null {
+  return subscriptions?.find((sub) => isActiveSubscription(sub)) ?? null;
 }

--- a/packages/core/src/orgs/org-permissions.ts
+++ b/packages/core/src/orgs/org-permissions.ts
@@ -28,8 +28,8 @@ async function getOrganizationId({
 const cachedHasCoursePermission = cache(
   async (
     permission: CoursePermission,
-    orgId: string | null | undefined,
-    orgSlug: string | undefined,
+    orgId?: string | null,
+    orgSlug?: string,
     reqHeaders?: Headers,
   ): Promise<boolean> => {
     const organizationId = await getOrganizationId({ orgId, orgSlug });

--- a/packages/core/src/player/contracts/build-investigation-action-results.ts
+++ b/packages/core/src/player/contracts/build-investigation-action-results.ts
@@ -26,7 +26,7 @@ export function buildInvestigationActionResults({
   investigationLoop,
   steps,
 }: {
-  investigationLoop: InvestigationLoopState | undefined;
+  investigationLoop?: InvestigationLoopState;
   steps: { id: string; kind: string; content: unknown }[];
 }): ActionStepResult[] {
   if (!investigationLoop) {

--- a/packages/core/src/player/contracts/build-word-bank-options.ts
+++ b/packages/core/src/player/contracts/build-word-bank-options.ts
@@ -53,10 +53,13 @@ function splitMultiWordEntries(lessonWord: SerializedWord): [string, WordMetadat
  * not carry translations. Preserve any existing translation when a later source only
  * contributes render metadata.
  */
-function mergeWordMetadata(
-  current: WordMetadata | undefined,
-  incoming: WordMetadata,
-): WordMetadata {
+function mergeWordMetadata({
+  current,
+  incoming,
+}: {
+  current?: WordMetadata;
+  incoming: WordMetadata;
+}): WordMetadata {
   return {
     audioUrl: incoming.audioUrl ?? current?.audioUrl ?? null,
     romanization: incoming.romanization ?? current?.romanization ?? null,
@@ -85,7 +88,7 @@ function getMergedWordMetadata(
   return entries
     .filter(([entryKey]) => entryKey === key)
     .map(([, metadata]) => metadata)
-    .reduce((current, incoming) => mergeWordMetadata(current, incoming));
+    .reduce((current, incoming) => mergeWordMetadata({ current, incoming }));
 }
 
 /**

--- a/packages/next/src/i18n/next-intl-codec.ts
+++ b/packages/next/src/i18n/next-intl-codec.ts
@@ -47,9 +47,9 @@ function localeCompare(a: string, b: string) {
   return a.localeCompare(b, "en");
 }
 
-function getUniqueReferences(references: Entry["references"]): { path: string }[] | undefined {
+function getUniqueReferences(references: Entry["references"]): { path: string }[] | null {
   if (!references || references.length === 0) {
-    return;
+    return null;
   }
 
   const uniquePaths = [...new Set(references.map((ref) => ref.path))];
@@ -110,13 +110,15 @@ export default defineCodec(() => {
         }
 
         const { description, id, message, references, ...rest } = msg;
+        const uniqueReferences = getUniqueReferences(references);
+
         return {
           ...(description && { extractedComments: [description] }),
+          ...(uniqueReferences ? { references: uniqueReferences } : {}),
           ...rest,
           msgctxt: id,
           msgid: sourceMessage,
           msgstr: message,
-          references: getUniqueReferences(references),
         };
       });
 

--- a/packages/player/src/components/_utils/feedback-romanization.test.ts
+++ b/packages/player/src/components/_utils/feedback-romanization.test.ts
@@ -72,7 +72,13 @@ describe(getFeedbackRomanization, () => {
       const result = buildResult({ arrangedWords: ["こんにちは", "世界"], kind: "reading" });
       const step = buildStep({ sentenceRomanization: "konnichiwa sekai" });
 
-      const rom = getFeedbackRomanization(result, step, "こんにちは 世界", null, null);
+      const rom = getFeedbackRomanization({
+        correctAnswer: null,
+        questionText: null,
+        result,
+        selectedText: "こんにちは 世界",
+        step,
+      });
 
       expect(rom.correctReading).toBe("konnichiwa sekai");
     });
@@ -81,7 +87,13 @@ describe(getFeedbackRomanization, () => {
       const result = buildResult({ arrangedWords: ["hello", "world"], kind: "reading" });
       const step = buildStep({ sentenceRomanization: "hello world" });
 
-      const rom = getFeedbackRomanization(result, step, "hello world", null, null);
+      const rom = getFeedbackRomanization({
+        correctAnswer: null,
+        questionText: null,
+        result,
+        selectedText: "hello world",
+        step,
+      });
 
       expect(rom.correctReading).toBeNull();
     });
@@ -90,7 +102,13 @@ describe(getFeedbackRomanization, () => {
       const result = buildResult({ arrangedWords: ["世界", "こんにちは"], kind: "reading" });
       const step = buildStep({ sentenceRomanization: "konnichiwa sekai" });
 
-      const rom = getFeedbackRomanization(result, step, null, "こんにちは 世界", null);
+      const rom = getFeedbackRomanization({
+        correctAnswer: "こんにちは 世界",
+        questionText: null,
+        result,
+        selectedText: null,
+        step,
+      });
 
       expect(rom.wrongReading).toBe("konnichiwa sekai");
     });
@@ -99,7 +117,13 @@ describe(getFeedbackRomanization, () => {
       const result = buildResult({ arrangedWords: ["world", "hello"], kind: "reading" });
       const step = buildStep({ sentenceRomanization: "hello world" });
 
-      const rom = getFeedbackRomanization(result, step, null, "hello world", null);
+      const rom = getFeedbackRomanization({
+        correctAnswer: "hello world",
+        questionText: null,
+        result,
+        selectedText: null,
+        step,
+      });
 
       expect(rom.wrongReading).toBeNull();
     });
@@ -115,7 +139,13 @@ describe(getFeedbackRomanization, () => {
       });
       const step = buildStep({ wordRomanization: "konnichiwa" });
 
-      const rom = getFeedbackRomanization(result, step, "こんにちは", null, "hello");
+      const rom = getFeedbackRomanization({
+        correctAnswer: null,
+        questionText: "hello",
+        result,
+        selectedText: "こんにちは",
+        step,
+      });
 
       expect(rom.correctReading).toBe("konnichiwa");
     });
@@ -129,7 +159,13 @@ describe(getFeedbackRomanization, () => {
       });
       const step = buildStep({ wordRomanization: "konnichiwa" });
 
-      const rom = getFeedbackRomanization(result, step, "konnichiwa", null, "hello");
+      const rom = getFeedbackRomanization({
+        correctAnswer: null,
+        questionText: "hello",
+        result,
+        selectedText: "konnichiwa",
+        step,
+      });
 
       expect(rom.correctReading).toBeNull();
     });
@@ -143,7 +179,13 @@ describe(getFeedbackRomanization, () => {
       });
       const step = buildStep({ wordRomanization: "konnichiwa" });
 
-      const rom = getFeedbackRomanization(result, step, "さようなら", "こんにちは", "hello");
+      const rom = getFeedbackRomanization({
+        correctAnswer: "こんにちは",
+        questionText: "hello",
+        result,
+        selectedText: "さようなら",
+        step,
+      });
 
       expect(rom.wrongReading).toBe("konnichiwa");
     });
@@ -157,7 +199,13 @@ describe(getFeedbackRomanization, () => {
       });
       const step = buildStep({ wordRomanization: "konnichiwa" });
 
-      const rom = getFeedbackRomanization(result, step, "wrong", "konnichiwa", "hello");
+      const rom = getFeedbackRomanization({
+        correctAnswer: "konnichiwa",
+        questionText: "hello",
+        result,
+        selectedText: "wrong",
+        step,
+      });
 
       expect(rom.wrongReading).toBeNull();
     });
@@ -171,7 +219,13 @@ describe(getFeedbackRomanization, () => {
       });
       const step = buildStep({ wordRomanization: "konnichiwa" });
 
-      const rom = getFeedbackRomanization(result, step, "こんにちは", null, "hello");
+      const rom = getFeedbackRomanization({
+        correctAnswer: null,
+        questionText: "hello",
+        result,
+        selectedText: "こんにちは",
+        step,
+      });
 
       expect(rom.translate).toBeNull();
     });
@@ -185,7 +239,13 @@ describe(getFeedbackRomanization, () => {
       });
       const step = buildStep();
 
-      const rom = getFeedbackRomanization(result, step, "こんにちは", null, "hello");
+      const rom = getFeedbackRomanization({
+        correctAnswer: null,
+        questionText: "hello",
+        result,
+        selectedText: "こんにちは",
+        step,
+      });
 
       expect(rom.correctReading).toBeNull();
       expect(rom.wrongReading).toBeNull();
@@ -197,7 +257,13 @@ describe(getFeedbackRomanization, () => {
       const result = buildResult({ arrangedWords: ["hello", "world"], kind: "listening" });
       const step = buildStep({ sentenceRomanization: "konnichiwa sekai" });
 
-      const rom = getFeedbackRomanization(result, step, null, null, "こんにちは 世界");
+      const rom = getFeedbackRomanization({
+        correctAnswer: null,
+        questionText: "こんにちは 世界",
+        result,
+        selectedText: null,
+        step,
+      });
 
       expect(rom.translate).toBe("konnichiwa sekai");
     });
@@ -206,7 +272,13 @@ describe(getFeedbackRomanization, () => {
       const result = buildResult({ arrangedWords: ["hello"], kind: "listening" });
       const step = buildStep({ sentenceRomanization: "konnichiwa" });
 
-      const rom = getFeedbackRomanization(result, step, null, null, "konnichiwa");
+      const rom = getFeedbackRomanization({
+        correctAnswer: null,
+        questionText: "konnichiwa",
+        result,
+        selectedText: null,
+        step,
+      });
 
       expect(rom.translate).toBeNull();
     });
@@ -215,7 +287,13 @@ describe(getFeedbackRomanization, () => {
       const result = buildResult({ arrangedWords: ["hello"], kind: "listening" });
       const step = buildStep({ sentenceRomanization: "konnichiwa" });
 
-      const rom = getFeedbackRomanization(result, step, "hello", "world", "こんにちは");
+      const rom = getFeedbackRomanization({
+        correctAnswer: "world",
+        questionText: "こんにちは",
+        result,
+        selectedText: "hello",
+        step,
+      });
 
       expect(rom.correctReading).toBeNull();
       expect(rom.wrongReading).toBeNull();
@@ -231,7 +309,13 @@ describe(getFeedbackRomanization, () => {
       });
       const step = buildStep({ sentenceRomanization: "romaji", wordRomanization: "romaji" });
 
-      const rom = getFeedbackRomanization(result, step, "option A", null, null);
+      const rom = getFeedbackRomanization({
+        correctAnswer: null,
+        questionText: null,
+        result,
+        selectedText: "option A",
+        step,
+      });
 
       expect(rom.correctReading).toBeNull();
       expect(rom.wrongReading).toBeNull();
@@ -244,7 +328,13 @@ describe(getFeedbackRomanization, () => {
       const result = buildResult();
       const step = buildStep({ sentenceRomanization: "romaji", wordRomanization: "romaji" });
 
-      const rom = getFeedbackRomanization(result, step, null, null, null);
+      const rom = getFeedbackRomanization({
+        correctAnswer: null,
+        questionText: null,
+        result,
+        selectedText: null,
+        step,
+      });
 
       expect(rom.correctReading).toBeNull();
       expect(rom.wrongReading).toBeNull();

--- a/packages/player/src/components/_utils/feedback-romanization.ts
+++ b/packages/player/src/components/_utils/feedback-romanization.ts
@@ -7,10 +7,13 @@ import { type StepResult } from "../../player-reducer";
  * (bad AI generation data where the original script was copied into
  * the romanization field instead of the Latin transliteration).
  */
-function getVisibleRomanization(
-  romanization: string | null | undefined,
-  displayedText: string,
-): string | null {
+function getVisibleRomanization({
+  displayedText,
+  romanization,
+}: {
+  displayedText: string;
+  romanization?: string | null;
+}): string | null {
   if (!romanization) {
     return null;
   }
@@ -22,39 +25,59 @@ function getVisibleRomanization(
   return romanization;
 }
 
-function getCorrectReadingRomanization(
-  kind: string | undefined,
-  selectedText: string | null,
+function getCorrectReadingRomanization({
+  kind,
+  romanizations,
+  selectedText,
+}: {
+  kind?: string;
+  selectedText: string | null;
   romanizations: {
-    sentenceRomanization: string | null | undefined;
-    wordRomanization: string | null | undefined;
-  },
-): string | null {
+    sentenceRomanization?: string | null;
+    wordRomanization?: string | null;
+  };
+}): string | null {
   if (kind === "reading" && selectedText) {
-    return getVisibleRomanization(romanizations.sentenceRomanization, selectedText);
+    return getVisibleRomanization({
+      displayedText: selectedText,
+      romanization: romanizations.sentenceRomanization,
+    });
   }
 
   if (kind === "translation" && selectedText) {
-    return getVisibleRomanization(romanizations.wordRomanization, selectedText);
+    return getVisibleRomanization({
+      displayedText: selectedText,
+      romanization: romanizations.wordRomanization,
+    });
   }
 
   return null;
 }
 
-function getWrongReadingRomanization(
-  kind: string | undefined,
-  correctAnswer: string | null | undefined,
+function getWrongReadingRomanization({
+  correctAnswer,
+  kind,
+  romanizations,
+}: {
+  correctAnswer?: string | null;
+  kind?: string;
   romanizations: {
-    sentenceRomanization: string | null | undefined;
-    wordRomanization: string | null | undefined;
-  },
-): string | null {
+    sentenceRomanization?: string | null;
+    wordRomanization?: string | null;
+  };
+}): string | null {
   if (kind === "reading" && correctAnswer) {
-    return getVisibleRomanization(romanizations.sentenceRomanization, correctAnswer);
+    return getVisibleRomanization({
+      displayedText: correctAnswer,
+      romanization: romanizations.sentenceRomanization,
+    });
   }
 
   if (kind === "translation" && correctAnswer) {
-    return getVisibleRomanization(romanizations.wordRomanization, correctAnswer);
+    return getVisibleRomanization({
+      displayedText: correctAnswer,
+      romanization: romanizations.wordRomanization,
+    });
   }
 
   return null;
@@ -70,13 +93,19 @@ function getWrongReadingRomanization(
  * to prevent showing romanization that matches the displayed text
  * (bad AI data).
  */
-export function getFeedbackRomanization(
-  result: StepResult,
-  step: SerializedStep | undefined,
-  selectedText: string | null,
-  correctAnswer: string | null | undefined,
-  questionText: string | null,
-) {
+export function getFeedbackRomanization({
+  correctAnswer,
+  questionText,
+  result,
+  selectedText,
+  step,
+}: {
+  correctAnswer?: string | null;
+  questionText: string | null;
+  result: StepResult;
+  selectedText: string | null;
+  step?: SerializedStep;
+}) {
   const sentenceRomanization = step?.sentence?.romanization;
   const wordRomanization = step?.word?.romanization;
   const kind = result.answer?.kind;
@@ -86,24 +115,35 @@ export function getFeedbackRomanization(
      * Romanization for the "Your answer:" line on correct answers.
      * Used by both reading (sentence romanization) and translation (word romanization).
      */
-    correctReading: getCorrectReadingRomanization(kind, selectedText, {
-      sentenceRomanization,
-      wordRomanization,
+    correctReading: getCorrectReadingRomanization({
+      kind,
+      romanizations: {
+        sentenceRomanization,
+        wordRomanization,
+      },
+      selectedText,
     }),
 
     /** Romanization for the "Translate:" line — only for listening (shows target language sentence). */
     translate:
       kind === "listening"
-        ? getVisibleRomanization(sentenceRomanization, questionText ?? "")
+        ? getVisibleRomanization({
+            displayedText: questionText ?? "",
+            romanization: sentenceRomanization,
+          })
         : null,
 
     /**
      * Romanization for the "Correct answer:" line on wrong answers.
      * Used by both reading (sentence romanization) and translation (word romanization).
      */
-    wrongReading: getWrongReadingRomanization(kind, correctAnswer, {
-      sentenceRomanization,
-      wordRomanization,
+    wrongReading: getWrongReadingRomanization({
+      correctAnswer,
+      kind,
+      romanizations: {
+        sentenceRomanization,
+        wordRomanization,
+      },
     }),
   };
 }

--- a/packages/player/src/components/arrange-words-answer-area.tsx
+++ b/packages/player/src/components/arrange-words-answer-area.tsx
@@ -44,7 +44,7 @@ function PlacedWordTile({
   resultState?: "correct" | "incorrect";
 }) {
   const t = useExtracted();
-  const hasResult = resultState !== undefined;
+  const hasResult = Boolean(resultState);
 
   const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({
     disabled: hasResult,

--- a/packages/player/src/components/arrange-words.tsx
+++ b/packages/player/src/components/arrange-words.tsx
@@ -101,7 +101,7 @@ export function ArrangeWordsInteraction({
   correctWords: string[];
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
   result?: StepResult;
-  selectedAnswer: SelectedAnswer | undefined;
+  selectedAnswer?: SelectedAnswer;
   stepId: string;
   wordBankOptions: WordBankOption[];
 }) {

--- a/packages/player/src/components/feedback-answer-blocks.tsx
+++ b/packages/player/src/components/feedback-answer-blocks.tsx
@@ -67,7 +67,7 @@ export function IncorrectAnswerBlock({
   romanization,
   selectedText,
 }: {
-  correctAnswer: string | null | undefined;
+  correctAnswer?: string | null;
   romanization: string | null;
   selectedText: string | null;
 }) {

--- a/packages/player/src/components/feedback-screen.tsx
+++ b/packages/player/src/components/feedback-screen.tsx
@@ -63,7 +63,13 @@ function StandardFeedbackContent({ result, step }: { result: StepResult; step?: 
       ? result.answer.selectedText
       : getArrangeWordsSelectedText(result);
   const questionText = getQuestionText(result, step);
-  const rom = getFeedbackRomanization(result, step, selectedText, correctAnswer, questionText);
+  const rom = getFeedbackRomanization({
+    correctAnswer,
+    questionText,
+    result,
+    selectedText,
+    step,
+  });
   const audioUrl = getFeedbackAudioUrl(step);
 
   return (

--- a/packages/player/src/components/fill-blank-step.test.tsx
+++ b/packages/player/src/components/fill-blank-step.test.tsx
@@ -49,7 +49,7 @@ function ParentWithState({
 }: {
   children: (props: {
     onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
-    selectedAnswer: SelectedAnswer | undefined;
+    selectedAnswer?: SelectedAnswer;
   }) => ReactNode;
 }) {
   const [answers, setAnswers] = useState<Record<string, SelectedAnswer>>({});

--- a/packages/player/src/components/fill-blank-step.tsx
+++ b/packages/player/src/components/fill-blank-step.tsx
@@ -20,11 +20,11 @@ function getBlankResultState(
   index: number,
   blanks: (string | null)[],
   answers: string[],
-): "correct" | "incorrect" | undefined {
+): "correct" | "incorrect" | null {
   const userAnswer = blanks[index];
 
   if (!userAnswer) {
-    return undefined;
+    return null;
   }
 
   return userAnswer.toLowerCase() === answers[index]?.toLowerCase() ? "correct" : "incorrect";
@@ -38,11 +38,11 @@ function BlankSlot({
 }: {
   index: number;
   onRemove: () => void;
-  resultState?: "correct" | "incorrect";
+  resultState: "correct" | "incorrect" | null;
   word: string | null;
 }) {
   const t = useExtracted();
-  const hasResult = resultState !== undefined;
+  const hasResult = Boolean(resultState);
 
   if (word) {
     return (
@@ -110,7 +110,7 @@ function TemplateText({
             <BlankSlot
               index={index}
               onRemove={() => onRemoveWord(index)}
-              resultState={hasResult ? getBlankResultState(index, blanks, answers) : undefined}
+              resultState={hasResult ? getBlankResultState(index, blanks, answers) : null}
               word={blanks[index] ?? null}
             />
           )}
@@ -208,7 +208,7 @@ export function FillBlankStep({
 }: {
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
   result?: StepResult;
-  selectedAnswer: SelectedAnswer | undefined;
+  selectedAnswer?: SelectedAnswer;
   step: SerializedStep;
 }) {
   const t = useExtracted();

--- a/packages/player/src/components/investigation-action-variant.tsx
+++ b/packages/player/src/components/investigation-action-variant.tsx
@@ -114,7 +114,7 @@ export function InvestigationActionVariant({
   content: ActionContent;
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
   result?: StepResult;
-  selectedAnswer: SelectedAnswer | undefined;
+  selectedAnswer?: SelectedAnswer;
   step: SerializedStep;
 }) {
   const { state } = usePlayerRuntime();

--- a/packages/player/src/components/investigation-call-variant.tsx
+++ b/packages/player/src/components/investigation-call-variant.tsx
@@ -41,9 +41,9 @@ function getResultState({
   hasFeedback: boolean;
   id: string;
   selectedId: string | null;
-}): "correct" | "incorrect" | undefined {
+}): "correct" | "incorrect" | null {
   if (!hasFeedback) {
-    return undefined;
+    return null;
   }
 
   if (id === selectedId) {
@@ -54,7 +54,7 @@ function getResultState({
     return "correct";
   }
 
-  return undefined;
+  return null;
 }
 
 /**
@@ -184,7 +184,7 @@ export function InvestigationCallVariant({
   content: CallContent;
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
   result?: StepResult;
-  selectedAnswer: SelectedAnswer | undefined;
+  selectedAnswer?: SelectedAnswer;
   step: SerializedStep;
 }) {
   const t = useExtracted();

--- a/packages/player/src/components/investigation-step.tsx
+++ b/packages/player/src/components/investigation-step.tsx
@@ -22,7 +22,7 @@ export function InvestigationStep({
 }: {
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
   result?: StepResult;
-  selectedAnswer: SelectedAnswer | undefined;
+  selectedAnswer?: SelectedAnswer;
   step: SerializedStep;
 }) {
   const descriptor = describePlayerStep(step);

--- a/packages/player/src/components/listening-step.tsx
+++ b/packages/player/src/components/listening-step.tsx
@@ -42,7 +42,7 @@ export function ListeningStep({
 }: {
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
   result?: StepResult;
-  selectedAnswer: SelectedAnswer | undefined;
+  selectedAnswer?: SelectedAnswer;
   step: SerializedStep;
 }) {
   if (!step.sentence) {

--- a/packages/player/src/components/match-columns-step.tsx
+++ b/packages/player/src/components/match-columns-step.tsx
@@ -147,7 +147,7 @@ export function MatchColumnsStep({
   step,
 }: {
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
-  selectedAnswer: SelectedAnswer | undefined;
+  selectedAnswer?: SelectedAnswer;
   step: SerializedStep;
 }) {
   const content = useMemo(() => parseStepContent("matchColumns", step.content), [step.content]);

--- a/packages/player/src/components/multiple-choice-step.tsx
+++ b/packages/player/src/components/multiple-choice-step.tsx
@@ -5,7 +5,7 @@ import { parseStepContent } from "@zoonk/core/steps/contract/content";
 import { type SelectedAnswer } from "../player-reducer";
 import { ChoiceStepLayout } from "./choice-step-layout";
 
-function getSelectedIndex(selectedAnswer: SelectedAnswer | undefined): number | null {
+function getSelectedIndex(selectedAnswer?: SelectedAnswer): number | null {
   if (selectedAnswer?.kind !== "multipleChoice") {
     return null;
   }
@@ -19,7 +19,7 @@ export function MultipleChoiceStep({
   step,
 }: {
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
-  selectedAnswer: SelectedAnswer | undefined;
+  selectedAnswer?: SelectedAnswer;
   step: SerializedStep;
 }) {
   const content = parseStepContent("multipleChoice", step.content);

--- a/packages/player/src/components/option-card.tsx
+++ b/packages/player/src/components/option-card.tsx
@@ -16,7 +16,7 @@ export function OptionCard({
   isDimmed?: boolean;
   isSelected: boolean;
   onSelect: () => void;
-  resultState?: "correct" | "incorrect";
+  resultState: "correct" | "incorrect" | null;
 }) {
   return (
     <button
@@ -36,7 +36,7 @@ export function OptionCard({
       role="radio"
       type="button"
     >
-      <ResultKbd isSelected={isSelected} resultState={resultState}>
+      <ResultKbd isSelected={isSelected} resultState={resultState ?? undefined}>
         {index + 1}
       </ResultKbd>
 

--- a/packages/player/src/components/player-choice-scene.tsx
+++ b/packages/player/src/components/player-choice-scene.tsx
@@ -16,7 +16,7 @@ type PlayerChoiceSceneOption = {
   isDimmed?: boolean;
   isSelected: boolean;
   key: string;
-  resultState?: PlayerChoiceOptionResultState;
+  resultState?: PlayerChoiceOptionResultState | null;
 };
 
 /**
@@ -142,7 +142,7 @@ export function PlayerChoiceSceneOptions({
           isSelected={option.isSelected}
           key={option.key}
           onSelect={() => onSelect(index)}
-          resultState={option.resultState}
+          resultState={option.resultState ?? null}
         >
           {option.content}
         </OptionCard>

--- a/packages/player/src/components/reading-step.tsx
+++ b/packages/player/src/components/reading-step.tsx
@@ -19,7 +19,7 @@ export function ReadingStep({
 }: {
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
   result?: StepResult;
-  selectedAnswer: SelectedAnswer | undefined;
+  selectedAnswer?: SelectedAnswer;
   step: SerializedStep;
 }) {
   const t = useExtracted();

--- a/packages/player/src/components/romanization-text.tsx
+++ b/packages/player/src/components/romanization-text.tsx
@@ -1,4 +1,4 @@
-export function RomanizationText({ children }: { children: string | null | undefined }) {
+export function RomanizationText({ children }: { children?: string | null }) {
   if (!children) {
     return null;
   }

--- a/packages/player/src/components/select-image-step.tsx
+++ b/packages/player/src/components/select-image-step.tsx
@@ -13,7 +13,7 @@ import { InlineFeedback } from "./inline-feedback";
 import { QuestionText } from "./question-text";
 import { InteractiveStepLayout } from "./step-layouts";
 
-function getSelectedIndex(selectedAnswer: SelectedAnswer | undefined): number | null {
+function getSelectedIndex(selectedAnswer?: SelectedAnswer): number | null {
   if (selectedAnswer?.kind !== "selectImage") {
     return null;
   }
@@ -25,7 +25,7 @@ function getImageOptionResultState(
   index: number,
   content: SelectImageStepContent,
   selectedIndex: number,
-): "correct" | "incorrect" | undefined {
+): "correct" | "incorrect" | null {
   if (content.options[index]?.isCorrect) {
     return "correct";
   }
@@ -34,10 +34,10 @@ function getImageOptionResultState(
     return "incorrect";
   }
 
-  return undefined;
+  return null;
 }
 
-function ImageWithFallback({ alt, url }: { alt: string; url: string | undefined }) {
+function ImageWithFallback({ alt, url }: { alt: string; url?: string }) {
   const [hasError, setHasError] = useState(false);
 
   if (!url || hasError) {
@@ -74,8 +74,8 @@ function ImageOptionCard({
   isSelected: boolean;
   onSelect: () => void;
   prompt: string;
-  resultState?: "correct" | "incorrect";
-  url: string | undefined;
+  resultState: "correct" | "incorrect" | null;
+  url?: string;
 }) {
   return (
     <button
@@ -107,7 +107,7 @@ export function SelectImageStep({
 }: {
   onSelectAnswer: (stepId: string, answer: SelectedAnswer) => void;
   result?: StepResult;
-  selectedAnswer: SelectedAnswer | undefined;
+  selectedAnswer?: SelectedAnswer;
   step: SerializedStep;
 }) {
   const t = useExtracted();
@@ -138,7 +138,7 @@ export function SelectImageStep({
           const resultState =
             hasResult && selectedIndex !== null
               ? getImageOptionResultState(index, content, selectedIndex)
-              : undefined;
+              : null;
           const isDimmed = hasResult && !resultState;
 
           return (

--- a/packages/player/src/components/sort-order-step.tsx
+++ b/packages/player/src/components/sort-order-step.tsx
@@ -237,7 +237,7 @@ export function SortOrderStep({
 }: {
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
   result?: StepResult;
-  selectedAnswer: SelectedAnswer | undefined;
+  selectedAnswer?: SelectedAnswer;
   step: SerializedStep;
 }) {
   const t = useExtracted();

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -53,7 +53,7 @@ function hasEmbeddedDesktopAction({
   step,
 }: {
   screen: PlayerRuntimeContextValue["screen"];
-  step: SerializedStep | undefined;
+  step?: SerializedStep;
 }) {
   if (screen.stageIsFullBleed) {
     return true;

--- a/packages/player/src/components/step-renderer.tsx
+++ b/packages/player/src/components/step-renderer.tsx
@@ -26,7 +26,7 @@ type StepRendererProps = {
   onNavigatePrev: () => void;
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
   result?: StepResult;
-  selectedAnswer: SelectedAnswer | undefined;
+  selectedAnswer?: SelectedAnswer;
   step: SerializedStep;
 };
 

--- a/packages/player/src/components/story-step.tsx
+++ b/packages/player/src/components/story-step.tsx
@@ -5,10 +5,13 @@ import { parseStepContent } from "@zoonk/core/steps/contract/content";
 import { type SelectedAnswer } from "../player-reducer";
 import { ChoiceStepLayout } from "./choice-step-layout";
 
-function getSelectedIndex(
-  selectedAnswer: SelectedAnswer | undefined,
-  choices: { id: string }[],
-): number | null {
+function getSelectedIndex({
+  choices,
+  selectedAnswer,
+}: {
+  choices: { id: string }[];
+  selectedAnswer?: SelectedAnswer;
+}): number | null {
   if (selectedAnswer?.kind !== "story") {
     return null;
   }
@@ -28,11 +31,11 @@ export function StoryStep({
   step,
 }: {
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
-  selectedAnswer: SelectedAnswer | undefined;
+  selectedAnswer?: SelectedAnswer;
   step: SerializedStep;
 }) {
   const content = parseStepContent("story", step.content);
-  const selectedIndex = getSelectedIndex(selectedAnswer, content.choices);
+  const selectedIndex = getSelectedIndex({ choices: content.choices, selectedAnswer });
 
   const handleSelect = (index: number) => {
     const choice = content.choices[index];

--- a/packages/player/src/components/translation-step.tsx
+++ b/packages/player/src/components/translation-step.tsx
@@ -17,7 +17,7 @@ import {
 } from "./player-choice-scene";
 import { RomanizationText } from "./romanization-text";
 
-function getSelectedWordId(selectedAnswer: SelectedAnswer | undefined): string | null {
+function getSelectedWordId(selectedAnswer?: SelectedAnswer): string | null {
   if (selectedAnswer?.kind !== "translation") {
     return null;
   }
@@ -51,7 +51,7 @@ export function TranslationStep({
   step,
 }: {
   onSelectAnswer: (stepId: string, answer: SelectedAnswer) => void;
-  selectedAnswer: SelectedAnswer | undefined;
+  selectedAnswer?: SelectedAnswer;
   step: SerializedStep;
 }) {
   const t = useExtracted();

--- a/packages/player/src/investigation-reducer.ts
+++ b/packages/player/src/investigation-reducer.ts
@@ -50,7 +50,7 @@ export function recordActionInLoop({
  */
 function clearStepAnswer(
   state: PlayerState,
-  stepId: string | undefined,
+  stepId?: string,
 ): { results: PlayerState["results"]; selectedAnswers: PlayerState["selectedAnswers"] } {
   if (!stepId) {
     return { results: state.results, selectedAnswers: state.selectedAnswers };

--- a/packages/player/src/investigation.test.ts
+++ b/packages/player/src/investigation.test.ts
@@ -165,10 +165,10 @@ describe(getInvestigationStepByVariant, () => {
     expect(step?.id).toBe("action-step");
   });
 
-  test("returns undefined when variant not found", () => {
+  test("returns null when variant not found", () => {
     const steps = [buildStep({ id: "s1", kind: "static" })];
     const step = getInvestigationStepByVariant(steps, "problem");
-    expect(step).toBeUndefined();
+    expect(step).toBeNull();
   });
 });
 

--- a/packages/player/src/investigation.ts
+++ b/packages/player/src/investigation.ts
@@ -27,29 +27,31 @@ type InvestigationVariant = InvestigationStepContent["variant"];
  * Investigation activities store each variant as a separate physical step
  * with `kind: "investigation"`. This helper scans all steps and parses
  * their content to find the one with the requested variant. Returns
- * undefined if no matching step exists.
+ * null if no matching step exists.
  */
 export function getInvestigationStepByVariant(
   steps: SerializedStep[],
   variant: InvestigationVariant,
-): SerializedStep | undefined {
-  return steps.find((step) => {
-    const descriptor = describePlayerStep(step);
+): SerializedStep | null {
+  return (
+    steps.find((step) => {
+      const descriptor = describePlayerStep(step);
 
-    if (descriptor?.kind === "investigationAction") {
-      return variant === "action";
-    }
+      if (descriptor?.kind === "investigationAction") {
+        return variant === "action";
+      }
 
-    if (descriptor?.kind === "investigationCall") {
-      return variant === "call";
-    }
+      if (descriptor?.kind === "investigationCall") {
+        return variant === "call";
+      }
 
-    if (descriptor?.kind === "investigationProblem") {
-      return variant === "problem";
-    }
+      if (descriptor?.kind === "investigationProblem") {
+        return variant === "problem";
+      }
 
-    return false;
-  });
+      return false;
+    }) ?? null
+  );
 }
 
 /**

--- a/packages/player/src/player-reducer.ts
+++ b/packages/player/src/player-reducer.ts
@@ -32,7 +32,7 @@ export type SelectedAnswer =
 
 export type StepResult = {
   stepId: string;
-  answer: SelectedAnswer | undefined;
+  answer?: SelectedAnswer;
   result: AnswerResult;
 };
 

--- a/packages/player/src/use-word-audio.ts
+++ b/packages/player/src/use-word-audio.ts
@@ -11,7 +11,7 @@ type UseWordAudioOptions = {
  * Word banks can repeat the same audio URL or include empty entries. Normalizing the list in one
  * place keeps the preload effect focused on the small set of files that can actually be played.
  */
-function getUniqueAudioUrls(urls: (string | null)[] | undefined): string[] {
+function getUniqueAudioUrls(urls?: (string | null)[]): string[] {
   if (!urls) {
     return [];
   }

--- a/packages/ui/src/hooks/use-keyboard.ts
+++ b/packages/ui/src/hooks/use-keyboard.ts
@@ -47,11 +47,15 @@ function getModifierChecks(event: KeyboardEvent, modifiers: KeyboardModifiers): 
   return checks;
 }
 
-function checkModifiers(
-  event: KeyboardEvent,
-  modifiers: KeyboardModifiers | undefined,
-  mode: ModifierMode,
-): boolean {
+function checkModifiers({
+  event,
+  mode,
+  modifiers,
+}: {
+  event: KeyboardEvent;
+  mode: ModifierMode;
+  modifiers?: KeyboardModifiers;
+}): boolean {
   if (mode === "none") {
     return !hasAnyModifier(event);
   }
@@ -142,7 +146,7 @@ export function useKeyboardCallback(
 
       const mods = { altKey, ctrlKey, metaKey, shiftKey };
 
-      if (checkModifiers(event, mods, mode)) {
+      if (checkModifiers({ event, mode, modifiers: mods })) {
         onKeyPress(event);
       }
     }

--- a/packages/utils/src/locale.ts
+++ b/packages/utils/src/locale.ts
@@ -23,11 +23,11 @@ export const LOCALE_LABELS: Record<SupportedLocale, string> = {
   pt: "Português",
 } as const;
 
-function parseRegion(tag: string): string | undefined {
+function parseRegion(tag: string): string | null {
   try {
-    return new Intl.Locale(tag.split(";")[0]?.trim() ?? "").region;
+    return new Intl.Locale(tag.split(";")[0]?.trim() ?? "").region ?? null;
   } catch {
-    return undefined;
+    return null;
   }
 }
 
@@ -39,7 +39,7 @@ export function getCountryFromAcceptLanguage(acceptLanguage: string | null): str
   const region = acceptLanguage
     .split(",")
     .map((tag) => parseRegion(tag))
-    .find((found) => found !== undefined);
+    .find(Boolean);
 
   return region ?? DEFAULT_COUNTRY;
 }

--- a/packages/utils/src/subscription.ts
+++ b/packages/utils/src/subscription.ts
@@ -75,7 +75,7 @@ export function getPlanTier(planName: string | null): number {
  * the subscription. Every other provider needs a different handoff.
  */
 export function isWebManagedSubscriptionProvider(
-  provider: SubscriptionProvider | null | undefined,
+  provider?: SubscriptionProvider | null,
 ): provider is "stripe" {
   return provider === "stripe";
 }
@@ -85,7 +85,7 @@ export function isWebManagedSubscriptionProvider(
  * pretending the web app can cancel or change them.
  */
 export function isStoreSubscriptionProvider(
-  provider: SubscriptionProvider | null | undefined,
+  provider?: SubscriptionProvider | null,
 ): provider is "apple" | "google" {
   return provider === "apple" || provider === "google";
 }


### PR DESCRIPTION
Simplifies optional type shapes across the repo by using optional fields and parameters instead of explicit undefined unions.

Normalizes intentional no-result return contracts to null while preserving framework and JavaScript sentinel undefined cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes absence handling across the codebase by using optional params/fields and returning null for intentional “no result”, with focused updates in `packages/player` and UI helpers. This simplifies types, clarifies contracts, and reduces undefined unions.

- **Refactors**
  - Replaced `T | undefined` unions with optional params/props across `apps/*`, `packages/*`.
  - Normalized “not found” to `null` in helpers (e.g., `getModelById`, `getTaskById`, `findActiveSubscription`, `getAuthor`, output lookups).
  - Player updates:
    - `getFeedbackRomanization` now uses a single options object and keeps romanization hidden when it matches displayed text.
    - Result-state props now use `"correct" | "incorrect" | null` and checks use `Boolean(...)`.
    - Component props accept `selectedAnswer?`; reducer/result types use optional `answer`.
    - `getInvestigationStepByVariant` returns `null` when missing.

- **Migration**
  - Expect `null` (not `undefined`) from “no result” helpers.
  - Update calls to `getFeedbackRomanization`:
    - Before: `getFeedbackRomanization(result, step, selectedText, correctAnswer, questionText)`
    - After: `getFeedbackRomanization({ result, step, selectedText, correctAnswer, questionText })`
  - Pass/handle `null` result states in player UI (`OptionCard`, image/multiple choice/select components).

<sup>Written for commit 48595a311bf409e84a9d12756a7fbd281de51e78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

