### PR TITLE
fix(main): update catalog header media

### DIFF
--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -171,15 +171,16 @@ test.beforeAll(async () => {
 });
 
 test.describe("Chapter Detail Page", () => {
-  test("shows chapter content with title, description, and position", async ({ page }) => {
+  test("shows chapter content with title, description, and image", async ({ page }) => {
     await page.goto(chapterUrl);
 
-    await expect(page.getByRole("heading", { level: 1, name: chapterTitle })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { exact: true, level: 1, name: `1. ${chapterTitle}` }),
+    ).toBeVisible();
 
     await expect(page.getByText(`Different types of learning ${uniqueId}`)).toBeVisible();
 
-    const positionIcon = page.getByRole("img", { name: /chapter 01/iu }).first();
-    await expect(positionIcon).toBeVisible();
+    await expect(page.getByRole("img", { exact: true, name: chapterTitle })).toBeVisible();
   });
 
   test("displays lesson rows", async ({ page }) => {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -265,10 +265,6 @@ msgstr "Score"
 msgid "4dsZTc"
 msgstr "{value}% correct answers"
 
-#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
-msgid "B9hCYt"
-msgstr "Chapter {position}"
-
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "ssvp3R"
 msgstr "Search lessons..."

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -265,10 +265,6 @@ msgstr "Aciertos"
 msgid "4dsZTc"
 msgstr "{value}% de respuestas correctas"
 
-#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
-msgid "B9hCYt"
-msgstr "Capítulo {position}"
-
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "ssvp3R"
 msgstr "Buscar lecciones..."

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -265,10 +265,6 @@ msgstr "Acertos"
 msgid "4dsZTc"
 msgstr "{value}% de respostas corretas"
 
-#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
-msgid "B9hCYt"
-msgstr "Capítulo {position}"
-
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "ssvp3R"
 msgstr "Buscar aulas..."

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
@@ -1,24 +1,22 @@
 import { AIWarning } from "@/components/catalog/ai-warning";
+import { CatalogHeaderImage } from "@/components/catalog/catalog-header-image";
 import { type ChapterWithDetails } from "@/data/chapters/get-chapter";
+import { getDefaultChapterImage } from "@/lib/catalog/default-images";
 import {
   MediaCard,
   MediaCardBreadcrumb,
   MediaCardContent,
   MediaCardDescription,
   MediaCardHeader,
-  MediaCardIcon,
-  MediaCardIconText,
   MediaCardIndicator,
   MediaCardPopover,
   MediaCardPopoverText,
   MediaCardTitle,
   MediaCardTrigger,
 } from "@zoonk/ui/components/media-card";
-import { formatPosition } from "@zoonk/utils/number";
-import { getExtracted } from "next-intl/server";
 import Link from "next/link";
 
-export async function ChapterHeader({
+export function ChapterHeader({
   brandSlug,
   chapter,
   courseSlug,
@@ -27,14 +25,14 @@ export async function ChapterHeader({
   chapter: ChapterWithDetails;
   courseSlug: string;
 }) {
-  const t = await getExtracted();
-  const chapterPosition = formatPosition(chapter.position);
+  const chapterNumber = chapter.position + 1;
+
+  const chapterImage =
+    chapter.imageUrl ?? getDefaultChapterImage({ categories: chapter.course.categories });
 
   return (
     <MediaCard>
-      <MediaCardIcon aria-label={t("Chapter {position}", { position: chapterPosition })} role="img">
-        <MediaCardIconText>{chapterPosition}</MediaCardIconText>
-      </MediaCardIcon>
+      <CatalogHeaderImage alt={chapter.title} src={chapterImage} />
 
       <MediaCardContent>
         <MediaCardBreadcrumb>
@@ -48,7 +46,9 @@ export async function ChapterHeader({
 
         <MediaCardTrigger>
           <MediaCardHeader>
-            <MediaCardTitle>{chapter.title}</MediaCardTitle>
+            <MediaCardTitle>
+              <span className="text-muted-foreground">{chapterNumber}.</span> {chapter.title}
+            </MediaCardTitle>
             <MediaCardIndicator />
           </MediaCardHeader>
           <MediaCardDescription>{chapter.description}</MediaCardDescription>

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-header.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-header.tsx
@@ -1,4 +1,5 @@
 import { AIWarning } from "@/components/catalog/ai-warning";
+import { CatalogHeaderImage } from "@/components/catalog/catalog-header-image";
 import { type CourseWithDetails } from "@/data/courses/get-course";
 import { getCategories } from "@/lib/categories/category";
 import { Badge } from "@zoonk/ui/components/badge";
@@ -8,7 +9,6 @@ import {
   MediaCardDescription,
   MediaCardHeader,
   MediaCardIcon,
-  MediaCardImage,
   MediaCardIndicator,
   MediaCardPopover,
   MediaCardPopoverBadges,
@@ -20,7 +20,6 @@ import {
   MediaCardTrigger,
 } from "@zoonk/ui/components/media-card";
 import { NotebookPenIcon } from "lucide-react";
-import Image from "next/image";
 import Link from "next/link";
 
 export async function CourseHeader({
@@ -38,16 +37,7 @@ export async function CourseHeader({
   return (
     <MediaCard>
       {course.imageUrl ? (
-        <MediaCardImage>
-          <Image
-            alt={course.title}
-            className="size-full rounded-xl object-cover outline -outline-offset-1 outline-black/10 dark:outline-white/10"
-            fill
-            loading="eager"
-            sizes="(max-width: 640px) 80px, 96px"
-            src={course.imageUrl}
-          />
-        </MediaCardImage>
+        <CatalogHeaderImage alt={course.title} src={course.imageUrl} />
       ) : (
         <MediaCardIcon aria-label={course.title} role="img">
           <NotebookPenIcon aria-hidden="true" className="text-muted-foreground/80 size-8" />

--- a/apps/main/src/components/catalog/catalog-header-image.tsx
+++ b/apps/main/src/components/catalog/catalog-header-image.tsx
@@ -1,0 +1,21 @@
+import { MediaCardImage } from "@zoonk/ui/components/media-card";
+import Image, { type ImageProps } from "next/image";
+
+/**
+ * Course and chapter headers share the same media-card image treatment, so this
+ * component keeps the sizing, eager loading, and crop styling in one place.
+ */
+export function CatalogHeaderImage({ alt, src }: { alt: string; src: ImageProps["src"] }) {
+  return (
+    <MediaCardImage>
+      <Image
+        alt={alt}
+        className="size-full rounded-xl object-cover outline -outline-offset-1 outline-black/10 dark:outline-white/10"
+        fill
+        loading="eager"
+        sizes="(max-width: 640px) 120px, 160px"
+        src={src}
+      />
+    </MediaCardImage>
+  );
+}

--- a/apps/main/src/data/chapters/get-chapter.ts
+++ b/apps/main/src/data/chapters/get-chapter.ts
@@ -4,7 +4,7 @@ import { cache } from "react";
 
 const cachedGetChapter = cache(async (brandSlug: string, courseSlug: string, chapterSlug: string) =>
   prisma.chapter.findFirst({
-    include: { course: true },
+    include: { course: { include: { categories: true } } },
     where: getPublishedChapterWhere({
       chapterWhere: { slug: chapterSlug },
       courseWhere: { organization: { kind: "brand", slug: brandSlug }, slug: courseSlug },

--- a/packages/ui/src/components/media-card.tsx
+++ b/packages/ui/src/components/media-card.tsx
@@ -11,7 +11,10 @@ export function MediaCard({ children, className }: React.ComponentProps<"header"
   return (
     <Popover>
       <header
-        className={cn("mx-auto flex w-full items-start gap-4 px-4 lg:max-w-xl", className)}
+        className={cn(
+          "mx-auto grid w-full grid-cols-[auto_minmax(0,1fr)] items-stretch gap-4 px-4 lg:max-w-xl",
+          className,
+        )}
         data-slot="media-card"
       >
         {children}
@@ -36,7 +39,10 @@ export function MediaCardTrigger({ children, className }: React.ComponentProps<"
 export function MediaCardImage({ children, className }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("relative size-20 shrink-0 overflow-hidden rounded-xl sm:size-24", className)}
+      className={cn(
+        "relative aspect-square h-full min-h-20 min-w-20 overflow-hidden rounded-xl sm:min-h-24 sm:min-w-24",
+        className,
+      )}
       data-slot="media-card-image"
     >
       {children}
@@ -48,7 +54,7 @@ export function MediaCardIcon({ children, className, ...props }: React.Component
   return (
     <div
       className={cn(
-        "bg-muted/70 flex size-20 shrink-0 items-center justify-center rounded-xl sm:size-24",
+        "bg-muted/70 flex aspect-square h-full min-h-20 min-w-20 items-center justify-center rounded-xl sm:min-h-24 sm:min-w-24",
         className,
       )}
       data-slot="media-card-icon"

--- a/packages/utils/src/number.test.ts
+++ b/packages/utils/src/number.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatPosition, validateOffset } from "./number";
+import { validateOffset } from "./number";
 
 describe(validateOffset, () => {
   it("parses valid positive integer", () => {
@@ -32,17 +32,5 @@ describe(validateOffset, () => {
 
   it("returns 0 for empty string", () => {
     expect(validateOffset("")).toBe(0);
-  });
-});
-
-describe(formatPosition, () => {
-  it("formats single digit positions with leading zero", () => {
-    expect(formatPosition(0)).toBe("01");
-    expect(formatPosition(8)).toBe("09");
-  });
-
-  it("formats double digit positions without leading zero", () => {
-    expect(formatPosition(9)).toBe("10");
-    expect(formatPosition(99)).toBe("100");
   });
 });

--- a/packages/utils/src/number.ts
+++ b/packages/utils/src/number.ts
@@ -3,15 +3,6 @@ export function validateOffset(value?: unknown): number {
   return Number.isFinite(parsed) ? Math.max(0, Math.trunc(parsed)) : 0;
 }
 
-/**
- * Formats a 0-indexed position as a 2-digit display string.
- * @example formatPosition(0) // "01"
- * @example formatPosition(9) // "10"
- */
-export function formatPosition(position: number): string {
-  return String(position + 1).padStart(2, "0");
-}
-
 export function sumOf(values: number[]): number {
   return values.reduce((a, b) => a + b, 0);
 }


### PR DESCRIPTION
Updates catalog headers to show chapter images, share image rendering, keep square media aligned with header content, and remove obsolete position formatting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show chapter images in catalog headers and align media with header content. Replaces the position badge with a shared image component and removes obsolete position formatting.

- New Features
  - Chapter headers display the chapter image (or a category-based default) and prefix the title with the chapter number.
  - Square media is consistently aligned with header content.

- Refactors
  - Added `CatalogHeaderImage` to standardize `next/image` rendering; used by course and chapter headers.
  - Updated `@zoonk/ui` `MediaCard` to a grid layout and adjusted media sizing for consistent crops.
  - `get-chapter` now includes `course.categories` to support default images.
  - Removed `formatPosition` and its tests; dropped the "Chapter {position}" i18n key in `en`, `es`, and `pt`.
  - Updated e2e tests to assert the numbered title and chapter image alt text.

<sup>Written for commit dd798fc29c0670ba0dd3a3caa3523bf6ad1fa387. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1501?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

