### PR TITLE
fix(main): prevent category pill vertical scroll jitter

### DIFF
--- a/apps/main/e2e/horizontal-scroll.test.ts
+++ b/apps/main/e2e/horizontal-scroll.test.ts
@@ -21,4 +21,19 @@ test.describe("Horizontal Scroll - Category Pills", () => {
     const scrollLeft = page.getByRole("button", { name: /scroll left/iu });
     await expect(scrollLeft).toBeVisible();
   });
+
+  test("category pill row cannot scroll vertically", async ({ page }) => {
+    await page.goto("/courses");
+
+    const categories = page.getByRole("navigation", { name: /course categories/iu });
+    await expect(categories).toBeVisible();
+
+    const verticalScrollRange = await categories.evaluate((nav) => {
+      const scrollTarget = nav.parentElement;
+
+      return scrollTarget ? scrollTarget.scrollHeight - scrollTarget.clientHeight : null;
+    });
+
+    expect(verticalScrollRange).toBe(0);
+  });
 });

--- a/apps/main/src/app/(catalog)/courses/category-pills.tsx
+++ b/apps/main/src/app/(catalog)/courses/category-pills.tsx
@@ -32,11 +32,7 @@ export function CategoryPills({
 
   return (
     <HorizontalScroll>
-      <HorizontalScrollContent
-        aria-label={t("Course categories")}
-        className="pb-0"
-        role="navigation"
-      >
+      <HorizontalScrollContent aria-label={t("Course categories")} role="navigation">
         <Link
           className={buttonVariants({
             size: "sm",

--- a/packages/ui/src/components/horizontal-scroll.tsx
+++ b/packages/ui/src/components/horizontal-scroll.tsx
@@ -41,7 +41,7 @@ function HorizontalScroll({ className, children, ...props }: React.ComponentProp
     <div className={cn("relative", className)} data-slot="horizontal-scroll" {...props}>
       <div
         className={cn(
-          "scrollbar-none overflow-x-auto [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden",
+          "scrollbar-none overflow-x-auto overflow-y-hidden [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden",
           canScrollLeft &&
             canScrollRight &&
             "mask-[linear-gradient(to_right,transparent,black_64px,black_calc(100%-64px),transparent)]",
@@ -85,7 +85,7 @@ function HorizontalScroll({ className, children, ...props }: React.ComponentProp
 function HorizontalScrollContent({ className, children, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("flex w-max min-w-full gap-2 px-4 pb-1", className)}
+      className={cn("flex w-max min-w-full gap-2 px-4 pb-2", className)}
       data-slot="horizontal-scroll-content"
       {...props}
     >


### PR DESCRIPTION
## Summary
- lock the shared horizontal scroll container to the horizontal axis
- keep the category pill row from gaining vertical scroll range
- add an e2e regression that checks the pill row cannot scroll vertically

## Testing
- Playwright e2e coverage added for the category pill scroll behavior
- formatting, lint, and typecheck passed locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes vertical scroll jitter in the course category pills by locking the shared horizontal scroll to the x-axis and preventing any vertical scroll range.

- **Bug Fixes**
  - UI: set `overflow-y-hidden` on `HorizontalScroll`, adjust bottom padding, and remove the extra padding override in `CategoryPills` to stop vertical movement.
  - Tests: add a Playwright check that the category nav has zero vertical scroll range.

<sup>Written for commit b9a31d77b1ad8f1f28bd1c3d691ba9be10ab9f49. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1515?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

