### PR TITLE
feat(main): add smooth floating back-to-top action to catalog grids

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1677,6 +1677,10 @@ msgstr "Not helpful"
 msgid "G5YSJR"
 msgstr "Send feedback"
 
+#: src/components/catalog/catalog-grid.tsx
+msgid "Gs9Kfp"
+msgstr "Back to top"
+
 #: src/components/catalog/continue-lesson-link.tsx
 msgid "mOFG3K"
 msgstr "Start"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1677,6 +1677,10 @@ msgstr "No es útil"
 msgid "G5YSJR"
 msgstr "Enviar comentarios"
 
+#: src/components/catalog/catalog-grid.tsx
+msgid "Gs9Kfp"
+msgstr "Volver arriba"
+
 #: src/components/catalog/continue-lesson-link.tsx
 msgid "mOFG3K"
 msgstr "Comenzar"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1677,6 +1677,10 @@ msgstr "Não foi útil"
 msgid "G5YSJR"
 msgstr "Enviar opinião"
 
+#: src/components/catalog/catalog-grid.tsx
+msgid "Gs9Kfp"
+msgstr "Voltar ao topo"
+
 #: src/components/catalog/continue-lesson-link.tsx
 msgid "mOFG3K"
 msgstr "Começar"

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -1,4 +1,5 @@
 import {
+  CatalogGridContent,
   CatalogGridEmpty,
   CatalogGridItem,
   CatalogGridSearch,
@@ -9,7 +10,6 @@ import { getLessonDisplayMeta } from "@/lib/lessons";
 import { getLessonProgress } from "@zoonk/core/progress/lessons";
 import { type Lesson } from "@zoonk/db";
 import {
-  GridContent,
   GridGroup,
   GridItemContent,
   GridItemDescription,
@@ -143,7 +143,7 @@ export async function LessonList({
   }));
 
   return (
-    <GridContent>
+    <CatalogGridContent>
       <CatalogGridSearch items={searchItems} placeholder={t("Search lessons...")}>
         <CatalogGridEmpty>{t("No lessons found")}</CatalogGridEmpty>
         <GridGroup variant="pane">
@@ -167,6 +167,6 @@ export async function LessonList({
           })}
         </GridGroup>
       </CatalogGridSearch>
-    </GridContent>
+    </CatalogGridContent>
   );
 }

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -1,4 +1,5 @@
 import {
+  CatalogGridContent,
   CatalogGridEmpty,
   CatalogGridItem,
   CatalogGridSearch,
@@ -7,7 +8,6 @@ import { CatalogGridImage } from "@/components/catalog/catalog-grid-image";
 import { type CourseChapter } from "@/data/chapters/list-course-chapters";
 import { getChapterProgress } from "@zoonk/core/progress/chapters";
 import {
-  GridContent,
   GridGroup,
   GridItemContent,
   GridItemDescription,
@@ -181,7 +181,7 @@ export async function ChapterList({
   const completionMap = new Map(completionData.map((row) => [row.chapterId, row]));
 
   return (
-    <GridContent>
+    <CatalogGridContent>
       <CatalogGridSearch items={chapters} placeholder={t("Search chapters...")}>
         <CatalogGridEmpty>{t("No chapters found")}</CatalogGridEmpty>
         <GridGroup variant="pane">
@@ -210,6 +210,6 @@ export async function ChapterList({
           })}
         </GridGroup>
       </CatalogGridSearch>
-    </GridContent>
+    </CatalogGridContent>
   );
 }

--- a/apps/main/src/app/(catalog)/courses/course-list-client.tsx
+++ b/apps/main/src/app/(catalog)/courses/course-list-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CatalogGridItem } from "@/components/catalog/catalog-grid";
+import { CatalogGridContent, CatalogGridItem } from "@/components/catalog/catalog-grid";
 import { CatalogGridImage } from "@/components/catalog/catalog-grid-image";
 import { type CourseWithOrg } from "@/data/courses/list-courses";
 import {
@@ -80,7 +80,7 @@ export function CourseListClient({
   }
 
   return (
-    <>
+    <CatalogGridContent>
       <GridGroup>
         {courses.map((course) => (
           <CourseTile course={course} key={course.id} />
@@ -95,6 +95,6 @@ export function CourseListClient({
           />
         )}
       </div>
-    </>
+    </CatalogGridContent>
   );
 }

--- a/apps/main/src/app/(catalog)/layout.tsx
+++ b/apps/main/src/app/(catalog)/layout.tsx
@@ -1,3 +1,4 @@
+import { CATALOG_TOP_TARGET_ID } from "@/components/catalog/catalog-top-target";
 import { getSession } from "@zoonk/core/users/session/get";
 import { AvatarSkeleton } from "@zoonk/ui/components/avatar";
 import { Navbar } from "@zoonk/ui/components/navbar";
@@ -22,6 +23,8 @@ export default function CatalogLayout({ children }: LayoutProps<"/">) {
           <UserAvatarMenu />
         </Suspense>
       </Navbar>
+
+      <div aria-hidden="true" className="scroll-mt-20" id={CATALOG_TOP_TARGET_ID} />
 
       {children}
     </div>

--- a/apps/main/src/components/catalog/catalog-grid.tsx
+++ b/apps/main/src/components/catalog/catalog-grid.tsx
@@ -1,21 +1,31 @@
 "use client";
 
-import { GridEmpty, GridGroupItem, GridItem } from "@zoonk/ui/components/grid";
+import {
+  GridBackToTop,
+  GridContent,
+  GridEmpty,
+  GridGroupItem,
+  GridItem,
+} from "@zoonk/ui/components/grid";
 import { Input } from "@zoonk/ui/components/input";
 import { cn } from "@zoonk/ui/lib/utils";
 import { normalizeString } from "@zoonk/utils/string";
 import { SearchIcon } from "lucide-react";
 import { type Route } from "next";
+import { useExtracted } from "next-intl";
 import Link from "next/link";
 import { useQueryState } from "nuqs";
-import { type ReactNode, useMemo } from "react";
+import { type MouseEvent, type ReactNode, useEffect, useMemo, useState } from "react";
 import { CatalogGridContext, useCatalogGridContext } from "./catalog-grid-context";
+import { CATALOG_TOP_TARGET_ID } from "./catalog-top-target";
 
 type CatalogGridSearchItem = {
   description?: string | null;
   id: string | number | bigint;
   title: string;
 };
+
+const BACK_TO_TOP_VISIBLE_SCROLL_Y = 360;
 
 /**
  * Catalog search should match the text learners scan inside each tile. Generated
@@ -38,6 +48,104 @@ function matchesCatalogSearchQuery({
   query: string;
 }): boolean {
   return normalizeString(getCatalogSearchText(item)).includes(query);
+}
+
+/**
+ * The floating top action should appear only after the reader has left the
+ * page header; showing it immediately would add chrome before it can help.
+ */
+function isBackToTopVisible({ scrollY }: { scrollY: number }): boolean {
+  return scrollY > BACK_TO_TOP_VISIBLE_SCROLL_Y;
+}
+
+/**
+ * Users who reduce motion should still get the same destination without the
+ * animated movement that can make scrolling feel uncomfortable.
+ */
+function getBackToTopScrollBehavior(): ScrollBehavior {
+  if (globalThis.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    return "auto";
+  }
+
+  return "smooth";
+}
+
+/**
+ * The anchor href stays as a no-JS fallback, but hydrated catalog pages should
+ * scroll smoothly so the jump back to the sticky navigation does not feel harsh.
+ */
+function handleBackToTopClick(event: MouseEvent<HTMLAnchorElement>) {
+  event.preventDefault();
+
+  const catalogTopTarget = globalThis.document.querySelector(`#${CATALOG_TOP_TARGET_ID}`);
+  catalogTopTarget?.scrollIntoView({ behavior: getBackToTopScrollBehavior(), block: "start" });
+}
+
+/**
+ * Long generated course grids need a reachable escape hatch while scrolling,
+ * so this centralized action follows the viewport instead of waiting for the
+ * user to reach the end of the collection.
+ */
+function CatalogGridBackToTop() {
+  const t = useExtracted();
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    /**
+     * Scroll position lives outside React, so the listener keeps this utility
+     * visible only when it can help without forcing every grid item to know
+     * anything about viewport state.
+     */
+    function syncBackToTopVisibility() {
+      const nextIsVisible = isBackToTopVisible({ scrollY: globalThis.scrollY });
+
+      setIsVisible((currentIsVisible) =>
+        currentIsVisible === nextIsVisible ? currentIsVisible : nextIsVisible,
+      );
+    }
+
+    syncBackToTopVisibility();
+    globalThis.addEventListener("scroll", syncBackToTopVisibility, { passive: true });
+
+    return () => globalThis.removeEventListener("scroll", syncBackToTopVisibility);
+  }, []);
+
+  return (
+    <GridBackToTop
+      aria-label={t("Back to top")}
+      className={cn(
+        "bg-background/85 border-border/40 fixed right-4 bottom-[calc(env(safe-area-inset-bottom)+1rem)] z-30 border shadow-[0_8px_24px_rgb(0_0_0/0.08)] backdrop-blur-md transition-all duration-150 md:right-6",
+        isVisible
+          ? "pointer-events-auto translate-y-0 opacity-100"
+          : "pointer-events-none translate-y-2 opacity-0",
+      )}
+      href={`#${CATALOG_TOP_TARGET_ID}`}
+      onClick={handleBackToTopClick}
+      title={t("Back to top")}
+    >
+      <span className="hidden sm:inline">{t("Back to top")}</span>
+    </GridBackToTop>
+  );
+}
+
+/**
+ * Catalog grids share the same floating utility action so course, chapter, and
+ * lesson pages can offer quick scroll recovery without duplicating viewport
+ * listeners or page-specific positioning.
+ */
+export function CatalogGridContent({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <GridContent className={className}>
+      {children}
+      <CatalogGridBackToTop />
+    </GridContent>
+  );
 }
 
 /**

--- a/apps/main/src/components/catalog/catalog-top-target.ts
+++ b/apps/main/src/components/catalog/catalog-top-target.ts
@@ -1,0 +1,1 @@
+export const CATALOG_TOP_TARGET_ID = "catalog-top";

--- a/packages/ui/src/components/grid.tsx
+++ b/packages/ui/src/components/grid.tsx
@@ -1,10 +1,11 @@
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
+import { buttonVariants } from "@zoonk/ui/components/button";
 import { WIDE_CONTENT_MAX_WIDTH_CLASS } from "@zoonk/ui/components/layout";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { cn } from "@zoonk/ui/lib/utils";
 import { type VariantProps, cva } from "class-variance-authority";
-import { CircleCheckIcon, CircleDashedIcon } from "lucide-react";
+import { ArrowUpIcon, CircleCheckIcon, CircleDashedIcon } from "lucide-react";
 
 /**
  * Grid frames provide the shared wide browsing column for tile-based pages, so
@@ -46,6 +47,36 @@ export function GridToolbar({ className, ...props }: React.ComponentProps<"div">
 export function GridContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div className={cn("flex flex-col gap-6", className)} data-slot="grid-content" {...props} />
+  );
+}
+
+type GridBackToTopProps = Omit<React.ComponentProps<"a">, "href"> & { href?: string };
+
+/**
+ * Back-to-top is a normal anchor because grid pages only need a quiet way back
+ * to the page header, and keeping the behavior browser-native avoids scroll
+ * state or page-specific client logic.
+ */
+export function GridBackToTop({
+  children,
+  className,
+  href = "#top",
+  ...props
+}: GridBackToTopProps) {
+  return (
+    <a
+      className={cn(
+        buttonVariants({ size: "sm", variant: "ghost" }),
+        "text-muted-foreground/80 hover:text-foreground px-2 text-xs",
+        className,
+      )}
+      data-slot="grid-back-to-top"
+      href={href}
+      {...props}
+    >
+      <ArrowUpIcon aria-hidden="true" className="size-3.5" />
+      {children}
+    </a>
   );
 }
 


### PR DESCRIPTION
## Summary
- Adds a subtle floating back-to-top control for catalog grid pages once the user scrolls down
- Reuses a shared catalog grid wrapper so courses, chapters, and lessons inherit the behavior without duplication
- Keeps a browser-native anchor fallback, but smooth-scrolls when hydrated and respects reduced motion

## Testing
- `pnpm --filter @zoonk/ui typecheck`
- `pnpm --filter main typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm i18n`
- Verified in the local browser on `/b/ai/c/japones-pt` that the control appears after scrolling and scrolls smoothly back to the top

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a floating “Back to top” action to catalog grids (courses, chapters, lessons). It appears after scrolling and smooth-scrolls to the header; respects reduced motion and works without JS.

- **New Features**
  - Introduced `GridBackToTop` in `@zoonk/ui` and `CatalogGridContent` so all catalog grids share the control and viewport logic.
  - Shows after ~360px scroll and scrolls to `#catalog-top` (added via `CATALOG_TOP_TARGET_ID` in catalog layout).
  - Updated course, chapter, and lesson lists to wrap content with `CatalogGridContent`.
  - Added “Back to top” i18n strings for en/es/pt; keeps anchor fallback and honors `prefers-reduced-motion`.

<sup>Written for commit dc0fb6d7e7c5897eb83d6f2fb9dfe63187058589. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1518?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

