### PR TITLE
refactor(player): normalize activity option contracts

### DIFF
--- a/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/core-activity-workflow.test.ts
@@ -128,16 +128,16 @@ function createStoryChoices() {
           {
             alignment: "strong",
             consequence: "Workers rally.",
-            label: "Address the team",
             metricEffects: [{ effect: "positive", metric: "Morale" }],
             stateImagePrompt: "Factory floor after a direct address calms the team",
+            text: "Address the team",
           },
           {
             alignment: "weak",
             consequence: "Rumors spread.",
-            label: "Send an email",
             metricEffects: [{ effect: "negative", metric: "Morale" }],
             stateImagePrompt: "Factory floor after a vague email leaves workers confused",
+            text: "Send an email",
           },
         ],
       },

--- a/apps/api/src/workflows/activity-generation/kinds/investigation-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/investigation-workflow.test.ts
@@ -25,9 +25,9 @@ const { mockScenario, mockAccuracy, mockActions, mockFindings } = vi.hoisted(() 
   },
   mockActions: {
     actions: [
-      { label: "Check the logs", quality: "critical" as const },
-      { label: "Interview workers", quality: "useful" as const },
-      { label: "Look at the ceiling", quality: "weak" as const },
+      { quality: "critical" as const, text: "Check the logs" },
+      { quality: "useful" as const, text: "Interview workers" },
+      { quality: "weak" as const, text: "Look at the ceiling" },
     ],
   },
   mockFindings: {
@@ -214,11 +214,11 @@ describe("investigation activity workflow", () => {
       where: { activityId: activity.id, position: 1 },
     });
 
-    const actions = getArray(actionStep?.content, "actions");
+    const actions = getArray(actionStep?.content, "options");
     expect(actions).toHaveLength(3);
-    expect(getString(actions[0], "label")).toBe("Check the logs");
+    expect(getString(actions[0], "text")).toBe("Check the logs");
     expect(getString(actions[0], "quality")).toBe("critical");
-    expect(getString(actions[0], "finding")).toBe(mockFindings.findings[0]);
+    expect(getString(actions[0], "feedback")).toBe(mockFindings.findings[0]);
   });
 
   test("saves correct call step content with per-explanation feedback", async () => {
@@ -248,7 +248,7 @@ describe("investigation activity workflow", () => {
       where: { activityId: activity.id, position: 2 },
     });
 
-    const explanations = getArray(callStep?.content, "explanations");
+    const explanations = getArray(callStep?.content, "options");
     expect(explanations).toHaveLength(3);
     expect(getString(explanations[0], "accuracy")).toBe("best");
     expect(getString(explanations[0], "feedback")).toBe("This is the most complete explanation.");

--- a/apps/api/src/workflows/activity-generation/kinds/practice-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/practice-workflow.test.ts
@@ -145,10 +145,10 @@ describe("practice activity workflow", () => {
       },
       kind: "core",
       options: [
-        { feedback: "Great choice!", isCorrect: true, text: "Option A" },
-        { feedback: "Not quite.", isCorrect: false, text: "Option B" },
-        { feedback: "Try again.", isCorrect: false, text: "Option C" },
-        { feedback: "Nope.", isCorrect: false, text: "Option D" },
+        { feedback: "Great choice!", id: "option-1", isCorrect: true, text: "Option A" },
+        { feedback: "Not quite.", id: "option-2", isCorrect: false, text: "Option B" },
+        { feedback: "Try again.", id: "option-3", isCorrect: false, text: "Option C" },
+        { feedback: "Nope.", id: "option-4", isCorrect: false, text: "Option D" },
       ],
       question: "What should you do?",
     });

--- a/apps/api/src/workflows/activity-generation/kinds/story-workflow.test.ts
+++ b/apps/api/src/workflows/activity-generation/kinds/story-workflow.test.ts
@@ -64,16 +64,16 @@ const { mockStoryChoices, mockStoryData, mockStoryImages, mockStoryPlan } = vi.h
           {
             alignment: "strong",
             consequence: "Workers rally behind you.",
-            label: "Address the team directly",
             metricEffects: [{ effect: "positive", metric: "Morale" }],
             stateImagePrompt: "Factory floor after a direct address calms the team",
+            text: "Address the team directly",
           },
           {
             alignment: "weak",
             consequence: "Rumors spread unchecked.",
-            label: "Send an email instead",
             metricEffects: [{ effect: "negative", metric: "Morale" }],
             stateImagePrompt: "Factory floor after a vague email leaves workers confused",
+            text: "Send an email instead",
           },
         ],
       },
@@ -82,20 +82,20 @@ const { mockStoryChoices, mockStoryData, mockStoryImages, mockStoryPlan } = vi.h
           {
             alignment: "partial",
             consequence: "You find a reasonable alternative.",
-            label: "Contact backup suppliers",
             metricEffects: [{ effect: "positive", metric: "Production" }],
             stateImagePrompt: "Temporary supply shipment arriving at the factory loading dock",
+            text: "Contact backup suppliers",
           },
           {
             alignment: "strong",
             consequence: "Innovation emerges from constraint.",
-            label: "Redesign the product to use different materials",
             metricEffects: [
               { effect: "positive", metric: "Production" },
               { effect: "positive", metric: "Cash" },
             ],
             stateImagePrompt:
               "Factory team adapting the product with new materials and renewed momentum",
+            text: "Redesign the product to use different materials",
           },
         ],
       },

--- a/apps/api/src/workflows/activity-generation/steps/_utils/add-option-ids.ts
+++ b/apps/api/src/workflows/activity-generation/steps/_utils/add-option-ids.ts
@@ -1,0 +1,14 @@
+/**
+ * AI tasks generate option text and feedback, but the stored player contract
+ * needs stable option IDs so shuffled options can be answered and validated by
+ * identity instead of by render order or display text.
+ */
+export function addOptionIds<Option extends object>({
+  options,
+  prefix = "option",
+}: {
+  options: readonly Option[];
+  prefix?: string;
+}): (Option & { id: string })[] {
+  return options.map((option, index) => ({ ...option, id: `${prefix}-${index + 1}` }));
+}

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-actions-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-actions-step.test.ts
@@ -47,9 +47,9 @@ const mockAccuracy = {
 
 const mockActionsData = {
   actions: [
-    { label: "Check server logs", quality: "critical" as const },
-    { label: "Review DNS records", quality: "useful" as const },
-    { label: "Ask a colleague", quality: "weak" as const },
+    { quality: "critical" as const, text: "Check server logs" },
+    { quality: "useful" as const, text: "Review DNS records" },
+    { quality: "weak" as const, text: "Ask a colleague" },
   ],
 };
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-investigation-findings-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-investigation-findings-step.test.ts
@@ -47,8 +47,8 @@ const mockAccuracy = {
 
 const mockActions = {
   actions: [
-    { label: "Check server logs", quality: "critical" as const },
-    { label: "Review DNS records", quality: "useful" as const },
+    { quality: "critical" as const, text: "Check server logs" },
+    { quality: "useful" as const, text: "Review DNS records" },
   ],
 };
 

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-choices-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-choices-step.test.ts
@@ -81,17 +81,17 @@ const mockStoryChoices = {
         {
           alignment: "strong",
           consequence: "Workers rally.",
-          label: "Address the team",
           metricEffects: [{ effect: "positive", metric: "Morale" }],
           stateImagePrompt:
             "Factory floor after the leader addresses the team and confidence returns",
+          text: "Address the team",
         },
         {
           alignment: "weak",
           consequence: "Rumors spread.",
-          label: "Send an email",
           metricEffects: [{ effect: "negative", metric: "Morale" }],
           stateImagePrompt: "Factory floor after a vague email leaves workers confused",
+          text: "Send an email",
         },
       ],
     },

--- a/apps/api/src/workflows/activity-generation/steps/generate-story-images-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/generate-story-images-step.test.ts
@@ -67,16 +67,16 @@ describe(generateStoryImagesStep, () => {
             {
               alignment: "strong" as const,
               consequence: "Workers rally.",
-              label: "Address the team",
               metricEffects: [{ effect: "positive" as const, metric: "Morale" }],
               stateImagePrompt: "Factory floor after a direct address calms the team",
+              text: "Address the team",
             },
             {
               alignment: "weak" as const,
               consequence: "Rumors spread.",
-              label: "Send an email",
               metricEffects: [{ effect: "negative" as const, metric: "Morale" }],
               stateImagePrompt: "Factory floor after a vague email leaves workers confused",
+              text: "Send an email",
             },
           ],
           imagePrompt: "Factory floor with halted lines and empty parts bins",

--- a/apps/api/src/workflows/activity-generation/steps/save-grammar-steps-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-grammar-steps-step.ts
@@ -5,6 +5,7 @@ import { assertStepContent } from "@zoonk/core/steps/contract/content";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
+import { addOptionIds } from "./_utils/add-option-ids";
 import { findActivityByKind } from "./_utils/find-activity-by-kind";
 import { type LessonActivity } from "./get-lesson-activities-step";
 
@@ -73,7 +74,7 @@ function buildGrammarSteps(
     content: assertStepContent("multipleChoice", {
       ...(discoveryContext ? { context: discoveryContext } : {}),
       kind: "core",
-      options: userContent.discovery.options,
+      options: addOptionIds({ options: userContent.discovery.options }),
       ...(discoveryQuestion ? { question: discoveryQuestion } : {}),
     }),
     kind: "multipleChoice" as const,

--- a/apps/api/src/workflows/activity-generation/steps/save-investigation-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-investigation-activity-step.test.ts
@@ -39,9 +39,9 @@ const mockAccuracy = {
 
 const mockActions = {
   actions: [
-    { label: "Check server logs", quality: "critical" as const },
-    { label: "Ask a colleague", quality: "weak" as const },
-    { label: "Review metrics", quality: "useful" as const },
+    { quality: "critical" as const, text: "Check server logs" },
+    { quality: "weak" as const, text: "Ask a colleague" },
+    { quality: "useful" as const, text: "Review metrics" },
   ],
 };
 
@@ -127,22 +127,22 @@ describe(saveInvestigationActivityStep, () => {
     expect(dbSteps[2]?.position).toBe(2);
     expect(getString(dbSteps[2]?.content, "variant")).toBe("call");
     const explanations = dbSteps[2]?.content as {
-      explanations: { accuracy: string; feedback: string; id: string; text: string }[];
+      options: { accuracy: string; feedback: string; id: string; text: string }[];
     };
-    expect(explanations.explanations[0]?.feedback).toBe("This is the correct answer.");
-    expect(explanations.explanations[1]?.feedback).toBe("This is incorrect.");
+    expect(explanations.options[0]?.feedback).toBe("This is the correct answer.");
+    expect(explanations.options[1]?.feedback).toBe("This is incorrect.");
 
     // Verify UUIDs are stamped on explanations
-    for (const explanation of explanations.explanations) {
+    for (const explanation of explanations.options) {
       expect(explanation.id).toMatch(/^[\da-f-]+$/);
     }
 
     // Verify UUIDs are stamped on actions
     const actions = dbSteps[1]?.content as {
-      actions: { id: string; label: string }[];
+      options: { id: string; text: string }[];
     };
 
-    for (const action of actions.actions) {
+    for (const action of actions.options) {
       expect(action.id).toMatch(/^[\da-f-]+$/);
     }
 

--- a/apps/api/src/workflows/activity-generation/steps/save-investigation-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-investigation-activity-step.ts
@@ -63,11 +63,11 @@ function buildInvestigationStepRecords({
   const actionStep = {
     activityId,
     content: assertStepContent("investigation", {
-      actions: actions.actions.map((action, index) => ({
-        finding: findings.findings[index] ?? "",
+      options: actions.actions.map((action, index) => ({
+        feedback: findings.findings[index] ?? "",
         id: randomUUID(),
-        label: action.label,
         quality: action.quality,
+        text: action.text,
       })),
       variant: "action" as const,
     }),
@@ -79,7 +79,7 @@ function buildInvestigationStepRecords({
   const callStep = {
     activityId,
     content: assertStepContent("investigation", {
-      explanations,
+      options: explanations,
       variant: "call" as const,
     }),
     isPublished: true,

--- a/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.test.ts
@@ -146,10 +146,10 @@ describe(savePracticeActivityStep, () => {
       image: practiceImages[1],
       kind: "core",
       options: [
-        { feedback: "Correct!", isCorrect: true, text: "Option A" },
-        { feedback: "Incorrect.", isCorrect: false, text: "Option B" },
-        { feedback: "Incorrect.", isCorrect: false, text: "Option C" },
-        { feedback: "Incorrect.", isCorrect: false, text: "Option D" },
+        { feedback: "Correct!", id: "option-1", isCorrect: true, text: "Option A" },
+        { feedback: "Incorrect.", id: "option-2", isCorrect: false, text: "Option B" },
+        { feedback: "Incorrect.", id: "option-3", isCorrect: false, text: "Option C" },
+        { feedback: "Incorrect.", id: "option-4", isCorrect: false, text: "Option D" },
       ],
       question: steps[0]?.question,
     });
@@ -159,10 +159,10 @@ describe(savePracticeActivityStep, () => {
       image: practiceImages[2],
       kind: "core",
       options: [
-        { feedback: "Incorrect.", isCorrect: false, text: "Option A" },
-        { feedback: "Correct!", isCorrect: true, text: "Option B" },
-        { feedback: "Incorrect.", isCorrect: false, text: "Option C" },
-        { feedback: "Incorrect.", isCorrect: false, text: "Option D" },
+        { feedback: "Incorrect.", id: "option-1", isCorrect: false, text: "Option A" },
+        { feedback: "Correct!", id: "option-2", isCorrect: true, text: "Option B" },
+        { feedback: "Incorrect.", id: "option-3", isCorrect: false, text: "Option C" },
+        { feedback: "Incorrect.", id: "option-4", isCorrect: false, text: "Option D" },
       ],
       question: steps[1]?.question,
     });

--- a/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-practice-activity-step.ts
@@ -4,6 +4,7 @@ import { type StepImage } from "@zoonk/core/steps/contract/image";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
+import { addOptionIds } from "./_utils/add-option-ids";
 import { type PracticeScenario, type PracticeStep } from "./generate-practice-content-step";
 
 /**
@@ -89,7 +90,7 @@ function buildPracticeQuestionRecords({
       context: step.context,
       image,
       kind: "core",
-      options: step.options,
+      options: addOptionIds({ options: step.options }),
       question: step.question,
     });
 

--- a/apps/api/src/workflows/activity-generation/steps/save-quiz-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-quiz-activity-step.ts
@@ -4,29 +4,67 @@ import { assertStepContent } from "@zoonk/core/steps/contract/content";
 import { type ActivityStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
+import { addOptionIds } from "./_utils/add-option-ids";
 import { type QuizQuestionWithUrls } from "./generate-quiz-images-step";
+
+type QuizQuestionInput = QuizQuestion | QuizQuestionWithUrls;
+
+/**
+ * Select-image answers are submitted by option ID so the player can shuffle
+ * images without making server validation depend on the rendered order.
+ */
+function addSelectImageOptionIds(question: Extract<QuizQuestionInput, { format: "selectImage" }>) {
+  return {
+    ...question,
+    options: addOptionIds({ options: question.options }),
+  };
+}
+
+/**
+ * Converts AI quiz output into the stored step contract. AI output stays lean,
+ * while the database contract carries runtime-only fields like image option IDs.
+ */
+function buildQuizStepContent(question: QuizQuestionInput) {
+  if (question.format === "multipleChoice") {
+    const { format, ...rawContent } = question;
+
+    return assertStepContent(format, {
+      ...rawContent,
+      kind: "core",
+      options: addOptionIds({ options: question.options }),
+    });
+  }
+
+  if (question.format === "selectImage") {
+    const { format, ...rawContent } = addSelectImageOptionIds(question);
+    return assertStepContent(format, rawContent);
+  }
+
+  const { format, ...rawContent } = question;
+
+  return assertStepContent(format, rawContent);
+}
 
 /**
  * Builds step records from quiz questions.
  * For multipleChoice questions, adds `kind: "core"` to the content.
  * The `format` field from AI output maps to the step `kind` in the DB.
  */
-function buildQuizStepRecords(
-  activityId: string,
-  questions: (QuizQuestion | QuizQuestionWithUrls)[],
-) {
+function buildQuizStepRecords({
+  activityId,
+  questions,
+}: {
+  activityId: string;
+  questions: QuizQuestionInput[];
+}) {
   return questions.map((question, index) => {
-    const { format, ...rawContent } = question;
-    const content =
-      format === "multipleChoice"
-        ? assertStepContent(format, { ...rawContent, kind: "core" })
-        : assertStepContent(format, rawContent);
+    const content = buildQuizStepContent(question);
 
     return {
       activityId,
       content,
       isPublished: true,
-      kind: format,
+      kind: question.format,
       position: index,
     };
   });
@@ -55,7 +93,7 @@ export async function saveQuizActivityStep({
 
   await stream.status({ status: "started", step: "saveQuizActivity" });
 
-  const stepRecords = buildQuizStepRecords(activityId, questions);
+  const stepRecords = buildQuizStepRecords({ activityId, questions });
 
   const { error } = await safeAsync(() =>
     prisma.$transaction([

--- a/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.test.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.test.ts
@@ -12,9 +12,9 @@ import { saveStoryActivityStep } from "./save-story-activity-step";
 
 const writeMock = vi.fn().mockResolvedValue(null);
 
-type StepContentWithChoices = {
-  choices?: { id?: string; text?: string }[];
+type StepContentWithOptions = {
   image?: { url?: string };
+  options?: { id?: string; text?: string }[];
 };
 
 type StepContentWithImage = {
@@ -75,16 +75,16 @@ const storyData = {
         {
           alignment: "strong" as const,
           consequence: "Workers rally behind you.",
-          label: "Address the team directly",
           metricEffects: [{ effect: "positive" as const, metric: "Morale" }],
           stateImagePrompt: "Factory floor after a direct address calms the team",
+          text: "Address the team directly",
         },
         {
           alignment: "weak" as const,
           consequence: "Rumors spread.",
-          label: "Send an email",
           metricEffects: [{ effect: "negative" as const, metric: "Morale" }],
           stateImagePrompt: "Factory floor after a vague email leaves workers confused",
+          text: "Send an email",
         },
       ],
       imagePrompt: "Factory floor with halted lines and empty parts bins",
@@ -95,20 +95,20 @@ const storyData = {
         {
           alignment: "partial" as const,
           consequence: "Reasonable alternative found.",
-          label: "Contact backup suppliers",
           metricEffects: [{ effect: "positive" as const, metric: "Production" }],
           stateImagePrompt: "Temporary supply shipment arriving at the factory loading dock",
+          text: "Contact backup suppliers",
         },
         {
           alignment: "strong" as const,
           consequence: "Innovation emerges.",
-          label: "Redesign the product",
           metricEffects: [
             { effect: "positive" as const, metric: "Production" },
             { effect: "positive" as const, metric: "Cash" },
           ],
           stateImagePrompt:
             "Factory team adapting the product with new materials and renewed momentum",
+          text: "Redesign the product",
         },
       ],
       imagePrompt: "Production area paused while engineers debate how to proceed without parts",
@@ -215,7 +215,7 @@ describe(saveStoryActivityStep, () => {
     const secondDecisionStep = dbSteps[2]!;
     const outcomeStep = dbSteps[3]!;
     const introContent = introStep.content as StepContentWithImage;
-    const firstDecisionContent = firstDecisionStep.content as StepContentWithChoices;
+    const firstDecisionContent = firstDecisionStep.content as StepContentWithOptions;
     const outcomeContent = outcomeStep.content as StepContentWithOutcomes;
 
     // 1 intro + 2 decision steps + 1 outcome = 4
@@ -233,11 +233,11 @@ describe(saveStoryActivityStep, () => {
     expect(firstDecisionStep.kind).toBe("story");
     expect(firstDecisionStep.position).toBe(1);
     expect(firstDecisionContent.image?.url).toBe("https://example.com/step-1.webp");
-    expect(firstDecisionContent.choices?.map((choice) => choice.id)).toEqual([
+    expect(firstDecisionContent.options?.map((choice) => choice.id)).toEqual([
       expect.stringMatching(uuidPattern),
       expect.stringMatching(uuidPattern),
     ]);
-    expect(firstDecisionContent.choices?.map((choice) => choice.text)).toEqual([
+    expect(firstDecisionContent.options?.map((choice) => choice.text)).toEqual([
       "Address the team directly",
       "Send an email",
     ]);

--- a/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.ts
+++ b/apps/api/src/workflows/activity-generation/steps/save-story-activity-step.ts
@@ -32,11 +32,11 @@ function buildStoryChoices({
 
     return {
       alignment: choice.alignment,
-      consequence: choice.consequence,
+      feedback: choice.consequence,
       id: randomUUID(),
       metricEffects: choice.metricEffects,
       stateImage,
-      text: choice.label,
+      text: choice.text,
     };
   });
 }
@@ -101,7 +101,7 @@ function buildStoryOutcomes({
  * generated image bundle.
  *
  * - Position 0: static intro step (scene setup + metric definitions)
- * - Positions 1..N: story decision steps (problem + choices)
+ * - Positions 1..N: story decision steps (problem + options)
  * - Position N+1: static outcome step (narrative results + final metrics)
  */
 function buildStoryStepRecords(
@@ -127,14 +127,14 @@ function buildStoryStepRecords(
   const decisionRecords = storyData.steps.map((step, index) => ({
     activityId,
     content: assertStepContent("story", {
-      choices: buildStoryChoices({
-        choiceStateImages: storyImages.choiceStateImages[index] ?? [],
-        choices: step.choices,
-        stepIndex: index,
-      }),
       image: getRequiredStoryImage({
         image: storyImages.stepImages[index],
         label: `step ${index + 1}`,
+      }),
+      options: buildStoryChoices({
+        choiceStateImages: storyImages.choiceStateImages[index] ?? [],
+        choices: step.choices,
+        stepIndex: index,
       }),
       problem: step.problem,
     }),
@@ -164,7 +164,7 @@ function buildStoryStepRecords(
 /**
  * Persists all generated story data in one transaction:
  * - Static intro step with setup title, text, and image
- * - Interactive decision steps with choices and consequences
+ * - Interactive decision steps with options and consequences
  * - Static outcome step with narrative results and final metrics
  * - Marks the activity as completed
  *

--- a/apps/evals/src/tasks/activity-investigation-actions/test-cases.ts
+++ b/apps/evals/src/tasks/activity-investigation-actions/test-cases.ts
@@ -9,7 +9,7 @@ EVALUATION CRITERIA:
 
 4. COVERAGE: Actions should cover different investigation angles — some that would confirm the best explanation, some that test alternatives, some tangential.
 
-5. LANGUAGE: All action labels must be in the specified language.
+5. LANGUAGE: All action text must be in the specified language.
 `;
 
 export const TEST_CASES = [

--- a/apps/evals/src/tasks/activity-investigation-findings/test-cases.ts
+++ b/apps/evals/src/tasks/activity-investigation-findings/test-cases.ts
@@ -23,28 +23,28 @@ export const TEST_CASES = [
       actions: {
         actions: [
           {
-            label: "Check where the delay happens between the user's browser and the app",
             quality: "critical",
+            text: "Check where the delay happens between the user's browser and the app",
           },
           {
-            label: "Compare the path requests take from the slow region versus a normal region",
             quality: "critical",
+            text: "Compare the path requests take from the slow region versus a normal region",
           },
           {
-            label: "Review network device records for dropped or delayed traffic on that route",
             quality: "useful",
+            text: "Review network device records for dropped or delayed traffic on that route",
           },
           {
-            label: "Look for signs that replies are being sent back the wrong way and retried",
             quality: "useful",
+            text: "Look for signs that replies are being sent back the wrong way and retried",
           },
           {
-            label: "Test page loads from several places outside the data center",
             quality: "useful",
+            text: "Test page loads from several places outside the data center",
           },
           {
-            label: "Recheck one busy app server just in case it's slowing every request",
             quality: "weak",
+            text: "Recheck one busy app server just in case it's slowing every request",
           },
         ],
       },
@@ -75,22 +75,22 @@ ${SHARED_EXPECTATIONS}
       actions: {
         actions: [
           {
-            label: "Ver onde os campos vazios ou inválidos entram nas contas",
             quality: "critical",
+            text: "Ver onde os campos vazios ou inválidos entram nas contas",
           },
-          { label: "Refazer o caminho dos dados nos relatórios com problema", quality: "critical" },
+          { quality: "critical", text: "Refazer o caminho dos dados nos relatórios com problema" },
           {
-            label: "Comparar pedidos aprovados, bloqueados e não avaliados para achar um padrão",
             quality: "useful",
+            text: "Comparar pedidos aprovados, bloqueados e não avaliados para achar um padrão",
           },
-          { label: "Checar em que etapa os números passam a ficar sem sentido", quality: "useful" },
+          { quality: "useful", text: "Checar em que etapa os números passam a ficar sem sentido" },
           {
-            label: "Revisar as regras que escolhem quais pedidos vão para revisão",
             quality: "useful",
+            text: "Revisar as regras que escolhem quais pedidos vão para revisão",
           },
           {
-            label: "Olhar se houve mudança recente na troca de dados com outro sistema",
             quality: "weak",
+            text: "Olhar se houve mudança recente na troca de dados com outro sistema",
           },
         ],
       },
@@ -121,29 +121,28 @@ ${SHARED_EXPECTATIONS}
       actions: {
         actions: [
           {
-            label: "Revisar qué reactivo se usó y si era más fuerte de lo normal",
             quality: "critical",
+            text: "Revisar qué reactivo se usó y si era más fuerte de lo normal",
           },
           {
-            label: "Mirar en qué momento la mezcla debió parar y si siguió cambiando después",
             quality: "critical",
+            text: "Mirar en qué momento la mezcla debió parar y si siguió cambiando después",
           },
           {
-            label:
-              "Comparar los compuestos inesperados con los que aparecen cuando la reacción se pasa de largo",
             quality: "useful",
+            text: "Comparar los compuestos inesperados con los que aparecen cuando la reacción se pasa de largo",
           },
           {
-            label: "Revisar si la transformación podía ocurrir en más de un lugar de la molécula",
             quality: "useful",
+            text: "Revisar si la transformación podía ocurrir en más de un lugar de la molécula",
           },
           {
-            label: "Ver cómo se preparó el intermedio o paso previo en esta corrida",
             quality: "useful",
+            text: "Ver cómo se preparó el intermedio o paso previo en esta corrida",
           },
           {
-            label: "Comprobar si alguna materia prima venía con una impureza pequeña",
             quality: "weak",
+            text: "Comprobar si alguna materia prima venía con una impureza pequeña",
           },
         ],
       },
@@ -170,25 +169,25 @@ ${SHARED_EXPECTATIONS}
       actions: {
         actions: [
           {
-            label: "Compare this fall's sales trend with the rest of the market",
             quality: "critical",
+            text: "Compare this fall's sales trend with the rest of the market",
           },
           {
-            label: "Check whether older stores are dropping in the same pattern as the new ones",
             quality: "critical",
+            text: "Check whether older stores are dropping in the same pattern as the new ones",
           },
-          { label: "Review what made the first half unusually strong", quality: "useful" },
+          { quality: "useful", text: "Review what made the first half unusually strong" },
           {
-            label: "Look at competitor openings and promo activity in those cities",
             quality: "useful",
+            text: "Look at competitor openings and promo activity in those cities",
           },
           {
-            label: "Check if key products were out of stock when sales started falling",
             quality: "useful",
+            text: "Check if key products were out of stock when sales started falling",
           },
           {
-            label: "Walk through store layout and staffing at the weakest new locations",
             quality: "weak",
+            text: "Walk through store layout and staffing at the weakest new locations",
           },
         ],
       },
@@ -219,32 +218,28 @@ ${SHARED_EXPECTATIONS}
       actions: {
         actions: [
           {
-            label: "Ver por onde os pedidos problemáticos estão passando em cada etapa da compra",
             quality: "critical",
+            text: "Ver por onde os pedidos problemáticos estão passando em cada etapa da compra",
           },
           {
-            label:
-              "Comparar pedidos que deram certo com os que ficaram pela metade depois da mudança recente",
             quality: "critical",
+            text: "Comparar pedidos que deram certo com os que ficaram pela metade depois da mudança recente",
           },
           {
-            label:
-              "Revisar quando o caminho novo começou a receber pedidos e o que mudou nesse momento",
             quality: "useful",
+            text: "Revisar quando o caminho novo começou a receber pedidos e o que mudou nesse momento",
           },
           {
-            label:
-              "Checar se partes diferentes estão mostrando dados diferentes para o mesmo pedido ou cliente",
             quality: "useful",
+            text: "Checar se partes diferentes estão mostrando dados diferentes para o mesmo pedido ou cliente",
           },
           {
-            label:
-              "Observar se há acúmulo de espera ou travas na conversa entre as partes do sistema",
             quality: "useful",
+            text: "Observar se há acúmulo de espera ou travas na conversa entre as partes do sistema",
           },
           {
-            label: "Olhar o volume de acessos dos últimos dias para ver se houve pico de uso",
             quality: "weak",
+            text: "Olhar o volume de acessos dos últimos dias para ver se houve pico de uso",
           },
         ],
       },
@@ -271,33 +266,28 @@ ${SHARED_EXPECTATIONS}
       actions: {
         actions: [
           {
-            label:
-              "Check whether local labs had enough trained people to run production safely at full speed",
             quality: "critical",
+            text: "Check whether local labs had enough trained people to run production safely at full speed",
           },
           {
-            label:
-              "Look at whether the labs already had working step-by-step routines that could be repeated on a larger scale",
             quality: "critical",
+            text: "Look at whether the labs already had working step-by-step routines that could be repeated on a larger scale",
           },
           {
-            label:
-              "Review how much the country was relying on imported doses when outside shipments slowed down",
             quality: "useful",
+            text: "Review how much the country was relying on imported doses when outside shipments slowed down",
           },
           {
-            label:
-              "Trace how information and materials moved between research centers, factories, and clinics",
             quality: "useful",
+            text: "Trace how information and materials moved between research centers, factories, and clinics",
           },
           {
-            label:
-              "Compare planned dose output with what local facilities had actually produced before the outbreak",
             quality: "useful",
+            text: "Compare planned dose output with what local facilities had actually produced before the outbreak",
           },
           {
-            label: "Look over public arguments and purchasing delays between officials",
             quality: "weak",
+            text: "Look over public arguments and purchasing delays between officials",
           },
         ],
       },

--- a/apps/evals/src/tasks/activity-story-choices/test-cases.ts
+++ b/apps/evals/src/tasks/activity-story-choices/test-cases.ts
@@ -5,11 +5,11 @@ EVALUATION CRITERIA:
 
 2. CHOICE QUALITY: Every step must have 3-4 choices. Choices must be plausible next moves in the professional workflow, not opinions, lesson summaries, or app instructions.
 
-3. ANSWER MASKING: A learner who only sees the choice labels should not be able to identify the best or worst answer by tone, breadth, professionalism, or scope. Avoid giveaway wording like only, just, single, local, final, complete, broad, quick, minimal, ignore, or translated equivalents.
+3. ANSWER MASKING: A learner who only sees the choice text should not be able to identify the best or worst answer by tone, breadth, professionalism, or scope. Avoid giveaway wording like only, just, single, local, final, complete, broad, quick, minimal, ignore, or translated equivalents.
 
 4. DISTINCT STRATEGIES: Choices should pull different decision levers: evidence source, artifact, mechanism, workflow, timing, risk control, reversibility, or constraint. Do not make all choices near-paraphrases of the same meaning.
 
-5. ALIGNMENT MIX: Each step must include one strong choice, at least one partial choice, and at least one weak choice. The alignment tags must not be hinted at by the label wording.
+5. ALIGNMENT MIX: Each step must include one strong choice, at least one partial choice, and at least one weak choice. The alignment tags must not be hinted at by the text wording.
 
 6. CONSEQUENCE QUALITY: Consequences must show what happened after the action and, for weak or partial choices, point to the better practical next move. They should not become mini-lectures.
 

--- a/apps/main/e2e/lesson-completion.test.ts
+++ b/apps/main/e2e/lesson-completion.test.ts
@@ -56,8 +56,8 @@ async function createQuizActivity(lessonId: string, orgId: string, uniqueId: str
     content: {
       kind: "core",
       options: [
-        { feedback: "Correct!", isCorrect: true, text: `Right ${uniqueId}` },
-        { feedback: "Wrong", isCorrect: false, text: `Wrong ${uniqueId}` },
+        { feedback: "Correct!", id: "right", isCorrect: true, text: `Right ${uniqueId}` },
+        { feedback: "Wrong", id: "wrong", isCorrect: false, text: `Wrong ${uniqueId}` },
       ],
       question: `Question ${uniqueId}`,
     },

--- a/packages/ai/src/tasks/activities/core/activity-investigation-actions.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-investigation-actions.prompt.md
@@ -12,7 +12,7 @@ The learner has been presented with a mystery scenario and has chosen a hypothes
 
 ## What You Generate
 
-4-5 investigation actions, each with a label and quality tier.
+4-5 investigation actions, each with text and a quality tier.
 
 ## Action Rules
 
@@ -32,7 +32,7 @@ The learner has been presented with a mystery scenario and has chosen a hypothes
 
 ## Language
 
-Generate ALL content in the specified LANGUAGE. Never mix languages. Every action label must be in the specified language — no English words slipping into Portuguese or Spanish output. The only English in the output should be the JSON field names and enum values (like "critical", "useful", "weak").
+Generate ALL content in the specified LANGUAGE. Never mix languages. Every action text must be in the specified language — no English words slipping into Portuguese or Spanish output. The only English in the output should be the JSON field names and enum values (like "critical", "useful", "weak").
 
 - `en`: US English
 - `pt`: Brazilian Portuguese

--- a/packages/ai/src/tasks/activities/core/activity-investigation-actions.ts
+++ b/packages/ai/src/tasks/activities/core/activity-investigation-actions.ts
@@ -14,8 +14,8 @@ const schema = z.object({
   actions: z
     .array(
       z.object({
-        label: z.string(),
         quality: z.enum(["critical", "useful", "weak"]),
+        text: z.string(),
       }),
     )
     .min(INVESTIGATION_EXPERIMENT_COUNT),

--- a/packages/ai/src/tasks/activities/core/activity-investigation-findings.ts
+++ b/packages/ai/src/tasks/activities/core/activity-investigation-findings.ts
@@ -49,7 +49,7 @@ function formatInputsForPrompt({
     .join("\n");
 
   const actionList = actions.actions
-    .map((action, i) => `${i}. ${action.label} (${action.quality})`)
+    .map((action, i) => `${i}. ${action.text} (${action.quality})`)
     .join("\n");
 
   return `

--- a/packages/ai/src/tasks/activities/core/activity-story-choices.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-story-choices.prompt.md
@@ -103,7 +103,7 @@ Start from the real decision boundary:
 - What plausible evidence would solve a nearby but incomplete version of the problem?
 - What plausible evidence would a competent person reach for if they were focused on the wrong constraint?
 
-Then write text that hide those differences.
+Then write text that hides those differences.
 
 Use this pattern:
 
@@ -240,7 +240,7 @@ Choices:
 
 Before finalizing each step, run these tests:
 
-- Text-only test: If the learner saw only the choice text, could they likely pick the best answer by tone, breadth, scope, or professionalism? If yes, rewrite the labels.
+- Text-only test: If the learner saw only the choice text, could they likely pick the best answer by tone, breadth, scope, or professionalism? If yes, rewrite the text.
 - Completeness test: Is the strong choice the only one with multiple evidence sources or a more complete-sounding verb? If yes, make the decoys similarly specific.
 - Weakness test: Does the weak choice announce its limitation through words like "only", "local", "quick", "ignore", "simple", "basic", or equivalent meaning in the target language? If yes, rewrite it as a plausible but wrong professional move.
 - Mirror test: Does the strong choice merely repeat the key words from the problem? If yes, rewrite it as the concrete action that would produce that result.

--- a/packages/ai/src/tasks/activities/core/activity-story-choices.prompt.md
+++ b/packages/ai/src/tasks/activities/core/activity-story-choices.prompt.md
@@ -15,7 +15,7 @@ Each step has **3-4 choices**.
 
 Each choice has:
 
-- a **label**
+- **text** for the choice shown to the learner
 - a **consequence**
 - a **stateImagePrompt**
 - **metricEffects**
@@ -37,10 +37,10 @@ The player never sees the alignment tags.
 
 ## Length Limits
 
-| Element      | Max words | Max sentences |
-| ------------ | --------- | ------------- |
-| choice label | 10        | 1             |
-| consequence  | 30        | 2             |
+| Element     | Max words | Max sentences |
+| ----------- | --------- | ------------- |
+| choice text | 10        | 1             |
+| consequence | 30        | 2             |
 
 ## Choice Label Rules
 
@@ -83,15 +83,15 @@ Do not make weak choices jump to an unrelated subsystem, cosmetic layer, adminis
 Do not force choices into identical grammar if that makes them mean the same thing.
 Do not make choices differ mainly by scope words like local, regional, global, narrow, broad, current, complete, isolated, direct, or comprehensive.
 
-All choices in the same set must look similarly competent from the label alone.
+All choices in the same set must look similarly competent from the text alone.
 The learner should need the problem, image, and consequence to know which one fits.
 
-- Do not make the strong choice the only label that compares, cross-checks, validates, integrates, or uses multiple inputs.
+- Do not make the strong choice the only text that compares, cross-checks, validates, integrates, or uses multiple inputs.
 - Do not make the weak choice a refusal, shortcut, delay, obvious patch, or visibly smaller version of the strong choice.
 - Do not make weak choices fail by sounding lazy. Make them fail because they use the wrong evidence, wrong baseline, wrong timing, wrong unit, wrong threshold, wrong artifact, wrong causal direction, or wrong constraint for this specific situation.
 - If the strong choice uses a real domain term, give the partial and weak choices equally authentic domain terms.
 - If the strong choice names two or three evidence sources, the other choices should have comparable specificity, not one-word or obviously incomplete labels.
-- Do not make the correct label the longest, broadest, most polished, or most senior-sounding option by default.
+- Do not make the correct text the longest, broadest, most polished, or most senior-sounding option by default.
 
 ## Choice Set Construction
 
@@ -103,7 +103,7 @@ Start from the real decision boundary:
 - What plausible evidence would solve a nearby but incomplete version of the problem?
 - What plausible evidence would a competent person reach for if they were focused on the wrong constraint?
 
-Then write labels that hide those differences.
+Then write text that hide those differences.
 
 Use this pattern:
 
@@ -111,14 +111,14 @@ Use this pattern:
 - `partial`: concrete action or artifact that helps but leaves a named gap.
 - `weak`: concrete action or artifact that sounds reasonable but targets the wrong part of the case.
 
-The weak label should still be something a real teammate might suggest before the consequence reveals why it misses.
+The weak text should still be something a real teammate might suggest before the consequence reveals why it misses.
 
 ## Specific Competing Actions
 
-Choice labels should sound like clear instructions one competent colleague could give another.
-Do not hide the answer by making labels vague.
+Choice text should sound like clear instructions one competent colleague could give another.
+Do not hide the answer by making text vague.
 
-Each label should make the next move concrete:
+Each text should make the next move concrete:
 
 - what to change
 - what to compare
@@ -130,7 +130,7 @@ Each label should make the next move concrete:
 - what to test
 - what source to trust
 
-Avoid labels that only say:
+Avoid text that only say:
 
 - "review X"
 - "inspect X"
@@ -138,7 +138,7 @@ Avoid labels that only say:
 - "adjust X"
 - "check X"
 
-unless the label also says what about X is being reviewed, fixed, adjusted, or checked.
+unless the text also says what about X is being reviewed, fixed, adjusted, or checked.
 
 The strong choice may use precise professional language, including the property or constraint that matters, if that is how people in that role would naturally say the action.
 
@@ -149,26 +149,26 @@ The important rule is symmetry:
 - If the strong choice names a field, measurement, source, or artifact, the partial and weak choices must be equally concrete.
 - Do not make the correct choice the only one that sounds actionable.
 
-Partial and weak labels should be wrong because they apply a plausible action to the wrong field, source, timing, threshold, unit, layer, or constraint.
+Partial and weak texts should be wrong because they apply a plausible action to the wrong field, source, timing, threshold, unit, layer, or constraint.
 They should not be wrong because they are vague.
 
 ## Answer Masking
 
-The label must not reveal the alignment.
-A learner who sees only the choice labels, without the problem or image, should not be able to identify the strong or weak choice.
+The text must not reveal the alignment.
+A learner who sees only the choice text, without the problem or image, should not be able to identify the strong or weak choice.
 
 Weak choices should name a plausible evidence source or action, not its limitation.
 Partial choices should name a useful strategy, not the fact that it is incomplete.
 Strong choices should name the concrete evidence or action that solves the problem, not the lesson-shaped goal.
 
-A choice label should not paraphrase the problem's requested outcome.
+A choice text should not paraphrase the problem's requested outcome.
 
 If the problem already names the desired property, relationship, category, scale, or diagnostic direction, do not make the strong choice simply repeat that wording.
 Turn it into a specific action in the work surface.
 
 If the problem already leaks the concept, scale, or desired outcome, the choices must become competing concrete actions, not concept labels.
 
-Do not make the strong choice the only label that contains the key conceptual property.
+Do not make the strong choice the only text that contains the key conceptual property.
 If that property must appear because it is the natural professional fix, make the other choices similarly precise and plausible.
 
 If a learner could pick the strong choice by recognizing the lesson topic instead of reading the case evidence, rewrite the whole choice set so every option sounds like a specific, credible fix.
@@ -218,7 +218,7 @@ A weak choice can be wrong because it checks:
 
 Do not make the weak choice wrong because it is obviously careless, unrelated, or superficial.
 
-If the weak label sounds like no competent teammate would suggest it, rewrite it.
+If the weak text sounds like no competent teammate would suggest it, rewrite it.
 
 Bad:
 
@@ -240,14 +240,14 @@ Choices:
 
 Before finalizing each step, run these tests:
 
-- Label-only test: If the learner saw only the choice labels, could they likely pick the best answer by tone, breadth, scope, or professionalism? If yes, rewrite the labels.
+- Text-only test: If the learner saw only the choice text, could they likely pick the best answer by tone, breadth, scope, or professionalism? If yes, rewrite the labels.
 - Completeness test: Is the strong choice the only one with multiple evidence sources or a more complete-sounding verb? If yes, make the decoys similarly specific.
 - Weakness test: Does the weak choice announce its limitation through words like "only", "local", "quick", "ignore", "simple", "basic", or equivalent meaning in the target language? If yes, rewrite it as a plausible but wrong professional move.
 - Mirror test: Does the strong choice merely repeat the key words from the problem? If yes, rewrite it as the concrete action that would produce that result.
 - Concept test: Would the strong choice be obvious to someone who merely recognizes the lesson concept name? If yes, make every option a similarly specific competing fix so the case evidence decides.
 - Work-surface test: Do all choices belong to the same plausible subsystem or evidence surface? If not, rewrite the outlier.
 - Near-miss test: Would the weak choice fix a plausible neighboring issue? If not, rewrite it as a better near miss.
-- Vague-label test: Could someone ask "what exactly do you want me to change or check?" after reading a label? If yes, make the label more specific.
+- Vague-text test: Could someone ask "what exactly do you want me to change or check?" after reading the text? If yes, make the text more specific.
 
 ## Consequence Rules
 

--- a/packages/ai/src/tasks/activities/core/activity-story-schemas.ts
+++ b/packages/ai/src/tasks/activities/core/activity-story-schemas.ts
@@ -21,9 +21,9 @@ const storyOutcomeSchemaShape = {
 const storyChoiceSchema = z.object({
   alignment: storyAlignmentSchema,
   consequence: z.string(),
-  label: z.string(),
   metricEffects: z.array(z.object({ effect: storyMetricEffectSchema, metric: z.string() })).min(1),
   stateImagePrompt: z.string().min(1),
+  text: z.string(),
 });
 
 const storyStepPlanSchema = z.object({

--- a/packages/core/src/player/commands/submit-activity-completion.test.ts
+++ b/packages/core/src/player/commands/submit-activity-completion.test.ts
@@ -25,7 +25,7 @@ describe(submitActivityCompletion, () => {
 
   function stepResult(isCorrect: boolean) {
     return {
-      answer: { kind: "multipleChoice", selectedIndex: 0 },
+      answer: { kind: "multipleChoice", selectedOptionId: "a" },
       answeredAt: new Date(),
       dayOfWeek: 1,
       durationSeconds: 5,
@@ -53,8 +53,8 @@ describe(submitActivityCompletion, () => {
       content: {
         kind: "core",
         options: [
-          { feedback: "Correct!", isCorrect: true, text: "A" },
-          { feedback: "Wrong.", isCorrect: false, text: "B" },
+          { feedback: "Correct!", id: "a", isCorrect: true, text: "A" },
+          { feedback: "Wrong.", id: "b", isCorrect: false, text: "B" },
         ],
       },
       kind: "multipleChoice",

--- a/packages/core/src/player/commands/submit-player-completion.test.ts
+++ b/packages/core/src/player/commands/submit-player-completion.test.ts
@@ -64,8 +64,8 @@ async function createMultipleChoiceActivity(params: {
     content: {
       kind: "core",
       options: [
-        { feedback: "Correct!", isCorrect: true, text: "A" },
-        { feedback: "Wrong.", isCorrect: false, text: "B" },
+        { feedback: "Correct!", id: "a", isCorrect: true, text: "A" },
+        { feedback: "Wrong.", id: "b", isCorrect: false, text: "B" },
       ],
       question: "Choose",
     },
@@ -83,8 +83,7 @@ async function createMultipleChoiceActivity(params: {
  */
 function buildCompletionInput(params: {
   activityId: string;
-  selectedIndex?: number;
-  selectedText?: string;
+  selectedOptionId?: string;
   startedAt?: number;
   stepId: string;
 }): CompletionInput {
@@ -96,8 +95,7 @@ function buildCompletionInput(params: {
     answers: {
       [stepId]: {
         kind: "multipleChoice",
-        selectedIndex: params.selectedIndex ?? 0,
-        selectedText: params.selectedText ?? "A",
+        selectedOptionId: params.selectedOptionId ?? "a",
       },
     },
     localDate: todayLocalDate(),

--- a/packages/core/src/player/contracts/build-investigation-action-results.test.ts
+++ b/packages/core/src/player/contracts/build-investigation-action-results.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, test } from "vitest";
 import { buildInvestigationActionResults } from "./build-investigation-action-results";
 
 const actionContent = {
-  actions: [
-    { finding: "Critical evidence", id: "a1", label: "Check logs", quality: "critical" as const },
-    { finding: "Useful data", id: "a2", label: "Review metrics", quality: "useful" as const },
-    { finding: "Nothing here", id: "a3", label: "Random check", quality: "weak" as const },
+  options: [
+    { feedback: "Critical evidence", id: "a1", quality: "critical" as const, text: "Check logs" },
+    { feedback: "Useful data", id: "a2", quality: "useful" as const, text: "Review metrics" },
+    { feedback: "Nothing here", id: "a3", quality: "weak" as const, text: "Random check" },
   ],
   variant: "action" as const,
 };
@@ -22,7 +22,7 @@ describe(buildInvestigationActionResults, () => {
     const results = buildInvestigationActionResults({
       investigationLoop: {
         actionTimings: [baseTiming, baseTiming],
-        usedActionIds: ["a1", "a3"],
+        usedOptionIds: ["a1", "a3"],
       },
       steps: [{ content: actionContent, id: "100", kind: "investigation" }],
     });
@@ -36,7 +36,7 @@ describe(buildInvestigationActionResults, () => {
     const results = buildInvestigationActionResults({
       investigationLoop: {
         actionTimings: [baseTiming, baseTiming],
-        usedActionIds: ["a1", "a2"],
+        usedOptionIds: ["a1", "a2"],
       },
       steps: [{ content: actionContent, id: "42", kind: "investigation" }],
     });
@@ -53,7 +53,7 @@ describe(buildInvestigationActionResults, () => {
     const results = buildInvestigationActionResults({
       investigationLoop: {
         actionTimings: timings,
-        usedActionIds: ["a1", "a2"],
+        usedOptionIds: ["a1", "a2"],
       },
       steps: [{ content: actionContent, id: "1", kind: "investigation" }],
     });
@@ -62,23 +62,23 @@ describe(buildInvestigationActionResults, () => {
     expect(results[1]?.durationSeconds).toBe(8);
   });
 
-  test("stores selectedActionId in the answer", () => {
+  test("stores selectedOptionId in the answer", () => {
     const results = buildInvestigationActionResults({
       investigationLoop: {
         actionTimings: [baseTiming, baseTiming],
-        usedActionIds: ["a3", "a1"],
+        usedOptionIds: ["a3", "a1"],
       },
       steps: [{ content: actionContent, id: "1", kind: "investigation" }],
     });
 
     expect(results[0]?.answer).toEqual({
       kind: "investigation",
-      selectedActionId: "a3",
+      selectedOptionId: "a3",
       variant: "action",
     });
     expect(results[1]?.answer).toEqual({
       kind: "investigation",
-      selectedActionId: "a1",
+      selectedOptionId: "a1",
       variant: "action",
     });
   });
@@ -96,7 +96,7 @@ describe(buildInvestigationActionResults, () => {
     const results = buildInvestigationActionResults({
       investigationLoop: {
         actionTimings: [baseTiming],
-        usedActionIds: ["a1"],
+        usedOptionIds: ["a1"],
       },
       steps: [
         {
@@ -110,11 +110,11 @@ describe(buildInvestigationActionResults, () => {
     expect(results).toEqual([]);
   });
 
-  test("skips entries where actionTimings and usedActionIds are mismatched", () => {
+  test("skips entries where actionTimings and usedOptionIds are mismatched", () => {
     const results = buildInvestigationActionResults({
       investigationLoop: {
         actionTimings: [baseTiming], // Only 1 timing
-        usedActionIds: ["a1", "a2", "a3"], // 3 IDs
+        usedOptionIds: ["a1", "a2", "a3"], // 3 IDs
       },
       steps: [{ content: actionContent, id: "1", kind: "investigation" }],
     });
@@ -123,11 +123,11 @@ describe(buildInvestigationActionResults, () => {
     expect(results[0]?.isCorrect).toBe(true); // critical
   });
 
-  test("returns empty array when usedActionIds is empty", () => {
+  test("returns empty array when usedOptionIds is empty", () => {
     const results = buildInvestigationActionResults({
       investigationLoop: {
         actionTimings: [],
-        usedActionIds: [],
+        usedOptionIds: [],
       },
       steps: [{ content: actionContent, id: "1", kind: "investigation" }],
     });

--- a/packages/core/src/player/contracts/build-investigation-action-results.ts
+++ b/packages/core/src/player/contracts/build-investigation-action-results.ts
@@ -52,8 +52,8 @@ export function buildInvestigationActionResults({
     return [];
   }
 
-  return investigationLoop.usedActionIds.flatMap((actionId, i) => {
-    const action = actionContent.actions.find((a) => a.id === actionId);
+  return investigationLoop.usedOptionIds.flatMap((actionId, i) => {
+    const action = actionContent.options.find((a) => a.id === actionId);
     const timing = investigationLoop.actionTimings[i];
 
     if (!action || !timing) {
@@ -64,7 +64,7 @@ export function buildInvestigationActionResults({
       {
         answer: {
           kind: "investigation" as const,
-          selectedActionId: actionId,
+          selectedOptionId: actionId,
           variant: "action" as const,
         },
         answeredAt: new Date(timing.answeredAt),

--- a/packages/core/src/player/contracts/check-answer.test.ts
+++ b/packages/core/src/player/contracts/check-answer.test.ts
@@ -23,29 +23,29 @@ describe(checkMultipleChoiceAnswer, () => {
     const content: MultipleChoiceStepContent = {
       kind: "core",
       options: [
-        { feedback: "Correct!", isCorrect: true, text: "A" },
-        { feedback: "Wrong.", isCorrect: false, text: "B" },
+        { feedback: "Correct!", id: "a", isCorrect: true, text: "A" },
+        { feedback: "Wrong.", id: "b", isCorrect: false, text: "B" },
       ],
     };
 
-    test("returns correct with feedback for correct index", () => {
-      expect(checkMultipleChoiceAnswer(content, 0)).toEqual({
+    test("returns correct with feedback for correct text", () => {
+      expect(checkMultipleChoiceAnswer(content, "a")).toEqual({
         correctAnswer: "A",
         feedback: "Correct!",
         isCorrect: true,
       });
     });
 
-    test("returns incorrect with feedback for wrong index", () => {
-      expect(checkMultipleChoiceAnswer(content, 1)).toEqual({
+    test("returns incorrect with feedback for wrong text", () => {
+      expect(checkMultipleChoiceAnswer(content, "b")).toEqual({
         correctAnswer: "A",
         feedback: "Wrong.",
         isCorrect: false,
       });
     });
 
-    test("returns incorrect with null feedback for out-of-bounds index", () => {
-      expect(checkMultipleChoiceAnswer(content, 5)).toEqual({
+    test("returns incorrect with null feedback for unknown text", () => {
+      expect(checkMultipleChoiceAnswer(content, "missing")).toEqual({
         correctAnswer: "A",
         feedback: null,
         isCorrect: false,
@@ -228,30 +228,30 @@ describe(checkSortOrderAnswer, () => {
 describe(checkSelectImageAnswer, () => {
   const content: SelectImageStepContent = {
     options: [
-      { feedback: "Yes, a cat!", isCorrect: true, prompt: "A cat" },
-      { feedback: "That's a dog.", isCorrect: false, prompt: "A dog" },
+      { feedback: "Yes, a cat!", id: "cat", isCorrect: true, prompt: "A cat" },
+      { feedback: "That's a dog.", id: "dog", isCorrect: false, prompt: "A dog" },
     ],
     question: "Which image shows a cat?",
   };
 
-  test("returns correct with feedback for correct index", () => {
-    expect(checkSelectImageAnswer(content, 0)).toEqual({
+  test("returns correct with feedback for correct option id", () => {
+    expect(checkSelectImageAnswer(content, "cat")).toEqual({
       correctAnswer: null,
       feedback: "Yes, a cat!",
       isCorrect: true,
     });
   });
 
-  test("returns incorrect with feedback for wrong index", () => {
-    expect(checkSelectImageAnswer(content, 1)).toEqual({
+  test("returns incorrect with feedback for wrong option id", () => {
+    expect(checkSelectImageAnswer(content, "dog")).toEqual({
       correctAnswer: null,
       feedback: "That's a dog.",
       isCorrect: false,
     });
   });
 
-  test("returns incorrect with null feedback for out-of-bounds index", () => {
-    expect(checkSelectImageAnswer(content, 99)).toEqual({
+  test("returns incorrect with null feedback for unknown option id", () => {
+    expect(checkSelectImageAnswer(content, "missing")).toEqual({
       correctAnswer: null,
       feedback: null,
       isCorrect: false,
@@ -279,10 +279,10 @@ describe(checkTranslationAnswer, () => {
 
 describe(checkStoryAnswer, () => {
   const content = {
-    choices: [
+    options: [
       {
         alignment: "strong" as const,
-        consequence: "Things improve.",
+        feedback: "Things improve.",
         id: "1a",
         metricEffects: [{ effect: "positive" as const, metric: "Production" }],
         stateImage: { prompt: "State after the strong choice" },
@@ -290,7 +290,7 @@ describe(checkStoryAnswer, () => {
       },
       {
         alignment: "partial" as const,
-        consequence: "Mixed results.",
+        feedback: "Mixed results.",
         id: "1b",
         metricEffects: [{ effect: "neutral" as const, metric: "Production" }],
         stateImage: { prompt: "State after the partial choice" },
@@ -298,7 +298,7 @@ describe(checkStoryAnswer, () => {
       },
       {
         alignment: "weak" as const,
-        consequence: "Things get worse.",
+        feedback: "Things get worse.",
         id: "1c",
         metricEffects: [{ effect: "negative" as const, metric: "Production" }],
         stateImage: { prompt: "State after the weak choice" },
@@ -308,7 +308,7 @@ describe(checkStoryAnswer, () => {
     problem: "You face a decision.",
   };
 
-  test("strong alignment is correct with consequence as feedback", () => {
+  test("strong alignment is correct with feedback text", () => {
     expect(checkStoryAnswer(content, "1a")).toEqual({
       correctAnswer: null,
       feedback: "Things improve.",
@@ -316,7 +316,7 @@ describe(checkStoryAnswer, () => {
     });
   });
 
-  test("partial alignment is correct with consequence as feedback", () => {
+  test("partial alignment is correct with feedback text", () => {
     expect(checkStoryAnswer(content, "1b")).toEqual({
       correctAnswer: null,
       feedback: "Mixed results.",
@@ -324,7 +324,7 @@ describe(checkStoryAnswer, () => {
     });
   });
 
-  test("weak alignment is incorrect with consequence as feedback", () => {
+  test("weak alignment is incorrect with feedback text", () => {
     expect(checkStoryAnswer(content, "1c")).toEqual({
       correctAnswer: null,
       feedback: "Things get worse.",
@@ -332,7 +332,7 @@ describe(checkStoryAnswer, () => {
     });
   });
 
-  test("unknown choice ID is incorrect with null feedback", () => {
+  test("unknown option ID is incorrect with null feedback", () => {
     expect(checkStoryAnswer(content, "unknown")).toEqual({
       correctAnswer: null,
       feedback: null,

--- a/packages/core/src/player/contracts/check-answer.ts
+++ b/packages/core/src/player/contracts/check-answer.ts
@@ -17,13 +17,15 @@ export type AnswerResult = {
 
 export function checkMultipleChoiceAnswer(
   content: MultipleChoiceStepContent,
-  selectedIndex: number,
+  selectedOptionId: string,
 ): AnswerResult {
   const correctAnswer = content.options.find((opt) => opt.isCorrect)?.text ?? null;
-  const option = content.options[selectedIndex];
+  const option = content.options.find((item) => item.id === selectedOptionId);
+
   if (!option) {
     return { correctAnswer, feedback: null, isCorrect: false };
   }
+
   return { correctAnswer, feedback: option.feedback, isCorrect: option.isCorrect };
 }
 
@@ -74,42 +76,45 @@ export function checkSortOrderAnswer(
 
 export function checkSelectImageAnswer(
   content: SelectImageStepContent,
-  selectedIndex: number,
+  selectedOptionId: string,
 ): AnswerResult {
-  const option = content.options[selectedIndex];
+  const option = content.options.find((item) => item.id === selectedOptionId);
+
   if (!option) {
     return { correctAnswer: null, feedback: null, isCorrect: false };
   }
+
   return { correctAnswer: null, feedback: option.feedback, isCorrect: option.isCorrect };
 }
 
 export function checkTranslationAnswer(
   correctWordId: string,
-  selectedWordId: string,
+  selectedOptionId: string,
   correctWord?: string,
 ): AnswerResult {
   return {
     correctAnswer: correctWord ?? null,
     feedback: null,
-    isCorrect: correctWordId === selectedWordId,
+    isCorrect: correctWordId === selectedOptionId,
   };
 }
 
 /**
- * Check a story answer by looking up the selected choice's alignment.
+ * Check a story answer by looking up the selected option's alignment.
  *
  * Alignment is hidden from the player during play, but determines correctness
  * for analytics/metrics: strong and partial count as correct, weak as incorrect.
- * The choice's consequence text is returned as feedback for display on the
- * feedback screen — it describes what happens as a result of the player's decision.
+ * The option's feedback text describes what happens as a result of the player's
+ * decision and is returned for display on the feedback screen.
  */
 export function checkStoryAnswer(
   content: StoryStepContent,
-  selectedChoiceId: string,
+  selectedOptionId: string,
 ): AnswerResult {
-  const choice = content.choices.find((option) => option.id === selectedChoiceId);
-  const isCorrect = choice ? choice.alignment !== "weak" : false;
-  return { correctAnswer: null, feedback: choice?.consequence ?? null, isCorrect };
+  const option = content.options.find((item) => item.id === selectedOptionId);
+  const isCorrect = option ? option.alignment !== "weak" : false;
+
+  return { correctAnswer: null, feedback: option?.feedback ?? null, isCorrect };
 }
 
 export function checkArrangeWordsAnswer(
@@ -125,20 +130,20 @@ export function checkArrangeWordsAnswer(
  *
  * Critical and useful actions are correct (strong evidence choices).
  * Weak actions are incorrect (poor investigation decisions).
- * Returns the finding text as feedback so the evidence can be shown
+ * Returns the option feedback so the evidence can be shown
  * after checking.
  */
 export function checkInvestigationAction(
   content: Extract<InvestigationStepContent, { variant: "action" }>,
-  selectedActionId: string,
+  selectedOptionId: string,
 ): AnswerResult {
-  const action = content.actions.find((a) => a.id === selectedActionId);
+  const action = content.options.find((a) => a.id === selectedOptionId);
 
   if (!action) {
     return { correctAnswer: null, feedback: null, isCorrect: false };
   }
 
-  return { correctAnswer: null, feedback: action.finding, isCorrect: action.quality !== "weak" };
+  return { correctAnswer: null, feedback: action.feedback, isCorrect: action.quality !== "weak" };
 }
 
 /**
@@ -152,9 +157,9 @@ export function checkInvestigationAction(
  */
 export function checkInvestigationCall(
   content: Extract<InvestigationStepContent, { variant: "call" }>,
-  selectedExplanationId: string,
+  selectedOptionId: string,
 ): AnswerResult {
-  const explanation = content.explanations.find((exp) => exp.id === selectedExplanationId);
+  const explanation = content.options.find((exp) => exp.id === selectedOptionId);
 
   if (!explanation) {
     return { correctAnswer: null, feedback: null, isCorrect: false };

--- a/packages/core/src/player/contracts/completion-input-schema.ts
+++ b/packages/core/src/player/contracts/completion-input-schema.ts
@@ -22,8 +22,7 @@ const matchColumnsAnswerSchema = z.object({
 
 const multipleChoiceAnswerSchema = z.object({
   kind: z.literal("multipleChoice"),
-  selectedIndex: z.number(),
-  selectedText: z.string(),
+  selectedOptionId: z.string(),
 });
 
 const readingAnswerSchema = z.object({
@@ -33,7 +32,7 @@ const readingAnswerSchema = z.object({
 
 const selectImageAnswerSchema = z.object({
   kind: z.literal("selectImage"),
-  selectedIndex: z.number(),
+  selectedOptionId: z.string(),
 });
 
 const sortOrderAnswerSchema = z.object({
@@ -43,15 +42,12 @@ const sortOrderAnswerSchema = z.object({
 
 const storyAnswerSchema = z.object({
   kind: z.literal("story"),
-  selectedChoiceId: z.string(),
-  selectedText: z.string(),
+  selectedOptionId: z.string(),
 });
 
 const translationAnswerSchema = z.object({
   kind: z.literal("translation"),
-  questionText: z.string(),
-  selectedText: z.string(),
-  selectedWordId: z.string(),
+  selectedOptionId: z.string(),
 });
 
 const investigationProblemAnswerSchema = z.object({
@@ -61,13 +57,13 @@ const investigationProblemAnswerSchema = z.object({
 
 const investigationActionAnswerSchema = z.object({
   kind: z.literal("investigation"),
-  selectedActionId: z.string(),
+  selectedOptionId: z.string(),
   variant: z.literal("action"),
 });
 
 const investigationCallAnswerSchema = z.object({
   kind: z.literal("investigation"),
-  selectedExplanationId: z.string(),
+  selectedOptionId: z.string(),
   variant: z.literal("call"),
 });
 
@@ -107,7 +103,7 @@ const stepTimingSchema = z.object({
  */
 const investigationLoopSchema = z.object({
   actionTimings: z.array(stepTimingSchema).default([]),
-  usedActionIds: z.array(z.string()),
+  usedOptionIds: z.array(z.string()),
 });
 
 export const completionInputSchema = z.object({

--- a/packages/core/src/player/contracts/compute-score.test.ts
+++ b/packages/core/src/player/contracts/compute-score.test.ts
@@ -229,7 +229,7 @@ describe("computeActivityScore (investigation)", () => {
     });
   });
 
-  test("mixed actions: critical + useful + best call = 3/3 correct, +9 energy", () => {
+  test("mixed options: critical + useful + best call = 3/3 correct, +9 energy", () => {
     const result = computeActivityScore({
       investigation: {
         actionQualities: ["critical", "useful"],
@@ -313,17 +313,15 @@ describe(buildScoringInput, () => {
   test("returns story input when activity has story steps and answers", () => {
     const result = buildScoringInput({
       activityKind: "story",
-      answers: {
-        "1": { kind: "story", selectedChoiceId: "c1", selectedText: "Strong choice" },
-      },
+      answers: { "1": { kind: "story", selectedOptionId: "c1" } },
       stepResults: [],
       steps: [
         {
           content: {
-            choices: [
+            options: [
               {
                 alignment: "strong",
-                consequence: "Good",
+                feedback: "Good",
                 id: "c1",
                 metricEffects: [],
                 stateImage: { prompt: "State after the strong choice" },
@@ -331,7 +329,7 @@ describe(buildScoringInput, () => {
               },
               {
                 alignment: "weak",
-                consequence: "Bad",
+                feedback: "Bad",
                 id: "c2",
                 metricEffects: [],
                 stateImage: { prompt: "State after the weak choice" },
@@ -357,25 +355,25 @@ describe(buildScoringInput, () => {
     const result = buildScoringInput({
       activityKind: "investigation",
       answers: {
-        "call-1": { kind: "investigation", selectedExplanationId: "e1", variant: "call" },
+        "call-1": { kind: "investigation", selectedOptionId: "e1", variant: "call" },
       },
       investigationLoop: {
         actionTimings: [],
-        usedActionIds: ["a1"],
+        usedOptionIds: ["a1"],
       },
       stepResults: [],
       steps: [
         {
           content: {
-            actions: [
+            options: [
               {
-                finding: "Logs show memory climbing",
+                feedback: "Logs show memory climbing",
                 id: "a1",
-                label: "Check logs",
                 quality: "critical",
+                text: "Check logs",
               },
-              { finding: "Filler", id: "a2", label: "Filler 1", quality: "useful" },
-              { finding: "Filler", id: "a3", label: "Filler 2", quality: "weak" },
+              { feedback: "Filler", id: "a2", quality: "useful", text: "Filler 1" },
+              { feedback: "Filler", id: "a3", quality: "weak", text: "Filler 2" },
             ],
             variant: "action",
           },
@@ -384,7 +382,7 @@ describe(buildScoringInput, () => {
         },
         {
           content: {
-            explanations: [
+            options: [
               { accuracy: "best", feedback: "Correct!", id: "e1", text: "Memory leak" },
               { accuracy: "wrong", feedback: "Incorrect.", id: "e2", text: "Network" },
             ],
@@ -423,10 +421,10 @@ describe(buildScoringInput, () => {
       steps: [
         {
           content: {
-            choices: [
+            options: [
               {
                 alignment: "strong",
-                consequence: "Good",
+                feedback: "Good",
                 id: "c1",
                 metricEffects: [],
                 stateImage: { prompt: "State after the strong choice" },
@@ -434,7 +432,7 @@ describe(buildScoringInput, () => {
               },
               {
                 alignment: "weak",
-                consequence: "Bad",
+                feedback: "Bad",
                 id: "c2",
                 metricEffects: [],
                 stateImage: { prompt: "State after the weak choice" },

--- a/packages/core/src/player/contracts/compute-score.ts
+++ b/packages/core/src/player/contracts/compute-score.ts
@@ -192,9 +192,9 @@ function extractStoryAlignments({
     }
 
     const content = parseStepContent("story", step.content);
-    const choice = content.choices.find((option) => option.id === answer.selectedChoiceId);
+    const option = content.options.find((item) => item.id === answer.selectedOptionId);
 
-    return choice ? [choice.alignment] : [];
+    return option ? [option.alignment] : [];
   });
 }
 
@@ -236,8 +236,8 @@ function extractInvestigationInput({
     return null;
   }
 
-  const actionQualities = investigationLoop.usedActionIds.flatMap((id) => {
-    const action = actionContent.actions.find((a) => a.id === id);
+  const actionQualities = investigationLoop.usedOptionIds.flatMap((id) => {
+    const action = actionContent.options.find((a) => a.id === id);
     return action ? [action.quality] : [];
   });
 
@@ -266,8 +266,8 @@ function extractInvestigationInput({
     return null;
   }
 
-  const selectedExplanation = callContent.explanations.find(
-    (exp) => exp.id === callAnswer.selectedExplanationId,
+  const selectedExplanation = callContent.options.find(
+    (exp) => exp.id === callAnswer.selectedOptionId,
   );
 
   if (!selectedExplanation) {

--- a/packages/core/src/player/contracts/prepare-activity-data.test.ts
+++ b/packages/core/src/player/contracts/prepare-activity-data.test.ts
@@ -438,8 +438,8 @@ describe(prepareLessonActivityData, () => {
           content: {
             kind: "core",
             options: [
-              { feedback: "Yes", isCorrect: true, text: "Alpha" },
-              { feedback: "No", isCorrect: false, text: "Beta" },
+              { feedback: "Yes", id: "alpha", isCorrect: true, text: "Alpha" },
+              { feedback: "No", id: "beta", isCorrect: false, text: "Beta" },
             ],
             question: "Pick one",
           },
@@ -452,8 +452,8 @@ describe(prepareLessonActivityData, () => {
     expect(result.steps[0]?.content).toEqual({
       kind: "core",
       options: [
-        { feedback: "Yes", isCorrect: true, text: "Alpha" },
-        { feedback: "No", isCorrect: false, text: "Beta" },
+        { feedback: "Yes", id: "alpha", isCorrect: true, text: "Alpha" },
+        { feedback: "No", id: "beta", isCorrect: false, text: "Beta" },
       ],
       question: "Pick one",
     });
@@ -466,10 +466,10 @@ describe(prepareLessonActivityData, () => {
       activity: makeActivity([
         makeStep({
           content: {
-            choices: [
+            options: [
               {
                 alignment: "strong",
-                consequence: "Best outcome",
+                feedback: "Best outcome",
                 id: "choice-1",
                 metricEffects: [{ effect: "positive", metric: "Trust" }],
                 stateImage: { prompt: "Best outcome state" },
@@ -477,7 +477,7 @@ describe(prepareLessonActivityData, () => {
               },
               {
                 alignment: "partial",
-                consequence: "Mixed outcome",
+                feedback: "Mixed outcome",
                 id: "choice-2",
                 metricEffects: [{ effect: "neutral", metric: "Trust" }],
                 stateImage: { prompt: "Mixed outcome state" },
@@ -485,7 +485,7 @@ describe(prepareLessonActivityData, () => {
               },
               {
                 alignment: "weak",
-                consequence: "Worst outcome",
+                feedback: "Worst outcome",
                 id: "choice-3",
                 metricEffects: [{ effect: "negative", metric: "Trust" }],
                 stateImage: { prompt: "Worst outcome state" },
@@ -510,7 +510,51 @@ describe(prepareLessonActivityData, () => {
 
     const storyContent = parseStepContent("story", storyStep.content);
 
-    expect(storyContent.choices.map(({ id }) => id)).toEqual(["choice-3", "choice-2", "choice-1"]);
+    expect(storyContent.options.map(({ id }) => id)).toEqual(["choice-3", "choice-2", "choice-1"]);
+  });
+
+  test("shuffles select image options during serialization", () => {
+    shuffleMock.mockImplementationOnce((items) => items.toReversed());
+
+    const result = prepare({
+      activity: makeActivity([
+        makeStep({
+          content: {
+            options: [
+              {
+                feedback: "Correct",
+                id: "image-1",
+                isCorrect: true,
+                prompt: "Alpha",
+                url: "/alpha.png",
+              },
+              {
+                feedback: "Wrong",
+                id: "image-2",
+                isCorrect: false,
+                prompt: "Beta",
+                url: "/beta.png",
+              },
+            ],
+            question: "Pick the matching image",
+          },
+          id: "32",
+          kind: "selectImage",
+        }),
+      ]),
+    });
+
+    const selectImageStep = result.steps[0];
+
+    expect(selectImageStep?.kind).toBe("selectImage");
+
+    if (selectImageStep?.kind !== "selectImage") {
+      return;
+    }
+
+    const selectImageContent = parseStepContent("selectImage", selectImageStep.content);
+
+    expect(selectImageContent.options.map(({ id }) => id)).toEqual(["image-2", "image-1"]);
   });
 
   test("builds reading and listening word banks from stored distractors only", () => {

--- a/packages/core/src/player/contracts/prepare-activity-data.ts
+++ b/packages/core/src/player/contracts/prepare-activity-data.ts
@@ -1,5 +1,6 @@
 import {
   type ActivityKind,
+  type InvestigationStepContent,
   type StepContentByKind,
   type SupportedStepKind,
   isSupportedStepKind,
@@ -107,6 +108,10 @@ type PrepareLessonActivityInput = {
   steps?: ActivityStepInput[];
 };
 
+type OptionsContent = {
+  options: readonly unknown[];
+};
+
 /**
  * Canonical lesson words travel through the player with lesson-scoped translations and
  * distractor arrays. This serializer keeps string IDs stable and copies arrays defensively.
@@ -149,39 +154,47 @@ function serializeSentence(sentence: SentenceDataInput): SerializedSentence {
 }
 
 /**
+ * Option-based activity payloads share the same stored field name, so the
+ * serializer can randomize them without repeating object-copying code.
+ */
+function shuffleOptions<Content extends OptionsContent>(content: Content): Content {
+  return { ...content, options: shuffle(content.options) };
+}
+
+/**
+ * Investigation problem steps are read-only setup content. Only action and call
+ * variants have selectable options that should be randomized for the learner.
+ */
+function hasShuffleableInvestigationOptions(
+  content: InvestigationStepContent,
+): content is Extract<InvestigationStepContent, OptionsContent> {
+  return content.variant === "action" || content.variant === "call";
+}
+
+/**
  * Parses step content and applies server-side shuffling where needed.
  *
- * Multiple choice options, story choices, investigation actions, and call
- * explanations are shuffled during serialization so the client receives a
+ * Multiple choice, story, investigation action, and investigation call
+ * options are shuffled during serialization so the client receives a
  * randomized order.
  * This avoids client-side shuffling which can cause hydration errors.
  */
 function parseAndShuffleContent(kind: SupportedStepKind, content: unknown) {
   if (kind === "multipleChoice") {
-    const parsedMultipleChoice = parseStepContent("multipleChoice", content);
+    return shuffleOptions(parseStepContent("multipleChoice", content));
+  }
 
-    return parsedMultipleChoice.kind === "core"
-      ? { ...parsedMultipleChoice, options: shuffle(parsedMultipleChoice.options) }
-      : parsedMultipleChoice;
+  if (kind === "selectImage") {
+    return shuffleOptions(parseStepContent("selectImage", content));
   }
 
   if (kind === "story") {
-    const parsedStory = parseStepContent("story", content);
-    return { ...parsedStory, choices: shuffle(parsedStory.choices) };
+    return shuffleOptions(parseStepContent("story", content));
   }
 
   if (kind === "investigation") {
     const parsed = parseStepContent("investigation", content);
-
-    if (parsed.variant === "action") {
-      return { ...parsed, actions: shuffle(parsed.actions) };
-    }
-
-    if (parsed.variant === "call") {
-      return { ...parsed, explanations: shuffle(parsed.explanations) };
-    }
-
-    return parsed;
+    return hasShuffleableInvestigationOptions(parsed) ? shuffleOptions(parsed) : parsed;
   }
 
   return parseStepContent(kind, content);

--- a/packages/core/src/player/contracts/validate-answers.test.ts
+++ b/packages/core/src/player/contracts/validate-answers.test.ts
@@ -4,8 +4,8 @@ import { validateAnswers } from "./validate-answers";
 const coreMultipleChoiceContent = {
   kind: "core" as const,
   options: [
-    { feedback: "Correct!", isCorrect: true, text: "Option A" },
-    { feedback: "Wrong.", isCorrect: false, text: "Option B" },
+    { feedback: "Correct!", id: "option-a", isCorrect: true, text: "Option A" },
+    { feedback: "Wrong.", id: "option-b", isCorrect: false, text: "Option B" },
   ],
 };
 
@@ -21,7 +21,7 @@ describe(validateAnswers, () => {
     const steps = [{ content: coreMultipleChoiceContent, id: "1", kind: "multipleChoice" }];
 
     const results = validateAnswers(steps, {
-      "1": { kind: "multipleChoice", selectedIndex: 0, selectedText: "Option A" },
+      "1": { kind: "multipleChoice", selectedOptionId: "option-a" },
     });
 
     expect(results).toHaveLength(1);
@@ -33,7 +33,7 @@ describe(validateAnswers, () => {
     const steps = [{ content: coreMultipleChoiceContent, id: "1", kind: "multipleChoice" }];
 
     const results = validateAnswers(steps, {
-      "1": { kind: "multipleChoice", selectedIndex: 1, selectedText: "Option B" },
+      "1": { kind: "multipleChoice", selectedOptionId: "option-b" },
     });
 
     expect(results).toHaveLength(1);
@@ -58,7 +58,7 @@ describe(validateAnswers, () => {
     ];
 
     const results = validateAnswers(steps, {
-      "1": { kind: "multipleChoice", selectedIndex: 0, selectedText: "Option A" },
+      "1": { kind: "multipleChoice", selectedOptionId: "option-a" },
     });
 
     expect(results).toHaveLength(1);
@@ -76,12 +76,7 @@ describe(validateAnswers, () => {
     ];
 
     const results = validateAnswers(steps, {
-      "4": {
-        kind: "translation",
-        questionText: "palabra",
-        selectedText: "word",
-        selectedWordId: "100",
-      },
+      "4": { kind: "translation", selectedOptionId: "100" },
     });
 
     expect(results).toHaveLength(1);
@@ -99,12 +94,7 @@ describe(validateAnswers, () => {
     ];
 
     const results = validateAnswers(steps, {
-      "4": {
-        kind: "translation",
-        questionText: "palabra",
-        selectedText: "wrong",
-        selectedWordId: "999",
-      },
+      "4": { kind: "translation", selectedOptionId: "999" },
     });
 
     expect(results).toHaveLength(1);
@@ -233,10 +223,10 @@ describe(validateAnswers, () => {
 
   test("validates story strong choice as correct", () => {
     const storyContent = {
-      choices: [
+      options: [
         {
           alignment: "strong",
-          consequence: "Things improve.",
+          feedback: "Things improve.",
           id: "1a",
           metricEffects: [{ effect: "positive", metric: "Production" }],
           stateImage: { prompt: "State after the strong choice" },
@@ -244,7 +234,7 @@ describe(validateAnswers, () => {
         },
         {
           alignment: "weak",
-          consequence: "Things get worse.",
+          feedback: "Things get worse.",
           id: "1b",
           metricEffects: [{ effect: "negative", metric: "Production" }],
           stateImage: { prompt: "State after the weak choice" },
@@ -256,9 +246,7 @@ describe(validateAnswers, () => {
 
     const steps = [{ content: storyContent, id: "8", kind: "story" }];
 
-    const results = validateAnswers(steps, {
-      "8": { kind: "story", selectedChoiceId: "1a", selectedText: "Do the right thing" },
-    });
+    const results = validateAnswers(steps, { "8": { kind: "story", selectedOptionId: "1a" } });
 
     expect(results).toHaveLength(1);
     expect(results[0]?.isCorrect).toBe(true);
@@ -266,10 +254,10 @@ describe(validateAnswers, () => {
 
   test("validates story weak choice as incorrect", () => {
     const storyContent = {
-      choices: [
+      options: [
         {
           alignment: "strong",
-          consequence: "Things improve.",
+          feedback: "Things improve.",
           id: "1a",
           metricEffects: [{ effect: "positive", metric: "Production" }],
           stateImage: { prompt: "State after the strong choice" },
@@ -277,7 +265,7 @@ describe(validateAnswers, () => {
         },
         {
           alignment: "weak",
-          consequence: "Things get worse.",
+          feedback: "Things get worse.",
           id: "1b",
           metricEffects: [{ effect: "negative", metric: "Production" }],
           stateImage: { prompt: "State after the weak choice" },
@@ -289,9 +277,7 @@ describe(validateAnswers, () => {
 
     const steps = [{ content: storyContent, id: "8", kind: "story" }];
 
-    const results = validateAnswers(steps, {
-      "8": { kind: "story", selectedChoiceId: "1b", selectedText: "Do the wrong thing" },
-    });
+    const results = validateAnswers(steps, { "8": { kind: "story", selectedOptionId: "1b" } });
 
     expect(results).toHaveLength(1);
     expect(results[0]?.isCorrect).toBe(false);
@@ -299,10 +285,10 @@ describe(validateAnswers, () => {
 
   test("story validator returns empty for wrong answer kind", () => {
     const storyContent = {
-      choices: [
+      options: [
         {
           alignment: "strong",
-          consequence: "Things improve.",
+          feedback: "Things improve.",
           id: "1a",
           metricEffects: [{ effect: "positive", metric: "Production" }],
           stateImage: { prompt: "State after the strong choice" },
@@ -310,7 +296,7 @@ describe(validateAnswers, () => {
         },
         {
           alignment: "weak",
-          consequence: "Things get worse.",
+          feedback: "Things get worse.",
           id: "1b",
           metricEffects: [{ effect: "negative", metric: "Production" }],
           stateImage: { prompt: "State after the weak choice" },
@@ -323,7 +309,7 @@ describe(validateAnswers, () => {
     const steps = [{ content: storyContent, id: "9", kind: "story" }];
 
     const results = validateAnswers(steps, {
-      "9": { kind: "multipleChoice", selectedIndex: 0, selectedText: "Option A" },
+      "9": { kind: "multipleChoice", selectedOptionId: "option-a" },
     });
 
     expect(results).toHaveLength(0);
@@ -333,7 +319,7 @@ describe(validateAnswers, () => {
     const steps = [{ content: {}, id: "7", kind: "unknownKind" }];
 
     const results = validateAnswers(steps, {
-      "7": { kind: "multipleChoice", selectedIndex: 0, selectedText: "Option A" },
+      "7": { kind: "multipleChoice", selectedOptionId: "option-a" },
     });
 
     expect(results).toHaveLength(0);
@@ -362,15 +348,15 @@ describe(validateAnswers, () => {
     const steps = [
       {
         content: {
-          actions: [
+          options: [
             {
-              finding: "Logs show memory climbing",
+              feedback: "Logs show memory climbing",
               id: "a1",
-              label: "Check logs",
               quality: "critical",
+              text: "Check logs",
             },
-            { finding: "Filler", id: "a2", label: "Filler 1", quality: "useful" },
-            { finding: "Filler", id: "a3", label: "Filler 2", quality: "weak" },
+            { feedback: "Filler", id: "a2", quality: "useful", text: "Filler 1" },
+            { feedback: "Filler", id: "a3", quality: "weak", text: "Filler 2" },
           ],
           variant: "action",
         },
@@ -382,7 +368,7 @@ describe(validateAnswers, () => {
     const results = validateAnswers(steps, {
       "11": {
         kind: "investigation",
-        selectedActionId: "a1",
+        selectedOptionId: "a1",
         variant: "action",
       },
     });
@@ -394,7 +380,7 @@ describe(validateAnswers, () => {
     const steps = [
       {
         content: {
-          explanations: [
+          options: [
             { accuracy: "best", feedback: "Correct!", id: "e1", text: "Memory leak" },
             { accuracy: "wrong", feedback: "Incorrect.", id: "e2", text: "Network failure" },
           ],
@@ -406,7 +392,7 @@ describe(validateAnswers, () => {
     ];
 
     const results = validateAnswers(steps, {
-      "14": { kind: "investigation", selectedExplanationId: "e1", variant: "call" },
+      "14": { kind: "investigation", selectedOptionId: "e1", variant: "call" },
     });
 
     expect(results).toHaveLength(1);
@@ -417,7 +403,7 @@ describe(validateAnswers, () => {
     const steps = [
       {
         content: {
-          explanations: [
+          options: [
             { accuracy: "best", feedback: "Correct!", id: "e1", text: "Memory leak" },
             { accuracy: "wrong", feedback: "Incorrect.", id: "e2", text: "Network failure" },
           ],
@@ -429,7 +415,7 @@ describe(validateAnswers, () => {
     ];
 
     const results = validateAnswers(steps, {
-      "15": { kind: "investigation", selectedExplanationId: "e2", variant: "call" },
+      "15": { kind: "investigation", selectedOptionId: "e2", variant: "call" },
     });
 
     expect(results).toHaveLength(1);

--- a/packages/core/src/player/contracts/validate-answers.ts
+++ b/packages/core/src/player/contracts/validate-answers.ts
@@ -94,13 +94,7 @@ function validateMultipleChoice(
   }
 
   const content = parseStepContent("multipleChoice", step.content);
-  const index = content.options.findIndex((option) => option.text === answer.selectedText);
-
-  if (index === -1) {
-    return { answer, isCorrect: false, stepId: step.id };
-  }
-
-  const result = checkMultipleChoiceAnswer(content, index);
+  const result = checkMultipleChoiceAnswer(content, answer.selectedOptionId);
 
   return { answer, isCorrect: result.isCorrect, stepId: step.id };
 }
@@ -141,7 +135,7 @@ function validateSelectImage(step: StepData, answer: SelectedAnswer): ValidatedS
   }
 
   const content = parseStepContent("selectImage", step.content);
-  const result = checkSelectImageAnswer(content, answer.selectedIndex);
+  const result = checkSelectImageAnswer(content, answer.selectedOptionId);
   return { answer, isCorrect: result.isCorrect, stepId: step.id };
 }
 
@@ -154,7 +148,7 @@ function validateTranslation(step: StepData, answer: SelectedAnswer): ValidatedS
     return null;
   }
 
-  const result = checkTranslationAnswer(step.word.id, answer.selectedWordId);
+  const result = checkTranslationAnswer(step.word.id, answer.selectedOptionId);
   return { answer, isCorrect: result.isCorrect, stepId: step.id };
 }
 
@@ -207,7 +201,7 @@ function validateInvestigation(step: StepData, answer: SelectedAnswer): Validate
   }
 
   if (content.variant === "call" && answer.variant === "call") {
-    const result = checkInvestigationCall(content, answer.selectedExplanationId);
+    const result = checkInvestigationCall(content, answer.selectedOptionId);
     return { answer, isCorrect: result.isCorrect, stepId: step.id };
   }
 
@@ -220,7 +214,7 @@ function validateStory(step: StepData, answer: SelectedAnswer): ValidatedStepRes
   }
 
   const content = parseStepContent("story", step.content);
-  const result = checkStoryAnswer(content, answer.selectedChoiceId);
+  const result = checkStoryAnswer(content, answer.selectedOptionId);
 
   return { answer, isCorrect: result.isCorrect, stepId: step.id };
 }

--- a/packages/core/src/player/queries/get-review-steps.test.ts
+++ b/packages/core/src/player/queries/get-review-steps.test.ts
@@ -391,10 +391,10 @@ describe(getReviewSteps, () => {
     await stepFixture({
       activityId: storyActivity.id,
       content: {
-        choices: [
+        options: [
           {
             alignment: "strong",
-            consequence: "Good outcome",
+            feedback: "Good outcome",
             id: "c1",
             metricEffects: [{ effect: "positive", metric: "Score" }],
             text: "Choice A",
@@ -434,7 +434,6 @@ describe(getReviewSteps, () => {
     await stepFixture({
       activityId: investigationActivity.id,
       content: {
-        explanations: [{ accuracy: "best", text: "Explanation A" }],
         scenario: "A mystery scenario",
         variant: "problem",
         visual: { kind: "image", url: "https://example.com/img.jpg" },
@@ -741,8 +740,8 @@ describe(getReviewValidationSteps, () => {
     const mcContent = {
       kind: "core",
       options: [
-        { feedback: "Correct!", isCorrect: true, text: "A" },
-        { feedback: "Wrong.", isCorrect: false, text: "B" },
+        { feedback: "Correct!", id: "a", isCorrect: true, text: "A" },
+        { feedback: "Wrong.", id: "b", isCorrect: false, text: "B" },
       ],
     };
 

--- a/packages/core/src/steps/contract/content.test.ts
+++ b/packages/core/src/steps/contract/content.test.ts
@@ -5,12 +5,12 @@ describe("step content contracts", () => {
   test("parses core multipleChoice with optional context/question omitted", () => {
     const content = parseStepContent("multipleChoice", {
       kind: "core",
-      options: [{ feedback: "Correct", isCorrect: true, text: "A" }],
+      options: [{ feedback: "Correct", id: "a", isCorrect: true, text: "A" }],
     });
 
     expect(content).toEqual({
       kind: "core",
-      options: [{ feedback: "Correct", isCorrect: true, text: "A" }],
+      options: [{ feedback: "Correct", id: "a", isCorrect: true, text: "A" }],
     });
   });
 
@@ -23,8 +23,8 @@ describe("step content contracts", () => {
       },
       kind: "core",
       options: [
-        { feedback: "Correct!", isCorrect: true, text: "A" },
-        { feedback: "Wrong.", isCorrect: false, text: "B" },
+        { feedback: "Correct!", id: "a", isCorrect: true, text: "A" },
+        { feedback: "Wrong.", id: "b", isCorrect: false, text: "B" },
       ],
       question: "What is correct?",
     });
@@ -37,8 +37,8 @@ describe("step content contracts", () => {
       },
       kind: "core",
       options: [
-        { feedback: "Correct!", isCorrect: true, text: "A" },
-        { feedback: "Wrong.", isCorrect: false, text: "B" },
+        { feedback: "Correct!", id: "a", isCorrect: true, text: "A" },
+        { feedback: "Wrong.", id: "b", isCorrect: false, text: "B" },
       ],
       question: "What is correct?",
     });
@@ -47,7 +47,7 @@ describe("step content contracts", () => {
   test("rejects multipleChoice without kind", () => {
     expect(() =>
       parseStepContent("multipleChoice", {
-        options: [{ feedback: "Correct", isCorrect: true, text: "A" }],
+        options: [{ feedback: "Correct", id: "a", isCorrect: true, text: "A" }],
       }),
     ).toThrow();
   });
@@ -58,8 +58,8 @@ describe("step content contracts", () => {
         kind: "core",
         options: [
           {
-            consequence: "Something",
             effects: [{ dimension: "X", impact: "positive" }],
+            feedback: "Something",
             text: "A",
           },
         ],
@@ -71,7 +71,7 @@ describe("step content contracts", () => {
     expect(() =>
       parseStepContent("multipleChoice", {
         kind: "unknown",
-        options: [{ feedback: "Correct", isCorrect: true, text: "A" }],
+        options: [{ feedback: "Correct", id: "a", isCorrect: true, text: "A" }],
       }),
     ).toThrow();
   });
@@ -186,12 +186,28 @@ describe("step content contracts", () => {
 
   test("parses selectImage", () => {
     const content = parseStepContent("selectImage", {
-      options: [{ feedback: "Correct", isCorrect: true, prompt: "A cat", url: "https://a.co/x" }],
+      options: [
+        {
+          feedback: "Correct",
+          id: "image-1",
+          isCorrect: true,
+          prompt: "A cat",
+          url: "https://a.co/x",
+        },
+      ],
       question: "Which image shows a cat?",
     });
 
     expect(content).toEqual({
-      options: [{ feedback: "Correct", isCorrect: true, prompt: "A cat", url: "https://a.co/x" }],
+      options: [
+        {
+          feedback: "Correct",
+          id: "image-1",
+          isCorrect: true,
+          prompt: "A cat",
+          url: "https://a.co/x",
+        },
+      ],
       question: "Which image shows a cat?",
     });
   });
@@ -249,43 +265,43 @@ describe("step content contracts", () => {
   describe("story", () => {
     const baseChoice = {
       alignment: "strong" as const,
-      consequence: "Things improve.",
+      feedback: "Things improve.",
       id: "1a",
       metricEffects: [{ effect: "positive" as const, metric: "Production" }],
       stateImage: { prompt: "World state after the helpful action" },
       text: "Do the right thing",
     };
 
-    test("parses step with problem and choices", () => {
+    test("parses step with problem and options", () => {
       const content = parseStepContent("story", {
-        choices: [baseChoice, { ...baseChoice, alignment: "weak", id: "1b" }],
         image: { prompt: "Story decision scene" },
+        options: [baseChoice, { ...baseChoice, alignment: "weak", id: "1b" }],
         problem: "You face a decision.",
       });
 
       expect(content.problem).toBe("You face a decision.");
-      expect(content.choices).toHaveLength(2);
+      expect(content.options).toHaveLength(2);
     });
 
-    test("accepts more than 4 choices", () => {
-      const choices = Array.from({ length: 5 }, (_, i) => ({
+    test("accepts more than 4 options", () => {
+      const options = Array.from({ length: 5 }, (_, i) => ({
         ...baseChoice,
         id: `choice-${i}`,
       }));
 
       const content = parseStepContent("story", {
-        choices,
         image: { prompt: "Crowded decision scene" },
+        options,
         problem: "Many options available.",
       });
 
-      expect(content.choices).toHaveLength(5);
+      expect(content.options).toHaveLength(5);
     });
 
     test("rejects fewer than 2 choices", () => {
       expect(() =>
         parseStepContent("story", {
-          choices: [baseChoice],
+          options: [baseChoice],
           problem: "Only one option.",
         }),
       ).toThrow();
@@ -294,8 +310,8 @@ describe("step content contracts", () => {
     test("rejects extra fields on step content", () => {
       expect(() =>
         parseStepContent("story", {
-          choices: [baseChoice, { ...baseChoice, id: "1b" }],
           intro: "Not allowed here.",
+          options: [baseChoice, { ...baseChoice, id: "1b" }],
           problem: "Test.",
         }),
       ).toThrow();
@@ -304,7 +320,7 @@ describe("step content contracts", () => {
     test("rejects extra fields on choice", () => {
       expect(() =>
         parseStepContent("story", {
-          choices: [{ ...baseChoice, extra: "field" }],
+          options: [{ ...baseChoice, extra: "field" }],
           problem: "Test.",
         }),
       ).toThrow();
@@ -313,7 +329,7 @@ describe("step content contracts", () => {
     test("rejects missing problem", () => {
       expect(() =>
         parseStepContent("story", {
-          choices: [baseChoice, { ...baseChoice, id: "1b" }],
+          options: [baseChoice, { ...baseChoice, id: "1b" }],
         }),
       ).toThrow();
     });
@@ -460,22 +476,22 @@ describe("step content contracts", () => {
       ).toThrow();
     });
 
-    test("parses action variant with labels, quality, and embedded findings", () => {
+    test("parses action variant with text, quality, and embedded feedback", () => {
       const content = parseStepContent("investigation", {
-        actions: [
+        options: [
           {
-            finding: "The footage shows movement at 11pm.",
+            feedback: "The footage shows movement at 11pm.",
             id: "a1",
-            label: "Check the security footage",
             quality: "critical",
+            text: "Check the security footage",
           },
           {
-            finding: "The gardener was in the shed.",
+            feedback: "The gardener was in the shed.",
             id: "a2",
-            label: "Interview the gardener",
             quality: "useful",
+            text: "Interview the gardener",
           },
-          { finding: "No clues here.", id: "a3", label: "Check the attic", quality: "weak" },
+          { feedback: "No clues here.", id: "a3", quality: "weak", text: "Check the attic" },
         ],
         variant: "action",
       });
@@ -486,10 +502,10 @@ describe("step content contracts", () => {
     test("rejects invalid quality value", () => {
       expect(() =>
         parseStepContent("investigation", {
-          actions: [
-            { finding: "Something", id: "a1", label: "Do something", quality: "excellent" },
-            { finding: "Something", id: "a2", label: "Do more", quality: "critical" },
-            { finding: "Something", id: "a3", label: "Do other", quality: "useful" },
+          options: [
+            { feedback: "Something", id: "a1", quality: "excellent", text: "Do something" },
+            { feedback: "Something", id: "a2", quality: "critical", text: "Do more" },
+            { feedback: "Something", id: "a3", quality: "useful", text: "Do other" },
           ],
           variant: "action",
         }),
@@ -498,7 +514,7 @@ describe("step content contracts", () => {
 
     test("parses call variant with explanations and per-explanation feedback", () => {
       const content = parseStepContent("investigation", {
-        explanations: [
+        options: [
           {
             accuracy: "best",
             feedback: "Correct — the butler did it.",
@@ -528,9 +544,7 @@ describe("step content contracts", () => {
       expect(() =>
         parseStepContent("investigation", {
           correctExplanationIndex: 0,
-          explanations: [
-            { accuracy: "best", feedback: "Correct.", id: "e1", text: "Explanation." },
-          ],
+          options: [{ accuracy: "best", feedback: "Correct.", id: "e1", text: "Explanation." }],
           variant: "call",
         }),
       ).toThrow();

--- a/packages/core/src/steps/contract/content.test.ts
+++ b/packages/core/src/steps/contract/content.test.ts
@@ -60,6 +60,8 @@ describe("step content contracts", () => {
           {
             effects: [{ dimension: "X", impact: "positive" }],
             feedback: "Something",
+            id: "a",
+            isCorrect: true,
             text: "A",
           },
         ],

--- a/packages/core/src/steps/contract/exercise.ts
+++ b/packages/core/src/steps/contract/exercise.ts
@@ -4,6 +4,7 @@ import { stepImageSchema } from "./image";
 const coreOptionSchema = z
   .object({
     feedback: z.string(),
+    id: z.string(),
     isCorrect: z.boolean(),
     text: z.string(),
   })
@@ -59,6 +60,7 @@ export const sortOrderContentSchema = z
 const selectImageOptionSchema = z
   .object({
     feedback: z.string(),
+    id: z.string(),
     isCorrect: z.boolean(),
     prompt: z.string(),
     url: z.string().optional(),

--- a/packages/core/src/steps/contract/investigation.ts
+++ b/packages/core/src/steps/contract/investigation.ts
@@ -5,7 +5,7 @@ const investigationActionQualitySchema = z.enum(["critical", "useful", "weak"]);
 
 const investigationAccuracySchema = z.enum(["best", "partial", "wrong"]);
 
-const investigationExplanationSchema = z
+const investigationCallOptionSchema = z
   .object({
     accuracy: investigationAccuracySchema,
     feedback: z.string(),
@@ -15,16 +15,16 @@ const investigationExplanationSchema = z
   .strict();
 
 /**
- * Each action carries its own finding data so that evidence
+ * Each action carries its own feedback data so that evidence
  * travels with the action through server-side shuffle.
- * When the learner checks an action, the finding is shown as feedback.
+ * When the learner checks an action, the feedback is shown as evidence.
  */
-const investigationActionItemSchema = z
+const investigationActionOptionSchema = z
   .object({
-    finding: z.string(),
+    feedback: z.string(),
     id: z.string(),
-    label: z.string(),
     quality: investigationActionQualitySchema,
+    text: z.string(),
   })
   .strict();
 
@@ -42,12 +42,12 @@ const investigationProblemContentSchema = z
 /**
  * Action step: the full list of actions the learner can choose from.
  * The player filters out already-picked actions using the investigation loop.
- * Each action carries its finding data for the feedback screen.
+ * Each action carries its feedback data for the feedback screen.
  * `quality` indicates how informative the action is for scoring.
  */
 const investigationActionContentSchema = z
   .object({
-    actions: z.array(investigationActionItemSchema).min(INVESTIGATION_EXPERIMENT_COUNT),
+    options: z.array(investigationActionOptionSchema).min(INVESTIGATION_EXPERIMENT_COUNT),
     variant: z.literal("action"),
   })
   .strict();
@@ -61,7 +61,7 @@ const investigationActionContentSchema = z
  */
 const investigationCallContentSchema = z
   .object({
-    explanations: z.array(investigationExplanationSchema),
+    options: z.array(investigationCallOptionSchema),
     variant: z.literal("call"),
   })
   .strict();

--- a/packages/core/src/steps/contract/story.ts
+++ b/packages/core/src/steps/contract/story.ts
@@ -49,10 +49,10 @@ const storyMetricEffectEntrySchema = z
   })
   .strict();
 
-const storyChoiceSchema = z
+const storyOptionSchema = z
   .object({
     alignment: storyAlignmentSchema,
-    consequence: z.string(),
+    feedback: z.string(),
     id: z.string(),
     metricEffects: z.array(storyMetricEffectEntrySchema),
     stateImage: stepImageSchema,
@@ -60,11 +60,11 @@ const storyChoiceSchema = z
   })
   .strict();
 
-/** Schema for a story decision step's content (problem + choices). */
+/** Schema for a story decision step's content (problem + selectable options). */
 export const storyContentSchema = z
   .object({
-    choices: z.array(storyChoiceSchema).min(2),
     image: stepImageSchema.optional(),
+    options: z.array(storyOptionSchema).min(2),
     problem: z.string(),
   })
   .strict();

--- a/packages/db/src/prisma/seed/steps.ts
+++ b/packages/db/src/prisma/seed/steps.ts
@@ -106,18 +106,21 @@ const stepsData: {
           options: [
             {
               feedback: "Both use electricity. Think about how they solve problems.",
+              id: "electricity",
               isCorrect: false,
               text: "Traditional programming uses electricity, ML uses batteries",
             },
             {
               feedback:
                 "Exactly! ML discovers patterns from examples rather than following pre-programmed rules.",
+              id: "patterns-from-data",
               isCorrect: true,
               text: "ML learns patterns from data instead of following explicit rules",
             },
             {
               feedback:
                 "Speed isn't the key difference. Consider how each approach solves problems.",
+              id: "programming-speed",
               isCorrect: false,
               text: "Traditional programming is faster than ML",
             },
@@ -173,12 +176,14 @@ const stepsData: {
           options: [
             {
               feedback: "Correct! Neural networks have interconnected layers of nodes.",
+              id: "neural-network",
               isCorrect: true,
               prompt: "A clear diagram of a neural network with connected layers of nodes",
               url: "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/courses/machine_learning-jmaDwiS0MptNV2EGCZzYWU7RBJs3Qg.webp",
             },
             {
               feedback: "This is a flowchart, not a neural network architecture.",
+              id: "flowchart",
               isCorrect: false,
               prompt: "A simple flowchart with boxes and arrows",
               url: "https://to3kaoi21m60hzgu.public.blob.vercel-storage.com/courses/astronomy-OfBov0VHGQPk98amhfAPg4UVrJH114.webp",

--- a/packages/player/src/_browser-tests/player-choice.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-choice.browser.test.tsx
@@ -21,8 +21,8 @@ describe("player browser integration: choice steps", () => {
             content: {
               kind: "core",
               options: [
-                { feedback: "Nope", isCorrect: false, text: "Paris" },
-                { feedback: "Correct", isCorrect: true, text: "Berlin" },
+                { feedback: "Nope", id: "Paris", isCorrect: false, text: "Paris" },
+                { feedback: "Correct", id: "Berlin", isCorrect: true, text: "Berlin" },
               ],
               question: "What is the capital of Germany?",
             },
@@ -116,12 +116,14 @@ describe("player browser integration: choice steps", () => {
               options: [
                 {
                   feedback: "Correct cat",
+                  id: "cat",
                   isCorrect: true,
                   prompt: "Cat",
                   url: "https://example.com/cat.png",
                 },
                 {
                   feedback: "Wrong dog",
+                  id: "dog",
                   isCorrect: false,
                   prompt: "Dog",
                   url: "https://example.com/dog.png",
@@ -152,8 +154,8 @@ describe("player browser integration: choice steps", () => {
               context: "Read the clue first",
               kind: "core",
               options: [
-                { feedback: "Nope", isCorrect: false, text: "Paris" },
-                { feedback: "Correct", isCorrect: true, text: "Berlin" },
+                { feedback: "Nope", id: "Paris", isCorrect: false, text: "Paris" },
+                { feedback: "Correct", id: "Berlin", isCorrect: true, text: "Berlin" },
               ],
               question: "What is the capital of Germany?",
             },
@@ -201,8 +203,18 @@ describe("player browser integration: choice steps", () => {
               },
               kind: "core",
               options: [
-                { feedback: "Correct", isCorrect: true, text: "March dropped sharply" },
-                { feedback: "Nope", isCorrect: false, text: "March stayed flat" },
+                {
+                  feedback: "Correct",
+                  id: "March dropped sharply",
+                  isCorrect: true,
+                  text: "March dropped sharply",
+                },
+                {
+                  feedback: "Nope",
+                  id: "March stayed flat",
+                  isCorrect: false,
+                  text: "March stayed flat",
+                },
               ],
               question: "What changed?",
             },
@@ -305,12 +317,14 @@ describe("player browser integration: choice steps", () => {
               options: [
                 {
                   feedback: "Correct cat",
+                  id: "cat",
                   isCorrect: true,
                   prompt: "Cat",
                   url: undefined,
                 },
                 {
                   feedback: "Wrong dog",
+                  id: "dog",
                   isCorrect: false,
                   prompt: "Dog",
                   url: "https://example.com/dog.png",
@@ -347,8 +361,13 @@ describe("player browser integration: choice steps", () => {
               context: "{{NAME}}, we have a situation",
               kind: "core",
               options: [
-                { feedback: "{{NAME}}, great call", isCorrect: true, text: "Investigate" },
-                { feedback: "Wrong", isCorrect: false, text: "Ignore it" },
+                {
+                  feedback: "{{NAME}}, great call",
+                  id: "Investigate",
+                  isCorrect: true,
+                  text: "Investigate",
+                },
+                { feedback: "Wrong", id: "Ignore it", isCorrect: false, text: "Ignore it" },
               ],
               question: "What should we do?",
             },
@@ -374,8 +393,13 @@ describe("player browser integration: choice steps", () => {
               context: "{{NAME}}, we have a situation",
               kind: "core",
               options: [
-                { feedback: "{{NAME}}, great call", isCorrect: true, text: "Investigate" },
-                { feedback: "Wrong", isCorrect: false, text: "Ignore it" },
+                {
+                  feedback: "{{NAME}}, great call",
+                  id: "Investigate",
+                  isCorrect: true,
+                  text: "Investigate",
+                },
+                { feedback: "Wrong", id: "Ignore it", isCorrect: false, text: "Ignore it" },
               ],
               question: "What should we do?",
             },

--- a/packages/player/src/_browser-tests/player-completion.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-completion.browser.test.tsx
@@ -26,8 +26,8 @@ function buildCompletionQuizActivity({
         content: {
           kind: "core" as const,
           options: [
-            { feedback: "Correct!", isCorrect: true, text: correctText },
-            { feedback: "Not this one", isCorrect: false, text: wrongText },
+            { feedback: "Correct!", id: "correct", isCorrect: true, text: correctText },
+            { feedback: "Not this one", id: "wrong", isCorrect: false, text: wrongText },
           ],
           question,
         },

--- a/packages/player/src/_browser-tests/player-explanation.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-explanation.browser.test.tsx
@@ -47,11 +47,13 @@ describe("player browser integration: explanation activity flow", () => {
               options: [
                 {
                   feedback: "Right. That label helps the network forward it.",
+                  id: "routing-label",
                   isCorrect: true,
                   text: "A routing label",
                 },
                 {
                   feedback: "Not this one. The message still needs routing information.",
+                  id: "color-tag",
                   isCorrect: false,
                   text: "A random color tag",
                 },

--- a/packages/player/src/_browser-tests/player-investigation.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-investigation.browser.test.tsx
@@ -20,18 +20,18 @@ describe("player browser integration: investigation", () => {
           }),
           buildSerializedStep({
             content: {
-              actions: [
+              options: [
                 {
-                  finding: "Logs point to a memory leak.",
+                  feedback: "Logs point to a memory leak.",
                   id: "action-1",
-                  label: "Check server logs",
                   quality: "critical" as const,
+                  text: "Check server logs",
                 },
                 {
-                  finding: "The latest deploy introduced a regression.",
+                  feedback: "The latest deploy introduced a regression.",
                   id: "action-2",
-                  label: "Check deploy history",
                   quality: "critical" as const,
+                  text: "Check deploy history",
                 },
               ],
               variant: "action" as const,
@@ -42,7 +42,7 @@ describe("player browser integration: investigation", () => {
           }),
           buildSerializedStep({
             content: {
-              explanations: [
+              options: [
                 {
                   accuracy: "best" as const,
                   feedback: "Correct. The memory leak caused the failures.",
@@ -112,24 +112,24 @@ describe("player browser integration: investigation", () => {
           }),
           buildSerializedStep({
             content: {
-              actions: [
+              options: [
                 {
-                  finding: "Logs point to a memory leak.",
+                  feedback: "Logs point to a memory leak.",
                   id: "action-1",
-                  label: "Check server logs",
                   quality: "critical" as const,
+                  text: "Check server logs",
                 },
                 {
-                  finding: "The latest deploy introduced a regression.",
+                  feedback: "The latest deploy introduced a regression.",
                   id: "action-2",
-                  label: "Check deploy history",
                   quality: "useful" as const,
+                  text: "Check deploy history",
                 },
                 {
-                  finding: "A cache node restarted once.",
+                  feedback: "A cache node restarted once.",
                   id: "action-3",
-                  label: "Inspect the cache",
                   quality: "weak" as const,
+                  text: "Inspect the cache",
                 },
               ],
               variant: "action" as const,
@@ -140,7 +140,7 @@ describe("player browser integration: investigation", () => {
           }),
           buildSerializedStep({
             content: {
-              explanations: [
+              options: [
                 {
                   accuracy: "best" as const,
                   feedback: "Correct. The memory leak caused the failures.",

--- a/packages/player/src/_browser-tests/player-practice.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-practice.browser.test.tsx
@@ -42,11 +42,13 @@ describe("player browser integration: practice activities", () => {
               options: [
                 {
                   feedback: "Yes. Start with the shared pattern before blaming a random order.",
+                  id: "check-discounted-orders",
                   isCorrect: true,
                   text: "Check the discounted orders first",
                 },
                 {
                   feedback: "That skips the one pattern we already know matters.",
+                  id: "inspect-latest-order",
                   isCorrect: false,
                   text: "Ignore discounts and inspect the latest order",
                 },

--- a/packages/player/src/_browser-tests/player-story.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-story.browser.test.tsx
@@ -128,10 +128,14 @@ describe("player browser integration: story", () => {
           }),
           buildSerializedStep({
             content: {
-              choices: [
+              image: {
+                prompt: "Factory floor in crisis with stalled stations and workers waiting",
+                url: buildInlineImageUrl({ label: "Story step" }),
+              },
+              options: [
                 {
                   alignment: "strong" as const,
-                  consequence: "Production surges",
+                  feedback: "Production surges",
                   id: "story-choice-1",
                   metricEffects: [
                     { effect: "positive" as const, metric: "Production" },
@@ -145,7 +149,7 @@ describe("player browser integration: story", () => {
                 },
                 {
                   alignment: "weak" as const,
-                  consequence: "Morale drops",
+                  feedback: "Morale drops",
                   id: "story-choice-2",
                   metricEffects: [
                     { effect: "negative" as const, metric: "Production" },
@@ -159,10 +163,6 @@ describe("player browser integration: story", () => {
                   text: "Cut costs",
                 },
               ],
-              image: {
-                prompt: "Factory floor in crisis with stalled stations and workers waiting",
-                url: buildInlineImageUrl({ label: "Story step" }),
-              },
               problem: "A crisis hits the factory floor",
             },
             id: "story-decision",
@@ -258,10 +258,14 @@ describe("player browser integration: story", () => {
           }),
           buildSerializedStep({
             content: {
-              choices: [
+              image: {
+                prompt: "Factory floor in crisis with stalled stations and workers waiting",
+                url: buildInlineImageUrl({ label: "Story step context" }),
+              },
+              options: [
                 {
                   alignment: "strong" as const,
-                  consequence: "Production surges",
+                  feedback: "Production surges",
                   id: "story-choice-1",
                   metricEffects: [
                     { effect: "positive" as const, metric: "Production" },
@@ -275,7 +279,7 @@ describe("player browser integration: story", () => {
                 },
                 {
                   alignment: "weak" as const,
-                  consequence: "Morale drops",
+                  feedback: "Morale drops",
                   id: "story-choice-2",
                   metricEffects: [
                     { effect: "negative" as const, metric: "Production" },
@@ -289,10 +293,6 @@ describe("player browser integration: story", () => {
                   text: "Cut costs",
                 },
               ],
-              image: {
-                prompt: "Factory floor in crisis with stalled stations and workers waiting",
-                url: buildInlineImageUrl({ label: "Story step context" }),
-              },
               problem: "A crisis hits the factory floor",
             },
             id: "story-decision-context",
@@ -376,10 +376,14 @@ describe("player browser integration: story", () => {
         steps: [
           buildSerializedStep({
             content: {
-              choices: [
+              image: {
+                prompt: "Factory floor with a broken conveyor and a long repair queue",
+                url: buildInlineImageUrl({ label: "Story scroll decision" }),
+              },
+              options: [
                 {
                   alignment: "weak" as const,
-                  consequence: "The repair backlog grows.",
+                  feedback: "The repair backlog grows.",
                   id: "story-choice-1",
                   metricEffects: [{ effect: "negative" as const, metric: "Production" }],
                   stateImage: {
@@ -390,7 +394,7 @@ describe("player browser integration: story", () => {
                 },
                 {
                   alignment: "partial" as const,
-                  consequence: "The team understands the risk but output still slips.",
+                  feedback: "The team understands the risk but output still slips.",
                   id: "story-choice-2",
                   metricEffects: [{ effect: "neutral" as const, metric: "Production" }],
                   stateImage: {
@@ -401,7 +405,7 @@ describe("player browser integration: story", () => {
                 },
                 {
                   alignment: "strong" as const,
-                  consequence:
+                  feedback:
                     "Repairs restart safely and the team sees the plan. The maintenance lead checks every station, the floor manager explains the pause, and the next batch moves only after the checklist is visible to everyone.",
                   id: "story-choice-3",
                   metricEffects: STORY_SCROLL_METRICS.map((metric) => ({
@@ -415,10 +419,6 @@ describe("player browser integration: story", () => {
                   text: "Pause the line, assign repair owners, and reopen only after the checklist passes.",
                 },
               ],
-              image: {
-                prompt: "Factory floor with a broken conveyor and a long repair queue",
-                url: buildInlineImageUrl({ label: "Story scroll decision" }),
-              },
               problem:
                 "A conveyor breaks during the busiest hour. Workers are waiting for direction, inventory is piling up, and the fastest option is buried below the first visible choices.",
             },

--- a/packages/player/src/check-step.test.ts
+++ b/packages/player/src/check-step.test.ts
@@ -28,8 +28,8 @@ describe(checkStep, () => {
       content: {
         kind: "core" as const,
         options: [
-          { feedback: "Correct!", isCorrect: true, text: "4" },
-          { feedback: "Wrong!", isCorrect: false, text: "3" },
+          { feedback: "Correct!", id: "four", isCorrect: true, text: "4" },
+          { feedback: "Wrong!", id: "three", isCorrect: false, text: "3" },
         ],
         question: "What is 2+2?",
       },
@@ -40,8 +40,7 @@ describe(checkStep, () => {
     test("correct answer returns isCorrect true", () => {
       const answer: SelectedAnswer = {
         kind: "multipleChoice",
-        selectedIndex: 0,
-        selectedText: "4",
+        selectedOptionId: "four",
       };
       const { result } = checkStep(step, answer);
       expect(result.isCorrect).toBe(true);
@@ -51,8 +50,7 @@ describe(checkStep, () => {
     test("incorrect answer returns isCorrect false", () => {
       const answer: SelectedAnswer = {
         kind: "multipleChoice",
-        selectedIndex: 1,
-        selectedText: "3",
+        selectedOptionId: "three",
       };
       const { result } = checkStep(step, answer);
       expect(result.isCorrect).toBe(false);
@@ -159,8 +157,8 @@ describe(checkStep, () => {
     const step = buildStep({
       content: {
         options: [
-          { feedback: "Yes!", isCorrect: true, prompt: "Cat" },
-          { feedback: "No!", isCorrect: false, prompt: "Dog" },
+          { feedback: "Yes!", id: "cat", isCorrect: true, prompt: "Cat" },
+          { feedback: "No!", id: "dog", isCorrect: false, prompt: "Dog" },
         ],
         question: "Select the correct image",
       },
@@ -169,13 +167,13 @@ describe(checkStep, () => {
     });
 
     test("correct selection", () => {
-      const answer: SelectedAnswer = { kind: "selectImage", selectedIndex: 0 };
+      const answer: SelectedAnswer = { kind: "selectImage", selectedOptionId: "cat" };
       const { result } = checkStep(step, answer);
       expect(result.isCorrect).toBe(true);
     });
 
     test("incorrect selection", () => {
-      const answer: SelectedAnswer = { kind: "selectImage", selectedIndex: 1 };
+      const answer: SelectedAnswer = { kind: "selectImage", selectedOptionId: "dog" };
       const { result } = checkStep(step, answer);
       expect(result.isCorrect).toBe(false);
     });
@@ -198,23 +196,13 @@ describe(checkStep, () => {
     });
 
     test("correct word", () => {
-      const answer: SelectedAnswer = {
-        kind: "translation",
-        questionText: "hola",
-        selectedText: "hello",
-        selectedWordId: "word-1",
-      };
+      const answer: SelectedAnswer = { kind: "translation", selectedOptionId: "word-1" };
       const { result } = checkStep(step, answer);
       expect(result.isCorrect).toBe(true);
     });
 
     test("incorrect word", () => {
-      const answer: SelectedAnswer = {
-        kind: "translation",
-        questionText: "hola",
-        selectedText: "wrong",
-        selectedWordId: "word-99",
-      };
+      const answer: SelectedAnswer = { kind: "translation", selectedOptionId: "word-99" };
       const { result } = checkStep(step, answer);
       expect(result.isCorrect).toBe(false);
     });
@@ -229,9 +217,7 @@ describe(checkStep, () => {
       });
       const answer: SelectedAnswer = {
         kind: "translation",
-        questionText: "hola",
-        selectedText: "hello",
-        selectedWordId: "word-1",
+        selectedOptionId: "word-1",
       };
       const { result } = checkStep(step, answer);
       expect(result.isCorrect).toBe(false);
@@ -402,10 +388,10 @@ describe(checkStep, () => {
   describe("story", () => {
     const step = buildStep({
       content: {
-        choices: [
+        options: [
           {
             alignment: "strong",
-            consequence: "Things improve.",
+            feedback: "Things improve.",
             id: "1a",
             metricEffects: [{ effect: "positive", metric: "Production" }],
             stateImage: { prompt: "State after the strong choice" },
@@ -413,7 +399,7 @@ describe(checkStep, () => {
           },
           {
             alignment: "weak",
-            consequence: "Things get worse.",
+            feedback: "Things get worse.",
             id: "1b",
             metricEffects: [{ effect: "negative", metric: "Production" }],
             stateImage: { prompt: "State after the weak choice" },
@@ -427,29 +413,21 @@ describe(checkStep, () => {
     });
 
     test("strong alignment returns isCorrect true", () => {
-      const answer: SelectedAnswer = {
-        kind: "story",
-        selectedChoiceId: "1a",
-        selectedText: "Do the right thing",
-      };
+      const answer: SelectedAnswer = { kind: "story", selectedOptionId: "1a" };
 
       const { result } = checkStep(step, answer);
       expect(result.isCorrect).toBe(true);
     });
 
     test("weak alignment returns isCorrect false", () => {
-      const answer: SelectedAnswer = {
-        kind: "story",
-        selectedChoiceId: "1b",
-        selectedText: "Do the wrong thing",
-      };
+      const answer: SelectedAnswer = { kind: "story", selectedOptionId: "1b" };
 
       const { result } = checkStep(step, answer);
       expect(result.isCorrect).toBe(false);
     });
 
     test("returns mismatch for wrong answer kind", () => {
-      const answer: SelectedAnswer = { kind: "multipleChoice", selectedIndex: 0, selectedText: "" };
+      const answer: SelectedAnswer = { kind: "multipleChoice", selectedOptionId: "missing" };
       const { result } = checkStep(step, answer);
       expect(result.isCorrect).toBe(false);
     });
@@ -460,7 +438,7 @@ describe(checkStep, () => {
       const step = buildStep({
         content: {
           kind: "core" as const,
-          options: [{ feedback: "OK", isCorrect: true, text: "A" }],
+          options: [{ feedback: "OK", id: "a", isCorrect: true, text: "A" }],
           question: "Test",
         },
         kind: "multipleChoice",
@@ -473,7 +451,7 @@ describe(checkStep, () => {
 
     test("static step returns mismatch result", () => {
       const step = buildStep();
-      const answer: SelectedAnswer = { kind: "multipleChoice", selectedIndex: 0, selectedText: "" };
+      const answer: SelectedAnswer = { kind: "multipleChoice", selectedOptionId: "missing" };
       const { result } = checkStep(step, answer);
       expect(result.isCorrect).toBe(false);
       expect(result.feedback).toBeNull();
@@ -500,15 +478,15 @@ describe(checkStep, () => {
     test("action variant: critical quality is correct", () => {
       const step = buildStep({
         content: {
-          actions: [
+          options: [
             {
-              finding: "Logs show memory climbing",
+              feedback: "Logs show memory climbing",
               id: "a1",
-              label: "Check logs",
               quality: "critical" as const,
+              text: "Check logs",
             },
-            { finding: "Filler", id: "a2", label: "Filler 1", quality: "useful" as const },
-            { finding: "Filler", id: "a3", label: "Filler 2", quality: "weak" as const },
+            { feedback: "Filler", id: "a2", quality: "useful" as const, text: "Filler 1" },
+            { feedback: "Filler", id: "a3", quality: "weak" as const, text: "Filler 2" },
           ],
           variant: "action" as const,
         },
@@ -516,7 +494,7 @@ describe(checkStep, () => {
       });
       const answer: SelectedAnswer = {
         kind: "investigation",
-        selectedActionId: "a1",
+        selectedOptionId: "a1",
         variant: "action",
       };
       const { result } = checkStep(step, answer);
@@ -527,15 +505,15 @@ describe(checkStep, () => {
     test("action variant: useful quality is correct", () => {
       const step = buildStep({
         content: {
-          actions: [
+          options: [
             {
-              finding: "Some useful data found",
+              feedback: "Some useful data found",
               id: "a1",
-              label: "Review logs",
               quality: "useful" as const,
+              text: "Review logs",
             },
-            { finding: "Filler", id: "a2", label: "Filler 1", quality: "critical" as const },
-            { finding: "Filler", id: "a3", label: "Filler 2", quality: "weak" as const },
+            { feedback: "Filler", id: "a2", quality: "critical" as const, text: "Filler 1" },
+            { feedback: "Filler", id: "a3", quality: "weak" as const, text: "Filler 2" },
           ],
           variant: "action" as const,
         },
@@ -543,7 +521,7 @@ describe(checkStep, () => {
       });
       const answer: SelectedAnswer = {
         kind: "investigation",
-        selectedActionId: "a1",
+        selectedOptionId: "a1",
         variant: "action",
       };
       const { result } = checkStep(step, answer);
@@ -554,15 +532,15 @@ describe(checkStep, () => {
     test("action variant: weak quality is incorrect", () => {
       const step = buildStep({
         content: {
-          actions: [
+          options: [
             {
-              finding: "Nothing useful here",
+              feedback: "Nothing useful here",
               id: "a1",
-              label: "Random check",
               quality: "weak" as const,
+              text: "Random check",
             },
-            { finding: "Filler", id: "a2", label: "Filler 1", quality: "critical" as const },
-            { finding: "Filler", id: "a3", label: "Filler 2", quality: "useful" as const },
+            { feedback: "Filler", id: "a2", quality: "critical" as const, text: "Filler 1" },
+            { feedback: "Filler", id: "a3", quality: "useful" as const, text: "Filler 2" },
           ],
           variant: "action" as const,
         },
@@ -570,7 +548,7 @@ describe(checkStep, () => {
       });
       const answer: SelectedAnswer = {
         kind: "investigation",
-        selectedActionId: "a1",
+        selectedOptionId: "a1",
         variant: "action",
       };
       const { result } = checkStep(step, answer);
@@ -581,15 +559,15 @@ describe(checkStep, () => {
     test("action variant: unknown ID is incorrect", () => {
       const step = buildStep({
         content: {
-          actions: [
+          options: [
             {
-              finding: "Logs show memory climbing",
+              feedback: "Logs show memory climbing",
               id: "a1",
-              label: "Check logs",
               quality: "critical" as const,
+              text: "Check logs",
             },
-            { finding: "Filler", id: "a2", label: "Filler 1", quality: "useful" as const },
-            { finding: "Filler", id: "a3", label: "Filler 2", quality: "weak" as const },
+            { feedback: "Filler", id: "a2", quality: "useful" as const, text: "Filler 1" },
+            { feedback: "Filler", id: "a3", quality: "weak" as const, text: "Filler 2" },
           ],
           variant: "action" as const,
         },
@@ -597,7 +575,7 @@ describe(checkStep, () => {
       });
       const answer: SelectedAnswer = {
         kind: "investigation",
-        selectedActionId: "nonexistent",
+        selectedOptionId: "nonexistent",
         variant: "action",
       };
       const { result } = checkStep(step, answer);
@@ -607,7 +585,7 @@ describe(checkStep, () => {
     test("call variant: best accuracy is correct with per-explanation feedback", () => {
       const step = buildStep({
         content: {
-          explanations: [
+          options: [
             {
               accuracy: "best" as const,
               feedback: "Correct — this fully explains it.",
@@ -627,7 +605,7 @@ describe(checkStep, () => {
       });
       const answer: SelectedAnswer = {
         kind: "investigation",
-        selectedExplanationId: "e1",
+        selectedOptionId: "e1",
         variant: "call",
       };
       const { result } = checkStep(step, answer);
@@ -638,7 +616,7 @@ describe(checkStep, () => {
     test("call variant: wrong accuracy is incorrect with its own feedback", () => {
       const step = buildStep({
         content: {
-          explanations: [
+          options: [
             {
               accuracy: "best" as const,
               feedback: "Correct — this fully explains it.",
@@ -658,7 +636,7 @@ describe(checkStep, () => {
       });
       const answer: SelectedAnswer = {
         kind: "investigation",
-        selectedExplanationId: "e2",
+        selectedOptionId: "e2",
         variant: "call",
       };
       const { result } = checkStep(step, answer);
@@ -674,7 +652,7 @@ describe(checkStep, () => {
         },
         kind: "investigation",
       });
-      const answer: SelectedAnswer = { kind: "multipleChoice", selectedIndex: 0, selectedText: "" };
+      const answer: SelectedAnswer = { kind: "multipleChoice", selectedOptionId: "missing" };
       const { result } = checkStep(step, answer);
       expect(result.isCorrect).toBe(false);
     });

--- a/packages/player/src/check-step.ts
+++ b/packages/player/src/check-step.ts
@@ -32,7 +32,7 @@ function checkMultipleChoice(step: SerializedStep, answer: SelectedAnswer): Chec
   }
 
   const content = parseStepContent("multipleChoice", step.content);
-  const result = checkMultipleChoiceAnswer(content, answer.selectedIndex);
+  const result = checkMultipleChoiceAnswer(content, answer.selectedOptionId);
 
   return { result };
 }
@@ -72,7 +72,7 @@ function checkSelectImage(step: SerializedStep, answer: SelectedAnswer): CheckSt
   }
 
   const content = parseStepContent("selectImage", step.content);
-  return { result: checkSelectImageAnswer(content, answer.selectedIndex) };
+  return { result: checkSelectImageAnswer(content, answer.selectedOptionId) };
 }
 
 function checkTranslationStep(step: SerializedStep, answer: SelectedAnswer): CheckStepResult {
@@ -85,7 +85,7 @@ function checkTranslationStep(step: SerializedStep, answer: SelectedAnswer): Che
   }
 
   return {
-    result: checkTranslationAnswer(step.word.id, answer.selectedWordId, step.word.word),
+    result: checkTranslationAnswer(step.word.id, answer.selectedOptionId, step.word.word),
   };
 }
 
@@ -169,7 +169,7 @@ function checkInvestigationActionStep(
   }
 
   return {
-    result: checkInvestigationActionAnswer(content, answer.selectedActionId),
+    result: checkInvestigationActionAnswer(content, answer.selectedOptionId),
   };
 }
 
@@ -185,7 +185,7 @@ function checkInvestigationCallStep(step: SerializedStep, answer: SelectedAnswer
   }
 
   return {
-    result: checkInvestigationCall(content, answer.selectedExplanationId),
+    result: checkInvestigationCall(content, answer.selectedOptionId),
   };
 }
 
@@ -196,7 +196,7 @@ function checkStory(step: SerializedStep, answer: SelectedAnswer): CheckStepResu
 
   const content = parseStepContent("story", step.content);
 
-  return { result: checkStoryAnswer(content, answer.selectedChoiceId) };
+  return { result: checkStoryAnswer(content, answer.selectedOptionId) };
 }
 
 const CHECKERS: Record<

--- a/packages/player/src/components/_utils/feedback-romanization.test.ts
+++ b/packages/player/src/components/_utils/feedback-romanization.test.ts
@@ -133,9 +133,7 @@ describe(getFeedbackRomanization, () => {
     it("returns word romanization on correct translation answer", () => {
       const result = buildResult({
         kind: "translation",
-        questionText: "hello",
-        selectedText: "こんにちは",
-        selectedWordId: "w-1",
+        selectedOptionId: "w-1",
       });
       const step = buildStep({ wordRomanization: "konnichiwa" });
 
@@ -153,9 +151,7 @@ describe(getFeedbackRomanization, () => {
     it("returns null when word romanization matches selected text (dedup)", () => {
       const result = buildResult({
         kind: "translation",
-        questionText: "hello",
-        selectedText: "konnichiwa",
-        selectedWordId: "w-1",
+        selectedOptionId: "w-1",
       });
       const step = buildStep({ wordRomanization: "konnichiwa" });
 
@@ -173,9 +169,7 @@ describe(getFeedbackRomanization, () => {
     it("returns word romanization on wrong translation's correct answer line", () => {
       const result = buildResult({
         kind: "translation",
-        questionText: "hello",
-        selectedText: "さようなら",
-        selectedWordId: "w-2",
+        selectedOptionId: "w-2",
       });
       const step = buildStep({ wordRomanization: "konnichiwa" });
 
@@ -193,9 +187,7 @@ describe(getFeedbackRomanization, () => {
     it("returns null wrongReading when word romanization matches correct answer (dedup)", () => {
       const result = buildResult({
         kind: "translation",
-        questionText: "hello",
-        selectedText: "wrong",
-        selectedWordId: "w-2",
+        selectedOptionId: "w-2",
       });
       const step = buildStep({ wordRomanization: "konnichiwa" });
 
@@ -203,7 +195,7 @@ describe(getFeedbackRomanization, () => {
         correctAnswer: "konnichiwa",
         questionText: "hello",
         result,
-        selectedText: "wrong",
+        selectedText: "さようなら",
         step,
       });
 
@@ -213,9 +205,7 @@ describe(getFeedbackRomanization, () => {
     it("returns null for translate field (only used by listening)", () => {
       const result = buildResult({
         kind: "translation",
-        questionText: "hello",
-        selectedText: "こんにちは",
-        selectedWordId: "w-1",
+        selectedOptionId: "w-1",
       });
       const step = buildStep({ wordRomanization: "konnichiwa" });
 
@@ -233,9 +223,7 @@ describe(getFeedbackRomanization, () => {
     it("returns null when step has no word", () => {
       const result = buildResult({
         kind: "translation",
-        questionText: "hello",
-        selectedText: "こんにちは",
-        selectedWordId: "w-1",
+        selectedOptionId: "w-1",
       });
       const step = buildStep();
 
@@ -291,7 +279,7 @@ describe(getFeedbackRomanization, () => {
         correctAnswer: "world",
         questionText: "こんにちは",
         result,
-        selectedText: "hello",
+        selectedText: null,
         step,
       });
 
@@ -304,8 +292,7 @@ describe(getFeedbackRomanization, () => {
     it("returns null for all fields", () => {
       const result = buildResult({
         kind: "multipleChoice",
-        selectedIndex: 0,
-        selectedText: "option A",
+        selectedOptionId: "option-a",
       });
       const step = buildStep({ sentenceRomanization: "romaji", wordRomanization: "romaji" });
 
@@ -313,7 +300,7 @@ describe(getFeedbackRomanization, () => {
         correctAnswer: null,
         questionText: null,
         result,
-        selectedText: "option A",
+        selectedText: null,
         step,
       });
 

--- a/packages/player/src/components/choice-step-layout.tsx
+++ b/packages/player/src/components/choice-step-layout.tsx
@@ -22,15 +22,25 @@ function ChoiceStepLayoutContent({
   onSelect,
   options,
   question,
-  selectedIndex,
+  selectedKey,
 }: {
   context?: string | null;
-  onSelect: (index: number) => void;
+  onSelect: (key: string) => void;
   options: readonly { key: string; text: string }[];
   question?: string | null;
-  selectedIndex: number | null;
+  selectedKey: string | null;
 }) {
-  const hasSelection = selectedIndex !== null;
+  const hasSelection = selectedKey !== null;
+
+  const handleSelect = (index: number) => {
+    const option = options[index];
+
+    if (!option) {
+      return;
+    }
+
+    onSelect(option.key);
+  };
 
   return (
     <>
@@ -42,11 +52,11 @@ function ChoiceStepLayoutContent({
       )}
 
       <PlayerChoiceSceneOptions
-        onSelect={onSelect}
-        options={options.map((option, index) => ({
+        onSelect={handleSelect}
+        options={options.map((option) => ({
           content: <PlayerChoiceSceneOptionText>{option.text}</PlayerChoiceSceneOptionText>,
-          isDimmed: hasSelection && selectedIndex !== index,
-          isSelected: selectedIndex === index,
+          isDimmed: hasSelection && selectedKey !== option.key,
+          isSelected: selectedKey === option.key,
           key: option.key,
         }))}
       />
@@ -126,14 +136,14 @@ export function ChoiceStepLayout({
   onSelect,
   options,
   question,
-  selectedIndex,
+  selectedKey,
 }: {
   context?: string | null;
   image?: StepImage | null;
-  onSelect: (index: number) => void;
+  onSelect: (key: string) => void;
   options: readonly { key: string; text: string }[];
   question?: string | null;
-  selectedIndex: number | null;
+  selectedKey: string | null;
 }) {
   const content = (
     <ChoiceStepLayoutContent
@@ -141,7 +151,7 @@ export function ChoiceStepLayout({
       onSelect={onSelect}
       options={options}
       question={question}
-      selectedIndex={selectedIndex}
+      selectedKey={selectedKey}
     />
   );
 

--- a/packages/player/src/components/feedback-screen.tsx
+++ b/packages/player/src/components/feedback-screen.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type SerializedStep } from "@zoonk/core/player/contracts/prepare-activity-data";
+import { parseStepContent } from "@zoonk/core/steps/contract/content";
 import { useExtracted } from "next-intl";
 import { type StepResult } from "../player-reducer";
 import { useReplaceName } from "../user-name-context";
@@ -21,9 +22,49 @@ function getArrangeWordsSelectedText(result: StepResult): string | null {
   return null;
 }
 
+/**
+ * Multiple-choice submissions store the option ID so shuffled options validate
+ * against the canonical content. The feedback screen still displays learner
+ * text, so it derives that text from the step content at render time.
+ */
+function getMultipleChoiceSelectedText(result: StepResult, step?: SerializedStep): string | null {
+  if (result.answer?.kind !== "multipleChoice" || step?.kind !== "multipleChoice") {
+    return null;
+  }
+
+  const { selectedOptionId } = result.answer;
+  const content = parseStepContent("multipleChoice", step.content);
+  return content.options.find((option) => option.id === selectedOptionId)?.text ?? null;
+}
+
+/**
+ * Translation answers use the same selectedOptionId shape as other option
+ * activities. The selected display text comes from the serialized option pool.
+ */
+function getTranslationSelectedText(result: StepResult, step?: SerializedStep): string | null {
+  if (result.answer?.kind !== "translation") {
+    return null;
+  }
+
+  const { selectedOptionId } = result.answer;
+  return step?.translationOptions.find((option) => option.id === selectedOptionId)?.word ?? null;
+}
+
+function getSelectedText(result: StepResult, step?: SerializedStep): string | null {
+  if (result.answer?.kind === "multipleChoice") {
+    return getMultipleChoiceSelectedText(result, step);
+  }
+
+  if (result.answer?.kind === "translation") {
+    return getTranslationSelectedText(result, step);
+  }
+
+  return getArrangeWordsSelectedText(result);
+}
+
 function getQuestionText(result: StepResult, step?: SerializedStep): string | null {
   if (result.answer?.kind === "translation") {
-    return result.answer.questionText;
+    return step?.word?.translation ?? null;
   }
 
   if (result.answer?.kind === "reading" && step?.sentence) {
@@ -58,10 +99,7 @@ function StandardFeedbackContent({ result, step }: { result: StepResult; step?: 
   const replaceName = useReplaceName();
   const { isCorrect, feedback: rawFeedback, correctAnswer } = result.result;
   const feedback = rawFeedback ? replaceName(rawFeedback) : null;
-  const selectedText =
-    result.answer?.kind === "multipleChoice" || result.answer?.kind === "translation"
-      ? result.answer.selectedText
-      : getArrangeWordsSelectedText(result);
+  const selectedText = getSelectedText(result, step);
   const questionText = getQuestionText(result, step);
   const rom = getFeedbackRomanization({
     correctAnswer,

--- a/packages/player/src/components/investigation-action-variant.tsx
+++ b/packages/player/src/components/investigation-action-variant.tsx
@@ -67,10 +67,10 @@ function useQuestionText(experimentNumber: number): string {
 
 /**
  * Renders the evidence feedback shown after checking an action.
- * Shows the quality indicator, finding text, and a transition message
+ * Shows the quality indicator, feedback text, and a transition message
  * after the final experiment to prepare the learner for the call step.
  */
-type ActionItem = ActionContent["actions"][number];
+type ActionItem = ActionContent["options"][number];
 
 function ActionFeedback({
   action,
@@ -86,7 +86,7 @@ function ActionFeedback({
     <PlayerReadScene>
       <PlayerReadSceneTitle tone={quality.tone}>{quality.label}</PlayerReadSceneTitle>
 
-      <PlayerReadSceneBody>{action.finding}</PlayerReadSceneBody>
+      <PlayerReadSceneBody>{action.feedback}</PlayerReadSceneBody>
 
       {isLastExperiment && (
         <PlayerSupportingText>
@@ -102,7 +102,7 @@ function ActionFeedback({
  *
  * Before checking: shows available actions (used ones filtered out).
  * After checking: shows evidence feedback — quality indicator
- * and finding text for the selected action.
+ * and feedback text for the selected action.
  */
 export function InvestigationActionVariant({
   content,
@@ -120,19 +120,19 @@ export function InvestigationActionVariant({
   const { state } = usePlayerRuntime();
 
   const loop = state.investigationLoop;
-  const usedIds = loop?.usedActionIds ?? [];
+  const usedIds = loop?.usedOptionIds ?? [];
   const experimentNumber = usedIds.length;
-  const availableActions = getAvailableActions(content.actions, usedIds);
+  const availableActions = getAvailableActions(content.options, usedIds);
   const hasFeedback = result !== undefined;
 
   const questionText = useQuestionText(experimentNumber);
 
-  const selectedActionId =
+  const selectedOptionId =
     selectedAnswer?.kind === "investigation" && selectedAnswer.variant === "action"
-      ? selectedAnswer.selectedActionId
+      ? selectedAnswer.selectedOptionId
       : null;
 
-  const hasSelection = selectedActionId !== null;
+  const hasSelection = selectedOptionId !== null;
 
   const handleSelect = (index: number) => {
     if (hasFeedback) {
@@ -145,22 +145,22 @@ export function InvestigationActionVariant({
       return;
     }
 
-    if (selectedActionId === action.id) {
+    if (selectedOptionId === action.id) {
       onSelectAnswer(step.id, null);
       return;
     }
 
     onSelectAnswer(step.id, {
       kind: "investigation",
-      selectedActionId: action.id,
+      selectedOptionId: action.id,
       variant: "action",
     });
   };
 
   const selectedAction =
-    selectedActionId === null
+    selectedOptionId === null
       ? null
-      : (content.actions.find((a) => a.id === selectedActionId) ?? null);
+      : (content.options.find((a) => a.id === selectedOptionId) ?? null);
 
   if (hasFeedback && selectedAction) {
     return (
@@ -182,9 +182,9 @@ export function InvestigationActionVariant({
         keyboardEnabled={!hasFeedback}
         onSelect={handleSelect}
         options={availableActions.map((action) => ({
-          content: <PlayerChoiceSceneOptionText>{action.label}</PlayerChoiceSceneOptionText>,
-          isDimmed: hasSelection && selectedActionId !== action.id,
-          isSelected: selectedActionId === action.id,
+          content: <PlayerChoiceSceneOptionText>{action.text}</PlayerChoiceSceneOptionText>,
+          isDimmed: hasSelection && selectedOptionId !== action.id,
+          isSelected: selectedOptionId === action.id,
           key: action.id,
         }))}
       />

--- a/packages/player/src/components/investigation-call-variant.tsx
+++ b/packages/player/src/components/investigation-call-variant.tsx
@@ -77,9 +77,9 @@ function QualityBadge({ quality }: { quality: InvestigationActionQuality }) {
 }
 
 type GatheredEvidence = {
-  finding: string;
-  label: string;
+  feedback: string;
   quality: InvestigationActionQuality;
+  text: string;
 };
 
 /**
@@ -106,14 +106,14 @@ function useGatheredEvidence(): GatheredEvidence[] {
     return [];
   }
 
-  return loop.usedActionIds.flatMap((id) => {
-    const action = actionContent.actions.find((a) => a.id === id);
+  return loop.usedOptionIds.flatMap((id) => {
+    const action = actionContent.options.find((a) => a.id === id);
 
     if (!action) {
       return [];
     }
 
-    return [{ finding: action.finding, label: action.label, quality: action.quality }];
+    return [{ feedback: action.feedback, quality: action.quality, text: action.text }];
   });
 }
 
@@ -121,11 +121,11 @@ function EvidenceItem({ item }: { item: GatheredEvidence }) {
   return (
     <div className="flex flex-col gap-1">
       <div className="flex items-start gap-2">
-        <p className="text-sm font-medium">{item.label}</p>
+        <p className="text-sm font-medium">{item.text}</p>
         <QualityBadge quality={item.quality} />
       </div>
 
-      <p className="text-muted-foreground text-sm leading-relaxed">{item.finding}</p>
+      <p className="text-muted-foreground text-sm leading-relaxed">{item.feedback}</p>
     </div>
   );
 }
@@ -159,7 +159,7 @@ function EvidenceDrawer({ evidence }: { evidence: GatheredEvidence[] }) {
         <DrawerContent>
           <div className="flex flex-col gap-5">
             {evidence.map((item) => (
-              <EvidenceItem item={item} key={item.label} />
+              <EvidenceItem item={item} key={item.text} />
             ))}
           </div>
         </DrawerContent>
@@ -189,13 +189,13 @@ export function InvestigationCallVariant({
 }) {
   const t = useExtracted();
 
-  const { explanations } = content;
+  const { options } = content;
   const hasFeedback = result !== undefined;
   const evidence = useGatheredEvidence();
 
   const selectedId =
     selectedAnswer?.kind === "investigation" && selectedAnswer.variant === "call"
-      ? selectedAnswer.selectedExplanationId
+      ? selectedAnswer.selectedOptionId
       : null;
 
   const hasSelection = selectedId !== null;
@@ -205,7 +205,7 @@ export function InvestigationCallVariant({
       return;
     }
 
-    const explanation = explanations[index];
+    const explanation = options[index];
 
     if (!explanation) {
       return;
@@ -218,7 +218,7 @@ export function InvestigationCallVariant({
 
     onSelectAnswer(step.id, {
       kind: "investigation",
-      selectedExplanationId: explanation.id,
+      selectedOptionId: explanation.id,
       variant: "call",
     });
   };
@@ -234,7 +234,7 @@ export function InvestigationCallVariant({
       <PlayerChoiceSceneOptions
         keyboardEnabled={!hasFeedback}
         onSelect={handleSelect}
-        options={explanations.map((explanation) => ({
+        options={options.map((explanation) => ({
           content: <PlayerChoiceSceneOptionText>{explanation.text}</PlayerChoiceSceneOptionText>,
           disabled: hasFeedback,
           isDimmed: hasSelection && selectedId !== explanation.id,

--- a/packages/player/src/components/multiple-choice-step.tsx
+++ b/packages/player/src/components/multiple-choice-step.tsx
@@ -5,12 +5,12 @@ import { parseStepContent } from "@zoonk/core/steps/contract/content";
 import { type SelectedAnswer } from "../player-reducer";
 import { ChoiceStepLayout } from "./choice-step-layout";
 
-function getSelectedIndex(selectedAnswer?: SelectedAnswer): number | null {
+function getSelectedOptionId(selectedAnswer?: SelectedAnswer): string | null {
   if (selectedAnswer?.kind !== "multipleChoice") {
     return null;
   }
 
-  return selectedAnswer.selectedIndex;
+  return selectedAnswer.selectedOptionId;
 }
 
 export function MultipleChoiceStep({
@@ -23,16 +23,15 @@ export function MultipleChoiceStep({
   step: SerializedStep;
 }) {
   const content = parseStepContent("multipleChoice", step.content);
-  const selectedIndex = getSelectedIndex(selectedAnswer);
+  const selectedOptionId = getSelectedOptionId(selectedAnswer);
 
-  const handleSelect = (index: number) => {
-    if (selectedIndex === index) {
+  const handleSelect = (optionId: string) => {
+    if (selectedOptionId === optionId) {
       onSelectAnswer(step.id, null);
       return;
     }
 
-    const selectedText = content.options[index]?.text ?? "";
-    onSelectAnswer(step.id, { kind: "multipleChoice", selectedIndex: index, selectedText });
+    onSelectAnswer(step.id, { kind: "multipleChoice", selectedOptionId: optionId });
   };
 
   return (
@@ -40,9 +39,9 @@ export function MultipleChoiceStep({
       context={content.context}
       image={content.image}
       onSelect={handleSelect}
-      options={content.options.map((option) => ({ key: option.text, text: option.text }))}
+      options={content.options.map((option) => ({ key: option.id, text: option.text }))}
       question={content.question}
-      selectedIndex={selectedIndex}
+      selectedKey={selectedOptionId}
     />
   );
 }

--- a/packages/player/src/components/select-image-step.tsx
+++ b/packages/player/src/components/select-image-step.tsx
@@ -13,24 +13,23 @@ import { InlineFeedback } from "./inline-feedback";
 import { QuestionText } from "./question-text";
 import { InteractiveStepLayout } from "./step-layouts";
 
-function getSelectedIndex(selectedAnswer?: SelectedAnswer): number | null {
+function getSelectedOptionId(selectedAnswer?: SelectedAnswer): string | null {
   if (selectedAnswer?.kind !== "selectImage") {
     return null;
   }
 
-  return selectedAnswer.selectedIndex;
+  return selectedAnswer.selectedOptionId;
 }
 
 function getImageOptionResultState(
-  index: number,
-  content: SelectImageStepContent,
-  selectedIndex: number,
+  option: SelectImageStepContent["options"][number],
+  selectedOptionId: string,
 ): "correct" | "incorrect" | null {
-  if (content.options[index]?.isCorrect) {
+  if (option.isCorrect) {
     return "correct";
   }
 
-  if (index === selectedIndex) {
+  if (option.id === selectedOptionId) {
     return "incorrect";
   }
 
@@ -112,7 +111,7 @@ export function SelectImageStep({
 }) {
   const t = useExtracted();
   const content = parseStepContent("selectImage", step.content);
-  const selectedIndex = getSelectedIndex(selectedAnswer);
+  const selectedOptionId = getSelectedOptionId(selectedAnswer);
   const hasResult = Boolean(result);
 
   const handleSelect = (index: number) => {
@@ -120,7 +119,13 @@ export function SelectImageStep({
       return;
     }
 
-    onSelectAnswer(step.id, { kind: "selectImage", selectedIndex: index });
+    const option = content.options[index];
+
+    if (!option) {
+      return;
+    }
+
+    onSelectAnswer(step.id, { kind: "selectImage", selectedOptionId: option.id });
   };
 
   useOptionKeyboard({
@@ -136,17 +141,18 @@ export function SelectImageStep({
       <div aria-label={t("Image options")} className="grid grid-cols-2 gap-3" role="radiogroup">
         {content.options.map((option, index) => {
           const resultState =
-            hasResult && selectedIndex !== null
-              ? getImageOptionResultState(index, content, selectedIndex)
+            hasResult && selectedOptionId
+              ? getImageOptionResultState(option, selectedOptionId)
               : null;
           const isDimmed = hasResult && !resultState;
+          const isSelected = selectedOptionId === option.id;
 
           return (
             <ImageOptionCard
               disabled={hasResult}
               isDimmed={isDimmed}
-              isSelected={selectedIndex === index}
-              key={option.prompt}
+              isSelected={isSelected}
+              key={option.id}
               onSelect={() => handleSelect(index)}
               prompt={option.prompt}
               resultState={resultState}

--- a/packages/player/src/components/story-feedback-content.tsx
+++ b/packages/player/src/components/story-feedback-content.tsx
@@ -14,7 +14,7 @@ import { PlayerFeedbackScene, PlayerFeedbackSceneMessage } from "./player-feedba
 import { PlayerReadSceneDivider, PlayerReadSceneMetaLabel } from "./player-read-scene";
 import { getStoryMetricValueClass } from "./story-metric-pill";
 
-type StoryChoice = StoryStepContent["choices"][number];
+type StoryOption = StoryStepContent["options"][number];
 
 type MetricDelta = {
   delta: number;
@@ -23,43 +23,37 @@ type MetricDelta = {
 };
 
 /**
- * Finds the selected choice by id because story choices are shuffled before
+ * Finds the selected option by id because story options are shuffled before
  * they reach the player. The rendered option index is only presentation state.
  */
-function getSelectedChoice({
+function getSelectedOption({
   content,
-  selectedChoiceId,
+  selectedOptionId,
 }: {
   content: StoryStepContent;
-  selectedChoiceId: string;
+  selectedOptionId: string;
 }) {
-  return content.choices.find((choice) => choice.id === selectedChoiceId) ?? null;
+  return content.options.find((option) => option.id === selectedOptionId) ?? null;
 }
 
 /**
- * Returns the immediate effect one choice had on a metric. Metrics that were
- * not touched by the selected choice still need a row in feedback so learners
+ * Returns the immediate effect one option had on a metric. Metrics that were
+ * not touched by the selected option still need a row in feedback so learners
  * keep the full story state in view.
  */
-function getChoiceMetricDelta({ choice, metric }: { choice: StoryChoice; metric: string }) {
-  const effect = choice.metricEffects.find((entry) => entry.metric === metric);
+function getOptionMetricDelta({ metric, option }: { metric: string; option: StoryOption }) {
+  const effect = option.metricEffects.find((entry) => entry.metric === metric);
   return effect ? EFFECT_DELTA_MAP[effect.effect] : 0;
 }
 
 /**
  * Computes a full metric snapshot for feedback. Every defined story metric is
- * shown, with changed metrics first so the consequence is easy to scan before
+ * shown, with changed metrics first so the feedback is easy to scan before
  * the unchanged state rows.
  */
-function getMetricDeltas({
-  choice,
-  metrics,
-}: {
-  choice: StoryChoice;
-  metrics: StoryMetric[];
-}): MetricDelta[] {
+function getMetricDeltas({ metrics, option }: { metrics: StoryMetric[]; option: StoryOption }) {
   const metricDeltas = metrics.map((entry) => ({
-    delta: getChoiceMetricDelta({ choice, metric: entry.metric }),
+    delta: getOptionMetricDelta({ metric: entry.metric, option }),
     metric: entry.metric,
     value: entry.value,
   }));
@@ -72,7 +66,7 @@ function getMetricDeltas({
 
 /**
  * Formats metric deltas once so the visual value and accessible row label stay
- * in sync. Positive effects need the plus sign because story choices can move
+ * in sync. Positive effects need the plus sign because story options can move
  * several metrics in different directions at the same time.
  */
 function formatMetricDelta(delta: number) {
@@ -105,8 +99,8 @@ function getMetricDeltaClass(delta: number) {
 }
 
 /**
- * Renders one consequence impact as a quiet row instead of another gameplay
- * pill. The delta answers "what did my choice do?", and the final value
+ * Renders one feedback impact as a quiet row instead of another gameplay
+ * pill. The delta answers "what did my option do?", and the final value
  * answers "where does that leave the story now?"
  */
 function MetricDeltaRow({ delta, metric, value }: MetricDelta) {
@@ -131,11 +125,11 @@ function MetricDeltaRow({ delta, metric, value }: MetricDelta) {
 }
 
 /**
- * Story-specific feedback screen showing the consequence narrative and
+ * Story-specific feedback screen showing the feedback narrative and
  * metric deltas.
  *
  * Intentionally omits correct/incorrect framing — in stories, the
- * consequence IS the feedback. There are no "Your answer" / "Correct answer"
+ * feedback IS the result. There are no "Your answer" / "Correct answer"
  * blocks, no green check or red X.
  */
 export function StoryFeedbackContent({
@@ -151,35 +145,35 @@ export function StoryFeedbackContent({
   const metricChangesLabel = t("Metric changes");
   const storyContent = step ? parseStepContent("story", step.content) : null;
   const answer = result.answer?.kind === "story" ? result.answer : null;
-  const selectedChoice =
+  const selectedOption =
     storyContent && answer
-      ? getSelectedChoice({ content: storyContent, selectedChoiceId: answer.selectedChoiceId })
+      ? getSelectedOption({ content: storyContent, selectedOptionId: answer.selectedOptionId })
       : null;
 
-  if (!answer || !selectedChoice) {
+  if (!answer || !selectedOption) {
     return null;
   }
 
-  const metricDeltas = getMetricDeltas({ choice: selectedChoice, metrics: getStoryMetrics(state) });
-  const consequence = result.result.feedback;
+  const metricDeltas = getMetricDeltas({ metrics: getStoryMetrics(state), option: selectedOption });
+  const feedback = result.result.feedback;
 
   return (
     <PlayerFeedbackScene>
       <ExpandableStepImageStage
         className="aspect-square w-full rounded-3xl"
         fit="contain"
-        image={selectedChoice.stateImage}
+        image={selectedOption.stateImage}
       />
 
       <div className="flex flex-col gap-3">
         <div className="flex min-w-0 flex-col gap-1">
           <p className="text-foreground text-sm font-medium sm:text-base">
-            {replaceName(answer.selectedText)}
+            {replaceName(selectedOption.text)}
           </p>
         </div>
 
-        {consequence && (
-          <PlayerFeedbackSceneMessage>{replaceName(consequence)}</PlayerFeedbackSceneMessage>
+        {feedback && (
+          <PlayerFeedbackSceneMessage>{replaceName(feedback)}</PlayerFeedbackSceneMessage>
         )}
       </div>
 

--- a/packages/player/src/components/story-outcome-content.tsx
+++ b/packages/player/src/components/story-outcome-content.tsx
@@ -7,7 +7,7 @@ import { type StoryOutcomeTier } from "@zoonk/utils/activities";
 import { useExtracted } from "next-intl";
 import { usePlayerRuntime } from "../player-context";
 import { type PlayerState } from "../player-reducer";
-import { findSelectedChoice, getStoryMetrics } from "../player-selectors";
+import { findSelectedStoryOption, getStoryMetrics } from "../player-selectors";
 import { getStoryOutcomeDisplayTier } from "../story-outcome";
 import {
   PlayerReadSceneBody,
@@ -40,8 +40,8 @@ function getStoryStepAlignment({
   results: PlayerState["results"];
   step: SerializedStep;
 }): StoryAlignment {
-  const choice = findSelectedChoice({ results, step });
-  return choice?.alignment ?? "weak";
+  const option = findSelectedStoryOption({ results, step });
+  return option?.alignment ?? "weak";
 }
 
 /**
@@ -92,7 +92,7 @@ function getOutcomeTierTone(tier: StoryOutcomeTier): PlayerReadSceneTitleTone {
 }
 
 /**
- * Outcome screen shown after the final decision step's consequence.
+ * Outcome screen shown after the final decision step feedback.
  *
  * Displays the narrative result of the player's decisions with a
  * tone-coded title reflecting how well they did.

--- a/packages/player/src/components/story-step.tsx
+++ b/packages/player/src/components/story-step.tsx
@@ -5,24 +5,12 @@ import { parseStepContent } from "@zoonk/core/steps/contract/content";
 import { type SelectedAnswer } from "../player-reducer";
 import { ChoiceStepLayout } from "./choice-step-layout";
 
-function getSelectedIndex({
-  choices,
-  selectedAnswer,
-}: {
-  choices: { id: string }[];
-  selectedAnswer?: SelectedAnswer;
-}): number | null {
+function getSelectedOptionId(selectedAnswer?: SelectedAnswer): string | null {
   if (selectedAnswer?.kind !== "story") {
     return null;
   }
 
-  const index = choices.findIndex((choice) => choice.id === selectedAnswer.selectedChoiceId);
-
-  if (index === -1) {
-    return null;
-  }
-
-  return index;
+  return selectedAnswer.selectedOptionId;
 }
 
 export function StoryStep({
@@ -35,24 +23,23 @@ export function StoryStep({
   step: SerializedStep;
 }) {
   const content = parseStepContent("story", step.content);
-  const selectedIndex = getSelectedIndex({ choices: content.choices, selectedAnswer });
+  const selectedOptionId = getSelectedOptionId(selectedAnswer);
 
-  const handleSelect = (index: number) => {
-    const choice = content.choices[index];
+  const handleSelect = (optionId: string) => {
+    const option = content.options.find((item) => item.id === optionId);
 
-    if (!choice) {
+    if (!option) {
       return;
     }
 
-    if (selectedIndex === index) {
+    if (selectedOptionId === option.id) {
       onSelectAnswer(step.id, null);
       return;
     }
 
     onSelectAnswer(step.id, {
       kind: "story",
-      selectedChoiceId: choice.id,
-      selectedText: choice.text,
+      selectedOptionId: option.id,
     });
   };
 
@@ -61,8 +48,8 @@ export function StoryStep({
       context={content.problem}
       image={content.image}
       onSelect={handleSelect}
-      options={content.choices.map((choice) => ({ key: choice.id, text: choice.text }))}
-      selectedIndex={selectedIndex}
+      options={content.options.map((option) => ({ key: option.id, text: option.text }))}
+      selectedKey={selectedOptionId}
     />
   );
 }

--- a/packages/player/src/components/translation-step.tsx
+++ b/packages/player/src/components/translation-step.tsx
@@ -17,12 +17,12 @@ import {
 } from "./player-choice-scene";
 import { RomanizationText } from "./romanization-text";
 
-function getSelectedWordId(selectedAnswer?: SelectedAnswer): string | null {
+function getSelectedOptionId(selectedAnswer?: SelectedAnswer): string | null {
   if (selectedAnswer?.kind !== "translation") {
     return null;
   }
 
-  return selectedAnswer.selectedWordId;
+  return selectedAnswer.selectedOptionId;
 }
 
 function TranslationOptionContent({
@@ -56,7 +56,7 @@ export function TranslationStep({
 }) {
   const t = useExtracted();
   const correctWord = step.word;
-  const selectedWordId = getSelectedWordId(selectedAnswer);
+  const selectedOptionId = getSelectedOptionId(selectedAnswer);
   const options = step.translationOptions;
 
   const { play } = useWordAudio({
@@ -71,12 +71,7 @@ export function TranslationStep({
     }
 
     play(word.audioUrl);
-    onSelectAnswer(step.id, {
-      kind: "translation",
-      questionText: correctWord?.translation ?? "",
-      selectedText: word.word,
-      selectedWordId: word.id,
-    });
+    onSelectAnswer(step.id, { kind: "translation", selectedOptionId: word.id });
   };
 
   if (!correctWord) {
@@ -94,8 +89,10 @@ export function TranslationStep({
         keyboardEnabled={!selectedAnswer || selectedAnswer.kind === "translation"}
         onSelect={handleSelect}
         options={options.map((word) => ({
-          content: <TranslationOptionContent isSelected={selectedWordId === word.id} word={word} />,
-          isSelected: selectedWordId === word.id,
+          content: (
+            <TranslationOptionContent isSelected={selectedOptionId === word.id} word={word} />
+          ),
+          isSelected: selectedOptionId === word.id,
           key: word.id,
         }))}
       />

--- a/packages/player/src/investigation-call-verdict.ts
+++ b/packages/player/src/investigation-call-verdict.ts
@@ -30,7 +30,7 @@ export function getInvestigationCallVerdict({
     return result.result.isCorrect ? "best" : "wrong";
   }
 
-  const explanation = content.explanations.find((item) => item.id === answer.selectedExplanationId);
+  const explanation = content.options.find((item) => item.id === answer.selectedOptionId);
 
   if (!explanation) {
     return "wrong";

--- a/packages/player/src/investigation-reducer.ts
+++ b/packages/player/src/investigation-reducer.ts
@@ -12,7 +12,7 @@ import { type PlayerState, type SelectedAnswer } from "./player-reducer";
  * across the fixed experiments.
  */
 function initInvestigationLoop(): InvestigationLoopState {
-  return { actionTimings: [], usedActionIds: [] };
+  return { actionTimings: [], usedOptionIds: [] };
 }
 
 /**
@@ -37,7 +37,7 @@ export function recordActionInLoop({
   return {
     ...loop,
     actionTimings: [...loop.actionTimings, timing],
-    usedActionIds: [...loop.usedActionIds, answer.selectedActionId],
+    usedOptionIds: [...loop.usedOptionIds, answer.selectedOptionId],
   };
 }
 
@@ -92,7 +92,7 @@ export function continueFromAction(state: PlayerState): PlayerState {
     return state;
   }
 
-  const experimentsDone = loop.usedActionIds.length;
+  const experimentsDone = loop.usedOptionIds.length;
 
   if (experimentsDone >= INVESTIGATION_EXPERIMENT_COUNT) {
     const callStep = getInvestigationStepByVariant(state.steps, "call");

--- a/packages/player/src/investigation.test.ts
+++ b/packages/player/src/investigation.test.ts
@@ -37,31 +37,31 @@ const problemContent = {
 };
 
 const actionContent = {
-  actions: [
+  options: [
     {
-      finding: "Logs show memory climbing",
+      feedback: "Logs show memory climbing",
       id: "a1",
-      label: "Check logs",
       quality: "critical" as const,
+      text: "Check logs",
     },
     {
-      finding: "Witness saw restart",
+      feedback: "Witness saw restart",
       id: "a2",
-      label: "Ask witness",
       quality: "useful" as const,
+      text: "Ask witness",
     },
     {
-      finding: "Nothing useful here",
+      feedback: "Nothing useful here",
       id: "a3",
-      label: "Random check",
       quality: "weak" as const,
+      text: "Random check",
     },
   ],
   variant: "action" as const,
 };
 
 const callContent = {
-  explanations: [
+  options: [
     {
       accuracy: "best" as const,
       feedback: "Correct — memory leak.",
@@ -126,9 +126,9 @@ describe("computeActivityScore (investigation)", () => {
 
 describe(getAvailableActions, () => {
   const actions = [
-    { id: "a1", label: "Check logs", quality: "critical" as const },
-    { id: "a2", label: "Ask witness", quality: "useful" as const },
-    { id: "a3", label: "Read docs", quality: "weak" as const },
+    { id: "a1", quality: "critical" as const, text: "Check logs" },
+    { id: "a2", quality: "useful" as const, text: "Ask witness" },
+    { id: "a3", quality: "weak" as const, text: "Read docs" },
   ];
 
   test("returns all actions when none used", () => {
@@ -143,7 +143,7 @@ describe(getAvailableActions, () => {
     const available = getAvailableActions(actions, ["a1", "a3"]);
     expect(available).toHaveLength(1);
     expect(available[0]?.id).toBe("a2");
-    expect(available[0]?.label).toBe("Ask witness");
+    expect(available[0]?.text).toBe("Ask witness");
   });
 
   test("returns empty when all actions used", () => {
@@ -175,15 +175,15 @@ describe(getInvestigationStepByVariant, () => {
 describe("server/client agreement after shuffling", () => {
   test("action correctness is the same regardless of array order", () => {
     const original = {
-      actions: [
-        { finding: "F1", id: "a-critical", label: "Critical action", quality: "critical" as const },
-        { finding: "F2", id: "a-useful", label: "Useful action", quality: "useful" as const },
-        { finding: "F3", id: "a-weak", label: "Weak action", quality: "weak" as const },
+      options: [
+        { feedback: "F1", id: "a-critical", quality: "critical" as const, text: "Critical action" },
+        { feedback: "F2", id: "a-useful", quality: "useful" as const, text: "Useful action" },
+        { feedback: "F3", id: "a-weak", quality: "weak" as const, text: "Weak action" },
       ],
       variant: "action" as const,
     };
 
-    const shuffled = { ...original, actions: shuffle(original.actions) };
+    const shuffled = { ...original, options: shuffle(original.options) };
 
     // Pick the weak action from the shuffled array by ID
     const resultFromShuffled = checkInvestigationAction(shuffled, "a-weak");
@@ -196,14 +196,14 @@ describe("server/client agreement after shuffling", () => {
 
   test("explanation correctness is the same regardless of array order", () => {
     const original = {
-      explanations: [
+      options: [
         { accuracy: "best" as const, feedback: "Correct!", id: "e-best", text: "Best" },
         { accuracy: "wrong" as const, feedback: "Wrong.", id: "e-wrong", text: "Wrong" },
       ],
       variant: "call" as const,
     };
 
-    const shuffled = { ...original, explanations: shuffle(original.explanations) };
+    const shuffled = { ...original, options: shuffle(original.options) };
 
     const resultFromShuffled = checkInvestigationCall(shuffled, "e-best");
     const resultFromOriginal = checkInvestigationCall(original, "e-best");
@@ -218,7 +218,7 @@ describe("investigation content schema validation", () => {
   test("rejects action content with fewer than 2 actions", () => {
     expect(() =>
       parseStepContent("investigation", {
-        actions: [{ finding: "F1", id: "a1", label: "Action 1", quality: "critical" }],
+        options: [{ feedback: "F1", id: "a1", quality: "critical", text: "Action 1" }],
         variant: "action",
       }),
     ).toThrow();
@@ -226,9 +226,9 @@ describe("investigation content schema validation", () => {
 
   test("accepts action content with exactly 2 actions", () => {
     const result = parseStepContent("investigation", {
-      actions: [
-        { finding: "F1", id: "a1", label: "Action 1", quality: "critical" },
-        { finding: "F2", id: "a2", label: "Action 2", quality: "useful" },
+      options: [
+        { feedback: "F1", id: "a1", quality: "critical", text: "Action 1" },
+        { feedback: "F2", id: "a2", quality: "useful", text: "Action 2" },
       ],
       variant: "action",
     });
@@ -236,7 +236,7 @@ describe("investigation content schema validation", () => {
     expect(result.variant).toBe("action");
 
     if (result.variant === "action") {
-      expect(result.actions).toHaveLength(2);
+      expect(result.options).toHaveLength(2);
     }
   });
 });

--- a/packages/player/src/investigation.ts
+++ b/packages/player/src/investigation.ts
@@ -14,7 +14,7 @@ export type ActionTiming = {
 
 export type InvestigationLoopState = {
   actionTimings: ActionTiming[];
-  usedActionIds: string[];
+  usedOptionIds: string[];
 };
 
 type InvestigationVariant = InvestigationStepContent["variant"];
@@ -60,12 +60,12 @@ export function getInvestigationStepByVariant(
  * order-independent (safe across shuffling).
  */
 export function getAvailableActions(
-  actions: { id: string; label: string; quality: InvestigationActionQuality }[],
+  options: { id: string; quality: InvestigationActionQuality; text: string }[],
   usedIds: string[],
-): { id: string; label: string; quality: InvestigationActionQuality }[] {
+): { id: string; quality: InvestigationActionQuality; text: string }[] {
   const usedSet = new Set(usedIds);
 
-  return actions.flatMap((action) =>
-    usedSet.has(action.id) ? [] : [{ id: action.id, label: action.label, quality: action.quality }],
+  return options.flatMap((action) =>
+    usedSet.has(action.id) ? [] : [{ id: action.id, quality: action.quality, text: action.text }],
   );
 }

--- a/packages/player/src/player-completion.test.ts
+++ b/packages/player/src/player-completion.test.ts
@@ -42,10 +42,10 @@ function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
 }
 
 const storyStepContent = {
-  choices: [
+  options: [
     {
       alignment: "strong" as const,
-      consequence: "Things improve.",
+      feedback: "Things improve.",
       id: "1a",
       metricEffects: [{ effect: "positive" as const, metric: "Production" }],
       stateImage: { prompt: "State after the strong choice" },
@@ -53,7 +53,7 @@ const storyStepContent = {
     },
     {
       alignment: "partial" as const,
-      consequence: "Mixed results.",
+      feedback: "Mixed results.",
       id: "1b",
       metricEffects: [{ effect: "neutral" as const, metric: "Production" }],
       stateImage: { prompt: "State after the partial choice" },
@@ -61,7 +61,7 @@ const storyStepContent = {
     },
     {
       alignment: "weak" as const,
-      consequence: "Things get worse.",
+      feedback: "Things get worse.",
       id: "1c",
       metricEffects: [{ effect: "negative" as const, metric: "Production" }],
       stateImage: { prompt: "State after the weak choice" },
@@ -75,14 +75,14 @@ function buildStoryStep(id: string, position: number): SerializedStep {
   return buildStep({ content: storyStepContent, id, kind: "story", position });
 }
 
-function buildStoryAnswer(selectedChoiceId: string): SelectedAnswer {
-  return { kind: "story", selectedChoiceId, selectedText: "choice" };
+function buildStoryAnswer(selectedOptionId: string): SelectedAnswer {
+  return { kind: "story", selectedOptionId };
 }
 
-function buildStoryResult(stepId: string, selectedChoiceId: string): StepResult {
+function buildStoryResult(stepId: string, selectedOptionId: string): StepResult {
   return {
-    answer: buildStoryAnswer(selectedChoiceId),
-    result: { correctAnswer: null, feedback: null, isCorrect: selectedChoiceId !== "1c" },
+    answer: buildStoryAnswer(selectedOptionId),
+    result: { correctAnswer: null, feedback: null, isCorrect: selectedOptionId !== "1c" },
     stepId,
   };
 }
@@ -94,7 +94,7 @@ describe(computeLocalCompletion, () => {
         buildStep({
           content: {
             kind: "core" as const,
-            options: [{ feedback: "Yes", isCorrect: true, text: "A" }],
+            options: [{ feedback: "Yes", id: "a", isCorrect: true, text: "A" }],
           },
           id: "mc-1",
           kind: "multipleChoice",
@@ -103,7 +103,7 @@ describe(computeLocalCompletion, () => {
 
       const results: Record<string, StepResult> = {
         "mc-1": {
-          answer: { kind: "multipleChoice", selectedIndex: 0, selectedText: "A" },
+          answer: { kind: "multipleChoice", selectedOptionId: "a" },
           result: { correctAnswer: null, feedback: "Yes", isCorrect: true },
           stepId: "mc-1",
         },
@@ -267,21 +267,21 @@ describe(computeLocalCompletion, () => {
 
   describe("investigation activities", () => {
     const actionContent = {
-      actions: [
+      options: [
         {
-          finding: "Critical evidence",
+          feedback: "Critical evidence",
           id: "a1",
-          label: "Check logs",
           quality: "critical" as const,
+          text: "Check logs",
         },
-        { finding: "Useful data", id: "a2", label: "Review metrics", quality: "useful" as const },
-        { finding: "Nothing here", id: "a3", label: "Random check", quality: "weak" as const },
+        { feedback: "Useful data", id: "a2", quality: "useful" as const, text: "Review metrics" },
+        { feedback: "Nothing here", id: "a3", quality: "weak" as const, text: "Random check" },
       ],
       variant: "action" as const,
     };
 
     const callContent = {
-      explanations: [
+      options: [
         { accuracy: "best" as const, feedback: "Correct!", id: "e1", text: "Memory leak" },
         { accuracy: "wrong" as const, feedback: "Wrong.", id: "e2", text: "Network" },
       ],
@@ -295,12 +295,12 @@ describe(computeLocalCompletion, () => {
       ];
 
       const selectedAnswers: Record<string, SelectedAnswer> = {
-        "call-1": { kind: "investigation", selectedExplanationId: "e2", variant: "call" },
+        "call-1": { kind: "investigation", selectedOptionId: "e2", variant: "call" },
       };
 
       const investigationLoop = {
         actionTimings: [],
-        usedActionIds: ["a1", "a3"], // critical, weak
+        usedOptionIds: ["a1", "a3"], // critical, weak
       };
 
       const completion = computeLocalCompletion(
@@ -325,12 +325,12 @@ describe(computeLocalCompletion, () => {
       ];
 
       const selectedAnswers: Record<string, SelectedAnswer> = {
-        "call-1": { kind: "investigation", selectedExplanationId: "e1", variant: "call" },
+        "call-1": { kind: "investigation", selectedOptionId: "e1", variant: "call" },
       };
 
       const investigationLoop = {
         actionTimings: [],
-        usedActionIds: ["a1", "a2"], // critical, useful — all correct
+        usedOptionIds: ["a1", "a2"], // critical, useful — all correct
       };
 
       const completion = computeLocalCompletion(

--- a/packages/player/src/player-controller.test.ts
+++ b/packages/player/src/player-controller.test.ts
@@ -72,7 +72,7 @@ describe(getPlayerTransition, () => {
 
   test("does not persist completion for non-terminal actions", () => {
     const action: PlayerAction = {
-      answer: { kind: "multipleChoice", selectedIndex: 0, selectedText: "A" },
+      answer: { kind: "multipleChoice", selectedOptionId: "a" },
       stepId: "step-1",
       type: "SELECT_ANSWER",
     };
@@ -89,7 +89,7 @@ describe(buildCompletionInput, () => {
     const now = new Date("2026-03-18T18:45:00.000Z");
     const state = buildState({
       selectedAnswers: {
-        "step-1": { kind: "multipleChoice", selectedIndex: 0, selectedText: "A" },
+        "step-1": { kind: "multipleChoice", selectedOptionId: "a" },
       },
       stepTimings: {
         "step-1": {
@@ -104,8 +104,9 @@ describe(buildCompletionInput, () => {
     expect(buildCompletionInput(state, now)).toEqual({
       activityId: "activity-1",
       answers: {
-        "step-1": { kind: "multipleChoice", selectedIndex: 0, selectedText: "A" },
+        "step-1": { kind: "multipleChoice", selectedOptionId: "a" },
       },
+      investigationLoop: undefined,
       localDate: "2026-03-18",
       startedAt: 1000,
       stepTimings: {

--- a/packages/player/src/player-haptics.test.ts
+++ b/packages/player/src/player-haptics.test.ts
@@ -45,10 +45,10 @@ describe(getPlayerHapticSequence, () => {
   test("keeps story consequence haptics for positive feedback", () => {
     const step = buildStep({
       content: {
-        choices: [
+        options: [
           {
             alignment: "strong" as const,
-            consequence: "Things improve.",
+            feedback: "Things improve.",
             id: "choice-1",
             metricEffects: [{ effect: "positive" as const, metric: "Morale" }],
             stateImage: { prompt: "State after the helpful choice" },
@@ -66,7 +66,7 @@ describe(getPlayerHapticSequence, () => {
         metrics: [{ metric: "Morale", value: 65 }],
         phase: "feedback",
         result: buildResult({
-          answer: { kind: "story", selectedChoiceId: "choice-1", selectedText: "Help" },
+          answer: { kind: "story", selectedOptionId: "choice-1" },
           stepId: "story-1",
         }),
         step,
@@ -116,8 +116,8 @@ describe(getPlayerHapticSequence, () => {
       content: {
         kind: "core" as const,
         options: [
-          { feedback: "Nope", isCorrect: false, text: "A" },
-          { feedback: "Yes", isCorrect: true, text: "B" },
+          { feedback: "Nope", id: "a", isCorrect: false, text: "A" },
+          { feedback: "Yes", id: "b", isCorrect: true, text: "B" },
         ],
         question: "Choose",
       },
@@ -129,7 +129,7 @@ describe(getPlayerHapticSequence, () => {
       current: buildSnapshot({
         phase: "feedback",
         result: buildResult({
-          answer: { kind: "multipleChoice", selectedIndex: 0, selectedText: "A" },
+          answer: { kind: "multipleChoice", selectedOptionId: "a" },
           result: { correctAnswer: null, feedback: "Nope", isCorrect: false },
           stepId: "mc-1",
         }),
@@ -175,9 +175,9 @@ describe(getPlayerHapticSequence, () => {
     });
     const currentStep = buildStep({
       content: {
-        actions: [
-          { finding: "CPU spiked.", id: "a1", label: "Check logs", quality: "critical" },
-          { finding: "Nothing useful.", id: "a2", label: "Refresh cache", quality: "weak" },
+        options: [
+          { feedback: "CPU spiked.", id: "a1", quality: "critical", text: "Check logs" },
+          { feedback: "Nothing useful.", id: "a2", quality: "weak", text: "Refresh cache" },
         ],
         variant: "action" as const,
       },
@@ -197,9 +197,9 @@ describe(getPlayerHapticSequence, () => {
   test("only celebrates investigation action feedback when the clue is strong", () => {
     const step = buildStep({
       content: {
-        actions: [
-          { finding: "CPU spiked.", id: "a1", label: "Check logs", quality: "critical" },
-          { finding: "Nothing useful.", id: "a2", label: "Refresh cache", quality: "weak" },
+        options: [
+          { feedback: "CPU spiked.", id: "a1", quality: "critical", text: "Check logs" },
+          { feedback: "Nothing useful.", id: "a2", quality: "weak", text: "Refresh cache" },
         ],
         variant: "action" as const,
       },
@@ -211,7 +211,7 @@ describe(getPlayerHapticSequence, () => {
       current: buildSnapshot({
         phase: "feedback",
         result: buildResult({
-          answer: { kind: "investigation", selectedActionId: "a1", variant: "action" },
+          answer: { kind: "investigation", selectedOptionId: "a1", variant: "action" },
           result: { correctAnswer: null, feedback: "CPU spiked.", isCorrect: true },
           stepId: "inv-action",
         }),
@@ -227,7 +227,7 @@ describe(getPlayerHapticSequence, () => {
   test("uses a softer haptic for a partial investigation call", () => {
     const step = buildStep({
       content: {
-        explanations: [
+        options: [
           {
             accuracy: "partial" as const,
             feedback: "Close, but not quite.",
@@ -246,7 +246,7 @@ describe(getPlayerHapticSequence, () => {
       current: buildSnapshot({
         phase: "feedback",
         result: buildResult({
-          answer: { kind: "investigation", selectedExplanationId: "exp-1", variant: "call" },
+          answer: { kind: "investigation", selectedOptionId: "exp-1", variant: "call" },
           result: { correctAnswer: null, feedback: "Close, but not quite.", isCorrect: false },
           stepId: "inv-call",
         }),

--- a/packages/player/src/player-haptics.ts
+++ b/packages/player/src/player-haptics.ts
@@ -82,7 +82,7 @@ function getStoryConsequenceHaptic({
  * Warns when a story metric crosses into a danger or critical band.
  *
  * Threshold haptics are distinct from consequence haptics: they communicate
- * state urgency, not the immediate quality of a single choice.
+ * state urgency, not the immediate quality of a single option.
  */
 function getStoryThresholdHaptic({
   currentMetrics,
@@ -165,7 +165,7 @@ function getInvestigationActionFeedbackHaptic({
     return null;
   }
 
-  const action = content.actions.find((item) => item.id === answer.selectedActionId);
+  const action = content.options.find((item) => item.id === answer.selectedOptionId);
 
   if (!action) {
     return null;

--- a/packages/player/src/player-reducer.test.ts
+++ b/packages/player/src/player-reducer.test.ts
@@ -14,8 +14,8 @@ import {
 const coreMultipleChoiceContent = {
   kind: "core" as const,
   options: [
-    { feedback: "Yes", isCorrect: true, text: "A" },
-    { feedback: "No", isCorrect: false, text: "B" },
+    { feedback: "Yes", id: "option-a", isCorrect: true, text: "A" },
+    { feedback: "No", id: "option-b", isCorrect: false, text: "B" },
   ],
 };
 
@@ -78,8 +78,7 @@ function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
 
 const multipleChoiceAnswer: SelectedAnswer = {
   kind: "multipleChoice",
-  selectedIndex: 0,
-  selectedText: "Option A",
+  selectedOptionId: "option-a",
 };
 
 describe(createInitialState, () => {
@@ -154,7 +153,7 @@ describe("SELECT_ANSWER", () => {
   test("overwrites previous answer for same step", () => {
     const state = buildState({
       selectedAnswers: {
-        "step-1": { kind: "multipleChoice", selectedIndex: 1, selectedText: "Option B" },
+        "step-1": { kind: "multipleChoice", selectedOptionId: "option-b" },
       },
     });
     const next = playerReducer(state, {
@@ -264,10 +263,10 @@ describe("CHECK_ANSWER", () => {
 
   test("story step enters feedback phase instead of auto-continuing", () => {
     const storyContent = {
-      choices: [
+      options: [
         {
           alignment: "strong" as const,
-          consequence: "Things improve.",
+          feedback: "Things improve.",
           id: "1a",
           metricEffects: [{ effect: "positive" as const, metric: "Production" }],
           stateImage: { prompt: "State after the strong choice" },
@@ -275,7 +274,7 @@ describe("CHECK_ANSWER", () => {
         },
         {
           alignment: "weak" as const,
-          consequence: "Things get worse.",
+          feedback: "Things get worse.",
           id: "1b",
           metricEffects: [{ effect: "negative" as const, metric: "Production" }],
           stateImage: { prompt: "State after the weak choice" },
@@ -848,8 +847,7 @@ describe("edge cases", () => {
     const step = buildMultipleChoiceStep({ id: "mc-1" });
     const answer: SelectedAnswer = {
       kind: "multipleChoice",
-      selectedIndex: 2,
-      selectedText: "Option C",
+      selectedOptionId: "option-c",
     };
     const state = buildState({ selectedAnswers: { "mc-1": answer }, steps: [step] });
     const next = playerReducer(state, {

--- a/packages/player/src/player-reducer.ts
+++ b/packages/player/src/player-reducer.ts
@@ -18,17 +18,17 @@ export type PlayerPhase = "playing" | "feedback" | "completed";
 
 export type SelectedAnswer =
   | { kind: "fillBlank"; userAnswers: string[] }
-  | { kind: "investigation"; variant: "action"; selectedActionId: string }
-  | { kind: "investigation"; variant: "call"; selectedExplanationId: string }
+  | { kind: "investigation"; variant: "action"; selectedOptionId: string }
+  | { kind: "investigation"; variant: "call"; selectedOptionId: string }
   | { kind: "investigation"; variant: "problem" }
   | { kind: "listening"; arrangedWords: string[] }
   | { kind: "matchColumns"; userPairs: { left: string; right: string }[]; mistakes: number }
-  | { kind: "multipleChoice"; selectedIndex: number; selectedText: string }
+  | { kind: "multipleChoice"; selectedOptionId: string }
   | { kind: "reading"; arrangedWords: string[] }
-  | { kind: "selectImage"; selectedIndex: number }
+  | { kind: "selectImage"; selectedOptionId: string }
   | { kind: "sortOrder"; userOrder: string[] }
-  | { kind: "story"; selectedChoiceId: string; selectedText: string }
-  | { kind: "translation"; selectedWordId: string; selectedText: string; questionText: string };
+  | { kind: "story"; selectedOptionId: string }
+  | { kind: "translation"; selectedOptionId: string };
 
 export type StepResult = {
   stepId: string;
@@ -144,7 +144,7 @@ function handleCheckAnswer(
 
   /**
    * Investigation action steps enter the feedback phase to show
-   * evidence (the finding for the chosen action). Record the
+   * evidence (the feedback for the chosen action). Record the
    * chosen action and its timing in the loop state before entering
    * feedback. Per-experiment timings are stored in the loop (not
    * in stepTimings) because all experiments share the same step ID

--- a/packages/player/src/player-screen.test.ts
+++ b/packages/player/src/player-screen.test.ts
@@ -144,7 +144,7 @@ describe(getPlayerScreenModel, () => {
           buildStep({
             content: {
               kind: "core" as const,
-              options: [{ feedback: "Correct", isCorrect: true, text: "A" }],
+              options: [{ feedback: "Correct", id: "A", isCorrect: true, text: "A" }],
               question: "Choose",
             },
             kind: "multipleChoice",
@@ -170,10 +170,10 @@ describe(getPlayerScreenModel, () => {
         steps: [
           buildStep({
             content: {
-              choices: [
+              options: [
                 {
                   alignment: "strong" as const,
-                  consequence: "Good call",
+                  feedback: "Good call",
                   id: "choice-1",
                   metricEffects: [],
                   stateImage: { prompt: "State after option A" },

--- a/packages/player/src/player-selectors.test.ts
+++ b/packages/player/src/player-selectors.test.ts
@@ -2,7 +2,7 @@ import { type SerializedStep } from "@zoonk/core/player/contracts/prepare-activi
 import { describe, expect, test } from "vitest";
 import { type PlayerState, type StepResult } from "./player-reducer";
 import {
-  findSelectedChoice,
+  findSelectedStoryOption,
   getInvestigationProgress,
   getStoryMetrics,
   getUpcomingImages,
@@ -47,10 +47,10 @@ function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
 }
 
 const storyStepContent = {
-  choices: [
+  options: [
     {
       alignment: "strong" as const,
-      consequence: "Things improve.",
+      feedback: "Things improve.",
       id: "c1",
       metricEffects: [{ effect: "positive" as const, metric: "Production" }],
       stateImage: { prompt: "State after the strong choice" },
@@ -58,7 +58,7 @@ const storyStepContent = {
     },
     {
       alignment: "partial" as const,
-      consequence: "Mixed results.",
+      feedback: "Mixed results.",
       id: "c2",
       metricEffects: [{ effect: "neutral" as const, metric: "Production" }],
       stateImage: { prompt: "State after the partial choice" },
@@ -66,7 +66,7 @@ const storyStepContent = {
     },
     {
       alignment: "weak" as const,
-      consequence: "Things get worse.",
+      feedback: "Things get worse.",
       id: "c3",
       metricEffects: [
         { effect: "negative" as const, metric: "Production" },
@@ -115,22 +115,22 @@ function buildStoryOutcomeStep(position: number): SerializedStep {
   });
 }
 
-function buildStoryResult(stepId: string, selectedChoiceId: string): StepResult {
+function buildStoryResult(stepId: string, selectedOptionId: string): StepResult {
   return {
-    answer: { kind: "story", selectedChoiceId, selectedText: "choice" },
-    result: { correctAnswer: null, feedback: null, isCorrect: selectedChoiceId !== "c3" },
+    answer: { kind: "story", selectedOptionId },
+    result: { correctAnswer: null, feedback: null, isCorrect: selectedOptionId !== "c3" },
     stepId,
   };
 }
 
-describe(findSelectedChoice, () => {
-  test("returns the matching choice when a story answer exists", () => {
+describe(findSelectedStoryOption, () => {
+  test("returns the matching option when a story answer exists", () => {
     const step = buildStoryStep("s1", 0);
     const results = { s1: buildStoryResult("s1", "c1") };
 
-    const choice = findSelectedChoice({ results, step });
+    const option = findSelectedStoryOption({ results, step });
 
-    expect(choice).toEqual(
+    expect(option).toEqual(
       expect.objectContaining({ alignment: "strong", id: "c1", text: "Strong choice" }),
     );
   });
@@ -138,29 +138,29 @@ describe(findSelectedChoice, () => {
   test("returns null when the step has no result", () => {
     const step = buildStoryStep("s1", 0);
 
-    expect(findSelectedChoice({ results: {}, step })).toBeNull();
+    expect(findSelectedStoryOption({ results: {}, step })).toBeNull();
   });
 
   test("returns null when the answer is not a story kind", () => {
     const step = buildStoryStep("s1", 0);
     const results = {
       s1: {
-        answer: { kind: "multipleChoice" as const, selectedIndex: 0, selectedText: "A" },
+        answer: { kind: "multipleChoice" as const, selectedOptionId: "a" },
         result: { correctAnswer: null, feedback: null, isCorrect: true },
         stepId: "s1",
       },
     };
 
-    expect(findSelectedChoice({ results, step })).toBeNull();
+    expect(findSelectedStoryOption({ results, step })).toBeNull();
   });
 
-  test("returns null when the choice ID does not match any option", () => {
+  test("returns null when the option ID does not match any option", () => {
     const step = buildStoryStep("s1", 0);
     const results = {
       s1: buildStoryResult("s1", "nonexistent"),
     };
 
-    expect(findSelectedChoice({ results, step })).toBeNull();
+    expect(findSelectedStoryOption({ results, step })).toBeNull();
   });
 });
 
@@ -298,10 +298,10 @@ describe(getStoryMetrics, () => {
 function buildInvestigationActionStep(): SerializedStep {
   return buildStep({
     content: {
-      actions: [
-        { finding: "Clue A", id: "a1", label: "Check logs", quality: "critical" as const },
-        { finding: "Clue B", id: "a2", label: "Ask witness", quality: "useful" as const },
-        { finding: "Clue C", id: "a3", label: "Check camera", quality: "weak" as const },
+      options: [
+        { feedback: "Clue A", id: "a1", quality: "critical" as const, text: "Check logs" },
+        { feedback: "Clue B", id: "a2", quality: "useful" as const, text: "Ask witness" },
+        { feedback: "Clue C", id: "a3", quality: "weak" as const, text: "Check camera" },
       ],
       variant: "action" as const,
     },
@@ -315,7 +315,7 @@ describe(getInvestigationProgress, () => {
   test("returns progress when current step is an investigation action step", () => {
     const state = buildState({
       currentStepIndex: 0,
-      investigationLoop: { actionTimings: [], usedActionIds: ["a1"] },
+      investigationLoop: { actionTimings: [], usedOptionIds: ["a1"] },
       steps: [buildInvestigationActionStep()],
     });
 
@@ -325,7 +325,7 @@ describe(getInvestigationProgress, () => {
   test("returns 0 collected when no actions have been used", () => {
     const state = buildState({
       currentStepIndex: 0,
-      investigationLoop: { actionTimings: [], usedActionIds: [] },
+      investigationLoop: { actionTimings: [], usedOptionIds: [] },
       steps: [buildInvestigationActionStep()],
     });
 
@@ -335,7 +335,7 @@ describe(getInvestigationProgress, () => {
   test("returns 2 collected when all experiments are done", () => {
     const state = buildState({
       currentStepIndex: 0,
-      investigationLoop: { actionTimings: [], usedActionIds: ["a1", "a2"] },
+      investigationLoop: { actionTimings: [], usedOptionIds: ["a1", "a2"] },
       steps: [buildInvestigationActionStep()],
     });
 
@@ -360,11 +360,11 @@ describe(getInvestigationProgress, () => {
   test("returns collected count for investigation call step", () => {
     const state = buildState({
       currentStepIndex: 0,
-      investigationLoop: { actionTimings: [], usedActionIds: ["a1", "a2"] },
+      investigationLoop: { actionTimings: [], usedOptionIds: ["a1", "a2"] },
       steps: [
         buildStep({
           content: {
-            explanations: [
+            options: [
               {
                 accuracy: "best" as const,
                 feedback: "Correct!",
@@ -449,7 +449,9 @@ describe(getUpcomingImages, () => {
               url: "https://example.com/refund-dashboard.jpg",
             },
             kind: "core",
-            options: [{ feedback: "Yes", isCorrect: true, text: "Check totals" }],
+            options: [
+              { feedback: "Yes", id: "Check totals", isCorrect: true, text: "Check totals" },
+            ],
             question: "What should we inspect?",
           },
           id: "s2",
@@ -473,12 +475,14 @@ describe(getUpcomingImages, () => {
             options: [
               {
                 feedback: "Yes",
+                id: "cat",
                 isCorrect: true,
                 prompt: "Cat",
                 url: "https://example.com/cat.jpg",
               },
               {
                 feedback: "No",
+                id: "dog",
                 isCorrect: false,
                 prompt: "Dog",
                 url: "https://example.com/dog.jpg",
@@ -637,9 +641,10 @@ describe(getUpcomingImages, () => {
         buildStep({
           content: {
             options: [
-              { feedback: "Yes", isCorrect: true, prompt: "No URL" },
+              { feedback: "Yes", id: "no-url", isCorrect: true, prompt: "No URL" },
               {
                 feedback: "No",
+                id: "has-url",
                 isCorrect: false,
                 prompt: "Has URL",
                 url: "https://example.com/img.jpg",
@@ -686,10 +691,10 @@ describe(getUpcomingImages, () => {
   });
 
   test("includes current story feedback images and dedupes repeated URLs", () => {
-    const choices = storyStepContent.choices.map((choice, index) => ({
-      ...choice,
+    const options = storyStepContent.options.map((option, index) => ({
+      ...option,
       stateImage: {
-        prompt: choice.stateImage.prompt,
+        prompt: option.stateImage.prompt,
         url: `https://example.com/feedback-${index}.jpg`,
       },
     }));
@@ -698,7 +703,7 @@ describe(getUpcomingImages, () => {
       activityKind: "story",
       steps: [
         buildStep({
-          content: { ...storyStepContent, choices },
+          content: { ...storyStepContent, options },
           id: "s1",
           kind: "story",
         }),

--- a/packages/player/src/player-selectors.ts
+++ b/packages/player/src/player-selectors.ts
@@ -58,7 +58,7 @@ export function getInvestigationProgress(state: PlayerState): InvestigationProgr
     return null;
   }
 
-  const collected = state.investigationLoop?.usedActionIds.length ?? 0;
+  const collected = state.investigationLoop?.usedOptionIds.length ?? 0;
   return { collected, total: INVESTIGATION_EXPERIMENT_COUNT };
 }
 
@@ -106,13 +106,13 @@ function findStoryMetricDefinitions(steps: SerializedStep[]) {
 }
 
 /**
- * Extracts the selected choice from a story step result, if available.
- * Returns null when the step has no result or the choice ID doesn't match.
+ * Extracts the selected option from a story step result, if available.
+ * Returns null when the step has no result or the option ID doesn't match.
  *
- * Also used by the outcome screen to determine choice alignment
+ * Also used by the outcome screen to determine option alignment
  * without duplicating the lookup logic.
  */
-export function findSelectedChoice({
+export function findSelectedStoryOption({
   step,
   results,
 }: {
@@ -127,17 +127,17 @@ export function findSelectedChoice({
     descriptor?.kind !== "storyDecision" ||
     !answer ||
     answer.kind !== "story" ||
-    !answer.selectedChoiceId
+    !answer.selectedOptionId
   ) {
     return null;
   }
 
-  return descriptor.content.choices.find((option) => option.id === answer.selectedChoiceId) ?? null;
+  return descriptor.content.options.find((option) => option.id === answer.selectedOptionId) ?? null;
 }
 
 /**
  * Returns the delta a single step contributes to a specific metric.
- * Returns 0 when the step has no result or the choice doesn't affect
+ * Returns 0 when the step has no result or the option doesn't affect
  * the given metric.
  */
 function getStepMetricDelta({
@@ -149,13 +149,13 @@ function getStepMetricDelta({
   results: PlayerState["results"];
   step: SerializedStep;
 }): number {
-  const choice = findSelectedChoice({ results, step });
+  const option = findSelectedStoryOption({ results, step });
 
-  if (!choice) {
+  if (!option) {
     return 0;
   }
 
-  const effect = choice.metricEffects.find((entry) => entry.metric === metric);
+  const effect = option.metricEffects.find((entry) => entry.metric === metric);
   return effect ? EFFECT_DELTA_MAP[effect.effect] : 0;
 }
 
@@ -164,7 +164,7 @@ function getStepMetricDelta({
  * from all completed story steps.
  *
  * Reads metric names from the story outcome step, then for each
- * answered story step, looks up the selected choice's metricEffects and
+ * answered story step, looks up the selected option's metricEffects and
  * accumulates deltas (positive = +15, neutral = 0, negative = -15) starting
  * from 50.
  */
@@ -218,7 +218,7 @@ function getStoryOutcomeImages(step: SerializedStep): PreloadableImage[] {
 }
 
 /**
- * Story decision steps preload the main scene plus the consequence image for
+ * Story decision steps preload the main scene plus the feedback image for
  * every option so feedback transitions stay instant.
  */
 function getStoryDecisionImages(step: SerializedStep): PreloadableImage[] {
@@ -230,7 +230,7 @@ function getStoryDecisionImages(step: SerializedStep): PreloadableImage[] {
 
   return [
     ...getOptionalStepImage(getPlayerStepImage(descriptor)?.url),
-    ...descriptor.content.choices.flatMap((choice) => getOptionalStepImage(choice.stateImage?.url)),
+    ...descriptor.content.options.flatMap((option) => getOptionalStepImage(option.stateImage?.url)),
   ];
 }
 
@@ -251,7 +251,7 @@ function getSelectImageOptionImages(step: SerializedStep): PreloadableImage[] {
 }
 
 /**
- * Story consequence screens are reached from the current decision before the
+ * Story feedback screens are reached from the current decision before the
  * step index advances. They must be part of the preload set even though they
  * do not belong to an upcoming step.
  */
@@ -262,8 +262,8 @@ function getCurrentStoryFeedbackImages(state: PlayerState): PreloadableImage[] {
     return [];
   }
 
-  return descriptor.content.choices.flatMap((choice) =>
-    choice.stateImage?.url ? [{ kind: "step" as const, url: choice.stateImage.url }] : [],
+  return descriptor.content.options.flatMap((option) =>
+    option.stateImage?.url ? [{ kind: "step" as const, url: option.stateImage.url }] : [],
   );
 }
 

--- a/packages/player/src/player-step-behavior.test.ts
+++ b/packages/player/src/player-step-behavior.test.ts
@@ -86,7 +86,7 @@ describe(getPlayerStepBehavior, () => {
   test("routes investigation call through shared feedback and validation behavior", () => {
     const step = buildStep({
       content: {
-        explanations: [
+        options: [
           {
             accuracy: "best" as const,
             feedback: "Correct",
@@ -115,18 +115,18 @@ describe(getPlayerStepBehavior, () => {
   test("skips validation for investigation action while keeping its check behavior", () => {
     const step = buildStep({
       content: {
-        actions: [
+        options: [
           {
-            finding: "A clue",
+            feedback: "A clue",
             id: "action-1",
-            label: "Inspect the logs",
             quality: "critical" as const,
+            text: "Inspect the logs",
           },
           {
-            finding: "Another clue",
+            feedback: "Another clue",
             id: "action-2",
-            label: "Interview the witness",
             quality: "useful" as const,
+            text: "Interview the witness",
           },
         ],
         variant: "action" as const,

--- a/packages/player/src/player-step.test.ts
+++ b/packages/player/src/player-step.test.ts
@@ -51,7 +51,7 @@ describe(describePlayerStep, () => {
     const descriptor = describePlayerStep(
       buildStep({
         content: {
-          explanations: [
+          options: [
             {
               accuracy: "best" as const,
               feedback: "Correct",
@@ -85,7 +85,7 @@ describe(describePlayerStep, () => {
         content: {
           image,
           kind: "core" as const,
-          options: [{ feedback: "Correct", isCorrect: true, text: "A" }],
+          options: [{ feedback: "Correct", id: "A", isCorrect: true, text: "A" }],
           question: "Choose",
         },
         kind: "multipleChoice",

--- a/packages/player/src/player-step.ts
+++ b/packages/player/src/player-step.ts
@@ -210,7 +210,7 @@ export function describePlayerStep(step?: SerializedStep | null): PlayerStepDesc
  * Returns the one primary image attached directly to a step descriptor.
  *
  * Some steps have additional image collections, such as select-image options
- * or story choice outcomes. Those stay in their domain helpers; this function
+ * or story option outcomes. Those stay in their domain helpers; this function
  * only answers the shared "does this step have its own main image?" question.
  */
 export function getPlayerStepImage(descriptor?: PlayerStepDescriptor | null): StepImage | null {

--- a/packages/player/src/story.ts
+++ b/packages/player/src/story.ts
@@ -10,9 +10,9 @@ export const METRIC_AVERAGE_THRESHOLD = 50;
 export const METRIC_GOOD_THRESHOLD = 60;
 
 /**
- * Fixed delta applied to a metric when a story choice has a positive,
+ * Fixed delta applied to a metric when a story option has a positive,
  * neutral, or negative effect. Used by both the metrics bar (cumulative
- * totals) and the feedback screen (per-choice badges).
+ * totals) and the feedback screen (per-option badges).
  */
 export const EFFECT_DELTA_MAP = {
   negative: -15,

--- a/packages/player/src/use-player-actions.test.tsx
+++ b/packages/player/src/use-player-actions.test.tsx
@@ -79,7 +79,7 @@ describe(usePlayerActions, () => {
         buildStep({
           content: {
             kind: "core" as const,
-            options: [{ feedback: "Correct", isCorrect: true, text: "A" }],
+            options: [{ feedback: "Correct", id: "A", isCorrect: true, text: "A" }],
             question: "Choose",
           },
           kind: "multipleChoice",


### PR DESCRIPTION
Normalize player activity option contracts around options, text, feedback, and selectedOptionId. Add persisted option IDs for generated options before saving, and update player feedback/checking flows plus seed and eval test data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize all selectable step schemas around a single options model with stable option IDs. Answers now send selectedOptionId instead of order/text, improving shuffle safety and validation across the player.

- **Refactors**
  - Unified options: story choices → options; investigation actions/explanations → options.
  - Field renames: label → text; consequence/finding → feedback; usedActionIds → usedOptionIds.
  - Answers: multipleChoice, selectImage, story, translation, and investigation now use selectedOptionId.
  - Stable IDs: added `addOptionIds` and assign IDs in practice, grammar, and quiz saves (incl. select-image).
  - Serialization: shared option shuffler for option-based content.
  - Validation/scoring/haptics: now use option IDs; prompts/schemas updated to require text; tests/evals adjusted.

- **Migration**
  - Content schemas:
    - Story: choices → options; choice.consequence → feedback.
    - Investigation (action): actions → options; label → text; finding → feedback.
    - Investigation (call): explanations → options.
  - Client/server answers: switch to selectedOptionId for all affected steps.
  - Ensure every option has an id; use `addOptionIds` on save/seed (practice, grammar, quiz, select-image).
  - Remove order/text-based validation; rely on IDs only.

<sup>Written for commit 34e2c75efefb4b8af77aaa2a3717e06b652ff291. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

