### PR TITLE
fix(main): reset generation progress phase timer

### DIFF
--- a/apps/main/src/lib/workflow/use-animated-progress.test.ts
+++ b/apps/main/src/lib/workflow/use-animated-progress.test.ts
@@ -75,6 +75,31 @@ describe(useAnimatedProgress, () => {
     expect(result.current).toBe(50);
   });
 
+  it("restarts the phase timer when the active phase target changes", () => {
+    const { result, rerender } = renderHook((props) => useAnimatedProgress(props), {
+      initialProps: {
+        estimatedDurationMs: 20_000,
+        isActive: true,
+        realProgress: 0,
+        targetProgress: 31,
+      },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(45_000);
+    });
+
+    expect(result.current).toBe(31);
+
+    rerender({ estimatedDurationMs: 45_000, isActive: true, realProgress: 31, targetProgress: 99 });
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current).toBe(31);
+  });
+
   it("never exceeds targetProgress", () => {
     const { result } = renderHook(() =>
       useAnimatedProgress({ isActive: true, realProgress: 10, targetProgress: 30 }),

--- a/apps/main/src/lib/workflow/use-animated-progress.ts
+++ b/apps/main/src/lib/workflow/use-animated-progress.ts
@@ -26,6 +26,28 @@ function getDriftProgress({
 }
 
 /**
+ * Detects when the backend has moved into a new active phase window.
+ * The displayed percentage may already equal the new real progress because the
+ * previous phase drifted to its target, so real progress alone is not enough to
+ * know when the elapsed timer should restart.
+ */
+function hasProgressWindowChanged({
+  estimatedDurationMs,
+  previousEstimatedDurationMs,
+  previousTargetProgress,
+  targetProgress,
+}: {
+  estimatedDurationMs?: number | undefined;
+  previousEstimatedDurationMs?: number | undefined;
+  previousTargetProgress: number;
+  targetProgress: number;
+}) {
+  return (
+    targetProgress !== previousTargetProgress || estimatedDurationMs !== previousEstimatedDurationMs
+  );
+}
+
+/**
  * Wraps a real progress value and slowly ticks it forward
  * while streaming is active, creating the illusion of movement
  * during long-running backend steps.
@@ -54,31 +76,44 @@ export function useAnimatedProgress({
 }): number {
   const [display, setDisplay] = useState(realProgress);
   const rafRef = useRef<number>(0);
-  const startTimeRef = useRef<number>(0);
+  const startTimeRef = useRef<number | null>(null);
   const baseRef = useRef(realProgress);
   const highWaterRef = useRef(realProgress);
+  const estimatedDurationRef = useRef(estimatedDurationMs);
+  const targetProgressRef = useRef(targetProgress);
 
-  // Only reset the drift timer when realProgress exceeds the high-water mark
   useEffect(() => {
-    baseRef.current = realProgress;
+    const progressWindowChanged = hasProgressWindowChanged({
+      estimatedDurationMs,
+      previousEstimatedDurationMs: estimatedDurationRef.current,
+      previousTargetProgress: targetProgressRef.current,
+      targetProgress,
+    });
 
-    if (realProgress > highWaterRef.current) {
-      highWaterRef.current = realProgress;
+    baseRef.current = realProgress;
+    estimatedDurationRef.current = estimatedDurationMs;
+    targetProgressRef.current = targetProgress;
+
+    if (realProgress > highWaterRef.current || progressWindowChanged) {
+      highWaterRef.current = Math.max(highWaterRef.current, realProgress);
       startTimeRef.current = performance.now();
     }
-  }, [realProgress]);
+  }, [estimatedDurationMs, realProgress, targetProgress]);
 
   useEffect(() => {
     if (!isActive) {
       setDisplay(realProgress);
       highWaterRef.current = realProgress;
+      startTimeRef.current = null;
       cancelAnimationFrame(rafRef.current);
       return;
     }
 
     function tick() {
       const gap = Math.max(0, targetProgress - baseRef.current);
-      const elapsed = performance.now() - startTimeRef.current;
+      const now = performance.now();
+      startTimeRef.current ??= now;
+      const elapsed = now - startTimeRef.current;
       const drift = gap * getDriftProgress({ elapsed, estimatedDurationMs });
       const animated = baseRef.current + drift;
       const capped = Math.min(animated, CAP);


### PR DESCRIPTION
Reset the animated progress timer when generation moves into a new active phase window. Keep displayed progress monotonic while preventing later phases from inheriting stale elapsed time and jumping to 97%.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset the animated progress timer when generation enters a new active phase to stop the bar from jumping to the cap (~97%). Keeps progress smooth and monotonic across phases.

- **Bug Fixes**
  - Restart the elapsed timer when `targetProgress` or `estimatedDurationMs` changes to avoid inheriting stale time.
  - Initialize `startTimeRef` on first tick and clear it when inactive to prevent drift carryover.
  - Added a unit test to confirm the phase timer restarts when the active phase target changes.

<sup>Written for commit 8cf88eb8540f6f32ffd18b8a46e00129300117d9. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1498?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

