### PR TITLE
feat(main): add new catalog layout variant

### DIFF
--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
@@ -20,10 +20,12 @@ export function ChapterHeader({
   brandSlug,
   chapter,
   courseSlug,
+  variant,
 }: {
   brandSlug: string;
   chapter: ChapterWithDetails;
   courseSlug: string;
+  variant?: "default" | "sidebar";
 }) {
   const chapterNumber = chapter.position + 1;
 
@@ -31,7 +33,7 @@ export function ChapterHeader({
     chapter.imageUrl ?? getDefaultChapterImage({ categories: chapter.course.categories });
 
   return (
-    <MediaCard>
+    <MediaCard variant={variant}>
       <CatalogHeaderImage alt={chapter.title} src={chapterImage} />
 
       <MediaCardContent>

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -146,7 +146,7 @@ export async function LessonList({
     <GridContent>
       <CatalogGridSearch items={searchItems} placeholder={t("Search lessons...")}>
         <CatalogGridEmpty>{t("No lessons found")}</CatalogGridEmpty>
-        <GridGroup>
+        <GridGroup variant="pane">
           {lessonRows.map(({ display, lesson }) => {
             const completion = completionMap.get(lesson.id);
             const isCompleted = completion?.isCompleted ?? false;

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/loading.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/loading.tsx
@@ -1,9 +1,5 @@
 import { CatalogPageSkeleton } from "@/components/catalog/catalog-skeletons";
 
 export default function ChapterLoading() {
-  return (
-    <main className="flex flex-1 flex-col gap-4">
-      <CatalogPageSkeleton />
-    </main>
-  );
+  return <CatalogPageSkeleton />;
 }

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -1,4 +1,5 @@
 import { CatalogActions } from "@/components/catalog/catalog-actions";
+import { CatalogDetailLayout } from "@/components/catalog/catalog-detail-layout";
 import { CatalogGridSkeleton } from "@/components/catalog/catalog-skeletons";
 import {
   ContinueLessonLink,
@@ -62,26 +63,36 @@ export default async function ChapterPage({
     : undefined;
 
   return (
-    <main className="flex flex-1 flex-col gap-6 py-2">
-      <ChapterHeader brandSlug={brandSlug} chapter={chapter} courseSlug={courseSlug} />
-
-      <Grid>
-        <GridToolbar>
-          <Suspense fallback={<ContinueLessonLinkSkeleton />}>
-            <ContinueLessonLink
-              chapterId={chapter.id}
-              completedHref={completedHref}
-              fallbackHref={fallbackHref}
-            />
-          </Suspense>
-          <CatalogActions
-            contentId={`${courseSlug}/${chapterSlug}`}
-            defaultEmail={session?.user.email}
-            kind="chapter"
+    <CatalogDetailLayout
+      sidebar={
+        <>
+          <ChapterHeader
+            brandSlug={brandSlug}
+            chapter={chapter}
+            courseSlug={courseSlug}
+            variant="sidebar"
           />
-        </GridToolbar>
-
-        <Suspense fallback={<CatalogGridSkeleton count={lessons.length} search />}>
+          <GridToolbar>
+            <Suspense fallback={<ContinueLessonLinkSkeleton />}>
+              <ContinueLessonLink
+                chapterId={chapter.id}
+                completedHref={completedHref}
+                fallbackHref={fallbackHref}
+              />
+            </Suspense>
+            <CatalogActions
+              contentId={`${courseSlug}/${chapterSlug}`}
+              defaultEmail={session?.user.email}
+              kind="chapter"
+            />
+          </GridToolbar>
+        </>
+      }
+    >
+      <Grid variant="pane">
+        <Suspense
+          fallback={<CatalogGridSkeleton count={lessons.length} groupVariant="pane" search />}
+        >
           <LessonList
             brandSlug={brandSlug}
             chapterId={chapter.id}
@@ -91,6 +102,6 @@ export default async function ChapterPage({
           />
         </Suspense>
       </Grid>
-    </main>
+    </CatalogDetailLayout>
   );
 }

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -184,7 +184,7 @@ export async function ChapterList({
     <GridContent>
       <CatalogGridSearch items={chapters} placeholder={t("Search chapters...")}>
         <CatalogGridEmpty>{t("No chapters found")}</CatalogGridEmpty>
-        <GridGroup>
+        <GridGroup variant="pane">
           {chapters.map((chapter) => {
             const completion = completionMap.get(chapter.id);
             const completedLessons = completion?.completedLessons ?? 0;

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-header.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-header.tsx
@@ -25,9 +25,11 @@ import Link from "next/link";
 export async function CourseHeader({
   brandSlug,
   course,
+  variant,
 }: {
   brandSlug: string;
   course: CourseWithDetails;
+  variant?: "default" | "sidebar";
 }) {
   const categoryLabels = await getCategories();
   const courseCategoryKeys = new Set(course.categories.map((item) => item.category));
@@ -35,7 +37,7 @@ export async function CourseHeader({
   const displayCategories = categoryLabels.filter((cat) => courseCategoryKeys.has(cat.key));
 
   return (
-    <MediaCard>
+    <MediaCard variant={variant}>
       {course.imageUrl ? (
         <CatalogHeaderImage alt={course.title} src={course.imageUrl} />
       ) : (

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/loading.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/loading.tsx
@@ -1,9 +1,5 @@
 import { CatalogPageSkeleton } from "@/components/catalog/catalog-skeletons";
 
 export default function CourseLoading() {
-  return (
-    <main className="flex flex-1 flex-col gap-4">
-      <CatalogPageSkeleton />
-    </main>
-  );
+  return <CatalogPageSkeleton />;
 }

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
@@ -1,4 +1,5 @@
 import { CatalogActions } from "@/components/catalog/catalog-actions";
+import { CatalogDetailLayout } from "@/components/catalog/catalog-detail-layout";
 import { CatalogGridSkeleton } from "@/components/catalog/catalog-skeletons";
 import {
   ContinueLessonLink,
@@ -60,18 +61,27 @@ export default async function CoursePage({ params }: PageProps<"/b/[brandSlug]/c
   const defaultChapterImage = getDefaultChapterImage({ categories: course.categories });
 
   return (
-    <main className="flex flex-1 flex-col gap-6 py-2">
-      <CourseHeader brandSlug={brandSlug} course={course} />
-
-      <Grid>
-        <GridToolbar>
-          <Suspense fallback={<ContinueLessonLinkSkeleton />}>
-            <ContinueLessonLink courseId={course.id} fallbackHref={fallbackHref} />
-          </Suspense>
-          <CatalogActions contentId={courseSlug} defaultEmail={session?.user.email} kind="course" />
-        </GridToolbar>
-
-        <Suspense fallback={<CatalogGridSkeleton count={chapters.length} search />}>
+    <CatalogDetailLayout
+      sidebar={
+        <>
+          <CourseHeader brandSlug={brandSlug} course={course} variant="sidebar" />
+          <GridToolbar>
+            <Suspense fallback={<ContinueLessonLinkSkeleton />}>
+              <ContinueLessonLink courseId={course.id} fallbackHref={fallbackHref} />
+            </Suspense>
+            <CatalogActions
+              contentId={courseSlug}
+              defaultEmail={session?.user.email}
+              kind="course"
+            />
+          </GridToolbar>
+        </>
+      }
+    >
+      <Grid variant="pane">
+        <Suspense
+          fallback={<CatalogGridSkeleton count={chapters.length} groupVariant="pane" search />}
+        >
           <ChapterList
             brandSlug={brandSlug}
             chapters={chapters}
@@ -81,6 +91,6 @@ export default async function CoursePage({ params }: PageProps<"/b/[brandSlug]/c
           />
         </Suspense>
       </Grid>
-    </main>
+    </CatalogDetailLayout>
   );
 }

--- a/apps/main/src/components/catalog/catalog-detail-layout.tsx
+++ b/apps/main/src/components/catalog/catalog-detail-layout.tsx
@@ -1,0 +1,21 @@
+import { type ReactNode } from "react";
+
+/**
+ * Course and chapter detail pages need the same reading order on mobile, but a
+ * split layout on desktop so the content identity stays visible while learners
+ * scan the chapter or lesson list.
+ */
+export function CatalogDetailLayout({
+  children,
+  sidebar,
+}: {
+  children: ReactNode;
+  sidebar: ReactNode;
+}) {
+  return (
+    <main className="grid w-full flex-1 grid-cols-1 gap-6 px-4 pt-2 pb-8 md:pb-10 lg:grid-cols-[minmax(16rem,20rem)_minmax(0,1fr)] lg:items-start lg:gap-8 xl:grid-cols-[minmax(18rem,22rem)_minmax(0,1fr)]">
+      <aside className="flex min-w-0 flex-col gap-6 lg:sticky lg:top-20 lg:gap-4">{sidebar}</aside>
+      <section className="min-w-0">{children}</section>
+    </main>
+  );
+}

--- a/apps/main/src/components/catalog/catalog-header-image.tsx
+++ b/apps/main/src/components/catalog/catalog-header-image.tsx
@@ -13,7 +13,7 @@ export function CatalogHeaderImage({ alt, src }: { alt: string; src: ImageProps[
         className="size-full rounded-xl object-cover outline -outline-offset-1 outline-black/10 dark:outline-white/10"
         fill
         loading="eager"
-        sizes="(max-width: 640px) 120px, 160px"
+        sizes="(max-width: 640px) 120px, (max-width: 1024px) 160px, 352px"
         src={src}
       />
     </MediaCardImage>

--- a/apps/main/src/components/catalog/catalog-skeletons.tsx
+++ b/apps/main/src/components/catalog/catalog-skeletons.tsx
@@ -1,4 +1,5 @@
-import { Grid, GridSkeleton, GridToolbar } from "@zoonk/ui/components/grid";
+import { CatalogDetailLayout } from "@/components/catalog/catalog-detail-layout";
+import { Grid, type GridGroupVariant, GridSkeleton, GridToolbar } from "@zoonk/ui/components/grid";
 import { MediaCardSkeleton } from "@zoonk/ui/components/media-card";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 
@@ -8,9 +9,11 @@ import { Skeleton } from "@zoonk/ui/components/skeleton";
  */
 export function CatalogGridSkeleton({
   count,
+  groupVariant,
   search = false,
 }: {
   count: number;
+  groupVariant?: GridGroupVariant;
   search?: boolean;
 }) {
   return (
@@ -20,7 +23,7 @@ export function CatalogGridSkeleton({
           <Skeleton className="h-10 w-full rounded-md" />
         </div>
       )}
-      <GridSkeleton count={count} />
+      <GridSkeleton count={count} variant={groupVariant} />
     </div>
   );
 }
@@ -35,15 +38,20 @@ export function CatalogPageSkeleton({
   showSearch?: boolean;
 }) {
   return (
-    <>
-      <MediaCardSkeleton />
-      <Grid>
-        <GridToolbar>
-          <Skeleton className="h-10 flex-1 rounded-full" />
-          <Skeleton className="size-10 rounded-full" />
-        </GridToolbar>
-        <CatalogGridSkeleton count={listCount} search={showSearch} />
+    <CatalogDetailLayout
+      sidebar={
+        <>
+          <MediaCardSkeleton variant="sidebar" />
+          <GridToolbar>
+            <Skeleton className="h-10 flex-1 rounded-full" />
+            <Skeleton className="size-10 rounded-full" />
+          </GridToolbar>
+        </>
+      }
+    >
+      <Grid variant="pane">
+        <CatalogGridSkeleton count={listCount} groupVariant="pane" search={showSearch} />
       </Grid>
-    </>
+    </CatalogDetailLayout>
   );
 }

--- a/packages/ui/src/components/grid.tsx
+++ b/packages/ui/src/components/grid.tsx
@@ -11,17 +11,23 @@ import { CircleCheckIcon, CircleDashedIcon } from "lucide-react";
  * callers can change the catalog width in one component instead of repeating
  * page-level padding and max-width classes.
  */
-export function Grid({ className, ...props }: React.ComponentProps<"section">) {
+const gridVariants = cva("flex w-full flex-col gap-5", {
+  defaultVariants: { variant: "default" },
+  variants: {
+    variant: {
+      default: cn("mx-auto px-4 pb-8 md:pb-10", WIDE_CONTENT_MAX_WIDTH_CLASS),
+      pane: "pb-0 md:pb-0",
+    },
+  },
+});
+
+export type GridVariant = NonNullable<VariantProps<typeof gridVariants>["variant"]>;
+
+type GridProps = React.ComponentProps<"section"> & VariantProps<typeof gridVariants>;
+
+export function Grid({ className, variant, ...props }: GridProps) {
   return (
-    <section
-      className={cn(
-        "mx-auto flex w-full flex-col gap-5 px-4 pb-8 md:pb-10",
-        WIDE_CONTENT_MAX_WIDTH_CLASS,
-        className,
-      )}
-      data-slot="grid"
-      {...props}
-    />
+    <section className={cn(gridVariants({ variant }), className)} data-slot="grid" {...props} />
   );
 }
 
@@ -46,11 +52,27 @@ export function GridContent({ className, ...props }: React.ComponentProps<"div">
 /**
  * Grid groups define the shared responsive browsing rhythm for tile-based
  * collections without coupling the layout to any app-specific data or routing.
+ * The pane variant keeps card widths stable when a collection shares the
+ * viewport with a persistent info rail.
  */
-export function GridGroup({ className, ...props }: React.ComponentProps<"div">) {
+const gridGroupVariants = cva("grid grid-cols-1 gap-4", {
+  defaultVariants: { variant: "default" },
+  variants: {
+    variant: {
+      default: "sm:grid-cols-2 lg:grid-cols-3",
+      pane: "sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4",
+    },
+  },
+});
+
+export type GridGroupVariant = NonNullable<VariantProps<typeof gridGroupVariants>["variant"]>;
+
+type GridGroupProps = React.ComponentProps<"div"> & VariantProps<typeof gridGroupVariants>;
+
+export function GridGroup({ className, variant, ...props }: GridGroupProps) {
   return (
     <div
-      className={cn("grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3", className)}
+      className={cn(gridGroupVariants({ variant }), className)}
       data-slot="grid-group"
       role="list"
       {...props}
@@ -298,9 +320,15 @@ const DEFAULT_GRID_SKELETON_COUNT = 6;
  * The shared skeleton mirrors the same circular media, text block, and footer
  * rhythm as real grid items so loading states do not invent a second layout.
  */
-export function GridSkeleton({ count = DEFAULT_GRID_SKELETON_COUNT }: { count?: number }) {
+export function GridSkeleton({
+  count = DEFAULT_GRID_SKELETON_COUNT,
+  variant,
+}: {
+  count?: number;
+  variant?: GridGroupVariant;
+}) {
   return (
-    <GridGroup>
+    <GridGroup variant={variant}>
       {Array.from({ length: count }).map((_, index) => (
         // oxlint-disable-next-line eslint/no-array-index-key -- Static skeleton placeholders.
         <GridGroupItem key={index}>

--- a/packages/ui/src/components/media-card.tsx
+++ b/packages/ui/src/components/media-card.tsx
@@ -6,17 +6,35 @@ import { WIDE_CONTENT_MAX_WIDTH_CLASS } from "@zoonk/ui/components/layout";
 import { Popover, PopoverContent, PopoverTrigger } from "@zoonk/ui/components/popover";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { cn } from "@zoonk/ui/lib/utils";
+import { type VariantProps, cva } from "class-variance-authority";
 import { ChevronRightIcon, SparklesIcon } from "lucide-react";
 
-export function MediaCard({ children, className }: React.ComponentProps<"header">) {
+const mediaCardVariants = cva(
+  "mx-auto grid w-full grid-cols-[auto_minmax(0,1fr)] items-stretch gap-3 px-4 sm:gap-4",
+  {
+    defaultVariants: { variant: "default" },
+    variants: {
+      variant: {
+        default: WIDE_CONTENT_MAX_WIDTH_CLASS,
+        sidebar:
+          "max-w-none px-0 lg:grid-cols-1 lg:items-start lg:**:data-[slot=media-card-description]:line-clamp-5 lg:**:data-[slot=media-card-icon]:h-auto lg:**:data-[slot=media-card-icon]:min-h-0 lg:**:data-[slot=media-card-icon]:w-full lg:**:data-[slot=media-card-icon]:min-w-0 lg:**:data-[slot=media-card-image]:h-auto lg:**:data-[slot=media-card-image]:min-h-0 lg:**:data-[slot=media-card-image]:w-full lg:**:data-[slot=media-card-image]:min-w-0 lg:**:data-[slot=media-card-title]:text-2xl",
+      },
+    },
+  },
+);
+
+type MediaCardVariantProps = VariantProps<typeof mediaCardVariants>;
+
+export function MediaCard({
+  children,
+  className,
+  variant,
+}: React.ComponentProps<"header"> & MediaCardVariantProps) {
   return (
     <Popover>
       <header
-        className={cn(
-          "mx-auto grid w-full grid-cols-[auto_minmax(0,1fr)] items-stretch gap-3 px-4 sm:gap-4",
-          WIDE_CONTENT_MAX_WIDTH_CLASS,
-          className,
-        )}
+        className={cn(mediaCardVariants({ variant }), className)}
+        data-variant={variant}
         data-slot="media-card"
       >
         {children}
@@ -261,17 +279,25 @@ export function MediaCardPopoverAILabel({ children, className }: React.Component
   );
 }
 
-export function MediaCardSkeleton({ className }: { className?: string }) {
+export function MediaCardSkeleton({
+  className,
+  variant,
+}: { className?: string } & MediaCardVariantProps) {
+  const skeletonImageClassName =
+    variant === "sidebar" ? "lg:h-auto lg:min-h-0 lg:min-w-0 lg:w-full" : undefined;
+
   return (
     <header
-      className={cn(
-        "mx-auto grid w-full grid-cols-[auto_minmax(0,1fr)] items-stretch gap-3 px-4 sm:gap-4",
-        WIDE_CONTENT_MAX_WIDTH_CLASS,
-        className,
-      )}
+      className={cn(mediaCardVariants({ variant }), className)}
+      data-variant={variant}
       data-slot="media-card"
     >
-      <Skeleton className="aspect-square h-full min-h-20 min-w-20 rounded-xl sm:min-h-32 sm:min-w-32" />
+      <Skeleton
+        className={cn(
+          "aspect-square h-full min-h-20 min-w-20 rounded-xl sm:min-h-32 sm:min-w-32",
+          skeletonImageClassName,
+        )}
+      />
       <div className="flex min-w-0 flex-1 flex-col">
         <div className="grid grid-cols-[1fr_auto] items-center gap-1">
           <Skeleton className="h-5 w-3/4 sm:h-6" />


### PR DESCRIPTION
## Summary
- Added explicit `pane` variants to the shared `Grid` and `GridGroup` primitives instead of overriding `className` at the page level
- Updated course and chapter detail pages, their loading states, and the shared catalog skeletons to use the new variants
- Kept the split-layout shell and sidebar media treatment aligned with the new full-width detail pages

## Testing
- `pnpm --filter main typecheck`
- `pnpm --filter @zoonk/ui typecheck`
- `pnpm exec oxfmt --check`
- `pnpm exec oxlint --deny-warnings`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved catalog detail layout overrides into component variants and added a shared detail layout with a sticky sidebar to keep course/chapter identity visible while browsing. This stabilizes grid widths on desktop and simplifies page code.

- **Refactors**
  - Added `variant` props to `Grid` (`default` | `pane`), `GridGroup` (`default` | `pane`), and `MediaCard` (`default` | `sidebar`) in `@zoonk/ui` to replace page-level class overrides.
  - Introduced `CatalogDetailLayout` for a split layout (sticky sidebar + content pane) and applied it to course and chapter pages and their loading states.
  - Updated headers and lists to use the new variants; aligned skeletons (`CatalogGridSkeleton`, `CatalogPageSkeleton`, `GridSkeleton`, `MediaCardSkeleton`) with pane/sidebar layouts.
  - Improved `CatalogHeaderImage` responsive `sizes` for better image loading.

<sup>Written for commit 4af589812a43afae9149d95ba9db175272518bdb. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1517?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

