### PR TITLE
feat(player): add desktop step navigation arrows

### DIFF
--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -232,6 +232,14 @@ msgstr "Check"
 msgid "acrOoz"
 msgstr "Continue"
 
+#: src/components/swipe-navigable-step-layout.tsx
+msgid "aNzy1T"
+msgstr "Previous step"
+
+#: src/components/swipe-navigable-step-layout.tsx
+msgid "d+qgix"
+msgstr "Next step"
+
 #: src/components/translation-step.tsx
 msgid "MxLxkr"
 msgstr "Translate this word:"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -232,6 +232,14 @@ msgstr "Revisar"
 msgid "acrOoz"
 msgstr "Continuar"
 
+#: src/components/swipe-navigable-step-layout.tsx
+msgid "aNzy1T"
+msgstr "Paso anterior"
+
+#: src/components/swipe-navigable-step-layout.tsx
+msgid "d+qgix"
+msgstr "Siguiente paso"
+
 #: src/components/translation-step.tsx
 msgid "MxLxkr"
 msgstr "Traduce esta palabra:"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -232,6 +232,14 @@ msgstr "Verificar"
 msgid "acrOoz"
 msgstr "Continuar"
 
+#: src/components/swipe-navigable-step-layout.tsx
+msgid "aNzy1T"
+msgstr "Etapa anterior"
+
+#: src/components/swipe-navigable-step-layout.tsx
+msgid "d+qgix"
+msgstr "Próxima etapa"
+
 #: src/components/translation-step.tsx
 msgid "MxLxkr"
 msgstr "Traduza esta palavra:"

--- a/packages/player/src/_browser-tests/player-static.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-static.browser.test.tsx
@@ -74,7 +74,7 @@ function tapExpandedImageBackdrop(target: HTMLElement) {
 }
 
 describe("player browser integration: static steps", () => {
-  it("uses keyboard navigation without visible step arrows", async () => {
+  it("shows desktop arrows while preserving keyboard navigation", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({
         kind: "explanation",
@@ -95,11 +95,16 @@ describe("player browser integration: static steps", () => {
     });
 
     await expect.element(page.getByRole("heading", { name: "First step" })).toBeInTheDocument();
-    await expect.element(page.getByRole("button", { name: /next step/iu })).not.toBeInTheDocument();
 
     await expect
       .element(page.getByRole("button", { name: /previous step/iu }))
       .not.toBeInTheDocument();
+
+    await page.getByRole("button", { name: /next step/iu }).click();
+    await expect.element(page.getByRole("heading", { name: "Second step" })).toBeInTheDocument();
+
+    await page.getByRole("button", { name: /previous step/iu }).click();
+    await expect.element(page.getByRole("heading", { name: "First step" })).toBeInTheDocument();
 
     fireEvent.keyDown(globalThis.window, { key: "ArrowRight" });
     await expect.element(page.getByRole("heading", { name: "Second step" })).toBeInTheDocument();

--- a/packages/player/src/components/swipe-navigable-step-layout.tsx
+++ b/packages/player/src/components/swipe-navigable-step-layout.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import { Button } from "@zoonk/ui/components/button";
+import { cn } from "@zoonk/ui/lib/utils";
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import { useExtracted } from "next-intl";
 import { type TouchEvent, useEffect, useRef } from "react";
 import { NavigableStepLayout } from "./step-layouts";
 
@@ -10,6 +14,7 @@ const TAP_DISTANCE_THRESHOLD = 12;
 type SwipeGesture = { container: HTMLDivElement; startX: number; startY: number; touchId: number };
 
 export type SwipeNavigableStepFrame = "default" | "media";
+type DesktopNavigationSide = "previous" | "next";
 
 /**
  * Image-backed read steps need the swipe surface to use the full stage width
@@ -22,6 +27,40 @@ function getNavigableFrameClass(frame: SwipeNavigableStepFrame) {
   }
 
   return "";
+}
+
+/**
+ * Desktop read screens still benefit from a visible navigation affordance, but
+ * touch screens already use the whole surface for tap and swipe navigation.
+ * Keeping these controls pointer-fine only avoids competing with the mobile
+ * gesture model while giving keyboard users a discoverable mouse target.
+ */
+function DesktopNavigationButton({
+  "aria-label": ariaLabel,
+  children,
+  onClick,
+  side,
+}: {
+  "aria-label": string;
+  children: React.ReactNode;
+  onClick: () => void;
+  side: DesktopNavigationSide;
+}) {
+  return (
+    <Button
+      aria-label={ariaLabel}
+      className={cn(
+        "bg-background/70 text-muted-foreground/70 hover:bg-background hover:text-foreground border-border/40 absolute top-1/2 z-20 flex -translate-y-1/2 opacity-55 shadow-sm backdrop-blur-md transition-[background-color,border-color,color,opacity,scale] hover:opacity-100 focus-visible:opacity-100 pointer-coarse:hidden",
+        side === "previous" ? "left-3 xl:left-6" : "right-3 xl:right-6",
+      )}
+      onClick={onClick}
+      size="icon"
+      type="button"
+      variant="outline"
+    >
+      {children}
+    </Button>
+  );
 }
 
 /**
@@ -133,6 +172,7 @@ export function SwipeNavigableStepLayout({
   onNavigateNext: () => void;
   onNavigatePrev: () => void;
 }) {
+  const t = useExtracted();
   const gestureRef = useRef<SwipeGesture | null>(null);
   const endHandlerRef = useRef<((event: globalThis.TouchEvent) => void) | null>(null);
   const cancelHandlerRef = useRef<(() => void) | null>(null);
@@ -274,6 +314,20 @@ export function SwipeNavigableStepLayout({
   return (
     <NavigableStepLayout className={getNavigableFrameClass(frame)} onTouchStart={handleTouchStart}>
       <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col items-center">{children}</div>
+
+      {canNavigatePrev && (
+        <DesktopNavigationButton
+          aria-label={t("Previous step")}
+          onClick={onNavigatePrev}
+          side="previous"
+        >
+          <ChevronLeftIcon />
+        </DesktopNavigationButton>
+      )}
+
+      <DesktopNavigationButton aria-label={t("Next step")} onClick={onNavigateNext} side="next">
+        <ChevronRightIcon />
+      </DesktopNavigationButton>
     </NavigableStepLayout>
   );
 }


### PR DESCRIPTION
## Summary
- Add subtle desktop-only previous/next arrow controls to the swipe navigable static-step layout
- Keep touch swipe and tap navigation unchanged for mobile/coarse pointers
- Update static-step browser coverage and translations for the new navigation labels

## Testing
- Browser coverage updated for desktop arrow navigation and existing keyboard navigation
- `@zoonk/player` typecheck, formatting, lint, and player browser tests passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add desktop-only Previous/Next arrow buttons to the swipe-navigable static-step layout so mouse users have clear controls, with mobile swipe/tap behavior unchanged. Adds localized labels (EN/ES/PT) and updates player browser tests to cover the new arrows and keyboard navigation.

<sup>Written for commit d98cc0fec1fe27d97d937599cfcb2baa77ea5892. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1512?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

