### PR TITLE
feat(oxlint): add padding rule for multiline statements

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -132,7 +132,8 @@
     "zoonk/no-get-extracted-in-promise": "error",
     "zoonk/no-object-params-in-cache": ["error", { "exceptions": ["headers"] }],
     "zoonk/no-hardcoded-aria-label": "off",
-    "zoonk/no-t-function-as-argument": "error"
+    "zoonk/no-t-function-as-argument": "error",
+    "zoonk/padding-around-multiline-statements": "error"
   },
   "overrides": [
     {

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/step-image.ts
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/step-image.ts
@@ -25,6 +25,7 @@ export async function uploadStepImageAction(
   }
 
   const targetLabel = imageTarget === "step" ? "step" : `option-${imageTarget}`;
+
   const { data: imageUrl, error: uploadError } = await processAndUploadImage({
     file,
     fileName: `steps/admin-review/${stepId}-${targetLabel}.webp`,
@@ -50,6 +51,7 @@ export async function uploadStepImageAction(
   const { error: updateError } = await safeAsync(() => {
     if (imageTarget === "step") {
       const content = parseStepContent("static", step.content);
+
       return prisma.step.update({
         data: { content: { ...content, image: { ...content.image, url: imageUrl } } },
         where: { id: stepId },
@@ -57,6 +59,7 @@ export async function uploadStepImageAction(
     }
 
     const content = parseStepContent("selectImage", step.content);
+
     const updatedOptions = content.options.map((option, index) =>
       index === imageTarget ? { ...option, url: imageUrl } : option,
     );

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/audio-edit.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/audio-edit.tsx
@@ -34,6 +34,7 @@ export function AudioEdit({
 
   const handleUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
+
     if (!file) {
       return;
     }

--- a/apps/admin/src/app/(private)/review/[group]/[task]/flagged-list.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/flagged-list.tsx
@@ -44,12 +44,14 @@ export async function FlaggedList({
   searchParams: PageProps<"/review/[group]/[task]">["searchParams"];
 }) {
   const { page, limit, offset } = parseSearchParams(await searchParams);
+
   const { items, total } = await listReviewedItems({
     limit,
     offset,
     status: "needsChanges",
     taskType,
   });
+
   const totalPages = Math.ceil(total / limit);
 
   const taskPath = getTaskPath(taskType);

--- a/apps/admin/src/app/(private)/review/[group]/[task]/review-queue.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/review-queue.tsx
@@ -19,6 +19,7 @@ import { ReviewProgress } from "../../_components/review-progress";
 async function renderContent(taskType: ReviewTaskType, entityId: string) {
   if (taskType === "stepImage") {
     const item = await getStepImageReview(entityId);
+
     if (!item) {
       return null;
     }
@@ -39,9 +40,11 @@ async function renderContent(taskType: ReviewTaskType, entityId: string) {
 
   if (taskType === "stepSelectImage") {
     const item = await getStepImageReview(entityId);
+
     if (!item) {
       return null;
     }
+
     return <StepSelectImageReview item={item} />;
   }
 

--- a/apps/admin/src/app/(private)/review/_actions/mark-needs-changes.ts
+++ b/apps/admin/src/app/(private)/review/_actions/mark-needs-changes.ts
@@ -17,6 +17,7 @@ export async function markNeedsChangesAction(formData: FormData) {
   if (!taskType || !entityId || !isValidTaskType(taskType)) {
     throw new Error("Invalid form data");
   }
+
   const userId = session.user.id;
 
   const { error } = await safeAsync(() =>

--- a/apps/admin/src/app/(private)/review/_actions/mark-reviewed.ts
+++ b/apps/admin/src/app/(private)/review/_actions/mark-reviewed.ts
@@ -17,6 +17,7 @@ export async function markReviewedAction(formData: FormData) {
   if (!taskType || !entityId || !isValidTaskType(taskType)) {
     throw new Error("Invalid form data");
   }
+
   const userId = session.user.id;
 
   const { error } = await safeAsync(() =>

--- a/apps/admin/src/app/(private)/stats/content/content-chart-filter.tsx
+++ b/apps/admin/src/app/(private)/stats/content/content-chart-filter.tsx
@@ -21,6 +21,7 @@ function getCountForFilter(row: DailyContentRow, filter: ContentFilterValue): nu
   if (filter === "all") {
     return row.courses + row.chapters + row.lessons + row.steps;
   }
+
   return row[filter];
 }
 
@@ -38,6 +39,7 @@ export function ContentChart({
       count: getCountForFilter(row, filter),
       date: row.date,
     }));
+
     return buildChartData(filtered, period, "en");
   }, [dailyContent, filter, period]);
 

--- a/apps/admin/src/data/review/get-next-review-item.ts
+++ b/apps/admin/src/data/review/get-next-review-item.ts
@@ -34,6 +34,7 @@ async function getNextCourseSuggestion(): Promise<ReviewQueueResult> {
 
 async function getNextStepImage(): Promise<ReviewQueueResult> {
   const excludeIds = await reviewedEntityIds("stepImage");
+
   const steps = await prisma.step.findMany({
     orderBy: { createdAt: "asc" },
     select: { content: true, id: true },

--- a/apps/admin/src/data/review/list-reviewed-items.ts
+++ b/apps/admin/src/data/review/list-reviewed-items.ts
@@ -13,6 +13,7 @@ const cachedListReviewedItems = cache(async function cachedListReviewedItems(
   if (!(await isAdmin())) {
     return { items: [], total: 0 };
   }
+
   const where = { status, taskType };
 
   const [items, total] = await Promise.all([

--- a/apps/admin/src/data/stats/get-daily-content-created.ts
+++ b/apps/admin/src/data/stats/get-daily-content-created.ts
@@ -46,6 +46,7 @@ export const getDailyContentCreated = cache(async (start: Date, end: Date) => {
 
   for (const row of results) {
     const key = row.date.toISOString().slice(0, 10);
+
     const existing = dateMap.get(key) ?? {
       chapters: 0,
       courses: 0,

--- a/apps/admin/src/lib/review-utils.ts
+++ b/apps/admin/src/lib/review-utils.ts
@@ -52,6 +52,7 @@ function resolveTaskType(group: string, task: string): ReviewTaskType | null {
   if (!isValidTaskType(taskType)) {
     return null;
   }
+
   if (getTaskGroup(taskType) !== group) {
     return null;
   }

--- a/apps/api/e2e/course-search.test.ts
+++ b/apps/api/e2e/course-search.test.ts
@@ -51,6 +51,7 @@ test.describe("Course Search API", () => {
     });
 
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.get(
       `/v1/courses/search?query=${encodeURIComponent(uniqueId)}&language=en`,
     );
@@ -72,6 +73,7 @@ test.describe("Course Search API", () => {
 
   test("returns empty data array when no matches found", async () => {
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.get(
       "/v1/courses/search?query=nonexistentcourse999xyz&language=en",
     );
@@ -122,6 +124,7 @@ test.describe("Course Search API", () => {
     const enResponse = await apiContext.get(
       `/v1/courses/search?query=${encodeURIComponent(uniqueId)}&language=en`,
     );
+
     const ptResponse = await apiContext.get(
       `/v1/courses/search?query=${encodeURIComponent(uniqueId)}&language=pt`,
     );
@@ -205,6 +208,7 @@ test.describe("Course Search API", () => {
       ...secondBody.data.map((course: { id: number }) => course.id),
       ...thirdBody.data.map((course: { id: number }) => course.id),
     ];
+
     const uniqueIds = new Set(allIds);
 
     expect(uniqueIds.size).toBe(5);
@@ -244,6 +248,7 @@ test.describe("Course Search API", () => {
     });
 
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.get(
       `/v1/courses/search?query=${encodeURIComponent(uniqueId)}`,
     );
@@ -275,6 +280,7 @@ test.describe("Course Search API", () => {
     });
 
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.get(
       `/v1/courses/search?query=${encodeURIComponent(`limit ${uniqueId}`)}&language=en&limit=5`,
     );
@@ -318,6 +324,7 @@ test.describe("Course Search API", () => {
     ]);
 
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.get(
       `/v1/courses/search?query=${encodeURIComponent(uniqueId)}&language=en`,
     );
@@ -370,6 +377,7 @@ test.describe("Course Search API", () => {
     ]);
 
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.get(
       `/v1/courses/search?query=${encodeURIComponent(uniqueId)}&language=en`,
     );
@@ -406,6 +414,7 @@ test.describe("Course Search API", () => {
     });
 
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.get(
       `/v1/courses/search?query=${encodeURIComponent(uniqueId)}&language=en`,
     );

--- a/apps/api/e2e/otp.test.ts
+++ b/apps/api/e2e/otp.test.ts
@@ -63,6 +63,7 @@ test.describe("OTP Login Flow", () => {
     await page.goto(
       `/auth/otp?email=${encodeURIComponent(TEST_EMAIL)}&redirectTo=${encodeURIComponent(REDIRECT_URL)}`,
     );
+
     await page.getByRole("link", { name: /change email/i }).click();
     await page.waitForURL(/\/auth\/login/);
 

--- a/apps/api/e2e/workflows-chapter-generation.test.ts
+++ b/apps/api/e2e/workflows-chapter-generation.test.ts
@@ -22,6 +22,7 @@ test.describe("Chapter Generation Workflow API", () => {
 
   test("returns validation error when chapterId is missing", async () => {
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.post("/v1/workflows/chapter-generation/trigger", {
       data: {},
     });
@@ -38,6 +39,7 @@ test.describe("Chapter Generation Workflow API", () => {
 
   test("returns validation error when chapterId is invalid type", async () => {
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.post("/v1/workflows/chapter-generation/trigger", {
       data: { chapterId: "invalid" },
     });
@@ -54,6 +56,7 @@ test.describe("Chapter Generation Workflow API", () => {
 
   test("returns validation error when chapterId is negative", async () => {
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.post("/v1/workflows/chapter-generation/trigger", {
       data: { chapterId: -1 },
     });
@@ -100,6 +103,7 @@ test.describe("Chapter Generation Workflow API", () => {
     });
 
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.post("/v1/workflows/chapter-generation/trigger", {
       data: { chapterId: chapter.id },
     });
@@ -150,6 +154,7 @@ test.describe("Chapter Generation Workflow API", () => {
     });
 
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.post("/v1/workflows/chapter-generation/trigger", {
       data: { chapterId: chapter.id },
     });
@@ -195,6 +200,7 @@ test.describe("Chapter Generation Workflow API", () => {
     });
 
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.post("/v1/workflows/chapter-generation/trigger", {
       data: { chapterId: chapter.id },
     });
@@ -225,6 +231,7 @@ test.describe("Chapter Generation Workflow API", () => {
 
     // Create unique user via sign-up API
     const signupContext = await request.newContext({ baseURL });
+
     const signupResponse = await signupContext.post("/v1/auth/sign-up/email", {
       data: { email, name: `E2E User ${uniqueId}`, password },
     });
@@ -234,6 +241,7 @@ test.describe("Chapter Generation Workflow API", () => {
 
     // Get the user and create subscription
     const user = await prisma.user.findUniqueOrThrow({ where: { email } });
+
     await prisma.subscription.create({
       data: {
         id: randomUUID(),
@@ -274,6 +282,7 @@ test.describe("Chapter Generation Workflow API", () => {
 
     // Sign in and test
     const apiContext = await request.newContext({ baseURL });
+
     const signInResponse = await apiContext.post("/v1/auth/sign-in/email", {
       data: { email, password },
     });

--- a/apps/api/e2e/workflows-course-generation.test.ts
+++ b/apps/api/e2e/workflows-course-generation.test.ts
@@ -52,6 +52,7 @@ test.describe("Course Generation Workflow API", () => {
 
   test("returns validation error when courseSuggestionId is invalid type", async () => {
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.post("/v1/workflows/course-generation/trigger", {
       data: { courseSuggestionId: "invalid" },
     });
@@ -68,6 +69,7 @@ test.describe("Course Generation Workflow API", () => {
 
   test("returns validation error when courseSuggestionId is negative", async () => {
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.post("/v1/workflows/course-generation/trigger", {
       data: { courseSuggestionId: -1 },
     });
@@ -84,12 +86,14 @@ test.describe("Course Generation Workflow API", () => {
 
   test("starts workflow for valid course suggestion", async () => {
     const uniqueId = randomUUID().slice(0, 8);
+
     const suggestion = await createCompletedCourseSuggestion({
       slug: `e2e-workflow-test-${uniqueId}`,
       title: `E2E Workflow Test ${uniqueId}`,
     });
 
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.post("/v1/workflows/course-generation/trigger", {
       data: { courseSuggestionId: suggestion.id },
     });
@@ -121,6 +125,7 @@ test.describe("Course Generation Workflow API", () => {
 
   test("returns SSE stream for valid runId", async () => {
     const uniqueId = randomUUID().slice(0, 8);
+
     const suggestion = await createCompletedCourseSuggestion({
       slug: `e2e-status-test-${uniqueId}`,
       title: `E2E Status Test ${uniqueId}`,

--- a/apps/api/e2e/workflows-lesson-generation.test.ts
+++ b/apps/api/e2e/workflows-lesson-generation.test.ts
@@ -22,6 +22,7 @@ async function createSubscribedApiContext({
   const password = "password123";
 
   const signupContext = await request.newContext({ baseURL });
+
   const signupResponse = await signupContext.post("/v1/auth/sign-up/email", {
     data: { email, name: `E2E User ${uniqueId}`, password },
   });
@@ -30,6 +31,7 @@ async function createSubscribedApiContext({
   await signupContext.dispose();
 
   const user = await prisma.user.findUniqueOrThrow({ where: { email } });
+
   await prisma.subscription.create({
     data: {
       id: randomUUID(),
@@ -42,6 +44,7 @@ async function createSubscribedApiContext({
   });
 
   const apiContext = await request.newContext({ baseURL });
+
   const signInResponse = await apiContext.post("/v1/auth/sign-in/email", {
     data: { email, password },
   });
@@ -82,6 +85,7 @@ test.describe("Lesson Generation Workflow API", () => {
 
   test("returns validation error when lessonId is invalid type", async () => {
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
       data: { lessonId: "invalid" },
     });
@@ -98,6 +102,7 @@ test.describe("Lesson Generation Workflow API", () => {
 
   test("returns validation error when lessonId is negative", async () => {
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
       data: { lessonId: -1 },
     });
@@ -158,6 +163,7 @@ test.describe("Lesson Generation Workflow API", () => {
     });
 
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
       data: { lessonId: lesson.id },
     });
@@ -236,6 +242,7 @@ test.describe("Lesson Generation Workflow API", () => {
     });
 
     const apiContext = await request.newContext({ baseURL });
+
     const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
       data: { lessonId: lesson.id },
     });

--- a/apps/api/src/app/auth/login/page.tsx
+++ b/apps/api/src/app/auth/login/page.tsx
@@ -23,6 +23,7 @@ async function LoginView({ searchParams }: PageProps<"/auth/login">) {
   const { redirectTo } = await searchParams;
 
   const session = await getSession();
+
   if (session && redirectTo) {
     redirect(`/auth/callback?redirectTo=${encodeURIComponent(String(redirectTo))}`);
   }

--- a/apps/api/src/app/v1/workflows/chapter-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/chapter-generation/trigger/route.ts
@@ -16,6 +16,7 @@ async function getChapterPosition(chapterId: string) {
     select: { position: true },
     where: getAiGenerationChapterWhere({ chapterWhere: { id: chapterId } }),
   });
+
   return chapter;
 }
 

--- a/apps/api/src/lib/openapi/schemas/progress.ts
+++ b/apps/api/src/lib/openapi/schemas/progress.ts
@@ -48,6 +48,7 @@ export const nextLessonQuerySchema = z
       const provided = [data.courseId, data.chapterId, data.lessonId].filter(
         (value) => value !== undefined,
       );
+
       return provided.length === 1;
     },
     { message: "Exactly one of courseId, chapterId, or lessonId must be provided" },

--- a/apps/api/src/workflows/_test-utils/rejected-error.ts
+++ b/apps/api/src/workflows/_test-utils/rejected-error.ts
@@ -22,6 +22,7 @@ export async function getRejectedAggregateError(
   promise: Promise<unknown>,
 ): Promise<AggregateError> {
   const error = await getRejectedError(promise);
+
   if (error instanceof AggregateError) {
     return error;
   }

--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
@@ -70,6 +70,7 @@ describe(chapterGenerationWorkflow, () => {
       const completionEvent = getStreamedEvents().find(
         (event) => event.step === CHAPTER_COMPLETION_STEP && event.status === "completed",
       );
+
       expect(completionEvent).toBeUndefined();
     });
 
@@ -91,6 +92,7 @@ describe(chapterGenerationWorkflow, () => {
       const completionEvent = getStreamedEvents().find(
         (event) => event.step === CHAPTER_COMPLETION_STEP && event.status === "completed",
       );
+
       expect(completionEvent).toBeDefined();
     });
 
@@ -121,6 +123,7 @@ describe(chapterGenerationWorkflow, () => {
   describe("happy path", () => {
     it("calls lessonGenerationWorkflow with first lesson's ID", async () => {
       const title = `Lesson Gen Chapter ${randomUUID()}`;
+
       const chapter = await chapterFixture({
         courseId: course.id,
         generationStatus: "pending",
@@ -140,6 +143,7 @@ describe(chapterGenerationWorkflow, () => {
 
     it("sets chapter as completed before the first lesson generation runs", async () => {
       const title = `Completed Before Lesson Gen ${randomUUID()}`;
+
       const chapter = await chapterFixture({
         courseId: course.id,
         generationStatus: "pending",
@@ -162,6 +166,7 @@ describe(chapterGenerationWorkflow, () => {
 
     it("updates chapter status: pending → running → completed", async () => {
       const title = `Status Transition Chapter ${randomUUID()}`;
+
       const chapter = await chapterFixture({
         courseId: course.id,
         generationStatus: "pending",
@@ -186,6 +191,7 @@ describe(chapterGenerationWorkflow, () => {
       );
 
       const title = `Lesson Fail Chapter ${randomUUID()}`;
+
       const chapter = await chapterFixture({
         courseId: course.id,
         generationStatus: "pending",
@@ -206,6 +212,7 @@ describe(chapterGenerationWorkflow, () => {
       vi.mocked(generateChapterLessons).mockRejectedValueOnce(new Error("AI generation failed"));
 
       const title = `Error Chapter ${randomUUID()}`;
+
       const chapter = await chapterFixture({
         courseId: course.id,
         generationStatus: "pending",
@@ -223,6 +230,7 @@ describe(chapterGenerationWorkflow, () => {
       const errorEvent = getStreamedEvents().find(
         (event) => event.status === "error" && event.step === "workflowError",
       );
+
       expect(errorEvent).toBeDefined();
     });
 

--- a/apps/api/src/workflows/chapter-generation/steps/_utils/lesson-plan-expansion.test.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/_utils/lesson-plan-expansion.test.ts
@@ -82,10 +82,12 @@ describe(expandChapterLessons, () => {
       description: null,
       title: null,
     });
+
     expect(lessons.find((lesson) => lesson.kind === "quiz")).toMatchObject({
       description: null,
       title: null,
     });
+
     expect(lessons.find((lesson) => lesson.kind === "review")).toMatchObject({
       description: null,
       title: null,

--- a/apps/api/src/workflows/chapter-generation/steps/_utils/lesson-plan-expansion.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/_utils/lesson-plan-expansion.ts
@@ -130,8 +130,10 @@ function expandContentLessons({
     (state, lesson) => {
       const nextExplanationCount =
         lesson.kind === "explanation" ? state.explanationCount + 1 : state.explanationCount;
+
       const shouldAddPractice =
         lesson.kind === "explanation" && groupEnds.has(nextExplanationCount);
+
       const nextPracticeCount = shouldAddPractice ? state.practiceCount + 1 : state.practiceCount;
       const shouldAddQuiz = shouldAddPractice && nextPracticeCount % 2 === 0;
 
@@ -229,6 +231,7 @@ function expandLanguageLessons({
 
   if (firstLesson.kind === "vocabulary") {
     const { rest, run } = takeVocabularyRun(lessons);
+
     return [
       ...expandVocabularyRun({ lessons: run, targetLanguage }),
       ...expandLanguageLessons({ lessons: rest, targetLanguage }),

--- a/apps/api/src/workflows/chapter-generation/steps/add-lessons-step.test.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/add-lessons-step.test.ts
@@ -111,11 +111,13 @@ describe(addLessonsStep, () => {
 
   it("expands language lessons when the course has a target language", async () => {
     const course = await courseFixture({ organizationId, targetLanguage: "es" });
+
     const chapter = await chapterFixture({
       courseId: course.id,
       organizationId,
       title: `Add Language Lessons ${randomUUID()}`,
     });
+
     const chapterContext: ChapterContext = {
       ...chapter,
       _count: { lessons: 0 },
@@ -142,6 +144,7 @@ describe(addLessonsStep, () => {
       "listening",
       "review",
     ]);
+
     expect(dbLessons[1]?.title).toBeNull();
     expect(dbLessons[1]?.description).toBeNull();
     expect(dbLessons[2]?.title).toBeNull();

--- a/apps/api/src/workflows/chapter-generation/steps/classify-lessons-step.test.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/classify-lessons-step.test.ts
@@ -17,6 +17,7 @@ describe(classifyLessonsStep, () => {
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();
     const course = await courseFixture({ organizationId: organization.id });
+
     const chapter = await chapterFixture({
       courseId: course.id,
       organizationId: organization.id,
@@ -51,6 +52,7 @@ describe(classifyLessonsStep, () => {
     ]);
 
     expect(generateLessonKindMock).toHaveBeenCalledTimes(2);
+
     expect(generateLessonKindMock).toHaveBeenNthCalledWith(1, {
       chapterTitle: context.title,
       courseTitle: context.course.title,
@@ -58,6 +60,7 @@ describe(classifyLessonsStep, () => {
       lessonDescription: "Intro",
       lessonTitle: "Lesson 1",
     });
+
     expect(generateLessonKindMock).toHaveBeenNthCalledWith(2, {
       chapterTitle: context.title,
       courseTitle: context.course.title,
@@ -71,6 +74,7 @@ describe(classifyLessonsStep, () => {
     expect(events).toContainEqual(
       expect.objectContaining({ status: "started", step: "generateLessonKind" }),
     );
+
     expect(events).toContainEqual(
       expect.objectContaining({ status: "completed", step: "generateLessonKind" }),
     );

--- a/apps/api/src/workflows/chapter-generation/steps/generate-lessons-step.test.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/generate-lessons-step.test.ts
@@ -26,6 +26,7 @@ describe(generateLessonsStep, () => {
 
   beforeAll(async () => {
     const organization = await aiOrganizationFixture();
+
     const [course, languageCourse] = await Promise.all([
       courseFixture({ organizationId: organization.id }),
       courseFixture({ organizationId: organization.id, targetLanguage: "es" }),
@@ -105,6 +106,7 @@ describe(generateLessonsStep, () => {
       targetLanguage: "es",
       userLanguage: languageContext.language,
     });
+
     const events = getStreamedEvents();
 
     expect(events).not.toContainEqual(expect.objectContaining({ step: "generateLessonKind" }));

--- a/apps/api/src/workflows/chapter-generation/steps/get-chapter-step.test.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/get-chapter-step.test.ts
@@ -66,6 +66,7 @@ describe(getChapterStep, () => {
     const result = await getChapterStep(middleChapter.id);
 
     const neighborTitles = result.neighboringChapters.map((ch) => ch.title);
+
     const expectedNeighborTitles = chapters
       .filter((ch) => ch.id !== middleChapter.id)
       .map((ch) => ch.title);
@@ -86,6 +87,7 @@ describe(getChapterStep, () => {
   it("throws FatalError when chapter is outside the AI organization", async () => {
     const otherOrg = await organizationFixture();
     const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+
     const chapter = await chapterFixture({
       courseId: otherCourse.id,
       organizationId: otherOrg.id,

--- a/apps/api/src/workflows/course-generation/_internal/generate-missing-content.test.ts
+++ b/apps/api/src/workflows/course-generation/_internal/generate-missing-content.test.ts
@@ -66,12 +66,15 @@ describe(generateMissingContent, () => {
 
   it("generates all content when nothing exists", async () => {
     generateCourseDescriptionMock.mockResolvedValue({ data: { description: "Generated desc" } });
+
     generateCourseImageMock.mockResolvedValue({
       data: "https://example.com/img.webp",
       error: null,
     });
+
     generateAlternativeTitlesMock.mockResolvedValue({ data: { alternatives: ["Alt 1"] } });
     generateCourseCategoriesMock.mockResolvedValue({ data: { categories: ["programming"] } });
+
     generateCourseChaptersMock.mockResolvedValue({
       data: { chapters: [{ description: "Ch1 desc", title: "Ch1" }] },
     });
@@ -118,10 +121,12 @@ describe(generateMissingContent, () => {
     const langCourse: CourseContext = { ...course, targetLanguage: "es" };
 
     generateCourseDescriptionMock.mockResolvedValue({ data: { description: "Lang desc" } });
+
     generateCourseImageMock.mockResolvedValue({
       data: "https://example.com/lang.webp",
       error: null,
     });
+
     generateAlternativeTitlesMock.mockResolvedValue({ data: { alternatives: [] } });
     generateLanguageCourseChaptersMock.mockResolvedValue({ data: { chapters: [] } });
 
@@ -133,14 +138,18 @@ describe(generateMissingContent, () => {
 
   it("filters out 'languages' from non-language course categories", async () => {
     generateCourseDescriptionMock.mockResolvedValue({ data: { description: "desc" } });
+
     generateCourseImageMock.mockResolvedValue({
       data: "https://example.com/non-lang.webp",
       error: null,
     });
+
     generateAlternativeTitlesMock.mockResolvedValue({ data: { alternatives: [] } });
+
     generateCourseCategoriesMock.mockResolvedValue({
       data: { categories: ["programming", "languages", "web"] },
     });
+
     generateCourseChaptersMock.mockResolvedValue({ data: { chapters: [] } });
 
     const result = await generateMissingContent(course, emptyExisting);

--- a/apps/api/src/workflows/course-generation/_internal/generate-missing-content.ts
+++ b/apps/api/src/workflows/course-generation/_internal/generate-missing-content.ts
@@ -24,6 +24,7 @@ async function descriptionOrSkip(
     await streamSkipStep("generateDescription");
     return null;
   }
+
   return generateDescriptionStep(course);
 }
 
@@ -35,6 +36,7 @@ async function imageOrSkip(
     await streamSkipStep("generateImage");
     return null;
   }
+
   return generateImageStep(course);
 }
 
@@ -46,6 +48,7 @@ async function altTitlesOrSkip(
     await streamSkipStep("generateAlternativeTitles");
     return [];
   }
+
   return generateAlternativeTitlesStep(course);
 }
 
@@ -76,6 +79,7 @@ async function chaptersOrSkip(
     await streamSkipStep("generateChapters");
     return [];
   }
+
   return generateChaptersStep(course);
 }
 

--- a/apps/api/src/workflows/course-generation/_internal/persist-generated-content.test.ts
+++ b/apps/api/src/workflows/course-generation/_internal/persist-generated-content.test.ts
@@ -112,11 +112,13 @@ describe(persistGeneratedContent, () => {
     expect(chapters).toStrictEqual([]);
 
     const events = getStreamedEvents();
+
     const completedSteps = events
       .filter((event) => event.status === "completed")
       .map((event) => event.step);
 
     expect(completedSteps).toHaveLength(4);
+
     expect(completedSteps).toStrictEqual(
       expect.arrayContaining([
         "updateCourse",

--- a/apps/api/src/workflows/course-generation/_internal/persist-generated-content.ts
+++ b/apps/api/src/workflows/course-generation/_internal/persist-generated-content.ts
@@ -17,12 +17,15 @@ async function emitSkippedPersistSteps(
   if (!needsCourseUpdate) {
     await streamSkipStep("updateCourse");
   }
+
   if (!needsAlternativeTitles) {
     await streamSkipStep("addAlternativeTitles");
   }
+
   if (!needsCategories) {
     await streamSkipStep("addCategories");
   }
+
   if (!needsChapters) {
     await streamSkipStep("addChapters");
   }

--- a/apps/api/src/workflows/course-generation/_internal/setup-course.test.ts
+++ b/apps/api/src/workflows/course-generation/_internal/setup-course.test.ts
@@ -83,14 +83,18 @@ describe(setupCourse, () => {
     };
 
     generateCourseDescriptionMock.mockResolvedValue({ data: { description: "Setup desc" } });
+
     generateCourseImageMock.mockResolvedValue({
       data: "https://example.com/setup.webp",
       error: null,
     });
+
     generateAlternativeTitlesMock.mockResolvedValue({
       data: { alternatives: [`Alt ${randomUUID()}`] },
     });
+
     generateCourseCategoriesMock.mockResolvedValue({ data: { categories: ["testing"] } });
+
     generateCourseChaptersMock.mockResolvedValue({
       data: { chapters: [{ description: "Ch desc", title: `Setup Ch ${randomUUID()}` }] },
     });

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -101,6 +101,7 @@ vi.mock("@zoonk/ai/tasks/chapters/language-lessons", () => ({
 
 vi.mock("./_internal/get-or-create-course", async (importOriginal) => {
   const mod = await importOriginal();
+
   return {
     getOrCreateCourse: vi.fn(
       (mod as { getOrCreateCourse: typeof getOrCreateCourse }).getOrCreateCourse,
@@ -145,6 +146,7 @@ describe(courseGenerationWorkflow, () => {
       const completionEvent = getStreamedEvents().find(
         (event) => event.step === COURSE_COMPLETION_STEP && event.status === "completed",
       );
+
       expect(completionEvent).toBeUndefined();
     });
 
@@ -166,6 +168,7 @@ describe(courseGenerationWorkflow, () => {
       const completionEvent = getStreamedEvents().find(
         (event) => event.step === COURSE_COMPLETION_STEP && event.status === "completed",
       );
+
       expect(completionEvent).toBeDefined();
     });
 
@@ -193,6 +196,7 @@ describe(courseGenerationWorkflow, () => {
       const completionEvent = getStreamedEvents().find(
         (event) => event.step === COURSE_COMPLETION_STEP && event.status === "completed",
       );
+
       expect(completionEvent).toBeUndefined();
     });
 
@@ -220,6 +224,7 @@ describe(courseGenerationWorkflow, () => {
       const completionEvent = getStreamedEvents().find(
         (event) => event.step === COURSE_COMPLETION_STEP && event.status === "completed",
       );
+
       expect(completionEvent).toBeDefined();
     });
   });
@@ -349,6 +354,7 @@ describe(courseGenerationWorkflow, () => {
       const errorEvent = getStreamedEvents().find(
         (event) => event.status === "error" && event.step === "workflowError",
       );
+
       expect(errorEvent).toBeDefined();
     });
 
@@ -375,6 +381,7 @@ describe(courseGenerationWorkflow, () => {
       const errorEvent = getStreamedEvents().find(
         (event) => event.status === "error" && event.step === "workflowError",
       );
+
       expect(errorEvent).toBeDefined();
     });
 

--- a/apps/api/src/workflows/course-generation/steps/add-categories-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/add-categories-step.test.ts
@@ -39,6 +39,7 @@ describe(addCategoriesStep, () => {
     const dbCategories = await prisma.courseCategory.findMany({ where: { courseId: course.id } });
 
     expect(dbCategories).toHaveLength(2);
+
     expect(dbCategories.map((cat) => cat.category).toSorted()).toStrictEqual([
       "programming",
       "web",

--- a/apps/api/src/workflows/lesson-generation/kinds/reading-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-generation/kinds/reading-workflow.test.ts
@@ -235,14 +235,18 @@ describe(readingLessonWorkflow, () => {
       audioUrl: `https://example.com/audio/${encodeURIComponent(canonicalWord)}.mp3`,
       word: canonicalWord,
     });
+
     expect(canonicalRecord?.pronunciations[0]?.pronunciation).toBe(
       `${canonicalWord} pronunciation`,
     );
+
     expect(duplicateDistractorRecord).toBeNull();
+
     expect(validDistractorRecord).toMatchObject({
       audioUrl: `https://example.com/audio/${encodeURIComponent(validDistractor)}.mp3`,
       word: validDistractor,
     });
+
     expect(lessonWord).toMatchObject({ translation: `${canonicalWord} translated` });
     expect(lessonWord?.word.word).toBe(canonicalWord);
   });

--- a/apps/api/src/workflows/lesson-generation/kinds/vocabulary-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-generation/kinds/vocabulary-workflow.test.ts
@@ -92,6 +92,7 @@ describe(vocabularyLessonWorkflow, () => {
       { translation: `cat ${uniqueId}`, word: catWord },
       { translation: `water ${uniqueId}`, word: waterWord },
     ];
+
     vocabularyState.distractors = {
       [catWord]: [dogWord, birdWord],
       [waterWord]: [fireWord, earthWord],
@@ -193,14 +194,18 @@ describe(vocabularyLessonWorkflow, () => {
       romanization: `${canonicalWord} romanized`,
       word: canonicalWord,
     });
+
     expect(canonicalRecord?.pronunciations[0]?.pronunciation).toBe(
       `${canonicalWord} pronunciation`,
     );
+
     expect(duplicateDistractorRecord).toBeNull();
+
     expect(lessonWord).toMatchObject({
       distractors: [validDistractor],
       translation: `water ${uniqueId}`,
     });
+
     expect(lessonWord?.word.word).toBe(canonicalWord);
   });
 });

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
@@ -247,6 +247,7 @@ async function createWorkflowTree({ organizationId }: { organizationId: string }
     organizationId,
     title: `Workflow Course ${randomUUID()}`,
   });
+
   const chapter = await chapterFixture({
     courseId: course.id,
     isPublished: true,
@@ -263,12 +264,14 @@ async function createWorkflowTree({ organizationId }: { organizationId: string }
  */
 async function createLanguageWorkflowTree({ organizationId }: { organizationId: string }) {
   const uniqueId = randomUUID();
+
   const course = await courseFixture({
     isPublished: true,
     organizationId,
     targetLanguage: "ja",
     title: `Language Workflow Course ${uniqueId}`,
   });
+
   const chapter = await chapterFixture({
     courseId: course.id,
     isPublished: true,
@@ -339,6 +342,7 @@ describe(lessonGenerationWorkflow, () => {
       { translation: "cat", word: "猫" },
       { translation: "water", word: "水" },
     );
+
     languageMockState.distractors = Object.fromEntries([
       ["水", ["火", "土"]],
       ["猫", ["犬", "鳥"]],
@@ -347,6 +351,7 @@ describe(lessonGenerationWorkflow, () => {
 
   it("runs the explanation image workflow and saves images on static steps", async () => {
     const { chapter } = await createWorkflowTree({ organizationId });
+
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       generationStatus: "pending",
@@ -361,6 +366,7 @@ describe(lessonGenerationWorkflow, () => {
     expect(generateLessonExplanation).toHaveBeenCalledOnce();
     expect(generateStepImagePrompts).toHaveBeenCalledOnce();
     expect(generateContentStepImage).toHaveBeenCalledTimes(3);
+
     expect(completedStreamedSteps()).toStrictEqual(
       expect.arrayContaining([
         "generateExplanationContent",
@@ -375,10 +381,12 @@ describe(lessonGenerationWorkflow, () => {
       orderBy: { position: "asc" },
       where: { lessonId: lesson.id },
     });
+
     const contents = steps.map((step) => parseStepContent("static", step.content));
     const imageUrls = contents.map((content) => content.image?.url);
 
     expect(steps).toHaveLength(3);
+
     expect(imageUrls).toStrictEqual([
       "https://example.com/content/first%20image%20prompt.webp",
       "https://example.com/content/second%20image%20prompt.webp",
@@ -392,6 +400,7 @@ describe(lessonGenerationWorkflow, () => {
 
   it("runs the tutorial image workflow and saves generated procedural steps", async () => {
     const { chapter } = await createWorkflowTree({ organizationId });
+
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       generationStatus: "pending",
@@ -404,6 +413,7 @@ describe(lessonGenerationWorkflow, () => {
     await lessonGenerationWorkflow(lesson.id);
 
     expect(generateLessonTutorial).toHaveBeenCalledOnce();
+
     expect(generateStepImagePrompts).toHaveBeenCalledWith(
       expect.objectContaining({
         steps: [
@@ -412,7 +422,9 @@ describe(lessonGenerationWorkflow, () => {
         ],
       }),
     );
+
     expect(generateContentStepImage).toHaveBeenCalledTimes(2);
+
     expect(completedStreamedSteps()).toStrictEqual(
       expect.arrayContaining([
         "generateTutorialContent",
@@ -427,12 +439,14 @@ describe(lessonGenerationWorkflow, () => {
       orderBy: { position: "asc" },
       where: { lessonId: lesson.id },
     });
+
     const contents = steps.map((step) => parseStepContent("static", step.content));
 
     expect(contents.map((content) => ("title" in content ? content.title : null))).toStrictEqual([
       "Open settings",
       "Save project",
     ]);
+
     expect(contents.map((content) => content.image?.url)).toStrictEqual([
       "https://example.com/content/tutorial%20first%20image%20prompt.webp",
       "https://example.com/content/tutorial%20second%20image%20prompt.webp",
@@ -482,9 +496,11 @@ describe(lessonGenerationWorkflow, () => {
     expect(generateLessonPractice).toHaveBeenCalledWith(
       expect.objectContaining({ explanationSteps: [{ text: "New explanation", title: "New" }] }),
     );
+
     expect(generateContentStepImage).toHaveBeenCalledWith(
       expect.objectContaining({ preset: "practice", prompt: "practice scenario image" }),
     );
+
     expect(completedStreamedSteps()).toStrictEqual(
       expect.arrayContaining([
         "generatePracticeContent",
@@ -498,11 +514,13 @@ describe(lessonGenerationWorkflow, () => {
       orderBy: { position: "asc" },
       where: { lessonId: practice.id },
     });
+
     const intro = parseStepContent("static", steps[0]?.content);
     const question = parseStepContent("multipleChoice", steps[1]?.content);
 
     expect(intro.variant).toBe("intro");
     expect(intro.image?.url).toBe("https://example.com/content/practice%20scenario%20image.webp");
+
     expect(question.image?.url).toBe(
       "https://example.com/content/practice%20question%20image.webp",
     );
@@ -599,7 +617,9 @@ describe(lessonGenerationWorkflow, () => {
         explanationSteps: [{ text: "Unquizzed explanation", title: "New Quiz Scope" }],
       }),
     );
+
     expect(generateStepImage).toHaveBeenCalledTimes(2);
+
     expect(completedStreamedSteps()).toStrictEqual(
       expect.arrayContaining([
         "generateQuizContent",
@@ -636,6 +656,7 @@ describe(lessonGenerationWorkflow, () => {
       { translation: `cat ${uniqueId}`, word: catWord },
       { translation: `water ${uniqueId}`, word: waterWord },
     );
+
     languageMockState.distractors = {
       [catWord]: [dogWord, birdWord],
       [waterWord]: [fireWord, earthWord],
@@ -647,12 +668,14 @@ describe(lessonGenerationWorkflow, () => {
       targetLanguage: "ja",
       title: `Language Workflow Course ${uniqueId}`,
     });
+
     const chapter = await chapterFixture({
       courseId: course.id,
       isPublished: true,
       organizationId,
       title: `Language Workflow Chapter ${uniqueId}`,
     });
+
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       generationStatus: "pending",
@@ -668,9 +691,11 @@ describe(lessonGenerationWorkflow, () => {
     expect(generateLessonDistractors).toHaveBeenCalledTimes(2);
     expect(generateLanguageAudio).toHaveBeenCalledTimes(6);
     expect(generateLessonPronunciation).toHaveBeenCalledTimes(6);
+
     expect(generateLessonRomanization).toHaveBeenCalledWith(
       expect.objectContaining({ targetLanguage: "ja", texts: allRenderedWords }),
     );
+
     expect(completedStreamedSteps()).toStrictEqual(
       expect.arrayContaining([
         "generateVocabularyContent",
@@ -688,6 +713,7 @@ describe(lessonGenerationWorkflow, () => {
       orderBy: { word: { word: "asc" } },
       where: { lessonId: lesson.id },
     });
+
     const words = lessonWords
       .map((row) => ({
         audioUrl: row.word.audioUrl,
@@ -722,6 +748,7 @@ describe(lessonGenerationWorkflow, () => {
   it("translation generation creates translation steps from the previous vocabulary lesson", async () => {
     const uniqueId = randomUUID().slice(0, 8);
     const { chapter } = await createLanguageWorkflowTree({ organizationId });
+
     const [vocabularyLesson, word] = await Promise.all([
       lessonFixture({
         chapterId: chapter.id,
@@ -779,6 +806,7 @@ describe(lessonGenerationWorkflow, () => {
   it("reading generation uses vocabulary since the previous reading and saves enriched sentences", async () => {
     const uniqueId = randomUUID().slice(0, 8);
     const { chapter } = await createLanguageWorkflowTree({ organizationId });
+
     const [vocabularyLesson, catWord, waterWord] = await Promise.all([
       lessonFixture({
         chapterId: chapter.id,
@@ -822,8 +850,10 @@ describe(lessonGenerationWorkflow, () => {
     expect(generateLessonSentences).toHaveBeenCalledWith(
       expect.objectContaining({ words: expect.arrayContaining([catWord.word, waterWord.word]) }),
     );
+
     expect(generateTranslation).toHaveBeenCalledWith(expect.objectContaining({ word: "猫" }));
     expect(generateTranslation).toHaveBeenCalledWith(expect.objectContaining({ word: "水" }));
+
     expect(completedStreamedSteps()).toStrictEqual(
       expect.arrayContaining([
         "generateReadingContent",
@@ -842,6 +872,7 @@ describe(lessonGenerationWorkflow, () => {
       include: { sentence: true },
       where: { lessonId: readingLesson.id },
     });
+
     const sentenceLink = await prisma.lessonSentence.findFirst({
       where: { lessonId: readingLesson.id },
     });
@@ -854,6 +885,7 @@ describe(lessonGenerationWorkflow, () => {
   it("listening generation copies sentence steps from the previous reading lesson", async () => {
     const uniqueId = randomUUID().slice(0, 8);
     const { chapter } = await createLanguageWorkflowTree({ organizationId });
+
     const [readingLesson, sentence] = await Promise.all([
       lessonFixture({
         chapterId: chapter.id,
@@ -909,6 +941,7 @@ describe(lessonGenerationWorkflow, () => {
   it("grammar generation keeps content, user-language exercises, romanization, and saving phases", async () => {
     const uniqueId = randomUUID().slice(0, 8);
     const { chapter } = await createLanguageWorkflowTree({ organizationId });
+
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       generationStatus: "pending",
@@ -921,12 +954,15 @@ describe(lessonGenerationWorkflow, () => {
     await lessonGenerationWorkflow(lesson.id);
 
     expect(generateLessonGrammarContent).toHaveBeenCalledOnce();
+
     expect(generateLessonGrammarUserContent).toHaveBeenCalledWith(
       expect.objectContaining({ examples: [{ highlight: "猫", sentence: "猫がいます" }] }),
     );
+
     expect(generateLessonRomanization).toHaveBeenCalledWith(
       expect.objectContaining({ texts: expect.arrayContaining(["猫がいます", "猫", "犬", "鳥"]) }),
     );
+
     expect(completedStreamedSteps()).toStrictEqual(
       expect.arrayContaining([
         "generateGrammarContent",
@@ -952,6 +988,7 @@ describe(lessonGenerationWorkflow, () => {
 
   it("repairs a pending lesson with existing steps without calling AI", async () => {
     const { chapter } = await createWorkflowTree({ organizationId });
+
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       generationStatus: "pending",
@@ -983,11 +1020,13 @@ describe(lessonGenerationWorkflow, () => {
     const completionEvent = getStreamedEvents().find(
       (event) => event.step === "setLessonAsCompleted" && event.status === "completed",
     );
+
     expect(completionEvent).toBeDefined();
   });
 
   it("regenerates failed lessons with leftover steps instead of repairing them", async () => {
     const { chapter } = await createWorkflowTree({ organizationId });
+
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       generationStatus: "failed",
@@ -1017,6 +1056,7 @@ describe(lessonGenerationWorkflow, () => {
       orderBy: { position: "asc" },
       where: { lessonId: lesson.id },
     });
+
     const contents = steps.map((step) => parseStepContent("static", step.content));
 
     expect(contents.map((content) => ("title" in content ? content.title : null))).toStrictEqual([

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
@@ -18,6 +18,7 @@ import { setLessonAsCompletedStep } from "./steps/set-lesson-as-completed-step";
 import { setLessonAsRunningStep } from "./steps/set-lesson-as-running-step";
 
 type LessonGenerationContext = Awaited<ReturnType<typeof getLessonStep>>;
+
 type GeneratedLessonContext = LessonGenerationContext & {
   kind: Exclude<LessonGenerationContext["kind"], "custom" | "review">;
 };

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/generate-direct-distractors.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/generate-direct-distractors.test.ts
@@ -26,6 +26,7 @@ describe(generateDirectDistractors, () => {
     });
 
     expect(result["word-1"]).toStrictEqual(expect.arrayContaining(["wrong1", "wrong2", "wrong3"]));
+
     expect(generateLessonDistractorsMock).toHaveBeenCalledWith({
       input: "hola",
       language: "es",

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/generate-lesson-romanizations.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/generate-lesson-romanizations.test.ts
@@ -29,6 +29,7 @@ describe(generateLessonRomanizations, () => {
       あれは犬です: "are wa inu desu",
       これは猫です: "kore wa neko desu",
     });
+
     expect(generateLessonRomanizationMock).toHaveBeenCalledWith({ targetLanguage: "ja", texts });
   });
 

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/generate-step-images.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/generate-step-images.test.ts
@@ -25,12 +25,14 @@ describe(generateStepImages, () => {
       { prompt: "Prompt 1", url: "https://example.com/step-1.webp" },
       { prompt: "Prompt 2", url: "https://example.com/step-2.webp" },
     ]);
+
     expect(generateContentStepImageMock).toHaveBeenNthCalledWith(1, {
       language: "en",
       orgSlug: "ai-org",
       preset: undefined,
       prompt: "Prompt 1",
     });
+
     expect(generateContentStepImageMock).toHaveBeenNthCalledWith(2, {
       language: "en",
       orgSlug: "ai-org",

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/generate-word-audio-urls.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/generate-word-audio-urls.test.ts
@@ -38,6 +38,7 @@ describe(generateWordAudioUrls, () => {
     });
 
     expect(result[word]).toBe(`/audio/${word}.mp3`);
+
     expect(generateLanguageAudioMock).toHaveBeenCalledWith(
       expect.objectContaining({ language: "es", text: word }),
     );

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/generate-word-audio-urls.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/generate-word-audio-urls.ts
@@ -39,6 +39,7 @@ export async function generateWordAudioUrls(params: {
   );
 
   const wordsNeedingAudio = words.filter((word) => !existingAudioByLower[word.toLowerCase()]);
+
   const results = await Promise.all(
     wordsNeedingAudio.map((word) => generateAudioForText(word, targetLanguage, orgSlug)),
   );

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/generate-word-pronunciations.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/generate-word-pronunciations.test.ts
@@ -71,6 +71,7 @@ describe(generateWordPronunciations, () => {
     });
 
     expect(result[wordText]).toBe("NWEH-voh");
+
     expect(generateLessonPronunciationMock).toHaveBeenCalledWith({
       targetLanguage: "es",
       userLanguage: "en",
@@ -82,6 +83,7 @@ describe(generateWordPronunciations, () => {
     const id = randomUUID().slice(0, 8);
     const existingWordText = `Gato${id}`;
     const newWordText = `Perro${id}`;
+
     const word = await wordFixture({
       organizationId,
       targetLanguage: "es",

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/generate-word-pronunciations.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/generate-word-pronunciations.ts
@@ -22,9 +22,11 @@ export async function generateWordPronunciations(params: {
   }
 
   const existingPronunciations = await fetchExistingPronunciations(params);
+
   const wordsNeedingPronunciation = params.words.filter(
     (word) => !existingPronunciations[word.toLowerCase()],
   );
+
   const generatedPronunciations = await generateMissingPronunciations({
     targetLanguage: params.targetLanguage,
     userLanguage: params.userLanguage,

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/save-core-lesson-content.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/save-core-lesson-content.ts
@@ -148,6 +148,7 @@ function buildQuizStepContent(question: QuizQuestionWithUrls) {
 
   if (question.format === "selectImage") {
     const { format, ...rawContent } = question;
+
     return assertStepContent(format, {
       ...rawContent,
       options: addOptionIds({ options: question.options }),

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/save-language-lesson-content.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/save-language-lesson-content.ts
@@ -99,6 +99,7 @@ function buildGrammarSteps({
 
   const exerciseSteps = content.exercises.map((exercise, index) => {
     const fullSentence = exercise.template.replace("[BLANK]", exercise.answer);
+
     const optionRomanizations = buildOptionRomanizations(
       [fullSentence, exercise.answer, ...exercise.distractors],
       romanizations,

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/save-reading-target-words.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/save-reading-target-words.test.ts
@@ -25,6 +25,7 @@ async function createLanguageLesson({
     targetLanguage,
     title: `Reading Target Course ${randomUUID()}`,
   });
+
   const chapter = await chapterFixture({
     courseId: course.id,
     isPublished: true,
@@ -89,6 +90,7 @@ describe(saveReadingTargetWords, () => {
     const id = randomUUID().replaceAll("-", "").slice(0, 8);
     const existingWord = `Gato${id}`;
     const lowercaseWord = existingWord.toLowerCase();
+
     const [lesson] = await Promise.all([
       createLanguageLesson({ organizationId }),
       wordFixture({

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/save-reading-target-words.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/save-reading-target-words.ts
@@ -28,6 +28,7 @@ export async function saveReadingTargetWords(params: {
   wordMetadata: Record<string, WordMetadataEntry>;
 }): Promise<void> {
   const canonicalWords = extractCanonicalWords(params.sentences, params.wordMetadata);
+
   const allTargetWords = collectTargetWords({
     canonicalWords,
     generatedWords: extractDistractorWords(params.sentences, params.distractors),
@@ -42,6 +43,7 @@ export async function saveReadingTargetWords(params: {
     targetLanguage: params.targetLanguage,
     words: allTargetWords,
   });
+
   const canonicalWordSet = new Set(canonicalWords);
   const distractorOnlyWords = allTargetWords.filter((word) => !canonicalWordSet.has(word));
 
@@ -140,6 +142,7 @@ async function saveCanonicalSentenceWord(params: {
   const translation = metadata?.translation ?? "";
   const romanization = emptyToNull(metadata?.romanization ?? null);
   const dbWord = params.existingCasing[params.word.toLowerCase()] ?? params.word;
+
   const wordId = await upsertWordWithPronunciation({
     audioUrl: params.wordAudioUrls[params.word] ?? null,
     organizationId: params.organizationId,

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/upsert-word-with-pronunciation.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/upsert-word-with-pronunciation.test.ts
@@ -78,6 +78,7 @@ describe(upsertWordWithPronunciation, () => {
     const organization = await organizationFixture({ kind: "brand" });
     const id = randomUUID().slice(0, 8);
     const wordText = `sora-${id}`;
+
     const existing = await wordFixture({
       audioUrl: null,
       organizationId: organization.id,

--- a/apps/api/src/workflows/lesson-generation/steps/generate-explanation-content-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-explanation-content-step.test.ts
@@ -52,6 +52,7 @@ describe(generateExplanationContentStep, () => {
       { text: "Concept explanation.", title: "Concept" },
       { text: "Apply the idea elsewhere.", title: "Transfer" },
     ]);
+
     expect(generateLessonExplanation).toHaveBeenCalledWith(
       expect.objectContaining({
         lessonDescription: context.description,
@@ -59,6 +60,7 @@ describe(generateExplanationContentStep, () => {
         otherLessonTitles: ["Sibling explanation"],
       }),
     );
+
     expect(getStreamedEvents()).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({ status: "started", step: "generateExplanationContent" }),

--- a/apps/api/src/workflows/lesson-generation/steps/generate-explanation-content-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-explanation-content-step.ts
@@ -19,6 +19,7 @@ export async function generateExplanationContentStep(
   await stream.status({ status: "started", step: "generateExplanationContent" });
 
   const otherLessonTitles = await getOtherExplanationLessonTitles(context);
+
   const result = await generateLessonExplanation({
     chapterTitle: context.chapter.title,
     courseTitle: context.chapter.course.title,

--- a/apps/api/src/workflows/lesson-generation/steps/generate-grammar-content-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-grammar-content-step.test.ts
@@ -37,6 +37,7 @@ describe(generateGrammarContentStep, () => {
     const grammarContent = await generateGrammarContentStep(context);
 
     expect(grammarContent.examples).toStrictEqual([{ highlight: "猫", sentence: "猫がいます" }]);
+
     expect(generateLessonGrammarContent).toHaveBeenCalledWith(
       expect.objectContaining({ targetLanguage: "ja" }),
     );

--- a/apps/api/src/workflows/lesson-generation/steps/generate-grammar-romanization-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-grammar-romanization-step.test.ts
@@ -32,9 +32,11 @@ describe(generateGrammarRomanizationStep, () => {
       organizationId,
       targetLanguage: "ja",
     });
+
     const catWord = "猫";
     const dogWord = "犬";
     const grammarSentence = "猫がいます";
+
     const grammarContent = {
       examples: [{ highlight: catWord, sentence: grammarSentence }],
       exercises: [{ answer: catWord, distractors: [dogWord], template: "[BLANK]がいます" }],
@@ -47,6 +49,7 @@ describe(generateGrammarRomanizationStep, () => {
       [dogWord]: `${dogWord} romanized`,
       [grammarSentence]: `${grammarSentence} romanized`,
     });
+
     expect(generateLessonRomanization).toHaveBeenCalledWith({
       targetLanguage: "ja",
       texts: [grammarSentence, grammarSentence, catWord, dogWord],

--- a/apps/api/src/workflows/lesson-generation/steps/generate-grammar-romanization-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-grammar-romanization-step.ts
@@ -33,6 +33,7 @@ export async function generateGrammarRomanizationStep({
       ...exercise.distractors,
     ]),
   ];
+
   const romanizations = await generateLessonRomanizations({ targetLanguage, texts });
 
   await stream.status({ status: "completed", step: "generateGrammarRomanization" });

--- a/apps/api/src/workflows/lesson-generation/steps/generate-grammar-user-content-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-grammar-user-content-step.test.ts
@@ -42,6 +42,7 @@ describe(generateGrammarUserContentStep, () => {
       organizationId,
       targetLanguage: "ja",
     });
+
     const grammarContent = {
       examples: [{ highlight: "猫", sentence: "猫がいます" }],
       exercises: [{ answer: "猫", distractors: ["犬"], template: "[BLANK]がいます" }],
@@ -50,6 +51,7 @@ describe(generateGrammarUserContentStep, () => {
     const userContent = await generateGrammarUserContentStep({ context, grammarContent });
 
     expect(userContent.ruleName).toBe("Existence");
+
     expect(generateLessonGrammarUserContent).toHaveBeenCalledWith(
       expect.objectContaining({ targetLanguage: "ja", userLanguage: "en" }),
     );

--- a/apps/api/src/workflows/lesson-generation/steps/generate-image-prompts-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-image-prompts-step.test.ts
@@ -24,6 +24,7 @@ describe(generateImagePromptsStep, () => {
 
   it("generates image prompts for static lesson steps", async () => {
     const context = await createLessonContext({ organizationId });
+
     const steps = [
       { text: "First text", title: "First" },
       { text: "Second text", title: "Second" },
@@ -32,6 +33,7 @@ describe(generateImagePromptsStep, () => {
     const result = await generateImagePromptsStep({ context, steps });
 
     expect(result).toStrictEqual({ prompts: ["first prompt", "second prompt"] });
+
     expect(generateStepImagePrompts).toHaveBeenCalledWith(
       expect.objectContaining({ lessonDescription: context.description, steps }),
     );

--- a/apps/api/src/workflows/lesson-generation/steps/generate-practice-content-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-practice-content-step.test.ts
@@ -48,6 +48,7 @@ describe(generatePracticeContentStep, () => {
       text: "Old explanation",
       title: "Old",
     });
+
     await lessonFixture({
       chapterId: context.chapterId,
       generationStatus: "completed",
@@ -56,6 +57,7 @@ describe(generatePracticeContentStep, () => {
       organizationId,
       position: 1,
     });
+
     await createCompletedExplanation({
       chapterId: context.chapterId,
       organizationId,
@@ -67,6 +69,7 @@ describe(generatePracticeContentStep, () => {
     const result = await generatePracticeContentStep(context);
 
     expect(result.kind).toBe("practice");
+
     expect(generateLessonPractice).toHaveBeenCalledWith(
       expect.objectContaining({ explanationSteps: [{ text: "New explanation", title: "New" }] }),
     );

--- a/apps/api/src/workflows/lesson-generation/steps/generate-quiz-content-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-quiz-content-step.test.ts
@@ -68,6 +68,7 @@ describe(generateQuizContentStep, () => {
     const result = await generateQuizContentStep(context);
 
     expect(result.kind).toBe("quiz");
+
     expect(generateLessonQuiz).toHaveBeenCalledWith(
       expect.objectContaining({
         explanationSteps: [{ text: "New quiz explanation", title: "New" }],

--- a/apps/api/src/workflows/lesson-generation/steps/generate-quiz-images-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-quiz-images-step.test.ts
@@ -51,6 +51,7 @@ describe(generateQuizImagesStep, () => {
     });
 
     expect(generateStepImage).toHaveBeenCalledTimes(2);
+
     expect(result).toStrictEqual([
       {
         format: "selectImage",

--- a/apps/api/src/workflows/lesson-generation/steps/generate-reading-audio-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-reading-audio-step.test.ts
@@ -28,6 +28,7 @@ describe(generateReadingAudioStep, () => {
     const uniqueId = randomUUID().replaceAll("-", "").slice(0, 8);
     const existingSentence = `既存${uniqueId}`;
     const newSentence = `新しい${uniqueId}`;
+
     const [context] = await Promise.all([
       createLessonContext({ kind: "reading", organizationId, targetLanguage: "ja" }),
       prisma.sentence.create({
@@ -54,6 +55,7 @@ describe(generateReadingAudioStep, () => {
         [newSentence]: `/audio/${newSentence}.mp3`,
       },
     });
+
     expect(generateLanguageAudio).toHaveBeenCalledExactlyOnceWith({
       language: "ja",
       orgSlug: "ai",

--- a/apps/api/src/workflows/lesson-generation/steps/generate-reading-audio-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-reading-audio-step.ts
@@ -39,12 +39,15 @@ export async function generateReadingAudioStep({
       targetLanguage,
     },
   });
+
   const existingAudioUrls = Object.fromEntries(
     existingAudios.flatMap((record) =>
       record.audioUrl ? [[record.sentence, record.audioUrl]] : [],
     ),
   );
+
   const sentencesNeedingAudio = sentences.filter((entry) => !existingAudioUrls[entry.sentence]);
+
   const results = await Promise.all(
     sentencesNeedingAudio.map((entry) =>
       generateAudioForText(entry.sentence, targetLanguage, organization.slug),

--- a/apps/api/src/workflows/lesson-generation/steps/generate-reading-content-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-reading-content-step.test.ts
@@ -33,12 +33,14 @@ describe(generateReadingContentStep, () => {
 
   it("generates reading content from vocabulary lessons since the previous reading", async () => {
     const uniqueId = randomUUID().replaceAll("-", "").slice(0, 8);
+
     const context = await createLessonContext({
       kind: "reading",
       organizationId,
       position: 4,
       targetLanguage: "ja",
     });
+
     const [oldVocabularyLesson, previousReading, currentVocabularyLesson] = await Promise.all([
       lessonFixture({
         chapterId: context.chapterId,
@@ -65,6 +67,7 @@ describe(generateReadingContentStep, () => {
         position: 2,
       }),
     ]);
+
     const [oldWord, catWord, waterWord] = await Promise.all([
       wordFixture({ organizationId, targetLanguage: "ja", word: `古い${uniqueId}` }),
       wordFixture({ organizationId, targetLanguage: "ja", word: `猫${uniqueId}` }),
@@ -95,16 +98,20 @@ describe(generateReadingContentStep, () => {
     const result = await generateReadingContentStep(context);
 
     expect(previousReading.position).toBe(1);
+
     expect(result).toStrictEqual({
       kind: "reading",
       sentences: [
         { explanation: "Uses both words.", sentence: "猫と水", translation: "cat and water" },
       ],
     });
+
     const sentenceInput = vi.mocked(generateLessonSentences).mock.calls[0]?.[0];
+
     expect(sentenceInput?.words).toStrictEqual(
       expect.arrayContaining([`猫${uniqueId}`, `水${uniqueId}`]),
     );
+
     expect(sentenceInput?.words).toHaveLength(2);
   });
 });

--- a/apps/api/src/workflows/lesson-generation/steps/generate-reading-romanization-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-reading-romanization-step.test.ts
@@ -31,17 +31,20 @@ describe(generateReadingRomanizationStep, () => {
     const uniqueId = randomUUID().replaceAll("-", "").slice(0, 8);
     const catWord = `猫${uniqueId}`;
     const waterWord = `水${uniqueId}`;
+
     const context = await createLessonContext({
       kind: "reading",
       organizationId,
       targetLanguage: "ja",
     });
+
     const sentence = `${catWord} ${waterWord}`;
     const sentences = [{ explanation: "", sentence, translation: "cat and water" }];
 
     await expect(generateReadingRomanizationStep({ context, sentences })).resolves.toStrictEqual({
       romanizations: { [sentence]: `${sentence} romanized` },
     });
+
     expect(generateLessonRomanization).toHaveBeenCalledWith({
       targetLanguage: "ja",
       texts: [sentence],

--- a/apps/api/src/workflows/lesson-generation/steps/generate-reading-romanization-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-reading-romanization-step.ts
@@ -24,6 +24,7 @@ export async function generateReadingRomanizationStep({
   await stream.status({ status: "started", step: "generateReadingRomanization" });
 
   const sentenceStrings = sentences.map((entry) => entry.sentence);
+
   const romanizations = await generateLessonRomanizations({
     targetLanguage,
     texts: sentenceStrings,

--- a/apps/api/src/workflows/lesson-generation/steps/generate-sentence-distractors-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-sentence-distractors-step.test.ts
@@ -29,11 +29,13 @@ describe(generateSentenceDistractorsStep, () => {
     const uniqueId = randomUUID().replaceAll("-", "").slice(0, 8);
     const catWord = `猫${uniqueId}`;
     const waterWord = `水${uniqueId}`;
+
     const context = await createLessonContext({
       kind: "reading",
       organizationId,
       targetLanguage: "ja",
     });
+
     const sentences = [
       { explanation: "", sentence: `${catWord} ${waterWord}`, translation: "cat and water" },
     ];
@@ -42,11 +44,13 @@ describe(generateSentenceDistractorsStep, () => {
       distractors: { [`${catWord} ${waterWord}`]: ["火"] },
       translationDistractors: { "cat and water": ["dog"] },
     });
+
     expect(generateLessonDistractors).toHaveBeenCalledWith({
       input: `${catWord} ${waterWord}`,
       language: "ja",
       shape: "single-word",
     });
+
     expect(generateLessonDistractors).toHaveBeenCalledWith({
       input: "cat and water",
       language: "en",

--- a/apps/api/src/workflows/lesson-generation/steps/generate-sentence-word-audio-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-sentence-word-audio-step.test.ts
@@ -28,11 +28,13 @@ describe(generateSentenceWordAudioStep, () => {
     const catWord = `猫${uniqueId}`;
     const fireWord = `火${uniqueId}`;
     const waterWord = `水${uniqueId}`;
+
     const context = await createLessonContext({
       kind: "reading",
       organizationId,
       targetLanguage: "ja",
     });
+
     const words = [catWord, waterWord, fireWord];
 
     await expect(generateSentenceWordAudioStep({ context, words })).resolves.toStrictEqual({
@@ -42,7 +44,9 @@ describe(generateSentenceWordAudioStep, () => {
         [waterWord]: `/audio/${waterWord}.mp3`,
       },
     });
+
     expect(generateLanguageAudio).toHaveBeenCalledTimes(3);
+
     expect(generateLanguageAudio).toHaveBeenCalledWith({
       language: "ja",
       orgSlug: "ai",

--- a/apps/api/src/workflows/lesson-generation/steps/generate-sentence-word-metadata-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-sentence-word-metadata-step.test.ts
@@ -42,11 +42,13 @@ describe(generateSentenceWordMetadataStep, () => {
     const catWord = `猫${uniqueId}`;
     const waterWord = `水${uniqueId}`;
     const fireWord = `火${uniqueId}`;
+
     const context = await createLessonContext({
       kind: "reading",
       organizationId,
       targetLanguage: "ja",
     });
+
     const sentences = [
       { explanation: "", sentence: `${catWord} ${waterWord}`, translation: "cat and water" },
     ];
@@ -72,12 +74,15 @@ describe(generateSentenceWordMetadataStep, () => {
         translation: `${waterWord} translated`,
       },
     });
+
     expect(generateTranslation).toHaveBeenCalledWith(
       expect.objectContaining({ targetLanguage: "ja", userLanguage: "en", word: catWord }),
     );
+
     expect(generateTranslation).toHaveBeenCalledWith(
       expect.objectContaining({ targetLanguage: "ja", userLanguage: "en", word: waterWord }),
     );
+
     expect(generateLessonRomanization).toHaveBeenCalledWith({
       targetLanguage: "ja",
       texts: [waterWord, fireWord],

--- a/apps/api/src/workflows/lesson-generation/steps/generate-sentence-word-metadata-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-sentence-word-metadata-step.ts
@@ -80,14 +80,17 @@ export async function generateSentenceWordMetadataStep({
 
   const targetLanguage = course.targetLanguage ?? "";
   const canonicalWords = extractUniqueSentenceWords(sentences.map((entry) => entry.sentence));
+
   const existingRomanizations = await fetchExistingWordRomanizations({
     organizationId: course.organization.id,
     targetLanguage,
     words: targetWords,
   });
+
   const wordsNeedingRomanization = targetWords.filter(
     (word) => !existingRomanizations[word.toLowerCase()],
   );
+
   const [translations, newRomanizations] = await Promise.all([
     generateMissingTranslations({
       targetLanguage,

--- a/apps/api/src/workflows/lesson-generation/steps/generate-sentence-word-pronunciation-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-sentence-word-pronunciation-step.test.ts
@@ -28,11 +28,13 @@ describe(generateSentenceWordPronunciationStep, () => {
     const catWord = `猫${uniqueId}`;
     const fireWord = `火${uniqueId}`;
     const waterWord = `水${uniqueId}`;
+
     const context = await createLessonContext({
       kind: "reading",
       organizationId,
       targetLanguage: "ja",
     });
+
     const words = [catWord, waterWord, fireWord];
 
     await expect(generateSentenceWordPronunciationStep({ context, words })).resolves.toStrictEqual({
@@ -42,7 +44,9 @@ describe(generateSentenceWordPronunciationStep, () => {
         [waterWord]: `${waterWord} pron`,
       },
     });
+
     expect(generateLessonPronunciation).toHaveBeenCalledTimes(3);
+
     expect(generateLessonPronunciation).toHaveBeenCalledWith({
       targetLanguage: "ja",
       userLanguage: context.language,

--- a/apps/api/src/workflows/lesson-generation/steps/generate-step-images-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-step-images-step.test.ts
@@ -40,12 +40,14 @@ describe(generateStepImagesStep, () => {
       { prompt: "first prompt", url: "https://example.com/first%20prompt.webp" },
       { prompt: "second prompt", url: "https://example.com/second%20prompt.webp" },
     ]);
+
     expect(generateContentStepImage).toHaveBeenCalledWith({
       language: context.language,
       orgSlug: "ai",
       preset: "practice",
       prompt: "first prompt",
     });
+
     expect(generateContentStepImage).toHaveBeenCalledWith({
       language: context.language,
       orgSlug: "ai",

--- a/apps/api/src/workflows/lesson-generation/steps/generate-tutorial-content-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-tutorial-content-step.test.ts
@@ -28,6 +28,7 @@ describe(generateTutorialContentStep, () => {
     const result = await generateTutorialContentStep(context);
 
     expect(result).toStrictEqual({ steps: [{ text: "Open settings.", title: "Settings" }] });
+
     expect(generateLessonTutorial).toHaveBeenCalledWith(
       expect.objectContaining({
         lessonDescription: context.description,

--- a/apps/api/src/workflows/lesson-generation/steps/generate-vocabulary-audio-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-vocabulary-audio-step.test.ts
@@ -33,11 +33,13 @@ describe(generateVocabularyAudioStep, () => {
     await expect(generateVocabularyAudioStep({ context, words })).resolves.toStrictEqual({
       wordAudioUrls: { [catWord]: `/audio/${catWord}.mp3`, [dogWord]: `/audio/${dogWord}.mp3` },
     });
+
     expect(generateLanguageAudio).toHaveBeenCalledWith({
       language: "ja",
       orgSlug: "ai",
       text: catWord,
     });
+
     expect(generateLanguageAudio).toHaveBeenCalledWith({
       language: "ja",
       orgSlug: "ai",

--- a/apps/api/src/workflows/lesson-generation/steps/generate-vocabulary-content-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-vocabulary-content-step.test.ts
@@ -31,6 +31,7 @@ describe(generateVocabularyContentStep, () => {
       kind: "vocabulary",
       words: [{ translation: "cat", word: "猫" }],
     });
+
     expect(generateLessonVocabulary).toHaveBeenCalledWith(
       expect.objectContaining({ targetLanguage: "ja", userLanguage: context.language }),
     );

--- a/apps/api/src/workflows/lesson-generation/steps/generate-vocabulary-content-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-vocabulary-content-step.ts
@@ -24,6 +24,7 @@ export async function generateVocabularyContentStep(
   await stream.status({ status: "started", step: "generateVocabularyContent" });
 
   const targetLanguage = getTargetLanguage(context);
+
   const result = await generateLessonVocabulary({
     chapterTitle: context.chapter.title,
     lessonDescription: context.description ?? "",

--- a/apps/api/src/workflows/lesson-generation/steps/generate-vocabulary-distractors-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-vocabulary-distractors-step.test.ts
@@ -34,6 +34,7 @@ describe(generateVocabularyDistractorsStep, () => {
         words: [{ translation: "cat", word: catWord }],
       }),
     ).resolves.toStrictEqual({ distractors: { [catWord]: [`${catWord} alt`] } });
+
     expect(generateLessonDistractors).toHaveBeenCalledWith({
       input: catWord,
       language: "ja",

--- a/apps/api/src/workflows/lesson-generation/steps/generate-vocabulary-pronunciation-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-vocabulary-pronunciation-step.test.ts
@@ -33,11 +33,13 @@ describe(generateVocabularyPronunciationStep, () => {
     await expect(generateVocabularyPronunciationStep({ context, words })).resolves.toStrictEqual({
       pronunciations: { [catWord]: `${catWord} pron`, [dogWord]: `${dogWord} pron` },
     });
+
     expect(generateLessonPronunciation).toHaveBeenCalledWith({
       targetLanguage: "ja",
       userLanguage: context.language,
       word: catWord,
     });
+
     expect(generateLessonPronunciation).toHaveBeenCalledWith({
       targetLanguage: "ja",
       userLanguage: context.language,

--- a/apps/api/src/workflows/lesson-generation/steps/generate-vocabulary-romanization-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-vocabulary-romanization-step.test.ts
@@ -35,6 +35,7 @@ describe(generateVocabularyRomanizationStep, () => {
     await expect(generateVocabularyRomanizationStep({ context, words })).resolves.toStrictEqual({
       romanizations: { [catWord]: `${catWord} romanized`, [dogWord]: `${dogWord} romanized` },
     });
+
     expect(generateLessonRomanization).toHaveBeenCalledWith({ targetLanguage: "ja", texts: words });
   });
 });

--- a/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/get-lesson-step.test.ts
@@ -19,6 +19,7 @@ describe(getLessonStep, () => {
 
     expect(context.id).toBe(lesson.id);
     expect(context.chapter.course.organization?.id).toBe(organizationId);
+
     expect(getStreamedEvents()).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({ status: "started", step: "getLesson" }),
@@ -32,6 +33,7 @@ describe(getLessonStep, () => {
     const lesson = await createLessonContext({ organizationId: otherOrg.id });
 
     await expect(getLessonStep(lesson.id)).rejects.toThrow("Lesson not found");
+
     expect(getStreamedEvents()).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({ reason: "notFound", status: "error", step: "getLesson" }),

--- a/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.test.ts
@@ -26,6 +26,7 @@ describe(handleLessonFailureStep, () => {
     const updatedLesson = await prisma.lesson.findUniqueOrThrow({ where: { id: lesson.id } });
 
     expect(updatedLesson.generationStatus).toBe("failed");
+
     expect(getStreamedEvents()).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/apps/api/src/workflows/lesson-generation/steps/save-grammar-lesson-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-grammar-lesson-step.test.ts
@@ -15,6 +15,7 @@ describe(saveGrammarLessonStep, () => {
 
   it("saves grammar examples, discovery, rule, and practice steps", async () => {
     const id = randomUUID().replaceAll("-", "").slice(0, 8);
+
     const context = await createLessonContext({
       kind: "grammar",
       organizationId,
@@ -72,21 +73,25 @@ describe(saveGrammarLessonStep, () => {
       [3, "static"],
       [4, "fillBlank"],
     ]);
+
     expect(steps[0]?.content).toMatchObject({
       romanization: `das ist${id} gut`,
       sentence: `Das ist${id} gut`,
       translation: `That is${id} good`,
       variant: "grammarExample",
     });
+
     expect(steps[2]?.content).toMatchObject({
       context: `Look at the examples ${id}`,
       question: `What verb fits? ${id}`,
     });
+
     expect(steps[3]?.content).toStrictEqual({
       ruleName: `Present tense ${id}`,
       ruleSummary: `Use ist${id} for present tense`,
       variant: "grammarRule",
     });
+
     expect(steps[4]?.content).toStrictEqual({
       answers: [`ist${id}`],
       distractors: [`war${id}`, `hat${id}`],

--- a/apps/api/src/workflows/lesson-generation/steps/save-listening-lesson-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-listening-lesson-step.test.ts
@@ -22,6 +22,7 @@ describe(saveListeningLessonStep, () => {
       position: 2,
       targetLanguage: "de",
     });
+
     const [readingLesson, firstSentence, secondSentence] = await Promise.all([
       lessonFixture({
         chapterId: context.chapterId,

--- a/apps/api/src/workflows/lesson-generation/steps/save-listening-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-listening-lesson-step.ts
@@ -40,6 +40,7 @@ export async function saveListeningLessonStep(context: LessonContext): Promise<v
   }
 
   await prisma.step.deleteMany({ where: { lessonId: context.id } });
+
   await prisma.step.createMany({
     data: readingSteps.map((readingStep) => ({
       content: assertStepContent("listening", {}),

--- a/apps/api/src/workflows/lesson-generation/steps/save-practice-lesson-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-practice-lesson-step.test.ts
@@ -14,6 +14,7 @@ describe(savePracticeLessonStep, () => {
 
   it("saves practice scenario and question steps with option ids", async () => {
     const context = await createLessonContext({ kind: "practice", organizationId });
+
     const images = [
       {
         prompt: "Support desk with refund dashboard.",
@@ -58,12 +59,14 @@ describe(savePracticeLessonStep, () => {
       [0, "static"],
       [1, "multipleChoice"],
     ]);
+
     expect(steps[0]?.content).toStrictEqual({
       image: images[0],
       text: "A support report does not line up with the refund totals.",
       title: "Night shift",
       variant: "intro",
     });
+
     expect(steps[1]?.content).toStrictEqual({
       context: "The discounted orders are the only ones acting weird.",
       image: images[1],

--- a/apps/api/src/workflows/lesson-generation/steps/save-quiz-lesson-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-quiz-lesson-step.test.ts
@@ -52,6 +52,7 @@ describe(saveQuizLessonStep, () => {
       [0, "multipleChoice"],
       [1, "selectImage"],
     ]);
+
     expect(steps[0]?.content).toStrictEqual({
       context: "Look at the rule.",
       options: [
@@ -60,6 +61,7 @@ describe(saveQuizLessonStep, () => {
       ],
       question: "What is true?",
     });
+
     expect(steps[1]?.content).toStrictEqual({
       options: [
         {

--- a/apps/api/src/workflows/lesson-generation/steps/save-reading-lesson-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-reading-lesson-step.test.ts
@@ -20,6 +20,7 @@ describe(saveReadingLessonStep, () => {
     const generatedDistractorWords = [`Abend${id}`, `Fenster${id}`] as const;
     const sentence = canonicalWords.join(" ");
     const translation = `Good morning ${id}`;
+
     const context = await createLessonContext({
       kind: "reading",
       organizationId,
@@ -59,6 +60,7 @@ describe(saveReadingLessonStep, () => {
     const savedSentence = await prisma.sentence.findFirstOrThrow({
       where: { organizationId, sentence, targetLanguage: "de" },
     });
+
     const [lessonSentence, lessonWords, distractorLessonWords, step, pronunciations] =
       await Promise.all([
         prisma.lessonSentence.findUniqueOrThrow({
@@ -92,18 +94,22 @@ describe(saveReadingLessonStep, () => {
       romanization: normalizedCanonicalWords.join(" "),
       sentence,
     });
+
     expect(lessonSentence).toMatchObject({
       distractors: [...generatedDistractorWords],
       explanation: "Greeting",
       translation,
       translationDistractors: [`hello-${id}`, `bye-${id}`],
     });
+
     expect(step).toMatchObject({ content: {}, isPublished: true, sentenceId: savedSentence.id });
+
     expect(lessonWords.map((entry) => [entry.word.word, entry.translation])).toStrictEqual([
       [normalizedCanonicalWords[0]!, `good-${id}`],
       [normalizedCanonicalWords[2]!, canonicalWords[2]],
       [normalizedCanonicalWords[1]!, `morning-${id}`],
     ]);
+
     expect(distractorLessonWords).toStrictEqual([]);
     expect(pronunciations).toHaveLength(5);
   });

--- a/apps/api/src/workflows/lesson-generation/steps/save-reading-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-reading-lesson-step.ts
@@ -98,18 +98,22 @@ async function saveOneSentence(params: {
 }): Promise<void> {
   const sentence = normalizePunctuation(params.readingSentence.sentence);
   const translation = normalizePunctuation(params.readingSentence.translation);
+
   const sentenceDistractors = sanitizeDistractors({
     distractors: params.distractors[params.readingSentence.sentence] ?? [],
     input: params.readingSentence.sentence,
     shape: "single-word",
   });
+
   const sentenceTranslationDistractors = sanitizeDistractors({
     distractors: params.translationDistractors[params.readingSentence.translation] ?? [],
     input: params.readingSentence.translation,
     shape: "single-word",
   });
+
   const audioUrl = params.sentenceAudioUrls[params.readingSentence.sentence] ?? null;
   const romanization = params.sentenceRomanizations[params.readingSentence.sentence] ?? null;
+
   const record = await prisma.sentence.upsert({
     create: {
       audioUrl,

--- a/apps/api/src/workflows/lesson-generation/steps/save-static-lesson-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-static-lesson-step.test.ts
@@ -17,6 +17,7 @@ describe(saveExplanationLessonStep, () => {
 
   it("saves static explanation steps with generated images", async () => {
     const context = await createLessonContext({ kind: "explanation", organizationId });
+
     await stepFixture({
       content: { text: "stale", title: "Stale", variant: "text" },
       kind: "static",
@@ -27,6 +28,7 @@ describe(saveExplanationLessonStep, () => {
       { text: `Why does this happen? ${randomUUID()}`, title: "Question" },
       { text: `Each layer adds a different label. ${randomUUID()}`, title: "Layers" },
     ];
+
     const images = [
       { prompt: "A packet with labels added around it.", url: "https://example.com/packet.webp" },
       { prompt: "Each layer adding a label.", url: "https://example.com/labels.webp" },
@@ -43,18 +45,21 @@ describe(saveExplanationLessonStep, () => {
       [0, "static"],
       [1, "static"],
     ]);
+
     expect(steps[0]?.content).toStrictEqual({
       image: images[0],
       text: stepsToSave[0]?.text,
       title: "Question",
       variant: "text",
     });
+
     expect(steps[1]?.content).toStrictEqual({
       image: images[1],
       text: stepsToSave[1]?.text,
       title: "Layers",
       variant: "text",
     });
+
     expect(getStreamedEvents()).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({ status: "started", step: "saveExplanationLesson" }),

--- a/apps/api/src/workflows/lesson-generation/steps/save-translation-lesson-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-translation-lesson-step.test.ts
@@ -23,6 +23,7 @@ describe(saveTranslationLessonStep, () => {
       position: 2,
       targetLanguage: "pt",
     });
+
     const [vocabularyLesson, firstWord, secondWord] = await Promise.all([
       lessonFixture({
         chapterId: context.chapterId,

--- a/apps/api/src/workflows/lesson-generation/steps/save-translation-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-translation-lesson-step.ts
@@ -51,6 +51,7 @@ export async function saveTranslationLessonStep(context: LessonContext): Promise
     orderBy: { position: "asc" },
     where: { kind: "vocabulary", lessonId: sourceLesson.id, wordId: { not: null } },
   });
+
   const wordIds = sourceSteps.flatMap((step) => (step.wordId ? [step.wordId] : []));
 
   if (wordIds.length === 0) {
@@ -58,6 +59,7 @@ export async function saveTranslationLessonStep(context: LessonContext): Promise
   }
 
   await prisma.step.deleteMany({ where: { lessonId: context.id } });
+
   await prisma.step.createMany({
     data: wordIds.map((wordId, position) => ({
       content: assertStepContent("translation", {}),

--- a/apps/api/src/workflows/lesson-generation/steps/save-vocabulary-lesson-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-vocabulary-lesson-step.test.ts
@@ -17,6 +17,7 @@ describe(saveVocabularyLessonStep, () => {
     const id = randomUUID().replaceAll("-", "").slice(0, 8);
     const vocabularyWord = `boa noite ${id}`;
     const distractorWords = [`boa tarde ${id}`, `bom dia ${id}`] as const;
+
     const context = await createLessonContext({
       kind: "vocabulary",
       organizationId,
@@ -70,19 +71,24 @@ describe(saveVocabularyLessonStep, () => {
     ]);
 
     expect(lessonWords).toHaveLength(1);
+
     expect(lessonWords[0]).toMatchObject({
       distractors: [...distractorWords],
       translation: "good evening",
     });
+
     expect(lessonWords[0]?.word.word).toBe(vocabularyWord);
     expect(distractorLessonWords).toStrictEqual([]);
+
     expect(words.map((entry) => [entry.word, entry.audioUrl])).toStrictEqual([
       [vocabularyWord, `/audio/boa-noite-${id}.mp3`],
       [distractorWords[0], `/audio/boa-tarde-${id}.mp3`],
       [distractorWords[1], `/audio/bom-dia-${id}.mp3`],
     ]);
+
     expect(pronunciations).toHaveLength(3);
     expect(steps).toHaveLength(1);
+
     expect(steps[0]).toMatchObject({
       content: {},
       isPublished: true,

--- a/apps/api/src/workflows/lesson-generation/steps/save-vocabulary-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-vocabulary-lesson-step.ts
@@ -51,11 +51,13 @@ export async function saveVocabularyLessonStep({
   await prisma.step.deleteMany({ where: { lessonId: context.id } });
 
   const allTargetWords = collectVocabularyTargetWords({ distractors, words });
+
   const existingCasing = await fetchExistingWordCasing({
     organizationId,
     targetLanguage,
     words: allTargetWords,
   });
+
   const canonicalWords = new Set(words.map((word) => word.word));
   const distractorWords = allTargetWords.filter((word) => !canonicalWords.has(word));
 
@@ -117,11 +119,13 @@ async function saveOneVocabularyWord(params: {
 }): Promise<void> {
   const dbWord = params.existingCasing[params.word.word.toLowerCase()] ?? params.word.word;
   const romanization = params.romanizations[params.word.word] ?? null;
+
   const wordDistractors = sanitizeDistractors({
     distractors: params.distractors[params.word.word] ?? [],
     input: params.word.word,
     shape: "any",
   });
+
   const wordId = await upsertWordWithPronunciation({
     audioUrl: params.wordAudioUrls[params.word.word] ?? null,
     organizationId: params.organizationId,

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-completed-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-completed-step.test.ts
@@ -21,6 +21,7 @@ describe(setLessonAsCompletedStep, () => {
     const updatedLesson = await prisma.lesson.findUniqueOrThrow({ where: { id: context.id } });
 
     expect(updatedLesson.generationStatus).toBe("completed");
+
     expect(getStreamedEvents()).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({ status: "completed", step: "setLessonAsCompleted" }),

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.test.ts
@@ -16,6 +16,7 @@ describe(setLessonAsRunningStep, () => {
 
   it("marks a lesson as running and clears stale steps when requested", async () => {
     const lesson = await createLessonContext({ generationStatus: "failed", organizationId });
+
     await stepFixture({
       content: { text: "stale", title: "Stale", variant: "text" },
       kind: "static",
@@ -37,7 +38,9 @@ describe(setLessonAsRunningStep, () => {
       generationRunId: "workflow-running-1",
       generationStatus: "running",
     });
+
     expect(remainingSteps).toHaveLength(0);
+
     expect(getStreamedEvents()).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({ status: "started", step: "setLessonAsRunning" }),

--- a/apps/evals/src/app/tasks/[taskId]/[modelId]/test-case.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/[modelId]/test-case.tsx
@@ -11,6 +11,7 @@ function formatValue(value: unknown): string {
   if (typeof value === "string") {
     return value;
   }
+
   if (Array.isArray(value)) {
     if (value.length === 0) {
       return "[]";
@@ -22,6 +23,7 @@ function formatValue(value: unknown): string {
 
     return JSON.stringify(value, null, 2);
   }
+
   return JSON.stringify(value);
 }
 

--- a/apps/evals/src/app/tasks/[taskId]/battles/battle-matchup-list.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/battles/battle-matchup-list.tsx
@@ -37,6 +37,7 @@ function resolveModelId(modelId: string, anonymousIdMap: Map<string, string>): s
   if (getModelById(modelId)) {
     return modelId;
   }
+
   return anonymousIdMap.get(modelId) ?? modelId;
 }
 
@@ -62,6 +63,7 @@ function buildJudgeViews(
     for (const judgment of matchup.judgments) {
       if (!judgeNames.has(judgment.judgeId)) {
         const judgeModel = getModelById(judgment.judgeId);
+
         judgeNames.set(
           judgment.judgeId,
           judgeModel ? getModelDisplayName(judgeModel) : judgment.judgeId,
@@ -74,12 +76,14 @@ function buildJudgeViews(
       for (const ranking of judgment.rankings) {
         const modelId = resolveModelId(ranking.modelId, anonymousIdMap);
         const entries = modelMap.get(modelId) ?? [];
+
         entries.push({
           anonymousId: ranking.anonymousId,
           reasoning: ranking.reasoning,
           score: ranking.score,
           testCaseId: matchup.testCaseId,
         });
+
         modelMap.set(modelId, entries);
       }
     }

--- a/apps/evals/src/app/tasks/[taskId]/leaderboard-export.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/leaderboard-export.tsx
@@ -25,6 +25,7 @@ export function LeaderboardExport({
       // Export with position, average score, duration, and cost only
       markdown = "| Position | Avg Score | Avg Duration | Cost |\n";
       markdown += "|----------|-----------|--------------|------|\n";
+
       for (const [index, entry] of entries.entries()) {
         markdown += `| ${index + 1} | ${entry.averageScore.toFixed(2)} | ${entry.averageDuration.toFixed(2)}s | $${entry.totalCost.toFixed(2)} |\n`;
       }
@@ -32,6 +33,7 @@ export function LeaderboardExport({
       // Export all data
       markdown = "| Model | Provider | Avg Score | Avg Duration | Cost |\n";
       markdown += "|-------|----------|-----------|--------------|------|\n";
+
       for (const entry of entries) {
         markdown += `| ${entry.modelName} | ${entry.provider} | ${entry.averageScore.toFixed(2)} | ${entry.averageDuration.toFixed(2)}s | $${entry.totalCost.toFixed(2)} |\n`;
       }

--- a/apps/evals/src/lib/battle-loader.ts
+++ b/apps/evals/src/lib/battle-loader.ts
@@ -17,6 +17,7 @@ export const getBattleMatchups = cache(async (taskId: string): Promise<BattleMat
 
   try {
     const files = await fs.readdir(taskDir);
+
     const matchupFiles = files.filter(
       (file) => file.endsWith(".json") && file !== "leaderboard.json",
     );
@@ -62,6 +63,7 @@ function aggregateScoresFromMatchups(matchups: BattleMatchup[]): {
   for (const matchup of matchups) {
     for (const judgment of matchup.judgments) {
       totalJudgments += 1;
+
       for (const ranking of judgment.rankings) {
         const existing = modelScores.get(ranking.modelId) ?? {
           scoresByJudge: {},
@@ -70,8 +72,10 @@ function aggregateScoresFromMatchups(matchups: BattleMatchup[]): {
         };
 
         existing.totalScore += ranking.score;
+
         existing.scoresByJudge[judgment.judgeId] =
           (existing.scoresByJudge[judgment.judgeId] ?? 0) + ranking.score;
+
         existing.scoresByTestCase[matchup.testCaseId] =
           (existing.scoresByTestCase[matchup.testCaseId] ?? 0) + ranking.score;
 
@@ -101,6 +105,7 @@ function calculateModelMetrics({
 
   const avgInputTokens =
     outputs.outputs.reduce((sum, output) => sum + output.inputTokens, 0) / numOutputs;
+
   const avgOutputTokens =
     outputs.outputs.reduce((sum, output) => sum + output.outputTokens, 0) / numOutputs;
 
@@ -121,6 +126,7 @@ function buildLeaderboardEntry(
   matchupsCount: number,
 ): BattleLeaderboardEntry | null {
   const model = getModelById(modelId);
+
   if (!model) {
     return null;
   }
@@ -158,6 +164,7 @@ export const getBattleLeaderboard = cache(
 
     for (const [modelId, scores] of modelScores) {
       const entry = buildLeaderboardEntry(modelId, scores, allOutputs, matchups.length);
+
       if (entry) {
         entries.push(entry);
       }

--- a/apps/evals/src/lib/battle-runner.ts
+++ b/apps/evals/src/lib/battle-runner.ts
@@ -31,12 +31,14 @@ function getMatchupFilePath(taskId: string, testCaseId: string): string {
 
 function shuffleArray<T>(array: T[]): T[] {
   const shuffled = [...array];
+
   for (let i = shuffled.length - 1; i > 0; i -= 1) {
     const j = Math.floor(Math.random() * (i + 1));
     const temp = shuffled[i];
     shuffled[i] = shuffled[j] as T;
     shuffled[j] = temp as T;
   }
+
   return shuffled;
 }
 
@@ -64,6 +66,7 @@ async function loadExistingMatchup(
   testCaseId: string,
 ): Promise<BattleMatchup | null> {
   const filePath = getMatchupFilePath(taskId, testCaseId);
+
   try {
     const data = await fs.readFile(filePath, "utf8");
     return JSON.parse(data) as BattleMatchup;
@@ -82,6 +85,7 @@ function extractMappingFromMatchup(
   matchup: BattleMatchup,
 ): { anonymousId: string; modelId: string }[] {
   const firstJudgment = matchup.judgments[0];
+
   if (!firstJudgment) {
     return [];
   }
@@ -101,6 +105,7 @@ function hasNewModels(existingMatchup: BattleMatchup, currentModelIds: string[])
   const existingModelIds = new Set(
     extractMappingFromMatchup(existingMatchup).map((item) => item.modelId),
   );
+
   return currentModelIds.some((modelId) => !existingModelIds.has(modelId));
 }
 
@@ -117,6 +122,7 @@ function collectModelOutputsForTestCase(
 
   for (const [modelId, modelOutputs] of allOutputs) {
     const output = getOutputForTestCase(modelOutputs, testCaseId);
+
     if (output) {
       outputs.push({ modelId, output: output.output });
 
@@ -138,10 +144,12 @@ function getAnonymizationForBattle(
   }
 
   const mapping = extractMappingFromMatchup(existingMatchup);
+
   const anonymizedOutputs = modelOutputs.map((item) => {
     const mapEntry = mapping.find((entry) => entry.modelId === item.modelId);
     return { anonymousId: mapEntry?.anonymousId ?? item.modelId, output: item.output };
   });
+
   return { anonymizedOutputs, mapping };
 }
 
@@ -175,6 +183,7 @@ async function runBattleForTestCase(
   existingMatchup: BattleMatchup | null,
 ): Promise<BattleMatchup> {
   const testCaseId = `${testCase.id}-1`;
+
   const { outputs: modelOutputs, userPrompt } = collectModelOutputsForTestCase(
     testCaseId,
     allOutputs,
@@ -186,6 +195,7 @@ async function runBattleForTestCase(
 
   const currentModelIds = modelOutputs.map((item) => item.modelId);
   const newModelsDetected = existingMatchup && hasNewModels(existingMatchup, currentModelIds);
+
   if (newModelsDetected) {
     logInfo(`New models detected for ${testCaseId}, re-running all judges`);
   }
@@ -196,6 +206,7 @@ async function runBattleForTestCase(
   const judgesToRun = effectiveExisting
     ? getMissingJudges(effectiveExisting)
     : [...BATTLE_JUDGES_CONFIG];
+
   if (judgesToRun.length === 0 && effectiveExisting) {
     return effectiveExisting;
   }
@@ -207,6 +218,7 @@ async function runBattleForTestCase(
     mapping,
     userPrompt,
   });
+
   const allJudgments = effectiveExisting
     ? [...effectiveExisting.judgments, ...newJudgments]
     : newJudgments;
@@ -244,8 +256,10 @@ export async function runBattleMode(task: Task): Promise<void> {
 
   // Filter to only include complete models
   const completeOutputs = new Map<string, ModelOutputs>();
+
   for (const modelId of completeModels) {
     const outputs = allOutputs.get(modelId);
+
     if (outputs) {
       completeOutputs.set(modelId, outputs);
     }
@@ -273,6 +287,7 @@ export async function runBattleMode(task: Task): Promise<void> {
 
   logInfo("\n=== Battle Mode Complete ===");
   logInfo("Top 3 models:");
+
   leaderboard.slice(0, 3).forEach((entry, i) => {
     logInfo(`  ${i + 1}. ${entry.modelName}: ${entry.totalScore} points`);
   });

--- a/apps/evals/src/lib/battle-score.ts
+++ b/apps/evals/src/lib/battle-score.ts
@@ -55,9 +55,11 @@ Ties are allowed if outputs are truly equivalent in quality.
   // Map anonymous IDs back to model IDs, normalizing format variations.
   const rankings: ModelRanking[] = result.rankings.map((ranking) => {
     const normalizedRanking = normalizeAnonymousId(ranking.anonymousId);
+
     const modelMapping = mapping.find(
       (entry) => normalizeAnonymousId(entry.anonymousId) === normalizedRanking,
     );
+
     return {
       anonymousId: modelMapping?.anonymousId ?? ranking.anonymousId,
       modelId: modelMapping?.modelId ?? ranking.anonymousId,

--- a/apps/evals/src/lib/eval-runner.ts
+++ b/apps/evals/src/lib/eval-runner.ts
@@ -28,6 +28,7 @@ function getResultsFilePath(taskId: string, modelId: string): string {
 
 async function loadExistingScoredResults(taskId: string, modelId: string): Promise<ScoredResult[]> {
   const filePath = getResultsFilePath(taskId, modelId);
+
   try {
     const data = await fs.readFile(filePath, "utf8");
     const parsed = JSON.parse(data) as ScoredTaskResults;
@@ -80,6 +81,7 @@ export async function runEval(task: Task, modelId: string): Promise<TaskEvalResu
 
   // Load pre-generated outputs
   const modelOutputs = await loadModelOutputs(task.id, modelId);
+
   if (!modelOutputs || modelOutputs.outputs.length === 0) {
     throw new Error(`No outputs found for model ${modelId}. Generate outputs first.`);
   }
@@ -105,9 +107,11 @@ export async function runEval(task: Task, modelId: string): Promise<TaskEvalResu
   const results = await Promise.allSettled(
     outputsToScore.map((output) => {
       const testCase = findTestCaseForOutput(task, output.testCaseId);
+
       if (!testCase) {
         return Promise.reject(new Error(`Test case not found for output: ${output.testCaseId}`));
       }
+
       return scoreOutput(output, testCase);
     }),
   );
@@ -140,6 +144,7 @@ function combineOutputsAndResults(
 ): TaskEvalResults {
   const results = scoredResults.flatMap((scored) => {
     const output = outputs.find((entry) => entry.testCaseId === scored.testCase.id);
+
     if (!output) {
       return [];
     }
@@ -160,17 +165,20 @@ function combineOutputsAndResults(
 export const getTaskResults = cache(
   async (taskId: string, modelId: string): Promise<TaskEvalResults | null> => {
     const modelOutputs = await loadModelOutputs(taskId, modelId);
+
     if (!modelOutputs) {
       return null;
     }
 
     const scoredResults = await loadExistingScoredResults(taskId, modelId);
+
     if (scoredResults.length === 0) {
       return null;
     }
 
     const results = scoredResults.flatMap((scored) => {
       const output = modelOutputs.outputs.find((entry) => entry.testCaseId === scored.testCase.id);
+
       if (!output) {
         return [];
       }

--- a/apps/evals/src/lib/output-generator.ts
+++ b/apps/evals/src/lib/output-generator.ts
@@ -15,12 +15,14 @@ async function generateOutputForTestCase(
   const model = getModelById(modelId);
   const gatewayModelId = getGatewayModelId(modelId);
   const startTime = performance.now();
+
   const result = await task.generate({
     ...testCase.userInput,
     model: gatewayModelId,
     reasoningEffort: model?.reasoningEffort,
     useFallback: false,
   });
+
   const duration = performance.now() - startTime;
 
   const testCaseId = `${testCase.id}-${runNumber}`;
@@ -49,6 +51,7 @@ type TestCaseRun = { testCase: TestCase; runNumber: number };
 
 function collectTestCaseRuns(testCases: TestCase[], existingEntries: OutputEntry[]): TestCaseRun[] {
   const runs: TestCaseRun[] = [];
+
   for (const testCase of testCases) {
     for (let runNumber = 1; runNumber <= RUNS_PER_TEST_CASE; runNumber += 1) {
       if (!shouldSkipTestCase(existingEntries, testCase.id, runNumber)) {
@@ -56,6 +59,7 @@ function collectTestCaseRuns(testCases: TestCase[], existingEntries: OutputEntry
       }
     }
   }
+
   return runs;
 }
 
@@ -80,6 +84,7 @@ function createModelOutputs(taskId: string, modelId: string, outputs: OutputEntr
 export async function generateOutputs(task: Task, modelId: string): Promise<ModelOutputs> {
   const safeModelId = modelId.replaceAll(/[\r\n]/g, "");
   logInfo(`\nGenerating outputs for task: ${task.name}, model: [${safeModelId}]`);
+
   logInfo(
     `Total test cases: ${task.testCases.length} (${task.testCases.length * RUNS_PER_TEST_CASE} runs)`,
   );

--- a/apps/evals/src/lib/output-loader.ts
+++ b/apps/evals/src/lib/output-loader.ts
@@ -29,6 +29,7 @@ export async function saveModelOutputs(
 export const loadModelOutputs = cache(
   async (taskId: string, modelId: string): Promise<ModelOutputs | null> => {
     const filePath = getOutputsFilePath(taskId, modelId);
+
     try {
       const data = await fs.readFile(filePath, "utf8");
       return JSON.parse(data) as ModelOutputs;

--- a/apps/evals/src/lib/utils.ts
+++ b/apps/evals/src/lib/utils.ts
@@ -8,6 +8,7 @@ export type ModelStatus = "completed" | "outputsReady" | "incomplete" | "notStar
 
 export async function getModelStatus(taskId: string, modelId: string): Promise<ModelStatus> {
   const totalTestCases = getTotalTestCases(taskId);
+
   const [results, outputStatus] = await Promise.all([
     getTaskResults(taskId, modelId),
     getOutputStatus(taskId, modelId, totalTestCases),

--- a/apps/main/e2e/catalog-actions.test.ts
+++ b/apps/main/e2e/catalog-actions.test.ts
@@ -153,6 +153,7 @@ test.describe("Catalog Actions", () => {
       "aria-checked",
       "true",
     );
+
     await expect(page.getByRole("menuitemradio", { name: /^helpful$/i })).toHaveAttribute(
       "aria-checked",
       "false",

--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -270,12 +270,14 @@ test.describe("Chapter - No Lessons", () => {
   test("non-AI chapters with no lessons stay on the chapter page", async ({ page }) => {
     const nonAiUniqueId = randomUUID().slice(0, 8);
     const org = await createOrganization();
+
     const course = await courseFixture({
       isPublished: true,
       organizationId: org.id,
       slug: `non-ai-chapter-course-${nonAiUniqueId}`,
       title: `Non AI Chapter Course ${nonAiUniqueId}`,
     });
+
     const chapter = await chapterFixture({
       courseId: course.id,
       description: `Non AI chapter ${nonAiUniqueId}`,
@@ -284,14 +286,17 @@ test.describe("Chapter - No Lessons", () => {
       slug: `non-ai-chapter-${nonAiUniqueId}`,
       title: `Non AI Chapter ${nonAiUniqueId}`,
     });
+
     const url = `/b/${org.slug}/c/${course.slug}/ch/${chapter.slug}`;
 
     await page.goto(url);
 
     await expect(page).toHaveURL(url);
+
     await expect(
       page.getByRole("heading", { level: 1, name: `Non AI Chapter ${nonAiUniqueId}` }),
     ).toBeVisible();
+
     await expect(page.getByRole("link", { name: /^start$/i })).not.toBeVisible();
   });
 });

--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -40,6 +40,7 @@ test.describe("Command Palette - Unauthenticated", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
+
     await expect(
       page.getByRole("navigation").getByRole("button", { name: /search/i }),
     ).toBeVisible();
@@ -81,6 +82,7 @@ test.describe("Command Palette - Unauthenticated", () => {
     await page
       .locator("[data-slot='dialog-overlay']")
       .click({ force: true, position: { x: 10, y: 10 } });
+
     await expect(page.getByRole("dialog")).not.toBeVisible();
   });
 
@@ -216,6 +218,7 @@ test.describe("Command Palette - Authenticated", () => {
       .getByRole("dialog")
       .getByText(/^logout$/i)
       .click();
+
     await logoutPage.waitForURL(/^[^?]*\/$/);
     await logoutPage.waitForLoadState("networkidle");
 
@@ -318,6 +321,7 @@ test.describe("Command Palette - Course Search", () => {
     // Create test courses with a unique prefix to avoid conflicts
     const uniqueId = randomUUID().slice(0, 8);
     const exactMatchTitle = `Zlaw ${uniqueId}`;
+
     const partialMatchTitles = [
       `Criminal Zlaw ${uniqueId}`,
       `Tax Zlaw ${uniqueId}`,
@@ -467,9 +471,11 @@ test.describe("Command Palette - Accessibility", () => {
     await openCommandPalette(page);
 
     const dialog = page.getByRole("dialog");
+
     const hasLabel = await dialog.evaluate(
       (el) => el.hasAttribute("aria-label") || el.hasAttribute("aria-labelledby"),
     );
+
     expect(hasLabel).toBe(true);
   });
 

--- a/apps/main/e2e/continue-learning-revalidation.test.ts
+++ b/apps/main/e2e/continue-learning-revalidation.test.ts
@@ -100,9 +100,11 @@ test.describe("Continue Learning Revalidation", () => {
 
     // 1. Navigate to home page (full load)
     await page.goto("/");
+
     const nextLink = page.getByRole("link", {
       name: new RegExp(`Next:.*Current Next ${uniqueId}`),
     });
+
     await expect(nextLink.first()).toBeVisible();
 
     // 2. Click the continue learning card link (client-side navigation)

--- a/apps/main/e2e/continue-lesson-link.test.ts
+++ b/apps/main/e2e/continue-lesson-link.test.ts
@@ -147,6 +147,7 @@ test.describe("Continue Lesson Link", () => {
     await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
     await expect(page.getByText(/lesson not available/i)).toBeVisible();
+
     await expect(page.getByRole("link", { name: /create lesson/i })).toHaveAttribute(
       "href",
       `/generate/l/${lesson.id}`,
@@ -160,6 +161,7 @@ test.describe("Continue Lesson Link", () => {
 
     const startLink = page.getByRole("link", { name: /^start$/i });
     await expect(startLink).toBeVisible();
+
     await expect(startLink).toHaveAttribute(
       "href",
       expect.stringContaining(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`),
@@ -173,6 +175,7 @@ test.describe("Continue Lesson Link", () => {
 
     const startLink = page.getByRole("link", { name: /^start$/i });
     await expect(startLink).toBeVisible();
+
     await expect(startLink).toHaveAttribute(
       "href",
       expect.stringContaining(`/ch/${chapter.slug}/l/${lesson.slug}`),
@@ -208,6 +211,7 @@ test.describe("Continue Lesson Link", () => {
 
     const continueLink = authenticatedPage.getByRole("link", { name: /^continue$/i });
     await expect(continueLink).toBeVisible();
+
     await expect(continueLink).toHaveAttribute(
       "href",
       `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${pendingLesson.slug}`,
@@ -271,6 +275,7 @@ test.describe("Continue Lesson Link", () => {
 
     const continueLink = authenticatedPage.getByRole("link", { name: /^continue$/i });
     await expect(continueLink).toBeVisible();
+
     await expect(continueLink).toHaveAttribute(
       "href",
       `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${nextLesson.slug}`,
@@ -340,6 +345,7 @@ test.describe("Continue Lesson Link", () => {
 
     const continueLink = authenticatedPage.getByRole("link", { name: /^continue$/i });
     await expect(continueLink).toBeVisible();
+
     await expect(continueLink).toHaveAttribute(
       "href",
       `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter2.slug}`,

--- a/apps/main/e2e/course-chapters.test.ts
+++ b/apps/main/e2e/course-chapters.test.ts
@@ -33,6 +33,7 @@ test.beforeAll(async () => {
     second: `Beta Chapter ${uniqueId}`,
     third: `Gamma Chapter ${uniqueId}`,
   };
+
   chapterSlugs = { first: `e2e-alpha-${uniqueId}` };
   unpublishedChapterName = `Unpublished Chapter ${uniqueId}`;
 

--- a/apps/main/e2e/course-detail.test.ts
+++ b/apps/main/e2e/course-detail.test.ts
@@ -25,6 +25,7 @@ async function mockWorkflowApis(route: Route) {
       contentType: "application/json",
       status: 200,
     });
+
     return;
   }
 
@@ -34,6 +35,7 @@ async function mockWorkflowApis(route: Route) {
       contentType: "text/event-stream",
       status: 200,
     });
+
     return;
   }
 
@@ -182,6 +184,7 @@ test.describe("Course Detail Page", () => {
   test("non-AI courses with no chapters stay on the course page", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, UUID_SHORT_LENGTH);
     const org = await createOrganization();
+
     const course = await courseFixture({
       isPublished: true,
       language: "en",
@@ -190,14 +193,17 @@ test.describe("Course Detail Page", () => {
       slug: `non-ai-empty-course-${uniqueId}`,
       title: `Non AI Empty Course ${uniqueId}`,
     });
+
     const url = `/b/${org.slug}/c/${course.slug}`;
 
     await page.goto(url);
 
     await expect(page).toHaveURL(url);
+
     await expect(
       page.getByRole("heading", { level: 1, name: `Non AI Empty Course ${uniqueId}` }),
     ).toBeVisible();
+
     await expect(page.getByRole("link", { name: /^start$/i })).not.toBeVisible();
   });
 

--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -61,13 +61,16 @@ function createRouteHandler(options: MockApiOptions) {
           contentType: "application/json",
           status: triggerResponse.status ?? 500,
         });
+
         return;
       }
+
       await route.fulfill({
         body: JSON.stringify({ message: "Workflow started", runId: triggerResponse.runId }),
         contentType: "application/json",
         status: 200,
       });
+
       return;
     }
 
@@ -77,16 +80,19 @@ function createRouteHandler(options: MockApiOptions) {
         await route.abort("failed");
         return;
       }
+
       if (statusDelayMs > 0) {
         await new Promise<void>((resolve) => {
           setTimeout(resolve, statusDelayMs);
         });
       }
+
       await route.fulfill({
         body: createSSEStream(streamMessages),
         contentType: "text/event-stream",
         status: 200,
       });
+
       return;
     }
 
@@ -217,6 +223,7 @@ test.describe("Generate Chapter Page - With Subscription", () => {
 
     // Create a lesson so the chapter page doesn't redirect back to /generate
     const uniqueId = randomUUID().slice(0, 8);
+
     await lessonFixture({
       chapterId: chapter.id,
       isPublished: true,
@@ -267,6 +274,7 @@ test.describe("Generate Chapter Page - With Subscription", () => {
     const { chapter, organizationId } = await createPendingChapter();
 
     const uniqueId = randomUUID().slice(0, 8);
+
     await lessonFixture({
       chapterId: chapter.id,
       isPublished: true,
@@ -293,6 +301,7 @@ test.describe("Generate Chapter Page - With Subscription", () => {
      * The client uses `startIndex` to resume from where it left off.
      */
     let statusRequestCount = 0;
+
     await userWithoutProgress.route("**/v1/workflows/chapter-generation/**", async (route) => {
       const url = route.request().url();
       const method = route.request().method();
@@ -303,17 +312,20 @@ test.describe("Generate Chapter Page - With Subscription", () => {
           contentType: "application/json",
           status: 200,
         });
+
         return;
       }
 
       if (url.includes("/status")) {
         statusRequestCount += 1;
         const messages = statusRequestCount === 1 ? partialMessages : remainingMessages;
+
         await route.fulfill({
           body: createSSEStream(messages),
           contentType: "text/event-stream",
           status: 200,
         });
+
         return;
       }
 

--- a/apps/main/e2e/generate-course-redirect.test.ts
+++ b/apps/main/e2e/generate-course-redirect.test.ts
@@ -19,6 +19,7 @@ async function mockWorkflowApis(route: Route) {
       contentType: "application/json",
       status: 200,
     });
+
     return;
   }
 
@@ -29,6 +30,7 @@ async function mockWorkflowApis(route: Route) {
       contentType: "text/event-stream",
       status: 200,
     });
+
     return;
   }
 
@@ -38,6 +40,7 @@ async function mockWorkflowApis(route: Route) {
 test.describe("Generate Course Redirect", () => {
   test("redirects to generate/cs/[id] when course suggestion exists", async ({ page }) => {
     const slug = `e2e-redirect-${randomUUID().slice(0, 8)}`;
+
     const suggestion = await courseSuggestionFixture({
       generationStatus: "running",
       language: "en",

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -69,13 +69,16 @@ function createRouteHandler(options: MockApiOptions) {
           contentType: "application/json",
           status: triggerResponse.status ?? 500,
         });
+
         return;
       }
+
       await route.fulfill({
         body: JSON.stringify({ message: "Workflow started", runId: triggerResponse.runId }),
         contentType: "application/json",
         status: 200,
       });
+
       return;
     }
 
@@ -85,16 +88,19 @@ function createRouteHandler(options: MockApiOptions) {
         await route.abort("failed");
         return;
       }
+
       if (statusDelayMs > 0) {
         await new Promise<void>((resolve) => {
           setTimeout(resolve, statusDelayMs);
         });
       }
+
       await route.fulfill({
         body: createSSEStream(streamMessages),
         contentType: "text/event-stream",
         status: 200,
       });
+
       return;
     }
 
@@ -118,6 +124,7 @@ test.describe("Generate Course Page", () => {
     test("shows triggering state immediately on page load", async ({ page }) => {
       // Create a unique suggestion to avoid PPR caching issues with seeded data
       const slug = `e2e-trigger-${randomUUID().slice(0, 8)}`;
+
       const suggestion = await courseSuggestionFixture({
         generationStatus: "running",
         language: "en",

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -62,13 +62,16 @@ function createRouteHandler(options: MockApiOptions) {
           contentType: "application/json",
           status: triggerResponse.status ?? 500,
         });
+
         return;
       }
+
       await route.fulfill({
         body: JSON.stringify({ message: "Workflow started", runId: triggerResponse.runId }),
         contentType: "application/json",
         status: 200,
       });
+
       return;
     }
 
@@ -78,16 +81,19 @@ function createRouteHandler(options: MockApiOptions) {
         await route.abort("failed");
         return;
       }
+
       if (statusDelayMs > 0) {
         await new Promise<void>((resolve) => {
           setTimeout(resolve, statusDelayMs);
         });
       }
+
       await route.fulfill({
         body: createSSEStream(streamMessages),
         contentType: "text/event-stream",
         status: 200,
       });
+
       return;
     }
 
@@ -305,6 +311,7 @@ test.describe("Generate Lesson Page - With Subscription", () => {
     const { lesson } = await createPendingLesson();
 
     const uniqueId = randomUUID().slice(0, 8);
+
     await stepFixture({
       content: {
         text: `E2E Generated Lesson ${uniqueId}`,
@@ -413,6 +420,7 @@ test.describe("Generate Lesson Page - Running Generation Bypasses Auth", () => {
     });
 
     const lessonTitle = `E2E Running Lesson ${uniqueId}`;
+
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       generationRunId: `run-${uniqueId}`,

--- a/apps/main/e2e/learn.test.ts
+++ b/apps/main/e2e/learn.test.ts
@@ -34,6 +34,7 @@ async function handleCourseGenerationRoute(route: Route): Promise<void> {
       contentType: "application/json",
       status: 200,
     });
+
     return;
   }
 

--- a/apps/main/e2e/lesson-completion.test.ts
+++ b/apps/main/e2e/lesson-completion.test.ts
@@ -14,6 +14,7 @@ async function createUniqueUser(baseURL: string) {
   const email = `e2e-lcomp-${uniqueId}@zoonk.test`;
 
   const signupContext = await request.newContext({ baseURL });
+
   const response = await signupContext.post("/api/auth/sign-up/email", {
     data: { email, name: `E2E LComp ${uniqueId}`, password: "password123" },
   });
@@ -424,6 +425,7 @@ test.describe("Lesson Completion UX", () => {
     });
 
     const completedLessonTitle = `Done Lesson ${uniqueId}`;
+
     const completedLesson = await lessonFixture({
       chapterId: chapter.id,
       description: `Completed lesson ${uniqueId}`,
@@ -436,6 +438,7 @@ test.describe("Lesson Completion UX", () => {
     });
 
     const pendingLessonTitle = `Pending Lesson ${uniqueId}`;
+
     const pendingLesson = await lessonFixture({
       chapterId: chapter.id,
       description: `Pending lesson ${uniqueId}`,
@@ -474,12 +477,14 @@ test.describe("Lesson Completion UX", () => {
     const completedItem = authenticatedPage.getByRole("link", {
       name: new RegExp(completedLessonTitle),
     });
+
     await expect(completedItem).toBeVisible();
     await expect(completedItem.getByRole("img", { name: /^completed$/i })).toBeVisible();
 
     const pendingItem = authenticatedPage.getByRole("link", {
       name: new RegExp(pendingLessonTitle),
     });
+
     await expect(pendingItem).toBeVisible();
   });
 });

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -30,6 +30,7 @@ async function createTestLesson(options?: {
   });
 
   const lessonTitle = `E2E Lesson Lesson ${uniqueId}`;
+
   const lesson = await lessonFixture({
     chapterId: chapter.id,
     description: `E2E lesson description ${uniqueId}`,
@@ -73,6 +74,7 @@ async function createBlockedPracticeLesson() {
   const org = await getAiOrganization();
 
   const uniqueId = randomUUID().slice(0, 8);
+
   const course = await courseFixture({
     isPublished: true,
     organizationId: org.id,
@@ -122,6 +124,7 @@ async function createEmptyReviewLesson() {
   const org = await getAiOrganization();
 
   const uniqueId = randomUUID().slice(0, 8);
+
   const course = await courseFixture({
     isPublished: true,
     organizationId: org.id,
@@ -226,6 +229,7 @@ test.describe("Lesson Player Page", () => {
     await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${review.slug}`);
 
     await expect(page.getByText("Review locked")).toBeVisible();
+
     await expect(
       page.getByText("Create earlier lessons first, then come back to review."),
     ).toBeVisible();
@@ -239,12 +243,14 @@ test.describe("Lesson Player Page", () => {
   test("pending non-AI lessons do not show a generate link", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const org = await createOrganization();
+
     const course = await courseFixture({
       isPublished: true,
       organizationId: org.id,
       slug: `non-ai-lesson-course-${uniqueId}`,
       title: `Non AI Lesson Course ${uniqueId}`,
     });
+
     const chapter = await chapterFixture({
       courseId: course.id,
       isPublished: true,
@@ -252,6 +258,7 @@ test.describe("Lesson Player Page", () => {
       slug: `non-ai-lesson-chapter-${uniqueId}`,
       title: `Non AI Lesson Chapter ${uniqueId}`,
     });
+
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       generationStatus: "pending",

--- a/apps/main/e2e/lesson-start-tracking.test.ts
+++ b/apps/main/e2e/lesson-start-tracking.test.ts
@@ -14,6 +14,7 @@ async function createUniqueUser(baseURL: string) {
   const email = `e2e-start-${uniqueId}@zoonk.test`;
 
   const signupContext = await request.newContext({ baseURL });
+
   const response = await signupContext.post("/api/auth/sign-up/email", {
     data: { email, name: `E2E Start ${uniqueId}`, password: "password123" },
   });
@@ -98,6 +99,7 @@ test.describe("Lesson Start Tracking", () => {
     const before = await prisma.lessonProgress.findUnique({
       where: { userLesson: { lessonId: lesson.id, userId } },
     });
+
     expect(before).toBeNull();
 
     await page.goto(url);

--- a/apps/main/e2e/performance-charts.test.ts
+++ b/apps/main/e2e/performance-charts.test.ts
@@ -22,6 +22,7 @@ test.describe("Performance Charts", () => {
       });
 
       await authenticatedPage.goto(chartPage.path);
+
       await expect(
         authenticatedPage.getByRole("figure", { name: chartPage.chartName }),
       ).toBeVisible();

--- a/apps/main/e2e/review-step.test.ts
+++ b/apps/main/e2e/review-step.test.ts
@@ -134,6 +134,7 @@ async function completeVocabStep(
     .getByText(/translate this word/i)
     .locator("..")
     .textContent();
+
   const correctWord = Object.entries(translationToWord).find(([translation]) =>
     promptText?.includes(translation),
   )?.[1];
@@ -347,6 +348,7 @@ test.describe("Review Step", () => {
     await expect(completionScreen).toBeVisible();
     await expect(completionScreen.getByRole("heading", { name: /course complete/i })).toBeVisible();
     await expect(completionScreen.getByRole("link", { name: /review course/i })).toBeVisible();
+
     await expect(
       completionScreen.getByText(completionScoreText, { exact: true }),
     ).not.toBeVisible();

--- a/apps/main/e2e/subscription.test.ts
+++ b/apps/main/e2e/subscription.test.ts
@@ -20,6 +20,7 @@ async function createUserWithSubscription(
   const password = "password123";
 
   const signupContext = await request.newContext({ baseURL });
+
   const signupResponse = await signupContext.post("/api/auth/sign-up/email", {
     data: { email, name: `E2E Sub ${uniqueId}`, password },
   });
@@ -131,6 +132,7 @@ test.describe("Subscription Page - No Subscription", () => {
     await authenticatedPage.goto("/subscription");
 
     await authenticatedPage.getByRole("radio", { name: /hobby/i }).click();
+
     await expect(
       authenticatedPage.getByRole("button", { name: /upgrade to hobby/i }),
     ).toBeVisible();
@@ -143,6 +145,7 @@ test.describe("Subscription Page - No Subscription", () => {
     await expect(authenticatedPage.getByRole("button", { name: /upgrade to pro/i })).toBeVisible();
 
     await authenticatedPage.getByRole("radio", { name: /free/i }).click();
+
     await expect(
       authenticatedPage.getByRole("button", { name: /upgrade to pro/i }),
     ).not.toBeVisible();
@@ -236,14 +239,17 @@ test.describe("Subscription Page - Provider Managed", () => {
 
     await expect(page.getByText(/managed through the app store/i)).toBeVisible();
     await expect(page.getByRole("link", { name: /manage in app store/i })).toBeVisible();
+
     await expect(page.getByRole("link", { name: /manage in app store/i })).toHaveAttribute(
       "href",
       "https://support.apple.com/billing",
     );
+
     await expect(page.getByRole("link", { name: /contact support/i })).toHaveAttribute(
       "href",
       "/support",
     );
+
     await expect(page.getByRole("radio", { name: /free/i })).not.toBeVisible();
     await expect(page.getByRole("button", { name: /manage/i })).not.toBeVisible();
 
@@ -260,10 +266,12 @@ test.describe("Subscription Page - Provider Managed", () => {
     await page.goto("/subscription");
 
     await expect(page.getByText(/managed by zoonk/i)).toBeVisible();
+
     await expect(page.getByRole("link", { name: /contact support/i })).toHaveAttribute(
       "href",
       "/support",
     );
+
     await expect(page.getByRole("radio", { name: /free/i })).not.toBeVisible();
     await expect(page.getByRole("button", { name: /manage/i })).not.toBeVisible();
 

--- a/apps/main/src/app/(settings)/subscription/plan-list.tsx
+++ b/apps/main/src/app/(settings)/subscription/plan-list.tsx
@@ -202,9 +202,11 @@ function getPriceLabel(planName: string, price: PriceInfo | null): string {
   if (planName === "free") {
     return "";
   }
+
   if (!price) {
     return "";
   }
+
   return formatPrice(price.amount, price.currency);
 }
 

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
@@ -46,6 +46,7 @@ export function LessonPlayerClient({
   userName: string | null;
 }) {
   const router = useRouter();
+
   const model = buildLessonPlayerModel({
     brandSlug,
     chapterSlug,
@@ -53,6 +54,7 @@ export function LessonPlayerClient({
     nextLesson,
     nextSibling,
   });
+
   const onNextHref = model.onNextHref;
   const handleNext = onNextHref ? () => router.push(onNextHref) : undefined;
 

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.test.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.test.ts
@@ -63,6 +63,7 @@ describe(buildLessonPlayerModel, () => {
       nextHref: "/b/brand/c/course/ch/chapter-2",
       reviewHref: "/b/brand/c/course/ch/chapter-1",
     });
+
     expect(model.onNextHref).toBe("/b/brand/c/course/ch/chapter-2/l/lesson-2");
   });
 
@@ -80,6 +81,7 @@ describe(buildLessonPlayerModel, () => {
       reviewHref: "/b/brand/c/course",
       secondaryReviewHref: "/b/brand/c/course/ch/chapter-1",
     });
+
     expect(model.onNextHref).toBeNull();
   });
 });

--- a/apps/main/src/app/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generation-client.tsx
@@ -51,6 +51,7 @@ export function GenerationClient({
 
   const isActive = generation.status === "triggering" || generation.status === "streaming";
   const displayProgress = useAnimatedProgress({ isActive, realProgress: progress, targetProgress });
+
   const thinkingMessages = useThinkingMessages(
     thinkingGenerators,
     isActive ? activePhaseNames : [],

--- a/apps/main/src/app/generate/cs/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generation-client.tsx
@@ -49,6 +49,7 @@ export function GenerationClient({
 
   const isActive = generation.status === "triggering" || generation.status === "streaming";
   const displayProgress = useAnimatedProgress({ isActive, realProgress: progress, targetProgress });
+
   const thinkingMessages = useThinkingMessages(
     thinkingGenerators,
     isActive ? activePhaseNames : [],

--- a/apps/main/src/app/generate/l/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/l/[id]/generation-client.tsx
@@ -61,6 +61,7 @@ export function GenerationClient({
 
   const isActive = generation.status === "triggering" || generation.status === "streaming";
   const displayProgress = useAnimatedProgress({ isActive, realProgress: progress, targetProgress });
+
   const thinkingMessages = useThinkingMessages(
     thinkingGenerators,
     isActive ? activePhaseNames : [],

--- a/apps/main/src/components/catalog/catalog-actions.tsx
+++ b/apps/main/src/components/catalog/catalog-actions.tsx
@@ -44,6 +44,7 @@ export function CatalogActions({
     if (feedback === value) {
       return;
     }
+
     setFeedback(value);
     trackFeedback({ contentId, feedback: value, kind });
     toast.success(t("Thanks for your feedback"));

--- a/apps/main/src/components/catalog/catalog-list.tsx
+++ b/apps/main/src/components/catalog/catalog-list.tsx
@@ -56,6 +56,7 @@ export function CatalogListSearch<T extends { id: string | number; title: string
 
   const { filteredIds, isSearchActive } = useMemo(() => {
     const query = normalizeString(search);
+
     if (!query) {
       return { filteredIds: null, isSearchActive: false };
     }

--- a/apps/main/src/data/chapters/get-chapter-for-generation.test.ts
+++ b/apps/main/src/data/chapters/get-chapter-for-generation.test.ts
@@ -60,6 +60,7 @@ describe(getChapterForGeneration, () => {
   it("returns null for chapters outside the AI organization", async () => {
     const otherOrg = await organizationFixture();
     const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+
     const otherChapter = await chapterFixture({
       courseId: otherCourse.id,
       organizationId: otherOrg.id,

--- a/apps/main/src/data/courses/course-suggestions.test.ts
+++ b/apps/main/src/data/courses/course-suggestions.test.ts
@@ -73,6 +73,7 @@ describe("course-suggestions", () => {
     const dbItem = await prisma.courseSuggestion.findUnique({
       where: { languageSlug: { language, slug: toSlug("Vitest") } },
     });
+
     expect(dbItem).not.toBeNull();
     expect(dbItem?.title).toBe("Vitest");
 
@@ -106,6 +107,7 @@ describe("course-suggestions", () => {
     const items = await prisma.courseSuggestion.findMany({
       where: { language, slug: toSlug("Common Course") },
     });
+
     expect(items).toHaveLength(1);
   });
 
@@ -236,6 +238,7 @@ describe("course-suggestions", () => {
       language: "en",
       slug: `non-existent-${randomUUID()}`,
     });
+
     expect(result).toBeNull();
   });
 

--- a/apps/main/src/data/courses/get-continue-learning.test.ts
+++ b/apps/main/src/data/courses/get-continue-learning.test.ts
@@ -76,6 +76,7 @@ describe("authenticated users", () => {
     const result = await getContinueLearning(headers);
 
     expect(result).toHaveLength(1);
+
     expect(result[0]).toMatchObject({
       chapter: { id: chapter.id, title: chapter.title },
       course: { id: course.id },
@@ -137,6 +138,7 @@ describe("authenticated users", () => {
     const result = await getContinueLearning(headers);
 
     expect(result).toHaveLength(1);
+
     expect(result[0]).toMatchObject({
       chapter: { id: chapter.id, title: chapter.title },
       course: { id: course.id },
@@ -333,6 +335,7 @@ describe("authenticated users", () => {
     const result = await getContinueLearning(headers);
 
     expect(result).toHaveLength(1);
+
     expect(result[0]).toMatchObject({
       chapter: { id: chapter2.id, title: chapter2.title },
       lesson: { id: lesson2.id },
@@ -412,6 +415,7 @@ describe("authenticated users", () => {
     const result = await getContinueLearning(headers);
 
     expect(result).toHaveLength(1);
+
     expect(result[0]).toMatchObject({
       course: { id: course.id, organization: null },
       lesson: { id: lesson2.id },
@@ -457,6 +461,7 @@ describe("authenticated users", () => {
     const result = await getContinueLearning(headers);
 
     expect(result).toHaveLength(1);
+
     expect(result[0]).toMatchObject({
       chapter: { id: chapter.id, slug: chapter.slug, title: chapter.title },
       course: { id: course.id },
@@ -513,6 +518,7 @@ describe("authenticated users", () => {
     const result = await getContinueLearning(headers);
 
     expect(result).toHaveLength(1);
+
     expect(result[0]).toMatchObject({
       chapter: { id: chapter.id, slug: chapter.slug, title: chapter.title },
       course: { id: course.id },
@@ -568,6 +574,7 @@ describe("authenticated users", () => {
     const result = await getContinueLearning(headers);
 
     expect(result).toHaveLength(1);
+
     expect(result[0]).toMatchObject({
       chapter: { id: chapter.id, slug: chapter.slug, title: chapter.title },
       course: { id: course.id },
@@ -614,6 +621,7 @@ describe("authenticated users", () => {
     const result = await getContinueLearning(headers);
 
     expect(result).toHaveLength(1);
+
     expect(result[0]).toMatchObject({
       chapter: { id: chapter2.id, slug: chapter2.slug, title: chapter2.title },
       course: { id: course.id },

--- a/apps/main/src/data/lessons/get-lesson-for-generation.test.ts
+++ b/apps/main/src/data/lessons/get-lesson-for-generation.test.ts
@@ -55,10 +55,12 @@ describe(getLessonForGeneration, () => {
   it("returns null for lessons outside the AI organization", async () => {
     const otherOrg = await organizationFixture();
     const otherCourse = await courseFixture({ organizationId: otherOrg.id });
+
     const otherChapter = await chapterFixture({
       courseId: otherCourse.id,
       organizationId: otherOrg.id,
     });
+
     const otherLesson = await lessonFixture({
       chapterId: otherChapter.id,
       organizationId: otherOrg.id,

--- a/apps/main/src/data/progress/_fill-gaps.test.ts
+++ b/apps/main/src/data/progress/_fill-gaps.test.ts
@@ -27,6 +27,7 @@ describe(fillGapsWithDecay, () => {
     ]);
 
     expect(result).toHaveLength(5);
+
     expect(dateKeys(result)).toStrictEqual([
       "2025-01-10",
       "2025-01-11",
@@ -34,6 +35,7 @@ describe(fillGapsWithDecay, () => {
       "2025-01-13",
       "2025-01-14",
     ]);
+
     expect(result.map((point) => point.energy)).toStrictEqual([75, 74, 73, 72, 80]);
   });
 
@@ -45,6 +47,7 @@ describe(fillGapsWithDecay, () => {
     ]);
 
     expect(result).toHaveLength(4);
+
     expect(dateKeys(result)).toStrictEqual([
       "2025-03-08",
       "2025-03-09",
@@ -61,6 +64,7 @@ describe(fillGapsWithDecay, () => {
     ]);
 
     expect(result).toHaveLength(4);
+
     expect(dateKeys(result)).toStrictEqual([
       "2025-11-01",
       "2025-11-02",
@@ -77,6 +81,7 @@ describe(fillGapsWithDecay, () => {
     ]);
 
     expect(result).toHaveLength(4);
+
     expect(dateKeys(result)).toStrictEqual([
       "2025-03-29",
       "2025-03-30",

--- a/apps/main/src/data/progress/_fill-gaps.ts
+++ b/apps/main/src/data/progress/_fill-gaps.ts
@@ -4,18 +4,22 @@ type DataPoint = { date: Date; energy: number };
 
 function buildDateEnergyMap(dataPoints: DataPoint[]): Map<string, number> {
   const map = new Map<string, number>();
+
   for (const point of dataPoints) {
     map.set(point.date.toISOString().slice(0, 10), point.energy);
   }
+
   return map;
 }
 
 function getDateBounds(sorted: DataPoint[]): { firstDate: Date; lastDate: Date } | null {
   const first = sorted[0];
   const last = sorted.at(-1);
+
   if (!first || !last) {
     return null;
   }
+
   return { firstDate: first.date, lastDate: last.date };
 }
 
@@ -25,11 +29,13 @@ function getDayCount(firstDate: Date, lastDate: Date): number {
     firstDate.getUTCMonth(),
     firstDate.getUTCDate(),
   );
+
   const utcLast = Date.UTC(
     lastDate.getUTCFullYear(),
     lastDate.getUTCMonth(),
     lastDate.getUTCDate(),
   );
+
   return Math.round((utcLast - utcFirst) / (1000 * 60 * 60 * 24));
 }
 
@@ -69,6 +75,7 @@ export function fillGapsWithDecay(dataPoints: DataPoint[]): DataPoint[] {
 
   const sorted = [...dataPoints].toSorted((a, b) => a.date.getTime() - b.date.getTime());
   const bounds = getDateBounds(sorted);
+
   if (!bounds) {
     return [];
   }

--- a/apps/main/src/data/progress/get-belt-level.test.ts
+++ b/apps/main/src/data/progress/get-belt-level.test.ts
@@ -29,6 +29,7 @@ describe("authenticated users", () => {
     });
 
     const result = await getBeltLevel(headers);
+
     expect(result).toStrictEqual({
       bpPerLevel: 1000,
       bpToNextLevel: 500,

--- a/apps/main/src/data/progress/get-best-day.ts
+++ b/apps/main/src/data/progress/get-best-day.ts
@@ -10,6 +10,7 @@ type BestDayData = { score: number; dayOfWeek: number };
 const cachedGetBestDay = cache(
   async (startDateIso?: string, headers?: Headers): Promise<BestDayData | null> => {
     const session = await getSession(headers);
+
     if (!session) {
       return null;
     }

--- a/apps/main/src/data/progress/get-best-time.test.ts
+++ b/apps/main/src/data/progress/get-best-time.test.ts
@@ -18,6 +18,7 @@ type StepAttemptParams = {
 
 function buildStepAttemptData(params: StepAttemptParams) {
   const answeredAt = params.answeredAt ?? new Date();
+
   return {
     answer: { selectedOption: params.isCorrect ? 1 : 0 },
     answeredAt,
@@ -52,6 +53,7 @@ async function createTestStep(orgId: string) {
   const course = await courseFixture({ organizationId: orgId });
   const chapter = await chapterFixture({ courseId: course.id, organizationId: orgId });
   const lesson = await lessonFixture({ chapterId: chapter.id, organizationId: orgId });
+
   const step = await prisma.step.create({
     data: {
       content: { options: [{ feedback: "Yes", isCorrect: true, text: "A" }] },
@@ -82,6 +84,7 @@ describe("authenticated users", () => {
 
   it("returns best time when user has data for multiple periods", async () => {
     const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+
     const [headers, step] = await Promise.all([
       signInAs(user.email, user.password),
       createTestStep(org.id),
@@ -106,6 +109,7 @@ describe("authenticated users", () => {
 
   it("excludes records older than 90 days", async () => {
     const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+
     const [headers, step] = await Promise.all([
       signInAs(user.email, user.password),
       createTestStep(org.id),
@@ -134,6 +138,7 @@ describe("authenticated users", () => {
 
   it("uses period with most answers as tiebreaker", async () => {
     const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+
     const [headers, step] = await Promise.all([
       signInAs(user.email, user.password),
       createTestStep(org.id),
@@ -158,6 +163,7 @@ describe("authenticated users", () => {
 
   it("returns correct score calculation", async () => {
     const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+
     const [headers, step] = await Promise.all([
       signInAs(user.email, user.password),
       createTestStep(org.id),
@@ -178,6 +184,7 @@ describe("authenticated users", () => {
 
   it("correctly maps hours to periods", async () => {
     const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+
     const [headers, step] = await Promise.all([
       signInAs(user.email, user.password),
       createTestStep(org.id),
@@ -198,6 +205,7 @@ describe("authenticated users", () => {
 
   it("filters by custom date range when startDate is provided", async () => {
     const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+
     const [headers, step] = await Promise.all([
       signInAs(user.email, user.password),
       createTestStep(org.id),

--- a/apps/main/src/data/progress/get-best-time.ts
+++ b/apps/main/src/data/progress/get-best-time.ts
@@ -11,6 +11,7 @@ type BestTimeData = { score: number; period: number };
 const cachedGetBestTime = cache(
   async (startDateIso?: string, headers?: Headers): Promise<BestTimeData | null> => {
     const session = await getSession(headers);
+
     if (!session) {
       return null;
     }

--- a/apps/main/src/data/progress/get-bp-history.test.ts
+++ b/apps/main/src/data/progress/get-bp-history.test.ts
@@ -79,6 +79,7 @@ describe("authenticated users", () => {
       });
 
       const date = createSafeDate(0);
+
       await prisma.dailyProgress.create({
         data: { brainPowerEarned: 100, date, dayOfWeek: date.getDay(), userId: user.id },
       });
@@ -264,6 +265,7 @@ describe("authenticated users", () => {
       const headers = await signInAs(user.email, user.password);
 
       const date = createSafeDate(0);
+
       await prisma.dailyProgress.create({
         data: { brainPowerEarned: 100, date, dayOfWeek: date.getDay(), userId: user.id },
       });

--- a/apps/main/src/data/progress/get-bp-history.ts
+++ b/apps/main/src/data/progress/get-bp-history.ts
@@ -79,6 +79,7 @@ function getPreviousPeriodTotal(previousData: RawDataPoint[] | null): number | n
   if (!previousData || previousData.length === 0) {
     return null;
   }
+
   return sumBp(previousData);
 }
 
@@ -86,6 +87,7 @@ async function hasEarlierData(userId: string, beforeDate: Date): Promise<boolean
   const { data } = await safeAsync(() =>
     prisma.dailyProgress.findFirst({ where: { date: { lt: beforeDate }, userId } }),
   );
+
   return Boolean(data);
 }
 
@@ -97,6 +99,7 @@ const cachedGetBpHistory = cache(
     headers?: Headers,
   ): Promise<BpHistoryData | null> => {
     const session = await getSession(headers);
+
     if (!session) {
       return null;
     }
@@ -115,6 +118,7 @@ const cachedGetBpHistory = cache(
     }
 
     const processedData = processBpData(currentResult.data, period);
+
     const dataPoints: BpDataPoint[] = processedData.map((row) => ({
       bp: row.bp,
       date: row.date,

--- a/apps/main/src/data/progress/get-energy-history.test.ts
+++ b/apps/main/src/data/progress/get-energy-history.test.ts
@@ -307,6 +307,7 @@ describe("authenticated users", () => {
       });
 
       const result = await getEnergyHistory({ headers, period: "month" });
+
       if (!result) {
         throw new Error("Expected result");
       }

--- a/apps/main/src/data/progress/get-energy-history.ts
+++ b/apps/main/src/data/progress/get-energy-history.ts
@@ -26,6 +26,7 @@ function calculateAverage(dataPoints: { energy: number }[]): number {
   if (dataPoints.length === 0) {
     return 0;
   }
+
   const sum = dataPoints.reduce((acc, point) => acc + point.energy, 0);
   return sum / dataPoints.length;
 }
@@ -46,6 +47,7 @@ function getPreviousAverage(
   if (!previousData || previousData.length === 0) {
     return null;
   }
+
   const processed = processEnergyData(previousData, period);
   return processed.length > 0 ? calculateAverage(processed) : null;
 }
@@ -54,6 +56,7 @@ async function hasEarlierData(userId: string, beforeDate: Date): Promise<boolean
   const { data } = await safeAsync(() =>
     prisma.dailyProgress.findFirst({ where: { date: { lt: beforeDate }, userId } }),
   );
+
   return Boolean(data);
 }
 
@@ -65,6 +68,7 @@ const cachedGetEnergyHistory = cache(
     headers?: Headers,
   ): Promise<EnergyHistoryData | null> => {
     const session = await getSession(headers);
+
     if (!session) {
       return null;
     }
@@ -82,6 +86,7 @@ const cachedGetEnergyHistory = cache(
     }
 
     const currentData = processEnergyData(currentResult.data, period);
+
     const dataPoints: EnergyDataPoint[] = currentData.map((row) => ({
       date: row.date,
       energy: row.energy,

--- a/apps/main/src/data/progress/get-energy-level.test.ts
+++ b/apps/main/src/data/progress/get-energy-level.test.ts
@@ -38,9 +38,11 @@ describe("authenticated users", () => {
 
     // Anchor to UTC midnight so a midnight rollover can't shift the day count
     const today = new Date();
+
     const todayMidnight = new Date(
       Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()),
     );
+
     const fiveDaysAgo = new Date(todayMidnight.getTime() - 5 * 86_400_000);
 
     await prisma.userProgress.create({
@@ -56,9 +58,11 @@ describe("authenticated users", () => {
     const headers = await signInAs(user.email, user.password);
 
     const today = new Date();
+
     const todayMidnight = new Date(
       Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()),
     );
+
     const longAgo = new Date(todayMidnight.getTime() - 100 * 86_400_000);
 
     await prisma.userProgress.create({

--- a/apps/main/src/data/progress/get-score-history.test.ts
+++ b/apps/main/src/data/progress/get-score-history.test.ts
@@ -26,6 +26,7 @@ describe("authenticated users", () => {
     const headers = await signInAs(user.email, user.password);
 
     const date = new Date();
+
     await prisma.dailyProgress.create({
       data: {
         correctAnswers: 0,

--- a/apps/main/src/data/progress/get-score-history.ts
+++ b/apps/main/src/data/progress/get-score-history.ts
@@ -25,9 +25,11 @@ type RawDataPoint = { date: Date; correct: number; incorrect: number };
 
 function calculateScore(correct: number, incorrect: number): number {
   const total = correct + incorrect;
+
   if (total === 0) {
     return 0;
   }
+
   return (correct / total) * 100;
 }
 
@@ -35,6 +37,7 @@ function calculateAverage(dataPoints: { score: number }[]): number {
   if (dataPoints.length === 0) {
     return 0;
   }
+
   const sum = dataPoints.reduce((acc, point) => acc + point.score, 0);
   return sum / dataPoints.length;
 }
@@ -96,9 +99,11 @@ function getPreviousAverage(
   period: ScorePeriod,
 ): number | null {
   const valid = filterValidData(previousData ?? []);
+
   if (valid.length === 0) {
     return null;
   }
+
   const processed = processScoreData(valid, period);
   return processed.length > 0 ? calculateAverage(processed) : null;
 }
@@ -113,6 +118,7 @@ async function hasEarlierScoreData(userId: string, beforeDate: Date): Promise<bo
       },
     }),
   );
+
   return Boolean(data);
 }
 
@@ -124,6 +130,7 @@ const cachedGetScoreHistory = cache(
     headers?: Headers,
   ): Promise<ScoreHistoryData | null> => {
     const session = await getSession(headers);
+
     if (!session) {
       return null;
     }
@@ -141,11 +148,13 @@ const cachedGetScoreHistory = cache(
     }
 
     const validData = filterValidData(currentResult.data);
+
     if (validData.length === 0) {
       return null;
     }
 
     const currentData = processScoreData(validData, period);
+
     const dataPoints: ScoreDataPoint[] = currentData.map((row) => ({
       date: row.date,
       label: formatLabel(row.date, period, locale),

--- a/apps/main/src/data/progress/get-score.ts
+++ b/apps/main/src/data/progress/get-score.ts
@@ -14,6 +14,7 @@ function getDateRange(
   if (startDateIso && endDateIso) {
     return { endDate: new Date(endDateIso), startDate: new Date(startDateIso) };
   }
+
   const endDate = new Date();
   const startDate = new Date();
   startDate.setDate(startDate.getDate() - DEFAULT_PROGRESS_LOOKBACK_DAYS);
@@ -22,9 +23,11 @@ function getDateRange(
 
 function calculateScoreFromTotals(correct: number, incorrect: number): number | null {
   const total = correct + incorrect;
+
   if (total === 0) {
     return null;
   }
+
   return (correct / total) * 100;
 }
 
@@ -35,6 +38,7 @@ const cachedGetScore = cache(
     headers?: Headers,
   ): Promise<ScoreData | null> => {
     const session = await getSession(headers);
+
     if (!session) {
       return null;
     }

--- a/apps/main/src/lib/generation-phases.test.ts
+++ b/apps/main/src/lib/generation-phases.test.ts
@@ -232,6 +232,7 @@ describe(enforcePhaseProgression, () => {
       makePhase("pending"),
       makePhase("active"),
     ];
+
     const result = enforcePhaseProgression(input);
     expect(result.at(4)?.status).toBe("active");
     expect(result.at(5)?.status).toBe("pending");

--- a/apps/main/src/lib/workflow/generation-store.test.ts
+++ b/apps/main/src/lib/workflow/generation-store.test.ts
@@ -15,6 +15,7 @@ describe(generationReducer, () => {
         step: "stepA",
         type: "stepCompleted",
       });
+
       expect(state.completedSteps).toStrictEqual(["stepA"]);
     });
 
@@ -23,6 +24,7 @@ describe(generationReducer, () => {
         step: "stepA",
         type: "stepCompleted",
       });
+
       const second = generationReducer(first, { step: "stepA", type: "stepCompleted" });
       expect(second.completedSteps).toStrictEqual(["stepA"]);
     });
@@ -32,6 +34,7 @@ describe(generationReducer, () => {
         step: "stepA",
         type: "stepCompleted",
       });
+
       expect(state.currentStep).toBeNull();
     });
 
@@ -40,6 +43,7 @@ describe(generationReducer, () => {
         step: "stepA",
         type: "stepCompleted",
       });
+
       expect(state.currentStep).toBe("stepB");
     });
   });
@@ -50,6 +54,7 @@ describe(generationReducer, () => {
         step: "stepA",
         type: "stepStarted",
       });
+
       expect(state.currentStep).toBe("stepA");
     });
   });
@@ -59,6 +64,7 @@ describe(generationReducer, () => {
       const state = generationReducer(initialGenerationState({ status: "streaming" }), {
         type: "reconnect",
       });
+
       expect(state.reconnectCount).toBe(1);
     });
 
@@ -66,6 +72,7 @@ describe(generationReducer, () => {
       const first = generationReducer(initialGenerationState({ status: "streaming" }), {
         type: "reconnect",
       });
+
       const second = generationReducer(first, { type: "reconnect" });
       expect(second.reconnectCount).toBe(2);
     });
@@ -77,6 +84,7 @@ describe(generationReducer, () => {
         initialGenerationState({ reconnectCount: 3, status: "streaming" }),
         { type: "reset" },
       );
+
       expect(state.reconnectCount).toBe(0);
     });
   });
@@ -87,6 +95,7 @@ describe(generationReducer, () => {
         initialGenerationState({ error: "Some error", status: "error" }),
         { type: "streamEnded" },
       );
+
       expect(state.status).toBe("error");
     });
 
@@ -94,6 +103,7 @@ describe(generationReducer, () => {
       const state = generationReducer(initialGenerationState({ status: "completed" }), {
         type: "streamEnded",
       });
+
       expect(state.status).toBe("completed");
     });
 
@@ -101,6 +111,7 @@ describe(generationReducer, () => {
       const state = generationReducer(initialGenerationState({ status: "streaming" }), {
         type: "streamEnded",
       });
+
       expect(state.status).toBe("completed");
     });
 
@@ -109,6 +120,7 @@ describe(generationReducer, () => {
         initialGenerationState({ completedSteps: ["done"], status: "streaming" }),
         { completionStep: "done", type: "streamEnded" },
       );
+
       expect(state.status).toBe("completed");
     });
 
@@ -117,6 +129,7 @@ describe(generationReducer, () => {
         completionStep: "done",
         type: "streamEnded",
       });
+
       expect(state.status).toBe("error");
       expect(state.error).toBe("Generation ended unexpectedly. Please try again.");
     });
@@ -126,9 +139,11 @@ describe(generationReducer, () => {
 describe(handleStepStreamMessage, () => {
   function applyActions(actions: GenerationAction[], initial: GenerationState) {
     let state = initial;
+
     for (const action of actions) {
       state = generationReducer(state, action);
     }
+
     return state;
   }
 
@@ -153,57 +168,67 @@ describe(handleStepStreamMessage, () => {
 
   it("triggers streamEnded on completionStep match", () => {
     const actions: GenerationAction[] = [];
+
     handleStepStreamMessage({
       completionStep: "done",
       dispatch: (a) => actions.push(a),
       message: { status: "completed", step: "done" },
     });
+
     const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
     expect(state.status).toBe("completed");
   });
 
   it("triggers streamEnded when entityId matches the completed lesson", () => {
     const actions: GenerationAction[] = [];
+
     handleStepStreamMessage({
       completionStep: "done",
       dispatch: (a) => actions.push(a),
       entityId: "42",
       message: { entityId: "42", status: "completed", step: "done" },
     });
+
     const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
     expect(state.status).toBe("completed");
   });
 
   it("does not trigger streamEnded when entityId does not match", () => {
     const actions: GenerationAction[] = [];
+
     handleStepStreamMessage({
       completionStep: "done",
       dispatch: (a) => actions.push(a),
       entityId: "42",
       message: { entityId: "99", status: "completed", step: "done" },
     });
+
     const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
     expect(state.status).toBe("streaming");
   });
 
   it("triggers streamEnded when no entityId filter is set (non-lesson workflows)", () => {
     const actions: GenerationAction[] = [];
+
     handleStepStreamMessage({
       completionStep: "done",
       dispatch: (a) => actions.push(a),
       message: { entityId: "99", status: "completed", step: "done" },
     });
+
     const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
     expect(state.status).toBe("completed");
   });
 
   it("does not trigger streamEnded for non-completion steps", () => {
     const actions: GenerationAction[] = [];
+
     handleStepStreamMessage({
       completionStep: "done",
       dispatch: (a) => actions.push(a),
       message: { status: "completed", step: "stepA" },
     });
+
     const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
     expect(state.status).toBe("streaming");
   });
@@ -322,6 +347,7 @@ describe(handleStepStreamMessage, () => {
 
   it("does NOT set error when error entityId doesn't match viewer", () => {
     const actions: GenerationAction[] = [];
+
     handleStepStreamMessage({
       dispatch: (a) => actions.push(a),
       entityId: "100",
@@ -332,6 +358,7 @@ describe(handleStepStreamMessage, () => {
         step: "generateVisuals",
       },
     });
+
     const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
     expect(state.status).toBe("streaming");
     expect(state.error).toBeNull();
@@ -339,6 +366,7 @@ describe(handleStepStreamMessage, () => {
 
   it("sets error when error entityId matches viewer", () => {
     const actions: GenerationAction[] = [];
+
     handleStepStreamMessage({
       dispatch: (a) => actions.push(a),
       entityId: "100",
@@ -349,12 +377,14 @@ describe(handleStepStreamMessage, () => {
         step: "generateVisuals",
       },
     });
+
     const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
     expect(state.status).toBe("error");
   });
 
   it("sets error when error has no entityId (shared/batch step failure)", () => {
     const actions: GenerationAction[] = [];
+
     handleStepStreamMessage({
       dispatch: (a) => actions.push(a),
       entityId: "100",
@@ -364,6 +394,7 @@ describe(handleStepStreamMessage, () => {
         step: "generateExplanationContent",
       },
     });
+
     const state = applyActions(actions, initialGenerationState({ status: "streaming" }));
     expect(state.status).toBe("error");
   });

--- a/apps/main/src/lib/workflow/generation-store.ts
+++ b/apps/main/src/lib/workflow/generation-store.ts
@@ -68,6 +68,7 @@ export function generationReducer<TStep extends string>(
       if (state.status === "completed" || state.status === "error") {
         return state;
       }
+
       if (action.completionStep && !state.completedSteps.includes(action.completionStep)) {
         return {
           ...state,
@@ -75,6 +76,7 @@ export function generationReducer<TStep extends string>(
           status: "error",
         };
       }
+
       return { ...state, status: "completed" };
 
     case "triggerStart":
@@ -118,6 +120,7 @@ export function handleStepStreamMessage<TStep extends string>(params: {
       if (isEventRelevantToViewer(message.entityId, entityId)) {
         dispatch({ step: message.step, type: "stepStarted" });
       }
+
       break;
     case "completed": {
       if (isEventRelevantToViewer(message.entityId, entityId)) {
@@ -135,6 +138,7 @@ export function handleStepStreamMessage<TStep extends string>(params: {
       if (isCompletionForThisEntity) {
         dispatch({ completionStep, type: "streamEnded" });
       }
+
       break;
     }
     case "error":
@@ -145,6 +149,7 @@ export function handleStepStreamMessage<TStep extends string>(params: {
 
         dispatch({ error: errorMessage, type: "setError" });
       }
+
       break;
 
     default: {

--- a/apps/main/src/lib/workflow/use-animated-progress.test.ts
+++ b/apps/main/src/lib/workflow/use-animated-progress.test.ts
@@ -173,6 +173,7 @@ describe(useAnimatedProgress, () => {
 
   it("cleans up animation frame on unmount", () => {
     const cancelSpy = vi.spyOn(globalThis, "cancelAnimationFrame");
+
     const { unmount } = renderHook(() =>
       useAnimatedProgress({ isActive: true, realProgress: 10, targetProgress: 50 }),
     );

--- a/apps/main/src/lib/workflow/use-sse.ts
+++ b/apps/main/src/lib/workflow/use-sse.ts
@@ -29,6 +29,7 @@ export function useSSE<T>(
     void (async () => {
       try {
         const fullUrl = `${url}&startIndex=${indexRef.current}`;
+
         const response = await fetch(fullUrl, {
           credentials: "include",
           signal: controller.signal,
@@ -40,11 +41,13 @@ export function useSSE<T>(
         }
 
         const reader = response.body?.getReader();
+
         if (!reader) {
           return;
         }
 
         const decoder = new TextDecoder();
+
         const parser = createParser({
           onEvent: (event: EventSourceMessage) => {
             indexRef.current += 1;

--- a/apps/main/src/lib/workflow/use-thinking-messages.test.ts
+++ b/apps/main/src/lib/workflow/use-thinking-messages.test.ts
@@ -52,6 +52,7 @@ describe(useThinkingMessages, () => {
     const { result } = renderHook(() =>
       useThinkingMessages(cyclingGenerators, ["phaseA", "phaseB"]),
     );
+
     expect(result.current).toStrictEqual({ phaseA: "Analyzing...", phaseB: "Loading..." });
   });
 

--- a/apps/main/src/lib/workflow/use-workflow-generation.ts
+++ b/apps/main/src/lib/workflow/use-workflow-generation.ts
@@ -33,6 +33,7 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
     triggerBody,
     triggerUrl,
   } = config;
+
   const hasTriggeredRef = useRef(false);
 
   // Wrapper preserves the TStep generic that useReducer would otherwise widen to string.
@@ -134,6 +135,7 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
     if (!autoTrigger || state.status !== "idle" || hasTriggeredRef.current) {
       return;
     }
+
     hasTriggeredRef.current = true;
     void startTrigger();
   }, [autoTrigger, state.status]);

--- a/packages/ai/src/tasks/chapters/chapter-lessons.ts
+++ b/packages/ai/src/tasks/chapters/chapter-lessons.ts
@@ -5,6 +5,7 @@ import { type ReasoningEffort, buildProviderOptions } from "../../provider-optio
 import systemPrompt from "./chapter-lessons.prompt.md";
 
 const defaultModel = "openai/gpt-5.5";
+
 const fallbackModels = [
   "openai/gpt-5.4",
   "google/gemini-3.1-pro-preview",

--- a/packages/ai/src/tasks/courses/course-categories.ts
+++ b/packages/ai/src/tasks/courses/course-categories.ts
@@ -6,6 +6,7 @@ import { type ReasoningEffort, buildProviderOptions } from "../../provider-optio
 import promptTemplate from "./course-categories.prompt.md";
 
 const defaultModel = "google/gemini-3.1-flash-lite-preview";
+
 const fallbackModels = [
   "openai/gpt-5.4-nano",
   "anthropic/claude-haiku-4.5",
@@ -40,6 +41,7 @@ export async function generateCourseCategories({
   const userPrompt = `
     COURSE_TITLE: ${courseTitle}
   `;
+
   const systemPrompt = promptTemplate.replace("{{CATEGORIES}}", () => AI_CATEGORIES.join(", "));
 
   const providerOptions = buildProviderOptions({

--- a/packages/ai/src/tasks/courses/course-chapters.ts
+++ b/packages/ai/src/tasks/courses/course-chapters.ts
@@ -5,6 +5,7 @@ import { type ReasoningEffort, buildProviderOptions } from "../../provider-optio
 import systemPrompt from "./course-chapters.prompt.md";
 
 const defaultModel = "openai/gpt-5.5";
+
 const fallbackModels = [
   "openai/gpt-5.4",
   "anthropic/claude-opus-4.7",

--- a/packages/ai/src/tasks/lessons/language/lesson-distractors.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-distractors.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import systemPrompt from "./lesson-distractors.prompt.md";
 
 const defaultModel = "openai/gpt-5.4";
+
 const fallbackModels = [
   "google/gemini-3.1-flash-lite-preview",
   "anthropic/claude-sonnet-4.6",

--- a/packages/ai/src/tasks/lessons/lesson-kind.ts
+++ b/packages/ai/src/tasks/lessons/lesson-kind.ts
@@ -5,6 +5,7 @@ import { type ReasoningEffort, buildProviderOptions } from "../../provider-optio
 import systemPrompt from "./lesson-kind.prompt.md";
 
 const defaultModel = "openai/gpt-5.4-nano";
+
 const fallbackModels = [
   "google/gemini-3.1-flash-lite-preview",
   "meta/llama-4-scout",

--- a/packages/ai/src/tasks/steps/step-content-image.ts
+++ b/packages/ai/src/tasks/steps/step-content-image.ts
@@ -47,6 +47,7 @@ export async function generateStepContentImage({
   quality = DEFAULT_QUALITY,
 }: StepContentImageParams): Promise<SafeReturn<GeneratedFile>> {
   const imagePreset = STEP_CONTENT_IMAGE_PRESETS[preset];
+
   const { data, error } = await safeAsync(() =>
     generateImage({
       maxImagesPerCall: 1,

--- a/packages/auth/src/username-validator.ts
+++ b/packages/auth/src/username-validator.ts
@@ -4,5 +4,6 @@ export function isUsernameAllowed(username: string): boolean {
   if (username.includes(".")) {
     return false;
   }
+
   return !BLOCKED_USERNAMES.has(username.toLowerCase());
 }

--- a/packages/core/src/auth/hooks/use-username-availability.ts
+++ b/packages/core/src/auth/hooks/use-username-availability.ts
@@ -22,6 +22,7 @@ export function useUsernameAvailability(currentUsername?: string | null) {
 
   if (currentUsername !== prevCurrentUsername) {
     setPrevCurrentUsername(currentUsername);
+
     if (currentUsername) {
       setUsername(currentUsername);
     }

--- a/packages/core/src/lessons/find-last-completed.test.ts
+++ b/packages/core/src/lessons/find-last-completed.test.ts
@@ -19,12 +19,14 @@ describe(findLastCompleted, () => {
 
   it("returns null when user has no completions", async () => {
     const course = await courseFixture({ isPublished: true, organizationId: orgId });
+
     const chapter = await chapterFixture({
       courseId: course.id,
       isPublished: true,
       organizationId: orgId,
       position: 0,
     });
+
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       isPublished: true,
@@ -47,12 +49,14 @@ describe(findLastCompleted, () => {
 
   it("returns null when completedAt is null (started but not finished)", async () => {
     const course = await courseFixture({ isPublished: true, organizationId: orgId });
+
     const chapter = await chapterFixture({
       courseId: course.id,
       isPublished: true,
       organizationId: orgId,
       position: 0,
     });
+
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       generationStatus: "completed",
@@ -78,12 +82,14 @@ describe(findLastCompleted, () => {
     const uid = user.id;
 
     const course = await courseFixture({ isPublished: true, organizationId: orgId });
+
     const chapter = await chapterFixture({
       courseId: course.id,
       isPublished: true,
       organizationId: orgId,
       position: 0,
     });
+
     const [lesson1, lesson2] = await Promise.all([
       lessonFixture({
         chapterId: chapter.id,
@@ -128,6 +134,7 @@ describe(findLastCompleted, () => {
       lessonPosition: 1,
       lessonSlug: lesson2.slug,
     });
+
     expect(result).toHaveProperty("orgSlug");
   });
 
@@ -136,12 +143,14 @@ describe(findLastCompleted, () => {
     const uid = user.id;
 
     const course = await courseFixture({ isPublished: true, organizationId: orgId });
+
     const chapter = await chapterFixture({
       courseId: course.id,
       isPublished: true,
       organizationId: orgId,
       position: 0,
     });
+
     const [lesson1, lesson2] = await Promise.all([
       lessonFixture({
         chapterId: chapter.id,
@@ -368,6 +377,7 @@ describe(findLastCompleted, () => {
       const uid = user.id;
 
       const course = await courseFixture({ isPublished: true, organizationId: orgId });
+
       const chapter = await chapterFixture({
         courseId: course.id,
         isPublished: true,
@@ -418,12 +428,14 @@ describe(findLastCompleted, () => {
     const uid = user.id;
 
     const course = await courseFixture({ isPublished: true, organizationId: orgId });
+
     const chapter = await chapterFixture({
       courseId: course.id,
       isPublished: true,
       organizationId: orgId,
       position: 0,
     });
+
     const [publishedLesson, unpublishedLesson] = await Promise.all([
       lessonFixture({
         chapterId: chapter.id,
@@ -466,6 +478,7 @@ describe(findLastCompleted, () => {
     const uid = user.id;
 
     const course = await courseFixture({ isPublished: true, organizationId: orgId });
+
     const chapter = await chapterFixture({
       courseId: course.id,
       isPublished: true,
@@ -576,12 +589,14 @@ describe(findLastCompleted, () => {
     const [user1, user2] = await Promise.all([userFixture(), userFixture()]);
 
     const course = await courseFixture({ isPublished: true, organizationId: orgId });
+
     const chapter = await chapterFixture({
       courseId: course.id,
       isPublished: true,
       organizationId: orgId,
       position: 0,
     });
+
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       generationStatus: "completed",

--- a/packages/core/src/lessons/generation-prerequisites.test.ts
+++ b/packages/core/src/lessons/generation-prerequisites.test.ts
@@ -90,6 +90,7 @@ describe(getBlockingLessonGenerationPrerequisite, () => {
         position: 4,
       }),
     ]);
+
     const runningExplanation = lessons[3];
     const practice = lessons[4];
 

--- a/packages/core/src/lessons/generation-prerequisites.ts
+++ b/packages/core/src/lessons/generation-prerequisites.ts
@@ -9,10 +9,12 @@ type BlockingLessonGenerationPrerequisite = {
 };
 
 type LessonGenerationPrerequisiteTarget = Pick<Lesson, "chapterId" | "kind" | "position">;
+
 type LessonGenerationPrerequisiteKind = Extract<
   Lesson["kind"],
   "listening" | "practice" | "quiz" | "reading" | "translation"
 >;
+
 type SourceBoundaryLessonKind = Extract<Lesson["kind"], "practice" | "quiz" | "reading">;
 type SourceLessonKind = Extract<Lesson["kind"], "alphabet" | "reading" | "vocabulary">;
 

--- a/packages/core/src/lessons/get-next-lesson-in-course.test.ts
+++ b/packages/core/src/lessons/get-next-lesson-in-course.test.ts
@@ -145,12 +145,14 @@ describe(getNextLessonInCourse, () => {
   it("skips unpublished lessons", async () => {
     const testOrg = await organizationFixture({ kind: "brand" });
     const testCourse = await courseFixture({ isPublished: true, organizationId: testOrg.id });
+
     const testChapter = await chapterFixture({
       courseId: testCourse.id,
       isPublished: true,
       organizationId: testOrg.id,
       position: 0,
     });
+
     const lessons = await Promise.all([
       lessonFixture({
         chapterId: testChapter.id,
@@ -196,12 +198,14 @@ describe(getNextLessonInCourse, () => {
   it("returns the next lesson shell even when it still needs generation", async () => {
     const testOrg = await organizationFixture({ kind: "brand" });
     const testCourse = await courseFixture({ isPublished: true, organizationId: testOrg.id });
+
     const testChapter = await chapterFixture({
       courseId: testCourse.id,
       isPublished: true,
       organizationId: testOrg.id,
       position: 0,
     });
+
     const pendingLessons = await Promise.all([
       lessonFixture({
         chapterId: testChapter.id,
@@ -247,6 +251,7 @@ describe(getNextLessonInCourse, () => {
   it("skips unpublished lessons when moving through a chapter", async () => {
     const testOrg = await organizationFixture({ kind: "brand" });
     const testCourse = await courseFixture({ isPublished: true, organizationId: testOrg.id });
+
     const testChapter = await chapterFixture({
       courseId: testCourse.id,
       isPublished: true,

--- a/packages/core/src/player/commands/_utils/durable-curriculum-completion-rules.test.ts
+++ b/packages/core/src/player/commands/_utils/durable-curriculum-completion-rules.test.ts
@@ -60,6 +60,7 @@ describe("durable curriculum completion rules", () => {
     const lesson10 = createTestUuid(10);
     const lesson11 = createTestUuid(11);
     const lesson20 = createTestUuid(20);
+
     const rows = [
       createRow({ chapterId: chapter1, lessonId: lesson10 }),
       createRow({ chapterId: chapter1, lessonId: lesson11 }),
@@ -107,6 +108,7 @@ describe("durable curriculum completion rules", () => {
     const lesson10 = createTestUuid(10);
     const lesson11 = createTestUuid(11);
     const missingChapterId = createTestUuid(99);
+
     const rowsByChapter = groupRowsByChapter({
       rows: [
         createRow({ chapterId, isCompleted: true, lessonId: lesson10 }),
@@ -163,6 +165,7 @@ describe("durable curriculum completion rules", () => {
     const chapter3 = createTestUuid(3);
     const lesson10 = createTestUuid(10);
     const lesson20 = createTestUuid(20);
+
     const rowsByChapter = groupRowsByChapter({
       rows: [
         createRow({ chapterId: chapter1, isCompleted: true, lessonId: lesson10 }),
@@ -203,6 +206,7 @@ describe("durable curriculum completion rules", () => {
     const chapter2 = createTestUuid(2);
     const lesson10 = createTestUuid(10);
     const lesson20 = createTestUuid(20);
+
     const rowsByChapter = groupRowsByChapter({
       rows: [
         createRow({ chapterId: chapter1, isCompleted: true, lessonId: lesson10 }),

--- a/packages/core/src/player/commands/submit-lesson-completion.test.ts
+++ b/packages/core/src/player/commands/submit-lesson-completion.test.ts
@@ -106,11 +106,13 @@ describe(submitLessonCompletion, () => {
     const userId = user.id;
 
     const publishedCourse = await courseFixture({ isPublished: true, organizationId: org.id });
+
     const chapter = await chapterFixture({
       courseId: publishedCourse.id,
       isPublished: true,
       organizationId: org.id,
     });
+
     const [firstLesson, secondLesson] = await Promise.all([
       lessonFixture({
         chapterId: chapter.id,
@@ -344,6 +346,7 @@ describe(submitLessonCompletion, () => {
     const courseUser = await prisma.courseUser.findUnique({
       where: { courseUser: { courseId: course.id, userId } },
     });
+
     expect(courseUser).not.toBeNull();
 
     const courseAfter = await prisma.course.findUniqueOrThrow({ where: { id: course.id } });
@@ -378,6 +381,7 @@ describe(submitLessonCompletion, () => {
     const courseUsers = await prisma.courseUser.findMany({
       where: { courseId: course.id, userId },
     });
+
     expect(courseUsers).toHaveLength(1);
   });
 
@@ -387,9 +391,11 @@ describe(submitLessonCompletion, () => {
 
     // Anchor to UTC midnight so a midnight rollover can't shift the day count
     const today = new Date();
+
     const todayMidnight = new Date(
       Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()),
     );
+
     const yesterday = new Date(todayMidnight.getTime() - 86_400_000);
 
     await userProgressFixture({ currentEnergy: 50, lastActiveAt: yesterday, userId });
@@ -412,6 +418,7 @@ describe(submitLessonCompletion, () => {
       orderBy: { date: "asc" },
       where: { userId },
     });
+
     expect(dailyRecords).toHaveLength(1);
     expect(dailyRecords[0]?.date).toStrictEqual(parseLocalDate(todayLocalDate()));
     expect(dailyRecords[0]?.energyAtEnd).toBeCloseTo(50.2);
@@ -476,6 +483,7 @@ describe(submitLessonCompletion, () => {
     const daily = await prisma.dailyProgress.findFirst({ where: { userId } });
 
     expect(daily).not.toBeNull();
+
     expect(daily?.date).toStrictEqual(
       new Date(
         Date.UTC(yesterday.getUTCFullYear(), yesterday.getUTCMonth(), yesterday.getUTCDate()),
@@ -561,9 +569,11 @@ describe(submitLessonCompletion, () => {
     const userId = user.id;
 
     const today = new Date();
+
     const todayMidnight = new Date(
       Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()),
     );
+
     const fiveDaysAgo = new Date(todayMidnight.getTime() - 5 * 86_400_000);
 
     await userProgressFixture({ currentEnergy: 50, lastActiveAt: fiveDaysAgo, userId });

--- a/packages/core/src/player/commands/submit-lesson-completion.ts
+++ b/packages/core/src/player/commands/submit-lesson-completion.ts
@@ -95,6 +95,7 @@ export async function submitLessonCompletion(input: {
     // Fill DailyProgress records for inactive days
     if (existingProgress) {
       const lastActiveDate = toUTCMidnight(existingProgress.lastActiveAt);
+
       await fillDecayGaps({
         currentEnergy: existingProgress.currentEnergy,
         lastActiveDate,

--- a/packages/core/src/player/commands/submit-player-completion.test.ts
+++ b/packages/core/src/player/commands/submit-player-completion.test.ts
@@ -29,6 +29,7 @@ function todayLocalDate(): string {
 async function createPublishedChapterContext() {
   const organization = await organizationFixture({ kind: "brand" });
   const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+
   const chapter = await chapterFixture({
     courseId: course.id,
     isPublished: true,
@@ -55,6 +56,7 @@ async function createMultipleChoiceLesson(params: {
     organizationId: params.organizationId,
     position: params.position ?? 0,
   });
+
   const step = await stepFixture({
     content: {
       options: [
@@ -113,6 +115,7 @@ describe(submitPlayerCompletion, () => {
       userFixture(),
       createPublishedChapterContext(),
     ]);
+
     const [currentLesson, nextLesson] = await Promise.all([
       lessonFixture({
         chapterId: chapter.id,
@@ -128,6 +131,7 @@ describe(submitPlayerCompletion, () => {
         position: 1,
       }),
     ]);
+
     const { lesson, step } = await createMultipleChoiceLesson({
       lessonId: currentLesson.id,
       organizationId: organization.id,

--- a/packages/core/src/player/commands/submit-player-completion.ts
+++ b/packages/core/src/player/commands/submit-player-completion.ts
@@ -72,6 +72,7 @@ export async function submitPlayerCompletion(params: {
   userId: string;
 }): Promise<PlayerCompletionEffects | null> {
   const lessonId = params.input.lessonId;
+
   const lesson = await prisma.lesson.findUnique({
     include: {
       steps: {

--- a/packages/core/src/player/contracts/_utils/lesson-data-mappers.ts
+++ b/packages/core/src/player/contracts/_utils/lesson-data-mappers.ts
@@ -174,6 +174,7 @@ export function attachTranslationsToSteps(
   lessonSentences: LessonSentenceInput[],
 ): StepDataInput[] {
   const wordMap = new Map(lessonWords.map((lessonWord) => [lessonWord.word.id, lessonWord]));
+
   const sentenceMap = new Map(
     lessonSentences.map((lessonSentence) => [lessonSentence.sentence.id, lessonSentence]),
   );

--- a/packages/core/src/player/contracts/build-word-bank-options.test.ts
+++ b/packages/core/src/player/contracts/build-word-bank-options.test.ts
@@ -142,6 +142,7 @@ describe(buildWordBankOptions, () => {
       "Bom",
       "noite",
     ]);
+
     expect(options.find((option) => option.word === "noite")).toStrictEqual({
       audioUrl: null,
       romanization: null,

--- a/packages/core/src/player/contracts/build-word-bank-options.ts
+++ b/packages/core/src/player/contracts/build-word-bank-options.ts
@@ -250,6 +250,7 @@ export function buildWordBankOptions(
 
   const distractors = removeCanonicalWordCollisions(config.distractors, config.correctWords);
   const words = shuffle([...config.correctWords, ...distractors]);
+
   const buildOption = config.usesTargetLanguageMetadata
     ? createWordOptionBuilder({ distractorWords, lessonWords, sentenceWordMap })
     : emptyWordOption;

--- a/packages/core/src/player/contracts/check-answer.ts
+++ b/packages/core/src/player/contracts/check-answer.ts
@@ -32,11 +32,13 @@ export function checkFillBlankAnswer(
   userAnswers: string[],
 ): AnswerResult {
   const isSameLength = content.answers.length === userAnswers.length;
+
   const isCorrect =
     isSameLength &&
     content.answers.every(
       (answer, index) => answer.toLowerCase() === (userAnswers[index] ?? "").trim().toLowerCase(),
     );
+
   return { correctAnswer: null, feedback: content.feedback, isCorrect };
 }
 

--- a/packages/core/src/player/contracts/prepare-lesson-data.test.ts
+++ b/packages/core/src/player/contracts/prepare-lesson-data.test.ts
@@ -142,6 +142,7 @@ describe(preparePlayerLessonData, () => {
         word: "boa noite",
       }),
     });
+
     const sentence = makeLessonSentence({
       distractors: ["Abend"],
       explanation: "Greeting",
@@ -171,6 +172,7 @@ describe(preparePlayerLessonData, () => {
       organizationId: "org-42",
       title: "Lesson",
     });
+
     expect(result.lessonWords).toStrictEqual([
       {
         audioUrl: "/audio/boa-noite.mp3",
@@ -182,6 +184,7 @@ describe(preparePlayerLessonData, () => {
         word: "boa noite",
       },
     ]);
+
     expect(result.lessonSentences).toStrictEqual([
       {
         audioUrl: "/audio/guten-morgen.mp3",
@@ -208,6 +211,7 @@ describe(preparePlayerLessonData, () => {
     });
 
     expect(result.steps).toHaveLength(1);
+
     expect(result.steps[0]?.content).toStrictEqual({
       text: "Hello world",
       title: "Intro",
@@ -253,10 +257,12 @@ describe(preparePlayerLessonData, () => {
     });
 
     expect(result.steps[0]?.sortOrderItems).toStrictEqual(["first", "second", "third"]);
+
     expect(result.steps[1]?.fillBlankOptions).toStrictEqual([
       { audioUrl: null, romanization: null, translation: null, word: "sky" },
       { audioUrl: null, romanization: "ground-rom", translation: null, word: "ground" },
     ]);
+
     expect(result.steps[2]?.matchColumnsRightItems).toStrictEqual(["1", "2"]);
   });
 
@@ -266,6 +272,7 @@ describe(preparePlayerLessonData, () => {
       translation: "good evening",
       word: makeWordRecord({ id: "10", word: "boa noite" }),
     });
+
     const sentence = makeLessonSentence({
       distractors: ["Abend", "Fenster"],
       sentence: makeSentenceRecord({ id: "20", sentence: "Guten Morgen, Lara." }),

--- a/packages/core/src/player/contracts/prepare-lesson-data.ts
+++ b/packages/core/src/player/contracts/prepare-lesson-data.ts
@@ -262,6 +262,7 @@ function buildSerializedLesson(
   const serializedLessonSentences = lessonSentences.map((sentence) => serializeSentence(sentence));
   const serializedDistractorWords = distractorWords.map((word) => serializeDistractorWord(word));
   const distractorLookup = buildDistractorWordLookup(serializedDistractorWords);
+
   const sentenceWordMap = new Map(
     sentenceWords.map((word) => [normalizeDistractorKey(word.word), word]),
   );

--- a/packages/core/src/player/queries/get-lesson-distractor-words.test.ts
+++ b/packages/core/src/player/queries/get-lesson-distractor-words.test.ts
@@ -36,6 +36,7 @@ describe(getLessonDistractorWordsForLessons, () => {
 
   it("returns unique target-language distractor words with pronunciation for the lesson language", async () => {
     const id = crypto.randomUUID();
+
     const [
       lessonForTest,
       canonicalWord,
@@ -105,6 +106,7 @@ describe(getLessonDistractorWordsForLessons, () => {
     expect(result.map((item) => item.word).toSorted()).toStrictEqual(
       [lessonWordDistractor.word, sharedDistractor.word].toSorted(),
     );
+
     expect(result).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -129,6 +131,7 @@ describe(getLessonDistractorWordsForLessons, () => {
 
   it("ignores translation distractors and unresolved target-language texts", async () => {
     const id = crypto.randomUUID();
+
     const [lessonForTest, canonicalWord, canonicalSentence, resolvedDistractor] = await Promise.all(
       [
         lessonFixture({

--- a/packages/core/src/player/queries/get-lesson-distractor-words.ts
+++ b/packages/core/src/player/queries/get-lesson-distractor-words.ts
@@ -18,8 +18,10 @@ async function listLessonDistractorWordsForLessons({ lessonIds }: { lessonIds: s
   const lessonWord = lessonWords[0];
   const lessonSentence = lessonSentences[0];
   const organizationId = lessonWord?.word.organizationId ?? lessonSentence?.sentence.organizationId;
+
   const targetLanguage =
     lessonWord?.word.targetLanguage ?? lessonSentence?.sentence.targetLanguage ?? "";
+
   const userLanguage = lessonWord?.userLanguage ?? lessonSentence?.userLanguage ?? "";
 
   if (!organizationId || !targetLanguage || !userLanguage) {

--- a/packages/core/src/player/queries/get-lesson-sentences.test.ts
+++ b/packages/core/src/player/queries/get-lesson-sentences.test.ts
@@ -90,6 +90,7 @@ describe(getLessonSentencesForLessons, () => {
     const result = await getLessonSentencesForLessons({ lessonIds: [newLesson.id] });
 
     expect(result).toHaveLength(1);
+
     expect(result[0]).toMatchObject({
       distractors: ["Adoro"],
       sentence: expect.objectContaining({

--- a/packages/core/src/player/queries/get-lesson-words.test.ts
+++ b/packages/core/src/player/queries/get-lesson-words.test.ts
@@ -96,6 +96,7 @@ describe(getLessonWordsForLessons, () => {
     const result = await getLessonWordsForLessons({ lessonIds: [newLesson.id] });
 
     expect(result).toHaveLength(1);
+
     expect(result[0]).toMatchObject({
       distractors: [],
       translation: "dog",

--- a/packages/core/src/player/queries/get-next-lesson.test.ts
+++ b/packages/core/src/player/queries/get-next-lesson.test.ts
@@ -83,6 +83,7 @@ describe(getNextLesson, () => {
   it("skips unpublished lessons", async () => {
     const testOrg = await organizationFixture({ kind: "brand" });
     const testCourse = await courseFixture({ isPublished: true, organizationId: testOrg.id });
+
     const testChapter = await chapterFixture({
       courseId: testCourse.id,
       isPublished: true,
@@ -169,6 +170,7 @@ describe(getNextLesson, () => {
     it("returns needsGeneration true when lesson is pending", async () => {
       const testOrg = await organizationFixture({ kind: "brand" });
       const testCourse = await courseFixture({ isPublished: true, organizationId: testOrg.id });
+
       const testChapter = await chapterFixture({
         courseId: testCourse.id,
         isPublished: true,
@@ -199,6 +201,7 @@ describe(getNextLesson, () => {
     it("returns needsGeneration true when lesson is failed", async () => {
       const testOrg = await organizationFixture({ kind: "brand" });
       const testCourse = await courseFixture({ isPublished: true, organizationId: testOrg.id });
+
       const testChapter = await chapterFixture({
         courseId: testCourse.id,
         isPublished: true,
@@ -229,6 +232,7 @@ describe(getNextLesson, () => {
     it("returns needsGeneration false when next lesson is completed", async () => {
       const testOrg = await organizationFixture({ kind: "brand" });
       const testCourse = await courseFixture({ isPublished: true, organizationId: testOrg.id });
+
       const testChapter = await chapterFixture({
         courseId: testCourse.id,
         isPublished: true,
@@ -259,6 +263,7 @@ describe(getNextLesson, () => {
     it("returns needsGeneration false when lesson generation is already in flight", async () => {
       const testOrg = await organizationFixture({ kind: "brand" });
       const testCourse = await courseFixture({ isPublished: true, organizationId: testOrg.id });
+
       const testChapter = await chapterFixture({
         courseId: testCourse.id,
         isPublished: true,

--- a/packages/core/src/player/queries/get-review-steps.test.ts
+++ b/packages/core/src/player/queries/get-review-steps.test.ts
@@ -105,6 +105,7 @@ describe(getReviewSteps, () => {
 
     // The 3 mistake steps should be included
     const resultIds = result.map((step) => step.id);
+
     for (const step of newLesson.steps.slice(0, 3)) {
       expect(resultIds).toContain(step.id);
     }
@@ -166,6 +167,7 @@ describe(getReviewSteps, () => {
 
     // All 5 mistake steps (tier 1 + tier 2) should be included
     const resultIds = result.map((step) => step.id);
+
     for (const step of newLesson.steps.slice(0, 5)) {
       expect(resultIds).toContain(step.id);
     }
@@ -609,11 +611,13 @@ describe(getReviewValidationSteps, () => {
     const org = await organizationFixture();
     organizationId = org.id;
     const course = await courseFixture({ isPublished: true, organizationId: org.id });
+
     const chapter = await chapterFixture({
       courseId: course.id,
       isPublished: true,
       organizationId: org.id,
     });
+
     lesson = await lessonFixture({
       chapterId: chapter.id,
       isPublished: true,

--- a/packages/core/src/player/queries/get-sentence-words.test.ts
+++ b/packages/core/src/player/queries/get-sentence-words.test.ts
@@ -84,6 +84,7 @@ describe(getSentenceWordsForLessons, () => {
 
   it("returns empty when sentence words have no matching LessonWord records", async () => {
     const uniqueId = crypto.randomUUID().replaceAll("-", "").slice(0, 8);
+
     const [newLesson, sentence] = await Promise.all([
       lessonFixture({
         chapterId: chapter.id,
@@ -107,6 +108,7 @@ describe(getSentenceWordsForLessons, () => {
   it("strips punctuation when matching sentence words to LessonWord records", async () => {
     const uniqueId = crypto.randomUUID().replaceAll("-", "").slice(0, 8);
     const wordText = `sabes${uniqueId}`;
+
     const [newLesson, sentence, word] = await Promise.all([
       lessonFixture({
         chapterId: chapter.id,
@@ -169,6 +171,7 @@ describe(getSentenceWordsForLessons, () => {
   it("deduplicates words across multiple sentences", async () => {
     const uniqueId = crypto.randomUUID().replaceAll("-", "").slice(0, 8);
     const wordText = `gato${uniqueId}`;
+
     const [newLesson, sentence1, sentence2, word] = await Promise.all([
       lessonFixture({
         chapterId: chapter.id,

--- a/packages/core/src/progress/get-chapter-progress.test.ts
+++ b/packages/core/src/progress/get-chapter-progress.test.ts
@@ -93,6 +93,7 @@ describe(getChapterProgress, () => {
     });
 
     const result2 = await getChapterProgress({ courseId: course.id, headers });
+
     expect(result2).toStrictEqual([
       { chapterId: chapter.id, completedLessons: 2, totalLessons: 2 },
     ]);
@@ -144,6 +145,7 @@ describe(getChapterProgress, () => {
 
     const headers = await signInAs(user.email, user.password);
     const result = await getChapterProgress({ courseId: course.id, headers });
+
     expect(result).toStrictEqual([
       { chapterId: chapter1.id, completedLessons: 1, totalLessons: 1 },
       { chapterId: chapter2.id, completedLessons: 0, totalLessons: 1 },

--- a/packages/core/src/progress/get-lesson-progress.test.ts
+++ b/packages/core/src/progress/get-lesson-progress.test.ts
@@ -16,6 +16,7 @@ describe(getLessonProgress, () => {
 
   async function createPublishedChapter() {
     const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+
     return chapterFixture({
       courseId: course.id,
       isPublished: true,
@@ -34,6 +35,7 @@ describe(getLessonProgress, () => {
 
   it("returns completion rows for published lessons in the chapter", async () => {
     const [user, chapter] = await Promise.all([userFixture(), createPublishedChapter()]);
+
     const [completedLesson, pendingLesson] = await Promise.all([
       lessonFixture({
         chapterId: chapter.id,
@@ -67,6 +69,7 @@ describe(getLessonProgress, () => {
 
   it("excludes started-but-not-completed lessons", async () => {
     const [user, chapter] = await Promise.all([userFixture(), createPublishedChapter()]);
+
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       isPublished: true,
@@ -89,6 +92,7 @@ describe(getLessonProgress, () => {
 
   it("excludes unpublished lessons", async () => {
     const [user, chapter] = await Promise.all([userFixture(), createPublishedChapter()]);
+
     const [publishedLesson, unpublishedLesson] = await Promise.all([
       lessonFixture({
         chapterId: chapter.id,
@@ -127,6 +131,7 @@ describe(getLessonProgress, () => {
 
   it("keeps a completed lesson completed when a new lesson is added later", async () => {
     const [user, chapter] = await Promise.all([userFixture(), createPublishedChapter()]);
+
     const completedLesson = await lessonFixture({
       chapterId: chapter.id,
       isPublished: true,

--- a/packages/core/src/progress/get-next-lesson.test.ts
+++ b/packages/core/src/progress/get-next-lesson.test.ts
@@ -31,6 +31,7 @@ describe(getNextLesson, () => {
     lessonStatuses?: ("completed" | "failed" | "pending" | "running")[];
   } = {}): Promise<CourseTree> {
     const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+
     const chapter = await chapterFixture({
       courseId: course.id,
       isPublished: true,

--- a/packages/db/src/prisma/seed/course-users.ts
+++ b/packages/db/src/prisma/seed/course-users.ts
@@ -19,6 +19,7 @@ export async function seedCourseUsers(
   // Enroll owner in all 5 courses with different startedAt times
   // So they appear in order in the continue learning section
   const now = new Date();
+
   await Promise.all(
     courses.map((course, index) =>
       prisma.courseUser.upsert({
@@ -35,6 +36,7 @@ export async function seedCourseUsers(
 
   // Also enroll member in the first course
   const firstCourse = courses[0];
+
   if (firstCourse) {
     await prisma.courseUser.upsert({
       create: { courseId: firstCourse.id, userId: users.member.id },

--- a/packages/db/src/prisma/seed/progress.ts
+++ b/packages/db/src/prisma/seed/progress.ts
@@ -107,6 +107,7 @@ async function seedStepAttempts(
   });
 
   const firstStep = steps[0];
+
   if (!firstStep) {
     return;
   }

--- a/packages/e2e/src/base.config.ts
+++ b/packages/e2e/src/base.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 const E2E_DATABASE_URL =
   process.env.DATABASE_URL ?? "postgres://postgres:postgres@localhost:5432/zoonk_e2e";
+
 const E2E_API_URL = "http://localhost:49152";
 
 export function createBaseConfig(options: {

--- a/packages/e2e/src/fixtures/users.ts
+++ b/packages/e2e/src/fixtures/users.ts
@@ -37,6 +37,7 @@ export async function createE2EUser(
   const name = `E2E User ${uniqueId}`;
 
   const signupContext = await request.newContext({ baseURL });
+
   const signupResponse = await signupContext.post("/api/auth/sign-up/email", {
     data: { email, name, password },
   });
@@ -80,6 +81,7 @@ export async function createE2EUser(
   }
 
   const signinContext = await request.newContext({ baseURL });
+
   const signinResponse = await signinContext.post("/api/auth/sign-in/email", {
     data: { email, password },
   });

--- a/packages/next/src/i18n/next-intl-codec.ts
+++ b/packages/next/src/i18n/next-intl-codec.ts
@@ -15,6 +15,7 @@ function setNestedProperty(obj: Record<string, unknown>, keyPath: string, value:
   let current = obj;
 
   const keysToTraverse = keys.slice(0, -1);
+
   for (const key of keysToTraverse) {
     if (!(key in current) || typeof current[key] !== "object" || current[key] === null) {
       current[key] = {};
@@ -39,6 +40,7 @@ function getSortedMessages(messages: ExtractedMessage[]): ExtractedMessage[] {
     if (pathA === pathB) {
       return localeCompare(messageA.id, messageB.id);
     }
+
     return localeCompare(pathA, pathB);
   });
 }
@@ -69,9 +71,11 @@ export default defineCodec(() => {
   return {
     decode(content, context) {
       const catalog = POParser.parse(content);
+
       if (catalog.meta) {
         metadataByLocale.set(context.locale, catalog.meta);
       }
+
       const messages = catalog.messages ?? [];
 
       return messages.map((msg) => {
@@ -101,6 +105,7 @@ export default defineCodec(() => {
     encode(messages, context) {
       const encodedMessages = getSortedMessages(messages).map((msg) => {
         const sourceMessage = context.sourceMessagesById.get(msg.id)?.message;
+
         if (!sourceMessage) {
           throw new Error(
             `Source message not found for id "${msg.id}" in locale "${context.locale}".`,
@@ -133,9 +138,11 @@ export default defineCodec(() => {
     toJSONString(source, context) {
       const parsed = this.decode(source, context);
       const messagesObject = {};
+
       for (const message of parsed) {
         setNestedProperty(messagesObject, message.id, message.message);
       }
+
       return JSON.stringify(messagesObject);
     },
   };

--- a/packages/oxlint-plugin/index.js
+++ b/packages/oxlint-plugin/index.js
@@ -4,6 +4,7 @@ import noGetExtractedInPromise from "./rules/no-get-extracted-in-promise.js";
 import noHardcodedAriaLabel from "./rules/no-hardcoded-aria-label.js";
 import noObjectParamsInCache from "./rules/no-object-params-in-cache.js";
 import noTFunctionAsArgument from "./rules/no-t-function-as-argument.js";
+import paddingAroundMultilineStatements from "./rules/padding-around-multiline-statements.js";
 
 /** @public */
 export default eslintCompatPlugin({
@@ -14,5 +15,6 @@ export default eslintCompatPlugin({
     "no-hardcoded-aria-label": noHardcodedAriaLabel,
     "no-object-params-in-cache": noObjectParamsInCache,
     "no-t-function-as-argument": noTFunctionAsArgument,
+    "padding-around-multiline-statements": paddingAroundMultilineStatements,
   },
 });

--- a/packages/oxlint-plugin/rules/no-object-params-in-cache.js
+++ b/packages/oxlint-plugin/rules/no-object-params-in-cache.js
@@ -91,9 +91,11 @@ export default defineRule({
     return {
       before() {
         const options = context.options[0] || {};
+
         exceptions = (options.exceptions || ["headers"]).map((exception) =>
           exception.toLowerCase(),
         );
+
         cacheImported = false;
         cacheLocalName = "cache";
       },

--- a/packages/oxlint-plugin/rules/no-t-function-as-argument.js
+++ b/packages/oxlint-plugin/rules/no-t-function-as-argument.js
@@ -52,6 +52,7 @@ function checkObjectProperty(prop, tVariableNames, context) {
       loc: prop.key.loc,
       messageId: "noTFunctionAsArgument",
     });
+
     return;
   }
 

--- a/packages/oxlint-plugin/rules/padding-around-multiline-statements.js
+++ b/packages/oxlint-plugin/rules/padding-around-multiline-statements.js
@@ -1,0 +1,170 @@
+import { defineRule } from "@oxlint/plugins";
+
+const MODULE_BOUNDARY_STATEMENTS = new Set([
+  "ExportAllDeclaration",
+  "ExportDefaultDeclaration",
+  "ExportNamedDeclaration",
+  "ImportDeclaration",
+  "TSExportAssignment",
+  "TSImportEqualsDeclaration",
+  "TSNamespaceExportDeclaration",
+]);
+
+/**
+ * Module imports and exports already have dedicated formatting in oxfmt, so this
+ * rule should stay focused on local statement flow inside executable code.
+ */
+function isModuleBoundaryStatement(statement) {
+  return MODULE_BOUNDARY_STATEMENTS.has(statement.type);
+}
+
+/**
+ * Multiline statements carry enough visual weight that adjacent statements need
+ * a blank line to make each step in the block scannable.
+ */
+function isMultilineStatement(statement) {
+  return statement.loc.start.line !== statement.loc.end.line;
+}
+
+/**
+ * Fixes need stable byte ranges so they can replace only the whitespace between
+ * two statements without touching the statements themselves.
+ */
+function hasUsableRange(statement) {
+  return Array.isArray(statement.range) && statement.range.length === 2;
+}
+
+/**
+ * A pair with comments in the gap is skipped because a comment may belong to
+ * either side, and automatic whitespace fixes should not guess that ownership.
+ */
+function isPlainWhitespaceGap({ sourceText, previousStatement, nextStatement }) {
+  const gap = sourceText.slice(previousStatement.range[1], nextStatement.range[0]);
+
+  return /^\s*$/.test(gap);
+}
+
+/**
+ * Existing blank lines are valid; the rule only adds the missing separator and
+ * never normalizes larger gaps to avoid creating noisy formatting churn.
+ */
+function hasBlankLineBetween({ previousStatement, nextStatement }) {
+  return nextStatement.loc.start.line > previousStatement.loc.end.line + 1;
+}
+
+/**
+ * Deriving indentation from the next statement's source line keeps the fixer
+ * stable even if two statements somehow started on the same physical line.
+ */
+function getStatementIndentation({ sourceText, statement }) {
+  const lineStart = sourceText.lastIndexOf("\n", statement.range[0] - 1) + 1;
+  const linePrefix = sourceText.slice(lineStart, statement.range[0]);
+
+  return linePrefix.match(/^\s*/)[0];
+}
+
+/**
+ * Statement pairs are checked only when a multiline statement touches another
+ * statement and the auto-fix can safely operate on plain whitespace.
+ */
+function shouldCheckStatementPair({ sourceText, previousStatement, nextStatement }) {
+  if (!hasUsableRange(previousStatement) || !hasUsableRange(nextStatement)) {
+    return false;
+  }
+
+  if (isModuleBoundaryStatement(previousStatement) || isModuleBoundaryStatement(nextStatement)) {
+    return false;
+  }
+
+  if (!isMultilineStatement(previousStatement) && !isMultilineStatement(nextStatement)) {
+    return false;
+  }
+
+  if (hasBlankLineBetween({ previousStatement, nextStatement })) {
+    return false;
+  }
+
+  return isPlainWhitespaceGap({ sourceText, previousStatement, nextStatement });
+}
+
+/**
+ * The replacement keeps the next statement's existing indentation while adding
+ * exactly one empty line between the two statements.
+ */
+function getReplacementGap({ sourceText, previousStatement, nextStatement }) {
+  const gap = sourceText.slice(previousStatement.range[1], nextStatement.range[0]);
+  const newline = gap.includes("\r\n") ? "\r\n" : "\n";
+  const indentation = getStatementIndentation({ sourceText, statement: nextStatement });
+
+  return `${newline}${newline}${indentation}`;
+}
+
+/**
+ * Reporting against the next statement makes the diagnostic point at the code
+ * that needs to move down, while the fix only changes the preceding whitespace.
+ */
+function reportMissingBlankLine({ context, sourceText, previousStatement, nextStatement }) {
+  context.report({
+    loc: nextStatement.loc,
+    messageId: "missingBlankLine",
+    fix(fixer) {
+      return fixer.replaceTextRange(
+        [previousStatement.range[1], nextStatement.range[0]],
+        getReplacementGap({ sourceText, previousStatement, nextStatement }),
+      );
+    },
+  });
+}
+
+/**
+ * Adjacent statements are the only relationships that matter for this rule; the
+ * AST visitor supplies each statement list that can contain executable steps.
+ */
+function checkStatementList({ context, sourceText, statements }) {
+  for (const [index, nextStatement] of statements.entries()) {
+    const previousStatement = statements[index - 1];
+
+    const shouldReport =
+      previousStatement &&
+      shouldCheckStatementPair({ sourceText, previousStatement, nextStatement });
+
+    if (shouldReport) {
+      reportMissingBlankLine({ context, sourceText, previousStatement, nextStatement });
+    }
+  }
+}
+
+export default defineRule({
+  create(context) {
+    const sourceText = context.sourceCode.getText();
+
+    return {
+      BlockStatement(node) {
+        checkStatementList({ context, sourceText, statements: node.body });
+      },
+
+      Program(node) {
+        checkStatementList({ context, sourceText, statements: node.body });
+      },
+
+      StaticBlock(node) {
+        checkStatementList({ context, sourceText, statements: node.body });
+      },
+
+      SwitchCase(node) {
+        checkStatementList({ context, sourceText, statements: node.consequent });
+      },
+    };
+  },
+
+  meta: {
+    docs: {
+      description:
+        "Require blank lines around multiline statements while leaving imports, exports, and commented gaps untouched",
+    },
+    fixable: "whitespace",
+    messages: { missingBlankLine: "Add a blank line around this multiline statement." },
+    schema: [],
+    type: "layout",
+  },
+});

--- a/packages/player/src/_browser-tests/player-arrangement.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-arrangement.browser.test.tsx
@@ -60,6 +60,7 @@ describe("player browser integration: arrangement steps", () => {
 
     await expect.element(page.getByRole("button", { name: /check/i })).toBeEnabled();
     await page.getByRole("button", { name: /check/i }).click();
+
     await expect
       .element(page.getByRole("region", { name: /answer feedback/i }))
       .toBeInTheDocument();

--- a/packages/player/src/_browser-tests/player-choice.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-choice.browser.test.tsx
@@ -139,6 +139,7 @@ describe("player browser integration: choice steps", () => {
 
     await page.getByRole("radio", { name: "Cat" }).click();
     await page.getByRole("button", { name: /check/i }).click();
+
     await expect
       .element(page.getByRole("region", { name: /answer feedback/i }))
       .toBeInTheDocument();
@@ -168,15 +169,19 @@ describe("player browser integration: choice steps", () => {
     await expect.element(page.getByRole("button", { name: /check/i })).toBeDisabled();
 
     fireEvent.keyDown(globalThis.window, { key: "2" });
+
     await expect
       .element(page.getByRole("radio", { name: "Berlin" }))
       .toHaveAttribute("aria-checked", "true");
+
     await expect.element(page.getByRole("button", { name: /check/i })).toBeEnabled();
 
     await page.getByRole("radio", { name: "Berlin" }).click();
+
     await expect
       .element(page.getByRole("radio", { name: "Berlin" }))
       .toHaveAttribute("aria-checked", "false");
+
     await expect.element(page.getByRole("button", { name: /check/i })).toBeDisabled();
 
     await page.getByRole("radio", { name: "Paris" }).click();
@@ -300,6 +305,7 @@ describe("player browser integration: choice steps", () => {
     await expect.element(page.getByText(/translate:/i)).toBeInTheDocument();
     await expect.element(page.getByText("Capital of Germany")).toBeInTheDocument();
     await expect.element(page.getByText("beru-rin")).toBeInTheDocument();
+
     await expect
       .element(page.getByRole("button", { name: /play pronunciation/i }))
       .toBeInTheDocument();
@@ -346,6 +352,7 @@ describe("player browser integration: choice steps", () => {
     await expect
       .element(page.getByRole("region", { name: /answer feedback/i }))
       .toBeInTheDocument();
+
     await expect.element(page.getByRole("radio", { name: "Cat" })).toBeInTheDocument();
   });
 

--- a/packages/player/src/_browser-tests/player-completion.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-completion.browser.test.tsx
@@ -57,6 +57,7 @@ describe("player browser integration: completion", () => {
     });
 
     await expect.element(page.getByRole("link", { name: /close/i })).toBeInTheDocument();
+
     await expect
       .element(page.getByRole("progressbar", { name: /lesson progress/i }))
       .toBeInTheDocument();
@@ -67,18 +68,24 @@ describe("player browser integration: completion", () => {
 
     await expect.element(completionScreen.getByText("1/1")).toBeInTheDocument();
     await expect.element(completionScreen.getByText(/\+10\s*BP/i)).toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByRole("progressbar", { name: /level progress/i }))
       .toBeInTheDocument();
+
     await expect.element(completionScreen.getByRole("link", { name: "Next" })).toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByRole("link", { name: /all lessons/i }))
       .toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByRole("button", { name: /try again/i }))
       .toBeInTheDocument();
+
     await expect.element(page.getByText("Custom completion footer")).toBeInTheDocument();
     await expect.element(page.getByRole("link", { name: /close/i })).not.toBeInTheDocument();
+
     await expect
       .element(page.getByRole("progressbar", { name: /lesson progress/i }))
       .not.toBeInTheDocument();
@@ -88,6 +95,7 @@ describe("player browser integration: completion", () => {
     await expect
       .element(page.getByRole("heading", { name: "Completion question" }))
       .toBeInTheDocument();
+
     await expect.element(page.getByRole("link", { name: /close/i })).toBeInTheDocument();
   });
 
@@ -103,18 +111,23 @@ describe("player browser integration: completion", () => {
     const completionScreen = page.getByRole("status");
 
     await expect.element(completionScreen.getByText(/\+10\s*BP/i)).toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByRole("link", { name: /all lessons/i }))
       .toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByRole("button", { name: /try again/i }))
       .toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByRole("link", { name: "Next" }))
       .not.toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByRole("progressbar", { name: /level progress/i }))
       .not.toBeInTheDocument();
+
     await expect.element(completionScreen.getByText(/belt/i)).not.toBeInTheDocument();
   });
 
@@ -132,20 +145,26 @@ describe("player browser integration: completion", () => {
     const nextLink = completionScreen.getByRole("link", { name: "Next" });
 
     await expect.element(completionScreen.getByText("1/1")).toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByText(/sign up to track your progress/i))
       .toBeInTheDocument();
+
     await expect.element(nextLink).toBeInTheDocument();
     await expect.element(nextLink).toHaveAttribute("href", "/lesson/play");
     await expect.element(loginLink).toBeInTheDocument();
     await expect.element(loginLink).toHaveAttribute("href", "/login");
+
     await expect
       .element(completionScreen.getByRole("link", { name: /all lessons/i }))
       .toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByRole("button", { name: /try again/i }))
       .toBeInTheDocument();
+
     await expect.element(completionScreen.getByText(/\+10\s*BP/i)).not.toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByRole("progressbar", { name: /level progress/i }))
       .not.toBeInTheDocument();
@@ -163,9 +182,11 @@ describe("player browser integration: completion", () => {
     const completionScreen = page.getByRole("status");
 
     await expect.element(completionScreen.getByText(/chapter complete/i)).toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByRole("link", { name: /review chapter/i }))
       .toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByRole("link", { name: /next chapter/i }))
       .not.toBeInTheDocument();
@@ -187,9 +208,11 @@ describe("player browser integration: completion", () => {
     const completionScreen = page.getByRole("status");
 
     await expect.element(completionScreen.getByText(/course complete/i)).toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByRole("link", { name: /review course/i }))
       .toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByRole("link", { name: /review chapter/i }))
       .toBeInTheDocument();
@@ -211,10 +234,13 @@ describe("player browser integration: completion", () => {
     await expect
       .element(completionScreen.getByText(/sign up to track your progress/i))
       .toBeInTheDocument();
+
     await expect.element(loginLink).toHaveAttribute("href", "/sign-in");
+
     await expect
       .element(completionScreen.getByRole("link", { name: /review chapter/i }))
       .toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByRole("link", { name: /next chapter/i }))
       .not.toBeInTheDocument();

--- a/packages/player/src/_browser-tests/player-explanation.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-explanation.browser.test.tsx
@@ -88,17 +88,20 @@ describe("player browser integration: explanation lesson flow", () => {
     await expect
       .element(page.getByRole("heading", { name: /whole message travel as one blob/i }))
       .toBeInTheDocument();
+
     await expect
       .element(page.getByAltText(/wrapped network packet moving through layered labels/i))
       .toBeInTheDocument();
 
     fireEvent.keyDown(globalThis.window, { key: "ArrowRight" });
     await expect.element(page.getByText(/each layer adds its own label/i)).toBeInTheDocument();
+
     await expect
       .element(page.getByAltText(/different network layers adding their own labels/i))
       .toBeInTheDocument();
 
     fireEvent.keyDown(globalThis.window, { key: "ArrowRight" });
+
     await expect
       .element(
         page.getByText(/which label helps the network decide where to send the packet next/i),
@@ -111,6 +114,7 @@ describe("player browser integration: explanation lesson flow", () => {
 
     await expect.element(page.getByRole("heading", { name: "This is why" })).toBeInTheDocument();
     await expect.element(page.getByText(/whatsapp/i)).toBeInTheDocument();
+
     await expect
       .element(
         page.getByAltText(

--- a/packages/player/src/_browser-tests/player-header-info.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-header-info.browser.test.tsx
@@ -37,9 +37,11 @@ describe("player header: lesson title and lesson info", () => {
     await page.getByRole("button", { name: /lesson info/i }).click();
 
     await expect.element(page.getByRole("heading", { name: "Present Tense" })).toBeInTheDocument();
+
     await expect
       .element(page.getByText("Use present tense patterns to describe what someone does now."))
       .toBeInTheDocument();
+
     await expect.element(page.getByText("Verb Fundamentals")).toBeInTheDocument();
   });
 

--- a/packages/player/src/_browser-tests/player-practice.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-practice.browser.test.tsx
@@ -65,6 +65,7 @@ describe("player browser integration: practice lessons", () => {
     });
 
     await expect.element(page.getByRole("heading", { name: "Night shift" })).toBeInTheDocument();
+
     await expect
       .element(
         page.getByAltText(
@@ -72,6 +73,7 @@ describe("player browser integration: practice lessons", () => {
         ),
       )
       .toBeInTheDocument();
+
     await expect
       .element(
         page.getByText(
@@ -85,6 +87,7 @@ describe("player browser integration: practice lessons", () => {
     await expect
       .element(page.getByRole("heading", { name: "What should I check first?" }))
       .toBeInTheDocument();
+
     await expect
       .element(page.getByAltText(/refund dashboard filtered to discounted orders/i))
       .toBeInTheDocument();

--- a/packages/player/src/_browser-tests/player-static.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-static.browser.test.tsx
@@ -29,6 +29,7 @@ function swipeLeft(target: HTMLElement) {
     targetTouches: [startTouch],
     touches: [startTouch],
   });
+
   fireEvent.touchEnd(globalThis.window, { changedTouches: [endTouch], touches: [] });
 }
 
@@ -40,6 +41,7 @@ function tapLeft(target: HTMLElement) {
     targetTouches: [touch],
     touches: [touch],
   });
+
   fireEvent.touchEnd(globalThis.window, { changedTouches: [touch], touches: [] });
 }
 
@@ -51,6 +53,7 @@ function tapRight(target: HTMLElement) {
     targetTouches: [touch],
     touches: [touch],
   });
+
   fireEvent.touchEnd(globalThis.window, { changedTouches: [touch], touches: [] });
 }
 
@@ -93,6 +96,7 @@ describe("player browser integration: static steps", () => {
 
     await expect.element(page.getByRole("heading", { name: "First step" })).toBeInTheDocument();
     await expect.element(page.getByRole("button", { name: /next step/i })).not.toBeInTheDocument();
+
     await expect
       .element(page.getByRole("button", { name: /previous step/i }))
       .not.toBeInTheDocument();
@@ -178,6 +182,7 @@ describe("player browser integration: static steps", () => {
     await expect
       .element(page.getByRole("heading", { name: "One step, one image" }))
       .toBeInTheDocument();
+
     await expect
       .element(page.getByAltText(/lantern lighting up one idea at a time/i))
       .toBeInTheDocument();
@@ -273,6 +278,7 @@ describe("player browser integration: static steps", () => {
     await expect.element(page.getByRole("heading", { name: "Second step" })).toBeInTheDocument();
 
     tapLeft(screen.getByRole("heading", { name: "Second step" }));
+
     await expect
       .element(page.getByRole("heading", { name: "One step, one image" }))
       .toBeInTheDocument();

--- a/packages/player/src/_browser-tests/player-vocabulary.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-vocabulary.browser.test.tsx
@@ -96,6 +96,7 @@ describe("player browser integration: vocabulary", () => {
 
     await expect.element(completionScreen).toBeInTheDocument();
     await expect.element(completionScreen.getByText(/\+10\s*BP/i)).toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByRole("progressbar", { name: /level progress/i }))
       .toBeInTheDocument();

--- a/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
@@ -191,6 +191,7 @@ describe("player browser integration: word bank steps", () => {
     await expect.element(page.getByText(/correct answer:/i)).toBeInTheDocument();
     await expect.element(page.getByText("Hola mundo")).toBeInTheDocument();
     await expect.element(page.getByText("OH-la MUN-do")).toBeInTheDocument();
+
     await expect
       .element(page.getByText("The sentence keeps the greeting first."))
       .toBeInTheDocument();
@@ -221,6 +222,7 @@ describe("player browser integration: word bank steps", () => {
     });
 
     await expect.element(page.getByText("Hola mundo")).toBeInTheDocument();
+
     await expect
       .element(page.getByRole("button", { name: /play pronunciation/i }))
       .not.toBeInTheDocument();

--- a/packages/player/src/_test-utils/build-inline-image-url.ts
+++ b/packages/player/src/_test-utils/build-inline-image-url.ts
@@ -14,6 +14,7 @@ function escapeSvgText(value: string): string {
  */
 export function buildInlineImageUrl({ label }: { label: string }): string {
   const safeLabel = escapeSvgText(label);
+
   const svg = [
     '<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024">',
     '<rect width="1024" height="1024" fill="#f4f4f5" />',

--- a/packages/player/src/check-step.test.ts
+++ b/packages/player/src/check-step.test.ts
@@ -98,6 +98,7 @@ describe(checkStep, () => {
           { left: "B", right: "2" },
         ],
       };
+
       const { result } = checkStep(step, answer);
       expect(result.isCorrect).toBe(true);
     });
@@ -111,6 +112,7 @@ describe(checkStep, () => {
           { left: "B", right: "1" },
         ],
       };
+
       const { result } = checkStep(step, answer);
       expect(result.isCorrect).toBe(false);
     });
@@ -252,6 +254,7 @@ describe(checkStep, () => {
           translationDistractors: [],
         },
       });
+
       const answer: SelectedAnswer = { arrangedWords: ["world", "Hello"], kind: "reading" };
       const { result } = checkStep(stepWithExplanation, answer);
       expect(result.feedback).toBe("Word order matters in this language.");
@@ -278,6 +281,7 @@ describe(checkStep, () => {
         arrangedWords: ["Guten", "Morgen,", "Lara."],
         kind: "reading",
       };
+
       const { result } = checkStep(stepWithDistractors, answer);
 
       expect(result.isCorrect).toBe(false);
@@ -332,6 +336,7 @@ describe(checkStep, () => {
           translationDistractors: [],
         },
       });
+
       const answer: SelectedAnswer = { arrangedWords: ["dias", "Buenos"], kind: "listening" };
       const { result } = checkStep(stepWithExplanation, answer);
       expect(result.feedback).toBe("Pay attention to accent marks.");
@@ -371,6 +376,7 @@ describe(checkStep, () => {
         },
         kind: "multipleChoice",
       });
+
       const answer: SelectedAnswer = { kind: "fillBlank", userAnswers: ["test"] };
       const { result } = checkStep(step, answer);
       expect(result.isCorrect).toBe(false);

--- a/packages/player/src/components/_utils/strip-wrapping-quotes.test.ts
+++ b/packages/player/src/components/_utils/strip-wrapping-quotes.test.ts
@@ -28,12 +28,15 @@ describe(stripWrappingQuotes, () => {
     expect(stripWrappingQuotes('"this" should preserve quotes in the first and last "words"')).toBe(
       '"this" should preserve quotes in the first and last "words"',
     );
+
     expect(stripWrappingQuotes("“this” should preserve quotes in the first and last “words”")).toBe(
       "“this” should preserve quotes in the first and last “words”",
     );
+
     expect(stripWrappingQuotes("'this' should preserve quotes in the first and last 'words'")).toBe(
       "'this' should preserve quotes in the first and last 'words'",
     );
+
     expect(stripWrappingQuotes("‘this’ should preserve quotes in the first and last ‘words’")).toBe(
       "‘this’ should preserve quotes in the first and last ‘words’",
     );

--- a/packages/player/src/components/arrange-words.tsx
+++ b/packages/player/src/components/arrange-words.tsx
@@ -65,9 +65,11 @@ function WordBank({
     <div aria-label={t("Word bank")} className="flex flex-wrap gap-2.5" role="group">
       {words.map((option, index) => {
         const usedCount = placedWords.filter((placed) => placed.word === option.word).length;
+
         const totalCount = words
           .slice(0, index + 1)
           .filter((item) => item.word === option.word).length;
+
         const isUsed = usedCount >= totalCount;
 
         return (

--- a/packages/player/src/components/belt-progress.tsx
+++ b/packages/player/src/components/belt-progress.tsx
@@ -20,8 +20,10 @@ export function BeltProgressHint({
   const { levelHref } = usePlayerNavigation();
   const currentBelt = calculateBeltLevel(newTotalBp);
   const previousBelt = calculateBeltLevel(newTotalBp - brainPower);
+
   const didLevelUp =
     currentBelt.color !== previousBelt.color || currentBelt.level !== previousBelt.level;
+
   const colorLabel = useBeltColorLabel(currentBelt.color);
   const currentPercent = getBeltProgressPercent(currentBelt);
 

--- a/packages/player/src/components/fill-blank-step.tsx
+++ b/packages/player/src/components/fill-blank-step.tsx
@@ -171,9 +171,11 @@ function WordBank({
     >
       {options.map((option, index) => {
         const usedCount = usedWords.filter((used) => used === option.word).length;
+
         const totalCount = options
           .slice(0, index + 1)
           .filter((item) => item.word === option.word).length;
+
         const isUsed = usedCount >= totalCount;
 
         return (

--- a/packages/player/src/components/match-columns-step.tsx
+++ b/packages/player/src/components/match-columns-step.tsx
@@ -111,6 +111,7 @@ function MatchGrid({
     <div className="grid grid-cols-2 gap-2 sm:gap-3">
       {leftItems.map((left, index) => {
         const right = rightItems[index];
+
         if (!right) {
           return null;
         }

--- a/packages/player/src/components/select-image-step.tsx
+++ b/packages/player/src/components/select-image-step.tsx
@@ -144,6 +144,7 @@ export function SelectImageStep({
             hasResult && selectedOptionId
               ? getImageOptionResultState(option, selectedOptionId)
               : null;
+
           const isDimmed = hasResult && !resultState;
           const isSelected = selectedOptionId === option.id;
 

--- a/packages/player/src/components/swipe-navigable-step-layout.tsx
+++ b/packages/player/src/components/swipe-navigable-step-layout.tsx
@@ -229,6 +229,7 @@ export function SwipeNavigableStepLayout({
     }
 
     detachWindowTouchListeners();
+
     gestureRef.current = {
       container: event.currentTarget,
       startX: touch.clientX,

--- a/packages/player/src/player-controller.test.ts
+++ b/packages/player/src/player-controller.test.ts
@@ -77,6 +77,7 @@ describe(buildCompletionInput, () => {
   it("builds completion payload from the player state", () => {
     const answeredAt = new Date("2026-03-18T15:30:00.000Z").getTime();
     const now = new Date("2026-03-18T18:45:00.000Z");
+
     const state = buildState({
       selectedAnswers: { "step-1": { kind: "multipleChoice", selectedOptionId: "a" } },
       stepTimings: { "step-1": { answeredAt, dayOfWeek: 3, durationSeconds: 12, hourOfDay: 12 } },

--- a/packages/player/src/player-provider.tsx
+++ b/packages/player/src/player-provider.tsx
@@ -48,6 +48,7 @@ export function PlayerProvider({
     () => ({ lesson, totalBrainPower }),
     [lesson, totalBrainPower],
   );
+
   const [state, dispatch] = useReducer(playerReducer, initInput, createInitialState);
   const actions = usePlayerActions(state, dispatch, onComplete, viewer.isAuthenticated);
   const screen = useMemo(() => getPlayerScreenModel(state), [state]);

--- a/packages/player/src/player-reducer.test.ts
+++ b/packages/player/src/player-reducer.test.ts
@@ -110,6 +110,7 @@ describe(createInitialState, () => {
     const sortItems = ["Banana", "Apple", "Cherry"];
     const steps = [buildStep({ id: "sort-1", kind: "sortOrder", sortOrderItems: sortItems })];
     const state = createInitialState({ lesson: buildLesson({ steps }), totalBrainPower: 0 });
+
     expect(state.selectedAnswers["sort-1"]).toStrictEqual({
       kind: "sortOrder",
       userOrder: sortItems,
@@ -121,6 +122,7 @@ describe(createInitialState, () => {
       buildStep({ id: "s1", kind: "static" }),
       buildMultipleChoiceStep({ id: "mc-1" }),
     ];
+
     const state = createInitialState({ lesson: buildLesson({ steps }), totalBrainPower: 0 });
     expect(state.selectedAnswers).toStrictEqual({});
   });
@@ -129,21 +131,25 @@ describe(createInitialState, () => {
 describe("SELECT_ANSWER", () => {
   it("stores answer by stepId", () => {
     const state = buildState();
+
     const next = playerReducer(state, {
       answer: multipleChoiceAnswer,
       stepId: "step-1",
       type: "SELECT_ANSWER",
     });
+
     expect(next.selectedAnswers["step-1"]).toStrictEqual(multipleChoiceAnswer);
   });
 
   it("does not change phase or index", () => {
     const state = buildState();
+
     const next = playerReducer(state, {
       answer: multipleChoiceAnswer,
       stepId: "step-1",
       type: "SELECT_ANSWER",
     });
+
     expect(next.phase).toBe("playing");
     expect(next.currentStepIndex).toBe(0);
   });
@@ -152,11 +158,13 @@ describe("SELECT_ANSWER", () => {
     const state = buildState({
       selectedAnswers: { "step-1": { kind: "multipleChoice", selectedOptionId: "option-b" } },
     });
+
     const next = playerReducer(state, {
       answer: multipleChoiceAnswer,
       stepId: "step-1",
       type: "SELECT_ANSWER",
     });
+
     expect(next.selectedAnswers["step-1"]).toStrictEqual(multipleChoiceAnswer);
   });
 });
@@ -165,12 +173,15 @@ describe("CHECK_ANSWER", () => {
   it("transitions from playing to feedback and stores result", () => {
     const step = buildMultipleChoiceStep({ id: "mc-1" });
     const state = buildState({ steps: [step] });
+
     const next = playerReducer(state, {
       result: { correctAnswer: null, feedback: "Correct!", isCorrect: true },
       stepId: "mc-1",
       type: "CHECK_ANSWER",
     });
+
     expect(next.phase).toBe("feedback");
+
     expect(next.results["mc-1"]).toStrictEqual({
       answer: undefined,
       result: { correctAnswer: null, feedback: "Correct!", isCorrect: true },
@@ -181,11 +192,13 @@ describe("CHECK_ANSWER", () => {
   it("includes selected answer in the result", () => {
     const step = buildMultipleChoiceStep({ id: "mc-1" });
     const state = buildState({ selectedAnswers: { "mc-1": multipleChoiceAnswer }, steps: [step] });
+
     const next = playerReducer(state, {
       result: { correctAnswer: null, feedback: "Correct!", isCorrect: true },
       stepId: "mc-1",
       type: "CHECK_ANSWER",
     });
+
     expect(next.results["mc-1"]?.answer).toStrictEqual(multipleChoiceAnswer);
   });
 
@@ -195,14 +208,18 @@ describe("CHECK_ANSWER", () => {
         buildStep({ id: "mc-1", kind: "matchColumns", position: 0 }),
         buildStep({ id: "mc-2", kind: "matchColumns", position: 1 }),
       ];
+
       const state = buildState({ steps });
+
       const next = playerReducer(state, {
         result: { correctAnswer: null, feedback: null, isCorrect: true },
         stepId: "mc-1",
         type: "CHECK_ANSWER",
       });
+
       expect(next.phase).toBe("playing");
       expect(next.currentStepIndex).toBe(1);
+
       expect(next.results["mc-1"]).toStrictEqual({
         answer: undefined,
         result: { correctAnswer: null, feedback: null, isCorrect: true },
@@ -213,12 +230,15 @@ describe("CHECK_ANSWER", () => {
     it("sets completed when matchColumns is the last step", () => {
       const steps = [buildStep({ id: "mc-1", kind: "matchColumns", position: 0 })];
       const state = buildState({ steps });
+
       const next = playerReducer(state, {
         result: { correctAnswer: null, feedback: null, isCorrect: true },
         stepId: "mc-1",
         type: "CHECK_ANSWER",
       });
+
       expect(next.phase).toBe("completed");
+
       expect(next.results["mc-1"]).toStrictEqual({
         answer: undefined,
         result: { correctAnswer: null, feedback: null, isCorrect: true },
@@ -243,6 +263,7 @@ describe("CHECK_ANSWER", () => {
       });
 
       expect(next.phase).toBe("completed");
+
       expect(next.stepTimings["mc-1"]).toStrictEqual({
         answeredAt: Date.now(),
         dayOfWeek: 0,
@@ -256,21 +277,25 @@ describe("CHECK_ANSWER", () => {
 
   it("no-ops in feedback phase", () => {
     const state = buildState({ phase: "feedback" });
+
     const next = playerReducer(state, {
       result: { correctAnswer: null, feedback: null, isCorrect: true },
       stepId: "step-1",
       type: "CHECK_ANSWER",
     });
+
     expect(next).toBe(state);
   });
 
   it("no-ops in completed phase", () => {
     const state = buildState({ phase: "completed" });
+
     const next = playerReducer(state, {
       result: { correctAnswer: null, feedback: null, isCorrect: true },
       stepId: "step-1",
       type: "CHECK_ANSWER",
     });
+
     expect(next).toBe(state);
   });
 });
@@ -347,6 +372,7 @@ describe("NAVIGATE_STEP", () => {
       buildMultipleChoiceStep({ id: "mc-1", position: 0 }),
       buildStep({ id: "s1", kind: "static", position: 1 }),
     ];
+
     const state = buildState({ currentStepIndex: 1, steps });
     const next = playerReducer(state, { direction: "prev", type: "NAVIGATE_STEP" });
     expect(next).toBe(state);
@@ -482,6 +508,7 @@ describe("RESTART", () => {
       buildMultipleChoiceStep({ id: "s1" }),
       buildMultipleChoiceStep({ id: "s2", position: 1 }),
     ];
+
     const state = buildState({
       currentStepIndex: 1,
       phase: "completed",
@@ -503,6 +530,7 @@ describe("RESTART", () => {
 
   it("clears results and selectedAnswers", () => {
     const steps = [buildMultipleChoiceStep({ id: "s1" })];
+
     const state = buildState({
       phase: "completed",
       results: {
@@ -532,17 +560,21 @@ describe("RESTART", () => {
 
   it("re-seeds sortOrder answers on restart", () => {
     const sortItems = ["Banana", "Apple", "Cherry"];
+
     const steps = [
       buildStep({ id: "sort-1", kind: "sortOrder", sortOrderItems: sortItems }),
       buildMultipleChoiceStep({ id: "mc-1", position: 1 }),
     ];
+
     const state = buildState({ phase: "completed", results: {}, selectedAnswers: {}, steps });
 
     const next = playerReducer(state, { type: "RESTART" });
+
     expect(next.selectedAnswers["sort-1"]).toStrictEqual({
       kind: "sortOrder",
       userOrder: sortItems,
     });
+
     expect(next.selectedAnswers["mc-1"]).toBeUndefined();
   });
 });
@@ -555,7 +587,9 @@ describe("CLEAR_ANSWER", () => {
         "step-2": { kind: "fillBlank", userAnswers: ["cat", "mat"] },
       },
     });
+
     const next = playerReducer(state, { stepId: "step-1", type: "CLEAR_ANSWER" });
+
     expect(next.selectedAnswers).toStrictEqual({
       "step-2": { kind: "fillBlank", userAnswers: ["cat", "mat"] },
     });
@@ -599,6 +633,7 @@ describe("timing", () => {
     const state = buildState({ stepStartedAt: startTime, steps: [step] });
 
     vi.setSystemTime(new Date("2026-03-15T14:30:05"));
+
     const next = playerReducer(state, {
       result: { correctAnswer: null, feedback: "Correct!", isCorrect: true },
       stepId: "mc-1",
@@ -617,6 +652,7 @@ describe("timing", () => {
     const steps = [buildStep({ id: "s1" }), buildStep({ id: "s2", position: 1 })];
 
     vi.setSystemTime(new Date("2026-03-15T10:00:00"));
+
     const state = buildState({
       currentStepIndex: 0,
       phase: "feedback",
@@ -644,10 +680,12 @@ describe("timing", () => {
 
   it("NAVIGATE_STEP next resets stepStartedAt", () => {
     vi.setSystemTime(new Date("2026-03-15T10:00:00"));
+
     const staticSteps = [
       buildStep({ id: "s1", kind: "static", position: 0 }),
       buildStep({ id: "s2", kind: "static", position: 1 }),
     ];
+
     const state = buildState({ stepStartedAt: 1000, steps: staticSteps });
 
     const next = playerReducer(state, { direction: "next", type: "NAVIGATE_STEP" });
@@ -656,10 +694,12 @@ describe("timing", () => {
 
   it("NAVIGATE_STEP prev resets stepStartedAt", () => {
     vi.setSystemTime(new Date("2026-03-15T10:00:00"));
+
     const staticSteps = [
       buildStep({ id: "s1", kind: "static", position: 0 }),
       buildStep({ id: "s2", kind: "static", position: 1 }),
     ];
+
     const state = buildState({ currentStepIndex: 1, stepStartedAt: 1000, steps: staticSteps });
 
     const next = playerReducer(state, { direction: "prev", type: "NAVIGATE_STEP" });
@@ -668,6 +708,7 @@ describe("timing", () => {
 
   it("RESTART resets startedAt, stepStartedAt, and clears stepTimings", () => {
     vi.setSystemTime(new Date("2026-03-15T10:00:00"));
+
     const state = buildState({
       phase: "completed",
       startedAt: 500,
@@ -703,16 +744,19 @@ describe("edge cases", () => {
     const step = buildMultipleChoiceStep({ id: "mc-1" });
     const answer: SelectedAnswer = { kind: "multipleChoice", selectedOptionId: "option-c" };
     const state = buildState({ selectedAnswers: { "mc-1": answer }, steps: [step] });
+
     const next = playerReducer(state, {
       result: { correctAnswer: null, feedback: "Good!", isCorrect: true },
       stepId: "mc-1",
       type: "CHECK_ANSWER",
     });
+
     const expected: StepResult = {
       answer,
       result: { correctAnswer: null, feedback: "Good!", isCorrect: true },
       stepId: "mc-1",
     };
+
     expect(next.results["mc-1"]).toStrictEqual(expected);
   });
 });

--- a/packages/player/src/player-screen.test.ts
+++ b/packages/player/src/player-screen.test.ts
@@ -99,12 +99,14 @@ describe(getPlayerScreenModel, () => {
     });
 
     expect(screen.kind).toBe("step");
+
     expect(screen.bottomBar).toStrictEqual({
       button: "check",
       disabled: true,
       kind: "primaryAction",
       run: "check",
     });
+
     expect(screen.keyboard.enterAction).toBeNull();
   });
 

--- a/packages/player/src/player-screen.ts
+++ b/packages/player/src/player-screen.ts
@@ -139,6 +139,7 @@ function getKeyboardModel({
 
   const enterAction =
     bottomBar.kind === "primaryAction" && !bottomBar.disabled ? bottomBar.run : null;
+
   const behavior = getPlayerStepBehavior(step);
 
   return {

--- a/packages/player/src/player-step-behavior.test.ts
+++ b/packages/player/src/player-step-behavior.test.ts
@@ -38,6 +38,7 @@ describe(getPlayerStepBehavior, () => {
       render: "static",
       validation: "none",
     });
+
     expect(hasStaticNavigation(descriptor)).toBe(true);
     expect(hasFeedbackScreen(descriptor)).toBe(false);
   });

--- a/packages/player/src/player-step.test.ts
+++ b/packages/player/src/player-step.test.ts
@@ -40,9 +40,11 @@ describe(describePlayerStep, () => {
 
   it("returns the primary image from image-backed descriptors", () => {
     const image = { prompt: "A useful diagram", url: "data:image/svg+xml,diagram" };
+
     const staticDescriptor = describePlayerStep(
       buildStep({ content: { image, text: "Hello", title: "Intro", variant: "text" as const } }),
     );
+
     const choiceDescriptor = describePlayerStep(
       buildStep({
         content: {

--- a/packages/player/src/use-player-actions.test.tsx
+++ b/packages/player/src/use-player-actions.test.tsx
@@ -46,6 +46,7 @@ describe(usePlayerActions, () => {
   it("check still no-ops for unanswered interactive steps", () => {
     const dispatch = vi.fn();
     const onComplete = vi.fn();
+
     const state = buildState({
       steps: [
         buildStep({

--- a/packages/player/src/use-player-keyboard.test.ts
+++ b/packages/player/src/use-player-keyboard.test.ts
@@ -38,6 +38,7 @@ describe(usePlayerKeyboard, () => {
       const opts = buildOptions({
         keyboard: { canRestart: false, enterAction: "check", leftAction: null, rightAction: null },
       });
+
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter");
@@ -54,6 +55,7 @@ describe(usePlayerKeyboard, () => {
           rightAction: null,
         },
       });
+
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter");
@@ -73,6 +75,7 @@ describe(usePlayerKeyboard, () => {
 
     it("calls onNext when completion Enter action prefers next", () => {
       const onNext = vi.fn();
+
       const opts = buildOptions({
         keyboard: {
           canRestart: true,
@@ -82,6 +85,7 @@ describe(usePlayerKeyboard, () => {
         },
         onNext,
       });
+
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter");
@@ -100,6 +104,7 @@ describe(usePlayerKeyboard, () => {
         },
         onNext: null,
       });
+
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter");
@@ -120,6 +125,7 @@ describe(usePlayerKeyboard, () => {
           rightAction: "navigateNext",
         },
       });
+
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("ArrowRight");
@@ -136,6 +142,7 @@ describe(usePlayerKeyboard, () => {
           rightAction: null,
         },
       });
+
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("ArrowLeft");
@@ -183,6 +190,7 @@ describe(usePlayerKeyboard, () => {
           rightAction: null,
         },
       });
+
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("r");
@@ -208,6 +216,7 @@ describe(usePlayerKeyboard, () => {
           rightAction: null,
         },
       });
+
       renderHook(() => usePlayerKeyboard(opts));
 
       const input = document.createElement("input");
@@ -231,6 +240,7 @@ describe(usePlayerKeyboard, () => {
           rightAction: "navigateNext",
         },
       });
+
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter", { metaKey: true });
@@ -244,6 +254,7 @@ describe(usePlayerKeyboard, () => {
       const opts = buildOptions({
         keyboard: { canRestart: false, enterAction: "check", leftAction: null, rightAction: null },
       });
+
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter", { ctrlKey: true });
@@ -255,6 +266,7 @@ describe(usePlayerKeyboard, () => {
       const opts = buildOptions({
         keyboard: { canRestart: false, enterAction: "check", leftAction: null, rightAction: null },
       });
+
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter", { shiftKey: true });
@@ -266,6 +278,7 @@ describe(usePlayerKeyboard, () => {
       const opts = buildOptions({
         keyboard: { canRestart: false, enterAction: "check", leftAction: null, rightAction: null },
       });
+
       renderHook(() => usePlayerKeyboard(opts));
 
       fireKey("Enter", { altKey: true });
@@ -278,6 +291,7 @@ describe(usePlayerKeyboard, () => {
     const opts = buildOptions({
       keyboard: { canRestart: false, enterAction: "check", leftAction: null, rightAction: null },
     });
+
     const { unmount } = renderHook(() => usePlayerKeyboard(opts));
 
     unmount();

--- a/packages/player/vitest.config.mts
+++ b/packages/player/vitest.config.mts
@@ -5,11 +5,14 @@ import { defineConfig } from "vitest/config";
 
 const browserTests = ["src/**/*.browser.test.tsx"];
 const unitTests = ["src/**/*.test.ts", "src/**/*.test.tsx"];
+
 const nextImageShim = fileURLToPath(
   new URL("src/_test-utils/shims/next-image.tsx", import.meta.url),
 );
+
 const nextIntlShim = fileURLToPath(new URL("src/_test-utils/shims/next-intl.ts", import.meta.url));
 const nextLinkShim = fileURLToPath(new URL("src/_test-utils/shims/next-link.tsx", import.meta.url));
+
 const webHapticsShim = fileURLToPath(
   new URL("src/_test-utils/shims/web-haptics-react.ts", import.meta.url),
 );

--- a/packages/testing/src/fixtures/courses.ts
+++ b/packages/testing/src/fixtures/courses.ts
@@ -41,6 +41,7 @@ export async function courseCategoryFixture(attrs: Omit<CourseCategory, "id" | "
   const courseCategory = await prisma.courseCategory.create({
     data: { category: attrs.category, courseId: attrs.courseId },
   });
+
   return courseCategory;
 }
 

--- a/packages/testing/src/fixtures/orgs.ts
+++ b/packages/testing/src/fixtures/orgs.ts
@@ -42,6 +42,7 @@ export async function aiOrganizationFixture() {
         return existing;
       }
     }
+
     throw error;
   }
 }

--- a/packages/testing/src/fixtures/steps.ts
+++ b/packages/testing/src/fixtures/steps.ts
@@ -20,5 +20,6 @@ export async function stepFixture(attrs: {
       wordId: attrs.wordId,
     },
   });
+
   return step;
 }

--- a/packages/testing/src/fixtures/users.ts
+++ b/packages/testing/src/fixtures/users.ts
@@ -23,6 +23,7 @@ function userAttrs(attrs?: Partial<UserAttrs>): UserAttrs {
  */
 export async function userFixture(attrs?: Partial<UserAttrs>) {
   const params = userAttrs(attrs);
+
   const user = await prisma.user.create({
     data: {
       accounts: {

--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -226,6 +226,7 @@ function FieldDynamicDescription({
 
       return () => clearTimeout(timer);
     }
+
     setShowSuccess(false);
   }, [successMessage]);
 

--- a/packages/ui/src/components/image-upload.tsx
+++ b/packages/ui/src/components/image-upload.tsx
@@ -21,9 +21,11 @@ const ImageUploadContext = createContext<ImageUploadContextValue | undefined>(un
 
 function useImageUpload() {
   const context = useContext(ImageUploadContext);
+
   if (!context) {
     throw new Error("ImageUpload components must be used within an ImageUploadProvider.");
   }
+
   return context;
 }
 
@@ -99,6 +101,7 @@ function ImageUploadProvider({
   const handleFileSelect = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
+
       if (
         !(
           file &&

--- a/packages/ui/src/components/input-group.tsx
+++ b/packages/ui/src/components/input-group.tsx
@@ -53,6 +53,7 @@ function InputGroupAddon({
         if (event.target instanceof HTMLElement && event.target.closest("button")) {
           return;
         }
+
         event.currentTarget.parentElement?.querySelector("input")?.focus();
       }}
       role="group"

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -44,6 +44,7 @@ const SidebarContext = createContext<SidebarContextProps | undefined>(undefined)
 
 function useSidebar() {
   const context = useContext(SidebarContext);
+
   if (!context) {
     throw new Error("useSidebar must be used within a SidebarProvider.");
   }
@@ -71,9 +72,11 @@ function SidebarProvider({
   // We use openProp and setOpenProp for control from outside the component.
   const [open, setOpen] = useState(defaultOpen);
   const isOpen = openProp ?? open;
+
   const setIsOpen = useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {
       const openState = typeof value === "function" ? value(isOpen) : value;
+
       if (setOpenProp) {
         setOpenProp(openState);
       } else {
@@ -486,6 +489,7 @@ function SidebarMenuButton({
     tooltip?: string | React.ComponentProps<typeof TooltipContent>;
   } & VariantProps<typeof sidebarMenuButtonVariants>) {
   const { isMobile, state } = useSidebar();
+
   const comp = useRender({
     defaultTagName: "button",
     props: mergeProps<"button">(

--- a/packages/ui/src/components/sonner.tsx
+++ b/packages/ui/src/components/sonner.tsx
@@ -21,6 +21,7 @@ function isValidTheme(theme: string): theme is ValidTheme {
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme();
   const validTheme: ValidTheme = isValidTheme(theme) ? theme : "system";
+
   const style: CSSPropertiesWithVariables = {
     "--border-radius": "var(--radius)",
     "--normal-bg": "var(--popover)",

--- a/packages/ui/src/components/wizard.tsx
+++ b/packages/ui/src/components/wizard.tsx
@@ -240,6 +240,7 @@ export function useWizardKeyboard({
       if (isFirstStep) {
         return false;
       }
+
       onBack();
     },
     { mode: "none" },
@@ -251,6 +252,7 @@ export function useWizardKeyboard({
       if (!canProceed || isLastStep) {
         return false;
       }
+
       onNext();
     },
     { mode: "none" },

--- a/packages/utils/src/aggregation.ts
+++ b/packages/utils/src/aggregation.ts
@@ -7,6 +7,7 @@ const SUNDAY_DAYS_SINCE_MONDAY = 6;
 function getMondayOfWeek(date: Date): Date {
   const dayOfWeek = date.getUTCDay();
   const daysSinceMonday = dayOfWeek === 0 ? SUNDAY_DAYS_SINCE_MONDAY : dayOfWeek - 1;
+
   return new Date(
     Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() - daysSinceMonday),
   );
@@ -52,6 +53,7 @@ export function aggregateByPeriod<T extends { date: Date }>(
   for (const point of dataPoints) {
     const key = getKey(point.date);
     const existing = map.get(key);
+
     if (existing) {
       existing.total += getValue(point);
       existing.count += 1;
@@ -81,6 +83,7 @@ export function aggregateScoreByPeriod(
   for (const point of dataPoints) {
     const key = getKey(point.date);
     const existing = map.get(key);
+
     if (existing) {
       existing.correct += point.correct;
       existing.incorrect += point.incorrect;

--- a/packages/utils/src/belt-level.test.ts
+++ b/packages/utils/src/belt-level.test.ts
@@ -5,6 +5,7 @@ describe(calculateBeltLevel, () => {
   describe("white belt (250 BP per level)", () => {
     it("0 BP returns White 1 with 250 BP to next", () => {
       const result = calculateBeltLevel(0);
+
       expect(result).toStrictEqual({
         bpPerLevel: 250,
         bpToNextLevel: 250,
@@ -17,6 +18,7 @@ describe(calculateBeltLevel, () => {
 
     it("249 BP returns White 1 with 1 BP to next", () => {
       const result = calculateBeltLevel(249);
+
       expect(result).toStrictEqual({
         bpPerLevel: 250,
         bpToNextLevel: 1,
@@ -29,6 +31,7 @@ describe(calculateBeltLevel, () => {
 
     it("250 BP returns White 2 with 250 BP to next", () => {
       const result = calculateBeltLevel(250);
+
       expect(result).toStrictEqual({
         bpPerLevel: 250,
         bpToNextLevel: 250,
@@ -41,6 +44,7 @@ describe(calculateBeltLevel, () => {
 
     it("2250 BP returns White 10 with 250 BP to next", () => {
       const result = calculateBeltLevel(2250);
+
       expect(result).toStrictEqual({
         bpPerLevel: 250,
         bpToNextLevel: 250,
@@ -53,6 +57,7 @@ describe(calculateBeltLevel, () => {
 
     it("2499 BP returns White 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(2499);
+
       expect(result).toStrictEqual({
         bpPerLevel: 250,
         bpToNextLevel: 1,
@@ -67,6 +72,7 @@ describe(calculateBeltLevel, () => {
   describe("yellow belt (500 BP per level)", () => {
     it("2500 BP returns Yellow 1 with 500 BP to next", () => {
       const result = calculateBeltLevel(2500);
+
       expect(result).toStrictEqual({
         bpPerLevel: 500,
         bpToNextLevel: 500,
@@ -79,6 +85,7 @@ describe(calculateBeltLevel, () => {
 
     it("7000 BP returns Yellow 10 with 500 BP to next", () => {
       const result = calculateBeltLevel(7000);
+
       expect(result).toStrictEqual({
         bpPerLevel: 500,
         bpToNextLevel: 500,
@@ -91,6 +98,7 @@ describe(calculateBeltLevel, () => {
 
     it("7499 BP returns Yellow 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(7499);
+
       expect(result).toStrictEqual({
         bpPerLevel: 500,
         bpToNextLevel: 1,
@@ -105,6 +113,7 @@ describe(calculateBeltLevel, () => {
   describe("orange belt (1000 BP per level)", () => {
     it("7500 BP returns Orange 1 with 1000 BP to next", () => {
       const result = calculateBeltLevel(7500);
+
       expect(result).toStrictEqual({
         bpPerLevel: 1000,
         bpToNextLevel: 1000,
@@ -117,6 +126,7 @@ describe(calculateBeltLevel, () => {
 
     it("15000 BP returns Orange 8 with 500 BP to next (E2E test user)", () => {
       const result = calculateBeltLevel(15_000);
+
       expect(result).toStrictEqual({
         bpPerLevel: 1000,
         bpToNextLevel: 500,
@@ -129,6 +139,7 @@ describe(calculateBeltLevel, () => {
 
     it("17499 BP returns Orange 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(17_499);
+
       expect(result).toStrictEqual({
         bpPerLevel: 1000,
         bpToNextLevel: 1,
@@ -143,6 +154,7 @@ describe(calculateBeltLevel, () => {
   describe("green belt (5000 BP per level)", () => {
     it("17500 BP returns Green 1 with 5000 BP to next", () => {
       const result = calculateBeltLevel(17_500);
+
       expect(result).toStrictEqual({
         bpPerLevel: 5000,
         bpToNextLevel: 5000,
@@ -155,6 +167,7 @@ describe(calculateBeltLevel, () => {
 
     it("67499 BP returns Green 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(67_499);
+
       expect(result).toStrictEqual({
         bpPerLevel: 5000,
         bpToNextLevel: 1,
@@ -169,6 +182,7 @@ describe(calculateBeltLevel, () => {
   describe("blue belt (10000 BP per level)", () => {
     it("67500 BP returns Blue 1 with 10000 BP to next", () => {
       const result = calculateBeltLevel(67_500);
+
       expect(result).toStrictEqual({
         bpPerLevel: 10_000,
         bpToNextLevel: 10_000,
@@ -181,6 +195,7 @@ describe(calculateBeltLevel, () => {
 
     it("167499 BP returns Blue 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(167_499);
+
       expect(result).toStrictEqual({
         bpPerLevel: 10_000,
         bpToNextLevel: 1,
@@ -195,6 +210,7 @@ describe(calculateBeltLevel, () => {
   describe("purple belt (20000 BP per level)", () => {
     it("167500 BP returns Purple 1 with 20000 BP to next", () => {
       const result = calculateBeltLevel(167_500);
+
       expect(result).toStrictEqual({
         bpPerLevel: 20_000,
         bpToNextLevel: 20_000,
@@ -207,6 +223,7 @@ describe(calculateBeltLevel, () => {
 
     it("367499 BP returns Purple 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(367_499);
+
       expect(result).toStrictEqual({
         bpPerLevel: 20_000,
         bpToNextLevel: 1,
@@ -221,6 +238,7 @@ describe(calculateBeltLevel, () => {
   describe("brown belt (40000 BP per level)", () => {
     it("367500 BP returns Brown 1 with 40000 BP to next", () => {
       const result = calculateBeltLevel(367_500);
+
       expect(result).toStrictEqual({
         bpPerLevel: 40_000,
         bpToNextLevel: 40_000,
@@ -233,6 +251,7 @@ describe(calculateBeltLevel, () => {
 
     it("767499 BP returns Brown 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(767_499);
+
       expect(result).toStrictEqual({
         bpPerLevel: 40_000,
         bpToNextLevel: 1,
@@ -247,6 +266,7 @@ describe(calculateBeltLevel, () => {
   describe("red belt (60000 BP per level)", () => {
     it("767500 BP returns Red 1 with 60000 BP to next", () => {
       const result = calculateBeltLevel(767_500);
+
       expect(result).toStrictEqual({
         bpPerLevel: 60_000,
         bpToNextLevel: 60_000,
@@ -259,6 +279,7 @@ describe(calculateBeltLevel, () => {
 
     it("1367499 BP returns Red 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(1_367_499);
+
       expect(result).toStrictEqual({
         bpPerLevel: 60_000,
         bpToNextLevel: 1,
@@ -273,6 +294,7 @@ describe(calculateBeltLevel, () => {
   describe("gray belt (80000 BP per level)", () => {
     it("1367500 BP returns Gray 1 with 80000 BP to next", () => {
       const result = calculateBeltLevel(1_367_500);
+
       expect(result).toStrictEqual({
         bpPerLevel: 80_000,
         bpToNextLevel: 80_000,
@@ -285,6 +307,7 @@ describe(calculateBeltLevel, () => {
 
     it("2167499 BP returns Gray 10 with 1 BP to next", () => {
       const result = calculateBeltLevel(2_167_499);
+
       expect(result).toStrictEqual({
         bpPerLevel: 80_000,
         bpToNextLevel: 1,
@@ -299,6 +322,7 @@ describe(calculateBeltLevel, () => {
   describe("black belt (100000 BP per level)", () => {
     it("2167500 BP returns Black 1 with 100000 BP to next", () => {
       const result = calculateBeltLevel(2_167_500);
+
       expect(result).toStrictEqual({
         bpPerLevel: 100_000,
         bpToNextLevel: 100_000,
@@ -311,6 +335,7 @@ describe(calculateBeltLevel, () => {
 
     it("3067500 BP returns Black 10 at max level", () => {
       const result = calculateBeltLevel(3_067_500);
+
       expect(result).toStrictEqual({
         bpPerLevel: 100_000,
         bpToNextLevel: 0,
@@ -323,6 +348,7 @@ describe(calculateBeltLevel, () => {
 
     it("beyond max level still returns Black 10", () => {
       const result = calculateBeltLevel(5_000_000);
+
       expect(result).toStrictEqual({
         bpPerLevel: 100_000,
         bpToNextLevel: 0,
@@ -337,6 +363,7 @@ describe(calculateBeltLevel, () => {
   describe("edge cases", () => {
     it("negative BP is treated as 0", () => {
       const result = calculateBeltLevel(-100);
+
       expect(result).toStrictEqual({
         bpPerLevel: 250,
         bpToNextLevel: 250,

--- a/packages/utils/src/belt-level.ts
+++ b/packages/utils/src/belt-level.ts
@@ -59,6 +59,7 @@ export function calculateBeltLevel(totalBrainPower: number): BeltLevelResult {
   const currentBelt = findCurrentBelt(bp);
 
   const bpInCurrentBelt = bp - currentBelt.startBp;
+
   const level = Math.min(
     LEVELS_PER_COLOR,
     Math.floor(bpInCurrentBelt / currentBelt.bpPerLevel) + 1,

--- a/packages/utils/src/chart.test.ts
+++ b/packages/utils/src/chart.test.ts
@@ -38,6 +38,7 @@ describe(isValidChartPayload, () => {
     const isValidPayload = isValidChartPayload<{ name: string; value: number }>(payload);
 
     expect(isValidPayload).toBe(true);
+
     if (!isValidPayload) {
       throw new Error("Expected chart payload to be valid.");
     }
@@ -114,6 +115,7 @@ describe(buildChartData, () => {
       { count: 20, date: new Date(Date.UTC(2025, 8, 6)) },
       { count: 30, date: new Date(Date.UTC(2026, 1, 10)) },
     ];
+
     const result = buildChartData(crossYearPoints, "all", "en");
     expect(result.dataPoints).toHaveLength(2);
     expect(result.dataPoints.map((dp) => dp.value)).toStrictEqual([30, 30]);

--- a/packages/utils/src/date-ranges.ts
+++ b/packages/utils/src/date-ranges.ts
@@ -39,10 +39,13 @@ function endOfDay(date: Date): Date {
 
 function getMonthDateRanges(now: Date, offset: number): DateRanges {
   const currentStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset, 1));
+
   const currentEnd = endOfDay(
     new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset + 1, 0)),
   );
+
   const previousStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset - 1, 1));
+
   const previousEnd = endOfDay(
     new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset, 0)),
   );
@@ -58,12 +61,15 @@ function getHalfYearDateRanges(now: Date, offset: number): DateRanges {
     (Math.floor(now.getUTCMonth() / MONTHS_PER_HALF_YEAR) - offset) * MONTHS_PER_HALF_YEAR;
 
   const currentStart = new Date(Date.UTC(now.getUTCFullYear(), startMonth, 1));
+
   const currentEnd = endOfDay(
     new Date(Date.UTC(now.getUTCFullYear(), startMonth + MONTHS_PER_HALF_YEAR, 0)),
   );
+
   const previousStart = new Date(
     Date.UTC(now.getUTCFullYear(), startMonth - MONTHS_PER_HALF_YEAR, 1),
   );
+
   const previousEnd = endOfDay(new Date(Date.UTC(now.getUTCFullYear(), startMonth, 0)));
 
   return {
@@ -75,10 +81,13 @@ function getHalfYearDateRanges(now: Date, offset: number): DateRanges {
 function getYearDateRanges(now: Date, offset: number): DateRanges {
   const currentYear = now.getUTCFullYear() - offset;
   const currentStart = new Date(Date.UTC(currentYear, 0, 1));
+
   const currentEnd = endOfDay(
     new Date(Date.UTC(currentYear, DECEMBER_INDEX, LAST_DAY_OF_DECEMBER)),
   );
+
   const previousStart = new Date(Date.UTC(currentYear - 1, 0, 1));
+
   const previousEnd = endOfDay(
     new Date(Date.UTC(currentYear - 1, DECEMBER_INDEX, LAST_DAY_OF_DECEMBER)),
   );
@@ -141,7 +150,9 @@ export function getDefaultStartDate(startDateIso?: string): Date {
   if (startDateIso) {
     return new Date(startDateIso);
   }
+
   const now = new Date();
+
   return new Date(
     Date.UTC(
       now.getUTCFullYear(),

--- a/packages/utils/src/search.test.ts
+++ b/packages/utils/src/search.test.ts
@@ -6,6 +6,7 @@ type TestItem = { id: string; title: string };
 describe(mergeSearchResults, () => {
   it("returns exact match first when it exists", () => {
     const exactMatch: TestItem = { id: "1", title: "Law" };
+
     const containsMatches: TestItem[] = [
       { id: "2", title: "Criminal Law" },
       { id: "3", title: "Tax Law" },
@@ -30,6 +31,7 @@ describe(mergeSearchResults, () => {
 
   it("removes duplicate from contains matches when exact match exists", () => {
     const exactMatch: TestItem = { id: "1", title: "Law" };
+
     const containsMatches: TestItem[] = [
       { id: "1", title: "Law" },
       { id: "2", title: "Criminal Law" },
@@ -59,6 +61,7 @@ describe(mergeSearchResults, () => {
 
   it("preserves order of contains matches after exact match", () => {
     const exactMatch: TestItem = { id: "1", title: "Law" };
+
     const containsMatches: TestItem[] = [
       { id: "2", title: "Criminal Law" },
       { id: "3", title: "Tax Law" },

--- a/packages/utils/src/settled.test.ts
+++ b/packages/utils/src/settled.test.ts
@@ -5,6 +5,7 @@ describe(settledFailures, () => {
   it("returns every rejected reason and fulfilled error", () => {
     const rejectedError = new Error("rejected");
     const fulfilledError = new Error("fulfilled error");
+
     const results: PromiseSettledResult<unknown>[] = [
       { status: "fulfilled", value: "ok" },
       { reason: rejectedError, status: "rejected" },
@@ -47,6 +48,7 @@ describe(getSettledFailureError, () => {
 describe(throwSettledFailures, () => {
   it("throws AggregateError with every failure", () => {
     const errors = [new Error("first"), new Error("second")];
+
     const results: PromiseSettledResult<unknown>[] = [
       { reason: errors[0], status: "rejected" },
       { reason: errors[1], status: "rejected" },

--- a/packages/utils/src/string.test.ts
+++ b/packages/utils/src/string.test.ts
@@ -223,6 +223,7 @@ describe(toSlug, () => {
   it("truncates to SLUG_MAX_LENGTH", () => {
     const long = "a".repeat(100);
     expect(toSlug(long)).toBe("a".repeat(50));
+
     expect(
       toSlug("Introduction to Conditional Probability and Bayesian Inference Methods"),
     ).toHaveLength(50);
@@ -243,6 +244,7 @@ describe(deduplicateSlugs, () => {
 
   it("appends counter suffix to duplicate slugs", () => {
     const items = [{ slug: "x" }, { slug: "x" }, { slug: "x" }];
+
     expect(deduplicateSlugs(items)).toStrictEqual([
       { slug: "x" },
       { slug: "x-1" },
@@ -257,6 +259,7 @@ describe(deduplicateSlugs, () => {
 
   it("avoids collision with pre-existing slugs", () => {
     const items = [{ slug: "x" }, { slug: "x" }, { slug: "x-1" }];
+
     expect(deduplicateSlugs(items)).toStrictEqual([
       { slug: "x" },
       { slug: "x-2" },
@@ -269,6 +272,7 @@ describe(deduplicateSlugs, () => {
       { slug: "a", title: "A" },
       { slug: "a", title: "B" },
     ];
+
     const result = deduplicateSlugs(items);
     expect(result[0]).toStrictEqual({ slug: "a", title: "A" });
     expect(result[1]).toStrictEqual({ slug: "a-1", title: "B" });

--- a/packages/utils/src/subscription.ts
+++ b/packages/utils/src/subscription.ts
@@ -62,6 +62,7 @@ export function getPlanTier(planName: string | null): number {
   if (!planName) {
     return 0;
   }
+
   return ALL_SUBSCRIPTION_PLANS.find((plan) => plan.name === planName)?.tier ?? 0;
 }
 


### PR DESCRIPTION
## Summary
- Add a custom Oxlint layout rule that inserts blank lines around adjacent multiline statements
- Skip imports, exports, and gaps with comments so `oxfmt` keeps owning module layout
- Enable the rule in the shared Oxlint config and apply the autofix across the repo

## Testing
- `oxfmt --check` passed
- `oxlint --quiet .` passed
- `git diff --check` passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a custom `oxlint` rule to pad adjacent multiline statements with blank lines and enables it repo-wide. Only formatting changed; imports/exports and comment-separated gaps are left to `oxfmt`.

- **New Features**
  - Added `zoonk/padding-around-multiline-statements` to `.oxlintrc.json`.
  - Skips imports/exports and comment-separated blocks so `oxfmt` keeps module layout.
  - Applied autofix across the repo with no runtime or logic changes.

<sup>Written for commit b6246db6062037d346fa05acf7e1545496db441e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

