### PR TITLE
fix(main): ensure unique lesson badge colors by lesson group

### DIFF
--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/_utils/lesson-kind-tones.test.ts
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/_utils/lesson-kind-tones.test.ts
@@ -1,0 +1,37 @@
+import { type LessonKind } from "@zoonk/db";
+import { describe, expect, it } from "vitest";
+import { getLessonKindTone } from "./lesson-kind-tones";
+
+const LANGUAGE_LESSON_KINDS = [
+  "alphabet",
+  "custom",
+  "grammar",
+  "listening",
+  "reading",
+  "review",
+  "translation",
+  "vocabulary",
+] satisfies LessonKind[];
+
+const NON_LANGUAGE_LESSON_KINDS = [
+  "custom",
+  "explanation",
+  "practice",
+  "quiz",
+  "review",
+  "tutorial",
+] satisfies LessonKind[];
+
+describe(getLessonKindTone, () => {
+  it("uses one tone per language lesson kind", () => {
+    const tones = LANGUAGE_LESSON_KINDS.map((kind) => getLessonKindTone({ kind }));
+
+    expect(new Set(tones).size).toBe(tones.length);
+  });
+
+  it("uses one tone per non-language lesson kind", () => {
+    const tones = NON_LANGUAGE_LESSON_KINDS.map((kind) => getLessonKindTone({ kind }));
+
+    expect(new Set(tones).size).toBe(tones.length);
+  });
+});

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/_utils/lesson-kind-tones.ts
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/_utils/lesson-kind-tones.ts
@@ -1,0 +1,26 @@
+import { type LessonKind } from "@zoonk/db";
+import { type GridItemTone } from "@zoonk/ui/components/grid";
+
+const LESSON_KIND_TONES: Record<LessonKind, GridItemTone> = {
+  alphabet: "blue",
+  custom: "gray",
+  explanation: "blue",
+  grammar: "purple",
+  listening: "red",
+  practice: "green",
+  quiz: "yellow",
+  reading: "yellow",
+  review: "brown",
+  translation: "orange",
+  tutorial: "purple",
+  vocabulary: "green",
+};
+
+/**
+ * Chapter pages show one generated lesson family at a time. This lookup keeps
+ * lesson-kind badges stable without making the list calculate colors from row
+ * order, which would change the meaning of a color as lessons are added.
+ */
+export function getLessonKindTone({ kind }: { kind: LessonKind }) {
+  return LESSON_KIND_TONES[kind];
+}

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -7,7 +7,7 @@ import { CatalogGridImage } from "@/components/catalog/catalog-grid-image";
 import { getDefaultLessonImage } from "@/lib/catalog/default-images";
 import { getLessonDisplayMeta } from "@/lib/lessons";
 import { getLessonProgress } from "@zoonk/core/progress/lessons";
-import { type Lesson, type LessonKind } from "@zoonk/db";
+import { type Lesson } from "@zoonk/db";
 import {
   GridContent,
   GridGroup,
@@ -19,34 +19,11 @@ import {
   GridItemStatusCompleted,
   GridItemStatusIdle,
   GridItemTitle,
-  type GridItemTone,
 } from "@zoonk/ui/components/grid";
 import { getExtracted } from "next-intl/server";
+import { getLessonKindTone } from "./_utils/lesson-kind-tones";
 
 type LessonRow = { display: Awaited<ReturnType<typeof getLessonDisplayMeta>>; lesson: Lesson };
-
-const LESSON_KIND_TONES: Record<LessonKind, GridItemTone> = {
-  alphabet: "blue",
-  custom: "gray",
-  explanation: "blue",
-  grammar: "purple",
-  listening: "purple",
-  practice: "green",
-  quiz: "yellow",
-  reading: "green",
-  review: "purple",
-  translation: "orange",
-  tutorial: "blue",
-  vocabulary: "blue",
-};
-
-/**
- * Lesson kind is a stronger visual grouping than position because repeated
- * companion lessons should be recognizable across the chapter.
- */
-function getLessonKindTone({ kind }: { kind: LessonKind }) {
-  return LESSON_KIND_TONES[kind];
-}
 
 /**
  * Lesson rows only need a binary completion state, so the visual stays quieter


### PR DESCRIPTION
## Summary
- Move lesson badge tone selection into a shared chapter-list utility
- Assign distinct tones within the language and non-language lesson groups so nearby kinds no longer share the same badge color
- Add unit coverage to lock the tone mapping for both groups

## Testing
- Unit tests added for the tone mapping utility
- `main` typecheck passed
- Scoped formatting and lint checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure lesson kind badges use unique colors within language and non-language groups, preventing nearby badges from sharing the same tone. Centralizes tone selection and keeps color meanings stable as lessons change.

- **Bug Fixes**
  - Assign one tone per lesson kind within each group.
  - Move tone lookup to `_utils/lesson-kind-tones` and use it in `lesson-list.tsx`.
  - Add unit tests to lock the mapping for both groups.

<sup>Written for commit b71eded1facf501bf3b2ac37a0bd18bc5bc5ba57. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1511?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

