### PR TITLE
fix(main): remove performance chart size warnings

### DIFF
--- a/apps/main/e2e/performance-charts.test.ts
+++ b/apps/main/e2e/performance-charts.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "./fixtures";
+
+const CHART_SIZE_WARNING = "The width(-1) and height(-1) of chart should be greater than 0";
+
+const chartPages = [
+  { chartName: /energy chart/i, label: "energy", path: "/energy" },
+  { chartName: /brain power chart/i, label: "level", path: "/level" },
+  { chartName: /score chart/i, label: "score", path: "/score" },
+];
+
+test.describe("Performance Charts", () => {
+  for (const chartPage of chartPages) {
+    test(`${chartPage.label} chart renders without invalid size warnings`, async ({
+      authenticatedPage,
+    }) => {
+      const chartWarnings: string[] = [];
+
+      authenticatedPage.on("console", (message) => {
+        if (message.text().includes(CHART_SIZE_WARNING)) {
+          chartWarnings.push(message.text());
+        }
+      });
+
+      await authenticatedPage.goto(chartPage.path);
+      await expect(
+        authenticatedPage.getByRole("figure", { name: chartPage.chartName }),
+      ).toBeVisible();
+
+      expect(chartWarnings).toEqual([]);
+    });
+  }
+});

--- a/apps/main/src/app/(performance)/_components/performance-area-chart.tsx
+++ b/apps/main/src/app/(performance)/_components/performance-area-chart.tsx
@@ -1,0 +1,246 @@
+import { cn } from "@zoonk/ui/lib/utils";
+import { isValidChartPayload } from "@zoonk/utils/chart";
+import { type CSSProperties, type ComponentProps, type ReactNode } from "react";
+import { Area, AreaChart, CartesianGrid, ReferenceLine, Tooltip, XAxis, YAxis } from "recharts";
+
+type PerformanceAreaChartProps = Omit<
+  ComponentProps<typeof AreaChart>,
+  "margin" | "responsive" | "style"
+>;
+
+type PerformanceChartFigureProps = {
+  children: ReactNode;
+  label: string;
+};
+
+type PerformanceChartTooltipProps<DataPoint> = {
+  children: (data: DataPoint) => ReactNode;
+};
+
+type PerformanceChartGradientProps = {
+  color: string;
+  id: string;
+};
+
+type PerformanceChartAreaProps = {
+  color: string;
+  dataKey: string;
+  gradientId: string;
+};
+
+type PerformanceChartAverageLineProps = {
+  children: string;
+  y: number;
+};
+
+type PerformanceChartCompactYAxisProps = {
+  locale: string;
+};
+
+const PERFORMANCE_CHART_MARGIN = { bottom: 0, left: 0, right: 0, top: 10 };
+
+const PERFORMANCE_CHART_STYLE = {
+  height: 256,
+  width: "100%",
+} satisfies CSSProperties;
+
+/**
+ * Gives each performance chart the same accessible container and flex-safe
+ * width behavior. Recharts measures the chart from this parent, so every chart
+ * should use the same `min-w-0` guard instead of relying on each page to
+ * remember it.
+ */
+export function PerformanceChartFigure({ children, label }: PerformanceChartFigureProps) {
+  return (
+    <figure aria-label={label} className="w-full min-w-0">
+      {children}
+    </figure>
+  );
+}
+
+/**
+ * Keeps every performance AreaChart on the same Recharts sizing path.
+ * Recharts' ResponsiveContainer warns during the first render because it starts
+ * with a temporary -1 by -1 measurement. The chart-level `responsive` prop uses
+ * normal CSS sizing instead, so each chart gets a stable height before the
+ * browser measures its width.
+ */
+export function PerformanceAreaChart(props: PerformanceAreaChartProps) {
+  return (
+    <AreaChart
+      {...props}
+      margin={PERFORMANCE_CHART_MARGIN}
+      responsive
+      style={PERFORMANCE_CHART_STYLE}
+    />
+  );
+}
+
+/**
+ * Keeps chart background grid styling consistent across every performance
+ * metric. The vertical grid stays hidden because these charts compare trends
+ * across time and the horizontal guides are enough for scanning values.
+ */
+export function PerformanceChartGrid() {
+  return <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />;
+}
+
+/**
+ * Keeps every performance chart on the same x-axis contract. All chart data is
+ * serialized with a learner-facing `label`, so keeping that data key here
+ * prevents one metric from drifting into a different tick style.
+ */
+export function PerformanceChartXAxis() {
+  return (
+    <XAxis
+      axisLine={false}
+      dataKey="label"
+      fontSize={12}
+      stroke="var(--muted-foreground)"
+      tickLine={false}
+      tickMargin={8}
+    />
+  );
+}
+
+/**
+ * Keeps percent-based metrics on the same y-axis scale. Energy and score both
+ * live on a 0-100 range, so the domain, width, and tick spacing should stay in
+ * one shared component.
+ */
+export function PerformanceChartPercentYAxis() {
+  return (
+    <YAxis
+      axisLine={false}
+      domain={[0, 100]}
+      fontSize={12}
+      stroke="var(--muted-foreground)"
+      tickLine={false}
+      tickMargin={8}
+      width={40}
+    />
+  );
+}
+
+/**
+ * Keeps Brain Power on the same y-axis style while allowing locale-aware compact
+ * numbers. BP can grow beyond a percent range, so it needs its own axis variant
+ * but should still match the shared performance chart typography and chrome.
+ */
+export function PerformanceChartCompactYAxis({ locale }: PerformanceChartCompactYAxisProps) {
+  return (
+    <YAxis
+      axisLine={false}
+      fontSize={12}
+      stroke="var(--muted-foreground)"
+      tickFormatter={(value: number) =>
+        new Intl.NumberFormat(locale, { notation: "compact" }).format(value)
+      }
+      tickLine={false}
+      tickMargin={8}
+      width={48}
+    />
+  );
+}
+
+/**
+ * Keeps area fills visually consistent while leaving the metric color explicit.
+ * Every performance chart uses the same fade shape, and the caller only decides
+ * which CSS color token owns that metric.
+ */
+export function PerformanceChartGradient({ color, id }: PerformanceChartGradientProps) {
+  return (
+    <linearGradient id={id} x1="0" x2="0" y1="0" y2="1">
+      <stop offset="5%" stopColor={color} stopOpacity={0.3} />
+      <stop offset="95%" stopColor={color} stopOpacity={0} />
+    </linearGradient>
+  );
+}
+
+/**
+ * Keeps area-series styling consistent while leaving the metric key and color
+ * explicit. Without this wrapper, small differences like fill opacity or stroke
+ * width can drift between charts that should feel like one family.
+ */
+export function PerformanceChartArea({ color, dataKey, gradientId }: PerformanceChartAreaProps) {
+  return (
+    <Area
+      dataKey={dataKey}
+      fill={`url(#${gradientId})`}
+      fillOpacity={1}
+      stroke={color}
+      strokeWidth={2}
+      type="monotone"
+    />
+  );
+}
+
+/**
+ * Handles Recharts' tooltip payload guard once for all performance charts.
+ * The chart-specific tooltip content still lives at the call site, but the
+ * fragile active/payload validation no longer needs to be copied into every
+ * metric chart.
+ */
+export function PerformanceChartTooltip<DataPoint>({
+  children,
+}: PerformanceChartTooltipProps<DataPoint>) {
+  return (
+    <Tooltip
+      content={({ active, payload }) => {
+        if (!(active && isValidChartPayload<DataPoint>(payload))) {
+          return null;
+        }
+
+        return children(payload[0].payload);
+      }}
+    />
+  );
+}
+
+/**
+ * Keeps tooltip containers visually identical across performance charts. The
+ * metric-specific rows are composed inside this shell so color and text can vary
+ * without changing the shared border, background, or spacing.
+ */
+export function PerformanceChartTooltipContent({ children }: { children: ReactNode }) {
+  return <div className="bg-background rounded-lg border px-3 py-2 shadow-sm">{children}</div>;
+}
+
+/**
+ * Keeps tooltip date labels muted and compact across every performance chart.
+ * These labels identify the active point, so they should stay quieter than the
+ * metric value regardless of which metric is being shown.
+ */
+export function PerformanceChartTooltipLabel({ children }: { children: ReactNode }) {
+  return <p className="text-muted-foreground text-xs">{children}</p>;
+}
+
+/**
+ * Keeps tooltip metric values on the same type scale while letting each metric
+ * pass its own color class. The color is the only intended visual difference
+ * between the energy, score, and BP values.
+ */
+export function PerformanceChartTooltipValue({ children, className }: ComponentProps<"p">) {
+  return <p className={cn("text-sm font-medium", className)}>{children}</p>;
+}
+
+/**
+ * Keeps the average marker identical for percent-based performance charts.
+ * Energy and score both show an average line, so the line style and label
+ * placement should stay shared while the caller supplies the localized label.
+ */
+export function PerformanceChartAverageLine({ children, y }: PerformanceChartAverageLineProps) {
+  return (
+    <ReferenceLine
+      label={{
+        fill: "var(--muted-foreground)",
+        fontSize: 11,
+        position: "insideBottomRight",
+        value: children,
+      }}
+      stroke="var(--muted-foreground)"
+      strokeDasharray="3 3"
+      y={y}
+    />
+  );
+}

--- a/apps/main/src/app/(performance)/energy/energy-chart-client.tsx
+++ b/apps/main/src/app/(performance)/energy/energy-chart-client.tsx
@@ -1,17 +1,20 @@
 "use client";
 
-import { isValidChartPayload } from "@zoonk/utils/chart";
 import { useExtracted } from "next-intl";
 import {
-  Area,
-  AreaChart,
-  CartesianGrid,
-  ReferenceLine,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+  PerformanceAreaChart,
+  PerformanceChartArea,
+  PerformanceChartAverageLine,
+  PerformanceChartFigure,
+  PerformanceChartGradient,
+  PerformanceChartGrid,
+  PerformanceChartPercentYAxis,
+  PerformanceChartTooltip,
+  PerformanceChartTooltipContent,
+  PerformanceChartTooltipLabel,
+  PerformanceChartTooltipValue,
+  PerformanceChartXAxis,
+} from "../_components/performance-area-chart";
 
 type SerializedDataPoint = {
   date: string;
@@ -27,79 +30,41 @@ export function EnergyChartClient({
   dataPoints: SerializedDataPoint[];
 }) {
   const t = useExtracted();
+  const color = "var(--energy)";
+  const gradientId = "energyGradient";
 
   return (
-    <figure aria-label={t("Energy chart")} className="h-64 w-full">
-      <ResponsiveContainer height="100%" width="100%">
-        <AreaChart data={dataPoints} margin={{ bottom: 0, left: 0, right: 0, top: 10 }}>
-          <defs>
-            <linearGradient id="energyGradient" x1="0" x2="0" y1="0" y2="1">
-              <stop offset="5%" stopColor="var(--energy)" stopOpacity={0.3} />
-              <stop offset="95%" stopColor="var(--energy)" stopOpacity={0} />
-            </linearGradient>
-          </defs>
+    <PerformanceChartFigure label={t("Energy chart")}>
+      <PerformanceAreaChart data={dataPoints}>
+        <defs>
+          <PerformanceChartGradient color={color} id={gradientId} />
+        </defs>
 
-          <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
+        <PerformanceChartGrid />
+        <PerformanceChartXAxis />
+        <PerformanceChartPercentYAxis />
 
-          <XAxis
-            axisLine={false}
-            dataKey="label"
-            fontSize={12}
-            stroke="var(--muted-foreground)"
-            tickLine={false}
-            tickMargin={8}
-          />
+        <PerformanceChartTooltip<SerializedDataPoint>>
+          {(data) => {
+            const value = data.energy.toFixed(1);
 
-          <YAxis
-            axisLine={false}
-            domain={[0, 100]}
-            fontSize={12}
-            stroke="var(--muted-foreground)"
-            tickLine={false}
-            tickMargin={8}
-            width={40}
-          />
+            return (
+              <PerformanceChartTooltipContent>
+                <PerformanceChartTooltipLabel>{data.label}</PerformanceChartTooltipLabel>
+                <PerformanceChartTooltipValue className="text-energy">
+                  {t("{value}%", { value })}
+                </PerformanceChartTooltipValue>
+              </PerformanceChartTooltipContent>
+            );
+          }}
+        </PerformanceChartTooltip>
 
-          <Tooltip
-            content={({ active, payload }) => {
-              if (!(active && isValidChartPayload<SerializedDataPoint>(payload))) {
-                return null;
-              }
+        <PerformanceChartAverageLine y={average}>
+          {`${t("Avg")}: ${average.toFixed(1)}%`}
+        </PerformanceChartAverageLine>
 
-              const data = payload[0].payload;
-              const value = data.energy.toFixed(1);
-
-              return (
-                <div className="bg-background rounded-lg border px-3 py-2 shadow-sm">
-                  <p className="text-muted-foreground text-xs">{data.label}</p>
-                  <p className="text-energy text-sm font-medium">{t("{value}%", { value })}</p>
-                </div>
-              );
-            }}
-          />
-
-          <ReferenceLine
-            label={{
-              fill: "var(--muted-foreground)",
-              fontSize: 11,
-              position: "insideBottomRight",
-              value: `${t("Avg")}: ${average.toFixed(1)}%`,
-            }}
-            stroke="var(--muted-foreground)"
-            strokeDasharray="3 3"
-            y={average}
-          />
-
-          <Area
-            dataKey="energy"
-            fill="url(#energyGradient)"
-            fillOpacity={1}
-            stroke="var(--energy)"
-            strokeWidth={2}
-            type="monotone"
-          />
-        </AreaChart>
-      </ResponsiveContainer>
-    </figure>
+        <PerformanceChartArea color={color} dataKey="energy" gradientId={gradientId} />
+      </PerformanceAreaChart>
+    </PerformanceChartFigure>
   );
 }

--- a/apps/main/src/app/(performance)/level/level-chart-client.tsx
+++ b/apps/main/src/app/(performance)/level/level-chart-client.tsx
@@ -1,16 +1,19 @@
 "use client";
 
-import { isValidChartPayload } from "@zoonk/utils/chart";
 import { useExtracted, useLocale } from "next-intl";
 import {
-  Area,
-  AreaChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+  PerformanceAreaChart,
+  PerformanceChartArea,
+  PerformanceChartCompactYAxis,
+  PerformanceChartFigure,
+  PerformanceChartGradient,
+  PerformanceChartGrid,
+  PerformanceChartTooltip,
+  PerformanceChartTooltipContent,
+  PerformanceChartTooltipLabel,
+  PerformanceChartTooltipValue,
+  PerformanceChartXAxis,
+} from "../_components/performance-area-chart";
 
 type SerializedDataPoint = {
   date: string;
@@ -29,72 +32,41 @@ export function LevelChartClient({
   const locale = useLocale();
 
   const formattedTotal = new Intl.NumberFormat(locale).format(total);
+  const color = "var(--primary)";
+  const gradientId = "bpGradient";
 
   return (
-    <figure aria-label={t("Brain Power chart")} className="h-64 w-full">
-      <ResponsiveContainer height="100%" width="100%">
-        <AreaChart data={dataPoints} margin={{ bottom: 0, left: 0, right: 0, top: 10 }}>
-          <defs>
-            <linearGradient id="bpGradient" x1="0" x2="0" y1="0" y2="1">
-              <stop offset="5%" stopColor="var(--primary)" stopOpacity={0.3} />
-              <stop offset="95%" stopColor="var(--primary)" stopOpacity={0} />
-            </linearGradient>
-          </defs>
+    <PerformanceChartFigure label={t("Brain Power chart")}>
+      <PerformanceAreaChart data={dataPoints}>
+        <defs>
+          <PerformanceChartGradient color={color} id={gradientId} />
+        </defs>
 
-          <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
+        <PerformanceChartGrid />
+        <PerformanceChartXAxis />
+        <PerformanceChartCompactYAxis locale={locale} />
 
-          <XAxis
-            axisLine={false}
-            dataKey="label"
-            fontSize={12}
-            stroke="var(--muted-foreground)"
-            tickLine={false}
-          />
+        <PerformanceChartTooltip<SerializedDataPoint>>
+          {(data) => {
+            const formattedValue = new Intl.NumberFormat(locale).format(data.bp);
 
-          <YAxis
-            axisLine={false}
-            fontSize={12}
-            stroke="var(--muted-foreground)"
-            tickFormatter={(value: number) =>
-              new Intl.NumberFormat(locale, { notation: "compact" }).format(value)
-            }
-            tickLine={false}
-            width={48}
-          />
+            return (
+              <PerformanceChartTooltipContent>
+                <PerformanceChartTooltipLabel>{data.label}</PerformanceChartTooltipLabel>
+                <PerformanceChartTooltipValue>
+                  {t("{value} BP", { value: formattedValue })}
+                </PerformanceChartTooltipValue>
+              </PerformanceChartTooltipContent>
+            );
+          }}
+        </PerformanceChartTooltip>
 
-          <Tooltip
-            content={({ active, payload }) => {
-              if (!(active && isValidChartPayload<SerializedDataPoint>(payload))) {
-                return null;
-              }
-
-              const data = payload[0].payload;
-              const formattedValue = new Intl.NumberFormat(locale).format(data.bp);
-
-              return (
-                <div className="bg-background rounded-lg border px-3 py-2 shadow-sm">
-                  <p className="text-muted-foreground text-xs">{data.label}</p>
-                  <p className="text-sm font-medium">
-                    {t("{value} BP", { value: formattedValue })}
-                  </p>
-                </div>
-              );
-            }}
-          />
-
-          <Area
-            dataKey="bp"
-            fill="url(#bpGradient)"
-            stroke="var(--primary)"
-            strokeWidth={2}
-            type="monotone"
-          />
-        </AreaChart>
-      </ResponsiveContainer>
+        <PerformanceChartArea color={color} dataKey="bp" gradientId={gradientId} />
+      </PerformanceAreaChart>
 
       <figcaption className="sr-only">
         {t("Total Brain Power earned: {total}", { total: formattedTotal })}
       </figcaption>
-    </figure>
+    </PerformanceChartFigure>
   );
 }

--- a/apps/main/src/app/(performance)/score/score-chart-client.tsx
+++ b/apps/main/src/app/(performance)/score/score-chart-client.tsx
@@ -1,17 +1,20 @@
 "use client";
 
-import { isValidChartPayload } from "@zoonk/utils/chart";
 import { useExtracted } from "next-intl";
 import {
-  Area,
-  AreaChart,
-  CartesianGrid,
-  ReferenceLine,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+  PerformanceAreaChart,
+  PerformanceChartArea,
+  PerformanceChartAverageLine,
+  PerformanceChartFigure,
+  PerformanceChartGradient,
+  PerformanceChartGrid,
+  PerformanceChartPercentYAxis,
+  PerformanceChartTooltip,
+  PerformanceChartTooltipContent,
+  PerformanceChartTooltipLabel,
+  PerformanceChartTooltipValue,
+  PerformanceChartXAxis,
+} from "../_components/performance-area-chart";
 
 type SerializedDataPoint = {
   date: string;
@@ -27,79 +30,41 @@ export function ScoreChartClient({
   dataPoints: SerializedDataPoint[];
 }) {
   const t = useExtracted();
+  const color = "var(--score)";
+  const gradientId = "scoreGradient";
 
   return (
-    <figure aria-label={t("Score chart")} className="h-64 w-full">
-      <ResponsiveContainer height="100%" width="100%">
-        <AreaChart data={dataPoints} margin={{ bottom: 0, left: 0, right: 0, top: 10 }}>
-          <defs>
-            <linearGradient id="scoreGradient" x1="0" x2="0" y1="0" y2="1">
-              <stop offset="5%" stopColor="var(--score)" stopOpacity={0.3} />
-              <stop offset="95%" stopColor="var(--score)" stopOpacity={0} />
-            </linearGradient>
-          </defs>
+    <PerformanceChartFigure label={t("Score chart")}>
+      <PerformanceAreaChart data={dataPoints}>
+        <defs>
+          <PerformanceChartGradient color={color} id={gradientId} />
+        </defs>
 
-          <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
+        <PerformanceChartGrid />
+        <PerformanceChartXAxis />
+        <PerformanceChartPercentYAxis />
 
-          <XAxis
-            axisLine={false}
-            dataKey="label"
-            fontSize={12}
-            stroke="var(--muted-foreground)"
-            tickLine={false}
-            tickMargin={8}
-          />
+        <PerformanceChartTooltip<SerializedDataPoint>>
+          {(data) => {
+            const value = data.score.toFixed(1);
 
-          <YAxis
-            axisLine={false}
-            domain={[0, 100]}
-            fontSize={12}
-            stroke="var(--muted-foreground)"
-            tickLine={false}
-            tickMargin={8}
-            width={40}
-          />
+            return (
+              <PerformanceChartTooltipContent>
+                <PerformanceChartTooltipLabel>{data.label}</PerformanceChartTooltipLabel>
+                <PerformanceChartTooltipValue className="text-score">
+                  {t("{value}%", { value })}
+                </PerformanceChartTooltipValue>
+              </PerformanceChartTooltipContent>
+            );
+          }}
+        </PerformanceChartTooltip>
 
-          <Tooltip
-            content={({ active, payload }) => {
-              if (!(active && isValidChartPayload<SerializedDataPoint>(payload))) {
-                return null;
-              }
+        <PerformanceChartAverageLine y={average}>
+          {`${t("Avg")}: ${average.toFixed(1)}%`}
+        </PerformanceChartAverageLine>
 
-              const data = payload[0].payload;
-              const value = data.score.toFixed(1);
-
-              return (
-                <div className="bg-background rounded-lg border px-3 py-2 shadow-sm">
-                  <p className="text-muted-foreground text-xs">{data.label}</p>
-                  <p className="text-score text-sm font-medium">{t("{value}%", { value })}</p>
-                </div>
-              );
-            }}
-          />
-
-          <ReferenceLine
-            label={{
-              fill: "var(--muted-foreground)",
-              fontSize: 11,
-              position: "insideBottomRight",
-              value: `${t("Avg")}: ${average.toFixed(1)}%`,
-            }}
-            stroke="var(--muted-foreground)"
-            strokeDasharray="3 3"
-            y={average}
-          />
-
-          <Area
-            dataKey="score"
-            fill="url(#scoreGradient)"
-            fillOpacity={1}
-            stroke="var(--score)"
-            strokeWidth={2}
-            type="monotone"
-          />
-        </AreaChart>
-      </ResponsiveContainer>
-    </figure>
+        <PerformanceChartArea color={color} dataKey="score" gradientId={gradientId} />
+      </PerformanceAreaChart>
+    </PerformanceChartFigure>
   );
 }


### PR DESCRIPTION
Refactors performance charts onto shared compound components so Recharts receives stable dimensions and the energy, level, and score charts stay consistent. Adds an e2e regression for the chart-size console warning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates `Recharts` chart size warnings by switching performance charts to shared components with stable dimensions. Adds an e2e test to prevent regressions.

- **Bug Fixes**
  - Charts mount with a fixed height and flex-safe width, removing "The width(-1) and height(-1) of chart should be greater than 0" warning.
  - New e2e test visits /energy, /level, and /score and asserts no size warnings.

- **Refactors**
  - Added shared chart components (axes, grid, gradients, tooltip, average line) in `(performance)/_components/performance-area-chart.tsx`.
  - Migrated Energy, Brain Power, and Score chart clients to the shared components for consistent UI.
  - Percent metrics use a common 0–100 Y-axis; Brain Power uses a compact, locale-aware Y-axis.

<sup>Written for commit 629ba36652486431c3059dbbf5f1064179d9199b. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1324?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

