### PR TITLE
chore(ai): update to gpt-5.5

### DIFF
--- a/packages/ai/src/tasks/courses/language-course-chapters.ts
+++ b/packages/ai/src/tasks/courses/language-course-chapters.ts
@@ -5,7 +5,7 @@ import { type ReasoningEffort, buildProviderOptions } from "../../provider-optio
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./language-course-chapters.prompt.md";
 
-const defaultModel = "openai/gpt-5.4";
+const defaultModel = "openai/gpt-5.5";
 const fallbackModels = ["google/gemini-3.1-pro-preview", "anthropic/claude-sonnet-4.6"] as const;
 
 const schema = z.object({

--- a/packages/ai/src/tasks/lessons/core/lesson-practice.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-practice.ts
@@ -7,7 +7,7 @@ import { appendLessonRichTextPrompt } from "../_utils/append-lesson-rich-text-pr
 import { formatExplanationStepsForPrompt } from "./_utils/format-explanation-steps";
 import baseSystemPrompt from "./lesson-practice.prompt.md";
 
-const defaultModel = "openai/gpt-5.4";
+const defaultModel = "openai/gpt-5.5";
 const fallbackModels = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"] as const;
 const systemPrompt = appendLessonRichTextPrompt(baseSystemPrompt);
 

--- a/packages/ai/src/tasks/lessons/core/lesson-quiz.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-quiz.ts
@@ -6,7 +6,7 @@ import { getPromptLanguageName } from "../../_utils/prompt-language";
 import { formatExplanationStepsForPrompt } from "./_utils/format-explanation-steps";
 import systemPrompt from "./lesson-quiz.prompt.md";
 
-const defaultModel = "openai/gpt-5.4";
+const defaultModel = "openai/gpt-5.5";
 const fallbackModels = ["anthropic/claude-opus-4.6"] as const;
 
 const multipleChoiceSchema = z.object({

--- a/packages/ai/src/tasks/lessons/language/lesson-distractors.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-distractors.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { getPromptLanguageName } from "../../_utils/prompt-language";
 import systemPrompt from "./lesson-distractors.prompt.md";
 
-const defaultModel = "openai/gpt-5.4";
+const defaultModel = "openai/gpt-5.5";
 const fallbackModels = ["google/gemini-3.1-flash-lite", "anthropic/claude-sonnet-4.6"] as const;
 
 const schema = z.object({ distractors: z.array(z.string().min(1)).min(1) });

--- a/packages/ai/src/tasks/lessons/language/lesson-grammar-content.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-grammar-content.ts
@@ -7,7 +7,7 @@ import { formatConceptLines } from "../config";
 import systemPrompt from "./lesson-grammar-content.prompt.md";
 
 const defaultModel = "google/gemini-3.1-pro-preview";
-const fallbackModels = ["openai/gpt-5.4", "anthropic/claude-opus-4.6"] as const;
+const fallbackModels = ["openai/gpt-5.5", "anthropic/claude-opus-4.6"] as const;
 
 const exampleSchema = z.object({ highlight: z.string(), sentence: z.string() });
 

--- a/packages/ai/src/tasks/lessons/language/lesson-grammar-user-content.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-grammar-user-content.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { getLanguagePromptContext } from "../../_utils/prompt-language";
 import systemPrompt from "./lesson-grammar-user-content.prompt.md";
 
-const defaultModel = "openai/gpt-5.4";
+const defaultModel = "openai/gpt-5.5";
 const fallbackModels = ["anthropic/claude-opus-4.6", "google/gemini-3-flash"] as const;
 
 const schema = z.object({

--- a/packages/ai/src/tasks/lessons/language/lesson-romanization.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-romanization.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { getPromptLanguageName } from "../../_utils/prompt-language";
 import systemPrompt from "./lesson-romanization.prompt.md";
 
-const defaultModel = "openai/gpt-5.4";
+const defaultModel = "openai/gpt-5.5";
 const fallbackModels = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"] as const;
 
 const romanizationSchema = z.string().min(1);

--- a/packages/ai/src/tasks/lessons/language/lesson-sentences.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-sentences.ts
@@ -6,7 +6,7 @@ import { getLanguagePromptContext } from "../../_utils/prompt-language";
 import { formatConceptLines } from "../config";
 import systemPrompt from "./lesson-sentences.prompt.md";
 
-const defaultModel = "openai/gpt-5.4";
+const defaultModel = "openai/gpt-5.5";
 const fallbackModels = ["google/gemini-3.1-pro-preview", "anthropic/claude-opus-4.6"] as const;
 
 const sentenceSchema = z.object({

--- a/packages/ai/src/tasks/lessons/language/lesson-vocabulary.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-vocabulary.ts
@@ -7,7 +7,7 @@ import { formatConceptLines } from "../config";
 import systemPrompt from "./lesson-vocabulary.prompt.md";
 
 const defaultModel = "google/gemini-3-flash";
-const fallbackModels = ["google/gemini-3.1-pro-preview", "openai/gpt-5.4"] as const;
+const fallbackModels = ["google/gemini-3.1-pro-preview", "openai/gpt-5.5"] as const;
 
 const wordSchema = z.object({ translation: z.string(), word: z.string() });
 

--- a/packages/ai/src/tasks/lessons/tutorial/lesson-tutorial.ts
+++ b/packages/ai/src/tasks/lessons/tutorial/lesson-tutorial.ts
@@ -7,7 +7,7 @@ import { appendLessonRichTextPrompt } from "../_utils/append-lesson-rich-text-pr
 import baseSystemPrompt from "./lesson-tutorial.prompt.md";
 
 const defaultModel = "google/gemini-3-flash";
-const fallbackModels = ["anthropic/claude-opus-4.6", "openai/gpt-5.4"] as const;
+const fallbackModels = ["anthropic/claude-opus-4.6", "openai/gpt-5.5"] as const;
 const systemPrompt = appendLessonRichTextPrompt(baseSystemPrompt);
 
 const stepSchema = z.object({ text: z.string(), title: z.string() });

--- a/packages/ai/src/tasks/steps/step-image-prompts.ts
+++ b/packages/ai/src/tasks/steps/step-image-prompts.ts
@@ -5,7 +5,7 @@ import { type ReasoningEffort, buildProviderOptions } from "../../provider-optio
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./step-image-prompts.prompt.md";
 
-const defaultModel = "openai/gpt-5.4";
+const defaultModel = "openai/gpt-5.5";
 const fallbackModels = ["anthropic/claude-opus-4.6", "google/gemini-3.1-pro-preview"] as const;
 
 const imagePromptSchema = z.string().min(1);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches default OpenAI model from `openai/gpt-5.4` to `openai/gpt-5.5` across course, lesson, and step tasks. Aligns fallbacks to prefer `gpt-5.5` for consistency.

- **Dependencies**
  - Set `openai/gpt-5.5` as the default in course chapters, lesson generators, and image prompt steps.
  - Updated fallbacks to replace `openai/gpt-5.4` with `openai/gpt-5.5` where applicable.

<sup>Written for commit 80125163205407c7356baefb6bc1cae339663de0. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1524?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

