### PR TITLE
fix(player): remove tap navigation from read steps

### DIFF
--- a/packages/player/src/_browser-tests/player-alphabet.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-alphabet.browser.test.tsx
@@ -84,6 +84,55 @@ describe("player browser integration: alphabet", () => {
     await expect.element(card.getByText("بـ")).toBeInTheDocument();
   });
 
+  it("plays alphabet audio without moving to the next card", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        kind: "alphabet",
+        steps: [
+          buildSerializedStep({
+            content: {
+              audioText: "ب",
+              audioUrl: "https://example.com/ba.mp3",
+              forms: [],
+              pronunciation: "like b in book",
+              readingAid: "b",
+              symbol: "ب",
+            },
+            id: "alphabet-audio-1",
+            kind: "alphabet",
+          }),
+          buildSerializedStep({
+            content: {
+              audioText: "ت",
+              audioUrl: "https://example.com/ta.mp3",
+              forms: [],
+              pronunciation: "like t in tea",
+              readingAid: "t",
+              symbol: "ت",
+            },
+            id: "alphabet-audio-2",
+            kind: "alphabet",
+            position: 1,
+          }),
+        ],
+      }),
+      navigation: buildNavigation({ nextLessonHref: null }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await page.getByRole("button", { name: /play pronunciation/iu }).click();
+
+    await expect
+      .element(page.getByRole("button", { name: /pause pronunciation/iu }))
+      .toBeInTheDocument();
+
+    await expect.element(page.getByRole("region", { name: /alphabet: ب/iu })).toBeInTheDocument();
+
+    await expect
+      .element(page.getByRole("region", { name: /alphabet: ت/iu }))
+      .not.toBeInTheDocument();
+  });
+
   it("navigates alphabet cards without quiz controls", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({

--- a/packages/player/src/_browser-tests/player-static.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-static.browser.test.tsx
@@ -33,6 +33,23 @@ function swipeLeft(target: HTMLElement) {
   fireEvent.touchEnd(globalThis.window, { changedTouches: [endTouch], touches: [] });
 }
 
+/**
+ * Exercises the intentional backward gesture without relying on browser-level
+ * swipe synthesis, which is not available inside the package browser harness.
+ */
+function swipeRight(target: HTMLElement) {
+  const startTouch = buildTouch({ identifier: 4, target, x: 120, y: 220 });
+  const endTouch = buildTouch({ identifier: 4, target, x: 320, y: 210 });
+
+  fireEvent.touchStart(target, {
+    changedTouches: [startTouch],
+    targetTouches: [startTouch],
+    touches: [startTouch],
+  });
+
+  fireEvent.touchEnd(globalThis.window, { changedTouches: [endTouch], touches: [] });
+}
+
 function tapLeft(target: HTMLElement) {
   const touch = buildTouch({ identifier: 2, target, x: 24, y: 220 });
 
@@ -55,6 +72,36 @@ function tapRight(target: HTMLElement) {
   });
 
   fireEvent.touchEnd(globalThis.window, { changedTouches: [touch], touches: [] });
+}
+
+/**
+ * Restores the real viewport object after a test forces a pinch-zoom scale.
+ * Browser runners expose this as a global read-only-ish object, so preserving
+ * the descriptor avoids leaking one test's zoom state into later tests.
+ */
+function restoreVisualViewport(descriptor: PropertyDescriptor | undefined) {
+  if (descriptor) {
+    Object.defineProperty(globalThis, "visualViewport", descriptor);
+    return;
+  }
+
+  delete (globalThis as { visualViewport?: VisualViewport }).visualViewport;
+}
+
+/**
+ * Forces `visualViewport.scale` so the gesture contract can be verified without
+ * depending on real mobile pinch gestures in the desktop browser runner.
+ */
+async function runWithViewportScale({ run, scale }: { run: () => Promise<void>; scale: number }) {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "visualViewport");
+
+  Object.defineProperty(globalThis, "visualViewport", { configurable: true, value: { scale } });
+
+  try {
+    await run();
+  } finally {
+    restoreVisualViewport(descriptor);
+  }
 }
 
 function buildLongStaticText() {
@@ -322,7 +369,7 @@ describe("player browser integration: static steps", () => {
     await expect.element(page.getByRole("heading", { name: "Second step" })).toBeInTheDocument();
   });
 
-  it("uses single taps on the left and right halves for touch navigation", async () => {
+  it("uses swipes for touch navigation and ignores single taps", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({
         kind: "explanation",
@@ -350,14 +397,79 @@ describe("player browser integration: static steps", () => {
       viewer: buildAuthenticatedViewer(),
     });
 
-    tapRight(screen.getByAltText(/lantern lighting up one idea at a time/iu));
-    await expect.element(page.getByRole("heading", { name: "Second step" })).toBeInTheDocument();
-
-    tapLeft(screen.getByRole("heading", { name: "Second step" }));
+    tapLeft(screen.getByAltText(/lantern lighting up one idea at a time/iu));
 
     await expect
       .element(page.getByRole("heading", { name: "One step, one image" }))
       .toBeInTheDocument();
+
+    tapRight(screen.getByAltText(/lantern lighting up one idea at a time/iu));
+
+    await expect
+      .element(page.getByRole("heading", { name: "One step, one image" }))
+      .toBeInTheDocument();
+
+    swipeLeft(screen.getByAltText(/lantern lighting up one idea at a time/iu));
+
+    await expect.element(page.getByRole("heading", { name: "Second step" })).toBeInTheDocument();
+
+    tapLeft(screen.getByRole("heading", { name: "Second step" }));
+
+    await expect.element(page.getByRole("heading", { name: "Second step" })).toBeInTheDocument();
+
+    tapRight(screen.getByRole("heading", { name: "Second step" }));
+
+    await expect.element(page.getByRole("heading", { name: "Second step" })).toBeInTheDocument();
+
+    swipeRight(screen.getByRole("heading", { name: "Second step" }));
+
+    await expect
+      .element(page.getByRole("heading", { name: "One step, one image" }))
+      .toBeInTheDocument();
+  });
+
+  it("ignores touch navigation while the viewport is zoomed", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        kind: "explanation",
+        steps: [
+          buildSerializedStep({
+            content: {
+              image: {
+                prompt: "A lantern lighting up one idea at a time",
+                url: buildInlineImageUrl({ label: "A lantern lighting up one idea at a time" }),
+              },
+              text: "An image can now live inside the same readable step.",
+              title: "One step, one image",
+              variant: "text" as const,
+            },
+            id: "zoom-static-image",
+          }),
+          buildSerializedStep({
+            content: { text: "Second body", title: "Second step", variant: "text" as const },
+            id: "zoom-static-second",
+            position: 1,
+          }),
+        ],
+      }),
+      navigation: buildNavigation({ nextLessonHref: null }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await runWithViewportScale({
+      run: async () => {
+        swipeLeft(screen.getByAltText(/lantern lighting up one idea at a time/iu));
+
+        await expect
+          .element(page.getByRole("heading", { name: "One step, one image" }))
+          .toBeInTheDocument();
+
+        await expect
+          .element(page.getByRole("heading", { name: "Second step" }))
+          .not.toBeInTheDocument();
+      },
+      scale: 2,
+    });
   });
 
   it("supports keyboard navigation on static steps and keyboard completion actions", async () => {

--- a/packages/player/src/_browser-tests/player-vocabulary.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-vocabulary.browser.test.tsx
@@ -37,6 +37,55 @@ describe("player browser integration: vocabulary", () => {
     await expect.element(page.getByText("Hello")).toBeInTheDocument();
   });
 
+  it("plays vocabulary audio without moving to the next card", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        kind: "vocabulary",
+        steps: [
+          buildSerializedStep({
+            content: {},
+            id: "vocab-audio-1",
+            kind: "vocabulary",
+            word: buildSerializedWord({
+              audioUrl: "https://example.com/hola.mp3",
+              id: "word-audio-1",
+              translation: "Hello",
+              word: "Hola",
+            }),
+          }),
+          buildSerializedStep({
+            content: {},
+            id: "vocab-audio-2",
+            kind: "vocabulary",
+            position: 1,
+            word: buildSerializedWord({
+              audioUrl: "https://example.com/adios.mp3",
+              id: "word-audio-2",
+              translation: "Goodbye",
+              word: "Adios",
+            }),
+          }),
+        ],
+      }),
+      navigation: buildNavigation({ nextLessonHref: null }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await page.getByRole("button", { name: /play pronunciation/iu }).click();
+
+    await expect
+      .element(page.getByRole("button", { name: /pause pronunciation/iu }))
+      .toBeInTheDocument();
+
+    await expect
+      .element(page.getByRole("region", { name: /vocabulary: Hola/iu }))
+      .toBeInTheDocument();
+
+    await expect
+      .element(page.getByRole("region", { name: /vocabulary: Adios/iu }))
+      .not.toBeInTheDocument();
+  });
+
   it("navigates vocabulary cards without quiz controls", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({

--- a/packages/player/src/components/swipe-navigable-step-layout.tsx
+++ b/packages/player/src/components/swipe-navigable-step-layout.tsx
@@ -9,9 +9,9 @@ import { NavigableStepLayout } from "./step-layouts";
 
 const SWIPE_DISTANCE_THRESHOLD = 48;
 const SWIPE_HORIZONTAL_RATIO = 1.05;
-const TAP_DISTANCE_THRESHOLD = 12;
+const VIEWPORT_ZOOM_SCALE_THRESHOLD = 1.01;
 
-type SwipeGesture = { container: HTMLDivElement; startX: number; startY: number; touchId: number };
+type SwipeGesture = { startX: number; startY: number; touchId: number };
 
 export type SwipeNavigableStepFrame = "default" | "media";
 type DesktopNavigationSide = "previous" | "next";
@@ -31,9 +31,9 @@ function getNavigableFrameClass(frame: SwipeNavigableStepFrame) {
 
 /**
  * Desktop read screens still benefit from a visible navigation affordance, but
- * touch screens already use the whole surface for tap and swipe navigation.
- * Keeping these controls pointer-fine only avoids competing with the mobile
- * gesture model while giving keyboard users a discoverable mouse target.
+ * touch screens use the surface for swipe navigation. Keeping these controls
+ * pointer-fine only avoids competing with the mobile gesture model while giving
+ * keyboard users a discoverable mouse target.
  */
 function DesktopNavigationButton({
   "aria-label": ariaLabel,
@@ -69,7 +69,7 @@ function DesktopNavigationButton({
  * gestures from interactive descendants like the vocabulary audio button.
  */
 function isInteractiveSwipeTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) {
+  if (!(target instanceof Element)) {
     return false;
   }
 
@@ -105,35 +105,12 @@ function isHorizontalSwipe({ deltaX, deltaY }: { deltaX: number; deltaY: number 
 }
 
 /**
- * Touch-friendly read steps should also support single-tap navigation so users
- * can move through content with one hand. Using the left/right half split keeps
- * the interaction simple and avoids adding visible controls back into the UI.
+ * Native pinch zoom should take over the image-reading interaction completely.
+ * When the viewport is zoomed, single-finger touches are usually attempts to
+ * inspect or pan the image rather than requests to change player steps.
  */
-function runTapNavigation({
-  canNavigatePrev,
-  container,
-  clientX,
-  onNavigateNext,
-  onNavigatePrev,
-}: {
-  canNavigatePrev: boolean;
-  container: HTMLDivElement;
-  clientX: number;
-  onNavigateNext: () => void;
-  onNavigatePrev: () => void;
-}) {
-  const bounds = container.getBoundingClientRect();
-  const isLeftHalf = clientX - bounds.left < bounds.width / 2;
-
-  if (isLeftHalf) {
-    if (canNavigatePrev) {
-      onNavigatePrev();
-    }
-
-    return;
-  }
-
-  onNavigateNext();
+function isViewportZoomed() {
+  return (globalThis.visualViewport?.scale ?? 1) > VIEWPORT_ZOOM_SCALE_THRESHOLD;
 }
 
 /**
@@ -154,10 +131,9 @@ function findTouchById(touchList: TouchList, touchId: number) {
 }
 
 /**
- * Navigable read steps no longer show visible arrow chrome, so touch devices
- * need a direct gesture surface that maps into the existing next/prev actions.
- * This wrapper keeps swipe behavior local to those read-only screens while
- * desktop users continue to rely on keyboard navigation.
+ * Navigable read steps keep touch gestures local to read-only screens. Taps
+ * stay available for real content controls, horizontal swipes move
+ * forward/back, and desktop users keep the subtle arrow/keyboard affordances.
  */
 export function SwipeNavigableStepLayout({
   canNavigatePrev,
@@ -219,6 +195,12 @@ export function SwipeNavigableStepLayout({
       return;
     }
 
+    if (isViewportZoomed()) {
+      detachWindowTouchListeners();
+      resetSwipeGesture();
+      return;
+    }
+
     const deltaX = clientX - gesture.startX;
     const deltaY = clientY - gesture.startY;
 
@@ -234,29 +216,21 @@ export function SwipeNavigableStepLayout({
       return;
     }
 
-    const isTap =
-      Math.abs(deltaX) <= TAP_DISTANCE_THRESHOLD && Math.abs(deltaY) <= TAP_DISTANCE_THRESHOLD;
-
-    if (isTap) {
-      runTapNavigation({
-        canNavigatePrev,
-        clientX,
-        container: gesture.container,
-        onNavigateNext,
-        onNavigatePrev,
-      });
-    }
-
     detachWindowTouchListeners();
     resetSwipeGesture();
   }
 
   /**
-   * Only touch input should trigger swipe or tap navigation. We also skip
-   * obvious interactive descendants so taps on controls keep their native job.
+   * Only unzoomed single-touch input should trigger swipe navigation. We also
+   * skip obvious interactive descendants so taps on controls keep their native
+   * job.
    */
   function handleTouchStart(event: TouchEvent<HTMLDivElement>) {
-    if (event.touches.length !== 1 || isInteractiveSwipeTarget(event.target)) {
+    if (
+      event.touches.length !== 1 ||
+      isInteractiveSwipeTarget(event.target) ||
+      isViewportZoomed()
+    ) {
       detachWindowTouchListeners();
       resetSwipeGesture();
       return;
@@ -271,7 +245,6 @@ export function SwipeNavigableStepLayout({
     detachWindowTouchListeners();
 
     gestureRef.current = {
-      container: event.currentTarget,
       startX: touch.clientX,
       startY: touch.clientY,
       touchId: touch.identifier,


### PR DESCRIPTION
## Summary
- Removed tap-to-navigate from the shared read-step gesture layer so touch taps stay available for real controls like alphabet/vocabulary audio buttons
- Kept swipe navigation for touch, plus keyboard and desktop arrow navigation
- Added browser coverage for audio playback, swipe-only navigation, and zoomed-image behavior

## Testing
- Focused player browser tests passed for static, alphabet, and vocabulary flows
- `typecheck`, formatting, lint, and diff-check passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make read-step navigation swipe-only so taps trigger real controls like audio instead of advancing. Kept swipe, keyboard, and desktop arrows; added browser tests for audio playback, swipe-only navigation, and zoomed-image behavior.

- **Bug Fixes**
  - Removed tap-to-navigate on read steps; horizontal swipes move next/previous.
  - Disabled touch navigation when the viewport is pinch-zoomed.
  - Prevented taps on interactive elements (e.g., pronunciation buttons) from being intercepted.

<sup>Written for commit 7363881a211c86e642365ac17a0872833c2b1fbb. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1529?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

