### PR TITLE
feat(api): add current user endpoints

### DIFF
--- a/apps/api/e2e/docs.test.ts
+++ b/apps/api/e2e/docs.test.ts
@@ -55,6 +55,7 @@ test.describe("API Documentation", () => {
     expect(spec.paths).toHaveProperty("/auth/health");
     expect(spec.paths).toHaveProperty("/courses/search");
     expect(spec.paths).toHaveProperty("/feedback");
+    expect(spec.paths).toHaveProperty("/me");
     expect(spec.paths).toHaveProperty("/workflows/course-generation/trigger");
     expect(spec.paths).toHaveProperty("/workflows/course-generation/status");
     expect(spec.paths).toHaveProperty("/workflows/chapter-generation/trigger");

--- a/apps/api/e2e/me.test.ts
+++ b/apps/api/e2e/me.test.ts
@@ -1,0 +1,230 @@
+import { randomUUID } from "node:crypto";
+import { type APIResponse, request } from "@playwright/test";
+import { prisma } from "@zoonk/db";
+import { expect, test } from "@zoonk/e2e/fixtures";
+import { getString } from "@zoonk/utils/json";
+
+const PASSWORD = "password123";
+
+/**
+ * Verifies the public API error envelope so tests assert the client contract
+ * instead of coupling to framework-specific response details.
+ */
+async function expectApiError({
+  code,
+  response,
+  status,
+}: {
+  code: string;
+  response: APIResponse;
+  status: number;
+}) {
+  expect(response.status()).toBe(status);
+
+  const body = await response.json();
+
+  expect(body.error.code).toBe(code);
+}
+
+/**
+ * Signs in through the public auth endpoint only to mint the session token, then
+ * returns a bearer-authenticated context so `/v1/me` is tested like native apps
+ * will call it instead of relying on browser cookies.
+ */
+async function createBearerApiContext({
+  baseURL,
+  uniqueId,
+  withSubscription = false,
+}: {
+  baseURL: string;
+  uniqueId: string;
+  withSubscription?: boolean;
+}) {
+  const email = `e2e-me-${uniqueId}@zoonk.test`;
+  const name = `E2E Me User ${uniqueId}`;
+  const username = `e2e_me_${uniqueId}`;
+  const signupContext = await request.newContext({ baseURL });
+
+  const signupResponse = await signupContext.post("/v1/auth/sign-up/email", {
+    data: { email, name, password: PASSWORD, username },
+  });
+
+  expect(signupResponse.ok()).toBe(true);
+  await signupContext.dispose();
+
+  const user = await prisma.user.findUniqueOrThrow({ where: { email } });
+
+  if (withSubscription) {
+    await prisma.subscription.create({
+      data: {
+        id: randomUUID(),
+        plan: "hobby",
+        provider: "zoonk",
+        referenceId: user.id,
+        status: "active",
+      },
+    });
+  }
+
+  const signInContext = await request.newContext({ baseURL });
+
+  const signInResponse = await signInContext.post("/v1/auth/sign-in/email", {
+    data: { email, password: PASSWORD },
+  });
+
+  expect(signInResponse.ok()).toBe(true);
+
+  const signInBody = await signInResponse.json();
+  await signInContext.dispose();
+
+  const token = getString(signInBody, "token");
+
+  if (!token) {
+    throw new Error("Sign-in response did not include a session token.");
+  }
+
+  const apiContext = await request.newContext({
+    baseURL,
+    extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+  });
+
+  return { apiContext, email, name, userId: user.id, username };
+}
+
+test.describe("Current User API", () => {
+  let baseURL: string;
+
+  test.beforeAll(() => {
+    baseURL = process.env.E2E_BASE_URL ?? "";
+  });
+
+  test.afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  test("rejects unauthenticated requests", async () => {
+    const apiContext = await request.newContext({ baseURL });
+    const response = await apiContext.get("/v1/me");
+
+    await expectApiError({ code: "UNAUTHORIZED", response, status: 401 });
+
+    await apiContext.dispose();
+  });
+
+  test("rejects unauthenticated profile updates", async () => {
+    const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.patch("/v1/me", { data: { name: "Unauthenticated User" } });
+
+    await expectApiError({ code: "UNAUTHORIZED", response, status: 401 });
+
+    await apiContext.dispose();
+  });
+
+  test("returns the signed-in user and account state", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const { apiContext, email, name, userId, username } = await createBearerApiContext({
+      baseURL,
+      uniqueId,
+      withSubscription: true,
+    });
+
+    const response = await apiContext.get("/v1/me");
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+
+    expect(body.user).toMatchObject({ email, id: userId, name, username });
+    expect(body.user.emailVerified).toBe(false);
+    expect(body.account.hasActiveSubscription).toBe(true);
+
+    expect(body.account.subscription).toMatchObject({
+      plan: "hobby",
+      provider: "zoonk",
+      status: "active",
+    });
+
+    await apiContext.dispose();
+  });
+
+  test("updates the signed-in user's profile", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { apiContext, email, userId } = await createBearerApiContext({ baseURL, uniqueId });
+    const nextName = `Updated Me User ${uniqueId}`;
+    const nextUsername = `updated_me_${uniqueId}`;
+
+    const updateResponse = await apiContext.patch("/v1/me", {
+      data: { name: nextName, username: nextUsername },
+    });
+
+    expect(updateResponse.status()).toBe(200);
+
+    const updateBody = await updateResponse.json();
+
+    expect(updateBody.user).toMatchObject({
+      email,
+      id: userId,
+      name: nextName,
+      username: nextUsername,
+    });
+
+    const user = await prisma.user.findUniqueOrThrow({ where: { id: userId } });
+
+    expect(user.name).toBe(nextName);
+    expect(user.username).toBe(nextUsername);
+
+    const getResponse = await apiContext.get("/v1/me");
+    const getBody = await getResponse.json();
+
+    expect(getBody.user.name).toBe(nextName);
+    expect(getBody.user.username).toBe(nextUsername);
+
+    await apiContext.dispose();
+  });
+
+  test("rejects empty profile updates", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { apiContext } = await createBearerApiContext({ baseURL, uniqueId });
+
+    const response = await apiContext.patch("/v1/me", { data: {} });
+
+    await expectApiError({ code: "VALIDATION_ERROR", response, status: 400 });
+
+    await apiContext.dispose();
+  });
+
+  test("rejects invalid username updates", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const { apiContext, userId, username } = await createBearerApiContext({ baseURL, uniqueId });
+
+    const response = await apiContext.patch("/v1/me", { data: { username: "" } });
+
+    await expectApiError({ code: "BAD_REQUEST", response, status: 400 });
+
+    const user = await prisma.user.findUniqueOrThrow({ where: { id: userId } });
+
+    expect(user.username).toBe(username);
+
+    await apiContext.dispose();
+  });
+
+  test("rejects username updates when the username is already taken", async () => {
+    const takenUniqueId = randomUUID().slice(0, 8);
+    const nextUniqueId = randomUUID().slice(0, 8);
+    const taken = await createBearerApiContext({ baseURL, uniqueId: takenUniqueId });
+    const next = await createBearerApiContext({ baseURL, uniqueId: nextUniqueId });
+
+    const response = await next.apiContext.patch("/v1/me", { data: { username: taken.username } });
+
+    await expectApiError({ code: "CONFLICT", response, status: 409 });
+
+    const user = await prisma.user.findUniqueOrThrow({ where: { id: next.userId } });
+
+    expect(user.username).toBe(next.username);
+
+    await taken.apiContext.dispose();
+    await next.apiContext.dispose();
+  });
+});

--- a/apps/api/src/app/v1/me/_utils/me-profile-update.ts
+++ b/apps/api/src/app/v1/me/_utils/me-profile-update.ts
@@ -1,0 +1,64 @@
+import { errors, httpStatus } from "@/lib/api-errors";
+import { getBetterAuthError } from "@/lib/better-auth-errors";
+import { type meUpdateSchema } from "@/lib/openapi/schemas/me";
+import { type z } from "zod";
+
+type ProfileUpdate = z.infer<typeof meUpdateSchema>;
+type UserUpdateBody = { name?: string; username?: string };
+
+/**
+ * Mirrors the main app's profile update behavior by always applying name
+ * changes while skipping a username write when the submitted username is
+ * already the current one.
+ */
+export function getUserUpdateBody({
+  currentUsername,
+  profile,
+}: {
+  currentUsername?: string | null;
+  profile: ProfileUpdate;
+}): UserUpdateBody {
+  return {
+    ...(profile.name !== undefined && { name: profile.name }),
+    ...(profile.username !== undefined &&
+      profile.username !== currentUsername && { username: profile.username }),
+  };
+}
+
+/**
+ * Detects idempotent profile updates, such as submitting the current username,
+ * so the route can return the current account document without asking Better
+ * Auth to update an empty body.
+ */
+export function hasUserUpdateBody(body: UserUpdateBody): boolean {
+  return Object.keys(body).length > 0;
+}
+
+/**
+ * Converts Better Auth update failures into the API app's standard error
+ * envelope while preserving the status distinctions clients can act on.
+ */
+export function getProfileUpdateErrorResponse(error: unknown) {
+  const authError = getBetterAuthError(error);
+
+  if (!authError) {
+    return errors.internal("Unable to update profile");
+  }
+
+  if (authError.statusCode === httpStatus.unauthorized) {
+    return errors.unauthorized();
+  }
+
+  if (authError.code === "USERNAME_IS_ALREADY_TAKEN") {
+    return errors.conflict("Username is already taken");
+  }
+
+  if (
+    authError.statusCode === httpStatus.badRequest ||
+    authError.statusCode === httpStatus.unprocessableEntity
+  ) {
+    return errors.badRequest(authError.message);
+  }
+
+  return errors.internal("Unable to update profile");
+}

--- a/apps/api/src/app/v1/me/_utils/me-response.ts
+++ b/apps/api/src/app/v1/me/_utils/me-response.ts
@@ -1,0 +1,64 @@
+import { type auth } from "@zoonk/core/auth";
+import { type Subscription } from "@zoonk/db";
+import { serializeDate } from "@zoonk/utils/date";
+
+type AuthSession = NonNullable<Awaited<ReturnType<typeof auth.api.getSession>>>;
+type ActiveSubscription = Subscription | null;
+
+/**
+ * Keeps `/v1/me` focused on the profile fields native clients need instead of
+ * exposing raw Better Auth session internals such as tokens and IP metadata.
+ */
+function serializeUser(user: AuthSession["user"]) {
+  return {
+    createdAt: serializeDate(user.createdAt) ?? "",
+    displayUsername: user.displayUsername ?? null,
+    email: user.email,
+    emailVerified: user.emailVerified,
+    id: user.id,
+    image: user.image ?? null,
+    name: user.name,
+    updatedAt: serializeDate(user.updatedAt) ?? "",
+    username: user.username ?? null,
+  };
+}
+
+/**
+ * Returns only account-state fields that are useful to clients for gating paid
+ * features, leaving provider-specific identifiers and billing internals private.
+ */
+function serializeSubscription(subscription: ActiveSubscription) {
+  if (!subscription) {
+    return null;
+  }
+
+  return {
+    cancelAtPeriodEnd: subscription.cancelAtPeriodEnd ?? null,
+    id: subscription.id,
+    periodEnd: serializeDate(subscription.periodEnd),
+    periodStart: serializeDate(subscription.periodStart),
+    plan: subscription.plan,
+    provider: subscription.provider,
+    status: subscription.status ?? null,
+  };
+}
+
+/**
+ * Builds the public `/v1/me` response from the fresh auth session and active
+ * subscription lookup so GET and PATCH return the exact same response shape.
+ */
+export function createMeResponse({
+  session,
+  subscription,
+}: {
+  session: AuthSession;
+  subscription: ActiveSubscription;
+}) {
+  return {
+    account: {
+      hasActiveSubscription: Boolean(subscription),
+      subscription: serializeSubscription(subscription),
+    },
+    user: serializeUser(session.user),
+  };
+}

--- a/apps/api/src/app/v1/me/route.ts
+++ b/apps/api/src/app/v1/me/route.ts
@@ -1,0 +1,102 @@
+import { errors } from "@/lib/api-errors";
+import { parseBody } from "@/lib/body-parser";
+import { meUpdateSchema } from "@/lib/openapi/schemas/me";
+import { auth } from "@zoonk/core/auth";
+import { getActiveSubscription } from "@zoonk/core/auth/subscription";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  getProfileUpdateErrorResponse,
+  getUserUpdateBody,
+  hasUserUpdateBody,
+} from "./_utils/me-profile-update";
+import { createMeResponse } from "./_utils/me-response";
+
+/**
+ * Reads the current session from the source session token instead of the cached
+ * user cookie so `/v1/me` immediately reflects profile updates.
+ */
+async function getCurrentSession(headers: Headers) {
+  return auth.api.getSession({ headers, query: { disableCookieCache: true } });
+}
+
+/**
+ * Mirrors the main app's subscription lookup: Better Auth decides which row is
+ * active, then Prisma reads the app-owned provider field from that row.
+ */
+async function getCurrentSubscription(headers: Headers) {
+  const activeSubscription = await getActiveSubscription(headers);
+
+  if (!activeSubscription) {
+    return null;
+  }
+
+  return prisma.subscription.findUnique({ where: { id: activeSubscription.id } });
+}
+
+/**
+ * Combines the current auth profile with billing state in one response so
+ * native clients can bootstrap account UI with a single authenticated request.
+ */
+async function getMeResponse({
+  headers,
+  session,
+}: {
+  headers: Headers;
+  session: NonNullable<Awaited<ReturnType<typeof getCurrentSession>>>;
+}) {
+  const subscription = await getCurrentSubscription(headers);
+  return NextResponse.json(createMeResponse({ session, subscription }));
+}
+
+/**
+ * Exposes the signed-in user's profile and account state to native clients.
+ */
+export async function GET(request: NextRequest) {
+  const session = await getCurrentSession(request.headers);
+
+  if (!session) {
+    return errors.unauthorized();
+  }
+
+  return getMeResponse({ headers: request.headers, session });
+}
+
+/**
+ * Updates the signed-in user's public profile using the same Better Auth path
+ * as the main app, including username validation and uniqueness checks.
+ */
+export async function PATCH(request: NextRequest) {
+  const session = await getCurrentSession(request.headers);
+
+  if (!session) {
+    return errors.unauthorized();
+  }
+
+  const parsed = await parseBody(request, meUpdateSchema);
+
+  if (!parsed.success) {
+    return errors.validation(parsed.error);
+  }
+
+  const body = getUserUpdateBody({ currentUsername: session.user.username, profile: parsed.data });
+
+  if (!hasUserUpdateBody(body)) {
+    return getMeResponse({ headers: request.headers, session });
+  }
+
+  const { error } = await safeAsync(() => auth.api.updateUser({ body, headers: request.headers }));
+
+  if (error) {
+    return getProfileUpdateErrorResponse(error);
+  }
+
+  const updatedSession = await getCurrentSession(request.headers);
+
+  if (!updatedSession) {
+    return errors.unauthorized();
+  }
+
+  return getMeResponse({ headers: request.headers, session: updatedSession });
+}

--- a/apps/api/src/lib/api-errors.ts
+++ b/apps/api/src/lib/api-errors.ts
@@ -1,30 +1,35 @@
 import { NextResponse } from "next/server";
 import { type z } from "zod";
 
-const HTTP_BAD_REQUEST = 400;
-const HTTP_UNAUTHORIZED = 401;
-const HTTP_PAYMENT_REQUIRED = 402;
-const HTTP_FORBIDDEN = 403;
-const HTTP_NOT_FOUND = 404;
-const HTTP_CONFLICT = 409;
-const HTTP_INTERNAL_ERROR = 500;
+export const httpStatus = {
+  badRequest: 400,
+  conflict: 409,
+  forbidden: 403,
+  internalError: 500,
+  notFound: 404,
+  paymentRequired: 402,
+  unauthorized: 401,
+  unprocessableEntity: 422,
+} as const;
 
 function errorResponse(code: string, message: string, status: number, details?: unknown) {
   return NextResponse.json({ error: { code, details, message } }, { status });
 }
 
 export const errors = {
-  conflict: (msg = "Resource already exists") => errorResponse("CONFLICT", msg, HTTP_CONFLICT),
-  forbidden: (msg = "Access denied") => errorResponse("FORBIDDEN", msg, HTTP_FORBIDDEN),
+  badRequest: (msg = "Invalid request") => errorResponse("BAD_REQUEST", msg, httpStatus.badRequest),
+  conflict: (msg = "Resource already exists") =>
+    errorResponse("CONFLICT", msg, httpStatus.conflict),
+  forbidden: (msg = "Access denied") => errorResponse("FORBIDDEN", msg, httpStatus.forbidden),
   internal: (msg = "Internal server error") =>
-    errorResponse("INTERNAL_ERROR", msg, HTTP_INTERNAL_ERROR),
-  notFound: (msg = "Resource not found") => errorResponse("NOT_FOUND", msg, HTTP_NOT_FOUND),
+    errorResponse("INTERNAL_ERROR", msg, httpStatus.internalError),
+  notFound: (msg = "Resource not found") => errorResponse("NOT_FOUND", msg, httpStatus.notFound),
   paymentRequired: (msg = "Active subscription required") =>
-    errorResponse("PAYMENT_REQUIRED", msg, HTTP_PAYMENT_REQUIRED),
+    errorResponse("PAYMENT_REQUIRED", msg, httpStatus.paymentRequired),
   unauthorized: (msg = "Authentication required") =>
-    errorResponse("UNAUTHORIZED", msg, HTTP_UNAUTHORIZED),
+    errorResponse("UNAUTHORIZED", msg, httpStatus.unauthorized),
   validation: (zodError: z.ZodError) => {
     const details = zodError.issues.map((issue) => ({ message: issue.message, path: issue.path }));
-    return errorResponse("VALIDATION_ERROR", "Invalid request", HTTP_BAD_REQUEST, details);
+    return errorResponse("VALIDATION_ERROR", "Invalid request", httpStatus.badRequest, details);
   },
 } as const;

--- a/apps/api/src/lib/better-auth-errors.ts
+++ b/apps/api/src/lib/better-auth-errors.ts
@@ -1,0 +1,23 @@
+import { getNumber, getString, isJsonObject } from "@zoonk/utils/json";
+
+type BetterAuthError = { code?: string; message: string; statusCode?: number };
+
+/**
+ * Narrows Better Auth's thrown APIError without importing its transitive
+ * better-call package into API routes that only need the public error details.
+ */
+export function getBetterAuthError(error: unknown): BetterAuthError | null {
+  if (getString(error, "name") !== "APIError") {
+    return null;
+  }
+
+  const body = isJsonObject(error) ? error.body : null;
+  const code = getString(body, "code");
+  const statusCode = getNumber(error, "statusCode");
+
+  return {
+    ...(code && { code }),
+    message: getString(body, "message") ?? getString(error, "message") ?? "Invalid auth request",
+    ...(statusCode && { statusCode }),
+  };
+}

--- a/apps/api/src/lib/openapi/document.ts
+++ b/apps/api/src/lib/openapi/document.ts
@@ -3,6 +3,7 @@ import { createDocument } from "zod-openapi";
 import { paginationSchema } from "./schemas/common";
 import { courseResultSchema, courseSearchQuerySchema } from "./schemas/courses";
 import { feedbackResponseSchema, feedbackSubmissionSchema } from "./schemas/feedback";
+import { meResponseSchema, meUpdateSchema } from "./schemas/me";
 import {
   chapterCompletionQuerySchema,
   chapterCompletionResponseSchema,
@@ -12,6 +13,9 @@ import {
   nextLessonResponseSchema,
 } from "./schemas/progress";
 import {
+  badRequestResponse,
+  conflictResponse,
+  unauthorizedResponse,
   validationErrorResponse,
   workflowStatusEndpoint,
   workflowTriggerEndpoint,
@@ -76,6 +80,33 @@ export const openAPIDocument = createDocument({
         },
         summary: "Submit a feedback message",
         tags: ["Feedback"],
+      },
+    },
+    "/me": {
+      get: {
+        responses: {
+          "200": {
+            content: { "application/json": { schema: meResponseSchema } },
+            description: "Current user and account state",
+          },
+          "401": unauthorizedResponse,
+        },
+        summary: "Get current user",
+        tags: ["Auth"],
+      },
+      patch: {
+        requestBody: { content: { "application/json": { schema: meUpdateSchema } } },
+        responses: {
+          "200": {
+            content: { "application/json": { schema: meResponseSchema } },
+            description: "Updated user and account state",
+          },
+          "400": badRequestResponse,
+          "401": unauthorizedResponse,
+          "409": conflictResponse,
+        },
+        summary: "Update current user",
+        tags: ["Auth"],
       },
     },
     "/progress/chapter-completion": {

--- a/apps/api/src/lib/openapi/schemas/me.ts
+++ b/apps/api/src/lib/openapi/schemas/me.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+/**
+ * Requires PATCH callers to send at least one profile field while still letting
+ * each field remain optional for partial updates.
+ */
+function hasProfileUpdate(data: { name?: string; username?: string }) {
+  return data.name !== undefined || data.username !== undefined;
+}
+
+export const meUpdateSchema = z
+  .object({
+    name: z.string().trim().min(1).optional().meta({ description: "Display name" }),
+    username: z
+      .string()
+      .trim()
+      .toLowerCase()
+      .optional()
+      .meta({ description: "Username shown in profile URLs and mentions" }),
+  })
+  .refine(hasProfileUpdate, { message: "At least one profile field must be provided" })
+  .meta({ id: "MeUpdate" });
+
+const meUserSchema = z
+  .object({
+    createdAt: z.string().meta({ description: "User creation timestamp" }),
+    displayUsername: z.string().nullable().meta({ description: "Display username" }),
+    email: z.email().meta({ description: "Email address" }),
+    emailVerified: z.boolean().meta({ description: "Whether the email has been verified" }),
+    id: z.string().meta({ description: "User ID" }),
+    image: z.string().nullable().meta({ description: "Profile image URL" }),
+    name: z.string().meta({ description: "Display name" }),
+    updatedAt: z.string().meta({ description: "User update timestamp" }),
+    username: z.string().nullable().meta({ description: "Normalized username" }),
+  })
+  .meta({ id: "MeUser" });
+
+const meSubscriptionSchema = z
+  .object({
+    cancelAtPeriodEnd: z
+      .boolean()
+      .nullable()
+      .meta({ description: "Whether cancellation is scheduled" }),
+    id: z.string().meta({ description: "Subscription ID" }),
+    periodEnd: z.string().nullable().meta({ description: "Current billing period end" }),
+    periodStart: z.string().nullable().meta({ description: "Current billing period start" }),
+    plan: z.string().meta({ description: "Subscription plan" }),
+    provider: z.string().meta({ description: "Billing provider" }),
+    status: z.string().nullable().meta({ description: "Subscription status" }),
+  })
+  .meta({ id: "MeSubscription" });
+
+export const meResponseSchema = z
+  .object({
+    account: z
+      .object({
+        hasActiveSubscription: z
+          .boolean()
+          .meta({ description: "Whether the account has an active or trialing subscription" }),
+        subscription: meSubscriptionSchema
+          .nullable()
+          .meta({ description: "Active subscription details, when present" }),
+      })
+      .meta({ description: "Account state for the current user" }),
+    user: meUserSchema,
+  })
+  .meta({ id: "MeResponse" });

--- a/apps/api/src/lib/openapi/schemas/responses.ts
+++ b/apps/api/src/lib/openapi/schemas/responses.ts
@@ -7,6 +7,21 @@ export const validationErrorResponse = {
   description: "Validation error",
 } as const;
 
+export const badRequestResponse = {
+  content: { "application/json": { schema: errorSchema } },
+  description: "Bad request",
+} as const;
+
+export const conflictResponse = {
+  content: { "application/json": { schema: errorSchema } },
+  description: "Conflict",
+} as const;
+
+export const unauthorizedResponse = {
+  content: { "application/json": { schema: errorSchema } },
+  description: "Authentication required",
+} as const;
+
 const subscriptionRequiredResponse = {
   content: { "application/json": { schema: errorSchema } },
   description: "Subscription required",

--- a/packages/utils/src/date.test.ts
+++ b/packages/utils/src/date.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseLocalDate } from "./date";
+import { parseLocalDate, serializeDate } from "./date";
 
 describe(parseLocalDate, () => {
   it("parses a valid YYYY-MM-DD string to UTC midnight", () => {
@@ -27,5 +27,22 @@ describe(parseLocalDate, () => {
   it("handles leap day", () => {
     const result = parseLocalDate("2028-02-29");
     expect(result).toStrictEqual(new Date(Date.UTC(2028, 1, 29)));
+  });
+});
+
+describe(serializeDate, () => {
+  it("serializes Date objects as ISO strings", () => {
+    const value = new Date("2026-05-04T12:30:00.000Z");
+
+    expect(serializeDate(value)).toBe("2026-05-04T12:30:00.000Z");
+  });
+
+  it("returns existing strings without changing them", () => {
+    expect(serializeDate("2026-05-04T12:30:00.000Z")).toBe("2026-05-04T12:30:00.000Z");
+  });
+
+  it("returns null for missing values", () => {
+    expect(serializeDate(null)).toBeNull();
+    expect(serializeDate()).toBeNull();
   });
 });

--- a/packages/utils/src/date.ts
+++ b/packages/utils/src/date.ts
@@ -9,3 +9,16 @@ export function parseLocalDate(dateString: string): Date {
   const parts = dateString.split("-").map(Number);
   return new Date(Date.UTC(parts[0] ?? 0, (parts[1] ?? 1) - 1, parts[2] ?? 1));
 }
+
+/**
+ * Normalizes date values that may already be serialized at an API boundary, so
+ * callers can safely mix Prisma Date objects and auth/session strings in one
+ * JSON response without special-casing each source.
+ */
+export function serializeDate(value?: Date | string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  return value instanceof Date ? value.toISOString() : value;
+}

--- a/packages/utils/src/json.test.ts
+++ b/packages/utils/src/json.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { getNumber } from "./json";
+
+describe(getNumber, () => {
+  it("reads a numeric property from an unknown object", () => {
+    expect(getNumber({ statusCode: 401 }, "statusCode")).toBe(401);
+  });
+
+  it("reads a numeric string property from an unknown object", () => {
+    expect(getNumber({ statusCode: "401" }, "statusCode")).toBe(401);
+  });
+
+  it("returns null when a string property is not numeric", () => {
+    expect(getNumber({ statusCode: "not-found" }, "statusCode")).toBeNull();
+  });
+
+  it("returns null when a string property is empty", () => {
+    expect(getNumber({ statusCode: " " }, "statusCode")).toBeNull();
+  });
+
+  it("returns null when the input is not an object", () => {
+    expect(getNumber(null, "statusCode")).toBeNull();
+  });
+});

--- a/packages/utils/src/json.ts
+++ b/packages/utils/src/json.ts
@@ -11,3 +11,51 @@ export function getString(body: unknown, key: string): string | null {
 
   return typeof value === "string" ? value : null;
 }
+
+/**
+ * Reads numeric fields from unknown JSON-like values without forcing callers to
+ * cast an object shape before the runtime value has proven it contains a number
+ * or a numeric string.
+ */
+export function getNumber(body: unknown, key: string): number | null {
+  if (!isJsonObject(body) || !(key in body)) {
+    return null;
+  }
+
+  const value = body[key];
+
+  return parseJsonNumber(value);
+}
+
+/**
+ * Accepts both real JSON numbers and stringified numbers because third-party
+ * libraries sometimes expose response metadata as strings even when callers
+ * need to compare it as a number.
+ */
+function parseJsonNumber(value: unknown): number | null {
+  const parsed = getJsonNumberCandidate(value);
+
+  return parsed !== null && Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Converts the supported JSON value shapes into a number candidate first, so
+ * validation stays in one place and each input type only handles normalization.
+ */
+function getJsonNumberCandidate(value: unknown): number | null {
+  if (typeof value === "number") {
+    return value;
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+
+  if (!normalized) {
+    return null;
+  }
+
+  return Number(normalized);
+}


### PR DESCRIPTION
Adds authenticated /v1/me endpoints for retrieving and updating the current user's profile and account state.

Closes #1338
Closes #1339

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add authenticated `/v1/me` GET and PATCH endpoints to return and update the signed-in user's profile and subscription state. Updates OpenAPI docs and adds full e2e coverage.

- **New Features**
  - GET `/v1/me`: returns `user` and `account` (with `hasActiveSubscription` and `subscription`), reading the session from the bearer token; returns `401 UNAUTHORIZED` for unauthenticated calls.
  - PATCH `/v1/me`: partial updates for `name` and/or `username` with validation; idempotent when no changes; `409 CONFLICT` if username is taken; `400 BAD_REQUEST` for invalid input; returns the same response shape as GET.
  - OpenAPI: documents `/me` GET/PATCH with `MeResponse` and `MeUpdate`, plus `400/401/409` error responses.

- **Refactors**
  - Standardized error helpers: added `httpStatus`, `badRequest`, and Better Auth error mapping via `getBetterAuthError`.
  - Response helpers: `createMeResponse` and serializers that use `@zoonk/utils` `serializeDate`.
  - Utils: added `getNumber` for JSON parsing and tests for `json` and `date`.

<sup>Written for commit 132eee2714ed0cb760d991e054596db999a04a9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

