### PR TITLE
fix(ai): focus step image prompts

### DIFF
--- a/packages/ai/src/tasks/steps/step-content-image.prompt.md
+++ b/packages/ai/src/tasks/steps/step-content-image.prompt.md
@@ -2,19 +2,23 @@ Generate an educational illustration for a modern learning app.
 
 Style: Modern flat illustration with clean geometric shapes, a refined limited color palette (2-4 harmonious colors with soft tints and shades), generous white space, crisp edges without heavy outlines, subtle ambient shadows for depth, clean sans-serif typography when text is needed, balanced composition, and clear visual hierarchy. Keep the overall look polished, minimal, and educational.
 
+Primary goal: create a focused teaching image, not an infographic. The learner should understand the image in a few seconds.
+
 Art direction:
 
 - Use a clean white background.
 - Keep colors restrained and tasteful.
+- Show one clear focal point. Prefer a close crop of the important artifact, state, object, or clue over a complete system.
 - When the content needs a table, dashboard, form, label, diagram, or screen, render it in this same clean visual system.
-- If text appears in the image, keep it short, legible, and useful.
+- If text appears in the image, keep it short, large, legible, and useful. Use only the few labels needed to understand the focal point.
 - Compose around one centered primary artifact, scene, diagram, or screen. Avoid wide side-by-side layouts unless the prompt explicitly requires comparing two states.
-- If a comparison is required, stack the states vertically or place them inside one centered panel instead of spreading them across the full width.
-- For tables, dashboards, forms, code, diagrams, and screens, remove sidebars, browser chrome, file trees, toolbars, and extra columns unless they are the actual clue.
-- Avoid dense paragraphs, tiny unreadable text, photorealism, glossy 3D, neon gradients, generic screenshot aesthetics, and loud saturated backdrops.
+- If a comparison is required, compare only one difference between two small states. Stack them vertically or place them inside one centered panel instead of spreading them across the full width.
+- For tables, dashboards, forms, code, diagrams, and screens, remove sidebars, browser chrome, file trees, toolbars, extra columns, and extra cards unless they are the actual clue.
+- Avoid full-board overviews, posters, summary cards, multi-section layouts, legends, subtitles, conclusion boxes, icon lists, dense paragraphs, tiny unreadable text, photorealism, glossy 3D, neon gradients, generic screenshot aesthetics, and loud saturated backdrops.
 - Especially avoid heavy blue or purple background fills unless the prompt truly requires them.
 
 The illustration should clearly communicate the educational idea while staying easy to inspect and understand.
+Favor clarity over completeness. It is better to show fewer things clearly than many things weakly.
 
 LANGUAGE: **{{LANGUAGE}}**
 

--- a/packages/ai/src/tasks/steps/step-image-prompts.prompt.md
+++ b/packages/ai/src/tasks/steps/step-image-prompts.prompt.md
@@ -13,23 +13,28 @@ For each learning step, describe a single image that helps a learner understand 
 
 The image prompt should:
 
+- teach one learner takeaway, not summarize the whole step
 - focus on the concrete concept from the step
 - choose the clearest visual explanation for that specific step
 - be self-contained, so the image model does not need to see the original step text
-- show the relationships, comparisons, structure, or action that matter most for learning the concept
+- show only the relationship, comparison, structure, or action that matters most for learning the concept
 
 # Prompt Rules
 
 - Prefer concrete scenes, objects, and spatial relationships over abstract words.
-- Use whatever kind of image best teaches the step: a scene, process illustration, comparison graphic, labeled explanatory image, sequence, annotated close-up, simple chart-like composition, code-focused visual, or another clear teaching image.
-- Use labels, arrows, simple text, numbers, or structured layout inside the image when they genuinely help explain the concept better.
+- Use whatever focused image best teaches the step: a close-up, single artifact, cropped screen, small diagram, one-card example, one visible state, one concrete scene clue, or another clear teaching image.
+- Use labels, arrows, simple text, numbers, or structured layout inside the image only when they are the main evidence the learner must inspect.
 - Avoid defaulting to vague metaphors when a more direct explanatory image would teach better.
 - Avoid repeating the same metaphor or composition across multiple prompts in the same response unless the concept truly needs visual continuity.
 - Do not reference copyrighted or trademarked characters, logos, or brands.
 - If the step is abstract, choose the clearest visual explanation available. Use a metaphor only when it genuinely improves understanding.
+- Prefer a tight crop of the important part over a complete board, dashboard, workflow, document, timeline, or room.
 - Prefer one centered primary artifact, diagram, screen, scene, or object over a wide layout with many panels.
-- If a comparison is necessary, ask for two states stacked vertically or contained inside one centered panel, not spread across the full width.
+- If a comparison is necessary, compare only one difference between two small states stacked vertically or contained inside one centered panel, not spread across the full width.
 - For screens, dashboards, code, tables, forms, and documents, ask for only the relevant section. Do not include sidebars, browser chrome, file trees, toolbars, or extra columns unless they are the clue.
+- Keep generated text minimal: usually 1-4 short labels. Avoid paragraphs, legends, subtitles, explanations, conclusions, icon lists, and "why this matters" text inside the image.
+- Avoid asking for full infographics, posters, summary cards, multi-step timelines, many arrows, many icons, many columns, or many cards.
+- When the step involves a complex system, choose the smallest concrete slice that proves the idea instead of showing the entire system.
 
 # Quality Bar
 
@@ -37,7 +42,7 @@ Each prompt should make the image model answer:
 
 1. What is in the scene?
 2. What details matter?
-3. What relationship or action should be visible?
-4. Why would this image help a learner understand this step better?
+3. What single relationship or action should be visible?
+4. What should be left out so the image stays easy to inspect?
 
 Prefer the most educational image, not the most decorative one. Keep prompts concise but specific. One strong sentence is usually enough, but use two short sentences if needed for clarity.


### PR DESCRIPTION
## Summary

- tighten explanation step image prompt generation around one learner takeaway and one focal visual clue
- add downstream illustration guidance to avoid infographic-style dense images

## Verification

- pnpm format

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens image prompt templates in `packages/ai` to produce focused, single-takeaway teaching images and avoid infographic-style outputs. Updates rules to prefer tight crops, minimal labels, and small, scoped comparisons for clearer learning.

- **Refactors**
  - Tightened `step-content-image.prompt.md` and `step-image-prompts.prompt.md` to emphasize one focal point, tight crops, and 1–4 short labels; avoid posters, summary cards, and dense layouts.
  - Comparison and screen rules: show one difference only; stack vertically or within one centered panel; include only the relevant section and remove sidebars/chrome/extra columns/cards unless they are the clue.
  - Quality bar now asks for the single relationship to show and what to omit to keep the image easy to inspect.

<sup>Written for commit b1d942fc2a53afe9eb47684fd14a96da03cad4b5. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1521?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

