### PR TITLE
fix(test): quiet e2e workflow noise

### DIFF
--- a/apps/api/e2e/workflows-chapter-generation.test.ts
+++ b/apps/api/e2e/workflows-chapter-generation.test.ts
@@ -143,6 +143,7 @@ test.describe("Chapter Generation Workflow API", () => {
       data: {
         courseId: course.id,
         description: "First chapter - should be free",
+        generationStatus: "completed",
         isPublished: true,
         language: "en",
         normalizedTitle: normalizeString("First Chapter Free"),
@@ -270,6 +271,7 @@ test.describe("Chapter Generation Workflow API", () => {
       data: {
         courseId: course.id,
         description: "Test chapter for workflow success",
+        generationStatus: "completed",
         isPublished: true,
         language: "en",
         normalizedTitle: normalizeString("Test Chapter Success"),

--- a/apps/api/e2e/workflows-lesson-generation.test.ts
+++ b/apps/api/e2e/workflows-lesson-generation.test.ts
@@ -443,6 +443,7 @@ test.describe("Lesson Generation Workflow API", () => {
       data: {
         chapterId: chapter.id,
         description: "Test lesson for workflow success",
+        generationStatus: "completed",
         isPublished: true,
         kind: "explanation",
         language: "en",

--- a/packages/auth/src/e2e.ts
+++ b/packages/auth/src/e2e.ts
@@ -1,8 +1,11 @@
 import { betterAuth } from "better-auth/minimal";
+import { nextCookies } from "better-auth/next-js";
 import { emailOTP, oneTimeToken } from "better-auth/plugins";
 import { sendVerificationOTP } from "./plugins/otp";
 import { baseAuthConfig, baseAuthPlugins, fullPlugins, socialProviders } from "./server";
 import { stripePlugin } from "./stripe/plugin";
+
+const e2ePluginOverrideIds = new Set(["email-otp", "next-cookies", "one-time-token", "stripe"]);
 
 /**
  * @public
@@ -22,13 +25,11 @@ export const auth = betterAuth({
   },
   plugins: [
     ...baseAuthPlugins,
-    ...fullPlugins.filter(
-      (plugin) =>
-        plugin.id !== "email-otp" && plugin.id !== "one-time-token" && plugin.id !== "stripe",
-    ),
+    ...fullPlugins.filter((plugin) => !e2ePluginOverrideIds.has(plugin.id)),
     stripePlugin({ createCustomerOnSignUp: false }),
     emailOTP({ overrideDefaultEmailVerification: true, sendVerificationOTP, storeOTP: "plain" }),
     oneTimeToken({ storeToken: "plain" }),
+    nextCookies(),
   ],
   rateLimit: { enabled: false },
   socialProviders,


### PR DESCRIPTION
Quiets API e2e noise by keeping workflow trigger fixtures on completed rows so route-contract tests do not start downstream AI generation.

Also keeps the E2E Better Auth cookie plugin last after test-specific overrides.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quiet e2e workflow tests by marking fixtures as completed and ordering the `better-auth` cookie plugin last. This prevents background generation and keeps test cookie behavior stable.

- **Bug Fixes**
  - Set `generationStatus: "completed"` on chapter and lesson fixtures to avoid triggering downstream jobs.
  - Filter out conflicting auth plugins and add `nextCookies()` from `better-auth/next-js` at the end so e2e overrides take precedence.

<sup>Written for commit ea2c72c865e3c6e740529ef1c94f833dee9a3dab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

