### PR TITLE
fix(api): preserve workflow step failures

### DIFF
--- a/apps/api/src/workflows/_shared/stream-status.ts
+++ b/apps/api/src/workflows/_shared/stream-status.ts
@@ -20,7 +20,7 @@ export function getAIResultErrorReason({
   return "contentValidationFailed";
 }
 
-export type StepStream<T extends string> = {
+type StepStream<T extends string> = {
   status: (params: StepStreamMessage<T>) => Promise<void>;
   error: (params: { reason: WorkflowErrorReason; step: T }) => Promise<void>;
   [Symbol.asyncDispose]: () => Promise<void>;

--- a/apps/api/src/workflows/_shared/workflow-error.test.ts
+++ b/apps/api/src/workflows/_shared/workflow-error.test.ts
@@ -52,4 +52,21 @@ describe(serializeWorkflowError, () => {
       stack: expect.any(String),
     });
   });
+
+  test("serializes circular nested errors without recursing forever", () => {
+    const error = new AggregateError([], "Course status updates failed");
+    error.errors.push(error);
+
+    expect(serializeWorkflowError(error)).toEqual({
+      errors: [
+        {
+          message: "Circular error reference",
+          name: "Error",
+        },
+      ],
+      message: "Course status updates failed",
+      name: "AggregateError",
+      stack: expect.any(String),
+    });
+  });
 });

--- a/apps/api/src/workflows/_shared/workflow-error.test.ts
+++ b/apps/api/src/workflows/_shared/workflow-error.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+import { serializeWorkflowError } from "./workflow-error";
+
+describe(serializeWorkflowError, () => {
+  test("preserves Error details", () => {
+    const error = new TypeError("AI provider failed");
+
+    expect(serializeWorkflowError(error)).toEqual({
+      message: "AI provider failed",
+      name: "TypeError",
+      stack: expect.any(String),
+    });
+  });
+
+  test("preserves message fields from plain provider errors", () => {
+    expect(
+      serializeWorkflowError({
+        message: "Rate limit exceeded",
+        name: "AI_RetryError",
+        stack: "stack trace",
+      }),
+    ).toEqual({
+      message: "Rate limit exceeded",
+      name: "AI_RetryError",
+      stack: "stack trace",
+    });
+  });
+
+  test("serializes unusual thrown values without throwing", () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+
+    expect(serializeWorkflowError(circular)).toEqual({
+      message: "[object Object]",
+      name: "Error",
+    });
+  });
+
+  test("preserves every nested AggregateError failure", () => {
+    const error = new AggregateError(
+      [new Error("course update failed"), new Error("suggestion update failed")],
+      "Course status updates failed",
+    );
+
+    expect(serializeWorkflowError(error)).toEqual({
+      errors: [
+        expect.objectContaining({ message: "course update failed", name: "Error" }),
+        expect.objectContaining({ message: "suggestion update failed", name: "Error" }),
+      ],
+      message: "Course status updates failed",
+      name: "AggregateError",
+      stack: expect.any(String),
+    });
+  });
+});

--- a/apps/api/src/workflows/_shared/workflow-error.ts
+++ b/apps/api/src/workflows/_shared/workflow-error.ts
@@ -1,0 +1,92 @@
+import { isJsonObject } from "@zoonk/utils/json";
+
+export type WorkflowErrorLog = {
+  errors?: WorkflowErrorLog[];
+  message: string;
+  name: string;
+  stack?: string;
+};
+
+/**
+ * Reads string properties from non-Error thrown values. Some provider and SDK
+ * failures cross boundaries as plain objects, and preserving their `message`,
+ * `name`, and `stack` fields is more useful than logging a generic JSON blob.
+ */
+function getStringProperty(value: unknown, key: string): string | undefined {
+  if (!isJsonObject(value) || !(key in value)) {
+    return undefined;
+  }
+
+  const property = value[key];
+
+  return typeof property === "string" ? property : undefined;
+}
+
+/**
+ * Reads nested errors from AggregateError-like values. Workflow serialization
+ * may preserve an AggregateError as a plain object, so this accepts any object
+ * with an array-shaped `errors` field.
+ */
+function getErrorsProperty(value: unknown): unknown[] | undefined {
+  if (!isJsonObject(value) || !("errors" in value)) {
+    return undefined;
+  }
+
+  return Array.isArray(value.errors) ? value.errors : undefined;
+}
+
+/**
+ * Stringifies unusual thrown values without letting logging serialization become
+ * a second workflow failure. This handles circular objects and values like
+ * BigInt that `JSON.stringify` cannot encode.
+ */
+function stringifyUnknownError(error: unknown): string {
+  try {
+    const serialized = JSON.stringify(error);
+    return serialized ?? String(error);
+  } catch {
+    return String(error);
+  }
+}
+
+/**
+ * Converts an unknown thrown value into a plain object that can cross workflow
+ * step boundaries. Workflow steps persist arguments, so passing raw `Error`
+ * instances is fragile; this keeps the original AI/provider message visible in
+ * final failure logs without changing the thrown error itself.
+ */
+export function serializeWorkflowError(error: unknown): WorkflowErrorLog {
+  if (error instanceof Error) {
+    const errors = getErrorsProperty(error);
+
+    return {
+      ...(errors
+        ? { errors: errors.map((nestedError) => serializeWorkflowError(nestedError)) }
+        : {}),
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+    };
+  }
+
+  if (typeof error === "string") {
+    return { message: error, name: "Error" };
+  }
+
+  const message = getStringProperty(error, "message");
+
+  if (message) {
+    const errors = getErrorsProperty(error);
+
+    return {
+      ...(errors
+        ? { errors: errors.map((nestedError) => serializeWorkflowError(nestedError)) }
+        : {}),
+      message,
+      name: getStringProperty(error, "name") ?? "Error",
+      stack: getStringProperty(error, "stack"),
+    };
+  }
+
+  return { message: stringifyUnknownError(error), name: "Error" };
+}

--- a/apps/api/src/workflows/_shared/workflow-error.ts
+++ b/apps/api/src/workflows/_shared/workflow-error.ts
@@ -23,19 +23,6 @@ function getStringProperty(value: unknown, key: string): string | undefined {
 }
 
 /**
- * Reads nested errors from AggregateError-like values. Workflow serialization
- * may preserve an AggregateError as a plain object, so this accepts any object
- * with an array-shaped `errors` field.
- */
-function getErrorsProperty(value: unknown): unknown[] | undefined {
-  if (!isJsonObject(value) || !("errors" in value)) {
-    return undefined;
-  }
-
-  return Array.isArray(value.errors) ? value.errors : undefined;
-}
-
-/**
  * Stringifies unusual thrown values without letting logging serialization become
  * a second workflow failure. This handles circular objects and values like
  * BigInt that `JSON.stringify` cannot encode.
@@ -50,43 +37,70 @@ function stringifyUnknownError(error: unknown): string {
 }
 
 /**
+ * Serializes AggregateError-style nested failures when they exist. Workflow can
+ * deserialize AggregateError as a plain object, so this checks the shape instead
+ * of relying only on `instanceof AggregateError`.
+ */
+function serializeNestedErrors(
+  error: unknown,
+  seen: WeakSet<object>,
+): WorkflowErrorLog[] | undefined {
+  if (!isJsonObject(error) || !Array.isArray(error.errors)) {
+    return undefined;
+  }
+
+  return error.errors.map((nestedError) => serializeWorkflowError(nestedError, seen));
+}
+
+/**
  * Converts an unknown thrown value into a plain object that can cross workflow
  * step boundaries. Workflow steps persist arguments, so passing raw `Error`
  * instances is fragile; this keeps the original AI/provider message visible in
  * final failure logs without changing the thrown error itself.
  */
-export function serializeWorkflowError(error: unknown): WorkflowErrorLog {
-  if (error instanceof Error) {
-    const errors = getErrorsProperty(error);
+export function serializeWorkflowError(
+  error: unknown,
+  seen = new WeakSet<object>(),
+): WorkflowErrorLog {
+  if (typeof error === "object" && error !== null) {
+    if (seen.has(error)) {
+      return { message: "Circular error reference", name: "Error" };
+    }
 
-    return {
-      ...(errors
-        ? { errors: errors.map((nestedError) => serializeWorkflowError(nestedError)) }
-        : {}),
-      message: error.message,
-      name: error.name,
-      stack: error.stack,
-    };
+    seen.add(error);
   }
 
-  if (typeof error === "string") {
-    return { message: error, name: "Error" };
+  try {
+    const errors = serializeNestedErrors(error, seen);
+
+    if (error instanceof Error) {
+      return {
+        ...(errors ? { errors } : {}),
+        message: error.message,
+        name: error.name,
+        stack: error.stack,
+      };
+    }
+
+    if (typeof error === "string") {
+      return { message: error, name: "Error" };
+    }
+
+    const message = getStringProperty(error, "message");
+
+    if (message) {
+      return {
+        ...(errors ? { errors } : {}),
+        message,
+        name: getStringProperty(error, "name") ?? "Error",
+        stack: getStringProperty(error, "stack"),
+      };
+    }
+
+    return { message: stringifyUnknownError(error), name: "Error" };
+  } finally {
+    if (typeof error === "object" && error !== null) {
+      seen.delete(error);
+    }
   }
-
-  const message = getStringProperty(error, "message");
-
-  if (message) {
-    const errors = getErrorsProperty(error);
-
-    return {
-      ...(errors
-        ? { errors: errors.map((nestedError) => serializeWorkflowError(nestedError)) }
-        : {}),
-      message,
-      name: getStringProperty(error, "name") ?? "Error",
-      stack: getStringProperty(error, "stack"),
-    };
-  }
-
-  return { message: stringifyUnknownError(error), name: "Error" };
 }

--- a/apps/api/src/workflows/activity-generation/activity-generation-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/activity-generation-workflow.ts
@@ -1,3 +1,4 @@
+import { serializeWorkflowError } from "@/workflows/_shared/workflow-error";
 import { FatalError, getWorkflowMetadata } from "workflow";
 import { coreActivityWorkflow } from "./core-activity-workflow";
 import { customActivityWorkflow } from "./custom-activity-workflow";
@@ -99,7 +100,10 @@ export async function activityGenerationWorkflow(
     });
   } catch (error) {
     if (!options.regeneration) {
-      await handleWorkflowFailureStep({ lessonId });
+      await handleWorkflowFailureStep({
+        error: serializeWorkflowError(error),
+        lessonId,
+      });
     }
 
     throw error;

--- a/apps/api/src/workflows/activity-generation/handle-activity-workflow-error.test.ts
+++ b/apps/api/src/workflows/activity-generation/handle-activity-workflow-error.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { failActivityWorkflow, failActivityWorkflows } from "./handle-activity-workflow-error";
+import { handleActivityFailureStep } from "./steps/handle-failure-step";
+
+vi.mock("./steps/handle-failure-step", () => ({
+  handleActivityFailureStep: vi.fn(async () => {}),
+}));
+
+describe("activity workflow failure handling", () => {
+  beforeEach(() => {
+    vi.mocked(handleActivityFailureStep).mockReset();
+    vi.mocked(handleActivityFailureStep).mockImplementation(async () => {});
+  });
+
+  test("rethrows the original workflow error when the failure step rejects", async () => {
+    const originalError = new Error("AI generation failed");
+
+    vi.mocked(handleActivityFailureStep).mockRejectedValueOnce(
+      new Error("Failed to mark activity failed"),
+    );
+
+    await expect(
+      failActivityWorkflow({
+        activityId: "activity-1",
+        error: originalError,
+      }),
+    ).rejects.toBe(originalError);
+  });
+
+  test("attempts every activity failure update before rethrowing the original error", async () => {
+    const originalError = new Error("Vocabulary generation failed");
+
+    vi.mocked(handleActivityFailureStep).mockRejectedValueOnce(new Error("First update failed"));
+
+    await expect(
+      failActivityWorkflows({
+        activityIds: ["vocabulary-activity", "translation-activity"],
+        error: originalError,
+      }),
+    ).rejects.toBe(originalError);
+
+    expect(handleActivityFailureStep).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/workflows/activity-generation/handle-activity-workflow-error.ts
+++ b/apps/api/src/workflows/activity-generation/handle-activity-workflow-error.ts
@@ -17,11 +17,17 @@ export async function failActivityWorkflow({
   error: unknown;
   reason?: WorkflowErrorReason;
 }): Promise<never> {
-  await handleActivityFailureStep({
-    activityId,
-    error: serializeWorkflowError(error),
-    reason,
-  });
+  try {
+    await handleActivityFailureStep({
+      activityId,
+      error: serializeWorkflowError(error),
+      reason,
+    });
+  } catch {
+    // Preserve the original workflow failure. The failure step logs the original
+    // error before it writes permanent state, so this cleanup path must never
+    // replace the AI/task error that caused the workflow to fail.
+  }
 
   throw error;
 }
@@ -41,7 +47,7 @@ export async function failActivityWorkflows({
   error: unknown;
   reason?: WorkflowErrorReason;
 }): Promise<never> {
-  await Promise.all(
+  await Promise.allSettled(
     activityIds.map((activityId) =>
       handleActivityFailureStep({
         activityId,

--- a/apps/api/src/workflows/activity-generation/handle-activity-workflow-error.ts
+++ b/apps/api/src/workflows/activity-generation/handle-activity-workflow-error.ts
@@ -1,0 +1,55 @@
+import { serializeWorkflowError } from "@/workflows/_shared/workflow-error";
+import { type WorkflowErrorReason } from "@zoonk/core/workflows/steps";
+import { handleActivityFailureStep } from "./steps/handle-failure-step";
+
+/**
+ * Converts a final activity-kind workflow error into permanent activity state.
+ * Step functions should still throw their original errors so Workflow can retry
+ * them; this helper is only for catch blocks that run after those retries are
+ * exhausted and need to update the affected activity row.
+ */
+export async function failActivityWorkflow({
+  activityId,
+  error,
+  reason,
+}: {
+  activityId: string;
+  error: unknown;
+  reason?: WorkflowErrorReason;
+}): Promise<never> {
+  await handleActivityFailureStep({
+    activityId,
+    error: serializeWorkflowError(error),
+    reason,
+  });
+
+  throw error;
+}
+
+/**
+ * Marks every activity that depends on the same failed workflow branch, then
+ * rethrows the original error so the branch remains failed in Workflow
+ * observability. Use this only when those activities cannot complete without
+ * the same upstream artifact, such as translation depending on vocabulary.
+ */
+export async function failActivityWorkflows({
+  activityIds,
+  error,
+  reason,
+}: {
+  activityIds: string[];
+  error: unknown;
+  reason?: WorkflowErrorReason;
+}): Promise<never> {
+  await Promise.all(
+    activityIds.map((activityId) =>
+      handleActivityFailureStep({
+        activityId,
+        error: serializeWorkflowError(error),
+        reason,
+      }),
+    ),
+  );
+
+  throw error;
+}

--- a/apps/api/src/workflows/activity-generation/kinds/custom-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/custom-workflow.ts
@@ -1,29 +1,9 @@
+import { failActivityWorkflow } from "../handle-activity-workflow-error";
 import { generateCustomContentStep } from "../steps/generate-custom-content-step";
 import { generateCustomImagePromptsStep } from "../steps/generate-custom-image-prompts-step";
 import { generateCustomStepImagesStep } from "../steps/generate-custom-step-images-step";
 import { type LessonActivity } from "../steps/get-lesson-activities-step";
-import { handleActivityFailureStep } from "../steps/handle-failure-step";
 import { saveCustomActivityStep } from "../steps/save-custom-activity-step";
-
-/**
- * Marks custom activities as failed when the content generation step
- * dropped their result (e.g., the AI call threw and Promise.allSettled
- * silently discarded the rejected promise). Without this, those activities
- * would stay "running" forever since no downstream step touches them.
- */
-async function markDroppedCustomActivitiesAsFailed(
-  activitiesToGenerate: LessonActivity[],
-  contentResults: { activityId: string }[],
-): Promise<void> {
-  const customActivitiesToGenerate = activitiesToGenerate.filter((a) => a.kind === "custom");
-  const resultActivityIds = new Set(contentResults.map((result) => result.activityId));
-
-  await Promise.allSettled(
-    customActivitiesToGenerate
-      .filter((activity) => !resultActivityIds.has(activity.id))
-      .map((activity) => handleActivityFailureStep({ activityId: activity.id })),
-  );
-}
 
 /**
  * Orchestrates custom activity generation with per-entity save.
@@ -48,35 +28,21 @@ export async function customActivityWorkflow({
     return;
   }
 
-  const customContent = await generateCustomContentStep(customActivitiesToGenerate);
-
-  await markDroppedCustomActivitiesAsFailed(activitiesToGenerate, customContent);
-
-  const customPrompts = await generateCustomImagePromptsStep(
-    customActivitiesToGenerate,
-    customContent,
-  );
-  const customImages = await generateCustomStepImagesStep(
-    customActivitiesToGenerate,
-    customPrompts,
-  );
-
   await Promise.allSettled(
-    customContent.map(async (contentResult) => {
-      const imageResult = customImages.find(
-        (image) => image.activityId === contentResult.activityId,
-      );
-      const images = imageResult?.images ?? [];
-
+    customActivitiesToGenerate.map(async (activity) => {
       try {
+        const contentResult = await generateCustomContentStep(activity);
+        const promptResult = await generateCustomImagePromptsStep(activity, contentResult);
+        const { images } = await generateCustomStepImagesStep(activity, promptResult);
+
         await saveCustomActivityStep({
           activityId: contentResult.activityId,
           contentSteps: contentResult.steps,
           images,
           workflowRunId,
         });
-      } catch {
-        await handleActivityFailureStep({ activityId: contentResult.activityId });
+      } catch (error) {
+        await failActivityWorkflow({ activityId: activity.id, error });
       }
     }),
   );

--- a/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.test.ts
@@ -410,7 +410,7 @@ describe("explanation activity workflow", () => {
     expect(healthyResult.generationStatus).toBe("completed");
   });
 
-  test("streams entity ids for image generation and save steps, but not for batch content generation", async () => {
+  test("streams entity ids for generated explanation steps", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       concepts: ["First Concept", "Second Concept"],
@@ -449,6 +449,7 @@ describe("explanation activity workflow", () => {
     const activityIds = new Set([firstActivity.id, secondActivity.id]);
 
     for (const stepName of [
+      "generateExplanationContent",
       "generateImagePrompts",
       "generateStepImages",
       "saveExplanationActivity",
@@ -460,16 +461,6 @@ describe("explanation activity workflow", () => {
         expect(message.entityId).toBeDefined();
         expect(activityIds.has(message.entityId!)).toBe(true);
       }
-    }
-
-    const batchMessages = streamedMessages.filter(
-      (message) => message.step === "generateExplanationContent",
-    );
-
-    expect(batchMessages.length).toBeGreaterThan(0);
-
-    for (const message of batchMessages) {
-      expect(message.entityId).toBeUndefined();
     }
   });
 });

--- a/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/explanation-workflow.ts
@@ -1,3 +1,5 @@
+import { settledValues } from "@zoonk/utils/settled";
+import { failActivityWorkflow } from "../handle-activity-workflow-error";
 import { getExistingContentSteps } from "../steps/_utils/content-step-helpers";
 import { findActivitiesByKind } from "../steps/_utils/find-activity-by-kind";
 import { generateActivityStepImagesStep } from "../steps/generate-activity-step-images-step";
@@ -8,28 +10,7 @@ import {
 } from "../steps/generate-explanation-content-step";
 import { generateExplanationImagePromptsStep } from "../steps/generate-explanation-image-prompts-step";
 import { type LessonActivity } from "../steps/get-lesson-activities-step";
-import { handleActivityFailureStep } from "../steps/handle-failure-step";
 import { saveExplanationActivityStep } from "../steps/save-explanation-activity-step";
-
-/**
- * Marks explanation activities as failed when the content generation step
- * dropped their result (e.g., the AI call threw and Promise.allSettled
- * silently discarded the rejected promise). Without this, those activities
- * would stay "running" forever since no downstream step touches them.
- */
-async function markDroppedExplanationsAsFailed(
-  activitiesToGenerate: LessonActivity[],
-  results: GeneratedExplanationResult[],
-): Promise<void> {
-  const explanationsToGenerate = findActivitiesByKind(activitiesToGenerate, "explanation");
-  const resultActivityIds = new Set(results.map((result) => result.activityId));
-
-  await Promise.allSettled(
-    explanationsToGenerate
-      .filter((activity) => !resultActivityIds.has(activity.id))
-      .map((activity) => handleActivityFailureStep({ activityId: activity.id })),
-  );
-}
 
 /**
  * Builds explanation results from completed activities by reading their
@@ -89,44 +70,36 @@ export async function explanationActivityWorkflow({
 
   const explanationsToGenerate = findActivitiesByKind(activitiesToGenerate, "explanation");
 
-  const [completedResults, generatedData] = await Promise.all([
+  const [completedResults, generatedSettledResults] = await Promise.all([
     getResultsFromCompletedActivities(allActivities, activitiesToGenerate),
-    explanationsToGenerate.length > 0
-      ? generateExplanationContentStep({
-          activities: explanationsToGenerate,
-          allActivities,
-          lessonConcepts,
-        })
-      : { results: [] },
+    Promise.allSettled(
+      explanationsToGenerate.map(async (activity): Promise<GeneratedExplanationResult> => {
+        try {
+          const result = await generateExplanationContentStep({
+            activity,
+            allActivities,
+            lessonConcepts,
+          });
+
+          const { prompts } = await generateExplanationImagePromptsStep(activity, result.steps);
+          const { images } = await generateActivityStepImagesStep(activity, prompts);
+
+          await saveExplanationActivityStep({
+            activityId: result.activityId,
+            images,
+            steps: result.steps,
+            workflowRunId,
+          });
+
+          return result;
+        } catch (error) {
+          return failActivityWorkflow({ activityId: activity.id, error });
+        }
+      }),
+    ),
   ]);
 
-  const { results: generatedResults } = generatedData;
-
-  await markDroppedExplanationsAsFailed(activitiesToGenerate, generatedResults);
-
-  await Promise.allSettled(
-    generatedResults.map(async (result) => {
-      const activity = explanationsToGenerate.find((a) => a.id === result.activityId);
-
-      if (!activity || result.steps.length === 0) {
-        return;
-      }
-
-      try {
-        const { prompts } = await generateExplanationImagePromptsStep(activity, result.steps);
-        const { images } = await generateActivityStepImagesStep(activity, prompts);
-
-        await saveExplanationActivityStep({
-          activityId: result.activityId,
-          images,
-          steps: result.steps,
-          workflowRunId,
-        });
-      } catch {
-        await handleActivityFailureStep({ activityId: result.activityId });
-      }
-    }),
-  );
+  const generatedResults = settledValues(generatedSettledResults);
 
   return { results: [...completedResults, ...generatedResults] };
 }

--- a/apps/api/src/workflows/activity-generation/kinds/grammar-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/grammar-workflow.test.ts
@@ -196,12 +196,14 @@ describe(grammarActivityWorkflow, () => {
     });
 
     const activities = await fetchLessonActivities(lesson.id);
-    await grammarActivityWorkflow({
-      activitiesToGenerate: activities,
-      concepts: [],
-      neighboringConcepts: [],
-      workflowRunId: "test-run-id",
-    });
+    await expect(
+      grammarActivityWorkflow({
+        activitiesToGenerate: activities,
+        concepts: [],
+        neighboringConcepts: [],
+        workflowRunId: "test-run-id",
+      }),
+    ).rejects.toThrow("AI failed");
 
     const dbActivity = await prisma.activity.findUnique({ where: { id: activity.id } });
     expect(dbActivity?.generationStatus).toBe("failed");
@@ -232,12 +234,14 @@ describe(grammarActivityWorkflow, () => {
     });
 
     const activities = await fetchLessonActivities(lesson.id);
-    await grammarActivityWorkflow({
-      activitiesToGenerate: activities,
-      concepts: [],
-      neighboringConcepts: [],
-      workflowRunId: "test-run-id",
-    });
+    await expect(
+      grammarActivityWorkflow({
+        activitiesToGenerate: activities,
+        concepts: [],
+        neighboringConcepts: [],
+        workflowRunId: "test-run-id",
+      }),
+    ).rejects.toThrow("contentValidationFailed");
 
     const dbActivity = await prisma.activity.findUnique({ where: { id: activity.id } });
     expect(dbActivity?.generationStatus).toBe("failed");
@@ -265,12 +269,14 @@ describe(grammarActivityWorkflow, () => {
     });
 
     const activities = await fetchLessonActivities(lesson.id);
-    await grammarActivityWorkflow({
-      activitiesToGenerate: activities,
-      concepts: [],
-      neighboringConcepts: [],
-      workflowRunId: "test-run-id",
-    });
+    await expect(
+      grammarActivityWorkflow({
+        activitiesToGenerate: activities,
+        concepts: [],
+        neighboringConcepts: [],
+        workflowRunId: "test-run-id",
+      }),
+    ).rejects.toThrow("User content generation failed");
 
     const dbActivity = await prisma.activity.findUnique({ where: { id: activity.id } });
     expect(dbActivity?.generationStatus).toBe("failed");

--- a/apps/api/src/workflows/activity-generation/kinds/grammar-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/grammar-workflow.ts
@@ -1,10 +1,9 @@
-import { settled } from "@zoonk/utils/settled";
+import { failActivityWorkflow } from "../handle-activity-workflow-error";
 import { findActivityByKind } from "../steps/_utils/find-activity-by-kind";
 import { generateGrammarContentStep } from "../steps/generate-grammar-content-step";
 import { generateGrammarRomanizationStep } from "../steps/generate-grammar-romanization-step";
 import { generateGrammarUserContentStep } from "../steps/generate-grammar-user-content-step";
 import { type LessonActivity } from "../steps/get-lesson-activities-step";
-import { handleActivityFailureStep } from "../steps/handle-failure-step";
 import { saveGrammarActivityStep } from "../steps/save-grammar-steps-step";
 
 /**
@@ -34,35 +33,35 @@ export async function grammarActivityWorkflow({
     return;
   }
 
-  const { generated, grammarContent } = await generateGrammarContentStep(
-    grammarActivity,
-    workflowRunId,
-    concepts,
-    neighboringConcepts,
-  );
+  try {
+    const { generated, grammarContent } = await generateGrammarContentStep(
+      grammarActivity,
+      workflowRunId,
+      concepts,
+      neighboringConcepts,
+    );
 
-  if (!generated || !grammarContent) {
-    return;
+    if (!generated || !grammarContent) {
+      throw new Error("Grammar content step returned no content");
+    }
+
+    const [{ userContent }, { romanizations }] = await Promise.all([
+      generateGrammarUserContentStep(activitiesToGenerate, grammarContent),
+      generateGrammarRomanizationStep(activitiesToGenerate, grammarContent),
+    ]);
+
+    if (!userContent) {
+      throw new Error("Grammar user content is missing");
+    }
+
+    await saveGrammarActivityStep(
+      activitiesToGenerate,
+      workflowRunId,
+      grammarContent,
+      userContent,
+      romanizations,
+    );
+  } catch (error) {
+    await failActivityWorkflow({ activityId: grammarActivity.id, error });
   }
-
-  const [userContentResult, romanizationResult] = await Promise.allSettled([
-    generateGrammarUserContentStep(activitiesToGenerate, grammarContent),
-    generateGrammarRomanizationStep(activitiesToGenerate, grammarContent),
-  ]);
-
-  const { userContent } = settled(userContentResult, { userContent: null });
-  const { romanizations } = settled(romanizationResult, { romanizations: null });
-
-  if (!userContent) {
-    await handleActivityFailureStep({ activityId: grammarActivity.id });
-    return;
-  }
-
-  await saveGrammarActivityStep(
-    activitiesToGenerate,
-    workflowRunId,
-    grammarContent,
-    userContent,
-    romanizations,
-  );
 }

--- a/apps/api/src/workflows/activity-generation/kinds/investigation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/investigation-workflow.test.ts
@@ -302,10 +302,12 @@ describe("investigation activity workflow", () => {
 
     const activities = await getLessonActivitiesStep({ lessonId: lesson.id });
 
-    await investigationActivityWorkflow({
-      activitiesToGenerate: activities,
-      workflowRunId: "test-run-id",
-    });
+    await expect(
+      investigationActivityWorkflow({
+        activitiesToGenerate: activities,
+        workflowRunId: "test-run-id",
+      }),
+    ).rejects.toThrow("AI failed");
 
     const dbActivity = await prisma.activity.findUnique({ where: { id: activity.id } });
     expect(dbActivity?.generationStatus).toBe("failed");
@@ -332,10 +334,12 @@ describe("investigation activity workflow", () => {
 
     const activities = await getLessonActivitiesStep({ lessonId: lesson.id });
 
-    await investigationActivityWorkflow({
-      activitiesToGenerate: activities,
-      workflowRunId: "test-run-id",
-    });
+    await expect(
+      investigationActivityWorkflow({
+        activitiesToGenerate: activities,
+        workflowRunId: "test-run-id",
+      }),
+    ).rejects.toThrow("AI failed");
 
     const dbActivity = await prisma.activity.findUnique({ where: { id: activity.id } });
     expect(dbActivity?.generationStatus).toBe("failed");
@@ -363,10 +367,12 @@ describe("investigation activity workflow", () => {
 
     const activities = await getLessonActivitiesStep({ lessonId: lesson.id });
 
-    await investigationActivityWorkflow({
-      activitiesToGenerate: activities,
-      workflowRunId: "test-run-id",
-    });
+    await expect(
+      investigationActivityWorkflow({
+        activitiesToGenerate: activities,
+        workflowRunId: "test-run-id",
+      }),
+    ).rejects.toThrow("AI failed");
 
     const dbActivity = await prisma.activity.findUnique({ where: { id: activity.id } });
     expect(dbActivity?.generationStatus).toBe("failed");
@@ -393,10 +399,12 @@ describe("investigation activity workflow", () => {
 
     const activities = await getLessonActivitiesStep({ lessonId: lesson.id });
 
-    await investigationActivityWorkflow({
-      activitiesToGenerate: activities,
-      workflowRunId: "test-run-id",
-    });
+    await expect(
+      investigationActivityWorkflow({
+        activitiesToGenerate: activities,
+        workflowRunId: "test-run-id",
+      }),
+    ).rejects.toThrow("AI failed");
 
     const dbActivity = await prisma.activity.findUnique({ where: { id: activity.id } });
     expect(dbActivity?.generationStatus).toBe("failed");

--- a/apps/api/src/workflows/activity-generation/kinds/investigation-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/investigation-workflow.ts
@@ -1,3 +1,5 @@
+import { failActivityWorkflow } from "../handle-activity-workflow-error";
+import { findActivityByKind } from "../steps/_utils/find-activity-by-kind";
 import { generateInvestigationAccuracyStep } from "../steps/generate-investigation-accuracy-step";
 import { generateInvestigationActionsStep } from "../steps/generate-investigation-actions-step";
 import { generateInvestigationFindingsStep } from "../steps/generate-investigation-findings-step";
@@ -27,59 +29,57 @@ export async function investigationActivityWorkflow({
 }): Promise<void> {
   "use workflow";
 
-  const { activityId, scenario, title } =
-    await generateInvestigationScenarioStep(activitiesToGenerate);
+  const investigationActivity = findActivityByKind(activitiesToGenerate, "investigation");
 
-  if (!activityId || !scenario || !title) {
+  if (!investigationActivity) {
     return;
   }
 
-  const activity = activitiesToGenerate.find((a) => a.id === activityId);
+  try {
+    const { activityId, scenario, title } =
+      await generateInvestigationScenarioStep(activitiesToGenerate);
 
-  if (!activity) {
-    return;
+    if (!activityId || !scenario || !title) {
+      throw new Error("Investigation scenario step returned incomplete content");
+    }
+
+    const activity = activitiesToGenerate.find((a) => a.id === activityId);
+
+    if (!activity) {
+      throw new Error("Investigation scenario step returned an unknown activity id");
+    }
+
+    const accuracy = await generateInvestigationAccuracyStep({
+      activity,
+      activityId,
+      scenario,
+    });
+
+    const actions = await generateInvestigationActionsStep({
+      accuracy,
+      activityId,
+      language: activity.language,
+      scenario,
+    });
+
+    const findings = await generateInvestigationFindingsStep({
+      accuracy,
+      actions,
+      activityId,
+      language: activity.language,
+      scenario,
+    });
+
+    await saveInvestigationActivityStep({
+      accuracy,
+      actions,
+      activityId,
+      findings,
+      scenario,
+      title,
+      workflowRunId,
+    });
+  } catch (error) {
+    await failActivityWorkflow({ activityId: investigationActivity.id, error });
   }
-
-  const accuracy = await generateInvestigationAccuracyStep({
-    activity,
-    activityId,
-    scenario,
-  });
-
-  if (!accuracy) {
-    return;
-  }
-
-  const actions = await generateInvestigationActionsStep({
-    accuracy,
-    activityId,
-    language: activity.language,
-    scenario,
-  });
-
-  if (!actions) {
-    return;
-  }
-
-  const findings = await generateInvestigationFindingsStep({
-    accuracy,
-    actions,
-    activityId,
-    language: activity.language,
-    scenario,
-  });
-
-  if (!findings) {
-    return;
-  }
-
-  await saveInvestigationActivityStep({
-    accuracy,
-    actions,
-    activityId,
-    findings,
-    scenario,
-    title,
-    workflowRunId,
-  });
 }

--- a/apps/api/src/workflows/activity-generation/kinds/listening-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/listening-workflow.test.ts
@@ -161,7 +161,7 @@ describe(listeningActivityWorkflow, () => {
     expect(dbActivity?.generationStatus).toBe("completed");
   });
 
-  test("fails gracefully when reading activity does not exist", async () => {
+  test("marks listening as failed when reading activity does not exist", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       kind: "language",
@@ -179,7 +179,9 @@ describe(listeningActivityWorkflow, () => {
     });
 
     const activities = await fetchLessonActivities(lesson.id);
-    await listeningActivityWorkflow({ allActivities: activities, workflowRunId: "test-run-id" });
+    await expect(
+      listeningActivityWorkflow({ allActivities: activities, workflowRunId: "test-run-id" }),
+    ).rejects.toThrow("noSourceData");
 
     const dbActivity = await prisma.activity.findUnique({ where: { id: listeningActivity.id } });
     expect(dbActivity?.generationStatus).toBe("failed");

--- a/apps/api/src/workflows/activity-generation/kinds/listening-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/listening-workflow.ts
@@ -1,3 +1,5 @@
+import { failActivityWorkflow } from "../handle-activity-workflow-error";
+import { findActivityByKind } from "../steps/_utils/find-activity-by-kind";
 import { type LessonActivity } from "../steps/get-lesson-activities-step";
 import { saveListeningActivityStep } from "../steps/save-listening-activity-step";
 
@@ -21,5 +23,15 @@ export async function listeningActivityWorkflow({
 }): Promise<void> {
   "use workflow";
 
-  await saveListeningActivityStep(allActivities, workflowRunId);
+  const listeningActivity = findActivityByKind(allActivities, "listening");
+
+  if (!listeningActivity) {
+    return;
+  }
+
+  try {
+    await saveListeningActivityStep(allActivities, workflowRunId);
+  } catch (error) {
+    await failActivityWorkflow({ activityId: listeningActivity.id, error });
+  }
 }

--- a/apps/api/src/workflows/activity-generation/kinds/practice-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/practice-workflow.ts
@@ -1,3 +1,4 @@
+import { failActivityWorkflow } from "../handle-activity-workflow-error";
 import { findActivitiesByKind } from "../steps/_utils/find-activity-by-kind";
 import { getExplanationStepsForPractice } from "../steps/_utils/get-explanation-steps-for-practice";
 import { getPracticeImagePrompts } from "../steps/_utils/get-practice-image-prompts";
@@ -5,7 +6,6 @@ import { generateActivityStepImagesStep } from "../steps/generate-activity-step-
 import { type ExplanationResult } from "../steps/generate-explanation-content-step";
 import { generatePracticeContentStep } from "../steps/generate-practice-content-step";
 import { type LessonActivity } from "../steps/get-lesson-activities-step";
-import { handleActivityFailureStep } from "../steps/handle-failure-step";
 import { savePracticeActivityStep } from "../steps/save-practice-activity-step";
 
 /**
@@ -54,7 +54,7 @@ export async function practiceActivityWorkflow({
         );
 
         if (!activityId || !scenario || steps.length === 0 || !title) {
-          return;
+          throw new Error("Practice content step returned incomplete content");
         }
 
         const { images } = await generateActivityStepImagesStep(
@@ -70,8 +70,8 @@ export async function practiceActivityWorkflow({
           title,
           workflowRunId,
         });
-      } catch {
-        await handleActivityFailureStep({ activityId: practice.id });
+      } catch (error) {
+        await failActivityWorkflow({ activityId: practice.id, error });
       }
     }),
   );

--- a/apps/api/src/workflows/activity-generation/kinds/quiz-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/quiz-workflow.test.ts
@@ -194,11 +194,13 @@ describe("quiz activity workflow", () => {
     const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
     const explanationResults = buildExplanationResults(explanationActivity.id);
 
-    await quizActivityWorkflow({
-      activitiesToGenerate: activities,
-      explanationResults,
-      workflowRunId: "test-run-id",
-    });
+    await expect(
+      quizActivityWorkflow({
+        activitiesToGenerate: activities,
+        explanationResults,
+        workflowRunId: "test-run-id",
+      }),
+    ).rejects.toThrow("Quiz generation failed");
 
     const dbActivity = await prisma.activity.findUnique({
       where: { id: quizActivity.id },
@@ -224,11 +226,13 @@ describe("quiz activity workflow", () => {
 
     const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
 
-    await quizActivityWorkflow({
-      activitiesToGenerate: activities,
-      explanationResults: [],
-      workflowRunId: "test-run-id",
-    });
+    await expect(
+      quizActivityWorkflow({
+        activitiesToGenerate: activities,
+        explanationResults: [],
+        workflowRunId: "test-run-id",
+      }),
+    ).rejects.toThrow("Quiz generation needs explanation steps");
 
     const dbActivity = await prisma.activity.findUnique({
       where: { id: quizActivity.id },

--- a/apps/api/src/workflows/activity-generation/kinds/quiz-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/quiz-workflow.ts
@@ -1,3 +1,5 @@
+import { failActivityWorkflow } from "../handle-activity-workflow-error";
+import { findActivitiesByKind } from "../steps/_utils/find-activity-by-kind";
 import { type ExplanationResult } from "../steps/generate-explanation-content-step";
 import { generateQuizContentStep } from "../steps/generate-quiz-content-step";
 import { generateQuizImagesStep } from "../steps/generate-quiz-images-step";
@@ -24,23 +26,34 @@ export async function quizActivityWorkflow({
 }): Promise<void> {
   "use workflow";
 
-  const explanationSteps = explanationResults.flatMap((result) => result.steps);
-  const { activityId, questions } = await generateQuizContentStep(
-    activitiesToGenerate,
-    explanationSteps,
-    workflowRunId,
-  );
+  const quizActivity = findActivitiesByKind(activitiesToGenerate, "quiz")[0];
 
-  if (!activityId || questions.length === 0) {
+  if (!quizActivity) {
     return;
   }
 
-  const questionsWithImages = await generateQuizImagesStep(activitiesToGenerate, questions);
-  const finalQuestions = questionsWithImages.length > 0 ? questionsWithImages : questions;
+  const explanationSteps = explanationResults.flatMap((result) => result.steps);
 
-  await saveQuizActivityStep({
-    activityId,
-    questions: finalQuestions,
-    workflowRunId,
-  });
+  try {
+    const { activityId, questions } = await generateQuizContentStep(
+      activitiesToGenerate,
+      explanationSteps,
+      workflowRunId,
+    );
+
+    if (!activityId || questions.length === 0) {
+      throw new Error("Quiz content step returned incomplete content");
+    }
+
+    const questionsWithImages = await generateQuizImagesStep(activitiesToGenerate, questions);
+    const finalQuestions = questionsWithImages.length > 0 ? questionsWithImages : questions;
+
+    await saveQuizActivityStep({
+      activityId,
+      questions: finalQuestions,
+      workflowRunId,
+    });
+  } catch (error) {
+    await failActivityWorkflow({ activityId: quizActivity.id, error });
+  }
 }

--- a/apps/api/src/workflows/activity-generation/kinds/reading-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/reading-workflow.test.ts
@@ -9,6 +9,12 @@ import { generateSentenceWordPronunciationStep } from "../steps/generate-sentenc
 import { saveReadingActivityStep } from "../steps/save-reading-activity-step";
 import { readingActivityWorkflow } from "./reading-workflow";
 
+vi.mock("../handle-activity-workflow-error", () => ({
+  failActivityWorkflow: vi.fn(async ({ error }: { error: unknown }) => {
+    throw error;
+  }),
+}));
+
 vi.mock("../steps/generate-reading-content-step", () => ({
   generateReadingContentStep: vi.fn().mockResolvedValue({
     sentences: [
@@ -214,7 +220,7 @@ describe(readingActivityWorkflow, () => {
     );
   });
 
-  test("falls back to empty enrichment maps when non-critical substeps fail", async () => {
+  test("throws when enrichment substeps fail", async () => {
     vi.mocked(generateReadingAudioStep).mockRejectedValueOnce(new Error("audio failed"));
     vi.mocked(generateReadingRomanizationStep).mockRejectedValueOnce(
       new Error("romanization failed"),
@@ -226,24 +232,17 @@ describe(readingActivityWorkflow, () => {
 
     const activities = [makeActivity("reading")];
 
-    await readingActivityWorkflow({
-      activitiesToGenerate: activities as never,
-      allActivities: activities as never,
-      concepts: [],
-      neighboringConcepts: [],
-      words: [],
-      workflowRunId: "workflow-3",
-    });
-
-    expect(saveReadingActivityStep).toHaveBeenCalledWith(
-      expect.objectContaining({
-        activities,
-        pronunciations: {},
-        sentenceAudioUrls: {},
-        sentenceRomanizations: {},
-        wordAudioUrls: {},
+    await expect(
+      readingActivityWorkflow({
+        activitiesToGenerate: activities as never,
+        allActivities: activities as never,
+        concepts: [],
+        neighboringConcepts: [],
+        words: [],
         workflowRunId: "workflow-3",
       }),
-    );
+    ).rejects.toThrow("audio failed");
+
+    expect(saveReadingActivityStep).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/workflows/activity-generation/kinds/reading-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/reading-workflow.ts
@@ -1,6 +1,6 @@
 import { type VocabularyWord } from "@zoonk/ai/tasks/activities/language/vocabulary";
-import { settled } from "@zoonk/utils/settled";
 import { deduplicateNormalizedTexts, extractUniqueSentenceWords } from "@zoonk/utils/string";
+import { failActivityWorkflow } from "../handle-activity-workflow-error";
 import { findActivityByKind } from "../steps/_utils/find-activity-by-kind";
 import { generateReadingAudioStep } from "../steps/generate-reading-audio-step";
 import { generateReadingContentStep } from "../steps/generate-reading-content-step";
@@ -57,53 +57,51 @@ export async function readingActivityWorkflow({
     return;
   }
 
-  const { sentences } = await generateReadingContentStep(
-    readingActivity,
-    workflowRunId,
-    words,
-    concepts,
-    neighboringConcepts,
-  );
+  try {
+    const { sentences } = await generateReadingContentStep(
+      readingActivity,
+      workflowRunId,
+      words,
+      concepts,
+      neighboringConcepts,
+    );
 
-  const [audioResult, romanizationResult] = await Promise.allSettled([
-    generateReadingAudioStep(activitiesToGenerate, sentences),
-    generateReadingRomanizationStep(activitiesToGenerate, sentences),
-  ]);
+    const [{ sentenceAudioUrls }, { romanizations: sentenceRomanizations }] = await Promise.all([
+      generateReadingAudioStep(activitiesToGenerate, sentences),
+      generateReadingRomanizationStep(activitiesToGenerate, sentences),
+    ]);
 
-  const { sentenceAudioUrls } = settled(audioResult, { sentenceAudioUrls: {} });
-  const { romanizations: sentenceRomanizations } = settled(romanizationResult, {
-    romanizations: {},
-  });
+    const { distractors, translationDistractors } = await generateSentenceDistractorsStep(
+      activitiesToGenerate,
+      sentences,
+    );
 
-  const { distractors, translationDistractors } = await generateSentenceDistractorsStep(
-    activitiesToGenerate,
-    sentences,
-  );
-  const targetWords = collectReadingTargetWords({ distractors, sentences });
-  const { wordMetadata } = await generateSentenceWordMetadataStep(
-    activitiesToGenerate,
-    sentences,
-    targetWords,
-  );
+    const targetWords = collectReadingTargetWords({ distractors, sentences });
 
-  const [wordAudioResult, wordPronunciationResult] = await Promise.allSettled([
-    generateSentenceWordAudioStep(activitiesToGenerate, targetWords),
-    generateSentenceWordPronunciationStep(activitiesToGenerate, targetWords),
-  ]);
+    const { wordMetadata } = await generateSentenceWordMetadataStep(
+      activitiesToGenerate,
+      sentences,
+      targetWords,
+    );
 
-  const { wordAudioUrls } = settled(wordAudioResult, { wordAudioUrls: {} });
-  const { pronunciations } = settled(wordPronunciationResult, { pronunciations: {} });
+    const [{ wordAudioUrls }, { pronunciations }] = await Promise.all([
+      generateSentenceWordAudioStep(activitiesToGenerate, targetWords),
+      generateSentenceWordPronunciationStep(activitiesToGenerate, targetWords),
+    ]);
 
-  await saveReadingActivityStep({
-    activities: allActivities,
-    distractors,
-    pronunciations,
-    sentenceAudioUrls,
-    sentenceRomanizations,
-    sentences,
-    translationDistractors,
-    wordAudioUrls,
-    wordMetadata,
-    workflowRunId,
-  });
+    await saveReadingActivityStep({
+      activities: allActivities,
+      distractors,
+      pronunciations,
+      sentenceAudioUrls,
+      sentenceRomanizations,
+      sentences,
+      translationDistractors,
+      wordAudioUrls,
+      wordMetadata,
+      workflowRunId,
+    });
+  } catch (error) {
+    await failActivityWorkflow({ activityId: readingActivity.id, error });
+  }
 }

--- a/apps/api/src/workflows/activity-generation/kinds/story-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/story-workflow.test.ts
@@ -308,11 +308,13 @@ describe("story activity workflow", () => {
 
     const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
 
-    await storyActivityWorkflow({
-      activitiesToGenerate: activities,
-      explanationSteps: storyExplanationSteps,
-      workflowRunId: "test-run-id",
-    });
+    await expect(
+      storyActivityWorkflow({
+        activitiesToGenerate: activities,
+        explanationSteps: storyExplanationSteps,
+        workflowRunId: "test-run-id",
+      }),
+    ).rejects.toThrow("AI failed");
 
     const dbActivity = await prisma.activity.findUnique({
       where: { id: storyActivity.id },
@@ -342,11 +344,13 @@ describe("story activity workflow", () => {
 
     const activities = await getLessonActivitiesStep({ lessonId: testLesson.id });
 
-    await storyActivityWorkflow({
-      activitiesToGenerate: activities,
-      explanationSteps: storyExplanationSteps,
-      workflowRunId: "test-run-id",
-    });
+    await expect(
+      storyActivityWorkflow({
+        activitiesToGenerate: activities,
+        explanationSteps: storyExplanationSteps,
+        workflowRunId: "test-run-id",
+      }),
+    ).rejects.toThrow("Images failed");
 
     const dbActivity = await prisma.activity.findUnique({
       where: { id: storyActivity.id },

--- a/apps/api/src/workflows/activity-generation/kinds/story-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/story-workflow.ts
@@ -1,10 +1,10 @@
+import { failActivityWorkflow } from "../handle-activity-workflow-error";
 import { findActivityByKind } from "../steps/_utils/find-activity-by-kind";
 import { type ActivitySteps } from "../steps/_utils/get-activity-steps";
 import { generateStoryChoicesStep } from "../steps/generate-story-choices-step";
 import { generateStoryContentStep } from "../steps/generate-story-content-step";
 import { generateStoryImagesStep } from "../steps/generate-story-images-step";
 import { type LessonActivity } from "../steps/get-lesson-activities-step";
-import { handleActivityFailureStep } from "../steps/handle-failure-step";
 import { saveStoryActivityStep } from "../steps/save-story-activity-step";
 
 /**
@@ -41,7 +41,7 @@ export async function storyActivityWorkflow({
     );
 
     if (!activityId || !storyPlan) {
-      return;
+      throw new Error("Story content step returned incomplete content");
     }
 
     const storyData = await generateStoryChoicesStep({
@@ -51,7 +51,7 @@ export async function storyActivityWorkflow({
     });
 
     if (!storyData) {
-      return;
+      throw new Error("Story choices step returned no content");
     }
 
     const storyImages = await generateStoryImagesStep({
@@ -65,7 +65,7 @@ export async function storyActivityWorkflow({
       storyImages,
       workflowRunId,
     });
-  } catch {
-    await handleActivityFailureStep({ activityId: storyActivity.id });
+  } catch (error) {
+    await failActivityWorkflow({ activityId: storyActivity.id, error });
   }
 }

--- a/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.test.ts
@@ -8,6 +8,12 @@ import { saveTranslationFromExistingVocabularyStep } from "../steps/save-transla
 import { saveVocabularyActivityStep } from "../steps/save-vocabulary-activity-step";
 import { vocabularyActivityWorkflow } from "./vocabulary-workflow";
 
+vi.mock("../handle-activity-workflow-error", () => ({
+  failActivityWorkflows: vi.fn(async ({ error }: { error: unknown }) => {
+    throw error;
+  }),
+}));
+
 vi.mock("../steps/generate-vocabulary-content-step", () => ({
   generateVocabularyContentStep: vi.fn().mockResolvedValue({
     words: [{ translation: "good evening", word: "boa noite" }],
@@ -156,7 +162,7 @@ describe(vocabularyActivityWorkflow, () => {
     expect(saveVocabularyActivityStep).not.toHaveBeenCalled();
   });
 
-  test("falls back to empty enrichment maps when optional steps fail", async () => {
+  test("throws when enrichment steps fail", async () => {
     const activities = [makeActivity("vocabulary"), makeActivity("translation")];
 
     vi.mocked(generateVocabularyPronunciationStep).mockRejectedValueOnce(
@@ -167,22 +173,16 @@ describe(vocabularyActivityWorkflow, () => {
       new Error("romanization failed"),
     );
 
-    await vocabularyActivityWorkflow({
-      activitiesToGenerate: activities as never,
-      allActivities: activities as never,
-      concepts: [],
-      neighboringConcepts: [],
-      workflowRunId: "workflow-3",
-    });
-
-    expect(saveVocabularyActivityStep).toHaveBeenCalledWith(
-      expect.objectContaining({
-        activities,
-        pronunciations: {},
-        romanizations: {},
-        wordAudioUrls: {},
+    await expect(
+      vocabularyActivityWorkflow({
+        activitiesToGenerate: activities as never,
+        allActivities: activities as never,
+        concepts: [],
+        neighboringConcepts: [],
         workflowRunId: "workflow-3",
       }),
-    );
+    ).rejects.toThrow("pronunciation failed");
+
+    expect(saveVocabularyActivityStep).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/vocabulary-workflow.ts
@@ -1,6 +1,6 @@
 import { type VocabularyWord } from "@zoonk/ai/tasks/activities/language/vocabulary";
-import { settled } from "@zoonk/utils/settled";
 import { deduplicateNormalizedTexts } from "@zoonk/utils/string";
+import { failActivityWorkflows } from "../handle-activity-workflow-error";
 import { findActivityByKind } from "../steps/_utils/find-activity-by-kind";
 import { generateVocabularyAudioStep } from "../steps/generate-vocabulary-audio-step";
 import { generateVocabularyContentStep } from "../steps/generate-vocabulary-content-step";
@@ -58,41 +58,56 @@ export async function vocabularyActivityWorkflow({
     const translationActivity = findActivityByKind(activitiesToGenerate, "translation");
 
     if (translationActivity) {
-      await saveTranslationFromExistingVocabularyStep({ allActivities, workflowRunId });
+      try {
+        await saveTranslationFromExistingVocabularyStep({ allActivities, workflowRunId });
+      } catch (error) {
+        return failActivityWorkflows({
+          activityIds: [translationActivity.id],
+          error,
+        });
+      }
     }
 
     return { words: [] };
   }
 
-  const { words } = await generateVocabularyContentStep(
-    vocabularyActivity,
-    workflowRunId,
-    concepts,
-    neighboringConcepts,
-  );
+  try {
+    const { words } = await generateVocabularyContentStep(
+      vocabularyActivity,
+      workflowRunId,
+      concepts,
+      neighboringConcepts,
+    );
 
-  const { distractors } = await generateVocabularyDistractorsStep(activitiesToGenerate, words);
-  const vocabularyTargetWords = collectVocabularyTargetWords(words, distractors);
+    const { distractors } = await generateVocabularyDistractorsStep(activitiesToGenerate, words);
+    const vocabularyTargetWords = collectVocabularyTargetWords(words, distractors);
 
-  const [pronunciationResult, audioResult, romanizationResult] = await Promise.allSettled([
-    generateVocabularyPronunciationStep(activitiesToGenerate, vocabularyTargetWords),
-    generateVocabularyAudioStep(activitiesToGenerate, vocabularyTargetWords),
-    generateVocabularyRomanizationStep(activitiesToGenerate, vocabularyTargetWords),
-  ]);
+    const [{ pronunciations }, { wordAudioUrls }, { romanizations }] = await Promise.all([
+      generateVocabularyPronunciationStep(activitiesToGenerate, vocabularyTargetWords),
+      generateVocabularyAudioStep(activitiesToGenerate, vocabularyTargetWords),
+      generateVocabularyRomanizationStep(activitiesToGenerate, vocabularyTargetWords),
+    ]);
 
-  const { pronunciations } = settled(pronunciationResult, { pronunciations: {} });
-  const { wordAudioUrls } = settled(audioResult, { wordAudioUrls: {} });
-  const { romanizations } = settled(romanizationResult, { romanizations: {} });
+    await saveVocabularyActivityStep({
+      activities: allActivities,
+      distractors,
+      pronunciations,
+      romanizations,
+      wordAudioUrls,
+      words,
+      workflowRunId,
+    });
 
-  await saveVocabularyActivityStep({
-    activities: allActivities,
-    distractors,
-    pronunciations,
-    romanizations,
-    wordAudioUrls,
-    words,
-    workflowRunId,
-  });
+    return { words };
+  } catch (error) {
+    const translationActivity = findActivityByKind(activitiesToGenerate, "translation");
 
-  return { words };
+    return failActivityWorkflows({
+      activityIds: [
+        vocabularyActivity.id,
+        ...(translationActivity ? [translationActivity.id] : []),
+      ],
+      error,
+    });
+  }
 }

--- a/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/language-activity-workflow.test.ts
@@ -156,4 +156,20 @@ describe(languageActivityWorkflow, () => {
       workflowRunId: "workflow-3",
     });
   });
+
+  test("stops before listening when reading generation fails", async () => {
+    vi.mocked(readingActivityWorkflow).mockRejectedValueOnce(new Error("reading failed"));
+
+    const activities = [makeActivity("reading"), makeActivity("listening")];
+
+    await expect(
+      languageActivityWorkflow({
+        activitiesToGenerate: activities as never,
+        allActivities: activities as never,
+        workflowRunId: "workflow-reading-failed",
+      }),
+    ).rejects.toThrow("reading failed");
+
+    expect(listeningActivityWorkflow).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/workflows/activity-generation/steps/_utils/content-step-helpers.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/content-step-helpers.test.ts
@@ -96,7 +96,7 @@ describe(getExistingContentSteps, () => {
     expect(result).toEqual([]);
   });
 
-  test("returns empty array when content cannot be parsed", async () => {
+  test("throws when content cannot be parsed", async () => {
     const lesson = await lessonFixture({
       chapterId,
       organizationId,
@@ -117,8 +117,6 @@ describe(getExistingContentSteps, () => {
       position: 0,
     });
 
-    const result = await getExistingContentSteps(activity.id);
-
-    expect(result).toEqual([]);
+    await expect(getExistingContentSteps(activity.id)).rejects.toThrow();
   });
 });

--- a/apps/api/src/workflows/activity-generation/steps/_utils/content-step-helpers.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/content-step-helpers.ts
@@ -1,5 +1,4 @@
 import { prisma } from "@zoonk/db";
-import { safeAsync } from "@zoonk/utils/error";
 import { type ActivitySteps, parseActivitySteps } from "./get-activity-steps";
 
 /**
@@ -10,21 +9,15 @@ import { type ActivitySteps, parseActivitySteps } from "./get-activity-steps";
  */
 export async function getExistingContentSteps(activityId: string): Promise<ActivitySteps> {
   "use step";
-  const { data: existingSteps } = await safeAsync(() =>
-    prisma.step.findMany({
-      orderBy: { position: "asc" },
-      select: { content: true },
-      where: { activityId, kind: "static" },
-    }),
-  );
+  const existingSteps = await prisma.step.findMany({
+    orderBy: { position: "asc" },
+    select: { content: true },
+    where: { activityId, kind: "static" },
+  });
 
   if (!existingSteps?.length) {
     return [];
   }
 
-  try {
-    return parseActivitySteps(existingSteps);
-  } catch {
-    return [];
-  }
+  return parseActivitySteps(existingSteps);
 }

--- a/apps/api/src/workflows/activity-generation/steps/_utils/generate-activity-romanizations.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/generate-activity-romanizations.test.ts
@@ -10,13 +10,13 @@ vi.mock("@zoonk/ai/tasks/activities/language/romanization", () => ({
 }));
 
 describe(generateActivityRomanizations, () => {
-  test("returns null for Roman-script languages without calling AI", async () => {
+  test("returns empty romanization map for Roman-script languages without calling AI", async () => {
     const result = await generateActivityRomanizations({
       targetLanguage: "es",
       texts: ["hola"],
     });
 
-    expect(result).toBeNull();
+    expect(result).toEqual({});
     expect(generateActivityRomanizationMock).not.toHaveBeenCalled();
   });
 
@@ -39,26 +39,26 @@ describe(generateActivityRomanizations, () => {
     });
   });
 
-  test("returns null when AI call fails", async () => {
+  test("throws when AI call fails", async () => {
     generateActivityRomanizationMock.mockRejectedValue(new Error("AI error"));
 
-    const result = await generateActivityRomanizations({
-      targetLanguage: "ja",
-      texts: ["これは猫です"],
-    });
-
-    expect(result).toBeNull();
+    await expect(
+      generateActivityRomanizations({
+        targetLanguage: "ja",
+        texts: ["これは猫です"],
+      }),
+    ).rejects.toThrow("AI error");
   });
 
-  test("returns null when AI returns no data", async () => {
+  test("throws when AI returns no data", async () => {
     generateActivityRomanizationMock.mockResolvedValue({ data: null });
 
-    const result = await generateActivityRomanizations({
-      targetLanguage: "ja",
-      texts: ["これは猫です"],
-    });
-
-    expect(result).toBeNull();
+    await expect(
+      generateActivityRomanizations({
+        targetLanguage: "ja",
+        texts: ["これは猫です"],
+      }),
+    ).rejects.toThrow("romanizationFailed");
   });
 
   test("filters out texts where AI returned undefined", async () => {

--- a/apps/api/src/workflows/activity-generation/steps/_utils/generate-activity-romanizations.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/generate-activity-romanizations.ts
@@ -13,18 +13,19 @@ import { needsRomanization } from "@zoonk/utils/languages";
  * streaming events for Roman-script languages). This function checks it again
  * as defense-in-depth.
  *
- * Returns `null` when the language uses Roman script (no romanization needed)
- * or when the AI call fails. The caller decides how to interpret `null`
- * (e.g., grammar returns it directly; vocabulary/reading convert to `{}`).
+ * Returns an empty object when the language uses Roman script because there is
+ * no AI work to do. AI call failures throw the original error so the owning
+ * workflow step can be retried by Workflow instead of silently saving missing
+ * romanization.
  */
 export async function generateActivityRomanizations(params: {
   targetLanguage: string;
   texts: string[];
-}): Promise<Record<string, string> | null> {
+}): Promise<Record<string, string>> {
   const { targetLanguage, texts } = params;
 
   if (!needsRomanization(targetLanguage)) {
-    return null;
+    return {};
   }
 
   const { data: result, error } = await safeAsync(() =>
@@ -32,7 +33,7 @@ export async function generateActivityRomanizations(params: {
   );
 
   if (error || !result?.data) {
-    return null;
+    throw error ?? new Error("romanizationFailed");
   }
 
   return Object.fromEntries(

--- a/apps/api/src/workflows/activity-generation/steps/_utils/generate-audio-for-text.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/generate-audio-for-text.ts
@@ -4,7 +4,7 @@ export async function generateAudioForText(
   text: string,
   language: string,
   orgSlug?: string,
-): Promise<{ audioUrl: string; text: string } | null> {
+): Promise<{ audioUrl: string; text: string }> {
   const { data, error } = await generateLanguageAudio({
     language,
     orgSlug,
@@ -12,7 +12,7 @@ export async function generateAudioForText(
   });
 
   if (error || !data) {
-    return null;
+    throw error ?? new Error("audioGenerationFailed");
   }
 
   return { audioUrl: data, text };

--- a/apps/api/src/workflows/activity-generation/steps/_utils/generate-direct-distractors.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/generate-direct-distractors.test.ts
@@ -34,19 +34,19 @@ describe(generateDirectDistractors, () => {
     });
   });
 
-  test("returns empty array for entries where AI call fails", async () => {
+  test("throws when an AI call fails", async () => {
     generateActivityDistractorsMock.mockRejectedValue(new Error("AI failure"));
 
-    const result = await generateDirectDistractors({
-      entries: [{ input: "hola", key: "word-1" }],
-      language: "es",
-      shape: "single-word",
-    });
-
-    expect(result["word-1"]).toEqual([]);
+    await expect(
+      generateDirectDistractors({
+        entries: [{ input: "hola", key: "word-1" }],
+        language: "es",
+        shape: "single-word",
+      }),
+    ).rejects.toThrow("AI failure");
   });
 
-  test("handles multiple entries independently", async () => {
+  test("throws when any entry fails", async () => {
     generateActivityDistractorsMock
       .mockResolvedValueOnce({
         data: { distractors: ["d1", "d2", "d3"] },
@@ -56,30 +56,28 @@ describe(generateDirectDistractors, () => {
         data: { distractors: ["d4", "d5", "d6"] },
       });
 
-    const result = await generateDirectDistractors({
-      entries: [
-        { input: "hola", key: "k1" },
-        { input: "adios", key: "k2" },
-        { input: "gracias", key: "k3" },
-      ],
-      language: "es",
-      shape: "single-word",
-    });
-
-    expect(result.k1!.length).toBeGreaterThan(0);
-    expect(result.k2).toEqual([]);
-    expect(result.k3!.length).toBeGreaterThan(0);
+    await expect(
+      generateDirectDistractors({
+        entries: [
+          { input: "hola", key: "k1" },
+          { input: "adios", key: "k2" },
+          { input: "gracias", key: "k3" },
+        ],
+        language: "es",
+        shape: "single-word",
+      }),
+    ).rejects.toThrow("fail");
   });
 
-  test("returns empty array when AI returns null data", async () => {
+  test("throws when AI returns null data", async () => {
     generateActivityDistractorsMock.mockResolvedValue({ data: null });
 
-    const result = await generateDirectDistractors({
-      entries: [{ input: "hola", key: "word-1" }],
-      language: "es",
-      shape: "single-word",
-    });
-
-    expect(result["word-1"]).toEqual([]);
+    await expect(
+      generateDirectDistractors({
+        entries: [{ input: "hola", key: "word-1" }],
+        language: "es",
+        shape: "single-word",
+      }),
+    ).rejects.toThrow("distractorGenerationFailed");
   });
 });

--- a/apps/api/src/workflows/activity-generation/steps/_utils/generate-direct-distractors.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/generate-direct-distractors.ts
@@ -15,9 +15,8 @@ type DistractorEntry = {
  * - normalize and clean the output
  * - preserve per-input ordering
  *
- * Failures degrade to an empty array for that input instead of throwing, which keeps
- * the activity pipeline linear while still allowing downstream tests to assert the
- * stored distractors and hydration behavior.
+ * Failures throw the original AI error so Workflow retries the owning step
+ * instead of silently saving activities with missing distractors.
  */
 export async function generateDirectDistractors(params: {
   entries: DistractorEntry[];
@@ -35,7 +34,7 @@ export async function generateDirectDistractors(params: {
       );
 
       if (error || !result?.data) {
-        return [entry.key, []] as const;
+        throw error ?? new Error("distractorGenerationFailed");
       }
 
       return [

--- a/apps/api/src/workflows/activity-generation/steps/_utils/generate-word-audio-urls.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/generate-word-audio-urls.ts
@@ -48,10 +48,8 @@ export async function generateWordAudioUrls(params: {
     wordsNeedingAudio.map((word) => generateAudioForText(word, targetLanguage, orgSlug)),
   );
 
-  const fulfilled = results.filter((result) => result !== null);
-
   return {
     ...existingAudioUrls,
-    ...Object.fromEntries(fulfilled.map((result) => [result.text, result.audioUrl])),
+    ...Object.fromEntries(results.map((result) => [result.text, result.audioUrl])),
   };
 }

--- a/apps/api/src/workflows/activity-generation/steps/_utils/generate-word-pronunciations.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/generate-word-pronunciations.test.ts
@@ -119,19 +119,19 @@ describe(generateWordPronunciations, () => {
     expect(generateActivityPronunciationMock).toHaveBeenCalledOnce();
   });
 
-  test("omits word from result when AI call fails", async () => {
+  test("throws when an AI call fails", async () => {
     const id = randomUUID().slice(0, 8);
     const wordText = `Fallo${id}`;
 
     generateActivityPronunciationMock.mockRejectedValue(new Error("AI failure"));
 
-    const result = await generateWordPronunciations({
-      organizationId,
-      targetLanguage: "es",
-      userLanguage: "en",
-      words: [wordText],
-    });
-
-    expect(result[wordText]).toBeUndefined();
+    await expect(
+      generateWordPronunciations({
+        organizationId,
+        targetLanguage: "es",
+        userLanguage: "en",
+        words: [wordText],
+      }),
+    ).rejects.toThrow("AI failure");
   });
 });

--- a/apps/api/src/workflows/activity-generation/steps/_utils/generate-word-pronunciations.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/generate-word-pronunciations.ts
@@ -91,7 +91,7 @@ async function generateMissingPronunciations(params: {
       );
 
       if (error || !result?.data) {
-        return null;
+        throw error ?? new Error("pronunciationGenerationFailed");
       }
 
       return {
@@ -101,5 +101,5 @@ async function generateMissingPronunciations(params: {
     }),
   );
 
-  return results.filter((entry): entry is PronunciationEntry => entry !== null);
+  return results;
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-custom-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-custom-content-step.test.ts
@@ -51,7 +51,7 @@ describe(generateCustomContentStep, () => {
     vi.clearAllMocks();
   });
 
-  test("returns custom content results for each activity", async () => {
+  test("returns custom content for one activity", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -86,17 +86,37 @@ describe(generateCustomContentStep, () => {
       },
     });
 
-    const results = await generateCustomContentStep(activities);
+    const result = await generateCustomContentStep(activities[0]!);
 
-    expect(results).toHaveLength(2);
-    expect(results[0]?.activityId).toBe(activities[0]?.id);
-    expect(results[0]?.steps).toEqual([{ text: "Custom step text", title: "Custom step title" }]);
-    expect(results[1]?.activityId).toBe(activities[1]?.id);
+    expect(result.activityId).toBe(activities[0]?.id);
+    expect(result.steps).toEqual([{ text: "Custom step text", title: "Custom step title" }]);
   });
 
-  test("returns empty array when activities list is empty", async () => {
-    const results = await generateCustomContentStep([]);
-    expect(results).toEqual([]);
+  test("throws when AI returns empty content", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Custom Empty ${randomUUID()}`,
+    });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "custom",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Custom ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    generateActivityCustomMock.mockResolvedValue({
+      data: { steps: [] },
+    });
+
+    await expect(generateCustomContentStep(activities[0]!)).rejects.toThrow(
+      "Empty AI result for custom content",
+    );
   });
 
   test("streams started and completed events", async () => {
@@ -121,7 +141,7 @@ describe(generateCustomContentStep, () => {
       data: { steps: [{ text: "text", title: "title" }] },
     });
 
-    await generateCustomContentStep(activities);
+    await generateCustomContentStep(activities[0]!);
 
     const events = getStreamedEvents(writeMock);
 
@@ -134,45 +154,27 @@ describe(generateCustomContentStep, () => {
     );
   });
 
-  test("streams error status when some AI calls fail", async () => {
+  test("throws AI errors without streaming an error status", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
       title: `Custom Error ${randomUUID()}`,
     });
 
-    await Promise.all([
-      activityFixture({
-        generationStatus: "pending",
-        kind: "custom",
-        language: "en",
-        lessonId: lesson.id,
-        organizationId,
-        title: `Good Custom ${randomUUID()}`,
-      }),
-      activityFixture({
-        generationStatus: "pending",
-        kind: "custom",
-        language: "en",
-        lessonId: lesson.id,
-        organizationId,
-        position: 1,
-        title: `Bad Custom ${randomUUID()}`,
-      }),
-    ]);
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "custom",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Bad Custom ${randomUUID()}`,
+    });
 
     const activities = await fetchLessonActivities(lesson.id);
 
-    generateActivityCustomMock
-      .mockResolvedValueOnce({
-        data: { steps: [{ text: "ok", title: "ok" }] },
-      })
-      .mockRejectedValueOnce(new Error("AI failure"));
+    generateActivityCustomMock.mockRejectedValue(new Error("AI failure"));
 
-    const results = await generateCustomContentStep(activities);
-
-    expect(results).toHaveLength(1);
-    expect(results[0]?.activityId).toBe(activities[0]?.id);
+    await expect(generateCustomContentStep(activities[0]!)).rejects.toThrow("AI failure");
 
     const events = getStreamedEvents(writeMock);
 
@@ -180,7 +182,7 @@ describe(generateCustomContentStep, () => {
       expect.objectContaining({ status: "started", step: "generateCustomContent" }),
     );
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateCustomContent" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/generate-custom-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-custom-content-step.ts
@@ -1,7 +1,6 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { generateActivityCustom } from "@zoonk/ai/tasks/activities/custom";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
-import { rejected, settledValues } from "@zoonk/utils/settled";
 import { type ActivitySteps } from "./_utils/get-activity-steps";
 import { type LessonActivity } from "./get-lesson-activities-step";
 
@@ -43,31 +42,23 @@ async function generateForActivity(activity: LessonActivity): Promise<CustomCont
 }
 
 /**
- * Generates custom content for all custom activities in parallel.
+ * Generates custom content for one custom activity.
  * Returns the raw content data without saving to the database.
- * Each activity's content will be persisted later by `saveCustomActivityStep`.
  *
- * Only receives activities that need generation — no status checks needed.
+ * The caller fans out per activity at the workflow level so one failed custom
+ * activity can be retried and marked failed without affecting its siblings.
  */
 export async function generateCustomContentStep(
-  activities: LessonActivity[],
-): Promise<CustomContentResult[]> {
+  activity: LessonActivity,
+): Promise<CustomContentResult> {
   "use step";
 
-  if (activities.length === 0) {
-    return [];
-  }
-
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({ status: "started", step: "generateCustomContent" });
 
-  const allSettled = await Promise.allSettled(activities.map((act) => generateForActivity(act)));
+  const result = await generateForActivity(activity);
 
-  await stream.status({
-    status: rejected(allSettled) ? "error" : "completed",
-    step: "generateCustomContent",
-  });
-
-  return settledValues(allSettled);
+  await stream.status({ status: "completed", step: "generateCustomContent" });
+  return result;
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-custom-image-prompts-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-custom-image-prompts-step.test.ts
@@ -70,28 +70,24 @@ describe(generateCustomImagePromptsStep, () => {
     const activities = await fetchLessonActivities(lesson.id);
     const activity = activities[0]!;
 
-    const contentResults = [
-      {
-        activityId: activity.id,
-        steps: [{ text: "Step 1 text", title: "Step 1" }],
-      },
-    ];
+    const contentResult = {
+      activityId: activity.id,
+      steps: [{ text: "Step 1 text", title: "Step 1" }],
+    };
 
     generateStepImagePromptsMock.mockResolvedValue({
       data: { prompts: ["A lesson illustration for Step 1"] },
     });
 
-    const results = await generateCustomImagePromptsStep(activities, contentResults);
+    const result = await generateCustomImagePromptsStep(activity, contentResult);
 
-    expect(results).toEqual([
-      {
-        activityId: activity.id,
-        prompts: ["A lesson illustration for Step 1"],
-      },
-    ]);
+    expect(result).toEqual({
+      activityId: activity.id,
+      prompts: ["A lesson illustration for Step 1"],
+    });
   });
 
-  test("returns empty array when content results are empty", async () => {
+  test("throws when image prompt generation returns empty output", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -108,10 +104,16 @@ describe(generateCustomImagePromptsStep, () => {
     });
 
     const activities = await fetchLessonActivities(lesson.id);
+    const activity = activities[0]!;
 
-    const results = await generateCustomImagePromptsStep(activities, []);
+    generateStepImagePromptsMock.mockResolvedValue(null);
 
-    expect(results).toEqual([]);
+    await expect(
+      generateCustomImagePromptsStep(activity, {
+        activityId: activity.id,
+        steps: [{ text: "text", title: "title" }],
+      }),
+    ).rejects.toThrow("Empty step image prompt result for custom activity");
   });
 
   test("returns empty prompts for an activity with empty content steps", async () => {
@@ -133,11 +135,12 @@ describe(generateCustomImagePromptsStep, () => {
     const activities = await fetchLessonActivities(lesson.id);
     const activity = activities[0]!;
 
-    const results = await generateCustomImagePromptsStep(activities, [
-      { activityId: activity.id, steps: [] },
-    ]);
+    const result = await generateCustomImagePromptsStep(activity, {
+      activityId: activity.id,
+      steps: [],
+    });
 
-    expect(results).toEqual([{ activityId: activity.id, prompts: [] }]);
+    expect(result).toEqual({ activityId: activity.id, prompts: [] });
     expect(generateStepImagePromptsMock).not.toHaveBeenCalled();
   });
 
@@ -164,9 +167,10 @@ describe(generateCustomImagePromptsStep, () => {
       data: { prompts: ["A lesson illustration for title"] },
     });
 
-    await generateCustomImagePromptsStep(activities, [
-      { activityId: activity.id, steps: [{ text: "text", title: "title" }] },
-    ]);
+    await generateCustomImagePromptsStep(activity, {
+      activityId: activity.id,
+      steps: [{ text: "text", title: "title" }],
+    });
 
     const events = getStreamedEvents(writeMock);
 
@@ -178,52 +182,36 @@ describe(generateCustomImagePromptsStep, () => {
     );
   });
 
-  test("streams error status when some AI calls fail", async () => {
+  test("throws AI errors without streaming an error status", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
       title: `Custom Prompts Error ${randomUUID()}`,
     });
 
-    await Promise.all([
-      activityFixture({
-        generationStatus: "pending",
-        kind: "custom",
-        language: "en",
-        lessonId: lesson.id,
-        organizationId,
-        title: `Custom OK ${randomUUID()}`,
-      }),
-      activityFixture({
-        generationStatus: "pending",
-        kind: "custom",
-        language: "en",
-        lessonId: lesson.id,
-        organizationId,
-        position: 1,
-        title: `Custom Fail ${randomUUID()}`,
-      }),
-    ]);
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "custom",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Custom Fail ${randomUUID()}`,
+    });
 
     const activities = await fetchLessonActivities(lesson.id);
+    const activity = activities[0]!;
 
-    generateStepImagePromptsMock
-      .mockResolvedValueOnce({
-        data: { prompts: ["A lesson illustration"] },
-      })
-      .mockRejectedValueOnce(new Error("Prompt generation failed"));
+    generateStepImagePromptsMock.mockRejectedValue(new Error("Prompt generation failed"));
 
-    const contentResults = activities.map((activity) => ({
-      activityId: activity.id,
-      steps: [{ text: "text", title: "title" }],
-    }));
-
-    const results = await generateCustomImagePromptsStep(activities, contentResults);
-
-    expect(results).toHaveLength(1);
+    await expect(
+      generateCustomImagePromptsStep(activity, {
+        activityId: activity.id,
+        steps: [{ text: "text", title: "title" }],
+      }),
+    ).rejects.toThrow("Prompt generation failed");
 
     const events = getStreamedEvents(writeMock);
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateImagePrompts" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/generate-custom-image-prompts-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-custom-image-prompts-step.ts
@@ -1,7 +1,6 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { generateStepImagePrompts } from "@zoonk/ai/tasks/steps/image-prompts";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
-import { rejected, settledValues } from "@zoonk/utils/settled";
 import { type CustomContentResult } from "./generate-custom-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
 
@@ -39,42 +38,21 @@ async function generatePromptsForActivity(
 }
 
 /**
- * Generates image prompts for all custom activities in parallel.
+ * Generates image prompts for one custom activity.
  * Pure data producer: no DB writes happen here.
  */
 export async function generateCustomImagePromptsStep(
-  activities: LessonActivity[],
-  customContentResults: CustomContentResult[],
-): Promise<CustomImagePromptResult[]> {
+  activity: LessonActivity,
+  contentResult: CustomContentResult,
+): Promise<CustomImagePromptResult> {
   "use step";
 
-  if (customContentResults.length === 0) {
-    return [];
-  }
-
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({ status: "started", step: "generateImagePrompts" });
 
-  const allSettled = await Promise.allSettled(
-    customContentResults.map((contentResult) => {
-      const activity = activities.find((act) => act.id === contentResult.activityId);
+  const result = await generatePromptsForActivity(activity, contentResult);
 
-      if (!activity) {
-        return Promise.resolve({
-          activityId: contentResult.activityId,
-          prompts: [],
-        });
-      }
-
-      return generatePromptsForActivity(activity, contentResult);
-    }),
-  );
-
-  await stream.status({
-    status: rejected(allSettled) ? "error" : "completed",
-    step: "generateImagePrompts",
-  });
-
-  return settledValues(allSettled);
+  await stream.status({ status: "completed", step: "generateImagePrompts" });
+  return result;
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-custom-step-images-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-custom-step-images-step.test.ts
@@ -77,27 +77,23 @@ describe(generateCustomStepImagesStep, () => {
       },
     ]);
 
-    const results = await generateCustomStepImagesStep(activities, [
-      {
-        activityId: activity.id,
-        prompts: ["A lesson illustration for Step 1"],
-      },
-    ]);
+    const result = await generateCustomStepImagesStep(activity, {
+      activityId: activity.id,
+      prompts: ["A lesson illustration for Step 1"],
+    });
 
-    expect(results).toEqual([
-      {
-        activityId: activity.id,
-        images: [
-          {
-            prompt: "A lesson illustration for Step 1",
-            url: "https://example.com/step-1.webp",
-          },
-        ],
-      },
-    ]);
+    expect(result).toEqual({
+      activityId: activity.id,
+      images: [
+        {
+          prompt: "A lesson illustration for Step 1",
+          url: "https://example.com/step-1.webp",
+        },
+      ],
+    });
   });
 
-  test("returns empty array when prompt results are empty", async () => {
+  test("throws image generation errors", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -114,10 +110,16 @@ describe(generateCustomStepImagesStep, () => {
     });
 
     const activities = await fetchLessonActivities(lesson.id);
+    const activity = activities[0]!;
 
-    const results = await generateCustomStepImagesStep(activities, []);
+    generateStepImagesMock.mockRejectedValue(new Error("Image generation failed"));
 
-    expect(results).toEqual([]);
+    await expect(
+      generateCustomStepImagesStep(activity, {
+        activityId: activity.id,
+        prompts: ["A lesson illustration"],
+      }),
+    ).rejects.toThrow("Image generation failed");
   });
 
   test("returns empty images for an activity with empty prompts", async () => {
@@ -139,11 +141,12 @@ describe(generateCustomStepImagesStep, () => {
     const activities = await fetchLessonActivities(lesson.id);
     const activity = activities[0]!;
 
-    const results = await generateCustomStepImagesStep(activities, [
-      { activityId: activity.id, prompts: [] },
-    ]);
+    const result = await generateCustomStepImagesStep(activity, {
+      activityId: activity.id,
+      prompts: [],
+    });
 
-    expect(results).toEqual([{ activityId: activity.id, images: [] }]);
+    expect(result).toEqual({ activityId: activity.id, images: [] });
     expect(generateStepImagesMock).not.toHaveBeenCalled();
   });
 
@@ -173,9 +176,10 @@ describe(generateCustomStepImagesStep, () => {
       },
     ]);
 
-    await generateCustomStepImagesStep(activities, [
-      { activityId: activity.id, prompts: ["A lesson illustration for title"] },
-    ]);
+    await generateCustomStepImagesStep(activity, {
+      activityId: activity.id,
+      prompts: ["A lesson illustration for title"],
+    });
 
     const events = getStreamedEvents(writeMock);
 
@@ -187,55 +191,36 @@ describe(generateCustomStepImagesStep, () => {
     );
   });
 
-  test("streams error status when some image generations fail", async () => {
+  test("does not stream an error status when image generation throws", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
       title: `Custom Images Error ${randomUUID()}`,
     });
 
-    await Promise.all([
-      activityFixture({
-        generationStatus: "pending",
-        kind: "custom",
-        language: "en",
-        lessonId: lesson.id,
-        organizationId,
-        title: `Custom OK ${randomUUID()}`,
-      }),
-      activityFixture({
-        generationStatus: "pending",
-        kind: "custom",
-        language: "en",
-        lessonId: lesson.id,
-        organizationId,
-        position: 1,
-        title: `Custom Fail ${randomUUID()}`,
-      }),
-    ]);
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "custom",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Custom Fail ${randomUUID()}`,
+    });
 
     const activities = await fetchLessonActivities(lesson.id);
+    const activity = activities[0]!;
 
-    generateStepImagesMock
-      .mockResolvedValueOnce([
-        {
-          prompt: "A lesson illustration",
-          url: "https://example.com/ok.webp",
-        },
-      ])
-      .mockRejectedValueOnce(new Error("Image generation failed"));
+    generateStepImagesMock.mockRejectedValue(new Error("Image generation failed"));
 
-    const promptResults = activities.map((activity) => ({
-      activityId: activity.id,
-      prompts: ["A lesson illustration"],
-    }));
-
-    const results = await generateCustomStepImagesStep(activities, promptResults);
-
-    expect(results).toHaveLength(1);
+    await expect(
+      generateCustomStepImagesStep(activity, {
+        activityId: activity.id,
+        prompts: ["A lesson illustration"],
+      }),
+    ).rejects.toThrow("Image generation failed");
 
     const events = getStreamedEvents(writeMock);
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateStepImages" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/generate-custom-step-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-custom-step-images-step.ts
@@ -1,7 +1,6 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { type StepImage } from "@zoonk/core/steps/contract/image";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
-import { rejected, settledValues } from "@zoonk/utils/settled";
 import { generateStepImages } from "./_utils/generate-step-images";
 import { type CustomImagePromptResult } from "./generate-custom-image-prompts-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
@@ -33,42 +32,21 @@ async function generateImagesForActivity(
 }
 
 /**
- * Generates uploaded step illustrations for all custom activities in parallel.
+ * Generates uploaded step illustrations for one custom activity.
  * Pure data producer: no DB writes happen here.
  */
 export async function generateCustomStepImagesStep(
-  activities: LessonActivity[],
-  promptResults: CustomImagePromptResult[],
-): Promise<CustomStepImageResult[]> {
+  activity: LessonActivity,
+  promptResult: CustomImagePromptResult,
+): Promise<CustomStepImageResult> {
   "use step";
 
-  if (promptResults.length === 0) {
-    return [];
-  }
-
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({ status: "started", step: "generateStepImages" });
 
-  const allSettled = await Promise.allSettled(
-    promptResults.map((promptResult) => {
-      const activity = activities.find((act) => act.id === promptResult.activityId);
+  const result = await generateImagesForActivity(activity, promptResult);
 
-      if (!activity) {
-        return Promise.resolve({
-          activityId: promptResult.activityId,
-          images: [],
-        });
-      }
-
-      return generateImagesForActivity(activity, promptResult);
-    }),
-  );
-
-  await stream.status({
-    status: rejected(allSettled) ? "error" : "completed",
-    step: "generateStepImages",
-  });
-
-  return settledValues(allSettled);
+  await stream.status({ status: "completed", step: "generateStepImages" });
+  return result;
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-explanation-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-explanation-content-step.test.ts
@@ -86,7 +86,7 @@ describe(generateExplanationContentStep, () => {
     vi.clearAllMocks();
   });
 
-  test("returns explanation results for each activity", async () => {
+  test("returns explanation content for one activity", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -120,14 +120,13 @@ describe(generateExplanationContentStep, () => {
     generateActivityExplanationMock.mockResolvedValue(createExplanationResult());
 
     const result = await generateExplanationContentStep({
-      activities,
+      activity: activities[0]!,
       allActivities: activities,
       lessonConcepts: lesson.concepts,
     });
 
-    expect(result.results).toHaveLength(2);
-    expect(result.results[0]?.activityId).toBe(activities[0]?.id);
-    expect(result.results[0]?.steps).toEqual([
+    expect(result.activityId).toBe(activities[0]?.id);
+    expect(result.steps).toEqual([
       {
         text: "You send a photo on WhatsApp. In under a second, it appears on your friend's screen, even if you're on the bus.",
         title: "O envio",
@@ -149,7 +148,6 @@ describe(generateExplanationContentStep, () => {
         title: "Every send",
       },
     ]);
-    expect(result.results[1]?.activityId).toBe(activities[1]?.id);
     expect(generateActivityExplanationMock).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -161,13 +159,33 @@ describe(generateExplanationContentStep, () => {
     );
   });
 
-  test("returns empty results when activities list is empty", async () => {
-    const result = await generateExplanationContentStep({
-      activities: [],
-      allActivities: [],
-      lessonConcepts: ["concept"],
+  test("throws when AI returns empty content", async () => {
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      organizationId,
+      title: `Explanation Empty ${randomUUID()}`,
     });
-    expect(result).toEqual({ results: [] });
+
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "explanation",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Empty Concept ${randomUUID()}`,
+    });
+
+    const activities = await fetchLessonActivities(lesson.id);
+
+    generateActivityExplanationMock.mockResolvedValue(null);
+
+    await expect(
+      generateExplanationContentStep({
+        activity: activities[0]!,
+        allActivities: activities,
+        lessonConcepts: lesson.concepts,
+      }),
+    ).rejects.toThrow("Empty AI result for explanation content");
   });
 
   test("streams started and completed events", async () => {
@@ -191,7 +209,7 @@ describe(generateExplanationContentStep, () => {
     generateActivityExplanationMock.mockResolvedValue(createExplanationResult());
 
     await generateExplanationContentStep({
-      activities,
+      activity: activities[0]!,
       allActivities: activities,
       lessonConcepts: lesson.concepts,
     });
@@ -207,49 +225,33 @@ describe(generateExplanationContentStep, () => {
     );
   });
 
-  test("streams error status when some AI calls fail", async () => {
+  test("throws AI errors without streaming an error status", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
       title: `Explanation Error ${randomUUID()}`,
     });
 
-    await Promise.all([
-      activityFixture({
-        generationStatus: "pending",
-        kind: "explanation",
-        language: "en",
-        lessonId: lesson.id,
-        organizationId,
-        title: `Good Concept ${randomUUID()}`,
-      }),
-      activityFixture({
-        generationStatus: "pending",
-        kind: "explanation",
-        language: "en",
-        lessonId: lesson.id,
-        organizationId,
-        position: 1,
-        title: `Bad Concept ${randomUUID()}`,
-      }),
-    ]);
+    await activityFixture({
+      generationStatus: "pending",
+      kind: "explanation",
+      language: "en",
+      lessonId: lesson.id,
+      organizationId,
+      title: `Bad Concept ${randomUUID()}`,
+    });
 
     const activities = await fetchLessonActivities(lesson.id);
 
-    generateActivityExplanationMock
-      .mockResolvedValueOnce({
-        data: createExplanationResult().data,
-      })
-      .mockRejectedValueOnce(new Error("AI failure"));
+    generateActivityExplanationMock.mockRejectedValue(new Error("AI failure"));
 
-    const result = await generateExplanationContentStep({
-      activities,
-      allActivities: activities,
-      lessonConcepts: lesson.concepts,
-    });
-
-    expect(result.results).toHaveLength(1);
-    expect(result.results[0]?.activityId).toBe(activities[0]?.id);
+    await expect(
+      generateExplanationContentStep({
+        activity: activities[0]!,
+        allActivities: activities,
+        lessonConcepts: lesson.concepts,
+      }),
+    ).rejects.toThrow("AI failure");
 
     const events = getStreamedEvents(writeMock);
 
@@ -257,7 +259,7 @@ describe(generateExplanationContentStep, () => {
       expect.objectContaining({ status: "started", step: "generateExplanationContent" }),
     );
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateExplanationContent" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/generate-explanation-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-explanation-content-step.ts
@@ -1,7 +1,6 @@
-import { createStepStream } from "@/workflows/_shared/stream-status";
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { generateActivityExplanation } from "@zoonk/ai/tasks/activities/core/explanation";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
-import { rejected, settledValues } from "@zoonk/utils/settled";
 import { buildExplanationActivitySteps } from "./_utils/build-explanation-activity-plan";
 import { type ActivitySteps } from "./_utils/get-activity-steps";
 import { type LessonActivity } from "./get-lesson-activities-step";
@@ -82,48 +81,37 @@ function getOtherExplanationTitles({
 }
 
 /**
- * Generates explanation content for all explanation activities in parallel.
+ * Generates explanation content for one explanation activity.
  * Returns the raw content data without saving to the database.
- * Each activity's content will be persisted later by `saveExplanationActivityStep`.
  *
- * Only receives activities that need generation — no status checks needed.
+ * The caller fans out per activity at the workflow level so one failed
+ * explanation can be retried and marked failed without affecting sibling
+ * explanations.
  */
 export async function generateExplanationContentStep({
-  activities,
+  activity,
   allActivities,
   lessonConcepts,
 }: {
-  activities: LessonActivity[];
+  activity: LessonActivity;
   allActivities: LessonActivity[];
   lessonConcepts: string[];
-}): Promise<{ results: GeneratedExplanationResult[] }> {
+}): Promise<GeneratedExplanationResult> {
   "use step";
 
-  if (activities.length === 0) {
-    return { results: [] };
-  }
-
-  await using stream = createStepStream<ActivityStepName>();
+  await using stream = createEntityStepStream<ActivityStepName>(activity.id);
 
   await stream.status({ status: "started", step: "generateExplanationContent" });
 
-  const allSettled = await Promise.allSettled(
-    activities.map((activity) =>
-      generateSingleExplanation({
-        activity,
-        lessonConcepts,
-        otherExplanationTitles: getOtherExplanationTitles({
-          activities: allActivities,
-          currentActivityId: activity.id,
-        }),
-      }),
-    ),
-  );
-
-  await stream.status({
-    status: rejected(allSettled) ? "error" : "completed",
-    step: "generateExplanationContent",
+  const result = await generateSingleExplanation({
+    activity,
+    lessonConcepts,
+    otherExplanationTitles: getOtherExplanationTitles({
+      activities: allActivities,
+      currentActivityId: activity.id,
+    }),
   });
 
-  return { results: settledValues(allSettled) };
+  await stream.status({ status: "completed", step: "generateExplanationContent" });
+  return result;
 }

--- a/apps/api/src/workflows/activity-generation/steps/generate-grammar-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-grammar-content-step.test.ts
@@ -97,7 +97,7 @@ describe(generateGrammarContentStep, () => {
     );
   });
 
-  test("marks activity as failed and streams error when AI fails", async () => {
+  test("throws AI errors without streaming an error status", async () => {
     vi.mocked(generateActivityGrammarContent).mockRejectedValueOnce(new Error("AI error"));
 
     const lesson = await lessonFixture({
@@ -117,21 +117,19 @@ describe(generateGrammarContentStep, () => {
     });
 
     const [activity] = await fetchLessonActivities(lesson.id);
-    const result = await generateGrammarContentStep(activity!, "workflow-2");
-
-    expect(result).toEqual({ generated: false, grammarContent: null });
+    await expect(generateGrammarContentStep(activity!, "workflow-2")).rejects.toThrow("AI error");
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateGrammarContent" }),
     );
   });
 
-  test("marks activity as failed and streams error when grammar content has no exercises", async () => {
+  test("throws when grammar content has no exercises", async () => {
     vi.mocked(generateActivityGrammarContent).mockResolvedValueOnce({
       data: { examples: [{ highlight: "は", sentence: "test" }], exercises: [] },
     } as never);
@@ -153,16 +151,16 @@ describe(generateGrammarContentStep, () => {
     });
 
     const [activity] = await fetchLessonActivities(lesson.id);
-    const result = await generateGrammarContentStep(activity!, "workflow-3");
-
-    expect(result).toEqual({ generated: false, grammarContent: null });
+    await expect(generateGrammarContentStep(activity!, "workflow-3")).rejects.toThrow(
+      "contentValidationFailed",
+    );
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateGrammarContent" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/generate-grammar-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-grammar-content-step.ts
@@ -7,7 +7,6 @@ import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { z } from "zod";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 const minimumGrammarContentSchema = z.object({
   examples: z.array(z.unknown()).min(1),
@@ -57,10 +56,7 @@ export async function generateGrammarContentStep(
     );
 
   if (error || !result || !hasMinimumGrammarContent(result.data)) {
-    const reason = getAIResultErrorReason({ error, result });
-    await stream.error({ reason, step: "generateGrammarContent" });
-    await handleActivityFailureStep({ activityId: activity.id });
-    return { generated: false, grammarContent: null };
+    throw error ?? new Error(getAIResultErrorReason({ result }));
   }
 
   await stream.status({ status: "completed", step: "generateGrammarContent" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-grammar-romanization-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-grammar-romanization-step.test.ts
@@ -168,7 +168,7 @@ describe(generateGrammarRomanizationStep, () => {
     expect(generateActivityRomanization).not.toHaveBeenCalled();
   });
 
-  test("marks activity as failed and streams error when AI romanization fails", async () => {
+  test("throws AI errors without streaming an error status", async () => {
     vi.mocked(generateActivityRomanization).mockRejectedValueOnce(new Error("AI error"));
 
     const course = await courseFixture({ organizationId, targetLanguage: "ja" });
@@ -202,16 +202,16 @@ describe(generateGrammarRomanizationStep, () => {
       exercises: [{ answer: "は", distractors: ["が", "を"], template: "これ[BLANK]猫です" }],
     };
 
-    const result = await generateGrammarRomanizationStep(activities, grammarContent);
-
-    expect(result).toEqual({ romanizations: null });
+    await expect(generateGrammarRomanizationStep(activities, grammarContent)).rejects.toThrow(
+      "AI error",
+    );
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateGrammarRomanization" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/generate-grammar-romanization-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-grammar-romanization-step.ts
@@ -5,7 +5,6 @@ import { needsRomanization } from "@zoonk/utils/languages";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { generateActivityRomanizations } from "./_utils/generate-activity-romanizations";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Builds the full sentence by replacing [BLANK] with the correct answer.
@@ -64,12 +63,6 @@ export async function generateGrammarRomanizationStep(
   await stream.status({ status: "started", step: "generateGrammarRomanization" });
 
   const romanizations = await generateActivityRomanizations({ targetLanguage, texts: allTexts });
-
-  if (!romanizations) {
-    await stream.error({ reason: "romanizationFailed", step: "generateGrammarRomanization" });
-    await handleActivityFailureStep({ activityId: activity.id });
-    return { romanizations: null };
-  }
 
   await stream.status({ status: "completed", step: "generateGrammarRomanization" });
   return { romanizations };

--- a/apps/api/src/workflows/activity-generation/steps/generate-grammar-user-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-grammar-user-content-step.test.ts
@@ -153,7 +153,7 @@ describe(generateGrammarUserContentStep, () => {
     expect(generateActivityGrammarUserContent).not.toHaveBeenCalled();
   });
 
-  test("marks activity as failed and streams error when AI fails", async () => {
+  test("throws AI errors without streaming an error status", async () => {
     vi.mocked(generateActivityGrammarUserContent).mockRejectedValueOnce(new Error("AI error"));
 
     const lesson = await lessonFixture({
@@ -179,21 +179,21 @@ describe(generateGrammarUserContentStep, () => {
       exercises: [{ answer: "は", distractors: ["が"], template: "test[BLANK]" }],
     };
 
-    const result = await generateGrammarUserContentStep(activities, grammarContent);
-
-    expect(result).toEqual({ userContent: null });
+    await expect(generateGrammarUserContentStep(activities, grammarContent)).rejects.toThrow(
+      "AI error",
+    );
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateGrammarUserContent" }),
     );
   });
 
-  test("marks activity as failed and streams error when AI returns empty result", async () => {
+  test("throws when AI returns empty result", async () => {
     vi.mocked(generateActivityGrammarUserContent).mockResolvedValueOnce(null as never);
 
     const lesson = await lessonFixture({
@@ -219,16 +219,16 @@ describe(generateGrammarUserContentStep, () => {
       exercises: [{ answer: "は", distractors: ["が"], template: "test[BLANK]" }],
     };
 
-    const result = await generateGrammarUserContentStep(activities, grammarContent);
-
-    expect(result).toEqual({ userContent: null });
+    await expect(generateGrammarUserContentStep(activities, grammarContent)).rejects.toThrow(
+      "aiEmptyResult",
+    );
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateGrammarUserContent" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/generate-grammar-user-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-grammar-user-content-step.ts
@@ -8,7 +8,6 @@ import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Generates USER_LANGUAGE content for grammar activities: translations,
@@ -49,10 +48,7 @@ export async function generateGrammarUserContentStep(
     );
 
   if (error || !result) {
-    const reason = error ? "aiGenerationFailed" : "aiEmptyResult";
-    await stream.error({ reason, step: "generateGrammarUserContent" });
-    await handleActivityFailureStep({ activityId: activity.id });
-    return { userContent: null };
+    throw error ?? new Error("aiEmptyResult");
   }
 
   await stream.status({ status: "completed", step: "generateGrammarUserContent" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-accuracy-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-accuracy-step.test.ts
@@ -152,7 +152,7 @@ describe(generateInvestigationAccuracyStep, () => {
     );
   });
 
-  test("returns null and marks as failed when AI call throws", async () => {
+  test("throws AI errors without streaming an error status", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -182,20 +182,20 @@ describe(generateInvestigationAccuracyStep, () => {
 
     generateActivityInvestigationAccuracyMock.mockRejectedValue(new Error("AI failed"));
 
-    const result = await generateInvestigationAccuracyStep({
-      activity: activityWithNumericId,
-      activityId: dbActivity.id,
-      scenario: mockScenario,
-    });
-
-    expect(result).toBeNull();
+    await expect(
+      generateInvestigationAccuracyStep({
+        activity: activityWithNumericId,
+        activityId: dbActivity.id,
+        scenario: mockScenario,
+      }),
+    ).rejects.toThrow("AI failed");
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({
         entityId: dbActivity.id,
         status: "error",

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-accuracy-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-accuracy-step.ts
@@ -7,7 +7,6 @@ import { type ActivityInvestigationScenarioSchema } from "@zoonk/ai/tasks/activi
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { safeAsync } from "@zoonk/utils/error";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Assigns accuracy tiers (best/partial/wrong) to each explanation
@@ -15,7 +14,8 @@ import { handleActivityFailureStep } from "./handle-failure-step";
  * to avoid length bias — the scenario task writes explanations
  * without knowing which is "best".
  *
- * Returns the accuracy tiers or null if generation fails.
+ * Throws on generation failure so Workflow can retry before the activity is
+ * marked permanently failed by the workflow catch.
  */
 export async function generateInvestigationAccuracyStep({
   activityId,
@@ -25,7 +25,7 @@ export async function generateInvestigationAccuracyStep({
   activityId: string;
   activity: LessonActivity;
   scenario: ActivityInvestigationScenarioSchema;
-}): Promise<ActivityInvestigationAccuracySchema | null> {
+}): Promise<ActivityInvestigationAccuracySchema> {
   "use step";
 
   await using stream = createEntityStepStream<ActivityStepName>(activityId);
@@ -42,12 +42,7 @@ export async function generateInvestigationAccuracyStep({
   );
 
   if (error || !result) {
-    const reason = getAIResultErrorReason({ error, result });
-
-    await stream.error({ reason, step: "generateInvestigationAccuracy" });
-    await handleActivityFailureStep({ activityId });
-
-    return null;
+    throw error ?? new Error(getAIResultErrorReason({ result }));
   }
 
   await stream.status({ status: "completed", step: "generateInvestigationAccuracy" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-actions-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-actions-step.test.ts
@@ -135,7 +135,7 @@ describe(generateInvestigationActionsStep, () => {
     );
   });
 
-  test("returns null and marks as failed when AI returns empty actions", async () => {
+  test("throws when AI returns empty actions", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -155,21 +155,21 @@ describe(generateInvestigationActionsStep, () => {
       data: { actions: [] },
     });
 
-    const result = await generateInvestigationActionsStep({
-      accuracy: mockAccuracy,
-      activityId: dbActivity.id,
-      language: "en",
-      scenario: mockScenario,
-    });
-
-    expect(result).toBeNull();
+    await expect(
+      generateInvestigationActionsStep({
+        accuracy: mockAccuracy,
+        activityId: dbActivity.id,
+        language: "en",
+        scenario: mockScenario,
+      }),
+    ).rejects.toThrow("contentValidationFailed");
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({
         entityId: dbActivity.id,
         status: "error",
@@ -178,7 +178,7 @@ describe(generateInvestigationActionsStep, () => {
     );
   });
 
-  test("returns null and marks as failed when AI call throws", async () => {
+  test("throws AI errors without streaming an error status", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -196,21 +196,21 @@ describe(generateInvestigationActionsStep, () => {
 
     generateActivityInvestigationActionsMock.mockRejectedValue(new Error("AI failed"));
 
-    const result = await generateInvestigationActionsStep({
-      accuracy: mockAccuracy,
-      activityId: dbActivity.id,
-      language: "en",
-      scenario: mockScenario,
-    });
-
-    expect(result).toBeNull();
+    await expect(
+      generateInvestigationActionsStep({
+        accuracy: mockAccuracy,
+        activityId: dbActivity.id,
+        language: "en",
+        scenario: mockScenario,
+      }),
+    ).rejects.toThrow("AI failed");
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({
         entityId: dbActivity.id,
         status: "error",

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-actions-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-actions-step.ts
@@ -7,13 +7,13 @@ import {
 import { type ActivityInvestigationScenarioSchema } from "@zoonk/ai/tasks/activities/core/investigation-scenario";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { safeAsync } from "@zoonk/utils/error";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Generates investigation actions (5-6 options with quality tiers)
  * that represent different angles the learner can investigate.
  *
- * Returns the actions or null if generation fails.
+ * Throws on generation failure so Workflow can retry before the activity is
+ * marked permanently failed by the workflow catch.
  */
 export async function generateInvestigationActionsStep({
   activityId,
@@ -25,7 +25,7 @@ export async function generateInvestigationActionsStep({
   accuracy: ActivityInvestigationAccuracySchema;
   language: string;
   scenario: ActivityInvestigationScenarioSchema;
-}): Promise<ActivityInvestigationActionsSchema | null> {
+}): Promise<ActivityInvestigationActionsSchema> {
   "use step";
 
   await using stream = createEntityStepStream<ActivityStepName>(activityId);
@@ -41,12 +41,7 @@ export async function generateInvestigationActionsStep({
   );
 
   if (error || !result || result.data.actions.length === 0) {
-    const reason = getAIResultErrorReason({ error, result });
-
-    await stream.error({ reason, step: "generateInvestigationActions" });
-    await handleActivityFailureStep({ activityId });
-
-    return null;
+    throw error ?? new Error(getAIResultErrorReason({ result }));
   }
 
   await stream.status({ status: "completed", step: "generateInvestigationActions" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-findings-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-findings-step.test.ts
@@ -144,7 +144,7 @@ describe(generateInvestigationFindingsStep, () => {
     );
   });
 
-  test("returns null and marks as failed when AI returns empty findings", async () => {
+  test("throws when AI returns empty findings", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -164,22 +164,22 @@ describe(generateInvestigationFindingsStep, () => {
       data: { findings: [] },
     });
 
-    const result = await generateInvestigationFindingsStep({
-      accuracy: mockAccuracy,
-      actions: mockActions,
-      activityId: dbActivity.id,
-      language: "en",
-      scenario: mockScenario,
-    });
-
-    expect(result).toBeNull();
+    await expect(
+      generateInvestigationFindingsStep({
+        accuracy: mockAccuracy,
+        actions: mockActions,
+        activityId: dbActivity.id,
+        language: "en",
+        scenario: mockScenario,
+      }),
+    ).rejects.toThrow("contentValidationFailed");
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({
         entityId: dbActivity.id,
         status: "error",
@@ -188,7 +188,7 @@ describe(generateInvestigationFindingsStep, () => {
     );
   });
 
-  test("returns null and marks as failed when AI call throws", async () => {
+  test("throws AI errors without streaming an error status", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -206,22 +206,22 @@ describe(generateInvestigationFindingsStep, () => {
 
     generateActivityInvestigationFindingsMock.mockRejectedValue(new Error("AI failed"));
 
-    const result = await generateInvestigationFindingsStep({
-      accuracy: mockAccuracy,
-      actions: mockActions,
-      activityId: dbActivity.id,
-      language: "en",
-      scenario: mockScenario,
-    });
-
-    expect(result).toBeNull();
+    await expect(
+      generateInvestigationFindingsStep({
+        accuracy: mockAccuracy,
+        actions: mockActions,
+        activityId: dbActivity.id,
+        language: "en",
+        scenario: mockScenario,
+      }),
+    ).rejects.toThrow("AI failed");
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({
         entityId: dbActivity.id,
         status: "error",

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-findings-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-findings-step.ts
@@ -8,13 +8,13 @@ import {
 import { type ActivityInvestigationScenarioSchema } from "@zoonk/ai/tasks/activities/core/investigation-scenario";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { safeAsync } from "@zoonk/utils/error";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Generates deliberately ambiguous findings for each investigation action.
  * Each finding has a complicating factor that makes interpretation non-trivial.
  *
- * Returns the findings or null if generation fails.
+ * Throws on generation failure so Workflow can retry before the activity is
+ * marked permanently failed by the workflow catch.
  */
 export async function generateInvestigationFindingsStep({
   activityId,
@@ -28,7 +28,7 @@ export async function generateInvestigationFindingsStep({
   actions: ActivityInvestigationActionsSchema;
   language: string;
   scenario: ActivityInvestigationScenarioSchema;
-}): Promise<ActivityInvestigationFindingsSchema | null> {
+}): Promise<ActivityInvestigationFindingsSchema> {
   "use step";
 
   await using stream = createEntityStepStream<ActivityStepName>(activityId);
@@ -45,12 +45,7 @@ export async function generateInvestigationFindingsStep({
   );
 
   if (error || !result || result.data.findings.length === 0) {
-    const reason = getAIResultErrorReason({ error, result });
-
-    await stream.error({ reason, step: "generateInvestigationFindings" });
-    await handleActivityFailureStep({ activityId });
-
-    return null;
+    throw error ?? new Error(getAIResultErrorReason({ result }));
   }
 
   await stream.status({ status: "completed", step: "generateInvestigationFindings" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-scenario-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-scenario-step.test.ts
@@ -150,7 +150,7 @@ describe(generateInvestigationScenarioStep, () => {
     expect(generateActivityInvestigationScenarioMock).not.toHaveBeenCalled();
   });
 
-  test("marks activity as failed when AI returns empty explanations", async () => {
+  test("throws when AI returns empty explanations", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -172,16 +172,16 @@ describe(generateInvestigationScenarioStep, () => {
       data: { explanations: [], scenario: "A scenario", title: "Who froze the payment queue?" },
     });
 
-    const result = await generateInvestigationScenarioStep(activities);
-
-    expect(result).toEqual({ activityId: null, scenario: null, title: null });
+    await expect(generateInvestigationScenarioStep(activities)).rejects.toThrow(
+      "contentValidationFailed",
+    );
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({
         entityId: dbActivity.id,
         status: "error",
@@ -190,7 +190,7 @@ describe(generateInvestigationScenarioStep, () => {
     );
   });
 
-  test("marks activity as failed when AI call throws", async () => {
+  test("throws AI errors without streaming an error status", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -210,16 +210,14 @@ describe(generateInvestigationScenarioStep, () => {
 
     generateActivityInvestigationScenarioMock.mockRejectedValue(new Error("AI failed"));
 
-    const result = await generateInvestigationScenarioStep(activities);
-
-    expect(result).toEqual({ activityId: null, scenario: null, title: null });
+    await expect(generateInvestigationScenarioStep(activities)).rejects.toThrow("AI failed");
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({
         entityId: dbActivity.id,
         status: "error",

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-scenario-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-scenario-step.ts
@@ -7,7 +7,6 @@ import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { safeAsync } from "@zoonk/utils/error";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 type InvestigationScenarioResult = {
   activityId: string | null;
@@ -21,7 +20,8 @@ type InvestigationScenarioResult = {
  * first step in the investigation pipeline — subsequent steps (accuracy,
  * actions, findings, etc.) take this output as input.
  *
- * Returns the scenario data or null fields if generation fails.
+ * Returns null fields only when there is no investigation activity to generate.
+ * AI/provider failures throw so Workflow can retry the step.
  */
 export async function generateInvestigationScenarioStep(
   activities: LessonActivity[],
@@ -52,12 +52,7 @@ export async function generateInvestigationScenarioStep(
   );
 
   if (error || !result || result.data.explanations.length === 0) {
-    const reason = getAIResultErrorReason({ error, result });
-
-    await stream.error({ reason, step: "generateInvestigationScenario" });
-    await handleActivityFailureStep({ activityId: investigationActivity.id });
-
-    return { activityId: null, scenario: null, title: null };
+    throw error ?? new Error(getAIResultErrorReason({ result }));
   }
 
   await stream.status({ status: "completed", step: "generateInvestigationScenario" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-practice-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-practice-content-step.test.ts
@@ -140,7 +140,7 @@ describe(generatePracticeContentStep, () => {
     expect(generateActivityPracticeMock).not.toHaveBeenCalled();
   });
 
-  test("marks activity as failed when explanation steps are empty", async () => {
+  test("throws when explanation steps are empty", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -158,22 +158,17 @@ describe(generatePracticeContentStep, () => {
 
     const activities = await fetchLessonActivities(lesson.id);
 
-    const result = await generatePracticeContentStep(activities, [], "run-3");
-
-    expect(result).toEqual({
-      activityId: null,
-      scenario: null,
-      steps: [],
-      title: null,
-    });
+    await expect(generatePracticeContentStep(activities, [], "run-3")).rejects.toThrow(
+      "Practice generation needs explanation steps",
+    );
 
     const updated = await prisma.activity.findUniqueOrThrow({
       where: { id: dbActivity.id },
     });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
   });
 
-  test("marks activity as failed when AI returns empty steps", async () => {
+  test("throws when AI returns empty steps", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -199,23 +194,14 @@ describe(generatePracticeContentStep, () => {
       },
     });
 
-    const result = await generatePracticeContentStep(
-      activities,
-      [{ text: "text", title: "title" }],
-      "run-4",
-    );
-
-    expect(result).toEqual({
-      activityId: null,
-      scenario: null,
-      steps: [],
-      title: null,
-    });
+    await expect(
+      generatePracticeContentStep(activities, [{ text: "text", title: "title" }], "run-4"),
+    ).rejects.toThrow("contentValidationFailed");
 
     const updated = await prisma.activity.findUniqueOrThrow({
       where: { id: dbActivity.id },
     });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
   });
 
   test("streams started and completed events on success", async () => {
@@ -273,7 +259,7 @@ describe(generatePracticeContentStep, () => {
     );
   });
 
-  test("marks activity as failed and streams error when AI call fails", async () => {
+  test("throws AI errors without streaming an error status", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -294,27 +280,18 @@ describe(generatePracticeContentStep, () => {
 
     generateActivityPracticeMock.mockRejectedValue(new Error("AI failed"));
 
-    const result = await generatePracticeContentStep(
-      activities,
-      [{ text: "text", title: "title" }],
-      "run-6",
-    );
-
-    expect(result).toEqual({
-      activityId: null,
-      scenario: null,
-      steps: [],
-      title: null,
-    });
+    await expect(
+      generatePracticeContentStep(activities, [{ text: "text", title: "title" }], "run-6"),
+    ).rejects.toThrow("AI failed");
 
     const updated = await prisma.activity.findUniqueOrThrow({
       where: { id: dbActivity.id },
     });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({
         entityId: practiceActivity.id,
         status: "error",

--- a/apps/api/src/workflows/activity-generation/steps/generate-practice-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-practice-content-step.ts
@@ -5,10 +5,10 @@ import {
 } from "@zoonk/ai/tasks/activities/core/practice";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { FatalError } from "workflow";
 import { findActivitiesByKind } from "./_utils/find-activity-by-kind";
 import { type ActivitySteps } from "./_utils/get-activity-steps";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 export type PracticeScenario = ActivityPracticeSchema["scenario"];
 export type PracticeStep = ActivityPracticeSchema["steps"][number];
@@ -19,8 +19,9 @@ export type PracticeStep = ActivityPracticeSchema["steps"][number];
  * The scenario and steps will be passed to `savePracticeActivityStep` for persistence.
  *
  * No status checks — the caller only passes activities that need generation.
- * Like the quiz step, this uses safeAsync because empty explanations
- * represent a permanent failure (not retryable).
+ * Empty explanation data is a permanent dependency failure, so that case uses
+ * `FatalError`. AI/provider errors still throw the original error so Workflow
+ * retries the practice step before the activity is marked failed.
  */
 export async function generatePracticeContentStep(
   activities: LessonActivity[],
@@ -42,8 +43,7 @@ export async function generatePracticeContentStep(
   }
 
   if (explanationSteps.length === 0) {
-    await handleActivityFailureStep({ activityId: practiceActivity.id });
-    return { activityId: null, scenario: null, steps: [], title: null };
+    throw new FatalError("Practice generation needs explanation steps");
   }
 
   await using stream = createEntityStepStream<ActivityStepName>(practiceActivity.id);
@@ -63,10 +63,7 @@ export async function generatePracticeContentStep(
   );
 
   if (error || !result || result.data.steps.length === 0) {
-    const reason = getAIResultErrorReason({ error, result });
-    await stream.error({ reason, step: "generatePracticeContent" });
-    await handleActivityFailureStep({ activityId: practiceActivity.id });
-    return { activityId: null, scenario: null, steps: [], title: null };
+    throw error ?? new Error(getAIResultErrorReason({ result }));
   }
 
   await stream.status({ status: "completed", step: "generatePracticeContent" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-content-step.test.ts
@@ -119,7 +119,7 @@ describe(generateQuizContentStep, () => {
     expect(generateActivityQuizMock).not.toHaveBeenCalled();
   });
 
-  test("marks activity as failed when explanation steps are empty", async () => {
+  test("throws when explanation steps are empty", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -137,15 +137,15 @@ describe(generateQuizContentStep, () => {
 
     const activities = await fetchLessonActivities(lesson.id);
 
-    const result = await generateQuizContentStep(activities, [], "run-3");
-
-    expect(result).toEqual({ activityId: null, questions: [] });
+    await expect(generateQuizContentStep(activities, [], "run-3")).rejects.toThrow(
+      "Quiz generation needs explanation steps",
+    );
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
   });
 
-  test("marks activity as failed when AI returns empty questions", async () => {
+  test("throws when AI returns empty questions", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -165,16 +165,12 @@ describe(generateQuizContentStep, () => {
 
     generateActivityQuizMock.mockResolvedValue({ data: { questions: [] } });
 
-    const result = await generateQuizContentStep(
-      activities,
-      [{ text: "text", title: "title" }],
-      "run-4",
-    );
-
-    expect(result).toEqual({ activityId: null, questions: [] });
+    await expect(
+      generateQuizContentStep(activities, [{ text: "text", title: "title" }], "run-4"),
+    ).rejects.toThrow("contentValidationFailed");
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
   });
 
   test("streams started and completed events on success", async () => {
@@ -229,7 +225,7 @@ describe(generateQuizContentStep, () => {
     );
   });
 
-  test("marks activity as failed and streams error when AI call fails", async () => {
+  test("throws AI errors without streaming an error status", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -250,20 +246,16 @@ describe(generateQuizContentStep, () => {
 
     generateActivityQuizMock.mockRejectedValue(new Error("AI failed"));
 
-    const result = await generateQuizContentStep(
-      activities,
-      [{ text: "text", title: "title" }],
-      "run-6",
-    );
-
-    expect(result).toEqual({ activityId: null, questions: [] });
+    await expect(
+      generateQuizContentStep(activities, [{ text: "text", title: "title" }], "run-6"),
+    ).rejects.toThrow("AI failed");
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({
         entityId: quizActivity.id,
         status: "error",

--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-content-step.ts
@@ -6,10 +6,10 @@ import {
 } from "@zoonk/ai/tasks/activities/core/quiz";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
+import { FatalError } from "workflow";
 import { findActivitiesByKind } from "./_utils/find-activity-by-kind";
 import { type ActivitySteps } from "./_utils/get-activity-steps";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Generates quiz questions from explanation content via AI.
@@ -18,9 +18,10 @@ import { handleActivityFailureStep } from "./handle-failure-step";
  * then to `saveQuizActivityStep` for persistence.
  *
  * No status checks — the caller only passes activities that need generation.
- * Uses safeAsync + handleActivityFailureStep because the quiz depends on
- * explanation data existing — if explanations are empty, that's a permanent
- * failure (not retryable).
+ * Empty explanation data is a permanent dependency failure, so the step throws
+ * `FatalError` for that case. AI/provider errors still throw the original
+ * error so Workflow can retry the step before the quiz activity is marked
+ * failed by the kind-level catch block.
  */
 export async function generateQuizContentStep(
   activities: LessonActivity[],
@@ -37,8 +38,7 @@ export async function generateQuizContentStep(
   }
 
   if (explanationSteps.length === 0) {
-    await handleActivityFailureStep({ activityId: quizActivity.id });
-    return { activityId: null, questions: [] };
+    throw new FatalError("Quiz generation needs explanation steps");
   }
 
   await using stream = createEntityStepStream<ActivityStepName>(quizActivity.id);
@@ -57,10 +57,7 @@ export async function generateQuizContentStep(
   );
 
   if (error || !result || result.data.questions.length === 0) {
-    const reason = getAIResultErrorReason({ error, result });
-    await stream.error({ reason, step: "generateQuizContent" });
-    await handleActivityFailureStep({ activityId: quizActivity.id });
-    return { activityId: null, questions: [] };
+    throw error ?? new Error(getAIResultErrorReason({ result }));
   }
 
   await stream.status({ status: "completed", step: "generateQuizContent" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.test.ts
@@ -184,7 +184,7 @@ describe(generateQuizImagesStep, () => {
     expect(result).toEqual([]);
   });
 
-  test("returns original options without URLs when image generation fails", async () => {
+  test("throws when image generation fails", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -215,21 +215,15 @@ describe(generateQuizImagesStep, () => {
 
     generateStepImageMock.mockRejectedValue(new Error("Image generation failed"));
 
-    const result = await generateQuizImagesStep(activities, questions);
+    await expect(generateQuizImagesStep(activities, questions)).rejects.toThrow(
+      "Image generation failed",
+    );
 
-    expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({
-      format: "selectImage",
-      options: [
-        expect.objectContaining({ prompt: "a cat" }),
-        expect.objectContaining({ prompt: "a dog" }),
-      ],
-    });
+    const events = getStreamedEvents(writeMock);
 
-    // Options should not have URLs since generation failed
-    const options = (result[0] as { options: { url?: string }[] }).options;
-    expect(options[0]?.url).toBeUndefined();
-    expect(options[1]?.url).toBeUndefined();
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ status: "error", step: "generateQuizImages" }),
+    );
   });
 
   test("streams started and completed events", async () => {

--- a/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-quiz-images-step.ts
@@ -2,7 +2,6 @@ import { createEntityStepStream } from "@/workflows/_shared/stream-status";
 import { type QuizQuestion, type SelectImageQuestion } from "@zoonk/ai/tasks/activities/core/quiz";
 import { generateStepImage } from "@zoonk/core/steps/image";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
-import { rejected } from "@zoonk/utils/settled";
 import { findActivitiesByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
 
@@ -34,20 +33,20 @@ async function generateOptionImages({
   language: string;
   options: SelectImageOption[];
   orgSlug?: string;
-}): Promise<{ hadFailure: boolean; updatedOptions: SelectImageOption[] }> {
-  const results = await Promise.allSettled(
-    options.map(({ prompt }) => generateStepImage({ language, orgSlug, prompt })),
+}): Promise<SelectImageOption[]> {
+  const results = await Promise.all(
+    options.map(async ({ prompt }) => {
+      const { data, error } = await generateStepImage({ language, orgSlug, prompt });
+
+      if (error || !data) {
+        throw error ?? new Error(`Image generation returned no URL for prompt: ${prompt}`);
+      }
+
+      return data;
+    }),
   );
 
-  const updatedOptions = options.map((option, index) => {
-    const result = results[index];
-    if (result?.status === "fulfilled" && !result.value.error) {
-      return { ...option, url: result.value.data };
-    }
-    return option;
-  });
-
-  return { hadFailure: rejected(results), updatedOptions };
+  return options.map((option, index) => ({ ...option, url: results[index] }));
 }
 
 /**
@@ -84,7 +83,7 @@ export async function generateQuizImagesStep(
 
   const orgSlug = activity.lesson.chapter.course.organization?.slug;
 
-  const imageResults = await Promise.allSettled(
+  const imageResults = await Promise.all(
     selectImageQuestions.map((question) =>
       generateOptionImages({
         language: activity.language,
@@ -98,9 +97,9 @@ export async function generateQuizImagesStep(
 
   selectImageQuestions.forEach((question, idx) => {
     const result = imageResults[idx];
-    if (result?.status === "fulfilled") {
+    if (result) {
       const questionIndex = questions.indexOf(question);
-      updatedSelectImageMap.set(questionIndex, result.value.updatedOptions);
+      updatedSelectImageMap.set(questionIndex, result);
     }
   });
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.test.ts
@@ -203,7 +203,7 @@ describe(generateReadingAudioStep, () => {
     expect(result).toEqual({ sentenceAudioUrls: {} });
   });
 
-  test("skips sentences when TTS generation fails and returns partial results", async () => {
+  test("throws when TTS generation fails", async () => {
     const { generateLanguageAudio } = await import("@zoonk/core/audio/generate");
 
     const course = await courseFixture({ organizationId, targetLanguage: "de" });
@@ -250,10 +250,7 @@ describe(generateReadingAudioStep, () => {
       .mockResolvedValueOnce({ data: `/audio/guten-morgen-${id}.mp3`, error: null })
       .mockResolvedValueOnce({ data: null, error: new Error("TTS failed") });
 
-    const result = await generateReadingAudioStep(activities, sentences);
-
-    expect(result.sentenceAudioUrls[`Guten Morgen ${id}`]).toBe(`/audio/guten-morgen-${id}.mp3`);
-    expect(result.sentenceAudioUrls[`Gute Nacht ${id}`]).toBeUndefined();
+    await expect(generateReadingAudioStep(activities, sentences)).rejects.toThrow("TTS failed");
   });
 
   test("returns empty map for unsupported TTS languages", async () => {

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-audio-step.ts
@@ -63,11 +63,9 @@ export async function generateReadingAudioStep(
     ),
   );
 
-  const fulfilled = results.filter((result) => result !== null);
-
   const sentenceAudioUrls: Record<string, string> = {
     ...existingAudioUrls,
-    ...Object.fromEntries(fulfilled.map((result) => [result.text, result.audioUrl])),
+    ...Object.fromEntries(results.map((result) => [result.text, result.audioUrl])),
   };
 
   await stream.status({ status: "completed", step: "generateAudio" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-content-step.test.ts
@@ -116,7 +116,7 @@ describe(generateReadingContentStep, () => {
     expect(dbActivity?.generationStatus).toBe("pending");
   });
 
-  test("marks the activity as failed when no source words are available", async () => {
+  test("throws when no source words are available", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       kind: "language",
@@ -135,15 +135,15 @@ describe(generateReadingContentStep, () => {
 
     const [activity] = await fetchLessonActivities(lesson.id);
 
-    const result = await generateReadingContentStep(activity!, "workflow-2", []);
-
-    expect(result).toEqual({ sentences: [] });
+    await expect(generateReadingContentStep(activity!, "workflow-2", [])).rejects.toThrow(
+      "noSourceData",
+    );
     expect(generateActivitySentences).not.toHaveBeenCalled();
 
     const dbActivity = await prisma.activity.findUnique({
       where: { id: readingActivity.id },
     });
 
-    expect(dbActivity?.generationStatus).toBe("failed");
+    expect(dbActivity?.generationStatus).toBe("pending");
   });
 });

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-content-step.ts
@@ -1,18 +1,13 @@
-import {
-  type StepStream,
-  createEntityStepStream,
-  getAIResultErrorReason,
-} from "@/workflows/_shared/stream-status";
+import { createEntityStepStream, getAIResultErrorReason } from "@/workflows/_shared/stream-status";
 import {
   type ActivitySentencesSchema,
   generateActivitySentences,
 } from "@zoonk/ai/tasks/activities/language/sentences";
 import { type VocabularyWord } from "@zoonk/ai/tasks/activities/language/vocabulary";
-import { type ActivityStepName, type WorkflowErrorReason } from "@zoonk/core/workflows/steps";
+import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 type SourceWord = Pick<VocabularyWord, "word">;
 
@@ -92,20 +87,6 @@ async function resolveSourceWords(input: {
 }
 
 /**
- * Reading generation failures need to mark the activity as failed and return an empty
- * payload so the workflow can stop without leaving partially-generated sentences in play.
- */
-async function handleReadingGenerationFailure(
-  stream: StepStream<ActivityStepName>,
-  activityId: string,
-  reason: WorkflowErrorReason,
-): Promise<{ sentences: ReadingSentence[] }> {
-  await stream.error({ reason, step: "generateSentences" });
-  await handleActivityFailureStep({ activityId });
-  return { sentences: [] };
-}
-
-/**
  * Generates the canonical reading sentences for a lesson.
  *
  * This step intentionally produces only the real sentence pairs. Distractors are
@@ -139,7 +120,7 @@ export async function generateReadingContentStep(
 
   if (sourceWords.error || sourceWords.words.length === 0) {
     const reason = sourceWords.error ? "dbFetchFailed" : "noSourceData";
-    return await handleReadingGenerationFailure(stream, activity.id, reason);
+    throw sourceWords.error ?? new Error(reason);
   }
 
   const { data: result, error } = await safeAsync(() =>
@@ -158,8 +139,7 @@ export async function generateReadingContentStep(
   const sentences = result?.data.sentences ?? [];
 
   if (error || !result || sentences.length === 0 || !hasValidSentences(sentences)) {
-    const reason = getAIResultErrorReason({ error, result });
-    return await handleReadingGenerationFailure(stream, activity.id, reason);
+    throw error ?? new Error(getAIResultErrorReason({ result }));
   }
 
   await stream.status({ status: "completed", step: "generateSentences" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-romanization-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-romanization-step.test.ts
@@ -170,7 +170,7 @@ describe(generateReadingRomanizationStep, () => {
     expect(generateActivityRomanization).not.toHaveBeenCalled();
   });
 
-  test("marks activity as failed and streams error when AI romanization fails", async () => {
+  test("throws AI errors without streaming an error status", async () => {
     vi.mocked(generateActivityRomanization).mockRejectedValueOnce(new Error("AI error"));
 
     const course = await courseFixture({ organizationId, targetLanguage: "ja" });
@@ -199,23 +199,23 @@ describe(generateReadingRomanizationStep, () => {
 
     const activities = await fetchLessonActivities(lesson.id);
 
-    const result = await generateReadingRomanizationStep(activities, [
-      { explanation: "test explanation", sentence: "これは猫です", translation: "This is a cat" },
-    ]);
-
-    expect(result).toEqual({ romanizations: {} });
+    await expect(
+      generateReadingRomanizationStep(activities, [
+        { explanation: "test explanation", sentence: "これは猫です", translation: "This is a cat" },
+      ]),
+    ).rejects.toThrow("AI error");
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateReadingRomanization" }),
     );
   });
 
-  test("marks activity as failed and streams error when some romanizations are missing", async () => {
+  test("throws when some romanizations are missing", async () => {
     vi.mocked(generateActivityRomanization).mockResolvedValueOnce({
       data: { romanizations: ["kore wa neko desu"] },
     } as never);
@@ -251,16 +251,16 @@ describe(generateReadingRomanizationStep, () => {
       { explanation: "test explanation", sentence: "あれは犬です", translation: "That is a dog" },
     ];
 
-    const result = await generateReadingRomanizationStep(activities, sentences);
-
-    expect(result.romanizations["これは猫です"]).toBe("kore wa neko desu");
+    await expect(generateReadingRomanizationStep(activities, sentences)).rejects.toThrow(
+      "romanizationFailed",
+    );
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateReadingRomanization" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/generate-reading-romanization-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-reading-romanization-step.ts
@@ -5,7 +5,6 @@ import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { generateActivityRomanizations } from "./_utils/generate-activity-romanizations";
 import { type ReadingSentence } from "./generate-reading-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Generates romanized (Latin-script) representations of reading sentences
@@ -42,16 +41,8 @@ export async function generateReadingRomanizationStep(
     texts: sentenceStrings,
   });
 
-  if (!romanizations) {
-    await stream.error({ reason: "romanizationFailed", step: "generateReadingRomanization" });
-    await handleActivityFailureStep({ activityId: activity.id });
-    return { romanizations: {} };
-  }
-
   if (Object.keys(romanizations).length < sentences.length) {
-    await stream.error({ reason: "romanizationFailed", step: "generateReadingRomanization" });
-    await handleActivityFailureStep({ activityId: activity.id });
-    return { romanizations };
+    throw new Error("romanizationFailed");
   }
 
   await stream.status({ status: "completed", step: "generateReadingRomanization" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-sentence-distractors-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-sentence-distractors-step.test.ts
@@ -126,7 +126,7 @@ describe(generateSentenceDistractorsStep, () => {
     expect(generateActivityDistractors).not.toHaveBeenCalled();
   });
 
-  test("returns empty distractors for a sentence when AI fails", async () => {
+  test("throws when distractor AI fails", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       kind: "language",
@@ -161,10 +161,9 @@ describe(generateSentenceDistractorsStep, () => {
       })
       .mockRejectedValueOnce(new Error("AI failed"));
 
-    const result = await generateSentenceDistractorsStep(activities, sentences);
-
-    expect(result.distractors[`Guten Morgen ${id}`]).toEqual([`dist1-Guten`, `dist2-Guten`]);
-    expect(result.translationDistractors[`Good morning ${id}`]).toEqual([]);
+    await expect(generateSentenceDistractorsStep(activities, sentences)).rejects.toThrow(
+      "AI failed",
+    );
   });
 
   test("returns empty maps when sentences array is empty", async () => {

--- a/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-audio-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-audio-step.test.ts
@@ -190,7 +190,7 @@ describe(generateSentenceWordAudioStep, () => {
     expect(result).toEqual({ wordAudioUrls: {} });
   });
 
-  test("skips words when TTS generation fails and returns partial results", async () => {
+  test("throws when TTS generation fails", async () => {
     const { generateLanguageAudio } = await import("@zoonk/core/audio/generate");
 
     const course = await courseFixture({ organizationId, targetLanguage: "de" });
@@ -225,10 +225,7 @@ describe(generateSentenceWordAudioStep, () => {
       .mockResolvedValueOnce({ data: `/audio/guten-${id}.mp3`, error: null })
       .mockResolvedValueOnce({ data: null, error: new Error("TTS failed") });
 
-    const result = await generateSentenceWordAudioStep(activities, words);
-
-    expect(result.wordAudioUrls[`guten-${id}`]).toBe(`/audio/guten-${id}.mp3`);
-    expect(result.wordAudioUrls[`morgen-${id}`]).toBeUndefined();
+    await expect(generateSentenceWordAudioStep(activities, words)).rejects.toThrow("TTS failed");
   });
 
   test("returns empty map for unsupported TTS languages", async () => {

--- a/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-metadata-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-metadata-step.test.ts
@@ -231,7 +231,7 @@ describe(generateSentenceWordMetadataStep, () => {
     expect(generateTranslation).not.toHaveBeenCalled();
   });
 
-  test("marks activity as failed and streams error when translations are incomplete", async () => {
+  test("throws translation errors without streaming an error status", async () => {
     vi.mocked(generateTranslation).mockRejectedValue(new Error("AI error"));
 
     const course = await courseFixture({ organizationId, targetLanguage: "de" });
@@ -269,19 +269,16 @@ describe(generateSentenceWordMetadataStep, () => {
       },
     ];
 
-    const result = await generateSentenceWordMetadataStep(activities, sentences, [
-      `hallo${id}`,
-      `welt${id}`,
-    ]);
-
-    expect(result.wordMetadata).toBeDefined();
+    await expect(
+      generateSentenceWordMetadataStep(activities, sentences, [`hallo${id}`, `welt${id}`]),
+    ).rejects.toThrow("AI error");
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({
         status: "error",
         step: "generateSentenceWordMetadata",

--- a/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-metadata-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-metadata-step.ts
@@ -9,7 +9,6 @@ import { extractUniqueSentenceWords } from "@zoonk/utils/string";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type ReadingSentence } from "./generate-reading-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 type WordMetadataEntry = {
   romanization: string | null;
@@ -47,13 +46,13 @@ async function translateWord(
   word: string,
   userLanguage: string,
   targetLanguage: string,
-): Promise<{ translation: string; word: string } | null> {
+): Promise<{ translation: string; word: string }> {
   const { data: result, error } = await safeAsync(() =>
     generateTranslation({ targetLanguage, userLanguage, word }),
   );
 
   if (error || !result?.data) {
-    return null;
+    throw error ?? new Error("translationGenerationFailed");
   }
 
   return { translation: result.data.translation, word };
@@ -64,19 +63,11 @@ async function generateMissingTranslations(
   userLanguage: string,
   targetLanguage: string,
 ): Promise<Record<string, string>> {
-  const results = await Promise.allSettled(
+  const results = await Promise.all(
     wordsNeedingTranslation.map((word) => translateWord(word, userLanguage, targetLanguage)),
   );
 
-  return Object.fromEntries(
-    results.flatMap((result) => {
-      if (result.status !== "fulfilled" || !result.value) {
-        return [];
-      }
-
-      return [[result.value.word, result.value.translation]];
-    }),
-  );
+  return Object.fromEntries(results.map((result) => [result.word, result.translation]));
 }
 
 /**
@@ -97,7 +88,7 @@ async function generateWordRomanizations(
   );
 
   if (error || !result?.data) {
-    return {};
+    throw error ?? new Error("romanizationFailed");
   }
 
   return Object.fromEntries(
@@ -136,17 +127,13 @@ async function buildWordMetadata(params: {
     words: uniqueWords,
   });
 
-  const [translationResult, romanizationResult] = await Promise.allSettled([
+  const [translations, newRomanizations] = await Promise.all([
     generateMissingTranslations(canonicalWords, params.userLanguage, params.targetLanguage),
     generateWordRomanizations(
       uniqueWords.filter((word) => !existingRomanizations[word.toLowerCase()]),
       params.targetLanguage,
     ),
   ]);
-
-  const translations = translationResult.status === "fulfilled" ? translationResult.value : {};
-  const newRomanizations =
-    romanizationResult.status === "fulfilled" ? romanizationResult.value : {};
 
   const isComplete = Object.keys(translations).length === canonicalWords.length;
 
@@ -195,12 +182,7 @@ export async function generateSentenceWordMetadataStep(
   });
 
   if (!isComplete) {
-    await stream.error({
-      reason: "translationGenerationFailed",
-      step: "generateSentenceWordMetadata",
-    });
-    await handleActivityFailureStep({ activityId: activity.id });
-    return { wordMetadata };
+    throw new Error("translationGenerationFailed");
   }
 
   await stream.status({ status: "completed", step: "generateSentenceWordMetadata" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-pronunciation-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-sentence-word-pronunciation-step.test.ts
@@ -197,7 +197,7 @@ describe(generateSentenceWordPronunciationStep, () => {
     expect(result).toEqual({ pronunciations: {} });
   });
 
-  test("skips words when pronunciation AI fails and returns partial results", async () => {
+  test("throws when pronunciation AI fails", async () => {
     const course = await courseFixture({ organizationId, targetLanguage: "de" });
 
     const chapter = await chapterFixture({
@@ -233,10 +233,9 @@ describe(generateSentenceWordPronunciationStep, () => {
       })
       .mockRejectedValueOnce(new Error("AI failed"));
 
-    const result = await generateSentenceWordPronunciationStep(activities, words);
-
-    expect(result.pronunciations[`guten-${id}`]).toBe(`pron-guten-${id}`);
-    expect(result.pronunciations[`morgen-${id}`]).toBeUndefined();
+    await expect(generateSentenceWordPronunciationStep(activities, words)).rejects.toThrow(
+      "AI failed",
+    );
   });
 
   test("returns empty pronunciations when course has no organization", async () => {

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-choices-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-choices-step.test.ts
@@ -173,7 +173,7 @@ describe(generateStoryChoicesStep, () => {
     });
   });
 
-  test("marks story as failed when choice generation returns no result", async () => {
+  test("throws when choice generation returns no result", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -194,20 +194,20 @@ describe(generateStoryChoicesStep, () => {
 
     generateActivityStoryChoicesMock.mockResolvedValue(null);
 
-    const result = await generateStoryChoicesStep({
-      activity: storyActivity,
-      explanationSteps: [{ text: "Explanation content.", title: "Explanation" }],
-      storyPlan: mockStoryPlan,
-    });
-
-    expect(result).toBeNull();
+    await expect(
+      generateStoryChoicesStep({
+        activity: storyActivity,
+        explanationSteps: [{ text: "Explanation content.", title: "Explanation" }],
+        storyPlan: mockStoryPlan,
+      }),
+    ).rejects.toThrow("aiEmptyResult");
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({
         entityId: dbActivity.id,
         status: "error",

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-choices-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-choices-step.ts
@@ -11,7 +11,6 @@ import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { safeAsync } from "@zoonk/utils/error";
 import { type ActivitySteps } from "./_utils/get-activity-steps";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Generates learner choices after the story skeleton exists.
@@ -48,12 +47,7 @@ export async function generateStoryChoicesStep({
   );
 
   if (error || !result) {
-    const reason = getAIResultErrorReason({ error, result });
-
-    await stream.error({ reason, step: "generateStoryChoices" });
-    await handleActivityFailureStep({ activityId: activity.id });
-
-    return null;
+    throw error ?? new Error(getAIResultErrorReason({ result }));
   }
 
   const { data: storyData, error: mergeError } = await safeAsync(async () =>
@@ -61,10 +55,7 @@ export async function generateStoryChoicesStep({
   );
 
   if (mergeError || !storyData) {
-    await stream.error({ reason: "contentValidationFailed", step: "generateStoryChoices" });
-    await handleActivityFailureStep({ activityId: activity.id });
-
-    return null;
+    throw mergeError ?? new Error("contentValidationFailed");
   }
 
   await stream.status({ status: "completed", step: "generateStoryChoices" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.test.ts
@@ -183,7 +183,7 @@ describe(generateStoryContentStep, () => {
     expect(generateActivityStoryMock).not.toHaveBeenCalled();
   });
 
-  test("marks story as failed when explanation steps are missing", async () => {
+  test("throws when explanation steps are missing", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -201,16 +201,16 @@ describe(generateStoryContentStep, () => {
 
     const activities = await fetchLessonActivities(lesson.id);
 
-    const result = await generateStoryContentStep(activities, []);
-
-    expect(result).toEqual({ activityId: null, storyPlan: null });
+    await expect(generateStoryContentStep(activities, [])).rejects.toThrow(
+      "Story generation needs explanation steps",
+    );
     expect(generateActivityStoryMock).not.toHaveBeenCalled();
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
   });
 
-  test("marks activity as failed when AI returns no result", async () => {
+  test("throws when AI returns no result", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -230,18 +230,18 @@ describe(generateStoryContentStep, () => {
 
     generateActivityStoryMock.mockResolvedValue(null);
 
-    const result = await generateStoryContentStep(activities, [
-      { text: "Explanation content.", title: "Explanation" },
-    ]);
-
-    expect(result).toEqual({ activityId: null, storyPlan: null });
+    await expect(
+      generateStoryContentStep(activities, [
+        { text: "Explanation content.", title: "Explanation" },
+      ]),
+    ).rejects.toThrow("aiEmptyResult");
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({
         entityId: dbActivity.id,
         status: "error",
@@ -250,7 +250,7 @@ describe(generateStoryContentStep, () => {
     );
   });
 
-  test("marks activity as failed and streams error when AI call throws", async () => {
+  test("throws AI errors without streaming an error status", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -270,18 +270,18 @@ describe(generateStoryContentStep, () => {
 
     generateActivityStoryMock.mockRejectedValue(new Error("AI failed"));
 
-    const result = await generateStoryContentStep(activities, [
-      { text: "Explanation content.", title: "Explanation" },
-    ]);
-
-    expect(result).toEqual({ activityId: null, storyPlan: null });
+    await expect(
+      generateStoryContentStep(activities, [
+        { text: "Explanation content.", title: "Explanation" },
+      ]),
+    ).rejects.toThrow("AI failed");
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({
         entityId: dbActivity.id,
         status: "error",

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-content-step.ts
@@ -5,10 +5,10 @@ import {
 } from "@zoonk/ai/tasks/activities/core/story";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { safeAsync } from "@zoonk/utils/error";
+import { FatalError } from "workflow";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type ActivitySteps } from "./_utils/get-activity-steps";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 type StoryContentResult = {
   activityId: string | null;
@@ -35,10 +35,7 @@ export async function generateStoryContentStep(
   await using stream = createEntityStepStream<ActivityStepName>(storyActivity.id);
 
   if (explanationSteps.length === 0) {
-    await stream.error({ reason: "contentValidationFailed", step: "generateStoryContent" });
-    await handleActivityFailureStep({ activityId: storyActivity.id });
-
-    return { activityId: null, storyPlan: null };
+    throw new FatalError("Story generation needs explanation steps");
   }
 
   await stream.status({ status: "started", step: "generateStoryContent" });
@@ -59,12 +56,7 @@ export async function generateStoryContentStep(
   );
 
   if (error || !result) {
-    const reason = getAIResultErrorReason({ error, result });
-
-    await stream.error({ reason, step: "generateStoryContent" });
-    await handleActivityFailureStep({ activityId: storyActivity.id });
-
-    return { activityId: null, storyPlan: null };
+    throw error ?? new Error(getAIResultErrorReason({ result }));
   }
 
   await stream.status({ status: "completed", step: "generateStoryContent" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-audio-step.test.ts
@@ -190,7 +190,7 @@ describe(generateVocabularyAudioStep, () => {
     expect(result).toEqual({ wordAudioUrls: {} });
   });
 
-  test("skips words when TTS generation fails and returns partial results", async () => {
+  test("throws when TTS generation fails", async () => {
     const { generateLanguageAudio } = await import("@zoonk/core/audio/generate");
 
     const course = await courseFixture({ organizationId, targetLanguage: "es" });
@@ -225,10 +225,7 @@ describe(generateVocabularyAudioStep, () => {
       .mockResolvedValueOnce({ data: `/audio/bueno-${id}.mp3`, error: null })
       .mockResolvedValueOnce({ data: null, error: new Error("TTS failed") });
 
-    const result = await generateVocabularyAudioStep(activities, words);
-
-    expect(result.wordAudioUrls[`bueno-${id}`]).toBe(`/audio/bueno-${id}.mp3`);
-    expect(result.wordAudioUrls[`malo-${id}`]).toBeUndefined();
+    await expect(generateVocabularyAudioStep(activities, words)).rejects.toThrow("TTS failed");
   });
 
   test("returns empty map for unsupported TTS languages", async () => {

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.test.ts
@@ -100,7 +100,7 @@ describe(generateVocabularyContentStep, () => {
     );
   });
 
-  test("marks activity as failed and streams error when AI fails", async () => {
+  test("throws AI errors without streaming an error status", async () => {
     vi.mocked(generateActivityVocabulary).mockRejectedValueOnce(new Error("AI error"));
 
     const lesson = await lessonFixture({
@@ -120,21 +120,21 @@ describe(generateVocabularyContentStep, () => {
     });
 
     const [activity] = await fetchLessonActivities(lesson.id);
-    const result = await generateVocabularyContentStep(activity!, "workflow-2");
-
-    expect(result).toEqual({ words: [] });
+    await expect(generateVocabularyContentStep(activity!, "workflow-2")).rejects.toThrow(
+      "AI error",
+    );
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateVocabularyContent" }),
     );
   });
 
-  test("marks activity as failed and streams error when AI returns empty words array", async () => {
+  test("throws when AI returns empty words array", async () => {
     vi.mocked(generateActivityVocabulary).mockResolvedValueOnce({
       data: { words: [] },
     } as never);
@@ -156,18 +156,17 @@ describe(generateVocabularyContentStep, () => {
     });
 
     const [activity] = await fetchLessonActivities(lesson.id);
-    const result = await generateVocabularyContentStep(activity!, "workflow-3");
-
-    expect(result).toEqual({ words: [] });
+    await expect(generateVocabularyContentStep(activity!, "workflow-3")).rejects.toThrow(
+      "contentValidationFailed",
+    );
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({
-        reason: "contentValidationFailed",
         status: "error",
         step: "generateVocabularyContent",
       }),

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-content-step.ts
@@ -6,7 +6,6 @@ import {
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { safeAsync } from "@zoonk/utils/error";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Generates vocabulary words via AI for a single vocabulary activity.
@@ -39,16 +38,11 @@ export async function generateVocabularyContentStep(
   );
 
   if (error || !result) {
-    const reason = error ? "aiGenerationFailed" : "aiEmptyResult";
-    await stream.error({ reason, step: "generateVocabularyContent" });
-    await handleActivityFailureStep({ activityId: activity.id });
-    return { words: [] };
+    throw error ?? new Error("aiEmptyResult");
   }
 
   if (result.data.words.length === 0) {
-    await stream.error({ reason: "contentValidationFailed", step: "generateVocabularyContent" });
-    await handleActivityFailureStep({ activityId: activity.id });
-    return { words: [] };
+    throw new Error("contentValidationFailed");
   }
 
   await stream.status({ status: "completed", step: "generateVocabularyContent" });

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-distractors-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-distractors-step.test.ts
@@ -120,7 +120,7 @@ describe(generateVocabularyDistractorsStep, () => {
     expect(generateActivityDistractors).not.toHaveBeenCalled();
   });
 
-  test("returns empty distractors for a word when AI fails", async () => {
+  test("throws when distractor AI fails", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       kind: "language",
@@ -152,10 +152,7 @@ describe(generateVocabularyDistractorsStep, () => {
       })
       .mockRejectedValueOnce(new Error("AI failed"));
 
-    const result = await generateVocabularyDistractorsStep(activities, words);
-
-    expect(result.distractors[`hola-${id}`]).toEqual([`not-hola-${id}`, `fake-hola-${id}`]);
-    expect(result.distractors[`adiós-${id}`]).toEqual([]);
+    await expect(generateVocabularyDistractorsStep(activities, words)).rejects.toThrow("AI failed");
   });
 
   test("returns empty distractors when words array is empty", async () => {

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-pronunciation-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-pronunciation-step.test.ts
@@ -166,7 +166,7 @@ describe(generateVocabularyPronunciationStep, () => {
     expect(result).toEqual({ pronunciations: {} });
   });
 
-  test("skips words when pronunciation AI fails and returns partial results", async () => {
+  test("throws when pronunciation AI fails", async () => {
     const course = await courseFixture({ organizationId, targetLanguage: "es" });
 
     const chapter = await chapterFixture({
@@ -202,10 +202,9 @@ describe(generateVocabularyPronunciationStep, () => {
       })
       .mockRejectedValueOnce(new Error("AI failed"));
 
-    const result = await generateVocabularyPronunciationStep(activities, words);
-
-    expect(result.pronunciations[`bueno-${id}`]).toBe(`pron-bueno-${id}`);
-    expect(result.pronunciations[`malo-${id}`]).toBeUndefined();
+    await expect(generateVocabularyPronunciationStep(activities, words)).rejects.toThrow(
+      "AI failed",
+    );
   });
 
   test("returns empty pronunciations when words array is empty", async () => {

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-romanization-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-romanization-step.test.ts
@@ -155,7 +155,7 @@ describe(generateVocabularyRomanizationStep, () => {
     expect(generateActivityRomanization).not.toHaveBeenCalled();
   });
 
-  test("marks activity as failed and streams error when AI romanization fails", async () => {
+  test("throws AI errors without streaming an error status", async () => {
     vi.mocked(generateActivityRomanization).mockRejectedValueOnce(new Error("AI error"));
 
     const course = await courseFixture({ organizationId, targetLanguage: "ja" });
@@ -183,21 +183,21 @@ describe(generateVocabularyRomanizationStep, () => {
     });
 
     const activities = await fetchLessonActivities(lesson.id);
-    const result = await generateVocabularyRomanizationStep(activities, ["猫"]);
-
-    expect(result).toEqual({ romanizations: {} });
+    await expect(generateVocabularyRomanizationStep(activities, ["猫"])).rejects.toThrow(
+      "AI error",
+    );
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateVocabularyRomanization" }),
     );
   });
 
-  test("marks activity as failed and streams error when some romanizations are missing", async () => {
+  test("throws when some romanizations are missing", async () => {
     vi.mocked(generateActivityRomanization).mockResolvedValueOnce({
       data: { romanizations: ["neko"] },
     } as never);
@@ -227,16 +227,16 @@ describe(generateVocabularyRomanizationStep, () => {
     });
 
     const activities = await fetchLessonActivities(lesson.id);
-    const result = await generateVocabularyRomanizationStep(activities, ["猫", "犬"]);
-
-    expect(result.romanizations["猫"]).toBe("neko");
+    await expect(generateVocabularyRomanizationStep(activities, ["猫", "犬"])).rejects.toThrow(
+      "romanizationFailed",
+    );
 
     const updated = await prisma.activity.findUniqueOrThrow({ where: { id: dbActivity.id } });
-    expect(updated.generationStatus).toBe("failed");
+    expect(updated.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateVocabularyRomanization" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-romanization-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-vocabulary-romanization-step.ts
@@ -4,7 +4,6 @@ import { needsRomanization } from "@zoonk/utils/languages";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { generateActivityRomanizations } from "./_utils/generate-activity-romanizations";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Generates romanized (Latin-script) representations of vocabulary words
@@ -36,16 +35,8 @@ export async function generateVocabularyRomanizationStep(
 
   const romanizations = await generateActivityRomanizations({ targetLanguage, texts: words });
 
-  if (!romanizations) {
-    await stream.error({ reason: "romanizationFailed", step: "generateVocabularyRomanization" });
-    await handleActivityFailureStep({ activityId: activity.id });
-    return { romanizations: {} };
-  }
-
   if (Object.keys(romanizations).length < words.length) {
-    await stream.error({ reason: "romanizationFailed", step: "generateVocabularyRomanization" });
-    await handleActivityFailureStep({ activityId: activity.id });
-    return { romanizations };
+    throw new Error("romanizationFailed");
   }
 
   await stream.status({ status: "completed", step: "generateVocabularyRomanization" });

--- a/apps/api/src/workflows/activity-generation/steps/get-lesson-activities-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/get-lesson-activities-step.test.ts
@@ -107,7 +107,7 @@ describe(getLessonActivitiesStep, () => {
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "getLessonActivities" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/get-lesson-activities-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/get-lesson-activities-step.ts
@@ -37,12 +37,10 @@ export async function getLessonActivitiesStep(input: {
   const { data: activities, error } = await safeAsync(fetchActivities);
 
   if (error) {
-    await stream.error({ reason: "dbFetchFailed", step: "getLessonActivities" });
     throw error;
   }
 
   if (activities.length === 0) {
-    await stream.error({ reason: "noSourceData", step: "getLessonActivities" });
     throw new FatalError("No activities found for lesson");
   }
 

--- a/apps/api/src/workflows/activity-generation/steps/get-neighboring-concepts-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/get-neighboring-concepts-step.ts
@@ -43,8 +43,7 @@ export async function getNeighboringConceptsStep(activities: LessonActivity[]): 
   );
 
   if (error) {
-    await stream.error({ reason: "dbFetchFailed", step: "getNeighboringConcepts" });
-    return [];
+    throw error;
   }
 
   await stream.status({ status: "completed", step: "getNeighboringConcepts" });

--- a/apps/api/src/workflows/activity-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/handle-failure-step.ts
@@ -1,16 +1,43 @@
+import { createEntityStepStream } from "@/workflows/_shared/stream-status";
+import { type WorkflowErrorLog } from "@/workflows/_shared/workflow-error";
+import { type ActivityStepName, type WorkflowErrorReason } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { logError } from "@zoonk/utils/logger";
 
-export async function handleActivityFailureStep(input: { activityId: string }): Promise<void> {
+/**
+ * Records a permanent activity-generation failure after workflow retries are
+ * exhausted. Generation steps should throw and let Workflow retry them; callers
+ * use this step only from final catch blocks so the DB state and SSE error event
+ * represent a real terminal failure, not a transient attempt.
+ */
+export async function handleActivityFailureStep(input: {
+  activityId: string;
+  error?: WorkflowErrorLog;
+  reason?: WorkflowErrorReason;
+}): Promise<void> {
   "use step";
 
-  logError("[Activity Failure]", `activityId: ${input.activityId}`);
+  logError("[Activity Failure]", {
+    activityId: input.activityId,
+    error: input.error,
+  });
 
-  await safeAsync(() =>
+  const { error } = await safeAsync(() =>
     prisma.activity.update({
       data: { generationStatus: "failed" },
       where: { id: input.activityId },
     }),
   );
+
+  if (error) {
+    logError("[Activity Failure Status Update Failed]", error);
+    throw error;
+  }
+
+  await using stream = createEntityStepStream<ActivityStepName>(input.activityId);
+  await stream.error({
+    reason: input.reason ?? "aiGenerationFailed",
+    step: "workflowError",
+  });
 }

--- a/apps/api/src/workflows/activity-generation/steps/handle-workflow-failure-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/handle-workflow-failure-step.ts
@@ -1,7 +1,9 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
+import { type WorkflowErrorLog } from "@/workflows/_shared/workflow-error";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
+import { logError } from "@zoonk/utils/logger";
 
 /**
  * Marks published activities left in "running" state by initial generation as
@@ -12,10 +14,18 @@ import { safeAsync } from "@zoonk/utils/error";
  * that temporary replacement set on failure instead of keeping failed rows
  * around.
  */
-export async function handleWorkflowFailureStep(input: { lessonId: string }): Promise<void> {
+export async function handleWorkflowFailureStep(input: {
+  error?: WorkflowErrorLog;
+  lessonId: string;
+}): Promise<void> {
   "use step";
 
-  await safeAsync(() =>
+  logError("[Activity Workflow Failure]", {
+    error: input.error,
+    lessonId: input.lessonId,
+  });
+
+  const { error } = await safeAsync(() =>
     prisma.activity.updateMany({
       data: { generationStatus: "failed" },
       where: {
@@ -26,6 +36,11 @@ export async function handleWorkflowFailureStep(input: { lessonId: string }): Pr
       },
     }),
   );
+
+  if (error) {
+    logError("[Activity Workflow Failure Status Update Failed]", error);
+    throw error;
+  }
 
   await using stream = createStepStream<ActivityStepName>();
   await stream.error({ reason: "aiGenerationFailed", step: "workflowError" });

--- a/apps/api/src/workflows/activity-generation/steps/mark-all-activities-as-running-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/mark-all-activities-as-running-step.test.ts
@@ -165,7 +165,7 @@ describe(markAllActivitiesAsRunningStep, () => {
     ).resolves.toBeUndefined();
   });
 
-  test("streams error and throws when DB transaction fails", async () => {
+  test("throws without streaming an error status when DB transaction fails", async () => {
     const lesson = await lessonFixture({
       chapterId,
       kind: "language",
@@ -193,7 +193,7 @@ describe(markAllActivitiesAsRunningStep, () => {
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "setActivityAsRunning" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/mark-all-activities-as-running-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/mark-all-activities-as-running-step.ts
@@ -59,7 +59,6 @@ export async function markAllActivitiesAsRunningStep({
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "setActivityAsRunning" });
     throw error;
   }
 

--- a/apps/api/src/workflows/activity-generation/steps/save-custom-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-custom-activity-step.test.ts
@@ -127,19 +127,21 @@ describe(saveCustomActivityStep, () => {
     );
   });
 
-  test("streams error when DB transaction fails", async () => {
+  test("throws DB errors without streaming an error status", async () => {
     const invalidActivityId = randomUUID();
 
-    await saveCustomActivityStep({
-      activityId: invalidActivityId,
-      contentSteps: [{ text: "Step text", title: "Step title" }],
-      images: [{ prompt: "A step image", url: "https://example.com/image.webp" }],
-      workflowRunId: "workflow-error",
-    });
+    await expect(
+      saveCustomActivityStep({
+        activityId: invalidActivityId,
+        contentSteps: [{ text: "Step text", title: "Step title" }],
+        images: [{ prompt: "A step image", url: "https://example.com/image.webp" }],
+        workflowRunId: "workflow-error",
+      }),
+    ).rejects.toThrow();
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "saveCustomActivity" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/save-custom-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-custom-activity-step.ts
@@ -5,7 +5,6 @@ import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { buildStaticStepRecords } from "./_utils/build-static-step-records";
 import { type ActivitySteps } from "./_utils/get-activity-steps";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Persists all generated data for a single custom activity in one batch:
@@ -36,9 +35,7 @@ export async function saveCustomActivityStep({
   );
 
   if (buildError || !stepRecords) {
-    await stream.error({ reason: "dbSaveFailed", step: "saveCustomActivity" });
-    await handleActivityFailureStep({ activityId });
-    return;
+    throw buildError ?? new Error("Failed to build custom step records");
   }
 
   const { error } = await safeAsync(() =>
@@ -52,9 +49,7 @@ export async function saveCustomActivityStep({
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "saveCustomActivity" });
-    await handleActivityFailureStep({ activityId });
-    return;
+    throw error;
   }
 
   await stream.status({ status: "completed", step: "saveCustomActivity" });

--- a/apps/api/src/workflows/activity-generation/steps/save-explanation-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-explanation-activity-step.test.ts
@@ -148,19 +148,21 @@ describe(saveExplanationActivityStep, () => {
     );
   });
 
-  test("streams error when DB transaction fails", async () => {
+  test("throws DB errors without streaming an error status", async () => {
     const invalidActivityId = randomUUID();
 
-    await saveExplanationActivityStep({
-      activityId: invalidActivityId,
-      images: [{ prompt: "A step image", url: "https://example.com/image.webp" }],
-      steps: [{ text: "some text", title: "Title" }],
-      workflowRunId: "workflow-2",
-    });
+    await expect(
+      saveExplanationActivityStep({
+        activityId: invalidActivityId,
+        images: [{ prompt: "A step image", url: "https://example.com/image.webp" }],
+        steps: [{ text: "some text", title: "Title" }],
+        workflowRunId: "workflow-2",
+      }),
+    ).rejects.toThrow();
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({
         status: "error",
         step: "saveExplanationActivity",

--- a/apps/api/src/workflows/activity-generation/steps/save-explanation-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-explanation-activity-step.ts
@@ -5,7 +5,6 @@ import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { buildStaticStepRecords } from "./_utils/build-static-step-records";
 import { type ActivitySteps } from "./_utils/get-activity-steps";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Persists explanation activity steps and their embedded images in one
@@ -35,9 +34,7 @@ export async function saveExplanationActivityStep({
   );
 
   if (buildError || !stepRecords) {
-    await stream.error({ reason: "dbSaveFailed", step: "saveExplanationActivity" });
-    await handleActivityFailureStep({ activityId });
-    return;
+    throw buildError ?? new Error("Failed to build explanation step records");
   }
 
   const { error } = await safeAsync(() =>
@@ -51,9 +48,7 @@ export async function saveExplanationActivityStep({
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "saveExplanationActivity" });
-    await handleActivityFailureStep({ activityId });
-    return;
+    throw error;
   }
 
   await stream.status({ status: "completed", step: "saveExplanationActivity" });

--- a/apps/api/src/workflows/activity-generation/steps/save-grammar-steps-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-grammar-steps-step.test.ts
@@ -189,7 +189,7 @@ describe(saveGrammarActivityStep, () => {
     expect(steps).toHaveLength(0);
   });
 
-  test("streams error when DB transaction fails", async () => {
+  test("throws DB errors without streaming an error status", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       kind: "language",
@@ -211,35 +211,37 @@ describe(saveGrammarActivityStep, () => {
     // Delete the activity so the prisma.activity.update inside the transaction fails
     await prisma.activity.delete({ where: { id: grammarActivity.id } });
 
-    await saveGrammarActivityStep(
-      activities,
-      "workflow-grammar-error",
-      {
-        examples: [{ highlight: "ist", sentence: "Das ist gut" }],
-        exercises: [{ answer: "ist", distractors: ["war", "hat"], template: "Das [BLANK] gut" }],
-      },
-      {
-        discovery: {
-          context: "Look at the example",
-          options: [
-            { feedback: "Correct!", isCorrect: true, text: "ist" },
-            { feedback: "Not quite", isCorrect: false, text: "war" },
-          ],
-          question: "What verb fits?",
+    await expect(
+      saveGrammarActivityStep(
+        activities,
+        "workflow-grammar-error",
+        {
+          examples: [{ highlight: "ist", sentence: "Das ist gut" }],
+          exercises: [{ answer: "ist", distractors: ["war", "hat"], template: "Das [BLANK] gut" }],
         },
-        exampleTranslations: ["That is good"],
-        exerciseFeedback: ["Because ist fits here"],
-        exerciseQuestions: ["Fill in the blank"],
-        exerciseTranslations: ["That is good"],
-        ruleName: "Present tense",
-        ruleSummary: "The verb ist is used for present tense",
-      },
-      null,
-    );
+        {
+          discovery: {
+            context: "Look at the example",
+            options: [
+              { feedback: "Correct!", isCorrect: true, text: "ist" },
+              { feedback: "Not quite", isCorrect: false, text: "war" },
+            ],
+            question: "What verb fits?",
+          },
+          exampleTranslations: ["That is good"],
+          exerciseFeedback: ["Because ist fits here"],
+          exerciseQuestions: ["Fill in the blank"],
+          exerciseTranslations: ["That is good"],
+          ruleName: "Present tense",
+          ruleSummary: "The verb ist is used for present tense",
+        },
+        null,
+      ),
+    ).rejects.toThrow();
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "saveGrammarActivity" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/save-grammar-steps-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-grammar-steps-step.ts
@@ -7,7 +7,6 @@ import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 function nullableNonEmpty(value?: string | null): string | null {
   if (!value || value.trim().length === 0) {
@@ -154,9 +153,7 @@ export async function saveGrammarActivityStep(
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "saveGrammarActivity" });
-    await handleActivityFailureStep({ activityId: activity.id });
-    return;
+    throw error;
   }
 
   await stream.status({ status: "completed", step: "saveGrammarActivity" });

--- a/apps/api/src/workflows/activity-generation/steps/save-investigation-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-investigation-activity-step.test.ts
@@ -202,7 +202,7 @@ describe(saveInvestigationActivityStep, () => {
     expect(dbActivity.title).toBe(mockScenario.title);
   });
 
-  test("streams error when DB transaction fails", async () => {
+  test("throws DB errors without streaming an error status", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -221,19 +221,21 @@ describe(saveInvestigationActivityStep, () => {
     // Delete the activity so the prisma.activity.update inside the transaction fails
     await prisma.activity.delete({ where: { id: activity.id } });
 
-    await saveInvestigationActivityStep({
-      accuracy: mockAccuracy,
-      actions: mockActions,
-      activityId: activity.id,
-      findings: mockFindings,
-      scenario: mockScenario,
-      title: mockScenario.title,
-      workflowRunId: "workflow-error",
-    });
+    await expect(
+      saveInvestigationActivityStep({
+        accuracy: mockAccuracy,
+        actions: mockActions,
+        activityId: activity.id,
+        findings: mockFindings,
+        scenario: mockScenario,
+        title: mockScenario.title,
+        workflowRunId: "workflow-error",
+      }),
+    ).rejects.toThrow();
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "saveInvestigationActivity" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/save-investigation-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-investigation-activity-step.ts
@@ -8,7 +8,6 @@ import { assertStepContent } from "@zoonk/core/steps/contract/content";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Zips scenario explanations with accuracy tiers and feedback
@@ -144,9 +143,7 @@ export async function saveInvestigationActivityStep({
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "saveInvestigationActivity" });
-    await handleActivityFailureStep({ activityId });
-    return;
+    throw error;
   }
 
   await stream.status({ status: "completed", step: "saveInvestigationActivity" });

--- a/apps/api/src/workflows/activity-generation/steps/save-listening-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-listening-activity-step.test.ts
@@ -146,7 +146,7 @@ describe(saveListeningActivityStep, () => {
     );
   });
 
-  test("marks listening as failed when reading activity has no steps", async () => {
+  test("throws when reading activity has no steps", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       kind: "language",
@@ -177,7 +177,9 @@ describe(saveListeningActivityStep, () => {
 
     const activities = await fetchLessonActivities(lesson.id);
 
-    await saveListeningActivityStep(activities, "workflow-listening-2");
+    await expect(saveListeningActivityStep(activities, "workflow-listening-2")).rejects.toThrow(
+      "noSourceData",
+    );
 
     const listeningActivity = activities.find((act) => act.kind === "listening")!;
 
@@ -191,11 +193,11 @@ describe(saveListeningActivityStep, () => {
     ]);
 
     expect(steps).toHaveLength(0);
-    expect(dbActivity.generationStatus).toBe("failed");
+    expect(dbActivity.generationStatus).toBe("pending");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "saveListeningActivity" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/save-listening-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-listening-activity-step.ts
@@ -5,7 +5,6 @@ import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Checks if the reading source data is available and valid for copying.
@@ -46,13 +45,12 @@ async function fetchReadingSourceSteps(
  * Creates listening steps from reading steps and marks the activity as completed
  * in a single transaction. This ensures steps and completion status are always
  * in sync — if either fails, both are rolled back.
- * Returns true on success, false on failure.
  */
 async function createListeningStepsAndComplete(params: {
   listeningId: string;
   readingSteps: { position: number; sentenceId: string | null }[];
   workflowRunId: string;
-}): Promise<boolean> {
+}): Promise<void> {
   const { error } = await safeAsync(() =>
     prisma.$transaction([
       prisma.step.createMany({
@@ -72,7 +70,9 @@ async function createListeningStepsAndComplete(params: {
     ]),
   );
 
-  return !error;
+  if (error) {
+    throw error;
+  }
 }
 
 /**
@@ -109,24 +109,16 @@ export async function saveListeningActivityStep(
   const readingSteps = await fetchReadingSourceSteps(activities);
 
   if (!readingSteps) {
-    await stream.error({ reason: "noSourceData", step: "saveListeningActivity" });
-    await handleActivityFailureStep({ activityId: listening.id });
-    return;
+    throw new Error("noSourceData");
   }
 
   await stream.status({ status: "started", step: "saveListeningActivity" });
 
-  const success = await createListeningStepsAndComplete({
+  await createListeningStepsAndComplete({
     listeningId: listening.id,
     readingSteps,
     workflowRunId,
   });
-
-  if (!success) {
-    await stream.error({ reason: "dbSaveFailed", step: "saveListeningActivity" });
-    await handleActivityFailureStep({ activityId: listening.id });
-    return;
-  }
 
   await stream.status({ status: "completed", step: "saveListeningActivity" });
 }

--- a/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.test.ts
@@ -184,7 +184,7 @@ describe(savePracticeActivityStep, () => {
     );
   });
 
-  test("streams error when DB transaction fails", async () => {
+  test("throws DB errors without streaming an error status", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -217,18 +217,20 @@ describe(savePracticeActivityStep, () => {
       },
     ];
 
-    await savePracticeActivityStep({
-      activityId: activity.id,
-      images: practiceImages.slice(0, 2),
-      scenario: practiceScenario,
-      steps,
-      title: "The game store signup mix-up",
-      workflowRunId: "workflow-error",
-    });
+    await expect(
+      savePracticeActivityStep({
+        activityId: activity.id,
+        images: practiceImages.slice(0, 2),
+        scenario: practiceScenario,
+        steps,
+        title: "The game store signup mix-up",
+        workflowRunId: "workflow-error",
+      }),
+    ).rejects.toThrow();
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "savePracticeActivity" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.ts
@@ -5,7 +5,6 @@ import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { type PracticeScenario, type PracticeStep } from "./generate-practice-content-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Practice now saves one image for the opening scenario plus one image for
@@ -167,9 +166,7 @@ export async function savePracticeActivityStep({
   );
 
   if (buildError || !stepRecords) {
-    await stream.error({ reason: "dbSaveFailed", step: "savePracticeActivity" });
-    await handleActivityFailureStep({ activityId });
-    return;
+    throw buildError ?? new Error("Failed to build practice step records");
   }
 
   const { error } = await safeAsync(() =>
@@ -183,9 +180,7 @@ export async function savePracticeActivityStep({
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "savePracticeActivity" });
-    await handleActivityFailureStep({ activityId });
-    return;
+    throw error;
   }
 
   await stream.status({ status: "completed", step: "savePracticeActivity" });

--- a/apps/api/src/workflows/activity-generation/steps/save-quiz-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-quiz-activity-step.test.ts
@@ -121,7 +121,7 @@ describe(saveQuizActivityStep, () => {
     );
   });
 
-  test("streams error when DB transaction fails", async () => {
+  test("throws DB errors without streaming an error status", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -152,15 +152,17 @@ describe(saveQuizActivityStep, () => {
       },
     ];
 
-    await saveQuizActivityStep({
-      activityId: activity.id,
-      questions,
-      workflowRunId: "workflow-error",
-    });
+    await expect(
+      saveQuizActivityStep({
+        activityId: activity.id,
+        questions,
+        workflowRunId: "workflow-error",
+      }),
+    ).rejects.toThrow();
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "saveQuizActivity" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/save-quiz-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-quiz-activity-step.ts
@@ -5,7 +5,6 @@ import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { type QuizQuestionWithUrls } from "./generate-quiz-images-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Builds step records from quiz questions.
@@ -69,9 +68,7 @@ export async function saveQuizActivityStep({
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "saveQuizActivity" });
-    await handleActivityFailureStep({ activityId });
-    return;
+    throw error;
   }
 
   await stream.status({ status: "completed", step: "saveQuizActivity" });

--- a/apps/api/src/workflows/activity-generation/steps/save-reading-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-reading-activity-step.ts
@@ -9,7 +9,6 @@ import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type WordMetadataEntry, saveReadingTargetWords } from "./_utils/save-reading-target-words";
 import { type ReadingSentence } from "./generate-reading-content-step";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Persists canonical reading sentences, their direct distractor arrays, and the
@@ -49,14 +48,18 @@ export async function saveReadingActivityStep(params: {
 
   const activity = findActivityByKind(activities, "reading");
 
-  if (!activity || sentences.length === 0) {
+  if (!activity) {
     return;
+  }
+
+  if (sentences.length === 0) {
+    throw new Error("Reading save step received no sentences");
   }
 
   const course = activity.lesson.chapter.course;
 
   if (!course.organization) {
-    return;
+    throw new Error("Reading save step needs course organization data");
   }
 
   await using stream = createEntityStepStream<ActivityStepName>(activity.id);
@@ -88,9 +91,7 @@ export async function saveReadingActivityStep(params: {
   );
 
   if (sentenceError) {
-    await stream.error({ reason: "dbSaveFailed", step: "saveReadingActivity" });
-    await handleActivityFailureStep({ activityId: activity.id });
-    return;
+    throw sentenceError;
   }
 
   const { error: wordError } = await safeAsync(() =>
@@ -108,9 +109,7 @@ export async function saveReadingActivityStep(params: {
   );
 
   if (wordError) {
-    await stream.error({ reason: "dbSaveFailed", step: "saveReadingActivity" });
-    await handleActivityFailureStep({ activityId: activity.id });
-    return;
+    throw wordError;
   }
 
   await markActivityAsCompleted(activity.id, workflowRunId);

--- a/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.test.ts
@@ -276,7 +276,7 @@ describe(saveStoryActivityStep, () => {
     );
   });
 
-  test("streams error and marks failed when DB transaction fails", async () => {
+  test("throws DB errors without streaming an error status", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       organizationId,
@@ -295,16 +295,18 @@ describe(saveStoryActivityStep, () => {
     // Delete the activity so the prisma.activity.update inside the transaction fails
     await prisma.activity.delete({ where: { id: activity.id } });
 
-    await saveStoryActivityStep({
-      activityId: activity.id,
-      storyData,
-      storyImages,
-      workflowRunId: "workflow-error",
-    });
+    await expect(
+      saveStoryActivityStep({
+        activityId: activity.id,
+        storyData,
+        storyImages,
+        workflowRunId: "workflow-error",
+      }),
+    ).rejects.toThrow();
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "saveStoryActivity" }),
     );
   });

--- a/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.ts
@@ -8,7 +8,6 @@ import { prisma } from "@zoonk/db";
 import { type StoryOutcomeTier } from "@zoonk/utils/activities";
 import { safeAsync } from "@zoonk/utils/error";
 import { type GeneratedStoryImages } from "./generate-story-images-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * The AI only owns learner-facing story content. Runtime identity is assigned
@@ -207,9 +206,7 @@ export async function saveStoryActivityStep({
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "saveStoryActivity" });
-    await handleActivityFailureStep({ activityId });
-    return;
+    throw error;
   }
 
   await stream.status({ status: "completed", step: "saveStoryActivity" });

--- a/apps/api/src/workflows/activity-generation/steps/save-translation-from-existing-vocabulary-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-translation-from-existing-vocabulary-step.test.ts
@@ -122,7 +122,7 @@ describe(saveTranslationFromExistingVocabularyStep, () => {
     });
   });
 
-  test("marks translation as failed when vocabulary steps do not exist", async () => {
+  test("throws when vocabulary steps do not exist", async () => {
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       kind: "language",
@@ -153,15 +153,17 @@ describe(saveTranslationFromExistingVocabularyStep, () => {
 
     const activities = await fetchLessonActivities(lesson.id);
 
-    await saveTranslationFromExistingVocabularyStep({
-      allActivities: activities,
-      workflowRunId: "workflow-2",
-    });
+    await expect(
+      saveTranslationFromExistingVocabularyStep({
+        allActivities: activities,
+        workflowRunId: "workflow-2",
+      }),
+    ).rejects.toThrow("noSourceData");
 
     const dbActivity = await prisma.activity.findUniqueOrThrow({
       where: { id: translationActivity.id },
     });
 
-    expect(dbActivity.generationStatus).toBe("failed");
+    expect(dbActivity.generationStatus).toBe("pending");
   });
 });

--- a/apps/api/src/workflows/activity-generation/steps/save-translation-from-existing-vocabulary-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-translation-from-existing-vocabulary-step.ts
@@ -5,7 +5,6 @@ import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Creates translation steps from an already-completed vocabulary activity.
@@ -32,8 +31,12 @@ export async function saveTranslationFromExistingVocabularyStep({
   const vocabularyActivity = findActivityByKind(allActivities, "vocabulary");
   const translationActivity = findActivityByKind(allActivities, "translation");
 
-  if (!vocabularyActivity || !translationActivity) {
+  if (!translationActivity) {
     return;
+  }
+
+  if (!vocabularyActivity) {
+    throw new Error("Translation save step needs a completed vocabulary activity");
   }
 
   await using stream = createEntityStepStream<ActivityStepName>(translationActivity.id);
@@ -46,9 +49,7 @@ export async function saveTranslationFromExistingVocabularyStep({
   });
 
   if (vocabularySteps.length === 0) {
-    await stream.error({ reason: "noSourceData", step: "saveVocabularyActivity" });
-    await handleActivityFailureStep({ activityId: translationActivity.id });
-    return;
+    throw new Error("noSourceData");
   }
 
   const translationStepData = vocabularySteps.map((step) => ({
@@ -71,9 +72,7 @@ export async function saveTranslationFromExistingVocabularyStep({
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "saveVocabularyActivity" });
-    await handleActivityFailureStep({ activityId: translationActivity.id });
-    return;
+    throw error;
   }
 
   await stream.status({ status: "completed", step: "saveVocabularyActivity" });

--- a/apps/api/src/workflows/activity-generation/steps/save-vocabulary-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-vocabulary-activity-step.ts
@@ -10,7 +10,6 @@ import { fetchExistingWordCasing } from "./_utils/fetch-existing-word-casing";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { upsertWordWithPronunciation } from "./_utils/upsert-word-with-pronunciation";
 import { type LessonActivity } from "./get-lesson-activities-step";
-import { handleActivityFailureStep } from "./handle-failure-step";
 
 /**
  * Persists canonical vocabulary words, their direct distractors, and the vocabulary plus
@@ -43,14 +42,18 @@ export async function saveVocabularyActivityStep(params: {
 
   const vocabularyActivity = findActivityByKind(activities, "vocabulary");
 
-  if (!vocabularyActivity || words.length === 0) {
+  if (!vocabularyActivity) {
     return;
+  }
+
+  if (words.length === 0) {
+    throw new Error("Vocabulary save step received no words");
   }
 
   const course = vocabularyActivity.lesson.chapter.course;
 
   if (!course.organization) {
-    return;
+    throw new Error("Vocabulary save step needs course organization data");
   }
 
   await using stream = createStepStream<ActivityStepName>();
@@ -123,16 +126,7 @@ export async function saveVocabularyActivityStep(params: {
   });
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "saveVocabularyActivity" });
-
-    await Promise.all([
-      handleActivityFailureStep({ activityId: vocabularyActivity.id }),
-      translationActivity
-        ? handleActivityFailureStep({ activityId: translationActivity.id })
-        : null,
-    ]);
-
-    return;
+    throw error;
   }
 
   await markActivityAsCompleted(vocabularyActivity.id, workflowRunId);

--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
@@ -39,6 +39,12 @@ vi.mock("@zoonk/ai/tasks/lessons/kind", () => ({
   }),
 }));
 
+vi.mock("@zoonk/ai/tasks/lessons/applied-activity-kind", () => ({
+  generateAppliedActivityKind: vi.fn().mockResolvedValue({
+    data: { appliedActivityKind: "story" },
+  }),
+}));
+
 vi.mock("@/workflows/activity-generation/activity-generation-workflow", () => ({
   activityGenerationWorkflow: vi.fn().mockResolvedValue({}),
 }));

--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
@@ -236,7 +236,7 @@ describe(chapterGenerationWorkflow, () => {
       expect(dbChapter?.generationStatus).toBe("completed");
     });
 
-    test("marks chapter as 'failed' when AI generation throws and streams error", async () => {
+    test("marks chapter as 'failed' when AI generation throws after retries", async () => {
       vi.mocked(generateChapterLessons).mockRejectedValueOnce(new Error("AI generation failed"));
 
       const title = `Error Chapter ${randomUUID()}`;

--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.ts
@@ -1,4 +1,5 @@
 import { streamSkipStep } from "@/workflows/_shared/stream-skip-step";
+import { serializeWorkflowError } from "@/workflows/_shared/workflow-error";
 import { activityGenerationWorkflow } from "@/workflows/activity-generation/activity-generation-workflow";
 import { handleChapterFailureStep } from "@/workflows/course-generation/steps/handle-failure-step";
 import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
@@ -45,7 +46,11 @@ export async function chapterGenerationWorkflow(chapterId: string): Promise<void
 
   // Chapter-specific work with failure handling
   const createdLessons = await generateAndAddLessons(context).catch(async (error: unknown) => {
-    await handleChapterFailureStep({ chapterId });
+    await handleChapterFailureStep({
+      chapterId,
+      error: serializeWorkflowError(error),
+    });
+
     throw error;
   });
 

--- a/apps/api/src/workflows/chapter-generation/steps/add-lessons-step.test.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/add-lessons-step.test.ts
@@ -49,7 +49,7 @@ describe(addLessonsStep, () => {
     vi.clearAllMocks();
   });
 
-  test("streams error and throws when DB save fails", async () => {
+  test("throws without streaming error when DB save fails", async () => {
     const brokenContext: ChapterContext = {
       ...context,
       id: randomUUID(),
@@ -61,7 +61,9 @@ describe(addLessonsStep, () => {
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(expect.objectContaining({ status: "error", step: "addLessons" }));
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ status: "error", step: "addLessons" }),
+    );
   });
 
   test("creates lessons in the database and returns them", async () => {

--- a/apps/api/src/workflows/chapter-generation/steps/add-lessons-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/add-lessons-step.ts
@@ -42,7 +42,6 @@ export async function addLessonsStep(input: {
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "addLessons" });
     throw error;
   }
 

--- a/apps/api/src/workflows/chapter-generation/steps/generate-lessons-step.test.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/generate-lessons-step.test.ts
@@ -125,14 +125,14 @@ describe(generateLessonsStep, () => {
     });
   });
 
-  test("throws and streams error when AI generation fails", async () => {
+  test("throws without streaming error when AI generation fails", async () => {
     generateChapterLessonsMock.mockRejectedValue(new Error("AI failure"));
 
     await expect(generateLessonsStep(context)).rejects.toThrow("AI failure");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateLessons" }),
     );
   });

--- a/apps/api/src/workflows/chapter-generation/steps/generate-lessons-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/generate-lessons-step.ts
@@ -33,7 +33,6 @@ export async function generateLessonsStep(context: ChapterContext): Promise<Chap
   const { data: result, error } = await safeAsync(() => generateLessons(context));
 
   if (error) {
-    await stream.error({ reason: "aiGenerationFailed", step: "generateLessons" });
     throw error;
   }
 

--- a/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-completed-step.test.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-completed-step.test.ts
@@ -36,7 +36,7 @@ describe(setChapterAsCompletedStep, () => {
     vi.clearAllMocks();
   });
 
-  test("streams error and throws when chapter does not exist", async () => {
+  test("throws without streaming error when chapter does not exist", async () => {
     const chapter = await chapterFixture({
       courseId: course.id,
       organizationId,
@@ -57,7 +57,7 @@ describe(setChapterAsCompletedStep, () => {
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "setChapterAsCompleted" }),
     );
   });

--- a/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-completed-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-completed-step.ts
@@ -24,7 +24,6 @@ export async function setChapterAsCompletedStep(input: {
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "setChapterAsCompleted" });
     throw error;
   }
 

--- a/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-running-step.test.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-running-step.test.ts
@@ -36,14 +36,14 @@ describe(setChapterAsRunningStep, () => {
     vi.clearAllMocks();
   });
 
-  test("streams error and throws when chapter does not exist", async () => {
+  test("throws without streaming error when chapter does not exist", async () => {
     await expect(
       setChapterAsRunningStep({ chapterId: randomUUID(), workflowRunId: "run-id" }),
     ).rejects.toThrow();
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "setChapterAsRunning" }),
     );
   });

--- a/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-running-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-running-step.ts
@@ -23,7 +23,6 @@ export async function setChapterAsRunningStep(input: {
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "setChapterAsRunning" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/_internal/generate-missing-content.test.ts
+++ b/apps/api/src/workflows/course-generation/_internal/generate-missing-content.test.ts
@@ -142,7 +142,10 @@ describe(generateMissingContent, () => {
     generateCourseDescriptionMock.mockResolvedValue({
       data: { description: "Lang desc" },
     });
-    generateCourseImageMock.mockResolvedValue({ data: null, error: new Error("skip") });
+    generateCourseImageMock.mockResolvedValue({
+      data: "https://example.com/lang.webp",
+      error: null,
+    });
     generateAlternativeTitlesMock.mockResolvedValue({
       data: { alternatives: [] },
     });
@@ -160,7 +163,10 @@ describe(generateMissingContent, () => {
     generateCourseDescriptionMock.mockResolvedValue({
       data: { description: "desc" },
     });
-    generateCourseImageMock.mockResolvedValue({ data: null, error: new Error("skip") });
+    generateCourseImageMock.mockResolvedValue({
+      data: "https://example.com/non-lang.webp",
+      error: null,
+    });
     generateAlternativeTitlesMock.mockResolvedValue({
       data: { alternatives: [] },
     });

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -374,7 +374,7 @@ describe(courseGenerationWorkflow, () => {
   });
 
   describe("error handling", () => {
-    test("marks course and suggestion as 'failed' on error and streams error", async () => {
+    test("marks course and suggestion as 'failed' when generation fails after retries", async () => {
       vi.mocked(generateCourseDescription).mockRejectedValueOnce(new Error("AI generation failed"));
 
       const title = `Error Course ${randomUUID()}`;

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -102,6 +102,12 @@ vi.mock("@zoonk/ai/tasks/lessons/kind", () => ({
   }),
 }));
 
+vi.mock("@zoonk/ai/tasks/lessons/applied-activity-kind", () => ({
+  generateAppliedActivityKind: vi.fn().mockResolvedValue({
+    data: { appliedActivityKind: "story" },
+  }),
+}));
+
 vi.mock("@zoonk/ai/tasks/lessons/custom-activities", () => ({
   generateLessonCustomActivities: vi.fn().mockResolvedValue({
     data: { activities: [] },

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.ts
@@ -1,8 +1,9 @@
 import { streamSkipStep } from "@/workflows/_shared/stream-skip-step";
+import { serializeWorkflowError } from "@/workflows/_shared/workflow-error";
 import { chapterGenerationWorkflow } from "@/workflows/chapter-generation/chapter-generation-workflow";
 import { COURSE_COMPLETION_STEP } from "@zoonk/core/workflows/steps";
 import { logError } from "@zoonk/utils/logger";
-import { FatalError, getWorkflowMetadata } from "workflow";
+import { getWorkflowMetadata } from "workflow";
 import { getOrCreateCourse } from "./_internal/get-or-create-course";
 import { setupCourse } from "./_internal/setup-course";
 import { checkExistingCourseStep } from "./steps/check-existing-course-step";
@@ -49,11 +50,12 @@ export async function courseGenerationWorkflow(courseSuggestionId: string): Prom
     await handleCourseFailureStep({
       courseId: existingCourse?.id ?? null,
       courseSuggestionId,
+      error: serializeWorkflowError(error),
     });
 
     logError(`[workflow ${workflowRunId}] Course initialization failed`, error);
 
-    throw FatalError;
+    throw error;
   });
 
   const chapters = await setupCourse(course, courseSuggestionId, existing).catch(
@@ -61,11 +63,12 @@ export async function courseGenerationWorkflow(courseSuggestionId: string): Prom
       await handleCourseFailureStep({
         courseId: course.courseId,
         courseSuggestionId,
+        error: serializeWorkflowError(error),
       });
 
       logError(`[workflow ${workflowRunId}] Course generation failed`, error);
 
-      throw FatalError;
+      throw error;
     },
   );
 

--- a/apps/api/src/workflows/course-generation/steps/add-alternative-titles-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/add-alternative-titles-step.test.ts
@@ -33,7 +33,7 @@ describe(addAlternativeTitlesStep, () => {
     vi.clearAllMocks();
   });
 
-  test("streams error and throws when DB save fails", async () => {
+  test("throws without streaming error when DB save fails", async () => {
     const brokenContext: CourseContext = {
       courseId: randomUUID(),
       courseSlug: "broken",
@@ -52,7 +52,7 @@ describe(addAlternativeTitlesStep, () => {
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "addAlternativeTitles" }),
     );
   });

--- a/apps/api/src/workflows/course-generation/steps/add-alternative-titles-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/add-alternative-titles-step.ts
@@ -20,7 +20,6 @@ export async function addAlternativeTitlesStep(input: {
   });
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "addAlternativeTitles" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/add-categories-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/add-categories-step.ts
@@ -27,7 +27,6 @@ export async function addCategoriesStep(input: {
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "addCategories" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/add-chapters-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/add-chapters-step.test.ts
@@ -44,7 +44,7 @@ describe(addChaptersStep, () => {
     vi.clearAllMocks();
   });
 
-  test("streams error and throws when DB save fails", async () => {
+  test("throws without streaming error when DB save fails", async () => {
     const brokenContext: CourseContext = {
       ...courseContext,
       courseId: randomUUID(),
@@ -56,7 +56,7 @@ describe(addChaptersStep, () => {
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "addChapters" }),
     );
   });

--- a/apps/api/src/workflows/course-generation/steps/add-chapters-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/add-chapters-step.ts
@@ -39,7 +39,6 @@ export async function addChaptersStep(input: {
   );
 
   if (error || !createdChapters) {
-    await stream.error({ reason: "dbSaveFailed", step: "addChapters" });
     throw error ?? new Error("Failed to create chapters");
   }
 

--- a/apps/api/src/workflows/course-generation/steps/check-existing-course-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/check-existing-course-step.ts
@@ -58,7 +58,6 @@ export async function checkExistingCourseStep(
   );
 
   if (error) {
-    await stream.error({ reason: "dbFetchFailed", step: "checkExistingCourse" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.test.ts
@@ -33,17 +33,24 @@ describe(completeCourseSetupStep, () => {
     vi.clearAllMocks();
   });
 
-  test("streams error and throws when DB save fails", async () => {
-    await expect(
-      completeCourseSetupStep({
-        courseId: randomUUID(),
-        courseSuggestionId: randomUUID(),
-      }),
-    ).rejects.toThrow("DB save failed in completeCourseSetup");
+  test("throws all DB save failures without streaming error", async () => {
+    const promise = completeCourseSetupStep({
+      courseId: randomUUID(),
+      courseSuggestionId: randomUUID(),
+    });
+
+    await expect(promise).rejects.toThrow(AggregateError);
+
+    await promise.catch((error: unknown) => {
+      expect(error).toBeInstanceOf(AggregateError);
+      if (error instanceof AggregateError) {
+        expect(error.errors).toHaveLength(2);
+      }
+    });
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "completeCourseSetup" }),
     );
   });

--- a/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.ts
@@ -1,7 +1,7 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
-import { rejected } from "@zoonk/utils/settled";
+import { throwSettledFailures } from "@zoonk/utils/settled";
 
 export async function completeCourseSetupStep(input: {
   courseSuggestionId: string;
@@ -24,10 +24,7 @@ export async function completeCourseSetupStep(input: {
     }),
   ]);
 
-  if (rejected(results)) {
-    await stream.error({ reason: "dbSaveFailed", step: "completeCourseSetup" });
-    throw new Error("DB save failed in completeCourseSetup");
-  }
+  throwSettledFailures({ message: "Failed to complete course setup", results });
 
   await stream.status({ status: "completed", step: "completeCourseSetup" });
 }

--- a/apps/api/src/workflows/course-generation/steps/generate-alternative-titles-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-alternative-titles-step.test.ts
@@ -64,14 +64,14 @@ describe(generateAlternativeTitlesStep, () => {
     );
   });
 
-  test("throws and streams error when AI generation fails", async () => {
+  test("throws without streaming error when AI generation fails", async () => {
     generateAlternativeTitlesMock.mockRejectedValue(new Error("AI failure"));
 
     await expect(generateAlternativeTitlesStep(course)).rejects.toThrow("AI failure");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateAlternativeTitles" }),
     );
   });

--- a/apps/api/src/workflows/course-generation/steps/generate-alternative-titles-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-alternative-titles-step.ts
@@ -19,7 +19,6 @@ export async function generateAlternativeTitlesStep(course: CourseContext): Prom
   );
 
   if (error) {
-    await stream.error({ reason: "aiGenerationFailed", step: "generateAlternativeTitles" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/generate-categories-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-categories-step.test.ts
@@ -63,14 +63,14 @@ describe(generateCategoriesStep, () => {
     );
   });
 
-  test("throws and streams error when AI generation fails", async () => {
+  test("throws without streaming error when AI generation fails", async () => {
     generateCourseCategoriesMock.mockRejectedValue(new Error("AI failure"));
 
     await expect(generateCategoriesStep(course)).rejects.toThrow("AI failure");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateCategories" }),
     );
   });

--- a/apps/api/src/workflows/course-generation/steps/generate-categories-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-categories-step.ts
@@ -18,7 +18,6 @@ export async function generateCategoriesStep(course: CourseContext): Promise<str
   );
 
   if (error) {
-    await stream.error({ reason: "aiGenerationFailed", step: "generateCategories" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/generate-chapters-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-chapters-step.test.ts
@@ -92,14 +92,14 @@ describe(generateChaptersStep, () => {
     });
   });
 
-  test("throws and streams error when AI generation fails", async () => {
+  test("throws without streaming error when AI generation fails", async () => {
     generateCourseChaptersMock.mockRejectedValue(new Error("AI failure"));
 
     await expect(generateChaptersStep(baseCourse)).rejects.toThrow("AI failure");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateChapters" }),
     );
   });

--- a/apps/api/src/workflows/course-generation/steps/generate-chapters-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-chapters-step.ts
@@ -29,7 +29,6 @@ export async function generateChaptersStep(course: CourseContext): Promise<Cours
   const { data: result, error } = await safeAsync(() => generateChapters(course));
 
   if (error) {
-    await stream.error({ reason: "aiGenerationFailed", step: "generateChapters" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/generate-description-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-description-step.test.ts
@@ -64,14 +64,14 @@ describe(generateDescriptionStep, () => {
     );
   });
 
-  test("throws and streams error when AI generation fails", async () => {
+  test("throws without streaming error when AI generation fails", async () => {
     generateCourseDescriptionMock.mockRejectedValue(new Error("AI failure"));
 
     await expect(generateDescriptionStep(course)).rejects.toThrow("AI failure");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateDescription" }),
     );
   });

--- a/apps/api/src/workflows/course-generation/steps/generate-description-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-description-step.ts
@@ -19,7 +19,6 @@ export async function generateDescriptionStep(course: CourseContext): Promise<st
   );
 
   if (error) {
-    await stream.error({ reason: "aiGenerationFailed", step: "generateDescription" });
     throw error;
   }
 

--- a/apps/api/src/workflows/course-generation/steps/generate-image-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-image-step.test.ts
@@ -60,20 +60,18 @@ describe(generateImageStep, () => {
     );
   });
 
-  test("returns null when image generation fails (non-critical)", async () => {
+  test("throws without streaming error when image generation fails", async () => {
     generateCourseImageMock.mockResolvedValue({
       data: null,
       error: new Error("Image generation failed"),
     });
 
-    const result = await generateImageStep(course);
-
-    expect(result).toBeNull();
+    await expect(generateImageStep(course)).rejects.toThrow("Image generation failed");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
-      expect.objectContaining({ status: "completed", step: "generateImage" }),
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ status: "error", step: "generateImage" }),
     );
   });
 });

--- a/apps/api/src/workflows/course-generation/steps/generate-image-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-image-step.ts
@@ -15,9 +15,11 @@ export async function generateImageStep(course: CourseContext): Promise<string |
   });
 
   if (error) {
-    // Image generation failure is not critical, continue without image
-    await stream.status({ status: "completed", step: "generateImage" });
-    return null;
+    throw error;
+  }
+
+  if (!imageUrl) {
+    throw new Error("Course image generation returned no URL");
   }
 
   await stream.status({ status: "completed", step: "generateImage" });

--- a/apps/api/src/workflows/course-generation/steps/get-course-chapters-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/get-course-chapters-step.ts
@@ -20,7 +20,6 @@ export async function getCourseChaptersStep(courseId: string): Promise<Chapter[]
   );
 
   if (error || !chapters) {
-    await stream.error({ reason: "dbFetchFailed", step: "getExistingChapters" });
     throw error ?? new Error("Failed to fetch existing chapters");
   }
 

--- a/apps/api/src/workflows/course-generation/steps/handle-failure-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/handle-failure-step.test.ts
@@ -71,6 +71,22 @@ describe(handleCourseFailureStep, () => {
     );
   });
 
+  test("throws all status update failures", async () => {
+    const promise = handleCourseFailureStep({
+      courseId: randomUUID(),
+      courseSuggestionId: randomUUID(),
+    });
+
+    await expect(promise).rejects.toThrow(AggregateError);
+
+    await promise.catch((error: unknown) => {
+      expect(error).toBeInstanceOf(AggregateError);
+      if (error instanceof AggregateError) {
+        expect(error.errors).toHaveLength(2);
+      }
+    });
+  });
+
   test("marks only suggestion as failed when courseId is null", async () => {
     const suggestion = await courseSuggestionFixture({
       generationRunId: "old-run",

--- a/apps/api/src/workflows/course-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/handle-failure-step.ts
@@ -1,18 +1,34 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
+import { type WorkflowErrorLog, serializeWorkflowError } from "@/workflows/_shared/workflow-error";
 import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
+import { logError } from "@zoonk/utils/logger";
+import { getSettledFailureError, settledFailures } from "@zoonk/utils/settled";
 
+/**
+ * Marks a course-generation run as permanently failed after the workflow has
+ * stopped retrying the step that threw. The original error is logged here so
+ * Workflow can keep retryable steps clean while final failure diagnostics still
+ * show the provider or database error that caused the run to fail.
+ */
 export async function handleCourseFailureStep(input: {
   courseId: string | null;
   courseSuggestionId: string;
+  error?: WorkflowErrorLog;
 }): Promise<void> {
   "use step";
 
   const { courseId, courseSuggestionId } = input;
 
+  logError("[Course Workflow Failure]", {
+    courseId,
+    courseSuggestionId,
+    error: input.error,
+  });
+
   if (courseId) {
-    await Promise.allSettled([
+    const results = await Promise.allSettled([
       prisma.course.update({
         data: { generationRunId: null, generationStatus: "failed" },
         where: { id: courseId },
@@ -22,6 +38,21 @@ export async function handleCourseFailureStep(input: {
         where: { id: courseSuggestionId },
       }),
     ]);
+
+    const failures = settledFailures(results);
+
+    const failureError = getSettledFailureError({
+      failures,
+      message: "Failed to mark course workflow as failed",
+    });
+
+    if (failureError) {
+      logError("[Course Workflow Failure Status Update Failed]", {
+        errors: failures.map((failure) => serializeWorkflowError(failure)),
+      });
+
+      throw failureError;
+    }
   } else {
     await prisma.courseSuggestion.update({
       data: { generationRunId: null, generationStatus: "failed" },
@@ -33,15 +64,33 @@ export async function handleCourseFailureStep(input: {
   await stream.error({ reason: "aiGenerationFailed", step: "workflowError" });
 }
 
-export async function handleChapterFailureStep(input: { chapterId: string }): Promise<void> {
+/**
+ * Marks a chapter-generation run as permanently failed only after the
+ * chapter-level workflow catch receives the final error. Individual chapter
+ * steps should throw and let Workflow retry before this status is written.
+ */
+export async function handleChapterFailureStep(input: {
+  chapterId: string;
+  error?: WorkflowErrorLog;
+}): Promise<void> {
   "use step";
 
-  await safeAsync(() =>
+  logError("[Chapter Workflow Failure]", {
+    chapterId: input.chapterId,
+    error: input.error,
+  });
+
+  const { error } = await safeAsync(() =>
     prisma.chapter.update({
       data: { generationRunId: null, generationStatus: "failed" },
       where: { id: input.chapterId },
     }),
   );
+
+  if (error) {
+    logError("[Chapter Workflow Failure Status Update Failed]", error);
+    throw error;
+  }
 
   await using stream = createStepStream<CourseWorkflowStepName>();
   await stream.error({ reason: "aiGenerationFailed", step: "workflowError" });

--- a/apps/api/src/workflows/course-generation/steps/initialize-course-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/initialize-course-step.test.ts
@@ -29,7 +29,7 @@ describe(initializeCourseStep, () => {
     vi.clearAllMocks();
   });
 
-  test("streams error and throws when suggestion update fails", async () => {
+  test("throws without streaming error when suggestion update fails", async () => {
     const suggestion = await courseSuggestionFixture({
       title: `Missing Suggestion ${randomUUID()}`,
     });
@@ -47,7 +47,7 @@ describe(initializeCourseStep, () => {
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "initializeCourse" }),
     );
   });

--- a/apps/api/src/workflows/course-generation/steps/initialize-course-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/initialize-course-step.ts
@@ -1,5 +1,5 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
-import { type CourseWorkflowStepName, type WorkflowErrorReason } from "@zoonk/core/workflows/steps";
+import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
 import { type CourseSuggestion, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
@@ -20,13 +20,9 @@ export type CourseContext = {
  * This is a pure save step — one DB operation.
  */
 async function updateCourseSuggestionToRunning({
-  stream,
   suggestionId,
   workflowRunId,
 }: {
-  stream: {
-    error: (params: { reason: WorkflowErrorReason; step: CourseWorkflowStepName }) => Promise<void>;
-  };
   suggestionId: string;
   workflowRunId: string;
 }): Promise<{ error: Error | null }> {
@@ -40,10 +36,6 @@ async function updateCourseSuggestionToRunning({
     }),
   );
 
-  if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "initializeCourse" });
-  }
-
   return { error };
 }
 
@@ -53,14 +45,10 @@ async function updateCourseSuggestionToRunning({
  */
 async function createCourseEntity({
   organizationId,
-  stream,
   suggestion,
   workflowRunId,
 }: {
   organizationId: string;
-  stream: {
-    error: (params: { reason: WorkflowErrorReason; step: CourseWorkflowStepName }) => Promise<void>;
-  };
   suggestion: CourseSuggestion;
   workflowRunId: string;
 }): Promise<{ course: CourseContext | null; error: Error | null }> {
@@ -85,7 +73,6 @@ async function createCourseEntity({
   );
 
   if (error || !course) {
-    await stream.error({ reason: "dbSaveFailed", step: "initializeCourse" });
     return { course: null, error: error ?? new Error("Failed to create course") };
   }
 
@@ -129,12 +116,10 @@ export async function initializeCourseStep(input: {
   );
 
   if (orgError || !aiOrg) {
-    await stream.error({ reason: "dbFetchFailed", step: "initializeCourse" });
     throw orgError ?? new Error("AI organization not found");
   }
 
   const { error: suggestionError } = await updateCourseSuggestionToRunning({
-    stream,
     suggestionId: suggestion.id,
     workflowRunId,
   });
@@ -145,7 +130,6 @@ export async function initializeCourseStep(input: {
 
   const { course, error: createError } = await createCourseEntity({
     organizationId: aiOrg.id,
-    stream,
     suggestion,
     workflowRunId,
   });

--- a/apps/api/src/workflows/course-generation/steps/set-course-as-running-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/set-course-as-running-step.test.ts
@@ -33,18 +33,25 @@ describe(setCourseAsRunningStep, () => {
     vi.clearAllMocks();
   });
 
-  test("streams error and throws when DB save fails", async () => {
-    await expect(
-      setCourseAsRunningStep({
-        courseId: randomUUID(),
-        courseSuggestionId: randomUUID(),
-        workflowRunId: "run-id",
-      }),
-    ).rejects.toThrow("DB save failed in setCourseAsRunning");
+  test("throws all DB save failures without streaming error", async () => {
+    const promise = setCourseAsRunningStep({
+      courseId: randomUUID(),
+      courseSuggestionId: randomUUID(),
+      workflowRunId: "run-id",
+    });
+
+    await expect(promise).rejects.toThrow(AggregateError);
+
+    await promise.catch((error: unknown) => {
+      expect(error).toBeInstanceOf(AggregateError);
+      if (error instanceof AggregateError) {
+        expect(error.errors).toHaveLength(2);
+      }
+    });
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "setCourseAsRunning" }),
     );
   });

--- a/apps/api/src/workflows/course-generation/steps/set-course-as-running-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/set-course-as-running-step.ts
@@ -1,7 +1,7 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
-import { rejected } from "@zoonk/utils/settled";
+import { throwSettledFailures } from "@zoonk/utils/settled";
 
 export async function setCourseAsRunningStep(input: {
   courseId: string;
@@ -28,10 +28,7 @@ export async function setCourseAsRunningStep(input: {
     }),
   ]);
 
-  if (rejected(results)) {
-    await stream.error({ reason: "dbSaveFailed", step: "setCourseAsRunning" });
-    throw new Error("DB save failed in setCourseAsRunning");
-  }
+  throwSettledFailures({ message: "Failed to set course as running", results });
 
   await stream.status({ status: "completed", step: "setCourseAsRunning" });
 }

--- a/apps/api/src/workflows/course-generation/steps/update-course-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/update-course-step.test.ts
@@ -33,7 +33,7 @@ describe(updateCourseStep, () => {
     vi.clearAllMocks();
   });
 
-  test("streams error and throws when course does not exist", async () => {
+  test("throws without streaming error when course does not exist", async () => {
     const brokenContext: CourseContext = {
       courseId: randomUUID(),
       courseSlug: "broken",
@@ -53,7 +53,7 @@ describe(updateCourseStep, () => {
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "updateCourse" }),
     );
   });

--- a/apps/api/src/workflows/course-generation/steps/update-course-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/update-course-step.ts
@@ -27,7 +27,6 @@ export async function updateCourseStep(input: {
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "updateCourse" });
     throw error;
   }
 

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
@@ -187,7 +187,7 @@ describe(lessonGenerationWorkflow, () => {
   });
 
   describe("error handling", () => {
-    test("marks lesson as 'failed' when AI generation throws and streams error", async () => {
+    test("marks lesson as 'failed' when AI generation throws after retries", async () => {
       vi.mocked(generateLessonKind).mockRejectedValueOnce(new Error("AI generation failed"));
 
       const title = `Error Lesson ${randomUUID()}`;

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
@@ -1,4 +1,5 @@
 import { streamSkipStep } from "@/workflows/_shared/stream-skip-step";
+import { serializeWorkflowError } from "@/workflows/_shared/workflow-error";
 import { type LessonKind } from "@zoonk/db";
 import { getWorkflowMetadata } from "workflow";
 import { addActivitiesStep } from "./steps/add-activities-step";
@@ -269,7 +270,11 @@ async function runInitialLessonGeneration(input: {
 
     return "ready";
   } catch (error) {
-    await handleLessonFailureStep({ lessonId: input.lessonId });
+    await handleLessonFailureStep({
+      error: serializeWorkflowError(error),
+      lessonId: input.lessonId,
+    });
+
     throw error;
   }
 }

--- a/apps/api/src/workflows/lesson-generation/steps/add-activities-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/add-activities-step.test.ts
@@ -165,7 +165,7 @@ describe(addActivitiesStep, () => {
     expect(practices).toHaveLength(2);
   });
 
-  test("streams error and throws when DB save fails", async () => {
+  test("throws without streaming error when DB save fails", async () => {
     const brokenContext: LessonContext = {
       ...context,
       id: randomUUID(),
@@ -186,7 +186,7 @@ describe(addActivitiesStep, () => {
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "addActivities" }),
     );
   });

--- a/apps/api/src/workflows/lesson-generation/steps/add-activities-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/add-activities-step.ts
@@ -49,7 +49,6 @@ export async function addActivitiesStep(input: {
   const { error } = await safeAsync(() => prisma.activity.createMany({ data: activitiesData }));
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "addActivities" });
     throw error;
   }
 

--- a/apps/api/src/workflows/lesson-generation/steps/determine-applied-activity-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/determine-applied-activity-step.test.ts
@@ -99,17 +99,14 @@ describe(determineAppliedActivityStep, () => {
     );
   });
 
-  test("returns null when AI generation fails (non-fatal)", async () => {
+  test("throws without streaming error when AI generation fails", async () => {
     generateAppliedActivityKindMock.mockRejectedValue(new Error("AI failure"));
 
-    const result = await determineAppliedActivityStep(context);
-
-    expect(result).toBeNull();
+    await expect(determineAppliedActivityStep(context)).rejects.toThrow("AI failure");
 
     const events = getStreamedEvents(writeMock);
 
-    // Should still stream completed (not error) since failure is non-fatal
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "completed", step: "determineAppliedActivity" }),
     );
 

--- a/apps/api/src/workflows/lesson-generation/steps/determine-applied-activity-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/determine-applied-activity-step.ts
@@ -39,11 +39,9 @@ async function getRecentAppliedKinds(
 
 /**
  * Classifies whether this core lesson should include an applied activity
- * (story, investigation, etc).
- *
- * Non-fatal: if the classifier fails, the lesson proceeds without an
- * applied activity. This is an optional enhancement, not a structural
- * requirement.
+ * (story, investigation, etc). A classifier failure leaves the lesson without
+ * a reliable activity plan, so the step throws and lets Workflow retry it
+ * instead of saving a partial lesson shape.
  */
 export async function determineAppliedActivityStep(
   context: LessonContext,
@@ -68,11 +66,11 @@ export async function determineAppliedActivityStep(
     }),
   );
 
-  await stream.status({ status: "completed", step: "determineAppliedActivity" });
-
   if (error) {
-    return null;
+    throw error;
   }
+
+  await stream.status({ status: "completed", step: "determineAppliedActivity" });
 
   return result.data.appliedActivityKind;
 }

--- a/apps/api/src/workflows/lesson-generation/steps/determine-lesson-kind-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/determine-lesson-kind-step.test.ts
@@ -86,14 +86,14 @@ describe(determineLessonKindStep, () => {
     );
   });
 
-  test("throws and streams error when AI generation fails", async () => {
+  test("throws without streaming error when AI generation fails", async () => {
     generateLessonKindMock.mockRejectedValue(new Error("AI failure"));
 
     await expect(determineLessonKindStep(context)).rejects.toThrow("AI failure");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "determineLessonKind" }),
     );
   });

--- a/apps/api/src/workflows/lesson-generation/steps/determine-lesson-kind-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/determine-lesson-kind-step.ts
@@ -23,7 +23,6 @@ export async function determineLessonKindStep(context: LessonContext): Promise<L
   );
 
   if (error) {
-    await stream.error({ reason: "aiGenerationFailed", step: "determineLessonKind" });
     throw error;
   }
 

--- a/apps/api/src/workflows/lesson-generation/steps/generate-core-activities-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-core-activities-step.test.ts
@@ -99,14 +99,14 @@ describe(generateCoreActivitiesStep, () => {
     );
   });
 
-  test("throws and streams error when AI generation fails", async () => {
+  test("throws without streaming error when AI generation fails", async () => {
     generateLessonCoreActivitiesMock.mockRejectedValue(new Error("AI failure"));
 
     await expect(generateCoreActivitiesStep(context)).rejects.toThrow("AI failure");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateCoreActivities" }),
     );
   });

--- a/apps/api/src/workflows/lesson-generation/steps/generate-core-activities-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-core-activities-step.ts
@@ -33,7 +33,6 @@ export async function generateCoreActivitiesStep(
   );
 
   if (error) {
-    await stream.error({ reason: "aiGenerationFailed", step: "generateCoreActivities" });
     throw error;
   }
 

--- a/apps/api/src/workflows/lesson-generation/steps/generate-custom-activities-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-custom-activities-step.test.ts
@@ -92,14 +92,14 @@ describe(generateCustomActivitiesStep, () => {
     );
   });
 
-  test("throws and streams error when AI generation fails", async () => {
+  test("throws without streaming error when AI generation fails", async () => {
     generateLessonCustomActivitiesMock.mockRejectedValue(new Error("AI failure"));
 
     await expect(generateCustomActivitiesStep(context)).rejects.toThrow("AI failure");
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "generateCustomActivities" }),
     );
   });

--- a/apps/api/src/workflows/lesson-generation/steps/generate-custom-activities-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-custom-activities-step.ts
@@ -27,7 +27,6 @@ export async function generateCustomActivitiesStep(
   );
 
   if (error) {
-    await stream.error({ reason: "aiGenerationFailed", step: "generateCustomActivities" });
     throw error;
   }
 

--- a/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.ts
@@ -1,18 +1,35 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
+import { type WorkflowErrorLog } from "@/workflows/_shared/workflow-error";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
+import { logError } from "@zoonk/utils/logger";
 
-export async function handleLessonFailureStep(input: { lessonId: string }): Promise<void> {
+/**
+ * Marks a lesson-generation run as permanently failed after Workflow has
+ * exhausted retries for the throwing step. The original error is passed in as
+ * serializable data so logs preserve the real AI or database failure.
+ */
+export async function handleLessonFailureStep(input: {
+  error?: WorkflowErrorLog;
+  lessonId: string;
+}): Promise<void> {
   "use step";
 
   await using stream = createStepStream();
 
-  await safeAsync(() =>
+  logError("[Lesson Workflow Failure]", { error: input.error, lessonId: input.lessonId });
+
+  const { error } = await safeAsync(() =>
     prisma.lesson.update({
       data: { generationStatus: "failed" },
       where: { id: input.lessonId },
     }),
   );
+
+  if (error) {
+    logError("[Lesson Workflow Failure Status Update Failed]", error);
+    throw error;
+  }
 
   await stream.error({ reason: "aiGenerationFailed", step: "workflowError" });
 }

--- a/apps/api/src/workflows/lesson-generation/steps/remove-non-language-lesson-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/remove-non-language-lesson-step.test.ts
@@ -42,12 +42,12 @@ describe(removeNonLanguageLessonStep, () => {
     vi.clearAllMocks();
   });
 
-  test("streams error and throws when lesson does not exist", async () => {
+  test("throws without streaming error when lesson does not exist", async () => {
     await expect(removeNonLanguageLessonStep({ lessonId: randomUUID() })).rejects.toThrow();
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "removeNonLanguageLesson" }),
     );
   });

--- a/apps/api/src/workflows/lesson-generation/steps/remove-non-language-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/remove-non-language-lesson-step.ts
@@ -13,7 +13,6 @@ export async function removeNonLanguageLessonStep(input: { lessonId: string }): 
   const { error } = await safeAsync(() => prisma.lesson.delete({ where: { id: input.lessonId } }));
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "removeNonLanguageLesson" });
     throw error;
   }
 

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-completed-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-completed-step.test.ts
@@ -46,7 +46,7 @@ describe(setLessonAsCompletedStep, () => {
     vi.clearAllMocks();
   });
 
-  test("streams error and throws when lesson does not exist", async () => {
+  test("throws without streaming error when lesson does not exist", async () => {
     const lesson = await lessonFixture({
       chapterId,
       organizationId,
@@ -69,7 +69,7 @@ describe(setLessonAsCompletedStep, () => {
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "setLessonAsCompleted" }),
     );
   });

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-completed-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-completed-step.ts
@@ -26,7 +26,6 @@ export async function setLessonAsCompletedStep(input: {
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "setLessonAsCompleted" });
     throw error;
   }
 

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.test.ts
@@ -42,14 +42,14 @@ describe(setLessonAsRunningStep, () => {
     vi.clearAllMocks();
   });
 
-  test("streams error and throws when lesson does not exist", async () => {
+  test("throws without streaming error when lesson does not exist", async () => {
     await expect(
       setLessonAsRunningStep({ lessonId: randomUUID(), workflowRunId: "run-id" }),
     ).rejects.toThrow();
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "setLessonAsRunning" }),
     );
   });

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.ts
@@ -24,7 +24,6 @@ export async function setLessonAsRunningStep(input: {
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "setLessonAsRunning" });
     throw error;
   }
 

--- a/apps/api/src/workflows/lesson-generation/steps/update-lesson-kind-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/update-lesson-kind-step.test.ts
@@ -42,14 +42,14 @@ describe(updateLessonKindStep, () => {
     vi.clearAllMocks();
   });
 
-  test("streams error and throws when lesson does not exist", async () => {
+  test("throws without streaming error when lesson does not exist", async () => {
     await expect(
       updateLessonKindStep({ kind: "language", lessonId: randomUUID() }),
     ).rejects.toThrow();
 
     const events = getStreamedEvents(writeMock);
 
-    expect(events).toContainEqual(
+    expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "updateLessonKind" }),
     );
   });

--- a/apps/api/src/workflows/lesson-generation/steps/update-lesson-kind-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/update-lesson-kind-step.ts
@@ -21,7 +21,6 @@ export async function updateLessonKindStep(input: {
   );
 
   if (error) {
-    await stream.error({ reason: "dbSaveFailed", step: "updateLessonKind" });
     throw error;
   }
 

--- a/apps/api/vitest.config.mts
+++ b/apps/api/vitest.config.mts
@@ -25,6 +25,7 @@ export default defineConfig({
   },
   test: {
     env: {
+      AI_GATEWAY_API_KEY: "",
       DATABASE_URL: "postgres://postgres:postgres@localhost:5432/zoonk_test",
       DATABASE_URL_UNPOOLED: "postgres://postgres:postgres@localhost:5432/zoonk_test",
       NEXT_PUBLIC_APP_DOMAIN: "localhost:9002",

--- a/packages/utils/src/settled.test.ts
+++ b/packages/utils/src/settled.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "vitest";
-import { rejected, settled, settledValues } from "./settled";
+import {
+  getSettledFailureError,
+  settled,
+  settledFailures,
+  settledValues,
+  throwSettledFailures,
+} from "./settled";
 
 describe(settled, () => {
   test("returns fulfilled value", () => {
@@ -21,43 +27,58 @@ describe(settled, () => {
   });
 });
 
-describe(rejected, () => {
-  test("returns true when any result is rejected", () => {
-    const results: PromiseSettledResult<string>[] = [
+describe(settledFailures, () => {
+  test("returns every rejected reason and fulfilled error", () => {
+    const rejectedError = new Error("rejected");
+    const fulfilledError = new Error("fulfilled error");
+    const results: PromiseSettledResult<unknown>[] = [
       { status: "fulfilled", value: "ok" },
-      { reason: new Error("fail"), status: "rejected" },
+      { reason: rejectedError, status: "rejected" },
+      { status: "fulfilled", value: { data: null, error: fulfilledError } },
     ];
 
-    expect(rejected(results)).toBe(true);
+    expect(settledFailures(results)).toEqual([rejectedError, fulfilledError]);
   });
 
-  test("returns true when a fulfilled value has a truthy error property", () => {
-    const results: PromiseSettledResult<{ data: null; error: Error }>[] = [
-      { status: "fulfilled", value: { data: null, error: new Error("fail") } },
-    ];
-
-    expect(rejected(results)).toBe(true);
-  });
-
-  test("returns false when a fulfilled value has a falsy error property", () => {
-    const results: PromiseSettledResult<{ data: string; error: null }>[] = [
+  test("returns an empty array when nothing failed", () => {
+    const results: PromiseSettledResult<unknown>[] = [
+      { status: "fulfilled", value: "ok" },
       { status: "fulfilled", value: { data: "ok", error: null } },
     ];
 
-    expect(rejected(results)).toBe(false);
+    expect(settledFailures(results)).toEqual([]);
+  });
+});
+
+describe(getSettledFailureError, () => {
+  test("returns null when there are no failures", () => {
+    expect(getSettledFailureError({ failures: [], message: "failed" })).toBeNull();
   });
 
-  test("returns false when all results are fulfilled without errors", () => {
-    const results: PromiseSettledResult<string>[] = [
-      { status: "fulfilled", value: "a" },
-      { status: "fulfilled", value: "b" },
+  test("returns the original error when exactly one operation failed", () => {
+    const error = new Error("single");
+
+    expect(getSettledFailureError({ failures: [error], message: "failed" })).toBe(error);
+  });
+
+  test("returns AggregateError when multiple operations failed", () => {
+    const errors = [new Error("first"), new Error("second")];
+    const error = getSettledFailureError({ failures: errors, message: "multiple failed" });
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect(error).toMatchObject({ errors, message: "multiple failed" });
+  });
+});
+
+describe(throwSettledFailures, () => {
+  test("throws AggregateError with every failure", () => {
+    const errors = [new Error("first"), new Error("second")];
+    const results: PromiseSettledResult<unknown>[] = [
+      { reason: errors[0], status: "rejected" },
+      { reason: errors[1], status: "rejected" },
     ];
 
-    expect(rejected(results)).toBe(false);
-  });
-
-  test("returns false for an empty array", () => {
-    expect(rejected([])).toBe(false);
+    expect(() => throwSettledFailures({ message: "both failed", results })).toThrow(AggregateError);
   });
 });
 

--- a/packages/utils/src/settled.ts
+++ b/packages/utils/src/settled.ts
@@ -8,19 +8,95 @@ export function settled<T>(result: PromiseSettledResult<T>, fallback: T): T {
 }
 
 /**
- * Checks if any Promise.allSettled result failed — either by rejection or by
- * resolving with a truthy `error` property (the `{ data, error }` pattern).
+ * Extracts every failure carried by Promise.allSettled results. This keeps the
+ * real thrown reasons for rejected promises and also supports older helpers
+ * that resolve to `{ data, error }` instead of throwing.
  */
-export function rejected(results: PromiseSettledResult<unknown>[]): boolean {
-  return results.some(
-    (result) =>
-      result.status === "rejected" ||
-      (result.status === "fulfilled" && hasValueError(result.value)),
-  );
+export function settledFailures(results: PromiseSettledResult<unknown>[]): Error[] {
+  return results.flatMap((result) => {
+    if (result.status === "rejected") {
+      return [toError(result.reason)];
+    }
+
+    const error = getValueError(result.value);
+    return error ? [error] : [];
+  });
 }
 
-function hasValueError(value: unknown): boolean {
-  return isJsonObject(value) && "error" in value && Boolean(value.error);
+/**
+ * Converts collected failures into the error shape callers should throw. A
+ * single failure keeps its original identity, while multiple failures become an
+ * AggregateError so final workflow logs can include every underlying problem.
+ */
+export function getSettledFailureError({
+  failures,
+  message,
+}: {
+  failures: Error[];
+  message: string;
+}): Error | null {
+  if (failures.length === 0) {
+    return null;
+  }
+
+  if (failures.length === 1) {
+    return failures[0] ?? null;
+  }
+
+  return new AggregateError(failures, message);
+}
+
+/**
+ * Throws all failures from Promise.allSettled results, preserving the original
+ * error when only one operation failed and aggregating when several failed.
+ */
+export function throwSettledFailures({
+  message,
+  results,
+}: {
+  message: string;
+  results: PromiseSettledResult<unknown>[];
+}): void {
+  const error = getSettledFailureError({ failures: settledFailures(results), message });
+
+  if (error) {
+    throw error;
+  }
+}
+
+function getValueError(value: unknown): Error | null {
+  if (!isJsonObject(value) || !("error" in value) || !value.error) {
+    return null;
+  }
+
+  return toError(value.error);
+}
+
+/**
+ * Normalizes unusual promise rejection values into throwable Error objects.
+ * JavaScript allows rejecting with strings or plain provider objects, but our
+ * callers throw these failures so the value must be an Error.
+ */
+function toError(value: unknown): Error {
+  if (value instanceof Error) {
+    return value;
+  }
+
+  if (isJsonObject(value) && typeof value.message === "string") {
+    const error = new Error(value.message, { cause: value });
+
+    if (typeof value.name === "string") {
+      error.name = value.name;
+    }
+
+    if (typeof value.stack === "string") {
+      error.stack = value.stack;
+    }
+
+    return error;
+  }
+
+  return new Error(String(value), { cause: value });
 }
 
 /**


### PR DESCRIPTION
Summary:
- let retryable workflow steps throw original AI and DB failures
- move failed state, final streams, and real error logs to workflow catches
- aggregate settled status update failures so all errors are preserved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves real provider/DB errors in activity-generation workflows and hardens failure handling: steps throw to enable retries, and only workflow catches mark failure, log serialized errors, and stream a single terminal error.

- **Bug Fixes**
  - Serialize and keep original error details via `serializeWorkflowError`; persisted/logged in `handleActivityFailureStep` and `handleWorkflowFailureStep` (top-level workflow now passes serialized errors and logs them).
  - Remove per-step error streaming; retryable steps now throw (audio, romanization, distractors, pronunciations, translations, images, DB writes, content saves).
  - Enforce prerequisites by throwing (e.g., missing explanation steps for quiz/story/practice; no source data for reading; listening fails if reading is missing).
  - Correct failure propagation across custom, explanation, grammar, investigation, reading, listening, practice, quiz, story, and vocabulary workflows.

- **Refactors**
  - Added `failActivityWorkflow`/`failActivityWorkflows` helpers; `StepStream` is now internal; unified `createEntityStepStream` usage.
  - Simplified steps to operate on a single activity; callers fan out. Utilities and DB steps now throw on errors (e.g., `getExistingContentSteps`, neighboring concepts, activity fetch), letting workflow catches handle final failure.

<sup>Written for commit 21cd751cd02f87903fde07dfba5263905fb45ac7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

