### PR TITLE
fix(player): show lesson images without cropping

### DIFF
--- a/packages/ai/src/tasks/lessons/core/lesson-practice.prompt.md
+++ b/packages/ai/src/tasks/lessons/core/lesson-practice.prompt.md
@@ -88,7 +88,6 @@ Image rules:
 - Compose each image prompt around one centered primary artifact, screen, document, device, scene detail, or clue.
 - Avoid wide side-by-side panels unless the question truly depends on comparing two states at once.
 - If the step needs comparison, stack the states vertically or place them inside one centered artifact instead of spreading important details across the full width.
-- Keep all essential labels, numbers, code, UI controls, and evidence away from the outer edges of the image.
 - For screens, dashboards, code editors, tables, forms, receipts, and documents, ask for only the relevant section. Do not include sidebars, browser chrome, file trees, toolbars, or extra columns unless they are the clue.
 - If text is needed inside the image, keep it short and legible.
 - Use labels, totals, column names, timestamps, badges, short notes, or short dialogue bubbles when useful.

--- a/packages/ai/src/tasks/steps/step-content-image.prompt.md
+++ b/packages/ai/src/tasks/steps/step-content-image.prompt.md
@@ -4,14 +4,12 @@ Style: Modern flat illustration with clean geometric shapes, a refined limited c
 
 Art direction:
 
-- Prefer off-white, warm gray, or other soft neutral backgrounds.
+- Use a clean white background.
 - Keep colors restrained and tasteful.
 - When the content needs a table, dashboard, form, label, diagram, or screen, render it in this same clean visual system.
 - If text appears in the image, keep it short, legible, and useful.
 - Compose around one centered primary artifact, scene, diagram, or screen. Avoid wide side-by-side layouts unless the prompt explicitly requires comparing two states.
 - If a comparison is required, stack the states vertically or place them inside one centered panel instead of spreading them across the full width.
-- Keep every essential subject, label, number, arrow, code line, UI control, and teaching detail inside the central 80% of the frame. The outer edges may be cropped by the app.
-- Leave only non-essential background, margins, or decorative whitespace near the outer edges.
 - For tables, dashboards, forms, code, diagrams, and screens, remove sidebars, browser chrome, file trees, toolbars, and extra columns unless they are the actual clue.
 - Avoid dense paragraphs, tiny unreadable text, photorealism, glossy 3D, neon gradients, generic screenshot aesthetics, and loud saturated backdrops.
 - Especially avoid heavy blue or purple background fills unless the prompt truly requires them.

--- a/packages/ai/src/tasks/steps/step-content-practice-image.prompt.md
+++ b/packages/ai/src/tasks/steps/step-content-practice-image.prompt.md
@@ -10,13 +10,11 @@ Art direction:
 - If the scene contains a complex board, screen, document, or workspace, simplify it to the minimum readable surface needed for the clue.
 - Prefer close crops and clear hierarchy over wide shots with many competing details.
 - Leave out unrelated widgets, cards, labels, windows, desk objects, or background business unless they are needed to understand the scene.
-- Keep backgrounds neutral and unobtrusive.
+- Use a clean white background.
 - If people appear, keep them natural and grounded in a real task, but do not let them distract from the artifact or evidence.
 - If text appears in the image, keep it short, legible, and useful.
 - Compose around one centered primary artifact, screen, document, device, workspace detail, or situation. Avoid wide side-by-side layouts unless the prompt explicitly requires comparing two states.
 - If a comparison is required, stack the states vertically or place them inside one centered panel instead of spreading them across the full width.
-- Keep every essential clue, artifact, label, number, code line, UI control, and readable detail inside the central 80% of the frame. The outer edges may be cropped by the app.
-- Leave only non-essential background, margins, or decorative whitespace near the outer edges.
 - For dashboards, code editors, forms, tables, receipts, documents, and app screens, remove sidebars, browser chrome, file trees, toolbars, and extra columns unless they are the actual clue.
 - Avoid dense paragraphs, tiny unreadable text, cluttered frames, overfilled dashboards or boards, surreal fantasy, glossy 3D, cartoon styling, stock-photo posing, dramatic cinematic lighting, and loud saturated backdrops.
 - Aim for clean, believable realism, not generic decorative concept art.

--- a/packages/ai/src/tasks/steps/step-image-prompts.prompt.md
+++ b/packages/ai/src/tasks/steps/step-image-prompts.prompt.md
@@ -29,7 +29,6 @@ The image prompt should:
 - If the step is abstract, choose the clearest visual explanation available. Use a metaphor only when it genuinely improves understanding.
 - Prefer one centered primary artifact, diagram, screen, scene, or object over a wide layout with many panels.
 - If a comparison is necessary, ask for two states stacked vertically or contained inside one centered panel, not spread across the full width.
-- Keep all essential labels, numbers, arrows, code, UI controls, and evidence away from the outer edges of the image.
 - For screens, dashboards, code, tables, forms, and documents, ask for only the relevant section. Do not include sidebars, browser chrome, file trees, toolbars, or extra columns unless they are the clue.
 
 # Quality Bar

--- a/packages/player/src/components/choice-step-layout.tsx
+++ b/packages/player/src/components/choice-step-layout.tsx
@@ -73,7 +73,7 @@ function ChoiceStepImageStage({ image }: { image: StepImage }) {
   return (
     <div className="w-full lg:h-full lg:min-h-0" data-slot="choice-step-image-stage-shell">
       <div
-        className="relative aspect-square w-full overflow-hidden rounded-xl lg:aspect-auto lg:h-full lg:rounded-none [&_img]:object-top"
+        className="relative aspect-square w-full overflow-hidden rounded-xl lg:aspect-auto lg:h-full lg:rounded-none"
         data-slot="choice-step-image-stage"
       >
         <ExpandableStepImageStage image={image} />

--- a/packages/player/src/components/expandable-step-image-stage.tsx
+++ b/packages/player/src/components/expandable-step-image-stage.tsx
@@ -16,16 +16,16 @@ import { Maximize2Icon, XIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
 import Image from "next/image";
 import { type MouseEvent, type TouchEvent, useState } from "react";
-import { type StepImageFit, StepImageView } from "./step-image";
+import { StepImageView } from "./step-image";
 
 type ImageSize = { height: number; width: number };
 
 type Rect = { bottom: number; left: number; right: number; top: number };
 
 /**
- * Gives cropped step images an explicit escape hatch without adding visible
- * navigation chrome to every media layout. Mobile keeps the button visible
- * because hover does not exist there, while desktop reveals it on hover/focus.
+ * Gives step images a larger inspection view without adding visible navigation
+ * chrome to every media layout. Mobile keeps the button visible because hover
+ * does not exist there, while desktop reveals it on hover/focus.
  */
 function StepImageExpandButton() {
   const t = useExtracted();
@@ -155,9 +155,9 @@ function stopLightboxNavigationPropagation(event: TouchEvent<HTMLDivElement>) {
 }
 
 /**
- * Shows the original image with `contain` so learners can inspect anything
- * the immersive player crop hides. The dialog stays visually quiet: one close
- * control, tokenized surfaces, and no additional framing around the image.
+ * Shows the original image with `contain` so learners can inspect fine details
+ * at a larger size. The dialog stays visually quiet: one close control,
+ * tokenized surfaces, and no additional framing around the image.
  */
 function StepImageFullScreenDialog({
   image,
@@ -231,17 +231,15 @@ function StepImageFullScreenDialog({
 }
 
 /**
- * Shared media stage for player images that are allowed to crop in the normal
- * lesson view. Layout components decide the size and border radius with
- * `className`; this component owns rendering, fallback, and full-image access.
+ * Shared media stage for player images that should preserve their full content.
+ * Layout components decide the size and border radius with `className`; this
+ * component owns rendering, fallback, and full-image access.
  */
 export function ExpandableStepImageStage({
   className,
-  fit = "cover",
   image,
 }: {
   className?: string;
-  fit?: StepImageFit;
   image: StepImage;
 }) {
   const [open, setOpen] = useState(false);
@@ -250,12 +248,12 @@ export function ExpandableStepImageStage({
     <Dialog onOpenChange={setOpen} open={open}>
       <div
         className={cn(
-          "group/step-image-stage bg-muted relative h-full w-full overflow-hidden",
+          "group/step-image-stage bg-background relative h-full w-full overflow-hidden",
           className,
         )}
         data-slot="expandable-step-image-stage"
       >
-        <StepImageView fit={fit} image={image} />
+        <StepImageView image={image} />
         <StepImageExpandButton />
       </div>
 

--- a/packages/player/src/components/step-image.tsx
+++ b/packages/player/src/components/step-image.tsx
@@ -5,13 +5,6 @@ import Image from "next/image";
 import { useState } from "react";
 import { STEP_IMAGE_SIZES } from "../image-config";
 
-export type StepImageFit = "contain" | "cover";
-
-const IMAGE_FIT_CLASS: Record<StepImageFit, string> = {
-  contain: "object-contain",
-  cover: "object-cover",
-};
-
 function StepImageFallback({ prompt }: { prompt: string }) {
   return (
     <div className="flex h-full w-full items-center justify-center p-6">
@@ -24,16 +17,10 @@ function StepImageFallback({ prompt }: { prompt: string }) {
  * Readable lesson steps now own their illustration directly. This component
  * keeps the render/fallback behavior shared between explanation and tutorial
  * steps so a missing upload still leaves the learner with the intended prompt.
- * Story screens also reuse it for larger hero scenes by switching the image fit
- * from the default contained illustration mode to cover.
+ * The player renders images contained by default so generated content is not
+ * clipped by the lesson frame.
  */
-export function StepImageView({
-  fit = "contain",
-  image,
-}: {
-  fit?: StepImageFit;
-  image: StepImage;
-}) {
+export function StepImageView({ image }: { image: StepImage }) {
   const [errorUrl, setErrorUrl] = useState<string | null>(null);
 
   if (!image.url || errorUrl === image.url) {
@@ -44,7 +31,7 @@ export function StepImageView({
     <div className="relative h-full w-full" data-slot="step-image-view">
       <Image
         alt={image.prompt}
-        className={IMAGE_FIT_CLASS[fit]}
+        className="object-contain"
         fill
         loading="eager"
         onError={() => setErrorUrl(image.url ?? null)}

--- a/packages/player/src/components/step-intro-hero-layout.tsx
+++ b/packages/player/src/components/step-intro-hero-layout.tsx
@@ -35,9 +35,9 @@ function StepIntroHeroContent({ text, title }: { text: string; title: string }) 
 /**
  * Hero illustrations are immersive on mobile and composed on desktop.
  *
- * Small screens keep the image as a full-bleed background. Large screens reuse
- * the feedback-screen treatment: a centered, rounded square image above the
- * content so the generated scene feels intentional instead of oversized.
+ * Small screens keep the image behind the bottom card. Large screens reuse the
+ * feedback-screen treatment: a centered, rounded square image above the content
+ * so the generated scene feels intentional instead of oversized.
  */
 function StepHeroImage({ image }: { image: StepImage }) {
   return (
@@ -45,7 +45,7 @@ function StepHeroImage({ image }: { image: StepImage }) {
       className="bg-muted absolute inset-0 overflow-hidden lg:relative lg:inset-auto lg:aspect-square lg:w-full lg:rounded-3xl"
       data-slot="step-hero-image"
     >
-      <ExpandableStepImageStage fit="cover" image={image} />
+      <ExpandableStepImageStage image={image} />
     </div>
   );
 }

--- a/packages/player/src/components/step-media-layout.tsx
+++ b/packages/player/src/components/step-media-layout.tsx
@@ -22,7 +22,7 @@ export function StepMediaLayout({
       data-slot="step-media-layout"
     >
       <div className="min-h-0" data-slot="step-media-stage">
-        <ExpandableStepImageStage className="[&_img]:object-top" image={image} />
+        <ExpandableStepImageStage image={image} />
       </div>
 
       <div


### PR DESCRIPTION
Changes lesson image rendering to preserve full generated images and moves white-background styling into the downstream image generation prompts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show lesson images without cropping by rendering them contained in the player. Moves white-background styling into the image-generation prompts so the art direction matches the new layout.

- **Bug Fixes**
  - Render all step images with contained fit to preserve full content.
  - Remove crop hacks: drop `object-top` overrides and `fit="cover"` in hero/media stages.
  - Use background tokens for the stage; expand dialog keeps quiet UI for inspection.

- **Refactors**
  - Remove `StepImageFit` and related classes; `StepImageView` is always contained.
  - Update prompts to request a clean white background and remove edge-cropping guidance.

<sup>Written for commit 9d46d2e0660e9f846a7ae7fc2ebc5ba5b94a5672. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

