### PR TITLE
feat(main): preload next lesson after step change

### DIFF
--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.test.ts
@@ -28,6 +28,9 @@ import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { lessonWordFixture, wordFixture } from "@zoonk/testing/fixtures/words";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { lessonGenerationWorkflow } from "./lesson-generation-workflow";
+import { type setLessonAsRunningStep } from "./steps/set-lesson-as-running-step";
+
+type SetLessonAsRunningStepModule = { setLessonAsRunningStep: typeof setLessonAsRunningStep };
 
 const languageMockState = vi.hoisted(() => ({
   distractors: Object.fromEntries([
@@ -39,6 +42,29 @@ const languageMockState = vi.hoisted(() => ({
     { translation: "water", word: "水" },
   ],
 }));
+
+const claimRaceMockState = vi.hoisted(() => ({
+  completeBeforeClaim: null as null | ((input: { lessonId: string }) => Promise<void>),
+}));
+
+vi.mock("./steps/set-lesson-as-running-step", async () => {
+  const actual = await vi.importActual<SetLessonAsRunningStepModule>(
+    "./steps/set-lesson-as-running-step",
+  );
+
+  return {
+    ...actual,
+    setLessonAsRunningStep: vi.fn(
+      async (input: Parameters<typeof actual.setLessonAsRunningStep>[0]) => {
+        if (claimRaceMockState.completeBeforeClaim) {
+          await claimRaceMockState.completeBeforeClaim({ lessonId: input.lessonId });
+        }
+
+        return actual.setLessonAsRunningStep(input);
+      },
+    ),
+  };
+});
 
 vi.mock("@zoonk/ai/tasks/lessons/core/explanation", () => ({
   generateLessonExplanation: vi.fn().mockResolvedValue({
@@ -349,6 +375,7 @@ describe(lessonGenerationWorkflow, () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    claimRaceMockState.completeBeforeClaim = null;
 
     languageMockState.words.splice(
       0,
@@ -1050,6 +1077,43 @@ describe(lessonGenerationWorkflow, () => {
     );
 
     expect(completionEvent).toBeDefined();
+  });
+
+  it("streams completion when another run completes before this run claims the lesson", async () => {
+    const { chapter } = await createWorkflowTree({ organizationId });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      generationStatus: "pending",
+      isPublished: true,
+      kind: "explanation",
+      organizationId,
+      title: `Claim Race Lesson ${randomUUID()}`,
+    });
+
+    claimRaceMockState.completeBeforeClaim = async ({ lessonId }) => {
+      await stepFixture({
+        content: assertStepContent("static", {
+          text: "Saved by another workflow run.",
+          title: "Already complete",
+          variant: "text",
+        }),
+        isPublished: true,
+        kind: "static",
+        lessonId,
+        position: 0,
+      });
+
+      await prisma.lesson.update({
+        data: { generationStatus: "completed" },
+        where: { id: lessonId },
+      });
+    };
+
+    await expect(lessonGenerationWorkflow(lesson.id)).resolves.toBe("ready");
+
+    expect(generateLessonExplanation).not.toHaveBeenCalled();
+    expect(completedStreamedSteps()).toContain("setLessonAsCompleted");
   });
 
   it("regenerates failed lessons with leftover steps instead of repairing them", async () => {

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
@@ -144,11 +144,15 @@ async function runLessonGeneration(input: {
     return "blocked";
   }
 
-  await setLessonAsRunningStep({
+  const claimResult = await setLessonAsRunningStep({
     lessonId: input.lessonId,
     resetExistingSteps: input.context.generationStatus === "failed",
     workflowRunId: input.workflowRunId,
   });
+
+  if (claimResult === "skipped") {
+    return "ready";
+  }
 
   try {
     const [, imageUrl] = await Promise.all([

--- a/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
+++ b/apps/api/src/workflows/lesson-generation/lesson-generation-workflow.ts
@@ -150,6 +150,11 @@ async function runLessonGeneration(input: {
     workflowRunId: input.workflowRunId,
   });
 
+  if (claimResult === "completed") {
+    await streamSkipStep(LESSON_COMPLETION_STEP);
+    return "ready";
+  }
+
   if (claimResult === "skipped") {
     return "ready";
   }

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.test.ts
@@ -76,4 +76,19 @@ describe(setLessonAsRunningStep, () => {
     expect(updatedLesson.generationStatus).toBe("running");
     expect(remainingSteps).toHaveLength(1);
   });
+
+  it("returns completed when another workflow already finished the lesson", async () => {
+    const lesson = await createLessonContext({ generationStatus: "completed", organizationId });
+
+    const result = await setLessonAsRunningStep({
+      lessonId: lesson.id,
+      workflowRunId: "workflow-running-3",
+    });
+
+    const updatedLesson = await prisma.lesson.findUniqueOrThrow({ where: { id: lesson.id } });
+
+    expect(result).toBe("completed");
+    expect(updatedLesson.generationRunId).not.toBe("workflow-running-3");
+    expect(updatedLesson.generationStatus).toBe("completed");
+  });
 });

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.test.ts
@@ -23,7 +23,7 @@ describe(setLessonAsRunningStep, () => {
       lessonId: lesson.id,
     });
 
-    await setLessonAsRunningStep({
+    const result = await setLessonAsRunningStep({
       lessonId: lesson.id,
       resetExistingSteps: true,
       workflowRunId: "workflow-running-1",
@@ -33,6 +33,8 @@ describe(setLessonAsRunningStep, () => {
       prisma.lesson.findUniqueOrThrow({ where: { id: lesson.id } }),
       prisma.step.findMany({ where: { lessonId: lesson.id } }),
     ]);
+
+    expect(result).toBe("claimed");
 
     expect(updatedLesson).toMatchObject({
       generationRunId: "workflow-running-1",
@@ -47,5 +49,31 @@ describe(setLessonAsRunningStep, () => {
         expect.objectContaining({ status: "completed", step: "setLessonAsRunning" }),
       ]),
     );
+  });
+
+  it("does not clear steps when another workflow already claimed the lesson", async () => {
+    const lesson = await createLessonContext({ generationStatus: "running", organizationId });
+
+    await stepFixture({
+      content: { text: "keep", title: "Keep", variant: "text" },
+      kind: "static",
+      lessonId: lesson.id,
+    });
+
+    const result = await setLessonAsRunningStep({
+      lessonId: lesson.id,
+      resetExistingSteps: true,
+      workflowRunId: "workflow-running-2",
+    });
+
+    const [updatedLesson, remainingSteps] = await Promise.all([
+      prisma.lesson.findUniqueOrThrow({ where: { id: lesson.id } }),
+      prisma.step.findMany({ where: { lessonId: lesson.id } }),
+    ]);
+
+    expect(result).toBe("skipped");
+    expect(updatedLesson.generationRunId).not.toBe("workflow-running-2");
+    expect(updatedLesson.generationStatus).toBe("running");
+    expect(remainingSteps).toHaveLength(1);
   });
 });

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.ts
@@ -8,30 +8,54 @@ type SetLessonAsRunningInput = {
   workflowRunId: string;
 };
 
+type LessonGenerationClaimResult = "claimed" | "skipped";
+
 /**
  * Failed lesson retries need to clear any partial steps from the previous run,
  * while normal pending lessons should keep the write to a single status update.
  */
-function buildRunningTransaction(input: SetLessonAsRunningInput) {
-  return [
-    ...(input.resetExistingSteps
-      ? [prisma.step.deleteMany({ where: { lessonId: input.lessonId } })]
-      : []),
-    prisma.lesson.update({
-      data: { generationRunId: input.workflowRunId, generationStatus: "running" },
-      where: { id: input.lessonId },
-    }),
-  ];
+function getClaimableGenerationStatus(input: SetLessonAsRunningInput) {
+  return input.resetExistingSteps ? "failed" : "pending";
 }
 
-export async function setLessonAsRunningStep(input: SetLessonAsRunningInput): Promise<void> {
+/**
+ * Claims a lesson before any AI work starts. The status predicate makes the
+ * claim atomic: if an early preload and completion fallback race, only one run
+ * can move the lesson into `running`, and the loser leaves existing steps alone.
+ */
+async function claimLessonGeneration(
+  input: SetLessonAsRunningInput,
+): Promise<LessonGenerationClaimResult> {
+  return prisma.$transaction(async (tx) => {
+    const claim = await tx.lesson.updateMany({
+      data: { generationRunId: input.workflowRunId, generationStatus: "running" },
+      where: { generationStatus: getClaimableGenerationStatus(input), id: input.lessonId },
+    });
+
+    if (claim.count === 0) {
+      return "skipped";
+    }
+
+    if (input.resetExistingSteps) {
+      await tx.step.deleteMany({ where: { lessonId: input.lessonId } });
+    }
+
+    return "claimed";
+  });
+}
+
+export async function setLessonAsRunningStep(
+  input: SetLessonAsRunningInput,
+): Promise<LessonGenerationClaimResult> {
   "use step";
 
   await using stream = createStepStream<LessonStepName>();
 
   await stream.status({ status: "started", step: "setLessonAsRunning" });
 
-  await prisma.$transaction(buildRunningTransaction(input));
+  const result = await claimLessonGeneration(input);
 
   await stream.status({ status: "completed", step: "setLessonAsRunning" });
+
+  return result;
 }

--- a/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/set-lesson-as-running-step.ts
@@ -1,6 +1,6 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type LessonStepName } from "@zoonk/core/workflows/steps";
-import { prisma } from "@zoonk/db";
+import { type TransactionClient, prisma } from "@zoonk/db";
 
 type SetLessonAsRunningInput = {
   lessonId: string;
@@ -8,7 +8,7 @@ type SetLessonAsRunningInput = {
   workflowRunId: string;
 };
 
-type LessonGenerationClaimResult = "claimed" | "skipped";
+type LessonGenerationClaimResult = "claimed" | "completed" | "skipped";
 
 /**
  * Failed lesson retries need to clear any partial steps from the previous run,
@@ -16,6 +16,27 @@ type LessonGenerationClaimResult = "claimed" | "skipped";
  */
 function getClaimableGenerationStatus(input: SetLessonAsRunningInput) {
   return input.resetExistingSteps ? "failed" : "pending";
+}
+
+/**
+ * A failed claim means another workflow changed the lesson first. Completed
+ * lessons need a distinct result so the losing workflow can mirror the
+ * completion event into the stream its client is watching.
+ */
+async function getSkippedLessonGenerationClaimResult({
+  lessonId,
+  tx,
+}: {
+  lessonId: string;
+  tx: TransactionClient;
+}): Promise<Exclude<LessonGenerationClaimResult, "claimed">> {
+  const lesson = await tx.lesson.findUnique({ where: { id: lessonId } });
+
+  if (lesson?.generationStatus === "completed") {
+    return "completed";
+  }
+
+  return "skipped";
 }
 
 /**
@@ -33,7 +54,7 @@ async function claimLessonGeneration(
     });
 
     if (claim.count === 0) {
-      return "skipped";
+      return getSkippedLessonGenerationClaimResult({ lessonId: input.lessonId, tx });
     }
 
     if (input.resetExistingSteps) {

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
@@ -3,11 +3,12 @@
 import { ContentFeedback } from "@/components/feedback/content-feedback";
 import { type CompletionInput } from "@zoonk/core/player/contracts/completion-input-schema";
 import { type SerializedLesson } from "@zoonk/core/player/contracts/prepare-lesson-data";
-import { PlayerProvider } from "@zoonk/player/provider";
+import { PlayerProvider, type PlayerStepChangeEvent } from "@zoonk/player/provider";
 import { PlayerShell } from "@zoonk/player/shell";
 import { useRouter } from "next/navigation";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { buildLessonPlayerModel } from "./lesson-player-model";
+import { preloadNextLesson } from "./preload-next-lesson-action";
 import { submitCompletion } from "./submit-completion-action";
 
 export function LessonPlayerClient({
@@ -38,6 +39,7 @@ export function LessonPlayerClient({
   userName: string | null;
 }) {
   const router = useRouter();
+  const hasRequestedNextLessonPreload = useRef(false);
 
   const model = buildLessonPlayerModel({ brandSlug, chapterSlug, courseSlug, nextLesson });
 
@@ -48,6 +50,24 @@ export function LessonPlayerClient({
   const handleComplete = useCallback((input: CompletionInput) => {
     void submitCompletion(input);
   }, []);
+
+  /** Fire once after the first forward step change; completion handles short lessons. */
+  const handleStepChange = useCallback(
+    (event: PlayerStepChangeEvent) => {
+      if (
+        !isAuthenticated ||
+        event.direction !== "next" ||
+        event.previousStepIndex !== 0 ||
+        hasRequestedNextLessonPreload.current
+      ) {
+        return;
+      }
+
+      hasRequestedNextLessonPreload.current = true;
+      void preloadNextLesson(event.lessonId);
+    },
+    [isAuthenticated],
+  );
 
   return (
     <PlayerProvider
@@ -60,6 +80,7 @@ export function LessonPlayerClient({
       onComplete={handleComplete}
       onEscape={() => router.push(model.navigation.chapterHref)}
       onNext={handleNext}
+      onStepChange={handleStepChange}
       totalBrainPower={totalBrainPower}
       viewer={{
         completionFooter: (

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/preload-next-lesson-action.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/preload-next-lesson-action.ts
@@ -1,0 +1,56 @@
+"use server";
+
+import { triggerLessonPreload } from "@/data/progress/trigger-lesson-preload";
+import { getNextLessonPreloadTarget } from "@zoonk/core/player/commands/get-next-lesson-preload-target";
+import { getSession } from "@zoonk/core/users/session/get";
+import { logError } from "@zoonk/utils/logger";
+import { headers } from "next/headers";
+import { after } from "next/server";
+
+type NextLessonPreloadInput = { cookieHeader: string; lessonId: string; userId: string };
+
+/**
+ * Runs the expensive preload path after the server action returns. Keeping this
+ * in a named helper makes the action itself a linear auth-and-schedule wrapper,
+ * while still swallowing background errors so preload failures do not surface
+ * as user-visible player errors.
+ */
+async function triggerNextLessonPreload(input: NextLessonPreloadInput): Promise<void> {
+  try {
+    const preloadLessonId = await getNextLessonPreloadTarget({
+      lessonId: input.lessonId,
+      userId: input.userId,
+    });
+
+    if (!preloadLessonId) {
+      return;
+    }
+
+    await triggerLessonPreload({ cookieHeader: input.cookieHeader, lessonId: preloadLessonId });
+  } catch (error) {
+    logError("[preloadNextLesson] Failed to trigger next lesson preload:", error);
+  }
+}
+
+/**
+ * Starts generating the next lesson after the learner has shown real progress
+ * in the current lesson. The client only sends the current lesson id; the
+ * server derives the expensive generation target after auth and visibility
+ * checks so this cannot be used as a generic lesson-generation proxy.
+ */
+export async function preloadNextLesson(lessonId: string): Promise<void> {
+  const reqHeaders = await headers();
+  const session = await getSession(reqHeaders);
+
+  if (!session) {
+    return;
+  }
+
+  after(() =>
+    triggerNextLessonPreload({
+      cookieHeader: reqHeaders.get("cookie") ?? "",
+      lessonId,
+      userId: session.user.id,
+    }),
+  );
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,7 @@
     "./lessons/last-completed": "./src/lessons/find-last-completed.ts",
     "./lessons/next-chapter-in-course": "./src/lessons/get-next-chapter-in-course.ts",
     "./lessons/next-in-course": "./src/lessons/get-next-lesson-in-course.ts",
+    "./player/commands/get-next-lesson-preload-target": "./src/player/commands/get-next-lesson-preload-target.ts",
     "./player/commands/start-lesson": "./src/player/commands/start-lesson.ts",
     "./player/commands/submit-player-completion": "./src/player/commands/submit-player-completion.ts",
     "./player/contracts/arrange-words-answers": "./src/player/contracts/arrange-words-answers.ts",

--- a/packages/core/src/player/commands/_utils/completable-lesson.ts
+++ b/packages/core/src/player/commands/_utils/completable-lesson.ts
@@ -1,0 +1,20 @@
+import "server-only";
+import { getPublishedLessonWhere } from "@zoonk/db";
+
+/**
+ * Player write commands must only act on lessons the learner can reach through
+ * the product. Public brand courses are always eligible, while user-owned
+ * organization-less courses are only eligible for their owner.
+ */
+export function getCompletableLessonWhere({
+  lessonId,
+  userId,
+}: {
+  lessonId: string;
+  userId: string;
+}) {
+  return getPublishedLessonWhere({
+    courseWhere: { OR: [{ organization: { kind: "brand" } }, { organizationId: null, userId }] },
+    lessonWhere: { id: lessonId },
+  });
+}

--- a/packages/core/src/player/commands/get-next-lesson-preload-target.test.ts
+++ b/packages/core/src/player/commands/get-next-lesson-preload-target.test.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from "node:crypto";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { describe, expect, it } from "vitest";
+import { getNextLessonPreloadTarget } from "./get-next-lesson-preload-target";
+
+type PreloadTargetVisibility = {
+  chapterIsPublished?: boolean;
+  courseIsPublished?: boolean;
+  organizationKind?: string;
+};
+
+const preloadGenerationStatuses = ["pending", "failed"] as const;
+const nonPreloadGenerationStatuses = ["completed", "running"] as const;
+
+const inaccessibleCurrentLessonCases: {
+  currentLessonIsPublished?: boolean;
+  name: string;
+  visibility?: PreloadTargetVisibility;
+}[] = [
+  { name: "course", visibility: { courseIsPublished: false } },
+  { name: "chapter", visibility: { chapterIsPublished: false } },
+  { currentLessonIsPublished: false, name: "lesson" },
+  { name: "organization", visibility: { organizationKind: "school" } },
+];
+
+/**
+ * Preload target tests need a normal learner-visible course tree but no player
+ * steps, because this command only decides whether the next structural lesson
+ * should be generated early.
+ */
+async function createChapterContext(params: PreloadTargetVisibility = {}) {
+  const organization = await organizationFixture({ kind: params.organizationKind ?? "brand" });
+
+  const course = await courseFixture({
+    isPublished: params.courseIsPublished ?? true,
+    organizationId: organization.id,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: params.chapterIsPublished ?? true,
+    organizationId: organization.id,
+  });
+
+  return { chapter, organization };
+}
+
+/**
+ * The command derives the preload target from the current lesson position, so
+ * each test creates a two-lesson path with explicit positions and a configurable
+ * next lesson generation state.
+ */
+async function createLessonPair(params: {
+  currentLessonIsPublished?: boolean;
+  nextLessonGenerationStatus: "completed" | "failed" | "pending" | "running";
+  visibility?: PreloadTargetVisibility;
+}) {
+  const { chapter, organization } = await createChapterContext(params.visibility);
+
+  const [currentLesson, nextLesson] = await Promise.all([
+    lessonFixture({
+      chapterId: chapter.id,
+      isPublished: params.currentLessonIsPublished ?? true,
+      organizationId: organization.id,
+      position: 0,
+    }),
+    lessonFixture({
+      chapterId: chapter.id,
+      generationStatus: params.nextLessonGenerationStatus,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 1,
+    }),
+  ]);
+
+  return { currentLesson, nextLesson };
+}
+
+describe(getNextLessonPreloadTarget, () => {
+  it.each(preloadGenerationStatuses)(
+    "returns the next lesson id when its generation state is %s",
+    async (nextLessonGenerationStatus) => {
+      const [user, lessons] = await Promise.all([
+        userFixture(),
+        createLessonPair({ nextLessonGenerationStatus }),
+      ]);
+
+      const result = await getNextLessonPreloadTarget({
+        lessonId: lessons.currentLesson.id,
+        userId: user.id,
+      });
+
+      expect(result).toBe(lessons.nextLesson.id);
+    },
+  );
+
+  it.each(nonPreloadGenerationStatuses)(
+    "returns null when the next lesson generation state is %s",
+    async (nextLessonGenerationStatus) => {
+      const [user, lessons] = await Promise.all([
+        userFixture(),
+        createLessonPair({ nextLessonGenerationStatus }),
+      ]);
+
+      const result = await getNextLessonPreloadTarget({
+        lessonId: lessons.currentLesson.id,
+        userId: user.id,
+      });
+
+      expect(result).toBeNull();
+    },
+  );
+
+  it.each(inaccessibleCurrentLessonCases)(
+    "returns null when the current $name is not publicly completable",
+    async (testCase) => {
+      const [user, lessons] = await Promise.all([
+        userFixture(),
+        createLessonPair({
+          nextLessonGenerationStatus: "pending",
+          ...("currentLessonIsPublished" in testCase
+            ? { currentLessonIsPublished: testCase.currentLessonIsPublished }
+            : {}),
+          ...(testCase.visibility ? { visibility: testCase.visibility } : {}),
+        }),
+      ]);
+
+      const result = await getNextLessonPreloadTarget({
+        lessonId: lessons.currentLesson.id,
+        userId: user.id,
+      });
+
+      expect(result).toBeNull();
+    },
+  );
+
+  it("returns null for malformed lesson ids before querying UUID columns", async () => {
+    const user = await userFixture();
+
+    const result = await getNextLessonPreloadTarget({
+      lessonId: `not-a-uuid-${randomUUID()}`,
+      userId: user.id,
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/core/src/player/commands/get-next-lesson-preload-target.ts
+++ b/packages/core/src/player/commands/get-next-lesson-preload-target.ts
@@ -1,0 +1,76 @@
+import "server-only";
+import { type GenerationStatus, prisma } from "@zoonk/db";
+import { isUuid } from "@zoonk/utils/uuid";
+import {
+  type NextLessonInCourse,
+  getNextLessonInCourse,
+} from "../../lessons/get-next-lesson-in-course";
+import { getCompletableLessonWhere } from "./_utils/completable-lesson";
+
+const preloadableGenerationStatuses = new Set<GenerationStatus>(["pending", "failed"]);
+
+/**
+ * Early preload should only enqueue work that can still become useful. Pending
+ * and failed lessons need generation, while running and completed lessons
+ * already have either active work or usable content.
+ */
+function isPreloadableNextLesson(
+  nextLesson: NextLessonInCourse | null,
+): nextLesson is NextLessonInCourse {
+  if (!nextLesson) {
+    return false;
+  }
+
+  return preloadableGenerationStatuses.has(nextLesson.lessonGenerationStatus);
+}
+
+/**
+ * Completion already has the next lesson row loaded, so it can reuse the same
+ * preload eligibility rule without doing another current-lesson lookup.
+ */
+export function getNextLessonPreloadId({
+  nextLesson,
+}: {
+  nextLesson: NextLessonInCourse | null;
+}): string | null {
+  if (!isPreloadableNextLesson(nextLesson)) {
+    return null;
+  }
+
+  return nextLesson.lessonId;
+}
+
+/**
+ * The browser only proves that a learner interacted with the current lesson.
+ * This command derives the next structural lesson on the server so callers do
+ * not trust a client-provided target for an expensive AI generation job.
+ */
+export async function getNextLessonPreloadTarget({
+  lessonId,
+  userId,
+}: {
+  lessonId: string;
+  userId: string;
+}): Promise<string | null> {
+  if (!isUuid(lessonId) || !isUuid(userId)) {
+    return null;
+  }
+
+  const lesson = await prisma.lesson.findFirst({
+    include: { chapter: true },
+    where: getCompletableLessonWhere({ lessonId, userId }),
+  });
+
+  if (!lesson) {
+    return null;
+  }
+
+  const nextLesson = await getNextLessonInCourse({
+    chapterId: lesson.chapterId,
+    chapterPosition: lesson.chapter.position,
+    courseId: lesson.chapter.courseId,
+    lessonPosition: lesson.position,
+  });
+
+  return getNextLessonPreloadId({ nextLesson });
+}

--- a/packages/core/src/player/commands/submit-player-completion.ts
+++ b/packages/core/src/player/commands/submit-player-completion.ts
@@ -1,14 +1,13 @@
 import "server-only";
-import { type LessonSentence, type StepKind, getPublishedLessonWhere, prisma } from "@zoonk/db";
-import {
-  type NextLessonInCourse,
-  getNextLessonInCourse,
-} from "../../lessons/get-next-lesson-in-course";
+import { type LessonSentence, type StepKind, prisma } from "@zoonk/db";
+import { getNextLessonInCourse } from "../../lessons/get-next-lesson-in-course";
 import { type CompletionInput } from "../contracts/completion-input-schema";
 import { computeLessonScore } from "../contracts/compute-score";
 import { countAnswerableSteps, validateAnswers } from "../contracts/validate-answers";
 import { getLessonSentencesForLessons } from "../queries/get-lesson-sentences";
 import { getReviewValidationData } from "../queries/get-review-steps";
+import { getCompletableLessonWhere } from "./_utils/completable-lesson";
+import { getNextLessonPreloadId } from "./get-next-lesson-preload-target";
 import { submitLessonCompletion } from "./submit-lesson-completion";
 
 const MAX_DURATION_SECONDS = 7200;
@@ -28,18 +27,6 @@ type StepWithSentence = {
 };
 
 type PlayerCompletionEffects = { preloadLessonId: string | null };
-
-/**
- * Completion is only valid for lessons the learner can reach through the
- * product. Public brand courses are always eligible, and organization-less
- * courses are eligible only for the user who owns that generated course.
- */
-function getCompletableLessonWhere({ lessonId, userId }: { lessonId: string; userId: string }) {
-  return getPublishedLessonWhere({
-    courseWhere: { OR: [{ organization: { kind: "brand" } }, { organizationId: null, userId }] },
-    lessonWhere: { id: lessonId },
-  });
-}
 
 /**
  * Attaches sentence translation data from `LessonSentence` records to steps.
@@ -92,26 +79,6 @@ function hasCompleteAnswerCoverage(params: {
   }
 
   return params.validatedStepCount === params.expectedStepCount;
-}
-
-/**
- * Completion only asks the host app to preload lesson generation when the next
- * structural lesson exists and is in a retryable unfinished state. Running
- * generation already has work in flight, and completed lessons need no preload.
- */
-function getPreloadLessonId({ nextLesson }: { nextLesson: NextLessonInCourse | null }) {
-  if (!nextLesson) {
-    return null;
-  }
-
-  if (
-    nextLesson.lessonGenerationStatus === "pending" ||
-    nextLesson.lessonGenerationStatus === "failed"
-  ) {
-    return nextLesson.lessonId;
-  }
-
-  return null;
 }
 
 /**
@@ -212,5 +179,5 @@ export async function submitPlayerCompletion(params: {
     lessonPosition: lesson.position,
   });
 
-  return { preloadLessonId: getPreloadLessonId({ nextLesson }) };
+  return { preloadLessonId: getNextLessonPreloadId({ nextLesson }) };
 }

--- a/packages/player/src/player-controller.test.ts
+++ b/packages/player/src/player-controller.test.ts
@@ -1,6 +1,7 @@
 import { type SerializedStep } from "@zoonk/core/player/contracts/prepare-lesson-data";
 import { describe, expect, it } from "vitest";
 import { buildCompletionInput, getPlayerTransition } from "./player-controller";
+import { getPlayerStepChangeEvent } from "./player-events";
 import { type PlayerAction, type PlayerState } from "./player-reducer";
 
 function buildStep(overrides: Partial<SerializedStep> = {}): SerializedStep {
@@ -70,6 +71,45 @@ describe(getPlayerTransition, () => {
     const transition = getPlayerTransition(buildState(), action);
 
     expect(transition.shouldPersistCompletion).toBe(false);
+  });
+});
+
+describe(getPlayerStepChangeEvent, () => {
+  it("returns a next-step event when the player advances", () => {
+    const steps = [buildStep({ id: "step-1" }), buildStep({ id: "step-2", position: 1 })];
+    const state = buildState({ currentStepIndex: 0, steps });
+    const transition = getPlayerTransition(state, { direction: "next", type: "NAVIGATE_STEP" });
+
+    expect(getPlayerStepChangeEvent({ nextState: transition.nextState, state })).toStrictEqual({
+      direction: "next",
+      lessonId: "lesson-1",
+      nextStepId: "step-2",
+      nextStepIndex: 1,
+      previousStepId: "step-1",
+      previousStepIndex: 0,
+    });
+  });
+
+  it("returns a previous-step event when the player goes back", () => {
+    const steps = [buildStep({ id: "step-1" }), buildStep({ id: "step-2", position: 1 })];
+    const state = buildState({ currentStepIndex: 1, steps });
+    const transition = getPlayerTransition(state, { direction: "prev", type: "NAVIGATE_STEP" });
+
+    expect(getPlayerStepChangeEvent({ nextState: transition.nextState, state })).toStrictEqual({
+      direction: "prev",
+      lessonId: "lesson-1",
+      nextStepId: "step-1",
+      nextStepIndex: 0,
+      previousStepId: "step-2",
+      previousStepIndex: 1,
+    });
+  });
+
+  it("returns null when the transition completes the lesson", () => {
+    const state = buildState();
+    const transition = getPlayerTransition(state, { direction: "next", type: "NAVIGATE_STEP" });
+
+    expect(getPlayerStepChangeEvent({ nextState: transition.nextState, state })).toBeNull();
   });
 });
 

--- a/packages/player/src/player-events.ts
+++ b/packages/player/src/player-events.ts
@@ -1,0 +1,43 @@
+import { type PlayerState } from "./player-reducer";
+
+export type PlayerStepChangeEvent = {
+  direction: "next" | "prev";
+  lessonId: string;
+  nextStepId: string;
+  nextStepIndex: number;
+  previousStepId: string;
+  previousStepIndex: number;
+};
+
+/**
+ * Host apps sometimes need to react to real player progress without depending
+ * on reducer internals. This converts a before/after reducer pair into a small
+ * semantic event and ignores terminal transitions where there is no next step.
+ */
+export function getPlayerStepChangeEvent({
+  nextState,
+  state,
+}: {
+  nextState: PlayerState;
+  state: PlayerState;
+}): PlayerStepChangeEvent | null {
+  if (state.currentStepIndex === nextState.currentStepIndex || nextState.phase !== "playing") {
+    return null;
+  }
+
+  const previousStep = state.steps[state.currentStepIndex];
+  const nextStep = nextState.steps[nextState.currentStepIndex];
+
+  if (!previousStep || !nextStep) {
+    return null;
+  }
+
+  return {
+    direction: nextState.currentStepIndex > state.currentStepIndex ? "next" : "prev",
+    lessonId: state.lessonId,
+    nextStepId: nextStep.id,
+    nextStepIndex: nextState.currentStepIndex,
+    previousStepId: previousStep.id,
+    previousStepIndex: state.currentStepIndex,
+  };
+}

--- a/packages/player/src/player-provider.tsx
+++ b/packages/player/src/player-provider.tsx
@@ -10,12 +10,15 @@ import {
   PlayerRuntimeContext,
   type PlayerViewer,
 } from "./player-context";
+import { type PlayerStepChangeEvent } from "./player-events";
 import { type InitialStateInput } from "./player-initial-state";
 import { createInitialState, playerReducer } from "./player-reducer";
 import { getPlayerScreenModel } from "./player-screen";
 import { usePlayerActions } from "./use-player-actions";
 import { usePlayerKeyboard } from "./use-player-keyboard";
 import { UserNameProvider } from "./user-name-context";
+
+export type { PlayerStepChangeEvent } from "./player-events";
 
 export function PlayerProvider({
   lesson,
@@ -28,6 +31,7 @@ export function PlayerProvider({
   onComplete,
   onEscape,
   onNext,
+  onStepChange,
   totalBrainPower,
   viewer,
 }: {
@@ -41,6 +45,7 @@ export function PlayerProvider({
   onComplete: (input: CompletionInput) => void;
   onEscape: () => void;
   onNext?: () => void;
+  onStepChange?: (event: PlayerStepChangeEvent) => void;
   totalBrainPower: number;
   viewer: PlayerViewer;
 }) {
@@ -50,7 +55,15 @@ export function PlayerProvider({
   );
 
   const [state, dispatch] = useReducer(playerReducer, initInput, createInitialState);
-  const actions = usePlayerActions(state, dispatch, onComplete, viewer.isAuthenticated);
+
+  const actions = usePlayerActions(
+    state,
+    dispatch,
+    onComplete,
+    viewer.isAuthenticated,
+    onStepChange,
+  );
+
   const screen = useMemo(() => getPlayerScreenModel(state), [state]);
 
   const handleNext = useCallback(() => {

--- a/packages/player/src/use-player-actions.ts
+++ b/packages/player/src/use-player-actions.ts
@@ -4,6 +4,7 @@ import { type CompletionInput } from "@zoonk/core/player/contracts/completion-in
 import { type Dispatch, useCallback } from "react";
 import { checkStep } from "./check-step";
 import { buildCompletionInput, getPlayerTransition } from "./player-controller";
+import { type PlayerStepChangeEvent, getPlayerStepChangeEvent } from "./player-events";
 import {
   type PlayerAction,
   type PlayerState,
@@ -25,6 +26,7 @@ export function usePlayerActions(
   dispatch: Dispatch<Parameters<typeof playerReducer>[1]>,
   onComplete: (input: CompletionInput) => void,
   isAuthenticated: boolean,
+  onStepChange?: (event: PlayerStepChangeEvent) => void,
 ) {
   const currentStep = state.steps[state.currentStepIndex];
 
@@ -36,8 +38,14 @@ export function usePlayerActions(
       if (transition.shouldPersistCompletion && isAuthenticated) {
         onComplete(buildCompletionInput(transition.nextState));
       }
+
+      const stepChangeEvent = getPlayerStepChangeEvent({ nextState: transition.nextState, state });
+
+      if (stepChangeEvent) {
+        onStepChange?.(stepChangeEvent);
+      }
     },
-    [dispatch, isAuthenticated, onComplete, state],
+    [dispatch, isAuthenticated, onComplete, onStepChange, state],
   );
 
   const selectAnswer = useCallback(


### PR DESCRIPTION
Moves next-lesson preloading to the first forward player step change while keeping lesson completion as a fallback. Adds server-derived preload targeting and atomic lesson-generation claiming so early and completion triggers do not duplicate AI work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preloads the next lesson as soon as the learner moves past the first step, with completion as a fallback. Adds server-derived targeting and atomic generation claiming to prevent duplicate work and unintended step deletion.

- New Features
  - Preload triggers on the first forward step change; completion still preloads for very short lessons.
  - `@zoonk/player` exposes `onStepChange` with `PlayerStepChangeEvent`; the app calls a server action once to preload.
  - Server action `preloadNextLesson` derives the target via `@zoonk/core/player/commands/get-next-lesson-preload-target` and runs `triggerLessonPreload` in the background; visibility enforced by `getCompletableLessonWhere`.
  - Completion path reuses `getNextLessonPreloadId` to avoid duplicate eligibility logic.

- Bug Fixes
  - `set-lesson-as-running-step` now atomically claims generation and returns "claimed"/"skipped"/"completed"; losing runs keep steps and avoid duplicate work.
  - If another run completes before this run claims the lesson, the workflow streams the completion event and exits early; tests cover this race.

<sup>Written for commit 503bcce98f7e526883f74a33a42b61a247d97e02. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1500?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

