### PR TITLE
fix(admin): guard stats data reads

### DIFF
--- a/apps/admin/src/app/(private)/layout.tsx
+++ b/apps/admin/src/app/(private)/layout.tsx
@@ -1,23 +1,12 @@
-import { getSession } from "@zoonk/core/users/session/get";
+import { requireAdminRouteAccess } from "@/lib/admin-guard";
 import { FullPageLoading } from "@zoonk/ui/components/loading";
 import { SidebarInset, SidebarProvider } from "@zoonk/ui/components/sidebar";
-import { redirect, unauthorized } from "next/navigation";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { Suspense } from "react";
 import { AppSidebar } from "./app-sidebar";
 
 async function PrivateLayoutContent({ children }: React.PropsWithChildren) {
-  const session = await getSession();
-
-  if (!session) {
-    redirect("/login");
-  }
-
-  const isAdmin = session.user.role === "admin";
-
-  if (!isAdmin) {
-    unauthorized();
-  }
+  await requireAdminRouteAccess();
 
   return (
     <NuqsAdapter>

--- a/apps/admin/src/data/stats/_utils/admin-stats-cache.ts
+++ b/apps/admin/src/data/stats/_utils/admin-stats-cache.ts
@@ -1,0 +1,17 @@
+import "server-only";
+import { requireAdminRouteAccess } from "@/lib/admin-guard";
+import { cache } from "react";
+
+/**
+ * Stats data can be fetched by leaf route segments while App Router reuses the
+ * shared private layout during client-side navigation. This wrapper keeps the
+ * admin check next to the Prisma reads and keeps React's per-render memoization.
+ */
+export function adminStatsCache<Args extends unknown[], Result>(
+  loadStats: (...args: Args) => Result | Promise<Result>,
+) {
+  return cache(async (...args: Args) => {
+    await requireAdminRouteAccess();
+    return loadStats(...args);
+  });
+}

--- a/apps/admin/src/data/stats/count-active-learners.ts
+++ b/apps/admin/src/data/stats/count-active-learners.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const countActiveLearners = cache(async (sevenDaysAgo: Date, thirtyDaysAgo: Date) => {
   const [last7DaysResult, last30DaysResult] = await Promise.all([

--- a/apps/admin/src/data/stats/count-content.ts
+++ b/apps/admin/src/data/stats/count-content.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const countContent = cache(async () => {
   const [courses, chapters, lessons, steps] = await Promise.all([

--- a/apps/admin/src/data/stats/count-courses.ts
+++ b/apps/admin/src/data/stats/count-courses.ts
@@ -1,5 +1,5 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const countCourses = cache(() => prisma.course.count());

--- a/apps/admin/src/data/stats/count-subscribers-by-plan.ts
+++ b/apps/admin/src/data/stats/count-subscribers-by-plan.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const countSubscribersByPlan = cache(async () => {
   const results = await prisma.subscription.groupBy({

--- a/apps/admin/src/data/stats/count-total-pending-reviews.ts
+++ b/apps/admin/src/data/stats/count-total-pending-reviews.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { countPendingReviews } from "@/data/review/count-pending-reviews";
-import { cache } from "react";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 
 export const countTotalPendingReviews = cache(async () => {
   const counts = await countPendingReviews();

--- a/apps/admin/src/data/stats/count-users.ts
+++ b/apps/admin/src/data/stats/count-users.ts
@@ -1,5 +1,5 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const countUsers = cache(() => prisma.user.count());

--- a/apps/admin/src/data/stats/get-accuracy-rate.ts
+++ b/apps/admin/src/data/stats/get-accuracy-rate.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getAccuracyRate = cache(async () => {
   const [total, correct] = await Promise.all([

--- a/apps/admin/src/data/stats/get-activation-rate.ts
+++ b/apps/admin/src/data/stats/get-activation-rate.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getActivationRate = cache(async () => {
   const [activatedResult, total] = await Promise.all([

--- a/apps/admin/src/data/stats/get-avg-lesson-time.ts
+++ b/apps/admin/src/data/stats/get-avg-lesson-time.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getAvgLessonTime = cache(async () => {
   const result = await prisma.lessonProgress.aggregate({

--- a/apps/admin/src/data/stats/get-avg-lessons-per-learner.ts
+++ b/apps/admin/src/data/stats/get-avg-lessons-per-learner.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getAvgLessonsPerLearner = cache(async () => {
   const result = await prisma.$queryRaw<[{ total: bigint; learners: bigint }]>`

--- a/apps/admin/src/data/stats/get-avg-time-by-lesson-kind.ts
+++ b/apps/admin/src/data/stats/get-avg-time-by-lesson-kind.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getAvgTimeByLessonKind = cache(async (start: Date, end: Date) => {
   const results = await prisma.$queryRaw<

--- a/apps/admin/src/data/stats/get-completion-rate.ts
+++ b/apps/admin/src/data/stats/get-completion-rate.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getCompletionRate = cache(async () => {
   const [started, completed] = await Promise.all([

--- a/apps/admin/src/data/stats/get-conversion-rate.ts
+++ b/apps/admin/src/data/stats/get-conversion-rate.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getConversionRate = cache(async () => {
   const [paid, total] = await Promise.all([

--- a/apps/admin/src/data/stats/get-daily-active-learners.ts
+++ b/apps/admin/src/data/stats/get-daily-active-learners.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getDailyActiveLearners = cache(async (start: Date, end: Date) => {
   const results = await prisma.$queryRaw<{ date: Date; count: bigint }[]>`

--- a/apps/admin/src/data/stats/get-daily-content-created.ts
+++ b/apps/admin/src/data/stats/get-daily-content-created.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export type DailyContentRow = {
   chapters: number;

--- a/apps/admin/src/data/stats/get-daily-signups.ts
+++ b/apps/admin/src/data/stats/get-daily-signups.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getDailySignups = cache(async (start: Date, end: Date) => {
   const results = await prisma.$queryRaw<{ date: Date; count: bigint }[]>`

--- a/apps/admin/src/data/stats/get-new-signups.ts
+++ b/apps/admin/src/data/stats/get-new-signups.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getNewSignups = cache(async (start: Date, end: Date) =>
   prisma.user.count({ where: { createdAt: { gte: start, lte: end } } }),

--- a/apps/admin/src/data/stats/get-period-accuracy-rate.ts
+++ b/apps/admin/src/data/stats/get-period-accuracy-rate.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getPeriodAccuracyRate = cache(async (start: Date, end: Date) => {
   const [total, correct] = await Promise.all([

--- a/apps/admin/src/data/stats/get-period-active-learners.ts
+++ b/apps/admin/src/data/stats/get-period-active-learners.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getPeriodActiveLearners = cache(async (start: Date, end: Date) => {
   const result = await prisma.$queryRaw<[{ count: bigint }]>`

--- a/apps/admin/src/data/stats/get-period-avg-lesson-time.ts
+++ b/apps/admin/src/data/stats/get-period-avg-lesson-time.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getPeriodAvgLessonTime = cache(async (start: Date, end: Date) => {
   const result = await prisma.lessonProgress.aggregate({

--- a/apps/admin/src/data/stats/get-period-completion-rate.ts
+++ b/apps/admin/src/data/stats/get-period-completion-rate.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getPeriodCompletionRate = cache(async (start: Date, end: Date) => {
   const where = { startedAt: { gte: start, lte: end } };

--- a/apps/admin/src/data/stats/get-period-content-created.ts
+++ b/apps/admin/src/data/stats/get-period-content-created.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getPeriodContentCreated = cache(async (start: Date, end: Date) => {
   const [courses, lessons] = await Promise.all([

--- a/apps/admin/src/data/stats/get-period-learning-time.ts
+++ b/apps/admin/src/data/stats/get-period-learning-time.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getPeriodLearningTime = cache(async (start: Date, end: Date) => {
   const result = await prisma.dailyProgress.aggregate({

--- a/apps/admin/src/data/stats/get-total-learning-time.ts
+++ b/apps/admin/src/data/stats/get-total-learning-time.ts
@@ -1,6 +1,6 @@
 import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
 import { prisma } from "@zoonk/db";
-import { cache } from "react";
 
 export const getTotalLearningTime = cache(async () => {
   const result = await prisma.dailyProgress.aggregate({ _sum: { timeSpentSeconds: true } });

--- a/apps/admin/src/lib/admin-guard.ts
+++ b/apps/admin/src/lib/admin-guard.ts
@@ -1,6 +1,12 @@
 import "server-only";
 import { getSession } from "@zoonk/core/users/session/get";
+import { redirect, unauthorized } from "next/navigation";
 
+/**
+ * Server actions need a hard authorization stop before mutating admin-only data.
+ * Throwing keeps these action handlers simple: nothing after this guard runs when
+ * the caller is not an admin.
+ */
 export async function assertAdmin() {
   const session = await getSession();
 
@@ -11,6 +17,28 @@ export async function assertAdmin() {
   return session;
 }
 
+/**
+ * Admin route renders should preserve the existing login redirect while still
+ * interrupting non-admin users before admin-only server components read data.
+ */
+export async function requireAdminRouteAccess() {
+  const session = await getSession();
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  if (session.user.role !== "admin") {
+    unauthorized();
+  }
+
+  return session;
+}
+
+/**
+ * Read-only admin data helpers use a boolean guard when the safest fallback is
+ * an empty result instead of interrupting the whole route render.
+ */
 export async function isAdmin() {
   const session = await getSession();
   return session?.user.role === "admin";


### PR DESCRIPTION
## Summary

- Move the private admin layout check into a shared route-access guard.
- Wrap admin stats data helpers so leaf route renders verify admin access before Prisma reads.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened admin stats data reads by enforcing an access guard on leaf loaders and moving the admin check into a shared route guard. Prevents non-admin reads during client-side navigation while keeping React caching behavior.

- **Bug Fixes**
  - Added `requireAdminRouteAccess` and used it in the private admin layout to keep login redirect and unauthorized handling.
  - Introduced `adminStatsCache` that runs the admin guard before each stats query and preserves React `cache` memoization; applied across all admin stats helpers.
  - Kept `assertAdmin` for server actions and `isAdmin` for read-only checks, with clearer docs.

<sup>Written for commit cdf1f2957b05714aa3a3d854147f67e688f04093. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

