### PR TITLE
fix(main): show chapter continue state before generated lessons exist

### DIFF
--- a/apps/main/e2e/continue-lesson-link.test.ts
+++ b/apps/main/e2e/continue-lesson-link.test.ts
@@ -282,6 +282,67 @@ test.describe("Continue Lesson Link", () => {
     );
   });
 
+  test("course page shows Continue linking to ungenerated next chapter", async ({
+    authenticatedPage,
+    withProgressUser,
+  }) => {
+    const org = await getAiOrganization();
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: org.id,
+      slug: `e2e-cal-next-empty-course-${uniqueId}`,
+      title: `E2E CAL Next Empty Course ${uniqueId}`,
+    });
+
+    const [chapter1, chapter2] = await Promise.all([
+      chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        organizationId: org.id,
+        position: 0,
+        slug: `e2e-cal-next-empty-ch1-${uniqueId}`,
+        title: `E2E CAL Next Empty Ch1 ${uniqueId}`,
+      }),
+      chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        organizationId: org.id,
+        position: 1,
+        slug: `e2e-cal-next-empty-ch2-${uniqueId}`,
+        title: `E2E CAL Next Empty Ch2 ${uniqueId}`,
+      }),
+    ]);
+
+    const lesson = await lessonFixture({
+      chapterId: chapter1.id,
+      generationStatus: "completed",
+      isPublished: true,
+      organizationId: org.id,
+      position: 0,
+      slug: `e2e-cal-next-empty-l1-${uniqueId}`,
+      title: `E2E CAL Next Empty L1 ${uniqueId}`,
+    });
+
+    await lessonProgressFixture({
+      completedAt: new Date(),
+      durationSeconds: 60,
+      lessonId: lesson.id,
+      userId: withProgressUser.id,
+    });
+
+    await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
+
+    const continueLink = authenticatedPage.getByRole("link", { name: /^continue$/iu });
+    await expect(continueLink).toBeVisible();
+
+    await expect(continueLink).toHaveAttribute(
+      "href",
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter2.slug}`,
+    );
+  });
+
   test("chapter page shows Continue linking to next chapter when completed", async ({
     authenticatedPage,
     withProgressUser,

--- a/apps/main/e2e/lesson-completion.test.ts
+++ b/apps/main/e2e/lesson-completion.test.ts
@@ -182,6 +182,58 @@ async function createChapterCompleteScenario(prefix: string) {
 }
 
 /**
+ * The next chapter can exist before its lesson shells are generated. Completing
+ * the current chapter should still show a chapter milestone, then let the
+ * chapter page redirect to generation instead of declaring the course done.
+ */
+async function createChapterCompleteWithUngeneratedNextChapterScenario(prefix: string) {
+  const org = await getAiOrganization();
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-${prefix}-course-${uniqueId}`,
+  });
+
+  const [chapter1, chapter2] = await Promise.all([
+    chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: org.id,
+      position: 0,
+      slug: `e2e-${prefix}-ch1-${uniqueId}`,
+      title: `First Chapter ${uniqueId}`,
+    }),
+    chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: org.id,
+      position: 1,
+      slug: `e2e-${prefix}-ch2-${uniqueId}`,
+      title: `Second Chapter ${uniqueId}`,
+    }),
+  ]);
+
+  const lesson = await lessonFixture({
+    chapterId: chapter1.id,
+    isPublished: true,
+    kind: "quiz",
+    organizationId: org.id,
+    position: 0,
+    slug: `e2e-${prefix}-lesson-${uniqueId}`,
+  });
+
+  await createQuizLesson(lesson.id, uniqueId);
+
+  return {
+    chapter2,
+    lessonUrl: `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter1.slug}/l/${lesson.slug}`,
+    uniqueId,
+  };
+}
+
+/**
  * One chapter, one lesson, one lesson. Completing it → "Course Complete".
  * "Review Course" → course page. "Review Chapter" → chapter page.
  */
@@ -305,6 +357,30 @@ test.describe("Lesson Completion UX", () => {
 
     await completionScreen.getByRole("link", { name: /review chapter/iu }).click();
     await expect(page.getByRole("heading", { level: 1, name: chapter1.title })).toBeVisible();
+
+    await browserContext.close();
+  });
+
+  test("chapter complete: ungenerated next chapter is not course complete", async ({
+    baseURL,
+    browser,
+  }) => {
+    const email = await createUniqueUser(baseURL!);
+    const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
+
+    const { chapter2, lessonUrl, uniqueId } =
+      await createChapterCompleteWithUngeneratedNextChapterScenario("chpending");
+
+    await page.goto(lessonUrl);
+    await page.waitForLoadState("networkidle");
+    await completeQuiz(page, uniqueId);
+
+    const completionScreen = page.getByRole("status");
+    await expect(completionScreen.getByText(/chapter complete/iu)).toBeVisible();
+    await expect(completionScreen.getByText(/course complete/iu)).not.toBeVisible();
+
+    await completionScreen.getByRole("link", { name: /next chapter/iu }).click();
+    await expect(page).toHaveURL(new RegExp(`/generate/ch/${chapter2.id}$`, "u"));
 
     await browserContext.close();
   });

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
@@ -20,6 +20,7 @@ export function LessonPlayerClient({
   isAuthenticated,
   lessonDescription,
   lessonTitle,
+  nextChapter,
   nextLesson,
   totalBrainPower,
   userEmail,
@@ -33,6 +34,7 @@ export function LessonPlayerClient({
   isAuthenticated: boolean;
   lessonDescription: string;
   lessonTitle: string;
+  nextChapter: { brandSlug: string; chapterSlug: string; courseSlug: string } | null;
   nextLesson: { chapterSlug: string; lessonSlug: string; lessonTitle: string | null } | null;
   totalBrainPower: number;
   userEmail?: string;
@@ -41,7 +43,13 @@ export function LessonPlayerClient({
   const router = useRouter();
   const hasRequestedNextLessonPreload = useRef(false);
 
-  const model = buildLessonPlayerModel({ brandSlug, chapterSlug, courseSlug, nextLesson });
+  const model = buildLessonPlayerModel({
+    brandSlug,
+    chapterSlug,
+    courseSlug,
+    nextChapter,
+    nextLesson,
+  });
 
   const onNextHref = model.onNextHref;
   const handleNext = onNextHref ? () => router.push(onNextHref) : undefined;

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.test.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.test.ts
@@ -61,4 +61,22 @@ describe(buildLessonPlayerModel, () => {
 
     expect(model.onNextHref).toBeNull();
   });
+
+  it("returns a chapter milestone when the next chapter has no lesson shell yet", () => {
+    const model = buildLessonPlayerModel({
+      brandSlug: "brand",
+      chapterSlug: "chapter-1",
+      courseSlug: "course",
+      nextChapter: { brandSlug: "brand", chapterSlug: "chapter-2", courseSlug: "course" },
+      nextLesson: null,
+    });
+
+    expect(model.milestone).toStrictEqual({
+      kind: "chapter",
+      nextHref: "/b/brand/c/course/ch/chapter-2",
+      reviewHref: "/b/brand/c/course/ch/chapter-1",
+    });
+
+    expect(model.onNextHref).toBe("/b/brand/c/course/ch/chapter-2");
+  });
 });

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.ts
@@ -1,38 +1,97 @@
 type NextLesson = { chapterSlug: string; lessonSlug: string; lessonTitle: string | null };
+type NextChapter = { brandSlug: string; chapterSlug: string; courseSlug: string };
 
-export function buildLessonPlayerModel({
+/**
+ * The next playable lesson is only available after generation has created a
+ * lesson shell. Keep this separate from chapter progression so an empty next
+ * chapter does not look like the whole course is complete.
+ */
+function getNextLessonHref({
+  brandSlug,
+  courseSlug,
+  nextLesson,
+}: {
+  brandSlug: string;
+  courseSlug: string;
+  nextLesson: NextLesson | null;
+}) {
+  if (!nextLesson) {
+    return null;
+  }
+
+  return `/b/${brandSlug}/c/${courseSlug}/ch/${nextLesson.chapterSlug}/l/${nextLesson.lessonSlug}` as const;
+}
+
+/**
+ * Chapter completion is a structural boundary, not proof that the next lesson
+ * is ready. A next chapter with no lessons should still show the chapter
+ * milestone and send learners to the chapter page, where generation can start.
+ */
+function getNextChapterHref({
   brandSlug,
   chapterSlug,
   courseSlug,
+  nextChapter,
   nextLesson,
 }: {
   brandSlug: string;
   chapterSlug: string;
   courseSlug: string;
+  nextChapter: NextChapter | null;
+  nextLesson: NextLesson | null;
+}) {
+  if (nextLesson?.chapterSlug === chapterSlug) {
+    return null;
+  }
+
+  if (nextChapter) {
+    return `/b/${nextChapter.brandSlug}/c/${nextChapter.courseSlug}/ch/${nextChapter.chapterSlug}` as const;
+  }
+
+  if (nextLesson) {
+    return `/b/${brandSlug}/c/${courseSlug}/ch/${nextLesson.chapterSlug}` as const;
+  }
+
+  return null;
+}
+
+/**
+ * Builds the player route model from course structure. The screen should only
+ * say "Course Complete" when there is no later published chapter, even if the
+ * next chapter has not generated a lesson yet.
+ */
+export function buildLessonPlayerModel({
+  brandSlug,
+  chapterSlug,
+  courseSlug,
+  nextChapter = null,
+  nextLesson,
+}: {
+  brandSlug: string;
+  chapterSlug: string;
+  courseSlug: string;
+  nextChapter?: NextChapter | null;
   nextLesson: NextLesson | null;
 }) {
   const chapterHref = `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}` as const;
   const courseHref = `/b/${brandSlug}/c/${courseSlug}` as const;
+  const nextLessonHref = getNextLessonHref({ brandSlug, courseSlug, nextLesson });
 
-  const nextLessonHref = nextLesson
-    ? (`/b/${brandSlug}/c/${courseSlug}/ch/${nextLesson.chapterSlug}/l/${nextLesson.lessonSlug}` as const)
-    : null;
-
-  const nextChapterHref = (() => {
-    if (nextLesson && nextLesson.chapterSlug !== chapterSlug) {
-      return `/b/${brandSlug}/c/${courseSlug}/ch/${nextLesson.chapterSlug}`;
-    }
-
-    return null;
-  })();
+  const nextChapterHref = getNextChapterHref({
+    brandSlug,
+    chapterSlug,
+    courseSlug,
+    nextChapter,
+    nextLesson,
+  });
 
   const milestone = (() => {
-    if (!nextLesson) {
-      return { kind: "course" as const, reviewHref: courseHref, secondaryReviewHref: chapterHref };
-    }
-
     if (nextChapterHref) {
       return { kind: "chapter" as const, nextHref: nextChapterHref, reviewHref: chapterHref };
+    }
+
+    if (!nextLesson) {
+      return { kind: "course" as const, reviewHref: courseHref, secondaryReviewHref: chapterHref };
     }
 
     return null;
@@ -47,6 +106,6 @@ export function buildLessonPlayerModel({
       loginHref: "/login",
       nextLessonHref,
     },
-    onNextHref: nextLessonHref,
+    onNextHref: nextLessonHref ?? nextChapterHref,
   };
 }

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -1,6 +1,7 @@
 import { getLesson as getCatalogLesson } from "@/data/lessons/get-lesson";
 import { getLessonDisplayMeta, getLessonSeoMeta } from "@/lib/lessons";
 import { getBlockingLessonGenerationPrerequisite } from "@zoonk/core/lessons/generation-prerequisites";
+import { getNextChapterInCourse } from "@zoonk/core/lessons/next-chapter-in-course";
 import { getNextLessonInCourse } from "@zoonk/core/lessons/next-in-course";
 import { startLesson } from "@zoonk/core/player/commands/start-lesson";
 import { preparePlayerLessonData } from "@zoonk/core/player/contracts/prepare-lesson-data";
@@ -66,18 +67,23 @@ export default async function LessonPage({ params }: Props) {
     notFound();
   }
 
-  const [lesson, nextLesson, session, reviewLessonData, totalBrainPower] = await Promise.all([
-    getPlayerLesson({ lessonId: lessonShell.id }),
-    getNextLessonInCourse({
-      chapterId: lessonShell.chapter.id,
-      chapterPosition: lessonShell.chapter.position,
-      courseId: lessonShell.chapter.course.id,
-      lessonPosition: lessonShell.position,
-    }),
-    getSession(),
-    fetchReviewLessonData(lessonShell.id),
-    getTotalBrainPower(),
-  ]);
+  const [lesson, nextChapter, nextLesson, session, reviewLessonData, totalBrainPower] =
+    await Promise.all([
+      getPlayerLesson({ lessonId: lessonShell.id }),
+      getNextChapterInCourse({
+        chapterPosition: lessonShell.chapter.position,
+        courseId: lessonShell.chapter.course.id,
+      }),
+      getNextLessonInCourse({
+        chapterId: lessonShell.chapter.id,
+        chapterPosition: lessonShell.chapter.position,
+        courseId: lessonShell.chapter.course.id,
+        lessonPosition: lessonShell.position,
+      }),
+      getSession(),
+      fetchReviewLessonData(lessonShell.id),
+      getTotalBrainPower(),
+    ]);
 
   if (!lesson) {
     notFound();
@@ -144,6 +150,7 @@ export default async function LessonPage({ params }: Props) {
       isAuthenticated={Boolean(session)}
       lessonDescription={lessonMeta.description}
       lessonTitle={lessonMeta.title}
+      nextChapter={nextChapter}
       nextLesson={nextLesson}
       totalBrainPower={totalBrainPower}
       userEmail={session?.user.email}

--- a/apps/main/src/components/catalog/continue-lesson-link.tsx
+++ b/apps/main/src/components/catalog/continue-lesson-link.tsx
@@ -110,6 +110,24 @@ export async function ContinueLessonLink<Href extends string, CompletedHref exte
     return renderFallback({ label });
   }
 
+  /**
+   * Completed generated lessons can still lead to an ungenerated next chapter.
+   * Those targets intentionally have no lesson slug, so route them to the
+   * chapter page where the normal generation redirect can take over.
+   */
+  if (!("lessonSlug" in data)) {
+    return (
+      <Link
+        className={className}
+        href={`/b/${data.brandSlug}/c/${data.courseSlug}/ch/${data.chapterSlug}`}
+        prefetch={false}
+      >
+        {label}
+        <ChevronRightIcon aria-hidden="true" />
+      </Link>
+    );
+  }
+
   if (data.canPrefetch) {
     return (
       <Link

--- a/packages/core/src/progress/get-continue-lesson-target.test.ts
+++ b/packages/core/src/progress/get-continue-lesson-target.test.ts
@@ -158,6 +158,56 @@ describe(getContinueLessonTarget, () => {
     });
   });
 
+  it("returns a chapter target when the next chapter has no lesson shell yet", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const [completedChapter, nextChapter] = await Promise.all([
+      chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    const lesson = await lessonFixture({
+      chapterId: completedChapter.id,
+      generationStatus: "completed",
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    await lessonProgressFixture({
+      completedAt: new Date(),
+      durationSeconds: 60,
+      lessonId: lesson.id,
+      userId: user.id,
+    });
+
+    const headers = await signInAs(user.email, user.password);
+
+    const result = await getContinueLessonTarget({ headers, scope: { courseId: course.id } });
+
+    expect(result).toStrictEqual({
+      brandSlug: organization.slug,
+      canPrefetch: false,
+      chapterSlug: nextChapter.slug,
+      completed: false,
+      courseSlug: course.slug,
+      hasStarted: true,
+    });
+  });
+
   it("chapter scope stays inside the requested chapter", async () => {
     const [user, tree] = await Promise.all([userFixture(), createCourseTree()]);
     const [completedLesson, nextLesson] = tree.lessons;

--- a/packages/core/src/progress/get-continue-lesson-target.ts
+++ b/packages/core/src/progress/get-continue-lesson-target.ts
@@ -1,6 +1,23 @@
 import { type LessonScope, findLastCompleted } from "@zoonk/core/lessons/last-completed";
+import { getNextChapterInCourse } from "../lessons/get-next-chapter-in-course";
 import { getSession } from "../users/get-user-session";
-import { getNextLessonStateForUser } from "./get-next-lesson-state";
+import { type NextLessonState, getNextLessonStateForUser } from "./get-next-lesson-state";
+
+type ContinueLessonTargetBase = {
+  brandSlug: string | null;
+  chapterSlug: string;
+  completed: boolean;
+  courseSlug: string;
+  hasStarted: boolean;
+};
+
+type ContinueLessonTarget = ContinueLessonTargetBase & {
+  canPrefetch: boolean;
+  lessonPosition: number;
+  lessonSlug: string;
+};
+
+type ContinueChapterTarget = ContinueLessonTargetBase & { canPrefetch: false; completed: false };
 
 /**
  * Resolves the lesson destination that start/continue/review buttons should
@@ -13,16 +30,7 @@ export async function getContinueLessonTarget({
 }: {
   scope: LessonScope;
   headers?: Headers;
-}): Promise<{
-  lessonPosition: number;
-  brandSlug: string | null;
-  canPrefetch: boolean;
-  chapterSlug: string;
-  completed: boolean;
-  courseSlug: string;
-  hasStarted: boolean;
-  lessonSlug: string;
-} | null> {
+}): Promise<ContinueChapterTarget | ContinueLessonTarget | null> {
   const session = await getSession(headers);
   const userId = session?.user.id;
   const lastCompleted = userId ? await findLastCompleted(userId, scope) : null;
@@ -43,6 +51,12 @@ export async function getContinueLessonTarget({
     return null;
   }
 
+  const pendingChapterTarget = await getPendingChapterTarget({ scope, state });
+
+  if (pendingChapterTarget) {
+    return pendingChapterTarget;
+  }
+
   return {
     brandSlug: state.brandSlug,
     canPrefetch: state.canPrefetch,
@@ -52,5 +66,40 @@ export async function getContinueLessonTarget({
     hasStarted: state.hasStarted,
     lessonPosition: state.lessonPosition,
     lessonSlug: state.lessonSlug,
+  };
+}
+
+/**
+ * A course can be complete relative to its generated lessons while a later
+ * published chapter still has no lesson shells. In that state the course CTA
+ * should continue to the chapter page, not review the completed lesson.
+ */
+async function getPendingChapterTarget({
+  scope,
+  state,
+}: {
+  scope: LessonScope;
+  state: NextLessonState;
+}): Promise<ContinueChapterTarget | null> {
+  if (!("courseId" in scope) || !state.completed || state.scopeDurablyCompleted) {
+    return null;
+  }
+
+  const nextChapter = await getNextChapterInCourse({
+    chapterPosition: state.chapterPosition,
+    courseId: state.courseId,
+  });
+
+  if (!nextChapter) {
+    return null;
+  }
+
+  return {
+    brandSlug: nextChapter.brandSlug,
+    canPrefetch: false,
+    chapterSlug: nextChapter.chapterSlug,
+    completed: false,
+    courseSlug: nextChapter.courseSlug,
+    hasStarted: true,
   };
 }

--- a/packages/core/src/progress/get-next-lesson-state.ts
+++ b/packages/core/src/progress/get-next-lesson-state.ts
@@ -31,6 +31,7 @@ export type NextLessonState = {
   brandSlug: string | null;
   canPrefetch: boolean;
   chapterId: string;
+  chapterPosition: number;
   chapterSlug: string;
   chapterTitle: string;
   completed: boolean;
@@ -155,6 +156,7 @@ function buildCompletedScopeState({
     brandSlug: firstRow.brandSlug,
     canPrefetch: canPrefetchLesson({ row: firstRow }),
     chapterId: firstRow.chapterId,
+    chapterPosition: firstRow.chapterPosition,
     chapterSlug: firstRow.chapterSlug,
     chapterTitle: firstRow.chapterTitle,
     completed: true,
@@ -198,6 +200,7 @@ async function buildOpenLessonState({
       brandSlug: lesson.brandSlug,
       canPrefetch: true,
       chapterId: lesson.chapterId,
+      chapterPosition: lesson.chapterPosition,
       chapterSlug: lesson.chapterSlug,
       chapterTitle: lesson.chapterTitle,
       completed: false,
@@ -245,6 +248,7 @@ function toPendingLessonState({
     brandSlug: lesson.brandSlug,
     canPrefetch: false,
     chapterId: lesson.chapterId,
+    chapterPosition: lesson.chapterPosition,
     chapterSlug: lesson.chapterSlug,
     chapterTitle: lesson.chapterTitle,
     completed,


### PR DESCRIPTION
**Summary**
- Corrects the shared continue-target logic so a completed course/chapter with a not-yet-generated next chapter shows `Continue` to the chapter page instead of `Review` to the finished lesson.
- Updates the player completion model so the completion screen treats an ungenerated next chapter as chapter completion, not course completion.
- Adds coverage for the shared progress resolver, course CTA, player completion state, and the regression scenarios in main e2e tests.

**Testing**
- Added focused unit and integration coverage for the new chapter-target behavior.
- Verified formatting and typecheck passed locally; Playwright e2e remains unrun in the sandbox.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “Continue” CTA and completion screen when the next chapter exists but its lessons aren’t generated yet. Users now see “Continue” to the chapter and a Chapter Complete milestone, not “Review” or Course Complete.

- **Bug Fixes**
  - `get-continue-lesson-target` now returns a chapter target when the course looks complete due to missing lesson shells, using `getNextChapterInCourse`.
  - Lesson player accepts `nextChapter` and sets the milestone/onNext to the chapter when the next lesson isn’t available; lesson page now fetches `getNextChapterInCourse`. `ContinueLessonLink` routes chapter targets (no `lessonSlug`) to the chapter page.
  - Added focused unit/integration tests and e2e coverage for the progress resolver, course CTA, and completion UX.

<sup>Written for commit 9e276afbf6a10b0f10aeeb3cd473af3327e5e97c. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1508?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

