### PR TITLE
fix(main): reject padded uuid route params

### DIFF
--- a/apps/main/src/data/chapters/get-chapter-for-generation.test.ts
+++ b/apps/main/src/data/chapters/get-chapter-for-generation.test.ts
@@ -57,6 +57,14 @@ describe(getChapterForGeneration, () => {
     expect(result).toBeNull();
   });
 
+  it("returns null for valid chapter ids padded with whitespace", async () => {
+    const chapter = await chapterFixture({ courseId: course.id, organizationId });
+
+    const result = await getChapterForGeneration(` ${chapter.id} `);
+
+    expect(result).toBeNull();
+  });
+
   it("returns null for chapters outside the AI organization", async () => {
     const otherOrg = await organizationFixture();
     const otherCourse = await courseFixture({ organizationId: otherOrg.id });

--- a/apps/main/src/data/courses/course-suggestions.test.ts
+++ b/apps/main/src/data/courses/course-suggestions.test.ts
@@ -211,6 +211,18 @@ describe("course-suggestions", () => {
     expect(result).toBeNull();
   });
 
+  it("getCourseSuggestionById returns null for valid ids padded with whitespace", async () => {
+    const title = `padded-id-${randomUUID()}`;
+
+    const item = await prisma.courseSuggestion.create({
+      data: { description: "Test description", language: "en", slug: toSlug(title), title },
+    });
+
+    const result = await getCourseSuggestionById(` ${item.id} `);
+
+    expect(result).toBeNull();
+  });
+
   it("getCourseSuggestionById returns suggestion by id", async () => {
     const language = "en";
     const title = `by-id-${randomUUID()}`;

--- a/apps/main/src/data/lessons/get-lesson-for-generation.test.ts
+++ b/apps/main/src/data/lessons/get-lesson-for-generation.test.ts
@@ -52,6 +52,14 @@ describe(getLessonForGeneration, () => {
     expect(result).toBeNull();
   });
 
+  it("returns null for valid lesson ids padded with whitespace", async () => {
+    const lesson = await lessonFixture({ chapterId: chapter.id, organizationId });
+
+    const result = await getLessonForGeneration(` ${lesson.id} `);
+
+    expect(result).toBeNull();
+  });
+
   it("returns null for lessons outside the AI organization", async () => {
     const otherOrg = await organizationFixture();
     const otherCourse = await courseFixture({ organizationId: otherOrg.id });

--- a/packages/utils/src/uuid.test.ts
+++ b/packages/utils/src/uuid.test.ts
@@ -13,4 +13,8 @@ describe(isUuid, () => {
     expect(isUuid("")).toBe(false);
     expect(isUuid(null)).toBe(false);
   });
+
+  it("returns false for UUID strings padded with whitespace", () => {
+    expect(isUuid(" 018f5c3e-a9f8-7cc9-88d4-31e5c7286210 ")).toBe(false);
+  });
 });

--- a/packages/utils/src/uuid.ts
+++ b/packages/utils/src/uuid.ts
@@ -9,7 +9,5 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3
  * @example isUuid("invalid-id") // false
  */
 export function isUuid(value: unknown): value is string {
-  const normalizedValue = typeof value === "string" ? value.trim() : "";
-
-  return UUID_PATTERN.test(normalizedValue);
+  return typeof value === "string" && UUID_PATTERN.test(value);
 }


### PR DESCRIPTION
## Summary
- reject whitespace-padded UUID route params before Prisma sees them
- cover generation and course suggestion UUID lookups with regression tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject whitespace-padded UUID route params to close a trim-bypass and prevent invalid lookups from hitting Prisma. Adds regression tests for chapter/lesson generation and course suggestions.

- **Bug Fixes**
  - Updated `isUuid` to validate the raw string (removed `.trim()`), so `" <uuid> "` is rejected.
  - Ensured `getChapterForGeneration`, `getLessonForGeneration`, and `getCourseSuggestionById` return null for padded IDs.

<sup>Written for commit 871cab27bfcf4b18c43b17dfa8359923f33a798a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

