### PR TITLE
fix(ai): use white bg for thumbs

### DIFF
--- a/packages/ai/src/tasks/content/content-thumbnail.prompt.md
+++ b/packages/ai/src/tasks/content/content-thumbnail.prompt.md
@@ -20,7 +20,7 @@ The icon must:
 - Use 2–4 colors maximum
 - Have soft realistic lighting
 - Have a subtle shadow underneath
-- Be isolated on a very light warm gray background (#f5f5f3)
+- Be isolated on a white background
 - Square format (1:1)
 
 Choose ONE simple metaphor object that best represents the topic. If more than one object is generated, the image is incorrect.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the content thumbnail generation prompt in `packages/ai` to require a white background instead of warm gray (#f5f5f3). This standardizes thumbnail backgrounds and avoids unintended tinting across themes.

<sup>Written for commit 7b5dcc2562913ea085c982e27c31efffc1d9c2d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

