### PR TITLE
fix(test): block gateway calls during tests

### DIFF
--- a/apps/api/src/instrumentation.ts
+++ b/apps/api/src/instrumentation.ts
@@ -1,6 +1,9 @@
 import { captureRequestError } from "@sentry/nextjs";
+import { zoonkGateway } from "@zoonk/core/ai";
 
 export async function register() {
+  globalThis.AI_SDK_DEFAULT_PROVIDER = zoonkGateway;
+
   if (process.env.NEXT_RUNTIME === "nodejs") {
     await import("../sentry.server.config");
   }

--- a/packages/ai/src/gateway.test.ts
+++ b/packages/ai/src/gateway.test.ts
@@ -1,0 +1,11 @@
+import { generateText } from "ai";
+import { describe, expect, test } from "vitest";
+import { zoonkGateway } from "./gateway";
+
+describe(zoonkGateway, () => {
+  test("blocks provider requests during tests", async () => {
+    await expect(
+      generateText({ model: zoonkGateway("openai/gpt-5.4"), prompt: "hello" }),
+    ).rejects.toThrow("AI Gateway calls are disabled during tests.");
+  });
+});

--- a/packages/ai/src/gateway.ts
+++ b/packages/ai/src/gateway.ts
@@ -1,6 +1,21 @@
-import { createGateway } from "@ai-sdk/gateway";
+import { type GatewayProviderSettings, createGateway } from "@ai-sdk/gateway";
+
+const isTest =
+  process.env.E2E_TESTING === "true" ||
+  process.env.NODE_ENV === "test" ||
+  process.env.VITEST === "true";
+
+/**
+ * Tests can exercise real server routes or integration code, so missed mocks
+ * must fail before a provider request leaves the process and spends credits.
+ */
+const blockTestGatewayFetch: NonNullable<GatewayProviderSettings["fetch"]> = async () => {
+  throw new Error("AI Gateway calls are disabled during tests.");
+};
 
 export const zoonkGateway = createGateway({
+  apiKey: isTest ? "test-disabled" : undefined,
+  fetch: isTest ? blockTestGatewayFetch : undefined,
   headers: {
     "http-referer": "https://www.zoonk.com",
     "x-title": "Zoonk",

--- a/packages/db/.env.e2e
+++ b/packages/db/.env.e2e
@@ -2,3 +2,7 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5432/zoonk_e2e
 DATABASE_URL_UNPOOLED=postgres://postgres:postgres@localhost:5432/zoonk_e2e
 E2E_TESTING=true
 NEXT_PUBLIC_API_URL=http://localhost:49152
+AI_GATEWAY_API_KEY=e2e-disabled
+OPENAI_API_KEY=e2e-disabled
+GEMINI_API_KEY=e2e-disabled
+VERCEL_OIDC_TOKEN=

--- a/packages/e2e/src/base.config.ts
+++ b/packages/e2e/src/base.config.ts
@@ -30,11 +30,15 @@ export function createBaseConfig(options: {
     webServer: {
       command: "pnpm start -p 0",
       env: {
+        AI_GATEWAY_API_KEY: "e2e-disabled",
         DATABASE_URL: E2E_DATABASE_URL,
         DATABASE_URL_UNPOOLED: E2E_DATABASE_URL,
         E2E_TESTING: "true",
+        GEMINI_API_KEY: "e2e-disabled",
         NEXT_PUBLIC_API_URL: E2E_API_URL,
+        OPENAI_API_KEY: "e2e-disabled",
         STRIPE_SECRET_KEY: "sk_test_fake",
+        VERCEL_OIDC_TOKEN: "",
         ...options.webServerEnv,
       },
       timeout: 120_000,


### PR DESCRIPTION
## Summary
- register the shared Zoonk Gateway provider in the API app
- block Gateway fetches during test and e2e runs before they can reach Vercel
- force disabled AI credentials for e2e build and web-server environments

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks real AI Gateway calls during tests and e2e to avoid hitting Vercel and spending credits. Also registers the shared Zoonk Gateway provider in the API app.

- **Bug Fixes**
  - Register `zoonkGateway` from `@zoonk/core/ai` in API instrumentation.
  - In test/e2e modes, force gateway `fetch` to throw and set a disabled `apiKey` via `@ai-sdk/gateway`.
  - Add a `vitest` check using `generateText` from `ai` to verify calls are blocked.
  - Disable provider creds in e2e and web-server envs (`AI_GATEWAY_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `VERCEL_OIDC_TOKEN`).

<sup>Written for commit f0a75036c4452ad131560782d10a01f34a3a2316. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1318?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

