### PR TITLE
fix(main): prevent mobile catalog search shift on empty results

### DIFF
--- a/apps/main/e2e/catalog-search.ts
+++ b/apps/main/e2e/catalog-search.ts
@@ -1,0 +1,28 @@
+import { type Page } from "@playwright/test";
+
+/**
+ * Mobile browsers clamp scroll when filtering removes content below a focused
+ * search input. Aligning the field below the sticky nav reproduces the real
+ * flow where learners search after reaching a catalog list.
+ */
+export async function scrollSearchInputToTop({ label, page }: { label: RegExp; page: Page }) {
+  const input = page.getByLabel(label);
+
+  await input.evaluate((element) => {
+    const stickyNavOffset = 72;
+    const top = element.getBoundingClientRect().top + globalThis.scrollY - stickyNavOffset;
+
+    globalThis.scrollTo({ top });
+  });
+}
+
+/**
+ * Catalog search regressions here are visual position drift, so measuring the
+ * accessible input gives the tests a direct signal without depending on CSS
+ * selectors or component internals.
+ */
+export async function getSearchInputTop({ label, page }: { label: RegExp; page: Page }) {
+  const box = await page.getByLabel(label).boundingBox();
+
+  return box?.y ?? 0;
+}

--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -5,9 +5,11 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { normalizeString } from "@zoonk/utils/string";
+import { getSearchInputTop, scrollSearchInputToTop } from "./catalog-search";
 import { expect, test } from "./fixtures";
 
 const uniqueId = randomUUID();
+const SEARCH_LESSONS_LABEL = /search lessons/iu;
 
 let chapterUrl: string;
 let courseSlug: string;
@@ -301,6 +303,32 @@ test.describe("Chapter Lesson Search", () => {
     await expect(
       page.getByRole("link", { name: new RegExp(lessonNames.second, "u") }),
     ).toBeVisible();
+  });
+});
+
+test.describe("Chapter Lesson Search - Mobile", () => {
+  test.use({ viewport: { height: 667, width: 375 } });
+
+  test("keeps the search field anchored when no lessons match", async ({ page }) => {
+    await page.goto(chapterUrl);
+    await scrollSearchInputToTop({ label: SEARCH_LESSONS_LABEL, page });
+
+    const searchInput = page.getByLabel(SEARCH_LESSONS_LABEL);
+
+    await searchInput.fill("E2E Testing");
+
+    await expect(
+      page.getByRole("link", { name: new RegExp(lessonNames.first, "u") }),
+    ).toBeVisible();
+
+    const matchingTop = await getSearchInputTop({ label: SEARCH_LESSONS_LABEL, page });
+
+    await searchInput.fill("nonexistent xyz");
+    await expect(page.getByText(/no lessons found/iu)).toBeVisible();
+
+    await expect
+      .poll(() => getSearchInputTop({ label: SEARCH_LESSONS_LABEL, page }))
+      .toBeLessThanOrEqual(matchingTop + 1);
   });
 });
 

--- a/apps/main/e2e/course-chapters.test.ts
+++ b/apps/main/e2e/course-chapters.test.ts
@@ -6,8 +6,10 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { normalizeString } from "@zoonk/utils/string";
+import { getSearchInputTop, scrollSearchInputToTop } from "./catalog-search";
 import { expect, test } from "./fixtures";
 
+const SEARCH_CHAPTERS_LABEL = /search chapters/iu;
 let courseUrl: string;
 let ptCourseUrl: string;
 let chapterSlugs: { first: string };
@@ -279,5 +281,31 @@ test.describe("Course Chapter Search", () => {
 
     await expect(firstChapter).toBeVisible();
     await expect(secondChapter).not.toBeVisible();
+  });
+});
+
+test.describe("Course Chapter Search - Mobile", () => {
+  test.use({ viewport: { height: 667, width: 375 } });
+
+  test("keeps the search field anchored when no chapters match", async ({ page }) => {
+    await page.goto(courseUrl);
+    await scrollSearchInputToTop({ label: SEARCH_CHAPTERS_LABEL, page });
+
+    const searchInput = page.getByLabel(SEARCH_CHAPTERS_LABEL);
+
+    await searchInput.fill("Chapter");
+
+    await expect(
+      page.getByRole("link", { name: new RegExp(chapterNames.third, "u") }),
+    ).toBeVisible();
+
+    const matchingTop = await getSearchInputTop({ label: SEARCH_CHAPTERS_LABEL, page });
+
+    await searchInput.fill("nonexistent xyz");
+    await expect(page.getByText(/no chapters found/iu)).toBeVisible();
+
+    await expect
+      .poll(() => getSearchInputTop({ label: SEARCH_CHAPTERS_LABEL, page }))
+      .toBeLessThanOrEqual(matchingTop + 1);
   });
 });

--- a/apps/main/src/components/catalog/catalog-grid.tsx
+++ b/apps/main/src/components/catalog/catalog-grid.tsx
@@ -203,7 +203,8 @@ export function CatalogGridSearch({
 
 /**
  * Grid empty state stays tied to the shared search context so filtered empty
- * results do not require every catalog page to duplicate visibility logic.
+ * results do not require every catalog page to duplicate visibility logic. The
+ * empty frame keeps mobile scroll from collapsing under a focused search field.
  */
 export function CatalogGridEmpty({ className, ...props }: React.ComponentProps<"p">) {
   const context = useCatalogGridContext();
@@ -216,7 +217,15 @@ export function CatalogGridEmpty({ className, ...props }: React.ComponentProps<"
     return null;
   }
 
-  return <GridEmpty className={className} {...props} />;
+  return (
+    <GridEmpty
+      className={cn(
+        "flex min-h-[calc(100dvh-8rem)] items-center justify-center md:min-h-64",
+        className,
+      )}
+      {...props}
+    />
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Keep the catalog search input anchored on mobile when chapter or lesson filters return no matches.
- Add shared Playwright helpers for measuring search input position across catalog search tests.
- Cover the regression on both course chapter and chapter lesson pages with mobile e2e checks.

## Testing
- Playwright e2e for course chapters and chapter lessons, including the new mobile no-results regression.
- Typecheck, lint, and formatting checks passed locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a mobile bug that shifted the catalog search field when filters returned no results. Keeps the input anchored on course chapter and chapter lesson pages and adds mobile e2e coverage to prevent regressions.

- **Bug Fixes**
  - Render an empty-state frame with a min height to stop scroll collapse under the sticky nav on mobile.
  - Applies to chapter and lesson catalogs so the search field stays in place with no matches.

- **Refactors**
  - Introduced shared Playwright helpers to scroll the search input into view and read its position.
  - Added mobile e2e tests for no-results cases on chapters and lessons.

<sup>Written for commit 109dfd2703ac7c739ebc564baf564433c2d81721. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1528?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

