### PR TITLE
fix(ai): relax selectimage guidance

### DIFF
--- a/apps/evals/src/tasks/lesson-quiz/test-cases.ts
+++ b/apps/evals/src/tasks/lesson-quiz/test-cases.ts
@@ -24,7 +24,7 @@ EVALUATION CRITERIA:
    - Match columns: Best when the concept involves connecting observations to principles (symptoms to causes, effects to mechanisms).
    - Sort order: ONLY when the concept IS about sequence — when order matters conceptually (biological processes, compilation phases).
    - Fill blank: Best for completing relationships or processes where the blank tests conceptual understanding.
-   - Select image: ONLY when visual recognition genuinely tests understanding.
+   - Select image: Best when an image is the strongest way to test understanding, including visual recognition, comparing visible features, reading diagrams, or identifying spatial patterns.
 
    PENALIZE when:
    - Formats are used for variety rather than fit

--- a/packages/ai/src/tasks/lessons/core/lesson-quiz.prompt.md
+++ b/packages/ai/src/tasks/lessons/core/lesson-quiz.prompt.md
@@ -90,9 +90,9 @@ Use when the concept IS about sequence and order matters conceptually (e.g., ste
 
 ## selectImage
 
-Use SPARINGLY — only when visual recognition genuinely tests understanding better than text-based formats.
+Use when an image is the best way to test understanding, such as visual recognition, comparing visible features, reading diagrams, or identifying spatial patterns.
 
-- `question`: A scenario where visual identification demonstrates understanding
+- `question`: A scenario where image-based evidence helps the learner demonstrate understanding
 - `options`: 2-4 image options. Each has `prompt` (image generation prompt describing content, not style), `isCorrect`, and `feedback`
 - NEVER reference copyrighted or trademarked characters (e.g., Mickey Mouse, Spider-Man, Mario, Pikachu). Describe concepts abstractly or use generic, original characters instead
 


### PR DESCRIPTION
## Summary
- Remove the scarcity warning from the quiz prompt so `selectImage` is chosen when it is the best test format.
- Align the eval rubric with the same broader guidance.
- Reword the `question` description to emphasize image-based evidence instead of visual identification.

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxed `selectImage` quiz guidance so it’s used when images are the best way to test understanding, and aligned the eval rubric to match. Reworded the `question` field to emphasize image-based evidence over simple visual identification.

<sup>Written for commit 5f2c6b4c2dec29b47ad85fbfaf0d6adcdc8ecd36. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1520?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

