### PR TITLE
fix(main): localize untitled lesson seo titles

### DIFF
--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -609,6 +609,52 @@ test.describe("Lesson Player Page", () => {
     await expect(page).toHaveTitle(new RegExp(lessonTitle, "u"));
   });
 
+  test("page title describes lessons without a stored title", async ({ page }) => {
+    const org = await getAiOrganization();
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: org.id,
+      slug: `e2e-titleless-course-${uniqueId}`,
+      title: `E2E Titleless Course ${uniqueId}`,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: org.id,
+      slug: `e2e-titleless-chapter-${uniqueId}`,
+      title: `E2E Titleless Chapter ${uniqueId}`,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      generationStatus: "completed",
+      isPublished: true,
+      kind: "quiz",
+      organizationId: org.id,
+      position: 2,
+      slug: `e2e-titleless-quiz-${uniqueId}`,
+      title: null,
+    });
+
+    await stepFixture({
+      content: {
+        text: `Titleless quiz step ${uniqueId}`,
+        title: `Titleless quiz ${uniqueId}`,
+        variant: "text",
+      },
+      isPublished: true,
+      lessonId: lesson.id,
+    });
+
+    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+
+    await expect(page).toHaveTitle(new RegExp(`${chapter.title} Quiz ${lesson.position + 1}`, "u"));
+    await expect(page).not.toHaveTitle(/Quiz Quiz/u);
+  });
+
   test("unpublished lesson shows 404 page", async ({ page }) => {
     const org = await getAiOrganization();
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -2007,9 +2007,9 @@ msgid "3198Ew"
 msgstr "Learn new {topic} words with flashcards — see each word, its translation, and pronunciation."
 
 #: src/lib/lessons.ts
-msgid "qHbgYB"
-msgstr "{lesson} - {course}"
+msgid "oCxmX9"
+msgstr "{chapter} {kind} {position}"
 
 #: src/lib/lessons.ts
-msgid "MOpDCK"
-msgstr "{kind} {lesson}"
+msgid "qHbgYB"
+msgstr "{lesson} - {course}"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -2007,9 +2007,9 @@ msgid "3198Ew"
 msgstr "Aprende nuevas palabras de {topic} con tarjetas didácticas — ve cada palabra, su traducción y pronunciación."
 
 #: src/lib/lessons.ts
-msgid "qHbgYB"
-msgstr "{lesson} - {course}"
+msgid "oCxmX9"
+msgstr "{kind} {chapter} {position}"
 
 #: src/lib/lessons.ts
-msgid "MOpDCK"
-msgstr "{kind} {lesson}"
+msgid "qHbgYB"
+msgstr "{lesson} - {course}"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -2007,9 +2007,9 @@ msgid "3198Ew"
 msgstr "Aprenda novas palavras de {topic} com flashcards — veja cada palavra, sua tradução e pronúncia."
 
 #: src/lib/lessons.ts
-msgid "qHbgYB"
-msgstr "{lesson} - {course}"
+msgid "oCxmX9"
+msgstr "{kind} {chapter} {position}"
 
 #: src/lib/lessons.ts
-msgid "MOpDCK"
-msgstr "{kind} {lesson}"
+msgid "qHbgYB"
+msgstr "{lesson} - {course}"

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -32,13 +32,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     return {};
   }
 
-  const lesson = await getPlayerLesson({ lessonId: lessonShell.id });
-
-  if (!lesson) {
-    return {};
-  }
-
-  return getLessonSeoMeta(lesson, lesson.title);
+  return getLessonSeoMeta(lessonShell);
 }
 
 export default async function LessonPage({ params }: Props) {

--- a/apps/main/src/lib/lessons.ts
+++ b/apps/main/src/lib/lessons.ts
@@ -3,6 +3,11 @@ import { getExtracted } from "next-intl/server";
 
 type LessonDisplayInput = { kind: LessonKind; title: string | null; description: string | null };
 
+type LessonSeoInput = LessonDisplayInput & {
+  chapter: { title: string; course: { title: string } };
+  position: number;
+};
+
 /**
  * Lesson kind labels are used in several app-level fallbacks. Keeping them in
  * one translated map prevents the chapter list, player metadata, and SEO copy
@@ -25,24 +30,6 @@ async function getLessonKindLabels(): Promise<Record<LessonKind, string>> {
     tutorial: t("Tutorial"),
     vocabulary: t("Vocabulary"),
   };
-}
-
-async function getLessonKinds(): Promise<{ key: LessonKind; label: string }[]> {
-  const labels = await getLessonKindLabels();
-
-  return [
-    { key: "alphabet", label: labels.alphabet },
-    { key: "tutorial", label: labels.tutorial },
-    { key: "explanation", label: labels.explanation },
-    { key: "quiz", label: labels.quiz },
-    { key: "practice", label: labels.practice },
-    { key: "vocabulary", label: labels.vocabulary },
-    { key: "translation", label: labels.translation },
-    { key: "grammar", label: labels.grammar },
-    { key: "reading", label: labels.reading },
-    { key: "listening", label: labels.listening },
-    { key: "review", label: labels.review },
-  ];
 }
 
 /**
@@ -131,40 +118,64 @@ async function getSeoDescription(kind: LessonKind, topic: string): Promise<strin
 }
 
 export async function getLessonSeoMeta(
-  lesson: { kind: LessonKind; title: string | null; description: string | null },
-  lessonTitle: string | null,
+  lesson: LessonSeoInput,
 ): Promise<{ title: string; description: string }> {
-  const displayMeta = await getLessonDisplayMeta(lesson);
-  const title = await getSeoTitle(lesson, lessonTitle ?? displayMeta.title);
-  const description = await getSeoLessonDescription(lesson, lessonTitle ?? displayMeta.title);
+  const title = await getSeoTitle({ lesson });
+
+  const description = await getSeoLessonDescription({
+    lesson,
+    lessonTitle: lesson.title ?? lesson.chapter.title,
+  });
 
   return { description, title };
 }
 
-async function getSeoTitle(
-  lesson: { kind: LessonKind; title: string | null },
-  lessonTitle: string,
-): Promise<string> {
+/**
+ * Generated companion lessons often store no title because their title would be
+ * only the lesson kind. SEO needs enough context to distinguish several quizzes
+ * or practices in the same chapter, so the fallback names the chapter, kind, and
+ * human lesson number instead of repeating the kind label.
+ */
+async function getUntitledLessonSeoTitle({
+  chapterTitle,
+  kind,
+  position,
+}: {
+  chapterTitle: string;
+  kind: LessonKind;
+  position: number;
+}) {
+  const labels = await getLessonKindLabels();
   const t = await getExtracted();
 
-  if (lesson.title) {
-    return t("{lesson} - {course}", { course: lessonTitle, lesson: lesson.title });
-  }
-
-  const kinds = await getLessonKinds();
-  const kindInfo = kinds.find((kind) => kind.key === lesson.kind);
-
-  if (kindInfo) {
-    return t("{kind} {lesson}", { kind: kindInfo.label, lesson: lessonTitle });
-  }
-
-  return lessonTitle;
+  return t("{chapter} {kind} {position}", {
+    chapter: chapterTitle,
+    kind: labels[kind],
+    position: String(position + 1),
+  });
 }
 
-async function getSeoLessonDescription(
-  lesson: { kind: LessonKind; description: string | null },
-  lessonTitle: string,
-): Promise<string> {
+async function getSeoTitle({ lesson }: { lesson: LessonSeoInput }): Promise<string> {
+  if (lesson.title) {
+    const t = await getExtracted();
+
+    return t("{lesson} - {course}", { course: lesson.chapter.course.title, lesson: lesson.title });
+  }
+
+  return getUntitledLessonSeoTitle({
+    chapterTitle: lesson.chapter.title,
+    kind: lesson.kind,
+    position: lesson.position,
+  });
+}
+
+async function getSeoLessonDescription({
+  lesson,
+  lessonTitle,
+}: {
+  lesson: { kind: LessonKind; description: string | null };
+  lessonTitle: string;
+}): Promise<string> {
   if (lesson.kind === "custom" && lesson.description) {
     return lesson.description;
   }


### PR DESCRIPTION
## Summary
- Use chapter-aware SEO titles for lessons without a stored title so title-less quizzes no longer collapse into `Quiz Quiz`
- Keep titled lessons on the existing `lesson - course` pattern
- Add an e2e regression for a title-less quiz lesson and update extracted `en`, `es`, and `pt` messages

## Testing
- `pnpm --filter main typecheck`
- `pnpm --filter main build:e2e`
- `pnpm i18n`
- Playwright coverage for the lesson title cases passed, including the new title-less lesson regression

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SEO titles for lessons without stored titles by using a localized, chapter-aware fallback to avoid duplicates like "Quiz Quiz". Titled lessons still use "lesson - course".

- **Bug Fixes**
  - Untitled lessons now use "{chapter} {kind} {position}" (localized), e.g., "Intro Quiz 3".
  - Added a Playwright regression test to cover a title-less quiz.

- **Refactors**
  - Simplified metadata generation by calling `getLessonSeoMeta(lessonShell)` and introducing `getUntitledLessonSeoTitle`; removed `getLessonKinds`.
  - Updated `en`, `es`, and `pt` message keys for the new title pattern.

<sup>Written for commit 9779da87df3220ff721ec8d1e90a7244a08a23ba. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1530?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

