### PR TITLE
fix(api): filter alphabet lessons for roman languages

### DIFF
--- a/apps/api/src/workflows/chapter-generation/steps/_utils/lesson-plan-expansion.test.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/_utils/lesson-plan-expansion.test.ts
@@ -133,4 +133,35 @@ describe(expandChapterLessons, () => {
       "review",
     ]);
   });
+
+  it("drops alphabet lessons for Roman-script target languages", () => {
+    const lessons: GeneratedChapterLesson[] = [
+      { description: "Letters", kind: "alphabet", title: "Alphabet" },
+      { description: "Words", kind: "vocabulary", title: "Words" },
+    ];
+
+    expect(kinds(expandChapterLessons({ lessons, targetLanguage: "es" }))).toStrictEqual([
+      "vocabulary",
+      "translation",
+      "reading",
+      "listening",
+      "review",
+    ]);
+  });
+
+  it("keeps alphabet lessons for non-Roman target languages", () => {
+    const lessons: GeneratedChapterLesson[] = [
+      { description: "Kana", kind: "alphabet", title: "Kana" },
+      { description: "Words", kind: "vocabulary", title: "Words" },
+    ];
+
+    expect(kinds(expandChapterLessons({ lessons, targetLanguage: "ja" }))).toStrictEqual([
+      "alphabet",
+      "vocabulary",
+      "translation",
+      "reading",
+      "listening",
+      "review",
+    ]);
+  });
 });

--- a/apps/api/src/workflows/chapter-generation/steps/_utils/lesson-plan-expansion.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/_utils/lesson-plan-expansion.ts
@@ -1,5 +1,5 @@
 import { type LessonKind } from "@zoonk/db";
-import { isTTSSupportedLanguage } from "@zoonk/utils/languages";
+import { isTTSSupportedLanguage, needsRomanization } from "@zoonk/utils/languages";
 
 type GeneratedChapterLesson = {
   description?: string | null;
@@ -216,6 +216,27 @@ function takeVocabularyRun(lessons: GeneratedChapterLesson[]) {
 }
 
 /**
+ * Alphabet lessons only help when the learner must first recognize a writing
+ * system that is not written with Roman letters. Models sometimes create
+ * alphabet rows for languages like Spanish because the topic is common in
+ * beginner curricula, but those rows duplicate pronunciation practice and
+ * should never become stored lesson records.
+ */
+function shouldKeepLanguageLesson({
+  lesson,
+  targetLanguage,
+}: {
+  lesson: GeneratedChapterLesson;
+  targetLanguage: string;
+}) {
+  if (lesson.kind !== "alphabet") {
+    return true;
+  }
+
+  return needsRomanization(targetLanguage);
+}
+
+/**
  * Language plans keep the model-authored grammar/alphabet order and expand only
  * contiguous vocabulary runs. A single chapter-level review is appended after
  * all generated language content.
@@ -263,7 +284,11 @@ export function expandChapterLessons({
     return expandContentLessons({ lessons });
   }
 
-  const expanded = expandLanguageLessons({ lessons, targetLanguage });
+  const filteredLessons = lessons.filter((lesson) =>
+    shouldKeepLanguageLesson({ lesson, targetLanguage }),
+  );
+
+  const expanded = expandLanguageLessons({ lessons: filteredLessons, targetLanguage });
 
   if (expanded.length === 0) {
     return [];


### PR DESCRIPTION
Filters AI-generated alphabet lessons out of Roman-script language course plans before lesson rows are stored. Keeps alphabet lessons for non-Roman target languages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops alphabet lessons for Roman-script languages during chapter expansion to avoid redundant content. Keeps them for languages that need romanization.

- **Bug Fixes**
  - Use `needsRomanization` from `@zoonk/utils/languages` to filter `alphabet` lessons in `expandChapterLessons`.
  - Added tests for Spanish (dropped) and Japanese (kept).

<sup>Written for commit 46a49e5fb9e164bdc3734ea747169be2d9e6d01f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

