### PR TITLE
fix(core): require public lessons for completion

### DIFF
--- a/packages/core/src/player/commands/_utils/durable-curriculum-completion-queries.ts
+++ b/packages/core/src/player/commands/_utils/durable-curriculum-completion-queries.ts
@@ -1,4 +1,4 @@
-import { type TransactionClient } from "@zoonk/db";
+import { type TransactionClient, getPublishedLessonWhere } from "@zoonk/db";
 
 type LessonCurriculumContext = { chapterId: string; courseId: string; lessonId: string };
 
@@ -9,8 +9,9 @@ export type PublishedLessonCompletionRow = {
 };
 
 /**
- * Completion sync starts from a lesson id and resolves the chapter and course
- * once so every later completion decision derives from the curriculum tree.
+ * Completion sync re-checks the published curriculum tree inside the write
+ * transaction. This prevents raw lesson ids from creating durable progress for
+ * draft courses, draft chapters, or draft lessons.
  */
 export async function getLessonCurriculumContext({
   lessonId,
@@ -19,13 +20,13 @@ export async function getLessonCurriculumContext({
   lessonId: string;
   tx: TransactionClient;
 }): Promise<LessonCurriculumContext> {
-  const lesson = await tx.lesson.findUnique({
+  const lesson = await tx.lesson.findFirst({
     select: { chapter: { select: { courseId: true } }, chapterId: true, id: true },
-    where: { id: lessonId },
+    where: getPublishedLessonWhere({ lessonWhere: { id: lessonId } }),
   });
 
   if (!lesson) {
-    throw new Error("Lesson not found");
+    throw new Error("Lesson is not completable");
   }
 
   return { chapterId: lesson.chapterId, courseId: lesson.chapter.courseId, lessonId: lesson.id };
@@ -54,10 +55,13 @@ export async function listPublishedCourseLessonCompletionRows({
     JOIN chapters ch
       ON ch.id = l.chapter_id
       AND ch.is_published = true
+    JOIN courses c
+      ON c.id = ch.course_id
+      AND c.is_published = true
     LEFT JOIN lesson_progress lp
       ON lp.lesson_id = l.id
       AND lp.user_id = ${userId}
-    WHERE ch.course_id = ${courseId}
+    WHERE c.id = ${courseId}
       AND l.is_published = true
   `;
 }
@@ -76,7 +80,7 @@ export async function listPublishedCourseChapters({
 }) {
   return tx.chapter.findMany({
     orderBy: { position: "asc" },
-    where: { courseId, isPublished: true },
+    where: { course: { isPublished: true }, courseId, isPublished: true },
   });
 }
 
@@ -96,7 +100,10 @@ export async function listDurableCourseLessonIds({
   const rows = await tx.lessonProgress.findMany({
     where: {
       completedAt: { not: null },
-      lesson: { chapter: { courseId, isPublished: true }, isPublished: true },
+      lesson: {
+        chapter: { course: { isPublished: true }, courseId, isPublished: true },
+        isPublished: true,
+      },
       userId,
     },
   });
@@ -119,7 +126,7 @@ export async function listDurableCourseChapterIds({
   userId: string;
 }): Promise<Set<string>> {
   const rows = await tx.chapterCompletion.findMany({
-    where: { chapter: { courseId, isPublished: true }, userId },
+    where: { chapter: { course: { isPublished: true }, courseId, isPublished: true }, userId },
   });
 
   return new Set(rows.map((row) => row.chapterId));

--- a/packages/core/src/player/commands/submit-lesson-completion.test.ts
+++ b/packages/core/src/player/commands/submit-lesson-completion.test.ts
@@ -36,10 +36,20 @@ describe(submitLessonCompletion, () => {
 
   beforeAll(async () => {
     org = await organizationFixture();
-    course = await courseFixture({ organizationId: org.id });
-    const chapter = await chapterFixture({ courseId: course.id, organizationId: org.id });
+    course = await courseFixture({ isPublished: true, organizationId: org.id });
 
-    lesson = await lessonFixture({ chapterId: chapter.id, kind: "quiz", organizationId: org.id });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: org.id,
+    });
+
+    lesson = await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      kind: "quiz",
+      organizationId: org.id,
+    });
 
     step = await stepFixture({
       content: {
@@ -99,6 +109,51 @@ describe(submitLessonCompletion, () => {
     expect(progress).not.toBeNull();
     expect(progress?.completedAt).not.toBeNull();
     expect(progress?.durationSeconds).toBe(15);
+  });
+
+  it("rolls back progress writes when the lesson tree is not completable", async () => {
+    const user = await userFixture();
+    const userId = user.id;
+
+    const draftCourse = await courseFixture({ organizationId: org.id });
+
+    const draftChapter = await chapterFixture({
+      courseId: draftCourse.id,
+      isPublished: true,
+      organizationId: org.id,
+    });
+
+    const draftLesson = await lessonFixture({
+      chapterId: draftChapter.id,
+      isPublished: true,
+      organizationId: org.id,
+    });
+
+    await expect(
+      submitLessonCompletion({
+        durationSeconds: 10,
+        lessonId: draftLesson.id,
+        localDate: todayLocalDate(),
+        score: { brainPower: 10, correctCount: 0, energyDelta: 0.1, incorrectCount: 0 },
+        startedAt: new Date(Date.now() - 10_000),
+        stepResults: [],
+        userId,
+      }),
+    ).rejects.toThrow("Lesson is not completable");
+
+    const [courseUser, dailyProgress, lessonProgress, userProgress] = await Promise.all([
+      prisma.courseUser.findUnique({ where: { courseUser: { courseId: draftCourse.id, userId } } }),
+      prisma.dailyProgress.findMany({ where: { userId } }),
+      prisma.lessonProgress.findUnique({
+        where: { userLesson: { lessonId: draftLesson.id, userId } },
+      }),
+      prisma.userProgress.findUnique({ where: { userId } }),
+    ]);
+
+    expect(courseUser).toBeNull();
+    expect(dailyProgress).toHaveLength(0);
+    expect(lessonProgress).toBeNull();
+    expect(userProgress).toBeNull();
   });
 
   it("marks lesson, chapter, and course as durably completed when the final lesson is completed", async () => {
@@ -283,6 +338,7 @@ describe(submitLessonCompletion, () => {
     const userId = user.id;
 
     const staticLesson = await lessonFixture({
+      isPublished: true,
       kind: "explanation",
       lessonId: lesson.id,
       organizationId: org.id,

--- a/packages/core/src/player/commands/submit-player-completion.test.ts
+++ b/packages/core/src/player/commands/submit-player-completion.test.ts
@@ -10,6 +10,20 @@ import { describe, expect, it } from "vitest";
 import { type CompletionInput } from "../contracts/completion-input-schema";
 import { submitPlayerCompletion } from "./submit-player-completion";
 
+type CompletableLessonVisibility = {
+  chapterIsPublished?: boolean;
+  courseIsPublished?: boolean;
+  lessonIsPublished?: boolean;
+  organizationKind?: string;
+};
+
+const inaccessibleLessonCases: { name: string; visibility: CompletableLessonVisibility }[] = [
+  { name: "course", visibility: { courseIsPublished: false } },
+  { name: "chapter", visibility: { chapterIsPublished: false } },
+  { name: "lesson", visibility: { lessonIsPublished: false } },
+  { name: "organization", visibility: { organizationKind: "school" } },
+];
+
 /**
  * Completion writes store a local calendar day alongside UTC timestamps so the
  * daily progress tables can aggregate by the learner's own timezone. Tests only
@@ -22,21 +36,25 @@ function todayLocalDate(): string {
 }
 
 /**
- * The shared completion command only needs a standard published curriculum path:
- * org -> course -> chapter. Keeping this setup centralized makes each test focus
- * on the lesson state it wants to verify.
+ * The shared completion command only needs a standard curriculum path:
+ * org -> course -> chapter. Visibility stays configurable so tests can verify
+ * that the command rejects non-public curriculum before writing progress.
  */
-async function createPublishedChapterContext() {
-  const organization = await organizationFixture({ kind: "brand" });
-  const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+async function createChapterContext(params: CompletableLessonVisibility = {}) {
+  const organization = await organizationFixture({ kind: params.organizationKind ?? "brand" });
 
-  const chapter = await chapterFixture({
-    courseId: course.id,
-    isPublished: true,
+  const course = await courseFixture({
+    isPublished: params.courseIsPublished ?? true,
     organizationId: organization.id,
   });
 
-  return { chapter, organization };
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: params.chapterIsPublished ?? true,
+    organizationId: organization.id,
+  });
+
+  return { chapter, course, organization };
 }
 
 /**
@@ -45,14 +63,15 @@ async function createPublishedChapterContext() {
  * follow-up effect planning without dragging in unrelated player variants.
  */
 async function createMultipleChoiceLesson(params: {
-  lessonId: string;
+  chapterId: string;
+  isPublished?: boolean;
   organizationId: string;
   position?: number;
 }) {
   const lesson = await lessonFixture({
-    isPublished: true,
+    chapterId: params.chapterId,
+    isPublished: params.isPublished ?? true,
     kind: "quiz",
-    lessonId: params.lessonId,
     organizationId: params.organizationId,
     position: params.position ?? 0,
   });
@@ -100,26 +119,108 @@ function buildCompletionInput(params: {
   };
 }
 
+/**
+ * Inaccessible completions must leave every progress table untouched. Reading
+ * the affected rows in one helper keeps the rejection test focused on the
+ * authorization boundary instead of repeating persistence details.
+ */
+async function readCompletionWrites(params: {
+  courseId: string;
+  lessonId: string;
+  stepId: string;
+  userId: string;
+}) {
+  const [
+    chapterCompletion,
+    courseCompletion,
+    courseUser,
+    dailyProgress,
+    lessonProgress,
+    stepAttempts,
+    userProgress,
+  ] = await Promise.all([
+    prisma.chapterCompletion.findMany({ where: { userId: params.userId } }),
+    prisma.courseCompletion.findMany({
+      where: { courseId: params.courseId, userId: params.userId },
+    }),
+    prisma.courseUser.findUnique({
+      where: { courseUser: { courseId: params.courseId, userId: params.userId } },
+    }),
+    prisma.dailyProgress.findMany({ where: { userId: params.userId } }),
+    prisma.lessonProgress.findUnique({
+      where: { userLesson: { lessonId: params.lessonId, userId: params.userId } },
+    }),
+    prisma.stepAttempt.findMany({ where: { stepId: params.stepId, userId: params.userId } }),
+    prisma.userProgress.findUnique({ where: { userId: params.userId } }),
+  ]);
+
+  return {
+    chapterCompletion,
+    courseCompletion,
+    courseUser,
+    dailyProgress,
+    lessonProgress,
+    stepAttempts,
+    userProgress,
+  };
+}
+
 describe(submitPlayerCompletion, () => {
   it("returns null when the submitted lesson no longer exists", async () => {
     const result = await submitPlayerCompletion({
       input: buildCompletionInput({ lessonId: randomUUID(), stepId: randomUUID() }),
-      userId: "missing-user-id",
+      userId: randomUUID(),
     });
 
     expect(result).toBeNull();
   });
 
+  it.each(inaccessibleLessonCases)(
+    "returns null without writing progress when the submitted $name is not publicly completable",
+    async (testCase) => {
+      const [user, context] = await Promise.all([
+        userFixture(),
+        createChapterContext(testCase.visibility),
+      ]);
+
+      const { lesson, step } = await createMultipleChoiceLesson({
+        chapterId: context.chapter.id,
+        isPublished: testCase.visibility.lessonIsPublished,
+        organizationId: context.organization.id,
+      });
+
+      const result = await submitPlayerCompletion({
+        input: buildCompletionInput({ lessonId: lesson.id, stepId: step.id }),
+        userId: user.id,
+      });
+
+      const writes = await readCompletionWrites({
+        courseId: context.course.id,
+        lessonId: lesson.id,
+        stepId: step.id,
+        userId: user.id,
+      });
+
+      expect(result).toBeNull();
+      expect(writes.chapterCompletion).toHaveLength(0);
+      expect(writes.courseCompletion).toHaveLength(0);
+      expect(writes.courseUser).toBeNull();
+      expect(writes.dailyProgress).toHaveLength(0);
+      expect(writes.lessonProgress).toBeNull();
+      expect(writes.stepAttempts).toHaveLength(0);
+      expect(writes.userProgress).toBeNull();
+    },
+  );
+
   it("persists completion and requests preloading when the next lesson needs generation", async () => {
     const [user, { chapter, organization }] = await Promise.all([
       userFixture(),
-      createPublishedChapterContext(),
+      createChapterContext(),
     ]);
 
     const [currentLesson, nextLesson] = await Promise.all([
-      lessonFixture({
+      createMultipleChoiceLesson({
         chapterId: chapter.id,
-        isPublished: true,
         organizationId: organization.id,
         position: 0,
       }),
@@ -132,24 +233,22 @@ describe(submitPlayerCompletion, () => {
       }),
     ]);
 
-    const { lesson, step } = await createMultipleChoiceLesson({
-      lessonId: currentLesson.id,
-      organizationId: organization.id,
-    });
-
     const result = await submitPlayerCompletion({
-      input: buildCompletionInput({ lessonId: lesson.id, stepId: step.id }),
+      input: buildCompletionInput({
+        lessonId: currentLesson.lesson.id,
+        stepId: currentLesson.step.id,
+      }),
       userId: user.id,
     });
 
     const [lessonProgress, stepAttempts] = await Promise.all([
       prisma.lessonProgress.findUnique({
-        where: { userLesson: { lessonId: lesson.id, userId: user.id } },
+        where: { userLesson: { lessonId: currentLesson.lesson.id, userId: user.id } },
       }),
-      prisma.stepAttempt.findMany({ where: { stepId: step.id, userId: user.id } }),
+      prisma.stepAttempt.findMany({ where: { stepId: currentLesson.step.id, userId: user.id } }),
     ]);
 
-    expect(nextLesson.position).toBeGreaterThan(currentLesson.position);
+    expect(nextLesson.position).toBeGreaterThan(currentLesson.lesson.position);
     expect(result).toStrictEqual({ preloadLessonId: nextLesson.id });
     expect(lessonProgress?.completedAt).toBeInstanceOf(Date);
     expect(stepAttempts).toHaveLength(1);

--- a/packages/core/src/player/commands/submit-player-completion.ts
+++ b/packages/core/src/player/commands/submit-player-completion.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { type LessonSentence, prisma } from "@zoonk/db";
+import { type LessonSentence, getPublishedLessonWhere, prisma } from "@zoonk/db";
 import { type CompletionInput } from "../contracts/completion-input-schema";
 import { computeLessonScore } from "../contracts/compute-score";
 import { validateAnswers } from "../contracts/validate-answers";
@@ -25,6 +25,18 @@ type StepWithSentence = {
 };
 
 type PlayerCompletionEffects = { preloadLessonId: string | null };
+
+/**
+ * Completion is only valid for lessons the learner can reach through the
+ * product. Public brand courses are always eligible, and organization-less
+ * courses are eligible only for the user who owns that generated course.
+ */
+function getCompletableLessonWhere({ lessonId, userId }: { lessonId: string; userId: string }) {
+  return getPublishedLessonWhere({
+    courseWhere: { OR: [{ organization: { kind: "brand" } }, { organizationId: null, userId }] },
+    lessonWhere: { id: lessonId },
+  });
+}
 
 /**
  * Attaches sentence translation data from `LessonSentence` records to steps.
@@ -73,7 +85,7 @@ export async function submitPlayerCompletion(params: {
 }): Promise<PlayerCompletionEffects | null> {
   const lessonId = params.input.lessonId;
 
-  const lesson = await prisma.lesson.findUnique({
+  const lesson = await prisma.lesson.findFirst({
     include: {
       steps: {
         include: { sentence: true, word: true },
@@ -81,7 +93,7 @@ export async function submitPlayerCompletion(params: {
         where: { isPublished: true },
       },
     },
-    where: { id: lessonId },
+    where: getCompletableLessonWhere({ lessonId, userId: params.userId }),
   });
 
   if (!lesson) {


### PR DESCRIPTION
Requires completion submissions to resolve through the public curriculum boundary before writing progress, re-checks published course trees during durable rollups, and adds regressions for inaccessible curriculum and rollback behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require public lessons for completion and block progress writes from raw lesson IDs. We now re-check the published course → chapter → lesson tree during completion and rollups to prevent durable progress on drafts or private content.

- **Bug Fixes**
  - Gate lesson lookups behind `getPublishedLessonWhere` from `@zoonk/db` in both curriculum context and `submitPlayerCompletion`.
  - Restrict completion to brand courses or user-owned, org-less courses; return null for inaccessible lessons and throw "Lesson is not completable" in curriculum resolution.
  - Enforce published course filters in rollup queries (course joins and Prisma where clauses) so drafts never affect durable progress.
  - Verified no writes on rejection across all progress tables via new regression tests (inaccessible curriculum and rollback).

<sup>Written for commit 638395f0e8f0df30a15413ab0963b607de36bd8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

