### PR TITLE
fix(core): reject incomplete lesson completions

### DIFF
--- a/packages/core/src/player/commands/submit-player-completion.test.ts
+++ b/packages/core/src/player/commands/submit-player-completion.test.ts
@@ -641,4 +641,67 @@ describe(submitPlayerCompletion, () => {
     expect(lessonProgress).toBeNull();
     expect(stepAttempts).toHaveLength(0);
   });
+
+  it("persists review completion when only non-answerable fillers are missing", async () => {
+    const [user, { chapter, organization }] = await Promise.all([
+      userFixture(),
+      createChapterContext(),
+    ]);
+
+    const [reviewLesson, sourceLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        kind: "review",
+        organizationId: organization.id,
+        position: 1,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        kind: "vocabulary",
+        organizationId: organization.id,
+        position: 0,
+      }),
+    ]);
+
+    const answerableSteps = await Promise.all(
+      Array.from({ length: REVIEW_TARGET_STEP_COUNT - 1 }, (_, position) =>
+        stepFixture({
+          content: buildMultipleChoiceContent(),
+          isPublished: true,
+          kind: "multipleChoice",
+          lessonId: sourceLesson.id,
+          position,
+        }),
+      ),
+    );
+
+    await stepFixture({
+      content: {},
+      isPublished: true,
+      kind: "vocabulary",
+      lessonId: sourceLesson.id,
+      position: REVIEW_TARGET_STEP_COUNT,
+    });
+
+    const result = await submitPlayerCompletion({
+      input: buildReviewCompletionInput({
+        lessonId: reviewLesson.id,
+        stepIds: answerableSteps.map((step) => step.id),
+      }),
+      userId: user.id,
+    });
+
+    const [dailyProgress, stepAttempts] = await Promise.all([
+      prisma.dailyProgress.findFirst({ where: { userId: user.id } }),
+      prisma.stepAttempt.findMany({
+        where: { stepId: { in: answerableSteps.map((step) => step.id) }, userId: user.id },
+      }),
+    ]);
+
+    expect(result).toStrictEqual({ preloadLessonId: null });
+    expect(stepAttempts).toHaveLength(REVIEW_TARGET_STEP_COUNT - 1);
+    expect(dailyProgress?.correctAnswers).toBe(REVIEW_TARGET_STEP_COUNT - 1);
+  });
 });

--- a/packages/core/src/player/commands/submit-player-completion.test.ts
+++ b/packages/core/src/player/commands/submit-player-completion.test.ts
@@ -90,6 +90,60 @@ async function createMultipleChoiceLesson(params: {
 }
 
 /**
+ * Multi-question completion coverage must be enforced by the server, so this
+ * helper creates two trusted answerable steps without relying on player UI state.
+ */
+async function createTwoStepMultipleChoiceLesson(params: {
+  chapterId: string;
+  organizationId: string;
+}) {
+  const lesson = await lessonFixture({
+    chapterId: params.chapterId,
+    isPublished: true,
+    kind: "quiz",
+    organizationId: params.organizationId,
+    position: 0,
+  });
+
+  const steps = await Promise.all(
+    [0, 1].map((position) =>
+      stepFixture({
+        content: buildMultipleChoiceContent(),
+        isPublished: true,
+        kind: "multipleChoice",
+        lessonId: lesson.id,
+        position,
+      }),
+    ),
+  );
+
+  return { lesson, steps };
+}
+
+/**
+ * Static lessons intentionally submit no answers. Keeping this fixture separate
+ * prevents the completion-coverage tests from accidentally treating static
+ * reading content as an answerable quiz.
+ */
+async function createStaticLesson(params: { chapterId: string; organizationId: string }) {
+  const lesson = await lessonFixture({
+    chapterId: params.chapterId,
+    isPublished: true,
+    kind: "explanation",
+    organizationId: params.organizationId,
+  });
+
+  const step = await stepFixture({
+    content: { text: "Read this first", title: "Intro", variant: "text" },
+    isPublished: true,
+    kind: "static",
+    lessonId: lesson.id,
+  });
+
+  return { lesson, step };
+}
+
+/**
  * Review abuse tests need many equivalent interactive steps. Sharing this
  * content shape keeps the setup focused on the number of submitted step IDs,
  * not on differences between step contracts.
@@ -175,6 +229,48 @@ function buildCompletionInput(params: {
     stepTimings: {
       [stepId]: { answeredAt: startedAt + 5000, dayOfWeek: 1, durationSeconds: 5, hourOfDay: 12 },
     },
+  };
+}
+
+/**
+ * Forged completion payloads are the easiest way to prove the server does not
+ * trust the browser's idea of which answerable steps were completed.
+ */
+function buildCompletionInputForSteps(params: {
+  lessonId: string;
+  selectedOptionId?: string;
+  startedAt?: number;
+  stepIds: string[];
+}): CompletionInput {
+  const startedAt = params.startedAt ?? Date.now() - 10_000;
+
+  return {
+    answers: Object.fromEntries(
+      params.stepIds.map((stepId) => [
+        stepId,
+        { kind: "multipleChoice", selectedOptionId: params.selectedOptionId ?? "a" },
+      ]),
+    ),
+    lessonId: params.lessonId,
+    localDate: todayLocalDate(),
+    startedAt,
+    stepTimings: Object.fromEntries(
+      params.stepIds.map((stepId) => buildStepTimingEntry({ startedAt, stepId })),
+    ),
+  };
+}
+
+/**
+ * Empty completions should only be accepted for trusted static lessons. The
+ * schema allows this shape, so command-level tests need a direct way to submit it.
+ */
+function buildEmptyCompletionInput(params: { lessonId: string }): CompletionInput {
+  return {
+    answers: {},
+    lessonId: params.lessonId,
+    localDate: todayLocalDate(),
+    startedAt: Date.now() - 10_000,
+    stepTimings: {},
   };
 }
 
@@ -314,6 +410,125 @@ describe(submitPlayerCompletion, () => {
     expect(stepAttempts[0]?.isCorrect).toBe(true);
   });
 
+  it("rejects empty answers for an interactive lesson without writing progress", async () => {
+    const [user, { chapter, course, organization }] = await Promise.all([
+      userFixture(),
+      createChapterContext(),
+    ]);
+
+    const { lesson, step } = await createMultipleChoiceLesson({
+      chapterId: chapter.id,
+      organizationId: organization.id,
+    });
+
+    const result = await submitPlayerCompletion({
+      input: buildEmptyCompletionInput({ lessonId: lesson.id }),
+      userId: user.id,
+    });
+
+    const writes = await readCompletionWrites({
+      courseId: course.id,
+      lessonId: lesson.id,
+      stepId: step.id,
+      userId: user.id,
+    });
+
+    expect(result).toBeNull();
+    expect(writes.dailyProgress).toHaveLength(0);
+    expect(writes.lessonProgress).toBeNull();
+    expect(writes.stepAttempts).toHaveLength(0);
+    expect(writes.userProgress).toBeNull();
+  });
+
+  it("rejects partial answers for an interactive lesson without writing progress", async () => {
+    const [user, { chapter, course, organization }] = await Promise.all([
+      userFixture(),
+      createChapterContext(),
+    ]);
+
+    const { lesson, steps } = await createTwoStepMultipleChoiceLesson({
+      chapterId: chapter.id,
+      organizationId: organization.id,
+    });
+
+    const result = await submitPlayerCompletion({
+      input: buildCompletionInputForSteps({ lessonId: lesson.id, stepIds: [steps[0]!.id] }),
+      userId: user.id,
+    });
+
+    const writes = await readCompletionWrites({
+      courseId: course.id,
+      lessonId: lesson.id,
+      stepId: steps[0]!.id,
+      userId: user.id,
+    });
+
+    expect(result).toBeNull();
+    expect(writes.dailyProgress).toHaveLength(0);
+    expect(writes.lessonProgress).toBeNull();
+    expect(writes.stepAttempts).toHaveLength(0);
+    expect(writes.userProgress).toBeNull();
+  });
+
+  it("persists completion when every interactive answer is present but incorrect", async () => {
+    const [user, { chapter, organization }] = await Promise.all([
+      userFixture(),
+      createChapterContext(),
+    ]);
+
+    const { lesson, steps } = await createTwoStepMultipleChoiceLesson({
+      chapterId: chapter.id,
+      organizationId: organization.id,
+    });
+
+    const result = await submitPlayerCompletion({
+      input: buildCompletionInputForSteps({
+        lessonId: lesson.id,
+        selectedOptionId: "b",
+        stepIds: steps.map((step) => step.id),
+      }),
+      userId: user.id,
+    });
+
+    const stepAttempts = await prisma.stepAttempt.findMany({
+      where: { stepId: { in: steps.map((step) => step.id) }, userId: user.id },
+    });
+
+    expect(result).toStrictEqual({ preloadLessonId: null });
+    expect(stepAttempts).toHaveLength(2);
+    expect(stepAttempts.every((attempt) => !attempt.isCorrect)).toBe(true);
+  });
+
+  it("persists static-only lessons with empty answers", async () => {
+    const [user, { chapter, organization }] = await Promise.all([
+      userFixture(),
+      createChapterContext(),
+    ]);
+
+    const { lesson, step } = await createStaticLesson({
+      chapterId: chapter.id,
+      organizationId: organization.id,
+    });
+
+    const result = await submitPlayerCompletion({
+      input: buildEmptyCompletionInput({ lessonId: lesson.id }),
+      userId: user.id,
+    });
+
+    const [dailyProgress, lessonProgress, stepAttempts] = await Promise.all([
+      prisma.dailyProgress.findFirst({ where: { userId: user.id } }),
+      prisma.lessonProgress.findUnique({
+        where: { userLesson: { lessonId: lesson.id, userId: user.id } },
+      }),
+      prisma.stepAttempt.findMany({ where: { stepId: step.id, userId: user.id } }),
+    ]);
+
+    expect(result).toStrictEqual({ preloadLessonId: null });
+    expect(dailyProgress?.staticCompleted).toBe(1);
+    expect(lessonProgress?.completedAt).toBeInstanceOf(Date);
+    expect(stepAttempts).toHaveLength(0);
+  });
+
   it("caps review completion validation at the review target count", async () => {
     const [user, { chapter, organization }] = await Promise.all([
       userFixture(),
@@ -366,5 +581,64 @@ describe(submitPlayerCompletion, () => {
 
     expect(stepAttempts).toHaveLength(REVIEW_TARGET_STEP_COUNT);
     expect(dailyProgress?.correctAnswers).toBe(REVIEW_TARGET_STEP_COUNT);
+  });
+
+  it("rejects review completion when fewer than the on-demand target steps are submitted", async () => {
+    const [user, { chapter, organization }] = await Promise.all([
+      userFixture(),
+      createChapterContext(),
+    ]);
+
+    const [reviewLesson, sourceLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        kind: "review",
+        organizationId: organization.id,
+        position: 1,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        kind: "quiz",
+        organizationId: organization.id,
+        position: 0,
+      }),
+    ]);
+
+    const reviewableSteps = await Promise.all(
+      Array.from({ length: REVIEW_TARGET_STEP_COUNT }, (_, position) =>
+        stepFixture({
+          content: buildMultipleChoiceContent(),
+          isPublished: true,
+          kind: "multipleChoice",
+          lessonId: sourceLesson.id,
+          position,
+        }),
+      ),
+    );
+
+    const result = await submitPlayerCompletion({
+      input: buildReviewCompletionInput({
+        lessonId: reviewLesson.id,
+        stepIds: reviewableSteps.slice(0, 1).map((step) => step.id),
+      }),
+      userId: user.id,
+    });
+
+    const [dailyProgress, lessonProgress, stepAttempts] = await Promise.all([
+      prisma.dailyProgress.findFirst({ where: { userId: user.id } }),
+      prisma.lessonProgress.findUnique({
+        where: { userLesson: { lessonId: reviewLesson.id, userId: user.id } },
+      }),
+      prisma.stepAttempt.findMany({
+        where: { stepId: { in: reviewableSteps.map((step) => step.id) }, userId: user.id },
+      }),
+    ]);
+
+    expect(result).toBeNull();
+    expect(dailyProgress).toBeNull();
+    expect(lessonProgress).toBeNull();
+    expect(stepAttempts).toHaveLength(0);
   });
 });

--- a/packages/core/src/player/commands/submit-player-completion.ts
+++ b/packages/core/src/player/commands/submit-player-completion.ts
@@ -1,11 +1,11 @@
 import "server-only";
-import { type LessonSentence, getPublishedLessonWhere, prisma } from "@zoonk/db";
+import { type LessonSentence, type StepKind, getPublishedLessonWhere, prisma } from "@zoonk/db";
 import { type CompletionInput } from "../contracts/completion-input-schema";
 import { computeLessonScore } from "../contracts/compute-score";
-import { validateAnswers } from "../contracts/validate-answers";
+import { countAnswerableSteps, validateAnswers } from "../contracts/validate-answers";
 import { getLessonSentencesForLessons } from "../queries/get-lesson-sentences";
 import { getNextLesson } from "../queries/get-next-lesson";
-import { getReviewValidationSteps } from "../queries/get-review-steps";
+import { getReviewValidationData } from "../queries/get-review-steps";
 import { submitLessonCompletion } from "./submit-lesson-completion";
 
 const MAX_DURATION_SECONDS = 7200;
@@ -17,7 +17,7 @@ function clampDuration(startedAt: number): number {
 
 type StepWithSentence = {
   id: string;
-  kind: string;
+  kind: StepKind;
   content: unknown;
   lessonId: string;
   word: { id: string } | null;
@@ -74,6 +74,24 @@ function getValidationSentenceLessonIds({
 }
 
 /**
+ * Interactive completion is only trustworthy when every server-required answer
+ * produced a validation result. Static lessons have zero required answers, but
+ * review lessons are never static: the page shows an empty state instead of the
+ * player when there are no on-demand review steps.
+ */
+function hasCompleteAnswerCoverage(params: {
+  expectedStepCount: number;
+  lessonKind: string;
+  validatedStepCount: number;
+}) {
+  if (params.lessonKind === "review" && params.expectedStepCount === 0) {
+    return false;
+  }
+
+  return params.validatedStepCount === params.expectedStepCount;
+}
+
+/**
  * The app shell should only orchestrate request-specific concerns such as auth,
  * cache revalidation, and background execution. This command owns the shared
  * completion workflow: validate the submission, persist authoritative progress,
@@ -100,13 +118,15 @@ export async function submitPlayerCompletion(params: {
     return null;
   }
 
-  const rawStepsForValidation =
+  const validationData =
     lesson.kind === "review"
-      ? await getReviewValidationSteps({
+      ? await getReviewValidationData({
           lessonId: lesson.id,
           stepIds: Object.keys(params.input.answers),
         })
-      : lesson.steps;
+      : { expectedStepCount: countAnswerableSteps(lesson.steps), steps: lesson.steps };
+
+  const rawStepsForValidation = validationData.steps;
 
   const lessonSentences = await getLessonSentencesForLessons({
     lessonIds:
@@ -121,6 +141,16 @@ export async function submitPlayerCompletion(params: {
   );
 
   const stepResults = validateAnswers(stepsForValidation, params.input.answers);
+
+  if (
+    !hasCompleteAnswerCoverage({
+      expectedStepCount: validationData.expectedStepCount,
+      lessonKind: lesson.kind,
+      validatedStepCount: stepResults.length,
+    })
+  ) {
+    return null;
+  }
 
   const score = computeLessonScore({ results: stepResults });
 

--- a/packages/core/src/player/contracts/validate-answers.test.ts
+++ b/packages/core/src/player/contracts/validate-answers.test.ts
@@ -17,7 +17,7 @@ const fillBlankContent = {
 
 describe(validateAnswers, () => {
   it("validates correct multipleChoice answer server-side", () => {
-    const steps = [{ content: multipleChoiceContent, id: "1", kind: "multipleChoice" }];
+    const steps = [{ content: multipleChoiceContent, id: "1", kind: "multipleChoice" }] as const;
 
     const results = validateAnswers(steps, {
       "1": { kind: "multipleChoice", selectedOptionId: "option-a" },
@@ -29,7 +29,7 @@ describe(validateAnswers, () => {
   });
 
   it("validates incorrect multipleChoice answer", () => {
-    const steps = [{ content: multipleChoiceContent, id: "1", kind: "multipleChoice" }];
+    const steps = [{ content: multipleChoiceContent, id: "1", kind: "multipleChoice" }] as const;
 
     const results = validateAnswers(steps, {
       "1": { kind: "multipleChoice", selectedOptionId: "option-b" },
@@ -40,7 +40,7 @@ describe(validateAnswers, () => {
   });
 
   it("validates fillBlank answer", () => {
-    const steps = [{ content: fillBlankContent, id: "2", kind: "fillBlank" }];
+    const steps = [{ content: fillBlankContent, id: "2", kind: "fillBlank" }] as const;
 
     const results = validateAnswers(steps, { "2": { kind: "fillBlank", userAnswers: ["dog"] } });
 
@@ -52,7 +52,7 @@ describe(validateAnswers, () => {
     const steps = [
       { content: multipleChoiceContent, id: "1", kind: "multipleChoice" },
       { content: { text: "Hello", title: "Intro", variant: "text" }, id: "2", kind: "static" },
-    ];
+    ] as const;
 
     const results = validateAnswers(steps, {
       "1": { kind: "multipleChoice", selectedOptionId: "option-a" },
@@ -63,7 +63,7 @@ describe(validateAnswers, () => {
   });
 
   it("validates translation answer against word ID", () => {
-    const steps = [{ content: {}, id: "4", kind: "translation", word: { id: "100" } }];
+    const steps = [{ content: {}, id: "4", kind: "translation", word: { id: "100" } }] as const;
 
     const results = validateAnswers(steps, {
       "4": { kind: "translation", selectedOptionId: "100" },
@@ -74,7 +74,7 @@ describe(validateAnswers, () => {
   });
 
   it("translation answer with wrong word ID is incorrect", () => {
-    const steps = [{ content: {}, id: "4", kind: "translation", word: { id: "100" } }];
+    const steps = [{ content: {}, id: "4", kind: "translation", word: { id: "100" } }] as const;
 
     const results = validateAnswers(steps, {
       "4": { kind: "translation", selectedOptionId: "999" },
@@ -98,7 +98,7 @@ describe(validateAnswers, () => {
           translationDistractors: [],
         },
       },
-    ];
+    ] as const;
 
     const results = validateAnswers(steps, {
       "5": { arrangedWords: ["hello", "world"], kind: "reading" },
@@ -122,7 +122,7 @@ describe(validateAnswers, () => {
           translationDistractors: [],
         },
       },
-    ];
+    ] as const;
 
     const results = validateAnswers(steps, {
       "6": { arrangedWords: ["olá", "mundo"], kind: "listening" },
@@ -146,7 +146,7 @@ describe(validateAnswers, () => {
           translationDistractors: [],
         },
       },
-    ];
+    ] as const;
 
     const results = validateAnswers(steps, {
       "7": { arrangedWords: ["guten", "morgen", "lara"], kind: "reading" },
@@ -170,7 +170,7 @@ describe(validateAnswers, () => {
           translationDistractors: ["bom"],
         },
       },
-    ];
+    ] as const;
 
     const results = validateAnswers(steps, {
       "10": { arrangedWords: ["bom", "dia", "lara"], kind: "listening" },
@@ -194,7 +194,7 @@ describe(validateAnswers, () => {
           translationDistractors: [],
         },
       },
-    ];
+    ] as const;
 
     const results = validateAnswers(steps, {
       "8": { arrangedWords: ["bom", "dia", "lara"], kind: "listening" },
@@ -204,8 +204,8 @@ describe(validateAnswers, () => {
     expect(results[0]?.isCorrect).toBe(true);
   });
 
-  it("skips unsupported step kinds", () => {
-    const steps = [{ content: {}, id: "7", kind: "unknownKind" }];
+  it("skips non-answerable step kinds", () => {
+    const steps = [{ content: {}, id: "7", kind: "visual" }] as const;
 
     const results = validateAnswers(steps, {
       "7": { kind: "multipleChoice", selectedOptionId: "option-a" },
@@ -215,7 +215,7 @@ describe(validateAnswers, () => {
   });
 
   it("skips malformed unanswered static steps instead of throwing", () => {
-    const steps = [{ content: { text: "Legacy static step" }, id: "16", kind: "static" }];
+    const steps = [{ content: { text: "Legacy static step" }, id: "16", kind: "static" }] as const;
 
     const runValidation = () => validateAnswers(steps, {});
 

--- a/packages/core/src/player/contracts/validate-answers.ts
+++ b/packages/core/src/player/contracts/validate-answers.ts
@@ -1,4 +1,5 @@
 import { parseStepContent } from "@zoonk/core/steps/contract/content";
+import { type StepKind } from "@zoonk/db";
 import { buildAcceptedArrangeWordSequences } from "./arrange-words-answers";
 import {
   checkArrangeWordsAnswer,
@@ -17,9 +18,9 @@ import { type SelectedAnswer } from "./completion-input-schema";
  * table, so sentence carries only the canonical translation string used
  * by listening validation.
  */
-type StepData = {
+export type StepData = {
   id: string;
-  kind: string;
+  kind: StepKind;
   content: unknown;
   word?: { id: string } | null;
   sentence?: { id: string; sentence: string; translation: string } | null;
@@ -38,32 +39,40 @@ type ServerValidationBehavior =
   | "sortOrder"
   | "translation";
 
+type AnswerableStepKind = Exclude<ServerValidationBehavior, "none">;
+
+const ANSWERABLE_STEP_KINDS: readonly AnswerableStepKind[] = [
+  "fillBlank",
+  "listening",
+  "matchColumns",
+  "multipleChoice",
+  "reading",
+  "selectImage",
+  "sortOrder",
+  "translation",
+];
+
+/**
+ * Step kinds that share their database name with a validator can return that
+ * name directly. This keeps non-answerable kinds such as static, vocabulary,
+ * and visual out of completion coverage without duplicating every identity case
+ * in a switch.
+ */
+function isAnswerableStepKind(kind: StepKind): kind is AnswerableStepKind {
+  return ANSWERABLE_STEP_KINDS.some((answerableKind) => answerableKind === kind);
+}
+
 /**
  * Server validation should follow the semantic step contract directly instead
  * of depending on the React player's render behavior table. The raw step kind
- * kind is enough to decide whether the submission should emit a StepAttempt.
+ * is enough to decide whether the submission should emit a StepAttempt.
  */
-function getValidationBehavior(step: StepData): ServerValidationBehavior {
-  switch (step.kind) {
-    case "fillBlank":
-      return "fillBlank";
-    case "listening":
-      return "listening";
-    case "matchColumns":
-      return "matchColumns";
-    case "multipleChoice":
-      return "multipleChoice";
-    case "reading":
-      return "reading";
-    case "selectImage":
-      return "selectImage";
-    case "sortOrder":
-      return "sortOrder";
-    case "translation":
-      return "translation";
-    default:
-      return "none";
+function getValidationBehavior(step: { kind: StepKind }): ServerValidationBehavior {
+  if (isAnswerableStepKind(step.kind)) {
+    return step.kind;
   }
+
+  return "none";
 }
 
 function validateMultipleChoice(
@@ -176,8 +185,17 @@ const validators: Record<
   translation: validateTranslation,
 };
 
+/**
+ * Completion persistence needs the same answerable-step definition as answer
+ * validation. Keeping the count tied to the validation behavior table prevents
+ * a new checked step kind from becoming completable without a submitted answer.
+ */
+export function countAnswerableSteps(steps: readonly { kind: StepKind }[]): number {
+  return steps.filter((step) => getValidationBehavior(step) !== "none").length;
+}
+
 export function validateAnswers(
-  steps: StepData[],
+  steps: readonly StepData[],
   clientAnswers: Record<string, SelectedAnswer>,
 ): ValidatedStepResult[] {
   return steps.flatMap((step) => {

--- a/packages/core/src/player/contracts/validate-answers.ts
+++ b/packages/core/src/player/contracts/validate-answers.ts
@@ -28,20 +28,7 @@ export type StepData = {
 
 type ValidatedStepResult = { answer: object; isCorrect: boolean; stepId: string };
 
-type ServerValidationBehavior =
-  | "fillBlank"
-  | "listening"
-  | "matchColumns"
-  | "multipleChoice"
-  | "none"
-  | "reading"
-  | "selectImage"
-  | "sortOrder"
-  | "translation";
-
-type AnswerableStepKind = Exclude<ServerValidationBehavior, "none">;
-
-const ANSWERABLE_STEP_KINDS: readonly AnswerableStepKind[] = [
+export const ANSWERABLE_STEP_KINDS = [
   "fillBlank",
   "listening",
   "matchColumns",
@@ -50,7 +37,10 @@ const ANSWERABLE_STEP_KINDS: readonly AnswerableStepKind[] = [
   "selectImage",
   "sortOrder",
   "translation",
-];
+] as const satisfies readonly StepKind[];
+
+type AnswerableStepKind = (typeof ANSWERABLE_STEP_KINDS)[number];
+type ServerValidationBehavior = AnswerableStepKind | "none";
 
 /**
  * Step kinds that share their database name with a validator can return that

--- a/packages/core/src/player/queries/get-review-steps.test.ts
+++ b/packages/core/src/player/queries/get-review-steps.test.ts
@@ -7,7 +7,7 @@ import { stepAttemptFixture } from "@zoonk/testing/fixtures/step-attempts";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { beforeAll, describe, expect, it } from "vitest";
-import { getReviewSteps, getReviewValidationSteps } from "./get-review-steps";
+import { getReviewSteps, getReviewValidationData } from "./get-review-steps";
 
 const REVIEW_TARGET_COUNT = 10;
 
@@ -600,7 +600,7 @@ describe(getReviewSteps, () => {
   });
 });
 
-describe(getReviewValidationSteps, () => {
+describe(getReviewValidationData, () => {
   let lesson: Awaited<ReturnType<typeof lessonFixture>>;
   let organizationId: string;
   let quizStep: Awaited<ReturnType<typeof stepFixture>>;
@@ -669,7 +669,7 @@ describe(getReviewValidationSteps, () => {
   });
 
   it("excludes steps from review lessons", async () => {
-    const steps = await getReviewValidationSteps({
+    const { steps } = await getReviewValidationData({
       lessonId: lesson.id,
       stepIds: [quizStep.id, reviewStep.id],
     });
@@ -681,7 +681,7 @@ describe(getReviewValidationSteps, () => {
   });
 
   it("excludes static steps", async () => {
-    const steps = await getReviewValidationSteps({
+    const { steps } = await getReviewValidationData({
       lessonId: lesson.id,
       stepIds: [quizStep.id, staticStep.id],
     });
@@ -716,7 +716,7 @@ describe(getReviewValidationSteps, () => {
       }),
     ]);
 
-    const steps = await getReviewValidationSteps({
+    const { steps } = await getReviewValidationData({
       lessonId: lesson.id,
       stepIds: [readingStep.id],
     });

--- a/packages/core/src/player/queries/get-review-steps.test.ts
+++ b/packages/core/src/player/queries/get-review-steps.test.ts
@@ -377,6 +377,26 @@ describe(getReviewSteps, () => {
     }
   });
 
+  it("excludes vocabulary steps", async () => {
+    const isolated = await createLessonWithSteps(org.id, 3);
+
+    await stepFixture({
+      content: {},
+      isPublished: true,
+      kind: "vocabulary",
+      lessonId: isolated.lesson.id,
+      position: 10,
+    });
+
+    const result = await getReviewSteps({ lessonId: isolated.lesson.id, userId: null });
+
+    expect(result).toHaveLength(3);
+
+    for (const step of result) {
+      expect(step.kind).not.toBe("vocabulary");
+    }
+  });
+
   it("fills with random steps when total mistakes < 10", async () => {
     const [newLesson, newUser] = await Promise.all([
       createLessonWithSteps(org.id, 12),

--- a/packages/core/src/player/queries/get-review-steps.ts
+++ b/packages/core/src/player/queries/get-review-steps.ts
@@ -1,10 +1,10 @@
 import "server-only";
-import { type LessonKind, type StepKind, getPublishedStepWhere, prisma } from "@zoonk/db";
+import { type LessonKind, getPublishedStepWhere, prisma } from "@zoonk/db";
 import { shuffle } from "@zoonk/utils/shuffle";
+import { ANSWERABLE_STEP_KINDS } from "../contracts/validate-answers";
 
 const REVIEW_TARGET_COUNT = 10;
 const EXCLUDED_LESSON_KINDS: LessonKind[] = ["review"];
-const NON_REVIEWABLE_STEP_KINDS: StepKind[] = ["static", "visual"];
 
 async function getReviewChapterId(lessonId: string) {
   const lesson = await prisma.lesson.findUnique({
@@ -19,7 +19,7 @@ function reviewableStepFilter(chapterId: string) {
   return getPublishedStepWhere({
     chapterWhere: { id: chapterId },
     lessonWhere: { kind: { notIn: EXCLUDED_LESSON_KINDS } },
-    stepWhere: { kind: { notIn: NON_REVIEWABLE_STEP_KINDS } },
+    stepWhere: { kind: { in: [...ANSWERABLE_STEP_KINDS] } },
   });
 }
 

--- a/packages/core/src/player/queries/get-review-steps.ts
+++ b/packages/core/src/player/queries/get-review-steps.ts
@@ -101,23 +101,28 @@ export async function getReviewSteps({
 }
 
 /**
- * Fetches steps for validating a review lesson submission.
- * Only returns steps that are eligible for review — excludes
- * steps from review lessons and static steps. Review submissions can be
- * forged directly against the server action, so validation only considers the
- * same number of step IDs the server would serve in a normal review session.
+ * Fetches the server-accepted review step subset and the number of answers a
+ * normal review session would ask for. Review steps are chosen on demand, so
+ * completion should require the capped target count, not every eligible step in
+ * the chapter.
  */
-export async function getReviewValidationSteps(params: { lessonId: string; stepIds: string[] }) {
+export async function getReviewValidationData(params: { lessonId: string; stepIds: string[] }) {
   const chapterId = await getReviewChapterId(params.lessonId);
 
   if (!chapterId) {
-    return [];
+    return { expectedStepCount: 0, steps: [] };
   }
 
   const submittedStepIds = params.stepIds.slice(0, REVIEW_TARGET_COUNT);
+  const stepFilter = reviewableStepFilter(chapterId);
 
-  return prisma.step.findMany({
-    include: { sentence: true, word: true },
-    where: { ...reviewableStepFilter(chapterId), id: { in: submittedStepIds } },
-  });
+  const [eligibleStepCount, steps] = await Promise.all([
+    prisma.step.count({ where: stepFilter }),
+    prisma.step.findMany({
+      include: { sentence: true, word: true },
+      where: { ...stepFilter, id: { in: submittedStepIds } },
+    }),
+  ]);
+
+  return { expectedStepCount: Math.min(eligibleStepCount, REVIEW_TARGET_COUNT), steps };
 }


### PR DESCRIPTION
Reject forged empty or partial player completion payloads before progress is persisted.

Keep static lessons completable without answers and preserve review lessons' capped on-demand target behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject empty or partial completion submissions for interactive lessons and align review validation to answerable-only steps. Static lessons still complete without answers, and review lessons must meet the capped on-demand target.

- **Bug Fixes**
  - Enforce complete server-validated coverage of answerable steps before persisting; incomplete or zero-eligible review submissions return null with no writes.
  - Align review pools and completion coverage to server-defined answerable kinds; exclude non-answerable steps (static, visual, vocabulary) and cap required answers to the target count.

<sup>Written for commit 071d43f02f6f931b9bb38ae9701d264646056d76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

