### PR TITLE
fix(main): tune generation progress timing

### DIFF
--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -180,7 +180,7 @@ test.describe("Generate Course Page", () => {
       // Should show triggering or streaming state (no idle state)
       await expect(page.getByText(/creating your course/iu)).toBeVisible({ timeout: 10_000 });
 
-      await expect(page.getByText(/this usually takes about a minute/iu)).toBeVisible();
+      await expect(page.getByText(/this usually takes about 2 minutes/iu)).toBeVisible();
     });
   });
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -987,7 +987,6 @@ msgid "ViO6Dt"
 msgstr "Creating your lessons"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
 msgid "kiZUDf"
 msgstr "This usually takes about a minute"
 
@@ -1022,10 +1021,6 @@ msgid "gnxL73"
 msgstr "Choosing lesson types"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "1Q0Y9/"
-msgstr "Creating chapter image"
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgid "aJev/w"
 msgstr "Getting things ready"
@@ -1049,18 +1044,6 @@ msgstr "Choosing type for lesson {number}..."
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "Vbn5Wz"
 msgstr "Reviewing the lesson mix..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "JjJCYL"
-msgstr "Designing the chapter thumbnail..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "6sYiuc"
-msgstr "Creating the chapter image..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "lXIWAI"
-msgstr "Refining the chapter artwork..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
@@ -1103,6 +1086,10 @@ msgstr "Putting it all together..."
 #: src/app/generate/cs/[id]/generation-client.tsx
 msgid "DFlapX"
 msgstr "Creating your course"
+
+#: src/app/generate/cs/[id]/generation-client.tsx
+msgid "GJKrUK"
+msgstr "This usually takes about 2 minutes"
 
 #: src/app/generate/cs/[id]/generation-client.tsx
 msgid "0o41MR"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -987,7 +987,6 @@ msgid "ViO6Dt"
 msgstr "Creando tus lecciones"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
 msgid "kiZUDf"
 msgstr "Esto suele tomar alrededor de un minuto"
 
@@ -1022,10 +1021,6 @@ msgid "gnxL73"
 msgstr "Eligiendo tipos de lección"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "1Q0Y9/"
-msgstr "Creando imagen del capítulo"
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgid "aJev/w"
 msgstr "Preparando todo"
@@ -1049,18 +1044,6 @@ msgstr "Eligiendo el tipo para la lección {number}..."
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "Vbn5Wz"
 msgstr "Revisando la combinación de lecciones..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "JjJCYL"
-msgstr "Diseñando la miniatura del capítulo..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "6sYiuc"
-msgstr "Creando la imagen del capítulo..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "lXIWAI"
-msgstr "Refinando la imagen del capítulo..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
@@ -1103,6 +1086,10 @@ msgstr "Juntando todo..."
 #: src/app/generate/cs/[id]/generation-client.tsx
 msgid "DFlapX"
 msgstr "Creando tu curso"
+
+#: src/app/generate/cs/[id]/generation-client.tsx
+msgid "GJKrUK"
+msgstr "Esto suele tomar alrededor de 2 minutos"
 
 #: src/app/generate/cs/[id]/generation-client.tsx
 msgid "0o41MR"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -987,7 +987,6 @@ msgid "ViO6Dt"
 msgstr "Criando suas aulas"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
 msgid "kiZUDf"
 msgstr "Isso geralmente leva cerca de um minuto"
 
@@ -1022,10 +1021,6 @@ msgid "gnxL73"
 msgstr "Escolhendo os tipos de aulas"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "1Q0Y9/"
-msgstr "Criando imagem do capítulo"
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgid "aJev/w"
 msgstr "Preparando as coisas"
@@ -1049,18 +1044,6 @@ msgstr "Escolhendo o tipo da aula {number}..."
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "Vbn5Wz"
 msgstr "Revisando a combinação de aulas..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "JjJCYL"
-msgstr "Criando a miniatura do capítulo..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "6sYiuc"
-msgstr "Criando a imagem do capítulo..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "lXIWAI"
-msgstr "Ajustando a arte do capítulo..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
@@ -1103,6 +1086,10 @@ msgstr "Juntando tudo..."
 #: src/app/generate/cs/[id]/generation-client.tsx
 msgid "DFlapX"
 msgstr "Criando seu curso"
+
+#: src/app/generate/cs/[id]/generation-client.tsx
+msgid "GJKrUK"
+msgstr "Isso geralmente leva cerca de 2 minutos"
 
 #: src/app/generate/cs/[id]/generation-client.tsx
 msgid "0o41MR"

--- a/apps/main/src/app/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generation-client.tsx
@@ -46,11 +46,27 @@ export function GenerationClient({
     triggerUrl: `${API_URL}/v1/workflows/chapter-generation/trigger`,
   });
 
-  const { activePhaseNames, phases, progress, targetProgress, thinkingGenerators } =
-    useGenerationPhases(generation.completedSteps, generation.currentStep, generation.startedSteps);
+  const {
+    activePhaseDurationMs,
+    activePhaseNames,
+    phases,
+    progress,
+    targetProgress,
+    thinkingGenerators,
+  } = useGenerationPhases(
+    generation.completedSteps,
+    generation.currentStep,
+    generation.startedSteps,
+  );
 
   const isActive = generation.status === "triggering" || generation.status === "streaming";
-  const displayProgress = useAnimatedProgress({ isActive, realProgress: progress, targetProgress });
+
+  const displayProgress = useAnimatedProgress({
+    estimatedDurationMs: activePhaseDurationMs,
+    isActive,
+    realProgress: progress,
+    targetProgress,
+  });
 
   const thinkingMessages = useThinkingMessages(
     thinkingGenerators,

--- a/apps/main/src/app/generate/ch/[id]/generation-phases.test.ts
+++ b/apps/main/src/app/generate/ch/[id]/generation-phases.test.ts
@@ -2,12 +2,11 @@ import { describe, expect, it } from "vitest";
 import { calculateWeightedProgress, getPhaseOrder, getPhaseStatus } from "./generation-phases";
 
 describe("chapter generation phases", () => {
-  it("returns all 5 chapter phases in order", () => {
+  it("returns all 4 chapter phases in order", () => {
     const phases = getPhaseOrder();
 
     expect(phases).toStrictEqual([
       "gettingReady",
-      "creatingChapterImage",
       "preparingLessons",
       "classifyingLessons",
       "savingLessons",
@@ -47,7 +46,6 @@ describe("chapter generation phases", () => {
         "setChapterAsRunning",
         "generateLessons",
         "generateLessonKind",
-        "generateChapterImage",
         "addLessons",
         "setChapterAsCompleted",
       ],
@@ -55,16 +53,6 @@ describe("chapter generation phases", () => {
     );
 
     expect(status).toBe("completed");
-  });
-
-  it("marks chapter image generation as its own active phase", () => {
-    const status = getPhaseStatus(
-      "creatingChapterImage",
-      ["getChapter", "setChapterAsRunning", "generateLessons", "generateLessonKind"],
-      "generateChapterImage",
-    );
-
-    expect(status).toBe("active");
   });
 
   it("returns 0 progress at start", () => {
@@ -78,7 +66,6 @@ describe("chapter generation phases", () => {
       "setChapterAsRunning",
       "generateLessons",
       "generateLessonKind",
-      "generateChapterImage",
       "addLessons",
       "setChapterAsCompleted",
     ] as const;

--- a/apps/main/src/app/generate/ch/[id]/generation-phases.ts
+++ b/apps/main/src/app/generate/ch/[id]/generation-phases.ts
@@ -3,13 +3,13 @@ import {
   type PhaseStatus,
   calculateWeightedProgress as calculateProgress,
   calculateTargetProgress as calculateTarget,
+  getActivePhaseDurationMs as getDuration,
   getPhaseStatus as getStatus,
 } from "@/lib/generation-phases";
 import { type ChapterStepName, type ChapterWorkflowStepName } from "@zoonk/core/workflows/steps";
 import {
   BookOpenIcon,
   CheckCircleIcon,
-  ImageIcon,
   type LucideIcon,
   SettingsIcon,
   TagsIcon,
@@ -19,12 +19,10 @@ export type PhaseName =
   | "gettingReady"
   | "preparingLessons"
   | "classifyingLessons"
-  | "creatingChapterImage"
   | "savingLessons";
 
 const PHASE_STEPS = {
   classifyingLessons: ["generateLessonKind"],
-  creatingChapterImage: ["generateChapterImage"],
   gettingReady: ["getChapter", "setChapterAsRunning"],
   preparingLessons: ["generateLessons"],
   savingLessons: ["addLessons", "setChapterAsCompleted"],
@@ -35,7 +33,6 @@ type _ValidateChapter = AssertAllCovered<Exclude<ChapterStepName, AssignedSteps>
 
 const PHASE_ORDER: PhaseName[] = [
   "gettingReady",
-  "creatingChapterImage",
   "preparingLessons",
   "classifyingLessons",
   "savingLessons",
@@ -47,19 +44,21 @@ export function getPhaseOrder(): PhaseName[] {
 
 export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
   classifyingLessons: TagsIcon,
-  creatingChapterImage: ImageIcon,
   gettingReady: SettingsIcon,
   preparingLessons: BookOpenIcon,
   savingLessons: CheckCircleIcon,
 };
 
 const PHASE_WEIGHTS: Record<PhaseName, number> = {
-  classifyingLessons: 5,
-  creatingChapterImage: 40,
-  gettingReady: 5,
-  preparingLessons: 40,
-  savingLessons: 5,
+  classifyingLessons: 2,
+  gettingReady: 1,
+  preparingLessons: 50,
+  savingLessons: 1,
 };
+
+export function getActivePhaseDurationMs(activePhaseNames: PhaseName[]): number | undefined {
+  return getDuration({ activePhases: activePhaseNames, phaseWeights: PHASE_WEIGHTS });
+}
 
 export function getPhaseStatus(
   phase: PhaseName,

--- a/apps/main/src/app/generate/ch/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/ch/[id]/use-generation-phases.ts
@@ -13,6 +13,7 @@ import {
   type PhaseName,
   calculateTargetProgress,
   calculateWeightedProgress,
+  getActivePhaseDurationMs,
   getPhaseOrder,
   getPhaseStatus,
 } from "./generation-phases";
@@ -26,7 +27,6 @@ export function useGenerationPhases(
 
   const labels: Record<PhaseName, string> = {
     classifyingLessons: t("Choosing lesson types"),
-    creatingChapterImage: t("Creating chapter image"),
     gettingReady: t("Getting things ready"),
     preparingLessons: t("Preparing lessons"),
     savingLessons: t("Saving your lessons"),
@@ -55,21 +55,14 @@ export function useGenerationPhases(
     .filter((phase) => phase.status === "active")
     .map((phase) => phase.name);
 
+  const activePhaseDurationMs = getActivePhaseDurationMs(activePhaseNames);
+
   const thinkingGenerators: Record<PhaseName, ThinkingMessageGenerator> = {
     classifyingLessons: createCountingGenerator({
       intro: [t("Checking how each lesson should be taught...")],
       itemTemplate: (num) => t("Choosing type for lesson {number}...", { number: String(num) }),
       reviewMessage: t("Reviewing the lesson mix..."),
     }),
-    creatingChapterImage: (index) =>
-      cycleMessage(
-        [
-          t("Designing the chapter thumbnail..."),
-          t("Creating the chapter image..."),
-          t("Refining the chapter artwork..."),
-        ],
-        index,
-      ),
     gettingReady: (index) =>
       cycleMessage([t("Setting things up..."), t("Getting everything ready...")], index),
     preparingLessons: createCountingGenerator({
@@ -81,5 +74,12 @@ export function useGenerationPhases(
       cycleMessage([t("Saving your progress..."), t("Putting it all together...")], index),
   };
 
-  return { activePhaseNames, phases, progress, targetProgress, thinkingGenerators };
+  return {
+    activePhaseDurationMs,
+    activePhaseNames,
+    phases,
+    progress,
+    targetProgress,
+    thinkingGenerators,
+  };
 }

--- a/apps/main/src/app/generate/cs/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generation-client.tsx
@@ -46,11 +46,27 @@ export function GenerationClient({
     triggerUrl: `${API_URL}/v1/workflows/course-generation/trigger`,
   });
 
-  const { activePhaseNames, phases, progress, targetProgress, thinkingGenerators } =
-    useGenerationPhases(generation.completedSteps, generation.currentStep, generation.startedSteps);
+  const {
+    activePhaseDurationMs,
+    activePhaseNames,
+    phases,
+    progress,
+    targetProgress,
+    thinkingGenerators,
+  } = useGenerationPhases(
+    generation.completedSteps,
+    generation.currentStep,
+    generation.startedSteps,
+  );
 
   const isActive = generation.status === "triggering" || generation.status === "streaming";
-  const displayProgress = useAnimatedProgress({ isActive, realProgress: progress, targetProgress });
+
+  const displayProgress = useAnimatedProgress({
+    estimatedDurationMs: activePhaseDurationMs,
+    isActive,
+    realProgress: progress,
+    targetProgress,
+  });
 
   const thinkingMessages = useThinkingMessages(
     thinkingGenerators,
@@ -67,7 +83,7 @@ export function GenerationClient({
         <GenerationTimelineHeader>
           <GenerationTimelineTitle>{t("Creating your course")}</GenerationTimelineTitle>
           <GenerationTimelineSubtitle>
-            {t("This usually takes about a minute")}
+            {t("This usually takes about 2 minutes")}
           </GenerationTimelineSubtitle>
           <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
         </GenerationTimelineHeader>

--- a/apps/main/src/app/generate/cs/[id]/generation-phases.ts
+++ b/apps/main/src/app/generate/cs/[id]/generation-phases.ts
@@ -3,6 +3,7 @@ import {
   type PhaseStatus,
   calculateWeightedProgress as calculateProgress,
   calculateTargetProgress as calculateTarget,
+  getActivePhaseDurationMs as getDuration,
   getPhaseStatus as getStatus,
 } from "@/lib/generation-phases";
 import { type CourseStepName, type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
@@ -78,16 +79,20 @@ export const PHASE_ICONS: Record<PhaseName, LucideIcon> = {
 };
 
 const PHASE_WEIGHTS: Record<PhaseName, number> = {
-  categorizingCourse: 3,
-  checkingCourseIdentity: 3,
-  creatingCoverImage: 15,
-  findingSimilarCourses: 3,
+  categorizingCourse: 2,
+  checkingCourseIdentity: 2,
+  creatingCoverImage: 20,
+  findingSimilarCourses: 2,
   gettingReady: 1,
-  outliningChapters: 50,
+  outliningChapters: 102,
   preparingCourse: 1,
-  savingCourseInfo: 2,
-  writingDescription: 3,
+  savingCourseInfo: 1,
+  writingDescription: 4,
 };
+
+export function getActivePhaseDurationMs(activePhaseNames: PhaseName[]): number | undefined {
+  return getDuration({ activePhases: activePhaseNames, phaseWeights: PHASE_WEIGHTS });
+}
 
 export function getPhaseStatus(
   phase: PhaseName,

--- a/apps/main/src/app/generate/cs/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/cs/[id]/use-generation-phases.ts
@@ -13,6 +13,7 @@ import {
   type PhaseName,
   calculateTargetProgress,
   calculateWeightedProgress,
+  getActivePhaseDurationMs,
   getPhaseOrder,
   getPhaseStatus,
 } from "./generation-phases";
@@ -59,6 +60,8 @@ export function useGenerationPhases(
     .filter((phase) => phase.status === "active")
     .map((phase) => phase.name);
 
+  const activePhaseDurationMs = getActivePhaseDurationMs(activePhaseNames);
+
   const thinkingGenerators: Record<PhaseName, ThinkingMessageGenerator> = {
     categorizingCourse: (index) =>
       cycleMessage([t("Figuring out the right categories..."), t("Tagging your course...")], index),
@@ -104,5 +107,12 @@ export function useGenerationPhases(
       cycleMessage([t("Summarizing what you'll learn..."), t("Writing the overview...")], index),
   };
 
-  return { activePhaseNames, phases, progress, targetProgress, thinkingGenerators };
+  return {
+    activePhaseDurationMs,
+    activePhaseNames,
+    phases,
+    progress,
+    targetProgress,
+    thinkingGenerators,
+  };
 }

--- a/apps/main/src/app/generate/l/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/l/[id]/generation-client.tsx
@@ -51,16 +51,28 @@ export function GenerationClient({
     triggerUrl: `${API_URL}/v1/workflows/lesson-generation/trigger`,
   });
 
-  const { activePhaseNames, phases, progress, targetProgress, thinkingGenerators } =
-    useGenerationPhases(
-      generation.completedSteps,
-      generation.currentStep,
-      lessonKind,
-      generation.startedSteps,
-    );
+  const {
+    activePhaseDurationMs,
+    activePhaseNames,
+    phases,
+    progress,
+    targetProgress,
+    thinkingGenerators,
+  } = useGenerationPhases(
+    generation.completedSteps,
+    generation.currentStep,
+    lessonKind,
+    generation.startedSteps,
+  );
 
   const isActive = generation.status === "triggering" || generation.status === "streaming";
-  const displayProgress = useAnimatedProgress({ isActive, realProgress: progress, targetProgress });
+
+  const displayProgress = useAnimatedProgress({
+    estimatedDurationMs: activePhaseDurationMs,
+    isActive,
+    realProgress: progress,
+    targetProgress,
+  });
 
   const thinkingMessages = useThinkingMessages(
     thinkingGenerators,

--- a/apps/main/src/app/generate/l/[id]/generation-phase-weights.ts
+++ b/apps/main/src/app/generate/l/[id]/generation-phase-weights.ts
@@ -30,85 +30,85 @@ export function getPhaseWeights(kind: GeneratedLessonKind): Record<PhaseName, nu
   if (kind === "alphabet" || kind === "vocabulary") {
     return {
       ...ZERO_WEIGHTS,
-      addingPronunciation: 20,
-      addingRomanization: 10,
-      buildingWordList: 15,
+      addingPronunciation: 65,
+      addingRomanization: 4,
+      buildingWordList: 6,
       creatingExercises: 5,
-      gettingStarted: 3,
-      recordingAudio: 45,
-      saving: 2,
+      gettingStarted: 1,
+      recordingAudio: 6,
+      saving: 1,
     };
   }
 
   if (kind === "grammar") {
     return {
       ...ZERO_WEIGHTS,
-      addingRomanization: 15,
-      creatingExercises: 30,
-      gettingStarted: 5,
-      saving: 5,
-      writingContent: 45,
+      addingRomanization: 4,
+      creatingExercises: 8,
+      gettingStarted: 1,
+      saving: 1,
+      writingContent: 15,
     };
   }
 
   if (kind === "reading") {
     return {
       ...ZERO_WEIGHTS,
-      addingRomanization: 10,
-      addingWordPronunciation: 7,
-      creatingExercises: 20,
-      creatingSentences: 20,
-      gettingStarted: 3,
-      lookingUpWords: 20,
-      recordingAudio: 10,
-      recordingWordAudio: 5,
-      saving: 5,
+      addingRomanization: 4,
+      addingWordPronunciation: 5,
+      creatingExercises: 5,
+      creatingSentences: 12,
+      gettingStarted: 1,
+      lookingUpWords: 5,
+      recordingAudio: 5,
+      recordingWordAudio: 10,
+      saving: 1,
     };
   }
 
   if (kind === "tutorial") {
     return {
       ...ZERO_WEIGHTS,
-      creatingImages: 35,
-      creatingLessonImage: 35,
-      gettingStarted: 3,
-      preparingImages: 44,
-      saving: 4,
-      writingContent: 14,
+      creatingImages: 45,
+      creatingLessonImage: 30,
+      gettingStarted: 1,
+      preparingImages: 8,
+      saving: 1,
+      writingContent: 10,
     };
   }
 
   if (kind === "explanation") {
     return {
       ...ZERO_WEIGHTS,
-      creatingImages: 33,
-      creatingLessonImage: 33,
-      gettingStarted: 3,
-      preparingImages: 40,
-      saving: 4,
-      writingContent: 20,
+      creatingImages: 50,
+      creatingLessonImage: 30,
+      gettingStarted: 1,
+      preparingImages: 15,
+      saving: 1,
+      writingContent: 35,
     };
   }
 
   if (kind === "quiz") {
     return {
       ...ZERO_WEIGHTS,
-      creatingImages: 42,
-      gettingStarted: 3,
-      saving: 5,
-      writingContent: 50,
+      creatingImages: 45,
+      gettingStarted: 1,
+      saving: 1,
+      writingContent: 30,
     };
   }
 
   if (kind === "practice") {
     return {
       ...ZERO_WEIGHTS,
-      creatingImages: 30,
-      gettingStarted: 5,
-      saving: 5,
-      writingContent: 60,
+      creatingImages: 45,
+      gettingStarted: 1,
+      saving: 1,
+      writingContent: 20,
     };
   }
 
-  return { ...ZERO_WEIGHTS, gettingStarted: 10, saving: 90 };
+  return { ...ZERO_WEIGHTS, gettingStarted: 1, saving: 1 };
 }

--- a/apps/main/src/app/generate/l/[id]/generation-phases.ts
+++ b/apps/main/src/app/generate/l/[id]/generation-phases.ts
@@ -2,6 +2,7 @@ import {
   type PhaseStatus,
   calculateWeightedProgress as calculateProgress,
   calculateTargetProgress as calculateTarget,
+  getActivePhaseDurationMs as getDuration,
   getPhaseStatus as getStatus,
 } from "@/lib/generation-phases";
 import { type LessonStepName } from "@zoonk/core/workflows/steps";
@@ -95,4 +96,12 @@ export function calculateTargetProgress(
   startedSteps?: LessonStepName[],
 ): number {
   return calculateTarget(completedSteps, currentStep, getProgressConfig(lessonKind, startedSteps));
+}
+
+/** Returns the longest active lesson phase duration in milliseconds. */
+export function getActivePhaseDurationMs(
+  activePhaseNames: PhaseName[],
+  lessonKind: GeneratedLessonKind,
+): number | undefined {
+  return getDuration({ activePhases: activePhaseNames, phaseWeights: getPhaseWeights(lessonKind) });
 }

--- a/apps/main/src/app/generate/l/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/l/[id]/use-generation-phases.ts
@@ -7,6 +7,7 @@ import {
   PHASE_ICONS,
   calculateTargetProgress,
   calculateWeightedProgress,
+  getActivePhaseDurationMs,
   getPhaseStatus,
 } from "./generation-phases";
 import { usePhaseLabels } from "./use-phase-labels";
@@ -49,7 +50,16 @@ export function useGenerationPhases(
     .filter((phase) => phase.status === "active")
     .map((phase) => phase.name);
 
+  const activePhaseDurationMs = getActivePhaseDurationMs(activePhaseNames, lessonKind);
+
   const thinkingGenerators = usePhaseThinkingGenerators();
 
-  return { activePhaseNames, phases, progress, targetProgress, thinkingGenerators };
+  return {
+    activePhaseDurationMs,
+    activePhaseNames,
+    phases,
+    progress,
+    targetProgress,
+    thinkingGenerators,
+  };
 }

--- a/apps/main/src/lib/generation-phases.ts
+++ b/apps/main/src/lib/generation-phases.ts
@@ -130,6 +130,24 @@ type ProgressConfig<TPhase extends string, TStep extends string> = {
   startedSteps?: TStep[];
 };
 
+/**
+ * Converts the currently active phase weights into an animation duration.
+ * Generation phase weights are second-based estimates, and parallel phases can
+ * be active together, so the visible timer should follow the longest active
+ * phase instead of adding independent work that runs at the same time.
+ */
+export function getActivePhaseDurationMs<TPhase extends string>({
+  activePhases,
+  phaseWeights,
+}: {
+  activePhases: TPhase[];
+  phaseWeights: Record<TPhase, number>;
+}): number | undefined {
+  const durationSeconds = Math.max(...activePhases.map((phase) => phaseWeights[phase]));
+
+  return durationSeconds > 0 ? durationSeconds * 1000 : undefined;
+}
+
 export function calculateWeightedProgress<TPhase extends string, TStep extends string>(
   completedSteps: TStep[],
   currentStep: TStep | null,

--- a/apps/main/src/lib/workflow/use-animated-progress.test.ts
+++ b/apps/main/src/lib/workflow/use-animated-progress.test.ts
@@ -58,6 +58,23 @@ describe(useAnimatedProgress, () => {
     expect(large.current).toBeGreaterThan(small.current);
   });
 
+  it("uses the estimated duration when the active phase has a time weight", () => {
+    const { result } = renderHook(() =>
+      useAnimatedProgress({
+        estimatedDurationMs: 120_000,
+        isActive: true,
+        realProgress: 21,
+        targetProgress: 99,
+      }),
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(45_000);
+    });
+
+    expect(result.current).toBe(50);
+  });
+
   it("never exceeds targetProgress", () => {
     const { result } = renderHook(() =>
       useAnimatedProgress({ isActive: true, realProgress: 10, targetProgress: 30 }),

--- a/apps/main/src/lib/workflow/use-animated-progress.ts
+++ b/apps/main/src/lib/workflow/use-animated-progress.ts
@@ -6,6 +6,26 @@ const HALF_LIFE = 12_000;
 const CAP = 97;
 
 /**
+ * Uses the phase's estimated duration when one exists so a long single-step phase
+ * advances at the same pace as the time weight that produced the progress target.
+ * Without this, a 120-second phase still races toward its full target with the
+ * default 12-second half-life because the backend can only report started/done.
+ */
+function getDriftProgress({
+  elapsed,
+  estimatedDurationMs,
+}: {
+  elapsed: number;
+  estimatedDurationMs?: number | undefined;
+}) {
+  if (estimatedDurationMs && estimatedDurationMs > 0) {
+    return Math.min(elapsed / estimatedDurationMs, 1);
+  }
+
+  return 1 - Math.exp(-elapsed / HALF_LIFE);
+}
+
+/**
  * Wraps a real progress value and slowly ticks it forward
  * while streaming is active, creating the illusion of movement
  * during long-running backend steps.
@@ -22,10 +42,12 @@ const CAP = 97;
  * preventing visual "snap-back" when real progress drops after drift inflation.
  */
 export function useAnimatedProgress({
+  estimatedDurationMs,
   isActive,
   realProgress,
   targetProgress,
 }: {
+  estimatedDurationMs?: number | undefined;
   isActive: boolean;
   realProgress: number;
   targetProgress: number;
@@ -57,7 +79,7 @@ export function useAnimatedProgress({
     function tick() {
       const gap = Math.max(0, targetProgress - baseRef.current);
       const elapsed = performance.now() - startTimeRef.current;
-      const drift = gap * (1 - Math.exp(-elapsed / HALF_LIFE));
+      const drift = gap * getDriftProgress({ elapsed, estimatedDurationMs });
       const animated = baseRef.current + drift;
       const capped = Math.min(animated, CAP);
       const monotonic = Math.max(capped, highWaterRef.current);
@@ -77,7 +99,7 @@ export function useAnimatedProgress({
     return () => {
       cancelAnimationFrame(rafRef.current);
     };
-  }, [isActive, realProgress, targetProgress]);
+  }, [estimatedDurationMs, isActive, realProgress, targetProgress]);
 
   return display;
 }

--- a/packages/core/src/workflows/steps.ts
+++ b/packages/core/src/workflows/steps.ts
@@ -40,7 +40,6 @@ const CHAPTER_STEPS = [
   "setChapterAsRunning",
   "generateLessons",
   "generateLessonKind",
-  "generateChapterImage",
   "addLessons",
   "setChapterAsCompleted",
 ] as const;


### PR DESCRIPTION
## Summary

- tune generation phase weights to represent second-based timing
- pace progress animation from the active phase duration
- remove stale chapter image progress from chapter generation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns generation progress with real timing by switching phase weights to seconds and pacing the progress bar using the active phase’s estimated duration. Also removes the deprecated chapter image phase and updates copy to “about 2 minutes” for course generation.

- **Refactors**
  - Added getActivePhaseDurationMs to map active phase weights to ms and use the longest active phase.
  - Updated use-animated-progress to accept estimatedDurationMs for drift pacing.
  - Rebalanced phase weights for chapter, course, and lesson flows to represent seconds.
  - Clients now pass estimatedDurationMs from useGenerationPhases to the progress hook.
  - Updated i18n and UI copy to “This usually takes about 2 minutes.”
  - Adjusted tests (unit and e2e) to the new timing model and copy; synced steps in `@zoonk/core`.

- **Bug Fixes**
  - Removed stale chapter image phase and related messages from chapter generation.
  - Fixed progress “racing” in long single-step phases by tying animation speed to phase duration.

<sup>Written for commit 7a6d71f5a87eb03dc87efd07571bc47047f43bdd. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1496?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

