### PR TITLE
chore(ai): remove preview from gemini-3.1-flash-lite

### DIFF
--- a/packages/ai/src/tasks/courses/course-categories.ts
+++ b/packages/ai/src/tasks/courses/course-categories.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
 import promptTemplate from "./course-categories.prompt.md";
 
-const defaultModel = "google/gemini-3.1-flash-lite-preview";
+const defaultModel = "google/gemini-3.1-flash-lite";
 
 const fallbackModels = [
   "openai/gpt-5.4-nano",

--- a/packages/ai/src/tasks/courses/course-suggestions.ts
+++ b/packages/ai/src/tasks/courses/course-suggestions.ts
@@ -6,7 +6,7 @@ import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./course-suggestions.prompt.md";
 
 const defaultModel = "openai/gpt-5.4-mini";
-const fallbackModels = ["google/gemini-3.1-flash-lite-preview"] as const;
+const fallbackModels = ["google/gemini-3.1-flash-lite"] as const;
 
 const schema = z.object({
   courses: z.array(

--- a/packages/ai/src/tasks/lessons/language/lesson-distractors.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-distractors.ts
@@ -7,11 +7,7 @@ import { getPromptLanguageName } from "../../_utils/prompt-language";
 import systemPrompt from "./lesson-distractors.prompt.md";
 
 const defaultModel = "openai/gpt-5.4";
-
-const fallbackModels = [
-  "google/gemini-3.1-flash-lite-preview",
-  "anthropic/claude-sonnet-4.6",
-] as const;
+const fallbackModels = ["google/gemini-3.1-flash-lite", "anthropic/claude-sonnet-4.6"] as const;
 
 const schema = z.object({ distractors: z.array(z.string().min(1)).min(1) });
 

--- a/packages/ai/src/tasks/lessons/lesson-kind.ts
+++ b/packages/ai/src/tasks/lessons/lesson-kind.ts
@@ -8,7 +8,7 @@ import systemPrompt from "./lesson-kind.prompt.md";
 const defaultModel = "openai/gpt-5.4-nano";
 
 const fallbackModels = [
-  "google/gemini-3.1-flash-lite-preview",
+  "google/gemini-3.1-flash-lite",
   "meta/llama-4-scout",
   "anthropic/claude-haiku-4.5",
 ] as const;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced `google/gemini-3.1-flash-lite-preview` with `google/gemini-3.1-flash-lite` in course categories, course suggestions, lesson distractors, and lesson kind tasks. Uses the stable model for default/fallbacks and removes preview-only constraints.

<sup>Written for commit b2b5337d684b6a7b44dc58f6469aed3829f246b9. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1495?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

