### PR TITLE
fix(core): normalize translation option casing and punctuation

### DIFF
--- a/packages/core/src/player/contracts/prepare-lesson-data.test.ts
+++ b/packages/core/src/player/contracts/prepare-lesson-data.test.ts
@@ -378,6 +378,84 @@ describe(preparePlayerLessonData, () => {
     ]);
   });
 
+  it("matches translation option casing to the correct target-language word", () => {
+    const word = makeLessonWord({
+      distractors: ["boa tarde", "boa noite"],
+      translation: "Good morning",
+      word: makeWordRecord({ id: "10", word: "Bom dia" }),
+    });
+
+    const result = prepare({
+      chapterWords: [word],
+      lesson: makeLesson([
+        makeStep({
+          id: "11",
+          kind: "translation",
+          word: makeStepWord({ id: "10", word: "Bom dia" }),
+        }),
+      ]),
+    });
+
+    expect(result.steps[0]?.translationOptions.map((option) => option.word)).toStrictEqual([
+      "Bom dia",
+      "Boa tarde",
+      "Boa noite",
+    ]);
+  });
+
+  it("adds the visible translation prompt punctuation to every translation option", () => {
+    const word = makeLessonWord({
+      distractors: ["Boa tarde", "Boa noite."],
+      translation: "Good morning!",
+      word: makeWordRecord({ id: "10", word: "Bom dia" }),
+    });
+
+    const result = prepare({
+      chapterWords: [word],
+      lesson: makeLesson([
+        makeStep({
+          id: "11",
+          kind: "translation",
+          word: makeStepWord({ id: "10", word: "Bom dia" }),
+        }),
+      ]),
+    });
+
+    expect(result.steps[0]?.translationOptions.map((option) => option.word)).toStrictEqual([
+      "Bom dia!",
+      "Boa tarde!",
+      "Boa noite!",
+    ]);
+  });
+
+  it("strips terminal punctuation from translation options when the prompt has none", () => {
+    const word = makeLessonWord({
+      distractors: ["Boa tarde.", "Boa noite!"],
+      translation: "Good morning",
+      word: makeWordRecord({ id: "10", word: "Bom dia" }),
+    });
+
+    const result = prepare({
+      chapterWords: [word],
+      distractorWords: [
+        makeDistractorWord({ audioUrl: "/audio/boa-tarde.mp3", id: "101", word: "Boa tarde." }),
+      ],
+      lesson: makeLesson([
+        makeStep({
+          id: "11",
+          kind: "translation",
+          word: makeStepWord({ id: "10", word: "Bom dia" }),
+        }),
+      ]),
+    });
+
+    expect(result.steps[0]?.translationOptions).toMatchObject([
+      { id: "10", word: "Bom dia" },
+      { audioUrl: "/audio/boa-tarde.mp3", id: "101", word: "Boa tarde" },
+      { id: "distractor:boa noite", word: "Boa noite" },
+    ]);
+  });
+
   it("uses the exact chapter word referenced by the step when resources share a word", () => {
     const vocabularyWord = makeLessonWord({
       distractors: ["Danke"],

--- a/packages/core/src/player/contracts/translation-options.test.ts
+++ b/packages/core/src/player/contracts/translation-options.test.ts
@@ -38,6 +38,7 @@ describe(buildTranslationOptions, () => {
         id: "word-1",
         pronunciation: "tea-pron",
         romanization: null,
+        translation: "tea",
         word: "tea",
       },
     });

--- a/packages/core/src/player/contracts/translation-options.ts
+++ b/packages/core/src/player/contracts/translation-options.ts
@@ -1,7 +1,12 @@
 import { normalizeDistractorKey, sanitizeDistractors } from "@zoonk/utils/distractors";
 import { shuffle } from "@zoonk/utils/shuffle";
+import { normalizePunctuation } from "@zoonk/utils/string";
 
 const VOCABULARY_DISTRACTOR_COUNT = 3;
+const FIRST_LETTER_PATTERN = /\p{L}/u;
+const TERMINAL_PUNCTUATION_PATTERN = /[.!?…。！？؟]+$/u;
+
+type InitialCasing = "lowercase" | "none" | "uppercase";
 
 export type TranslationOption = {
   id: string;
@@ -22,6 +27,7 @@ export type DistractorWord = {
 type TranslationSourceWord = {
   id: string;
   word: string;
+  translation: string;
   distractors: string[];
   pronunciation: string | null;
   romanization: string | null;
@@ -62,6 +68,134 @@ function toTranslationOption(word: TranslationSourceWord | DistractorWord): Tran
 }
 
 /**
+ * Some scripts do not have uppercase/lowercase forms. Treat those as neutral so
+ * translation options in scripts like Japanese or Chinese keep their original text.
+ */
+function isCasedLetter(letter: string): boolean {
+  return letter.toLocaleLowerCase() !== letter.toLocaleUpperCase();
+}
+
+/**
+ * The correct target-language answer defines the casing style learners should see.
+ * Matching distractors to that first-letter style removes answer leaks such as only the
+ * correct option starting with an uppercase letter.
+ */
+function getInitialCasing(text: string): InitialCasing {
+  const firstLetter = FIRST_LETTER_PATTERN.exec(text)?.[0];
+
+  if (!firstLetter || !isCasedLetter(firstLetter)) {
+    return "none";
+  }
+
+  if (firstLetter === firstLetter.toLocaleUpperCase()) {
+    return "uppercase";
+  }
+
+  return "lowercase";
+}
+
+/**
+ * Applies one shared first-letter casing style while preserving the rest of the option.
+ * This keeps phrases like "Bom dia" sentence-cased without title-casing every word.
+ */
+function applyInitialCasing(params: { casing: InitialCasing; text: string }): string {
+  if (params.casing === "none") {
+    return params.text;
+  }
+
+  return params.text.replace(FIRST_LETTER_PATTERN, (letter) =>
+    params.casing === "uppercase" ? letter.toLocaleUpperCase() : letter.toLocaleLowerCase(),
+  );
+}
+
+/**
+ * The prompt is what learners are translating, so its terminal punctuation is the
+ * reference for every answer option. Returning only the final punctuation run handles
+ * cases like "Good morning!" and "Really?!" without changing internal punctuation.
+ */
+function getTerminalPunctuation(text: string): string {
+  const normalizedText = normalizePunctuation(text).trim();
+
+  return TERMINAL_PUNCTUATION_PATTERN.exec(normalizedText)?.[0] ?? "";
+}
+
+/**
+ * Distractors often arrive with punctuation that belongs to a different prompt. Strip
+ * only terminal sentence punctuation so internal punctuation and accents stay intact.
+ */
+function stripTerminalPunctuation(text: string): string {
+  return normalizePunctuation(text).trim().replace(TERMINAL_PUNCTUATION_PATTERN, "").trimEnd();
+}
+
+/**
+ * Rebuilds an option label from the two learner-visible references: answer casing from
+ * the correct target word and ending punctuation from the prompt being translated.
+ */
+function normalizeTranslationOptionWord(params: {
+  casing: InitialCasing;
+  optionWord: string;
+  terminalPunctuation: string;
+}): string {
+  const textWithoutPunctuation = stripTerminalPunctuation(params.optionWord);
+  const textWithPunctuation = `${textWithoutPunctuation}${params.terminalPunctuation}`;
+
+  return applyInitialCasing({ casing: params.casing, text: textWithPunctuation });
+}
+
+/**
+ * Metadata and IDs must keep pointing at the original word records, but the visible label
+ * should be normalized so option formatting cannot identify the correct answer.
+ */
+function normalizeTranslationOption(params: {
+  casing: InitialCasing;
+  option: TranslationOption;
+  terminalPunctuation: string;
+}): TranslationOption {
+  return {
+    ...params.option,
+    word: normalizeTranslationOptionWord({
+      casing: params.casing,
+      optionWord: params.option.word,
+      terminalPunctuation: params.terminalPunctuation,
+    }),
+  };
+}
+
+/**
+ * Generated distractor text is still usable when we cannot hydrate it from a word
+ * record. Keep the normalized key in the ID so the fallback stays stable across casing
+ * and punctuation differences in regenerated content.
+ */
+function buildFallbackDistractorOption(params: { key: string; word: string }): TranslationOption {
+  return {
+    audioUrl: null,
+    id: `distractor:${params.key}`,
+    pronunciation: null,
+    romanization: null,
+    word: params.word,
+  };
+}
+
+/**
+ * Direct distractors are stored as text, while enriched distractors are fetched as word
+ * records. This joins those paths before display normalization so both hydrated and
+ * fallback distractors receive the same casing and punctuation treatment.
+ */
+function buildDirectDistractorOption(params: {
+  distractorLookup: Map<string, DistractorWord>;
+  word: string;
+}): TranslationOption {
+  const distractorKey = normalizeDistractorKey(params.word);
+  const hydrated = params.distractorLookup.get(distractorKey);
+
+  if (hydrated) {
+    return toTranslationOption(hydrated);
+  }
+
+  return buildFallbackDistractorOption({ key: distractorKey, word: params.word });
+}
+
+/**
  * Target-language distractors are looked up by normalized surface text. Missing word
  * records still render as plain options so the lesson keeps working even if enrichment
  * underflows.
@@ -90,20 +224,15 @@ export function buildTranslationOptions(params: {
     input: params.word.word,
     shape: "any",
   })
-    .map((word) => {
-      const hydrated = params.distractorLookup.get(normalizeDistractorKey(word));
-
-      return hydrated
-        ? toTranslationOption(hydrated)
-        : {
-            audioUrl: null,
-            id: `distractor:${normalizeDistractorKey(word)}`,
-            pronunciation: null,
-            romanization: null,
-            word,
-          };
-    })
+    .map((word) => buildDirectDistractorOption({ distractorLookup: params.distractorLookup, word }))
     .slice(0, VOCABULARY_DISTRACTOR_COUNT);
 
-  return shuffle([toTranslationOption(params.word), ...directDistractors]);
+  const casing = getInitialCasing(params.word.word);
+  const terminalPunctuation = getTerminalPunctuation(params.word.translation);
+
+  const options = [toTranslationOption(params.word), ...directDistractors].map((option) =>
+    normalizeTranslationOption({ casing, option, terminalPunctuation }),
+  );
+
+  return shuffle(options);
 }


### PR DESCRIPTION
## Summary
- Normalize translation multiple-choice labels so distractors match the correct answer’s casing style.
- Apply the prompt’s terminal punctuation to every translation option, and strip stray terminal punctuation when the prompt has none.
- Added regression coverage for casing, punctuation propagation, and punctuation stripping at the shared player contract boundary.

## Testing
- Added focused contract tests for `preparePlayerLessonData` and `buildTranslationOptions`.
- Verified with `pnpm --filter @zoonk/core test -- src/player/contracts/prepare-lesson-data.test.ts src/player/contracts/translation-options.test.ts`.
- Verified with `pnpm --filter @zoonk/core typecheck`, formatting, and lint checks on the touched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize translation option casing and terminal punctuation to prevent distractors from signaling the correct answer. Improves consistency across hydrated and fallback options.

- **Bug Fixes**
  - Match distractor first-letter casing to the correct target-language word; scripts without casing stay unchanged.
  - Apply the prompt’s terminal punctuation to every option; strip terminal punctuation when the prompt has none.
  - Add focused contract tests for `preparePlayerLessonData` and `buildTranslationOptions`.

<sup>Written for commit f5fbe06fbca649023ab1ccb0ffb647a69318b914. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1536?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

