### PR TITLE
refactor(ai): centralize task model config

### DIFF
--- a/apps/admin/src/data/stats/ai/ai-task-catalog.ts
+++ b/apps/admin/src/data/stats/ai/ai-task-catalog.ts
@@ -1,128 +1,11 @@
+import { AI_TASK_MODEL_CONFIG, type AiTaskName } from "@zoonk/core/ai";
 import { formatAiTaskLabel } from "./ai-task-stats";
-
-type AiTaskMetadata = {
-  defaultModel: string;
-  supportsFallbackReporting: boolean;
-};
 
 type AiTaskCatalogGroupDefinition = {
   description: string;
   taskNames: AiTaskName[];
   title: string;
 };
-
-const AI_TASK_METADATA = {
-  "activity-custom": {
-    defaultModel: "google/gemini-3-flash",
-    supportsFallbackReporting: true,
-  },
-  "activity-distractors": {
-    defaultModel: "openai/gpt-5.4",
-    supportsFallbackReporting: true,
-  },
-  "activity-explanation": {
-    defaultModel: "openai/gpt-5.4",
-    supportsFallbackReporting: true,
-  },
-  "activity-grammar-content": {
-    defaultModel: "google/gemini-3.1-pro-preview",
-    supportsFallbackReporting: true,
-  },
-  "activity-grammar-user-content": {
-    defaultModel: "openai/gpt-5.4",
-    supportsFallbackReporting: true,
-  },
-  "activity-practice": {
-    defaultModel: "openai/gpt-5.4",
-    supportsFallbackReporting: true,
-  },
-  "activity-pronunciation": {
-    defaultModel: "google/gemini-3-flash",
-    supportsFallbackReporting: true,
-  },
-  "activity-quiz": {
-    defaultModel: "openai/gpt-5.4",
-    supportsFallbackReporting: true,
-  },
-  "activity-romanization": {
-    defaultModel: "openai/gpt-5.4",
-    supportsFallbackReporting: true,
-  },
-  "activity-sentences": {
-    defaultModel: "openai/gpt-5.4",
-    supportsFallbackReporting: true,
-  },
-  "activity-translation": {
-    defaultModel: "openai/gpt-5.4-mini",
-    supportsFallbackReporting: true,
-  },
-  "activity-vocabulary": {
-    defaultModel: "google/gemini-3-flash",
-    supportsFallbackReporting: true,
-  },
-  "alternative-titles": {
-    defaultModel: "openai/gpt-5.4",
-    supportsFallbackReporting: true,
-  },
-  "chapter-lessons": {
-    defaultModel: "openai/gpt-5.4",
-    supportsFallbackReporting: true,
-  },
-  "course-categories": {
-    defaultModel: "google/gemini-3.1-flash-lite-preview",
-    supportsFallbackReporting: true,
-  },
-  "course-chapters": {
-    defaultModel: "openai/gpt-5.4",
-    supportsFallbackReporting: true,
-  },
-  "course-description": {
-    defaultModel: "openai/gpt-5.4-nano",
-    supportsFallbackReporting: true,
-  },
-  "course-suggestions": {
-    defaultModel: "openai/gpt-5.4-mini",
-    supportsFallbackReporting: true,
-  },
-  "course-thumbnail": {
-    defaultModel: "openai/gpt-image-2",
-    supportsFallbackReporting: false,
-  },
-  "language-chapter-lessons": {
-    defaultModel: "openai/gpt-5.4",
-    supportsFallbackReporting: true,
-  },
-  "language-course-chapters": {
-    defaultModel: "openai/gpt-5.4",
-    supportsFallbackReporting: true,
-  },
-  "lesson-core-activities": {
-    defaultModel: "openai/gpt-5.4",
-    supportsFallbackReporting: true,
-  },
-  "lesson-custom-activities": {
-    defaultModel: "google/gemini-3-flash",
-    supportsFallbackReporting: true,
-  },
-  "lesson-kind": {
-    defaultModel: "openai/gpt-5.4-nano",
-    supportsFallbackReporting: true,
-  },
-  "step-content-image": {
-    defaultModel: "openai/gpt-image-2",
-    supportsFallbackReporting: false,
-  },
-  "step-image-prompts": {
-    defaultModel: "openai/gpt-5.4",
-    supportsFallbackReporting: true,
-  },
-  "step-select-image": {
-    defaultModel: "openai/gpt-image-2",
-    supportsFallbackReporting: false,
-  },
-} satisfies Record<string, AiTaskMetadata>;
-
-export type AiTaskName = keyof typeof AI_TASK_METADATA;
 
 export type AiTaskCatalogTask = {
   defaultModel: string;
@@ -215,11 +98,11 @@ export function listAiTaskCatalogTasks() {
  * wherever the admin UI needs to render or analyze a task.
  */
 function buildAiTaskCatalogTask({ taskName }: { taskName: AiTaskName }): AiTaskCatalogTask {
-  const metadata = AI_TASK_METADATA[taskName];
+  const metadata = AI_TASK_MODEL_CONFIG[taskName];
 
   return {
     defaultModel: metadata.defaultModel,
-    supportsFallbackReporting: metadata.supportsFallbackReporting,
+    supportsFallbackReporting: metadata.fallbackModels.length > 0,
     taskLabel: formatAiTaskLabel(taskName),
     taskName,
   };

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -6,6 +6,7 @@
     "./gateway": "./src/gateway.ts",
     "./provider-options": "./src/provider-options.ts",
     "./reporting-tags": "./src/reporting-tags.ts",
+    "./tasks/metadata": "./src/tasks/metadata.ts",
     "./tasks/activities/core/explanation": "./src/tasks/activities/core/activity-explanation.ts",
     "./tasks/activities/core/practice": "./src/tasks/activities/core/activity-practice.ts",
     "./tasks/activities/core/quiz": "./src/tasks/activities/core/activity-quiz.ts",

--- a/packages/ai/src/provider-options.ts
+++ b/packages/ai/src/provider-options.ts
@@ -38,7 +38,7 @@ function buildGatewayProviderOptions({
   taskName,
   useFallback,
 }: {
-  fallbackModels: string[];
+  fallbackModels: readonly string[];
   model: string;
   taskName: string;
   useFallback: boolean;
@@ -49,7 +49,7 @@ function buildGatewayProviderOptions({
     : undefined;
 
   return {
-    models: useFallback ? fallbackModels : [],
+    models: useFallback ? [...fallbackModels] : [],
     ...(order ? { order } : {}),
     ...(tags ? { tags } : {}),
   };
@@ -163,7 +163,7 @@ export function buildProviderOptions({
 }: {
   model: string;
   useFallback: boolean;
-  fallbackModels: string[];
+  fallbackModels: readonly string[];
   reasoningEffort?: ReasoningEffort;
   taskName: string;
 }): ProviderOptionsResult {

--- a/packages/ai/src/tasks/activities/core/activity-explanation.ts
+++ b/packages/ai/src/tasks/activities/core/activity-explanation.ts
@@ -1,11 +1,12 @@
 import "server-only";
 import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import systemPrompt from "./activity-explanation.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.4";
-const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"];
+const taskName = "activity-explanation";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const anchorSchema = z
   .object({
@@ -55,25 +56,27 @@ export async function generateActivityExplanation({
   activityTitle,
   lessonConcepts,
   otherActivityTitles,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   useFallback = true,
   reasoningEffort,
 }: ActivityExplanationParams) {
-  const userPrompt = `LESSON_TITLE: ${lessonTitle}
-LESSON_DESCRIPTION: ${lessonDescription}
-CHAPTER_TITLE: ${chapterTitle}
-COURSE_TITLE: ${courseTitle}
-LANGUAGE: ${language}
-ACTIVITY_TITLE: ${activityTitle}
-ACTIVITY_GOAL: ${activityGoal}
-LESSON_CONCEPTS: ${lessonConcepts.join(", ")}
-OTHER_EXPLANATION_ACTIVITY_TITLES: ${otherActivityTitles.join(", ")}`;
+  const userPrompt = `
+    LESSON_TITLE: ${lessonTitle}
+    LESSON_DESCRIPTION: ${lessonDescription}
+    CHAPTER_TITLE: ${chapterTitle}
+    COURSE_TITLE: ${courseTitle}
+    LANGUAGE: ${language}
+    ACTIVITY_TITLE: ${activityTitle}
+    ACTIVITY_GOAL: ${activityGoal}
+    LESSON_CONCEPTS: ${lessonConcepts.join(", ")}
+    OTHER_EXPLANATION_ACTIVITY_TITLES: ${otherActivityTitles.join(", ")}
+  `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "activity-explanation",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/activities/core/activity-practice.ts
+++ b/packages/ai/src/tasks/activities/core/activity-practice.ts
@@ -1,12 +1,13 @@
 import "server-only";
 import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { formatExplanationStepsForPrompt } from "./_utils/format-explanation-steps";
 import systemPrompt from "./activity-practice.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.4";
-const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"];
+const taskName = "activity-practice";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const practiceOptionSchema = z.object({
   feedback: z.string(),
@@ -52,25 +53,26 @@ export async function generateActivityPractice({
   courseTitle,
   language,
   explanationSteps,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   useFallback = true,
   reasoningEffort,
 }: ActivityPracticeParams) {
   const formattedExplanationSteps = formatExplanationStepsForPrompt(explanationSteps);
 
-  const userPrompt = `LESSON_TITLE: ${lessonTitle}
-LESSON_DESCRIPTION: ${lessonDescription}
-CHAPTER_TITLE: ${chapterTitle}
-COURSE_TITLE: ${courseTitle}
-LANGUAGE: ${language}
-EXPLANATION_STEPS:
-${formattedExplanationSteps}`;
+  const userPrompt = `
+    LESSON_TITLE: ${lessonTitle}
+    LESSON_DESCRIPTION: ${lessonDescription}
+    CHAPTER_TITLE: ${chapterTitle}
+    COURSE_TITLE: ${courseTitle}
+    LANGUAGE: ${language}
+    EXPLANATION_STEPS: ${formattedExplanationSteps}
+  `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "activity-practice",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/activities/core/activity-quiz.ts
+++ b/packages/ai/src/tasks/activities/core/activity-quiz.ts
@@ -1,12 +1,13 @@
 import "server-only";
 import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { formatExplanationStepsForPrompt } from "./_utils/format-explanation-steps";
 import systemPrompt from "./activity-quiz.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.4";
-const FALLBACK_MODELS = ["anthropic/claude-opus-4.6"];
+const taskName = "activity-quiz";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const multipleChoiceSchema = z.object({
   context: z.string(),
@@ -95,25 +96,26 @@ export async function generateActivityQuiz({
   courseTitle,
   language,
   explanationSteps,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   useFallback = true,
   reasoningEffort,
 }: ActivityQuizParams) {
   const formattedExplanationSteps = formatExplanationStepsForPrompt(explanationSteps);
 
-  const userPrompt = `LESSON_TITLE: ${lessonTitle}
-LESSON_DESCRIPTION: ${lessonDescription}
-CHAPTER_TITLE: ${chapterTitle}
-COURSE_TITLE: ${courseTitle}
-LANGUAGE: ${language}
-EXPLANATION_STEPS:
-${formattedExplanationSteps}`;
+  const userPrompt = `
+    LESSON_TITLE: ${lessonTitle}
+    LESSON_DESCRIPTION: ${lessonDescription}
+    CHAPTER_TITLE: ${chapterTitle}
+    COURSE_TITLE: ${courseTitle}
+    LANGUAGE: ${language}
+    EXPLANATION_STEPS: ${formattedExplanationSteps}
+  `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "activity-quiz",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/activities/custom/activity-custom.ts
+++ b/packages/ai/src/tasks/activities/custom/activity-custom.ts
@@ -1,11 +1,12 @@
 import "server-only";
 import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import systemPrompt from "./activity-custom.prompt.md";
 
-const DEFAULT_MODEL = "google/gemini-3-flash";
-const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "openai/gpt-5.4"];
+const taskName = "activity-custom";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   steps: z.array(
@@ -39,23 +40,25 @@ export async function generateActivityCustom({
   language,
   activityTitle,
   activityDescription,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   useFallback = true,
   reasoningEffort,
 }: ActivityCustomParams) {
-  const userPrompt = `LESSON_TITLE: ${lessonTitle}
-LESSON_DESCRIPTION: ${lessonDescription}
-CHAPTER_TITLE: ${chapterTitle}
-COURSE_TITLE: ${courseTitle}
-LANGUAGE: ${language}
-ACTIVITY_TITLE: ${activityTitle}
-ACTIVITY_DESCRIPTION: ${activityDescription}`;
+  const userPrompt = `
+    LESSON_TITLE: ${lessonTitle}
+    LESSON_DESCRIPTION: ${lessonDescription}
+    CHAPTER_TITLE: ${chapterTitle}
+    COURSE_TITLE: ${courseTitle}
+    LANGUAGE: ${language}
+    ACTIVITY_TITLE: ${activityTitle}
+    ACTIVITY_DESCRIPTION: ${activityDescription}
+  `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "activity-custom",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/activities/language/activity-distractors.ts
+++ b/packages/ai/src/tasks/activities/language/activity-distractors.ts
@@ -1,13 +1,14 @@
 import "server-only";
 import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { type DistractorShape } from "@zoonk/utils/distractors";
 import { getLanguageName } from "@zoonk/utils/languages";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import systemPrompt from "./activity-distractors.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.4";
-const FALLBACK_MODELS = ["google/gemini-3.1-flash-lite-preview", "anthropic/claude-sonnet-4.6"];
+const taskName = "activity-distractors";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   distractors: z.array(z.string()),
@@ -39,23 +40,25 @@ export async function generateActivityDistractors({
   input,
   language,
   shape,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   reasoningEffort,
   useFallback = true,
 }: ActivityDistractorsParams) {
   const languageName = getLanguageName({ targetLanguage: language, userLanguage: "en" });
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "activity-distractors",
+    taskName,
     useFallback,
   });
 
-  const userPrompt = `INPUT: ${input}
-LANGUAGE: ${languageName} (${language})
-SHAPE: ${shape}`;
+  const userPrompt = `
+    INPUT: ${input}
+    LANGUAGE: ${languageName} (${language})
+    SHAPE: ${shape}
+  `;
 
   const { output, usage } = await generateText({
     model,

--- a/packages/ai/src/tasks/activities/language/activity-grammar-content.ts
+++ b/packages/ai/src/tasks/activities/language/activity-grammar-content.ts
@@ -1,13 +1,14 @@
 import "server-only";
 import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { getLanguageName } from "@zoonk/utils/languages";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { formatConceptLines } from "../config";
 import systemPrompt from "./activity-grammar-content.prompt.md";
 
-const DEFAULT_MODEL = "google/gemini-3.1-pro-preview";
-const FALLBACK_MODELS = ["openai/gpt-5.4", "anthropic/claude-opus-4.6"];
+const taskName = "activity-grammar-content";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   examples: z.array(
@@ -51,7 +52,7 @@ export async function generateActivityGrammarContent({
   concepts = [],
   lessonDescription,
   lessonTitle,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   neighboringConcepts = [],
   reasoningEffort,
   targetLanguage,
@@ -59,17 +60,19 @@ export async function generateActivityGrammarContent({
 }: ActivityGrammarContentParams) {
   const targetLanguageName = getLanguageName({ targetLanguage });
 
-  const userPrompt = `TARGET_LANGUAGE: ${targetLanguageName}
-CHAPTER_TITLE: ${chapterTitle}
-LESSON_TITLE: ${lessonTitle}
-LESSON_DESCRIPTION: ${lessonDescription}
-${formatConceptLines(concepts, neighboringConcepts)}`;
+  const userPrompt = `
+    TARGET_LANGUAGE: ${targetLanguageName}
+    CHAPTER_TITLE: ${chapterTitle}
+    LESSON_TITLE: ${lessonTitle}
+    LESSON_DESCRIPTION: ${lessonDescription}
+    ${formatConceptLines(concepts, neighboringConcepts)}
+  `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "activity-grammar-content",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/activities/language/activity-grammar-user-content.ts
+++ b/packages/ai/src/tasks/activities/language/activity-grammar-user-content.ts
@@ -1,12 +1,13 @@
 import "server-only";
 import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getLanguagePromptContext } from "./_utils/language-prompt-context";
 import systemPrompt from "./activity-grammar-user-content.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.4";
-const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3-flash"];
+const taskName = "activity-grammar-user-content";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   discovery: z.object({
@@ -58,7 +59,7 @@ export async function generateActivityGrammarUserContent({
   exercises,
   lessonDescription,
   lessonTitle,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   reasoningEffort,
   targetLanguage,
   useFallback = true,
@@ -66,23 +67,21 @@ export async function generateActivityGrammarUserContent({
 }: ActivityGrammarUserContentParams) {
   const promptContext = getLanguagePromptContext({ targetLanguage, userLanguage });
 
-  const userPrompt = `TARGET_LANGUAGE: ${promptContext.targetLanguageName}
-USER_LANGUAGE: ${promptContext.userLanguage}
-CHAPTER_TITLE: ${chapterTitle}
-LESSON_TITLE: ${lessonTitle}
-LESSON_DESCRIPTION: ${lessonDescription}
-
-EXAMPLES:
-${JSON.stringify(examples, null, 2)}
-
-EXERCISES:
-${JSON.stringify(exercises, null, 2)}`;
+  const userPrompt = `
+    TARGET_LANGUAGE: ${promptContext.targetLanguageName}
+    USER_LANGUAGE: ${promptContext.userLanguage}
+    CHAPTER_TITLE: ${chapterTitle}
+    LESSON_TITLE: ${lessonTitle}
+    LESSON_DESCRIPTION: ${lessonDescription}
+    EXAMPLES: ${JSON.stringify(examples, null, 2)}
+    EXERCISES: ${JSON.stringify(exercises, null, 2)}
+  `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "activity-grammar-user-content",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/activities/language/activity-pronunciation.ts
+++ b/packages/ai/src/tasks/activities/language/activity-pronunciation.ts
@@ -1,12 +1,13 @@
 import "server-only";
 import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getLanguagePromptContext } from "./_utils/language-prompt-context";
 import systemPrompt from "./activity-pronunciation.prompt.md";
 
-const DEFAULT_MODEL = "google/gemini-3-flash";
-const FALLBACK_MODELS = ["anthropic/claude-sonnet-4.6", "openai/gpt-5.1-instant"];
+const taskName = "activity-pronunciation";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   pronunciation: z.string(),
@@ -24,7 +25,7 @@ export type ActivityPronunciationParams = {
 };
 
 export async function generateActivityPronunciation({
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   reasoningEffort,
   targetLanguage,
   userLanguage,
@@ -33,17 +34,17 @@ export async function generateActivityPronunciation({
 }: ActivityPronunciationParams) {
   const promptContext = getLanguagePromptContext({ targetLanguage, userLanguage });
 
-  const userPrompt = `WORD: ${word}
-TARGET_LANGUAGE: ${promptContext.targetLanguageName}
-USER_LANGUAGE: ${promptContext.userLanguage}
-
-Generate a pronunciation guide for this word using only sounds from the native language.`;
+  const userPrompt = `
+    WORD: ${word}
+    TARGET_LANGUAGE: ${promptContext.targetLanguageName}
+    USER_LANGUAGE: ${promptContext.userLanguage}
+  `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "activity-pronunciation",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/activities/language/activity-romanization.ts
+++ b/packages/ai/src/tasks/activities/language/activity-romanization.ts
@@ -1,11 +1,12 @@
 import "server-only";
 import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import systemPrompt from "./activity-romanization.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.4";
-const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"];
+const taskName = "activity-romanization";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   romanizations: z.array(z.string()),
@@ -27,7 +28,7 @@ export type ActivityRomanizationParams = {
  * This is used to help learners read and pronounce text written in unfamiliar scripts.
  */
 export async function generateActivityRomanization({
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   reasoningEffort,
   targetLanguage,
   texts,
@@ -35,18 +36,16 @@ export async function generateActivityRomanization({
 }: ActivityRomanizationParams) {
   const formattedTexts = texts.map((text, index) => `${index + 1}. ${text}`).join("\n");
 
-  const userPrompt = `TARGET_LANGUAGE: ${targetLanguage}
-
-TEXTS:
-${formattedTexts}
-
-Romanize each text using the standard romanization system for the target language. Return one romanization per text in the same order.`;
+  const userPrompt = `
+    TARGET_LANGUAGE: ${targetLanguage}
+    TEXTS: ${formattedTexts}
+  `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "activity-romanization",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/activities/language/activity-sentences.ts
+++ b/packages/ai/src/tasks/activities/language/activity-sentences.ts
@@ -1,13 +1,14 @@
 import "server-only";
 import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { formatConceptLines } from "../config";
 import { getLanguagePromptContext } from "./_utils/language-prompt-context";
 import systemPrompt from "./activity-sentences.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.4";
-const FALLBACK_MODELS = ["google/gemini-3.1-pro-preview", "anthropic/claude-opus-4.6"];
+const taskName = "activity-sentences";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   sentences: z.array(
@@ -40,7 +41,7 @@ export async function generateActivitySentences({
   concepts = [],
   lessonDescription,
   lessonTitle,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   neighboringConcepts = [],
   reasoningEffort,
   targetLanguage,
@@ -50,19 +51,21 @@ export async function generateActivitySentences({
 }: ActivitySentencesParams) {
   const promptContext = getLanguagePromptContext({ targetLanguage, userLanguage });
 
-  const userPrompt = `TARGET_LANGUAGE: ${promptContext.targetLanguageName}
-USER_LANGUAGE: ${promptContext.userLanguage}
-${chapterTitle ? `CHAPTER_TITLE: ${chapterTitle}\n` : ""}LESSON_TITLE: ${lessonTitle}
-${lessonDescription ? `LESSON_DESCRIPTION: ${lessonDescription}\n` : ""}VOCABULARY_WORDS: ${words.join(", ")}
-${formatConceptLines(concepts, neighboringConcepts)}
-
-Generate practice sentences using these vocabulary words in everyday situations.`;
+  const userPrompt = `
+    TARGET_LANGUAGE: ${promptContext.targetLanguageName}
+    USER_LANGUAGE: ${promptContext.userLanguage}
+    CHAPTER_TITLE: ${chapterTitle}
+    LESSON_TITLE: ${lessonTitle}
+    LESSON_DESCRIPTION: ${lessonDescription}
+    VOCABULARY_WORDS: ${words.join(", ")}
+    ${formatConceptLines(concepts, neighboringConcepts)}
+  `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "activity-sentences",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/activities/language/activity-translation.ts
+++ b/packages/ai/src/tasks/activities/language/activity-translation.ts
@@ -1,12 +1,13 @@
 import "server-only";
 import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getLanguagePromptContext } from "./_utils/language-prompt-context";
 import systemPrompt from "./activity-translation.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.4-mini";
-const FALLBACK_MODELS = ["google/gemini-3-flash", "anthropic/claude-opus-4.6"];
+const taskName = "activity-translation";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   translation: z.string(),
@@ -29,7 +30,7 @@ export type TranslationParams = {
  * by `generateActivityRomanization` for non-Roman script languages.
  */
 export async function generateTranslation({
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   reasoningEffort,
   targetLanguage,
   userLanguage,
@@ -38,15 +39,17 @@ export async function generateTranslation({
 }: TranslationParams) {
   const promptContext = getLanguagePromptContext({ targetLanguage, userLanguage });
 
-  const userPrompt = `WORD: ${word}
-TARGET_LANGUAGE: ${promptContext.targetLanguageName}
-USER_LANGUAGE: ${promptContext.userLanguage}`;
+  const userPrompt = `
+    WORD: ${word}
+    TARGET_LANGUAGE: ${promptContext.targetLanguageName}
+    USER_LANGUAGE: ${promptContext.userLanguage}
+  `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "activity-translation",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/activities/language/activity-vocabulary.ts
+++ b/packages/ai/src/tasks/activities/language/activity-vocabulary.ts
@@ -1,13 +1,14 @@
 import "server-only";
 import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { formatConceptLines } from "../config";
 import { getLanguagePromptContext } from "./_utils/language-prompt-context";
 import systemPrompt from "./activity-vocabulary.prompt.md";
 
-const DEFAULT_MODEL = "google/gemini-3-flash";
-const FALLBACK_MODELS = ["google/gemini-3.1-pro-preview", "openai/gpt-5.4"];
+const taskName = "activity-vocabulary";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   words: z.array(
@@ -39,7 +40,7 @@ export async function generateActivityVocabulary({
   concepts = [],
   lessonDescription,
   lessonTitle,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   neighboringConcepts = [],
   reasoningEffort,
   targetLanguage,
@@ -48,20 +49,20 @@ export async function generateActivityVocabulary({
 }: ActivityVocabularyParams) {
   const promptContext = getLanguagePromptContext({ targetLanguage, userLanguage });
 
-  const userPrompt = `TARGET_LANGUAGE: ${promptContext.targetLanguageName}
-USER_LANGUAGE: ${promptContext.userLanguage}
-CHAPTER_TITLE: ${chapterTitle}
-LESSON_TITLE: ${lessonTitle}
-LESSON_DESCRIPTION: ${lessonDescription}
-${formatConceptLines(concepts, neighboringConcepts)}
-
-Generate a focused, representative vocabulary list for this language lesson. Include essential words for this specific topic - quality over quantity.`;
+  const userPrompt = `
+    TARGET_LANGUAGE: ${promptContext.targetLanguageName}
+    USER_LANGUAGE: ${promptContext.userLanguage}
+    CHAPTER_TITLE: ${chapterTitle}
+    LESSON_TITLE: ${lessonTitle}
+    LESSON_DESCRIPTION: ${lessonDescription}
+    ${formatConceptLines(concepts, neighboringConcepts)}
+  `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "activity-vocabulary",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/chapters/chapter-lessons.ts
+++ b/packages/ai/src/tasks/chapters/chapter-lessons.ts
@@ -1,15 +1,12 @@
 import "server-only";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./chapter-lessons.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.5";
-const FALLBACK_MODELS = [
-  "openai/gpt-5.4",
-  "google/gemini-3.1-pro-preview",
-  "anthropic/claude-opus-4.7",
-];
+const taskName = "chapter-lessons";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   lessons: z.array(
@@ -40,7 +37,7 @@ export async function generateChapterLessons({
   courseTitle,
   language,
   neighboringChapters,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   useFallback = true,
   reasoningEffort,
 }: {
@@ -65,10 +62,10 @@ export async function generateChapterLessons({
   `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "chapter-lessons",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/chapters/language-chapter-lessons.ts
+++ b/packages/ai/src/tasks/chapters/language-chapter-lessons.ts
@@ -1,12 +1,13 @@
 import "server-only";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { getLanguageName } from "@zoonk/utils/languages";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./language-chapter-lessons.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.4";
-const FALLBACK_MODELS = ["google/gemini-3.1-pro-preview", "anthropic/claude-sonnet-4.6"];
+const taskName = "language-chapter-lessons";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   lessons: z.array(
@@ -23,7 +24,7 @@ export async function generateLanguageChapterLessons({
   chapterTitle,
   userLanguage,
   targetLanguage,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   useFallback = true,
   reasoningEffort,
 }: {
@@ -45,10 +46,10 @@ export async function generateLanguageChapterLessons({
   `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "language-chapter-lessons",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/courses/alternative-titles.ts
+++ b/packages/ai/src/tasks/courses/alternative-titles.ts
@@ -1,11 +1,12 @@
 import "server-only";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./alternative-titles.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.4";
-const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"];
+const taskName = "alternative-titles";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   alternatives: z.array(z.string()),
@@ -24,7 +25,7 @@ export type AlternativeTitlesParams = {
 export async function generateAlternativeTitles({
   title,
   language,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   useFallback = true,
   reasoningEffort,
 }: AlternativeTitlesParams) {
@@ -34,10 +35,10 @@ export async function generateAlternativeTitles({
   `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "alternative-titles",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/courses/course-categories.ts
+++ b/packages/ai/src/tasks/courses/course-categories.ts
@@ -1,12 +1,13 @@
 import "server-only";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { COURSE_CATEGORIES } from "@zoonk/utils/categories";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import promptTemplate from "./course-categories.prompt.md";
 
-const DEFAULT_MODEL = "google/gemini-3.1-flash-lite-preview";
-const FALLBACK_MODELS = ["openai/gpt-5.4-nano", "anthropic/claude-haiku-4.5", "meta/llama-4-scout"];
+const taskName = "course-categories";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 /**
  * Categories available for AI assignment.
@@ -31,18 +32,20 @@ export type CourseCategoriesParams = {
 
 export async function generateCourseCategories({
   courseTitle,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   useFallback = true,
   reasoningEffort,
 }: CourseCategoriesParams) {
-  const userPrompt = `COURSE_TITLE: ${courseTitle}`;
+  const userPrompt = `
+    COURSE_TITLE: ${courseTitle}
+  `;
   const systemPrompt = promptTemplate.replace("{{CATEGORIES}}", () => AI_CATEGORIES.join(", "));
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "course-categories",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/courses/course-chapters.ts
+++ b/packages/ai/src/tasks/courses/course-chapters.ts
@@ -1,15 +1,12 @@
 import "server-only";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./course-chapters.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.5";
-const FALLBACK_MODELS = [
-  "openai/gpt-5.4",
-  "anthropic/claude-opus-4.7",
-  "google/gemini-3.1-pro-preview",
-];
+const taskName = "course-chapters";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   chapters: z.array(
@@ -34,7 +31,7 @@ export type CourseChaptersParams = {
 export async function generateCourseChapters({
   language,
   courseTitle,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   useFallback = true,
   reasoningEffort,
 }: CourseChaptersParams) {
@@ -44,10 +41,10 @@ export async function generateCourseChapters({
   `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "course-chapters",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/courses/course-description.ts
+++ b/packages/ai/src/tasks/courses/course-description.ts
@@ -1,11 +1,12 @@
 import "server-only";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./course-description.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.4-nano";
-const FALLBACK_MODELS = ["google/gemini-3-flash", "anthropic/claude-haiku-4.5"];
+const taskName = "course-description";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   description: z.string(),
@@ -24,7 +25,7 @@ export type CourseDescriptionParams = {
 export async function generateCourseDescription({
   title,
   language,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   useFallback = true,
   reasoningEffort,
 }: CourseDescriptionParams) {
@@ -34,10 +35,10 @@ export async function generateCourseDescription({
   `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "course-description",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/courses/course-suggestions.ts
+++ b/packages/ai/src/tasks/courses/course-suggestions.ts
@@ -1,11 +1,12 @@
 import "server-only";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./course-suggestions.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.4-mini";
-const FALLBACK_MODELS = ["google/gemini-3-flash"];
+const taskName = "course-suggestions";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   courses: z.array(
@@ -30,7 +31,7 @@ export type CourseSuggestionsParams = {
 export async function generateCourseSuggestions({
   language,
   prompt,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   useFallback = true,
   reasoningEffort,
 }: CourseSuggestionsParams) {
@@ -40,10 +41,10 @@ export async function generateCourseSuggestions({
   `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "course-suggestions",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/courses/course-thumbnail.ts
+++ b/packages/ai/src/tasks/courses/course-thumbnail.ts
@@ -1,10 +1,12 @@
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { logError } from "@zoonk/utils/logger";
 import { type GeneratedFile, type ImageModel, generateImage } from "ai";
 import { type ImageGenerationQuality, buildImageProviderOptions } from "../../provider-options";
 import promptTemplate from "./course-thumbnail.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-image-2";
+const taskName = "course-thumbnail";
+const { defaultModel } = AI_TASK_MODEL_CONFIG[taskName];
 const DEFAULT_QUALITY = "low";
 
 function getCourseThumbnailPrompt(title: string) {
@@ -19,7 +21,7 @@ export type CourseThumbnailParams = {
 
 export async function generateCourseThumbnail({
   title,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   quality = DEFAULT_QUALITY,
 }: CourseThumbnailParams): Promise<SafeReturn<GeneratedFile>> {
   const { data, error } = await safeAsync(() =>
@@ -30,7 +32,7 @@ export async function generateCourseThumbnail({
       providerOptions: buildImageProviderOptions({
         model,
         quality,
-        taskName: "course-thumbnail",
+        taskName,
       }),
       size: "1024x1024",
     }),

--- a/packages/ai/src/tasks/courses/language-course-chapters.ts
+++ b/packages/ai/src/tasks/courses/language-course-chapters.ts
@@ -1,12 +1,13 @@
 import "server-only";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { getLanguageName } from "@zoonk/utils/languages";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./language-course-chapters.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.4";
-const FALLBACK_MODELS = ["google/gemini-3.1-pro-preview", "anthropic/claude-sonnet-4.6"];
+const taskName = "language-course-chapters";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   chapters: z.array(
@@ -30,7 +31,7 @@ export type LanguageCourseChaptersParams = {
 export async function generateLanguageCourseChapters({
   userLanguage,
   targetLanguage,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   useFallback = true,
   reasoningEffort,
 }: LanguageCourseChaptersParams) {
@@ -42,10 +43,10 @@ export async function generateLanguageCourseChapters({
   `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "language-course-chapters",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/lessons/lesson-core-activities.ts
+++ b/packages/ai/src/tasks/lessons/lesson-core-activities.ts
@@ -1,11 +1,12 @@
 import "server-only";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./lesson-core-activities.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.4";
-const FALLBACK_MODELS = ["anthropic/claude-opus-4.7", "google/gemini-3.1-pro-preview"];
+const taskName = "lesson-core-activities";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   activities: z.array(
@@ -44,7 +45,7 @@ export async function generateLessonCoreActivities({
   courseTitle,
   concepts,
   language,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   useFallback = true,
   reasoningEffort,
 }: LessonCoreActivitiesParams) {
@@ -58,10 +59,10 @@ export async function generateLessonCoreActivities({
   `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "lesson-core-activities",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/lessons/lesson-custom-activities.ts
+++ b/packages/ai/src/tasks/lessons/lesson-custom-activities.ts
@@ -1,11 +1,12 @@
 import "server-only";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./lesson-custom-activities.prompt.md";
 
-const DEFAULT_MODEL = "google/gemini-3-flash";
-const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "openai/gpt-5.4"];
+const taskName = "lesson-custom-activities";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   activities: z.array(
@@ -36,21 +37,23 @@ export async function generateLessonCustomActivities({
   chapterTitle,
   courseTitle,
   language,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   useFallback = true,
   reasoningEffort,
 }: LessonCustomActivitiesParams) {
-  const userPrompt = `LESSON_TITLE: ${lessonTitle}
-LESSON_DESCRIPTION: ${lessonDescription}
-CHAPTER_TITLE: ${chapterTitle}
-COURSE_TITLE: ${courseTitle}
-LANGUAGE: ${language}`;
+  const userPrompt = `
+    LESSON_TITLE: ${lessonTitle}
+    LESSON_DESCRIPTION: ${lessonDescription}
+    CHAPTER_TITLE: ${chapterTitle}
+    COURSE_TITLE: ${courseTitle}
+    LANGUAGE: ${language}
+  `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "lesson-custom-activities",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/lessons/lesson-kind.ts
+++ b/packages/ai/src/tasks/lessons/lesson-kind.ts
@@ -1,16 +1,12 @@
 import "server-only";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./lesson-kind.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.4-nano";
-
-const FALLBACK_MODELS = [
-  "google/gemini-3.1-flash-lite-preview",
-  "meta/llama-4-scout",
-  "anthropic/claude-haiku-4.5",
-];
+const taskName = "lesson-kind";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const schema = z.object({
   kind: z.enum(["core", "language", "custom"]),
@@ -35,21 +31,23 @@ export async function generateLessonKind({
   chapterTitle,
   courseTitle,
   language,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   useFallback = true,
   reasoningEffort,
 }: LessonKindParams) {
-  const userPrompt = `LESSON_TITLE: ${lessonTitle}
-LESSON_DESCRIPTION: ${lessonDescription}
-CHAPTER_TITLE: ${chapterTitle}
-COURSE_TITLE: ${courseTitle}
-LANGUAGE: ${language}`;
+  const userPrompt = `
+    LESSON_TITLE: ${lessonTitle}
+    LESSON_DESCRIPTION: ${lessonDescription}
+    CHAPTER_TITLE: ${chapterTitle}
+    COURSE_TITLE: ${courseTitle}
+    LANGUAGE: ${language}
+  `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "lesson-kind",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/metadata.ts
+++ b/packages/ai/src/tasks/metadata.ts
@@ -1,0 +1,129 @@
+type AiTaskModelConfig = {
+  defaultModel: string;
+  fallbackModels: readonly string[];
+};
+
+export const AI_TASK_MODEL_CONFIG = {
+  "activity-custom": {
+    defaultModel: "google/gemini-3-flash",
+    fallbackModels: ["anthropic/claude-opus-4.6", "openai/gpt-5.4"],
+  },
+  "activity-distractors": {
+    defaultModel: "openai/gpt-5.4",
+    fallbackModels: ["google/gemini-3.1-flash-lite-preview", "anthropic/claude-sonnet-4.6"],
+  },
+  "activity-explanation": {
+    defaultModel: "openai/gpt-5.4",
+    fallbackModels: ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"],
+  },
+  "activity-grammar-content": {
+    defaultModel: "google/gemini-3.1-pro-preview",
+    fallbackModels: ["openai/gpt-5.4", "anthropic/claude-opus-4.6"],
+  },
+  "activity-grammar-user-content": {
+    defaultModel: "openai/gpt-5.4",
+    fallbackModels: ["anthropic/claude-opus-4.6", "google/gemini-3-flash"],
+  },
+  "activity-practice": {
+    defaultModel: "openai/gpt-5.4",
+    fallbackModels: ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"],
+  },
+  "activity-pronunciation": {
+    defaultModel: "google/gemini-3-flash",
+    fallbackModels: ["anthropic/claude-sonnet-4.6", "openai/gpt-5.1-instant"],
+  },
+  "activity-quiz": {
+    defaultModel: "openai/gpt-5.4",
+    fallbackModels: ["anthropic/claude-opus-4.6"],
+  },
+  "activity-romanization": {
+    defaultModel: "openai/gpt-5.4",
+    fallbackModels: ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"],
+  },
+  "activity-sentences": {
+    defaultModel: "openai/gpt-5.4",
+    fallbackModels: ["google/gemini-3.1-pro-preview", "anthropic/claude-opus-4.6"],
+  },
+  "activity-translation": {
+    defaultModel: "openai/gpt-5.4-mini",
+    fallbackModels: ["google/gemini-3-flash", "anthropic/claude-opus-4.6"],
+  },
+  "activity-vocabulary": {
+    defaultModel: "google/gemini-3-flash",
+    fallbackModels: ["google/gemini-3.1-pro-preview", "openai/gpt-5.4"],
+  },
+  "alternative-titles": {
+    defaultModel: "openai/gpt-5.4",
+    fallbackModels: ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"],
+  },
+  "chapter-lessons": {
+    defaultModel: "openai/gpt-5.5",
+    fallbackModels: [
+      "openai/gpt-5.4",
+      "google/gemini-3.1-pro-preview",
+      "anthropic/claude-opus-4.7",
+    ],
+  },
+  "course-categories": {
+    defaultModel: "google/gemini-3.1-flash-lite-preview",
+    fallbackModels: ["openai/gpt-5.4-nano", "anthropic/claude-haiku-4.5", "meta/llama-4-scout"],
+  },
+  "course-chapters": {
+    defaultModel: "openai/gpt-5.5",
+    fallbackModels: [
+      "openai/gpt-5.4",
+      "anthropic/claude-opus-4.7",
+      "google/gemini-3.1-pro-preview",
+    ],
+  },
+  "course-description": {
+    defaultModel: "openai/gpt-5.4-nano",
+    fallbackModels: ["google/gemini-3-flash", "anthropic/claude-haiku-4.5"],
+  },
+  "course-suggestions": {
+    defaultModel: "openai/gpt-5.4-mini",
+    fallbackModels: ["google/gemini-3-flash"],
+  },
+  "course-thumbnail": {
+    defaultModel: "openai/gpt-image-2",
+    fallbackModels: [],
+  },
+  "language-chapter-lessons": {
+    defaultModel: "openai/gpt-5.4",
+    fallbackModels: ["google/gemini-3.1-pro-preview", "anthropic/claude-sonnet-4.6"],
+  },
+  "language-course-chapters": {
+    defaultModel: "openai/gpt-5.4",
+    fallbackModels: ["google/gemini-3.1-pro-preview", "anthropic/claude-sonnet-4.6"],
+  },
+  "lesson-core-activities": {
+    defaultModel: "openai/gpt-5.4",
+    fallbackModels: ["anthropic/claude-opus-4.7", "google/gemini-3.1-pro-preview"],
+  },
+  "lesson-custom-activities": {
+    defaultModel: "google/gemini-3-flash",
+    fallbackModels: ["anthropic/claude-opus-4.6", "openai/gpt-5.4"],
+  },
+  "lesson-kind": {
+    defaultModel: "openai/gpt-5.4-nano",
+    fallbackModels: [
+      "google/gemini-3.1-flash-lite-preview",
+      "meta/llama-4-scout",
+      "anthropic/claude-haiku-4.5",
+    ],
+  },
+  "step-content-image": {
+    defaultModel: "openai/gpt-image-2",
+    fallbackModels: [],
+  },
+  "step-image-prompts": {
+    defaultModel: "openai/gpt-5.4",
+    fallbackModels: ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"],
+  },
+  "step-select-image": {
+    defaultModel: "openai/gpt-image-2",
+    fallbackModels: [],
+  },
+} satisfies Record<string, AiTaskModelConfig>;
+
+export type AiTaskName = keyof typeof AI_TASK_MODEL_CONFIG;

--- a/packages/ai/src/tasks/steps/step-content-image.ts
+++ b/packages/ai/src/tasks/steps/step-content-image.ts
@@ -1,3 +1,4 @@
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { logError } from "@zoonk/utils/logger";
 import { type GeneratedFile, type ImageModel, generateImage } from "ai";
@@ -5,14 +6,15 @@ import { type ImageGenerationQuality, buildImageProviderOptions } from "../../pr
 import illustrationPromptTemplate from "./step-content-image.prompt.md";
 import practicePromptTemplate from "./step-content-practice-image.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-image-2";
+const taskName = "step-content-image";
+const { defaultModel } = AI_TASK_MODEL_CONFIG[taskName];
 const DEFAULT_QUALITY = "low";
 
 const STEP_CONTENT_IMAGE_PRESETS = {
   illustration: {
     promptTemplate: illustrationPromptTemplate,
     size: "1024x1280",
-    taskName: "step-content-image",
+    taskName,
   },
   practice: {
     promptTemplate: practicePromptTemplate,
@@ -49,7 +51,7 @@ export type StepContentImageParams = {
 
 export async function generateStepContentImage({
   language,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   preset = DEFAULT_PRESET,
   prompt,
   quality = DEFAULT_QUALITY,

--- a/packages/ai/src/tasks/steps/step-image-prompts.ts
+++ b/packages/ai/src/tasks/steps/step-image-prompts.ts
@@ -1,11 +1,12 @@
 import "server-only";
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import systemPrompt from "./step-image-prompts.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-5.4";
-const FALLBACK_MODELS = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"];
+const taskName = "step-image-prompts";
+const { defaultModel, fallbackModels } = AI_TASK_MODEL_CONFIG[taskName];
 
 const imagePromptSchema = z.string().min(1);
 
@@ -44,7 +45,7 @@ export async function generateStepImagePrompts({
   courseTitle,
   language,
   steps,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   useFallback = true,
   reasoningEffort,
 }: StepImagePromptsParams) {
@@ -52,19 +53,20 @@ export async function generateStepImagePrompts({
     .map((step, index) => `${index}. ${step.title}: ${step.text}`)
     .join("\n");
 
-  const userPrompt = `LESSON_TITLE: ${lessonTitle}
-LESSON_DESCRIPTION: ${lessonDescription}
-CHAPTER_TITLE: ${chapterTitle}
-COURSE_TITLE: ${courseTitle}
-LANGUAGE: ${language}
-STEPS:
-${formattedSteps}`;
+  const userPrompt = `
+    LESSON_TITLE: ${lessonTitle}
+    LESSON_DESCRIPTION: ${lessonDescription}
+    CHAPTER_TITLE: ${chapterTitle}
+    COURSE_TITLE: ${courseTitle}
+    LANGUAGE: ${language}
+    STEPS: ${formattedSteps}
+  `;
 
   const providerOptions = buildProviderOptions({
-    fallbackModels: FALLBACK_MODELS,
+    fallbackModels,
     model,
     reasoningEffort,
-    taskName: "step-image-prompts",
+    taskName,
     useFallback,
   });
 

--- a/packages/ai/src/tasks/steps/step-select-image.ts
+++ b/packages/ai/src/tasks/steps/step-select-image.ts
@@ -1,10 +1,12 @@
+import { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { logError } from "@zoonk/utils/logger";
 import { type GeneratedFile, type ImageModel, generateImage } from "ai";
 import { type ImageGenerationQuality, buildImageProviderOptions } from "../../provider-options";
 import promptTemplate from "./step-select-image.prompt.md";
 
-const DEFAULT_MODEL = "openai/gpt-image-2";
+const taskName = "step-select-image";
+const { defaultModel } = AI_TASK_MODEL_CONFIG[taskName];
 const DEFAULT_QUALITY = "low";
 
 function getSelectImageStepPrompt(prompt: string, language: string) {
@@ -21,7 +23,7 @@ export type SelectImageStepParams = {
 export async function generateSelectImageStep({
   prompt,
   language,
-  model = DEFAULT_MODEL,
+  model = defaultModel,
   quality = DEFAULT_QUALITY,
 }: SelectImageStepParams): Promise<SafeReturn<GeneratedFile>> {
   const { data, error } = await safeAsync(() =>
@@ -32,7 +34,7 @@ export async function generateSelectImageStep({
       providerOptions: buildImageProviderOptions({
         model,
         quality,
-        taskName: "step-select-image",
+        taskName,
       }),
       size: "1024x1024",
     }),

--- a/packages/core/src/ai.ts
+++ b/packages/core/src/ai.ts
@@ -1,5 +1,8 @@
 export { zoonkGateway } from "@zoonk/ai/gateway";
 
+export { AI_TASK_MODEL_CONFIG } from "@zoonk/ai/tasks/metadata";
+export type { AiTaskName } from "@zoonk/ai/tasks/metadata";
+
 export {
   buildGatewayTaskTag,
   extractGatewayDefaultModel,


### PR DESCRIPTION
Centralizes AI task model and fallback metadata in the AI package, reuses it from admin reporting, and normalizes AI task user prompt template formatting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes AI task model configuration into a single source of truth and updates all tasks and the admin catalog to use it. Also standardizes user prompt formatting and hardens fallback handling.

- **Refactors**
  - Added `AI_TASK_MODEL_CONFIG` and `AiTaskName` in `@zoonk/ai/tasks/metadata`, re-exported via `@zoonk/core/ai`.
  - Replaced per-task hardcoded defaults with config-driven `defaultModel` and `fallbackModels`.
  - Admin `ai-task-catalog` now imports from `@zoonk/core/ai` and derives `supportsFallbackReporting` from `fallbackModels.length`.
  - `buildProviderOptions` now accepts `readonly` fallback arrays; spread when passing to providers to avoid mutation.
  - Normalized user prompt templates to concise, multi-line strings for consistency.

<sup>Written for commit 1bf44e5b6b193053c34b37c02f34a163b80f06a6. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1319?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

