### PR TITLE
fix(player): render over-escaped latex in generated text

### DIFF
--- a/packages/player/src/_browser-tests/player-static.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-static.browser.test.tsx
@@ -258,6 +258,34 @@ describe("player browser integration: static steps", () => {
     expect(bodyText).not.toContain("`");
   });
 
+  it("renders over-escaped generated LaTeX as math", async () => {
+    const { container } = renderPlayer({
+      lesson: buildSerializedLesson({
+        kind: "explanation",
+        steps: [
+          buildSerializedStep({
+            content: {
+              text: String.raw`A forma básica é: estado atual + ação → próximo estado esperado. Em notação curta: \\(s, a \\rightarrow s'\\), onde \\(s\\) é o estado.`,
+              title: "A seta da previsão",
+              variant: "text" as const,
+            },
+            id: "static-over-escaped-latex",
+          }),
+        ],
+      }),
+      navigation: buildNavigation({ nextLessonHref: null }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await expect
+      .element(page.getByRole("heading", { name: "A seta da previsão" }))
+      .toBeInTheDocument();
+
+    const bodyText = container.textContent?.replaceAll(/\s/gu, "");
+
+    expect(bodyText).toContain("s,a→s");
+  });
+
   it("allows long text-only static steps to scroll to the bottom", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({

--- a/packages/player/src/components/player-rich-text.tsx
+++ b/packages/player/src/components/player-rich-text.tsx
@@ -13,6 +13,8 @@ type RichTextSegment =
   | { kind: "text"; text: string };
 
 const MATH_DELIMITERS = [
+  { close: "\\\\)", kind: "math" as const, open: "\\\\(" },
+  { close: "\\\\]", kind: "displayMath" as const, open: "\\\\[" },
   { close: "\\)", kind: "math" as const, open: "\\(" },
   { close: "\\]", kind: "displayMath" as const, open: "\\[" },
 ];
@@ -148,7 +150,21 @@ function parseMarkedSegment({
  * reviewable instead of invisible.
  */
 function renderMathToHtml({ displayMode, text }: { displayMode: boolean; text: string }) {
-  return renderToString(text, { displayMode, output: "mathml", throwOnError: false, trust: false });
+  return renderToString(normalizeLatexCommands(text), {
+    displayMode,
+    output: "mathml",
+    throwOnError: false,
+    trust: false,
+  });
+}
+
+/**
+ * Some structured AI responses include JSON-escaped LaTeX commands as literal
+ * learner text, such as `\\rightarrow`. KaTeX expects `\rightarrow`, so the
+ * player accepts that common over-escaped shape at render time.
+ */
+function normalizeLatexCommands(text: string) {
+  return text.replaceAll(/\\\\([A-Za-z]+)/gu, (_escapedCommand, command: string) => `\\${command}`);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Teach `PlayerRichText` to accept over-escaped LaTeX delimiters and commands from generated lesson text
- Add browser coverage for the exact `\\(s, a \\rightarrow s'\\)` shape

## Testing
- Player browser test updated for the over-escaped math case
- Player typecheck, lint, and formatting checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rendering of over-escaped LaTeX in player rich text. We now accept double-escaped delimiters and normalize commands before passing to `katex`, so math like \\(s, a \\rightarrow s'\\) displays correctly.

- **Bug Fixes**
  - Support `\\(` and `\\[` delimiters in `PlayerRichText`.
  - Normalize `\\command` to `\command` during render.

<sup>Written for commit 608304311ad0a91ff4560e6e4d058a9d9e793189. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1539?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

