### PR TITLE
chore: remove waitlist link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,5 @@
 # Contributing
 
-Thanks for your interest in contributing! The project is still in its early stages, so we’re not ready to accept contributions yet as we’re still setting things up. However, we’d love to hear your feedback and ideas—feel free to [start a discussion](https://github.com/orgs/zoonk/discussions/new/choose).
-
 ## Translations
 
 At the moment, we support only these languages:

--- a/README.md
+++ b/README.md
@@ -8,14 +8,8 @@
   The open-source platform for interactive learning.
   <br />
   <br />
-  <a href="https://forms.gle/jHeTqPUkw1vA7wLh8">Waitlist</a>
+  <a href="https://www.zoonk.com">Try for free</a>
 </p>
-
-> [!CAUTION]
->
-> ## Early Development Notice
->
-> This project is still in early development and **not ready for use**. There will be breaking changes before stable that won't be backwards compatible. Star this repository or follow us on social media to stay updated.
 
 ## Table of Contents
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced the README waitlist link with a “Try for free” link to https://www.zoonk.com and removed early-development notices. Also dropped the “not accepting contributions yet” note from CONTRIBUTING.

<sup>Written for commit f41f130d3020ad5427933c3739ea4ae4292b1915. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1534?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

