### PR TITLE
fix(player): reset feedback screen scroll

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -327,6 +327,11 @@ msgctxt "EqkwlK"
 msgid "evidence"
 msgstr "evidence"
 
+#: ../../packages/player/src/components/player-shell.tsx
+msgctxt "tJtNzs"
+msgid "Player screen"
+msgstr "Player screen"
+
 #: ../../packages/player/src/components/reward-badges.tsx
 #: src/app/(performance)/level/level-stats.tsx
 msgctxt "/Q0taG"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -327,6 +327,11 @@ msgctxt "EqkwlK"
 msgid "evidence"
 msgstr "evidencias"
 
+#: ../../packages/player/src/components/player-shell.tsx
+msgctxt "tJtNzs"
+msgid "Player screen"
+msgstr "Pantalla del jugador"
+
 #: ../../packages/player/src/components/reward-badges.tsx
 #: src/app/(performance)/level/level-stats.tsx
 msgctxt "/Q0taG"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -327,6 +327,11 @@ msgctxt "EqkwlK"
 msgid "evidence"
 msgstr "evidências"
 
+#: ../../packages/player/src/components/player-shell.tsx
+msgctxt "tJtNzs"
+msgid "Player screen"
+msgstr "Tela do jogador"
+
 #: ../../packages/player/src/components/reward-badges.tsx
 #: src/app/(performance)/level/level-stats.tsx
 msgctxt "/Q0taG"

--- a/i18n.lock
+++ b/i18n.lock
@@ -221,7 +221,10 @@ checksums:
     Lesson%20Complete/singular: c2353c93f81c6ff8aab8825a73bcbb6a
     correct/singular: 0c2df4a764cea47295c0b550477e8e29
     Chapter%20Complete/singular: 93c49bef3b2cfd1305e910cd79381afd
-    Context/singular: 71588d4b2baccf54e6dc6956717b960e
+    Full%20image/singular: 7e0a5bc710dbbbabb834fc8db9a3c59e
+    Open%20full%20image/singular: 1bc1e3192bd7c596b537e13c8af5224c
+    Shows%20the%20full%20uncropped%20step%20image./singular: 5a8af8e3cb8532c28483cdad2539ba96
+    Close%20full%20image/singular: a2550b38090fe8e260471254b4dea4cc
     Your%20answer%3A/singular: 663abc310ccb6229c6325f8c857adce2
     Correct%20answer%3A/singular: a8b8cc0d5d0059cbfeee0ad4721540d5
     Translate%3A/singular: 0a44ccd6c0e1dd4545fd00d059eaf0a5
@@ -251,6 +254,7 @@ checksums:
     Close/singular: 2c2e22f8424a1031de89063bd0022e16
     Activity%20progress/singular: 8ff2fb7372b8a2525f2955c851c4fa42
     evidence/singular: e79d4526b88aca84fbc283178ed61264
+    Player%20screen/singular: e43d67a1c04707801ae2545c8ddf09a6
     BP/singular: 842ed01b3a4d0efa6fe96ae8c595726c
     Energy/singular: 958809db5050650b97519e0f1f3e1951
     Image%20options/singular: 64a1aee44b26dbaff851cb846eb4274d
@@ -261,10 +265,8 @@ checksums:
     Continue/singular: 3cfba90b4600131e82fc4260c568d044
     Begin/singular: cc2a17a662cb60dd2d8335a2e8440997
     Check/singular: 023cc2ba432775c38e3efc004ad7b9ef
-    Your%20move/singular: ab492491d3981122f7bd74377215ae25
     Metric%20changes/singular: b47eb6ffcf56070345e7783cb048b563
     Impact/singular: 9419c16af83da3c0cf7e536b058c235f
-    Current%20status/singular: b9c587d6cd7ee919b59e75066fa4675f
     Final%20status/singular: 62c3befb232a9d290e74b84d6ddbf22c
     Translate%20this%20word%3A/singular: 05fede3c583e9ea39f27ac9fdf17fcc3
     Not%20quite/singular: e570085e69662802acf485c4565e3e3e

--- a/packages/player/src/_browser-tests/player-story.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-story.browser.test.tsx
@@ -9,6 +9,19 @@ import { renderPlayer } from "../_test-utils/render-player";
 const STORY_METRICS = [{ label: "Production" }, { label: "Morale" }];
 const STORY_CONTEXT_METRICS = [...STORY_METRICS, { label: "Safety" }];
 
+const STORY_SCROLL_METRICS = [
+  { label: "Production" },
+  { label: "Morale" },
+  { label: "Safety" },
+  { label: "Inventory" },
+  { label: "Quality" },
+  { label: "Training" },
+  { label: "Maintenance" },
+  { label: "Delivery" },
+  { label: "Focus" },
+  { label: "Trust" },
+];
+
 const STORY_OUTCOMES = {
   bad: {
     narrative: "The factory barely holds together",
@@ -59,6 +72,39 @@ async function expectCurrentStepImageExpands(imageAlt: string) {
 
   await page.getByRole("button", { name: /close full image/i }).click();
   await expect.element(dialog).not.toBeInTheDocument();
+}
+
+/**
+ * Returns the shared player scroll container through its accessible region.
+ * The feedback scroll regression lives on this shell, not inside a specific
+ * story child component, so the test needs to inspect the real stage element.
+ */
+function getPlayerScreenElement() {
+  return page.getByRole("region", { name: /player screen/i }).element() as HTMLElement;
+}
+
+/**
+ * Recreates the user path where a learner scrolls down before choosing an
+ * answer. The assertion proves the test is exercising an actual scrollable
+ * screen instead of setting scrollTop on a short page.
+ */
+function scrollPlayerScreenToBottom() {
+  const playerScreen = getPlayerScreenElement();
+
+  expect(playerScreen.scrollHeight).toBeGreaterThan(playerScreen.clientHeight);
+
+  playerScreen.scrollTop = playerScreen.scrollHeight;
+  fireEvent.scroll(playerScreen);
+
+  expect(playerScreen.scrollTop).toBeGreaterThan(0);
+}
+
+/**
+ * Checks the active player screen after a scene transition. Feedback should
+ * always start at the top so the image and first consequence are visible.
+ */
+function expectPlayerScreenAtTop() {
+  expect(getPlayerScreenElement().scrollTop).toBe(0);
 }
 
 describe("player browser integration: story", () => {
@@ -321,5 +367,95 @@ describe("player browser integration: story", () => {
     await expect
       .element(page.getByRole("status", { name: /current status/i }))
       .not.toBeInTheDocument();
+  });
+
+  test("shows story feedback from the top after selecting from a scrolled decision", async () => {
+    renderPlayer({
+      activity: buildSerializedActivity({
+        kind: "story",
+        steps: [
+          buildSerializedStep({
+            content: {
+              choices: [
+                {
+                  alignment: "weak" as const,
+                  consequence: "The repair backlog grows.",
+                  id: "story-choice-1",
+                  metricEffects: [{ effect: "negative" as const, metric: "Production" }],
+                  stateImage: {
+                    prompt: "Factory floor with stalled repairs and anxious workers",
+                    url: buildInlineImageUrl({ label: "Story scroll feedback stalled" }),
+                  },
+                  text: "Keep the current shift running and hope the broken conveyor holds.",
+                },
+                {
+                  alignment: "partial" as const,
+                  consequence: "The team understands the risk but output still slips.",
+                  id: "story-choice-2",
+                  metricEffects: [{ effect: "neutral" as const, metric: "Production" }],
+                  stateImage: {
+                    prompt: "Factory floor with a short repair briefing beside the conveyor",
+                    url: buildInlineImageUrl({ label: "Story scroll feedback briefing" }),
+                  },
+                  text: "Hold a short briefing, then ask each station to report problems later.",
+                },
+                {
+                  alignment: "strong" as const,
+                  consequence:
+                    "Repairs restart safely and the team sees the plan. The maintenance lead checks every station, the floor manager explains the pause, and the next batch moves only after the checklist is visible to everyone.",
+                  id: "story-choice-3",
+                  metricEffects: STORY_SCROLL_METRICS.map((metric) => ({
+                    effect: "positive" as const,
+                    metric: metric.label,
+                  })),
+                  stateImage: {
+                    prompt: "Factory floor after repairs restart safely with a clear team plan",
+                    url: buildInlineImageUrl({ label: "Story scroll feedback repair" }),
+                  },
+                  text: "Pause the line, assign repair owners, and reopen only after the checklist passes.",
+                },
+              ],
+              image: {
+                prompt: "Factory floor with a broken conveyor and a long repair queue",
+                url: buildInlineImageUrl({ label: "Story scroll decision" }),
+              },
+              problem:
+                "A conveyor breaks during the busiest hour. Workers are waiting for direction, inventory is piling up, and the fastest option is buried below the first visible choices.",
+            },
+            id: "story-scroll-decision",
+            kind: "story",
+          }),
+          buildSerializedStep({
+            content: {
+              metrics: STORY_SCROLL_METRICS,
+              outcomes: STORY_OUTCOMES,
+              variant: "storyOutcome" as const,
+            },
+            id: "story-scroll-outcome",
+            kind: "static",
+            position: 1,
+          }),
+        ],
+      }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    scrollPlayerScreenToBottom();
+
+    await page
+      .getByRole("radio", {
+        name: /pause the line, assign repair owners/i,
+      })
+      .click();
+
+    await page.getByRole("button", { name: /check/i }).click();
+
+    await expect
+      .element(
+        page.getByAltText("Factory floor after repairs restart safely with a clear team plan"),
+      )
+      .toBeInTheDocument();
+
+    expectPlayerScreenAtTop();
   });
 });

--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -33,6 +33,17 @@ function BottomBarContent() {
   );
 }
 
+/**
+ * Gives the scroll-owning stage a new DOM identity when the visible player
+ * surface changes. Inline feedback keeps the same step surface so learners
+ * stay near the answer they checked, while dedicated feedback and completion
+ * screens start from the top because their first content is a new result image
+ * or summary.
+ */
+function getStageResetKey({ screenKind, stepId }: { screenKind: string; stepId?: string }) {
+  return `${stepId ?? "completion"}:${screenKind}`;
+}
+
 export function PlayerShell() {
   const t = useExtracted();
   const { screen, state } = usePlayerRuntime();
@@ -47,6 +58,7 @@ export function PlayerShell() {
   const progressValue = getProgressValue(state);
   const storyMetrics = getStoryMetrics(state);
   const upcomingImages = getUpcomingImages(state);
+  const stageResetKey = getStageResetKey({ screenKind: screen.kind, stepId: currentStep?.id });
 
   usePlayerHaptics({
     current: {
@@ -77,8 +89,10 @@ export function PlayerShell() {
       )}
 
       <PlayerStage
+        aria-label={t("Player screen")}
         isFullBleed={screen.stageIsFullBleed}
         isStatic={screen.stageIsStatic}
+        key={stageResetKey}
         phase={state.phase}
         scene={screen.scene}
       >


### PR DESCRIPTION
## Summary

- reset the player stage when dedicated feedback and completion screens replace the active step
- keep inline feedback on the same scroll surface so checked answers do not jump away
- add a story browser regression for scrolled decisions leading into tall feedback screens

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset the player stage scroll when switching to dedicated feedback or completion screens so learners see feedback from the top. Keep inline feedback on the same scroll surface so checked answers don’t jump.

- **Bug Fixes**
  - Give the stage a new DOM key (`stepId:screenKind`) for dedicated screens to reset scroll to 0.
  - Preserve scroll for inline feedback by keeping the same stage identity.
  - Add an accessible region label “Player screen” with i18n, and a browser test that scrolls a long decision and verifies feedback starts at the top.

<sup>Written for commit 4d5a8b5be346e3a4c13e9e934808774d92b54169. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

