### PR TITLE
feat(agents): add platform design guideline skills

### DIFF
--- a/.agents/skills/android-material-guidelines/SKILL.md
+++ b/.agents/skills/android-material-guidelines/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: android-material-guidelines
+description: Use when designing, reviewing, or implementing Android UI or features for phones, tablets, foldables, ChromeOS, desktop windowing, Wear OS, Android TV, Android for Cars, Android XR, widgets, Jetpack Compose, Material 3, Material Design, adaptive layouts, dynamic color, icons, dark theme, edge-to-edge UI, accessibility, or when porting web or iOS features to Android. Ensures current official Android Developers and Material Design guidance is checked and Android conventions are preferred over copying other platforms.
+license: MIT
+metadata:
+  author: zoonk
+  version: "1.0.0"
+---
+
+# Android Material Guidelines
+
+This skill is a workflow, not a frozen copy of Google's Android or Material Design docs. Google's official Android Developers and Material Design docs are the source of truth.
+
+## Required Workflow
+
+1. Identify every target surface: phone, tablet, foldable, ChromeOS, desktop windowing, Wear OS, Android TV, Android for Cars, Android XR, widgets, or other Android device categories.
+2. Read the current official Android and Material pages that match the feature, component, interaction, and form factor. Start with [references/official-links.md](references/official-links.md).
+3. If a Material page requires JavaScript, use the official Material sitemap to find the current page:
+   - `https://m3.material.io/sitemap.xml`
+4. Prefer Android and Material conventions first. Use custom UI only when Material components, Android system patterns, or form-factor guidance do not fit the product need.
+5. Before finishing, review the work against the relevant Android form-factor page, Material foundation pages, and component pages.
+
+## Product Rule
+
+Preserve product intent, not web or iOS implementation details. Zoonk's `main` app is a web app, and Apple apps have their own conventions. When porting a feature to Android, do not map the same layout, navigation, density, controls, or visual treatment by default. Design the native version for the Android surface, screen size, and input method in front of you.
+
+Examples:
+
+- Mobile Android should use Material 3, Android navigation patterns, edge-to-edge layout, system bars, touch targets, and adaptive layouts.
+- Tablets, foldables, ChromeOS, and desktop windowing should use window size classes, canonical layouts, panes, keyboard and pointer behavior, and resizable layouts.
+- Wear OS should favor glanceable, low-friction, wrist-sized interactions.
+- Android TV should optimize for focus, D-pad/remote input, distance from the screen, and clear selected states.
+- Android for Cars should follow car templates and driver-distraction constraints.
+- Android XR should use XR-specific spatial guidance instead of flattening a phone UI into a headset.
+
+## Design Defaults
+
+- Prefer Jetpack Compose with Material 3 components for new native Android UI unless the local app architecture requires Views.
+- Prefer Material color schemes, dynamic color where appropriate, semantic roles, typography, shape, motion, and design tokens.
+- Prefer Material Symbols or platform-standard icons for standard actions and objects. Use custom icons only when no official symbol communicates the concept.
+- Support dark theme, accessibility, font scaling, contrast, reduced motion, system gestures, edge-to-edge behavior, and proper system bar handling.
+- Use platform-provided components and AndroidX libraries before custom controls.
+- Keep platform differences intentional. A feature can share the same domain model and product goal across Android, Apple, and web while using different native UI on each platform.
+
+## Official Starting Points
+
+- Android Design and Plan: https://developer.android.com/design
+- Android UI Design: https://developer.android.com/design/ui
+- Android mobile design: https://developer.android.com/design/ui/mobile
+- Material Design 3: https://m3.material.io/
+- Material components overview: https://developer.android.com/design/ui/mobile/guides/components/material-overview
+- Material Design 3 in Compose: https://developer.android.com/develop/ui/compose/designsystems/material3
+- Material Design for Android Views: https://developer.android.com/develop/ui/views/theming/look-and-feel
+- Adaptive apps: https://developer.android.com/adaptive-apps

--- a/.agents/skills/android-material-guidelines/references/official-links.md
+++ b/.agents/skills/android-material-guidelines/references/official-links.md
@@ -1,0 +1,115 @@
+# Official Android and Material Design Links
+
+Use these links as entry points, then verify the current page content from Google before making or reviewing Android UI decisions.
+
+Source indexes:
+
+- https://developer.android.com/design
+- https://developer.android.com/design/ui
+- https://m3.material.io/sitemap.xml
+
+## Android Design
+
+- [Design and Plan](https://developer.android.com/design)
+- [UI Design](https://developer.android.com/design/ui)
+- [Mobile](https://developer.android.com/design/ui/mobile)
+- [Desktop experiences](https://developer.android.com/design/ui/desktop)
+- [XR Headsets and XR Glasses](https://developer.android.com/design/ui/xr)
+- [AI Glasses](https://developer.android.com/design/ui/ai-glasses)
+- [Widgets](https://developer.android.com/design/ui/widget)
+- [Wear OS](https://developer.android.com/design/ui/wear)
+- [Android TV](https://developer.android.com/design/ui/tv)
+- [Android for Cars](https://developer.android.com/design/ui/cars)
+- [Adaptive apps](https://developer.android.com/adaptive-apps)
+
+## Mobile Android
+
+- [10 Steps to Android](https://developer.android.com/design/ui/mobile/guides/foundations/translate-designs)
+- [Mobile accessibility](https://developer.android.com/design/ui/mobile/guides/foundations/accessibility)
+- [Material components overview](https://developer.android.com/design/ui/mobile/guides/components/material-overview)
+- [Mobile samples](https://developer.android.com/design/ui/mobile/samples)
+- [Android themes](https://developer.android.com/design/ui/mobile/guides/styles/themes)
+- [Window size classes](https://developer.android.com/develop/ui/compose/layouts/adaptive/window-size-classes)
+
+## Material Design 3
+
+- [Material Design 3](https://m3.material.io/)
+- [Get started](https://m3.material.io/get-started)
+- [Foundations](https://m3.material.io/foundations)
+- [Components](https://m3.material.io/components)
+- [Styles](https://m3.material.io/styles)
+- [Material Theme Builder](https://m3.material.io/theme-builder#/dynamic)
+
+## Material Foundations
+
+- [Adaptive design](https://m3.material.io/foundations/adaptive-design)
+- [Accessibility: color contrast](https://m3.material.io/foundations/designing/color-contrast)
+- [Design tokens](https://m3.material.io/foundations/design-tokens/overview)
+- [Gestures](https://m3.material.io/foundations/interaction/gestures)
+- [Inputs](https://m3.material.io/foundations/interaction/inputs)
+- [States](https://m3.material.io/foundations/interaction/states/overview)
+- [Window size classes](https://m3.material.io/foundations/layout/applying-layout/window-size-classes)
+- [Canonical layouts](https://m3.material.io/foundations/layout/canonical-layouts/overview)
+- [Spacing](https://m3.material.io/foundations/layout/understanding-layout/spacing)
+- [Bidirectionality and RTL](https://m3.material.io/foundations/layout/understanding-layout/bidirectionality-rtl)
+
+## Material Styles
+
+- [Color](https://m3.material.io/styles/color/overview)
+- [Dynamic color](https://m3.material.io/styles/color/dynamic-color/overview)
+- [Elevation](https://m3.material.io/styles/elevation/overview)
+- [Motion](https://m3.material.io/styles/motion/overview)
+- [Shape](https://m3.material.io/styles/shape/overview-principles)
+- [Typography](https://m3.material.io/styles/typography/overview)
+- [Icons](https://m3.material.io/styles/icons/overview)
+
+## Material Components
+
+- [All components](https://m3.material.io/components)
+- [App bars](https://m3.material.io/components/app-bars/overview)
+- [Badges](https://m3.material.io/components/badges/overview)
+- [Bottom sheets](https://m3.material.io/components/bottom-sheets/overview)
+- [Buttons](https://m3.material.io/components/buttons/overview)
+- [Button groups](https://m3.material.io/components/button-groups/overview)
+- [Cards](https://m3.material.io/components/cards/overview)
+- [Carousel](https://m3.material.io/components/carousel/overview)
+- [Checkbox](https://m3.material.io/components/checkbox/overview)
+- [Chips](https://m3.material.io/components/chips/overview)
+- [Date pickers](https://m3.material.io/components/date-pickers/overview)
+- [Dialogs](https://m3.material.io/components/dialogs/overview)
+- [Divider](https://m3.material.io/components/divider/overview)
+- [Extended FAB](https://m3.material.io/components/extended-fab/overview)
+- [FAB menu](https://m3.material.io/components/fab-menu/overview)
+- [Floating action button](https://m3.material.io/components/floating-action-button/overview)
+- [Icon buttons](https://m3.material.io/components/icon-buttons/overview)
+- [Lists](https://m3.material.io/components/lists/overview)
+- [Loading indicator](https://m3.material.io/components/loading-indicator/overview)
+- [Menus](https://m3.material.io/components/menus/overview)
+- [Navigation bar](https://m3.material.io/components/navigation-bar/overview)
+- [Navigation drawer](https://m3.material.io/components/navigation-drawer/overview)
+- [Navigation rail](https://m3.material.io/components/navigation-rail/overview)
+- [Progress indicators](https://m3.material.io/components/progress-indicators/overview)
+- [Radio button](https://m3.material.io/components/radio-button/overview)
+- [Search](https://m3.material.io/components/search/overview)
+- [Segmented buttons](https://m3.material.io/components/segmented-buttons/overview)
+- [Side sheets](https://m3.material.io/components/side-sheets/overview)
+- [Sliders](https://m3.material.io/components/sliders/overview)
+- [Snackbar](https://m3.material.io/components/snackbar/overview)
+- [Split button](https://m3.material.io/components/split-button/overview)
+- [Switch](https://m3.material.io/components/switch/overview)
+- [Tabs](https://m3.material.io/components/tabs/overview)
+- [Text fields](https://m3.material.io/components/text-fields/overview)
+- [Time pickers](https://m3.material.io/components/time-pickers/overview)
+- [Toolbars](https://m3.material.io/components/toolbars/overview)
+- [Tooltips](https://m3.material.io/components/tooltips/overview)
+
+For component-specific accessibility, behavior, and specs, use the matching Material component page with the selected component slug and the `accessibility`, `guidelines`, or `specs` suffix.
+
+## Implementation Docs
+
+- [Material Design 3 in Compose](https://developer.android.com/develop/ui/compose/designsystems/material3)
+- [Design systems in Compose](https://developer.android.com/develop/ui/compose/designsystems)
+- [Adopt Compose for teams](https://developer.android.com/develop/ui/compose/adopt)
+- [Material Design for Android Views](https://developer.android.com/develop/ui/views/theming/look-and-feel)
+- [Material Components for Android](https://github.com/material-components/material-components-android)
+- [Material Symbols and Icons](https://fonts.google.com/icons)

--- a/.agents/skills/apple-human-interface-guidelines/SKILL.md
+++ b/.agents/skills/apple-human-interface-guidelines/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: apple-human-interface-guidelines
+description: Use when designing, reviewing, or implementing any Apple-platform UI or feature for iOS, iPadOS, macOS, visionOS, tvOS, watchOS, SwiftUI, UIKit, AppKit, WatchKit, app icons, Dark Mode, SF Symbols, system colors, native controls, or when porting web features to Apple platforms. Ensures current official Apple Human Interface Guidelines are checked and platform conventions are preferred over copying web layouts.
+license: MIT
+metadata:
+  author: zoonk
+  version: "1.0.0"
+---
+
+# Apple Human Interface Guidelines
+
+This skill is a workflow, not a frozen copy of Apple's HIG. Apple's official docs are the source of truth. Use this skill to make sure Apple-platform work starts from current HIG guidance and native platform conventions.
+
+## Required Workflow
+
+1. Identify every target platform: iOS, iPadOS, macOS, visionOS, tvOS, and/or watchOS.
+2. Read the current official HIG pages that match the feature, component, interaction, and platform. Start with [references/official-links.md](references/official-links.md).
+3. If a page requires JavaScript, fetch the official JSON data instead:
+   - Index: `https://developer.apple.com/tutorials/data/index/design--human-interface-guidelines.json`
+   - Topic: `https://developer.apple.com/tutorials/data/design/human-interface-guidelines/<slug>.json`
+4. Choose the platform convention first. Only use custom UI when the system component, color, symbol, material, navigation pattern, or interaction truly does not fit the product need.
+5. Before finishing, review the work against the relevant platform page, foundation pages, and component or pattern pages.
+
+## Product Rule
+
+Preserve product intent, not web implementation details. Zoonk's `main` app is a web app; when porting a feature to an Apple app, do not map the same layout, navigation, density, controls, or visual treatment by default. Design the native version for the Apple platform and input method in front of you.
+
+Examples:
+
+- iOS and iPadOS should use native navigation, safe areas, sheets, tab bars/sidebar patterns, Dynamic Type, and touch-friendly controls where appropriate.
+- macOS should respect menu bar, window, toolbar, sidebar, keyboard, pointer, and multiwindow conventions.
+- visionOS should use spatial layout, depth, ornaments, focus, and immersive guidance instead of flattening the web layout into a window.
+- tvOS should optimize for focus, remote input, large viewing distance, and clear selection states.
+- watchOS should favor glanceable, compact, crown-aware interactions.
+
+## Design Defaults
+
+- Prefer system colors, semantic colors, materials, typography, spacing, controls, and navigation structures.
+- Prefer SF Symbols for standard actions and objects. Use custom symbols only when no platform symbol communicates the concept.
+- Support Dark Mode with semantic colors instead of hardcoded light or dark values.
+- Respect safe areas, Dynamic Type, VoiceOver, reduced motion, contrast settings, platform gestures, pointer/focus behavior, and input-specific affordances.
+- Use platform-provided components before custom components.
+- Keep platform differences intentional. A feature can share the same domain model and product goal across Apple platforms while using different native UI on each platform.
+
+## Official Starting Points
+
+- Human Interface Guidelines: https://developer.apple.com/design/human-interface-guidelines
+- Apple Design: https://developer.apple.com/design/
+- Apple Design Resources: https://developer.apple.com/design/resources/
+- SF Symbols: https://developer.apple.com/sf-symbols/
+- Icon Composer: https://developer.apple.com/icon-composer/
+- Adopting Liquid Glass: https://developer.apple.com/documentation/TechnologyOverviews/adopting-liquid-glass

--- a/.agents/skills/apple-human-interface-guidelines/references/official-links.md
+++ b/.agents/skills/apple-human-interface-guidelines/references/official-links.md
@@ -1,0 +1,231 @@
+# Official Apple HIG Links
+
+Use these links as entry points, then verify the current page content from Apple before making or reviewing Apple-platform UI decisions.
+
+Source index:
+
+- https://developer.apple.com/design/human-interface-guidelines
+- https://developer.apple.com/tutorials/data/index/design--human-interface-guidelines.json
+
+## Core
+
+- [Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines)
+
+## Getting Started
+
+- [Getting started](https://developer.apple.com/design/human-interface-guidelines/getting-started)
+- [Designing for iOS](https://developer.apple.com/design/human-interface-guidelines/designing-for-ios)
+- [Designing for iPadOS](https://developer.apple.com/design/human-interface-guidelines/designing-for-ipados)
+- [Designing for macOS](https://developer.apple.com/design/human-interface-guidelines/designing-for-macos)
+- [Designing for tvOS](https://developer.apple.com/design/human-interface-guidelines/designing-for-tvos)
+- [Designing for visionOS](https://developer.apple.com/design/human-interface-guidelines/designing-for-visionos)
+- [Designing for watchOS](https://developer.apple.com/design/human-interface-guidelines/designing-for-watchos)
+- [Designing for games](https://developer.apple.com/design/human-interface-guidelines/designing-for-games)
+
+## Foundations
+
+- [Foundations](https://developer.apple.com/design/human-interface-guidelines/foundations)
+- [Accessibility](https://developer.apple.com/design/human-interface-guidelines/accessibility)
+- [App icons](https://developer.apple.com/design/human-interface-guidelines/app-icons)
+- [Branding](https://developer.apple.com/design/human-interface-guidelines/branding)
+- [Color](https://developer.apple.com/design/human-interface-guidelines/color)
+- [Dark Mode](https://developer.apple.com/design/human-interface-guidelines/dark-mode)
+- [Icons](https://developer.apple.com/design/human-interface-guidelines/icons)
+- [Images](https://developer.apple.com/design/human-interface-guidelines/images)
+- [Immersive experiences](https://developer.apple.com/design/human-interface-guidelines/immersive-experiences)
+- [Inclusion](https://developer.apple.com/design/human-interface-guidelines/inclusion)
+- [Layout](https://developer.apple.com/design/human-interface-guidelines/layout)
+- [Materials](https://developer.apple.com/design/human-interface-guidelines/materials)
+- [Motion](https://developer.apple.com/design/human-interface-guidelines/motion)
+- [Privacy](https://developer.apple.com/design/human-interface-guidelines/privacy)
+- [Right to left](https://developer.apple.com/design/human-interface-guidelines/right-to-left)
+- [SF Symbols](https://developer.apple.com/design/human-interface-guidelines/sf-symbols)
+- [Spatial layout](https://developer.apple.com/design/human-interface-guidelines/spatial-layout)
+- [Typography](https://developer.apple.com/design/human-interface-guidelines/typography)
+- [Writing](https://developer.apple.com/design/human-interface-guidelines/writing)
+
+## Patterns
+
+- [Patterns](https://developer.apple.com/design/human-interface-guidelines/patterns)
+- [Charting data](https://developer.apple.com/design/human-interface-guidelines/charting-data)
+- [Collaboration and sharing](https://developer.apple.com/design/human-interface-guidelines/collaboration-and-sharing)
+- [Drag and drop](https://developer.apple.com/design/human-interface-guidelines/drag-and-drop)
+- [Entering data](https://developer.apple.com/design/human-interface-guidelines/entering-data)
+- [Feedback](https://developer.apple.com/design/human-interface-guidelines/feedback)
+- [File management](https://developer.apple.com/design/human-interface-guidelines/file-management)
+- [Going full screen](https://developer.apple.com/design/human-interface-guidelines/going-full-screen)
+- [Launching](https://developer.apple.com/design/human-interface-guidelines/launching)
+- [Live-viewing apps](https://developer.apple.com/design/human-interface-guidelines/live-viewing-apps)
+- [Loading](https://developer.apple.com/design/human-interface-guidelines/loading)
+- [Managing accounts](https://developer.apple.com/design/human-interface-guidelines/managing-accounts)
+- [Managing notifications](https://developer.apple.com/design/human-interface-guidelines/managing-notifications)
+- [Modality](https://developer.apple.com/design/human-interface-guidelines/modality)
+- [Multitasking](https://developer.apple.com/design/human-interface-guidelines/multitasking)
+- [Offering help](https://developer.apple.com/design/human-interface-guidelines/offering-help)
+- [Onboarding](https://developer.apple.com/design/human-interface-guidelines/onboarding)
+- [Playing audio](https://developer.apple.com/design/human-interface-guidelines/playing-audio)
+- [Playing haptics](https://developer.apple.com/design/human-interface-guidelines/playing-haptics)
+- [Playing video](https://developer.apple.com/design/human-interface-guidelines/playing-video)
+- [Printing](https://developer.apple.com/design/human-interface-guidelines/printing)
+- [Ratings and reviews](https://developer.apple.com/design/human-interface-guidelines/ratings-and-reviews)
+- [Searching](https://developer.apple.com/design/human-interface-guidelines/searching)
+- [Settings](https://developer.apple.com/design/human-interface-guidelines/settings)
+- [Undo and redo](https://developer.apple.com/design/human-interface-guidelines/undo-and-redo)
+- [Workouts](https://developer.apple.com/design/human-interface-guidelines/workouts)
+
+## Components
+
+- [Components](https://developer.apple.com/design/human-interface-guidelines/components)
+
+### Content
+
+- [Content](https://developer.apple.com/design/human-interface-guidelines/content)
+- [Charts](https://developer.apple.com/design/human-interface-guidelines/charts)
+- [Image views](https://developer.apple.com/design/human-interface-guidelines/image-views)
+- [Text views](https://developer.apple.com/design/human-interface-guidelines/text-views)
+- [Web views](https://developer.apple.com/design/human-interface-guidelines/web-views)
+
+### Layout and Organization
+
+- [Layout and organization](https://developer.apple.com/design/human-interface-guidelines/layout-and-organization)
+- [Boxes](https://developer.apple.com/design/human-interface-guidelines/boxes)
+- [Collections](https://developer.apple.com/design/human-interface-guidelines/collections)
+- [Column views](https://developer.apple.com/design/human-interface-guidelines/column-views)
+- [Disclosure controls](https://developer.apple.com/design/human-interface-guidelines/disclosure-controls)
+- [Labels](https://developer.apple.com/design/human-interface-guidelines/labels)
+- [Lists and tables](https://developer.apple.com/design/human-interface-guidelines/lists-and-tables)
+- [Lockups](https://developer.apple.com/design/human-interface-guidelines/lockups)
+- [Outline views](https://developer.apple.com/design/human-interface-guidelines/outline-views)
+- [Split views](https://developer.apple.com/design/human-interface-guidelines/split-views)
+- [Tab views](https://developer.apple.com/design/human-interface-guidelines/tab-views)
+
+### Menus and Actions
+
+- [Menus and actions](https://developer.apple.com/design/human-interface-guidelines/menus-and-actions)
+- [Activity views](https://developer.apple.com/design/human-interface-guidelines/activity-views)
+- [Buttons](https://developer.apple.com/design/human-interface-guidelines/buttons)
+- [Context menus](https://developer.apple.com/design/human-interface-guidelines/context-menus)
+- [Dock menus](https://developer.apple.com/design/human-interface-guidelines/dock-menus)
+- [Edit menus](https://developer.apple.com/design/human-interface-guidelines/edit-menus)
+- [Home Screen quick actions](https://developer.apple.com/design/human-interface-guidelines/home-screen-quick-actions)
+- [Menus](https://developer.apple.com/design/human-interface-guidelines/menus)
+- [Ornaments](https://developer.apple.com/design/human-interface-guidelines/ornaments)
+- [Pop-up buttons](https://developer.apple.com/design/human-interface-guidelines/pop-up-buttons)
+- [Pull-down buttons](https://developer.apple.com/design/human-interface-guidelines/pull-down-buttons)
+- [The menu bar](https://developer.apple.com/design/human-interface-guidelines/the-menu-bar)
+- [Toolbars](https://developer.apple.com/design/human-interface-guidelines/toolbars)
+
+### Navigation and Search
+
+- [Navigation and search](https://developer.apple.com/design/human-interface-guidelines/navigation-and-search)
+- [Path controls](https://developer.apple.com/design/human-interface-guidelines/path-controls)
+- [Search fields](https://developer.apple.com/design/human-interface-guidelines/search-fields)
+- [Sidebars](https://developer.apple.com/design/human-interface-guidelines/sidebars)
+- [Tab bars](https://developer.apple.com/design/human-interface-guidelines/tab-bars)
+- [Token fields](https://developer.apple.com/design/human-interface-guidelines/token-fields)
+
+### Presentation
+
+- [Presentation](https://developer.apple.com/design/human-interface-guidelines/presentation)
+- [Action sheets](https://developer.apple.com/design/human-interface-guidelines/action-sheets)
+- [Alerts](https://developer.apple.com/design/human-interface-guidelines/alerts)
+- [Page controls](https://developer.apple.com/design/human-interface-guidelines/page-controls)
+- [Panels](https://developer.apple.com/design/human-interface-guidelines/panels)
+- [Popovers](https://developer.apple.com/design/human-interface-guidelines/popovers)
+- [Scroll views](https://developer.apple.com/design/human-interface-guidelines/scroll-views)
+- [Sheets](https://developer.apple.com/design/human-interface-guidelines/sheets)
+- [Windows](https://developer.apple.com/design/human-interface-guidelines/windows)
+
+### Selection and Input
+
+- [Selection and input](https://developer.apple.com/design/human-interface-guidelines/selection-and-input)
+- [Color wells](https://developer.apple.com/design/human-interface-guidelines/color-wells)
+- [Combo boxes](https://developer.apple.com/design/human-interface-guidelines/combo-boxes)
+- [Digit entry views](https://developer.apple.com/design/human-interface-guidelines/digit-entry-views)
+- [Image wells](https://developer.apple.com/design/human-interface-guidelines/image-wells)
+- [Pickers](https://developer.apple.com/design/human-interface-guidelines/pickers)
+- [Segmented controls](https://developer.apple.com/design/human-interface-guidelines/segmented-controls)
+- [Sliders](https://developer.apple.com/design/human-interface-guidelines/sliders)
+- [Steppers](https://developer.apple.com/design/human-interface-guidelines/steppers)
+- [Text fields](https://developer.apple.com/design/human-interface-guidelines/text-fields)
+- [Toggles](https://developer.apple.com/design/human-interface-guidelines/toggles)
+- [Virtual keyboards](https://developer.apple.com/design/human-interface-guidelines/virtual-keyboards)
+
+### Status
+
+- [Status](https://developer.apple.com/design/human-interface-guidelines/status)
+- [Activity rings](https://developer.apple.com/design/human-interface-guidelines/activity-rings)
+- [Gauges](https://developer.apple.com/design/human-interface-guidelines/gauges)
+- [Progress indicators](https://developer.apple.com/design/human-interface-guidelines/progress-indicators)
+- [Rating indicators](https://developer.apple.com/design/human-interface-guidelines/rating-indicators)
+
+### System Experiences
+
+- [System experiences](https://developer.apple.com/design/human-interface-guidelines/system-experiences)
+- [App Shortcuts](https://developer.apple.com/design/human-interface-guidelines/app-shortcuts)
+- [Complications](https://developer.apple.com/design/human-interface-guidelines/complications)
+- [Controls](https://developer.apple.com/design/human-interface-guidelines/controls)
+- [Live Activities](https://developer.apple.com/design/human-interface-guidelines/live-activities)
+- [Notifications](https://developer.apple.com/design/human-interface-guidelines/notifications)
+- [Status bars](https://developer.apple.com/design/human-interface-guidelines/status-bars)
+- [Top Shelf](https://developer.apple.com/design/human-interface-guidelines/top-shelf)
+- [Watch faces](https://developer.apple.com/design/human-interface-guidelines/watch-faces)
+- [Widgets](https://developer.apple.com/design/human-interface-guidelines/widgets)
+
+## Inputs
+
+- [Inputs](https://developer.apple.com/design/human-interface-guidelines/inputs)
+- [Action button](https://developer.apple.com/design/human-interface-guidelines/action-button)
+- [Apple Pencil and Scribble](https://developer.apple.com/design/human-interface-guidelines/apple-pencil-and-scribble)
+- [Camera Control](https://developer.apple.com/design/human-interface-guidelines/camera-control)
+- [Digital Crown](https://developer.apple.com/design/human-interface-guidelines/digital-crown)
+- [Eyes](https://developer.apple.com/design/human-interface-guidelines/eyes)
+- [Focus and selection](https://developer.apple.com/design/human-interface-guidelines/focus-and-selection)
+- [Game controls](https://developer.apple.com/design/human-interface-guidelines/game-controls)
+- [Gestures](https://developer.apple.com/design/human-interface-guidelines/gestures)
+- [Gyroscope and accelerometer](https://developer.apple.com/design/human-interface-guidelines/gyro-and-accelerometer)
+- [Keyboards](https://developer.apple.com/design/human-interface-guidelines/keyboards)
+- [Nearby interactions](https://developer.apple.com/design/human-interface-guidelines/nearby-interactions)
+- [Pointing devices](https://developer.apple.com/design/human-interface-guidelines/pointing-devices)
+- [Remotes](https://developer.apple.com/design/human-interface-guidelines/remotes)
+
+## Technologies
+
+- [Technologies](https://developer.apple.com/design/human-interface-guidelines/technologies)
+- [AirPlay](https://developer.apple.com/design/human-interface-guidelines/airplay)
+- [Always On](https://developer.apple.com/design/human-interface-guidelines/always-on)
+- [App Clips](https://developer.apple.com/design/human-interface-guidelines/app-clips)
+- [Apple Pay](https://developer.apple.com/design/human-interface-guidelines/apple-pay)
+- [Augmented reality](https://developer.apple.com/design/human-interface-guidelines/augmented-reality)
+- [CareKit](https://developer.apple.com/design/human-interface-guidelines/carekit)
+- [CarPlay](https://developer.apple.com/design/human-interface-guidelines/carplay)
+- [Game Center](https://developer.apple.com/design/human-interface-guidelines/game-center)
+- [Generative AI](https://developer.apple.com/design/human-interface-guidelines/generative-ai)
+- [HealthKit](https://developer.apple.com/design/human-interface-guidelines/healthkit)
+- [HomeKit](https://developer.apple.com/design/human-interface-guidelines/homekit)
+- [iCloud](https://developer.apple.com/design/human-interface-guidelines/icloud)
+- [ID Verifier](https://developer.apple.com/design/human-interface-guidelines/id-verifier)
+- [iMessage apps and stickers](https://developer.apple.com/design/human-interface-guidelines/imessage-apps-and-stickers)
+- [In-app purchase](https://developer.apple.com/design/human-interface-guidelines/in-app-purchase)
+- [Live Photos](https://developer.apple.com/design/human-interface-guidelines/live-photos)
+- [Mac Catalyst](https://developer.apple.com/design/human-interface-guidelines/mac-catalyst)
+- [Machine learning](https://developer.apple.com/design/human-interface-guidelines/machine-learning)
+- [Maps](https://developer.apple.com/design/human-interface-guidelines/maps)
+- [NFC](https://developer.apple.com/design/human-interface-guidelines/nfc)
+- [Photo editing](https://developer.apple.com/design/human-interface-guidelines/photo-editing)
+- [ResearchKit](https://developer.apple.com/design/human-interface-guidelines/researchkit)
+- [SharePlay](https://developer.apple.com/design/human-interface-guidelines/shareplay)
+- [ShazamKit](https://developer.apple.com/design/human-interface-guidelines/shazamkit)
+- [Sign in with Apple](https://developer.apple.com/design/human-interface-guidelines/sign-in-with-apple)
+- [Siri](https://developer.apple.com/design/human-interface-guidelines/siri)
+- [Tap to Pay on iPhone](https://developer.apple.com/design/human-interface-guidelines/tap-to-pay-on-iphone)
+- [VoiceOver](https://developer.apple.com/design/human-interface-guidelines/voiceover)
+- [Wallet](https://developer.apple.com/design/human-interface-guidelines/wallet)
+
+## Related Official Docs
+
+- [Apple Design](https://developer.apple.com/design/)
+- [Apple Design Resources](https://developer.apple.com/design/resources/)
+- [SF Symbols](https://developer.apple.com/sf-symbols/)
+- [Icon Composer](https://developer.apple.com/icon-composer/)
+- [Adopting Liquid Glass](https://developer.apple.com/documentation/TechnologyOverviews/adopting-liquid-glass)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,18 @@ Some design preferences:
 
 For detailed UX guidelines (interactions, animation, layout, accessibility), see [.agents/skills/zoonk-design/SKILL.md](.agents/skills/zoonk-design/SKILL.md)
 
+## Apple Platforms
+
+- For any development targeting iOS, iPadOS, macOS, visionOS, tvOS, or watchOS, read [.agents/skills/apple-human-interface-guidelines/SKILL.md](.agents/skills/apple-human-interface-guidelines/SKILL.md) and follow Apple's Human Interface Guidelines.
+- Always prefer Apple platform conventions over copying the web app. The `main` app can define product intent, but native Apple apps should use platform-appropriate navigation, layout, controls, input behavior, and system integration for each target platform.
+- Prefer system colors, semantic colors, system materials, system typography, native controls, and SF Symbols when available. Avoid custom colors, custom symbols, and custom controls unless the platform component does not fit the product need.
+
+## Android Platforms
+
+- For any development targeting Android phones, tablets, foldables, ChromeOS, desktop windowing, Wear OS, Android TV, Android for Cars, Android XR, widgets, or other Android surfaces, read [.agents/skills/android-material-guidelines/SKILL.md](.agents/skills/android-material-guidelines/SKILL.md) and follow Google's Android and Material Design guidance.
+- Always prefer Android platform conventions over copying the web app or Apple apps. The `main` app can define product intent, but native Android apps should use Material 3, adaptive layouts, Android navigation patterns, system bars, input behavior, and form-factor-specific guidance.
+- Prefer Material components, Material color schemes, dynamic color where appropriate, Material Symbols, AndroidX libraries, and platform-provided behavior before custom colors, icons, controls, or gestures.
+
 ## Conventions
 
 - Prefer server components over client components. Only use client components when absolutely necessary


### PR DESCRIPTION
Adds Apple HIG and Android Material guideline skills, plus AGENTS.md references so platform development follows current official guidance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds new Apple HIG and Android Material skills to standardize native UI decisions and link to current official guidance. Updates AGENTS.md to require platform-first patterns for Apple and Android work.

- New Features
  - Added `.agents/skills/apple-human-interface-guidelines` with a workflow, design defaults, and an official links index.
  - Added `.agents/skills/android-material-guidelines` with a workflow, design defaults, and an official links index.
  - Updated `AGENTS.md` with Apple and Android sections that link to these skills and emphasize using native components, colors, icons, navigation, and form-factor guidance.

<sup>Written for commit 4b8d0af72e9538ef2e508e93fd9644cf43c0da71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

