### PR TITLE
fix(core): capitalize translation option labels

### DIFF
--- a/packages/core/src/player/contracts/prepare-lesson-data.test.ts
+++ b/packages/core/src/player/contracts/prepare-lesson-data.test.ts
@@ -352,33 +352,33 @@ describe(preparePlayerLessonData, () => {
         id: "10",
         pronunciation: "boa noite",
         romanization: null,
-        word: "boa noite",
+        word: "Boa noite",
       },
       {
         audioUrl: "/audio/boa-tarde.mp3",
         id: "101",
         pronunciation: "boa tarde",
         romanization: null,
-        word: "boa tarde",
+        word: "Boa tarde",
       },
       {
         audioUrl: "/audio/bom-dia.mp3",
         id: "102",
         pronunciation: "bom dia",
         romanization: null,
-        word: "bom dia",
+        word: "Bom dia",
       },
       {
         audioUrl: null,
         id: "distractor:ate logo",
         pronunciation: null,
         romanization: null,
-        word: "até logo",
+        word: "Até logo",
       },
     ]);
   });
 
-  it("matches translation option casing to the correct target-language word", () => {
+  it("capitalizes every translation option", () => {
     const word = makeLessonWord({
       distractors: ["boa tarde", "boa noite"],
       translation: "Good morning",
@@ -400,6 +400,31 @@ describe(preparePlayerLessonData, () => {
       "Bom dia",
       "Boa tarde",
       "Boa noite",
+    ]);
+  });
+
+  it("capitalizes under-cased generated translation answers", () => {
+    const word = makeLessonWord({
+      distractors: ["i'm busy", "i'm tired"],
+      translation: "Estoy bien",
+      word: makeWordRecord({ id: "10", word: "i'm fine" }),
+    });
+
+    const result = prepare({
+      chapterWords: [word],
+      lesson: makeLesson([
+        makeStep({
+          id: "11",
+          kind: "translation",
+          word: makeStepWord({ id: "10", word: "i'm fine" }),
+        }),
+      ]),
+    });
+
+    expect(result.steps[0]?.translationOptions.map((option) => option.word)).toStrictEqual([
+      "I'm fine",
+      "I'm busy",
+      "I'm tired",
     ]);
   });
 

--- a/packages/core/src/player/contracts/translation-options.test.ts
+++ b/packages/core/src/player/contracts/translation-options.test.ts
@@ -49,14 +49,14 @@ describe(buildTranslationOptions, () => {
         id: "word-1",
         pronunciation: "tea-pron",
         romanization: null,
-        word: "tea",
+        word: "Tea",
       },
       {
         audioUrl: "/audio/cafe.mp3",
         id: "distractor-1",
         pronunciation: "ka-fe",
         romanization: "cafe",
-        word: "café",
+        word: "Café",
       },
     ]);
   });

--- a/packages/core/src/player/contracts/translation-options.ts
+++ b/packages/core/src/player/contracts/translation-options.ts
@@ -6,8 +6,6 @@ const VOCABULARY_DISTRACTOR_COUNT = 3;
 const FIRST_LETTER_PATTERN = /\p{L}/u;
 const TERMINAL_PUNCTUATION_PATTERN = /[.!?…。！？؟]+$/u;
 
-type InitialCasing = "lowercase" | "none" | "uppercase";
-
 export type TranslationOption = {
   id: string;
   word: string;
@@ -76,36 +74,18 @@ function isCasedLetter(letter: string): boolean {
 }
 
 /**
- * The correct target-language answer defines the casing style learners should see.
- * Matching distractors to that first-letter style removes answer leaks such as only the
- * correct option starting with an uppercase letter.
+ * Translate options are standalone choices, so each visible label should start like a
+ * sentence. This removes casing as an answer clue without trusting generated lowercase
+ * answers like "i'm fine"; scripts without casing keep their original text.
  */
-function getInitialCasing(text: string): InitialCasing {
+function capitalizeFirstCasedLetter(text: string): string {
   const firstLetter = FIRST_LETTER_PATTERN.exec(text)?.[0];
 
   if (!firstLetter || !isCasedLetter(firstLetter)) {
-    return "none";
+    return text;
   }
 
-  if (firstLetter === firstLetter.toLocaleUpperCase()) {
-    return "uppercase";
-  }
-
-  return "lowercase";
-}
-
-/**
- * Applies one shared first-letter casing style while preserving the rest of the option.
- * This keeps phrases like "Bom dia" sentence-cased without title-casing every word.
- */
-function applyInitialCasing(params: { casing: InitialCasing; text: string }): string {
-  if (params.casing === "none") {
-    return params.text;
-  }
-
-  return params.text.replace(FIRST_LETTER_PATTERN, (letter) =>
-    params.casing === "uppercase" ? letter.toLocaleUpperCase() : letter.toLocaleLowerCase(),
-  );
+  return text.replace(FIRST_LETTER_PATTERN, (letter) => letter.toLocaleUpperCase());
 }
 
 /**
@@ -132,14 +112,13 @@ function stripTerminalPunctuation(text: string): string {
  * the correct target word and ending punctuation from the prompt being translated.
  */
 function normalizeTranslationOptionWord(params: {
-  casing: InitialCasing;
   optionWord: string;
   terminalPunctuation: string;
 }): string {
   const textWithoutPunctuation = stripTerminalPunctuation(params.optionWord);
   const textWithPunctuation = `${textWithoutPunctuation}${params.terminalPunctuation}`;
 
-  return applyInitialCasing({ casing: params.casing, text: textWithPunctuation });
+  return capitalizeFirstCasedLetter(textWithPunctuation);
 }
 
 /**
@@ -147,14 +126,12 @@ function normalizeTranslationOptionWord(params: {
  * should be normalized so option formatting cannot identify the correct answer.
  */
 function normalizeTranslationOption(params: {
-  casing: InitialCasing;
   option: TranslationOption;
   terminalPunctuation: string;
 }): TranslationOption {
   return {
     ...params.option,
     word: normalizeTranslationOptionWord({
-      casing: params.casing,
       optionWord: params.option.word,
       terminalPunctuation: params.terminalPunctuation,
     }),
@@ -227,11 +204,10 @@ export function buildTranslationOptions(params: {
     .map((word) => buildDirectDistractorOption({ distractorLookup: params.distractorLookup, word }))
     .slice(0, VOCABULARY_DISTRACTOR_COUNT);
 
-  const casing = getInitialCasing(params.word.word);
   const terminalPunctuation = getTerminalPunctuation(params.word.translation);
 
   const options = [toTranslationOption(params.word), ...directDistractors].map((option) =>
-    normalizeTranslationOption({ casing, option, terminalPunctuation }),
+    normalizeTranslationOption({ option, terminalPunctuation }),
   );
 
   return shuffle(options);


### PR DESCRIPTION
## Summary
- Capitalize every visible translate option instead of mirroring the generated answer's casing
- Keep punctuation aligned with the translated prompt and strip stray terminal punctuation from distractors
- Add regression coverage for capitalized options and under-cased generated answers like `i'm fine`

## Testing
- Focused Vitest coverage for the player contract tests
- `typecheck`, formatting, and lint checks passed on the touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always capitalize visible translation options and align ending punctuation with the prompt to remove casing and punctuation clues. Adds regression tests and handles lowercase generated answers like "i'm fine".

- **Bug Fixes**
  - Capitalize the first cased letter of each option; leave uncased scripts unchanged.
  - Append the prompt’s terminal punctuation to every option; strip stray terminal punctuation from distractors.

- **Refactors**
  - Removed shared casing detection; use a single capitalize-first-letter helper for normalization.

<sup>Written for commit b4776d327fd6446dea94b2653b4eb360e62299a7. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1538?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

