### PR TITLE
chore: disable vercel analytics logs

### DIFF
--- a/apps/blog/src/app/layout.tsx
+++ b/apps/blog/src/app/layout.tsx
@@ -35,7 +35,7 @@ export default function RootLayout({ children }: LayoutProps<"/">) {
           </footer>
         </div>
 
-        <Analytics />
+        <Analytics debug={false} />
       </body>
     </html>
   );

--- a/apps/main/src/app/layout.tsx
+++ b/apps/main/src/app/layout.tsx
@@ -26,7 +26,7 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
           <NuqsAdapter>
             <NextIntlClientProvider>{children}</NextIntlClientProvider>
           </NuqsAdapter>
-          <Analytics />
+          <Analytics debug={false} />
           <Toaster />
         </body>
       </HtmlDocument>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable Vercel Analytics debug logs in `apps/blog` and `apps/main` by setting `<Analytics debug={false} />` to reduce console noise.

<sup>Written for commit 881b90c1e310e83a579dec053f25c425e70ca484. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

