### PR TITLE
fix(api): complete skipped romanization steps

### DIFF
--- a/apps/api/src/workflows/lesson-generation/steps/_test-utils/create-romanization-lesson-context.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_test-utils/create-romanization-lesson-context.ts
@@ -1,0 +1,14 @@
+import { type RomanizationStepContext } from "../_utils/romanization-step-context";
+
+/**
+ * Creates the smallest lesson context needed by romanization step tests.
+ * These steps only inspect the target language, so avoiding database fixtures
+ * keeps the tests focused on the stream contract instead of Prisma setup.
+ */
+export function createRomanizationLessonContext({
+  targetLanguage,
+}: {
+  targetLanguage: string | null;
+}): RomanizationStepContext {
+  return { chapter: { course: { targetLanguage } } };
+}

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/romanization-step-context.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/romanization-step-context.ts
@@ -1,0 +1,1 @@
+export type RomanizationStepContext = { chapter: { course: { targetLanguage: string | null } } };

--- a/apps/api/src/workflows/lesson-generation/steps/generate-grammar-romanization-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-grammar-romanization-step.test.ts
@@ -1,7 +1,7 @@
+import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { generateLessonRomanization } from "@zoonk/ai/tasks/lessons/language/romanization";
-import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { createLessonContext } from "./_test-utils/create-lesson-context";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createRomanizationLessonContext } from "./_test-utils/create-romanization-lesson-context";
 import { generateGrammarRomanizationStep } from "./generate-grammar-romanization-step";
 
 vi.mock("@zoonk/ai/tasks/lessons/language/romanization", () => ({
@@ -15,23 +15,12 @@ vi.mock("@zoonk/ai/tasks/lessons/language/romanization", () => ({
 }));
 
 describe(generateGrammarRomanizationStep, () => {
-  let organizationId: string;
-
-  beforeAll(async () => {
-    const organization = await aiOrganizationFixture();
-    organizationId = organization.id;
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("generates grammar sentence and option romanizations", async () => {
-    const context = await createLessonContext({
-      kind: "grammar",
-      organizationId,
-      targetLanguage: "ja",
-    });
+    const context = createRomanizationLessonContext({ targetLanguage: "ja" });
 
     const catWord = "猫";
     const dogWord = "犬";
@@ -53,6 +42,26 @@ describe(generateGrammarRomanizationStep, () => {
     expect(generateLessonRomanization).toHaveBeenCalledWith({
       targetLanguage: "ja",
       texts: [grammarSentence, grammarSentence, catWord, dogWord],
+    });
+  });
+
+  it("streams completion when romanization is skipped for Roman-script languages", async () => {
+    const context = createRomanizationLessonContext({ targetLanguage: "es" });
+
+    const grammarContent = {
+      examples: [{ highlight: "gato", sentence: "Hay un gato" }],
+      exercises: [{ answer: "gato", distractors: ["perro"], template: "Hay un [BLANK]" }],
+    };
+
+    await expect(
+      generateGrammarRomanizationStep({ context, grammarContent }),
+    ).resolves.toStrictEqual({ romanizations: null });
+
+    expect(generateLessonRomanization).not.toHaveBeenCalled();
+
+    expect(getStreamedEvents()).toContainEqual({
+      status: "completed",
+      step: "generateGrammarRomanization",
     });
   });
 });

--- a/apps/api/src/workflows/lesson-generation/steps/generate-grammar-romanization-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-grammar-romanization-step.ts
@@ -1,9 +1,10 @@
+import { streamSkipStep } from "@/workflows/_shared/stream-skip-step";
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type generateLessonGrammarContent } from "@zoonk/ai/tasks/lessons/language/grammar-content";
 import { type LessonStepName } from "@zoonk/core/workflows/steps";
 import { needsRomanization } from "@zoonk/utils/languages";
 import { generateLessonRomanizations } from "./_utils/generate-lesson-romanizations";
-import { type LessonContext } from "./get-lesson-step";
+import { type RomanizationStepContext } from "./_utils/romanization-step-context";
 
 type GrammarContent = Awaited<ReturnType<typeof generateLessonGrammarContent>>["data"];
 
@@ -11,7 +12,7 @@ export async function generateGrammarRomanizationStep({
   context,
   grammarContent,
 }: {
-  context: LessonContext;
+  context: RomanizationStepContext;
   grammarContent: GrammarContent;
 }): Promise<{ romanizations: Record<string, string> | null }> {
   "use step";
@@ -19,6 +20,7 @@ export async function generateGrammarRomanizationStep({
   const targetLanguage = context.chapter.course.targetLanguage ?? "";
 
   if (!needsRomanization(targetLanguage)) {
+    await streamSkipStep("generateGrammarRomanization");
     return { romanizations: null };
   }
 

--- a/apps/api/src/workflows/lesson-generation/steps/generate-reading-romanization-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-reading-romanization-step.test.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from "node:crypto";
+import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { generateLessonRomanization } from "@zoonk/ai/tasks/lessons/language/romanization";
-import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { createLessonContext } from "./_test-utils/create-lesson-context";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createRomanizationLessonContext } from "./_test-utils/create-romanization-lesson-context";
 import { generateReadingRomanizationStep } from "./generate-reading-romanization-step";
 
 vi.mock("@zoonk/ai/tasks/lessons/language/romanization", () => ({
@@ -16,13 +16,6 @@ vi.mock("@zoonk/ai/tasks/lessons/language/romanization", () => ({
 }));
 
 describe(generateReadingRomanizationStep, () => {
-  let organizationId: string;
-
-  beforeAll(async () => {
-    const organization = await aiOrganizationFixture();
-    organizationId = organization.id;
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -32,11 +25,7 @@ describe(generateReadingRomanizationStep, () => {
     const catWord = `猫${uniqueId}`;
     const waterWord = `水${uniqueId}`;
 
-    const context = await createLessonContext({
-      kind: "reading",
-      organizationId,
-      targetLanguage: "ja",
-    });
+    const context = createRomanizationLessonContext({ targetLanguage: "ja" });
 
     const sentence = `${catWord} ${waterWord}`;
     const sentences = [{ explanation: "", sentence, translation: "cat and water" }];
@@ -48,6 +37,26 @@ describe(generateReadingRomanizationStep, () => {
     expect(generateLessonRomanization).toHaveBeenCalledWith({
       targetLanguage: "ja",
       texts: [sentence],
+    });
+  });
+
+  it("streams completion when romanization is skipped for Roman-script languages", async () => {
+    const context = createRomanizationLessonContext({ targetLanguage: "es" });
+
+    await expect(
+      generateReadingRomanizationStep({
+        context,
+        sentences: [
+          { explanation: "", sentence: "el gato bebe agua", translation: "the cat drinks water" },
+        ],
+      }),
+    ).resolves.toStrictEqual({ romanizations: {} });
+
+    expect(generateLessonRomanization).not.toHaveBeenCalled();
+
+    expect(getStreamedEvents()).toContainEqual({
+      status: "completed",
+      step: "generateReadingRomanization",
     });
   });
 });

--- a/apps/api/src/workflows/lesson-generation/steps/generate-reading-romanization-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-reading-romanization-step.ts
@@ -1,15 +1,16 @@
+import { streamSkipStep } from "@/workflows/_shared/stream-skip-step";
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type LessonStepName } from "@zoonk/core/workflows/steps";
 import { needsRomanization } from "@zoonk/utils/languages";
 import { generateLessonRomanizations } from "./_utils/generate-lesson-romanizations";
 import { type ReadingLessonContent } from "./_utils/generated-lesson-content";
-import { type LessonContext } from "./get-lesson-step";
+import { type RomanizationStepContext } from "./_utils/romanization-step-context";
 
 export async function generateReadingRomanizationStep({
   context,
   sentences,
 }: {
-  context: LessonContext;
+  context: RomanizationStepContext;
   sentences: ReadingLessonContent["sentences"];
 }): Promise<{ romanizations: Record<string, string> }> {
   "use step";
@@ -17,6 +18,7 @@ export async function generateReadingRomanizationStep({
   const targetLanguage = context.chapter.course.targetLanguage ?? "";
 
   if (sentences.length === 0 || !needsRomanization(targetLanguage)) {
+    await streamSkipStep("generateReadingRomanization");
     return { romanizations: {} };
   }
 

--- a/apps/api/src/workflows/lesson-generation/steps/generate-vocabulary-romanization-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-vocabulary-romanization-step.test.ts
@@ -1,7 +1,7 @@
+import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { generateLessonRomanization } from "@zoonk/ai/tasks/lessons/language/romanization";
-import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { createLessonContext } from "./_test-utils/create-lesson-context";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createRomanizationLessonContext } from "./_test-utils/create-romanization-lesson-context";
 import { generateVocabularyRomanizationStep } from "./generate-vocabulary-romanization-step";
 
 vi.mock("@zoonk/ai/tasks/lessons/language/romanization", () => ({
@@ -15,19 +15,12 @@ vi.mock("@zoonk/ai/tasks/lessons/language/romanization", () => ({
 }));
 
 describe(generateVocabularyRomanizationStep, () => {
-  let organizationId: string;
-
-  beforeAll(async () => {
-    const organization = await aiOrganizationFixture();
-    organizationId = organization.id;
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("generates romanizations for vocabulary words", async () => {
-    const context = await createLessonContext({ organizationId, targetLanguage: "ja" });
+    const context = createRomanizationLessonContext({ targetLanguage: "ja" });
     const catWord = "猫";
     const dogWord = "犬";
     const words = [catWord, dogWord];
@@ -37,5 +30,20 @@ describe(generateVocabularyRomanizationStep, () => {
     });
 
     expect(generateLessonRomanization).toHaveBeenCalledWith({ targetLanguage: "ja", texts: words });
+  });
+
+  it("streams completion when romanization is skipped for Roman-script languages", async () => {
+    const context = createRomanizationLessonContext({ targetLanguage: "es" });
+
+    await expect(
+      generateVocabularyRomanizationStep({ context, words: ["gato"] }),
+    ).resolves.toStrictEqual({ romanizations: {} });
+
+    expect(generateLessonRomanization).not.toHaveBeenCalled();
+
+    expect(getStreamedEvents()).toContainEqual({
+      status: "completed",
+      step: "generateVocabularyRomanization",
+    });
   });
 });

--- a/apps/api/src/workflows/lesson-generation/steps/generate-vocabulary-romanization-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-vocabulary-romanization-step.ts
@@ -1,14 +1,15 @@
+import { streamSkipStep } from "@/workflows/_shared/stream-skip-step";
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type LessonStepName } from "@zoonk/core/workflows/steps";
 import { needsRomanization } from "@zoonk/utils/languages";
 import { generateLessonRomanizations } from "./_utils/generate-lesson-romanizations";
-import { type LessonContext } from "./get-lesson-step";
+import { type RomanizationStepContext } from "./_utils/romanization-step-context";
 
 export async function generateVocabularyRomanizationStep({
   context,
   words,
 }: {
-  context: LessonContext;
+  context: RomanizationStepContext;
   words: string[];
 }): Promise<{ romanizations: Record<string, string> }> {
   "use step";
@@ -16,6 +17,7 @@ export async function generateVocabularyRomanizationStep({
   const targetLanguage = context.chapter.course.targetLanguage ?? "";
 
   if (words.length === 0 || !needsRomanization(targetLanguage)) {
+    await streamSkipStep("generateVocabularyRomanization");
     return { romanizations: {} };
   }
 


### PR DESCRIPTION
## Summary
- Stream a completed event when vocabulary, reading, or grammar romanization is skipped for Roman-script languages.
- Narrow the romanization step context to the lesson fields those steps actually read.
- Add focused API tests covering the skipped-path stream behavior.

## Testing
- `pnpm --filter api test src/workflows/lesson-generation/steps/generate-vocabulary-romanization-step.test.ts src/workflows/lesson-generation/steps/generate-reading-romanization-step.test.ts src/workflows/lesson-generation/steps/generate-grammar-romanization-step.test.ts`
- `pnpm --filter api typecheck`
- Scoped `oxfmt --check` and `oxlint --deny-warnings` passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stream a completed event when romanization is skipped for Roman‑script languages, so lesson generation doesn’t hang. Also narrowed romanization steps to only read the target language and added focused tests.

- **Bug Fixes**
  - Emit `completed` via `streamSkipStep` when skipping romanization in vocabulary, reading, and grammar steps.
  - Return empty results without calling the romanization task.

- **Refactors**
  - Introduced `RomanizationStepContext` scoped to `chapter.course.targetLanguage` and a minimal `createRomanizationLessonContext` test util.
  - Added targeted tests to verify skip-path streaming behavior.

<sup>Written for commit 3fdd75157a6f0d3a7f391f6b1889cf63b322ae25. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1513?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

