### PR TITLE
fix(main): update lesson generation timing label

### DIFF
--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -407,7 +407,7 @@ test.describe("Generate Lesson Page - With Subscription", () => {
 
     await userWithoutProgress.goto(`/generate/l/${lesson.id}`);
 
-    await expect(userWithoutProgress.getByText(/this usually takes a few seconds/iu)).toBeVisible({
+    await expect(userWithoutProgress.getByText(/this usually takes 1-2 minutes/iu)).toBeVisible({
       timeout: 10_000,
     });
   });

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1217,8 +1217,8 @@ msgid "mFR5UU"
 msgstr "Creating your lesson"
 
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "THvPMp"
-msgstr "This usually takes a few seconds"
+msgid "3vY0Zu"
+msgstr "This usually takes 1-2 minutes"
 
 #: src/app/generate/l/[id]/generation-client.tsx
 msgid "T2TGxR"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1217,8 +1217,8 @@ msgid "mFR5UU"
 msgstr "Creando tu lección"
 
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "THvPMp"
-msgstr "Esto generalmente toma unos segundos"
+msgid "3vY0Zu"
+msgstr "Esto generalmente toma de 1 a 2 minutos"
 
 #: src/app/generate/l/[id]/generation-client.tsx
 msgid "T2TGxR"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1217,8 +1217,8 @@ msgid "mFR5UU"
 msgstr "Criando sua aula"
 
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "THvPMp"
-msgstr "Isso geralmente leva alguns segundos"
+msgid "3vY0Zu"
+msgstr "Isso geralmente leva de 1 a 2 minutos"
 
 #: src/app/generate/l/[id]/generation-client.tsx
 msgid "T2TGxR"

--- a/apps/main/src/app/generate/l/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/l/[id]/generation-client.tsx
@@ -90,7 +90,7 @@ export function GenerationClient({
         <GenerationTimelineHeader>
           <GenerationTimelineTitle>{t("Creating your lesson")}</GenerationTimelineTitle>
           <GenerationTimelineSubtitle>
-            {t("This usually takes a few seconds")}
+            {t("This usually takes 1-2 minutes")}
           </GenerationTimelineSubtitle>
           <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
         </GenerationTimelineHeader>


### PR DESCRIPTION
## Summary
- Update the lesson generation subtitle to say it usually takes 1-2 minutes
- Refresh the extracted message catalogs for English, Spanish, and Portuguese
- Update the e2e assertion that checks the generate lesson page copy

## Testing
- Typecheck passed for the `main` app
- E2E coverage updated to match the new timing label

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the lesson generation subtitle to say “This usually takes 1-2 minutes” to set clearer expectations. Refreshed EN/ES/PT message catalogs and updated the e2e test to match the new copy.

<sup>Written for commit a1e5f971dbc35b31bd63f2608da04536c10ebf00. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1510?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

