### PR TITLE
feat(api): generate all course chapters

### DIFF
--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.test.ts
@@ -140,7 +140,7 @@ describe(chapterGenerationWorkflow, () => {
   });
 
   describe("happy path", () => {
-    it("calls lessonGenerationWorkflow with first lesson's ID", async () => {
+    it("calls lessonGenerationWorkflow with the first lesson's ID for the first chapter", async () => {
       const title = `Lesson Gen Chapter ${randomUUID()}`;
 
       const chapter = await chapterFixture({
@@ -157,7 +157,7 @@ describe(chapterGenerationWorkflow, () => {
         prisma.chapter.findUnique({ where: { id: chapter.id } }),
       ]);
 
-      expect(lessonGenerationWorkflow).toHaveBeenCalledWith(lessons[0]?.id);
+      expect(lessonGenerationWorkflow).toHaveBeenCalledExactlyOnceWith(lessons[0]?.id);
       expect(lessons.every((lesson) => lesson.imageUrl === null)).toBe(true);
 
       expect(dbChapter?.imageUrl).toBe(
@@ -169,7 +169,30 @@ describe(chapterGenerationWorkflow, () => {
       );
     });
 
-    it("sets chapter as completed before the first lesson generation runs", async () => {
+    it("does not call lessonGenerationWorkflow for later course chapters", async () => {
+      const title = `Later Chapter ${randomUUID()}`;
+
+      const chapter = await chapterFixture({
+        courseId: course.id,
+        generationStatus: "pending",
+        organizationId,
+        position: 1,
+        title,
+      });
+
+      await chapterGenerationWorkflow(chapter.id);
+
+      const [lessons, dbChapter] = await Promise.all([
+        prisma.lesson.findMany({ orderBy: { position: "asc" }, where: { chapterId: chapter.id } }),
+        prisma.chapter.findUnique({ where: { id: chapter.id } }),
+      ]);
+
+      expect(lessonGenerationWorkflow).not.toHaveBeenCalled();
+      expect(lessons).toHaveLength(5);
+      expect(dbChapter?.generationStatus).toBe("completed");
+    });
+
+    it("sets chapter as completed before lesson generation runs", async () => {
       const title = `Completed Before Lesson Gen ${randomUUID()}`;
 
       const chapter = await chapterFixture({

--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.ts
@@ -44,8 +44,8 @@ async function generateChapterShellContent(
 
 /**
  * Creates the chapter thumbnail and lesson rows, then marks the chapter as
- * completed. The first lesson generation starts only after this chapter shell
- * is fully ready.
+ * completed. Lesson content generation starts only after this chapter shell is
+ * fully ready.
  */
 async function generateLessonsAndCompleteChapter({
   context,
@@ -60,6 +60,37 @@ async function generateLessonsAndCompleteChapter({
   await setChapterAsCompletedStep({ context, imageUrl, workflowRunId });
 
   return createdLessons;
+}
+
+/**
+ * Picks the first saved lesson by its authored position instead of relying on
+ * database return order from createManyAndReturn.
+ */
+function getFirstLesson(lessons: Lesson[]): Lesson | undefined {
+  return lessons.find((lesson) => lesson.position === 0);
+}
+
+/**
+ * Generates only the first lesson for the first chapter. Later chapter
+ * workflows stop after lesson-shell creation so the course has a full outline
+ * without spending AI work on locked future content.
+ */
+async function generateFirstChapterLesson({
+  context,
+  lessons,
+}: {
+  context: Awaited<ReturnType<typeof getChapterStep>>;
+  lessons: Lesson[];
+}): Promise<void> {
+  if (context.position !== 0) {
+    return;
+  }
+
+  const firstLesson = getFirstLesson(lessons);
+
+  if (firstLesson) {
+    await lessonGenerationWorkflow(firstLesson.id);
+  }
 }
 
 export async function chapterGenerationWorkflow(chapterId: string): Promise<void> {
@@ -100,11 +131,7 @@ export async function chapterGenerationWorkflow(chapterId: string): Promise<void
     },
   );
 
-  // Generate the first lesson outside chapter failure handling so lesson
-  // failures mark that lesson without rolling back the completed chapter plan.
-  const firstLesson = createdLessons[0];
-
-  if (firstLesson) {
-    await lessonGenerationWorkflow(firstLesson.id);
-  }
+  // Generate lesson content outside chapter failure handling so lesson failures
+  // mark that lesson without rolling back the completed chapter plan.
+  await generateFirstChapterLesson({ context, lessons: createdLessons });
 }

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
+import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
 import { generateChapterLessons } from "@zoonk/ai/tasks/chapters/lessons";
 import { generateAlternativeTitles } from "@zoonk/ai/tasks/courses/alternative-titles";
 import { generateCourseCategories } from "@zoonk/ai/tasks/courses/categories";
@@ -17,7 +18,7 @@ import {
 } from "@zoonk/testing/fixtures/courses";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { toSlug } from "@zoonk/utils/string";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getOrCreateCourse } from "./_internal/get-or-create-course";
 import { courseGenerationWorkflow } from "./course-generation-workflow";
 
@@ -118,6 +119,10 @@ describe(courseGenerationWorkflow, () => {
   beforeAll(async () => {
     const org = await aiOrganizationFixture();
     organizationId = org.id;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
   describe("early returns", () => {
@@ -233,7 +238,7 @@ describe(courseGenerationWorkflow, () => {
   });
 
   describe("happy path", () => {
-    it("triggers chapter generation for first chapter", async () => {
+    it("triggers chapter generation for every chapter and lesson generation for the first lesson", async () => {
       const title = `First Chapter Gen Course ${randomUUID()}`;
       const slug = toSlug(title);
 
@@ -246,7 +251,12 @@ describe(courseGenerationWorkflow, () => {
       await courseGenerationWorkflow(suggestion.id);
 
       const course = await prisma.course.findFirst({
-        include: { chapters: { include: { lessons: true }, orderBy: { position: "asc" } } },
+        include: {
+          chapters: {
+            include: { lessons: { orderBy: { position: "asc" } } },
+            orderBy: { position: "asc" },
+          },
+        },
         where: { slug },
       });
 
@@ -256,9 +266,13 @@ describe(courseGenerationWorkflow, () => {
       expect(firstChapter?.imageUrl).toBe("https://example.com/chapter/Chapter%201.webp");
 
       const secondChapter = course?.chapters[1];
-      expect(secondChapter?.generationStatus).toBe("pending");
-      expect(secondChapter?.lessons).toHaveLength(0);
-      expect(secondChapter?.imageUrl).toBeNull();
+      expect(secondChapter?.generationStatus).toBe("completed");
+      expect(secondChapter?.lessons).toHaveLength(5);
+      expect(secondChapter?.imageUrl).toBe("https://example.com/chapter/Chapter%202.webp");
+
+      expect(lessonGenerationWorkflow).toHaveBeenCalledExactlyOnceWith(
+        firstChapter?.lessons[0]?.id,
+      );
     });
   });
 
@@ -393,7 +407,7 @@ describe(courseGenerationWorkflow, () => {
       expect(errorEvent).toBeDefined();
     });
 
-    it("chapter generation errors don't mark course as failed", async () => {
+    it("chapter generation errors don't fail the course workflow or other chapters", async () => {
       vi.mocked(generateChapterLessons).mockRejectedValueOnce(
         new Error("Chapter generation failed"),
       );
@@ -407,9 +421,7 @@ describe(courseGenerationWorkflow, () => {
         title,
       });
 
-      await expect(courseGenerationWorkflow(suggestion.id)).rejects.toThrow(
-        "Chapter generation failed",
-      );
+      await expect(courseGenerationWorkflow(suggestion.id)).resolves.toBeUndefined();
 
       const course = await prisma.course.findFirst({
         include: { chapters: { orderBy: { position: "asc" } } },
@@ -418,8 +430,16 @@ describe(courseGenerationWorkflow, () => {
 
       expect(course?.generationStatus).toBe("completed");
 
-      const firstChapter = course?.chapters[0];
-      expect(firstChapter?.generationStatus).toBe("failed");
+      const failedChapters = course?.chapters.filter(
+        (chapter) => chapter.generationStatus === "failed",
+      );
+
+      const completedChapters = course?.chapters.filter(
+        (chapter) => chapter.generationStatus === "completed",
+      );
+
+      expect(failedChapters).toHaveLength(1);
+      expect(completedChapters).toHaveLength(1);
     });
   });
 });

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.ts
@@ -36,6 +36,15 @@ async function setupCourseContent({
   return chapters;
 }
 
+/**
+ * Starts every chapter workflow as one fan-out wave after the course shell is
+ * saved. Each chapter workflow owns its own failure state, so the course row can
+ * stay completed even when one or more chapters need a retry.
+ */
+async function generateCourseChapters(chapters: Chapter[]): Promise<void> {
+  await Promise.allSettled(chapters.map((chapter) => chapterGenerationWorkflow(chapter.id)));
+}
+
 export async function courseGenerationWorkflow(courseSuggestionId: string): Promise<void> {
   "use workflow";
 
@@ -104,9 +113,5 @@ export async function courseGenerationWorkflow(courseSuggestionId: string): Prom
   // Start chapter generation outside the course error handling.
   // Chapter generation has its own error handling that marks the chapter as failed.
   // We don't want chapter failures to mark the entire course as failed.
-  const firstChapter = chapters[0];
-
-  if (firstChapter) {
-    await chapterGenerationWorkflow(firstChapter.id);
-  }
+  await generateCourseChapters(chapters);
 }

--- a/packages/core/src/workflows/steps.ts
+++ b/packages/core/src/workflows/steps.ts
@@ -119,14 +119,14 @@ export const COURSE_COMPLETION_STEP: CourseStepName = "completeCourseSetup";
 
 /**
  * All step names the SSE stream can emit during chapter generation.
- * The chapter workflow also generates the first lesson, so the stream includes
- * both chapter and lesson step events.
+ * The first chapter workflow also generates lesson content, so the stream
+ * includes both chapter and lesson step events.
  */
 export type ChapterWorkflowStepName = ChapterStepName | LessonStepName | WorkflowErrorStepName;
 
 /**
  * All step names the SSE stream can emit during course generation.
- * The course workflow also generates the first chapter and lesson, so the
- * stream includes all downstream step events.
+ * The course workflow also generates all chapter shells and first-chapter
+ * lesson content, so the stream includes all downstream step events.
  */
 export type CourseWorkflowStepName = CourseStepName | ChapterWorkflowStepName;


### PR DESCRIPTION
## Summary

- generate chapter shells for every course chapter in parallel
- keep chapter workflow failures isolated with allSettled
- keep lesson generation limited to the first lesson of the first chapter

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate all course chapters in parallel and isolate failures, while limiting lesson content generation to the first lesson of the first chapter. This speeds up course setup and avoids a single chapter error failing the course.

- **New Features**
  - Fan-out chapter generation: run `chapterGenerationWorkflow` for every chapter via `Promise.allSettled`.
  - Chapter failures mark only that chapter; the course stays completed.
  - Only the first chapter triggers `lessonGenerationWorkflow` for its first lesson (picked by `position === 0`).
  - Updated tests and SSE step types to reflect parallel chapter shells and first-chapter-only lesson content.

<sup>Written for commit fba0ff0288f4140b33156cf82fa89e3d537a41fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

