### PR TITLE
fix(ai): share rich text rules across lesson prompts

### DIFF
--- a/packages/ai/src/tasks/lessons/_utils/append-lesson-rich-text-prompt.ts
+++ b/packages/ai/src/tasks/lessons/_utils/append-lesson-rich-text-prompt.ts
@@ -1,0 +1,11 @@
+import richTextPrompt from "./lesson-rich-text.prompt.md";
+
+/**
+ * Appends the player rich-text contract to lesson prompts that generate learner
+ * copy. Explanation, tutorial, and practice lessons all render through the same
+ * player text component, so keeping the formatting rules here prevents one
+ * lesson kind from drifting away from what the player actually supports.
+ */
+export function appendLessonRichTextPrompt(basePrompt: string): string {
+  return `${basePrompt.trimEnd()}\n\n${richTextPrompt.trim()}`;
+}

--- a/packages/ai/src/tasks/lessons/_utils/lesson-rich-text.prompt.md
+++ b/packages/ai/src/tasks/lessons/_utils/lesson-rich-text.prompt.md
@@ -1,0 +1,15 @@
+# Rich Text
+
+The player can render a small rich-text subset in learner-facing text fields:
+
+- inline LaTeX with `\(...\)`
+- display LaTeX with `\[...\]`
+- bold with `**...**`
+- italic with `*...*`
+- inline code with single backticks, like `greetUser();`
+
+Use LaTeX for formulas when it improves clarity, for example `\(d\sin\theta = m\lambda\)`. Explain what each important symbol means in plain language. Use inline code for short code snippets, function names, commands, file paths, or literal values. Use bold or italic sparingly to emphasize a key term or value.
+
+Do not use Markdown headings, lists, tables, links, blockquotes, images, or code fences inside learner-facing text fields. If code is necessary, keep it short enough to fit in prose as inline code.
+
+If this task includes an `imagePrompt` field, do not use rich-text markers there unless the marker itself should be visible text in the generated image.

--- a/packages/ai/src/tasks/lessons/core/lesson-explanation.prompt.md
+++ b/packages/ai/src/tasks/lessons/core/lesson-explanation.prompt.md
@@ -76,20 +76,6 @@ Use short, clear titles in `LANGUAGE` that name the idea, relationship, rule, or
 - Avoid rhetorical-question-only steps.
 - If you use an analogy, quickly return to the real mechanism.
 
-# Rich Text
-
-The player can render a small rich-text subset:
-
-- inline LaTeX with `\(...\)`
-- display LaTeX with `\[...\]`
-- bold with `**...**`
-- italic with `*...*`
-- inline code with single backticks, like `greetUser();`
-
-Use LaTeX for formulas when it improves clarity, for example `\(d\sin\theta = m\lambda\)`. Explain what each important symbol means in plain language. Use inline code for short code snippets, function names, commands, or literal values. Use bold or italic sparingly to emphasize a key term.
-
-Do not use Markdown headings, lists, tables, links, or code fences inside a step. If code is necessary, keep it short enough to fit in prose as inline code.
-
 # Static Lesson Rules
 
 - This is explanation-only: no quiz checks, choices, option lists, or "guess before continuing" moments.

--- a/packages/ai/src/tasks/lessons/core/lesson-explanation.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-explanation.ts
@@ -3,10 +3,12 @@ import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-o
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getPromptLanguageName } from "../../_utils/prompt-language";
-import systemPrompt from "./lesson-explanation.prompt.md";
+import { appendLessonRichTextPrompt } from "../_utils/append-lesson-rich-text-prompt";
+import baseSystemPrompt from "./lesson-explanation.prompt.md";
 
 const defaultModel = "openai/gpt-5.5";
 const fallbackModels = ["anthropic/claude-opus-4.7", "google/gemini-3.1-pro-preview"] as const;
+const systemPrompt = appendLessonRichTextPrompt(baseSystemPrompt);
 
 const anchorSchema = z.object({ text: z.string(), title: z.string().min(1) }).strict();
 

--- a/packages/ai/src/tasks/lessons/core/lesson-practice.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-practice.ts
@@ -3,11 +3,13 @@ import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-o
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getPromptLanguageName } from "../../_utils/prompt-language";
+import { appendLessonRichTextPrompt } from "../_utils/append-lesson-rich-text-prompt";
 import { formatExplanationStepsForPrompt } from "./_utils/format-explanation-steps";
-import systemPrompt from "./lesson-practice.prompt.md";
+import baseSystemPrompt from "./lesson-practice.prompt.md";
 
 const defaultModel = "openai/gpt-5.4";
 const fallbackModels = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"] as const;
+const systemPrompt = appendLessonRichTextPrompt(baseSystemPrompt);
 
 const practiceOptionSchema = z.object({
   feedback: z.string(),

--- a/packages/ai/src/tasks/lessons/tutorial/lesson-tutorial.ts
+++ b/packages/ai/src/tasks/lessons/tutorial/lesson-tutorial.ts
@@ -3,10 +3,12 @@ import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-o
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getPromptLanguageName } from "../../_utils/prompt-language";
-import systemPrompt from "./lesson-tutorial.prompt.md";
+import { appendLessonRichTextPrompt } from "../_utils/append-lesson-rich-text-prompt";
+import baseSystemPrompt from "./lesson-tutorial.prompt.md";
 
 const defaultModel = "google/gemini-3-flash";
 const fallbackModels = ["anthropic/claude-opus-4.6", "openai/gpt-5.4"] as const;
+const systemPrompt = appendLessonRichTextPrompt(baseSystemPrompt);
 
 const stepSchema = z.object({ text: z.string(), title: z.string() });
 


### PR DESCRIPTION
## Summary
- Extracted the player rich-text contract into a shared lesson prompt fragment
- Applied the formatting rules to explanation, tutorial, and practice lesson generation
- Kept the prompt aligned with the player’s supported subset: LaTeX, bold, italic, and inline code

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes the player rich‑text rules in a shared prompt and applies them to explanation, tutorial, and practice lessons to keep formatting consistent and prevent drift. Removes duplicate rules from the explanation prompt.

- **Refactors**
  - Added shared fragment `lesson-rich-text.prompt.md` with allowed rich text (inline/display LaTeX, bold, italic, inline code) and disallowed elements (headings, lists, tables, links, blockquotes, images, code fences); includes `imagePrompt` guidance.
  - Introduced `appendLessonRichTextPrompt` to append the fragment to any lesson prompt.
  - Wired into `lesson-explanation.ts`, `lesson-tutorial.ts`, and `lesson-practice.ts`.
  - Deleted the inlined rich‑text section from `lesson-explanation.prompt.md`.

<sup>Written for commit 3cb74b7c35c4f5da69909ee2ad517fc6064e9aa0. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1506?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

