### PR TITLE
fix(auth): enforce shared username rules

### DIFF
--- a/apps/api/src/app/auth/setup/setup-form.tsx
+++ b/apps/api/src/app/auth/setup/setup-form.tsx
@@ -9,11 +9,10 @@ import {
   SetupSubmit,
 } from "@/components/setup";
 import {
-  USERNAME_MAX_LENGTH,
-  USERNAME_MIN_LENGTH,
   type UsernameStatus,
   useUsernameAvailability,
 } from "@zoonk/core/auth/hooks/username-availability";
+import { USERNAME_MAX_LENGTH, USERNAME_MIN_LENGTH } from "@zoonk/core/auth/username-rules";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@zoonk/ui/components/input-group";
 import { Spinner } from "@zoonk/ui/components/spinner";
 import { cn } from "@zoonk/ui/lib/utils";
@@ -97,10 +96,7 @@ export function SetupProfileForm({
             maxLength={USERNAME_MAX_LENGTH}
             minLength={USERNAME_MIN_LENGTH}
             name="username"
-            onChange={(event) => {
-              event.target.value = event.target.value.toLowerCase();
-              setUsername(event.target.value);
-            }}
+            onChange={(event) => setUsername(event.target.value)}
             placeholder={t("your-username")}
             required
             spellCheck={false}

--- a/apps/main/src/app/(settings)/profile/profile-form.tsx
+++ b/apps/main/src/app/(settings)/profile/profile-form.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import {
-  USERNAME_MAX_LENGTH,
-  USERNAME_MIN_LENGTH,
   type UsernameStatus as UsernameStatusType,
   useUsernameAvailability,
 } from "@zoonk/core/auth/hooks/username-availability";
+import { USERNAME_MAX_LENGTH, USERNAME_MIN_LENGTH } from "@zoonk/core/auth/username-rules";
 import {
   Field,
   FieldContent,
@@ -127,7 +126,7 @@ export function ProfileForm({
               maxLength={USERNAME_MAX_LENGTH}
               minLength={USERNAME_MIN_LENGTH}
               name="username"
-              onChange={(event) => setUsername(event.target.value.toLowerCase())}
+              onChange={(event) => setUsername(event.target.value)}
               required
               spellCheck={false}
               value={username}

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -9,6 +9,7 @@
     "./next": "./src/next.ts",
     "./testing": "./src/testing.ts",
     "./permissions": "./src/permissions.ts",
+    "./username-rules": "./src/username-rules.ts",
     "./stripe-prices": "./src/stripe/prices.ts",
     "./subscription": "./src/stripe/subscription.ts"
   },

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -27,6 +27,7 @@ import { trustedOriginPlugin } from "./plugins/trusted-origin";
 import { appleProvider } from "./providers/apple";
 import { googleProvider } from "./providers/google";
 import { stripePlugin } from "./stripe/plugin";
+import { USERNAME_MAX_LENGTH, USERNAME_MIN_LENGTH, normalizeUsername } from "./username-rules";
 import { isUsernameAllowed } from "./username-validator";
 
 /**
@@ -54,7 +55,13 @@ export const baseAuthConfig: Omit<BetterAuthOptions, "rateLimit"> = {
 
 export const baseAuthPlugins = [
   adminPlugin(),
-  username({ usernameValidator: (value) => isUsernameAllowed(value) }),
+  username({
+    maxUsernameLength: USERNAME_MAX_LENGTH,
+    minUsernameLength: USERNAME_MIN_LENGTH,
+    usernameNormalization: normalizeUsername,
+    usernameValidator: (value) => isUsernameAllowed(value),
+    validationOrder: { username: "post-normalization" },
+  }),
   organization({
     ac,
     // Temporarily disable organization creation

--- a/packages/auth/src/username-rules.ts
+++ b/packages/auth/src/username-rules.ts
@@ -1,0 +1,28 @@
+export const USERNAME_MIN_LENGTH = 3;
+export const USERNAME_MAX_LENGTH = 30;
+
+const USERNAME_ALLOWED_CHARACTERS = /^[a-z0-9_]+$/u;
+
+/**
+ * Keeps every username entry point on the same canonical value before
+ * validation or storage. Better Auth lowercases usernames by default, but it
+ * does not trim direct API submissions unless we provide the normalizer here.
+ */
+export function normalizeUsername(username: string): string {
+  return username.trim().toLowerCase();
+}
+
+/**
+ * Defines the URL-safe username shape that the UI has always promised:
+ * lowercase letters, numbers, and underscores within the supported length
+ * range. Callers may pass raw input because this function normalizes first.
+ */
+export function isUsernameSyntaxValid(username: string): boolean {
+  const normalizedUsername = normalizeUsername(username);
+
+  return (
+    normalizedUsername.length >= USERNAME_MIN_LENGTH &&
+    normalizedUsername.length <= USERNAME_MAX_LENGTH &&
+    USERNAME_ALLOWED_CHARACTERS.test(normalizedUsername)
+  );
+}

--- a/packages/auth/src/username-validator.test.ts
+++ b/packages/auth/src/username-validator.test.ts
@@ -1,5 +1,40 @@
 import { describe, expect, it } from "vitest";
+import {
+  USERNAME_MAX_LENGTH,
+  USERNAME_MIN_LENGTH,
+  isUsernameSyntaxValid,
+  normalizeUsername,
+} from "./username-rules";
 import { isUsernameAllowed } from "./username-validator";
+
+describe(normalizeUsername, () => {
+  it("normalizes direct server submissions the same way the UI does", () => {
+    expect(normalizeUsername(" John_Doe ")).toBe("john_doe");
+  });
+});
+
+describe(isUsernameSyntaxValid, () => {
+  it("allows lowercase letters, numbers, and underscores within the username length range", () => {
+    expect(isUsernameSyntaxValid("john_doe42")).toBe(true);
+  });
+
+  it("normalizes uppercase usernames before checking syntax", () => {
+    expect(isUsernameSyntaxValid("John_Doe42")).toBe(true);
+  });
+
+  it("blocks usernames outside the length range", () => {
+    expect(isUsernameSyntaxValid("a".repeat(USERNAME_MIN_LENGTH - 1))).toBe(false);
+    expect(isUsernameSyntaxValid("a".repeat(USERNAME_MAX_LENGTH + 1))).toBe(false);
+  });
+
+  it("blocks characters that are unsafe in profile URLs and mentions", () => {
+    expect(isUsernameSyntaxValid("john doe")).toBe(false);
+    expect(isUsernameSyntaxValid("john/doe")).toBe(false);
+    expect(isUsernameSyntaxValid("<tag>")).toBe(false);
+    expect(isUsernameSyntaxValid("john-doe")).toBe(false);
+    expect(isUsernameSyntaxValid("john.doe")).toBe(false);
+  });
+});
 
 describe(isUsernameAllowed, () => {
   describe("reserved usernames", () => {
@@ -38,11 +73,14 @@ describe(isUsernameAllowed, () => {
   });
 
   describe("invalid characters", () => {
-    it("blocks usernames containing dots", () => {
+    it("blocks usernames with characters outside the shared syntax policy", () => {
       expect(isUsernameAllowed("dev.ops")).toBe(false);
       expect(isUsernameAllowed("john.doe")).toBe(false);
       expect(isUsernameAllowed(".leading")).toBe(false);
       expect(isUsernameAllowed("trailing.")).toBe(false);
+      expect(isUsernameAllowed("john doe")).toBe(false);
+      expect(isUsernameAllowed("john/doe")).toBe(false);
+      expect(isUsernameAllowed("<tag>")).toBe(false);
     });
   });
 

--- a/packages/auth/src/username-validator.ts
+++ b/packages/auth/src/username-validator.ts
@@ -1,9 +1,19 @@
 import { BLOCKED_USERNAMES } from "./blocked-usernames";
+import { isUsernameSyntaxValid, normalizeUsername } from "./username-rules";
 
+/**
+ * Applies the full server-side username policy before Better Auth writes a
+ * profile update. Syntax lives in `username-rules` so the client can share it
+ * without bundling the reserved-name blocklist, while this function also
+ * enforces names that must stay unavailable because they collide with routes,
+ * infrastructure, or product terms.
+ */
 export function isUsernameAllowed(username: string): boolean {
-  if (username.includes(".")) {
+  const normalizedUsername = normalizeUsername(username);
+
+  if (!isUsernameSyntaxValid(normalizedUsername)) {
     return false;
   }
 
-  return !BLOCKED_USERNAMES.has(username.toLowerCase());
+  return !BLOCKED_USERNAMES.has(normalizedUsername);
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
     "./auth/ott/state": "./src/auth/ott-state.ts",
     "./auth/stripe-prices": "./src/auth/stripe-prices.ts",
     "./auth/subscription": "./src/auth/subscription.ts",
+    "./auth/username-rules": "./src/auth/username-rules.ts",
     "./content/thumbnail": "./src/content/content-thumbnail.ts",
     "./courses/search": "./src/courses/search-courses.ts",
     "./feedback/send": "./src/feedback/send-feedback-message.ts",

--- a/packages/core/src/auth/hooks/use-username-availability.ts
+++ b/packages/core/src/auth/hooks/use-username-availability.ts
@@ -2,16 +2,21 @@
 
 import { authClient } from "@zoonk/auth/client";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { USERNAME_MIN_LENGTH, isUsernameSyntaxValid, normalizeUsername } from "../username-rules";
 
 export type UsernameStatus = "idle" | "checking" | "available" | "taken" | "invalid";
 
-export const USERNAME_MIN_LENGTH = 3;
-export const USERNAME_MAX_LENGTH = 30;
-const USERNAME_REGEX = /^[a-z0-9_]{3,30}$/u;
 const DEBOUNCE_MS = 300;
 
+/**
+ * Keeps profile/setup username fields on the same normalized syntax policy as
+ * the server while still asking Better Auth for reserved-name and duplicate
+ * checks. That split lets the client reject impossible URL shapes immediately
+ * without bundling the full reserved username blocklist.
+ */
 export function useUsernameAvailability(currentUsername?: string | null) {
-  const [username, setUsername] = useState(currentUsername ?? "");
+  const normalizedCurrentUsername = currentUsername ? normalizeUsername(currentUsername) : "";
+  const [username, setUsername] = useState(normalizedCurrentUsername);
   const [status, setStatus] = useState<UsernameStatus>("idle");
   const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
   const abortRef = useRef<AbortController>(null);
@@ -24,9 +29,13 @@ export function useUsernameAvailability(currentUsername?: string | null) {
     setPrevCurrentUsername(currentUsername);
 
     if (currentUsername) {
-      setUsername(currentUsername);
+      setUsername(normalizedCurrentUsername);
     }
   }
+
+  const setNormalizedUsername = useCallback((value: string) => {
+    setUsername(normalizeUsername(value));
+  }, []);
 
   const checkAvailability = useCallback(
     async (value: string) => {
@@ -34,12 +43,12 @@ export function useUsernameAvailability(currentUsername?: string | null) {
       const controller = new AbortController();
       abortRef.current = controller;
 
-      if (!USERNAME_REGEX.test(value)) {
+      if (!isUsernameSyntaxValid(value)) {
         setStatus("invalid");
         return;
       }
 
-      if (value === currentUsername) {
+      if (value === normalizedCurrentUsername) {
         setStatus("idle");
         return;
       }
@@ -69,7 +78,7 @@ export function useUsernameAvailability(currentUsername?: string | null) {
         setStatus("idle");
       }
     },
-    [currentUsername],
+    [normalizedCurrentUsername],
   );
 
   useEffect(() => {
@@ -93,5 +102,5 @@ export function useUsernameAvailability(currentUsername?: string | null) {
     };
   }, [username, checkAvailability]);
 
-  return { setUsername, status, username };
+  return { setUsername: setNormalizedUsername, status, username };
 }

--- a/packages/core/src/auth/username-rules.ts
+++ b/packages/core/src/auth/username-rules.ts
@@ -1,0 +1,6 @@
+export {
+  USERNAME_MAX_LENGTH,
+  USERNAME_MIN_LENGTH,
+  isUsernameSyntaxValid,
+  normalizeUsername,
+} from "@zoonk/auth/username-rules";


### PR DESCRIPTION
## Summary
- centralize username normalization and syntax rules in auth
- configure Better Auth and client availability checks to share the same policy
- cover URL-unsafe usernames and normalization with focused tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce a single, shared username policy across server and client to block validation bypass and keep profile URLs safe. Normalization and syntax rules are now consistent in the UI, API, and availability checks.

- **Bug Fixes**
  - Centralized min/max length, normalization, and syntax checks in `@zoonk/auth/username-rules` and re-exported via `@zoonk/core/auth/username-rules`.
  - Configured the auth `username` plugin with min/max, normalization, and post-normalization validation; reserved names still enforced via `isUsernameAllowed`.
  - Updated `useUsernameAvailability` to normalize input, validate syntax locally, and only query the server for duplicates and reserved names.
  - Removed ad‑hoc lowercasing in setup/profile forms; inputs now pass raw text and rely on the shared normalizer.
  - Added focused tests for normalization and URL-unsafe characters (spaces, slashes, dots, etc.).

<sup>Written for commit b48bfc6a5b27811de85e4bcf503111bf6dd9c6e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

