### PR TITLE
feat(oxlint-plugin): add tailwind canonical class rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -138,7 +138,8 @@
     "zoonk/no-object-params-in-cache": ["error", { "exceptions": ["headers"] }],
     "zoonk/no-hardcoded-aria-label": "off",
     "zoonk/no-t-function-as-argument": "error",
-    "zoonk/padding-around-multiline-statements": "error"
+    "zoonk/padding-around-multiline-statements": "error",
+    "zoonk/tailwind-canonical-classes": "error"
   },
   "overrides": [
     {

--- a/apps/main/src/app/(catalog)/(home)/continue-learning.tsx
+++ b/apps/main/src/app/(catalog)/(home)/continue-learning.tsx
@@ -39,7 +39,7 @@ function ContinueLearningLayout({
   }
 
   return (
-    <div className="overflow-x-auto [scrollbar-width:none] sm:overflow-x-visible [&::-webkit-scrollbar]:hidden">
+    <div className="overflow-x-auto scrollbar-none sm:overflow-x-visible [&::-webkit-scrollbar]:hidden">
       <div className="flex w-max min-w-full snap-x snap-mandatory gap-4 px-4 pb-1 sm:grid sm:w-auto sm:min-w-0 sm:snap-none sm:grid-cols-2 sm:pb-0 lg:grid-cols-3 xl:grid-cols-4">
         {children}
       </div>

--- a/apps/main/src/app/(catalog)/(home)/continue-learning.tsx
+++ b/apps/main/src/app/(catalog)/(home)/continue-learning.tsx
@@ -39,7 +39,7 @@ function ContinueLearningLayout({
   }
 
   return (
-    <div className="overflow-x-auto scrollbar-none sm:overflow-x-visible [&::-webkit-scrollbar]:hidden">
+    <div className="scrollbar-none overflow-x-auto sm:overflow-x-visible [&::-webkit-scrollbar]:hidden">
       <div className="flex w-max min-w-full snap-x snap-mandatory gap-4 px-4 pb-1 sm:grid sm:w-auto sm:min-w-0 sm:snap-none sm:grid-cols-2 sm:pb-0 lg:grid-cols-3 xl:grid-cols-4">
         {children}
       </div>

--- a/packages/oxlint-plugin/index.js
+++ b/packages/oxlint-plugin/index.js
@@ -5,6 +5,7 @@ import noHardcodedAriaLabel from "./rules/no-hardcoded-aria-label.js";
 import noObjectParamsInCache from "./rules/no-object-params-in-cache.js";
 import noTFunctionAsArgument from "./rules/no-t-function-as-argument.js";
 import paddingAroundMultilineStatements from "./rules/padding-around-multiline-statements.js";
+import tailwindCanonicalClasses from "./rules/tailwind-canonical-classes.js";
 
 /** @public */
 export default eslintCompatPlugin({
@@ -16,5 +17,6 @@ export default eslintCompatPlugin({
     "no-object-params-in-cache": noObjectParamsInCache,
     "no-t-function-as-argument": noTFunctionAsArgument,
     "padding-around-multiline-statements": paddingAroundMultilineStatements,
+    "tailwind-canonical-classes": tailwindCanonicalClasses,
   },
 });

--- a/packages/oxlint-plugin/package.json
+++ b/packages/oxlint-plugin/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@oxlint/plugins": "1.64.0"
+    "@oxlint/plugins": "1.64.0",
+    "@tailwindcss/node": "4.3.0"
   }
 }

--- a/packages/oxlint-plugin/rules/tailwind-canonical-classes.js
+++ b/packages/oxlint-plugin/rules/tailwind-canonical-classes.js
@@ -1,0 +1,295 @@
+import { readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineRule } from "@oxlint/plugins";
+import { __unstable__loadDesignSystem } from "@tailwindcss/node";
+
+const CLASS_ATTRIBUTE_NAMES = new Set(["class", "className"]);
+const CLASS_FUNCTION_NAMES = new Set(["clsx", "cn", "cva", "twMerge"]);
+const STYLESHEET_URL = new URL("../../../packages/ui/src/styles/globals.css", import.meta.url);
+const STYLESHEET_PATH = fileURLToPath(STYLESHEET_URL);
+
+const designSystem = await loadDesignSystem();
+
+/**
+ * The Tailwind language server uses Tailwind's own design system to decide
+ * which utility spelling is canonical. Loading the same stylesheet keeps this
+ * lint rule aligned with the CSS entrypoint that defines Zoonk's theme tokens.
+ */
+async function loadDesignSystem() {
+  const stylesheet = await readFile(STYLESHEET_PATH, "utf8");
+
+  return __unstable__loadDesignSystem(stylesheet, { base: dirname(STYLESHEET_PATH) });
+}
+
+/**
+ * JSX namespaced attributes are not class attributes in this codebase. Keeping
+ * the name check narrow avoids treating unrelated SVG or framework attributes
+ * as Tailwind class lists.
+ */
+function isClassAttributeName(name) {
+  return name.type === "JSXIdentifier" && CLASS_ATTRIBUTE_NAMES.has(name.name);
+}
+
+/**
+ * The rule only inspects known class composition helpers because ordinary
+ * function string arguments may be copy, IDs, URLs, or enum values rather than
+ * Tailwind classes.
+ */
+function getClassFunctionName(callee) {
+  if (callee.type === "Identifier") {
+    return callee.name;
+  }
+
+  if (callee.type === "MemberExpression" && callee.property.type === "Identifier") {
+    return callee.property.name;
+  }
+
+  return null;
+}
+
+/**
+ * Dynamic template strings can contain partial utility names, so Tailwind cannot
+ * safely canonicalize them as complete candidates. Static templates are handled
+ * the same way as normal string literals.
+ */
+function getStaticStringExpression(expression) {
+  if (expression.type === "Literal" && typeof expression.value === "string") {
+    return expression;
+  }
+
+  if (expression.type === "TemplateLiteral" && expression.expressions.length === 0) {
+    return expression;
+  }
+
+  return null;
+}
+
+/**
+ * Replacement ranges are based on the raw source, not the decoded JS value, so
+ * fixes preserve the surrounding quotes/backticks and only replace class tokens.
+ */
+function getStringContentRange({ node, sourceText }) {
+  const text = sourceText.slice(node.range[0], node.range[1]);
+  const quote = text[0];
+  const closesWithSameQuote = text.at(-1) === quote;
+  const isQuoted = quote === '"' || quote === "'" || quote === "`";
+  const content = text.slice(1, -1);
+
+  if (!isQuoted || !closesWithSameQuote || content.includes("\\")) {
+    return null;
+  }
+
+  return { content, start: node.range[0] + 1 };
+}
+
+/**
+ * Tailwind classes are whitespace-delimited in source files. Reporting each
+ * token separately gives Oxlint a small, conflict-free fix range for `--fix`.
+ */
+function getClassTokens({ content, start }) {
+  return Array.from(content.matchAll(/\S+/gu), (match) => ({
+    end: start + match.index + match[0].length,
+    start: start + match.index,
+    value: match[0],
+  }));
+}
+
+/**
+ * Tailwind returns the original candidate when no better canonical spelling is
+ * available. This helper isolates that API detail from the reporting logic.
+ */
+function getCanonicalClassName(className) {
+  const [canonicalClassName] = designSystem.canonicalizeCandidates([className]);
+
+  if (!canonicalClassName || canonicalClassName === className) {
+    return null;
+  }
+
+  return canonicalClassName;
+}
+
+/**
+ * Mapping byte offsets back to a source location makes diagnostics point at the
+ * exact class token instead of the whole attribute or helper call.
+ */
+function getTokenLocation({ sourceCode, token }) {
+  return {
+    end: sourceCode.getLocFromIndex(token.end),
+    start: sourceCode.getLocFromIndex(token.start),
+  };
+}
+
+/**
+ * Object values in class helpers may contain nested class strings, but condition
+ * values like identifiers and booleans are not classes. This lets `clsx` object
+ * keys still be linted without treating every property name as a class.
+ */
+function canContainClassString(expression) {
+  if (expression.type === "Literal") {
+    return typeof expression.value === "string";
+  }
+
+  return (
+    expression.type === "ArrayExpression" ||
+    expression.type === "ConditionalExpression" ||
+    expression.type === "LogicalExpression" ||
+    expression.type === "ObjectExpression" ||
+    expression.type === "TemplateLiteral"
+  );
+}
+
+/**
+ * Static class strings are fixed token-by-token, which preserves existing class
+ * ordering and whitespace while still applying Tailwind's canonical spellings.
+ */
+function reportClassString({ context, node, sourceText }) {
+  const contentRange = getStringContentRange({ node, sourceText });
+
+  if (!contentRange) {
+    return;
+  }
+
+  const tokens = getClassTokens(contentRange);
+
+  for (const token of tokens) {
+    const canonicalClassName = getCanonicalClassName(token.value);
+
+    if (canonicalClassName) {
+      context.report({
+        data: { actual: token.value, expected: canonicalClassName },
+        loc: getTokenLocation({ sourceCode: context.sourceCode, token }),
+        messageId: "useCanonicalClass",
+        fix(fixer) {
+          return fixer.replaceTextRange([token.start, token.end], canonicalClassName);
+        },
+      });
+    }
+  }
+}
+
+/**
+ * Class helpers accept arrays, conditionals, and object values. Walking those
+ * small expression containers lets the rule catch static classes without trying
+ * to evaluate runtime conditions.
+ */
+function checkClassExpression({ context, expression, sourceText }) {
+  const staticString = getStaticStringExpression(expression);
+
+  if (staticString) {
+    reportClassString({ context, node: staticString, sourceText });
+
+    return;
+  }
+
+  if (expression.type === "ArrayExpression") {
+    for (const element of expression.elements) {
+      if (element) {
+        checkClassExpression({ context, expression: element, sourceText });
+      }
+    }
+
+    return;
+  }
+
+  if (expression.type === "ConditionalExpression") {
+    checkClassExpression({ context, expression: expression.consequent, sourceText });
+    checkClassExpression({ context, expression: expression.alternate, sourceText });
+
+    return;
+  }
+
+  if (expression.type === "LogicalExpression") {
+    checkClassExpression({ context, expression: expression.right, sourceText });
+
+    return;
+  }
+
+  if (expression.type === "ObjectExpression") {
+    for (const property of expression.properties) {
+      checkClassProperty({ context, property, sourceText });
+    }
+  }
+}
+
+/**
+ * Object properties show up in both `clsx({ "class": condition })` and `cva`
+ * variant maps. Values are always safe to inspect; string keys are checked only
+ * when the value is not itself another class expression.
+ */
+function checkClassProperty({ context, property, sourceText }) {
+  if (property.type !== "Property") {
+    return;
+  }
+
+  const valueCanContainClassString = canContainClassString(property.value);
+
+  if (valueCanContainClassString) {
+    checkClassExpression({ context, expression: property.value, sourceText });
+  }
+
+  if (!valueCanContainClassString && property.key.type === "Literal") {
+    checkClassExpression({ context, expression: property.key, sourceText });
+  }
+}
+
+/**
+ * A helper call inside `className={...}` is already covered by the surrounding
+ * JSX attribute visitor, so skipping it here prevents duplicate diagnostics.
+ */
+function isInsideClassAttribute({ context, node }) {
+  return context.sourceCode
+    .getAncestors(node)
+    .some((ancestor) => ancestor.type === "JSXAttribute" && isClassAttributeName(ancestor.name));
+}
+
+export default defineRule({
+  create(context) {
+    const sourceText = context.sourceCode.getText();
+
+    return {
+      CallExpression(node) {
+        const classFunctionName = getClassFunctionName(node.callee);
+
+        if (!classFunctionName || !CLASS_FUNCTION_NAMES.has(classFunctionName)) {
+          return;
+        }
+
+        if (isInsideClassAttribute({ context, node })) {
+          return;
+        }
+
+        for (const argument of node.arguments) {
+          checkClassExpression({ context, expression: argument, sourceText });
+        }
+      },
+
+      JSXAttribute(node) {
+        if (!isClassAttributeName(node.name) || !node.value) {
+          return;
+        }
+
+        if (node.value.type === "Literal") {
+          reportClassString({ context, node: node.value, sourceText });
+
+          return;
+        }
+
+        if (node.value.type === "JSXExpressionContainer") {
+          checkClassExpression({ context, expression: node.value.expression, sourceText });
+        }
+      },
+    };
+  },
+
+  meta: {
+    docs: {
+      description:
+        "Require Tailwind utility classes to use the canonical spelling returned by Tailwind CSS",
+    },
+    fixable: "code",
+    messages: { useCanonicalClass: "Use '{{expected}}' instead of '{{actual}}'." },
+    schema: [],
+    type: "suggestion",
+  },
+});

--- a/packages/ui/src/components/button-group.tsx
+++ b/packages/ui/src/components/button-group.tsx
@@ -5,15 +5,15 @@ import { cn } from "@zoonk/ui/lib/utils";
 import { type VariantProps, cva } from "class-variance-authority";
 
 const buttonGroupVariants = cva(
-  "flex w-fit items-stretch has-[>[data-slot=button-group]]:gap-2 [&>*]:focus-visible:relative [&>*]:focus-visible:z-10 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-4xl [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+  "flex w-fit items-stretch has-[>[data-slot=button-group]]:gap-2 *:focus-visible:relative *:focus-visible:z-10 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-4xl [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
   {
     defaultVariants: { orientation: "horizontal" },
     variants: {
       orientation: {
         horizontal:
-          "[&>[data-slot]]:rounded-r-none [&>[data-slot]:not(:has(~[data-slot]))]:rounded-r-4xl! [&>[data-slot]~[data-slot]]:rounded-l-none [&>[data-slot]~[data-slot]]:border-l-0",
+          "*:data-slot:rounded-r-none [&>[data-slot]:not(:has(~[data-slot]))]:rounded-r-4xl! [&>[data-slot]~[data-slot]]:rounded-l-none [&>[data-slot]~[data-slot]]:border-l-0",
         vertical:
-          "flex-col [&>[data-slot]]:rounded-b-none [&>[data-slot]:not(:has(~[data-slot]))]:rounded-b-4xl! [&>[data-slot]~[data-slot]]:rounded-t-none [&>[data-slot]~[data-slot]]:border-t-0",
+          "flex-col *:data-slot:rounded-b-none [&>[data-slot]:not(:has(~[data-slot]))]:rounded-b-4xl! [&>[data-slot]~[data-slot]]:rounded-t-none [&>[data-slot]~[data-slot]]:border-t-0",
       },
     },
   },

--- a/packages/ui/src/components/button-group.tsx
+++ b/packages/ui/src/components/button-group.tsx
@@ -5,7 +5,7 @@ import { cn } from "@zoonk/ui/lib/utils";
 import { type VariantProps, cva } from "class-variance-authority";
 
 const buttonGroupVariants = cva(
-  "flex w-fit items-stretch has-[>[data-slot=button-group]]:gap-2 *:focus-visible:relative *:focus-visible:z-10 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-4xl [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+  "flex w-fit items-stretch *:focus-visible:relative *:focus-visible:z-10 has-[>[data-slot=button-group]]:gap-2 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-4xl [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
   {
     defaultVariants: { orientation: "horizontal" },
     variants: {

--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -59,7 +59,7 @@ const fieldVariants = cva("group/field data-[invalid=true]:text-destructive flex
       horizontal:
         "flex-row items-center has-[>[data-slot=field-content]]:items-start *:data-[slot=field-label]:flex-auto has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
       responsive:
-        "flex-col @md/field-group:flex-row @md/field-group:items-center @md/field-group:has-[>[data-slot=field-content]]:items-start *:w-full @md/field-group:*:w-auto [&>.sr-only]:w-auto @md/field-group:*:data-[slot=field-label]:flex-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        "flex-col *:w-full @md/field-group:flex-row @md/field-group:items-center @md/field-group:*:w-auto @md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:*:data-[slot=field-label]:flex-auto [&>.sr-only]:w-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
       vertical: "flex-col *:w-full [&>.sr-only]:w-auto",
     },
   },

--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -57,10 +57,10 @@ const fieldVariants = cva("group/field data-[invalid=true]:text-destructive flex
   variants: {
     orientation: {
       horizontal:
-        "flex-row items-center has-[>[data-slot=field-content]]:items-start [&>[data-slot=field-label]]:flex-auto has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        "flex-row items-center has-[>[data-slot=field-content]]:items-start *:data-[slot=field-label]:flex-auto has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
       responsive:
-        "flex-col @md/field-group:flex-row @md/field-group:items-center @md/field-group:has-[>[data-slot=field-content]]:items-start [&>*]:w-full @md/field-group:[&>*]:w-auto [&>.sr-only]:w-auto @md/field-group:[&>[data-slot=field-label]]:flex-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
-      vertical: "flex-col [&>*]:w-full [&>.sr-only]:w-auto",
+        "flex-col @md/field-group:flex-row @md/field-group:items-center @md/field-group:has-[>[data-slot=field-content]]:items-start *:w-full @md/field-group:*:w-auto [&>.sr-only]:w-auto @md/field-group:*:data-[slot=field-label]:flex-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+      vertical: "flex-col *:w-full [&>.sr-only]:w-auto",
     },
   },
 });

--- a/packages/ui/src/components/input-group.tsx
+++ b/packages/ui/src/components/input-group.tsx
@@ -31,8 +31,8 @@ const inputGroupAddonVariants = cva(
           "order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-3 [.border-t]:pt-3",
         "block-start":
           "order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-3 [.border-b]:pb-3",
-        "inline-end": "order-last pr-3 has-[>button]:mr-[-0.25rem] has-[>kbd]:mr-[-0.15rem]",
-        "inline-start": "order-first pl-3 has-[>button]:ml-[-0.25rem] has-[>kbd]:ml-[-0.15rem]",
+        "inline-end": "order-last pr-3 has-[>button]:-mr-1 has-[>kbd]:mr-[-0.15rem]",
+        "inline-start": "order-first pl-3 has-[>button]:-ml-1 has-[>kbd]:ml-[-0.15rem]",
       },
     },
   },

--- a/packages/ui/src/components/item.tsx
+++ b/packages/ui/src/components/item.tsx
@@ -50,7 +50,7 @@ const itemVariants = cva(
       size: {
         default: "gap-3.5 px-4 py-3.5",
         sm: "gap-3.5 px-3.5 py-3",
-        xs: "gap-2.5 px-3 py-2.5 [[data-slot=dropdown-menu-content]_&]:p-0",
+        xs: "gap-2.5 px-3 py-2.5 in-data-[slot=dropdown-menu-content]:p-0",
       },
       variant: {
         default: "border-transparent",
@@ -73,7 +73,7 @@ function Item({ className, variant = "default", size = "default", render, ...pro
 }
 
 const itemMediaVariants = cva(
-  "flex shrink-0 items-center justify-center gap-2 group-has-[[data-slot=item-description]]/item:translate-y-0.5 group-has-[[data-slot=item-description]]/item:self-start [&_svg]:pointer-events-none",
+  "flex shrink-0 items-center justify-center gap-2 group-has-data-[slot=item-description]/item:translate-y-0.5 group-has-data-[slot=item-description]/item:self-start [&_svg]:pointer-events-none",
   {
     defaultVariants: { variant: "default" },
     variants: {

--- a/packages/ui/src/components/loading.tsx
+++ b/packages/ui/src/components/loading.tsx
@@ -3,7 +3,7 @@ export function FullPageLoading() {
     <div aria-busy="true" className="bg-background fixed inset-0 flex items-center justify-center">
       <div
         aria-hidden="true"
-        className="bg-foreground/80 inset-0 size-5 animate-[breathe_2s_ease-in-out_infinite] rounded-full"
+        className="bg-foreground/80 inset-0 size-5 animate-breathe rounded-full"
       />
     </div>
   );

--- a/packages/ui/src/components/loading.tsx
+++ b/packages/ui/src/components/loading.tsx
@@ -3,7 +3,7 @@ export function FullPageLoading() {
     <div aria-busy="true" className="bg-background fixed inset-0 flex items-center justify-center">
       <div
         aria-hidden="true"
-        className="bg-foreground/80 inset-0 size-5 animate-breathe rounded-full"
+        className="bg-foreground/80 animate-breathe inset-0 size-5 rounded-full"
       />
     </div>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -810,6 +810,9 @@ importers:
       '@oxlint/plugins':
         specifier: 1.64.0
         version: 1.64.0
+      '@tailwindcss/node':
+        specifier: 4.3.0
+        version: 4.3.0
 
   packages/player:
     dependencies:


### PR DESCRIPTION
Adds a custom Oxlint rule that uses Tailwind's canonicalizer to catch and auto-fix non-canonical static class names. Also applies the current canonical class cleanup across the repo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Tailwind canonical class lint rule to our `oxlint` plugin that flags and auto-fixes non-canonical utility classes. Also updates class names across the repo to their canonical forms.

- **New Features**
  - Added rule `zoonk/tailwind-canonical-classes` in `packages/oxlint-plugin` and enabled it as `error` in `.oxlintrc.json`.
  - Uses Tailwind’s canonicalizer via `@tailwindcss/node`, loading `packages/ui/src/styles/globals.css`; checks static strings in `class`/`className` and helpers (`clsx`, `cn`, `cva`, `twMerge`), walking arrays/conditionals/object values (and safe string keys), and auto-fixes token-by-token.
  - Applied canonical class updates in UI components and app code.

- **Dependencies**
  - Added `@tailwindcss/node@4.3.0` (dev).

<sup>Written for commit 32f928be4ec44c1a396590660af85484d61c6d1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

