### PR TITLE
fix(player): render generated rich text

### DIFF
--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -18,6 +18,7 @@
     "@zoonk/core": "workspace:*",
     "@zoonk/ui": "workspace:*",
     "@zoonk/utils": "workspace:*",
+    "katex": "0.16.45",
     "react": "catalog:",
     "react-dom": "catalog:",
     "web-haptics": "0.0.6"

--- a/packages/player/src/_browser-tests/player-static.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-static.browser.test.tsx
@@ -151,6 +151,40 @@ describe("player browser integration: static steps", () => {
     await expect.element(page.getByText("Add -ed to regular verbs")).toBeInTheDocument();
   });
 
+  it("renders generated rich text without exposing LaTeX delimiters", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        kind: "explanation",
+        steps: [
+          buildSerializedStep({
+            content: {
+              text: "{{NAME}}, a regra é \\(d\\sin\\theta = m\\lambda\\). Use **destaque** e *ênfase*.",
+              title: "A equação",
+              variant: "text" as const,
+            },
+            id: "static-rich-text",
+          }),
+        ],
+      }),
+      navigation: buildNavigation({ nextLessonHref: null }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await expect.element(page.getByRole("heading", { name: "A equação" })).toBeInTheDocument();
+    await expect.element(page.getByText("destaque")).toBeInTheDocument();
+    await expect.element(page.getByText("ênfase")).toBeInTheDocument();
+
+    const boldText = screen.getByText("destaque");
+    const italicText = screen.getByText("ênfase");
+    const bodyText = screen.getByText(/Alex, a regra é/).textContent;
+
+    expect(boldText.tagName).toBe("STRONG");
+    expect(italicText.tagName).toBe("EM");
+    expect(bodyText).not.toContain("{{NAME}}");
+    expect(bodyText).not.toContain(String.raw`\(`);
+    expect(bodyText).not.toContain(String.raw`\)`);
+  });
+
   it("renders embedded step images inside the shared static shell", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({

--- a/packages/player/src/components/feedback-screen.tsx
+++ b/packages/player/src/components/feedback-screen.tsx
@@ -4,7 +4,6 @@ import { type SerializedStep } from "@zoonk/core/player/contracts/prepare-lesson
 import { parseStepContent } from "@zoonk/core/steps/contract/content";
 import { useExtracted } from "next-intl";
 import { type StepResult } from "../player-reducer";
-import { useReplaceName } from "../user-name-context";
 import { getFeedbackRomanization } from "./_utils/feedback-romanization";
 import { CorrectAnswerBlock, IncorrectAnswerBlock } from "./feedback-answer-blocks";
 import { PlayAudioButton } from "./play-audio-button";
@@ -105,9 +104,7 @@ export function FeedbackScreenContent({
   step?: SerializedStep;
 }) {
   const t = useExtracted();
-  const replaceName = useReplaceName();
-  const { isCorrect, feedback: rawFeedback, correctAnswer } = result.result;
-  const feedback = rawFeedback ? replaceName(rawFeedback) : null;
+  const { isCorrect, feedback, correctAnswer } = result.result;
   const selectedText = getSelectedText(result, step);
   const questionText = getQuestionText(result, step);
   const rom = getFeedbackRomanization({ correctAnswer, questionText, result, selectedText, step });

--- a/packages/player/src/components/fill-blank-step.tsx
+++ b/packages/player/src/components/fill-blank-step.tsx
@@ -9,7 +9,6 @@ import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { useCallback, useMemo, useState } from "react";
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
-import { useReplaceName } from "../user-name-context";
 import { getTemplateRomanization } from "./_utils/template-romanization";
 import { InlineFeedback } from "./inline-feedback";
 import { QuestionText } from "./question-text";
@@ -215,7 +214,6 @@ export function FillBlankStep({
 }) {
   const t = useExtracted();
   const content = useMemo(() => parseStepContent("fillBlank", step.content), [step.content]);
-  const replaceName = useReplaceName();
   const blankCount = content.answers.length;
   const hasResult = result !== undefined;
 
@@ -279,7 +277,7 @@ export function FillBlankStep({
 
   return (
     <InteractiveStepLayout>
-      {content.question && <QuestionText>{replaceName(content.question)}</QuestionText>}
+      {content.question && <QuestionText>{content.question}</QuestionText>}
 
       <TemplateText
         answers={content.answers}

--- a/packages/player/src/components/inline-feedback.tsx
+++ b/packages/player/src/components/inline-feedback.tsx
@@ -2,7 +2,7 @@
 
 import { useExtracted } from "next-intl";
 import { type StepResult } from "../player-reducer";
-import { useReplaceName } from "../user-name-context";
+import { PlayerRichText } from "./player-rich-text";
 import { VerdictLabel } from "./verdict-label";
 
 export function InlineFeedback({
@@ -13,9 +13,8 @@ export function InlineFeedback({
   result: StepResult;
 }) {
   const t = useExtracted();
-  const replaceName = useReplaceName();
   const isCorrect = result.result.isCorrect;
-  const feedback = result.result.feedback ? replaceName(result.result.feedback) : null;
+  const feedback = result.result.feedback;
 
   return (
     <div
@@ -26,7 +25,11 @@ export function InlineFeedback({
     >
       <VerdictLabel verdict={isCorrect ? "correct" : "incorrect"} />
 
-      {feedback && <p className="text-muted-foreground text-sm">{feedback}</p>}
+      {feedback && (
+        <p className="text-muted-foreground text-sm">
+          <PlayerRichText text={feedback} />
+        </p>
+      )}
 
       {children}
     </div>

--- a/packages/player/src/components/match-columns-step.tsx
+++ b/packages/player/src/components/match-columns-step.tsx
@@ -8,7 +8,6 @@ import { useExtracted } from "next-intl";
 import { Fragment, useCallback, useMemo, useRef, useState } from "react";
 import { useWebHaptics } from "web-haptics/react";
 import { type SelectedAnswer } from "../player-reducer";
-import { useReplaceName } from "../user-name-context";
 import { QuestionText } from "./question-text";
 import { InteractiveStepLayout } from "./step-layouts";
 
@@ -152,7 +151,6 @@ export function MatchColumnsStep({
   step: SerializedStep;
 }) {
   const content = useMemo(() => parseStepContent("matchColumns", step.content), [step.content]);
-  const replaceName = useReplaceName();
   const t = useExtracted();
   const { trigger } = useWebHaptics();
 
@@ -223,7 +221,7 @@ export function MatchColumnsStep({
 
   return (
     <InteractiveStepLayout>
-      {content.question && <QuestionText>{replaceName(content.question)}</QuestionText>}
+      {content.question && <QuestionText>{content.question}</QuestionText>}
 
       <MatchGrid
         correctPairs={correctPairs}

--- a/packages/player/src/components/player-choice-scene.tsx
+++ b/packages/player/src/components/player-choice-scene.tsx
@@ -2,8 +2,8 @@
 
 import { useExtracted } from "next-intl";
 import { useOptionKeyboard } from "../use-option-keyboard";
-import { useReplaceName } from "../user-name-context";
 import { OptionCard } from "./option-card";
+import { PlayerRichText } from "./player-rich-text";
 import { ContextText, QuestionText } from "./question-text";
 import { SectionLabel } from "./section-label";
 import { InteractiveStepLayout } from "./step-layouts";
@@ -60,13 +60,11 @@ export function PlayerChoiceSceneEyebrow({ children }: { children: React.ReactNo
  * being repeated in every adapter component.
  */
 export function PlayerChoiceSceneContext({ children }: { children?: string | null }) {
-  const replaceName = useReplaceName();
-
   if (!children) {
     return null;
   }
 
-  return <ContextText>{replaceName(children)}</ContextText>;
+  return <ContextText>{children}</ContextText>;
 }
 
 /**
@@ -76,13 +74,11 @@ export function PlayerChoiceSceneContext({ children }: { children?: string | nul
  * treatment even though they come from different step kinds.
  */
 export function PlayerChoiceSceneQuestion({ children }: { children?: string | null }) {
-  const replaceName = useReplaceName();
-
   if (!children) {
     return null;
   }
 
-  return <QuestionText>{replaceName(children)}</QuestionText>;
+  return <QuestionText>{children}</QuestionText>;
 }
 
 /**
@@ -95,7 +91,7 @@ export function PlayerChoiceSceneQuestion({ children }: { children?: string | nu
 export function PlayerChoiceSceneOptionText({ children }: { children: React.ReactNode }) {
   return (
     <span className="text-base leading-6" data-slot="player-choice-scene-option-text">
-      {children}
+      {typeof children === "string" ? <PlayerRichText text={children} /> : children}
     </span>
   );
 }

--- a/packages/player/src/components/player-feedback-scene.tsx
+++ b/packages/player/src/components/player-feedback-scene.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@zoonk/ui/lib/utils";
+import { PlayerRichText } from "./player-rich-text";
 import { PlayerContentFrame } from "./step-layouts";
 
 /**
@@ -42,7 +43,7 @@ export function PlayerFeedbackSceneMessage({
       data-slot="player-feedback-scene-message"
       {...props}
     >
-      {children}
+      {typeof children === "string" ? <PlayerRichText text={children} /> : children}
     </p>
   );
 }

--- a/packages/player/src/components/player-read-scene.tsx
+++ b/packages/player/src/components/player-read-scene.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@zoonk/ui/lib/utils";
-import { stripWrappingQuotes } from "./_utils/strip-wrapping-quotes";
+import { PlayerRichText } from "./player-rich-text";
 import { PlayerContentFrame } from "./step-layouts";
 
 type PlayerReadSceneTitleTone = "destructive" | "foreground" | "muted" | "success" | "warning";
@@ -83,7 +83,7 @@ export function PlayerReadSceneTitle({
       )}
       data-slot="player-read-scene-title"
     >
-      {children}
+      {typeof children === "string" ? <PlayerRichText text={children} /> : children}
     </h2>
   );
 }
@@ -95,14 +95,12 @@ export function PlayerReadSceneTitle({
  * typography lives here.
  */
 export function PlayerReadSceneBody({ children }: { children: React.ReactNode }) {
-  const content = typeof children === "string" ? stripWrappingQuotes(children) : children;
-
   return (
     <p
       className="text-lg leading-relaxed sm:text-xl sm:leading-relaxed"
       data-slot="player-read-scene-body"
     >
-      {content}
+      {typeof children === "string" ? <PlayerRichText text={children} /> : children}
     </p>
   );
 }

--- a/packages/player/src/components/player-rich-text.tsx
+++ b/packages/player/src/components/player-rich-text.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { renderToString } from "katex";
+import { useReplaceName } from "../user-name-context";
+import { stripWrappingQuotes } from "./_utils/strip-wrapping-quotes";
+
+type RichTextSegment =
+  | { kind: "bold"; text: string }
+  | { kind: "displayMath"; text: string }
+  | { kind: "italic"; text: string }
+  | { kind: "math"; text: string }
+  | { kind: "text"; text: string };
+
+const MATH_DELIMITERS = [
+  { close: "\\)", kind: "math" as const, open: "\\(" },
+  { close: "\\]", kind: "displayMath" as const, open: "\\[" },
+];
+
+/**
+ * Finds the next LaTeX delimiter because generated lessons commonly use
+ * standard inline math markers inside otherwise plain prose. The player only
+ * needs to recognize those markers, not the full Markdown grammar.
+ */
+function findNextMathDelimiter(text: string) {
+  const matches = MATH_DELIMITERS.map((delimiter) => ({
+    ...delimiter,
+    index: text.indexOf(delimiter.open),
+  })).filter((match) => match.index >= 0);
+
+  return matches.toSorted((first, second) => first.index - second.index)[0] ?? null;
+}
+
+/**
+ * Splits lesson prose into math and non-math regions so lightweight Markdown
+ * markers never modify LaTeX commands such as \lambda or \theta.
+ */
+function parseMathSegments(text: string): RichTextSegment[] {
+  const delimiter = findNextMathDelimiter(text);
+
+  if (!delimiter) {
+    return parseEmphasisSegments(text);
+  }
+
+  const before = text.slice(0, delimiter.index);
+  const mathStart = delimiter.index + delimiter.open.length;
+  const mathEnd = text.indexOf(delimiter.close, mathStart);
+
+  if (mathEnd === -1) {
+    return parseEmphasisSegments(text);
+  }
+
+  const mathText = text.slice(mathStart, mathEnd);
+  const after = text.slice(mathEnd + delimiter.close.length);
+
+  return [
+    ...parseEmphasisSegments(before),
+    { kind: delimiter.kind, text: mathText },
+    ...parseMathSegments(after),
+  ];
+}
+
+/**
+ * Parses the small text emphasis subset that AI lesson copy actually uses.
+ * This intentionally avoids a broad Markdown renderer so generated headings,
+ * lists, tables, or links cannot unexpectedly change the player layout.
+ */
+function parseEmphasisSegments(text: string): RichTextSegment[] {
+  const boldStart = text.indexOf("**");
+  const italicStart = text.indexOf("*");
+  const hasBold = boldStart !== -1;
+  const hasItalic = italicStart !== -1;
+
+  if (!hasBold && !hasItalic) {
+    return text ? [{ kind: "text", text }] : [];
+  }
+
+  if (hasBold && (!hasItalic || boldStart <= italicStart)) {
+    return parseMarkedSegment({ close: "**", kind: "bold", open: "**", text });
+  }
+
+  return parseMarkedSegment({ close: "*", kind: "italic", open: "*", text });
+}
+
+/**
+ * Converts one matched emphasis pair and then recursively parses the text
+ * around it. Unmatched markers stay visible because showing the original
+ * generated text is better than dropping learner-facing content.
+ */
+function parseMarkedSegment({
+  close,
+  kind,
+  open,
+  text,
+}: {
+  close: string;
+  kind: "bold" | "italic";
+  open: string;
+  text: string;
+}): RichTextSegment[] {
+  const start = text.indexOf(open);
+  const contentStart = start + open.length;
+  const end = text.indexOf(close, contentStart);
+
+  if (start === -1 || end === -1) {
+    return text ? [{ kind: "text", text }] : [];
+  }
+
+  const before = text.slice(0, start);
+  const content = text.slice(contentStart, end);
+  const after = text.slice(end + close.length);
+
+  return [
+    ...parseEmphasisSegments(before),
+    { kind, text: content },
+    ...parseEmphasisSegments(after),
+  ];
+}
+
+/**
+ * Renders LaTeX through KaTeX with errors kept inline. AI-generated formulas
+ * should never crash the player, and visible fallback text makes bad formulas
+ * reviewable instead of invisible.
+ */
+function renderMathToHtml({ displayMode, text }: { displayMode: boolean; text: string }) {
+  return renderToString(text, { displayMode, output: "mathml", throwOnError: false, trust: false });
+}
+
+/**
+ * Renders generated lesson copy with only the formatting primitives we support
+ * in player content: LaTeX math plus simple bold and italic emphasis.
+ */
+export function PlayerRichText({ text }: { text: string }) {
+  const replaceName = useReplaceName();
+  const displayText = stripWrappingQuotes(replaceName(text));
+
+  return parseMathSegments(displayText).map((segment, index) => {
+    const key = `${segment.kind}-${index}`;
+
+    if (segment.kind === "bold") {
+      return <strong key={key}>{segment.text}</strong>;
+    }
+
+    if (segment.kind === "italic") {
+      return <em key={key}>{segment.text}</em>;
+    }
+
+    if (segment.kind === "math" || segment.kind === "displayMath") {
+      return (
+        <span
+          className={segment.kind === "displayMath" ? "my-3 block overflow-x-auto" : undefined}
+          // eslint-disable-next-line react/no-danger -- KaTeX returns escaped MathML with trust disabled, which lets formulas render without allowing AI-provided HTML.
+          dangerouslySetInnerHTML={{
+            __html: renderMathToHtml({
+              displayMode: segment.kind === "displayMath",
+              text: segment.text,
+            }),
+          }}
+          key={key}
+        />
+      );
+    }
+
+    return <span key={key}>{segment.text}</span>;
+  });
+}

--- a/packages/player/src/components/question-text.tsx
+++ b/packages/player/src/components/question-text.tsx
@@ -1,15 +1,17 @@
-import { stripWrappingQuotes } from "./_utils/strip-wrapping-quotes";
+import { PlayerRichText } from "./player-rich-text";
 
 export function ContextText({ children }: { children: React.ReactNode }) {
-  const content = typeof children === "string" ? stripWrappingQuotes(children) : children;
-
-  return <p className="text-lg leading-relaxed sm:text-xl sm:leading-relaxed">{content}</p>;
+  return (
+    <p className="text-lg leading-relaxed sm:text-xl sm:leading-relaxed">
+      {typeof children === "string" ? <PlayerRichText text={children} /> : children}
+    </p>
+  );
 }
 
 export function QuestionText({ children }: { children: React.ReactNode }) {
   return (
     <h2 className="text-muted-foreground text-lg font-semibold tracking-tight sm:text-xl">
-      {children}
+      {typeof children === "string" ? <PlayerRichText text={children} /> : children}
     </h2>
   );
 }

--- a/packages/player/src/components/sort-order-step.tsx
+++ b/packages/player/src/components/sort-order-step.tsx
@@ -27,7 +27,6 @@ import { useExtracted } from "next-intl";
 import { useCallback, useId, useMemo, useState } from "react";
 import { useWebHaptics } from "web-haptics/react";
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
-import { useReplaceName } from "../user-name-context";
 import { InlineFeedback } from "./inline-feedback";
 import { QuestionText } from "./question-text";
 import { ResultKbd } from "./result-kbd";
@@ -239,7 +238,6 @@ export function SortOrderStep({
 }) {
   const t = useExtracted();
   const content = useMemo(() => parseStepContent("sortOrder", step.content), [step.content]);
-  const replaceName = useReplaceName();
   const [items, setItems] = useState<SortItem[]>(() => initItems(step, result));
 
   const handleReorder = useCallback(
@@ -255,7 +253,7 @@ export function SortOrderStep({
 
   return (
     <InteractiveStepLayout>
-      {content.question && <QuestionText>{replaceName(content.question)}</QuestionText>}
+      {content.question && <QuestionText>{content.question}</QuestionText>}
 
       {!hasResult && (
         <p className="text-muted-foreground text-sm">{t("Drag items into the correct order")}</p>

--- a/packages/player/src/components/static-step.tsx
+++ b/packages/player/src/components/static-step.tsx
@@ -2,7 +2,6 @@
 
 import { type SerializedStep } from "@zoonk/core/player/contracts/prepare-lesson-data";
 import { describePlayerStep, getPlayerStepImage } from "../player-step";
-import { useReplaceName } from "../user-name-context";
 import { HighlightText } from "./highlight-text";
 import {
   PlayerReadScene,
@@ -15,12 +14,10 @@ import { StaticStepLayout } from "./static-step-layout";
 import { StepIntroHero } from "./step-intro-hero-layout";
 
 function TextVariant({ title, text }: { title: string; text: string }) {
-  const replaceName = useReplaceName();
-
   return (
     <PlayerReadSceneStack>
-      <PlayerReadSceneTitle>{replaceName(title)}</PlayerReadSceneTitle>
-      <PlayerReadSceneBody>{replaceName(text)}</PlayerReadSceneBody>
+      <PlayerReadSceneTitle>{title}</PlayerReadSceneTitle>
+      <PlayerReadSceneBody>{text}</PlayerReadSceneBody>
     </PlayerReadSceneStack>
   );
 }

--- a/packages/player/src/components/step-intro-hero-layout.tsx
+++ b/packages/player/src/components/step-intro-hero-layout.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { type StepImage } from "@zoonk/core/steps/contract/image";
-import { useReplaceName } from "../user-name-context";
 import { ExpandableStepImageStage } from "./expandable-step-image-stage";
 import {
   PlayerReadScene,
@@ -20,14 +19,12 @@ import { StepActionButton } from "./step-action-button";
  * placement from drifting.
  */
 function StepIntroHeroContent({ text, title }: { text: string; title: string }) {
-  const replaceName = useReplaceName();
-
   return (
     <div className="flex flex-col gap-6">
       <PlayerReadSceneStack>
-        <PlayerReadSceneTitle tone="foreground">{replaceName(title)}</PlayerReadSceneTitle>
+        <PlayerReadSceneTitle tone="foreground">{title}</PlayerReadSceneTitle>
 
-        <PlayerReadSceneBody>{replaceName(text)}</PlayerReadSceneBody>
+        <PlayerReadSceneBody>{text}</PlayerReadSceneBody>
       </PlayerReadSceneStack>
 
       <StepActionButton />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,6 +842,9 @@ importers:
       '@zoonk/utils':
         specifier: workspace:*
         version: link:../utils
+      katex:
+        specifier: 0.16.45
+        version: 0.16.45
       lucide-react:
         specifier: 'catalog:'
         version: 1.14.0(react@19.2.5)
@@ -6469,6 +6472,10 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  katex@0.16.45:
+    resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
+    hasBin: true
+
   keyv@5.6.0:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
 
@@ -9413,7 +9420,7 @@ snapshots:
       '@mdx-js/mdx': 3.1.1
       source-map: 0.7.6
     optionalDependencies:
-      webpack: 5.105.0
+      webpack: 5.105.0(esbuild@0.25.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13968,6 +13975,10 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  katex@0.16.45:
+    dependencies:
+      commander: 8.3.0
+
   keyv@5.6.0:
     dependencies:
       '@keyv/serialize': 1.1.1
@@ -15081,7 +15092,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.0
+      webpack: 5.105.0(esbuild@0.25.0)
 
   rc9@3.0.1:
     dependencies:
@@ -15718,14 +15729,6 @@ snapshots:
     optionalDependencies:
       esbuild: 0.27.7
 
-  terser-webpack-plugin@5.5.0(webpack@5.105.0):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.46.2
-      webpack: 5.105.0
-
   terser@5.46.2:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -16132,38 +16135,6 @@ snapshots:
   webpack-sources@3.4.1: {}
 
   webpack-virtual-modules@0.6.2: {}
-
-  webpack@5.105.0:
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.21.0
-      es-module-lexer: 2.1.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.2
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      terser-webpack-plugin: 5.5.0(webpack@5.105.0)
-      watchpack: 2.5.1
-      webpack-sources: 3.4.1
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
 
   webpack@5.105.0(@swc/core@1.15.3)(esbuild@0.27.7):
     dependencies:


### PR DESCRIPTION
Render generated player copy through a shared rich text renderer for MathML formulas, bold, and italic text.

Centralize name replacement and quote cleanup in the player text renderer so static copy, questions, and feedback use the same display path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders all player text through a shared rich text renderer that supports LaTeX math (MathML), bold, and italic. Fixes escaped formulas showing in the UI and unifies name replacement and quote cleanup across static copy, questions, and feedback.

- **Bug Fixes**
  - Introduced `PlayerRichText` and used it for titles, bodies, questions, options, inline and scene feedback.
  - Supports `\(...\)` and `\[...\]` LaTeX delimiters and outputs MathML; unmatched markers are kept as text.
  - Centralized `{{NAME}}` replacement and quote stripping inside the renderer; removed per-component replacements.
  - Added a browser test to verify math, emphasis, and name replacement render correctly.

- **Dependencies**
  - Added `katex@0.16.45`.

<sup>Written for commit 387edea1f288f38019f03d5324d12eeb8b8491bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

