### PR TITLE
fix(test): prevent ai calls in learn e2e

### DIFF
--- a/.agents/skills/zoonk-commit/SKILL.md
+++ b/.agents/skills/zoonk-commit/SKILL.md
@@ -54,6 +54,7 @@ Example:
 - `agents` - CLAUDE.md, AGENTS.md, `.claude/` folder
 - `ci` - GitHub workflows, CI/CD configuration
 - `deps` - dependency updates across multiple packages
+- `test` - when only test files are changed
 
 ### Good Scope Choices
 
@@ -80,6 +81,7 @@ refactor(db): use enum for status field
 chore(deps): update react to v19
 chore(agents): add commit skill
 fix(ci): update node version in workflow
+fix(test): fix e2e test flakiness for course chapters
 ```
 
 ## Rules

--- a/apps/main/e2e/learn.test.ts
+++ b/apps/main/e2e/learn.test.ts
@@ -1,9 +1,73 @@
+import { prisma } from "@zoonk/db";
+import { type Page, type Route } from "@zoonk/e2e/fixtures";
 import { searchPromptWithSuggestionsFixture } from "@zoonk/testing/fixtures/course-suggestions";
+import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
+
+const TEST_RUN_ID = "test-run-id-learn-generate-link";
 
 let prompt: string;
 let suggestionTitle: string;
 let suggestionDescription: string;
+
+/**
+ * The suggestion-link test only verifies navigation into the generation page.
+ * Mocking the workflow API keeps that page from starting real course generation
+ * after the URL assertion has already proved the behavior under test.
+ */
+async function mockCourseGenerationWorkflow(page: Page): Promise<void> {
+  await page.route("**/v1/workflows/course-generation/**", handleCourseGenerationRoute);
+}
+
+/**
+ * The generation client expects the trigger endpoint to return a run id and
+ * the status endpoint to speak SSE. Returning an empty stream is enough for
+ * the navigation test while preventing the API app from touching AI providers.
+ */
+async function handleCourseGenerationRoute(route: Route): Promise<void> {
+  const url = route.request().url();
+  const method = route.request().method();
+
+  if (url.includes("/v1/workflows/course-generation/trigger") && method === "POST") {
+    await route.fulfill({
+      body: JSON.stringify({ message: "Workflow started", runId: TEST_RUN_ID }),
+      contentType: "application/json",
+      status: 200,
+    });
+    return;
+  }
+
+  if (url.includes("/v1/workflows/course-generation/status")) {
+    await route.fulfill({
+      body: "",
+      contentType: "text/event-stream",
+      status: 200,
+    });
+    return;
+  }
+
+  await route.continue();
+}
+
+/**
+ * The visible subject links are shuffled from fixed copy on the learn page.
+ * Seeding the clicked prompt before navigation keeps the destination page on
+ * the cached DB path instead of asking AI to create suggestions during e2e.
+ */
+async function ensureSuggestionsForPrompt(rawPrompt: string): Promise<void> {
+  const normalizedPrompt = normalizeString(rawPrompt);
+
+  const existing = await prisma.searchPrompt.findUnique({
+    include: { suggestions: true },
+    where: { languagePrompt: { language: "en", prompt: normalizedPrompt } },
+  });
+
+  if (existing && existing.suggestions.length > 0) {
+    return;
+  }
+
+  await searchPromptWithSuggestionsFixture({ prompt: rawPrompt });
+}
 
 test.beforeAll(async () => {
   const fixture = await searchPromptWithSuggestionsFixture();
@@ -33,6 +97,13 @@ test.describe("Learn Form", () => {
 
     const suggestions = page.getByRole("navigation", { name: /suggested subjects/i });
     const firstLink = suggestions.getByRole("link").first();
+    const subject = await firstLink.textContent();
+
+    if (!subject) {
+      throw new Error("No subject link text found");
+    }
+
+    await ensureSuggestionsForPrompt(subject);
     await firstLink.click();
 
     await expect(page).toHaveURL(/\/learn\/.+/);
@@ -64,6 +135,8 @@ test.describe("Course Suggestions", () => {
   });
 
   test("Generate link navigates to generate page", async ({ page }) => {
+    await mockCourseGenerationWorkflow(page);
+
     await page.goto(`/learn/${encodeURIComponent(prompt)}`);
 
     await expect(page.getByRole("heading", { name: /course ideas for/i })).toBeVisible();


### PR DESCRIPTION
## Summary

- seed learn-page subject suggestions before navigation so e2e stays on cached data
- mock course-generation workflow calls for the generate-link navigation test
- document the test commit scope in the commit skill

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes learn E2E by seeding subject suggestions before navigation and mocking course-generation workflow trigger/status, preventing external calls during the generate-link test. Also documents the `test` commit scope in the commit skill guide.

<sup>Written for commit 02ca3988639099e8bd6cd16fc65ecdeb4e3bd763. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1325?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

