### PR TITLE
feat(main): allow first chapter lesson generation

### DIFF
--- a/apps/api/e2e/workflows-lesson-generation.test.ts
+++ b/apps/api/e2e/workflows-lesson-generation.test.ts
@@ -3,6 +3,9 @@ import { request } from "@playwright/test";
 import { prisma } from "@zoonk/db";
 import { expect, test } from "@zoonk/e2e/fixtures";
 import { createOrganization, getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { normalizeString } from "@zoonk/utils/string";
 
 /**
@@ -52,6 +55,44 @@ async function createSubscribedApiContext({
   expect(signInResponse.ok()).toBe(true);
 
   return apiContext;
+}
+
+/**
+ * Route-contract tests only need a published AI-owned lesson with a specific
+ * chapter position. The lesson is already completed so starting the workflow
+ * exercises the API gate without making the test depend on real AI generation.
+ */
+async function createAiLessonForWorkflow({
+  aiOrgId,
+  chapterPosition,
+  uniqueId,
+}: {
+  aiOrgId: string;
+  chapterPosition: number;
+  uniqueId: string;
+}) {
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: aiOrgId,
+    title: `E2E Lesson Workflow ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: aiOrgId,
+    position: chapterPosition,
+    title: `E2E Lesson Chapter ${uniqueId}`,
+  });
+
+  return lessonFixture({
+    chapterId: chapter.id,
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "explanation",
+    organizationId: aiOrgId,
+    title: `E2E Lesson ${uniqueId}`,
+  });
 }
 
 test.describe("Lesson Generation Workflow API", () => {
@@ -119,48 +160,7 @@ test.describe("Lesson Generation Workflow API", () => {
 
   test("returns 402 when user has no active subscription", async () => {
     const uniqueId = randomUUID().slice(0, 8);
-    const courseTitle = `E2E Lesson Test ${uniqueId}`;
-
-    const course = await prisma.course.create({
-      data: {
-        description: "Test course for lesson generation",
-        isPublished: true,
-        language: "en",
-        normalizedTitle: normalizeString(courseTitle),
-        organizationId: aiOrgId,
-        slug: `e2e-lesson-test-${uniqueId}`,
-        title: courseTitle,
-      },
-    });
-
-    const chapter = await prisma.chapter.create({
-      data: {
-        courseId: course.id,
-        description: "Test chapter description",
-        isPublished: true,
-        language: "en",
-        normalizedTitle: normalizeString("Test Chapter"),
-        organizationId: aiOrgId,
-        position: 0,
-        slug: `e2e-chapter-${uniqueId}`,
-        title: "Test Chapter",
-      },
-    });
-
-    const lesson = await prisma.lesson.create({
-      data: {
-        chapterId: chapter.id,
-        description: "Test lesson description",
-        isPublished: true,
-        kind: "explanation",
-        language: "en",
-        normalizedTitle: normalizeString("Test Lesson"),
-        organizationId: aiOrgId,
-        position: 0,
-        slug: `e2e-lesson-${uniqueId}`,
-        title: "Test Lesson",
-      },
-    });
+    const lesson = await createAiLessonForWorkflow({ aiOrgId, chapterPosition: 1, uniqueId });
 
     const apiContext = await request.newContext({ baseURL });
 
@@ -176,9 +176,28 @@ test.describe("Lesson Generation Workflow API", () => {
     expect(body.error.code).toBe("PAYMENT_REQUIRED");
     expect(body.error.message).toBe("Active subscription required");
 
-    await prisma.lesson.delete({ where: { id: lesson.id } });
-    await prisma.chapter.delete({ where: { id: chapter.id } });
-    await prisma.course.delete({ where: { id: course.id } });
+    await apiContext.dispose();
+  });
+
+  test("allows first chapter lesson generation without subscription", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const lesson = await createAiLessonForWorkflow({ aiOrgId, chapterPosition: 0, uniqueId });
+
+    const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
+      data: { lessonId: lesson.id },
+    });
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+
+    expect(body.message).toBe("Workflow started");
+    expect(body.runId).toBeDefined();
+    expect(typeof body.runId).toBe("string");
+
     await apiContext.dispose();
   });
 

--- a/apps/api/e2e/workflows-lesson-preload.test.ts
+++ b/apps/api/e2e/workflows-lesson-preload.test.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from "node:crypto";
+import { request } from "@playwright/test";
+import { prisma } from "@zoonk/db";
+import { expect, test } from "@zoonk/e2e/fixtures";
+import { createOrganization, getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+
+/**
+ * Preload trigger tests should prove the subscription gate, not the lesson
+ * generation workflow internals. Completed lesson rows make the triggered
+ * workflow finish as a no-op after the route has accepted the request.
+ */
+async function createAiLessonForPreload({
+  aiOrgId,
+  chapterPosition,
+  uniqueId,
+}: {
+  aiOrgId: string;
+  chapterPosition: number;
+  uniqueId: string;
+}) {
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: aiOrgId,
+    title: `E2E Preload Workflow ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: aiOrgId,
+    position: chapterPosition,
+    title: `E2E Preload Chapter ${uniqueId}`,
+  });
+
+  return lessonFixture({
+    chapterId: chapter.id,
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "explanation",
+    organizationId: aiOrgId,
+    title: `E2E Preload Lesson ${uniqueId}`,
+  });
+}
+
+test.describe("Lesson Preload Workflow API", () => {
+  let baseURL: string;
+  let aiOrgId: string;
+
+  test.beforeAll(async () => {
+    baseURL = process.env.E2E_BASE_URL ?? "";
+
+    const aiOrg = await getAiOrganization();
+    aiOrgId = aiOrg.id;
+  });
+
+  test.afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  test("returns 402 when a later chapter lesson has no active subscription", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const lesson = await createAiLessonForPreload({ aiOrgId, chapterPosition: 1, uniqueId });
+
+    const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/workflows/lesson-preload/trigger", {
+      data: { lessonId: lesson.id },
+    });
+
+    expect(response.status()).toBe(402);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("PAYMENT_REQUIRED");
+    expect(body.error.message).toBe("Active subscription required");
+
+    await apiContext.dispose();
+  });
+
+  test("allows first chapter lesson preload without subscription", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const lesson = await createAiLessonForPreload({ aiOrgId, chapterPosition: 0, uniqueId });
+
+    const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/workflows/lesson-preload/trigger", {
+      data: { lessonId: lesson.id },
+    });
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+
+    expect(body.message).toBe("Workflow started");
+    expect(body.runId).toBeDefined();
+    expect(typeof body.runId).toBe("string");
+
+    await apiContext.dispose();
+  });
+
+  test("returns 404 before skipping auth for non-AI first chapter lessons", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const org = await createOrganization();
+
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: org.id,
+      title: `E2E Non-AI Preload ${uniqueId}`,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: org.id,
+      position: 0,
+      title: `E2E Non-AI Preload Chapter ${uniqueId}`,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      generationStatus: "completed",
+      isPublished: true,
+      organizationId: org.id,
+      title: `E2E Non-AI Preload Lesson ${uniqueId}`,
+    });
+
+    const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/workflows/lesson-preload/trigger", {
+      data: { lessonId: lesson.id },
+    });
+
+    expect(response.status()).toBe(404);
+
+    await apiContext.dispose();
+  });
+});

--- a/apps/api/src/app/v1/workflows/chapter-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/chapter-generation/trigger/route.ts
@@ -1,24 +1,14 @@
 import { errors } from "@/lib/api-errors";
 import { parseBody } from "@/lib/body-parser";
 import { chapterGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
+import {
+  getAiGenerationChapterForWorkflow,
+  hasWorkflowSubscriptionAccess,
+  requiresSubscriptionForChapterGeneration,
+} from "@/lib/workflow-generation-access";
 import { chapterGenerationWorkflow } from "@/workflows/chapter-generation/chapter-generation-workflow";
-import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
-import { getAiGenerationChapterWhere, prisma } from "@zoonk/db";
 import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
-
-/**
- * The first-chapter free path is intentionally public, so this lookup must
- * also prove the chapter belongs to the AI curriculum before we skip auth.
- */
-async function getChapterPosition(chapterId: string) {
-  const chapter = await prisma.chapter.findFirst({
-    select: { position: true },
-    where: getAiGenerationChapterWhere({ chapterWhere: { id: chapterId } }),
-  });
-
-  return chapter;
-}
 
 export async function POST(request: NextRequest) {
   const parsed = await parseBody(request, chapterGenerationTriggerSchema);
@@ -27,18 +17,19 @@ export async function POST(request: NextRequest) {
     return errors.validation(parsed.error);
   }
 
-  const chapter = await getChapterPosition(parsed.data.chapterId);
+  const chapter = await getAiGenerationChapterForWorkflow({ chapterId: parsed.data.chapterId });
 
   if (!chapter) {
     return errors.notFound();
   }
 
-  if (chapter.position !== 0) {
-    const hasSubscription = await hasActiveSubscription(request.headers);
+  const hasAccess = await hasWorkflowSubscriptionAccess({
+    headers: request.headers,
+    requiresSubscription: requiresSubscriptionForChapterGeneration(chapter),
+  });
 
-    if (!hasSubscription) {
-      return errors.paymentRequired();
-    }
+  if (!hasAccess) {
+    return errors.paymentRequired();
   }
 
   const run = await start(chapterGenerationWorkflow, [parsed.data.chapterId]);

--- a/apps/api/src/app/v1/workflows/lesson-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/lesson-generation/trigger/route.ts
@@ -1,13 +1,16 @@
 import { errors } from "@/lib/api-errors";
 import { parseBody } from "@/lib/body-parser";
 import { lessonGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
+import {
+  getAiGenerationLessonForWorkflow,
+  hasWorkflowSubscriptionAccess,
+  requiresSubscriptionForLessonGeneration,
+} from "@/lib/workflow-generation-access";
 import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
-import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
 import {
   getBlockingLessonGenerationPrerequisite,
   hasLessonGenerationPrerequisites,
 } from "@zoonk/core/lessons/generation-prerequisites";
-import { getAiGenerationLessonWhere, prisma } from "@zoonk/db";
 import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 
@@ -18,17 +21,18 @@ export async function POST(request: NextRequest) {
     return errors.validation(parsed.error);
   }
 
-  const lesson = await prisma.lesson.findFirst({
-    where: getAiGenerationLessonWhere({ lessonWhere: { id: parsed.data.lessonId } }),
-  });
+  const lesson = await getAiGenerationLessonForWorkflow({ lessonId: parsed.data.lessonId });
 
   if (!lesson) {
     return errors.notFound();
   }
 
-  const hasSubscription = await hasActiveSubscription(request.headers);
+  const hasAccess = await hasWorkflowSubscriptionAccess({
+    headers: request.headers,
+    requiresSubscription: requiresSubscriptionForLessonGeneration(lesson),
+  });
 
-  if (!hasSubscription) {
+  if (!hasAccess) {
     return errors.paymentRequired();
   }
 

--- a/apps/api/src/app/v1/workflows/lesson-preload/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/lesson-preload/trigger/route.ts
@@ -1,9 +1,12 @@
 import { errors } from "@/lib/api-errors";
 import { parseBody } from "@/lib/body-parser";
 import { lessonPreloadTriggerSchema } from "@/lib/openapi/schemas/workflows";
+import {
+  getAiGenerationLessonForWorkflow,
+  hasWorkflowSubscriptionAccess,
+  requiresSubscriptionForLessonGeneration,
+} from "@/lib/workflow-generation-access";
 import { lessonPreloadWorkflow } from "@/workflows/lesson-preload/lesson-preload-workflow";
-import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
-import { getAiGenerationLessonWhere, prisma } from "@zoonk/db";
 import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 
@@ -14,18 +17,18 @@ export async function POST(request: NextRequest) {
     return errors.validation(parsed.error);
   }
 
-  const lesson = await prisma.lesson.findFirst({
-    select: { id: true },
-    where: getAiGenerationLessonWhere({ lessonWhere: { id: parsed.data.lessonId } }),
-  });
+  const lesson = await getAiGenerationLessonForWorkflow({ lessonId: parsed.data.lessonId });
 
   if (!lesson) {
     return errors.notFound();
   }
 
-  const hasSubscription = await hasActiveSubscription(request.headers);
+  const hasAccess = await hasWorkflowSubscriptionAccess({
+    headers: request.headers,
+    requiresSubscription: requiresSubscriptionForLessonGeneration(lesson),
+  });
 
-  if (!hasSubscription) {
+  if (!hasAccess) {
     return errors.paymentRequired();
   }
 

--- a/apps/api/src/lib/workflow-generation-access.ts
+++ b/apps/api/src/lib/workflow-generation-access.ts
@@ -1,0 +1,69 @@
+import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
+import {
+  type Chapter,
+  type Lesson,
+  getAiGenerationChapterWhere,
+  getAiGenerationLessonWhere,
+  prisma,
+} from "@zoonk/db";
+
+type LessonWithChapter = Lesson & { chapter: Chapter };
+
+/**
+ * Workflow trigger routes receive raw ids from the client, so they need one
+ * shared lookup that proves the chapter belongs to the AI curriculum before any
+ * subscription exception can apply.
+ */
+export async function getAiGenerationChapterForWorkflow(params: { chapterId: string }) {
+  return prisma.chapter.findFirst({
+    where: getAiGenerationChapterWhere({ chapterWhere: { id: params.chapterId } }),
+  });
+}
+
+/**
+ * Lesson generation and preload share the same subscription exception: lessons
+ * in the first course chapter are free, later chapters require a subscription.
+ * Loading the chapter with the lesson keeps that rule tied to the trusted row
+ * instead of accepting a client-provided course or chapter position.
+ */
+export async function getAiGenerationLessonForWorkflow(params: {
+  lessonId: string;
+}): Promise<LessonWithChapter | null> {
+  return prisma.lesson.findFirst({
+    include: { chapter: true },
+    where: getAiGenerationLessonWhere({ lessonWhere: { id: params.lessonId } }),
+  });
+}
+
+/**
+ * Position 0 is the product's first-chapter marker. That chapter is the free
+ * starter experience; any later chapter stays behind the subscription gate.
+ */
+export function requiresSubscriptionForChapterGeneration(chapter: Pick<Chapter, "position">) {
+  return chapter.position !== 0;
+}
+
+/**
+ * Lesson access follows the parent chapter, not the lesson position. This lets
+ * every lesson in the first chapter be generated or preloaded before purchase.
+ */
+export function requiresSubscriptionForLessonGeneration(lesson: {
+  chapter: Pick<Chapter, "position">;
+}) {
+  return requiresSubscriptionForChapterGeneration(lesson.chapter);
+}
+
+/**
+ * First-chapter workflow triggers should not even touch auth, while later
+ * chapters must keep using the normal active-subscription check.
+ */
+export async function hasWorkflowSubscriptionAccess(params: {
+  headers: Headers;
+  requiresSubscription: boolean;
+}) {
+  if (!params.requiresSubscription) {
+    return true;
+  }
+
+  return hasActiveSubscription(params.headers);
+}

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -13,10 +13,11 @@ import { expect, test } from "./fixtures";
 /**
  * Test Architecture for Lesson Generation Page
  *
- * The generation page has 3 access states:
- * 1. Unauthenticated - Shows login prompt
- * 2. Authenticated without subscription - Shows upgrade CTA
- * 3. Authenticated with subscription - Shows generation UI
+ * The generation page has 4 access states:
+ * 1. Unauthenticated later chapter - Shows login prompt
+ * 2. Authenticated later chapter without subscription - Shows upgrade CTA
+ * 3. First chapter or running generation - Shows generation UI without gating
+ * 4. Authenticated with subscription - Shows generation UI
  *
  * The generation flow interacts with 2 APIs on the API server:
  * 1. POST ${API_BASE_URL}/v1/workflows/lesson-generation/trigger - Starts the workflow, returns { runId: string }
@@ -113,7 +114,7 @@ async function setupMockApis(page: Page, options: MockApiOptions = {}): Promise<
 /**
  * Creates a lesson with pending generation status for testing the generation workflow.
  */
-async function createPendingLesson() {
+async function createPendingLesson(chapterPosition = 0) {
   const org = await getAiOrganization();
 
   const uniqueId = randomUUID().slice(0, 8);
@@ -135,6 +136,7 @@ async function createPendingLesson() {
     isPublished: true,
     normalizedTitle: normalizeString(chapterTitle),
     organizationId: org.id,
+    position: chapterPosition,
     slug: `e2e-lesson-chapter-${uniqueId}`,
     title: chapterTitle,
   });
@@ -234,7 +236,7 @@ async function createTestSubscription(userId: string) {
 
 test.describe("Generate Lesson Page - Unauthenticated", () => {
   test("shows login prompt with link to login page", async ({ page }) => {
-    const { lesson } = await createPendingLesson();
+    const { lesson } = await createPendingLesson(1);
     await page.goto(`/generate/l/${lesson.id}`);
 
     await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
@@ -247,7 +249,7 @@ test.describe("Generate Lesson Page - Unauthenticated", () => {
 
 test.describe("Generate Lesson Page - No Subscription", () => {
   test("shows upgrade CTA with link to subscription page", async ({ authenticatedPage }) => {
-    const { lesson } = await createPendingLesson();
+    const { lesson } = await createPendingLesson(1);
     await authenticatedPage.goto(`/generate/l/${lesson.id}`);
 
     await expect(authenticatedPage.getByText(/upgrade to create/iu)).toBeVisible();
@@ -255,6 +257,42 @@ test.describe("Generate Lesson Page - No Subscription", () => {
     const upgradeLink = authenticatedPage.getByRole("link", { name: /upgrade/iu });
     await expect(upgradeLink).toBeVisible();
     await expect(upgradeLink).toHaveAttribute("href", /\/subscription/u);
+  });
+});
+
+test.describe("Generate Lesson Page - First Chapter Free", () => {
+  test("unauthenticated user sees generation UI for first chapter lesson", async ({ page }) => {
+    const { lesson } = await createPendingLesson(0);
+
+    await setupMockApis(page, {
+      statusDelayMs: 2500,
+      streamMessages: [{ status: "started", step: "getLesson" }],
+    });
+
+    await page.goto(`/generate/l/${lesson.id}`);
+
+    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toHaveCount(0);
+    await expect(page.getByText(/upgrade to create/iu)).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: lesson.title ?? "" })).toBeVisible();
+  });
+
+  test("authenticated user without subscription sees generation UI for first chapter lesson", async ({
+    authenticatedPage,
+  }) => {
+    const { lesson } = await createPendingLesson(0);
+
+    await setupMockApis(authenticatedPage, {
+      statusDelayMs: 2500,
+      streamMessages: [{ status: "started", step: "getLesson" }],
+    });
+
+    await authenticatedPage.goto(`/generate/l/${lesson.id}`);
+
+    await expect(authenticatedPage.getByText(/upgrade to create/iu)).toHaveCount(0);
+
+    await expect(
+      authenticatedPage.getByRole("heading", { name: lesson.title ?? "" }),
+    ).toBeVisible();
   });
 });
 

--- a/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
+++ b/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
@@ -54,6 +54,8 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
   }
 
   const hasStarted = lesson.generationStatus !== "pending";
+  const isFirstChapter = lesson.chapter.position === 0;
+  const bypassAuth = isFirstChapter || hasStarted;
   const t = await getExtracted();
   const lessonMeta = await getLessonDisplayMeta(lesson);
 
@@ -112,7 +114,7 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
     );
   }
 
-  if (!session && !hasStarted) {
+  if (!session && !bypassAuth) {
     return <LoginRequired backHref={backHref} backLabel={backLabel} title={t("Create Lesson")} />;
   }
 
@@ -126,7 +128,7 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
       </ContainerHeader>
 
       <ContainerBody>
-        <SubscriptionGate backHref={backHref} backLabel={backLabel} bypass={hasStarted}>
+        <SubscriptionGate backHref={backHref} backLabel={backLabel} bypass={bypassAuth}>
           <GenerationClient
             chapterSlug={lesson.chapter.slug}
             courseSlug={lesson.chapter.course.slug}


### PR DESCRIPTION
## Summary
- allow first-chapter lesson generation and preload without login or subscription
- keep later chapter lesson/chapter generation behind existing gates
- add API and main e2e coverage for the free first-chapter path

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow generating and preloading first‑chapter lessons without login or an active subscription; later chapters remain gated by subscription. Centralizes workflow access checks and adds e2e coverage for the free first‑chapter path.

- **New Features**
  - First‑chapter (position 0) AI curriculum lessons can trigger `lesson-generation` and `lesson-preload` without auth or subscription; later chapters still require an active subscription.
  - Generate page bypasses login/subscription gates for first‑chapter lessons or once generation has started.

- **Refactors**
  - Added `workflow-generation-access` helpers to validate AI content and decide when a subscription is required; updated chapter/lesson trigger routes to use them.
  - Added route-contract and main e2e tests to cover free first‑chapter behavior.

<sup>Written for commit 1d2a2fc952f8cfe86ff52c06edd1610a910e31db. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1497?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

