### PR TITLE
fix(main): rename lesson thumb phase and move it earlier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,7 +213,7 @@ How to verify your work:
 - pnpm build --filter <app>
 - pnpm test --filter <app>
 - pnpm e2e --filter <app>
-- pnpm i18n
+- pnpm i18n to check translations, no need for msgfmt --check
 
 ## Docs
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1285,12 +1285,12 @@ msgid "W2b0tx"
 msgstr "Designing the lesson thumbnail..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "4TTl72"
-msgstr "Creating the lesson image..."
+msgid "fRAHqN"
+msgstr "Creating the lesson thumbnail..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "6k562E"
-msgstr "Refining the lesson artwork..."
+msgid "elwtxf"
+msgstr "Refining the lesson thumbnail..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "uDzgwu"
@@ -1585,8 +1585,8 @@ msgid "aKNA/b"
 msgstr "Creating images"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "tcyV4j"
-msgstr "Creating lesson image"
+msgid "WI2yui"
+msgstr "Creating lesson thumbnail"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "mIpv67"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1285,12 +1285,12 @@ msgid "W2b0tx"
 msgstr "Diseñando la miniatura de la lección..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "4TTl72"
-msgstr "Creando la imagen de la lección..."
+msgid "fRAHqN"
+msgstr "Creando la miniatura de la lección..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "6k562E"
-msgstr "Refinando la imagen de la lección..."
+msgid "elwtxf"
+msgstr "Refinando la miniatura de la lección..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "uDzgwu"
@@ -1585,8 +1585,8 @@ msgid "aKNA/b"
 msgstr "Creando imágenes"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "tcyV4j"
-msgstr "Creando imagen de la lección"
+msgid "WI2yui"
+msgstr "Creando miniatura de la lección"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "mIpv67"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1285,12 +1285,12 @@ msgid "W2b0tx"
 msgstr "Criando a miniatura da aula..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "4TTl72"
-msgstr "Criando a imagem da aula..."
+msgid "fRAHqN"
+msgstr "Criando a miniatura da aula..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "6k562E"
-msgstr "Ajustando a arte da aula..."
+msgid "elwtxf"
+msgstr "Refinando a miniatura da aula..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "uDzgwu"
@@ -1585,8 +1585,8 @@ msgid "aKNA/b"
 msgstr "Criando imagens"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "tcyV4j"
-msgstr "Criando imagem da aula"
+msgid "WI2yui"
+msgstr "Criando miniatura da aula"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "mIpv67"

--- a/apps/main/src/app/generate/l/[id]/generation-phases.test.ts
+++ b/apps/main/src/app/generate/l/[id]/generation-phases.test.ts
@@ -15,10 +15,10 @@ describe(getPhaseOrder, () => {
   it("keeps explanation generation split into content, visual planning, images, and saving", () => {
     expect(getPhaseOrder("explanation")).toStrictEqual([
       "gettingStarted",
+      "creatingLessonImage",
       "writingContent",
       "preparingImages",
       "creatingImages",
-      "creatingLessonImage",
       "saving",
     ]);
   });

--- a/apps/main/src/app/generate/l/[id]/phase-kind-steps/explanation.ts
+++ b/apps/main/src/app/generate/l/[id]/phase-kind-steps/explanation.ts
@@ -30,9 +30,9 @@ type _ValidateExplanation = AssertAllCovered<
 
 export const EXPLANATION_PHASE_ORDER: PhaseName[] = [
   "gettingStarted",
+  "creatingLessonImage",
   "writingContent",
   "preparingImages",
   "creatingImages",
-  "creatingLessonImage",
   "saving",
 ];

--- a/apps/main/src/app/generate/l/[id]/phase-kind-steps/tutorial.ts
+++ b/apps/main/src/app/generate/l/[id]/phase-kind-steps/tutorial.ts
@@ -27,9 +27,9 @@ type _ValidateTutorial = AssertAllCovered<
 
 export const TUTORIAL_PHASE_ORDER: PhaseName[] = [
   "gettingStarted",
+  "creatingLessonImage",
   "writingContent",
   "preparingImages",
   "creatingImages",
-  "creatingLessonImage",
   "saving",
 ];

--- a/apps/main/src/app/generate/l/[id]/phase-thinking-generators/content.ts
+++ b/apps/main/src/app/generate/l/[id]/phase-thinking-generators/content.ts
@@ -44,8 +44,8 @@ export function useContentPhaseGenerators(): Partial<Record<PhaseName, ThinkingM
       cycleMessage(
         [
           t("Designing the lesson thumbnail..."),
-          t("Creating the lesson image..."),
-          t("Refining the lesson artwork..."),
+          t("Creating the lesson thumbnail..."),
+          t("Refining the lesson thumbnail..."),
         ],
         index,
       ),

--- a/apps/main/src/app/generate/l/[id]/use-phase-labels.ts
+++ b/apps/main/src/app/generate/l/[id]/use-phase-labels.ts
@@ -17,7 +17,7 @@ export function usePhaseLabels(): Record<PhaseName, string> {
     creatingAnswerOptions: t("Preparing options"),
     creatingExercises: t("Creating exercises"),
     creatingImages: t("Creating images"),
-    creatingLessonImage: t("Creating lesson image"),
+    creatingLessonImage: t("Creating lesson thumbnail"),
     creatingSentences: t("Creating sentences"),
     gettingStarted: t("Getting started"),
     lookingUpWords: t("Looking up words"),


### PR DESCRIPTION
## Summary
- Rename the lesson thumbnail phase copy from “Creating lesson image” to “Creating lesson thumbnail” across the main app and translations
- Move that phase ahead of “Writing the content” for explanation and tutorial lesson generation
- Update the lesson phase-order test to match the new visible timeline

## Testing
- Updated the affected phase-order test to cover the new ordering
- Translation files were rechecked after extraction and the new strings were filled in

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the lesson phase to “Creating lesson thumbnail” and moved it before “Writing content” for explanation and tutorial generation to better match the flow and UI.

- **Refactors**
  - Reordered the phase earlier in both explanation and tutorial timelines.
  - Updated phase label and cycle messages to use “thumbnail”.
  - Synced translations in `en.po`, `es.po`, and `pt.po`.
  - Adjusted the phase-order test to reflect the new order.
  - Clarified `pnpm i18n` usage in `AGENTS.md`.

<sup>Written for commit a9993a3cc42fa4a94229591ffe60ab34c6dfb06f. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1514?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

