### PR TITLE
fix(main): bound score insights by period end

### DIFF
--- a/apps/main/src/app/(progress)/score/score-content.tsx
+++ b/apps/main/src/app/(progress)/score/score-content.tsx
@@ -54,7 +54,11 @@ export async function ScoreContent({
         periodStart={data.periodStart}
       />
 
-      <ScoreInsights period={validPeriod} periodStart={data.periodStart} />
+      <ScoreInsights
+        period={validPeriod}
+        periodEnd={data.periodEnd}
+        periodStart={data.periodStart}
+      />
 
       <ScoreExplanation />
     </div>

--- a/apps/main/src/app/(progress)/score/score-insights.tsx
+++ b/apps/main/src/app/(progress)/score/score-insights.tsx
@@ -32,16 +32,18 @@ async function getPeriodLabel(period: HistoryPeriod): Promise<string> {
 
 export async function ScoreInsights({
   period,
+  periodEnd,
   periodStart,
 }: {
   period: HistoryPeriod;
+  periodEnd: Date;
   periodStart: Date;
 }) {
   const locale = await getLocale();
 
   const [bestDayData, bestTimeData, periodLabel] = await Promise.all([
-    getBestDay({ startDate: periodStart }),
-    getBestTime({ startDate: periodStart }),
+    getBestDay({ endDate: periodEnd, startDate: periodStart }),
+    getBestTime({ endDate: periodEnd, startDate: periodStart }),
     getPeriodLabel(period),
   ]);
 

--- a/apps/main/src/data/progress/get-best-day.test.ts
+++ b/apps/main/src/data/progress/get-best-day.test.ts
@@ -120,6 +120,40 @@ describe("authenticated users", () => {
     expect(result?.score).toBe(90);
   });
 
+  it("excludes later records when endDate is provided", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+
+    await prisma.dailyProgress.createMany({
+      data: [
+        {
+          correctAnswers: 8,
+          date: new Date("2025-01-06T12:00:00Z"),
+          dayOfWeek: 1, // Monday
+          incorrectAnswers: 2,
+          userId: user.id,
+        },
+        {
+          correctAnswers: 10,
+          date: new Date("2025-02-02T12:00:00Z"),
+          dayOfWeek: 0, // Sunday
+          incorrectAnswers: 0,
+          userId: user.id,
+        },
+      ],
+    });
+
+    const result = await getBestDay({
+      endDate: new Date("2025-01-31T23:59:59.999Z"),
+      headers,
+      startDate: new Date("2025-01-01T00:00:00Z"),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.dayOfWeek).toBe(1); // Monday
+    expect(result?.score).toBe(80);
+  });
+
   it("returns correct score calculation", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);

--- a/apps/main/src/data/progress/get-best-day.ts
+++ b/apps/main/src/data/progress/get-best-day.ts
@@ -8,7 +8,11 @@ import { cache } from "react";
 type BestDayData = { score: number; dayOfWeek: number };
 
 const cachedGetBestDay = cache(
-  async (startDateIso?: string, headers?: Headers): Promise<BestDayData | null> => {
+  async (
+    startDateIso?: string,
+    endDateIso?: string,
+    headers?: Headers,
+  ): Promise<BestDayData | null> => {
     const session = await getSession(headers);
 
     if (!session) {
@@ -17,11 +21,13 @@ const cachedGetBestDay = cache(
 
     const userId = session.user.id;
     const startDate = getDefaultStartDate(startDateIso);
+    const endDate = endDateIso ? new Date(endDateIso) : undefined;
+    const dateFilter = endDate ? { gte: startDate, lte: endDate } : { gte: startDate };
 
     const results = await prisma.dailyProgress.groupBy({
       _sum: { correctAnswers: true, incorrectAnswers: true },
       by: ["dayOfWeek"],
-      where: { date: { gte: startDate }, userId },
+      where: { date: dateFilter, userId },
     });
 
     if (results.length === 0) {
@@ -39,9 +45,20 @@ const cachedGetBestDay = cache(
   },
 );
 
+/**
+ * Score insights use this for both rolling summaries and fixed historical
+ * periods. Keeping the end date optional lets the homepage keep its rolling
+ * lookback while score-page history can prevent future progress from affecting
+ * a previous period.
+ */
 export function getBestDay(params?: {
+  endDate?: Date;
   headers?: Headers;
   startDate?: Date;
 }): Promise<BestDayData | null> {
-  return cachedGetBestDay(params?.startDate?.toISOString(), params?.headers);
+  return cachedGetBestDay(
+    params?.startDate?.toISOString(),
+    params?.endDate?.toISOString(),
+    params?.headers,
+  );
 }

--- a/apps/main/src/data/progress/get-best-time.test.ts
+++ b/apps/main/src/data/progress/get-best-time.test.ts
@@ -234,4 +234,41 @@ describe("authenticated users", () => {
     expect(result?.period).toBe(1); // Morning (only recent data)
     expect(result?.score).toBe(80);
   });
+
+  it("excludes later records when endDate is provided", async () => {
+    const [user, org] = await Promise.all([userFixture(), organizationFixture()]);
+
+    const [headers, step] = await Promise.all([
+      signInAs(user.email, user.password),
+      createTestStep(org.id),
+    ]);
+
+    const userId = user.id;
+    const stepId = step.id;
+
+    await Promise.all([
+      // Morning inside the requested historical period: 80%
+      createStepAttempts(
+        { answeredAt: new Date("2025-01-06T09:00:00Z"), hourOfDay: 9, stepId, userId },
+        8,
+        2,
+      ),
+      // Afternoon after the requested historical period: 100%
+      createStepAttempts(
+        { answeredAt: new Date("2025-02-02T15:00:00Z"), hourOfDay: 15, stepId, userId },
+        10,
+        0,
+      ),
+    ]);
+
+    const result = await getBestTime({
+      endDate: new Date("2025-01-31T23:59:59.999Z"),
+      headers,
+      startDate: new Date("2025-01-01T00:00:00Z"),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.period).toBe(1); // Morning
+    expect(result?.score).toBe(80);
+  });
 });

--- a/apps/main/src/data/progress/get-best-time.ts
+++ b/apps/main/src/data/progress/get-best-time.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { getSession } from "@zoonk/core/users/session/get";
-import { prisma } from "@zoonk/db";
+import { type Sql, prisma, sql } from "@zoonk/db";
 import { type ScoredRow, findBestByScore } from "@zoonk/utils/aggregation";
 import { getDefaultStartDate } from "@zoonk/utils/date-ranges";
 import { safeAsync } from "@zoonk/utils/error";
@@ -8,8 +8,26 @@ import { cache } from "react";
 
 type BestTimeData = { score: number; period: number };
 
+/**
+ * Historical score views need the same closed date window for insight cards as
+ * they use for the chart. The end filter stays optional so homepage summaries
+ * can keep their default rolling lookback without pretending there is a fixed
+ * period end.
+ */
+function getAnsweredAtEndFilter({ endDate }: { endDate?: Date }): Sql {
+  if (!endDate) {
+    return sql`TRUE`;
+  }
+
+  return sql`answered_at <= ${endDate}`;
+}
+
 const cachedGetBestTime = cache(
-  async (startDateIso?: string, headers?: Headers): Promise<BestTimeData | null> => {
+  async (
+    startDateIso?: string,
+    endDateIso?: string,
+    headers?: Headers,
+  ): Promise<BestTimeData | null> => {
     const session = await getSession(headers);
 
     if (!session) {
@@ -18,6 +36,8 @@ const cachedGetBestTime = cache(
 
     const userId = session.user.id;
     const startDate = getDefaultStartDate(startDateIso);
+    const endDate = endDateIso ? new Date(endDateIso) : undefined;
+    const answeredAtEndFilter = getAnsweredAtEndFilter({ endDate });
 
     const { data: results, error } = await safeAsync(
       () =>
@@ -35,6 +55,7 @@ const cachedGetBestTime = cache(
           COUNT(*) FILTER (WHERE is_correct = false)::int AS "incorrect"
         FROM step_attempts
         WHERE user_id = ${userId} AND answered_at >= ${startDate}
+          AND ${answeredAtEndFilter}
         GROUP BY 1
         HAVING COUNT(*) FILTER (WHERE is_correct = true) + COUNT(*) FILTER (WHERE is_correct = false) > 0
       `,
@@ -55,10 +76,20 @@ const cachedGetBestTime = cache(
   },
 );
 
+/**
+ * Score insights use this for both rolling summaries and fixed historical
+ * periods. Keeping the end date optional lets the homepage keep its rolling
+ * lookback while score-page history can prevent future attempts from affecting
+ * a previous period.
+ */
 export function getBestTime(params?: {
   headers?: Headers;
   startDate?: Date;
   endDate?: Date;
 }): Promise<BestTimeData | null> {
-  return cachedGetBestTime(params?.startDate?.toISOString(), params?.headers);
+  return cachedGetBestTime(
+    params?.startDate?.toISOString(),
+    params?.endDate?.toISOString(),
+    params?.headers,
+  );
 }


### PR DESCRIPTION
## Summary

- bound score insight cards to the selected historical period end
- add regressions for best-day and best-time period bounds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound score insight cards to the selected period end so Best Day/Time only use data within the chosen history window. Prevents future attempts from skewing historical score insights.

- **Bug Fixes**
  - Pass `periodEnd` from `ScoreContent` to `ScoreInsights`, and into `getBestDay`/`getBestTime`.
  - Add end-date filtering: Prisma `date: { gte: startDate, lte: endDate }` and SQL `answered_at <= endDate` (applied only when provided).
  - Add regression tests to confirm records after `endDate` are excluded for both best-day and best-time.

<sup>Written for commit df5ef499db890680558aa4da800f2f81d00010f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

