### PR TITLE
chore(nextjs): remove turbopack root config

### DIFF
--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { withSentryConfig } from "@sentry/nextjs";
 import { getPublicAppSecurityHeaders } from "@zoonk/next/security/headers";
 import { withBotId } from "botid/next/config";
@@ -20,7 +19,6 @@ const nextConfig: NextConfig = {
   reactCompiler: true,
   turbopack: {
     resolveAlias: { ...e2eAliases },
-    root: path.resolve(import.meta.dirname, "../.."),
     rules: {
       // Allow to import MDX files used for AI prompts
       "*.md": { as: "*.js", loaders: ["raw-loader"] },

--- a/apps/evals/next.config.ts
+++ b/apps/evals/next.config.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { type NextConfig } from "next";
 
 const nextConfig: NextConfig = {
@@ -13,7 +12,6 @@ const nextConfig: NextConfig = {
   pageExtensions: ["ts", "tsx"],
   reactCompiler: true,
   turbopack: {
-    root: path.resolve(import.meta.dirname, "../.."),
     rules: {
       // Allow to import MDX files used for AI prompts
       "*.md": { as: "*.js", loaders: ["raw-loader"] },

--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import createMDX from "@next/mdx";
 import { withSentryConfig } from "@sentry/nextjs";
 import { getPublicAppSecurityHeaders } from "@zoonk/next/security/headers";
@@ -36,7 +35,6 @@ const nextConfig: NextConfig = {
   reactCompiler: true,
   turbopack: {
     resolveAlias: { ...e2eAliases },
-    root: path.resolve(import.meta.dirname, "../.."),
     rules: {
       // Allow to import MDX files used for AI prompts
       "*.md": { as: "*.js", loaders: ["raw-loader"] },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove the `turbopack.root` override from the Next.js configs to rely on default workspace resolution across apps.

- **Refactors**
  - Removed `turbopack.root` and the `path` import in `apps/api`, `apps/evals`, and `apps/main` `next.config.ts`.
  - Kept existing `turbopack.resolveAlias` and rule settings unchanged.

<sup>Written for commit 8851beabe4761c4e7290cce70e332ea8967827d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

