### PR TITLE
fix(player): strip ai quotes in match and sort labels

### DIFF
--- a/packages/player/src/_browser-tests/player-arrangement.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-arrangement.browser.test.tsx
@@ -63,6 +63,45 @@ describe("player browser integration: arrangement steps", () => {
     await expect.element(page.getByRole("heading", { name: "Match the pairs." })).toBeVisible();
   });
 
+  it("strips model-added wrapping quotes from match-column labels", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        steps: [
+          buildSerializedStep({
+            content: {
+              pairs: [
+                { left: '"Sun"', right: "“Day”" },
+                { left: "‘Moon’", right: '"Night"' },
+              ],
+              question: "Match each item",
+            },
+            id: "match-quoted-labels",
+            kind: "matchColumns",
+            matchColumnsRightItems: ["“Day”", '"Night"'],
+          }),
+        ],
+      }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    const sun = page.getByRole("button", { name: "Sun" });
+    const day = page.getByRole("button", { name: "Day" });
+    const moon = page.getByRole("button", { name: "Moon" });
+    const night = page.getByRole("button", { name: "Night" });
+
+    await expect.element(sun).toHaveTextContent(/^Sun$/u);
+    await expect.element(day).toHaveTextContent(/^Day$/u);
+    await expect.element(moon).toHaveTextContent(/^Moon$/u);
+    await expect.element(night).toHaveTextContent(/^Night$/u);
+
+    await sun.click();
+    await day.click();
+    await moon.click();
+    await night.click();
+
+    await expect.element(page.getByRole("button", { name: /check/iu })).toBeEnabled();
+  });
+
   it("keeps duplicate match-column labels selectable until each visible item is matched", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({
@@ -124,6 +163,43 @@ describe("player browser integration: arrangement steps", () => {
     });
 
     await expect.element(page.getByRole("button", { name: /check/iu })).toBeEnabled();
+    await page.getByRole("button", { name: /check/iu }).click();
+
+    await expect
+      .element(page.getByRole("region", { name: /answer feedback/iu }))
+      .toBeInTheDocument();
+  });
+
+  it("strips model-added wrapping quotes from sort-order labels", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        steps: [
+          buildSerializedStep({
+            content: {
+              feedback: "Ordered",
+              items: ['"Alpha"', "“Beta”", "‘Gamma’"],
+              question: "Sort alphabetically",
+            },
+            kind: "sortOrder",
+            sortOrderItems: ['"Alpha"', "“Beta”", "‘Gamma’"],
+          }),
+        ],
+      }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await expect
+      .element(page.getByRole("button", { name: "Alpha" }).getByText(/^Alpha$/u))
+      .toBeInTheDocument();
+
+    await expect
+      .element(page.getByRole("button", { name: "Beta" }).getByText(/^Beta$/u))
+      .toBeInTheDocument();
+
+    await expect
+      .element(page.getByRole("button", { name: "Gamma" }).getByText(/^Gamma$/u))
+      .toBeInTheDocument();
+
     await page.getByRole("button", { name: /check/iu }).click();
 
     await expect

--- a/packages/player/src/_browser-tests/player-choice.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-choice.browser.test.tsx
@@ -193,6 +193,36 @@ describe("player browser integration: choice steps", () => {
     await expect.element(page.getByText("Berlin")).toBeInTheDocument();
   });
 
+  it("strips model-added wrapping quotes from multiple-choice option labels", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        steps: [
+          buildSerializedStep({
+            content: {
+              options: [
+                { feedback: "Nope", id: "Paris", isCorrect: false, text: '"Paris"' },
+                { feedback: "Correct", id: "Berlin", isCorrect: true, text: "“Berlin”" },
+              ],
+              question: "What is the capital of Germany?",
+            },
+            kind: "multipleChoice",
+          }),
+        ],
+      }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    const parisOption = page.getByRole("radio", { name: "Paris" });
+    const berlinOption = page.getByRole("radio", { name: "Berlin" });
+
+    await expect.element(parisOption.getByText(/^Paris$/u)).toBeInTheDocument();
+    await expect.element(berlinOption.getByText(/^Berlin$/u)).toBeInTheDocument();
+
+    await parisOption.click();
+
+    await expect.element(page.getByRole("button", { name: /check/iu })).toBeEnabled();
+  });
+
   it("renders image-led multiple-choice evidence inline", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({

--- a/packages/player/src/components/match-columns-step.tsx
+++ b/packages/player/src/components/match-columns-step.tsx
@@ -8,6 +8,7 @@ import { useExtracted } from "next-intl";
 import { Fragment, useCallback, useMemo, useRef, useState } from "react";
 import { useWebHaptics } from "web-haptics/react";
 import { type SelectedAnswer } from "../player-reducer";
+import { stripWrappingQuotes } from "./_utils/strip-wrapping-quotes";
 import { QuestionText } from "./question-text";
 import { InteractiveStepLayout } from "./step-layouts";
 
@@ -141,10 +142,11 @@ function MatchItem({
   state: ItemVisualState;
 }) {
   const isLocked = state === "correct" || state === "incorrectFlash";
+  const displayLabel = stripWrappingQuotes(label);
 
   return (
     <button
-      aria-label={label}
+      aria-label={displayLabel}
       aria-pressed={state === "selected"}
       className={cn(
         "border-border flex min-h-11 items-center rounded-lg border px-2.5 py-2.5 text-left text-sm wrap-break-word transition-all duration-150 sm:px-4 sm:py-3.5 sm:text-base",
@@ -155,7 +157,7 @@ function MatchItem({
       onClick={onTap}
       type="button"
     >
-      <span>{label}</span>
+      <span>{displayLabel}</span>
     </button>
   );
 }

--- a/packages/player/src/components/sort-order-step.tsx
+++ b/packages/player/src/components/sort-order-step.tsx
@@ -27,6 +27,7 @@ import { useExtracted } from "next-intl";
 import { useCallback, useId, useMemo, useState } from "react";
 import { useWebHaptics } from "web-haptics/react";
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
+import { stripWrappingQuotes } from "./_utils/strip-wrapping-quotes";
 import { InlineFeedback } from "./inline-feedback";
 import { QuestionText } from "./question-text";
 import { ResultKbd } from "./result-kbd";
@@ -56,6 +57,7 @@ function SortableItem({
   });
 
   const style = { transform: CSS.Transform.toString(transform), transition };
+  const displayText = stripWrappingQuotes(item.text);
 
   return (
     <div
@@ -67,7 +69,7 @@ function SortableItem({
       <button
         {...attributes}
         {...listeners}
-        aria-label={item.text}
+        aria-label={displayText}
         className={cn(
           "flex min-h-11 w-full touch-none items-center gap-3 px-3 py-2 text-left select-none sm:px-4 sm:py-2.5",
           !isDragging && "hover:bg-muted/50",
@@ -76,17 +78,19 @@ function SortableItem({
         type="button"
       >
         <ResultKbd isSelected>{String(index + 1)}</ResultKbd>
-        <span className="text-base">{item.text}</span>
+        <span className="text-base">{displayText}</span>
       </button>
     </div>
   );
 }
 
 function DragOverlayItem({ index, item }: { index: number; item: SortItem }) {
+  const displayText = stripWrappingQuotes(item.text);
+
   return (
     <div className="bg-background flex min-h-11 items-center gap-3 rounded-lg border px-3 py-2 text-left shadow-md sm:px-4 sm:py-2.5">
       <ResultKbd isSelected>{String(index + 1)}</ResultKbd>
-      <span className="text-base">{item.text}</span>
+      <span className="text-base">{displayText}</span>
     </div>
   );
 }
@@ -190,11 +194,12 @@ function ResultItemList({
       <div aria-label={t("Sort items")} className="flex flex-col gap-2" role="list">
         {correctItems.map((item, index) => {
           const resultState = getItemResultState(item, index, userOrder);
+          const displayItem = stripWrappingQuotes(item);
 
           return (
             <div
               aria-label={t("{item}. {result}.", {
-                item,
+                item: displayItem,
                 result: resultState === "correct" ? t("Correct") : t("Incorrect"),
               })}
               className={cn(
@@ -209,7 +214,7 @@ function ResultItemList({
               role="listitem"
             >
               <ResultKbd resultState={resultState}>{String(index + 1)}</ResultKbd>
-              <span className="text-base">{item}</span>
+              <span className="text-base">{displayItem}</span>
             </div>
           );
         })}


### PR DESCRIPTION
## Summary
- Strip model-added wrapper quotes from match-column labels and sort-order labels in the player.
- Keep multiple-choice coverage focused on option labels, since that path already flows through the existing rich-text renderer.
- Add browser coverage for the affected match/sort and multiple-choice option cases.

## Testing
- `pnpm --filter @zoonk/player test -- src/_browser-tests/player-choice.browser.test.tsx src/_browser-tests/player-arrangement.browser.test.tsx`
- `pnpm --filter @zoonk/player typecheck`
- Targeted lint and diff checks passed locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip model-added wrapper quotes from match-column and sort-order labels so the player shows clean text and accurate ARIA labels. Multiple-choice options are already handled by the rich-text renderer; added browser tests covering quoted labels across match, sort, and multiple-choice.

<sup>Written for commit 95f8f5aaf92d4b99355e4ae01d6dfb7228bf496f. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1525?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

