### PR TITLE
feat(main): search catalog tiles by description

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ For detailed UX guidelines (interactions, animation, layout, accessibility), see
 - Always add comments to functions explaining why that function exists. Use clear language, assume the reader has no context, be verbose if needed and add examples to illustrate it. Use plain language, no jargon. Comments should be meaningful and explain the "why" behind the code (eg why did we need to create this function, why is this logic necessary, etc.). Avoid vague statements. For example, "remove anything we don't support" is vague. What we don't support?
 - When writing comments, use `/** ... */` for functions, so we can get JSDoc tooltips
 - When refactoring code, double check if the remaining or replaced logic still makes sense. For example, it's pointless to just reassign a type or const like `type ExistingCourse = Course` or `const existingCourse = course`. Just use the original type or const instead of creating an alias that adds no value
+- Don't run next.js build and e2e tests inside your sandbox. They don't work there
 
 ## Prisma Queries
 

--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -17,6 +17,7 @@ let unpublishedChapterSlug: string;
 let noLessonsChapterId: string;
 let noLessonsChapterUrl: string;
 let lessonNames: { first: string; second: string };
+let lessonDescriptions: { first: string; second: string };
 let lessonSlugs: { first: string; second: string };
 let ptChapterUrl: string;
 let ptLessonNames: { first: string; second: string };
@@ -57,6 +58,11 @@ test.beforeAll(async () => {
     second: `History of E2E Testing ${uniqueId}`,
   };
 
+  lessonDescriptions = {
+    first: `Practical setup ${uniqueId}`,
+    second: `Hidden archive keyword ${uniqueId}`,
+  };
+
   lessonSlugs = { first: `e2e-what-is-${uniqueId}`, second: `e2e-history-of-${uniqueId}` };
 
   const unpublishedLessonTitle = `Unpublished Lesson ${uniqueId}`;
@@ -64,6 +70,7 @@ test.beforeAll(async () => {
   await Promise.all([
     lessonFixture({
       chapterId: chapter.id,
+      description: lessonDescriptions.first,
       isPublished: true,
       normalizedTitle: normalizeString(lessonNames.first),
       organizationId: org.id,
@@ -73,6 +80,7 @@ test.beforeAll(async () => {
     }),
     lessonFixture({
       chapterId: chapter.id,
+      description: lessonDescriptions.second,
       isPublished: true,
       normalizedTitle: normalizeString(lessonNames.second),
       organizationId: org.id,
@@ -242,6 +250,20 @@ test.describe("Chapter Lesson Search", () => {
     await page.goto(chapterUrl);
 
     await page.getByLabel(/search lessons/iu).fill("History");
+
+    await expect(
+      page.getByRole("link", { name: new RegExp(lessonNames.second, "u") }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole("link", { name: new RegExp(lessonNames.first, "u") }),
+    ).not.toBeVisible();
+  });
+
+  test("filters lessons by description", async ({ page }) => {
+    await page.goto(chapterUrl);
+
+    await page.getByLabel(/search lessons/iu).fill("archive keyword");
 
     await expect(
       page.getByRole("link", { name: new RegExp(lessonNames.second, "u") }),

--- a/apps/main/e2e/course-chapters.test.ts
+++ b/apps/main/e2e/course-chapters.test.ts
@@ -12,6 +12,7 @@ let courseUrl: string;
 let ptCourseUrl: string;
 let chapterSlugs: { first: string };
 let chapterNames: { first: string; second: string; third: string };
+let chapterDescriptions: { first: string; second: string; third: string };
 let ptChapterNames: { first: string; second: string };
 let unpublishedChapterName: string;
 
@@ -34,12 +35,19 @@ test.beforeAll(async () => {
     third: `Gamma Chapter ${uniqueId}`,
   };
 
+  chapterDescriptions = {
+    first: `Alpha description ${uniqueId}`,
+    second: `Beta description ${uniqueId}`,
+    third: `Hidden orbital keyword ${uniqueId}`,
+  };
+
   chapterSlugs = { first: `e2e-alpha-${uniqueId}` };
   unpublishedChapterName = `Unpublished Chapter ${uniqueId}`;
 
   // Create first chapter separately so we can add a lesson (prevents redirect to /generate)
   const firstChapter = await chapterFixture({
     courseId: enCourse.id,
+    description: chapterDescriptions.first,
     isPublished: true,
     normalizedTitle: normalizeString(chapterNames.first),
     organizationId: org.id,
@@ -59,6 +67,7 @@ test.beforeAll(async () => {
   await Promise.all([
     chapterFixture({
       courseId: enCourse.id,
+      description: chapterDescriptions.second,
       isPublished: true,
       normalizedTitle: normalizeString(chapterNames.second),
       organizationId: org.id,
@@ -68,6 +77,7 @@ test.beforeAll(async () => {
     }),
     chapterFixture({
       courseId: enCourse.id,
+      description: chapterDescriptions.third,
       isPublished: true,
       normalizedTitle: normalizeString(chapterNames.third),
       organizationId: org.id,
@@ -192,6 +202,20 @@ test.describe("Course Chapter Search", () => {
     await page.goto(courseUrl);
 
     await page.getByLabel(/search chapters/iu).fill("Gamma");
+
+    const firstChapter = page.getByRole("link", { name: new RegExp(chapterNames.first, "u") });
+    const secondChapter = page.getByRole("link", { name: new RegExp(chapterNames.second, "u") });
+    const thirdChapter = page.getByRole("link", { name: new RegExp(chapterNames.third, "u") });
+
+    await expect(thirdChapter).toBeVisible();
+    await expect(firstChapter).not.toBeVisible();
+    await expect(secondChapter).not.toBeVisible();
+  });
+
+  test("filters chapters by description", async ({ page }) => {
+    await page.goto(courseUrl);
+
+    await page.getByLabel(/search chapters/iu).fill("orbital keyword");
 
     const firstChapter = page.getByRole("link", { name: new RegExp(chapterNames.first, "u") });
     const secondChapter = page.getByRole("link", { name: new RegExp(chapterNames.second, "u") });

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -160,6 +160,7 @@ export async function LessonList({
   const lessonRows = await getLessonRows(lessons);
 
   const searchItems = lessonRows.map(({ display, lesson }) => ({
+    description: display.description,
     id: lesson.id,
     title: display.title,
   }));

--- a/apps/main/src/components/catalog/catalog-grid.tsx
+++ b/apps/main/src/components/catalog/catalog-grid.tsx
@@ -11,12 +11,41 @@ import { useQueryState } from "nuqs";
 import { type ReactNode, useMemo } from "react";
 import { CatalogGridContext, useCatalogGridContext } from "./catalog-grid-context";
 
+type CatalogGridSearchItem = {
+  description?: string | null;
+  id: string | number | bigint;
+  title: string;
+};
+
+/**
+ * Catalog search should match the text learners scan inside each tile. Generated
+ * chapters and lessons often put the disambiguating detail in the description,
+ * so filtering only by title hides relevant results.
+ */
+function getCatalogSearchText(item: CatalogGridSearchItem): string {
+  return [item.title, item.description].filter(Boolean).join(" ");
+}
+
+/**
+ * Normalizing the combined tile text once per candidate keeps chapter and lesson
+ * search accent-insensitive without each page rebuilding the same rules.
+ */
+function matchesCatalogSearchQuery({
+  item,
+  query,
+}: {
+  item: CatalogGridSearchItem;
+  query: string;
+}): boolean {
+  return normalizeString(getCatalogSearchText(item)).includes(query);
+}
+
 /**
  * The catalog grid search owns query-string filtering so course, chapter, and
  * lesson grids can share one search behavior while each page keeps its own data
  * fetching on the server.
  */
-export function CatalogGridSearch<T extends { id: string | number; title: string }>({
+export function CatalogGridSearch({
   children,
   className,
   items,
@@ -24,7 +53,7 @@ export function CatalogGridSearch<T extends { id: string | number; title: string
 }: {
   children: ReactNode;
   className?: string;
-  items: T[];
+  items: CatalogGridSearchItem[];
   placeholder: string;
 }) {
   const [search, setSearch] = useQueryState("q", {
@@ -40,7 +69,7 @@ export function CatalogGridSearch<T extends { id: string | number; title: string
       return { filteredIds: null, isSearchActive: false };
     }
 
-    const matching = items.filter((item) => normalizeString(item.title).includes(query));
+    const matching = items.filter((item) => matchesCatalogSearchQuery({ item, query }));
     return { filteredIds: new Set(matching.map((item) => String(item.id))), isSearchActive: true };
   }, [items, search]);
 


### PR DESCRIPTION
## Summary
- Expand course chapter and lesson catalog search to match both title and description.
- Keep the shared grid filter in one place and pass lesson display descriptions into the search items.
- Add e2e coverage for chapter and lesson searches that only match on description.

## Testing
- `pnpm --filter main build:e2e`
- `pnpm --filter main e2e course-chapters.test.ts chapter-detail.test.ts`
- `pnpm --filter main typecheck`
- `pnpm exec oxfmt --check ...`
- `pnpm exec oxlint --deny-warnings ...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missed results in the catalog by making search match the text shown on tiles, including descriptions for chapters and lessons. This improves discoverability and keeps filtering consistent across grids.

- **Bug Fixes**
  - Filter by combined, normalized title + description in `CatalogGridSearch` (accent-insensitive).
  - Pass `display.description` into lesson search items so lesson pages support description search.
  - Add e2e tests for description-only matches on chapter and lesson pages.

<sup>Written for commit b33ee434d53ddb8fbc48f53d5df5f342c4ae7adf. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1504?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

