### PR TITLE
fix(main): route contact feedback through api

### DIFF
--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -1,6 +1,5 @@
 import { withSentryConfig } from "@sentry/nextjs";
 import { getPublicAppSecurityHeaders } from "@zoonk/next/security/headers";
-import { withBotId } from "botid/next/config";
 import { type NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 import { withWorkflow } from "workflow/next";
@@ -41,7 +40,7 @@ const withNextIntl = createNextIntlPlugin({
   },
 });
 
-export default withSentryConfig(withWorkflow(withBotId(withNextIntl(nextConfig))), {
+export default withSentryConfig(withWorkflow(withNextIntl(nextConfig)), {
   org: "zoonk",
   project: "zoonk-api",
   silent: true,

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,7 +26,6 @@
     "@zoonk/next": "workspace:*",
     "@zoonk/ui": "workspace:*",
     "@zoonk/utils": "workspace:*",
-    "botid": "catalog:",
     "lucide-react": "catalog:",
     "next": "catalog:",
     "next-intl": "catalog:",

--- a/apps/api/src/instrumentation-client.ts
+++ b/apps/api/src/instrumentation-client.ts
@@ -1,5 +1,4 @@
 import { captureRouterTransitionStart, init } from "@sentry/nextjs";
-import { initBotId } from "botid/client/core";
 
 if (process.env.NODE_ENV === "production") {
   init({
@@ -11,11 +10,3 @@ if (process.env.NODE_ENV === "production") {
 }
 
 export const onRouterTransitionStart = captureRouterTransitionStart;
-
-initBotId({
-  protect: [
-    { method: "POST", path: "/v1/*" },
-    { method: "GET", path: "/v1/*" },
-    { method: "PATCH", path: "/v1/*" },
-  ],
-});

--- a/apps/main/e2e/content-feedback.test.ts
+++ b/apps/main/e2e/content-feedback.test.ts
@@ -46,6 +46,18 @@ test.describe("Content Feedback", () => {
   });
 
   test("submit with valid data shows success message", async ({ page }) => {
+    let feedbackBody: unknown = null;
+
+    await page.route("**/v1/feedback", async (route) => {
+      feedbackBody = route.request().postDataJSON();
+
+      await route.fulfill({
+        contentType: "application/json",
+        json: { message: "Feedback received" },
+        status: 200,
+      });
+    });
+
     const feedbackButton = page.getByRole("button", { name: /send feedback/i });
     const dialog = page.getByRole("dialog");
     await openDialog(feedbackButton, dialog);
@@ -64,6 +76,10 @@ test.describe("Content Feedback", () => {
     await dialog.getByRole("button", { name: /send message/i }).click();
 
     await expect(dialog.getByText(/message sent successfully/i)).toBeVisible();
+
+    await expect
+      .poll(() => feedbackBody)
+      .toStrictEqual({ email: "test@example.com", message: "This is test feedback" });
   });
 
   test("submit with invalid email shows validation error", async ({ page }) => {

--- a/apps/main/e2e/content-feedback.test.ts
+++ b/apps/main/e2e/content-feedback.test.ts
@@ -1,5 +1,6 @@
 import { openDialog } from "@zoonk/e2e/fixtures/dialog";
 import { searchPromptWithSuggestionsFixture } from "@zoonk/testing/fixtures/course-suggestions";
+import { mockFeedbackSubmission } from "./feedback";
 import { expect, test } from "./fixtures";
 
 let prompt: string;
@@ -46,17 +47,7 @@ test.describe("Content Feedback", () => {
   });
 
   test("submit with valid data shows success message", async ({ page }) => {
-    let feedbackBody: unknown = null;
-
-    await page.route("**/v1/feedback", async (route) => {
-      feedbackBody = route.request().postDataJSON();
-
-      await route.fulfill({
-        contentType: "application/json",
-        json: { message: "Feedback received" },
-        status: 200,
-      });
-    });
+    const feedbackSubmission = await mockFeedbackSubmission(page);
 
     const feedbackButton = page.getByRole("button", { name: /send feedback/i });
     const dialog = page.getByRole("dialog");
@@ -77,9 +68,10 @@ test.describe("Content Feedback", () => {
 
     await expect(dialog.getByText(/message sent successfully/i)).toBeVisible();
 
-    await expect
-      .poll(() => feedbackBody)
-      .toStrictEqual({ email: "test@example.com", message: "This is test feedback" });
+    await expect(feedbackSubmission.requestBody).resolves.toStrictEqual({
+      email: "test@example.com",
+      message: "This is test feedback",
+    });
   });
 
   test("submit with invalid email shows validation error", async ({ page }) => {

--- a/apps/main/e2e/feedback.ts
+++ b/apps/main/e2e/feedback.ts
@@ -1,0 +1,26 @@
+import { type Page } from "@playwright/test";
+
+type FeedbackSubmissionMock = { requestBody: Promise<unknown> };
+
+/**
+ * Replaces the public feedback API with a local success response so feedback
+ * UI tests prove the browser sends the expected payload without consuming
+ * mailer quota or depending on the API app being available during main e2e.
+ */
+export async function mockFeedbackSubmission(page: Page): Promise<FeedbackSubmissionMock> {
+  await page.route("**/v1/feedback", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      json: { message: "Feedback received" },
+      status: 200,
+    });
+  });
+
+  return {
+    requestBody: page.waitForRequest("**/v1/feedback").then((request) => {
+      const requestBody: unknown = request.postDataJSON();
+
+      return requestBody;
+    }),
+  };
+}

--- a/apps/main/e2e/support.test.ts
+++ b/apps/main/e2e/support.test.ts
@@ -1,4 +1,5 @@
 import { openDialog } from "@zoonk/e2e/fixtures/dialog";
+import { mockFeedbackSubmission } from "./feedback";
 import { expect, test } from "./fixtures";
 
 test.describe("Support page", () => {
@@ -15,6 +16,8 @@ test.describe("Support page", () => {
   });
 
   test("submit with valid data shows success message", async ({ page }) => {
+    const feedbackSubmission = await mockFeedbackSubmission(page);
+
     const supportButton = page.getByRole("button", { name: /contact support/i });
     const dialog = page.getByRole("dialog");
     await openDialog(supportButton, dialog);
@@ -31,6 +34,11 @@ test.describe("Support page", () => {
     await dialog.getByRole("button", { name: /send message/i }).click();
 
     await expect(dialog.getByText(/message sent successfully/i)).toBeVisible();
+
+    await expect(feedbackSubmission.requestBody).resolves.toStrictEqual({
+      email: "test@example.com",
+      message: "Test message",
+    });
   });
 
   test("submit with invalid email shows validation error", async ({ page }) => {

--- a/apps/main/src/components/feedback/contact-form-action.ts
+++ b/apps/main/src/components/feedback/contact-form-action.ts
@@ -1,21 +1,61 @@
-"use server";
-
-import { sendFeedbackMessage } from "@zoonk/core/feedback/send";
+import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
+import { API_URL } from "@zoonk/utils/url";
 
-export async function contactFormAction(_prevState: unknown, formData: FormData) {
+export type ContactFormState = { status: "idle" | "error" | "success" };
+
+type FeedbackPayload = { email: string; message: string };
+
+const FEEDBACK_URL = new URL("/v1/feedback", API_URL).toString();
+
+/**
+ * Normalizes the form before sending it to the API so the UI can fail fast for
+ * empty messages while the public API remains the source of truth for feedback
+ * validation and abuse controls.
+ */
+function getFeedbackPayload(formData: FormData): FeedbackPayload | null {
   const email = parseFormField(formData, "email");
   const message = parseFormField(formData, "message");
 
   if (!(email && message)) {
+    return null;
+  }
+
+  return { email, message };
+}
+
+/**
+ * Sends web feedback through the same public endpoint native clients use so
+ * quota protection stays attached to one ingestion path instead of each UI
+ * surface calling the mailer directly.
+ */
+async function sendFeedbackRequest(payload: FeedbackPayload): Promise<boolean> {
+  const { data: response, error } = await safeAsync(() =>
+    fetch(FEEDBACK_URL, {
+      body: JSON.stringify(payload),
+      headers: { "Content-Type": "application/json" },
+      method: "POST",
+    }),
+  );
+
+  return Boolean(response?.ok && !error);
+}
+
+/**
+ * Handles the browser form submission and maps API failures back to the small
+ * state shape the dialog already understands.
+ */
+export async function contactFormAction(
+  _prevState: ContactFormState,
+  formData: FormData,
+): Promise<ContactFormState> {
+  const payload = getFeedbackPayload(formData);
+
+  if (!payload) {
     return { status: "error" };
   }
 
-  const { error } = await sendFeedbackMessage({ email, message });
+  const sent = await sendFeedbackRequest(payload);
 
-  if (error) {
-    return { status: "error" };
-  }
-
-  return { status: "success" };
+  return { status: sent ? "success" : "error" };
 }

--- a/apps/main/src/components/feedback/contact-form.tsx
+++ b/apps/main/src/components/feedback/contact-form.tsx
@@ -13,9 +13,9 @@ import { Textarea } from "@zoonk/ui/components/textarea";
 import { SubmitButton } from "@zoonk/ui/patterns/buttons/submit";
 import { useExtracted } from "next-intl";
 import { useActionState, useId } from "react";
-import { contactFormAction } from "./contact-form-action";
+import { type ContactFormState, contactFormAction } from "./contact-form-action";
 
-const initialState: { status: "idle" | "error" | "success" } = { status: "idle" };
+const initialState: ContactFormState = { status: "idle" };
 
 export function ContactForm({ defaultEmail }: { defaultEmail?: string }) {
   const t = useExtracted();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,9 +227,6 @@ importers:
       '@zoonk/utils':
         specifier: workspace:*
         version: link:../../packages/utils
-      botid:
-        specifier: 'catalog:'
-        version: 1.5.11(next@16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       lucide-react:
         specifier: 'catalog:'
         version: 1.14.0(react@19.2.5)


### PR DESCRIPTION
## Summary
- route main contact form submissions through the existing API feedback endpoint
- remove unused BotID setup from the API app
- cover the feedback API request in the content feedback e2e test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route contact and support feedback through the public `/v1/feedback` API to centralize validation and abuse/quota checks. Add a shared e2e mock to verify payloads without hitting the API, and remove unused `botid` from the API app.

- **Refactors**
  - `contact-form-action` now posts to `${API_URL}/v1/feedback` using `fetch` and maps the API result to the dialog state.
  - Introduced `ContactFormState` type; no UI changes.
  - Added `mockFeedbackSubmission` for e2e and used it in content feedback and support tests to assert the JSON body.

- **Dependencies**
  - Removed `botid` integration from the API app (`next.config`, instrumentation, `package.json`, lockfile).

<sup>Written for commit 7e9b93eda94e4ec6eb021155cf7279a9abd13e8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

