### PR TITLE
fix(main): use neutral labels for completed status

### DIFF
--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -276,7 +276,7 @@ msgstr "No se encontraron lecciones"
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "95stPq"
-msgstr "Completada"
+msgstr "Completado"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -293,7 +293,7 @@ msgstr "No se encontraron capítulos"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "V1rAYd"
-msgstr "{completed}/{total} completadas"
+msgstr "{completed}/{total} completados"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
 msgid "wPdQ13"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -276,7 +276,7 @@ msgstr "Nenhuma aula encontrada"
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "95stPq"
-msgstr "Concluída"
+msgstr "Concluído"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -293,7 +293,7 @@ msgstr "Nenhum capítulo encontrado"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "V1rAYd"
-msgstr "{completed}/{total} concluídas"
+msgstr "{completed}/{total} concluídos"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
 msgid "wPdQ13"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use neutral wording for the completed status in Spanish and Portuguese across lesson and chapter lists. Updated `es.po` and `pt.po` to use “Completado”/“{completed}/{total} completados” and “Concluído”/“{completed}/{total} concluídos” for consistent, inclusive labels.

<sup>Written for commit 49b46b66a6d392880d95cc54ef40f84c4241835f. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1507?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

