### PR TITLE
fix(ai): move read-aloud instruction to prompt end

### DIFF
--- a/apps/evals/src/tasks/lesson-sentences/test-cases.ts
+++ b/apps/evals/src/tasks/lesson-sentences/test-cases.ts
@@ -72,6 +72,11 @@ EVALUATION CRITERIA:
     - Null is acceptable for trivially simple sentences (single-word greetings, very basic structures)
     - Penalize if explanations are in the wrong language or describe vocabulary meaning instead of grammar patterns
 
+12. WORD-BANK PUNCTUATION:
+    - Sentences and translations should avoid decorative terminal punctuation because they become word-bank tiles
+    - Penalize unnecessary punctuation on simple greetings, farewells, thanks, statements, labels, or short conversational chunks (e.g., "Good morning!" should be "Good morning"; "See you later." should be "See you later")
+    - Do NOT penalize punctuation that changes meaning or is grammatically required, especially question marks for questions (e.g., "How are you?") and required target-language question punctuation (e.g., "¿Cómo estás?")
+
 ANTI-CHECKLIST GUIDANCE (CRITICAL):
 - Do NOT penalize for specific sentence choices - accept ANY valid sentences that use the vocabulary
 - Do NOT penalize for not including specific contexts you might expect
@@ -96,9 +101,10 @@ These words MUST appear in the generated sentences.
 DIFFICULTY: This is clearly a BEGINNER-level lesson. Chapter "Basic Greetings and Introductions" + Lesson "Greetings and Introductions" + simple greeting vocabulary = absolute beginner.
 - Sentences MUST be very simple (2-5 words max)
 - No compound sentences, no subordinate clauses
-- Examples of acceptable complexity: "¡Hola!", "Buenos días, María.", "¡Gracias!"
+- Examples of acceptable complexity: "Hola", "Buenos días, María", "Gracias"
 - Examples of UNACCEPTABLE complexity: "As she entered the coffee shop, she immediately said good afternoon"
 - Penalize SEVERELY if any sentence has more than 5-6 words or uses complex structures
+- Penalize unnecessary exclamation marks or periods on greeting chunks; keep question marks only for actual questions
 
 ACCURACY PITFALLS - Penalize SEVERELY if:
 - Any sentence doesn't use at least one of the provided vocabulary words

--- a/apps/evals/src/tasks/lesson-vocabulary/test-cases.ts
+++ b/apps/evals/src/tasks/lesson-vocabulary/test-cases.ts
@@ -51,7 +51,12 @@ EVALUATION CRITERIA:
    - The word field contains usage notes, alternative meanings, or pronunciation hints in parentheses
    - Any text in parentheses appears in the word field (this breaks text-to-speech)
 
-9. NO OVER-ENUMERATION OF VARIANTS: Vocabulary should be representative, not exhaustive. Penalize if:
+9. CLEAN WORD FIELD - ONLY MEANINGFUL PUNCTUATION: Penalize unnecessary punctuation because vocabulary can become word-bank tiles.
+   - Simple greetings, farewells, thanks, short phrases, and conversational chunks should not include decorative terminal punctuation
+   - Examples: "Good morning" is better than "Good morning!"; "See you later" is better than "See you later."
+   - Do NOT penalize punctuation that changes meaning or is grammatically required, especially question marks for question phrases
+
+10. NO OVER-ENUMERATION OF VARIANTS: Vocabulary should be representative, not exhaustive. Penalize if:
    - Multiple variants of the same base item are listed when 1-2 would suffice
    - The list appears inflated with excessive sub-types of a single category
    - A base concept is represented by 5+ specific variants instead of the base term plus 1-2 examples

--- a/packages/ai/src/tasks/audio/generate-language-audio.prompt.md
+++ b/packages/ai/src/tasks/audio/generate-language-audio.prompt.md
@@ -1,5 +1,3 @@
-The following text is {{LANGUAGE}}. Read it aloud in {{LANGUAGE}}.
+Speak clearly at a moderate pace suitable for language learners. Enunciate each word precisely.
 
 Some words may look like English words but they are {{LANGUAGE}} words and must be pronounced according to {{LANGUAGE}} phonology. For example, "fruit" in Dutch is pronounced "frœyt", not the English "froot."
-
-Speak clearly at a moderate pace suitable for language learners. Enunciate each word precisely.

--- a/packages/ai/src/tasks/audio/generate-language-audio.ts
+++ b/packages/ai/src/tasks/audio/generate-language-audio.ts
@@ -12,6 +12,7 @@ import { generateWithOpenAI } from "./provider-openai";
 const DEFAULT_VOICE: TTSVoice = "Kore";
 const MAX_ATTEMPTS_PER_PROVIDER = 3;
 const INITIAL_BACKOFF_MS = 1000;
+const READ_ALOUD_TEMPLATE = "The following text is {{LANGUAGE}}. Read it aloud in {{LANGUAGE}}.";
 
 type AudioFormat = "opus" | "wav";
 
@@ -48,8 +49,13 @@ function buildInstructions({
     : getPromptLanguageName({ language: "en" });
 
   const usagePrompt = usage ? usagePrompts[usage] : "";
+  const readAloudPrompt = READ_ALOUD_TEMPLATE.replaceAll("{{LANGUAGE}}", () => languageName);
 
-  return [promptTemplate.replaceAll("{{LANGUAGE}}", () => languageName), usagePrompt]
+  return [
+    promptTemplate.replaceAll("{{LANGUAGE}}", () => languageName),
+    usagePrompt,
+    readAloudPrompt,
+  ]
     .filter(Boolean)
     .join("\n\n");
 }

--- a/packages/ai/src/tasks/lessons/language/lesson-sentences.prompt.md
+++ b/packages/ai/src/tasks/lessons/language/lesson-sentences.prompt.md
@@ -35,7 +35,7 @@ Analyze CHAPTER_TITLE, LESSON_TITLE, LESSON_DESCRIPTION, VOCABULARY_WORDS, and C
 - **Intermediate**: medium sentences (4-8 words), simple + compound, some additional common vocabulary
 - **Advanced**: longer/complex sentences, subordinate clauses, broader vocabulary
 
-Example: A lesson on "Greetings" with vocabulary ["hola", "buenos días"] should produce "¡Buenos días!" — NOT "As she entered the coffee shop, she immediately said good afternoon."
+Example: A lesson on "Greetings" with vocabulary ["hola", "buenos días"] should produce "Buenos días" — NOT "As she entered the coffee shop, she immediately said good afternoon."
 
 # Sentence Generation Principles
 
@@ -61,6 +61,22 @@ Example: A lesson on "Greetings" with vocabulary ["hola", "buenos días"] should
 - Vary sentence beginnings - avoid starting every sentence the same way
 - Include different sentence types (statements, questions, exclamations) when appropriate
 - Keep sentences focused and clear - avoid overly complex constructions that obscure the vocabulary
+
+## Punctuation for Word Banks
+
+The `sentence` and `translation` fields are split into word-bank tiles. Punctuation should only appear when it changes the meaning, grammar, or natural reading of the text.
+
+- Do NOT add decorative terminal punctuation to simple statements, greetings, farewells, thanks, labels, or short conversational chunks.
+- Do keep punctuation that is required for meaning or grammar, especially question marks for questions.
+- Do keep punctuation required by the target language when the sentence type needs it, such as Spanish inverted question marks in questions.
+- Do keep internal punctuation when it is part of the natural sentence structure, such as commas in direct address.
+
+Examples:
+
+- `Good morning` — NOT `Good morning!`
+- `See you later` — NOT `See you later.`
+- `How are you?` — keep `?` because this is a question.
+- `¿Cómo estás?` — keep both question marks because Spanish questions require them.
 
 ## What to Avoid
 

--- a/packages/ai/src/tasks/lessons/language/lesson-vocabulary.prompt.md
+++ b/packages/ai/src/tasks/lessons/language/lesson-vocabulary.prompt.md
@@ -111,11 +111,16 @@ Before including any noun, verify the grammatical gender is correct:
 
 The word field is used for text-to-speech and display - parenthetical content breaks these features. If a word has multiple meanings, include only the meaning relevant to the lesson topic without any disambiguation text.
 
-3. **Only valid target language words**: Every word in the `word` field must be a real word in the TARGET_LANGUAGE. Do not include words from other languages.
+3. **Clean word field - ONLY MEANINGFUL PUNCTUATION**: The `word` field may be used in word-bank lessons, so punctuation should only appear when it is part of the vocabulary item itself or required for the item to read correctly.
+   - Do NOT add decorative terminal punctuation to greetings, farewells, thanks, short phrases, or conversational chunks.
+   - Do keep punctuation that changes meaning or is required by the target language.
+   - Examples: `Good morning`, NOT `Good morning!`; `See you later`, NOT `See you later.`; `How are you?`, because the question mark is meaningful.
 
-4. **Consistent articles**: All nouns in gendered languages must include their articles (der/die/das, le/la, el/la, o/a, il/la).
+4. **Only valid target language words**: Every word in the `word` field must be a real word in the TARGET_LANGUAGE. Do not include words from other languages.
 
-5. **Focused vocabulary, not inflated lists**: Aim for a curated, learnable list. If you find yourself listing many variants of the same base concept, stop and select only the most essential 1-2. A vocabulary list with 15-20 well-chosen words is better than 40+ words padded with excessive variants. Ask yourself: "Would a learner benefit from memorizing all these variants, or would they learn the same concept from fewer examples?"
+5. **Consistent articles**: All nouns in gendered languages must include their articles (der/die/das, le/la, el/la, o/a, il/la).
+
+6. **Focused vocabulary, not inflated lists**: Aim for a curated, learnable list. If you find yourself listing many variants of the same base concept, stop and select only the most essential 1-2. A vocabulary list with 15-20 well-chosen words is better than 40+ words padded with excessive variants. Ask yourself: "Would a learner benefit from memorizing all these variants, or would they learn the same concept from fewer examples?"
 
    **Signs you're over-enumerating**:
    - You're listing 5+ items that are all "types of X"


### PR DESCRIPTION
## Summary
- Move the language read-aloud instruction to the end of the audio prompt assembly so it sits immediately before the actual text.
- Keep usage-specific audio guidance, like alphabet-symbol handling, before that final instruction.
- Update sentence and vocabulary eval expectations to reject decorative punctuation that breaks word-bank tiles while preserving meaningful punctuation like question marks.

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the TTS “read aloud” instruction to the end of the audio prompt and tightens sentence/vocabulary rules to avoid decorative punctuation in word-bank tiles while keeping meaningful marks like question marks.

- Bug Fixes
  - Audio: Append the read-aloud instruction after usage guidance so it sits right before the text (`packages/ai/src/tasks/audio/generate-language-audio.ts`, `generate-language-audio.prompt.md`); added `READ_ALOUD_TEMPLATE`.
  - Lessons/Evals: Update `lesson-sentences.prompt.md` and `lesson-vocabulary.prompt.md` to forbid decorative terminal punctuation in word-bank items; keep required punctuation (e.g., “?” and Spanish inverted marks). Align eval test cases in `apps/evals` to enforce this.

<sup>Written for commit 960b170f17f927e3f06a86db4711c721003dccb8. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1537?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

