### PR TITLE
fix(main): simplify chapter mobile navigation

### DIFF
--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -12,6 +12,7 @@ const uniqueId = randomUUID();
 const SEARCH_LESSONS_LABEL = /search lessons/iu;
 
 let chapterUrl: string;
+let courseUrl: string;
 let courseSlug: string;
 let courseTitle: string;
 let chapterTitle: string;
@@ -53,7 +54,8 @@ test.beforeAll(async () => {
     title: chapterTitle,
   });
 
-  chapterUrl = `/b/${AI_ORG_SLUG}/c/${courseSlug}/ch/${chapterSlug}`;
+  courseUrl = `/b/${AI_ORG_SLUG}/c/${courseSlug}`;
+  chapterUrl = `${courseUrl}/ch/${chapterSlug}`;
 
   lessonNames = {
     first: `What is E2E Testing ${uniqueId}`,
@@ -244,6 +246,46 @@ test.describe("Chapter Detail - Locale", () => {
     await expect(
       page.getByRole("link", { name: new RegExp(ptLessonNames.second, "u") }),
     ).toBeVisible();
+  });
+});
+
+test.describe("Chapter Navbar - Mobile", () => {
+  test.use({ viewport: { height: 667, width: 375 } });
+
+  test("shows only course back and home close links", async ({ page }) => {
+    await page.goto(chapterUrl);
+
+    const catalogNavbar = page.getByRole("navigation").first();
+    const courseLink = catalogNavbar.getByRole("link", { name: /course page/iu });
+    const homeLink = catalogNavbar.getByRole("link", { name: /home page/iu });
+
+    await expect(courseLink).toBeVisible();
+    await expect(courseLink).toHaveAttribute("href", courseUrl);
+
+    await expect(homeLink).toBeVisible();
+    await expect(homeLink).toHaveAttribute("href", "/");
+
+    await expect(page.getByRole("main").getByRole("link", { name: courseTitle })).not.toBeVisible();
+
+    await expect(
+      catalogNavbar.getByRole("link", { exact: true, name: "Courses" }),
+    ).not.toBeVisible();
+
+    await expect(catalogNavbar.getByRole("button", { name: /search/iu })).not.toBeVisible();
+    await expect(catalogNavbar.getByRole("button", { name: /user menu/iu })).not.toBeVisible();
+  });
+});
+
+test.describe("Chapter Navbar - Desktop", () => {
+  test("keeps the full catalog navbar", async ({ page }) => {
+    await page.goto(chapterUrl);
+
+    const catalogNavbar = page.getByRole("navigation").first();
+
+    await expect(catalogNavbar.getByRole("link", { exact: true, name: "Courses" })).toBeVisible();
+    await expect(catalogNavbar.getByRole("button", { name: /search/iu })).toBeVisible();
+    await expect(catalogNavbar.getByRole("link", { name: /course page/iu })).not.toBeVisible();
+    await expect(page.getByRole("main").getByRole("link", { name: courseTitle })).toBeVisible();
   });
 });
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -100,6 +100,10 @@ msgid "SENRqu"
 msgstr "Help"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
+msgid "onRJrc"
+msgstr "Course page"
+
+#: src/app/(catalog)/_components/navbar-links.tsx
 msgid "IbrSk1"
 msgstr "Learn"
 

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -100,6 +100,10 @@ msgid "SENRqu"
 msgstr "Ayuda"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
+msgid "onRJrc"
+msgstr "Página del curso"
+
+#: src/app/(catalog)/_components/navbar-links.tsx
 msgid "IbrSk1"
 msgstr "Aprender"
 

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -100,6 +100,10 @@ msgid "SENRqu"
 msgstr "Ajuda"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
+msgid "onRJrc"
+msgstr "Página do curso"
+
+#: src/app/(catalog)/_components/navbar-links.tsx
 msgid "IbrSk1"
 msgstr "Aprender"
 

--- a/apps/main/src/app/(catalog)/_components/command-palette.tsx
+++ b/apps/main/src/app/(catalog)/_components/command-palette.tsx
@@ -20,7 +20,18 @@ import { useRouter } from "next/navigation";
 import { useCallback } from "react";
 import { type CourseSearchResult, searchCoursesAction } from "./search-courses-action";
 
-export function CommandPalette({ isLoggedIn }: { isLoggedIn: boolean }) {
+/**
+ * The catalog navbar sometimes hides the search trigger responsively while the
+ * dialog logic stays unchanged. Accepting a trigger class keeps that layout
+ * concern out of the command palette state and search behavior.
+ */
+export function CommandPalette({
+  className,
+  isLoggedIn,
+}: {
+  className?: string;
+  isLoggedIn: boolean;
+}) {
   const router = useRouter();
   const t = useExtracted();
   const locale = useLocale();
@@ -72,7 +83,13 @@ export function CommandPalette({ isLoggedIn }: { isLoggedIn: boolean }) {
 
   return (
     <>
-      <Button aria-keyshortcuts="Meta+K Control+K" onClick={open} size="icon" variant="outline">
+      <Button
+        aria-keyshortcuts="Meta+K Control+K"
+        className={className}
+        onClick={open}
+        size="icon"
+        variant="outline"
+      >
         <Search aria-hidden="true" />
         <span className="sr-only">{t("Search")}</span>
       </Button>

--- a/apps/main/src/app/(catalog)/_components/mobile-chapter-nav-target.ts
+++ b/apps/main/src/app/(catalog)/_components/mobile-chapter-nav-target.ts
@@ -1,0 +1,19 @@
+export type MobileChapterNavTarget = { courseHref: `/b/${string}/c/${string}` };
+
+const CHAPTER_PAGE_PATH_PATTERN = /^\/b\/(?<brandSlug>[^/]+)\/c\/(?<courseSlug>[^/]+)\/ch\/[^/]+$/u;
+
+/**
+ * Chapter pages need route-specific mobile chrome, but the catalog layout sits
+ * above the dynamic route params. Deriving the parent course URL from the
+ * client pathname keeps that one navigation rule centralized without reshaping
+ * the route tree or fetching chapter data in the shared layout.
+ */
+export function getMobileChapterNavTarget(pathname: string): MobileChapterNavTarget | null {
+  const groups = CHAPTER_PAGE_PATH_PATTERN.exec(pathname)?.groups;
+
+  if (!groups?.brandSlug || !groups.courseSlug) {
+    return null;
+  }
+
+  return { courseHref: `/b/${groups.brandSlug}/c/${groups.courseSlug}` as const };
+}

--- a/apps/main/src/app/(catalog)/_components/navbar-links.tsx
+++ b/apps/main/src/app/(catalog)/_components/navbar-links.tsx
@@ -3,10 +3,16 @@
 import { getMenu } from "@/lib/menu";
 import { buttonVariants } from "@zoonk/ui/components/button";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { cn } from "@zoonk/ui/lib/utils";
+import { ArrowLeftIcon, XIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { CommandPalette } from "./command-palette";
+import {
+  type MobileChapterNavTarget,
+  getMobileChapterNavTarget,
+} from "./mobile-chapter-nav-target";
 
 function getVariant(href: string, pathname: string): "outline" | "secondary" | "default" {
   if (href === pathname) {
@@ -27,8 +33,54 @@ function getVariant(href: string, pathname: string): "outline" | "secondary" | "
 const homeMenu = getMenu("home");
 const coursesMenu = getMenu("courses");
 const learnMenu = getMenu("learn");
+const MOBILE_CHAPTER_NAV_CLASS = "sm:hidden";
+const DESKTOP_CHAPTER_NAV_CLASS = "hidden sm:inline-flex";
+
+/**
+ * Chapter pages need mobile chrome that points to the parent course instead of
+ * the broader catalog sections. Keeping this as links preserves normal Next.js
+ * prefetching and accessibility while removing the extra catalog actions on
+ * small screens.
+ */
+function MobileChapterNavbarLinks({ courseHref }: MobileChapterNavTarget) {
+  const t = useExtracted();
+
+  return (
+    <>
+      <Link
+        className={cn(
+          buttonVariants({ size: "icon", variant: "outline" }),
+          MOBILE_CHAPTER_NAV_CLASS,
+        )}
+        href={courseHref}
+        prefetch
+      >
+        <ArrowLeftIcon aria-hidden="true" />
+        <span className="sr-only">{t("Course page")}</span>
+      </Link>
+
+      <Link
+        className={cn(
+          buttonVariants({ size: "icon", variant: "outline" }),
+          MOBILE_CHAPTER_NAV_CLASS,
+        )}
+        href="/"
+        prefetch
+      >
+        <XIcon aria-hidden="true" />
+        <span className="sr-only">{t("Home page")}</span>
+      </Link>
+    </>
+  );
+}
 
 export function NavbarLinksSkeleton() {
+  const mobileChapterNavTarget = getMobileChapterNavTarget(usePathname());
+
+  if (mobileChapterNavTarget) {
+    return null;
+  }
+
   return (
     <>
       <Skeleton className="size-9 rounded-full" />
@@ -42,6 +94,8 @@ export function NavbarLinksSkeleton() {
 export function NavbarLinks({ isLoggedIn }: { isLoggedIn: boolean }) {
   const pathname = usePathname();
   const t = useExtracted();
+  const mobileChapterNavTarget = getMobileChapterNavTarget(pathname);
+  const desktopClassName = mobileChapterNavTarget ? DESKTOP_CHAPTER_NAV_CLASS : undefined;
 
   const homeVariant = getVariant(homeMenu.url, pathname);
   const coursesVariant = getVariant(coursesMenu.url, pathname);
@@ -49,9 +103,13 @@ export function NavbarLinks({ isLoggedIn }: { isLoggedIn: boolean }) {
 
   return (
     <>
+      {mobileChapterNavTarget && (
+        <MobileChapterNavbarLinks courseHref={mobileChapterNavTarget.courseHref} />
+      )}
+
       <Link
         aria-current={homeVariant === "default" ? "page" : undefined}
-        className={buttonVariants({ size: "icon", variant: homeVariant })}
+        className={cn(buttonVariants({ size: "icon", variant: homeVariant }), desktopClassName)}
         href={homeMenu.url}
         prefetch
       >
@@ -61,7 +119,10 @@ export function NavbarLinks({ isLoggedIn }: { isLoggedIn: boolean }) {
 
       <Link
         aria-current={coursesVariant === "default" ? "page" : undefined}
-        className={buttonVariants({ size: "adaptive", variant: coursesVariant })}
+        className={cn(
+          buttonVariants({ size: "adaptive", variant: coursesVariant }),
+          desktopClassName,
+        )}
         href={coursesMenu.url}
         prefetch
       >
@@ -69,15 +130,15 @@ export function NavbarLinks({ isLoggedIn }: { isLoggedIn: boolean }) {
         <span className="sr-only sm:not-sr-only">{t("Courses")}</span>
       </Link>
 
-      <CommandPalette isLoggedIn={isLoggedIn} />
+      <CommandPalette className={desktopClassName} isLoggedIn={isLoggedIn} />
 
       <Link
         aria-current={learnVariant === "default" ? "page" : undefined}
-        className={buttonVariants({
-          className: "ml-auto",
-          size: "adaptive",
-          variant: learnVariant,
-        })}
+        className={cn(
+          buttonVariants({ size: "adaptive", variant: learnVariant }),
+          "ml-auto",
+          desktopClassName,
+        )}
         href={learnMenu.url}
         prefetch
       >

--- a/apps/main/src/app/(catalog)/_components/navbar-user-slot.tsx
+++ b/apps/main/src/app/(catalog)/_components/navbar-user-slot.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { type ReactNode } from "react";
+import { getMobileChapterNavTarget } from "./mobile-chapter-nav-target";
+
+/**
+ * Chapter pages replace the mobile catalog menu with back and close controls.
+ * The account menu stays available on larger screens, but hiding it on mobile
+ * leaves the close control as the only right-side navbar action.
+ */
+export function NavbarUserSlot({ children }: { children: ReactNode }) {
+  const mobileChapterNavTarget = getMobileChapterNavTarget(usePathname());
+
+  if (!mobileChapterNavTarget) {
+    return children;
+  }
+
+  return <div className="hidden sm:block">{children}</div>;
+}

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
@@ -37,7 +37,7 @@ export function ChapterHeader({
       <CatalogHeaderImage alt={chapter.title} src={chapterImage} />
 
       <MediaCardContent>
-        <MediaCardBreadcrumb>
+        <MediaCardBreadcrumb className="hidden sm:block">
           <Link
             className="hover:text-foreground truncate transition-colors"
             href={`/b/${brandSlug}/c/${courseSlug}`}

--- a/apps/main/src/app/(catalog)/layout.tsx
+++ b/apps/main/src/app/(catalog)/layout.tsx
@@ -4,6 +4,7 @@ import { AvatarSkeleton } from "@zoonk/ui/components/avatar";
 import { Navbar } from "@zoonk/ui/components/navbar";
 import { Suspense } from "react";
 import { NavbarLinks, NavbarLinksSkeleton } from "./_components/navbar-links";
+import { NavbarUserSlot } from "./_components/navbar-user-slot";
 import { UserAvatarMenu } from "./_components/user-avatar-menu";
 
 async function NavbarLinksWithAuth() {
@@ -19,9 +20,11 @@ export default function CatalogLayout({ children }: LayoutProps<"/">) {
           <NavbarLinksWithAuth />
         </Suspense>
 
-        <Suspense fallback={<AvatarSkeleton />}>
-          <UserAvatarMenu />
-        </Suspense>
+        <NavbarUserSlot>
+          <Suspense fallback={<AvatarSkeleton />}>
+            <UserAvatarMenu />
+          </Suspense>
+        </NavbarUserSlot>
       </Navbar>
 
       <div aria-hidden="true" className="scroll-mt-20" id={CATALOG_TOP_TARGET_ID} />

--- a/apps/main/src/components/catalog/catalog-detail-layout.tsx
+++ b/apps/main/src/components/catalog/catalog-detail-layout.tsx
@@ -13,7 +13,7 @@ export function CatalogDetailLayout({
   sidebar: ReactNode;
 }) {
   return (
-    <main className="grid w-full flex-1 grid-cols-1 gap-6 px-4 pt-2 pb-8 md:pb-10 lg:grid-cols-[minmax(16rem,20rem)_minmax(0,1fr)] lg:items-start lg:gap-8 xl:grid-cols-[minmax(18rem,22rem)_minmax(0,1fr)]">
+    <main className="grid w-full flex-1 grid-cols-1 gap-6 px-4 pb-8 sm:pt-2 md:pb-10 lg:grid-cols-[minmax(16rem,20rem)_minmax(0,1fr)] lg:items-start lg:gap-8 xl:grid-cols-[minmax(18rem,22rem)_minmax(0,1fr)]">
       <aside className="flex min-w-0 flex-col gap-6 lg:sticky lg:top-20 lg:gap-4">{sidebar}</aside>
       <section className="min-w-0">{children}</section>
     </main>


### PR DESCRIPTION
## Summary
- Replace the mobile chapter navbar with a course back link and home close link, while keeping the desktop catalog navbar unchanged.
- Hide the chapter breadcrumb title on mobile now that the course back link provides that context.
- Add e2e coverage for the mobile and desktop navbar/header behavior and keep the locale strings in sync.

## Testing
- `pnpm --filter main build:e2e`
- `pnpm --filter main e2e e2e/chapter-detail.test.ts --grep "Chapter Navbar"`
- `pnpm lint`
- `pnpm --filter main typecheck`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the chapter page on mobile by replacing the catalog navbar with a back-to-course and close-to-home control. Keeps the full catalog navbar on desktop and hides the chapter breadcrumb on mobile.

- **New Features**
  - Mobile chapter pages show only course back and home links; catalog links, search, and user menu are hidden.
  - Desktop keeps the full catalog navbar; chapter breadcrumb is desktop-only.
  - Added a pathname-based helper to derive the parent course URL (no extra fetch).
  - `CommandPalette` accepts `className` for responsive visibility; `NavbarUserSlot` hides the account menu on mobile chapter pages.
  - E2E coverage for mobile/desktop navbar behavior; added "Course page" translations in `en`, `es`, and `pt`.

<sup>Written for commit ef812d95380cb145e5f05f852351286d7a488344. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1532?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

