### PR TITLE
fix(main): stabilize mobile catalog thumbnail sizing

### DIFF
--- a/apps/main/src/components/catalog/catalog-header-image.tsx
+++ b/apps/main/src/components/catalog/catalog-header-image.tsx
@@ -13,7 +13,7 @@ export function CatalogHeaderImage({ alt, src }: { alt: string; src: ImageProps[
         className="size-full rounded-xl object-cover outline -outline-offset-1 outline-black/10 dark:outline-white/10"
         fill
         loading="eager"
-        sizes="(max-width: 640px) 120px, (max-width: 1024px) 160px, 352px"
+        sizes="(max-width: 640px) 80px, (max-width: 1024px) 128px, 352px"
         src={src}
       />
     </MediaCardImage>

--- a/packages/ui/src/components/media-card.tsx
+++ b/packages/ui/src/components/media-card.tsx
@@ -17,13 +17,14 @@ const mediaCardVariants = cva(
       variant: {
         default: WIDE_CONTENT_MAX_WIDTH_CLASS,
         sidebar:
-          "max-w-none px-0 lg:grid-cols-1 lg:items-start lg:**:data-[slot=media-card-description]:line-clamp-5 lg:**:data-[slot=media-card-icon]:h-auto lg:**:data-[slot=media-card-icon]:min-h-0 lg:**:data-[slot=media-card-icon]:w-full lg:**:data-[slot=media-card-icon]:min-w-0 lg:**:data-[slot=media-card-image]:h-auto lg:**:data-[slot=media-card-image]:min-h-0 lg:**:data-[slot=media-card-image]:w-full lg:**:data-[slot=media-card-image]:min-w-0 lg:**:data-[slot=media-card-title]:text-2xl",
+          "max-w-none px-0 lg:grid-cols-1 lg:items-start lg:**:data-[slot=media-card-description]:line-clamp-5 lg:**:data-[slot=media-card-icon]:h-auto lg:**:data-[slot=media-card-icon]:w-full lg:**:data-[slot=media-card-image]:h-auto lg:**:data-[slot=media-card-image]:w-full lg:**:data-[slot=media-card-title]:text-2xl",
       },
     },
   },
 );
 
 type MediaCardVariantProps = VariantProps<typeof mediaCardVariants>;
+const MEDIA_CARD_MEDIA_CLASS = "aspect-square size-20 shrink-0 sm:size-32";
 
 export function MediaCard({
   children,
@@ -59,10 +60,7 @@ export function MediaCardTrigger({ children, className }: React.ComponentProps<"
 export function MediaCardImage({ children, className }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn(
-        "relative aspect-square h-full min-h-20 min-w-20 overflow-hidden rounded-xl sm:min-h-32 sm:min-w-32",
-        className,
-      )}
+      className={cn("relative overflow-hidden rounded-xl", MEDIA_CARD_MEDIA_CLASS, className)}
       data-slot="media-card-image"
     >
       {children}
@@ -74,7 +72,8 @@ export function MediaCardIcon({ children, className, ...props }: React.Component
   return (
     <div
       className={cn(
-        "bg-muted/70 flex aspect-square h-full min-h-20 min-w-20 items-center justify-center rounded-xl sm:min-h-32 sm:min-w-32",
+        "bg-muted/70 flex items-center justify-center rounded-xl",
+        MEDIA_CARD_MEDIA_CLASS,
         className,
       )}
       data-slot="media-card-icon"
@@ -283,8 +282,7 @@ export function MediaCardSkeleton({
   className,
   variant,
 }: { className?: string } & MediaCardVariantProps) {
-  const skeletonImageClassName =
-    variant === "sidebar" ? "lg:h-auto lg:min-h-0 lg:min-w-0 lg:w-full" : undefined;
+  const skeletonImageClassName = variant === "sidebar" ? "lg:h-auto lg:w-full" : undefined;
 
   return (
     <header
@@ -292,12 +290,7 @@ export function MediaCardSkeleton({
       data-variant={variant}
       data-slot="media-card"
     >
-      <Skeleton
-        className={cn(
-          "aspect-square h-full min-h-20 min-w-20 rounded-xl sm:min-h-32 sm:min-w-32",
-          skeletonImageClassName,
-        )}
-      />
+      <Skeleton className={cn("rounded-xl", MEDIA_CARD_MEDIA_CLASS, skeletonImageClassName)} />
       <div className="flex min-w-0 flex-1 flex-col">
         <div className="grid grid-cols-[1fr_auto] items-center gap-1">
           <Skeleton className="h-5 w-3/4 sm:h-6" />


### PR DESCRIPTION
## Summary
- Make the shared catalog media slot use a fixed square size on mobile/tablet so orientation changes do not inflate the course/chapter thumbnail.
- Keep the sidebar variant full-width on desktop while preserving the same square media contract in loading states.
- Update `next/image` `sizes` to match the smaller rendered mobile slot.

## Testing
- Lint and formatting checks passed on the touched files.
- Typecheck passed for `main` and `@zoonk/ui`.
- Verified the course and chapter headers in the local app with browser inspection across portrait, landscape, and reload states.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes mobile/tablet catalog thumbnails by locking a square media slot and matching `next/image` sizes to prevent orientation-based growth. Keeps the sidebar full-width on desktop while preserving the same square contract, including in loading states.

- **Bug Fixes**
  - Lock square thumbnail to `size-20`/`sm:size-32` on small screens to stop inflated course/chapter headers on rotate/reload.
  - Update `next/image` `sizes` from 120/160 to 80/128 to match the smaller rendered mobile slot.

- **Refactors**
  - Extract `MEDIA_CARD_MEDIA_CLASS` to unify image, icon, and skeleton dimensions and simplify sidebar overrides.

<sup>Written for commit 143970f857aadbc70d6ecada7b07387791224deb. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1519?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

