### PR TITLE
feat(ai): improve lesson explanations

### DIFF
--- a/apps/evals/src/tasks/lesson-explanation/test-cases.ts
+++ b/apps/evals/src/tasks/lesson-explanation/test-cases.ts
@@ -4,54 +4,65 @@ EVALUATION CRITERIA:
 1. FACTUAL ACCURACY: The explanation must be technically correct for the topic. Penalize invented mechanisms, wrong cause-effect chains, or misleading simplifications.
 
 2. REQUIRED STRUCTURE: The output must contain exactly two top-level fields:
-   - explanation[]: an array of narrative steps, each with title and text
+   - explanation[]: an array of explanation steps, each with title and text
    - anchor: { title, text } (no visual)
 
-3. LESSON DELIVERY: The lesson must actually deliver on LESSON_TITLE and LESSON_DESCRIPTION. The learner should finish the lesson knowing what the thing is, why it exists or is used (when the description implies it), and how it works or is written in practice (when the description implies it). Penalize lessons that stay surface-level and leave the learner still unsure what the thing is, why it matters, or how it's written when the description required these.
+3. LESSON DELIVERY: The lesson must actually deliver on LESSON_TITLE and LESSON_DESCRIPTION. The learner should finish with a full working understanding of what the topic is, how it works, how it is used/measured/written/recognized in practice when relevant, why it matters when relevant, and what the important terms, formulas, structures, rules, caveats, or limits mean. Penalize lessons that stay friendly but surface-level, or technically dense but hard to understand.
 
-4. LESSON BOUNDARY: The lesson must stay focused on the selected LESSON_TITLE and leave sibling angles in OTHER_EXPLANATION_LESSON_TITLES for those other lessons. Penalize explanations that spend their main arc teaching a sibling lesson instead of the chosen one.
+4. BEGINNER + EXPERT FIT: The lesson should feel like a precise expert explaining the topic to a smart non-expert friend. It should use everyday language without dumbing down the topic. Penalize:
+   - Academic phrasing that makes a simple idea feel harder than it is
+   - "Friendly" explanations that omit the expert essentials required by the lesson scope
+   - Dense explanations that contain the right terms but do not explain them in plain language
+   - Formal terms, formulas, or code snippets that appear without enough plain-language explanation
 
-5. SCENE SPINE: The entire lesson must revolve around ONE concrete moment (e.g. tapping a button, sending a message, opening a contact list). Every step refers back to or deepens that same moment. The single scene is the vehicle for covering what/why/how when the lesson requires all three. Penalize:
-   - Lessons that jump between multiple unrelated scenarios
-   - An opening scenario that gets abandoned after step 1
-   - Definitions that float in abstractly instead of pointing at something already shown in the scene
+5. MECHANISM + FORMAL DETAIL: The lesson must include the real mechanism, structure, relationship, calculation, rule, or procedure required by the title and description. Penalize:
+   - Skipping formulas, variables, code shapes, uncertainty, exceptions, limits, or precise terms that an expert would expect for this lesson scope
+   - Including those details without explaining what the parts mean
+   - Using an analogy, vibe, story, or visual scene as a substitute for the actual mechanism
 
-6. COLD OPEN: Step 1 must land the learner inside a concrete sensory moment with no question-as-hook, no "Imagine...", no resolution, and no definition. Penalize steps that answer their own setup within the same step, or that open with abstract framing.
+6. LESSON BOUNDARY: The lesson must stay focused on the selected LESSON_TITLE and leave sibling angles in OTHER_EXPLANATION_LESSON_TITLES for those other lessons. Penalize explanations that spend their main teaching energy on a sibling lesson instead of the chosen one.
 
-7. NARRATIVE ARC: The explanation[] array should unfold a clear arc: cold open → mystery (something hidden) → reveal (what was hidden) → naming (from inside the scene) → zoom (into one piece, often "how") → optional stakes (why, when the lesson calls for it) → payoff (callback to the opening). Step count is flexible — deeper topics need more steps, simpler topics fewer — but these narrative functions should be present in order. Penalize:
-   - A structure that reads as stacked definitions rather than a single unfolding story
-   - Missing a payoff/callback as the last step
-   - Naming a term before showing an example of it in the scene
+7. EXPLANATION FLOW: There is no required opening pattern, cold open, or story arc. The explanation[] array should choose the clearest order for this topic and connect ideas so the learner can follow how the topic works. Penalize:
+   - Stacked definitions that do not connect to each other
+   - Scenic or subjective prose that does not help explain the concept
+   - Missing the practical payoff when the lesson calls for why this matters
+   - Naming terms before giving enough context to understand them, when that makes the lesson harder to follow
 
-8. STEP QUALITY: Each step.text is 1–3 short sentences of prose. Step titles are short (1–3 words), narrative markers (not textbook section headers), and unique within the lesson. Penalize:
+8. STEP QUALITY: Each step.text is 1-3 short sentences of prose. Step titles are short, unique, and useful for understanding what the step teaches. Penalize:
    - Long paragraphs
-   - Titles like "Programa", "Instrução", "Encapsulation" that sound like chapter headers
+   - Titles that are only props, moods, vague story beats, or generic labels
    - Repetition between steps
 
-9. STEP CONCRETENESS: The explanation steps must be specific enough that a downstream image-prompt task could clearly infer what should be shown. Penalize:
-   - Vague prose that never makes the scene or reveal concrete
-   - Mechanism steps that stay too abstract to picture
-   - Lessons about "how it's written" that never describe the structure or code detail clearly enough to visualize
+9. CONCRETENESS: The lesson should use concrete examples, measurements, cases, code-shaped details, or realistic situations when they make the mechanism easier to understand. Penalize:
+   - Vague prose that never makes the mechanism concrete
+   - Examples that are only atmospheric decoration
+   - Lessons about "how it's written" that never describe the structure or code detail clearly enough to understand
 
-10. STATIC-ONLY DELIVERY: The lesson should stay entirely within narrative explanation steps plus the closing anchor. Penalize:
+10. STATIC + RICH TEXT DELIVERY: The lesson should stay entirely within explanation steps plus the closing anchor. It may use inline LaTeX, display LaTeX, bold, italic, and inline code with single backticks. Penalize:
    - Quiz-like interruptions, option lists, or explicit "guess before continuing" instructions
-   - Steps that stop the narrative to ask the learner to choose instead of revealing the next beat
-   - Rhetorical-question-only steps that replace a real explanation move
+   - Steps that stop to ask the learner to choose instead of explaining
+   - Rhetorical-question-only steps that replace a real explanation
+   - Markdown headings, lists, tables, links, or large code fences inside a step
+   - Malformed LaTeX or unsupported formatting that would show raw clutter to the learner
 
-11. ANCHOR QUALITY: anchor has no visual. It callbacks the opening scene by naming a specific real thing — a named product (e.g., Instagram, WhatsApp), a named event/figure/case, or a concrete physical action the learner has actually done — and what it does there. Penalize:
+11. ANCHOR QUALITY: anchor has no visual. It answers why the topic is useful and where it shows up outside the lesson by naming one specific real-world instance — a named product (e.g., Instagram, WhatsApp), recognizable product family (e.g., ChatGPT-style models), named technology/service/system, named mission/instrument, named event/figure/case/place, or concrete physical action the learner has actually done — and what it does there. Penalize:
    - Abstract "this is why it matters" wrap-ups
-   - Brand new scenarios unrelated to the opening
    - Metaphors or vague generalities
+   - Classroom demonstrations, lab videos, school apparatus, research instruments, or professional workflows that do not name the product, service, system, or public-world outcome they enable
+   - Category-list anchors that name a type of use instead of a vivid instance ("a star, a lamp, or a gas cloud"; "many apps"; "some medical devices")
    - Generic placeholders standing in for a specific real thing ("a real app", "a real court case", "an exoplanet", "every time a button does X in three places")
 
-12. STYLE: Clear, short, concrete, beginner-friendly. Penalize academic tone, filler lines, and redundancy across steps and anchor.
+12. STYLE: Clear, short, concrete, beginner-friendly, and precise. Penalize academic tone, atmospheric storytelling, filler lines, subjectivity that does not teach, and redundancy across steps and anchor.
 
 ANTI-CHECKLIST GUIDANCE (CRITICAL):
-- Do NOT require a fixed number of steps. Complex topics need more; simple topics fewer. Both are fine as long as the arc is present and the lesson is delivered
+- Do NOT require a fixed number of steps. Complex topics need more; simple topics fewer. Both are fine as long as the lesson is delivered
+- Do NOT require a cold open, story arc, single scene, or specific opening style
 - Do NOT require specific title wording, a particular choice of product or event, or a specific visual kind. The anchor must name some specific real thing, but any reasonable choice is fine — do not penalize the model for picking Instagram over WhatsApp, or one named case over another
-- Do NOT penalize creative scenes as long as they stay concrete and the same scene threads through every step
+- Do NOT penalize anchors that use a widely recognized product family tied to a named product, such as "ChatGPT-style models", when the learner can clearly recognize the real-world surface
+- Do NOT penalize direct explanatory writing when it is clear, plain, concrete, and complete
+- Do NOT penalize density when the density comes from necessary expert content explained in everyday language
 - Do NOT focus on JSON wrapping or formatting trivia. Evaluate the content and structural fit
-- ONLY penalize for: wrong top-level structure, factual errors, failing to deliver LESSON_TITLE and LESSON_DESCRIPTION, drifting into sibling lessons, broken scene continuity, weak cold open, missing arc, weak imagery cues, anchor drift, or broken writing constraints
+- ONLY penalize for: wrong top-level structure, factual errors, failing to deliver LESSON_TITLE and LESSON_DESCRIPTION, missing beginner/expert balance, missing required mechanism/detail, drifting into sibling lessons, unclear flow, unsupported formatting, weak real-world anchor, or broken writing constraints
 `;
 
 export const TEST_CASES = [
@@ -89,7 +100,7 @@ TOPIC-SPECIFIC GUIDANCE:
    - Raids are reduced to random violence or simple looting
    - Captives are treated as incidental rather than part of the meaning and aim of warfare
 
-2. BOUNDARY CHECK: The main arc should stay on raids and captives. Penalize if the explanation turns into a broader lesson about colonial stereotypes, revenge logic, or war leadership instead of this selected lesson.
+2. BOUNDARY CHECK: The main arc should stay on raids, captives, and conflict aims. Brief context about honor, memory, alliance, or revenge is fine when it explains why raids or captives mattered. Penalize if revenge logic, colonial stereotypes, or war leadership becomes the primary lesson instead of support for raids and captives.
 
 ${SHARED_EXPECTATIONS}
     `,
@@ -99,8 +110,8 @@ ${SHARED_EXPECTATIONS}
       courseTitle: "Brazilian History",
       language: "en",
       lessonDescription:
-        "Examine conflict on its own terms instead of through colonial stereotypes. Warfare often followed rules tied to honor, memory, alliance, and the taking of captives.",
-      lessonTitle: "Understanding warfare beyond colonial stereotypes",
+        "Examine raids and captives on their own terms instead of through colonial stereotypes. Show how conflict could follow rules tied to honor, memory, alliance, and the taking of captives.",
+      lessonTitle: "Why raids and captives mattered in warfare",
       otherLessonTitles: [
         "Seeing warfare on its own terms",
         "Why revenge was more than retaliation",
@@ -118,7 +129,7 @@ TOPIC-SPECIFIC GUIDANCE:
    - The parties are shown as learning decisive information only after the judge acts
    - Contraditório or ampla defesa are reduced to empty formalities instead of a real chance to know and respond
 
-2. BOUNDARY CHECK: The core arc should stay on avoiding surprise in the process. Penalize if the explanation spends its main energy on who can start the case or on equality between the parties, which belong to sibling lessons.
+2. BOUNDARY CHECK: The core arc should stay on avoiding surprise in the process. Brief mentions of procedure, request limits, deadlines, evidence, or reasoning are fine when they explain how the parties know, respond, and influence before a decision. Penalize if the explanation becomes a broad survey of civil-procedure principles or spends its main energy on who can start the case or equality between the parties.
 
 ${SHARED_EXPECTATIONS}
     `,
@@ -128,11 +139,41 @@ ${SHARED_EXPECTATIONS}
       courseTitle: "Direito",
       language: "pt",
       lessonDescription:
-        "Entenda as regras básicas que dão forma ao processo civil e limitam o poder do juiz e das partes. Esse bloco ajuda a ler qualquer procedimento sem se perder no caminho.",
-      lessonTitle: "Lendo o processo pelas regras do jogo",
+        "Entenda como devido processo legal, contraditório e ampla defesa impedem decisões surpresa. A ideia central é saber, responder e influenciar antes que o juiz decida.",
+      lessonTitle: "Como o processo evita decisões surpresa",
       otherLessonTitles: [
         "Quando o processo começa: quem pode pôr a máquina em movimento",
         "O que significa tratar as partes com igualdade de verdade",
+      ],
+    },
+  },
+  {
+    expectations: `
+LANGUAGE REQUIREMENT: Titles and text must be in Portuguese.
+
+TOPIC-SPECIFIC GUIDANCE:
+
+1. ACCURACY CHECK: This lesson is about measuring hydrogen spectral lines from positions and angles, then turning those readings into wavelengths. Penalize if:
+   - Spectral lines are treated as decorative colors instead of measured wavelengths
+   - Diffraction angles, wavelength, or uncertainty are described with a wrong cause-effect chain
+
+2. REAL-WORLD ANCHOR CHECK: The anchor must not end at a lab video, school spectroscope, classroom demo, or "next time you see this in a lab" framing. It should connect the measured-spectrum idea to a product, technology, system, or public-world result a normal learner can recognize, such as phone/display color tuning, LED or laser manufacturing, medical or environmental spectroscopy, or identifying hydrogen in named telescope observations.
+
+${SHARED_EXPECTATIONS}
+    `,
+    id: "pt-fisica-quantica-linhas-hidrogenio",
+    userInput: {
+      chapterTitle: "A assinatura colorida do hidrogênio",
+      courseTitle: "Física Quântica",
+      language: "pt",
+      lessonDescription:
+        "Trace o caminho do tubo de descarga até o padrão no espectroscópio: gás excitado, fenda, rede ou prisma e linhas separadas por cor. Use ângulos, ordens de difração e incerteza de leitura para transformar posições no anteparo em comprimentos de onda.",
+      lessonTitle: "Medir as linhas do hidrogênio",
+      otherLessonTitles: [
+        "Calcular a série de Balmer",
+        "Encontrar séries e limites espectrais",
+        "Ligar cores a saltos de energia",
+        "Julgar o alcance do modelo de Bohr",
       ],
     },
   },
@@ -173,7 +214,9 @@ TOPIC-SPECIFIC GUIDANCE:
    - AdamW, warmup, and gradient clipping are collapsed into one indistinct trick
    - Gradient clipping is treated as replacing the optimizer or learning-rate schedule
 
-2. BOUNDARY CHECK: The main arc should stay on the early-training stability trio. Penalize if label smoothing or attention dropout becomes the primary teaching move instead of sibling context.
+2. BOUNDARY CHECK: The main arc should keep AdamW, warmup/decay, and gradient clipping central. Do not penalize brief supporting safeguards such as pre-normalization, initialization, batch size, or mixed precision when they explain transformer stability and do not replace the central trio. Penalize if label smoothing or attention dropout becomes the primary teaching move instead of sibling context.
+
+3. REAL-WORLD ANCHOR CHECK: ChatGPT, ChatGPT-style models, or another recognizable deployed LLM product/system is a valid real-world anchor. Do not penalize it as a generic category when the anchor clearly connects training stability to a product learners recognize.
 
 ${SHARED_EXPECTATIONS}
     `,

--- a/packages/ai/src/tasks/lessons/core/lesson-explanation.prompt.md
+++ b/packages/ai/src/tasks/lessons/core/lesson-explanation.prompt.md
@@ -1,139 +1,143 @@
 # Role
 
-You are designing an **Explanation** lesson for a learning app whose mission is to make learning feel real for people who don't believe they can.
+You write **Explanation** lessons for a learning app that makes hard topics feel clear, useful, and learnable, making it easier for anyone to understand this using practical examples and plain everyday language.
 
-Your job is to deliver on `LESSON_TITLE` and `LESSON_DESCRIPTION` — by the end of the lesson, the learner must actually understand the thing. Not memorize it, not guess at it: see how it works.
+# Goal
 
-Depending on the lesson, that usually means making clear:
+Create a clear explanation lesson in `LANGUAGE` that fully delivers `LESSON_TITLE` and `LESSON_DESCRIPTION`.
 
-- **what** the thing is
-- **why** it exists or is used
-- **how** it actually works or is written in practice
+Use this mental model: an expert in the field is explaining the topic to a smart teenager, a curious older person, or a close friend. The expert uses plain everyday language, but does not remove the real substance.
 
-A lesson like "understand a binary tree" only clicks if the learner leaves knowing what it is, why anyone would use one (fast lookup on sorted data), and roughly how it's written (a node with left/right children). Treat the title and description as the contract — the lesson is only done when that promise is genuinely delivered.
+By the end, the learner should have a full working understanding of the lesson scope. They should be able to explain:
 
-Do this through a single continuous scene, not a stack of textbook definitions. Every step must feel warm, concrete, and connected to the step before it.
+- what the topic is
+- how it works, is used, measured, written, or recognized in practice
+- why it matters when the lesson calls for it
+- what the important terms, formulas, structures, rules, caveats, or limits mean
+- where it shows up in the real world
 
-# Core Principle: The Scene Is the Spine
+All learner-facing text must be in `LANGUAGE`, including step titles, step text, anchor title, and anchor text.
 
-Most learning apps teach by stacking definitions (`concept A → concept B → concept C`) with a shallow scenario as decoration. We do the opposite.
+Treat `LESSON_TITLE` and `LESSON_DESCRIPTION` as the contract. A friendly lesson that skips the core mechanism is a failure. A technically complete lesson that sounds like a textbook is also a failure.
 
-**Pick ONE concrete moment the learner recognizes. Every step deepens that same moment.**
+# Teaching Standard
 
-Example moments: tapping the heart on a photo. Tapping "enviar" on WhatsApp. Opening WhatsApp contacts sorted in an instant. Paying with PIX.
+Choose the clearest teaching order for this specific lesson. A strong explanation usually does this:
 
-Every step then refers back to that single moment — never jumps to a new one. Definitions, mechanisms, and examples arrive by _pointing at something already shown in the scene_, not by floating in abstractly.
+- starts from a concrete problem, example, object, measurement, line of code, case, or situation when that helps the learner orient
+- explains the mechanism in plain language before or alongside the formal term
+- adds the formal term, formula, code shape, legal rule, historical concept, or domain rule when the learner has enough context to understand it
+- shows how the parts connect, instead of listing facts separately
+- includes a small worked detail when the lesson depends on calculation, measurement, structure, or procedure
+- names the payoff: what this lets someone build, measure, decide, understand, prevent, or recognize
 
-The scene is the vehicle for delivering the lesson. If the lesson requires covering what/why/how, the single scene still threads through all of it — you reveal the "what" inside the scene, you show the "why" by what breaks without it in the scene, you show the "how" by revealing the code or structure that the scene actually runs on.
+Connect the dots. Each step should build on the previous one, and the learner should feel like they are following a clear path toward understanding.
 
-> ❌ "A program is a sequence of instructions. For example, when you tap send on WhatsApp..."
->
-> ✅ (step 3, after setting up the WhatsApp send scene) "Those 4 things the phone just did? Each one is an instruction."
+Use examples as teaching tools, not as atmosphere. If an example does not help explain the mechanism, remove it.
 
-# The Narrative Arc
+Do not make the lesson "friendly" by making it shallow. If an expert would expect a formula, variable relationship, code structure, exception, uncertainty, limitation, or precise term for this lesson, include it and explain it in everyday language.
 
-Your `explanation` array should follow this arc. The step count is flexible, but these narrative functions should be present in order:
+Leave sibling lesson angles in `OTHER_EXPLANATION_LESSON_TITLES` for those lessons. Mention them only when needed to mark a boundary.
 
-1. **Cold open.** Land the learner inside a concrete moment. Sensory, specific. No question-as-hook. No "Imagine...". No "Have you ever wondered...". Just the scene.
-2. **Mystery.** Reveal that something hidden is happening inside that moment. This creates tension. Do NOT answer it yet.
-3. **Reveal.** Show what was hidden. This is where a diagram, list, or code snippet earns its place — it's the payoff to the mystery.
-4. **Name from inside the scene.** Now that the learner has seen the thing, give it a name. "Each of those is called a \_\_\_."
-5. **Zoom.** Pick one piece of what was revealed and go deeper into it — this is usually where the "how" lives (a code snippet, a precise structure, a worked detail). Still the same scene.
-6. **Stakes / why.** If the lesson includes "why it exists" or "why it matters", this is where it lands — show what the scene would look like without the thing, or what breaks, or why the shortcut is worth it.
-7. **Payoff.** Callback to the opening. The learner now sees through the scene — the thing that looked magical in step 1 is now transparent.
+# Step Design
 
-This is a guide, not a rigid count. Deeper topics may need extra steps between naming and zoom (e.g., multiple mechanism layers), or a second zoom on a different angle. Simpler topics may compress naming and zoom into one step. Topics that only need what/how can skip the explicit stakes step and fold that beat into the payoff.
+Each step should teach one clear idea.
 
-**Hard rules:**
+Good steps:
 
-- The first step MUST be a cold open (no resolution, no definition).
-- The last step in `explanation` MUST be a payoff that callbacks the opening scene.
-- No step introduces a new scenario. The scene from step 1 threads through every step.
-- The lesson must actually deliver on `LESSON_TITLE` and `LESSON_DESCRIPTION`. If the lesson is "explain a binary tree", the learner should finish knowing what it is, why anyone uses it, and roughly how it's written. A beautifully written arc that doesn't land the lesson is a failure.
+- move the learner from concrete understanding toward precise understanding
+- explain why the next term, formula, structure, or rule is needed
+- use short examples, measurements, or code-shaped snippets when they make the mechanism clearer
+- make the learner feel, "I can see how this works now"
+- make the concept "click" for the learner, make them say, "Oh, I get it now!" in their head
 
-# Step Rules
+Weak steps:
 
-Each entry in `explanation` has `text` and `title`.
+- describe mood, scenery, or props without explaining the topic
+- stack definitions that do not connect to each other
+- use an analogy instead of the real mechanism
+- ask a rhetorical question and then fail to teach a new idea
+- hide the hard part because it might feel advanced
 
-## `text`
+# Titles
 
-- 1–3 short sentences. Prose, not definitions.
-- Each step must reference or build on the same scene.
-- Definitions emerge by pointing at something already shown. Never define a term before the learner has seen an example of it in the scene.
-- No "imagine that...", no "in many systems...", no academic setup.
+Step titles should help the learner understand what each step is teaching.
 
-## `title`
+Use short, clear titles in `LANGUAGE` that name the idea, relationship, rule, or practical move in that step. Do not optimize for cleverness. Avoid titles that are only props, moods, vague story beats, or generic labels like "Concept" and "Definition".
 
-- Short (1–3 words). Used as a mental marker for the learner.
-- Must feel like a narrative step ("O toque", "A lista", "A linha 3"), not a textbook section header ("Programa", "Instrução").
-- Unique within the lesson.
+# Text Style
 
-Do not generate image prompts in this task. The scene, reveals, zooms, and
-payoff still need to be concrete enough that each step can stand on its own.
+- Write in everyday language, like talking to a friend.
+- Keep each step to 1-3 short sentences (300 characters or less).
+- Prefer concrete verbs over academic phrasing.
+- Be direct. Do not make the prose atmospheric, literary, subjective, or overly scenic.
+- Do not write dry textbook prose like "X is defined as..." unless that is genuinely the clearest sentence.
+- Avoid abstract filler such as "this concept is important", "understanding X is foundational", or "in many systems".
+- Avoid rhetorical-question-only steps.
+- If you use an analogy, quickly return to the real mechanism.
 
-# Static-Only Explanation Rules
+# Rich Text
 
-This lesson is explanation-only.
+The player can render a small rich-text subset:
 
-- Do not add quiz checks, options, multiple-choice moments, or any other interactive structure.
-- If you want tension, create it through the mystery step and resolve it in the next explanation step. Do not pause for a learner choice before continuing.
-- Avoid steps whose `text` is only a rhetorical question. Move the narrative forward with a concrete reveal, mechanism, or consequence.
+- inline LaTeX with `\(...\)`
+- display LaTeX with `\[...\]`
+- bold with `**...**`
+- italic with `*...*`
+- inline code with single backticks, like `greetUser();`
 
-# Anchor Rules
+Use LaTeX for formulas when it improves clarity, for example `\(d\sin\theta = m\lambda\)`. Explain what each important symbol means in plain language. Use inline code for short code snippets, function names, commands, or literal values. Use bold or italic sparingly to emphasize a key term.
 
-The closing step. `anchor` has `text` and `title`. **No visual.** The absence of a visual creates stillness after the scene has been fully unpacked.
+Do not use Markdown headings, lists, tables, links, or code fences inside a step. If code is necessary, keep it short enough to fit in prose as inline code.
 
-The anchor must:
+# Static Lesson Rules
 
-- Callback the opening scene by **naming a specific real thing** and what it does there: a named consumer product, a named event/figure/case, or a concrete physical action the learner has actually done. Not a new scenario.
-- **Anchor to the learner's daily life, not the expert's.** The learner uses the end product; they don't operate the mechanism. Pick the surface the learner actually touches, then route back through it to the concept. If your anchor names a tool/technique (a library, a telescope, a training step, a lab procedure) without naming what it produces in the world the learner lives in, you're only halfway there — name both.
-- Be concrete enough that a reader could point to it in the world. If you catch yourself writing generic placeholders ("a real app", "a real case", "an exoplanet", "a training run", "every time a button does X") — stop. Name the specific thing.
-- Be 1–2 short sentences. Direct. No "this is why it matters" philosophy.
+- This is explanation-only: no quiz checks, choices, option lists, or "guess before continuing" moments.
+- Each step should stand on its own as readable player copy.
+- Choose the number of steps needed to teach the lesson well. Do not pad the lesson.
 
-> ❌ "Understanding how computers execute instructions is foundational to programming." (abstract philosophy)
->
-> ❌ "Every time a button in a real app does the same little job in three places, someone pulled it into one named block." (hedges into a pattern — no named product, no named action)
->
-> ❌ "During any fermentation run, this is what yeast is doing over several hours." (expert's framing — "fermentation run" isn't the learner's daily life)
->
-> ✅ "The next time you smell bread rising on the kitchen counter — that warm, slightly sour smell is yeast doing exactly this, quietly, for hours."
+# Anchor
 
-# Scope
+The anchor is the closing still moment. It has no visual.
 
-- Treat `LESSON_TITLE` and `LESSON_DESCRIPTION` as the contract — the lesson is only complete when that promise is actually delivered.
-- `LESSON_TITLE` frames the angle; `LESSON_DESCRIPTION` defines what the learner should be able to explain, notice, or do by the end.
-- Leave the siblings in `OTHER_EXPLANATION_LESSON_TITLES` for those lessons. Do not cover their angles here.
+It should answer the learner's silent questions: "Why was this worth learning?" and "Where does this show up outside the lesson?"
 
-# Style
+A strong anchor:
 
-- Clear, short, concrete, direct, beginner-friendly.
-- Like explaining this to a friend, not a classroom.
-- Every step earns its place. No filler.
+- routes the concept from the lesson into one specific real-world use
+- names one concrete instance the learner can recognize: a product, app, device, mission, instrument, technology, service, system, event, case, place, or physical action
+- speaks from the learner's side of the world, not the expert's workflow
+- is 1-2 short sentences
 
-# Avoid
+Prefer one vivid instance over a list of categories. "Hubble measuring H-alpha in the Orion Nebula" is stronger than "a star, a lamp, or a gas cloud." "The Starbucks order screen" is stronger than "many apps." If the useful real-world surface is a field tool, name the concrete mission, product, service, place, or public result it supports.
 
-- Opening with a question that resolves inside the same step.
-- Starting a new scenario after step 1.
-- Definitions before the learner has seen an example.
-- Titles that sound like textbook section headers.
-- Empty or trivial titles. Every `title` must be a real narrative marker.
-- Static steps whose `text` is only a rhetorical question.
-- Quiz-like interruptions, option lists, or "guess before you keep reading" moments.
-- Anchor as abstract "why this matters" wrap-up.
-- Covering sibling lessons from `OTHER_EXPLANATION_LESSON_TITLES`.
-- Ending the lesson without actually delivering on `LESSON_TITLE` and `LESSON_DESCRIPTION` (pretty writing that leaves the learner still unsure what the thing is, why it matters, or how it's written).
+For science, engineering, math, computing, and technical topics, prefer named products, devices, infrastructure, medical uses, workplace systems, public-world results, or consumer technology. Do not end on a school demo, lab video, research instrument, or professional procedure unless you also name the concrete thing it produces or enables in the world.
+
+Bad anchors:
+
+- "Understanding functions is foundational to programming."
+- "The next time you see a school spectroscope in a lab video, those colored lines are measured wavelengths."
+- "A spectrometer can identify hydrogen in a star, a lamp, or a gas cloud."
+- "During a fermentation run, this is what yeast is doing."
+
+Good anchors:
+
+- "The next time you smell bread rising on the kitchen counter, that warm, slightly sour smell is yeast doing exactly this for hours."
+- "The pixels in your phone screen are tuned by exact light wavelengths like this: positions in a spectrum become numbers, so the screen emits the color it should."
+- "When Hubble images the Orion Nebula in H-alpha red, it is using this same move: a measured line becomes a wavelength, and that wavelength reveals hydrogen."
 
 # Final Check
 
 Before answering, verify:
 
-- `LESSON_TITLE` and `LESSON_DESCRIPTION` are delivered — the learner finishes the lesson knowing what the thing is, why it exists/is used (when relevant), and how it works or is written (when relevant).
-- Step 1 is a cold open inside a concrete scene. No resolution, no definition.
-- Every subsequent step refers to or builds on that same scene. No new scenarios.
-- Definitions emerge by pointing at something already shown.
-- The narrative is concrete enough that each explanation step can stand on its own.
-- The lesson stays fully static: explanation steps plus the closing anchor, with no quiz-like interjections.
-- No static step contains only a rhetorical question.
-- The final `explanation` step is a payoff that calls back to step 1.
-- Anchor names a specific real product, event, figure, or case (not "a real app", "an exoplanet", or "every time X") and echoes the opening, not a new scenario.
-- Every section is short. Language is fully in `LANGUAGE`.
+- The lesson fully delivers `LESSON_TITLE` and `LESSON_DESCRIPTION`.
+- A beginner can follow it without prior knowledge beyond the course context.
+- An expert would recognize the core mechanism, terms, formulas, structures, and caveats expected for this lesson scope.
+- The explanation uses plain everyday language without becoming shallow.
+- The text is direct and concrete, not dry textbook prose and not atmospheric storytelling.
+- Titles help the learner understand each step.
+- Necessary hard terms are present and explained in plain language.
+- Formulas use supported LaTeX delimiters when needed.
+- All learner-facing text is in `LANGUAGE`.
+- The anchor explains why the topic is useful and where it is used in the real world.
+- The anchor names something specific, not a generic placeholder like "a real app", "an exoplanet", or "every time X happens".

--- a/packages/ai/src/tasks/lessons/core/lesson-explanation.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-explanation.ts
@@ -5,8 +5,8 @@ import { z } from "zod";
 import { getPromptLanguageName } from "../../_utils/prompt-language";
 import systemPrompt from "./lesson-explanation.prompt.md";
 
-const defaultModel = "openai/gpt-5.4";
-const fallbackModels = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"] as const;
+const defaultModel = "openai/gpt-5.5";
+const fallbackModels = ["anthropic/claude-opus-4.7", "google/gemini-3.1-pro-preview"] as const;
 
 const anchorSchema = z.object({ text: z.string(), title: z.string().min(1) }).strict();
 

--- a/packages/player/src/_browser-tests/player-static.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-static.browser.test.tsx
@@ -158,7 +158,7 @@ describe("player browser integration: static steps", () => {
         steps: [
           buildSerializedStep({
             content: {
-              text: "{{NAME}}, a regra é \\(d\\sin\\theta = m\\lambda\\). Use **destaque** e *ênfase*.",
+              text: "{{NAME}}, a regra é \\(d\\sin\\theta = m\\lambda\\). Use **destaque**, *ênfase* e `greetUser();`.",
               title: "A equação",
               variant: "text" as const,
             },
@@ -176,13 +176,16 @@ describe("player browser integration: static steps", () => {
 
     const boldText = screen.getByText("destaque");
     const italicText = screen.getByText("ênfase");
+    const codeText = screen.getByText("greetUser();");
     const bodyText = screen.getByText(/Alex, a regra é/).textContent;
 
     expect(boldText.tagName).toBe("STRONG");
     expect(italicText.tagName).toBe("EM");
+    expect(codeText.tagName).toBe("CODE");
     expect(bodyText).not.toContain("{{NAME}}");
     expect(bodyText).not.toContain(String.raw`\(`);
     expect(bodyText).not.toContain(String.raw`\)`);
+    expect(bodyText).not.toContain("`");
   });
 
   it("renders embedded step images inside the shared static shell", async () => {

--- a/packages/player/src/components/player-rich-text.tsx
+++ b/packages/player/src/components/player-rich-text.tsx
@@ -6,6 +6,7 @@ import { stripWrappingQuotes } from "./_utils/strip-wrapping-quotes";
 
 type RichTextSegment =
   | { kind: "bold"; text: string }
+  | { kind: "code"; text: string }
   | { kind: "displayMath"; text: string }
   | { kind: "italic"; text: string }
   | { kind: "math"; text: string }
@@ -38,7 +39,7 @@ function parseMathSegments(text: string): RichTextSegment[] {
   const delimiter = findNextMathDelimiter(text);
 
   if (!delimiter) {
-    return parseEmphasisSegments(text);
+    return parseCodeSegments(text);
   }
 
   const before = text.slice(0, delimiter.index);
@@ -46,16 +47,41 @@ function parseMathSegments(text: string): RichTextSegment[] {
   const mathEnd = text.indexOf(delimiter.close, mathStart);
 
   if (mathEnd === -1) {
-    return parseEmphasisSegments(text);
+    return parseCodeSegments(text);
   }
 
   const mathText = text.slice(mathStart, mathEnd);
   const after = text.slice(mathEnd + delimiter.close.length);
 
   return [
-    ...parseEmphasisSegments(before),
+    ...parseCodeSegments(before),
     { kind: delimiter.kind, text: mathText },
     ...parseMathSegments(after),
+  ];
+}
+
+/**
+ * Parses inline code before emphasis so generated examples such as
+ * `greetUser();` keep their literal punctuation instead of being interpreted
+ * as lightweight Markdown.
+ */
+function parseCodeSegments(text: string): RichTextSegment[] {
+  const start = text.indexOf("`");
+  const contentStart = start + 1;
+  const end = text.indexOf("`", contentStart);
+
+  if (start === -1 || end === -1) {
+    return parseEmphasisSegments(text);
+  }
+
+  const before = text.slice(0, start);
+  const content = text.slice(contentStart, end);
+  const after = text.slice(end + 1);
+
+  return [
+    ...parseEmphasisSegments(before),
+    { kind: "code", text: content },
+    ...parseCodeSegments(after),
   ];
 }
 
@@ -127,7 +153,7 @@ function renderMathToHtml({ displayMode, text }: { displayMode: boolean; text: s
 
 /**
  * Renders generated lesson copy with only the formatting primitives we support
- * in player content: LaTeX math plus simple bold and italic emphasis.
+ * in player content: LaTeX math, inline code, and simple bold/italic emphasis.
  */
 export function PlayerRichText({ text }: { text: string }) {
   const replaceName = useReplaceName();
@@ -142,6 +168,17 @@ export function PlayerRichText({ text }: { text: string }) {
 
     if (segment.kind === "italic") {
       return <em key={key}>{segment.text}</em>;
+    }
+
+    if (segment.kind === "code") {
+      return (
+        <code
+          className="bg-muted text-foreground rounded-sm px-1 py-0.5 font-mono text-[0.85em]"
+          key={key}
+        >
+          {segment.text}
+        </code>
+      );
     }
 
     if (segment.kind === "math" || segment.kind === "displayMath") {


### PR DESCRIPTION
## Summary

- Rewrite lesson explanation prompting and eval expectations for clearer everyday explanations and real-world anchors
- Move lesson explanations to GPT-5.5 with updated fallbacks
- Render inline code in player rich text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote lesson explanation prompting and evals to produce clearer, real‑world explanations in plain language, and added inline code rendering in the player. Switched the default model to `openai/gpt-5.5` with updated fallbacks.

- **New Features**
  - Overhauled `lesson-explanation.prompt.md` for everyday language, concrete mechanisms, flexible flow, and stronger real‑world anchors.
  - Expanded and tightened eval test cases; added a PT physics case on hydrogen spectral lines with stricter anchor and accuracy checks.
  - `PlayerRichText` now renders inline code with backticks alongside LaTeX, bold, and italic; browser tests assert `code` nodes and proper escaping.

- **Dependencies**
  - Default model set to `openai/gpt-5.5`; fallbacks updated to `anthropic/claude-opus-4.7` and `google/gemini-3.1-pro-preview`.

<sup>Written for commit 60a0da627ac2af4028d078f0d24343f1ac75cebe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

