### PR TITLE
fix(mailer): fail closed without mailer config

### DIFF
--- a/packages/mailer/package.json
+++ b/packages/mailer/package.json
@@ -6,6 +6,8 @@
     ".": "./src/client.ts"
   },
   "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
@@ -14,6 +16,7 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@typescript/native-preview": "catalog:",
-    "@zoonk/tsconfig": "workspace:*"
+    "@zoonk/tsconfig": "workspace:*",
+    "vitest": "catalog:"
   }
 }

--- a/packages/mailer/src/client.test.ts
+++ b/packages/mailer/src/client.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const otpBody = "<h2>123456</h2>";
+
+/**
+ * Imports the mailer after each test sets env vars because the production code
+ * used to read MAILER_API_KEY at module load time. Keeping the import isolated
+ * makes the regression test prove the missing-key behavior in each environment.
+ */
+async function getSendEmail() {
+  vi.resetModules();
+
+  const { sendEmail } = await import("./client");
+
+  return sendEmail;
+}
+
+describe("sendEmail", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("logs the email body when local development disables email sending", async () => {
+    vi.stubEnv("MAILER_API_KEY", "");
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("VERCEL_ENV", "");
+
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    const sendEmail = await getSendEmail();
+
+    const { data, error } = await sendEmail({
+      htmlBody: otpBody,
+      subject: "Your OTP code",
+      to: "user@example.com",
+    });
+
+    expect(error).toBeNull();
+    expect(data?.ok).toBe(true);
+
+    expect(info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: "Your OTP code",
+        textBody: otpBody,
+        to: "user@example.com",
+      }),
+    );
+  });
+
+  it("allows missing mailer config in e2e without logging the email body", async () => {
+    vi.stubEnv("E2E_TESTING", "true");
+    vi.stubEnv("MAILER_API_KEY", "");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERCEL_ENV", "");
+
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    const sendEmail = await getSendEmail();
+
+    const { data, error } = await sendEmail({
+      htmlBody: otpBody,
+      subject: "Your OTP code",
+      to: "user@example.com",
+    });
+
+    expect(error).toBeNull();
+    expect(data?.ok).toBe(true);
+    expect(JSON.stringify(info.mock.calls)).not.toContain(otpBody);
+  });
+
+  it("fails in deployed environments when the mailer api key is missing", async () => {
+    vi.stubEnv("MAILER_API_KEY", "");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERCEL_ENV", "production");
+
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    const sendEmail = await getSendEmail();
+
+    const { data, error } = await sendEmail({
+      htmlBody: otpBody,
+      subject: "Your OTP code",
+      to: "user@example.com",
+    });
+
+    expect(data).toBeNull();
+
+    expect(error).toStrictEqual(
+      new Error("MAILER_API_KEY is required to send email outside development."),
+    );
+
+    expect(JSON.stringify(errorLog.mock.calls)).not.toContain(otpBody);
+    expect(JSON.stringify(info.mock.calls)).not.toContain(otpBody);
+  });
+});

--- a/packages/mailer/src/client.ts
+++ b/packages/mailer/src/client.ts
@@ -1,27 +1,29 @@
+import { getEnvironment } from "@zoonk/utils/environment";
 import { type SafeReturn, toError } from "@zoonk/utils/error";
 import { logError, logInfo } from "@zoonk/utils/logger";
 
 const apiUrl = "https://api.zeptomail.com/v1.1/email";
-const apiKey = process.env.MAILER_API_KEY;
-const sendEmailDisabled = !apiKey;
 
-export async function sendEmail({
-  to,
-  subject,
-  htmlBody,
-  textBody,
-  replyTo,
-}: {
+type SendEmailParams = {
   to: string;
   subject: string;
   htmlBody?: string;
   textBody?: string;
   replyTo?: string;
-}): Promise<SafeReturn<Response>> {
-  if (sendEmailDisabled) {
-    logInfo("Email sending is disabled.");
-    logInfo({ subject, textBody: textBody ?? htmlBody, to });
-    return { data: Response.json({ ok: true }), error: null };
+};
+
+/**
+ * Sends product emails through the configured provider while preserving the
+ * local development workflow where missing credentials print OTP emails to the
+ * terminal. Deployed environments must fail closed so a missing secret cannot
+ * turn authentication codes into application logs.
+ */
+export async function sendEmail(params: SendEmailParams): Promise<SafeReturn<Response>> {
+  const { to, subject, htmlBody, textBody, replyTo } = params;
+  const apiKey = process.env.MAILER_API_KEY;
+
+  if (!apiKey) {
+    return handleMissingMailerApiKey(params);
   }
 
   try {
@@ -52,4 +54,57 @@ export async function sendEmail({
   } catch (error) {
     return { data: null, error: toError(error) };
   }
+}
+
+/**
+ * Handles missing credentials in the one place that knows whether email is
+ * optional. Local development needs a disabled-mailer mode for OTP login, but
+ * previews and production should expose the configuration problem immediately.
+ */
+function handleMissingMailerApiKey(params: SendEmailParams): SafeReturn<Response> {
+  if (isMissingMailerApiKeyAllowed()) {
+    logDisabledEmail(params);
+
+    return { data: Response.json({ ok: true }), error: null };
+  }
+
+  const error = new Error("MAILER_API_KEY is required to send email outside development.");
+
+  logError("Email send failed", error.message);
+
+  return { data: null, error };
+}
+
+/**
+ * Allows no-provider email only in environments that are not real mail
+ * delivery surfaces. E2E reads OTPs from the database, while local development
+ * prints them for manual login.
+ */
+function isMissingMailerApiKeyAllowed(): boolean {
+  const environment = getEnvironment();
+
+  return environment === "development" || environment === "e2e";
+}
+
+/**
+ * Logs disabled-mailer output without treating every non-provider environment
+ * the same. Developers need the body locally to copy OTP codes, but E2E and any
+ * future non-delivery mode should keep secret-bearing content out of logs.
+ */
+function logDisabledEmail(params: SendEmailParams): void {
+  logInfo("Email sending is disabled.");
+  logInfo(getDisabledEmailLogPayload(params));
+}
+
+/**
+ * Keeps the redaction rule explicit at the payload boundary so future mail
+ * fields do not accidentally reintroduce OTP or message-body logging outside
+ * local development.
+ */
+function getDisabledEmailLogPayload({ subject, textBody, htmlBody, to }: SendEmailParams) {
+  if (getEnvironment() === "development") {
+    return { subject, textBody: textBody ?? htmlBody, to };
+  }
+
+  return { subject, to };
 }

--- a/packages/mailer/vitest.config.mts
+++ b/packages/mailer/vitest.config.mts
@@ -1,0 +1,3 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({ resolve: { tsconfigPaths: true }, test: { environment: "node" } });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -773,6 +773,9 @@ importers:
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/next:
     dependencies:


### PR DESCRIPTION
## Summary

- keep local development OTP body logging when the mailer is disabled
- fail closed when deployed environments try to send email without MAILER_API_KEY
- add mailer tests for missing-key behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed when `MAILER_API_KEY` is missing outside development, while keeping OTP body logging in local dev. Adds tests and moves mailer config checks to call-time to prevent secret leaks.

- **Bug Fixes**
  - Deployed envs without `MAILER_API_KEY` now return an error and never log email bodies.
  - Local development still logs subject/to and OTP body for manual OTP login.
  - E2E is allowed without a key but redacts bodies from logs (environment handled via `@zoonk/utils/environment`).

- **Dependencies**
  - Added `vitest` and test config; new tests cover missing-key behavior.
  - Added `test` and `test:watch` scripts in `packages/mailer`.

<sup>Written for commit 0c0384b3677c0247fb8bc4a97e94c5f8500b6d6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

